### PR TITLE
chore: colocate refactor-loop 脚本到 skill 目录(防再被误清)

### DIFF
--- a/.claude/skills/codex-refactor-loop/SKILL.md
+++ b/.claude/skills/codex-refactor-loop/SKILL.md
@@ -63,7 +63,7 @@ gh issue view <N> --json comments --jq '
 - **SKILL.md 历史 reference** `per Auric YYYY-MM-DD` 保留(只 controller 自己读,不输出到 GitHub)
 - **@-mention whitelist 不变**:loning / louis4li / eanzhao / jason-aelf / AbigailDeng / potter-sun(verbatim git blame 验证)
 
-### Wakeup 第一动作:`bash tools/refactor-loop/peek.sh`(强制)
+### Wakeup 第一动作:`bash .claude/skills/codex-refactor-loop/scripts/peek.sh`(强制)
 
 减少人工 grep / parse 错误。一眼看全:
 - 活跃 codex 数(harness-tracked 和 detached 都算)
@@ -125,13 +125,13 @@ Per Auric 2026-05-22 "大量标记 auto-loop-stuck 的实际并不需要人介�
 
 ### Spawn / merge / banner 后必须 peek(强制 — 防 maintainer 漏读)
 
-任何 controller turn 派 codex / merge PR / post banner / close issue 之后,**turn 结束前必须 `bash tools/refactor-loop/peek.sh | tail -80` 一次扫 maintainer 评论 + 0-codex 漏洞**。
+任何 controller turn 派 codex / merge PR / post banner / close issue 之后,**turn 结束前必须 `bash .claude/skills/codex-refactor-loop/scripts/peek.sh | tail -80` 一次扫 maintainer 评论 + 0-codex 漏洞**。
 
 理由:`task-notification` 触发的 turn 容易陷入"处理 marker → spawn 下一步 → end turn"线性思维,会跳过 peek 而错过 maintainer 与此 task 并行的新评论。Auric 2026-05-22 04:15 #779 "命名/架构也很差" 评论在 controller spawn #796 r3 judge 期间到达,因为没 peek 漏读 ~20 min,Auric 直接报错 "没监控到"。
 
 例外:turn 唯一动作是 ScheduleWakeup(纯休眠)可省 peek。
 
-### Concurrency monitor:`tools/refactor-loop/concurrency_monitor.py`(强制)
+### Concurrency monitor:`.claude/skills/codex-refactor-loop/scripts/concurrency_monitor.py`(强制)
 
 **60s** 周期 daemon(per Auric 2026-05-21 "60s 就扫描一次"),监控 actual vs expected codex 并发数:
 - expected = active issue/PR 数(per phase 表)
@@ -148,7 +148,7 @@ Per Auric 2026-05-22 "大量标记 auto-loop-stuck 的实际并不需要人介�
 
 启动:
 ```bash
-nohup python3 tools/refactor-loop/concurrency_monitor.py \
+nohup python3 .claude/skills/codex-refactor-loop/scripts/concurrency_monitor.py \
   >> .refactor-loop/logs/concurrency-monitor.log 2>&1 &
 disown
 ```
@@ -179,12 +179,12 @@ fi
 
 事故记录(2026-05-25):session 累计 8 个 issue(#959/#967/#968/#969/#971/#974/#977/#988)merge 后未 close,显示在 open issue list 误导 maintainer。每次 wakeup sweep 见 `🚀 phase:pr-open` label 但关联 PR 已 merged → 必须立即补 close。
 
-### Controller helper 库:`tools/refactor-loop/controller_lib.sh`(强制,per Auric 2026-05-21 "搞错了吧 #690" + "改一下脚本")
+### Controller helper 库:`.claude/skills/codex-refactor-loop/scripts/controller_lib.sh`(强制,per Auric 2026-05-21 "搞错了吧 #690" + "改一下脚本")
 
 7 个曾发生的 bug 都来自 controller boilerplate 重复 + bash 变量传值 bug。统一抽 helper:
 
 ```bash
-source tools/refactor-loop/controller_lib.sh
+source .claude/skills/codex-refactor-loop/scripts/controller_lib.sh
 
 safe_worktree iter25 cluster-026 origin/auto-refact-dev   # → exports WT_PATH + BRANCH
 open_pr_with_label "iter25 cluster-XXX: title" body.md    # → exports PR_NUM(原地传值,无 grep subshell bug)
@@ -268,7 +268,7 @@ Bash(
 
 1. **先 post banner**(blocking Bash,几秒):
    ```bash
-   python3 tools/refactor-loop/post_banner.py \
+   python3 .claude/skills/codex-refactor-loop/scripts/post_banner.py \
      --banner-target <num> --banner-kind <issue|pr> \
      --banner-role <role> --banner-detail "..." \
      --log <log-path> --cd <worktree> --timeout <s>
@@ -902,10 +902,10 @@ Runs **first** on every controller wakeup, before Phase 7 design-issue sweep and
 
 ### Phase 6 现在由独立 daemon 自主完成(per Auric 2026-05-20 "写一个独立脚本, 自动 merge dev 到 auto-refact-dev 分支. 如果有冲突让脚本调用 codex 解决冲突合并. daemon 运行")
 
-**`tools/refactor-loop/dev_sync_daemon.py`** 是独立 daemon,**600s 周期**自主跑 sync,不依赖 controller wakeup:
+**`.claude/skills/codex-refactor-loop/scripts/dev_sync_daemon.py`** 是独立 daemon,**600s 周期**自主跑 sync,不依赖 controller wakeup:
 
 ```bash
-nohup python3 tools/refactor-loop/dev_sync_daemon.py \
+nohup python3 .claude/skills/codex-refactor-loop/scripts/dev_sync_daemon.py \
   >> .refactor-loop/logs/dev-sync-daemon.log 2>&1 &
 disown
 ```
@@ -1043,13 +1043,13 @@ maintainer 只加 1 label:`auto-loop-triage`
 
 **Daemon 自包含**(per Auric 2026-05-23 "不用单独一个脚本吧,复用现有脚本就好"):
 
-`tools/refactor-loop/triage-monitor.sh` 60s 周期:
+`.claude/skills/codex-refactor-loop/scripts/triage-monitor.sh` 60s 周期:
 - 扫 `gh issue list --label "auto-loop-triage" --state open`
 - 新 issue → mark seen + **直接 spawn triage codex**(nohup + disown,daemon 自己派)
 - triage codex 自己读 issue body + update GitHub(reshape or 评论 + label 切换)
 - daemon 不依赖 controller 中转,无中间 event log
 - state 存 `.refactor-loop/triage-monitor-state.json` 防重复
-- 启动:`nohup bash tools/refactor-loop/triage-monitor.sh >> .refactor-loop/logs/triage-monitor.log 2>&1 & disown`
+- 启动:`nohup bash .claude/skills/codex-refactor-loop/scripts/triage-monitor.sh >> .refactor-loop/logs/triage-monitor.log 2>&1 & disown`
 - Liveness:每 wakeup `ps -ef | grep triage-monitor.sh` 必须 ≥1,死了 restart
 - Codex 完成 marker:`TRIAGE_DONE:<issue>:<accept|reject>:<reason>`(写 issue 评论 + 切 label)
 - Controller 下次 wakeup 从 GitHub state derive(issue label 改了即看见)
@@ -1142,7 +1142,7 @@ Update `state.design_pending[i].last_comment_count` and `last_checked` after eve
 
 设计:**daemon 脚本 → 写持续 log → controller sweep 读 log → 处理**。三段解耦:
 
-1. **Daemon 脚本**(`tools/refactor-loop/comment-monitor.sh`)forever 跑,30s 轮询 GitHub:
+1. **Daemon 脚本**(`.claude/skills/codex-refactor-loop/scripts/comment-monitor.sh`)forever 跑,30s 轮询 GitHub:
    - 自己 `gh api .../reactions content=eyes` 给 team-member 新评论加 👀(脚本内 side-effect,不需 controller)
    - emit `new-team-comment: <issue> <author> <comment-id> eyes-reacted-at=<ISO8601>` 到 **stdout**
    - emit `new-outsider-comment: <issue> <author> <id>` 同
@@ -1150,7 +1150,7 @@ Update `state.design_pending[i].last_comment_count` and `last_checked` after eve
 
 2. **持续 log 文件**(强制,per Auric 2026-05-20 修复 stdout 丢失 bug):
    ```bash
-   nohup bash tools/refactor-loop/comment-monitor.sh >> .refactor-loop/logs/comment-monitor.log 2>&1 &
+   nohup bash .claude/skills/codex-refactor-loop/scripts/comment-monitor.sh >> .refactor-loop/logs/comment-monitor.log 2>&1 &
    disown
    ```
    **禁止** `> /dev/null`(之前的 bug)— 否则 controller 看不到 event。所有 daemon(`comment-monitor.sh` / `codex-progress-reporter.sh`)都 append 写自己的 `.log` 文件。
@@ -1847,7 +1847,7 @@ controller **不派 fix codex 不 auto-merge**(此 phase 是 advisory,不接 fix
 | **Issue body 有最小描述** | body 长度 ≥ 100 chars(过短 issue triage 也判不出) |
 | **未在 ongoing 维护讨论** | 最近 24h 内**无** human comment(避免打断真人 maintainer 已在 reply 的 issue) |
 
-全部 yes → 加 `auto-loop-triage` label,由 `tools/refactor-loop/triage-monitor.sh` daemon 自动 spawn triage codex(已有现成 daemon,本 phase 复用)。
+全部 yes → 加 `auto-loop-triage` label,由 `.claude/skills/codex-refactor-loop/scripts/triage-monitor.sh` daemon 自动 spawn triage codex(已有现成 daemon,本 phase 复用)。
 
 ### Triage codex 行为(已 by Phase 7 Path B 定义)
 
@@ -1912,7 +1912,7 @@ Concretely, this means:
 1. **下一 iter audit**(若上一 iter audit `AUDIT_DONE` 且对应 N+1 audit log 不存在)— 最有价值,产出新 cluster 链路
 2. **next-next iter audit**(N+2,speculative parallel)— 即使 iter N+1 audit 仍在跑也可派
 3. **历史 closed design issue retrospective codex** — 检查最近 5 个 closed design issue,是否有 follow-up cluster 被漏(典型:reflector r4 提到的 "cross-stream unification" 应该被独立 cluster 捕获)
-4. **tools/refactor-loop self-audit codex** — 审计 skill / scripts 自身 tech debt(过长 section / 重复 helper / 老 prompt 文件可删)
+4. **.claude/skills/codex-refactor-loop/scripts self-audit codex** — 审计 skill / scripts 自身 tech debt(过长 section / 重复 helper / 老 prompt 文件可删)
 5. **docs sync codex** — 用最近 merged PRs 自动更新 `docs/audit-scorecard/`(如缺)
 6. **CI guard completeness codex** — 检查 `tools/ci/*_guard.sh` 是否覆盖所有 CLAUDE 条款
 
@@ -2265,13 +2265,13 @@ done
 
 **问题**:codex 单 task 可能跑 30–120 分钟。期间人类打开 issue/PR 只看到"派出"banner,看不到中间进展(它在分析哪个文件 / 在写什么 / 跑到第几步)。等结果 banner 时已经 1–2 小时过去。
 
-**规则**:`tools/refactor-loop/codex-progress-reporter.sh` 作为**长跑 daemon**每 600s 扫所有 in-flight codex log,对每个 codex **edit-in-place** 一条 progress comment 到关联 issue/PR(不堆评论)。Comment body 包含:已跑时长 + log tail 25 行。完成时把 ⏳ 改 ✅。
+**规则**:`.claude/skills/codex-refactor-loop/scripts/codex-progress-reporter.sh` 作为**长跑 daemon**每 600s 扫所有 in-flight codex log,对每个 codex **edit-in-place** 一条 progress comment 到关联 issue/PR(不堆评论)。Comment body 包含:已跑时长 + log tail 25 行。完成时把 ⏳ 改 ✅。
 
 ### 启动 / 运维
 
 ```bash
 # 启动(放后台,长跑直到 loop 停)
-INTERVAL=600 bash tools/refactor-loop/codex-progress-reporter.sh &
+INTERVAL=600 bash .claude/skills/codex-refactor-loop/scripts/codex-progress-reporter.sh &
 # 停止
 pkill -f codex-progress-reporter.sh
 # 重置(误 post 后清理)

--- a/.claude/skills/codex-refactor-loop/prompts/_github-post-rules.md
+++ b/.claude/skills/codex-refactor-loop/prompts/_github-post-rules.md
@@ -33,7 +33,7 @@ escalation / consensus pick **必须**给清晰"方案 1/2/3"表格,cell 一行�
 
 ## 硬约束
 
-- **第一行 `## 🤖 ` 开头**:`tools/refactor-loop/comment-monitor.sh` 据此识别 controller-post 跳过 👀 react。漏 🤖 → monitor 会把你的 post 当成 maintainer 评论 react 自己 → 误循环。
+- **第一行 `## 🤖 ` 开头**:`.claude/skills/codex-refactor-loop/scripts/comment-monitor.sh` 据此识别 controller-post 跳过 👀 react。漏 🤖 → monitor 会把你的 post 当成 maintainer 评论 react 自己 → 误循环。
 - **中文 only**:per [SKILL.md 工作语言规则],不要平行 EN section。Code identifier / file path / proto 字段名保留原英文。CLAUDE/AGENTS 条款引用 verbatim 不翻译。
 - **TL;DR ≤ 6 行**(3 bullet + 可选 cc 行)。
 - **raw artifact 必折叠**:不要让 TL;DR 之后立刻出现 raw YAML / verbatim spec dump。先用人话讲,raw 都进 `<details>`。

--- a/.claude/skills/codex-refactor-loop/scripts/codex-progress-reporter.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/codex-progress-reporter.sh
@@ -1,0 +1,240 @@
+#!/bin/bash
+# codex-progress-reporter.sh
+# Per Auric 2026-05-19 "每 10 分钟更新一次各 codex 进展到 issue/PR".
+# 每 600s 扫 .refactor-loop/logs/*.log; 对未结束 (无 EXIT=) 的 log 提取 tail; edit-in-place
+# 一条 progress comment 到关联 issue/PR. 首次创建, 后续 update 同一 comment id.
+# 不会膨胀评论数. 完成时(检测到 EXIT=) 自动 post 终结 banner 并停止追该 log.
+#
+# State: .refactor-loop/codex-progress-state.json
+#   { "<log-basename>": { "target": "<num>", "kind": "issue|pr", "comment_id": <id>, "last_md5": "<sha>", "finished": false } }
+#
+# 启动: bash .claude/skills/codex-refactor-loop/scripts/codex-progress-reporter.sh &
+# 停止: kill <pid>
+
+set -u  # 不用 -e/pipefail — daemon 必须存活,subshell 偶发 non-zero 不应导致整个 daemon 死
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+INTERVAL="${INTERVAL:-600}"
+STATE_DIR=".refactor-loop"
+STATE_FILE="$STATE_DIR/codex-progress-state.json"
+LOG_DIR="$STATE_DIR/logs"
+PROMPTS_DIR="$STATE_DIR/prompts"
+
+mkdir -p "$STATE_DIR"
+[ -f "$STATE_FILE" ] || echo "{}" > "$STATE_FILE"
+
+log_msg() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" >&2; }
+
+# parse log basename → target number (issue or PR)
+# 优先从对应 prompt 文件 grep "#NNN"; 次选从 log 文件名 pattern 提取
+parse_target() {
+  local base=$1
+  local n=""
+  # review-pr*/fix-pr*/phase9-issue* 等文件名本身带权威 target → 优先文件名
+  case "$base" in
+    review-pr*) n=$(echo "$base" | sed -nE 's/^review-pr([0-9]+).*/\1/p') ;;
+    fix-pr*) n=$(echo "$base" | sed -nE 's/^fix-pr([0-9]+).*/\1/p') ;;
+    phase9-issue*) n=$(echo "$base" | sed -nE 's/^phase9-issue([0-9]+).*/\1/p') ;;
+  esac
+  if [ -z "$n" ]; then
+    # implement-/verify- 等 cluster log 没有 PR 号 → 从 prompt body 取最后 #NNN
+    # meta-cluster prompts 如 "(关 #711 #713 #715)" → primary 是最后(#715)
+    local prompt="$PROMPTS_DIR/$base.md"
+    if [ -f "$prompt" ]; then
+      n=$(grep -oE "#[0-9]+" "$prompt" 2>/dev/null | tail -1 | tr -d '#' || true)
+    fi
+  fi
+  echo "$n"
+}
+
+# return "pr" or "issue"
+parse_kind() {
+  local n=$1
+  if gh pr view "$n" --json number >/dev/null 2>&1; then
+    echo "pr"
+  else
+    echo "issue"
+  fi
+}
+
+is_finished() {
+  # 只看末 5 行 — wrapper 在结束时 append "EXIT=<code>\nDONE_AT=..." 作为最后两行
+  # 不能 grep 全 log,因为 codex 中途可能 echo / cat 含 "EXIT=" 的内容造成误判
+  tail -5 "$1" | grep -q "^EXIT="
+}
+
+# zombie: 30 min 未写,但无 EXIT marker → 进程很可能死了,不该再当 in-flight 持续 post
+is_zombie() {
+  local log=$1
+  if is_finished "$log"; then return 1; fi
+  local mtime now
+  mtime=$(stat -f %m "$log" 2>/dev/null || stat -c %Y "$log")
+  now=$(date +%s)
+  [ $(( now - mtime )) -gt 1800 ]
+}
+
+extract_tail() {
+  # 取 last 25 行, 跳过 EXIT/DONE_AT marker (不影响)
+  tail -30 "$1" | head -25
+}
+
+elapsed_sec() {
+  local log=$1 mtime now
+  mtime=$(stat -f %B "$log" 2>/dev/null || stat -c %Y "$log")
+  now=$(date +%s)
+  echo $(( now - mtime ))
+}
+
+build_body() {
+  local base=$1 log=$2 finished=$3
+  local elapsed_s
+  elapsed_s=$(elapsed_sec "$log")
+  local elapsed_min=$(( elapsed_s / 60 ))
+  local tail_block
+  tail_block=$(extract_tail "$log")
+  cat <<EOF
+## 📊 codex 进展 $base (⏳ 进行中; 已跑 ${elapsed_min} min)
+
+\`\`\`
+$tail_block
+\`\`\`
+
+> 自动更新每 10 分钟;edit-in-place 不堆评论;**codex 完成后此 comment 自动删除**(per Auric "完成后删掉就好了 否则太占空间")。
+🤖 controller progress reporter
+EOF
+}
+
+state_get() {
+  local key=$1 field=$2
+  jq -r --arg k "$key" --arg f "$field" '.[$k][$f] // empty' "$STATE_FILE"
+}
+
+state_set() {
+  local key=$1 target=$2 kind=$3 cid=$4 md5=$5 finished=$6
+  local tmp
+  tmp=$(mktemp)
+  jq --arg k "$key" --arg t "$target" --arg kd "$kind" --argjson cid "$cid" --arg m "$md5" --argjson fin "$finished" \
+    '.[$k] = {target: $t, kind: $kd, comment_id: $cid, last_md5: $m, finished: $fin}' \
+    "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+}
+
+post_or_update() {
+  local base=$1 log=$2
+  local target kind cid prev_md5 finished
+  target=$(state_get "$base" "target")
+  if [ -z "$target" ]; then
+    target=$(parse_target "$base")
+    if [ -z "$target" ]; then
+      log_msg "skip $base: no target"
+      return
+    fi
+    kind=$(parse_kind "$target")
+    cid="null"
+    prev_md5=""
+  else
+    kind=$(state_get "$base" "kind")
+    cid=$(state_get "$base" "comment_id")
+    prev_md5=$(state_get "$base" "last_md5")
+  fi
+  [ -z "$cid" ] && cid="null"
+
+  if is_finished "$log"; then
+    finished="true"
+  elif is_zombie "$log"; then
+    log_msg "skip zombie log $base (no EXIT, mtime > 30 min)"
+    return
+  else
+    finished="false"
+  fi
+
+  # 已 finished 且上次已记录 finished=true → skip
+  local prev_finished
+  prev_finished=$(state_get "$base" "finished")
+  if [ "$finished" = "true" ] && [ "$prev_finished" = "true" ]; then
+    return
+  fi
+
+  # 状态从 in-flight → finished: 删 comment + 从 state 移除 (per Auric "完成后删掉就好了, 否则太占空间")
+  if [ "$finished" = "true" ] && [ -n "$cid" ] && [ "$cid" != "null" ] && [ "$cid" != "0" ]; then
+    if gh api -X DELETE "repos/aevatarAI/aevatar/issues/comments/$cid" >/dev/null 2>&1; then
+      log_msg "deleted progress comment for $base (finished, cid=$cid was=$kind #$target)"
+    else
+      log_msg "FAIL to delete comment $cid for $base (already gone?); marking finished anyway"
+    fi
+    # mark finished in state so we don't re-create next tick
+    state_set "$base" "$target" "$kind" "0" "deleted" "true"
+    return
+  fi
+
+  local body cur_md5
+  body=$(build_body "$base" "$log" "$finished")
+  cur_md5=$(echo "$body" | md5)
+
+  # 内容没变化且没 finish 切换 → skip
+  if [ "$cur_md5" = "$prev_md5" ] && [ "$finished" = "$prev_finished" ]; then
+    return
+  fi
+
+  local body_file
+  body_file="/tmp/codex-progress-$$-$(date +%s%N)-$RANDOM.md"
+  echo "$body" > "$body_file"
+
+  if [ "$cid" = "null" ] || [ -z "$cid" ]; then
+    # 首次见到。Per Auric 2026-05-20 "GitHub 反映原则" + "实际状态 = GitHub 状态":
+    # 短 codex 在 reporter tick 间 spawn+complete,首次见到时已 finished — 之前 silent skip
+    # 导致 GitHub 上看不到任何 codex 痕迹(maintainer 不知道有事发生)。
+    # 修法:首见 finished log → post 一张简短"✅ 已完成"banner(不删,留下 GitHub 痕迹)。
+    # Controller 后续 sweep 处理 marker 时再覆盖 / append 新 banner。
+    local url
+    # parse_kind fallback:先 try $kind,fail 再 try 另一个(防 #700 issue 被当 pr)
+    if [ "$kind" = "pr" ]; then
+      url=$(gh pr comment "$target" --body-file "$body_file" 2>/dev/null | tail -1)
+      [ -z "$url" ] && {
+        url=$(gh issue comment "$target" --body-file "$body_file" 2>/dev/null | tail -1)
+        [ -n "$url" ] && kind="issue"
+      }
+    else
+      url=$(gh issue comment "$target" --body-file "$body_file" 2>/dev/null | tail -1)
+      [ -z "$url" ] && {
+        url=$(gh pr comment "$target" --body-file "$body_file" 2>/dev/null | tail -1)
+        [ -n "$url" ] && kind="pr"
+      }
+    fi
+    local new_cid
+    new_cid=$(echo "$url" | grep -oE 'issuecomment-[0-9]+' | sed 's/issuecomment-//')
+    if [ -n "$new_cid" ]; then
+      state_set "$base" "$target" "$kind" "$new_cid" "$cur_md5" "$finished"
+      log_msg "created progress comment for $base → $kind #$target (cid=$new_cid)"
+    else
+      log_msg "FAIL to create comment for $base → $kind #$target"
+    fi
+  else
+    # edit 现有 comment
+    if gh api -X PATCH "repos/aevatarAI/aevatar/issues/comments/$cid" -F body=@"$body_file" >/dev/null 2>&1; then
+      state_set "$base" "$target" "$kind" "$cid" "$cur_md5" "$finished"
+      log_msg "edited progress comment for $base (cid=$cid, finished=$finished)"
+    else
+      log_msg "FAIL to edit comment $cid for $base; will retry next tick"
+    fi
+  fi
+
+  rm -f "$body_file"
+}
+
+# 主 loop
+while true; do
+  log_msg "tick"
+  for log in "$LOG_DIR"/*.log; do
+    [ -f "$log" ] || continue
+    base=$(basename "$log" .log)
+    # 跳过 audit log(audit 完成后才能进 phase 2,不挂 issue);可以选 post 到 dashboard
+    case "$base" in
+      audit-iter-*) continue ;;
+      remote-ci-*) continue ;;
+    esac
+    post_or_update "$base" "$log"
+  done
+  sleep "$INTERVAL"
+done

--- a/.claude/skills/codex-refactor-loop/scripts/comment-monitor.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/comment-monitor.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# .claude/skills/codex-refactor-loop/scripts/comment-monitor.sh
+#
+# 独立运行的 comment monitor:
+# - 自己跑 gh api 查 design issue / PR 新评论
+# - 检测到 team-member 新评论 → 自己加 👀 react(不等 controller)
+# - 同时 emit `new-team-comment: <issue> <author> <comment-id>` 到 stdout
+#   (controller 通过 Monitor tool 包它,把 stdout 行变成 task-notification)
+# - 跑 forever,除非外部 kill
+#
+# 用法(controller 通过 Monitor tool 包):
+#   Monitor(persistent: true, command: ".claude/skills/codex-refactor-loop/scripts/comment-monitor.sh")
+#
+# state 文件:.refactor-loop/comment-monitor-state.json (JSON map: comment_id → "seen")
+
+set -u
+REPO="aevatarAI/aevatar"
+STATE_FILE="${STATE_FILE:-/Users/auric/aevatar/.refactor-loop/comment-monitor-state.json}"
+INTERVAL="${INTERVAL:-30}"
+
+mkdir -p "$(dirname "$STATE_FILE")"
+[ -f "$STATE_FILE" ] || echo '{}' > "$STATE_FILE"
+
+# Maintainer whitelist (handles + git author names) per SKILL.md
+is_team_member() {
+  case "$1" in
+    loning|Loning|eanzhao|louis4li|louis.li|jason|jason-aelf|AbigailDeng|potter|potter-sun) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Skip controller / writer-codex own posts. body first line check.
+# 包括:
+# - "## 🤖" (codex artifact)
+# - "## 📊" (controller status banner per SKILL.md status-banner)
+# - "## 📢 cc" (cc 原作者)
+# - "## 📎" (attachment / raw)
+# - "## ✅" (consensus reached / merged)
+# - "## 🎉" (celebration)
+# - "## 🔄" (rebase / round dispatched)
+# - "## Phase " (writer-codex 标题如 "## Phase 9 r2 已收敛..." / "## Phase 8 ...")
+# - "## Studio " / "## Workflow " / "## iter1" (writer-codex 通常用 cluster 主题做标题)
+# - "Generated with Claude Code" 后缀
+# - 任何 body 内含 "POSTED:phase" 标记的(writer-codex 自身 marker 不会出现在 body,但若误传则 skip)
+is_controller_post() {
+  # 主判定:sentinel ⟦AI:AUTO-LOOP⟧ 在 body 任意位置 → AI post(per SKILL "AI 内容标识符")
+  case "$2" in
+    *"⟦AI:AUTO-LOOP⟧"*) return 0 ;;
+    *"Generated with Claude Code"*) return 0 ;;
+  esac
+  # Legacy emoji-prefix(过渡期老评论无 sentinel)— 任何 ## + emoji + ... 第一行
+  case "$1" in
+    "## 🤖"*|"## 📊"*|"## 📢"*|"## 📎"*|"## ✅"*|"## 🆘"*|"## 🎉"*|"## 🔄"*|"## ⏸️"*|"## 🔍"*|"## 🛠️"*|"## 🚀"*|"## 👀"*|"## 🔧"*|"## ⚙️"*|"## Phase "*|"## Studio "*|"## Workflow "*|"## iter"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+seen() {
+  jq -e --arg id "$1" 'has($id)' "$STATE_FILE" > /dev/null 2>&1
+}
+
+mark_seen() {
+  local id="$1" tmp
+  tmp=$(mktemp)
+  jq --arg id "$id" '. + {($id): "seen"}' "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+}
+
+while true; do
+  # Auto-discover targets: open issues with refactor-design-needed label + open PRs with auto-loop label
+  targets=$(
+    {
+      gh issue list --repo "$REPO" --state open --label "refactor-design-needed" --json number -q '.[].number' 2>/dev/null
+      gh pr list --repo "$REPO" --state open --label "auto-loop" --json number -q '.[].number' 2>/dev/null
+    } | sort -u
+  )
+
+  for n in $targets; do
+    # Try issue then pr
+    comments=$(gh api "repos/$REPO/issues/$n/comments" --jq '.[] | {id, author: .user.login, body, created_at}' 2>/dev/null)
+    [ -z "$comments" ] && continue
+
+    while IFS= read -r raw; do
+      id=$(jq -r '.id' <<<"$raw")
+      author=$(jq -r '.author' <<<"$raw")
+      body=$(jq -r '.body' <<<"$raw")
+      created=$(jq -r '.created_at' <<<"$raw")
+      [ -z "$id" ] && continue
+
+      if seen "$id"; then continue; fi
+
+      first_line=$(echo "$body" | head -1)
+      if is_controller_post "$first_line" "$body"; then
+        mark_seen "$id"
+        continue
+      fi
+
+      if ! is_team_member "$author"; then
+        # Not a team member; mark seen so we don't keep checking,
+        # but log a one-line event for controller to decide (e.g. PushNotification)
+        mark_seen "$id"
+        echo "new-outsider-comment: $n $author $id (skipped reply per security gate)"
+        continue
+      fi
+
+      # Team member new comment → 立刻 eyes react
+      react_out=$(gh api "repos/$REPO/issues/comments/$id/reactions" -X POST -f content=eyes 2>&1)
+      react_ok=$?
+      if [ $react_ok -eq 0 ]; then
+        echo "new-team-comment: $n $author $id eyes-reacted-at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        # 通知 controller 缩 wakeup:append 到 pending events file
+        # controller per-wakeup 第一步读此文件,有新 entry → 下次 wakeup 缩到 600s
+        echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) new-team-comment $n $author $id" \
+          >> /Users/auric/aevatar/.refactor-loop/.controller-pending-events.log
+        # 立刻 post status 卡片让 maintainer 看到 daemon 已识别 + controller 在路上
+        # (per Auric 2026-05-20 "加了'看到'表情后, codex 启动也并没有更新状态卡片")
+        body_excerpt=$(echo "$body" | head -1 | head -c 80)
+        tmp_banner=$(mktemp)
+        cat > "$tmp_banner" <<EOF
+## 📊 状态 — 已收到 maintainer 评论(daemon 识别)
+
+| 维度 | 值 |
+|---|---|
+| 触发评论 | id=$id author=$author |
+| 评论摘要 | $body_excerpt |
+| daemon 反应 | 👀 eyes react 已加 |
+| 下一步 | controller 下次 wakeup(≤25 min)读 daemon log → 派 fresh codex round(maintainer-reply-resets-the-round)→ 更新本卡片 |
+| **是否需要人介入** | ❌ 否(自动响应中) |
+
+🤖 comment-monitor.sh daemon
+
+⟦AI:AUTO-LOOP⟧
+EOF
+        post_out=$(gh issue comment "$n" --repo "$REPO" --body-file "$tmp_banner" 2>&1)
+        if [ $? -eq 0 ]; then
+          echo "daemon-banner-posted: $n $id $(echo "$post_out" | grep -oE 'https://[^ ]+' | head -1)"
+        else
+          post_out=$(gh pr comment "$n" --repo "$REPO" --body-file "$tmp_banner" 2>&1)
+          [ $? -eq 0 ] && echo "daemon-banner-posted: $n $id $(echo "$post_out" | grep -oE 'https://[^ ]+' | head -1)" \
+            || echo "daemon-banner-FAILED: $n $id $(echo "$post_out" | head -1)"
+        fi
+        rm -f "$tmp_banner"
+      else
+        echo "new-team-comment: $n $author $id eyes-react-FAILED: $(echo "$react_out" | head -1)"
+      fi
+      mark_seen "$id"
+    done < <(echo "$comments" | jq -c '.')
+  done
+
+  sleep "$INTERVAL"
+done

--- a/.claude/skills/codex-refactor-loop/scripts/concurrency_monitor.py
+++ b/.claude/skills/codex-refactor-loop/scripts/concurrency_monitor.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""
+concurrency_monitor.py — 监控 codex 并发数,不足则告警 + 主动介入修复
+
+per Auric 2026-05-20 "写一个脚本监控一下, 如果并发 codex 数量不足, 则告警, 主动
+介入修复并同时升级 skills"。
+
+设计:
+- 周期 300s tick
+- 从 GitHub 推算 期望并发数(每个 active phase issue/PR contribute 1)
+  - 🔍 design-solving       → 1 solver-round OR 1 judge OR 1 reflector
+  - 🔧 fixing               → 1 fix codex
+  - 👀 reviewing            → 3 reviewer(每 r1 round)
+  - 🛠️ implementing         → 1 implement codex
+  - ⚙️ ci-running           → 0(等 CI,无需 codex)
+  - 🚀 pr-open(待派 reviewer) → 0~3
+- 与实际 `ps codex exec` 数对比
+- 不足(实际 < 期望 * 0.5)且持续 2 个 tick → 告警
+
+主动介入修复:
+1. 写告警到 `.refactor-loop/.concurrency-alert.log`(append + timestamp + 详情)
+2. 写到 `.refactor-loop/.controller-pending-events.log`(controller 下次 wakeup 处理)
+3. log 详细 expected breakdown(哪些 issue/PR 缺 codex)
+4. 不自动 spawn codex(business logic 在 controller,不在 daemon)
+
+启动:
+  nohup python3 .claude/skills/codex-refactor-loop/scripts/concurrency_monitor.py \\
+    >> .refactor-loop/logs/concurrency-monitor.log 2>&1 &
+  disown
+
+⟦AI:AUTO-LOOP⟧
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+INTERVAL = int(os.environ.get("INTERVAL", "60"))  # per Auric 2026-05-21 "60s 就扫描一次"
+MIN_PARALLEL = int(os.environ.get("MIN_PARALLEL", "1"))  # 任何 active task 都至少要 1 codex
+REPO_ROOT = Path(os.environ.get("REPO_ROOT", "/Users/auric/aevatar"))
+ALERT_LOG = REPO_ROOT / ".refactor-loop" / ".concurrency-alert.log"
+PENDING_EVENTS = REPO_ROOT / ".refactor-loop" / ".controller-pending-events.log"
+
+# phase label → 期望 codex 数(per active issue/PR)
+PHASE_EXPECTED = {
+    "🔍 phase:design-solving": 1,  # 至少 1 codex(solver round / judge / reflector)
+    "🔧 phase:fixing": 1,
+    "👀 phase:reviewing": 1,        # 至少 1 reviewer
+    "🛠️ phase:implementing": 1,
+    # 下列 phase 不期望 codex:
+    "⚙️ phase:ci-running": 0,
+    "🚀 phase:pr-open": 0,
+    "✅ phase:consensus-reached": 0,
+    "🎉 phase:merged": 0,
+    "⏸️ phase:blocked": 0,
+}
+
+# consecutive low-tick counter persisted in state file
+STATE_FILE = REPO_ROOT / ".refactor-loop" / ".concurrency-monitor-state.json"
+
+
+def log(msg: str) -> None:
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    print(f"[{ts}] {msg}", flush=True)
+
+
+def run(cmd: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def load_state() -> dict:
+    if STATE_FILE.exists():
+        try:
+            return json.loads(STATE_FILE.read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def save_state(s: dict) -> None:
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    STATE_FILE.write_text(json.dumps(s, indent=2))
+
+
+def count_in_flight_codex() -> int:
+    r = run(["ps", "-eo", "command="])
+    n = sum(1 for line in r.stdout.splitlines()
+            if "timeout 3600 codex" in line or "timeout 5400 codex" in line)
+    return n
+
+
+def list_auto_loop_issues() -> list[dict]:
+    """[{number, kind:issue|pr, phase_label, human_label}]"""
+    items: list[dict] = []
+    for kind, gh_cmd in (("issue", "issue"), ("pr", "pr")):
+        r = run(["gh", gh_cmd, "list",
+                 "--label", "auto-loop", "--state", "open",
+                 "--json", "number,labels", "--limit", "100"])
+        if r.returncode != 0:
+            continue
+        try:
+            arr = json.loads(r.stdout)
+        except Exception:
+            continue
+        for entry in arr:
+            num = entry.get("number")
+            labels = [l.get("name", "") for l in entry.get("labels", [])]
+            phase = next((l for l in labels if l.startswith(("🔍", "🔧", "👀", "🛠️", "⚙️", "🚀", "✅", "🎉", "⏸️"))), "")
+            human = next((l for l in labels if l.startswith(("🤖", "👤", "🆘"))), "")
+            items.append({"number": num, "kind": kind, "phase": phase, "human": human})
+    return items
+
+
+def compute_expected(items: list[dict]) -> tuple[int, list[dict]]:
+    """Return (total_expected, breakdown)."""
+    breakdown = []
+    total = 0
+    for it in items:
+        if it["human"] in ("👤 human:需-maintainer-决策", "🆘 human:卡死", "🆘 human:卡死-需-rework"):
+            # 等人介入,不期望 codex
+            continue
+        n = PHASE_EXPECTED.get(it["phase"], 0)
+        if n > 0:
+            breakdown.append({"id": f"#{it['number']}", "kind": it["kind"], "phase": it["phase"], "expected": n})
+            total += n
+    return total, breakdown
+
+
+def write_alert(msg: str, detail: dict) -> None:
+    ALERT_LOG.parent.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    line = f"[{ts}] {msg} | detail={json.dumps(detail, ensure_ascii=False)}"
+    with ALERT_LOG.open("a") as f:
+        f.write(line + "\n")
+    # 通知 controller(events log)
+    with PENDING_EVENTS.open("a") as f:
+        f.write(f"{ts} concurrency-alert {msg}\n")
+
+
+def tick() -> None:
+    state = load_state()
+    low_streak = int(state.get("low_streak", 0))
+    zero_streak = int(state.get("zero_streak", 0))
+
+    items = list_auto_loop_issues()
+    expected, breakdown = compute_expected(items)
+    actual = count_in_flight_codex()
+
+    log(f"actual={actual} expected={expected} low_streak={low_streak} zero_streak={zero_streak}")
+
+    # P0 规则:有 active task 但 actual==0 → IMMEDIATE alert
+    # per Auric 2026-05-21 "没有并行 codex 就有问题"。controller 必须立刻 no-gap 补派。
+    if expected > 0 and actual == 0:
+        zero_streak += 1
+        state["zero_streak"] = zero_streak
+        detail = {
+            "actual": 0,
+            "expected": expected,
+            "breakdown": breakdown,
+            "zero_streak": zero_streak,
+            "severity": "P0",
+            "rule": "no-gap-violation",
+        }
+        write_alert(f"P0 no-gap-violation: 0 codex with {expected} active task(s)", detail)
+        log(f"P0 ALERT: 0 codex but {expected} active task(s);streak={zero_streak};see {ALERT_LOG}")
+        # 0 streak 不阻止其他逻辑,return
+        save_state(state)
+        return
+    else:
+        state["zero_streak"] = 0
+
+    # 阈值:实际 < ceil(expected/2) 算 low
+    threshold = max(1, (expected + 1) // 2) if expected > 0 else 0
+    if expected == 0:
+        # 无 active task,don't alert
+        state["low_streak"] = 0
+        save_state(state)
+        return
+
+    if actual < threshold:
+        low_streak += 1
+        state["low_streak"] = low_streak
+        # >= 2 consecutive low tick → alert(避免 reporter 临时未识别 codex 误报)
+        if low_streak >= 2:
+            detail = {
+                "actual": actual,
+                "expected": expected,
+                "threshold": threshold,
+                "breakdown": breakdown,
+                "low_streak": low_streak,
+            }
+            write_alert(f"codex-concurrency-low actual={actual} expected={expected}", detail)
+            log(f"ALERT: actual={actual} < threshold={threshold} (streak={low_streak}); see {ALERT_LOG}")
+    else:
+        if low_streak > 0:
+            log(f"recovered: actual={actual} >= threshold={threshold}")
+        state["low_streak"] = 0
+    save_state(state)
+
+
+def main() -> None:
+    log(f"concurrency_monitor (Python) started: interval={INTERVAL}s")
+    while True:
+        try:
+            tick()
+        except Exception as e:
+            log(f"EXCEPTION in tick: {e!r}")
+        time.sleep(INTERVAL)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/codex-refactor-loop/scripts/controller_lib.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/controller_lib.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# controller_lib.sh — bash library for codex-refactor-loop controller actions
+#
+# per Auric 2026-05-21 "你完整分析一下,改一下脚本":
+# 7 个系统性问题中的 1/2/3/5/6 都源于 controller 每次手工写 boilerplate
+# (post_banner + spawn + commit + push + close issue + cleanup labels)。
+# 这个库统一抽象,消除 bash 变量传值 bug、重复 sed、worktree race。
+#
+# Usage(在 controller 里):
+#   source .claude/skills/codex-refactor-loop/scripts/controller_lib.sh
+#   merge_pr 781 778   # PR #781 merge + close #778 + cleanup labels
+#   safe_worktree iter25 cluster-026 origin/auto-refact-dev
+#   open_pr_with_label "iter25 cluster-NNN: ..." pr-body.md auto-refact-dev
+#
+# ⟦AI:AUTO-LOOP⟧
+
+set -u
+
+REPO_ROOT="${REPO_ROOT:-/Users/auric/aevatar}"
+
+# Fixes "git worktree add already exists" — detect-or-create
+# Usage: safe_worktree <iter> <cluster-id> <base-ref>
+# Sets WT_PATH and BRANCH env vars on success.
+safe_worktree() {
+  local iter="$1" cluster="$2" base="$3"
+  WT_PATH="${REPO_ROOT}-wt-iter${iter}-${cluster}"
+  BRANCH="refactor/iter${iter}-${cluster}"
+  if [ -d "$WT_PATH" ]; then
+    echo "  ✓ worktree exists: $WT_PATH" >&2
+    return 0
+  fi
+  if git -C "$REPO_ROOT" show-ref --quiet "refs/heads/$BRANCH"; then
+    git -C "$REPO_ROOT" worktree add "$WT_PATH" "$BRANCH" 2>&1 | tail -2 >&2
+  else
+    git -C "$REPO_ROOT" worktree add -b "$BRANCH" "$WT_PATH" "$base" 2>&1 | tail -2 >&2
+  fi
+  export WT_PATH BRANCH
+}
+
+# Post-merge cleanup: merge PR + close linked issue + cleanup labels on both
+# Usage: merge_pr <pr-number> [linked-issue]
+merge_pr() {
+  local pr="$1" linked_issue="${2:-}"
+  if [ -z "$pr" ]; then
+    echo "merge_pr: missing pr number" >&2
+    return 1
+  fi
+  # Auto-extract Closes #N if linked_issue not provided
+  if [ -z "$linked_issue" ]; then
+    linked_issue=$(gh pr view "$pr" --json body --jq '.body' 2>/dev/null | grep -oE "Closes #[0-9]+" | head -1 | grep -oE "[0-9]+")
+  fi
+  gh pr merge "$pr" --admin --squash --delete-branch 2>&1 | tail -1
+  # Cleanup PR labels: in-flight → merged
+  gh pr edit "$pr" \
+    --remove-label "🚀 phase:pr-open" \
+    --remove-label "👀 phase:reviewing" \
+    --remove-label "🔧 phase:fixing" \
+    --remove-label "⏸️ phase:blocked" \
+    --remove-label "auto-loop-stuck" \
+    --add-label "🎉 phase:merged" 2>&1 >/dev/null
+  # Close linked issue + cleanup its labels
+  if [ -n "$linked_issue" ]; then
+    gh issue close "$linked_issue" --reason "completed" --comment "✅ Auto-merged via PR #${pr}。⟦AI:AUTO-LOOP⟧" 2>&1 | tail -1
+    gh issue edit "$linked_issue" \
+      --remove-label "🔍 phase:design-solving" \
+      --remove-label "🛠️ phase:implementing" \
+      --remove-label "🤖 human:auto-推进" \
+      --remove-label "⏸️ phase:blocked" \
+      --remove-label "auto-loop-stuck" \
+      --remove-label "🆘 human:卡死-需-rework" \
+      --add-label "🎉 phase:merged" 2>&1 >/dev/null
+  fi
+  # Remove worktree if exists
+  local wt
+  wt=$(git -C "$REPO_ROOT" worktree list --porcelain | awk -v b="$(gh pr view "$pr" --json headRefName --jq '.headRefName' 2>/dev/null)" '
+    $1 == "worktree" { path=$2 }
+    $1 == "branch" && $2 == "refs/heads/"b { print path; exit }
+  ')
+  [ -n "$wt" ] && [ "$wt" != "$REPO_ROOT" ] && git -C "$REPO_ROOT" worktree remove "$wt" --force 2>&1 | tail -1
+}
+
+# Open PR + add auto-loop label atomically + capture PR number into PR_NUM
+# Usage: open_pr_with_label <title> <body-file> [base] [head]
+# Sets PR_NUM env var.
+# head 必须显式传(controller 当前分支可能不是 cluster branch),per 2026-05-22
+# Auric "PR #802 创建失败 same as base branch" 教训。
+open_pr_with_label() {
+  local title="$1" body_file="$2" base="${3:-auto-refact-dev}" head="${4:-}"
+  if [ -z "$head" ]; then
+    echo "open_pr_with_label: head branch required (avoid gh fallback to current branch = base)" >&2
+    return 1
+  fi
+  local pr_url
+  pr_url=$(gh pr create --base "$base" --head "$head" --title "$title" --body-file "$body_file" 2>&1 | tail -1)
+  PR_NUM=$(echo "$pr_url" | grep -oE "pull/[0-9]+" | grep -oE "[0-9]+")
+  if [ -z "$PR_NUM" ]; then
+    echo "open_pr_with_label: failed to extract PR num from: $pr_url" >&2
+    return 1
+  fi
+  gh pr edit "$PR_NUM" --add-label "auto-loop,🚀 phase:pr-open,👀 phase:reviewing,🤖 human:auto-推进" 2>&1 >/dev/null
+  echo "$pr_url"
+  export PR_NUM
+}
+
+# Substitute {{handlebars}} placeholders in a template using current env vars
+# Usage: render_template <template-file> <output-file>
+# Reads $CLUSTER_ID, $ITERATION, $WORKTREE_PATH, $BRANCH, $OLD_PATTERN, $NEW_PRINCIPLE, $SCOPE_PATHS, $VERIFICATION_HINTS, and $VAR in template.
+render_template() {
+  local in="$1" out="$2"
+  perl -pe '
+    s/\{\{cluster_id\}\}/$ENV{CLUSTER_ID}/g;
+    s/\{\{iteration\}\}/$ENV{ITERATION}/g;
+    s/\{\{worktree_path\}\}/$ENV{WORKTREE_PATH}/g;
+    s/\{\{branch\}\}/$ENV{BRANCH}/g;
+    s/\{\{old_pattern\}\}/$ENV{OLD_PATTERN}/g;
+    s/\{\{new_principle\}\}/$ENV{NEW_PRINCIPLE}/g;
+    s/\{\{scope_paths\}\}/$ENV{SCOPE_PATHS}/g;
+    s/\{\{verification_hints\}\}/$ENV{VERIFICATION_HINTS}/g;
+  ' < "$in" | envsubst > "$out"
+}
+
+# Sweep all closed auto-loop issues/PRs and clean stale in-flight phase labels
+# Usage: sweep_stale_labels
+sweep_stale_labels() {
+  local n_fixed=0
+  for kind in issue pr; do
+    gh "$kind" list --label "auto-loop" --state closed --limit 50 --json number,labels 2>/dev/null | \
+      python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+stale = ['🚀 phase:pr-open', '👀 phase:reviewing', '🔧 phase:fixing', '⏸️ phase:blocked', 'auto-loop-stuck', '🆘 human:卡死-需-rework', '🔍 phase:design-solving', '🛠️ phase:implementing', '🤖 human:auto-推进']
+for x in d:
+    bad = [l['name'] for l in x['labels'] if l['name'] in stale]
+    if bad:
+        print(x['number'], ','.join(bad))
+" | while read num bad; do
+        [ -z "$num" ] && continue
+        local args=""
+        old_IFS="$IFS"; IFS=,
+        for l in $bad; do
+          args="$args --remove-label \"$l\""
+        done
+        IFS="$old_IFS"
+        # Add 🎉 phase:merged if it's MERGED
+        if [ "$kind" = "pr" ]; then
+          local state
+          state=$(gh pr view "$num" --json state --jq '.state' 2>/dev/null)
+          [ "$state" = "MERGED" ] && args="$args --add-label '🎉 phase:merged'"
+        else
+          args="$args --add-label '🎉 phase:merged'"
+        fi
+        eval "gh $kind edit $num $args" 2>&1 >/dev/null && n_fixed=$((n_fixed+1)) && echo "  cleaned $kind #$num: $bad"
+      done
+  done
+  echo "  total fixed: $n_fixed"
+}
+
+# Validate prompt file has no unresolved {{var}}
+# Usage: validate_prompt <prompt-file>
+validate_prompt() {
+  local f="$1"
+  local n
+  n=$(grep -c "{{" "$f" 2>/dev/null | tr -d ' \n' || echo "0")
+  [ -z "$n" ] && n=0
+  if [ "$n" -gt 0 ] 2>/dev/null; then
+    echo "❌ prompt $f 仍有 $n 个未解析 {{var}}:" >&2
+    grep -n "{{" "$f" | head -5 >&2
+    return 1
+  fi
+  return 0
+}
+
+# Verify trunk builds after merge — call after merge_pr to catch cross-PR API breaks
+# Usage: verify_trunk_build
+# per Auric 2026-05-22 iter25 #788+#795 trunk break(both green独立 PR,合并后 API mismatch)
+verify_trunk_build() {
+  cd "$REPO_ROOT" || return 1
+  git pull --ff-only origin auto-refact-dev 2>&1 | tail -1
+  local err
+  err=$(dotnet build aevatar.slnx --nologo 2>&1 | tail -3 | grep -oE "[0-9]+ Error" | head -1)
+  if [ "$err" != "0 Error" ]; then
+    echo "❌ trunk build broken after merge: $err — 派 hotfix codex(参考 SKILL Phase 4 hotfix 段)" >&2
+    dotnet build aevatar.slnx --nologo 2>&1 | grep -E "error CS" | head -5 >&2
+    return 2
+  fi
+  echo "✓ trunk build green"
+  return 0
+}
+
+# ⟦AI:AUTO-LOOP⟧

--- a/.claude/skills/codex-refactor-loop/scripts/dev_sync_daemon.py
+++ b/.claude/skills/codex-refactor-loop/scripts/dev_sync_daemon.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""
+dev_sync_daemon.py — 自动 merge origin/dev → auto-refact-dev 的 daemon
+
+Per Auric 2026-05-20 "改这个 daemon 在一个独立 worktree 工作, 改用 python 写吧.
+merge 的时候在 worktree, 不会影响" — daemon 跑在独立 worktree,main repo
+controller 工作不受 daemon 的 merge 状态干扰。
+
+设计:
+- 独立 worktree:/Users/auric/aevatar-wt-dev-sync(off auto-refact-dev)
+- 600s 周期 check `git rev-list HEAD..origin/dev`
+- behind>0:try ff-only → no-ff merge → 冲突 spawn-codex resolve
+- 成功 → push origin auto-refact-dev → main repo controller 下次 fetch 拉到
+- main repo working tree 不被 merge 状态污染
+
+启动:
+  nohup python3 .claude/skills/codex-refactor-loop/scripts/dev_sync_daemon.py \
+    >> .refactor-loop/logs/dev-sync-daemon.log 2>&1 &
+  disown
+
+⟦AI:AUTO-LOOP⟧
+"""
+
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+INTERVAL = int(os.environ.get("INTERVAL", "600"))
+MAIN_REPO = Path(os.environ.get("REPO_ROOT", "/Users/auric/aevatar"))
+WORKTREE = Path(os.environ.get("WORKTREE", "/Users/auric/aevatar-wt-dev-sync"))
+INTEGRATION = os.environ.get("INTEGRATION", "auto-refact-dev")
+REVIEW_BASE = os.environ.get("REVIEW_BASE", "dev")
+SPAWN_CODEX = MAIN_REPO / ".claude" / "skills" / "codex-refactor-loop" / "scripts" / "spawn-codex.sh"
+
+
+def log(msg: str) -> None:
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    print(f"[{ts}] {msg}", flush=True)
+
+
+def run(cmd: list[str], cwd: Path | None = None, check: bool = False) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=check)
+
+
+def ensure_worktree() -> bool:
+    """Ensure the daemon's dedicated worktree exists (detached HEAD off INTEGRATION).
+
+    git 不允许两个 worktree checkout 同 branch,所以 daemon 用 detached HEAD。
+    Push 时 `git push origin HEAD:INTEGRATION` 显式映射回 branch。
+    """
+    if not WORKTREE.exists():
+        log(f"creating worktree {WORKTREE} (detached off origin/{INTEGRATION})")
+        # fetch 先,确保 origin/INTEGRATION 是最新
+        run(["git", "fetch", "origin", "--quiet"], cwd=MAIN_REPO)
+        r = run(["git", "worktree", "add", "--detach", str(WORKTREE),
+                 f"origin/{INTEGRATION}"], cwd=MAIN_REPO)
+        if r.returncode != 0:
+            log(f"FATAL: git worktree add failed: {r.stderr.strip()}")
+            return False
+    return True
+
+
+def reset_to_remote(cwd: Path) -> bool:
+    """每 tick 开始 reset 到 origin/INTEGRATION,确保 base 最新。"""
+    run(["git", "fetch", "origin", "--quiet"], cwd=cwd)
+    r = run(["git", "reset", "--hard", f"origin/{INTEGRATION}"], cwd=cwd)
+    if r.returncode != 0:
+        log(f"FAIL reset to origin/{INTEGRATION}: {r.stderr.strip()[:120]}")
+        return False
+    return True
+
+
+def codex_resolve_in_flight() -> bool:
+    r = run(["pgrep", "-f", "dev-sync-codex-"])
+    return r.returncode == 0
+
+
+def dispatch_codex_resolve() -> None:
+    """Spawn a codex to resolve the in-progress merge conflicts in WORKTREE."""
+    ts = int(time.time())
+    prompt_file = MAIN_REPO / ".refactor-loop" / "prompts" / f"dev-sync-conflict-{ts}.md"
+    log_file = MAIN_REPO / ".refactor-loop" / "logs" / f"dev-sync-codex-{ts}.log"
+    prompt_file.parent.mkdir(parents=True, exist_ok=True)
+    prompt_body = f"""# 任务:resolve merge conflict on {INTEGRATION} ← origin/{REVIEW_BASE} sync
+
+## Context
+
+dev_sync_daemon (Python) 在独立 worktree `{WORKTREE}` 做 merge,遇到冲突。你
+在该 worktree 内 resolve + `git add` + `git merge --continue`,**不 push**
+(daemon 后续 push)。
+
+## 任务
+
+1. `cd {WORKTREE}`
+2. `git status` 看 conflict 文件
+3. 读每个冲突文件,理解 `origin/{REVIEW_BASE}` 改动 vs `{INTEGRATION}` 改动
+4. 合并(保留两者实质改动:tests / new files / docs / production code)
+5. `git add <files>`(已 resolve 的)
+6. `git merge --continue`(default merge message,带 `Sync {INTEGRATION} with {REVIEW_BASE}`)
+7. `dotnet build aevatar.slnx --nologo` 验证编译(失败修)
+8. 完成 marker:`DEV_SYNC_RESOLVED:<files-resolved>` 或 `DEV_SYNC_BLOCKED:<reason>`
+
+## 硬约束
+
+- ❌ `git push` / `git merge --abort` / `git reset --hard`(daemon 控)
+- ❌ 删任一边的实质改动(test / production code / docs / proto)
+- ❌ 不 commit before `git merge --continue`(merge 自动 commit)
+- ❌ 写新产线代码(只 resolve + build verify)
+- proto 字段冲突(同字段号 不同语义)→ `DEV_SYNC_BLOCKED:proto-schema-conflict`
+- 整个工作在 worktree 内完成,不动 main repo `{MAIN_REPO}`
+
+完成时把 marker 写 stdout(daemon 读 log):
+- 成功:`DEV_SYNC_RESOLVED:<file1>,<file2>,...`
+- 阻塞:`DEV_SYNC_BLOCKED:<reason>:<short>`
+
+⟦AI:AUTO-LOOP⟧
+"""
+    prompt_file.write_text(prompt_body)
+    log(f"dispatching codex: prompt={prompt_file} log={log_file}")
+    # spawn-codex.sh 在 main repo,但 --cd 指 worktree
+    subprocess.Popen(
+        ["nohup", str(SPAWN_CODEX),
+         "--cd", str(WORKTREE),
+         "--add-dir", str(MAIN_REPO),
+         "--prompt", str(prompt_file),
+         "--log", str(log_file),
+         "--timeout", "5400"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+def working_tree_dirty(cwd: Path) -> bool:
+    r1 = run(["git", "diff", "--quiet"], cwd=cwd)
+    r2 = run(["git", "diff", "--cached", "--quiet"], cwd=cwd)
+    return r1.returncode != 0 or r2.returncode != 0
+
+
+def merge_in_progress(cwd: Path) -> bool:
+    return (cwd / ".git" / "MERGE_HEAD").exists() or (cwd / ".git" / "MERGE_MSG").exists()
+
+
+def tick() -> None:
+    cwd = WORKTREE
+    if not cwd.exists():
+        log(f"worktree {cwd} missing, attempting create")
+        if not ensure_worktree():
+            return
+
+    if merge_in_progress(cwd):
+        if codex_resolve_in_flight():
+            log("skip: merge in progress + codex resolving")
+        else:
+            log("WARN: merge in progress but no codex running — dispatching")
+            dispatch_codex_resolve()
+        return
+
+    if working_tree_dirty(cwd):
+        log("skip: worktree dirty (no merge in progress)")
+        return
+
+    # 每 tick reset 到 origin/INTEGRATION 确保最新(detached HEAD)
+    if not reset_to_remote(cwd):
+        return
+
+    behind = run(["git", "rev-list", "--count", f"HEAD..origin/{REVIEW_BASE}"], cwd=cwd).stdout.strip()
+    try:
+        behind_n = int(behind)
+    except ValueError:
+        behind_n = 0
+
+    if behind_n == 0:
+        log(f"up-to-date with origin/{REVIEW_BASE}")
+        return
+
+    log(f"behind origin/{REVIEW_BASE} by {behind_n} commits, attempting sync")
+
+    # 尝试 ff-only(detached HEAD push 用 HEAD:branch 映射)
+    r = run(["git", "merge", "--ff-only", f"origin/{REVIEW_BASE}"], cwd=cwd)
+    if r.returncode == 0 and ("Fast-forward" in r.stdout or "Already up to date" in r.stdout):
+        log(f"ff-merged with origin/{REVIEW_BASE} (+{behind_n} commits)")
+        push = run(["git", "push", "origin", f"HEAD:{INTEGRATION}"], cwd=cwd)
+        if push.returncode == 0:
+            log(f"pushed HEAD → origin/{INTEGRATION}")
+        else:
+            log(f"FAIL push: {push.stderr.strip()[:120]}")
+        return
+
+    # ff-only 失败 → no-ff merge
+    log("ff-only not possible, attempting no-ff merge")
+    r = run(["git", "merge", "--no-ff", "-m",
+             f"Sync {INTEGRATION} with {REVIEW_BASE} (auto by dev_sync_daemon)",
+             f"origin/{REVIEW_BASE}"], cwd=cwd)
+    if r.returncode == 0:
+        log(f"no-ff merge-committed +{behind_n} commits")
+        push = run(["git", "push", "origin", f"HEAD:{INTEGRATION}"], cwd=cwd)
+        if push.returncode == 0:
+            log(f"pushed HEAD → origin/{INTEGRATION}")
+        else:
+            log(f"FAIL push after merge: {push.stderr.strip()[:120]}")
+        return
+
+    # 冲突
+    if merge_in_progress(cwd):
+        log("CONFLICT detected (merge in progress)")
+        if not codex_resolve_in_flight():
+            dispatch_codex_resolve()
+        else:
+            log("codex already resolving, skip this tick")
+    else:
+        log(f"FAIL merge but no MERGE_HEAD: {r.stderr.strip()[:120]}")
+
+
+def main() -> None:
+    log(f"dev_sync_daemon (Python) started: interval={INTERVAL}s worktree={WORKTREE} {REVIEW_BASE} → {INTEGRATION}")
+    if not ensure_worktree():
+        log("FATAL: cannot ensure worktree, exiting")
+        sys.exit(1)
+    while True:
+        try:
+            tick()
+        except Exception as e:
+            log(f"EXCEPTION in tick: {e!r}")
+        time.sleep(INTERVAL)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/codex-refactor-loop/scripts/peek.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/peek.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+# peek.sh — controller wakeup 快速 sweep
+#
+# per Auric 2026-05-21 "主动发现问题" + "codex 可以执行得很好,为什么你做不到":
+# controller 每 wakeup 第一动作应该用这个 script 一眼看全状态,
+# 避免人工 grep / parse 出错(pr1_num empty bug 那种)。
+#
+# 输出:
+#   1. 活跃 codex 数 + 每个的 log 名(harness-tracked vs detached 分别标)
+#   2. 完成 markers + 推荐下一步路由(per skill route table)
+#   3. 每个 open auto-loop PR 的 CI + reviewer 状态
+#   4. monitor zero_streak 最大值(过去 10 tick)
+#
+# Usage: bash .claude/skills/codex-refactor-loop/scripts/peek.sh
+#
+# ⟦AI:AUTO-LOOP⟧
+
+set -e
+cd /Users/auric/aevatar
+git fetch origin --quiet 2>/dev/null
+
+echo "═══════════════ peek $(date -u +%H:%M:%SZ) ═══════════════"
+
+# 0. CRITICAL: maintainer 评论(non-AI 即非 sentinel)
+# per Auric 2026-05-21 漏读 #720 4h+ + 2026-05-22 #779 8h 漏读事故
+# 规则:
+#   (a) 最近 12h 任何 issue/PR 的 maintainer 评论 — 显示
+#   (b) stuck-label issue 的 LATEST maintainer 评论 — 无论多久都显示(避免漏读)
+echo ""
+echo "▍🚨 maintainer 评论(read first — 漏读 = controller bug):"
+{
+  gh issue list --label "auto-loop" --state open --json number 2>/dev/null | python3 -c "import json,sys; [print(f'i{x[\"number\"]}') for x in json.load(sys.stdin)]" 2>/dev/null
+  gh pr list --label "auto-loop" --state open --json number 2>/dev/null | python3 -c "import json,sys; [print(f'p{x[\"number\"]}') for x in json.load(sys.stdin)]" 2>/dev/null
+} | while read item; do
+  kind=$(echo "$item" | cut -c1)
+  num=$(echo "$item" | cut -c2-)
+  [ -z "$num" ] && continue
+  if [ "$kind" = "i" ]; then
+    raw=$(gh issue view "$num" --json comments 2>/dev/null)
+  else
+    raw=$(gh pr view "$num" --json comments 2>/dev/null)
+  fi
+  echo "$raw" | python3 -c "
+import json, sys
+from datetime import datetime, timezone
+try:
+    data = json.load(sys.stdin)
+    cs = data.get('comments', [])
+except: sys.exit(0)
+# non-AI = not AI sentinel, not status banner prefix, not codecov bot
+non_ai = [c for c in cs if '⟦AI:AUTO-LOOP⟧' not in (c.get('body','') or '')
+          and not (c.get('body','') or '').lstrip().startswith(('## 📊', '## 🤖', '## ✅', '## 🆘'))
+          and not (c.get('author',{}) or {}).get('login','').endswith('[bot]')]
+if not non_ai: sys.exit(0)
+last = max(non_ai, key=lambda c: c.get('createdAt',''))
+# Find latest AI reply (any AI sentinel or status banner)
+ai = [c for c in cs if c.get('createdAt','') > last.get('createdAt','') and
+      ('⟦AI:AUTO-LOOP⟧' in (c.get('body','') or '') or (c.get('body','') or '').lstrip().startswith(('## 📊', '## 🤖', '## ✅', '## 🆘')))]
+has_ai_reply = bool(ai)
+ts_str = last.get('createdAt','').rstrip('Z')
+try:
+    ts = datetime.fromisoformat(ts_str).replace(tzinfo=timezone.utc)
+except: sys.exit(0)
+delta_h = (datetime.now(timezone.utc) - ts).total_seconds() / 3600
+# 12h cutoff OR no AI reply since(无回应必显示,无论多久)
+if delta_h > 12 and has_ai_reply: sys.exit(0)
+flag = '⏰ no-AI-reply' if not has_ai_reply else ''
+author = (last.get('author', {}) or {}).get('login', '?')
+body = (last.get('body','') or '').replace('\n',' ')[:200]
+print(f'  {flag} [{author}] ${num} ${kind} ({delta_h:.1f}h ago): {body}')
+" 2>/dev/null
+done
+
+# 1. Active codex
+n=$(ps -ef | grep -E "timeout (3600|5400) codex" | grep -v grep | wc -l | tr -d ' ')
+echo ""
+echo "▍活跃 codex: ${n}"
+if [ "$n" -gt 0 ]; then
+  ps -ef | grep -E "timeout (3600|5400) codex" | grep -v grep | \
+    sed -E 's/.*--log [^ ]*\/([^ ]+)\.log.*/  • \1/' | sort
+fi
+
+# 2. Recently finished markers (last 60 min) + routing hint
+echo ""
+echo "▍最近 60 min 完成 codex(marker → 推荐下一步):"
+find .refactor-loop/logs -name "*.log" -mmin -60 -type f 2>/dev/null | while read f; do
+  base=$(basename "$f" .log)
+  # Skip in-progress (no EXIT line)
+  exit_line=$(grep "^EXIT=" "$f" 2>/dev/null | tail -1)
+  [ -z "$exit_line" ] && continue
+  marker=$(grep -hE "^[+]?(AUDIT_DONE|AUDIT_INCOMPLETE|IMPLEMENT_DONE|IMPLEMENT_BLOCKED|FIX_DONE|FIX_BLOCKED|REVIEW_DONE|SOLVER_DONE|META_JUDGE_DONE|META_RESOLVED|TEST_ADD_DONE):" "$f" 2>/dev/null | sed -E 's/^[+]+//' | tail -1 | head -c 100)
+  [ -z "$marker" ] && continue
+  # Routing hint
+  hint=""
+  case "$marker" in
+    IMPLEMENT_DONE:*:ok*)    hint="→ commit/push + open PR + 3 reviewer r1" ;;
+    IMPLEMENT_DONE:*:partial|IMPLEMENT_DONE:*:blocked) hint="→ inspect + re-prompt or escalate" ;;
+    IMPLEMENT_BLOCKED:*)     hint="→ inspect blocker + meta-reflect" ;;
+    FIX_DONE:*)              hint="→ commit/push + 3 reviewer r+1" ;;
+    FIX_BLOCKED:*)           hint="→ meta-reflect" ;;
+    REVIEW_DONE:*:approve)   hint="→ wait other 2 reviewers,then merge if all approve / mixed: ≥2 approve + 0 reject = merge" ;;
+    REVIEW_DONE:*:comment)   hint="→ advisory; wait other reviewers" ;;
+    REVIEW_DONE:*:reject)    hint="→ wait other 2 reviewers,then fix r+1" ;;
+    SOLVER_DONE:*)           hint="→ wait other 2 solvers,then meta-judge" ;;
+    META_JUDGE_DONE:consensus:*) hint="→ implement codex (worktree + spawn)" ;;
+    META_JUDGE_DONE:converge:*)  hint="→ re-spawn 3 solver with convergence question" ;;
+    META_JUDGE_DONE:escalate:philosophy:*) hint="→ label escalate-human + ASCII problem banner" ;;
+    META_JUDGE_DONE:escalate:*)  hint="→ reflector codex" ;;
+    META_RESOLVED:retry-fix:*)   hint="→ implement codex(or fix r+1 if PR exists)" ;;
+    META_RESOLVED:re-design:*)   hint="→ close PR + Phase 9 fresh round" ;;
+    META_RESOLVED:re-cluster:*)  hint="→ close PR + audit re-split" ;;
+    META_RESOLVED:drop:*)        hint="→ close PR + close issue wontfix" ;;
+    META_RESOLVED:escalate-human:*) hint="→ label 🆘 + push notify" ;;
+    AUDIT_DONE:*)            hint="→ 验证 cluster evidence + 开 design issues + 派 implement" ;;
+    AUDIT_INCOMPLETE:*)      hint="→ re-dispatch audit with missing pieces" ;;
+    TEST_ADD_DONE:*)         hint="→ commit/push 等 CI" ;;
+  esac
+  echo "  • ${base}: ${marker}"
+  [ -n "$hint" ] && echo "    ${hint}"
+done
+
+# 3. Open auto-loop PRs + state
+echo ""
+echo "▍Open auto-loop PRs:"
+gh pr list --label "auto-loop" --state open --json number,title --jq '.[]' | while IFS= read -r line; do
+  num=$(echo "$line" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['number'])" 2>/dev/null)
+  title=$(echo "$line" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['title'][:60])" 2>/dev/null)
+  [ -z "$num" ] && continue
+  fail=$(gh pr checks "$num" --json bucket --jq '[.[] | select(.bucket=="fail") | 1] | length' 2>/dev/null)
+  pending=$(gh pr checks "$num" --json bucket --jq '[.[] | select(.bucket=="pending") | 1] | length' 2>/dev/null)
+  pass=$(gh pr checks "$num" --json bucket --jq '[.[] | select(.bucket=="pass") | 1] | length' 2>/dev/null)
+  state=$(gh pr view "$num" --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null)
+  echo "  • PR #${num} [${state}] CI: fail=${fail} pending=${pending} pass=${pass} — ${title}"
+done
+
+# 4. Monitor recent zero_streak max
+echo ""
+echo "▍Monitor zero_streak (过去 10 tick):"
+tail -10 .refactor-loop/logs/concurrency-monitor.log 2>/dev/null | \
+  grep -oE "zero_streak=[0-9]+" | sort -t= -k2 -rn | head -1 | sed 's/^/  最大: /'
+zero_now=$(tail -1 .refactor-loop/logs/concurrency-monitor.log 2>/dev/null | grep -oE "zero_streak=[0-9]+" | head -1)
+[ -n "$zero_now" ] && echo "  当前: ${zero_now}"
+
+# 5. Mergeable PRs (per reviewer consensus + CI green)
+echo ""
+echo "▍可合并 PR(controller 应立即 merge):"
+gh pr list --label "auto-loop" --state open --json number,title --jq '.[].number' 2>/dev/null | while read pr_num; do
+  [ -z "$pr_num" ] && continue
+  # CI must have 0 fail + 0 pending
+  fail=$(gh pr checks "$pr_num" --json bucket --jq '[.[] | select(.bucket=="fail") | 1] | length' 2>/dev/null)
+  pending=$(gh pr checks "$pr_num" --json bucket --jq '[.[] | select(.bucket=="pending") | 1] | length' 2>/dev/null)
+  [ "$fail" != "0" ] || [ "$pending" != "0" ] && continue
+  state=$(gh pr view "$pr_num" --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null)
+  # Reviewer consensus: latest round per role, count approve/reject/comment
+  # find latest round N for this PR
+  max_round=0
+  for r in 1 2 3 4 5 6; do
+    cnt=$(ls .refactor-loop/logs/review-pr${pr_num}-*-r${r}.log 2>/dev/null | wc -l | tr -d ' ')
+    [ "$cnt" -ge 3 ] && max_round=$r
+  done
+  [ "$max_round" = "0" ] && continue
+  approve=0; comment=0; reject=0
+  for role in architect tests quality; do
+    f=".refactor-loop/logs/review-pr${pr_num}-${role}-r${max_round}.log"
+    [ -f "$f" ] || continue
+    v=$(grep -hE "^[+]?REVIEW_DONE:" "$f" 2>/dev/null | sed -E 's/^[+]+//; s/.*:([a-z]+)\s*$/\1/' | tail -1)
+    case "$v" in
+      approve) approve=$((approve+1)) ;;
+      comment) comment=$((comment+1)) ;;
+      reject)  reject=$((reject+1)) ;;
+    esac
+  done
+  # Merge rule: 0 reject AND >= 2 approve (mixed comment OK)
+  if [ "$reject" = "0" ] && [ "$approve" -ge 2 ]; then
+    echo "  ✅ PR #${pr_num} [${state}] r${max_round}: approve=${approve} comment=${comment} reject=0 — gh pr merge ${pr_num} --admin --squash --delete-branch"
+  fi
+done
+
+# 5b. Stale-label detection on CLOSED issues/PRs(per Auric 2026-05-21 "状态、PR跟issues的关联状态有问题")
+echo ""
+echo "▍Stale labels(已 CLOSED 但还挂 in-flight phase 标签):"
+gh issue list --label "auto-loop" --state closed --limit 30 --json number,labels --jq '.[] | "\(.number)|\(.labels | map(.name) | map(select(. | startswith("🔍") or startswith("🛠") or startswith("🔧") or startswith("👀") or startswith("⏸") or startswith("auto-loop-stuck") or startswith("🆘"))) | join(","))"' 2>/dev/null | while IFS='|' read -r num labels; do
+  [ -z "$num" ] || [ -z "$labels" ] && continue
+  echo "  ⚠️ closed issue #${num} 仍挂: ${labels}  → controller 应清理 + 加 🎉 phase:merged"
+done
+gh pr list --label "auto-loop" --state closed --limit 30 --json number,labels --jq '.[] | "\(.number)|\(.labels | map(.name) | map(select(. | startswith("🔍") or startswith("🛠") or startswith("🔧") or startswith("👀") or startswith("⏸") or startswith("auto-loop-stuck") or startswith("🆘") or startswith("🚀"))) | join(","))"' 2>/dev/null | while IFS='|' read -r num labels; do
+  [ -z "$num" ] || [ -z "$labels" ] && continue
+  echo "  ⚠️ closed PR #${num} 仍挂: ${labels}"
+done
+
+# 5c. Linkage check:open issues phase:implementing 但没对应 in-flight PR / open PRs 没对应 design issue
+echo ""
+echo "▍Issue/PR linkage 不一致:"
+gh issue list --label "🛠️ phase:implementing" --state open --json number,title --jq '.[] | "\(.number)|\(.title)"' 2>/dev/null | while IFS='|' read -r num title; do
+  [ -z "$num" ] && continue
+  # 找 closes #num 的 open PR
+  pr_count=$(gh pr list --label "auto-loop" --state open --search "in:body Closes #${num}" --json number --jq 'length' 2>/dev/null || echo 0)
+  if [ "$pr_count" = "0" ]; then
+    # 还要找 closed PR 是否已 merge
+    merged_pr=$(gh pr list --label "auto-loop" --state merged --search "in:body Closes #${num}" --json number --jq '.[0].number' 2>/dev/null)
+    if [ -z "$merged_pr" ] || [ "$merged_pr" = "null" ]; then
+      echo "  ⚠️ issue #${num} [🛠️ implementing] 无对应 in-flight 或 merged PR(implement codex 失败/未派?)"
+    else
+      echo "  ⚠️ issue #${num} [🛠️ implementing] PR #${merged_pr} 已 merged 但 issue 未关 — controller 应 gh issue close"
+    fi
+  fi
+done
+
+# 5d. Spawn drop detection: 3 solver artifact 完整但对应 judge log 没有
+echo ""
+echo "▍Spawn drop(solver 完成 N 但 judge 漏派):"
+for f in .refactor-loop/runs/phase9-issue*-r*-minimal.md; do
+  [ -f "$f" ] || continue
+  base=$(basename "$f" -minimal.md)
+  issue=$(echo "$base" | sed -E 's/phase9-issue([0-9]+)-r.*/\1/')
+  round=$(echo "$base" | sed -E 's/.*-r([0-9]+)/\1/')
+  s_min="$f"
+  s_str=".refactor-loop/runs/${base}-structural.md"
+  s_del=".refactor-loop/runs/${base}-delete.md"
+  judge_log=".refactor-loop/logs/${base}-judge.log"
+  if [ -f "$s_str" ] && [ -f "$s_del" ] && [ ! -f "$judge_log" ]; then
+    issue_state=$(gh issue view "$issue" --json state --jq '.state' 2>/dev/null)
+    [ "$issue_state" = "OPEN" ] || continue  # only flag if issue still open
+    echo "  ⚠️ issue #${issue} r${round} 3 solver done 但 judge log 不存在(需重派 judge)"
+  fi
+done
+
+# 6. Drift detection: phase:* label set but no log file being actively written for that issue/PR
+echo ""
+echo "▍Drift(label vs codex 不一致):"
+active_logs_file=$(mktemp)
+# 用 log 文件最近活跃来判断:no EXIT= 末行 + mtime < 10 min = codex 在跑
+for f in .refactor-loop/logs/*.log; do
+  [ -f "$f" ] || continue
+  # mtime > 10 min: 没在更新
+  [ -n "$(find "$f" -mmin -10)" ] || continue
+  # 已有 EXIT=:已完成
+  if grep -q "^EXIT=" "$f" 2>/dev/null; then continue; fi
+  basename "$f" .log >> "$active_logs_file"
+done
+check_drift() {
+  local kind="$1" num="$2" phase="$3"
+  case "$phase" in
+    *design-solving* | *implementing* | *fixing* | *reviewing*) ;;
+    *) return ;;
+  esac
+  if ! grep -qE "(pr${num}|issue${num})" "$active_logs_file" 2>/dev/null; then
+    echo "  ⚠️ ${kind} #${num} label=${phase} 但 0 codex referencing"
+  fi
+}
+gh issue list --label "auto-loop" --state open --json number,labels --jq '.[] | "\(.number)|\(.labels | map(.name) | map(select(. | startswith("🔍") or startswith("🛠") or startswith("🔧") or startswith("👀"))) | first)"' 2>/dev/null | while IFS='|' read -r num phase; do
+  [ -z "$num" ] || [ -z "$phase" ] && continue
+  check_drift issue "$num" "$phase"
+done
+gh pr list --label "auto-loop" --state open --json number,labels --jq '.[] | "\(.number)|\(.labels | map(.name) | map(select(. | startswith("🔍") or startswith("🛠") or startswith("🔧") or startswith("👀"))) | first)"' 2>/dev/null | while IFS='|' read -r num phase; do
+  [ -z "$num" ] || [ -z "$phase" ] && continue
+  check_drift pr "$num" "$phase"
+done
+
+# 7. Stale worktree(branch 已 merged 但 worktree 还在)
+echo ""
+echo "▍Stale worktree(branch 已 merged 应清理):"
+git worktree list --porcelain | grep "^worktree " | sed 's/^worktree //' | while read wt; do
+  base=$(basename "$wt")
+  # skip main + dev-sync
+  case "$base" in
+    aevatar | aevatar-wt-dev-sync) continue ;;
+  esac
+  # If worktree branch is in remote merged-to-master list, mark stale
+  branch=$(git -C "$wt" branch --show-current 2>/dev/null)
+  if [ -n "$branch" ]; then
+    # branch exists on remote? if not, stale
+    if ! git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+      echo "  ⚠️ $wt  branch=$branch(remote 已不存在 — git worktree remove $wt --force && git branch -D $branch)"
+    fi
+  fi
+done
+
+# 8. Stuck-too-long(issue/PR 有 stuck label 且 last non-AI comment > 6h)
+echo ""
+echo "▍Stuck too long(>6h 无 maintainer 回复;考虑 4h reflector 重判):"
+gh issue list --label "auto-loop-stuck" --state open --json number,title 2>/dev/null | python3 -c "
+import json, sys, subprocess
+from datetime import datetime, timezone
+data = json.load(sys.stdin)
+for it in data:
+    num = it['number']
+    r = subprocess.run(['gh', 'issue', 'view', str(num), '--json', 'comments'], capture_output=True, text=True)
+    if r.returncode != 0: continue
+    try:
+        comments = json.loads(r.stdout).get('comments', [])
+    except:
+        continue
+    # filter non-AI(no ⟦AI:AUTO-LOOP⟧ sentinel)
+    non_ai = [c for c in comments if '⟦AI:AUTO-LOOP⟧' not in (c.get('body','') or '')]
+    if not non_ai: continue
+    last = max(non_ai, key=lambda c: c.get('createdAt',''))
+    ts_str = last.get('createdAt','').rstrip('Z')
+    try:
+        ts = datetime.fromisoformat(ts_str).replace(tzinfo=timezone.utc)
+    except:
+        continue
+    delta_h = (datetime.now(timezone.utc) - ts).total_seconds() / 3600
+    if delta_h > 6:
+        print(f'  ⚠️ #{num} last maintainer comment {delta_h:.1f}h ago — {it[\"title\"][:50]}')
+" 2>/dev/null
+
+# 9. Open auto-loop issues + label state
+echo ""
+echo "▍Open auto-loop issues:"
+gh issue list --label "auto-loop" --state open --json number,title,labels --jq '.[] | "  • #\(.number) labels=[\(.labels | map(.name) | map(select(. | startswith("🔍") or startswith("🛠") or startswith("⚙") or startswith("⏸") or startswith("🆘") or startswith("👤") or startswith("🤖"))) | join(", "))] — \(.title | .[0:55])"' 2>/dev/null
+
+echo ""
+echo "═══════════════════════════════════════════════════"

--- a/.claude/skills/codex-refactor-loop/scripts/post_banner.py
+++ b/.claude/skills/codex-refactor-loop/scripts/post_banner.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+post_banner.py — 只 post GitHub status banner,不 spawn codex
+
+per Auric 2026-05-21 "codex 可以执行得很好,为什么你做不到":
+spawn_with_banner.py 的 detached Popen 模式让 harness 看不见 codex,导致
+codex done 后 controller 不知道,monitor 60s 报警 zero_streak 涨 13 没人理。
+
+新架构:**两步**
+1. 此脚本(blocking,几秒)post banner 到 issue/PR
+2. 调用方用 Bash `run_in_background: true` 跑 `spawn-codex.sh` — harness 跟踪 →
+   codex exit 时 harness fire <task-notification> → controller 立即唤醒
+
+Usage:
+  python3 .claude/skills/codex-refactor-loop/scripts/post_banner.py \\
+    --banner-target <num> --banner-kind <issue|pr> \\
+    --banner-role <role> --banner-detail "..." \\
+    --log <log-path> --cd <worktree> --timeout <s>
+
+返回:
+- exit 0 if banner posted,stderr 打印 BANNER_POSTED: <kind> #<num> <url>
+- exit 1 if banner failed
+
+⟦AI:AUTO-LOOP⟧
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROLE_NEXT_STEPS = {
+    "test-add": "1. test-add 完成 marker `TEST_ADD_DONE:...`  2. controller 自动 commit + push  3. codecov 重测",
+    "fix": "1. fix r<N> 完成 marker `FIX_DONE:...`  2. controller commit + push  3. 派 reviewer r<N+1>",
+    "reviewer": "1. 三 reviewer 完成 verdict marker  2. controller 计算 consensus  3. unanimous → auto-merge / reject → fix r<N+1>",
+    "implement": "1. implement 完成 marker `IMPLEMENT_DONE:<cluster>:<status>`  2. controller commit + push  3. open PR + 派 reviewer r1",
+    "solver": "1. 三 solver `SOLVER_DONE:...`  2. controller 派 meta-judge r<N>  3. consensus → implement / converge → fresh round",
+    "judge": "1. judge `META_JUDGE_DONE:...`  2. consensus → implement / converge → fresh round / escalate → reflector or 人介入",
+    "reflector": "1. reflector `META_RESOLVED:<kind>`  2. controller 按 kind 路由(retry-fix / re-design / re-cluster / drop / escalate-human)",
+    "audit": "1. audit 完成 marker `AUDIT_DONE:...:<N>`  2. controller 验证 + 开 design issues + 派 implement",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--banner-target", required=True)
+    p.add_argument("--banner-kind", choices=["issue", "pr"], required=True)
+    p.add_argument("--banner-role", required=True, choices=list(ROLE_NEXT_STEPS.keys()))
+    p.add_argument("--banner-detail", default="")
+    p.add_argument("--log", required=True, help="codex log path (for banner display)")
+    p.add_argument("--cd", required=True, help="codex cwd (for banner display)")
+    p.add_argument("--timeout", type=int, required=True, help="codex timeout seconds (for banner display)")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    role = args.banner_role
+    next_step = ROLE_NEXT_STEPS[role]
+    log_name = Path(args.log).name
+    body = f"""## 📊 状态卡片 — {role} 派出
+
+| 维度 | 值 |
+|---|---|
+| 阶段 | **派出 codex(role=`{role}`)** |
+| codex log | `{log_name}` |
+| 工作目录 | `{args.cd}` |
+| timeout | {args.timeout}s(~{args.timeout // 60} min 上限) |
+| 上下文 | {args.banner_detail or "(none)"} |
+| 下一步自动会做 | {next_step} |
+| **是否需要人介入** | **❌ 否**(自动推进) |
+
+🤖 controller status banner
+
+⟦AI:AUTO-LOOP⟧
+"""
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False)
+    tmp.write(body)
+    tmp.close()
+    cmd = ["gh", args.banner_kind, "comment", str(args.banner_target), "--body-file", tmp.name]
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    os.unlink(tmp.name)
+    if r.returncode != 0:
+        sys.stderr.write(f"FAIL banner post: {r.stderr.strip()}\n")
+        return 1
+    url = r.stdout.strip()
+    sys.stderr.write(f"BANNER_POSTED: {args.banner_kind} #{args.banner_target} {url}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/codex-refactor-loop/scripts/spawn_with_banner.py
+++ b/.claude/skills/codex-refactor-loop/scripts/spawn_with_banner.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+spawn_with_banner.py — spawn-codex wrapper 自动 post GitHub status banner
+
+per Auric 2026-05-20 "...也看不到运行状态. 你继续修 skills 吧. 然后需要写脚本你
+可以写脚本":controller 派 codex 时常忘 post banner,导致 GitHub 上看不到运行
+状态。Helper script enforce "spawn 必配 banner"。
+
+Usage:
+  python3 .claude/skills/codex-refactor-loop/scripts/spawn_with_banner.py \\
+    --cd <worktree> --prompt <prompt-file> --log <log-file> \\
+    --timeout 5400 \\
+    --banner-target <issue-or-pr-num> \\
+    --banner-kind <issue|pr> \\
+    --banner-role <test-add|fix|reviewer|implement|solver|judge|reflector> \\
+    --banner-detail "<short context, 1 line>"
+  [--add-dir <main-repo-path>]
+
+Behavior:
+- spawn-codex.sh 后台跑(nohup + disown)
+- 立即 post banner 到 target issue/pr,format `## 📊 状态卡片 — <role> 派出`
+- banner 含 codex 任务名 / timeout / "下一步自动会做" / 是否需要人介入
+- 末尾 `🤖 controller status banner` + ⟦AI:AUTO-LOOP⟧ sentinel
+- Exit 0 if both succeed;exit 非 0 + 错误信息 otherwise
+
+⟦AI:AUTO-LOOP⟧
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(os.environ.get("REPO_ROOT", "/Users/auric/aevatar"))
+SPAWN_CODEX = REPO_ROOT / ".claude" / "skills" / "codex-refactor-loop" / "scripts" / "spawn-codex.sh"
+
+ROLE_NEXT_STEPS = {
+    "test-add": "1. test-add 完成 marker `TEST_ADD_DONE:...`  2. controller 自动 commit + push  3. codecov 重测",
+    "fix": "1. fix r<N> 完成 marker `FIX_DONE:...`  2. controller commit + push  3. 派 reviewer r<N+1>",
+    "reviewer": "1. 三 reviewer 完成 verdict marker  2. controller 计算 consensus  3. unanimous → auto-merge / reject → fix r<N+1>",
+    "implement": "1. implement 完成 marker `IMPLEMENT_DONE:<cluster>:<status>`  2. controller commit + push  3. open PR + 派 reviewer r1",
+    "solver": "1. 三 solver `SOLVER_DONE:...`  2. controller 派 meta-judge r<N>  3. consensus → implement / converge → fresh round",
+    "judge": "1. judge `META_JUDGE_DONE:...`  2. consensus → implement / converge → fresh round / escalate → reflector or 人介入",
+    "reflector": "1. reflector `META_RESOLVED:<kind>`  2. controller 按 kind 路由(retry-fix / re-design / re-cluster / drop / escalate-human)",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--cd", required=True, help="cwd for codex(usually worktree)")
+    p.add_argument("--prompt", required=True, help="codex prompt file")
+    p.add_argument("--log", required=True, help="codex log file")
+    p.add_argument("--timeout", type=int, required=True, help="codex timeout seconds(>=3600)")
+    p.add_argument("--add-dir", default=None, help="extra dir for codex(usually main repo when cd is worktree)")
+    p.add_argument("--banner-target", required=True, help="issue/PR number to post banner")
+    p.add_argument("--banner-kind", choices=["issue", "pr"], required=True)
+    p.add_argument("--banner-role", required=True, choices=list(ROLE_NEXT_STEPS.keys()))
+    p.add_argument("--banner-detail", default="", help="one-line context for banner")
+    return p.parse_args()
+
+
+def post_banner(args: argparse.Namespace) -> int:
+    role = args.banner_role
+    next_step = ROLE_NEXT_STEPS[role]
+    log_name = Path(args.log).name
+    body = f"""## 📊 状态卡片 — {role} 派出
+
+| 维度 | 值 |
+|---|---|
+| 阶段 | **派出 codex(role=`{role}`)** |
+| codex log | `{log_name}` |
+| 工作目录 | `{args.cd}` |
+| timeout | {args.timeout}s(~{args.timeout // 60} min 上限) |
+| 上下文 | {args.banner_detail or "(none)"} |
+| 下一步自动会做 | {next_step} |
+| **是否需要人介入** | **❌ 否**(自动推进) |
+
+🤖 controller status banner
+
+⟦AI:AUTO-LOOP⟧
+"""
+    tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False)
+    tmp.write(body)
+    tmp.close()
+    cmd = ["gh", args.banner_kind, "comment", str(args.banner_target), "--body-file", tmp.name]
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    os.unlink(tmp.name)
+    if r.returncode != 0:
+        sys.stderr.write(f"FAIL banner post: {r.stderr.strip()}\n")
+        return 1
+    url = r.stdout.strip()
+    sys.stderr.write(f"BANNER_POSTED: {args.banner_kind} #{args.banner_target} {url}\n")
+    return 0
+
+
+def spawn_codex(args: argparse.Namespace) -> int:
+    cmd = [str(SPAWN_CODEX),
+           "--cd", args.cd,
+           "--prompt", args.prompt,
+           "--log", args.log,
+           "--timeout", str(args.timeout)]
+    if args.add_dir:
+        cmd.extend(["--add-dir", args.add_dir])
+    # nohup + start_new_session(脱离 parent)
+    subprocess.Popen(
+        ["nohup", *cmd],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    sys.stderr.write(f"CODEX_SPAWNED: log={args.log}\n")
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+    if args.timeout < 3600:
+        sys.stderr.write(f"FATAL: timeout {args.timeout} < 3600 (per CLAUDE.md floor)\n")
+        return 2
+    # 1. Post banner first(让 maintainer 立即看到状态)
+    rc = post_banner(args)
+    if rc != 0:
+        sys.stderr.write("WARN: banner post failed, continuing with spawn anyway\n")
+    # 2. Spawn codex
+    rc = spawn_codex(args)
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/codex-refactor-loop/scripts/triage-monitor.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/triage-monitor.sh
@@ -10,7 +10,7 @@
 #     `<ISO8601> new-triage-issue <issue> <author>`
 #   - state 存 .refactor-loop/triage-monitor-state.json(seen issue id)
 # - 不自己派 codex(controller 责任)
-# - 启动: nohup bash tools/refactor-loop/triage-monitor.sh >> .refactor-loop/logs/triage-monitor.log 2>&1 & disown
+# - 启动: nohup bash .claude/skills/codex-refactor-loop/scripts/triage-monitor.sh >> .refactor-loop/logs/triage-monitor.log 2>&1 & disown
 #
 # ⟦AI:AUTO-LOOP⟧
 


### PR DESCRIPTION
## 摘要

把 9 个 codex-refactor-loop skill 专用 script 从 `tools/refactor-loop/` 挪到 `.claude/skills/codex-refactor-loop/scripts/`,与 SKILL.md + prompts/ + spawn-codex.sh colocate。Skill 完全**自包含**。

## 背景 — 5+ 天 daemon dead 事故链

1. **2026-05-20** dev_sync_daemon 启动,初次 sync 遇 merge conflict,resolve codex 失败 → worktree 卡 MERGE_HEAD
2. **2026-05-23** eanzhao `4a029981c` "Clean non-production assets" 删 `tools/refactor-loop/` 8 file(1571 行)— **误判**:这些是 SKILL.md 强制依赖
3. Daemon 进程 in-memory 仍跑(python 已加载),但**功能 dead**:
   - daemon `merge_in_progress()` 检查 `WORKTREE/.git/MERGE_HEAD`,但 secondary worktree `.git` 是**文件**(`gitdir:` 指向 main repo),真路径在 `/Users/auric/aevatar/.git/worktrees/aevatar-wt-dev-sync/MERGE_HEAD` → daemon **永远 detect 不到 merge** → fallback 到 "skip dirty (no merge in progress)"
   - 5+ 天每 600s skip → behind origin/dev **50 commits**
4. **2026-05-27** 手动 `git merge --abort` 清 stale + 派 codex 手动 sync

## 修复

- restore 8 file(daemon / comment-monitor / codex-progress-reporter / concurrency_monitor / controller_lib / peek / post_banner / spawn_with_banner)+ move triage-monitor.sh
- 全 colocate 到 `.claude/skills/codex-refactor-loop/scripts/`
- 删空目录 `tools/refactor-loop/`
- sed bulk replace 27 处 path(SKILL.md 17 + prompts 1 + scripts 自身 9)

## 后续(本 PR 不含)

- daemon `merge_in_progress()` 改用 `git rev-parse --git-dir` 替代硬编码 `.git/MERGE_HEAD`,修 path bug
- daemon 进程 restart(让它跑新代码)

## 影响

- skill 自包含,review 时 cleanup 看到 `.claude/skills/` 不会再当 "non-production" 清
- 现役 daemon 进程不受影响(in-memory)
- 后续 spawn 用新路径

📢 cc:@loning @eanzhao

⟦AI:AUTO-LOOP⟧