### PR TITLE
Improve team test error copy

### DIFF
--- a/apps/aevatar-console-web/src/pages/teams/components/TeamTestPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/components/TeamTestPanel.tsx
@@ -207,7 +207,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
         <AevatarInspectorEmpty
           compact
           title="成员清单暂不可见"
-          description="当前无法读取 Team 成员，暂时不能选择入口成员。"
+          description="当前无法读取团队成员，暂时不能选择入口成员。"
         />
       );
     }
@@ -217,8 +217,8 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
         <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
           <AevatarInspectorEmpty
             compact
-            title="这支 Team 还没有成员"
-            description="先创建一个成员，完成 Build / Bind 后再测试 Team。"
+            title="这支团队还没有成员"
+            description="先创建一个成员，完成构建和绑定后再测试团队。"
           />
           {createMemberHref ? (
             <Button
@@ -240,7 +240,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
             showIcon
             type="warning"
             message="还没有可作为入口的成员"
-            description="成员需要完成 Build / Bind，并进入可调用状态后才能测试 Team。"
+            description="成员需要完成构建和绑定，并进入可调用状态后才能测试团队。"
           />
         ) : null}
         {rosterRows.map((row) => (
@@ -313,7 +313,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
                   onClick={handleNavigate(row.buildStudioHref)}
                   size="small"
                 >
-                  先 Build / Bind
+                  先构建和绑定
                 </Button>
               )}
             </Space>
@@ -341,7 +341,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
           <Space align="center" size={8} wrap>
             <WarningOutlined style={{ color: token.colorWarning }} />
-            <Typography.Text strong>入口成员不在当前 Team 成员清单中</Typography.Text>
+            <Typography.Text strong>入口成员不在当前团队成员清单中</Typography.Text>
             <CompactFactValue value={normalizedEntryMemberId} />
           </Space>
           {renderEntrySelection()}
@@ -416,7 +416,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
               onClick={handleNavigate(entryMember.editStudioHref)}
               size="small"
             >
-              在 Studio 编辑
+              在工作室编辑
             </Button>
           ) : null}
           {onClearEntry ? (
@@ -473,7 +473,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
             />
           </Space>
           <Typography.Text style={{ fontSize: 13 }} type="secondary">
-            通过入口成员发起一次真实 Team 调用。
+            通过入口成员发起一次真实团队调用。
           </Typography.Text>
         </div>
         {lastResult ? (
@@ -545,7 +545,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
           autoSize={{ minRows: 3, maxRows: 8 }}
           disabled={disabled || isRunning || isSettingEntry}
           onChange={(event) => onPromptChange(event.target.value)}
-          placeholder="输入这支 Team 要处理的问题..."
+          placeholder="输入这支团队要处理的问题..."
           style={{ flex: "1 1 280px" }}
           value={prompt}
         />
@@ -572,7 +572,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
               开始测试
             </Button>
           )}
-          {error?.actionLabel === "Retry" && !isRunning ? (
+          {error?.actionLabel === "重试" && !isRunning ? (
             <Button block disabled={!canTest} onClick={onTest}>
               重试
             </Button>
@@ -626,7 +626,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
         >
           {resultText ||
             (isRunning
-              ? "等待 Team 返回..."
+              ? "等待团队返回..."
               : "测试结果会显示在这里。")}
         </Typography.Paragraph>
       </div>

--- a/apps/aevatar-console-web/src/pages/teams/components/teamTestErrors.ts
+++ b/apps/aevatar-console-web/src/pages/teams/components/teamTestErrors.ts
@@ -59,7 +59,7 @@ export function isAbortLikeError(error: unknown): boolean {
 
 export function describeTeamTestError(
   error: unknown,
-  fallback = "Team Test failed."
+  fallback = "团队测试失败。"
 ): TeamTestErrorDescription {
   if (isAbortLikeError(error)) {
     return {
@@ -76,23 +76,23 @@ export function describeTeamTestError(
 
   if (normalized.includes("TEAM_NOT_FOUND")) {
     return {
-      description: "这支 Team 在当前 Scope 中不可见，请返回 Teams 列表重新选择。",
+      description: "这支团队在当前工作区中不可见，请返回团队列表重新选择。",
       kind: "team_not_found",
-      title: "Team 不存在",
+      title: "团队不存在",
     };
   }
 
   if (normalized.includes("STUDIO_TEAM_NOT_FOUND")) {
     return {
-      description: "这支 Team 在当前 Scope 中不可见，请返回 Teams 列表重新选择。",
+      description: "这支团队在当前工作区中不可见，请返回团队列表重新选择。",
       kind: "team_not_found",
-      title: "Team 不存在",
+      title: "团队不存在",
     };
   }
 
   if (normalized.includes("TEAM_ENTRY_MEMBER_NOT_CONFIGURED")) {
     return {
-      description: "这支 Team 还没有入口成员，请先选择一个已绑定的成员作为入口。",
+      description: "这支团队还没有入口成员，请先选择一个已绑定的成员作为入口。",
       kind: "entry_missing",
       title: "未设置入口成员",
     };
@@ -100,7 +100,7 @@ export function describeTeamTestError(
 
   if (normalized.includes("TEAM_ENTRY_MEMBER_NOT_READY")) {
     return {
-      description: "入口成员还没有完成 Build / Bind，暂时不能作为 Team Test 的运行入口。",
+      description: "入口成员还没有完成构建和绑定，暂时不能作为团队测试的运行入口。",
       kind: "entry_not_ready",
       title: "入口成员尚未就绪",
     };
@@ -111,7 +111,7 @@ export function describeTeamTestError(
     normalized.includes("STUDIO_MEMBER_NOT_FOUND")
   ) {
     return {
-      description: "当前入口成员不在这支 Team 的成员清单中，请重新选择入口成员。",
+      description: "当前入口成员不在这支团队的成员清单中，请重新选择入口成员。",
       kind: "entry_not_found",
       title: "入口成员不可见",
     };
@@ -119,7 +119,7 @@ export function describeTeamTestError(
 
   if (normalized.includes("TEAM_ENTRY_MEMBER_MISMATCH")) {
     return {
-      description: "入口成员不属于当前 Team，请从当前 Team 成员中重新选择。",
+      description: "入口成员不属于当前团队，请从当前团队成员中重新选择。",
       kind: "entry_mismatch",
       title: "入口成员不匹配",
     };
@@ -127,25 +127,25 @@ export function describeTeamTestError(
 
   if (normalized.includes("TEAM_ARCHIVED")) {
     return {
-      description: "归档后的 Team 不能继续发起测试。",
+      description: "归档后的团队不能继续发起测试。",
       kind: "team_archived",
-      title: "Team 已归档",
+      title: "团队已归档",
     };
   }
 
   if (status === 404 || status === 405) {
     return {
-      actionLabel: "Retry",
+      actionLabel: "重试",
       description:
-        "当前后端还没有部署 Team entry-member 或 Team invoke 接口。前端会保留入口配置和测试草稿，等后端支持后可直接重试。",
+        "当前后端还没有部署团队入口成员或团队调用接口。前端会保留入口配置和测试草稿，等后端支持后可直接重试。",
       kind: "backend_unsupported",
-      title: "后端暂不支持 Team Test",
+      title: "后端暂不支持团队测试",
     };
   }
 
   if (status === 403) {
     return {
-      description: "当前账号没有修改或测试这支 Team 的权限。",
+      description: "当前账号没有修改或测试这支团队的权限。",
       kind: "permission_denied",
       title: "权限不足",
     };
@@ -153,7 +153,8 @@ export function describeTeamTestError(
 
   if (status === 400) {
     return {
-      description: message,
+      description:
+        "当前入口成员的绑定产物不可用。请回到工作室重新构建和绑定该成员，然后再测试团队。",
       kind: "invalid_entry",
       title: "入口成员无效",
     };
@@ -161,10 +162,10 @@ export function describeTeamTestError(
 
   if (status === 409) {
     return {
-      actionLabel: "Retry",
+      actionLabel: "重试",
       description: message,
       kind: "conflict",
-      title: "Team 状态已变化",
+      title: "团队状态已变化",
     };
   }
 
@@ -173,7 +174,7 @@ export function describeTeamTestError(
     message.toLowerCase().includes("network")
   ) {
     return {
-      actionLabel: "Retry",
+      actionLabel: "重试",
       description: "网络请求中断，请检查登录状态或稍后重试。",
       kind: "network",
       title: "网络请求失败",
@@ -181,7 +182,7 @@ export function describeTeamTestError(
   }
 
   return {
-    actionLabel: "Retry",
+    actionLabel: "重试",
     description: message,
     kind: "unknown",
     title: fallback,

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -1294,7 +1294,7 @@ describe("TeamDetailPage", () => {
         name: "设为入口并测试",
       }),
     ).toBeNull();
-    expect(within(dialog).getByRole("link", { name: "先 Build / Bind" }))
+    expect(within(dialog).getByRole("link", { name: "先构建和绑定" }))
       .toHaveAttribute("href", expect.stringContaining("member-unpublished"));
   });
 
@@ -1398,10 +1398,10 @@ describe("TeamDetailPage", () => {
     });
     fireEvent.click(within(dialog).getByRole("button", { name: "设为入口并测试" }));
 
-    expect(await screen.findByText("Team entry 正在同步")).toBeTruthy();
+    expect(await screen.findByText("团队入口正在同步")).toBeTruthy();
     expect(
       screen.getAllByText(
-        "Team entry 已被后端受理，但读模型还没有确认新入口成员。请稍后重试测试团队。",
+        "团队入口已被后端受理，但读模型还没有确认新入口成员。请稍后重试测试团队。",
       ).length,
     ).toBeGreaterThan(0);
     expect(runtimeRunsApi.streamTeamChat).not.toHaveBeenCalled();
@@ -1422,10 +1422,37 @@ describe("TeamDetailPage", () => {
     });
     fireEvent.click(within(dialog).getByRole("button", { name: "开始测试" }));
 
-    expect(await screen.findByText("后端暂不支持 Team Test")).toBeTruthy();
+    expect(await screen.findByText("后端暂不支持团队测试")).toBeTruthy();
     expect(
-      screen.getAllByText(/当前后端还没有部署 Team entry-member/).length,
+      screen.getAllByText(/当前后端还没有部署团队入口成员/).length,
     ).toBeGreaterThan(0);
+  });
+
+  it("does not expose raw backend artifact details for invalid Team Test entry responses", async () => {
+    const invalidEntryError = new Error(
+      "Prepared artifact for 'scope-1:default:member-team-alpha' revision 'rev-platform-bind-123' is missing.",
+    ) as Error & { status: number };
+    invalidEntryError.status = 400;
+    (runtimeRunsApi.streamTeamChat as jest.Mock).mockRejectedValueOnce(
+      invalidEntryError,
+    );
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    const dialog = await openTeamTestDialog();
+    fireEvent.change(within(dialog).getByLabelText("测试问题"), {
+      target: { value: "Try invalid entry" },
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "开始测试" }));
+
+    expect(await screen.findByText("入口成员无效")).toBeTruthy();
+    expect(
+      screen.getAllByText(
+        "当前入口成员的绑定产物不可用。请回到工作室重新构建和绑定该成员，然后再测试团队。",
+      ).length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText(/Prepared artifact/)).toBeNull();
+    expect(screen.queryByText(/rev-platform-bind-123/)).toBeNull();
   });
 
   it("shows Team entry configuration errors from the router backend", async () => {
@@ -1446,10 +1473,10 @@ describe("TeamDetailPage", () => {
     expect(await screen.findByText("未设置入口成员")).toBeTruthy();
     expect(
       screen.getAllByText(
-        "这支 Team 还没有入口成员，请先选择一个已绑定的成员作为入口。",
+        "这支团队还没有入口成员，请先选择一个已绑定的成员作为入口。",
       ).length,
     ).toBeGreaterThan(0);
-    expect(screen.queryByText("后端暂不支持 Team Test")).toBeNull();
+    expect(screen.queryByText("后端暂不支持团队测试")).toBeNull();
   });
 
   it("does not treat router Team not found as an undeployed backend", async () => {
@@ -1469,13 +1496,13 @@ describe("TeamDetailPage", () => {
     });
     fireEvent.click(within(dialog).getByRole("button", { name: "开始测试" }));
 
-    expect(await screen.findByText("Team 不存在")).toBeTruthy();
+    expect(await screen.findByText("团队不存在")).toBeTruthy();
     expect(
       screen.getAllByText(
-        "这支 Team 在当前 Scope 中不可见，请返回 Teams 列表重新选择。",
+        "这支团队在当前工作区中不可见，请返回团队列表重新选择。",
       ).length,
     ).toBeGreaterThan(0);
-    expect(screen.queryByText("后端暂不支持 Team Test")).toBeNull();
+    expect(screen.queryByText("后端暂不支持团队测试")).toBeNull();
   });
 
   it("routes member build actions into Studio with Team context", async () => {

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -1267,11 +1267,11 @@ const TeamDetailPage: React.FC = () => {
           const entryVisible = await waitForTeamEntryVisibility(normalizedMemberId);
           if (!entryVisible) {
             const errorDescription: TeamTestErrorDescription = {
-              actionLabel: "Retry",
+              actionLabel: "重试",
               description:
-                "Team entry 已被后端受理，但读模型还没有确认新入口成员。请稍后重试测试团队。",
+                "团队入口已被后端受理，但读模型还没有确认新入口成员。请稍后重试测试团队。",
               kind: "entry_syncing",
-              title: "Team entry 正在同步",
+              title: "团队入口正在同步",
             };
             setTeamTestStatus("error");
             setTeamTestError(errorDescription);
@@ -1290,7 +1290,7 @@ const TeamDetailPage: React.FC = () => {
       } catch (error) {
         const errorDescription = describeTeamTestError(
           error,
-          "Team entry update failed.",
+          "团队入口更新失败。",
         );
         setTeamTestStatus("error");
         setTeamTestError(errorDescription);
@@ -1331,7 +1331,7 @@ const TeamDetailPage: React.FC = () => {
     } catch (error) {
       const errorDescription = describeTeamTestError(
         error,
-        "Team entry update failed.",
+        "团队入口更新失败。",
       );
       setTeamTestStatus("error");
       setTeamTestError(errorDescription);


### PR DESCRIPTION
## 问题与根因
Team Test 弹窗和错误态仍有多处用户可见中英混排，且 400 invalid entry 响应会把后端原始 artifact/revision 细节直接展示给用户。根因是前端 Team Test panel/error mapper 使用英文 fallback copy，并对 `status === 400` 直接透传后端 message。

## 修复方案
- 将 Team Test 弹窗内的直接用户可见 copy 本地化：真实团队调用、工作室编辑、构建和绑定、placeholder、等待团队返回等。
- 将 Team Test 错误 mapper 的 title/description/actionLabel 本地化：团队不存在、团队入口同步、后端暂不支持团队测试、团队状态变化等。
- 对 `status === 400` 的 invalid entry 响应显示中文可行动说明，不再暴露 raw backend artifact/revision details；仍保留错误状态，不伪造成功。
- 增加 regression test，模拟 `Prepared artifact ... revision ...` 后端消息，断言 UI 不外露 raw details。

## 影响路径
- `apps/aevatar-console-web/src/pages/teams/components/TeamTestPanel.tsx`
- `apps/aevatar-console-web/src/pages/teams/components/teamTestErrors.ts`
- `apps/aevatar-console-web/src/pages/teams/detail.tsx`
- `apps/aevatar-console-web/src/pages/teams/detail.test.tsx`

## Browser 证据
- Cycle 1：在 `http://localhost:5173/teams/...?...&tab=members` 打开 Team Test modal 后，确认可见 `通过入口成员发起一次真实团队调用。`、`在工作室编辑`、placeholder `输入这支团队要处理的问题...`；旧文案 `真实 Team 调用`、`在 Studio 编辑`、`输入这支 Team 要处理的问题` 不再出现。
- Cycle 2：输入测试问题并点击开始测试，modal 正常进入失败态；未出现旧 `Team Test` / `Team entry` / `Team 不存在` / `后端暂不支持 Team Test` 文案。真实后端返回 400 时仍显示错误状态，没有伪造成功。
- Cycle 3：重新触发真实 400 后显示 `入口成员无效` 和 `当前入口成员的绑定产物不可用。请回到工作室重新构建和绑定该成员，然后再测试团队。`；DOM 未再出现 `Prepared artifact for`、`revision`、`Team Test`、`Team entry`。
- Console：本轮页面 reload 和 modal 操作正常渲染；浏览器 console 面板仍保留 2026-05-27 旧热更新错误历史记录，未观察到本轮新增当前页面编译/runtime 错误。

## 验证命令与结果
- `./node_modules/.bin/jest src/pages/teams/detail.test.tsx --runInBand`：passed，40/40 tests；Jest 结束后仍提示既有 open handles warning，exit code 0。
- `./node_modules/.bin/tsc --noEmit`：passed
- `git diff --check -- apps/aevatar-console-web`：passed
- `bash tools/ci/test_stability_guards.sh`：passed

## Scope check
- 本 PR diff 只包含 `apps/aevatar-console-web/` 下 4 个文件。
- 未修改 backend。
- 未修改 proto。
- 未修改 docs/tools/scripts。
- 未修改 `.slnx`、`.csproj`、`.cs`、generated files 或 shared contracts。
