### PR TITLE
Localize team overview copy

### DIFF
--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -1161,7 +1161,7 @@ describe("TeamDetailPage", () => {
     await waitFor(() => {
       expect(screen.getAllByText("Team Alpha Operator").length).toBeGreaterThan(0);
     });
-    expect(screen.getByText("调用这支 Team 时会先路由到这个成员。")).toBeTruthy();
+    expect(screen.getByText("调用这支团队时会先路由到这个成员。")).toBeTruthy();
     expect(screen.getByRole("button", { name: "清除入口成员" })).toBeEnabled();
 
     fireEvent.click(screen.getByRole("button", { name: "团队成员" }));
@@ -1600,7 +1600,7 @@ describe("TeamDetailPage", () => {
     expect(screen.getByText("已启用")).toBeTruthy();
     expect((await screen.findAllByText("Team summary")).length).toBeGreaterThan(0);
     expect(screen.getAllByText("3 个成员").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("来自 Team 更新时间").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("来自团队更新时间").length).toBeGreaterThan(0);
     expect(screen.getByText("当前态势")).toBeTruthy();
     expect(screen.getByText("团队构成")).toBeTruthy();
     expect(screen.getByText("配置明细")).toBeTruthy();
@@ -1628,6 +1628,13 @@ describe("TeamDetailPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "编辑团队" }));
 
     const nameInput = await screen.findByLabelText("编辑团队名称");
+    expect(screen.getByRole("button", { name: "取 消" })).toBeTruthy();
+    expect(
+      screen.getByText("这里更新的是团队摘要。即使团队已归档，仍然可以继续编辑和维护。"),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText("这里更新的是 Team summary。即使团队已归档，仍然可以继续编辑和维护。"),
+    ).toBeNull();
     expect(nameInput).toHaveValue("Alpha Support Team");
     fireEvent.change(nameInput, {
       target: { value: " Alpha Ops Team " },

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -793,7 +793,7 @@ const TeamDetailPage: React.FC = () => {
     activeWorkflowSummary?.updatedAt ||
     "";
   const latestVisibleUpdateNote = teamSummaryQuery.data?.updatedAt
-    ? "来自 Team 更新时间"
+    ? "来自团队更新时间"
     : lens.currentRun?.lastUpdatedAt
       ? trimText(lens.currentRun?.runId)
       ? `来自 run ${compactId(lens.currentRun?.runId)}`
@@ -1508,6 +1508,7 @@ const TeamDetailPage: React.FC = () => {
         <div data-testid="team-test-modal-body">{teamTestPanel}</div>
       </Modal>
       <Modal
+        cancelText="取消"
         confirmLoading={teamEditorSaving}
         okButtonProps={{ disabled: !teamEditorName.trim() }}
         okText="保存团队"
@@ -1537,7 +1538,7 @@ const TeamDetailPage: React.FC = () => {
             />
           </div>
           <Typography.Text type="secondary">
-            这里更新的是 Team summary。即使团队已归档，仍然可以继续编辑和维护。
+            这里更新的是团队摘要。即使团队已归档，仍然可以继续编辑和维护。
           </Typography.Text>
         </div>
       </Modal>

--- a/apps/aevatar-console-web/src/pages/teams/home.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.test.tsx
@@ -158,21 +158,21 @@ describe("TeamsHomePage", () => {
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
     expect(await screen.findByRole("button", { name: "查看团队" })).toBeTruthy();
-    expect(screen.getByText("Aevatar / Teams")).toBeTruthy();
+    expect(screen.getByText("Aevatar / 团队")).toBeTruthy();
     expect(screen.getByText("我的 AI 团队")).toBeTruthy();
     expect(screen.queryByText("当前工作空间")).toBeNull();
-    expect(screen.getByText("AI Team 总数")).toBeTruthy();
-    expect(screen.getByText("待处理 Team")).toBeTruthy();
+    expect(screen.getByText("AI 团队总数")).toBeTruthy();
+    expect(screen.getByText("待处理团队")).toBeTruthy();
     expect(screen.getByText("运行稳定")).toBeTruthy();
     expect(screen.getByText("团队列表")).toBeTruthy();
     expect(
-      screen.getByText("按 Team 聚合成员与最近运行信号，优先处理异常或待关注项。"),
+      screen.getByText("按团队聚合成员与最近运行信号，优先处理异常或待关注项。"),
     ).toBeTruthy();
     expect(screen.queryByText("运行正常")).toBeNull();
     expect(screen.queryByText("需要处理")).toBeNull();
     expect(screen.getByRole("button", { name: "组建新团队" })).toBeTruthy();
     expect(screen.getByRole("heading", { level: 3, name: "客服团队" })).toBeTruthy();
-    expect(screen.getByText("Team 标识：t-support")).toBeTruthy();
+    expect(screen.getByText("团队标识：t-support")).toBeTruthy();
     expect(screen.getByText("客服运行时")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "切换到列表视图" })).toBeNull();
     expect(screen.queryByRole("button", { name: "更多" })).toBeNull();
@@ -324,7 +324,7 @@ describe("TeamsHomePage", () => {
       "title",
       expect.stringContaining("另一个非常长的服务名用于验证 hover 全量展示"),
     );
-    expect(screen.getByText("Team 标识：t-long").closest("[title]")).toHaveAttribute(
+    expect(screen.getByText("团队标识：t-long").closest("[title]")).toHaveAttribute(
       "title",
       "t-long",
     );
@@ -471,7 +471,7 @@ describe("TeamsHomePage", () => {
     expect(scopeRuntimeApi.listServices).not.toHaveBeenCalled();
     expect(screen.queryByText("部分团队信号暂时不可见")).toBeNull();
     expect(screen.queryByText("团队列表暂时无法加载。")).toBeNull();
-    expect(screen.queryByText("AI Team 总数")).toBeNull();
+    expect(screen.queryByText("AI 团队总数")).toBeNull();
 
     await waitFor(() => {
       expect(new URLSearchParams(window.location.search).get("scopeId")).toBe("scope-a");
@@ -540,7 +540,7 @@ describe("TeamsHomePage", () => {
 
     expect(await screen.findByRole("heading", { level: 3, name: "客服团队" })).toBeTruthy();
     expect(screen.getByRole("heading", { level: 3, name: "joker" })).toBeTruthy();
-    expect(screen.getByText("Team 标识：t-joker")).toBeTruthy();
+    expect(screen.getByText("团队标识：t-joker")).toBeTruthy();
     expect(screen.getAllByRole("button", { name: "查看团队" })).toHaveLength(2);
   });
 
@@ -569,7 +569,7 @@ describe("TeamsHomePage", () => {
 
     expect(await screen.findByText("团队列表")).toBeTruthy();
     expect(screen.queryByText("存在未归队成员")).toBeNull();
-    expect(screen.getByText("Team 标识：t-support")).toBeTruthy();
+    expect(screen.getByText("团队标识：t-support")).toBeTruthy();
     expect(screen.queryByRole("heading", { level: 3, name: "未归队成员" })).toBeNull();
   });
 
@@ -589,7 +589,7 @@ describe("TeamsHomePage", () => {
 
     expect(
       await screen.findByText(
-        "当前账号还没有创建任何 Team。创建后，这里会展示你的 AI 团队列表。",
+        "当前账号还没有创建任何团队。创建后，这里会展示你的 AI 团队列表。",
       ),
     ).toBeTruthy();
     expect(scopeRuntimeApi.listMemberRuns).not.toHaveBeenCalled();
@@ -622,7 +622,7 @@ describe("TeamsHomePage", () => {
     expect(
       await screen.findByRole("heading", { level: 3, name: "刚创建的团队" }),
     ).toBeTruthy();
-    expect(screen.getByText("Team 标识：t-new")).toBeTruthy();
+    expect(screen.getByText("团队标识：t-new")).toBeTruthy();
     expect(
       screen.queryByText(
         "当前工作空间还没有创建任何 Team。创建 Team 后，这里会按后端 roster 展示真实团队。",

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -598,10 +598,10 @@ function buildTeamRosterPreview(input: {
 
   let attention: TeamOperationalAttention =
     mostImportantMemberPreview?.attention ?? "draft";
-  let attentionDetail = "这个 Team 已经存在后端事实，但还没有分配成员。";
+  let attentionDetail = "这个团队已经存在后端事实，但还没有分配成员。";
   if (input.team.lifecycleStage === "archived") {
     attention = "draft";
-    attentionDetail = "这个 Team 已归档，列表中仅保留它的后端 roster 事实。";
+    attentionDetail = "这个团队已归档，列表中仅保留它的后端成员清单事实。";
   } else if (mostImportantMemberPreview) {
     attentionDetail = mostImportantMemberPreview.attentionDetail;
   }
@@ -620,7 +620,7 @@ function buildTeamRosterPreview(input: {
     serviceTooltip,
     team: input.team,
     teamId: input.team.teamId,
-    title: pickMeaningfulLabel(input.team.displayName, input.team.teamId) || "未命名 Team",
+    title: pickMeaningfulLabel(input.team.displayName, input.team.teamId) || "未命名团队",
     updatedAt:
       latestRun?.lastUpdatedAt ||
       mostImportantMemberPreview?.updatedAt ||
@@ -697,7 +697,7 @@ const TeamRosterCard: React.FC<{
           fontSize: 13,
         }}
       >
-        Team 标识：{preview.teamId}
+        团队标识：{preview.teamId}
       </Typography.Text>
 
       <div
@@ -826,7 +826,7 @@ const TeamRosterRow: React.FC<{
               marginTop: 4,
             }}
           >
-            Team 标识：{preview.teamId}
+            团队标识：{preview.teamId}
           </Typography.Text>
         </div>
 
@@ -1054,7 +1054,7 @@ const TeamsHomePage: React.FC = () => {
   const useCompactRoster = resolvedRosterView === "list";
   const emptyRosterHint =
     canLoadRoster
-      ? "当前账号还没有创建任何 Team。创建后，这里会展示你的 AI 团队列表。"
+      ? "当前账号还没有创建任何团队。创建后，这里会展示你的 AI 团队列表。"
       : "当前登录状态还没有解析出可用的团队范围，请刷新后重试。";
   const partialIssues = [
     membersQuery.isError ? "当前工作空间的成员清单暂时不可见。" : null,
@@ -1069,7 +1069,7 @@ const TeamsHomePage: React.FC = () => {
           fontSize: 14,
         }}
       >
-        Aevatar / Teams
+        Aevatar / 团队
       </Typography.Text>
       <Typography.Title
         level={1}
@@ -1151,8 +1151,8 @@ const TeamsHomePage: React.FC = () => {
                 gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
               }}
             >
-              <SummaryStatCard accent label="AI Team 总数" value={visibleTeamCount} />
-              <SummaryStatCard label="待处理 Team" value={actionableTeamCount} />
+              <SummaryStatCard accent label="AI 团队总数" value={visibleTeamCount} />
+              <SummaryStatCard label="待处理团队" value={actionableTeamCount} />
               <SummaryStatCard label="运行稳定" value={healthyTeamCount} />
             </div>
 
@@ -1191,7 +1191,7 @@ const TeamsHomePage: React.FC = () => {
                       团队列表
                     </Typography.Title>
                     <Typography.Text type="secondary">
-                      按 Team 聚合成员与最近运行信号，优先处理异常或待关注项。
+                      按团队聚合成员与最近运行信号，优先处理异常或待关注项。
                     </Typography.Text>
                   </div>
                   {visibleTeamCount > 1 ? (

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx
@@ -151,7 +151,7 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
             value={entryMemberLabel || entryMemberId || "未配置"}
             caption={
               hasEntryMember
-                ? "调用这支 Team 时会先路由到这个成员。"
+                ? "调用这支团队时会先路由到这个成员。"
                 : "测试或调用前，请先设置一个入口成员。"
             }
           />


### PR DESCRIPTION
## 问题与根因
- Team detail overview、edit modal、Teams list 仍混有英文 Team/Teams 或 backend-facing roster 文案。
- 这些都是前端本地可见文案，根因不涉及 API shape、backend、proto 或 shared contract。

## 修复方案
- 将 Team detail overview 的更新时间来源、entry member 提示改为中文团队文案。
- 将 Edit Team modal 的摘要说明与取消按钮本地化。
- 将 Teams list 的 breadcrumb、统计卡、列表说明、团队标识、归档说明、空状态文案改为中文。
- 更新对应 focused tests 锁定这些用户可见文案。

## 影响路径
- apps/aevatar-console-web/src/pages/teams/detail.tsx
- apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx
- apps/aevatar-console-web/src/pages/teams/home.tsx
- apps/aevatar-console-web/src/pages/teams/detail.test.tsx
- apps/aevatar-console-web/src/pages/teams/home.test.tsx

## Browser 证据
- Cycle 1: 复验 Team detail overview，DOM 显示「来自团队更新时间」「调用这支团队时会先路由到这个成员。」旧文案不再出现。
- Cycle 2: 复验 Edit Team modal，DOM/截图显示「团队摘要」说明与「取消」按钮，未再出现 `Team summary` 或 `Cancel` 按钮文案。
- Cycle 3: 复验 Teams list `/teams?scopeId=ccb108c4-dcb3-473a-a0f7-e9859bb2f2a0`，DOM/截图显示「Aevatar / 团队」「AI 团队总数」「待处理团队」「按团队聚合...」「团队标识」，归档说明显示「后端成员清单事实」。
- Console: 仅观察到 2026-05-27 的历史 `@/shared/i18n/localization` 编译错误记录；当前 reload 后页面正常渲染，未观察到本轮新增 runtime/console error。

## 验证命令与结果
- `cd apps/aevatar-console-web && ./node_modules/.bin/jest src/pages/teams/home.test.tsx --runInBand` -> passed, 16/16 tests.
- `cd apps/aevatar-console-web && ./node_modules/.bin/jest src/pages/teams/detail.test.tsx src/pages/teams/home.test.tsx --runInBand` -> passed, 55/55 tests.
- `cd apps/aevatar-console-web && ./node_modules/.bin/tsc --noEmit` -> passed.
- `git diff --check -- apps/aevatar-console-web` -> passed.
- `bash tools/ci/test_stability_guards.sh` -> passed.

## Scope check
- All changed files are under `apps/aevatar-console-web/`.
- 未修改 backend。
- 未修改 proto。
- 未修改 docs/tools。