### PR TITLE
Improve team bind setup copy

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/components/StudioShell.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioShell.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
+import { Grid } from 'antd';
 import React from 'react';
 import StudioShell, {
   type StudioLifecycleStep,
@@ -55,6 +56,10 @@ describe('StudioShell', () => {
       status: 'available',
     },
   ];
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
   it('renders the member rail and forwards member and lifecycle selection', async () => {
     const handleCreateMember = jest.fn();
@@ -245,6 +250,43 @@ describe('StudioShell', () => {
     expect(screen.getByTestId('studio-shell-content').parentElement).toHaveStyle({
       minWidth: '0',
       overflow: 'hidden',
+    });
+  });
+
+  it('stacks the member rail above the studio workbench on compact screens', () => {
+    jest.spyOn(Grid, 'useBreakpoint').mockReturnValue({
+      xs: true,
+      sm: true,
+      md: false,
+      lg: false,
+      xl: false,
+      xxl: false,
+    });
+
+    const { container } = render(
+      <StudioShell
+        currentLifecycleStep="build"
+        lifecycleSteps={lifecycleSteps}
+        members={members}
+        onSelectLifecycleStep={jest.fn()}
+        onSelectMember={jest.fn()}
+        pageTitle="Studio page"
+        selectedMemberKey="workflow:workspace-demo"
+      >
+        <div>Studio content</div>
+      </StudioShell>,
+    );
+
+    expect(container.firstChild).toHaveStyle({
+      flexDirection: 'column',
+    });
+    expect(screen.getByLabelText('Team members')).toHaveStyle({
+      borderRight: '0',
+      maxHeight: '320px',
+      width: '100%',
+    });
+    expect(screen.getByTestId('studio-shell-main')).toHaveStyle({
+      width: '100%',
     });
   });
 });

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioShell.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioShell.tsx
@@ -6,7 +6,7 @@ import {
   RobotOutlined,
   TeamOutlined,
 } from '@ant-design/icons';
-import { Popover, Typography } from 'antd';
+import { Grid, Popover, Typography } from 'antd';
 import React from 'react';
 import {
   AEVATAR_INTERACTIVE_BUTTON_CLASS,
@@ -84,6 +84,15 @@ const railStyle: React.CSSProperties = {
   flexShrink: 0,
   minHeight: 0,
   width: 276,
+};
+
+const compactRailStyle: React.CSSProperties = {
+  ...railStyle,
+  borderBottom: '1px solid #ebe2d4',
+  borderRight: 0,
+  maxHeight: 320,
+  overflow: 'hidden',
+  width: '100%',
 };
 
 const railHeaderStyle: React.CSSProperties = {
@@ -421,6 +430,9 @@ const StudioShell: React.FC<StudioShellProps> = ({
   const [memberFilter, setMemberFilter] = React.useState<
     'all' | StudioShellMemberKind
   >('all');
+  const screens = Grid.useBreakpoint();
+  const hasResolvedBreakpoint = Object.values(screens).some(Boolean);
+  const useCompactShell = hasResolvedBreakpoint && screens.md === false;
 
   const memberFilterOptions = React.useMemo(() => {
     const counts = members.reduce<Record<string, number>>((current, member) => {
@@ -498,10 +510,23 @@ const StudioShell: React.FC<StudioShellProps> = ({
         ...shellPageBodyStyle,
         overflowY: contentOverflow,
       } satisfies React.CSSProperties);
+  const rootStyle = useCompactShell
+    ? ({
+        ...shellRootStyle,
+        flexDirection: 'column',
+      } satisfies React.CSSProperties)
+    : shellRootStyle;
+  const resolvedRailStyle = useCompactShell ? compactRailStyle : railStyle;
+  const resolvedMainStyle = useCompactShell
+    ? ({
+        ...mainStyle,
+        width: '100%',
+      } satisfies React.CSSProperties)
+    : mainStyle;
 
   return (
-    <div style={shellRootStyle}>
-      <aside style={railStyle} aria-label="Team members">
+    <div style={rootStyle}>
+      <aside style={resolvedRailStyle} aria-label="Team members">
         <div style={railHeaderStyle}>
           <div
             style={{
@@ -761,7 +786,7 @@ const StudioShell: React.FC<StudioShellProps> = ({
 
       </aside>
 
-      <div data-testid="studio-shell-main" style={mainStyle}>
+      <div data-testid="studio-shell-main" style={resolvedMainStyle}>
         {contextBar}
         {lifecycleSteps.length > 0 ? (
           <div data-testid="studio-lifecycle-section" style={lifecycleSectionStyle}>

--- a/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx
@@ -805,8 +805,8 @@ describe('StudioMemberBindPanel', () => {
           kind: 'workflow',
           displayName: 'draft',
           description:
-            'Publish the current workflow revision first, then Studio can reveal the invoke URL and endpoint contract for this member.',
-          actionLabel: 'Bind current revision',
+            '先发布当前 workflow 版本，然后 Studio 会展示这个成员的调用 URL 和端点契约。',
+          actionLabel: '绑定当前版本',
         },
         onBindPendingCandidate: handleBindPendingCandidate,
         services: [],
@@ -815,12 +815,12 @@ describe('StudioMemberBindPanel', () => {
 
     expect(await screen.findByTestId('studio-bind-surface')).toBeTruthy();
     expect(
-      screen.getByText('No published contract exists for draft yet.'),
+      screen.getByText('draft 还没有已发布契约。'),
     ).toBeTruthy();
-    expect(screen.getByText('Publish current member')).toBeTruthy();
+    expect(screen.getByText('发布当前成员')).toBeTruthy();
 
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: 'Bind current revision' }));
+      fireEvent.click(screen.getByRole('button', { name: '绑定当前版本' }));
     });
 
     expect(handleBindPendingCandidate).toHaveBeenCalledTimes(1);
@@ -833,8 +833,8 @@ describe('StudioMemberBindPanel', () => {
         kind: 'workflow' as const,
         displayName: 'draft1',
         description:
-          'Publish the current workflow revision first, then Studio can reveal the invoke URL and endpoint contract for this member.',
-        actionLabel: 'Bind current revision',
+          '先发布当前 workflow 版本，然后 Studio 会展示这个成员的调用 URL 和端点契约。',
+        actionLabel: '绑定当前版本',
       });
 
       return React.createElement(React.Fragment, null, [
@@ -848,8 +848,8 @@ describe('StudioMemberBindPanel', () => {
                 kind: 'workflow',
                 displayName: 'joker',
                 description:
-                  'Publish the current workflow revision first, then Studio can reveal the invoke URL and endpoint contract for this member.',
-                actionLabel: 'Bind current revision',
+                  '先发布当前 workflow 版本，然后 Studio 会展示这个成员的调用 URL 和端点契约。',
+                actionLabel: '绑定当前版本',
               }),
           },
           'Switch candidate',
@@ -874,26 +874,26 @@ describe('StudioMemberBindPanel', () => {
     renderWithQueryClient(React.createElement(CandidateHarness));
 
     await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: 'Bind current revision' }));
+      fireEvent.click(screen.getByRole('button', { name: '绑定当前版本' }));
     });
 
     expect(
       await screen.findByText(
-        'draft1 binding request was accepted. Studio will show the published contract after the run completes.',
+        'draft1 的绑定请求已接受。运行完成后，Studio 会显示已发布契约。',
       ),
     ).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Switch candidate' }));
 
-    expect(await screen.findByText('No published contract exists for joker yet.')).toBeTruthy();
+    expect(await screen.findByText('joker 还没有已发布契约。')).toBeTruthy();
     expect(
       screen.queryByText(
-        'draft1 binding request was accepted. Studio will show the published contract after the run completes.',
+        'draft1 的绑定请求已接受。运行完成后，Studio 会显示已发布契约。',
       ),
     ).toBeNull();
     expect(
       screen.queryByText(
-        'joker binding request was accepted. Studio will show the published contract after the run completes.',
+        'joker 的绑定请求已接受。运行完成后，Studio 会显示已发布契约。',
       ),
     ).toBeNull();
   });

--- a/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx
@@ -940,7 +940,7 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
       setPendingBindNotice({
         message:
           resultNotice?.message ||
-          `${pendingBindingCandidate.displayName} binding request was accepted. Studio will show the published contract after the run completes.`,
+          `${pendingBindingCandidate.displayName} 的绑定请求已接受。运行完成后，Studio 会显示已发布契约。`,
         type: resultNotice?.type || 'info',
       });
     } catch (error) {
@@ -987,18 +987,18 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
         <div data-testid="studio-bind-surface" style={rootStyle}>
           <Alert
             showIcon
-            message={`No published contract exists for ${pendingBindingCandidate.displayName} yet.`}
+            message={`${pendingBindingCandidate.displayName} 还没有已发布契约。`}
             description={pendingBindingCandidate.description}
             type="info"
           />
           <AevatarPanel
-            title="Publish current member"
-            titleHelp="Bind publishes the current revision first, then Studio reveals the invoke URL, endpoint contract, and smoke-test entry for this member."
+            title="发布当前成员"
+            titleHelp="Bind 会先发布当前版本，然后 Studio 展示这个成员的调用 URL、端点契约和 smoke test 入口。"
           >
             <div style={{ display: 'grid', gap: 12 }}>
               <div style={parameterGridStyle}>
                 <div style={valueCardStyle}>
-                  <Typography.Text type="secondary">Implementation kind</Typography.Text>
+                  <Typography.Text type="secondary">实现类型</Typography.Text>
                   <Typography.Text strong>
                     {pendingBindingCandidate.kind === 'workflow'
                       ? 'Workflow'
@@ -1008,13 +1008,13 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
                   </Typography.Text>
                 </div>
                 <div style={valueCardStyle}>
-                  <Typography.Text type="secondary">Current member</Typography.Text>
+                  <Typography.Text type="secondary">当前成员</Typography.Text>
                   <Typography.Text strong style={{ wordBreak: 'break-word' }}>
                     {pendingBindingCandidate.displayName}
                   </Typography.Text>
                 </div>
                 <div style={valueCardStyle}>
-                  <Typography.Text type="secondary">Workspace ID</Typography.Text>
+                  <Typography.Text type="secondary">工作区 ID</Typography.Text>
                   <Typography.Text strong style={{ wordBreak: 'break-word' }}>
                     {scopeId}
                   </Typography.Text>

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -4381,8 +4381,8 @@ const StudioPage: React.FC = () => {
         kind: 'workflow' as const,
         displayName,
         description:
-          'Publish the current workflow revision first, then Studio can reveal the invoke URL and endpoint contract for this member.',
-        actionLabel: 'Bind current revision',
+          '先发布当前 workflow 版本，然后 Studio 会展示这个成员的调用 URL 和端点契约。',
+        actionLabel: '绑定当前版本',
       };
     }
 
@@ -9435,7 +9435,7 @@ const StudioPage: React.FC = () => {
         : isObserveSurface
           ? '围绕当前 member 的最近运行、回放和基线继续观察'
           : isBindSurface
-            ? '确认当前 member 的 published contract，并继续去 Invoke'
+            ? '确认当前成员的已发布契约，并继续去 Invoke'
             : isInvokeSurface
               ? '调用当前成员并保留运行观察上下文'
               : '成员工作台';
@@ -9445,7 +9445,7 @@ const StudioPage: React.FC = () => {
         trimOptional(workbenchPublishedService?.serviceId) ||
         trimOptional(workbenchStudioMember?.publishedServiceId) ||
         trimOptional(workbenchStudioMemberSummary?.publishedServiceId) ||
-        'No bound service'
+        '暂无绑定服务'
       : '';
   const studioContextMetaParts = [
     studioContextDescriptor,

--- a/apps/aevatar-console-web/src/pages/teams/new.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/new.test.tsx
@@ -53,13 +53,13 @@ describe('TeamCreatePage', () => {
   it('renders the simplified Team create page', async () => {
     renderWithQueryClient(React.createElement(TeamCreatePage));
 
-    expect(await screen.findByText('Aevatar / Teams')).toBeTruthy();
-    expect(screen.getByRole('heading', { level: 2, name: 'Create Team' })).toBeTruthy();
+    expect(await screen.findByText('Aevatar / 团队')).toBeTruthy();
+    expect(screen.getByRole('heading', { level: 2, name: '创建团队' })).toBeTruthy();
     expect(screen.getByText('团队信息')).toBeTruthy();
-    expect(screen.getByLabelText('Team name')).toBeTruthy();
-    expect(screen.getByLabelText('Team description')).toBeTruthy();
-    expect(screen.getAllByRole('button', { name: 'Create Team' }).length).toBeGreaterThan(0);
-    expect(screen.getByRole('button', { name: 'Back to My Teams' })).toBeTruthy();
+    expect(screen.getByLabelText('团队名称')).toBeTruthy();
+    expect(screen.getByLabelText('团队描述')).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: '创建团队' }).length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: '返回我的团队' })).toBeTruthy();
     expect(screen.queryByText('工作空间上下文')).toBeNull();
     expect(screen.queryByText('StudioTeam')).toBeNull();
     expect(screen.queryByRole('button', { name: 'Continue in Studio' })).toBeNull();
@@ -87,13 +87,13 @@ describe('TeamCreatePage', () => {
 
     const { queryClient } = renderWithQueryClient(React.createElement(TeamCreatePage));
 
-    fireEvent.change(await screen.findByLabelText('Team name'), {
+    fireEvent.change(await screen.findByLabelText('团队名称'), {
       target: { value: '订单助手团队' },
     });
-    fireEvent.change(screen.getByLabelText('Team description'), {
+    fireEvent.change(screen.getByLabelText('团队描述'), {
       target: { value: '处理订单异常' },
     });
-    fireEvent.click(screen.getAllByRole('button', { name: 'Create Team' })[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: '创建团队' })[0]);
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -117,7 +117,7 @@ describe('TeamCreatePage', () => {
     const params = new URLSearchParams(window.location.search);
     expect(params.get('scopeId')).toBeNull();
     expect(params.get('teamId')).toBeNull();
-    expect(message.success).toHaveBeenCalledWith('已创建 Team。');
+    expect(message.success).toHaveBeenCalledWith('已创建团队。');
   });
 
   it('ignores legacy scopeId=new links and creates under the authenticated scope', async () => {
@@ -145,17 +145,17 @@ describe('TeamCreatePage', () => {
 
     renderWithQueryClient(React.createElement(TeamCreatePage));
 
-    expect(await screen.findByLabelText('Team name')).toHaveValue('test');
+    expect(await screen.findByLabelText('团队名称')).toHaveValue('test');
     await waitFor(() => {
       expect(new URLSearchParams(window.location.search).get('scopeId')).toBe(
         'scope-a',
       );
     });
 
-    fireEvent.change(screen.getByLabelText('Team description'), {
+    fireEvent.change(screen.getByLabelText('团队描述'), {
       target: { value: 'test' },
     });
-    fireEvent.click(screen.getAllByRole('button', { name: 'Create Team' })[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: '创建团队' })[0]);
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(

--- a/apps/aevatar-console-web/src/pages/teams/new.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/new.tsx
@@ -141,7 +141,7 @@ const TeamCreatePage: React.FC = () => {
       await queryClient.invalidateQueries({
         queryKey: ['teams', 'roster', team.scopeId],
       });
-      void message.success('已创建 Team。');
+      void message.success('已创建团队。');
       history.push(
         buildTeamDetailHref({
           scopeId: team.scopeId,
@@ -152,7 +152,7 @@ const TeamCreatePage: React.FC = () => {
       const errorMessage =
         error instanceof Error && error.message.trim()
           ? error.message
-          : '创建 Team 失败。';
+          : '创建团队失败。';
       void message.error(errorMessage);
     } finally {
       setIsCreatingTeam(false);
@@ -160,7 +160,7 @@ const TeamCreatePage: React.FC = () => {
   };
   return (
     <ConsoleMenuPageShell
-      breadcrumb="Aevatar / Teams"
+      breadcrumb="Aevatar / 团队"
       extra={
         <Space wrap>
           <Button
@@ -169,17 +169,17 @@ const TeamCreatePage: React.FC = () => {
             onClick={() => void handleCreateTeam()}
             style={primaryActionButtonStyle}
           >
-            Create Team
+            创建团队
           </Button>
         </Space>
       }
-      title="Create Team"
+      title="创建团队"
     >
       {authSessionIssue ? (
         <Alert
           description={
             resolvedScope?.scopeId
-              ? `${authSessionIssue} 已使用本地登录信息继续创建 Team。`
+              ? `${authSessionIssue} 已使用本地登录信息继续创建团队。`
               : authSessionIssue
           }
           showIcon
@@ -216,19 +216,19 @@ const TeamCreatePage: React.FC = () => {
           }}
         >
           <div style={{ display: 'grid', gap: 8 }}>
-            <Typography.Text strong>Team name</Typography.Text>
+            <Typography.Text strong>团队名称</Typography.Text>
             <Input
-              aria-label="Team name"
+              aria-label="团队名称"
               placeholder="例如：订单助手团队"
               value={teamName}
               onChange={(event) => setTeamName(event.target.value)}
             />
           </div>
           <div style={{ display: 'grid', gap: 8 }}>
-            <Typography.Text strong>Description</Typography.Text>
+            <Typography.Text strong>团队描述</Typography.Text>
             <Input
-              aria-label="Team description"
-              placeholder="这个 Team 负责什么"
+              aria-label="团队描述"
+              placeholder="这个团队负责什么"
               value={teamDescription}
               onChange={(event) => setTeamDescription(event.target.value)}
             />
@@ -241,10 +241,10 @@ const TeamCreatePage: React.FC = () => {
               onClick={() => void handleCreateTeam()}
               style={primaryActionButtonStyle}
             >
-              Create Team
+              创建团队
             </Button>
             <Button onClick={() => history.push(buildTeamsHref())}>
-              Back to My Teams
+              返回我的团队
             </Button>
           </Space>
         </div>


### PR DESCRIPTION
## 问题与根因
- Create Team 页面仍显示英文标题、字段和按钮，团队创建入口对中文用户不一致。
- Studio 在窄屏下仍保持左右双栏，成员 rail 挤占主工作台，Build/Bind/Invoke 内容被压成窄条。
- Studio Bind 未发布契约状态仍使用英文行动指引，用户在发布/绑定当前 workflow 版本时不够清晰。
- 根因均为前端展示与布局问题，不涉及 API shape、backend、proto 或 shared contract。

## 修复方案
- 本地化 Create Team 页面标题、breadcrumb、字段、按钮、placeholder、成功/失败提示。
- 在 `StudioShell` 中使用既有 AntD breakpoint；小屏时将 member rail 堆叠到主工作台上方，并保持桌面布局不变。
- 本地化 workflow pending bind 空状态、发布面板参数标签、绑定按钮和默认 accepted notice。
- 更新对应 focused tests 锁定这些用户可见行为。

## 影响路径
- apps/aevatar-console-web/src/pages/teams/new.tsx
- apps/aevatar-console-web/src/pages/teams/new.test.tsx
- apps/aevatar-console-web/src/pages/studio/components/StudioShell.tsx
- apps/aevatar-console-web/src/pages/studio/components/StudioShell.test.tsx
- apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx
- apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx
- apps/aevatar-console-web/src/pages/studio/index.tsx

## Browser 证据
- Cycle 1: 复验 `/teams/new?scopeId=...`，DOM/截图显示「Aevatar / 团队」「创建团队」「团队名称」「团队描述」「返回我的团队」，旧 `Create Team`、`Team name`、`Back to My Teams` 不再出现。
- Cycle 2: 复验 `/studio?...step=build...` 小屏布局，root flex direction 为 `column`，rail/main 都是完整 333px 宽；`Workflow 构建`、lifecycle stepper、Build actions 不再被挤成竖条。
- Cycle 3: 复验 `/studio?...step=bind...`，DOM/截图显示「暂无绑定服务」「确认当前成员的已发布契约」「draft 还没有已发布契约」「发布当前成员」「实现类型」「工作区 ID」「绑定当前版本」，旧英文 bind 文案不再出现。
- Console: 仅观察到 2026-05-27 的历史 `@/shared/i18n/localization` 编译错误记录；当前 reload 后页面正常渲染，未观察到本轮新增 runtime/console error。

## 验证命令与结果
- `cd apps/aevatar-console-web && ./node_modules/.bin/jest src/pages/teams/new.test.tsx --runInBand` -> passed, 4/4 tests.
- `cd apps/aevatar-console-web && ./node_modules/.bin/jest src/pages/studio/components/StudioShell.test.tsx --runInBand` -> passed, 5/5 tests.
- `cd apps/aevatar-console-web && ./node_modules/.bin/jest src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx --runInBand` -> passed, 10/10 tests.
- `cd apps/aevatar-console-web && ./node_modules/.bin/jest src/pages/teams/new.test.tsx src/pages/studio/components/StudioShell.test.tsx src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx --runInBand` -> passed, 19/19 tests.
- `cd apps/aevatar-console-web && ./node_modules/.bin/tsc --noEmit` -> passed.
- `git diff --check -- apps/aevatar-console-web` -> passed.
- `bash tools/ci/test_stability_guards.sh` -> passed.

## Scope check
- All changed files are under `apps/aevatar-console-web/`.
- 未修改 backend。
- 未修改 proto。
- 未修改 docs/tools。