### PR TITLE
Localize account and workflow detail copy

### DIFF
--- a/apps/aevatar-console-web/src/pages/settings/accountContent.tsx
+++ b/apps/aevatar-console-web/src/pages/settings/accountContent.tsx
@@ -20,7 +20,7 @@ import { buildSettingsPanelStyle, SummaryField, SummaryMetric } from "./shared";
 
 function formatSessionExpiry(value?: number): string {
   if (!value) {
-    return "Unavailable";
+    return "不可用";
   }
 
   return new Intl.DateTimeFormat("zh-CN", {
@@ -31,12 +31,12 @@ function formatSessionExpiry(value?: number): string {
 
 function formatIsoSessionExpiry(value?: string | null): string {
   if (!value) {
-    return "Unavailable";
+    return "不可用";
   }
 
   const parsed = Date.parse(value);
   if (Number.isNaN(parsed)) {
-    return "Unavailable";
+    return "不可用";
   }
 
   return formatSessionExpiry(parsed);
@@ -68,28 +68,28 @@ const AccountSettingsContent: React.FC<AccountSettingsContentProps> = ({
       authSession?.user.name ||
       authSession?.user.email ||
       authSession?.user.sub ||
-      "No active session",
+      "没有活动会话",
     [authSession, backendProfile],
   );
   const accountSecondaryText = useMemo(() => {
     if (!authenticated) {
-      return "This browser does not have a restorable sign-in session.";
+      return "此浏览器没有可恢复的登录会话。";
     }
 
     if (backendProfile?.email || backendProfile?.subject) {
       return backendProfile.email || backendProfile.subject;
     }
 
-    return authSession?.user.email || authSession?.user.sub || "Unavailable";
+    return authSession?.user.email || authSession?.user.sub || "不可用";
   }, [authSession, authenticated, backendProfile]);
   const rolesLabel =
     (backendProfile?.roles && backendProfile.roles.length > 0
       ? backendProfile.roles.join(", ")
-      : authSession?.user.roles?.join(", ")) || "No roles";
+      : authSession?.user.roles?.join(", ")) || "无角色";
   const groupsLabel =
     (backendProfile?.groups && backendProfile.groups.length > 0
       ? backendProfile.groups.join(", ")
-      : authSession?.user.groups?.join(", ")) || "No groups";
+      : authSession?.user.groups?.join(", ")) || "无分组";
   const userId = backendProfile?.subject || authSession?.user.sub || "";
   const picture = backendProfile?.picture || authSession?.user.picture;
   const emailVerified =
@@ -106,12 +106,12 @@ const AccountSettingsContent: React.FC<AccountSettingsContentProps> = ({
         extra={
           authenticated && showInlineSignOut ? (
             <Button danger icon={<LogoutOutlined />} onClick={handleSignOut}>
-              Sign out
+              退出登录
             </Button>
           ) : null
         }
         style={settingsPanelStyle}
-        title="Profile"
+        title="个人资料"
       >
         {authenticated ? (
           <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
@@ -136,22 +136,22 @@ const AccountSettingsContent: React.FC<AccountSettingsContentProps> = ({
 
             <div style={summaryMetricGridStyle}>
               <SummaryMetric
-                label="Session"
+                label="会话"
                 tone={backendSession?.authenticated || authSession ? "success" : "warning"}
-                value={backendSession?.authenticated || authSession ? "Active" : "Browser only"}
+                value={backendSession?.authenticated || authSession ? "已激活" : "仅浏览器"}
               />
               <SummaryMetric
-                label="Email"
+                label="邮箱"
                 tone={emailVerified ? "success" : "warning"}
                 value={
-                  emailVerified ? "Verified" : "Needs review"
+                  emailVerified ? "已验证" : "待确认"
                 }
               />
             </div>
 
             <div style={summaryFieldGridStyle}>
               <SummaryField
-                label="User ID"
+                label="用户 ID"
                 value={
                   <AevatarCompactText
                     copyable
@@ -163,29 +163,29 @@ const AccountSettingsContent: React.FC<AccountSettingsContentProps> = ({
                   />
                 }
               />
-              <SummaryField label="Roles" value={rolesLabel} />
-              <SummaryField label="Groups" value={groupsLabel} />
+              <SummaryField label="角色" value={rolesLabel} />
+              <SummaryField label="分组" value={groupsLabel} />
             </div>
           </div>
         ) : (
           <Empty
-            description="This browser does not have a restorable sign-in session."
+            description="此浏览器没有可恢复的登录会话。"
             image={Empty.PRESENTED_IMAGE_SIMPLE}
           >
             <Button
               type="primary"
               onClick={() => window.location.replace("/login")}
             >
-              Sign in
+              登录
             </Button>
           </Empty>
         )}
       </AevatarPanel>
 
-      <AevatarPanel style={settingsPanelStyle} title="Authentication">
+      <AevatarPanel style={settingsPanelStyle} title="认证信息">
         <div style={summaryFieldGridStyle}>
           <SummaryField
-            label="Session expires"
+            label="会话过期时间"
             value={
               backendSession?.expiresAtUtc
                 ? formatIsoSessionExpiry(backendSession.expiresAtUtc)
@@ -194,15 +194,15 @@ const AccountSettingsContent: React.FC<AccountSettingsContentProps> = ({
           />
           <SummaryField
             label="Provider"
-            value={authMeQuery.data?.providerDisplayName || "Unavailable"}
+            value={authMeQuery.data?.providerDisplayName || "不可用"}
           />
           <SummaryField
             label="Scope"
-            value={authMeQuery.data?.scopeId || authSession?.tokens.scope || "Unavailable"}
+            value={authMeQuery.data?.scopeId || authSession?.tokens.scope || "不可用"}
           />
           <SummaryField
-            label="Local refresh token"
-            value={authSession?.tokens.refreshToken ? "Available" : "Unavailable"}
+            label="本地 refresh token"
+            value={authSession?.tokens.refreshToken ? "可用" : "不可用"}
           />
         </div>
       </AevatarPanel>

--- a/apps/aevatar-console-web/src/pages/settings/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/settings/index.test.tsx
@@ -193,9 +193,10 @@ describe("SettingsPage", () => {
       expect(window.location.search).toBe("?section=account");
     });
     expect(screen.queryByRole("button", { name: "Save config" })).toBeNull();
-    expect(await screen.findByText("Profile")).toBeTruthy();
+    expect(await screen.findByText("个人资料")).toBeTruthy();
     expect(screen.getByText("Ada Lovelace")).toBeTruthy();
-    expect(screen.getByText("Authentication")).toBeTruthy();
+    expect(screen.getByText("认证信息")).toBeTruthy();
+    expect(screen.getByText("已验证")).toBeTruthy();
   });
 
   it("shows gateway models from backend model groups", async () => {

--- a/apps/aevatar-console-web/src/pages/workflows/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflows/index.test.tsx
@@ -53,7 +53,6 @@ jest.mock("@/shared/api/runtimeCatalogApi", () => ({
             maxTokens: 0,
             maxToolRounds: 0,
             maxHistoryMessages: 0,
-            streamBufferCapacity: 0,
             eventModules: [],
             eventRoutes: "",
             connectors: ["memory"],
@@ -92,7 +91,7 @@ describe("WorkflowsPage", () => {
       );
     });
 
-    expect(await screen.findByText("Definition summary")).toBeTruthy();
+    expect(await screen.findByText("定义摘要")).toBeTruthy();
     expect(window.location.search).toContain("workflow=demo_flow");
   });
 
@@ -111,36 +110,36 @@ describe("WorkflowsPage", () => {
 
     await waitFor(() => {
       expect(window.location.search).toBe("");
-      expect(screen.queryByText("Definition summary")).toBeNull();
+      expect(screen.queryByText("定义摘要")).toBeNull();
     });
   });
 
   it("renders a compact workflow filter bar with runtime-focused controls", async () => {
     renderWithQueryClient(React.createElement(WorkflowsPage));
 
-    expect(await screen.findByText("Find workflows")).toBeTruthy();
-    expect(screen.getByPlaceholderText("Search workflow, description, group, or primitive")).toBeTruthy();
-    expect(screen.getByText("Workflow catalog")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Reset" })).toBeTruthy();
+    expect(await screen.findByText("查找 Workflow")).toBeTruthy();
+    expect(screen.getByPlaceholderText("搜索 Workflow、描述、分组或 primitive")).toBeTruthy();
+    expect(screen.getByText("Workflow 目录")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "清除筛选" })).toBeTruthy();
   });
 
   it("renders the catalog as a table with inspect and run actions", async () => {
     renderWithQueryClient(React.createElement(WorkflowsPage));
 
-    expect(await screen.findByText("Closed-world ready")).toBeTruthy();
-    expect(screen.getByRole("columnheader", { name: "Collection" })).toBeTruthy();
-    expect(screen.getByRole("columnheader", { name: "Runtime fit" })).toBeTruthy();
+    expect(await screen.findByText("闭环就绪")).toBeTruthy();
+    expect(screen.getByRole("columnheader", { name: "集合" })).toBeTruthy();
+    expect(screen.getByRole("columnheader", { name: "运行适配" })).toBeTruthy();
     expect(screen.getByRole("columnheader", { name: "Primitives" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Inspect" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Run" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "查看" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "运行" })).toBeTruthy();
   });
 
   it("opens the definition inspector when the inspect action is clicked", async () => {
     renderWithQueryClient(React.createElement(WorkflowsPage));
 
-    fireEvent.click(await screen.findByRole("button", { name: "Inspect" }));
+    fireEvent.click(await screen.findByRole("button", { name: "查看" }));
 
-    expect(await screen.findByText("Definition summary")).toBeTruthy();
+    expect(await screen.findByText("定义摘要")).toBeTruthy();
   });
 
   it("opens the Studio workflow editor from the definition inspector", async () => {
@@ -148,10 +147,10 @@ describe("WorkflowsPage", () => {
 
     renderWithQueryClient(React.createElement(WorkflowsPage));
 
-    expect(await screen.findByText("Definition summary")).toBeTruthy();
+    expect(await screen.findByText("定义摘要")).toBeTruthy();
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Open workflow editor" }),
+      screen.getByRole("button", { name: "打开 Workflow 编辑器" }),
     );
 
     await waitFor(() => {

--- a/apps/aevatar-console-web/src/pages/workflows/index.tsx
+++ b/apps/aevatar-console-web/src/pages/workflows/index.tsx
@@ -103,8 +103,8 @@ function buildWorkflowSummary(workflow: WorkflowCatalogItem): string {
   }
 
   return workflow.requiresLlmProvider
-    ? "This workflow depends on an LLM provider before runtime handoff can start."
-    : "Closed-world definition ready for direct runtime invocation.";
+    ? "此 Workflow 需要 LLM provider 才能开始运行时移交。"
+    : "闭环定义已就绪，可直接运行。";
 }
 
 function formatListPreview(values: readonly string[], emptyLabel = "None"): string {
@@ -117,6 +117,16 @@ function formatListPreview(values: readonly string[], emptyLabel = "None"): stri
   }
 
   return `${values.slice(0, 3).join(", ")} +${values.length - 3}`;
+}
+
+function formatWorkflowLoadError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message.includes("streamBufferCapacity")
+      ? "Workflow 详情使用了旧版运行时字段，当前前端已按空值处理；请刷新后重试。"
+      : error.message;
+  }
+
+  return "加载 Workflow 详情失败。";
 }
 
 function buildLibraryMetrics(rows: readonly WorkflowLibraryRow[]) {
@@ -194,7 +204,7 @@ const WorkflowCatalogStatusTags: React.FC<{
   <Space size={[8, 8]} wrap>
     <AevatarStatusTag
       domain="governance"
-      label={workflow.requiresLlmProvider ? "LLM required" : "Closed-world ready"}
+      label={workflow.requiresLlmProvider ? "需要 LLM" : "闭环就绪"}
       status={workflow.requiresLlmProvider ? "active" : "ready"}
     />
     <Tag
@@ -291,7 +301,7 @@ const WorkflowsPage: React.FC = () => {
         },
       },
       {
-        title: "Collection",
+        title: "集合",
         key: "collection",
         width: "18%",
         render: (_value, workflow) => (
@@ -302,7 +312,7 @@ const WorkflowsPage: React.FC = () => {
         ),
       },
       {
-        title: "Runtime fit",
+        title: "运行适配",
         key: "runtime-fit",
         width: "18%",
         render: (_value, workflow) => <WorkflowCatalogStatusTags workflow={workflow} />,
@@ -315,13 +325,13 @@ const WorkflowsPage: React.FC = () => {
           <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
             <Typography.Text strong>{workflow.primitives.length}</Typography.Text>
             <Typography.Text type="secondary">
-              {formatListPreview(workflow.primitives, "No primitive data")}
+              {formatListPreview(workflow.primitives, "暂无 primitive 数据")}
             </Typography.Text>
           </div>
         ),
       },
       {
-        title: "Actions",
+        title: "操作",
         key: "actions",
         width: 240,
         render: (_value, workflow) => (
@@ -333,7 +343,7 @@ const WorkflowsPage: React.FC = () => {
                 setSelectedWorkflow(workflow.name);
               }}
             >
-              Inspect
+              查看
             </Button>
             <Button
               icon={<PlayCircleOutlined />}
@@ -348,7 +358,7 @@ const WorkflowsPage: React.FC = () => {
               style={workflowRunTextButtonStyle}
               type="text"
             >
-              Run
+              运行
             </Button>
           </Space>
         ),
@@ -360,7 +370,7 @@ const WorkflowsPage: React.FC = () => {
   const roleColumns = useMemo<ColumnsType<WorkflowCatalogRole>>(
     () => [
       {
-        title: "Role",
+        title: "角色",
         dataIndex: "name",
         key: "role",
         width: "28%",
@@ -377,27 +387,27 @@ const WorkflowsPage: React.FC = () => {
         width: "24%",
         render: (_value, role) => (
           <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-            <Typography.Text>{role.provider || "No provider"}</Typography.Text>
-            <Typography.Text type="secondary">{role.model || "No model"}</Typography.Text>
+            <Typography.Text>{role.provider || "无 provider"}</Typography.Text>
+            <Typography.Text type="secondary">{role.model || "无 model"}</Typography.Text>
           </div>
         ),
       },
       {
-        title: "Connectors",
+        title: "连接器",
         key: "connectors",
         width: "24%",
         render: (_value, role) => (
           <Typography.Text type="secondary">
-            {formatListPreview(role.connectors)}
+            {formatListPreview(role.connectors, "无连接器")}
           </Typography.Text>
         ),
       },
       {
-        title: "Runtime limits",
+        title: "运行限制",
         key: "limits",
         render: (_value, role) => (
           <Typography.Text type="secondary">
-            {`Tool rounds ${role.maxToolRounds ?? "n/a"} · History ${
+            {`工具轮次 ${role.maxToolRounds ?? "n/a"} · 历史消息 ${
               role.maxHistoryMessages ?? "n/a"
             }`}
           </Typography.Text>
@@ -410,7 +420,7 @@ const WorkflowsPage: React.FC = () => {
   const stepColumns = useMemo<ColumnsType<WorkflowStepRow>>(
     () => [
       {
-        title: "Step",
+        title: "步骤",
         dataIndex: "id",
         key: "step",
         width: "20%",
@@ -425,7 +435,7 @@ const WorkflowsPage: React.FC = () => {
         ),
       },
       {
-        title: "Type",
+        title: "类型",
         dataIndex: "type",
         key: "type",
         width: "16%",
@@ -436,7 +446,7 @@ const WorkflowsPage: React.FC = () => {
         ),
       },
       {
-        title: "Target role",
+        title: "目标角色",
         dataIndex: "targetRole",
         key: "targetRole",
         width: "16%",
@@ -445,25 +455,25 @@ const WorkflowsPage: React.FC = () => {
         ),
       },
       {
-        title: "Flow",
+        title: "流程",
         key: "flow",
         width: "24%",
         render: (_value, step) => (
           <Typography.Text type="secondary">
             {step.next
-              ? `Next: ${step.next}`
+              ? `下一步：${step.next}`
               : step.branchCount > 0
-                ? `${step.branchCount} branch routes`
-                : "No explicit next step"}
+                ? `${step.branchCount} 条分支路由`
+                : "没有显式下一步"}
           </Typography.Text>
         ),
       },
       {
-        title: "Parameters",
+        title: "参数",
         key: "parameters",
         render: (_value, step) => (
           <Typography.Text type="secondary">
-            {step.parameterCount} params · {step.childCount} child steps
+            {step.parameterCount} 个参数 · {step.childCount} 个子步骤
           </Typography.Text>
         ),
       },
@@ -474,8 +484,8 @@ const WorkflowsPage: React.FC = () => {
   return (
     <AevatarPageShell
       layoutMode="document"
-      title="Workflow Library"
-      titleHelp="Browse runtime-exposed workflow definitions, inspect how they are wired, then jump into run or editor from the same catalog."
+      title="Workflow 库"
+      titleHelp="浏览运行时暴露的 Workflow 定义，查看连接方式，再从同一个目录进入运行或编辑。"
     >
       <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
         {catalogQuery.error ? (
@@ -497,23 +507,23 @@ const WorkflowsPage: React.FC = () => {
             gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
           }}
         >
-          <WorkflowSummaryMetric label="Workflows in library" value={metrics.workflows} />
-          <WorkflowSummaryMetric label="Groups" value={metrics.groups} />
-          <WorkflowSummaryMetric label="LLM required" value={metrics.llmRequired} />
-          <WorkflowSummaryMetric label="Your workflows" value={metrics.yourWorkflows} />
+          <WorkflowSummaryMetric label="库内 Workflow" value={metrics.workflows} />
+          <WorkflowSummaryMetric label="分组" value={metrics.groups} />
+          <WorkflowSummaryMetric label="需要 LLM" value={metrics.llmRequired} />
+          <WorkflowSummaryMetric label="你的 Workflow" value={metrics.yourWorkflows} />
         </div>
 
         <AevatarPanel
-          description="The runtime catalog is already loaded. Filters apply immediately so you can stay focused on selecting a runnable definition."
+          description="运行时目录已加载。筛选会立即生效，方便你专注选择可运行的定义。"
           extra={
             <Button
               onClick={() => setFilters(defaultWorkflowLibraryFilter)}
               type="default"
             >
-              Reset
+              清除筛选
             </Button>
           }
-          title="Find workflows"
+          title="查找 Workflow"
         >
           <div
             style={{
@@ -529,7 +539,7 @@ const WorkflowsPage: React.FC = () => {
                   keyword: event.target.value,
                 }))
               }
-              placeholder="Search workflow, description, group, or primitive"
+              placeholder="搜索 Workflow、描述、分组或 primitive"
               value={filters.keyword}
             />
             <Select
@@ -542,7 +552,7 @@ const WorkflowsPage: React.FC = () => {
                 }))
               }
               options={groupOptions}
-              placeholder="Groups"
+              placeholder="分组"
               value={filters.groups}
             />
             <Select
@@ -555,7 +565,7 @@ const WorkflowsPage: React.FC = () => {
                 }))
               }
               options={sourceOptions}
-              placeholder="Sources"
+              placeholder="来源"
               value={filters.sources}
             />
             <Select
@@ -566,9 +576,9 @@ const WorkflowsPage: React.FC = () => {
                 }))
               }
               options={[
-                { label: "All workflows", value: "all" },
-                { label: "LLM required", value: "required" },
-                { label: "Closed-world ready", value: "optional" },
+                { label: "全部 Workflow", value: "all" },
+                { label: "需要 LLM", value: "required" },
+                { label: "闭环就绪", value: "optional" },
               ]}
               value={filters.llmRequirement}
             />
@@ -576,14 +586,14 @@ const WorkflowsPage: React.FC = () => {
         </AevatarPanel>
 
         <AevatarPanel
-          description="This page is the runtime catalog, not the draft workspace. Stay here to choose a definition, then inspect, run, or open the editor."
-          title="Workflow catalog"
+          description="这是运行时目录，不是草稿工作区。先在这里选择定义，再查看、运行或打开编辑器。"
+          title="Workflow 目录"
         >
           {catalogQuery.isLoading ? (
-            <Typography.Text type="secondary">Loading workflow catalog…</Typography.Text>
+            <Typography.Text type="secondary">正在加载 Workflow 目录...</Typography.Text>
           ) : filteredRows.length === 0 ? (
             <Empty
-              description="No workflows matched the current filters."
+              description="没有 Workflow 匹配当前筛选。"
               image={Empty.PRESENTED_IMAGE_SIMPLE}
             />
           ) : (
@@ -620,7 +630,7 @@ const WorkflowsPage: React.FC = () => {
                   )
                 }
               >
-                Open workflow editor
+                打开 Workflow 编辑器
               </Button>
               <Button
                 icon={<PlayCircleOutlined />}
@@ -634,43 +644,43 @@ const WorkflowsPage: React.FC = () => {
                 style={workflowRunTextButtonStyle}
                 type="text"
               >
-                Run workflow
+                运行 Workflow
               </Button>
             </Space>
           ) : null
         }
         onClose={() => setSelectedWorkflow("")}
         open={Boolean(selectedWorkflow)}
-        subtitle="Runtime workflow detail"
+        subtitle="运行时 Workflow 详情"
         title={selectedWorkflowDetail?.catalog.name || selectedWorkflow || "Workflow"}
         width={920}
       >
         {!selectedWorkflow ? null : selectedWorkflowQuery.isLoading ? (
-          <Typography.Text type="secondary">Loading workflow detail…</Typography.Text>
+          <Typography.Text type="secondary">正在加载 Workflow 详情...</Typography.Text>
         ) : selectedWorkflowQuery.error ? (
           <Alert
             showIcon
             title={
               selectedWorkflowQuery.error instanceof Error
-                ? selectedWorkflowQuery.error.message
-                : "Failed to load workflow detail."
+                ? formatWorkflowLoadError(selectedWorkflowQuery.error)
+                : "加载 Workflow 详情失败。"
             }
             type="error"
           />
         ) : !selectedWorkflowDetail ? (
-          <AevatarInspectorEmpty description="Choose a workflow to inspect its runtime wiring, role model, and source YAML." />
+          <AevatarInspectorEmpty description="选择一个 Workflow 查看运行时连线、角色模型和源 YAML。" />
         ) : (
           <Tabs
             defaultActiveKey="overview"
             items={[
               {
                 key: "overview",
-                label: "Overview",
+                label: "概览",
                 children: (
                   <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
                     <AevatarPanel
-                      description="Check the runtime fit, role count, step count, and linked connectors before you decide to run or edit this definition."
-                      title="Definition summary"
+                      description="运行或编辑定义前，先确认运行适配、角色数量、步骤数量和连接器。"
+                      title="定义摘要"
                     >
                       <div
                         style={{
@@ -680,44 +690,44 @@ const WorkflowsPage: React.FC = () => {
                         }}
                       >
                         <WorkflowField
-                          label="Collection"
+                          label="集合"
                           value={selectedWorkflowDetail.catalog.groupLabel}
                         />
                         <WorkflowField
-                          label="Source"
+                          label="来源"
                           value={selectedWorkflowDetail.catalog.sourceLabel}
                         />
                         <WorkflowField
-                          label="Closed-world mode"
+                          label="闭环模式"
                           value={
                             selectedWorkflowDetail.definition.closedWorldMode
-                              ? "Enabled"
-                              : "Disabled"
+                              ? "已启用"
+                              : "已禁用"
                           }
                         />
                         <WorkflowField
-                          label="Requires LLM provider"
+                          label="需要 LLM provider"
                           value={
                             selectedWorkflowDetail.catalog.requiresLlmProvider
-                              ? "Yes"
-                              : "No"
+                              ? "是"
+                              : "否"
                           }
                         />
                         <WorkflowField
-                          label="Roles"
+                          label="角色"
                           value={selectedWorkflowDetail.definition.roles.length}
                         />
                         <WorkflowField
-                          label="Steps"
+                          label="步骤"
                           value={selectedWorkflowDetail.definition.steps.length}
                         />
                         <WorkflowField
-                          label="Topology edges"
+                          label="拓扑边"
                           value={selectedWorkflowDetail.edges.length}
                         />
                         <WorkflowField
-                          label="Connectors"
-                          value={formatListPreview(connectorSummary)}
+                          label="连接器"
+                          value={formatListPreview(connectorSummary, "无连接器")}
                         />
                       </div>
                       <div
@@ -733,11 +743,11 @@ const WorkflowsPage: React.FC = () => {
                         }}
                       >
                         <Typography.Text style={summaryFieldLabelStyle}>
-                          Description
+                          描述
                         </Typography.Text>
                         <Typography.Text>
                           {selectedWorkflowDetail.catalog.description ||
-                            "No description provided."}
+                            "暂无描述。"}
                         </Typography.Text>
                       </div>
                       <div
@@ -768,11 +778,11 @@ const WorkflowsPage: React.FC = () => {
               },
               {
                 key: "roles",
-                label: `Roles (${selectedWorkflowDetail.definition.roles.length})`,
+                label: `角色 (${selectedWorkflowDetail.definition.roles.length})`,
                 children: (
                   <AevatarPanel
-                    description="These are the runtime roles the workflow definition declares, including provider/model hints and attached connectors."
-                    title="Role model"
+                    description="这些是 Workflow 定义声明的运行时角色，包括 provider/model 提示和已挂载连接器。"
+                    title="角色模型"
                   >
                     <Table<WorkflowCatalogRole>
                       columns={roleColumns}
@@ -786,11 +796,11 @@ const WorkflowsPage: React.FC = () => {
               },
               {
                 key: "steps",
-                label: `Steps (${stepRows.length})`,
+                label: `步骤 (${stepRows.length})`,
                 children: (
                   <AevatarPanel
-                    description="Use this view to understand the execution path before opening the full editor."
-                    title="Execution steps"
+                    description="打开完整编辑器前，可先在这里理解执行路径。"
+                    title="执行步骤"
                   >
                     <Table<WorkflowStepRow>
                       columns={stepColumns}
@@ -807,8 +817,8 @@ const WorkflowsPage: React.FC = () => {
                 label: "YAML",
                 children: (
                   <AevatarPanel
-                    description="Keep source close by for inspection, but off the main stage so the library stays scannable."
-                    title="Definition source"
+                    description="源码保留在独立视图里，方便检查，同时不打断目录浏览。"
+                    title="定义源码"
                   >
                     <pre
                       style={{

--- a/apps/aevatar-console-web/src/shared/api/__tests__/runtimeDecoders.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/__tests__/runtimeDecoders.test.ts
@@ -1,4 +1,7 @@
-import { decodeWorkflowCapabilitiesResponse } from "../runtimeDecoders";
+import {
+  decodeWorkflowCapabilitiesResponse,
+  decodeWorkflowCatalogItemDetailResponse,
+} from "../runtimeDecoders";
 
 describe("decodeWorkflowCapabilitiesResponse", () => {
   it("decodes primitive capabilities without the removed closedWorldBlocked field", () => {
@@ -31,5 +34,52 @@ describe("decodeWorkflowCapabilitiesResponse", () => {
     expect(decoded.primitives).toHaveLength(1);
     expect(decoded.primitives[0].name).toBe("llm_call");
     expect(decoded.primitives[0]).not.toHaveProperty("closedWorldBlocked");
+  });
+});
+
+describe("decodeWorkflowCatalogItemDetailResponse", () => {
+  it("treats the retired streamBufferCapacity role field as null when omitted", () => {
+    const decoded = decodeWorkflowCatalogItemDetailResponse({
+      catalog: {
+        name: "direct",
+        description: "Direct chat workflow.",
+        category: "chat",
+        group: "starter",
+        groupLabel: "Starter Workflows",
+        sortOrder: 1,
+        source: "BuiltIn",
+        sourceLabel: "Built-in",
+        showInLibrary: true,
+        isPrimitiveExample: false,
+        requiresLlmProvider: true,
+        primitives: ["llm_call"],
+      },
+      yaml: "name: direct\n",
+      definition: {
+        name: "direct",
+        description: "Direct chat workflow.",
+        closedWorldMode: true,
+        roles: [
+          {
+            id: "assistant",
+            name: "Assistant",
+            systemPrompt: "Help the user.",
+            provider: "",
+            model: "",
+            temperature: null,
+            maxTokens: null,
+            maxToolRounds: null,
+            maxHistoryMessages: null,
+            eventModules: [],
+            eventRoutes: "",
+            connectors: [],
+          },
+        ],
+        steps: [],
+      },
+      edges: [],
+    });
+
+    expect(decoded.definition.roles[0].streamBufferCapacity).toBeNull();
   });
 });

--- a/apps/aevatar-console-web/src/shared/api/runtimeDecoders.ts
+++ b/apps/aevatar-console-web/src/shared/api/runtimeDecoders.ts
@@ -111,7 +111,7 @@ function decodeWorkflowCatalogRole(
       `${label}.maxHistoryMessages`
     ),
     streamBufferCapacity: expectNullableNumber(
-      record.streamBufferCapacity,
+      record.streamBufferCapacity ?? null,
       `${label}.streamBufferCapacity`
     ),
     eventModules: expectStringArray(
@@ -414,7 +414,7 @@ function decodeWorkflowAuthoringRole(
       `${label}.maxHistoryMessages`
     ),
     streamBufferCapacity: expectNullableNumber(
-      record.streamBufferCapacity,
+      record.streamBufferCapacity ?? null,
       `${label}.streamBufferCapacity`
     ),
     eventModules: expectStringArray(

--- a/apps/aevatar-console-web/src/shared/ui/aevatarPageShells.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/aevatarPageShells.tsx
@@ -200,6 +200,29 @@ const titleRowStyle: React.CSSProperties = {
   maxWidth: '100%',
 };
 
+const contextDrawerHeaderStyle: React.CSSProperties = {
+  alignItems: 'flex-start',
+  flexWrap: 'wrap',
+  gap: 12,
+};
+
+const contextDrawerTitleStyle: React.CSSProperties = {
+  maxWidth: 'min(100%, 420px)',
+  minWidth: 0,
+};
+
+const contextDrawerTitleTextStyle: React.CSSProperties = {
+  display: 'block',
+  maxWidth: '100%',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+};
+
+const contextDrawerExtraStyle: React.CSSProperties = {
+  minWidth: 0,
+};
+
 export const AevatarHelpTooltip: React.FC<{
   content: React.ReactNode;
 }> = ({ content }) => {
@@ -485,18 +508,30 @@ export const AevatarContextDrawer: React.FC<AevatarContextDrawerProps> = ({
           ? 'large'
           : 'default'
       }
-      styles={{ body: aevatarDrawerBodyStyle }}
       title={
-        <Space orientation="vertical" size={2}>
-          <Typography.Text strong>{title}</Typography.Text>
+        <Space orientation="vertical" size={2} style={contextDrawerTitleStyle}>
+          <Typography.Text strong style={contextDrawerTitleTextStyle}>
+            {title}
+          </Typography.Text>
           {subtitle ? (
-            <Typography.Text style={{ color: token.colorTextSecondary }}>
+            <Typography.Text
+              style={{
+                ...contextDrawerTitleTextStyle,
+                color: token.colorTextSecondary,
+              }}
+            >
               {subtitle}
             </Typography.Text>
           ) : null}
         </Space>
       }
-      extra={extra}
+      extra={
+        extra ? <div style={contextDrawerExtraStyle}>{extra}</div> : undefined
+      }
+      styles={{
+        body: aevatarDrawerBodyStyle,
+        header: contextDrawerHeaderStyle,
+      }}
     >
       <div style={aevatarDrawerScrollStyle}>{children}</div>
     </Drawer>


### PR DESCRIPTION
## 问题与根因
- Settings Account 页核心资料/认证卡片仍显示英文文案，和控制台当前中文体验不一致。
- Workflow Library 的筛选、列表和操作区仍显示英文文案，用户在运行时目录里会看到中英混杂状态。
- Workflow detail drawer 一方面仍显示英文壳层/详情文案，另一方面前端 decoder 仍要求 retired `streamBufferCapacity` 字段存在，导致当前 backend 返回省略该字段时，抽屉直接展示 `WorkflowCatalogItemDetail.definition.roles[0].streamBufferCapacity must be a number.` 技术错误。

## 修复方案
- 将 Account content 的用户可见文案本地化为中文，并更新对应测试断言。
- 将 Workflow Library 的筛选、列表、操作、状态和详情抽屉文案本地化为中文。
- 对 retired `streamBufferCapacity` 缺省值按 `null` 归一，保留非数字值的 decoder 校验。
- 调整通用 `AevatarContextDrawer` header 的 wrap/ellipsis 行为，避免窄视口下标题被操作按钮挤成竖排。

## 影响路径
- `apps/aevatar-console-web/src/pages/settings/accountContent.tsx`
- `apps/aevatar-console-web/src/pages/settings/index.test.tsx`
- `apps/aevatar-console-web/src/pages/workflows/index.tsx`
- `apps/aevatar-console-web/src/pages/workflows/index.test.tsx`
- `apps/aevatar-console-web/src/shared/api/runtimeDecoders.ts`
- `apps/aevatar-console-web/src/shared/api/__tests__/runtimeDecoders.test.ts`
- `apps/aevatar-console-web/src/shared/ui/aevatarPageShells.tsx`

## Browser 证据
- Cycle 1: `http://localhost:5173/settings?section=account&scopeId=ccb108c4-dcb3-473a-a0f7-e9859bb2f2a0` reload 后，Account content 显示 `个人资料`、`认证信息`、`已验证` 等中文文案；目标英文文案不再出现。
- Cycle 2: `http://localhost:5173/runtime/workflows` reload 后，页面显示 `Workflow 库`、`查找 Workflow`、`Workflow 目录`、`查看`、`运行`，列表/筛选用户可见文案中文化。
- Cycle 3: `http://localhost:5173/runtime/workflows?workflow=direct` reload 后，详情抽屉显示 `运行时 Workflow 详情`、`定义摘要`、`打开 Workflow 编辑器`、`运行 Workflow`；`streamBufferCapacity` 技术错误消失；窄视口标题不再竖排。
- Console: browser logs only showed historical 2026-05-27 errors/warnings; no new current reload errors were introduced by this PR.

## 验证命令与结果
- `./node_modules/.bin/jest src/pages/settings/index.test.tsx src/pages/workflows/index.test.tsx src/shared/api/__tests__/runtimeDecoders.test.ts --runInBand` — passed, 14 tests.
- `./node_modules/.bin/tsc --noEmit` — passed.
- `git diff --check -- apps/aevatar-console-web` — passed.
- `bash tools/ci/test_stability_guards.sh` — passed.
- Browser reload/revisit verification — passed for Settings Account, Workflow Library, and Workflow detail drawer.

## Scope check
- All changed files are under `apps/aevatar-console-web/`.
- 未修改 backend。
- 未修改 proto。
- 未修改 docs/tools/scripts。
- 未修改 `.slnx`、`.csproj`、`.cs`、`.proto` 或 generated/shared contracts outside frontend.
