### PR TITLE
Clarify selected team member state

### DIFF
--- a/apps/aevatar-console-web/src/pages/teams/components/TeamTestPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/components/TeamTestPanel.tsx
@@ -45,6 +45,8 @@ export type TeamTestLastResult = {
 
 type TeamTestPanelProps = {
   readonly createMemberHref: string;
+  readonly currentMemberId?: string | null;
+  readonly currentMemberLabel?: string;
   readonly disabled?: boolean;
   readonly entryActionBusyMemberId?: string;
   readonly entryMemberId?: string | null;
@@ -141,6 +143,8 @@ function formatLifecycleLabelForTeamTest(label: string): string {
 
 const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
   createMemberHref,
+  currentMemberId,
+  currentMemberLabel,
   disabled = false,
   entryActionBusyMemberId = "",
   entryMemberId,
@@ -163,6 +167,10 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
 }) => {
   const { token } = theme.useToken();
   const normalizedEntryMemberId = entryMemberId?.trim() ?? "";
+  const normalizedCurrentMemberId = currentMemberId?.trim() ?? "";
+  const showCurrentMemberContext =
+    normalizedCurrentMemberId.length > 0 &&
+    normalizedCurrentMemberId !== normalizedEntryMemberId;
   const entryMember =
     rosterRows.find((row) => row.memberId === normalizedEntryMemberId) ?? null;
   const readyRows = rosterRows.filter((row) => row.canInvokeAsEntry);
@@ -475,6 +483,12 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
           <Typography.Text style={{ fontSize: 13 }} type="secondary">
             通过入口成员发起一次真实 Team 调用。
           </Typography.Text>
+          {showCurrentMemberContext ? (
+            <Typography.Text style={{ fontSize: 12 }} type="secondary">
+              当前页面选中的是 {currentMemberLabel || normalizedCurrentMemberId}
+              ，Team 测试仍通过入口成员发起。
+            </Typography.Text>
+          ) : null}
         </div>
         {lastResult ? (
           <div

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -1152,6 +1152,33 @@ describe("TeamDetailPage", () => {
     expect(screen.queryByRole("button", { name: "打开 Services" })).toBeNull();
   });
 
+  it("marks the route-selected member in the members tab", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1/t-alpha?memberId=member-team-alpha&tab=members",
+    );
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    expect(await screen.findByText("Team Alpha Operator")).toBeTruthy();
+    expect(screen.getByText("当前选中")).toBeTruthy();
+  });
+
+  it("shows the route-selected member in the overview status cards", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1/t-alpha?memberId=member-team-alpha",
+    );
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    expect(await screen.findByText("当前成员")).toBeTruthy();
+    expect(screen.getAllByText("member-team-alpha").length).toBeGreaterThan(0);
+    expect(screen.getByText("memberId · member-team-alpha")).toBeTruthy();
+  });
+
   it("shows the configured Team entry member without treating it as the service target", async () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
@@ -1261,6 +1288,24 @@ describe("TeamDetailPage", () => {
     });
     expect(await screen.findByText("Team response")).toBeTruthy();
     expect(await screen.findByText(/上次测试/)).toBeTruthy();
+  });
+
+  it("explains when Team Test uses the entry member instead of the selected member", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1/t-alpha?memberId=member-support&testTeam=1",
+    );
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    const dialog = await screen.findByTestId("team-test-modal-body");
+
+    expect(
+      within(dialog).getByText(
+        "当前页面选中的是 member-support，Team 测试仍通过入口成员发起。",
+      ),
+    ).toBeTruthy();
   });
 
   it("auto-opens Team Test from the Team Detail route intent", async () => {

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -629,6 +629,7 @@ const TeamDetailPage: React.FC = () => {
   const currentMemberId =
     trimText(preferredMemberSummary?.memberId) ||
     trimText(preferredMemberId);
+  const selectedRosterMemberId = currentMemberId;
   React.useEffect(() => {
     const canonicalMemberId = trimText(currentMemberId);
     if (
@@ -764,6 +765,7 @@ const TeamDetailPage: React.FC = () => {
         lifecycleLabel: formatStudioMemberLifecycleStage(member.lifecycleStage),
         lifecycleStyle: resolveStatusPillStyle(token, member.lifecycleStage),
         isEntryMember: trimText(member.memberId) === entryMemberId,
+        isSelectedMember: trimText(member.memberId) === selectedRosterMemberId,
         memberId: member.memberId,
         name: trimText(member.displayName) || member.memberId,
         serviceId: trimText(member.publishedServiceId) || "--",
@@ -771,6 +773,7 @@ const TeamDetailPage: React.FC = () => {
     [
       buildTeamReturnHref,
       entryMemberId,
+      selectedRosterMemberId,
       scopeId,
       selectedTeamId,
       teamMembersQuery.data?.members,
@@ -829,6 +832,17 @@ const TeamDetailPage: React.FC = () => {
   const currentRunFriendly = activeRunId
     ? formatFriendlyStatus(currentRunStatus)
     : "暂无可见运行";
+  const currentMemberLabel =
+    trimText(preferredMemberSummary?.displayName) ||
+    teamRosterRows.find((row) => row.memberId === currentMemberId)?.name ||
+    currentMemberId ||
+    "--";
+  const currentMemberCardCaption = currentMemberId
+    ? `memberId · ${compactOptionalId(currentMemberId)}`
+    : "当前还没有选中成员";
+  const currentMemberCardTooltip = currentMemberId
+    ? `memberId · ${currentMemberId}`
+    : "当前还没有选中成员";
   const currentServiceFriendly =
     currentServiceDisplayName !== "--"
       ? currentServiceDisplayName
@@ -1351,6 +1365,8 @@ const TeamDetailPage: React.FC = () => {
   const teamTestPanel = (
     <TeamTestPanel
       createMemberHref={createMemberHref}
+      currentMemberId={currentMemberId || null}
+      currentMemberLabel={currentMemberLabel}
       disabled={isTeamArchived}
       entryActionBusyMemberId={entryActionBusyMemberId}
       entryMemberId={teamSummaryQuery.data?.entryMemberId}
@@ -1382,6 +1398,9 @@ const TeamDetailPage: React.FC = () => {
         currentDeploymentPillText={currentDeploymentPillText}
         currentHeaderStatusFriendly={currentHeaderStatusFriendly}
         currentHeaderStatusStyle={resolveStatusPillStyle(token, currentHeaderStatus)}
+        currentMemberCardCaption={currentMemberCardCaption}
+        currentMemberCardTooltip={currentMemberCardTooltip}
+        currentMemberLabel={currentMemberLabel}
         currentRunCardCaption={currentRunCardCaption}
         currentRunCardTooltip={currentRunCardTooltip}
         currentRunFriendly={currentRunFriendly}

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
@@ -17,6 +17,7 @@ type TeamRosterMemberRow = {
   readonly description: string;
   readonly implementationKind: string;
   readonly isEntryMember?: boolean;
+  readonly isSelectedMember?: boolean;
   readonly key: string;
   readonly lifecycleLabel: string;
   readonly lifecycleStyle: React.CSSProperties;
@@ -162,11 +163,15 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                       alignItems: "center",
                       background: row.isEntryMember
                         ? "linear-gradient(90deg, var(--ant-colorPrimaryBg) 0%, var(--ant-colorBgContainer) 34%)"
+                        : row.isSelectedMember
+                          ? "var(--ant-colorFillQuaternary)"
                         : undefined,
                       borderTop:
                         index === 0 ? "none" : "1px solid var(--ant-colorBorderSecondary)",
                       boxShadow: row.isEntryMember
                         ? "inset 4px 0 0 var(--ant-colorPrimary)"
+                        : row.isSelectedMember
+                          ? "inset 4px 0 0 var(--ant-colorInfo)"
                         : undefined,
                       display: "grid",
                       gap: 16,
@@ -194,6 +199,17 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                               color: token.colorSuccess,
                             }}
                             text="入口成员"
+                          />
+                        ) : null}
+                        {row.isSelectedMember ? (
+                          <DetailPill
+                            compact
+                            style={{
+                              background: token.colorInfoBg,
+                              border: `1px solid ${token.colorInfoBorder}`,
+                              color: token.colorInfo,
+                            }}
+                            text="当前选中"
                           />
                         ) : null}
                       </div>

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx
@@ -29,6 +29,9 @@ type TeamOverviewTabProps = {
   readonly currentDeploymentPillText: string;
   readonly currentHeaderStatusFriendly: string;
   readonly currentHeaderStatusStyle: React.CSSProperties;
+  readonly currentMemberCardCaption: string;
+  readonly currentMemberCardTooltip: string;
+  readonly currentMemberLabel: string;
   readonly currentRunCardCaption: string;
   readonly currentRunCardTooltip: string;
   readonly currentRunFriendly: string;
@@ -67,6 +70,9 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
   currentDeploymentPillText,
   currentHeaderStatusFriendly,
   currentHeaderStatusStyle,
+  currentMemberCardCaption,
+  currentMemberCardTooltip,
+  currentMemberLabel,
   currentRunCardCaption,
   currentRunCardTooltip,
   currentRunFriendly,
@@ -129,6 +135,12 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
             gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
           }}
         >
+          <SignalCard
+            label="当前成员"
+            value={currentMemberLabel}
+            caption={currentMemberCardCaption}
+            captionTooltip={currentMemberCardTooltip}
+          />
           <SignalCard
             label="当前服务"
             value={currentServiceFriendly}


### PR DESCRIPTION
## 问题与根因
- Team detail URL 带 `memberId` 时，团队成员列表没有显示哪一行是当前 route-selected member，用户很容易以为路由状态没有生效。
- Team overview 的当前态势只显示当前服务；当选中的 member 还没有 published service 时，页面显示 `当前服务 --`，但没有同步显示当前 route member，容易被误读为没有选中成员。
- Team Test 弹窗会按正确语义通过 Team entry member 发起调用，但当当前页面选中的是另一个 member 时，弹窗缺少说明，容易被误解为 stale member state。

## 修复方案
- 在 Team members tab 中把 route-selected member 标记为 `当前选中`，并给选中行增加轻量视觉提示。
- 在 Team overview 当前态势中新增 `当前成员` 信号卡，展示当前 route member 与压缩 memberId；当前服务仍诚实显示服务状态，不伪造服务存在。
- 在 Team Test 面板中，当当前页面选中成员和入口成员不一致时，显示说明：Team 测试仍通过入口成员发起。
- 新增 focused regression tests 覆盖 members tab、overview status card 和 Team Test context hint。

## 影响路径
- `apps/aevatar-console-web/src/pages/teams/detail.tsx`
- `apps/aevatar-console-web/src/pages/teams/detail.test.tsx`
- `apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx`
- `apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx`
- `apps/aevatar-console-web/src/pages/teams/components/TeamTestPanel.tsx`

## Browser 证据
- Cycle 1: `http://localhost:5173/teams/ccb108c4-dcb3-473a-a0f7-e9859bb2f2a0/t-df2d3eca8f6a41b6974019fae7d55e0b?memberId=m-9975e1dcd98f44d8a7ec6ceafe7f486c&tab=members` reload 后，`draft` 行显示 `当前选中`，入口成员仍显示 `入口成员`。
- Cycle 2: `http://localhost:5173/teams/ccb108c4-dcb3-473a-a0f7-e9859bb2f2a0/t-df2d3eca8f6a41b6974019fae7d55e0b?memberId=m-9975e1dcd98f44d8a7ec6ceafe7f486c` reload 后，overview 当前态势显示 `当前成员 draft` 和压缩 `memberId`；`当前服务 --` 仍保持诚实状态。
- Cycle 3: `http://localhost:5173/teams/ccb108c4-dcb3-473a-a0f7-e9859bb2f2a0/t-df2d3eca8f6a41b6974019fae7d55e0b?memberId=m-9975e1dcd98f44d8a7ec6ceafe7f486c&testTeam=1` reload 后，Team Test 弹窗显示 `当前页面选中的是 draft，Team 测试仍通过入口成员发起。`，入口成员卡仍指向真实 entry member。
- Console: browser logs only showed historical 2026-05-27 errors/warnings; no new current reload errors were introduced by this PR.

## 验证命令与结果
- `./node_modules/.bin/jest src/pages/teams/detail.test.tsx --runInBand` — passed, 42 tests.
- `./node_modules/.bin/tsc --noEmit` — passed.
- `git diff --check -- apps/aevatar-console-web` — passed.
- `bash tools/ci/test_stability_guards.sh` — passed.
- Browser reload/revisit verification — passed for Team members tab, Team overview, and Team Test dialog.

## Scope check
- All changed files are under `apps/aevatar-console-web/`.
- 未修改 backend。
- 未修改 proto。
- 未修改 docs/tools/scripts。
- 未修改 `.slnx`、`.csproj`、`.cs`、`.proto` 或 generated/shared contracts outside frontend.
