### PR TITLE
Clarify team form copy

### DIFF
--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -1645,7 +1645,7 @@ describe("TeamDetailPage", () => {
         description: null,
       });
     });
-    expect(message.success).toHaveBeenCalledWith("Team updated.");
+    expect(message.success).toHaveBeenCalledWith("团队已更新。");
     await waitFor(() => {
       expect(studioApi.getTeam).toHaveBeenCalledTimes(2);
     });
@@ -1665,11 +1665,16 @@ describe("TeamDetailPage", () => {
       name: "Alpha Support Team",
     });
     fireEvent.click(screen.getByRole("button", { name: "编辑团队" }));
-    fireEvent.change(await screen.findByLabelText("编辑团队名称"), {
+    const nameInput = await screen.findByLabelText("编辑团队名称");
+    expect(screen.getByRole("button", { name: "取消" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+    expect(screen.getByRole("button", { name: "关闭" })).toBeTruthy();
+    fireEvent.change(nameInput, {
       target: { value: "   " },
     });
 
     expect(screen.getByRole("button", { name: "保存团队" })).toBeDisabled();
+    expect(screen.getByText("填写团队名称后即可保存。")).toBeTruthy();
     expect(studioApi.updateTeam).not.toHaveBeenCalled();
   });
 

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -1029,7 +1029,7 @@ const TeamDetailPage: React.FC = () => {
 
     const displayName = teamEditorName.trim();
     if (!displayName) {
-      void message.error("Team name is required.");
+      void message.error("请填写团队名称。");
       return;
     }
 
@@ -1041,11 +1041,11 @@ const TeamDetailPage: React.FC = () => {
         displayName,
         description: teamEditorDescription.trim() || null,
       });
-      void message.success("Team updated.");
+      void message.success("团队已更新。");
       setTeamEditorOpen(false);
       await refreshTeamAuthority();
     } catch (error) {
-      void message.error(describeError(error, "Team update failed."));
+      void message.error(describeError(error, "团队更新失败。"));
     } finally {
       setTeamEditorSaving(false);
     }
@@ -1508,6 +1508,9 @@ const TeamDetailPage: React.FC = () => {
         <div data-testid="team-test-modal-body">{teamTestPanel}</div>
       </Modal>
       <Modal
+        cancelText="取消"
+        cancelButtonProps={{ "aria-label": "取消" }}
+        closable={{ "aria-label": "关闭" }}
         confirmLoading={teamEditorSaving}
         okButtonProps={{ disabled: !teamEditorName.trim() }}
         okText="保存团队"
@@ -1539,6 +1542,11 @@ const TeamDetailPage: React.FC = () => {
           <Typography.Text type="secondary">
             这里更新的是 Team summary。即使团队已归档，仍然可以继续编辑和维护。
           </Typography.Text>
+          {!teamEditorName.trim() ? (
+            <Typography.Text type="secondary">
+              填写团队名称后即可保存。
+            </Typography.Text>
+          ) : null}
         </div>
       </Modal>
       <Modal

--- a/apps/aevatar-console-web/src/pages/teams/home.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.test.tsx
@@ -161,8 +161,8 @@ describe("TeamsHomePage", () => {
     expect(screen.getByText("Aevatar / Teams")).toBeTruthy();
     expect(screen.getByText("我的 AI 团队")).toBeTruthy();
     expect(screen.queryByText("当前工作空间")).toBeNull();
-    expect(screen.getByText("AI Team 总数")).toBeTruthy();
-    expect(screen.getByText("待处理 Team")).toBeTruthy();
+    expect(screen.getByText("AI 团队总数")).toBeTruthy();
+    expect(screen.getByText("待处理团队")).toBeTruthy();
     expect(screen.getByText("运行稳定")).toBeTruthy();
     expect(screen.getByText("团队列表")).toBeTruthy();
     expect(
@@ -471,7 +471,7 @@ describe("TeamsHomePage", () => {
     expect(scopeRuntimeApi.listServices).not.toHaveBeenCalled();
     expect(screen.queryByText("部分团队信号暂时不可见")).toBeNull();
     expect(screen.queryByText("团队列表暂时无法加载。")).toBeNull();
-    expect(screen.queryByText("AI Team 总数")).toBeNull();
+    expect(screen.queryByText("AI 团队总数")).toBeNull();
 
     await waitFor(() => {
       expect(new URLSearchParams(window.location.search).get("scopeId")).toBe("scope-a");

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -1151,8 +1151,8 @@ const TeamsHomePage: React.FC = () => {
                 gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
               }}
             >
-              <SummaryStatCard accent label="AI Team 总数" value={visibleTeamCount} />
-              <SummaryStatCard label="待处理 Team" value={actionableTeamCount} />
+              <SummaryStatCard accent label="AI 团队总数" value={visibleTeamCount} />
+              <SummaryStatCard label="待处理团队" value={actionableTeamCount} />
               <SummaryStatCard label="运行稳定" value={healthyTeamCount} />
             </div>
 

--- a/apps/aevatar-console-web/src/pages/teams/new.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/new.test.tsx
@@ -54,12 +54,13 @@ describe('TeamCreatePage', () => {
     renderWithQueryClient(React.createElement(TeamCreatePage));
 
     expect(await screen.findByText('Aevatar / Teams')).toBeTruthy();
-    expect(screen.getByRole('heading', { level: 2, name: 'Create Team' })).toBeTruthy();
+    expect(screen.getByRole('heading', { level: 2, name: '创建团队' })).toBeTruthy();
     expect(screen.getByText('团队信息')).toBeTruthy();
-    expect(screen.getByLabelText('Team name')).toBeTruthy();
-    expect(screen.getByLabelText('Team description')).toBeTruthy();
-    expect(screen.getAllByRole('button', { name: 'Create Team' }).length).toBeGreaterThan(0);
-    expect(screen.getByRole('button', { name: 'Back to My Teams' })).toBeTruthy();
+    expect(screen.getByLabelText('团队名称')).toBeTruthy();
+    expect(screen.getByLabelText('团队说明')).toBeTruthy();
+    expect(screen.getByText('填写团队名称后即可创建。')).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: '创建团队' }).length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: '返回团队列表' })).toBeTruthy();
     expect(screen.queryByText('工作空间上下文')).toBeNull();
     expect(screen.queryByText('StudioTeam')).toBeNull();
     expect(screen.queryByRole('button', { name: 'Continue in Studio' })).toBeNull();
@@ -87,13 +88,13 @@ describe('TeamCreatePage', () => {
 
     const { queryClient } = renderWithQueryClient(React.createElement(TeamCreatePage));
 
-    fireEvent.change(await screen.findByLabelText('Team name'), {
+    fireEvent.change(await screen.findByLabelText('团队名称'), {
       target: { value: '订单助手团队' },
     });
-    fireEvent.change(screen.getByLabelText('Team description'), {
+    fireEvent.change(screen.getByLabelText('团队说明'), {
       target: { value: '处理订单异常' },
     });
-    fireEvent.click(screen.getAllByRole('button', { name: 'Create Team' })[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: '创建团队' })[0]);
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -145,17 +146,17 @@ describe('TeamCreatePage', () => {
 
     renderWithQueryClient(React.createElement(TeamCreatePage));
 
-    expect(await screen.findByLabelText('Team name')).toHaveValue('test');
+    expect(await screen.findByLabelText('团队名称')).toHaveValue('test');
     await waitFor(() => {
       expect(new URLSearchParams(window.location.search).get('scopeId')).toBe(
         'scope-a',
       );
     });
 
-    fireEvent.change(screen.getByLabelText('Team description'), {
+    fireEvent.change(screen.getByLabelText('团队说明'), {
       target: { value: 'test' },
     });
-    fireEvent.click(screen.getAllByRole('button', { name: 'Create Team' })[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: '创建团队' })[0]);
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(

--- a/apps/aevatar-console-web/src/pages/teams/new.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/new.tsx
@@ -121,6 +121,11 @@ const TeamCreatePage: React.FC = () => {
     );
   }, [authSessionQuery.error, authSessionQuery.isError]);
   const canCreateTeam = Boolean(scopeId && teamName.trim());
+  const createTeamDisabledHint = !scopeId
+    ? '当前登录范围还不可用，暂时不能创建团队。'
+    : !teamName.trim()
+      ? '填写团队名称后即可创建。'
+      : '';
   const handleCreateTeam = async () => {
     if (!canCreateTeam || isCreatingTeam) {
       return;
@@ -169,11 +174,11 @@ const TeamCreatePage: React.FC = () => {
             onClick={() => void handleCreateTeam()}
             style={primaryActionButtonStyle}
           >
-            Create Team
+            创建团队
           </Button>
         </Space>
       }
-      title="Create Team"
+      title="创建团队"
     >
       {authSessionIssue ? (
         <Alert
@@ -216,23 +221,28 @@ const TeamCreatePage: React.FC = () => {
           }}
         >
           <div style={{ display: 'grid', gap: 8 }}>
-            <Typography.Text strong>Team name</Typography.Text>
+            <Typography.Text strong>团队名称</Typography.Text>
             <Input
-              aria-label="Team name"
+              aria-label="团队名称"
               placeholder="例如：订单助手团队"
               value={teamName}
               onChange={(event) => setTeamName(event.target.value)}
             />
           </div>
           <div style={{ display: 'grid', gap: 8 }}>
-            <Typography.Text strong>Description</Typography.Text>
+            <Typography.Text strong>团队说明</Typography.Text>
             <Input
-              aria-label="Team description"
+              aria-label="团队说明"
               placeholder="这个 Team 负责什么"
               value={teamDescription}
               onChange={(event) => setTeamDescription(event.target.value)}
             />
           </div>
+          {createTeamDisabledHint ? (
+            <Typography.Text style={{ fontSize: 13 }} type="secondary">
+              {createTeamDisabledHint}
+            </Typography.Text>
+          ) : null}
           <Space wrap size={[8, 8]}>
             <Button
               icon={<TeamOutlined />}
@@ -241,10 +251,10 @@ const TeamCreatePage: React.FC = () => {
               onClick={() => void handleCreateTeam()}
               style={primaryActionButtonStyle}
             >
-              Create Team
+              创建团队
             </Button>
             <Button onClick={() => history.push(buildTeamsHref())}>
-              Back to My Teams
+              返回团队列表
             </Button>
           </Space>
         </div>


### PR DESCRIPTION
## 问题与根因
- Team 创建页仍残留英文标题、字段标签和按钮文案，空名称时创建按钮 disabled 但缺少可见原因。
- Teams 首页首屏统计混用 `AI Team` / `待处理 Team`，与页面中文主语不一致。
- Team 详情页编辑团队弹窗残留 `Cancel` / `Close` 可访问名称，以及英文保存成功/失败提示；空团队名时保存按钮 disabled 但缺少解释。

## 修复方案
- 将 Team 创建页主操作、字段 label、返回按钮本地化，并在缺少 scope 或团队名称为空时显示 disabled 原因。
- 将 Teams 首页统计文案统一为 `AI 团队总数`、`待处理团队`。
- 将 Team 编辑弹窗取消/关闭/保存反馈本地化，为取消/关闭按钮补充稳定中文 aria label，并在团队名称为空时显示保存提示。
- 补充 focused regression tests 覆盖创建页、首页统计与详情编辑弹窗状态。

## 影响路径
- `apps/aevatar-console-web/src/pages/teams/new.tsx`
- `apps/aevatar-console-web/src/pages/teams/home.tsx`
- `apps/aevatar-console-web/src/pages/teams/detail.tsx`
- 对应 focused tests：`new.test.tsx`、`home.test.tsx`、`detail.test.tsx`

## Browser 证据
- Cycle 1：`/teams/new?scopeId=ccb108c4-dcb3-473a-a0f7-e9859bb2f2a0` reload 后显示 `创建团队`、`团队名称`、`团队说明`、`返回团队列表`，空名称时显示 `填写团队名称后即可创建。`。
- Cycle 2：`/teams?scopeId=ccb108c4-dcb3-473a-a0f7-e9859bb2f2a0` reload 后首屏统计显示 `AI 团队总数`、`待处理团队`、`运行稳定`。
- Cycle 3：`/teams/ccb108c4-dcb3-473a-a0f7-e9859bb2f2a0/t-df2d3eca8f6a41b6974019fae7d55e0b` reload 后打开 `编辑团队` 弹窗，清空团队名称后保存按钮 disabled，显示 `填写团队名称后即可保存。`；DOM 中没有 `Cancel` / `Close` 按钮名。
- Console：复验时只看到 2026-05-27 历史 `@/shared/i18n/localization` module-not-found 噪声；本轮 reload/弹窗操作未新增当前错误。

## 验证命令与结果
- `./node_modules/.bin/jest src/pages/teams/new.test.tsx --runInBand`：通过，4 passed。
- `./node_modules/.bin/jest src/pages/teams/home.test.tsx --runInBand`：通过，16 passed。
- `./node_modules/.bin/jest src/pages/teams/detail.test.tsx --runInBand`：通过，39 passed。
- `./node_modules/.bin/jest src/pages/teams/new.test.tsx src/pages/teams/home.test.tsx src/pages/teams/detail.test.tsx --runInBand`：通过，59 passed。
- `./node_modules/.bin/tsc --noEmit`：通过。
- `git diff --check -- apps/aevatar-console-web`：通过。
- `bash tools/ci/test_stability_guards.sh`：通过。

## Scope check
- `git diff --name-only HEAD~1..HEAD` 仅包含 `apps/aevatar-console-web/` 下文件。
- 未修改 backend。
- 未修改 proto。
- 未修改 docs/tools。
