### PR TITLE
Fix platform query form states

### DIFF
--- a/apps/aevatar-console-web/src/pages/Deployments/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/Deployments/index.test.tsx
@@ -327,7 +327,7 @@ describe("DeploymentsPage", () => {
     expect(screen.getByRole("button", { name: "加载范围变更" })).toBeInTheDocument();
     expect(screen.getByText("Trade Agent")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: /重\s*置/ }));
+    fireEvent.click(screen.getByRole("button", { name: "重置" }));
 
     expect(await screen.findByText("已加载范围已锁定")).toBeInTheDocument();
     expect(screen.getByText("显示已加载范围")).toBeInTheDocument();

--- a/apps/aevatar-console-web/src/pages/Deployments/index.tsx
+++ b/apps/aevatar-console-web/src/pages/Deployments/index.tsx
@@ -547,12 +547,17 @@ const DeploymentsScopeCard: React.FC<{
     <div
       style={{
         alignItems: "center",
-        display: "grid",
+        display: "flex",
+        flexWrap: "wrap",
         gap: 12,
-        gridTemplateColumns: "minmax(0, 1fr) auto",
+        justifyContent: "space-between",
       }}
     >
-      <Space orientation="vertical" size={2} style={{ width: "100%" }}>
+      <Space
+        orientation="vertical"
+        size={2}
+        style={{ flex: "1 1 160px", minWidth: 160 }}
+      >
         <span
           style={{
             color: "var(--ant-color-primary)",
@@ -584,12 +589,13 @@ const DeploymentsScopeCard: React.FC<{
             borderRadius: 999,
             color: "var(--ant-color-primary)",
             display: "inline-flex",
+            flex: "0 1 auto",
             fontSize: 12,
             fontWeight: 600,
-            minHeight: 30,
             maxWidth: "100%",
+            minHeight: 30,
+            overflowWrap: "anywhere",
             padding: "0 12px",
-            whiteSpace: "nowrap",
             overflow: "hidden",
             textOverflow: "ellipsis",
           }}
@@ -716,7 +722,7 @@ const DeploymentsScopeCard: React.FC<{
       </div>
 
       <Space size={8}>
-        <Button size="small" onClick={onReset}>
+        <Button aria-label="重置" size="small" onClick={onReset}>
           重置
         </Button>
         <Button

--- a/apps/aevatar-console-web/src/pages/governance/components/GovernanceQueryCard.test.tsx
+++ b/apps/aevatar-console-web/src/pages/governance/components/GovernanceQueryCard.test.tsx
@@ -86,12 +86,14 @@ describe('GovernanceQueryCard', () => {
             serviceId: 'svc-1',
           },
         ]}
+        onReset={() => {}}
         onChange={() => {}}
         onLoad={() => {}}
       />,
     );
 
     expect(screen.getByText('先选择服务')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '重置' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '加载治理信息' })).toBeDisabled();
   });
 });

--- a/apps/aevatar-console-web/src/pages/governance/components/GovernanceQueryCard.tsx
+++ b/apps/aevatar-console-web/src/pages/governance/components/GovernanceQueryCard.tsx
@@ -133,12 +133,17 @@ const GovernanceQueryCard: React.FC<GovernanceQueryCardProps> = ({
       <div
         style={{
           alignItems: 'flex-start',
-          display: 'grid',
+          display: 'flex',
+          flexWrap: 'wrap',
           gap: 12,
-          gridTemplateColumns: 'minmax(0, 1fr) auto',
+          justifyContent: 'space-between',
         }}
       >
-        <Space orientation="vertical" size={4} style={{ width: '100%' }}>
+        <Space
+          orientation="vertical"
+          size={4}
+          style={{ flex: '1 1 160px', minWidth: 160 }}
+        >
           <span
             style={{
               color: 'var(--ant-color-primary)',
@@ -169,11 +174,13 @@ const GovernanceQueryCard: React.FC<GovernanceQueryCardProps> = ({
             borderRadius: 999,
             color: 'var(--ant-color-primary)',
             display: 'inline-flex',
+            flex: '0 1 auto',
             fontSize: 12,
             fontWeight: 600,
+            maxWidth: '100%',
             minHeight: 30,
+            overflowWrap: 'anywhere',
             padding: '0 12px',
-            whiteSpace: 'nowrap',
           }}
         >
           {selectedScopeSegments.length > 0
@@ -381,7 +388,11 @@ const GovernanceQueryCard: React.FC<GovernanceQueryCardProps> = ({
           {loadDisabledReason}
         </span>
         <Space size={10}>
-          {onReset ? <Button onClick={onReset}>重置</Button> : null}
+          {onReset ? (
+            <Button aria-label="重置" onClick={onReset}>
+              重置
+            </Button>
+          ) : null}
           <Button
             aria-disabled={loadDisabled}
             disabled={loadDisabled}

--- a/apps/aevatar-console-web/src/pages/services/components/ServiceQueryCard.tsx
+++ b/apps/aevatar-console-web/src/pages/services/components/ServiceQueryCard.tsx
@@ -56,7 +56,7 @@ const ServiceQueryCard: React.FC<ServiceQueryCardProps> = ({
         {[
           {
             key: 'tenantId',
-            label: 'Team / Tenant',
+            label: '团队 / Tenant',
             placeholder: '团队 ID',
             value: draft.tenantId,
           },
@@ -109,7 +109,7 @@ const ServiceQueryCard: React.FC<ServiceQueryCardProps> = ({
             width: '100%',
           }}
         >
-          <Typography.Text style={fieldLabelStyle}>Result window</Typography.Text>
+          <Typography.Text style={fieldLabelStyle}>结果数量</Typography.Text>
           <InputNumber
             controls={false}
             min={1}
@@ -140,7 +140,11 @@ const ServiceQueryCard: React.FC<ServiceQueryCardProps> = ({
           <Button onClick={onLoad} type="primary">
             {loadLabel}
           </Button>
-          {onReset ? <Button onClick={onReset}>重置</Button> : null}
+          {onReset ? (
+            <Button aria-label="重置" onClick={onReset}>
+              重置
+            </Button>
+          ) : null}
         </div>
       </div>
     </div>

--- a/apps/aevatar-console-web/src/pages/services/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/services/index.test.tsx
@@ -129,6 +129,11 @@ describe('ServicesPage', () => {
     expect(await screen.findByText('无公开入口')).toBeTruthy();
     expect(await screen.findByText('查找服务')).toBeTruthy();
     expect(await screen.findByText('Service Alpha')).toBeTruthy();
+    expect(screen.getByText('团队 / Tenant')).toBeTruthy();
+    expect(screen.getByText('结果数量')).toBeTruthy();
+    expect(screen.getByRole('button', { name: '重置' })).toBeTruthy();
+    expect(screen.queryByText('Team / Tenant')).toBeNull();
+    expect(screen.queryByText('Result window')).toBeNull();
     expect(screen.getByText('Services 是 Platform 的权威服务目录，回答当前范围内有什么服务、它当前挂到哪、由谁承载，并指引你继续进入 Governance、Deployments 或 Topology。')).toBeTruthy();
     expect(screen.getByText('服务目录')).toBeTruthy();
     expect(screen.getByText('按行扫描状态、部署和入口，点击行或按钮在抽屉里查看详情。')).toBeTruthy();


### PR DESCRIPTION
## 问题与根因
- Services 查询表单仍显示 `Team / Tenant`、`Result window`，与页面中文文案混杂；Ant Design 两字按钮让 `重置` 的 accessible name 变成 `重 置`。
- Governance 查询卡片在移动宽度下使用两列 grid，右侧长 scope badge 抢占宽度，把 `治理范围 / 选择服务范围` 挤成竖排；重置按钮同样被读成 `重 置`。
- Deployments 查询卡片同样被长 scope badge 挤压，`部署范围 / 团队 / 应用 / 命名空间` 在移动宽度下竖排；重置按钮 accessible name 不稳定。

## 修复方案
- Services：将查询字段文案调整为 `团队 / Tenant`、`结果数量`，并为重置按钮增加 `aria-label="重置"`。
- Governance：将查询卡片 header 从两列 grid 改为可换行 flex，scope badge 允许换行；重置按钮增加稳定中文 aria label。
- Deployments：使用同样的可换行 header 结构避免移动端标题被挤压；重置按钮增加稳定中文 aria label。
- 补充/收紧 focused tests，防止 `重置` 的 accessible name 回退为带空格形式。

## 影响路径
- `apps/aevatar-console-web/src/pages/services/components/ServiceQueryCard.tsx`
- `apps/aevatar-console-web/src/pages/services/index.test.tsx`
- `apps/aevatar-console-web/src/pages/governance/components/GovernanceQueryCard.tsx`
- `apps/aevatar-console-web/src/pages/governance/components/GovernanceQueryCard.test.tsx`
- `apps/aevatar-console-web/src/pages/Deployments/index.tsx`
- `apps/aevatar-console-web/src/pages/Deployments/index.test.tsx`

## Browser 证据
- Cycle 1 Services：`/services?tenantId=ccb108c4-dcb3-473a-a0f7-e9859bb2f2a0&appId=default&namespace=default&take=200` reload 后 DOM 显示 `团队 / Tenant`、`结果数量`、`button "重置"`；旧 `Team / Tenant`、`Result window`、`button "重 置"` 不再出现。
- Cycle 2 Governance：`/governance?tenantId=ccb108c4-dcb3-473a-a0f7-e9859bb2f2a0&appId=default&namespace=default` reload 后移动视图中 `治理范围 / 选择服务范围` 正常横向显示，scope badge 换行不挤压标题；DOM 显示 `button "重置"`。
- Cycle 3 Deployments：`/deployments?tenantId=ccb108c4-dcb3-473a-a0f7-e9859bb2f2a0&appId=default&namespace=default&take=200` reload 后移动视图中 `部署范围 / 团队 / 应用 / 命名空间` 正常显示，scope badge 换行；DOM 显示 `button "重置"`。
- Console：复验时只看到 2026-05-27 历史 `@/shared/i18n/localization` module-not-found 噪声；本轮 reload 未新增当前错误。

## 验证命令与结果
- `./node_modules/.bin/jest src/pages/services/index.test.tsx --runInBand`：通过，2 passed。
- `./node_modules/.bin/jest src/pages/governance/components/GovernanceQueryCard.test.tsx --runInBand`：通过，3 passed。
- `./node_modules/.bin/jest src/pages/Deployments/index.test.tsx --runInBand`：通过，7 passed。
- `./node_modules/.bin/jest src/pages/services/index.test.tsx src/pages/governance/components/GovernanceQueryCard.test.tsx src/pages/Deployments/index.test.tsx --runInBand`：通过，12 passed。
- `./node_modules/.bin/tsc --noEmit`：通过。
- `git diff --check -- apps/aevatar-console-web`：通过。
- `bash tools/ci/test_stability_guards.sh`：通过。

## Scope check
- `git diff --name-only HEAD~1..HEAD` 仅包含 `apps/aevatar-console-web/` 下文件。
- 未修改 backend。
- 未修改 proto。
- 未修改 docs/tools。
