### PR TITLE
Improve platform page copy

### DIFF
--- a/apps/aevatar-console-web/src/pages/actors/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/actors/index.test.tsx
@@ -160,6 +160,8 @@ describe("ActorsPage", () => {
     expect(screen.getByRole("button", { name: "刷新列表" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "打开追查详情" })).toBeTruthy();
     expect(screen.queryByText("示例数据")).toBeNull();
+    expect(container.textContent).toContain("数据源");
+    expect(container.textContent).toContain("Actor Query");
     expect(container.textContent).toContain("SupportRoot");
     expect(screen.getAllByRole("button", { name: "查看概览" }).length).toBeGreaterThan(0);
   });

--- a/apps/aevatar-console-web/src/pages/actors/index.tsx
+++ b/apps/aevatar-console-web/src/pages/actors/index.tsx
@@ -349,6 +349,7 @@ const TopologyMetricCard: React.FC<{
       flexDirection: "column",
       gap: compact ? 4 : 6,
       minHeight: compact ? 78 : 94,
+      minWidth: 0,
       padding: compact ? 14 : 16,
     }}
   >
@@ -1270,12 +1271,21 @@ export const TopologyExplorerPage: React.FC<{
           <div
             style={{
               alignItems: "flex-start",
-              display: "grid",
+              display: "flex",
+              flexWrap: "wrap",
               gap: 14,
-              gridTemplateColumns: "minmax(0, 1fr) auto",
+              justifyContent: "space-between",
             }}
           >
-            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            <div
+              style={{
+                display: "flex",
+                flex: "1 1 180px",
+                flexDirection: "column",
+                gap: 6,
+                minWidth: 180,
+              }}
+            >
               <Typography.Text
                 style={{
                   color: token.colorPrimary,
@@ -1295,8 +1305,10 @@ export const TopologyExplorerPage: React.FC<{
               style={{
                 alignItems: "flex-end",
                 display: "flex",
+                flex: "0 1 auto",
                 flexDirection: "column",
                 gap: 8,
+                maxWidth: "100%",
               }}
             >
               <div
@@ -1309,8 +1321,9 @@ export const TopologyExplorerPage: React.FC<{
                   display: "inline-flex",
                   fontSize: 12,
                   fontWeight: 600,
-                  minHeight: 32,
                   maxWidth: "100%",
+                  minHeight: 32,
+                  overflowWrap: "anywhere",
                   padding: "0 14px",
                 }}
               >
@@ -1401,7 +1414,7 @@ export const TopologyExplorerPage: React.FC<{
           style={{
             display: "grid",
             gap: 12,
-            gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
+            gridTemplateColumns: "repeat(auto-fit, minmax(128px, 1fr))",
           }}
         >
           {detailOnly ? (

--- a/apps/aevatar-console-web/src/pages/gagents/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/gagents/index.test.tsx
@@ -258,6 +258,14 @@ describe("GAgentsPage", () => {
     expect(
       (await screen.findAllByText("OrdersGAgent (Tests)")).length
     ).toBeGreaterThan(0);
+    expect(screen.getByText("工作区上下文")).toBeInTheDocument();
+    expect(screen.getByLabelText("工作区 ID")).toHaveValue("scope-a");
+    expect(screen.getByText("NyxID 已解析工作区：scope-a")).toBeInTheDocument();
+    expect(screen.getByText("GAgent 类型")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "刷新" })).toBeInTheDocument();
+    expect(screen.getByLabelText("筛选 GAgent 类型")).toBeInTheDocument();
+    expect(screen.queryByText("Workspace Context")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Refresh" })).toBeNull();
     await waitFor(() => {
       expect(mockedRuntimeGAgentApi.listActors).toHaveBeenCalledWith("scope-a");
     });
@@ -320,11 +328,23 @@ describe("GAgentsPage", () => {
     expect(
       (await screen.findAllByText("OrdersGAgent (Tests)")).length
     ).toBeGreaterThan(0);
-    fireEvent.click(screen.getByRole("tab", { name: "Draft Run" }));
-    fireEvent.change(screen.getByLabelText("Draft prompt"), {
+    fireEvent.click(screen.getByRole("tab", { name: "草稿运行" }));
+    expect(screen.getByText("发布前先测试选中的 GAgent 类型。")).toBeInTheDocument();
+    expect(screen.getByText("创建新 Actor")).toBeInTheDocument();
+    expect(screen.getAllByText("运行输出").length).toBeGreaterThan(0);
+    expect(screen.getByText("回复")).toBeInTheDocument();
+    expect(screen.getByText("事件流 (0)")).toBeInTheDocument();
+    expect(
+      screen.getByText("运行草稿提示词后，会在这里看到流式 GAgent 回复。")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Draft Run")).toBeNull();
+    expect(screen.queryByText("Run Output")).toBeNull();
+    expect(screen.queryByText("Transcript")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("草稿提示词"), {
       target: { value: "hello agent" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /Run draft prompt/i }));
+    fireEvent.click(screen.getByRole("button", { name: "运行草稿提示词" }));
 
     await waitFor(() => {
       expect(mockedRuntimeGAgentApi.streamDraftRun).toHaveBeenCalledWith(
@@ -340,7 +360,7 @@ describe("GAgentsPage", () => {
     });
 
     expect((await screen.findAllByText("hello from gagent")).length).toBeGreaterThan(0);
-    fireEvent.click(screen.getByRole("button", { name: /Continue in Runs/i }));
+    fireEvent.click(screen.getByRole("button", { name: "在 Runs 中继续" }));
 
     expect(window.location.pathname).toBe("/runtime/runs");
     const draftKey = new URLSearchParams(window.location.search).get("draftKey");

--- a/apps/aevatar-console-web/src/pages/gagents/index.tsx
+++ b/apps/aevatar-console-web/src/pages/gagents/index.tsx
@@ -1342,17 +1342,17 @@ const GAgentsPage: React.FC = () => {
   const rail = (
     <div style={cliRailShellStyle}>
       <div style={cliRailSectionStyle}>
-        <div style={cliCardLabelStyle}>Workspace Context</div>
+        <div style={cliCardLabelStyle}>工作区上下文</div>
         <Input
-          aria-label="Workspace ID"
+          aria-label="工作区 ID"
           onChange={(event) => setScopeId(event.target.value)}
-          placeholder="Workspace ID"
+          placeholder="工作区 ID"
           value={scopeId}
         />
         <Typography.Text type="secondary">
           {resolvedScope?.scopeId
-            ? `NyxID resolved workspace: ${resolvedScope.scopeId}`
-            : 'No workspace was resolved from the current session.'}
+            ? `NyxID 已解析工作区：${resolvedScope.scopeId}`
+            : '当前会话还没有解析到工作区。'}
         </Typography.Text>
         {bindingQuery.data?.available ? (
           <div
@@ -1403,20 +1403,20 @@ const GAgentsPage: React.FC = () => {
               justifyContent: 'space-between',
             }}
           >
-            <div style={cliCardLabelStyle}>GAgent Types</div>
+            <div style={cliCardLabelStyle}>GAgent 类型</div>
             <Button
               icon={<ReloadOutlined />}
               onClick={() => void gAgentTypesQuery.refetch()}
               size="small"
               type="text"
             >
-              Refresh
+              刷新
             </Button>
           </div>
           <Input
-            aria-label="Filter GAgent types"
+            aria-label="筛选 GAgent 类型"
             onChange={(event) => setTypeFilter(event.target.value)}
-            placeholder="Filter GAgent types"
+            placeholder="筛选 GAgent 类型"
             value={typeFilter}
           />
           {gAgentTypesQuery.error ? (
@@ -1648,22 +1648,22 @@ const GAgentsPage: React.FC = () => {
 
   const runOutputPanel = (
     <WorkbenchCard
-      description="Transcript and runtime events from the most recent draft run."
-      eyebrow="Run Output"
+      description="最近一次草稿运行的回复和运行时事件。"
+      eyebrow="运行输出"
       extra={
         <Space size={[8, 8]} wrap>
           {runState.actorId ? <Tag>{runState.actorId}</Tag> : null}
           {runState.commandId ? <Tag>{runState.commandId}</Tag> : null}
         </Space>
       }
-      title={runState.runId ? `Run ${runState.runId}` : 'Run Output'}
+      title={runState.runId ? `Run ${runState.runId}` : '运行输出'}
     >
       <Tabs
         activeKey={activeRunOutputTab}
         items={[
           {
             key: 'transcript',
-            label: 'Transcript',
+            label: '回复',
             children: runState.assistantText.trim() ? (
               <Typography.Paragraph
                 style={{
@@ -1677,15 +1677,15 @@ const GAgentsPage: React.FC = () => {
                 {runState.assistantText}
               </Typography.Paragraph>
             ) : (
-              <AevatarInspectorEmpty description="Run a draft prompt to watch the streamed GAgent response here." />
+              <AevatarInspectorEmpty description="运行草稿提示词后，会在这里看到流式 GAgent 回复。" />
             ),
           },
           {
             key: 'events',
-            label: `Event Feed (${runState.events.length})`,
+            label: `事件流 (${runState.events.length})`,
             children:
               runState.events.length === 0 ? (
-                <AevatarInspectorEmpty description="No events captured yet." />
+                <AevatarInspectorEmpty description="还没有捕获到事件。" />
               ) : (
                 <div style={{ ...scrollColumnStyle, maxHeight: 360 }}>
                   {runState.events.slice(-12).map((event, index) => (
@@ -2541,15 +2541,15 @@ const GAgentsPage: React.FC = () => {
 
   const draftRunPanel = (
     <WorkbenchCard
-      description="Test the selected GAgent type before publishing."
-      eyebrow="Draft Run"
+      description="发布前先测试选中的 GAgent 类型。"
+      eyebrow="草稿运行"
       extra={
         <Space size={[8, 8]} wrap>
           <AevatarStatusTag domain="run" status={runState.status} />
           {runState.runId ? <Tag>{runState.runId}</Tag> : null}
         </Space>
       }
-      title={selectedType ? selectedType.typeName : 'GAgent Draft Run'}
+      title={selectedType ? selectedType.typeName : 'GAgent 草稿运行'}
     >
       <Space orientation="vertical" size={16} style={{ width: '100%' }}>
         {selectedType ? (
@@ -2561,34 +2561,34 @@ const GAgentsPage: React.FC = () => {
             }}
           >
             <div>
-              <Typography.Text type="secondary">Type</Typography.Text>
+              <Typography.Text type="secondary">类型</Typography.Text>
               <Typography.Paragraph style={wrappedTextStyle}>
                 {selectedType.fullName}
               </Typography.Paragraph>
             </div>
             <div>
-              <Typography.Text type="secondary">Saved actors</Typography.Text>
+              <Typography.Text type="secondary">已保存 Actor</Typography.Text>
               <Typography.Paragraph style={wrappedTextStyle}>
                 {savedActorIds.length}
               </Typography.Paragraph>
             </div>
             <div>
-              <Typography.Text type="secondary">Observed actor</Typography.Text>
+              <Typography.Text type="secondary">观察到的 Actor</Typography.Text>
               <Typography.Paragraph style={wrappedTextStyle}>
                 {runState.actorId || 'n/a'}
               </Typography.Paragraph>
             </div>
           </div>
         ) : (
-          <AevatarInspectorEmpty description="Select a discovered GAgent type before drafting a direct run." />
+          <AevatarInspectorEmpty description="先选择已发现的 GAgent 类型，再创建草稿运行。" />
         )}
 
         <Select
-          aria-label="Actor reuse mode"
+          aria-label="Actor 复用模式"
           onChange={(value) => setActorReuseMode(value)}
           options={[
-            { label: 'Create new actor', value: 'new' },
-            { label: 'Reuse existing actor', value: 'existing' },
+            { label: '创建新 Actor', value: 'new' },
+            { label: '复用已有 Actor', value: 'existing' },
           ]}
           value={actorReuseMode}
         />
@@ -2606,8 +2606,8 @@ const GAgentsPage: React.FC = () => {
               }))}
               placeholder={
                 gAgentActorsQuery.isLoading
-                  ? 'Loading saved actors'
-                  : 'Reuse a saved actor (optional)'
+                  ? '正在加载已保存 Actor'
+                  : '复用已保存 Actor（可选）'
               }
               showSearch
               style={{ width: '100%' }}
@@ -2627,23 +2627,21 @@ const GAgentsPage: React.FC = () => {
               />
             ) : (
               <Typography.Text type="secondary">
-                Leave the saved actor selector empty if you want to type a known
-                actor id manually.
+                如果要手动输入已知 actor id，可以留空上面的已保存 Actor 选择器。
               </Typography.Text>
             )}
           </Space>
         ) : (
           <Typography.Text type="secondary">
-            New actor mode lets the runtime allocate a fresh actor and persist
-            it for future reuse.
+            创建新 Actor 模式会让 runtime 分配一个新的 actor，并持久化以便后续复用。
           </Typography.Text>
         )}
 
         <Input.TextArea
-          aria-label="Draft prompt"
+          aria-label="草稿提示词"
           autoSize={{ minRows: 4, maxRows: 8 }}
           onChange={(event) => setPrompt(event.target.value)}
-          placeholder="Enter a direct prompt for the selected GAgent type"
+          placeholder="输入要直接发送给所选 GAgent 类型的提示词"
           value={prompt}
         />
 
@@ -2654,7 +2652,7 @@ const GAgentsPage: React.FC = () => {
             onClick={() => void handleRun()}
             type="primary"
           >
-            Run draft prompt
+            运行草稿提示词
           </Button>
           <Button
             danger
@@ -2662,14 +2660,14 @@ const GAgentsPage: React.FC = () => {
             icon={<StopOutlined />}
             onClick={handleStop}
           >
-            Stop run
+            停止运行
           </Button>
           <Button
             disabled={runState.events.length === 0}
             icon={<EyeOutlined />}
             onClick={handleOpenRuns}
           >
-            Continue in Runs
+            在 Runs 中继续
           </Button>
         </Space>
 
@@ -2683,7 +2681,7 @@ const GAgentsPage: React.FC = () => {
   const workbenchTabs = [
     {
       key: 'draft',
-      label: 'Draft Run',
+      label: '草稿运行',
       children: (
         <div style={workbenchColumnStyle}>
           {draftRunPanel}


### PR DESCRIPTION
## 问题与根因

- Runtime Explorer 在移动视口下会把追查对象标题和指标卡文本挤成竖排，根因是头部和指标网格使用过窄的固定列布局，长内容缺少可换行空间。
- Runtime GAgents 左侧 rail 仍有 Workspace Context / Refresh / Filter GAgent types 等英文文案，和当前中文控制台体验不一致。
- Runtime GAgents 草稿运行工作台仍有 Draft Run / Run Output / Transcript / Run draft prompt 等英文文案，用户在核心调试路径里会遇到中英混杂。

## 修复方案

- 调整 Runtime Explorer 移动布局：头部改为 wrapping flex，指标网格使用 `auto-fit` 和最小宽度，避免标题和指标竖排挤压。
- 将 GAgents rail 的工作区、刷新、筛选文案改为中文，并补回归断言防止旧英文回流。
- 将 GAgents 草稿运行、运行输出、回复/事件流、按钮与输入框文案改为中文，并补 focused test 覆盖用户可见状态。

## 影响路径

- `apps/aevatar-console-web/src/pages/actors/index.tsx`
- `apps/aevatar-console-web/src/pages/actors/index.test.tsx`
- `apps/aevatar-console-web/src/pages/gagents/index.tsx`
- `apps/aevatar-console-web/src/pages/gagents/index.test.tsx`

## Browser 证据

- Cycle 1: `http://localhost:5173/runtime/explorer?scopeId=ccb108c4-dcb3-473a-a0f7-e9859bb2f2a0` 移动视口复验，`选择追查对象` 和 `Actor Query` 不再被挤成竖排；console 没有本次新增错误。
- Cycle 2: `http://localhost:5173/runtime/gagents?scopeId=ccb108c4-dcb3-473a-a0f7-e9859bb2f2a0&type=Aevatar.GAgents.NyxidChat.NyxIdChatGAgent` 复验，`工作区上下文`、`工作区 ID`、`NyxID 已解析工作区`、`GAgent 类型`、`刷新`、`筛选 GAgent 类型` 可见，旧 `Workspace Context` / `Refresh` / `Filter GAgent types` 不再出现；console 没有本次新增错误。
- Cycle 3: 同一 GAgents route reload 后复验，`草稿运行`、`发布前先测试选中的 GAgent 类型。`、`创建新 Actor`、`草稿提示词`、`运行草稿提示词`、`停止运行`、`在 Runs 中继续`、`运行输出`、`回复`、`事件流` 可见，旧 `Draft Run` / `Run Output` / `Transcript` / `Run draft prompt` / `Continue in Runs` 不再出现；console 仅剩 2026-05-27 历史噪声，无本次新增错误。

## 验证命令与结果

- `./node_modules/.bin/jest src/pages/gagents/index.test.tsx --runInBand`：通过，6 tests passed。
- `./node_modules/.bin/jest src/pages/actors/index.test.tsx src/pages/gagents/index.test.tsx --runInBand`：通过，14 tests passed；Jest 仍提示已有 open handles 风险，但退出码为 0。
- `./node_modules/.bin/tsc --noEmit`：通过。
- `git diff --check -- apps/aevatar-console-web`：通过。
- `bash tools/ci/test_stability_guards.sh`：通过。

## Scope check

- `git diff --name-only` 仅包含 `apps/aevatar-console-web/` 下 4 个文件。
- 未修改 backend。
- 未修改 proto。
- 未修改 docs/tools/scripts。
- 未修改 `.slnx` / `.csproj` / `.cs` / generated files / shared contracts。
