### PR TITLE
Improve GAgent page labels

### DIFF
--- a/apps/aevatar-console-web/src/pages/gagents/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/gagents/index.test.tsx
@@ -67,12 +67,13 @@ jest.mock("@/shared/ui/aevatarPageShells", () => ({
     const mockReact = require("react");
     return mockReact.createElement("div", null, description);
   },
-  AevatarPageShell: ({ children, title }: any) => {
+  AevatarPageShell: ({ children, extra, title }: any) => {
     const mockReact = require("react");
     return mockReact.createElement(
       "section",
       null,
       mockReact.createElement("h1", null, title),
+      extra ? mockReact.createElement("div", null, extra) : null,
       children
     );
   },
@@ -258,6 +259,23 @@ describe("GAgentsPage", () => {
     expect(
       (await screen.findAllByText("OrdersGAgent (Tests)")).length
     ).toBeGreaterThan(0);
+    expect(screen.getByRole("heading", { name: "GAgent 类型" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "团队成员" })).toBeNull();
+    expect(screen.getByText("工作区 ID")).toBeInTheDocument();
+    expect(screen.getAllByText("scope-a").length).toBeGreaterThan(0);
+    expect(screen.getByText("选中类型")).toBeInTheDocument();
+    expect(
+      screen.getByText("当前类型选择会同时驱动草稿运行和发布绑定。")
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "管理 Actor" })).toBeInTheDocument();
+    expect(screen.getByText("类型")).toBeInTheDocument();
+    expect(screen.getByText("程序集")).toBeInTheDocument();
+    expect(screen.getByText("已保存 Actor")).toBeInTheDocument();
+    expect(screen.getByText("发布目标")).toBeInTheDocument();
+    expect(screen.getByText("此类型尚未提供服务")).toBeInTheDocument();
+    expect(screen.queryByText("Selected Type")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Manage actors" })).toBeNull();
+    expect(screen.queryByText("Published target")).toBeNull();
     await waitFor(() => {
       expect(mockedRuntimeGAgentApi.listActors).toHaveBeenCalledWith("scope-a");
     });
@@ -286,9 +304,9 @@ describe("GAgentsPage", () => {
       (await screen.findAllByText("OrdersGAgent (Tests)")).length
     ).toBeGreaterThan(0);
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Manage actors" })).not.toBeDisabled();
+      expect(screen.getByRole("button", { name: "管理 Actor" })).not.toBeDisabled();
     });
-    fireEvent.click(await screen.findByRole("button", { name: "Manage actors" }));
+    fireEvent.click(await screen.findByRole("button", { name: "管理 Actor" }));
     expect((await screen.findAllByText("Actor Registry")).length).toBeGreaterThan(0);
 
     expect(screen.queryByRole("button", { name: "Save actor" })).toBeNull();
@@ -421,7 +439,8 @@ describe("GAgentsPage", () => {
 
     fireEvent.click(await screen.findByRole("tab", { name: "Serving" }));
     expect((await screen.findAllByText("Orders Assistant")).length).toBeGreaterThan(0);
-    expect(await screen.findByText("Active binding")).toBeTruthy();
+    expect(await screen.findByText("活跃绑定")).toBeTruthy();
+    expect(screen.queryByText("Active binding")).toBeNull();
     expect((await screen.findAllByText("Tests.OrdersGAgent, Tests")).length).toBeGreaterThan(0);
     expect((await screen.findAllByText("rev-1")).length).toBeGreaterThan(0);
   });

--- a/apps/aevatar-console-web/src/pages/gagents/index.tsx
+++ b/apps/aevatar-console-web/src/pages/gagents/index.tsx
@@ -1518,8 +1518,8 @@ const GAgentsPage: React.FC = () => {
 
   const selectedTypePanel = (
     <WorkbenchCard
-      description="Current type selection that drives both draft runs and published bindings."
-      eyebrow="Selected Type"
+      description="当前类型选择会同时驱动草稿运行和发布绑定。"
+      eyebrow="选中类型"
       extra={
         <Space size={[8, 8]} wrap>
           <Button
@@ -1527,23 +1527,23 @@ const GAgentsPage: React.FC = () => {
             onClick={() => setIsActorRegistryDrawerOpen(true)}
             size="small"
           >
-            Manage actors
+            管理 Actor
           </Button>
           {selectedType ? (
             <>
               {currentBindingMatchesSelectedType ? (
-                <Tag color="success">Active binding</Tag>
+                <Tag color="success">活跃绑定</Tag>
               ) : null}
               {savedActorIds.length > 0 ? (
-                <Tag>{savedActorIds.length} actors</Tag>
+                <Tag>{savedActorIds.length} 个 Actor</Tag>
               ) : null}
             </>
           ) : (
-            <Tag>Choose a type</Tag>
+            <Tag>选择类型</Tag>
           )}
         </Space>
       }
-      title={selectedType ? selectedType.typeName : 'No type selected'}
+      title={selectedType ? selectedType.typeName : '未选择类型'}
     >
       {selectedType ? (
         <div
@@ -1554,36 +1554,36 @@ const GAgentsPage: React.FC = () => {
           }}
         >
           <div style={summaryMetricStyle}>
-            <Typography.Text type="secondary">Type</Typography.Text>
+            <Typography.Text type="secondary">类型</Typography.Text>
             <Typography.Paragraph style={wrappedTextStyle}>
               {selectedType.fullName}
             </Typography.Paragraph>
           </div>
           <div style={summaryMetricStyle}>
-            <Typography.Text type="secondary">Assembly</Typography.Text>
+            <Typography.Text type="secondary">程序集</Typography.Text>
             <Typography.Paragraph style={wrappedTextStyle}>
               {selectedType.assemblyName}
             </Typography.Paragraph>
           </div>
           <div style={summaryMetricStyle}>
-            <Typography.Text type="secondary">Saved actors</Typography.Text>
+            <Typography.Text type="secondary">已保存 Actor</Typography.Text>
             <Typography.Paragraph style={wrappedTextStyle}>
               {savedActorIds.length}
             </Typography.Paragraph>
           </div>
           <div style={summaryMetricStyle}>
-            <Typography.Text type="secondary">Published target</Typography.Text>
+            <Typography.Text type="secondary">发布目标</Typography.Text>
             <Typography.Paragraph style={wrappedTextStyle}>
               {currentBindingMatchesSelectedType
                 ? describeRuntimeGAgentBindingRevisionTarget(
                     currentBindingRevision,
                   )
-                : 'Not serving this type yet'}
+                : '此类型尚未提供服务'}
             </Typography.Paragraph>
           </div>
         </div>
       ) : (
-        <AevatarInspectorEmpty description="Choose a discovered GAgent type from the left rail to prepare draft runs or published bindings." />
+        <AevatarInspectorEmpty description="从左侧列表选择已发现的 GAgent 类型，以准备草稿运行或发布绑定。" />
       )}
     </WorkbenchCard>
   );
@@ -2744,14 +2744,14 @@ const GAgentsPage: React.FC = () => {
       layoutMode="document"
       extra={
         <Space size={[8, 8]} wrap>
-          <Typography.Text type="secondary">Workspace ID</Typography.Text>
+          <Typography.Text type="secondary">工作区 ID</Typography.Text>
           <Typography.Text style={{ maxWidth: 320 }} strong>
-            {normalizedScopeId || resolvedScope?.scopeId || 'Not resolved'}
+            {normalizedScopeId || resolvedScope?.scopeId || '未解析'}
           </Typography.Text>
         </Space>
       }
-      title="团队成员"
-      titleHelp="这里保留原有 GAgent runtime 能力，但统一对外表述为团队成员管理与绑定工作台。"
+      title="GAgent 类型"
+      titleHelp="查看 runtime 已发现的 GAgent 类型，并管理草稿运行、发布绑定和已保存 Actor。"
     >
       <AevatarWorkbenchLayout
         layoutMode="document"


### PR DESCRIPTION
## 问题与根因

- Runtime GAgents 页面主标题仍显示为 `团队成员`，route identity 与 `/runtime/gagents` 不一致。
- GAgents 选中类型摘要卡仍使用 `Selected Type`、`Manage actors`、`Assembly`、`Published target` 等英文文案，和中文控制台上下文不一致。
- 页面右上角 workspace 标识仍显示 `Workspace ID` / `Not resolved` 英文兜底。

## 修复方案

- 将 GAgents 页面 shell 标题改为 `GAgent 类型`，并更新帮助文案。
- 将选中类型摘要卡的说明、管理按钮、状态标签和指标 label 改为中文。
- 将页面 shell 右上角 workspace label 和未解析兜底改为中文。
- 更新 `GAgentsPage` focused test，覆盖 page shell title、extra、摘要卡中文文案以及旧英文回流防线。

## 影响路径

- `apps/aevatar-console-web/src/pages/gagents/index.tsx`
- `apps/aevatar-console-web/src/pages/gagents/index.test.tsx`

## Browser 证据

- Cycle 1: 在 `http://localhost:5173/runtime/gagents?scopeId=ccb108c4-dcb3-473a-a0f7-e9859bb2f2a0&type=Aevatar.GAgents.NyxidChat.NyxIdChatGAgent` reload 后，摘要卡显示 `选中类型`、`当前类型选择会同时驱动草稿运行和发布绑定。`、`管理 Actor`、`类型`、`程序集`、`已保存 Actor`、`发布目标`、`此类型尚未提供服务`；旧 `Selected Type` / `Manage actors` / `Published target` 不再出现在摘要卡区域；console 无新增 error/warn。
- Cycle 2: 同一路由 reload 后，页面主标题显示 `GAgent 类型`，旧 `团队成员` 标题消失；console 无新增 error/warn。
- Cycle 3: 同一路由最终复验，右上角显示 `工作区 ID`，页面标题、摘要卡、workspace 标识均为新中文；旧 scoped 英文 `Selected Type` / `Manage actors` / `Assembly` / `Published target` / `Not serving this type yet` 消失；console 无新增 error/warn。

## 验证命令与结果

- `./node_modules/.bin/jest src/pages/gagents/index.test.tsx --runInBand`：通过，6 tests passed。
- `./node_modules/.bin/tsc --noEmit`：通过。
- `git diff --check -- apps/aevatar-console-web`：通过。
- `bash tools/ci/test_stability_guards.sh`：通过。

## Scope check

- `git diff --name-only` 仅包含 `apps/aevatar-console-web/src/pages/gagents/index.tsx` 和 `apps/aevatar-console-web/src/pages/gagents/index.test.tsx`。
- 未修改 backend。
- 未修改 proto。
- 未修改 docs/tools/scripts。
- 未修改 `.slnx` / `.csproj` / `.cs` / generated files / shared contracts。
