### PR TITLE
iter112 #1091: typed-only WorkflowChatRunRequest(Application 内部 normalize)

### DIFF
--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -201,18 +201,24 @@ public sealed class AevatarInvocationDispatcher
 
         var metadata = BuildLegacyMetadata(scope.Value!, request.Inputs.Headers);
         metadata[WorkflowRunCommandMetadataKeys.ScopeId] = scope.Value!.ScopeId;
+        var workflowYamls = request.WorkflowYamls.Count == 0
+            ? null
+            : request.WorkflowYamls
+                .Where(static item => !string.IsNullOrWhiteSpace(item))
+                .Select(static item => item.Trim())
+                .ToArray();
+        var workflowName = request.WorkflowId.Trim();
+        var actorId = string.IsNullOrWhiteSpace(request.ActorId) ? null : request.ActorId.Trim();
+        var source = workflowYamls is { Length: > 0 }
+            ? WorkflowChatSource.InlineYamlBundle(workflowYamls, workflowName, actorId)
+            : string.IsNullOrWhiteSpace(actorId)
+                ? WorkflowChatSource.CatalogWorkflow(workflowName)
+                : WorkflowChatSource.DefinitionActor(actorId, workflowName);
         var command = new WorkflowChatRunRequest(
             Prompt: request.Inputs.Prompt,
-            WorkflowName: request.WorkflowId.Trim(),
-            ActorId: string.IsNullOrWhiteSpace(request.ActorId) ? null : request.ActorId.Trim(),
+            Source: source,
             SessionId: ResolveSessionId(),
             InputParts: ToWorkflowInputParts(request.Inputs),
-            WorkflowYamls: request.WorkflowYamls.Count == 0
-                ? null
-                : request.WorkflowYamls
-                    .Where(static item => !string.IsNullOrWhiteSpace(item))
-                    .Select(static item => item.Trim())
-                    .ToArray(),
             Metadata: metadata,
             ScopeId: scope.Value.ScopeId);
 

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -125,10 +125,8 @@ public static class ScopeServiceEndpoints
 
             var chatRequest = new WorkflowChatRunRequest(
                 Prompt: request.Prompt?.Trim() ?? string.Empty,
-                WorkflowName: null,
-                ActorId: null,
+                Source: WorkflowChatSource.InlineYamlBundle(request.WorkflowYamls),
                 SessionId: request.SessionId,
-                WorkflowYamls: request.WorkflowYamls,
                 Metadata: scopedHeaders,
                 ScopeId: scopeId,
                 LlmControl: await BuildScopedLlmControlAsync(http, ct));
@@ -148,7 +146,7 @@ public static class ScopeServiceEndpoints
                 new ChatInput
                 {
                     Prompt = chatRequest.Prompt,
-                    WorkflowYamls = chatRequest.WorkflowYamls,
+                    WorkflowYamls = chatRequest.Source.WorkflowYamls,
                     SessionId = chatRequest.SessionId,
                     ScopeId = scopeId,
                     Metadata = scopedHeaders,

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
@@ -433,10 +433,8 @@ public static class ScopeWorkflowEndpoints
             http,
             new WorkflowChatRunRequest(
                 prompt,
-                workflow.WorkflowName,
-                workflow.ActorId,
+                WorkflowChatSource.DefinitionActor(workflow.ActorId, workflow.WorkflowName),
                 sessionId,
-                WorkflowYamls: null,
                 Metadata: headers,
                 ScopeId: NormalizeRequired(scopeId, nameof(scopeId)),
                 LlmControl: llmControl),

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunModels.cs
@@ -49,20 +49,17 @@ public sealed record WorkflowChatSource(
         new(WorkflowChatSourceKind.Direct, ActorId: actorId);
 }
 
+// Refactor (iter112/cluster-3): Old pattern: application commands carried typed source plus legacy mirror fields. New principle: Application owns one typed WorkflowChatSource representation.
 public sealed record WorkflowChatRunRequest(
     string Prompt,
-    string? WorkflowName,
-    string? ActorId,
+    WorkflowChatSource Source,
     string? SessionId = null,
     IReadOnlyList<WorkflowChatInputPart>? InputParts = null,
-    // Inline workflow YAML bundle; first item is the entry workflow.
-    IReadOnlyList<string>? WorkflowYamls = null,
     IReadOnlyDictionary<string, string>? Metadata = null,
     // Refactor (iter15/cluster-029):
     //   Old pattern: scope id / channel facts fell back to metadata bag string keys.
     //   New principle: stable business semantics use typed proto field; metadata bag only for genuine open extension.
     string? ScopeId = null,
-    WorkflowChatSource? Source = null,
     LLMControlContext? LlmControl = null);
 
 public enum WorkflowChatRunStartError

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowDirectFallbackPolicy.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowDirectFallbackPolicy.cs
@@ -6,6 +6,7 @@ namespace Aevatar.Workflow.Application.Runs;
 /// <summary>
 /// Decides whether a failed workflow run should be retried against the direct workflow.
 /// </summary>
+// Refactor (iter112/cluster-3): Old pattern: fallback policy treated legacy request mirrors as the command source. New principle: fallback decisions are derived from typed WorkflowChatSource only.
 public sealed class WorkflowDirectFallbackPolicy
     : ICommandFallbackPolicy<WorkflowChatRunRequest>
 {
@@ -21,13 +22,14 @@ public sealed class WorkflowDirectFallbackPolicy
     /// </summary>
     public bool ShouldFallback(WorkflowChatRunRequest request, Exception ex)
     {
+        // Refactor (iter112/cluster-3): Old pattern: fallback policy inspected legacy WorkflowName/WorkflowYamls mirrors. New principle: fallback reads only the typed WorkflowChatSource.
         if (!_behaviorOptions.EnableDirectFallback)
             return false;
         if (ex is OperationCanceledException)
             return false;
         if (!IsWhitelistedException(ex))
             return false;
-        if (request.WorkflowYamls is { Count: > 0 })
+        if (request.Source.WorkflowYamls is { Count: > 0 })
             return false;
 
         var workflowName = ResolveEffectiveWorkflowName(request);
@@ -67,9 +69,10 @@ public sealed class WorkflowDirectFallbackPolicy
 
     private string ResolveEffectiveWorkflowName(WorkflowChatRunRequest request)
     {
+        // Refactor (iter112/cluster-3): Old pattern: effective workflow resolution read WorkflowName directly. New principle: workflow identity is read through WorkflowChatSource.
         ArgumentNullException.ThrowIfNull(request);
 
-        var requestedWorkflowName = WorkflowRunNameNormalizer.NormalizeWorkflowName(request.WorkflowName);
+        var requestedWorkflowName = WorkflowRunNameNormalizer.NormalizeWorkflowName(request.Source.WorkflowName);
         if (!string.IsNullOrWhiteSpace(requestedWorkflowName))
             return requestedWorkflowName;
 
@@ -82,12 +85,12 @@ public sealed class WorkflowDirectFallbackPolicy
             : configuredDefault;
     }
 
-    public WorkflowChatRunRequest ToFallbackRequest(WorkflowChatRunRequest request) =>
-        request with
+    public WorkflowChatRunRequest ToFallbackRequest(WorkflowChatRunRequest request)
+    {
+        // Refactor (iter112/cluster-3): Old pattern: fallback rewrote mirror fields individually. New principle: fallback replaces the typed source atomically.
+        return request with
         {
-            WorkflowName = WorkflowRunBehaviorOptions.DirectWorkflowName,
-            ActorId = null,
-            WorkflowYamls = null,
             Source = WorkflowChatSource.CatalogWorkflow(WorkflowRunBehaviorOptions.DirectWorkflowName),
         };
+    }
 }

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunActorResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunActorResolver.cs
@@ -29,7 +29,8 @@ public sealed class WorkflowRunActorResolver : IWorkflowRunActorResolver
         WorkflowChatRunRequest request,
         CancellationToken ct = default)
     {
-        var source = ResolveSource(request);
+        // Refactor (iter112/cluster-3): Old pattern: resolver rebuilt source from legacy request mirrors. New principle: Application consumes the typed WorkflowChatSource as the single command source.
+        var source = request.Source;
         var requestedWorkflowName = WorkflowRunNameNormalizer.NormalizeWorkflowName(source.WorkflowName);
         var sourceActorId = source.ActorId;
         var inlineWorkflowYamls = source.WorkflowYamls?.ToList() ?? [];
@@ -103,23 +104,6 @@ public sealed class WorkflowRunActorResolver : IWorkflowRunActorResolver
             createdRun,
             workflowNameForRun,
             WorkflowChatRunStartError.None);
-    }
-
-    private static WorkflowChatSource ResolveSource(WorkflowChatRunRequest request)
-    {
-        if (request.Source != null)
-            return request.Source;
-
-        if (request.WorkflowYamls is { Count: > 0 })
-            return WorkflowChatSource.InlineYamlBundle(request.WorkflowYamls, request.WorkflowName, request.ActorId);
-
-        if (!string.IsNullOrWhiteSpace(request.ActorId))
-            return WorkflowChatSource.DefinitionActor(request.ActorId, request.WorkflowName);
-
-        if (!string.IsNullOrWhiteSpace(request.WorkflowName))
-            return WorkflowChatSource.CatalogWorkflow(request.WorkflowName);
-
-        return WorkflowChatSource.Direct();
     }
 
     private async Task<WorkflowActorResolutionResult> ResolveFromSourceActorAsync(

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunRequestNormalizer.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunRequestNormalizer.cs
@@ -20,6 +20,7 @@ internal readonly record struct ChatRunRequestNormalizationResult(
 
 internal static class ChatRunRequestNormalizer
 {
+    // Refactor (iter112/cluster-3): Old pattern: Host adapters populated Application mirror fields beside typed source. New principle: Host keeps wire aliases but normalizes them once into typed WorkflowChatSource.
     // Refactor (iter15/cluster-029):
     //   Old pattern: normalized context carried metadata-derived scope conflict state.
     //   New principle: scope is owned by the typed field; metadata only carries open extension entries.
@@ -32,6 +33,7 @@ internal static class ChatRunRequestNormalizer
         WorkflowCapabilitiesDocument? capabilities = null,
         IReadOnlyDictionary<string, string>? defaultMetadata = null)
     {
+        // Refactor (iter112/cluster-3): Old pattern: host passed normalized legacy mirror fields into Application commands. New principle: host normalizes wire aliases once into typed WorkflowChatSource.
         ArgumentNullException.ThrowIfNull(input);
 
         var normalizedInputParts = NormalizeInputParts(input.InputParts);
@@ -62,14 +64,11 @@ internal static class ChatRunRequestNormalizer
         return ChatRunRequestNormalizationResult.Success(
             new WorkflowChatRunRequest(
                 Prompt: normalizedPrompt,
-                WorkflowName: string.IsNullOrWhiteSpace(source.WorkflowName) ? null : source.WorkflowName,
-                ActorId: NormalizeAgentId(source.ActorId),
+                Source: source,
                 SessionId: NormalizeSessionId(input.SessionId),
                 InputParts: normalizedInputParts,
-                WorkflowYamls: source.WorkflowYamls,
                 Metadata: normalizedMetadata,
                 ScopeId: normalizedContext.ScopeId,
-                Source: source,
                 LlmControl: NormalizeLlmControl(input.LlmControl)));
     }
 

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -405,7 +405,7 @@ public sealed class AevatarInvocationToolSourceTests
 
         ErrorCodeOrNull(output).Should().BeNull(output);
         harness.WorkflowDispatch.Command.Should().NotBeNull();
-        harness.WorkflowDispatch.Command!.WorkflowName.Should().Be("wf-main");
+        harness.WorkflowDispatch.Command!.Source.WorkflowName.Should().Be("wf-main");
         harness.WorkflowDispatch.Command.Prompt.Should().Be("run workflow");
         harness.WorkflowDispatch.Command.ScopeId.Should().Be("scope-1");
         harness.WorkflowDispatch.Command.Metadata.Should().Contain("scope_id", "scope-1");

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -418,6 +418,65 @@ public sealed class AevatarInvocationToolSourceTests
     }
 
     [Fact]
+    public async Task aevatar_start_workflow_with_actor_id_dispatches_definition_actor_source()
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync("aevatar_start_workflow");
+
+        using var _ = PushContext(callId: "call-workflow-actor");
+        var output = await tool.ExecuteAsync("""
+            {
+              "workflow_id": " wf-main ",
+              "actor_id": " workflow-definition-actor ",
+              "inputs": {
+                "prompt": "run workflow"
+              },
+              "wait": "ack"
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        harness.WorkflowDispatch.Command.Should().NotBeNull();
+        harness.WorkflowDispatch.Command!.Source.Kind.Should().Be(WorkflowChatSourceKind.DefinitionActor);
+        harness.WorkflowDispatch.Command.Source.ActorId.Should().Be("workflow-definition-actor");
+        harness.WorkflowDispatch.Command.Source.WorkflowName.Should().Be("wf-main");
+    }
+
+    [Fact]
+    public async Task aevatar_start_workflow_with_workflow_yamls_dispatches_inline_yaml_bundle_source_and_trims_blank_entries()
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync("aevatar_start_workflow");
+
+        using var _ = PushContext(callId: "call-workflow-yamls");
+        var output = await tool.ExecuteAsync("""
+            {
+              "workflow_id": " wf-main ",
+              "actor_id": " workflow-definition-actor ",
+              "workflow_yamls": [
+                "  name: first\nsteps: []  ",
+                "   ",
+                "",
+                "name: second\nsteps: []\n"
+              ],
+              "inputs": {
+                "prompt": "run workflow"
+              },
+              "wait": "ack"
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        harness.WorkflowDispatch.Command.Should().NotBeNull();
+        harness.WorkflowDispatch.Command!.Source.Kind.Should().Be(WorkflowChatSourceKind.InlineYamlBundle);
+        harness.WorkflowDispatch.Command.Source.ActorId.Should().Be("workflow-definition-actor");
+        harness.WorkflowDispatch.Command.Source.WorkflowName.Should().Be("wf-main");
+        harness.WorkflowDispatch.Command.Source.WorkflowYamls.Should().Equal(
+            "name: first\nsteps: []",
+            "name: second\nsteps: []");
+    }
+
+    [Fact]
     public async Task StartWorkflow_ShouldRejectPayloadHeaderCredentialOverrides()
     {
         var harness = new Harness();

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -1302,8 +1302,8 @@ public sealed class ScopeServiceEndpointsTests
         body.Should().Contain("aevatar.run.context");
         host.InteractionService.LastRequest.Should().NotBeNull();
         host.InteractionService.LastRequest!.ScopeId.Should().Be("scope-a");
-        host.InteractionService.LastRequest.WorkflowYamls.Should().NotBeNull();
-        host.InteractionService.LastRequest.WorkflowYamls.Should().HaveCount(2);
+        host.InteractionService.LastRequest.Source.WorkflowYamls.Should().NotBeNull();
+        host.InteractionService.LastRequest.Source.WorkflowYamls.Should().HaveCount(2);
     }
 
     [Fact]
@@ -1352,7 +1352,7 @@ public sealed class ScopeServiceEndpointsTests
         body.Should().Contain("\"humanInputRequest\"");
         body.Should().Contain("aevatar.run.context");
         host.InteractionService.LastRequest.Should().NotBeNull();
-        host.InteractionService.LastRequest!.WorkflowYamls.Should().HaveCount(1);
+        host.InteractionService.LastRequest!.Source.WorkflowYamls.Should().HaveCount(1);
     }
 
     [Fact]
@@ -1471,7 +1471,7 @@ public sealed class ScopeServiceEndpointsTests
         response.StatusCode.Should().Be(HttpStatusCode.OK, "stream body: {0}", body);
         body.Should().Contain("aevatar.run.context");
         host.InteractionService.LastRequest.Should().NotBeNull();
-        host.InteractionService.LastRequest!.ActorId.Should().Be("definition-actor-1");
+        host.InteractionService.LastRequest!.Source.ActorId.Should().Be("definition-actor-1");
         host.InteractionService.LastRequest.ScopeId.Should().Be("scope-a");
         host.InteractionService.LastRequest.Metadata.Should().ContainKey("source").WhoseValue.Should().Be("tests");
         // Service-run registry receives the actual workflow run actor id as the run id, so
@@ -2136,7 +2136,7 @@ public sealed class ScopeServiceEndpointsTests
         response.StatusCode.Should().Be(HttpStatusCode.OK, "stream body: {0}", body);
         body.Should().Contain("aevatar.run.context");
         host.InteractionService.LastRequest.Should().NotBeNull();
-        host.InteractionService.LastRequest!.ActorId.Should().Be("definition-actor-orders");
+        host.InteractionService.LastRequest!.Source.ActorId.Should().Be("definition-actor-orders");
         host.InteractionService.LastRequest.ScopeId.Should().Be("scope-a");
         host.InteractionService.LastRequest.Metadata.Should().ContainKey("channel").WhoseValue.Should().Be("tests");
     }
@@ -2219,7 +2219,7 @@ public sealed class ScopeServiceEndpointsTests
         response.StatusCode.Should().Be(HttpStatusCode.OK, "stream body: {0}", body);
         body.Should().Contain("aevatar.run.context");
         host.InteractionService.LastRequest.Should().NotBeNull();
-        host.InteractionService.LastRequest!.ActorId.Should().Be("definition-actor-member-a");
+        host.InteractionService.LastRequest!.Source.ActorId.Should().Be("definition-actor-member-a");
         host.InteractionService.LastRequest.ScopeId.Should().Be("scope-a");
         host.InteractionService.LastRequest.Metadata.Should().ContainKey("channel").WhoseValue.Should().Be("member-tests");
     }
@@ -2308,7 +2308,7 @@ public sealed class ScopeServiceEndpointsTests
         body.Should().Contain("aevatar.run.context");
         host.TeamEntryMemberResolver.Calls.Should().ContainSingle().Which.Should().Be(("scope-a", "team-a"));
         host.InteractionService.LastRequest.Should().NotBeNull();
-        host.InteractionService.LastRequest!.ActorId.Should().Be("definition-actor-member-a");
+        host.InteractionService.LastRequest!.Source.ActorId.Should().Be("definition-actor-member-a");
         host.InteractionService.LastRequest.ScopeId.Should().Be("scope-a");
         host.InteractionService.LastRequest.Metadata.Should().ContainKey("channel").WhoseValue.Should().Be("team-tests");
     }
@@ -2436,7 +2436,7 @@ public sealed class ScopeServiceEndpointsTests
         response.StatusCode.Should().Be(HttpStatusCode.OK, "stream body: {0}", body);
         body.Should().Contain("aevatar.run.context");
         host.InteractionService.LastRequest.Should().NotBeNull();
-        host.InteractionService.LastRequest!.ActorId.Should().Be("definition-actor-orders");
+        host.InteractionService.LastRequest!.Source.ActorId.Should().Be("definition-actor-orders");
         host.InteractionService.LastRequest.ScopeId.Should().Be("scope-a");
         host.InteractionService.LastRequest.Metadata.Should().ContainKey("channel").WhoseValue.Should().Be("tests");
     }

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
@@ -312,7 +312,7 @@ public sealed class ScopeWorkflowEndpointsTests
         body.Should().Contain("aevatar.run.context");
         body.Should().Contain("\"delta\": \"hello\"");
         interactionService.LastRequest.Should().NotBeNull();
-        interactionService.LastRequest!.ActorId.Should().Be("definition-actor-1");
+        interactionService.LastRequest!.Source.ActorId.Should().Be("definition-actor-1");
         interactionService.LastRequest.SessionId.Should().Be("session-1");
         interactionService.LastRequest.ScopeId.Should().Be("user-1");
         interactionService.LastRequest.Metadata.Should().ContainKey("source").WhoseValue.Should().Be("user-api");
@@ -406,7 +406,7 @@ public sealed class ScopeWorkflowEndpointsTests
         body.Should().Contain("\"textMessageContent\": { \"messageId\": \"msg-1\", \"delta\": \"hello\" }");
         body.Should().Contain("\"humanInputRequest\": { \"stepId\": \"approve\"");
         interactionService.LastRequest.Should().NotBeNull();
-        interactionService.LastRequest!.ActorId.Should().Be("definition-actor-1");
+        interactionService.LastRequest!.Source.ActorId.Should().Be("definition-actor-1");
         interactionService.LastRequest.ScopeId.Should().Be("user-1");
         interactionService.LastRequest.Metadata.Should().NotContainKey(WorkflowRunCommandMetadataKeys.ScopeId);
         interactionService.LastRequest.Metadata.Should().NotContainKey("scope_id");

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationLayerTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationLayerTests.cs
@@ -34,7 +34,7 @@ public sealed class WorkflowApplicationLayerTests
             new FakeDurableCompletionResolver());
 
         var result = await service.ExecuteAsync(
-            new WorkflowChatRunRequest("hello", "direct", null),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("direct")),
             static (_, _) => ValueTask.CompletedTask,
             ct: CancellationToken.None);
 
@@ -78,7 +78,7 @@ public sealed class WorkflowApplicationLayerTests
         var acceptedReceipts = new ConcurrentQueue<WorkflowChatRunAcceptedReceipt>();
 
         var result = await service.ExecuteAsync(
-            new WorkflowChatRunRequest("hello", "direct", null),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("direct")),
             (frame, _) =>
             {
                 emittedFrames.Enqueue(frame);
@@ -135,7 +135,7 @@ public sealed class WorkflowApplicationLayerTests
             new FakeDurableCompletionResolver());
 
         var executeTask = service.ExecuteAsync(
-            new WorkflowChatRunRequest("hello", "direct", null),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("direct")),
             static (_, _) => ValueTask.CompletedTask,
             async (acceptedReceipt, _) =>
             {
@@ -181,7 +181,7 @@ public sealed class WorkflowApplicationLayerTests
             new FakeDurableCompletionResolver());
 
         var act = () => service.ExecuteAsync(
-            new WorkflowChatRunRequest("hello", "direct", null),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("direct")),
             static (_, _) => ValueTask.CompletedTask,
             ct: CancellationToken.None);
 
@@ -220,7 +220,7 @@ public sealed class WorkflowApplicationLayerTests
                     WorkflowProjectionCompletionStatus.Completed)));
 
         var result = await service.ExecuteAsync(
-            new WorkflowChatRunRequest("hello", "direct", null),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("direct")),
             static (_, _) => ValueTask.CompletedTask,
             ct: CancellationToken.None);
 
@@ -250,7 +250,7 @@ public sealed class WorkflowApplicationLayerTests
             new FakeDurableCompletionResolver());
 
         var result = await service.ExecuteAsync(
-            new WorkflowChatRunRequest("hello", "direct", null),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("direct")),
             static (_, _) => ValueTask.CompletedTask,
             ct: CancellationToken.None);
 
@@ -273,7 +273,7 @@ public sealed class WorkflowApplicationLayerTests
         var service = CreateAcceptedOnlyDispatchService(
             pipeline);
 
-        var result = await service.DispatchAsync(new WorkflowChatRunRequest("hello", "missing", null));
+        var result = await service.DispatchAsync(new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("missing")));
 
         result.Succeeded.Should().BeFalse();
         result.Error.Should().Be(WorkflowChatRunStartError.WorkflowNotFound);
@@ -291,7 +291,7 @@ public sealed class WorkflowApplicationLayerTests
         var service = CreateAcceptedOnlyDispatchService(
             new FakeAcceptedDispatchPipeline { Result = AcceptedSuccess(target, receipt) });
 
-        var result = await service.DispatchAsync(new WorkflowChatRunRequest("hello", "direct", null));
+        var result = await service.DispatchAsync(new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("direct")));
 
         result.Succeeded.Should().BeTrue();
         result.Receipt.Should().Be(receipt);

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationRegistrationAndExecutionTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationRegistrationAndExecutionTests.cs
@@ -151,13 +151,13 @@ public sealed class WorkflowApplicationRegistrationAndExecutionTests
         options.DirectFallbackWorkflowWhitelist.Should().ContainSingle().Which.Should().Be("analysis");
         options.DirectFallbackExceptionWhitelist.Should().ContainSingle().Which.Should().Be(typeof(TimeoutException));
 
-        policy.ShouldFallback(new WorkflowChatRunRequest("hello", "analysis", null), new TimeoutException("timeout"))
+        policy.ShouldFallback(new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("analysis")), new TimeoutException("timeout"))
             .Should().BeTrue();
         policy.ShouldFallback(
-                new WorkflowChatRunRequest("hello", "analysis", null),
+                new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("analysis")),
                 new WorkflowDirectFallbackTriggerException("boom"))
             .Should().BeFalse();
-        policy.ShouldFallback(new WorkflowChatRunRequest("hello", "analysis", null), new InvalidOperationException("boom"))
+        policy.ShouldFallback(new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("analysis")), new InvalidOperationException("boom"))
             .Should().BeFalse();
     }
 
@@ -283,8 +283,7 @@ public sealed class WorkflowApplicationRegistrationAndExecutionTests
             });
         var command = new WorkflowChatRunRequest(
             "hello",
-            "direct",
-            "actor-1",
+            WorkflowChatSource.DefinitionActor("actor-1", "direct"),
             SessionId: "session-42",
             Metadata: new Dictionary<string, string>(StringComparer.Ordinal)
             {
@@ -318,8 +317,7 @@ public sealed class WorkflowApplicationRegistrationAndExecutionTests
         var factory = provider.GetRequiredService<ICommandEnvelopeFactory<WorkflowChatRunRequest>>();
         var command = new WorkflowChatRunRequest(
             "describe this",
-            null,
-            "actor-1",
+            WorkflowChatSource.DefinitionActor("actor-1"),
             InputParts:
             [
                 new WorkflowChatInputPart
@@ -361,7 +359,7 @@ public sealed class WorkflowApplicationRegistrationAndExecutionTests
         services.AddWorkflowApplication();
         using var provider = services.BuildServiceProvider();
         var factory = provider.GetRequiredService<ICommandEnvelopeFactory<WorkflowChatRunRequest>>();
-        var command = new WorkflowChatRunRequest("hello", null, null);
+        var command = new WorkflowChatRunRequest("hello", WorkflowChatSource.Direct());
 
         var noMetadata = factory.CreateEnvelope(command, new CommandContext(
             "actor-2",
@@ -370,7 +368,7 @@ public sealed class WorkflowApplicationRegistrationAndExecutionTests
             new Dictionary<string, string>()));
         noMetadata.Payload.Unpack<ChatRequestEvent>().SessionId.Should().Be("corr-2");
 
-        var whiteSpaceSession = factory.CreateEnvelope(new WorkflowChatRunRequest("hello", null, null, SessionId: "   "), new CommandContext(
+        var whiteSpaceSession = factory.CreateEnvelope(new WorkflowChatRunRequest("hello", WorkflowChatSource.Direct(), SessionId: "   "), new CommandContext(
             "actor-3",
             "cmd-3",
             "corr-3",

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunActorResolverTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunActorResolverTests.cs
@@ -18,7 +18,7 @@ public sealed class WorkflowRunActorResolverTests
         var resolver = new WorkflowRunActorResolver(bindingReader, actorPort, actorPort, registry);
 
         var result = await resolver.ResolveOrCreateAsync(
-            new WorkflowChatRunRequest("hello", " direct ", null),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow(" direct ")),
             CancellationToken.None);
 
         result.Error.Should().Be(WorkflowChatRunStartError.None);
@@ -41,8 +41,7 @@ public sealed class WorkflowRunActorResolverTests
         var result = await resolver.ResolveOrCreateAsync(
             new WorkflowChatRunRequest(
                 "hello",
-                "direct",
-                null,
+                WorkflowChatSource.CatalogWorkflow("direct"),
                 ScopeId: "scope-user-1"),
             CancellationToken.None);
 
@@ -64,7 +63,7 @@ public sealed class WorkflowRunActorResolverTests
             });
 
         var result = await resolver.ResolveOrCreateAsync(
-            new WorkflowChatRunRequest("hello", null, null),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.Direct()),
             CancellationToken.None);
 
         result.Error.Should().Be(WorkflowChatRunStartError.None);
@@ -85,7 +84,7 @@ public sealed class WorkflowRunActorResolverTests
             });
 
         var result = await resolver.ResolveOrCreateAsync(
-            new WorkflowChatRunRequest("hello", null, null),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.Direct()),
             CancellationToken.None);
 
         result.Error.Should().Be(WorkflowChatRunStartError.None);
@@ -100,7 +99,7 @@ public sealed class WorkflowRunActorResolverTests
         var resolver = new WorkflowRunActorResolver(new StaticWorkflowActorBindingReader(null), new RecordingWorkflowRunActorPort(), new RecordingWorkflowRunActorPort(), new InMemoryWorkflowDefinitionCatalog());
 
         var result = await resolver.ResolveOrCreateAsync(
-            new WorkflowChatRunRequest("hello", "missing", null),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("missing")),
             CancellationToken.None);
 
         result.Error.Should().Be(WorkflowChatRunStartError.WorkflowNotFound);
@@ -141,7 +140,9 @@ public sealed class WorkflowRunActorResolverTests
         var resolver = new WorkflowRunActorResolver(bindingReader, actorPort, actorPort, new InMemoryWorkflowDefinitionCatalog());
 
         var result = await resolver.ResolveOrCreateAsync(
-            new WorkflowChatRunRequest("hello", null, "agent-1", WorkflowYamls: [entryWorkflowYaml, helperWorkflowYaml]),
+            new WorkflowChatRunRequest(
+                "hello",
+                WorkflowChatSource.InlineYamlBundle([entryWorkflowYaml, helperWorkflowYaml], actorId: "agent-1")),
             CancellationToken.None);
 
         result.Error.Should().Be(WorkflowChatRunStartError.None);
@@ -188,8 +189,6 @@ public sealed class WorkflowRunActorResolverTests
         var result = await resolver.ResolveOrCreateAsync(
             new WorkflowChatRunRequest(
                 "hello",
-                null,
-                null,
                 ScopeId: "request-scope-1",
                 Source: WorkflowChatSource.InlineYamlBundle([entryWorkflowYaml], actorId: sourceActorId)),
             CancellationToken.None);
@@ -232,10 +231,9 @@ public sealed class WorkflowRunActorResolverTests
         var result = await resolver.ResolveOrCreateAsync(
             new WorkflowChatRunRequest(
                 "hello",
-                "direct",
-                sourceActorId,
+                WorkflowChatSource.DefinitionActor(sourceActorId, "direct"),
                 ScopeId: "request-scope-1",
-                Source: WorkflowChatSource.DefinitionActor(sourceActorId, "direct")),
+                LlmControl: null),
             CancellationToken.None);
 
         result.Error.Should().Be(WorkflowChatRunStartError.None);
@@ -271,7 +269,9 @@ public sealed class WorkflowRunActorResolverTests
         var resolver = new WorkflowRunActorResolver(bindingReader, actorPort, actorPort, new InMemoryWorkflowDefinitionCatalog());
 
         var result = await resolver.ResolveOrCreateAsync(
-            new WorkflowChatRunRequest("hello", null, "agent-1", WorkflowYamls: [entryWorkflowYaml]),
+            new WorkflowChatRunRequest(
+                "hello",
+                WorkflowChatSource.InlineYamlBundle([entryWorkflowYaml], actorId: "agent-1")),
             CancellationToken.None);
 
         result.Error.Should().Be(WorkflowChatRunStartError.WorkflowBindingMismatch);
@@ -300,7 +300,9 @@ public sealed class WorkflowRunActorResolverTests
         var resolver = new WorkflowRunActorResolver(new StaticWorkflowActorBindingReader(null), actorPort, actorPort, new InMemoryWorkflowDefinitionCatalog());
 
         var result = await resolver.ResolveOrCreateAsync(
-            new WorkflowChatRunRequest("hello", "auto", null, WorkflowYamls: [entryWorkflowYaml, helperWorkflowYaml]),
+            new WorkflowChatRunRequest(
+                "hello",
+                WorkflowChatSource.InlineYamlBundle([entryWorkflowYaml, helperWorkflowYaml], "auto")),
             CancellationToken.None);
 
         result.Error.Should().Be(WorkflowChatRunStartError.WorkflowNameMismatch);
@@ -317,7 +319,7 @@ public sealed class WorkflowRunActorResolverTests
         var resolver = new WorkflowRunActorResolver(new StaticWorkflowActorBindingReader(null), actorPort, actorPort, new InMemoryWorkflowDefinitionCatalog());
 
         var result = await resolver.ResolveOrCreateAsync(
-            new WorkflowChatRunRequest("hello", null, null, WorkflowYamls: ["bad"]),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.InlineYamlBundle(["bad"])),
             CancellationToken.None);
 
         result.Error.Should().Be(WorkflowChatRunStartError.InvalidWorkflowYaml);
@@ -345,7 +347,7 @@ public sealed class WorkflowRunActorResolverTests
         var resolver = new WorkflowRunActorResolver(new StaticWorkflowActorBindingReader(null), actorPort, actorPort, new InMemoryWorkflowDefinitionCatalog());
 
         var result = await resolver.ResolveOrCreateAsync(
-            new WorkflowChatRunRequest("hello", null, null, WorkflowYamls: [firstYaml, secondYaml]),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.InlineYamlBundle([firstYaml, secondYaml])),
             CancellationToken.None);
 
         result.Error.Should().Be(WorkflowChatRunStartError.InvalidWorkflowYaml);
@@ -358,7 +360,7 @@ public sealed class WorkflowRunActorResolverTests
         var resolver = new WorkflowRunActorResolver(new StaticWorkflowActorBindingReader(null), new RecordingWorkflowRunActorPort(), new RecordingWorkflowRunActorPort(), new InMemoryWorkflowDefinitionCatalog());
 
         var result = await resolver.ResolveOrCreateAsync(
-            new WorkflowChatRunRequest("hello", null, "agent-404"),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.DefinitionActor("agent-404")),
             CancellationToken.None);
 
         result.Error.Should().Be(WorkflowChatRunStartError.AgentNotFound);
@@ -371,7 +373,7 @@ public sealed class WorkflowRunActorResolverTests
         var resolver = new WorkflowRunActorResolver(new StaticWorkflowActorBindingReader(WorkflowActorBinding.Unsupported("agent-1")), new RecordingWorkflowRunActorPort(), new RecordingWorkflowRunActorPort(), new InMemoryWorkflowDefinitionCatalog());
 
         var result = await resolver.ResolveOrCreateAsync(
-            new WorkflowChatRunRequest("hello", null, "agent-1"),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.DefinitionActor("agent-1")),
             CancellationToken.None);
 
         result.Error.Should().Be(WorkflowChatRunStartError.AgentTypeNotSupported);
@@ -396,7 +398,7 @@ public sealed class WorkflowRunActorResolverTests
             new InMemoryWorkflowDefinitionCatalog());
 
         var result = await resolver.ResolveOrCreateAsync(
-            new WorkflowChatRunRequest("hello", null, "agent-1"),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.DefinitionActor("agent-1")),
             CancellationToken.None);
 
         result.Error.Should().Be(WorkflowChatRunStartError.AgentWorkflowNotConfigured);
@@ -420,7 +422,7 @@ public sealed class WorkflowRunActorResolverTests
             new InMemoryWorkflowDefinitionCatalog());
 
         var result = await resolver.ResolveOrCreateAsync(
-            new WorkflowChatRunRequest("hello", "requested", "agent-1"),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.DefinitionActor("agent-1", "requested")),
             CancellationToken.None);
 
         result.Error.Should().Be(WorkflowChatRunStartError.WorkflowBindingMismatch);
@@ -448,7 +450,7 @@ public sealed class WorkflowRunActorResolverTests
             registry);
 
         var result = await resolver.ResolveOrCreateAsync(
-            new WorkflowChatRunRequest("hello", null, "agent-1"),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.DefinitionActor("agent-1")),
             CancellationToken.None);
 
         result.Error.Should().Be(WorkflowChatRunStartError.None);
@@ -478,7 +480,7 @@ public sealed class WorkflowRunActorResolverTests
             registry);
 
         var result = await resolver.ResolveOrCreateAsync(
-            new WorkflowChatRunRequest("hello", null, "agent-1"),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.DefinitionActor("agent-1")),
             CancellationToken.None);
 
         result.Error.Should().Be(WorkflowChatRunStartError.None);
@@ -522,7 +524,7 @@ public sealed class WorkflowRunActorResolverTests
         var resolver = new WorkflowRunActorResolver(bindingReader, actorPort, actorPort, registry);
 
         var boundResult = await resolver.ResolveOrCreateAsync(
-            new WorkflowChatRunRequest("hello", null, opaqueActorId),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.DefinitionActor(opaqueActorId)),
             CancellationToken.None);
 
         boundResult.Error.Should().Be(WorkflowChatRunStartError.None);
@@ -535,7 +537,7 @@ public sealed class WorkflowRunActorResolverTests
         actorPort.CreateRunBindings.Clear();
 
         var freshResult = await resolver.ResolveOrCreateAsync(
-            new WorkflowChatRunRequest("hello", "direct", null),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("direct")),
             CancellationToken.None);
 
         freshResult.Error.Should().Be(WorkflowChatRunStartError.None);
@@ -564,7 +566,7 @@ public sealed class WorkflowRunActorResolverTests
             new InMemoryWorkflowDefinitionCatalog());
 
         var result = await resolver.ResolveOrCreateAsync(
-            new WorkflowChatRunRequest("hello", null, "agent-1"),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.DefinitionActor("agent-1")),
             CancellationToken.None);
 
         result.Error.Should().Be(WorkflowChatRunStartError.AgentWorkflowNotConfigured);
@@ -583,7 +585,7 @@ public sealed class WorkflowRunActorResolverTests
         var resolver = new WorkflowRunActorResolver(new StaticWorkflowActorBindingReader(null), actorPort, actorPort, registry);
 
         var act = async () => await resolver.ResolveOrCreateAsync(
-            new WorkflowChatRunRequest("hello", "direct", null),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("direct")),
             CancellationToken.None);
 
         var ex = await act.Should().ThrowAsync<WorkflowDirectFallbackTriggerException>();
@@ -607,7 +609,7 @@ public sealed class WorkflowRunActorResolverTests
         var resolver = new WorkflowRunActorResolver(new StaticWorkflowActorBindingReader(null), actorPort, actorPort, new InMemoryWorkflowDefinitionCatalog());
 
         var act = async () => await resolver.ResolveOrCreateAsync(
-            new WorkflowChatRunRequest("hello", null, null, WorkflowYamls: [entryWorkflowYaml]),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.InlineYamlBundle([entryWorkflowYaml])),
             CancellationToken.None);
 
         var ex = await act.Should().ThrowAsync<InvalidOperationException>();

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
@@ -561,7 +561,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
             new FakeWorkflowRunActorPort(),
             new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
 
-        var result = await resolver.ResolveAsync(new WorkflowChatRunRequest("hello", "auto", null), CancellationToken.None);
+        var result = await resolver.ResolveAsync(new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("auto")), CancellationToken.None);
 
         result.Succeeded.Should().BeFalse();
         result.Error.Should().Be(WorkflowChatRunStartError.AgentNotFound);
@@ -588,7 +588,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
 
         var context = new CommandContext("actor-1", "cmd-1", "corr-1", new Dictionary<string, string>());
         var act = async () => await lifecycle.BindAsync(
-            new WorkflowChatRunRequest("hello", "workflow-1", null),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("workflow-1")),
             new CommandDispatchExecution<WorkflowRunCommandTarget, WorkflowChatRunAcceptedReceipt>
             {
                 Target = target,

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunFallbackCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunFallbackCoverageTests.cs
@@ -44,11 +44,13 @@ public sealed class WorkflowRunFallbackCoverageTests
         var policy = new WorkflowDirectFallbackPolicy(options);
         var request = new WorkflowChatRunRequest(
             Prompt: "hello",
-            WorkflowName: workflowName,
-            ActorId: null,
+            Source: hasInlineYamls
+                ? WorkflowChatSource.InlineYamlBundle(["name: inline"], workflowName)
+                : string.IsNullOrWhiteSpace(workflowName)
+                    ? WorkflowChatSource.Direct()
+                    : WorkflowChatSource.CatalogWorkflow(workflowName),
             SessionId: null,
-            InputParts: null,
-            WorkflowYamls: hasInlineYamls ? ["name: inline"] : null);
+            InputParts: null);
         Exception exception = operationCanceled
             ? new OperationCanceledException("cancelled")
             : whitelistedException
@@ -66,17 +68,14 @@ public sealed class WorkflowRunFallbackCoverageTests
         var policy = new WorkflowDirectFallbackPolicy();
         var request = new WorkflowChatRunRequest(
             "hello",
-            "auto",
-            "actor-1",
+            WorkflowChatSource.InlineYamlBundle(["name: inline"], "auto", "actor-1"),
             SessionId: "session-1",
-            WorkflowYamls: ["name: inline"]);
+            Metadata: null);
 
         var fallback = policy.ToFallbackRequest(request);
 
-        fallback.WorkflowName.Should().Be(WorkflowRunBehaviorOptions.DirectWorkflowName);
-        fallback.WorkflowYamls.Should().BeNull();
+        fallback.Source.Should().BeEquivalentTo(WorkflowChatSource.CatalogWorkflow(WorkflowRunBehaviorOptions.DirectWorkflowName));
         fallback.Prompt.Should().Be(request.Prompt);
-        fallback.ActorId.Should().BeNull();
         fallback.SessionId.Should().Be(request.SessionId);
     }
 
@@ -96,7 +95,7 @@ public sealed class WorkflowRunFallbackCoverageTests
         var policy = new WorkflowDirectFallbackPolicy(options);
 
         var shouldFallback = policy.ShouldFallback(
-            new WorkflowChatRunRequest("hello", WorkflowName: null, ActorId: "actor-1"),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.DefinitionActor("actor-1")),
             new WorkflowDirectFallbackTriggerException("fallback"));
 
         shouldFallback.Should().BeTrue();
@@ -145,13 +144,13 @@ public sealed class WorkflowRunFallbackCoverageTests
             logger: null);
 
         var result = await service.ExecuteAsync(
-            new WorkflowChatRunRequest("hello", "auto", "actor-requested"),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.DefinitionActor("actor-requested", "auto")),
             static (_, _) => ValueTask.CompletedTask,
             ct: CancellationToken.None);
 
         result.Succeeded.Should().BeTrue();
-        pipeline.Requests.Select(static x => x.WorkflowName).Should().Equal("auto", "direct");
-        pipeline.Requests.Select(static x => x.ActorId).Should().Equal("actor-requested", null);
+        pipeline.Requests.Select(static x => x.Source.WorkflowName).Should().Equal("auto", "direct");
+        pipeline.Requests.Select(static x => x.Source.ActorId).Should().Equal("actor-requested", null);
         actorPort.DestroyCalls.Should().ContainSingle().Which.Should().Be("actor-1");
     }
 
@@ -169,12 +168,12 @@ public sealed class WorkflowRunFallbackCoverageTests
             logger: null);
 
         var result = await service.DispatchAsync(
-            new WorkflowChatRunRequest("hello", "auto", "actor-requested"),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.DefinitionActor("actor-requested", "auto")),
             CancellationToken.None);
 
         result.Succeeded.Should().BeTrue();
-        dispatchService.Requests.Select(static x => x.WorkflowName).Should().Equal("auto", "direct");
-        dispatchService.Requests.Select(static x => x.ActorId).Should().Equal("actor-requested", null);
+        dispatchService.Requests.Select(static x => x.Source.WorkflowName).Should().Equal("auto", "direct");
+        dispatchService.Requests.Select(static x => x.Source.ActorId).Should().Equal("actor-requested", null);
     }
 
     private static WorkflowRunCommandTarget CreateBoundTarget(

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
@@ -23,7 +23,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
             new FakeWorkflowRunActorPort(),
             new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
 
-        var result = await resolver.ResolveAsync(new WorkflowChatRunRequest("hello", "auto", null));
+        var result = await resolver.ResolveAsync(new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("auto")));
 
         result.Succeeded.Should().BeFalse();
         result.Error.Should().Be(WorkflowChatRunStartError.ProjectionDisabled);
@@ -41,7 +41,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
             new FakeWorkflowRunActorPort(),
             new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
 
-        var result = await resolver.ResolveAsync(new WorkflowChatRunRequest("hello", "auto", null));
+        var result = await resolver.ResolveAsync(new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("auto")));
 
         result.Succeeded.Should().BeTrue();
         result.Target.Should().NotBeNull();
@@ -61,7 +61,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
                 new WorkflowActorResolutionResult(new WorkflowRunCreationReceipt(actor.Id, string.Empty, ["definition-1", "actor-accepted"]), "direct", WorkflowChatRunStartError.None)),
             actorPort);
 
-        var result = await resolver.ResolveAsync(new WorkflowChatRunRequest("hello", "direct", null), CancellationToken.None);
+        var result = await resolver.ResolveAsync(new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("direct")), CancellationToken.None);
 
         result.Succeeded.Should().BeTrue();
         result.Target.Should().NotBeNull();
@@ -80,7 +80,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
             actorResolver,
             new FakeWorkflowRunActorPort());
 
-        var result = await resolver.ResolveAsync(new WorkflowChatRunRequest("hello", "auto", null));
+        var result = await resolver.ResolveAsync(new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("auto")));
 
         result.Succeeded.Should().BeTrue();
         actorResolver.ResolveCallCount.Should().Be(1);
@@ -95,7 +95,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
             actorResolver,
             new FakeWorkflowRunActorPort());
 
-        var result = await resolver.ResolveAsync(new WorkflowChatRunRequest("hello", "missing", null));
+        var result = await resolver.ResolveAsync(new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("missing")));
 
         result.Succeeded.Should().BeFalse();
         result.Error.Should().Be(WorkflowChatRunStartError.WorkflowNotFound);
@@ -209,7 +209,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
             actorPort,
             new WorkflowRunDurableCompletionResolver(queryPort));
 
-        var result = await resolver.ResolveAsync(new WorkflowChatRunRequest("hello", "direct", null), CancellationToken.None);
+        var result = await resolver.ResolveAsync(new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("direct")), CancellationToken.None);
         result.Target.Should().NotBeNull();
         result.Target!.BindLiveObservation(
             new FakeProjectionLease("actor-1", "cmd-1"),
@@ -245,7 +245,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
             new Dictionary<string, string>());
 
         var result = await lifecycle.BindAsync(
-            new WorkflowChatRunRequest("hello", "direct", null),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("direct")),
             CreateExecution(target, context),
             CancellationToken.None);
 
@@ -281,7 +281,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
             new Dictionary<string, string>());
 
         var result = await lifecycle.BindAsync(
-            new WorkflowChatRunRequest("hello", "direct", null),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("direct")),
             CreateExecution(target, context),
             CancellationToken.None);
 
@@ -315,7 +315,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
             new Dictionary<string, string>());
 
         var act = () => lifecycle.BindAsync(
-            new WorkflowChatRunRequest("hello", "direct", null),
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.CatalogWorkflow("direct")),
             CreateExecution(target, context),
             CancellationToken.None);
 

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
@@ -37,7 +37,7 @@ public sealed class ChatEndpointsInternalTests
         var body = await ReadBodyAsync(http.Response);
 
         service.LastCommand.Should().NotBeNull();
-        service.LastCommand!.WorkflowName.Should().Be("direct");
+        service.LastCommand!.Source.WorkflowName.Should().Be("direct");
         http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
         body.Should().Contain("cmd-1");
         body.Should().Contain("corr-1");
@@ -115,7 +115,7 @@ public sealed class ChatEndpointsInternalTests
         http.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
         body.Should().Contain("WORKFLOW_NOT_FOUND");
         service.LastCommand.Should().NotBeNull();
-        service.LastCommand!.WorkflowName.Should().Be("missing");
+        service.LastCommand!.Source.WorkflowName.Should().Be("missing");
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowCapabilityEndpointsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowCapabilityEndpointsCoverageTests.cs
@@ -26,12 +26,9 @@ public sealed class WorkflowCapabilityEndpointsCoverageTests
         result.Request.Should().BeEquivalentTo(
             new WorkflowChatRunRequest(
                 "hello",
-                "auto",
-                "actor-1",
+                WorkflowChatSource.InlineYamlBundle(["name: inline"], "auto", "actor-1"),
                 SessionId: "session-1",
-                WorkflowYamls: ["name: inline"],
-                Metadata: new Dictionary<string, string>(),
-                Source: WorkflowChatSource.InlineYamlBundle(["name: inline"], "auto", "actor-1")));
+                Metadata: new Dictionary<string, string>()));
     }
 
     [Fact]
@@ -50,12 +47,9 @@ public sealed class WorkflowCapabilityEndpointsCoverageTests
         result.Request.Should().BeEquivalentTo(
             new WorkflowChatRunRequest(
                 "hello",
-                null,
-                "actor-1",
+                WorkflowChatSource.InlineYamlBundle(["name: inline"], actorId: "actor-1"),
                 SessionId: null,
-                WorkflowYamls: ["name: inline"],
-                Metadata: new Dictionary<string, string>(),
-                Source: WorkflowChatSource.InlineYamlBundle(["name: inline"], actorId: "actor-1")));
+                Metadata: new Dictionary<string, string>()));
     }
 
     [Fact]
@@ -103,11 +97,9 @@ public sealed class WorkflowCapabilityEndpointsCoverageTests
         result.Request.Should().BeEquivalentTo(
             new WorkflowChatRunRequest(
                 "hello",
-                null,
-                null,
-                null,
+                WorkflowChatSource.Direct(),
                 Metadata: new Dictionary<string, string>(),
-                Source: WorkflowChatSource.Direct()));
+                LlmControl: null));
     }
 
     [Fact]
@@ -148,6 +140,35 @@ public sealed class WorkflowCapabilityEndpointsCoverageTests
     }
 
     [Fact]
+    public void ChatRunRequestNormalizer_ShouldNormalizeTypedAndLegacyInputsToEquivalentTypedSource()
+    {
+        var typed = ChatRunRequestNormalizer.Normalize(new ChatInput
+        {
+            Prompt = "hello",
+            Source = new WorkflowChatSourceInput
+            {
+                Kind = "inline-yaml-bundle",
+                WorkflowName = " auto ",
+                ActorId = " source-actor-1 ",
+                WorkflowYamls = ["name: auto"],
+            },
+        });
+        var legacy = ChatRunRequestNormalizer.Normalize(new ChatInput
+        {
+            Prompt = "hello",
+            Workflow = " auto ",
+            AgentId = " source-actor-1 ",
+            WorkflowYamls = ["name: auto"],
+        });
+
+        typed.Succeeded.Should().BeTrue();
+        legacy.Succeeded.Should().BeTrue();
+        typed.Request!.Source.Should().BeEquivalentTo(legacy.Request!.Source);
+        typed.Request.Source.Should().BeEquivalentTo(
+            WorkflowChatSource.InlineYamlBundle(["name: auto"], "auto", "source-actor-1"));
+    }
+
+    [Fact]
     public void ChatRunRequestNormalizer_ShouldPreserveTypedInlineYamlSourceActorId()
     {
         var input = new ChatInput
@@ -167,7 +188,7 @@ public sealed class WorkflowCapabilityEndpointsCoverageTests
         result.Succeeded.Should().BeTrue();
         result.Request!.Source.Should().BeEquivalentTo(
             WorkflowChatSource.InlineYamlBundle(["name: auto"], "auto", "source-actor-1"));
-        result.Request.ActorId.Should().Be("source-actor-1");
+        result.Request.Source.ActorId.Should().Be("source-actor-1");
     }
 
     [Fact]
@@ -185,8 +206,8 @@ public sealed class WorkflowCapabilityEndpointsCoverageTests
         result.Succeeded.Should().BeTrue();
         result.Request!.Source.Should().BeEquivalentTo(
             WorkflowChatSource.DefinitionActor("source-actor-1", "direct"));
-        result.Request.WorkflowName.Should().Be("direct");
-        result.Request.ActorId.Should().Be("source-actor-1");
+        result.Request.Source.WorkflowName.Should().Be("direct");
+        result.Request.Source.ActorId.Should().Be("source-actor-1");
     }
 
     [Theory]
@@ -277,9 +298,7 @@ public sealed class WorkflowCapabilityEndpointsCoverageTests
         result.Request.Should().BeEquivalentTo(
             new WorkflowChatRunRequest(
                 "describe this",
-                null,
-                null,
-                null,
+                WorkflowChatSource.Direct(),
                 InputParts:
                 [
                     new WorkflowChatInputPart
@@ -296,7 +315,7 @@ public sealed class WorkflowCapabilityEndpointsCoverageTests
                     },
                 ],
                 Metadata: new Dictionary<string, string>(),
-                Source: WorkflowChatSource.Direct()));
+                LlmControl: null));
     }
 
     [Fact]


### PR DESCRIPTION
## 摘要

iter112 cluster-3:WorkflowChatRunRequest 双 source surface(high,RM-SIDEREAD / STATE-AUTH 相关)。

- **Old**:Application 层 `WorkflowChatRunRequest` 同时持 typed `WorkflowChatSource` + legacy mirror 字段 + resolver fallback(双重表示同一事实)
- **New**:Application 层只持 typed `WorkflowChatSource`(单一表示);Host 边界保留 wire-level legacy aliases + 一次性 normalize 到 typed source(internal static helper);不改 docs/canon

违反:CLAUDE.md「API 字段单一语义」+「字段命名与 Metadata 决策树:核心语义强类型,不因未来可能扩展先放 bag」。

## 范围

18 files changed (+158/-155)。Application + Application.Abstractions + Infrastructure/CapabilityApi + Host.Api + 对应 test。

完整 Phase 9 r2 共识链路(reflector r2 narrow-no-canon-edit ruling + 3/3 unanimous propose-delete framing):https://github.com/aevatarAI/aevatar/issues/1091

## Phase 9 共识 / Phase 8 工作流

Base = `auto-refact-dev`(integration branch)。closes #1091。

implement 经历:r1 SCOPE_EXTEND blocked(scope 误)→ r2/r3 API 503 死 mid-stream → r4 resume from staged changes 完整 implement + full slnx test pass。

🤖 Auto-loop / codex-refactor-loop iter112

⟦AI:AUTO-LOOP⟧
