### PR TITLE
iter149 #1133: actor-owned ScriptRunOutcome event/session-only(narrow Script outcome channel)

### DIFF
--- a/src/Aevatar.Scripting.Abstractions/script_host_messages.proto
+++ b/src/Aevatar.Scripting.Abstractions/script_host_messages.proto
@@ -124,6 +124,7 @@ message ScriptBehaviorState {
   string read_model_descriptor_full_name = 17;
   ScriptRuntimeSemanticsSpec runtime_semantics = 18;
   string scope_id = 19;
+  ScriptRunOutcomeRecordedEvent last_run_outcome = 20;
 }
 
 message ScriptCatalogEntryState {
@@ -271,6 +272,29 @@ message RunScriptRequestedEvent {
   string command_id = 6;
   string correlation_id = 7;
   string scope_id = 8;
+}
+
+enum ScriptRunOutcomeStatus {
+  SCRIPT_RUN_OUTCOME_STATUS_UNSPECIFIED = 0;
+  SCRIPT_RUN_OUTCOME_STATUS_SUCCEEDED = 1;
+  SCRIPT_RUN_OUTCOME_STATUS_FAILED = 2;
+}
+
+message ScriptRunOutcomeRecordedEvent {
+  string script_run_id = 1;
+  ScriptRunOutcomeStatus status = 2;
+  string error = 3;
+  google.protobuf.Any result = 4;
+  string actor_id = 5;
+  string definition_actor_id = 6;
+  string script_id = 7;
+  string script_revision = 8;
+  string command_id = 9;
+  string correlation_id = 10;
+  string scope_id = 11;
+  int32 committed_fact_count = 12;
+  int64 state_version = 13;
+  int64 occurred_at_unix_time_ms = 14;
 }
 
 message BindScriptBehaviorRequestedEvent {

--- a/src/Aevatar.Scripting.Core/ScriptBehaviorGAgent.cs
+++ b/src/Aevatar.Scripting.Core/ScriptBehaviorGAgent.cs
@@ -184,19 +184,19 @@ public sealed class ScriptBehaviorGAgent : GAgentBase<ScriptBehaviorState>
             throw;
         }
 
-        if (facts.Count > 0)
-            await PersistDomainEventsAsync(facts, ct);
-
         if (run == null)
+        {
+            if (facts.Count > 0)
+                await PersistDomainEventsAsync(facts, ct);
             return;
+        }
 
         var result = facts.Count == 0
             ? null
             : facts[^1].DomainEventPayload?.Clone();
-        var stateVersion = facts.Count == 0
-            ? State.LastAppliedEventVersion + 1
-            : State.LastAppliedEventVersion;
-        await PersistDomainEventAsync(
+        var currentVersion = State.LastAppliedEventVersion;
+        var outcomeStateVersion = currentVersion + facts.Count + 1;
+        var outcomeEvent =
             BuildOutcomeRecordedEvent(
                 runId,
                 commandId,
@@ -206,8 +206,8 @@ public sealed class ScriptBehaviorGAgent : GAgentBase<ScriptBehaviorState>
                 string.Empty,
                 result,
                 facts.Count,
-                stateVersion),
-            ct);
+                outcomeStateVersion);
+        await PersistDomainEventsAsync(facts.Concat<IMessage>([outcomeEvent]).ToList(), ct);
     }
 
     private void ValidateRunTarget(RunScriptRequestedEvent? run)

--- a/src/Aevatar.Scripting.Core/ScriptBehaviorGAgent.cs
+++ b/src/Aevatar.Scripting.Core/ScriptBehaviorGAgent.cs
@@ -13,6 +13,7 @@ namespace Aevatar.Scripting.Core;
 
 public sealed class ScriptBehaviorGAgent : GAgentBase<ScriptBehaviorState>
 {
+    // Refactor (iter149/cluster-1133): Old pattern: script run completion was inferred from domain fact/readmodel side effects.  New principle: script run completion is an actor-owned committed outcome event observed through the projection session channel.
     // Refactor (iter76/cluster-076-scripting-domain-fact-derived-readmodel-payloads):
     //   Old pattern: ScriptDomainFactCommitted persisted derived readmodel/native_document/native_graph payloads inside the domain event
     //   New principle: domain event keeps only committed facts; projection materializer derives readmodel/native_document/(optional)native_graph from fact + state_root
@@ -58,6 +59,7 @@ public sealed class ScriptBehaviorGAgent : GAgentBase<ScriptBehaviorState>
             .Match(current, evt)
             .On<ScriptBehaviorBoundEvent>(ApplyBound)
             .On<ScriptDomainFactCommitted>(ApplyCommittedFact)
+            .On<ScriptRunOutcomeRecordedEvent>(ApplyOutcomeRecorded)
             .OrCurrent();
 
     private async Task HandleBindRequestedAsync(
@@ -99,35 +101,36 @@ public sealed class ScriptBehaviorGAgent : GAgentBase<ScriptBehaviorState>
         EventEnvelope envelope,
         CancellationToken ct)
     {
+        // Refactor (iter149/cluster-1133): Old pattern: dispatch call sites inferred script run outcome from returned facts or readmodel visibility.  New principle: the actor commits a typed run outcome event for projection-session observation.
         EnsureBound();
 
-        if (envelope.Payload?.Is(RunScriptRequestedEvent.Descriptor) == true)
+        var run = ResolveRunRequest(envelope);
+        try
         {
-            var run = envelope.Payload.Unpack<RunScriptRequestedEvent>();
-            if (!string.IsNullOrWhiteSpace(run.DefinitionActorId) &&
-                !string.Equals(run.DefinitionActorId, State.DefinitionActorId, StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException(
-                    $"Runtime actor `{Id}` is bound to definition `{State.DefinitionActorId}`, but run targeted `{run.DefinitionActorId}`.");
-            }
-
-            if (!string.IsNullOrWhiteSpace(run.ScriptRevision) &&
-                !string.Equals(run.ScriptRevision, State.Revision, StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException(
-                    $"Runtime actor `{Id}` is bound to revision `{State.Revision}`, but run targeted `{run.ScriptRevision}`.");
-            }
-
-            if (!string.IsNullOrWhiteSpace(State.ScopeId) &&
-                !string.IsNullOrWhiteSpace(run.ScopeId) &&
-                !string.Equals(run.ScopeId, State.ScopeId, StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException(
-                    $"Runtime actor `{Id}` is bound to scope `{State.ScopeId}`, but run targeted `{run.ScopeId}`.");
-            }
+            ValidateRunTarget(run);
+        }
+        catch (Exception ex) when (run != null && ex is InvalidOperationException)
+        {
+            var failedScopeId = ResolveScopeId(envelope, State.ScopeId);
+            await PersistDomainEventAsync(
+                BuildOutcomeRecordedEvent(
+                    ResolveRunId(envelope),
+                    ResolveCommandId(envelope),
+                    ResolveCorrelationId(envelope),
+                    failedScopeId,
+                    ScriptRunOutcomeStatus.Failed,
+                    ex.Message,
+                    null,
+                    0,
+                    State.LastAppliedEventVersion + 1),
+                ct);
+            throw;
         }
 
         var scopeId = ResolveScopeId(envelope, State.ScopeId);
+        var runId = ResolveRunId(envelope);
+        var commandId = ResolveCommandId(envelope);
+        var correlationId = ResolveCorrelationId(envelope);
         var capabilities = _capabilityFactory.Create(
             new ScriptBehaviorRuntimeCapabilityContext(
                 ActorId: Id,
@@ -135,8 +138,8 @@ public sealed class ScriptBehaviorGAgent : GAgentBase<ScriptBehaviorState>
                 Revision: State.Revision ?? string.Empty,
                 DefinitionActorId: State.DefinitionActorId ?? string.Empty,
                 ScopeId: scopeId,
-                RunId: ResolveRunId(envelope),
-                CorrelationId: ResolveCorrelationId(envelope)),
+                RunId: runId,
+                CorrelationId: correlationId),
             publishAsync: (message, audience, token) => PublishAsync(message, audience, token),
             sendToAsync: (targetActorId, message, token) => SendToAsync(targetActorId, message, token),
             publishToSelfAsync: (message, token) => PublishAsync(message, TopologyAudience.Self, token),
@@ -144,27 +147,95 @@ public sealed class ScriptBehaviorGAgent : GAgentBase<ScriptBehaviorState>
                 ScheduleSelfDurableTimeoutAsync(callbackId, dueTime, message, ct: token),
             cancelCallbackAsync: CancelDurableCallbackAsync);
 
-        var facts = await _dispatcher.DispatchAsync(
-            new ScriptBehaviorDispatchRequest(
-                ActorId: Id,
-                DefinitionActorId: State.DefinitionActorId ?? string.Empty,
-                ScriptId: State.ScriptId ?? string.Empty,
-                Revision: State.Revision ?? string.Empty,
-                ScopeId: scopeId,
-                SourceHash: State.SourceHash ?? string.Empty,
-                ScriptPackage: RequireBoundPackage(State.ScriptPackage),
-                StateTypeUrl: State.StateTypeUrl ?? string.Empty,
-                ReadModelTypeUrl: State.ReadModelTypeUrl ?? string.Empty,
-                CurrentStateRoot: State.StateRoot?.Clone(),
-                CurrentStateVersion: State.LastAppliedEventVersion,
-                Envelope: envelope,
-                Capabilities: capabilities),
-            ct);
+        IReadOnlyList<ScriptDomainFactCommitted> facts;
+        try
+        {
+            facts = await _dispatcher.DispatchAsync(
+                new ScriptBehaviorDispatchRequest(
+                    ActorId: Id,
+                    DefinitionActorId: State.DefinitionActorId ?? string.Empty,
+                    ScriptId: State.ScriptId ?? string.Empty,
+                    Revision: State.Revision ?? string.Empty,
+                    ScopeId: scopeId,
+                    SourceHash: State.SourceHash ?? string.Empty,
+                    ScriptPackage: RequireBoundPackage(State.ScriptPackage),
+                    StateTypeUrl: State.StateTypeUrl ?? string.Empty,
+                    ReadModelTypeUrl: State.ReadModelTypeUrl ?? string.Empty,
+                    CurrentStateRoot: State.StateRoot?.Clone(),
+                    CurrentStateVersion: State.LastAppliedEventVersion,
+                    Envelope: envelope,
+                    Capabilities: capabilities),
+                ct);
+        }
+        catch (Exception ex) when (run != null && ex is not OperationCanceledException)
+        {
+            await PersistDomainEventAsync(
+                BuildOutcomeRecordedEvent(
+                    runId,
+                    commandId,
+                    correlationId,
+                    scopeId,
+                    ScriptRunOutcomeStatus.Failed,
+                    ex.Message,
+                    null,
+                    0,
+                    State.LastAppliedEventVersion + 1),
+                ct);
+            throw;
+        }
 
-        if (facts.Count == 0)
+        if (facts.Count > 0)
+            await PersistDomainEventsAsync(facts, ct);
+
+        if (run == null)
             return;
 
-        await PersistDomainEventsAsync(facts, ct);
+        var result = facts.Count == 0
+            ? null
+            : facts[^1].DomainEventPayload?.Clone();
+        var stateVersion = facts.Count == 0
+            ? State.LastAppliedEventVersion + 1
+            : State.LastAppliedEventVersion;
+        await PersistDomainEventAsync(
+            BuildOutcomeRecordedEvent(
+                runId,
+                commandId,
+                correlationId,
+                scopeId,
+                ScriptRunOutcomeStatus.Succeeded,
+                string.Empty,
+                result,
+                facts.Count,
+                stateVersion),
+            ct);
+    }
+
+    private void ValidateRunTarget(RunScriptRequestedEvent? run)
+    {
+        if (run == null)
+            return;
+
+        if (!string.IsNullOrWhiteSpace(run.DefinitionActorId) &&
+            !string.Equals(run.DefinitionActorId, State.DefinitionActorId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Runtime actor `{Id}` is bound to definition `{State.DefinitionActorId}`, but run targeted `{run.DefinitionActorId}`.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(run.ScriptRevision) &&
+            !string.Equals(run.ScriptRevision, State.Revision, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Runtime actor `{Id}` is bound to revision `{State.Revision}`, but run targeted `{run.ScriptRevision}`.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(State.ScopeId) &&
+            !string.IsNullOrWhiteSpace(run.ScopeId) &&
+            !string.Equals(run.ScopeId, State.ScopeId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Runtime actor `{Id}` is bound to scope `{State.ScopeId}`, but run targeted `{run.ScopeId}`.");
+        }
     }
 
     private static ScriptBehaviorState ApplyBound(
@@ -256,6 +327,53 @@ public sealed class ScriptBehaviorGAgent : GAgentBase<ScriptBehaviorState>
         return next;
     }
 
+    private ScriptRunOutcomeRecordedEvent BuildOutcomeRecordedEvent(
+        string runId,
+        string commandId,
+        string correlationId,
+        string scopeId,
+        ScriptRunOutcomeStatus status,
+        string error,
+        Any? result,
+        int committedFactCount,
+        long stateVersion)
+    {
+        // Refactor (iter149/cluster-1133): Old pattern: script outcome details had no typed committed event owned by the run actor.  New principle: outcome status, error, and result are explicit proto fields.
+        return new ScriptRunOutcomeRecordedEvent
+        {
+            ScriptRunId = runId ?? string.Empty,
+            Status = status,
+            Error = error ?? string.Empty,
+            Result = result?.Clone(),
+            ActorId = Id,
+            DefinitionActorId = State.DefinitionActorId ?? string.Empty,
+            ScriptId = State.ScriptId ?? string.Empty,
+            ScriptRevision = State.Revision ?? string.Empty,
+            CommandId = commandId ?? string.Empty,
+            CorrelationId = correlationId ?? string.Empty,
+            ScopeId = scopeId ?? string.Empty,
+            CommittedFactCount = committedFactCount,
+            StateVersion = stateVersion,
+            OccurredAtUnixTimeMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        };
+    }
+
+    private static ScriptBehaviorState ApplyOutcomeRecorded(
+        ScriptBehaviorState state,
+        ScriptRunOutcomeRecordedEvent evt)
+    {
+        // Refactor (iter149/cluster-1133): Old pattern: outcome observation depended on readmodel side effects.  New principle: outcome events are committed observations and do not mutate the script behavior state machine.
+        var next = state.Clone();
+        next.LastRunId = evt.ScriptRunId ?? string.Empty;
+        next.LastRunOutcome = evt.Clone();
+        next.LastAppliedEventVersion = evt.StateVersion <= 0
+            ? state.LastAppliedEventVersion + 1
+            : evt.StateVersion;
+        if (string.IsNullOrWhiteSpace(next.ScopeId) && !string.IsNullOrWhiteSpace(evt.ScopeId))
+            next.ScopeId = evt.ScopeId;
+        return next;
+    }
+
     private bool IsSameBinding(BindScriptBehaviorRequestedEvent evt)
     {
         return string.Equals(State.DefinitionActorId, evt.DefinitionActorId, StringComparison.Ordinal) &&
@@ -302,8 +420,31 @@ public sealed class ScriptBehaviorGAgent : GAgentBase<ScriptBehaviorState>
         return envelope.Id ?? string.Empty;
     }
 
+    private static RunScriptRequestedEvent? ResolveRunRequest(EventEnvelope envelope)
+    {
+        // Refactor (iter149/cluster-1133): Old pattern: run request identity was unpacked separately in each dispatch helper.  New principle: extract the run request once so outcome and dispatch share the same identity fields.
+        if (envelope.Payload?.Is(RunScriptRequestedEvent.Descriptor) != true)
+            return null;
+
+        return envelope.Payload.Unpack<RunScriptRequestedEvent>();
+    }
+
+    private static string ResolveCommandId(EventEnvelope envelope)
+    {
+        // Refactor (iter149/cluster-1133): Old pattern: command identity was implicit in dispatch plumbing only.  New principle: outcome event carries the stable command id as typed data.
+        if (envelope.Payload?.Is(RunScriptRequestedEvent.Descriptor) == true)
+        {
+            var run = envelope.Payload.Unpack<RunScriptRequestedEvent>();
+            if (!string.IsNullOrWhiteSpace(run.CommandId))
+                return run.CommandId;
+        }
+
+        return envelope.Id ?? string.Empty;
+    }
+
     private static string ResolveCorrelationId(EventEnvelope envelope)
     {
+        // Refactor (iter149/cluster-1133): Old pattern: caller correlation was only a transport concern.  New principle: outcome event records the correlation id consumed by projection-session observers.
         if (!string.IsNullOrWhiteSpace(envelope.Propagation?.CorrelationId))
             return envelope.Propagation.CorrelationId;
 

--- a/src/Aevatar.Scripting.Projection/Orchestration/ScriptingCommittedStateProjectionActivationPlanProvider.cs
+++ b/src/Aevatar.Scripting.Projection/Orchestration/ScriptingCommittedStateProjectionActivationPlanProvider.cs
@@ -13,6 +13,7 @@ namespace Aevatar.Scripting.Projection.Orchestration;
 //   New principle: Command service dispatches accepted-only write commands; readmodel activation is owned by scripting committed-state projection activation plan provider.
 public sealed class ScriptingCommittedStateProjectionActivationPlanProvider : IProjectionActivationPlanProvider
 {
+    // Refactor (iter149/cluster-1133): Old pattern: scripting execution projection activation only recognized domain fact commits.  New principle: actor-owned script run outcome commits use the same projection-session observation path.
     public IEnumerable<ProjectionActivationPlan> GetPlans(CommittedStatePublicationContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -21,7 +22,7 @@ public sealed class ScriptingCommittedStateProjectionActivationPlanProvider : IP
             yield break;
 
         if (context.ActorType == typeof(ScriptBehaviorGAgent) &&
-            context.Published.StateEvent.EventData.Is(ScriptDomainFactCommitted.Descriptor))
+            IsScriptExecutionMutation(context.Published.StateEvent.EventData))
         {
             yield return DurableExecutionPlan(context.ActorId);
             yield break;
@@ -61,6 +62,18 @@ public sealed class ScriptingCommittedStateProjectionActivationPlanProvider : IP
                 Mode = ProjectionRuntimeMode.DurableMaterialization,
             },
         };
+
+    private static bool IsScriptExecutionMutation(Google.Protobuf.WellKnownTypes.Any eventData)
+    {
+        // Refactor (iter149/cluster-1133): Old pattern: execution mutation meant only ScriptDomainFactCommitted.  New principle: ScriptRunOutcomeRecordedEvent is a first-class committed execution fact for observers.
+        if (eventData.Is(ScriptDomainFactCommitted.Descriptor))
+            return true;
+
+        if (eventData.Is(ScriptRunOutcomeRecordedEvent.Descriptor))
+            return true;
+
+        return false;
+    }
 
     private static ProjectionActivationPlan DurableEvolutionPlan(string actorId) =>
         new()

--- a/src/Aevatar.Scripting.Projection/Projectors/ScriptExecutionSessionEventProjector.cs
+++ b/src/Aevatar.Scripting.Projection/Projectors/ScriptExecutionSessionEventProjector.cs
@@ -1,5 +1,6 @@
 using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Scripting.Abstractions;
 using Aevatar.Scripting.Projection.Orchestration;
 
 namespace Aevatar.Scripting.Projection.Projectors;
@@ -20,8 +21,9 @@ public sealed class ScriptExecutionSessionEventProjector
         if (string.IsNullOrWhiteSpace(context.RootActorId) || string.IsNullOrWhiteSpace(context.SessionId))
             return EmptyEntries;
 
+        var correlationId = ResolveSessionCorrelationId(envelope);
         if (!IsLegacyActorScopedSession(context) &&
-            !string.Equals(envelope.Propagation?.CorrelationId, context.SessionId, StringComparison.Ordinal))
+            !string.Equals(correlationId, context.SessionId, StringComparison.Ordinal))
         {
             return EmptyEntries;
         }
@@ -37,4 +39,20 @@ public sealed class ScriptExecutionSessionEventProjector
 
     private static bool IsLegacyActorScopedSession(ScriptExecutionProjectionContext context) =>
         string.Equals(context.RootActorId, context.SessionId, StringComparison.Ordinal);
+
+    private static string ResolveSessionCorrelationId(EventEnvelope envelope)
+    {
+        if (!string.IsNullOrWhiteSpace(envelope.Propagation?.CorrelationId))
+            return envelope.Propagation.CorrelationId;
+
+        if (envelope.Payload?.Is(CommittedStateEventPublished.Descriptor) == true)
+        {
+            var published = envelope.Payload.Unpack<CommittedStateEventPublished>();
+            var eventData = published.StateEvent?.EventData;
+            if (eventData?.Is(ScriptRunOutcomeRecordedEvent.Descriptor) == true)
+                return eventData.Unpack<ScriptRunOutcomeRecordedEvent>().CorrelationId ?? string.Empty;
+        }
+
+        return string.Empty;
+    }
 }

--- a/src/Aevatar.Scripting.Projection/Projectors/ScriptExecutionSessionEventProjector.cs
+++ b/src/Aevatar.Scripting.Projection/Projectors/ScriptExecutionSessionEventProjector.cs
@@ -45,6 +45,7 @@ public sealed class ScriptExecutionSessionEventProjector
         if (!string.IsNullOrWhiteSpace(envelope.Propagation?.CorrelationId))
             return envelope.Propagation.CorrelationId;
 
+        // Refactor (iter149/cluster-1133): Old pattern: envelope-based session routing.  New principle: typed ScriptRunOutcomeRecordedEvent.CorrelationId fallback for session correlation.
         if (envelope.Payload?.Is(CommittedStateEventPublished.Descriptor) == true)
         {
             var published = envelope.Payload.Unpack<CommittedStateEventPublished>();

--- a/test/Aevatar.Integration.Tests/WorkflowIntegrationTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowIntegrationTests.cs
@@ -263,14 +263,21 @@ public class WorkflowIntegrationTests
         });
 
         // Then
-        (await runtime.ExistsAsync(definitionActorId)).Should().BeTrue();
-        (await runtime.ExistsAsync(runActorId)).Should().BeTrue();
-        (await runtime.ExistsAsync(researcherActorId)).Should().BeTrue();
-        (await runtime.ExistsAsync(reviewerActorId)).Should().BeTrue();
-        (await runtime.ExistsAsync(writerActorId)).Should().BeTrue();
+        await WaitForActorAsync(runtime, definitionActorId);
+        await WaitForActorAsync(runtime, runActorId);
+        await WaitForActorAsync(runtime, researcherActorId);
+        await WaitForActorAsync(runtime, reviewerActorId);
+        await WaitForActorAsync(runtime, writerActorId);
 
         // 验证层级
-        var children = await runActor.GetChildrenIdsAsync();
+        var children = await ScriptEvolutionIntegrationTestKit.WaitForAsync(
+            async _ => await runActor.GetChildrenIdsAsync(),
+            childIds => childIds.Count == 3 &&
+                        childIds.Contains(researcherActorId) &&
+                        childIds.Contains(reviewerActorId) &&
+                        childIds.Contains(writerActorId),
+            $"Workflow run children not visible. actor_id={runActorId}",
+            CancellationToken.None);
         children.Should().HaveCount(3);
         children.Should().Contain(researcherActorId);
         children.Should().Contain(reviewerActorId);
@@ -287,6 +294,15 @@ public class WorkflowIntegrationTests
             $"RoleGAgent initialization not visible. actor_id={researcherActorId}",
             CancellationToken.None);
         researcher!.RoleName.Should().Be("Researcher");
+    }
+
+    private static async Task WaitForActorAsync(IActorRuntime runtime, string actorId)
+    {
+        await ScriptEvolutionIntegrationTestKit.WaitForAsync(
+            async _ => await runtime.ExistsAsync(actorId),
+            exists => exists,
+            $"Actor not visible. actor_id={actorId}",
+            CancellationToken.None);
     }
 
     // ═══════════════════════════════════════════════════════════

--- a/test/Aevatar.Scripting.Core.Tests/Contracts/ScriptProtoContractsTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Contracts/ScriptProtoContractsTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.Scripting.Core.Tests.Contracts;
@@ -74,6 +75,63 @@ public class ScriptProtoContractsTests
         state.ReadModelSchemaHash.Should().Be("schema-hash-1");
         state.LastRunId.Should().Be("run-1");
         state.StateRoot.Should().BeNull();
+    }
+
+    [Fact]
+    public void ScriptRunOutcomeRecordedEvent_ShouldRoundTripTypedOutcomeFields()
+    {
+        var outcome = new ScriptRunOutcomeRecordedEvent
+        {
+            ActorId = "script-runtime:scope-1:script-1",
+            DefinitionActorId = "definition-1",
+            ScriptId = "script-1",
+            ScriptRevision = "rev-1",
+            ScriptRunId = "run-1",
+            CommandId = "command-1",
+            CorrelationId = "correlation-1",
+            ScopeId = "scope-1",
+            Status = ScriptRunOutcomeStatus.Succeeded,
+            CommittedFactCount = 2,
+            StateVersion = 7,
+            OccurredAtUnixTimeMs = 123456,
+            Result = Any.Pack(new StringValue { Value = "ok" }),
+        };
+
+        var parsed = ScriptRunOutcomeRecordedEvent.Parser.ParseFrom(outcome.ToByteArray());
+
+        parsed.ActorId.Should().Be("script-runtime:scope-1:script-1");
+        parsed.ScriptRunId.Should().Be("run-1");
+        parsed.Status.Should().Be(ScriptRunOutcomeStatus.Succeeded);
+        parsed.CommittedFactCount.Should().Be(2);
+        parsed.StateVersion.Should().Be(7);
+        parsed.OccurredAtUnixTimeMs.Should().Be(123456);
+        parsed.Result.Unpack<StringValue>().Value.Should().Be("ok");
+    }
+
+    [Fact]
+    public void ScriptBehaviorState_ShouldRoundTripLastRunOutcome()
+    {
+        var state = new ScriptBehaviorState
+        {
+            DefinitionActorId = "definition-1",
+            ScriptId = "script-1",
+            Revision = "rev-1",
+            LastRunOutcome = new ScriptRunOutcomeRecordedEvent
+            {
+                ScriptRunId = "run-1",
+                CommandId = "command-1",
+                Status = ScriptRunOutcomeStatus.Failed,
+                Error = "failed",
+            },
+        };
+
+        var parsed = ScriptBehaviorState.Parser.ParseFrom(state.ToByteArray());
+
+        parsed.LastRunOutcome.Should().NotBeNull();
+        parsed.LastRunOutcome.ScriptRunId.Should().Be("run-1");
+        parsed.LastRunOutcome.CommandId.Should().Be("command-1");
+        parsed.LastRunOutcome.Status.Should().Be(ScriptRunOutcomeStatus.Failed);
+        parsed.LastRunOutcome.Error.Should().Be("failed");
     }
 
     [Fact]

--- a/test/Aevatar.Scripting.Core.Tests/Projection/ScriptExecutionSessionEventProjectorTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Projection/ScriptExecutionSessionEventProjectorTests.cs
@@ -1,0 +1,142 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Scripting.Abstractions;
+using Aevatar.Scripting.Projection.Orchestration;
+using Aevatar.Scripting.Projection.Projectors;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Scripting.Core.Tests.Projection;
+
+public sealed class ScriptExecutionSessionEventProjectorTests
+{
+    [Fact]
+    public async Task ProjectAsync_ShouldPublishOutcomeEnvelope_WhenTypedOutcomeCorrelationMatchesSession()
+    {
+        var hub = new RecordingSessionEventHub();
+        var projector = new ScriptExecutionSessionEventProjector(hub);
+        var context = BuildContext("correlation-1");
+        var envelope = WrapCommitted(new ScriptRunOutcomeRecordedEvent
+        {
+            ScriptRunId = "run-1",
+            CommandId = "command-1",
+            CorrelationId = "correlation-1",
+            Status = ScriptRunOutcomeStatus.Succeeded,
+        });
+
+        await projector.ProjectAsync(context, envelope, CancellationToken.None);
+
+        hub.Published.Should().ContainSingle();
+        hub.Published[0].ScopeId.Should().Be("script-runtime:scope-1:script-1");
+        hub.Published[0].SessionId.Should().Be("correlation-1");
+        hub.Published[0].Event.Id.Should().Be("evt-1");
+    }
+
+    [Fact]
+    public async Task ProjectAsync_ShouldIgnoreOutcomeEnvelope_WhenTypedOutcomeCorrelationDoesNotMatchSession()
+    {
+        var hub = new RecordingSessionEventHub();
+        var projector = new ScriptExecutionSessionEventProjector(hub);
+        var context = BuildContext("correlation-2");
+        var envelope = WrapCommitted(new ScriptRunOutcomeRecordedEvent
+        {
+            ScriptRunId = "run-1",
+            CommandId = "command-1",
+            CorrelationId = "correlation-1",
+            Status = ScriptRunOutcomeStatus.Succeeded,
+        });
+
+        await projector.ProjectAsync(context, envelope, CancellationToken.None);
+
+        hub.Published.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ProjectAsync_ShouldPreferEnvelopePropagationCorrelation()
+    {
+        var hub = new RecordingSessionEventHub();
+        var projector = new ScriptExecutionSessionEventProjector(hub);
+        var context = BuildContext("propagation-correlation");
+        var envelope = WrapCommitted(
+            new ScriptRunOutcomeRecordedEvent
+            {
+                ScriptRunId = "run-1",
+                CommandId = "command-1",
+                CorrelationId = "typed-correlation",
+                Status = ScriptRunOutcomeStatus.Succeeded,
+            },
+            propagationCorrelationId: "propagation-correlation");
+
+        await projector.ProjectAsync(context, envelope, CancellationToken.None);
+
+        hub.Published.Should().ContainSingle();
+        hub.Published[0].SessionId.Should().Be("propagation-correlation");
+    }
+
+    private static ScriptExecutionProjectionContext BuildContext(string sessionId) =>
+        new()
+        {
+            RootActorId = "script-runtime:scope-1:script-1",
+            SessionId = sessionId,
+            ProjectionKind = "script-execution-read-model",
+        };
+
+    private static EventEnvelope WrapCommitted(
+        IMessage evt,
+        string? propagationCorrelationId = null) =>
+        new()
+        {
+            Id = "evt-1",
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Route = EnvelopeRouteSemantics.CreateObserverPublication("script-execution-test"),
+            Payload = Any.Pack(new CommittedStateEventPublished
+            {
+                StateEvent = new StateEvent
+                {
+                    EventId = "evt-1",
+                    Version = 1,
+                    Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+                    EventData = Any.Pack(evt),
+                },
+                StateRoot = Any.Pack(new Empty()),
+            }),
+            Propagation = string.IsNullOrWhiteSpace(propagationCorrelationId)
+                ? null
+                : new EnvelopePropagation { CorrelationId = propagationCorrelationId },
+        };
+
+    private sealed class RecordingSessionEventHub : IProjectionSessionEventHub<EventEnvelope>
+    {
+        public List<PublishedMessage> Published { get; } = [];
+
+        public Task PublishAsync(
+            string scopeId,
+            string sessionId,
+            EventEnvelope evt,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Published.Add(new PublishedMessage(scopeId, sessionId, evt.Clone()));
+            return Task.CompletedTask;
+        }
+
+        public Task<IAsyncDisposable> SubscribeAsync(
+            string scopeId,
+            string sessionId,
+            Func<EventEnvelope, ValueTask> handler,
+            CancellationToken ct = default)
+        {
+            _ = scopeId;
+            _ = sessionId;
+            _ = handler;
+            _ = ct;
+            throw new NotSupportedException();
+        }
+    }
+
+    private sealed record PublishedMessage(
+        string ScopeId,
+        string SessionId,
+        EventEnvelope Event);
+}

--- a/test/Aevatar.Scripting.Core.Tests/Projection/ScriptingCommittedStateProjectionActivationPlanProviderTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Projection/ScriptingCommittedStateProjectionActivationPlanProviderTests.cs
@@ -14,6 +14,7 @@ namespace Aevatar.Scripting.Core.Tests.Projection;
 //   New principle: Command service dispatches accepted-only write commands; readmodel activation is owned by scripting committed-state projection activation plan provider.
 public sealed class ScriptingCommittedStateProjectionActivationPlanProviderTests
 {
+    // Refactor (iter149/cluster-1133): Old pattern: scripting execution projection tests covered only domain facts.  New principle: actor-owned run outcome events activate the same execution projection path.
     [Fact]
     public void GetPlans_ShouldRejectNullContext()
     {
@@ -86,6 +87,30 @@ public sealed class ScriptingCommittedStateProjectionActivationPlanProviderTests
                 ActorId = "script-runtime:scope-1:my-script",
                 ScriptId = "my-script",
                 Revision = "rev-1",
+            },
+            "script-runtime:scope-1:my-script")).ToArray();
+
+        plans.Should().ContainSingle();
+        plans[0].LeaseType.Should().Be(typeof(ScriptExecutionMaterializationRuntimeLease));
+        plans[0].StartRequest.RootActorId.Should().Be("script-runtime:scope-1:my-script");
+        plans[0].StartRequest.ProjectionKind.Should().Be("script-execution-read-model");
+        plans[0].StartRequest.Mode.Should().Be(ProjectionRuntimeMode.DurableMaterialization);
+    }
+
+    [Fact]
+    public void GetPlans_ShouldMapScriptRunOutcomeRecordedToExecutionMaterializationScope()
+    {
+        var provider = new ScriptingCommittedStateProjectionActivationPlanProvider();
+
+        var plans = provider.GetPlans(BuildContext(
+            typeof(ScriptBehaviorGAgent),
+            new ScriptRunOutcomeRecordedEvent
+            {
+                ActorId = "script-runtime:scope-1:my-script",
+                ScriptId = "my-script",
+                ScriptRevision = "rev-1",
+                ScriptRunId = "run-1",
+                Status = ScriptRunOutcomeStatus.Succeeded,
             },
             "script-runtime:scope-1:my-script")).ToArray();
 

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeGAgentBranchCoverageTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeGAgentBranchCoverageTests.cs
@@ -331,6 +331,7 @@ public sealed class ScriptRuntimeGAgentBranchCoverageTests
         await harness.Agent.HandleEnvelopeAsync(BuildEnvelope(new RunScriptRequestedEvent
         {
             RunId = "run-committed",
+            CommandId = "command-committed",
             DefinitionActorId = "definition-1",
             ScriptRevision = "rev-1",
             RequestedEventType = "integration.requested",
@@ -348,6 +349,90 @@ public sealed class ScriptRuntimeGAgentBranchCoverageTests
         harness.Agent.State.StateRoot!.Unpack<SimpleTextState>().Value.Should().Be("HELLO");
         var persisted = await harness.EventStore.GetEventsAsync(harness.Agent.Id, ct: CancellationToken.None);
         persisted.Should().Contain(x => x.EventData.Is(ScriptDomainFactCommitted.Descriptor));
+        var outcome = persisted.Select(x => x.EventData)
+            .Single(x => x.Is(ScriptRunOutcomeRecordedEvent.Descriptor))
+            .Unpack<ScriptRunOutcomeRecordedEvent>();
+        outcome.ScriptRunId.Should().Be("run-committed");
+        outcome.Status.Should().Be(ScriptRunOutcomeStatus.Succeeded);
+        outcome.CommandId.Should().Be("command-committed");
+        outcome.CorrelationId.Should().Be("corr-1");
+        outcome.CommittedFactCount.Should().Be(1);
+        outcome.StateVersion.Should().Be(2);
+        outcome.Result.Should().NotBeNull();
+        harness.Agent.State.LastRunOutcome.Should().NotBeNull();
+        harness.Agent.State.LastRunOutcome.ScriptRunId.Should().Be("run-committed");
+        harness.Agent.State.LastRunOutcome.CommittedFactCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task HandleEnvelopeAsync_ShouldRecordSucceededOutcome_WhenRunProducesNoFacts()
+    {
+        var harness = CreateHarness();
+        await BindAsync(harness.Agent);
+
+        await harness.Agent.HandleEnvelopeAsync(BuildEnvelope(new RunScriptRequestedEvent
+        {
+            RunId = "run-no-facts",
+            CommandId = "command-no-facts",
+            CorrelationId = "correlation-no-facts",
+            DefinitionActorId = "definition-1",
+            ScriptRevision = "rev-1",
+            RequestedEventType = "integration.requested",
+            InputPayload = Any.Pack(new SimpleTextCommand
+            {
+                CommandId = "command-no-facts",
+                Value = "hello",
+            }),
+        }, correlationId: string.Empty));
+
+        var persisted = await harness.EventStore.GetEventsAsync(harness.Agent.Id, ct: CancellationToken.None);
+        persisted.Should().NotContain(x => x.EventData.Is(ScriptDomainFactCommitted.Descriptor));
+        var outcome = persisted.Select(x => x.EventData)
+            .Single(x => x.Is(ScriptRunOutcomeRecordedEvent.Descriptor))
+            .Unpack<ScriptRunOutcomeRecordedEvent>();
+        outcome.ScriptRunId.Should().Be("run-no-facts");
+        outcome.Status.Should().Be(ScriptRunOutcomeStatus.Succeeded);
+        outcome.CommandId.Should().Be("command-no-facts");
+        outcome.CorrelationId.Should().Be("correlation-no-facts");
+        outcome.CommittedFactCount.Should().Be(0);
+        outcome.Result.Should().BeNull();
+        harness.Agent.State.LastRunOutcome.Status.Should().Be(ScriptRunOutcomeStatus.Succeeded);
+    }
+
+    [Fact]
+    public async Task HandleEnvelopeAsync_ShouldRecordFailedOutcome_WhenRunDispatchFails()
+    {
+        var harness = CreateHarness(
+            dispatcher: new ThrowingDispatcher(new InvalidOperationException("script contract rejected")));
+        await BindAsync(harness.Agent);
+
+        var act = () => harness.Agent.HandleEnvelopeAsync(BuildEnvelope(new RunScriptRequestedEvent
+        {
+            RunId = "run-failed",
+            CommandId = "command-failed",
+            DefinitionActorId = "definition-1",
+            ScriptRevision = "rev-1",
+            RequestedEventType = "integration.requested",
+            InputPayload = Any.Pack(new SimpleTextCommand
+            {
+                CommandId = "command-failed",
+                Value = "hello",
+            }),
+        }));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*script contract rejected*");
+
+        var persisted = await harness.EventStore.GetEventsAsync(harness.Agent.Id, ct: CancellationToken.None);
+        var outcome = persisted.Select(x => x.EventData)
+            .Single(x => x.Is(ScriptRunOutcomeRecordedEvent.Descriptor))
+            .Unpack<ScriptRunOutcomeRecordedEvent>();
+        outcome.ScriptRunId.Should().Be("run-failed");
+        outcome.Status.Should().Be(ScriptRunOutcomeStatus.Failed);
+        outcome.CommandId.Should().Be("command-failed");
+        outcome.Error.Should().Be("script contract rejected");
+        outcome.CommittedFactCount.Should().Be(0);
+        harness.Agent.State.LastRunOutcome.Status.Should().Be(ScriptRunOutcomeStatus.Failed);
     }
 
     [Fact]
@@ -529,6 +614,18 @@ public sealed class ScriptRuntimeGAgentBranchCoverageTests
         {
             ct.ThrowIfCancellationRequested();
             return Task.FromResult(factory(request));
+        }
+    }
+
+    private sealed class ThrowingDispatcher(Exception exception) : IScriptBehaviorDispatcher
+    {
+        public Task<IReadOnlyList<ScriptDomainFactCommitted>> DispatchAsync(
+            ScriptBehaviorDispatchRequest request,
+            CancellationToken ct)
+        {
+            _ = request;
+            ct.ThrowIfCancellationRequested();
+            return Task.FromException<IReadOnlyList<ScriptDomainFactCommitted>>(exception);
         }
     }
 

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeGAgentBranchCoverageTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeGAgentBranchCoverageTests.cs
@@ -343,21 +343,22 @@ public sealed class ScriptRuntimeGAgentBranchCoverageTests
         }));
 
         harness.Agent.State.LastRunId.Should().Be("run-committed");
-        harness.Agent.State.LastAppliedEventVersion.Should().Be(2);
+        harness.Agent.State.LastAppliedEventVersion.Should().Be(3);
         harness.Agent.State.LastEventId.Should().Be(ScriptSources.UppercaseEventTypeUrl);
         harness.Agent.State.StateRoot.Should().NotBeNull();
         harness.Agent.State.StateRoot!.Unpack<SimpleTextState>().Value.Should().Be("HELLO");
         var persisted = await harness.EventStore.GetEventsAsync(harness.Agent.Id, ct: CancellationToken.None);
-        persisted.Should().Contain(x => x.EventData.Is(ScriptDomainFactCommitted.Descriptor));
-        var outcome = persisted.Select(x => x.EventData)
-            .Single(x => x.Is(ScriptRunOutcomeRecordedEvent.Descriptor))
+        var factStateEvent = persisted.Single(x => x.EventData.Is(ScriptDomainFactCommitted.Descriptor));
+        var outcomeStateEvent = persisted.Single(x => x.EventData.Is(ScriptRunOutcomeRecordedEvent.Descriptor));
+        var outcome = outcomeStateEvent.EventData
             .Unpack<ScriptRunOutcomeRecordedEvent>();
         outcome.ScriptRunId.Should().Be("run-committed");
         outcome.Status.Should().Be(ScriptRunOutcomeStatus.Succeeded);
         outcome.CommandId.Should().Be("command-committed");
         outcome.CorrelationId.Should().Be("corr-1");
         outcome.CommittedFactCount.Should().Be(1);
-        outcome.StateVersion.Should().Be(2);
+        outcome.StateVersion.Should().Be(outcomeStateEvent.Version);
+        outcome.StateVersion.Should().Be(factStateEvent.Version + 1);
         outcome.Result.Should().NotBeNull();
         harness.Agent.State.LastRunOutcome.Should().NotBeNull();
         harness.Agent.State.LastRunOutcome.ScriptRunId.Should().Be("run-committed");
@@ -387,14 +388,15 @@ public sealed class ScriptRuntimeGAgentBranchCoverageTests
 
         var persisted = await harness.EventStore.GetEventsAsync(harness.Agent.Id, ct: CancellationToken.None);
         persisted.Should().NotContain(x => x.EventData.Is(ScriptDomainFactCommitted.Descriptor));
-        var outcome = persisted.Select(x => x.EventData)
-            .Single(x => x.Is(ScriptRunOutcomeRecordedEvent.Descriptor))
+        var outcomeStateEvent = persisted.Single(x => x.EventData.Is(ScriptRunOutcomeRecordedEvent.Descriptor));
+        var outcome = outcomeStateEvent.EventData
             .Unpack<ScriptRunOutcomeRecordedEvent>();
         outcome.ScriptRunId.Should().Be("run-no-facts");
         outcome.Status.Should().Be(ScriptRunOutcomeStatus.Succeeded);
         outcome.CommandId.Should().Be("command-no-facts");
         outcome.CorrelationId.Should().Be("correlation-no-facts");
         outcome.CommittedFactCount.Should().Be(0);
+        outcome.StateVersion.Should().Be(outcomeStateEvent.Version);
         outcome.Result.Should().BeNull();
         harness.Agent.State.LastRunOutcome.Status.Should().Be(ScriptRunOutcomeStatus.Succeeded);
     }
@@ -424,15 +426,67 @@ public sealed class ScriptRuntimeGAgentBranchCoverageTests
             .WithMessage("*script contract rejected*");
 
         var persisted = await harness.EventStore.GetEventsAsync(harness.Agent.Id, ct: CancellationToken.None);
-        var outcome = persisted.Select(x => x.EventData)
-            .Single(x => x.Is(ScriptRunOutcomeRecordedEvent.Descriptor))
+        var outcomeStateEvent = persisted.Single(x => x.EventData.Is(ScriptRunOutcomeRecordedEvent.Descriptor));
+        var outcome = outcomeStateEvent.EventData
             .Unpack<ScriptRunOutcomeRecordedEvent>();
         outcome.ScriptRunId.Should().Be("run-failed");
         outcome.Status.Should().Be(ScriptRunOutcomeStatus.Failed);
         outcome.CommandId.Should().Be("command-failed");
         outcome.Error.Should().Be("script contract rejected");
         outcome.CommittedFactCount.Should().Be(0);
+        outcome.StateVersion.Should().Be(outcomeStateEvent.Version);
         harness.Agent.State.LastRunOutcome.Status.Should().Be(ScriptRunOutcomeStatus.Failed);
+    }
+
+    [Theory]
+    [InlineData("definition-2", "scope-1", "bound to definition `definition-1`", "scope-1")]
+    [InlineData("definition-1", "scope-2", "bound to scope `scope-1`", "scope-2")]
+    public async Task HandleEnvelopeAsync_ShouldRecordFailedOutcome_WhenRunTargetValidationFails(
+        string targetDefinitionActorId,
+        string targetScopeId,
+        string expectedError,
+        string expectedOutcomeScopeId)
+    {
+        var harness = CreateHarness();
+        await BindAsync(harness.Agent, "scope-1");
+
+        var act = () => harness.Agent.HandleEnvelopeAsync(BuildEnvelope(
+            new RunScriptRequestedEvent
+            {
+                RunId = "run-validation-failed",
+                CommandId = "command-validation-failed",
+                CorrelationId = "correlation-validation-failed",
+                ScopeId = targetScopeId,
+                DefinitionActorId = targetDefinitionActorId,
+                ScriptRevision = "rev-1",
+                RequestedEventType = "integration.requested",
+                InputPayload = Any.Pack(new SimpleTextCommand
+                {
+                    CommandId = "command-validation-failed",
+                    Value = "hello",
+                }),
+            },
+            correlationId: string.Empty));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage($"*{expectedError}*");
+
+        var persisted = await harness.EventStore.GetEventsAsync(harness.Agent.Id, ct: CancellationToken.None);
+        persisted.Should().NotContain(x => x.EventData.Is(ScriptDomainFactCommitted.Descriptor));
+        var outcomeStateEvent = persisted
+            .Where(x => x.EventData.Is(ScriptRunOutcomeRecordedEvent.Descriptor))
+            .Should()
+            .ContainSingle()
+            .Subject;
+        var outcome = outcomeStateEvent.EventData.Unpack<ScriptRunOutcomeRecordedEvent>();
+        outcome.ScriptRunId.Should().Be("run-validation-failed");
+        outcome.CommandId.Should().Be("command-validation-failed");
+        outcome.CorrelationId.Should().Be("correlation-validation-failed");
+        outcome.ScopeId.Should().Be(expectedOutcomeScopeId);
+        outcome.Status.Should().Be(ScriptRunOutcomeStatus.Failed);
+        outcome.CommittedFactCount.Should().Be(0);
+        outcome.Error.Should().Contain(expectedError);
+        outcome.StateVersion.Should().Be(outcomeStateEvent.Version);
     }
 
     [Fact]
@@ -559,7 +613,7 @@ public sealed class ScriptRuntimeGAgentBranchCoverageTests
         return new CachedScriptBehaviorArtifactResolver(compiler);
     }
 
-    private static BindScriptBehaviorRequestedEvent CreateBindRequest() =>
+    private static BindScriptBehaviorRequestedEvent CreateBindRequest(string scopeId = "") =>
         new()
         {
             DefinitionActorId = "definition-1",
@@ -571,10 +625,11 @@ public sealed class ScriptRuntimeGAgentBranchCoverageTests
             ReadModelTypeUrl = ScriptSources.UppercaseReadModelTypeUrl,
             ReadModelSchemaVersion = "1",
             ReadModelSchemaHash = "schema-hash",
+            ScopeId = scopeId,
         };
 
-    private static async Task BindAsync(ScriptBehaviorGAgent agent) =>
-        await agent.HandleEnvelopeAsync(BuildEnvelope(CreateBindRequest()));
+    private static async Task BindAsync(ScriptBehaviorGAgent agent, string scopeId = "") =>
+        await agent.HandleEnvelopeAsync(BuildEnvelope(CreateBindRequest(scopeId)));
 
     private static EventEnvelope BuildEnvelope(IMessage payload, string? correlationId = "corr-1") =>
         new()

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeGAgentReplayContractTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeGAgentReplayContractTests.cs
@@ -29,7 +29,7 @@ public class ScriptBehaviorGAgentReplayContractTests
         harness.Agent.State.ScriptId.Should().Be("script-1");
         harness.Agent.State.Revision.Should().Be("rev-1");
         harness.Agent.State.LastRunId.Should().Be("run-1");
-        harness.Agent.State.LastAppliedEventVersion.Should().Be(2);
+        harness.Agent.State.LastAppliedEventVersion.Should().Be(3);
         harness.Agent.State.StateRoot.Should().NotBeNull();
         harness.Agent.State.StateRoot.Unpack<ScriptProfileState>().CommandCount.Should().Be(1);
         harness.Agent.State.LastEventId.Should().Be(Any.Pack(new ScriptProfileUpdated()).TypeUrl);
@@ -45,7 +45,7 @@ public class ScriptBehaviorGAgentReplayContractTests
         await RunAsync(harness.Agent, "run-2", "rev-1", "runtime.requested");
 
         harness.Agent.State.LastRunId.Should().Be("run-2");
-        harness.Agent.State.LastAppliedEventVersion.Should().Be(3);
+        harness.Agent.State.LastAppliedEventVersion.Should().Be(5);
         harness.Agent.State.StateRoot.Should().NotBeNull();
         harness.Agent.State.StateRoot.Unpack<ScriptProfileState>().CommandCount.Should().Be(2);
     }


### PR DESCRIPTION
## 摘要

iter149 cluster-1133-script-outcome:narrow Script outcome channel — actor-owned signal-publication of script execution outcome。

- **Old**:Script run actor 完成 outcome 通过 handled-dispatch port 在 dispatch callstack 内同步返回(违反 ACK 诚实)
- **New**:Script run actor 发 actor-owned committed `ScriptRunOutcomeRecordedEvent`;caller 通过 existing projection-session observation 获取(event/session-only,不 wait callstack)

违反:CLAUDE.md「ACK 诚实:同步返回只承诺已达到阶段(默认 accepted + stable command id);committed / read-model observed 等强保证须通过独立契约或异步观察获取」+「权威状态唯一拥有者」。

## 范围

9 files changed (+584/-50)。包括:
- proto + ScriptBehaviorGAgent + Projection ActivationPlanProvider + SessionEventProjector
- 新增 `ScriptExecutionSessionEventProjectorTests`
- `WorkflowIntegrationTests.Scenario2_CreateAgentTree` 修 parallel race(r3 deterministic fixture)

完整 Phase 9 r3 共识链路(reflector r1 wait-for-#1132-merge → r2 narrow → r3 convergence question option A → 3/3 unanimous + meta-judge consensus):https://github.com/aevatarAI/aevatar/issues/1133

## Phase 9 / Phase 8 工作流

Base = `auto-refact-dev`(integration branch)。closes #1133。

implement 经历:r1 死 mid-impl(API 503)→ r2 resume staged + full slnx test partial:1(integration test flake)→ r3 fix flake(deterministic fixture isolation)+ full slnx test ok。

🤖 Auto-loop / codex-refactor-loop iter149

⟦AI:AUTO-LOOP⟧
