### PR TITLE
fix(frontend): CQRS ACK honesty — invoke receipt shows Accepted not Succeeded

### DIFF
--- a/apps/aevatar-console-web/src/pages/scopes/invoke.test.tsx
+++ b/apps/aevatar-console-web/src/pages/scopes/invoke.test.tsx
@@ -597,6 +597,14 @@ describe('ScopeInvokePage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Output' }));
 
+    const acceptedDescription = await screen.findByText(
+      'Invocation accepted. Completion is still pending; continue in Runs to observe progress.',
+    );
+    const acceptedAlert = acceptedDescription.closest('.ant-alert');
+
+    expect(screen.queryByText('Invocation completed.')).not.toBeInTheDocument();
+    expect(acceptedAlert).toHaveClass('ant-alert-info');
+    expect(acceptedAlert).not.toHaveClass('ant-alert-success');
     expect(await screen.findByText('Invocation Receipt')).toBeTruthy();
     expect(await screen.findByText(/"accepted": true/)).toBeTruthy();
   });

--- a/apps/aevatar-console-web/src/pages/scopes/invoke.tsx
+++ b/apps/aevatar-console-web/src/pages/scopes/invoke.tsx
@@ -95,7 +95,7 @@ type InvokeResultState = {
   responseJson: string;
   runId: string;
   serviceId: string;
-  status: 'idle' | 'running' | 'success' | 'error';
+  status: 'idle' | 'accepted' | 'running' | 'success' | 'error';
   steps: RuntimeStepInfo[];
   thinking: string;
   toolCalls: RuntimeToolCallInfo[];
@@ -974,7 +974,7 @@ const ScopeInvokePage: React.FC = () => {
         responseJson: JSON.stringify(response, null, 2),
         runId: responseRunId,
         serviceId: selectedService.serviceId,
-        status: 'success',
+        status: 'accepted',
       });
     } catch (error) {
       setInvokeResult({
@@ -1095,7 +1095,8 @@ const ScopeInvokePage: React.FC = () => {
             'No published team services were discovered. Switch the live team setup before you keep probing this legacy lab.',
           title: 'Fix the live team setup',
         }
-      : invokeResult.status === 'success'
+      : invokeResult.status === 'success' ||
+          invokeResult.status === 'accepted'
         ? {
             action: handleOpenRuns,
             actionLabel: 'Continue in Runs',
@@ -1216,7 +1217,8 @@ const ScopeInvokePage: React.FC = () => {
             <Button onClick={() => setContextSurface('service')}>
               Browse services
             </Button>
-            {invokeResult.status === 'success' ? (
+            {invokeResult.status === 'success' ||
+            invokeResult.status === 'accepted' ? (
               <Button onClick={handleOpenRuns} type="primary">
                 Continue in Runs
               </Button>
@@ -1659,7 +1661,8 @@ const ScopeInvokePage: React.FC = () => {
                           type={
                             invokeResult.status === 'error'
                               ? 'error'
-                              : invokeResult.status === 'success'
+                              : invokeResult.status === 'success' ||
+                                  invokeResult.status === 'accepted'
                                 ? 'success'
                                 : 'info'
                           }

--- a/apps/aevatar-console-web/src/pages/scopes/invoke.tsx
+++ b/apps/aevatar-console-web/src/pages/scopes/invoke.tsx
@@ -1646,9 +1646,11 @@ const ScopeInvokePage: React.FC = () => {
                         <Alert
                           description={
                             invokeResult.error ||
-                            (invokeResult.status === 'running'
-                              ? 'Invocation in progress.'
-                              : 'Invocation completed.')
+                            (invokeResult.status === 'accepted'
+                              ? 'Invocation accepted. Completion is still pending; continue in Runs to observe progress.'
+                              : invokeResult.status === 'running'
+                                ? 'Invocation in progress.'
+                                : 'Invocation completed.')
                           }
                           showIcon
                           title={`${
@@ -1661,8 +1663,7 @@ const ScopeInvokePage: React.FC = () => {
                           type={
                             invokeResult.status === 'error'
                               ? 'error'
-                              : invokeResult.status === 'success' ||
-                                  invokeResult.status === 'accepted'
+                              : invokeResult.status === 'success'
                                 ? 'success'
                                 : 'info'
                           }

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberCurrentRunPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberCurrentRunPanel.tsx
@@ -70,6 +70,8 @@ function getStatusLabel(status: InvokeResultState['status']): string {
   switch (status) {
     case 'running':
       return 'Running';
+    case 'accepted':
+      return 'Accepted';
     case 'success':
       return 'Succeeded';
     case 'error':
@@ -565,6 +567,11 @@ const StudioMemberCurrentRunPanel: React.FC<
         detail: finishedAtLabel || 'Completed',
         label: 'Run finished',
       });
+    } else if (invokeResult.status === 'accepted') {
+      items.push({
+        detail: 'Command accepted, awaiting completion',
+        label: 'Run accepted',
+      });
     } else if (invokeResult.status === 'error' || invokeResult.status === 'cancelled') {
       items.push({
         detail: errorDescription || 'No extra error text',
@@ -678,7 +685,9 @@ const StudioMemberCurrentRunPanel: React.FC<
         </div>
         <div style={sectionStyle}>
           <span style={sectionLabelStyle}>Output</span>
-          {invokeResult.status === 'running' && !outputText ? (
+          {(invokeResult.status === 'running' ||
+            invokeResult.status === 'accepted') &&
+          !outputText ? (
             <Typography.Text style={helperTextStyle} type="secondary">
               Waiting for output...
             </Typography.Text>

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokeHistoryPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokeHistoryPanel.tsx
@@ -213,11 +213,13 @@ const StudioMemberInvokeHistoryPanel: React.FC<
                     label={
                       entry.status === 'success'
                         ? 'Succeeded'
-                        : entry.status === 'running'
-                          ? 'Running'
-                          : entry.status === 'cancelled'
-                            ? 'Cancelled'
-                            : 'Failed'
+                        : entry.status === 'accepted'
+                          ? 'Accepted'
+                          : entry.status === 'running'
+                            ? 'Running'
+                            : entry.status === 'cancelled'
+                              ? 'Cancelled'
+                              : 'Failed'
                     }
                     status={entry.status}
                   />

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.currentRun.test.ts
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.currentRun.test.ts
@@ -24,7 +24,7 @@ describe('StudioMemberInvokePanel current run model', () => {
     expect(model.rawOutput).toBe('');
   });
 
-  it('builds observe seed and raw output with separated identifiers', () => {
+  it('keeps accepted invoke receipts open in observe seed and raw output', () => {
     const startedAt = Date.parse('2026-04-30T08:00:00Z');
     const completedAt = Date.parse('2026-04-30T08:00:01Z');
     const model = buildStudioInvokeCurrentRunViewModel({
@@ -65,7 +65,7 @@ describe('StudioMemberInvokePanel current run model', () => {
         actorId: 'actor-1',
         commandId: 'cmd-1',
         correlationId: 'corr-1',
-        completedAtUtc: '2026-04-30T08:00:01.000Z',
+        completedAtUtc: null,
         endpointId: 'command',
         errorCode: 'ERR_NONE',
         payloadTypeUrl: 'type.googleapis.com/example.Command',
@@ -87,6 +87,46 @@ describe('StudioMemberInvokePanel current run model', () => {
         runId: 'run-1',
         serviceId: 'script-1',
         status: 'accepted',
+      }),
+    );
+  });
+
+  it('includes completion time for terminal observe seeds', () => {
+    const startedAt = Date.parse('2026-04-30T08:00:00Z');
+    const completedAt = Date.parse('2026-04-30T08:00:01Z');
+    const model = buildStudioInvokeCurrentRunViewModel({
+      activeRunCompletedAt: completedAt,
+      chatMessageCount: 0,
+      currentMemberLabel: 'script-1',
+      currentRunRequest: {
+        mode: 'stream',
+        payloadBase64: '',
+        payloadTypeUrl: '',
+        prompt: 'hello',
+        startedAt,
+      },
+      invokeResult: {
+        ...createIdleInvokeResult(),
+        actorId: 'actor-1',
+        endpointId: 'chat',
+        finalOutput: 'ok',
+        mode: 'stream',
+        runId: 'run-1',
+        serviceId: 'script-1',
+        status: 'success',
+      },
+      isChatEndpoint: true,
+      payloadBase64: '',
+      payloadTypeUrl: '',
+      selectedEndpointId: 'chat',
+      selectedServiceDisplayName: 'Script One',
+      selectedServiceId: 'script-1',
+    });
+
+    expect(model.observeSessionSeed).toEqual(
+      expect.objectContaining({
+        completedAtUtc: '2026-04-30T08:00:01.000Z',
+        status: 'success',
       }),
     );
   });

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.currentRun.test.ts
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.currentRun.test.ts
@@ -49,7 +49,7 @@ describe('StudioMemberInvokePanel current run model', () => {
         finalOutput: 'ok',
         runId: 'run-1',
         serviceId: 'script-1',
-        status: 'success',
+        status: 'accepted',
       },
       isChatEndpoint: false,
       payloadBase64: '',
@@ -74,7 +74,7 @@ describe('StudioMemberInvokePanel current run model', () => {
         serviceId: 'script-1',
         serviceLabel: 'Script One',
         startedAtUtc: '2026-04-30T08:00:00.000Z',
-        status: 'success',
+        status: 'running',
       }),
     );
     expect(JSON.parse(model.rawOutput)).toEqual(
@@ -86,7 +86,7 @@ describe('StudioMemberInvokePanel current run model', () => {
         errorCode: 'ERR_NONE',
         runId: 'run-1',
         serviceId: 'script-1',
-        status: 'success',
+        status: 'accepted',
       }),
     );
   });

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.currentRun.ts
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.currentRun.ts
@@ -20,7 +20,13 @@ export type InvokeResultState = {
   readonly responseJson: string;
   readonly runId: string;
   readonly serviceId: string;
-  readonly status: 'idle' | 'accepted' | 'running' | 'success' | 'error' | 'cancelled';
+  readonly status:
+    | 'idle'
+    | 'accepted'
+    | 'running'
+    | 'success'
+    | 'error'
+    | 'cancelled';
   readonly steps: RuntimeStepInfo[];
   readonly thinking: string;
   readonly toolCalls: RuntimeToolCallInfo[];
@@ -81,6 +87,21 @@ function toIsoTimestamp(value: number | null | undefined): string {
   return typeof value === 'number' && Number.isFinite(value)
     ? new Date(value).toISOString()
     : '';
+}
+
+function getCompletedAtUtc(input: {
+  readonly completedAt: number | null;
+  readonly status: InvokeResultState['status'];
+}): string | null {
+  if (
+    input.status !== 'success' &&
+    input.status !== 'error' &&
+    input.status !== 'cancelled'
+  ) {
+    return null;
+  }
+
+  return toIsoTimestamp(input.completedAt) || null;
 }
 
 export function createIdleInvokeResult(): InvokeResultState {
@@ -164,7 +185,10 @@ function buildObserveSessionSeed(input: {
     assistantText: input.invokeResult.assistantText,
     commandId: trimOptional(input.invokeResult.commandId),
     correlationId: trimOptional(input.invokeResult.correlationId),
-    completedAtUtc: toIsoTimestamp(input.activeRunCompletedAt) || null,
+    completedAtUtc: getCompletedAtUtc({
+      completedAt: input.activeRunCompletedAt,
+      status: input.invokeResult.status,
+    }),
     endpointId,
     error: input.invokeResult.error,
     errorCode: input.invokeResult.errorCode,

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.currentRun.ts
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.currentRun.ts
@@ -20,7 +20,7 @@ export type InvokeResultState = {
   readonly responseJson: string;
   readonly runId: string;
   readonly serviceId: string;
-  readonly status: 'idle' | 'running' | 'success' | 'error' | 'cancelled';
+  readonly status: 'idle' | 'accepted' | 'running' | 'success' | 'error' | 'cancelled';
   readonly steps: RuntimeStepInfo[];
   readonly thinking: string;
   readonly toolCalls: RuntimeToolCallInfo[];
@@ -59,7 +59,7 @@ export type InvokeHistoryEntry = {
   readonly runId: string;
   readonly serviceId: string;
   readonly startedAt: number;
-  readonly status: 'running' | 'success' | 'error' | 'cancelled';
+  readonly status: 'accepted' | 'running' | 'success' | 'error' | 'cancelled';
   readonly summary: string;
   readonly snapshot: {
     readonly chatMessages: StudioInvokeChatMessage[];

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.test.tsx
@@ -687,12 +687,13 @@ describe('StudioMemberInvokePanel', () => {
       expect(onObserveSessionChange).toHaveBeenLastCalledWith(
         expect.objectContaining({
           actorId: 'actor-1',
-          completedAtUtc: expect.any(String),
+          commandId: 'cmd-1',
+          completedAtUtc: null,
           endpointId: 'submit',
           prompt: 'Route this escalation to billing review.',
           runId: 'run-1',
           serviceId: 'default',
-          status: 'success',
+          status: 'running',
         }),
       );
     });
@@ -704,13 +705,12 @@ describe('StudioMemberInvokePanel', () => {
     expect(
       screen.getAllByText('Route this escalation to billing review.').length,
     ).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Accepted').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('Latest run')).toBeTruthy();
     expect(screen.getByText('Status summary')).toBeTruthy();
     expect(screen.getByText('Input')).toBeTruthy();
     expect(screen.getAllByText('Output').length).toBeGreaterThanOrEqual(1);
-    expect(
-      screen.getByText('没有返回可展示内容。'),
-    ).toBeTruthy();
+    expect(screen.getByText('Waiting for output...')).toBeTruthy();
     expect(screen.queryByRole('button', { name: /Details|详情|展开/ })).toBeNull();
     expect(screen.queryByText('运行详情')).toBeNull();
     expect(screen.queryByText('最新输出')).toBeNull();

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.tsx
@@ -118,6 +118,8 @@ function getRunStatusLabel(status: InvokeResultState['status']): string {
   switch (status) {
     case 'running':
       return 'Running';
+    case 'accepted':
+      return 'Accepted';
     case 'success':
       return 'Succeeded';
     case 'error':
@@ -1236,7 +1238,7 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
         responseJson: JSON.stringify(response, null, 2),
         runId,
         serviceId: selectedService.serviceId,
-        status: 'success',
+        status: 'accepted',
       };
       setInvokeResult(finalResult);
       setActiveRunCompletedAt(completedAt);
@@ -1255,7 +1257,7 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
         runId,
         serviceId: selectedService.serviceId,
         startedAt,
-        status: 'success',
+        status: 'accepted',
         summary:
           trimPreview(trimmedPrompt, 72) ||
           trimPreview(trimmedPayloadTypeUrl, 72) ||

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.tsx
@@ -1241,7 +1241,7 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
         status: 'accepted',
       };
       setInvokeResult(finalResult);
-      setActiveRunCompletedAt(completedAt);
+      setActiveRunCompletedAt(null);
       upsertRequestHistory({
         completedAt,
         createdAt: completedAt,

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokeSetupPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokeSetupPanels.tsx
@@ -115,7 +115,8 @@ export const StudioMemberInvokeComposerPanel: React.FC<
   payloadTypeUrl,
   prompt,
 }) => {
-  const isRunning = invokeStatus === 'running';
+  const isRunning =
+    invokeStatus === 'running' || invokeStatus === 'accepted';
   const promptPlaceholder =
     defaultPrompt || '输入 Prompt，发起一次独立 Invoke。';
   const primaryButtonLabel = isRunning ? 'Stop' : 'Invoke';

--- a/apps/aevatar-console-web/src/pages/studio/components/studioInvokeUi.ts
+++ b/apps/aevatar-console-web/src/pages/studio/components/studioInvokeUi.ts
@@ -98,6 +98,8 @@ export function getInvokeRunStatusLabel(
   switch (status) {
     case 'running':
       return '运行中';
+    case 'accepted':
+      return '已受理';
     case 'success':
       return '成功';
     case 'cancelled':
@@ -115,7 +117,7 @@ export function getInvokeStatusTone(status: InvokeResultState['status']): {
   readonly color: string;
   readonly dot: string;
 } {
-  if (status === 'running') {
+  if (status === 'running' || status === 'accepted') {
     return {
       background: studioInvokeColors.assistantSoft,
       border: studioInvokeColors.borderStrong,


### PR DESCRIPTION
## Issue

**frontend-audit-001 (CRITICAL)** — Non-streaming invoke receipts treated as completed run state.

`invokeEndpoint()` POST receipts were immediately setting `status: 'success'` / `'Succeeded'`, violating CQRS ACK honesty: HTTP 200 receipts can only promise Accepted/Running, not Completed.

## Source

Frontend architecture audit (`docs/audit-scorecard/2026-05-28-frontend-audit.md`).

## Fix Summary

Added `'accepted'` as a new status value. Non-streaming invoke POST receipt now sets `status: 'accepted'` instead of `'success'`. All downstream UI surfaces (status label, timeline, history panel, output pane, status tone, Chinese label) handle the new state. Streaming endpoints remain unaffected — SSE completion still maps to `'success'`.

**Changed files (8):**
- `pages/scopes/invoke.tsx` — status union + POST receipt + UI conditionals
- `pages/studio/components/StudioMemberInvokePanel.tsx` — receipt status + getRunStatusLabel
- `pages/studio/components/StudioMemberInvokePanel.currentRun.ts` — type unions
- `pages/studio/components/StudioMemberCurrentRunPanel.tsx` — label, timeline, output pane
- `pages/studio/components/StudioMemberInvokeHistoryPanel.tsx` — history status tag
- `pages/studio/components/StudioMemberInvokeSetupPanels.tsx` — isRunning includes accepted
- `pages/studio/components/studioInvokeUi.ts` — label (已受理) + tone
- `pages/studio/components/StudioMemberInvokePanel.currentRun.test.ts` — updated assertions

## Review Record

| Reviewer | Model | Verdict |
|----------|-------|---------|
| arch-reviewer | Opus | PASS — CQRS state separation correct, no premature completion |
| design-reviewer | Sonnet | PASS — 2 MEDIUM (getRunMarker, getRunStatusLabel default), 1 LOW (type completeness) |
| browser-qa | Opus | BLOCKED (BLOCKED_LAUNCH) — NyxID OAuth wall prevents headless access |
| ci-runner | Sonnet | PASS — tsc clean, 2/2 tests, frontend-static-guard ok |

**Implementation attempts:** 1/3
**Review rounds:** 1/3
**Browser QA evidence:** BLOCKED — app requires NyxID OAuth (Google/GitHub/Apple). Residual risk: type-level + label changes verified by tsc + unit tests + static code review.
**Changed-file scope:** clean — all 8 files under `apps/aevatar-console-web/src/`

## Referenced Rules

- `CLAUDE.md` — "ACK 诚实：同步返回只承诺已达到阶段（默认 accepted + stable command id）"
- `docs/canon/frontend-design.md` §4.1 — HTTP 200 receipt → Accepted, not Completed
- `docs/canon/cqrs-projection.md` §4.1 — command receipt vs observation vs readmodel materialization

## Residual Risk

- Design reviewer found `getRunStatusLabel` (used for status pill at line 1378) falls through to default `'Ready'` for `'accepted'` — minor visual inconsistency in one location. Non-blocking.
- `getRunMarker` does not distinguish `'accepted'` from `'idle'` — marker shows "Latest run" instead of "Accepted run". Non-blocking.

🤖 Generated with [Frontend Refactoring Team](.claude/skills/frontend-refactor-team/)