### PR TITLE
refactor(frontend): migrate execution trace to CqrsStatus

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/components/StudioWorkbenchSections.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioWorkbenchSections.tsx
@@ -900,7 +900,7 @@ export const StudioExecutionPage: React.FC<StudioExecutionPageProps> = ({
   const activeExecutionInteraction =
     activeExecutionLog?.interaction &&
     activeExecutionLog.stepId &&
-    executionTrace?.stepStates.get(activeExecutionLog.stepId)?.status === 'waiting'
+    executionTrace?.stepStates.get(activeExecutionLog.stepId)?.status === 'paused'
       ? activeExecutionLog.interaction
       : null;
   const executionActionKeyBase =

--- a/apps/aevatar-console-web/src/shared/graphs/GraphCanvas.tsx
+++ b/apps/aevatar-console-web/src/shared/graphs/GraphCanvas.tsx
@@ -101,9 +101,9 @@ function StudioWorkflowNode({
       ? '#16A34A'
       : executionStatus === 'failed'
         ? '#DC2626'
-        : executionStatus === 'waiting'
+        : executionStatus === 'paused'
           ? '#D97706'
-          : executionStatus === 'active'
+          : executionStatus === 'running'
             ? '#2563EB'
             : '#94A3B8';
 
@@ -192,7 +192,7 @@ function StudioWorkflowNode({
                   ? '#DCFCE7'
                   : executionStatus === 'failed'
                     ? '#FEE2E2'
-                    : executionStatus === 'waiting'
+                    : executionStatus === 'paused'
                       ? '#FEF3C7'
                       : '#DBEAFE',
               borderRadius: 999,

--- a/apps/aevatar-console-web/src/shared/studio/execution.ts
+++ b/apps/aevatar-console-web/src/shared/studio/execution.ts
@@ -3,6 +3,7 @@ import {
   type Edge,
   type Node,
 } from '@xyflow/react';
+import type { CqrsStatus } from '@/shared/models/cqrsState';
 import type { StudioGraphEdgeData, StudioGraphNodeData } from './graph';
 import type { StudioExecutionDetail } from './models';
 
@@ -19,7 +20,7 @@ export type ExecutionLogItem = {
 
 export type StepExecutionState = {
   readonly stepId: string;
-  status: 'idle' | 'active' | 'waiting' | 'completed' | 'failed';
+  status: CqrsStatus;
   stepType: string;
   targetRole: string;
   startedAt: string | null;
@@ -234,7 +235,7 @@ export function buildExecutionTrace(
       }
 
       const stepState = getOrCreateExecutionStepState(stepStates, stepId);
-      stepState.status = 'active';
+      stepState.status = 'running';
       stepState.stepType = String(customPayload?.stepType || stepState.stepType || '');
       stepState.targetRole = String(
         customPayload?.targetRole || stepState.targetRole || '',
@@ -274,7 +275,7 @@ export function buildExecutionTrace(
       }
 
       const stepState = getOrCreateExecutionStepState(stepStates, stepId);
-      stepState.status = 'waiting';
+      stepState.status = 'paused';
       stepState.stepType = stepState.stepType || interactionKind;
       latestStepId = stepId;
 
@@ -374,7 +375,7 @@ export function buildExecutionTrace(
       }
 
       const stepState = getOrCreateExecutionStepState(stepStates, stepId);
-      stepState.status = 'active';
+      stepState.status = 'running';
       latestStepId = stepId;
       const interactionKind = normalizeExecutionInteractionKind(
         customPayload?.suspensionType,
@@ -501,7 +502,7 @@ export function buildExecutionTrace(
     if (
       logs[index].interaction &&
       stepId &&
-      stepStates.get(stepId)?.status === 'waiting'
+      stepStates.get(stepId)?.status === 'paused'
     ) {
       defaultLogIndex = index;
       break;

--- a/apps/aevatar-console-web/src/shared/studio/graph.ts
+++ b/apps/aevatar-console-web/src/shared/studio/graph.ts
@@ -5,6 +5,7 @@ import {
   type Node,
   type XYPosition,
 } from '@xyflow/react';
+import type { CqrsStatus } from '@/shared/models/cqrsState';
 
 export type StudioGraphRole = {
   readonly id: string;
@@ -43,7 +44,7 @@ export type StudioGraphNodeData = {
   readonly targetRole: string;
   readonly parametersSummary: string;
   readonly branchCount: number;
-  readonly executionStatus?: 'idle' | 'active' | 'waiting' | 'completed' | 'failed';
+  readonly executionStatus?: CqrsStatus;
   readonly executionFocused?: boolean;
 };
 


### PR DESCRIPTION
## Issue

**frontend-audit-003 (HIGH)** — Incomplete CQRS state model in execution trace.

`StepExecutionState.status` was typed as `'idle' | 'active' | 'waiting' | 'completed' | 'failed'`, missing Accepted, Streaming, Paused, Observed, StillProcessing states required by the design baseline.

## Source

Frontend architecture audit (`docs/audit-scorecard/2026-05-28-frontend-audit.md`).

## Fix Summary

Migrated `execution.ts` to use the shared `CqrsStatus` type from PR #1152. Renamed:
- `'active'` → `'running'` (observation phase)
- `'waiting'` → `'paused'` (waiting for human input/approval/signal)

Updated 3 consumer files:
- `graph.ts` — `StudioGraphNodeData.executionStatus` type
- `GraphCanvas.tsx` — status color and badge rendering
- `StudioWorkbenchSections.tsx` — interaction detection check

## Review Record

| Reviewer | Model | Verdict |
|----------|-------|---------|
| ci-runner | Sonnet | PASS — tsc clean, 656/656 tests |

**Stacked on:** PR #1152 (shared CqrsStatus type)

🤖 Generated with [Frontend Refactoring Team](.claude/skills/frontend-refactor-team/)