### PR TITLE
skill: audit prompt 收紧 cluster scope(防 reflector 连续 re-cluster)

### DIFF
--- a/.claude/skills/codex-refactor-loop/prompts/audit.md
+++ b/.claude/skills/codex-refactor-loop/prompts/audit.md
@@ -26,7 +26,11 @@
    {"rule_id":"<clause id>","path":"<file>","line":1,"evidence":"<snippet>","verdict":"accept|reject","reject_reason":"<if reject>","prior_cluster_overlap":"<cluster-id|none>"}
    ```
    `candidate_count >= 25`，除非 analyzer 全 0 且有证据。
-4. 从 `accept` candidates 形成 cluster。要求：文件交集 ≤5%；单 cluster 估计 ≤30 文件（小重构 ≤15）；不新增功能；明确 old/new pattern；深层协议/actor/proto 迁移标 `requires_design: true`，不要拒绝。
+4. 从 `accept` candidates 形成 cluster。要求：文件交集 ≤5%；每个 cluster 只能表达一个 implementation concern；`rule_ids` 数量 ≤2（优选 1）；`files_touched_estimate` 严格上限 6 文件，超过必须拆分；不新增功能；明确 old/new pattern；深层协议/actor/proto 迁移标 `requires_design: true`，不要拒绝。
+   - Single-concern cluster rule：多条规则命中同一段代码时，仍按可独立修复的 concern 拆成多个 cluster，可以共享 evidence file，但不能把多个 sub-concern 合并成一个 PR。
+   - Sub-concern detection：emit cluster 前自问 implementer 能否一次 PR 修完这个问题；如果能想到 ≥2 个实现步骤、≥2 个 sub-rule、≥2 个业务决策，或需要同时改两个独立协议/边界，就拆成更小 cluster。
+   - Estimate cap：`files_touched_estimate` 的最大值不得超过 6；若初步估计是 `4-12`、`8-18` 等范围，必须在输出前拆到每个子 cluster 的上限 ≤6。
+   - Pre-check：每个 cluster 输出前执行自检：`if rule_ids.length > 2 OR files_touched_estimate.max > 6 => split into sub-clusters`。未通过自检禁止 emit。
 5. 每个 cluster 输出：
    ```yaml
    id: cluster-NNN-<slug>


### PR DESCRIPTION
## 摘要

skill 自审改进 — audit prompt 收紧 cluster scope。

**Pattern observed**:最近 3 个 design issue 全被 reflector ruled `re-cluster`:
- #1084 / PR #1151:cluster 涵盖 inline IO 删 / retry-timeout eventize / worker eventize 3 sub-concern
- #1156:resolver-pure / lifecycle-command-narrow / catalog-actor-future 3 sub-concern
- #1157:route-delete / artifact-ownership 2 sub-concern

每个 cluster 触发多个 reject + reflector 介入,浪费 ~30 codex per issue × 3 issues = ~90 codex on cluster-scope misalignment。

## 改动

`audit.md` cluster 形成规则收紧:
- **rule_ids ≤2**(优选 1):多 rule 命中同代码 → 拆 cluster(可共享 evidence file)
- **files_touched_estimate ≤6**(从 ≤30 / ≤15 收紧):超过必拆
- **Sub-concern detection**:emit cluster 前自问 implementer 能否一 PR 修完;能想到 ≥2 步 / ≥2 sub-rule / ≥2 业务决策 → 拆
- **Pre-check**:`rule_ids.length>2 OR files_touched_estimate.max>6 → split into sub-clusters`,未通过禁止 emit

## 影响

- audit-iter-155/156 in-flight(已 spawn,旧 prompt)— 不影响
- iter-157+ 新 audit 用新 prompt 应避免再 re-cluster
- 单 cluster PR diff 更小 → reviewer 更易 unanimous approve

## 范围

1 file changed(+5/-1)。skill prompt only,不影响产线代码,无 dotnet test 需求。

🤖 Auto-loop / codex-refactor-loop self-improvement

⟦AI:AUTO-LOOP⟧
