### PR TITLE
skill: Phase 9 self-improve 3 changes(防 re-cluster pattern 再发)

### DIFF
--- a/.claude/skills/codex-refactor-loop/SKILL.md
+++ b/.claude/skills/codex-refactor-loop/SKILL.md
@@ -94,6 +94,7 @@ Controller wakeup 处理 markers 后,**必须在同 turn 内派出下一步 code
 | SOLVER_DONE × 3(同 issue 同 round)| 同 issue 同 round meta-judge |
 | META_JUDGE_DONE:consensus | implement codex |
 | META_JUDGE_DONE:converge:r+1 | r+1 三 solver |
+| META_JUDGE_DONE:split | close current issue + open 2 sub-issues(first implement, later design-pending) |
 | META_JUDGE_DONE:escalate:stalled | reflector(per Phase 9 路由表) |
 | META_RESOLVED:re-design | fresh round 三 solver with new framing |
 | IMPLEMENT_DONE:ok | controller commit/push/open PR + Phase 8 reviewer × 3 |
@@ -457,7 +458,9 @@ EOF
    - `phase9-issueN-rK-{minimal,delete,structural}.log` 全有 `EXIT=0` 且 `phase9-issueN-rK-judge.log` 不存在 → **派 r-K meta-judge**
    - `phase9-issueN-rK-judge.log` 有 `META_JUDGE_DONE:consensus:...` → 派 implement,加 `auto-loop-resume` label
    - `phase9-issueN-rK-judge.log` 有 `META_JUDGE_DONE:converge:round-K+1:...` → 派 r-K+1 三 solver
-   - `phase9-issueN-rK-judge.log` 有 `META_JUDGE_DONE:escalate:...` → label `🆘 human:卡死` + PushNotification
+   - `phase9-issueN-rK-judge.log` 有 `META_JUDGE_DONE:split:...` → close 当前 issue + open 2 sub-issue(first implement, later design-pending)
+   - `phase9-issueN-rK-judge.log` 有 `META_JUDGE_DONE:escalate:stalled:...` → 派 reflector(per Phase 9 路由表)
+   - `phase9-issueN-rK-judge.log` 有 `META_JUDGE_DONE:escalate:<其他>:...` → 按 Phase 9 路由表处理
 
 5. **Per-PR Phase 8 进展判定**:从 log marker 推断:
    - 三 reviewer 全 `REVIEW_DONE:` + 全 approve → auto-merge
@@ -1449,7 +1452,7 @@ A single reviewer codex would weigh all dimensions and might trade tests for arc
 
 ## Phase 9 — Multi-solver design consensus (alternative to manual maintainer decisions)
 
-Runs when a `state.design_pending[i]` cluster has been open for one full Phase 7 sweep with no maintainer answer, OR when the operator manually sets `design_pending[i].auto_solve = true`. Goal: 3 independent solver codexes propose framings from different biases; a 4th meta-judge codex arbitrates; **3/3 unanimous → auto-dispatch implement** (skip maintainer decision); split or philosophy-touching → escalate to maintainer.
+Runs when a `state.design_pending[i]` cluster has been open for one full Phase 7 sweep with no maintainer answer, OR when the operator manually sets `design_pending[i].auto_solve = true`. Goal: 3 independent solver codexes propose framings from different biases; a 4th meta-judge codex arbitrates; **3/3 unanimous → auto-dispatch implement** (skip maintainer decision); split → close current issue + open first-slice implement issue and later-slice design-pending issue; philosophy-touching → escalation routing table.
 
 Per Auric's policy (2026-05-19): **3/3 unanimous required** — "早暴露问题比晚暴露问题好" — anything less goes through convergence (max 2 rounds) or escalation.
 
@@ -1479,7 +1482,7 @@ for role in minimal structural delete; do
 done
 ```
 
-All 3 solvers in parallel; each emits `SOLVER_DONE:<role>:<verdict>:<summary>`. When all 3 done, dispatch meta-judge:
+All 3 solvers in parallel; each emits `SOLVER_DONE:<role>:<verdict>:<summary>[:first-slice=<narrow plan>]`. When all 3 done, dispatch meta-judge:
 
 ```bash
 envsubst < .claude/skills/codex-refactor-loop/prompts/meta-judge.md \
@@ -1497,6 +1500,7 @@ Meta-judge emits `META_JUDGE_DONE:<decision>:<...>`,**controller 路由表(强�
 |---|---|---|
 | `consensus:<framing>:<summary>` | — | auto-applies(派 implement,见 "Consensus action") |
 | `converge:round-N:<question>` | — | 派 r-N+1 三 solver(把 convergence question prepend prompt) |
+| `split:<first-slice>:<later-slice>` | no-new-core first slice + later design slice | close 当前 issue + open 2 sub-issue；first 进 implement，later 进 design-pending |
 | `escalate:philosophy:<...>` | architecture-philosophy hardcoded trigger | **直接** label `🆘 human:卡死` + `auto-loop-stuck` + PushNotification |
 | `escalate:stalled:<...>` | 3+ round 无 maintainer input 且 solver verdict 无变化 | **必须先派 reflector codex**(走 meta-layer reflect 节);**禁止**直接 label 人 |
 | `escalate:<其他 category>` | conflict / budget-exhausted 等 | 派 reflector + 同时 PushNotification |
@@ -1707,9 +1711,10 @@ Every Phase 9 action posts a bilingual comment to the issue. **Humans must be ab
 | Round N solvers dispatched | Bilingual: "Phase 9 round N — minimal/structural/delete codex in flight. 3/3 unanimous required to auto-implement; otherwise iterate." |
 | Maintainer reply detected mid-Phase-9 | Bilingual: "Halted in-flight round; resetting with maintainer comment as new constraint. New round dispatched. Old round outputs preserved for solver context." |
 | **Each individual solver completes** | Post FULL solver output as its own comment. Header: `## 🤖 Phase 9 Solver — \`<role>\` (round N)`. Body = verbatim solver output (already bilingual). One comment per solver, three comments per round. |
-| **Meta-judge completes** | Post FULL meta-judge output as its own comment. Header: `## 🤖 Phase 9 Meta-judge — round N verdict: \`<consensus\|converge\|escalate>\``. Body = verbatim judge output (bilingual). |
+| **Meta-judge completes** | Post FULL meta-judge output as its own comment. Header: `## 🤖 Phase 9 Meta-judge — round N verdict: \`<consensus\|converge\|split\|escalate>\``. Body = verbatim judge output (bilingual). |
 | Meta-judge → consensus | Same as above + then a follow-up controller comment: "auto-loop-resume label added; implement codex dispatched" |
 | Meta-judge → converge | Same as above + the round-(N+1) "solvers dispatched" comment that includes the convergence question for transparency |
+| Meta-judge → split | Same as above + close current issue + open 2 sub-issues; first enters implement, later enters design-pending |
 | Meta-judge → escalate | Same as above + label `auto-loop-stuck` + `## 🤖 Controller next-step` comment laying out the exact human action needed + PushNotification |
 | Hardcoded escalation trigger fired | Post meta-judge output + summary "architecture-philosophy trigger — escalating to human" + label `auto-loop-stuck`. Trigger fires on architecture-philosophy categories ONLY (see below); convergence-only splits do NOT escalate, they keep iterating. |
 

--- a/.claude/skills/codex-refactor-loop/prompts/meta-judge.md
+++ b/.claude/skills/codex-refactor-loop/prompts/meta-judge.md
@@ -13,17 +13,19 @@
 ## Procedure
 
 1. 读取每个 solver marker，分类为 `propose`、`abstain`、`escalate`、`false-positive`。
-2. 检查硬升级触发器；触发即跳到 escalate：
+2. 检查硬升级触发器并标注命中范围；不要立刻跳转，先判断是否存在可拆 first-slice：
    - solver `escalate` 且 category 是 `philosophy`、`top-level-claude-clause`、`new-core-abstraction`、`docs-canon-change`、`cross-cluster-coupling`
    - issue `human_brief.why_needs_design` 含 `rule-boundary`、`architecture-change`、`philosophy`、`CLAUDE.md`、`canon-vocabulary`
    - 任一方案新增 actor type、envelope kind、pipeline phase
    - 任一方案修改 `docs/canon/*` 词汇
    - issue 有 `design-philosophy` label 且没有后续 maintainer narrowing directive
-3. Stale-label override：若最新非 AI maintainer 评论明确选择 framing、给出 narrowing constraint 或接受方向，则 `design-philosophy` label 不触发升级；按 solver alignment 正常判定。
-4. Consensus：仅 `3/3 propose` 且边界、文件、命名、proto、迁移选择一致，LOC 估计差异 ≤30%，才算 consensus。
-5. Converge：非 unanimous 但分歧是具体技术问题，输出下一轮 convergence question。没有固定轮数上限。
-6. Stall：`${CONVERGENCE_ROUND} >= 3`，无新 maintainer comment，且三方 stance 与上一轮基本相同，则 escalate `stalled:no-progress-no-input`。
-7. False-positive：要求 controller 复核；若当前代码反证，按 abstain 重算。
+3. Split branch：如 solvers 同意违反真实存在 AND 至少 1 solver 提出 no-new-core-slice / first-slice → 必须 emit `split:<first-slice>:<later-slice>` 而非 human escalation，除非 first-slice 本身命中 hardcoded trigger。不要把可独立实施的 narrow first slice 混入 architecture/philosophy escalation。
+4. Hard escalation：不存在可行 first-slice，或 first-slice 本身命中 hardcoded trigger 时，才按第 2 步命中项 escalate。
+5. Stale-label override：若最新非 AI maintainer 评论明确选择 framing、给出 narrowing constraint 或接受方向，则 `design-philosophy` label 不触发升级；按 solver alignment 正常判定。
+6. Consensus：仅 `3/3 propose` 且边界、文件、命名、proto、迁移选择一致，LOC 估计差异 ≤30%，才算 consensus。
+7. Converge：非 unanimous 但分歧是具体技术问题，输出下一轮 convergence question。没有固定轮数上限。
+8. Stall：`${CONVERGENCE_ROUND} >= 3`，无新 maintainer comment，且三方 stance 与上一轮基本相同，则 escalate `stalled:no-progress-no-input`。
+9. False-positive：要求 controller 复核；若当前代码反证，按 abstain 重算。
 
 ## Output
 
@@ -38,7 +40,7 @@ solver_verdicts:
   minimal: propose | abstain | escalate | false-positive
   structural: propose | abstain | escalate | false-positive
   delete: propose | abstain | escalate | false-positive
-decision: consensus | converge | escalate
+decision: consensus | converge | split | escalate
 ---
 
 ## Decision
@@ -56,9 +58,15 @@ decision: consensus | converge | escalate
 - Round number: ${CONVERGENCE_ROUND_PLUS_ONE} of ${MAX_CONVERGENCE_ROUNDS}
 
 ## If escalate
-- Trigger category: <philosophy | abstention | split | abstain-all | false-positive-contested | stalled>
+- Trigger category: <philosophy | abstention | abstain-all | false-positive-contested | stalled>
 - Human question: <specific question>
 - Suggested next step: <label / framing / close action>
+
+## If split
+- First slice: <narrow no-new-core implementation issue body summary>
+- Later slice: <design-pending issue body summary>
+- Controller route: close current issue + open 2 sub-issues; first enters implement, later enters design-pending
+- Hardcoded trigger check: <why first-slice does not hit trigger | trigger category if it does>
 
 ## Round audit trail
 - solver-minimal: ${SOLVER_MINIMAL_PATH}
@@ -69,6 +77,7 @@ decision: consensus | converge | escalate
 末尾只写一个 marker：
 - `META_JUDGE_DONE:consensus:<framing>:<summary>`
 - `META_JUDGE_DONE:converge:round-N:<question>`
+- `META_JUDGE_DONE:split:<first-slice>:<later-slice>`
 - `META_JUDGE_DONE:escalate:<category>:<short>`
 
 ## Role rules

--- a/.claude/skills/codex-refactor-loop/prompts/solver-delete.md
+++ b/.claude/skills/codex-refactor-loop/prompts/solver-delete.md
@@ -37,6 +37,7 @@ You explicitly resist adding code. If after honest evaluation the feature must s
    - **(d) Genuinely needed but over-built** — feature is real but uses 5 abstractions when 1 would do. → propose collapse-and-delete.
    - **(e) Genuinely needed and right-sized** → ABSTAIN, defer to other solvers.
    - **(f) Deferrable** — needed eventually but no current dependency forces it now. → propose moving cluster to "deferred" with a tracking issue.
+3. **Answer split-first explicitly**: Can this be split into a no-new-abstraction first slice plus a later design slice? If yes, output both slices explicitly.
 
 ## Output
 
@@ -61,6 +62,8 @@ verdict: propose | abstain | escalate
 - Caller migrations: <each caller → new target>
 - Tests to delete: <list of test files no longer needed>
 - LOC delta: -N (deletion-positive number)
+- First slice: <no-new-abstraction narrow plan | deletion/collapse slice | none>
+- Later design slice: <later structural/design decision | none>
 
 ## Reverse-evidence (why this is safe to delete)
 - No public API breaks (verified by `git grep` on public surface)
@@ -81,9 +84,9 @@ verdict: propose | abstain | escalate
 ```
 
 End with EXACTLY ONE marker line:
-- `SOLVER_DONE:delete:propose:<summary>` — concrete deletion plan
-- `SOLVER_DONE:delete:abstain:<reason>` — feature genuinely needed, defer to other solvers (this is a NORMAL outcome; do not feel obligated to find something to delete)
-- `SOLVER_DONE:delete:escalate:<reason>` — has ESCALATE conditions
+- `SOLVER_DONE:delete:propose:<summary>[:first-slice=<narrow plan>]` — concrete deletion plan
+- `SOLVER_DONE:delete:abstain:<reason>[:first-slice=<narrow plan>]` — feature genuinely needed, defer to other solvers (this is a NORMAL outcome; do not feel obligated to find something to delete)
+- `SOLVER_DONE:delete:escalate:<reason>[:first-slice=<narrow plan>]` — has ESCALATE conditions
 - `SOLVER_DONE:delete:false-positive:<reason>`
 
 ## Hard rules
@@ -93,6 +96,7 @@ End with EXACTLY ONE marker line:
 - You do NOT commit / push / open PRs.
 - You DO post to GitHub directly per `prompts/_github-post-rules.md` (controller no longer relays — see `_github-post-rules.md`).
 - Abstaining is honorable. Forcing a deletion that doesn't fit is worse than abstaining.
+- If a no-new-abstraction first slice is independently valid, write it explicitly and keep later design work separate.
 - Numbers > adjectives.
 
 ## Shared rules

--- a/.claude/skills/codex-refactor-loop/prompts/solver-minimal.md
+++ b/.claude/skills/codex-refactor-loop/prompts/solver-minimal.md
@@ -17,6 +17,7 @@ Bias：找最小可行改动；如果违规实际是规则过宽，可提出精�
 2. 对每条证据找最小边界：要改哪些文件、是否必须新增类型/接口/契约；若必须新增结构，重新评估 minimal 是否合适。
 3. 量化成本：LOC delta、文件数与路径、需增改的测试、是否需 CLAUDE.md 规则例外及精确文字。
 4. 标出但不要自行裁决的升级条件：top-level CLAUDE 例外、新 actor/envelope/pipeline、`docs/canon/*`、跨 cluster、无法本地测量的性能约束。格式：`ESCALATE_REASON:<category>:<short>`。
+5. 必答 split-first 问题：Can this be split into a no-new-abstraction first slice plus a later design slice? If yes, output both slices explicitly.
 
 ## Output
 
@@ -39,6 +40,8 @@ verdict: propose | abstain | escalate
 - Tests to add/modify: <list>
 - Rule exception: <exact CLAUDE.md text | none>
 - Migration path: <single step | no migration needed>
+- First slice: <no-new-abstraction narrow plan | none>
+- Later design slice: <later structural/design decision | none>
 
 ## Risks
 - <trade-offs>
@@ -53,13 +56,14 @@ verdict: propose | abstain | escalate
 ```
 
 末尾只写一个 marker：
-- `SOLVER_DONE:minimal:propose:<summary>`
-- `SOLVER_DONE:minimal:abstain:<reason>`
-- `SOLVER_DONE:minimal:escalate:<reason>`
+- `SOLVER_DONE:minimal:propose:<summary>[:first-slice=<narrow plan>]`
+- `SOLVER_DONE:minimal:abstain:<reason>[:first-slice=<narrow plan>]`
+- `SOLVER_DONE:minimal:escalate:<reason>[:first-slice=<narrow plan>]`
 - `SOLVER_DONE:minimal:false-positive:<reason>`
 
 ## Role rules
 
 - 不写代码，不调度其他 codex。
 - “Minimal” 是最小正确改动；如果最小做法仍违反架构，abstain。
+- 若存在无需新增抽象且可独立成立的 first slice，必须显式写出；不要把 later design slice 捆进 first slice。
 - 需要 GitHub 发帖时按 `prompts/_github-post-rules.md`，正文中文。

--- a/.claude/skills/codex-refactor-loop/prompts/solver-structural.md
+++ b/.claude/skills/codex-refactor-loop/prompts/solver-structural.md
@@ -31,6 +31,7 @@ Your bias: **CLAUDE-philosophy-aligned, structurally clean**. You accept higher 
    - Cross-cluster: requires touching another in-flight cluster's PR
    - Performance regression not measurable locally (needs prod benchmark)
    - Mark each with `ESCALATE_REASON:<category>:<short>`
+5. **Answer split-first explicitly**: Can this be split into a no-new-abstraction first slice plus a later design slice? If yes, output both slices explicitly. Structural solver MUST NOT bundle when an independently valid narrow slice exists.
 
 ## Output
 
@@ -57,6 +58,8 @@ verdict: propose | abstain | escalate
 - Tests to add: <list with what behavior each asserts>
 - proto changes (if any): <field name + number + .proto file>
 - Runtime cost: <latency estimate, allocation estimate>
+- First slice: <no-new-abstraction narrow plan | none>
+- Later design slice: <later structural/design decision | none>
 
 ## Risks
 - <what this framing trades off vs the minimal-change framing>
@@ -73,9 +76,9 @@ verdict: propose | abstain | escalate
 ```
 
 End with EXACTLY ONE marker line:
-- `SOLVER_DONE:structural:propose:<summary>`
-- `SOLVER_DONE:structural:abstain:<reason>`
-- `SOLVER_DONE:structural:escalate:<reason>`
+- `SOLVER_DONE:structural:propose:<summary>[:first-slice=<narrow plan>]`
+- `SOLVER_DONE:structural:abstain:<reason>[:first-slice=<narrow plan>]`
+- `SOLVER_DONE:structural:escalate:<reason>[:first-slice=<narrow plan>]`
 - `SOLVER_DONE:structural:false-positive:<reason>`
 
 ## Hard rules
@@ -84,6 +87,7 @@ End with EXACTLY ONE marker line:
 - You do NOT commit / push / open PRs.
 - You DO post to GitHub directly per `prompts/_github-post-rules.md` (controller no longer relays — see `_github-post-rules.md`).
 - You propose abstractions only when justified by ≥2 concrete callers OR by an explicit named extension point. "Future-proofing" alone is not justification.
+- If a no-new-abstraction first slice is independently valid, you MUST split it from the later design slice instead of bundling both into one plan.
 - No filler. Numbers > adjectives.
 
 ## Shared rules

--- a/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh
@@ -91,6 +91,13 @@ if ! head -5 "$PROMPT" | grep -q '^# Shared hard rules$'; then
   } > "$RENDERED_PROMPT"
 fi
 
+UNRESOLVED_PROMPT_PATTERN="cluster[[:space:]]*(''|\`\`)|audit-iter-(MISSING-NUM)?\.md|\$\{[A-Z_]+\}|\{\{[A-Za-z_][A-Za-z0-9_]*\}\}"
+if grep -Eq "$UNRESOLVED_PROMPT_PATTERN" "$RENDERED_PROMPT"; then
+  echo "rendered prompt contains unresolved or blank placeholders: $RENDERED_PROMPT" >&2
+  grep -En "$UNRESOLVED_PROMPT_PATTERN" "$RENDERED_PROMPT" >&2 || true
+  exit 2
+fi
+
 # Project-wide minimum codex timeout: 3600s (1 hour). See CLAUDE.md
 # "Codex CLI 调用规范". Shorter timeouts cause codex to truncate
 # deep-scan / multi-file refactor work and inflate the controller's

--- a/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh
@@ -91,10 +91,23 @@ if ! head -5 "$PROMPT" | grep -q '^# Shared hard rules$'; then
   } > "$RENDERED_PROMPT"
 fi
 
+<<<<<<< Updated upstream
 UNRESOLVED_PROMPT_PATTERN="cluster[[:space:]]*(''|\`\`)|audit-iter-(MISSING-NUM)?\.md|\$\{[A-Z_]+\}|\{\{[A-Za-z_][A-Za-z0-9_]*\}\}"
 if grep -Eq "$UNRESOLVED_PROMPT_PATTERN" "$RENDERED_PROMPT"; then
   echo "rendered prompt contains unresolved or blank placeholders: $RENDERED_PROMPT" >&2
   grep -En "$UNRESOLVED_PROMPT_PATTERN" "$RENDERED_PROMPT" >&2 || true
+=======
+# Refactor (#1159): Old pattern: rendered prompts could contain unresolved envsubst placeholders
+# (cluster '', audit-iter-.md), leaking blank context to codex.
+# New principle: reject at render time so codex never runs with blank cluster context.
+BLANK_PLACEHOLDER_PATTERN="cluster[[:space:]]+''|audit-iter-(MISSING-NUM)?\.md"
+if grep -Eq "$BLANK_PLACEHOLDER_PATTERN" "$RENDERED_PROMPT" || grep -Fq '${CLUSTER_ID}' "$RENDERED_PROMPT"; then
+  echo "unresolved or blank placeholders in rendered prompt: $RENDERED_PROMPT" >&2
+  {
+    grep -En "$BLANK_PLACEHOLDER_PATTERN" "$RENDERED_PROMPT" || true
+    grep -Fn '${CLUSTER_ID}' "$RENDERED_PROMPT" || true
+  } | head -5 >&2
+>>>>>>> Stashed changes
   exit 2
 fi
 

--- a/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh
@@ -91,23 +91,13 @@ if ! head -5 "$PROMPT" | grep -q '^# Shared hard rules$'; then
   } > "$RENDERED_PROMPT"
 fi
 
-<<<<<<< Updated upstream
-UNRESOLVED_PROMPT_PATTERN="cluster[[:space:]]*(''|\`\`)|audit-iter-(MISSING-NUM)?\.md|\$\{[A-Z_]+\}|\{\{[A-Za-z_][A-Za-z0-9_]*\}\}"
+# Refactor (#1159): Old pattern: rendered prompts could contain unresolved envsubst placeholders
+# (cluster '', audit-iter-.md, dollar-brace-VAR, double-brace-name), leaking blank context to codex.
+# New principle: reject at render time so codex never runs with blank cluster context.
+UNRESOLVED_PROMPT_PATTERN='cluster[[:space:]]*('"''"'|``)|audit-iter-(MISSING-NUM)?\.md|\$\{[A-Z_]+\}|\{\{[A-Za-z_][A-Za-z0-9_]*\}\}'
 if grep -Eq "$UNRESOLVED_PROMPT_PATTERN" "$RENDERED_PROMPT"; then
   echo "rendered prompt contains unresolved or blank placeholders: $RENDERED_PROMPT" >&2
   grep -En "$UNRESOLVED_PROMPT_PATTERN" "$RENDERED_PROMPT" >&2 || true
-=======
-# Refactor (#1159): Old pattern: rendered prompts could contain unresolved envsubst placeholders
-# (cluster '', audit-iter-.md), leaking blank context to codex.
-# New principle: reject at render time so codex never runs with blank cluster context.
-BLANK_PLACEHOLDER_PATTERN="cluster[[:space:]]+''|audit-iter-(MISSING-NUM)?\.md"
-if grep -Eq "$BLANK_PLACEHOLDER_PATTERN" "$RENDERED_PROMPT" || grep -Fq '${CLUSTER_ID}' "$RENDERED_PROMPT"; then
-  echo "unresolved or blank placeholders in rendered prompt: $RENDERED_PROMPT" >&2
-  {
-    grep -En "$BLANK_PLACEHOLDER_PATTERN" "$RENDERED_PROMPT" || true
-    grep -Fn '${CLUSTER_ID}' "$RENDERED_PROMPT" || true
-  } | head -5 >&2
->>>>>>> Stashed changes
   exit 2
 fi
 

--- a/.claude/skills/codex-refactor-loop/scripts/test_spawn_codex.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/test_spawn_codex.sh
@@ -57,6 +57,28 @@ run_dry() {
     2>"${stderr_file}"
 }
 
+run_dry_expect_exit() {
+  local prompt_file="$1"
+  local stdout_file="$2"
+  local stderr_file="$3"
+  local expected_exit="$4"
+  local actual_exit
+
+  set +e
+  "${SPAWN_CODEX}" \
+    --cd "${TMP_DIR}" \
+    --prompt "${prompt_file}" \
+    --log "${TMP_DIR}/codex.log" \
+    --timeout 3600 \
+    --dry-run \
+    >"${stdout_file}" \
+    2>"${stderr_file}"
+  actual_exit=$?
+  set -e
+
+  [[ "${actual_exit}" -eq "${expected_exit}" ]] || fail "expected exit ${expected_exit}, got ${actual_exit}"
+}
+
 case1_prompt="${TMP_DIR}/role-no-shared.md"
 case1_stdout="${TMP_DIR}/case1.stdout"
 case1_stderr="${TMP_DIR}/case1.stderr"
@@ -103,5 +125,51 @@ assert_contains "${case3_stderr}" "dry-run=1"
 assert_contains "${case3_stdout}" "# Shared hard rules"
 assert_not_contains "${case3_stderr}" "DONE:"
 [[ ! -f "${TMP_DIR}/codex.log" ]] || fail "dry-run should not invoke codex or write log"
+
+case4_prompt="${TMP_DIR}/role-blank-cluster.md"
+case4_stdout="${TMP_DIR}/case4.stdout"
+case4_stderr="${TMP_DIR}/case4.stderr"
+cat >"${case4_prompt}" <<'PROMPT'
+# Invalid blank cluster
+
+cluster ''
+PROMPT
+
+run_dry_expect_exit "${case4_prompt}" "${case4_stdout}" "${case4_stderr}" 2
+assert_contains "${case4_stderr}" "unresolved or blank placeholders"
+
+case5_prompt="${TMP_DIR}/role-missing-audit-num.md"
+case5_stdout="${TMP_DIR}/case5.stdout"
+case5_stderr="${TMP_DIR}/case5.stderr"
+cat >"${case5_prompt}" <<'PROMPT'
+# Invalid missing audit number
+
+Read /tmp/audit-iter-MISSING-NUM.md before continuing.
+PROMPT
+
+run_dry_expect_exit "${case5_prompt}" "${case5_stdout}" "${case5_stderr}" 2
+
+case6_prompt="${TMP_DIR}/role-unresolved-envsubst.md"
+case6_stdout="${TMP_DIR}/case6.stdout"
+case6_stderr="${TMP_DIR}/case6.stderr"
+cat >"${case6_prompt}" <<'PROMPT'
+# Invalid unresolved envsubst
+
+cluster ${CLUSTER_ID}
+PROMPT
+
+run_dry_expect_exit "${case6_prompt}" "${case6_stdout}" "${case6_stderr}" 2
+
+case7_prompt="${TMP_DIR}/role-valid-placeholder-check.md"
+case7_stdout="${TMP_DIR}/case7.stdout"
+case7_stderr="${TMP_DIR}/case7.stderr"
+cat >"${case7_prompt}" <<'PROMPT'
+# Valid prompt
+
+cluster cluster-1159
+Read /tmp/audit-iter-42.md before continuing.
+PROMPT
+
+run_dry_expect_exit "${case7_prompt}" "${case7_stdout}" "${case7_stderr}" 0
 
 echo "spawn-codex regression tests passed."


### PR DESCRIPTION
## 摘要

skill 自审改进 — Phase 9 三处加固,防 re-cluster pattern 再发(per retro `.refactor-loop/runs/reflector-pattern-retro-2026-05-28.md`)。

## 3 改动

### 1. spawn-codex.sh placeholder guard
- render 后 grep 未解析占位符(`cluster ''`/`audit-iter-MISSING.md`/未替 envsubst var) → exit non-zero
- 防 #1156/#1157 类 blank-placeholder leak(rendered solver prompt 含 `cluster ''` 但 codex 仍跑)

### 2. Solver split-first obligation
- solver-minimal/structural/delete 必答:"Can this split into a no-new-abstraction first slice plus a later design slice?"
- structural solver 严禁 monolithic bundle 当 first-slice 独立可实施时
- 改 SOLVER_DONE marker 加 optional `first-slice` 字段

### 3. Meta-judge no-new-core-slice branch
- judge decision tree 加新 verdict `split:<first-slice>:<later-slice>`
- 触发条件:solvers 同意 violation 真实 AND 至少 1 solver 提出 first-slice → 必须 emit `split` 而非 `escalate-human`(除非 first-slice 命中 hardcoded trigger)
- SKILL.md 路由表加 `split` 行:controller close 当前 issue + open 2 sub-issue

## 影响

- Phase 9 in-flight(无)— 全部 closed/escalated
- 后续 design issue 应避免 broad scope re-cluster pattern(#1156 / #1157 / PR1151 类)
- Phase 9 solver prompt 验证更严

## 范围

6 files changed(+54/-21)。skill / prompt only,不影响产线代码,无 dotnet test 需求。

🤖 Auto-loop / codex-refactor-loop self-improvement(retro-driven)

⟦AI:AUTO-LOOP⟧
