### PR TITLE
refactor(frontend): consolidate mono font to aevatarMonoFontFamily

### DIFF
--- a/apps/aevatar-console-web/src/modules/studio/scripts/ScriptCodeEditor.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/ScriptCodeEditor.tsx
@@ -6,6 +6,7 @@ import Editor, {
 import React from 'react';
 import 'monaco-editor/esm/vs/basic-languages/csharp/csharp.contribution';
 import type * as MonacoEditorNamespace from 'monaco-editor';
+import { aevatarMonoFontFamily } from '@/shared/ui/compactText';
 
 const monacoEditor = require(
   'monaco-editor/esm/vs/editor/editor.api.js',
@@ -168,7 +169,7 @@ const ScriptCodeEditor: React.FC<ScriptCodeEditorProps> = ({
         onMount={onMount}
         options={{
           automaticLayout: true,
-          fontFamily: 'Menlo, Monaco, Consolas, monospace',
+          fontFamily: aevatarMonoFontFamily,
           fontLigatures: false,
           fontSize: 13,
           glyphMargin: true,

--- a/apps/aevatar-console-web/src/pages/MissionControl/InspectorPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/MissionControl/InspectorPanel.tsx
@@ -5,6 +5,7 @@ import {
 } from '@ant-design/icons';
 import { Alert, Button, Card, Empty, Input, Space, Tag, Typography, theme } from 'antd';
 import React, { useEffect, useMemo, useState } from 'react';
+import { aevatarMonoFontFamily } from '@/shared/ui/compactText';
 import {
   drawerBodyStyle,
   drawerScrollStyle,
@@ -35,8 +36,7 @@ import {
 } from './presentation';
 
 const monoStyle: React.CSSProperties = {
-  fontFamily:
-    "'SFMono-Regular', 'SFMono-Regular', Consolas, 'Liberation Mono', monospace",
+  fontFamily: aevatarMonoFontFamily,
 };
 
 type InspectorPanelProps = {

--- a/apps/aevatar-console-web/src/pages/MissionControl/index.tsx
+++ b/apps/aevatar-console-web/src/pages/MissionControl/index.tsx
@@ -29,6 +29,7 @@ import React, {
 import { history } from '@/shared/navigation/history';
 import { buildRuntimeRunsHref } from '@/shared/navigation/runtimeRoutes';
 import { buildTeamDetailHref } from '@/shared/navigation/teamRoutes';
+import { aevatarMonoFontFamily } from '@/shared/ui/compactText';
 import { AEVATAR_INTERACTIVE_BUTTON_CLASS } from '@/shared/ui/interactionStandards';
 import { useMissionControlRuntime, type UseMissionControlRuntimeResult } from './hooks/useMissionControlRuntime';
 import InspectorPanel from './InspectorPanel';
@@ -61,8 +62,7 @@ const scrollerStyle: React.CSSProperties = {
 };
 
 const monoStyle: React.CSSProperties = {
-  fontFamily:
-    "'SFMono-Regular', 'SFMono-Regular', Consolas, 'Liberation Mono', monospace",
+  fontFamily: aevatarMonoFontFamily,
 };
 
 type MissionStageView = 'topology' | 'execution_flow';

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
@@ -1,4 +1,5 @@
 import { parseCustomEvent } from '@aevatar-react-sdk/agui';
+import { aevatarMonoFontFamily } from '@/shared/ui/compactText';
 import {
   AGUIEventType,
   CustomEventName,
@@ -315,7 +316,7 @@ const workflowDryRunOutputStyle: React.CSSProperties = {
   border: '1px solid #efe7da',
   borderRadius: 14,
   color: '#425466',
-  fontFamily: 'Monaco, Menlo, monospace',
+  fontFamily: aevatarMonoFontFamily,
   fontSize: 12,
   lineHeight: '20px',
   margin: 0,
@@ -418,7 +419,7 @@ const dryRunOutputStyle: React.CSSProperties = {
   border: '1px solid #efe7da',
   borderRadius: 14,
   color: '#425466',
-  fontFamily: 'Monaco, Menlo, monospace',
+  fontFamily: aevatarMonoFontFamily,
   fontSize: 12,
   lineHeight: '20px',
   margin: 0,

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioFilesDetailPane.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioFilesDetailPane.tsx
@@ -14,6 +14,7 @@ import type {
   StoredChatMessage,
 } from '@/pages/chat/chatTypes';
 import { formatDateTime } from '@/shared/datetime/dateTime';
+import { aevatarMonoFontFamily } from '@/shared/ui/compactText';
 import { studioApi } from '@/shared/studio/api';
 import type {
   StudioConnectorCatalog,
@@ -172,7 +173,7 @@ const editorTextAreaStyle: React.CSSProperties = {
   border: 'none',
   color: '#374151',
   fontFamily:
-    'ui-monospace, SFMono-Regular, SF Mono, Menlo, Monaco, Consolas, Liberation Mono, monospace',
+    aevatarMonoFontFamily,
   fontSize: 13,
   lineHeight: 1.7,
   minHeight: 400,
@@ -188,7 +189,7 @@ const codePreviewStyle: React.CSSProperties = {
   borderRadius: 14,
   color: '#374151',
   fontFamily:
-    'ui-monospace, SFMono-Regular, SF Mono, Menlo, Monaco, Consolas, Liberation Mono, monospace',
+    aevatarMonoFontFamily,
   fontSize: 12,
   lineHeight: 1.7,
   margin: 0,
@@ -286,7 +287,7 @@ const fieldTextareaStyle: React.CSSProperties = {
   ...fieldInputStyle,
   background: '#FAFAF9',
   fontFamily:
-    'ui-monospace, SFMono-Regular, SF Mono, Menlo, Monaco, Consolas, Liberation Mono, monospace',
+    aevatarMonoFontFamily,
   lineHeight: 1.6,
   minHeight: 72,
   resize: 'vertical',
@@ -919,7 +920,7 @@ function FieldInput(props: {
         style={{
           ...fieldInputStyle,
           fontFamily: props.mono
-            ? 'ui-monospace, SFMono-Regular, SF Mono, Menlo, Monaco, Consolas, Liberation Mono, monospace'
+            ? aevatarMonoFontFamily
             : fieldInputStyle.fontFamily,
         }}
       />
@@ -1410,7 +1411,7 @@ const StudioFilesDetailPane: React.FC<Props> = ({
                     <span
                       style={{
                         fontFamily:
-                          'ui-monospace, SFMono-Regular, SF Mono, Menlo, Monaco, Consolas, Liberation Mono, monospace',
+                          aevatarMonoFontFamily,
                       }}
                     >
                       {role.id || 'role_id'}

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioInspectorPane.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioInspectorPane.tsx
@@ -1,4 +1,5 @@
 import { Button, Empty, Input, Select, Space, Tag, Typography } from 'antd';
+import { aevatarMonoFontFamily } from '@/shared/ui/compactText';
 import React from 'react';
 import type { StudioNodeInspectorDraft } from '@/shared/studio/document';
 import {
@@ -156,8 +157,7 @@ const yamlEditorStyle: React.CSSProperties = {
   background: 'var(--ant-color-fill-quaternary)',
   border: '1px solid var(--ant-color-border-secondary)',
   borderRadius: 10,
-  fontFamily:
-    "'SFMono-Regular', 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace",
+  fontFamily: aevatarMonoFontFamily,
   fontSize: 13,
   lineHeight: 1.5,
 };

--- a/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx
@@ -21,6 +21,7 @@ import type {
   ServiceCatalogSnapshot,
   ServiceEndpointSnapshot,
 } from '@/shared/models/services';
+import { aevatarMonoFontFamily } from '@/shared/ui/compactText';
 import { isChatServiceEndpoint } from '@/shared/runs/scopeConsole';
 import {
   describeScopeServiceBindingTarget,
@@ -184,8 +185,7 @@ function buildRevisionFromMemberBinding(
   };
 }
 
-const monoFontFamily =
-  "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace";
+const monoFontFamily = aevatarMonoFontFamily;
 
 const rootStyle: React.CSSProperties = {
   minWidth: 0,

--- a/apps/aevatar-console-web/src/pages/studio/components/studioInvokeUi.ts
+++ b/apps/aevatar-console-web/src/pages/studio/components/studioInvokeUi.ts
@@ -1,4 +1,5 @@
 import type React from 'react';
+import { aevatarMonoFontFamily } from '@/shared/ui/compactText';
 import type { InvokeResultState } from './StudioMemberInvokePanel.currentRun';
 
 export const studioInvokeColors = {
@@ -27,8 +28,7 @@ export const studioInvokeColors = {
   textSoft: '#334155',
 } as const;
 
-export const monoFontFamily =
-  "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace";
+export const monoFontFamily = aevatarMonoFontFamily;
 
 export const contractStatusPillBaseStyle: React.CSSProperties = {
   borderRadius: 999,

--- a/apps/aevatar-console-web/src/pages/studio/explorer/ExplorerDetailPane.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/explorer/ExplorerDetailPane.tsx
@@ -1,6 +1,7 @@
 import { Alert, Button, Input, Space, Spin, Tag, Typography } from "antd";
 import React from "react";
 import type { ExplorerManifestEntry } from "@/shared/api/explorerApi";
+import { aevatarMonoFontFamily } from "@/shared/ui/compactText";
 import ExplorerContentView from "./ExplorerContentView";
 
 type ExplorerDetailPaneProps = {
@@ -59,8 +60,7 @@ const editorShellStyle: React.CSSProperties = {
 };
 
 const editorStyle: React.CSSProperties = {
-  fontFamily:
-    'ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, "Liberation Mono", monospace',
+  fontFamily: aevatarMonoFontFamily,
   fontSize: 13,
   minHeight: 360,
 };

--- a/apps/aevatar-console-web/src/pages/workflows/WorkflowYamlViewer.tsx
+++ b/apps/aevatar-console-web/src/pages/workflows/WorkflowYamlViewer.tsx
@@ -5,6 +5,7 @@ import {
 } from '@ant-design/icons';
 import { Button, Empty, Modal, message, Space, Tag, Typography } from 'antd';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { aevatarMonoFontFamily } from '@/shared/ui/compactText';
 import { cardStackStyle, embeddedPanelStyle } from '@/shared/ui/proComponents';
 
 type WorkflowYamlViewerProps = {
@@ -80,7 +81,7 @@ const lineNumberStyle = {
   borderRight: '1px solid rgba(148, 163, 184, 0.14)',
   color: 'var(--ant-color-text-tertiary)',
   fontFamily:
-    "'SFMono-Regular', 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace",
+    aevatarMonoFontFamily,
   fontSize: 12,
   padding: '4px 12px',
   textAlign: 'right',
@@ -90,7 +91,7 @@ const lineNumberStyle = {
 const codeContentStyle = {
   color: '#0f172a',
   fontFamily:
-    "'SFMono-Regular', 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace",
+    aevatarMonoFontFamily,
   fontSize: 13,
   minHeight: 22,
   padding: '4px 16px',

--- a/apps/aevatar-console-web/src/shared/agui/runtimeConversationPresentation.tsx
+++ b/apps/aevatar-console-web/src/shared/agui/runtimeConversationPresentation.tsx
@@ -5,6 +5,7 @@ import type {
   RuntimeStepInfo,
   RuntimeToolCallInfo,
 } from "./runtimeEventSemantics";
+import { aevatarMonoFontFamily } from "@/shared/ui/compactText";
 import { AEVATAR_INTERACTIVE_BUTTON_CLASS } from "@/shared/ui/interactionStandards";
 
 function renderInline(text: string): React.ReactNode[] {
@@ -19,7 +20,7 @@ function renderInline(text: string): React.ReactNode[] {
             borderRadius: 6,
             color: "#be185d",
             fontFamily:
-              "SFMono-Regular, ui-monospace, SFMono-Regular, Menlo, monospace",
+              aevatarMonoFontFamily,
             fontSize: 12,
             padding: "2px 6px",
           }}
@@ -74,7 +75,7 @@ function renderContent(text: string): React.ReactNode {
                 borderBottom: "1px solid #e5e7eb",
                 color: "#6b7280",
                 fontFamily:
-                  "SFMono-Regular, ui-monospace, SFMono-Regular, Menlo, monospace",
+                  aevatarMonoFontFamily,
                 fontSize: 11,
                 padding: "8px 12px",
               }}
@@ -85,7 +86,7 @@ function renderContent(text: string): React.ReactNode {
           <pre
             style={{
               fontFamily:
-                "SFMono-Regular, ui-monospace, SFMono-Regular, Menlo, monospace",
+                aevatarMonoFontFamily,
               fontSize: 13,
               margin: 0,
               overflowX: "auto",
@@ -301,7 +302,7 @@ function ToolCallIndicator({
         <span
           style={{
             fontFamily:
-              "SFMono-Regular, ui-monospace, SFMono-Regular, Menlo, monospace",
+              aevatarMonoFontFamily,
           }}
         >
           {tool.name || tool.id}
@@ -314,7 +315,7 @@ function ToolCallIndicator({
             borderRadius: 10,
             color: "#6b7280",
             fontFamily:
-              "SFMono-Regular, ui-monospace, SFMono-Regular, Menlo, monospace",
+              aevatarMonoFontFamily,
             fontSize: 11,
             margin: "6px 0 0 22px",
             maxHeight: 120,
@@ -709,7 +710,7 @@ export function RuntimeEventPreviewPanel({
               color: "#4b5563",
               display: "flex",
               fontFamily:
-                "SFMono-Regular, ui-monospace, SFMono-Regular, Menlo, monospace",
+                aevatarMonoFontFamily,
               fontSize: 11,
               gap: 8,
               padding: "8px 14px",


### PR DESCRIPTION
## Issue

**frontend-audit-017 (MEDIUM)** — Duplicated mono font constants across 15+ locations.

11 files defined independent mono font family strings with different stacks (SFMono-Regular, Consolas, Liberation Mono, Menlo, Monaco, ui-monospace). The shared `aevatarMonoFontFamily` constant in `compactText.tsx` was only imported by 4 files.

## Source

Frontend architecture audit cycle 3.

## Fix Summary

Replaced all 15+ inline mono font strings with imports of `aevatarMonoFontFamily` from `@/shared/ui/compactText`. Preserved `studioInvokeUi.ts:monoFontFamily` as a re-export to avoid breaking its 4 downstream consumers.

**Changed files (11):** MissionControl/InspectorPanel.tsx, MissionControl/index.tsx, runtimeConversationPresentation.tsx, ScriptCodeEditor.tsx, ExplorerDetailPane.tsx, StudioInspectorPane.tsx, StudioFilesDetailPane.tsx, StudioBuildPanels.tsx, studioInvokeUi.ts, StudioMemberBindPanel.tsx, WorkflowYamlViewer.tsx

## Review Record

| Reviewer | Model | Verdict |
|----------|-------|---------|
| ci-runner | Opus | PASS — tsc clean |

**Implementation attempts:** 1/3
**Browser QA evidence:** BLOCKED (OAuth) — non-visible style token change
**Changed-file scope:** clean

## Referenced Rules

- `docs/canon/frontend-design.md` §6.1 (Token priority), §6.2 (Font strategy)

🤖 Generated with [Frontend Refactoring Team](.claude/skills/frontend-refactor-team/)