### PR TITLE
iter158 #1160: delete inline CTS + actor-owned durable self-signal timeout(+624 LOC,typed event)

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
@@ -48,7 +48,6 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
     internal static readonly TimeSpan TerminalCleanupDelay = TimeSpan.FromMinutes(5);
     private const string TerminalCleanupCallbackPrefix = "agent-run-terminal-cleanup";
     private const string GenerationTimeoutCallbackPrefix = "agent-run-generation-timeout";
-    internal static readonly TimeSpan OutputDispatchTimeout = TimeSpan.FromSeconds(10);
     internal static readonly TimeSpan OutputDispatchRetryDelay = TimeSpan.FromSeconds(5);
     private const string OutputDispatchRetryCallbackPrefix = "agent-run-output-dispatch-retry";
     internal static readonly TimeSpan DropNotificationRetryDelay = TimeSpan.FromSeconds(5);
@@ -1032,8 +1031,7 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         };
         try
         {
-            using var outputCts = new CancellationTokenSource(OutputDispatchTimeout);
-            await SendToAsync(request.TargetActorId, ready, outputCts.Token);
+            await SendToAsync(request.TargetActorId, ready, CancellationToken.None);
         }
         catch (Exception ex)
         {
@@ -1082,8 +1080,7 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
 
         try
         {
-            using var outputCts = new CancellationTokenSource(OutputDispatchTimeout);
-            await SendToAsync(targetActorId, dropped, outputCts.Token);
+            await SendToAsync(targetActorId, dropped, CancellationToken.None);
         }
         catch (Exception ex)
         {
@@ -1112,8 +1109,7 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
 
         try
         {
-            using var outputCts = new CancellationTokenSource(OutputDispatchTimeout);
-            await SendToAsync(command.TargetActorId, dropped, outputCts.Token);
+            await SendToAsync(command.TargetActorId, dropped, CancellationToken.None);
         }
         catch (Exception ex)
         {

--- a/agents/Aevatar.GAgents.StatusDashboard/HealthProbeTargetGAgent.cs
+++ b/agents/Aevatar.GAgents.StatusDashboard/HealthProbeTargetGAgent.cs
@@ -113,7 +113,7 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
 
         try
         {
-            await PersistDomainEventAsync(new HealthProbeObserved { Outcome = outcome });
+            await PersistProbeTerminalEventsAsync(outcome, active.OperationId);
         }
         catch (EventStoreOptimisticConcurrencyException ex)
         {
@@ -139,7 +139,7 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
 
         try
         {
-            await PersistDomainEventAsync(new HealthProbeObserved { Outcome = completed.Outcome });
+            await PersistProbeTerminalEventsAsync(completed.Outcome, active.OperationId);
         }
         catch (EventStoreOptimisticConcurrencyException ex)
         {
@@ -149,6 +149,19 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
         }
 
         await EnsureNextTickAsync(initial: false);
+    }
+
+    private Task PersistProbeTerminalEventsAsync(HealthProbeOutcome outcome, string operationId)
+    {
+        // Refactor (iter158/cluster-157-004-timeout-cts):
+        // Old: HealthProbeObserved also cleared ActiveExecution, leaving the typed
+        //      HealthProbeExecutionCleared domain event with no producer.
+        // New: probe completion persists observed outcome and explicit clear event
+        //      together, so execution lifecycle remains actor-owned and observable.
+        return PersistDomainEventsAsync([
+            new HealthProbeObserved { Outcome = outcome },
+            new HealthProbeExecutionCleared { OperationId = operationId },
+        ]);
     }
 
     // ─── Probe execution ───
@@ -357,7 +370,6 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
             next.RecentOutcomes.Add(outcome.Clone());
             TrimRecentOutcomes(next, outcome.ObservedAt);
         }
-        next.ActiveExecution = null;
 
         if (outcome?.Status == HealthOutcomeStatus.Ok)
         {

--- a/agents/Aevatar.GAgents.StatusDashboard/HealthProbeTargetGAgent.cs
+++ b/agents/Aevatar.GAgents.StatusDashboard/HealthProbeTargetGAgent.cs
@@ -1,6 +1,7 @@
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Attributes;
 using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.GAgents.StatusDashboard.Executors;
@@ -25,8 +26,10 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
     public static string ProjectionKind => "health-probe-target";
 
     internal const string TickCallbackId = "health-probe-tick";
+    internal const string ExecutionTimeoutCallbackPrefix = "health-probe-execution-timeout";
     internal const int RetainedOutcomeCount = 120;
     private static readonly TimeSpan RetainedOutcomeWindow = TimeSpan.FromHours(2);
+    private TimeProvider? _cachedTimeProvider;
 
     // ─── Commands ───
 
@@ -79,7 +82,34 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
             return;
         }
 
-        var outcome = await ExecuteProbeWithGuardsAsync(descriptor);
+        await StartProbeExecutionAsync(descriptor);
+    }
+
+    [EventHandler(AllowSelfHandling = true, OnlySelfHandling = true)]
+    public async Task HandleTimeoutFiredAsync(HealthProbeTimeoutFiredEvent timeout)
+    {
+        ArgumentNullException.ThrowIfNull(timeout);
+        var active = State.ActiveExecution;
+        if (active == null ||
+            string.IsNullOrWhiteSpace(timeout.OperationId) ||
+            !string.Equals(active.OperationId, timeout.OperationId, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var timedOutAt = timeout.TimedOutAt ?? Timestamp.FromDateTimeOffset(ResolveTimeProvider().GetUtcNow());
+        var startedAt = active.StartedAt?.ToDateTimeOffset() ?? timedOutAt.ToDateTimeOffset();
+        var latencyMs = Math.Max(0, (int)Math.Round((timedOutAt.ToDateTimeOffset() - startedAt).TotalMilliseconds));
+        var timeoutMs = timeout.TimeoutMs > 0 ? timeout.TimeoutMs : active.TimeoutMs;
+        var descriptor = State.Spec;
+        var outcome = new HealthProbeOutcome
+        {
+            Status = HealthOutcomeStatus.Down,
+            LatencyMs = latencyMs,
+            Detail = "timeout",
+            ErrorMessage = $"Probe '{descriptor?.ProbeKind ?? active.Slug}' exceeded {timeoutMs}ms.",
+            ObservedAt = timedOutAt,
+        };
 
         try
         {
@@ -88,8 +118,34 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
         catch (EventStoreOptimisticConcurrencyException ex)
         {
             Logger.LogInformation(ex,
+                "Probe {Slug} timeout outcome lost a concurrent tick race; next tick will be re-armed",
+                timeout.Slug);
+        }
+
+        await EnsureNextTickAsync(initial: false);
+    }
+
+    [EventHandler(AllowSelfHandling = true, OnlySelfHandling = true)]
+    public async Task HandleCompletedAsync(HealthProbeCompletedEvent completed)
+    {
+        ArgumentNullException.ThrowIfNull(completed);
+        var active = State.ActiveExecution;
+        if (active == null ||
+            string.IsNullOrWhiteSpace(completed.OperationId) ||
+            !string.Equals(active.OperationId, completed.OperationId, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        try
+        {
+            await PersistDomainEventAsync(new HealthProbeObserved { Outcome = completed.Outcome });
+        }
+        catch (EventStoreOptimisticConcurrencyException ex)
+        {
+            Logger.LogInformation(ex,
                 "Probe {Slug} observed outcome lost a concurrent tick race; next tick will be re-armed",
-                descriptor.Slug);
+                completed.Slug);
         }
 
         await EnsureNextTickAsync(initial: false);
@@ -97,7 +153,7 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
 
     // ─── Probe execution ───
 
-    private async Task<HealthProbeOutcome> ExecuteProbeWithGuardsAsync(HealthProbeTargetDescriptor descriptor)
+    private async Task StartProbeExecutionAsync(HealthProbeTargetDescriptor descriptor)
     {
         var registry = Services.GetService<IHealthProbeExecutorRegistry>();
         var timeProvider = ResolveTimeProvider();
@@ -108,55 +164,54 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
 
         if (registry == null)
         {
-            return new HealthProbeOutcome
+            await ObserveImmediateOutcomeAsync(new HealthProbeOutcome
             {
                 Status = HealthOutcomeStatus.Down,
                 Detail = "registry_unavailable",
                 ErrorMessage = "IHealthProbeExecutorRegistry is not registered in DI.",
                 ObservedAt = observedAt,
-            };
+            });
+            return;
         }
 
         var executor = registry.Resolve(descriptor.ProbeKind);
         if (executor == null)
         {
-            return new HealthProbeOutcome
+            await ObserveImmediateOutcomeAsync(new HealthProbeOutcome
             {
                 Status = HealthOutcomeStatus.Down,
                 Detail = "unknown_probe_kind",
                 ErrorMessage = $"No executor registered for probe kind '{descriptor.ProbeKind}'.",
                 ObservedAt = observedAt,
-            };
+            });
+            return;
         }
 
-        var timeoutMs = descriptor.TimeoutMs > 0 ? descriptor.TimeoutMs : 5_000;
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(timeoutMs), timeProvider);
         var startedAt = timeProvider.GetTimestamp();
+        var timeoutMs = descriptor.TimeoutMs > 0 ? descriptor.TimeoutMs : 5_000;
+        var execution = await RegisterExecutionTimeoutAsync(descriptor, timeoutMs);
+        _ = ExecuteProbeAndSignalAsync(executor, descriptor.Clone(), execution, startedAt);
+    }
+
+    private async Task ExecuteProbeAndSignalAsync(
+        IHealthProbeExecutor executor,
+        HealthProbeTargetDescriptor descriptor,
+        HealthProbeExecutionState execution,
+        long startedAt)
+    {
+        var timeProvider = ResolveTimeProvider();
+        HealthProbeOutcome outcome;
         try
         {
-            var outcome = await executor.ProbeAsync(descriptor, cts.Token);
-            // Always overwrite latency and observed_at with the in-actor values
-            // so executors stay focused on the upstream signal.
+            outcome = await executor.ProbeAsync(descriptor, CancellationToken.None);
             outcome.LatencyMs = ToLatencyMs(timeProvider.GetElapsedTime(startedAt));
             outcome.ObservedAt = Timestamp.FromDateTimeOffset(timeProvider.GetUtcNow());
-            return outcome;
-        }
-        catch (OperationCanceledException) when (cts.IsCancellationRequested)
-        {
-            return new HealthProbeOutcome
-            {
-                Status = HealthOutcomeStatus.Down,
-                LatencyMs = ToLatencyMs(timeProvider.GetElapsedTime(startedAt)),
-                Detail = "timeout",
-                ErrorMessage = $"Probe '{descriptor.ProbeKind}' exceeded {timeoutMs}ms.",
-                ObservedAt = Timestamp.FromDateTimeOffset(timeProvider.GetUtcNow()),
-            };
         }
         catch (Exception ex)
         {
             Logger.LogWarning(ex, "Probe '{Kind}' for {Slug} threw unexpectedly",
                 descriptor.ProbeKind, descriptor.Slug);
-            return new HealthProbeOutcome
+            outcome = new HealthProbeOutcome
             {
                 Status = HealthOutcomeStatus.Down,
                 LatencyMs = ToLatencyMs(timeProvider.GetElapsedTime(startedAt)),
@@ -165,6 +220,27 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
                 ObservedAt = Timestamp.FromDateTimeOffset(timeProvider.GetUtcNow()),
             };
         }
+
+        await SendToAsync(Id, new HealthProbeCompletedEvent
+        {
+            Slug = descriptor.Slug,
+            OperationId = execution.OperationId,
+            Outcome = outcome,
+        }, CancellationToken.None);
+    }
+
+    private async Task ObserveImmediateOutcomeAsync(HealthProbeOutcome outcome)
+    {
+        try
+        {
+            await PersistDomainEventAsync(new HealthProbeObserved { Outcome = outcome });
+        }
+        catch (EventStoreOptimisticConcurrencyException ex)
+        {
+            Logger.LogInformation(ex, "Immediate probe outcome lost a concurrent tick race; next tick will be re-armed");
+        }
+
+        await EnsureNextTickAsync(initial: false);
     }
 
     // ─── Self-scheduling ───
@@ -191,6 +267,46 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
             });
     }
 
+    private async Task<HealthProbeExecutionState> RegisterExecutionTimeoutAsync(
+        HealthProbeTargetDescriptor descriptor,
+        int timeoutMs)
+    {
+        var now = ResolveTimeProvider().GetUtcNow();
+        var ticks = ResolveTimeProvider().GetTimestamp();
+        var operationId = RuntimeCallbackKeyComposer.BuildCallbackId(
+            "health-probe-operation",
+            descriptor.Slug,
+            now.ToUnixTimeMilliseconds().ToString(),
+            ticks.ToString());
+        var execution = new HealthProbeExecutionState
+        {
+            OperationId = operationId,
+            Slug = descriptor.Slug,
+            StartedAt = Timestamp.FromDateTimeOffset(now),
+            TimeoutMs = timeoutMs,
+        };
+        await PersistDomainEventAsync(new HealthProbeExecutionStarted
+        {
+            Execution = execution.Clone(),
+        });
+
+        await ScheduleSelfDurableTimeoutAsync(
+            RuntimeCallbackKeyComposer.BuildCallbackId(
+                ExecutionTimeoutCallbackPrefix,
+                descriptor.Slug,
+                operationId),
+            TimeSpan.FromMilliseconds(timeoutMs),
+            new HealthProbeTimeoutFiredEvent
+            {
+                Slug = descriptor.Slug,
+                OperationId = operationId,
+                TimedOutAt = Timestamp.FromDateTimeOffset(now.AddMilliseconds(timeoutMs)),
+                TimeoutMs = timeoutMs,
+            });
+
+        return execution;
+    }
+
     // ─── Activation ───
 
     protected override async Task OnActivateAsync(CancellationToken ct)
@@ -213,6 +329,8 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
             .Match(current, evt)
             .On<HealthProbeConfigured>(ApplyConfigured)
             .On<HealthProbeObserved>(ApplyObserved)
+            .On<HealthProbeExecutionStarted>(ApplyExecutionStarted)
+            .On<HealthProbeExecutionCleared>(ApplyExecutionCleared)
             .OrCurrent();
 
     private static HealthProbeTargetState ApplyConfigured(HealthProbeTargetState s, HealthProbeConfigured evt)
@@ -224,6 +342,7 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
         next.LastSuccessAt = null;
         next.ConsecutiveFailures = 0;
         next.RecentOutcomes.Clear();
+        next.ActiveExecution = null;
         return next;
     }
 
@@ -238,6 +357,7 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
             next.RecentOutcomes.Add(outcome.Clone());
             TrimRecentOutcomes(next, outcome.ObservedAt);
         }
+        next.ActiveExecution = null;
 
         if (outcome?.Status == HealthOutcomeStatus.Ok)
         {
@@ -247,6 +367,24 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
         else
         {
             next.ConsecutiveFailures += 1;
+        }
+        return next;
+    }
+
+    private static HealthProbeTargetState ApplyExecutionStarted(HealthProbeTargetState s, HealthProbeExecutionStarted evt)
+    {
+        var next = s.Clone();
+        next.ActiveExecution = evt.Execution?.Clone();
+        return next;
+    }
+
+    private static HealthProbeTargetState ApplyExecutionCleared(HealthProbeTargetState s, HealthProbeExecutionCleared evt)
+    {
+        var next = s.Clone();
+        if (next.ActiveExecution != null &&
+            string.Equals(next.ActiveExecution.OperationId, evt.OperationId, StringComparison.Ordinal))
+        {
+            next.ActiveExecution = null;
         }
         return next;
     }
@@ -273,7 +411,7 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
         timestamp != null && timestamp.ToDateTimeOffset() < cutoff;
 
     private TimeProvider ResolveTimeProvider() =>
-        Services.GetService<TimeProvider>() ?? TimeProvider.System;
+        _cachedTimeProvider ??= Services.GetService<TimeProvider>() ?? TimeProvider.System;
 
     private static int ToLatencyMs(TimeSpan elapsed) =>
         (int)Math.Clamp(elapsed.TotalMilliseconds, 0, int.MaxValue);

--- a/agents/Aevatar.GAgents.StatusDashboard/protos/status_dashboard.proto
+++ b/agents/Aevatar.GAgents.StatusDashboard/protos/status_dashboard.proto
@@ -53,6 +53,14 @@ message HealthProbeTargetState {
   google.protobuf.Timestamp last_success_at = 4;
   google.protobuf.Timestamp last_check_at = 5;
   repeated HealthProbeOutcome recent_outcomes = 6;
+  HealthProbeExecutionState active_execution = 7;
+}
+
+message HealthProbeExecutionState {
+  string operation_id = 1;
+  string slug = 2;
+  google.protobuf.Timestamp started_at = 3;
+  int32 timeout_ms = 4;
 }
 
 // ─── Commands (envelope payloads) ───
@@ -71,6 +79,19 @@ message HealthProbeTickRequested {
   google.protobuf.Timestamp scheduled_for = 2;
 }
 
+message HealthProbeTimeoutFiredEvent {
+  string slug = 1;
+  string operation_id = 2;
+  google.protobuf.Timestamp timed_out_at = 3;
+  int32 timeout_ms = 4;
+}
+
+message HealthProbeCompletedEvent {
+  string slug = 1;
+  string operation_id = 2;
+  HealthProbeOutcome outcome = 3;
+}
+
 // ─── Domain events ───
 
 message HealthProbeConfigured {
@@ -80,6 +101,14 @@ message HealthProbeConfigured {
 
 message HealthProbeObserved {
   HealthProbeOutcome outcome = 1;
+}
+
+message HealthProbeExecutionStarted {
+  HealthProbeExecutionState execution = 1;
+}
+
+message HealthProbeExecutionCleared {
+  string operation_id = 1;
 }
 
 // ─── Projection read model ───

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -272,6 +272,18 @@ message WorkflowStepTimeoutFiredEvent { string run_id = 1; string step_id = 2; i
 message WorkflowStepRetryBackoffFiredEvent { string run_id = 1; string step_id = 2; int32 delay_ms = 3; int32 next_attempt = 4; }
 message DelayStepTimeoutFiredEvent { string run_id = 1; string step_id = 2; int32 duration_ms = 3; }
 message LlmCallWatchdogTimeoutFiredEvent { string run_id = 1; string step_id = 2; string session_id = 3; int32 timeout_ms = 4; }
+message WorkflowConnectorTimeoutFiredEvent { string run_id = 1; string step_id = 2; string operation_id = 3; int32 timeout_ms = 4; int32 attempt = 5; }
+message WorkflowConnectorAttemptCompletedEvent {
+  string run_id = 1;
+  string step_id = 2;
+  string operation_id = 3;
+  int32 attempt = 4;
+  bool success = 5;
+  string output = 6;
+  string error = 7;
+  map<string, string> annotations = 8;
+  string execution_id = 9;
+}
 message WorkflowSignalBufferedEvent
 {
   string run_id = 1;

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.cs
@@ -202,6 +202,8 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
             ExecutionId = pending.ExecutionId,
         };
         completion.Annotations["connector.name"] = pending.ConnectorName;
+        completion.Annotations["connector.step_id"] = pending.StepId;
+        completion.Annotations["connector.run_id"] = pending.RunId;
         completion.Annotations["connector.type"] = pending.ConnectorType;
         completion.Annotations["connector.operation"] = pending.Operation;
         completion.Annotations["connector.attempts"] = pending.Attempt.ToString();

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.cs
@@ -5,6 +5,8 @@ using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.Foundation.Abstractions.EventModules;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Workflow.Core.Execution;
 using Aevatar.Workflow.Abstractions.Execution;
 using Aevatar.Workflow.Core.Primitives;
 using Microsoft.Extensions.Logging;
@@ -17,6 +19,8 @@ namespace Aevatar.Workflow.Core.Modules;
 /// </summary>
 public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutionContext>
 {
+    private const string ModuleStateKey = "connector_call";
+    private const string TimeoutCallbackPrefix = "workflow-connector-timeout";
     private readonly IWorkflowConnectorResolver _connectorResolver;
 
     public ConnectorCallModule(IWorkflowConnectorResolver connectorResolver)
@@ -34,6 +38,8 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
         return payload != null &&
                (payload.Is(StepRequestEvent.Descriptor) ||
                 payload.Is(SecureValueCapturedEvent.Descriptor) ||
+                payload.Is(WorkflowConnectorTimeoutFiredEvent.Descriptor) ||
+                payload.Is(WorkflowConnectorAttemptCompletedEvent.Descriptor) ||
                 payload.Is(WorkflowCompletedEvent.Descriptor));
     }
 
@@ -64,6 +70,18 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
                 ctx,
                 envelope.Payload.Unpack<WorkflowCompletedEvent>().RunId,
                 ct);
+            return;
+        }
+
+        if (envelope.Payload.Is(WorkflowConnectorTimeoutFiredEvent.Descriptor))
+        {
+            await HandleTimeoutFiredAsync(envelope.Payload.Unpack<WorkflowConnectorTimeoutFiredEvent>(), envelope, ctx, ct);
+            return;
+        }
+
+        if (envelope.Payload.Is(WorkflowConnectorAttemptCompletedEvent.Descriptor))
+        {
+            await HandleAttemptCompletedAsync(envelope.Payload.Unpack<WorkflowConnectorAttemptCompletedEvent>(), ctx, ct);
             return;
         }
 
@@ -128,116 +146,420 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
         //        the module.
         //   New: Connector duration is measured through the workflow context
         //        monotonic elapsed API.
-        var startedAt = ctx.GetTimestamp();
         var attempts = Math.Max(1, retry + 1);
-        ConnectorResponse? response = null;
-        Exception? lastError = null;
+        var runId = string.IsNullOrEmpty(request.RunId)
+            ? envelope.Propagation?.CorrelationId ?? string.Empty
+            : request.RunId;
+        await StartAttemptAsync(
+            envelope,
+            request,
+            runId,
+            connectorName,
+            operation,
+            connector,
+            attempt: 1,
+            attempts,
+            timeoutMs,
+            string.Equals(onError, "continue", StringComparison.OrdinalIgnoreCase),
+            isSecureStep,
+            ctx,
+            ct);
+    }
 
-        for (var attempt = 1; attempt <= attempts; attempt++)
+    private async Task HandleTimeoutFiredAsync(
+        WorkflowConnectorTimeoutFiredEvent evt,
+        EventEnvelope envelope,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(evt.OperationId))
+            return;
+
+        var state = WorkflowExecutionStateAccess.Load<ConnectorCallModuleState>(ctx, ModuleStateKey);
+        if (!state.PendingByOperationId.TryGetValue(evt.OperationId, out var pending))
+            return;
+
+        if (!MatchesPendingTimeout(envelope, pending))
         {
-            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            timeoutCts.CancelAfter(TimeSpan.FromMilliseconds(timeoutMs));
-
-            try
-            {
-                var runId = string.IsNullOrEmpty(request.RunId)
-                    ? envelope.Propagation?.CorrelationId ?? string.Empty
-                    : request.RunId;
-                var connectorRequest = new ConnectorRequest
-                {
-                    Metadata = ExtractConnectorMetadata(ctx),
-                    RunId = runId,
-                    StepId = request.StepId,
-                    Connector = connectorName,
-                    Operation = operation,
-                    Payload = ResolvePayload(request, isSecureStep, ctx) ?? string.Empty,
-                    Parameters = request.Parameters.ToDictionary(kv => kv.Key, kv => kv.Value),
-                };
-
-                response = await connector.ExecuteAsync(connectorRequest, timeoutCts.Token);
-                if (response.Success) break;
-
-                lastError = new InvalidOperationException(response.Error);
-                if (attempt < attempts)
-                {
-                    ctx.Logger.LogWarning(
-                        "ConnectorCall: step={StepId} connector={Connector} attempt={Attempt}/{Attempts} failed: {Error}",
-                        request.StepId, connectorName, attempt, attempts, response.Error);
-                }
-            }
-            catch (Exception ex)
-            {
-                lastError = ex;
-                if (attempt < attempts)
-                {
-                    ctx.Logger.LogWarning(
-                        ex,
-                        "ConnectorCall: step={StepId} connector={Connector} attempt={Attempt}/{Attempts} exception",
-                        request.StepId, connectorName, attempt, attempts);
-                }
-            }
+            ctx.Logger.LogDebug(
+                "ConnectorCall: ignore timeout without matching lease operation={OperationId}",
+                evt.OperationId);
+            return;
         }
 
-        var durationMs = ctx.GetElapsedTime(startedAt).TotalMilliseconds;
-        if (response is { Success: true })
+        var completion = new StepCompletedEvent
         {
-            var resolvedOutput = response.Output ?? string.Empty;
-            if (!TryAssertResponseOutput(request.Parameters, resolvedOutput, out var assertionError))
+            StepId = pending.StepId,
+            RunId = pending.RunId,
+            Success = pending.OnErrorContinue,
+            Output = pending.OnErrorContinue ? pending.Input : string.Empty,
+            Error = pending.OnErrorContinue ? string.Empty : $"connector call timed out after {evt.TimeoutMs}ms",
+            ExecutionId = pending.ExecutionId,
+        };
+        completion.Annotations["connector.name"] = pending.ConnectorName;
+        completion.Annotations["connector.type"] = pending.ConnectorType;
+        completion.Annotations["connector.operation"] = pending.Operation;
+        completion.Annotations["connector.attempts"] = pending.Attempt.ToString();
+        completion.Annotations["connector.timeout_ms"] = evt.TimeoutMs.ToString();
+        completion.Annotations["connector.duration_ms"] = evt.TimeoutMs.ToString("F2");
+        completion.Annotations["connector.timeout_fired"] = "true";
+        if (pending.OnErrorContinue)
+        {
+            completion.Annotations["connector.continued_on_error"] = "true";
+            completion.Annotations["connector.error"] = completion.Error;
+        }
+
+        await ctx.PublishAsync(completion, TopologyAudience.Self, ct);
+        RemovePending(state, pending);
+        await SaveStateAsync(state, ctx, ct);
+    }
+
+    private async Task HandleAttemptCompletedAsync(
+        WorkflowConnectorAttemptCompletedEvent evt,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(evt.OperationId))
+            return;
+
+        var state = WorkflowExecutionStateAccess.Load<ConnectorCallModuleState>(ctx, ModuleStateKey);
+        if (!state.PendingByOperationId.TryGetValue(evt.OperationId, out var pending))
+            return;
+
+        RemovePending(state, pending);
+        await SaveStateAsync(state, ctx, ct);
+        await WorkflowRuntimeCallbackLeaseSupport.CancelAsync(ctx, pending.TimeoutLease, CancellationToken.None);
+
+        var durationMs = ParseDuration(evt);
+        if (evt.Success)
+        {
+            var resolvedOutput = evt.Output ?? string.Empty;
+            if (!TryAssertResponseOutput(pending.Parameters, resolvedOutput, out var assertionError))
             {
-                await PublishFailureAsync(ctx, request, assertionError, ct);
+                await PublishPendingCompletionAsync(pending, false, string.Empty, assertionError, durationMs, evt.Annotations, ctx, ct);
                 return;
             }
 
-            if (ParseBool(request.Parameters.GetValueOrDefault("pass_through_input", "false")))
-                resolvedOutput = request.Input ?? string.Empty;
+            if (ParseBool(pending.Parameters.GetValueOrDefault("pass_through_input", "false")))
+                resolvedOutput = pending.Input ?? string.Empty;
 
-            var ok = new StepCompletedEvent
-            {
-                StepId = request.StepId,
-                RunId = request.RunId,
-                Success = true,
-                Output = resolvedOutput,
-            };
-            AppendBaseMetadata(ok, connector, connectorName, operation, attempts, timeoutMs, durationMs);
-            foreach (var (key, value) in response.Metadata)
-                ok.Annotations[key] = value;
-            await ctx.PublishAsync(ok, TopologyAudience.Self, ct);
+            await PublishPendingCompletionAsync(pending, true, resolvedOutput, string.Empty, durationMs, evt.Annotations, ctx, ct);
             return;
         }
 
-        var errorText = response?.Error;
-        if (string.IsNullOrWhiteSpace(errorText))
-            errorText = lastError?.Message ?? "connector call failed";
-
-        if (string.Equals(onError, "continue", StringComparison.OrdinalIgnoreCase))
+        var errorText = string.IsNullOrWhiteSpace(evt.Error) ? "connector call failed" : evt.Error;
+        if (pending.Attempt < pending.Attempts)
         {
             ctx.Logger.LogWarning(
-                "ConnectorCall: step={StepId} connector={Connector} failed but continue: {Error}",
-                request.StepId, connectorName, errorText);
-
-            var continued = new StepCompletedEvent
+                "ConnectorCall: step={StepId} connector={Connector} attempt={Attempt}/{Attempts} failed: {Error}",
+                pending.StepId, pending.ConnectorName, pending.Attempt, pending.Attempts, errorText);
+            var nextRequest = BuildRetryStepRequest(pending);
+            var connector = await _connectorResolver.ResolveAsync(ctx, pending.ConnectorName, ct);
+            if (connector == null)
             {
-                StepId = request.StepId,
-                RunId = request.RunId,
-                Success = true,
-                Output = request.Input,
-            };
-            AppendBaseMetadata(continued, connector, connectorName, operation, attempts, timeoutMs, durationMs);
-            continued.Annotations["connector.continued_on_error"] = "true";
-            continued.Annotations["connector.error"] = errorText ?? "";
-            await ctx.PublishAsync(continued, TopologyAudience.Self, ct);
+                await PublishPendingCompletionAsync(
+                    pending,
+                    false,
+                    string.Empty,
+                    $"connector '{pending.ConnectorName}' not found",
+                    durationMs,
+                    evt.Annotations,
+                    ctx,
+                    ct);
+                return;
+            }
+
+            await StartAttemptAsync(
+                new EventEnvelope { Id = pending.OperationId },
+                nextRequest,
+                pending.RunId,
+                pending.ConnectorName,
+                pending.Operation,
+                connector,
+                pending.Attempt + 1,
+                pending.Attempts,
+                pending.TimeoutMs,
+                pending.OnErrorContinue,
+                pending.SecureStep,
+                ctx,
+                ct);
             return;
         }
 
-        var failed = new StepCompletedEvent
+        await PublishPendingCompletionAsync(
+            pending,
+            false,
+            string.Empty,
+            errorText,
+            durationMs,
+            evt.Annotations,
+            ctx,
+            ct);
+    }
+
+    private async Task StartAttemptAsync(
+        EventEnvelope envelope,
+        StepRequestEvent request,
+        string runId,
+        string connectorName,
+        string operation,
+        IConnector connector,
+        int attempt,
+        int attempts,
+        int timeoutMs,
+        bool onErrorContinue,
+        bool isSecureStep,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var pending = await RegisterPendingAsync(
+            envelope,
+            request,
+            runId,
+            connectorName,
+            operation,
+            connector.Type,
+            attempt,
+            attempts,
+            timeoutMs,
+            onErrorContinue,
+            isSecureStep,
+            ctx,
+            ct);
+        var connectorRequest = new ConnectorRequest
+        {
+            Metadata = ExtractConnectorMetadata(ctx),
+            RunId = runId,
+            StepId = request.StepId,
+            Connector = connectorName,
+            Operation = operation,
+            Payload = ResolvePayload(request, isSecureStep, ctx) ?? string.Empty,
+            Parameters = request.Parameters.ToDictionary(kv => kv.Key, kv => kv.Value),
+        };
+        _ = ExecuteConnectorAndSignalAsync(ctx, connector, connectorRequest, pending);
+    }
+
+    private static async Task ExecuteConnectorAndSignalAsync(
+        IWorkflowExecutionContext ctx,
+        IConnector connector,
+        ConnectorRequest request,
+        PendingConnectorCallState pending)
+    {
+        var startedAt = ctx.GetTimestamp();
+        var completed = new WorkflowConnectorAttemptCompletedEvent
+        {
+            RunId = pending.RunId,
+            StepId = pending.StepId,
+            OperationId = pending.OperationId,
+            Attempt = pending.Attempt,
+            ExecutionId = pending.ExecutionId,
+        };
+        try
+        {
+            var response = await connector.ExecuteAsync(request, CancellationToken.None);
+            completed.Success = response.Success;
+            completed.Output = response.Output ?? string.Empty;
+            completed.Error = response.Error ?? string.Empty;
+            foreach (var (key, value) in response.Metadata)
+                completed.Annotations[key] = value;
+        }
+        catch (Exception ex)
+        {
+            completed.Success = false;
+            completed.Error = ex.Message;
+        }
+
+        completed.Annotations["connector.duration_ms"] = ctx.GetElapsedTime(startedAt).TotalMilliseconds.ToString("F2");
+        await ctx.PublishAsync(completed, TopologyAudience.Self, CancellationToken.None);
+    }
+
+    private async Task<PendingConnectorCallState> RegisterPendingAsync(
+        EventEnvelope envelope,
+        StepRequestEvent request,
+        string runId,
+        string connectorName,
+        string operation,
+        string connectorType,
+        int attempt,
+        int attempts,
+        int timeoutMs,
+        bool onErrorContinue,
+        bool isSecureStep,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var operationId = BuildOperationId(runId, request.StepId, attempt, request.ExecutionId, ResolveOriginEnvelopeId(envelope));
+        var callbackId = RuntimeCallbackKeyComposer.BuildCallbackId(
+            TimeoutCallbackPrefix,
+            runId,
+            request.StepId,
+            operationId,
+            attempt.ToString());
+        var pending = new PendingConnectorCallState
         {
             StepId = request.StepId,
-            RunId = request.RunId,
-            Success = false,
-            Error = errorText ?? "connector call failed",
+            RunId = runId,
+            OperationId = operationId,
+            Input = request.Input ?? string.Empty,
+            ConnectorName = connectorName,
+            Operation = operation,
+            Attempt = attempt,
+            Attempts = attempts,
+            TimeoutMs = timeoutMs,
+            OnErrorContinue = onErrorContinue,
+            TimeoutCallbackId = callbackId,
+            ExecutionId = request.ExecutionId,
+            SecureStep = isSecureStep,
+            ConnectorType = connectorType,
         };
-        AppendBaseMetadata(failed, connector, connectorName, operation, attempts, timeoutMs, durationMs);
-        await ctx.PublishAsync(failed, TopologyAudience.Self, ct);
+        foreach (var (key, value) in request.Parameters)
+            pending.Parameters[key] = value;
+
+        var state = WorkflowExecutionStateAccess.Load<ConnectorCallModuleState>(ctx, ModuleStateKey);
+        RemovePendingForStep(state, runId, request.StepId);
+        state.PendingByOperationId[operationId] = pending;
+        state.PendingOperationIdByStepId[BuildStepKey(runId, request.StepId)] = operationId;
+        await SaveStateAsync(state, ctx, ct);
+
+        var lease = await ctx.ScheduleSelfDurableTimeoutAsync(
+            callbackId,
+            TimeSpan.FromMilliseconds(timeoutMs),
+            new WorkflowConnectorTimeoutFiredEvent
+            {
+                RunId = runId,
+                StepId = request.StepId,
+                OperationId = operationId,
+                TimeoutMs = timeoutMs,
+                Attempt = attempt,
+            },
+            ct: ct);
+
+        state = WorkflowExecutionStateAccess.Load<ConnectorCallModuleState>(ctx, ModuleStateKey);
+        if (!state.PendingByOperationId.TryGetValue(operationId, out pending))
+            return pending;
+
+        pending.TimeoutLease = WorkflowRuntimeCallbackLeaseStateCodec.ToState(lease);
+        state.PendingByOperationId[operationId] = pending;
+        await SaveStateAsync(state, ctx, ct);
+        return pending;
+    }
+
+    private static bool MatchesPendingTimeout(EventEnvelope envelope, PendingConnectorCallState pending)
+    {
+        if (pending.TimeoutLease != null)
+            return WorkflowRuntimeCallbackLeaseSupport.MatchesLease(envelope, pending.TimeoutLease);
+
+        return RuntimeCallbackEnvelopeStateReader.TryRead(envelope, out var callbackState) &&
+               string.Equals(callbackState.CallbackId, pending.TimeoutCallbackId, StringComparison.Ordinal);
+    }
+
+    private static void RemovePendingForStep(
+        ConnectorCallModuleState state,
+        string runId,
+        string stepId)
+    {
+        var stepKey = BuildStepKey(runId, stepId);
+        if (!state.PendingOperationIdByStepId.Remove(stepKey, out var operationId))
+            return;
+
+        state.PendingByOperationId.Remove(operationId);
+    }
+
+    private static void RemovePending(
+        ConnectorCallModuleState state,
+        PendingConnectorCallState pending)
+    {
+        state.PendingByOperationId.Remove(pending.OperationId);
+        state.PendingOperationIdByStepId.Remove(BuildStepKey(pending.RunId, pending.StepId));
+    }
+
+    private static Task SaveStateAsync(
+        ConnectorCallModuleState state,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct) =>
+        WorkflowExecutionStateAccess.SaveAsync(ctx, ModuleStateKey, state, ct);
+
+    private static string ResolveOriginEnvelopeId(EventEnvelope envelope) =>
+        string.IsNullOrWhiteSpace(envelope.Id)
+            ? Guid.NewGuid().ToString("N")
+            : envelope.Id;
+
+    private static string BuildOperationId(
+        string runId,
+        string stepId,
+        int attempt,
+        string executionId,
+        string originEnvelopeId) =>
+        RuntimeCallbackKeyComposer.BuildCallbackId(
+            "connector-operation",
+            runId,
+            stepId,
+            string.IsNullOrWhiteSpace(executionId) ? originEnvelopeId : executionId,
+            attempt.ToString());
+
+    private static string BuildStepKey(string runId, string stepId) =>
+        $"{runId}:{stepId}";
+
+    private static StepRequestEvent BuildRetryStepRequest(PendingConnectorCallState pending)
+    {
+        var request = new StepRequestEvent
+        {
+            StepId = pending.StepId,
+            StepType = pending.SecureStep ? "secure_connector_call" : "connector_call",
+            RunId = pending.RunId,
+            Input = pending.Input,
+            ExecutionId = pending.ExecutionId,
+        };
+        foreach (var (key, value) in pending.Parameters)
+            request.Parameters[key] = value;
+        return request;
+    }
+
+    private static double ParseDuration(WorkflowConnectorAttemptCompletedEvent evt)
+    {
+        return double.TryParse(
+            evt.Annotations.GetValueOrDefault("connector.duration_ms", "0"),
+            out var durationMs)
+            ? durationMs
+            : 0d;
+    }
+
+    private static async Task PublishPendingCompletionAsync(
+        PendingConnectorCallState pending,
+        bool success,
+        string output,
+        string error,
+        double durationMs,
+        IReadOnlyDictionary<string, string> responseAnnotations,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var completed = new StepCompletedEvent
+        {
+            StepId = pending.StepId,
+            RunId = pending.RunId,
+            Success = success,
+            Output = success ? output : string.Empty,
+            Error = success ? string.Empty : error,
+            ExecutionId = pending.ExecutionId,
+        };
+        AppendBaseMetadata(completed, pending, durationMs);
+        foreach (var (key, value) in responseAnnotations)
+        {
+            if (!string.Equals(key, "connector.duration_ms", StringComparison.Ordinal))
+                completed.Annotations[key] = value;
+        }
+
+        if (!success && pending.OnErrorContinue)
+        {
+            completed.Success = true;
+            completed.Output = pending.Input;
+            completed.Error = string.Empty;
+            completed.Annotations["connector.continued_on_error"] = "true";
+            completed.Annotations["connector.error"] = error ?? string.Empty;
+        }
+
+        await ctx.PublishAsync(completed, TopologyAudience.Self, ct);
     }
 
     private static async Task PublishFailureAsync(
@@ -376,18 +698,14 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
 
     private static void AppendBaseMetadata(
         StepCompletedEvent evt,
-        IConnector connector,
-        string connectorName,
-        string operation,
-        int attempts,
-        int timeoutMs,
+        PendingConnectorCallState pending,
         double durationMs)
     {
-        evt.Annotations["connector.name"] = connectorName;
-        evt.Annotations["connector.type"] = connector.Type;
-        evt.Annotations["connector.operation"] = operation;
-        evt.Annotations["connector.attempts"] = attempts.ToString();
-        evt.Annotations["connector.timeout_ms"] = timeoutMs.ToString();
+        evt.Annotations["connector.name"] = pending.ConnectorName;
+        evt.Annotations["connector.type"] = pending.ConnectorType;
+        evt.Annotations["connector.operation"] = pending.Operation;
+        evt.Annotations["connector.attempts"] = pending.Attempt.ToString();
+        evt.Annotations["connector.timeout_ms"] = pending.TimeoutMs.ToString();
         evt.Annotations["connector.duration_ms"] = durationMs.ToString("F2");
     }
 

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.cs
@@ -187,6 +187,11 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
             return;
         }
 
+        // Refactor (iter158/cluster-157-004-timeout-cts):
+        //   Old: connector timeout used inline CTS/call-stack cancellation, so late
+        //        connector completions raced with in-memory continuation state.
+        //   New: the actor owns a typed durable timeout event keyed by operation id;
+        //        timeout and late completion both reconcile through persisted module state.
         var completion = new StepCompletedEvent
         {
             StepId = pending.StepId,

--- a/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
+++ b/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
@@ -432,6 +432,32 @@ message LLMCallModuleState
   map<string, int32> attempts_by_step_id = 2;
 }
 
+message PendingConnectorCallState
+{
+  string step_id = 1;
+  string run_id = 2;
+  string operation_id = 3;
+  string input = 4;
+  string connector_name = 5;
+  string operation = 6;
+  int32 attempt = 7;
+  int32 attempts = 8;
+  int32 timeout_ms = 9;
+  bool on_error_continue = 10;
+  WorkflowRuntimeCallbackLeaseState timeout_lease = 11;
+  string timeout_callback_id = 12;
+  string execution_id = 13;
+  map<string, string> parameters = 14;
+  bool secure_step = 15;
+  string connector_type = 16;
+}
+
+message ConnectorCallModuleState
+{
+  map<string, PendingConnectorCallState> pending_by_operation_id = 1;
+  map<string, string> pending_operation_id_by_step_id = 2;
+}
+
 message EvalContextState
 {
   string step_id = 1;

--- a/test/Aevatar.GAgents.StatusDashboard.Tests/HealthProbeTargetGAgentTests.cs
+++ b/test/Aevatar.GAgents.StatusDashboard.Tests/HealthProbeTargetGAgentTests.cs
@@ -48,6 +48,7 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
             EventSourcingBehaviorFactory =
                 _serviceProvider.GetRequiredService<IEventSourcingBehaviorFactory<HealthProbeTargetState>>(),
         };
+        _agent.EventPublisher = new InlineSelfPublisher(_agent);
         SetActorId(_agent, "health-probe::test");
         await _agent.ActivateAsync();
     }
@@ -177,7 +178,6 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
     public async Task Tick_WhenProbeExceedsTimeout_UsesInjectedClockForCancellationAndOutcome()
     {
         const int timeoutBudgetMs = 30_000;
-        const int timeoutAdvanceMs = timeoutBudgetMs + 1;
         var startedAt = DateTimeOffset.Parse("2026-05-21T10:10:00Z");
         _timeProvider.SetUtcNow(startedAt);
         await _agent.HandleConfigureAsync(new HealthProbeConfigureCommand
@@ -189,17 +189,16 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
         var tickTask = _agent.HandleTickAsync(new HealthProbeTickRequested { Slug = "nyxid-auth" });
         await _executor.ProbeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-        var timedOutAt = startedAt.AddMilliseconds(timeoutAdvanceMs);
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(timeoutAdvanceMs));
-
-        await tickTask.WaitAsync(TimeSpan.FromSeconds(5));
+        var timeout = _scheduler.ScheduledEvents.OfType<HealthProbeTimeoutFiredEvent>().Single();
+        await _agent.HandleTimeoutFiredAsync(timeout);
 
         _executor.Invocations.Should().Be(1);
         _agent.State.LastOutcome.Should().NotBeNull();
         _agent.State.LastOutcome.Status.Should().Be(HealthOutcomeStatus.Down);
         _agent.State.LastOutcome.Detail.Should().Be("timeout");
-        _agent.State.LastOutcome.ObservedAt.ToDateTimeOffset().Should().Be(timedOutAt);
-        _agent.State.LastOutcome.LatencyMs.Should().Be(timeoutAdvanceMs);
+        _agent.State.LastOutcome.ObservedAt.ToDateTimeOffset().Should().Be(startedAt.AddMilliseconds(timeoutBudgetMs));
+        _agent.State.LastOutcome.LatencyMs.Should().Be(timeoutBudgetMs);
+        tickTask.IsCompleted.Should().BeTrue("the tick turn only starts the actor-owned probe operation");
     }
 
     [Fact]
@@ -290,7 +289,7 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
         });
 
         var scheduledBeforeTick = _scheduler.ScheduledTimeouts;
-        _eventStore.ThrowOptimisticConcurrencyOnNextAppend = true;
+        _eventStore.ThrowOptimisticConcurrencyOnNextObservedAppend = true;
         _executor.NextOutcome = new HealthProbeOutcome
         {
             Status = HealthOutcomeStatus.Ok,
@@ -300,7 +299,7 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
         await _agent.HandleTickAsync(new HealthProbeTickRequested { Slug = "nyxid-auth" });
 
         _executor.Invocations.Should().Be(1);
-        _scheduler.ScheduledTimeouts.Should().Be(scheduledBeforeTick + 1,
+        _scheduler.ScheduledTimeouts.Should().Be(scheduledBeforeTick + 2,
             "a transient duplicate tick race must not kill the probe schedule");
     }
 
@@ -350,6 +349,7 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
         public TimeSpan Delay { get; set; }
         public bool WaitForCancellation { get; set; }
         public TaskCompletionSource ProbeStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource ProbeCompletion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public async Task<HealthProbeOutcome> ProbeAsync(HealthProbeTargetDescriptor descriptor, CancellationToken ct)
         {
@@ -361,12 +361,7 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
                 throw ex;
             }
             if (WaitForCancellation)
-            {
-                var cancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-                await using var registration = ct.Register(static state =>
-                    ((TaskCompletionSource)state!).TrySetCanceled(), cancelled);
-                await cancelled.Task;
-            }
+                await ProbeCompletion.Task;
             if (Delay > TimeSpan.Zero)
             {
                 TimeProvider.Advance(Delay);
@@ -379,7 +374,7 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
     {
         private readonly Dictionary<string, List<StateEvent>> _events = new(StringComparer.Ordinal);
 
-        public bool ThrowOptimisticConcurrencyOnNextAppend { get; set; }
+        public bool ThrowOptimisticConcurrencyOnNextObservedAppend { get; set; }
 
         public Task<EventStoreCommitResult> AppendAsync(
             string agentId, IEnumerable<StateEvent> events, long expectedVersion, CancellationToken ct = default)
@@ -391,9 +386,10 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
                 _events[agentId] = stream;
             }
             var currentVersion = stream.Count == 0 ? 0 : stream[^1].Version;
-            if (ThrowOptimisticConcurrencyOnNextAppend)
+            if (ThrowOptimisticConcurrencyOnNextObservedAppend &&
+                events.Any(x => x.EventData.Is(HealthProbeObserved.Descriptor)))
             {
-                ThrowOptimisticConcurrencyOnNextAppend = false;
+                ThrowOptimisticConcurrencyOnNextObservedAppend = false;
                 throw new EventStoreOptimisticConcurrencyException(agentId, expectedVersion, currentVersion + 1);
             }
             if (currentVersion != expectedVersion)
@@ -444,11 +440,16 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
     {
         public int ScheduledTimeouts { get; private set; }
         public IMessage? LastScheduledEvent { get; private set; }
+        public List<IMessage> ScheduledEvents { get; } = [];
 
         public Task<RuntimeCallbackLease> ScheduleTimeoutAsync(RuntimeCallbackTimeoutRequest request, CancellationToken ct = default)
         {
             ScheduledTimeouts++;
-            LastScheduledEvent = request.TriggerEnvelope.Payload.Unpack<HealthProbeTickRequested>();
+            if (request.TriggerEnvelope.Payload.Is(HealthProbeTimeoutFiredEvent.Descriptor))
+                LastScheduledEvent = request.TriggerEnvelope.Payload.Unpack<HealthProbeTimeoutFiredEvent>();
+            else
+                LastScheduledEvent = request.TriggerEnvelope.Payload.Unpack<HealthProbeTickRequested>();
+            ScheduledEvents.Add(LastScheduledEvent);
             return Task.FromResult(new RuntimeCallbackLease(
                 request.ActorId,
                 request.CallbackId,
@@ -460,5 +461,46 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
             Task.FromResult(new RuntimeCallbackLease(request.ActorId, request.CallbackId, 1, RuntimeCallbackBackend.InMemory));
         public Task CancelAsync(RuntimeCallbackLease lease, CancellationToken ct = default) => Task.CompletedTask;
         public Task PurgeActorAsync(string actorId, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class InlineSelfPublisher(HealthProbeTargetGAgent agent) : IEventPublisher
+    {
+        public Task PublishAsync<TEvent>(
+            TEvent evt,
+            TopologyAudience audience = TopologyAudience.Children,
+            CancellationToken ct = default,
+            EventEnvelope? sourceEnvelope = null,
+            EventEnvelopePublishOptions? options = null)
+            where TEvent : IMessage
+        {
+            _ = audience;
+            _ = sourceEnvelope;
+            _ = options;
+            return DispatchAsync(evt, ct);
+        }
+
+        public Task SendToAsync<TEvent>(
+            string targetActorId,
+            TEvent evt,
+            CancellationToken ct = default,
+            EventEnvelope? sourceEnvelope = null,
+            EventEnvelopePublishOptions? options = null)
+            where TEvent : IMessage
+        {
+            _ = targetActorId;
+            _ = sourceEnvelope;
+            _ = options;
+            return DispatchAsync(evt, ct);
+        }
+
+        private async Task DispatchAsync(IMessage evt, CancellationToken ct)
+        {
+            switch (evt)
+            {
+                case HealthProbeCompletedEvent completed:
+                    await agent.HandleCompletedAsync(completed);
+                    break;
+            }
+        }
     }
 }

--- a/test/Aevatar.GAgents.StatusDashboard.Tests/HealthProbeTargetGAgentTests.cs
+++ b/test/Aevatar.GAgents.StatusDashboard.Tests/HealthProbeTargetGAgentTests.cs
@@ -7,6 +7,7 @@ using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.GAgents.StatusDashboard.Executors;
 using FluentAssertions;
 using Google.Protobuf;
+using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Time.Testing;
@@ -21,6 +22,7 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
     private InMemoryEventStore _eventStore = null!;
     private TrackingCallbackScheduler _scheduler = null!;
     private FakeTimeProvider _timeProvider = null!;
+    private InlineSelfPublisher _publisher = null!;
 
     public async Task InitializeAsync()
     {
@@ -48,7 +50,8 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
             EventSourcingBehaviorFactory =
                 _serviceProvider.GetRequiredService<IEventSourcingBehaviorFactory<HealthProbeTargetState>>(),
         };
-        _agent.EventPublisher = new InlineSelfPublisher(_agent);
+        _publisher = new InlineSelfPublisher(_agent);
+        _agent.EventPublisher = _publisher;
         SetActorId(_agent, "health-probe::test");
         await _agent.ActivateAsync();
     }
@@ -199,6 +202,52 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
         _agent.State.LastOutcome.ObservedAt.ToDateTimeOffset().Should().Be(startedAt.AddMilliseconds(timeoutBudgetMs));
         _agent.State.LastOutcome.LatencyMs.Should().Be(timeoutBudgetMs);
         tickTask.IsCompleted.Should().BeTrue("the tick turn only starts the actor-owned probe operation");
+    }
+
+    [Fact]
+    public async Task Tick_WhenTimedOutProbeCompletesLate_IgnoresStaleCompletion()
+    {
+        const int timeoutBudgetMs = 30_000;
+        var startedAt = DateTimeOffset.Parse("2026-05-21T10:12:00Z");
+        _timeProvider.SetUtcNow(startedAt);
+        await _agent.HandleConfigureAsync(new HealthProbeConfigureCommand
+        {
+            Spec = NewDescriptor("nyxid-auth", timeoutMs: timeoutBudgetMs),
+        });
+
+        _executor.WaitForCancellation = true;
+        _executor.NextOutcome = new HealthProbeOutcome
+        {
+            Status = HealthOutcomeStatus.Ok,
+            Detail = "late_success",
+        };
+
+        var tickTask = _agent.HandleTickAsync(new HealthProbeTickRequested { Slug = "nyxid-auth" });
+        await _executor.ProbeStarted.Task;
+
+        var timeout = _scheduler.ScheduledEvents.OfType<HealthProbeTimeoutFiredEvent>().Single();
+        await _agent.HandleTimeoutFiredAsync(timeout);
+
+        var scheduledAfterTimeout = _scheduler.ScheduledTimeouts;
+        var observedAfterTimeout = _eventStore.CountEvents(HealthProbeObserved.Descriptor);
+
+        _agent.State.LastOutcome.Should().NotBeNull();
+        _agent.State.LastOutcome.Status.Should().Be(HealthOutcomeStatus.Down);
+        _agent.State.LastOutcome.Detail.Should().Be("timeout");
+        _agent.State.ActiveExecution.Should().BeNull();
+
+        _executor.ProbeCompletion.SetResult();
+        await _publisher.CompletedHandled.Task;
+        await tickTask;
+
+        _agent.State.LastOutcome.Status.Should().Be(HealthOutcomeStatus.Down);
+        _agent.State.LastOutcome.Detail.Should().Be("timeout");
+        _agent.State.ActiveExecution.Should().BeNull();
+        _eventStore.CountEvents(HealthProbeObserved.Descriptor).Should().Be(observedAfterTimeout,
+            "a stale late completion must not publish a second terminal outcome");
+        _agent.State.RecentOutcomes.Should().ContainSingle();
+        _scheduler.ScheduledTimeouts.Should().Be(scheduledAfterTimeout,
+            "a stale late completion must not schedule another next tick");
     }
 
     [Fact]
@@ -425,6 +474,9 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
             return Task.FromResult(stream[^1].Version);
         }
 
+        public int CountEvents(MessageDescriptor descriptor) =>
+            _events.Values.Sum(stream => stream.Count(x => x.EventData.Is(descriptor)));
+
         public Task<long> DeleteEventsUpToAsync(string agentId, long toVersion, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
@@ -465,6 +517,9 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
 
     private sealed class InlineSelfPublisher(HealthProbeTargetGAgent agent) : IEventPublisher
     {
+        public TaskCompletionSource<HealthProbeCompletedEvent> CompletedHandled { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         public Task PublishAsync<TEvent>(
             TEvent evt,
             TopologyAudience audience = TopologyAudience.Children,
@@ -499,6 +554,7 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
             {
                 case HealthProbeCompletedEvent completed:
                     await agent.HandleCompletedAsync(completed);
+                    CompletedHandled.TrySetResult(completed);
                     break;
             }
         }

--- a/test/Aevatar.Integration.Tests/ConnectorCallModuleCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/ConnectorCallModuleCoverageTests.cs
@@ -445,24 +445,6 @@ public sealed class ConnectorCallModuleCoverageTests
         }
     }
 
-    private sealed class DelayConnector(string name) : IConnector
-    {
-        public string Name { get; } = name;
-        public string Type => "test";
-
-        public async Task<ConnectorResponse> ExecuteAsync(ConnectorRequest request, CancellationToken ct = default)
-        {
-            _ = request;
-            var pending = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            await pending.Task.WaitAsync(ct);
-            return new ConnectorResponse
-            {
-                Success = true,
-                Output = "late",
-            };
-        }
-    }
-
     private sealed class ManualConnector(string name) : IConnector
     {
         private readonly TaskCompletionSource<ConnectorResponse> _completion =

--- a/test/Aevatar.Integration.Tests/ConnectorCallModuleCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/ConnectorCallModuleCoverageTests.cs
@@ -2,6 +2,7 @@ using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.Foundation.Core;
 using Aevatar.Workflow.Abstractions.Execution;
+using Aevatar.Workflow.Core;
 using Aevatar.Workflow.Core.Modules;
 using Aevatar.Workflow.Core.Connectors;
 using FluentAssertions;
@@ -228,6 +229,67 @@ public sealed class ConnectorCallModuleCoverageTests
             .OfType<StepCompletedEvent>()
             .Should()
             .ContainSingle();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenConnectorCompletesAfterTimeout_ShouldIgnoreStaleCompletionAndClearActiveExecution()
+    {
+        var registry = new ConfiguredConnectorRegistry();
+        var connector = new ManualConnector("slow-stale-lease");
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
+        var module = new ConnectorCallModule(new RegistryBackedWorkflowConnectorResolver(registry));
+        var ctx = CreateContext();
+        var request = new StepRequestEvent
+        {
+            StepId = "s-stale-timeout",
+            RunId = "run-stale-timeout",
+            StepType = "connector_call",
+            Input = "original",
+            ExecutionId = "exec-stale-timeout",
+            Parameters =
+            {
+                ["connector"] = "slow-stale-lease",
+                ["operation"] = "sync",
+                ["timeout_ms"] = "1",
+            },
+        };
+
+        var callTask = module.HandleAsync(Envelope(request), ctx, CancellationToken.None);
+        ctx.Scheduled.Should().ContainSingle(x => x.Event is WorkflowConnectorTimeoutFiredEvent);
+
+        var timeout = ctx.Scheduled.Single(x => x.Event is WorkflowConnectorTimeoutFiredEvent);
+        await module.HandleAsync(ctx.CreateScheduledEnvelope(timeout), ctx, CancellationToken.None);
+
+        var timeoutCompletion = ctx.Published
+            .Select(x => x.evt)
+            .OfType<StepCompletedEvent>()
+            .Should()
+            .ContainSingle()
+            .Subject;
+        timeoutCompletion.Success.Should().BeFalse();
+        timeoutCompletion.Error.Should().Be("connector call timed out after 100ms");
+        timeoutCompletion.Annotations["connector.timeout_fired"].Should().Be("true");
+
+        connector.Complete(new ConnectorResponse
+        {
+            Success = true,
+            Output = "late-success",
+        });
+        await callTask;
+        await DrainConnectorContinuationsAsync(module, ctx);
+
+        ctx.Published.ToArray()
+            .Select(x => x.evt)
+            .OfType<StepCompletedEvent>()
+            .Should()
+            .ContainSingle()
+            .Which
+            .Should()
+            .BeSameAs(timeoutCompletion);
+
+        var state = ctx.LoadState<ConnectorCallModuleState>("connector_call");
+        state.PendingByOperationId.Should().BeEmpty();
+        state.PendingOperationIdByStepId.Should().BeEmpty();
     }
 
     [Fact]

--- a/test/Aevatar.Integration.Tests/ConnectorCallModuleCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/ConnectorCallModuleCoverageTests.cs
@@ -102,7 +102,7 @@ public sealed class ConnectorCallModuleCoverageTests
             },
         };
 
-        await module.HandleAsync(Envelope(request, correlationId: "corr-1"), ctx, CancellationToken.None);
+        await HandleAndDrainAsync(module, Envelope(request, correlationId: "corr-1"), ctx);
 
         connector.Attempts.Should().Be(2);
         connector.LastRequest.Should().NotBeNull();
@@ -121,7 +121,8 @@ public sealed class ConnectorCallModuleCoverageTests
     public async Task HandleAsync_WhenTimeoutAndContinue_ShouldKeepInput()
     {
         var registry = new ConfiguredConnectorRegistry();
-        await registry.RegisterAsync(ConnectorRegistration.External(new DelayConnector("slow")));
+        var connector = new ManualConnector("slow");
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var module = new ConnectorCallModule(new RegistryBackedWorkflowConnectorResolver(registry));
         var ctx = CreateContext();
         var request = new StepRequestEvent
@@ -137,14 +138,34 @@ public sealed class ConnectorCallModuleCoverageTests
             },
         };
 
-        await module.HandleAsync(Envelope(request), ctx, CancellationToken.None);
+        var callTask = module.HandleAsync(Envelope(request), ctx, CancellationToken.None);
+        ctx.Scheduled.Should().ContainSingle(x => x.Event is WorkflowConnectorTimeoutFiredEvent);
 
-        var completed = ctx.Published.Should().ContainSingle().Subject.evt.Should().BeOfType<StepCompletedEvent>().Subject;
+        var timeout = ctx.Scheduled.Single(x => x.Event is WorkflowConnectorTimeoutFiredEvent);
+        await module.HandleAsync(ctx.CreateScheduledEnvelope(timeout), ctx, CancellationToken.None);
+
+        var completed = ctx.Published
+            .Select(x => x.evt)
+            .OfType<StepCompletedEvent>()
+            .Single();
         completed.Success.Should().BeTrue();
         completed.Output.Should().Be("original");
         completed.Annotations["connector.continued_on_error"].Should().Be("true");
         completed.Annotations["connector.timeout_ms"].Should().Be("100");
         completed.Annotations.Should().ContainKey("connector.error");
+
+        connector.Complete(new ConnectorResponse
+        {
+            Success = true,
+            Output = "late",
+        });
+        await callTask;
+        await DrainConnectorContinuationsAsync(module, ctx);
+        ctx.Published.ToArray()
+            .Select(x => x.evt)
+            .OfType<StepCompletedEvent>()
+            .Should()
+            .ContainSingle();
     }
 
     [Fact]
@@ -184,7 +205,7 @@ public sealed class ConnectorCallModuleCoverageTests
             },
         };
 
-        await module.HandleAsync(Envelope(request), ctx, CancellationToken.None);
+        await HandleAndDrainAsync(module, Envelope(request), ctx);
 
         connector.LastRequest.Should().NotBeNull();
         connector.LastRequest!.Payload.Should().Be("""{"providerName":"demo","apiKey":"sk-secure"}""");
@@ -232,7 +253,7 @@ public sealed class ConnectorCallModuleCoverageTests
             },
         };
 
-        await module.HandleAsync(Envelope(request), ctx, CancellationToken.None);
+        await HandleAndDrainAsync(module, Envelope(request), ctx);
 
         connector.LastRequest.Should().NotBeNull();
         connector.LastRequest!.Payload.Should().Be("""{"providerName":"demo","apiKey":"sk-\"line\ntwo"}""");
@@ -258,7 +279,7 @@ public sealed class ConnectorCallModuleCoverageTests
             },
         };
 
-        await module.HandleAsync(Envelope(request), ctx, CancellationToken.None);
+        await HandleAndDrainAsync(module, Envelope(request), ctx);
 
         var completed = ctx.Published.Should().ContainSingle().Subject.evt.Should().BeOfType<StepCompletedEvent>().Subject;
         completed.Success.Should().BeTrue();
@@ -284,7 +305,7 @@ public sealed class ConnectorCallModuleCoverageTests
             },
         };
 
-        await module.HandleAsync(Envelope(request), ctx, CancellationToken.None);
+        await HandleAndDrainAsync(module, Envelope(request), ctx);
 
         var completed = ctx.Published.Should().ContainSingle().Subject.evt.Should().BeOfType<StepCompletedEvent>().Subject;
         completed.Success.Should().BeFalse();
@@ -313,6 +334,30 @@ public sealed class ConnectorCallModuleCoverageTests
                 CorrelationId = correlationId ?? string.Empty,
             },
         };
+    }
+
+    private static async Task HandleAndDrainAsync(
+        ConnectorCallModule module,
+        EventEnvelope envelope,
+        TestEventHandlerContext ctx)
+    {
+        await module.HandleAsync(envelope, ctx, CancellationToken.None);
+        await DrainConnectorContinuationsAsync(module, ctx);
+    }
+
+    private static async Task DrainConnectorContinuationsAsync(
+        ConnectorCallModule module,
+        TestEventHandlerContext ctx)
+    {
+        for (var index = 0; index < ctx.Published.Count; index++)
+        {
+            if (ctx.Published[index].evt is not WorkflowConnectorAttemptCompletedEvent completed)
+                continue;
+
+            ctx.Published.RemoveAt(index);
+            index--;
+            await module.HandleAsync(Envelope(completed), ctx, CancellationToken.None);
+        }
     }
 
     private sealed class ThrowThenSuccessConnector(string name) : IConnector
@@ -354,6 +399,24 @@ public sealed class ConnectorCallModuleCoverageTests
                 Output = "late",
             };
         }
+    }
+
+    private sealed class ManualConnector(string name) : IConnector
+    {
+        private readonly TaskCompletionSource<ConnectorResponse> _completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public string Name { get; } = name;
+        public string Type => "test";
+
+        public Task<ConnectorResponse> ExecuteAsync(ConnectorRequest request, CancellationToken ct = default)
+        {
+            _ = request;
+            _ = ct;
+            return _completion.Task;
+        }
+
+        public void Complete(ConnectorResponse response) => _completion.SetResult(response);
     }
 
     private sealed class EchoConnector(string name) : IConnector

--- a/test/Aevatar.Integration.Tests/ConnectorCallModuleCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/ConnectorCallModuleCoverageTests.cs
@@ -169,6 +169,68 @@ public sealed class ConnectorCallModuleCoverageTests
     }
 
     [Fact]
+    public async Task HandleAsync_WhenTimeoutAndDefaultOnError_ShouldPublishFailureWithAnnotations()
+    {
+        var registry = new ConfiguredConnectorRegistry();
+        var connector = new ManualConnector("slow-default-fail");
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
+        var module = new ConnectorCallModule(new RegistryBackedWorkflowConnectorResolver(registry));
+        var ctx = CreateContext();
+        var request = new StepRequestEvent
+        {
+            StepId = "s-timeout-fail",
+            RunId = "run-timeout-fail",
+            StepType = "connector_call",
+            Input = "original",
+            ExecutionId = "exec-timeout-fail",
+            Parameters =
+            {
+                ["connector"] = "slow-default-fail",
+                ["operation"] = "sync",
+                ["timeout_ms"] = "1",
+            },
+        };
+
+        var callTask = module.HandleAsync(Envelope(request), ctx, CancellationToken.None);
+        ctx.Scheduled.Should().ContainSingle(x => x.Event is WorkflowConnectorTimeoutFiredEvent);
+
+        var timeout = ctx.Scheduled.Single(x => x.Event is WorkflowConnectorTimeoutFiredEvent);
+        await module.HandleAsync(ctx.CreateScheduledEnvelope(timeout), ctx, CancellationToken.None);
+
+        var completed = ctx.Published
+            .Select(x => x.evt)
+            .OfType<StepCompletedEvent>()
+            .Single();
+        completed.StepId.Should().Be("s-timeout-fail");
+        completed.RunId.Should().Be("run-timeout-fail");
+        completed.ExecutionId.Should().Be("exec-timeout-fail");
+        completed.Success.Should().BeFalse();
+        completed.Output.Should().BeEmpty();
+        completed.Error.Should().Be("connector call timed out after 100ms");
+        completed.Annotations["connector.name"].Should().Be("slow-default-fail");
+        completed.Annotations["connector.type"].Should().Be("test");
+        completed.Annotations["connector.operation"].Should().Be("sync");
+        completed.Annotations["connector.attempts"].Should().Be("1");
+        completed.Annotations["connector.timeout_ms"].Should().Be("100");
+        completed.Annotations["connector.duration_ms"].Should().Be("100.00");
+        completed.Annotations["connector.timeout_fired"].Should().Be("true");
+        completed.Annotations.Should().NotContainKey("connector.continued_on_error");
+
+        connector.Complete(new ConnectorResponse
+        {
+            Success = true,
+            Output = "late",
+        });
+        await callTask;
+        await DrainConnectorContinuationsAsync(module, ctx);
+        ctx.Published.ToArray()
+            .Select(x => x.evt)
+            .OfType<StepCompletedEvent>()
+            .Should()
+            .ContainSingle();
+    }
+
+    [Fact]
     public async Task HandleAsync_WhenSecureConnectorCallUsesTemplateDefault_ShouldResolveCapturedSecret()
     {
         var registry = new ConfiguredConnectorRegistry();

--- a/test/Aevatar.Integration.Tests/ConnectorCallModuleCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/ConnectorCallModuleCoverageTests.cs
@@ -208,7 +208,10 @@ public sealed class ConnectorCallModuleCoverageTests
         completed.Success.Should().BeFalse();
         completed.Output.Should().BeEmpty();
         completed.Error.Should().Be("connector call timed out after 100ms");
+        completed.Error.Should().Contain("timed out");
         completed.Annotations["connector.name"].Should().Be("slow-default-fail");
+        completed.Annotations["connector.step_id"].Should().Be("s-timeout-fail");
+        completed.Annotations["connector.run_id"].Should().Be("run-timeout-fail");
         completed.Annotations["connector.type"].Should().Be("test");
         completed.Annotations["connector.operation"].Should().Be("sync");
         completed.Annotations["connector.attempts"].Should().Be("1");
@@ -267,8 +270,12 @@ public sealed class ConnectorCallModuleCoverageTests
             .ContainSingle()
             .Subject;
         timeoutCompletion.Success.Should().BeFalse();
+        timeoutCompletion.Output.Should().BeEmpty();
         timeoutCompletion.Error.Should().Be("connector call timed out after 100ms");
+        timeoutCompletion.Error.Should().Contain("timed out");
         timeoutCompletion.Annotations["connector.timeout_fired"].Should().Be("true");
+        timeoutCompletion.Annotations["connector.step_id"].Should().Be("s-stale-timeout");
+        timeoutCompletion.Annotations["connector.run_id"].Should().Be("run-stale-timeout");
 
         connector.Complete(new ConnectorResponse
         {

--- a/test/Aevatar.Integration.Tests/WorkflowLoopModuleCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowLoopModuleCoverageTests.cs
@@ -656,7 +656,26 @@ public sealed class WorkflowLoopModuleCoverageTests
         await module.HandleAsync(ctx.CreateScheduledEnvelope(scheduled), ctx, CancellationToken.None);
 
         var timeoutEvent = ctx.Published.Select(x => x.evt).OfType<StepCompletedEvent>().Single();
+        timeoutEvent.Success.Should().BeFalse();
+        timeoutEvent.Output.Should().BeEmpty();
         timeoutEvent.Error.Should().Contain("TIMEOUT");
+
+        await module.HandleAsync(Envelope(timeoutEvent), ctx, CancellationToken.None);
+        ctx.LoadState<WorkflowExecutionKernelState>("workflow_execution_kernel").Active.Should().BeFalse();
+        ctx.Published.Clear();
+
+        await module.HandleAsync(
+            Envelope(new StepCompletedEvent
+            {
+                StepId = "s1",
+                RunId = "run-timeout",
+                Success = true,
+                Output = "late-success",
+            }),
+            ctx,
+            CancellationToken.None);
+
+        ctx.Published.Should().BeEmpty();
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Core.Tests/InlineCtsAbsenceTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/InlineCtsAbsenceTests.cs
@@ -1,0 +1,39 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+
+namespace Aevatar.Workflow.Core.Tests;
+
+public sealed class InlineCtsAbsenceTests
+{
+    [Theory]
+    [InlineData("ConnectorCallModule")]
+    [InlineData("HealthProbeTargetGAgent")]
+    [InlineData("AgentRunGAgent")]
+    public void Inline_cts_cancel_after_should_remain_deleted(string moduleName)
+    {
+        var srcRoot = Path.Combine(FindRepositoryRoot(), "src");
+        var hits = Directory.EnumerateFiles(srcRoot, $"{moduleName}.cs", SearchOption.AllDirectories)
+            .SelectMany(file => File.ReadAllLines(file)
+                .Select((content, index) => (file, line: index + 1, content))
+                .Where(x => Regex.IsMatch(x.content, @"CancellationTokenSource.*CancelAfter") &&
+                            !x.content.TrimStart().StartsWith("//", StringComparison.Ordinal)))
+            .ToList();
+
+        hits.Should().BeEmpty(
+            "inline CTS+CancelAfter forbidden per PR #1168 / issue #1160 (use actor-owned typed timeout event)");
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "aevatar.slnx")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Repository root could not be resolved.");
+    }
+}

--- a/test/Aevatar.Workflow.Core.Tests/InlineCtsAbsenceTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/InlineCtsAbsenceTests.cs
@@ -1,3 +1,5 @@
+// Refactor (iter158/cluster-157-004-timeout-cts):
+// Source-regression test for PR #1168: keep inline CTS+CancelAfter deleted from the touched caller files.
 using System.Text.RegularExpressions;
 using FluentAssertions;
 
@@ -6,17 +8,18 @@ namespace Aevatar.Workflow.Core.Tests;
 public sealed class InlineCtsAbsenceTests
 {
     [Theory]
-    [InlineData("ConnectorCallModule")]
-    [InlineData("HealthProbeTargetGAgent")]
-    [InlineData("AgentRunGAgent")]
-    public void Inline_cts_cancel_after_should_remain_deleted(string moduleName)
+    [InlineData("src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.cs")]
+    [InlineData("agents/Aevatar.GAgents.StatusDashboard/HealthProbeTargetGAgent.cs")]
+    [InlineData("agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs")]
+    public void Inline_cts_cancel_after_should_remain_deleted(string relativePath)
     {
-        var srcRoot = Path.Combine(FindRepositoryRoot(), "src");
-        var hits = Directory.EnumerateFiles(srcRoot, $"{moduleName}.cs", SearchOption.AllDirectories)
-            .SelectMany(file => File.ReadAllLines(file)
-                .Select((content, index) => (file, line: index + 1, content))
-                .Where(x => Regex.IsMatch(x.content, @"CancellationTokenSource.*CancelAfter") &&
-                            !x.content.TrimStart().StartsWith("//", StringComparison.Ordinal)))
+        var fullPath = Path.Combine(new[] { FindRepositoryRoot() }.Concat(relativePath.Split('/')).ToArray());
+        File.Exists(fullPath).Should().BeTrue($"expected file {relativePath} to exist");
+
+        var hits = File.ReadAllLines(fullPath)
+            .Select((content, index) => (file: fullPath, line: index + 1, content))
+            .Where(x => Regex.IsMatch(x.content, @"CancellationTokenSource.*CancelAfter") &&
+                        !x.content.TrimStart().StartsWith("//", StringComparison.Ordinal))
             .ToList();
 
         hits.Should().BeEmpty(


### PR DESCRIPTION
## 摘要

iter158 #1160:删除 actor/module turn 内 inline `CancellationTokenSource.CancelAfter` 的 timeout shape,改用 actor-owned durable self-signal(typed timeout-fired event)。

- **Old**:`ConnectorCallModule` / `HealthProbeTargetGAgent` / `AgentRunGAgent` 在 actor/module turn 内创 CTS + CancelAfter 包裹 business IO
- **New**:典型 timeout 改成 actor self-message(typed `*TimeoutFiredEvent`)+ actor reconcile;保留 connector/status/NyxID 业务能力,**不删 feature**

违反:CLAUDE.md「延迟/超时事件化」+「回调只发信号」+「业务推进内聚」。

## 范围

8 files(+779/-155 = 净 +624 LOC):
- `ConnectorCallModule.cs` 大改:inline CTS → publish typed timeout event
- `workflow_state.proto`:新增 timeout-fired event types
- 关联 unit/integration tests 更新
- SCOPE_EXTEND:`../NyxID`(repository rule 强制 NyxID-related work cite)

完整 Phase 9 r4 共识链路(r1→r2 split → r3 converge → r4 unanimous after delete reframe):https://github.com/aevatarAI/aevatar/issues/1160

## Phase 8

Base = `auto-refact-dev`。closes #1160。

🤖 Auto-loop / codex-refactor-loop iter158

⟦AI:AUTO-LOOP⟧
