### PR TITLE
fix(frontend): align TeamTestPanel status with CQRS model

### DIFF
--- a/apps/aevatar-console-web/src/pages/teams/components/TeamTestPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/components/TeamTestPanel.tsx
@@ -14,15 +14,16 @@ import {
   FactLine,
   factValueFontFamily,
 } from "./TeamDetailPrimitives";
+import type { CqrsStatus } from "@/shared/models/cqrsState";
 import type { TeamTestErrorDescription } from "./teamTestErrors";
 
-export type TeamTestStatus =
-  | "idle"
-  | "setting-entry"
-  | "running"
-  | "success"
-  | "error"
-  | "stopped";
+/**
+ * UI-local status for the team test panel.
+ *
+ * Terminal values ("completed" / "failed") are CQRS-aligned via CqrsStatus.
+ * "setting-entry" is a UI-only transient phase with no CQRS equivalent.
+ */
+export type TeamTestStatus = CqrsStatus | "setting-entry";
 
 export type TeamTestRosterRow = {
   readonly buildStudioHref: string;
@@ -39,7 +40,7 @@ export type TeamTestRosterRow = {
 export type TeamTestLastResult = {
   readonly finishedAtLabel: string;
   readonly runId?: string;
-  readonly status: "success" | "error" | "stopped";
+  readonly status: "completed" | "failed";
   readonly summary: string;
 };
 
@@ -78,23 +79,17 @@ function resolveTestStatusPill(
         border: `1px solid ${token.colorInfoBorder}`,
         color: token.colorInfo,
       };
-    case "success":
+    case "completed":
       return {
         background: token.colorSuccessBg,
         border: `1px solid ${token.colorSuccessBorder}`,
         color: token.colorSuccess,
       };
-    case "error":
+    case "failed":
       return {
         background: token.colorErrorBg,
         border: `1px solid ${token.colorErrorBorder}`,
         color: token.colorError,
-      };
-    case "stopped":
-      return {
-        background: token.colorWarningBg,
-        border: `1px solid ${token.colorWarningBorder}`,
-        color: token.colorWarning,
       };
     default:
       return {
@@ -111,12 +106,10 @@ function formatStatusLabel(status: TeamTestStatus): string {
       return "正在设置入口";
     case "running":
       return "测试中";
-    case "success":
+    case "completed":
       return "已完成";
-    case "error":
+    case "failed":
       return "失败";
-    case "stopped":
-      return "已停止";
     default:
       return "待测试";
   }

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -1156,11 +1156,11 @@ const TeamDetailPage: React.FC = () => {
           accumulator.finalOutput ||
           accumulator.errorText ||
           "Team Test stopped.";
-        setTeamTestStatus("stopped");
+        setTeamTestStatus("failed");
         setTeamTestLastResult({
           finishedAtLabel: formatLocalTimeLabel(new Date()),
           runId: accumulator.runId || undefined,
-          status: "stopped",
+          status: "failed",
           summary: stoppedSummary,
         });
         return;
@@ -1171,7 +1171,7 @@ const TeamDetailPage: React.FC = () => {
         accumulator.finalOutput ||
         accumulator.assistantText ||
         "Team returned an empty response.";
-      const nextStatus = accumulator.errorText ? "error" : "success";
+      const nextStatus = accumulator.errorText ? "failed" : "completed";
       setTeamTestResultText(summary);
       setTeamTestStatus(nextStatus);
       if (accumulator.errorText) {
@@ -1185,23 +1185,23 @@ const TeamDetailPage: React.FC = () => {
       });
     } catch (error) {
       if (controller.signal.aborted || isAbortLikeError(error)) {
-        setTeamTestStatus("stopped");
+        setTeamTestStatus("failed");
         setTeamTestError(describeTeamTestError(error));
         setTeamTestLastResult({
           finishedAtLabel: formatLocalTimeLabel(new Date()),
-          status: "stopped",
+          status: "failed",
           summary: "Team Test stopped.",
         });
         return;
       }
 
       const errorDescription = describeTeamTestError(error);
-      setTeamTestStatus("error");
+      setTeamTestStatus("failed");
       setTeamTestError(errorDescription);
       setTeamTestResultText(errorDescription.description);
       setTeamTestLastResult({
         finishedAtLabel: formatLocalTimeLabel(new Date()),
-        status: "error",
+        status: "failed",
         summary: errorDescription.description,
       });
     } finally {
@@ -1273,12 +1273,12 @@ const TeamDetailPage: React.FC = () => {
               kind: "entry_syncing",
               title: "Team entry 正在同步",
             };
-            setTeamTestStatus("error");
+            setTeamTestStatus("failed");
             setTeamTestError(errorDescription);
             setTeamTestResultText(errorDescription.description);
             setTeamTestLastResult({
               finishedAtLabel: formatLocalTimeLabel(new Date()),
-              status: "error",
+              status: "failed",
               summary: errorDescription.description,
             });
             return;
@@ -1292,7 +1292,7 @@ const TeamDetailPage: React.FC = () => {
           error,
           "Team entry update failed.",
         );
-        setTeamTestStatus("error");
+        setTeamTestStatus("failed");
         setTeamTestError(errorDescription);
         void message.error(errorDescription.title);
       } finally {
@@ -1333,7 +1333,7 @@ const TeamDetailPage: React.FC = () => {
         error,
         "Team entry update failed.",
       );
-      setTeamTestStatus("error");
+      setTeamTestStatus("failed");
       setTeamTestError(errorDescription);
       void message.error(errorDescription.title);
     } finally {

--- a/apps/aevatar-console-web/src/shared/models/cqrsState.ts
+++ b/apps/aevatar-console-web/src/shared/models/cqrsState.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared CQRS-aligned UI state vocabulary.
+ *
+ * Derived from docs/canon/frontend-design.md section 4.1.
+ * Every status model in the frontend MUST use a subset of these values;
+ * ad-hoc aliases like "success", "error", "stopped" are forbidden.
+ */
+export type CqrsStatus =
+  | "idle"
+  | "accepted"
+  | "running"
+  | "streaming"
+  | "paused"
+  | "observed"
+  | "completed"
+  | "still-processing"
+  | "failed";


### PR DESCRIPTION
## Issue

**NEW-001 (MEDIUM)** — TeamTestPanel introduces divergent CQRS state model variant.

`TeamTestStatus = "idle" | "setting-entry" | "running" | "success" | "error" | "stopped"` diverged from CQRS vocabulary.

## Fix

- Imported shared `CqrsStatus` type
- `TeamTestStatus` → `CqrsStatus | "setting-entry"` (UI-only phase retained)
- `"success"` → `"completed"`, `"error"`/`"stopped"` → `"failed"`
- Updated 8 status literals in `detail.tsx`

🤖 Generated with [Frontend Refactoring Team](.claude/skills/frontend-refactor-team/)