### PR TITLE
iter159 #1178: strip NyxID bearer from workflow durable + pending approval surfaces

### DIFF
--- a/src/Aevatar.AI.Core/RoleGAgent.cs
+++ b/src/Aevatar.AI.Core/RoleGAgent.cs
@@ -127,8 +127,8 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
                 "[{Role}] Tool approval APPROVED. Executing tool={Tool} request={RequestId}",
                 RoleName, pending.ToolName, pending.RequestId);
 
-            // Restore typed context (NyxID access token etc.) so tool execution can
-            // read AgentToolRequestContext typed accessors.
+            // Restore scrubbed typed context so tool execution can read stable
+            // AgentToolRequestContext accessors without durable request bearer.
             try
             {
                 using (AgentToolContextScope.Push(AgentToolExecutionContextMapper.FromMetadata(
@@ -167,7 +167,7 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
                         SessionId = Guid.NewGuid().ToString("N"),
                         ScopeId = pending.SessionId,
                     };
-                    foreach (var kv in pending.Metadata)
+                    foreach (var kv in ScrubPendingApprovalMetadata(pending.Metadata))
                         continuationRequest.Metadata[kv.Key] = kv.Value;
 
                     await SendToAsync(Id, continuationRequest);
@@ -238,7 +238,7 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
                     pending.ArgumentsJson,
                     ToolApprovalMode.Auto,
                     pending.IsDestructive,
-                    new Dictionary<string, string>(pending.Metadata, StringComparer.Ordinal)),
+                    new Dictionary<string, string>(ScrubPendingApprovalMetadata(pending.Metadata), StringComparer.Ordinal)),
                 CancellationToken.None);
 
             var callbackId = BuildRemoteApprovalStatusCallbackId(pending.RequestId, submission.RemoteApprovalId, 1);
@@ -301,7 +301,7 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
                 new RemoteToolApprovalStatusQuery(
                     pending.RequestId,
                     pending.RemoteApprovalId,
-                    new Dictionary<string, string>(pending.Metadata, StringComparer.Ordinal)),
+                    new Dictionary<string, string>(ScrubPendingApprovalMetadata(pending.Metadata), StringComparer.Ordinal)),
                 CancellationToken.None);
         }
         catch (Exception ex)
@@ -424,8 +424,10 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
                     ArgumentsJson = args,
                     IsDestructive = true,
                 };
-                // Preserve metadata (NyxID access token etc.) for continuation
-                foreach (var kv in request.Metadata)
+                // Refactor (iter159/cluster-613-first):
+                //   Old pattern: NyxID bearer entered workflow durable + pending approval surface.
+                //   New principle: request bearer scrubbed at envelope/state/continuation; only durable model/route controls remain.
+                foreach (var kv in ScrubPendingApprovalMetadata(request.Metadata))
                     pending.Metadata[kv.Key] = kv.Value;
 
                 return pending;
@@ -535,6 +537,10 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
                $"{toolResult ?? "(no output)"}\n\n" +
                "Please continue with the original task based on this result.";
     }
+
+    private static IReadOnlyDictionary<string, string> ScrubPendingApprovalMetadata(
+        IReadOnlyDictionary<string, string>? metadata) =>
+        AgentToolExecutionContextMapper.StripOwnedControlKeys(metadata);
 
     // ─── Pending approval state transitions ───
 

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs
@@ -29,7 +29,7 @@ internal sealed class WorkflowChatRequestEnvelopeFactory : ICommandEnvelopeFacto
         // Refactor (iter56/cluster-917-workflow-llm-control-metadata): old=Headers/Metadata bag for control fields, new=typed ChatRequestEvent.Telegram
         AppendMetadata(chatRequest.Metadata, command.Metadata);
         if (command.LlmControl != null)
-            chatRequest.LlmControl = command.LlmControl.ToPayload();
+            chatRequest.LlmControl = ToDurableLlmControlPayload(command.LlmControl);
 
         var envelope = new EventEnvelope
         {
@@ -90,4 +90,17 @@ internal sealed class WorkflowChatRequestEnvelopeFactory : ICommandEnvelopeFacto
     private static bool IsScopeMetadataKey(string key) =>
         string.Equals(key, "scope_id", StringComparison.Ordinal) ||
         string.Equals(key, WorkflowRunCommandMetadataKeys.ScopeId, StringComparison.Ordinal);
+
+    // Refactor (iter159/cluster-613-first):
+    //   Old pattern: NyxID bearer entered workflow durable + pending approval surface.
+    //   New principle: request bearer scrubbed at envelope/state/continuation; only durable model/route controls remain.
+    private static LLMControlContextPayload ToDurableLlmControlPayload(LLMControlContext control) =>
+        new LLMControlContext(
+            NyxIdAccessToken: null,
+            NyxIdOrgToken: null,
+            SenderNyxIdAccessToken: null,
+            ModelOverride: control.ModelOverride,
+            NyxIdRoutePreference: control.NyxIdRoutePreference,
+            MaxToolRoundsOverride: control.MaxToolRoundsOverride,
+            UserMemoryPrompt: control.UserMemoryPrompt).ToPayload();
 }

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunCommittedStateRedactionHook.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunCommittedStateRedactionHook.cs
@@ -3,11 +3,9 @@ using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.Workflow.Core.Execution;
 
-// Refactor (iter115/cluster-3):
-//   Old pattern: raw security/control state could become observable through
-//                committed WorkflowRunState state_root publication.
-//   New principle: actor state remains typed, while the observation envelope
-//                  gets a redacted clone before projection/AGUI fanout.
+// Refactor (iter159/cluster-613-first):
+//   Old pattern: NyxID bearer entered workflow durable + pending approval surface.
+//   New principle: request bearer scrubbed at envelope/state/continuation; only durable model/route controls remain.
 internal sealed class WorkflowRunCommittedStateRedactionHook : ICommittedStatePublicationHook
 {
     public Task BeforePublishAsync(CommittedStatePublicationContext context, CancellationToken ct)

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunExecutionContextStateAccess.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunExecutionContextStateAccess.cs
@@ -2,11 +2,9 @@ using Aevatar.Workflow.Core.Primitives;
 
 namespace Aevatar.Workflow.Core.Execution;
 
-// Refactor (iter115/cluster-3):
-//   Old pattern: request-scoped LLM and connector control facts lived in
-//                WorkflowExecutionRuntimeContext and disappeared on replay.
-//   New principle: durable control/security facts are typed actor state under
-//                  WorkflowRunState.ExecutionContext.
+// Refactor (iter159/cluster-613-first):
+//   Old pattern: NyxID bearer entered workflow durable + pending approval surface.
+//   New principle: request bearer scrubbed at envelope/state/continuation; only durable model/route controls remain.
 internal static class WorkflowRunExecutionContextStateAccess
 {
     public static WorkflowRunExecutionContextState Get(IWorkflowExecutionStateHost stateHost)
@@ -95,13 +93,11 @@ internal static class WorkflowRunExecutionContextStateAccess
 
         var llm = new WorkflowRunLlmExecutionContextDelta
         {
-            NyxidAccessToken = Normalize(toolContext.Credentials.NyxIdAccessToken),
             ModelOverride = Normalize(toolContext.Routing.ModelOverride),
             NyxidRoutePreference = Normalize(toolContext.Routing.NyxIdRoutePreference),
         };
 
-        if (string.IsNullOrWhiteSpace(llm.NyxidAccessToken) &&
-            string.IsNullOrWhiteSpace(llm.ModelOverride) &&
+        if (string.IsNullOrWhiteSpace(llm.ModelOverride) &&
             string.IsNullOrWhiteSpace(llm.NyxidRoutePreference))
         {
             return delta;
@@ -131,8 +127,7 @@ internal static class WorkflowRunExecutionContextStateAccess
         out WorkflowLlmExecutionContextState llm)
     {
         llm = Get(ctx).Llm ?? new WorkflowLlmExecutionContextState();
-        return !string.IsNullOrWhiteSpace(llm.NyxidAccessToken) ||
-               !string.IsNullOrWhiteSpace(llm.ModelOverride) ||
+        return !string.IsNullOrWhiteSpace(llm.ModelOverride) ||
                !string.IsNullOrWhiteSpace(llm.NyxidRoutePreference);
     }
 

--- a/src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs
@@ -333,9 +333,9 @@ public sealed class LLMCallModule : IEventModule<IWorkflowExecutionContext>
         return true;
     }
 
-    // Refactor (iter115/cluster-3):
-    //   Old pattern: LLM control values were recovered from process-local runtime context.
-    //   New principle: LLM control values are typed actor state and survive actor replay.
+    // Refactor (iter159/cluster-613-first):
+    //   Old pattern: NyxID bearer entered workflow durable + pending approval surface.
+    //   New principle: request bearer scrubbed at envelope/state/continuation; only durable model/route controls remain.
     private static void ApplyTypedLlmControl(
         IWorkflowExecutionContext ctx,
         ChatRequestEvent chatRequest)
@@ -344,7 +344,7 @@ public sealed class LLMCallModule : IEventModule<IWorkflowExecutionContext>
             return;
 
         chatRequest.LlmControl = new LLMControlContext(
-            NyxIdAccessToken: Normalize(llm.NyxidAccessToken),
+            NyxIdAccessToken: null,
             NyxIdOrgToken: null,
             SenderNyxIdAccessToken: null,
             ModelOverride: Normalize(llm.ModelOverride),

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
@@ -22,11 +22,9 @@ namespace Aevatar.Workflow.Core;
     "Maintainability",
     "CA1506:Avoid excessive class coupling",
     Justification = "WorkflowRunGAgent is the run-scoped orchestration boundary and intentionally coordinates workflow execution dependencies.")]
-// Refactor (iter115/cluster-3):
-//   Old pattern: WorkflowRunGAgent kept durable control/security facts in
-//                process-local runtime context.
-//   New principle: durable control/security facts live in typed WorkflowRunState;
-//                  runtime context carries only same-turn passthrough metadata.
+// Refactor (iter159/cluster-613-first):
+//   Old pattern: NyxID bearer entered workflow durable + pending approval surface.
+//   New principle: request bearer scrubbed at envelope/state/continuation; only durable model/route controls remain.
 // Refactor (iter149/issue1132): Old pattern: workflow role initialization preferred handled-dispatch when available.  New principle: role initialization uses accepted-only IActorDispatchPort and observes completion through workflow events.
 // Refactor (iter78/cluster-078-workflow-subrun-lifecycle-handoff):
 //   Old pattern: create/link/bind/start child before persisting invocation → orphan on crash

--- a/test/Aevatar.AI.Tests/RoleGAgentStateCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/RoleGAgentStateCoverageTests.cs
@@ -327,6 +327,7 @@ public sealed class RoleGAgentStateCoverageTests
             ArgumentsJson = "{\"value\":1}",
         };
         agent.State.PendingApproval.Metadata["nyxid.access_token"] = "token-1";
+        agent.State.PendingApproval.Metadata["trace-id"] = "trace-1";
 
         await agent.HandleToolApprovalDecision(new ToolApprovalDecisionEvent
         {
@@ -342,7 +343,8 @@ public sealed class RoleGAgentStateCoverageTests
             .Should()
             .ContainSingle(x =>
                 x.ScopeId == "session-a" &&
-                x.Metadata["nyxid.access_token"] == "token-1" &&
+                !x.Metadata.ContainsKey("nyxid.access_token") &&
+                x.Metadata["trace-id"] == "trace-1" &&
                 x.Prompt.Contains("dangerous_tool") &&
                 x.Prompt.Contains("RESULT:{\"value\":1}"));
     }
@@ -469,6 +471,7 @@ public sealed class RoleGAgentStateCoverageTests
             ArgumentsJson = "{}",
         };
         agent.State.PendingApproval.Metadata["nyxid.access_token"] = "token-1";
+        agent.State.PendingApproval.Metadata["trace-id"] = "trace-1";
 
         await agent.HandleToolApprovalTimeout(new ToolApprovalTimeoutFiredEvent
         {
@@ -482,7 +485,8 @@ public sealed class RoleGAgentStateCoverageTests
         agent.State.PendingApproval.RemoteApprovalExpiresAtUnixMs.Should()
             .Be(DateTimeOffset.FromUnixTimeSeconds(1_800).ToUnixTimeMilliseconds());
         remotePort.Submitted.Should().ContainSingle()
-            .Which.Items[LLMRequestMetadataKeys.NyxIdAccessToken].Should().Be("token-1");
+            .Which.Items.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
+        remotePort.Submitted.Single().Items["trace-id"].Should().Be("trace-1");
         remotePort.StatusQueries.Should().BeEmpty();
         ((RecordingRuntimeCallbackScheduler)provider.GetRequiredService<IActorRuntimeCallbackScheduler>())
             .TimeoutRequests.Should().ContainSingle(x =>
@@ -879,6 +883,11 @@ public sealed class RoleGAgentStateCoverageTests
             SessionId = "session-a",
         };
         request.Metadata["trace-id"] = "trace-1";
+        request.Metadata[LLMRequestMetadataKeys.NyxIdAccessToken] = "token-1";
+        request.Metadata[LLMRequestMetadataKeys.NyxIdOrgToken] = "org-1";
+        request.Metadata[LLMRequestMetadataKeys.SenderNyxIdAccessToken] = "sender-token-1";
+        request.Metadata[LLMRequestMetadataKeys.ModelOverride] = "model-a";
+        request.Metadata[LLMRequestMetadataKeys.NyxIdRoutePreference] = "route-a";
 
         var pending = InvokePrivateInstance<PendingToolApprovalState?>(
             DetectPendingApprovalFromHistoryMethod,
@@ -893,6 +902,11 @@ public sealed class RoleGAgentStateCoverageTests
         pending.ArgumentsJson.Should().Be("{\"x\":1}");
         pending.IsDestructive.Should().BeTrue();
         pending.Metadata["trace-id"].Should().Be("trace-1");
+        pending.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
+        pending.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdOrgToken);
+        pending.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.SenderNyxIdAccessToken);
+        pending.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.ModelOverride);
+        pending.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdRoutePreference);
     }
 
     [Fact]

--- a/test/Aevatar.AI.Tests/RoleGAgentStateCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/RoleGAgentStateCoverageTests.cs
@@ -640,6 +640,63 @@ public sealed class RoleGAgentStateCoverageTests
     }
 
     [Fact]
+    public async Task HandleRemoteApprovalStatusCheck_ShouldScrubOwnedKeysAndPreserveTraceMetadata()
+    {
+        using var provider = BuildServiceProvider();
+        var remotePort = new StubRemoteApprovalPort(
+            submit: _ => throw new InvalidOperationException("submit should not be called"),
+            status: _ => Task.FromResult(new RemoteToolApprovalStatusSnapshot(
+                RemoteToolApprovalStatus.Unknown,
+                "still pending")));
+        var agent = CreateRoleAgent(provider, "role-status-scrub-metadata", remotePort);
+        await agent.ActivateAsync();
+        agent.State.PendingApproval = new PendingToolApprovalState
+        {
+            RequestId = "req-1",
+            SessionId = "session-a",
+            ToolName = "dangerous_tool",
+            ToolCallId = "call-1",
+            ArgumentsJson = "{}",
+            RemoteApprovalId = "remote-1",
+            RemoteStatusCheckAttempt = 1,
+            RemoteApprovalExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeMilliseconds(),
+        };
+        var ownedKeys = new[]
+        {
+            LLMRequestMetadataKeys.RequestId,
+            LLMRequestMetadataKeys.CallId,
+            LLMRequestMetadataKeys.ScopeId,
+            LLMRequestMetadataKeys.OwnerSubject,
+            LLMRequestMetadataKeys.ResponseId,
+            LLMRequestMetadataKeys.NyxIdAccessToken,
+            LLMRequestMetadataKeys.NyxIdOrgToken,
+            LLMRequestMetadataKeys.SenderNyxIdAccessToken,
+            LLMRequestMetadataKeys.SenderBindingId,
+            LLMRequestMetadataKeys.NyxIdRoutePreference,
+            LLMRequestMetadataKeys.ModelOverride,
+            LLMRequestMetadataKeys.MaxToolRoundsOverride,
+            LLMRequestMetadataKeys.UserMemoryPrompt,
+            LLMRequestMetadataKeys.ConnectedServicesContext,
+        };
+
+        foreach (var key in ownedKeys)
+            agent.State.PendingApproval.Metadata[key] = $"owned-{key}";
+        agent.State.PendingApproval.Metadata["trace-id"] = "trace-1";
+
+        await agent.HandleRemoteApprovalStatusCheck(new ToolApprovalRemoteStatusCheckFiredEvent
+        {
+            RequestId = "req-1",
+            SessionId = "session-a",
+            RemoteApprovalId = "remote-1",
+            Attempt = 1,
+        });
+
+        var items = remotePort.StatusQueries.Should().ContainSingle().Which.Items;
+        items.Should().NotContainKeys(ownedKeys);
+        items.Should().ContainKey("trace-id").WhoseValue.Should().Be("trace-1");
+    }
+
+    [Fact]
     public async Task HandleRemoteApprovalStatusCheck_WhenUnknownReachesMaxAttempts_ShouldPersistTerminalFailure()
     {
         using var provider = BuildServiceProvider();

--- a/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
@@ -2031,7 +2031,7 @@ public sealed class WorkflowAdditionalModulesCoverageTests
             CancellationToken.None);
 
         var chatRequest = ctx.Published.Select(x => x.evt).OfType<ChatRequestEvent>().Single();
-        chatRequest.LlmControl.NyxIdAccessToken.Should().Be("token-123");
+        chatRequest.LlmControl.NyxIdAccessToken.Should().BeEmpty();
         chatRequest.LlmControl.ModelOverride.Should().Be("model-main");
         chatRequest.LlmControl.NyxIdRoutePreference.Should().Be("route-fast");
         chatRequest.Metadata["trace-id"].Should().Be("trace-abc");

--- a/test/Aevatar.Integration.Tests/WorkflowGAgentCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowGAgentCoverageTests.cs
@@ -485,7 +485,9 @@ public class WorkflowGAgentCoverageTests
         });
 
         agent1.State.ExecutionContext.Connector!.HttpAuthorization.Should().Be("Bearer secret");
-        agent1.State.ExecutionContext.Llm!.NyxidAccessToken.Should().Be("token-123");
+        agent1.State.ExecutionContext.Llm!.NyxidAccessToken.Should().BeEmpty();
+        agent1.State.ExecutionContext.Llm.ModelOverride.Should().Be("model-main");
+        agent1.State.ExecutionContext.Llm.NyxidRoutePreference.Should().Be("route-fast");
         await agent1.DeactivateAsync();
 
         var persisted = await eventStore.GetEventsAsync(agent1.Id);
@@ -496,7 +498,7 @@ public class WorkflowGAgentCoverageTests
         await agent2.ActivateAsync();
 
         agent2.State.ExecutionContext.Connector!.HttpAuthorization.Should().Be("Bearer secret");
-        agent2.State.ExecutionContext.Llm!.NyxidAccessToken.Should().Be("token-123");
+        agent2.State.ExecutionContext.Llm!.NyxidAccessToken.Should().BeEmpty();
         agent2.State.ExecutionContext.Llm.ModelOverride.Should().Be("model-main");
         agent2.State.ExecutionContext.Llm.NyxidRoutePreference.Should().Be("route-fast");
     }
@@ -552,7 +554,9 @@ public class WorkflowGAgentCoverageTests
                 },
             }));
 
-        agent.State.ExecutionContext.Llm!.NyxidAccessToken.Should().Be("token");
+        agent.State.ExecutionContext.Llm!.NyxidAccessToken.Should().BeEmpty();
+        agent.State.ExecutionContext.Llm.ModelOverride.Should().Be("model");
+        agent.State.ExecutionContext.Llm.NyxidRoutePreference.Should().Be("route");
         agent.State.ExecutionContext.Connector!.HttpAuthorization.Should().Be("Bearer secret");
         agent.State.ExecutionStates[SecureInputStateAccess.ModuleStateKey]
             .Unpack<SecureInputModuleState>()

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationRegistrationAndExecutionTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationRegistrationAndExecutionTests.cs
@@ -1,4 +1,5 @@
 using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
@@ -306,6 +307,41 @@ public sealed class WorkflowApplicationRegistrationAndExecutionTests
         request.Metadata[WorkflowRunCommandMetadataKeys.ChannelId].Should().Be("slack#request");
         request.Headers.Should().NotContainKey(WorkflowRunCommandMetadataKeys.ScopeId);
         request.Headers.Should().NotContainKey("scope_id");
+    }
+
+    [Fact]
+    public void EnvelopeFactory_ShouldScrubBearerFromDurableLlmControl_AndKeepRouting()
+    {
+        var services = new ServiceCollection();
+        services.AddWorkflowApplication();
+        using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<ICommandEnvelopeFactory<WorkflowChatRunRequest>>();
+        var command = new WorkflowChatRunRequest(
+            "hello",
+            WorkflowChatSource.DefinitionActor("actor-1", "direct"),
+            LlmControl: new LLMControlContext(
+                NyxIdAccessToken: " access-token ",
+                NyxIdOrgToken: " org-token ",
+                SenderNyxIdAccessToken: " sender-token ",
+                ModelOverride: " model-a ",
+                NyxIdRoutePreference: " route-a ",
+                MaxToolRoundsOverride: 3,
+                UserMemoryPrompt: " memory "));
+
+        var envelope = factory.CreateEnvelope(command, new CommandContext(
+            "actor-1",
+            "cmd-1",
+            "corr-1",
+            new Dictionary<string, string>()));
+        var request = envelope.Payload.Unpack<ChatRequestEvent>();
+
+        request.LlmControl.NyxIdAccessToken.Should().BeEmpty();
+        request.LlmControl.NyxIdOrgToken.Should().BeEmpty();
+        request.LlmControl.SenderNyxIdAccessToken.Should().BeEmpty();
+        request.LlmControl.ModelOverride.Should().Be(" model-a ");
+        request.LlmControl.NyxIdRoutePreference.Should().Be(" route-a ");
+        request.LlmControl.MaxToolRoundsOverride.Should().Be(3);
+        request.LlmControl.UserMemoryPrompt.Should().Be(" memory ");
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
@@ -45,7 +45,7 @@ public sealed class WorkflowExecutionRuntimeContextTests
     }
 
     [Fact]
-    public async Task SetToolContext_ShouldPromoteLlmValuesToTypedState()
+    public async Task SetToolContext_ShouldPromoteOnlyDurableLlmValuesToTypedState()
     {
         var host = new RecordingStateHost();
 
@@ -64,7 +64,7 @@ public sealed class WorkflowExecutionRuntimeContextTests
                 },
             });
 
-        host.ExecutionContextState.Llm!.NyxidAccessToken.Should().Be("token");
+        host.ExecutionContextState.Llm!.NyxidAccessToken.Should().BeEmpty();
         host.ExecutionContextState.Llm.ModelOverride.Should().Be("model");
         host.ExecutionContextState.Llm.NyxidRoutePreference.Should().Be("route");
     }
@@ -113,6 +113,7 @@ public sealed class WorkflowExecutionRuntimeContextTests
             AgentToolExecutionContext.Empty with
             {
                 Credentials = AgentToolCredentials.Empty with { NyxIdAccessToken = "token" },
+                Routing = LLMRequestRoutingContext.Empty with { ModelOverride = "model" },
             });
 
         await WorkflowRequestMetadataRuntimeContextAccess.RemoveRequestMetadataAsync(host);


### PR DESCRIPTION
## 摘要

iter159 cluster-613-first:strip NyxID bearer from workflow durable + pending approval boundaries。

closes #1178

## 改动范围

| 文件 | 改动 |
|---|---|
| `src/Aevatar.AI.Core/RoleGAgent.cs` | pending approval metadata 用 owned-control-key 剥离 bearer |
| `src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs` | sanitize ChatRequestEvent.LlmControl,只保留 durable model/route |
| `src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunExecutionContextStateAccess.cs` | BuildToolContextDelta / TryGetLlm 不再持久化 bearer/org/sender token |
| `src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunCommittedStateRedactionHook.cs` | committed state redaction 配合 |
| `src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs` | 重建时只从 execution context 恢复 durable model/route |
| `src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs` | 调用入口配合 |
| `test/Aevatar.AI.Tests/` | RoleGAgent pending approval credential scrub tests |
| `test/Aevatar.Workflow.Core.Tests/` | WorkflowRun + LLMCallModule + envelope factory tests |
| `test/Aevatar.Integration.Tests/` | 配套集成测试 |
| `test/Aevatar.Workflow.Application.Tests/` | application 层 token-not-persisted 断言 |

## 验证

- `dotnet build aevatar.slnx --nologo` ✓
- `dotnet test aevatar.slnx --nologo --no-build` ✓(SKILL hard rule 10:full slnx test pass)
- `bash tools/ci/test_stability_guards.sh` ✓
- `bash tools/ci/architecture_guards.sh` ✓

## 共识与来源

- 父 issue #613 → Phase 9 r1 meta-judge: **split**(3/3 propose)
- First-slice 共识工件:`.refactor-loop/artifacts/meta-judge-issue613-r1.md`
- Later-slice 设计 issue:#1179

⟦AI:AUTO-LOOP⟧
