### PR TITLE
iter159 #1176: Studio binding-run readmodel freshness (StateVersion + UI marker)

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -13,7 +13,7 @@ import {
   cleanupTestQueryClients,
   renderWithQueryClient,
 } from "../../../tests/reactQueryTestUtils";
-import StudioPage from "./index";
+import StudioPage, { buildStudioMemberBindingPendingNotice } from "./index";
 
 jest.mock("antd", () => {
   const actual = jest.requireActual("antd");
@@ -5277,6 +5277,7 @@ describe("StudioPage", () => {
       scopeId: "scope-1",
       memberId: "workspace-demo",
       status: "platform_binding_pending",
+      stateVersion: 11,
       failure: null,
       updatedAt: "2026-04-27T08:15:01Z",
     });
@@ -5308,6 +5309,24 @@ describe("StudioPage", () => {
 
     const searchParams = new URLSearchParams(window.location.search);
     expect(searchParams.get("member")).toBe("member:workspace-demo");
+  });
+
+  it("includes readmodel freshness in pending member binding notices", () => {
+    expect(
+      buildStudioMemberBindingPendingNotice("workspace-demo", {
+        bindingRunId: "bind-member-workflow-1",
+        scopeId: "scope-1",
+        memberId: "workspace-demo",
+        status: "platform_binding_pending",
+        stateVersion: 11,
+        failure: null,
+        updatedAt: "2026-04-27T08:15:01Z",
+      }).message,
+    ).toContain("Read model observed v11.");
+
+    expect(
+      buildStudioMemberBindingPendingNotice("workspace-demo", null).message,
+    ).toContain("Read model has not materialized this run yet.");
   });
 
   it("normalizes legacy workflow:default links and keeps the bound member contract when switching away and back", async () => {

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -268,13 +268,17 @@ function resolveStudioMemberBindingRunOutcome(
   return { kind: 'pending', run };
 }
 
-function buildStudioMemberBindingPendingNotice(
+export function buildStudioMemberBindingPendingNotice(
   displayName: string,
   run: StudioMemberBindingRunStatusResponse | null,
 ): StudioNotice {
   const status = run?.status ? ` Current status: ${run.status}.` : '';
+  const freshness =
+    typeof run?.stateVersion === 'number'
+      ? ` Read model observed v${run.stateVersion}.`
+      : ' Read model has not materialized this run yet.';
   return {
-    message: `${displayName} binding request was accepted and is still running.${status} Studio will keep refreshing the status before treating it as bound.`,
+    message: `${displayName} binding request was accepted and is still running.${status}${freshness} Studio will keep refreshing the status before treating it as bound.`,
     type: 'info',
   };
 }

--- a/apps/aevatar-console-web/src/shared/studio/api.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.test.ts
@@ -1067,6 +1067,7 @@ describe('studioApi host-session requests', () => {
           status: 'platform_binding_pending',
           scopeId: 'scope-1',
           memberId: 'joker',
+          stateVersion: 7,
           updatedAt: '2026-03-26T08:01:00Z',
         },
       }),
@@ -1082,12 +1083,58 @@ describe('studioApi host-session requests', () => {
         currentBindingRun: expect.objectContaining({
           bindingRunId: 'bind-1',
           status: 'platform_binding_pending',
+          stateVersion: 7,
         }),
       }),
     );
 
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/scopes/scope-1/members/joker/binding',
+      expect.objectContaining({
+        credentials: 'same-origin',
+      }),
+    );
+  });
+
+  it('loads member binding run status with readmodel state version freshness', async () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: 'access-token',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        expiresAt: Date.now() + 3_600_000,
+      },
+      user: {
+        sub: 'user-1',
+      },
+    });
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        BindingRunId: 'bind-1',
+        Status: 'platform_binding_pending',
+        ScopeId: 'scope-1',
+        MemberId: 'joker',
+        StateVersion: 9,
+        UpdatedAt: '2026-03-26T08:01:00Z',
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(
+      studioApi.getMemberBindingRun('scope-1', 'joker', 'bind-1'),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        bindingRunId: 'bind-1',
+        status: 'platform_binding_pending',
+        stateVersion: 9,
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/scopes/scope-1/members/joker/binding-runs/bind-1',
       expect.objectContaining({
         credentials: 'same-origin',
       }),

--- a/apps/aevatar-console-web/src/shared/studio/api.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.ts
@@ -1368,6 +1368,8 @@ function decodeStudioMemberBindingRunStatusResponse(
       ["memberId", "MemberId"],
       "StudioMemberBindingRunStatusResponse.memberId"
     ),
+    stateVersion:
+      readOptionalNumber(record.stateVersion ?? record.StateVersion) ?? null,
     platformBindingCommandId:
       readNullableString(
         record,

--- a/apps/aevatar-console-web/src/shared/studio/models.ts
+++ b/apps/aevatar-console-web/src/shared/studio/models.ts
@@ -503,6 +503,7 @@ export interface StudioMemberBindingRunStatusResponse {
   readonly bindingRunId: string;
   readonly scopeId: string;
   readonly memberId: string;
+  readonly stateVersion?: number | null;
   readonly platformBindingCommandId?: string | null;
   readonly failure?: StudioMemberBindingFailure | null;
   readonly updatedAt?: string | null;

--- a/src/Aevatar.Studio.Application/Studio/Contracts/MemberContracts.cs
+++ b/src/Aevatar.Studio.Application/Studio/Contracts/MemberContracts.cs
@@ -116,11 +116,15 @@ public sealed record StudioMemberBindingFailureResponse(
     string Message,
     DateTimeOffset FailedAt);
 
+// Refactor (iter159/cluster-594-first):
+//   Old pattern: Studio member binding-run status response 未暴露 StateVersion
+//   New principle: 暴露 readmodel 已有的 StateVersion; 前端用 freshness marker 诚实表达 not-yet-materialized 状态
 public sealed record StudioMemberBindingRunStatusResponse(
     string BindingRunId,
     string ScopeId,
     string MemberId,
     string Status,
+    long StateVersion,
     StudioMemberBindingFailureResponse? Failure = null,
     DateTimeOffset? UpdatedAt = null)
 {

--- a/src/Aevatar.Studio.Projection/QueryPorts/ProjectionStudioMemberBindingRunQueryPort.cs
+++ b/src/Aevatar.Studio.Projection/QueryPorts/ProjectionStudioMemberBindingRunQueryPort.cs
@@ -9,6 +9,9 @@ namespace Aevatar.Studio.Projection.QueryPorts;
 /// <summary>
 /// Reads binding-run status from the run actor's current-state read model.
 /// </summary>
+// Refactor (iter159/cluster-594-first):
+//   Old pattern: Studio member binding-run status response 未暴露 StateVersion
+//   New principle: 暴露 readmodel 已有的 StateVersion; 前端用 freshness marker 诚实表达 not-yet-materialized 状态
 public sealed class ProjectionStudioMemberBindingRunQueryPort : IStudioMemberBindingRunQueryPort
 {
     private readonly IProjectionDocumentReader<StudioMemberBindingRunCurrentStateDocument, string> _documentReader;
@@ -55,6 +58,7 @@ public sealed class ProjectionStudioMemberBindingRunQueryPort : IStudioMemberBin
             ScopeId: document.ScopeId,
             MemberId: document.MemberId,
             Status: NormalizeBindingRunStatusWire(document.Status),
+            StateVersion: document.StateVersion,
             Failure: failure,
             UpdatedAt: document.UpdatedAt?.ToDateTimeOffset())
         {

--- a/src/Aevatar.Studio.Projection/QueryPorts/ProjectionStudioMemberQueryPort.cs
+++ b/src/Aevatar.Studio.Projection/QueryPorts/ProjectionStudioMemberQueryPort.cs
@@ -192,6 +192,9 @@ public sealed class ProjectionStudioMemberQueryPort : IStudioMemberQueryPort
         if (string.IsNullOrEmpty(document.BindingCurrentRunId))
             return null;
 
+        // Refactor (iter159/cluster-594-first):
+        //   Old pattern: Studio member binding-run status response 未暴露 StateVersion
+        //   New principle: 暴露 readmodel 已有的 StateVersion; 前端用 freshness marker 诚实表达 not-yet-materialized 状态
         StudioMemberBindingFailureResponse? failure = null;
         if (!string.IsNullOrEmpty(document.BindingFailureCode))
         {
@@ -206,6 +209,7 @@ public sealed class ProjectionStudioMemberQueryPort : IStudioMemberQueryPort
             ScopeId: document.ScopeId,
             MemberId: document.MemberId,
             Status: NormalizeBindingRunStatusWire(document.BindingCurrentStatus),
+            StateVersion: document.StateVersion,
             Failure: failure,
             UpdatedAt: document.BindingUpdatedAt?.ToDateTimeOffset());
     }

--- a/test/Aevatar.Studio.Tests/StudioMemberBindingHostedConsistencyTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberBindingHostedConsistencyTests.cs
@@ -282,6 +282,7 @@ public sealed class StudioMemberBindingHostedConsistencyTests
                         ScopeId: scopeId,
                         MemberId: memberId,
                         Status: StudioMemberBindingRunStatusNames.Accepted,
+                        StateVersion: 1,
                         UpdatedAt: now.AddMinutes(-1)),
             };
         }
@@ -323,6 +324,7 @@ public sealed class StudioMemberBindingHostedConsistencyTests
                 ScopeId: scopeId,
                 MemberId: memberId,
                 Status: status,
+                StateVersion: _scenario.Completed ? 2 : 1,
                 UpdatedAt: DateTimeOffset.Parse("2026-05-21T00:00:00Z"))
             {
                 PlatformBindingCommandId = "platform-bind-1",

--- a/test/Aevatar.Studio.Tests/StudioMemberBindingRunQueryPortTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberBindingRunQueryPortTests.cs
@@ -23,6 +23,7 @@ public sealed class StudioMemberBindingRunQueryPortTests
                 ScopeId = "scope-1",
                 MemberId = "m-1",
                 Status = StudioMemberBindingRunStatusNames.PlatformBindingPending,
+                StateVersion = 7,
                 PlatformBindingCommandId = "platform-bind-1",
                 UpdatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-04-30T08:00:00Z")),
             },
@@ -36,6 +37,7 @@ public sealed class StudioMemberBindingRunQueryPortTests
         run.ScopeId.Should().Be("scope-1");
         run.MemberId.Should().Be("m-1");
         run.Status.Should().Be(StudioMemberBindingRunStatusNames.PlatformBindingPending);
+        run.StateVersion.Should().Be(7);
         run.PlatformBindingCommandId.Should().Be("platform-bind-1");
         run.UpdatedAt.Should().Be(DateTimeOffset.Parse("2026-04-30T08:00:00Z"));
     }

--- a/test/Aevatar.Studio.Tests/StudioMemberEndpointsTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberEndpointsTests.cs
@@ -260,6 +260,7 @@ public sealed class StudioMemberEndpointsTests
             ScopeId: ScopeId,
             MemberId: "member-1",
             Status: StudioMemberBindingRunStatusNames.PlatformBindingPending,
+            StateVersion: 7,
             UpdatedAt: DateTimeOffset.UtcNow);
         var service = new RecordingMemberService
         {

--- a/test/Aevatar.Studio.Tests/StudioMemberQueryPortTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberQueryPortTests.cs
@@ -36,6 +36,7 @@ public sealed class ProjectionStudioMemberQueryPortTests
             includeImplementationRef: true,
             includeLastBinding: true,
             includeBindingStatus: true);
+        document.StateVersion = 7;
 
         var reader = new StubDocumentReader([document]);
         var port = new ProjectionStudioMemberQueryPort(reader);
@@ -55,6 +56,7 @@ public sealed class ProjectionStudioMemberQueryPortTests
         detail.CurrentBindingRun.Should().NotBeNull();
         detail.CurrentBindingRun!.BindingRunId.Should().Be("bind-1");
         detail.CurrentBindingRun.Status.Should().Be(StudioMemberBindingRunStatusNames.PlatformBindingPending);
+        detail.CurrentBindingRun.StateVersion.Should().Be(7);
     }
 
     [Fact]

--- a/test/Aevatar.Studio.Tests/StudioMemberServiceBindingTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberServiceBindingTests.cs
@@ -170,6 +170,7 @@ public sealed class StudioMemberServiceBindingTests
                 ScopeId: ScopeId,
                 MemberId: MemberId,
                 Status: StudioMemberBindingRunStatusNames.PlatformBindingPending,
+                StateVersion: 1,
                 UpdatedAt: DateTimeOffset.UtcNow.AddMinutes(-1)),
         };
         var runQuery = new InMemoryBindingRunQueryPort(new StudioMemberBindingRunStatusResponse(
@@ -177,6 +178,7 @@ public sealed class StudioMemberServiceBindingTests
             ScopeId: ScopeId,
             MemberId: MemberId,
             Status: StudioMemberBindingRunStatusNames.PlatformBindingPending,
+            StateVersion: 2,
             UpdatedAt: DateTimeOffset.UtcNow)
         {
             PlatformBindingCommandId = "platform-bind-1",
@@ -204,13 +206,15 @@ public sealed class StudioMemberServiceBindingTests
                 BindingRunId: "bind-1",
                 ScopeId: ScopeId,
                 MemberId: MemberId,
-                Status: StudioMemberBindingRunStatusNames.PlatformBindingPending),
+                Status: StudioMemberBindingRunStatusNames.PlatformBindingPending,
+                StateVersion: 1),
         };
         var runQuery = new InMemoryBindingRunQueryPort(new StudioMemberBindingRunStatusResponse(
             BindingRunId: "bind-1",
             ScopeId: ScopeId,
             MemberId: MemberId,
-            Status: StudioMemberBindingRunStatusNames.PlatformBindingPending)
+            Status: StudioMemberBindingRunStatusNames.PlatformBindingPending,
+            StateVersion: 2)
         {
             PlatformBindingCommandId = "platform-bind-1",
         });
@@ -235,6 +239,7 @@ public sealed class StudioMemberServiceBindingTests
             ScopeId: ScopeId,
             MemberId: MemberId,
             Status: StudioMemberBindingRunStatusNames.PlatformBindingPending,
+            StateVersion: 3,
             UpdatedAt: DateTimeOffset.UtcNow)
         {
             PlatformBindingCommandId = "platform-bind-1",


### PR DESCRIPTION
## 摘要

iter159 cluster-594-first:暴露 Studio binding-run readmodel freshness — StateVersion 字段 + UI freshness marker。

closes #1176

## 改动范围

| 文件 | 改动 |
|---|---|
| `src/Aevatar.Studio.Application/Studio/Contracts/MemberContracts.cs` | StudioMemberBindingRunStatusResponse 增加 StateVersion |
| `src/Aevatar.Studio.Projection/QueryPorts/ProjectionStudioMemberBindingRunQueryPort.cs` | 从 document.StateVersion 映射 |
| `src/Aevatar.Studio.Projection/QueryPorts/ProjectionStudioMemberQueryPort.cs` | 配套调整 |
| `apps/aevatar-console-web/src/shared/studio/api.ts` | client API 支持 stateVersion |
| `apps/aevatar-console-web/src/shared/studio/models.ts` | model 加 StateVersion |
| `apps/aevatar-console-web/src/pages/studio/index.tsx` | UI freshness marker |
| `test/Aevatar.Studio.Tests/StudioMemberBindingRunQueryPortTests.cs` | query port 测试 |
| `test/Aevatar.Studio.Tests/StudioMemberEndpointsTests.cs` | endpoint freshness 断言 |
| `apps/aevatar-console-web/src/.../api.test.ts` + `index.test.tsx` | decoder + UI 测试 |

## 验证

- `dotnet build aevatar.slnx --nologo` ✓
- `dotnet test aevatar.slnx --nologo --no-build` ✓
- `tools/ci/test_stability_guards.sh` ✓
- `tools/ci/architecture_guards.sh` ✓

## 共识来源

- 父 issue #594 → Phase 9 r1 meta-judge: **split**
- Later-slice 设计 issue: #1177

⟦AI:AUTO-LOOP⟧
