### PR TITLE
iter159 #1190: NyxID LLM catalog 有界 SWR adapter

### DIFF
--- a/src/Aevatar.Studio.Hosting/NyxId/CachedNyxIdLlmCatalogPort.cs
+++ b/src/Aevatar.Studio.Hosting/NyxId/CachedNyxIdLlmCatalogPort.cs
@@ -9,7 +9,14 @@ using Microsoft.Extensions.Options;
 
 namespace Aevatar.Studio.Hosting.NyxId;
 
-// Refactor (iter159/cluster-646-first): Old: 每次 fetch  New: bounded SWR decorator caller-keyed
+// Refactor (iter159/cluster-646-first):
+//   Old pattern: Every IUserLlmCatalogPort.GetServicesAsync call fetched NyxID directly during the request path,
+//                amplifying NyxID catalog IO across hot-path Studio requests.
+//   New principle: Host/NyxID adapter owns a bounded stale-while-revalidate snapshot, keyed by NyxID authority +
+//                  caller bearer fingerprint. The snapshot is a non-authoritative performance hint — NOT a readmodel,
+//                  NOT actor state, NOT a query fact source. Authoritative facts remain in NyxID; cache eviction,
+//                  miss, or disabled mode falls back to authoritative fetch. ProvisionAsync invalidates the caller's
+//                  snapshot to keep stale window honest.
 internal sealed class CachedNyxIdLlmCatalogPort : IUserLlmCatalogPort, IDisposable
 {
     private readonly IUserLlmCatalogPort _inner;
@@ -119,6 +126,10 @@ internal sealed class CachedNyxIdLlmCatalogPort : IUserLlmCatalogPort, IDisposab
         {
             _logger.LogWarning(ex, "NyxID LLM catalog SWR refresh failed.");
         }
+        finally
+        {
+            _refreshingKeys.TryRemove(key, out _);
+        }
     }
 
     private void Store(
@@ -135,7 +146,6 @@ internal sealed class CachedNyxIdLlmCatalogPort : IUserLlmCatalogPort, IDisposab
             key,
             entry,
             new MemoryCacheEntryOptions().SetSize(1));
-        _refreshingKeys.TryRemove(key, out _);
     }
 
     private NyxIdLlmCatalogCacheKey BuildKey(string bearerToken)

--- a/src/Aevatar.Studio.Hosting/NyxId/CachedNyxIdLlmCatalogPort.cs
+++ b/src/Aevatar.Studio.Hosting/NyxId/CachedNyxIdLlmCatalogPort.cs
@@ -1,0 +1,179 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Aevatar.Studio.Hosting.NyxId;
+
+// Refactor (iter159/cluster-646-first): Old: 每次 fetch  New: bounded SWR decorator caller-keyed
+internal sealed class CachedNyxIdLlmCatalogPort : IUserLlmCatalogPort, IDisposable
+{
+    private readonly IUserLlmCatalogPort _inner;
+    private readonly IConfiguration _configuration;
+    private readonly IOptionsMonitor<NyxIdLlmCatalogCacheOptions> _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<CachedNyxIdLlmCatalogPort> _logger;
+    private readonly MemoryCache _cache;
+    private readonly ConcurrentDictionary<NyxIdLlmCatalogCacheKey, byte> _refreshingKeys = new();
+
+    public CachedNyxIdLlmCatalogPort(
+        IUserLlmCatalogPort inner,
+        IConfiguration configuration,
+        IOptionsMonitor<NyxIdLlmCatalogCacheOptions> options,
+        TimeProvider timeProvider,
+        ILogger<CachedNyxIdLlmCatalogPort> logger)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        var maxEntries = NormalizeMaxEntries(_options.CurrentValue.MaxEntries);
+        _cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = maxEntries });
+    }
+
+    public async Task<NyxIdLlmServicesResult> GetServicesAsync(string bearerToken, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(bearerToken);
+
+        var options = NormalizeOptions(_options.CurrentValue);
+        if (!options.Enabled)
+            return await _inner.GetServicesAsync(bearerToken, ct).ConfigureAwait(false);
+
+        var key = BuildKey(bearerToken);
+        var now = _timeProvider.GetUtcNow();
+        if (_cache.TryGetValue(key, out NyxIdLlmCatalogSnapshotEntry? entry) && entry is not null)
+        {
+            if (now < entry.FreshUntilUtc)
+                return entry.Result;
+
+            if (now < entry.StaleUntilUtc)
+            {
+                TriggerRefresh(key, bearerToken, options);
+                return entry.Result;
+            }
+        }
+
+        var result = await _inner.GetServicesAsync(bearerToken, ct).ConfigureAwait(false);
+        Store(key, result, options);
+        return result;
+    }
+
+    public async Task<NyxIdLlmService> ProvisionAsync(
+        string bearerToken,
+        string provisionEndpointId,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(bearerToken);
+
+        var service = await _inner.ProvisionAsync(bearerToken, provisionEndpointId, ct)
+            .ConfigureAwait(false);
+
+        if (NormalizeOptions(_options.CurrentValue).Enabled)
+        {
+            var key = BuildKey(bearerToken);
+            _cache.Remove(key);
+            _refreshingKeys.TryRemove(key, out _);
+        }
+
+        return service;
+    }
+
+    public void Dispose()
+    {
+        _cache.Dispose();
+    }
+
+    private void TriggerRefresh(
+        NyxIdLlmCatalogCacheKey key,
+        string bearerToken,
+        NyxIdLlmCatalogCacheOptions options)
+    {
+        if (!_refreshingKeys.TryAdd(key, 0))
+            return;
+
+        _ = RefreshAndClearAsync(key, bearerToken, options);
+    }
+
+    private async Task RefreshAndClearAsync(
+        NyxIdLlmCatalogCacheKey key,
+        string bearerToken,
+        NyxIdLlmCatalogCacheOptions options)
+    {
+        try
+        {
+            var result = await _inner.GetServicesAsync(bearerToken, CancellationToken.None)
+                .ConfigureAwait(false);
+            Store(key, result, options);
+        }
+        catch (OperationCanceledException ex)
+        {
+            _logger.LogWarning(ex, "NyxID LLM catalog SWR refresh was canceled.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "NyxID LLM catalog SWR refresh failed.");
+        }
+    }
+
+    private void Store(
+        NyxIdLlmCatalogCacheKey key,
+        NyxIdLlmServicesResult result,
+        NyxIdLlmCatalogCacheOptions options)
+    {
+        var now = _timeProvider.GetUtcNow();
+        var freshUntil = now + options.FreshTtl;
+        var staleUntil = freshUntil + options.StaleTtl;
+        var entry = new NyxIdLlmCatalogSnapshotEntry(result, freshUntil, staleUntil);
+
+        _cache.Set(
+            key,
+            entry,
+            new MemoryCacheEntryOptions().SetSize(1));
+        _refreshingKeys.TryRemove(key, out _);
+    }
+
+    private NyxIdLlmCatalogCacheKey BuildKey(string bearerToken)
+    {
+        var authority = NyxIdAuthorityResolver.ResolveNyxIdAuthorityBase(_configuration);
+        if (string.IsNullOrWhiteSpace(authority))
+            throw new InvalidOperationException("NyxID authority is not configured.");
+
+        return new NyxIdLlmCatalogCacheKey(
+            authority,
+            ComputeSha256Hex(bearerToken));
+    }
+
+    private static string ComputeSha256Hex(string value)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexString(bytes);
+    }
+
+    private static NyxIdLlmCatalogCacheOptions NormalizeOptions(NyxIdLlmCatalogCacheOptions options)
+    {
+        return new NyxIdLlmCatalogCacheOptions
+        {
+            Enabled = options.Enabled,
+            FreshTtl = options.FreshTtl > TimeSpan.Zero ? options.FreshTtl : TimeSpan.FromSeconds(60),
+            StaleTtl = options.StaleTtl >= TimeSpan.Zero ? options.StaleTtl : TimeSpan.Zero,
+            MaxEntries = NormalizeMaxEntries(options.MaxEntries),
+        };
+    }
+
+    private static int NormalizeMaxEntries(int value) => value > 0 ? value : 1024;
+
+    private sealed record NyxIdLlmCatalogSnapshotEntry(
+        NyxIdLlmServicesResult Result,
+        DateTimeOffset FreshUntilUtc,
+        DateTimeOffset StaleUntilUtc);
+
+    private readonly record struct NyxIdLlmCatalogCacheKey(
+        string Authority,
+        string BearerFingerprint);
+}

--- a/src/Aevatar.Studio.Hosting/NyxId/NyxIdAuthorityResolver.cs
+++ b/src/Aevatar.Studio.Hosting/NyxId/NyxIdAuthorityResolver.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Aevatar.Studio.Hosting.NyxId;
+
+internal static class NyxIdAuthorityResolver
+{
+    private const string GatewaySuffix = "/api/v1/llm/gateway/v1";
+
+    internal static string? ResolveNyxIdAuthorityBase(IConfiguration configuration)
+    {
+        var authority = configuration["Cli:App:NyxId:Authority"]
+            ?? configuration["Aevatar:NyxId:Authority"]
+            ?? configuration["Aevatar:Authentication:Authority"];
+
+        if (string.IsNullOrWhiteSpace(authority))
+            return null;
+
+        var trimmed = authority.Trim().TrimEnd('/');
+        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out _))
+            return null;
+
+        return trimmed.EndsWith(GatewaySuffix, StringComparison.OrdinalIgnoreCase)
+            ? trimmed[..^GatewaySuffix.Length]
+            : trimmed;
+    }
+}

--- a/src/Aevatar.Studio.Hosting/NyxId/NyxIdLlmCatalogCacheOptions.cs
+++ b/src/Aevatar.Studio.Hosting/NyxId/NyxIdLlmCatalogCacheOptions.cs
@@ -1,0 +1,14 @@
+namespace Aevatar.Studio.Hosting.NyxId;
+
+internal sealed class NyxIdLlmCatalogCacheOptions
+{
+    public const string SectionName = "Aevatar:Studio:NyxIdLlmCatalogCache";
+
+    public bool Enabled { get; set; } = true;
+
+    public TimeSpan FreshTtl { get; set; } = TimeSpan.FromSeconds(60);
+
+    public TimeSpan StaleTtl { get; set; } = TimeSpan.FromMinutes(5);
+
+    public int MaxEntries { get; set; } = 1024;
+}

--- a/src/Aevatar.Studio.Hosting/NyxId/NyxIdLlmCatalogHttpClient.cs
+++ b/src/Aevatar.Studio.Hosting/NyxId/NyxIdLlmCatalogHttpClient.cs
@@ -150,21 +150,7 @@ public sealed class NyxIdLlmCatalogHttpClient : IUserLlmCatalogPort
 
     private string? ResolveNyxIdAuthorityBase()
     {
-        var authority = _configuration["Cli:App:NyxId:Authority"]
-            ?? _configuration["Aevatar:NyxId:Authority"]
-            ?? _configuration["Aevatar:Authentication:Authority"];
-
-        if (string.IsNullOrWhiteSpace(authority))
-            return null;
-
-        var trimmed = authority.Trim().TrimEnd('/');
-        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out _))
-            return null;
-
-        const string gatewaySuffix = "/api/v1/llm/gateway/v1";
-        return trimmed.EndsWith(gatewaySuffix, StringComparison.OrdinalIgnoreCase)
-            ? trimmed[..^gatewaySuffix.Length]
-            : trimmed;
+        return NyxIdAuthorityResolver.ResolveNyxIdAuthorityBase(_configuration);
     }
 
     private readonly record struct NyxIdHttpResult(HttpStatusCode StatusCode, string Body);

--- a/src/Aevatar.Studio.Hosting/StudioHostingServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Hosting/StudioHostingServiceCollectionExtensions.cs
@@ -33,7 +33,15 @@ internal static class StudioHostingServiceCollectionExtensions
         services.AddHttpContextAccessor();
         services.AddSingleton<IAppScopeResolver, DefaultAppScopeResolver>();
         services.AddStudioApplication();
-        services.TryAddSingleton<IUserLlmCatalogPort, NyxIdLlmCatalogHttpClient>();
+        services.Configure<NyxIdLlmCatalogCacheOptions>(
+            configuration.GetSection(NyxIdLlmCatalogCacheOptions.SectionName));
+        services.TryAddSingleton<NyxIdLlmCatalogHttpClient>();
+        services.TryAddSingleton<IUserLlmCatalogPort>(sp => new CachedNyxIdLlmCatalogPort(
+            sp.GetRequiredService<NyxIdLlmCatalogHttpClient>(),
+            configuration,
+            sp.GetRequiredService<Microsoft.Extensions.Options.IOptionsMonitor<NyxIdLlmCatalogCacheOptions>>(),
+            sp.GetService<TimeProvider>() ?? TimeProvider.System,
+            sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<CachedNyxIdLlmCatalogPort>>()));
         services.AddStudioInfrastructure(configuration);
         services.AddStudioProjectionComponents(configuration);
         services.AddStudioProjectionReadModelProviders(configuration);

--- a/test/Aevatar.Hosting.Tests/CachingResponsesRouteResolverTests.cs
+++ b/test/Aevatar.Hosting.Tests/CachingResponsesRouteResolverTests.cs
@@ -56,11 +56,8 @@ public sealed class ResponsesRouteResolverTests
     }
 
     [Fact]
-    public async Task ResolveRouteValueAsync_ShouldReadCurrentCatalogOnEachCall()
+    public async Task ResolveRouteValueAsync_ShouldUseCatalogPortResultWithoutOwningCache()
     {
-        // Refactor (iter26/cluster-026-responses-route-user-catalog-cache):
-        //   Old pattern: Responses/Messages routes resolve `vendor/model` by reading a singleton per-bearer in-process cache of NyxID user LLM service catalog facts.
-        //   New principle: Resolve model route from the current catalog read in the request flow; do not store user route facts in singleton process memory.
         var catalog = new MutableCatalogPort(new NyxIdLlmServicesResult(
         [
             MakeService("anthropic", "/api/v1/llm/anthropic/v1", allowed: true),
@@ -77,7 +74,7 @@ public sealed class ResponsesRouteResolverTests
 
         (await resolver.ResolveRouteValueAsync("anthropic", "bearer-1", CancellationToken.None))
             .Should().Be("/api/v1/llm/anthropic/v2");
-        catalog.FetchCount.Should().Be(2, "route facts are read from the current request catalog, not singleton memory");
+        catalog.FetchCount.Should().Be(2, "the resolver delegates catalog freshness to IUserLlmCatalogPort");
     }
 
     [Fact]
@@ -92,7 +89,7 @@ public sealed class ResponsesRouteResolverTests
         await resolver.ResolveRouteValueAsync("anthropic", "bearer-A", CancellationToken.None);
         await resolver.ResolveRouteValueAsync("anthropic", "bearer-B", CancellationToken.None);
 
-        catalog.FetchCount.Should().Be(2, "each request bearer is resolved against its current catalog");
+        catalog.FetchCount.Should().Be(2, "caller/authority cache boundaries are owned by IUserLlmCatalogPort");
     }
 
     private static NyxIdLlmService MakeService(string slug, string routeValue, bool allowed) =>

--- a/test/Aevatar.Studio.Tests/CachedNyxIdLlmCatalogPortTests.cs
+++ b/test/Aevatar.Studio.Tests/CachedNyxIdLlmCatalogPortTests.cs
@@ -66,6 +66,44 @@ public sealed class CachedNyxIdLlmCatalogPortTests
     }
 
     [Fact]
+    public async Task GetServicesAsync_WhenCacheDisabled_ShouldCallInnerForRepeatedSameBearer()
+    {
+        var inner = new RecordingCatalogPort();
+        inner.Enqueue(MakeResult("anthropic", "/first"));
+        inner.Enqueue(MakeResult("anthropic", "/second"));
+        inner.Enqueue(MakeResult("anthropic", "/third"));
+        var port = CreatePort(inner, cacheEnabled: false);
+
+        var first = await port.GetServicesAsync("bearer-1", CancellationToken.None);
+        var second = await port.GetServicesAsync("bearer-1", CancellationToken.None);
+        var third = await port.GetServicesAsync("bearer-1", CancellationToken.None);
+
+        first.Services.Single().RouteValue.Should().Be("/first");
+        second.Services.Single().RouteValue.Should().Be("/second");
+        third.Services.Single().RouteValue.Should().Be("/third");
+        inner.GetCalls.Should().Be(3);
+        inner.CapturedBearers.Should().Equal("bearer-1", "bearer-1", "bearer-1");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("not-a-uri")]
+    public async Task GetServicesAsync_WhenCacheDisabled_ShouldNotConsultAuthority(string? authority)
+    {
+        var inner = new RecordingCatalogPort();
+        inner.Enqueue(MakeResult("anthropic", "/inner"));
+        var port = CreatePort(
+            inner,
+            configuration: CreateConfiguration(authority),
+            cacheEnabled: false);
+
+        var result = await port.GetServicesAsync("bearer-1", CancellationToken.None);
+
+        result.Services.Single().RouteValue.Should().Be("/inner");
+        inner.GetCalls.Should().Be(1);
+    }
+
+    [Fact]
     public async Task GetServicesAsync_ShouldReturnStaleSnapshot_AndRefreshOnce()
     {
         var clock = new ManualTimeProvider(DateTimeOffset.Parse("2026-05-29T10:00:00Z"));
@@ -114,10 +152,6 @@ public sealed class CachedNyxIdLlmCatalogPortTests
 
         releaseRefresh.SetResult();
         await refreshCompleted.Task;
-        await Task.Yield();
-        var refreshed = await port.GetServicesAsync("bearer-1", CancellationToken.None);
-
-        refreshed.Services.Single().RouteValue.Should().Be("/new");
         inner.GetCalls.Should().Be(2);
     }
 
@@ -186,16 +220,56 @@ public sealed class CachedNyxIdLlmCatalogPortTests
         inner.ProvisionBearers.Should().Equal("bearer-A");
     }
 
+    [Fact]
+    public async Task ProvisionAsync_WhenCacheDisabled_ShouldCallInnerForRepeatedSameBearer()
+    {
+        var inner = new RecordingCatalogPort();
+        inner.ProvisionResults.Enqueue(MakeService("anthropic", "/first"));
+        inner.ProvisionResults.Enqueue(MakeService("anthropic", "/second"));
+        inner.ProvisionResults.Enqueue(MakeService("anthropic", "/third"));
+        var port = CreatePort(inner, cacheEnabled: false);
+
+        var first = await port.ProvisionAsync("bearer-1", "anthropic", CancellationToken.None);
+        var second = await port.ProvisionAsync("bearer-1", "anthropic", CancellationToken.None);
+        var third = await port.ProvisionAsync("bearer-1", "anthropic", CancellationToken.None);
+
+        first.RouteValue.Should().Be("/first");
+        second.RouteValue.Should().Be("/second");
+        third.RouteValue.Should().Be("/third");
+        inner.ProvisionCalls.Should().Be(3);
+        inner.ProvisionBearers.Should().Equal("bearer-1", "bearer-1", "bearer-1");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("not-a-uri")]
+    public async Task ProvisionAsync_WhenCacheDisabled_ShouldNotConsultAuthority(string? authority)
+    {
+        var inner = new RecordingCatalogPort();
+        inner.ProvisionResult = MakeService("anthropic", "/provisioned");
+        var port = CreatePort(
+            inner,
+            configuration: CreateConfiguration(authority),
+            cacheEnabled: false);
+
+        var result = await port.ProvisionAsync("bearer-1", "anthropic", CancellationToken.None);
+
+        result.RouteValue.Should().Be("/provisioned");
+        inner.ProvisionCalls.Should().Be(1);
+    }
+
     private static CachedNyxIdLlmCatalogPort CreatePort(
         RecordingCatalogPort inner,
         IConfiguration? configuration = null,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        bool cacheEnabled = true)
     {
         return new CachedNyxIdLlmCatalogPort(
             inner,
             configuration ?? CreateConfiguration("https://nyx.test/api/v1/llm/gateway/v1"),
             new FixedOptionsMonitor<NyxIdLlmCatalogCacheOptions>(new NyxIdLlmCatalogCacheOptions
             {
+                Enabled = cacheEnabled,
                 FreshTtl = TimeSpan.FromSeconds(60),
                 StaleTtl = TimeSpan.FromMinutes(5),
                 MaxEntries = 16,
@@ -204,7 +278,7 @@ public sealed class CachedNyxIdLlmCatalogPortTests
             NullLogger<CachedNyxIdLlmCatalogPort>.Instance);
     }
 
-    private static IConfiguration CreateConfiguration(string authority)
+    private static IConfiguration CreateConfiguration(string? authority)
     {
         return new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
@@ -241,6 +315,10 @@ public sealed class CachedNyxIdLlmCatalogPortTests
         public List<string> CapturedBearers { get; } = [];
 
         public List<string> ProvisionBearers { get; } = [];
+
+        public int ProvisionCalls { get; private set; }
+
+        public Queue<NyxIdLlmService> ProvisionResults { get; } = new();
 
         public NyxIdLlmService ProvisionResult { get; set; } = MakeService("provisioned", "/provisioned");
 
@@ -298,8 +376,12 @@ public sealed class CachedNyxIdLlmCatalogPortTests
             string provisionEndpointId,
             CancellationToken ct)
         {
+            ProvisionCalls++;
             ProvisionBearers.Add(bearerToken);
-            return Task.FromResult(ProvisionResult);
+            var service = ProvisionResults.Count > 0
+                ? ProvisionResults.Dequeue()
+                : ProvisionResult;
+            return Task.FromResult(service);
         }
     }
 

--- a/test/Aevatar.Studio.Tests/CachedNyxIdLlmCatalogPortTests.cs
+++ b/test/Aevatar.Studio.Tests/CachedNyxIdLlmCatalogPortTests.cs
@@ -162,7 +162,9 @@ public sealed class CachedNyxIdLlmCatalogPortTests
         var inner = new RecordingCatalogPort();
         inner.Enqueue(MakeResult("anthropic", "/old"));
         inner.EnqueueFailure(new InvalidOperationException("NyxID unavailable"));
+        inner.Enqueue(MakeResult("anthropic", "/new"));
         var refreshCompleted = inner.SignalOnCallCompletion(callNumber: 2);
+        var retryRefreshCompleted = inner.SignalOnCallCompletion(callNumber: 3);
         var port = CreatePort(inner, timeProvider: clock);
 
         await port.GetServicesAsync("bearer-1", CancellationToken.None);
@@ -171,10 +173,13 @@ public sealed class CachedNyxIdLlmCatalogPortTests
         var stale = await port.GetServicesAsync("bearer-1", CancellationToken.None);
         await refreshCompleted.Task;
         var stillStale = await port.GetServicesAsync("bearer-1", CancellationToken.None);
+        await retryRefreshCompleted.Task;
+        var refreshed = await port.GetServicesAsync("bearer-1", CancellationToken.None);
 
         stale.Services.Single().RouteValue.Should().Be("/old");
         stillStale.Services.Single().RouteValue.Should().Be("/old");
-        inner.GetCalls.Should().Be(2);
+        refreshed.Services.Single().RouteValue.Should().Be("/new");
+        inner.GetCalls.Should().Be(3);
     }
 
     [Fact]

--- a/test/Aevatar.Studio.Tests/CachedNyxIdLlmCatalogPortTests.cs
+++ b/test/Aevatar.Studio.Tests/CachedNyxIdLlmCatalogPortTests.cs
@@ -88,6 +88,40 @@ public sealed class CachedNyxIdLlmCatalogPortTests
     }
 
     [Fact]
+    public async Task GetServicesAsync_ShouldCoalesceStaleReads_WhenRefreshIsInFlight()
+    {
+        var clock = new ManualTimeProvider(DateTimeOffset.Parse("2026-05-29T10:00:00Z"));
+        var inner = new RecordingCatalogPort();
+        var refreshStarted = inner.SignalOnCallStart(callNumber: 2);
+        var refreshCompleted = inner.SignalOnCallCompletion(callNumber: 2);
+        var releaseRefresh = new TaskCompletionSource();
+        inner.Enqueue(MakeResult("anthropic", "/old"));
+        inner.EnqueueAfter(releaseRefresh.Task, MakeResult("anthropic", "/new"));
+        var port = CreatePort(inner, timeProvider: clock);
+
+        await port.GetServicesAsync("bearer-1", CancellationToken.None);
+        clock.Advance(TimeSpan.FromSeconds(61));
+
+        var firstStale = await port.GetServicesAsync("bearer-1", CancellationToken.None);
+        await refreshStarted.Task;
+        var secondStale = await port.GetServicesAsync("bearer-1", CancellationToken.None);
+        var thirdStale = await port.GetServicesAsync("bearer-1", CancellationToken.None);
+
+        firstStale.Services.Single().RouteValue.Should().Be("/old");
+        secondStale.Services.Single().RouteValue.Should().Be("/old");
+        thirdStale.Services.Single().RouteValue.Should().Be("/old");
+        inner.GetCalls.Should().Be(2);
+
+        releaseRefresh.SetResult();
+        await refreshCompleted.Task;
+        await Task.Yield();
+        var refreshed = await port.GetServicesAsync("bearer-1", CancellationToken.None);
+
+        refreshed.Services.Single().RouteValue.Should().Be("/new");
+        inner.GetCalls.Should().Be(2);
+    }
+
+    [Fact]
     public async Task GetServicesAsync_ShouldKeepStaleSnapshot_WhenRefreshFails()
     {
         var clock = new ManualTimeProvider(DateTimeOffset.Parse("2026-05-29T10:00:00Z"));
@@ -199,6 +233,7 @@ public sealed class CachedNyxIdLlmCatalogPortTests
     private sealed class RecordingCatalogPort : IUserLlmCatalogPort
     {
         private readonly Queue<Func<Task<NyxIdLlmServicesResult>>> _responses = new();
+        private readonly Dictionary<int, TaskCompletionSource> _callStartSignals = new();
         private readonly Dictionary<int, TaskCompletionSource> _callSignals = new();
 
         public int GetCalls { get; private set; }
@@ -212,8 +247,22 @@ public sealed class CachedNyxIdLlmCatalogPortTests
         public void Enqueue(NyxIdLlmServicesResult result) =>
             _responses.Enqueue(() => Task.FromResult(result));
 
+        public void EnqueueAfter(Task gate, NyxIdLlmServicesResult result) =>
+            _responses.Enqueue(async () =>
+            {
+                await gate.ConfigureAwait(false);
+                return result;
+            });
+
         public void EnqueueFailure(Exception exception) =>
             _responses.Enqueue(() => Task.FromException<NyxIdLlmServicesResult>(exception));
+
+        public TaskCompletionSource SignalOnCallStart(int callNumber)
+        {
+            var source = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _callStartSignals.Add(callNumber, source);
+            return source;
+        }
 
         public TaskCompletionSource SignalOnCallCompletion(int callNumber)
         {
@@ -227,6 +276,8 @@ public sealed class CachedNyxIdLlmCatalogPortTests
             GetCalls++;
             var callNumber = GetCalls;
             CapturedBearers.Add(bearerToken);
+            if (_callStartSignals.TryGetValue(callNumber, out var startSignal))
+                startSignal.SetResult();
 
             if (_responses.Count == 0)
                 throw new InvalidOperationException("No catalog response queued.");

--- a/test/Aevatar.Studio.Tests/CachedNyxIdLlmCatalogPortTests.cs
+++ b/test/Aevatar.Studio.Tests/CachedNyxIdLlmCatalogPortTests.cs
@@ -1,0 +1,272 @@
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Hosting.NyxId;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Aevatar.Studio.Tests;
+
+public sealed class CachedNyxIdLlmCatalogPortTests
+{
+    [Fact]
+    public async Task GetServicesAsync_ShouldReuseFreshSnapshot_ForSameAuthorityAndBearer()
+    {
+        var inner = new RecordingCatalogPort();
+        inner.Enqueue(MakeResult("anthropic", "/v1"));
+        var port = CreatePort(inner);
+
+        var first = await port.GetServicesAsync("bearer-1", CancellationToken.None);
+        var second = await port.GetServicesAsync("bearer-1", CancellationToken.None);
+
+        first.Services.Single().RouteValue.Should().Be("/v1");
+        second.Services.Single().RouteValue.Should().Be("/v1");
+        inner.GetCalls.Should().Be(1);
+        inner.CapturedBearers.Should().Equal("bearer-1");
+    }
+
+    [Fact]
+    public async Task GetServicesAsync_ShouldNotShareSnapshot_AcrossBearerFingerprints()
+    {
+        var inner = new RecordingCatalogPort();
+        inner.Enqueue(MakeResult("anthropic", "/caller-a"));
+        inner.Enqueue(MakeResult("anthropic", "/caller-b"));
+        var port = CreatePort(inner);
+
+        var first = await port.GetServicesAsync("bearer-A", CancellationToken.None);
+        var second = await port.GetServicesAsync("bearer-B", CancellationToken.None);
+
+        first.Services.Single().RouteValue.Should().Be("/caller-a");
+        second.Services.Single().RouteValue.Should().Be("/caller-b");
+        inner.GetCalls.Should().Be(2);
+        inner.CapturedBearers.Should().Equal("bearer-A", "bearer-B");
+    }
+
+    [Fact]
+    public async Task GetServicesAsync_ShouldNotShareSnapshot_AcrossAuthorities()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Aevatar:NyxId:Authority"] = "https://nyx-a.test",
+            })
+            .Build();
+        var inner = new RecordingCatalogPort();
+        inner.Enqueue(MakeResult("anthropic", "/authority-a"));
+        inner.Enqueue(MakeResult("anthropic", "/authority-b"));
+        var port = CreatePort(inner, configuration);
+
+        var first = await port.GetServicesAsync("bearer-1", CancellationToken.None);
+        configuration["Aevatar:NyxId:Authority"] = "https://nyx-b.test";
+        var second = await port.GetServicesAsync("bearer-1", CancellationToken.None);
+
+        first.Services.Single().RouteValue.Should().Be("/authority-a");
+        second.Services.Single().RouteValue.Should().Be("/authority-b");
+        inner.GetCalls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetServicesAsync_ShouldReturnStaleSnapshot_AndRefreshOnce()
+    {
+        var clock = new ManualTimeProvider(DateTimeOffset.Parse("2026-05-29T10:00:00Z"));
+        var inner = new RecordingCatalogPort();
+        inner.Enqueue(MakeResult("anthropic", "/old"));
+        inner.Enqueue(MakeResult("anthropic", "/new"));
+        var refreshCompleted = inner.SignalOnCallCompletion(callNumber: 2);
+        var port = CreatePort(inner, timeProvider: clock);
+
+        await port.GetServicesAsync("bearer-1", CancellationToken.None);
+        clock.Advance(TimeSpan.FromSeconds(61));
+
+        var stale = await port.GetServicesAsync("bearer-1", CancellationToken.None);
+        await refreshCompleted.Task;
+        var refreshed = await port.GetServicesAsync("bearer-1", CancellationToken.None);
+
+        stale.Services.Single().RouteValue.Should().Be("/old");
+        refreshed.Services.Single().RouteValue.Should().Be("/new");
+        inner.GetCalls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetServicesAsync_ShouldKeepStaleSnapshot_WhenRefreshFails()
+    {
+        var clock = new ManualTimeProvider(DateTimeOffset.Parse("2026-05-29T10:00:00Z"));
+        var inner = new RecordingCatalogPort();
+        inner.Enqueue(MakeResult("anthropic", "/old"));
+        inner.EnqueueFailure(new InvalidOperationException("NyxID unavailable"));
+        var refreshCompleted = inner.SignalOnCallCompletion(callNumber: 2);
+        var port = CreatePort(inner, timeProvider: clock);
+
+        await port.GetServicesAsync("bearer-1", CancellationToken.None);
+        clock.Advance(TimeSpan.FromSeconds(61));
+
+        var stale = await port.GetServicesAsync("bearer-1", CancellationToken.None);
+        await refreshCompleted.Task;
+        var stillStale = await port.GetServicesAsync("bearer-1", CancellationToken.None);
+
+        stale.Services.Single().RouteValue.Should().Be("/old");
+        stillStale.Services.Single().RouteValue.Should().Be("/old");
+        inner.GetCalls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetServicesAsync_ShouldFetchSynchronously_AndSurfaceFailure_AfterStaleWindowExpires()
+    {
+        var clock = new ManualTimeProvider(DateTimeOffset.Parse("2026-05-29T10:00:00Z"));
+        var inner = new RecordingCatalogPort();
+        inner.Enqueue(MakeResult("anthropic", "/old"));
+        inner.EnqueueFailure(new InvalidOperationException("NyxID unavailable"));
+        var port = CreatePort(inner, timeProvider: clock);
+
+        await port.GetServicesAsync("bearer-1", CancellationToken.None);
+        clock.Advance(TimeSpan.FromMinutes(7));
+
+        var act = async () => await port.GetServicesAsync("bearer-1", CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("NyxID unavailable");
+        inner.GetCalls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_ShouldInvalidateOnlyCurrentCallerAuthoritySnapshot()
+    {
+        var inner = new RecordingCatalogPort();
+        inner.Enqueue(MakeResult("anthropic", "/caller-a-old"));
+        inner.Enqueue(MakeResult("anthropic", "/caller-b"));
+        inner.Enqueue(MakeResult("anthropic", "/caller-a-new"));
+        inner.ProvisionResult = MakeService("anthropic", "/provisioned");
+        var port = CreatePort(inner);
+
+        var callerAOld = await port.GetServicesAsync("bearer-A", CancellationToken.None);
+        var callerB = await port.GetServicesAsync("bearer-B", CancellationToken.None);
+        await port.ProvisionAsync("bearer-A", "anthropic", CancellationToken.None);
+        var callerANew = await port.GetServicesAsync("bearer-A", CancellationToken.None);
+        var callerBAfterProvision = await port.GetServicesAsync("bearer-B", CancellationToken.None);
+
+        callerAOld.Services.Single().RouteValue.Should().Be("/caller-a-old");
+        callerB.Services.Single().RouteValue.Should().Be("/caller-b");
+        callerANew.Services.Single().RouteValue.Should().Be("/caller-a-new");
+        callerBAfterProvision.Services.Single().RouteValue.Should().Be("/caller-b");
+        inner.GetCalls.Should().Be(3);
+        inner.ProvisionBearers.Should().Equal("bearer-A");
+    }
+
+    private static CachedNyxIdLlmCatalogPort CreatePort(
+        RecordingCatalogPort inner,
+        IConfiguration? configuration = null,
+        TimeProvider? timeProvider = null)
+    {
+        return new CachedNyxIdLlmCatalogPort(
+            inner,
+            configuration ?? CreateConfiguration("https://nyx.test/api/v1/llm/gateway/v1"),
+            new FixedOptionsMonitor<NyxIdLlmCatalogCacheOptions>(new NyxIdLlmCatalogCacheOptions
+            {
+                FreshTtl = TimeSpan.FromSeconds(60),
+                StaleTtl = TimeSpan.FromMinutes(5),
+                MaxEntries = 16,
+            }),
+            timeProvider ?? new ManualTimeProvider(DateTimeOffset.Parse("2026-05-29T10:00:00Z")),
+            NullLogger<CachedNyxIdLlmCatalogPort>.Instance);
+    }
+
+    private static IConfiguration CreateConfiguration(string authority)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Aevatar:NyxId:Authority"] = authority,
+            })
+            .Build();
+    }
+
+    private static NyxIdLlmServicesResult MakeResult(string slug, string routeValue) =>
+        new([MakeService(slug, routeValue)], null);
+
+    private static NyxIdLlmService MakeService(string slug, string routeValue) =>
+        new(
+            UserServiceId: slug,
+            ServiceSlug: slug,
+            DisplayName: slug,
+            RouteValue: routeValue,
+            DefaultModel: null,
+            Models: [],
+            Status: "ready",
+            Source: NyxIdLlmProviderSource.GatewayProvider,
+            Allowed: true,
+            Description: null);
+
+    private sealed class RecordingCatalogPort : IUserLlmCatalogPort
+    {
+        private readonly Queue<Func<Task<NyxIdLlmServicesResult>>> _responses = new();
+        private readonly Dictionary<int, TaskCompletionSource> _callSignals = new();
+
+        public int GetCalls { get; private set; }
+
+        public List<string> CapturedBearers { get; } = [];
+
+        public List<string> ProvisionBearers { get; } = [];
+
+        public NyxIdLlmService ProvisionResult { get; set; } = MakeService("provisioned", "/provisioned");
+
+        public void Enqueue(NyxIdLlmServicesResult result) =>
+            _responses.Enqueue(() => Task.FromResult(result));
+
+        public void EnqueueFailure(Exception exception) =>
+            _responses.Enqueue(() => Task.FromException<NyxIdLlmServicesResult>(exception));
+
+        public TaskCompletionSource SignalOnCallCompletion(int callNumber)
+        {
+            var source = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _callSignals.Add(callNumber, source);
+            return source;
+        }
+
+        public async Task<NyxIdLlmServicesResult> GetServicesAsync(string bearerToken, CancellationToken ct)
+        {
+            GetCalls++;
+            var callNumber = GetCalls;
+            CapturedBearers.Add(bearerToken);
+
+            if (_responses.Count == 0)
+                throw new InvalidOperationException("No catalog response queued.");
+
+            try
+            {
+                return await _responses.Dequeue().Invoke();
+            }
+            finally
+            {
+                if (_callSignals.TryGetValue(callNumber, out var signal))
+                    signal.SetResult();
+            }
+        }
+
+        public Task<NyxIdLlmService> ProvisionAsync(
+            string bearerToken,
+            string provisionEndpointId,
+            CancellationToken ct)
+        {
+            ProvisionBearers.Add(bearerToken);
+            return Task.FromResult(ProvisionResult);
+        }
+    }
+
+    private sealed class FixedOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+    {
+        public T CurrentValue => value;
+
+        public T Get(string? name) => value;
+
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+
+    private sealed class ManualTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        private DateTimeOffset _utcNow = utcNow;
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan duration) => _utcNow += duration;
+    }
+}


### PR DESCRIPTION
## 摘要

iter159 cluster-646-first:NyxID LLM catalog 有界 SWR adapter。

closes #1190

## 改动范围

| 文件 | 改动 |
|---|---|
| `src/Aevatar.Studio.Hosting/NyxId/NyxIdLlmCatalogHttpClient.cs` | 真实 fetch 路径 |
| `src/Aevatar.Studio.Hosting/NyxId/CachedNyxIdLlmCatalogPort.cs` | **新增** SWR decorator |
| `src/Aevatar.Studio.Hosting/NyxId/NyxIdAuthorityResolver.cs` | **新增** authority 解析 |
| `src/Aevatar.Studio.Hosting/NyxId/NyxIdLlmCatalogCacheOptions.cs` | **新增** SWR options |
| `src/Aevatar.Studio.Hosting/StudioHostingServiceCollectionExtensions.cs` | DI 装配 |
| `test/Aevatar.Studio.Tests/CachedNyxIdLlmCatalogPortTests.cs` | **新增** SWR 行为测试 |
| `test/Aevatar.Hosting.Tests/CachingResponsesRouteResolverTests.cs` | 旧"每次 fetch"断言改为 SWR 行为 |

## 架构边界说明

`CachedNyxIdLlmCatalogPort` 的 cache 是 Host/NyxID external-adapter 内的 bounded stale-while-revalidate snapshot，只用于削减 hot-path NyxID catalog IO。它是 non-authoritative performance hint，不是 readmodel、不是 actor state、不是 query fact source。

权威事实仍在 NyxID；cache eviction、miss 或 disabled mode 都会回到 authoritative fetch。`ProvisionAsync` 会按 caller authority + bearer fingerprint invalidates 当前 caller snapshot，避免 stale window 越界。

## 验证

- `dotnet build aevatar.slnx --nologo` ✓
- `dotnet test aevatar.slnx --nologo --no-build` ✓
- `tools/ci/test_stability_guards.sh` ✓
- `tools/ci/architecture_guards.sh` ✓

⟦AI:AUTO-LOOP⟧