### PR TITLE
iter159 #1197: thread typed caller-scope resolution context

### DIFF
--- a/src/Aevatar.Mainnet.Host.Api/ChatCompletions/ChatCompletionsEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/ChatCompletions/ChatCompletionsEndpoints.cs
@@ -70,6 +70,7 @@ internal static class ChatCompletionsApiEndpoints
         var bearerToken = ExtractBearerToken(http);
         if (string.IsNullOrWhiteSpace(bearerToken))
             return ToErrorResult(StatusCodes.Status401Unauthorized, "authentication_required", "Authorization bearer token is required.");
+        var callerScopeContext = ResponsesApiEndpoints.BuildCallerScopeResolutionContext(http, bearerToken);
 
         var normalizedResult = ChatCompletionsRequestNormalizer.Normalize(request);
         if (!normalizedResult.Succeeded)
@@ -84,7 +85,7 @@ internal static class ChatCompletionsApiEndpoints
         ResponsesCallerScope callerScope;
         try
         {
-            callerScope = await callerScopeResolver.ResolveAsync(bearerToken, ct);
+            callerScope = await callerScopeResolver.ResolveAsync(callerScopeContext, ct);
         }
         catch (ResponsesCallerScopeUnavailableException ex)
         {

--- a/src/Aevatar.Mainnet.Host.Api/Messages/MessagesEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Messages/MessagesEndpoints.cs
@@ -56,7 +56,8 @@ internal static partial class MessagesApiEndpoints
                 commandRequest.ErrorMessage ?? "Invalid request.");
         }
 
-        var result = await commandFacade.CreateAsync(commandRequest.Request!, bearerToken, ct);
+        var callerScopeContext = ResponsesApiEndpoints.BuildCallerScopeResolutionContext(http, bearerToken);
+        var result = await commandFacade.CreateAsync(commandRequest.Request!, callerScopeContext, ct);
         if (result.Error is not null)
             return ToErrorResult(result.Error.StatusCode, result.Error.Code, result.Error.Message);
 

--- a/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesCallerScope.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesCallerScope.cs
@@ -13,10 +13,14 @@ internal sealed class NyxIdResponsesCallerScopeResolver : IResponsesCallerScopeR
         _currentUserResolver = currentUserResolver ?? throw new ArgumentNullException(nameof(currentUserResolver));
     }
 
+    // Refactor (iter159/cluster-640-first): Old: ResolveAsync(string bearer)  New: ResolveAsync(ResponsesCallerScopeResolutionContext)
     public async Task<ResponsesCallerScope> ResolveAsync(
-        string nyxIdAccessToken,
+        ResponsesCallerScopeResolutionContext context,
         CancellationToken ct = default)
     {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var nyxIdAccessToken = context.InboundBearerToken;
         if (string.IsNullOrWhiteSpace(nyxIdAccessToken))
             throw new ResponsesCallerScopeUnavailableException("NyxID access token is required.");
 

--- a/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesEndpoints.cs
@@ -23,14 +23,16 @@ namespace Aevatar.Mainnet.Host.Api.Responses;
 internal static partial class ResponsesApiEndpoints
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    internal const string NyxIdIdentityTokenHeader = "X-NyxID-Identity-Token";
+    internal const string NyxIdDelegationTokenHeader = "X-NyxID-Delegation-Token";
 
     public static IEndpointRouteBuilder MapResponsesApiEndpoints(this IEndpointRouteBuilder app)
     {
         ArgumentNullException.ThrowIfNull(app);
 
         var group = app.MapGroup("/v1").WithTags("Responses");
-        // Auth is endpoint-internal: each handler manually extracts the inbound
-        // bearer and resolves the caller via NyxID `/me`. Opt out of the host's
+        // Auth is endpoint-internal: each handler extracts inbound caller
+        // evidence for the shared caller-scope resolver. Opt out of the host's
         // FallbackPolicy.RequireAuthenticatedUser() so opaque NyxID API keys
         // (non-JWT) reach the handler instead of being 401'd by JwtBearer.
         group.MapPost("/responses", HandleCreateResponseAsync).AllowAnonymous();
@@ -68,7 +70,8 @@ internal static partial class ResponsesApiEndpoints
                 commandRequest.ErrorMessage ?? "Invalid request.");
         }
 
-        var result = await commandFacade.CreateAsync(commandRequest.Request!, bearerToken, ct);
+        var callerScopeContext = BuildCallerScopeResolutionContext(http, bearerToken);
+        var result = await commandFacade.CreateAsync(commandRequest.Request!, callerScopeContext, ct);
         if (result.Error is not null)
             return ToErrorResult(result.Error.StatusCode, result.Error.Code, result.Error.Message);
 
@@ -132,7 +135,8 @@ internal static partial class ResponsesApiEndpoints
                 "authentication_required",
                 "Authorization bearer token is required.");
 
-        var result = await commandFacade.CancelAsync(responseId, bearerToken, ct);
+        var callerScopeContext = BuildCallerScopeResolutionContext(http, bearerToken);
+        var result = await commandFacade.CancelAsync(responseId, callerScopeContext, ct);
         if (result.Error is not null)
             return ToErrorResult(result.Error.StatusCode, result.Error.Code, result.Error.Message);
 
@@ -704,6 +708,27 @@ internal static partial class ResponsesApiEndpoints
         return authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
             ? authHeader["Bearer ".Length..].Trim()
             : null;
+    }
+
+    internal static ResponsesCallerScopeResolutionContext BuildCallerScopeResolutionContext(
+        HttpContext http,
+        string bearerToken)
+    {
+        ArgumentNullException.ThrowIfNull(http);
+
+        return new ResponsesCallerScopeResolutionContext(
+            bearerToken,
+            ExtractHeaderValue(http, NyxIdIdentityTokenHeader),
+            ExtractHeaderValue(http, NyxIdDelegationTokenHeader));
+    }
+
+    private static string? ExtractHeaderValue(HttpContext http, string headerName)
+    {
+        if (!http.Request.Headers.TryGetValue(headerName, out var values))
+            return null;
+
+        var value = values.FirstOrDefault();
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
     }
 
     /// <summary>OpenAI-spec `GET /v1/models`. Fans out across every NyxID-routed service the caller

--- a/src/platform/Aevatar.GAgentService.Application/Responses/MessagesCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/MessagesCommandFacade.cs
@@ -31,10 +31,11 @@ public sealed class MessagesCommandFacade(
 
     public async Task<MessagesCreateCommandResult> CreateAsync(
         MessagesCommandRequest request,
-        string bearerToken,
+        ResponsesCallerScopeResolutionContext callerScopeContext,
         CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(callerScopeContext);
 
         var normalizedResult = MessagesRequestNormalizer.Normalize(request);
         if (!normalizedResult.Succeeded)
@@ -46,7 +47,7 @@ public sealed class MessagesCommandFacade(
         }
 
         var normalized = normalizedResult.Request!;
-        var callerScopeResult = await ResolveCallerScopeAsync(bearerToken, ct);
+        var callerScopeResult = await ResolveCallerScopeAsync(callerScopeContext, ct);
         if (callerScopeResult.Error is not null)
             return MessagesCreateCommandResult.FromError(
                 callerScopeResult.Error.StatusCode,
@@ -72,7 +73,7 @@ public sealed class MessagesCommandFacade(
             callerScopeResult.Scope!,
             routedModelResult.Model!,
             routedModelResult.Action!,
-            bearerToken,
+            callerScopeContext.InboundBearerToken,
             sessionResult.Session!,
             ct);
 
@@ -123,11 +124,13 @@ public sealed class MessagesCommandFacade(
         }
     }
 
-    private async Task<CallerScopeResult> ResolveCallerScopeAsync(string bearerToken, CancellationToken ct)
+    private async Task<CallerScopeResult> ResolveCallerScopeAsync(
+        ResponsesCallerScopeResolutionContext callerScopeContext,
+        CancellationToken ct)
     {
         try
         {
-            var callerScope = await callerScopeResolver.ResolveAsync(bearerToken, ct);
+            var callerScope = await callerScopeResolver.ResolveAsync(callerScopeContext, ct);
             return new CallerScopeResult(callerScope, null);
         }
         catch (ResponsesCallerScopeUnavailableException ex)

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandContracts.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandContracts.cs
@@ -15,13 +15,21 @@ public sealed record ResponsesCallerScope(
     string OwnerSubject,
     LlmSessionOriginKind OriginKind);
 
+// Refactor (iter159/cluster-640-first): Old: ResolveAsync(string bearer)  New: ResolveAsync(ResponsesCallerScopeResolutionContext)
+//   Old pattern: caller-scope resolution received only the inbound bearer string, so NyxID proxy assertions could not travel through the shared admission seam.
+//   New principle: Host adapters carry all inbound caller evidence as typed Application input while the resolver decides the authoritative scope.
+public sealed record ResponsesCallerScopeResolutionContext(
+    string InboundBearerToken,
+    string? NyxIdIdentityToken,
+    string? NyxIdDelegationToken);
+
 // Refactor (iter35/cluster-037-mainnet-responses-host-orchestration):
 //   Old pattern: Each endpoint resolved NyxID bearer tokens directly before continuing its inline command flow.
 //   New principle: Token-to-caller-scope resolution is a narrow Application port; Host composes the concrete adapter and command facades consume the typed result.
 public interface IResponsesCallerScopeResolver
 {
     Task<ResponsesCallerScope> ResolveAsync(
-        string nyxIdAccessToken,
+        ResponsesCallerScopeResolutionContext context,
         CancellationToken ct = default);
 }
 
@@ -308,12 +316,12 @@ public interface IResponsesCommandFacade
 {
     Task<ResponsesCreateCommandResult> CreateAsync(
         ResponsesCommandRequest request,
-        string bearerToken,
+        ResponsesCallerScopeResolutionContext callerScopeContext,
         CancellationToken ct = default);
 
     Task<ResponsesCancelCommandResult> CancelAsync(
         string responseId,
-        string bearerToken,
+        ResponsesCallerScopeResolutionContext callerScopeContext,
         CancellationToken ct = default);
 
     Task<ResponsesStreamCommandResult> StreamAsync(
@@ -329,7 +337,7 @@ public interface IMessagesCommandFacade
 {
     Task<MessagesCreateCommandResult> CreateAsync(
         MessagesCommandRequest request,
-        string bearerToken,
+        ResponsesCallerScopeResolutionContext callerScopeContext,
         CancellationToken ct = default);
 
     Task<ResponsesStreamCommandResult> StreamAsync(

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandFacade.cs
@@ -35,10 +35,11 @@ public sealed class ResponsesCommandFacade(
 
     public async Task<ResponsesCreateCommandResult> CreateAsync(
         ResponsesCommandRequest request,
-        string bearerToken,
+        ResponsesCallerScopeResolutionContext callerScopeContext,
         CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(callerScopeContext);
 
         var normalizedResult = ResponsesRequestNormalizer.Normalize(request);
         if (!normalizedResult.Succeeded)
@@ -50,7 +51,7 @@ public sealed class ResponsesCommandFacade(
         }
 
         var normalized = normalizedResult.Request!;
-        var callerScopeResult = await ResolveCallerScopeAsync(bearerToken, ct);
+        var callerScopeResult = await ResolveCallerScopeAsync(callerScopeContext, ct);
         if (callerScopeResult.Error is not null)
             return ResponsesCreateCommandResult.FromError(
                 callerScopeResult.Error.StatusCode,
@@ -99,7 +100,7 @@ public sealed class ResponsesCommandFacade(
             continuation.PreviousSnapshot,
             callerScope,
             routedModelResult.Action!,
-            bearerToken,
+            callerScopeContext.InboundBearerToken,
             sessionResult.Session!,
             createdAt,
             ct);
@@ -118,12 +119,13 @@ public sealed class ResponsesCommandFacade(
     //   New principle: Application validates visibility and advances session status; Host maps the typed result to HTTP.
     public async Task<ResponsesCancelCommandResult> CancelAsync(
         string responseId,
-        string bearerToken,
+        ResponsesCallerScopeResolutionContext callerScopeContext,
         CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(responseId);
+        ArgumentNullException.ThrowIfNull(callerScopeContext);
 
-        var callerScopeResult = await ResolveCallerScopeAsync(bearerToken, ct);
+        var callerScopeResult = await ResolveCallerScopeAsync(callerScopeContext, ct);
         if (callerScopeResult.Error is not null)
             return ResponsesCancelCommandResult.FromError(
                 callerScopeResult.Error.StatusCode,
@@ -209,11 +211,13 @@ public sealed class ResponsesCommandFacade(
         }
     }
 
-    private async Task<CallerScopeResult> ResolveCallerScopeAsync(string bearerToken, CancellationToken ct)
+    private async Task<CallerScopeResult> ResolveCallerScopeAsync(
+        ResponsesCallerScopeResolutionContext callerScopeContext,
+        CancellationToken ct)
     {
         try
         {
-            var callerScope = await callerScopeResolver.ResolveAsync(bearerToken, ct);
+            var callerScope = await callerScopeResolver.ResolveAsync(callerScopeContext, ct);
             return new CallerScopeResult(callerScope, null);
         }
         catch (ResponsesCallerScopeUnavailableException ex)

--- a/test/Aevatar.GAgentService.Tests/Application/MessagesCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/MessagesCommandFacadeTests.cs
@@ -20,7 +20,7 @@ public sealed class MessagesCommandFacadeTests
         var dispatch = new RecordingActorDispatchPort();
         var facade = CreateFacade(sessionPort: sessions, dispatchPort: dispatch);
 
-        var result = await facade.CreateAsync(BuildRequest("claude-sonnet"), "token");
+        var result = await facade.CreateAsync(BuildRequest("claude-sonnet"), CallerScopeContext("token"));
 
         result.Error.Should().BeNull();
         result.Accepted.Should().NotBeNull();
@@ -42,7 +42,7 @@ public sealed class MessagesCommandFacadeTests
         var sessions = new RecordingSessionPort();
         var facade = CreateFacade(sessionPort: sessions);
 
-        var result = await facade.CreateAsync(BuildRequest("claude-sonnet"), "token");
+        var result = await facade.CreateAsync(BuildRequest("claude-sonnet"), CallerScopeContext("token"));
 
         sessions.RecordedCompletions.Should().BeEmpty();
         result.Completed.Should().BeNull();
@@ -56,7 +56,7 @@ public sealed class MessagesCommandFacadeTests
         var sessions = new RecordingSessionPort();
         var facade = CreateFacade(sessionPort: sessions);
 
-        var result = await facade.CreateAsync(BuildRequest("anthropic/claude", stream: true), "token");
+        var result = await facade.CreateAsync(BuildRequest("anthropic/claude", stream: true), CallerScopeContext("token"));
 
         result.Error.Should().BeNull();
         result.StreamPlan.Should().NotBeNull();
@@ -119,6 +119,9 @@ public sealed class MessagesCommandFacadeTests
             NullLogger<MessagesCommandFacade>.Instance);
     }
 
+    private static ResponsesCallerScopeResolutionContext CallerScopeContext(string bearerToken) =>
+        new(bearerToken, null, null);
+
     private static MessagesCreateCommandPlan BuildStreamPlan() =>
         new(
             new NormalizedMessagesRequest(
@@ -148,7 +151,9 @@ public sealed class MessagesCommandFacadeTests
 
     private sealed class StaticCallerScopeResolver : IResponsesCallerScopeResolver
     {
-        public Task<ResponsesCallerScope> ResolveAsync(string nyxIdAccessToken, CancellationToken ct = default) =>
+        public Task<ResponsesCallerScope> ResolveAsync(
+            ResponsesCallerScopeResolutionContext context,
+            CancellationToken ct = default) =>
             Task.FromResult(new ResponsesCallerScope("scope-1", "owner-1", LlmSessionOriginKind.ApiKey));
     }
 

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
@@ -36,7 +36,7 @@ public sealed class ResponsesCommandFacadeTests
             null,
             0.4,
             64,
-            []), "token");
+            []), CallerScopeContext("token"));
 
         result.Error.Should().BeNull();
         result.Accepted.Should().NotBeNull();
@@ -71,7 +71,7 @@ public sealed class ResponsesCommandFacadeTests
             null,
             null,
             null,
-            []), "token");
+            []), CallerScopeContext("token"));
 
         result.Error.Should().BeNull();
         sessions.Registered.Should().ContainSingle();
@@ -122,7 +122,7 @@ public sealed class ResponsesCommandFacadeTests
             null,
             null,
             null,
-            []), "token");
+            []), CallerScopeContext("token"));
 
         result.Error.Should().BeNull();
         result.Accepted.Should().NotBeNull();
@@ -144,7 +144,7 @@ public sealed class ResponsesCommandFacadeTests
             null,
             null,
             null,
-            []), "token");
+            []), CallerScopeContext("token"));
 
         result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
             401,
@@ -162,13 +162,13 @@ public sealed class ResponsesCommandFacadeTests
         var sessionPort = new RecordingSessionPort();
         var facade = CreateFacade(sessionPort: sessionPort, queryPort: queryPort);
 
-        var invisible = await facade.CancelAsync("resp_1", "token");
+        var invisible = await facade.CancelAsync("resp_1", CallerScopeContext("token"));
 
         invisible.Error!.Code.Should().Be("response_scope_mismatch");
         sessionPort.UpdatedStatuses.Should().BeEmpty();
 
         queryPort.Snapshot = BuildSnapshot("resp_1", scopeId: "scope-1");
-        var cancelled = await facade.CancelAsync("resp_1", "token");
+        var cancelled = await facade.CancelAsync("resp_1", CallerScopeContext("token"));
 
         cancelled.Error.Should().BeNull();
         cancelled.ResponseId.Should().Be("resp_1");
@@ -185,7 +185,7 @@ public sealed class ResponsesCommandFacadeTests
         var sessionPort = new RecordingSessionPort();
         var facade = CreateFacade(sessionPort: sessionPort, queryPort: queryPort);
 
-        var result = await facade.CancelAsync("resp_expired", "token");
+        var result = await facade.CancelAsync("resp_expired", CallerScopeContext("token"));
 
         result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
             400,
@@ -207,7 +207,7 @@ public sealed class ResponsesCommandFacadeTests
         };
         var facade = CreateFacade(sessionPort: sessionPort, queryPort: queryPort);
 
-        var result = await facade.CancelAsync("resp_active", "token");
+        var result = await facade.CancelAsync("resp_active", CallerScopeContext("token"));
 
         result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
             400,
@@ -309,6 +309,9 @@ public sealed class ResponsesCommandFacadeTests
             NullLogger<ResponsesCommandFacade>.Instance);
     }
 
+    private static ResponsesCallerScopeResolutionContext CallerScopeContext(string bearerToken) =>
+        new(bearerToken, null, null);
+
     private static ResponsesCreateCommandPlan BuildStreamPlan() =>
         new(
             new NormalizedResponsesRequest(
@@ -379,13 +382,17 @@ public sealed class ResponsesCommandFacadeTests
 
     private sealed class StaticCallerScopeResolver : IResponsesCallerScopeResolver
     {
-        public Task<ResponsesCallerScope> ResolveAsync(string nyxIdAccessToken, CancellationToken ct = default) =>
+        public Task<ResponsesCallerScope> ResolveAsync(
+            ResponsesCallerScopeResolutionContext context,
+            CancellationToken ct = default) =>
             Task.FromResult(new ResponsesCallerScope("scope-1", "owner-1", LlmSessionOriginKind.ApiKey));
     }
 
     private sealed class ThrowingCallerScopeResolver : IResponsesCallerScopeResolver
     {
-        public Task<ResponsesCallerScope> ResolveAsync(string nyxIdAccessToken, CancellationToken ct = default) =>
+        public Task<ResponsesCallerScope> ResolveAsync(
+            ResponsesCallerScopeResolutionContext context,
+            CancellationToken ct = default) =>
             throw new ResponsesCallerScopeUnavailableException("access token is invalid");
     }
 

--- a/test/Aevatar.Hosting.Tests/MainnetChatCompletionsEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetChatCompletionsEndpointsTests.cs
@@ -63,6 +63,8 @@ public sealed class MainnetChatCompletionsEndpointsTests
             """),
         };
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "openai-bearer");
+        request.Headers.Add(ResponsesApiEndpoints.NyxIdIdentityTokenHeader, "chat-identity-token");
+        request.Headers.Add(ResponsesApiEndpoints.NyxIdDelegationTokenHeader, "chat-delegation-token");
 
         var response = await client.SendAsync(request);
         var body = await response.Content.ReadAsStringAsync();
@@ -94,6 +96,14 @@ public sealed class MainnetChatCompletionsEndpointsTests
         provider.LastRequest.MaxTokens.Should().Be(256);
         provider.LastRequest.CallerContext!.Credentials!.NyxIdBearer.Should().Be("openai-bearer");
         provider.LastRequest.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
+        var callerScopeResolver = app.Services.GetRequiredService<IResponsesCallerScopeResolver>()
+            .Should()
+            .BeOfType<ChatCompletionsStubCallerScopeResolver>()
+            .Subject;
+        callerScopeResolver.LastContext.Should().Be(new ResponsesCallerScopeResolutionContext(
+            "openai-bearer",
+            "chat-identity-token",
+            "chat-delegation-token"));
     }
 
     [Fact]
@@ -495,10 +505,15 @@ public sealed class MainnetChatCompletionsEndpointsTests
 
     private sealed class ChatCompletionsStubCallerScopeResolver : IResponsesCallerScopeResolver
     {
+        public ResponsesCallerScopeResolutionContext? LastContext { get; private set; }
+
         public Task<ResponsesCallerScope> ResolveAsync(
-            string nyxIdAccessToken,
-            CancellationToken ct = default) =>
-            Task.FromResult(new ResponsesCallerScope("user-1", "user-1", LlmSessionOriginKind.ApiKey));
+            ResponsesCallerScopeResolutionContext context,
+            CancellationToken ct = default)
+        {
+            LastContext = context;
+            return Task.FromResult(new ResponsesCallerScope("user-1", "user-1", LlmSessionOriginKind.ApiKey));
+        }
     }
 
     private sealed class ChatCompletionsNoopRouteResolver : IResponsesRouteResolver

--- a/test/Aevatar.Hosting.Tests/MainnetMessagesEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetMessagesEndpointsTests.cs
@@ -68,6 +68,8 @@ public sealed class MainnetMessagesEndpointsTests
             """),
         };
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "anthropic-bearer");
+        request.Headers.Add(ResponsesApiEndpoints.NyxIdIdentityTokenHeader, "messages-identity-token");
+        request.Headers.Add(ResponsesApiEndpoints.NyxIdDelegationTokenHeader, "messages-delegation-token");
 
         var response = await client.SendAsync(request);
         var body = await response.Content.ReadAsStringAsync();
@@ -108,6 +110,14 @@ public sealed class MainnetMessagesEndpointsTests
         // Bearer goes on the typed CallerContext, not Metadata, per PR #625 round-2 fix.
         provider.LastRequest.CallerContext!.Credentials!.NyxIdBearer.Should().Be("anthropic-bearer");
         provider.LastRequest.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
+        var callerScopeResolver = app.Services.GetRequiredService<IResponsesCallerScopeResolver>()
+            .Should()
+            .BeOfType<MessagesStubCallerScopeResolver>()
+            .Subject;
+        callerScopeResolver.LastContext.Should().Be(new ResponsesCallerScopeResolutionContext(
+            "anthropic-bearer",
+            "messages-identity-token",
+            "messages-delegation-token"));
     }
 
     [Fact]
@@ -766,14 +776,14 @@ public sealed class MainnetMessagesEndpointsTests
     {
         public async Task<MessagesCreateCommandResult> CreateAsync(
             MessagesCommandRequest request,
-            string bearerToken,
+            ResponsesCallerScopeResolutionContext callerScopeContext,
             CancellationToken ct = default)
         {
             if (request.Stream == true)
-                return await inner.CreateAsync(request, bearerToken, ct);
+                return await inner.CreateAsync(request, callerScopeContext, ct);
 
             var planRequest = request with { Stream = true };
-            var result = await inner.CreateAsync(planRequest, bearerToken, ct);
+            var result = await inner.CreateAsync(planRequest, callerScopeContext, ct);
             if (result.Error is not null || result.StreamPlan is null)
                 return result;
 
@@ -916,10 +926,15 @@ public sealed class MainnetMessagesEndpointsTests
 
     private sealed class MessagesStubCallerScopeResolver : IResponsesCallerScopeResolver
     {
+        public ResponsesCallerScopeResolutionContext? LastContext { get; private set; }
+
         public Task<ResponsesCallerScope> ResolveAsync(
-            string nyxIdAccessToken,
-            CancellationToken ct = default) =>
-            Task.FromResult(new ResponsesCallerScope("user-1", "user-1", LlmSessionOriginKind.ApiKey));
+            ResponsesCallerScopeResolutionContext context,
+            CancellationToken ct = default)
+        {
+            LastContext = context;
+            return Task.FromResult(new ResponsesCallerScope("user-1", "user-1", LlmSessionOriginKind.ApiKey));
+        }
     }
 
     private sealed class MessagesNoopRouteResolver : IResponsesRouteResolver

--- a/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
@@ -65,6 +65,8 @@ public sealed class MainnetResponsesEndpointsTests
             """),
         };
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "secret-token");
+        request.Headers.Add(ResponsesApiEndpoints.NyxIdIdentityTokenHeader, "identity-token");
+        request.Headers.Add(ResponsesApiEndpoints.NyxIdDelegationTokenHeader, "delegation-token");
 
         var response = await client.SendAsync(request);
         var body = await response.Content.ReadAsStringAsync();
@@ -118,6 +120,14 @@ public sealed class MainnetResponsesEndpointsTests
         // Tool providers read the bearer from AgentToolRequestContext (separate path).
         provider.LastRequest.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
         provider.LastRequest.CallerContext!.Credentials!.NyxIdBearer.Should().Be("secret-token");
+        var callerScopeResolver = app.Services.GetRequiredService<IResponsesCallerScopeResolver>()
+            .Should()
+            .BeOfType<StubResponsesCallerScopeResolver>()
+            .Subject;
+        callerScopeResolver.LastContext.Should().Be(new ResponsesCallerScopeResolutionContext(
+            "secret-token",
+            "identity-token",
+            "delegation-token"));
 
         sessions.Registered.Should().ContainSingle();
         sessions.Registered[0].ScopeId.Should().Be("user-1");
@@ -2461,14 +2471,14 @@ public sealed class MainnetResponsesEndpointsTests
     {
         public async Task<ResponsesCreateCommandResult> CreateAsync(
             ResponsesCommandRequest request,
-            string bearerToken,
+            ResponsesCallerScopeResolutionContext callerScopeContext,
             CancellationToken ct = default)
         {
             if (request.Stream == true)
-                return await inner.CreateAsync(request, bearerToken, ct);
+                return await inner.CreateAsync(request, callerScopeContext, ct);
 
             var planRequest = request with { Stream = true };
-            var result = await inner.CreateAsync(planRequest, bearerToken, ct);
+            var result = await inner.CreateAsync(planRequest, callerScopeContext, ct);
             if (result.Error is not null || result.StreamPlan is null)
                 return result;
 
@@ -2498,9 +2508,9 @@ public sealed class MainnetResponsesEndpointsTests
 
         public Task<ResponsesCancelCommandResult> CancelAsync(
             string responseId,
-            string bearerToken,
+            ResponsesCallerScopeResolutionContext callerScopeContext,
             CancellationToken ct = default) =>
-            inner.CancelAsync(responseId, bearerToken, ct);
+            inner.CancelAsync(responseId, callerScopeContext, ct);
 
         public async Task<ResponsesStreamCommandResult> StreamAsync(
             ResponsesCreateCommandPlan plan,
@@ -2832,10 +2842,15 @@ public sealed class MainnetResponsesEndpointsTests
             _scope = new ResponsesCallerScope(scopeId, ownerSubject, originKind);
         }
 
+        public ResponsesCallerScopeResolutionContext? LastContext { get; private set; }
+
         public Task<ResponsesCallerScope> ResolveAsync(
-            string nyxIdAccessToken,
-            CancellationToken ct = default) =>
-            Task.FromResult(_scope);
+            ResponsesCallerScopeResolutionContext context,
+            CancellationToken ct = default)
+        {
+            LastContext = context;
+            return Task.FromResult(_scope);
+        }
     }
 
     private sealed class RecordingResponsesToolProvider : IResponsesToolProvider

--- a/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
@@ -1222,6 +1222,8 @@ public sealed class MainnetResponsesEndpointsTests
 
         using var request = new HttpRequestMessage(HttpMethod.Post, "/v1/responses/resp_previous/cancel");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "secret-token");
+        request.Headers.Add(ResponsesApiEndpoints.NyxIdIdentityTokenHeader, "identity-token");
+        request.Headers.Add(ResponsesApiEndpoints.NyxIdDelegationTokenHeader, "delegation-token");
 
         var response = await client.SendAsync(request);
         var body = await response.Content.ReadAsStringAsync();
@@ -1235,6 +1237,14 @@ public sealed class MainnetResponsesEndpointsTests
         snapshot!.Status.Should().Be(LlmSessionStatus.Cancelled);
         snapshot.ForwardedToolCalls.Should().ContainSingle()
             .Which.Status.Should().Be(LlmSessionForwardedToolCallStatus.Cancelled);
+        var callerScopeResolver = app.Services.GetRequiredService<IResponsesCallerScopeResolver>()
+            .Should()
+            .BeOfType<StubResponsesCallerScopeResolver>()
+            .Subject;
+        callerScopeResolver.LastContext.Should().Be(new ResponsesCallerScopeResolutionContext(
+            "secret-token",
+            "identity-token",
+            "delegation-token"));
         provider.LastRequest.Should().BeNull();
     }
 

--- a/test/Aevatar.Hosting.Tests/ResponsesCallerScopeResolverTests.cs
+++ b/test/Aevatar.Hosting.Tests/ResponsesCallerScopeResolverTests.cs
@@ -21,7 +21,7 @@ public sealed class ResponsesCallerScopeResolverTests
     {
         var resolver = new NyxIdResponsesCallerScopeResolver(new StubUserResolver(returnUserId: "user-1"));
 
-        var act = () => resolver.ResolveAsync(nyxIdAccessToken: "");
+        var act = () => resolver.ResolveAsync(CreateContext(""));
 
         await act.Should().ThrowAsync<ResponsesCallerScopeUnavailableException>()
             .WithMessage("*access token is required*");
@@ -32,7 +32,7 @@ public sealed class ResponsesCallerScopeResolverTests
     {
         var resolver = new NyxIdResponsesCallerScopeResolver(new StubUserResolver(returnUserId: "user-1"));
 
-        var act = () => resolver.ResolveAsync(nyxIdAccessToken: "   ");
+        var act = () => resolver.ResolveAsync(CreateContext("   "));
 
         await act.Should().ThrowAsync<ResponsesCallerScopeUnavailableException>();
     }
@@ -42,7 +42,7 @@ public sealed class ResponsesCallerScopeResolverTests
     {
         var resolver = new NyxIdResponsesCallerScopeResolver(new StubUserResolver(returnUserId: null));
 
-        var act = () => resolver.ResolveAsync("some-token");
+        var act = () => resolver.ResolveAsync(CreateContext("some-token"));
 
         await act.Should().ThrowAsync<ResponsesCallerScopeUnavailableException>()
             .WithMessage("*Could not resolve current NyxID user id*");
@@ -53,7 +53,7 @@ public sealed class ResponsesCallerScopeResolverTests
     {
         var resolver = new NyxIdResponsesCallerScopeResolver(new StubUserResolver(returnUserId: "   "));
 
-        var act = () => resolver.ResolveAsync("some-token");
+        var act = () => resolver.ResolveAsync(CreateContext("some-token"));
 
         await act.Should().ThrowAsync<ResponsesCallerScopeUnavailableException>();
     }
@@ -63,7 +63,7 @@ public sealed class ResponsesCallerScopeResolverTests
     {
         var resolver = new NyxIdResponsesCallerScopeResolver(new StubUserResolver(returnUserId: "  alice-1  "));
 
-        var scope = await resolver.ResolveAsync("token");
+        var scope = await resolver.ResolveAsync(CreateContext("token"));
 
         scope.ScopeId.Should().Be("alice-1");
         scope.OwnerSubject.Should().Be("alice-1");
@@ -77,11 +77,31 @@ public sealed class ResponsesCallerScopeResolverTests
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        var act = () => resolver.ResolveAsync("token", cts.Token);
+        var act = () => resolver.ResolveAsync(CreateContext("token"), cts.Token);
 
         // Stub honors cancellation token; ensures the resolver passes ct through.
         await act.Should().ThrowAsync<OperationCanceledException>();
     }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldContinueUsingInboundBearerForMeFallback()
+    {
+        var currentUserResolver = new StubUserResolver(returnUserId: "alice");
+        var resolver = new NyxIdResponsesCallerScopeResolver(currentUserResolver);
+
+        _ = await resolver.ResolveAsync(CreateContext(
+            "bearer-token",
+            identityToken: "identity-token",
+            delegationToken: "delegation-token"));
+
+        currentUserResolver.LastAccessToken.Should().Be("bearer-token");
+    }
+
+    private static ResponsesCallerScopeResolutionContext CreateContext(
+        string bearerToken,
+        string? identityToken = null,
+        string? delegationToken = null) =>
+        new(bearerToken, identityToken, delegationToken);
 
     private sealed class StubUserResolver : INyxIdCurrentUserResolver
     {
@@ -89,9 +109,12 @@ public sealed class ResponsesCallerScopeResolverTests
 
         public StubUserResolver(string? returnUserId) => _returnUserId = returnUserId;
 
+        public string? LastAccessToken { get; private set; }
+
         public Task<string?> ResolveCurrentUserIdAsync(string nyxIdAccessToken, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
+            LastAccessToken = nyxIdAccessToken;
             return Task.FromResult(_returnUserId);
         }
     }


### PR DESCRIPTION
## 摘要

iter159 cluster-640-first:typed caller-scope resolution context。

closes #1197

## 改动

- 新增 `ResponsesCallerScopeResolutionContext`(承载 bearer + Identity-Token + Delegation-Token)
- `IResponsesCallerScopeResolver.ResolveAsync(context)` 接受 typed input
- 三个 endpoint + 两个 facade thread 该 context
- 保留 `/me` fallback 和 scope/origin mismatch guard

## 不做

- 不实现 JWT/JWKS verifier(留 #1198 later-slice)
- 不新增 actor / readmodel / projection / envelope
- 不改 canon

## 验证

- dotnet build + full slnx test + guards 全 pass

⟦AI:AUTO-LOOP⟧
