### PR TITLE
iter163 #1220: workflow command_id 走 EventEnvelope.Id(first slice)

### DIFF
--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowRunCommandMetadataKeys.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowRunCommandMetadataKeys.cs
@@ -2,7 +2,6 @@ namespace Aevatar.Workflow.Application.Abstractions.Runs;
 
 public static class WorkflowRunCommandMetadataKeys
 {
-    public const string CommandId = "workflow.command_id";
     public const string SessionId = "workflow.session_id";
     public const string ChannelId = "workflow.channel_id";
     public const string ScopeId = "workflow.scope_id";

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs
@@ -24,7 +24,6 @@ internal sealed class WorkflowChatRequestEnvelopeFactory : ICommandEnvelopeFacto
         if (command.InputParts is { Count: > 0 })
             chatRequest.InputParts.Add(command.InputParts.Select(ToProto));
         AppendMetadata(chatRequest.Headers, context.Headers);
-        chatRequest.Headers[WorkflowRunCommandMetadataKeys.CommandId] = context.CommandId;
         chatRequest.Headers[WorkflowRunCommandMetadataKeys.SessionId] = sessionId;
         // Refactor (iter56/cluster-917-workflow-llm-control-metadata): old=Headers/Metadata bag for control fields, new=typed ChatRequestEvent.Telegram
         AppendMetadata(chatRequest.Metadata, command.Metadata);
@@ -33,7 +32,12 @@ internal sealed class WorkflowChatRequestEnvelopeFactory : ICommandEnvelopeFacto
 
         var envelope = new EventEnvelope
         {
-            Id = Guid.NewGuid().ToString("N"),
+            // Refactor (iter163/cluster-002-first):
+            //   Old pattern: workflow command id was written into ChatRequestEvent.Headers[workflow.command_id]
+            //                while Headers also carried transport context.
+            //   New principle: EventEnvelope.Id carries the workflow command identity;
+            //                  Headers stay transport-only.
+            Id = context.CommandId,
             Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
             Payload = Any.Pack(chatRequest),
             Route = EnvelopeRouteSemantics.CreateDirect("api", context.TargetId),

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
@@ -37,7 +37,6 @@ public sealed class WorkflowRunGAgent
     private const string CompletedStatus = "completed";
     private const string FailedStatus = "failed";
     private const string StoppedStatus = "stopped";
-    private const string WorkflowCommandIdMetadataKey = "workflow.command_id";
 
     private WorkflowDefinition? _compiledWorkflow;
     private readonly WorkflowParser _parser = new();
@@ -246,8 +245,13 @@ public sealed class WorkflowRunGAgent
             return;
         }
 
-        if (request.Headers.TryGetValue(WorkflowCommandIdMetadataKey, out var commandId) &&
-            !string.IsNullOrWhiteSpace(commandId))
+        // Refactor (iter163/cluster-002-first):
+        //   Old pattern: actor read command id from request.Headers[workflow.command_id],
+        //                making Headers a stable control flow channel.
+        //   New principle: actor reads command id from ActiveInboundEnvelope.Id,
+        //                  the typed envelope identity.
+        var commandId = ActiveInboundEnvelope?.Id;
+        if (!string.IsNullOrWhiteSpace(commandId))
         {
             await PersistDomainEventAsync(
                 new WorkflowCommandObservedEvent

--- a/test/Aevatar.Integration.Tests/WorkflowGAgentCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowGAgentCoverageTests.cs
@@ -1170,7 +1170,7 @@ public class WorkflowGAgentCoverageTests
     }
 
     [Fact]
-    public async Task WorkflowRunGAgent_ShouldPersistObservedWorkflowCommandId_FromChatMetadata()
+    public async Task WorkflowRunGAgent_ShouldPersistObservedWorkflowCommandId_FromInboundEnvelopeId()
     {
         var eventStore = new InMemoryEventStore();
         var agent = CreateRunAgent(eventStore: eventStore);
@@ -1186,13 +1186,24 @@ public class WorkflowGAgentCoverageTests
 
         (await agent.GetDescriptionAsync()).Should().Contain("bound");
 
-        await agent.HandleChatRequest(new ChatRequestEvent
+        var request = new ChatRequestEvent
         {
             Prompt = "hello",
             SessionId = "session-1",
             Headers =
             {
-                ["workflow.command_id"] = "cmd-123",
+                ["workflow.command_id"] = "legacy-header-must-not-win",
+            },
+        };
+        await agent.HandleEventAsync(new EventEnvelope
+        {
+            Id = "cmd-123",
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(request),
+            Route = EnvelopeRouteSemantics.CreateTopologyPublication("api", TopologyAudience.Self),
+            Propagation = new EnvelopePropagation
+            {
+                CorrelationId = "corr-123",
             },
         });
 

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationRegistrationAndExecutionTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationRegistrationAndExecutionTests.cs
@@ -295,6 +295,7 @@ public sealed class WorkflowApplicationRegistrationAndExecutionTests
         var envelope = factory.CreateEnvelope(command, context);
         var request = envelope.Payload.Unpack<ChatRequestEvent>();
 
+        envelope.Id.Should().Be("cmd-1");
         envelope.Route.GetTargetActorId().Should().Be("actor-1");
         envelope.Propagation!.CorrelationId.Should().Be("corr-1");
         envelope.Route.IsDirect().Should().BeTrue();
@@ -305,6 +306,7 @@ public sealed class WorkflowApplicationRegistrationAndExecutionTests
         request.Headers[WorkflowRunCommandMetadataKeys.ChannelId].Should().Be("slack#ops");
         request.Headers["source"].Should().Be("headers");
         request.Metadata[WorkflowRunCommandMetadataKeys.ChannelId].Should().Be("slack#request");
+        request.Headers.Should().NotContainKey("workflow.command_id");
         request.Headers.Should().NotContainKey(WorkflowRunCommandMetadataKeys.ScopeId);
         request.Headers.Should().NotContainKey("scope_id");
     }


### PR DESCRIPTION
## 摘要

iter163 #1220:workflow command identity 走 `EventEnvelope.Id`(Phase 9 r1 split first slice)。

**Old pattern**:`workflow.command_id` 通过 `ChatRequestEvent.Headers` 传递,`WorkflowRunGAgent` 从 `request.Headers` 读取持久化 `WorkflowCommandObservedEvent`。违反 CLAUDE.md「字段命名 / Metadata 决策树」(核心语义必须 typed)。

**New principle**:no-new-core collapse — `EventEnvelope.Id` 承载 command identity;Headers 仅留 transport/context;Actor 从 `ActiveInboundEnvelope.Id` 读取持久化 command observation。复用 `CommandContext.CommandId`、`EventEnvelope.Id`、`EnvelopePropagation.CorrelationId`、`WorkflowCommandObservedEvent.command_id`,无新核心抽象。

违反:[CLAUDE.md「字段命名 / Metadata 决策树」+「Command / Envelope / Dispatch」](../tree/auto-refact-dev/CLAUDE.md)。

## 范围

- `WorkflowChatRequestEnvelopeFactory.cs`:`envelope.Id = context.CommandId`,移除 Headers 写入
- `WorkflowRunGAgent.cs`:从 `ActiveInboundEnvelope.Id` 持久化,移除 Header fallback
- `WorkflowRunCommandMetadataKeys.cs`:删除 `CommandId` 常量
- 测试:envelope id assertion + Headers 不含 `workflow.command_id` + actor 不接受 Header fallback

## 验证

- `dotnet build aevatar.slnx --nologo`
- `dotnet test aevatar.slnx --nologo --no-build`
- `bash tools/ci/architecture_guards.sh` + `bash tools/ci/test_stability_guards.sh`

## Phase 9 split context

源自 #1218 Phase 9 r1 meta-judge `META_JUDGE_DONE:split:no-new-core-envelope-id-command-observation:broader-workflow-command-identity-design-pending`。
- First slice(本 PR):envelope id collapse,无新核心抽象
- Later slice(#1221 design-pending):resume/signal/stop 等 control envelope factories 是否扩展、跨命令一致性 doc/guard、多 workflow command 类型 typed payload 需求

Closes #1220

🤖 Auto-loop / codex-refactor-loop iter163

⟦AI:AUTO-LOOP⟧
