### PR TITLE
iter163 cluster-003: 移除 WorkflowSuspendedEvent metadata legacy fallback

### DIFF
--- a/.refactor-loop/runs/implement-iter163-cluster-003.md
+++ b/.refactor-loop/runs/implement-iter163-cluster-003.md
@@ -1,0 +1,27 @@
+# implement-iter163-cluster-003
+
+## Summary
+
+cluster-003-workflow-suspension-legacy-metadata 已实施。
+
+Old pattern: `WorkflowSuspendedEvent` 已有 typed `VariableName` / `Secure` / `RedactedOutput` 字段，但 AGUI 与 projection 仍从 `Metadata` 的 reserved legacy keys 读取 fallback。
+
+New pattern: AGUI 与 projection 只消费 typed suspension fields；`Metadata` 仅作为开放扩展数据，`variable` / `secure` / `input_mode` / `redacted_output` reserved legacy keys 被过滤且不参与控制语义。
+
+## Changes
+
+- `WorkflowHumanInteractionProjector` 删除 `Metadata` fallback，只从 typed suspension fields 构造 human interaction annotations。
+- `EventEnvelopeToWorkflowRunEventMapper` 同步删除 AGUI custom payload 的 `Metadata` fallback，并收窄共享 helper 为 typed string normalization + reserved-key filter。
+- `WorkflowExecutionArtifactMaterializationSupport` 删除 workflow suspended timeline metadata fallback，只从 typed fields 写入 reserved semantic entries。
+- `SecureInputModule` 更新 self-doc，明确生产 typed suspension fields，`Metadata` 不再承载 reserved secure input 语义。
+- Host API 相关测试改为 negative coverage：legacy reserved keys 存在时被忽略，只保留 open extension metadata。
+
+## Verification
+
+- `dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo --filter "FullyQualifiedName~WorkflowHumanInteractionProjectorTests|FullyQualifiedName~WorkflowExecutionProjectionProjectorTests|FullyQualifiedName~EventEnvelopeToAGUIEventMapperTests"`：通过，45 passed。
+- `dotnet build aevatar.slnx --nologo`：通过，0 errors，既有 warnings。
+- `dotnet test aevatar.slnx --nologo --no-build`：通过，0 failures；存在仓库既有条件 skip，未新增 skip。
+- `bash tools/ci/architecture_guards.sh`：通过。
+- `bash tools/ci/test_stability_guards.sh`：通过。
+
+⟦AI:AUTO-LOOP⟧

--- a/src/workflow/Aevatar.Workflow.Core/Modules/SecureInputModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/SecureInputModule.cs
@@ -90,9 +90,9 @@ public sealed class SecureInputModule : IEventModule<IWorkflowExecutionContext>
                 requestVariableName,
                 timeoutSeconds);
 
-            // Refactor (iter79/cluster-079-secure-input-suspension-metadata-bag):
-            //   Old pattern: WorkflowSuspendedEvent.Metadata string bag for secure/input_mode/redacted_output/variable
-            //   New principle (delete framing): typed bool secure + string redacted_output + reuse variable_name; Metadata open extension only; reserved keys read-only fallback
+            // Refactor (iter163/cluster-003-workflow-suspension-legacy-metadata):
+            //   Old pattern: reserved secure input values could be recovered from WorkflowSuspendedEvent.Metadata.
+            //   New principle: publish typed suspension fields; Metadata remains open extension data only.
             var suspended = new WorkflowSuspendedEvent
             {
                 RunId = runId,

--- a/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/EventEnvelopeToWorkflowRunEventMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/EventEnvelopeToWorkflowRunEventMapper.cs
@@ -610,13 +610,13 @@ public sealed class WorkflowSuspendedRunEventEnvelopeMappingHandler : IWorkflowR
 
         var evt = envelope.Payload.Unpack<WorkflowSuspendedEvent>();
         var ts = AGUIEventEnvelopeMappingHelpers.ToUnixMs(envelope.Timestamp);
-        // Refactor (iter79/cluster-079-secure-input-suspension-metadata-bag):
-        //   Old pattern: WorkflowSuspendedEvent.Metadata string bag for secure/input_mode/redacted_output/variable
-        //   New principle (delete framing): typed bool secure + string redacted_output + reuse variable_name; Metadata open extension only; reserved keys read-only fallback
+        // Refactor (iter163/cluster-003-workflow-suspension-legacy-metadata):
+        //   Old pattern: WorkflowSuspendedEvent.Metadata fallback for variable/secure/redacted_output reserved keys.
+        //   New principle: typed suspension fields are the single source; Metadata is open extension data only.
         var metadata = WorkflowSuspendedSecureInputMetadata.FilterOpenExtensionMetadata(evt.Metadata);
-        var variableName = WorkflowSuspendedSecureInputMetadata.ResolveVariableName(evt.VariableName, evt.Metadata);
-        var secure = WorkflowSuspendedSecureInputMetadata.ResolveSecure(evt.Secure, evt.Metadata);
-        var redactedOutput = WorkflowSuspendedSecureInputMetadata.ResolveRedactedOutput(evt.RedactedOutput, evt.Metadata);
+        var variableName = WorkflowSuspendedSecureInputMetadata.ResolveTypedString(evt.VariableName);
+        var secure = evt.Secure;
+        var redactedOutput = WorkflowSuspendedSecureInputMetadata.ResolveTypedString(evt.RedactedOutput);
 
         events =
         [
@@ -670,21 +670,10 @@ internal static class WorkflowSuspendedSecureInputMetadata
         return filtered;
     }
 
-    public static string ResolveVariableName(string? typedValue, IDictionary<string, string> metadata) =>
+    public static string ResolveTypedString(string? typedValue) =>
         !string.IsNullOrWhiteSpace(typedValue)
             ? typedValue
-            : metadata.TryGetValue("variable", out var legacy) ? legacy : string.Empty;
-
-    public static bool ResolveSecure(bool typedValue, IDictionary<string, string> metadata) =>
-        typedValue ||
-        (metadata.TryGetValue("secure", out var legacy) &&
-         bool.TryParse(legacy, out var parsed) &&
-         parsed);
-
-    public static string ResolveRedactedOutput(string? typedValue, IDictionary<string, string> metadata) =>
-        !string.IsNullOrWhiteSpace(typedValue)
-            ? typedValue
-            : metadata.TryGetValue("redacted_output", out var legacy) ? legacy : string.Empty;
+            : string.Empty;
 }
 
 public sealed class WorkflowWaitingSignalRunEventEnvelopeMappingHandler : IWorkflowRunEventEnvelopeMappingHandler

--- a/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/WorkflowHumanInteractionProjector.cs
+++ b/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/WorkflowHumanInteractionProjector.cs
@@ -35,9 +35,9 @@ public sealed class WorkflowHumanInteractionProjector
         if (string.IsNullOrWhiteSpace(evt.DeliveryTargetId))
             return;
 
-        // Refactor (iter79/cluster-079-secure-input-suspension-metadata-bag):
-        //   Old pattern: WorkflowSuspendedEvent.Metadata string bag for secure/input_mode/redacted_output/variable
-        //   New principle (delete framing): typed bool secure + string redacted_output + reuse variable_name; Metadata open extension only; reserved keys read-only fallback
+        // Refactor (iter163/cluster-003-workflow-suspension-legacy-metadata):
+        //   Old pattern: WorkflowSuspendedEvent.Metadata fallback for variable/secure/redacted_output reserved keys.
+        //   New principle: typed suspension fields are the single source; Metadata is open extension data only.
         var annotations = BuildAnnotations(evt);
 
         var request = new HumanInteractionRequest
@@ -71,9 +71,9 @@ public sealed class WorkflowHumanInteractionProjector
     private static Dictionary<string, string> BuildAnnotations(WorkflowSuspendedEvent evt)
     {
         var annotations = WorkflowSuspendedSecureInputMetadata.FilterOpenExtensionMetadata(evt.Metadata);
-        var variableName = WorkflowSuspendedSecureInputMetadata.ResolveVariableName(evt.VariableName, evt.Metadata);
-        var secure = WorkflowSuspendedSecureInputMetadata.ResolveSecure(evt.Secure, evt.Metadata);
-        var redactedOutput = WorkflowSuspendedSecureInputMetadata.ResolveRedactedOutput(evt.RedactedOutput, evt.Metadata);
+        var variableName = WorkflowSuspendedSecureInputMetadata.ResolveTypedString(evt.VariableName);
+        var secure = evt.Secure;
+        var redactedOutput = WorkflowSuspendedSecureInputMetadata.ResolveTypedString(evt.RedactedOutput);
 
         if (!string.IsNullOrWhiteSpace(variableName))
             annotations["variable"] = variableName;

--- a/src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowExecutionArtifactMaterializationSupport.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowExecutionArtifactMaterializationSupport.cs
@@ -278,9 +278,9 @@ internal static class WorkflowExecutionArtifactMaterializationSupport
         step.SuspensionTimeoutSeconds = evt.TimeoutSeconds == 0 ? null : evt.TimeoutSeconds;
         step.RequestedVariableName = evt.VariableName ?? string.Empty;
         readModel.CompletionStatus = WorkflowExecutionCompletionStatus.WaitingForSignal;
-        // Refactor (iter79/cluster-079-secure-input-suspension-metadata-bag):
-        //   Old pattern: WorkflowSuspendedEvent.Metadata string bag for secure/input_mode/redacted_output/variable
-        //   New principle (delete framing): typed bool secure + string redacted_output + reuse variable_name; Metadata open extension only; reserved keys read-only fallback
+        // Refactor (iter163/cluster-003-workflow-suspension-legacy-metadata):
+        //   Old pattern: WorkflowSuspendedEvent.Metadata fallback for variable/secure/redacted_output reserved keys.
+        //   New principle: typed suspension fields are the single source; Metadata is open extension data only.
         var timelineMetadata = BuildWorkflowSuspendedTimelineMetadata(evt);
         AddTimeline(
             readModel.Timeline,
@@ -297,18 +297,9 @@ internal static class WorkflowExecutionArtifactMaterializationSupport
     private static Dictionary<string, string> BuildWorkflowSuspendedTimelineMetadata(WorkflowSuspendedEvent evt)
     {
         var metadata = FilterOpenExtensionMetadata(evt.Metadata);
-        var variableName = !string.IsNullOrWhiteSpace(evt.VariableName)
-            ? evt.VariableName
-            : evt.Metadata.TryGetValue("variable", out var legacyVariable) ? legacyVariable : string.Empty;
-        var secure = evt.Secure ||
-                     (evt.Metadata.TryGetValue("secure", out var legacySecure) &&
-                      bool.TryParse(legacySecure, out var parsedSecure) &&
-                      parsedSecure);
-        var redactedOutput = !string.IsNullOrWhiteSpace(evt.RedactedOutput)
-            ? evt.RedactedOutput
-            : evt.Metadata.TryGetValue("redacted_output", out var legacyRedactedOutput)
-                ? legacyRedactedOutput
-                : string.Empty;
+        var variableName = !string.IsNullOrWhiteSpace(evt.VariableName) ? evt.VariableName : string.Empty;
+        var secure = evt.Secure;
+        var redactedOutput = !string.IsNullOrWhiteSpace(evt.RedactedOutput) ? evt.RedactedOutput : string.Empty;
 
         if (!string.IsNullOrWhiteSpace(variableName))
             metadata["variable"] = variableName;

--- a/test/Aevatar.Workflow.Host.Api.Tests/EventEnvelopeToAGUIEventMapperTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/EventEnvelopeToAGUIEventMapperTests.cs
@@ -360,7 +360,7 @@ public sealed class EventEnvelopeToAGUIEventMapperTests
     }
 
     [Fact]
-    public void WorkflowSuspended_ShouldFallbackLegacySecureInputMetadataToTypedPayload()
+    public void WorkflowSuspended_ShouldIgnoreLegacySecureInputMetadataReservedKeys()
     {
         var suspended = CreateMapper().Map(WrapCommitted(new WorkflowSuspendedEvent
         {
@@ -380,9 +380,9 @@ public sealed class EventEnvelopeToAGUIEventMapperTests
 
         suspended.Should().ContainSingle();
         var request = suspended[0].Custom.Payload.Unpack<WorkflowHumanInputRequestCustomPayload>();
-        request.VariableName.Should().Be("api_key");
-        request.Secure.Should().BeTrue();
-        request.RedactedOutput.Should().Be("[legacy captured]");
+        request.VariableName.Should().BeEmpty();
+        request.Secure.Should().BeFalse();
+        request.RedactedOutput.Should().BeEmpty();
         request.Metadata.Should().ContainKey("source").WhoseValue.Should().Be("legacy-test");
         request.Metadata.Should().NotContainKey("variable");
         request.Metadata.Should().NotContainKey("secure");

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionProjectionProjectorTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionProjectionProjectorTests.cs
@@ -562,7 +562,7 @@ public sealed class WorkflowExecutionProjectionProjectorTests
     }
 
     [Fact]
-    public void ApplyObservedPayloadToReport_ShouldFallbackLegacyOnlySecureInputMetadata()
+    public void ApplyObservedPayloadToReport_ShouldIgnoreLegacyOnlySecureInputMetadataReservedKeys()
     {
         var report = new WorkflowRunInsightReportDocument
         {
@@ -597,9 +597,9 @@ public sealed class WorkflowExecutionProjectionProjectorTests
             x.Stage == "workflow.suspended" &&
             x.StepId == "secure-input");
         suspendedTimeline.Data.Should().ContainKey("source").WhoseValue.Should().Be("legacy-test");
-        suspendedTimeline.Data.Should().ContainKey("variable").WhoseValue.Should().Be("api_key");
-        suspendedTimeline.Data.Should().ContainKey("secure").WhoseValue.Should().Be("true");
-        suspendedTimeline.Data.Should().ContainKey("redacted_output").WhoseValue.Should().Be("[legacy captured]");
+        suspendedTimeline.Data.Should().NotContainKey("variable");
+        suspendedTimeline.Data.Should().NotContainKey("secure");
+        suspendedTimeline.Data.Should().NotContainKey("redacted_output");
         suspendedTimeline.Data.Should().NotContainKey("input_mode");
     }
 

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowHumanInteractionProjectorTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowHumanInteractionProjectorTests.cs
@@ -64,7 +64,7 @@ public sealed class WorkflowHumanInteractionProjectorTests
     }
 
     [Fact]
-    public async Task ProjectAsync_ShouldFallbackLegacySecureInputMetadata()
+    public async Task ProjectAsync_ShouldIgnoreLegacySecureInputMetadataReservedKeys()
     {
         var port = new RecordingHumanInteractionPort();
         var projector = new WorkflowHumanInteractionProjector(port);
@@ -97,9 +97,9 @@ public sealed class WorkflowHumanInteractionProjectorTests
         port.Calls.Should().ContainSingle();
         var annotations = port.Calls[0].request.Annotations;
         annotations.Should().ContainKey("source").WhoseValue.Should().Be("legacy-test");
-        annotations.Should().ContainKey("variable").WhoseValue.Should().Be("api_key");
-        annotations.Should().ContainKey("secure").WhoseValue.Should().Be("true");
-        annotations.Should().ContainKey("redacted_output").WhoseValue.Should().Be("[legacy captured]");
+        annotations.Should().NotContainKey("variable");
+        annotations.Should().NotContainKey("secure");
+        annotations.Should().NotContainKey("redacted_output");
         annotations.Should().NotContainKey("input_mode");
     }
 


### PR DESCRIPTION
## 摘要

iter163 cluster-003:移除 `WorkflowSuspendedEvent` metadata legacy fallback。`requires_design: false` 直接 implement(无 design issue)。

**Old pattern**:`WorkflowSuspendedEvent` 已有 typed `secure` / `variable` / `redacted` 字段,但 projection / AGUI 仍从 `evt.Metadata` 读取 reserved values 作 fallback,违反 typed contract 单一来源原则。

**New principle**:Projection 与 AGUI 只消费 typed suspension fields;`Metadata` 仅留 open extension data;reserved legacy keys ignore / filter。

违反:[CLAUDE.md「字段命名与 Metadata 决策树」](../tree/auto-refact-dev/CLAUDE.md)。

## 范围

- `WorkflowHumanInteractionProjector.cs`:移除 `evt.Metadata` fallback for `variable` / `secure` / `redacted_output`
- `WorkflowExecutionArtifactMaterializationSupport.cs`:移除 timeline metadata fallback
- `SecureInputModule` + `EventEnvelopeToWorkflowRunEventMapper`:验证 typed 流端到端正确
- 测试更新 + negative test:证明 metadata fallback 不再触发

## 验证

- `dotnet build aevatar.slnx --nologo`
- `dotnet test aevatar.slnx --nologo --no-build`
- `bash tools/ci/architecture_guards.sh` + `bash tools/ci/test_stability_guards.sh`

🤖 Auto-loop / codex-refactor-loop iter163 cluster-003 direct implement

⟦AI:AUTO-LOOP⟧
