### PR TITLE
iter164 cluster-003: 移除 draft-run AGUI projection 对 raw frames 依赖

### DIFF
--- a/src/platform/Aevatar.GAgentService.Abstractions/ScopeGAgents/ScopeGAgentAguiEventMapper.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/ScopeGAgents/ScopeGAgentAguiEventMapper.cs
@@ -129,6 +129,20 @@ public static class ScopeGAgentAguiEventMapper
         return null;
     }
 
+    public static AGUIEvent? TryMapExplicitSessionObservation(EventEnvelope envelope)
+    {
+        ArgumentNullException.ThrowIfNull(envelope);
+
+        // Refactor (iter164/cluster-003-draft-run):
+        //   Old pattern: draft-run projection reused the broad live AI/tool mapper and treated raw frames as AGUI observations.
+        //   New principle: draft-run session projection only treats a wrapped AGUIEvent as an explicit observation contract.
+        var payload = envelope.Payload;
+        if (payload?.Is(AGUIEvent.Descriptor) != true)
+            return null;
+
+        return payload.Unpack<AGUIEvent>();
+    }
+
     private static AGUIEvent MapTextCompletion(string sessionId, string? content)
     {
         if (!string.IsNullOrEmpty(content))

--- a/src/platform/Aevatar.GAgentService.Projection/Projectors/GAgentDraftRunSessionEventProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Projectors/GAgentDraftRunSessionEventProjector.cs
@@ -35,7 +35,10 @@ public sealed class GAgentDraftRunSessionEventProjector
         if (committedEntries.Count > 0)
             return committedEntries;
 
-        var mapped = ScopeGAgentAguiEventMapper.TryMap(envelope);
+        // Refactor (iter164/cluster-003-draft-run):
+        //   Old pattern: raw TextMessage*/Tool* envelopes were projected as draft-run AGUI session events.
+        //   New principle: draft-run session observation only accepts committed completions above or explicit AGUI observation frames here.
+        var mapped = ScopeGAgentAguiEventMapper.TryMapExplicitSessionObservation(envelope);
         if (mapped == null)
             return EmptyEntries;
 

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsStreamTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsStreamTests.cs
@@ -287,7 +287,7 @@ public sealed class ScopeServiceEndpointsStreamTests
     }
 
     [Fact]
-    public async Task GAgentDraftRunSessionEventProjector_ShouldPublishMappedAguiEvent_ToCommandSession()
+    public async Task GAgentDraftRunSessionEventProjector_ShouldIgnoreRawTextFrame_WithoutCommittedCompletion()
     {
         var sessionHub = new RecordingProjectionSessionEventHub();
         var projector = new GAgentDraftRunSessionEventProjector(sessionHub);
@@ -310,6 +310,40 @@ public sealed class ScopeServiceEndpointsStreamTests
                 {
                     SessionId = "msg-1",
                     Delta = "hello",
+                }),
+            },
+            CancellationToken.None);
+
+        sessionHub.Published.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GAgentDraftRunSessionEventProjector_ShouldPublishExplicitAguiObservation_ToCommandSession()
+    {
+        var sessionHub = new RecordingProjectionSessionEventHub();
+        var projector = new GAgentDraftRunSessionEventProjector(sessionHub);
+        var context = new GAgentDraftRunProjectionContext
+        {
+            RootActorId = "actor-1",
+            SessionId = "cmd-1",
+            ProjectionKind = "service-draft-run-session",
+        };
+
+        await projector.ProjectAsync(
+            context,
+            new EventEnvelope
+            {
+                Propagation = new EnvelopePropagation
+                {
+                    CorrelationId = "cmd-1",
+                },
+                Payload = Any.Pack(new AGUIEvent
+                {
+                    TextMessageContent = new Aevatar.Presentation.AGUI.TextMessageContentEvent
+                    {
+                        MessageId = "msg-1",
+                        Delta = "hello",
+                    },
                 }),
             },
             CancellationToken.None);
@@ -509,7 +543,7 @@ public sealed class ScopeServiceEndpointsStreamTests
     }
 
     [Fact]
-    public async Task GAgentDraftRunSessionEventProjector_ShouldAppendRunFinished_ForLiveTextMessageEnd()
+    public async Task GAgentDraftRunSessionEventProjector_ShouldIgnoreRawTextMessageEnd_WithoutCommittedCompletion()
     {
         var sessionHub = new RecordingProjectionSessionEventHub();
         var projector = new GAgentDraftRunSessionEventProjector(sessionHub);
@@ -535,12 +569,7 @@ public sealed class ScopeServiceEndpointsStreamTests
             },
             CancellationToken.None);
 
-        sessionHub.Published.Should().HaveCount(2);
-        sessionHub.Published[0].Event.TextMessageEnd.Should().NotBeNull();
-        sessionHub.Published[0].Event.TextMessageEnd!.MessageId.Should().Be("msg-1");
-        sessionHub.Published[1].Event.RunFinished.Should().NotBeNull();
-        sessionHub.Published[1].Event.RunFinished!.ThreadId.Should().Be("actor-1");
-        sessionHub.Published[1].Event.RunFinished.RunId.Should().Be("cmd-1");
+        sessionHub.Published.Should().BeEmpty();
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/ScopeGAgentAguiEventMapperTests.cs
+++ b/test/Aevatar.GAgentService.Tests/ScopeGAgentAguiEventMapperTests.cs
@@ -118,6 +118,28 @@ public sealed class ScopeGAgentAguiEventMapperTests
     }
 
     [Fact]
+    public void TryMapExplicitSessionObservation_ShouldOnlyMapWrappedAguiEvent()
+    {
+        ScopeGAgentAguiEventMapper.TryMapExplicitSessionObservation(
+            BuildEventEnvelope(new AiTextContent { Delta = "d", SessionId = "s1" }))
+            .Should()
+            .BeNull();
+
+        var wrapped = new AGUIEvent
+        {
+            TextMessageContent = new Aevatar.Presentation.AGUI.TextMessageContentEvent
+            {
+                MessageId = "m1",
+                Delta = "hello",
+            },
+        };
+
+        ScopeGAgentAguiEventMapper.TryMapExplicitSessionObservation(BuildEventEnvelope(wrapped))
+            .Should()
+            .BeEquivalentTo(wrapped);
+    }
+
+    [Fact]
     public void TryMap_ShouldHandleUnknownPayloadAndWrappedAguiEvent()
     {
         ScopeGAgentAguiEventMapper.TryMap(new EventEnvelope


### PR DESCRIPTION
## 摘要

iter164 cluster-003:移除 draft-run AGUI projection 对 raw `TextMessage*`/`Tool*` frames 的依赖(direct implement,requires_design: false)。

**Old pattern**:`GAgentDraftRunSessionEventProjector` 把 raw `TextMessage*` / `Tool*` envelopes 映射成 AGUI session events,即使无 committed completion 也 emit。违反 CLAUDE.md「projection 只消费 committed facts」。

**New principle**:Draft-run AGUI projection 仅从 committed observed payloads / explicit session-observation contract emit,non-durable 性质不混 readmodel projection。

违反:[CLAUDE.md「权威状态 / ReadModel / Projection」](../tree/auto-refact-dev/CLAUDE.md):projection 仅消费 committed facts。

## 范围

- `GAgentDraftRunSessionEventProjector.cs`:移除 raw frame 映射
- `ScopeGAgentAguiEventMapper.cs`:调整映射边界
- 测试 + negative test

🤖 Auto-loop / codex-refactor-loop iter164 c3 direct implement

⟦AI:AUTO-LOOP⟧
