### PR TITLE
iter165 cluster-001: 移除 startup services 的 Task.Delay retry loop

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/ChannelBotRegistrationStartupService.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/ChannelBotRegistrationStartupService.cs
@@ -8,9 +8,9 @@ namespace Aevatar.GAgents.Channel.Runtime;
 /// at application startup so the query-side read model can catch up through
 /// the committed-state projection activation path after a restart.
 ///
-/// StartAsync awaits the activation with retries so the host does not
-/// accept HTTP requests until the registration projection binder is active.
-/// Request paths must not activate or prime this projection themselves.
+/// StartAsync dispatches one activation attempt. Retry/backoff belongs to
+/// actor/runtime scheduling infrastructure, and request paths must not
+/// activate or prime this projection themselves.
 /// </summary>
 internal sealed class ChannelBotRegistrationStartupService : IHostedService
 {
@@ -18,8 +18,7 @@ internal sealed class ChannelBotRegistrationStartupService : IHostedService
     // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=public rebuild surfaces, new=internal Runtime startup helper only
     // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=manual projection refresh surface, new=host startup projection activation
     // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=operator-triggered rebuild, new=activation-only startup warm-up
-    private const int MaxRetries = 5;
-    private static readonly TimeSpan InitialDelay = TimeSpan.FromSeconds(2);
+    // Refactor (iter165/cluster-001): Old pattern: startup owned a Task.Delay retry loop for projection activation. New principle: startup dispatches one bootstrap activation attempt; retry/backoff belongs to actor/runtime scheduling infrastructure, not this hosted service.
 
     private readonly ChannelBotRegistrationProjectionBootstrapActivator _projectionActivator;
     private readonly ILogger<ChannelBotRegistrationStartupService> _logger;
@@ -34,40 +33,22 @@ internal sealed class ChannelBotRegistrationStartupService : IHostedService
 
     public async Task StartAsync(CancellationToken ct)
     {
-        var delay = InitialDelay;
-        for (var attempt = 1; attempt <= MaxRetries; attempt++)
+        try
         {
-            try
-            {
-                await _projectionActivator.ActivateWellKnownCatalogAsync(ct);
-                _logger.LogInformation(
-                    "Channel bot registration projection scope activated for {ActorId} (attempt {Attempt})",
-                    ChannelBotRegistrationGAgent.WellKnownId, attempt);
-                return;
-            }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested)
-            {
-                return;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex,
-                    "Failed to activate channel bot registration projection scope (attempt {Attempt}/{MaxRetries})",
-                    attempt, MaxRetries);
-
-                if (attempt < MaxRetries)
-                    await Task.Delay(delay, ct);
-                delay *= 2; // exponential backoff
-            }
+            await _projectionActivator.ActivateWellKnownCatalogAsync(ct);
+            _logger.LogInformation(
+                "Channel bot registration projection scope activated for {ActorId}",
+                ChannelBotRegistrationGAgent.WellKnownId);
         }
-
-        // All retries exhausted — let the host start in degraded mode.
-        // Registrations may appear missing until the projection binder is
-        // activated by a later host restart or operator intervention.
-        _logger.LogError(
-            "Channel bot registration projection activation failed after {MaxRetries} attempts — " +
-            "registrations may not be visible until activation is re-triggered",
-            MaxRetries);
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Channel bot registration projection activation failed; registrations may not be visible until activation is re-triggered");
+        }
     }
 
     public Task StopAsync(CancellationToken ct) => Task.CompletedTask;

--- a/agents/Aevatar.GAgents.Device/DeviceRegistrationStartupService.cs
+++ b/agents/Aevatar.GAgents.Device/DeviceRegistrationStartupService.cs
@@ -5,8 +5,7 @@ namespace Aevatar.GAgents.Device;
 
 internal sealed class DeviceRegistrationStartupService : IHostedService
 {
-    private const int MaxRetries = 5;
-    private static readonly TimeSpan InitialDelay = TimeSpan.FromSeconds(2);
+    // Refactor (iter165/cluster-001): Old pattern: startup owned a Task.Delay retry loop for projection activation. New principle: startup dispatches one bootstrap activation attempt; retry/backoff belongs to actor/runtime scheduling infrastructure, not this hosted service.
 
     private readonly DeviceRegistrationProjectionBootstrapActivator _projectionActivator;
     private readonly ILogger<DeviceRegistrationStartupService> _logger;
@@ -21,40 +20,22 @@ internal sealed class DeviceRegistrationStartupService : IHostedService
 
     public async Task StartAsync(CancellationToken ct)
     {
-        var delay = InitialDelay;
-        for (var attempt = 1; attempt <= MaxRetries; attempt++)
+        try
         {
-            try
-            {
-                await _projectionActivator.ActivateWellKnownRegistryAsync(ct);
-                _logger.LogInformation(
-                    "Device registration projection scope activated for {ActorId} (attempt {Attempt})",
-                    DeviceRegistrationGAgent.WellKnownId,
-                    attempt);
-                return;
-            }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested)
-            {
-                return;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(
-                    ex,
-                    "Failed to activate device registration projection scope (attempt {Attempt}/{MaxRetries})",
-                    attempt,
-                    MaxRetries);
-
-                if (attempt < MaxRetries)
-                    await Task.Delay(delay, ct);
-
-                delay *= 2;
-            }
+            await _projectionActivator.ActivateWellKnownRegistryAsync(ct);
+            _logger.LogInformation(
+                "Device registration projection scope activated for {ActorId}",
+                DeviceRegistrationGAgent.WellKnownId);
         }
-
-        _logger.LogError(
-            "Device registration projection scope activation failed after {MaxRetries} attempts",
-            MaxRetries);
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Device registration projection scope activation failed; the host will continue in degraded mode");
+        }
     }
 
     public Task StopAsync(CancellationToken ct) => Task.CompletedTask;

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogStartupService.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogStartupService.cs
@@ -8,8 +8,7 @@ namespace Aevatar.GAgents.Scheduled;
 
 internal sealed class UserAgentCatalogStartupService : IHostedService
 {
-    private const int MaxRetries = 5;
-    private static readonly TimeSpan InitialDelay = TimeSpan.FromSeconds(2);
+    // Refactor (iter165/cluster-001): Old pattern: startup owned a Task.Delay retry loop for projection activation. New principle: startup dispatches one bootstrap activation attempt; retry/backoff belongs to actor/runtime scheduling infrastructure, not this hosted service.
     private static readonly string LegacyProjectionScopeActorId = ProjectionScopeActorId.Build(
         new ProjectionRuntimeScopeKey(
             UserAgentCatalogGAgent.WellKnownId,
@@ -35,41 +34,23 @@ internal sealed class UserAgentCatalogStartupService : IHostedService
 
     public async Task StartAsync(CancellationToken ct)
     {
-        var delay = InitialDelay;
-        for (var attempt = 1; attempt <= MaxRetries; attempt++)
+        try
         {
-            try
-            {
-                await CleanupLegacyProjectionScopeAsync(ct);
-                await _projectionActivator.ActivateWellKnownCatalogAsync(ct);
-                _logger.LogInformation(
-                    "User agent catalog projection scope activated for {ActorId} (attempt {Attempt})",
-                    UserAgentCatalogGAgent.WellKnownId,
-                    attempt);
-                return;
-            }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested)
-            {
-                return;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(
-                    ex,
-                    "Failed to activate user agent catalog projection scope (attempt {Attempt}/{MaxRetries})",
-                    attempt,
-                    MaxRetries);
-
-                if (attempt < MaxRetries)
-                    await Task.Delay(delay, ct);
-
-                delay *= 2;
-            }
+            await CleanupLegacyProjectionScopeAsync(ct);
+            await _projectionActivator.ActivateWellKnownCatalogAsync(ct);
+            _logger.LogInformation(
+                "User agent catalog projection scope activated for {ActorId}",
+                UserAgentCatalogGAgent.WellKnownId);
         }
-
-        _logger.LogError(
-            "User agent catalog projection scope activation failed after {MaxRetries} attempts",
-            MaxRetries);
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "User agent catalog projection scope activation failed; the host will continue in degraded mode");
+        }
     }
 
     public Task StopAsync(CancellationToken ct) => Task.CompletedTask;

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelBotRegistrationStartupServiceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelBotRegistrationStartupServiceTests.cs
@@ -36,4 +36,26 @@ public sealed class ChannelBotRegistrationStartupServiceTests
                 request.Mode == ProjectionRuntimeMode.DurableMaterialization),
             Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task StartAsync_WhenActivationFails_DispatchesOnlyOneActivationAttempt()
+    {
+        var activationService = Substitute.For<IProjectionScopeActivationService<ChannelBotRegistrationMaterializationRuntimeLease>>();
+        activationService.EnsureAsync(Arg.Any<ProjectionScopeStartRequest>(), Arg.Any<CancellationToken>())
+            .Returns<Task<ChannelBotRegistrationMaterializationRuntimeLease>>(_ => throw new InvalidOperationException("boom"));
+
+        var projectionActivator = new ChannelBotRegistrationProjectionBootstrapActivator(activationService);
+        var startupService = new ChannelBotRegistrationStartupService(
+            projectionActivator,
+            NullLogger<ChannelBotRegistrationStartupService>.Instance);
+
+        await startupService.StartAsync(CancellationToken.None);
+
+        await activationService.Received(1).EnsureAsync(
+            Arg.Is<ProjectionScopeStartRequest>(request =>
+                request.RootActorId == ChannelBotRegistrationGAgent.WellKnownId &&
+                request.ProjectionKind == ChannelBotRegistrationProjectionBootstrapActivator.ProjectionKind &&
+                request.Mode == ProjectionRuntimeMode.DurableMaterialization),
+            Arg.Any<CancellationToken>());
+    }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRuntimeSourceRegressionTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRuntimeSourceRegressionTests.cs
@@ -23,6 +23,25 @@ public sealed class ChannelRuntimeSourceRegressionTests
             "no-op lease abstraction deleted per Phase 8 r1 reject");
     }
 
+    [Fact]
+    public void Startup_projection_activation_must_not_reintroduce_delay_backed_retry_loop()
+    {
+        foreach (var relativeFile in new[]
+                 {
+                     "agents/Aevatar.GAgents.Channel.Runtime/ChannelBotRegistrationStartupService.cs",
+                     "agents/Aevatar.GAgents.Device/DeviceRegistrationStartupService.cs",
+                     "agents/Aevatar.GAgents.Scheduled/UserAgentCatalogStartupService.cs",
+                 })
+        {
+            var source = ReadRepositoryFile(relativeFile);
+
+            source.Should().NotContain("await Task." + "Delay(",
+                $"{relativeFile} should dispatch one activation attempt; retry/backoff belongs to actor/runtime scheduling infrastructure");
+            source.Should().NotContain("MaxRetries",
+                $"{relativeFile} should not own projection activation retry state in the hosted service");
+        }
+    }
+
     private static string ReadRepositorySources(params string[] relativeDirectories)
     {
         var repositoryRoot = GetRepositoryRoot();
@@ -40,6 +59,12 @@ public sealed class ChannelRuntimeSourceRegressionTests
         }
 
         return builder.ToString();
+    }
+
+    private static string ReadRepositoryFile(string relativeFile)
+    {
+        var repositoryRoot = GetRepositoryRoot();
+        return File.ReadAllText(Path.Combine(repositoryRoot, relativeFile), Encoding.UTF8);
     }
 
     private static string GetRepositoryRoot()

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceRegistrationStartupServiceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceRegistrationStartupServiceTests.cs
@@ -1,0 +1,61 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.GAgents.Device;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+public sealed class DeviceRegistrationStartupServiceTests
+{
+    [Fact]
+    public async Task StartAsync_ActivatesProjection()
+    {
+        var activationService = Substitute.For<IProjectionScopeActivationService<DeviceRegistrationMaterializationRuntimeLease>>();
+        activationService.EnsureAsync(Arg.Any<ProjectionScopeStartRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new DeviceRegistrationMaterializationRuntimeLease(
+                new DeviceRegistrationMaterializationContext
+                {
+                    RootActorId = DeviceRegistrationGAgent.WellKnownId,
+                    ProjectionKind = DeviceRegistrationProjectionBootstrapActivator.ProjectionKind,
+                })));
+
+        var projectionActivator = new DeviceRegistrationProjectionBootstrapActivator(activationService);
+        var startupService = new DeviceRegistrationStartupService(
+            projectionActivator,
+            NullLogger<DeviceRegistrationStartupService>.Instance);
+
+        await startupService.StartAsync(CancellationToken.None);
+
+        await activationService.Received(1).EnsureAsync(
+            Arg.Is<ProjectionScopeStartRequest>(request =>
+                request.RootActorId == DeviceRegistrationGAgent.WellKnownId &&
+                request.ProjectionKind == DeviceRegistrationProjectionBootstrapActivator.ProjectionKind &&
+                request.Mode == ProjectionRuntimeMode.DurableMaterialization),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenActivationFails_DispatchesOnlyOneActivationAttempt()
+    {
+        var activationService = Substitute.For<IProjectionScopeActivationService<DeviceRegistrationMaterializationRuntimeLease>>();
+        activationService.EnsureAsync(Arg.Any<ProjectionScopeStartRequest>(), Arg.Any<CancellationToken>())
+            .Returns<Task<DeviceRegistrationMaterializationRuntimeLease>>(_ => throw new InvalidOperationException("boom"));
+
+        var projectionActivator = new DeviceRegistrationProjectionBootstrapActivator(activationService);
+        var startupService = new DeviceRegistrationStartupService(
+            projectionActivator,
+            NullLogger<DeviceRegistrationStartupService>.Instance);
+
+        await startupService.StartAsync(CancellationToken.None);
+
+        await activationService.Received(1).EnsureAsync(
+            Arg.Is<ProjectionScopeStartRequest>(request =>
+                request.RootActorId == DeviceRegistrationGAgent.WellKnownId &&
+                request.ProjectionKind == DeviceRegistrationProjectionBootstrapActivator.ProjectionKind &&
+                request.Mode == ProjectionRuntimeMode.DurableMaterialization),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentCatalogStartupServiceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentCatalogStartupServiceTests.cs
@@ -45,6 +45,27 @@ public sealed class UserAgentCatalogStartupServiceTests
         actorRuntime.DestroyedActorIds.Should().ContainSingle().Which.Should().Be(legacyScopeActorId);
     }
 
+    [Fact]
+    public async Task StartAsync_WhenActivationFails_DispatchesOnlyOneActivationAttempt()
+    {
+        var operations = new ConcurrentQueue<string>();
+        var activationService = new FailingActivationService(operations);
+        var projectionActivator = new UserAgentCatalogProjectionBootstrapActivator(activationService);
+        var actorRuntime = new RecordingActorRuntime(operations, legacyScopeExists: false);
+        var streamProvider = new RecordingStreamProvider(operations);
+        var service = new UserAgentCatalogStartupService(
+            projectionActivator,
+            actorRuntime,
+            streamProvider,
+            NullLogger<UserAgentCatalogStartupService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+
+        activationService.AttemptCount.Should().Be(1);
+        operations.Should().ContainSingle(operation =>
+            operation == $"projection:ensure:{UserAgentCatalogGAgent.WellKnownId}:{UserAgentCatalogProjectionBootstrapActivator.ProjectionKind}");
+    }
+
     private sealed class RecordingActivationService(ConcurrentQueue<string> operations)
         : IProjectionScopeActivationService<UserAgentCatalogMaterializationRuntimeLease>
     {
@@ -62,6 +83,21 @@ public sealed class UserAgentCatalogStartupServiceTests
                     RootActorId = request.RootActorId,
                     ProjectionKind = request.ProjectionKind,
                 }));
+        }
+    }
+
+    private sealed class FailingActivationService(ConcurrentQueue<string> operations)
+        : IProjectionScopeActivationService<UserAgentCatalogMaterializationRuntimeLease>
+    {
+        public int AttemptCount { get; private set; }
+
+        public Task<UserAgentCatalogMaterializationRuntimeLease> EnsureAsync(
+            ProjectionScopeStartRequest request,
+            CancellationToken ct = default)
+        {
+            AttemptCount++;
+            operations.Enqueue($"projection:ensure:{request.RootActorId}:{request.ProjectionKind}");
+            throw new InvalidOperationException("boom");
         }
     }
 


### PR DESCRIPTION
## 摘要

iter165 cluster-001:移除 startup services 中的 `Task.Delay` retry loop(direct implement)。

**Old**:`UserAgentCatalogStartupService` / `DeviceRegistrationStartupService` / `ChannelBotRegistrationStartupService` 用 `Task.Delay`-backed retry loop 激活 projection scopes。违反 CLAUDE.md「回调只发信号」「延迟/超时事件化」。

**New**:Dispatch 一次或 delegate retry/backoff 给 hosted scheduling/runtime callback infrastructure。

违反:[CLAUDE.md「Actor 设计 / 生命周期 / 执行模型」](../tree/auto-refact-dev/CLAUDE.md):回调只发信号,延迟事件化。

## 范围

- 3 个 startup service 重构
- 测试更新 + source-regression test 防回归

🤖 Auto-loop / codex-refactor-loop iter165 c1 direct implement

⟦AI:AUTO-LOOP⟧
