### PR TITLE
iter165 cluster-007: WorkflowChatSource 字段单一语义化

### DIFF
--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -146,7 +146,9 @@ public static class ScopeServiceEndpoints
                 new ChatInput
                 {
                     Prompt = chatRequest.Prompt,
-                    WorkflowYamls = chatRequest.Source.WorkflowYamls,
+                    WorkflowYamls = chatRequest.Source.InlineBundle?.YamlDocuments
+                        .Select(static document => document.Yaml)
+                        .ToArray(),
                     SessionId = chatRequest.SessionId,
                     ScopeId = scopeId,
                     Metadata = scopedHeaders,
@@ -3198,7 +3200,7 @@ const response = await fetch("{{invokePath}}", {
 
     private static ScopeBindingWorkflowSpec? ToWorkflowSpec(UpsertScopeBindingHttpRequest request)
     {
-        var workflowYamls = request.Workflow?.WorkflowYamls ?? request.WorkflowYamls;
+        var workflowYamls = request.Workflow?.WorkflowYamls;
         return workflowYamls == null ? null : new ScopeBindingWorkflowSpec(workflowYamls);
     }
 
@@ -3243,6 +3245,9 @@ const response = await fetch("{{invokePath}}", {
 
     public sealed record UpsertScopeBindingHttpRequest(
         string ImplementationKind,
+        // Refactor (iter165/cluster-007):
+        //   Old pattern: top-level WorkflowYamls was a fallback for workflow.workflowYamls.
+        //   New principle: inline workflow documents live only under the workflow variant.
         IReadOnlyList<string>? WorkflowYamls = null,
         ScopeBindingWorkflowHttpRequest? Workflow = null,
         ScopeBindingScriptHttpRequest? Script = null,

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunModels.cs
@@ -30,23 +30,90 @@ public enum WorkflowChatSourceKind
     Direct = 4,
 }
 
-public sealed record WorkflowChatSource(
-    WorkflowChatSourceKind Kind,
-    string? WorkflowName = null,
-    string? ActorId = null,
-    IReadOnlyList<string>? WorkflowYamls = null)
+public sealed record WorkflowChatCatalogNameSource(string WorkflowName);
+
+public sealed record WorkflowChatDefinitionActorSource(string ActorId, string? WorkflowName = null);
+
+public sealed record WorkflowChatInlineYamlDocument(string Name, string Yaml);
+
+public sealed record WorkflowChatInlineYamlBundleSource(
+    string? EntryName,
+    IReadOnlyList<WorkflowChatInlineYamlDocument> YamlDocuments,
+    string? ActorId = null);
+
+// Refactor (iter165/cluster-007):
+//   Old pattern: InlineYamlBundle reused WorkflowName, ActorId, and WorkflowYamls on the parent source, so one field meant lookup identity or inline content depending on Kind.
+//   New principle: each source variant owns a single-purpose typed submessage; legacy parent properties are read-only migration views.
+public sealed record WorkflowChatSource
 {
+    public WorkflowChatSource(
+        WorkflowChatSourceKind kind,
+        WorkflowChatCatalogNameSource? catalogName = null,
+        WorkflowChatDefinitionActorSource? definitionActorSource = null,
+        WorkflowChatInlineYamlBundleSource? inlineBundle = null)
+    {
+        Kind = kind;
+        CatalogName = catalogName;
+        DefinitionActorSource = definitionActorSource;
+        InlineBundle = inlineBundle;
+    }
+
+    public WorkflowChatSourceKind Kind { get; init; }
+    public WorkflowChatCatalogNameSource? CatalogName { get; init; }
+    public WorkflowChatDefinitionActorSource? DefinitionActorSource { get; init; }
+    public WorkflowChatInlineYamlBundleSource? InlineBundle { get; init; }
+
+    public string? WorkflowName => Kind switch
+    {
+        WorkflowChatSourceKind.CatalogWorkflow => CatalogName?.WorkflowName,
+        WorkflowChatSourceKind.DefinitionActor => DefinitionActorSource?.WorkflowName,
+        WorkflowChatSourceKind.InlineYamlBundle => InlineBundle?.EntryName,
+        _ => null,
+    };
+
+    public string? ActorId => Kind switch
+    {
+        WorkflowChatSourceKind.DefinitionActor => DefinitionActorSource?.ActorId,
+        WorkflowChatSourceKind.InlineYamlBundle => InlineBundle?.ActorId,
+        WorkflowChatSourceKind.Direct => DefinitionActorSource?.ActorId,
+        _ => null,
+    };
+
+    public IReadOnlyList<string>? WorkflowYamls =>
+        InlineBundle?.YamlDocuments.Select(static document => document.Yaml).ToArray();
+
     public static WorkflowChatSource CatalogWorkflow(string workflowName) =>
-        new(WorkflowChatSourceKind.CatalogWorkflow, WorkflowName: workflowName);
+        new(
+            WorkflowChatSourceKind.CatalogWorkflow,
+            catalogName: new WorkflowChatCatalogNameSource(workflowName));
 
     public static WorkflowChatSource DefinitionActor(string actorId, string? workflowName = null) =>
-        new(WorkflowChatSourceKind.DefinitionActor, WorkflowName: workflowName, ActorId: actorId);
+        new(
+            WorkflowChatSourceKind.DefinitionActor,
+            definitionActorSource: new WorkflowChatDefinitionActorSource(actorId, workflowName));
+
+    public static WorkflowChatSource InlineYamlBundle(
+        string? entryName,
+        IReadOnlyList<WorkflowChatInlineYamlDocument> yamlDocuments,
+        string? actorId = null) =>
+        new(
+            WorkflowChatSourceKind.InlineYamlBundle,
+            inlineBundle: new WorkflowChatInlineYamlBundleSource(entryName, yamlDocuments, actorId));
 
     public static WorkflowChatSource InlineYamlBundle(IReadOnlyList<string> workflowYamls, string? workflowName = null, string? actorId = null) =>
-        new(WorkflowChatSourceKind.InlineYamlBundle, WorkflowName: workflowName, ActorId: actorId, WorkflowYamls: workflowYamls);
+        InlineYamlBundle(
+            workflowName,
+            workflowYamls.Select(static (yaml, index) => new WorkflowChatInlineYamlDocument(
+                string.Empty,
+                yaml)).ToArray(),
+            actorId);
 
     public static WorkflowChatSource Direct(string? actorId = null) =>
-        new(WorkflowChatSourceKind.Direct, ActorId: actorId);
+        new(
+            WorkflowChatSourceKind.Direct,
+            definitionActorSource: string.IsNullOrWhiteSpace(actorId)
+                ? null
+                : new WorkflowChatDefinitionActorSource(actorId));
 }
 
 // Refactor (iter112/cluster-3): Old pattern: application commands carried typed source plus legacy mirror fields. New principle: Application owns one typed WorkflowChatSource representation.

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowDirectFallbackPolicy.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowDirectFallbackPolicy.cs
@@ -29,7 +29,7 @@ public sealed class WorkflowDirectFallbackPolicy
             return false;
         if (!IsWhitelistedException(ex))
             return false;
-        if (request.Source.WorkflowYamls is { Count: > 0 })
+        if (request.Source.InlineBundle?.YamlDocuments is { Count: > 0 })
             return false;
 
         var workflowName = ResolveEffectiveWorkflowName(request);
@@ -72,7 +72,16 @@ public sealed class WorkflowDirectFallbackPolicy
         // Refactor (iter112/cluster-3): Old pattern: effective workflow resolution read WorkflowName directly. New principle: workflow identity is read through WorkflowChatSource.
         ArgumentNullException.ThrowIfNull(request);
 
-        var requestedWorkflowName = WorkflowRunNameNormalizer.NormalizeWorkflowName(request.Source.WorkflowName);
+        var requestedWorkflowName = request.Source.Kind switch
+        {
+            WorkflowChatSourceKind.CatalogWorkflow =>
+                WorkflowRunNameNormalizer.NormalizeWorkflowName(request.Source.CatalogName?.WorkflowName),
+            WorkflowChatSourceKind.DefinitionActor =>
+                WorkflowRunNameNormalizer.NormalizeWorkflowName(request.Source.DefinitionActorSource?.WorkflowName),
+            WorkflowChatSourceKind.InlineYamlBundle =>
+                WorkflowRunNameNormalizer.NormalizeWorkflowName(request.Source.InlineBundle?.EntryName),
+            _ => string.Empty,
+        };
         if (!string.IsNullOrWhiteSpace(requestedWorkflowName))
             return requestedWorkflowName;
 

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunActorResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunActorResolver.cs
@@ -31,10 +31,11 @@ public sealed class WorkflowRunActorResolver : IWorkflowRunActorResolver
     {
         // Refactor (iter112/cluster-3): Old pattern: resolver rebuilt source from legacy request mirrors. New principle: Application consumes the typed WorkflowChatSource as the single command source.
         var source = request.Source;
-        var requestedWorkflowName = WorkflowRunNameNormalizer.NormalizeWorkflowName(source.WorkflowName);
-        var sourceActorId = source.ActorId;
-        var inlineWorkflowYamls = source.WorkflowYamls?.ToList() ?? [];
-        var hasInlineWorkflowYamls = inlineWorkflowYamls.Count > 0;
+        var requestedWorkflowName = ResolveRequestedWorkflowName(source);
+        var sourceActorId = ResolveSourceActorId(source);
+        var inlineBundleSource = source.InlineBundle;
+        var inlineWorkflowDocuments = inlineBundleSource?.YamlDocuments ?? [];
+        var hasInlineWorkflowYamls = inlineWorkflowDocuments.Count > 0;
         var hasRequestedWorkflowName = !string.IsNullOrWhiteSpace(requestedWorkflowName);
         var workflowNameForRun = hasInlineWorkflowYamls
             ? string.Empty
@@ -49,7 +50,7 @@ public sealed class WorkflowRunActorResolver : IWorkflowRunActorResolver
 
         if (hasInlineWorkflowYamls)
         {
-            var inlineBundle = await BuildInlineWorkflowBundleAsync(inlineWorkflowYamls, ct);
+            var inlineBundle = await BuildInlineWorkflowBundleAsync(inlineWorkflowDocuments, ct);
             if (!inlineBundle.Succeeded)
                 return new WorkflowActorResolutionResult(null, workflowNameForRun, WorkflowChatRunStartError.InvalidWorkflowYaml);
 
@@ -206,20 +207,46 @@ public sealed class WorkflowRunActorResolver : IWorkflowRunActorResolver
             : configuredDefault;
     }
 
+    private static string ResolveRequestedWorkflowName(WorkflowChatSource source)
+    {
+        return source.Kind switch
+        {
+            WorkflowChatSourceKind.CatalogWorkflow =>
+                WorkflowRunNameNormalizer.NormalizeWorkflowName(source.CatalogName?.WorkflowName),
+            WorkflowChatSourceKind.DefinitionActor =>
+                WorkflowRunNameNormalizer.NormalizeWorkflowName(source.DefinitionActorSource?.WorkflowName),
+            WorkflowChatSourceKind.InlineYamlBundle =>
+                WorkflowRunNameNormalizer.NormalizeWorkflowName(source.InlineBundle?.EntryName),
+            _ => string.Empty,
+        };
+    }
+
+    private static string? ResolveSourceActorId(WorkflowChatSource source)
+    {
+        return source.Kind switch
+        {
+            WorkflowChatSourceKind.DefinitionActor => source.DefinitionActorSource?.ActorId,
+            WorkflowChatSourceKind.InlineYamlBundle => source.InlineBundle?.ActorId,
+            WorkflowChatSourceKind.Direct => source.DefinitionActorSource?.ActorId,
+            _ => null,
+        };
+    }
+
     private async Task<InlineWorkflowBundle> BuildInlineWorkflowBundleAsync(
-        IReadOnlyList<string> inlineWorkflowYamls,
+        IReadOnlyList<WorkflowChatInlineYamlDocument> inlineWorkflowDocuments,
         CancellationToken ct)
     {
-        if (inlineWorkflowYamls.Count == 0)
+        if (inlineWorkflowDocuments.Count == 0)
             return InlineWorkflowBundle.Invalid;
 
         var workflowByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         string entryWorkflowName = string.Empty;
         string entryWorkflowYaml = string.Empty;
 
-        for (var i = 0; i < inlineWorkflowYamls.Count; i++)
+        for (var i = 0; i < inlineWorkflowDocuments.Count; i++)
         {
-            var yaml = inlineWorkflowYamls[i];
+            var document = inlineWorkflowDocuments[i];
+            var yaml = document.Yaml;
             if (string.IsNullOrWhiteSpace(yaml))
                 return InlineWorkflowBundle.Invalid;
 
@@ -230,6 +257,13 @@ public sealed class WorkflowRunActorResolver : IWorkflowRunActorResolver
             var workflowName = WorkflowRunNameNormalizer.NormalizeWorkflowName(parseResult.WorkflowName);
             if (string.IsNullOrWhiteSpace(workflowName))
                 return InlineWorkflowBundle.Invalid;
+            var documentName = WorkflowRunNameNormalizer.NormalizeWorkflowName(document.Name);
+            if (!string.IsNullOrWhiteSpace(documentName) &&
+                !string.Equals(documentName, workflowName, StringComparison.OrdinalIgnoreCase))
+            {
+                return InlineWorkflowBundle.Invalid;
+            }
+
             if (!workflowByName.TryAdd(workflowName, yaml))
                 return InlineWorkflowBundle.Invalid;
 

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatCapabilityModels.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatCapabilityModels.cs
@@ -70,9 +70,42 @@ public sealed record ChatLlmControlInput
 public sealed record WorkflowChatSourceInput
 {
     public string? Kind { get; init; }
+    public WorkflowChatCatalogNameSourceInput? CatalogName { get; init; }
+    public WorkflowChatDefinitionActorSourceInput? DefinitionActor { get; init; }
+    public WorkflowChatInlineYamlBundleSourceInput? InlineBundle { get; init; }
+
+    /// <summary>Legacy source workflow name alias. Prefer the typed source variant submessages.</summary>
     public string? WorkflowName { get; init; }
+
+    /// <summary>Legacy source actor id alias. Prefer the typed source variant submessages.</summary>
     public string? ActorId { get; init; }
+
+    /// <summary>Legacy inline YAML bundle alias. Prefer <see cref="InlineBundle"/>.</summary>
     public IReadOnlyList<string>? WorkflowYamls { get; init; }
+}
+
+public sealed record WorkflowChatCatalogNameSourceInput
+{
+    public string? WorkflowName { get; init; }
+}
+
+public sealed record WorkflowChatDefinitionActorSourceInput
+{
+    public string? ActorId { get; init; }
+    public string? WorkflowName { get; init; }
+}
+
+public sealed record WorkflowChatInlineYamlBundleSourceInput
+{
+    public string? EntryName { get; init; }
+    public IReadOnlyList<WorkflowChatInlineYamlDocumentInput>? YamlDocuments { get; init; }
+    public string? ActorId { get; init; }
+}
+
+public sealed record WorkflowChatInlineYamlDocumentInput
+{
+    public string? Name { get; init; }
+    public string? Yaml { get; init; }
 }
 
 public sealed record ChatInputContentPart

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunRequestNormalizer.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunRequestNormalizer.cs
@@ -47,8 +47,8 @@ internal static class ChatRunRequestNormalizer
             return ChatRunRequestNormalizationResult.Failed(sourceResult.Error);
 
         var source = sourceResult.Source!;
-        var requestedWorkflowName = source.WorkflowName ?? string.Empty;
-        var inlineWorkflowYamls = source.WorkflowYamls ?? [];
+        var requestedWorkflowName = ResolveRequestedWorkflowName(source);
+        var inlineWorkflowYamls = source.InlineBundle?.YamlDocuments.Select(static document => document.Yaml).ToArray() ?? [];
 
         var rawPrompt = ResolvePrompt(input.Prompt, normalizedInputParts);
         if (rawPrompt.Length == 0)
@@ -57,7 +57,7 @@ internal static class ChatRunRequestNormalizer
         var normalizedPrompt = WorkflowAuthoringSkillPromptAugmentor.AugmentPrompt(
             rawPrompt,
             requestedWorkflowName,
-            inlineWorkflowYamls.Count > 0,
+            inlineWorkflowYamls.Length > 0,
             normalizedMetadata,
             capabilities);
 
@@ -122,9 +122,9 @@ internal static class ChatRunRequestNormalizer
             inlineWorkflowYamls = [legacyWorkflowYaml!];
 
         if (inlineWorkflowYamls.Count > 0)
-            return SourceNormalizationResult.Success(WorkflowChatSource.InlineYamlBundle(
-                inlineWorkflowYamls,
+            return SourceNormalizationResult.Success(ToInlineYamlBundleSource(
                 string.IsNullOrWhiteSpace(requestedWorkflowName) ? null : requestedWorkflowName,
+                inlineWorkflowYamls,
                 string.IsNullOrWhiteSpace(normalizedAgentId) ? null : normalizedAgentId));
 
         if (!string.IsNullOrWhiteSpace(normalizedAgentId))
@@ -141,9 +141,9 @@ internal static class ChatRunRequestNormalizer
     private static SourceNormalizationResult NormalizeTypedSource(WorkflowChatSourceInput source)
     {
         var kind = NormalizeSourceKind(source.Kind);
-        var workflowName = NormalizeWorkflowName(source.WorkflowName);
-        var actorId = NormalizeAgentId(source.ActorId);
-        var workflowYamls = NormalizeInlineWorkflowYamls(source.WorkflowYamls);
+        var workflowName = ResolveTypedWorkflowName(source, kind);
+        var actorId = ResolveTypedActorId(source, kind);
+        var inlineYamlDocuments = ResolveTypedInlineYamlDocuments(source, kind);
 
         return kind switch
         {
@@ -155,12 +155,13 @@ internal static class ChatRunRequestNormalizer
                 SourceNormalizationResult.Failed(WorkflowChatRunStartError.AgentNotFound),
             WorkflowChatSourceKind.DefinitionActor =>
                 SourceNormalizationResult.Success(WorkflowChatSource.DefinitionActor(actorId, string.IsNullOrWhiteSpace(workflowName) ? null : workflowName)),
-            WorkflowChatSourceKind.InlineYamlBundle when workflowYamls.Count == 0 || workflowYamls.Any(string.IsNullOrWhiteSpace) =>
+            WorkflowChatSourceKind.InlineYamlBundle when inlineYamlDocuments.Count == 0 ||
+                                                          inlineYamlDocuments.Any(static document => string.IsNullOrWhiteSpace(document.Yaml)) =>
                 SourceNormalizationResult.Failed(WorkflowChatRunStartError.InvalidWorkflowYaml),
             WorkflowChatSourceKind.InlineYamlBundle =>
                 SourceNormalizationResult.Success(WorkflowChatSource.InlineYamlBundle(
-                    workflowYamls,
                     string.IsNullOrWhiteSpace(workflowName) ? null : workflowName,
+                    inlineYamlDocuments,
                     string.IsNullOrWhiteSpace(actorId) ? null : actorId)),
             WorkflowChatSourceKind.Direct =>
                 SourceNormalizationResult.Success(WorkflowChatSource.Direct(actorId)),
@@ -191,6 +192,68 @@ internal static class ChatRunRequestNormalizer
             normalized.Add(yaml ?? string.Empty);
         return normalized;
     }
+
+    private static string ResolveRequestedWorkflowName(WorkflowChatSource source)
+    {
+        return source.Kind switch
+        {
+            WorkflowChatSourceKind.CatalogWorkflow => source.CatalogName?.WorkflowName ?? string.Empty,
+            WorkflowChatSourceKind.DefinitionActor => source.DefinitionActorSource?.WorkflowName ?? string.Empty,
+            WorkflowChatSourceKind.InlineYamlBundle => source.InlineBundle?.EntryName ?? string.Empty,
+            _ => string.Empty,
+        };
+    }
+
+    private static string ResolveTypedWorkflowName(WorkflowChatSourceInput source, WorkflowChatSourceKind kind)
+    {
+        var value = kind switch
+        {
+            WorkflowChatSourceKind.CatalogWorkflow => source.CatalogName?.WorkflowName ?? source.WorkflowName,
+            WorkflowChatSourceKind.DefinitionActor => source.DefinitionActor?.WorkflowName ?? source.WorkflowName,
+            WorkflowChatSourceKind.InlineYamlBundle => source.InlineBundle?.EntryName ?? source.WorkflowName,
+            _ => source.WorkflowName,
+        };
+        return NormalizeWorkflowName(value);
+    }
+
+    private static string ResolveTypedActorId(WorkflowChatSourceInput source, WorkflowChatSourceKind kind)
+    {
+        var value = kind switch
+        {
+            WorkflowChatSourceKind.DefinitionActor => source.DefinitionActor?.ActorId ?? source.ActorId,
+            WorkflowChatSourceKind.InlineYamlBundle => source.InlineBundle?.ActorId ?? source.ActorId,
+            _ => source.ActorId,
+        };
+        return NormalizeAgentId(value);
+    }
+
+    private static IReadOnlyList<WorkflowChatInlineYamlDocument> ResolveTypedInlineYamlDocuments(
+        WorkflowChatSourceInput source,
+        WorkflowChatSourceKind kind)
+    {
+        if (kind != WorkflowChatSourceKind.InlineYamlBundle)
+            return ToUnnamedInlineYamlDocuments(NormalizeInlineWorkflowYamls(source.WorkflowYamls));
+
+        if (source.InlineBundle?.YamlDocuments is not { Count: > 0 } documents)
+            return ToUnnamedInlineYamlDocuments(NormalizeInlineWorkflowYamls(source.WorkflowYamls));
+
+        return documents.Select(static document => new WorkflowChatInlineYamlDocument(
+            string.IsNullOrWhiteSpace(document?.Name) ? string.Empty : document.Name.Trim(),
+            document?.Yaml ?? string.Empty)).ToArray();
+    }
+
+    private static WorkflowChatSource ToInlineYamlBundleSource(
+        string? entryName,
+        IReadOnlyList<string> workflowYamls,
+        string? actorId)
+    {
+        var documents = ToUnnamedInlineYamlDocuments(workflowYamls);
+        return WorkflowChatSource.InlineYamlBundle(entryName, documents, actorId);
+    }
+
+    private static IReadOnlyList<WorkflowChatInlineYamlDocument> ToUnnamedInlineYamlDocuments(
+        IReadOnlyList<string> workflowYamls) =>
+        workflowYamls.Select(static yaml => new WorkflowChatInlineYamlDocument(string.Empty, yaml)).ToArray();
 
     private static string NormalizeWorkflowName(string? workflowName) =>
         string.IsNullOrWhiteSpace(workflowName) ? string.Empty : workflowName.Trim();

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -56,10 +56,13 @@ public sealed class ScopeServiceEndpointsTests
         {
             implementationKind = "workflow",
             displayName = "Orders App",
-            workflowYamls = new[]
+            workflow = new
             {
-                "name: main\nsteps:\n  - run: echo hello",
-                "name: child\nsteps:\n  - run: echo child",
+                workflowYamls = new[]
+                {
+                    "name: main\nsteps:\n  - run: echo hello",
+                    "name: child\nsteps:\n  - run: echo child",
+                },
             },
         });
 
@@ -74,6 +77,26 @@ public sealed class ScopeServiceEndpointsTests
         host.ScopeBindingPort.LastRequest.ImplementationKind.Should().Be(ScopeBindingImplementationKind.Workflow);
         host.ScopeBindingPort.LastRequest.Workflow.Should().NotBeNull();
         host.ScopeBindingPort.LastRequest.Workflow!.WorkflowYamls.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task ScopeBindingEndpoint_ShouldIgnoreTopLevelWorkflowYamlsFallback()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+
+        var response = await host.Client.PutAsJsonAsync("/api/scopes/scope-a/binding", new
+        {
+            implementationKind = "workflow",
+            displayName = "Orders App",
+            workflowYamls = new[]
+            {
+                "name: legacy\nsteps:\n  - run: echo legacy",
+            },
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        host.ScopeBindingPort.LastRequest.Should().NotBeNull();
+        host.ScopeBindingPort.LastRequest!.Workflow.Should().BeNull();
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunActorResolverTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunActorResolverTests.cs
@@ -355,6 +355,32 @@ public sealed class WorkflowRunActorResolverTests
     }
 
     [Fact]
+    public async Task ResolveOrCreateAsync_ShouldReturnInvalidWorkflowYaml_WhenNamedInlineDocumentNameMismatchesYaml()
+    {
+        const string helperWorkflowYaml =
+            """
+            name: helper
+            roles: []
+            steps: []
+            """;
+        var actorPort = new RecordingWorkflowRunActorPort();
+        actorPort.ParseResults[helperWorkflowYaml] = WorkflowYamlParseResult.Success("helper");
+        var resolver = new WorkflowRunActorResolver(new StaticWorkflowActorBindingReader(null), actorPort, actorPort, new InMemoryWorkflowDefinitionCatalog());
+
+        var result = await resolver.ResolveOrCreateAsync(
+            new WorkflowChatRunRequest(
+                "hello",
+                WorkflowChatSource.InlineYamlBundle(
+                    "foo",
+                    [new WorkflowChatInlineYamlDocument("foo", helperWorkflowYaml)])),
+            CancellationToken.None);
+
+        result.Error.Should().Be(WorkflowChatRunStartError.InvalidWorkflowYaml);
+        result.Target.Should().BeNull();
+        actorPort.CreateRunBindings.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task ResolveOrCreateAsync_ShouldReturnAgentNotFound_WhenSourceActorBindingMissing()
     {
         var resolver = new WorkflowRunActorResolver(new StaticWorkflowActorBindingReader(null), new RecordingWorkflowRunActorPort(), new RecordingWorkflowRunActorPort(), new InMemoryWorkflowDefinitionCatalog());

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunActorResolverTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunActorResolverTests.cs
@@ -381,6 +381,42 @@ public sealed class WorkflowRunActorResolverTests
     }
 
     [Fact]
+    public async Task ResolveOrCreateAsync_ShouldCreateRun_WhenNamedInlineDocumentNameMatchesYaml()
+    {
+        const string entryWorkflowYaml =
+            """
+            name: inline_entry
+            roles: []
+            steps: []
+            """;
+        var actorPort = new RecordingWorkflowRunActorPort();
+        actorPort.ParseResults[entryWorkflowYaml] = WorkflowYamlParseResult.Success("inline_entry");
+        var resolver = new WorkflowRunActorResolver(
+            new StaticWorkflowActorBindingReader(null),
+            actorPort,
+            actorPort,
+            new InMemoryWorkflowDefinitionCatalog());
+
+        var result = await resolver.ResolveOrCreateAsync(
+            new WorkflowChatRunRequest(
+                "hello",
+                WorkflowChatSource.InlineYamlBundle(
+                    "inline_entry",
+                    [new WorkflowChatInlineYamlDocument("inline_entry", entryWorkflowYaml)])),
+            CancellationToken.None);
+
+        result.Error.Should().Be(WorkflowChatRunStartError.None);
+        result.WorkflowNameForRun.Should().Be("inline_entry");
+        result.Target.Should().NotBeNull();
+        result.Target!.ActorId.Should().Be("run-1");
+        actorPort.CreateRunBindings.Should().ContainSingle();
+        actorPort.CreateRunBindings[0].WorkflowName.Should().Be("inline_entry");
+        actorPort.CreateRunBindings[0].WorkflowYaml.Should().Be(entryWorkflowYaml);
+        actorPort.CreateRunBindings[0].InlineWorkflowYamls.Should().ContainSingle()
+            .Which.Should().Be(new KeyValuePair<string, string>("inline_entry", entryWorkflowYaml));
+    }
+
+    [Fact]
     public async Task ResolveOrCreateAsync_ShouldReturnAgentNotFound_WhenSourceActorBindingMissing()
     {
         var resolver = new WorkflowRunActorResolver(new StaticWorkflowActorBindingReader(null), new RecordingWorkflowRunActorPort(), new RecordingWorkflowRunActorPort(), new InMemoryWorkflowDefinitionCatalog());

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowCapabilityEndpointsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowCapabilityEndpointsCoverageTests.cs
@@ -140,6 +140,42 @@ public sealed class WorkflowCapabilityEndpointsCoverageTests
     }
 
     [Fact]
+    public void ChatRunRequestNormalizer_ShouldNormalizeTypedInlineBundleSubmessage()
+    {
+        var input = new ChatInput
+        {
+            Prompt = "hello",
+            Source = new WorkflowChatSourceInput
+            {
+                Kind = "inline-yaml-bundle",
+                InlineBundle = new WorkflowChatInlineYamlBundleSourceInput
+                {
+                    EntryName = " auto ",
+                    ActorId = " source-actor-1 ",
+                    YamlDocuments =
+                    [
+                        new WorkflowChatInlineYamlDocumentInput
+                        {
+                            Name = "auto",
+                            Yaml = "name: auto",
+                        },
+                    ],
+                },
+            },
+        };
+
+        var result = ChatRunRequestNormalizer.Normalize(input);
+
+        result.Succeeded.Should().BeTrue();
+        result.Request!.Source.Kind.Should().Be(WorkflowChatSourceKind.InlineYamlBundle);
+        result.Request.Source.InlineBundle.Should().NotBeNull();
+        result.Request.Source.InlineBundle!.EntryName.Should().Be("auto");
+        result.Request.Source.InlineBundle.ActorId.Should().Be("source-actor-1");
+        result.Request.Source.InlineBundle.YamlDocuments.Should().ContainSingle()
+            .Which.Should().Be(new WorkflowChatInlineYamlDocument("auto", "name: auto"));
+    }
+
+    [Fact]
     public void ChatRunRequestNormalizer_ShouldNormalizeTypedAndLegacyInputsToEquivalentTypedSource()
     {
         var typed = ChatRunRequestNormalizer.Normalize(new ChatInput

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowCapabilityEndpointsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowCapabilityEndpointsCoverageTests.cs
@@ -176,6 +176,74 @@ public sealed class WorkflowCapabilityEndpointsCoverageTests
     }
 
     [Fact]
+    public void ChatRunRequestNormalizer_ShouldPreferTypedInlineBundleSubmessageOverLegacyAliases()
+    {
+        var input = new ChatInput
+        {
+            Prompt = "hello",
+            Source = new WorkflowChatSourceInput
+            {
+                Kind = "inline-yaml-bundle",
+                WorkflowName = "legacy",
+                ActorId = "legacy-actor",
+                WorkflowYamls = ["name: legacy"],
+                InlineBundle = new WorkflowChatInlineYamlBundleSourceInput
+                {
+                    EntryName = " typed ",
+                    ActorId = " typed-actor ",
+                    YamlDocuments =
+                    [
+                        new WorkflowChatInlineYamlDocumentInput
+                        {
+                            Name = "typed",
+                            Yaml = "name: typed",
+                        },
+                    ],
+                },
+            },
+        };
+
+        var result = ChatRunRequestNormalizer.Normalize(input);
+
+        result.Succeeded.Should().BeTrue();
+        result.Request!.Source.Kind.Should().Be(WorkflowChatSourceKind.InlineYamlBundle);
+        result.Request.Source.InlineBundle.Should().BeEquivalentTo(new WorkflowChatInlineYamlBundleSource(
+            "typed",
+            [new WorkflowChatInlineYamlDocument("typed", "name: typed")],
+            "typed-actor"));
+    }
+
+    [Fact]
+    public void ChatRunRequestNormalizer_ShouldRejectBlankTypedInlineBundleYamlDocument()
+    {
+        var input = new ChatInput
+        {
+            Prompt = "hello",
+            Source = new WorkflowChatSourceInput
+            {
+                Kind = "inline-yaml-bundle",
+                InlineBundle = new WorkflowChatInlineYamlBundleSourceInput
+                {
+                    EntryName = "auto",
+                    YamlDocuments =
+                    [
+                        new WorkflowChatInlineYamlDocumentInput
+                        {
+                            Name = "auto",
+                            Yaml = "   ",
+                        },
+                    ],
+                },
+            },
+        };
+
+        var result = ChatRunRequestNormalizer.Normalize(input);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(WorkflowChatRunStartError.InvalidWorkflowYaml);
+    }
+
+    [Fact]
     public void ChatRunRequestNormalizer_ShouldTrimTypedCatalogNameSubmessage()
     {
         var result = ChatRunRequestNormalizer.Normalize(new ChatInput

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowCapabilityEndpointsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowCapabilityEndpointsCoverageTests.cs
@@ -176,6 +176,125 @@ public sealed class WorkflowCapabilityEndpointsCoverageTests
     }
 
     [Fact]
+    public void ChatRunRequestNormalizer_ShouldTrimTypedCatalogNameSubmessage()
+    {
+        var result = ChatRunRequestNormalizer.Normalize(new ChatInput
+        {
+            Prompt = "hello",
+            Source = new WorkflowChatSourceInput
+            {
+                Kind = "catalog",
+                CatalogName = new WorkflowChatCatalogNameSourceInput
+                {
+                    WorkflowName = " auto ",
+                },
+            },
+        });
+        var blankResult = ChatRunRequestNormalizer.Normalize(new ChatInput
+        {
+            Prompt = "hello",
+            Source = new WorkflowChatSourceInput
+            {
+                Kind = "catalog",
+                CatalogName = new WorkflowChatCatalogNameSourceInput
+                {
+                    WorkflowName = "   ",
+                },
+            },
+        });
+
+        result.Succeeded.Should().BeTrue();
+        result.Request!.Source.Kind.Should().Be(WorkflowChatSourceKind.CatalogWorkflow);
+        result.Request.Source.CatalogName.Should().Be(new WorkflowChatCatalogNameSource("auto"));
+        blankResult.Succeeded.Should().BeFalse();
+        blankResult.Error.Should().Be(WorkflowChatRunStartError.WorkflowNotFound);
+    }
+
+    [Fact]
+    public void ChatRunRequestNormalizer_ShouldPreferTypedCatalogNameSubmessageOverLegacyAlias()
+    {
+        var result = ChatRunRequestNormalizer.Normalize(new ChatInput
+        {
+            Prompt = "hello",
+            Source = new WorkflowChatSourceInput
+            {
+                Kind = "catalog",
+                WorkflowName = "legacy",
+                CatalogName = new WorkflowChatCatalogNameSourceInput
+                {
+                    WorkflowName = " typed ",
+                },
+            },
+        });
+
+        result.Succeeded.Should().BeTrue();
+        result.Request!.Source.Kind.Should().Be(WorkflowChatSourceKind.CatalogWorkflow);
+        result.Request.Source.CatalogName.Should().Be(new WorkflowChatCatalogNameSource("typed"));
+    }
+
+    [Fact]
+    public void ChatRunRequestNormalizer_ShouldTrimTypedDefinitionActorSubmessage()
+    {
+        var result = ChatRunRequestNormalizer.Normalize(new ChatInput
+        {
+            Prompt = "hello",
+            Source = new WorkflowChatSourceInput
+            {
+                Kind = "actor",
+                DefinitionActor = new WorkflowChatDefinitionActorSourceInput
+                {
+                    ActorId = " actor-1 ",
+                    WorkflowName = " auto ",
+                },
+            },
+        });
+        var blankResult = ChatRunRequestNormalizer.Normalize(new ChatInput
+        {
+            Prompt = "hello",
+            Source = new WorkflowChatSourceInput
+            {
+                Kind = "actor",
+                DefinitionActor = new WorkflowChatDefinitionActorSourceInput
+                {
+                    ActorId = "   ",
+                    WorkflowName = " auto ",
+                },
+            },
+        });
+
+        result.Succeeded.Should().BeTrue();
+        result.Request!.Source.Kind.Should().Be(WorkflowChatSourceKind.DefinitionActor);
+        result.Request.Source.DefinitionActorSource.Should().Be(new WorkflowChatDefinitionActorSource("actor-1", "auto"));
+        blankResult.Succeeded.Should().BeFalse();
+        blankResult.Error.Should().Be(WorkflowChatRunStartError.AgentNotFound);
+    }
+
+    [Fact]
+    public void ChatRunRequestNormalizer_ShouldPreferTypedDefinitionActorSubmessageOverLegacyAliases()
+    {
+        var result = ChatRunRequestNormalizer.Normalize(new ChatInput
+        {
+            Prompt = "hello",
+            Source = new WorkflowChatSourceInput
+            {
+                Kind = "actor",
+                ActorId = "legacy-actor",
+                WorkflowName = "legacy-workflow",
+                DefinitionActor = new WorkflowChatDefinitionActorSourceInput
+                {
+                    ActorId = " typed-actor ",
+                    WorkflowName = " typed-workflow ",
+                },
+            },
+        });
+
+        result.Succeeded.Should().BeTrue();
+        result.Request!.Source.Kind.Should().Be(WorkflowChatSourceKind.DefinitionActor);
+        result.Request.Source.DefinitionActorSource.Should()
+            .Be(new WorkflowChatDefinitionActorSource("typed-actor", "typed-workflow"));
+    }
+
+    [Fact]
     public void ChatRunRequestNormalizer_ShouldNormalizeTypedAndLegacyInputsToEquivalentTypedSource()
     {
         var typed = ChatRunRequestNormalizer.Normalize(new ChatInput


### PR DESCRIPTION
## 摘要

iter165 cluster-007:`WorkflowChatSource` 字段单一语义化(direct implement)。

**Old**:`WorkflowChatSource.InlineYamlBundle` 用 `WorkflowName` / `ActorId` / `WorkflowYamls` 三字段共一 variant;endpoint 同时接受 top-level `WorkflowYamls` fallback。违反 CLAUDE.md「API 字段单一语义」。

**New**:Source variants 单一职责 typed submessage(catalog name / definition actor / inline bundle 显式 entry name + yaml documents)。

违反:[CLAUDE.md「字段命名与 Metadata 决策树」](../tree/auto-refact-dev/CLAUDE.md):API 字段单一语义,禁止双重语义。

## 范围

- `WorkflowChatRunModels.cs` / `ScopeServiceEndpoints.cs`:variant 单一职责 + 移除 top-level fallback
- 配套 normalize / fallback / resolver
- 测试同步

🤖 Auto-loop / codex-refactor-loop iter165 c7 direct implement

⟦AI:AUTO-LOOP⟧
