### PR TITLE
iter165 cluster-003: workflow query API/SDK 改 workflow-run/readmodel 命名

### DIFF
--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -279,7 +279,7 @@ public sealed class AevatarInvocationDispatcher
             if (terminal != null)
                 return AevatarInvocationJson.Serialize(MapTerminal(terminal, runId));
 
-            var workflow = await _workflowQueryService.GetActorSnapshotAsync(actorId!, ct);
+            var workflow = await _workflowQueryService.GetWorkflowRunCurrentStateAsync(actorId!, ct);
             if (workflow != null &&
                 (string.IsNullOrWhiteSpace(workflow.LastCommandId) ||
                  string.Equals(workflow.LastCommandId, runId, StringComparison.Ordinal)))
@@ -646,7 +646,7 @@ public sealed class AevatarInvocationDispatcher
             });
         }
 
-        var snapshot = await _workflowQueryService.GetActorSnapshotAsync(query.ActorId.Trim(), ct);
+        var snapshot = await _workflowQueryService.GetWorkflowRunCurrentStateAsync(query.ActorId.Trim(), ct);
         return AevatarInvocationJson.Serialize(new QueryReadModelResult
         {
             ReadmodelName = AevatarInvocationReadModels.WorkflowActorCurrentState,

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -279,7 +279,7 @@ public sealed class AevatarInvocationDispatcher
             if (terminal != null)
                 return AevatarInvocationJson.Serialize(MapTerminal(terminal, runId));
 
-            var workflow = await _workflowQueryService.GetWorkflowRunCurrentStateAsync(actorId!, ct);
+            var workflow = await _workflowQueryService.GetWorkflowActorCurrentStateAsync(actorId!, ct);
             if (workflow != null &&
                 (string.IsNullOrWhiteSpace(workflow.LastCommandId) ||
                  string.Equals(workflow.LastCommandId, runId, StringComparison.Ordinal)))
@@ -646,7 +646,7 @@ public sealed class AevatarInvocationDispatcher
             });
         }
 
-        var snapshot = await _workflowQueryService.GetWorkflowRunCurrentStateAsync(query.ActorId.Trim(), ct);
+        var snapshot = await _workflowQueryService.GetWorkflowActorCurrentStateAsync(query.ActorId.Trim(), ct);
         return AevatarInvocationJson.Serialize(new QueryReadModelResult
         {
             ReadmodelName = AevatarInvocationReadModels.WorkflowActorCurrentState,

--- a/src/Aevatar.AI.ToolProviders.Workflow/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.Workflow/ServiceCollectionExtensions.cs
@@ -8,7 +8,7 @@ namespace Aevatar.AI.ToolProviders.Workflow;
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers workflow inspection tools (workflow_status, workflow_artifact_query, actor_inspect, event_query).
+    /// Registers workflow inspection tools (workflow_status, workflow_artifact_query, workflow_run_current_state, event_query).
     /// Requires IWorkflowExecutionQueryApplicationService to be registered.
     /// </summary>
     // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):

--- a/src/Aevatar.AI.ToolProviders.Workflow/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.Workflow/ServiceCollectionExtensions.cs
@@ -8,7 +8,7 @@ namespace Aevatar.AI.ToolProviders.Workflow;
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers workflow inspection tools (workflow_status, workflow_artifact_query, workflow_run_current_state, event_query).
+    /// Registers workflow inspection tools (workflow_status, workflow_artifact_query, workflow_actor_current_state, event_query).
     /// Requires IWorkflowExecutionQueryApplicationService to be registered.
     /// </summary>
     // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):

--- a/src/Aevatar.AI.ToolProviders.Workflow/Tools/WorkflowActorCurrentStateTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Workflow/Tools/WorkflowActorCurrentStateTool.cs
@@ -5,15 +5,15 @@ using Aevatar.Workflow.Application.Abstractions.Queries;
 namespace Aevatar.AI.ToolProviders.Workflow.Tools;
 
 /// <summary>
-/// Reads workflow-run current state via committed projections (readmodel).
+/// Reads workflow actor current state via committed projections (readmodel).
 /// Never reads actor internals directly.
 /// </summary>
-public sealed class WorkflowRunCurrentStateTool : IAgentTool
+public sealed class WorkflowActorCurrentStateTool : IAgentTool
 {
     private readonly IWorkflowExecutionQueryApplicationService _queryService;
     private readonly WorkflowToolOptions _options;
 
-    public WorkflowRunCurrentStateTool(
+    public WorkflowActorCurrentStateTool(
         IWorkflowExecutionQueryApplicationService queryService,
         WorkflowToolOptions options)
     {
@@ -21,14 +21,14 @@ public sealed class WorkflowRunCurrentStateTool : IAgentTool
         _options = options;
     }
 
-    public string Name => "workflow_run_current_state";
+    public string Name => "workflow_actor_current_state";
 
     // Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
     //   Old pattern: workflow tooling exposed actor_inspect with actor_id snapshot semantics.
-    //   New principle: workflow tooling exposes workflow-run current-state readmodel semantics by workflow_run_id.
+    //   New principle: workflow tooling exposes workflow actor current-state readmodel semantics by actor_id.
     public string Description =>
-        "Read workflow-run current state via the projection readmodel. " +
-        "Shows workflow-run status, output, step counts, and registered agents. " +
+        "Read workflow actor current state via the projection readmodel. " +
+        "Shows workflow actor status, output, step counts, and registered agents. " +
         "All data is from committed projections, not live actor internals.";
 
     public string ParametersSchema => """
@@ -38,11 +38,11 @@ public sealed class WorkflowRunCurrentStateTool : IAgentTool
             "action": {
               "type": "string",
               "enum": ["snapshot", "list", "agents"],
-              "description": "Action: 'snapshot' (default) workflow-run current state, 'list' all workflow runs, 'agents' registered agents"
+              "description": "Action: 'snapshot' (default) workflow actor current state, 'list' all workflow actors, 'agents' registered agents"
             },
-            "workflow_run_id": {
+            "actor_id": {
               "type": "string",
-              "description": "Workflow run ID (required for 'snapshot')"
+              "description": "Workflow actor ID (required for 'snapshot')"
             },
             "take": {
               "type": "integer",
@@ -62,8 +62,8 @@ public sealed class WorkflowRunCurrentStateTool : IAgentTool
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {
-        if (!_queryService.WorkflowRunCurrentStateQueryEnabled)
-            return """{"error":"Workflow-run current-state query is not enabled on this deployment."}""";
+        if (!_queryService.WorkflowActorCurrentStateQueryEnabled)
+            return """{"error":"Workflow actor current-state query is not enabled on this deployment."}""";
 
         try
         {
@@ -74,7 +74,7 @@ public sealed class WorkflowRunCurrentStateTool : IAgentTool
             {
                 "list" or "agents" => await ListAgentsAsync(ct),
                 "snapshot" => await GetSnapshotAsync(args, ct),
-                _ => JsonSerializer.Serialize(new { error = $"Unsupported workflow_run_current_state action '{action}'" }),
+                _ => JsonSerializer.Serialize(new { error = $"Unsupported workflow_actor_current_state action '{action}'" }),
             };
         }
         catch (OperationCanceledException) { throw; }
@@ -86,17 +86,17 @@ public sealed class WorkflowRunCurrentStateTool : IAgentTool
 
     private async Task<string> GetSnapshotAsync(ToolArgs args, CancellationToken ct)
     {
-        var workflowRunId = args.Str("workflow_run_id");
-        if (string.IsNullOrWhiteSpace(workflowRunId))
-            return """{"error":"'workflow_run_id' is required. Use action='list' to find workflow runs."}""";
+        var actorId = args.Str("actor_id");
+        if (string.IsNullOrWhiteSpace(actorId))
+            return """{"error":"'actor_id' is required. Use action='list' to find workflow actors."}""";
 
-        var snapshot = await _queryService.GetWorkflowRunCurrentStateAsync(workflowRunId, ct);
+        var snapshot = await _queryService.GetWorkflowActorCurrentStateAsync(actorId, ct);
         if (snapshot == null)
-            return JsonSerializer.Serialize(new { error = $"No current state found for workflow run '{workflowRunId}'" });
+            return JsonSerializer.Serialize(new { error = $"No current state found for workflow actor '{actorId}'" });
 
         return JsonSerializer.Serialize(new
         {
-            workflow_run_id = snapshot.ActorId, workflow_name = snapshot.WorkflowName,
+            actor_id = snapshot.ActorId, workflow_name = snapshot.WorkflowName,
             status = snapshot.CompletionStatus.ToString(), state_version = snapshot.StateVersion,
             last_command_id = snapshot.LastCommandId, last_event_id = snapshot.LastEventId,
             last_updated_at = snapshot.LastUpdatedAt, last_success = snapshot.LastSuccess,

--- a/src/Aevatar.AI.ToolProviders.Workflow/Tools/WorkflowRunCurrentStateTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Workflow/Tools/WorkflowRunCurrentStateTool.cs
@@ -5,15 +5,15 @@ using Aevatar.Workflow.Application.Abstractions.Queries;
 namespace Aevatar.AI.ToolProviders.Workflow.Tools;
 
 /// <summary>
-/// Inspects actor state via committed projections (readmodel).
+/// Reads workflow-run current state via committed projections (readmodel).
 /// Never reads actor internals directly.
 /// </summary>
-public sealed class ActorInspectTool : IAgentTool
+public sealed class WorkflowRunCurrentStateTool : IAgentTool
 {
     private readonly IWorkflowExecutionQueryApplicationService _queryService;
     private readonly WorkflowToolOptions _options;
 
-    public ActorInspectTool(
+    public WorkflowRunCurrentStateTool(
         IWorkflowExecutionQueryApplicationService queryService,
         WorkflowToolOptions options)
     {
@@ -21,15 +21,14 @@ public sealed class ActorInspectTool : IAgentTool
         _options = options;
     }
 
-    public string Name => "actor_inspect";
+    public string Name => "workflow_run_current_state";
 
-    // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):
-    //   Old pattern: Workflow artifact/report/graph query surfaces still sit under actor inspection and actor-query enablement, even after documents were renamed as artifacts/exports.
-    //   New principle: Workflow artifacts have an explicit artifact/export query surface separate from actor current-state query and tool names — graph-only workflow_artifact_query tool on existing execution facade; delete actor-shaped graph wrapper and aliases; rename artifact gate away from actor query.
+    // Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
+    //   Old pattern: workflow tooling exposed actor_inspect with actor_id snapshot semantics.
+    //   New principle: workflow tooling exposes workflow-run current-state readmodel semantics by workflow_run_id.
     public string Description =>
-        "Inspect actor state via the projection readmodel. " +
-        "Shows actor snapshots (status, output, step counts), " +
-        "and registered agents. " +
+        "Read workflow-run current state via the projection readmodel. " +
+        "Shows workflow-run status, output, step counts, and registered agents. " +
         "All data is from committed projections, not live actor internals.";
 
     public string ParametersSchema => """
@@ -39,11 +38,11 @@ public sealed class ActorInspectTool : IAgentTool
             "action": {
               "type": "string",
               "enum": ["snapshot", "list", "agents"],
-              "description": "Action: 'snapshot' (default) actor state, 'list' all actors, 'agents' registered agents"
+              "description": "Action: 'snapshot' (default) workflow-run current state, 'list' all workflow runs, 'agents' registered agents"
             },
-            "actor_id": {
+            "workflow_run_id": {
               "type": "string",
-              "description": "Actor ID (required for 'snapshot')"
+              "description": "Workflow run ID (required for 'snapshot')"
             },
             "take": {
               "type": "integer",
@@ -63,8 +62,8 @@ public sealed class ActorInspectTool : IAgentTool
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {
-        if (!_queryService.ActorQueryEnabled)
-            return """{"error":"Actor query endpoints are not enabled on this deployment."}""";
+        if (!_queryService.WorkflowRunCurrentStateQueryEnabled)
+            return """{"error":"Workflow-run current-state query is not enabled on this deployment."}""";
 
         try
         {
@@ -75,7 +74,7 @@ public sealed class ActorInspectTool : IAgentTool
             {
                 "list" or "agents" => await ListAgentsAsync(ct),
                 "snapshot" => await GetSnapshotAsync(args, ct),
-                _ => JsonSerializer.Serialize(new { error = $"Unsupported actor_inspect action '{action}'" }),
+                _ => JsonSerializer.Serialize(new { error = $"Unsupported workflow_run_current_state action '{action}'" }),
             };
         }
         catch (OperationCanceledException) { throw; }
@@ -87,17 +86,17 @@ public sealed class ActorInspectTool : IAgentTool
 
     private async Task<string> GetSnapshotAsync(ToolArgs args, CancellationToken ct)
     {
-        var actorId = args.Str("actor_id");
-        if (string.IsNullOrWhiteSpace(actorId))
-            return """{"error":"'actor_id' is required. Use action='list' to find actors."}""";
+        var workflowRunId = args.Str("workflow_run_id");
+        if (string.IsNullOrWhiteSpace(workflowRunId))
+            return """{"error":"'workflow_run_id' is required. Use action='list' to find workflow runs."}""";
 
-        var snapshot = await _queryService.GetActorSnapshotAsync(actorId, ct);
+        var snapshot = await _queryService.GetWorkflowRunCurrentStateAsync(workflowRunId, ct);
         if (snapshot == null)
-            return JsonSerializer.Serialize(new { error = $"No snapshot found for actor '{actorId}'" });
+            return JsonSerializer.Serialize(new { error = $"No current state found for workflow run '{workflowRunId}'" });
 
         return JsonSerializer.Serialize(new
         {
-            actor_id = snapshot.ActorId, workflow_name = snapshot.WorkflowName,
+            workflow_run_id = snapshot.ActorId, workflow_name = snapshot.WorkflowName,
             status = snapshot.CompletionStatus.ToString(), state_version = snapshot.StateVersion,
             last_command_id = snapshot.LastCommandId, last_event_id = snapshot.LastEventId,
             last_updated_at = snapshot.LastUpdatedAt, last_success = snapshot.LastSuccess,

--- a/src/Aevatar.AI.ToolProviders.Workflow/WorkflowAgentToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.Workflow/WorkflowAgentToolSource.cs
@@ -9,7 +9,7 @@ namespace Aevatar.AI.ToolProviders.Workflow;
 
 /// <summary>
 /// Workflow tool source. Provides tools for inspecting workflow executions,
-/// actor state (via readmodel), and event timelines.
+/// workflow-run current state (via readmodel), and event timelines.
 /// </summary>
 public sealed class WorkflowAgentToolSource : IAgentToolSource
 {
@@ -39,7 +39,7 @@ public sealed class WorkflowAgentToolSource : IAgentToolSource
         {
             new WorkflowStatusTool(_queryService, _options),
             new WorkflowArtifactQueryTool(_queryService, _options),
-            new ActorInspectTool(_queryService, _options),
+            new WorkflowRunCurrentStateTool(_queryService, _options),
             new EventQueryTool(_queryService, _options),
         };
 

--- a/src/Aevatar.AI.ToolProviders.Workflow/WorkflowAgentToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.Workflow/WorkflowAgentToolSource.cs
@@ -9,7 +9,7 @@ namespace Aevatar.AI.ToolProviders.Workflow;
 
 /// <summary>
 /// Workflow tool source. Provides tools for inspecting workflow executions,
-/// workflow-run current state (via readmodel), and event timelines.
+/// workflow actor current state (via readmodel), and event timelines.
 /// </summary>
 public sealed class WorkflowAgentToolSource : IAgentToolSource
 {
@@ -39,7 +39,7 @@ public sealed class WorkflowAgentToolSource : IAgentToolSource
         {
             new WorkflowStatusTool(_queryService, _options),
             new WorkflowArtifactQueryTool(_queryService, _options),
-            new WorkflowRunCurrentStateTool(_queryService, _options),
+            new WorkflowActorCurrentStateTool(_queryService, _options),
             new EventQueryTool(_queryService, _options),
         };
 

--- a/src/Aevatar.AI.ToolProviders.Workflow/WorkflowToolOptions.cs
+++ b/src/Aevatar.AI.ToolProviders.Workflow/WorkflowToolOptions.cs
@@ -6,8 +6,8 @@ public sealed class WorkflowToolOptions
     /// <summary>Maximum number of timeline items to return per query (default: 50).</summary>
     public int MaxTimelineItems { get; set; } = 50;
 
-    /// <summary>Maximum number of workflow-run current states to list (default: 100).</summary>
-    public int MaxWorkflowRunCurrentStates { get; set; } = 100;
+    /// <summary>Maximum number of workflow actor current states to list (default: 100).</summary>
+    public int MaxWorkflowActorCurrentStates { get; set; } = 100;
 
     /// <summary>Maximum graph traversal depth for workflow_artifact_query subgraph queries (default: 2).</summary>
     public int MaxGraphDepth { get; set; } = 2;

--- a/src/Aevatar.AI.ToolProviders.Workflow/WorkflowToolOptions.cs
+++ b/src/Aevatar.AI.ToolProviders.Workflow/WorkflowToolOptions.cs
@@ -6,8 +6,8 @@ public sealed class WorkflowToolOptions
     /// <summary>Maximum number of timeline items to return per query (default: 50).</summary>
     public int MaxTimelineItems { get; set; } = 50;
 
-    /// <summary>Maximum number of actor snapshots to list (default: 100).</summary>
-    public int MaxActorSnapshots { get; set; } = 100;
+    /// <summary>Maximum number of workflow-run current states to list (default: 100).</summary>
+    public int MaxWorkflowRunCurrentStates { get; set; } = 100;
 
     /// <summary>Maximum graph traversal depth for workflow_artifact_query subgraph queries (default: 2).</summary>
     public int MaxGraphDepth { get; set; } = 2;

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ChatRunToolCompletionCoordinator.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ChatRunToolCompletionCoordinator.cs
@@ -219,7 +219,7 @@ public sealed class ChatRunToolCompletionCoordinator
     {
         if (!string.IsNullOrWhiteSpace(dispatch.ActorId))
         {
-            var snapshot = await _workflowQueryService.GetWorkflowRunCurrentStateAsync(dispatch.ActorId, ct);
+            var snapshot = await _workflowQueryService.GetWorkflowActorCurrentStateAsync(dispatch.ActorId, ct);
             if (snapshot != null &&
                 string.Equals(snapshot.LastCommandId, dispatch.RunId, StringComparison.Ordinal) &&
                 IsTerminalWorkflowStatus(snapshot.CompletionStatus))

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ChatRunToolCompletionCoordinator.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ChatRunToolCompletionCoordinator.cs
@@ -219,7 +219,7 @@ public sealed class ChatRunToolCompletionCoordinator
     {
         if (!string.IsNullOrWhiteSpace(dispatch.ActorId))
         {
-            var snapshot = await _workflowQueryService.GetActorSnapshotAsync(dispatch.ActorId, ct);
+            var snapshot = await _workflowQueryService.GetWorkflowRunCurrentStateAsync(dispatch.ActorId, ct);
             if (snapshot != null &&
                 string.Equals(snapshot.LastCommandId, dispatch.RunId, StringComparison.Ordinal) &&
                 IsTerminalWorkflowStatus(snapshot.CompletionStatus))

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -2593,7 +2593,7 @@ const response = await fetch("{{invokePath}}", {
         IWorkflowExecutionQueryApplicationService workflowExecutionQueryService,
         CancellationToken ct)
     {
-        var snapshot = await workflowExecutionQueryService.GetActorSnapshotAsync(binding.ActorId, ct);
+        var snapshot = await workflowExecutionQueryService.GetWorkflowRunCurrentStateAsync(binding.ActorId, ct);
         var deployment = ResolveRunDeployment(binding, service, deployments);
         return new ScopeServiceRunSummaryHttpResponse(
             scopeId,
@@ -2636,7 +2636,7 @@ const response = await fetch("{{invokePath}}", {
     {
         var workflowSnapshot = snapshot.ImplementationKind == ServiceImplementationKind.Workflow &&
                                !string.IsNullOrWhiteSpace(snapshot.TargetActorId)
-            ? await workflowExecutionQueryService.GetActorSnapshotAsync(snapshot.TargetActorId, ct)
+            ? await workflowExecutionQueryService.GetWorkflowRunCurrentStateAsync(snapshot.TargetActorId, ct)
             : null;
 
         return new ScopeServiceRunSummaryHttpResponse(

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -2593,7 +2593,7 @@ const response = await fetch("{{invokePath}}", {
         IWorkflowExecutionQueryApplicationService workflowExecutionQueryService,
         CancellationToken ct)
     {
-        var snapshot = await workflowExecutionQueryService.GetWorkflowRunCurrentStateAsync(binding.ActorId, ct);
+        var snapshot = await workflowExecutionQueryService.GetWorkflowActorCurrentStateAsync(binding.ActorId, ct);
         var deployment = ResolveRunDeployment(binding, service, deployments);
         return new ScopeServiceRunSummaryHttpResponse(
             scopeId,
@@ -2636,7 +2636,7 @@ const response = await fetch("{{invokePath}}", {
     {
         var workflowSnapshot = snapshot.ImplementationKind == ServiceImplementationKind.Workflow &&
                                !string.IsNullOrWhiteSpace(snapshot.TargetActorId)
-            ? await workflowExecutionQueryService.GetWorkflowRunCurrentStateAsync(snapshot.TargetActorId, ct)
+            ? await workflowExecutionQueryService.GetWorkflowActorCurrentStateAsync(snapshot.TargetActorId, ct)
             : null;
 
         return new ScopeServiceRunSummaryHttpResponse(

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Projections/IWorkflowExecutionCurrentStateQueryPort.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Projections/IWorkflowExecutionCurrentStateQueryPort.cs
@@ -4,20 +4,20 @@ namespace Aevatar.Workflow.Application.Abstractions.Projections;
 
 public interface IWorkflowExecutionCurrentStateQueryPort
 {
-    bool WorkflowRunCurrentStateQueryEnabled { get; }
+    bool WorkflowActorCurrentStateQueryEnabled { get; }
 
     // Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
     //   Old pattern: query callers requested an actor snapshot by raw actorId through actor-query naming.
-    //   New principle: query callers request a workflow-run current-state readmodel by workflowRunId.
-    Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(
-        string workflowRunId,
+    //   New principle: query callers request a workflow actor current-state readmodel by actorId.
+    Task<WorkflowActorSnapshot?> GetWorkflowActorCurrentStateAsync(
+        string actorId,
         CancellationToken ct = default);
 
-    Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowRunCurrentStatesAsync(
+    Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowActorCurrentStatesAsync(
         int take = 200,
         CancellationToken ct = default);
 
-    Task<WorkflowActorProjectionState?> GetWorkflowRunProjectionStateAsync(
-        string workflowRunId,
+    Task<WorkflowActorProjectionState?> GetWorkflowActorProjectionStateAsync(
+        string actorId,
         CancellationToken ct = default);
 }

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Projections/IWorkflowExecutionCurrentStateQueryPort.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Projections/IWorkflowExecutionCurrentStateQueryPort.cs
@@ -4,17 +4,20 @@ namespace Aevatar.Workflow.Application.Abstractions.Projections;
 
 public interface IWorkflowExecutionCurrentStateQueryPort
 {
-    bool EnableActorQueryEndpoints { get; }
+    bool WorkflowRunCurrentStateQueryEnabled { get; }
 
-    Task<WorkflowActorSnapshot?> GetActorSnapshotAsync(
-        string actorId,
+    // Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
+    //   Old pattern: query callers requested an actor snapshot by raw actorId through actor-query naming.
+    //   New principle: query callers request a workflow-run current-state readmodel by workflowRunId.
+    Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(
+        string workflowRunId,
         CancellationToken ct = default);
 
-    Task<IReadOnlyList<WorkflowActorSnapshot>> ListActorSnapshotsAsync(
+    Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowRunCurrentStatesAsync(
         int take = 200,
         CancellationToken ct = default);
 
-    Task<WorkflowActorProjectionState?> GetActorProjectionStateAsync(
-        string actorId,
+    Task<WorkflowActorProjectionState?> GetWorkflowRunProjectionStateAsync(
+        string workflowRunId,
         CancellationToken ct = default);
 }

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Queries/IWorkflowExecutionQueryApplicationService.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Queries/IWorkflowExecutionQueryApplicationService.cs
@@ -2,7 +2,7 @@ namespace Aevatar.Workflow.Application.Abstractions.Queries;
 
 public interface IWorkflowExecutionQueryApplicationService
 {
-    bool ActorQueryEnabled { get; }
+    bool WorkflowRunCurrentStateQueryEnabled { get; }
 
     Task<IReadOnlyList<WorkflowAgentSummary>> ListAgentsAsync(CancellationToken ct = default);
 
@@ -14,7 +14,10 @@ public interface IWorkflowExecutionQueryApplicationService
 
     Task<WorkflowCapabilitiesDocument> GetCapabilitiesAsync(CancellationToken ct = default);
 
-    Task<WorkflowActorSnapshot?> GetActorSnapshotAsync(string actorId, CancellationToken ct = default);
+    // Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
+    //   Old pattern: application query contract exposed actor snapshot inspection by actorId.
+    //   New principle: application query contract exposes workflow-run current-state readmodel lookup by workflowRunId.
+    Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string workflowRunId, CancellationToken ct = default);
 
     // Refactor (iter29/cluster-029-workflow-history-artifact):
     //   Old pattern: workflow history / report / graph are treated as current-state readmodels (current-state query path enriches actor snapshots by reading report artifacts; duplicate WorkflowRunTimelineDocument and WorkflowRunGraphArtifactDocument shells copy WorkflowRunInsightReportDocument; public application/query/tool/HTTP surfaces expose them as actor current-state queries instead of workflow-run artifacts)

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Queries/IWorkflowExecutionQueryApplicationService.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Queries/IWorkflowExecutionQueryApplicationService.cs
@@ -2,7 +2,7 @@ namespace Aevatar.Workflow.Application.Abstractions.Queries;
 
 public interface IWorkflowExecutionQueryApplicationService
 {
-    bool WorkflowRunCurrentStateQueryEnabled { get; }
+    bool WorkflowActorCurrentStateQueryEnabled { get; }
 
     Task<IReadOnlyList<WorkflowAgentSummary>> ListAgentsAsync(CancellationToken ct = default);
 
@@ -16,8 +16,8 @@ public interface IWorkflowExecutionQueryApplicationService
 
     // Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
     //   Old pattern: application query contract exposed actor snapshot inspection by actorId.
-    //   New principle: application query contract exposes workflow-run current-state readmodel lookup by workflowRunId.
-    Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string workflowRunId, CancellationToken ct = default);
+    //   New principle: application query contract exposes workflow actor current-state readmodel lookup by actorId.
+    Task<WorkflowActorSnapshot?> GetWorkflowActorCurrentStateAsync(string actorId, CancellationToken ct = default);
 
     // Refactor (iter29/cluster-029-workflow-history-artifact):
     //   Old pattern: workflow history / report / graph are treated as current-state readmodels (current-state query path enriches actor snapshots by reading report artifacts; duplicate WorkflowRunTimelineDocument and WorkflowRunGraphArtifactDocument shells copy WorkflowRunInsightReportDocument; public application/query/tool/HTTP surfaces expose them as actor current-state queries instead of workflow-run artifacts)

--- a/src/workflow/Aevatar.Workflow.Application/Queries/WorkflowExecutionQueryApplicationService.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Queries/WorkflowExecutionQueryApplicationService.cs
@@ -26,7 +26,7 @@ public sealed class WorkflowExecutionQueryApplicationService : IWorkflowExecutio
         _workflowCapabilitiesPort = workflowCapabilitiesPort ?? throw new ArgumentNullException(nameof(workflowCapabilitiesPort));
     }
 
-    public bool WorkflowRunCurrentStateQueryEnabled => _currentStateQueryPort.WorkflowRunCurrentStateQueryEnabled;
+    public bool WorkflowActorCurrentStateQueryEnabled => _currentStateQueryPort.WorkflowActorCurrentStateQueryEnabled;
 
     // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):
     //   Old pattern: Workflow artifact/report/graph query surfaces still sit under actor inspection and actor-query enablement, even after documents were renamed as artifacts/exports.
@@ -35,10 +35,10 @@ public sealed class WorkflowExecutionQueryApplicationService : IWorkflowExecutio
     public async Task<IReadOnlyList<WorkflowAgentSummary>> ListAgentsAsync(CancellationToken ct = default)
     {
         ct.ThrowIfCancellationRequested();
-        if (!WorkflowRunCurrentStateQueryEnabled)
+        if (!WorkflowActorCurrentStateQueryEnabled)
             return [];
 
-        var snapshots = await _currentStateQueryPort.ListWorkflowRunCurrentStatesAsync(ct: ct);
+        var snapshots = await _currentStateQueryPort.ListWorkflowActorCurrentStatesAsync(ct: ct);
         return snapshots
             .Select(snapshot => new WorkflowAgentSummary(
                 snapshot.ActorId,
@@ -67,13 +67,13 @@ public sealed class WorkflowExecutionQueryApplicationService : IWorkflowExecutio
 
     // Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
     //   Old pattern: application service exposed GetActorSnapshotAsync(actorId) as an actor inspection query.
-    //   New principle: application service exposes GetWorkflowRunCurrentStateAsync(workflowRunId) over the current-state readmodel.
-    public async Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string workflowRunId, CancellationToken ct = default)
+    //   New principle: application service exposes GetWorkflowActorCurrentStateAsync(actorId) over the current-state readmodel.
+    public async Task<WorkflowActorSnapshot?> GetWorkflowActorCurrentStateAsync(string actorId, CancellationToken ct = default)
     {
-        if (!WorkflowRunCurrentStateQueryEnabled)
+        if (!WorkflowActorCurrentStateQueryEnabled)
             return null;
 
-        return await _currentStateQueryPort.GetWorkflowRunCurrentStateAsync(workflowRunId, ct);
+        return await _currentStateQueryPort.GetWorkflowActorCurrentStateAsync(actorId, ct);
     }
 
     public async Task<WorkflowRunReport?> GetWorkflowRunReportArtifactAsync(string workflowRunId, CancellationToken ct = default)

--- a/src/workflow/Aevatar.Workflow.Application/Queries/WorkflowExecutionQueryApplicationService.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Queries/WorkflowExecutionQueryApplicationService.cs
@@ -26,7 +26,7 @@ public sealed class WorkflowExecutionQueryApplicationService : IWorkflowExecutio
         _workflowCapabilitiesPort = workflowCapabilitiesPort ?? throw new ArgumentNullException(nameof(workflowCapabilitiesPort));
     }
 
-    public bool ActorQueryEnabled => _currentStateQueryPort.EnableActorQueryEndpoints;
+    public bool WorkflowRunCurrentStateQueryEnabled => _currentStateQueryPort.WorkflowRunCurrentStateQueryEnabled;
 
     // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):
     //   Old pattern: Workflow artifact/report/graph query surfaces still sit under actor inspection and actor-query enablement, even after documents were renamed as artifacts/exports.
@@ -35,10 +35,10 @@ public sealed class WorkflowExecutionQueryApplicationService : IWorkflowExecutio
     public async Task<IReadOnlyList<WorkflowAgentSummary>> ListAgentsAsync(CancellationToken ct = default)
     {
         ct.ThrowIfCancellationRequested();
-        if (!ActorQueryEnabled)
+        if (!WorkflowRunCurrentStateQueryEnabled)
             return [];
 
-        var snapshots = await _currentStateQueryPort.ListActorSnapshotsAsync(ct: ct);
+        var snapshots = await _currentStateQueryPort.ListWorkflowRunCurrentStatesAsync(ct: ct);
         return snapshots
             .Select(snapshot => new WorkflowAgentSummary(
                 snapshot.ActorId,
@@ -65,12 +65,15 @@ public sealed class WorkflowExecutionQueryApplicationService : IWorkflowExecutio
     public Task<WorkflowCapabilitiesDocument> GetCapabilitiesAsync(CancellationToken ct = default) =>
         _workflowCapabilitiesPort.GetCapabilitiesAsync(ct);
 
-    public async Task<WorkflowActorSnapshot?> GetActorSnapshotAsync(string actorId, CancellationToken ct = default)
+    // Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
+    //   Old pattern: application service exposed GetActorSnapshotAsync(actorId) as an actor inspection query.
+    //   New principle: application service exposes GetWorkflowRunCurrentStateAsync(workflowRunId) over the current-state readmodel.
+    public async Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string workflowRunId, CancellationToken ct = default)
     {
-        if (!ActorQueryEnabled)
+        if (!WorkflowRunCurrentStateQueryEnabled)
             return null;
 
-        return await _currentStateQueryPort.GetActorSnapshotAsync(actorId, ct);
+        return await _currentStateQueryPort.GetWorkflowRunCurrentStateAsync(workflowRunId, ct);
     }
 
     public async Task<WorkflowRunReport?> GetWorkflowRunReportArtifactAsync(string workflowRunId, CancellationToken ct = default)

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunDurableCompletionResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunDurableCompletionResolver.cs
@@ -27,7 +27,7 @@ internal sealed class WorkflowRunDurableCompletionResolver
 
         try
         {
-            var snapshot = await _currentStateQueryPort.GetWorkflowRunCurrentStateAsync(actorId, ct);
+            var snapshot = await _currentStateQueryPort.GetWorkflowActorCurrentStateAsync(actorId, ct);
             return MapSnapshot(snapshot);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunDurableCompletionResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunDurableCompletionResolver.cs
@@ -27,7 +27,7 @@ internal sealed class WorkflowRunDurableCompletionResolver
 
         try
         {
-            var snapshot = await _currentStateQueryPort.GetActorSnapshotAsync(actorId, ct);
+            var snapshot = await _currentStateQueryPort.GetWorkflowRunCurrentStateAsync(actorId, ct);
             return MapSnapshot(snapshot);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunFinalizeEmitter.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunFinalizeEmitter.cs
@@ -56,7 +56,7 @@ public sealed class WorkflowRunFinalizeEmitter
     {
         try
         {
-            return await _currentStateQueryPort.GetActorSnapshotAsync(actorId, ct);
+            return await _currentStateQueryPort.GetWorkflowRunCurrentStateAsync(actorId, ct);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -72,7 +72,7 @@ public sealed class WorkflowRunFinalizeEmitter
     {
         try
         {
-            return await _currentStateQueryPort.GetActorProjectionStateAsync(actorId, ct);
+            return await _currentStateQueryPort.GetWorkflowRunProjectionStateAsync(actorId, ct);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunFinalizeEmitter.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunFinalizeEmitter.cs
@@ -56,7 +56,7 @@ public sealed class WorkflowRunFinalizeEmitter
     {
         try
         {
-            return await _currentStateQueryPort.GetWorkflowRunCurrentStateAsync(actorId, ct);
+            return await _currentStateQueryPort.GetWorkflowActorCurrentStateAsync(actorId, ct);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -72,7 +72,7 @@ public sealed class WorkflowRunFinalizeEmitter
     {
         try
         {
-            return await _currentStateQueryPort.GetWorkflowRunProjectionStateAsync(actorId, ct);
+            return await _currentStateQueryPort.GetWorkflowActorProjectionStateAsync(actorId, ct);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
@@ -207,7 +207,7 @@ public static class WorkflowCapabilityEndpoints
 
             // Refactor (iter56/cluster-891-endpoint-ack-honesty): old=200-shaped accepted, new=202 + Location
             //   Resume dispatch only proves inbox admission for the workflow actor, not applied continuation state.
-            //   The workflow-run current-state read model remains the status resource for observing the run after acceptance.
+            //   The workflow actor current-state read model remains the status resource for observing the run after acceptance.
             var statusUrl = BuildWorkflowRunStatusUrl(dispatch.Receipt);
             return Results.Accepted(statusUrl, new
             {
@@ -271,7 +271,7 @@ public static class WorkflowCapabilityEndpoints
 
             // Refactor (iter56/cluster-891-endpoint-ack-honesty): old=200-shaped accepted, new=202 + Location
             //   Signal dispatch only proves inbox admission for the workflow actor, not applied signal handling.
-            //   The workflow-run current-state read model remains the status resource for observing the run after acceptance.
+            //   The workflow actor current-state read model remains the status resource for observing the run after acceptance.
             var statusUrl = BuildWorkflowRunStatusUrl(dispatch.Receipt);
             return Results.Accepted(statusUrl, new
             {
@@ -332,7 +332,7 @@ public static class WorkflowCapabilityEndpoints
 
             // Refactor (iter56/cluster-891-endpoint-ack-honesty): old=200-shaped accepted, new=202 + Location
             //   Stop dispatch only proves inbox admission for the workflow actor, not terminal run state.
-            //   The workflow-run current-state read model remains the status resource for observing the run after acceptance.
+            //   The workflow actor current-state read model remains the status resource for observing the run after acceptance.
             var statusUrl = BuildWorkflowRunStatusUrl(dispatch.Receipt);
             return Results.Accepted(statusUrl, new
             {
@@ -361,9 +361,9 @@ public static class WorkflowCapabilityEndpoints
 
     // Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
     //   Old pattern: accepted status links pointed at /api/actors/{actorId}.
-    //   New principle: accepted status links point at the workflow-run current-state readmodel resource.
-    private static string BuildWorkflowRunStatusUrl(string workflowRunId) =>
-        $"/api/workflow-runs/{Uri.EscapeDataString(workflowRunId)}/current-state";
+    //   New principle: accepted status links point at the workflow actor current-state readmodel resource.
+    private static string BuildWorkflowRunStatusUrl(string actorId) =>
+        $"/api/workflow-actors/{Uri.EscapeDataString(actorId)}/current-state";
 
     private static WorkflowRunEventEnvelope BuildRunContextFrame(WorkflowChatRunAcceptedReceipt receipt) =>
         new()

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
@@ -148,7 +148,7 @@ public static class WorkflowCapabilityEndpoints
             }
 
             return Results.Accepted(
-                $"/api/actors/{dispatchResult.Receipt.ActorId}",
+                BuildWorkflowRunStatusUrl(dispatchResult.Receipt.ActorId),
                 CapabilityTraceContext.CreateAcceptedPayload(dispatchResult.Receipt));
         }
         catch (OperationCanceledException)
@@ -207,7 +207,7 @@ public static class WorkflowCapabilityEndpoints
 
             // Refactor (iter56/cluster-891-endpoint-ack-honesty): old=200-shaped accepted, new=202 + Location
             //   Resume dispatch only proves inbox admission for the workflow actor, not applied continuation state.
-            //   The actor read model remains the status resource for observing the run after acceptance.
+            //   The workflow-run current-state read model remains the status resource for observing the run after acceptance.
             var statusUrl = BuildWorkflowRunStatusUrl(dispatch.Receipt);
             return Results.Accepted(statusUrl, new
             {
@@ -271,7 +271,7 @@ public static class WorkflowCapabilityEndpoints
 
             // Refactor (iter56/cluster-891-endpoint-ack-honesty): old=200-shaped accepted, new=202 + Location
             //   Signal dispatch only proves inbox admission for the workflow actor, not applied signal handling.
-            //   The actor read model remains the status resource for observing the run after acceptance.
+            //   The workflow-run current-state read model remains the status resource for observing the run after acceptance.
             var statusUrl = BuildWorkflowRunStatusUrl(dispatch.Receipt);
             return Results.Accepted(statusUrl, new
             {
@@ -332,7 +332,7 @@ public static class WorkflowCapabilityEndpoints
 
             // Refactor (iter56/cluster-891-endpoint-ack-honesty): old=200-shaped accepted, new=202 + Location
             //   Stop dispatch only proves inbox admission for the workflow actor, not terminal run state.
-            //   The actor read model remains the status resource for observing the run after acceptance.
+            //   The workflow-run current-state read model remains the status resource for observing the run after acceptance.
             var statusUrl = BuildWorkflowRunStatusUrl(dispatch.Receipt);
             return Results.Accepted(statusUrl, new
             {
@@ -357,7 +357,13 @@ public static class WorkflowCapabilityEndpoints
     }
 
     private static string BuildWorkflowRunStatusUrl(WorkflowRunControlAcceptedReceipt receipt) =>
-        $"/api/actors/{Uri.EscapeDataString(receipt.ActorId)}";
+        BuildWorkflowRunStatusUrl(receipt.ActorId);
+
+    // Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
+    //   Old pattern: accepted status links pointed at /api/actors/{actorId}.
+    //   New principle: accepted status links point at the workflow-run current-state readmodel resource.
+    private static string BuildWorkflowRunStatusUrl(string workflowRunId) =>
+        $"/api/workflow-runs/{Uri.EscapeDataString(workflowRunId)}/current-state";
 
     private static WorkflowRunEventEnvelope BuildRunContextFrame(WorkflowChatRunAcceptedReceipt receipt) =>
         new()

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatQueryEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatQueryEndpoints.cs
@@ -29,7 +29,7 @@ public static class ChatQueryEndpoints
             .Produces(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status404NotFound);
 
-        group.MapGet("/actors/{actorId}", GetActorSnapshot)
+        group.MapGet("/workflow-runs/{workflowRunId}/current-state", GetWorkflowRunCurrentState)
             // security-allowlist: workflow standalone host is dev-only; production hosts must add .RequireAuthorization() -- see cluster-022
             .Produces(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status404NotFound);
@@ -110,13 +110,16 @@ public static class ChatQueryEndpoints
         return detail == null ? Results.NotFound() : Results.Ok(detail);
     }
 
-    internal static async Task<IResult> GetActorSnapshot(
-        string actorId,
+    // Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
+    //   Old pattern: HTTP query exposed /actors/{actorId} as actor snapshot inspection.
+    //   New principle: HTTP query exposes /workflow-runs/{workflowRunId}/current-state as a readmodel resource.
+    internal static async Task<IResult> GetWorkflowRunCurrentState(
+        string workflowRunId,
         IWorkflowExecutionQueryApplicationService queryService,
         CancellationToken ct = default)
     {
-        var snapshot = await queryService.GetActorSnapshotAsync(actorId, ct);
-        return snapshot == null ? Results.NotFound() : Results.Ok(MapSnapshot(snapshot));
+        var currentState = await queryService.GetWorkflowRunCurrentStateAsync(workflowRunId, ct);
+        return currentState == null ? Results.NotFound() : Results.Ok(MapCurrentState(currentState));
     }
 
     // Refactor (iter29/cluster-029-workflow-history-artifact):
@@ -155,13 +158,13 @@ public static class ChatQueryEndpoints
         string[]? edgeTypes = null,
         CancellationToken ct = default)
     {
-        var snapshot = await queryService.GetActorSnapshotAsync(workflowRunId, ct);
+        var snapshot = await queryService.GetWorkflowRunCurrentStateAsync(workflowRunId, ct);
         if (snapshot == null)
             return Results.NotFound();
 
         var graphOptions = BuildGraphQueryOptions(direction, edgeTypes);
         var subgraph = await queryService.GetWorkflowRunGraphExportSubgraphAsync(workflowRunId, depth, take, graphOptions, ct);
-        return Results.Ok(new WorkflowRunGraphExportEnrichedHttpResponse(MapSnapshot(snapshot), MapGraphSubgraph(subgraph)));
+        return Results.Ok(new WorkflowRunGraphExportEnrichedHttpResponse(MapCurrentState(snapshot), MapGraphSubgraph(subgraph)));
     }
 
     internal static async Task<IResult> GetWorkflowRunGraphExportSubgraph(
@@ -211,7 +214,7 @@ public static class ChatQueryEndpoints
             .ToArray();
     }
 
-    private static WorkflowActorSnapshotHttpResponse MapSnapshot(WorkflowActorSnapshot snapshot) =>
+    private static WorkflowRunCurrentStateHttpResponse MapCurrentState(WorkflowActorSnapshot snapshot) =>
         new(
             snapshot.ActorId,
             snapshot.WorkflowName,
@@ -293,8 +296,11 @@ public static class ChatQueryEndpoints
                 .ToList());
 }
 
-public sealed record WorkflowActorSnapshotHttpResponse(
-    string ActorId,
+// Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
+//   Old pattern: HTTP response was named WorkflowActorSnapshotHttpResponse and serialized actorId.
+//   New principle: HTTP response is workflow-run current-state shaped and serializes workflowRunId.
+public sealed record WorkflowRunCurrentStateHttpResponse(
+    string WorkflowRunId,
     string WorkflowName,
     string LastCommandId,
     WorkflowRunCompletionStatus CompletionStatus,
@@ -354,7 +360,7 @@ public sealed record WorkflowRunGraphExportSubgraphHttpResponse(
 //   Old pattern: enriched HTTP graph responses mixed actor current-state naming with graph artifacts.
 //   New principle: enriched HTTP graph responses are workflow-run graph export artifacts plus the current snapshot.
 public sealed record WorkflowRunGraphExportEnrichedHttpResponse(
-    WorkflowActorSnapshotHttpResponse Snapshot,
+    WorkflowRunCurrentStateHttpResponse CurrentState,
     WorkflowRunGraphExportSubgraphHttpResponse Subgraph);
 
 public sealed record WorkflowPrimitiveParameterDescriptorHttpResponse(

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatQueryEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatQueryEndpoints.cs
@@ -29,7 +29,7 @@ public static class ChatQueryEndpoints
             .Produces(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status404NotFound);
 
-        group.MapGet("/workflow-runs/{workflowRunId}/current-state", GetWorkflowRunCurrentState)
+        group.MapGet("/workflow-actors/{actorId}/current-state", GetWorkflowActorCurrentState)
             // security-allowlist: workflow standalone host is dev-only; production hosts must add .RequireAuthorization() -- see cluster-022
             .Produces(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status404NotFound);
@@ -112,13 +112,13 @@ public static class ChatQueryEndpoints
 
     // Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
     //   Old pattern: HTTP query exposed /actors/{actorId} as actor snapshot inspection.
-    //   New principle: HTTP query exposes /workflow-runs/{workflowRunId}/current-state as a readmodel resource.
-    internal static async Task<IResult> GetWorkflowRunCurrentState(
-        string workflowRunId,
+    //   New principle: HTTP query exposes /workflow-actors/{actorId}/current-state as a readmodel resource.
+    internal static async Task<IResult> GetWorkflowActorCurrentState(
+        string actorId,
         IWorkflowExecutionQueryApplicationService queryService,
         CancellationToken ct = default)
     {
-        var currentState = await queryService.GetWorkflowRunCurrentStateAsync(workflowRunId, ct);
+        var currentState = await queryService.GetWorkflowActorCurrentStateAsync(actorId, ct);
         return currentState == null ? Results.NotFound() : Results.Ok(MapCurrentState(currentState));
     }
 
@@ -158,13 +158,9 @@ public static class ChatQueryEndpoints
         string[]? edgeTypes = null,
         CancellationToken ct = default)
     {
-        var snapshot = await queryService.GetWorkflowRunCurrentStateAsync(workflowRunId, ct);
-        if (snapshot == null)
-            return Results.NotFound();
-
         var graphOptions = BuildGraphQueryOptions(direction, edgeTypes);
         var subgraph = await queryService.GetWorkflowRunGraphExportSubgraphAsync(workflowRunId, depth, take, graphOptions, ct);
-        return Results.Ok(new WorkflowRunGraphExportEnrichedHttpResponse(MapCurrentState(snapshot), MapGraphSubgraph(subgraph)));
+        return Results.Ok(MapGraphSubgraph(subgraph));
     }
 
     internal static async Task<IResult> GetWorkflowRunGraphExportSubgraph(
@@ -214,7 +210,7 @@ public static class ChatQueryEndpoints
             .ToArray();
     }
 
-    private static WorkflowRunCurrentStateHttpResponse MapCurrentState(WorkflowActorSnapshot snapshot) =>
+    private static WorkflowActorCurrentStateHttpResponse MapCurrentState(WorkflowActorSnapshot snapshot) =>
         new(
             snapshot.ActorId,
             snapshot.WorkflowName,
@@ -298,9 +294,9 @@ public static class ChatQueryEndpoints
 
 // Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
 //   Old pattern: HTTP response was named WorkflowActorSnapshotHttpResponse and serialized actorId.
-//   New principle: HTTP response is workflow-run current-state shaped and serializes workflowRunId.
-public sealed record WorkflowRunCurrentStateHttpResponse(
-    string WorkflowRunId,
+//   New principle: HTTP response is workflow actor current-state shaped and serializes actorId.
+public sealed record WorkflowActorCurrentStateHttpResponse(
+    string ActorId,
     string WorkflowName,
     string LastCommandId,
     WorkflowRunCompletionStatus CompletionStatus,
@@ -355,13 +351,6 @@ public sealed record WorkflowRunGraphExportSubgraphHttpResponse(
     string RootNodeId,
     List<WorkflowRunGraphExportNodeHttpResponse> Nodes,
     List<WorkflowRunGraphExportEdgeHttpResponse> Edges);
-
-// Refactor (iter29/cluster-029-workflow-history-artifact):
-//   Old pattern: enriched HTTP graph responses mixed actor current-state naming with graph artifacts.
-//   New principle: enriched HTTP graph responses are workflow-run graph export artifacts plus the current snapshot.
-public sealed record WorkflowRunGraphExportEnrichedHttpResponse(
-    WorkflowRunCurrentStateHttpResponse CurrentState,
-    WorkflowRunGraphExportSubgraphHttpResponse Subgraph);
 
 public sealed record WorkflowPrimitiveParameterDescriptorHttpResponse(
     string Name,

--- a/src/workflow/Aevatar.Workflow.Projection/Configuration/WorkflowExecutionProjectionOptions.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Configuration/WorkflowExecutionProjectionOptions.cs
@@ -15,9 +15,12 @@ public sealed class WorkflowExecutionProjectionOptions
     public bool Enabled { get; set; } = true;
 
     /// <summary>
-    /// Exposes read-side actor query endpoints.
+    /// Exposes workflow-run current-state readmodel query endpoints.
     /// </summary>
-    public bool EnableActorQueryEndpoints { get; set; } = true;
+    // Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
+    //   Old pattern: current-state query enablement was named EnableActorQueryEndpoints.
+    //   New principle: current-state query enablement is named for workflow-run readmodel semantics.
+    public bool WorkflowRunCurrentStateQueryEnabled { get; set; } = true;
 
     /// <summary>
     /// Exposes workflow artifact/export query endpoints.

--- a/src/workflow/Aevatar.Workflow.Projection/Configuration/WorkflowExecutionProjectionOptions.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Configuration/WorkflowExecutionProjectionOptions.cs
@@ -15,12 +15,12 @@ public sealed class WorkflowExecutionProjectionOptions
     public bool Enabled { get; set; } = true;
 
     /// <summary>
-    /// Exposes workflow-run current-state readmodel query endpoints.
+    /// Exposes workflow actor current-state readmodel query endpoints.
     /// </summary>
     // Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
     //   Old pattern: current-state query enablement was named EnableActorQueryEndpoints.
     //   New principle: current-state query enablement is named for workflow-run readmodel semantics.
-    public bool WorkflowRunCurrentStateQueryEnabled { get; set; } = true;
+    public bool WorkflowActorCurrentStateQueryEnabled { get; set; } = true;
 
     /// <summary>
     /// Exposes workflow artifact/export query endpoints.

--- a/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowExecutionCurrentStateQueryPort.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowExecutionCurrentStateQueryPort.cs
@@ -9,7 +9,7 @@ public sealed class WorkflowExecutionCurrentStateQueryPort : IWorkflowExecutionC
 {
     private readonly IProjectionDocumentReader<WorkflowExecutionCurrentStateDocument, string> _currentStateReader;
     private readonly WorkflowExecutionReadModelMapper _mapper;
-    private readonly bool _enableActorQueryEndpoints;
+    private readonly bool _workflowRunCurrentStateQueryEnabled;
 
     // Refactor (iter29/cluster-029-workflow-history-artifact):
     //   Old pattern: workflow history / report / graph are treated as current-state readmodels (current-state query path enriches actor snapshots by reading report artifacts; duplicate WorkflowRunTimelineDocument and WorkflowRunGraphArtifactDocument shells copy WorkflowRunInsightReportDocument; public application/query/tool/HTTP surfaces expose them as actor current-state queries instead of workflow-run artifacts)
@@ -22,30 +22,33 @@ public sealed class WorkflowExecutionCurrentStateQueryPort : IWorkflowExecutionC
     {
         _currentStateReader = currentStateReader ?? throw new ArgumentNullException(nameof(currentStateReader));
         _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
-        _enableActorQueryEndpoints = options == null || (options.Enabled && options.EnableActorQueryEndpoints);
+        _workflowRunCurrentStateQueryEnabled = options == null || (options.Enabled && options.WorkflowRunCurrentStateQueryEnabled);
     }
 
-    public bool EnableActorQueryEndpoints => _enableActorQueryEndpoints;
+    public bool WorkflowRunCurrentStateQueryEnabled => _workflowRunCurrentStateQueryEnabled;
 
-    public async Task<WorkflowActorSnapshot?> GetActorSnapshotAsync(
-        string actorId,
+    // Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
+    //   Old pattern: projection port exposed actor snapshot lookup by actorId.
+    //   New principle: projection port exposes workflow-run current-state lookup while still reading the actor-scoped document key.
+    public async Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(
+        string workflowRunId,
         CancellationToken ct = default)
     {
-        if (!_enableActorQueryEndpoints || string.IsNullOrWhiteSpace(actorId))
+        if (!_workflowRunCurrentStateQueryEnabled || string.IsNullOrWhiteSpace(workflowRunId))
             return null;
 
-        var currentState = await _currentStateReader.GetAsync(actorId, ct);
+        var currentState = await _currentStateReader.GetAsync(workflowRunId, ct);
         if (currentState == null)
             return null;
 
         return _mapper.ToActorSnapshot(currentState);
     }
 
-    public async Task<IReadOnlyList<WorkflowActorSnapshot>> ListActorSnapshotsAsync(
+    public async Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowRunCurrentStatesAsync(
         int take = 200,
         CancellationToken ct = default)
     {
-        if (!_enableActorQueryEndpoints)
+        if (!_workflowRunCurrentStateQueryEnabled)
             return [];
 
         var boundedTake = Math.Clamp(take, 1, 1000);
@@ -64,14 +67,14 @@ public sealed class WorkflowExecutionCurrentStateQueryPort : IWorkflowExecutionC
         return snapshots;
     }
 
-    public async Task<WorkflowActorProjectionState?> GetActorProjectionStateAsync(
-        string actorId,
+    public async Task<WorkflowActorProjectionState?> GetWorkflowRunProjectionStateAsync(
+        string workflowRunId,
         CancellationToken ct = default)
     {
-        if (!_enableActorQueryEndpoints || string.IsNullOrWhiteSpace(actorId))
+        if (!_workflowRunCurrentStateQueryEnabled || string.IsNullOrWhiteSpace(workflowRunId))
             return null;
 
-        var currentState = await _currentStateReader.GetAsync(actorId, ct);
+        var currentState = await _currentStateReader.GetAsync(workflowRunId, ct);
         return currentState == null ? null : _mapper.ToActorProjectionState(currentState);
     }
 }

--- a/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowExecutionCurrentStateQueryPort.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowExecutionCurrentStateQueryPort.cs
@@ -22,29 +22,29 @@ public sealed class WorkflowExecutionCurrentStateQueryPort : IWorkflowExecutionC
     {
         _currentStateReader = currentStateReader ?? throw new ArgumentNullException(nameof(currentStateReader));
         _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
-        _workflowRunCurrentStateQueryEnabled = options == null || (options.Enabled && options.WorkflowRunCurrentStateQueryEnabled);
+        _workflowRunCurrentStateQueryEnabled = options == null || (options.Enabled && options.WorkflowActorCurrentStateQueryEnabled);
     }
 
-    public bool WorkflowRunCurrentStateQueryEnabled => _workflowRunCurrentStateQueryEnabled;
+    public bool WorkflowActorCurrentStateQueryEnabled => _workflowRunCurrentStateQueryEnabled;
 
     // Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
     //   Old pattern: projection port exposed actor snapshot lookup by actorId.
-    //   New principle: projection port exposes workflow-run current-state lookup while still reading the actor-scoped document key.
-    public async Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(
-        string workflowRunId,
+    //   New principle: projection port exposes workflow actor current-state lookup while still reading the actor-scoped document key.
+    public async Task<WorkflowActorSnapshot?> GetWorkflowActorCurrentStateAsync(
+        string actorId,
         CancellationToken ct = default)
     {
-        if (!_workflowRunCurrentStateQueryEnabled || string.IsNullOrWhiteSpace(workflowRunId))
+        if (!_workflowRunCurrentStateQueryEnabled || string.IsNullOrWhiteSpace(actorId))
             return null;
 
-        var currentState = await _currentStateReader.GetAsync(workflowRunId, ct);
+        var currentState = await _currentStateReader.GetAsync(actorId, ct);
         if (currentState == null)
             return null;
 
         return _mapper.ToActorSnapshot(currentState);
     }
 
-    public async Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowRunCurrentStatesAsync(
+    public async Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowActorCurrentStatesAsync(
         int take = 200,
         CancellationToken ct = default)
     {
@@ -67,14 +67,14 @@ public sealed class WorkflowExecutionCurrentStateQueryPort : IWorkflowExecutionC
         return snapshots;
     }
 
-    public async Task<WorkflowActorProjectionState?> GetWorkflowRunProjectionStateAsync(
-        string workflowRunId,
+    public async Task<WorkflowActorProjectionState?> GetWorkflowActorProjectionStateAsync(
+        string actorId,
         CancellationToken ct = default)
     {
-        if (!_workflowRunCurrentStateQueryEnabled || string.IsNullOrWhiteSpace(workflowRunId))
+        if (!_workflowRunCurrentStateQueryEnabled || string.IsNullOrWhiteSpace(actorId))
             return null;
 
-        var currentState = await _currentStateReader.GetAsync(workflowRunId, ct);
+        var currentState = await _currentStateReader.GetAsync(actorId, ct);
         return currentState == null ? null : _mapper.ToActorProjectionState(currentState);
     }
 }

--- a/src/workflow/Aevatar.Workflow.Sdk/AevatarWorkflowClient.cs
+++ b/src/workflow/Aevatar.Workflow.Sdk/AevatarWorkflowClient.cs
@@ -248,16 +248,16 @@ public sealed class AevatarWorkflowClient : IAevatarWorkflowClient
 
     // Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
     //   Old pattern: SDK called /api/actors/{actorId} and named the result an actor snapshot.
-    //   New principle: SDK calls the workflow-run current-state readmodel endpoint by workflowRunId.
-    public async Task<JsonElement?> GetWorkflowRunCurrentStateAsync(
-        string workflowRunId,
+    //   New principle: SDK calls the workflow actor current-state readmodel endpoint by actorId.
+    public async Task<JsonElement?> GetWorkflowActorCurrentStateAsync(
+        string actorId,
         CancellationToken cancellationToken = default)
     {
-        EnsureNotBlank(workflowRunId, nameof(workflowRunId));
+        EnsureNotBlank(actorId, nameof(actorId));
 
         using var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/api/workflow-runs/{Uri.EscapeDataString(workflowRunId)}/current-state");
+            $"/api/workflow-actors/{Uri.EscapeDataString(actorId)}/current-state");
         using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         if (response.StatusCode == HttpStatusCode.NotFound)
             return null;
@@ -268,7 +268,7 @@ public sealed class AevatarWorkflowClient : IAevatarWorkflowClient
             throw WorkflowSdkJson.BuildHttpException(
                 response.StatusCode,
                 rawPayload,
-                $"Workflow-run current-state request failed with HTTP {(int)response.StatusCode}.");
+                $"Workflow actor current-state request failed with HTTP {(int)response.StatusCode}.");
         }
 
         if (string.IsNullOrWhiteSpace(rawPayload))
@@ -282,7 +282,7 @@ public sealed class AevatarWorkflowClient : IAevatarWorkflowClient
         catch (JsonException ex)
         {
             throw AevatarWorkflowException.StreamPayload(
-                "Failed to parse workflow-run current-state response payload.",
+                "Failed to parse workflow actor current-state response payload.",
                 rawPayload,
                 ex);
         }

--- a/src/workflow/Aevatar.Workflow.Sdk/AevatarWorkflowClient.cs
+++ b/src/workflow/Aevatar.Workflow.Sdk/AevatarWorkflowClient.cs
@@ -246,15 +246,18 @@ public sealed class AevatarWorkflowClient : IAevatarWorkflowClient
         }
     }
 
-    public async Task<JsonElement?> GetActorSnapshotAsync(
-        string actorId,
+    // Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
+    //   Old pattern: SDK called /api/actors/{actorId} and named the result an actor snapshot.
+    //   New principle: SDK calls the workflow-run current-state readmodel endpoint by workflowRunId.
+    public async Task<JsonElement?> GetWorkflowRunCurrentStateAsync(
+        string workflowRunId,
         CancellationToken cancellationToken = default)
     {
-        EnsureNotBlank(actorId, nameof(actorId));
+        EnsureNotBlank(workflowRunId, nameof(workflowRunId));
 
         using var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"/api/actors/{Uri.EscapeDataString(actorId)}");
+            $"/api/workflow-runs/{Uri.EscapeDataString(workflowRunId)}/current-state");
         using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         if (response.StatusCode == HttpStatusCode.NotFound)
             return null;
@@ -265,7 +268,7 @@ public sealed class AevatarWorkflowClient : IAevatarWorkflowClient
             throw WorkflowSdkJson.BuildHttpException(
                 response.StatusCode,
                 rawPayload,
-                $"Actor snapshot request failed with HTTP {(int)response.StatusCode}.");
+                $"Workflow-run current-state request failed with HTTP {(int)response.StatusCode}.");
         }
 
         if (string.IsNullOrWhiteSpace(rawPayload))
@@ -279,7 +282,7 @@ public sealed class AevatarWorkflowClient : IAevatarWorkflowClient
         catch (JsonException ex)
         {
             throw AevatarWorkflowException.StreamPayload(
-                "Failed to parse actor snapshot response payload.",
+                "Failed to parse workflow-run current-state response payload.",
                 rawPayload,
                 ex);
         }

--- a/src/workflow/Aevatar.Workflow.Sdk/IAevatarWorkflowClient.cs
+++ b/src/workflow/Aevatar.Workflow.Sdk/IAevatarWorkflowClient.cs
@@ -33,9 +33,9 @@ public interface IAevatarWorkflowClient
 
     // Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
     //   Old pattern: SDK exposed actor snapshot lookup by actorId.
-    //   New principle: SDK exposes workflow-run current-state lookup by workflowRunId.
-    Task<JsonElement?> GetWorkflowRunCurrentStateAsync(
-        string workflowRunId,
+    //   New principle: SDK exposes workflow actor current-state lookup by actorId.
+    Task<JsonElement?> GetWorkflowActorCurrentStateAsync(
+        string actorId,
         CancellationToken cancellationToken = default);
 
     // Refactor (iter29/cluster-029-workflow-history-artifact):

--- a/src/workflow/Aevatar.Workflow.Sdk/IAevatarWorkflowClient.cs
+++ b/src/workflow/Aevatar.Workflow.Sdk/IAevatarWorkflowClient.cs
@@ -31,8 +31,11 @@ public interface IAevatarWorkflowClient
         string workflowName,
         CancellationToken cancellationToken = default);
 
-    Task<JsonElement?> GetActorSnapshotAsync(
-        string actorId,
+    // Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
+    //   Old pattern: SDK exposed actor snapshot lookup by actorId.
+    //   New principle: SDK exposes workflow-run current-state lookup by workflowRunId.
+    Task<JsonElement?> GetWorkflowRunCurrentStateAsync(
+        string workflowRunId,
         CancellationToken cancellationToken = default);
 
     // Refactor (iter29/cluster-029-workflow-history-artifact):

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -968,7 +968,7 @@ public sealed class AevatarInvocationToolSourceTests
 
     private sealed class StubWorkflowExecutionQueryService : IWorkflowExecutionQueryApplicationService
     {
-        public bool WorkflowRunCurrentStateQueryEnabled => true;
+        public bool WorkflowActorCurrentStateQueryEnabled => true;
         public WorkflowActorSnapshot? Snapshot { get; set; }
         public IReadOnlyList<WorkflowRunTimelineExportItem> Timeline { get; set; } = [];
 
@@ -986,27 +986,27 @@ public sealed class AevatarInvocationToolSourceTests
         public Task<WorkflowCapabilitiesDocument> GetCapabilitiesAsync(CancellationToken ct = default) =>
             Task.FromResult(new WorkflowCapabilitiesDocument());
 
-        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string actorId, CancellationToken ct = default) =>
+        public Task<WorkflowActorSnapshot?> GetWorkflowActorCurrentStateAsync(string actorId, CancellationToken ct = default) =>
             Task.FromResult(Snapshot);
 
-        public Task<WorkflowRunReport?> GetWorkflowRunReportArtifactAsync(string workflowRunId, CancellationToken ct = default) =>
+        public Task<WorkflowRunReport?> GetWorkflowRunReportArtifactAsync(string actorId, CancellationToken ct = default) =>
             Task.FromResult<WorkflowRunReport?>(null);
 
         public Task<IReadOnlyList<WorkflowRunTimelineExportItem>> ListWorkflowRunTimelineExportAsync(
-            string workflowRunId,
+            string actorId,
             int take = 200,
             CancellationToken ct = default) =>
             Task.FromResult(Timeline);
 
         public Task<IReadOnlyList<WorkflowRunGraphExportEdge>> ListWorkflowRunGraphExportEdgesAsync(
-            string workflowRunId,
+            string actorId,
             int take = 200,
             WorkflowRunGraphExportQueryOptions? options = null,
             CancellationToken ct = default) =>
             Task.FromResult<IReadOnlyList<WorkflowRunGraphExportEdge>>([]);
 
         public Task<WorkflowRunGraphExportSubgraph> GetWorkflowRunGraphExportSubgraphAsync(
-            string workflowRunId,
+            string actorId,
             int depth = 2,
             int take = 200,
             WorkflowRunGraphExportQueryOptions? options = null,

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -968,7 +968,7 @@ public sealed class AevatarInvocationToolSourceTests
 
     private sealed class StubWorkflowExecutionQueryService : IWorkflowExecutionQueryApplicationService
     {
-        public bool ActorQueryEnabled => true;
+        public bool WorkflowRunCurrentStateQueryEnabled => true;
         public WorkflowActorSnapshot? Snapshot { get; set; }
         public IReadOnlyList<WorkflowRunTimelineExportItem> Timeline { get; set; } = [];
 
@@ -986,7 +986,7 @@ public sealed class AevatarInvocationToolSourceTests
         public Task<WorkflowCapabilitiesDocument> GetCapabilitiesAsync(CancellationToken ct = default) =>
             Task.FromResult(new WorkflowCapabilitiesDocument());
 
-        public Task<WorkflowActorSnapshot?> GetActorSnapshotAsync(string actorId, CancellationToken ct = default) =>
+        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string actorId, CancellationToken ct = default) =>
             Task.FromResult(Snapshot);
 
         public Task<WorkflowRunReport?> GetWorkflowRunReportArtifactAsync(string workflowRunId, CancellationToken ct = default) =>

--- a/test/Aevatar.AI.ToolProviders.Workflow.Tests/WorkflowDefinitionToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Workflow.Tests/WorkflowDefinitionToolsTests.cs
@@ -158,7 +158,7 @@ public class WorkflowDefinitionToolsTests
         var source = new WorkflowAgentToolSource(null!, options, definitionCommand: adapter);
         var tools = await source.DiscoverToolsAsync();
 
-        // 4 base tools (status, workflow_artifact_query, workflow_run_current_state, event_query) + 4 def tools (list, read, create, update) = 8
+        // 4 base tools (status, workflow_artifact_query, workflow_actor_current_state, event_query) + 4 def tools (list, read, create, update) = 8
         tools.Should().HaveCount(8);
         tools.Should().Contain(t => t is WorkflowArtifactQueryTool);
         tools.Should().Contain(t => t is WorkflowListDefsTool);

--- a/test/Aevatar.AI.ToolProviders.Workflow.Tests/WorkflowDefinitionToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Workflow.Tests/WorkflowDefinitionToolsTests.cs
@@ -158,7 +158,7 @@ public class WorkflowDefinitionToolsTests
         var source = new WorkflowAgentToolSource(null!, options, definitionCommand: adapter);
         var tools = await source.DiscoverToolsAsync();
 
-        // 4 base tools (status, workflow_artifact_query, actor_inspect, event_query) + 4 def tools (list, read, create, update) = 8
+        // 4 base tools (status, workflow_artifact_query, workflow_run_current_state, event_query) + 4 def tools (list, read, create, update) = 8
         tools.Should().HaveCount(8);
         tools.Should().Contain(t => t is WorkflowArtifactQueryTool);
         tools.Should().Contain(t => t is WorkflowListDefsTool);

--- a/test/Aevatar.AI.ToolProviders.Workflow.Tests/WorkflowRunToolContractTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Workflow.Tests/WorkflowRunToolContractTests.cs
@@ -242,15 +242,15 @@ public sealed class WorkflowRunToolContractTests
     }
 
     [Fact]
-    public async Task ActorInspectTool_Graph_ShouldNotExposeWorkflowArtifactSubgraph()
+    public async Task WorkflowRunCurrentStateTool_Graph_ShouldNotExposeWorkflowArtifactSubgraph()
     {
         var query = new RecordingWorkflowExecutionQueryService();
-        var tool = new ActorInspectTool(query, new WorkflowToolOptions { MaxGraphDepth = 2 });
+        var tool = new WorkflowRunCurrentStateTool(query, new WorkflowToolOptions { MaxGraphDepth = 2 });
 
-        var result = await tool.ExecuteAsync("""{"action":"graph","actor_id":"run-1","graph_depth":4,"take":11}""");
+        var result = await tool.ExecuteAsync("""{"action":"graph","workflow_run_id":"run-1","graph_depth":4,"take":11}""");
 
         using var document = JsonDocument.Parse(result);
-        document.RootElement.GetProperty("error").GetString().Should().Be("Unsupported actor_inspect action 'graph'");
+        document.RootElement.GetProperty("error").GetString().Should().Be("Unsupported workflow_run_current_state action 'graph'");
         tool.ParametersSchema.Should().NotContain("\"graph\"");
         tool.ParametersSchema.Should().NotContain("\"graph_depth\"");
         query.Calls.Should().BeEmpty();
@@ -332,7 +332,7 @@ public sealed class WorkflowRunToolContractTests
 
     private sealed class RecordingWorkflowExecutionQueryService : IWorkflowExecutionQueryApplicationService
     {
-        public bool ActorQueryEnabled { get; init; } = true;
+        public bool WorkflowRunCurrentStateQueryEnabled { get; init; } = true;
         public List<string> Calls { get; } = [];
         public WorkflowRunReport? Report { get; init; }
         public IReadOnlyList<WorkflowCatalogItem> Catalog { get; init; } = [];
@@ -363,7 +363,7 @@ public sealed class WorkflowRunToolContractTests
         public Task<WorkflowCapabilitiesDocument> GetCapabilitiesAsync(CancellationToken ct = default) =>
             Task.FromResult(new WorkflowCapabilitiesDocument());
 
-        public Task<WorkflowActorSnapshot?> GetActorSnapshotAsync(string actorId, CancellationToken ct = default) =>
+        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string workflowRunId, CancellationToken ct = default) =>
             Task.FromResult<WorkflowActorSnapshot?>(null);
 
         public Task<WorkflowRunReport?> GetWorkflowRunReportArtifactAsync(string workflowRunId, CancellationToken ct = default)

--- a/test/Aevatar.AI.ToolProviders.Workflow.Tests/WorkflowRunToolContractTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Workflow.Tests/WorkflowRunToolContractTests.cs
@@ -242,6 +242,101 @@ public sealed class WorkflowRunToolContractTests
     }
 
     [Fact]
+    public async Task WorkflowRunCurrentStateTool_DefaultSnapshot_ShouldUseWorkflowRunId()
+    {
+        var query = new RecordingWorkflowExecutionQueryService
+        {
+            CurrentState = new WorkflowActorSnapshot
+            {
+                ActorId = "run-1",
+                WorkflowName = "demo",
+                CompletionStatus = WorkflowRunCompletionStatus.Completed,
+                StateVersion = 42,
+                LastCommandId = "cmd-1",
+                LastEventId = "event-1",
+                LastUpdatedAt = new DateTimeOffset(2026, 5, 20, 1, 2, 3, TimeSpan.Zero),
+                LastSuccess = true,
+                LastOutput = "done",
+                TotalSteps = 3,
+                RequestedSteps = 3,
+                CompletedSteps = 3,
+                RoleReplyCount = 2,
+            },
+        };
+        var tool = new WorkflowRunCurrentStateTool(query, new WorkflowToolOptions());
+
+        var result = await tool.ExecuteAsync("""{"workflow_run_id":"run-1"}""");
+
+        using var document = JsonDocument.Parse(result);
+        var root = document.RootElement;
+        root.GetProperty("workflow_run_id").GetString().Should().Be("run-1");
+        root.GetProperty("workflow_name").GetString().Should().Be("demo");
+        root.GetProperty("status").GetString().Should().Be("Completed");
+        root.GetProperty("state_version").GetInt64().Should().Be(42);
+        root.GetProperty("steps").GetProperty("role_replies").GetInt32().Should().Be(2);
+        query.Calls.Should().Equal("GetWorkflowRunCurrentState:run-1");
+    }
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("""{"workflow_run_id":""}""")]
+    [InlineData("""{"workflow_run_id":"   "}""")]
+    public async Task WorkflowRunCurrentStateTool_WhenWorkflowRunIdMissingOrBlank_ShouldNotCallQueryService(
+        string argumentsJson)
+    {
+        var query = new RecordingWorkflowExecutionQueryService();
+        var tool = new WorkflowRunCurrentStateTool(query, new WorkflowToolOptions());
+
+        var result = await tool.ExecuteAsync(argumentsJson);
+
+        result.Should().Contain("'workflow_run_id' is required");
+        query.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task WorkflowRunCurrentStateTool_WhenCurrentStateQueryDisabled_ShouldReturnDeploymentDisabledError()
+    {
+        var query = new RecordingWorkflowExecutionQueryService
+        {
+            WorkflowRunCurrentStateQueryEnabled = false,
+        };
+        var tool = new WorkflowRunCurrentStateTool(query, new WorkflowToolOptions());
+
+        var result = await tool.ExecuteAsync("""{"workflow_run_id":"run-1"}""");
+
+        using var document = JsonDocument.Parse(result);
+        document.RootElement.GetProperty("error").GetString()
+            .Should().Be("Workflow-run current-state query is not enabled on this deployment.");
+        query.Calls.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("list")]
+    [InlineData("agents")]
+    public async Task WorkflowRunCurrentStateTool_ListAndAgents_ShouldReturnRegisteredAgents(string action)
+    {
+        var query = new RecordingWorkflowExecutionQueryService
+        {
+            Agents =
+            [
+                new WorkflowAgentSummary("agent-1", "assistant", "Assistant agent"),
+                new WorkflowAgentSummary("agent-2", "worker", "Worker agent"),
+            ],
+        };
+        var tool = new WorkflowRunCurrentStateTool(query, new WorkflowToolOptions());
+
+        var result = await tool.ExecuteAsync($$"""{"action":"{{action}}"}""");
+
+        using var document = JsonDocument.Parse(result);
+        var root = document.RootElement;
+        root.GetProperty("count").GetInt32().Should().Be(2);
+        root.GetProperty("agents")[0].GetProperty("id").GetString().Should().Be("agent-1");
+        root.GetProperty("agents")[0].GetProperty("type").GetString().Should().Be("assistant");
+        root.GetProperty("agents")[1].GetProperty("description").GetString().Should().Be("Worker agent");
+        query.Calls.Should().Equal("ListAgents");
+    }
+
+    [Fact]
     public async Task WorkflowRunCurrentStateTool_Graph_ShouldNotExposeWorkflowArtifactSubgraph()
     {
         var query = new RecordingWorkflowExecutionQueryService();
@@ -337,12 +432,17 @@ public sealed class WorkflowRunToolContractTests
         public WorkflowRunReport? Report { get; init; }
         public IReadOnlyList<WorkflowCatalogItem> Catalog { get; init; } = [];
         public WorkflowCatalogItemDetail? Detail { get; init; }
+        public IReadOnlyList<WorkflowAgentSummary> Agents { get; init; } = [];
+        public WorkflowActorSnapshot? CurrentState { get; init; }
         public IReadOnlyList<WorkflowRunTimelineExportItem> Timeline { get; init; } = [];
         public IReadOnlyList<WorkflowRunGraphExportEdge> GraphEdges { get; init; } = [];
         public WorkflowRunGraphExportSubgraph GraphSubgraph { get; init; } = new();
 
-        public Task<IReadOnlyList<WorkflowAgentSummary>> ListAgentsAsync(CancellationToken ct = default) =>
-            Task.FromResult<IReadOnlyList<WorkflowAgentSummary>>([]);
+        public Task<IReadOnlyList<WorkflowAgentSummary>> ListAgentsAsync(CancellationToken ct = default)
+        {
+            Calls.Add("ListAgents");
+            return Task.FromResult(Agents);
+        }
 
         public IReadOnlyList<string> ListWorkflows() => [];
 
@@ -363,8 +463,11 @@ public sealed class WorkflowRunToolContractTests
         public Task<WorkflowCapabilitiesDocument> GetCapabilitiesAsync(CancellationToken ct = default) =>
             Task.FromResult(new WorkflowCapabilitiesDocument());
 
-        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string workflowRunId, CancellationToken ct = default) =>
-            Task.FromResult<WorkflowActorSnapshot?>(null);
+        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string workflowRunId, CancellationToken ct = default)
+        {
+            Calls.Add($"GetWorkflowRunCurrentState:{workflowRunId}");
+            return Task.FromResult(CurrentState);
+        }
 
         public Task<WorkflowRunReport?> GetWorkflowRunReportArtifactAsync(string workflowRunId, CancellationToken ct = default)
         {

--- a/test/Aevatar.AI.ToolProviders.Workflow.Tests/WorkflowRunToolContractTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Workflow.Tests/WorkflowRunToolContractTests.cs
@@ -228,7 +228,7 @@ public sealed class WorkflowRunToolContractTests
     }
 
     [Fact]
-    public async Task WorkflowStatusTool_WhenWorkflowRunIdMissing_ShouldReturnNewErrors()
+    public async Task WorkflowStatusTool_WhenActorIdMissing_ShouldReturnNewErrors()
     {
         var query = new RecordingWorkflowExecutionQueryService();
         var tool = new WorkflowStatusTool(query, new WorkflowToolOptions());
@@ -242,7 +242,7 @@ public sealed class WorkflowRunToolContractTests
     }
 
     [Fact]
-    public async Task WorkflowRunCurrentStateTool_DefaultSnapshot_ShouldUseWorkflowRunId()
+    public async Task WorkflowActorCurrentStateTool_DefaultSnapshot_ShouldUseActorId()
     {
         var query = new RecordingWorkflowExecutionQueryService
         {
@@ -263,57 +263,57 @@ public sealed class WorkflowRunToolContractTests
                 RoleReplyCount = 2,
             },
         };
-        var tool = new WorkflowRunCurrentStateTool(query, new WorkflowToolOptions());
+        var tool = new WorkflowActorCurrentStateTool(query, new WorkflowToolOptions());
 
-        var result = await tool.ExecuteAsync("""{"workflow_run_id":"run-1"}""");
+        var result = await tool.ExecuteAsync("""{"actor_id":"run-1"}""");
 
         using var document = JsonDocument.Parse(result);
         var root = document.RootElement;
-        root.GetProperty("workflow_run_id").GetString().Should().Be("run-1");
+        root.GetProperty("actor_id").GetString().Should().Be("run-1");
         root.GetProperty("workflow_name").GetString().Should().Be("demo");
         root.GetProperty("status").GetString().Should().Be("Completed");
         root.GetProperty("state_version").GetInt64().Should().Be(42);
         root.GetProperty("steps").GetProperty("role_replies").GetInt32().Should().Be(2);
-        query.Calls.Should().Equal("GetWorkflowRunCurrentState:run-1");
+        query.Calls.Should().Equal("GetWorkflowActorCurrentState:run-1");
     }
 
     [Theory]
     [InlineData("{}")]
-    [InlineData("""{"workflow_run_id":""}""")]
-    [InlineData("""{"workflow_run_id":"   "}""")]
-    public async Task WorkflowRunCurrentStateTool_WhenWorkflowRunIdMissingOrBlank_ShouldNotCallQueryService(
+    [InlineData("""{"actor_id":""}""")]
+    [InlineData("""{"actor_id":"   "}""")]
+    public async Task WorkflowActorCurrentStateTool_WhenActorIdMissingOrBlank_ShouldNotCallQueryService(
         string argumentsJson)
     {
         var query = new RecordingWorkflowExecutionQueryService();
-        var tool = new WorkflowRunCurrentStateTool(query, new WorkflowToolOptions());
+        var tool = new WorkflowActorCurrentStateTool(query, new WorkflowToolOptions());
 
         var result = await tool.ExecuteAsync(argumentsJson);
 
-        result.Should().Contain("'workflow_run_id' is required");
+        result.Should().Contain("'actor_id' is required");
         query.Calls.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task WorkflowRunCurrentStateTool_WhenCurrentStateQueryDisabled_ShouldReturnDeploymentDisabledError()
+    public async Task WorkflowActorCurrentStateTool_WhenCurrentStateQueryDisabled_ShouldReturnDeploymentDisabledError()
     {
         var query = new RecordingWorkflowExecutionQueryService
         {
-            WorkflowRunCurrentStateQueryEnabled = false,
+            WorkflowActorCurrentStateQueryEnabled = false,
         };
-        var tool = new WorkflowRunCurrentStateTool(query, new WorkflowToolOptions());
+        var tool = new WorkflowActorCurrentStateTool(query, new WorkflowToolOptions());
 
-        var result = await tool.ExecuteAsync("""{"workflow_run_id":"run-1"}""");
+        var result = await tool.ExecuteAsync("""{"actor_id":"run-1"}""");
 
         using var document = JsonDocument.Parse(result);
         document.RootElement.GetProperty("error").GetString()
-            .Should().Be("Workflow-run current-state query is not enabled on this deployment.");
+            .Should().Be("Workflow actor current-state query is not enabled on this deployment.");
         query.Calls.Should().BeEmpty();
     }
 
     [Theory]
     [InlineData("list")]
     [InlineData("agents")]
-    public async Task WorkflowRunCurrentStateTool_ListAndAgents_ShouldReturnRegisteredAgents(string action)
+    public async Task WorkflowActorCurrentStateTool_ListAndAgents_ShouldReturnRegisteredAgents(string action)
     {
         var query = new RecordingWorkflowExecutionQueryService
         {
@@ -323,7 +323,7 @@ public sealed class WorkflowRunToolContractTests
                 new WorkflowAgentSummary("agent-2", "worker", "Worker agent"),
             ],
         };
-        var tool = new WorkflowRunCurrentStateTool(query, new WorkflowToolOptions());
+        var tool = new WorkflowActorCurrentStateTool(query, new WorkflowToolOptions());
 
         var result = await tool.ExecuteAsync($$"""{"action":"{{action}}"}""");
 
@@ -337,15 +337,15 @@ public sealed class WorkflowRunToolContractTests
     }
 
     [Fact]
-    public async Task WorkflowRunCurrentStateTool_Graph_ShouldNotExposeWorkflowArtifactSubgraph()
+    public async Task WorkflowActorCurrentStateTool_Graph_ShouldNotExposeWorkflowArtifactSubgraph()
     {
         var query = new RecordingWorkflowExecutionQueryService();
-        var tool = new WorkflowRunCurrentStateTool(query, new WorkflowToolOptions { MaxGraphDepth = 2 });
+        var tool = new WorkflowActorCurrentStateTool(query, new WorkflowToolOptions { MaxGraphDepth = 2 });
 
-        var result = await tool.ExecuteAsync("""{"action":"graph","workflow_run_id":"run-1","graph_depth":4,"take":11}""");
+        var result = await tool.ExecuteAsync("""{"action":"graph","actor_id":"run-1","graph_depth":4,"take":11}""");
 
         using var document = JsonDocument.Parse(result);
-        document.RootElement.GetProperty("error").GetString().Should().Be("Unsupported workflow_run_current_state action 'graph'");
+        document.RootElement.GetProperty("error").GetString().Should().Be("Unsupported workflow_actor_current_state action 'graph'");
         tool.ParametersSchema.Should().NotContain("\"graph\"");
         tool.ParametersSchema.Should().NotContain("\"graph_depth\"");
         query.Calls.Should().BeEmpty();
@@ -427,7 +427,7 @@ public sealed class WorkflowRunToolContractTests
 
     private sealed class RecordingWorkflowExecutionQueryService : IWorkflowExecutionQueryApplicationService
     {
-        public bool WorkflowRunCurrentStateQueryEnabled { get; init; } = true;
+        public bool WorkflowActorCurrentStateQueryEnabled { get; init; } = true;
         public List<string> Calls { get; } = [];
         public WorkflowRunReport? Report { get; init; }
         public IReadOnlyList<WorkflowCatalogItem> Catalog { get; init; } = [];
@@ -463,45 +463,45 @@ public sealed class WorkflowRunToolContractTests
         public Task<WorkflowCapabilitiesDocument> GetCapabilitiesAsync(CancellationToken ct = default) =>
             Task.FromResult(new WorkflowCapabilitiesDocument());
 
-        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string workflowRunId, CancellationToken ct = default)
+        public Task<WorkflowActorSnapshot?> GetWorkflowActorCurrentStateAsync(string actorId, CancellationToken ct = default)
         {
-            Calls.Add($"GetWorkflowRunCurrentState:{workflowRunId}");
+            Calls.Add($"GetWorkflowActorCurrentState:{actorId}");
             return Task.FromResult(CurrentState);
         }
 
-        public Task<WorkflowRunReport?> GetWorkflowRunReportArtifactAsync(string workflowRunId, CancellationToken ct = default)
+        public Task<WorkflowRunReport?> GetWorkflowRunReportArtifactAsync(string actorId, CancellationToken ct = default)
         {
-            Calls.Add($"GetWorkflowRunReportArtifact:{workflowRunId}");
+            Calls.Add($"GetWorkflowRunReportArtifact:{actorId}");
             return Task.FromResult(Report);
         }
 
         public Task<IReadOnlyList<WorkflowRunTimelineExportItem>> ListWorkflowRunTimelineExportAsync(
-            string workflowRunId,
+            string actorId,
             int take = 200,
             CancellationToken ct = default)
         {
-            Calls.Add($"ListWorkflowRunTimelineExport:{workflowRunId}:{take}");
+            Calls.Add($"ListWorkflowRunTimelineExport:{actorId}:{take}");
             return Task.FromResult(Timeline);
         }
 
         public Task<IReadOnlyList<WorkflowRunGraphExportEdge>> ListWorkflowRunGraphExportEdgesAsync(
-            string workflowRunId,
+            string actorId,
             int take = 200,
             WorkflowRunGraphExportQueryOptions? options = null,
             CancellationToken ct = default)
         {
-            Calls.Add($"ListWorkflowRunGraphExportEdges:{workflowRunId}:{take}:{options?.Direction}:{string.Join(",", options?.EdgeTypes ?? [])}");
+            Calls.Add($"ListWorkflowRunGraphExportEdges:{actorId}:{take}:{options?.Direction}:{string.Join(",", options?.EdgeTypes ?? [])}");
             return Task.FromResult(GraphEdges);
         }
 
         public Task<WorkflowRunGraphExportSubgraph> GetWorkflowRunGraphExportSubgraphAsync(
-            string workflowRunId,
+            string actorId,
             int depth = 2,
             int take = 200,
             WorkflowRunGraphExportQueryOptions? options = null,
             CancellationToken ct = default)
         {
-            Calls.Add($"GetWorkflowRunGraphExportSubgraph:{workflowRunId}:{depth}:{take}");
+            Calls.Add($"GetWorkflowRunGraphExportSubgraph:{actorId}:{depth}:{take}");
             return Task.FromResult(GraphSubgraph);
         }
     }

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeDraftRunWorkflowRunCurrentStateIntegrationTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeDraftRunWorkflowRunCurrentStateIntegrationTests.cs
@@ -31,12 +31,12 @@ using Microsoft.Extensions.Hosting;
 
 namespace Aevatar.GAgentService.Integration.Tests;
 
-public sealed class ScopeDraftRunWorkflowRunCurrentStateIntegrationTests
+public sealed class ScopeDraftRunWorkflowActorCurrentStateIntegrationTests
 {
     [Fact]
-    public async Task DraftRunEndpoint_ShouldExposeCompletedWorkflowRunCurrentStateViaWorkflowRunCurrentState()
+    public async Task DraftRunEndpoint_ShouldExposeCompletedWorkflowActorCurrentStateViaWorkflowActorCurrentState()
     {
-        await using var host = await DraftRunWorkflowRunCurrentStateHost.StartAsync();
+        await using var host = await DraftRunWorkflowActorCurrentStateHost.StartAsync();
         using var response = await host.Client.PostAsJsonAsync($"/api/scopes/{host.ScopeId}/workflow/draft-run", new
         {
             prompt = "  z\nz\ny  ",
@@ -50,12 +50,12 @@ public sealed class ScopeDraftRunWorkflowRunCurrentStateIntegrationTests
         var actorId = ExtractRunContextActorId(body);
         actorId.Should().NotBeNullOrWhiteSpace();
 
-        using var snapshotResponse = await host.Client.GetAsync($"/api/workflow-runs/{Uri.EscapeDataString(actorId!)}/current-state");
-        var snapshot = await snapshotResponse.Content.ReadFromJsonAsync<WorkflowRunCurrentStateHttpResponse>();
+        using var snapshotResponse = await host.Client.GetAsync($"/api/workflow-actors/{Uri.EscapeDataString(actorId!)}/current-state");
+        var snapshot = await snapshotResponse.Content.ReadFromJsonAsync<WorkflowActorCurrentStateHttpResponse>();
 
         snapshotResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         snapshot.Should().NotBeNull();
-        snapshot!.WorkflowRunId.Should().Be(actorId);
+        snapshot!.ActorId.Should().Be(actorId);
         snapshot.CompletionStatus.Should().Be(WorkflowRunCompletionStatus.Completed);
         snapshot.LastSuccess.Should().BeTrue();
         snapshot.LastOutput.Should().Be("y\nz");
@@ -93,11 +93,11 @@ public sealed class ScopeDraftRunWorkflowRunCurrentStateIntegrationTests
         return null;
     }
 
-    private sealed class DraftRunWorkflowRunCurrentStateHost : IAsyncDisposable
+    private sealed class DraftRunWorkflowActorCurrentStateHost : IAsyncDisposable
     {
         private readonly WebApplication _app;
 
-        private DraftRunWorkflowRunCurrentStateHost(WebApplication app, HttpClient client, string repoRoot, string scopeId)
+        private DraftRunWorkflowActorCurrentStateHost(WebApplication app, HttpClient client, string repoRoot, string scopeId)
         {
             _app = app;
             Client = client;
@@ -111,7 +111,7 @@ public sealed class ScopeDraftRunWorkflowRunCurrentStateIntegrationTests
 
         public string ScopeId { get; }
 
-        public static async Task<DraftRunWorkflowRunCurrentStateHost> StartAsync()
+        public static async Task<DraftRunWorkflowActorCurrentStateHost> StartAsync()
         {
             var repoRoot = FindRepoRoot();
             const string scopeId = "scope-a";
@@ -133,7 +133,7 @@ public sealed class ScopeDraftRunWorkflowRunCurrentStateIntegrationTests
             });
             builder.AddAevatarDefaultHost(options =>
             {
-                options.ServiceName = "Aevatar.ScopeDraftRunWorkflowRunCurrentState.Tests";
+                options.ServiceName = "Aevatar.ScopeDraftRunWorkflowActorCurrentState.Tests";
                 options.EnableConnectorBootstrap = false;
                 options.EnableHealthEndpoints = false;
                 options.MapRootHealthEndpoint = false;
@@ -148,7 +148,7 @@ public sealed class ScopeDraftRunWorkflowRunCurrentStateIntegrationTests
             builder.Services.AddSingleton<IGAgentActorRegistryCommandPort>(sp => sp.GetRequiredService<InMemoryGAgentActorStore>());
             builder.Services.AddSingleton<IGAgentActorRegistryQueryPort>(sp => sp.GetRequiredService<InMemoryGAgentActorStore>());
             builder.Services.AddSingleton<IScopeResourceAdmissionPort>(sp => sp.GetRequiredService<InMemoryGAgentActorStore>());
-            builder.Services.AddSingleton<ITeamEntryMemberResolver, DraftRunWorkflowRunCurrentStateTeamEntryMemberResolver>();
+            builder.Services.AddSingleton<ITeamEntryMemberResolver, DraftRunWorkflowActorCurrentStateTeamEntryMemberResolver>();
             DraftRunProjectionActivationServiceCollectionExtensions.AddWorkflowRunProjectionActivatingInteractionService(
                 builder.Services);
             builder.Services.AddAuthentication("Test")
@@ -177,7 +177,7 @@ public sealed class ScopeDraftRunWorkflowRunCurrentStateIntegrationTests
                 BaseAddress = new Uri(addressFeature.Addresses.Single()),
             };
 
-            return new DraftRunWorkflowRunCurrentStateHost(app, client, repoRoot, scopeId);
+            return new DraftRunWorkflowActorCurrentStateHost(app, client, repoRoot, scopeId);
         }
 
         public async ValueTask DisposeAsync()
@@ -202,7 +202,7 @@ public sealed class ScopeDraftRunWorkflowRunCurrentStateIntegrationTests
         }
     }
 
-    private sealed class DraftRunWorkflowRunCurrentStateTeamEntryMemberResolver : ITeamEntryMemberResolver
+    private sealed class DraftRunWorkflowActorCurrentStateTeamEntryMemberResolver : ITeamEntryMemberResolver
     {
         public Task<TeamEntryMemberResolution> ResolveAsync(
             string scopeId,
@@ -212,7 +212,7 @@ public sealed class ScopeDraftRunWorkflowRunCurrentStateIntegrationTests
                 TeamEntryMemberErrorCodes.TeamNotFound,
                 scopeId,
                 teamId,
-                $"team '{teamId}' is not configured for the draft-run workflow-run current-state query fixture.");
+                $"team '{teamId}' is not configured for the draft-run workflow actor current-state query fixture.");
     }
 
     private static class DraftRunProjectionActivationServiceCollectionExtensions

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeDraftRunWorkflowRunCurrentStateIntegrationTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeDraftRunWorkflowRunCurrentStateIntegrationTests.cs
@@ -31,12 +31,12 @@ using Microsoft.Extensions.Hosting;
 
 namespace Aevatar.GAgentService.Integration.Tests;
 
-public sealed class ScopeDraftRunActorQueryIntegrationTests
+public sealed class ScopeDraftRunWorkflowRunCurrentStateIntegrationTests
 {
     [Fact]
-    public async Task DraftRunEndpoint_ShouldExposeCompletedActorSnapshotViaActorQuery()
+    public async Task DraftRunEndpoint_ShouldExposeCompletedWorkflowRunCurrentStateViaWorkflowRunCurrentState()
     {
-        await using var host = await DraftRunActorQueryHost.StartAsync();
+        await using var host = await DraftRunWorkflowRunCurrentStateHost.StartAsync();
         using var response = await host.Client.PostAsJsonAsync($"/api/scopes/{host.ScopeId}/workflow/draft-run", new
         {
             prompt = "  z\nz\ny  ",
@@ -50,12 +50,12 @@ public sealed class ScopeDraftRunActorQueryIntegrationTests
         var actorId = ExtractRunContextActorId(body);
         actorId.Should().NotBeNullOrWhiteSpace();
 
-        using var snapshotResponse = await host.Client.GetAsync($"/api/actors/{Uri.EscapeDataString(actorId!)}");
-        var snapshot = await snapshotResponse.Content.ReadFromJsonAsync<WorkflowActorSnapshotHttpResponse>();
+        using var snapshotResponse = await host.Client.GetAsync($"/api/workflow-runs/{Uri.EscapeDataString(actorId!)}/current-state");
+        var snapshot = await snapshotResponse.Content.ReadFromJsonAsync<WorkflowRunCurrentStateHttpResponse>();
 
         snapshotResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         snapshot.Should().NotBeNull();
-        snapshot!.ActorId.Should().Be(actorId);
+        snapshot!.WorkflowRunId.Should().Be(actorId);
         snapshot.CompletionStatus.Should().Be(WorkflowRunCompletionStatus.Completed);
         snapshot.LastSuccess.Should().BeTrue();
         snapshot.LastOutput.Should().Be("y\nz");
@@ -93,11 +93,11 @@ public sealed class ScopeDraftRunActorQueryIntegrationTests
         return null;
     }
 
-    private sealed class DraftRunActorQueryHost : IAsyncDisposable
+    private sealed class DraftRunWorkflowRunCurrentStateHost : IAsyncDisposable
     {
         private readonly WebApplication _app;
 
-        private DraftRunActorQueryHost(WebApplication app, HttpClient client, string repoRoot, string scopeId)
+        private DraftRunWorkflowRunCurrentStateHost(WebApplication app, HttpClient client, string repoRoot, string scopeId)
         {
             _app = app;
             Client = client;
@@ -111,7 +111,7 @@ public sealed class ScopeDraftRunActorQueryIntegrationTests
 
         public string ScopeId { get; }
 
-        public static async Task<DraftRunActorQueryHost> StartAsync()
+        public static async Task<DraftRunWorkflowRunCurrentStateHost> StartAsync()
         {
             var repoRoot = FindRepoRoot();
             const string scopeId = "scope-a";
@@ -133,7 +133,7 @@ public sealed class ScopeDraftRunActorQueryIntegrationTests
             });
             builder.AddAevatarDefaultHost(options =>
             {
-                options.ServiceName = "Aevatar.ScopeDraftRunActorQuery.Tests";
+                options.ServiceName = "Aevatar.ScopeDraftRunWorkflowRunCurrentState.Tests";
                 options.EnableConnectorBootstrap = false;
                 options.EnableHealthEndpoints = false;
                 options.MapRootHealthEndpoint = false;
@@ -148,7 +148,7 @@ public sealed class ScopeDraftRunActorQueryIntegrationTests
             builder.Services.AddSingleton<IGAgentActorRegistryCommandPort>(sp => sp.GetRequiredService<InMemoryGAgentActorStore>());
             builder.Services.AddSingleton<IGAgentActorRegistryQueryPort>(sp => sp.GetRequiredService<InMemoryGAgentActorStore>());
             builder.Services.AddSingleton<IScopeResourceAdmissionPort>(sp => sp.GetRequiredService<InMemoryGAgentActorStore>());
-            builder.Services.AddSingleton<ITeamEntryMemberResolver, DraftRunActorQueryTeamEntryMemberResolver>();
+            builder.Services.AddSingleton<ITeamEntryMemberResolver, DraftRunWorkflowRunCurrentStateTeamEntryMemberResolver>();
             DraftRunProjectionActivationServiceCollectionExtensions.AddWorkflowRunProjectionActivatingInteractionService(
                 builder.Services);
             builder.Services.AddAuthentication("Test")
@@ -177,7 +177,7 @@ public sealed class ScopeDraftRunActorQueryIntegrationTests
                 BaseAddress = new Uri(addressFeature.Addresses.Single()),
             };
 
-            return new DraftRunActorQueryHost(app, client, repoRoot, scopeId);
+            return new DraftRunWorkflowRunCurrentStateHost(app, client, repoRoot, scopeId);
         }
 
         public async ValueTask DisposeAsync()
@@ -202,7 +202,7 @@ public sealed class ScopeDraftRunActorQueryIntegrationTests
         }
     }
 
-    private sealed class DraftRunActorQueryTeamEntryMemberResolver : ITeamEntryMemberResolver
+    private sealed class DraftRunWorkflowRunCurrentStateTeamEntryMemberResolver : ITeamEntryMemberResolver
     {
         public Task<TeamEntryMemberResolution> ResolveAsync(
             string scopeId,
@@ -212,7 +212,7 @@ public sealed class ScopeDraftRunActorQueryIntegrationTests
                 TeamEntryMemberErrorCodes.TeamNotFound,
                 scopeId,
                 teamId,
-                $"team '{teamId}' is not configured for the draft-run actor query fixture.");
+                $"team '{teamId}' is not configured for the draft-run workflow-run current-state query fixture.");
     }
 
     private static class DraftRunProjectionActivationServiceCollectionExtensions

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -5414,7 +5414,7 @@ public sealed class ScopeServiceEndpointsTests
 
     private sealed class FakeWorkflowExecutionQueryApplicationService : IWorkflowExecutionQueryApplicationService
     {
-        public bool ActorQueryEnabled => true;
+        public bool WorkflowRunCurrentStateQueryEnabled => true;
 
         public Dictionary<string, WorkflowActorSnapshot> SnapshotsByActorId { get; } = new(StringComparer.Ordinal);
 
@@ -5438,7 +5438,7 @@ public sealed class ScopeServiceEndpointsTests
         public Task<WorkflowCapabilitiesDocument> GetCapabilitiesAsync(CancellationToken ct = default) =>
             Task.FromResult(new WorkflowCapabilitiesDocument());
 
-        public Task<WorkflowActorSnapshot?> GetActorSnapshotAsync(string actorId, CancellationToken ct = default)
+        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string actorId, CancellationToken ct = default)
         {
             SnapshotCalls.Add(actorId);
             SnapshotsByActorId.TryGetValue(actorId, out var snapshot);

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -5414,7 +5414,7 @@ public sealed class ScopeServiceEndpointsTests
 
     private sealed class FakeWorkflowExecutionQueryApplicationService : IWorkflowExecutionQueryApplicationService
     {
-        public bool WorkflowRunCurrentStateQueryEnabled => true;
+        public bool WorkflowActorCurrentStateQueryEnabled => true;
 
         public Dictionary<string, WorkflowActorSnapshot> SnapshotsByActorId { get; } = new(StringComparer.Ordinal);
 
@@ -5438,7 +5438,7 @@ public sealed class ScopeServiceEndpointsTests
         public Task<WorkflowCapabilitiesDocument> GetCapabilitiesAsync(CancellationToken ct = default) =>
             Task.FromResult(new WorkflowCapabilitiesDocument());
 
-        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string actorId, CancellationToken ct = default)
+        public Task<WorkflowActorSnapshot?> GetWorkflowActorCurrentStateAsync(string actorId, CancellationToken ct = default)
         {
             SnapshotCalls.Add(actorId);
             SnapshotsByActorId.TryGetValue(actorId, out var snapshot);

--- a/test/Aevatar.GAgentService.Tests/Application/ChatRunToolCompletionCoordinatorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ChatRunToolCompletionCoordinatorTests.cs
@@ -318,7 +318,7 @@ public sealed class ChatRunToolCompletionCoordinatorTests
 
     private sealed class RecordingWorkflowQueryService : IWorkflowExecutionQueryApplicationService
     {
-        public bool ActorQueryEnabled => true;
+        public bool WorkflowRunCurrentStateQueryEnabled => true;
         public string? LastActorId { get; private set; }
         public WorkflowActorSnapshot? Snapshot { get; set; }
 
@@ -336,7 +336,7 @@ public sealed class ChatRunToolCompletionCoordinatorTests
         public Task<WorkflowCapabilitiesDocument> GetCapabilitiesAsync(CancellationToken ct = default) =>
             Task.FromResult(new WorkflowCapabilitiesDocument());
 
-        public Task<WorkflowActorSnapshot?> GetActorSnapshotAsync(string actorId, CancellationToken ct = default)
+        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string actorId, CancellationToken ct = default)
         {
             LastActorId = actorId;
             return Task.FromResult(Snapshot);

--- a/test/Aevatar.GAgentService.Tests/Application/ChatRunToolCompletionCoordinatorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ChatRunToolCompletionCoordinatorTests.cs
@@ -318,7 +318,7 @@ public sealed class ChatRunToolCompletionCoordinatorTests
 
     private sealed class RecordingWorkflowQueryService : IWorkflowExecutionQueryApplicationService
     {
-        public bool WorkflowRunCurrentStateQueryEnabled => true;
+        public bool WorkflowActorCurrentStateQueryEnabled => true;
         public string? LastActorId { get; private set; }
         public WorkflowActorSnapshot? Snapshot { get; set; }
 
@@ -336,30 +336,30 @@ public sealed class ChatRunToolCompletionCoordinatorTests
         public Task<WorkflowCapabilitiesDocument> GetCapabilitiesAsync(CancellationToken ct = default) =>
             Task.FromResult(new WorkflowCapabilitiesDocument());
 
-        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string actorId, CancellationToken ct = default)
+        public Task<WorkflowActorSnapshot?> GetWorkflowActorCurrentStateAsync(string actorId, CancellationToken ct = default)
         {
             LastActorId = actorId;
             return Task.FromResult(Snapshot);
         }
 
-        public Task<WorkflowRunReport?> GetWorkflowRunReportArtifactAsync(string workflowRunId, CancellationToken ct = default) =>
+        public Task<WorkflowRunReport?> GetWorkflowRunReportArtifactAsync(string actorId, CancellationToken ct = default) =>
             Task.FromResult<WorkflowRunReport?>(null);
 
         public Task<IReadOnlyList<WorkflowRunTimelineExportItem>> ListWorkflowRunTimelineExportAsync(
-            string workflowRunId,
+            string actorId,
             int take = 200,
             CancellationToken ct = default) =>
             Task.FromResult<IReadOnlyList<WorkflowRunTimelineExportItem>>([]);
 
         public Task<IReadOnlyList<WorkflowRunGraphExportEdge>> ListWorkflowRunGraphExportEdgesAsync(
-            string workflowRunId,
+            string actorId,
             int take = 200,
             WorkflowRunGraphExportQueryOptions? options = null,
             CancellationToken ct = default) =>
             Task.FromResult<IReadOnlyList<WorkflowRunGraphExportEdge>>([]);
 
         public Task<WorkflowRunGraphExportSubgraph> GetWorkflowRunGraphExportSubgraphAsync(
-            string workflowRunId,
+            string actorId,
             int depth = 2,
             int take = 200,
             WorkflowRunGraphExportQueryOptions? options = null,

--- a/test/Aevatar.Workflow.Application.Tests/NoopCurrentStateQueryPort.cs
+++ b/test/Aevatar.Workflow.Application.Tests/NoopCurrentStateQueryPort.cs
@@ -5,9 +5,9 @@ namespace Aevatar.Workflow.Application.Tests;
 
 internal sealed class NoopCurrentStateQueryPort : IWorkflowExecutionCurrentStateQueryPort
 {
-    public bool EnableActorQueryEndpoints => true;
+    public bool WorkflowRunCurrentStateQueryEnabled => true;
 
-    public Task<WorkflowActorSnapshot?> GetActorSnapshotAsync(
+    public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(
         string actorId,
         CancellationToken ct = default)
     {
@@ -16,7 +16,7 @@ internal sealed class NoopCurrentStateQueryPort : IWorkflowExecutionCurrentState
         return Task.FromResult<WorkflowActorSnapshot?>(null);
     }
 
-    public Task<IReadOnlyList<WorkflowActorSnapshot>> ListActorSnapshotsAsync(
+    public Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowRunCurrentStatesAsync(
         int take = 200,
         CancellationToken ct = default)
     {
@@ -25,7 +25,7 @@ internal sealed class NoopCurrentStateQueryPort : IWorkflowExecutionCurrentState
         return Task.FromResult<IReadOnlyList<WorkflowActorSnapshot>>([]);
     }
 
-    public Task<WorkflowActorProjectionState?> GetActorProjectionStateAsync(
+    public Task<WorkflowActorProjectionState?> GetWorkflowRunProjectionStateAsync(
         string actorId,
         CancellationToken ct = default)
     {

--- a/test/Aevatar.Workflow.Application.Tests/NoopCurrentStateQueryPort.cs
+++ b/test/Aevatar.Workflow.Application.Tests/NoopCurrentStateQueryPort.cs
@@ -5,9 +5,9 @@ namespace Aevatar.Workflow.Application.Tests;
 
 internal sealed class NoopCurrentStateQueryPort : IWorkflowExecutionCurrentStateQueryPort
 {
-    public bool WorkflowRunCurrentStateQueryEnabled => true;
+    public bool WorkflowActorCurrentStateQueryEnabled => true;
 
-    public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(
+    public Task<WorkflowActorSnapshot?> GetWorkflowActorCurrentStateAsync(
         string actorId,
         CancellationToken ct = default)
     {
@@ -16,7 +16,7 @@ internal sealed class NoopCurrentStateQueryPort : IWorkflowExecutionCurrentState
         return Task.FromResult<WorkflowActorSnapshot?>(null);
     }
 
-    public Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowRunCurrentStatesAsync(
+    public Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowActorCurrentStatesAsync(
         int take = 200,
         CancellationToken ct = default)
     {
@@ -25,7 +25,7 @@ internal sealed class NoopCurrentStateQueryPort : IWorkflowExecutionCurrentState
         return Task.FromResult<IReadOnlyList<WorkflowActorSnapshot>>([]);
     }
 
-    public Task<WorkflowActorProjectionState?> GetWorkflowRunProjectionStateAsync(
+    public Task<WorkflowActorProjectionState?> GetWorkflowActorProjectionStateAsync(
         string actorId,
         CancellationToken ct = default)
     {

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowExecutionQueryApplicationServiceTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowExecutionQueryApplicationServiceTests.cs
@@ -10,10 +10,10 @@ namespace Aevatar.Workflow.Application.Tests;
 public sealed class WorkflowExecutionQueryApplicationServiceTests
 {
     [Fact]
-    public async Task QueryMethods_ShouldShortCircuit_WhenWorkflowRunCurrentStateQueryDisabled()
+    public async Task QueryMethods_ShouldShortCircuit_WhenWorkflowActorCurrentStateQueryDisabled()
     {
         var calls = new List<string>();
-        var currentStatePort = new FakeCurrentStateQueryPort(calls) { WorkflowRunCurrentStateQueryEnabled = false };
+        var currentStatePort = new FakeCurrentStateQueryPort(calls) { WorkflowActorCurrentStateQueryEnabled = false };
         var artifactPort = new FakeArtifactQueryPort(calls) { WorkflowArtifactQueryEnabled = false };
         var service = new WorkflowExecutionQueryApplicationService(
             new StaticWorkflowDefinitionCatalog(["direct", "auto"]),
@@ -22,9 +22,9 @@ public sealed class WorkflowExecutionQueryApplicationServiceTests
             new StaticWorkflowCatalogPort(),
             new StaticWorkflowCapabilitiesPort());
 
-        service.WorkflowRunCurrentStateQueryEnabled.Should().BeFalse();
+        service.WorkflowActorCurrentStateQueryEnabled.Should().BeFalse();
         (await service.ListAgentsAsync()).Should().BeEmpty();
-        (await service.GetWorkflowRunCurrentStateAsync("run-1")).Should().BeNull();
+        (await service.GetWorkflowActorCurrentStateAsync("run-1")).Should().BeNull();
         (await service.ListWorkflowRunTimelineExportAsync("run-1")).Should().BeEmpty();
         (await service.ListWorkflowRunGraphExportEdgesAsync("run-1")).Should().BeEmpty();
         var subgraph = await service.GetWorkflowRunGraphExportSubgraphAsync("run-1");
@@ -34,10 +34,10 @@ public sealed class WorkflowExecutionQueryApplicationServiceTests
     }
 
     [Fact]
-    public async Task GraphQueries_ShouldShortCircuit_WhenWorkflowRunIdBlank()
+    public async Task GraphQueries_ShouldShortCircuit_WhenActorIdBlank()
     {
         var calls = new List<string>();
-        var currentStatePort = new FakeCurrentStateQueryPort(calls) { WorkflowRunCurrentStateQueryEnabled = true };
+        var currentStatePort = new FakeCurrentStateQueryPort(calls) { WorkflowActorCurrentStateQueryEnabled = true };
         var artifactPort = new FakeArtifactQueryPort(calls) { WorkflowArtifactQueryEnabled = true };
         var service = new WorkflowExecutionQueryApplicationService(
             new StaticWorkflowDefinitionCatalog([]),
@@ -52,7 +52,7 @@ public sealed class WorkflowExecutionQueryApplicationServiceTests
     }
 
     [Fact]
-    public async Task QueryMethods_ShouldDelegate_WhenWorkflowRunCurrentStateQueryEnabled()
+    public async Task QueryMethods_ShouldDelegate_WhenWorkflowActorCurrentStateQueryEnabled()
     {
         var snapshot = new WorkflowActorSnapshot
         {
@@ -85,7 +85,7 @@ public sealed class WorkflowExecutionQueryApplicationServiceTests
         var calls = new List<string>();
         var currentStatePort = new FakeCurrentStateQueryPort(calls)
         {
-            WorkflowRunCurrentStateQueryEnabled = true,
+            WorkflowActorCurrentStateQueryEnabled = true,
             Snapshots = [snapshot],
             SingleSnapshot = snapshot,
         };
@@ -109,7 +109,7 @@ public sealed class WorkflowExecutionQueryApplicationServiceTests
             new StaticWorkflowCapabilitiesPort());
 
         var agents = await service.ListAgentsAsync();
-        var currentState = await service.GetWorkflowRunCurrentStateAsync("run-1");
+        var currentState = await service.GetWorkflowActorCurrentStateAsync("run-1");
         var queriedTimeline = await service.ListWorkflowRunTimelineExportAsync("run-1", 5);
         var queriedEdges = await service.ListWorkflowRunGraphExportEdgesAsync("run-1", 7, options);
         var queriedSubgraph = await service.GetWorkflowRunGraphExportSubgraphAsync("run-1", 3, 9, options);
@@ -120,8 +120,8 @@ public sealed class WorkflowExecutionQueryApplicationServiceTests
         queriedEdges.Should().Equal(edges);
         queriedSubgraph.Should().BeSameAs(subgraph);
         calls.Should().ContainInOrder(
-            "ListWorkflowRunCurrentStates:200",
-            "GetWorkflowRunCurrentState:run-1",
+            "ListWorkflowActorCurrentStates:200",
+            "GetWorkflowActorCurrentState:run-1",
             "ListWorkflowRunTimelineExport:run-1:5",
             "GetWorkflowRunGraphExportEdges:run-1:7:Outbound:child",
             "GetWorkflowRunGraphExportSubgraph:run-1:3:9:Outbound:child");
@@ -132,7 +132,7 @@ public sealed class WorkflowExecutionQueryApplicationServiceTests
     {
         var service = new WorkflowExecutionQueryApplicationService(
             new StaticWorkflowDefinitionCatalog([]),
-            new FakeCurrentStateQueryPort([]) { WorkflowRunCurrentStateQueryEnabled = false },
+            new FakeCurrentStateQueryPort([]) { WorkflowActorCurrentStateQueryEnabled = false },
             new FakeArtifactQueryPort([]) { WorkflowArtifactQueryEnabled = false },
             new StaticWorkflowCatalogPort(),
             new StaticWorkflowCapabilitiesPort());
@@ -301,25 +301,25 @@ public sealed class WorkflowExecutionQueryApplicationServiceTests
 
     private sealed class FakeCurrentStateQueryPort(List<string> calls) : IWorkflowExecutionCurrentStateQueryPort
     {
-        public bool WorkflowRunCurrentStateQueryEnabled { get; set; }
+        public bool WorkflowActorCurrentStateQueryEnabled { get; set; }
         public IReadOnlyList<WorkflowActorSnapshot> Snapshots { get; init; } = [];
         public WorkflowActorSnapshot? SingleSnapshot { get; init; }
 
-        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string workflowRunId, CancellationToken ct = default)
+        public Task<WorkflowActorSnapshot?> GetWorkflowActorCurrentStateAsync(string actorId, CancellationToken ct = default)
         {
-            calls.Add($"GetWorkflowRunCurrentState:{workflowRunId}");
+            calls.Add($"GetWorkflowActorCurrentState:{actorId}");
             return Task.FromResult(SingleSnapshot);
         }
 
-        public Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowRunCurrentStatesAsync(int take = 200, CancellationToken ct = default)
+        public Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowActorCurrentStatesAsync(int take = 200, CancellationToken ct = default)
         {
-            calls.Add($"ListWorkflowRunCurrentStates:{take}");
+            calls.Add($"ListWorkflowActorCurrentStates:{take}");
             return Task.FromResult(Snapshots);
         }
 
-        public Task<WorkflowActorProjectionState?> GetWorkflowRunProjectionStateAsync(string workflowRunId, CancellationToken ct = default)
+        public Task<WorkflowActorProjectionState?> GetWorkflowActorProjectionStateAsync(string actorId, CancellationToken ct = default)
         {
-            calls.Add($"GetWorkflowRunProjectionState:{workflowRunId}");
+            calls.Add($"GetWorkflowActorProjectionState:{actorId}");
             return Task.FromResult<WorkflowActorProjectionState?>(null);
         }
     }

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowExecutionQueryApplicationServiceTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowExecutionQueryApplicationServiceTests.cs
@@ -10,10 +10,10 @@ namespace Aevatar.Workflow.Application.Tests;
 public sealed class WorkflowExecutionQueryApplicationServiceTests
 {
     [Fact]
-    public async Task QueryMethods_ShouldShortCircuit_WhenActorQueriesDisabled()
+    public async Task QueryMethods_ShouldShortCircuit_WhenWorkflowRunCurrentStateQueryDisabled()
     {
         var calls = new List<string>();
-        var currentStatePort = new FakeCurrentStateQueryPort(calls) { EnableActorQueryEndpoints = false };
+        var currentStatePort = new FakeCurrentStateQueryPort(calls) { WorkflowRunCurrentStateQueryEnabled = false };
         var artifactPort = new FakeArtifactQueryPort(calls) { WorkflowArtifactQueryEnabled = false };
         var service = new WorkflowExecutionQueryApplicationService(
             new StaticWorkflowDefinitionCatalog(["direct", "auto"]),
@@ -22,22 +22,22 @@ public sealed class WorkflowExecutionQueryApplicationServiceTests
             new StaticWorkflowCatalogPort(),
             new StaticWorkflowCapabilitiesPort());
 
-        service.ActorQueryEnabled.Should().BeFalse();
+        service.WorkflowRunCurrentStateQueryEnabled.Should().BeFalse();
         (await service.ListAgentsAsync()).Should().BeEmpty();
-        (await service.GetActorSnapshotAsync("actor-1")).Should().BeNull();
-        (await service.ListWorkflowRunTimelineExportAsync("actor-1")).Should().BeEmpty();
-        (await service.ListWorkflowRunGraphExportEdgesAsync("actor-1")).Should().BeEmpty();
-        var subgraph = await service.GetWorkflowRunGraphExportSubgraphAsync("actor-1");
-        subgraph.RootNodeId.Should().Be("actor-1");
+        (await service.GetWorkflowRunCurrentStateAsync("run-1")).Should().BeNull();
+        (await service.ListWorkflowRunTimelineExportAsync("run-1")).Should().BeEmpty();
+        (await service.ListWorkflowRunGraphExportEdgesAsync("run-1")).Should().BeEmpty();
+        var subgraph = await service.GetWorkflowRunGraphExportSubgraphAsync("run-1");
+        subgraph.RootNodeId.Should().Be("run-1");
         service.ListWorkflows().Should().Equal("direct", "auto");
         calls.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task GraphQueries_ShouldShortCircuit_WhenActorIdBlank()
+    public async Task GraphQueries_ShouldShortCircuit_WhenWorkflowRunIdBlank()
     {
         var calls = new List<string>();
-        var currentStatePort = new FakeCurrentStateQueryPort(calls) { EnableActorQueryEndpoints = true };
+        var currentStatePort = new FakeCurrentStateQueryPort(calls) { WorkflowRunCurrentStateQueryEnabled = true };
         var artifactPort = new FakeArtifactQueryPort(calls) { WorkflowArtifactQueryEnabled = true };
         var service = new WorkflowExecutionQueryApplicationService(
             new StaticWorkflowDefinitionCatalog([]),
@@ -52,11 +52,11 @@ public sealed class WorkflowExecutionQueryApplicationServiceTests
     }
 
     [Fact]
-    public async Task QueryMethods_ShouldDelegate_WhenActorQueriesEnabled()
+    public async Task QueryMethods_ShouldDelegate_WhenWorkflowRunCurrentStateQueryEnabled()
     {
         var snapshot = new WorkflowActorSnapshot
         {
-            ActorId = "actor-1",
+            ActorId = "run-1",
             WorkflowName = "direct",
         };
         var timeline = new[]
@@ -72,20 +72,20 @@ public sealed class WorkflowExecutionQueryApplicationServiceTests
             new WorkflowRunGraphExportEdge
             {
                 EdgeId = "edge-1",
-                FromNodeId = "actor-1",
-                ToNodeId = "actor-2",
+                FromNodeId = "run-1",
+                ToNodeId = "run-2",
             },
         };
         var subgraph = new WorkflowRunGraphExportSubgraph
         {
-            RootNodeId = "actor-1",
-            Nodes = { new WorkflowRunGraphExportNode { NodeId = "actor-1" } },
+            RootNodeId = "run-1",
+            Nodes = { new WorkflowRunGraphExportNode { NodeId = "run-1" } },
             Edges = { new WorkflowRunGraphExportEdge { EdgeId = "edge-2" } },
         };
         var calls = new List<string>();
         var currentStatePort = new FakeCurrentStateQueryPort(calls)
         {
-            EnableActorQueryEndpoints = true,
+            WorkflowRunCurrentStateQueryEnabled = true,
             Snapshots = [snapshot],
             SingleSnapshot = snapshot,
         };
@@ -109,22 +109,22 @@ public sealed class WorkflowExecutionQueryApplicationServiceTests
             new StaticWorkflowCapabilitiesPort());
 
         var agents = await service.ListAgentsAsync();
-        var actorSnapshot = await service.GetActorSnapshotAsync("actor-1");
-        var actorTimeline = await service.ListWorkflowRunTimelineExportAsync("actor-1", 5);
-        var actorEdges = await service.ListWorkflowRunGraphExportEdgesAsync("actor-1", 7, options);
-        var actorSubgraph = await service.GetWorkflowRunGraphExportSubgraphAsync("actor-1", 3, 9, options);
+        var currentState = await service.GetWorkflowRunCurrentStateAsync("run-1");
+        var queriedTimeline = await service.ListWorkflowRunTimelineExportAsync("run-1", 5);
+        var queriedEdges = await service.ListWorkflowRunGraphExportEdgesAsync("run-1", 7, options);
+        var queriedSubgraph = await service.GetWorkflowRunGraphExportSubgraphAsync("run-1", 3, 9, options);
 
-        agents.Should().ContainSingle().Which.Should().Be(new WorkflowAgentSummary("actor-1", "WorkflowRunGAgent", "WorkflowRunGAgent[direct]"));
-        actorSnapshot.Should().BeSameAs(snapshot);
-        actorTimeline.Should().Equal(timeline);
-        actorEdges.Should().Equal(edges);
-        actorSubgraph.Should().BeSameAs(subgraph);
+        agents.Should().ContainSingle().Which.Should().Be(new WorkflowAgentSummary("run-1", "WorkflowRunGAgent", "WorkflowRunGAgent[direct]"));
+        currentState.Should().BeSameAs(snapshot);
+        queriedTimeline.Should().Equal(timeline);
+        queriedEdges.Should().Equal(edges);
+        queriedSubgraph.Should().BeSameAs(subgraph);
         calls.Should().ContainInOrder(
-            "ListActorSnapshots:200",
-            "GetActorSnapshot:actor-1",
-            "ListWorkflowRunTimelineExport:actor-1:5",
-            "GetWorkflowRunGraphExportEdges:actor-1:7:Outbound:child",
-            "GetWorkflowRunGraphExportSubgraph:actor-1:3:9:Outbound:child");
+            "ListWorkflowRunCurrentStates:200",
+            "GetWorkflowRunCurrentState:run-1",
+            "ListWorkflowRunTimelineExport:run-1:5",
+            "GetWorkflowRunGraphExportEdges:run-1:7:Outbound:child",
+            "GetWorkflowRunGraphExportSubgraph:run-1:3:9:Outbound:child");
     }
 
     [Fact]
@@ -132,7 +132,7 @@ public sealed class WorkflowExecutionQueryApplicationServiceTests
     {
         var service = new WorkflowExecutionQueryApplicationService(
             new StaticWorkflowDefinitionCatalog([]),
-            new FakeCurrentStateQueryPort([]) { EnableActorQueryEndpoints = false },
+            new FakeCurrentStateQueryPort([]) { WorkflowRunCurrentStateQueryEnabled = false },
             new FakeArtifactQueryPort([]) { WorkflowArtifactQueryEnabled = false },
             new StaticWorkflowCatalogPort(),
             new StaticWorkflowCapabilitiesPort());
@@ -301,25 +301,25 @@ public sealed class WorkflowExecutionQueryApplicationServiceTests
 
     private sealed class FakeCurrentStateQueryPort(List<string> calls) : IWorkflowExecutionCurrentStateQueryPort
     {
-        public bool EnableActorQueryEndpoints { get; set; }
+        public bool WorkflowRunCurrentStateQueryEnabled { get; set; }
         public IReadOnlyList<WorkflowActorSnapshot> Snapshots { get; init; } = [];
         public WorkflowActorSnapshot? SingleSnapshot { get; init; }
 
-        public Task<WorkflowActorSnapshot?> GetActorSnapshotAsync(string actorId, CancellationToken ct = default)
+        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string workflowRunId, CancellationToken ct = default)
         {
-            calls.Add($"GetActorSnapshot:{actorId}");
+            calls.Add($"GetWorkflowRunCurrentState:{workflowRunId}");
             return Task.FromResult(SingleSnapshot);
         }
 
-        public Task<IReadOnlyList<WorkflowActorSnapshot>> ListActorSnapshotsAsync(int take = 200, CancellationToken ct = default)
+        public Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowRunCurrentStatesAsync(int take = 200, CancellationToken ct = default)
         {
-            calls.Add($"ListActorSnapshots:{take}");
+            calls.Add($"ListWorkflowRunCurrentStates:{take}");
             return Task.FromResult(Snapshots);
         }
 
-        public Task<WorkflowActorProjectionState?> GetActorProjectionStateAsync(string actorId, CancellationToken ct = default)
+        public Task<WorkflowActorProjectionState?> GetWorkflowRunProjectionStateAsync(string workflowRunId, CancellationToken ct = default)
         {
-            calls.Add($"GetActorProjectionState:{actorId}");
+            calls.Add($"GetWorkflowRunProjectionState:{workflowRunId}");
             return Task.FromResult<WorkflowActorProjectionState?>(null);
         }
     }

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunCommandTargetAndPolicyTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunCommandTargetAndPolicyTests.cs
@@ -488,19 +488,19 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
     {
         public WorkflowActorSnapshot? Snapshot { get; set; }
         public List<string> ActorIds { get; } = [];
-        public bool EnableActorQueryEndpoints => true;
+        public bool WorkflowRunCurrentStateQueryEnabled => true;
 
-        public Task<WorkflowActorSnapshot?> GetActorSnapshotAsync(string actorId, CancellationToken ct = default)
+        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string actorId, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
             ActorIds.Add(actorId);
             return Task.FromResult(Snapshot);
         }
 
-        public Task<IReadOnlyList<WorkflowActorSnapshot>> ListActorSnapshotsAsync(int take = 200, CancellationToken ct = default) =>
+        public Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowRunCurrentStatesAsync(int take = 200, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
-        public Task<WorkflowActorProjectionState?> GetActorProjectionStateAsync(string actorId, CancellationToken ct = default) =>
+        public Task<WorkflowActorProjectionState?> GetWorkflowRunProjectionStateAsync(string actorId, CancellationToken ct = default) =>
             throw new NotSupportedException();
     }
 

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunCommandTargetAndPolicyTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunCommandTargetAndPolicyTests.cs
@@ -488,19 +488,19 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
     {
         public WorkflowActorSnapshot? Snapshot { get; set; }
         public List<string> ActorIds { get; } = [];
-        public bool WorkflowRunCurrentStateQueryEnabled => true;
+        public bool WorkflowActorCurrentStateQueryEnabled => true;
 
-        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string actorId, CancellationToken ct = default)
+        public Task<WorkflowActorSnapshot?> GetWorkflowActorCurrentStateAsync(string actorId, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
             ActorIds.Add(actorId);
             return Task.FromResult(Snapshot);
         }
 
-        public Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowRunCurrentStatesAsync(int take = 200, CancellationToken ct = default) =>
+        public Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowActorCurrentStatesAsync(int take = 200, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
-        public Task<WorkflowActorProjectionState?> GetWorkflowRunProjectionStateAsync(string actorId, CancellationToken ct = default) =>
+        public Task<WorkflowActorProjectionState?> GetWorkflowActorProjectionStateAsync(string actorId, CancellationToken ct = default) =>
             throw new NotSupportedException();
     }
 

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunDurableCompletionResolverCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunDurableCompletionResolverCoverageTests.cs
@@ -127,9 +127,9 @@ public sealed class WorkflowRunDurableCompletionResolverCoverageTests
         public Exception? Exception { get; set; }
         public bool ThrowOnCancellation { get; set; }
         public List<string> ActorIds { get; } = [];
-        public bool EnableActorQueryEndpoints => true;
+        public bool WorkflowRunCurrentStateQueryEnabled => true;
 
-        public Task<WorkflowActorSnapshot?> GetActorSnapshotAsync(string actorId, CancellationToken ct = default)
+        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string actorId, CancellationToken ct = default)
         {
             ActorIds.Add(actorId);
             if (ThrowOnCancellation)
@@ -139,10 +139,10 @@ public sealed class WorkflowRunDurableCompletionResolverCoverageTests
             return Task.FromResult(Snapshot);
         }
 
-        public Task<IReadOnlyList<WorkflowActorSnapshot>> ListActorSnapshotsAsync(int take = 200, CancellationToken ct = default) =>
+        public Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowRunCurrentStatesAsync(int take = 200, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
-        public Task<WorkflowActorProjectionState?> GetActorProjectionStateAsync(string actorId, CancellationToken ct = default) =>
+        public Task<WorkflowActorProjectionState?> GetWorkflowRunProjectionStateAsync(string actorId, CancellationToken ct = default) =>
             throw new NotSupportedException();
     }
 }

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunDurableCompletionResolverCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunDurableCompletionResolverCoverageTests.cs
@@ -127,9 +127,9 @@ public sealed class WorkflowRunDurableCompletionResolverCoverageTests
         public Exception? Exception { get; set; }
         public bool ThrowOnCancellation { get; set; }
         public List<string> ActorIds { get; } = [];
-        public bool WorkflowRunCurrentStateQueryEnabled => true;
+        public bool WorkflowActorCurrentStateQueryEnabled => true;
 
-        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string actorId, CancellationToken ct = default)
+        public Task<WorkflowActorSnapshot?> GetWorkflowActorCurrentStateAsync(string actorId, CancellationToken ct = default)
         {
             ActorIds.Add(actorId);
             if (ThrowOnCancellation)
@@ -139,10 +139,10 @@ public sealed class WorkflowRunDurableCompletionResolverCoverageTests
             return Task.FromResult(Snapshot);
         }
 
-        public Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowRunCurrentStatesAsync(int take = 200, CancellationToken ct = default) =>
+        public Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowActorCurrentStatesAsync(int take = 200, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
-        public Task<WorkflowActorProjectionState?> GetWorkflowRunProjectionStateAsync(string actorId, CancellationToken ct = default) =>
+        public Task<WorkflowActorProjectionState?> GetWorkflowActorProjectionStateAsync(string actorId, CancellationToken ct = default) =>
             throw new NotSupportedException();
     }
 }

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
@@ -469,10 +469,10 @@ public sealed class WorkflowRunOrchestrationComponentTests
 
     private sealed class CompletingCurrentStateQueryPort : IWorkflowExecutionCurrentStateQueryPort
     {
-        public bool WorkflowRunCurrentStateQueryEnabled => true;
+        public bool WorkflowActorCurrentStateQueryEnabled => true;
         public List<string> ActorIds { get; } = [];
 
-        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string actorId, CancellationToken ct = default)
+        public Task<WorkflowActorSnapshot?> GetWorkflowActorCurrentStateAsync(string actorId, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
             ActorIds.Add(actorId);
@@ -480,10 +480,10 @@ public sealed class WorkflowRunOrchestrationComponentTests
                 new WorkflowActorSnapshot { CompletionStatus = WorkflowRunCompletionStatus.Completed });
         }
 
-        public Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowRunCurrentStatesAsync(int take = 200, CancellationToken ct = default) =>
+        public Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowActorCurrentStatesAsync(int take = 200, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
-        public Task<WorkflowActorProjectionState?> GetWorkflowRunProjectionStateAsync(string actorId, CancellationToken ct = default) =>
+        public Task<WorkflowActorProjectionState?> GetWorkflowActorProjectionStateAsync(string actorId, CancellationToken ct = default) =>
             throw new NotSupportedException();
     }
 

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
@@ -469,10 +469,10 @@ public sealed class WorkflowRunOrchestrationComponentTests
 
     private sealed class CompletingCurrentStateQueryPort : IWorkflowExecutionCurrentStateQueryPort
     {
-        public bool EnableActorQueryEndpoints => true;
+        public bool WorkflowRunCurrentStateQueryEnabled => true;
         public List<string> ActorIds { get; } = [];
 
-        public Task<WorkflowActorSnapshot?> GetActorSnapshotAsync(string actorId, CancellationToken ct = default)
+        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string actorId, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
             ActorIds.Add(actorId);
@@ -480,10 +480,10 @@ public sealed class WorkflowRunOrchestrationComponentTests
                 new WorkflowActorSnapshot { CompletionStatus = WorkflowRunCompletionStatus.Completed });
         }
 
-        public Task<IReadOnlyList<WorkflowActorSnapshot>> ListActorSnapshotsAsync(int take = 200, CancellationToken ct = default) =>
+        public Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowRunCurrentStatesAsync(int take = 200, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
-        public Task<WorkflowActorProjectionState?> GetActorProjectionStateAsync(string actorId, CancellationToken ct = default) =>
+        public Task<WorkflowActorProjectionState?> GetWorkflowRunProjectionStateAsync(string actorId, CancellationToken ct = default) =>
             throw new NotSupportedException();
     }
 

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunStateSnapshotEmitterTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunStateSnapshotEmitterTests.cs
@@ -152,12 +152,12 @@ public sealed class WorkflowRunFinalizeEmitterTests
 
     private sealed class FakeCurrentStateQueryPort : IWorkflowExecutionCurrentStateQueryPort
     {
-        public bool EnableActorQueryEndpoints => true;
+        public bool WorkflowRunCurrentStateQueryEnabled => true;
         public WorkflowActorSnapshot? Snapshot { get; set; }
         public WorkflowActorProjectionState? ProjectionState { get; set; }
         public Exception? SnapshotException { get; set; }
 
-        public Task<WorkflowActorSnapshot?> GetActorSnapshotAsync(string actorId, CancellationToken ct = default)
+        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string actorId, CancellationToken ct = default)
         {
             _ = actorId;
             ct.ThrowIfCancellationRequested();
@@ -166,10 +166,10 @@ public sealed class WorkflowRunFinalizeEmitterTests
             return Task.FromResult(Snapshot);
         }
 
-        public Task<IReadOnlyList<WorkflowActorSnapshot>> ListActorSnapshotsAsync(int take = 200, CancellationToken ct = default) =>
+        public Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowRunCurrentStatesAsync(int take = 200, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
-        public Task<WorkflowActorProjectionState?> GetActorProjectionStateAsync(string actorId, CancellationToken ct = default)
+        public Task<WorkflowActorProjectionState?> GetWorkflowRunProjectionStateAsync(string actorId, CancellationToken ct = default)
         {
             _ = actorId;
             ct.ThrowIfCancellationRequested();

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunStateSnapshotEmitterTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunStateSnapshotEmitterTests.cs
@@ -152,12 +152,12 @@ public sealed class WorkflowRunFinalizeEmitterTests
 
     private sealed class FakeCurrentStateQueryPort : IWorkflowExecutionCurrentStateQueryPort
     {
-        public bool WorkflowRunCurrentStateQueryEnabled => true;
+        public bool WorkflowActorCurrentStateQueryEnabled => true;
         public WorkflowActorSnapshot? Snapshot { get; set; }
         public WorkflowActorProjectionState? ProjectionState { get; set; }
         public Exception? SnapshotException { get; set; }
 
-        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string actorId, CancellationToken ct = default)
+        public Task<WorkflowActorSnapshot?> GetWorkflowActorCurrentStateAsync(string actorId, CancellationToken ct = default)
         {
             _ = actorId;
             ct.ThrowIfCancellationRequested();
@@ -166,10 +166,10 @@ public sealed class WorkflowRunFinalizeEmitterTests
             return Task.FromResult(Snapshot);
         }
 
-        public Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowRunCurrentStatesAsync(int take = 200, CancellationToken ct = default) =>
+        public Task<IReadOnlyList<WorkflowActorSnapshot>> ListWorkflowActorCurrentStatesAsync(int take = 200, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
-        public Task<WorkflowActorProjectionState?> GetWorkflowRunProjectionStateAsync(string actorId, CancellationToken ct = default)
+        public Task<WorkflowActorProjectionState?> GetWorkflowActorProjectionStateAsync(string actorId, CancellationToken ct = default)
         {
             _ = actorId;
             ct.ThrowIfCancellationRequested();

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
@@ -89,7 +89,7 @@ public sealed class ChatEndpointsInternalTests
         var body = await ReadBodyAsync(http.Response);
 
         http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
-        http.Response.Headers.Location.ToString().Should().Be($"/api/workflow-runs/{Uri.EscapeDataString(opaqueActorId)}/current-state");
+        http.Response.Headers.Location.ToString().Should().Be($"/api/workflow-actors/{Uri.EscapeDataString(opaqueActorId)}/current-state");
         body.Should().Contain(opaqueActorId);
     }
 
@@ -561,10 +561,10 @@ public sealed class ChatEndpointsInternalTests
         await result.ExecuteAsync(http);
 
         http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
-        http.Response.Headers.Location.ToString().Should().Be("/api/workflow-runs/actor-1/current-state");
+        http.Response.Headers.Location.ToString().Should().Be("/api/workflow-actors/actor-1/current-state");
         var body = await ReadBodyAsync(http.Response);
         body.Should().Contain("\"acceptedCommandId\":\"cmd-1\"");
-        body.Should().Contain("\"statusUrl\":\"/api/workflow-runs/actor-1/current-state\"");
+        body.Should().Contain("\"statusUrl\":\"/api/workflow-actors/actor-1/current-state\"");
         service.Commands.Should().ContainSingle();
         service.Commands.Single().ActorId.Should().Be("actor-1");
         service.Commands.Single().RunId.Should().Be("run-1");
@@ -601,7 +601,7 @@ public sealed class ChatEndpointsInternalTests
         await result.ExecuteAsync(http);
 
         http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
-        http.Response.Headers.Location.ToString().Should().Be($"/api/workflow-runs/{Uri.EscapeDataString(opaqueActorId)}/current-state");
+        http.Response.Headers.Location.ToString().Should().Be($"/api/workflow-actors/{Uri.EscapeDataString(opaqueActorId)}/current-state");
         var body = await ReadBodyAsync(http.Response);
         body.Should().Contain("\"acceptedCommandId\":\"cmd-1\"");
         service.Commands.Should().ContainSingle();
@@ -795,7 +795,7 @@ public sealed class ChatEndpointsInternalTests
         var body = await ReadBodyAsync(http.Response);
 
         http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
-        http.Response.Headers.Location.ToString().Should().Be("/api/workflow-runs/actor-1/current-state");
+        http.Response.Headers.Location.ToString().Should().Be("/api/workflow-actors/actor-1/current-state");
         service.Commands.Should().ContainSingle();
         service.Commands.Single().ActorId.Should().Be("actor-1");
         service.Commands.Single().RunId.Should().Be("run-1");
@@ -835,7 +835,7 @@ public sealed class ChatEndpointsInternalTests
         var body = await ReadBodyAsync(http.Response);
 
         http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
-        http.Response.Headers.Location.ToString().Should().Be("/api/workflow-runs/actor-1/current-state");
+        http.Response.Headers.Location.ToString().Should().Be("/api/workflow-actors/actor-1/current-state");
         service.Commands.Should().ContainSingle();
         service.Commands.Single().ActorId.Should().Be("actor-1");
         service.Commands.Single().RunId.Should().Be("run-1");
@@ -844,7 +844,7 @@ public sealed class ChatEndpointsInternalTests
         service.Commands.Single().CommandId.Should().BeNull();
         service.Commands.Single().StepId.Should().BeNull();
         body.Should().Contain($"\"acceptedCommandId\":\"{receipt.CommandId}\"");
-        body.Should().Contain("\"statusUrl\":\"/api/workflow-runs/actor-1/current-state\"");
+        body.Should().Contain("\"statusUrl\":\"/api/workflow-actors/actor-1/current-state\"");
         body.Should().Contain("\"accepted\":true");
     }
 
@@ -921,7 +921,7 @@ public sealed class ChatEndpointsInternalTests
         var body = await ReadBodyAsync(http.Response);
 
         http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
-        http.Response.Headers.Location.ToString().Should().Be("/api/workflow-runs/actor-1/current-state");
+        http.Response.Headers.Location.ToString().Should().Be("/api/workflow-actors/actor-1/current-state");
         service.Commands.Should().ContainSingle();
         service.Commands.Single().ActorId.Should().Be("actor-1");
         service.Commands.Single().RunId.Should().Be("run-1");
@@ -929,7 +929,7 @@ public sealed class ChatEndpointsInternalTests
         service.Commands.Single().Reason.Should().Be("user requested stop");
         body.Should().Contain("user requested stop");
         body.Should().Contain("\"acceptedCommandId\":\"stop-cmd-1\"");
-        body.Should().Contain("\"statusUrl\":\"/api/workflow-runs/actor-1/current-state\"");
+        body.Should().Contain("\"statusUrl\":\"/api/workflow-actors/actor-1/current-state\"");
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
@@ -89,7 +89,7 @@ public sealed class ChatEndpointsInternalTests
         var body = await ReadBodyAsync(http.Response);
 
         http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
-        http.Response.Headers.Location.ToString().Should().Be($"/api/actors/{opaqueActorId}");
+        http.Response.Headers.Location.ToString().Should().Be($"/api/workflow-runs/{Uri.EscapeDataString(opaqueActorId)}/current-state");
         body.Should().Contain(opaqueActorId);
     }
 
@@ -561,10 +561,10 @@ public sealed class ChatEndpointsInternalTests
         await result.ExecuteAsync(http);
 
         http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
-        http.Response.Headers.Location.ToString().Should().Be("/api/actors/actor-1");
+        http.Response.Headers.Location.ToString().Should().Be("/api/workflow-runs/actor-1/current-state");
         var body = await ReadBodyAsync(http.Response);
         body.Should().Contain("\"acceptedCommandId\":\"cmd-1\"");
-        body.Should().Contain("\"statusUrl\":\"/api/actors/actor-1\"");
+        body.Should().Contain("\"statusUrl\":\"/api/workflow-runs/actor-1/current-state\"");
         service.Commands.Should().ContainSingle();
         service.Commands.Single().ActorId.Should().Be("actor-1");
         service.Commands.Single().RunId.Should().Be("run-1");
@@ -601,7 +601,7 @@ public sealed class ChatEndpointsInternalTests
         await result.ExecuteAsync(http);
 
         http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
-        http.Response.Headers.Location.ToString().Should().Be($"/api/actors/{Uri.EscapeDataString(opaqueActorId)}");
+        http.Response.Headers.Location.ToString().Should().Be($"/api/workflow-runs/{Uri.EscapeDataString(opaqueActorId)}/current-state");
         var body = await ReadBodyAsync(http.Response);
         body.Should().Contain("\"acceptedCommandId\":\"cmd-1\"");
         service.Commands.Should().ContainSingle();
@@ -795,7 +795,7 @@ public sealed class ChatEndpointsInternalTests
         var body = await ReadBodyAsync(http.Response);
 
         http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
-        http.Response.Headers.Location.ToString().Should().Be("/api/actors/actor-1");
+        http.Response.Headers.Location.ToString().Should().Be("/api/workflow-runs/actor-1/current-state");
         service.Commands.Should().ContainSingle();
         service.Commands.Single().ActorId.Should().Be("actor-1");
         service.Commands.Single().RunId.Should().Be("run-1");
@@ -835,7 +835,7 @@ public sealed class ChatEndpointsInternalTests
         var body = await ReadBodyAsync(http.Response);
 
         http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
-        http.Response.Headers.Location.ToString().Should().Be("/api/actors/actor-1");
+        http.Response.Headers.Location.ToString().Should().Be("/api/workflow-runs/actor-1/current-state");
         service.Commands.Should().ContainSingle();
         service.Commands.Single().ActorId.Should().Be("actor-1");
         service.Commands.Single().RunId.Should().Be("run-1");
@@ -844,7 +844,7 @@ public sealed class ChatEndpointsInternalTests
         service.Commands.Single().CommandId.Should().BeNull();
         service.Commands.Single().StepId.Should().BeNull();
         body.Should().Contain($"\"acceptedCommandId\":\"{receipt.CommandId}\"");
-        body.Should().Contain("\"statusUrl\":\"/api/actors/actor-1\"");
+        body.Should().Contain("\"statusUrl\":\"/api/workflow-runs/actor-1/current-state\"");
         body.Should().Contain("\"accepted\":true");
     }
 
@@ -921,7 +921,7 @@ public sealed class ChatEndpointsInternalTests
         var body = await ReadBodyAsync(http.Response);
 
         http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
-        http.Response.Headers.Location.ToString().Should().Be("/api/actors/actor-1");
+        http.Response.Headers.Location.ToString().Should().Be("/api/workflow-runs/actor-1/current-state");
         service.Commands.Should().ContainSingle();
         service.Commands.Single().ActorId.Should().Be("actor-1");
         service.Commands.Single().RunId.Should().Be("run-1");
@@ -929,7 +929,7 @@ public sealed class ChatEndpointsInternalTests
         service.Commands.Single().Reason.Should().Be("user requested stop");
         body.Should().Contain("user requested stop");
         body.Should().Contain("\"acceptedCommandId\":\"stop-cmd-1\"");
-        body.Should().Contain("\"statusUrl\":\"/api/actors/actor-1\"");
+        body.Should().Contain("\"statusUrl\":\"/api/workflow-runs/actor-1/current-state\"");
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatQueryEndpointsTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatQueryEndpointsTests.cs
@@ -144,15 +144,15 @@ public sealed class ChatQueryEndpointsTests
     }
 
     [Fact]
-    public async Task GetWorkflowRunCurrentState_ShouldReturnNotFound_WhenCurrentStateMissing()
+    public async Task GetWorkflowActorCurrentState_ShouldReturnNotFound_WhenCurrentStateMissing()
     {
         var service = new FakeWorkflowExecutionQueryApplicationService();
 
-        var result = await ChatQueryEndpoints.GetWorkflowRunCurrentState("run-1", service, CancellationToken.None);
+        var result = await ChatQueryEndpoints.GetWorkflowActorCurrentState("actor-1", service, CancellationToken.None);
 
         var http = await ExecuteWithContextAsync(result);
         http.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
-        service.Calls.Should().ContainSingle().Which.Should().Be("GetWorkflowRunCurrentState:run-1");
+        service.Calls.Should().ContainSingle().Which.Should().Be("GetWorkflowActorCurrentState:actor-1");
     }
 
     [Fact]
@@ -199,23 +199,18 @@ public sealed class ChatQueryEndpointsTests
     }
 
     [Fact]
-    public async Task GetWorkflowRunGraphExportEnriched_ShouldCombineSnapshotAndSubgraph()
+    public async Task GetWorkflowRunGraphExportEnriched_ShouldReturnSubgraphOnly()
     {
         var service = new FakeWorkflowExecutionQueryApplicationService
         {
-            Snapshot = new WorkflowActorSnapshot
-            {
-                ActorId = "actor-1",
-                WorkflowName = "direct",
-            },
             GraphSubgraph = new WorkflowRunGraphExportSubgraph
             {
-                RootNodeId = "actor-1",
+                RootNodeId = "run-1",
             },
         };
 
         var result = await ChatQueryEndpoints.GetWorkflowRunGraphExportEnriched(
-            "actor-1",
+            "run-1",
             service,
             depth: 4,
             take: 9,
@@ -224,12 +219,9 @@ public sealed class ChatQueryEndpointsTests
             ct: CancellationToken.None);
 
         var body = await ExecuteAsync(result);
-        body.Should().Contain("currentState");
-        body.Should().Contain("subgraph");
-        body.Should().Contain("actor-1");
-        service.Calls.Should().ContainInOrder(
-            "GetWorkflowRunCurrentState:actor-1",
-            "GetWorkflowRunGraphExportSubgraph:actor-1:4:9:Inbound:child");
+        body.Should().Contain("run-1");
+        service.Calls.Should().ContainSingle()
+            .Which.Should().Be("GetWorkflowRunGraphExportSubgraph:run-1:4:9:Inbound:child");
     }
 
     [Fact]
@@ -254,7 +246,7 @@ public sealed class ChatQueryEndpointsTests
     }
 
     [Fact]
-    public async Task WorkflowRunExportRoutes_ShouldBindWorkflowRunIdAndQueryParameters()
+    public async Task WorkflowRunExportRoutes_ShouldBindActorIdAndQueryParameters()
     {
         var service = new FakeWorkflowExecutionQueryApplicationService
         {
@@ -320,12 +312,11 @@ public sealed class ChatQueryEndpointsTests
         (await timeline.Content.ReadAsStringAsync()).Should().Contain("step-1");
         (await edges.Content.ReadAsStringAsync()).Should().Contain("edge-1");
         (await subgraph.Content.ReadAsStringAsync()).Should().Contain("run-42");
-        (await enriched.Content.ReadAsStringAsync()).Should().Contain("currentState");
+        (await enriched.Content.ReadAsStringAsync()).Should().Contain("run-42");
         service.Calls.Should().ContainInOrder(
             "ListWorkflowRunTimelineExport:run-42:7",
             "ListWorkflowRunGraphExportEdges:run-42:8:Outbound:child,sibling",
             "GetWorkflowRunGraphExportSubgraph:run-42:3:9:Inbound:child",
-            "GetWorkflowRunCurrentState:run-42",
             "GetWorkflowRunGraphExportSubgraph:run-42:4:10:Both:child");
     }
 
@@ -387,7 +378,7 @@ public sealed class ChatQueryEndpointsTests
 
     private sealed class FakeWorkflowExecutionQueryApplicationService : IWorkflowExecutionQueryApplicationService
     {
-        public bool WorkflowRunCurrentStateQueryEnabled => true;
+        public bool WorkflowActorCurrentStateQueryEnabled => true;
         public IReadOnlyList<WorkflowAgentSummary> Agents { get; init; } = [];
         public IReadOnlyList<string> Workflows { get; init; } = [];
         public IReadOnlyList<WorkflowCatalogItem> WorkflowCatalog { get; init; } = [];
@@ -437,9 +428,9 @@ public sealed class ChatQueryEndpointsTests
             return Task.FromResult(Capabilities);
         }
 
-        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string workflowRunId, CancellationToken ct = default)
+        public Task<WorkflowActorSnapshot?> GetWorkflowActorCurrentStateAsync(string actorId, CancellationToken ct = default)
         {
-            Calls.Add($"GetWorkflowRunCurrentState:{workflowRunId}");
+            Calls.Add($"GetWorkflowActorCurrentState:{actorId}");
             return Task.FromResult(Snapshot);
         }
 

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatQueryEndpointsTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatQueryEndpointsTests.cs
@@ -144,15 +144,15 @@ public sealed class ChatQueryEndpointsTests
     }
 
     [Fact]
-    public async Task GetActorSnapshot_ShouldReturnNotFound_WhenSnapshotMissing()
+    public async Task GetWorkflowRunCurrentState_ShouldReturnNotFound_WhenCurrentStateMissing()
     {
         var service = new FakeWorkflowExecutionQueryApplicationService();
 
-        var result = await ChatQueryEndpoints.GetActorSnapshot("actor-1", service, CancellationToken.None);
+        var result = await ChatQueryEndpoints.GetWorkflowRunCurrentState("run-1", service, CancellationToken.None);
 
         var http = await ExecuteWithContextAsync(result);
         http.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
-        service.Calls.Should().ContainSingle().Which.Should().Be("GetActorSnapshot:actor-1");
+        service.Calls.Should().ContainSingle().Which.Should().Be("GetWorkflowRunCurrentState:run-1");
     }
 
     [Fact]
@@ -224,11 +224,11 @@ public sealed class ChatQueryEndpointsTests
             ct: CancellationToken.None);
 
         var body = await ExecuteAsync(result);
-        body.Should().Contain("snapshot");
+        body.Should().Contain("currentState");
         body.Should().Contain("subgraph");
         body.Should().Contain("actor-1");
         service.Calls.Should().ContainInOrder(
-            "GetActorSnapshot:actor-1",
+            "GetWorkflowRunCurrentState:actor-1",
             "GetWorkflowRunGraphExportSubgraph:actor-1:4:9:Inbound:child");
     }
 
@@ -320,12 +320,12 @@ public sealed class ChatQueryEndpointsTests
         (await timeline.Content.ReadAsStringAsync()).Should().Contain("step-1");
         (await edges.Content.ReadAsStringAsync()).Should().Contain("edge-1");
         (await subgraph.Content.ReadAsStringAsync()).Should().Contain("run-42");
-        (await enriched.Content.ReadAsStringAsync()).Should().Contain("snapshot");
+        (await enriched.Content.ReadAsStringAsync()).Should().Contain("currentState");
         service.Calls.Should().ContainInOrder(
             "ListWorkflowRunTimelineExport:run-42:7",
             "ListWorkflowRunGraphExportEdges:run-42:8:Outbound:child,sibling",
             "GetWorkflowRunGraphExportSubgraph:run-42:3:9:Inbound:child",
-            "GetActorSnapshot:run-42",
+            "GetWorkflowRunCurrentState:run-42",
             "GetWorkflowRunGraphExportSubgraph:run-42:4:10:Both:child");
     }
 
@@ -387,7 +387,7 @@ public sealed class ChatQueryEndpointsTests
 
     private sealed class FakeWorkflowExecutionQueryApplicationService : IWorkflowExecutionQueryApplicationService
     {
-        public bool ActorQueryEnabled => true;
+        public bool WorkflowRunCurrentStateQueryEnabled => true;
         public IReadOnlyList<WorkflowAgentSummary> Agents { get; init; } = [];
         public IReadOnlyList<string> Workflows { get; init; } = [];
         public IReadOnlyList<WorkflowCatalogItem> WorkflowCatalog { get; init; } = [];
@@ -437,9 +437,9 @@ public sealed class ChatQueryEndpointsTests
             return Task.FromResult(Capabilities);
         }
 
-        public Task<WorkflowActorSnapshot?> GetActorSnapshotAsync(string actorId, CancellationToken ct = default)
+        public Task<WorkflowActorSnapshot?> GetWorkflowRunCurrentStateAsync(string workflowRunId, CancellationToken ct = default)
         {
-            Calls.Add($"GetActorSnapshot:{actorId}");
+            Calls.Add($"GetWorkflowRunCurrentState:{workflowRunId}");
             return Task.FromResult(Snapshot);
         }
 

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionQueryPortsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionQueryPortsCoverageTests.cs
@@ -231,7 +231,7 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
             new WorkflowExecutionProjectionOptions
             {
                 Enabled = true,
-                EnableActorQueryEndpoints = true,
+                WorkflowRunCurrentStateQueryEnabled = true,
             },
             currentStateReader: new RecordingDocumentReader<WorkflowExecutionCurrentStateDocument>
             {
@@ -258,9 +258,9 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
                 ],
             });
 
-        var snapshot = await harness.CurrentStatePort.GetActorSnapshotAsync("actor-1");
-        var snapshots = await harness.CurrentStatePort.ListActorSnapshotsAsync(5);
-        var projectionState = await harness.CurrentStatePort.GetActorProjectionStateAsync("actor-1");
+        var snapshot = await harness.CurrentStatePort.GetWorkflowRunCurrentStateAsync("actor-1");
+        var snapshots = await harness.CurrentStatePort.ListWorkflowRunCurrentStatesAsync(5);
+        var projectionState = await harness.CurrentStatePort.GetWorkflowRunProjectionStateAsync("actor-1");
 
         snapshot.Should().NotBeNull();
         snapshot!.ActorId.Should().Be("actor-1");
@@ -279,12 +279,12 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
         var disabled = CreateHarness(new WorkflowExecutionProjectionOptions
         {
             Enabled = true,
-            EnableActorQueryEndpoints = false,
+            WorkflowRunCurrentStateQueryEnabled = false,
         });
-        disabled.CurrentStatePort.EnableActorQueryEndpoints.Should().BeFalse();
-        (await disabled.CurrentStatePort.GetActorSnapshotAsync("actor-1")).Should().BeNull();
-        (await disabled.CurrentStatePort.ListActorSnapshotsAsync()).Should().BeEmpty();
-        (await disabled.CurrentStatePort.GetActorProjectionStateAsync("actor-1")).Should().BeNull();
+        disabled.CurrentStatePort.WorkflowRunCurrentStateQueryEnabled.Should().BeFalse();
+        (await disabled.CurrentStatePort.GetWorkflowRunCurrentStateAsync("actor-1")).Should().BeNull();
+        (await disabled.CurrentStatePort.ListWorkflowRunCurrentStatesAsync()).Should().BeEmpty();
+        (await disabled.CurrentStatePort.GetWorkflowRunProjectionStateAsync("actor-1")).Should().BeNull();
         disabled.CurrentStateReader.GetCalls.Should().Be(0);
         disabled.CurrentStateReader.QueryCalls.Should().Be(0);
 
@@ -292,11 +292,11 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
             new WorkflowExecutionProjectionOptions
             {
                 Enabled = true,
-                EnableActorQueryEndpoints = true,
+                WorkflowRunCurrentStateQueryEnabled = true,
             },
             currentStateReader: new RecordingDocumentReader<WorkflowExecutionCurrentStateDocument>());
-        (await missing.CurrentStatePort.GetActorSnapshotAsync("   ")).Should().BeNull();
-        (await missing.CurrentStatePort.GetActorProjectionStateAsync("actor-404")).Should().BeNull();
+        (await missing.CurrentStatePort.GetWorkflowRunCurrentStateAsync("   ")).Should().BeNull();
+        (await missing.CurrentStatePort.GetWorkflowRunProjectionStateAsync("actor-404")).Should().BeNull();
         missing.CurrentStateReader.GetCalls.Should().Be(1);
     }
 

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionQueryPortsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionQueryPortsCoverageTests.cs
@@ -231,7 +231,7 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
             new WorkflowExecutionProjectionOptions
             {
                 Enabled = true,
-                WorkflowRunCurrentStateQueryEnabled = true,
+                WorkflowActorCurrentStateQueryEnabled = true,
             },
             currentStateReader: new RecordingDocumentReader<WorkflowExecutionCurrentStateDocument>
             {
@@ -258,9 +258,9 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
                 ],
             });
 
-        var snapshot = await harness.CurrentStatePort.GetWorkflowRunCurrentStateAsync("actor-1");
-        var snapshots = await harness.CurrentStatePort.ListWorkflowRunCurrentStatesAsync(5);
-        var projectionState = await harness.CurrentStatePort.GetWorkflowRunProjectionStateAsync("actor-1");
+        var snapshot = await harness.CurrentStatePort.GetWorkflowActorCurrentStateAsync("actor-1");
+        var snapshots = await harness.CurrentStatePort.ListWorkflowActorCurrentStatesAsync(5);
+        var projectionState = await harness.CurrentStatePort.GetWorkflowActorProjectionStateAsync("actor-1");
 
         snapshot.Should().NotBeNull();
         snapshot!.ActorId.Should().Be("actor-1");
@@ -279,12 +279,12 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
         var disabled = CreateHarness(new WorkflowExecutionProjectionOptions
         {
             Enabled = true,
-            WorkflowRunCurrentStateQueryEnabled = false,
+            WorkflowActorCurrentStateQueryEnabled = false,
         });
-        disabled.CurrentStatePort.WorkflowRunCurrentStateQueryEnabled.Should().BeFalse();
-        (await disabled.CurrentStatePort.GetWorkflowRunCurrentStateAsync("actor-1")).Should().BeNull();
-        (await disabled.CurrentStatePort.ListWorkflowRunCurrentStatesAsync()).Should().BeEmpty();
-        (await disabled.CurrentStatePort.GetWorkflowRunProjectionStateAsync("actor-1")).Should().BeNull();
+        disabled.CurrentStatePort.WorkflowActorCurrentStateQueryEnabled.Should().BeFalse();
+        (await disabled.CurrentStatePort.GetWorkflowActorCurrentStateAsync("actor-1")).Should().BeNull();
+        (await disabled.CurrentStatePort.ListWorkflowActorCurrentStatesAsync()).Should().BeEmpty();
+        (await disabled.CurrentStatePort.GetWorkflowActorProjectionStateAsync("actor-1")).Should().BeNull();
         disabled.CurrentStateReader.GetCalls.Should().Be(0);
         disabled.CurrentStateReader.QueryCalls.Should().Be(0);
 
@@ -292,11 +292,11 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
             new WorkflowExecutionProjectionOptions
             {
                 Enabled = true,
-                WorkflowRunCurrentStateQueryEnabled = true,
+                WorkflowActorCurrentStateQueryEnabled = true,
             },
             currentStateReader: new RecordingDocumentReader<WorkflowExecutionCurrentStateDocument>());
-        (await missing.CurrentStatePort.GetWorkflowRunCurrentStateAsync("   ")).Should().BeNull();
-        (await missing.CurrentStatePort.GetWorkflowRunProjectionStateAsync("actor-404")).Should().BeNull();
+        (await missing.CurrentStatePort.GetWorkflowActorCurrentStateAsync("   ")).Should().BeNull();
+        (await missing.CurrentStatePort.GetWorkflowActorProjectionStateAsync("actor-404")).Should().BeNull();
         missing.CurrentStateReader.GetCalls.Should().Be(1);
     }
 

--- a/test/Aevatar.Workflow.Sdk.Tests/AevatarWorkflowClientTests.cs
+++ b/test/Aevatar.Workflow.Sdk.Tests/AevatarWorkflowClientTests.cs
@@ -154,11 +154,16 @@ data: {"stateSnapshot":{"snapshot":{"@type":"type.googleapis.com/aevatar.workflo
     [Fact]
     public async Task GetWorkflowActorCurrentStateAsync_WhenNotFound_ShouldReturnNull()
     {
-        var client = CreateClient((_, _) =>
-            Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+        var client = CreateClient((request, _) =>
+        {
+            request.Method.Should().Be(HttpMethod.Get);
+            request.RequestUri?.PathAndQuery.Should().Be("/api/workflow-actors/missing-actor/current-state");
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
             {
                 Content = new StringContent("""{"error":"missing"}""", Encoding.UTF8, "application/json"),
-            }));
+            });
+        });
 
         var snapshot = await client.GetWorkflowActorCurrentStateAsync("missing-actor", CancellationToken.None);
         snapshot.Should().BeNull();

--- a/test/Aevatar.Workflow.Sdk.Tests/AevatarWorkflowClientTests.cs
+++ b/test/Aevatar.Workflow.Sdk.Tests/AevatarWorkflowClientTests.cs
@@ -152,7 +152,7 @@ data: {"stateSnapshot":{"snapshot":{"@type":"type.googleapis.com/aevatar.workflo
     }
 
     [Fact]
-    public async Task GetWorkflowRunCurrentStateAsync_WhenNotFound_ShouldReturnNull()
+    public async Task GetWorkflowActorCurrentStateAsync_WhenNotFound_ShouldReturnNull()
     {
         var client = CreateClient((_, _) =>
             Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
@@ -160,7 +160,7 @@ data: {"stateSnapshot":{"snapshot":{"@type":"type.googleapis.com/aevatar.workflo
                 Content = new StringContent("""{"error":"missing"}""", Encoding.UTF8, "application/json"),
             }));
 
-        var snapshot = await client.GetWorkflowRunCurrentStateAsync("missing-actor", CancellationToken.None);
+        var snapshot = await client.GetWorkflowActorCurrentStateAsync("missing-actor", CancellationToken.None);
         snapshot.Should().BeNull();
     }
 

--- a/test/Aevatar.Workflow.Sdk.Tests/AevatarWorkflowClientTests.cs
+++ b/test/Aevatar.Workflow.Sdk.Tests/AevatarWorkflowClientTests.cs
@@ -152,7 +152,7 @@ data: {"stateSnapshot":{"snapshot":{"@type":"type.googleapis.com/aevatar.workflo
     }
 
     [Fact]
-    public async Task GetActorSnapshotAsync_WhenNotFound_ShouldReturnNull()
+    public async Task GetWorkflowRunCurrentStateAsync_WhenNotFound_ShouldReturnNull()
     {
         var client = CreateClient((_, _) =>
             Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
@@ -160,7 +160,7 @@ data: {"stateSnapshot":{"snapshot":{"@type":"type.googleapis.com/aevatar.workflo
                 Content = new StringContent("""{"error":"missing"}""", Encoding.UTF8, "application/json"),
             }));
 
-        var snapshot = await client.GetActorSnapshotAsync("missing-actor", CancellationToken.None);
+        var snapshot = await client.GetWorkflowRunCurrentStateAsync("missing-actor", CancellationToken.None);
         snapshot.Should().BeNull();
     }
 

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -572,6 +572,7 @@ function record_if_unprotected() {
 
 BEGIN {
   in_endpoint = 0;
+  has_actor_current_state_route = 0;
 }
 
 FNR == 1 {
@@ -590,6 +591,8 @@ FNR == 1 {
 
   if (line ~ /MapGet[[:space:]]*\([[:space:]]*"\/(api\/)?agents"/ ||
       line ~ /MapGet[[:space:]]*\([[:space:]]*"\/(api\/)?workflow-actors\/\{[^}]+}\/current-state"/) {
+    if (line ~ /MapGet[[:space:]]*\([[:space:]]*"\/(api\/)?workflow-actors\/\{actorId}\/current-state"/)
+      has_actor_current_state_route = 1;
     record_if_unprotected();
     in_endpoint = 1;
     endpoint_file = FILENAME;
@@ -614,6 +617,10 @@ FNR == 1 {
 
 END {
   record_if_unprotected();
+  if (has_actor_current_state_route == 0) {
+    print "Workflow actor current-state route must be exposed as /workflow-actors/{ActorId}/current-state.";
+    exit 2;
+  }
 }
 ' "${workflow_actor_current_state_endpoint_files[@]}"
   )"

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -538,16 +538,14 @@ if [ -n "${forbidden_web_api_port_report}" ]; then
   exit 1
 fi
 
-# Refactor (iter12/cluster-022):
+# Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
 #   Old: actor query endpoints could be mapped without auth, exposing readmodel
 #   by raw actor id.
-#   New: CI guard requires explicit .RequireAuthorization() or
-#   security-allowlist comment per endpoint.
-#   TODO: Once a caller-scope query contract exists, extend this guard to require
-#   AI workflow tools to reference that scoped query port.
-workflow_actor_query_endpoint_files=()
+#   New: workflow-run current-state readmodel endpoints must carry the same
+#   explicit .RequireAuthorization() or security-allowlist protection.
+workflow_run_current_state_endpoint_files=()
 while IFS= read -r endpoint_file; do
-  workflow_actor_query_endpoint_files+=("${endpoint_file}")
+  workflow_run_current_state_endpoint_files+=("${endpoint_file}")
 done < <(
   find src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi \
     -type f \
@@ -555,9 +553,9 @@ done < <(
     | sort
 )
 
-if [ "${#workflow_actor_query_endpoint_files[@]}" -gt 0 ]; then
+if [ "${#workflow_run_current_state_endpoint_files[@]}" -gt 0 ]; then
   set +e
-  workflow_actor_query_authz_report="$(
+  workflow_run_current_state_authz_report="$(
     awk '
 function trim(value) {
   sub(/^[[:space:]]+/, "", value);
@@ -585,7 +583,7 @@ FNR == 1 {
   line = $0;
 
   if (line ~ /MapGet[[:space:]]*\([[:space:]]*"\/(api\/)?agents"/ ||
-      line ~ /MapGet[[:space:]]*\([[:space:]]*"\/(api\/)?actors\/\{[^}]+}/) {
+      line ~ /MapGet[[:space:]]*\([[:space:]]*"\/(api\/)?workflow-runs\/\{[^}]+}\/current-state"/) {
     record_if_unprotected();
     in_endpoint = 1;
     endpoint_file = FILENAME;
@@ -611,19 +609,19 @@ FNR == 1 {
 END {
   record_if_unprotected();
 }
-' "${workflow_actor_query_endpoint_files[@]}"
+' "${workflow_run_current_state_endpoint_files[@]}"
   )"
-  workflow_actor_query_authz_status=$?
+  workflow_run_current_state_authz_status=$?
   set -e
 
-  if [[ ${workflow_actor_query_authz_status} -ne 0 ]]; then
-    echo "Workflow actor query authorization guard execution failed."
-    exit "${workflow_actor_query_authz_status}"
+  if [[ ${workflow_run_current_state_authz_status} -ne 0 ]]; then
+    echo "Workflow run current-state authorization guard execution failed."
+    exit "${workflow_run_current_state_authz_status}"
   fi
 
-  if [ -n "${workflow_actor_query_authz_report}" ]; then
-    echo "${workflow_actor_query_authz_report}"
-    echo "Workflow actor query endpoints must call .RequireAuthorization() or carry a per-endpoint security-allowlist comment."
+  if [ -n "${workflow_run_current_state_authz_report}" ]; then
+    echo "${workflow_run_current_state_authz_report}"
+    echo "Workflow run current-state endpoints must call .RequireAuthorization() or carry a per-endpoint security-allowlist comment."
     exit 1
   fi
 fi

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -539,13 +539,13 @@ if [ -n "${forbidden_web_api_port_report}" ]; then
 fi
 
 # Refactor (iter165/cluster-003-workflow-actor-shaped-query-surface):
-#   Old: actor query endpoints could be mapped without auth, exposing readmodel
-#   by raw actor id.
-#   New: workflow-run current-state readmodel endpoints must carry the same
-#   explicit .RequireAuthorization() or security-allowlist protection.
-workflow_run_current_state_endpoint_files=()
+#   Old: workflow-run current-state endpoints presented actor-scoped
+#   readmodels as run-scoped resources.
+#   New: actor-scoped current-state readmodel endpoints must be honestly named
+#   and protected by explicit .RequireAuthorization() or security-allowlist.
+workflow_actor_current_state_endpoint_files=()
 while IFS= read -r endpoint_file; do
-  workflow_run_current_state_endpoint_files+=("${endpoint_file}")
+  workflow_actor_current_state_endpoint_files+=("${endpoint_file}")
 done < <(
   find src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi \
     -type f \
@@ -553,9 +553,9 @@ done < <(
     | sort
 )
 
-if [ "${#workflow_run_current_state_endpoint_files[@]}" -gt 0 ]; then
+if [ "${#workflow_actor_current_state_endpoint_files[@]}" -gt 0 ]; then
   set +e
-  workflow_run_current_state_authz_report="$(
+  workflow_actor_current_state_authz_report="$(
     awk '
 function trim(value) {
   sub(/^[[:space:]]+/, "", value);
@@ -582,8 +582,14 @@ FNR == 1 {
 {
   line = $0;
 
+  if (line ~ /MapGet[[:space:]]*\([[:space:]]*"\/(api\/)?workflow-runs\/\{[^}]+}\/current-state"/) {
+    print FILENAME ":" FNR ":" trim(line);
+    print "Workflow current-state endpoints must not be exposed under workflow-runs until a real run-id readmodel exists.";
+    exit 2;
+  }
+
   if (line ~ /MapGet[[:space:]]*\([[:space:]]*"\/(api\/)?agents"/ ||
-      line ~ /MapGet[[:space:]]*\([[:space:]]*"\/(api\/)?workflow-runs\/\{[^}]+}\/current-state"/) {
+      line ~ /MapGet[[:space:]]*\([[:space:]]*"\/(api\/)?workflow-actors\/\{[^}]+}\/current-state"/) {
     record_if_unprotected();
     in_endpoint = 1;
     endpoint_file = FILENAME;
@@ -609,19 +615,19 @@ FNR == 1 {
 END {
   record_if_unprotected();
 }
-' "${workflow_run_current_state_endpoint_files[@]}"
+' "${workflow_actor_current_state_endpoint_files[@]}"
   )"
-  workflow_run_current_state_authz_status=$?
+  workflow_actor_current_state_authz_status=$?
   set -e
 
-  if [[ ${workflow_run_current_state_authz_status} -ne 0 ]]; then
-    echo "Workflow run current-state authorization guard execution failed."
-    exit "${workflow_run_current_state_authz_status}"
+  if [[ ${workflow_actor_current_state_authz_status} -ne 0 ]]; then
+    echo "Workflow actor current-state authorization guard execution failed."
+    exit "${workflow_actor_current_state_authz_status}"
   fi
 
-  if [ -n "${workflow_run_current_state_authz_report}" ]; then
-    echo "${workflow_run_current_state_authz_report}"
-    echo "Workflow run current-state endpoints must call .RequireAuthorization() or carry a per-endpoint security-allowlist comment."
+  if [ -n "${workflow_actor_current_state_authz_report}" ]; then
+    echo "${workflow_actor_current_state_authz_report}"
+    echo "Workflow actor current-state endpoints must call .RequireAuthorization() or carry a per-endpoint security-allowlist comment."
     exit 1
   fi
 fi


### PR DESCRIPTION
## 摘要

iter165 cluster-003:workflow query API/SDK 改 workflow-run/readmodel 命名(direct implement)。

**Old**:Workflow query API/SDK 用 actor-query 命名暴露 actor snapshot by raw actorId。违反 CLAUDE.md「应用层契约以业务命名」「查询走 readmodel,不暴露 actor 内部状态」。

**New**:Workflow query surface 用 workflow-run/readmodel 命名,接受 run/workflow identifier,不暴露 actor inspection 语义。`ActorInspectTool` 删除。

违反:[CLAUDE.md「权威状态 / ReadModel / Projection」+「Actor 设计」](../tree/auto-refact-dev/CLAUDE.md):应用层契约以业务命名,禁止 actor 内省。

## 范围

- `IWorkflowExecutionCurrentStateQueryPort` / Service / Endpoints / SDK:命名 + 参数
- `ActorInspectTool` → `WorkflowRunCurrentStateTool`
- 配套 AI tool provider / 注册
- `architecture_guards.sh` 加新 guard

🤖 Auto-loop / codex-refactor-loop iter165 c3 direct implement

⟦AI:AUTO-LOOP⟧
