### PR TITLE
fix(frontend): replace forbidden purple gradients with theme tokens

### DIFF
--- a/apps/aevatar-console-web/src/pages/chat/chatPresentation.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/chatPresentation.tsx
@@ -1213,9 +1213,9 @@ export function ChatMessageBubble({
       <div
         style={{
           alignItems: "center",
-          background: "linear-gradient(135deg, #8b5cf6 0%, #4f46e5 100%)",
+          background: "var(--ant-color-primary)",
           borderRadius: 999,
-          boxShadow: "0 10px 25px rgba(99, 102, 241, 0.18)",
+          boxShadow: "0 10px 25px var(--ant-color-primary-bg)",
           color: "#ffffff",
           display: "flex",
           flexShrink: 0,

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioFilesDetailPane.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioFilesDetailPane.tsx
@@ -1401,7 +1401,7 @@ const StudioFilesDetailPane: React.FC<Props> = ({
                 onClick={() => setEditingRoleKey(role.key)}
                 style={catalogCardStyle}
               >
-                <TeamOutlined style={{ color: '#8b5cf6', fontSize: 18 }} />
+                <TeamOutlined style={{ color: 'var(--ant-color-primary)', fontSize: 18 }} />
                 <div style={{ flex: 1, minWidth: 0 }}>
                   <div style={{ color: '#1f2937', fontSize: 14, fontWeight: 600 }}>
                     {role.name || role.id || 'Role'}

--- a/apps/aevatar-console-web/src/pages/workflows/WorkflowYamlViewer.tsx
+++ b/apps/aevatar-console-web/src/pages/workflows/WorkflowYamlViewer.tsx
@@ -195,7 +195,7 @@ function renderYamlValue(value: string | undefined): React.ReactNode {
   }
 
   if (/^-?\d+(\.\d+)?$/.test(value.trim())) {
-    return <span style={{ color: '#7c3aed' }}>{value}</span>;
+    return <span style={{ color: 'var(--ant-color-primary)' }}>{value}</span>;
   }
 
   if (/[{}[\]]/.test(value)) {

--- a/apps/aevatar-console-web/src/shared/agui/runtimeConversationPresentation.tsx
+++ b/apps/aevatar-console-web/src/shared/agui/runtimeConversationPresentation.tsx
@@ -451,9 +451,9 @@ export function RuntimeAssistantOutput({
         <div
           style={{
             alignItems: "center",
-            background: "linear-gradient(135deg, #8b5cf6 0%, #4f46e5 100%)",
+            background: "var(--ant-color-primary)",
             borderRadius: 999,
-            boxShadow: "0 10px 25px rgba(99, 102, 241, 0.18)",
+            boxShadow: "0 10px 25px var(--ant-color-primary-bg)",
             color: "#ffffff",
             display: "flex",
             flexShrink: 0,
@@ -737,7 +737,7 @@ export function RuntimeEventPreviewPanel({
                         : event.type.startsWith("RUN")
                           ? "#22c55e"
                           : event.type.startsWith("TOOL")
-                            ? "#8b5cf6"
+                            ? "var(--ant-color-primary)"
                             : "#6b7280",
                 flexShrink: 0,
                 fontWeight: 700,


### PR DESCRIPTION
## Issue

**frontend-audit-005 (HIGH)** — Purple gradient pattern (forbidden "紫白渐变默认主题").

4 files use purple-to-indigo gradients (#8b5cf6 to #4f46e5) or hardcoded purple colors.

## Fix

Replaced 7 purple color references with `var(--ant-color-primary)` and `var(--ant-color-primary-bg)`:
- `runtimeConversationPresentation.tsx` — 2 gradient/color replacements
- `chatPresentation.tsx` — 1 gradient replacement
- `StudioFilesDetailPane.tsx` — 1 color replacement
- `WorkflowYamlViewer.tsx` — 1 color replacement

🤖 Generated with [Frontend Refactoring Team](.claude/skills/frontend-refactor-team/)