### PR TITLE
fix(frontend): replace hardcoded gradients with CSS variables

### DIFF
--- a/apps/aevatar-console-web/src/global.less
+++ b/apps/aevatar-console-web/src/global.less
@@ -740,6 +740,23 @@ ol {
   --studio-muted-text: #667085;
   --studio-placeholder-text: #7a7a8c;
   color: #1f2328;
+
+  /* Gradient surface tokens */
+  --gradient-surface-card: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(248, 250, 252, 0.96) 100%);
+  --gradient-surface-elevated: linear-gradient(180deg, rgba(248, 250, 252, 0.9) 0%, rgba(255, 255, 255, 0.78) 100%);
+  --gradient-surface-graph: linear-gradient(180deg, rgba(248, 250, 252, 0.94) 0%, rgba(255, 255, 255, 0.98) 100%);
+  --gradient-surface-primary-header: linear-gradient(180deg, rgba(24, 144, 255, 0.06) 0%, rgba(255, 255, 255, 0.98) 100%);
+  --gradient-surface-input-shell: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(248, 250, 252, 0.98) 100%);
+  --gradient-surface-rail-warm: linear-gradient(180deg, rgba(255, 253, 249, 0.98) 0%, rgba(249, 245, 237, 0.98) 100%);
+  --gradient-surface-dark-card: linear-gradient(180deg, rgba(25, 34, 48, 0.98) 0%, rgba(34, 43, 58, 0.98) 100%);
+
+  /* Gradient button tokens */
+  --gradient-button-hover: linear-gradient(180deg, rgba(255, 255, 255, 1) 0%, rgba(239, 246, 255, 0.92) 100%);
+  --gradient-accent-default: linear-gradient(180deg, rgba(239, 246, 255, 0.98) 0%, rgba(219, 234, 254, 0.88) 100%);
+  --gradient-accent-hover: linear-gradient(180deg, rgba(219, 234, 254, 1) 0%, rgba(191, 219, 254, 0.96) 100%);
+
+  /* Gradient decorative tokens */
+  --gradient-glow-accent: radial-gradient(circle at top right, rgba(22, 119, 255, 0.14), transparent 55%);
 }
 
 .studio-shell[data-appearance='coral'] {

--- a/apps/aevatar-console-web/src/pages/actors/index.tsx
+++ b/apps/aevatar-console-web/src/pages/actors/index.tsx
@@ -1746,7 +1746,7 @@ export const TopologyExplorerPage: React.FC<{
                                 </Typography.Text>
                                 <div
                                   style={{
-                                    background: "linear-gradient(180deg, rgba(248, 250, 252, 0.94) 0%, rgba(255, 255, 255, 0.98) 100%)",
+                                    background: "var(--gradient-surface-graph)",
                                     border: `1px solid ${token.colorBorderSecondary}`,
                                     borderRadius: 18,
                                     padding: 10,
@@ -1915,7 +1915,7 @@ export const TopologyExplorerPage: React.FC<{
                 {graphControls}
                 <div
                   style={{
-                    background: "linear-gradient(180deg, rgba(248, 250, 252, 0.94) 0%, rgba(255, 255, 255, 0.98) 100%)",
+                    background: "var(--gradient-surface-graph)",
                     border: `1px solid ${token.colorBorderSecondary}`,
                     borderRadius: 20,
                     flex: 1,

--- a/apps/aevatar-console-web/src/pages/governance/components/GovernanceWorkbench.tsx
+++ b/apps/aevatar-console-web/src/pages/governance/components/GovernanceWorkbench.tsx
@@ -1899,7 +1899,7 @@ const GovernanceWorkbench: React.FC = () => {
                   <div
                     style={{
                       background:
-                        "linear-gradient(180deg, rgba(24, 144, 255, 0.06) 0%, rgba(255, 255, 255, 0.98) 100%)",
+                        "var(--gradient-surface-primary-header)",
                       borderBottom: `1px solid ${surfaceToken.colorBorderSecondary}`,
                       display: "flex",
                       flexDirection: "column",

--- a/apps/aevatar-console-web/src/pages/runs/index.tsx
+++ b/apps/aevatar-console-web/src/pages/runs/index.tsx
@@ -147,8 +147,7 @@ const runsWorkbenchHeaderTitleStyle: React.CSSProperties = {
 const runsWorkbenchHeaderActionStyle: React.CSSProperties = {
   alignItems: "center",
   backdropFilter: "blur(10px)",
-  background:
-    "linear-gradient(180deg, rgba(248, 250, 252, 0.9) 0%, rgba(255, 255, 255, 0.78) 100%)",
+  background: "var(--gradient-surface-elevated)",
   border: "1px solid rgba(226, 232, 240, 0.95)",
   borderRadius: 16,
   display: "flex",
@@ -166,8 +165,7 @@ const runsWorkbenchHeaderButtonAccentClassName =
 const runsWorkbenchHeaderToolbarCss = `
 .${runsWorkbenchHeaderToolbarClassName} .${runsWorkbenchHeaderButtonClassName} {
   align-items: center;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(248, 250, 252, 0.96) 100%);
+  background: var(--gradient-surface-card);
   border: 1px solid rgba(148, 163, 184, 0.24);
   border-radius: 12px;
   box-shadow:
@@ -189,8 +187,7 @@ const runsWorkbenchHeaderToolbarCss = `
 
 .${runsWorkbenchHeaderToolbarClassName} .${runsWorkbenchHeaderButtonClassName}:hover,
 .${runsWorkbenchHeaderToolbarClassName} .${runsWorkbenchHeaderButtonClassName}:focus {
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 1) 0%, rgba(239, 246, 255, 0.92) 100%);
+  background: var(--gradient-button-hover);
   border-color: rgba(59, 130, 246, 0.3);
   box-shadow:
     0 10px 22px rgba(59, 130, 246, 0.12),
@@ -204,8 +201,7 @@ const runsWorkbenchHeaderToolbarCss = `
 }
 
 .${runsWorkbenchHeaderToolbarClassName} .${runsWorkbenchHeaderButtonAccentClassName} {
-  background:
-    linear-gradient(180deg, rgba(239, 246, 255, 0.98) 0%, rgba(219, 234, 254, 0.88) 100%);
+  background: var(--gradient-accent-default);
   border-color: rgba(59, 130, 246, 0.28);
   box-shadow:
     0 10px 22px rgba(59, 130, 246, 0.14),
@@ -215,8 +211,7 @@ const runsWorkbenchHeaderToolbarCss = `
 
 .${runsWorkbenchHeaderToolbarClassName} .${runsWorkbenchHeaderButtonAccentClassName}:hover,
 .${runsWorkbenchHeaderToolbarClassName} .${runsWorkbenchHeaderButtonAccentClassName}:focus {
-  background:
-    linear-gradient(180deg, rgba(219, 234, 254, 1) 0%, rgba(191, 219, 254, 0.96) 100%);
+  background: var(--gradient-accent-hover);
   border-color: rgba(37, 99, 235, 0.38);
   box-shadow:
     0 14px 28px rgba(37, 99, 235, 0.18),
@@ -295,8 +290,7 @@ const runsChatTraceWrapStyle: React.CSSProperties = {
 };
 
 const runsChatComposerCardStyle: React.CSSProperties = {
-  background:
-    "linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(248, 250, 252, 0.96) 100%)",
+  background: "var(--gradient-surface-card)",
   border: "1px solid rgba(148, 163, 184, 0.18)",
   borderRadius: 20,
   boxShadow: "0 18px 40px rgba(15, 23, 42, 0.08)",
@@ -372,7 +366,7 @@ const runsChatComposerCss = `
 
 .${runsChatComposerClassName}::before {
   background:
-    radial-gradient(circle at top right, rgba(22, 119, 255, 0.14), transparent 55%);
+    var(--gradient-glow-accent);
   content: "";
   height: 220px;
   pointer-events: none;
@@ -396,7 +390,7 @@ const runsChatComposerCss = `
 
 .${runsChatComposerInputShellClassName} {
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(248, 250, 252, 0.98) 100%);
+    var(--gradient-surface-input-shell);
   border: 1px solid rgba(148, 163, 184, 0.22);
   border-radius: 16px;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9);

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioShell.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioShell.tsx
@@ -77,7 +77,7 @@ const shellRootStyle: React.CSSProperties = {
 
 const railStyle: React.CSSProperties = {
   background:
-    'linear-gradient(180deg, rgba(255, 253, 249, 0.98) 0%, rgba(249, 245, 237, 0.98) 100%)',
+    'var(--gradient-surface-rail-warm)',
   borderRight: '1px solid #ebe2d4',
   display: 'flex',
   flexDirection: 'column',
@@ -610,7 +610,7 @@ const StudioShell: React.FC<StudioShellProps> = ({
                     role="button"
                     style={{
                       background: isSelected
-                        ? 'linear-gradient(180deg, rgba(25, 34, 48, 0.98) 0%, rgba(34, 43, 58, 0.98) 100%)'
+                        ? 'var(--gradient-surface-dark-card)'
                         : 'rgba(255, 252, 246, 0.98)',
                       border: `1px solid ${isSelected ? '#141a22' : '#ebe3d4'}`,
                       borderRadius: 16,


### PR DESCRIPTION
## Issue

**frontend-audit-006 (HIGH)** — Hardcoded gradient defaults across 17 page files.

## Fix

Added 11 gradient CSS variables in `global.less` and replaced 13 hardcoded gradients in 4 files:
- `runs/index.tsx` — 8 gradient replacements
- `StudioShell.tsx` — 2 gradient replacements
- `actors/index.tsx` — 2 gradient replacements
- `GovernanceWorkbench.tsx` — 1 gradient replacement
- `services/index.tsx` — already compliant

Remaining 12 files with hardcoded gradients deferred to follow-up PRs.

🤖 Generated with [Frontend Refactoring Team](.claude/skills/frontend-refactor-team/)