### PR TITLE
fix(lark): 使用审批操作人 user_id 执行动作

### DIFF
--- a/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContextMapper.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContextMapper.cs
@@ -44,7 +44,10 @@ public static class AgentToolExecutionContextMapper
         ArgumentNullException.ThrowIfNull(request);
 
         if (request.ToolContext is { } typedContext)
-            return request.LlmControl?.ToToolContext(typedContext) ?? typedContext;
+        {
+            var mergedContext = MergeExternalMetadata(typedContext, request.Metadata);
+            return request.LlmControl?.ToToolContext(mergedContext) ?? mergedContext;
+        }
 
         var mapped = FromMetadata(request.Metadata);
         mapped = request.LlmControl?.ToToolContext(mapped) ?? mapped;
@@ -77,6 +80,23 @@ public static class AgentToolExecutionContextMapper
         ArgumentNullException.ThrowIfNull(request);
 
         return FromRequest(request).WithCallId(callId);
+    }
+
+    public static AgentToolExecutionContext MergeExternalMetadata(
+        AgentToolExecutionContext context,
+        IReadOnlyDictionary<string, string>? metadata)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var incoming = StripOwnedControlKeys(metadata);
+        if (incoming.Count == 0)
+            return context;
+
+        var merged = new Dictionary<string, string>(incoming, StringComparer.Ordinal);
+        foreach (var pair in context.ExternalMetadata)
+            merged[pair.Key] = pair.Value;
+
+        return context with { ExternalMetadata = merged };
     }
 
     public static AgentToolExecutionContext FromPayload(AgentToolExecutionContextPayload? payload)

--- a/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
@@ -306,7 +306,7 @@ public sealed class ChatRuntime
         if (skillRecovery.RequiresInitialSearch)
         {
             await skillRecovery.ApplyInitialDirectivesAsync(
-                baseRequest.ToolContext ?? AgentToolExecutionContextMapper.FromRequest(baseRequest),
+                AgentToolExecutionContextMapper.FromRequest(baseRequest),
                 messages,
                 pendingHistoryMessages,
                 ToolCallLoop.ComposeRoundCallId(baseRequest.RequestId, 0),
@@ -324,7 +324,7 @@ public sealed class ChatRuntime
             var streamingExecutor = new StreamingToolExecutor(
                 _toolLoop.Tools, _hooks, _toolLoop.ToolMiddlewares,
                 requestMetadata: baseRequest.Metadata,
-                toolContext: baseRequest.ToolContext ?? AgentToolExecutionContextMapper.FromRequest(baseRequest));
+                toolContext: AgentToolExecutionContextMapper.FromRequest(baseRequest));
             using var streamingToolState = streamingExecutor.CreateExecutionState();
 
             List<ToolCall>? deferredToolCalls = _hooks != null ? [] : null;
@@ -677,7 +677,7 @@ public sealed class ChatRuntime
                 _hooks,
                 _toolLoop.ToolMiddlewares,
                 requestMetadata: baseRequest.Metadata,
-                toolContext: toolContext ?? baseRequest.ToolContext ?? AgentToolExecutionContextMapper.FromRequest(baseRequest)));
+                toolContext: toolContext ?? AgentToolExecutionContextMapper.FromRequest(baseRequest)));
 
     private async Task RunStopHookAsync(
         string? finalContent,
@@ -884,7 +884,11 @@ public sealed class ChatRuntime
         LLMControlContext? llmControl)
     {
         var effectiveLlmControl = llmControl ?? baseRequest.LlmControl;
-        var effectiveToolContext = toolContext ?? baseRequest.ToolContext ?? AgentToolExecutionContextMapper.FromRequest(baseRequest);
+        var effectiveToolContext = toolContext is null
+            ? AgentToolExecutionContextMapper.FromRequest(baseRequest)
+            : AgentToolExecutionContextMapper.MergeExternalMetadata(
+                toolContext,
+                MergeMetadata(baseRequest.Metadata, metadata));
         effectiveToolContext = effectiveLlmControl?.ToToolContext(effectiveToolContext) ?? effectiveToolContext;
         if (!string.IsNullOrWhiteSpace(requestId))
         {

--- a/src/Aevatar.AI.Core/Tools/ToolCallLoop.cs
+++ b/src/Aevatar.AI.Core/Tools/ToolCallLoop.cs
@@ -57,7 +57,7 @@ public sealed class ToolCallLoop
         // Refactor (iter24/cluster-002-agent-tool-context-generic-metadata-bag):
         //   Old pattern: ToolCallLoop pushed raw request Metadata into AsyncLocal.
         //   New principle: tool control semantics are typed context fields; Metadata is not the internal control plane.
-        var toolContext = baseRequest.ToolContext ?? AgentToolExecutionContextMapper.FromRequest(baseRequest);
+        var toolContext = AgentToolExecutionContextMapper.FromRequest(baseRequest);
         using var _ = AgentToolContextScope.Push(toolContext);
         return await ExecuteCoreAsync(provider, messages, baseRequest, maxRounds, ct);
     }

--- a/src/Aevatar.AI.ToolProviders.Lark/ILarkNyxClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/ILarkNyxClient.cs
@@ -87,6 +87,7 @@ public sealed record LarkApprovalTaskActionRequest(
     string Action,
     string InstanceCode,
     string TaskId,
+    string UserId,
     string? Comment,
     string? FormJson,
     string? TransferUserId,

--- a/src/Aevatar.AI.ToolProviders.Lark/LarkNyxClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/LarkNyxClient.cs
@@ -283,6 +283,7 @@ public sealed class LarkNyxClient : ILarkNyxClient
         {
             ["instance_code"] = request.InstanceCode,
             ["task_id"] = request.TaskId,
+            ["user_id"] = request.UserId,
         };
 
         if (!string.IsNullOrWhiteSpace(request.Comment))

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkApprovalsActTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkApprovalsActTool.cs
@@ -63,6 +63,10 @@ public sealed class LarkApprovalsActTool : AgentToolBase<LarkApprovalsActTool.Pa
         if (!string.IsNullOrWhiteSpace(userIdType) && !AllowedUserIdTypes.Contains(userIdType))
             return LarkProxyResponseParser.Serialize(new { success = false, error = "user_id_type must be one of: user_id, union_id, open_id" });
 
+        var userId = ResolveUserId(parameters.UserId);
+        if (string.IsNullOrWhiteSpace(userId))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "user_id is required. Use the Lark approval operator user_id from current turn context." });
+
         var transferUserId = parameters.TransferUserId?.Trim();
         if (action == "transfer" && string.IsNullOrWhiteSpace(transferUserId))
             return LarkProxyResponseParser.Serialize(new { success = false, error = "transfer_user_id is required when action=transfer." });
@@ -90,6 +94,7 @@ public sealed class LarkApprovalsActTool : AgentToolBase<LarkApprovalsActTool.Pa
                 Action: action,
                 InstanceCode: instanceCode,
                 TaskId: taskId,
+                UserId: userId,
                 Comment: parameters.Comment,
                 FormJson: parameters.FormJson,
                 TransferUserId: transferUserId,
@@ -114,8 +119,22 @@ public sealed class LarkApprovalsActTool : AgentToolBase<LarkApprovalsActTool.Pa
             action,
             instance_code = instanceCode,
             task_id = taskId,
+            user_id = userId,
             transfer_user_id = transferUserId,
         });
+    }
+
+    private static string? ResolveUserId(string? explicitUserId)
+    {
+        var operatorUserId = AgentToolRequestContext.TryGetExternalMetadata("channel.lark.operator_user_id")?.Trim();
+        if (!string.IsNullOrWhiteSpace(operatorUserId))
+            return operatorUserId;
+
+        var normalized = explicitUserId?.Trim();
+        if (!string.IsNullOrWhiteSpace(normalized))
+            return normalized;
+
+        return null;
     }
 
     public sealed class Parameters
@@ -123,6 +142,7 @@ public sealed class LarkApprovalsActTool : AgentToolBase<LarkApprovalsActTool.Pa
         public string? Action { get; set; }
         public string? InstanceCode { get; set; }
         public string? TaskId { get; set; }
+        public string? UserId { get; set; }
         public string? Comment { get; set; }
         public string? FormJson { get; set; }
         public string? TransferUserId { get; set; }

--- a/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
+++ b/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
@@ -61,6 +61,41 @@ public sealed class AgentToolExecutionContextMapperTests
     }
 
     [Fact]
+    public void FromRequest_WhenTypedContextExists_ShouldMergeExternalMetadataWithoutClobberingExplicitContextMetadata()
+    {
+        var request = new LLMRequest
+        {
+            Messages = [],
+            RequestId = "request-1",
+            Metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["channel.lark.operator_user_id"] = "lark-user-from-receive-flow",
+                ["channel.lark.operator_open_id"] = "ou_operator_1",
+                ["explicit"] = "from-request",
+                [LLMRequestMetadataKeys.NyxIdAccessToken] = "metadata-token",
+            },
+            ToolContext = AgentToolExecutionContext.Empty with
+            {
+                Credentials = new AgentToolCredentials("typed-token", null, null),
+                ExternalMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["explicit"] = "from-tool-context",
+                    ["tool-only"] = "kept",
+                },
+            },
+        };
+
+        var context = AgentToolExecutionContextMapper.FromRequest(request);
+
+        context.Credentials.NyxIdAccessToken.Should().Be("typed-token");
+        context.ExternalMetadata["channel.lark.operator_user_id"].Should().Be("lark-user-from-receive-flow");
+        context.ExternalMetadata["channel.lark.operator_open_id"].Should().Be("ou_operator_1");
+        context.ExternalMetadata["explicit"].Should().Be("from-tool-context");
+        context.ExternalMetadata["tool-only"].Should().Be("kept");
+        context.ExternalMetadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
+    }
+
+    [Fact]
     public void FromMetadata_WhenChannelCanonicalKeysAreAbsent_ShouldMapLegacyAliases()
     {
         var context = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>(StringComparer.Ordinal)

--- a/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
+++ b/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
@@ -136,6 +136,65 @@ public class ToolCallLoopTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_WhenTypedToolContextExists_ShouldExposeRequestExternalMetadataToToolExecution()
+    {
+        var provider = new QueueLLMProvider(
+        [
+            new LLMResponse
+            {
+                ToolCalls =
+                [
+                    new ToolCall
+                    {
+                        Id = "tc-context",
+                        Name = "capture_context",
+                        ArgumentsJson = "{}",
+                    },
+                ],
+            },
+            new LLMResponse { Content = "done" },
+        ]);
+        var tools = new ToolManager();
+        string? observedOperatorUserId = null;
+        string? observedExplicitMetadata = null;
+        string? observedAccessToken = null;
+        tools.Register(new DelegateTool("capture_context", _ =>
+        {
+            observedOperatorUserId = AgentToolRequestContext.TryGetExternalMetadata("channel.lark.operator_user_id");
+            observedExplicitMetadata = AgentToolRequestContext.TryGetExternalMetadata("explicit");
+            observedAccessToken = AgentToolRequestContext.NyxIdAccessToken;
+            return "{}";
+        }));
+        var loop = new ToolCallLoop(tools);
+        var messages = new List<ChatMessage> { ChatMessage.User("approve it") };
+        var request = new LLMRequest
+        {
+            Messages = [],
+            RequestId = "session-operator",
+            Metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["channel.lark.operator_user_id"] = "lark-user-1",
+                ["explicit"] = "from-request",
+                [LLMRequestMetadataKeys.NyxIdAccessToken] = "metadata-token",
+            },
+            ToolContext = AgentToolExecutionContext.Empty with
+            {
+                Credentials = new AgentToolCredentials("typed-token", null, null),
+                ExternalMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["explicit"] = "from-tool-context",
+                },
+            },
+        };
+
+        await loop.ExecuteAsync(provider, messages, request, maxRounds: 2, CancellationToken.None);
+
+        observedOperatorUserId.Should().Be("lark-user-1");
+        observedExplicitMetadata.Should().Be("from-tool-context");
+        observedAccessToken.Should().Be("typed-token");
+    }
+
+    [Fact]
     public async Task ExecuteAsync_WhenBaseRequestIdPresent_ShouldExposeStableRequestIdAndPerCallIdToLlmMiddlewareMetadata()
     {
         var provider = new QueueLLMProvider(

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/Aevatar.AI.ToolProviders.Lark.Tests.csproj
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/Aevatar.AI.ToolProviders.Lark.Tests.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>Aevatar.AI.ToolProviders.Lark.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Aevatar.AI.Core\Aevatar.AI.Core.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.AI.ToolProviders.Lark\Aevatar.AI.ToolProviders.Lark.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkCoverageTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkCoverageTests.cs
@@ -196,6 +196,7 @@ public sealed class LarkCoverageTests
                 "approve",
                 "inst-1",
                 "task-1",
+                "lark-user-1",
                 "looks good",
                 """{"field":"value"}""",
                 null,
@@ -210,7 +211,7 @@ public sealed class LarkCoverageTests
 
         await client.ActOnApprovalTaskAsync(
             "token-123",
-            new LarkApprovalTaskActionRequest("reject", "inst-1", "task-1", null, null, null, null),
+            new LarkApprovalTaskActionRequest("reject", "inst-1", "task-1", "lark-user-1", null, null, null, null),
             CancellationToken.None);
 
         handler.LastRequest!.RequestUri!.ToString()
@@ -219,7 +220,7 @@ public sealed class LarkCoverageTests
 
         await client.ActOnApprovalTaskAsync(
             "token-123",
-            new LarkApprovalTaskActionRequest("transfer", "inst-1", "task-1", null, null, "ou_target", null),
+            new LarkApprovalTaskActionRequest("transfer", "inst-1", "task-1", "lark-user-1", null, null, "ou_target", null),
             CancellationToken.None);
 
         handler.LastRequest!.RequestUri!.ToString()
@@ -228,7 +229,7 @@ public sealed class LarkCoverageTests
 
         var unsupported = () => client.ActOnApprovalTaskAsync(
             "token-123",
-            new LarkApprovalTaskActionRequest("escalate", "inst-1", "task-1", null, null, null, null),
+            new LarkApprovalTaskActionRequest("escalate", "inst-1", "task-1", "lark-user-1", null, null, null, null),
             CancellationToken.None);
 
         await unsupported.Should().ThrowAsync<InvalidOperationException>()

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.Tools;
 using Aevatar.AI.ToolProviders.Lark.Tools;
 using Aevatar.AI.ToolProviders.NyxId;
 using FluentAssertions;
@@ -972,19 +973,13 @@ public class LarkToolsTests
     public async Task LarkApprovalsActTool_ValidatesTransferTarget()
     {
         var tool = new LarkApprovalsActTool(new StubLarkNyxClient());
-        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        using (new AgentToolRequestMetadataScope("token-123", new Dictionary<string, string>(StringComparer.Ordinal)
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-123",
-        };
-
-        try
+            ["channel.lark.operator_user_id"] = "lark-user-1",
+        }))
         {
             var result = await tool.ExecuteAsync("""{"action":"transfer","instance_code":"inst_1","task_id":"task_1"}""");
             result.Should().Contain("transfer_user_id is required");
-        }
-        finally
-        {
-            AgentToolRequestContext.CurrentMetadata = null;
         }
     }
 
@@ -996,12 +991,10 @@ public class LarkToolsTests
             ApprovalActionResponse = """{"code":0,"data":{}}""",
         };
         var tool = new LarkApprovalsActTool(client);
-        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        using (new AgentToolRequestMetadataScope("token-123", new Dictionary<string, string>(StringComparer.Ordinal)
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-123",
-        };
-
-        try
+            ["channel.lark.operator_user_id"] = "lark-user-1",
+        }))
         {
             var result = await tool.ExecuteAsync(
                 """{"action":"approve","instance_code":"inst_1","task_id":"task_1","comment":"LGTM","form_json":"[{\"id\":\"field_1\",\"type\":\"input\",\"value\":\"ok\"}]"}""");
@@ -1010,12 +1003,87 @@ public class LarkToolsTests
             document.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
             client.LastApprovalActionRequest.Should().NotBeNull();
             client.LastApprovalActionRequest!.Action.Should().Be("approve");
+            client.LastApprovalActionRequest.UserId.Should().Be("lark-user-1");
             client.LastApprovalActionRequest.FormJson.Should().Contain("\"field_1\"");
         }
-        finally
+    }
+
+    [Fact]
+    public async Task LarkApprovalsActTool_UsesLarkOperatorUserIdFromTurnMetadataOverToolArgument()
+    {
+        var client = new StubLarkNyxClient
         {
-            AgentToolRequestContext.CurrentMetadata = null;
+            ApprovalActionResponse = """{"code":0,"data":{}}""",
+        };
+        var tool = new LarkApprovalsActTool(client);
+
+        using (new AgentToolRequestMetadataScope("token-123", new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["channel.lark.operator_user_id"] = "lark-user-1",
+            ["channel.lark.operator_open_id"] = "ou_4159cd4d1af9b836b0fb2dc05ef52efe",
+        }))
+        {
+            var result = await tool.ExecuteAsync(
+                """{"action":"approve","instance_code":"inst_1","task_id":"task_1","user_id":"ou_4159cd4d1af9b836b0fb2dc05ef52efe","comment":"LGTM"}""");
+
+            using var document = JsonDocument.Parse(result);
+            document.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+            client.LastApprovalActionRequest.Should().NotBeNull();
+            client.LastApprovalActionRequest!.UserId.Should().Be("lark-user-1");
+            client.LastApprovalActionRequest.UserId.Should().NotBe("ou_4159cd4d1af9b836b0fb2dc05ef52efe");
         }
+    }
+
+    [Fact]
+    public async Task LarkApprovalsActTool_UsesLarkOperatorUserIdFromProductionToolLoopMetadataBridge()
+    {
+        var client = new StubLarkNyxClient
+        {
+            ApprovalActionResponse = """{"code":0,"data":{}}""",
+        };
+        var tools = new ToolManager();
+        tools.Register(new LarkApprovalsActTool(client));
+        var provider = new QueueLLMProvider(
+        [
+            new LLMResponse
+            {
+                ToolCalls =
+                [
+                    new ToolCall
+                    {
+                        Id = "tc-lark-approval",
+                        Name = "lark_approvals_act",
+                        ArgumentsJson = """{"action":"approve","instance_code":"inst_1","task_id":"task_1","comment":"LGTM"}""",
+                    },
+                ],
+            },
+            new LLMResponse { Content = "done" },
+        ]);
+        var request = new LLMRequest
+        {
+            Messages = [],
+            RequestId = "session-lark-approval",
+            Metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["channel.lark.operator_user_id"] = "lark-user-1",
+                ["channel.lark.operator_open_id"] = "ou_operator_1",
+            },
+            ToolContext = AgentToolExecutionContext.Empty with
+            {
+                Credentials = new AgentToolCredentials("token-123", null, null),
+            },
+        };
+
+        await new ToolCallLoop(tools).ExecuteAsync(
+            provider,
+            [ChatMessage.User("approve the task")],
+            request,
+            maxRounds: 2,
+            CancellationToken.None);
+
+        client.LastApprovalActionRequest.Should().NotBeNull();
+        client.LastApprovalActionRequest!.UserId.Should().Be("lark-user-1");
+        client.LastApprovalActionRequest.UserId.Should().NotBe("ou_operator_1");
     }
 
     [Fact]
@@ -1037,13 +1105,15 @@ public class LarkToolsTests
                 .Should().Contain("instance_code is required");
             (await tool.ExecuteAsync("""{"action":"approve","instance_code":"inst_1"}"""))
                 .Should().Contain("task_id is required");
+            (await tool.ExecuteAsync("""{"action":"approve","instance_code":"inst_1","task_id":"task_1"}"""))
+                .Should().Contain("user_id is required");
             (await tool.ExecuteAsync("""{"action":"approve","instance_code":"inst_1","task_id":"task_1","user_id_type":"email"}"""))
                 .Should().Contain("user_id_type must be one of");
-            (await tool.ExecuteAsync("""{"action":"approve","instance_code":"inst_1","task_id":"task_1","transfer_user_id":"ou_1"}"""))
+            (await tool.ExecuteAsync("""{"action":"approve","instance_code":"inst_1","task_id":"task_1","user_id":"lark-user-1","transfer_user_id":"ou_1"}"""))
                 .Should().Contain("transfer_user_id is only allowed when action=transfer");
-            (await tool.ExecuteAsync("""{"action":"reject","instance_code":"inst_1","task_id":"task_1","form_json":"{}"}"""))
+            (await tool.ExecuteAsync("""{"action":"reject","instance_code":"inst_1","task_id":"task_1","user_id":"lark-user-1","form_json":"{}"}"""))
                 .Should().Contain("form_json is only supported when action=approve");
-            (await tool.ExecuteAsync("""{"action":"approve","instance_code":"inst_1","task_id":"task_1","form_json":"{bad json}"}"""))
+            (await tool.ExecuteAsync("""{"action":"approve","instance_code":"inst_1","task_id":"task_1","user_id":"lark-user-1","form_json":"{bad json}"}"""))
                 .Should().Contain("form_json is not valid JSON");
         }
 
@@ -1054,7 +1124,7 @@ public class LarkToolsTests
         using (new AgentToolRequestMetadataScope("token-123"))
         {
             var result = await errorTool.ExecuteAsync(
-                """{"action":"reject","instance_code":"inst_1","task_id":"task_1","comment":"nope"}""");
+                """{"action":"reject","instance_code":"inst_1","task_id":"task_1","user_id":"lark-user-1","comment":"nope"}""");
 
             result.Should().Contain("nyx_proxy_error status=409");
             result.Should().Contain("\"action\":\"reject\"");
@@ -1364,12 +1434,13 @@ public class LarkToolsTests
 
         await client.ActOnApprovalTaskAsync(
             "token-123",
-            new LarkApprovalTaskActionRequest("transfer", "inst_1", "task_1", "reassign", null, "ou_target", "open_id"),
+            new LarkApprovalTaskActionRequest("transfer", "inst_1", "task_1", "lark-user-1", "reassign", null, "ou_target", "open_id"),
             CancellationToken.None);
 
         handler.LastRequest.Should().NotBeNull();
         handler.LastRequest!.RequestUri!.ToString()
             .Should().Be("https://nyx.example.com/api/v1/proxy/s/api-lark-bot/open-apis/approval/v4/tasks/forward?user_id_type=open_id");
+        handler.LastBody.Should().Contain("\"user_id\":\"lark-user-1\"");
         handler.LastBody.Should().Contain("\"transfer_user_id\":\"ou_target\"");
     }
 
@@ -1477,6 +1548,43 @@ public class LarkToolsTests
         {
             LastApprovalActionRequest = request;
             return Task.FromResult(ApprovalActionResponse);
+        }
+    }
+
+    private sealed class QueueLLMProvider : ILLMProvider
+    {
+        private readonly Queue<LLMResponse> _responses;
+
+        public QueueLLMProvider(IEnumerable<LLMResponse> responses)
+        {
+            _responses = new Queue<LLMResponse>(responses);
+        }
+
+        public string Name => "queue";
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            var response = _responses.Count > 0 ? _responses.Dequeue() : new LLMResponse();
+
+            if (!string.IsNullOrEmpty(response.Content))
+                yield return new LLMStreamChunk { DeltaContent = response.Content };
+
+            if (response.ToolCalls is { Count: > 0 })
+            {
+                foreach (var toolCall in response.ToolCalls)
+                    yield return new LLMStreamChunk { DeltaToolCall = toolCall };
+            }
+
+            yield return new LLMStreamChunk
+            {
+                IsLast = true,
+                Usage = response.Usage,
+                FinishReason = response.FinishReason,
+            };
+            await Task.CompletedTask;
         }
     }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
@@ -98,7 +98,7 @@ public sealed class ChannelConversationTurnRunnerTests
     }
 
     [Fact]
-    public async Task RunInboundAsync_ShouldIncludeLarkOperatorIdsInLlmMetadata_WhenAvailable()
+    public async Task RunInboundAsync_ShouldUseLarkApprovalOperatorUserIdInLlmMetadata_WhenAvailable()
     {
         var registrationQueryPort = BuildRegistrationQueryPort();
         var adapter = new RecordingPlatformAdapter();
@@ -111,7 +111,8 @@ public sealed class ChannelConversationTurnRunnerTests
                 transportExtras: new TransportExtras
                 {
                     NyxPlatform = "lark",
-                    NyxLarkOperatorUserId = "ou_operator_1",
+                    NyxSenderUserId = "nyx-user-1",
+                    NyxLarkOperatorUserId = "lark-user-1",
                     NyxLarkOperatorOpenId = "ou_open_operator_1",
                     NyxLarkOperatorUnionId = "on_operator_1",
                 }),
@@ -119,7 +120,8 @@ public sealed class ChannelConversationTurnRunnerTests
 
         result.Success.Should().BeTrue();
         result.LlmReplyRequest.Should().NotBeNull();
-        result.LlmReplyRequest!.Metadata[ChannelMetadataKeys.LarkOperatorUserId].Should().Be("ou_operator_1");
+        result.LlmReplyRequest!.Metadata[ChannelMetadataKeys.LarkOperatorUserId].Should().Be("lark-user-1");
+        result.LlmReplyRequest.Metadata[ChannelMetadataKeys.LarkOperatorUserId].Should().NotBe("nyx-user-1");
         result.LlmReplyRequest.Metadata[ChannelMetadataKeys.LarkOperatorOpenId].Should().Be("ou_open_operator_1");
         result.LlmReplyRequest.Metadata[ChannelMetadataKeys.LarkOperatorUnionId].Should().Be("on_operator_1");
     }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
@@ -192,7 +192,7 @@ public sealed class ConversationReplyGeneratorTests
     }
 
     [Fact]
-    public async Task GenerateReplyAsync_WithChannelContextMiddleware_IncludesLarkOperatorUserIdInSystemPrompt()
+    public async Task GenerateReplyAsync_WithChannelContextMiddleware_IncludesLarkApprovalOperatorUserIdInSystemPrompt()
     {
         var providerFactory = new RecordingProviderFactory();
         var generator = new NyxIdConversationReplyGenerator(
@@ -213,7 +213,8 @@ public sealed class ConversationReplyGeneratorTests
                 [ChannelMetadataKeys.ChatType] = "group",
                 [ChannelMetadataKeys.SenderId] = "ou_sender_1",
                 [ChannelMetadataKeys.ConversationId] = "oc_1",
-                [ChannelMetadataKeys.LarkOperatorUserId] = "ou_operator_1",
+                [ChannelMetadataKeys.LarkOperatorUserId] = "lark-user-1",
+                [ChannelMetadataKeys.LarkOperatorOpenId] = "ou_operator_1",
             },
             streamingSink: null,
             CancellationToken.None);
@@ -221,7 +222,8 @@ public sealed class ConversationReplyGeneratorTests
         reply.Text.Should().Be("ok");
         var systemPrompt = providerFactory.Requests.Should().ContainSingle().Subject
             .Messages.First(message => message.Role == "system").Content;
-        systemPrompt.Should().Contain("operator_user_id: \"ou_operator_1\"");
+        systemPrompt.Should().Contain("operator_user_id: \"lark-user-1\"");
+        systemPrompt.Should().Contain("operator_open_id: \"ou_operator_1\"");
     }
 
     [Fact]


### PR DESCRIPTION
修复 Lark 审批动作身份来源，确保接收流程中的 operator_user_id 进入真实工具执行上下文，并优先于模型传入的 user_id，避免将 ou_* open_id 发送给审批系统。

验证：
- dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --nologo --filter "FullyQualifiedName~AgentToolExecutionContextMapperTests|FullyQualifiedName~ToolCallLoopTests"
- dotnet test test/Aevatar.AI.ToolProviders.Lark.Tests/Aevatar.AI.ToolProviders.Lark.Tests.csproj --nologo --filter "FullyQualifiedName~LarkApprovalsActTool|FullyQualifiedName~ActOnApprovalTaskAsync"
- dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo --filter "FullyQualifiedName~RunInboundAsync_ShouldUseLarkApprovalOperatorUserIdInLlmMetadata_WhenAvailable|FullyQualifiedName~GenerateReplyAsync_WithChannelContextMiddleware_IncludesLarkApprovalOperatorUserIdInSystemPrompt|FullyQualifiedName~ShouldExtractLarkOperatorIds"