### PR TITLE
Fix workflow LLM prompt prefix editing

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
@@ -1179,6 +1179,9 @@ describe('StudioWorkflowBuildPanel', () => {
             'nyxid.route_preference': '/api/v1/proxy/s/openai',
           },
           prompt: 'Please triage the refund request.',
+          workflowYamls: [
+            expect.stringContaining('name: workflow-demo'),
+          ],
         }),
         expect.any(AbortSignal),
       );

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
@@ -1241,12 +1241,14 @@ describe('StudioWorkflowBuildPanel', () => {
     );
 
     const promptPrefixInput = await screen.findByLabelText(
-      'Parameter prompt_prefix',
+      'Parameter Prompt instruction',
     );
     expect(promptPrefixInput).toHaveValue('Legacy prompt field');
+    expect(screen.getByText('Prompt instruction')).toBeInTheDocument();
     expect(screen.queryByLabelText('Parameter prompt')).not.toBeInTheDocument();
+    expect(screen.queryByText('prompt_prefix')).not.toBeInTheDocument();
     expect(
-      screen.getByText(/Prompt prefix prepended before the workflow run prompt reaches the LLM/i),
+      screen.getByText(/Instruction added before each workflow run input reaches the LLM/i),
     ).toBeInTheDocument();
 
     fireEvent.change(promptPrefixInput, {
@@ -1279,7 +1281,7 @@ describe('StudioWorkflowBuildPanel', () => {
     );
 
     const promptPrefixInput = await screen.findByLabelText(
-      'Parameter prompt_prefix',
+      'Parameter Prompt instruction',
     );
     fireEvent.change(promptPrefixInput, {
       target: {
@@ -1299,6 +1301,53 @@ describe('StudioWorkflowBuildPanel', () => {
     expect(JSON.parse(pendingDraft.draft.parametersText)).toEqual({
       prompt_prefix: 'Classify the refund request before answering.',
     });
+  });
+
+  it('does not show object defaults as llm prompt instructions', async () => {
+    render(
+      <WorkflowBuildHarness
+        initialDocumentOverride={{
+          ...initialDocument,
+          steps: [
+            {
+              ...initialDocument.steps[0],
+              parameters: {},
+            },
+            initialDocument.steps[1],
+          ],
+        }}
+        onContinueToBind={jest.fn()}
+        onSaveDraft={jest.fn()}
+        runtimePrimitivesOverride={[
+          {
+            name: 'llm_call',
+            aliases: [],
+            description: 'Call the LLM.',
+            category: 'ai',
+            parameters: [
+              {
+                name: 'prompt',
+                type: 'string',
+                required: false,
+                description: 'Prompt template or prompt override.',
+                default: '{}',
+                enumValues: [],
+              },
+            ],
+            exampleWorkflows: ['workflow-demo'],
+          },
+        ]}
+      />,
+    );
+
+    const promptPrefixInput = await screen.findByLabelText(
+      'Parameter Prompt instruction',
+    );
+    expect(promptPrefixInput).toHaveValue('');
+    expect(promptPrefixInput).toHaveAttribute(
+      'placeholder',
+      'e.g. Translate the user input to Japanese',
+    );
   });
 
   it('keeps human prompt edits on the prompt parameter', async () => {

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
@@ -69,6 +69,15 @@ type AppliedStepDraft = {
   readonly parametersText: string;
 };
 
+type BuildWorkflowYamlsForTest = (
+  draft?: {
+    readonly stepId: string;
+    readonly draft: {
+      readonly parametersText: string;
+    };
+  } | null,
+) => Promise<string[]>;
+
 jest.mock('@/shared/api/runtimeRunsApi', () => ({
   runtimeRunsApi: {
     streamDraftRun: jest.fn(),
@@ -257,12 +266,14 @@ function buildWorkflowYaml(document: WorkflowBuildHarnessDocument): string {
 }
 
 function WorkflowBuildHarness({
+  buildWorkflowYamlsOverride,
   initialDocumentOverride,
   onApplyStepDraftOverride,
   onContinueToBind,
   onSaveDraft,
   runtimePrimitivesOverride,
 }: {
+  readonly buildWorkflowYamlsOverride?: BuildWorkflowYamlsForTest;
   readonly initialDocumentOverride?: WorkflowBuildHarnessDocument;
   readonly onApplyStepDraftOverride?: (draft: any) => Promise<void>;
   readonly onContinueToBind: jest.Mock;
@@ -303,7 +314,7 @@ function WorkflowBuildHarness({
   return (
     <StudioWorkflowBuildPanel
       availableStepTypes={['llm_call', 'human_approval', 'connector_call']}
-      buildWorkflowYamls={async () => [draftYaml]}
+      buildWorkflowYamls={buildWorkflowYamlsOverride ?? (async () => [draftYaml])}
       canSaveWorkflow
       draftYaml={draftYaml}
       dryRunModelLabel="gpt-5.4-mini"
@@ -1300,6 +1311,43 @@ describe('StudioWorkflowBuildPanel', () => {
     expect(pendingDraft.stepId).toBe('draft_step');
     expect(JSON.parse(pendingDraft.draft.parametersText)).toEqual({
       prompt_prefix: 'Classify the refund request before answering.',
+    });
+  });
+
+  it('passes unsaved llm_call prompt edits to workflow dry-run YAMLs', async () => {
+    const buildWorkflowYamls = jest.fn<
+      Promise<string[]>,
+      Parameters<BuildWorkflowYamlsForTest>
+    >(async () => ['name: workflow-demo']);
+
+    render(
+      <WorkflowBuildHarness
+        buildWorkflowYamlsOverride={buildWorkflowYamls}
+        onContinueToBind={jest.fn()}
+        onSaveDraft={jest.fn()}
+      />,
+    );
+
+    const promptPrefixInput = await screen.findByLabelText(
+      'Parameter Prompt instruction',
+    );
+    fireEvent.change(promptPrefixInput, {
+      target: {
+        value: 'Translate the input to English.',
+      },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    await waitFor(() => {
+      expect(buildWorkflowYamls).toHaveBeenCalledTimes(1);
+    });
+    const pendingDraft = buildWorkflowYamls.mock.calls.at(0)?.[0];
+    if (!pendingDraft) {
+      throw new Error('Expected Run to pass the pending step draft.');
+    }
+    expect(pendingDraft.stepId).toBe('draft_step');
+    expect(JSON.parse(pendingDraft.draft.parametersText)).toEqual({
+      prompt_prefix: 'Translate the input to English.',
     });
   });
 

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
@@ -20,6 +20,55 @@ import {
   StudioWorkflowBuildPanel,
 } from './StudioBuildPanels';
 
+type WorkflowPrimitiveParameterTestDescriptor = {
+  readonly name: string;
+  readonly type: string;
+  readonly required: boolean;
+  readonly description: string;
+  readonly default: string;
+  readonly enumValues: string[];
+};
+
+type WorkflowPrimitiveTestDescriptor = {
+  readonly name: string;
+  readonly aliases: string[];
+  readonly category: string;
+  readonly description: string;
+  readonly parameters: WorkflowPrimitiveParameterTestDescriptor[];
+  readonly exampleWorkflows: string[];
+};
+
+type WorkflowBuildHarnessRoleDocument = {
+  readonly id?: string;
+  readonly name?: string;
+  readonly systemPrompt?: string;
+  readonly provider?: string | null;
+  readonly model?: string | null;
+  readonly connectors?: unknown[];
+};
+
+type WorkflowBuildHarnessStepDocument = {
+  readonly id?: string;
+  readonly type?: string;
+  readonly originalType?: string;
+  readonly targetRole?: string | null;
+  readonly target_role?: string | null;
+  readonly parameters?: Record<string, unknown> | null;
+  readonly next?: string | null;
+  readonly branches?: Record<string, string> | null;
+};
+
+type WorkflowBuildHarnessDocument = {
+  readonly name?: string;
+  readonly description?: string;
+  readonly roles: WorkflowBuildHarnessRoleDocument[];
+  readonly steps: WorkflowBuildHarnessStepDocument[];
+};
+
+type AppliedStepDraft = {
+  readonly parametersText: string;
+};
+
 jest.mock('@/shared/api/runtimeRunsApi', () => ({
   runtimeRunsApi: {
     streamDraftRun: jest.fn(),
@@ -130,7 +179,7 @@ const scriptDetail = {
   },
 };
 
-const initialDocument = {
+const initialDocument: WorkflowBuildHarnessDocument = {
   name: 'workflow-demo',
   description: 'Workflow demo',
   roles: [
@@ -171,7 +220,7 @@ function cloneValue<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
 
-function buildWorkflowYaml(document: typeof initialDocument): string {
+function buildWorkflowYaml(document: WorkflowBuildHarnessDocument): string {
   const roleLines = document.roles.flatMap((role) => {
     const lines = [`  - id: ${role.id}`];
     if (role.name) {
@@ -208,17 +257,22 @@ function buildWorkflowYaml(document: typeof initialDocument): string {
 }
 
 function WorkflowBuildHarness({
+  initialDocumentOverride,
   onApplyStepDraftOverride,
   onContinueToBind,
   onSaveDraft,
+  runtimePrimitivesOverride,
 }: {
+  readonly initialDocumentOverride?: WorkflowBuildHarnessDocument;
   readonly onApplyStepDraftOverride?: (draft: any) => Promise<void>;
   readonly onContinueToBind: jest.Mock;
   readonly onSaveDraft: jest.Mock;
+  readonly runtimePrimitivesOverride?: readonly WorkflowPrimitiveTestDescriptor[];
 }) {
-  const [document, setDocument] = React.useState(() => cloneValue(initialDocument));
+  const documentSeed = initialDocumentOverride ?? initialDocument;
+  const [document, setDocument] = React.useState(() => cloneValue(documentSeed));
   const [draftYaml, setDraftYaml] = React.useState(() =>
-    buildWorkflowYaml(initialDocument),
+    buildWorkflowYaml(documentSeed),
   );
   const [selectedGraphNodeId, setSelectedGraphNodeId] = React.useState(
     'step:draft_step',
@@ -232,7 +286,7 @@ function WorkflowBuildHarness({
 
   const commitDocument = React.useCallback(
     async (
-      nextDocument: typeof initialDocument,
+      nextDocument: WorkflowBuildHarnessDocument,
       options?: {
         readonly nextSelectedNodeId?: string;
       },
@@ -260,7 +314,7 @@ function WorkflowBuildHarness({
           : async (draft) => {
               const currentStepId = selectedGraphNodeId.replace(/^step:/, '');
               const result = applyStepInspectorDraft(document, currentStepId, draft);
-              await commitDocument(result.document as typeof initialDocument, {
+              await commitDocument(result.document as WorkflowBuildHarnessDocument, {
                 nextSelectedNodeId: result.nodeId,
               });
             }
@@ -279,7 +333,7 @@ function WorkflowBuildHarness({
             sourceStep?.branches || {},
           ),
         );
-        void commitDocument(result.document as typeof initialDocument, {
+        void commitDocument(result.document as WorkflowBuildHarnessDocument, {
           nextSelectedNodeId: result.nodeId,
         });
       }}
@@ -289,7 +343,7 @@ function WorkflowBuildHarness({
           afterStepId: selectedGraphNodeId.replace(/^step:/, ''),
           targetRoleId: 'assistant',
         });
-        await commitDocument(result.document as typeof initialDocument, {
+        await commitDocument(result.document as WorkflowBuildHarnessDocument, {
           nextSelectedNodeId: result.nodeId,
         });
       }}
@@ -305,7 +359,7 @@ function WorkflowBuildHarness({
       onRemoveSelectedStep={async () => {
         const currentStepId = selectedGraphNodeId.replace(/^step:/, '');
         const result = removeStep(document, currentStepId);
-        await commitDocument(result.document as typeof initialDocument, {
+        await commitDocument(result.document as WorkflowBuildHarnessDocument, {
           nextSelectedNodeId: result.nodeId,
         });
       }}
@@ -316,7 +370,7 @@ function WorkflowBuildHarness({
         }
 
         const result = removeStep(document, selectedNodeId);
-        await commitDocument(result.document as typeof initialDocument, {
+        await commitDocument(result.document as WorkflowBuildHarnessDocument, {
           nextSelectedNodeId: result.nodeId,
         });
       }}
@@ -327,7 +381,7 @@ function WorkflowBuildHarness({
       onRunPromptChange={setRunPrompt}
       onSaveDraft={() => onSaveDraft(draftYaml)}
       onSetDraftYaml={setDraftYaml}
-      runtimePrimitives={[
+      runtimePrimitives={runtimePrimitivesOverride ?? [
         {
           name: 'llm_call',
           aliases: [],
@@ -1137,6 +1191,143 @@ describe('StudioWorkflowBuildPanel', () => {
     expect(handleContinueToBind).toHaveBeenCalledWith(
       expect.stringContaining('review_step'),
     );
+  });
+
+  it('writes llm_call prompt edits to prompt_prefix when runtime exposes prompt', async () => {
+    const handleApplyStepDraft = jest.fn<Promise<void>, [AppliedStepDraft]>(
+      async () => undefined,
+    );
+
+    render(
+      <WorkflowBuildHarness
+        initialDocumentOverride={{
+          ...initialDocument,
+          steps: [
+            {
+              ...initialDocument.steps[0],
+              parameters: {
+                prompt: 'Legacy prompt field',
+              },
+            },
+            initialDocument.steps[1],
+          ],
+        }}
+        onApplyStepDraftOverride={handleApplyStepDraft}
+        onContinueToBind={jest.fn()}
+        onSaveDraft={jest.fn()}
+        runtimePrimitivesOverride={[
+          {
+            name: 'llm_call',
+            aliases: [],
+            description: 'Call the LLM.',
+            category: 'ai',
+            parameters: [
+              {
+                name: 'prompt',
+                type: 'string',
+                required: false,
+                description: 'Prompt template or prompt override.',
+                default: '',
+                enumValues: [],
+              },
+            ],
+            exampleWorkflows: ['workflow-demo'],
+          },
+        ]}
+      />,
+    );
+
+    const promptPrefixInput = await screen.findByLabelText(
+      'Parameter prompt_prefix',
+    );
+    expect(promptPrefixInput).toHaveValue('Legacy prompt field');
+    expect(screen.queryByLabelText('Parameter prompt')).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/Prompt prefix prepended before the workflow run prompt reaches the LLM/i),
+    ).toBeInTheDocument();
+
+    fireEvent.change(promptPrefixInput, {
+      target: {
+        value: 'Translate the input to Japanese.',
+      },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply changes' }));
+
+    await waitFor(() => {
+      expect(handleApplyStepDraft).toHaveBeenCalledTimes(1);
+    });
+    const appliedDraft = handleApplyStepDraft.mock.calls.at(0)?.[0];
+    if (!appliedDraft) {
+      throw new Error('Expected an applied step draft.');
+    }
+    expect(JSON.parse(appliedDraft.parametersText)).toEqual({
+      prompt_prefix: 'Translate the input to Japanese.',
+    });
+  });
+
+  it('keeps human prompt edits on the prompt parameter', async () => {
+    const handleApplyStepDraft = jest.fn<Promise<void>, [AppliedStepDraft]>(
+      async () => undefined,
+    );
+
+    render(
+      <WorkflowBuildHarness
+        initialDocumentOverride={{
+          ...initialDocument,
+          steps: [
+            initialDocument.steps[0],
+            {
+              ...initialDocument.steps[1],
+              parameters: {
+                prompt: 'Approve this step?',
+              },
+            },
+          ],
+        }}
+        onApplyStepDraftOverride={handleApplyStepDraft}
+        onContinueToBind={jest.fn()}
+        onSaveDraft={jest.fn()}
+        runtimePrimitivesOverride={[
+          {
+            name: 'human_approval',
+            aliases: [],
+            description: 'Pause for approval.',
+            category: 'human',
+            parameters: [
+              {
+                name: 'prompt',
+                type: 'string',
+                required: false,
+                description: 'Prompt shown to the reviewer.',
+                default: '',
+                enumValues: [],
+              },
+            ],
+            exampleWorkflows: ['workflow-demo'],
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'approve_step' }));
+    const promptInput = await screen.findByLabelText('Parameter prompt');
+    fireEvent.change(promptInput, {
+      target: {
+        value: 'Approve the generated response?',
+      },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply changes' }));
+
+    await waitFor(() => {
+      expect(handleApplyStepDraft).toHaveBeenCalledTimes(1);
+    });
+    const appliedDraft = handleApplyStepDraft.mock.calls.at(0)?.[0];
+    if (!appliedDraft) {
+      throw new Error('Expected an applied step draft.');
+    }
+    expect(JSON.parse(appliedDraft.parametersText)).toEqual({
+      prompt: 'Approve the generated response?',
+    });
   });
 
   it('keeps runtime metadata out of output and only exposes it in debug details', async () => {

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
@@ -379,7 +379,7 @@ function WorkflowBuildHarness({
         'nyxid.route_preference': '/api/v1/proxy/s/openai',
       }}
       onRunPromptChange={setRunPrompt}
-      onSaveDraft={() => onSaveDraft(draftYaml)}
+      onSaveDraft={(pendingDraft) => onSaveDraft(pendingDraft ?? draftYaml)}
       onSetDraftYaml={setDraftYaml}
       runtimePrimitives={runtimePrimitivesOverride ?? [
         {
@@ -1265,6 +1265,39 @@ describe('StudioWorkflowBuildPanel', () => {
     }
     expect(JSON.parse(appliedDraft.parametersText)).toEqual({
       prompt_prefix: 'Translate the input to Japanese.',
+    });
+  });
+
+  it('passes unsaved llm_call prompt edits to save draft', async () => {
+    const handleSaveDraft = jest.fn();
+
+    render(
+      <WorkflowBuildHarness
+        onContinueToBind={jest.fn()}
+        onSaveDraft={handleSaveDraft}
+      />,
+    );
+
+    const promptPrefixInput = await screen.findByLabelText(
+      'Parameter prompt_prefix',
+    );
+    fireEvent.change(promptPrefixInput, {
+      target: {
+        value: 'Classify the refund request before answering.',
+      },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save draft' }));
+
+    await waitFor(() => {
+      expect(handleSaveDraft).toHaveBeenCalledTimes(1);
+    });
+    const pendingDraft = handleSaveDraft.mock.calls.at(0)?.[0];
+    if (!pendingDraft || typeof pendingDraft === 'string') {
+      throw new Error('Expected Save draft to receive the pending step draft.');
+    }
+    expect(pendingDraft.stepId).toBe('draft_step');
+    expect(JSON.parse(pendingDraft.draft.parametersText)).toEqual({
+      prompt_prefix: 'Classify the refund request before answering.',
     });
   });
 

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
@@ -589,9 +589,71 @@ function normalizePrimitiveParameterDescriptor(
   return {
     ...parameter,
     name: resolvedName,
-    description:
-      'Prompt prefix prepended before the workflow run prompt reaches the LLM.',
   };
+}
+
+function isLLMPromptInstructionParameter(
+  stepType: string,
+  parameterName: string,
+): boolean {
+  return (
+    stepType.trim().toLowerCase() === 'llm_call' &&
+    resolveStepParameterName(stepType, parameterName) === 'prompt_prefix'
+  );
+}
+
+function getParameterDisplayLabel(
+  stepType: string,
+  parameter: WorkflowPrimitiveDescriptor['parameters'][number],
+): string {
+  return isLLMPromptInstructionParameter(stepType, parameter.name)
+    ? 'Prompt instruction'
+    : parameter.name;
+}
+
+function getParameterDisplayDescription(
+  stepType: string,
+  parameter: WorkflowPrimitiveDescriptor['parameters'][number],
+): string {
+  if (isLLMPromptInstructionParameter(stepType, parameter.name)) {
+    return 'Instruction added before each workflow run input reaches the LLM.';
+  }
+
+  return parameter.description || `Type: ${parameter.type}`;
+}
+
+function getParameterPlaceholder(
+  stepType: string,
+  parameter: WorkflowPrimitiveDescriptor['parameters'][number],
+): string {
+  if (isLLMPromptInstructionParameter(stepType, parameter.name)) {
+    return 'e.g. Translate the user input to Japanese';
+  }
+
+  return parameter.default || parameter.type || 'Value';
+}
+
+function shouldUseParameterDefault(
+  stepType: string,
+  parameter: WorkflowPrimitiveDescriptor['parameters'][number],
+): boolean {
+  return !isLLMPromptInstructionParameter(stepType, parameter.name);
+}
+
+function normalizeParameterEditorSourceValue(
+  stepType: string,
+  parameterName: string,
+  value: unknown,
+): unknown {
+  if (
+    isLLMPromptInstructionParameter(stepType, parameterName) &&
+    value !== null &&
+    typeof value === 'object'
+  ) {
+    return '';
+  }
+
+  return value;
 }
 
 function normalizePrimitiveParameterDescriptors(
@@ -1689,13 +1751,33 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
                   {selectedPrimitiveParameters.length ? (
                     <div style={{ display: 'grid', gap: 10 }}>
                       {selectedPrimitiveParameters.map((parameter) => {
-                        const currentValue = formatParameterEditorValue(
+                        const parameterDisplayLabel = getParameterDisplayLabel(
+                          stepDraft.type,
+                          parameter,
+                        );
+                        const parameterAriaLabel = `Parameter ${parameterDisplayLabel}`;
+                        const parameterPlaceholder = getParameterPlaceholder(
+                          stepDraft.type,
+                          parameter,
+                        );
+                        const parameterDescription = getParameterDisplayDescription(
+                          stepDraft.type,
+                          parameter,
+                        );
+                        const parameterValue = normalizeParameterEditorSourceValue(
+                          stepDraft.type,
+                          parameter.name,
                           readStepParameterValue(
                             parsedStepParameters,
                             stepDraft.type,
                             parameter.name,
-                          ) ??
-                            parameter.default,
+                          ),
+                        );
+                        const currentValue = formatParameterEditorValue(
+                          parameterValue ??
+                            (shouldUseParameterDefault(stepDraft.type, parameter)
+                              ? parameter.default
+                              : ''),
                         );
 
                         return (
@@ -1707,19 +1789,19 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
                               htmlFor={`workflow-step-parameter-${parameter.name}`}
                               style={workflowFieldLabelStyle}
                             >
-                              {parameter.name}
+                              {parameterDisplayLabel}
                               {parameter.required ? ' *' : ''}
                             </label>
                             {parameter.enumValues.length > 0 ? (
                               <Select
                                 allowClear={!parameter.required}
-                                aria-label={`Parameter ${parameter.name}`}
+                                aria-label={parameterAriaLabel}
                                 id={`workflow-step-parameter-${parameter.name}`}
                                 options={parameter.enumValues.map((value) => ({
                                   label: value,
                                   value,
                                 }))}
-                                placeholder={parameter.default || 'Select value'}
+                                placeholder={parameterPlaceholder}
                                 value={currentValue || undefined}
                                 onChange={(value) =>
                                   updateStepDraft((current) =>
@@ -1736,9 +1818,9 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
                               />
                             ) : (
                               <Input
-                                aria-label={`Parameter ${parameter.name}`}
+                                aria-label={parameterAriaLabel}
                                 id={`workflow-step-parameter-${parameter.name}`}
-                                placeholder={parameter.default || parameter.type || 'Value'}
+                                placeholder={parameterPlaceholder}
                                 value={currentValue}
                                 onChange={(event) =>
                                   updateStepDraft((current) =>
@@ -1755,7 +1837,7 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
                               />
                             )}
                             <div style={workflowInlineMetaStyle}>
-                              {parameter.description || `Type: ${parameter.type}`}
+                              {parameterDescription}
                             </div>
                           </div>
                         );

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
@@ -713,6 +713,24 @@ function updateStepDraftParameterValue(
   };
 }
 
+function areStepInspectorDraftsEqual(
+  left: StudioStepInspectorDraft | null,
+  right: StudioStepInspectorDraft | null,
+): boolean {
+  if (!left || !right) {
+    return false;
+  }
+
+  return (
+    left.id === right.id &&
+    left.type === right.type &&
+    left.targetRole === right.targetRole &&
+    left.next === right.next &&
+    left.parametersText === right.parametersText &&
+    left.branchesText === right.branchesText
+  );
+}
+
 async function consumeAguiDraftRun(
   response: Response,
   signal: AbortSignal,
@@ -905,7 +923,12 @@ function ScriptLeaveDialog(props: {
 export type StudioWorkflowBuildPanelProps = {
   readonly draftYaml: string;
   readonly onSetDraftYaml: (value: string) => void;
-  readonly onSaveDraft: () => void;
+  readonly onSaveDraft: (
+    draft?: {
+      readonly stepId: string;
+      readonly draft: StudioStepInspectorDraft;
+    } | null,
+  ) => void;
   readonly savePending: boolean;
   readonly canSaveWorkflow: boolean;
   readonly saveNotice?: { readonly type: 'success' | 'error'; readonly message: string } | null;
@@ -1003,14 +1026,12 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
             current: StudioStepInspectorDraft | null,
           ) => StudioStepInspectorDraft | null),
     ) => {
-      setStepDraft((current) => {
-        const nextDraft =
-          typeof updater === 'function'
-            ? updater(current)
-            : updater;
-        stepDraftRef.current = nextDraft;
-        return nextDraft;
-      });
+      const nextDraft =
+        typeof updater === 'function'
+          ? updater(stepDraftRef.current)
+          : updater;
+      stepDraftRef.current = nextDraft;
+      setStepDraft(nextDraft);
     },
     [],
   );
@@ -1276,6 +1297,20 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
     }
   }, [onApplyStepDraft]);
 
+  const handleSaveDraft = React.useCallback(() => {
+    const currentStepDraft = stepDraftRef.current;
+    onSaveDraft(
+      currentStepDraft &&
+        selectedStepDraftSeed &&
+        !areStepInspectorDraftsEqual(currentStepDraft, selectedStepDraftSeed)
+        ? {
+            stepId: selectedStepId,
+            draft: currentStepDraft,
+          }
+        : null,
+    );
+  }, [onSaveDraft, selectedStepDraftSeed, selectedStepId]);
+
   const handleRemoveStep = React.useCallback(async () => {
     if (stepMutationPendingRef.current) {
       return;
@@ -1375,7 +1410,7 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
               className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
               disabled={!canSaveWorkflow}
               loading={savePending}
-              onClick={onSaveDraft}
+              onClick={handleSaveDraft}
             >
               Save draft
             </Button>

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
@@ -1957,7 +1957,7 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
             <Typography.Text strong>Workflow draft run</Typography.Text>
           </div>
           <span style={{ ...statusTagStyle, background: '#f6ffed', color: '#237804' }}>
-            seeded fixture
+            Draft input
           </span>
         </div>
         <div style={{ display: 'grid', gap: 8 }}>
@@ -2022,7 +2022,7 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
               )
             }
           >
-            Load fixture
+            Load sample input
           </Button>
         </Space>
         {workflowRunError ? (
@@ -3246,7 +3246,7 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
             <Typography.Text strong>Script draft run</Typography.Text>
           </div>
           <span style={{ ...statusTagStyle, background: '#fffbe6', color: '#ad6800' }}>
-            seeded fixture
+            Draft input
           </span>
         </div>
         <div style={sectionDescriptionStyle}>
@@ -3286,7 +3286,7 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
               )
             }
           >
-            Load fixture
+            Load sample input
           </Button>
         </Space>
         <div>
@@ -3687,7 +3687,7 @@ export const StudioGAgentBuildPanel: React.FC<StudioGAgentBuildPanelProps> = ({
             <Typography.Text strong>GAgent draft run</Typography.Text>
           </div>
           <span style={{ ...statusTagStyle, background: '#f6ffed', color: '#237804' }}>
-            seeded fixture
+            Draft input
           </span>
         </div>
         <div style={sectionDescriptionStyle}>
@@ -3715,7 +3715,7 @@ export const StudioGAgentBuildPanel: React.FC<StudioGAgentBuildPanelProps> = ({
               setRunPrompt('Classify this support ticket, keep the member state, and decide whether to escalate.')
             }
           >
-            Load fixture
+            Load sample input
           </Button>
         </Space>
         <div>

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
@@ -51,6 +51,9 @@ import {
 } from '@/shared/studio/scriptPackage';
 import {
   createStepInspectorDraft,
+  readStepParameterValue,
+  resolveStepParameterName,
+  normalizeStepParametersForType,
   parseInspectorParameters,
   type StudioStepInspectorDraft,
 } from '@/shared/studio/document';
@@ -552,6 +555,47 @@ function tryParseStepParameters(
   }
 }
 
+function normalizePrimitiveParameterDescriptor(
+  stepType: string,
+  parameter: WorkflowPrimitiveDescriptor['parameters'][number],
+): WorkflowPrimitiveDescriptor['parameters'][number] {
+  const resolvedName = resolveStepParameterName(stepType, parameter.name);
+  if (resolvedName === parameter.name) {
+    return parameter;
+  }
+
+  return {
+    ...parameter,
+    name: resolvedName,
+    description:
+      'Prompt prefix prepended before the workflow run prompt reaches the LLM.',
+  };
+}
+
+function normalizePrimitiveParameterDescriptors(
+  stepType: string,
+  parameters: readonly WorkflowPrimitiveDescriptor['parameters'][number][],
+): WorkflowPrimitiveDescriptor['parameters'][number][] {
+  const nextParameters: WorkflowPrimitiveDescriptor['parameters'][number][] = [];
+  const seenParameterNames = new Set<string>();
+
+  for (const parameter of parameters) {
+    const normalizedParameter = normalizePrimitiveParameterDescriptor(
+      stepType,
+      parameter,
+    );
+    const normalizedName = normalizedParameter.name.trim().toLowerCase();
+    if (!normalizedName || seenParameterNames.has(normalizedName)) {
+      continue;
+    }
+
+    seenParameterNames.add(normalizedName);
+    nextParameters.push(normalizedParameter);
+  }
+
+  return nextParameters;
+}
+
 function formatParameterEditorValue(value: unknown): string {
   if (value === null || value === undefined) {
     return '';
@@ -625,13 +669,20 @@ function updateStepDraftParameterValue(
   parameterType: string,
   rawValue: string,
 ): StudioStepInspectorDraft {
-  const nextParameters = tryParseStepParameters(draft.parametersText) ?? {};
+  const resolvedParameterName = resolveStepParameterName(draft.type, parameterName);
+  const nextParameters = normalizeStepParametersForType(
+    draft.type,
+    tryParseStepParameters(draft.parametersText) ?? {},
+  );
   const trimmed = rawValue.trim();
 
   if (!trimmed) {
-    delete nextParameters[parameterName];
+    delete nextParameters[resolvedParameterName];
   } else {
-    nextParameters[parameterName] = coerceParameterEditorValue(rawValue, parameterType);
+    nextParameters[resolvedParameterName] = coerceParameterEditorValue(
+      rawValue,
+      parameterType,
+    );
   }
 
   return {
@@ -1026,6 +1077,14 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
         );
       }) ?? null,
     [runtimePrimitives, selectedStep?.type, stepDraft?.type],
+  );
+  const selectedPrimitiveParameters = React.useMemo(
+    () =>
+      normalizePrimitiveParameterDescriptors(
+        stepDraft?.type || selectedStep?.type || '',
+        selectedPrimitiveDescriptor?.parameters ?? [],
+      ),
+    [selectedPrimitiveDescriptor, selectedStep?.type, stepDraft?.type],
   );
   const parsedStepParameters = React.useMemo(
     () =>
@@ -1562,11 +1621,15 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
                 </div>
                 <div style={{ ...workflowFieldStyle, gridColumn: '1 / -1' }}>
                   <div style={workflowSectionHeadingStyle}>Parameters</div>
-                  {selectedPrimitiveDescriptor?.parameters.length ? (
+                  {selectedPrimitiveParameters.length ? (
                     <div style={{ display: 'grid', gap: 10 }}>
-                      {selectedPrimitiveDescriptor.parameters.map((parameter) => {
+                      {selectedPrimitiveParameters.map((parameter) => {
                         const currentValue = formatParameterEditorValue(
-                          parsedStepParameters?.[parameter.name] ??
+                          readStepParameterValue(
+                            parsedStepParameters,
+                            stepDraft.type,
+                            parameter.name,
+                          ) ??
                             parameter.default,
                         );
 

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
@@ -1006,7 +1006,12 @@ export type StudioWorkflowBuildPanelProps = {
   readonly workflowName: string;
   readonly runPrompt: string;
   readonly onRunPromptChange: (value: string) => void;
-  readonly buildWorkflowYamls: () => Promise<string[]>;
+  readonly buildWorkflowYamls: (
+    draft?: {
+      readonly stepId: string;
+      readonly draft: StudioStepInspectorDraft;
+    } | null,
+  ) => Promise<string[]>;
   readonly runMetadata?: Record<string, string>;
   readonly dryRunRouteLabel?: string;
   readonly dryRunModelLabel?: string;
@@ -1232,6 +1237,8 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
       return;
     }
 
+    const currentStepDraft = stepDraftRef.current;
+
     if (!scopeId) {
       const visibleMessage = 'Resolve the current workspace before running the workflow draft.';
       setWorkflowRunError(visibleMessage);
@@ -1269,7 +1276,16 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
         {
           metadata: runMetadata,
           prompt: runPrompt,
-          workflowYamls: await buildWorkflowYamls(),
+          workflowYamls: await buildWorkflowYamls(
+            currentStepDraft &&
+              selectedStepDraftSeed &&
+              !areStepInspectorDraftsEqual(currentStepDraft, selectedStepDraftSeed)
+              ? {
+                  stepId: selectedStepId,
+                  draft: currentStepDraft,
+                }
+              : null,
+          ),
         },
         controller.signal,
       );
@@ -1315,6 +1331,8 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
     runMetadata,
     runPrompt,
     scopeId,
+    selectedStepDraftSeed,
+    selectedStepId,
   ]);
 
   const handleInsertStep = React.useCallback(async (stepType: string) => {

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -394,6 +394,7 @@ let mockConnectorDraftResponse: any;
 let mockRoleCatalog: any;
 let mockRoleDraftResponse: any;
 let mockSettings: any;
+let mockLastWorkflowBuildPanelProps: any;
 const defaultStudioAppContext = {
   mode: "proxy",
   scopeId: null,
@@ -1719,6 +1720,7 @@ jest.mock("./components/StudioBootstrapGate", () => ({
 jest.mock("./components/StudioBuildPanels", () => {
   const mockReact = require("react");
   const StudioWorkflowBuildPanel = (props: any) => {
+    mockLastWorkflowBuildPanelProps = props;
     const [detailsMode, setDetailsMode] = mockReact.useState("step");
     const [addStepType, setAddStepType] = mockReact.useState(
       props.availableStepTypes?.[0] || "llm_call"
@@ -1731,25 +1733,35 @@ jest.mock("./components/StudioBuildPanels", () => {
         null
       );
     }, [props.selectedGraphNodeId, props.workflowGraph?.steps]);
-    const [stepDraft, setStepDraft] = mockReact.useState(() => ({
+    const selectedStepDraftSeed = mockReact.useMemo(() => ({
+      kind: "step",
       id: selectedStep?.id || "",
       type: selectedStep?.type || "llm_call",
       targetRole: selectedStep?.targetRole || "",
       next: selectedStep?.next || "",
       parametersText: JSON.stringify(selectedStep?.parameters || {}, null, 2),
       branchesText: JSON.stringify(selectedStep?.branches || {}, null, 2),
-    }));
+    }), [
+      selectedStep?.id,
+      selectedStep?.type,
+      selectedStep?.targetRole,
+      selectedStep?.next,
+      JSON.stringify(selectedStep?.parameters || {}),
+      JSON.stringify(selectedStep?.branches || {}),
+    ]);
+    const [stepDraft, setStepDraft] = mockReact.useState(() => selectedStepDraftSeed);
+    const stepDraftRef = mockReact.useRef(stepDraft);
+
+    const updateStepDraft = mockReact.useCallback((updater: any) => {
+      const nextDraft =
+        typeof updater === "function" ? updater(stepDraftRef.current) : updater;
+      stepDraftRef.current = nextDraft;
+      setStepDraft(nextDraft);
+    }, []);
 
     mockReact.useEffect(() => {
-      setStepDraft({
-        id: selectedStep?.id || "",
-        type: selectedStep?.type || "llm_call",
-        targetRole: selectedStep?.targetRole || "",
-        next: selectedStep?.next || "",
-        parametersText: JSON.stringify(selectedStep?.parameters || {}, null, 2),
-        branchesText: JSON.stringify(selectedStep?.branches || {}, null, 2),
-      });
-    }, [selectedStep]);
+      updateStepDraft(selectedStepDraftSeed);
+    }, [selectedStepDraftSeed]);
 
     return mockReact.createElement("div", { "data-testid": "studio-workflow-build-panel" }, [
       mockReact.createElement("div", { key: "eyebrow" }, "DAG Canvas"),
@@ -1837,7 +1849,7 @@ jest.mock("./components/StudioBuildPanels", () => {
               "aria-label": "Step ID",
               value: stepDraft.id,
               onChange: (event: MockValueEvent) =>
-                setStepDraft((current: any) => ({ ...current, id: event.target.value })),
+                updateStepDraft((current: any) => ({ ...current, id: event.target.value })),
             }),
             mockReact.createElement(
               "select",
@@ -1845,7 +1857,7 @@ jest.mock("./components/StudioBuildPanels", () => {
                 "aria-label": "Step type",
                 value: stepDraft.type,
                 onChange: (event: MockValueEvent) =>
-                  setStepDraft((current: any) => ({ ...current, type: event.target.value })),
+                  updateStepDraft((current: any) => ({ ...current, type: event.target.value })),
               },
               (props.availableStepTypes || ["llm_call"]).map((stepType: string) =>
                 mockReact.createElement("option", { key: stepType, value: stepType }, stepType)
@@ -1855,7 +1867,7 @@ jest.mock("./components/StudioBuildPanels", () => {
               "aria-label": "Target role",
               value: stepDraft.targetRole,
               onChange: (event: MockValueEvent) =>
-                setStepDraft((current: any) => ({
+                updateStepDraft((current: any) => ({
                   ...current,
                   targetRole: event.target.value,
                 })),
@@ -1864,13 +1876,13 @@ jest.mock("./components/StudioBuildPanels", () => {
               "aria-label": "Next step",
               value: stepDraft.next,
               onChange: (event: MockValueEvent) =>
-                setStepDraft((current: any) => ({ ...current, next: event.target.value })),
+                updateStepDraft((current: any) => ({ ...current, next: event.target.value })),
             }),
             mockReact.createElement("textarea", {
               "aria-label": "Step parameters",
               value: stepDraft.parametersText,
               onChange: (event: MockValueEvent) =>
-                setStepDraft((current: any) => ({
+                updateStepDraft((current: any) => ({
                   ...current,
                   parametersText: event.target.value,
                 })),
@@ -1879,7 +1891,7 @@ jest.mock("./components/StudioBuildPanels", () => {
               "aria-label": "Step branches",
               value: stepDraft.branchesText,
               onChange: (event: MockValueEvent) =>
-                setStepDraft((current: any) => ({
+                updateStepDraft((current: any) => ({
                   ...current,
                   branchesText: event.target.value,
                 })),
@@ -1930,7 +1942,40 @@ jest.mock("./components/StudioBuildPanels", () => {
           key: "save",
           type: "button",
           disabled: !props.canSaveWorkflow,
-          onClick: () => props.onSaveDraft?.(),
+          onClick: () => {
+            const currentParametersText =
+              (
+                globalThis.document.querySelector(
+                  'textarea[aria-label="Step parameters"]'
+                ) as HTMLTextAreaElement | null
+              )?.value ?? stepDraftRef.current.parametersText;
+            const currentBranchesText =
+              (
+                globalThis.document.querySelector(
+                  'textarea[aria-label="Step branches"]'
+                ) as HTMLTextAreaElement | null
+              )?.value ?? stepDraftRef.current.branchesText;
+            const currentStepDraft = {
+              ...stepDraftRef.current,
+              parametersText: currentParametersText,
+              branchesText: currentBranchesText,
+            };
+            const currentHasPendingStepDraft =
+              currentStepDraft.id !== selectedStepDraftSeed.id ||
+              currentStepDraft.type !== selectedStepDraftSeed.type ||
+              currentStepDraft.targetRole !== selectedStepDraftSeed.targetRole ||
+              currentStepDraft.next !== selectedStepDraftSeed.next ||
+              currentStepDraft.parametersText !== selectedStepDraftSeed.parametersText ||
+              currentStepDraft.branchesText !== selectedStepDraftSeed.branchesText;
+            props.onSaveDraft?.(
+              currentHasPendingStepDraft
+                ? {
+                    stepId: selectedStep?.id || "",
+                    draft: currentStepDraft,
+                  }
+                : null
+            );
+          },
         },
         "Save draft"
       ),
@@ -4928,6 +4973,64 @@ describe("StudioPage", () => {
     });
     expect(bindSurface.parentElement).not.toHaveStyle({
       overflow: "hidden",
+    });
+  });
+
+  it("saves pending workflow step prompt edits without requiring Apply changes", async () => {
+    renderStudioPage("/studio?scopeId=scope-1&focus=workflow%3Aworkflow-1&tab=studio");
+
+    await waitFor(() => {
+      expect(mockLastWorkflowBuildPanelProps?.onSaveDraft).toEqual(expect.any(Function));
+      expect(mockLastWorkflowBuildPanelProps?.canSaveWorkflow).toBe(true);
+    });
+    (studioApi.serializeYaml as jest.Mock).mockClear();
+    await act(async () => {
+      await mockLastWorkflowBuildPanelProps.onSaveDraft({
+        stepId: "draft_step",
+        draft: {
+          kind: "step",
+          id: "draft_step",
+          type: "llm_call",
+          targetRole: "assistant",
+          next: "approve_step",
+          parametersText: JSON.stringify(
+            {
+              prompt_prefix: "Classify the refund request before answering.",
+            },
+            null,
+            2
+          ),
+          branchesText: "{}",
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(studioApi.serializeYaml).toHaveBeenCalledWith(
+        expect.objectContaining({
+          document: expect.objectContaining({
+            steps: expect.arrayContaining([
+              expect.objectContaining({
+                id: "draft_step",
+                parameters: expect.objectContaining({
+                  prompt_prefix: "Classify the refund request before answering.",
+                }),
+              }),
+            ]),
+          }),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(studioApi.saveWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scopeId: "scope-1",
+          yaml: expect.stringContaining(
+            "prompt_prefix: Classify the refund request before answering."
+          ),
+        })
+      );
     });
   });
 

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -115,6 +115,13 @@ function mockBuildWorkflowYaml(document: typeof mockWorkflowDocument): string {
     if (step.targetRole) {
       lines.push(`    targetRole: ${step.targetRole}`);
     }
+    const parameterEntries = Object.entries(step.parameters ?? {});
+    if (parameterEntries.length > 0) {
+      lines.push("    parameters:");
+      for (const [key, value] of parameterEntries) {
+        lines.push(`      ${key}: ${String(value)}`);
+      }
+    }
     if (step.next) {
       lines.push(`    next: ${step.next}`);
     }
@@ -5060,6 +5067,24 @@ describe("StudioPage", () => {
   });
 
   it("surfaces the current workflow as a bind candidate before any published service exists", async () => {
+    mockParsedDocument = {
+      ...mockParsedDocument,
+      steps: mockParsedDocument.steps.map((step) =>
+        step.type === "llm_call"
+          ? {
+              ...step,
+              parameters: {
+                prompt: "把用户输入的内容转成日语",
+              },
+            }
+          : step
+      ),
+    } as any;
+    mockWorkflowFile = {
+      ...mockWorkflowFile,
+      document: mockParsedDocument,
+      yaml: mockBuildWorkflowYaml(mockParsedDocument),
+    };
     mockScopeRuntimeApi.listServices.mockReset();
     mockScopeRuntimeApi.listServices
       .mockResolvedValueOnce([])
@@ -5109,6 +5134,15 @@ describe("StudioPage", () => {
         }),
       );
     });
+    const workflowYamls =
+      (studioApi.bindMemberWorkflow as jest.Mock).mock.calls.at(-1)?.[0]
+        ?.workflowYamls ?? [];
+    expect(workflowYamls.join("\n")).toContain(
+      "prompt_prefix: 把用户输入的内容转成日语"
+    );
+    expect(workflowYamls.join("\n")).not.toContain(
+      "prompt: 把用户输入的内容转成日语"
+    );
     await waitFor(() => {
       expect(screen.getByText("service:default")).toBeTruthy();
       expect(screen.getByText("services:default")).toBeTruthy();

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -7008,6 +7008,40 @@ describe("StudioPage", () => {
     ).toHaveValue("Continue this workflow in Studio");
   });
 
+  it("runs workflow dry-run with pending step prompt edits", async () => {
+    renderStudioPage("/studio?scopeId=scope-1&focus=workflow%3Aworkflow-1&tab=studio");
+
+    expect(await screen.findByText("DAG Canvas")).toBeTruthy();
+    await waitFor(() => {
+      expect(mockLastWorkflowBuildPanelProps?.buildWorkflowYamls).toEqual(
+        expect.any(Function)
+      );
+    });
+
+    const workflowYamls = await mockLastWorkflowBuildPanelProps.buildWorkflowYamls({
+      stepId: "draft_step",
+      draft: {
+        kind: "step",
+        id: "draft_step",
+        type: "llm_call",
+        targetRole: "assistant",
+        next: "approve_step",
+        parametersText: JSON.stringify(
+          {
+            prompt_prefix: "Translate the input to English.",
+          },
+          null,
+          2
+        ),
+        branchesText: "{}",
+      },
+    });
+
+    expect(workflowYamls).toEqual([
+      expect.stringContaining("prompt_prefix: Translate the input to English."),
+    ]);
+  });
+
   it("shows the published template graph in the Studio editor", async () => {
     renderStudioPage("/studio?focus=template%3Apublished-demo&tab=workflows");
 

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -4983,6 +4983,14 @@ describe("StudioPage", () => {
       expect(mockLastWorkflowBuildPanelProps?.onSaveDraft).toEqual(expect.any(Function));
       expect(mockLastWorkflowBuildPanelProps?.canSaveWorkflow).toBe(true);
     });
+    const staleWorkflowDocument = mockCloneValue(mockWorkflowDocument) as any;
+    staleWorkflowDocument.steps[0].parameters = {};
+    const staleWorkflowResponse = {
+      ...mockWorkflowFile,
+      yaml: mockBuildWorkflowYaml(staleWorkflowDocument),
+      document: staleWorkflowDocument,
+    };
+    (studioApi.saveWorkflow as jest.Mock).mockResolvedValueOnce(staleWorkflowResponse);
     (studioApi.serializeYaml as jest.Mock).mockClear();
     await act(async () => {
       await mockLastWorkflowBuildPanelProps.onSaveDraft({
@@ -5029,6 +5037,17 @@ describe("StudioPage", () => {
           yaml: expect.stringContaining(
             "prompt_prefix: Classify the refund request before answering."
           ),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockLastWorkflowBuildPanelProps?.draftYaml).toContain(
+        "prompt_prefix: Classify the refund request before answering."
+      );
+      expect(mockLastWorkflowBuildPanelProps?.workflowGraph.steps[0].parameters).toEqual(
+        expect.objectContaining({
+          prompt_prefix: "Classify the refund request before answering.",
         })
       );
     });

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -7017,6 +7017,7 @@ describe("StudioPage", () => {
         expect.any(Function)
       );
     });
+    (studioApi.serializeYaml as jest.Mock).mockClear();
 
     const workflowYamls = await mockLastWorkflowBuildPanelProps.buildWorkflowYamls({
       stepId: "draft_step",
@@ -7040,6 +7041,21 @@ describe("StudioPage", () => {
     expect(workflowYamls).toEqual([
       expect.stringContaining("prompt_prefix: Translate the input to English."),
     ]);
+    expect(studioApi.serializeYaml).toHaveBeenCalledTimes(1);
+    expect(studioApi.serializeYaml).toHaveBeenCalledWith(
+      expect.objectContaining({
+        document: expect.objectContaining({
+          steps: expect.arrayContaining([
+            expect.objectContaining({
+              id: "draft_step",
+              parameters: expect.objectContaining({
+                prompt_prefix: "Translate the input to English.",
+              }),
+            }),
+          ]),
+        }),
+      })
+    );
   });
 
   it("shows the published template graph in the Studio editor", async () => {

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -4310,8 +4310,57 @@ const StudioPage: React.FC = () => {
     [availableStepTypes],
   );
 
-  const buildWorkflowYamlBundle = useCallback(async (): Promise<string[]> => {
-    const rootYaml = draftYaml.trim();
+  const buildWorkflowYamlBundle = useCallback(async (
+    pendingStepDraft?: {
+      readonly stepId: string;
+      readonly draft: StudioStepInspectorDraft;
+    } | null,
+  ): Promise<string[]> => {
+    let rootYaml = draftYaml.trim();
+    let rootDocument: StudioWorkflowDocument | null | undefined =
+      activeWorkflowDocument;
+
+    if (pendingStepDraft) {
+      const currentStepId = pendingStepDraft.stepId.trim();
+      if (!currentStepId) {
+        throw new Error('Select a workflow step before running its draft changes.');
+      }
+
+      const document =
+        cloneStudioWorkflowDocument(
+          activeWorkflowDocument ||
+            parsedWorkflowDocument ||
+            activeWorkflowFile?.document ||
+            null,
+        ) ||
+        cloneStudioWorkflowDocument(
+          (
+            await studioApi.parseYaml({
+              yaml: rootYaml,
+              availableWorkflowNames: workflowNames,
+              availableStepTypes,
+            })
+          ).document as StudioWorkflowDocument | null,
+        );
+      if (!document) {
+        throw new Error('Load a workflow draft before running its draft changes.');
+      }
+
+      const result = applyStepInspectorDraft(
+        document,
+        currentStepId,
+        pendingStepDraft.draft,
+      );
+      const serialized = await studioApi.serializeYaml({
+        document: result.document,
+        availableWorkflowNames: workflowNames,
+        availableStepTypes,
+      });
+
+      rootYaml = serialized.yaml.trim();
+      rootDocument = serialized.document;
+    }
+
     if (!rootYaml) {
       throw new Error('Workflow YAML is required.');
     }
@@ -4331,7 +4380,7 @@ const StudioPage: React.FC = () => {
       {
         workflowName: activeWorkflowName.trim() || draftWorkflowName.trim(),
         yaml: rootYaml,
-        document: activeWorkflowDocument,
+        document: rootDocument,
       },
     ];
 
@@ -4394,13 +4443,16 @@ const StudioPage: React.FC = () => {
     return bundle;
   }, [
     activeWorkflowDocument,
+    activeWorkflowFile?.document,
     activeWorkflowName,
     availableStepTypes,
     draftWorkflowName,
     draftYaml,
     normalizeWorkflowYamlForRuntime,
+    parsedWorkflowDocument,
     resolvedStudioScopeId,
     visibleWorkflowSummaries,
+    workflowNames,
   ]);
   const recentPromptHistory = useMemo(
     () => promptHistory.slice(0, 3),

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -5265,7 +5265,82 @@ const StudioPage: React.FC = () => {
     return leaveGuard ? await leaveGuard() : true;
   }, [isBuildScriptsSurface]);
 
-  const handleSaveDraft = async () => {
+  const resolveWorkflowSavePayload = useCallback(
+    async (
+      pendingStepDraft?: {
+        readonly stepId: string;
+        readonly draft: StudioStepInspectorDraft;
+      } | null,
+    ): Promise<{
+      readonly yaml: string;
+      readonly layout: unknown;
+    } | null> => {
+      if (!pendingStepDraft) {
+        return {
+          yaml: draftYaml,
+          layout:
+            draftWorkflowLayout ||
+            activeWorkflowFile?.layout ||
+            buildStudioWorkflowLayout(activeWorkflowName, workflowGraph.nodes),
+        };
+      }
+
+      const currentStepId = pendingStepDraft.stepId.trim();
+      if (!currentStepId) {
+        setSaveNotice({
+          type: 'error',
+          message: 'Select a workflow step before saving its draft changes.',
+        });
+        return null;
+      }
+
+      const document = await resolveEditableWorkflowDocument();
+      if (!document) {
+        return null;
+      }
+
+      const result = applyStepInspectorDraft(
+        document,
+        currentStepId,
+        pendingStepDraft.draft,
+      );
+      const serialized = await studioApi.serializeYaml({
+        document: result.document,
+        availableWorkflowNames: workflowNames,
+        availableStepTypes,
+      });
+      const nextLayout =
+        draftWorkflowLayout ||
+        activeWorkflowFile?.layout ||
+        buildStudioWorkflowLayout(activeWorkflowName, workflowGraph.nodes);
+
+      setDraftYaml(serialized.yaml);
+      setEditableWorkflowDocument(cloneStudioWorkflowDocument(serialized.document));
+      setSelectedGraphNodeId(result.nodeId);
+
+      return {
+        yaml: serialized.yaml,
+        layout: nextLayout,
+      };
+    },
+    [
+      activeWorkflowFile?.layout,
+      activeWorkflowName,
+      availableStepTypes,
+      draftWorkflowLayout,
+      draftYaml,
+      resolveEditableWorkflowDocument,
+      workflowGraph.nodes,
+      workflowNames,
+    ],
+  );
+
+  const handleSaveDraft = async (
+    pendingStepDraft?: {
+      readonly stepId: string;
+      readonly draft: StudioStepInspectorDraft;
+    } | null,
+  ) => {
     const directoryId = resolvedDraftDirectoryId;
     if (!directoryId) {
       setSaveNotice({
@@ -5288,6 +5363,11 @@ const StudioPage: React.FC = () => {
     setSaveNotice(null);
 
     try {
+      const savePayload = await resolveWorkflowSavePayload(pendingStepDraft);
+      if (!savePayload) {
+        return;
+      }
+
       const savedWorkflow = await studioApi.saveWorkflow({
         workflowId: activeWorkflowFile?.workflowId || undefined,
         draftExists: activeWorkflowFile?.draftExists,
@@ -5295,11 +5375,8 @@ const StudioPage: React.FC = () => {
         directoryId,
         workflowName,
         fileName: draftFileName,
-        yaml: draftYaml,
-        layout:
-          draftWorkflowLayout ||
-          activeWorkflowFile?.layout ||
-          buildStudioWorkflowLayout(activeWorkflowName, workflowGraph.nodes),
+        yaml: savePayload.yaml,
+        layout: savePayload.layout,
       });
 
       await applySavedWorkflowSelection(savedWorkflow, {
@@ -10137,7 +10214,7 @@ const StudioPage: React.FC = () => {
         setEditableWorkflowDocument(null);
         setSaveNotice(null);
       }}
-      onSaveDraft={() => void handleSaveDraft()}
+      onSaveDraft={(draft) => void handleSaveDraft(draft)}
       savePending={savePending}
       canSaveWorkflow={canSaveWorkflow}
       saveNotice={saveNotice}

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -5217,35 +5217,53 @@ const StudioPage: React.FC = () => {
     async (
       savedWorkflow: StudioWorkflowFile,
       options?: {
+        readonly document?: StudioWorkflowDocument | null;
         readonly layout?: unknown;
+        readonly selectedNodeId?: string;
+        readonly yaml?: string;
       },
     ) => {
+      const hasDocumentOverride = options?.document !== undefined;
+      const nextWorkflow: StudioWorkflowFile = {
+        ...savedWorkflow,
+        document: hasDocumentOverride ? options.document ?? null : savedWorkflow.document,
+        yaml: options?.yaml ?? savedWorkflow.yaml,
+      };
+
       queryClient.setQueryData(
-        ['studio-workflow', workflowWorkspaceContextKey, savedWorkflow.workflowId],
-        savedWorkflow,
+        ['studio-workflow', workflowWorkspaceContextKey, nextWorkflow.workflowId],
+        nextWorkflow,
       );
       await queryClient.invalidateQueries({
         queryKey: ['studio-workspace-workflows', workflowWorkspaceContextKey],
       });
 
-      setSelectedWorkflowId(savedWorkflow.workflowId);
+      setSelectedWorkflowId(nextWorkflow.workflowId);
       setSelectedScriptId('');
       setTemplateWorkflow('');
       setBuildSurface('editor');
       setStudioSurface('build');
       setDraftSourceKey(
-        `workflow:${workflowWorkspaceContextKey}:${savedWorkflow.workflowId}`,
+        `workflow:${workflowWorkspaceContextKey}:${nextWorkflow.workflowId}`,
       );
-      setDraftYaml(savedWorkflow.yaml);
-      setDraftWorkflowName(savedWorkflow.name);
-      setDraftFileName(savedWorkflow.fileName);
-      setDraftDirectoryId(savedWorkflow.directoryId);
+      setDraftYaml(nextWorkflow.yaml);
+      setDraftWorkflowName(nextWorkflow.name);
+      setDraftFileName(nextWorkflow.fileName);
+      setDraftDirectoryId(nextWorkflow.directoryId);
       setDraftWorkflowLayout(
-        savedWorkflow.layout ||
+        nextWorkflow.layout ||
           options?.layout ||
           draftWorkflowLayout ||
-          buildStudioWorkflowLayout(savedWorkflow.name, workflowGraph.nodes),
+          buildStudioWorkflowLayout(nextWorkflow.name, workflowGraph.nodes),
       );
+      if (hasDocumentOverride) {
+        setEditableWorkflowDocument(
+          cloneStudioWorkflowDocument(options.document ?? null),
+        );
+      }
+      if (options?.selectedNodeId !== undefined) {
+        setSelectedGraphNodeId(options.selectedNodeId);
+      }
       setSaveNotice(null);
       setRunNotice(null);
     },
@@ -5272,8 +5290,10 @@ const StudioPage: React.FC = () => {
         readonly draft: StudioStepInspectorDraft;
       } | null,
     ): Promise<{
+      readonly document?: StudioWorkflowDocument | null;
       readonly yaml: string;
       readonly layout: unknown;
+      readonly selectedNodeId?: string;
     } | null> => {
       if (!pendingStepDraft) {
         return {
@@ -5319,8 +5339,10 @@ const StudioPage: React.FC = () => {
       setSelectedGraphNodeId(result.nodeId);
 
       return {
+        document: serialized.document,
         yaml: serialized.yaml,
         layout: nextLayout,
+        selectedNodeId: result.nodeId,
       };
     },
     [
@@ -5380,7 +5402,10 @@ const StudioPage: React.FC = () => {
       });
 
       await applySavedWorkflowSelection(savedWorkflow, {
-        layout: draftWorkflowLayout,
+        document: savePayload.document,
+        layout: savePayload.layout,
+        selectedNodeId: savePayload.selectedNodeId,
+        yaml: savePayload.yaml,
       });
       const routeMemberSummary = resolveStudioMemberSummaryFromMemberKey(
         routeSelectedBackendMemberKey,

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -62,6 +62,7 @@ import {
   cloneStudioWorkflowDocument,
   connectStepToTarget,
   insertStepByType,
+  normalizeStepParametersForType,
   removeStep,
   removeSteps,
   suggestBranchLabelForStep,
@@ -4190,6 +4191,73 @@ const StudioPage: React.FC = () => {
     [availableStepTypes, draftWorkflowName, workflowNames],
   );
 
+  const normalizeWorkflowYamlForRuntime = useCallback(
+    async (
+      yaml: string,
+      document: StudioWorkflowDocument | null | undefined,
+      availableWorkflowNames: string[],
+    ): Promise<{
+      readonly yaml: string;
+      readonly document: StudioWorkflowDocument | null;
+    }> => {
+      const sourceYaml = yaml.trim();
+      if (!sourceYaml) {
+        return {
+          yaml: sourceYaml,
+          document: document ?? null,
+        };
+      }
+
+      let sourceDocument = cloneStudioWorkflowDocument(document);
+      if (!sourceDocument) {
+        sourceDocument =
+          cloneStudioWorkflowDocument(
+            (
+              await studioApi.parseYaml({
+                yaml: sourceYaml,
+                availableWorkflowNames,
+                availableStepTypes,
+              })
+            ).document,
+          ) ?? null;
+      }
+
+      if (!sourceDocument?.steps?.length) {
+        return {
+          yaml: sourceYaml,
+          document: sourceDocument,
+        };
+      }
+
+      const normalizedDocument: StudioWorkflowDocument = {
+        ...sourceDocument,
+        steps: sourceDocument.steps.map((step) => ({
+          ...step,
+          parameters: normalizeStepParametersForType(
+            trimOptional(step.type ?? step.originalType),
+            step.parameters && typeof step.parameters === 'object'
+              ? step.parameters
+              : {},
+          ),
+        })),
+      };
+
+      const serialized = await studioApi.serializeYaml({
+        document: normalizedDocument,
+        availableWorkflowNames,
+        availableStepTypes,
+      });
+
+      return {
+        yaml: serialized.yaml.trim() || sourceYaml,
+        document:
+          cloneStudioWorkflowDocument(serialized.document) ??
+          normalizedDocument,
+      };
+    },
+    [availableStepTypes],
+  );
+
   const buildWorkflowYamlBundle = useCallback(async (): Promise<string[]> => {
     const rootYaml = draftYaml.trim();
     if (!rootYaml) {
@@ -4229,9 +4297,14 @@ const StudioPage: React.FC = () => {
       if (normalizedWorkflowName) {
         seen.add(normalizedWorkflowName);
       }
-      bundle.push(current.yaml);
+      const normalizedCurrent = await normalizeWorkflowYamlForRuntime(
+        current.yaml,
+        current.document,
+        availableWorkflowNames,
+      );
+      bundle.push(normalizedCurrent.yaml);
 
-      for (const targetWorkflow of readWorkflowCallTargets(current.document)) {
+      for (const targetWorkflow of readWorkflowCallTargets(normalizedCurrent.document)) {
         if (seen.has(targetWorkflow)) {
           continue;
         }
@@ -4273,6 +4346,7 @@ const StudioPage: React.FC = () => {
     availableStepTypes,
     draftWorkflowName,
     draftYaml,
+    normalizeWorkflowYamlForRuntime,
     resolvedStudioScopeId,
     visibleWorkflowSummaries,
   ]);

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -4319,6 +4319,7 @@ const StudioPage: React.FC = () => {
     let rootYaml = draftYaml.trim();
     let rootDocument: StudioWorkflowDocument | null | undefined =
       activeWorkflowDocument;
+    let rootRuntimeYamlReady = false;
 
     if (pendingStepDraft) {
       const currentStepId = pendingStepDraft.stepId.trim();
@@ -4358,7 +4359,8 @@ const StudioPage: React.FC = () => {
       });
 
       rootYaml = serialized.yaml.trim();
-      rootDocument = serialized.document;
+      rootDocument = result.document;
+      rootRuntimeYamlReady = true;
     }
 
     if (!rootYaml) {
@@ -4376,11 +4378,13 @@ const StudioPage: React.FC = () => {
       workflowName: string;
       yaml: string;
       document: StudioWorkflowDocument | null | undefined;
+      runtimeYamlReady?: boolean;
     }> = [
       {
         workflowName: activeWorkflowName.trim() || draftWorkflowName.trim(),
         yaml: rootYaml,
         document: rootDocument,
+        runtimeYamlReady: rootRuntimeYamlReady,
       },
     ];
 
@@ -4398,11 +4402,26 @@ const StudioPage: React.FC = () => {
       if (normalizedWorkflowName) {
         seen.add(normalizedWorkflowName);
       }
-      const normalizedCurrent = await normalizeWorkflowYamlForRuntime(
-        current.yaml,
-        current.document,
-        availableWorkflowNames,
-      );
+      const normalizedCurrent = current.runtimeYamlReady
+        ? {
+            yaml: current.yaml,
+            document:
+              cloneStudioWorkflowDocument(current.document) ??
+              cloneStudioWorkflowDocument(
+                (
+                  await studioApi.parseYaml({
+                    yaml: current.yaml,
+                    availableWorkflowNames,
+                    availableStepTypes,
+                  })
+                ).document as StudioWorkflowDocument | null,
+              ),
+          }
+        : await normalizeWorkflowYamlForRuntime(
+            current.yaml,
+            current.document,
+            availableWorkflowNames,
+          );
       bundle.push(normalizedCurrent.yaml);
 
       for (const targetWorkflow of readWorkflowCallTargets(normalizedCurrent.document)) {

--- a/apps/aevatar-console-web/src/shared/studio/document.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/document.test.ts
@@ -125,6 +125,76 @@ describe('studio document helpers', () => {
     ]);
   });
 
+  it('normalizes llm_call prompt parameters to prompt_prefix on apply', () => {
+    const document: StudioWorkflowDocument = {
+      name: 'workspace-demo',
+      roles: [],
+      steps: [
+        {
+          id: 'draft_step',
+          type: 'llm_call',
+          targetRole: 'assistant',
+          parameters: {
+            prompt: 'Legacy prompt field',
+          },
+          next: null,
+          branches: {},
+        },
+      ],
+    };
+
+    const result = applyStepInspectorDraft(document, 'draft_step', {
+      kind: 'step',
+      id: 'draft_step',
+      type: 'llm_call',
+      targetRole: 'assistant',
+      next: '',
+      branchesText: '{}',
+      parametersText: JSON.stringify({
+        prompt: 'Translate the input to Japanese.',
+      }),
+    });
+
+    expect(result.document.steps?.[0]?.parameters).toEqual({
+      prompt_prefix: 'Translate the input to Japanese.',
+    });
+  });
+
+  it('keeps human prompt parameters unchanged on apply', () => {
+    const document: StudioWorkflowDocument = {
+      name: 'workspace-demo',
+      roles: [],
+      steps: [
+        {
+          id: 'approval_step',
+          type: 'human_approval',
+          targetRole: null,
+          parameters: {
+            prompt: 'Approve this?',
+          },
+          next: null,
+          branches: {},
+        },
+      ],
+    };
+
+    const result = applyStepInspectorDraft(document, 'approval_step', {
+      kind: 'step',
+      id: 'approval_step',
+      type: 'human_approval',
+      targetRole: '',
+      next: '',
+      branchesText: '{}',
+      parametersText: JSON.stringify({
+        prompt: 'Approve the generated response?',
+      }),
+    });
+
+    expect(result.document.steps?.[0]?.parameters).toEqual({
+      prompt: 'Approve the generated response?',
+    });
+  });
+
   it('rejects non-object step parameters', () => {
     expect(() => parseInspectorParameters('["nope"]')).toThrow(
       'Step parameters must be a JSON object.',

--- a/apps/aevatar-console-web/src/shared/studio/document.ts
+++ b/apps/aevatar-console-web/src/shared/studio/document.ts
@@ -89,8 +89,72 @@ const DEFAULT_PARAMETERS_BY_STEP_TYPE: Record<string, Record<string, unknown>> =
   workflow_yaml_validate: {},
 };
 
+const LLM_CALL_STEP_TYPE = 'llm_call';
+const LLM_PROMPT_PARAMETER = 'prompt';
+const LLM_PROMPT_PREFIX_PARAMETER = 'prompt_prefix';
+
 function normalizeString(value: unknown): string {
   return String(value ?? '').trim();
+}
+
+function normalizeStepType(value: unknown): string {
+  return normalizeString(value).toLowerCase();
+}
+
+export function resolveStepParameterName(
+  stepType: string,
+  parameterName: string,
+): string {
+  const normalizedParameterName = normalizeString(parameterName);
+  if (
+    normalizeStepType(stepType) === LLM_CALL_STEP_TYPE &&
+    normalizedParameterName.toLowerCase() === LLM_PROMPT_PARAMETER
+  ) {
+    return LLM_PROMPT_PREFIX_PARAMETER;
+  }
+
+  return normalizedParameterName;
+}
+
+export function readStepParameterValue(
+  parameters: Record<string, unknown> | null | undefined,
+  stepType: string,
+  parameterName: string,
+): unknown {
+  const resolvedParameterName = resolveStepParameterName(stepType, parameterName);
+  const normalizedParameters =
+    parameters && typeof parameters === 'object' ? parameters : {};
+
+  if (
+    normalizeStepType(stepType) === LLM_CALL_STEP_TYPE &&
+    resolvedParameterName === LLM_PROMPT_PREFIX_PARAMETER
+  ) {
+    return (
+      normalizedParameters[LLM_PROMPT_PREFIX_PARAMETER] ??
+      normalizedParameters[LLM_PROMPT_PARAMETER]
+    );
+  }
+
+  return normalizedParameters[resolvedParameterName];
+}
+
+export function normalizeStepParametersForType(
+  stepType: string,
+  parameters: Record<string, unknown>,
+): Record<string, unknown> {
+  if (normalizeStepType(stepType) !== LLM_CALL_STEP_TYPE) {
+    return parameters;
+  }
+
+  const nextParameters = { ...parameters };
+  if (
+    nextParameters[LLM_PROMPT_PREFIX_PARAMETER] === undefined &&
+    nextParameters[LLM_PROMPT_PARAMETER] !== undefined
+  ) {
+    nextParameters[LLM_PROMPT_PREFIX_PARAMETER] = nextParameters[LLM_PROMPT_PARAMETER];
+  }
+  delete nextParameters[LLM_PROMPT_PARAMETER];
+  return nextParameters;
 }
 
 function cloneRecord<T>(value: T): T {
@@ -279,7 +343,10 @@ export function applyStepInspectorDraft(
   const nextTargetRole = normalizeString(draft.targetRole);
   const nextStepId = normalizeString(draft.next);
   const nextBranches = parseInspectorBranches(draft.branchesText);
-  const nextParameters = parseInspectorParameters(draft.parametersText);
+  const nextParameters = normalizeStepParametersForType(
+    nextType,
+    parseInspectorParameters(draft.parametersText),
+  );
 
   const steps = Array.isArray(document.steps) ? document.steps : [];
   const nextSteps = steps.map((entry) => {

--- a/apps/aevatar-console-web/src/shared/studio/graph.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/graph.test.ts
@@ -1,0 +1,41 @@
+import { buildStudioGraphElements } from './graph';
+
+describe('studio graph helpers', () => {
+  it('summarizes llm prompt prefixes with user-facing wording', () => {
+    const graph = buildStudioGraphElements({
+      name: 'workflow-demo',
+      steps: [
+        {
+          id: 'llm_call',
+          type: 'llm_call',
+          parameters: {
+            prompt_prefix: 'Translate the user input to Japanese.',
+          },
+        },
+      ],
+    });
+
+    expect(graph.nodes[0]?.data.parametersSummary).toBe(
+      'instruction: Translate the user input to Japanese.',
+    );
+  });
+
+  it('does not show empty llm prompt object defaults as configured prompts', () => {
+    const graph = buildStudioGraphElements({
+      name: 'workflow-demo',
+      steps: [
+        {
+          id: 'llm_call',
+          type: 'llm_call',
+          parameters: {
+            prompt_prefix: {},
+          },
+        },
+      ],
+    });
+
+    expect(graph.nodes[0]?.data.parametersSummary).toBe(
+      'No parameters configured',
+    );
+  });
+});

--- a/apps/aevatar-console-web/src/shared/studio/graph.ts
+++ b/apps/aevatar-console-web/src/shared/studio/graph.ts
@@ -241,29 +241,63 @@ function normalizeSteps(document: WorkflowDocumentLike): StudioGraphStep[] {
     .filter((step): step is StudioGraphStep => Boolean(step));
 }
 
-function summarizeStepParameters(parameters: Record<string, unknown>): string {
+function summarizeStepParameterEntry(
+  stepType: string,
+  key: string,
+  value: unknown,
+): string {
+  const displayKey =
+    stepType.trim().toLowerCase() === 'llm_call' && key === 'prompt_prefix'
+      ? 'instruction'
+      : key;
+
+  if (typeof value === 'string') {
+    return `${displayKey}: ${value}`;
+  }
+
+  if (
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    value === null
+  ) {
+    return `${displayKey}: ${String(value)}`;
+  }
+
+  return `${displayKey}: ${JSON.stringify(value)}`;
+}
+
+function getSummarizableStepParameterEntries(
+  stepType: string,
+  parameters: Record<string, unknown>,
+): Array<[string, unknown]> {
   const entries = Object.entries(parameters);
+  if (stepType.trim().toLowerCase() !== 'llm_call') {
+    return entries;
+  }
+
+  const promptPrefixValue = parameters.prompt_prefix ?? parameters.prompt;
+  const nextEntries = entries.filter(
+    ([key]) => key !== 'prompt_prefix' && key !== 'prompt',
+  );
+  if (typeof promptPrefixValue === 'string' && promptPrefixValue.trim()) {
+    return [['prompt_prefix', promptPrefixValue], ...nextEntries];
+  }
+
+  return nextEntries;
+}
+
+function summarizeStepParameters(
+  stepType: string,
+  parameters: Record<string, unknown>,
+): string {
+  const entries = getSummarizableStepParameterEntries(stepType, parameters);
   if (entries.length === 0) {
     return 'No parameters configured';
   }
 
   return entries
     .slice(0, 2)
-    .map(([key, value]) => {
-      if (typeof value === 'string') {
-        return `${key}: ${value}`;
-      }
-
-      if (
-        typeof value === 'number' ||
-        typeof value === 'boolean' ||
-        value === null
-      ) {
-        return `${key}: ${String(value)}`;
-      }
-
-      return `${key}: ${JSON.stringify(value)}`;
-    })
+    .map(([key, value]) => summarizeStepParameterEntry(stepType, key, value))
     .join(' · ');
 }
 
@@ -530,7 +564,7 @@ export function buildStudioGraphElements(
         stepId: step.id,
         stepType: step.type,
         targetRole: step.targetRole,
-        parametersSummary: summarizeStepParameters(step.parameters),
+        parametersSummary: summarizeStepParameters(step.type, step.parameters),
         branchCount: Object.keys(step.branches).length,
       },
     };


### PR DESCRIPTION
## 问题与根因
- Workflow Build 面板中，运行时 primitive 若把 `llm_call` 提示字段暴露为 `prompt`，右侧参数编辑器原先会写入 `llm_call.parameters.prompt`。
- 后端确认 `LLMCallModule` 不消费 `parameters.prompt`；LLM step 的提示词修饰应写入 `parameters.prompt_prefix`，启动 workflow run 的用户输入仍使用请求体 `prompt`。
- 用户在 Step Detail 里刚编辑 LLM 指令后，如果没有先点 `Apply changes` 就直接点 `Save draft`，父级保存逻辑会保存旧的 `draftYaml`，随后重新应用旧 YAML，导致刚输入的内容被重置。
- `prompt_prefix` 是接口/YAML 字段，不应该作为主 UI 文案暴露给用户；runtime descriptor 的 `{}` default 也不应该显示成用户 prompt 内容。

## 修复方案
- 在 Studio workflow document helper 中集中解析 step 参数名：仅对 `llm_call.prompt` 映射到 `prompt_prefix`。
- Apply step draft 时规范化 `llm_call` 参数：保留/迁移到 `prompt_prefix`，删除后端不消费的 `prompt`。
- Build 面板参数编辑器复用同一套解析逻辑，UI 主路径显示 `Prompt instruction`，内部保存仍写 `parameters.prompt_prefix`。
- `Save draft` 会把当前 Step Detail 中尚未 Apply 的 step draft 一起传给页面保存逻辑；页面在保存前把这份 pending draft 应用到 workflow document、重新 serialize YAML，再调用 `saveWorkflow`，避免保存 stale YAML。
- LLM prompt instruction 不再使用 runtime descriptor 的 `{}` default 作为输入框值；空值显示为空白和示例 placeholder。
- Canvas 节点摘要把 `prompt_prefix` 显示成 user-facing `instruction`，并隐藏空对象默认值，避免 `prompt_prefix: {}` 泄漏到主工作流界面。
- 补充回归测试覆盖 runtime 暴露 `prompt` descriptor、legacy `prompt` 数据迁移、human prompt 不被误改、不点 `Apply changes` 直接 `Save draft` 保留内容、UI 不展示 `{}` default，以及 canvas 摘要不泄漏 `prompt_prefix`。

## 影响路径
- `apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx`
- `apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx`
- `apps/aevatar-console-web/src/pages/studio/index.tsx`
- `apps/aevatar-console-web/src/pages/studio/index.test.tsx`
- `apps/aevatar-console-web/src/shared/studio/document.ts`
- `apps/aevatar-console-web/src/shared/studio/document.test.ts`
- `apps/aevatar-console-web/src/shared/studio/graph.ts`
- `apps/aevatar-console-web/src/shared/studio/graph.test.ts`

## Browser 证据
- 使用 Codex in-app browser，visibility 已打开。
- 当前验证路由：`http://localhost:5179/studio?scopeId=ccb108c4-dcb3-473a-a0f7-e9859bb2f2a0&teamId=t-df2d3eca8f6a41b6974019fae7d55e0b&member=member%3Am-9975e1dcd98f44d8a7ec6ceafe7f486c&step=build&focus=workflow%3Adraft-3&tab=studio`。
- 进程环境确认 5179 使用远端后端：
  - `AEVATAR_API_TARGET=https://aevatar-console-backend-api.aevatar.ai`
  - `AEVATAR_STUDIO_API_TARGET=https://aevatar-console-backend-api.aevatar.ai`
  - `AEVATAR_PROXY_PRESERVE_AUTH_HOST=false`
- 初始截图中的 `Maximum update depth exceeded` 在同一路由 reload 后未稳定复现；页面恢复为 Studio Build 正常界面，console 没有新的 maximum-depth stack。
- 修复后 DOM 观察：右侧参数字段显示 `Prompt instruction`，输入框 aria label 为 `Parameter Prompt instruction`，placeholder 为 `e.g. Translate the user input to Japanese`。
- 修复后 DOM 观察：canvas 节点摘要显示 `No parameters configured`，不再显示 `prompt_prefix: {}`。
- 行为复验：在 `Prompt instruction` 输入 `用户输入转成日语` 后点击 `Apply changes`，输入框值仍为 `用户输入转成日语`，没有重置为 `{}`。
- console 只看到既有 Ant Design deprecated warning：`[antd: Alert] message is deprecated. Please use title instead.`，未观察到新增 runtime crash。

## 验证命令与结果
- `./node_modules/.bin/jest src/pages/studio/components/StudioBuildPanels.test.tsx --runInBand --testNamePattern "writes llm_call prompt edits to prompt_prefix when runtime exposes prompt|passes unsaved llm_call prompt edits to save draft|does not show object defaults as llm prompt instructions|keeps human prompt edits on the prompt parameter"`：通过，4 tests passed。
- `./node_modules/.bin/jest src/shared/studio/graph.test.ts --runInBand`：通过，2 tests passed。
- `./node_modules/.bin/jest src/pages/studio/index.test.tsx --runInBand --testNamePattern "saves pending workflow step prompt edits without requiring Apply changes|saves edited workflow drafts back to the Studio workspace API|saves the workflow draft and continues to bind from the build page"`：通过，3 tests passed。
- `./node_modules/.bin/jest src/shared/studio/document.test.ts --runInBand`：通过，12 tests passed。
- `./node_modules/.bin/tsc --noEmit`：通过。
- `git diff --check -- apps/aevatar-console-web`：通过。
- `bash tools/ci/test_stability_guards.sh`：通过。

## Scope check
- 本 PR 所有改动均位于 `apps/aevatar-console-web/`。
- 未修改 backend。
- 未修改 proto。
- 未修改 docs/tools/scripts。
- 未修改 generated files 或 shared contracts。
