### PR TITLE
#1249 first slice: resume/signal/stop EventEnvelope.Id 对齐 context.CommandId

### DIFF
--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowResumeCommandEnvelopeFactory.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowResumeCommandEnvelopeFactory.cs
@@ -27,7 +27,8 @@ internal sealed class WorkflowResumeCommandEnvelopeFactory : ICommandEnvelopeFac
 
         return new EventEnvelope
         {
-            Id = Guid.NewGuid().ToString("N"),
+            // Refactor (issue1249-first): Old: resume used a factory-local random envelope id. New: envelope id carries the accepted command identity.
+            Id = context.CommandId,
             Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
             Payload = Any.Pack(resumed),
             Route = EnvelopeRouteSemantics.CreateDirect("api.workflow.resume", context.TargetId),

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowSignalCommandEnvelopeFactory.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowSignalCommandEnvelopeFactory.cs
@@ -16,7 +16,8 @@ internal sealed class WorkflowSignalCommandEnvelopeFactory : ICommandEnvelopeFac
         var signalName = NormalizeRequired(command.SignalName, nameof(command.SignalName));
         return new EventEnvelope
         {
-            Id = Guid.NewGuid().ToString("N"),
+            // Refactor (issue1249-first): Old: signal used a factory-local random envelope id. New: envelope id carries the accepted command identity.
+            Id = context.CommandId,
             Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
             Payload = Any.Pack(new SignalReceivedEvent
             {

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowStopCommandEnvelopeFactory.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowStopCommandEnvelopeFactory.cs
@@ -15,7 +15,8 @@ internal sealed class WorkflowStopCommandEnvelopeFactory : ICommandEnvelopeFacto
 
         return new EventEnvelope
         {
-            Id = Guid.NewGuid().ToString("N"),
+            // Refactor (issue1249-first): Old: stop used a factory-local random envelope id. New: envelope id carries the accepted command identity.
+            Id = context.CommandId,
             Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
             Payload = Any.Pack(new WorkflowStoppedEvent
             {

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
@@ -240,6 +240,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
             context);
 
         var resumed = envelope.Payload.Unpack<WorkflowResumedEvent>();
+        envelope.Id.Should().Be("cmd-1");
         resumed.UserInput.Should().BeEmpty();
         resumed.EditedContent.Should().BeEmpty();
         resumed.Feedback.Should().BeEmpty();
@@ -267,6 +268,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
             new WorkflowSignalCommand("actor-1", "run-1", "approve", "cmd-1", null),
             context);
 
+        envelope.Id.Should().Be("cmd-1");
         envelope.Payload.Unpack<SignalReceivedEvent>().Payload.Should().BeEmpty();
 
         var actOnCommand = () => factory.CreateEnvelope(null!, context);
@@ -292,6 +294,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
             new WorkflowStopCommand("actor-1", "run-1", "cmd-1", null),
             context);
 
+        envelope.Id.Should().Be("cmd-1");
         envelope.Payload.Unpack<WorkflowStoppedEvent>().Reason.Should().BeEmpty();
 
         var actOnCommand = () => factory.CreateEnvelope(null!, context);

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlCommandTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlCommandTests.cs
@@ -132,6 +132,7 @@ public sealed class WorkflowRunControlCommandTests
 
         var resumed = envelope.Payload.Unpack<WorkflowResumedEvent>();
 
+        envelope.Id.Should().Be("cmd-1");
         envelope.Route!.PublisherActorId.Should().Be("api.workflow.resume");
         envelope.Route.GetTargetActorId().Should().Be("actor-1");
         envelope.Propagation!.CorrelationId.Should().Be("cmd-1");
@@ -166,6 +167,7 @@ public sealed class WorkflowRunControlCommandTests
 
         var signal = envelope.Payload.Unpack<SignalReceivedEvent>();
 
+        envelope.Id.Should().Be("cmd-1");
         envelope.Route!.PublisherActorId.Should().Be("api.workflow.signal");
         envelope.Route.GetTargetActorId().Should().Be("actor-1");
         envelope.Propagation!.CorrelationId.Should().Be("cmd-1");
@@ -196,6 +198,7 @@ public sealed class WorkflowRunControlCommandTests
 
         var stopped = envelope.Payload.Unpack<WorkflowStoppedEvent>();
 
+        envelope.Id.Should().Be("cmd-1");
         envelope.Route!.PublisherActorId.Should().Be("api.workflow.stop");
         envelope.Route.GetTargetActorId().Should().Be("actor-1");
         envelope.Propagation!.CorrelationId.Should().Be("cmd-1");


### PR DESCRIPTION
## 摘要

源自 #1221 Phase 9 r1 META_JUDGE_DONE:split 的 first-slice。

将 3 个 envelope factory(`WorkflowResumeCommandEnvelopeFactory` / `WorkflowSignalCommandEnvelopeFactory` / `WorkflowStopCommandEnvelopeFactory`)的 `EventEnvelope.Id` 从 factory-local `Guid.NewGuid().ToString("N")` 改为 `context.CommandId`,与其他 workflow command envelope 保持一致。

## 变更

- `src/workflow/Aevatar.Workflow.Application/Runs/WorkflowResumeCommandEnvelopeFactory.cs`
- `src/workflow/Aevatar.Workflow.Application/Runs/WorkflowSignalCommandEnvelopeFactory.cs`
- `src/workflow/Aevatar.Workflow.Application/Runs/WorkflowStopCommandEnvelopeFactory.cs`
- 测试:`WorkflowRunControlCommandTests` / `WorkflowRunControlAndAbstractionsCoverageTests` 加 `envelope.Id == context.CommandId` 断言

## No-new-core 边界

- 无新增 actor / proto field / envelope kind / pipeline phase
- 无 `docs/canon/*` 改动
- self-doc Old/New 注释

## 验证

- `dotnet build aevatar.slnx --nologo` 通过
- `dotnet test aevatar.slnx --nologo --no-build` 通过(0 failures)
- `bash tools/ci/architecture_guards.sh` 通过
- `bash tools/ci/test_stability_guards.sh` 通过

closes #1249

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧