### PR TITLE
#1255 first slice: typed DeviceInbound 清理 (no-new-core)

### DIFF
--- a/agents/Aevatar.GAgents.Device/DeviceEventEndpoints.cs
+++ b/agents/Aevatar.GAgents.Device/DeviceEventEndpoints.cs
@@ -192,7 +192,7 @@ public static class DeviceEventEndpoints
                      : string.Empty;
         }
 
-        // Refactor (issue1255-first):
+        // Refactor (iter162-cluster-001 #1255-first):
         //   Old pattern: pass content.text through as DeviceInbound.PayloadJson.
         //   New principle: terminate JSON here and map known events to typed Protobuf payloads.
         using var innerDoc = JsonDocument.Parse(contentText);

--- a/agents/Aevatar.GAgents.Device/DeviceEventEndpoints.cs
+++ b/agents/Aevatar.GAgents.Device/DeviceEventEndpoints.cs
@@ -192,7 +192,9 @@ public static class DeviceEventEndpoints
                      : string.Empty;
         }
 
-        // Refactor (issue1255-first): Old: pass content.text through as DeviceInbound.PayloadJson. New: terminate JSON here and map known events to typed Protobuf payloads.
+        // Refactor (issue1255-first):
+        //   Old pattern: pass content.text through as DeviceInbound.PayloadJson.
+        //   New principle: terminate JSON here and map known events to typed Protobuf payloads.
         using var innerDoc = JsonDocument.Parse(contentText);
         var inner = innerDoc.RootElement;
 

--- a/agents/Aevatar.GAgents.Device/DeviceEventEndpoints.cs
+++ b/agents/Aevatar.GAgents.Device/DeviceEventEndpoints.cs
@@ -179,7 +179,7 @@ public static class DeviceEventEndpoints
         using var doc = JsonDocument.Parse(bodyBytes);
         var root = doc.RootElement;
 
-        // content.text contains the raw device event JSON (same in both old and new format)
+        // content.text contains the raw device event JSON at the adapter boundary.
         var contentText = root.GetProperty("content").GetProperty("text").GetString()
                           ?? throw new JsonException("content.text is required");
 
@@ -192,7 +192,7 @@ public static class DeviceEventEndpoints
                      : string.Empty;
         }
 
-        // Parse the inner device event JSON from content.text
+        // Refactor (issue1255-first): Old: pass content.text through as DeviceInbound.PayloadJson. New: terminate JSON here and map known events to typed Protobuf payloads.
         using var innerDoc = JsonDocument.Parse(contentText);
         var inner = innerDoc.RootElement;
 
@@ -201,15 +201,75 @@ public static class DeviceEventEndpoints
         var eventType = inner.TryGetProperty("event_type", out var et) ? et.GetString() ?? string.Empty : string.Empty;
         var timestamp = inner.TryGetProperty("timestamp", out var ts) ? ts.GetString() ?? string.Empty : string.Empty;
 
-        return new DeviceInbound
+        var inbound = new DeviceInbound
         {
             EventId = eventId,
             Source = source,
             EventType = eventType,
             Timestamp = timestamp,
-            PayloadJson = contentText,
             DeviceId = senderId,
         };
+
+        ApplyKnownPayload(inbound, inner);
+        return inbound;
+    }
+
+    private static void ApplyKnownPayload(DeviceInbound inbound, JsonElement inner)
+    {
+        switch (inbound.EventType)
+        {
+            case "temperature_change":
+                inbound.Sensor = new SensorDeviceInboundPayload
+                {
+                    Temperature = GetOptionalDouble(inner, "temperature"),
+                    Humidity = GetOptionalDouble(inner, "humidity"),
+                    LightLevel = GetOptionalDouble(inner, "light_level"),
+                    MotionDetected = GetOptionalBoolean(inner, "motion"),
+                };
+                break;
+            case "person_detected":
+            case "scene_summary":
+                inbound.Camera = new CameraDeviceInboundPayload
+                {
+                    SceneDescription = GetOptionalString(inner, "description"),
+                };
+                break;
+            case "motion_detected":
+                inbound.Motion = new MotionDeviceInboundPayload
+                {
+                    Detected = GetOptionalBoolean(inner, "motion", defaultValue: true),
+                };
+                break;
+            case "speech_detected":
+                inbound.Speech = new SpeechDeviceInboundPayload
+                {
+                    Text = GetOptionalString(inner, "text"),
+                };
+                break;
+            default:
+                throw new JsonException($"Unsupported device event_type '{inbound.EventType}'");
+        }
+    }
+
+    private static string GetOptionalString(JsonElement root, string propertyName)
+    {
+        return root.TryGetProperty(propertyName, out var value)
+            ? value.GetString() ?? string.Empty
+            : string.Empty;
+    }
+
+    private static double GetOptionalDouble(JsonElement root, string propertyName)
+    {
+        return root.TryGetProperty(propertyName, out var value)
+            ? value.GetDouble()
+            : 0;
+    }
+
+    private static bool GetOptionalBoolean(JsonElement root, string propertyName, bool defaultValue = false)
+    {
+        return root.TryGetProperty(propertyName, out var value)
+            ? value.GetBoolean()
+            : defaultValue;
     }
 
     // ─── Registration CRUD ───

--- a/agents/Aevatar.GAgents.Household/HouseholdEntity.cs
+++ b/agents/Aevatar.GAgents.Household/HouseholdEntity.cs
@@ -192,7 +192,9 @@ public class HouseholdEntity : AIGAgentBase<HouseholdEntityState>
 
         try
         {
-            // Refactor (issue1255-first): Old: actor parsed DeviceInbound.PayloadJson based on event_type. New: actor consumes typed DeviceInbound payload cases only.
+            // Refactor (issue1255-first):
+            //   Old pattern: actor parsed DeviceInbound.PayloadJson based on event_type.
+            //   New principle: actor consumes typed DeviceInbound payload cases only.
             switch (evt.PayloadCase)
             {
                 case DeviceInbound.PayloadOneofCase.Sensor:

--- a/agents/Aevatar.GAgents.Household/HouseholdEntity.cs
+++ b/agents/Aevatar.GAgents.Household/HouseholdEntity.cs
@@ -192,7 +192,7 @@ public class HouseholdEntity : AIGAgentBase<HouseholdEntityState>
 
         try
         {
-            // Refactor (issue1255-first):
+            // Refactor (iter162-cluster-001 #1255-first):
             //   Old pattern: actor parsed DeviceInbound.PayloadJson based on event_type.
             //   New principle: actor consumes typed DeviceInbound payload cases only.
             switch (evt.PayloadCase)

--- a/agents/Aevatar.GAgents.Household/HouseholdEntity.cs
+++ b/agents/Aevatar.GAgents.Household/HouseholdEntity.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using System.Text.Json;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.Middleware;
@@ -193,62 +192,50 @@ public class HouseholdEntity : AIGAgentBase<HouseholdEntityState>
 
         try
         {
-            switch (evt.EventType)
+            // Refactor (issue1255-first): Old: actor parsed DeviceInbound.PayloadJson based on event_type. New: actor consumes typed DeviceInbound payload cases only.
+            switch (evt.PayloadCase)
             {
-                case "temperature_change":
+                case DeviceInbound.PayloadOneofCase.Sensor:
                 {
-                    using var doc = JsonDocument.Parse(evt.PayloadJson);
-                    var root = doc.RootElement;
-                    var sensorEvt = new SensorDataEvent();
-                    if (root.TryGetProperty("temperature", out var temp)) sensorEvt.Temperature = temp.GetDouble();
-                    if (root.TryGetProperty("humidity", out var hum)) sensorEvt.Humidity = hum.GetDouble();
-                    if (root.TryGetProperty("light_level", out var light)) sensorEvt.LightLevel = light.GetDouble();
-                    if (root.TryGetProperty("motion", out var motion)) sensorEvt.MotionDetected = motion.GetBoolean();
+                    await HandleSensorData(new SensorDataEvent
+                    {
+                        Temperature = evt.Sensor.Temperature,
+                        Humidity = evt.Sensor.Humidity,
+                        LightLevel = evt.Sensor.LightLevel,
+                        MotionDetected = evt.Sensor.MotionDetected,
+                    });
+                    break;
+                }
+                case DeviceInbound.PayloadOneofCase.Camera:
+                {
+                    await HandleCameraScene(new CameraSceneEvent { SceneDescription = evt.Camera.SceneDescription });
+                    break;
+                }
+                case DeviceInbound.PayloadOneofCase.Motion:
+                {
+                    var sensorEvt = new SensorDataEvent { MotionDetected = evt.Motion.Detected };
                     await HandleSensorData(sensorEvt);
                     break;
                 }
-                case "person_detected":
-                case "scene_summary":
+                case DeviceInbound.PayloadOneofCase.Speech:
                 {
-                    using var doc = JsonDocument.Parse(evt.PayloadJson);
-                    var root = doc.RootElement;
-                    var desc = root.TryGetProperty("description", out var d) ? d.GetString() ?? "" : "";
-                    await HandleCameraScene(new CameraSceneEvent { SceneDescription = desc });
-                    break;
-                }
-                case "motion_detected":
-                {
-                    var sensorEvt = new SensorDataEvent { MotionDetected = true };
-                    await HandleSensorData(sensorEvt);
-                    break;
-                }
-                case "speech_detected":
-                {
-                    using var doc = JsonDocument.Parse(evt.PayloadJson);
-                    var root = doc.RootElement;
-                    var text = root.TryGetProperty("text", out var t) ? t.GetString() ?? "" : "";
-                    if (!string.IsNullOrWhiteSpace(text))
+                    if (!string.IsNullOrWhiteSpace(evt.Speech.Text))
                     {
                         await HandleChat(new HouseholdChatEvent
                         {
-                            Prompt = text,
+                            Prompt = evt.Speech.Text,
                             SessionId = evt.EventId,
                         });
                     }
                     break;
                 }
+                case DeviceInbound.PayloadOneofCase.None:
                 default:
                     Logger.LogWarning(
-                        "[Household] Unknown device event type: {EventType}, source={Source}",
+                        "[Household] Device event has no typed payload: type={EventType}, source={Source}",
                         evt.EventType, evt.Source);
                     break;
             }
-        }
-        catch (JsonException ex)
-        {
-            Logger.LogWarning(ex,
-                "[Household] Failed to parse device event payload: type={EventType}, source={Source}",
-                evt.EventType, evt.Source);
         }
         catch (Exception ex)
         {

--- a/agents/Aevatar.GAgents.Household/household_messages.proto
+++ b/agents/Aevatar.GAgents.Household/household_messages.proto
@@ -153,7 +153,7 @@ message SpeechDeviceInboundPayload {
 // Defined in Household domain because it's the inbound contract for
 // HouseholdEntity; DeviceEventEndpoints (boundary layer) references
 // this project, keeping dependency direction correct (Host → Domain).
-// Refactor (issue1255-first):
+// Refactor (iter162-cluster-001 #1255-first):
 //   Old pattern: DeviceInbound carried raw payload_json through the actor boundary.
 //   New principle: DeviceInbound carries only known typed payload cases.
 message DeviceInbound {

--- a/agents/Aevatar.GAgents.Household/household_messages.proto
+++ b/agents/Aevatar.GAgents.Household/household_messages.proto
@@ -130,15 +130,44 @@ message TimePeriodChangedEvent {
 
 // ─── Device Inbound (from DeviceEventEndpoints via EventEnvelope) ───
 
+message SensorDeviceInboundPayload {
+  double temperature = 1;
+  double humidity = 2;
+  double light_level = 3;
+  bool motion_detected = 4;
+}
+
+message CameraDeviceInboundPayload {
+  string scene_description = 1;
+}
+
+message MotionDeviceInboundPayload {
+  bool detected = 1;
+}
+
+message SpeechDeviceInboundPayload {
+  string text = 1;
+}
+
 // Normalized device event from NyxID relay's CallbackPayload.
 // Defined in Household domain because it's the inbound contract for
 // HouseholdEntity; DeviceEventEndpoints (boundary layer) references
 // this project, keeping dependency direction correct (Host → Domain).
+// Refactor (issue1255-first): Old: DeviceInbound carried raw payload_json through the actor boundary. New: DeviceInbound carries only known typed payload cases.
 message DeviceInbound {
+  reserved 5;
+  reserved "payload_json";
+
   string event_id = 1;       // NyxID event envelope's event_id
   string source = 2;         // "camera-analyzer", "temperature-sensor", etc.
   string event_type = 3;     // "person_detected", "temperature_change", "motion_detected"
   string timestamp = 4;      // RFC 3339
-  string payload_json = 5;   // Raw device payload JSON (temporary — will evolve to typed sub-messages)
   string device_id = 6;      // Device identifier (optional)
+
+  oneof payload {
+    SensorDeviceInboundPayload sensor = 7;
+    CameraDeviceInboundPayload camera = 8;
+    MotionDeviceInboundPayload motion = 9;
+    SpeechDeviceInboundPayload speech = 10;
+  }
 }

--- a/agents/Aevatar.GAgents.Household/household_messages.proto
+++ b/agents/Aevatar.GAgents.Household/household_messages.proto
@@ -153,7 +153,9 @@ message SpeechDeviceInboundPayload {
 // Defined in Household domain because it's the inbound contract for
 // HouseholdEntity; DeviceEventEndpoints (boundary layer) references
 // this project, keeping dependency direction correct (Host → Domain).
-// Refactor (issue1255-first): Old: DeviceInbound carried raw payload_json through the actor boundary. New: DeviceInbound carries only known typed payload cases.
+// Refactor (issue1255-first):
+//   Old pattern: DeviceInbound carried raw payload_json through the actor boundary.
+//   New principle: DeviceInbound carries only known typed payload cases.
 message DeviceInbound {
   reserved 5;
   reserved "payload_json";

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceCommandFacadeTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceCommandFacadeTests.cs
@@ -141,7 +141,9 @@ public sealed class DeviceCommandFacadeTests
         result.Receipt.RegistrationId.Should().Be("reg-1");
         capturedEnvelope.Should().NotBeNull();
         capturedEnvelope!.Id.Should().Be("cmd-1");
-        capturedEnvelope.Payload.Unpack<DeviceInbound>().EventId.Should().Be("evt-3");
+        var inbound = capturedEnvelope.Payload.Unpack<DeviceInbound>();
+        inbound.EventId.Should().Be("evt-3");
+        DeviceInbound.Descriptor.FullName.Should().Be("aevatar.gagents.household.DeviceInbound");
         await actorRuntime.DidNotReceiveWithAnyArgs().CreateAsync(default!, default, default);
         await dispatchPort.Received(1).DispatchAsync(
             "household-scope-a",

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceEventEndpointsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceEventEndpointsTests.cs
@@ -186,6 +186,34 @@ public class DeviceEventEndpointsTests
         inbound.Speech.Text.Should().Be("Turn on the lights");
     }
 
+    [Theory]
+    [InlineData("person_detected")]
+    [InlineData("scene_summary")]
+    public void ParseCallbackPayload_known_camera_maps_to_camera_payload(string eventType)
+    {
+        var innerEvent = JsonSerializer.Serialize(new
+        {
+            event_id = $"evt-{eventType}",
+            source = "camera-analyzer",
+            event_type = eventType,
+            description = "Person standing near the front door",
+        });
+
+        var payload = JsonSerializer.Serialize(new
+        {
+            content = new { text = innerEvent },
+            sender = new { platform_id = "camera-1" },
+        });
+
+        var inbound = DeviceEventEndpoints.ParseCallbackPayload(Encoding.UTF8.GetBytes(payload));
+
+        inbound.EventType.Should().Be(eventType);
+        inbound.Source.Should().Be("camera-analyzer");
+        inbound.DeviceId.Should().Be("camera-1");
+        inbound.PayloadCase.Should().Be(Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.Camera);
+        inbound.Camera.SceneDescription.Should().Be("Person standing near the front door");
+    }
+
     // ─── HMAC Verification Tests ───
 
     private static DeviceRegistrationEntry MakeRegistration(string hmacKey = "test-secret") => new()

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceEventEndpointsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceEventEndpointsTests.cs
@@ -96,6 +96,29 @@ public class DeviceEventEndpointsTests
 
         inbound.DeviceId.Should().Be("legacy-device-1");
         inbound.PayloadCase.Should().Be(Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.Motion);
+        inbound.Motion.Detected.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ParseCallbackPayload_motion_detected_explicit_false_maps_to_false()
+    {
+        var innerEvent = JsonSerializer.Serialize(new
+        {
+            event_id = "evt-003",
+            event_type = "motion_detected",
+            motion = false,
+        });
+
+        var payload = JsonSerializer.Serialize(new
+        {
+            content = new { text = innerEvent },
+            sender = new { id = "device-3" },
+        });
+
+        var inbound = DeviceEventEndpoints.ParseCallbackPayload(Encoding.UTF8.GetBytes(payload));
+
+        inbound.PayloadCase.Should().Be(Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.Motion);
+        inbound.Motion.Detected.Should().BeFalse();
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceEventEndpointsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceEventEndpointsTests.cs
@@ -33,7 +33,7 @@ public class DeviceEventEndpointsTests
     }
 
     [Fact]
-    public void ParseCallbackPayload_nyxid_format_returns_device_inbound()
+    public void ParseCallbackPayload_known_temperature_maps_to_sensor_payload()
     {
         // NyxID's actual CallbackPayload format (sender.platform_id, nested conversation)
         var innerEvent = JsonSerializer.Serialize(new
@@ -42,6 +42,10 @@ public class DeviceEventEndpointsTests
             source = "temperature-sensor",
             event_type = "temperature_change",
             timestamp = "2026-04-09T10:00:00Z",
+            temperature = 28.5,
+            humidity = 65.0,
+            light_level = 70.0,
+            motion = true,
         });
 
         var payload = JsonSerializer.Serialize(new
@@ -64,14 +68,22 @@ public class DeviceEventEndpointsTests
         inbound.EventType.Should().Be("temperature_change");
         inbound.Timestamp.Should().Be("2026-04-09T10:00:00Z");
         inbound.DeviceId.Should().Be("device-42");
-        inbound.PayloadJson.Should().Be(innerEvent);
+        inbound.PayloadCase.Should().Be(Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.Sensor);
+        inbound.Sensor.Temperature.Should().Be(28.5);
+        inbound.Sensor.Humidity.Should().Be(65.0);
+        inbound.Sensor.LightLevel.Should().Be(70.0);
+        inbound.Sensor.MotionDetected.Should().BeTrue();
     }
 
     [Fact]
     public void ParseCallbackPayload_legacy_sender_id_also_works()
     {
         // Backward compat: if sender uses "id" instead of "platform_id"
-        var innerEvent = JsonSerializer.Serialize(new { event_id = "evt-002" });
+        var innerEvent = JsonSerializer.Serialize(new
+        {
+            event_id = "evt-002",
+            event_type = "motion_detected",
+        });
 
         var payload = JsonSerializer.Serialize(new
         {
@@ -83,6 +95,7 @@ public class DeviceEventEndpointsTests
         var inbound = DeviceEventEndpoints.ParseCallbackPayload(bodyBytes);
 
         inbound.DeviceId.Should().Be("legacy-device-1");
+        inbound.PayloadCase.Should().Be(Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.Motion);
     }
 
     [Fact]
@@ -128,10 +141,14 @@ public class DeviceEventEndpointsTests
     }
 
     [Fact]
-    public void ParseCallbackPayload_with_partial_inner_event_uses_defaults()
+    public void ParseCallbackPayload_unknown_event_type_throws_without_raw_payload()
     {
-        // Inner event JSON that lacks some optional fields
-        var innerEvent = JsonSerializer.Serialize(new { event_id = "evt-partial" });
+        var innerEvent = JsonSerializer.Serialize(new
+        {
+            event_id = "evt-unknown",
+            event_type = "unknown_type",
+            payload = new { foo = "bar" },
+        });
 
         var payload = JsonSerializer.Serialize(new
         {
@@ -140,12 +157,33 @@ public class DeviceEventEndpointsTests
         });
 
         var bodyBytes = Encoding.UTF8.GetBytes(payload);
-        var inbound = DeviceEventEndpoints.ParseCallbackPayload(bodyBytes);
 
-        inbound.EventId.Should().Be("evt-partial");
-        inbound.Source.Should().BeEmpty();
-        inbound.EventType.Should().BeEmpty();
-        inbound.Timestamp.Should().BeEmpty();
+        var act = () => DeviceEventEndpoints.ParseCallbackPayload(bodyBytes);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void ParseCallbackPayload_known_speech_maps_to_speech_payload()
+    {
+        var innerEvent = JsonSerializer.Serialize(new
+        {
+            event_id = "evt-speech",
+            source = "microphone",
+            event_type = "speech_detected",
+            text = "Turn on the lights",
+        });
+
+        var payload = JsonSerializer.Serialize(new
+        {
+            content = new { text = innerEvent },
+            sender = new { id = "device-8" },
+        });
+
+        var inbound = DeviceEventEndpoints.ParseCallbackPayload(Encoding.UTF8.GetBytes(payload));
+
+        inbound.PayloadCase.Should().Be(Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.Speech);
+        inbound.Speech.Text.Should().Be("Turn on the lights");
     }
 
     // ─── HMAC Verification Tests ───

--- a/test/Aevatar.GAgents.Household.Tests/HouseholdEntityDeviceInboundTests.cs
+++ b/test/Aevatar.GAgents.Household.Tests/HouseholdEntityDeviceInboundTests.cs
@@ -15,7 +15,7 @@ namespace Aevatar.GAgents.Household.Tests;
 
 /// <summary>
 /// Tests for <see cref="HouseholdEntity.HandleDeviceInbound"/> — validates that
-/// inbound device events are correctly dispatched, parsed, and applied to state.
+/// typed inbound device events are correctly dispatched and applied to state.
 /// </summary>
 public class HouseholdEntityDeviceInboundTests : IAsyncLifetime
 {
@@ -50,14 +50,19 @@ public class HouseholdEntityDeviceInboundTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task HandleDeviceInbound_TemperatureChange_UpdatesEnvironment()
+    public async Task HandleDeviceInbound_TypedTemperature_UpdatesEnvironment()
     {
         var evt = new DeviceInbound
         {
             EventId = "evt-1",
             Source = "temperature-sensor",
             EventType = "temperature_change",
-            PayloadJson = """{"temperature": 28.5, "humidity": 65.0, "light_level": 70.0}""",
+            Sensor = new SensorDeviceInboundPayload
+            {
+                Temperature = 28.5,
+                Humidity = 65.0,
+                LightLevel = 70.0,
+            },
         };
 
         await _entity.HandleDeviceInbound(evt);
@@ -69,14 +74,17 @@ public class HouseholdEntityDeviceInboundTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task HandleDeviceInbound_PersonDetected_UpdatesSceneDescription()
+    public async Task HandleDeviceInbound_TypedCamera_UpdatesSceneDescription()
     {
         var evt = new DeviceInbound
         {
             EventId = "evt-2",
             Source = "camera-analyzer",
             EventType = "person_detected",
-            PayloadJson = """{"description": "Two people sitting in the living room"}""",
+            Camera = new CameraDeviceInboundPayload
+            {
+                SceneDescription = "Two people sitting in the living room",
+            },
         };
 
         await _entity.HandleDeviceInbound(evt);
@@ -86,14 +94,14 @@ public class HouseholdEntityDeviceInboundTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task HandleDeviceInbound_MotionDetected_UpdatesMotionFlag()
+    public async Task HandleDeviceInbound_TypedMotion_UpdatesMotionFlag()
     {
         var evt = new DeviceInbound
         {
             EventId = "evt-3",
             Source = "motion-sensor",
             EventType = "motion_detected",
-            PayloadJson = "{}",
+            Motion = new MotionDeviceInboundPayload { Detected = true },
         };
 
         await _entity.HandleDeviceInbound(evt);
@@ -103,7 +111,7 @@ public class HouseholdEntityDeviceInboundTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task HandleDeviceInbound_UnknownEventType_NoStateChange()
+    public async Task HandleDeviceInbound_NoTypedPayload_NoStateChange()
     {
         // Capture baseline state after activation
         var prevTemp = _entity.State.Environment?.Temperature ?? 0;
@@ -115,7 +123,6 @@ public class HouseholdEntityDeviceInboundTests : IAsyncLifetime
             EventId = "evt-4",
             Source = "unknown-device",
             EventType = "unknown_type",
-            PayloadJson = """{"foo": "bar"}""",
         };
 
         // Should not throw and should not change state
@@ -128,34 +135,14 @@ public class HouseholdEntityDeviceInboundTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task HandleDeviceInbound_MalformedPayloadJson_NoStateChange()
-    {
-        var prevTemp = _entity.State.Environment?.Temperature ?? 0;
-
-        var evt = new DeviceInbound
-        {
-            EventId = "evt-5",
-            Source = "temperature-sensor",
-            EventType = "temperature_change",
-            PayloadJson = "not valid json",
-        };
-
-        // Should not throw — the handler catches JsonException
-        var act = () => _entity.HandleDeviceInbound(evt);
-        await act.Should().NotThrowAsync();
-
-        _entity.State.Environment!.Temperature.Should().Be(prevTemp);
-    }
-
-    [Fact]
-    public async Task HandleDeviceInbound_SpeechDetected_DoesNotThrow()
+    public async Task HandleDeviceInbound_TypedSpeech_DoesNotThrow()
     {
         var evt = new DeviceInbound
         {
             EventId = "evt-6",
             Source = "microphone",
             EventType = "speech_detected",
-            PayloadJson = """{"text": "Turn on the lights"}""",
+            Speech = new SpeechDeviceInboundPayload { Text = "Turn on the lights" },
         };
 
         // speech_detected triggers HandleChat -> RunReasoningAsync -> ChatStreamAsync.

--- a/test/Aevatar.GAgents.Household.Tests/HouseholdEntityDeviceInboundTests.cs
+++ b/test/Aevatar.GAgents.Household.Tests/HouseholdEntityDeviceInboundTests.cs
@@ -20,6 +20,7 @@ namespace Aevatar.GAgents.Household.Tests;
 public class HouseholdEntityDeviceInboundTests : IAsyncLifetime
 {
     private HouseholdEntity _entity = null!;
+    private RecordingLLMProvider _llmProvider = null!;
     private ServiceProvider _serviceProvider = null!;
 
     public async Task InitializeAsync()
@@ -33,7 +34,8 @@ public class HouseholdEntityDeviceInboundTests : IAsyncLifetime
 
         _serviceProvider = services.BuildServiceProvider();
 
-        _entity = new HouseholdEntity(new StubLLMProviderFactory())
+        _llmProvider = new RecordingLLMProvider("default");
+        _entity = new HouseholdEntity(new StubLLMProviderFactory(_llmProvider))
         {
             Services = _serviceProvider,
             EventSourcingBehaviorFactory =
@@ -135,8 +137,11 @@ public class HouseholdEntityDeviceInboundTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task HandleDeviceInbound_TypedSpeech_DoesNotThrow()
+    public async Task HandleDeviceInbound_TypedSpeech_ForwardsTextToReasoning()
     {
+        var previousReasoningCount = _entity.State.ReasoningCountToday;
+        var previousLastReasoningTs = _entity.State.LastReasoningTs;
+
         var evt = new DeviceInbound
         {
             EventId = "evt-6",
@@ -145,11 +150,38 @@ public class HouseholdEntityDeviceInboundTests : IAsyncLifetime
             Speech = new SpeechDeviceInboundPayload { Text = "Turn on the lights" },
         };
 
-        // speech_detected triggers HandleChat -> RunReasoningAsync -> ChatStreamAsync.
-        // With the stub LLM provider, ChatStreamAsync returns "NO_ACTION" (no tool calls).
-        // The handler should complete without throwing.
-        var act = () => _entity.HandleDeviceInbound(evt);
-        await act.Should().NotThrowAsync();
+        await _entity.HandleDeviceInbound(evt);
+
+        _llmProvider.CallCount.Should().Be(1);
+        _llmProvider.LastRequest.Should().NotBeNull();
+        _llmProvider.LastRequest!.Messages.Should().Contain(message =>
+            string.Equals(message.Role, "user", StringComparison.Ordinal) &&
+            message.Content != null &&
+            message.Content.Contains("Message from user: Turn on the lights", StringComparison.Ordinal));
+        _entity.State.ReasoningCountToday.Should().Be(previousReasoningCount + 1);
+        _entity.State.LastReasoningTs.Should().BeGreaterThan(previousLastReasoningTs);
+    }
+
+    [Fact]
+    public async Task HandleDeviceInbound_TypedSpeech_WhenTextBlank_SkipsReasoning()
+    {
+        var previousReasoningCount = _entity.State.ReasoningCountToday;
+        var previousLastReasoningTs = _entity.State.LastReasoningTs;
+
+        var evt = new DeviceInbound
+        {
+            EventId = "evt-7",
+            Source = "microphone",
+            EventType = "speech_detected",
+            Speech = new SpeechDeviceInboundPayload { Text = "   " },
+        };
+
+        await _entity.HandleDeviceInbound(evt);
+
+        _llmProvider.CallCount.Should().Be(0);
+        _llmProvider.LastRequest.Should().BeNull();
+        _entity.State.ReasoningCountToday.Should().Be(previousReasoningCount);
+        _entity.State.LastReasoningTs.Should().Be(previousLastReasoningTs);
     }
 
     // ─── Test doubles ───
@@ -222,22 +254,26 @@ public class HouseholdEntityDeviceInboundTests : IAsyncLifetime
         }
     }
 
-    private sealed class StubLLMProviderFactory : ILLMProviderFactory
+    private sealed class StubLLMProviderFactory(RecordingLLMProvider provider) : ILLMProviderFactory
     {
-        public ILLMProvider GetProvider(string name) => new StubLLMProvider(name);
-        public ILLMProvider GetDefault() => new StubLLMProvider("default");
+        public ILLMProvider GetProvider(string name) => provider;
+        public ILLMProvider GetDefault() => provider;
         public IReadOnlyList<string> GetAvailableProviders() => ["default"];
     }
 
-    private sealed class StubLLMProvider(string name) : ILLMProvider
+    private sealed class RecordingLLMProvider(string name) : ILLMProvider
     {
         public string Name => name;
+        public int CallCount { get; private set; }
+        public LLMRequest? LastRequest { get; private set; }
 
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
+            CallCount++;
+            LastRequest = request;
             await Task.CompletedTask;
             yield return new LLMStreamChunk { DeltaContent = "NO_ACTION — no intervention needed." };
             yield return new LLMStreamChunk { IsLast = true, FinishReason = "stop" };


### PR DESCRIPTION
## 摘要

源自 #1208 Phase 9 r1 META_JUDGE_DONE:split 的 first-slice。

JSON 在 adapter 边界终止;`HouseholdEntity` 只消费 typed payload;unknown event 在 endpoint reject,不传入 actor。

## 变更

- `agents/Aevatar.GAgents.Household/household_messages.proto`: reserve `payload_json` tag/name + 新增 typed payload `oneof`
- `agents/Aevatar.GAgents.Device/DeviceEventEndpoints.cs`: unknown event reject 在 adapter 边界
- `agents/Aevatar.GAgents.Household/HouseholdEntity.cs`: 移除 `PayloadJson` / JSON parsing,只消费 typed payload
- 测试覆盖 typed 通路 + unknown reject 负断言

## No-new-core 边界

- 无新增 actor / envelope kind / pipeline phase
- 无 `docs/canon/*` 改动
- 第三方/未知 device 扩展边界设计交 #1256-later

## 验证

- `dotnet build aevatar.slnx --nologo` 通过
- `dotnet test aevatar.slnx --nologo --no-build` 通过
- `bash tools/ci/architecture_guards.sh` 通过
- `bash tools/ci/test_stability_guards.sh` 通过

closes #1255

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧