### PR TITLE
#1251 first slice: Responses-owned typed web result closure

### DIFF
--- a/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesWebResultBoundaryJson.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesWebResultBoundaryJson.cs
@@ -1,0 +1,60 @@
+using System.Text.Json;
+using Aevatar.GAgentService.Abstractions;
+
+namespace Aevatar.Mainnet.Host.Api.Responses;
+
+// Refactor (iter161-cluster-001 #1251-first):
+//   Old pattern: typed Responses Web results exposed boundary JSON rendering from the
+//   shared Abstractions layer and projection queries could call it directly.
+//   New principle: external JSON rendering stays in the Host/API adapter boundary;
+//   lower layers exchange typed protobuf contracts only.
+internal static class ResponsesWebResultBoundaryJson
+{
+    public static string ToBoundaryJson(ResponsesWebToolResult? result)
+    {
+        if (result == null)
+            return "{}";
+
+        return result.ResultCase switch
+        {
+            ResponsesWebToolResult.ResultOneofCase.Fetch => ToBoundaryJson(result.Fetch),
+            ResponsesWebToolResult.ResultOneofCase.Search => ToBoundaryJson(result.Search),
+            ResponsesWebToolResult.ResultOneofCase.Error => ToBoundaryJson(result.Error),
+            _ => "{}",
+        };
+    }
+
+    public static string ToBoundaryJson(ResponsesWebFetchToolOutput? output)
+    {
+        var fields = new Dictionary<string, object?>
+        {
+            ["url"] = output?.Url ?? string.Empty,
+            ["status_code"] = output?.StatusCode ?? 0,
+            ["content_type"] = output?.ContentType ?? string.Empty,
+            ["content"] = output?.Content ?? string.Empty,
+        };
+        if (!string.IsNullOrWhiteSpace(output?.RedirectUrl))
+            fields["redirect_url"] = output.RedirectUrl;
+
+        return JsonSerializer.Serialize(fields);
+    }
+
+    public static string ToBoundaryJson(ResponsesWebSearchToolOutput? output) =>
+        JsonSerializer.Serialize(new
+        {
+            results = (output?.Results ?? Enumerable.Empty<ResponsesWebSearchResultItem>())
+                .Select(static item => new
+                {
+                    title = item.Title,
+                    url = item.Url,
+                    snippet = item.Snippet,
+                }),
+        });
+
+    public static string ToBoundaryJson(ResponsesWebToolError? error) =>
+        JsonSerializer.Serialize(new
+        {
+            error = error?.Code ?? string.Empty,
+            message = error?.Message ?? string.Empty,
+        });
+}

--- a/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesWebSubstituteBackendAdapter.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesWebSubstituteBackendAdapter.cs
@@ -55,7 +55,9 @@ internal sealed class ResponsesWebSubstituteBackendAdapter : IResponsesWebSubsti
             input.Query,
             input.MaxResults,
             ct).ConfigureAwait(false);
-        // Refactor (issue1251-first): Old: Host adapter passed provider Value into Application. New: Host maps provider JSON-like Value into Responses-owned typed search output.
+        // Refactor (iter161-cluster-001 #1251-first):
+        //   Old pattern: Host adapter passed provider Value into Application.
+        //   New principle: Host maps provider JSON-like Value into Responses-owned typed search output.
         return new ResponsesWebSearchBoundaryResult(ToSearchOutput(result));
     }
 

--- a/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesWebSubstituteBackendAdapter.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesWebSubstituteBackendAdapter.cs
@@ -1,7 +1,6 @@
 using Aevatar.AI.ToolProviders.Web;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Application.Responses;
-using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.Mainnet.Host.Api.Responses;
 
@@ -56,6 +55,36 @@ internal sealed class ResponsesWebSubstituteBackendAdapter : IResponsesWebSubsti
             input.Query,
             input.MaxResults,
             ct).ConfigureAwait(false);
-        return new ResponsesWebSearchBoundaryResult(result);
+        // Refactor (issue1251-first): Old: Host adapter passed provider Value into Application. New: Host maps provider JSON-like Value into Responses-owned typed search output.
+        return new ResponsesWebSearchBoundaryResult(ToSearchOutput(result));
+    }
+
+    private static ResponsesWebSearchToolOutput ToSearchOutput(Google.Protobuf.WellKnownTypes.Value value)
+    {
+        var output = new ResponsesWebSearchToolOutput();
+        if (value.KindCase != Google.Protobuf.WellKnownTypes.Value.KindOneofCase.StructValue ||
+            !value.StructValue.Fields.TryGetValue("results", out var results) ||
+            results.KindCase != Google.Protobuf.WellKnownTypes.Value.KindOneofCase.ListValue)
+        {
+            return output;
+        }
+
+        output.Results.AddRange(results.ListValue.Values
+            .Where(static item => item.KindCase == Google.Protobuf.WellKnownTypes.Value.KindOneofCase.StructValue)
+            .Select(static item => new ResponsesWebSearchResultItem
+            {
+                Title = ReadString(item, "title"),
+                Url = ReadString(item, "url"),
+                Snippet = ReadString(item, "snippet"),
+            }));
+        return output;
+    }
+
+    private static string ReadString(Google.Protobuf.WellKnownTypes.Value item, string key)
+    {
+        return item.StructValue.Fields.TryGetValue(key, out var value) &&
+               value.KindCase == Google.Protobuf.WellKnownTypes.Value.KindOneofCase.StringValue
+            ? value.StringValue
+            : string.Empty;
     }
 }

--- a/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesWebSubstituteToolJson.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesWebSubstituteToolJson.cs
@@ -33,12 +33,12 @@ internal static class ResponsesWebSubstituteToolJson
     public static string ToBoundaryJson(ResponsesWebSubstituteToolExecutionResult result) =>
         result.ResultCase switch
         {
-            ResponsesWebSubstituteToolExecutionResult.ResultOneofCase.TypedCached => ResponsesWebResultJson.ToBoundaryJson(result.TypedCached),
-            ResponsesWebSubstituteToolExecutionResult.ResultOneofCase.TypedError => ResponsesWebResultJson.ToBoundaryJson(result.TypedError),
-            ResponsesWebSubstituteToolExecutionResult.ResultOneofCase.TypedSearch => ResponsesWebResultJson.ToBoundaryJson(result.TypedSearch),
+            ResponsesWebSubstituteToolExecutionResult.ResultOneofCase.TypedCached => ResponsesWebResultBoundaryJson.ToBoundaryJson(result.TypedCached),
+            ResponsesWebSubstituteToolExecutionResult.ResultOneofCase.TypedError => ResponsesWebResultBoundaryJson.ToBoundaryJson(result.TypedError),
+            ResponsesWebSubstituteToolExecutionResult.ResultOneofCase.TypedSearch => ResponsesWebResultBoundaryJson.ToBoundaryJson(result.TypedSearch),
             ResponsesWebSubstituteToolExecutionResult.ResultOneofCase.Cached => ToBoundaryJson(result.Cached),
             ResponsesWebSubstituteToolExecutionResult.ResultOneofCase.Error => ToBoundaryJson(result.Error),
-            ResponsesWebSubstituteToolExecutionResult.ResultOneofCase.Fetch => ResponsesWebResultJson.ToBoundaryJson(result.Fetch),
+            ResponsesWebSubstituteToolExecutionResult.ResultOneofCase.Fetch => ResponsesWebResultBoundaryJson.ToBoundaryJson(result.Fetch),
             ResponsesWebSubstituteToolExecutionResult.ResultOneofCase.Search => ToBoundaryJson(result.Search),
             _ => "{}",
         };

--- a/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesWebSubstituteToolJson.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesWebSubstituteToolJson.cs
@@ -30,6 +30,9 @@ internal static class ResponsesWebSubstituteToolJson
         };
     }
 
+    // Refactor (iter161-cluster-001 #1251-first):
+    //   Old pattern: shared Abstractions rendered Web result JSON before Host boundary handling.
+    //   New principle: Host owns final external JSON rendering from typed Web result branches.
     public static string ToBoundaryJson(ResponsesWebSubstituteToolExecutionResult result) =>
         result.ResultCase switch
         {

--- a/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesWebSubstituteToolJson.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesWebSubstituteToolJson.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Responses;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 
@@ -32,24 +33,15 @@ internal static class ResponsesWebSubstituteToolJson
     public static string ToBoundaryJson(ResponsesWebSubstituteToolExecutionResult result) =>
         result.ResultCase switch
         {
+            ResponsesWebSubstituteToolExecutionResult.ResultOneofCase.TypedCached => ResponsesWebResultJson.ToBoundaryJson(result.TypedCached),
+            ResponsesWebSubstituteToolExecutionResult.ResultOneofCase.TypedError => ResponsesWebResultJson.ToBoundaryJson(result.TypedError),
+            ResponsesWebSubstituteToolExecutionResult.ResultOneofCase.TypedSearch => ResponsesWebResultJson.ToBoundaryJson(result.TypedSearch),
             ResponsesWebSubstituteToolExecutionResult.ResultOneofCase.Cached => ToBoundaryJson(result.Cached),
             ResponsesWebSubstituteToolExecutionResult.ResultOneofCase.Error => ToBoundaryJson(result.Error),
-            ResponsesWebSubstituteToolExecutionResult.ResultOneofCase.Fetch => ToBoundaryJson(result.Fetch),
+            ResponsesWebSubstituteToolExecutionResult.ResultOneofCase.Fetch => ResponsesWebResultJson.ToBoundaryJson(result.Fetch),
             ResponsesWebSubstituteToolExecutionResult.ResultOneofCase.Search => ToBoundaryJson(result.Search),
             _ => "{}",
         };
-
-    private static string ToBoundaryJson(ResponsesWebFetchToolOutput output)
-    {
-        var value = new Value { StructValue = new Struct() };
-        value.StructValue.Fields["url"] = Value.ForString(output.Url);
-        value.StructValue.Fields["status_code"] = Value.ForNumber(output.StatusCode);
-        value.StructValue.Fields["content_type"] = Value.ForString(output.ContentType);
-        value.StructValue.Fields["content"] = Value.ForString(output.Content);
-        if (!string.IsNullOrWhiteSpace(output.RedirectUrl))
-            value.StructValue.Fields["redirect_url"] = Value.ForString(output.RedirectUrl);
-        return ToBoundaryJson(value);
-    }
 
     private static string ToBoundaryJson(Value? value)
     {

--- a/src/platform/Aevatar.GAgentService.Abstractions/Ports/IResponsesAgentToolStateCommandPort.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Ports/IResponsesAgentToolStateCommandPort.cs
@@ -1,6 +1,4 @@
 using Aevatar.GAgentService.Abstractions.Queries;
-using Google.Protobuf.WellKnownTypes;
-
 namespace Aevatar.GAgentService.Abstractions.Ports;
 
 public interface IResponsesAgentToolStateCommandPort
@@ -30,7 +28,7 @@ public sealed record ResponsesWebTraceResult(
     string TraceId,
     string CacheKey,
     bool CacheHit,
-    Value Result);
+    ResponsesWebToolResult Result);
 
 public sealed record ResponsesWebTraceInput(
     string TraceId,
@@ -39,4 +37,4 @@ public sealed record ResponsesWebTraceInput(
     string Url,
     string Query,
     bool CacheHit,
-    Value Result);
+    ResponsesWebToolResult Result);

--- a/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
@@ -507,7 +507,7 @@ message ResponsesWebTrace {
   string url = 5;
   string query = 6;
   bool cache_hit = 7;
-  // Refactor (issue1251-first):
+  // Refactor (iter161-cluster-001 #1251-first):
   //   Old pattern: normal writes stored stable Web results in google.protobuf.Value.
   //   New principle: normal writes use typed ResponsesWebToolResult; result remains legacy read fallback only.
   google.protobuf.Value result = 8;
@@ -520,7 +520,7 @@ message ResponsesWebCacheEntry {
   string tool_name = 2;
   string url = 3;
   string query = 4;
-  // Refactor (issue1251-first):
+  // Refactor (iter161-cluster-001 #1251-first):
   //   Old pattern: cache result facts were written as google.protobuf.Value.
   //   New principle: typed_result is the write path; result is legacy read fallback only.
   google.protobuf.Value result = 5;
@@ -585,7 +585,7 @@ message ResponsesWebToolResult {
 
 message ResponsesWebSubstituteToolExecutionResult {
   oneof result {
-    // Refactor (issue1251-first):
+    // Refactor (iter161-cluster-001 #1251-first):
     //   Old pattern: cached/error/search used Value in the normal path.
     //   New principle: typed fields carry stable Responses Web result semantics; Value arms are legacy fallback only.
     google.protobuf.Value cached = 1;
@@ -658,7 +658,7 @@ message RecordResponsesWebTraceRequested {
   string url = 5;
   string query = 6;
   bool cache_hit = 7;
-  // Refactor (issue1251-first):
+  // Refactor (iter161-cluster-001 #1251-first):
   //   Old pattern: command carried normal Web result as Value.
   //   New principle: typed_result is the write path; result is legacy fallback only.
   google.protobuf.Value result = 8;

--- a/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
@@ -507,7 +507,9 @@ message ResponsesWebTrace {
   string url = 5;
   string query = 6;
   bool cache_hit = 7;
-  // Refactor (issue1251-first): Old: normal writes stored stable Web results in google.protobuf.Value. New: normal writes use typed ResponsesWebToolResult; result remains legacy read fallback only.
+  // Refactor (issue1251-first):
+  //   Old pattern: normal writes stored stable Web results in google.protobuf.Value.
+  //   New principle: normal writes use typed ResponsesWebToolResult; result remains legacy read fallback only.
   google.protobuf.Value result = 8;
   google.protobuf.Timestamp observed_at = 9;
   ResponsesWebToolResult typed_result = 10;
@@ -518,7 +520,9 @@ message ResponsesWebCacheEntry {
   string tool_name = 2;
   string url = 3;
   string query = 4;
-  // Refactor (issue1251-first): Old: cache result facts were written as google.protobuf.Value. New: typed_result is the write path; result is legacy read fallback only.
+  // Refactor (issue1251-first):
+  //   Old pattern: cache result facts were written as google.protobuf.Value.
+  //   New principle: typed_result is the write path; result is legacy read fallback only.
   google.protobuf.Value result = 5;
   google.protobuf.Timestamp cached_at = 6;
   google.protobuf.Timestamp last_hit_at = 7;
@@ -581,7 +585,9 @@ message ResponsesWebToolResult {
 
 message ResponsesWebSubstituteToolExecutionResult {
   oneof result {
-    // Refactor (issue1251-first): Old: cached/error/search used Value in the normal path. New: typed fields carry stable Responses Web result semantics; Value arms are legacy fallback only.
+    // Refactor (issue1251-first):
+    //   Old pattern: cached/error/search used Value in the normal path.
+    //   New principle: typed fields carry stable Responses Web result semantics; Value arms are legacy fallback only.
     google.protobuf.Value cached = 1;
     google.protobuf.Value error = 2;
     ResponsesWebFetchToolOutput fetch = 3;
@@ -652,7 +658,9 @@ message RecordResponsesWebTraceRequested {
   string url = 5;
   string query = 6;
   bool cache_hit = 7;
-  // Refactor (issue1251-first): Old: command carried normal Web result as Value. New: typed_result is the write path; result is legacy fallback only.
+  // Refactor (issue1251-first):
+  //   Old pattern: command carried normal Web result as Value.
+  //   New principle: typed_result is the write path; result is legacy fallback only.
   google.protobuf.Value result = 8;
   google.protobuf.Timestamp observed_at = 9;
   ResponsesWebToolResult typed_result = 10;

--- a/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
@@ -507,8 +507,10 @@ message ResponsesWebTrace {
   string url = 5;
   string query = 6;
   bool cache_hit = 7;
+  // Refactor (issue1251-first): Old: normal writes stored stable Web results in google.protobuf.Value. New: normal writes use typed ResponsesWebToolResult; result remains legacy read fallback only.
   google.protobuf.Value result = 8;
   google.protobuf.Timestamp observed_at = 9;
+  ResponsesWebToolResult typed_result = 10;
 }
 
 message ResponsesWebCacheEntry {
@@ -516,10 +518,12 @@ message ResponsesWebCacheEntry {
   string tool_name = 2;
   string url = 3;
   string query = 4;
+  // Refactor (issue1251-first): Old: cache result facts were written as google.protobuf.Value. New: typed_result is the write path; result is legacy read fallback only.
   google.protobuf.Value result = 5;
   google.protobuf.Timestamp cached_at = 6;
   google.protobuf.Timestamp last_hit_at = 7;
   int64 hit_count = 8;
+  ResponsesWebToolResult typed_result = 9;
 }
 
 message ResponsesWebFetchToolInput {
@@ -552,12 +556,39 @@ message ResponsesWebFetchToolOutput {
   string redirect_url = 5;
 }
 
+message ResponsesWebSearchResultItem {
+  string title = 1;
+  string url = 2;
+  string snippet = 3;
+}
+
+message ResponsesWebSearchToolOutput {
+  repeated ResponsesWebSearchResultItem results = 1;
+}
+
+message ResponsesWebToolError {
+  string code = 1;
+  string message = 2;
+}
+
+message ResponsesWebToolResult {
+  oneof result {
+    ResponsesWebFetchToolOutput fetch = 1;
+    ResponsesWebSearchToolOutput search = 2;
+    ResponsesWebToolError error = 3;
+  }
+}
+
 message ResponsesWebSubstituteToolExecutionResult {
   oneof result {
+    // Refactor (issue1251-first): Old: cached/error/search used Value in the normal path. New: typed fields carry stable Responses Web result semantics; Value arms are legacy fallback only.
     google.protobuf.Value cached = 1;
     google.protobuf.Value error = 2;
     ResponsesWebFetchToolOutput fetch = 3;
     google.protobuf.Value search = 4;
+    ResponsesWebToolResult typed_cached = 5;
+    ResponsesWebToolError typed_error = 6;
+    ResponsesWebSearchToolOutput typed_search = 7;
   }
 }
 
@@ -621,8 +652,10 @@ message RecordResponsesWebTraceRequested {
   string url = 5;
   string query = 6;
   bool cache_hit = 7;
+  // Refactor (issue1251-first): Old: command carried normal Web result as Value. New: typed_result is the write path; result is legacy fallback only.
   google.protobuf.Value result = 8;
   google.protobuf.Timestamp observed_at = 9;
+  ResponsesWebToolResult typed_result = 10;
 }
 
 message ResponsesWebTraceRecordedEvent {

--- a/src/platform/Aevatar.GAgentService.Abstractions/Queries/ResponsesAgentToolStateSnapshot.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Queries/ResponsesAgentToolStateSnapshot.cs
@@ -1,5 +1,3 @@
-using Google.Protobuf.WellKnownTypes;
-
 namespace Aevatar.GAgentService.Abstractions.Queries;
 
 public sealed record ResponsesAgentToolStateSnapshot(
@@ -41,6 +39,7 @@ public sealed record ResponsesWebTraceSnapshot(
     string Url,
     string Query,
     bool CacheHit,
+    ResponsesWebToolResult Result,
     string ResultJson,
     DateTimeOffset ObservedAt);
 
@@ -49,7 +48,7 @@ public sealed record ResponsesWebCacheEntrySnapshot(
     string ToolName,
     string Url,
     string Query,
-    Value Result,
+    ResponsesWebToolResult Result,
     DateTimeOffset CachedAt,
     DateTimeOffset? LastHitAt,
     long HitCount);

--- a/src/platform/Aevatar.GAgentService.Abstractions/Queries/ResponsesAgentToolStateSnapshot.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Queries/ResponsesAgentToolStateSnapshot.cs
@@ -40,7 +40,6 @@ public sealed record ResponsesWebTraceSnapshot(
     string Query,
     bool CacheHit,
     ResponsesWebToolResult Result,
-    string ResultJson,
     DateTimeOffset ObservedAt);
 
 public sealed record ResponsesWebCacheEntrySnapshot(

--- a/src/platform/Aevatar.GAgentService.Abstractions/Responses/ResponsesWebResultJson.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Responses/ResponsesWebResultJson.cs
@@ -1,0 +1,216 @@
+using System.Text.Json;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgentService.Abstractions.Responses;
+
+public static class ResponsesWebResultJson
+{
+    private static readonly JsonFormatter Formatter = new(new JsonFormatter.Settings(formatDefaultValues: false));
+
+    public static ResponsesWebToolResult FromFetch(ResponsesWebFetchToolOutput output) =>
+        new()
+        {
+            Fetch = output.Clone(),
+        };
+
+    public static ResponsesWebToolResult FromSearch(ResponsesWebSearchToolOutput output) =>
+        new()
+        {
+            Search = output.Clone(),
+        };
+
+    public static ResponsesWebToolResult FromError(string code, string message = "") =>
+        new()
+        {
+            Error = new ResponsesWebToolError
+            {
+                Code = code,
+                Message = message,
+            },
+        };
+
+    public static ResponsesWebToolResult FromLegacyValue(Value? value)
+    {
+        if (value == null || value.KindCase == Value.KindOneofCase.None)
+            return new ResponsesWebToolResult();
+
+        if (value.KindCase != Value.KindOneofCase.StructValue)
+            return FromError("legacy_value_result", ToBoundaryJson(value));
+
+        var fields = value.StructValue.Fields;
+        if (fields.TryGetValue("results", out var results) &&
+            results.KindCase == Value.KindOneofCase.ListValue)
+        {
+            return FromSearch(new ResponsesWebSearchToolOutput
+            {
+                Results =
+                {
+                    results.ListValue.Values
+                        .Where(static item => item.KindCase == Value.KindOneofCase.StructValue)
+                        .Select(static item => new ResponsesWebSearchResultItem
+                        {
+                            Title = ReadString(item.StructValue.Fields, "title"),
+                            Url = ReadString(item.StructValue.Fields, "url"),
+                            Snippet = ReadString(item.StructValue.Fields, "snippet"),
+                        }),
+                },
+            });
+        }
+
+        if (fields.TryGetValue("error", out var error))
+            return FromError(ReadValueAsString(error), ReadValueAsString(error));
+
+        if (fields.ContainsKey("url") ||
+            fields.ContainsKey("status_code") ||
+            fields.ContainsKey("content") ||
+            fields.ContainsKey("content_type"))
+        {
+            return FromFetch(new ResponsesWebFetchToolOutput
+            {
+                Url = ReadString(fields, "url"),
+                StatusCode = ReadInt32(fields, "status_code"),
+                ContentType = ReadString(fields, "content_type"),
+                Content = ReadString(fields, "content"),
+                RedirectUrl = ReadString(fields, "redirect_url"),
+            });
+        }
+
+        return FromError("legacy_value_result", ToBoundaryJson(value));
+    }
+
+    public static string ToBoundaryJson(ResponsesWebToolResult? result)
+    {
+        if (result == null)
+            return "{}";
+
+        return result.ResultCase switch
+        {
+            ResponsesWebToolResult.ResultOneofCase.Fetch => ToBoundaryJson(result.Fetch),
+            ResponsesWebToolResult.ResultOneofCase.Search => ToBoundaryJson(result.Search),
+            ResponsesWebToolResult.ResultOneofCase.Error => ToBoundaryJson(result.Error),
+            _ => "{}",
+        };
+    }
+
+    public static string ToBoundaryJson(ResponsesWebFetchToolOutput? output)
+    {
+        var fields = new Dictionary<string, object?>
+        {
+            ["url"] = output?.Url ?? string.Empty,
+            ["status_code"] = output?.StatusCode ?? 0,
+            ["content_type"] = output?.ContentType ?? string.Empty,
+            ["content"] = output?.Content ?? string.Empty,
+        };
+        if (!string.IsNullOrWhiteSpace(output?.RedirectUrl))
+            fields["redirect_url"] = output.RedirectUrl;
+
+        return JsonSerializer.Serialize(fields);
+    }
+
+    public static string ToBoundaryJson(ResponsesWebSearchToolOutput? output) =>
+        JsonSerializer.Serialize(new
+        {
+            results = (output?.Results ?? Enumerable.Empty<ResponsesWebSearchResultItem>())
+                .Select(static item => new
+                {
+                    title = item.Title,
+                    url = item.Url,
+                    snippet = item.Snippet,
+                }),
+        });
+
+    public static string ToBoundaryJson(ResponsesWebToolError? error) =>
+        JsonSerializer.Serialize(new
+        {
+            error = error?.Code ?? string.Empty,
+            message = error?.Message ?? string.Empty,
+        });
+
+    public static Value ToLegacyValue(ResponsesWebToolResult? result)
+    {
+        if (result == null)
+            return new Value();
+
+        return result.ResultCase switch
+        {
+            ResponsesWebToolResult.ResultOneofCase.Fetch => ToLegacyValue(result.Fetch),
+            ResponsesWebToolResult.ResultOneofCase.Search => ToLegacyValue(result.Search),
+            ResponsesWebToolResult.ResultOneofCase.Error => ToLegacyValue(result.Error),
+            _ => new Value(),
+        };
+    }
+
+    private static Value ToLegacyValue(ResponsesWebFetchToolOutput? output)
+    {
+        if (output == null)
+            return new Value();
+
+        var value = new Value { StructValue = new Struct() };
+        value.StructValue.Fields["url"] = Value.ForString(output.Url ?? string.Empty);
+        value.StructValue.Fields["status_code"] = Value.ForNumber(output.StatusCode);
+        value.StructValue.Fields["content_type"] = Value.ForString(output.ContentType ?? string.Empty);
+        value.StructValue.Fields["content"] = Value.ForString(output.Content ?? string.Empty);
+        if (!string.IsNullOrWhiteSpace(output.RedirectUrl))
+            value.StructValue.Fields["redirect_url"] = Value.ForString(output.RedirectUrl);
+        return value;
+    }
+
+    private static Value ToLegacyValue(ResponsesWebSearchToolOutput? output)
+    {
+        var value = new Value { StructValue = new Struct() };
+        var results = new ListValue();
+        foreach (var item in output?.Results ?? Enumerable.Empty<ResponsesWebSearchResultItem>())
+        {
+            var itemValue = new Value { StructValue = new Struct() };
+            itemValue.StructValue.Fields["title"] = Value.ForString(item.Title ?? string.Empty);
+            itemValue.StructValue.Fields["url"] = Value.ForString(item.Url ?? string.Empty);
+            itemValue.StructValue.Fields["snippet"] = Value.ForString(item.Snippet ?? string.Empty);
+            results.Values.Add(itemValue);
+        }
+
+        value.StructValue.Fields["results"] = new Value { ListValue = results };
+        return value;
+    }
+
+    private static Value ToLegacyValue(ResponsesWebToolError? error)
+    {
+        if (error == null)
+            return new Value();
+
+        var value = new Value { StructValue = new Struct() };
+        value.StructValue.Fields["error"] = Value.ForString(error.Code ?? string.Empty);
+        if (!string.IsNullOrWhiteSpace(error.Message))
+            value.StructValue.Fields["message"] = Value.ForString(error.Message);
+        return value;
+    }
+
+    private static string ToBoundaryJson(Value value)
+    {
+        using var document = JsonDocument.Parse(Formatter.Format(value));
+        return JsonSerializer.Serialize(document.RootElement);
+    }
+
+    private static string ReadString(IDictionary<string, Value> fields, string name) =>
+        fields.TryGetValue(name, out var value) ? ReadValueAsString(value) : string.Empty;
+
+    private static int ReadInt32(IDictionary<string, Value> fields, string name)
+    {
+        if (!fields.TryGetValue(name, out var value))
+            return 0;
+
+        return value.KindCase == Value.KindOneofCase.NumberValue
+            ? (int)value.NumberValue
+            : 0;
+    }
+
+    private static string ReadValueAsString(Value value) =>
+        value.KindCase switch
+        {
+            Value.KindOneofCase.StringValue => value.StringValue,
+            Value.KindOneofCase.NumberValue => value.NumberValue.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            Value.KindOneofCase.BoolValue => value.BoolValue ? "true" : "false",
+            Value.KindOneofCase.NullValue => string.Empty,
+            _ => ToBoundaryJson(value),
+        };
+}

--- a/src/platform/Aevatar.GAgentService.Abstractions/Responses/ResponsesWebResultJson.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Responses/ResponsesWebResultJson.cs
@@ -4,7 +4,7 @@ using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.GAgentService.Abstractions.Responses;
 
-// Refactor (issue1251-first):
+// Refactor (iter161-cluster-001 #1251-first):
 //   Old pattern: Responses Web fetch/search/error results moved through google.protobuf.Value
 //   as the normal internal contract, so actor state, cache, readmodels, and Host JSON each
 //   interpreted the same untyped payload shape.
@@ -37,7 +37,7 @@ public static class ResponsesWebResultJson
             },
         };
 
-    // Refactor (issue1251-first):
+    // Refactor (iter161-cluster-001 #1251-first):
     //   Old pattern: query snapshots exposed legacy google.protobuf.Value directly.
     //   New principle: old readmodels are lifted into typed ResponsesWebToolResult before
     //   leaving the projection query boundary.
@@ -90,7 +90,7 @@ public static class ResponsesWebResultJson
         return FromError("legacy_value_result", ToBoundaryJson(value));
     }
 
-    // Refactor (issue1251-first):
+    // Refactor (iter161-cluster-001 #1251-first):
     //   Old pattern: Host-facing JSON was assembled from whichever untyped Value branch
     //   happened to be present.
     //   New principle: boundary JSON is rendered from typed ResponsesWebToolResult, with
@@ -143,7 +143,7 @@ public static class ResponsesWebResultJson
             message = error?.Message ?? string.Empty,
         });
 
-    // Refactor (issue1251-first):
+    // Refactor (iter161-cluster-001 #1251-first):
     //   Old pattern: normal writes persisted stable Web result semantics as Value.
     //   New principle: writes carry typed ResponsesWebToolResult; Value is emitted only
     //   for legacy storage/readmodel compatibility during the migration slice.

--- a/src/platform/Aevatar.GAgentService.Abstractions/Responses/ResponsesWebResultJson.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Responses/ResponsesWebResultJson.cs
@@ -1,5 +1,3 @@
-using System.Text.Json;
-using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.GAgentService.Abstractions.Responses;
@@ -8,13 +6,10 @@ namespace Aevatar.GAgentService.Abstractions.Responses;
 //   Old pattern: Responses Web fetch/search/error results moved through google.protobuf.Value
 //   as the normal internal contract, so actor state, cache, readmodels, and Host JSON each
 //   interpreted the same untyped payload shape.
-//   New principle: ResponsesWebToolResult is the typed internal contract; this boundary
-//   utility intentionally keeps the three transition duties together while the old Value
-//   surface remains only for legacy readmodel fallback and external JSON formatting.
+//   New principle: ResponsesWebToolResult is the typed internal contract; this migration
+//   utility only bridges legacy Value payloads to and from the typed contract.
 public static class ResponsesWebResultJson
 {
-    private static readonly JsonFormatter Formatter = new(new JsonFormatter.Settings(formatDefaultValues: false));
-
     public static ResponsesWebToolResult FromFetch(ResponsesWebFetchToolOutput output) =>
         new()
         {
@@ -47,7 +42,7 @@ public static class ResponsesWebResultJson
             return new ResponsesWebToolResult();
 
         if (value.KindCase != Value.KindOneofCase.StructValue)
-            return FromError("legacy_value_result", ToBoundaryJson(value));
+            return FromError("legacy_value_result", ReadValueAsString(value));
 
         var fields = value.StructValue.Fields;
         if (fields.TryGetValue("results", out var results) &&
@@ -87,61 +82,8 @@ public static class ResponsesWebResultJson
             });
         }
 
-        return FromError("legacy_value_result", ToBoundaryJson(value));
+        return FromError("legacy_value_result", "unsupported legacy result value");
     }
-
-    // Refactor (iter161-cluster-001 #1251-first):
-    //   Old pattern: Host-facing JSON was assembled from whichever untyped Value branch
-    //   happened to be present.
-    //   New principle: boundary JSON is rendered from typed ResponsesWebToolResult, with
-    //   legacy Value formatting confined to explicit fallback conversion.
-    public static string ToBoundaryJson(ResponsesWebToolResult? result)
-    {
-        if (result == null)
-            return "{}";
-
-        return result.ResultCase switch
-        {
-            ResponsesWebToolResult.ResultOneofCase.Fetch => ToBoundaryJson(result.Fetch),
-            ResponsesWebToolResult.ResultOneofCase.Search => ToBoundaryJson(result.Search),
-            ResponsesWebToolResult.ResultOneofCase.Error => ToBoundaryJson(result.Error),
-            _ => "{}",
-        };
-    }
-
-    public static string ToBoundaryJson(ResponsesWebFetchToolOutput? output)
-    {
-        var fields = new Dictionary<string, object?>
-        {
-            ["url"] = output?.Url ?? string.Empty,
-            ["status_code"] = output?.StatusCode ?? 0,
-            ["content_type"] = output?.ContentType ?? string.Empty,
-            ["content"] = output?.Content ?? string.Empty,
-        };
-        if (!string.IsNullOrWhiteSpace(output?.RedirectUrl))
-            fields["redirect_url"] = output.RedirectUrl;
-
-        return JsonSerializer.Serialize(fields);
-    }
-
-    public static string ToBoundaryJson(ResponsesWebSearchToolOutput? output) =>
-        JsonSerializer.Serialize(new
-        {
-            results = (output?.Results ?? Enumerable.Empty<ResponsesWebSearchResultItem>())
-                .Select(static item => new
-                {
-                    title = item.Title,
-                    url = item.Url,
-                    snippet = item.Snippet,
-                }),
-        });
-
-    public static string ToBoundaryJson(ResponsesWebToolError? error) =>
-        JsonSerializer.Serialize(new
-        {
-            error = error?.Code ?? string.Empty,
-            message = error?.Message ?? string.Empty,
-        });
 
     // Refactor (iter161-cluster-001 #1251-first):
     //   Old pattern: normal writes persisted stable Web result semantics as Value.
@@ -205,12 +147,6 @@ public static class ResponsesWebResultJson
         return value;
     }
 
-    private static string ToBoundaryJson(Value value)
-    {
-        using var document = JsonDocument.Parse(Formatter.Format(value));
-        return JsonSerializer.Serialize(document.RootElement);
-    }
-
     private static string ReadString(IDictionary<string, Value> fields, string name) =>
         fields.TryGetValue(name, out var value) ? ReadValueAsString(value) : string.Empty;
 
@@ -231,6 +167,6 @@ public static class ResponsesWebResultJson
             Value.KindOneofCase.NumberValue => value.NumberValue.ToString(System.Globalization.CultureInfo.InvariantCulture),
             Value.KindOneofCase.BoolValue => value.BoolValue ? "true" : "false",
             Value.KindOneofCase.NullValue => string.Empty,
-            _ => ToBoundaryJson(value),
+            _ => "unsupported legacy result value",
         };
 }

--- a/src/platform/Aevatar.GAgentService.Abstractions/Responses/ResponsesWebResultJson.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Responses/ResponsesWebResultJson.cs
@@ -4,6 +4,13 @@ using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.GAgentService.Abstractions.Responses;
 
+// Refactor (issue1251-first):
+//   Old pattern: Responses Web fetch/search/error results moved through google.protobuf.Value
+//   as the normal internal contract, so actor state, cache, readmodels, and Host JSON each
+//   interpreted the same untyped payload shape.
+//   New principle: ResponsesWebToolResult is the typed internal contract; this boundary
+//   utility intentionally keeps the three transition duties together while the old Value
+//   surface remains only for legacy readmodel fallback and external JSON formatting.
 public static class ResponsesWebResultJson
 {
     private static readonly JsonFormatter Formatter = new(new JsonFormatter.Settings(formatDefaultValues: false));
@@ -30,6 +37,10 @@ public static class ResponsesWebResultJson
             },
         };
 
+    // Refactor (issue1251-first):
+    //   Old pattern: query snapshots exposed legacy google.protobuf.Value directly.
+    //   New principle: old readmodels are lifted into typed ResponsesWebToolResult before
+    //   leaving the projection query boundary.
     public static ResponsesWebToolResult FromLegacyValue(Value? value)
     {
         if (value == null || value.KindCase == Value.KindOneofCase.None)
@@ -79,6 +90,11 @@ public static class ResponsesWebResultJson
         return FromError("legacy_value_result", ToBoundaryJson(value));
     }
 
+    // Refactor (issue1251-first):
+    //   Old pattern: Host-facing JSON was assembled from whichever untyped Value branch
+    //   happened to be present.
+    //   New principle: boundary JSON is rendered from typed ResponsesWebToolResult, with
+    //   legacy Value formatting confined to explicit fallback conversion.
     public static string ToBoundaryJson(ResponsesWebToolResult? result)
     {
         if (result == null)
@@ -127,6 +143,10 @@ public static class ResponsesWebResultJson
             message = error?.Message ?? string.Empty,
         });
 
+    // Refactor (issue1251-first):
+    //   Old pattern: normal writes persisted stable Web result semantics as Value.
+    //   New principle: writes carry typed ResponsesWebToolResult; Value is emitted only
+    //   for legacy storage/readmodel compatibility during the migration slice.
     public static Value ToLegacyValue(ResponsesWebToolResult? result)
     {
         if (result == null)

--- a/src/platform/Aevatar.GAgentService.Abstractions/Responses/ResponsesWebResultMigration.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Responses/ResponsesWebResultMigration.cs
@@ -8,7 +8,7 @@ namespace Aevatar.GAgentService.Abstractions.Responses;
 //   interpreted the same untyped payload shape.
 //   New principle: ResponsesWebToolResult is the typed internal contract; this migration
 //   utility only bridges legacy Value payloads to and from the typed contract.
-public static class ResponsesWebResultJson
+public static class ResponsesWebResultMigration
 {
     public static ResponsesWebToolResult FromFetch(ResponsesWebFetchToolOutput output) =>
         new()

--- a/src/platform/Aevatar.GAgentService.Application/Responses/IResponsesWebSubstituteBackend.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/IResponsesWebSubstituteBackend.cs
@@ -36,5 +36,8 @@ public sealed record ResponsesWebSearchBoundaryInput(
     int MaxResults,
     string NyxIdAccessToken);
 
+// Refactor (iter161-cluster-001 #1251-first):
+//   Old pattern: Host returned untyped provider Value for Application to interpret.
+//   New principle: Host returns the Responses-owned typed Web search output.
 public sealed record ResponsesWebSearchBoundaryResult(
     ResponsesWebSearchToolOutput Output);

--- a/src/platform/Aevatar.GAgentService.Application/Responses/IResponsesWebSubstituteBackend.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/IResponsesWebSubstituteBackend.cs
@@ -1,3 +1,5 @@
+using Aevatar.GAgentService.Abstractions;
+
 namespace Aevatar.GAgentService.Application.Responses;
 
 // Refactor (iter159/cluster-1215):
@@ -35,4 +37,4 @@ public sealed record ResponsesWebSearchBoundaryInput(
     string NyxIdAccessToken);
 
 public sealed record ResponsesWebSearchBoundaryResult(
-    Google.Protobuf.WellKnownTypes.Value Value);
+    ResponsesWebSearchToolOutput Output);

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesWebSubstituteToolExecutionService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesWebSubstituteToolExecutionService.cs
@@ -91,7 +91,7 @@ public sealed class ResponsesWebSubstituteToolExecutionService
             Content = output.Content,
             RedirectUrl = output.RedirectUrl,
         };
-        var typedOutput = ResponsesWebResultJson.FromFetch(protoOutput);
+        var typedOutput = ResponsesWebResultMigration.FromFetch(protoOutput);
         await RecordTraceAsync(
             request,
             cacheKey,
@@ -143,7 +143,7 @@ public sealed class ResponsesWebSubstituteToolExecutionService
 
         if (string.IsNullOrWhiteSpace(request.NyxIdAccessToken))
         {
-            var authError = ResponsesWebResultJson.FromError(
+            var authError = ResponsesWebResultMigration.FromError(
                 "auth_required",
                 "No NyxID access token available. User must be authenticated.");
             await RecordTraceAsync(
@@ -162,7 +162,7 @@ public sealed class ResponsesWebSubstituteToolExecutionService
                     maxResults,
                     request.NyxIdAccessToken),
                 ct).ConfigureAwait(false)).Output;
-        var typedSearchResult = ResponsesWebResultJson.FromSearch(searchResult);
+        var typedSearchResult = ResponsesWebResultMigration.FromSearch(searchResult);
         await RecordTraceAsync(
             request,
             cacheKey,
@@ -226,7 +226,7 @@ public sealed class ResponsesWebSubstituteToolExecutionService
     {
         return new ResponsesWebSubstituteToolExecutionResult
         {
-            TypedError = ResponsesWebResultJson.FromError(code).Error,
+            TypedError = ResponsesWebResultMigration.FromError(code).Error,
         };
     }
 

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesWebSubstituteToolExecutionService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesWebSubstituteToolExecutionService.cs
@@ -4,7 +4,7 @@ using System.Net;
 using System.Net.Sockets;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
-using Google.Protobuf.WellKnownTypes;
+using Aevatar.GAgentService.Abstractions.Responses;
 
 namespace Aevatar.GAgentService.Application.Responses;
 
@@ -53,6 +53,7 @@ public sealed class ResponsesWebSubstituteToolExecutionService
 
         var url = validation.NormalizedUrl!;
         var cacheKey = ComputeCacheKey(request.ToolName, url);
+        // Refactor (issue1251-first): Old: fetch trace/cache result was downgraded to Value before recording. New: trace/cache normal writes carry typed ResponsesWebToolResult.
         var cached = await _queryPort.GetWebCacheEntryAsync(
             request.ScopeId,
             request.OwnerSubject,
@@ -71,7 +72,7 @@ public sealed class ResponsesWebSubstituteToolExecutionService
                 ct).ConfigureAwait(false);
             return new ResponsesWebSubstituteToolExecutionResult
             {
-                Cached = cached.Result.Clone(),
+                TypedCached = cached.Result.Clone(),
             };
         }
 
@@ -88,14 +89,14 @@ public sealed class ResponsesWebSubstituteToolExecutionService
             Content = output.Content,
             RedirectUrl = output.RedirectUrl,
         };
-        var outputValue = ToValue(protoOutput);
+        var typedOutput = ResponsesWebResultJson.FromFetch(protoOutput);
         await RecordTraceAsync(
             request,
             cacheKey,
             url,
             query: string.Empty,
             cacheHit: false,
-            outputValue,
+            typedOutput,
             ct).ConfigureAwait(false);
         return new ResponsesWebSubstituteToolExecutionResult { Fetch = protoOutput };
     }
@@ -114,6 +115,7 @@ public sealed class ResponsesWebSubstituteToolExecutionService
         maxResults = Math.Clamp(maxResults, 1, 20);
         var cacheValue = $"{query.Trim()}\n{maxResults}";
         var cacheKey = ComputeCacheKey(request.ToolName, cacheValue);
+        // Refactor (issue1251-first): Old: search/error trace/cache results were written as Value. New: typed search/error results are written through the existing command->actor->projection chain.
         var cached = await _queryPort.GetWebCacheEntryAsync(
             request.ScopeId,
             request.OwnerSubject,
@@ -131,26 +133,40 @@ public sealed class ResponsesWebSubstituteToolExecutionService
                 ct).ConfigureAwait(false);
             return new ResponsesWebSubstituteToolExecutionResult
             {
-                Cached = cached.Result.Clone(),
+                TypedCached = cached.Result.Clone(),
             };
         }
 
-        var searchResult = string.IsNullOrWhiteSpace(request.NyxIdAccessToken)
-            ? ErrorValue("No NyxID access token available. User must be authenticated.")
-            : (await _backend.ExecuteWebSearchAsync(
+        if (string.IsNullOrWhiteSpace(request.NyxIdAccessToken))
+        {
+            var authError = ResponsesWebResultJson.FromError(
+                "auth_required",
+                "No NyxID access token available. User must be authenticated.");
+            await RecordTraceAsync(
+                request,
+                cacheKey,
+                query,
+                cacheHit: false,
+                authError,
+                ct).ConfigureAwait(false);
+            return new ResponsesWebSubstituteToolExecutionResult { TypedError = authError.Error.Clone() };
+        }
+
+        var searchResult = (await _backend.ExecuteWebSearchAsync(
                 new ResponsesWebSearchBoundaryInput(
                     query.Trim(),
                     maxResults,
                     request.NyxIdAccessToken),
-                ct).ConfigureAwait(false)).Value;
+                ct).ConfigureAwait(false)).Output;
+        var typedSearchResult = ResponsesWebResultJson.FromSearch(searchResult);
         await RecordTraceAsync(
             request,
             cacheKey,
             query,
             cacheHit: false,
-            searchResult,
+            typedSearchResult,
             ct).ConfigureAwait(false);
-        return new ResponsesWebSubstituteToolExecutionResult { Search = searchResult };
+        return new ResponsesWebSubstituteToolExecutionResult { TypedSearch = searchResult };
     }
 
     private Task RecordTraceAsync(
@@ -159,7 +175,7 @@ public sealed class ResponsesWebSubstituteToolExecutionService
         string url,
         string query,
         bool cacheHit,
-        Value result,
+        ResponsesWebToolResult result,
         CancellationToken ct) =>
         _commandPort.RecordWebTraceAsync(
             request.ScopeId,
@@ -180,7 +196,7 @@ public sealed class ResponsesWebSubstituteToolExecutionService
         string cacheKey,
         string query,
         bool cacheHit,
-        Value result,
+        ResponsesWebToolResult result,
         CancellationToken ct) =>
         RecordTraceAsync(request, cacheKey, url: string.Empty, query, cacheHit, result, ct);
 
@@ -204,26 +220,10 @@ public sealed class ResponsesWebSubstituteToolExecutionService
 
     private static ResponsesWebSubstituteToolExecutionResult Error(string code)
     {
-        return new ResponsesWebSubstituteToolExecutionResult { Error = ErrorValue(code) };
-    }
-
-    private static Value ErrorValue(string code)
-    {
-        var error = new Value { StructValue = new Struct() };
-        error.StructValue.Fields["error"] = Value.ForString(code);
-        return error;
-    }
-
-    private static Value ToValue(ResponsesWebFetchToolOutput output)
-    {
-        var value = new Value { StructValue = new Struct() };
-        value.StructValue.Fields["url"] = Value.ForString(output.Url);
-        value.StructValue.Fields["status_code"] = Value.ForNumber(output.StatusCode);
-        value.StructValue.Fields["content_type"] = Value.ForString(output.ContentType);
-        value.StructValue.Fields["content"] = Value.ForString(output.Content);
-        if (!string.IsNullOrWhiteSpace(output.RedirectUrl))
-            value.StructValue.Fields["redirect_url"] = Value.ForString(output.RedirectUrl);
-        return value;
+        return new ResponsesWebSubstituteToolExecutionResult
+        {
+            TypedError = ResponsesWebResultJson.FromError(code).Error,
+        };
     }
 
     private static class ResponsesWebFetchUrlGuard

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesWebSubstituteToolExecutionService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesWebSubstituteToolExecutionService.cs
@@ -53,7 +53,9 @@ public sealed class ResponsesWebSubstituteToolExecutionService
 
         var url = validation.NormalizedUrl!;
         var cacheKey = ComputeCacheKey(request.ToolName, url);
-        // Refactor (issue1251-first): Old: fetch trace/cache result was downgraded to Value before recording. New: trace/cache normal writes carry typed ResponsesWebToolResult.
+        // Refactor (iter161-cluster-001 #1251-first):
+        //   Old pattern: fetch trace/cache result was downgraded to Value before recording.
+        //   New principle: trace/cache normal writes carry typed ResponsesWebToolResult.
         var cached = await _queryPort.GetWebCacheEntryAsync(
             request.ScopeId,
             request.OwnerSubject,
@@ -115,7 +117,9 @@ public sealed class ResponsesWebSubstituteToolExecutionService
         maxResults = Math.Clamp(maxResults, 1, 20);
         var cacheValue = $"{query.Trim()}\n{maxResults}";
         var cacheKey = ComputeCacheKey(request.ToolName, cacheValue);
-        // Refactor (issue1251-first): Old: search/error trace/cache results were written as Value. New: typed search/error results are written through the existing command->actor->projection chain.
+        // Refactor (iter161-cluster-001 #1251-first):
+        //   Old pattern: search/error trace/cache results were written as Value.
+        //   New principle: typed search/error results are written through the existing command->actor->projection chain.
         var cached = await _queryPort.GetWebCacheEntryAsync(
             request.ScopeId,
             request.OwnerSubject,

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/ResponsesAgentToolStateGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/ResponsesAgentToolStateGAgent.cs
@@ -108,7 +108,7 @@ public sealed class ResponsesAgentToolStateGAgent : GAgentBase<ResponsesAgentToo
             // Refactor (iter161-cluster-001 #1251-first):
             //   Old pattern: typed result writes left legacy Value empty.
             //   New principle: typed remains primary and Value is retained as readmodel fallback.
-            Result = command.Result?.Clone() ?? ResponsesWebResultJson.ToLegacyValue(command.TypedResult),
+            Result = command.Result?.Clone() ?? ResponsesWebResultMigration.ToLegacyValue(command.TypedResult),
             TypedResult = command.TypedResult?.Clone(),
             ObservedAt = observedAt,
         };

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/ResponsesAgentToolStateGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/ResponsesAgentToolStateGAgent.cs
@@ -105,7 +105,9 @@ public sealed class ResponsesAgentToolStateGAgent : GAgentBase<ResponsesAgentToo
             Url = NormalizeOptional(command.Url) ?? string.Empty,
             Query = NormalizeOptional(command.Query) ?? string.Empty,
             CacheHit = command.CacheHit,
-            // Refactor (issue1251-first-r2): Old: typed result writes left legacy Value empty. New: typed remains primary and Value is retained as readmodel fallback.
+            // Refactor (iter161-cluster-001 #1251-first):
+            //   Old pattern: typed result writes left legacy Value empty.
+            //   New principle: typed remains primary and Value is retained as readmodel fallback.
             Result = command.Result?.Clone() ?? ResponsesWebResultJson.ToLegacyValue(command.TypedResult),
             TypedResult = command.TypedResult?.Clone(),
             ObservedAt = observedAt,

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/ResponsesAgentToolStateGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/ResponsesAgentToolStateGAgent.cs
@@ -2,6 +2,7 @@ using Aevatar.Foundation.Abstractions.Attributes;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Responses;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 
@@ -104,7 +105,9 @@ public sealed class ResponsesAgentToolStateGAgent : GAgentBase<ResponsesAgentToo
             Url = NormalizeOptional(command.Url) ?? string.Empty,
             Query = NormalizeOptional(command.Query) ?? string.Empty,
             CacheHit = command.CacheHit,
-            Result = command.Result?.Clone(),
+            // Refactor (issue1251-first-r2): Old: typed result writes left legacy Value empty. New: typed remains primary and Value is retained as readmodel fallback.
+            Result = command.Result?.Clone() ?? ResponsesWebResultJson.ToLegacyValue(command.TypedResult),
+            TypedResult = command.TypedResult?.Clone(),
             ObservedAt = observedAt,
         };
         ValidateWebTrace(trace);
@@ -191,6 +194,7 @@ public sealed class ResponsesAgentToolStateGAgent : GAgentBase<ResponsesAgentToo
                 Url = trace.Url,
                 Query = trace.Query,
                 Result = trace.Result?.Clone(),
+                TypedResult = trace.TypedResult?.Clone(),
                 CachedAt = trace.ObservedAt.Clone(),
                 LastHitAt = trace.CacheHit ? trace.ObservedAt.Clone() : null,
                 HitCount = trace.CacheHit ? 1 : 0,
@@ -206,6 +210,7 @@ public sealed class ResponsesAgentToolStateGAgent : GAgentBase<ResponsesAgentToo
         }
 
         existing.Result = trace.Result?.Clone();
+        existing.TypedResult = trace.TypedResult?.Clone();
         existing.Url = trace.Url;
         existing.Query = trace.Query;
         existing.CachedAt = trace.ObservedAt.Clone();

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/ResponsesAgentToolStateCommandAdapter.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/ResponsesAgentToolStateCommandAdapter.cs
@@ -104,7 +104,7 @@ public sealed class ResponsesAgentToolStateCommandAdapter : IResponsesAgentToolS
                     // Refactor (iter161-cluster-001 #1251-first):
                     //   Old pattern: first slice stopped writing legacy Value.
                     //   New principle: keep typed result primary while writing Value as readmodel fallback.
-                    Result = ResponsesWebResultJson.ToLegacyValue(trace.Result),
+                    Result = ResponsesWebResultMigration.ToLegacyValue(trace.Result),
                     TypedResult = trace.Result.Clone(),
                     ObservedAt = Timestamp.FromDateTime(DateTime.UtcNow),
                 }),

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/ResponsesAgentToolStateCommandAdapter.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/ResponsesAgentToolStateCommandAdapter.cs
@@ -101,7 +101,9 @@ public sealed class ResponsesAgentToolStateCommandAdapter : IResponsesAgentToolS
                     Url = NormalizeOptional(trace.Url) ?? string.Empty,
                     Query = NormalizeOptional(trace.Query) ?? string.Empty,
                     CacheHit = trace.CacheHit,
-                    // Refactor (issue1251-first-r2): Old: first slice stopped writing legacy Value. New: keep typed result primary while writing Value as readmodel fallback.
+                    // Refactor (iter161-cluster-001 #1251-first):
+                    //   Old pattern: first slice stopped writing legacy Value.
+                    //   New principle: keep typed result primary while writing Value as readmodel fallback.
                     Result = ResponsesWebResultJson.ToLegacyValue(trace.Result),
                     TypedResult = trace.Result.Clone(),
                     ObservedAt = Timestamp.FromDateTime(DateTime.UtcNow),

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/ResponsesAgentToolStateCommandAdapter.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/ResponsesAgentToolStateCommandAdapter.cs
@@ -101,7 +101,9 @@ public sealed class ResponsesAgentToolStateCommandAdapter : IResponsesAgentToolS
                     Url = NormalizeOptional(trace.Url) ?? string.Empty,
                     Query = NormalizeOptional(trace.Query) ?? string.Empty,
                     CacheHit = trace.CacheHit,
-                    Result = trace.Result.Clone(),
+                    // Refactor (issue1251-first-r2): Old: first slice stopped writing legacy Value. New: keep typed result primary while writing Value as readmodel fallback.
+                    Result = ResponsesWebResultJson.ToLegacyValue(trace.Result),
+                    TypedResult = trace.Result.Clone(),
                     ObservedAt = Timestamp.FromDateTime(DateTime.UtcNow),
                 }),
                 $"{sourceResponseId}:web:{traceId}"),

--- a/src/platform/Aevatar.GAgentService.Projection/Projectors/ResponsesAgentToolStateCurrentStateProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Projectors/ResponsesAgentToolStateCurrentStateProjector.cs
@@ -83,6 +83,7 @@ public sealed class ResponsesAgentToolStateCurrentStateProjector
                 Query = trace.Query,
                 CacheHit = trace.CacheHit,
                 Result = trace.Result?.Clone(),
+                TypedResult = trace.TypedResult?.Clone(),
                 ObservedAt = trace.ObservedAt?.ToDateTimeOffset() ?? DateTimeOffset.MinValue,
             }).ToList(),
             WebCacheEntries = state.WebCacheEntries.Select(static entry => new ResponsesWebCacheEntryReadModel
@@ -92,6 +93,7 @@ public sealed class ResponsesAgentToolStateCurrentStateProjector
                 Url = entry.Url,
                 Query = entry.Query,
                 Result = entry.Result?.Clone(),
+                TypedResult = entry.TypedResult?.Clone(),
                 CachedAt = entry.CachedAt?.ToDateTimeOffset() ?? DateTimeOffset.MinValue,
                 LastHitAt = entry.LastHitAt?.ToDateTimeOffset(),
                 HitCount = entry.HitCount,

--- a/src/platform/Aevatar.GAgentService.Projection/Queries/ResponsesAgentToolStateQueryReader.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Queries/ResponsesAgentToolStateQueryReader.cs
@@ -79,7 +79,6 @@ public sealed class ResponsesAgentToolStateQueryReader : IResponsesAgentToolStat
                 trace.Query,
                 trace.CacheHit,
                 ResolveWebResult(trace.TypedResult, trace.Result),
-                ResponsesWebResultJson.ToBoundaryJson(ResolveWebResult(trace.TypedResult, trace.Result)),
                 trace.ObservedAt)).ToArray(),
             document.WebCacheEntries.Select(static entry => new ResponsesWebCacheEntrySnapshot(
                 entry.CacheKey,

--- a/src/platform/Aevatar.GAgentService.Projection/Queries/ResponsesAgentToolStateQueryReader.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Queries/ResponsesAgentToolStateQueryReader.cs
@@ -98,7 +98,9 @@ public sealed class ResponsesAgentToolStateQueryReader : IResponsesAgentToolStat
         if (typedResult != null && typedResult.ResultCase != ResponsesWebToolResult.ResultOneofCase.None)
             return typedResult.Clone();
 
-        // Refactor (issue1251-first): Old: query snapshots exposed legacy Value directly. New: typed result is primary; legacy Value is converted only for old readmodels.
+        // Refactor (iter161-cluster-001 #1251-first):
+        //   Old pattern: query snapshots exposed legacy Value directly.
+        //   New principle: typed result is primary; legacy Value is converted only for old readmodels.
         return ResponsesWebResultJson.FromLegacyValue(legacyResult);
     }
 

--- a/src/platform/Aevatar.GAgentService.Projection/Queries/ResponsesAgentToolStateQueryReader.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Queries/ResponsesAgentToolStateQueryReader.cs
@@ -100,7 +100,7 @@ public sealed class ResponsesAgentToolStateQueryReader : IResponsesAgentToolStat
         // Refactor (iter161-cluster-001 #1251-first):
         //   Old pattern: query snapshots exposed legacy Value directly.
         //   New principle: typed result is primary; legacy Value is converted only for old readmodels.
-        return ResponsesWebResultJson.FromLegacyValue(legacyResult);
+        return ResponsesWebResultMigration.FromLegacyValue(legacyResult);
     }
 
     private async Task<ResponsesAgentToolStateCurrentStateReadModel?> GetDocumentAsync(

--- a/src/platform/Aevatar.GAgentService.Projection/Queries/ResponsesAgentToolStateQueryReader.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Queries/ResponsesAgentToolStateQueryReader.cs
@@ -78,17 +78,29 @@ public sealed class ResponsesAgentToolStateQueryReader : IResponsesAgentToolStat
                 trace.Url,
                 trace.Query,
                 trace.CacheHit,
-                ResponsesJsonValues.ToBoundaryJson(trace.Result),
+                ResolveWebResult(trace.TypedResult, trace.Result),
+                ResponsesWebResultJson.ToBoundaryJson(ResolveWebResult(trace.TypedResult, trace.Result)),
                 trace.ObservedAt)).ToArray(),
             document.WebCacheEntries.Select(static entry => new ResponsesWebCacheEntrySnapshot(
                 entry.CacheKey,
                 entry.ToolName,
                 entry.Url,
                 entry.Query,
-                entry.Result.Clone(),
+                ResolveWebResult(entry.TypedResult, entry.Result),
                 entry.CachedAt,
                 entry.LastHitAt,
                 entry.HitCount)).ToArray());
+
+    private static ResponsesWebToolResult ResolveWebResult(
+        ResponsesWebToolResult? typedResult,
+        Google.Protobuf.WellKnownTypes.Value? legacyResult)
+    {
+        if (typedResult != null && typedResult.ResultCase != ResponsesWebToolResult.ResultOneofCase.None)
+            return typedResult.Clone();
+
+        // Refactor (issue1251-first): Old: query snapshots exposed legacy Value directly. New: typed result is primary; legacy Value is converted only for old readmodels.
+        return ResponsesWebResultJson.FromLegacyValue(legacyResult);
+    }
 
     private async Task<ResponsesAgentToolStateCurrentStateReadModel?> GetDocumentAsync(
         string scopeId,

--- a/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
+++ b/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
@@ -324,7 +324,7 @@ message ResponsesWebTraceReadModel {
   string url = 5;
   string query = 6;
   bool cache_hit = 7;
-  // Refactor (issue1251-first):
+  // Refactor (iter161-cluster-001 #1251-first):
   //   Old pattern: projected Web result readmodel carried only Value.
   //   New principle: typed_result mirrors actor-owned typed result; result is legacy fallback only.
   google.protobuf.Value result = 8;
@@ -337,7 +337,7 @@ message ResponsesWebCacheEntryReadModel {
   string tool_name = 2;
   string url = 3;
   string query = 4;
-  // Refactor (issue1251-first):
+  // Refactor (iter161-cluster-001 #1251-first):
   //   Old pattern: projected cache result carried only Value.
   //   New principle: typed_result is the normal query path; result is legacy fallback only.
   google.protobuf.Value result = 5;

--- a/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
+++ b/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
@@ -324,7 +324,9 @@ message ResponsesWebTraceReadModel {
   string url = 5;
   string query = 6;
   bool cache_hit = 7;
-  // Refactor (issue1251-first): Old: projected Web result readmodel carried only Value. New: typed_result mirrors actor-owned typed result; result is legacy fallback only.
+  // Refactor (issue1251-first):
+  //   Old pattern: projected Web result readmodel carried only Value.
+  //   New principle: typed_result mirrors actor-owned typed result; result is legacy fallback only.
   google.protobuf.Value result = 8;
   google.protobuf.Timestamp observed_at_utc_value = 9;
   aevatar.gagentservice.ResponsesWebToolResult typed_result = 10;
@@ -335,7 +337,9 @@ message ResponsesWebCacheEntryReadModel {
   string tool_name = 2;
   string url = 3;
   string query = 4;
-  // Refactor (issue1251-first): Old: projected cache result carried only Value. New: typed_result is the normal query path; result is legacy fallback only.
+  // Refactor (issue1251-first):
+  //   Old pattern: projected cache result carried only Value.
+  //   New principle: typed_result is the normal query path; result is legacy fallback only.
   google.protobuf.Value result = 5;
   google.protobuf.Timestamp cached_at_utc_value = 6;
   google.protobuf.Timestamp last_hit_at_utc_value = 7;

--- a/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
+++ b/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
@@ -6,6 +6,7 @@ option csharp_namespace = "Aevatar.GAgentService.Projection.ReadModels";
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/struct.proto";
+import "llm_sessions.proto";
 import "service_revision.proto";
 
 // --- ServiceCatalogReadModel ---
@@ -323,8 +324,10 @@ message ResponsesWebTraceReadModel {
   string url = 5;
   string query = 6;
   bool cache_hit = 7;
+  // Refactor (issue1251-first): Old: projected Web result readmodel carried only Value. New: typed_result mirrors actor-owned typed result; result is legacy fallback only.
   google.protobuf.Value result = 8;
   google.protobuf.Timestamp observed_at_utc_value = 9;
+  aevatar.gagentservice.ResponsesWebToolResult typed_result = 10;
 }
 
 message ResponsesWebCacheEntryReadModel {
@@ -332,8 +335,10 @@ message ResponsesWebCacheEntryReadModel {
   string tool_name = 2;
   string url = 3;
   string query = 4;
+  // Refactor (issue1251-first): Old: projected cache result carried only Value. New: typed_result is the normal query path; result is legacy fallback only.
   google.protobuf.Value result = 5;
   google.protobuf.Timestamp cached_at_utc_value = 6;
   google.protobuf.Timestamp last_hit_at_utc_value = 7;
   int64 hit_count = 8;
+  aevatar.gagentservice.ResponsesWebToolResult typed_result = 9;
 }

--- a/test/Aevatar.GAgentService.Tests/Abstractions/ResponsesWebResultJsonTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Abstractions/ResponsesWebResultJsonTests.cs
@@ -1,0 +1,135 @@
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Responses;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+using ProtoValue = Google.Protobuf.WellKnownTypes.Value;
+
+namespace Aevatar.GAgentService.Tests.Abstractions;
+
+public sealed class ResponsesWebResultJsonTests
+{
+    [Fact]
+    public void FromLegacyValue_ShouldMapFetchStruct_ToTypedFetchResult()
+    {
+        var value = new ProtoValue { StructValue = new Struct() };
+        value.StructValue.Fields["url"] = ProtoValue.ForString("https://example.com/page");
+        value.StructValue.Fields["status_code"] = ProtoValue.ForNumber(201);
+        value.StructValue.Fields["content_type"] = ProtoValue.ForString("text/html");
+        value.StructValue.Fields["content"] = ProtoValue.ForString("body");
+        value.StructValue.Fields["redirect_url"] = ProtoValue.ForString("https://example.com/final");
+
+        var result = ResponsesWebResultJson.FromLegacyValue(value);
+
+        result.ResultCase.Should().Be(ResponsesWebToolResult.ResultOneofCase.Fetch);
+        result.Fetch.Url.Should().Be("https://example.com/page");
+        result.Fetch.StatusCode.Should().Be(201);
+        result.Fetch.ContentType.Should().Be("text/html");
+        result.Fetch.Content.Should().Be("body");
+        result.Fetch.RedirectUrl.Should().Be("https://example.com/final");
+    }
+
+    [Fact]
+    public void FromLegacyValue_ShouldMapSearchStruct_ToTypedSearchResult()
+    {
+        var value = new ProtoValue { StructValue = new Struct() };
+        var results = new ListValue();
+        var first = new ProtoValue { StructValue = new Struct() };
+        first.StructValue.Fields["title"] = ProtoValue.ForString("First");
+        first.StructValue.Fields["url"] = ProtoValue.ForString("https://example.com/1");
+        first.StructValue.Fields["snippet"] = ProtoValue.ForString("Snippet");
+        results.Values.Add(first);
+        results.Values.Add(ProtoValue.ForString("ignored"));
+        value.StructValue.Fields["results"] = new ProtoValue { ListValue = results };
+
+        var result = ResponsesWebResultJson.FromLegacyValue(value);
+
+        result.ResultCase.Should().Be(ResponsesWebToolResult.ResultOneofCase.Search);
+        result.Search.Results.Should().ContainSingle();
+        result.Search.Results[0].Title.Should().Be("First");
+        result.Search.Results[0].Url.Should().Be("https://example.com/1");
+        result.Search.Results[0].Snippet.Should().Be("Snippet");
+    }
+
+    [Fact]
+    public void FromLegacyValue_ShouldMapErrorStruct_ToTypedErrorResult()
+    {
+        var value = new ProtoValue { StructValue = new Struct() };
+        value.StructValue.Fields["error"] = ProtoValue.ForString("auth_failed");
+
+        var result = ResponsesWebResultJson.FromLegacyValue(value);
+
+        result.ResultCase.Should().Be(ResponsesWebToolResult.ResultOneofCase.Error);
+        result.Error.Code.Should().Be("auth_failed");
+        result.Error.Message.Should().Be("auth_failed");
+    }
+
+    [Fact]
+    public void FromLegacyValue_ShouldMapUnknownStruct_ToLegacyValueError()
+    {
+        var value = new ProtoValue { StructValue = new Struct() };
+        value.StructValue.Fields["custom"] = ProtoValue.ForString("kept");
+
+        var result = ResponsesWebResultJson.FromLegacyValue(value);
+
+        result.ResultCase.Should().Be(ResponsesWebToolResult.ResultOneofCase.Error);
+        result.Error.Code.Should().Be("legacy_value_result");
+        result.Error.Message.Should().Be("""{"custom":"kept"}""");
+    }
+
+    [Fact]
+    public void FromLegacyValue_ShouldMapNonStructValue_ToLegacyValueError()
+    {
+        var result = ResponsesWebResultJson.FromLegacyValue(ProtoValue.ForString("plain"));
+
+        result.ResultCase.Should().Be(ResponsesWebToolResult.ResultOneofCase.Error);
+        result.Error.Code.Should().Be("legacy_value_result");
+        result.Error.Message.Should().Be("\"plain\"");
+    }
+
+    [Fact]
+    public void FromLegacyValue_ShouldReturnUnsetResult_ForEmptyValue()
+    {
+        ResponsesWebResultJson.FromLegacyValue(null).ResultCase
+            .Should().Be(ResponsesWebToolResult.ResultOneofCase.None);
+        ResponsesWebResultJson.FromLegacyValue(new ProtoValue()).ResultCase
+            .Should().Be(ResponsesWebToolResult.ResultOneofCase.None);
+    }
+
+    [Fact]
+    public void ToLegacyValue_ShouldMapSearchResult_ToLegacySearchStruct()
+    {
+        var result = ResponsesWebResultJson.FromSearch(new ResponsesWebSearchToolOutput
+        {
+            Results =
+            {
+                new ResponsesWebSearchResultItem
+                {
+                    Title = "First",
+                    Url = "https://example.com/1",
+                    Snippet = "Snippet",
+                },
+            },
+        });
+
+        var value = ResponsesWebResultJson.ToLegacyValue(result);
+
+        value.KindCase.Should().Be(ProtoValue.KindOneofCase.StructValue);
+        var results = value.StructValue.Fields["results"].ListValue.Values;
+        results.Should().ContainSingle();
+        results[0].StructValue.Fields["title"].StringValue.Should().Be("First");
+        results[0].StructValue.Fields["url"].StringValue.Should().Be("https://example.com/1");
+        results[0].StructValue.Fields["snippet"].StringValue.Should().Be("Snippet");
+    }
+
+    [Fact]
+    public void ToLegacyValue_ShouldMapErrorResult_ToLegacyErrorStruct()
+    {
+        var result = ResponsesWebResultJson.FromError("auth_failed", "Token missing");
+
+        var value = ResponsesWebResultJson.ToLegacyValue(result);
+
+        value.KindCase.Should().Be(ProtoValue.KindOneofCase.StructValue);
+        value.StructValue.Fields["error"].StringValue.Should().Be("auth_failed");
+        value.StructValue.Fields["message"].StringValue.Should().Be("Token missing");
+    }
+}

--- a/test/Aevatar.GAgentService.Tests/Abstractions/ResponsesWebResultMigrationTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Abstractions/ResponsesWebResultMigrationTests.cs
@@ -18,7 +18,7 @@ public sealed class ResponsesWebResultMigrationTests
         value.StructValue.Fields["content"] = ProtoValue.ForString("body");
         value.StructValue.Fields["redirect_url"] = ProtoValue.ForString("https://example.com/final");
 
-        var result = ResponsesWebResultJson.FromLegacyValue(value);
+        var result = ResponsesWebResultMigration.FromLegacyValue(value);
 
         result.ResultCase.Should().Be(ResponsesWebToolResult.ResultOneofCase.Fetch);
         result.Fetch.Url.Should().Be("https://example.com/page");
@@ -41,7 +41,7 @@ public sealed class ResponsesWebResultMigrationTests
         results.Values.Add(ProtoValue.ForString("ignored"));
         value.StructValue.Fields["results"] = new ProtoValue { ListValue = results };
 
-        var result = ResponsesWebResultJson.FromLegacyValue(value);
+        var result = ResponsesWebResultMigration.FromLegacyValue(value);
 
         result.ResultCase.Should().Be(ResponsesWebToolResult.ResultOneofCase.Search);
         result.Search.Results.Should().ContainSingle();
@@ -56,7 +56,7 @@ public sealed class ResponsesWebResultMigrationTests
         var value = new ProtoValue { StructValue = new Struct() };
         value.StructValue.Fields["error"] = ProtoValue.ForString("auth_failed");
 
-        var result = ResponsesWebResultJson.FromLegacyValue(value);
+        var result = ResponsesWebResultMigration.FromLegacyValue(value);
 
         result.ResultCase.Should().Be(ResponsesWebToolResult.ResultOneofCase.Error);
         result.Error.Code.Should().Be("auth_failed");
@@ -69,7 +69,7 @@ public sealed class ResponsesWebResultMigrationTests
         var value = new ProtoValue { StructValue = new Struct() };
         value.StructValue.Fields["custom"] = ProtoValue.ForString("kept");
 
-        var result = ResponsesWebResultJson.FromLegacyValue(value);
+        var result = ResponsesWebResultMigration.FromLegacyValue(value);
 
         result.ResultCase.Should().Be(ResponsesWebToolResult.ResultOneofCase.Error);
         result.Error.Code.Should().Be("legacy_value_result");
@@ -79,7 +79,7 @@ public sealed class ResponsesWebResultMigrationTests
     [Fact]
     public void FromLegacyValue_ShouldMapNonStructValue_ToLegacyValueError()
     {
-        var result = ResponsesWebResultJson.FromLegacyValue(ProtoValue.ForString("plain"));
+        var result = ResponsesWebResultMigration.FromLegacyValue(ProtoValue.ForString("plain"));
 
         result.ResultCase.Should().Be(ResponsesWebToolResult.ResultOneofCase.Error);
         result.Error.Code.Should().Be("legacy_value_result");
@@ -89,16 +89,16 @@ public sealed class ResponsesWebResultMigrationTests
     [Fact]
     public void FromLegacyValue_ShouldReturnUnsetResult_ForEmptyValue()
     {
-        ResponsesWebResultJson.FromLegacyValue(null).ResultCase
+        ResponsesWebResultMigration.FromLegacyValue(null).ResultCase
             .Should().Be(ResponsesWebToolResult.ResultOneofCase.None);
-        ResponsesWebResultJson.FromLegacyValue(new ProtoValue()).ResultCase
+        ResponsesWebResultMigration.FromLegacyValue(new ProtoValue()).ResultCase
             .Should().Be(ResponsesWebToolResult.ResultOneofCase.None);
     }
 
     [Fact]
     public void ToLegacyValue_ShouldMapSearchResult_ToLegacySearchStruct()
     {
-        var result = ResponsesWebResultJson.FromSearch(new ResponsesWebSearchToolOutput
+        var result = ResponsesWebResultMigration.FromSearch(new ResponsesWebSearchToolOutput
         {
             Results =
             {
@@ -111,7 +111,7 @@ public sealed class ResponsesWebResultMigrationTests
             },
         });
 
-        var value = ResponsesWebResultJson.ToLegacyValue(result);
+        var value = ResponsesWebResultMigration.ToLegacyValue(result);
 
         value.KindCase.Should().Be(ProtoValue.KindOneofCase.StructValue);
         var results = value.StructValue.Fields["results"].ListValue.Values;
@@ -124,9 +124,9 @@ public sealed class ResponsesWebResultMigrationTests
     [Fact]
     public void ToLegacyValue_ShouldMapErrorResult_ToLegacyErrorStruct()
     {
-        var result = ResponsesWebResultJson.FromError("auth_failed", "Token missing");
+        var result = ResponsesWebResultMigration.FromError("auth_failed", "Token missing");
 
-        var value = ResponsesWebResultJson.ToLegacyValue(result);
+        var value = ResponsesWebResultMigration.ToLegacyValue(result);
 
         value.KindCase.Should().Be(ProtoValue.KindOneofCase.StructValue);
         value.StructValue.Fields["error"].StringValue.Should().Be("auth_failed");

--- a/test/Aevatar.GAgentService.Tests/Abstractions/ResponsesWebResultMigrationTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Abstractions/ResponsesWebResultMigrationTests.cs
@@ -6,7 +6,7 @@ using ProtoValue = Google.Protobuf.WellKnownTypes.Value;
 
 namespace Aevatar.GAgentService.Tests.Abstractions;
 
-public sealed class ResponsesWebResultJsonTests
+public sealed class ResponsesWebResultMigrationTests
 {
     [Fact]
     public void FromLegacyValue_ShouldMapFetchStruct_ToTypedFetchResult()
@@ -73,7 +73,7 @@ public sealed class ResponsesWebResultJsonTests
 
         result.ResultCase.Should().Be(ResponsesWebToolResult.ResultOneofCase.Error);
         result.Error.Code.Should().Be("legacy_value_result");
-        result.Error.Message.Should().Be("""{"custom":"kept"}""");
+        result.Error.Message.Should().Be("unsupported legacy result value");
     }
 
     [Fact]
@@ -83,7 +83,7 @@ public sealed class ResponsesWebResultJsonTests
 
         result.ResultCase.Should().Be(ResponsesWebToolResult.ResultOneofCase.Error);
         result.Error.Code.Should().Be("legacy_value_result");
-        result.Error.Message.Should().Be("\"plain\"");
+        result.Error.Message.Should().Be("plain");
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesWebSubstituteToolExecutionServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesWebSubstituteToolExecutionServiceTests.cs
@@ -1,6 +1,7 @@
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.GAgentService.Abstractions.Responses;
 using Aevatar.GAgentService.Application.Responses;
 using FluentAssertions;
 using Google.Protobuf;
@@ -27,12 +28,13 @@ public sealed class ResponsesWebSubstituteToolExecutionServiceTests
             "WebFetch",
             """{"url":"http://example.com/docs"}"""));
 
-        result.Cached.StructValue.Fields["content"].StringValue.Should().Be("cached");
+        result.TypedCached.Fetch.Content.Should().Be("cached");
         backend.FetchCalls.Should().BeEmpty();
         state.WebTraces.Should().ContainSingle();
         state.WebTraces[0].Trace.CacheKey.Should().Be(cacheKey);
         state.WebTraces[0].Trace.Url.Should().Be("https://example.com/docs");
         state.WebTraces[0].Trace.CacheHit.Should().BeTrue();
+        state.WebTraces[0].Trace.Result.Fetch.Content.Should().Be("cached");
     }
 
     [Fact]
@@ -60,6 +62,7 @@ public sealed class ResponsesWebSubstituteToolExecutionServiceTests
         backend.FetchCalls[0].Url.Should().Be("https://example.com/docs");
         state.WebTraces.Should().ContainSingle();
         state.WebTraces[0].Trace.CacheHit.Should().BeFalse();
+        state.WebTraces[0].Trace.Result.Fetch.Content.Should().Be("fresh body");
     }
 
     [Fact]
@@ -73,7 +76,7 @@ public sealed class ResponsesWebSubstituteToolExecutionServiceTests
             "WebFetch",
             """{"url":"http://127.0.0.1/admin"}"""));
 
-        result.Error.StructValue.Fields["error"].StringValue.Should().Be("blocked_private_address");
+        result.TypedError.Code.Should().Be("blocked_private_address");
         backend.FetchCalls.Should().BeEmpty();
         state.WebTraces.Should().BeEmpty();
     }
@@ -85,7 +88,7 @@ public sealed class ResponsesWebSubstituteToolExecutionServiceTests
         var backend = new RecordingResponsesWebSubstituteBackend
         {
             SearchResult = new ResponsesWebSearchBoundaryResult(
-                StructValue(("results", ListValueValue(StructValue(("title", ProtoValue.ForString("fresh"))))))),
+                SearchOutput(("fresh", "https://example.com/fresh", "snippet"))),
         };
         var service = CreateService(state, backend);
 
@@ -94,9 +97,7 @@ public sealed class ResponsesWebSubstituteToolExecutionServiceTests
             """{"query":"aevatar docs","max_results":99}""",
             token: "secret-token"));
 
-        result.Search.StructValue.Fields["results"].ListValue.Values[0].StructValue.Fields["title"].StringValue
-            .Should()
-            .Be("fresh");
+        result.TypedSearch.Results[0].Title.Should().Be("fresh");
         backend.SearchCalls.Should().ContainSingle();
         backend.SearchCalls[0].NyxIdAccessToken.Should().Be("secret-token");
         backend.SearchCalls[0].Query.Should().Be("aevatar docs");
@@ -104,6 +105,7 @@ public sealed class ResponsesWebSubstituteToolExecutionServiceTests
         state.WebTraces.Should().ContainSingle();
         state.WebTraces[0].Trace.Query.Should().Be("aevatar docs");
         state.WebTraces[0].Trace.CacheHit.Should().BeFalse();
+        state.WebTraces[0].Trace.Result.Search.Results[0].Title.Should().Be("fresh");
     }
 
     [Fact]
@@ -118,9 +120,8 @@ public sealed class ResponsesWebSubstituteToolExecutionServiceTests
             """{"query":"aevatar docs"}""",
             token: string.Empty));
 
-        result.Search.StructValue.Fields["error"].StringValue
-            .Should()
-            .Be("No NyxID access token available. User must be authenticated.");
+        result.TypedError.Code.Should().Be("auth_required");
+        result.TypedError.Message.Should().Be("No NyxID access token available. User must be authenticated.");
         backend.SearchCalls.Should().BeEmpty();
         state.WebTraces.Should().ContainSingle();
         state.WebTraces[0].Trace.CacheHit.Should().BeFalse();
@@ -228,7 +229,7 @@ public sealed class ResponsesWebSubstituteToolExecutionServiceTests
         public List<ResponsesWebFetchBoundaryInput> FetchCalls { get; } = [];
 
         public ResponsesWebSearchBoundaryResult SearchResult { get; init; } =
-            new(StructValue(("results", ListValueValue())));
+            new(new ResponsesWebSearchToolOutput());
 
         public ResponsesWebFetchBoundaryResult FetchResult { get; init; } = new(
             "https://example.com",
@@ -244,7 +245,7 @@ public sealed class ResponsesWebSubstituteToolExecutionServiceTests
             CancellationToken ct)
         {
             SearchCalls.Add(input);
-            return Task.FromResult(new ResponsesWebSearchBoundaryResult(SearchResult.Value.Clone()));
+            return Task.FromResult(new ResponsesWebSearchBoundaryResult(SearchResult.Output.Clone()));
         }
 
         public Task<ResponsesWebFetchBoundaryResult> ExecuteWebFetchAsync(
@@ -273,7 +274,7 @@ public sealed class ResponsesWebSubstituteToolExecutionServiceTests
                 toolName,
                 value,
                 string.Empty,
-                JsonParser.Default.Parse<ProtoValue>(resultJson),
+                ResponsesWebResultJson.FromLegacyValue(JsonParser.Default.Parse<ProtoValue>(resultJson)),
                 DateTimeOffset.UtcNow,
                 null,
                 0);
@@ -322,18 +323,15 @@ public sealed class ResponsesWebSubstituteToolExecutionServiceTests
         }
     }
 
-    private static ProtoValue StructValue(params (string Key, ProtoValue Value)[] fields)
+    private static ResponsesWebSearchToolOutput SearchOutput(params (string Title, string Url, string Snippet)[] items)
     {
-        var value = new ProtoValue { StructValue = new Struct() };
-        foreach (var (key, fieldValue) in fields)
-            value.StructValue.Fields[key] = fieldValue;
-        return value;
-    }
-
-    private static ProtoValue ListValueValue(params ProtoValue[] values)
-    {
-        var value = new ProtoValue { ListValue = new Google.Protobuf.WellKnownTypes.ListValue() };
-        value.ListValue.Values.AddRange(values);
-        return value;
+        var output = new ResponsesWebSearchToolOutput();
+        output.Results.AddRange(items.Select(static item => new ResponsesWebSearchResultItem
+        {
+            Title = item.Title,
+            Url = item.Url,
+            Snippet = item.Snippet,
+        }));
+        return output;
     }
 }

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesWebSubstituteToolExecutionServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesWebSubstituteToolExecutionServiceTests.cs
@@ -274,7 +274,7 @@ public sealed class ResponsesWebSubstituteToolExecutionServiceTests
                 toolName,
                 value,
                 string.Empty,
-                ResponsesWebResultJson.FromLegacyValue(JsonParser.Default.Parse<ProtoValue>(resultJson)),
+                ResponsesWebResultMigration.FromLegacyValue(JsonParser.Default.Parse<ProtoValue>(resultJson)),
                 DateTimeOffset.UtcNow,
                 null,
                 0);

--- a/test/Aevatar.GAgentService.Tests/Core/ResponsesAgentToolStateGAgentTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ResponsesAgentToolStateGAgentTests.cs
@@ -72,7 +72,12 @@ public sealed class ResponsesAgentToolStateGAgentTests
         var actor = CreateActor();
         await RegisterAsync(actor);
 
-        var resultPayload = ResponsesJsonValues.ParseBoundaryPayload("""{"content":"fresh"}""");
+        var resultPayload = ResponsesWebResultJson.FromFetch(new ResponsesWebFetchToolOutput
+        {
+            Url = "https://example.com",
+            StatusCode = 200,
+            Content = "fresh",
+        });
         await actor.HandleRecordWebTraceAsync(new RecordResponsesWebTraceRequested
         {
             SourceResponseId = "resp_1",
@@ -80,7 +85,7 @@ public sealed class ResponsesAgentToolStateGAgentTests
             ToolName = "WebFetch",
             CacheKey = "cache-1",
             Url = "https://example.com",
-            Result = resultPayload,
+            TypedResult = resultPayload,
             ObservedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-05-12T00:00:00+00:00")),
         });
         await actor.HandleRecordWebTraceAsync(new RecordResponsesWebTraceRequested
@@ -91,16 +96,18 @@ public sealed class ResponsesAgentToolStateGAgentTests
             CacheKey = "cache-1",
             Url = "https://example.com",
             CacheHit = true,
-            Result = resultPayload,
+            TypedResult = resultPayload,
             ObservedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-05-12T00:01:00+00:00")),
         });
 
         actor.State.WebTraces.Should().HaveCount(2);
+        actor.State.WebTraces[0].TypedResult.Fetch.Content.Should().Be("fresh");
         ResponsesJsonValues.ToBoundaryJson(actor.State.WebTraces[0].Result)
-            .Should().Be("""{"content":"fresh"}""");
+            .Should().Be("""{"url":"https://example.com","status_code":200,"content_type":"","content":"fresh"}""");
         actor.State.WebCacheEntries.Should().ContainSingle();
+        actor.State.WebCacheEntries[0].TypedResult.Fetch.Content.Should().Be("fresh");
         ResponsesJsonValues.ToBoundaryJson(actor.State.WebCacheEntries[0].Result)
-            .Should().Be("""{"content":"fresh"}""");
+            .Should().Be("""{"url":"https://example.com","status_code":200,"content_type":"","content":"fresh"}""");
         actor.State.WebCacheEntries[0].HitCount.Should().Be(1);
         actor.State.WebCacheEntries[0].LastHitAt.Should().NotBeNull();
     }

--- a/test/Aevatar.GAgentService.Tests/Core/ResponsesAgentToolStateGAgentTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ResponsesAgentToolStateGAgentTests.cs
@@ -72,7 +72,7 @@ public sealed class ResponsesAgentToolStateGAgentTests
         var actor = CreateActor();
         await RegisterAsync(actor);
 
-        var resultPayload = ResponsesWebResultJson.FromFetch(new ResponsesWebFetchToolOutput
+        var resultPayload = ResponsesWebResultMigration.FromFetch(new ResponsesWebFetchToolOutput
         {
             Url = "https://example.com",
             StatusCode = 200,

--- a/test/Aevatar.GAgentService.Tests/Infrastructure/ResponsesAgentToolStateCommandAdapterTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Infrastructure/ResponsesAgentToolStateCommandAdapterTests.cs
@@ -152,7 +152,11 @@ public sealed class ResponsesAgentToolStateCommandAdapterTests
             Url: "https://example.com",
             Query: string.Empty,
             CacheHit: false,
-            Result: ResponsesJsonValues.ParseBoundaryPayload("""{"content":"x"}"""));
+            Result: ResponsesWebResultJson.FromFetch(new ResponsesWebFetchToolOutput
+            {
+                Url = "https://example.com",
+                Content = "x",
+            }));
 
         var result = await adapter.RecordWebTraceAsync("scope-1", "owner-1", "resp_1", trace);
 
@@ -160,7 +164,9 @@ public sealed class ResponsesAgentToolStateCommandAdapterTests
         dispatch.Calls.Should().HaveCount(2);
         var packed = dispatch.Calls[1].envelope.Payload.Unpack<RecordResponsesWebTraceRequested>();
         packed.TraceId.Should().Be("web_explicit");
-        ResponsesJsonValues.ToBoundaryJson(packed.Result).Should().Be("""{"content":"x"}""");
+        packed.TypedResult.Fetch.Content.Should().Be("x");
+        ResponsesJsonValues.ToBoundaryJson(packed.Result).Should().Be(
+            """{"url":"https://example.com","status_code":0,"content_type":"","content":"x"}""");
     }
 
     [Fact]
@@ -174,7 +180,7 @@ public sealed class ResponsesAgentToolStateCommandAdapterTests
             Url: string.Empty,
             Query: "weather",
             CacheHit: true,
-            Result: ResponsesJsonValues.ParseBoundaryPayload(string.Empty));
+            Result: new ResponsesWebToolResult());
 
         var result = await adapter.RecordWebTraceAsync("scope-1", "owner-1", "resp_1", trace);
 
@@ -182,7 +188,9 @@ public sealed class ResponsesAgentToolStateCommandAdapterTests
         result.CacheHit.Should().BeTrue();
         var packed = dispatch.Calls[1].envelope.Payload.Unpack<RecordResponsesWebTraceRequested>();
         packed.TraceId.Should().Be(result.TraceId);
-        ResponsesJsonValues.ToBoundaryJson(packed.Result).Should().Be("{}");
+        packed.TypedResult.ResultCase.Should().Be(ResponsesWebToolResult.ResultOneofCase.None);
+        packed.Result.Should().NotBeNull();
+        packed.Result.KindCase.Should().Be(Google.Protobuf.WellKnownTypes.Value.KindOneofCase.None);
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Infrastructure/ResponsesAgentToolStateCommandAdapterTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Infrastructure/ResponsesAgentToolStateCommandAdapterTests.cs
@@ -152,7 +152,7 @@ public sealed class ResponsesAgentToolStateCommandAdapterTests
             Url: "https://example.com",
             Query: string.Empty,
             CacheHit: false,
-            Result: ResponsesWebResultJson.FromFetch(new ResponsesWebFetchToolOutput
+            Result: ResponsesWebResultMigration.FromFetch(new ResponsesWebFetchToolOutput
             {
                 Url = "https://example.com",
                 Content = "x",

--- a/test/Aevatar.GAgentService.Tests/Projection/ResponsesAgentToolStateCurrentStateProjectorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ResponsesAgentToolStateCurrentStateProjectorTests.cs
@@ -51,12 +51,11 @@ public sealed class ResponsesAgentToolStateCurrentStateProjectorTests
         snapshot.Tasks[0].ArgumentsJson.Should().Be("{}");
         snapshot.Tasks[0].ResultJson.Should().Be("""{"status":"accepted"}""");
         snapshot.WebTraces.Should().ContainSingle(x => x.TraceId == "trace-1");
-        snapshot.WebTraces[0].ResultJson.Should().Be("""{"url":"https://example.com","status_code":200,"content_type":"","content":"fresh"}""");
         snapshot.WebTraces[0].Result.Fetch.Content.Should().Be("fresh");
 
         var cache = await reader.GetWebCacheEntryAsync(ScopeId, OwnerSubject, "WebFetch", "cache-1");
         cache.Should().NotBeNull();
-        ResponsesWebResultJson.ToBoundaryJson(cache!.Result).Should().Be("""{"url":"https://example.com","status_code":200,"content_type":"","content":"fresh"}""");
+        cache!.Result.Fetch.Content.Should().Be("fresh");
     }
 
     [Fact]
@@ -155,7 +154,6 @@ public sealed class ResponsesAgentToolStateCurrentStateProjectorTests
         snapshot!.WebTraces.Should().ContainSingle();
         snapshot.WebTraces[0].Result.ResultCase.Should().Be(ResponsesWebToolResult.ResultOneofCase.Fetch);
         snapshot.WebTraces[0].Result.Fetch.Content.Should().Be("legacy");
-        snapshot.WebTraces[0].ResultJson.Should().Be("""{"url":"https://legacy.example.com","status_code":202,"content_type":"","content":"legacy"}""");
         cache.Should().NotBeNull();
         cache!.Result.ResultCase.Should().Be(ResponsesWebToolResult.ResultOneofCase.Fetch);
         cache.Result.Fetch.StatusCode.Should().Be(202);

--- a/test/Aevatar.GAgentService.Tests/Projection/ResponsesAgentToolStateCurrentStateProjectorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ResponsesAgentToolStateCurrentStateProjectorTests.cs
@@ -201,7 +201,7 @@ public sealed class ResponsesAgentToolStateCurrentStateProjectorTests
             ToolName = "WebFetch",
             CacheKey = "cache-1",
             Url = "https://example.com",
-            TypedResult = ResponsesWebResultJson.FromFetch(new ResponsesWebFetchToolOutput
+            TypedResult = ResponsesWebResultMigration.FromFetch(new ResponsesWebFetchToolOutput
             {
                 Url = "https://example.com",
                 StatusCode = 200,
@@ -214,7 +214,7 @@ public sealed class ResponsesAgentToolStateCurrentStateProjectorTests
             CacheKey = "cache-1",
             ToolName = "WebFetch",
             Url = "https://example.com",
-            TypedResult = ResponsesWebResultJson.FromFetch(new ResponsesWebFetchToolOutput
+            TypedResult = ResponsesWebResultMigration.FromFetch(new ResponsesWebFetchToolOutput
             {
                 Url = "https://example.com",
                 StatusCode = 200,

--- a/test/Aevatar.GAgentService.Tests/Projection/ResponsesAgentToolStateCurrentStateProjectorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ResponsesAgentToolStateCurrentStateProjectorTests.cs
@@ -50,11 +50,12 @@ public sealed class ResponsesAgentToolStateCurrentStateProjectorTests
         snapshot.Tasks[0].ArgumentsJson.Should().Be("{}");
         snapshot.Tasks[0].ResultJson.Should().Be("""{"status":"accepted"}""");
         snapshot.WebTraces.Should().ContainSingle(x => x.TraceId == "trace-1");
-        snapshot.WebTraces[0].ResultJson.Should().Be("""{"content":"fresh"}""");
+        snapshot.WebTraces[0].ResultJson.Should().Be("""{"url":"https://example.com","status_code":200,"content_type":"","content":"fresh"}""");
+        snapshot.WebTraces[0].Result.Fetch.Content.Should().Be("fresh");
 
         var cache = await reader.GetWebCacheEntryAsync(ScopeId, OwnerSubject, "WebFetch", "cache-1");
         cache.Should().NotBeNull();
-        ResponsesJsonValues.ToBoundaryJson(cache!.Result).Should().Be("""{"content":"fresh"}""");
+        ResponsesWebResultJson.ToBoundaryJson(cache!.Result).Should().Be("""{"url":"https://example.com","status_code":200,"content_type":"","content":"fresh"}""");
     }
 
     [Fact]
@@ -140,7 +141,12 @@ public sealed class ResponsesAgentToolStateCurrentStateProjectorTests
             ToolName = "WebFetch",
             CacheKey = "cache-1",
             Url = "https://example.com",
-            Result = ResponsesJsonValues.ParseBoundaryPayload("""{"content":"fresh"}"""),
+            TypedResult = ResponsesWebResultJson.FromFetch(new ResponsesWebFetchToolOutput
+            {
+                Url = "https://example.com",
+                StatusCode = 200,
+                Content = "fresh",
+            }),
             ObservedAt = Timestamp.FromDateTimeOffset(observedAt),
         });
         state.WebCacheEntries.Add(new ResponsesWebCacheEntry
@@ -148,7 +154,12 @@ public sealed class ResponsesAgentToolStateCurrentStateProjectorTests
             CacheKey = "cache-1",
             ToolName = "WebFetch",
             Url = "https://example.com",
-            Result = ResponsesJsonValues.ParseBoundaryPayload("""{"content":"fresh"}"""),
+            TypedResult = ResponsesWebResultJson.FromFetch(new ResponsesWebFetchToolOutput
+            {
+                Url = "https://example.com",
+                StatusCode = 200,
+                Content = "fresh",
+            }),
             CachedAt = Timestamp.FromDateTimeOffset(observedAt),
         });
 

--- a/test/Aevatar.GAgentService.Tests/Projection/ResponsesAgentToolStateCurrentStateProjectorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ResponsesAgentToolStateCurrentStateProjectorTests.cs
@@ -9,6 +9,7 @@ using Aevatar.GAgentService.Projection.ReadModels;
 using FluentAssertions;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
+using ProtoValue = Google.Protobuf.WellKnownTypes.Value;
 
 namespace Aevatar.GAgentService.Tests.Projection;
 
@@ -97,6 +98,67 @@ public sealed class ResponsesAgentToolStateCurrentStateProjectorTests
         second.Todos.Should().ContainSingle(x => x.Id == "todo-1" && x.Content == "Store changed");
         second.Tasks.Should().ContainSingle(x => x.TaskId == "task_1" && x.ChildActorId == "child-2");
         second.WebCacheEntries.Should().ContainSingle(x => x.CacheKey == "cache-1" && x.HitCount == 9);
+    }
+
+    [Fact]
+    public async Task QueryReader_ShouldUseLegacyValueFallback_WhenReadModelHasNoTypedResult()
+    {
+        var store = new RecordingDocumentStore<ResponsesAgentToolStateCurrentStateReadModel>(x => x.Id);
+        var observedAt = DateTimeOffset.Parse("2026-05-12T00:01:00+00:00");
+        var legacyResult = new ProtoValue { StructValue = new Struct() };
+        legacyResult.StructValue.Fields["url"] = ProtoValue.ForString("https://legacy.example.com");
+        legacyResult.StructValue.Fields["status_code"] = ProtoValue.ForNumber(202);
+        legacyResult.StructValue.Fields["content"] = ProtoValue.ForString("legacy");
+
+        await store.UpsertAsync(new ResponsesAgentToolStateCurrentStateReadModel
+        {
+            Id = ActorId,
+            ActorId = ActorId,
+            ScopeId = ScopeId,
+            OwnerSubject = OwnerSubject,
+            StateVersion = 3,
+            CreatedAt = observedAt.AddMinutes(-1),
+            UpdatedAt = observedAt,
+            WebTraces =
+            {
+                new ResponsesWebTraceReadModel
+                {
+                    TraceId = "trace-legacy",
+                    SourceResponseId = "resp_legacy",
+                    ToolName = "WebFetch",
+                    CacheKey = "cache-legacy",
+                    Url = "https://legacy.example.com",
+                    Result = legacyResult.Clone(),
+                    ObservedAt = observedAt,
+                },
+            },
+            WebCacheEntries =
+            {
+                new ResponsesWebCacheEntryReadModel
+                {
+                    CacheKey = "cache-legacy",
+                    ToolName = "WebFetch",
+                    Url = "https://legacy.example.com",
+                    Result = legacyResult.Clone(),
+                    CachedAt = observedAt,
+                    HitCount = 2,
+                },
+            },
+        });
+
+        var reader = new ResponsesAgentToolStateQueryReader(store);
+
+        var snapshot = await reader.GetAsync(ScopeId, OwnerSubject);
+        var cache = await reader.GetWebCacheEntryAsync(ScopeId, OwnerSubject, "WebFetch", "cache-legacy");
+
+        snapshot.Should().NotBeNull();
+        snapshot!.WebTraces.Should().ContainSingle();
+        snapshot.WebTraces[0].Result.ResultCase.Should().Be(ResponsesWebToolResult.ResultOneofCase.Fetch);
+        snapshot.WebTraces[0].Result.Fetch.Content.Should().Be("legacy");
+        snapshot.WebTraces[0].ResultJson.Should().Be("""{"url":"https://legacy.example.com","status_code":202,"content_type":"","content":"legacy"}""");
+        cache.Should().NotBeNull();
+        cache!.Result.ResultCase.Should().Be(ResponsesWebToolResult.ResultOneofCase.Fetch);
+        cache.Result.Fetch.StatusCode.Should().Be(202);
     }
 
     private static EventEnvelope WrapCommittedState(DateTimeOffset observedAt)

--- a/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
@@ -2978,7 +2978,7 @@ public sealed class MainnetResponsesEndpointsTests
                 toolName,
                 value,
                 string.Empty,
-                ResponsesWebResultJson.FromLegacyValue(ResponsesJsonValues.ParseBoundaryPayload(resultJson)),
+                ResponsesWebResultMigration.FromLegacyValue(ResponsesJsonValues.ParseBoundaryPayload(resultJson)),
                 DateTimeOffset.UtcNow,
                 null,
                 0);

--- a/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
@@ -2938,19 +2938,7 @@ public sealed class MainnetResponsesEndpointsTests
             ResponsesWebSearchBoundaryInput input,
             CancellationToken ct) =>
             Task.FromResult(new ResponsesWebSearchBoundaryResult(
-                new Google.Protobuf.WellKnownTypes.Value
-                {
-                    StructValue = new Struct
-                    {
-                        Fields =
-                        {
-                            ["results"] = new Google.Protobuf.WellKnownTypes.Value
-                            {
-                                ListValue = new ListValue(),
-                            },
-                        },
-                    },
-                }));
+                new ResponsesWebSearchToolOutput()));
     }
 
     private sealed class StubAgentTool : IAgentTool
@@ -2990,7 +2978,7 @@ public sealed class MainnetResponsesEndpointsTests
                 toolName,
                 value,
                 string.Empty,
-                ResponsesJsonValues.ParseBoundaryPayload(resultJson),
+                ResponsesWebResultJson.FromLegacyValue(ResponsesJsonValues.ParseBoundaryPayload(resultJson)),
                 DateTimeOffset.UtcNow,
                 null,
                 0);

--- a/test/Aevatar.Hosting.Tests/Responses/ResponsesWebSubstituteBackendAdapterTests.cs
+++ b/test/Aevatar.Hosting.Tests/Responses/ResponsesWebSubstituteBackendAdapterTests.cs
@@ -45,7 +45,12 @@ public sealed class ResponsesWebSubstituteBackendAdapterTests
     {
         var webClient = new RecordingWebApiClient
         {
-            SearchResult = StructValue(("results", ListValue(StructValue(("title", ProtoValue.ForString("fresh")))))),
+            SearchResult = StructValue((
+                "results",
+                ListValue(StructValue(
+                    ("title", ProtoValue.ForString("fresh")),
+                    ("url", ProtoValue.ForString("https://example.com/fresh")),
+                    ("snippet", ProtoValue.ForString("fresh snippet")))))),
         };
         var adapter = new ResponsesWebSubstituteBackendAdapter(
             webClient,
@@ -57,6 +62,8 @@ public sealed class ResponsesWebSubstituteBackendAdapterTests
 
         result.Output.Results.Should().ContainSingle();
         result.Output.Results[0].Title.Should().Be("fresh");
+        result.Output.Results[0].Url.Should().Be("https://example.com/fresh");
+        result.Output.Results[0].Snippet.Should().Be("fresh snippet");
         webClient.SearchCalls.Should().ContainSingle();
         webClient.SearchCalls[0].Token.Should().Be("secret-token");
         webClient.SearchCalls[0].Query.Should().Be("aevatar docs");

--- a/test/Aevatar.Hosting.Tests/Responses/ResponsesWebSubstituteBackendAdapterTests.cs
+++ b/test/Aevatar.Hosting.Tests/Responses/ResponsesWebSubstituteBackendAdapterTests.cs
@@ -70,6 +70,30 @@ public sealed class ResponsesWebSubstituteBackendAdapterTests
         webClient.SearchCalls[0].MaxResults.Should().Be(5);
     }
 
+    [Theory]
+    [MemberData(nameof(MalformedSearchResults))]
+    public async Task ExecuteWebSearchAsync_WhenProviderValueHasNoResultsList_ShouldReturnEmptyTypedResults(
+        ProtoValue providerValue)
+    {
+        var webClient = new RecordingWebApiClient
+        {
+            SearchResult = providerValue,
+        };
+        var adapter = new ResponsesWebSubstituteBackendAdapter(
+            webClient,
+            new WebToolOptions { MaxSearchResults = 7 });
+
+        var result = await adapter.ExecuteWebSearchAsync(
+            new ResponsesWebSearchBoundaryInput("aevatar docs", 5, "secret-token"),
+            CancellationToken.None);
+
+        result.Output.Results.Should().BeEmpty();
+        webClient.SearchCalls.Should().ContainSingle();
+        webClient.SearchCalls[0].Token.Should().Be("secret-token");
+        webClient.SearchCalls[0].Query.Should().Be("aevatar docs");
+        webClient.SearchCalls[0].MaxResults.Should().Be(5);
+    }
+
     [Fact]
     public void HostComposition_ShouldBindResponsesWebBackendPortToAdapter()
     {
@@ -112,6 +136,14 @@ public sealed class ResponsesWebSubstituteBackendAdapterTests
             return Task.FromResult(FetchResult);
         }
     }
+
+    public static TheoryData<ProtoValue> MalformedSearchResults() =>
+        new()
+        {
+            ProtoValue.ForString("bad"),
+            StructValue(("items", ListValue(StructValue(("title", ProtoValue.ForString("fresh")))))),
+            StructValue(("results", ProtoValue.ForString("bad"))),
+        };
 
     private static ProtoValue StructValue(params (string Key, ProtoValue FieldValue)[] fields)
     {

--- a/test/Aevatar.Hosting.Tests/Responses/ResponsesWebSubstituteBackendAdapterTests.cs
+++ b/test/Aevatar.Hosting.Tests/Responses/ResponsesWebSubstituteBackendAdapterTests.cs
@@ -1,4 +1,5 @@
 using Aevatar.AI.ToolProviders.Web;
+using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Application.Responses;
 using Aevatar.Mainnet.Host.Api.Responses;
 using FluentAssertions;
@@ -54,9 +55,8 @@ public sealed class ResponsesWebSubstituteBackendAdapterTests
             new ResponsesWebSearchBoundaryInput("aevatar docs", 5, "secret-token"),
             CancellationToken.None);
 
-        result.Value.StructValue.Fields["results"].ListValue.Values[0].StructValue.Fields["title"].StringValue
-            .Should()
-            .Be("fresh");
+        result.Output.Results.Should().ContainSingle();
+        result.Output.Results[0].Title.Should().Be("fresh");
         webClient.SearchCalls.Should().ContainSingle();
         webClient.SearchCalls[0].Token.Should().Be("secret-token");
         webClient.SearchCalls[0].Query.Should().Be("aevatar docs");

--- a/test/Aevatar.Hosting.Tests/Responses/ResponsesWebSubstituteToolJsonTests.cs
+++ b/test/Aevatar.Hosting.Tests/Responses/ResponsesWebSubstituteToolJsonTests.cs
@@ -52,10 +52,15 @@ public sealed class ResponsesWebSubstituteToolJsonTests
     {
         var result = new ResponsesWebSubstituteToolExecutionResult
         {
-            Cached = StructValue(
-                ("url", ProtoValue.ForString("https://example.com/docs")),
-                ("content", ProtoValue.ForString("cached body")),
-                ("status_code", ProtoValue.ForNumber(200))),
+            TypedCached = new ResponsesWebToolResult
+            {
+                Fetch = new ResponsesWebFetchToolOutput
+                {
+                    Url = "https://example.com/docs",
+                    Content = "cached body",
+                    StatusCode = 200,
+                },
+            },
         };
 
         using var document = ParseBoundaryJson(result);
@@ -96,7 +101,10 @@ public sealed class ResponsesWebSubstituteToolJsonTests
     {
         var result = new ResponsesWebSubstituteToolExecutionResult
         {
-            Error = StructValue(("error", ProtoValue.ForString("blocked_private_address"))),
+            TypedError = new ResponsesWebToolError
+            {
+                Code = "blocked_private_address",
+            },
         };
 
         using var document = ParseBoundaryJson(result);
@@ -110,7 +118,7 @@ public sealed class ResponsesWebSubstituteToolJsonTests
     {
         var result = new ResponsesWebSubstituteToolExecutionResult
         {
-            Search = StructValue(("results", ListValue())),
+            TypedSearch = new ResponsesWebSearchToolOutput(),
         };
 
         using var document = ParseBoundaryJson(result);
@@ -131,7 +139,7 @@ public sealed class ResponsesWebSubstituteToolJsonTests
         var emptyFetch = ResponsesWebSubstituteToolJson.ToBoundaryJson(
             new ResponsesWebSubstituteToolExecutionResult { Fetch = new ResponsesWebFetchToolOutput() });
         var emptySearch = ResponsesWebSubstituteToolJson.ToBoundaryJson(
-            new ResponsesWebSubstituteToolExecutionResult { Search = StructValue(("results", ListValue())) });
+            new ResponsesWebSubstituteToolExecutionResult { TypedSearch = new ResponsesWebSearchToolOutput() });
 
         JsonDocument.Parse(emptyOneof).RootElement.ValueKind.Should().Be(JsonValueKind.Object);
         JsonDocument.Parse(emptyValue).RootElement.ValueKind.Should().Be(JsonValueKind.Object);

--- a/test/Aevatar.Hosting.Tests/Responses/ResponsesWebSubstituteToolJsonTests.cs
+++ b/test/Aevatar.Hosting.Tests/Responses/ResponsesWebSubstituteToolJsonTests.cs
@@ -2,7 +2,6 @@ using System.Text.Json;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.Mainnet.Host.Api.Responses;
 using FluentAssertions;
-using Google.Protobuf.WellKnownTypes;
 using ProtoValue = Google.Protobuf.WellKnownTypes.Value;
 
 namespace Aevatar.Hosting.Tests.Responses;
@@ -189,18 +188,4 @@ public sealed class ResponsesWebSubstituteToolJsonTests
     private static JsonDocument ParseBoundaryJson(ResponsesWebSubstituteToolExecutionResult result) =>
         JsonDocument.Parse(ResponsesWebSubstituteToolJson.ToBoundaryJson(result));
 
-    private static ProtoValue StructValue(params (string Key, ProtoValue FieldValue)[] fields)
-    {
-        var value = new ProtoValue { StructValue = new Struct() };
-        foreach (var (key, fieldValue) in fields)
-            value.StructValue.Fields[key] = fieldValue;
-        return value;
-    }
-
-    private static ProtoValue ListValue(params ProtoValue[] values)
-    {
-        var value = new ProtoValue { ListValue = new ListValue() };
-        value.ListValue.Values.AddRange(values);
-        return value;
-    }
 }

--- a/test/Aevatar.Hosting.Tests/Responses/ResponsesWebSubstituteToolJsonTests.cs
+++ b/test/Aevatar.Hosting.Tests/Responses/ResponsesWebSubstituteToolJsonTests.cs
@@ -130,6 +130,37 @@ public sealed class ResponsesWebSubstituteToolJsonTests
     }
 
     [Fact]
+    public void ToBoundaryJson_FreshWebSearchResult_EmitsResultFieldsJson()
+    {
+        var result = new ResponsesWebSubstituteToolExecutionResult
+        {
+            TypedSearch = new ResponsesWebSearchToolOutput
+            {
+                Results =
+                {
+                    new ResponsesWebSearchResultItem
+                    {
+                        Title = "fresh",
+                        Url = "https://example.com/fresh",
+                        Snippet = "fresh snippet",
+                    },
+                },
+            },
+        };
+
+        using var document = ParseBoundaryJson(result);
+        var root = document.RootElement;
+
+        root.TryGetProperty("results", out var results).Should().BeTrue();
+        results.ValueKind.Should().Be(JsonValueKind.Array);
+        results.GetArrayLength().Should().Be(1);
+        var item = results[0];
+        item.GetProperty("title").GetString().Should().Be("fresh");
+        item.GetProperty("url").GetString().Should().Be("https://example.com/fresh");
+        item.GetProperty("snippet").GetString().Should().Be("fresh snippet");
+    }
+
+    [Fact]
     public void ToBoundaryJson_EmptyProtobufValues_EmitsValidNullableJson()
     {
         var emptyOneof = ResponsesWebSubstituteToolJson.ToBoundaryJson(


### PR DESCRIPTION
## 摘要

源自 #1216 Phase 9 r1 META_JUDGE_DONE:split 的 first-slice。

Responses Web typed result (`ResponsesWebToolResult` proto) + execution result oneof 改用 typed branches。actor state / cache / readmodel 写入 typed,旧 `Value` 字段保留为 legacy read fallback(r2 修了 `ScriptNativeReadModelMaterializationIntegrationTests` regression)。Host JSON adapter 仍负责外部 JSON,Application 不再正常写入 Web result `Value`。

## 变更(20 files)

- 新增 `ResponsesWebToolResult` typed proto + `ResponsesWebResultJson` helper
- 改 `GAgentService.Abstractions / Application / Core / Infrastructure / Mainnet.Host.Api` 写路径
- 保留 legacy `Value` write 作 ReadModel fallback
- 测试覆盖 typed + legacy fallback 双路径

## No-new-core 边界

- 无新增 actor / envelope kind / pipeline phase
- 无 `docs/canon/*` 改动
- backend port 未移动,generic Web tools 不动
- provider symmetry + 更广 Web result contract 交 #1252-later

## 验证

- `dotnet build aevatar.slnx --nologo` 通过
- `dotnet test aevatar.slnx --nologo --no-build` 通过(0 failures)
- `bash tools/ci/architecture_guards.sh` / `test_stability_guards.sh` 通过

closes #1251

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧