### PR TITLE
#1259 first slice: skill-side typed workflow descriptor + handoff (no-new-core)

### DIFF
--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSources.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSources.cs
@@ -119,7 +119,8 @@ internal sealed class StartWorkflowTool : IAevatarInvocationTool
     public string Name => "aevatar_start_workflow";
 
     public string Description =>
-        "Start an Aevatar workflow by workflow_id with typed inputs.";
+        "Start an Aevatar workflow by workflow_id with typed inputs. " +
+        "When use_skill returns inline workflow_yamls, pass that bundle in workflow_yamls instead of treating the YAMLs as ordinary text.";
 
     public string ParametersSchema => AevatarInvocationToolSchemas.StartWorkflow;
 

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnRemoteSkillFetcher.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnRemoteSkillFetcher.cs
@@ -13,6 +13,7 @@ namespace Aevatar.AI.ToolProviders.Ornn;
 public sealed class OrnnRemoteSkillFetcher : IRemoteSkillFetcher
 {
     private readonly OrnnSkillClient _client;
+    private static readonly char[] PathSeparators = ['/', '\\'];
 
     public OrnnRemoteSkillFetcher(OrnnSkillClient client) => _client = client;
 
@@ -43,6 +44,7 @@ public sealed class OrnnRemoteSkillFetcher : IRemoteSkillFetcher
         // 尝试从 instructions 解析 frontmatter
         var parser = new SkillFrontmatterParser();
         var parsed = parser.Parse(instructions);
+        var workflows = DiscoverWorkflows(skill.Files, parsed.WorkflowEntry);
 
         return new SkillDefinition
         {
@@ -56,6 +58,55 @@ public sealed class OrnnRemoteSkillFetcher : IRemoteSkillFetcher
             IsModelInvocable = parsed.IsModelInvocable,
             IsUserInvocable = parsed.IsUserInvocable,
             AssociatedFiles = associatedFiles,
+            Workflows = workflows,
         };
+    }
+
+    private static IReadOnlyList<SkillWorkflowDescriptor> DiscoverWorkflows(
+        IReadOnlyDictionary<string, string>? files,
+        string? workflowEntry)
+    {
+        if (files is not { Count: > 0 })
+            return [];
+
+        // Refactor (issue1259-first):
+        //   Old pattern: Ornn workflow YAML files stayed in AssociatedFiles as untyped text, so the model had to infer tool handoff from generic attachments.
+        //   New principle: Keep the existing Ornn Files surface, but lift non-empty workflows/*.yaml|*.yml files into a typed skill workflow descriptor for aevatar_start_workflow.
+        var workflowFiles = files
+            .Where(static file => IsWorkflowYamlPath(file.Key) && !string.IsNullOrWhiteSpace(file.Value))
+            .OrderBy(static file => file.Key, StringComparer.Ordinal)
+            .ToArray();
+
+        if (workflowFiles.Length == 0)
+            return [];
+
+        var defaultWorkflowId = Path.GetFileNameWithoutExtension(workflowFiles[0].Key);
+        var workflowId = string.IsNullOrWhiteSpace(workflowEntry)
+            ? defaultWorkflowId
+            : Path.GetFileNameWithoutExtension(workflowEntry.Trim());
+
+        return
+        [
+            new SkillWorkflowDescriptor
+            {
+                WorkflowId = workflowId,
+                WorkflowYamls = workflowFiles.Select(static file => file.Value.Trim()).ToArray(),
+            }
+        ];
+    }
+
+    private static bool IsWorkflowYamlPath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return false;
+
+        var normalized = path.Replace('\\', '/');
+        if (!normalized.StartsWith("workflows/", StringComparison.Ordinal))
+            return false;
+
+        var fileName = normalized.Split(PathSeparators, StringSplitOptions.RemoveEmptyEntries).LastOrDefault();
+        return fileName is not null &&
+               (fileName.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase) ||
+                fileName.EndsWith(".yml", StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnRemoteSkillFetcher.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnRemoteSkillFetcher.cs
@@ -69,7 +69,7 @@ public sealed class OrnnRemoteSkillFetcher : IRemoteSkillFetcher
         if (files is not { Count: > 0 })
             return [];
 
-        // Refactor (issue1259-first):
+        // Refactor (iter161/cluster-triage-ornn-skill-workflow-tool-signal #1259-first):
         //   Old pattern: Ornn workflow YAML files stayed in AssociatedFiles as untyped text, so the model had to infer tool handoff from generic attachments.
         //   New principle: Keep the existing Ornn Files surface, but lift non-empty workflows/*.yaml|*.yml files into a typed skill workflow descriptor for aevatar_start_workflow.
         var workflowFiles = files

--- a/src/Aevatar.AI.ToolProviders.Skills/SkillDefinition.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/SkillDefinition.cs
@@ -58,4 +58,19 @@ public sealed class SkillDefinition
 
     /// <summary>关联文件内容（远程技能可能附带多个文件）。</summary>
     public IReadOnlyDictionary<string, string>? AssociatedFiles { get; init; }
+
+    /// <summary>技能附带的可运行 workflow YAML 描述。</summary>
+    public IReadOnlyList<SkillWorkflowDescriptor> Workflows { get; init; } = [];
+}
+
+/// <summary>
+/// Skill package workflow YAML handoff descriptor.
+/// </summary>
+public sealed class SkillWorkflowDescriptor
+{
+    /// <summary>Workflow identifier passed to aevatar_start_workflow.workflow_id.</summary>
+    public required string WorkflowId { get; init; }
+
+    /// <summary>Workflow YAML bundle passed to aevatar_start_workflow.workflow_yamls in stable path order.</summary>
+    public required IReadOnlyList<string> WorkflowYamls { get; init; }
 }

--- a/src/Aevatar.AI.ToolProviders.Skills/SkillFrontmatterParser.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/SkillFrontmatterParser.cs
@@ -31,6 +31,9 @@ public sealed class SkillParseResult
     /// <summary>Frontmatter 之后的正文内容（Instructions）。</summary>
     public required string Body { get; init; }
 
+    /// <summary>Frontmatter 中的 workflow entry hint.</summary>
+    public string? WorkflowEntry { get; init; }
+
     /// <summary>是否存在 frontmatter。</summary>
     public bool HasFrontmatter { get; init; }
 }
@@ -83,7 +86,7 @@ public sealed class SkillFrontmatterParser
         var body = bodyStart < rest.Length ? rest[bodyStart..].TrimStart('\n') : "";
 
         // 解析 frontmatter 键值对
-        string? name = null, description = null, arguments = null, whenToUse = null;
+        string? name = null, description = null, arguments = null, whenToUse = null, workflowEntry = null;
         var isModelInvocable = true;
         var isUserInvocable = true;
 
@@ -122,6 +125,9 @@ public sealed class SkillFrontmatterParser
                 case "when-to-use" or "when_to_use":
                     whenToUse = value;
                     break;
+                case "workflow" or "workflow-id" or "workflow_id":
+                    workflowEntry = value;
+                    break;
                 case "disable-model-invocation" or "disable_model_invocation":
                     isModelInvocable = !ParseBool(value);
                     break;
@@ -139,6 +145,7 @@ public sealed class SkillFrontmatterParser
             WhenToUse = whenToUse,
             IsModelInvocable = isModelInvocable,
             IsUserInvocable = isUserInvocable,
+            WorkflowEntry = workflowEntry,
             Body = body,
             HasFrontmatter = true,
         };

--- a/src/Aevatar.AI.ToolProviders.Skills/UseSkillTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/UseSkillTool.cs
@@ -125,6 +125,31 @@ public sealed class UseSkillTool : IAgentTool
         sb.AppendLine(
             "If these instructions leave you blocked by a missing capability, ambiguous workflow step, unavailable service, unknown API contract, repeated tool failure, or any other unsolved dependency, call `ornn_search_skills` with the concrete blocker/task and then `use_skill` the best matching result before trying generic proxy discovery or path guessing. Continue from the newly loaded skill.");
 
+        // Refactor (issue1259-first):
+        //   Old pattern: Runnable workflow YAML attachments were rendered only as generic Associated Files, leaving aevatar_start_workflow handoff implicit.
+        //   New principle: Render an explicit handoff section before generic files, preserving workflow_id and workflow_yamls as single-semantics tool fields.
+        if (skill.Workflows.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("## aevatar_start_workflow Handoff");
+            sb.AppendLine();
+            sb.AppendLine("Call `aevatar_start_workflow` with this inline workflow bundle before treating workflow YAMLs as ordinary reference files.");
+
+            foreach (var workflow in skill.Workflows)
+            {
+                var payload = new
+                {
+                    workflow_id = workflow.WorkflowId,
+                    workflow_yamls = workflow.WorkflowYamls,
+                };
+
+                sb.AppendLine();
+                sb.AppendLine("```json");
+                sb.AppendLine(JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true }));
+                sb.AppendLine("```");
+            }
+        }
+
         // 附带关联文件
         if (skill.AssociatedFiles is { Count: > 0 })
         {

--- a/src/Aevatar.AI.ToolProviders.Skills/UseSkillTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/UseSkillTool.cs
@@ -125,7 +125,7 @@ public sealed class UseSkillTool : IAgentTool
         sb.AppendLine(
             "If these instructions leave you blocked by a missing capability, ambiguous workflow step, unavailable service, unknown API contract, repeated tool failure, or any other unsolved dependency, call `ornn_search_skills` with the concrete blocker/task and then `use_skill` the best matching result before trying generic proxy discovery or path guessing. Continue from the newly loaded skill.");
 
-        // Refactor (issue1259-first):
+        // Refactor (iter161/cluster-triage-ornn-skill-workflow-tool-signal #1259-first):
         //   Old pattern: Runnable workflow YAML attachments were rendered only as generic Associated Files, leaving aevatar_start_workflow handoff implicit.
         //   New principle: Render an explicit handoff section before generic files, preserving workflow_id and workflow_yamls as single-semantics tool fields.
         if (skill.Workflows.Count > 0)

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -58,6 +58,15 @@ public sealed class AevatarInvocationToolSourceTests
     }
 
     [Fact]
+    public async Task StartWorkflowToolDescription_ShouldMentionInlineWorkflowYamls()
+    {
+        var tool = await DiscoverSingleAsync(new StartWorkflowToolSource(new Harness().CreateDispatcher()));
+
+        tool.Description.Should().Contain("workflow_yamls");
+        tool.Description.Should().Contain("use_skill");
+    }
+
+    [Fact]
     public async Task QueryReadModelSchema_ShouldExposeClosedReadModelSet()
     {
         var tool = await DiscoverSingleAsync(new QueryReadModelToolSource(new Harness().CreateDispatcher()));

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/LocalSkillCatalogTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/LocalSkillCatalogTests.cs
@@ -99,6 +99,52 @@ public sealed class LocalSkillCatalogTests
     }
 
     [Fact]
+    public async Task UseSkillTool_RendersWorkflowHandoffBeforeAssociatedFiles()
+    {
+        var catalog = new LocalSkillCatalog();
+        var tool = new UseSkillTool(catalog);
+        catalog.Register(MakeSkill(
+            "workflow-skill",
+            instructions: "run workflow",
+            workflows:
+            [
+                new SkillWorkflowDescriptor
+                {
+                    WorkflowId = "daily-report",
+                    WorkflowYamls = ["name: daily-report\nsteps: []"],
+                }
+            ],
+            associatedFiles: new Dictionary<string, string>
+            {
+                ["workflows/daily-report.yaml"] = "name: daily-report\nsteps: []",
+            }));
+
+        var result = await tool.ExecuteAsync("""{"skill":"workflow-skill"}""");
+
+        result.Should().Contain("## aevatar_start_workflow Handoff");
+        result.Should().Contain("\"workflow_id\": \"daily-report\"");
+        result.Should().Contain("\"workflow_yamls\"");
+        result.IndexOf("## aevatar_start_workflow Handoff", StringComparison.Ordinal)
+            .Should().BeLessThan(result.IndexOf("## Associated Files", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void SkillFrontmatterParser_ParsesWorkflowEntryScalar()
+    {
+        var parser = new SkillFrontmatterParser();
+
+        var parsed = parser.Parse("""
+            ---
+            name: workflow-skill
+            workflow_id: main-entry
+            ---
+            body
+            """);
+
+        parsed.WorkflowEntry.Should().Be("main-entry");
+    }
+
+    [Fact]
     public void SkillsSource_RemoteCacheRegressionTerms_DoNotAppearInExecutableCode()
     {
         var repoRoot = FindRepoRoot();
@@ -142,7 +188,12 @@ public sealed class LocalSkillCatalogTests
         }
     }
 
-    private static SkillDefinition MakeSkill(string name, string instructions = "body", string? remoteId = null)
+    private static SkillDefinition MakeSkill(
+        string name,
+        string instructions = "body",
+        string? remoteId = null,
+        IReadOnlyList<SkillWorkflowDescriptor>? workflows = null,
+        IReadOnlyDictionary<string, string>? associatedFiles = null)
     {
         return new SkillDefinition
         {
@@ -151,6 +202,8 @@ public sealed class LocalSkillCatalogTests
             Instructions = instructions,
             Source = remoteId is null ? SkillSource.Local : SkillSource.Remote,
             RemoteId = remoteId,
+            Workflows = workflows ?? [],
+            AssociatedFiles = associatedFiles,
         };
     }
 

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnSkillClientTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnSkillClientTests.cs
@@ -164,6 +164,34 @@ public sealed class OrnnSkillClientTests
     }
 
     [Fact]
+    public async Task RemoteSkillFetcher_DefaultsWorkflowIdToFirstSortedWorkflowFileNameWithoutFrontmatterEntry()
+    {
+        var handler = OrnnTestHttpMessageHandler.ReturningJson("""
+            {
+              "data": {
+                "name": "Workflow Skill",
+                "description": "Runs a workflow",
+                "files": {
+                  "SKILL.md": "---\nname: wf-skill\ndescription: Use workflow skill\n---\nRun it.",
+                  "workflows/z-child.yml": "name: z-child\nsteps: []\n",
+                  "workflows/a-main.yaml": "name: a-main\nsteps: []\n"
+                }
+              }
+            }
+            """);
+        var fetcher = new OrnnRemoteSkillFetcher(CreateClient(handler));
+
+        var skill = await fetcher.FetchSkillAsync("access-token", "Workflow Skill");
+
+        skill.Should().NotBeNull();
+        var workflow = skill!.Workflows.Should().ContainSingle().Subject;
+        workflow.WorkflowId.Should().Be("a-main");
+        workflow.WorkflowYamls.Should().Equal(
+            "name: a-main\nsteps: []",
+            "name: z-child\nsteps: []");
+    }
+
+    [Fact]
     public async Task GetSkillJsonAsync_ReturnsNullWhenNyxIdProxyReportsError()
     {
         var handler = OrnnTestHttpMessageHandler.ReturningJson(

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnSkillClientTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnSkillClientTests.cs
@@ -130,6 +130,40 @@ public sealed class OrnnSkillClientTests
     }
 
     [Fact]
+    public async Task RemoteSkillFetcher_LiftsWorkflowYamlFilesIntoTypedDescriptorWithFrontmatterEntryOverride()
+    {
+        var handler = OrnnTestHttpMessageHandler.ReturningJson("""
+            {
+              "data": {
+                "name": "Workflow Skill",
+                "description": "Runs a workflow",
+                "files": {
+                  "SKILL.md": "---\nname: wf-skill\ndescription: Use workflow skill\nworkflow: custom-entry\n---\nRun it.",
+                  "workflows/z-child.yml": " name: z-child\nsteps: []\n ",
+                  "workflows/a-main.yaml": "name: a-main\nsteps: []\n",
+                  "workflows/empty.yaml": "   ",
+                  "docs/workflows/ignored.yaml": "name: ignored\nsteps: []\n",
+                  "assets/readme.md": "reference"
+                }
+              }
+            }
+            """);
+        var fetcher = new OrnnRemoteSkillFetcher(CreateClient(handler));
+
+        var skill = await fetcher.FetchSkillAsync("access-token", "Workflow Skill");
+
+        skill.Should().NotBeNull();
+        skill!.Workflows.Should().ContainSingle();
+        var workflow = skill.Workflows.Single();
+        workflow.WorkflowId.Should().Be("custom-entry");
+        workflow.WorkflowYamls.Should().Equal(
+            "name: a-main\nsteps: []",
+            "name: z-child\nsteps: []");
+        skill.AssociatedFiles.Should().NotBeNull();
+        skill.AssociatedFiles!.Keys.Should().Contain("workflows/a-main.yaml");
+    }
+
+    [Fact]
     public async Task GetSkillJsonAsync_ReturnsNullWhenNyxIdProxyReportsError()
     {
         var handler = OrnnTestHttpMessageHandler.ReturningJson(


### PR DESCRIPTION
## 摘要

源自 #1089 Phase 9 r1 META_JUDGE_DONE:split 的 first-slice。

skill 加 `SkillWorkflowDescriptor` typed model;`OrnnRemoteSkillFetcher` 从现有 Ornn `Files` surface 识别 `workflows/*.yaml|*.yml`,稳定排序 + frontmatter `workflow/workflow_id` entry override;`UseSkillTool` 在 `Associated Files` 前输出 `aevatar_start_workflow` handoff(包含 `workflow_id` + `workflow_yamls`)。

## 变更

- `src/Aevatar.AI.ToolProviders.Skills/SkillDefinition.cs`: 新增 `SkillWorkflowDescriptor` typed model
- `src/Aevatar.AI.ToolProviders.Ornn/OrnnRemoteSkillFetcher.cs`: 从现有 Ornn Files 识别 workflows
- `src/Aevatar.AI.ToolProviders.Skills/UseSkillTool.cs`: handoff 输出
- `src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSources.cs`: tool description 更新
- 测试覆盖

## No-new-core 边界

- 无新增 actor / proto field / envelope kind / pipeline phase
- 无 `docs/canon/*` 改动
- 不要求外部仓库(chrono-ornn)改动
- richer workflow descriptor semantics + canon contract 交 #1260-later

## 验证

- `dotnet build aevatar.slnx --nologo` 通过
- `dotnet test aevatar.slnx --nologo --no-build` 通过
- `bash tools/ci/architecture_guards.sh` / `test_stability_guards.sh` 通过

closes #1259

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧