### PR TITLE
#1261 first slice: Console Web feature-local 等待 cleanup (no-new-backend)

### DIFF
--- a/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.test.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.test.tsx
@@ -333,6 +333,116 @@ describe('ScriptsWorkbenchPage', () => {
     expect(mockedScriptsApi.getScript).not.toHaveBeenCalled();
   });
 
+  it.each([
+    [
+      'stale',
+      () =>
+        mockedScriptsApi.getScriptCatalog.mockResolvedValueOnce({
+          scriptId: 'script-1',
+          activeRevision: 'rev-1',
+          activeDefinitionActorId: 'definition-1',
+          activeSourceHash: 'hash-1',
+          previousRevision: '',
+          revisionHistory: ['rev-1'],
+          lastProposalId: '',
+          catalogActorId: 'catalog-1',
+          scopeId: 'scope-1',
+          updatedAt: '2026-03-24T00:00:00Z',
+        }),
+    ],
+    [
+      'missing',
+      () => mockedScriptsApi.getScriptCatalog.mockResolvedValueOnce(null),
+    ],
+    [
+      'rejected',
+      () =>
+        mockedScriptsApi.getScriptCatalog.mockRejectedValueOnce(
+          new Error('read model is not visible yet'),
+        ),
+    ],
+  ])(
+    'keeps promotion pending when the catalog read model is %s',
+    async (_catalogState, arrangeCatalogRead) => {
+      window.localStorage.setItem(
+        'aevatar:console:scripts-studio:v1',
+        JSON.stringify([
+          {
+            key: 'draft-promotion',
+            scriptId: 'script-1',
+            revision: 'rev-2',
+            baseRevision: 'rev-1',
+            reason: 'Promote rev-2',
+            input: '',
+            package: {
+              csharpSources: [
+                {
+                  path: 'Behavior.cs',
+                  content: 'public sealed class DemoScript {}',
+                },
+              ],
+              protoFiles: [],
+              entryBehaviorTypeName: 'DraftBehavior',
+              entrySourcePath: 'Behavior.cs',
+            },
+            selectedFilePath: 'Behavior.cs',
+            definitionActorId: 'definition-1',
+            runtimeActorId: 'runtime-1',
+            updatedAtUtc: '2026-03-24T00:00:00Z',
+            lastSourceHash: 'hash-1',
+            scopeDetail: {
+              available: true,
+              scopeId: 'scope-1',
+              script: {
+                scopeId: 'scope-1',
+                scriptId: 'script-1',
+                catalogActorId: 'catalog-1',
+                definitionActorId: 'definition-1',
+                activeRevision: 'rev-1',
+                activeSourceHash: 'hash-1',
+                updatedAt: '2026-03-24T00:00:00Z',
+              },
+              source: {
+                sourceText: 'public sealed class DemoScript {}',
+                definitionActorId: 'definition-1',
+                revision: 'rev-1',
+                sourceHash: 'hash-1',
+              },
+            },
+          },
+        ]),
+      );
+      arrangeCatalogRead();
+
+      renderPage();
+
+      await screen.findByLabelText('Script ID');
+      fireEvent.click(screen.getByRole('button', { name: 'More script actions' }));
+      fireEvent.click(await screen.findByText('Promote'));
+      fireEvent.click(screen.getByRole('button', { name: 'Promote' }));
+
+      await waitFor(() => {
+        expect(mockedScriptsApi.proposeEvolution).toHaveBeenCalledWith(
+          'scope-1',
+          'script-1',
+          expect.objectContaining({
+            baseRevision: 'rev-1',
+            candidateRevision: 'rev-2',
+          }),
+        );
+      });
+      await waitFor(() => {
+        expect(mockedScriptsApi.getScriptCatalog).toHaveBeenCalledTimes(1);
+      });
+      expect(mockedScriptsApi.getScript).not.toHaveBeenCalled();
+      expect(
+        await screen.findByText(
+          'Promotion accepted for script-1 rev-2. Refresh the workspace catalog if the read model is still pending.',
+        ),
+      ).toBeTruthy();
+    },
+  );
+
   it('boots a fresh draft with the app script starter contract', async () => {
     renderPage();
 

--- a/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.test.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.test.tsx
@@ -312,25 +312,10 @@ describe('ScriptsWorkbenchPage', () => {
     });
   });
 
-  it('retries transient save-observation failures before surfacing an error', async () => {
-    mockedScriptsApi.observeSaveScript
-      .mockRejectedValueOnce(new Error('temporary timeout'))
-      .mockResolvedValueOnce({
-        scopeId: 'scope-1',
-        scriptId: 'script-1',
-        status: 'applied',
-        message: 'Revision active.',
-        currentScript: {
-          scopeId: 'scope-1',
-          scriptId: 'script-1',
-          catalogActorId: 'catalog-1',
-          definitionActorId: 'definition-1',
-          activeRevision: 'rev-1',
-          activeSourceHash: 'hash-1',
-          updatedAt: '2026-03-24T00:00:00Z',
-        },
-        isTerminal: true,
-      });
+  it('keeps save observation pending when the read model is not visible yet', async () => {
+    mockedScriptsApi.observeSaveScript.mockRejectedValueOnce(
+      new Error('temporary timeout'),
+    );
 
     renderPage();
 
@@ -338,11 +323,14 @@ describe('ScriptsWorkbenchPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
-      expect(mockedScriptsApi.observeSaveScript).toHaveBeenCalledTimes(2);
+      expect(mockedScriptsApi.observeSaveScript).toHaveBeenCalledTimes(1);
     });
     expect(
-      await screen.findByText('Saved script-1 into workspace scope-1.'),
+      await screen.findByText(
+        /Save accepted for script-1; observation is not available yet./,
+      ),
     ).toBeTruthy();
+    expect(mockedScriptsApi.getScript).not.toHaveBeenCalled();
   });
 
   it('boots a fresh draft with the app script starter contract', async () => {

--- a/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.tsx
@@ -649,10 +649,6 @@ function buildSaveObservationRequest(
   };
 }
 
-function wait(ms: number) {
-  return new Promise((resolve) => window.setTimeout(resolve, ms));
-}
-
 function catalogMatchesPromotion(
   catalog: ScriptCatalogSnapshot | null | undefined,
   decision: ScriptPromotionDecision,
@@ -1603,70 +1599,48 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
     accepted: ScopeScriptUpsertAcceptedResponse,
   ): Promise<ScopeScriptSaveObservationResult> => {
     const request = buildSaveObservationRequest(accepted);
-    let lastObservation: ScopeScriptSaveObservationResult | null = null;
-    let lastError: unknown = null;
-
-    for (let attempt = 0; attempt < 8; attempt += 1) {
-      try {
-        const observation = await scriptsApi.observeSaveScript(
-          resolvedScopeId,
-          accepted.acceptedScript.scriptId,
-          request,
-        );
-        lastObservation = observation;
-        lastError = null;
-        if (observation.isTerminal) {
-          return observation;
-        }
-      } catch (error) {
-        lastError = error;
-      }
-
-      await wait(250);
+    try {
+      // Refactor (iter160-cluster-001 #1261-first):
+      // Old pattern: the save path retried observation with fixed timer waits
+      // until the catalog read model looked applied.
+      // New principle: use the existing observation surface once and preserve
+      // pending/stale read-model freshness instead of manufacturing completion.
+      return await scriptsApi.observeSaveScript(
+        resolvedScopeId,
+        accepted.acceptedScript.scriptId,
+        request,
+      );
+    } catch (error) {
+      return {
+        scopeId: accepted.acceptedScript.scopeId,
+        scriptId: accepted.acceptedScript.scriptId,
+        status: 'pending',
+        message:
+          error instanceof Error
+            ? `Save accepted for ${accepted.acceptedScript.scriptId}; observation is not available yet. ${error.message}`
+            : `Save accepted for ${accepted.acceptedScript.scriptId}; observation is not available yet.`,
+        currentScript: null,
+        isTerminal: false,
+      };
     }
-
-    if (lastObservation != null) {
-      return lastObservation;
-    }
-
-    if (lastError != null) {
-      throw lastError;
-    }
-
-    return lastObservation ?? {
-      scopeId: accepted.acceptedScript.scopeId,
-      scriptId: accepted.acceptedScript.scriptId,
-      status: 'pending',
-      message: `Save request for ${accepted.acceptedScript.scriptId} is still waiting to appear in the workspace catalog.`,
-      currentScript: null,
-      isTerminal: false,
-    };
   }, [resolvedScopeId]);
 
-  const waitForPromotionCatalog = React.useCallback(async (
+  const readPromotionCatalogOnce = React.useCallback(async (
     decision: ScriptPromotionDecision,
   ): Promise<ScriptCatalogSnapshot | null> => {
     if (!decision.accepted) {
       return null;
     }
 
-    for (let attempt = 0; attempt < 8; attempt += 1) {
-      try {
-        const catalog = await scriptsApi.getScriptCatalog(
-          resolvedScopeId,
-          decision.scriptId,
-        );
-        if (catalogMatchesPromotion(catalog, decision)) {
-          return catalog;
-        }
-      } catch {
-        // Ignore transient query failures while the catalog is catching up.
-      }
-
-      await wait(250);
+    try {
+      const catalog = await scriptsApi.getScriptCatalog(
+        resolvedScopeId,
+        decision.scriptId,
+      );
+      return catalogMatchesPromotion(catalog, decision) ? catalog : null;
+    } catch {
+      return null;
     }
-
-    return null;
   }, [resolvedScopeId]);
 
   const handleSave = React.useCallback(async () => {
@@ -1676,7 +1650,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
       const accepted = await saveCurrentDraftToScope();
       setNotice({
         type: 'info',
-        message: `Save accepted for ${accepted.acceptedScript.scriptId}. Waiting for the workspace catalog to catch up.`,
+        message: `Save accepted for ${accepted.acceptedScript.scriptId}. Refresh the workspace catalog if the read model is still pending.`,
       });
       const observation = await observeAcceptedSave(accepted);
       await refreshScopeScripts();
@@ -1724,7 +1698,14 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
     } finally {
       setSavePending(false);
     }
-  }, [observeAcceptedSave, openWorkspaceSection, refreshScopeScripts, resolvedScopeId, saveCurrentDraftToScope, updateSelectedDraft]);
+  }, [
+    observeAcceptedSave,
+    openWorkspaceSection,
+    refreshScopeScripts,
+    resolvedScopeId,
+    saveCurrentDraftToScope,
+    updateSelectedDraft,
+  ]);
 
   const handleOpenBindScope = React.useCallback(() => {
     const scopeScript = selectedDraft?.scopeDetail?.script;
@@ -1937,7 +1918,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
       setActiveResultTab('promotion');
       openWorkspaceSection('activity');
       const observedCatalog = response.accepted
-        ? await waitForPromotionCatalog(response)
+        ? await readPromotionCatalogOnce(response)
         : null;
       if (observedCatalog) {
         const detail = await scriptsApi.getScript(
@@ -1978,7 +1959,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
         message: response.accepted
           ? observedCatalog
             ? `Promoted ${response.scriptId} to ${response.candidateRevision}.`
-            : `Promotion accepted for ${response.scriptId} ${response.candidateRevision}. Waiting for the catalog read model to catch up.`
+            : `Promotion accepted for ${response.scriptId} ${response.candidateRevision}. Refresh the workspace catalog if the read model is still pending.`
           : response.failureReason || 'Promotion proposal was rejected.',
       });
     } catch (error) {
@@ -2001,7 +1982,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
     scopeBacked,
     selectedDraft,
     updateSelectedDraft,
-    waitForPromotionCatalog,
+    readPromotionCatalogOnce,
   ]);
 
   const resetAskAiOutput = React.useCallback(() => {

--- a/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.tsx
@@ -1625,6 +1625,9 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
     }
   }, [resolvedScopeId]);
 
+  // Refactor (iter160-cluster-001 #1261-first):
+  //   Old pattern: fixed-time polling with retry sleep.
+  //   New principle: one-shot stale read; return a pending notice when the read model is pending.
   const readPromotionCatalogOnce = React.useCallback(async (
     decision: ScriptPromotionDecision,
   ): Promise<ScriptCatalogSnapshot | null> => {

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -5404,6 +5404,36 @@ describe("StudioPage", () => {
     expect(searchParams.get("member")).toBe("member:workspace-demo");
   });
 
+  it("keeps accepted member binding pending when the run readmodel is not visible yet", async () => {
+    mockScopeRuntimeApi.listServices.mockReset();
+    mockScopeRuntimeApi.listServices.mockResolvedValue([]);
+    (studioApi.getScopeBinding as jest.Mock).mockResolvedValueOnce(null);
+    const notFoundError = new Error("not found");
+    notFoundError.name = "StudioApiError";
+    Object.assign(notFoundError, { status: 404 });
+    (studioApi.getMemberBindingRun as jest.Mock).mockRejectedValueOnce(notFoundError);
+
+    renderStudioPage("/studio?scopeId=scope-1&member=member%3Aworkspace-demo&focus=workflow%3Aworkflow-1&tab=studio");
+
+    expect(await screen.findByTestId("studio-workflow-build-panel")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue to Bind" }));
+    expect(await screen.findByTestId("studio-bind-surface")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText("candidate:workspace-demo")).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Bind current member" }));
+    });
+
+    await waitFor(() => {
+      expect(studioApi.getMemberBindingRun).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByText("service:no-service")).toBeTruthy();
+    expect(screen.getByText("candidate:workspace-demo")).toBeTruthy();
+  });
+
   it("includes readmodel freshness in pending member binding notices", () => {
     expect(
       buildStudioMemberBindingPendingNotice("workspace-demo", {

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -229,21 +229,6 @@ type StudioBindingRunOutcome =
       readonly run: StudioMemberBindingRunStatusResponse | null;
     };
 
-const MEMBER_BINDING_RUN_POLL_INTERVAL_MS = 900;
-const MEMBER_BINDING_RUN_POLL_ATTEMPTS = 8;
-
-function waitForStudioMemberBindingRunTick(): Promise<void> {
-  return new Promise((resolve) => {
-    window.setTimeout(resolve, MEMBER_BINDING_RUN_POLL_INTERVAL_MS);
-  });
-}
-
-function isStudioMemberBindingRunTerminal(
-  run: StudioMemberBindingRunStatusResponse,
-): boolean {
-  return ['succeeded', 'failed', 'rejected'].includes(run.status);
-}
-
 function buildStudioMemberBindingFailureMessage(
   run: StudioMemberBindingRunStatusResponse,
 ): string {
@@ -4664,39 +4649,29 @@ const StudioPage: React.FC = () => {
     selectedWorkflowId,
     studioScopeMembers,
   ]);
-  const waitForMemberBindingRun = useCallback(
+  const observeMemberBindingRunOnce = useCallback(
     async (
       receipt: StudioMemberBindingAcceptedResponse,
     ): Promise<StudioMemberBindingRunStatusResponse | null> => {
-      let latestRun: StudioMemberBindingRunStatusResponse | null = null;
-
-      for (let attempt = 0; attempt < MEMBER_BINDING_RUN_POLL_ATTEMPTS; attempt += 1) {
-        if (attempt > 0) {
-          await waitForStudioMemberBindingRunTick();
+      try {
+        const run = await studioApi.getMemberBindingRun(
+          receipt.scopeId,
+          receipt.memberId,
+          receipt.bindingRunId,
+        );
+        return run;
+      } catch (error) {
+        // Refactor (iter160-cluster-001 #1261-first):
+        // Old pattern: the feature waited on repeated timer ticks until the
+        // read model appeared, which made accepted ACK look like completion.
+        // New principle: query the existing run read model once, then keep the
+        // UI in accepted/pending/stale state until normal query refresh catches up.
+        if (isStudioApiStatus(error, 404)) {
+          return null;
         }
 
-        try {
-          latestRun = await studioApi.getMemberBindingRun(
-            receipt.scopeId,
-            receipt.memberId,
-            receipt.bindingRunId,
-          );
-        } catch (error) {
-          // The run status is read-model backed, so the first request can
-          // legitimately arrive before projection catches up to the accepted ACK.
-          if (isStudioApiStatus(error, 404)) {
-            continue;
-          }
-
-          throw error;
-        }
-
-        if (isStudioMemberBindingRunTerminal(latestRun)) {
-          return latestRun;
-        }
+        throw error;
       }
-
-      return latestRun;
     },
     [],
   );
@@ -4729,7 +4704,7 @@ const StudioPage: React.FC = () => {
           ],
         });
         memberBindingRunOutcome = resolveStudioMemberBindingRunOutcome(
-          await waitForMemberBindingRun(receipt),
+          await observeMemberBindingRunOnce(receipt),
         );
         await queryClient.invalidateQueries({
           queryKey: [
@@ -4770,7 +4745,7 @@ const StudioPage: React.FC = () => {
           ],
         });
         memberBindingRunOutcome = resolveStudioMemberBindingRunOutcome(
-          await waitForMemberBindingRun(receipt),
+          await observeMemberBindingRunOnce(receipt),
         );
         await queryClient.invalidateQueries({
           queryKey: [
@@ -4813,7 +4788,7 @@ const StudioPage: React.FC = () => {
           ],
         });
         memberBindingRunOutcome = resolveStudioMemberBindingRunOutcome(
-          await waitForMemberBindingRun(receipt),
+          await observeMemberBindingRunOnce(receipt),
         );
         await queryClient.invalidateQueries({
           queryKey: [
@@ -5024,7 +4999,7 @@ const StudioPage: React.FC = () => {
     scopeServicesQuery,
     studioMembersQueryKey,
     studioScopeMembers,
-    waitForMemberBindingRun,
+    observeMemberBindingRunOnce,
   ]);
 
   const openWorkspaceWorkflow = useCallback((workflowId: string) => {


### PR DESCRIPTION
## 摘要

源自 #1201 Phase 9 r1 META_JUDGE_DONE:split 的 first-slice。

仅 `apps/aevatar-console-web` 范围,无新增 backend / docs 改动。

- Studio member binding: 移除固定时间轮询,accepted 后只查一次现有 run readmodel;404 时保留 pending/stale
- Scripts workbench save: 移除固定 retry sleep,改为一次已有 save observation;不可见时返回 pending

## 变更(4 files,+104/-130 LOC)

- `apps/aevatar-console-web/src/pages/studio/index.tsx` + 同级 `.test.tsx`
- `apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.tsx` + 同级 `.test.tsx`

## No-new-backend 边界

- 仅 console-web 前端范围
- 无新增 actor / proto field / envelope kind / pipeline phase
- 无 `docs/canon/*` 改动
- public observation contract + canon vocabulary 交 #1262-later

## 验证

- `dotnet build aevatar.slnx --nologo` 通过
- `dotnet test aevatar.slnx --nologo --no-build` 通过(0 failures)
- Console-web jest 121 tests passed
- Console-web tsc 通过
- `bash tools/ci/architecture_guards.sh` / `test_stability_guards.sh` 通过

closes #1261

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧