### PR TITLE
Add visible loop process guards

### DIFF
--- a/.claude/skills/codex-refactor-loop/SKILL.md
+++ b/.claude/skills/codex-refactor-loop/SKILL.md
@@ -74,6 +74,46 @@ gh issue view <N> --json comments --jq '
 
 输出格式稳定,易于直接判断派什么。
 
+If this repository snapshot is missing `.refactor-loop/host.env`, missing `.refactor-loop/logs/`, prompts, or GitHub state, keep the stable entrypoint as:
+
+```bash
+bash .claude/skills/codex-refactor-loop/scripts/peek.sh
+```
+
+`peek.sh` must degrade to a local read-only process/log/status snapshot and may delegate to:
+
+```bash
+bash .claude/skills/codex-refactor-loop/scripts/visible-loop-health.sh
+```
+
+The helper does not call GitHub and does not write loop state. It only reports host.env, peek, logs, prompts, runs, repo-scoped `spawn-codex.sh` process counts, recent local markers, visible-loop marker summaries, and monitor file status from the current git root. Use it as the degraded helper behind `peek.sh`; it does not replace the controller's later GitHub status synchronization when the full loop environment is available.
+
+For local visible worker logs, the safe marker summary helper is:
+
+```bash
+bash .claude/skills/codex-refactor-loop/scripts/visible-loop-log-summary.sh .refactor-loop/logs/visible-*.log
+```
+
+It treats a log as finished only when `tail -5` contains exact `EXIT=0`; reports `DONE_AT=` only from that tail; and only then reports the latest real `VISIBLE_WORKER_DONE:<role>:<ok|blocked>:<reason>` marker. It filters prompt placeholders such as `<role>`, `<ok|blocked>`, `<reason>`, `EXIT=$?`, and template-only values, so degraded visible-loop wakeups do not mistake prompt echoes for completed worker output.
+
+For process-only visible-loop helper changes, run the local read-only smoke command instead of repeating manual checks:
+
+```bash
+bash .claude/skills/codex-refactor-loop/scripts/visible-loop-smoke.sh /Users/abigaildeng/Documents/Playground/aevatar/.refactor-loop/logs
+```
+
+The smoke runner performs `git diff --check`, `bash -n` over the local shell helpers, `portable-timeout.sh --select`, a forced shell-fallback timeout success check, visible worker log summaries when logs are available, and capped degraded `peek.sh` / `visible-loop-health.sh` output. It does not call GitHub, does not write loop state, and does not modify tracked files.
+
+For visible-loop PR readiness, use these read-only threshold guards before preparing external GitHub content:
+
+```bash
+bash .claude/skills/codex-refactor-loop/scripts/visible-loop-prompt-guard.sh /Users/abigaildeng/Documents/Playground/aevatar/.refactor-loop/prompts/visible-*.md
+bash .claude/skills/codex-refactor-loop/scripts/visible-loop-batch-files.sh 10
+bash .claude/skills/codex-refactor-loop/scripts/visible-loop-pr-body-check.sh <pr-body-file>
+```
+
+`visible-loop-prompt-guard.sh` checks visible worker prompts for unresolved placeholders outside intentional marker examples, risky raw `@` mentions, and missing `⟦AI:AUTO-LOOP⟧` instructions when a prompt describes GitHub / PR / comment / body content. `visible-loop-batch-files.sh` uses `git ls-files -m -o --exclude-standard .claude/skills/codex-refactor-loop` as the stable scoped count for the process batch; the current PR threshold is 10 meaningful tracked or prospective tracked files. `visible-loop-pr-body-check.sh` validates a local PR body draft for the AI automation pipeline sections, required base branch, validation evidence, browser/runtime evidence or an explicit not-applicable note, and user dirty-workspace protection; it never calls GitHub. `visible-loop-smoke.sh` runs the prompt guard when visible prompts are discoverable, reports the 10-file threshold as readiness status, and only runs the PR body check when a body path is supplied.
+
 ### 0 codex + active task = bug(强制,per Auric 2026-05-20 "按说这个流程应该一直有 codex 工作的" + 2026-05-21 "没有并行 codex 就有问题")
 
 **铁律**:任何 active phase issue/PR(`🔍 design-solving` / `🔧 fixing` / `👀 reviewing` / `🛠️ implementing`)存在时,**应至少有 1 codex 在跑**。`ps codex exec | wc -l == 0` AND `gh issue list --label "🔍 design-solving"` non-empty → **P0 bug**(no-gap-violation)。

--- a/.claude/skills/codex-refactor-loop/scripts/peek.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/peek.sh
@@ -1,314 +1,313 @@
 #!/usr/bin/env bash
-# peek.sh — controller wakeup 快速 sweep
+# Stable read-only controller visibility entrypoint for codex-refactor-loop.
 #
-# per Auric 2026-05-21 "主动发现问题" + "codex 可以执行得很好,为什么你做不到":
-# controller 每 wakeup 第一动作应该用这个 script 一眼看全状态,
-# 避免人工 grep / parse 出错(pr1_num empty bug 那种)。
-#
-# 输出:
-#   1. 活跃 codex 数 + 每个的 log 名(harness-tracked vs detached 分别标)
-#   2. 完成 markers + 推荐下一步路由(per skill route table)
-#   3. 每个 open auto-loop PR 的 CI + reviewer 状态
-#   4. monitor zero_streak 最大值(过去 10 tick)
-#
-# Usage: bash .claude/skills/codex-refactor-loop/scripts/peek.sh
-#
-# ⟦AI:AUTO-LOOP⟧
+# This script intentionally prefers a local process/log snapshot. It does not
+# fetch, push, post comments, change labels, or call GitHub. When key loop
+# directories are missing, it delegates to visible-loop-health.sh as a degraded
+# helper so controller wakeups still have one stable command to run.
 
-set -e
-cd /Users/auric/aevatar
-git fetch origin --quiet 2>/dev/null
+set -euo pipefail
 
-echo "═══════════════ peek $(date -u +%H:%M:%SZ) ═══════════════"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper_script="$script_dir/visible-loop-health.sh"
+log_summary_script="$script_dir/visible-loop-log-summary.sh"
+script_git_root="$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+pwd_git_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 
-# 0. CRITICAL: maintainer 评论(non-AI 即非 sentinel)
-# per Auric 2026-05-21 漏读 #720 4h+ + 2026-05-22 #779 8h 漏读事故
-# 规则:
-#   (a) 最近 12h 任何 issue/PR 的 maintainer 评论 — 显示
-#   (b) stuck-label issue 的 LATEST maintainer 评论 — 无论多久都显示(避免漏读)
-echo ""
-echo "▍🚨 maintainer 评论(read first — 漏读 = controller bug):"
-{
-  gh issue list --label "auto-loop" --state open --json number 2>/dev/null | python3 -c "import json,sys; [print(f'i{x[\"number\"]}') for x in json.load(sys.stdin)]" 2>/dev/null
-  gh pr list --label "auto-loop" --state open --json number 2>/dev/null | python3 -c "import json,sys; [print(f'p{x[\"number\"]}') for x in json.load(sys.stdin)]" 2>/dev/null
-} | while read item; do
-  kind=$(echo "$item" | cut -c1)
-  num=$(echo "$item" | cut -c2-)
-  [ -z "$num" ] && continue
-  if [ "$kind" = "i" ]; then
-    raw=$(gh issue view "$num" --json comments 2>/dev/null)
+repo_root="${REPO_ROOT:-${script_git_root:-$pwd_git_root}}"
+host_env_status="missing"
+
+if [[ -n "$repo_root" && -f "$repo_root/.refactor-loop/host.env" ]]; then
+  host_env_status="present"
+  set +e +u
+  # shellcheck disable=SC1090
+  source "$repo_root/.refactor-loop/host.env"
+  source_rc=$?
+  set -euo pipefail
+  if [[ "$source_rc" -eq 0 ]]; then
+    host_env_status="loaded"
+    repo_root="${REPO_ROOT:-$repo_root}"
   else
-    raw=$(gh pr view "$num" --json comments 2>/dev/null)
+    host_env_status="load-failed"
   fi
-  echo "$raw" | python3 -c "
-import json, sys
-from datetime import datetime, timezone
-try:
-    data = json.load(sys.stdin)
-    cs = data.get('comments', [])
-except: sys.exit(0)
-# non-AI = not AI sentinel, not status banner prefix, not codecov bot
-non_ai = [c for c in cs if '⟦AI:AUTO-LOOP⟧' not in (c.get('body','') or '')
-          and not (c.get('body','') or '').lstrip().startswith(('## 📊', '## 🤖', '## ✅', '## 🆘'))
-          and not (c.get('author',{}) or {}).get('login','').endswith('[bot]')]
-if not non_ai: sys.exit(0)
-last = max(non_ai, key=lambda c: c.get('createdAt',''))
-# Find latest AI reply (any AI sentinel or status banner)
-ai = [c for c in cs if c.get('createdAt','') > last.get('createdAt','') and
-      ('⟦AI:AUTO-LOOP⟧' in (c.get('body','') or '') or (c.get('body','') or '').lstrip().startswith(('## 📊', '## 🤖', '## ✅', '## 🆘')))]
-has_ai_reply = bool(ai)
-ts_str = last.get('createdAt','').rstrip('Z')
-try:
-    ts = datetime.fromisoformat(ts_str).replace(tzinfo=timezone.utc)
-except: sys.exit(0)
-delta_h = (datetime.now(timezone.utc) - ts).total_seconds() / 3600
-# 12h cutoff OR no AI reply since(无回应必显示,无论多久)
-if delta_h > 12 and has_ai_reply: sys.exit(0)
-flag = '⏰ no-AI-reply' if not has_ai_reply else ''
-author = (last.get('author', {}) or {}).get('login', '?')
-body = (last.get('body','') or '').replace('\n',' ')[:200]
-print(f'  {flag} [{author}] ${num} ${kind} ({delta_h:.1f}h ago): {body}')
-" 2>/dev/null
-done
-
-# 1. Active codex
-n=$(ps -ef | grep -E "timeout (3600|5400) codex" | grep -v grep | wc -l | tr -d ' ')
-echo ""
-echo "▍活跃 codex: ${n}"
-if [ "$n" -gt 0 ]; then
-  ps -ef | grep -E "timeout (3600|5400) codex" | grep -v grep | \
-    sed -E 's/.*--log [^ ]*\/([^ ]+)\.log.*/  • \1/' | sort
 fi
 
-# 2. Recently finished markers (last 60 min) + routing hint
-echo ""
-echo "▍最近 60 min 完成 codex(marker → 推荐下一步):"
-find .refactor-loop/logs -name "*.log" -mmin -60 -type f 2>/dev/null | while read f; do
-  base=$(basename "$f" .log)
-  # Skip in-progress (no EXIT line)
-  exit_line=$(grep "^EXIT=" "$f" 2>/dev/null | tail -1)
-  [ -z "$exit_line" ] && continue
-  marker=$(grep -hE "^[+]?(AUDIT_DONE|AUDIT_INCOMPLETE|IMPLEMENT_DONE|IMPLEMENT_BLOCKED|FIX_DONE|FIX_BLOCKED|REVIEW_DONE|SOLVER_DONE|META_JUDGE_DONE|META_RESOLVED|TEST_ADD_DONE):" "$f" 2>/dev/null | sed -E 's/^[+]+//' | tail -1 | head -c 100)
-  [ -z "$marker" ] && continue
-  # Routing hint
-  hint=""
-  case "$marker" in
-    IMPLEMENT_DONE:*:ok*)    hint="→ commit/push + open PR + 3 reviewer r1" ;;
-    IMPLEMENT_DONE:*:partial|IMPLEMENT_DONE:*:blocked) hint="→ inspect + re-prompt or escalate" ;;
-    IMPLEMENT_BLOCKED:*)     hint="→ inspect blocker + meta-reflect" ;;
-    FIX_DONE:*)              hint="→ commit/push + 3 reviewer r+1" ;;
-    FIX_BLOCKED:*)           hint="→ meta-reflect" ;;
-    REVIEW_DONE:*:approve)   hint="→ wait other 2 reviewers,then merge if all approve / mixed: ≥2 approve + 0 reject = merge" ;;
-    REVIEW_DONE:*:comment)   hint="→ advisory; wait other reviewers" ;;
-    REVIEW_DONE:*:reject)    hint="→ wait other 2 reviewers,then fix r+1" ;;
-    SOLVER_DONE:*)           hint="→ wait other 2 solvers,then meta-judge" ;;
-    META_JUDGE_DONE:consensus:*) hint="→ implement codex (worktree + spawn)" ;;
-    META_JUDGE_DONE:converge:*)  hint="→ re-spawn 3 solver with convergence question" ;;
-    META_JUDGE_DONE:escalate:philosophy:*) hint="→ label escalate-human + ASCII problem banner" ;;
-    META_JUDGE_DONE:escalate:*)  hint="→ reflector codex" ;;
-    META_RESOLVED:retry-fix:*)   hint="→ implement codex(or fix r+1 if PR exists)" ;;
-    META_RESOLVED:re-design:*)   hint="→ close PR + Phase 9 fresh round" ;;
-    META_RESOLVED:re-cluster:*)  hint="→ close PR + audit re-split" ;;
-    META_RESOLVED:drop:*)        hint="→ close PR + close issue wontfix" ;;
-    META_RESOLVED:escalate-human:*) hint="→ label 🆘 + push notify" ;;
-    AUDIT_DONE:*)            hint="→ 验证 cluster evidence + 开 design issues + 派 implement" ;;
-    AUDIT_INCOMPLETE:*)      hint="→ re-dispatch audit with missing pieces" ;;
-    TEST_ADD_DONE:*)         hint="→ commit/push 等 CI" ;;
-  esac
-  echo "  • ${base}: ${marker}"
-  [ -n "$hint" ] && echo "    ${hint}"
-done
-
-# 3. Open auto-loop PRs + state
-echo ""
-echo "▍Open auto-loop PRs:"
-gh pr list --label "auto-loop" --state open --json number,title --jq '.[]' | while IFS= read -r line; do
-  num=$(echo "$line" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['number'])" 2>/dev/null)
-  title=$(echo "$line" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['title'][:60])" 2>/dev/null)
-  [ -z "$num" ] && continue
-  fail=$(gh pr checks "$num" --json bucket --jq '[.[] | select(.bucket=="fail") | 1] | length' 2>/dev/null)
-  pending=$(gh pr checks "$num" --json bucket --jq '[.[] | select(.bucket=="pending") | 1] | length' 2>/dev/null)
-  pass=$(gh pr checks "$num" --json bucket --jq '[.[] | select(.bucket=="pass") | 1] | length' 2>/dev/null)
-  state=$(gh pr view "$num" --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null)
-  echo "  • PR #${num} [${state}] CI: fail=${fail} pending=${pending} pass=${pass} — ${title}"
-done
-
-# 4. Monitor recent zero_streak max
-echo ""
-echo "▍Monitor zero_streak (过去 10 tick):"
-tail -10 .refactor-loop/logs/concurrency-monitor.log 2>/dev/null | \
-  grep -oE "zero_streak=[0-9]+" | sort -t= -k2 -rn | head -1 | sed 's/^/  最大: /'
-zero_now=$(tail -1 .refactor-loop/logs/concurrency-monitor.log 2>/dev/null | grep -oE "zero_streak=[0-9]+" | head -1)
-[ -n "$zero_now" ] && echo "  当前: ${zero_now}"
-
-# 5. Mergeable PRs (per reviewer consensus + CI green)
-echo ""
-echo "▍可合并 PR(controller 应立即 merge):"
-gh pr list --label "auto-loop" --state open --json number,title --jq '.[].number' 2>/dev/null | while read pr_num; do
-  [ -z "$pr_num" ] && continue
-  # CI must have 0 fail + 0 pending
-  fail=$(gh pr checks "$pr_num" --json bucket --jq '[.[] | select(.bucket=="fail") | 1] | length' 2>/dev/null)
-  pending=$(gh pr checks "$pr_num" --json bucket --jq '[.[] | select(.bucket=="pending") | 1] | length' 2>/dev/null)
-  [ "$fail" != "0" ] || [ "$pending" != "0" ] && continue
-  state=$(gh pr view "$pr_num" --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null)
-  # Reviewer consensus: latest round per role, count approve/reject/comment
-  # find latest round N for this PR
-  max_round=0
-  for r in 1 2 3 4 5 6; do
-    cnt=$(ls .refactor-loop/logs/review-pr${pr_num}-*-r${r}.log 2>/dev/null | wc -l | tr -d ' ')
-    [ "$cnt" -ge 3 ] && max_round=$r
-  done
-  [ "$max_round" = "0" ] && continue
-  approve=0; comment=0; reject=0
-  for role in architect tests quality; do
-    f=".refactor-loop/logs/review-pr${pr_num}-${role}-r${max_round}.log"
-    [ -f "$f" ] || continue
-    v=$(grep -hE "^[+]?REVIEW_DONE:" "$f" 2>/dev/null | sed -E 's/^[+]+//; s/.*:([a-z]+)\s*$/\1/' | tail -1)
-    case "$v" in
-      approve) approve=$((approve+1)) ;;
-      comment) comment=$((comment+1)) ;;
-      reject)  reject=$((reject+1)) ;;
-    esac
-  done
-  # Merge rule: 0 reject AND >= 2 approve (mixed comment OK)
-  if [ "$reject" = "0" ] && [ "$approve" -ge 2 ]; then
-    echo "  ✅ PR #${pr_num} [${state}] r${max_round}: approve=${approve} comment=${comment} reject=0 — gh pr merge ${pr_num} --admin --squash --delete-branch"
+if [[ -z "$repo_root" ]]; then
+  echo "codex_refactor_loop_peek"
+  echo "status=degraded"
+  echo "reason=not inside a git repository and REPO_ROOT is unset"
+  if [[ -x "$helper_script" ]]; then
+    echo "delegated_helper=$helper_script"
+    bash "$helper_script" || true
+  else
+    echo "delegated_helper=missing path=$helper_script"
   fi
-done
+  exit 0
+fi
 
-# 5b. Stale-label detection on CLOSED issues/PRs(per Auric 2026-05-21 "状态、PR跟issues的关联状态有问题")
-echo ""
-echo "▍Stale labels(已 CLOSED 但还挂 in-flight phase 标签):"
-gh issue list --label "auto-loop" --state closed --limit 30 --json number,labels --jq '.[] | "\(.number)|\(.labels | map(.name) | map(select(. | startswith("🔍") or startswith("🛠") or startswith("🔧") or startswith("👀") or startswith("⏸") or startswith("auto-loop-stuck") or startswith("🆘"))) | join(","))"' 2>/dev/null | while IFS='|' read -r num labels; do
-  [ -z "$num" ] || [ -z "$labels" ] && continue
-  echo "  ⚠️ closed issue #${num} 仍挂: ${labels}  → controller 应清理 + 加 🎉 phase:merged"
-done
-gh pr list --label "auto-loop" --state closed --limit 30 --json number,labels --jq '.[] | "\(.number)|\(.labels | map(.name) | map(select(. | startswith("🔍") or startswith("🛠") or startswith("🔧") or startswith("👀") or startswith("⏸") or startswith("auto-loop-stuck") or startswith("🆘") or startswith("🚀"))) | join(","))"' 2>/dev/null | while IFS='|' read -r num labels; do
-  [ -z "$num" ] || [ -z "$labels" ] && continue
-  echo "  ⚠️ closed PR #${num} 仍挂: ${labels}"
-done
+refactor_dir="$repo_root/.refactor-loop"
+log_dir="$refactor_dir/logs"
+prompt_dir="$refactor_dir/prompts"
+run_dir="$refactor_dir/runs"
 
-# 5c. Linkage check:open issues phase:implementing 但没对应 in-flight PR / open PRs 没对应 design issue
-echo ""
-echo "▍Issue/PR linkage 不一致:"
-gh issue list --label "🛠️ phase:implementing" --state open --json number,title --jq '.[] | "\(.number)|\(.title)"' 2>/dev/null | while IFS='|' read -r num title; do
-  [ -z "$num" ] && continue
-  # 找 closes #num 的 open PR
-  pr_count=$(gh pr list --label "auto-loop" --state open --search "in:body Closes #${num}" --json number --jq 'length' 2>/dev/null || echo 0)
-  if [ "$pr_count" = "0" ]; then
-    # 还要找 closed PR 是否已 merge
-    merged_pr=$(gh pr list --label "auto-loop" --state merged --search "in:body Closes #${num}" --json number --jq '.[0].number' 2>/dev/null)
-    if [ -z "$merged_pr" ] || [ "$merged_pr" = "null" ]; then
-      echo "  ⚠️ issue #${num} [🛠️ implementing] 无对应 in-flight 或 merged PR(implement codex 失败/未派?)"
-    else
-      echo "  ⚠️ issue #${num} [🛠️ implementing] PR #${merged_pr} 已 merged 但 issue 未关 — controller 应 gh issue close"
-    fi
-  fi
-done
-
-# 5d. Spawn drop detection: 3 solver artifact 完整但对应 judge log 没有
-echo ""
-echo "▍Spawn drop(solver 完成 N 但 judge 漏派):"
-for f in .refactor-loop/runs/phase9-issue*-r*-minimal.md; do
-  [ -f "$f" ] || continue
-  base=$(basename "$f" -minimal.md)
-  issue=$(echo "$base" | sed -E 's/phase9-issue([0-9]+)-r.*/\1/')
-  round=$(echo "$base" | sed -E 's/.*-r([0-9]+)/\1/')
-  s_min="$f"
-  s_str=".refactor-loop/runs/${base}-structural.md"
-  s_del=".refactor-loop/runs/${base}-delete.md"
-  judge_log=".refactor-loop/logs/${base}-judge.log"
-  if [ -f "$s_str" ] && [ -f "$s_del" ] && [ ! -f "$judge_log" ]; then
-    issue_state=$(gh issue view "$issue" --json state --jq '.state' 2>/dev/null)
-    [ "$issue_state" = "OPEN" ] || continue  # only flag if issue still open
-    echo "  ⚠️ issue #${issue} r${round} 3 solver done 但 judge log 不存在(需重派 judge)"
-  fi
-done
-
-# 6. Drift detection: phase:* label set but no log file being actively written for that issue/PR
-echo ""
-echo "▍Drift(label vs codex 不一致):"
-active_logs_file=$(mktemp)
-# 用 log 文件最近活跃来判断:no EXIT= 末行 + mtime < 10 min = codex 在跑
-for f in .refactor-loop/logs/*.log; do
-  [ -f "$f" ] || continue
-  # mtime > 10 min: 没在更新
-  [ -n "$(find "$f" -mmin -10)" ] || continue
-  # 已有 EXIT=:已完成
-  if grep -q "^EXIT=" "$f" 2>/dev/null; then continue; fi
-  basename "$f" .log >> "$active_logs_file"
-done
-check_drift() {
-  local kind="$1" num="$2" phase="$3"
-  case "$phase" in
-    *design-solving* | *implementing* | *fixing* | *reviewing*) ;;
-    *) return ;;
-  esac
-  if ! grep -qE "(pr${num}|issue${num})" "$active_logs_file" 2>/dev/null; then
-    echo "  ⚠️ ${kind} #${num} label=${phase} 但 0 codex referencing"
+path_status() {
+  local path="$1"
+  if [[ -d "$path" ]]; then
+    echo "present"
+  else
+    echo "missing"
   fi
 }
-gh issue list --label "auto-loop" --state open --json number,labels --jq '.[] | "\(.number)|\(.labels | map(.name) | map(select(. | startswith("🔍") or startswith("🛠") or startswith("🔧") or startswith("👀"))) | first)"' 2>/dev/null | while IFS='|' read -r num phase; do
-  [ -z "$num" ] || [ -z "$phase" ] && continue
-  check_drift issue "$num" "$phase"
-done
-gh pr list --label "auto-loop" --state open --json number,labels --jq '.[] | "\(.number)|\(.labels | map(.name) | map(select(. | startswith("🔍") or startswith("🛠") or startswith("🔧") or startswith("👀"))) | first)"' 2>/dev/null | while IFS='|' read -r num phase; do
-  [ -z "$num" ] || [ -z "$phase" ] && continue
-  check_drift pr "$num" "$phase"
-done
 
-# 7. Stale worktree(branch 已 merged 但 worktree 还在)
-echo ""
-echo "▍Stale worktree(branch 已 merged 应清理):"
-git worktree list --porcelain | grep "^worktree " | sed 's/^worktree //' | while read wt; do
-  base=$(basename "$wt")
-  # skip main + dev-sync
-  case "$base" in
-    aevatar | aevatar-wt-dev-sync) continue ;;
-  esac
-  # If worktree branch is in remote merged-to-master list, mark stale
-  branch=$(git -C "$wt" branch --show-current 2>/dev/null)
-  if [ -n "$branch" ]; then
-    # branch exists on remote? if not, stale
-    if ! git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
-      echo "  ⚠️ $wt  branch=$branch(remote 已不存在 — git worktree remove $wt --force && git branch -D $branch)"
-    fi
+file_status() {
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    echo "present"
+  else
+    echo "missing"
   fi
-done
+}
 
-# 8. Stuck-too-long(issue/PR 有 stuck label 且 last non-AI comment > 6h)
-echo ""
-echo "▍Stuck too long(>6h 无 maintainer 回复;考虑 4h reflector 重判):"
-gh issue list --label "auto-loop-stuck" --state open --json number,title 2>/dev/null | python3 -c "
-import json, sys, subprocess
-from datetime import datetime, timezone
-data = json.load(sys.stdin)
-for it in data:
-    num = it['number']
-    r = subprocess.run(['gh', 'issue', 'view', str(num), '--json', 'comments'], capture_output=True, text=True)
-    if r.returncode != 0: continue
-    try:
-        comments = json.loads(r.stdout).get('comments', [])
-    except:
-        continue
-    # filter non-AI(no ⟦AI:AUTO-LOOP⟧ sentinel)
-    non_ai = [c for c in comments if '⟦AI:AUTO-LOOP⟧' not in (c.get('body','') or '')]
-    if not non_ai: continue
-    last = max(non_ai, key=lambda c: c.get('createdAt',''))
-    ts_str = last.get('createdAt','').rstrip('Z')
-    try:
-        ts = datetime.fromisoformat(ts_str).replace(tzinfo=timezone.utc)
-    except:
-        continue
-    delta_h = (datetime.now(timezone.utc) - ts).total_seconds() / 3600
-    if delta_h > 6:
-        print(f'  ⚠️ #{num} last maintainer comment {delta_h:.1f}h ago — {it[\"title\"][:50]}')
-" 2>/dev/null
+count_files() {
+  local dir="$1"
+  if [[ ! -d "$dir" ]]; then
+    echo 0
+    return
+  fi
+  find "$dir" -type f 2>/dev/null | wc -l | tr -d ' '
+}
 
-# 9. Open auto-loop issues + label state
-echo ""
-echo "▍Open auto-loop issues:"
-gh issue list --label "auto-loop" --state open --json number,title,labels --jq '.[] | "  • #\(.number) labels=[\(.labels | map(.name) | map(select(. | startswith("🔍") or startswith("🛠") or startswith("⚙") or startswith("⏸") or startswith("🆘") or startswith("👤") or startswith("🤖"))) | join(", "))] — \(.title | .[0:55])"' 2>/dev/null
+tail_exit_line() {
+  local file="$1"
+  tail -5 "$file" 2>/dev/null | grep -E "^EXIT=[0-9]+$" | tail -1 || true
+}
 
-echo ""
-echo "═══════════════════════════════════════════════════"
+tail_exit_code() {
+  local file="$1"
+  local line
+  line="$(tail_exit_line "$file")"
+  if [[ -z "$line" ]]; then
+    echo "none"
+  else
+    echo "${line#EXIT=}"
+  fi
+}
+
+marker_from_log() {
+  local file="$1"
+  grep -hE "^[+]?(AUDIT_DONE|AUDIT_INCOMPLETE|IMPLEMENT_DONE|IMPLEMENT_BLOCKED|FIX_DONE|FIX_BLOCKED|REVIEW_DONE|SOLVER_DONE|META_JUDGE_DONE|META_RESOLVED|TEST_ADD_DONE):" "$file" 2>/dev/null \
+    | grep -vE "<reason>|<id>|<status>|<category>|<framing>|<role>|<verdict>|round-N" \
+    | sed -E 's/^[+]+//' \
+    | tail -1 \
+    | head -c 180 \
+    || true
+}
+
+route_hint() {
+  local marker="$1"
+  case "$marker" in
+    IMPLEMENT_DONE:*:ok*) echo "commit/push/open PR, then spawn 3 reviewers" ;;
+    IMPLEMENT_DONE:*:partial|IMPLEMENT_DONE:*:blocked) echo "inspect blocker, then re-prompt or reflect" ;;
+    IMPLEMENT_BLOCKED:*) echo "inspect blocker, then meta-reflect" ;;
+    FIX_DONE:*) echo "commit/push, then spawn reviewer round r+1" ;;
+    FIX_BLOCKED:*) echo "meta-reflect before more fix work" ;;
+    REVIEW_DONE:*:approve) echo "wait for remaining reviewers; merge only with consensus and green checks" ;;
+    REVIEW_DONE:*:comment) echo "advisory review; wait for remaining reviewers" ;;
+    REVIEW_DONE:*:reject) echo "wait for remaining reviewers, then spawn fix round r+1" ;;
+    SOLVER_DONE:*) echo "wait for 3 solvers in the same round, then spawn meta-judge" ;;
+    META_JUDGE_DONE:consensus:*) echo "spawn implementation codex" ;;
+    META_JUDGE_DONE:converge:*) echo "spawn next solver round with convergence framing" ;;
+    META_JUDGE_DONE:escalate:*) echo "spawn reflector or re-judge legacy escalation output" ;;
+    META_RESOLVED:retry-fix:*) echo "spawn implement or fix codex, depending on PR state" ;;
+    META_RESOLVED:re-design:*) echo "close stale PR path and start a fresh design round" ;;
+    META_RESOLVED:re-cluster:*) echo "close stale PR path and re-run audit split" ;;
+    META_RESOLVED:drop:*) echo "close issue as intentionally dropped" ;;
+    META_RESOLVED:escalate-human:*) echo "only now label human-blocked and post a decision banner" ;;
+    AUDIT_DONE:*) echo "validate evidence, open design issues, then dispatch implementation" ;;
+    AUDIT_INCOMPLETE:*) echo "re-dispatch audit for missing evidence" ;;
+    TEST_ADD_DONE:*) echo "commit/push test additions and wait for CI" ;;
+    *) echo "" ;;
+  esac
+}
+
+print_process_snapshot() {
+  local repo_scoped=0
+  local loop_like=0
+  local direct_codex=0
+  local line
+  local scoped_lines=()
+  local unscoped_lines=()
+
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    if [[ "$line" == *"codex exec"* ]]; then
+      direct_codex=$((direct_codex + 1))
+    fi
+    if [[ "$line" == *"spawn-codex.sh"* ]] &&
+       { [[ "$line" == *".refactor-loop/logs/"* ]] || [[ "$line" == *".refactor-loop/prompts/"* ]]; }; then
+      loop_like=$((loop_like + 1))
+      if [[ "$line" == *"$repo_root"* ]]; then
+        repo_scoped=$((repo_scoped + 1))
+        scoped_lines+=("$line")
+      else
+        unscoped_lines+=("$line")
+      fi
+    fi
+  done < <(ps -eo command= 2>/dev/null || ps -ef 2>/dev/null || true)
+
+  echo "active_codex:"
+  echo "  repo_scoped_spawn_codex=$repo_scoped"
+  echo "  loop_like_spawn_codex=$loop_like"
+  echo "  direct_codex_exec=$direct_codex"
+
+  if [[ "${#scoped_lines[@]}" -gt 0 ]]; then
+    echo "active_repo_scoped_logs:"
+    printf '%s\n' "${scoped_lines[@]}" \
+      | sed -E 's/[[:space:]]+/ /g; s#.*--log ([^ ]*/)?([^/ ]+)\.log.*#  \2#' \
+      | sort \
+      | head -10
+  fi
+
+  if [[ "$repo_scoped" -eq 0 && "${#unscoped_lines[@]}" -gt 0 ]]; then
+    echo "unscoped_loop_like_processes:"
+    printf '  %s\n' "${unscoped_lines[@]}" | sed -E 's/[[:space:]]+/ /g' | head -5
+  fi
+}
+
+print_active_logs() {
+  if [[ ! -d "$log_dir" ]]; then
+    echo "active_logs_last_10m:"
+    echo "  unavailable: logs directory missing"
+    return
+  fi
+
+  local found=0
+  local file
+  echo "active_logs_last_10m:"
+  while IFS= read -r file; do
+    [[ -f "$file" ]] || continue
+    [[ "$(tail_exit_code "$file")" == "none" ]] || continue
+    found=1
+    echo "  $(basename "$file")"
+  done < <(find "$log_dir" -name "*.log" -type f -mmin -10 2>/dev/null | sort || true)
+
+  if [[ "$found" -eq 0 ]]; then
+    echo "  none"
+  fi
+}
+
+print_recent_markers() {
+  if [[ ! -d "$log_dir" ]]; then
+    echo "recent_finished_markers_last_60m:"
+    echo "  unavailable: logs directory missing"
+    return
+  fi
+
+  local found=0
+  local file
+  local exit_code
+  local marker
+  local hint
+  echo "recent_finished_markers_last_60m:"
+  while IFS= read -r file; do
+    [[ -f "$file" ]] || continue
+    exit_code="$(tail_exit_code "$file")"
+    [[ "$exit_code" != "none" ]] || continue
+    marker="$(marker_from_log "$file")"
+    [[ -n "$marker" ]] || continue
+    found=1
+    echo "  $(basename "$file"): exit=$exit_code marker=$marker"
+    if [[ "$exit_code" == "0" ]]; then
+      hint="$(route_hint "$marker")"
+      [[ -z "$hint" ]] || echo "    next=$hint"
+    else
+      echo "    next=inspect failed log before routing"
+    fi
+  done < <(find "$log_dir" -name "*.log" -type f -mmin -60 2>/dev/null | sort || true)
+
+  if [[ "$found" -eq 0 ]]; then
+    echo "  none"
+  fi
+}
+
+print_visible_loop_log_summaries() {
+  if [[ ! -d "$log_dir" ]]; then
+    echo "visible_loop_log_summaries_last_60m:"
+    echo "  unavailable: logs directory missing"
+    return
+  fi
+
+  if [[ ! -x "$log_summary_script" ]]; then
+    echo "visible_loop_log_summaries_last_60m:"
+    echo "  unavailable: log summary helper missing path=$log_summary_script"
+    return
+  fi
+
+  local files=()
+  local file
+  while IFS= read -r file; do
+    files+=("$file")
+  done < <(find "$log_dir" -name "visible-*.log" -type f -mmin -60 2>/dev/null | sort || true)
+
+  echo "visible_loop_log_summaries_last_60m:"
+  if [[ "${#files[@]}" -eq 0 ]]; then
+    echo "  none"
+    return
+  fi
+
+  "$log_summary_script" "${files[@]}" | sed 's/^/  /'
+}
+
+print_monitor_snapshot() {
+  local monitor_log="$log_dir/concurrency-monitor.log"
+  echo "monitor:"
+  echo "  alert_log=$(file_status "$refactor_dir/.concurrency-alert.log")"
+  echo "  pending_events=$(file_status "$refactor_dir/.controller-pending-events.log")"
+  echo "  monitor_state=$(file_status "$refactor_dir/.concurrency-monitor-state.json")"
+  if [[ -f "$monitor_log" ]]; then
+    local max_zero
+    local current_zero
+    max_zero="$(tail -10 "$monitor_log" 2>/dev/null | grep -oE "zero_streak=[0-9]+" | sort -t= -k2 -rn | head -1 || true)"
+    current_zero="$(tail -1 "$monitor_log" 2>/dev/null | grep -oE "zero_streak=[0-9]+" | head -1 || true)"
+    echo "  zero_streak_max_10_ticks=${max_zero:-none}"
+    echo "  zero_streak_current=${current_zero:-none}"
+  else
+    echo "  zero_streak_max_10_ticks=unavailable"
+    echo "  zero_streak_current=unavailable"
+  fi
+}
+
+degraded_reasons=()
+[[ "$host_env_status" == "loaded" ]] || degraded_reasons+=("host_env_$host_env_status")
+[[ -d "$log_dir" ]] || degraded_reasons+=("logs_missing")
+[[ -d "$prompt_dir" ]] || degraded_reasons+=("prompts_missing")
+
+echo "codex_refactor_loop_peek"
+echo "timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "repo_root=$repo_root"
+echo "branch=$(git -C "$repo_root" branch --show-current 2>/dev/null || echo unknown)"
+echo "host_env=$host_env_status path=$repo_root/.refactor-loop/host.env"
+echo "refactor_loop_dir=$(path_status "$refactor_dir")"
+echo "logs_dir=$(path_status "$log_dir") file_count=$(count_files "$log_dir")"
+echo "prompts_dir=$(path_status "$prompt_dir") file_count=$(count_files "$prompt_dir")"
+echo "runs_dir=$(path_status "$run_dir") file_count=$(count_files "$run_dir")"
+echo "github_state=skipped local_read_only_peek"
+
+print_process_snapshot
+print_active_logs
+print_recent_markers
+print_visible_loop_log_summaries
+print_monitor_snapshot
+
+if [[ "${#degraded_reasons[@]}" -gt 0 ]]; then
+  echo "degraded=true"
+  printf 'degraded_reasons=%s\n' "$(IFS=,; echo "${degraded_reasons[*]}")"
+  if [[ -x "$helper_script" ]]; then
+    echo "delegated_helper=$helper_script"
+    bash "$helper_script" || true
+  else
+    echo "delegated_helper=missing path=$helper_script"
+  fi
+else
+  echo "degraded=false"
+fi

--- a/.claude/skills/codex-refactor-loop/scripts/portable-timeout.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/portable-timeout.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Cross-platform timeout wrapper for codex-refactor-loop process scripts.
+#
+# Linux hosts keep using GNU timeout when it is available. macOS hosts with
+# coreutils use gtimeout. Hosts with neither fall back to a shell watchdog that
+# returns 124 after the wall-clock limit, matching GNU timeout's timeout exit.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: portable-timeout.sh [--select] <seconds> <command> [args...]" >&2
+}
+
+select_timeout_runner() {
+  if [[ "${CODEX_LOOP_FORCE_TIMEOUT_FALLBACK:-0}" != "1" ]]; then
+    if command -v timeout >/dev/null 2>&1; then
+      echo "timeout"
+      return 0
+    fi
+    if command -v gtimeout >/dev/null 2>&1; then
+      echo "gtimeout"
+      return 0
+    fi
+  fi
+
+  echo "shell-fallback"
+}
+
+run_shell_timeout() {
+  local duration="$1"
+  shift
+
+  local command_pid=""
+  local timer_pid=""
+  local exit_code=0
+  local timeout_marker
+  timeout_marker="$(mktemp "${TMPDIR:-/tmp}/codex-loop-timeout.XXXXXXXX")"
+  rm -f "$timeout_marker"
+
+  "$@" &
+  command_pid=$!
+
+  (
+    sleep "$duration"
+    printf 'timeout\n' > "$timeout_marker"
+    kill -TERM "$command_pid" 2>/dev/null || exit 0
+    sleep "${CODEX_LOOP_TIMEOUT_KILL_AFTER:-5}"
+    kill -KILL "$command_pid" 2>/dev/null || true
+  ) &
+  timer_pid=$!
+
+  set +e
+  wait "$command_pid" 2>/dev/null
+  exit_code=$?
+  set -e
+
+  if [[ -f "$timeout_marker" ]]; then
+    wait "$timer_pid" 2>/dev/null || true
+    rm -f "$timeout_marker"
+    return 124
+  fi
+
+  kill "$timer_pid" 2>/dev/null || true
+  wait "$timer_pid" 2>/dev/null || true
+  rm -f "$timeout_marker"
+  return "$exit_code"
+}
+
+if [[ "${1:-}" == "--select" ]]; then
+  select_timeout_runner
+  exit 0
+fi
+
+if [[ $# -lt 2 ]]; then
+  usage
+  exit 2
+fi
+
+duration="$1"
+shift
+
+if [[ ! "$duration" =~ ^[0-9]+$ ]] || (( duration <= 0 )); then
+  echo "timeout seconds must be a positive integer: $duration" >&2
+  exit 2
+fi
+
+runner="$(select_timeout_runner)"
+case "$runner" in
+  timeout|gtimeout)
+    exec "$runner" "$duration" "$@"
+    ;;
+  shell-fallback)
+    run_shell_timeout "$duration" "$@"
+    exit $?
+    ;;
+  *)
+    echo "unknown timeout runner: $runner" >&2
+    exit 2
+    ;;
+esac

--- a/.claude/skills/codex-refactor-loop/scripts/portable-timeout.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/portable-timeout.sh
@@ -33,11 +33,14 @@ run_shell_timeout() {
   local command_pid=""
   local timer_pid=""
   local exit_code=0
+  local stdin_copy=""
   local timeout_marker
   timeout_marker="$(mktemp "${TMPDIR:-/tmp}/codex-loop-timeout.XXXXXXXX")"
   rm -f "$timeout_marker"
+  stdin_copy="$(mktemp "${TMPDIR:-/tmp}/codex-loop-stdin.XXXXXXXX")"
+  cat > "$stdin_copy"
 
-  "$@" &
+  "$@" < "$stdin_copy" &
   command_pid=$!
 
   (
@@ -57,12 +60,14 @@ run_shell_timeout() {
   if [[ -f "$timeout_marker" ]]; then
     wait "$timer_pid" 2>/dev/null || true
     rm -f "$timeout_marker"
+    rm -f "$stdin_copy"
     return 124
   fi
 
   kill "$timer_pid" 2>/dev/null || true
   wait "$timer_pid" 2>/dev/null || true
   rm -f "$timeout_marker"
+  rm -f "$stdin_copy"
   return "$exit_code"
 }
 

--- a/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh
@@ -25,6 +25,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TIMEOUT_WRAPPER="$SCRIPT_DIR/portable-timeout.sh"
+
 CD=""
 PROMPT=""
 PROMPT_TEXT=""
@@ -70,6 +73,11 @@ if [[ ! -f "$PROMPT" ]]; then
   exit 2
 fi
 
+if [[ ! -x "$TIMEOUT_WRAPPER" ]]; then
+  echo "timeout wrapper is not executable: $TIMEOUT_WRAPPER" >&2
+  exit 2
+fi
+
 # Project-wide minimum codex timeout: 3600s (1 hour). See CLAUDE.md
 # "Codex CLI 调用规范". Shorter timeouts cause codex to truncate
 # deep-scan / multi-file refactor work and inflate the controller's
@@ -112,7 +120,7 @@ ARGS+=(-)
 # Run with a hard wall-clock timeout. The harness watches the process; codex exits naturally
 # on completion. Append EXIT/DONE_AT footers so controller can post-mortem from log alone.
 set +e
-timeout "$TIMEOUT" codex "${ARGS[@]}" < "$PROMPT" > "$LOG" 2>&1
+"$TIMEOUT_WRAPPER" "$TIMEOUT" codex "${ARGS[@]}" < "$PROMPT" > "$LOG" 2>&1
 EXIT=$?
 set -e
 

--- a/.claude/skills/codex-refactor-loop/scripts/visible-loop-batch-files.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/visible-loop-batch-files.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Read-only file-count guard for the visible-loop process automation batch.
+#
+# Counts only modified tracked files and prospective tracked files under the
+# codex-refactor-loop skill directory. It deliberately excludes backend,
+# frontend, architecture docs, and shared dirty workspace files by path scope.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: visible-loop-batch-files.sh [minimum-count]" >&2
+  echo "   or: visible-loop-batch-files.sh --min <minimum-count>" >&2
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || true)"
+minimum_count=10
+scope_path=".claude/skills/codex-refactor-loop"
+status=0
+batch_files=()
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  --min)
+    if [[ $# -ne 2 ]]; then
+      usage
+      exit 2
+    fi
+    minimum_count="$2"
+    ;;
+  "")
+    ;;
+  *)
+    if [[ $# -ne 1 ]]; then
+      usage
+      exit 2
+    fi
+    minimum_count="$1"
+    ;;
+esac
+
+if [[ -z "$repo_root" ]]; then
+  echo "visible_loop_batch_files"
+  echo "status=blocked"
+  echo "reason=not inside a git repository"
+  exit 2
+fi
+
+if [[ ! "$minimum_count" =~ ^[0-9]+$ || "$minimum_count" -eq 0 ]]; then
+  echo "minimum count must be a positive integer: $minimum_count" >&2
+  exit 2
+fi
+
+while IFS= read -r file; do
+  [[ -n "$file" ]] || continue
+  batch_files+=("$file")
+done < <(git -C "$repo_root" ls-files -m -o --exclude-standard "$scope_path" | sort)
+
+file_count="${#batch_files[@]}"
+
+echo "visible_loop_batch_files"
+echo "repo_root=$repo_root"
+echo "scope=$scope_path"
+echo "excluded_scopes=backend,frontend,architecture_docs,shared_dirty_workspace"
+echo "minimum_count=$minimum_count"
+echo "file_count=$file_count"
+echo "files:"
+if [[ "$file_count" -eq 0 ]]; then
+  echo "  none"
+else
+  printf '  %s\n' "${batch_files[@]}"
+fi
+
+if (( file_count < minimum_count )); then
+  echo "threshold_status=below"
+  echo "shortfall=$((minimum_count - file_count))"
+  status=1
+else
+  echo "threshold_status=reached"
+  echo "shortfall=0"
+fi
+
+exit "$status"

--- a/.claude/skills/codex-refactor-loop/scripts/visible-loop-health.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/visible-loop-health.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# Read-only fallback health report for visible loop workers.
+#
+# This helper is intentionally smaller than peek.sh. It does not require
+# .refactor-loop/host.env, does not call GitHub, and does not mutate loop state.
+# Use it when the preferred peek path is unavailable or cannot be trusted.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_git_root="$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+pwd_git_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+
+repo_root="${REPO_ROOT:-${script_git_root:-$pwd_git_root}}"
+host_env="$repo_root/.refactor-loop/host.env"
+host_env_status="missing"
+
+if [[ -f "$host_env" ]]; then
+  host_env_status="present"
+  set +e +u
+  # shellcheck disable=SC1090
+  source "$host_env"
+  source_rc=$?
+  set -euo pipefail
+  if [[ "$source_rc" -eq 0 ]]; then
+    host_env_status="loaded"
+    repo_root="${REPO_ROOT:-$repo_root}"
+  else
+    host_env_status="load-failed"
+  fi
+fi
+
+if [[ -z "$repo_root" ]]; then
+  echo "visible_loop_process_health"
+  echo "status=blocked"
+  echo "reason=not inside a git repository and REPO_ROOT is unset"
+  exit 2
+fi
+
+refactor_dir="$repo_root/.refactor-loop"
+log_dir="$refactor_dir/logs"
+prompt_dir="$refactor_dir/prompts"
+run_dir="$refactor_dir/runs"
+peek_script="$repo_root/.claude/skills/codex-refactor-loop/scripts/peek.sh"
+log_summary_script="$repo_root/.claude/skills/codex-refactor-loop/scripts/visible-loop-log-summary.sh"
+
+count_files() {
+  local dir="$1"
+  if [[ ! -d "$dir" ]]; then
+    echo 0
+    return
+  fi
+  find "$dir" -type f 2>/dev/null | wc -l | tr -d ' '
+}
+
+tail_has_exit() {
+  local file="$1"
+  tail -5 "$file" 2>/dev/null | grep -q "^EXIT="
+}
+
+print_recent_markers() {
+  if [[ ! -d "$log_dir" ]]; then
+    echo "  none: logs directory missing"
+    return
+  fi
+
+  local found=0
+  while IFS= read -r file; do
+    [[ -f "$file" ]] || continue
+    tail_has_exit "$file" || continue
+    marker="$(
+      grep -hE "^[+]?(AUDIT_DONE|AUDIT_INCOMPLETE|IMPLEMENT_DONE|IMPLEMENT_BLOCKED|FIX_DONE|FIX_BLOCKED|REVIEW_DONE|SOLVER_DONE|META_JUDGE_DONE|META_RESOLVED|TEST_ADD_DONE):" "$file" 2>/dev/null \
+        | sed -E 's/^[+]+//' \
+        | tail -1 \
+        | head -c 160 \
+        || true
+    )"
+    [[ -n "$marker" ]] || continue
+    found=1
+    echo "  $(basename "$file"): $marker"
+  done < <(find "$log_dir" -name "*.log" -type f -mmin -60 2>/dev/null | sort)
+
+  if [[ "$found" -eq 0 ]]; then
+    echo "  none"
+  fi
+}
+
+print_active_logs() {
+  if [[ ! -d "$log_dir" ]]; then
+    echo "  none: logs directory missing"
+    return
+  fi
+
+  local found=0
+  while IFS= read -r file; do
+    [[ -f "$file" ]] || continue
+    tail_has_exit "$file" && continue
+    found=1
+    echo "  $(basename "$file")"
+  done < <(find "$log_dir" -name "*.log" -type f -mmin -10 2>/dev/null | sort)
+
+  if [[ "$found" -eq 0 ]]; then
+    echo "  none"
+  fi
+}
+
+print_visible_loop_log_summaries() {
+  if [[ ! -d "$log_dir" ]]; then
+    echo "  none: logs directory missing"
+    return
+  fi
+
+  if [[ ! -x "$log_summary_script" ]]; then
+    echo "  none: log summary helper missing path=$log_summary_script"
+    return
+  fi
+
+  local files=()
+  local file
+  while IFS= read -r file; do
+    files+=("$file")
+  done < <(find "$log_dir" -name "visible-*.log" -type f -mmin -60 2>/dev/null | sort || true)
+
+  if [[ "${#files[@]}" -eq 0 ]]; then
+    echo "  none"
+    return
+  fi
+
+  "$log_summary_script" "${files[@]}" | sed 's/^/  /'
+}
+
+process_report() {
+  local repo_scoped=0
+  local loop_like=0
+  local direct_codex=0
+  local scoped_lines=()
+  local loop_like_lines=()
+
+  while IFS= read -r line; do
+    if [[ "$line" == *"codex exec"* ]]; then
+      direct_codex=$((direct_codex + 1))
+    fi
+    if [[ "$line" == *"spawn-codex.sh"* ]] &&
+       { [[ "$line" == *".refactor-loop/logs/"* ]] || [[ "$line" == *".refactor-loop/prompts/"* ]]; }; then
+      loop_like=$((loop_like + 1))
+      if [[ "$line" == *"$repo_root"* ]]; then
+        repo_scoped=$((repo_scoped + 1))
+        scoped_lines+=("$line")
+      else
+        loop_like_lines+=("$line")
+      fi
+    fi
+  done < <(ps -eo command= 2>/dev/null || ps -ef 2>/dev/null || true)
+
+  echo "process_counts:"
+  echo "  repo_scoped_spawn_codex=$repo_scoped"
+  echo "  loop_like_spawn_codex=$loop_like"
+  echo "  direct_codex_exec=$direct_codex"
+
+  if [[ "${#scoped_lines[@]}" -gt 0 ]]; then
+    echo "repo_scoped_processes:"
+    printf '  %s\n' "${scoped_lines[@]}" | sed -E 's/[[:space:]]+/ /g' | head -5
+  fi
+
+  if [[ "$repo_scoped" -eq 0 && "${#loop_like_lines[@]}" -gt 0 ]]; then
+    echo "unscoped_loop_like_processes:"
+    printf '  %s\n' "${loop_like_lines[@]}" | sed -E 's/[[:space:]]+/ /g' | head -5
+  fi
+}
+
+path_status() {
+  local path="$1"
+  if [[ -d "$path" ]]; then
+    echo "present"
+  else
+    echo "missing"
+  fi
+}
+
+file_status() {
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    echo "present"
+  else
+    echo "missing"
+  fi
+}
+
+echo "visible_loop_process_health"
+echo "repo_root=$repo_root"
+echo "host_env=$host_env_status path=$host_env"
+echo "peek_sh=$(file_status "$peek_script") path=$peek_script"
+echo "log_summary_sh=$(file_status "$log_summary_script") path=$log_summary_script"
+echo "refactor_loop_dir=$(path_status "$refactor_dir")"
+echo "logs_dir=$(path_status "$log_dir") file_count=$(count_files "$log_dir")"
+echo "prompts_dir=$(path_status "$prompt_dir") file_count=$(count_files "$prompt_dir")"
+echo "runs_dir=$(path_status "$run_dir") file_count=$(count_files "$run_dir")"
+process_report
+echo "active_logs_last_10m:"
+print_active_logs
+echo "recent_finished_markers_last_60m:"
+print_recent_markers
+echo "visible_loop_log_summaries_last_60m:"
+print_visible_loop_log_summaries
+echo "monitor_files:"
+echo "  alert_log=$(file_status "$refactor_dir/.concurrency-alert.log")"
+echo "  pending_events=$(file_status "$refactor_dir/.controller-pending-events.log")"
+echo "  monitor_state=$(file_status "$refactor_dir/.concurrency-monitor-state.json")"
+
+if [[ "$host_env_status" == "missing" || ! -f "$peek_script" || ! -d "$log_dir" ]]; then
+  echo "conservative_status=degraded"
+else
+  echo "conservative_status=available"
+fi

--- a/.claude/skills/codex-refactor-loop/scripts/visible-loop-log-summary.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/visible-loop-log-summary.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Read-only visible-loop worker log summarizer.
+#
+# Completion is intentionally strict: a log is finished only when its last
+# five lines contain an exact EXIT=0 footer. Prompt templates and echoed marker
+# examples are ignored, and worker markers are reported only after completion.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: visible-loop-log-summary.sh <log-path> [log-path...]" >&2
+}
+
+tail_exit_line() {
+  local file="$1"
+  tail -5 "$file" 2>/dev/null | grep -E "^EXIT=[0-9]+$" | tail -1 || true
+}
+
+tail_has_exit_zero() {
+  local file="$1"
+  tail -5 "$file" 2>/dev/null | grep -q "^EXIT=0$"
+}
+
+tail_done_at() {
+  local file="$1"
+  tail -5 "$file" 2>/dev/null | grep -E "^DONE_AT=" | tail -1 | cut -d= -f2- || true
+}
+
+normalize_marker_line() {
+  local line="$1"
+  line="${line#"${line%%[![:space:]]*}"}"
+  line="${line#+}"
+  line="${line#"${line%%[![:space:]]*}"}"
+  printf '%s\n' "$line"
+}
+
+is_real_visible_worker_marker() {
+  local line="$1"
+  local prefix
+  local role
+  local status
+  local reason
+  local extra
+
+  case "$line" in
+    *"<"*|*">"*|*"EXIT=\$?"*|*"\$?"*) return 1 ;;
+  esac
+
+  [[ "$line" == VISIBLE_WORKER_DONE:* ]] || return 1
+
+  IFS=: read -r prefix role status reason extra <<< "$line"
+  [[ "$prefix" == "VISIBLE_WORKER_DONE" ]] || return 1
+  [[ -n "${role:-}" && -n "${status:-}" && -n "${reason:-}" && -z "${extra:-}" ]] || return 1
+  [[ "$status" == "ok" || "$status" == "blocked" ]] || return 1
+  [[ "$role" =~ ^[A-Za-z0-9._-]+$ ]] || return 1
+  [[ "$reason" =~ ^[A-Za-z0-9._/-]+$ ]] || return 1
+
+  case "$role" in
+    role|Role|ROLE|placeholder|example) return 1 ;;
+  esac
+
+  case "$reason" in
+    reason|short-reason|SHORT_REASON|placeholder|example|todo|TODO) return 1 ;;
+  esac
+
+  return 0
+}
+
+latest_visible_worker_marker() {
+  local file="$1"
+  local line
+  local normalized
+  local marker=""
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    normalized="$(normalize_marker_line "$line")"
+    if is_real_visible_worker_marker "$normalized"; then
+      marker="$normalized"
+    fi
+  done < "$file"
+
+  printf '%s\n' "$marker"
+}
+
+summarize_log() {
+  local file="$1"
+  local base
+  local exit_line
+  local exit_code="none"
+  local done_at
+  local finished="false"
+  local marker="none"
+
+  base="$(basename "$file")"
+
+  if [[ ! -f "$file" ]]; then
+    echo "$base exists=false finished=false exit=none done_at=none marker=none path=$file"
+    return 0
+  fi
+
+  exit_line="$(tail_exit_line "$file")"
+  if [[ -n "$exit_line" ]]; then
+    exit_code="${exit_line#EXIT=}"
+  fi
+
+  done_at="$(tail_done_at "$file")"
+  if [[ -z "$done_at" ]]; then
+    done_at="none"
+  fi
+
+  if tail_has_exit_zero "$file"; then
+    finished="true"
+    marker="$(latest_visible_worker_marker "$file")"
+    if [[ -z "$marker" ]]; then
+      marker="none"
+    fi
+  fi
+
+  echo "$base exists=true finished=$finished exit=$exit_code done_at=$done_at marker=$marker path=$file"
+}
+
+if [[ $# -eq 0 ]]; then
+  usage
+  exit 2
+fi
+
+for log_path in "$@"; do
+  summarize_log "$log_path"
+done

--- a/.claude/skills/codex-refactor-loop/scripts/visible-loop-pr-body-check.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/visible-loop-pr-body-check.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Read-only PR body readiness guard for visible-loop automation batches.
+#
+# This script validates a local PR body draft only. It does not call GitHub and
+# does not create, edit, or publish a PR.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: visible-loop-pr-body-check.sh <pr-body-file>" >&2
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 2
+fi
+
+body_file="$1"
+status=0
+required_base="feat/2026-05-29_ai-automation-pipeline"
+
+echo "visible_loop_pr_body_check"
+echo "body_file=$body_file"
+
+if [[ ! -f "$body_file" ]]; then
+  echo "status=blocked"
+  echo "reason=body_file_not_found"
+  exit 2
+fi
+
+check_pattern() {
+  local name="$1"
+  local pattern="$2"
+
+  if grep -Eiq "$pattern" "$body_file"; then
+    echo "check=$name result=ok"
+  else
+    echo "check=$name result=failed"
+    status=1
+  fi
+}
+
+check_problem_solution() {
+  local has_problem=0
+  local has_solution=0
+
+  grep -Eiq '(problem|issue|why)' "$body_file" && has_problem=1
+  grep -Eiq '(solution|approach|fix|change)' "$body_file" && has_solution=1
+
+  if [[ "$has_problem" -eq 1 && "$has_solution" -eq 1 ]]; then
+    echo "check=problem_solution result=ok"
+  else
+    echo "check=problem_solution result=failed"
+    status=1
+  fi
+}
+
+check_validation() {
+  local has_validation=0
+  local has_result=0
+
+  grep -Eiq '(validation|verification|validated|verify)' "$body_file" && has_validation=1
+  grep -Eiq '(command|result|passed|ok|exit=0)' "$body_file" && has_result=1
+
+  if [[ "$has_validation" -eq 1 && "$has_result" -eq 1 ]]; then
+    echo "check=validation_commands_results result=ok"
+  else
+    echo "check=validation_commands_results result=failed"
+    status=1
+  fi
+}
+
+check_file_list() {
+  local path_count
+  local has_list_phrase=0
+
+  path_count="$(
+    grep -Eo '\.claude/skills/codex-refactor-loop/[^ )`",]+' "$body_file" 2>/dev/null \
+      | sort -u \
+      | wc -l \
+      | tr -d ' '
+  )"
+  grep -Eiq '(10[- ]file|ten[- ]file|file list|meaningful file)' "$body_file" && has_list_phrase=1
+
+  echo "check=ten_file_list path_count=$path_count"
+  if [[ "$has_list_phrase" -eq 1 && "$path_count" -ge 10 ]]; then
+    echo "check=ten_file_list result=ok"
+  else
+    echo "check=ten_file_list result=failed"
+    status=1
+  fi
+}
+
+check_required_base() {
+  if grep -Fq "$required_base" "$body_file"; then
+    echo "check=required_base result=ok base=$required_base"
+  else
+    echo "check=required_base result=failed base=$required_base"
+    status=1
+  fi
+}
+
+check_problem_solution
+check_pattern "same_batch_rationale" '(same[- ]batch|same batch|batch rationale|rationale.*batch|why.*batch)'
+check_pattern "affected_paths" '(affected paths?|changed paths?|impact paths?|paths touched|path impact)'
+check_file_list
+check_validation
+check_pattern "browser_runtime_evidence" '((browser|runtime).*(evidence|not applicable|not-applicable|n/a|not needed)|(evidence|not applicable|not-applicable|n/a|not needed).*(browser|runtime))'
+check_pattern "dirty_workspace_protection" '(dirty[- ]workspace|dirty workspace|dirty worktree|user dirty|shared dirty|frontend dirty|protect.*dirty|dirty.*protect)'
+check_required_base
+
+if [[ "$status" -eq 0 ]]; then
+  echo "visible_loop_pr_body_check_result=ok"
+else
+  echo "visible_loop_pr_body_check_result=failed"
+fi
+
+exit "$status"

--- a/.claude/skills/codex-refactor-loop/scripts/visible-loop-prompt-guard.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/visible-loop-prompt-guard.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Read-only guard for visible-loop worker prompts.
+#
+# The guard checks only prompt text. It does not write loop state, call GitHub,
+# or modify tracked files. Marker template examples are allowed; unresolved
+# placeholders elsewhere are treated as readiness failures.
+
+set -euo pipefail
+
+usage() {
+  echo "usage: visible-loop-prompt-guard.sh [prompt-file...]" >&2
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || true)"
+fallback_prompt_dir="/Users/abigaildeng/Documents/Playground/aevatar/.refactor-loop/prompts"
+sentinel="⟦AI:AUTO-LOOP⟧"
+status=0
+prompt_files=()
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+discover_prompt_files() {
+  local dir
+  local file
+
+  for dir in \
+    "${repo_root:-}/.refactor-loop/prompts" \
+    "$fallback_prompt_dir"
+  do
+    [[ -n "$dir" && -d "$dir" ]] || continue
+    while IFS= read -r file; do
+      prompt_files+=("$file")
+    done < <(find "$dir" -maxdepth 1 -type f -name "visible-*.md" | sort)
+
+    if [[ "${#prompt_files[@]}" -gt 0 ]]; then
+      echo "prompt_dir=$dir"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+if [[ $# -gt 0 ]]; then
+  prompt_files=("$@")
+else
+  discover_prompt_files || true
+fi
+
+echo "visible_loop_prompt_guard"
+echo "repo_root=${repo_root:-unknown}"
+
+if [[ "${#prompt_files[@]}" -eq 0 ]]; then
+  echo "status=skipped"
+  echo "reason=no_visible_prompt_files_discovered"
+  exit 0
+fi
+
+check_placeholders() {
+  local file="$1"
+
+  awk '
+    function allowed_placeholder_line(line) {
+      if (line ~ /(VISIBLE_WORKER_DONE|SOLVER_DONE|REVIEW_DONE|META_JUDGE_DONE|META_RESOLVED|IMPLEMENT_DONE|IMPLEMENT_BLOCKED|FIX_DONE|FIX_BLOCKED|AUDIT_DONE|AUDIT_INCOMPLETE|TEST_ADD_DONE):/) {
+        return 1
+      }
+      if (line ~ /Completion marker/) {
+        return 1
+      }
+      if (line ~ /prompt echo|placeholder|template-only|marker example/) {
+        return 1
+      }
+      if (line ~ /`<\.\.\.>`/) {
+        return 1
+      }
+      return 0
+    }
+
+    {
+      if (($0 ~ /\{\{[^}][^}]*\}\}/ || $0 ~ /<[A-Za-z][A-Za-z0-9_.|\/-]*>/) && !allowed_placeholder_line($0)) {
+        print FILENAME ":" FNR ": violation=unresolved_placeholder line=" $0
+      }
+    }
+  ' "$file"
+}
+
+check_raw_mentions() {
+  local file="$1"
+
+  awk '
+    {
+      if ($0 ~ /(^|[^[:alnum:]_.%+-])@[[:alnum:]][[:alnum:]_-]+/) {
+        print FILENAME ":" FNR ": violation=risky_raw_at_mention line=" $0
+      }
+    }
+  ' "$file"
+}
+
+mentions_external_content() {
+  local file="$1"
+
+  grep -Eiq '(GitHub|pull[ -]request|external-facing|comment|body|issue|banner|[^[:alpha:]]PR[^[:alpha:]])' "$file"
+}
+
+check_prompt_file() {
+  local file="$1"
+  local file_status=0
+  local placeholder_output
+  local mention_output
+
+  echo "file=$file"
+
+  if [[ ! -f "$file" ]]; then
+    echo "result=prompt_file failed reason=not_found path=$file"
+    return 1
+  fi
+
+  placeholder_output="$(check_placeholders "$file")"
+  if [[ -n "$placeholder_output" ]]; then
+    printf '%s\n' "$placeholder_output"
+    file_status=1
+  else
+    echo "placeholders=ok"
+  fi
+
+  mention_output="$(check_raw_mentions "$file")"
+  if [[ -n "$mention_output" ]]; then
+    printf '%s\n' "$mention_output"
+    file_status=1
+  else
+    echo "raw_at_mentions=ok"
+  fi
+
+  if mentions_external_content "$file"; then
+    echo "external_content_reference=detected"
+    if grep -Fq "$sentinel" "$file"; then
+      echo "auto_loop_sentinel=ok"
+    else
+      echo "violation=missing_auto_loop_sentinel sentinel=$sentinel"
+      file_status=1
+    fi
+  else
+    echo "auto_loop_sentinel=skipped reason=no_external_content_reference"
+  fi
+
+  if [[ "$file_status" -eq 0 ]]; then
+    echo "result=prompt_file ok path=$file"
+  else
+    echo "result=prompt_file failed path=$file"
+  fi
+
+  return "$file_status"
+}
+
+for prompt_file in "${prompt_files[@]}"; do
+  if ! check_prompt_file "$prompt_file"; then
+    status=1
+  fi
+done
+
+if [[ "$status" -eq 0 ]]; then
+  echo "visible_loop_prompt_guard_result=ok"
+else
+  echo "visible_loop_prompt_guard_result=failed"
+fi
+
+exit "$status"

--- a/.claude/skills/codex-refactor-loop/scripts/visible-loop-smoke.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/visible-loop-smoke.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Read-only local smoke runner for visible-loop process helpers.
+#
+# This script is intentionally local-only. It does not call GitHub, does not
+# write loop state, and does not modify tracked files. Pass an optional log
+# directory to include visible worker log summaries. Pass an optional second
+# argument to validate a local PR body draft.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null || git rev-parse --show-toplevel 2>/dev/null || true)"
+log_dir_arg="${1:-}"
+pr_body_arg="${2:-}"
+status=0
+
+if [[ -z "$repo_root" ]]; then
+  echo "visible_loop_smoke"
+  echo "status=blocked"
+  echo "reason=not inside a git repository"
+  exit 2
+fi
+
+portable_timeout="$script_dir/portable-timeout.sh"
+log_summary="$script_dir/visible-loop-log-summary.sh"
+peek="$script_dir/peek.sh"
+health="$script_dir/visible-loop-health.sh"
+prompt_guard="$script_dir/visible-loop-prompt-guard.sh"
+batch_files="$script_dir/visible-loop-batch-files.sh"
+pr_body_check="$script_dir/visible-loop-pr-body-check.sh"
+
+run_check() {
+  local name="$1"
+  shift
+
+  echo "check=$name"
+  set +e
+  "$@"
+  local rc=$?
+  set -e
+
+  if [[ "$rc" -eq 0 ]]; then
+    echo "result=$name ok"
+  else
+    echo "result=$name failed exit=$rc"
+    status=1
+  fi
+}
+
+discover_log_dir() {
+  if [[ -n "$log_dir_arg" ]]; then
+    printf '%s\n' "$log_dir_arg"
+    return
+  fi
+
+  if [[ -d "$repo_root/.refactor-loop/logs" ]]; then
+    printf '%s\n' "$repo_root/.refactor-loop/logs"
+    return
+  fi
+
+  if [[ -d "/Users/abigaildeng/Documents/Playground/aevatar/.refactor-loop/logs" ]]; then
+    printf '%s\n' "/Users/abigaildeng/Documents/Playground/aevatar/.refactor-loop/logs"
+    return
+  fi
+}
+
+discover_prompt_files() {
+  local dir
+  local file
+
+  for dir in \
+    "$repo_root/.refactor-loop/prompts" \
+    "$(dirname "${log_dir_arg:-/none}")/prompts" \
+    "/Users/abigaildeng/Documents/Playground/aevatar/.refactor-loop/prompts"
+  do
+    [[ -d "$dir" ]] || continue
+    found_any=0
+    while IFS= read -r file; do
+      found_any=1
+      printf '%s\n' "$file"
+    done < <(find "$dir" -maxdepth 1 -type f -name "visible-*.md" | sort)
+    [[ "$found_any" -eq 0 ]] || return
+  done
+}
+
+print_capped_helper_output() {
+  local name="$1"
+  local helper="$2"
+  local max_lines="$3"
+
+  echo "check=${name}_capped"
+  if [[ ! -f "$helper" ]]; then
+    echo "result=${name}_capped skipped reason=missing path=$helper"
+    return
+  fi
+
+  local output
+  set +e
+  output="$(bash "$helper" 2>&1)"
+  local rc=$?
+  set -e
+
+  printf '%s\n' "$output" | sed -n "1,${max_lines}p"
+
+  if [[ "$rc" -eq 0 ]]; then
+    echo "result=${name}_capped ok"
+  else
+    echo "result=${name}_capped degraded exit=$rc"
+  fi
+}
+
+echo "visible_loop_smoke"
+echo "repo_root=$repo_root"
+echo "scripts_dir=$script_dir"
+echo "github_state=skipped local_read_only_smoke"
+
+run_check "git_diff_check" git -C "$repo_root" diff --check
+
+echo "check=bash_syntax"
+while IFS= read -r script_path; do
+  [[ -f "$script_path" ]] || continue
+  run_check "bash_n_$(basename "$script_path")" bash -n "$script_path"
+done < <(find "$script_dir" -maxdepth 1 -type f -name "*.sh" | sort)
+echo "result=bash_syntax complete"
+
+if [[ -x "$portable_timeout" ]]; then
+  run_check "portable_timeout_select" "$portable_timeout" --select
+  run_check "portable_timeout_forced_fallback" env CODEX_LOOP_FORCE_TIMEOUT_FALLBACK=1 "$portable_timeout" 2 bash -c 'exit 0'
+else
+  echo "result=portable_timeout failed reason=missing_or_not_executable path=$portable_timeout"
+  status=1
+fi
+
+echo "check=visible_loop_prompt_guard"
+prompt_files=()
+while IFS= read -r prompt_file; do
+  [[ -n "$prompt_file" ]] || continue
+  prompt_files+=("$prompt_file")
+done < <(discover_prompt_files || true)
+if [[ "${#prompt_files[@]}" -gt 0 && -x "$prompt_guard" ]]; then
+  run_check "visible_loop_prompt_guard" "$prompt_guard" "${prompt_files[@]}"
+elif [[ "${#prompt_files[@]}" -eq 0 ]]; then
+  echo "result=visible_loop_prompt_guard skipped reason=no_visible_prompts_discovered"
+else
+  echo "result=visible_loop_prompt_guard failed reason=missing_or_not_executable path=$prompt_guard"
+  status=1
+fi
+
+echo "check=visible_loop_batch_files"
+if [[ -x "$batch_files" ]]; then
+  set +e
+  "$batch_files" 10
+  batch_rc=$?
+  set -e
+  if [[ "$batch_rc" -eq 0 ]]; then
+    echo "result=visible_loop_batch_files readiness=reached"
+  else
+    echo "result=visible_loop_batch_files readiness=below_threshold exit=$batch_rc"
+  fi
+else
+  echo "result=visible_loop_batch_files failed reason=missing_or_not_executable path=$batch_files"
+  status=1
+fi
+
+if [[ -n "$pr_body_arg" ]]; then
+  if [[ -x "$pr_body_check" ]]; then
+    run_check "visible_loop_pr_body_check" "$pr_body_check" "$pr_body_arg"
+  else
+    echo "result=visible_loop_pr_body_check failed reason=missing_or_not_executable path=$pr_body_check"
+    status=1
+  fi
+else
+  echo "result=visible_loop_pr_body_check skipped reason=no_pr_body_path_supplied"
+fi
+
+log_dir="$(discover_log_dir || true)"
+echo "log_dir=${log_dir:-none}"
+if [[ -n "${log_dir:-}" && -d "$log_dir" && -x "$log_summary" ]]; then
+  visible_logs=()
+  while IFS= read -r log_path; do
+    visible_logs+=("$log_path")
+  done < <(find "$log_dir" -maxdepth 1 -type f -name "visible-*.log" | sort | tail -20)
+  if [[ "${#visible_logs[@]}" -gt 0 ]]; then
+    echo "check=visible_loop_log_summary"
+    "$log_summary" "${visible_logs[@]}" | sed -n '1,40p'
+    echo "result=visible_loop_log_summary ok files=${#visible_logs[@]}"
+  else
+    echo "result=visible_loop_log_summary skipped reason=no_visible_logs"
+  fi
+else
+  echo "result=visible_loop_log_summary skipped reason=missing_log_dir_or_helper"
+fi
+
+print_capped_helper_output "peek" "$peek" 80
+print_capped_helper_output "visible_loop_health" "$health" 80
+
+if [[ "$status" -eq 0 ]]; then
+  echo "visible_loop_smoke_result=ok"
+else
+  echo "visible_loop_smoke_result=failed"
+fi
+
+exit "$status"


### PR DESCRIPTION
## Problem and solution

The visible AI automation pipeline loop was relying on repeated manual controller checks for degraded process health, worker log completion, timeout portability, prompt readiness, batch file count, and future PR body readiness. That made the loop easy to misread, especially when worker logs echoed marker templates before a real tail `EXIT=0`.

This PR adds a process-only guard layer for the stable local skill entry `codex-refactor-loop`:
- degraded local `peek.sh` / health snapshots when host loop state is missing;
- portable timeout selection for `spawn-codex.sh`;
- safe visible worker log summarization based on tail `EXIT=0`;
- one read-only smoke runner for local helper validation;
- prompt, batch file threshold, and PR body guards before publishing automation PRs.

The PR base is `feat/2026-05-29_ai-automation-pipeline`.

## Same-batch rationale

All files belong to one AI automation pipeline self-healing batch: they harden the visible-thread loop's local process controls before a GitHub PR is created. The batch is intentionally scoped to `.claude/skills/codex-refactor-loop` and avoids backend, frontend, architecture, proto, workflow, runtime, database, or external repository changes.

## Affected paths

Only the local Codex refactor-loop skill and its process helpers are affected:
- `.claude/skills/codex-refactor-loop/SKILL.md`
- `.claude/skills/codex-refactor-loop/scripts/*`

## 10-file list

1. `.claude/skills/codex-refactor-loop/SKILL.md`
2. `.claude/skills/codex-refactor-loop/scripts/peek.sh`
3. `.claude/skills/codex-refactor-loop/scripts/portable-timeout.sh`
4. `.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh`
5. `.claude/skills/codex-refactor-loop/scripts/visible-loop-batch-files.sh`
6. `.claude/skills/codex-refactor-loop/scripts/visible-loop-health.sh`
7. `.claude/skills/codex-refactor-loop/scripts/visible-loop-log-summary.sh`
8. `.claude/skills/codex-refactor-loop/scripts/visible-loop-pr-body-check.sh`
9. `.claude/skills/codex-refactor-loop/scripts/visible-loop-prompt-guard.sh`
10. `.claude/skills/codex-refactor-loop/scripts/visible-loop-smoke.sh`

## Validation commands and results

- `git diff --check` in `/Users/abigaildeng/Documents/Playground/aevatar`: passed with no output.
- `git -C /private/tmp/aevatar-visible-20260529-191150-process-guard diff --check`: passed with no output.
- `bash -n` on each changed shell helper: passed.
- `bash .claude/skills/codex-refactor-loop/scripts/visible-loop-smoke.sh /Users/abigaildeng/Documents/Playground/aevatar/.refactor-loop/logs`: passed with `visible_loop_smoke_result=ok`.
- `bash .claude/skills/codex-refactor-loop/scripts/visible-loop-batch-files.sh 10`: passed with `file_count=10`, `threshold_status=reached`, `shortfall=0`.
- `bash .claude/skills/codex-refactor-loop/scripts/visible-loop-prompt-guard.sh /Users/abigaildeng/Documents/Playground/aevatar/.refactor-loop/prompts/visible-*.md`: passed with `visible_loop_prompt_guard_result=ok`.
- `bash .claude/skills/codex-refactor-loop/scripts/visible-loop-pr-body-check.sh /Users/abigaildeng/Documents/Playground/aevatar/.refactor-loop/logs/visible-20260529-204323-pr-body.md`: passed with `visible_loop_pr_body_check_result=ok`.

## Browser and runtime evidence

Browser evidence: not applicable. This PR has no frontend user-visible changes and does not touch `apps/aevatar-console-web`.

Runtime evidence: the visible loop worker logs show six completed process workers, including `VISIBLE_WORKER_DONE:threshold-guards:ok:threshold-guards-added`, and the final smoke runner summarized those logs with `visible_loop_smoke_result=ok`.

## User dirty-workspace protection

The shared workspace `/Users/abigaildeng/Documents/Playground/aevatar` had existing dirty frontend files under `apps/aevatar-console-web`. This batch was implemented in the isolated worktree `/private/tmp/aevatar-visible-20260529-191150-process-guard` and did not modify or use the user's dirty frontend files to reach the 10-file threshold.

## Backend boundary

No backend code, proto files, backend tests, backend configuration, actor/projection/workflow/runtime/database code, server logs, architecture docs, or external repositories were modified.

⟦AI:AUTO-LOOP⟧
