### PR TITLE
#1183 first slice: 删除 ResponsesTaskTrace dead surface(no-new-core)

### DIFF
--- a/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
@@ -581,7 +581,11 @@ message ResponsesWebSubstituteToolExecutionResult {
 }
 
 message ResponsesAgentToolState {
-  // Refactor (issue1183/first-slice): Old pattern: ResponsesTaskTrace dead trace surface. New principle: deleted/reserved per Phase 9 consensus, no consumer found.
+  // Refactor (issue1183/first-slice):
+  //   Old pattern: ResponsesTaskTrace dead trace surface — task_substitute / task_trace
+  //                readmodel surface 无 consumer,占用 proto field number。
+  //   New principle: deleted / reserved per Phase 9 r1 consensus (hybrid minimal/
+  //                  structural/delete), proto field number reserved 防重新占用。
   reserved 5;
   reserved "task_traces";
   ResponsesAgentToolStateRecord record = 1;

--- a/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
@@ -465,12 +465,6 @@ message ChatRunTerminatedEvent {
   google.protobuf.Timestamp observed_at = 2;
 }
 
-enum ResponsesAgentToolTaskStatus {
-  RESPONSES_AGENT_TOOL_TASK_STATUS_UNSPECIFIED = 0;
-  RESPONSES_AGENT_TOOL_TASK_STATUS_ACCEPTED = 1;
-  RESPONSES_AGENT_TOOL_TASK_STATUS_REJECTED = 2;
-}
-
 message ResponsesAgentToolStateRecord {
   string scope_id = 1;
   string owner_subject = 2;
@@ -485,18 +479,6 @@ message ResponsesTodoItem {
   string source_response_id = 4;
   google.protobuf.Timestamp created_at = 5;
   google.protobuf.Timestamp updated_at = 6;
-}
-
-message ResponsesTaskTrace {
-  string task_id = 1;
-  string source_response_id = 2;
-  string child_actor_id = 3;
-  string description = 4;
-  ResponsesAgentToolTaskStatus status = 5;
-  google.protobuf.Value arguments = 6;
-  google.protobuf.Value result = 7;
-  google.protobuf.Timestamp created_at = 8;
-  google.protobuf.Timestamp updated_at = 9;
 }
 
 message ResponsesWebTrace {
@@ -599,11 +581,13 @@ message ResponsesWebSubstituteToolExecutionResult {
 }
 
 message ResponsesAgentToolState {
+  // Refactor (issue1183/first-slice): Old pattern: ResponsesTaskTrace dead trace surface. New principle: deleted/reserved per Phase 9 consensus, no consumer found.
+  reserved 5;
+  reserved "task_traces";
   ResponsesAgentToolStateRecord record = 1;
   int64 last_applied_event_version = 2;
   string last_event_id = 3;
   repeated ResponsesTodoItem todo_items = 4;
-  repeated ResponsesTaskTrace task_traces = 5;
   repeated ResponsesWebTrace web_traces = 6;
   repeated ResponsesWebCacheEntry web_cache_entries = 7;
 }
@@ -633,21 +617,6 @@ message ResponsesTodoWriteAppliedEvent {
   google.protobuf.Value arguments = 2;
   repeated ResponsesTodoItem todo_items = 3;
   google.protobuf.Timestamp observed_at = 4;
-}
-
-message RecordResponsesTaskRequested {
-  string source_response_id = 1;
-  string task_id = 2;
-  string child_actor_id = 3;
-  string description = 4;
-  google.protobuf.Value arguments = 5;
-  google.protobuf.Value result = 6;
-  ResponsesAgentToolTaskStatus status = 7;
-  google.protobuf.Timestamp observed_at = 8;
-}
-
-message ResponsesTaskRecordedEvent {
-  ResponsesTaskTrace task = 1;
 }
 
 message RecordResponsesWebTraceRequested {

--- a/src/platform/Aevatar.GAgentService.Abstractions/Queries/ResponsesAgentToolStateSnapshot.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Queries/ResponsesAgentToolStateSnapshot.cs
@@ -8,7 +8,6 @@ public sealed record ResponsesAgentToolStateSnapshot(
     DateTimeOffset CreatedAt,
     DateTimeOffset UpdatedAt,
     IReadOnlyList<ResponsesTodoItemSnapshot> Todos,
-    IReadOnlyList<ResponsesTaskTraceSnapshot> Tasks,
     IReadOnlyList<ResponsesWebTraceSnapshot> WebTraces,
     IReadOnlyList<ResponsesWebCacheEntrySnapshot> WebCacheEntries);
 
@@ -17,17 +16,6 @@ public sealed record ResponsesTodoItemSnapshot(
     string Content,
     string Status,
     string SourceResponseId,
-    DateTimeOffset CreatedAt,
-    DateTimeOffset UpdatedAt);
-
-public sealed record ResponsesTaskTraceSnapshot(
-    string TaskId,
-    string SourceResponseId,
-    string ChildActorId,
-    string Description,
-    string Status,
-    string ArgumentsJson,
-    string ResultJson,
     DateTimeOffset CreatedAt,
     DateTimeOffset UpdatedAt);
 

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/ResponsesAgentToolStateGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/ResponsesAgentToolStateGAgent.cs
@@ -58,38 +58,6 @@ public sealed class ResponsesAgentToolStateGAgent : GAgentBase<ResponsesAgentToo
     }
 
     [EventHandler]
-    public async Task HandleRecordTaskAsync(RecordResponsesTaskRequested command)
-    {
-        ArgumentNullException.ThrowIfNull(command);
-        EnsureRegistered();
-
-        var observedAt = command.ObservedAt ?? Timestamp.FromDateTime(DateTime.UtcNow);
-        var task = new ResponsesTaskTrace
-        {
-            TaskId = NormalizeRequired(command.TaskId),
-            SourceResponseId = NormalizeOptional(command.SourceResponseId) ?? string.Empty,
-            ChildActorId = NormalizeRequired(command.ChildActorId),
-            Description = NormalizeOptional(command.Description) ?? string.Empty,
-            Arguments = command.Arguments?.Clone(),
-            Result = command.Result?.Clone(),
-            Status = command.Status == ResponsesAgentToolTaskStatus.Unspecified
-                ? ResponsesAgentToolTaskStatus.Accepted
-                : command.Status,
-            CreatedAt = observedAt,
-            UpdatedAt = observedAt,
-        };
-        ValidateTask(task);
-
-        if (State.TaskTraces.Any(x => string.Equals(x.TaskId, task.TaskId, StringComparison.Ordinal)))
-            return;
-
-        await PersistDomainEventAsync(new ResponsesTaskRecordedEvent
-        {
-            Task = task,
-        });
-    }
-
-    [EventHandler]
     public async Task HandleRecordWebTraceAsync(RecordResponsesWebTraceRequested command)
     {
         ArgumentNullException.ThrowIfNull(command);
@@ -128,7 +96,6 @@ public sealed class ResponsesAgentToolStateGAgent : GAgentBase<ResponsesAgentToo
             .Match(current, evt)
             .On<ResponsesAgentToolStateRegisteredEvent>(ApplyRegistered)
             .On<ResponsesTodoWriteAppliedEvent>(ApplyTodoWrite)
-            .On<ResponsesTaskRecordedEvent>(ApplyTaskRecorded)
             .On<ResponsesWebTraceRecordedEvent>(ApplyWebTraceRecorded)
             .OrCurrent();
 
@@ -151,18 +118,6 @@ public sealed class ResponsesAgentToolStateGAgent : GAgentBase<ResponsesAgentToo
         next.TodoItems.AddRange(evt.TodoItems.Select(static x => x.Clone()));
         Touch(next, evt.ObservedAt);
         Bump(next, $"{next.Record?.ScopeId}:todo:{evt.SourceResponseId}");
-        return next;
-    }
-
-    private static ResponsesAgentToolState ApplyTaskRecorded(
-        ResponsesAgentToolState state,
-        ResponsesTaskRecordedEvent evt)
-    {
-        var next = state.Clone();
-        if (evt.Task != null)
-            next.TaskTraces.Add(evt.Task.Clone());
-        Touch(next, evt.Task?.UpdatedAt);
-        Bump(next, $"{next.Record?.ScopeId}:task:{evt.Task?.TaskId}");
         return next;
     }
 
@@ -252,14 +207,6 @@ public sealed class ResponsesAgentToolStateGAgent : GAgentBase<ResponsesAgentToo
             throw new InvalidOperationException("scope_id is required.");
         if (string.IsNullOrWhiteSpace(record.OwnerSubject))
             throw new InvalidOperationException("owner_subject is required.");
-    }
-
-    private static void ValidateTask(ResponsesTaskTrace task)
-    {
-        if (string.IsNullOrWhiteSpace(task.TaskId))
-            throw new InvalidOperationException("task_id is required.");
-        if (string.IsNullOrWhiteSpace(task.ChildActorId))
-            throw new InvalidOperationException("child_actor_id is required.");
     }
 
     private static void ValidateWebTrace(ResponsesWebTrace trace)

--- a/src/platform/Aevatar.GAgentService.Projection/Projectors/ResponsesAgentToolStateCurrentStateProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Projectors/ResponsesAgentToolStateCurrentStateProjector.cs
@@ -61,18 +61,6 @@ public sealed class ResponsesAgentToolStateCurrentStateProjector
                 CreatedAt = todo.CreatedAt?.ToDateTimeOffset() ?? DateTimeOffset.MinValue,
                 UpdatedAt = todo.UpdatedAt?.ToDateTimeOffset() ?? DateTimeOffset.MinValue,
             }).ToList(),
-            Tasks = state.TaskTraces.Select(static task => new ResponsesTaskTraceReadModel
-            {
-                TaskId = task.TaskId,
-                SourceResponseId = task.SourceResponseId,
-                ChildActorId = task.ChildActorId,
-                Description = task.Description,
-                Status = task.Status.ToString(),
-                Arguments = task.Arguments?.Clone(),
-                Result = task.Result?.Clone(),
-                CreatedAt = task.CreatedAt?.ToDateTimeOffset() ?? DateTimeOffset.MinValue,
-                UpdatedAt = task.UpdatedAt?.ToDateTimeOffset() ?? DateTimeOffset.MinValue,
-            }).ToList(),
             WebTraces = state.WebTraces.Select(static trace => new ResponsesWebTraceReadModel
             {
                 TraceId = trace.TraceId,

--- a/src/platform/Aevatar.GAgentService.Projection/Queries/ResponsesAgentToolStateQueryReader.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Queries/ResponsesAgentToolStateQueryReader.cs
@@ -60,16 +60,6 @@ public sealed class ResponsesAgentToolStateQueryReader : IResponsesAgentToolStat
                 todo.SourceResponseId,
                 todo.CreatedAt,
                 todo.UpdatedAt)).ToArray(),
-            document.Tasks.Select(static task => new ResponsesTaskTraceSnapshot(
-                task.TaskId,
-                task.SourceResponseId,
-                task.ChildActorId,
-                task.Description,
-                task.Status,
-                ResponsesJsonValues.ToBoundaryJson(task.Arguments),
-                ResponsesJsonValues.ToBoundaryJson(task.Result),
-                task.CreatedAt,
-                task.UpdatedAt)).ToArray(),
             document.WebTraces.Select(static trace => new ResponsesWebTraceSnapshot(
                 trace.TraceId,
                 trace.SourceResponseId,

--- a/src/platform/Aevatar.GAgentService.Projection/ReadModels/ServiceProjectionReadModels.Partial.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/ReadModels/ServiceProjectionReadModels.Partial.cs
@@ -328,12 +328,6 @@ public sealed partial class ResponsesAgentToolStateCurrentStateReadModel
         set => ServiceProjectionReadModelSupport.ReplaceCollection(TodoItemEntries, value);
     }
 
-    public IList<ResponsesTaskTraceReadModel> Tasks
-    {
-        get => TaskTraceEntries;
-        set => ServiceProjectionReadModelSupport.ReplaceCollection(TaskTraceEntries, value);
-    }
-
     public IList<ResponsesWebTraceReadModel> WebTraces
     {
         get => WebTraceEntries;
@@ -348,21 +342,6 @@ public sealed partial class ResponsesAgentToolStateCurrentStateReadModel
 }
 
 public sealed partial class ResponsesTodoItemReadModel
-{
-    public DateTimeOffset CreatedAt
-    {
-        get => ServiceProjectionReadModelSupport.ToDateTimeOffset(CreatedAtUtcValue);
-        set => CreatedAtUtcValue = ServiceProjectionReadModelSupport.ToTimestamp(value);
-    }
-
-    public DateTimeOffset UpdatedAt
-    {
-        get => ServiceProjectionReadModelSupport.ToDateTimeOffset(UpdatedAtUtcValue);
-        set => UpdatedAtUtcValue = ServiceProjectionReadModelSupport.ToTimestamp(value);
-    }
-}
-
-public sealed partial class ResponsesTaskTraceReadModel
 {
     public DateTimeOffset CreatedAt
     {

--- a/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
+++ b/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
@@ -281,7 +281,11 @@ message LlmSessionTokenUsageReadModel {
 // --- ResponsesAgentToolStateCurrentStateReadModel ---
 
 message ResponsesAgentToolStateCurrentStateReadModel {
-  // Refactor (issue1183/first-slice): Old pattern: ResponsesTaskTrace dead trace surface. New principle: deleted/reserved per Phase 9 consensus, no consumer found.
+  // Refactor (issue1183/first-slice):
+  //   Old pattern: ResponsesTaskTrace dead trace surface — task_substitute / task_trace
+  //                readmodel surface 无 consumer,占用 proto field number。
+  //   New principle: deleted / reserved per Phase 9 r1 consensus (hybrid minimal/
+  //                  structural/delete), proto field number reserved 防重新占用。
   reserved 10;
   reserved "task_trace_entries";
   string id = 1;

--- a/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
+++ b/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
@@ -281,6 +281,9 @@ message LlmSessionTokenUsageReadModel {
 // --- ResponsesAgentToolStateCurrentStateReadModel ---
 
 message ResponsesAgentToolStateCurrentStateReadModel {
+  // Refactor (issue1183/first-slice): Old pattern: ResponsesTaskTrace dead trace surface. New principle: deleted/reserved per Phase 9 consensus, no consumer found.
+  reserved 10;
+  reserved "task_trace_entries";
   string id = 1;
   string actor_id = 2;
   int64 state_version = 3;
@@ -290,7 +293,6 @@ message ResponsesAgentToolStateCurrentStateReadModel {
   google.protobuf.Timestamp created_at_utc_value = 7;
   google.protobuf.Timestamp updated_at_utc_value = 8;
   repeated ResponsesTodoItemReadModel todo_item_entries = 9;
-  repeated ResponsesTaskTraceReadModel task_trace_entries = 10;
   repeated ResponsesWebTraceReadModel web_trace_entries = 11;
   repeated ResponsesWebCacheEntryReadModel web_cache_entry_entries = 12;
 }
@@ -302,18 +304,6 @@ message ResponsesTodoItemReadModel {
   string source_response_id = 4;
   google.protobuf.Timestamp created_at_utc_value = 5;
   google.protobuf.Timestamp updated_at_utc_value = 6;
-}
-
-message ResponsesTaskTraceReadModel {
-  string task_id = 1;
-  string source_response_id = 2;
-  string child_actor_id = 3;
-  string description = 4;
-  string status = 5;
-  google.protobuf.Value arguments = 6;
-  google.protobuf.Value result = 7;
-  google.protobuf.Timestamp created_at_utc_value = 8;
-  google.protobuf.Timestamp updated_at_utc_value = 9;
 }
 
 message ResponsesWebTraceReadModel {

--- a/test/Aevatar.GAgentService.Tests/Core/ResponsesAgentToolStateGAgentTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ResponsesAgentToolStateGAgentTests.cs
@@ -112,61 +112,6 @@ public sealed class ResponsesAgentToolStateGAgentTests
         actor.State.WebCacheEntries[0].LastHitAt.Should().NotBeNull();
     }
 
-    [Fact]
-    public async Task HandleRecordTaskAsync_ShouldPersistTaskTopologyTrace()
-    {
-        var actor = CreateActor();
-        await RegisterAsync(actor);
-
-        await actor.HandleRecordTaskAsync(new RecordResponsesTaskRequested
-        {
-            SourceResponseId = "resp_1",
-            TaskId = "task_1",
-            ChildActorId = "responses-agent-tools-scope-task-1",
-            Description = "summarize",
-            Arguments = ResponsesJsonValues.ParseBoundaryPayload("""{"prompt":"summarize"}"""),
-            Result = ResponsesJsonValues.ParseBoundaryPayload("""{"status":"accepted"}"""),
-            Status = ResponsesAgentToolTaskStatus.Accepted,
-        });
-
-        actor.State.TaskTraces.Should().ContainSingle();
-        actor.State.TaskTraces[0].ChildActorId.Should().Be("responses-agent-tools-scope-task-1");
-        actor.State.TaskTraces[0].Status.Should().Be(ResponsesAgentToolTaskStatus.Accepted);
-        ResponsesJsonValues.ToBoundaryJson(actor.State.TaskTraces[0].Arguments)
-            .Should().Be("""{"prompt":"summarize"}""");
-        ResponsesJsonValues.ToBoundaryJson(actor.State.TaskTraces[0].Result)
-            .Should().Be("""{"status":"accepted"}""");
-    }
-
-    [Fact]
-    public async Task HandleRecordTaskAsync_ShouldIgnoreDuplicateTaskRecord_AndReusePersistedTrace()
-    {
-        var actor = CreateActor();
-        await RegisterAsync(actor);
-
-        var command = new RecordResponsesTaskRequested
-        {
-            SourceResponseId = "resp_1",
-            TaskId = "task_1",
-            ChildActorId = "responses-agent-tools-scope-task-1",
-            Description = "summarize",
-            Arguments = ResponsesJsonValues.ParseBoundaryPayload("""{"prompt":"summarize"}"""),
-            Result = ResponsesJsonValues.ParseBoundaryPayload("""{"status":"accepted"}"""),
-            Status = ResponsesAgentToolTaskStatus.Accepted,
-            ObservedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-05-12T00:00:00+00:00")),
-        };
-
-        await actor.HandleRecordTaskAsync(command);
-        var versionAfterFirstRecord = actor.State.LastAppliedEventVersion;
-
-        await actor.HandleRecordTaskAsync(command);
-
-        actor.State.LastAppliedEventVersion.Should().Be(versionAfterFirstRecord);
-        actor.State.TaskTraces.Should().ContainSingle();
-        actor.State.TaskTraces[0].TaskId.Should().Be("task_1");
-        actor.State.TaskTraces[0].Status.Should().Be(ResponsesAgentToolTaskStatus.Accepted);
-    }
-
     private static ResponsesAgentToolStateGAgent CreateActor() =>
         GAgentServiceTestKit.CreateStatefulAgent<ResponsesAgentToolStateGAgent, ResponsesAgentToolState>(
             new InMemoryEventStore(),

--- a/test/Aevatar.GAgentService.Tests/Projection/LlmSessionsProtoSurfaceRegressionTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/LlmSessionsProtoSurfaceRegressionTests.cs
@@ -1,0 +1,39 @@
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Projection.ReadModels;
+using FluentAssertions;
+using Google.Protobuf.Reflection;
+
+namespace Aevatar.GAgentService.Tests.Projection;
+
+public sealed class LlmSessionsProtoSurfaceRegressionTests
+{
+    [Fact]
+    public void LlmSessionsProto_ShouldNotExposeDeletedTaskTraceSurface()
+    {
+        var descriptor = LlmSessionsReflection.Descriptor;
+
+        TopLevelMessageNames(descriptor).Should().NotContain(
+            [
+                "ResponsesTaskTrace",
+                "RecordResponsesTaskRequested",
+                "ResponsesTaskRecordedEvent",
+            ]);
+        descriptor.EnumTypes.Select(x => x.Name).Should().NotContain("ResponsesAgentToolTaskStatus");
+        ResponsesAgentToolState.Descriptor.FindFieldByName("task_traces").Should().BeNull();
+    }
+
+    [Fact]
+    public void ServiceProjectionReadModelsProto_ShouldNotExposeDeletedTaskTraceFields()
+    {
+        var descriptor = ServiceProjectionReadModelsReflection.Descriptor;
+
+        TopLevelMessageNames(descriptor).Should().NotContain("ResponsesTaskTraceReadModel");
+        ResponsesAgentToolStateCurrentStateReadModel.Descriptor
+            .FindFieldByName("task_trace_entries")
+            .Should()
+            .BeNull();
+    }
+
+    private static IEnumerable<string> TopLevelMessageNames(FileDescriptor descriptor) =>
+        descriptor.MessageTypes.Select(x => x.Name);
+}

--- a/test/Aevatar.GAgentService.Tests/Projection/ResponsesAgentToolStateCSharpSurfaceRegressionTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ResponsesAgentToolStateCSharpSurfaceRegressionTests.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.GAgentService.Core.GAgents;
+using FluentAssertions;
+
+namespace Aevatar.GAgentService.Tests.Projection;
+
+public sealed class ResponsesAgentToolStateCSharpSurfaceRegressionTests
+{
+    [Fact]
+    public void ResponsesAgentToolStateCSharpSurface_ShouldNotExposeDeletedTaskMembers()
+    {
+        typeof(ResponsesAgentToolStateSnapshot)
+            .GetProperty("Tasks")
+            .Should()
+            .BeNull();
+
+        Type.GetType(
+                "Aevatar.GAgentService.Abstractions.Queries.ResponsesTaskTraceSnapshot, " +
+                "Aevatar.GAgentService.Abstractions")
+            .Should()
+            .BeNull();
+
+        typeof(ResponsesAgentToolStateGAgent)
+            .GetMethod(
+                "HandleRecordTaskAsync",
+                BindingFlags.NonPublic | BindingFlags.Instance)
+            .Should()
+            .BeNull();
+
+        typeof(ResponsesAgentToolStateGAgent)
+            .GetMethod(
+                "HandleRecordTaskAsync",
+                BindingFlags.Public | BindingFlags.Instance)
+            .Should()
+            .BeNull();
+    }
+}

--- a/test/Aevatar.GAgentService.Tests/Projection/ResponsesAgentToolStateCurrentStateProjectorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ResponsesAgentToolStateCurrentStateProjectorTests.cs
@@ -20,7 +20,7 @@ public sealed class ResponsesAgentToolStateCurrentStateProjectorTests
     private static readonly string ActorId = ResponseAgentToolStateIds.BuildActorId(ScopeId, OwnerSubject);
 
     [Fact]
-    public async Task ProjectAsync_ShouldMaterializeTodoTaskWebState_AndQueryCache()
+    public async Task ProjectAsync_ShouldMaterializeTodoWebState_AndQueryCache()
     {
         var store = new RecordingDocumentStore<ResponsesAgentToolStateCurrentStateReadModel>(x => x.Id);
         var projector = new ResponsesAgentToolStateCurrentStateProjector(
@@ -40,16 +40,12 @@ public sealed class ResponsesAgentToolStateCurrentStateProjectorTests
         var doc = await store.GetAsync(ActorId);
         doc.Should().NotBeNull();
         doc!.Todos.Should().ContainSingle(x => x.Id == "todo-1");
-        doc.Tasks.Should().ContainSingle(x => x.TaskId == "task_1");
         doc.WebTraces.Should().ContainSingle(x => x.TraceId == "trace-1");
         doc.WebCacheEntries.Should().ContainSingle(x => x.CacheKey == "cache-1");
 
         var snapshot = await reader.GetAsync(ScopeId, OwnerSubject);
         snapshot.Should().NotBeNull();
         snapshot!.Todos.Should().ContainSingle(x => x.Content == "Ship");
-        snapshot.Tasks.Should().ContainSingle(x => x.ChildActorId == "child-1");
-        snapshot.Tasks[0].ArgumentsJson.Should().Be("{}");
-        snapshot.Tasks[0].ResultJson.Should().Be("""{"status":"accepted"}""");
         snapshot.WebTraces.Should().ContainSingle(x => x.TraceId == "trace-1");
         snapshot.WebTraces[0].Result.Fetch.Content.Should().Be("fresh");
 
@@ -81,7 +77,6 @@ public sealed class ResponsesAgentToolStateCurrentStateProjectorTests
 
         persisted.Should().NotBeNull();
         persisted!.Todos[0].Content = "Store changed";
-        persisted.Tasks[0].ChildActorId = "child-2";
         persisted.WebCacheEntries[0].HitCount = 9;
 
         var second = await new ResponsesAgentToolStateQueryReader(store).GetAsync(ScopeId, OwnerSubject);
@@ -89,13 +84,11 @@ public sealed class ResponsesAgentToolStateCurrentStateProjectorTests
         first.Should().NotBeNull();
         second.Should().NotBeNull();
         first!.Todos.Should().ContainSingle(x => x.Content == "Ship");
-        first.Tasks.Should().ContainSingle(x => x.ChildActorId == "child-1");
         first.WebCacheEntries.Should().ContainSingle(x => x.HitCount == 0);
         second.Should().NotBeSameAs(first);
         second!.ActorId.Should().Be(ActorId);
         second.StateVersion.Should().Be(4);
         second.Todos.Should().ContainSingle(x => x.Id == "todo-1" && x.Content == "Store changed");
-        second.Tasks.Should().ContainSingle(x => x.TaskId == "task_1" && x.ChildActorId == "child-2");
         second.WebCacheEntries.Should().ContainSingle(x => x.CacheKey == "cache-1" && x.HitCount == 9);
     }
 
@@ -179,18 +172,6 @@ public sealed class ResponsesAgentToolStateCurrentStateProjectorTests
             Content = "Ship",
             Status = "pending",
             SourceResponseId = "resp_1",
-            CreatedAt = Timestamp.FromDateTimeOffset(observedAt),
-            UpdatedAt = Timestamp.FromDateTimeOffset(observedAt),
-        });
-        state.TaskTraces.Add(new ResponsesTaskTrace
-        {
-            TaskId = "task_1",
-            SourceResponseId = "resp_1",
-            ChildActorId = "child-1",
-            Description = "summarize",
-            Status = ResponsesAgentToolTaskStatus.Accepted,
-            Arguments = ResponsesJsonValues.ParseBoundaryPayload("{}"),
-            Result = ResponsesJsonValues.ParseBoundaryPayload("""{"status":"accepted"}"""),
             CreatedAt = Timestamp.FromDateTimeOffset(observedAt),
             UpdatedAt = Timestamp.FromDateTimeOffset(observedAt),
         });


### PR DESCRIPTION
## 摘要

issue #1183 first slice(Phase 9 r1 hybrid consensus):**删除 ResponsesTaskTrace dead surface**,proto/readmodel field 标 reserved 保持向后兼容。

- **Old**:`ResponsesTaskTrace` 残余 dead trace surface(`task_substitute`、`task_trace` readmodel)无 consumer 但仍占用 proto field number + readmodel column
- **New**:删除 dead surface,proto field 标 `reserved`,readmodel column 保留 reserved 注释防重新占用

违反:CLAUDE.md「删除优先:空转发、重复抽象、无业务价值代码直接删除,不保留兼容空壳」

## 范围

9 files, +7 / -230 LOC(delete-heavy refactor)。

- `src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto`(reserved fields)
- `src/platform/Aevatar.GAgentService.Abstractions/Queries/ResponsesAgentToolStateSnapshot.cs`
- `src/platform/Aevatar.GAgentService.Core/GAgents/ResponsesAgentToolStateGAgent.cs`
- `src/platform/Aevatar.GAgentService.Projection/Projectors/ResponsesAgentToolStateCurrentStateProjector.cs`
- `src/platform/Aevatar.GAgentService.Projection/Queries/ResponsesAgentToolStateQueryReader.cs`
- `src/platform/Aevatar.GAgentService.Projection/ReadModels/ServiceProjectionReadModels.Partial.cs`
- `src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto`(reserved fields)
- `test/Aevatar.GAgentService.Tests/Core/ResponsesAgentToolStateGAgentTests.cs`
- `test/Aevatar.GAgentService.Tests/Projection/ResponsesAgentToolStateCurrentStateProjectorTests.cs`

## 验证

- `dotnet build aevatar.slnx --nologo`:绿
- `dotnet test aevatar.slnx --nologo --no-build`:绿(IMPLEMENT_DONE:ok marker)
- Phase 9 consensus: `META_JUDGE_DONE:consensus:hybrid-minimal-structural-delete`

Closes #1183

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧