### PR TITLE
#1287 first slice: 删除 hosted-service EventStore marker lease + per-target revalidation (no-new-core)

### DIFF
--- a/docs/operations/2026-04-28-retired-actor-startup-cleanup-runbook.md
+++ b/docs/operations/2026-04-28-retired-actor-startup-cleanup-runbook.md
@@ -54,21 +54,21 @@ A spec declares:
 
 For each spec the service:
 
-1. Acquires a per-spec lease at `__maintenance:retired-actor-cleanup:{specId}`
-   (waits if another pod holds an in-progress lease, takes over after
-   `InProgressTimeoutSeconds`).
+1. Starts a background cleanup pass during host startup; module startup is not
+   blocked on completion.
 2. Streams targets from `DiscoverDynamicTargetsAsync` first, then iterates
    `Targets`.
-3. For each target: probes the runtime type via `IActorTypeProbe`. When it
-   matches a retired token, removes upstream relays from `SourceStreamId`,
-   removes outgoing relays best-effort, deletes module-owned read models
-   best-effort, destroys the actor, and resets the event stream.
-4. Releases the lease.
+3. For each target: probes the runtime type via `IActorTypeProbe`, then
+   revalidates the same target immediately before destructive work. When the
+   final check still matches a retired token, it removes upstream relays from
+   `SourceStreamId`, removes outgoing relays best-effort, deletes module-owned
+   read models best-effort, destroys the actor, and resets the event stream.
 
 There is no "completed forever" marker. The cleanup runs every startup; targets
 already cleaned by a previous pod are detected as either "no runtime type and no
 event stream" (skip) or "no runtime type but stream still present" (continue
-reset path).
+reset path). Targets recreated with a current runtime type between discovery and
+cleanup are skipped by the per-target revalidation fence.
 
 ## Active Specs
 
@@ -92,8 +92,6 @@ Options:
 - `Enabled`: default `true`
 - `ResetEventStreams`: default `true`
 - `CleanupReadModels`: default `true`
-- `InProgressTimeoutSeconds`: default `300`
-- `WaitPollMilliseconds`: default `1000`
 
 Use `Enabled=false` only for emergency rollback while manually clearing the
 retired actors. Leaving it disabled means the old activation failure can return
@@ -117,10 +115,9 @@ the targets are fully cleaned (and remains a no-op afterwards). No changes to
 
 ## Expected Upgrade Behavior
 
-- First pod to start in a deployment wave acquires each spec's lease.
-- Other pods wait while a spec's marker is in progress.
-- If the owning pod dies before completion, another pod takes over after
-  `InProgressTimeoutSeconds`.
+- Every pod may trigger the startup cleanup pass.
+- Duplicate cleanup passes converge through per-target revalidation and
+  idempotent actor / stream / read-model cleanup.
 - New projection startup recreates the needed actors using the current runtime
   types and rebuild paths.
 
@@ -128,15 +125,15 @@ the targets are fully cleaned (and remains a no-op afterwards). No changes to
 
 Healthy startup logs should include one entry per spec:
 
-- `Retired actor cleanup completed for spec channel-runtime.`
-- `Retired actor cleanup completed for spec device.`
-- `Retired actor cleanup completed for spec scheduled.`
+- `Retired actor cleanup pass finished for spec channel-runtime.`
+- `Retired actor cleanup pass finished for spec device.`
+- `Retired actor cleanup pass finished for spec scheduled.`
 
 During the first cleanup of a newly-retired type, `IActorTypeProbe` may activate
 the retired actor long enough to read its persisted type name. Orleans can emit
 transient error logs like `Unable to resolve agent type …` for those actors
 before the cleanup removes them. Treat those as expected only when they are
-followed by `Retired actor cleanup completed for spec …`.
+followed by `Retired actor cleanup pass finished for spec …`.
 
 The failure signatures below should disappear after the cleanup has completed:
 

--- a/docs/operations/2026-04-28-retired-actor-startup-cleanup-runbook.md
+++ b/docs/operations/2026-04-28-retired-actor-startup-cleanup-runbook.md
@@ -37,7 +37,7 @@ Each retired module ships its own `IRetiredActorSpec` implementation alongside i
 DI extension (`AddChannelRuntime`, `AddDeviceRegistration`, `AddScheduledAgents`).
 A spec declares:
 
-- `SpecId` — stable identifier used as the marker stream namespace.
+- `SpecId` — stable identifier used for logs and operational diagnostics.
 - `Targets` — well-known retired actor ids and the CLR type name tokens that
   identify them as retired.
 - `DiscoverDynamicTargetsAsync` — optional. The Scheduled spec uses this to read
@@ -54,8 +54,8 @@ A spec declares:
 
 For each spec the service:
 
-1. Starts a background cleanup pass during host startup; module startup is not
-   blocked on completion.
+1. Triggers a background-service cleanup pass during host startup; module startup
+   is not blocked on completion.
 2. Streams targets from `DiscoverDynamicTargetsAsync` first, then iterates
    `Targets`.
 3. For each target: probes the runtime type via `IActorTypeProbe`, then

--- a/docs/operations/2026-04-28-retired-actor-startup-cleanup-runbook.md
+++ b/docs/operations/2026-04-28-retired-actor-startup-cleanup-runbook.md
@@ -120,8 +120,8 @@ the targets are fully cleaned (and remains a no-op afterwards). No changes to
 - Duplicate cleanup passes converge through per-target revalidation and
   idempotent actor / stream / read-model cleanup.
 - New projection startup recreates the needed actors using the current runtime
-  types and rebuild paths. The cleanup lease coordinates cleanup ownership only;
-  it is not a startup-wide readiness barrier.
+  types and rebuild paths. Startup cleanup is best-effort background work; it is
+  not a startup-wide readiness barrier.
 
 ## Validation
 

--- a/src/Aevatar.Foundation.Abstractions/Maintenance/IRetiredActorSpec.cs
+++ b/src/Aevatar.Foundation.Abstractions/Maintenance/IRetiredActorSpec.cs
@@ -6,10 +6,11 @@ namespace Aevatar.Foundation.Abstractions.Maintenance;
 /// previously persisted those types, and (optionally) how to discover dynamic
 /// targets and how to delete its read-model documents.
 /// </summary>
+// Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
 public interface IRetiredActorSpec
 {
     /// <summary>
-    /// Stable, module-scoped identifier (used as the marker stream namespace).
+    /// Stable, module-scoped identifier for logs and operational diagnostics.
     /// </summary>
     string SpecId { get; }
 

--- a/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupHostedService.cs
+++ b/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupHostedService.cs
@@ -47,7 +47,6 @@ public sealed class RetiredActorCleanupHostedService : BackgroundService
     private readonly RetiredActorCleanupOptions _options;
     private readonly ILogger<RetiredActorCleanupHostedService> _logger;
     private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
-    private Task? _cleanupTask;
 
     public RetiredActorCleanupHostedService(
         IEnumerable<IRetiredActorSpec> specs,
@@ -76,6 +75,9 @@ public sealed class RetiredActorCleanupHostedService : BackgroundService
 
     public Task Completion => _completion.Task;
 
+    // Refactor (issue1287-first):
+    //   Old pattern: startup completion was coordinated through persisted marker lease state.
+    //   New principle: host lifecycle owns one asynchronous pass; callers observe Completion honestly.
     protected override Task ExecuteAsync(CancellationToken stoppingToken)
     {
         if (!_options.Enabled)
@@ -91,8 +93,7 @@ public sealed class RetiredActorCleanupHostedService : BackgroundService
             return Task.CompletedTask;
         }
 
-        _cleanupTask = RunCleanupPassAfterStartupAsync(stoppingToken);
-        return _cleanupTask;
+        return RunCleanupPassAfterStartupAsync(stoppingToken);
     }
 
     private static async Task YieldStartupAsync()
@@ -100,6 +101,9 @@ public sealed class RetiredActorCleanupHostedService : BackgroundService
         await Task.Yield();
     }
 
+    // Refactor (issue1287-first):
+    //   Old pattern: cleanup implied a startup ordering invariant with module hosted services.
+    //   New principle: yield one host turn, then run an idempotent pass fenced per target.
     private async Task RunCleanupPassAfterStartupAsync(CancellationToken ct)
     {
         try
@@ -137,6 +141,9 @@ public sealed class RetiredActorCleanupHostedService : BackgroundService
         }
     }
 
+    // Refactor (issue1287-first):
+    //   Old pattern: one completed marker covered the entire spec.
+    //   New principle: every discovered and static target is independently revalidated and cleaned.
     private async Task RunSpecAsync(IRetiredActorSpec spec, CancellationToken ct)
     {
         try
@@ -158,6 +165,9 @@ public sealed class RetiredActorCleanupHostedService : BackgroundService
         }
     }
 
+    // Refactor (issue1287-first):
+    //   Old pattern: marker ownership decided whether destructive cleanup could proceed.
+    //   New principle: probe immediately before cleanup, then probe again before destruction/reset.
     private async Task CleanupTargetAsync(IRetiredActorSpec spec, RetiredActorTarget target, CancellationToken ct)
     {
         var candidate = await RevalidateTargetForCleanupAsync(target, ct).ConfigureAwait(false);
@@ -202,6 +212,9 @@ public sealed class RetiredActorCleanupHostedService : BackgroundService
             revalidation.CleanupReason);
     }
 
+    // Refactor (issue1287-first):
+    //   Old pattern: stale marker state represented cleanup truth.
+    //   New principle: runtime type and durable stream presence are the only cleanup facts.
     private async Task<CleanupTargetRevalidation> RevalidateTargetForCleanupAsync(
         RetiredActorTarget target,
         CancellationToken ct)

--- a/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupHostedService.cs
+++ b/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupHostedService.cs
@@ -3,7 +3,6 @@ using Aevatar.Foundation.Abstractions.Maintenance;
 using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.Foundation.Abstractions.TypeSystem;
-using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -22,15 +21,13 @@ namespace Aevatar.Foundation.Runtime.Hosting.Maintenance;
 /// work. New retired types take effect on the next pod startup with zero per-spec
 /// completion gating — the spec list itself is the only source of truth.
 ///
-/// Marker stream coordination prevents two pods running the same spec
-/// simultaneously during a startup wave (lease + stale timeout). It does not gate
-/// future runs; the cleanup runs every startup until the spec is removed.
+/// Startup only triggers the cleanup pass. Each target is revalidated immediately
+/// before destructive work, so duplicate startup waves converge through no-op
+/// checks instead of EventStore marker coordination.
 /// </summary>
+// Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
 public sealed class RetiredActorCleanupHostedService : IHostedService
 {
-    private const int MarkerInProgress = 1;
-    private const int MarkerReleased = 2;
-
     // Stable cleanupReason values for log/metric distinguishing of normal-match
     // vs orphaned-stream recovery paths. Ops dashboards group on these strings.
     private const string CleanupReasonRetiredTypeMatch = "retired-type-match";
@@ -46,7 +43,10 @@ public sealed class RetiredActorCleanupHostedService : IHostedService
     private readonly IServiceProvider _services;
     private readonly RetiredActorCleanupOptions _options;
     private readonly ILogger<RetiredActorCleanupHostedService> _logger;
+    private CancellationTokenSource? _cleanupCts;
+    private Task? _cleanupTask;
 
+    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     public RetiredActorCleanupHostedService(
         IEnumerable<IRetiredActorSpec> specs,
         IActorTypeProbe typeProbe,
@@ -72,105 +72,95 @@ public sealed class RetiredActorCleanupHostedService : IHostedService
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public async Task StartAsync(CancellationToken cancellationToken)
+    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
+    public Task Completion => _cleanupTask ?? Task.CompletedTask;
+
+    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
+    public Task StartAsync(CancellationToken cancellationToken)
     {
         if (!_options.Enabled)
         {
             _logger.LogInformation("Retired actor cleanup is disabled.");
-            return;
+            return Task.CompletedTask;
         }
 
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.CompletedTask;
+        }
+
+        _cleanupCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _cleanupTask = Task.Run(() => RunCleanupPassAsync(_cleanupCts.Token), CancellationToken.None);
+        return Task.CompletedTask;
+    }
+
+    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _ = cancellationToken;
+        _cleanupCts?.Cancel();
+        return Task.CompletedTask;
+    }
+
+    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
+    private async Task RunCleanupPassAsync(CancellationToken ct)
+    {
         try
         {
             foreach (var spec in _specs)
             {
-                await RunSpecAsync(spec, cancellationToken).ConfigureAwait(false);
+                await RunSpecAsync(spec, ct).ConfigureAwait(false);
             }
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Retired actor cleanup pass failed.");
         }
     }
 
-    public Task StopAsync(CancellationToken cancellationToken)
-    {
-        _ = cancellationToken;
-        return Task.CompletedTask;
-    }
-
+    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     private async Task RunSpecAsync(IRetiredActorSpec spec, CancellationToken ct)
     {
-        var lease = await TryAcquireLeaseAsync(spec.SpecId, ct).ConfigureAwait(false);
-        if (lease == null)
-            return;
-
         try
         {
             await foreach (var dynamicTarget in spec.DiscoverDynamicTargetsAsync(_services, ct).ConfigureAwait(false))
             {
-                if (!await IsLeaseOwnerAsync(spec.SpecId, lease, ct).ConfigureAwait(false))
-                {
-                    _logger.LogWarning(
-                        "Retired actor cleanup lease lost while processing spec {SpecId}. actorId={ActorId}",
-                        spec.SpecId,
-                        dynamicTarget.ActorId);
-                    return;
-                }
-
                 await CleanupTargetAsync(spec, dynamicTarget, ct).ConfigureAwait(false);
             }
 
             foreach (var target in spec.Targets)
             {
-                if (!await IsLeaseOwnerAsync(spec.SpecId, lease, ct).ConfigureAwait(false))
-                {
-                    _logger.LogWarning(
-                        "Retired actor cleanup lease lost while processing spec {SpecId}. actorId={ActorId}",
-                        spec.SpecId,
-                        target.ActorId);
-                    return;
-                }
-
                 await CleanupTargetAsync(spec, target, ct).ConfigureAwait(false);
             }
 
-            await ReleaseLeaseAsync(spec.SpecId, lease, ct).ConfigureAwait(false);
-            _logger.LogInformation("Retired actor cleanup completed for spec {SpecId}.", spec.SpecId);
+            _logger.LogInformation("Retired actor cleanup pass finished for spec {SpecId}.", spec.SpecId);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
         }
     }
 
+    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     private async Task CleanupTargetAsync(IRetiredActorSpec spec, RetiredActorTarget target, CancellationToken ct)
     {
-        var runtimeTypeName = await _typeProbe
-            .GetRuntimeAgentTypeNameAsync(target.ActorId, ct)
-            .ConfigureAwait(false);
-        var matchesRetiredRuntimeType = target.MatchesRuntimeType(runtimeTypeName);
-        var shouldContinueReset = false;
-        if (!matchesRetiredRuntimeType)
-        {
-            if (!string.IsNullOrWhiteSpace(runtimeTypeName))
-                return;
+        var candidate = await RevalidateTargetForCleanupAsync(target, ct).ConfigureAwait(false);
+        if (!candidate.ShouldClean)
+            return;
 
-            shouldContinueReset = target.ResetWhenRuntimeTypeUnavailable &&
-                                  await HasEventStreamAsync(target.ActorId, ct).ConfigureAwait(false);
-            if (!shouldContinueReset)
-                return;
-        }
+        var revalidation = await RevalidateTargetForCleanupAsync(target, ct).ConfigureAwait(false);
+        if (!revalidation.ShouldClean)
+            return;
 
-        var cleanupReason = matchesRetiredRuntimeType
-            ? CleanupReasonRetiredTypeMatch
-            : CleanupReasonOrphanedEventStream;
-
-        if (shouldContinueReset)
+        if (revalidation.ShouldContinueReset)
         {
             _logger.LogInformation(
                 "Retired actor stream cleanup recovering orphaned stream after partial cleanup. specId={SpecId} actorId={ActorId} cleanupReason={CleanupReason}",
                 spec.SpecId,
                 target.ActorId,
-                cleanupReason);
+                revalidation.CleanupReason);
         }
 
         if (!string.IsNullOrWhiteSpace(target.SourceStreamId))
@@ -194,10 +184,46 @@ public sealed class RetiredActorCleanupHostedService : IHostedService
             "Retired actor cleaned. specId={SpecId} actorId={ActorId} runtimeType={RuntimeType} cleanupReason={CleanupReason}",
             spec.SpecId,
             target.ActorId,
-            runtimeTypeName ?? string.Empty,
-            cleanupReason);
+            revalidation.RuntimeTypeName ?? string.Empty,
+            revalidation.CleanupReason);
     }
 
+    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
+    private async Task<CleanupTargetRevalidation> RevalidateTargetForCleanupAsync(
+        RetiredActorTarget target,
+        CancellationToken ct)
+    {
+        var runtimeTypeName = await _typeProbe
+            .GetRuntimeAgentTypeNameAsync(target.ActorId, ct)
+            .ConfigureAwait(false);
+        if (target.MatchesRuntimeType(runtimeTypeName))
+        {
+            return new CleanupTargetRevalidation(
+                ShouldClean: true,
+                RuntimeTypeName: runtimeTypeName,
+                ShouldContinueReset: false,
+                CleanupReason: CleanupReasonRetiredTypeMatch);
+        }
+
+        if (!string.IsNullOrWhiteSpace(runtimeTypeName))
+        {
+            return new CleanupTargetRevalidation(
+                ShouldClean: false,
+                RuntimeTypeName: runtimeTypeName,
+                ShouldContinueReset: false,
+                CleanupReason: string.Empty);
+        }
+
+        var shouldContinueReset = target.ResetWhenRuntimeTypeUnavailable &&
+                                  await HasEventStreamAsync(target.ActorId, ct).ConfigureAwait(false);
+        return new CleanupTargetRevalidation(
+            ShouldClean: shouldContinueReset,
+            RuntimeTypeName: runtimeTypeName,
+            ShouldContinueReset: shouldContinueReset,
+            CleanupReason: shouldContinueReset ? CleanupReasonOrphanedEventStream : string.Empty);
+    }
+
+    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     private async Task CleanupIncomingRelayBestEffortAsync(
         IRetiredActorSpec spec, RetiredActorTarget target, CancellationToken ct)
     {
@@ -223,6 +249,7 @@ public sealed class RetiredActorCleanupHostedService : IHostedService
         }
     }
 
+    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     private async Task CleanupOutgoingRelaysBestEffortAsync(IRetiredActorSpec spec, string actorId, CancellationToken ct)
     {
         try
@@ -249,6 +276,7 @@ public sealed class RetiredActorCleanupHostedService : IHostedService
         }
     }
 
+    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     private async Task CleanupReadModelsBestEffortAsync(IRetiredActorSpec spec, string actorId, CancellationToken ct)
     {
         try
@@ -269,6 +297,7 @@ public sealed class RetiredActorCleanupHostedService : IHostedService
         }
     }
 
+    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     private async Task CleanupStreamPubSubBestEffortAsync(IRetiredActorSpec spec, string actorId, CancellationToken ct)
     {
         if (_streamPubSubMaintenance == null)
@@ -292,133 +321,14 @@ public sealed class RetiredActorCleanupHostedService : IHostedService
         }
     }
 
+    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     private async Task<bool> HasEventStreamAsync(string actorId, CancellationToken ct) =>
         await _eventStore.GetVersionAsync(actorId, ct).ConfigureAwait(false) > 0;
 
-    private async Task<CleanupLease?> TryAcquireLeaseAsync(string specId, CancellationToken ct)
-    {
-        var markerStreamId = MarkerStreamId(specId);
-        var timeout = TimeSpan.FromSeconds(_options.InProgressTimeoutSeconds);
-        var pollDelay = TimeSpan.FromMilliseconds(_options.WaitPollMilliseconds);
-
-        while (true)
-        {
-            ct.ThrowIfCancellationRequested();
-            var marker = await ReadMarkerAsync(markerStreamId, ct).ConfigureAwait(false);
-            if (marker.Latest is { Status: MarkerInProgress } latest && !IsStale(latest, timeout))
-            {
-                await Task.Delay(pollDelay, ct).ConfigureAwait(false);
-                continue;
-            }
-
-            var lease = new CleanupLease(Guid.NewGuid().ToString("N"));
-            try
-            {
-                await AppendMarkerAsync(
-                    markerStreamId,
-                    MarkerInProgress,
-                    lease.Token,
-                    marker.CurrentVersion,
-                    ct).ConfigureAwait(false);
-                return lease;
-            }
-            catch (EventStoreOptimisticConcurrencyException)
-            {
-                continue;
-            }
-        }
-    }
-
-    private async Task<bool> IsLeaseOwnerAsync(string specId, CleanupLease lease, CancellationToken ct)
-    {
-        var marker = await ReadMarkerAsync(MarkerStreamId(specId), ct).ConfigureAwait(false);
-        return marker.Latest is { Status: MarkerInProgress } latest &&
-               string.Equals(latest.Token, lease.Token, StringComparison.Ordinal);
-    }
-
-    private async Task ReleaseLeaseAsync(string specId, CleanupLease lease, CancellationToken ct)
-    {
-        var markerStreamId = MarkerStreamId(specId);
-        var marker = await ReadMarkerAsync(markerStreamId, ct).ConfigureAwait(false);
-        if (marker.Latest is not { Status: MarkerInProgress } latest ||
-            !string.Equals(latest.Token, lease.Token, StringComparison.Ordinal))
-        {
-            _logger.LogWarning("Retired actor cleanup lease was lost before release for spec {SpecId}.", specId);
-            return;
-        }
-
-        await AppendMarkerAsync(
-            markerStreamId,
-            MarkerReleased,
-            lease.Token,
-            marker.CurrentVersion,
-            ct).ConfigureAwait(false);
-    }
-
-    private async Task<MarkerSnapshot> ReadMarkerAsync(string markerStreamId, CancellationToken ct)
-    {
-        var events = await _eventStore.GetEventsAsync(markerStreamId, ct: ct).ConfigureAwait(false);
-        MarkerRecord? latest = null;
-        foreach (var evt in events)
-        {
-            var parsed = TryParseMarker(evt);
-            if (parsed != null)
-                latest = parsed;
-        }
-
-        var version = events.Count > 0 ? events[^1].Version : 0;
-        return new MarkerSnapshot(version, latest);
-    }
-
-    private async Task AppendMarkerAsync(
-        string markerStreamId,
-        int status,
-        string token,
-        long expectedVersion,
-        CancellationToken ct)
-    {
-        await _eventStore.AppendAsync(
-            markerStreamId,
-            [
-                new StateEvent
-                {
-                    AgentId = markerStreamId,
-                    EventId = token,
-                    EventType = Int32Value.Descriptor.FullName,
-                    EventData = Any.Pack(new Int32Value { Value = status }),
-                    Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-                    Version = expectedVersion + 1,
-                },
-            ],
-            expectedVersion,
-            ct).ConfigureAwait(false);
-    }
-
-    private static MarkerRecord? TryParseMarker(StateEvent evt)
-    {
-        if (evt.EventData == null || !evt.EventData.TryUnpack<Int32Value>(out var status))
-            return null;
-
-        return new MarkerRecord(
-            status.Value,
-            evt.EventId ?? string.Empty,
-            evt.Timestamp?.ToDateTimeOffset() ?? DateTimeOffset.MinValue,
-            evt.Version);
-    }
-
-    private static bool IsStale(MarkerRecord marker, TimeSpan timeout) =>
-        DateTimeOffset.UtcNow - marker.Timestamp > timeout;
-
-    private static string MarkerStreamId(string specId) =>
-        $"__maintenance:retired-actor-cleanup:{specId}";
-
-    private sealed record CleanupLease(string Token);
-
-    private sealed record MarkerRecord(
-        int Status,
-        string Token,
-        DateTimeOffset Timestamp,
-        long Version);
-
-    private sealed record MarkerSnapshot(long CurrentVersion, MarkerRecord? Latest);
+    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
+    private sealed record CleanupTargetRevalidation(
+        bool ShouldClean,
+        string? RuntimeTypeName,
+        bool ShouldContinueReset,
+        string CleanupReason);
 }

--- a/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupHostedService.cs
+++ b/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupHostedService.cs
@@ -96,6 +96,9 @@ public sealed class RetiredActorCleanupHostedService : BackgroundService
         return RunCleanupPassAfterStartupAsync(stoppingToken);
     }
 
+    // Refactor (issue1287-first):
+    //   Old pattern: cleanup startup waited on marker lease state to imply ordering.
+    //   New principle: yield one host turn without inventing cleanup ownership state.
     private static async Task YieldStartupAsync()
     {
         await Task.Yield();
@@ -123,6 +126,9 @@ public sealed class RetiredActorCleanupHostedService : BackgroundService
         }
     }
 
+    // Refactor (issue1287-first):
+    //   Old pattern: a completed spec marker skipped later startup cleanup passes.
+    //   New principle: each startup pass iterates specs and lets target revalidation converge no-ops.
     private async Task RunCleanupPassAsync(CancellationToken ct)
     {
         try

--- a/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupHostedService.cs
+++ b/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupHostedService.cs
@@ -21,12 +21,15 @@ namespace Aevatar.Foundation.Runtime.Hosting.Maintenance;
 /// work. New retired types take effect on the next pod startup with zero per-spec
 /// completion gating — the spec list itself is the only source of truth.
 ///
-/// Startup only triggers the cleanup pass. Each target is revalidated immediately
-/// before destructive work, so duplicate startup waves converge through no-op
-/// checks instead of EventStore marker coordination.
+/// Startup only triggers the cleanup pass through the host's background-service
+/// lifecycle. Each target is revalidated immediately before destructive work, so
+/// duplicate startup waves converge through no-op checks instead of EventStore
+/// marker coordination.
 /// </summary>
-// Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
-public sealed class RetiredActorCleanupHostedService : IHostedService
+// Refactor (issue1287-first):
+//   Old pattern: EventStore marker lease recorded completed specs and startup owned cleanup completion.
+//   New principle: BackgroundService triggers cleanup once; per-target revalidation fences destructive work.
+public sealed class RetiredActorCleanupHostedService : BackgroundService
 {
     // Stable cleanupReason values for log/metric distinguishing of normal-match
     // vs orphaned-stream recovery paths. Ops dashboards group on these strings.
@@ -43,10 +46,9 @@ public sealed class RetiredActorCleanupHostedService : IHostedService
     private readonly IServiceProvider _services;
     private readonly RetiredActorCleanupOptions _options;
     private readonly ILogger<RetiredActorCleanupHostedService> _logger;
-    private CancellationTokenSource? _cleanupCts;
+    private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private Task? _cleanupTask;
 
-    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     public RetiredActorCleanupHostedService(
         IEnumerable<IRetiredActorSpec> specs,
         IActorTypeProbe typeProbe,
@@ -72,37 +74,51 @@ public sealed class RetiredActorCleanupHostedService : IHostedService
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
-    public Task Completion => _cleanupTask ?? Task.CompletedTask;
+    public Task Completion => _completion.Task;
 
-    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
-    public Task StartAsync(CancellationToken cancellationToken)
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
     {
         if (!_options.Enabled)
         {
             _logger.LogInformation("Retired actor cleanup is disabled.");
+            _completion.TrySetResult();
             return Task.CompletedTask;
         }
 
-        if (cancellationToken.IsCancellationRequested)
+        if (stoppingToken.IsCancellationRequested)
         {
+            _completion.TrySetCanceled(stoppingToken);
             return Task.CompletedTask;
         }
 
-        _cleanupCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        _cleanupTask = Task.Run(() => RunCleanupPassAsync(_cleanupCts.Token), CancellationToken.None);
-        return Task.CompletedTask;
+        _cleanupTask = RunCleanupPassAfterStartupAsync(stoppingToken);
+        return _cleanupTask;
     }
 
-    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
-    public Task StopAsync(CancellationToken cancellationToken)
+    private static async Task YieldStartupAsync()
     {
-        _ = cancellationToken;
-        _cleanupCts?.Cancel();
-        return Task.CompletedTask;
+        await Task.Yield();
     }
 
-    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
+    private async Task RunCleanupPassAfterStartupAsync(CancellationToken ct)
+    {
+        try
+        {
+            await YieldStartupAsync().ConfigureAwait(false);
+            await RunCleanupPassAsync(ct).ConfigureAwait(false);
+            _completion.TrySetResult();
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            _completion.TrySetCanceled(ct);
+        }
+        catch (Exception ex)
+        {
+            _completion.TrySetException(ex);
+            throw;
+        }
+    }
+
     private async Task RunCleanupPassAsync(CancellationToken ct)
     {
         try
@@ -121,7 +137,6 @@ public sealed class RetiredActorCleanupHostedService : IHostedService
         }
     }
 
-    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     private async Task RunSpecAsync(IRetiredActorSpec spec, CancellationToken ct)
     {
         try
@@ -143,7 +158,6 @@ public sealed class RetiredActorCleanupHostedService : IHostedService
         }
     }
 
-    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     private async Task CleanupTargetAsync(IRetiredActorSpec spec, RetiredActorTarget target, CancellationToken ct)
     {
         var candidate = await RevalidateTargetForCleanupAsync(target, ct).ConfigureAwait(false);
@@ -188,7 +202,6 @@ public sealed class RetiredActorCleanupHostedService : IHostedService
             revalidation.CleanupReason);
     }
 
-    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     private async Task<CleanupTargetRevalidation> RevalidateTargetForCleanupAsync(
         RetiredActorTarget target,
         CancellationToken ct)
@@ -223,7 +236,6 @@ public sealed class RetiredActorCleanupHostedService : IHostedService
             CleanupReason: shouldContinueReset ? CleanupReasonOrphanedEventStream : string.Empty);
     }
 
-    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     private async Task CleanupIncomingRelayBestEffortAsync(
         IRetiredActorSpec spec, RetiredActorTarget target, CancellationToken ct)
     {
@@ -249,7 +261,6 @@ public sealed class RetiredActorCleanupHostedService : IHostedService
         }
     }
 
-    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     private async Task CleanupOutgoingRelaysBestEffortAsync(IRetiredActorSpec spec, string actorId, CancellationToken ct)
     {
         try
@@ -276,7 +287,6 @@ public sealed class RetiredActorCleanupHostedService : IHostedService
         }
     }
 
-    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     private async Task CleanupReadModelsBestEffortAsync(IRetiredActorSpec spec, string actorId, CancellationToken ct)
     {
         try
@@ -297,7 +307,6 @@ public sealed class RetiredActorCleanupHostedService : IHostedService
         }
     }
 
-    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     private async Task CleanupStreamPubSubBestEffortAsync(IRetiredActorSpec spec, string actorId, CancellationToken ct)
     {
         if (_streamPubSubMaintenance == null)
@@ -321,11 +330,9 @@ public sealed class RetiredActorCleanupHostedService : IHostedService
         }
     }
 
-    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     private async Task<bool> HasEventStreamAsync(string actorId, CancellationToken ct) =>
         await _eventStore.GetVersionAsync(actorId, ct).ConfigureAwait(false) > 0;
 
-    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     private sealed record CleanupTargetRevalidation(
         bool ShouldClean,
         string? RuntimeTypeName,

--- a/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupOptions.cs
+++ b/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupOptions.cs
@@ -5,7 +5,6 @@ namespace Aevatar.Foundation.Runtime.Hosting.Maintenance;
 /// <summary>
 /// Tunables for the spec-driven retired-actor cleanup hosted service.
 /// </summary>
-// Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
 public sealed class RetiredActorCleanupOptions
 {
     public const string SectionName = "Aevatar:RetiredActorCleanup";
@@ -16,7 +15,6 @@ public sealed class RetiredActorCleanupOptions
 
     public bool CleanupReadModels { get; init; } = true;
 
-    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     public static RetiredActorCleanupOptions FromConfiguration(IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);
@@ -30,7 +28,6 @@ public sealed class RetiredActorCleanupOptions
         };
     }
 
-    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     private static bool ResolveBool(IConfiguration section, string key, bool fallback)
     {
         var raw = section[key];

--- a/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupOptions.cs
+++ b/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupOptions.cs
@@ -5,6 +5,7 @@ namespace Aevatar.Foundation.Runtime.Hosting.Maintenance;
 /// <summary>
 /// Tunables for the spec-driven retired-actor cleanup hosted service.
 /// </summary>
+// Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
 public sealed class RetiredActorCleanupOptions
 {
     public const string SectionName = "Aevatar:RetiredActorCleanup";
@@ -15,10 +16,7 @@ public sealed class RetiredActorCleanupOptions
 
     public bool CleanupReadModels { get; init; } = true;
 
-    public int InProgressTimeoutSeconds { get; init; } = 300;
-
-    public int WaitPollMilliseconds { get; init; } = 1000;
-
+    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     public static RetiredActorCleanupOptions FromConfiguration(IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);
@@ -29,26 +27,13 @@ public sealed class RetiredActorCleanupOptions
             Enabled = ResolveBool(section, nameof(Enabled), fallback: true),
             ResetEventStreams = ResolveBool(section, nameof(ResetEventStreams), fallback: true),
             CleanupReadModels = ResolveBool(section, nameof(CleanupReadModels), fallback: true),
-            InProgressTimeoutSeconds = ResolvePositiveInt(
-                section,
-                nameof(InProgressTimeoutSeconds),
-                fallback: 300),
-            WaitPollMilliseconds = ResolvePositiveInt(
-                section,
-                nameof(WaitPollMilliseconds),
-                fallback: 1000),
         };
     }
 
+    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     private static bool ResolveBool(IConfiguration section, string key, bool fallback)
     {
         var raw = section[key];
         return bool.TryParse(raw, out var value) ? value : fallback;
-    }
-
-    private static int ResolvePositiveInt(IConfiguration section, string key, int fallback)
-    {
-        var raw = section[key];
-        return int.TryParse(raw, out var value) && value > 0 ? value : fallback;
     }
 }

--- a/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupOptions.cs
+++ b/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupOptions.cs
@@ -15,6 +15,9 @@ public sealed class RetiredActorCleanupOptions
 
     public bool CleanupReadModels { get; init; } = true;
 
+    // Refactor (issue1287-first):
+    //   Old pattern: options included marker lease timeouts and polling cadence.
+    //   New principle: options only gate idempotent cleanup actions; no lease timing remains.
     public static RetiredActorCleanupOptions FromConfiguration(IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);

--- a/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupOptions.cs
+++ b/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupOptions.cs
@@ -5,6 +5,9 @@ namespace Aevatar.Foundation.Runtime.Hosting.Maintenance;
 /// <summary>
 /// Tunables for the spec-driven retired-actor cleanup hosted service.
 /// </summary>
+// Refactor (issue1287-first):
+//   Old pattern: options exposed marker lease timeout and polling controls.
+//   New principle: options only gate idempotent cleanup actions; no lease timing remains.
 public sealed class RetiredActorCleanupOptions
 {
     public const string SectionName = "Aevatar:RetiredActorCleanup";
@@ -15,9 +18,6 @@ public sealed class RetiredActorCleanupOptions
 
     public bool CleanupReadModels { get; init; } = true;
 
-    // Refactor (issue1287-first):
-    //   Old pattern: options included marker lease timeouts and polling cadence.
-    //   New principle: options only gate idempotent cleanup actions; no lease timing remains.
     public static RetiredActorCleanupOptions FromConfiguration(IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);

--- a/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupServiceCollectionExtensions.cs
+++ b/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupServiceCollectionExtensions.cs
@@ -4,7 +4,9 @@ using Microsoft.Extensions.Hosting;
 
 namespace Aevatar.Foundation.Runtime.Hosting.Maintenance;
 
-// Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
+// Refactor (issue1287-first):
+//   Old pattern: DI registered startup cleanup that completed through EventStore marker coordination.
+//   New principle: DI registers one BackgroundService trigger; target safety is owned by revalidation.
 public static class RetiredActorCleanupServiceCollectionExtensions
 {
     /// <summary>
@@ -14,7 +16,6 @@ public static class RetiredActorCleanupServiceCollectionExtensions
     /// Startup only triggers cleanup; per-target revalidation makes duplicate
     /// runs converge without requiring startup ordering against module services.
     /// </summary>
-    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     public static IServiceCollection AddRetiredActorCleanup(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);

--- a/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupServiceCollectionExtensions.cs
+++ b/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupServiceCollectionExtensions.cs
@@ -4,15 +4,17 @@ using Microsoft.Extensions.Hosting;
 
 namespace Aevatar.Foundation.Runtime.Hosting.Maintenance;
 
+// Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
 public static class RetiredActorCleanupServiceCollectionExtensions
 {
     /// <summary>
     /// Registers the spec-driven retired-actor cleanup hosted service. Each retired
     /// module separately contributes one or more <see cref="Aevatar.Foundation.Abstractions.Maintenance.IRetiredActorSpec"/>
     /// via <c>TryAddEnumerable</c> in its own <c>Add*</c> DI extension.
-    /// Call this before module DI extensions whose startup services activate the
-    /// retired actors.
+    /// Startup only triggers cleanup; per-target revalidation makes duplicate
+    /// runs converge without requiring startup ordering against module services.
     /// </summary>
+    // Refactor (issue1287-first): Old pattern: EventStore marker lease.  New principle: per-target revalidation fence + idempotent cleanup.
     public static IServiceCollection AddRetiredActorCleanup(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);

--- a/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupServiceCollectionExtensions.cs
+++ b/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupServiceCollectionExtensions.cs
@@ -16,6 +16,9 @@ public static class RetiredActorCleanupServiceCollectionExtensions
     /// Startup only triggers cleanup; per-target revalidation makes duplicate
     /// runs converge without requiring startup ordering against module services.
     /// </summary>
+    // Refactor (issue1287-first):
+    //   Old pattern: registration implied a startup cleanup owner coordinated by marker state.
+    //   New principle: registration only wires the BackgroundService trigger; target safety is revalidated.
     public static IServiceCollection AddRetiredActorCleanup(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);

--- a/test/Aevatar.Hosting.Tests/MainnetHostCompositionTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetHostCompositionTests.cs
@@ -218,7 +218,7 @@ public sealed class MainnetHostCompositionTests
     }
 
     [Fact]
-    public void AddAevatarMainnetHost_ShouldRunRetiredActorCleanup_BeforeProjectionStartupServices()
+    public void AddAevatarMainnetHost_ShouldRegisterRetiredActorCleanup()
     {
         using var home = new TemporaryAevatarHomeScope();
         var builder = CreateBuilder();
@@ -229,11 +229,7 @@ public sealed class MainnetHostCompositionTests
             options.EnableCors = false;
         });
 
-        var cleanupIndex = HostedServiceIndex<RetiredActorCleanupHostedService>(builder.Services);
-
-        HostedServiceIndex(builder.Services, "ChannelBotRegistrationStartupService").Should().BeGreaterThan(cleanupIndex);
-        HostedServiceIndex(builder.Services, "DeviceRegistrationStartupService").Should().BeGreaterThan(cleanupIndex);
-        HostedServiceIndex(builder.Services, "UserAgentCatalogStartupService").Should().BeGreaterThan(cleanupIndex);
+        HostedServiceIndex<RetiredActorCleanupHostedService>(builder.Services).Should().BeGreaterThanOrEqualTo(0);
     }
 
     private static WebApplicationBuilder CreateBuilder()

--- a/test/Aevatar.Hosting.Tests/RetiredActorCleanupHostedServiceTests.cs
+++ b/test/Aevatar.Hosting.Tests/RetiredActorCleanupHostedServiceTests.cs
@@ -573,6 +573,34 @@ public sealed class RetiredActorCleanupHostedServiceTests
         (await eventStore.GetVersionAsync("channel-bot-registration-store")).Should().Be(1);
     }
 
+    [Fact]
+    public async Task StartAsync_ShouldReturnBeforeCleanupDiscoveryCompletes()
+    {
+        var eventStore = new InMemoryEventStore();
+        await AppendSingleEventAsync(eventStore, "blocked-retired-actor");
+        var typeProbe = new StubActorTypeProbe(new Dictionary<string, string?>
+        {
+            ["blocked-retired-actor"] =
+                "Aevatar.Tests.Legacy.BlockedRetiredActor, Aevatar.Tests",
+        });
+        var runtime = new RecordingActorRuntime();
+        var spec = new BlockingDiscoveryRetiredActorSpec("blocked-retired-actor");
+        var service = CreateService(
+            typeProbe, runtime, new RecordingStreamProvider(), eventStore, spec);
+
+        await service.StartAsync(CancellationToken.None);
+
+        await spec.DiscoveryEntered.Task;
+        runtime.DestroyedActorIds.Should().BeEmpty();
+        service.Completion.IsCompleted.Should().BeFalse();
+
+        spec.ReleaseDiscovery();
+        await service.Completion;
+
+        runtime.DestroyedActorIds.Should().Contain("blocked-retired-actor");
+        (await eventStore.GetVersionAsync("blocked-retired-actor")).Should().Be(0);
+    }
+
     private static IRetiredActorSpec CreateChannelRuntimeSpec() => new ChannelRuntimeRetiredActorSpec();
 
     private static IRetiredActorSpec CreateDeviceSpec() => new DeviceRetiredActorSpec();
@@ -736,6 +764,33 @@ public sealed class RetiredActorCleanupHostedServiceTests
                 typeNames.TryGetValue(actorId, out var queue) && queue.Count > 0
                     ? queue.Dequeue()
                     : null);
+        }
+    }
+
+    private sealed class BlockingDiscoveryRetiredActorSpec(string actorId) : RetiredActorSpec
+    {
+        private readonly TaskCompletionSource _discoveryEntered = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _releaseDiscovery = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource DiscoveryEntered => _discoveryEntered;
+
+        public override string SpecId => "blocking-discovery";
+
+        public override IReadOnlyList<RetiredActorTarget> Targets => [];
+
+        public void ReleaseDiscovery() => _releaseDiscovery.SetResult();
+
+        public override async IAsyncEnumerable<RetiredActorTarget> DiscoverDynamicTargetsAsync(
+            IServiceProvider services,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            _discoveryEntered.SetResult();
+            await _releaseDiscovery.Task.WaitAsync(ct);
+            yield return new RetiredActorTarget(
+                actorId,
+                ["Aevatar.Tests.Legacy.BlockedRetiredActor"]);
         }
     }
 

--- a/test/Aevatar.Hosting.Tests/RetiredActorCleanupHostedServiceTests.cs
+++ b/test/Aevatar.Hosting.Tests/RetiredActorCleanupHostedServiceTests.cs
@@ -352,6 +352,25 @@ public sealed class RetiredActorCleanupHostedServiceTests
     }
 
     [Fact]
+    public void RetiredActorCleanupHostedService_ShouldNotReintroduceEventStoreMarkerLeaseOrPolling()
+    {
+        // Refactor (issue1287-first):
+        //   Old pattern: hosted cleanup used EventStore marker lease state and polling cadence.
+        //   New principle: source stays on BackgroundService trigger + per-target revalidation.
+        var source = File.ReadAllText(GetRetiredActorCleanupHostedServiceSourcePath());
+        var code = StripLineComments(source);
+
+        code.Should().NotContain("MarkerStreamId");
+        code.Should().NotContain("CleanupLease");
+        code.Should().NotContain("AppendMarkerAsync");
+        code.Should().NotContain("ReadMarkerAsync");
+        code.Should().NotContain("ReleaseLeaseAsync");
+        code.Should().NotContain("Task.Delay");
+        code.Should().NotContain("WaitPollMilliseconds");
+        code.Should().NotContain("InProgressTimeoutSeconds");
+    }
+
+    [Fact]
     public async Task StartAsync_ShouldDeleteMatchingReadModels()
     {
         var eventStore = new InMemoryEventStore();
@@ -732,6 +751,27 @@ public sealed class RetiredActorCleanupHostedServiceTests
 
         throw new FileNotFoundException(
             $"Could not locate ScheduledRetiredActorSpec.cs from {AppContext.BaseDirectory}");
+    }
+
+    private static string GetRetiredActorCleanupHostedServiceSourcePath()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(
+                directory.FullName,
+                "src",
+                "Aevatar.Foundation.Runtime.Hosting",
+                "Maintenance",
+                "RetiredActorCleanupHostedService.cs");
+            if (File.Exists(candidate))
+                return candidate;
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException(
+            $"Could not locate RetiredActorCleanupHostedService.cs from {AppContext.BaseDirectory}");
     }
 
     private sealed class StubActorTypeProbe(IReadOnlyDictionary<string, string?> typeNames) : IActorTypeProbe

--- a/test/Aevatar.Hosting.Tests/RetiredActorCleanupHostedServiceTests.cs
+++ b/test/Aevatar.Hosting.Tests/RetiredActorCleanupHostedServiceTests.cs
@@ -40,7 +40,7 @@ public sealed class RetiredActorCleanupHostedServiceTests
         streamProvider.SeedRelay("channel-bot-registration-store", "stale-child-stream");
         var service = CreateService(typeProbe, runtime, streamProvider, eventStore, CreateChannelRuntimeSpec());
 
-        await service.StartAsync(CancellationToken.None);
+        await RunStartupCleanupAsync(service);
 
         runtime.DestroyedActorIds.Should().Contain("channel-bot-registration-store");
         runtime.DestroyedActorIds.Should().Contain(
@@ -68,7 +68,7 @@ public sealed class RetiredActorCleanupHostedServiceTests
         var service = CreateService(
             typeProbe, runtime, new RecordingStreamProvider(), eventStore, CreateChannelRuntimeSpec());
 
-        await service.StartAsync(CancellationToken.None);
+        await RunStartupCleanupAsync(service);
 
         runtime.DestroyedActorIds.Should().BeEmpty();
         (await eventStore.GetVersionAsync("channel-bot-registration-store")).Should().Be(1);
@@ -88,7 +88,7 @@ public sealed class RetiredActorCleanupHostedServiceTests
         var service = CreateService(
             typeProbe, runtime, new RecordingStreamProvider(), eventStore, CreateChannelRuntimeSpec());
 
-        await service.StartAsync(CancellationToken.None);
+        await RunStartupCleanupAsync(service);
 
         runtime.DestroyedActorIds.Should().BeEmpty();
         (await eventStore.GetVersionAsync("channel-bot-registration-store")).Should().Be(1);
@@ -104,7 +104,7 @@ public sealed class RetiredActorCleanupHostedServiceTests
         var service = CreateService(
             typeProbe, runtime, new RecordingStreamProvider(), eventStore, CreateChannelRuntimeSpec());
 
-        await service.StartAsync(CancellationToken.None);
+        await RunStartupCleanupAsync(service);
 
         runtime.DestroyedActorIds.Should().Contain("channel-bot-registration-store");
         (await eventStore.GetVersionAsync("channel-bot-registration-store")).Should().Be(0);
@@ -160,7 +160,7 @@ public sealed class RetiredActorCleanupHostedServiceTests
             CreateScheduledSpec(),
             serviceCollection.BuildServiceProvider());
 
-        await service.StartAsync(CancellationToken.None);
+        await RunStartupCleanupAsync(service);
 
         runtime.DestroyedActorIds.Should().Contain("skill-runner-old");
         runtime.DestroyedActorIds.Should().Contain("workflow-agent-old");
@@ -195,7 +195,7 @@ public sealed class RetiredActorCleanupHostedServiceTests
         var service = CreateService(
             typeProbe, runtime, new RecordingStreamProvider(), eventStore, CreateScheduledSpec());
 
-        await service.StartAsync(CancellationToken.None);
+        await RunStartupCleanupAsync(service);
 
         runtime.DestroyedActorIds.Should().BeEmpty();
         probedActorIds.Should().NotContain("skill-runner-already-migrated");
@@ -251,7 +251,7 @@ public sealed class RetiredActorCleanupHostedServiceTests
             CreateScheduledSpec(),
             serviceCollection.BuildServiceProvider());
 
-        await service.StartAsync(CancellationToken.None);
+        await RunStartupCleanupAsync(service);
 
         runtime.DestroyedActorIds.Should().Contain("skill-runner-snapshotted");
         runtime.DestroyedActorIds.Should().Contain("workflow-agent-snapshotted");
@@ -280,7 +280,7 @@ public sealed class RetiredActorCleanupHostedServiceTests
         var service = CreateService(
             typeProbe, runtime, streamProvider, eventStore, CreateChannelRuntimeSpec());
 
-        await service.StartAsync(CancellationToken.None);
+        await RunStartupCleanupAsync(service);
 
         runtime.DestroyedActorIds.Should().Contain(projectionScopeActorId);
         (await eventStore.GetVersionAsync(projectionScopeActorId)).Should().Be(0);
@@ -325,7 +325,7 @@ public sealed class RetiredActorCleanupHostedServiceTests
             CreateScheduledSpec(),
             serviceCollection.BuildServiceProvider());
 
-        await service.StartAsync(CancellationToken.None);
+        await RunStartupCleanupAsync(service);
 
         runtime.DestroyedActorIds.Should().NotContain("skill-runner-recent");
         runtime.DestroyedActorIds.Should().Contain("agent-registry-store");
@@ -386,7 +386,7 @@ public sealed class RetiredActorCleanupHostedServiceTests
             CreateScheduledSpec(),
             serviceCollection.BuildServiceProvider());
 
-        await service.StartAsync(CancellationToken.None);
+        await RunStartupCleanupAsync(service);
 
         documents.DeletedIds.Should().Equal("agent-doc-delete");
         documents.RemainingIds.Should().Equal("agent-doc-keep");
@@ -418,7 +418,7 @@ public sealed class RetiredActorCleanupHostedServiceTests
             CreateChannelRuntimeSpec(),
             serviceCollection.BuildServiceProvider());
 
-        await service.StartAsync(CancellationToken.None);
+        await RunStartupCleanupAsync(service);
 
         runtime.DestroyedActorIds.Should().Contain("channel-bot-registration-store");
         (await eventStore.GetVersionAsync("channel-bot-registration-store")).Should().Be(0);
@@ -445,7 +445,7 @@ public sealed class RetiredActorCleanupHostedServiceTests
         var service = CreateService(
             typeProbe, runtime, new RecordingStreamProvider(), eventStore, CreateScheduledSpec());
 
-        await service.StartAsync(CancellationToken.None);
+        await RunStartupCleanupAsync(service);
 
         runtime.DestroyedActorIds.Should().Contain(newScopeKeyActorId);
         (await eventStore.GetVersionAsync(newScopeKeyActorId)).Should().Be(0);
@@ -486,7 +486,7 @@ public sealed class RetiredActorCleanupHostedServiceTests
             CreateChannelRuntimeSpec(),
             serviceCollection.BuildServiceProvider());
 
-        await service.StartAsync(CancellationToken.None);
+        await RunStartupCleanupAsync(service);
 
         pubSub.ResetActorIds.Should().Contain("channel-bot-registration-store");
         pubSub.ResetActorIds.Should().Contain(
@@ -516,7 +516,7 @@ public sealed class RetiredActorCleanupHostedServiceTests
             CreateChannelRuntimeSpec(),
             serviceCollection.BuildServiceProvider());
 
-        await service.StartAsync(CancellationToken.None);
+        await RunStartupCleanupAsync(service);
 
         runtime.DestroyedActorIds.Should().Contain("channel-bot-registration-store");
         (await eventStore.GetVersionAsync("channel-bot-registration-store")).Should().Be(0);
@@ -543,12 +543,34 @@ public sealed class RetiredActorCleanupHostedServiceTests
             eventStore,
             specs: [CreateDeviceSpec(), CreateChannelRuntimeSpec()]);
 
-        await service.StartAsync(CancellationToken.None);
+        await RunStartupCleanupAsync(service);
 
         runtime.DestroyedActorIds.Should().Contain("device-registration-store");
         runtime.DestroyedActorIds.Should().Contain("channel-bot-registration-store");
         (await eventStore.GetVersionAsync("device-registration-store")).Should().Be(0);
         (await eventStore.GetVersionAsync("channel-bot-registration-store")).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Cleanup_ShouldSkipDestructiveWork_WhenPerTargetRevalidationSeesCurrentRuntimeType()
+    {
+        var eventStore = new InMemoryEventStore();
+        await AppendSingleEventAsync(eventStore, "channel-bot-registration-store");
+        var typeProbe = new SequencedTypeProbe(new Dictionary<string, Queue<string?>>
+        {
+            ["channel-bot-registration-store"] = new Queue<string?>([
+                "Aevatar.GAgents.ChannelRuntime.ChannelBotRegistrationGAgent, Aevatar.GAgents.ChannelRuntime",
+                "Aevatar.GAgents.Channel.Runtime.ChannelBotRegistrationGAgent, Aevatar.GAgents.Channel.Runtime",
+            ]),
+        });
+        var runtime = new RecordingActorRuntime();
+        var service = CreateService(
+            typeProbe, runtime, new RecordingStreamProvider(), eventStore, CreateChannelRuntimeSpec());
+
+        await RunStartupCleanupAsync(service);
+
+        runtime.DestroyedActorIds.Should().BeEmpty();
+        (await eventStore.GetVersionAsync("channel-bot-registration-store")).Should().Be(1);
     }
 
     private static IRetiredActorSpec CreateChannelRuntimeSpec() => new ChannelRuntimeRetiredActorSpec();
@@ -575,11 +597,7 @@ public sealed class RetiredActorCleanupHostedServiceTests
         IServiceProvider? services = null)
     {
         var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Aevatar:RetiredActorCleanup:WaitPollMilliseconds"] = "1",
-                ["Aevatar:RetiredActorCleanup:InProgressTimeoutSeconds"] = "1",
-            })
+            .AddInMemoryCollection(new Dictionary<string, string?>())
             .Build();
 
         var resolvedServices = services ?? BuildSpecServices(eventStore, typeProbe);
@@ -603,6 +621,12 @@ public sealed class RetiredActorCleanupHostedServiceTests
         services.AddSingleton<Aevatar.Foundation.Abstractions.Persistence.IEventStore>(eventStore);
         services.AddSingleton(typeProbe);
         return services.BuildServiceProvider();
+    }
+
+    private static async Task RunStartupCleanupAsync(RetiredActorCleanupHostedService service)
+    {
+        await service.StartAsync(CancellationToken.None);
+        await service.Completion;
     }
 
     private static Task AppendSingleEventAsync(InMemoryEventStore eventStore, string actorId) =>
@@ -700,6 +724,18 @@ public sealed class RetiredActorCleanupHostedServiceTests
             ct.ThrowIfCancellationRequested();
             probedActorIds.Add(actorId);
             return Task.FromResult(typeNames.TryGetValue(actorId, out var typeName) ? typeName : null);
+        }
+    }
+
+    private sealed class SequencedTypeProbe(IReadOnlyDictionary<string, Queue<string?>> typeNames) : IActorTypeProbe
+    {
+        public Task<string?> GetRuntimeAgentTypeNameAsync(string actorId, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(
+                typeNames.TryGetValue(actorId, out var queue) && queue.Count > 0
+                    ? queue.Dequeue()
+                    : null);
         }
     }
 


### PR DESCRIPTION
## Phase 9 r3 consensus(3/3 unanimous)

framing:`hybrid-minimal-structural-delete:remove-marker-lease-add-per-target-revalidation`

### 改动

- 删除 `RetiredActorCleanupHostedService` 内 EventStore `__maintenance:retired-actor-cleanup:*` marker lease 读/写
- 引入 per-target revalidation fence(cleanup 前查 readmodel,target 仍 retired 才执行)
- no new actor / no new contract / no sync wait
- 删除 test/runbook 中 ordering-invariant 表述

closes #1287

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧