### PR TITLE
#1290 first slice: 删除 cleanup-before-startup ordering invariant(test/doc only)

### DIFF
--- a/docs/operations/2026-04-28-retired-actor-startup-cleanup-runbook.md
+++ b/docs/operations/2026-04-28-retired-actor-startup-cleanup-runbook.md
@@ -17,9 +17,9 @@ Older deployments persisted runtime actor identities such as:
 
 After the split into `Aevatar.GAgents.Channel.Runtime`, `Aevatar.GAgents.Device`,
 and `Aevatar.GAgents.Scheduled`, those actor implementation types no longer exist.
-When Orleans activates the persisted actors before the new projection startup path
-can rebuild them, activation fails and can abort pod startup. The same pattern
-appears whenever a runtime CLR type is renamed or moved across assemblies.
+When Orleans activates the persisted actors during startup or rebuild paths,
+activation fails and can abort pod startup. The same pattern appears whenever a
+runtime CLR type is renamed or moved across assemblies.
 
 `LegacyClrTypeName` remains a protobuf payload compatibility tool for renamed
 state messages; it does not make a retired actor implementation type safe to
@@ -29,8 +29,9 @@ names, not every legacy protobuf alias.
 ## Architecture
 
 `RetiredActorCleanupHostedService` (in `Aevatar.Foundation.Runtime.Hosting`) is
-registered by `Mainnet.Host.Api` via `services.AddRetiredActorCleanup()`, ahead of
-the per-module projection startup services. It iterates every
+registered by `Mainnet.Host.Api` via `services.AddRetiredActorCleanup()`. It is a
+best-effort, restart-idempotent maintenance pass, not a cross-pod completion
+barrier for per-module projection startup services. It iterates every
 `IRetiredActorSpec` registered in the container.
 
 Each retired module ships its own `IRetiredActorSpec` implementation alongside its
@@ -122,7 +123,8 @@ the targets are fully cleaned (and remains a no-op afterwards). No changes to
 - If the owning pod dies before completion, another pod takes over after
   `InProgressTimeoutSeconds`.
 - New projection startup recreates the needed actors using the current runtime
-  types and rebuild paths.
+  types and rebuild paths. The cleanup lease coordinates cleanup ownership only;
+  it is not a startup-wide readiness barrier.
 
 ## Validation
 
@@ -138,7 +140,8 @@ transient error logs like `Unable to resolve agent type …` for those actors
 before the cleanup removes them. Treat those as expected only when they are
 followed by `Retired actor cleanup completed for spec …`.
 
-The failure signatures below should disappear after the cleanup has completed:
+The failure signatures below should disappear once the relevant retired actor
+targets have been cleaned by one of the idempotent startup passes:
 
 - `Unable to resolve agent type Aevatar.GAgents.ChannelRuntime.*`
 - `projection.durable.scope:* is not a ProjectionMaterializationScopeGAgent<...new namespace...>`

--- a/test/Aevatar.Hosting.Tests/MainnetHostCompositionTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetHostCompositionTests.cs
@@ -218,7 +218,7 @@ public sealed class MainnetHostCompositionTests
     }
 
     [Fact]
-    public void AddAevatarMainnetHost_ShouldRunRetiredActorCleanup_BeforeProjectionStartupServices()
+    public void AddAevatarMainnetHost_ShouldRegisterRetiredActorCleanupHostedService()
     {
         using var home = new TemporaryAevatarHomeScope();
         var builder = CreateBuilder();
@@ -229,11 +229,8 @@ public sealed class MainnetHostCompositionTests
             options.EnableCors = false;
         });
 
-        var cleanupIndex = HostedServiceIndex<RetiredActorCleanupHostedService>(builder.Services);
-
-        HostedServiceIndex(builder.Services, "ChannelBotRegistrationStartupService").Should().BeGreaterThan(cleanupIndex);
-        HostedServiceIndex(builder.Services, "DeviceRegistrationStartupService").Should().BeGreaterThan(cleanupIndex);
-        HostedServiceIndex(builder.Services, "UserAgentCatalogStartupService").Should().BeGreaterThan(cleanupIndex);
+        // Refactor (issue1290-first): Old: strict cleanup-before-module-startup invariant.  New: cleanup is best-effort restart-idempotent, not a cross-pod completion barrier.
+        HostedServiceDescriptors<RetiredActorCleanupHostedService>(builder.Services).Should().ContainSingle();
     }
 
     private static WebApplicationBuilder CreateBuilder()
@@ -257,26 +254,11 @@ public sealed class MainnetHostCompositionTests
         return builder;
     }
 
-    private static int HostedServiceIndex<THostedService>(IServiceCollection services)
+    private static IEnumerable<ServiceDescriptor> HostedServiceDescriptors<THostedService>(IServiceCollection services)
         where THostedService : IHostedService
-        => HostedServiceIndex(services, typeof(THostedService).Name);
-
-    private static int HostedServiceIndex(IServiceCollection services, string implementationTypeName)
-    {
-        var index = services
-            .Select((descriptor, position) => new
-            {
-                descriptor,
-                position,
-            })
-            .Where(x => x.descriptor.ServiceType == typeof(IHostedService))
-            .Single(x => string.Equals(
-                x.descriptor.ImplementationType?.Name,
-                implementationTypeName,
-                StringComparison.Ordinal))
-            .position;
-        return index;
-    }
+        => services.Where(descriptor =>
+            descriptor.ServiceType == typeof(IHostedService) &&
+            descriptor.ImplementationType == typeof(THostedService));
 
     private sealed class BrokenMainnetService(MissingMainnetDependency dependency)
     {


### PR DESCRIPTION
## Phase 9 r2 consensus(3/3 unanimous)

framing:`hybrid-minimal-structural-delete:delete-ordering-invariant-test-di-doc-runbook-wording-no-startasync-change`

### 改动

- 删除 `RetiredActorCleanupHostedServiceTests` 中 ordering-invariant assertion
- 改 `2026-04-28-retired-actor-startup-cleanup-runbook.md` wording 为 "best-effort restart-idempotent,not a cross-pod completion barrier"
- **不**改 `RetiredActorCleanupHostedService.cs` 代码(由 #1293/#1287 处理,cross-cluster discipline)

closes #1290

🤖 Auto-loop

⟦AI:AUTO-LOOP⟧