### PR TITLE
Improve team startup journey

### DIFF
--- a/apps/aevatar-console-web/src/pages/runs/components/RunsLaunchRail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/runs/components/RunsLaunchRail.test.tsx
@@ -52,6 +52,7 @@ describe("RunsLaunchRail", () => {
         onEndpointChange={jest.fn()}
         onEndpointKindChange={jest.fn()}
         onSelectRouteName={jest.fn()}
+        onScopeIdChange={jest.fn()}
         onSubmitRun={async () => {}}
         onTransportChange={jest.fn()}
         onUsePreset={onUsePreset}
@@ -110,6 +111,7 @@ describe("RunsLaunchRail", () => {
         onEndpointChange={jest.fn()}
         onEndpointKindChange={jest.fn()}
         onSelectRouteName={jest.fn()}
+        onScopeIdChange={jest.fn()}
         onSubmitRun={async () => {}}
         onTransportChange={jest.fn()}
         onUsePreset={jest.fn()}

--- a/apps/aevatar-console-web/src/pages/runs/components/RunsLaunchRail.tsx
+++ b/apps/aevatar-console-web/src/pages/runs/components/RunsLaunchRail.tsx
@@ -52,6 +52,7 @@ type RunsLaunchRailProps = {
   onEndpointChange: (value: string) => void;
   onEndpointKindChange: (value: RunEndpointKind) => void;
   onSelectRouteName: (value: string) => void;
+  onScopeIdChange: (value: string) => void;
   onSubmitRun: (values: RunFormValues) => Promise<void>;
   onTransportChange: (value: RunTransport) => void;
   onUsePreset: (preset: RunPreset) => void;
@@ -388,6 +389,7 @@ const RunsLaunchRail: React.FC<RunsLaunchRailProps> = ({
   onEndpointChange,
   onEndpointKindChange,
   onSelectRouteName,
+  onScopeIdChange,
   onSubmitRun,
   onTransportChange,
   onUsePreset,
@@ -397,7 +399,7 @@ const RunsLaunchRail: React.FC<RunsLaunchRailProps> = ({
 
   return (
     <ProCard
-      title={isChatVariant ? "Setup" : "Run setup"}
+      title={isChatVariant ? "Run context" : "Run setup"}
       hoverable
       {...moduleCardProps}
       style={workbenchCardStyle}
@@ -444,7 +446,7 @@ const RunsLaunchRail: React.FC<RunsLaunchRailProps> = ({
           items={[
             {
               key: "compose",
-              label: "Compose",
+              label: isChatVariant ? "Context" : "Compose",
               children: (
                 <div style={compactStackStyle}>
                   {renderRouteMiniCard(
@@ -487,6 +489,13 @@ const RunsLaunchRail: React.FC<RunsLaunchRailProps> = ({
                         values.transport
                       ) {
                         onTransportChange(values.transport);
+                      }
+                      if ("scopeId" in changedValues) {
+                        onScopeIdChange(
+                          typeof values.scopeId === "string"
+                            ? values.scopeId
+                            : "",
+                        );
                       }
                     }}
                     onFinish={async (values) => {

--- a/apps/aevatar-console-web/src/pages/runs/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/runs/index.test.tsx
@@ -233,7 +233,11 @@ jest.mock("./components/RunsLaunchRail", () => {
     return React.createElement(
       "section",
       null,
-      React.createElement("div", null, "Run setup"),
+      React.createElement(
+        "div",
+        null,
+        props.variant === "chat" ? "Run context" : "Run setup"
+      ),
       props.showPromptField !== false
         ? React.createElement("textarea", {
             "aria-label": "Prompt",
@@ -248,11 +252,13 @@ jest.mock("./components/RunsLaunchRail", () => {
         : null,
       React.createElement("input", {
         "aria-label": "Workspace ID",
-        onChange: (event: any) =>
+        onChange: (event: any) => {
+          props.onScopeIdChange?.(event.target.value);
           setValues((current: Record<string, unknown>) => ({
             ...current,
             scopeId: event.target.value,
-          })),
+          }));
+        },
         value: values.scopeId ?? "",
       }),
       props.showSubmitActions !== false
@@ -345,20 +351,67 @@ describe("RunsPage", () => {
       screen.queryByRole("button", { name: "返回团队高级编辑" })
     ).toBeNull();
     expect(
-      screen.getByRole("button", { name: "Actor explorer" })
-    ).toBeTruthy();
+      screen.queryByRole("button", { name: "Actor explorer" })
+    ).toBeNull();
     expect(
-      screen.getByRole("button", { name: "Mission Control" })
-    ).toBeDisabled();
+      screen.queryByRole("button", { name: "Mission Control" })
+    ).toBeNull();
     expect(
       screen.queryByRole("button", { name: "Open observability hub" })
     ).toBeNull();
     expect(
       screen.getByPlaceholderText("Describe the task to run.")
     ).toBeTruthy();
-    expect(container.textContent).toContain("Run setup");
+    expect(container.textContent).toContain("Run context");
     expect(container.textContent).toContain("Conversation");
+    expect(container.textContent).toContain("Workspace: required");
+    expect(container.textContent).toContain("Route: direct");
+    expect(container.textContent).toContain("Endpoint: chat");
+    expect(container.textContent).toContain(
+      "Add a workspace ID in Run context before sending."
+    );
+    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
     expect(screen.queryByRole("button", { name: "Details" })).toBeNull();
+  });
+
+  it("enables the conversation composer only after a workspace is set", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/runtime/runs?prompt=Run%20it"
+    );
+
+    const { container } = renderWithQueryClient(React.createElement(RunsPage));
+
+    await screen.findByDisplayValue("Run it");
+    expect(container.textContent).toContain("Workspace: required");
+    const sendButton = screen.getByRole("button", { name: "Send" });
+    expect(sendButton).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Workspace ID"), {
+      target: { value: "scope-1" },
+    });
+
+    expect(container.textContent).toContain("Workspace: scope-1");
+    expect(container.textContent).not.toContain(
+      "Add a workspace ID in Run context before sending."
+    );
+    expect(sendButton).toBeEnabled();
+
+    fireEvent.click(sendButton);
+
+    await waitFor(() => {
+      expect(mockedRuntimeRunsApi.streamChat).toHaveBeenCalledWith(
+        "scope-1",
+        expect.objectContaining({
+          prompt: "Run it",
+        }),
+        expect.any(AbortSignal),
+        {
+          serviceId: "direct",
+        }
+      );
+    });
   });
 
   it("stacks the chat setup and conversation panes on compact screens", async () => {

--- a/apps/aevatar-console-web/src/pages/runs/index.tsx
+++ b/apps/aevatar-console-web/src/pages/runs/index.tsx
@@ -349,6 +349,36 @@ const runsChatComposerHintStyle: React.CSSProperties = {
   fontSize: 12,
 };
 
+const runsChatComposerContextStyle: React.CSSProperties = {
+  alignItems: "center",
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 6,
+  justifyContent: "flex-end",
+};
+
+const runsChatComposerContextTagStyle: React.CSSProperties = {
+  background: "rgba(255, 255, 255, 0.78)",
+  border: "1px solid rgba(148, 163, 184, 0.22)",
+  borderRadius: 999,
+  color: "var(--ant-color-text-secondary)",
+  fontSize: 12,
+  fontWeight: 600,
+  lineHeight: "18px",
+  maxWidth: 240,
+  overflow: "hidden",
+  padding: "3px 8px",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+const runsChatComposerWarningStyle: React.CSSProperties = {
+  color: "var(--ant-color-warning-text)",
+  fontSize: 12,
+  lineHeight: "18px",
+  textAlign: "right",
+};
+
 const runsChatComposerSendButtonStyle: React.CSSProperties = {
   borderRadius: 14,
   boxShadow: "0 12px 24px rgba(22, 119, 255, 0.2)",
@@ -680,6 +710,12 @@ const RunsPage: React.FC = () => {
   const handleEndpointChange = useCallback((value: string) => {
     const normalizedValue = value.trim();
     setActiveEndpointId((currentValue) =>
+      currentValue === normalizedValue ? currentValue : normalizedValue
+    );
+  }, []);
+  const handleScopeIdChange = useCallback((value: string) => {
+    const normalizedValue = value.trim();
+    setActiveScopeId((currentValue) =>
       currentValue === normalizedValue ? currentValue : normalizedValue
     );
   }, []);
@@ -1217,6 +1253,7 @@ const RunsPage: React.FC = () => {
   const actorId = session.context?.actorId;
   const commandId = session.context?.commandId ?? "";
   const canOpenMissionControl = Boolean(activeScopeId.trim() && session.runId);
+  const hasRunInspectorTarget = Boolean(actorId || session.runId);
   const handleOpenMissionControl = useCallback(() => {
     const runId = session.runId?.trim();
     const scopeId = activeScopeId.trim();
@@ -1909,6 +1946,11 @@ const RunsPage: React.FC = () => {
         : "/api/scopes/{scopeId}/invoke/{endpointId}";
 
   const isChatConsole = endpointKind === "chat";
+  const composerScopeId = resolveRunScopeId();
+  const composerRouteLabel =
+    routeName || (scopeDraftPayload ? scopeDraftPayload.bundleName : "Workspace default");
+  const composerEndpointLabel = endpointName || "chat";
+  const composerReady = Boolean(composerScopeId.trim());
 
   const handleSubmitResume = useCallback(
     async (values: ResumeFormValues) => {
@@ -2085,6 +2127,7 @@ const RunsPage: React.FC = () => {
       onEndpointChange={handleEndpointChange}
       onEndpointKindChange={handleEndpointKindChange}
       onSelectRouteName={handleRouteSelection}
+      onScopeIdChange={handleScopeIdChange}
       onSubmitRun={async (values) => {
         await sendRun(values.scopeId ?? "", values);
       }}
@@ -2174,31 +2217,33 @@ const RunsPage: React.FC = () => {
             >
               Workflow catalog
             </Button>
-            <Button
-              className={runsWorkbenchHeaderButtonClassName}
-              disabled={!actorId && !session.runId}
-              icon={<DeploymentUnitOutlined />}
-              onClick={() =>
-                history.push(
-                  buildRuntimeExplorerHref({
-                    actorId: actorId ?? undefined,
-                    runId: session.runId || undefined,
-                    scopeId: activeScopeId || undefined,
-                    serviceOverrideId: activeServiceOverrideId || undefined,
-                  })
-                )
-              }
-            >
-              Actor explorer
-            </Button>
-            <Button
-              className={`${runsWorkbenchHeaderButtonClassName} ${runsWorkbenchHeaderButtonAccentClassName}`}
-              disabled={!canOpenMissionControl}
-              icon={<ControlOutlined />}
-              onClick={handleOpenMissionControl}
-            >
-              Mission Control
-            </Button>
+            {hasRunInspectorTarget ? (
+              <Button
+                className={runsWorkbenchHeaderButtonClassName}
+                icon={<DeploymentUnitOutlined />}
+                onClick={() =>
+                  history.push(
+                    buildRuntimeExplorerHref({
+                      actorId: actorId ?? undefined,
+                      runId: session.runId || undefined,
+                      scopeId: activeScopeId || undefined,
+                      serviceOverrideId: activeServiceOverrideId || undefined,
+                    })
+                  )
+                }
+              >
+                Actor explorer
+              </Button>
+            ) : null}
+            {canOpenMissionControl ? (
+              <Button
+                className={`${runsWorkbenchHeaderButtonClassName} ${runsWorkbenchHeaderButtonAccentClassName}`}
+                icon={<ControlOutlined />}
+                onClick={handleOpenMissionControl}
+              >
+                Mission Control
+              </Button>
+            ) : null}
           </div>
         </div>
         {isChatConsole ? (
@@ -2256,10 +2301,26 @@ const RunsPage: React.FC = () => {
                 <style>{runsChatComposerCss}</style>
                 <div style={runsChatComposerHeaderStyle}>
                   <div style={runsChatComposerLabelStyle}>Prompt</div>
-                  <Typography.Text style={runsChatComposerHintStyle}>
-                    Enter to send
-                  </Typography.Text>
+                  <div style={runsChatComposerContextStyle}>
+                    <span style={runsChatComposerContextTagStyle}>
+                      Workspace: {composerScopeId || "required"}
+                    </span>
+                    <span style={runsChatComposerContextTagStyle}>
+                      Route: {composerRouteLabel}
+                    </span>
+                    <span style={runsChatComposerContextTagStyle}>
+                      Endpoint: {composerEndpointLabel}
+                    </span>
+                    <Typography.Text style={runsChatComposerHintStyle}>
+                      Enter to send
+                    </Typography.Text>
+                  </div>
                 </div>
+                {!composerReady ? (
+                  <div style={runsChatComposerWarningStyle}>
+                    Add a workspace ID in Run context before sending.
+                  </div>
+                ) : null}
                 <div className={runsChatComposerBodyClassName}>
                   <div style={runsChatComposerInputWrapStyle}>
                     <div
@@ -2279,7 +2340,9 @@ const RunsPage: React.FC = () => {
                             !event.nativeEvent.isComposing
                           ) {
                             event.preventDefault();
-                            void handleSubmitComposer();
+                            if (composerReady) {
+                              void handleSubmitComposer();
+                            }
                           }
                         }}
                         placeholder="Describe the task to run."
@@ -2293,6 +2356,7 @@ const RunsPage: React.FC = () => {
                     style={runsChatComposerActionsStyle}
                   >
                     <Button
+                      disabled={!composerReady}
                       icon={<SendOutlined />}
                       loading={streaming}
                       onClick={() => void handleSubmitComposer()}

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
@@ -483,7 +483,7 @@ describe('StudioWorkflowBuildPanel', () => {
     expect(screen.getByRole('button', { name: 'Save script' })).toBeDisabled();
   });
 
-  it('offers Add script from the empty Script build state', () => {
+  it('keeps the empty Script build state focused on creating the first script', () => {
     const handleCreateScriptDraft = jest.fn();
 
     render(
@@ -501,6 +501,22 @@ describe('StudioWorkflowBuildPanel', () => {
         onSelectScriptId={jest.fn()}
       />,
     );
+
+    expect(
+      screen.getByText(
+        'Create or select a script first. Validation, save, bind, and dry-run unlock after there is a script to work on.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Create a script capability or select a saved workspace script. After that, this panel will show validation, save, bind, and dry-run controls.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Create a script before running it')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Validate' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save script' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Run' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Load fixture' })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Add script' }));
     expect(handleCreateScriptDraft).toHaveBeenCalled();

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
@@ -2654,7 +2654,9 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
           <div style={{ display: 'grid', gap: 4 }}>
             <div style={sectionEyebrowStyle}>Script Source</div>
             <div style={sectionDescriptionStyle}>
-              Script mode 只做一件事：围绕当前 script draft 的 typed source、lints 和 dry-run 迭代实现。
+              {hasActiveScript
+                ? 'Script mode 只做一件事：围绕当前 script draft 的 typed source、lints 和 dry-run 迭代实现。'
+                : 'Create or select a script first. Validation, save, bind, and dry-run unlock after there is a script to work on.'}
             </div>
           </div>
           <div style={{ alignItems: 'center', display: 'flex', gap: 8, justifyContent: 'space-between' }}>
@@ -2702,25 +2704,27 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
                 ]}
               />
             </Space>
-            <Space wrap size={[8, 8]}>
-              <Button
-                className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
-                disabled={!activeScript?.script?.scriptId || validationPending}
-                loading={validationPending}
-                onClick={() => void handleValidate()}
-              >
-                Validate
-              </Button>
-              <Button
-                className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
-                disabled={saveDisabled}
-                icon={<CheckCircleOutlined />}
-                loading={savePending}
-                onClick={() => void handleSave()}
-              >
-                Save script
-              </Button>
-            </Space>
+            {hasActiveScript ? (
+              <Space wrap size={[8, 8]}>
+                <Button
+                  className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
+                  disabled={validationPending}
+                  loading={validationPending}
+                  onClick={() => void handleValidate()}
+                >
+                  Validate
+                </Button>
+                <Button
+                  className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
+                  disabled={saveDisabled}
+                  icon={<CheckCircleOutlined />}
+                  loading={savePending}
+                  onClick={() => void handleSave()}
+                >
+                  Save script
+                </Button>
+              </Space>
+            ) : null}
           </div>
           {saveNotice ? (
             <Alert
@@ -3005,7 +3009,7 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
             </div>
           ) : (
             <Empty
-              description="Create a Script draft or select a saved workspace script to start editing."
+              description="Create a script capability or select a saved workspace script. After that, this panel will show validation, save, bind, and dry-run controls."
             >
               <Button
                 className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
@@ -3018,21 +3022,37 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
           )}
         </section>
 
-        <div style={{ alignItems: 'center', display: 'flex', gap: 12, justifyContent: 'space-between' }}>
-          <Typography.Text type="secondary">
-            {scriptReadyToBind
-              ? 'Script revision is catalog-applied. Continue to Bind to publish the callable member contract.'
-              : `Script Build keeps code editing here. ${bindReadinessLabel}.`}
-          </Typography.Text>
-          <Button
-            className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
-            disabled={!scriptReadyToBind}
-            type="primary"
-            onClick={onContinueToBind}
+        {hasActiveScript ? (
+          <div style={{ alignItems: 'center', display: 'flex', gap: 12, justifyContent: 'space-between' }}>
+            <Typography.Text type="secondary">
+              {scriptReadyToBind
+                ? 'Script revision is catalog-applied. Continue to Bind to publish the callable member contract.'
+                : `Script Build keeps code editing here. ${bindReadinessLabel}.`}
+            </Typography.Text>
+            <Button
+              className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
+              disabled={!scriptReadyToBind}
+              type="primary"
+              onClick={onContinueToBind}
+            >
+              Continue to Bind
+            </Button>
+          </div>
+        ) : (
+          <div
+            style={{
+              background: '#fffdf8',
+              border: '1px solid #efe7da',
+              borderRadius: 16,
+              color: '#667085',
+              fontSize: 13,
+              lineHeight: '20px',
+              padding: '12px 14px',
+            }}
           >
-            Continue to Bind
-          </Button>
-        </div>
+            Start with Add script or select an existing script. Bind becomes available only after a saved catalog revision exists.
+          </div>
+        )}
 
         <ScriptLeaveDialog
           open={leaveDialogOpen}
@@ -3042,91 +3062,103 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
       </div>
 
       <aside style={dryRunAsideStyle}>
-        <div style={{ alignItems: 'center', display: 'flex', gap: 8, justifyContent: 'space-between' }}>
-          <div style={{ display: 'grid', gap: 4 }}>
-            <div style={sectionEyebrowStyle}>Dry-run</div>
-            <Typography.Text strong>Script draft run</Typography.Text>
-          </div>
-          <span style={{ ...statusTagStyle, background: '#fffbe6', color: '#ad6800' }}>
-            seeded fixture
-          </span>
-        </div>
-        <div style={sectionDescriptionStyle}>
-          Draft-run 会直接调用当前 source editor 里的脚本，不需要先把 scope 默认服务切到这个 script。
-        </div>
-        <Input.TextArea
-          aria-label="Script dry run input"
-          autoSize={{ minRows: 6, maxRows: 10 }}
-          disabled={!hasActiveScript}
-          value={runInput}
-          onChange={(event) => setRunInput(event.target.value)}
-        />
-        <Space wrap size={[8, 8]}>
-          <Button
-            className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
-            icon={<PlayCircleOutlined />}
-            disabled={!hasActiveScript}
-            loading={runPending}
-            type="primary"
-            onClick={() => void handleRun()}
-          >
-            Run
-          </Button>
-          <Button
-            className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
-            onClick={() =>
-              setRunInput(
-                JSON.stringify(
-                  {
-                    channel: 'telegram',
-                    text: 'refund for order #92817 — 3rd time asking',
-                    user: 'alex',
-                  },
-                  null,
-                  2,
-                ),
-              )
-            }
-          >
-            Load fixture
-          </Button>
-        </Space>
-        <div>
-          {lastRunResult ? (
-            <div
-              aria-label="Script dry run facts"
-              style={{
-                border: '1px solid #efe7da',
-                borderRadius: 14,
-                display: 'grid',
-                gap: 6,
-                marginBottom: 12,
-                padding: 12,
-              }}
-            >
-              <div style={sectionEyebrowStyle}>Run facts</div>
-              {[
-                ['Run', lastRunResult.runId],
-                ['Runtime', lastRunResult.runtimeActorId],
-                ['Definition', lastRunResult.definitionActorId],
-                ['Command type', lastRunResult.commandTypeUrl],
-                ['Source hash', lastRunResult.sourceHash],
-                ['Activity', lastRunResult.activityUrl],
-              ].map(([label, value]) => (
-                <div key={label} style={{ display: 'grid', gap: 2 }}>
-                  <span style={{ color: '#8b7b63', fontSize: 11, fontWeight: 700 }}>
-                    {label}
-                  </span>
-                  <Typography.Text copyable={Boolean(value)} ellipsis style={{ fontSize: 12 }}>
-                    {value || '-'}
-                  </Typography.Text>
-                </div>
-              ))}
+        {hasActiveScript ? (
+          <>
+            <div style={{ alignItems: 'center', display: 'flex', gap: 8, justifyContent: 'space-between' }}>
+              <div style={{ display: 'grid', gap: 4 }}>
+                <div style={sectionEyebrowStyle}>Dry-run</div>
+                <Typography.Text strong>Script draft run</Typography.Text>
+              </div>
+              <span style={{ ...statusTagStyle, background: '#fffbe6', color: '#ad6800' }}>
+                seeded fixture
+              </span>
             </div>
-          ) : null}
-          <div style={sectionEyebrowStyle}>Output</div>
-          <pre style={dryRunOutputStyle}>{runOutput}</pre>
-        </div>
+            <div style={sectionDescriptionStyle}>
+              Draft-run 会直接调用当前 source editor 里的脚本，不需要先把 scope 默认服务切到这个 script。
+            </div>
+            <Input.TextArea
+              aria-label="Script dry run input"
+              autoSize={{ minRows: 6, maxRows: 10 }}
+              value={runInput}
+              onChange={(event) => setRunInput(event.target.value)}
+            />
+            <Space wrap size={[8, 8]}>
+              <Button
+                className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
+                icon={<PlayCircleOutlined />}
+                loading={runPending}
+                type="primary"
+                onClick={() => void handleRun()}
+              >
+                Run
+              </Button>
+              <Button
+                className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
+                onClick={() =>
+                  setRunInput(
+                    JSON.stringify(
+                      {
+                        channel: 'telegram',
+                        text: 'refund for order #92817 — 3rd time asking',
+                        user: 'alex',
+                      },
+                      null,
+                      2,
+                    ),
+                  )
+                }
+              >
+                Load fixture
+              </Button>
+            </Space>
+            <div>
+              {lastRunResult ? (
+                <div
+                  aria-label="Script dry run facts"
+                  style={{
+                    border: '1px solid #efe7da',
+                    borderRadius: 14,
+                    display: 'grid',
+                    gap: 6,
+                    marginBottom: 12,
+                    padding: 12,
+                  }}
+                >
+                  <div style={sectionEyebrowStyle}>Run facts</div>
+                  {[
+                    ['Run', lastRunResult.runId],
+                    ['Runtime', lastRunResult.runtimeActorId],
+                    ['Definition', lastRunResult.definitionActorId],
+                    ['Command type', lastRunResult.commandTypeUrl],
+                    ['Source hash', lastRunResult.sourceHash],
+                    ['Activity', lastRunResult.activityUrl],
+                  ].map(([label, value]) => (
+                    <div key={label} style={{ display: 'grid', gap: 2 }}>
+                      <span style={{ color: '#8b7b63', fontSize: 11, fontWeight: 700 }}>
+                        {label}
+                      </span>
+                      <Typography.Text copyable={Boolean(value)} ellipsis style={{ fontSize: 12 }}>
+                        {value || '-'}
+                      </Typography.Text>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+              <div style={sectionEyebrowStyle}>Output</div>
+              <pre style={dryRunOutputStyle}>{runOutput}</pre>
+            </div>
+          </>
+        ) : (
+          <div style={{ display: 'grid', gap: 12 }}>
+            <div style={{ display: 'grid', gap: 4 }}>
+              <div style={sectionEyebrowStyle}>Dry-run</div>
+              <Typography.Text strong>Create a script before running it</Typography.Text>
+            </div>
+            <Typography.Text type="secondary">
+              The run input, fixture loader, and output stream appear after a script draft or saved script is selected.
+            </Typography.Text>
+          </div>
+        )}
         {hasActiveScript ? (
           <details
             aria-label="Script promotion history"

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -5669,8 +5669,8 @@ describe("StudioPage", () => {
     expect(await screen.findByTestId("studio-bind-surface")).toBeTruthy();
     await waitFor(() => {
       expect(screen.getByText("candidate:draft1")).toBeTruthy();
-      expect(screen.getByText("service:no-service")).toBeTruthy();
     });
+    expect(screen.queryByText("service:draft2")).toBeNull();
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Bind current member" }));

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -874,7 +874,7 @@ describe("TeamDetailPage", () => {
     expect(screen.getByRole("link", { name: "Teams" })).toBeTruthy();
     expect(screen.getByText("scopeId")).toBeTruthy();
     expect(screen.getByText("scope-1")).toBeTruthy();
-    const currentPostureHeading = screen.getByText("当前态势");
+    const currentPostureHeading = screen.getByText("启动状态");
     const compositionHeading = screen.getByText("团队构成");
     const configurationHeading = screen.getByText("配置明细");
     expect(screen.getByRole("button", { name: "测试团队" })).toBeTruthy();
@@ -918,7 +918,7 @@ describe("TeamDetailPage", () => {
 
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    expect(await screen.findByText("当前态势")).toBeTruthy();
+    expect(await screen.findByText("启动状态")).toBeTruthy();
     expect(screen.getByText("团队构成")).toBeTruthy();
     expect(screen.getByText("配置明细")).toBeTruthy();
     expect(screen.queryByText("信任态势")).toBeNull();
@@ -937,7 +937,7 @@ describe("TeamDetailPage", () => {
 
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    expect(await screen.findByText("当前态势")).toBeTruthy();
+    expect(await screen.findByText("启动状态")).toBeTruthy();
     expect(screen.queryByText("No successful baseline is available yet.")).toBeNull();
     expect(screen.queryByText("Comparing run run-current against baseline run-good.")).toBeNull();
     expect(scopeRuntimeApi.getServiceRunAudit).not.toHaveBeenCalled();
@@ -1102,7 +1102,7 @@ describe("TeamDetailPage", () => {
 
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    expect(await screen.findByText("当前态势")).toBeTruthy();
+    expect(await screen.findByText("启动状态")).toBeTruthy();
     expect(screen.queryByText("当前任务事件流")).toBeNull();
 
     await waitFor(() => {
@@ -1177,6 +1177,30 @@ describe("TeamDetailPage", () => {
     expect(await screen.findByText("当前成员")).toBeTruthy();
     expect(screen.getAllByText("member-team-alpha").length).toBeGreaterThan(0);
     expect(screen.getByText("memberId · member-team-alpha")).toBeTruthy();
+  });
+
+  it("guides the user to test the Team when no run is visible yet", async () => {
+    (scopeRuntimeApi.listMemberRuns as jest.Mock).mockResolvedValueOnce({
+      ...mockCreateRunsCatalog(),
+      runs: [],
+    });
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1/t-alpha?memberId=member-team-alpha",
+    );
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    expect(await screen.findByText("启动状态")).toBeTruthy();
+    expect(screen.getAllByText("等待首次测试").length).toBeGreaterThan(0);
+    expect(screen.getByText("下一步 · 测试团队")).toBeTruthy();
+    expect(
+      screen.getByText("团队入口已就绪，但还没有可见运行。点击“测试团队”生成第一条运行。"),
+    ).toBeTruthy();
+    expect(screen.getByText("测试团队后会在这里显示最新运行。")).toBeTruthy();
+    expect(screen.queryByText("暂无可见运行")).toBeNull();
+    expect(screen.queryByText("暂无近期可见运行")).toBeNull();
   });
 
   it("shows the configured Team entry member without treating it as the service target", async () => {
@@ -1646,7 +1670,7 @@ describe("TeamDetailPage", () => {
     expect((await screen.findAllByText("Team summary")).length).toBeGreaterThan(0);
     expect(screen.getAllByText("3 个成员").length).toBeGreaterThan(0);
     expect(screen.getAllByText("来自 Team 更新时间").length).toBeGreaterThan(0);
-    expect(screen.getByText("当前态势")).toBeTruthy();
+    expect(screen.getByText("启动状态")).toBeTruthy();
     expect(screen.getByText("团队构成")).toBeTruthy();
     expect(screen.getByText("配置明细")).toBeTruthy();
     expect(screen.queryByText("Team 更新时间")).toBeNull();
@@ -1789,7 +1813,7 @@ describe("TeamDetailPage", () => {
 
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    expect(await screen.findByText("当前态势")).toBeTruthy();
+    expect(await screen.findByText("启动状态")).toBeTruthy();
     expect(await screen.findByText("团队构成")).toBeTruthy();
     expect(await screen.findByText("配置明细")).toBeTruthy();
     expect(screen.queryByText("Team summary 暂不可用")).toBeNull();

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -808,6 +808,7 @@ const TeamDetailPage: React.FC = () => {
     lens.currentRun?.runId ||
     focusedOperationalUnit?.latestRun?.runId ||
     "";
+  const hasVisibleRun = Boolean(activeRunId);
   const currentRevisionId = trimText(lens.activeRevision?.revisionId) || "--";
   const currentRevisionStatus =
     trimText(lens.activeRevision?.servingState) ||
@@ -817,9 +818,6 @@ const TeamDetailPage: React.FC = () => {
     trimText(lens.currentService?.deploymentStatus) ||
     trimText(lens.activeRevision?.status) ||
     "--";
-  const currentHeaderStatus =
-    trimText(lens.currentRun?.completionStatus) || currentDeploymentStatus;
-  const currentHeaderStatusFriendly = formatFriendlyStatus(currentHeaderStatus);
   const currentRevisionFriendly = formatFriendlyStatus(currentRevisionStatus);
   const currentDeploymentFriendly = formatFriendlyStatus(currentDeploymentStatus);
   const currentServiceKey =
@@ -829,9 +827,9 @@ const TeamDetailPage: React.FC = () => {
   const currentServiceDisplayName =
     trimText(lens.currentService?.displayName) || "--";
   const currentRunStatus = trimText(lens.currentRun?.completionStatus) || "--";
-  const currentRunFriendly = activeRunId
+  const currentRunFriendly = hasVisibleRun
     ? formatFriendlyStatus(currentRunStatus)
-    : "暂无可见运行";
+    : "等待首次测试";
   const currentMemberLabel =
     trimText(preferredMemberSummary?.displayName) ||
     teamRosterRows.find((row) => row.memberId === currentMemberId)?.name ||
@@ -847,6 +845,22 @@ const TeamDetailPage: React.FC = () => {
     currentServiceDisplayName !== "--"
       ? currentServiceDisplayName
       : runtimeServiceId || "--";
+  const hasRunnableTeamEntry =
+    Boolean(entryMemberId) ||
+    Boolean(currentMemberId) ||
+    currentServiceFriendly !== "--" ||
+    currentServiceKey !== "--" ||
+    Boolean(runtimeServiceId);
+  const currentHeaderStatus = hasVisibleRun
+    ? currentRunStatus
+    : hasRunnableTeamEntry
+      ? "waiting"
+      : currentDeploymentStatus;
+  const currentHeaderStatusFriendly = hasVisibleRun
+    ? formatFriendlyStatus(currentRunStatus)
+    : hasRunnableTeamEntry
+      ? "等待首次测试"
+      : formatFriendlyStatus(currentDeploymentStatus);
   const currentVersionFriendly =
     currentRevisionFriendly !== "--"
       ? currentRevisionFriendly
@@ -859,9 +873,9 @@ const TeamDetailPage: React.FC = () => {
     currentVersionFriendly !== "--"
       ? `版本 · ${currentVersionFriendly}`
       : "版本待确认";
-  const currentRunPillText = activeRunId
+  const currentRunPillText = hasVisibleRun
     ? `运行 · ${currentRunFriendly}`
-    : "暂无近期可见运行";
+    : "下一步 · 测试团队";
   const currentServiceCardCaption = runtimeServiceId
     ? `serviceId · ${compactOptionalId(runtimeServiceId)}`
     : currentServiceKey !== "--" && currentServiceKey !== currentServiceFriendly
@@ -872,12 +886,17 @@ const TeamDetailPage: React.FC = () => {
     : currentServiceKey !== "--" && currentServiceKey !== currentServiceFriendly
       ? `serviceKey · ${currentServiceKey}`
       : "当前还没有更多服务标识";
-  const currentRunCardCaption = activeRunId
+  const currentRunCardCaption = hasVisibleRun
     ? `runId · ${compactId(activeRunId)}`
-    : "当前还没有同步到可见运行";
-  const currentRunCardTooltip = activeRunId
+    : "测试团队后会在这里显示最新运行。";
+  const currentRunCardTooltip = hasVisibleRun
     ? `runId · ${activeRunId}`
-    : "当前还没有同步到可见运行";
+    : "测试团队后会在这里显示最新运行。";
+  const teamStartupGuidance = hasVisibleRun
+    ? "最近运行已可见，可继续测试团队或调整成员配置。"
+    : hasRunnableTeamEntry
+      ? "团队入口已就绪，但还没有可见运行。点击“测试团队”生成第一条运行。"
+      : "还没有可用入口。先配置入口成员和服务，再测试团队。";
   const workflowNameValue =
     trimText(activeWorkflowSummary?.workflowName) ||
     trimText(lens.activeRevision?.workflowName) ||
@@ -947,7 +966,7 @@ const TeamDetailPage: React.FC = () => {
         key: "fallback-actor",
         kind: "actor",
         name: "当前执行",
-        summary: activeRunId ? currentRunFriendly : "暂无最近运行",
+        summary: hasVisibleRun ? currentRunFriendly : "测试团队后会显示最近运行",
       },
       {
         key: "fallback-service",
@@ -958,10 +977,10 @@ const TeamDetailPage: React.FC = () => {
     ];
   }, [
     activeWorkflowId,
-    activeRunId,
     currentRunFriendly,
     currentServiceFriendly,
     hasExplicitRuntimeFocus,
+    hasVisibleRun,
     teamRosterRows,
     workflowNameValue,
   ]);
@@ -1404,7 +1423,7 @@ const TeamDetailPage: React.FC = () => {
         currentRunCardCaption={currentRunCardCaption}
         currentRunCardTooltip={currentRunCardTooltip}
         currentRunFriendly={currentRunFriendly}
-        currentRunPillStyle={resolveStatusPillStyle(token, currentRunStatus)}
+        currentRunPillStyle={resolveStatusPillStyle(token, currentHeaderStatus)}
         currentRunPillText={currentRunPillText}
         currentServiceCardCaption={currentServiceCardCaption}
         currentServiceCardTooltip={currentServiceCardTooltip}
@@ -1425,6 +1444,7 @@ const TeamDetailPage: React.FC = () => {
             ? () => void handleClearEntry()
             : undefined
         }
+        startupGuidance={teamStartupGuidance}
       />
     );
   };

--- a/apps/aevatar-console-web/src/pages/teams/home.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.test.tsx
@@ -157,13 +157,13 @@ describe("TeamsHomePage", () => {
   it("renders the team homepage around real Team roster with member runtime hints", async () => {
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
-    expect(await screen.findByRole("button", { name: "查看团队" })).toBeTruthy();
+    expect(await screen.findByRole("button", { name: "测试或配置团队" })).toBeTruthy();
     expect(screen.getByText("Aevatar / Teams")).toBeTruthy();
     expect(screen.getByText("我的 AI 团队")).toBeTruthy();
     expect(screen.queryByText("当前工作空间")).toBeNull();
     expect(screen.getByText("AI Team 总数")).toBeTruthy();
-    expect(screen.getByText("待处理 Team")).toBeTruthy();
-    expect(screen.getByText("运行稳定")).toBeTruthy();
+    expect(screen.getByText("待启动 Team")).toBeTruthy();
+    expect(screen.getByText("已有稳定运行")).toBeTruthy();
     expect(screen.getByText("团队列表")).toBeTruthy();
     expect(
       screen.getByText("按 Team 聚合成员与最近运行信号，优先处理异常或待关注项。"),
@@ -172,7 +172,7 @@ describe("TeamsHomePage", () => {
     expect(screen.queryByText("需要处理")).toBeNull();
     expect(screen.getByRole("button", { name: "组建新团队" })).toBeTruthy();
     expect(screen.getByRole("heading", { level: 3, name: "客服团队" })).toBeTruthy();
-    expect(screen.getByText("Team 标识：t-support")).toBeTruthy();
+    expect(screen.getByText("ID：t-support")).toBeTruthy();
     expect(screen.getByText("客服运行时")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "切换到列表视图" })).toBeNull();
     expect(screen.queryByRole("button", { name: "更多" })).toBeNull();
@@ -181,7 +181,7 @@ describe("TeamsHomePage", () => {
   it("keeps team card actions focused on the Team detail page", async () => {
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
-    await screen.findByRole("button", { name: "查看团队" });
+    await screen.findByRole("button", { name: "测试或配置团队" });
     expect(screen.queryByRole("button", { name: "更多" })).toBeNull();
     expect(screen.queryByText("进入 Studio")).toBeNull();
     expect(screen.queryByText("新增成员")).toBeNull();
@@ -235,7 +235,7 @@ describe("TeamsHomePage", () => {
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
     expect(
-      await screen.findByText("成员已绑定服务，最近还没有运行记录。"),
+      await screen.findByText("成员已绑定服务。下一步：进入团队详情后测试团队，生成第一条可见运行。"),
     ).toBeTruthy();
     await waitFor(() => {
       expect(scopeRuntimeApi.listMemberRuns).toHaveBeenCalledTimes(13);
@@ -324,7 +324,7 @@ describe("TeamsHomePage", () => {
       "title",
       expect.stringContaining("另一个非常长的服务名用于验证 hover 全量展示"),
     );
-    expect(screen.getByText("Team 标识：t-long").closest("[title]")).toHaveAttribute(
+    expect(screen.getByText("ID：t-long").closest("[title]")).toHaveAttribute(
       "title",
       "t-long",
     );
@@ -420,13 +420,13 @@ describe("TeamsHomePage", () => {
     const article = screen
       .getByRole("heading", { level: 4, name: "列表团队 1" })
       .closest("article");
-    expect(article?.firstElementChild?.textContent).toContain("查看团队");
+    expect(article?.firstElementChild?.textContent).toContain("测试或配置团队");
   });
 
   it("opens the bound member detail handoff from the primary action", async () => {
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
-    fireEvent.click(await screen.findByRole("button", { name: "查看团队" }));
+    fireEvent.click(await screen.findByRole("button", { name: "测试或配置团队" }));
 
     await waitFor(() => {
       expect(window.location.pathname).toBe("/teams/scope-a/t-support");
@@ -540,8 +540,8 @@ describe("TeamsHomePage", () => {
 
     expect(await screen.findByRole("heading", { level: 3, name: "客服团队" })).toBeTruthy();
     expect(screen.getByRole("heading", { level: 3, name: "joker" })).toBeTruthy();
-    expect(screen.getByText("Team 标识：t-joker")).toBeTruthy();
-    expect(screen.getAllByRole("button", { name: "查看团队" })).toHaveLength(2);
+    expect(screen.getByText("ID：t-joker")).toBeTruthy();
+    expect(screen.getAllByRole("button", { name: "测试或配置团队" })).toHaveLength(2);
   });
 
   it("hides unassigned members instead of surfacing implementation alerts", async () => {
@@ -569,7 +569,7 @@ describe("TeamsHomePage", () => {
 
     expect(await screen.findByText("团队列表")).toBeTruthy();
     expect(screen.queryByText("存在未归队成员")).toBeNull();
-    expect(screen.getByText("Team 标识：t-support")).toBeTruthy();
+    expect(screen.getByText("ID：t-support")).toBeTruthy();
     expect(screen.queryByRole("heading", { level: 3, name: "未归队成员" })).toBeNull();
   });
 
@@ -622,7 +622,7 @@ describe("TeamsHomePage", () => {
     expect(
       await screen.findByRole("heading", { level: 3, name: "刚创建的团队" }),
     ).toBeTruthy();
-    expect(screen.getByText("Team 标识：t-new")).toBeTruthy();
+    expect(screen.getByText("ID：t-new")).toBeTruthy();
     expect(
       screen.queryByText(
         "当前工作空间还没有创建任何 Team。创建 Team 后，这里会按后端 roster 展示真实团队。",

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -495,7 +495,7 @@ function buildMemberRosterPreview(input: {
     attentionDetail = "最近一次成员运行正常，可继续进入详情查看。";
   } else if (serviceId || matchedService) {
     attention = "no-recent-runs";
-    attentionDetail = "成员已绑定服务，最近还没有运行记录。";
+    attentionDetail = "成员已绑定服务。下一步：进入团队详情后测试团队，生成第一条可见运行。";
   } else if (
     trimOptional(input.member.lastBoundRevisionId) ||
     input.member.lifecycleStage === "bind_ready"
@@ -598,7 +598,7 @@ function buildTeamRosterPreview(input: {
 
   let attention: TeamOperationalAttention =
     mostImportantMemberPreview?.attention ?? "draft";
-  let attentionDetail = "这个 Team 已经存在后端事实，但还没有分配成员。";
+  let attentionDetail = "这个 Team 还没有成员。下一步：添加入口成员后再测试团队。";
   if (input.team.lifecycleStage === "archived") {
     attention = "draft";
     attentionDetail = "这个 Team 已归档，列表中仅保留它的后端 roster 事实。";
@@ -694,10 +694,10 @@ const TeamRosterCard: React.FC<{
         style={{
           color: token.colorTextSecondary,
           display: "block",
-          fontSize: 13,
+          fontSize: 12,
         }}
       >
-        Team 标识：{preview.teamId}
+        ID：{preview.teamId}
       </Typography.Text>
 
       <div
@@ -749,7 +749,7 @@ const TeamRosterCard: React.FC<{
           size="large"
           type="primary"
         >
-          查看团队
+          测试或配置团队
         </Button>
       </Space>
     </article>
@@ -822,17 +822,17 @@ const TeamRosterRow: React.FC<{
             style={{
               color: token.colorTextSecondary,
               display: "block",
-              fontSize: 13,
+              fontSize: 12,
               marginTop: 4,
             }}
           >
-            Team 标识：{preview.teamId}
+            ID：{preview.teamId}
           </Typography.Text>
         </div>
 
         <Space className="teams-home-roster-row-actions" wrap>
           <Button onClick={() => history.push(preview.detailHref)} type="primary">
-            查看团队
+            测试或配置团队
           </Button>
         </Space>
       </div>
@@ -1152,8 +1152,8 @@ const TeamsHomePage: React.FC = () => {
               }}
             >
               <SummaryStatCard accent label="AI Team 总数" value={visibleTeamCount} />
-              <SummaryStatCard label="待处理 Team" value={actionableTeamCount} />
-              <SummaryStatCard label="运行稳定" value={healthyTeamCount} />
+              <SummaryStatCard label="待启动 Team" value={actionableTeamCount} />
+              <SummaryStatCard label="已有稳定运行" value={healthyTeamCount} />
             </div>
 
             {teamsQuery.isLoading ? (

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx
@@ -48,6 +48,7 @@ type TeamOverviewTabProps = {
   readonly latestVisibleUpdateLabel: string;
   readonly latestVisibleUpdateNote: string;
   readonly onClearEntryMember?: () => void;
+  readonly startupGuidance: string;
 };
 
 const surfaceStyle = (
@@ -89,6 +90,7 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
   latestVisibleUpdateLabel,
   latestVisibleUpdateNote,
   onClearEntryMember,
+  startupGuidance,
 }) => {
   const { token } = theme.useToken();
   const hasEntryMember = Boolean(entryMemberId?.trim());
@@ -108,13 +110,16 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
           <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
             <Space wrap size={8}>
               <Typography.Text strong style={{ fontSize: 16 }}>
-                当前态势
+                启动状态
               </Typography.Text>
               <DetailPill
                 style={currentHeaderStatusStyle}
                 text={currentHeaderStatusFriendly}
               />
             </Space>
+            <Typography.Text type="secondary">
+              {startupGuidance}
+            </Typography.Text>
           </div>
           <Space wrap size={[8, 8]}>
             <DetailPill


### PR DESCRIPTION
## Problem

This PR is part of the visible Aevatar AI automation pipeline UI discovery batch. From a user perspective, the Team -> Studio -> Run Console startup path had several first-screen friction points:

- Teams did not clearly explain the next action for teams with no visible run history.
- Studio Scripts exposed disabled script actions in the empty state instead of guiding the user toward creating/selecting a script.
- Run Console showed idle inspector actions and did not make the required workspace context visible near Send.

This intentionally does not handle the broader Chinese/English localization cleanup; that is reserved for a separate PR.

## Solution

- Clarify Teams Home and Team Detail startup states so the next action is visible before the first run.
- Tighten Studio Scripts empty-state UI by hiding unavailable build/run actions until a script exists.
- Make Run Console chat mode conversation-first:
  - rename the chat setup rail to Run context,
  - show Workspace / Route / Endpoint beside the composer,
  - disable Send and Enter-to-send until Workspace is set,
  - hide Actor explorer and Mission Control until a run/actor target exists.

## Impact paths

- `apps/aevatar-console-web/src/pages/teams/*`
- `apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels*`
- `apps/aevatar-console-web/src/pages/runs/*`

No backend/proto/API/actor/projection/workflow/runtime/database/backend tests/backend config/architecture docs were modified.

## Verification

- `git diff --check` -> passed with no output
- `npm exec --yes pnpm@10.2.1 -- --dir apps/aevatar-console-web tsc` -> passed
- `npm exec --yes pnpm@10.2.1 -- --dir apps/aevatar-console-web jest --selectProjects jsdom --runTestsByPath src/pages/runs/index.test.tsx src/pages/runs/components/RunsLaunchRail.test.tsx src/pages/teams/home.test.tsx src/pages/teams/detail.test.tsx src/pages/studio/components/StudioBuildPanels.test.tsx --runInBand` -> passed, 5 suites / 92 tests
- `bash tools/ci/test_stability_guards.sh` -> passed

Known test-environment noise: the focused Jest run still prints existing jsdom console warnings about an invalid NaN height style and undefined mocked actor snapshot query data, but all assertions passed.

## Automation notes

- Base branch: `feat/2026-05-29_ai-automation-pipeline`
- No auto-merge enabled or attempted.
- Local stable skill entry used by the visible supervisor: `/Users/abigaildeng/.codex/skills/codex-refactor-loop/SKILL.md`
