### PR TITLE
#1297 first slice: BuildChatRequest 删除 trusted bag mirrors(no-new-core)

### DIFF
--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -751,7 +751,7 @@ public sealed class AevatarInvocationDispatcher
         string commandId,
         InvocationCallerScope scope)
     {
-        // Refactor (issue1300-first): Old: stamp trusted caller/control to Headers/Metadata. New: typed ScopeId/ToolContext/LlmControl as authority.
+        // Refactor (issue1300-first): Old pattern: stamp trusted caller/control to Headers/Metadata. New principle: typed ScopeId/ToolContext/LlmControl are authority.
         var headers = BuildPayloadHeaders(payload.Headers);
         var request = new ChatRequestEvent
         {
@@ -770,7 +770,7 @@ public sealed class AevatarInvocationDispatcher
     private static Dictionary<string, string> BuildPayloadHeaders(
         Google.Protobuf.Collections.MapField<string, string>? headers)
     {
-        // Refactor (issue1300-first): Old: stamp trusted caller/control to Headers/Metadata. New: typed ScopeId/ToolContext/LlmControl as authority.
+        // Refactor (issue1300-first): Old pattern: stamp trusted caller/control to Headers/Metadata. New principle: typed ScopeId/ToolContext/LlmControl are authority.
         var metadata = new Dictionary<string, string>(StringComparer.Ordinal);
         if (headers == null)
             return metadata;
@@ -859,7 +859,7 @@ public sealed class AevatarInvocationDispatcher
 
     private static AgentToolExecutionContextPayload ToPayload(AgentToolExecutionContext? context)
     {
-        // Refactor (issue1300-first): Old: stamp trusted caller/control to Headers/Metadata. New: typed ScopeId/ToolContext/LlmControl as authority.
+        // Refactor (issue1300-first): Old pattern: stamp trusted caller/control to Headers/Metadata. New principle: typed ScopeId/ToolContext/LlmControl are authority.
         context ??= AgentToolExecutionContext.Empty;
         var payload = new AgentToolExecutionContextPayload
         {
@@ -912,7 +912,7 @@ public sealed class AevatarInvocationDispatcher
 
     private static LLMControlContextPayload ToLlmControlPayload(AgentToolExecutionContext? context)
     {
-        // Refactor (issue1300-first): Old: stamp trusted caller/control to Headers/Metadata. New: typed ScopeId/ToolContext/LlmControl as authority.
+        // Refactor (issue1300-first): Old pattern: stamp trusted caller/control to Headers/Metadata. New principle: typed ScopeId/ToolContext/LlmControl are authority.
         context ??= AgentToolExecutionContext.Empty;
         return new LLMControlContext(
             context.Credentials.NyxIdAccessToken,

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -751,19 +751,38 @@ public sealed class AevatarInvocationDispatcher
         string commandId,
         InvocationCallerScope scope)
     {
-        var metadata = BuildLegacyMetadata(scope, payload.Headers);
+        // Refactor (issue1300-first): Old: stamp trusted caller/control to Headers/Metadata. New: typed ScopeId/ToolContext/LlmControl as authority.
+        var headers = BuildPayloadHeaders(payload.Headers);
         var request = new ChatRequestEvent
         {
             Prompt = payload.Prompt,
             SessionId = commandId,
             ScopeId = scope.ScopeId,
             ToolContext = ToPayload(AgentToolRequestContext.Current),
+            LlmControl = ToLlmControlPayload(AgentToolRequestContext.Current),
         };
-        request.Headers[LLMRequestMetadataKeys.RequestId] = commandId;
-        AppendMetadata(request.Headers, metadata);
-        AppendMetadata(request.Metadata, metadata);
+        AppendMetadata(request.Headers, headers);
+        AppendMetadata(request.Metadata, headers);
         request.InputParts.Add(ToChatInputParts(payload));
         return request;
+    }
+
+    private static Dictionary<string, string> BuildPayloadHeaders(
+        Google.Protobuf.Collections.MapField<string, string>? headers)
+    {
+        // Refactor (issue1300-first): Old: stamp trusted caller/control to Headers/Metadata. New: typed ScopeId/ToolContext/LlmControl as authority.
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (headers == null)
+            return metadata;
+
+        foreach (var (key, value) in headers)
+        {
+            var normalizedKey = Normalize(key);
+            if (normalizedKey != null && !IsProtectedCallerMetadataKey(normalizedKey))
+                metadata[normalizedKey] = value ?? string.Empty;
+        }
+
+        return metadata;
     }
 
     private static Dictionary<string, string> BuildLegacyMetadata(
@@ -840,6 +859,7 @@ public sealed class AevatarInvocationDispatcher
 
     private static AgentToolExecutionContextPayload ToPayload(AgentToolExecutionContext? context)
     {
+        // Refactor (issue1300-first): Old: stamp trusted caller/control to Headers/Metadata. New: typed ScopeId/ToolContext/LlmControl as authority.
         context ??= AgentToolExecutionContext.Empty;
         var payload = new AgentToolExecutionContextPayload
         {
@@ -888,6 +908,20 @@ public sealed class AevatarInvocationDispatcher
         foreach (var (key, value) in context.ExternalMetadata)
             payload.ExternalMetadata[key] = value;
         return payload;
+    }
+
+    private static LLMControlContextPayload ToLlmControlPayload(AgentToolExecutionContext? context)
+    {
+        // Refactor (issue1300-first): Old: stamp trusted caller/control to Headers/Metadata. New: typed ScopeId/ToolContext/LlmControl as authority.
+        context ??= AgentToolExecutionContext.Empty;
+        return new LLMControlContext(
+            context.Credentials.NyxIdAccessToken,
+            context.Credentials.NyxIdOrgToken,
+            context.Credentials.SenderNyxIdAccessToken,
+            context.Routing.ModelOverride,
+            context.Routing.NyxIdRoutePreference,
+            context.Routing.MaxToolRoundsOverride,
+            context.Routing.UserMemoryPrompt).ToPayload();
     }
 
     private CallerScopeResolution ResolveCallerScope(bool requireOwner = true)

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -771,18 +771,18 @@ public sealed class AevatarInvocationDispatcher
         Google.Protobuf.Collections.MapField<string, string>? headers)
     {
         // Refactor (issue1300-first): Old pattern: stamp trusted caller/control to Headers/Metadata. New principle: typed ScopeId/ToolContext/LlmControl are authority.
-        var metadata = new Dictionary<string, string>(StringComparer.Ordinal);
+        var filteredHeaders = new Dictionary<string, string>(StringComparer.Ordinal);
         if (headers == null)
-            return metadata;
+            return filteredHeaders;
 
         foreach (var (key, value) in headers)
         {
             var normalizedKey = Normalize(key);
             if (normalizedKey != null && !IsProtectedCallerMetadataKey(normalizedKey))
-                metadata[normalizedKey] = value ?? string.Empty;
+                filteredHeaders[normalizedKey] = value ?? string.Empty;
         }
 
-        return metadata;
+        return filteredHeaders;
     }
 
     private static Dictionary<string, string> BuildLegacyMetadata(

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -144,12 +144,17 @@ public sealed class AevatarInvocationToolSourceTests
         payload.SessionId.Should().Be("call-gagent");
         payload.ScopeId.Should().Be("scope-1");
         payload.Headers["x-test"].Should().Be("yes");
-        payload.Headers[LLMRequestMetadataKeys.ScopeId].Should().Be("scope-1");
+        payload.Headers.Should().NotContainKey(LLMRequestMetadataKeys.ScopeId);
+        payload.Metadata["x-test"].Should().Be("yes");
+        ShouldNotCarryTrustedCallerValues(payload.Headers);
+        ShouldNotCarryTrustedCallerValues(payload.Metadata);
         payload.InputParts.Should().ContainSingle();
         payload.InputParts[0].Kind.Should().Be(ChatContentPartKind.Text);
         payload.InputParts[0].Text.Should().Be("typed part");
         payload.ToolContext.Caller.OwnerSubject.Should().Be("owner-1");
         payload.ToolContext.Credentials.NyxIdAccessToken.Should().Be("access-token");
+        payload.LlmControl.NyxIdAccessToken.Should().Be("access-token");
+        payload.LlmControl.ModelOverride.Should().Be("model-1");
 
         var result = Read(output);
         result.GetProperty("run_id").GetString().Should().Be("call-gagent");
@@ -210,8 +215,13 @@ public sealed class AevatarInvocationToolSourceTests
 
         ErrorCodeOrNull(output).Should().BeNull(output);
         var payload = harness.ActorDispatch.Calls.Single().Envelope.Payload.Unpack<ChatRequestEvent>();
-        ShouldCarryTrustedCallerValues(payload.Headers);
-        ShouldCarryTrustedCallerValues(payload.Metadata);
+        ShouldNotCarryTrustedCallerValues(payload.Headers);
+        ShouldNotCarryTrustedCallerValues(payload.Metadata);
+        payload.ScopeId.Should().Be("scope-1");
+        payload.ToolContext.Caller.OwnerSubject.Should().Be("owner-1");
+        payload.ToolContext.Credentials.NyxIdAccessToken.Should().Be("access-token");
+        payload.LlmControl.NyxIdAccessToken.Should().Be("access-token");
+        payload.LlmControl.NyxIdRoutePreference.Should().Be("route-1");
     }
 
     [Fact]
@@ -694,6 +704,28 @@ public sealed class AevatarInvocationToolSourceTests
         values.Should().Contain(LLMRequestMetadataKeys.SenderNyxIdAccessToken, "sender-token");
         values.Should().Contain(LLMRequestMetadataKeys.ScopeId, "scope-1");
         values.Should().Contain("scope_id", "scope-1");
+    }
+
+    private static void ShouldNotCarryTrustedCallerValues(IEnumerable<KeyValuePair<string, string>>? metadata)
+    {
+        // Refactor (issue1300-first): Old: stamp trusted caller/control to Headers/Metadata. New: typed ScopeId/ToolContext/LlmControl as authority.
+        metadata.Should().NotBeNull();
+        var values = metadata!.ToDictionary(static item => item.Key, static item => item.Value, StringComparer.Ordinal);
+        values.Should().NotContainKey(LLMRequestMetadataKeys.RequestId);
+        values.Should().NotContainKey(LLMRequestMetadataKeys.CallId);
+        values.Should().NotContainKey(LLMRequestMetadataKeys.OwnerSubject);
+        values.Should().NotContainKey(LLMRequestMetadataKeys.ResponseId);
+        values.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
+        values.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdOrgToken);
+        values.Should().NotContainKey(LLMRequestMetadataKeys.SenderNyxIdAccessToken);
+        values.Should().NotContainKey(LLMRequestMetadataKeys.SenderBindingId);
+        values.Should().NotContainKey(LLMRequestMetadataKeys.ScopeId);
+        values.Should().NotContainKey(LLMRequestMetadataKeys.ModelOverride);
+        values.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdRoutePreference);
+        values.Should().NotContainKey(LLMRequestMetadataKeys.MaxToolRoundsOverride);
+        values.Should().NotContainKey(LLMRequestMetadataKeys.ConnectedServicesContext);
+        values.Should().NotContainKey("scope_id");
+        values.Should().NotContainKey("external");
     }
 
     private static AgentToolContextScope PushContext(string callId, string? scopeId = "scope-1") =>

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -708,7 +708,7 @@ public sealed class AevatarInvocationToolSourceTests
 
     private static void ShouldNotCarryTrustedCallerValues(IEnumerable<KeyValuePair<string, string>>? metadata)
     {
-        // Refactor (issue1300-first): Old: stamp trusted caller/control to Headers/Metadata. New: typed ScopeId/ToolContext/LlmControl as authority.
+        // Refactor (issue1300-first): Old pattern: stamp trusted caller/control to Headers/Metadata. New principle: typed ScopeId/ToolContext/LlmControl are authority.
         metadata.Should().NotBeNull();
         var values = metadata!.ToDictionary(static item => item.Key, static item => item.Value, StringComparer.Ordinal);
         values.Should().NotContainKey(LLMRequestMetadataKeys.RequestId);


### PR DESCRIPTION
## 摘要

源自 #1297 Phase 9 r1-redo `META_JUDGE_DONE:split` 的 first-slice。

`BuildChatRequest` 不再 stamp trusted caller / control keys 到 `Headers` 或 `Metadata`;只复制非 protected payload headers;`ScopeId`、`ToolContext`、`LlmControl` 是权威来源。

## 变更

- `src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs`(+50/-7):删除 trusted bag stamping;typed context 是 authority
- `test/.../AevatarInvocationToolSourceTests.cs`(+38/-4):验证 trusted bag mirrors 已不被读取

## No-new-core 边界

- 无新增 actor / proto field / envelope kind / pipeline phase
- 无 `docs/canon/*` 改动
- workflow / team typed context boundary 留 #1301-later

## 验证

- `dotnet build aevatar.slnx --nologo` 通过
- `dotnet test aevatar.slnx --nologo --no-build` 通过

closes #1300

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧