### PR TITLE
#1296 first slice: ChatRun typed control fields + 删除 JSON control parsers(no-new-core)

### DIFF
--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -86,7 +86,7 @@ public sealed class AevatarInvocationDispatcher
     public async Task<string> InvokeGAgentAsync(string argumentsJson, CancellationToken ct = default) =>
         (await InvokeGAgentForChatRunAsync(null, argumentsJson, ct)).ToolExecutionResultJson;
 
-    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+    // Refactor (iter290/cluster001): Old pattern: GAgent dispatch control was encoded only in ResultJson. New principle: GAgent dispatch returns typed run, target, wait, and stream fields for chat-run observation.
     public async Task<ChatRunToolCompletionRequest> InvokeGAgentForChatRunAsync(
         ChatRunToolCompletionRequest? chatRunRequest,
         string argumentsJson,
@@ -153,7 +153,7 @@ public sealed class AevatarInvocationDispatcher
     public async Task<string> InvokeTeamAsync(string argumentsJson, CancellationToken ct = default) =>
         (await InvokeTeamForChatRunAsync(null, argumentsJson, ct)).ToolExecutionResultJson;
 
-    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+    // Refactor (iter290/cluster001): Old pattern: team dispatch control was encoded only in ResultJson. New principle: team dispatch returns typed run, service, endpoint, wait, and completion fields for chat-run observation.
     public async Task<ChatRunToolCompletionRequest> InvokeTeamForChatRunAsync(
         ChatRunToolCompletionRequest? chatRunRequest,
         string argumentsJson,
@@ -203,7 +203,7 @@ public sealed class AevatarInvocationDispatcher
     public async Task<string> StartWorkflowAsync(string argumentsJson, CancellationToken ct = default) =>
         (await StartWorkflowForChatRunAsync(null, argumentsJson, ct)).ToolExecutionResultJson;
 
-    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+    // Refactor (iter290/cluster001): Old pattern: workflow dispatch control was encoded only in ResultJson. New principle: workflow dispatch returns typed actor, run, wait, and completion fields for chat-run observation.
     public async Task<ChatRunToolCompletionRequest> StartWorkflowForChatRunAsync(
         ChatRunToolCompletionRequest? chatRunRequest,
         string argumentsJson,
@@ -478,7 +478,7 @@ public sealed class AevatarInvocationDispatcher
         };
     }
 
-    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+    // Refactor (iter290/cluster001): Old pattern: dispatcher-to-chat-run conversion left control facts inside boundary JSON. New principle: conversion mirrors stable control facts into typed completion fields while preserving boundary JSON.
     private static ChatRunToolCompletionRequest ToChatRunRequest(
         ChatRunToolCompletionRequest? request,
         InvocationToolResult result,
@@ -505,7 +505,6 @@ public sealed class AevatarInvocationDispatcher
         };
     }
 
-    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
     private static ChatRunToolCompletionRequest ToChatRunRequest(
         ChatRunToolCompletionRequest? request,
         string boundaryJson,

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -7,6 +7,7 @@ using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.GAgentService.Abstractions.Responses;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.Presentation.AGUI;
@@ -82,24 +83,31 @@ public sealed class AevatarInvocationDispatcher
         _logger = logger ?? NullLogger<AevatarInvocationDispatcher>.Instance;
     }
 
-    public async Task<string> InvokeGAgentAsync(string argumentsJson, CancellationToken ct = default)
+    public async Task<string> InvokeGAgentAsync(string argumentsJson, CancellationToken ct = default) =>
+        (await InvokeGAgentForChatRunAsync(null, argumentsJson, ct)).ToolExecutionResultJson;
+
+    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+    public async Task<ChatRunToolCompletionRequest> InvokeGAgentForChatRunAsync(
+        ChatRunToolCompletionRequest? chatRunRequest,
+        string argumentsJson,
+        CancellationToken ct = default)
     {
         var parsed = ProtoToolArguments.Parse<InvokeGAgentToolRequest>(argumentsJson);
         if (parsed.Error != null)
-            return AevatarInvocationJson.Error(parsed.Error);
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(parsed.Error), parsed.Error);
 
         var request = parsed.Value!;
         var error = ProtoToolArguments.RequirePayload(request.Payload, "payload");
         if (error != null)
-            return AevatarInvocationJson.Error(error);
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(error), error);
 
         var scope = ResolveCallerScope();
         if (scope.Error != null)
-            return AevatarInvocationJson.Error(scope.Error);
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(scope.Error), scope.Error);
 
         var target = await ResolveGAgentActorIdAsync(request, scope.Value!, ct);
         if (target.Error != null)
-            return AevatarInvocationJson.Error(target.Error);
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(target.Error), target.Error);
 
         var wait = ResolveWait(request.Wait);
         var commandId = ResolveCommandId();
@@ -122,12 +130,13 @@ public sealed class AevatarInvocationDispatcher
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            return AevatarInvocationJson.Error(Error(
+            var dispatchError = Error(
                 "dispatch_failed",
-                $"GAgent dispatch failed: {ex.Message}"));
+                $"GAgent dispatch failed: {ex.Message}");
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(dispatchError), dispatchError);
         }
 
-        return AevatarInvocationJson.Serialize(new InvocationToolResult
+        return ToChatRunRequest(chatRunRequest, new InvocationToolResult
         {
             RunId = commandId,
             Status = wait == InvocationWaitMode.Ack ? "accepted" : "streaming",
@@ -138,25 +147,32 @@ public sealed class AevatarInvocationDispatcher
             CommandId = commandId,
             CorrelationId = commandId,
             Wait = wait,
-        });
+        }, scope.Value!.ScopeId);
     }
 
-    public async Task<string> InvokeTeamAsync(string argumentsJson, CancellationToken ct = default)
+    public async Task<string> InvokeTeamAsync(string argumentsJson, CancellationToken ct = default) =>
+        (await InvokeTeamForChatRunAsync(null, argumentsJson, ct)).ToolExecutionResultJson;
+
+    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+    public async Task<ChatRunToolCompletionRequest> InvokeTeamForChatRunAsync(
+        ChatRunToolCompletionRequest? chatRunRequest,
+        string argumentsJson,
+        CancellationToken ct = default)
     {
         var parsed = ProtoToolArguments.Parse<InvokeTeamToolRequest>(argumentsJson);
         if (parsed.Error != null)
-            return AevatarInvocationJson.Error(parsed.Error);
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(parsed.Error), parsed.Error);
 
         var request = parsed.Value!;
         var error = ProtoToolArguments.Require(request.TeamId, "team_id", "team_id is required.") ??
                     ProtoToolArguments.Require(request.EndpointId, "endpoint_id", "endpoint_id is required.") ??
                     ProtoToolArguments.RequirePayload(request.Payload, "payload");
         if (error != null)
-            return AevatarInvocationJson.Error(error);
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(error), error);
 
         var scope = ResolveCallerScope();
         if (scope.Error != null)
-            return AevatarInvocationJson.Error(scope.Error);
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(scope.Error), scope.Error);
 
         var wait = ResolveWait(request.Wait);
         try
@@ -167,37 +183,46 @@ public sealed class AevatarInvocationDispatcher
                 ct);
             var invocation = BuildStaticInvocationRequest(resolution, request, scope.Value!);
             return wait == InvocationWaitMode.Complete
-                ? await InvokeTeamToCompletionAsync(invocation, resolution, request.EndpointId, wait, ct)
-                : await InvokeTeamToAcceptanceAsync(invocation, resolution, request.EndpointId, wait, ct);
+                ? await InvokeTeamToCompletionAsync(chatRunRequest, invocation, resolution, request.EndpointId, wait, ct)
+                : await InvokeTeamToAcceptanceAsync(chatRunRequest, invocation, resolution, request.EndpointId, wait, ct);
         }
         catch (TeamEntryMemberResolutionException ex)
         {
-            return AevatarInvocationJson.Error(Error(ex.Code, ex.Message));
+            var resolutionError = Error(ex.Code, ex.Message);
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(resolutionError), resolutionError);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            return AevatarInvocationJson.Error(Error(
+            var dispatchError = Error(
                 "dispatch_failed",
-                $"Team invocation failed: {ex.Message}"));
+                $"Team invocation failed: {ex.Message}");
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(dispatchError), dispatchError);
         }
     }
 
-    public async Task<string> StartWorkflowAsync(string argumentsJson, CancellationToken ct = default)
+    public async Task<string> StartWorkflowAsync(string argumentsJson, CancellationToken ct = default) =>
+        (await StartWorkflowForChatRunAsync(null, argumentsJson, ct)).ToolExecutionResultJson;
+
+    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+    public async Task<ChatRunToolCompletionRequest> StartWorkflowForChatRunAsync(
+        ChatRunToolCompletionRequest? chatRunRequest,
+        string argumentsJson,
+        CancellationToken ct = default)
     {
         var parsed = ProtoToolArguments.Parse<StartWorkflowToolRequest>(argumentsJson);
         if (parsed.Error != null)
-            return AevatarInvocationJson.Error(parsed.Error);
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(parsed.Error), parsed.Error);
 
         var request = parsed.Value!;
         var wait = ResolveWait(request.Wait);
         var error = ProtoToolArguments.Require(request.WorkflowId, "workflow_id", "workflow_id is required.") ??
                     ProtoToolArguments.RequirePayload(request.Inputs, "inputs");
         if (error != null)
-            return AevatarInvocationJson.Error(error);
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(error), error);
 
         var scope = ResolveCallerScope();
         if (scope.Error != null)
-            return AevatarInvocationJson.Error(scope.Error);
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(scope.Error), scope.Error);
 
         var metadata = BuildLegacyMetadata(scope.Value!, request.Inputs.Headers);
         metadata[WorkflowRunCommandMetadataKeys.ScopeId] = scope.Value!.ScopeId;
@@ -225,13 +250,14 @@ public sealed class AevatarInvocationDispatcher
         var result = await _workflowDispatchService.DispatchAsync(command, ct);
         if (!result.Succeeded || result.Receipt == null)
         {
-            return AevatarInvocationJson.Error(Error(
+            var startError = Error(
                 result.Error.ToString(),
-                $"Workflow start failed: {result.Error}"));
+                $"Workflow start failed: {result.Error}");
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(startError), startError);
         }
 
         var receipt = result.Receipt;
-        return AevatarInvocationJson.Serialize(new InvocationToolResult
+        return ToChatRunRequest(chatRunRequest, new InvocationToolResult
         {
             RunId = receipt.CommandId,
             Status = wait == InvocationWaitMode.Ack ? "accepted" : "streaming",
@@ -242,7 +268,7 @@ public sealed class AevatarInvocationDispatcher
             CommandId = receipt.CommandId,
             CorrelationId = receipt.CorrelationId,
             Wait = wait,
-        });
+        }, scope.Value.ScopeId);
     }
 
     public async Task<string> ObserveRunAsync(string argumentsJson, CancellationToken ct = default)
@@ -329,7 +355,8 @@ public sealed class AevatarInvocationDispatcher
         };
     }
 
-    private async Task<string> InvokeTeamToAcceptanceAsync(
+    private async Task<ChatRunToolCompletionRequest> InvokeTeamToAcceptanceAsync(
+        ChatRunToolCompletionRequest? chatRunRequest,
         StaticGAgentStreamInvocationRequest invocation,
         TeamEntryMemberResolution resolution,
         string endpointId,
@@ -356,40 +383,42 @@ public sealed class AevatarInvocationDispatcher
         if (acceptedSource.Task.Status == TaskStatus.RanToCompletion)
         {
             var signaledAcceptedReceipt = await acceptedSource.Task.WaitAsync(ct);
-            return AevatarInvocationJson.Serialize(BuildTeamAcceptedResult(
+            return ToChatRunRequest(chatRunRequest, BuildTeamAcceptedResult(
                 resolution,
                 endpointId,
                 signaledAcceptedReceipt,
-                wait));
+                wait), resolution.ScopeId);
         }
 
         var result = await invocationTask;
         if (acceptedSource.Task.Status == TaskStatus.RanToCompletion)
         {
             var completedAcceptedReceipt = await acceptedSource.Task.WaitAsync(ct);
-            return AevatarInvocationJson.Serialize(BuildTeamAcceptedResult(
+            return ToChatRunRequest(chatRunRequest, BuildTeamAcceptedResult(
                 resolution,
                 endpointId,
                 completedAcceptedReceipt,
-                wait));
+                wait), resolution.ScopeId);
         }
 
         if (!result.Succeeded || result.Accepted == null)
         {
-            return AevatarInvocationJson.Error(Error(
+            var startError = Error(
                 result.StartError.ToString(),
-                $"Team invocation was not accepted: {result.StartError}"));
+                $"Team invocation was not accepted: {result.StartError}");
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(startError), startError);
         }
 
         var resultAcceptedReceipt = result.Accepted;
-        return AevatarInvocationJson.Serialize(BuildTeamAcceptedResult(
+        return ToChatRunRequest(chatRunRequest, BuildTeamAcceptedResult(
             resolution,
             endpointId,
             resultAcceptedReceipt,
-            wait));
+            wait), resolution.ScopeId);
     }
 
-    private async Task<string> InvokeTeamToCompletionAsync(
+    private async Task<ChatRunToolCompletionRequest> InvokeTeamToCompletionAsync(
+        ChatRunToolCompletionRequest? chatRunRequest,
         StaticGAgentStreamInvocationRequest invocation,
         TeamEntryMemberResolution resolution,
         string endpointId,
@@ -409,9 +438,10 @@ public sealed class AevatarInvocationDispatcher
 
         if (!result.Succeeded || result.Accepted == null)
         {
-            return AevatarInvocationJson.Error(Error(
+            var startError = Error(
                 result.StartError.ToString(),
-                $"Team invocation was not accepted: {result.StartError}"));
+                $"Team invocation was not accepted: {result.StartError}");
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(startError), startError);
         }
 
         var accepted = BuildTeamAcceptedResult(resolution, endpointId, result.Accepted, wait);
@@ -422,7 +452,7 @@ public sealed class AevatarInvocationDispatcher
             completion_observed = result.CompletionObserved,
             events = frames.Select(static frame => AevatarInvocationToolSchemas.ParseObject(ProtoJsonFormatter.Format(frame))).ToArray(),
         });
-        return AevatarInvocationJson.Serialize(accepted);
+        return ToChatRunRequest(chatRunRequest, accepted, resolution.ScopeId);
     }
 
     private InvocationToolResult BuildTeamAcceptedResult(
@@ -446,6 +476,80 @@ public sealed class AevatarInvocationDispatcher
             EndpointId = endpointId.Trim(),
             Wait = wait,
         };
+    }
+
+    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+    private static ChatRunToolCompletionRequest ToChatRunRequest(
+        ChatRunToolCompletionRequest? request,
+        InvocationToolResult result,
+        string scopeId)
+    {
+        var boundaryJson = AevatarInvocationJson.Serialize(result);
+        var waitMode = ToChatRunWaitMode(result.Wait);
+        var completionObserved = !string.IsNullOrWhiteSpace(result.ResultJson) &&
+                                 IsTerminalDispatchStatus(result.Status);
+        return ToBaseChatRunRequest(request) with
+        {
+            ToolExecutionResultJson = boundaryJson,
+            RunId = result.RunId ?? string.Empty,
+            Status = result.Status ?? string.Empty,
+            StreamTopic = result.StreamTopic ?? string.Empty,
+            ActorId = result.ActorId ?? string.Empty,
+            ServiceId = result.ServiceId ?? string.Empty,
+            EndpointId = result.EndpointId ?? string.Empty,
+            ScopeId = scopeId ?? string.Empty,
+            WaitMode = waitMode,
+            CompletionResultJson = result.ResultJson ?? string.Empty,
+            CompletionObserved = completionObserved,
+            ErrorCode = result.Error?.Code ?? string.Empty,
+        };
+    }
+
+    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+    private static ChatRunToolCompletionRequest ToChatRunRequest(
+        ChatRunToolCompletionRequest? request,
+        string boundaryJson,
+        InvocationToolError error) =>
+        ToBaseChatRunRequest(request) with
+        {
+            ToolExecutionResultJson = boundaryJson,
+            ErrorCode = error.Code ?? string.Empty,
+        };
+
+    private static ChatRunToolCompletionRequest ToBaseChatRunRequest(ChatRunToolCompletionRequest? request) =>
+        request ?? new ChatRunToolCompletionRequest(
+            ResponseId: string.Empty,
+            ModelName: null,
+            Messages: [],
+            ToolCall: new ToolCall
+            {
+                Id = string.Empty,
+                Name = string.Empty,
+                ArgumentsJson = string.Empty,
+            },
+            ArgumentsJson: string.Empty,
+            ToolExecutionResultJson: string.Empty,
+            LlmRound: 0);
+
+    private static ChatRunSubRunWaitMode ToChatRunWaitMode(InvocationWaitMode wait) =>
+        wait switch
+        {
+            InvocationWaitMode.Ack => ChatRunSubRunWaitMode.Ack,
+            InvocationWaitMode.Complete => ChatRunSubRunWaitMode.Complete,
+            InvocationWaitMode.Stream => ChatRunSubRunWaitMode.Stream,
+            _ => ChatRunSubRunWaitMode.Unspecified,
+        };
+
+    private static bool IsTerminalDispatchStatus(string status)
+    {
+        if (string.IsNullOrWhiteSpace(status))
+            return false;
+
+        return !status.Equals("accepted", StringComparison.OrdinalIgnoreCase) &&
+               !status.Equals("streaming", StringComparison.OrdinalIgnoreCase) &&
+               !status.Equals("running", StringComparison.OrdinalIgnoreCase) &&
+               !status.Equals("in_progress", StringComparison.OrdinalIgnoreCase) &&
+               !status.Equals("unknown", StringComparison.OrdinalIgnoreCase);
     }
 
     private async Task ObserveDetachedInvocationAsync(Task invocationTask)

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSources.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSources.cs
@@ -87,7 +87,6 @@ internal sealed class InvokeGAgentTool : IAevatarInvocationChatRunTool
     public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
         _dispatcher.InvokeGAgentAsync(argumentsJson, ct);
 
-    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
     public Task<ChatRunToolCompletionRequest> ExecuteForChatRunAsync(
         ChatRunToolCompletionRequest request,
         CancellationToken ct = default) =>
@@ -113,7 +112,6 @@ internal sealed class InvokeTeamTool : IAevatarInvocationChatRunTool
     public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
         _dispatcher.InvokeTeamAsync(argumentsJson, ct);
 
-    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
     public Task<ChatRunToolCompletionRequest> ExecuteForChatRunAsync(
         ChatRunToolCompletionRequest request,
         CancellationToken ct = default) =>
@@ -140,7 +138,6 @@ internal sealed class StartWorkflowTool : IAevatarInvocationChatRunTool
     public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
         _dispatcher.StartWorkflowAsync(argumentsJson, ct);
 
-    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
     public Task<ChatRunToolCompletionRequest> ExecuteForChatRunAsync(
         ChatRunToolCompletionRequest request,
         CancellationToken ct = default) =>

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSources.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSources.cs
@@ -1,4 +1,5 @@
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.GAgentService.Abstractions.Responses;
 
 namespace Aevatar.AI.ToolProviders.AevatarInvocation;
 
@@ -67,7 +68,7 @@ public sealed class QueryReadModelToolSource : IAgentToolSource
         Task.FromResult<IReadOnlyList<IAgentTool>>([new QueryReadModelTool(_dispatcher)]);
 }
 
-internal sealed class InvokeGAgentTool : IAevatarInvocationTool
+internal sealed class InvokeGAgentTool : IAevatarInvocationChatRunTool
 {
     private readonly AevatarInvocationDispatcher _dispatcher;
 
@@ -85,9 +86,15 @@ internal sealed class InvokeGAgentTool : IAevatarInvocationTool
 
     public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
         _dispatcher.InvokeGAgentAsync(argumentsJson, ct);
+
+    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+    public Task<ChatRunToolCompletionRequest> ExecuteForChatRunAsync(
+        ChatRunToolCompletionRequest request,
+        CancellationToken ct = default) =>
+        _dispatcher.InvokeGAgentForChatRunAsync(request, request.ArgumentsJson, ct);
 }
 
-internal sealed class InvokeTeamTool : IAevatarInvocationTool
+internal sealed class InvokeTeamTool : IAevatarInvocationChatRunTool
 {
     private readonly AevatarInvocationDispatcher _dispatcher;
 
@@ -105,9 +112,15 @@ internal sealed class InvokeTeamTool : IAevatarInvocationTool
 
     public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
         _dispatcher.InvokeTeamAsync(argumentsJson, ct);
+
+    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+    public Task<ChatRunToolCompletionRequest> ExecuteForChatRunAsync(
+        ChatRunToolCompletionRequest request,
+        CancellationToken ct = default) =>
+        _dispatcher.InvokeTeamForChatRunAsync(request, request.ArgumentsJson, ct);
 }
 
-internal sealed class StartWorkflowTool : IAevatarInvocationTool
+internal sealed class StartWorkflowTool : IAevatarInvocationChatRunTool
 {
     private readonly AevatarInvocationDispatcher _dispatcher;
 
@@ -126,6 +139,12 @@ internal sealed class StartWorkflowTool : IAevatarInvocationTool
 
     public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
         _dispatcher.StartWorkflowAsync(argumentsJson, ct);
+
+    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+    public Task<ChatRunToolCompletionRequest> ExecuteForChatRunAsync(
+        ChatRunToolCompletionRequest request,
+        CancellationToken ct = default) =>
+        _dispatcher.StartWorkflowForChatRunAsync(request, request.ArgumentsJson, ct);
 }
 
 internal sealed class ObserveRunTool : IAevatarInvocationTool

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolTags.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolTags.cs
@@ -1,4 +1,5 @@
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.GAgentService.Abstractions.Responses;
 
 namespace Aevatar.AI.ToolProviders.AevatarInvocation;
 
@@ -11,3 +12,6 @@ public interface IAevatarInvocationTool : IAgentTool
 {
     string ToolSetTag => AevatarInvocationToolTags.ToolSet;
 }
+
+// Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+public interface IAevatarInvocationChatRunTool : IAevatarInvocationTool, IChatRunToolCompletionControlExecutor;

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolTags.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolTags.cs
@@ -13,5 +13,5 @@ public interface IAevatarInvocationTool : IAgentTool
     string ToolSetTag => AevatarInvocationToolTags.ToolSet;
 }
 
-// Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+// Refactor (iter290/cluster001): Old pattern: invocation tools exposed only boundary JSON to chat-run orchestration. New principle: chat-run invocation tools implement the typed completion-control contract.
 public interface IAevatarInvocationChatRunTool : IAevatarInvocationTool, IChatRunToolCompletionControlExecutor;

--- a/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
@@ -435,6 +435,7 @@ message ChatRunSubRunTerminalObserved {
   string service_id = 5;
   string endpoint_id = 6;
   google.protobuf.Timestamp observed_at = 7;
+  bool completion_observed = 8;
 }
 
 message ChatRunSubRunTerminalFoldedEvent {
@@ -444,6 +445,11 @@ message ChatRunSubRunTerminalFoldedEvent {
   string result_json = 4;
   int32 llm_round = 5;
   google.protobuf.Timestamp observed_at = 6;
+  string status = 7;
+  string actor_id = 8;
+  string service_id = 9;
+  string endpoint_id = 10;
+  bool completion_observed = 11;
 }
 
 message ChatRunToolResultReady {
@@ -453,6 +459,11 @@ message ChatRunToolResultReady {
   string tool_name = 4;
   string result_json = 5;
   int32 llm_round = 6;
+  string status = 7;
+  string actor_id = 8;
+  string service_id = 9;
+  string endpoint_id = 10;
+  bool completion_observed = 11;
 }
 
 message TerminateChatRunRequested {

--- a/src/platform/Aevatar.GAgentService.Abstractions/Responses/ChatRunActorPorts.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Responses/ChatRunActorPorts.cs
@@ -9,7 +9,7 @@ public sealed record ChatRunStartRequest(
     IReadOnlyList<ChatMessage> Messages,
     TimeSpan? IdleTtl = null);
 
-// Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+// Refactor (iter290/cluster001): Old pattern: chat-run completion control was parsed back out of ResultJson. New principle: completion control crosses the public contract as typed scalar fields.
 public sealed record ChatRunToolCompletionRequest(
     string ResponseId,
     string? ModelName,
@@ -30,7 +30,7 @@ public sealed record ChatRunToolCompletionRequest(
     bool CompletionObserved = false,
     string ErrorCode = "");
 
-// Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+// Refactor (iter290/cluster001): Old pattern: chat-run tools returned only boundary JSON to the coordinator. New principle: chat-run-aware tools return a typed completion request for command observation.
 public interface IChatRunToolCompletionControlExecutor
 {
     Task<ChatRunToolCompletionRequest> ExecuteForChatRunAsync(

--- a/src/platform/Aevatar.GAgentService.Abstractions/Responses/ChatRunActorPorts.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Responses/ChatRunActorPorts.cs
@@ -9,6 +9,7 @@ public sealed record ChatRunStartRequest(
     IReadOnlyList<ChatMessage> Messages,
     TimeSpan? IdleTtl = null);
 
+// Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
 public sealed record ChatRunToolCompletionRequest(
     string ResponseId,
     string? ModelName,
@@ -16,7 +17,26 @@ public sealed record ChatRunToolCompletionRequest(
     ToolCall ToolCall,
     string ArgumentsJson,
     string ToolExecutionResultJson,
-    int LlmRound);
+    int LlmRound,
+    string RunId = "",
+    string StreamTopic = "",
+    string ActorId = "",
+    string ServiceId = "",
+    string EndpointId = "",
+    string ScopeId = "",
+    ChatRunSubRunWaitMode WaitMode = ChatRunSubRunWaitMode.Unspecified,
+    string Status = "",
+    string CompletionResultJson = "",
+    bool CompletionObserved = false,
+    string ErrorCode = "");
+
+// Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+public interface IChatRunToolCompletionControlExecutor
+{
+    Task<ChatRunToolCompletionRequest> ExecuteForChatRunAsync(
+        ChatRunToolCompletionRequest request,
+        CancellationToken ct = default);
+}
 
 public sealed record ChatRunToolCompletionResult(
     string ActorId,

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ChatRunToolCompletionCoordinator.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ChatRunToolCompletionCoordinator.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.Foundation.Abstractions.Streaming;
@@ -8,6 +7,7 @@ using Aevatar.GAgentService.Abstractions.Responses;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Google.Protobuf;
+using System.Text.Json;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.GAgentService.Application.Responses;
@@ -65,7 +65,7 @@ public sealed class ChatRunToolCompletionCoordinator
         LLMRequest request,
         ToolCall toolCall,
         string argumentsJson,
-        Func<string, CancellationToken, Task<string>> executeToolAsync,
+        Func<ChatRunToolCompletionRequest, CancellationToken, Task<ChatRunToolCompletionRequest>> executeToolAsync,
         int llmRound,
         CancellationToken ct = default)
     {
@@ -110,34 +110,38 @@ public sealed class ChatRunToolCompletionCoordinator
                 ct);
         }
 
-        var dispatchResult = await executeToolAsync(argumentsJson, ct);
-        var completionRequest = new ChatRunToolCompletionRequest(
+        var initialRequest = new ChatRunToolCompletionRequest(
             responseId,
             request.Model,
             request.Messages,
             toolCall,
             argumentsJson,
-            dispatchResult,
+            string.Empty,
             llmRound);
+        var completionRequest = await executeToolAsync(initialRequest, ct);
+        var dispatchResult = completionRequest.ToolExecutionResultJson ?? string.Empty;
         await _chatRunActorPort.SubmitToolCallAsync(actorId, completionRequest, ct);
 
-        var parsed = ParseDispatchResult(dispatchResult);
-        if (!string.IsNullOrWhiteSpace(parsed.ErrorCode))
+        if (!string.IsNullOrWhiteSpace(completionRequest.ErrorCode))
             return dispatchResult;
 
-        parsed = NormalizeDispatchResultForObservation(toolCall, argumentsJson, parsed);
+        completionRequest = NormalizeDispatchResultForObservation(toolCall, argumentsJson, completionRequest);
         if (!isGAgentInvocation || !hasInlineGAgentActorId)
             await _chatRunActorPort.BeginSubRunObservationAsync(actorId, completionRequest, ct);
 
-        var terminal = TryBuildTerminalFromDispatchResult(parsed) ??
-                       await ResolveTerminalAsync(toolCall.Name, parsed, ct);
+        var terminal = TryBuildTerminalFromDispatchResult(completionRequest) ??
+                       await ResolveTerminalAsync(toolCall.Name, completionRequest, ct);
         if (terminal == null && isGAgentInvocation)
         {
             var observed = await readySource.Task.WaitAsync(ct);
             return observed.ResultJson;
         }
 
-        terminal ??= BuildTerminal(parsed, "completion_not_observed", BuildCompletionNotObservedResult(toolCall.Name, parsed));
+        terminal ??= BuildTerminal(
+            completionRequest,
+            "completion_not_observed",
+            BuildCompletionNotObservedResult(toolCall.Name, completionRequest),
+            completionObserved: false);
         if (string.IsNullOrWhiteSpace(terminal.RunId))
             return terminal.ResultJson;
 
@@ -146,24 +150,25 @@ public sealed class ChatRunToolCompletionCoordinator
         return (await readySource.Task.WaitAsync(ct)).ResultJson;
     }
 
-    private static ParsedDispatchResult NormalizeDispatchResultForObservation(
+    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+    private static ChatRunToolCompletionRequest NormalizeDispatchResultForObservation(
         ToolCall toolCall,
         string argumentsJson,
-        ParsedDispatchResult parsed)
+        ChatRunToolCompletionRequest request)
     {
         if (string.Equals(toolCall.Name, "aevatar_invoke_gagent", StringComparison.Ordinal) &&
-            string.IsNullOrWhiteSpace(parsed.ActorId) &&
+            string.IsNullOrWhiteSpace(request.ActorId) &&
             TryReadString(argumentsJson, "actor_id", out var actorId))
         {
-            return parsed with { ActorId = actorId };
+            return request with { ActorId = actorId };
         }
 
-        return parsed;
+        return request;
     }
 
     private async Task<ChatRunSubRunTerminalObserved?> ResolveTerminalAsync(
         string toolName,
-        ParsedDispatchResult dispatch,
+        ChatRunToolCompletionRequest dispatch,
         CancellationToken ct)
     {
         if (string.Equals(toolName, "aevatar_invoke_gagent", StringComparison.Ordinal))
@@ -179,7 +184,7 @@ public sealed class ChatRunToolCompletionCoordinator
     }
 
     private async Task<ChatRunSubRunTerminalObserved?> ResolveGAgentTerminalAsync(
-        ParsedDispatchResult dispatch,
+        ChatRunToolCompletionRequest dispatch,
         CancellationToken ct)
     {
         if (!string.IsNullOrWhiteSpace(dispatch.ActorId) && !string.IsNullOrWhiteSpace(dispatch.RunId))
@@ -189,14 +194,14 @@ public sealed class ChatRunToolCompletionCoordinator
                 dispatch.RunId,
                 ct);
             if (snapshot != null && snapshot.Status != GAgentRunTerminalStatus.Unknown)
-                return BuildTerminal(dispatch, snapshot.Status.ToString(), ToJson(snapshot));
+                return BuildTerminal(dispatch, snapshot.Status.ToString(), ToJson(snapshot), completionObserved: true);
         }
 
         return null;
     }
 
     private async Task<ChatRunSubRunTerminalObserved?> ResolveTeamTerminalAsync(
-        ParsedDispatchResult dispatch,
+        ChatRunToolCompletionRequest dispatch,
         CancellationToken ct)
     {
         if (!string.IsNullOrWhiteSpace(dispatch.ServiceId) && !string.IsNullOrWhiteSpace(dispatch.RunId))
@@ -207,14 +212,14 @@ public sealed class ChatRunToolCompletionCoordinator
                 dispatch.RunId,
                 ct);
             if (snapshot != null && IsTerminalServiceRunStatus(snapshot.Status))
-                return BuildTerminal(dispatch, snapshot.Status.ToString(), ToJson(snapshot));
+                return BuildTerminal(dispatch, snapshot.Status.ToString(), ToJson(snapshot), completionObserved: true);
         }
 
         return null;
     }
 
     private async Task<ChatRunSubRunTerminalObserved?> ResolveWorkflowTerminalAsync(
-        ParsedDispatchResult dispatch,
+        ChatRunToolCompletionRequest dispatch,
         CancellationToken ct)
     {
         if (!string.IsNullOrWhiteSpace(dispatch.ActorId))
@@ -224,30 +229,32 @@ public sealed class ChatRunToolCompletionCoordinator
                 string.Equals(snapshot.LastCommandId, dispatch.RunId, StringComparison.Ordinal) &&
                 IsTerminalWorkflowStatus(snapshot.CompletionStatus))
             {
-                return BuildTerminal(dispatch, snapshot.CompletionStatus.ToString(), ProtoJson(snapshot));
+                return BuildTerminal(dispatch, snapshot.CompletionStatus.ToString(), ProtoJson(snapshot), completionObserved: true);
             }
         }
 
         return null;
     }
 
-    private static ChatRunSubRunTerminalObserved? TryBuildTerminalFromDispatchResult(ParsedDispatchResult dispatch)
+    private static ChatRunSubRunTerminalObserved? TryBuildTerminalFromDispatchResult(ChatRunToolCompletionRequest dispatch)
     {
         if (string.IsNullOrWhiteSpace(dispatch.RunId) ||
-            string.IsNullOrWhiteSpace(dispatch.ResultJson) ||
+            string.IsNullOrWhiteSpace(dispatch.CompletionResultJson) ||
             !IsTerminalDispatchStatus(dispatch.Status) ||
-            DispatchResultExplicitlyIncomplete(dispatch.ResultJson))
+            !dispatch.CompletionObserved)
         {
             return null;
         }
 
-        return BuildTerminal(dispatch, dispatch.Status, dispatch.ResultJson);
+        return BuildTerminal(dispatch, dispatch.Status, dispatch.CompletionResultJson, completionObserved: true);
     }
 
+    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
     private static ChatRunSubRunTerminalObserved BuildTerminal(
-        ParsedDispatchResult dispatch,
+        ChatRunToolCompletionRequest dispatch,
         string status,
-        string resultJson) =>
+        string resultJson,
+        bool completionObserved) =>
         new()
         {
             RunId = dispatch.RunId,
@@ -256,35 +263,9 @@ public sealed class ChatRunToolCompletionCoordinator
             ActorId = dispatch.ActorId,
             ServiceId = dispatch.ServiceId,
             EndpointId = dispatch.EndpointId,
+            CompletionObserved = completionObserved,
             ObservedAt = Timestamp.FromDateTime(DateTime.UtcNow),
         };
-
-    private static ParsedDispatchResult ParseDispatchResult(string json)
-    {
-        if (string.IsNullOrWhiteSpace(json))
-            return ParsedDispatchResult.Empty;
-
-        using var document = JsonDocument.Parse(json);
-        var root = document.RootElement;
-        if (root.TryGetProperty("error", out var error) && error.ValueKind == JsonValueKind.Object)
-        {
-            return ParsedDispatchResult.Empty with
-            {
-                ErrorCode = ReadString(error, "code"),
-            };
-        }
-
-        return new ParsedDispatchResult(
-            RunId: ReadString(root, "run_id"),
-            Status: ReadString(root, "status"),
-            ResultJson: ReadRawJson(root, "result"),
-            ActorId: ReadString(root, "actor_id"),
-            ServiceId: ReadString(root, "service_id"),
-            EndpointId: ReadString(root, "endpoint_id"),
-            StreamTopic: ReadString(root, "stream_topic"),
-            ScopeId: ReadScopeId(root),
-            ErrorCode: string.Empty);
-    }
 
     private static string ResolveResponseId(LLMRequest request) =>
         request.CallerContext?.ResponseId?.Trim()
@@ -312,31 +293,6 @@ public sealed class ChatRunToolCompletionCoordinator
         }
     }
 
-    private static string ReadScopeId(JsonElement root)
-    {
-        if (root.TryGetProperty("scope_id", out var scopeId) &&
-            scopeId.ValueKind == JsonValueKind.String)
-        {
-            return scopeId.GetString()?.Trim() ?? string.Empty;
-        }
-
-        return string.Empty;
-    }
-
-    private static string ReadString(JsonElement root, string propertyName) =>
-        root.ValueKind == JsonValueKind.Object &&
-        root.TryGetProperty(propertyName, out var property) &&
-        property.ValueKind == JsonValueKind.String
-            ? property.GetString()?.Trim() ?? string.Empty
-            : string.Empty;
-
-    private static string ReadRawJson(JsonElement root, string propertyName) =>
-        root.ValueKind == JsonValueKind.Object &&
-        root.TryGetProperty(propertyName, out var property) &&
-        property.ValueKind is not JsonValueKind.Undefined and not JsonValueKind.Null
-            ? property.GetRawText()
-            : string.Empty;
-
     private static bool IsTerminalDispatchStatus(string status)
     {
         if (string.IsNullOrWhiteSpace(status))
@@ -347,21 +303,6 @@ public sealed class ChatRunToolCompletionCoordinator
                !status.Equals("running", StringComparison.OrdinalIgnoreCase) &&
                !status.Equals("in_progress", StringComparison.OrdinalIgnoreCase) &&
                !status.Equals("unknown", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static bool DispatchResultExplicitlyIncomplete(string resultJson)
-    {
-        try
-        {
-            using var document = JsonDocument.Parse(resultJson);
-            return document.RootElement.ValueKind == JsonValueKind.Object &&
-                   document.RootElement.TryGetProperty("completion_observed", out var observed) &&
-                   observed.ValueKind == JsonValueKind.False;
-        }
-        catch
-        {
-            return false;
-        }
     }
 
     private static bool IsTerminalServiceRunStatus(ServiceRunStatus status) =>
@@ -375,7 +316,7 @@ public sealed class ChatRunToolCompletionCoordinator
             or WorkflowRunCompletionStatus.NotFound
             or WorkflowRunCompletionStatus.Disabled;
 
-    private static string BuildCompletionNotObservedResult(string toolName, ParsedDispatchResult dispatch) =>
+    private static string BuildCompletionNotObservedResult(string toolName, ChatRunToolCompletionRequest dispatch) =>
         ToJson(new
         {
             run_id = EmptyToNull(dispatch.RunId),
@@ -410,6 +351,13 @@ public sealed class ChatRunToolCompletionCoordinator
         }
     }
 
+    private static string ReadString(JsonElement root, string propertyName) =>
+        root.ValueKind == JsonValueKind.Object &&
+        root.TryGetProperty(propertyName, out var property) &&
+        property.ValueKind == JsonValueKind.String
+            ? property.GetString()?.Trim() ?? string.Empty
+            : string.Empty;
+
     private static string ToJson<T>(T value) =>
         JsonSerializer.Serialize(value, JsonOptions);
 
@@ -418,28 +366,4 @@ public sealed class ChatRunToolCompletionCoordinator
 
     private static string? EmptyToNull(string value) =>
         string.IsNullOrWhiteSpace(value) ? null : value;
-
-    private sealed record ParsedDispatchResult(
-        string RunId,
-        string Status,
-        string ResultJson,
-        string ActorId,
-        string ServiceId,
-        string EndpointId,
-        string StreamTopic,
-        string ScopeId,
-        string ErrorCode)
-    {
-        public static ParsedDispatchResult Empty { get; } = new(
-            string.Empty,
-            string.Empty,
-            string.Empty,
-            string.Empty,
-            string.Empty,
-            string.Empty,
-            string.Empty,
-            string.Empty,
-            string.Empty);
-    }
-
 }

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ChatRunToolCompletionCoordinator.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ChatRunToolCompletionCoordinator.cs
@@ -150,7 +150,7 @@ public sealed class ChatRunToolCompletionCoordinator
         return (await readySource.Task.WaitAsync(ct)).ResultJson;
     }
 
-    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+    // Refactor (iter290/cluster001): Old pattern: observation targets were recovered from tool ResultJson after dispatch. New principle: observation target fields are normalized before entering actor observation.
     private static ChatRunToolCompletionRequest NormalizeDispatchResultForObservation(
         ToolCall toolCall,
         string argumentsJson,
@@ -249,7 +249,7 @@ public sealed class ChatRunToolCompletionCoordinator
         return BuildTerminal(dispatch, dispatch.Status, dispatch.CompletionResultJson, completionObserved: true);
     }
 
-    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+    // Refactor (iter290/cluster001): Old pattern: terminal observation rebuilt control facts from ResultJson. New principle: terminal observation copies typed dispatch fields into the actor event.
     private static ChatRunSubRunTerminalObserved BuildTerminal(
         ChatRunToolCompletionRequest dispatch,
         string status,

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCompletionApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCompletionApplicationService.cs
@@ -321,7 +321,7 @@ public sealed class ResponsesCompletionApplicationService : IResponsesCompletion
         }
     }
 
-    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+    // Refactor (iter290/cluster001): Old pattern: completion orchestration treated every tool as ResultJson-only. New principle: chat-run-aware tools may return typed control fields alongside boundary JSON.
     private static async Task<ChatRunToolCompletionRequest> ExecuteChatRunToolAsync(
         IAgentTool tool,
         ChatRunToolCompletionRequest request,

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCompletionApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCompletionApplicationService.cs
@@ -301,7 +301,7 @@ public sealed class ResponsesCompletionApplicationService : IResponsesCompletion
                                 request,
                                 toolCall,
                                 argumentsJson,
-                                tool.ExecuteAsync,
+                                (completionRequest, token) => ExecuteChatRunToolAsync(tool, completionRequest, token),
                                 llmRound,
                                 ct)
                             : await tool.ExecuteAsync(argumentsJson, ct);
@@ -319,6 +319,19 @@ public sealed class ResponsesCompletionApplicationService : IResponsesCompletion
                 messages.Add(ChatMessage.Tool(toolCall.Id, result));
             }
         }
+    }
+
+    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+    private static async Task<ChatRunToolCompletionRequest> ExecuteChatRunToolAsync(
+        IAgentTool tool,
+        ChatRunToolCompletionRequest request,
+        CancellationToken ct)
+    {
+        if (tool is IChatRunToolCompletionControlExecutor typedExecutor)
+            return await typedExecutor.ExecuteForChatRunAsync(request, ct);
+
+        var resultJson = await tool.ExecuteAsync(request.ArgumentsJson, ct);
+        return request with { ToolExecutionResultJson = resultJson };
     }
 
     private static async Task<(string Text, TokenUsage? Usage, IReadOnlyList<ToolCall> ToolCalls)> CollectStreamCompletionAsync(

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/ChatRunActor.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/ChatRunActor.cs
@@ -199,6 +199,7 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
             ActorId = pending.ActorId,
             ServiceId = pending.ServiceId,
             EndpointId = pending.EndpointId,
+            CompletionObserved = true,
             ObservedAt = Timestamp.FromDateTime(DateTime.UtcNow),
         });
     }

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/ChatRunActor.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/ChatRunActor.cs
@@ -145,7 +145,7 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
             ObservedAt = observed.ObservedAt ?? Timestamp.FromDateTime(DateTime.UtcNow),
         });
 
-        // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+        // Refactor (iter290/cluster001): Old pattern: ready notifications required consumers to parse ResultJson for completion facts. New principle: ready notifications publish typed completion facts with the result payload.
         await PublishAsync(new ChatRunToolResultReady
         {
             ResponseId = State.ResponseId,

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/ChatRunActor.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/ChatRunActor.cs
@@ -137,9 +137,15 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
             ToolName = pending.ToolName,
             ResultJson = resultJson,
             LlmRound = pending.LlmRound,
+            Status = observed.Status ?? string.Empty,
+            ActorId = FirstNonEmpty(observed.ActorId, pending.ActorId),
+            ServiceId = FirstNonEmpty(observed.ServiceId, pending.ServiceId),
+            EndpointId = FirstNonEmpty(observed.EndpointId, pending.EndpointId),
+            CompletionObserved = observed.CompletionObserved,
             ObservedAt = observed.ObservedAt ?? Timestamp.FromDateTime(DateTime.UtcNow),
         });
 
+        // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
         await PublishAsync(new ChatRunToolResultReady
         {
             ResponseId = State.ResponseId,
@@ -148,6 +154,11 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
             ToolName = pending.ToolName,
             ResultJson = resultJson,
             LlmRound = pending.LlmRound,
+            Status = observed.Status ?? string.Empty,
+            ActorId = FirstNonEmpty(observed.ActorId, pending.ActorId),
+            ServiceId = FirstNonEmpty(observed.ServiceId, pending.ServiceId),
+            EndpointId = FirstNonEmpty(observed.EndpointId, pending.EndpointId),
+            CompletionObserved = observed.CompletionObserved,
         }, TopologyAudience.Self);
     }
 

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/ChatRunActorAdapter.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/ChatRunActorAdapter.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions;
@@ -58,21 +57,21 @@ public sealed class ChatRunActorAdapter : IChatRunActorPort
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(request.ToolCall);
 
-        var parsed = ParseObservationTarget(request);
+        var target = ResolveObservationTarget(request);
         var command = new SubmitChatRunToolCallRequested
         {
             ToolCallId = NormalizeRequired(request.ToolCall.Id, nameof(request.ToolCall.Id)),
             ToolName = NormalizeRequired(request.ToolCall.Name, nameof(request.ToolCall.Name)),
             Arguments = ParseStruct(request.ArgumentsJson),
             ResultJson = request.ToolExecutionResultJson ?? string.Empty,
-            RunId = parsed.RunId,
+            RunId = target.RunId,
             TargetKind = ResolveTargetKind(request.ToolCall.Name),
-            TargetId = ResolveTargetId(parsed),
-            WaitMode = parsed.WaitMode,
-            StreamTopic = parsed.StreamTopic,
-            ActorId = parsed.ActorId,
-            ServiceId = parsed.ServiceId,
-            EndpointId = parsed.EndpointId,
+            TargetId = ResolveTargetId(target),
+            WaitMode = target.WaitMode,
+            StreamTopic = target.StreamTopic,
+            ActorId = target.ActorId,
+            ServiceId = target.ServiceId,
+            EndpointId = target.EndpointId,
             LlmRound = request.LlmRound,
             ObservedAt = Timestamp.FromDateTime(DateTime.UtcNow),
         };
@@ -92,8 +91,8 @@ public sealed class ChatRunActorAdapter : IChatRunActorPort
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(request.ToolCall);
 
-        var parsed = ParseObservationTarget(request);
-        if (parsed.WaitMode != ChatRunSubRunWaitMode.Complete || string.IsNullOrWhiteSpace(parsed.RunId))
+        var target = ResolveObservationTarget(request);
+        if (target.WaitMode != ChatRunSubRunWaitMode.Complete || string.IsNullOrWhiteSpace(target.RunId))
             return;
 
         var command = new PrepareChatRunSubRunObservationRequested
@@ -101,14 +100,14 @@ public sealed class ChatRunActorAdapter : IChatRunActorPort
             ToolCallId = NormalizeRequired(request.ToolCall.Id, nameof(request.ToolCall.Id)),
             ToolName = NormalizeRequired(request.ToolCall.Name, nameof(request.ToolCall.Name)),
             Arguments = ParseStruct(request.ArgumentsJson),
-            RunId = parsed.RunId,
+            RunId = target.RunId,
             TargetKind = ResolveTargetKind(request.ToolCall.Name),
-            TargetId = ResolveTargetId(parsed),
-            WaitMode = parsed.WaitMode,
-            StreamTopic = parsed.StreamTopic,
-            ActorId = parsed.ActorId,
-            ServiceId = parsed.ServiceId,
-            EndpointId = parsed.EndpointId,
+            TargetId = ResolveTargetId(target),
+            WaitMode = target.WaitMode,
+            StreamTopic = target.StreamTopic,
+            ActorId = target.ActorId,
+            ServiceId = target.ServiceId,
+            EndpointId = target.EndpointId,
             LlmRound = request.LlmRound,
             ObservedAt = Timestamp.FromDateTime(DateTime.UtcNow),
         };
@@ -122,17 +121,17 @@ public sealed class ChatRunActorAdapter : IChatRunActorPort
             ct);
     }
 
-    private static ParsedInvocationToolResult ParseObservationTarget(ChatRunToolCompletionRequest request)
+    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+    private static ChatRunToolCompletionRequest ResolveObservationTarget(ChatRunToolCompletionRequest request)
     {
-        var parsed = ParseInvocationToolResult(request.ToolExecutionResultJson);
-        if (parsed.WaitMode == ChatRunSubRunWaitMode.Complete && !string.IsNullOrWhiteSpace(parsed.RunId))
-            return parsed;
+        if (request.WaitMode == ChatRunSubRunWaitMode.Complete && !string.IsNullOrWhiteSpace(request.RunId))
+            return request;
 
         if (string.Equals(request.ToolCall.Name, "aevatar_invoke_gagent", StringComparison.Ordinal) &&
             !string.IsNullOrWhiteSpace(request.ToolCall.Id) &&
             TryReadString(request.ArgumentsJson, "actor_id", out var actorId))
         {
-            return parsed with
+            return request with
             {
                 RunId = request.ToolCall.Id.Trim(),
                 ActorId = actorId,
@@ -140,7 +139,7 @@ public sealed class ChatRunActorAdapter : IChatRunActorPort
             };
         }
 
-        return parsed;
+        return request;
     }
 
     public Task ObserveSubRunTerminalAsync(
@@ -234,30 +233,7 @@ public sealed class ChatRunActorAdapter : IChatRunActorPort
         }
     }
 
-    private static ParsedInvocationToolResult ParseInvocationToolResult(string? resultJson)
-    {
-        if (string.IsNullOrWhiteSpace(resultJson))
-            return ParsedInvocationToolResult.Empty;
-
-        try
-        {
-            using var document = JsonDocument.Parse(resultJson);
-            var root = document.RootElement;
-            return new ParsedInvocationToolResult(
-                ReadString(root, "run_id"),
-                ReadString(root, "stream_topic"),
-                ReadString(root, "actor_id"),
-                ReadString(root, "service_id"),
-                ReadString(root, "endpoint_id"),
-                ReadWait(root));
-        }
-        catch
-        {
-            return ParsedInvocationToolResult.Empty;
-        }
-    }
-
-    private static string ResolveTargetId(ParsedInvocationToolResult result) =>
+    private static string ResolveTargetId(ChatRunToolCompletionRequest result) =>
         FirstNonEmpty(result.ActorId, result.ServiceId, result.EndpointId);
 
     private static ChatRunSubRunTargetKind ResolveTargetKind(string toolName) =>
@@ -268,24 +244,6 @@ public sealed class ChatRunActorAdapter : IChatRunActorPort
             "aevatar_start_workflow" => ChatRunSubRunTargetKind.Workflow,
             _ => ChatRunSubRunTargetKind.Unspecified,
         };
-
-    private static ChatRunSubRunWaitMode ReadWait(JsonElement root)
-    {
-        var wait = ReadString(root, "wait");
-        return wait switch
-        {
-            "ack" => ChatRunSubRunWaitMode.Ack,
-            "complete" => ChatRunSubRunWaitMode.Complete,
-            _ => ChatRunSubRunWaitMode.Stream,
-        };
-    }
-
-    private static string ReadString(JsonElement root, string propertyName) =>
-        root.ValueKind == JsonValueKind.Object &&
-        root.TryGetProperty(propertyName, out var property) &&
-        property.ValueKind == JsonValueKind.String
-            ? property.GetString()?.Trim() ?? string.Empty
-            : string.Empty;
 
     private static bool TryReadString(
         string? json,
@@ -298,8 +256,13 @@ public sealed class ChatRunActorAdapter : IChatRunActorPort
 
         try
         {
-            using var document = JsonDocument.Parse(json);
-            value = ReadString(document.RootElement, propertyName);
+            var arguments = JsonParser.Default.Parse<Struct>(json);
+            if (arguments.Fields.TryGetValue(propertyName, out var property) &&
+                property.KindCase == Value.KindOneofCase.StringValue)
+            {
+                value = property.StringValue?.Trim() ?? string.Empty;
+            }
+
             return !string.IsNullOrWhiteSpace(value);
         }
         catch
@@ -335,21 +298,4 @@ public sealed class ChatRunActorAdapter : IChatRunActorPort
 
     private static string FirstNonEmpty(params string[] values) =>
         values.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value))?.Trim() ?? string.Empty;
-
-    private sealed record ParsedInvocationToolResult(
-        string RunId,
-        string StreamTopic,
-        string ActorId,
-        string ServiceId,
-        string EndpointId,
-        ChatRunSubRunWaitMode WaitMode)
-    {
-        public static ParsedInvocationToolResult Empty { get; } = new(
-            string.Empty,
-            string.Empty,
-            string.Empty,
-            string.Empty,
-            string.Empty,
-            ChatRunSubRunWaitMode.Unspecified);
-    }
 }

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/ChatRunActorAdapter.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/ChatRunActorAdapter.cs
@@ -121,7 +121,7 @@ public sealed class ChatRunActorAdapter : IChatRunActorPort
             ct);
     }
 
-    // Refactor (issue1298-first): Old: ResultJson string control parsing. New: typed scalar dispatch fields.
+    // Refactor (iter290/cluster001): Old pattern: actor observation target was inferred from ResultJson. New principle: actor observation uses typed run, target, and wait fields before dispatch.
     private static ChatRunToolCompletionRequest ResolveObservationTarget(ChatRunToolCompletionRequest request)
     {
         if (request.WaitMode == ChatRunSubRunWaitMode.Complete && !string.IsNullOrWhiteSpace(request.RunId))

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -7,6 +7,7 @@ using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.GAgentService.Abstractions.Responses;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.Presentation.AGUI;
@@ -158,6 +159,41 @@ public sealed class AevatarInvocationToolSourceTests
     }
 
     [Fact]
+    public async Task InvokeGAgentForChatRun_ShouldMapTypedControlFields()
+    {
+        var harness = new Harness();
+        var dispatcher = harness.CreateDispatcher();
+
+        using var _ = PushContext(callId: "call-gagent-typed");
+        var request = BuildChatRunRequest(
+            "response-gagent",
+            "call-gagent-typed-tool",
+            "aevatar_invoke_gagent",
+            """
+            {
+              "actor_id": "actor-1",
+              "payload": { "prompt": "hello" },
+              "wait": "stream"
+            }
+            """);
+        var result = await dispatcher.InvokeGAgentForChatRunAsync(request, request.ArgumentsJson);
+
+        result.ResponseId.Should().Be("response-gagent");
+        result.ToolCall.Should().BeSameAs(request.ToolCall);
+        result.ArgumentsJson.Should().Be(request.ArgumentsJson);
+        result.ToolExecutionResultJson.Should().NotBeNullOrWhiteSpace();
+        result.RunId.Should().Be("call-gagent-typed");
+        result.ScopeId.Should().Be("scope-1");
+        result.WaitMode.Should().Be(ChatRunSubRunWaitMode.Stream);
+        result.Status.Should().Be("streaming");
+        result.ActorId.Should().Be("actor-1");
+        result.StreamTopic.Should().Be("aevatar://actors/actor-1/runs/call-gagent-typed");
+        result.CompletionObserved.Should().BeFalse();
+        result.CompletionResultJson.Should().BeEmpty();
+        result.ErrorCode.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task InvokeGAgent_ShouldRejectActorIdOutsideCallerScope()
     {
         var harness = new Harness();
@@ -268,6 +304,43 @@ public sealed class AevatarInvocationToolSourceTests
         result.GetProperty("run_id").GetString().Should().Be("team-command");
         result.GetProperty("service_id").GetString().Should().Be("service-1");
         result.GetProperty("stream_topic").GetString().Should().Be("aevatar://scopes/scope-1/services/service-1/runs/team-command");
+    }
+
+    [Fact]
+    public async Task InvokeTeamForChatRun_ShouldMapTypedCompletionControlFields()
+    {
+        var harness = new Harness();
+        var dispatcher = harness.CreateDispatcher();
+
+        using var _ = PushContext(callId: "call-team-typed");
+        var request = BuildChatRunRequest(
+            "response-team",
+            "call-team-typed-tool",
+            "aevatar_invoke_team",
+            """
+            {
+              "team_id": "team-1",
+              "endpoint_id": "entry",
+              "payload": { "prompt": "go" },
+              "wait": "complete"
+            }
+            """);
+        var result = await dispatcher.InvokeTeamForChatRunAsync(request, request.ArgumentsJson);
+
+        result.ResponseId.Should().Be("response-team");
+        result.ToolCall.Should().BeSameAs(request.ToolCall);
+        result.ArgumentsJson.Should().Be(request.ArgumentsJson);
+        result.ToolExecutionResultJson.Should().NotBeNullOrWhiteSpace();
+        result.RunId.Should().Be("team-command");
+        result.ScopeId.Should().Be("scope-1");
+        result.WaitMode.Should().Be(ChatRunSubRunWaitMode.Complete);
+        result.Status.Should().Be(GAgentDraftRunCompletionStatus.RunFinished.ToString());
+        result.ActorId.Should().Be("team-actor");
+        result.ServiceId.Should().Be("service-1");
+        result.EndpointId.Should().Be("entry");
+        result.CompletionObserved.Should().BeTrue();
+        result.CompletionResultJson.Should().Contain("\"completion_observed\":true");
+        result.ErrorCode.Should().BeEmpty();
     }
 
     [Fact]
@@ -424,6 +497,105 @@ public sealed class AevatarInvocationToolSourceTests
         result.GetProperty("run_id").GetString().Should().Be("wf-command");
         result.GetProperty("actor_id").GetString().Should().Be("workflow-actor");
         result.GetProperty("stream_topic").GetString().Should().Be("aevatar://actors/workflow-actor/runs/wf-command");
+    }
+
+    [Fact]
+    public async Task StartWorkflowForChatRun_ShouldMapTypedControlFields()
+    {
+        var harness = new Harness();
+        harness.WorkflowDispatch.Result = CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>
+            .Success(new WorkflowChatRunAcceptedReceipt("workflow-actor", "wf-main", "wf-command", "wf-correlation"));
+        var dispatcher = harness.CreateDispatcher();
+
+        using var _ = PushContext(callId: "call-workflow-typed");
+        var request = BuildChatRunRequest(
+            "response-workflow",
+            "call-workflow-typed-tool",
+            "aevatar_start_workflow",
+            """
+            {
+              "workflow_id": "wf-main",
+              "inputs": { "prompt": "run workflow" },
+              "wait": "stream"
+            }
+            """);
+        var result = await dispatcher.StartWorkflowForChatRunAsync(request, request.ArgumentsJson);
+
+        result.ResponseId.Should().Be("response-workflow");
+        result.ToolCall.Should().BeSameAs(request.ToolCall);
+        result.ArgumentsJson.Should().Be(request.ArgumentsJson);
+        result.ToolExecutionResultJson.Should().NotBeNullOrWhiteSpace();
+        result.RunId.Should().Be("wf-command");
+        result.ScopeId.Should().Be("scope-1");
+        result.WaitMode.Should().Be(ChatRunSubRunWaitMode.Stream);
+        result.Status.Should().Be("streaming");
+        result.ActorId.Should().Be("workflow-actor");
+        result.StreamTopic.Should().Be("aevatar://actors/workflow-actor/runs/wf-command");
+        result.CompletionObserved.Should().BeFalse();
+        result.CompletionResultJson.Should().BeEmpty();
+        result.ErrorCode.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("aevatar_invoke_gagent")]
+    [InlineData("aevatar_invoke_team")]
+    [InlineData("aevatar_start_workflow")]
+    public async Task InvocationTools_ShouldImplementChatRunWrapperAndPreserveRequestFields(string toolName)
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync(toolName);
+        var chatRunTool = tool.Should().BeAssignableTo<IAevatarInvocationChatRunTool>().Subject;
+        var argumentsJson = BuildSuccessfulArguments(toolName);
+        if (toolName == "aevatar_start_workflow")
+        {
+            harness.WorkflowDispatch.Result = CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>
+                .Success(new WorkflowChatRunAcceptedReceipt("workflow-actor", "wf-main", "workflow-command", "workflow-correlation"));
+        }
+
+        using var _ = PushContext(callId: $"call-wrapper-{toolName}");
+        var request = BuildChatRunRequest(
+            $"response-{toolName}",
+            $"tool-call-{toolName}",
+            toolName,
+            argumentsJson);
+        var result = await chatRunTool.ExecuteForChatRunAsync(request);
+
+        result.ResponseId.Should().Be(request.ResponseId);
+        result.ModelName.Should().Be(request.ModelName);
+        result.Messages.Should().BeSameAs(request.Messages);
+        result.ToolCall.Should().BeSameAs(request.ToolCall);
+        result.ArgumentsJson.Should().Be(argumentsJson);
+        result.LlmRound.Should().Be(request.LlmRound);
+        result.ToolExecutionResultJson.Should().NotBeNullOrWhiteSpace();
+        result.ErrorCode.Should().BeEmpty();
+        result.RunId.Should().NotBeNullOrWhiteSpace();
+        result.ScopeId.Should().Be("scope-1");
+        result.WaitMode.Should().Be(ChatRunSubRunWaitMode.Stream);
+    }
+
+    [Fact]
+    public async Task InvokeGAgentForChatRun_WhenValidationFails_ShouldMapTypedErrorCodeAndPreserveRequest()
+    {
+        var harness = new Harness();
+        var dispatcher = harness.CreateDispatcher();
+
+        using var _ = PushContext(callId: "call-gagent-invalid");
+        var request = BuildChatRunRequest(
+            "response-invalid",
+            "call-invalid-tool",
+            "aevatar_invoke_gagent",
+            """{"actor_id":"actor-1"}""");
+        var result = await dispatcher.InvokeGAgentForChatRunAsync(request, request.ArgumentsJson);
+
+        result.ResponseId.Should().Be("response-invalid");
+        result.ToolCall.Should().BeSameAs(request.ToolCall);
+        result.ArgumentsJson.Should().Be(request.ArgumentsJson);
+        result.ToolExecutionResultJson.Should().NotBeNullOrWhiteSpace();
+        result.ErrorCode.Should().Be("invalid_arguments");
+        result.RunId.Should().BeEmpty();
+        result.ScopeId.Should().BeEmpty();
+        result.WaitMode.Should().Be(ChatRunSubRunWaitMode.Unspecified);
+        result.CompletionObserved.Should().BeFalse();
     }
 
     [Fact]
@@ -709,6 +881,56 @@ public sealed class AevatarInvocationToolSourceTests
             {
                 ["external"] = "value",
             }));
+
+    private static ChatRunToolCompletionRequest BuildChatRunRequest(
+        string responseId,
+        string toolCallId,
+        string toolName,
+        string argumentsJson)
+    {
+        var toolCall = new ToolCall
+        {
+            Id = toolCallId,
+            Name = toolName,
+            ArgumentsJson = argumentsJson,
+        };
+        return new ChatRunToolCompletionRequest(
+            responseId,
+            "model-test",
+            [ChatMessage.User("run tool")],
+            toolCall,
+            argumentsJson,
+            string.Empty,
+            3);
+    }
+
+    private static string BuildSuccessfulArguments(string toolName) =>
+        toolName switch
+        {
+            "aevatar_invoke_gagent" => """
+                {
+                  "actor_id": "actor-1",
+                  "payload": { "prompt": "hello" },
+                  "wait": "stream"
+                }
+                """,
+            "aevatar_invoke_team" => """
+                {
+                  "team_id": "team-1",
+                  "endpoint_id": "entry",
+                  "payload": { "prompt": "go" },
+                  "wait": "stream"
+                }
+                """,
+            "aevatar_start_workflow" => """
+                {
+                  "workflow_id": "wf-main",
+                  "inputs": { "prompt": "run workflow" },
+                  "wait": "stream"
+                }
+                """,
+            _ => throw new ArgumentOutOfRangeException(nameof(toolName), toolName, null),
+        };
 
     private static ServiceRunSnapshot BuildServiceRun(
         string scopeId,

--- a/test/Aevatar.GAgentService.Tests/Application/ChatRunToolCompletionCoordinatorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ChatRunToolCompletionCoordinatorTests.cs
@@ -30,20 +30,23 @@ public sealed class ChatRunToolCompletionCoordinatorTests
             BuildRequest(),
             toolCall,
             toolCall.ArgumentsJson,
-            (_, _) => Task.FromResult("""
-                {
-                  "run_id": "team-command",
-                  "status": "RunFinished",
-                  "result": {
-                    "completion_status": "RunFinished",
-                    "completion_observed": true,
-                    "events": [{ "type": "run_finished" }]
-                  },
-                  "service_id": "service-1",
-                  "endpoint_id": "entry",
-                  "wait": "complete"
-                }
-                """),
+            (request, _) => Task.FromResult(request with
+            {
+                ToolExecutionResultJson = """{"opaque":"llm-facing"}""",
+                RunId = "team-command",
+                Status = "RunFinished",
+                CompletionResultJson = """
+                    {
+                      "completion_status": "RunFinished",
+                      "completion_observed": true,
+                      "events": [{ "type": "run_finished" }]
+                    }
+                    """,
+                ServiceId = "service-1",
+                EndpointId = "entry",
+                WaitMode = ChatRunSubRunWaitMode.Complete,
+                CompletionObserved = true,
+            }),
             llmRound: 1);
 
         using var resultDocument = System.Text.Json.JsonDocument.Parse(result);
@@ -80,15 +83,15 @@ public sealed class ChatRunToolCompletionCoordinatorTests
             BuildRequest(),
             toolCall,
             toolCall.ArgumentsJson,
-            (_, _) => Task.FromResult("""
-                {
-                  "run_id": "wf-command",
-                  "status": "streaming",
-                  "stream_topic": "aevatar://actors/workflow-actor/runs/wf-command",
-                  "actor_id": "workflow-actor",
-                  "wait": "complete"
-                }
-                """),
+            (request, _) => Task.FromResult(request with
+            {
+                ToolExecutionResultJson = """{"opaque":"workflow-dispatch"}""",
+                RunId = "wf-command",
+                Status = "streaming",
+                StreamTopic = "aevatar://actors/workflow-actor/runs/wf-command",
+                ActorId = "workflow-actor",
+                WaitMode = ChatRunSubRunWaitMode.Complete,
+            }),
             llmRound: 1);
 
         result.Should().Contain("completion_not_observed");
@@ -128,15 +131,15 @@ public sealed class ChatRunToolCompletionCoordinatorTests
             BuildRequest(),
             toolCall,
             toolCall.ArgumentsJson,
-            (_, _) => Task.FromResult("""
-                {
-                  "run_id": "call_gagent_name",
-                  "status": "streaming",
-                  "stream_topic": "aevatar://actors/actor-from-name/runs/call_gagent_name",
-                  "actor_id": "actor-from-name",
-                  "wait": "complete"
-                }
-                """),
+            (request, _) => Task.FromResult(request with
+            {
+                ToolExecutionResultJson = """{"opaque":"gagent-dispatch"}""",
+                RunId = "call_gagent_name",
+                Status = "streaming",
+                StreamTopic = "aevatar://actors/actor-from-name/runs/call_gagent_name",
+                ActorId = "actor-from-name",
+                WaitMode = ChatRunSubRunWaitMode.Complete,
+            }),
             llmRound: 1);
 
         result.Should().Contain("resolved actor completed");
@@ -144,7 +147,8 @@ public sealed class ChatRunToolCompletionCoordinatorTests
         harness.TerminalQuery.LastCorrelationId.Should().Be("call_gagent_name");
         harness.ChatRunPort.ObservationRequests.Should().HaveCount(2);
         harness.ChatRunPort.ObservationRequests[0].ToolExecutionResultJson.Should().BeEmpty();
-        harness.ChatRunPort.ObservationRequests[1].ToolExecutionResultJson.Should().Contain("actor-from-name");
+        harness.ChatRunPort.ObservationRequests[1].ToolExecutionResultJson.Should().Be("""{"opaque":"gagent-dispatch"}""");
+        harness.ChatRunPort.ObservationRequests[1].ActorId.Should().Be("actor-from-name");
         harness.ChatRunPort.ObservedTerminals.Should().ContainSingle().Which.ActorId.Should().Be("actor-from-name");
     }
 
@@ -229,6 +233,11 @@ public sealed class ChatRunToolCompletionCoordinatorTests
                     ToolName = request.ToolCall.Name,
                     ResultJson = observed.ResultJson,
                     LlmRound = request.LlmRound,
+                    Status = observed.Status,
+                    ActorId = observed.ActorId,
+                    ServiceId = observed.ServiceId,
+                    EndpointId = observed.EndpointId,
+                    CompletionObserved = observed.CompletionObserved,
                 });
         }
 

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesCompletionApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesCompletionApplicationServiceTests.cs
@@ -1,0 +1,353 @@
+using System.Runtime.CompilerServices;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.Foundation.Abstractions.Streaming;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.GAgentService.Abstractions.Responses;
+using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.GAgentService.Application.Responses;
+using Aevatar.Workflow.Application.Abstractions.Queries;
+using FluentAssertions;
+using Google.Protobuf;
+
+namespace Aevatar.GAgentService.Tests.Application;
+
+public sealed class ResponsesCompletionApplicationServiceTests
+{
+    [Fact]
+    public async Task CollectAsync_WaitCompleteInvocationTool_ShouldRouteThroughChatRunTypedExecutor()
+    {
+        var harness = new CompletionHarness();
+        var service = new ResponsesCompletionApplicationService(harness.CreateCoordinator());
+        var tool = new TypedInvocationTool();
+        var provider = new WaitCompleteInvocationProvider();
+
+        var result = await service.CollectAsync(
+            provider,
+            BuildRequest(tool),
+            new Dictionary<string, string>(),
+            BuildClassification(tool));
+
+        result.Text.Should().Be("typed completion consumed");
+        provider.SecondRoundToolResult.Should().Contain("\"typed\":true");
+        tool.TypedExecuteCount.Should().Be(1);
+        tool.LegacyExecuteCount.Should().Be(0);
+        harness.ChatRunPort.SubmittedToolCalls.Should().ContainSingle().Which.ToolExecutionResultJson
+            .Should().Be("""{"dispatch":"typed"}""");
+    }
+
+    [Fact]
+    public async Task StreamAsync_WaitCompleteInvocationTool_ShouldRouteThroughChatRunTypedExecutor()
+    {
+        var harness = new CompletionHarness();
+        var service = new ResponsesCompletionApplicationService(harness.CreateCoordinator());
+        var tool = new TypedInvocationTool();
+        var provider = new WaitCompleteInvocationProvider();
+        var textDeltas = new List<string>();
+
+        var result = await service.StreamAsync(
+            provider,
+            BuildRequest(tool),
+            new Dictionary<string, string>(),
+            BuildClassification(tool),
+            (delta, _) =>
+            {
+                textDeltas.Add(delta);
+                return ValueTask.CompletedTask;
+            });
+
+        result.Text.Should().Be("typed completion consumed");
+        textDeltas.Should().Equal("typed completion consumed");
+        provider.SecondRoundToolResult.Should().Contain("\"typed\":true");
+        tool.TypedExecuteCount.Should().Be(1);
+        tool.LegacyExecuteCount.Should().Be(0);
+        harness.ChatRunPort.SubmittedToolCalls.Should().ContainSingle().Which.ToolExecutionResultJson
+            .Should().Be("""{"dispatch":"typed"}""");
+    }
+
+    private static LLMRequest BuildRequest(IAgentTool tool) =>
+        new()
+        {
+            Messages = [ChatMessage.User("run local invocation")],
+            RequestId = "request-1",
+            CallerContext = new LLMRequestCallerContext("scope-1", "owner-1", "resp_1"),
+            Model = "test-model",
+            Tools = [tool],
+        };
+
+    private static ResponsesToolClassification BuildClassification(IAgentTool tool) =>
+        new([], [tool], [tool.Name], []);
+
+    private sealed class WaitCompleteInvocationProvider : ILLMProvider
+    {
+        private int _round;
+
+        public string Name => "test";
+
+        public string? SecondRoundToolResult { get; private set; }
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            await Task.Yield();
+            _round++;
+            if (_round == 1)
+            {
+                yield return new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "call_team",
+                        Name = "aevatar_invoke_team",
+                        ArgumentsJson = """{"team_id":"team-1","endpoint_id":"entry","wait":"complete"}""",
+                    },
+                };
+                yield return new LLMStreamChunk { IsLast = true, FinishReason = "tool_calls" };
+                yield break;
+            }
+
+            SecondRoundToolResult = request.Messages.Last(message => message.Role == "tool").Content;
+            yield return new LLMStreamChunk
+            {
+                DeltaContent = "typed completion consumed",
+                IsLast = true,
+                FinishReason = "stop",
+            };
+        }
+    }
+
+    private sealed class TypedInvocationTool : IAgentTool, IChatRunToolCompletionControlExecutor
+    {
+        public string Name => "aevatar_invoke_team";
+
+        public string Description => "Invoke a team.";
+
+        public string ParametersSchema => """{"type":"object","properties":{}}""";
+
+        public int TypedExecuteCount { get; private set; }
+
+        public int LegacyExecuteCount { get; private set; }
+
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+        {
+            LegacyExecuteCount++;
+            return Task.FromResult("""{"legacy":true}""");
+        }
+
+        public Task<ChatRunToolCompletionRequest> ExecuteForChatRunAsync(
+            ChatRunToolCompletionRequest request,
+            CancellationToken ct = default)
+        {
+            TypedExecuteCount++;
+            return Task.FromResult(request with
+            {
+                ToolExecutionResultJson = """{"dispatch":"typed"}""",
+                RunId = "team-command",
+                Status = "RunFinished",
+                CompletionResultJson = """{"typed":true,"status":"RunFinished"}""",
+                ServiceId = "service-1",
+                EndpointId = "entry",
+                ScopeId = "scope-1",
+                WaitMode = ChatRunSubRunWaitMode.Complete,
+                CompletionObserved = true,
+            });
+        }
+    }
+
+    private sealed class CompletionHarness
+    {
+        private readonly RecordingSubscriptionProvider _subscriptionProvider = new();
+
+        public CompletionHarness()
+        {
+            ChatRunPort = new RecordingChatRunActorPort(_subscriptionProvider);
+        }
+
+        public RecordingChatRunActorPort ChatRunPort { get; }
+
+        public ChatRunToolCompletionCoordinator CreateCoordinator() =>
+            new(
+                ChatRunPort,
+                _subscriptionProvider,
+                new EmptyTerminalQueryPort(),
+                new EmptyServiceRunQueryPort(),
+                new EmptyWorkflowQueryService());
+    }
+
+    private sealed class RecordingChatRunActorPort(RecordingSubscriptionProvider subscriptionProvider)
+        : IChatRunActorPort
+    {
+        public ChatRunStartRequest? StartRequest { get; private set; }
+
+        public List<ChatRunToolCompletionRequest> SubmittedToolCalls { get; } = [];
+
+        public Task<string> StartAsync(ChatRunStartRequest request, CancellationToken ct = default)
+        {
+            StartRequest = request;
+            return Task.FromResult("chat-run:resp_1");
+        }
+
+        public Task SubmitToolCallAsync(
+            string chatRunActorId,
+            ChatRunToolCompletionRequest request,
+            CancellationToken ct = default)
+        {
+            SubmittedToolCalls.Add(request);
+            return Task.CompletedTask;
+        }
+
+        public Task BeginSubRunObservationAsync(
+            string chatRunActorId,
+            ChatRunToolCompletionRequest request,
+            CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task ObserveSubRunTerminalAsync(
+            string chatRunActorId,
+            ChatRunSubRunTerminalObserved observed,
+            CancellationToken ct = default) =>
+            subscriptionProvider.PublishReadyAsync(
+                chatRunActorId,
+                new ChatRunToolResultReady
+                {
+                    ResponseId = StartRequest?.ResponseId ?? string.Empty,
+                    RunId = observed.RunId,
+                    CallerToolCallId = SubmittedToolCalls.Single().ToolCall.Id,
+                    ToolName = SubmittedToolCalls.Single().ToolCall.Name,
+                    ResultJson = observed.ResultJson,
+                    LlmRound = SubmittedToolCalls.Single().LlmRound,
+                    Status = observed.Status,
+                    ServiceId = observed.ServiceId,
+                    EndpointId = observed.EndpointId,
+                    CompletionObserved = observed.CompletionObserved,
+                });
+
+        public Task TerminateAsync(
+            string chatRunActorId,
+            string reason,
+            CancellationToken ct = default) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class RecordingSubscriptionProvider : IActorEventSubscriptionProvider
+    {
+        private Func<ChatRunToolResultReady, Task>? _handler;
+
+        public Task<IAsyncDisposable> SubscribeAsync<TMessage>(
+            string actorId,
+            Func<TMessage, Task> handler,
+            CancellationToken ct = default)
+            where TMessage : class, IMessage, new()
+        {
+            if (typeof(TMessage) != typeof(ChatRunToolResultReady))
+                throw new NotSupportedException(typeof(TMessage).FullName);
+
+            _handler = ready => handler((TMessage)(object)ready);
+            return Task.FromResult<IAsyncDisposable>(new Subscription(this));
+        }
+
+        public Task PublishReadyAsync(string actorId, ChatRunToolResultReady ready) =>
+            _handler?.Invoke(ready) ?? Task.CompletedTask;
+
+        private sealed class Subscription(RecordingSubscriptionProvider owner) : IAsyncDisposable
+        {
+            public ValueTask DisposeAsync()
+            {
+                owner._handler = null;
+                return ValueTask.CompletedTask;
+            }
+        }
+    }
+
+    private sealed class EmptyServiceRunQueryPort : IServiceRunQueryPort
+    {
+        public Task<IReadOnlyList<ServiceRunSnapshot>> ListAsync(
+            ServiceRunQuery query,
+            CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<ServiceRunSnapshot>>([]);
+
+        public Task<ServiceRunSnapshot?> GetByRunIdAsync(
+            string scopeId,
+            string serviceId,
+            string runId,
+            CancellationToken ct = default) =>
+            Task.FromResult<ServiceRunSnapshot?>(null);
+
+        public Task<ServiceRunSnapshot?> GetByCommandIdAsync(
+            string scopeId,
+            string serviceId,
+            string commandId,
+            CancellationToken ct = default) =>
+            Task.FromResult<ServiceRunSnapshot?>(null);
+    }
+
+    private sealed class EmptyTerminalQueryPort : IGAgentRunTerminalQueryPort
+    {
+        public Task<GAgentRunTerminalSnapshot?> GetByCorrelationIdAsync(
+            string actorId,
+            string correlationId,
+            CancellationToken ct = default) =>
+            Task.FromResult<GAgentRunTerminalSnapshot?>(null);
+
+        public Task<GAgentRunTerminalSnapshot?> GetBySessionIdAsync(
+            string actorId,
+            string sessionId,
+            CancellationToken ct = default) =>
+            Task.FromResult<GAgentRunTerminalSnapshot?>(null);
+    }
+
+    private sealed class EmptyWorkflowQueryService : IWorkflowExecutionQueryApplicationService
+    {
+        public bool WorkflowActorCurrentStateQueryEnabled => true;
+
+        public Task<IReadOnlyList<WorkflowAgentSummary>> ListAgentsAsync(CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<WorkflowAgentSummary>>([]);
+
+        public IReadOnlyList<string> ListWorkflows() => [];
+
+        public Task<IReadOnlyList<WorkflowCatalogItem>> ListWorkflowCatalogAsync(CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<WorkflowCatalogItem>>([]);
+
+        public Task<WorkflowCatalogItemDetail?> GetWorkflowDetailAsync(
+            string workflowName,
+            CancellationToken ct = default) =>
+            Task.FromResult<WorkflowCatalogItemDetail?>(null);
+
+        public Task<WorkflowCapabilitiesDocument> GetCapabilitiesAsync(CancellationToken ct = default) =>
+            Task.FromResult(new WorkflowCapabilitiesDocument());
+
+        public Task<WorkflowActorSnapshot?> GetWorkflowActorCurrentStateAsync(
+            string actorId,
+            CancellationToken ct = default) =>
+            Task.FromResult<WorkflowActorSnapshot?>(null);
+
+        public Task<WorkflowRunReport?> GetWorkflowRunReportArtifactAsync(
+            string workflowRunId,
+            CancellationToken ct = default) =>
+            Task.FromResult<WorkflowRunReport?>(null);
+
+        public Task<IReadOnlyList<WorkflowRunTimelineExportItem>> ListWorkflowRunTimelineExportAsync(
+            string workflowRunId,
+            int take = 200,
+            CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<WorkflowRunTimelineExportItem>>([]);
+
+        public Task<IReadOnlyList<WorkflowRunGraphExportEdge>> ListWorkflowRunGraphExportEdgesAsync(
+            string workflowRunId,
+            int take = 200,
+            WorkflowRunGraphExportQueryOptions? options = null,
+            CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<WorkflowRunGraphExportEdge>>([]);
+
+        public Task<WorkflowRunGraphExportSubgraph> GetWorkflowRunGraphExportSubgraphAsync(
+            string workflowRunId,
+            int depth = 2,
+            int take = 200,
+            WorkflowRunGraphExportQueryOptions? options = null,
+            CancellationToken ct = default) =>
+            Task.FromResult(new WorkflowRunGraphExportSubgraph());
+    }
+}

--- a/test/Aevatar.GAgentService.Tests/Core/ChatRunActorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ChatRunActorTests.cs
@@ -1,3 +1,4 @@
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Streaming;
@@ -5,6 +6,7 @@ using Aevatar.Foundation.Runtime.Implementations.Local.DependencyInjection;
 using Aevatar.Foundation.Runtime.Persistence;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Responses;
+using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.GAgentService.Core.GAgents;
 using Aevatar.GAgentService.Infrastructure.Adapters;
 using Aevatar.GAgentService.Tests.TestSupport;
@@ -320,15 +322,65 @@ public sealed class ChatRunActorTests
         ((ChatRunActor)actor!.Agent).State.ActiveSubRunSubscriptions.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task ForwardedCommittedCompletion_ShouldPublishObservedToolResultReady()
+    {
+        var eventStore = new InMemoryEventStore();
+        var actor = await StartedActorAsync("resp_forwarded_completion", eventStore);
+
+        await actor.HandleSubmitToolCallAsync(BuildSubmit(
+            toolCallId: "call_forwarded",
+            runId: "run_forwarded",
+            waitMode: ChatRunSubRunWaitMode.Complete,
+            streamTopic: "aevatar://actors/role-actor-1/runs/run_forwarded",
+            resultJson: """{"run_id":"run_forwarded","actor_id":"role-actor-1","wait":"complete"}""",
+            actorId: "role-actor-1",
+            llmRound: 3));
+
+        await actor.HandleObservedEnvelopeAsync(BuildForwardedCommittedCompletionEnvelope(
+            sourceActorId: "role-actor-1",
+            targetActorId: actor.Id,
+            runId: "run_forwarded",
+            content: "forwarded done"));
+
+        actor.State.ActiveSubRunSubscriptions.Should().BeEmpty();
+        var folded = actor.State.ToolCallHistory.Should().ContainSingle().Subject;
+        folded.RunId.Should().Be("run_forwarded");
+        folded.ResultJson.Should().Contain("\"content\":\"forwarded done\"");
+
+        var foldedEvent = (await eventStore.GetEventsAsync(actor.Id))
+            .Select(static evt => evt.EventData)
+            .Where(static payload => payload.Is(ChatRunSubRunTerminalFoldedEvent.Descriptor))
+            .Select(static payload => payload.Unpack<ChatRunSubRunTerminalFoldedEvent>())
+            .Should()
+            .ContainSingle()
+            .Subject;
+        foldedEvent.Status.Should().Be(GAgentRunTerminalStatus.TextMessageCompleted.ToString());
+        foldedEvent.ActorId.Should().Be("role-actor-1");
+        foldedEvent.CompletionObserved.Should().BeTrue();
+    }
+
     private static ChatRunActor CreateActor(string responseId) =>
+        CreateActor(responseId, new InMemoryEventStore());
+
+    private static ChatRunActor CreateActor(string responseId, InMemoryEventStore eventStore) =>
         GAgentServiceTestKit.CreateStatefulAgent<ChatRunActor, ChatRunState>(
-            new InMemoryEventStore(),
+            eventStore,
             "chat-run-" + responseId,
             static () => new ChatRunActor());
 
     private static async Task<ChatRunActor> StartedActorAsync(string responseId)
     {
         var actor = CreateActor(responseId);
+        await StartActorAsync(actor, responseId);
+        return actor;
+    }
+
+    private static async Task<ChatRunActor> StartedActorAsync(
+        string responseId,
+        InMemoryEventStore eventStore)
+    {
+        var actor = CreateActor(responseId, eventStore);
         await StartActorAsync(actor, responseId);
         return actor;
     }
@@ -368,13 +420,14 @@ public sealed class ChatRunActorTests
         ChatRunSubRunWaitMode waitMode,
         string streamTopic = "",
         string resultJson = "",
+        string actorId = "actor-1",
         int llmRound = 1)
     {
         streamTopic = string.IsNullOrWhiteSpace(streamTopic)
-            ? $"aevatar://actors/actor-1/runs/{runId}"
+            ? $"aevatar://actors/{actorId}/runs/{runId}"
             : streamTopic;
         resultJson = string.IsNullOrWhiteSpace(resultJson)
-            ? $$"""{"run_id":"{{runId}}","actor_id":"actor-1","stream_topic":"{{streamTopic}}","wait":"{{WaitModeValue(waitMode)}}"}"""
+            ? $$"""{"run_id":"{{runId}}","actor_id":"{{actorId}}","stream_topic":"{{streamTopic}}","wait":"{{WaitModeValue(waitMode)}}"}"""
             : resultJson;
         return new SubmitChatRunToolCallRequested
         {
@@ -384,10 +437,10 @@ public sealed class ChatRunActorTests
             ResultJson = resultJson,
             RunId = runId,
             TargetKind = ChatRunSubRunTargetKind.Gagent,
-            TargetId = "actor-1",
+            TargetId = actorId,
             WaitMode = waitMode,
             StreamTopic = streamTopic,
-            ActorId = "actor-1",
+            ActorId = actorId,
             LlmRound = llmRound,
         };
     }
@@ -428,6 +481,44 @@ public sealed class ChatRunActorTests
             ChatRunSubRunWaitMode.Complete => "complete",
             _ => "stream",
         };
+
+    private static EventEnvelope BuildForwardedCommittedCompletionEnvelope(
+        string sourceActorId,
+        string targetActorId,
+        string runId,
+        string content)
+    {
+        var original = new EventEnvelope
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(new CommittedStateEventPublished
+            {
+                StateEvent = new StateEvent
+                {
+                    AgentId = sourceActorId,
+                    EventId = Guid.NewGuid().ToString("N"),
+                    EventType = RoleChatSessionCompletedEvent.Descriptor.FullName,
+                    Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+                    Version = 7,
+                    EventData = Any.Pack(new RoleChatSessionCompletedEvent
+                    {
+                        SessionId = runId,
+                        Content = content,
+                        ContentEmitted = true,
+                        RoleId = sourceActorId,
+                    }),
+                },
+            }),
+            Route = EnvelopeRouteSemantics.CreateObserverPublication(sourceActorId),
+        };
+
+        return StreamForwardingRules.BuildForwardedEnvelope(
+            original,
+            sourceActorId,
+            targetActorId,
+            StreamForwardingMode.HandleThenForward);
+    }
 
     private sealed class RecordingStreamProvider : IStreamProvider
     {

--- a/test/Aevatar.GAgentService.Tests/Core/ChatRunActorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ChatRunActorTests.cs
@@ -293,18 +293,28 @@ public sealed class ChatRunActorTests
                     ArgumentsJson = """{"actor_id":"actor-1","wait":"complete"}""",
                 },
                 """{"actor_id":"actor-1","wait":"complete"}""",
-                """{"run_id":"run_publish","actor_id":"actor-1","stream_topic":"aevatar://actors/actor-1/runs/run_publish","wait":"complete"}""",
-                1));
+                """{"opaque":"tool-output"}""",
+                1,
+                RunId: "run_publish",
+                StreamTopic: "aevatar://actors/actor-1/runs/run_publish",
+                ActorId: "actor-1",
+                WaitMode: ChatRunSubRunWaitMode.Complete));
         await port.ObserveSubRunTerminalAsync(actorId, new ChatRunSubRunTerminalObserved
         {
             RunId = "run_publish",
+            Status = "RunFinished",
             ResultJson = """{"run_id":"run_publish","content":"published"}""",
+            ActorId = "actor-1",
+            CompletionObserved = true,
         });
 
         var published = await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
         published.RunId.Should().Be("run_publish");
         published.CallerToolCallId.Should().Be("call_publish");
         published.ResultJson.Should().Contain("published");
+        published.Status.Should().Be("RunFinished");
+        published.ActorId.Should().Be("actor-1");
+        published.CompletionObserved.Should().BeTrue();
 
         var actor = await runtime.GetAsync(actorId);
         ((ChatRunActor)actor!.Agent).State.ActiveSubRunSubscriptions.Should().BeEmpty();


### PR DESCRIPTION
## 摘要

源自 #1296 Phase 9 r1 `META_JUDGE_DONE:split` 的 first-slice。

保留 ChatRun actor / coordinator / wait=complete 能力;`IChatRunActorPort` / request / command / event / ready payload 用 typed scalar fields 承载 dispatch / observation control facts;删除 `ChatRunActorAdapter.ParseInvocationToolResult`、`ChatRunToolCompletionCoordinator.ParseDispatchResult` 等重复 JSON control parser。

## 变更

- `src/Aevatar.AI.ToolProviders.AevatarInvocation/*`(+200/-150):typed dispatch fields,删除 JSON control parsers
- `src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto`(+5):typed dispatch result fields
- `src/platform/Aevatar.GAgentService.Abstractions/Responses/ChatRunActorPorts.cs`(+30/-20):typed scalar control fields
- (other 7 files): focused tests + adapter / coordinator typed control read

## No-new-core 边界

- 无新 actor / pipeline phase
- 无 `docs/canon/*` 改动
- 统一 typed value object + persistent event migration 留 #1299-later

## 验证

- `dotnet build aevatar.slnx --nologo` 通过
- `dotnet test aevatar.slnx --nologo --no-build` 通过

closes #1298

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧