### PR TITLE
#1307 first slice: 清理 spawn_with_banner.py 残留 reference

### DIFF
--- a/.claude/skills/codex-refactor-loop/scripts/post_banner.py
+++ b/.claude/skills/codex-refactor-loop/scripts/post_banner.py
@@ -2,9 +2,9 @@
 """
 post_banner.py — 只 post GitHub status banner,不 spawn codex
 
-per Auric 2026-05-21 "codex 可以执行得很好,为什么你做不到":
-spawn_with_banner.py 的 detached Popen 模式让 harness 看不见 codex,导致
-codex done 后 controller 不知道,monitor 60s 报警 zero_streak 涨 13 没人理。
+per 2026-05-21 incident review:
+detached Popen spawn made codex invisible to the harness, so the controller
+missed codex completion and the 60s monitor reported zero_streak=13.
 
 新架构:**两步**
 1. 此脚本(blocking,几秒)post banner 到 issue/PR


### PR DESCRIPTION
## 摘要

源自 #491 Phase 9 r1 split first-slice(no-new-core delete)。

`spawn_with_banner.py` 已在 #1242 删除,但 `post_banner.py` 仍含 dead reference,本 PR 清理:

- `.claude/skills/codex-refactor-loop/scripts/post_banner.py`:1 file changed, 3 +/-3

## No-new-core 边界

- 无新增 actor / proto field / envelope kind / pipeline phase
- 无 docs/canon/* 改动
- 仅删除残留 dead code reference;SKILL.md "## Codex 调用方式" 节里的废止说明保留

## 验证

skill-only 改动,无 .NET 编译影响;skill 文件不进入 .csproj。

closes #1307

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧