### PR TITLE
#1310 first slice: actor evolution canon matrix(no-new-core docs)

### DIFF
--- a/docs/adr/0020-actor-state-version-placement.md
+++ b/docs/adr/0020-actor-state-version-placement.md
@@ -14,11 +14,12 @@ Accepted (Phase 1 landed alongside ADR 0019). Co-issued with issues
 
 ## Context
 
-Issue #500 establishes the matrix of actor evolution patterns and identifies
-within-actor state migration as one cell of that matrix. The original
-sketch placed a `state_version` field directly on each business state proto
-("each agent's state proto carries its own schema version"). That coupling
-is wrong:
+The actor evolution matrix in
+`docs/canon/event-sourcing.md#22-actor-evolution-matrix` identifies
+within-actor state migration as one cell of a broader evolution decision.
+The original sketch placed a `state_version` field directly on each
+business state proto ("each agent's state proto carries its own schema
+version"). That coupling is wrong:
 
 - **Business state protos should be pure domain artifacts.** Adding a
   runtime concern (schema version) to every business state proto bleeds
@@ -56,9 +57,9 @@ follows the Protobuf-first mandate.
 Business state protos themselves stay pure domain artifacts and never
 carry a version field.
 
-### Consumer contract (issue #500's lazy migration)
+### Consumer contract (lazy migration)
 
-Issue #500 will land an `IActorStateMigration<TState>` interface for
+The canon matrix reserves an `IActorStateMigration<TState>` interface for
 within-actor schema upgrades. That mechanism reads
 `Identity.StateSchemaVersion` from the runtime envelope, applies registered
 migrations until the version reaches the agent's current schema, persists
@@ -87,7 +88,9 @@ interface lands):
   `IRandom`, or anything that performs I/O.
 
 These constraints are doctrine; the actual interface and CI guard land
-together with the first concrete migration case (deferred per #500).
+together with the first concrete migration case. Until then, the canon
+matrix owns the decision boundary and this ADR only fixes version
+placement.
 
 ### Phase 1 scope (this PR)
 
@@ -95,17 +98,17 @@ together with the first concrete migration case (deferred per #500).
 - Default value is `0`; no migrations are registered yet.
 - `RuntimeActorGrain` reads the field but does not yet route through any
   migration pipeline — that infrastructure lands with the first concrete
-  case per #500.
+  lazy migration case.
 
 This pre-records the field placement so #500's consumer contract reads
 from a known location and so the field is sized correctly in Phase 1
 state rows.
 
-### Out of scope (deferred to issue #500 + follow-up issues)
+### Out of scope (deferred to follow-up issues)
 
 - The migration interface + CI guard (zero-dependency constructor).
-- The strangler-fig (projection-driven) split / merge / re-key cookbook
-  and its `IActorBootstrapPort` prerequisite.
+- Defining actors, proto fields, envelope kinds, pipeline phases, or a
+  state-key protocol for projection-driven split / merge / re-key.
 - The event-immutability policy ADR (separate doctrine ADR).
 - A general-purpose data-transformation framework (explicit non-goal).
 
@@ -118,12 +121,15 @@ state rows.
   without deserializing the state body, decoupling activation safety from
   proto evolution.
 - Cross-actor state evolution (split / merge / re-key) is explicitly **not**
-  served by this version field — those go through projection-driven
-  bootstrap per #500's matrix.
+  served by this version field — those follow the projection-driven
+  bootstrap / retire cleanup / re-key redirect canon in
+  `docs/canon/event-sourcing.md` and `docs/canon/cqrs-projection.md`.
 
 ## References
 
 - Issue #498 — `AgentKind` identity (parent decision; runtime envelope
   introduced there).
-- Issue #500 — actor evolution pattern matrix (consumer of this field).
+- `docs/canon/event-sourcing.md` — actor evolution matrix and lazy state migration constraints.
+- `docs/canon/cqrs-projection.md` — projection-driven split / merge / re-key and query-time replay prohibition.
+- Issue #500 — parent actor evolution discussion.
 - ADR 0019 — companion identity ADR.

--- a/docs/canon/architecture-vocabulary.md
+++ b/docs/canon/architecture-vocabulary.md
@@ -40,6 +40,15 @@ owner: eanzhao
 | Service（如 `WriteService`、`QueryService`） | Module（无脑套用） | aevatar 的应用层契约必须承载业务语义、不是纯转发空壳；一个 "Service" 是不是 Module 取决于它的 Interface 是不是足够 deep。多数情况下，正确的形态是更窄的 `IXxxQueryPort` / `IActorDispatchPort`，而不是泛 `Service`。 |
 | Router | 新的转发 Actor / hot-path 调度中心 | 在 ingress 语境里，router = **config actor + boundary resolver**：`ChatRoutePolicyGAgent` 只作为 per-scope 配置权威持有策略，`ChatRouteResolver` 只在入口边界做无状态、瞬时决策；它不是新增 actor hop，也不持久化决策。见 [ADR-0024: Chat Route Policy — Config Actor + Boundary Resolver](../adr/0024-chat-route-policy.md)。 |
 
+### 1.2 Actor evolution 词汇
+
+| 术语 | 含义与口径 |
+|---|---|
+| Lazy state migration | 同一 actor、同一 identity、同一事实拥有者内的 state schema 懒迁移。只消费历史 state 与 runtime envelope 上的 schema version；不得做 I/O、跨 actor 调用、projection 写入或 readmodel 读取。 |
+| Projection-driven bootstrap | split / merge / re-key 时，从旧 actor 已提交事实或 committed state publication 物化新 actor bootstrap 输入的流程。bootstrap 输入不是新事实；新 actor 提交自己的 domain event 后才成为权威事实。 |
+| Retire cleanup | actor 演进完成后，对旧 actor、旧 readmodel、旧索引或旧路由的显式退役清理。它是演进协议的一部分，不是 query path 的临时兼容判断。 |
+| Re-key redirect | actor identity/key 改写时，旧 key 到新 key 的显式重定向事实。它用于目标解析与清理窗口，不允许调用方解析 actorId 字符串，也不允许用 commandId/correlationId 代替 actorId。 |
+
 ## 2. 关键原则（与 CLAUDE.md 已有规则的映射）
 
 ### 2.1 Deletion test（删除测试）

--- a/docs/canon/cqrs-projection.md
+++ b/docs/canon/cqrs-projection.md
@@ -113,7 +113,26 @@ CQRS 不应只提供零散 helper，而应定义所有 capability 复用的标�
 8. 持久投影 scope 的激活由 committed-state publication owner hook 触发：Actor 完成 domain event commit 并构造 `EventEnvelope<CommittedStateEventPublished>` 前，Foundation 调用 `ICommittedStatePublicationHook`，Projection Core 根据精确的 actor type 与 state event descriptor 生成 `ProjectionScopeStartRequest` 并分发给已有 `IProjectionScopeActivationService<TLease>`。命令入口不得同步调用 projection activation facade，也不得新增 actor/lifecycle phase 来“预热”读模型。
 9. Elasticsearch projection schema-drift 的唯一权威是 provider 生成的 augmented mapping fingerprint 与稳定 alias lifecycle。query resolver / query reader 不得读取 live ES mapping 作为第二真相；alias 指向非当前 fingerprint 的 physical index 时，lifecycle 必须 fail loud，projection 拒绝继续，而不是在 query-time 或 projection turn 内自动 repair / reindex。
 
-## 5.1 编排减重落地（当前实现）
+### 5.1 Projection-driven Split / Merge / Re-key
+
+Projection-driven bootstrap 只服务 actor 事实拥有者变化的演进：split、merge、re-key。它不是查询优化，也不是 lazy state migration 的替代品。
+
+口径：
+
+1. Split：旧 actor 的 committed fact 通过 projection materialize 出 bootstrap 输入；新 actor 必须提交自己的 domain event 后才成为新事实拥有者。
+2. Merge：多个旧 actor 的 committed fact 只能作为 bootstrap 输入；聚合后的事实必须由新的 aggregate actor 拥有。
+3. Re-key：旧 key 到新 key 的关系必须显式建模为 re-key redirect；调用方不得解析 actorId 字符串或把追踪 ID 当目标身份。
+4. Retire cleanup：旧 actor / 旧 readmodel / 旧索引的退役必须有显式清理语义，不能留给 query path 做“如果旧数据还在就忽略”的临时判断。
+5. Bootstrap 输入只来自 committed domain event、committed state publication 或同源 durable feed；不得订阅 command、self continuation 或 actor 内部 state mirror 临时结构推测完成态。
+
+禁止项：
+
+1. 禁止 query-time replay / bootstrap：query 方法不得读取 `IEventStore`、重放事件、临时重建 actor state 或补跑 projection 后再返回。
+2. 禁止 query-time priming：query/read adapter 不得激活 projection、ensure session、创建 actor、修复 index 或触发生命周期操作。
+3. 禁止把 bootstrap 当成新的 core phase：本口径不新增 envelope kind、pipeline phase、actor 类型或 proto 字段；它只约束现有 projection materialization 与 actor-owned fact 的使用方式。
+4. 禁止用 readmodel 反向定义业务事实：readmodel 只证明某个权威版本已物化可见，不决定 split / merge / re-key 的业务完成。
+
+## 5.2 编排减重落地（当前实现）
 
 1. CQRS 命令侧已统一为：
    `ICommandDispatchService<TCommand, TReceipt, TError>`（宿主入口） +
@@ -149,7 +168,7 @@ CQRS 不应只提供零散 helper，而应定义所有 capability 复用的标�
    `WorkflowExecutionCurrentStateQueryPort` / `WorkflowExecutionArtifactQueryPort`（查询映射；query 直接实现 read adapter，不再复用通用 query-port 基类）。
 5. CI 增加编排类体量守卫与 capability 边界守卫：关键编排类的非空行数与直接依赖数有上限，`workflow/scripting` 外部入口不得回退到私有 lifecycle 主链。
 
-## 5.2 Envelope / Annotation 口径（防理解偏差）
+## 5.3 Envelope / Annotation 口径（防理解偏差）
 
 1. `EventEnvelope.Propagation` 与 `EventEnvelope.Runtime` 属于包络级上下文，用于传播/追踪/投递，不作为业务完成语义主来源。
 2. `StepCompletedEvent.Annotations` 属于业务事件注解，Maker/Connector/Parallel 等模块信息写入此处。

--- a/docs/canon/event-sourcing.md
+++ b/docs/canon/event-sourcing.md
@@ -26,6 +26,34 @@ owner: eanzhao
 3. 只有 Actor 在处理这些入站消息后显式调用 `PersistDomainEventAsync(...)` / `PersistDomainEventsAsync(...)` 持久化的领域事件，才会成为 `StateEvent` 并进入 `EventStore`。
 4. 因此，`EventEnvelope` 流与 `StateEvent` 流不是同一层：前者是 transport/runtime 层，后者是事实/event-sourcing 层。
 
+## 2.2 Actor Evolution Matrix
+
+Actor 演进先按事实归属判定，而不是先设计新的迁移框架。默认选择如下：
+
+| 演进场景 | 权威事实是否仍属同一 actor | 推荐机制 | 禁止替代 |
+|---|---|---|---|
+| 同一 actor 内部 state schema 调整 | 是 | Lazy state migration | 新 actor、projection bootstrap、query-time replay |
+| 字段重命名、默认值补齐、枚举值规范化 | 是 | Lazy state migration | 把版本字段塞进业务 state proto |
+| Actor 拆分为多个事实拥有者 | 否 | Projection-driven bootstrap + redirect / retire cleanup | 在旧 actor 状态里临时拼新 actor 事实 |
+| 多个 actor 合并为一个事实拥有者 | 否 | Projection-driven bootstrap + retire cleanup | 查询时读取多个 actor event stream 临时聚合 |
+| Actor identity / key 改写 | 否 | Re-key redirect + projection-driven bootstrap | 把 commandId/correlationId 当 actorId 复用 |
+| 仅新增 readmodel / index / search view | 否，事实不变 | Projection materialization | 修改 write-side state 只为查询服务 |
+
+Lazy state migration 的适用边界：
+
+1. 只处理同一 actor、同一事实拥有者、同一 actor identity 下的内部 state schema 演进。
+2. 迁移输入只能是历史 state 与 runtime envelope 上的 `state_schema_version`。
+3. 迁移输出仍是同一 actor 的当前 state；不得创建其他 actor、写 projection store、发外部请求或读取 readmodel。
+4. 迁移必须保持 replay 同态：历史 `StateEvent` 仍可按原事件流恢复到等价当前 state。
+5. 迁移接口仍 deferred；本 canon 只定义判定矩阵与约束，不新增 actor、proto field、envelope kind 或 pipeline phase。
+
+Projection-driven 演进的适用边界：
+
+1. 只用于事实拥有者发生变化的 split / merge / re-key。
+2. 新事实必须由新 actor 自己提交的 domain event 成为权威事实；projection 只负责从旧 committed fact materialize bootstrap 输入。
+3. 旧 actor 的清理通过 retire cleanup 明确完成，不能依赖查询路径隐式忽略旧数据。
+4. 读侧切换以 projection/readmodel 可见版本为准，不把 accepted ACK 冒充为新事实已可查。
+
 ## 3. 当前代码事实（权威路径）
 - ES 行为契约：`src/Aevatar.Foundation.Core/EventSourcing/IEventSourcingBehavior.cs`
 - ES 默认实现：`src/Aevatar.Foundation.Core/EventSourcing/EventSourcingBehavior.cs`


### PR DESCRIPTION
## 摘要

源自 #500 Phase 9 r1 split first-slice(minimal+delete 2/3 同向 consensus)。

docs-only canon/ADR matrix:
- `docs/canon/event-sourcing.md`:**actor evolution matrix** + lazy state migration 约束
- `docs/canon/cqrs-projection.md`:projection-driven split/merge/re-key 口径 + 禁止 query-time replay/bootstrap
- `docs/canon/architecture-vocabulary.md`:lazy state migration / projection-driven bootstrap / retire cleanup / re-key redirect 术语
- `docs/adr/0020-actor-state-version-placement.md`:"deferred per #500" → 指向新 canon matrix

## No-new-core 边界

- 无新增 actor / proto field / envelope kind / pipeline phase
- 无 production code 改动(docs-only)
- 统一 state-key 协议设计留 #1311 later-slice

## 验证

- bash tools/docs/lint.sh 通过
- bash tools/ci/architecture_guards.sh 通过
- docs-only 不跑 dotnet test

closes #1310

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧