### PR TITLE
#1316 first slice: scoped draft create reuse existing StudioMember command authority(no-new-core)

### DIFF
--- a/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
+++ b/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
@@ -15,17 +15,20 @@ public sealed class AppScopedWorkflowService
     private readonly IWorkflowYamlDocumentService _yamlDocumentService;
     private readonly IStudioWorkspaceQueryPort? _workspaceQueryPort;
     private readonly IStudioWorkspaceCommandPort? _workspaceCommandPort;
+    private readonly IStudioMemberCommandPort? _memberCommandPort;
     private readonly ILogger<AppScopedWorkflowService>? _logger;
 
     public AppScopedWorkflowService(
         IWorkflowYamlDocumentService yamlDocumentService,
         IStudioWorkspaceQueryPort? workspaceQueryPort = null,
         IStudioWorkspaceCommandPort? workspaceCommandPort = null,
+        IStudioMemberCommandPort? memberCommandPort = null,
         ILogger<AppScopedWorkflowService>? logger = null)
     {
         _yamlDocumentService = yamlDocumentService ?? throw new ArgumentNullException(nameof(yamlDocumentService));
         _workspaceQueryPort = workspaceQueryPort;
         _workspaceCommandPort = workspaceCommandPort;
+        _memberCommandPort = memberCommandPort;
         _logger = logger;
     }
 
@@ -136,6 +139,17 @@ public sealed class AppScopedWorkflowService
             stored,
             workspace.StateVersion,
             ct);
+
+        if (existingDraft == null)
+        {
+            // Refactor (iter290/cluster1316-first): Old pattern: scoped draft save without member authority. New principle: reuse existing StudioMember command port.
+            await CreateMemberAuthorityAsync(
+                normalizedScopeId,
+                normalizedWorkflowId,
+                workflowName,
+                parsed.Document?.Description,
+                ct);
+        }
 
         return ToDraftWorkflowResponse(
             normalizedScopeId,
@@ -280,6 +294,26 @@ public sealed class AppScopedWorkflowService
             parse.Document?.Steps.Count ?? 0,
             HasLayout: false,
             draft.UpdatedAtUtc);
+    }
+
+    private async Task CreateMemberAuthorityAsync(
+        string scopeId,
+        string memberId,
+        string displayName,
+        string? description,
+        CancellationToken ct)
+    {
+        var memberCommandPort = _memberCommandPort
+            ?? throw new InvalidOperationException("Studio member command port is not configured.");
+
+        await memberCommandPort.CreateAsync(
+            scopeId,
+            new CreateStudioMemberRequest(
+                DisplayName: displayName,
+                ImplementationKind: MemberImplementationKindNames.Workflow,
+                Description: string.IsNullOrWhiteSpace(description) ? null : description.Trim(),
+                MemberId: memberId),
+            ct);
     }
 
     private WorkflowDraftResponse ToDraftWorkflowResponse(

--- a/src/Aevatar.Studio.Hosting/StudioHostingServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Hosting/StudioHostingServiceCollectionExtensions.cs
@@ -54,6 +54,7 @@ internal static class StudioHostingServiceCollectionExtensions
             sp.GetRequiredService<IWorkflowYamlDocumentService>(),
             sp.GetService<IStudioWorkspaceQueryPort>(),
             sp.GetService<IStudioWorkspaceCommandPort>(),
+            sp.GetService<IStudioMemberCommandPort>(),
             sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<AppScopedWorkflowService>>()));
         services.AddSingleton(sp => new AppScopedScriptService(
             sp.GetRequiredService<IHttpClientFactory>(),

--- a/test/Aevatar.Studio.Tests/AppScopedWorkflowServiceDeleteDraftTests.cs
+++ b/test/Aevatar.Studio.Tests/AppScopedWorkflowServiceDeleteDraftTests.cs
@@ -65,9 +65,11 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
     {
         using var environment = new ScopedWorkflowEnvironment();
         var workspacePort = new RecordingStudioWorkspacePorts();
+        var memberCommandPort = new RecordingMemberCommandPort();
         var service = environment.CreateService(
             workspaceQueryPort: workspacePort,
-            workspaceCommandPort: workspacePort);
+            workspaceCommandPort: workspacePort,
+            memberCommandPort: memberCommandPort);
 
         var saved = await service.CreateDraftAsync(
             "scope-1",
@@ -81,6 +83,98 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
         workspacePort.SavedDrafts[0].ScopeId.Should().Be("scope-1");
         workspacePort.SavedDrafts[0].ExpectedVersion.Should().Be(11);
         saved.WorkflowId.Should().Be("workflow-1");
+        var createdMember = memberCommandPort.CreatedMembers.Should().ContainSingle().Subject;
+        createdMember.ScopeId.Should().Be("scope-1");
+        createdMember.Request.MemberId.Should().Be("workflow-1");
+        createdMember.Request.DisplayName.Should().Be("workflow-1");
+        createdMember.Request.ImplementationKind.Should().Be(MemberImplementationKindNames.Workflow);
+    }
+
+    [Fact]
+    public async Task CreateDraftAsync_AfterSuccessfulScopedDraftSave_ShouldCreateMemberAuthority()
+    {
+        using var environment = new ScopedWorkflowEnvironment();
+        var workspacePort = new RecordingStudioWorkspacePorts();
+        var memberCommandPort = new RecordingMemberCommandPort();
+        var service = environment.CreateService(
+            workspaceQueryPort: workspacePort,
+            workspaceCommandPort: workspacePort,
+            memberCommandPort: memberCommandPort);
+
+        await service.CreateDraftAsync(
+            "scope-1",
+            new SaveWorkflowDraftRequest(
+                DirectoryId: "scope:scope-1",
+                WorkflowName: "Draft Name",
+                FileName: null,
+                Yaml: "name: Draft Name\ndescription: member description\nsteps: []\n"));
+
+        memberCommandPort.CreatedMembers.Should().ContainSingle().Which.Should().BeEquivalentTo(
+            new RecordedMemberCreate(
+                "scope-1",
+                new CreateStudioMemberRequest(
+                    DisplayName: "Draft Name",
+                    ImplementationKind: MemberImplementationKindNames.Workflow,
+                    Description: "member description",
+                    MemberId: "draft-name")));
+    }
+
+    [Fact]
+    public async Task UpdateDraftAsync_ShouldNotRecreateExistingMemberAuthority()
+    {
+        using var environment = new ScopedWorkflowEnvironment();
+        var workspacePort = new RecordingStudioWorkspacePorts(new[]
+        {
+            new ScopedDraft(
+                "scope-1",
+                NewDraft(
+                    "workflow-1",
+                    "workflow-1",
+                    "name: workflow-1\nsteps: []\n",
+                    DateTimeOffset.UtcNow)),
+        });
+        var memberCommandPort = new RecordingMemberCommandPort();
+        var service = environment.CreateService(
+            workspaceQueryPort: workspacePort,
+            workspaceCommandPort: workspacePort,
+            memberCommandPort: memberCommandPort);
+
+        await service.UpdateDraftAsync(
+            "scope-1",
+            "workflow-1",
+            new SaveWorkflowDraftRequest(
+                DirectoryId: "scope:scope-1",
+                WorkflowName: "workflow-renamed",
+                FileName: null,
+                Yaml: "name: workflow-renamed\nsteps: []\n"));
+
+        memberCommandPort.CreatedMembers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateDraftAsync_WhenScopedDraftSaveFails_ShouldNotCreateMemberAuthority()
+    {
+        using var environment = new ScopedWorkflowEnvironment();
+        var workspaceQueryPort = new RecordingStudioWorkspacePorts();
+        var workspaceCommandPort = new ThrowingWorkspaceCommandPort(
+            new InvalidOperationException("workspace command port is unavailable"));
+        var memberCommandPort = new RecordingMemberCommandPort();
+        var service = environment.CreateService(
+            workspaceQueryPort: workspaceQueryPort,
+            workspaceCommandPort: workspaceCommandPort,
+            memberCommandPort: memberCommandPort);
+
+        var act = () => service.CreateDraftAsync(
+            "scope-1",
+            new SaveWorkflowDraftRequest(
+                DirectoryId: "scope:scope-1",
+                WorkflowName: "workflow-1",
+                FileName: null,
+                Yaml: "name: workflow-1\nsteps: []\n"));
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("workspace command port is unavailable");
+        memberCommandPort.CreatedMembers.Should().BeEmpty();
     }
 
     [Fact]
@@ -199,7 +293,8 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
             new InvalidOperationException("workspace query port is unavailable"));
         var service = environment.CreateService(
             workspaceQueryPort: workspacePort,
-            workspaceCommandPort: new RecordingStudioWorkspacePorts());
+            workspaceCommandPort: new RecordingStudioWorkspacePorts(),
+            memberCommandPort: new RecordingMemberCommandPort());
         var layoutPath = environment.BuildLayoutPath("scope-1", "workflow-1");
 
         var act = () => service.CreateDraftAsync(
@@ -246,12 +341,14 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
 
         public AppScopedWorkflowService CreateService(
             IStudioWorkspaceQueryPort? workspaceQueryPort = null,
-            IStudioWorkspaceCommandPort? workspaceCommandPort = null)
+            IStudioWorkspaceCommandPort? workspaceCommandPort = null,
+            IStudioMemberCommandPort? memberCommandPort = null)
         {
             return new AppScopedWorkflowService(
                 new StubWorkflowYamlDocumentService(),
                 workspaceQueryPort,
-                workspaceCommandPort);
+                workspaceCommandPort,
+                memberCommandPort);
         }
 
         public string BuildLayoutPath(string scopeId, string workflowId) =>
@@ -273,11 +370,31 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
 
     private sealed class StubWorkflowYamlDocumentService : IWorkflowYamlDocumentService
     {
-        public WorkflowParseResult Parse(string yaml) =>
-            new(new WorkflowDocument { Name = "workflow" }, []);
+        public WorkflowParseResult Parse(string yaml)
+        {
+            var document = new WorkflowDocument
+            {
+                Name = ReadScalar(yaml, "name") ?? "workflow",
+                Description = ReadScalar(yaml, "description") ?? string.Empty,
+            };
+            return new WorkflowParseResult(document, []);
+        }
 
         public string Serialize(WorkflowDocument document) =>
             $"name: {document.Name}\nsteps: []\n";
+
+        private static string? ReadScalar(string yaml, string key)
+        {
+            foreach (var line in yaml.Split('\n'))
+            {
+                var trimmed = line.Trim();
+                var prefix = $"{key}:";
+                if (trimmed.StartsWith(prefix, StringComparison.Ordinal))
+                    return trimmed[prefix.Length..].Trim();
+            }
+
+            return null;
+        }
     }
 
     private sealed class ThrowingWorkspaceQueryPort : IStudioWorkspaceQueryPort
@@ -327,6 +444,49 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
             Task.FromException<StudioWorkspaceCommandReceipt>(_exception);
     }
 
+    private sealed class RecordingMemberCommandPort : IStudioMemberCommandPort
+    {
+        public List<RecordedMemberCreate> CreatedMembers { get; } = [];
+
+        public Task<StudioMemberSummaryResponse> CreateAsync(
+            string scopeId,
+            CreateStudioMemberRequest request,
+            CancellationToken ct = default)
+        {
+            CreatedMembers.Add(new RecordedMemberCreate(scopeId, request));
+            return Task.FromResult(new StudioMemberSummaryResponse(
+                MemberId: request.MemberId ?? "generated-member",
+                ScopeId: scopeId,
+                DisplayName: request.DisplayName,
+                Description: request.Description ?? string.Empty,
+                ImplementationKind: request.ImplementationKind,
+                LifecycleStage: MemberLifecycleStageNames.Created,
+                PublishedServiceId: $"studio-service:{request.MemberId ?? "generated-member"}",
+                LastBoundRevisionId: null,
+                CreatedAt: DateTimeOffset.UtcNow,
+                UpdatedAt: DateTimeOffset.UtcNow));
+        }
+
+        public Task UpdateImplementationAsync(
+            string scopeId,
+            string memberId,
+            StudioMemberImplementationRefResponse implementation,
+            CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task StartBindingRunAsync(
+            StudioMemberBindingRunStartRequest request,
+            CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task PatchTeamAssignmentAsync(
+            string scopeId,
+            string memberId,
+            string? targetTeamId,
+            CancellationToken ct = default) =>
+            Task.CompletedTask;
+    }
+
     private static StudioWorkflowDraftRecord NewDraft(
         string workflowId,
         string name,
@@ -347,3 +507,5 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
             1);
 
 }
+
+internal sealed record RecordedMemberCreate(string ScopeId, CreateStudioMemberRequest Request);


### PR DESCRIPTION
## 摘要

源自 #519 Phase 9 r1 split first-slice。

after-successful-scoped-draft-save 后通过现有 StudioMember command port 创建 member,无新 abstraction。

## 验证

- dotnet build + test 通过

closes #1316

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧