### PR TITLE
#1323 first slice: canonical Responses Web tool alias before cache identity(no-new-core)

### DIFF
--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesWebSubstituteToolExecutionService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesWebSubstituteToolExecutionService.cs
@@ -30,19 +30,23 @@ public sealed class ResponsesWebSubstituteToolExecutionService
     {
         ArgumentNullException.ThrowIfNull(request);
 
+        // Refactor (issue1323-first): canonicalize local Responses Web aliases before cache identity is built.
+        var canonicalToolName = CanonicalizeWebToolName(request.ToolName);
+
         // Refactor (iter159/cluster-624):
         //   Old pattern: Host 层 ResponsesAevatarToolProvider 直接编排 WebFetch/WebSearch 工具调用
         //   New principle: 编排下沉到 Application/AI 边界;Host 只做协议适配
-        return request.ToolName switch
+        return canonicalToolName switch
         {
-            "WebFetch" or "web_fetch" => await ExecuteFetchAsync(request, ct).ConfigureAwait(false),
-            "WebSearch" or "web_search" => await ExecuteSearchAsync(request, ct).ConfigureAwait(false),
+            "WebFetch" => await ExecuteFetchAsync(request, canonicalToolName, ct).ConfigureAwait(false),
+            "WebSearch" => await ExecuteSearchAsync(request, canonicalToolName, ct).ConfigureAwait(false),
             _ => throw new InvalidOperationException($"Unsupported Responses Web substitute tool '{request.ToolName}'."),
         };
     }
 
     private async Task<ResponsesWebSubstituteToolExecutionResult> ExecuteFetchAsync(
         ResponsesWebSubstituteToolExecutionRequest request,
+        string canonicalToolName,
         CancellationToken ct)
     {
         var validation = ResponsesWebFetchUrlGuard.Validate(NormalizeUrl(request.Fetch?.Url));
@@ -52,20 +56,21 @@ public sealed class ResponsesWebSubstituteToolExecutionService
         }
 
         var url = validation.NormalizedUrl!;
-        var cacheKey = ComputeCacheKey(request.ToolName, url);
+        var cacheKey = ComputeCacheKey(canonicalToolName, url);
         // Refactor (iter161-cluster-001 #1251-first):
         //   Old pattern: fetch trace/cache result was downgraded to Value before recording.
         //   New principle: trace/cache normal writes carry typed ResponsesWebToolResult.
         var cached = await _queryPort.GetWebCacheEntryAsync(
             request.ScopeId,
             request.OwnerSubject,
-            request.ToolName,
+            canonicalToolName,
             cacheKey,
             ct).ConfigureAwait(false);
         if (cached != null)
         {
             await RecordTraceAsync(
                 request,
+                canonicalToolName,
                 cacheKey,
                 url,
                 query: string.Empty,
@@ -94,6 +99,7 @@ public sealed class ResponsesWebSubstituteToolExecutionService
         var typedOutput = ResponsesWebResultMigration.FromFetch(protoOutput);
         await RecordTraceAsync(
             request,
+            canonicalToolName,
             cacheKey,
             url,
             query: string.Empty,
@@ -105,6 +111,7 @@ public sealed class ResponsesWebSubstituteToolExecutionService
 
     private async Task<ResponsesWebSubstituteToolExecutionResult> ExecuteSearchAsync(
         ResponsesWebSubstituteToolExecutionRequest request,
+        string canonicalToolName,
         CancellationToken ct)
     {
         var query = request.Search?.Query;
@@ -116,20 +123,21 @@ public sealed class ResponsesWebSubstituteToolExecutionService
             : _backend.DefaultMaxSearchResults;
         maxResults = Math.Clamp(maxResults, 1, 20);
         var cacheValue = $"{query.Trim()}\n{maxResults}";
-        var cacheKey = ComputeCacheKey(request.ToolName, cacheValue);
+        var cacheKey = ComputeCacheKey(canonicalToolName, cacheValue);
         // Refactor (iter161-cluster-001 #1251-first):
         //   Old pattern: search/error trace/cache results were written as Value.
         //   New principle: typed search/error results are written through the existing command->actor->projection chain.
         var cached = await _queryPort.GetWebCacheEntryAsync(
             request.ScopeId,
             request.OwnerSubject,
-            request.ToolName,
+            canonicalToolName,
             cacheKey,
             ct).ConfigureAwait(false);
         if (cached != null)
         {
             await RecordTraceAsync(
                 request,
+                canonicalToolName,
                 cacheKey,
                 query,
                 cacheHit: true,
@@ -148,6 +156,7 @@ public sealed class ResponsesWebSubstituteToolExecutionService
                 "No NyxID access token available. User must be authenticated.");
             await RecordTraceAsync(
                 request,
+                canonicalToolName,
                 cacheKey,
                 query,
                 cacheHit: false,
@@ -165,6 +174,7 @@ public sealed class ResponsesWebSubstituteToolExecutionService
         var typedSearchResult = ResponsesWebResultMigration.FromSearch(searchResult);
         await RecordTraceAsync(
             request,
+            canonicalToolName,
             cacheKey,
             query,
             cacheHit: false,
@@ -175,6 +185,7 @@ public sealed class ResponsesWebSubstituteToolExecutionService
 
     private Task RecordTraceAsync(
         ResponsesWebSubstituteToolExecutionRequest request,
+        string canonicalToolName,
         string cacheKey,
         string url,
         string query,
@@ -187,7 +198,7 @@ public sealed class ResponsesWebSubstituteToolExecutionService
             request.ResponseId,
             new ResponsesWebTraceInput(
                 ResponseAgentToolStateIds.NewWebTraceId(),
-                request.ToolName,
+                canonicalToolName,
                 cacheKey,
                 url,
                 query,
@@ -197,18 +208,28 @@ public sealed class ResponsesWebSubstituteToolExecutionService
 
     private Task RecordTraceAsync(
         ResponsesWebSubstituteToolExecutionRequest request,
+        string canonicalToolName,
         string cacheKey,
         string query,
         bool cacheHit,
         ResponsesWebToolResult result,
         CancellationToken ct) =>
-        RecordTraceAsync(request, cacheKey, url: string.Empty, query, cacheHit, result, ct);
+        RecordTraceAsync(request, canonicalToolName, cacheKey, url: string.Empty, query, cacheHit, result, ct);
 
     public static string ComputeCacheKey(string toolName, string value)
     {
-        var hash = SHA256.HashData(Encoding.UTF8.GetBytes($"{toolName}\n{value.Trim().ToLowerInvariant()}"));
+        var canonicalToolName = CanonicalizeWebToolName(toolName);
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes($"{canonicalToolName}\n{value.Trim().ToLowerInvariant()}"));
         return Convert.ToHexString(hash).ToLowerInvariant();
     }
+
+    private static string CanonicalizeWebToolName(string toolName) =>
+        toolName switch
+        {
+            "web_fetch" => "WebFetch",
+            "web_search" => "WebSearch",
+            _ => toolName,
+        };
 
     private static string? NormalizeUrl(string? url)
     {

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesWebSubstituteToolExecutionServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesWebSubstituteToolExecutionServiceTests.cs
@@ -38,6 +38,35 @@ public sealed class ResponsesWebSubstituteToolExecutionServiceTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_ShouldCanonicalizeFetchAliasBeforeCacheIdentity()
+    {
+        var state = new RecordingResponsesAgentToolStatePort();
+        var cacheKey = state.SeedWebCache(
+            "WebFetch",
+            "https://example.com/docs",
+            """{"url":"https://example.com/docs","content":"cached"}""");
+        var backend = new RecordingResponsesWebSubstituteBackend();
+        var service = CreateService(state, backend);
+
+        var result = await service.ExecuteAsync(CreateRequest(
+            "web_fetch",
+            """{"url":"http://example.com/docs"}"""));
+
+        result.TypedCached.Fetch.Content.Should().Be("cached");
+        backend.FetchCalls.Should().BeEmpty();
+        state.WebCacheLookups.Should().ContainSingle(x =>
+            x.ToolName == "WebFetch" &&
+            x.CacheKey == cacheKey);
+        state.WebTraces.Should().ContainSingle();
+        state.WebTraces[0].Trace.ToolName.Should().Be("WebFetch");
+        state.WebTraces[0].Trace.CacheKey.Should().Be(cacheKey);
+        ResponsesWebSubstituteToolExecutionService
+            .ComputeCacheKey("web_fetch", "https://example.com/docs")
+            .Should()
+            .Be(cacheKey);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_ShouldFetchWithoutForwardingNyxIdTokenAndRecordTrace()
     {
         var state = new RecordingResponsesAgentToolStatePort();
@@ -106,6 +135,36 @@ public sealed class ResponsesWebSubstituteToolExecutionServiceTests
         state.WebTraces[0].Trace.Query.Should().Be("aevatar docs");
         state.WebTraces[0].Trace.CacheHit.Should().BeFalse();
         state.WebTraces[0].Trace.Result.Search.Results[0].Title.Should().Be("fresh");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldCanonicalizeSearchAliasBeforeCacheIdentity()
+    {
+        var state = new RecordingResponsesAgentToolStatePort();
+        var cacheKey = state.SeedWebCache(
+            "WebSearch",
+            "aevatar docs\n3",
+            """{"results":[{"title":"cached","url":"https://example.com/cached","snippet":"snippet"}]}""");
+        var backend = new RecordingResponsesWebSubstituteBackend();
+        var service = CreateService(state, backend);
+
+        var result = await service.ExecuteAsync(CreateRequest(
+            "web_search",
+            """{"query":" aevatar docs ","max_results":3}""",
+            token: "secret-token"));
+
+        result.TypedCached.Search.Results.Should().ContainSingle(x => x.Title == "cached");
+        backend.SearchCalls.Should().BeEmpty();
+        state.WebCacheLookups.Should().ContainSingle(x =>
+            x.ToolName == "WebSearch" &&
+            x.CacheKey == cacheKey);
+        state.WebTraces.Should().ContainSingle();
+        state.WebTraces[0].Trace.ToolName.Should().Be("WebSearch");
+        state.WebTraces[0].Trace.CacheKey.Should().Be(cacheKey);
+        ResponsesWebSubstituteToolExecutionService
+            .ComputeCacheKey("web_search", "aevatar docs\n3")
+            .Should()
+            .Be(cacheKey);
     }
 
     [Fact]
@@ -266,6 +325,8 @@ public sealed class ResponsesWebSubstituteToolExecutionServiceTests
 
         public List<(string ScopeId, string OwnerSubject, string SourceResponseId, ResponsesWebTraceInput Trace)> WebTraces { get; } = [];
 
+        public List<(string ScopeId, string OwnerSubject, string ToolName, string CacheKey)> WebCacheLookups { get; } = [];
+
         public string SeedWebCache(string toolName, string value, string resultJson)
         {
             var cacheKey = ResponsesWebSubstituteToolExecutionService.ComputeCacheKey(toolName, value);
@@ -318,6 +379,7 @@ public sealed class ResponsesWebSubstituteToolExecutionServiceTests
             string cacheKey,
             CancellationToken ct = default)
         {
+            WebCacheLookups.Add((scopeId, ownerSubject, toolName, cacheKey));
             _webCache.TryGetValue((toolName, cacheKey), out var entry);
             return Task.FromResult(entry);
         }


### PR DESCRIPTION
## 摘要

源自 #1274 Phase 9 r1 split first-slice。

规范化 Responses Web tool 别名 → canonical name 在 cache identity 入口前完成,
复用现有 local Responses contracts,**no new public WebToolResult abstraction**。

## 边界(no-new-core)

- 不新增 actor type / envelope kind / pipeline phase / proto field
- 不引入 public AI Web WebToolResult abstraction
- 复用现有 local Responses contracts
- 别名规范化逻辑在 cache identity 入口前完成

## 验证

- 2 files changed,+93/-10
- 别名 → canonical 转换有测试覆盖
- cache identity 用 canonical 名而非原始别名
- 本地 build + test 通过

closes #1323

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧