### PR TITLE
#1326: stop workflow identity mixing with existing command context(no-new-core)

### DIFF
--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowRunControlModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowRunControlModels.cs
@@ -69,7 +69,7 @@ public abstract record WorkflowRunControlCommandBase(
     string ActorId,
     string RunId,
     string? CommandId,
-    // Refactor (issue1326): Keep workflow control correlation explicit so command identity is not reused as run/session trace identity.
+    // Refactor (issue1326): Old pattern: Workflow control commands reused command identity as the run/session trace identity. New principle: Keep workflow control correlation explicit and separate from command identity.
     string? CorrelationId = null) : IWorkflowRunControlCommand
 {
     public IReadOnlyDictionary<string, string>? Headers => null;

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowRunControlModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowRunControlModels.cs
@@ -68,10 +68,10 @@ public interface IWorkflowRunControlCommand : ICommandContextSeed
 public abstract record WorkflowRunControlCommandBase(
     string ActorId,
     string RunId,
-    string? CommandId) : IWorkflowRunControlCommand
+    string? CommandId,
+    // Refactor (issue1326): Keep workflow control correlation explicit so command identity is not reused as run/session trace identity.
+    string? CorrelationId = null) : IWorkflowRunControlCommand
 {
-    public string? CorrelationId => string.IsNullOrWhiteSpace(CommandId) ? null : CommandId;
-
     public IReadOnlyDictionary<string, string>? Headers => null;
 }
 
@@ -84,7 +84,8 @@ public sealed record WorkflowResumeCommand(
     string? UserInput,
     IReadOnlyDictionary<string, string>? Metadata = null,
     string? EditedContent = null,
-    string? Feedback = null) : WorkflowRunControlCommandBase(ActorId, RunId, CommandId);
+    string? Feedback = null,
+    string? CorrelationId = null) : WorkflowRunControlCommandBase(ActorId, RunId, CommandId, CorrelationId);
 
 public sealed record WorkflowSignalCommand(
     string ActorId,
@@ -92,13 +93,15 @@ public sealed record WorkflowSignalCommand(
     string SignalName,
     string? CommandId,
     string? Payload,
-    string? StepId = null) : WorkflowRunControlCommandBase(ActorId, RunId, CommandId);
+    string? StepId = null,
+    string? CorrelationId = null) : WorkflowRunControlCommandBase(ActorId, RunId, CommandId, CorrelationId);
 
 public sealed record WorkflowStopCommand(
     string ActorId,
     string RunId,
     string? CommandId,
-    string? Reason = null) : WorkflowRunControlCommandBase(ActorId, RunId, CommandId);
+    string? Reason = null,
+    string? CorrelationId = null) : WorkflowRunControlCommandBase(ActorId, RunId, CommandId, CorrelationId);
 
 public sealed record WorkflowRunControlAcceptedReceipt(
     string ActorId,

--- a/src/workflow/Aevatar.Workflow.Sdk/Session/RunSessionTracker.cs
+++ b/src/workflow/Aevatar.Workflow.Sdk/Session/RunSessionTracker.cs
@@ -94,7 +94,7 @@ public sealed class RunSessionTracker
             UserInput = userInput,
             EditedContent = editedContent,
             Feedback = feedback,
-            // Refactor (issue1326): Resume control commands must use a fresh server id unless the caller supplies an explicit id.
+            // Refactor (issue1326): Old pattern: Resume requests inherited the tracked start-run command id from the session. New principle: Resume control commands use a fresh server id unless the caller supplies an explicit id.
             CommandId = commandId,
             Metadata = metadata,
         };
@@ -129,7 +129,7 @@ public sealed class RunSessionTracker
             SignalName = resolvedSignalName!,
             StepId = resolvedStepId,
             Payload = payload,
-            // Refactor (issue1326): Signal control commands must not inherit the start run command id from session tracking.
+            // Refactor (issue1326): Old pattern: Signal requests inherited the tracked start-run command id from the session. New principle: Signal control commands use a fresh server id unless the caller supplies an explicit id.
             CommandId = commandId,
         };
     }

--- a/src/workflow/Aevatar.Workflow.Sdk/Session/RunSessionTracker.cs
+++ b/src/workflow/Aevatar.Workflow.Sdk/Session/RunSessionTracker.cs
@@ -94,7 +94,8 @@ public sealed class RunSessionTracker
             UserInput = userInput,
             EditedContent = editedContent,
             Feedback = feedback,
-            CommandId = commandId ?? _commandId,
+            // Refactor (issue1326): Resume control commands must use a fresh server id unless the caller supplies an explicit id.
+            CommandId = commandId,
             Metadata = metadata,
         };
     }
@@ -128,7 +129,8 @@ public sealed class RunSessionTracker
             SignalName = resolvedSignalName!,
             StepId = resolvedStepId,
             Payload = payload,
-            CommandId = commandId ?? _commandId,
+            // Refactor (issue1326): Signal control commands must not inherit the start run command id from session tracking.
+            CommandId = commandId,
         };
     }
 

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
@@ -108,22 +108,43 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
                 string.Empty));
     }
 
-    [Theory]
-    [InlineData(null, null)]
-    [InlineData("", null)]
-    [InlineData(" ", null)]
-    [InlineData("cmd-1", "cmd-1")]
-    public void WorkflowRunControlCommandBase_ShouldExposeCorrelationIdOnlyWhenCommandIdExists(
-        string? commandId,
-        string? expectedCorrelationId)
+    [Fact]
+    public void WorkflowRunControlCommandBase_ShouldKeepCorrelationIdExplicit()
     {
-        var resume = new WorkflowResumeCommand("actor-1", "run-1", "step-1", commandId, true, "approved");
-        var signal = new WorkflowSignalCommand("actor-1", "run-1", "approve", commandId, "payload");
-        var stop = new WorkflowStopCommand("actor-1", "run-1", commandId, "stop");
+        var resume = new WorkflowResumeCommand("actor-1", "run-1", "step-1", "cmd-1", true, "approved");
+        var signal = new WorkflowSignalCommand("actor-1", "run-1", "approve", "cmd-2", "payload");
+        var stop = new WorkflowStopCommand("actor-1", "run-1", "cmd-3", "stop");
 
-        resume.CorrelationId.Should().Be(expectedCorrelationId);
-        signal.CorrelationId.Should().Be(expectedCorrelationId);
-        stop.CorrelationId.Should().Be(expectedCorrelationId);
+        resume.CorrelationId.Should().BeNull();
+        signal.CorrelationId.Should().BeNull();
+        stop.CorrelationId.Should().BeNull();
+
+        var explicitResume = new WorkflowResumeCommand(
+            "actor-1",
+            "run-1",
+            "step-1",
+            "cmd-4",
+            true,
+            "approved",
+            CorrelationId: "corr-4");
+        var explicitSignal = new WorkflowSignalCommand(
+            "actor-1",
+            "run-1",
+            "approve",
+            "cmd-5",
+            "payload",
+            CorrelationId: "corr-5");
+        var explicitStop = new WorkflowStopCommand(
+            "actor-1",
+            "run-1",
+            "cmd-6",
+            "stop",
+            CorrelationId: "corr-6");
+
+        // Refactor (issue1326): Control command correlation is caller-provided context, not derived from command id.
+        explicitResume.CorrelationId.Should().Be("corr-4");
+        explicitSignal.CorrelationId.Should().Be("corr-5");
+        explicitStop.CorrelationId.Should().Be("corr-6");
         resume.Headers.Should().BeNull();
         signal.Headers.Should().BeNull();
         stop.Headers.Should().BeNull();

--- a/test/Aevatar.Workflow.Sdk.Tests/Session/RunSessionTrackerTests.cs
+++ b/test/Aevatar.Workflow.Sdk.Tests/Session/RunSessionTrackerTests.cs
@@ -53,7 +53,8 @@ public sealed class RunSessionTrackerTests
         resume.ActorId.Should().Be("actor-1");
         resume.RunId.Should().Be("run-1");
         resume.StepId.Should().Be("wait-1");
-        resume.CommandId.Should().Be("cmd-1");
+        // Refactor (issue1326): Session tracking keeps the start command id for observation, but does not reuse it for resume.
+        resume.CommandId.Should().BeNull();
         resume.EditedContent.Should().Be("approved draft");
         resume.Feedback.Should().Be("ship it");
 
@@ -64,7 +65,45 @@ public sealed class RunSessionTrackerTests
         signal.RunId.Should().Be("run-1");
         signal.SignalName.Should().Be("ops_window_open");
         signal.StepId.Should().Be("wait-1");
-        signal.CommandId.Should().Be("cmd-1");
+        signal.CommandId.Should().BeNull();
+    }
+
+    [Fact]
+    public void CreateResumeAndSignalRequest_ShouldUseExplicitCommandIdOnly()
+    {
+        var tracker = new RunSessionTracker();
+
+        tracker.Track(CustomFrame("aevatar.run.context", new WorkflowRunContextPayload
+        {
+            ActorId = "actor-1",
+            WorkflowName = "auto",
+            CommandId = "start-cmd",
+        }));
+        tracker.Track(CustomFrame("aevatar.human_input.request", new WorkflowHumanInputRequestCustomPayload
+        {
+            RunId = "run-1",
+            StepId = "approval-1",
+        }));
+        tracker.Track(CustomFrame("aevatar.workflow.waiting_signal", new WorkflowWaitingSignalCustomPayload
+        {
+            RunId = "run-1",
+            StepId = "wait-1",
+            SignalName = "ops_window_open",
+        }));
+
+        var resume = tracker.CreateResumeRequest(
+            "scope-a",
+            approved: true,
+            commandId: "resume-cmd",
+            serviceId: "orders");
+        var signal = tracker.CreateSignalRequest(
+            "scope-a",
+            commandId: "signal-cmd",
+            serviceId: "orders");
+
+        // Refactor (issue1326): Explicit control command ids remain caller owned; tracked start id is never a fallback.
+        resume.CommandId.Should().Be("resume-cmd");
+        signal.CommandId.Should().Be("signal-cmd");
     }
 
     [Fact]


### PR DESCRIPTION
## 摘要

源自 #1278 r2 split first-slice。

stop new workflow identity mixing with existing command context:
- `WorkflowRunControlCommandBase` 删除 CorrelationId 派生为 CommandId 的混用
- `RunSessionTracker` 不再把 start commandId 写入 resume/signal command id
- SDK control command 不再复用 runId trace fallback

## 边界(no-new-core)

- 不新增 actor type / envelope kind / pipeline phase
- 不引入新 workflow identity contract type(那是 later slice #1327)
- 保留 workflow identity 功能本身(只删除混用)

## 验证

- 4 files changed,+91/-26
- 本地 build + test 通过

closes #1326

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧