### PR TITLE
#1332 first slice: workflow typed tool context(reuse existing context,no-new-core)

### DIFF
--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunModels.cs
@@ -1,4 +1,5 @@
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
 
 namespace Aevatar.Workflow.Application.Abstractions.Runs;
 
@@ -127,7 +128,9 @@ public sealed record WorkflowChatRunRequest(
     //   Old pattern: scope id / channel facts fell back to metadata bag string keys.
     //   New principle: stable business semantics use typed proto field; metadata bag only for genuine open extension.
     string? ScopeId = null,
-    LLMControlContext? LlmControl = null);
+    LLMControlContext? LlmControl = null,
+    // Refactor (issue1332): Old pattern: workflow chat commands could only carry tool controls through metadata/LlmControl. New principle: reuse typed AgentToolExecutionContext as the workflow ToolContext control surface.
+    AgentToolExecutionContext? ToolContext = null);
 
 public enum WorkflowChatRunStartError
 {

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs
@@ -1,5 +1,6 @@
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Runs;
@@ -27,6 +28,8 @@ internal sealed class WorkflowChatRequestEnvelopeFactory : ICommandEnvelopeFacto
         chatRequest.Headers[WorkflowRunCommandMetadataKeys.SessionId] = sessionId;
         // Refactor (iter56/cluster-917-workflow-llm-control-metadata): old=Headers/Metadata bag for control fields, new=typed ChatRequestEvent.Telegram
         AppendMetadata(chatRequest.Metadata, command.Metadata);
+        if (command.ToolContext != null)
+            chatRequest.ToolContext = ToDurableToolContextPayload(command.ToolContext);
         if (command.LlmControl != null)
             chatRequest.LlmControl = ToDurableLlmControlPayload(command.LlmControl);
 
@@ -107,4 +110,11 @@ internal sealed class WorkflowChatRequestEnvelopeFactory : ICommandEnvelopeFacto
             NyxIdRoutePreference: control.NyxIdRoutePreference,
             MaxToolRoundsOverride: control.MaxToolRoundsOverride,
             UserMemoryPrompt: control.UserMemoryPrompt).ToPayload();
+
+    // Refactor (issue1332): Old pattern: workflow chat command envelope dropped typed ToolContext and relied on metadata/LlmControl. New principle: reuse AgentToolExecutionContext payload and scrub bearer fields before durable workflow state.
+    private static AgentToolExecutionContextPayload ToDurableToolContextPayload(AgentToolExecutionContext context) =>
+        (context with
+        {
+            Credentials = AgentToolCredentials.Empty,
+        }).ToPayload();
 }

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatCapabilityModels.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatCapabilityModels.cs
@@ -1,3 +1,5 @@
+using Aevatar.AI.Abstractions.ToolProviders;
+
 namespace Aevatar.Workflow.Infrastructure.CapabilityApi;
 
 internal static class ChatCapabilityMessageTypes
@@ -54,6 +56,9 @@ public sealed record ChatInput
     public IDictionary<string, string>? Metadata { get; init; }
 
     public ChatLlmControlInput? LlmControl { get; init; }
+
+    // Refactor (issue1332): Old pattern: workflow chat control used metadata or LlmControl only. New principle: reuse AgentToolExecutionContext as typed ToolContext without adding a workflow-specific abstraction.
+    public AgentToolExecutionContext? ToolContext { get; init; }
 }
 
 public sealed record ChatLlmControlInput

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunRequestNormalizer.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunRequestNormalizer.cs
@@ -69,7 +69,8 @@ internal static class ChatRunRequestNormalizer
                 InputParts: normalizedInputParts,
                 Metadata: normalizedMetadata,
                 ScopeId: normalizedContext.ScopeId,
-                LlmControl: NormalizeLlmControl(input.LlmControl)));
+                LlmControl: NormalizeLlmControl(input.LlmControl),
+                ToolContext: input.ToolContext));
     }
 
     private static LLMControlContext? NormalizeLlmControl(ChatLlmControlInput? source)

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationRegistrationAndExecutionTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationRegistrationAndExecutionTests.cs
@@ -1,5 +1,6 @@
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
@@ -344,6 +345,60 @@ public sealed class WorkflowApplicationRegistrationAndExecutionTests
         request.LlmControl.NyxIdRoutePreference.Should().Be(" route-a ");
         request.LlmControl.MaxToolRoundsOverride.Should().Be(3);
         request.LlmControl.UserMemoryPrompt.Should().Be(" memory ");
+    }
+
+    [Fact]
+    public void EnvelopeFactory_ShouldCarryTypedToolContext_AndScrubCredentials()
+    {
+        var services = new ServiceCollection();
+        services.AddWorkflowApplication();
+        using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<ICommandEnvelopeFactory<WorkflowChatRunRequest>>();
+        var command = new WorkflowChatRunRequest(
+            "hello",
+            WorkflowChatSource.DefinitionActor("actor-1", "direct"),
+            ToolContext: AgentToolExecutionContext.Empty with
+            {
+                Request = new AgentToolRequestIdentity(" req-1 ", " call-1 "),
+                Credentials = new AgentToolCredentials(" access-token ", " org-token ", " sender-token "),
+                Caller = new AgentToolCallerContext(" scope-1 ", " owner-1 ", " response-1 "),
+                Channel = new AgentToolChannelContext("lark", "sender-1", "reg-scope-1", "msg-1", "platform-msg-1"),
+                SenderBinding = new AgentToolSenderBindingContext("binding-1"),
+                Routing = LLMRequestRoutingContext.Empty with
+                {
+                    ModelOverride = " model-a ",
+                    NyxIdRoutePreference = " route-a ",
+                    MaxToolRoundsOverride = 4,
+                    UserMemoryPrompt = " memory ",
+                },
+                ConnectedServices = new AgentToolConnectedServicesContext("{\"service\":\"ok\"}"),
+                ExternalMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["trace-id"] = "trace-1",
+                },
+            });
+
+        var envelope = factory.CreateEnvelope(command, new CommandContext(
+            "actor-1",
+            "cmd-1",
+            "corr-1",
+            new Dictionary<string, string>()));
+        var request = envelope.Payload.Unpack<ChatRequestEvent>();
+        var toolContext = AgentToolExecutionContextMapper.FromPayload(request.ToolContext);
+
+        toolContext.Request.RequestId.Should().Be("req-1");
+        toolContext.Request.CallId.Should().Be("call-1");
+        toolContext.Credentials.Should().Be(AgentToolCredentials.Empty);
+        toolContext.Caller.ScopeId.Should().Be("scope-1");
+        toolContext.Caller.OwnerSubject.Should().Be("owner-1");
+        toolContext.Channel.MessageId.Should().Be("msg-1");
+        toolContext.SenderBinding.BindingId.Should().Be("binding-1");
+        toolContext.Routing.ModelOverride.Should().Be("model-a");
+        toolContext.Routing.NyxIdRoutePreference.Should().Be("route-a");
+        toolContext.Routing.MaxToolRoundsOverride.Should().Be(4);
+        toolContext.Routing.UserMemoryPrompt.Should().Be("memory");
+        toolContext.ConnectedServices.ContextJson.Should().Be("{\"service\":\"ok\"}");
+        toolContext.ExternalMetadata["trace-id"].Should().Be("trace-1");
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowCapabilityEndpointsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowCapabilityEndpointsCoverageTests.cs
@@ -2,6 +2,7 @@ using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Application.Runs;
 using Aevatar.Workflow.Infrastructure.CapabilityApi;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
 using FluentAssertions;
 
 namespace Aevatar.Workflow.Host.Api.Tests;
@@ -137,6 +138,37 @@ public sealed class WorkflowCapabilityEndpointsCoverageTests
             3,
             UserMemoryPrompt: null));
         result.Request.Metadata.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ChatRunRequestNormalizer_ShouldPreserveTypedToolContext()
+    {
+        var toolContext = AgentToolExecutionContext.Empty with
+        {
+            Request = new AgentToolRequestIdentity(" req-1 ", " call-1 "),
+            Caller = new AgentToolCallerContext(" scope-1 ", " owner-1 ", " response-1 "),
+            Routing = LLMRequestRoutingContext.Empty with
+            {
+                ModelOverride = " model-a ",
+                NyxIdRoutePreference = " route-a ",
+                MaxToolRoundsOverride = 2,
+            },
+            ExternalMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["trace-id"] = "trace-1",
+            },
+        };
+        var input = new ChatInput
+        {
+            Prompt = "hello",
+            ToolContext = toolContext,
+        };
+
+        var result = ChatRunRequestNormalizer.Normalize(input);
+
+        result.Succeeded.Should().BeTrue();
+        result.Request!.ToolContext.Should().BeSameAs(toolContext);
+        result.Request.LlmControl.Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## 摘要

源自 #1301 r1 split first-slice。reuse existing `AgentToolExecutionContext` / `LLMControlContext`,workflow ChatRun typed control fields。**no new ToolContext top-level abstraction**。

## 边界

- 复用现有 typed context
- 不引入新 ToolContext top-level type
- 6 files +108/-2

closes #1332

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧