### PR TITLE
#1334 first slice: ChatRun result json boundary quarantine(rename-only,no-new-core)

### DIFF
--- a/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
@@ -298,7 +298,7 @@ message ChatRunToolCallRecord {
   string tool_call_id = 1;
   string tool_name = 2;
   google.protobuf.Struct arguments = 3;
-  string result_json = 4;
+  string internal_result_json = 4;
   int32 llm_round = 5;
   string run_id = 6;
   google.protobuf.Timestamp observed_at = 7;
@@ -365,7 +365,7 @@ message SubmitChatRunToolCallRequested {
   string tool_call_id = 1;
   string tool_name = 2;
   google.protobuf.Struct arguments = 3;
-  string result_json = 4;
+  string internal_result_json = 4;
   string run_id = 5;
   ChatRunSubRunTargetKind target_kind = 6;
   string target_id = 7;
@@ -382,7 +382,7 @@ message ChatRunToolCallSubmittedEvent {
   string tool_call_id = 1;
   string tool_name = 2;
   google.protobuf.Struct arguments = 3;
-  string result_json = 4;
+  string internal_result_json = 4;
   string run_id = 5;
   ChatRunSubRunTargetKind target_kind = 6;
   string target_id = 7;
@@ -430,7 +430,7 @@ message ChatRunSubRunObservationStartedEvent {
 message ChatRunSubRunTerminalObserved {
   string run_id = 1;
   string status = 2;
-  string result_json = 3;
+  string internal_result_json = 3;
   string actor_id = 4;
   string service_id = 5;
   string endpoint_id = 6;
@@ -442,7 +442,7 @@ message ChatRunSubRunTerminalFoldedEvent {
   string run_id = 1;
   string caller_tool_call_id = 2;
   string tool_name = 3;
-  string result_json = 4;
+  string internal_result_json = 4;
   int32 llm_round = 5;
   google.protobuf.Timestamp observed_at = 6;
   string status = 7;
@@ -457,7 +457,7 @@ message ChatRunToolResultReady {
   string run_id = 2;
   string caller_tool_call_id = 3;
   string tool_name = 4;
-  string result_json = 5;
+  string internal_result_json = 5;
   int32 llm_round = 6;
   string status = 7;
   string actor_id = 8;

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ChatRunToolCompletionCoordinator.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ChatRunToolCompletionCoordinator.cs
@@ -37,6 +37,7 @@ public sealed class ChatRunToolCompletionCoordinator
     private readonly IServiceRunQueryPort _serviceRunQueryPort;
     private readonly IWorkflowExecutionQueryApplicationService _workflowQueryService;
 
+    // Refactor (issue1334): Old pattern: ChatRun completion coordination named folded actor results as generic ResultJson. New principle: actor-internal terminal payloads use internal_result_json and only boundary dispatch JSON remains boundary-named.
     public ChatRunToolCompletionCoordinator(
         IChatRunActorPort chatRunActorPort,
         IActorEventSubscriptionProvider subscriptionProvider,
@@ -134,7 +135,7 @@ public sealed class ChatRunToolCompletionCoordinator
         if (terminal == null && isGAgentInvocation)
         {
             var observed = await readySource.Task.WaitAsync(ct);
-            return observed.ResultJson;
+            return observed.InternalResultJson;
         }
 
         terminal ??= BuildTerminal(
@@ -143,11 +144,11 @@ public sealed class ChatRunToolCompletionCoordinator
             BuildCompletionNotObservedResult(toolCall.Name, completionRequest),
             completionObserved: false);
         if (string.IsNullOrWhiteSpace(terminal.RunId))
-            return terminal.ResultJson;
+            return terminal.InternalResultJson;
 
         await _chatRunActorPort.ObserveSubRunTerminalAsync(actorId, terminal, ct);
 
-        return (await readySource.Task.WaitAsync(ct)).ResultJson;
+        return (await readySource.Task.WaitAsync(ct)).InternalResultJson;
     }
 
     // Refactor (iter290/cluster001): Old pattern: observation targets were recovered from tool ResultJson after dispatch. New principle: observation target fields are normalized before entering actor observation.
@@ -259,7 +260,7 @@ public sealed class ChatRunToolCompletionCoordinator
         {
             RunId = dispatch.RunId,
             Status = status,
-            ResultJson = resultJson,
+            InternalResultJson = resultJson,
             ActorId = dispatch.ActorId,
             ServiceId = dispatch.ServiceId,
             EndpointId = dispatch.EndpointId,

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ChatRunToolCompletionCoordinator.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ChatRunToolCompletionCoordinator.cs
@@ -37,7 +37,9 @@ public sealed class ChatRunToolCompletionCoordinator
     private readonly IServiceRunQueryPort _serviceRunQueryPort;
     private readonly IWorkflowExecutionQueryApplicationService _workflowQueryService;
 
-    // Refactor (issue1334): Old pattern: ChatRun completion coordination named folded actor results as generic ResultJson. New principle: actor-internal terminal payloads use internal_result_json and only boundary dispatch JSON remains boundary-named.
+    // Refactor (iter1334/cluster-1334-chatrun-result-json-boundary-quarantine):
+    // Old pattern: ChatRun completion coordination named folded actor results as generic ResultJson.
+    // New principle: actor-internal terminal payloads use internal_result_json and only boundary dispatch JSON remains boundary-named.
     public ChatRunToolCompletionCoordinator(
         IChatRunActorPort chatRunActorPort,
         IActorEventSubscriptionProvider subscriptionProvider,

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/ChatRunActor.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/ChatRunActor.cs
@@ -17,6 +17,7 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
 {
     private static readonly Duration DefaultIdleTtl = Duration.FromTimeSpan(TimeSpan.FromMinutes(30));
 
+    // Refactor (issue1334): Old pattern: ChatRun persisted folded tool results used generic ResultJson naming. New principle: ChatRun actor state and events quarantine that JSON as internal_result_json while boundary payload names remain explicit.
     public ChatRunActor()
     {
         InitializeId();
@@ -101,7 +102,7 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
             ToolCallId = NormalizeRequired(command.ToolCallId, nameof(command.ToolCallId)),
             ToolName = NormalizeRequired(command.ToolName, nameof(command.ToolName)),
             Arguments = command.Arguments?.Clone() ?? new Struct(),
-            ResultJson = command.ResultJson ?? string.Empty,
+            InternalResultJson = command.InternalResultJson ?? string.Empty,
             RunId = command.RunId ?? string.Empty,
             TargetKind = command.TargetKind,
             TargetId = command.TargetId ?? string.Empty,
@@ -127,15 +128,15 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
         if (pending == null)
             return;
 
-        var resultJson = string.IsNullOrWhiteSpace(observed.ResultJson)
+        var internalResultJson = string.IsNullOrWhiteSpace(observed.InternalResultJson)
             ? BuildDefaultResultJson(pending, observed)
-            : observed.ResultJson;
+            : observed.InternalResultJson;
         await PersistDomainEventAsync(new ChatRunSubRunTerminalFoldedEvent
         {
             RunId = runId,
             CallerToolCallId = pending.CallerToolCallId,
             ToolName = pending.ToolName,
-            ResultJson = resultJson,
+            InternalResultJson = internalResultJson,
             LlmRound = pending.LlmRound,
             Status = observed.Status ?? string.Empty,
             ActorId = FirstNonEmpty(observed.ActorId, pending.ActorId),
@@ -152,7 +153,7 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
             RunId = runId,
             CallerToolCallId = pending.CallerToolCallId,
             ToolName = pending.ToolName,
-            ResultJson = resultJson,
+            InternalResultJson = internalResultJson,
             LlmRound = pending.LlmRound,
             Status = observed.Status ?? string.Empty,
             ActorId = FirstNonEmpty(observed.ActorId, pending.ActorId),
@@ -195,7 +196,7 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
         {
             RunId = pending.RunId,
             Status = ResolveGAgentTerminalStatus(completed),
-            ResultJson = BuildGAgentTerminalResultJson(pending, completed),
+            InternalResultJson = BuildGAgentTerminalResultJson(pending, completed),
             ActorId = pending.ActorId,
             ServiceId = pending.ServiceId,
             EndpointId = pending.EndpointId,
@@ -267,7 +268,7 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
         var next = current.Clone();
         var existingHistory = next.ToolCallHistory
             .LastOrDefault(call => string.Equals(call.ToolCallId, evt.ToolCallId, StringComparison.Ordinal));
-        var alreadyFolded = existingHistory != null && !string.IsNullOrWhiteSpace(existingHistory.ResultJson);
+        var alreadyFolded = existingHistory != null && !string.IsNullOrWhiteSpace(existingHistory.InternalResultJson);
         if (existingHistory == null)
         {
             next.ToolCallHistory.Add(new ChatRunToolCallRecord
@@ -275,7 +276,7 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
                 ToolCallId = evt.ToolCallId,
                 ToolName = evt.ToolName,
                 Arguments = evt.Arguments?.Clone() ?? new Struct(),
-                ResultJson = evt.ResultJson,
+                InternalResultJson = evt.InternalResultJson,
                 LlmRound = evt.LlmRound,
                 RunId = evt.RunId,
                 ObservedAt = evt.ObservedAt ?? Timestamp.FromDateTime(DateTime.UtcNow),
@@ -314,7 +315,7 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
         var next = current.Clone();
         var existingHistory = next.ToolCallHistory
             .LastOrDefault(call => string.Equals(call.ToolCallId, evt.ToolCallId, StringComparison.Ordinal));
-        if (existingHistory != null && !string.IsNullOrWhiteSpace(existingHistory.ResultJson))
+        if (existingHistory != null && !string.IsNullOrWhiteSpace(existingHistory.InternalResultJson))
         {
             next.CurrentLlmRound = Math.Max(next.CurrentLlmRound, evt.LlmRound);
             next.LastActivityAt = evt.ObservedAt ?? Timestamp.FromDateTime(DateTime.UtcNow);
@@ -328,7 +329,7 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
                 ToolCallId = evt.ToolCallId,
                 ToolName = evt.ToolName,
                 Arguments = evt.Arguments?.Clone() ?? new Struct(),
-                ResultJson = string.Empty,
+                InternalResultJson = string.Empty,
                 LlmRound = evt.LlmRound,
                 RunId = evt.RunId,
                 ObservedAt = evt.ObservedAt ?? Timestamp.FromDateTime(DateTime.UtcNow),
@@ -366,13 +367,13 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
         var history = next.ToolCallHistory
             .LastOrDefault(call => string.Equals(call.RunId, evt.RunId, StringComparison.Ordinal));
         if (history != null)
-            history.ResultJson = evt.ResultJson;
+            history.InternalResultJson = evt.InternalResultJson;
 
         next.Messages.Add(new ChatRunMessageRecord
         {
             Role = "tool",
             ToolCallId = evt.CallerToolCallId,
-            Content = evt.ResultJson,
+            Content = evt.InternalResultJson,
         });
         next.CurrentLlmRound = evt.LlmRound + 1;
         next.LastActivityAt = evt.ObservedAt ?? Timestamp.FromDateTime(DateTime.UtcNow);

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/ChatRunActor.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/ChatRunActor.cs
@@ -17,7 +17,9 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
 {
     private static readonly Duration DefaultIdleTtl = Duration.FromTimeSpan(TimeSpan.FromMinutes(30));
 
-    // Refactor (issue1334): Old pattern: ChatRun persisted folded tool results used generic ResultJson naming. New principle: ChatRun actor state and events quarantine that JSON as internal_result_json while boundary payload names remain explicit.
+    // Refactor (iter1334/cluster-1334-chatrun-result-json-boundary-quarantine):
+    // Old pattern: ChatRun persisted folded tool results used generic ResultJson naming.
+    // New principle: ChatRun actor state and events quarantine that JSON as internal_result_json while boundary payload names remain explicit.
     public ChatRunActor()
     {
         InitializeId();
@@ -129,7 +131,7 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
             return;
 
         var internalResultJson = string.IsNullOrWhiteSpace(observed.InternalResultJson)
-            ? BuildDefaultResultJson(pending, observed)
+            ? BuildDefaultInternalResultJson(pending, observed)
             : observed.InternalResultJson;
         await PersistDomainEventAsync(new ChatRunSubRunTerminalFoldedEvent
         {
@@ -196,7 +198,7 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
         {
             RunId = pending.RunId,
             Status = ResolveGAgentTerminalStatus(completed),
-            InternalResultJson = BuildGAgentTerminalResultJson(pending, completed),
+            InternalResultJson = BuildGAgentTerminalInternalResultJson(pending, completed),
             ActorId = pending.ActorId,
             ServiceId = pending.ServiceId,
             EndpointId = pending.EndpointId,
@@ -495,7 +497,7 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
             state.ActiveSubRunSubscriptions.Add(subscription);
     }
 
-    private static string BuildDefaultResultJson(
+    private static string BuildDefaultInternalResultJson(
         ChatRunSubRunSubscription pending,
         ChatRunSubRunTerminalObserved observed)
     {
@@ -517,7 +519,7 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
         });
     }
 
-    private static string BuildGAgentTerminalResultJson(
+    private static string BuildGAgentTerminalInternalResultJson(
         ChatRunSubRunSubscription pending,
         RoleChatSessionCompletedEvent completed)
     {

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/ChatRunActorAdapter.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/ChatRunActorAdapter.cs
@@ -15,6 +15,7 @@ public sealed class ChatRunActorAdapter : IChatRunActorPort
     private readonly IActorRuntime _runtime;
     private readonly IActorDispatchPort _dispatchPort;
 
+    // Refactor (issue1334): Old pattern: boundary ToolExecutionResultJson was written into ChatRun commands as generic ResultJson. New principle: adapter quarantines it into internal_result_json before actor persistence.
     public ChatRunActorAdapter(
         IActorRuntime runtime,
         IActorDispatchPort dispatchPort)
@@ -63,7 +64,7 @@ public sealed class ChatRunActorAdapter : IChatRunActorPort
             ToolCallId = NormalizeRequired(request.ToolCall.Id, nameof(request.ToolCall.Id)),
             ToolName = NormalizeRequired(request.ToolCall.Name, nameof(request.ToolCall.Name)),
             Arguments = ParseStruct(request.ArgumentsJson),
-            ResultJson = request.ToolExecutionResultJson ?? string.Empty,
+            InternalResultJson = request.ToolExecutionResultJson ?? string.Empty,
             RunId = target.RunId,
             TargetKind = ResolveTargetKind(request.ToolCall.Name),
             TargetId = ResolveTargetId(target),

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/ChatRunActorAdapter.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/ChatRunActorAdapter.cs
@@ -15,7 +15,9 @@ public sealed class ChatRunActorAdapter : IChatRunActorPort
     private readonly IActorRuntime _runtime;
     private readonly IActorDispatchPort _dispatchPort;
 
-    // Refactor (issue1334): Old pattern: boundary ToolExecutionResultJson was written into ChatRun commands as generic ResultJson. New principle: adapter quarantines it into internal_result_json before actor persistence.
+    // Refactor (iter1334/cluster-1334-chatrun-result-json-boundary-quarantine):
+    // Old pattern: boundary ToolExecutionResultJson was written into ChatRun commands as generic ResultJson.
+    // New principle: adapter quarantines it into internal_result_json before actor persistence.
     public ChatRunActorAdapter(
         IActorRuntime runtime,
         IActorDispatchPort dispatchPort)

--- a/test/Aevatar.GAgentService.Tests/Application/ChatRunToolCompletionCoordinatorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ChatRunToolCompletionCoordinatorTests.cs
@@ -58,7 +58,7 @@ public sealed class ChatRunToolCompletionCoordinatorTests
                         terminal.Status == "RunFinished" &&
                         terminal.ServiceId == "service-1" &&
                         terminal.EndpointId == "entry" &&
-                        terminal.ResultJson.Contains("\"completion_observed\": true", StringComparison.Ordinal));
+                        terminal.InternalResultJson.Contains("\"completion_observed\": true", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -101,7 +101,7 @@ public sealed class ChatRunToolCompletionCoordinatorTests
         harness.ChatRunPort.ObservedTerminals.Should().ContainSingle().Which.Should().Match<ChatRunSubRunTerminalObserved>(
             terminal => terminal.RunId == "wf-command" &&
                         terminal.Status == "completion_not_observed" &&
-                        terminal.ResultJson.Contains("completion_not_observed", StringComparison.Ordinal));
+                        terminal.InternalResultJson.Contains("completion_not_observed", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -231,7 +231,7 @@ public sealed class ChatRunToolCompletionCoordinatorTests
                     RunId = observed.RunId,
                     CallerToolCallId = request.ToolCall.Id,
                     ToolName = request.ToolCall.Name,
-                    ResultJson = observed.ResultJson,
+                    InternalResultJson = observed.InternalResultJson,
                     LlmRound = request.LlmRound,
                     Status = observed.Status,
                     ActorId = observed.ActorId,

--- a/test/Aevatar.GAgentService.Tests/Application/ChatRunToolCompletionCoordinatorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ChatRunToolCompletionCoordinatorTests.cs
@@ -152,6 +152,112 @@ public sealed class ChatRunToolCompletionCoordinatorTests
         harness.ChatRunPort.ObservedTerminals.Should().ContainSingle().Which.ActorId.Should().Be("actor-from-name");
     }
 
+    [Fact]
+    public async Task ExecuteAsync_WaitCompleteGAgent_WhenOnlyReadyNotificationArrives_ShouldReturnInternalResultJson()
+    {
+        var harness = new Harness();
+        var coordinator = harness.CreateCoordinator();
+        var toolCall = new ToolCall
+        {
+            Id = "call_gagent_ready",
+            Name = "aevatar_invoke_gagent",
+            ArgumentsJson = """{"actor_id":"actor-ready","payload":{"prompt":"hi"},"wait":"complete"}""",
+        };
+        const string foldedPayload = """{"run_id":"run-ready","content":"ready payload"}""";
+
+        var result = await coordinator.ExecuteAsync(
+            BuildRequest(),
+            toolCall,
+            toolCall.ArgumentsJson,
+            async (request, _) =>
+            {
+                await harness.PublishReadyAsync(new ChatRunToolResultReady
+                {
+                    ResponseId = request.ResponseId,
+                    RunId = "run-ready",
+                    CallerToolCallId = toolCall.Id,
+                    ToolName = toolCall.Name,
+                    InternalResultJson = foldedPayload,
+                    LlmRound = request.LlmRound,
+                    Status = "RunFinished",
+                    ActorId = "actor-ready",
+                    CompletionObserved = true,
+                });
+                return request with
+                {
+                    ToolExecutionResultJson = """{"opaque":"gagent-dispatch"}""",
+                    RunId = "run-ready",
+                    Status = "streaming",
+                    StreamTopic = "aevatar://actors/actor-ready/runs/run-ready",
+                    ActorId = "actor-ready",
+                    WaitMode = ChatRunSubRunWaitMode.Complete,
+                };
+            },
+            llmRound: 2);
+
+        result.Should().Be(foldedPayload);
+        harness.ChatRunPort.ObservedTerminals.Should().BeEmpty();
+        harness.ChatRunPort.SubmittedToolCalls.Should().ContainSingle()
+            .Which.ToolExecutionResultJson.Should().Be("""{"opaque":"gagent-dispatch"}""");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WaitCompleteTeam_WhenReadModelIsTerminal_ShouldReturnObservedInternalResultJson()
+    {
+        var harness = new Harness();
+        harness.ServiceRunQuery.ByRunId = new ServiceRunSnapshot(
+            "scope-1",
+            "service-1",
+            "service-key",
+            "team-run",
+            "command-1",
+            "correlation-1",
+            "entry",
+            ServiceImplementationKind.Static,
+            "target-actor",
+            "revision-1",
+            "deployment-1",
+            ServiceRunStatus.Completed,
+            "actor-1",
+            "tenant-1",
+            "app-1",
+            "namespace-1",
+            7,
+            "event-7",
+            DateTimeOffset.Parse("2026-05-23T00:00:00+00:00"),
+            DateTimeOffset.Parse("2026-05-23T00:01:00+00:00"));
+        var coordinator = harness.CreateCoordinator();
+        var toolCall = new ToolCall
+        {
+            Id = "call_team_readmodel",
+            Name = "aevatar_invoke_team",
+            ArgumentsJson = """{"team_id":"team-1","endpoint_id":"entry","wait":"complete"}""",
+        };
+
+        var result = await coordinator.ExecuteAsync(
+            BuildRequest(),
+            toolCall,
+            toolCall.ArgumentsJson,
+            (request, _) => Task.FromResult(request with
+            {
+                ToolExecutionResultJson = """{"opaque":"team-dispatch"}""",
+                RunId = "team-run",
+                Status = "running",
+                ServiceId = "service-1",
+                EndpointId = "entry",
+                ScopeId = "scope-1",
+                WaitMode = ChatRunSubRunWaitMode.Complete,
+            }),
+            llmRound: 1);
+
+        var observed = harness.ChatRunPort.ObservedTerminals.Should().ContainSingle().Subject;
+        observed.Should().Match<ChatRunSubRunTerminalObserved>(
+            terminal => terminal.RunId == "team-run" &&
+                        terminal.Status == ServiceRunStatus.Completed.ToString() &&
+                        terminal.InternalResultJson.Contains("\"service_key\":\"service-key\"", StringComparison.Ordinal));
+        result.Should().Be(observed.InternalResultJson);
+    }
+
     private static LLMRequest BuildRequest() =>
         new()
         {
@@ -181,6 +287,9 @@ public sealed class ChatRunToolCompletionCoordinatorTests
                 TerminalQuery,
                 ServiceRunQuery,
                 WorkflowQuery);
+
+        public Task PublishReadyAsync(ChatRunToolResultReady ready) =>
+            _subscriptionProvider.PublishReadyAsync(ChatRunPort.ActorId, ready);
     }
 
     private sealed class RecordingChatRunActorPort(RecordingSubscriptionProvider subscriptionProvider)

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesCompletionApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesCompletionApplicationServiceTests.cs
@@ -217,7 +217,7 @@ public sealed class ResponsesCompletionApplicationServiceTests
                     RunId = observed.RunId,
                     CallerToolCallId = SubmittedToolCalls.Single().ToolCall.Id,
                     ToolName = SubmittedToolCalls.Single().ToolCall.Name,
-                    ResultJson = observed.ResultJson,
+                    InternalResultJson = observed.InternalResultJson,
                     LlmRound = SubmittedToolCalls.Single().LlmRound,
                     Status = observed.Status,
                     ServiceId = observed.ServiceId,

--- a/test/Aevatar.GAgentService.Tests/Core/ChatRunActorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ChatRunActorTests.cs
@@ -118,6 +118,120 @@ public sealed class ChatRunActorTests
     }
 
     [Fact]
+    public async Task SubmitWaitCompleteThenTerminal_WhenObservedResultIsBlank_ShouldBuildDefaultInternalResultJson()
+    {
+        var eventStore = new InMemoryEventStore();
+        var actor = await StartedActorAsync("resp_default_result", eventStore);
+
+        await actor.HandleSubmitToolCallAsync(BuildSubmit(
+            toolCallId: "call_default",
+            runId: "run_default",
+            waitMode: ChatRunSubRunWaitMode.Complete,
+            actorId: "actor-default"));
+
+        await actor.HandleSubRunTerminalAsync(new ChatRunSubRunTerminalObserved
+        {
+            RunId = "run_default",
+            Status = "RunFinished",
+            InternalResultJson = " ",
+        });
+
+        var history = actor.State.ToolCallHistory.Should().ContainSingle().Subject;
+        history.InternalResultJson.Should().Contain("\"run_id\":\"run_default\"");
+        history.InternalResultJson.Should().Contain("\"actor_id\":\"actor-default\"");
+        actor.State.Messages.Should().ContainSingle(message =>
+            message.Role == "tool" &&
+            message.ToolCallId == "call_default" &&
+            message.Content == history.InternalResultJson);
+
+        var foldedEvent = (await eventStore.GetEventsAsync(actor.Id))
+            .Select(static evt => evt.EventData)
+            .Where(static payload => payload.Is(ChatRunSubRunTerminalFoldedEvent.Descriptor))
+            .Select(static payload => payload.Unpack<ChatRunSubRunTerminalFoldedEvent>())
+            .Should()
+            .ContainSingle()
+            .Subject;
+        foldedEvent.InternalResultJson.Should().Be(history.InternalResultJson);
+    }
+
+    [Fact]
+    public async Task SubmitWaitComplete_WhenHistoryAlreadyHasInternalResultJson_ShouldNotReopenSubscription()
+    {
+        var actor = await StartedActorAsync("resp_folded_resubmit");
+
+        await actor.HandleSubmitToolCallAsync(BuildSubmit(
+            toolCallId: "call_folded",
+            runId: "run_folded",
+            waitMode: ChatRunSubRunWaitMode.Complete));
+        await actor.HandleSubRunTerminalAsync(new ChatRunSubRunTerminalObserved
+        {
+            RunId = "run_folded",
+            Status = "RunFinished",
+            InternalResultJson = """{"content":"folded"}""",
+        });
+
+        await actor.HandleSubmitToolCallAsync(BuildSubmit(
+            toolCallId: "call_folded",
+            runId: "run_folded",
+            waitMode: ChatRunSubRunWaitMode.Complete,
+            resultJson: """{"content":"resubmitted"}"""));
+
+        actor.State.ActiveSubRunSubscriptions.Should().BeEmpty();
+        actor.State.ToolCallHistory.Should().ContainSingle()
+            .Which.InternalResultJson.Should().Contain("folded");
+    }
+
+    [Fact]
+    public async Task PrepareObservation_WhenHistoryAlreadyHasInternalResultJson_ShouldKeepFoldedResult()
+    {
+        var actor = await StartedActorAsync("resp_folded_prepare");
+
+        await actor.HandleSubmitToolCallAsync(BuildSubmit(
+            toolCallId: "call_folded_prepare",
+            runId: "run_folded_prepare",
+            waitMode: ChatRunSubRunWaitMode.Stream,
+            resultJson: """{"content":"already-folded"}"""));
+
+        await actor.HandlePrepareSubRunObservationAsync(BuildPrepareObservation(
+            toolCallId: "call_folded_prepare",
+            runId: "run_folded_prepare",
+            actorId: "actor-1"));
+
+        actor.State.ActiveSubRunSubscriptions.Should().BeEmpty();
+        actor.State.ToolCallHistory.Should().ContainSingle()
+            .Which.InternalResultJson.Should().Contain("already-folded");
+    }
+
+    [Fact]
+    public void ChatRunResultJsonFields_ShouldRoundTripAsInternalResultJsonOnExistingWireNumbers()
+    {
+        AssertInternalResultJsonRoundTrips(
+            new ChatRunToolCallRecord { ToolCallId = "call-1", InternalResultJson = """{"value":"record"}""" },
+            static message => ChatRunToolCallRecord.Parser.ParseFrom(message.ToByteArray()).InternalResultJson,
+            """{"value":"record"}""");
+        AssertInternalResultJsonRoundTrips(
+            new SubmitChatRunToolCallRequested { ToolCallId = "call-1", InternalResultJson = """{"value":"submit"}""" },
+            static message => SubmitChatRunToolCallRequested.Parser.ParseFrom(message.ToByteArray()).InternalResultJson,
+            """{"value":"submit"}""");
+        AssertInternalResultJsonRoundTrips(
+            new ChatRunToolCallSubmittedEvent { ToolCallId = "call-1", InternalResultJson = """{"value":"submitted"}""" },
+            static message => ChatRunToolCallSubmittedEvent.Parser.ParseFrom(message.ToByteArray()).InternalResultJson,
+            """{"value":"submitted"}""");
+        AssertInternalResultJsonRoundTrips(
+            new ChatRunSubRunTerminalObserved { RunId = "run-1", InternalResultJson = """{"value":"observed"}""" },
+            static message => ChatRunSubRunTerminalObserved.Parser.ParseFrom(message.ToByteArray()).InternalResultJson,
+            """{"value":"observed"}""");
+        AssertInternalResultJsonRoundTrips(
+            new ChatRunSubRunTerminalFoldedEvent { RunId = "run-1", InternalResultJson = """{"value":"folded"}""" },
+            static message => ChatRunSubRunTerminalFoldedEvent.Parser.ParseFrom(message.ToByteArray()).InternalResultJson,
+            """{"value":"folded"}""");
+        AssertInternalResultJsonRoundTrips(
+            new ChatRunToolResultReady { ResponseId = "resp-1", InternalResultJson = """{"value":"ready"}""" },
+            static message => ChatRunToolResultReady.Parser.ParseFrom(message.ToByteArray()).InternalResultJson,
+            """{"value":"ready"}""");
+    }
+
+    [Fact]
     public async Task State_ShouldExposeTypedSubRunSubscriptionShape()
     {
         var actor = await StartedActorAsync("resp_typed");
@@ -517,6 +631,15 @@ public sealed class ChatRunActorTests
             ChatRunSubRunWaitMode.Complete => "complete",
             _ => "stream",
         };
+
+    private static void AssertInternalResultJsonRoundTrips<TMessage>(
+        TMessage message,
+        Func<TMessage, string> parse,
+        string expected)
+        where TMessage : IMessage<TMessage>
+    {
+        parse(message).Should().Be(expected);
+    }
 
     private static EventEnvelope BuildForwardedCommittedCompletionEnvelope(
         string sourceActorId,

--- a/test/Aevatar.GAgentService.Tests/Core/ChatRunActorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ChatRunActorTests.cs
@@ -323,6 +323,42 @@ public sealed class ChatRunActorTests
     }
 
     [Fact]
+    public async Task AdapterSubmitToolCall_ShouldMapBoundaryToolExecutionResultJsonToInternalResultJson()
+    {
+        var dispatchPort = new RecordingDispatchPort();
+        var adapter = new ChatRunActorAdapter(new RecordingActorRuntime(), dispatchPort);
+        const string boundaryPayload = """{"opaque":"tool-output"}""";
+
+        await adapter.SubmitToolCallAsync(
+            "chat-run:resp_adapter",
+            new ChatRunToolCompletionRequest(
+                "resp_adapter",
+                "gpt-test",
+                [ChatMessage.User("hello")],
+                new ToolCall
+                {
+                    Id = "call_adapter",
+                    Name = "aevatar_invoke_gagent",
+                    ArgumentsJson = """{"actor_id":"actor-1","wait":"complete"}""",
+                },
+                """{"actor_id":"actor-1","wait":"complete"}""",
+                boundaryPayload,
+                1,
+                RunId: "run_adapter",
+                StreamTopic: "aevatar://actors/actor-1/runs/run_adapter",
+                ActorId: "actor-1",
+                WaitMode: ChatRunSubRunWaitMode.Complete));
+
+        var dispatched = dispatchPort.Calls.Should().ContainSingle().Subject;
+        dispatched.actorId.Should().Be("chat-run:resp_adapter");
+        var command = dispatched.envelope.Payload.Unpack<SubmitChatRunToolCallRequested>();
+
+        command.ToolCallId.Should().Be("call_adapter");
+        command.RunId.Should().Be("run_adapter");
+        command.InternalResultJson.Should().Be(boundaryPayload);
+    }
+
+    [Fact]
     public async Task ForwardedCommittedCompletion_ShouldPublishObservedToolResultReady()
     {
         var eventStore = new InMemoryEventStore();
@@ -593,6 +629,70 @@ public sealed class ChatRunActorTests
         {
             Entries.Add((logLevel, exception, formatter(state, exception)));
         }
+    }
+
+    private sealed class RecordingActorRuntime : IActorRuntime
+    {
+        public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
+            where TAgent : IAgent =>
+            Task.FromResult<IActor>(new RecordingActor(id ?? $"created:{typeof(TAgent).Name}"));
+
+        public Task<IActor> CreateAsync(System.Type agentType, string? id = null, CancellationToken ct = default) =>
+            Task.FromResult<IActor>(new RecordingActor(id ?? $"created:{agentType.Name}"));
+
+        public Task DestroyAsync(string id, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task<IActor?> GetAsync(string id) => Task.FromResult<IActor?>(new RecordingActor(id));
+
+        public Task<bool> ExistsAsync(string id) => Task.FromResult(true);
+
+        public Task LinkAsync(string parentId, string childId, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task UnlinkAsync(string childId, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class RecordingDispatchPort : IActorDispatchPort
+    {
+        public List<(string actorId, EventEnvelope envelope)> Calls { get; } = [];
+
+        public Task<DispatchAdmission> DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
+        {
+            Calls.Add((actorId, envelope.Clone()));
+            return Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
+        }
+    }
+
+    private sealed class RecordingActor(string id) : IActor
+    {
+        public string Id { get; } = id;
+
+        public IAgent Agent { get; } = new RecordingAgent(id);
+
+        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
+
+        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() => Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class RecordingAgent(string id) : IAgent
+    {
+        public string Id { get; } = id;
+
+        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task<string> GetDescriptionAsync() => Task.FromResult(string.Empty);
+
+        public Task<IReadOnlyList<System.Type>> GetSubscribedEventTypesAsync() =>
+            Task.FromResult<IReadOnlyList<System.Type>>([]);
+
+        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 
     private sealed class NoopAsyncDisposable : IAsyncDisposable

--- a/test/Aevatar.GAgentService.Tests/Core/ChatRunActorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ChatRunActorTests.cs
@@ -80,7 +80,7 @@ public sealed class ChatRunActorTests
         var history = actor.State.ToolCallHistory.Should().ContainSingle().Subject;
         history.ToolCallId.Should().Be("call_stream");
         history.RunId.Should().Be("run_stream");
-        history.ResultJson.Should().Contain("aevatar://actors/actor-1/runs/run_stream");
+        history.InternalResultJson.Should().Contain("aevatar://actors/actor-1/runs/run_stream");
         history.LlmRound.Should().Be(1);
     }
 
@@ -104,12 +104,12 @@ public sealed class ChatRunActorTests
         {
             RunId = "run_complete",
             Status = "RunFinished",
-            ResultJson = """{"run_id":"run_complete","status":"RunFinished","content":"done"}""",
+            InternalResultJson = """{"run_id":"run_complete","status":"RunFinished","content":"done"}""",
         });
 
         actor.State.ActiveSubRunSubscriptions.Should().BeEmpty();
         actor.State.ToolCallHistory.Should().ContainSingle()
-            .Which.ResultJson.Should().Contain("\"content\":\"done\"");
+            .Which.InternalResultJson.Should().Contain("\"content\":\"done\"");
         actor.State.Messages.Should().ContainSingle(message =>
             message.Role == "tool" &&
             message.ToolCallId == "call_complete" &&
@@ -160,7 +160,7 @@ public sealed class ChatRunActorTests
         await actor.HandleSubRunTerminalAsync(new ChatRunSubRunTerminalObserved
         {
             RunId = "run_second",
-            ResultJson = """{"run_id":"run_second","content":"second"}""",
+            InternalResultJson = """{"run_id":"run_second","content":"second"}""",
         });
 
         actor.State.ActiveSubRunSubscriptions.Should().ContainSingle()
@@ -173,7 +173,7 @@ public sealed class ChatRunActorTests
         await actor.HandleSubRunTerminalAsync(new ChatRunSubRunTerminalObserved
         {
             RunId = "run_first",
-            ResultJson = """{"run_id":"run_first","content":"first"}""",
+            InternalResultJson = """{"run_id":"run_first","content":"first"}""",
         });
 
         actor.State.ActiveSubRunSubscriptions.Should().BeEmpty();
@@ -183,9 +183,9 @@ public sealed class ChatRunActorTests
             .Should()
             .Equal("call_second", "call_first");
         actor.State.ToolCallHistory.Single(call => call.RunId == "run_first")
-            .ResultJson.Should().Contain("first");
+            .InternalResultJson.Should().Contain("first");
         actor.State.ToolCallHistory.Single(call => call.RunId == "run_second")
-            .ResultJson.Should().Contain("second");
+            .InternalResultJson.Should().Contain("second");
     }
 
     [Fact]
@@ -305,7 +305,7 @@ public sealed class ChatRunActorTests
         {
             RunId = "run_publish",
             Status = "RunFinished",
-            ResultJson = """{"run_id":"run_publish","content":"published"}""",
+            InternalResultJson = """{"run_id":"run_publish","content":"published"}""",
             ActorId = "actor-1",
             CompletionObserved = true,
         });
@@ -313,7 +313,7 @@ public sealed class ChatRunActorTests
         var published = await ready.Task.WaitAsync(TimeSpan.FromSeconds(5));
         published.RunId.Should().Be("run_publish");
         published.CallerToolCallId.Should().Be("call_publish");
-        published.ResultJson.Should().Contain("published");
+        published.InternalResultJson.Should().Contain("published");
         published.Status.Should().Be("RunFinished");
         published.ActorId.Should().Be("actor-1");
         published.CompletionObserved.Should().BeTrue();
@@ -346,7 +346,7 @@ public sealed class ChatRunActorTests
         actor.State.ActiveSubRunSubscriptions.Should().BeEmpty();
         var folded = actor.State.ToolCallHistory.Should().ContainSingle().Subject;
         folded.RunId.Should().Be("run_forwarded");
-        folded.ResultJson.Should().Contain("\"content\":\"forwarded done\"");
+        folded.InternalResultJson.Should().Contain("\"content\":\"forwarded done\"");
 
         var foldedEvent = (await eventStore.GetEventsAsync(actor.Id))
             .Select(static evt => evt.EventData)
@@ -434,7 +434,7 @@ public sealed class ChatRunActorTests
             ToolCallId = toolCallId,
             ToolName = "aevatar_invoke_gagent",
             Arguments = BuildArguments(waitMode),
-            ResultJson = resultJson,
+            InternalResultJson = resultJson,
             RunId = runId,
             TargetKind = ChatRunSubRunTargetKind.Gagent,
             TargetId = actorId,

--- a/test/Aevatar.GAgentService.Tests/Core/ChatRunActorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ChatRunActorTests.cs
@@ -232,6 +232,30 @@ public sealed class ChatRunActorTests
     }
 
     [Fact]
+    public void ChatRunInternalMessages_ShouldExposeInternalResultJsonFieldNameOnly()
+    {
+        var messageDescriptors = new[]
+        {
+            ChatRunToolCallRecord.Descriptor,
+            SubmitChatRunToolCallRequested.Descriptor,
+            ChatRunToolCallSubmittedEvent.Descriptor,
+            ChatRunSubRunTerminalObserved.Descriptor,
+            ChatRunSubRunTerminalFoldedEvent.Descriptor,
+            ChatRunToolResultReady.Descriptor,
+        };
+
+        foreach (var descriptor in messageDescriptors)
+        {
+            descriptor.Fields.InFieldNumberOrder()
+                .Should()
+                .ContainSingle(field => field.Name == "internal_result_json");
+            descriptor.Fields.InFieldNumberOrder()
+                .Should()
+                .NotContain(field => field.Name == "result_json");
+        }
+    }
+
+    [Fact]
     public async Task State_ShouldExposeTypedSubRunSubscriptionShape()
     {
         var actor = await StartedActorAsync("resp_typed");


### PR DESCRIPTION
## 摘要

源自 #1299 r2 split first-slice。

ChatRun result json 边界 quarantine,清晰区分 internal persistent semantics vs boundary payload;重命名/隔离已有 ChatRun result 类型,标明 internal 用途。**不引入新 typed value object**(那是 later slice #1335)。

closes #1334

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧