### PR TITLE
#1337 first slice: 删除 triage-monitor daemon self-spawn 改走 controller marker 路径(no-new-core)

### DIFF
--- a/.claude/skills/codex-refactor-loop/SKILL.md
+++ b/.claude/skills/codex-refactor-loop/SKILL.md
@@ -1070,16 +1070,17 @@ maintainer 只加 1 label:`auto-loop-triage`
 
 `.claude/skills/codex-refactor-loop/scripts/triage-monitor.sh` 60s 周期:
 - 扫 `gh issue list --label "auto-loop-triage" --state open`
-- 新 issue → mark seen + **直接 spawn triage codex**(nohup + disown,daemon 自己派)
+- 新 issue → mark seen + 物化 triage prompt/log path + 写 `.refactor-loop/.controller-pending-events.log`
+- controller 读取 pending event 后用 `spawn-codex.sh` 派 triage codex,由 `spawn-codex.sh` 写标准 `.refactor-loop/markers/*.running|done.json`
 - triage codex 自己读 issue body + update GitHub(reshape or 评论 + label 切换)
-- daemon 不依赖 controller 中转,无中间 event log
+- daemon 只负责 detect / log / prompt materialization,不自己派 codex
 - state 存 `.refactor-loop/triage-monitor-state.json` 防重复
 - 启动:`nohup bash .claude/skills/codex-refactor-loop/scripts/triage-monitor.sh >> .refactor-loop/logs/triage-monitor.log 2>&1 & disown`
 - Liveness:每 wakeup `ps -ef | grep triage-monitor.sh` 必须 ≥1,死了 restart
 - Codex 完成 marker:`TRIAGE_DONE:<issue>:<accept|reject>:<reason>`(写 issue 评论 + 切 label)
 - Controller 下次 wakeup 从 GitHub state derive(issue label 改了即看见)
 
-**事故记录**:2026-05-23 #560 maintainer 加 `auto-loop-triage` label,初版 daemon 只 emit event 到 `.controller-pending-events.log` 等 controller 中转,**但 controller 没 sweep pending-events**,#560 漏读 20min,maintainer 问"为什么没自动扫到"。修法:daemon 直接 spawn codex,移除中转环节(daemon = comment-monitor.sh eyes-react pattern,自己 take action 不让 controller 中转)。
+**事故修正(issue1337)**:`auto-loop-triage` daemon 不得 `nohup + disown` 自派 codex。daemon 写 pending event 后,controller 必须在 wakeup step 1.6 读取并用 `spawn-codex.sh` 派发,让 harness 可见并复用标准 marker path。
 
 Controller 每 wakeup sweep `--label "auto-loop-triage"`(daemon 漏了兜底),对每个新 issue:
 1. 派 **triage codex**(`prompts/triage-external-issue.md`)读 issue body + 判断:
@@ -1897,7 +1898,7 @@ controller **不派 fix codex 不 auto-merge**(此 phase 是 advisory,不接 fix
 | **Issue body 有最小描述** | body 长度 ≥ 100 chars(过短 issue triage 也判不出) |
 | **未在 ongoing 维护讨论** | 最近 24h 内**无** human comment(避免打断真人 maintainer 已在 reply 的 issue) |
 
-全部 yes → 加 `auto-loop-triage` label,由 `.claude/skills/codex-refactor-loop/scripts/triage-monitor.sh` daemon 自动 spawn triage codex(已有现成 daemon,本 phase 复用)。
+全部 yes → 加 `auto-loop-triage` label,由 `.claude/skills/codex-refactor-loop/scripts/triage-monitor.sh` daemon 写 controller pending event;controller 再用 `spawn-codex.sh` 派 triage codex。
 
 ### Triage codex 行为(已 by Phase 7 Path B 定义)
 
@@ -1971,7 +1972,7 @@ Concretely, this means:
 2. **stale `🚀 phase:pr-open` + `👀 phase:reviewing` PR**:扫 reviewer log,有 REVIEW_DONE × 3 + reject → 派 fix r+1;有 FIX_DONE → 派 reviewer r+1;all-approve + CI 绿 → merge
 3. **CI 红 PR**(`gh pr checks` bucket=fail):立即拉 fail log + 派 fix codex(per "CI 监控即时推进")
 4. **stuck label 3h+ issue**(`auto-loop-stuck` / `🆘 human:卡死` / `👤 human:需-maintainer-决策`):派 fresh reflector(per "Stuck issue 3h 超时" 节)
-5. **未处理 / 长期未动 open issue**(>3h 未 update,non-bot):batch `auto-loop-triage` label,daemon spawn triage codex
+5. **未处理 / 长期未动 open issue**(>3h 未 update,non-bot):batch `auto-loop-triage` label,daemon 写 controller pending event,controller spawn triage codex
 6a. **`🔍 phase:design-solving` issue 但 0 solver log**(从未派出 r1 三 solver)→ **每 issue 派 3 solver**(每 issue 占 3 codex slot)— **强制最高级 Phase 9 优先级**(per Auric 2026-05-29 "一堆issues没完成, 为什么发新审计?")。Auric 已纠正过两次:script 当 audit 是"floor 填底"时,会跨过此条 → 22+ design-solving issue 静默积压。修法:wakeup-check.sh Step F2 检测此状态,HARD GATE 优先级表把"design-solving 无 solver"压在 audit 之前。
 6b. **active Phase 9 issue 等 judge / r+1 solver**:三 solver 全 EXIT=0 但无 judge log → 派 judge;judge converge → 派 r+1 三 solver;judge consensus → 派 implement
 7. **Phase 10 advisory review**(eligible open PR 池,非 auto-loop)

--- a/.claude/skills/codex-refactor-loop/scripts/triage-monitor.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/triage-monitor.sh
@@ -6,10 +6,10 @@
 # 设计:
 # - 60s 周期 gh issue list --label "auto-loop-triage" --state open
 # - 对每个未处理的 issue:
-#   - 写 event 到 .refactor-loop/.controller-pending-events.log:
-#     `<ISO8601> new-triage-issue <issue> <author>`
+#   - 物化 triage prompt/log 路径,再写 event 到 .refactor-loop/.controller-pending-events.log:
+#     `<ISO8601> new-triage-issue <issue> <author> prompt=<path> log=<path> timeout=5400`
 #   - state 存 .refactor-loop/triage-monitor-state.json(seen issue id)
-# - 不自己派 codex(controller 责任)
+# - 不自己派 codex(controller 责任,controller 再用 spawn-codex.sh 生成标准 markers)
 # - 启动: nohup bash .claude/skills/codex-refactor-loop/scripts/triage-monitor.sh >> .refactor-loop/logs/triage-monitor.log 2>&1 & disown
 #
 # ⟦AI:AUTO-LOOP⟧
@@ -21,7 +21,7 @@ INTERVAL="${INTERVAL:-60}"
 STATE_FILE="$REPO_ROOT/.refactor-loop/triage-monitor-state.json"
 PENDING_LOG="$REPO_ROOT/.refactor-loop/.controller-pending-events.log"
 
-mkdir -p "$REPO_ROOT/.refactor-loop"
+mkdir -p "$REPO_ROOT/.refactor-loop" "$REPO_ROOT/.refactor-loop/prompts" "$REPO_ROOT/.refactor-loop/logs"
 [ -f "$STATE_FILE" ] || echo "{}" > "$STATE_FILE"
 
 log() {
@@ -34,6 +34,9 @@ while true; do
   # Query open issues with auto-loop-triage label
   issues=$(gh issue list --label "auto-loop-triage" --state open --json number,author --jq '.[] | "\(.number) \(.author.login)"' 2>/dev/null)
   if [ -z "$issues" ]; then
+    if [ "${TRIAGE_MONITOR_RUN_ONCE:-0}" = "1" ]; then
+      break
+    fi
     sleep "$INTERVAL"
     continue
   fi
@@ -65,17 +68,16 @@ while true; do
         log "FATAL: prompt for issue #$issue still has unresolved placeholders — skipping spawn"
         continue
       fi
-      # Spawn triage codex(nohup disown — daemon 自己派,不需 harness 跟踪;codex 自己 update GitHub)
       log_file="$REPO_ROOT/.refactor-loop/logs/triage-issue-${issue}.log"
-      ISSUE_NUMBER="$issue" nohup bash "$REPO_ROOT/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh" \
-        --cd "$REPO_ROOT" \
-        --prompt "$prompt_file" \
-        --log "$log_file" \
-        --timeout 5400 >> "$REPO_ROOT/.refactor-loop/logs/triage-monitor.log" 2>&1 &
-      disown
-      log "spawned: triage codex for issue #$issue (author=$author)"
+      # // Refactor (issue1337): Old: daemon detached spawn-codex.sh with nohup + disown. New: daemon only records the controller spawn request; controller invokes spawn-codex.sh so its standard marker files remain authoritative.
+      printf '%s new-triage-issue %s %s prompt=%s log=%s timeout=5400\n' \
+        "$ts" "$issue" "$author" "$prompt_file" "$log_file" >> "$PENDING_LOG"
+      log "queued: triage codex for issue #$issue (author=$author prompt=$prompt_file log=$log_file)"
     fi
   done <<< "$issues"
 
+  if [ "${TRIAGE_MONITOR_RUN_ONCE:-0}" = "1" ]; then
+    break
+  fi
   sleep "$INTERVAL"
 done

--- a/tests/test_triage_monitor_envsubst.sh
+++ b/tests/test_triage_monitor_envsubst.sh
@@ -36,4 +36,43 @@ fi
 grep -Fq '#999' "${TMP}" || fail "#999 not substituted"
 grep -Fq 'testuser' "${TMP}" || fail "testuser not substituted"
 
+FAKE_REPO="${TMP_DIR}/repo"
+FAKE_BIN="${TMP_DIR}/bin"
+mkdir -p "${FAKE_REPO}/.claude/skills/codex-refactor-loop/prompts" "${FAKE_BIN}"
+cp "${TEMPLATE}" "${FAKE_REPO}/.claude/skills/codex-refactor-loop/prompts/triage-external-issue.md"
+
+cat > "${FAKE_BIN}/gh" <<'FAKE_GH'
+#!/usr/bin/env bash
+if [ "$1" = "issue" ] && [ "$2" = "list" ]; then
+  printf '999 testuser\n'
+  exit 0
+fi
+echo "unexpected gh call: $*" >&2
+exit 2
+FAKE_GH
+chmod +x "${FAKE_BIN}/gh"
+
+PATH="${FAKE_BIN}:${PATH}" \
+REPO_ROOT="${FAKE_REPO}" \
+TRIAGE_MONITOR_RUN_ONCE=1 \
+bash "${REPO_ROOT}/.claude/skills/codex-refactor-loop/scripts/triage-monitor.sh" \
+  > "${TMP_DIR}/triage-monitor.out"
+
+PENDING="${FAKE_REPO}/.refactor-loop/.controller-pending-events.log"
+STATE="${FAKE_REPO}/.refactor-loop/triage-monitor-state.json"
+PROMPT="${FAKE_REPO}/.refactor-loop/prompts/triage-issue-999.md"
+LOG="${FAKE_REPO}/.refactor-loop/logs/triage-issue-999.log"
+
+test -f "${PENDING}" || fail "pending controller event was not written"
+grep -Fq "new-triage-issue 999 testuser prompt=${PROMPT} log=${LOG} timeout=5400" "${PENDING}" \
+  || fail "pending controller event does not carry spawn-codex inputs"
+test -f "${PROMPT}" || fail "triage prompt was not materialized"
+jq -e '."999"' "${STATE}" >/dev/null || fail "issue was not marked seen"
+grep -Fq "queued: triage codex for issue #999" "${TMP_DIR}/triage-monitor.out" \
+  || fail "triage monitor did not log queued controller spawn request"
+if sed '/^[[:space:]]*#/d' "${REPO_ROOT}/.claude/skills/codex-refactor-loop/scripts/triage-monitor.sh" \
+  | grep -Eq 'nohup .*spawn-codex|disown'; then
+  fail "triage-monitor still contains detached spawn-codex path"
+fi
+
 echo "triage-monitor envsubst tests passed."


### PR DESCRIPTION
## 摘要

源自 #1308 r1 split first-slice。

triage-monitor daemon 移除 nohup 自 spawn 路径,改走 controller marker → controller spawn 统一路径。daemon 仅做 detect / emit / eyes-react side-effect。

## 边界

- 不新增 abstraction
- 复用现有 spawn-codex.sh
- 3 files +59/-17

closes #1337

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧