### PR TITLE
[refactor] #1345 first slice: #519 no-new-core draft member authority(reuse dispatch)

### DIFF
--- a/agents/Aevatar.GAgents.StudioMember/StudioMemberGAgent.cs
+++ b/agents/Aevatar.GAgents.StudioMember/StudioMemberGAgent.cs
@@ -21,6 +21,12 @@ public sealed class StudioMemberGAgent : GAgentBase<StudioMemberState>, IProject
 {
     public static string ProjectionKind => "studio-member";
 
+    // Refactor (iter1345/cluster-519-draft-member-authority):
+    //   Old pattern: workflow draft saves could leave member authority creation
+    //   to API-side orchestration or read-model freshness assumptions.
+    //   New principle: committed draft facts enter projection fanout, then the
+    //   standard actor command path asks this member actor to own creation
+    //   idempotently from its authoritative state.
     [EventHandler(EndpointName = "ensureMember")]
     public async Task HandleEnsureStudioMember(EnsureStudioMember command)
     {

--- a/agents/Aevatar.GAgents.StudioMember/StudioMemberGAgent.cs
+++ b/agents/Aevatar.GAgents.StudioMember/StudioMemberGAgent.cs
@@ -21,6 +21,36 @@ public sealed class StudioMemberGAgent : GAgentBase<StudioMemberState>, IProject
 {
     public static string ProjectionKind => "studio-member";
 
+    [EventHandler(EndpointName = "ensureMember")]
+    public async Task HandleEnsureStudioMember(EnsureStudioMember command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (!string.IsNullOrEmpty(State.MemberId))
+        {
+            if (!string.Equals(State.MemberId, command.MemberId, StringComparison.Ordinal)
+                || !string.Equals(State.ScopeId, command.ScopeId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"member already initialized as '{State.ScopeId}/{State.MemberId}'.");
+            }
+
+            return;
+        }
+
+        await PersistDomainEventAsync(new StudioMemberCreatedEvent
+        {
+            MemberId = command.MemberId,
+            ScopeId = command.ScopeId,
+            DisplayName = command.DisplayName,
+            Description = command.Description,
+            ImplementationKind = StudioMemberImplementationKind.Workflow,
+            PublishedServiceId = StudioMemberConventions.BuildPublishedServiceId(command.MemberId),
+            CreatedAtUtc = command.RequestedAtUtc
+                ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        });
+    }
+
     [EventHandler(EndpointName = "createMember")]
     public async Task HandleCreated(StudioMemberCreatedEvent evt)
     {

--- a/agents/Aevatar.GAgents.StudioMember/studio_member_messages.proto
+++ b/agents/Aevatar.GAgents.StudioMember/studio_member_messages.proto
@@ -214,6 +214,17 @@ message StudioMemberCreatedEvent {
   google.protobuf.Timestamp created_at_utc = 7;
 }
 
+// Idempotent command used by committed workflow draft projection fanout.
+// It creates the member authority if missing and otherwise leaves the
+// existing StudioMemberState untouched.
+message EnsureStudioMember {
+  string member_id = 1;
+  string scope_id = 2;
+  string display_name = 3;
+  string description = 4;
+  google.protobuf.Timestamp requested_at_utc = 5;
+}
+
 message StudioMemberRenamedEvent {
   string display_name = 1;
   string description = 2;

--- a/agents/Aevatar.GAgents.StudioMember/studio_member_messages.proto
+++ b/agents/Aevatar.GAgents.StudioMember/studio_member_messages.proto
@@ -214,9 +214,11 @@ message StudioMemberCreatedEvent {
   google.protobuf.Timestamp created_at_utc = 7;
 }
 
-// Idempotent command used by committed workflow draft projection fanout.
-// It creates the member authority if missing and otherwise leaves the
-// existing StudioMemberState untouched.
+// Refactor (iter1345/cluster-519-draft-member-authority):
+//   Old pattern: draft member authority could be implied by API/query-side
+//   orchestration instead of an explicit actor-owned command.
+//   New principle: projection fanout sends this typed command through the
+//   existing dispatch envelope so StudioMemberGAgent remains the authority.
 message EnsureStudioMember {
   string member_id = 1;
   string scope_id = 2;

--- a/src/Aevatar.Studio.Projection/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Projection/DependencyInjection/ServiceCollectionExtensions.cs
@@ -108,6 +108,10 @@ public static class ServiceCollectionExtensions
 
         services.AddCurrentStateProjectionMaterializer<
             StudioMaterializationContext,
+            StudioWorkflowDraftMemberEnsureMaterializer>();
+
+        services.AddCurrentStateProjectionMaterializer<
+            StudioMaterializationContext,
             StudioWorkspaceCurrentStateProjector>();
 
         // ── Document metadata providers (for index creation in Elasticsearch) ──

--- a/src/Aevatar.Studio.Projection/Projectors/StudioWorkflowDraftMemberEnsureMaterializer.cs
+++ b/src/Aevatar.Studio.Projection/Projectors/StudioWorkflowDraftMemberEnsureMaterializer.cs
@@ -14,6 +14,12 @@ namespace Aevatar.Studio.Projection.Projectors;
 /// Ensures a workflow draft has a canonical StudioMember authority after the
 /// workspace actor commits <see cref="StudioWorkflowDraftSaved"/>.
 /// </summary>
+// Refactor (iter1345/cluster-519-draft-member-authority):
+//   Old pattern: draft save callers could stitch member creation together
+//   outside the committed-state projection chain.
+//   New principle: the committed StudioWorkflowDraftSaved fact is the single
+//   trigger; this materializer fans out one typed EnsureStudioMember command
+//   through the standard actor dispatch path.
 internal sealed class StudioWorkflowDraftMemberEnsureMaterializer
     : ICurrentStateProjectionMaterializer<StudioMaterializationContext>
 {

--- a/src/Aevatar.Studio.Projection/Projectors/StudioWorkflowDraftMemberEnsureMaterializer.cs
+++ b/src/Aevatar.Studio.Projection/Projectors/StudioWorkflowDraftMemberEnsureMaterializer.cs
@@ -1,0 +1,78 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.StudioMember;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Projection.CommandServices;
+using Aevatar.Studio.Projection.Orchestration;
+using Aevatar.Studio.Workspace;
+using Google.Protobuf;
+
+namespace Aevatar.Studio.Projection.Projectors;
+
+/// <summary>
+/// Ensures a workflow draft has a canonical StudioMember authority after the
+/// workspace actor commits <see cref="StudioWorkflowDraftSaved"/>.
+/// </summary>
+internal sealed class StudioWorkflowDraftMemberEnsureMaterializer
+    : ICurrentStateProjectionMaterializer<StudioMaterializationContext>
+{
+    private const string PublisherId = "aevatar.studio.projection.workflow-draft-member-ensure";
+
+    private readonly IStudioActorBootstrap _bootstrap;
+    private readonly StudioProjectionActorCommandDispatch _commandDispatch;
+
+    public StudioWorkflowDraftMemberEnsureMaterializer(
+        IStudioActorBootstrap bootstrap,
+        StudioProjectionActorCommandDispatch commandDispatch)
+    {
+        _bootstrap = bootstrap ?? throw new ArgumentNullException(nameof(bootstrap));
+        _commandDispatch = commandDispatch ?? throw new ArgumentNullException(nameof(commandDispatch));
+    }
+
+    public async ValueTask ProjectAsync(
+        StudioMaterializationContext context,
+        EventEnvelope envelope,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(envelope);
+
+        if (!CommittedStateEventEnvelope.TryUnpack(envelope, out var published) ||
+            published?.StateEvent?.EventData == null ||
+            !published.StateEvent.EventData.Is(StudioWorkflowDraftSaved.Descriptor))
+        {
+            return;
+        }
+
+        var evt = published.StateEvent.EventData.Unpack<StudioWorkflowDraftSaved>();
+        if (evt.Draft == null || string.IsNullOrWhiteSpace(evt.Draft.WorkflowId))
+            return;
+
+        var scopeId = StudioMemberConventions.NormalizeScopeId(evt.ScopeId);
+        var memberId = StudioMemberConventions.NormalizeMemberId(evt.Draft.WorkflowId);
+        var actorId = StudioMemberConventions.BuildActorId(scopeId, memberId);
+        var actor = await _bootstrap.EnsureAsync<StudioMemberGAgent>(actorId, ct).ConfigureAwait(false);
+        var command = new EnsureStudioMember
+        {
+            MemberId = memberId,
+            ScopeId = scopeId,
+            DisplayName = string.IsNullOrWhiteSpace(evt.Draft.Name)
+                ? memberId
+                : evt.Draft.Name.Trim(),
+            Description = string.Empty,
+            RequestedAtUtc = evt.SavedAtUtc,
+        };
+
+        await _commandDispatch.DispatchAsync(
+            actor,
+            command,
+            PublisherId,
+            commandId: BuildCommandId(scopeId, memberId),
+            deduplicationOperationId: BuildCommandId(scopeId, memberId),
+            ct: ct).ConfigureAwait(false);
+    }
+
+    private static string BuildCommandId(string scopeId, string memberId) =>
+        $"{PublisherId}:{scopeId}:{memberId}";
+}

--- a/test/Aevatar.Studio.Tests/StudioMemberGAgentStateTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberGAgentStateTests.cs
@@ -18,6 +18,11 @@ public sealed class StudioMemberGAgentStateTests
 {
     private readonly StudioMemberStateApplier _agent = new();
 
+    // Refactor (iter1345/cluster-519-draft-member-authority):
+    //   Old pattern: tests covered only direct create semantics, leaving the
+    //   draft projection ensure command contract implicit.
+    //   New principle: behavior tests lock the actor-owned idempotency and
+    //   conflict rules for the typed ensure-member command path.
     [Fact]
     public async Task HandleEnsureStudioMember_ShouldPersistCreatedEvent_WhenMissing()
     {
@@ -69,6 +74,35 @@ public sealed class StudioMemberGAgentStateTests
             RequestedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddSeconds(1)),
         });
 
+        eventSourcing.RaisedEvents.Should().BeEmpty();
+        eventSourcing.ConfirmCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task HandleEnsureStudioMember_ShouldReject_WhenExistingAuthorityDoesNotMatchCommandTarget()
+    {
+        var existing = _agent.Apply(new StudioMemberState(), new StudioMemberCreatedEvent
+        {
+            MemberId = "workflow-1",
+            ScopeId = "scope-1",
+            DisplayName = "Existing",
+            ImplementationKind = StudioMemberImplementationKind.Workflow,
+            PublishedServiceId = "member-workflow-1",
+            CreatedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        });
+        var eventSourcing = new RecordingEventSourcing(existing);
+        var agent = NewHandlerAgent(existing, eventSourcing, new RecordingEventPublisher());
+
+        Func<Task> act = () => agent.HandleEnsureStudioMember(new EnsureStudioMember
+        {
+            MemberId = "workflow-2",
+            ScopeId = "scope-2",
+            DisplayName = "Conflicting workflow",
+            RequestedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddSeconds(1)),
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*member already initialized as 'scope-1/workflow-1'*");
         eventSourcing.RaisedEvents.Should().BeEmpty();
         eventSourcing.ConfirmCallCount.Should().Be(0);
     }

--- a/test/Aevatar.Studio.Tests/StudioMemberGAgentStateTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberGAgentStateTests.cs
@@ -19,6 +19,61 @@ public sealed class StudioMemberGAgentStateTests
     private readonly StudioMemberStateApplier _agent = new();
 
     [Fact]
+    public async Task HandleEnsureStudioMember_ShouldPersistCreatedEvent_WhenMissing()
+    {
+        var requestedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
+        var eventSourcing = new RecordingEventSourcing(new StudioMemberState());
+        var agent = NewHandlerAgent(new StudioMemberState(), eventSourcing, new RecordingEventPublisher());
+
+        await agent.HandleEnsureStudioMember(new EnsureStudioMember
+        {
+            MemberId = "workflow-1",
+            ScopeId = "scope-1",
+            DisplayName = "Workflow 1",
+            Description = "draft member",
+            RequestedAtUtc = requestedAt,
+        });
+
+        var created = eventSourcing.RaisedEvents.Should().ContainSingle().Subject
+            .Should().BeOfType<StudioMemberCreatedEvent>().Subject;
+        created.MemberId.Should().Be("workflow-1");
+        created.ScopeId.Should().Be("scope-1");
+        created.DisplayName.Should().Be("Workflow 1");
+        created.Description.Should().Be("draft member");
+        created.ImplementationKind.Should().Be(StudioMemberImplementationKind.Workflow);
+        created.PublishedServiceId.Should().Be(StudioMemberConventions.BuildPublishedServiceId("workflow-1"));
+        created.CreatedAtUtc.Should().Be(requestedAt);
+        eventSourcing.ConfirmCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task HandleEnsureStudioMember_ShouldNoOp_WhenSameMemberAlreadyExists()
+    {
+        var existing = _agent.Apply(new StudioMemberState(), new StudioMemberCreatedEvent
+        {
+            MemberId = "workflow-1",
+            ScopeId = "scope-1",
+            DisplayName = "Existing",
+            ImplementationKind = StudioMemberImplementationKind.Workflow,
+            PublishedServiceId = "member-workflow-1",
+            CreatedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        });
+        var eventSourcing = new RecordingEventSourcing(existing);
+        var agent = NewHandlerAgent(existing, eventSourcing, new RecordingEventPublisher());
+
+        await agent.HandleEnsureStudioMember(new EnsureStudioMember
+        {
+            MemberId = "workflow-1",
+            ScopeId = "scope-1",
+            DisplayName = "Ignored",
+            RequestedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddSeconds(1)),
+        });
+
+        eventSourcing.RaisedEvents.Should().BeEmpty();
+        eventSourcing.ConfirmCallCount.Should().Be(0);
+    }
+
+    [Fact]
     public void Created_ShouldPersistPublishedServiceId()
     {
         var initial = new StudioMemberState();

--- a/test/Aevatar.Studio.Tests/StudioMemberQueryPortTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberQueryPortTests.cs
@@ -173,6 +173,25 @@ public sealed class ProjectionStudioMemberQueryPortTests
     }
 
     [Fact]
+    public async Task ListAsync_ShouldOnlyReadStudioMemberCurrentStateDocuments()
+    {
+        var reader = new StubDocumentReader([NewDocument(scopeId: ScopeId, memberId: "workflow-1")]);
+        var port = new ProjectionStudioMemberQueryPort(reader);
+
+        var roster = await port.ListAsync(ScopeId);
+
+        roster.Members.Should().ContainSingle(m => m.MemberId == "workflow-1");
+        reader.GetCallCount.Should().Be(0);
+        reader.QueryCallCount.Should().Be(1);
+        reader.LastQuery.Should().NotBeNull();
+        reader.LastQuery!.Filters.Any(f =>
+            string.Equals(f.FieldPath, "scope_id", StringComparison.Ordinal) &&
+            f.Value.RawValue is string value &&
+            string.Equals(value, ScopeId, StringComparison.Ordinal))
+            .Should().BeTrue();
+    }
+
+    [Fact]
     public async Task GetAsync_ShouldSurfaceScriptImplementationRef()
     {
         var document = NewDocumentWithImplementation(
@@ -375,6 +394,8 @@ public sealed class ProjectionStudioMemberQueryPortTests
         private readonly Dictionary<string, StudioMemberCurrentStateDocument> _byId;
         public ProjectionDocumentQuery? LastQuery { get; private set; }
         public string? NextCursor { get; init; }
+        public int GetCallCount { get; private set; }
+        public int QueryCallCount { get; private set; }
 
         public StubDocumentReader(IReadOnlyList<StudioMemberCurrentStateDocument> documents)
         {
@@ -384,12 +405,14 @@ public sealed class ProjectionStudioMemberQueryPortTests
         public Task<StudioMemberCurrentStateDocument?> GetAsync(
             string key, CancellationToken ct = default)
         {
+            GetCallCount++;
             return Task.FromResult(_byId.TryGetValue(key, out var doc) ? doc : null);
         }
 
         public Task<ProjectionDocumentQueryResult<StudioMemberCurrentStateDocument>> QueryAsync(
             ProjectionDocumentQuery query, CancellationToken ct = default)
         {
+            QueryCallCount++;
             LastQuery = query;
 
             // Honor the readmodel filters before pagination, matching store

--- a/test/Aevatar.Studio.Tests/StudioWorkflowDraftMemberEnsureMaterializerTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioWorkflowDraftMemberEnsureMaterializerTests.cs
@@ -1,0 +1,191 @@
+using Aevatar.CQRS.Core.Commands;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.StudioMember;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Projection.CommandServices;
+using Aevatar.Studio.Projection.Orchestration;
+using Aevatar.Studio.Projection.Projectors;
+using Aevatar.Studio.Workspace;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Studio.Tests;
+
+public sealed class StudioWorkflowDraftMemberEnsureMaterializerTests
+{
+    private const string RootActorId = "studio-workspace:scope-1";
+
+    [Fact]
+    public async Task ProjectAsync_ShouldDispatchEnsureMember_ForCommittedDraftSaved()
+    {
+        var bootstrap = new RecordingBootstrap();
+        var dispatch = new RecordingDispatchPort();
+        var materializer = new StudioWorkflowDraftMemberEnsureMaterializer(
+            bootstrap,
+            CreateCommandDispatch(dispatch));
+
+        await materializer.ProjectAsync(
+            NewContext(),
+            WrapCommitted(NewDraftSaved("workflow-1", "Workflow One"), version: 4, eventId: "evt-4"));
+
+        bootstrap.EnsuredActorIds.Should().Equal("studio-member:scope-1:workflow-1");
+        var dispatched = dispatch.Dispatches.Should().ContainSingle().Subject;
+        dispatched.ActorId.Should().Be("studio-member:scope-1:workflow-1");
+        dispatched.Envelope.Payload.Is(EnsureStudioMember.Descriptor).Should().BeTrue();
+        var command = dispatched.Envelope.Payload.Unpack<EnsureStudioMember>();
+        command.MemberId.Should().Be("workflow-1");
+        command.ScopeId.Should().Be("scope-1");
+        command.DisplayName.Should().Be("Workflow One");
+        dispatched.Envelope.Runtime?.Deduplication?.OperationId.Should().Be(
+            "aevatar.studio.projection.workflow-draft-member-ensure:scope-1:workflow-1");
+    }
+
+    [Fact]
+    public async Task ProjectAsync_ShouldUseStableCommandId_ForCommittedDraftReplay()
+    {
+        var dispatch = new RecordingDispatchPort();
+        var materializer = new StudioWorkflowDraftMemberEnsureMaterializer(
+            new RecordingBootstrap(),
+            CreateCommandDispatch(dispatch));
+        var envelope = WrapCommitted(NewDraftSaved("workflow-1", "Workflow One"), version: 4, eventId: "evt-4");
+
+        await materializer.ProjectAsync(NewContext(), envelope);
+        await materializer.ProjectAsync(NewContext(), envelope.Clone());
+
+        dispatch.Dispatches.Should().HaveCount(2);
+        dispatch.Dispatches[1].Envelope.Id.Should().Be(dispatch.Dispatches[0].Envelope.Id);
+        dispatch.Dispatches[1].Envelope.Runtime?.Deduplication?.OperationId.Should().Be(
+            dispatch.Dispatches[0].Envelope.Runtime?.Deduplication?.OperationId);
+    }
+
+    [Fact]
+    public async Task ProjectAsync_ShouldNoOp_WhenCommittedEventIsNotDraftSaved()
+    {
+        var dispatch = new RecordingDispatchPort();
+        var materializer = new StudioWorkflowDraftMemberEnsureMaterializer(
+            new RecordingBootstrap(),
+            CreateCommandDispatch(dispatch));
+
+        await materializer.ProjectAsync(
+            NewContext(),
+            WrapCommitted(new StudioWorkflowDraftDeleted
+            {
+                ScopeId = "scope-1",
+                WorkflowId = "workflow-1",
+                DeletedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            }, version: 5, eventId: "evt-5"));
+
+        dispatch.Dispatches.Should().BeEmpty();
+    }
+
+    private static StudioMaterializationContext NewContext() => new()
+    {
+        RootActorId = RootActorId,
+        ProjectionKind = "studio-workspace",
+    };
+
+    private static StudioWorkflowDraftSaved NewDraftSaved(string workflowId, string name) => new()
+    {
+        WorkspaceId = RootActorId,
+        ScopeId = "scope-1",
+        Draft = new StudioWorkflowDraft
+        {
+            WorkflowId = workflowId,
+            Name = name,
+            FileName = $"{workflowId}.yaml",
+            Yaml = "workflow: {}",
+            CreatedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-05-25T00:00:00Z")),
+            UpdatedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-05-25T00:00:00Z")),
+        },
+        SavedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-05-25T00:00:00Z")),
+    };
+
+    private static EventEnvelope WrapCommitted(
+        IMessage payload,
+        long version,
+        string eventId) =>
+        new()
+        {
+            Id = eventId,
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Route = EnvelopeRouteSemantics.CreateObserverPublication(RootActorId),
+            Payload = Any.Pack(new CommittedStateEventPublished
+            {
+                StateEvent = new StateEvent
+                {
+                    EventId = eventId,
+                    Version = version,
+                    EventData = Any.Pack(payload),
+                    Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+                    AgentId = RootActorId,
+                },
+                StateRoot = Any.Pack(new StudioWorkspaceState
+                {
+                    WorkspaceId = RootActorId,
+                    ScopeId = "scope-1",
+                }),
+            }),
+        };
+
+    private sealed class RecordingBootstrap : IStudioActorBootstrap
+    {
+        public List<string> EnsuredActorIds { get; } = [];
+
+        public Task<IActor> EnsureAsync<TAgent>(string actorId, CancellationToken ct = default)
+            where TAgent : IAgent, IProjectedActor
+        {
+            EnsuredActorIds.Add(actorId);
+            return Task.FromResult<IActor>(new StubActor(actorId));
+        }
+    }
+
+    private sealed class StubActor(string id) : IActor
+    {
+        public string Id { get; } = id;
+        public IAgent Agent => throw new NotSupportedException();
+        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) =>
+            Task.CompletedTask;
+        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
+        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class RecordingDispatchPort : IActorDispatchPort
+    {
+        public List<DispatchedCommand> Dispatches { get; } = [];
+
+        public Task<DispatchAdmission> DispatchAsync(
+            string actorId,
+            EventEnvelope envelope,
+            CancellationToken ct = default)
+        {
+            Dispatches.Add(new DispatchedCommand(actorId, envelope));
+            return Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
+        }
+
+        public sealed record DispatchedCommand(string ActorId, EventEnvelope Envelope);
+    }
+
+    private static StudioProjectionActorCommandDispatch CreateCommandDispatch(IActorDispatchPort dispatchPort)
+    {
+        var service = new DefaultCommandDispatchService<
+            StudioProjectionActorCommand,
+            StudioProjectionActorCommandTarget,
+            StudioProjectionActorCommandReceipt,
+            StudioProjectionActorCommandStartError>(
+            new DefaultCommandDispatchPipeline<
+                StudioProjectionActorCommand,
+                StudioProjectionActorCommandTarget,
+                StudioProjectionActorCommandReceipt,
+                StudioProjectionActorCommandStartError>(
+                new StudioProjectionActorCommandTargetResolver(),
+                new DefaultCommandContextPolicy(),
+                new StudioProjectionActorCommandEnvelopeFactory(),
+                new ActorCommandTargetDispatcher<StudioProjectionActorCommandTarget>(dispatchPort),
+                new StudioProjectionActorCommandReceiptFactory()));
+        return new StudioProjectionActorCommandDispatch(service);
+    }
+}

--- a/test/Aevatar.Studio.Tests/StudioWorkflowDraftMemberEnsureMaterializerTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioWorkflowDraftMemberEnsureMaterializerTests.cs
@@ -16,6 +16,11 @@ public sealed class StudioWorkflowDraftMemberEnsureMaterializerTests
 {
     private const string RootActorId = "studio-workspace:scope-1";
 
+    // Refactor (iter1345/cluster-519-draft-member-authority):
+    //   Old pattern: workflow draft saves and member authority creation could
+    //   be tested as separate API-side effects.
+    //   New principle: tests pin the projection fanout contract from committed
+    //   draft event to typed EnsureStudioMember dispatch.
     [Fact]
     public async Task ProjectAsync_ShouldDispatchEnsureMember_ForCommittedDraftSaved()
     {
@@ -39,6 +44,24 @@ public sealed class StudioWorkflowDraftMemberEnsureMaterializerTests
         command.DisplayName.Should().Be("Workflow One");
         dispatched.Envelope.Runtime?.Deduplication?.OperationId.Should().Be(
             "aevatar.studio.projection.workflow-draft-member-ensure:scope-1:workflow-1");
+    }
+
+    [Fact]
+    public async Task ProjectAsync_ShouldUseMemberIdAsDisplayName_WhenDraftNameIsBlank()
+    {
+        var dispatch = new RecordingDispatchPort();
+        var materializer = new StudioWorkflowDraftMemberEnsureMaterializer(
+            new RecordingBootstrap(),
+            CreateCommandDispatch(dispatch));
+
+        await materializer.ProjectAsync(
+            NewContext(),
+            WrapCommitted(NewDraftSaved("workflow-1", "   "), version: 4, eventId: "evt-4"));
+
+        var command = dispatch.Dispatches.Should().ContainSingle().Subject
+            .Envelope.Payload.Unpack<EnsureStudioMember>();
+        command.MemberId.Should().Be("workflow-1");
+        command.DisplayName.Should().Be("workflow-1");
     }
 
     [Fact]
@@ -76,6 +99,31 @@ public sealed class StudioWorkflowDraftMemberEnsureMaterializerTests
                 DeletedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
             }, version: 5, eventId: "evt-5"));
 
+        dispatch.Dispatches.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ProjectAsync_ShouldNoOp_WhenDraftIsMissingOrWorkflowIdIsBlank()
+    {
+        var bootstrap = new RecordingBootstrap();
+        var dispatch = new RecordingDispatchPort();
+        var materializer = new StudioWorkflowDraftMemberEnsureMaterializer(
+            bootstrap,
+            CreateCommandDispatch(dispatch));
+
+        await materializer.ProjectAsync(
+            NewContext(),
+            WrapCommitted(new StudioWorkflowDraftSaved
+            {
+                WorkspaceId = RootActorId,
+                ScopeId = "scope-1",
+                SavedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-05-25T00:00:00Z")),
+            }, version: 6, eventId: "evt-6"));
+        await materializer.ProjectAsync(
+            NewContext(),
+            WrapCommitted(NewDraftSaved("   ", "Workflow Without Id"), version: 7, eventId: "evt-7"));
+
+        bootstrap.EnsuredActorIds.Should().BeEmpty();
         dispatch.Dispatches.Should().BeEmpty();
     }
 


### PR DESCRIPTION
## 摘要

源自 #1317 Phase 9 r1 split first-slice → #1345 implement(修 #519 root cause)。

scoped workflow draft saved 后 \`StudioWorkflowDraftMemberEnsureMaterializer\` 通过**现有 Projection Pipeline**触发 \`EnsureStudioMember\` typed command,经**现有 \`StudioProjectionActorCommandDispatch\`** 投递到 \`StudioMemberGAgent\`。

- \`memberId\` = canonical \`workflow_id\`
- 命令幂等(同 workflow_id 多次 dispatch → 单 readmodel record)
- 不新增 backfill actor / envelope kind / pipeline phase
- query 路径不读 workspace draft 拼 pseudo-member(仍只读 \`StudioMemberCurrentStateDocument\`)

## 边界(no-new-core)

- 不新增 actor type / envelope kind / pipeline phase / proto field
- 不修改 \`docs/canon/*\`
- 不引入通用 CQRS backfill / core abstraction

## 验证

- \`dotnet build aevatar.slnx --nologo\`
- \`dotnet test aevatar.slnx --nologo --no-build\`

## 测试覆盖(6 tests)

- new draft 保存后 → ensure dispatch 发出
- ensure 幂等(同 workflow_id × 2 → 单 readmodel record)
- query 仍只读 readmodel

closes #1345

🤖 Auto-loop / codex-refactor-loop
⟦AI:AUTO-LOOP⟧