### PR TITLE
[refactor] #1349 first slice: static team 删除 trusted header 注入

### DIFF
--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -181,7 +181,7 @@ public sealed class AevatarInvocationDispatcher
                 scope.Value!.ScopeId,
                 request.TeamId.Trim(),
                 ct);
-            var invocation = BuildStaticInvocationRequest(resolution, request, scope.Value!);
+            var invocation = BuildStaticInvocationRequest(resolution, request);
             return wait == InvocationWaitMode.Complete
                 ? await InvokeTeamToCompletionAsync(chatRunRequest, invocation, resolution, request.EndpointId, wait, ct)
                 : await InvokeTeamToAcceptanceAsync(chatRunRequest, invocation, resolution, request.EndpointId, wait, ct);
@@ -569,10 +569,9 @@ public sealed class AevatarInvocationDispatcher
 
     private StaticGAgentStreamInvocationRequest BuildStaticInvocationRequest(
         TeamEntryMemberResolution resolution,
-        InvokeTeamToolRequest request,
-        InvocationCallerScope scope)
+        InvokeTeamToolRequest request)
     {
-        var headers = BuildLegacyMetadata(scope, request.Payload.Headers);
+        var headers = BuildPayloadHeaders(request.Payload.Headers);
         var identity = new ServiceIdentity
         {
             TenantId = resolution.ScopeId,

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -306,8 +306,8 @@ public sealed class AevatarInvocationToolSourceTests
         harness.TeamInvocation.Request.Identity.ServiceId.Should().Be("service-1");
         harness.TeamInvocation.Request.EndpointId.Should().Be("entry");
         harness.TeamInvocation.Request.Input.Prompt.Should().Be("go");
-        harness.TeamInvocation.Request.Input.Headers.Should().Contain("scope_id", "scope-1");
         harness.TeamInvocation.Request.Input.Headers.Should().Contain("h", "v");
+        ShouldNotCarryTrustedCallerValues(harness.TeamInvocation.Request.Input.Headers);
         harness.TeamInvocation.Request.Input.Caller!.TenantId.Should().Be("scope-1");
 
         var result = Read(output);
@@ -373,7 +373,7 @@ public sealed class AevatarInvocationToolSourceTests
         ErrorCodeOrNull(output).Should().BeNull(output);
         harness.TeamResolver.LastScopeId.Should().Be("scope-1");
         harness.TeamInvocation.Request!.Identity.TenantId.Should().Be("scope-1");
-        harness.TeamInvocation.Request.Input.Headers.Should().Contain("scope_id", "scope-1");
+        harness.TeamInvocation.Request.Input.Headers.Should().BeEmpty();
     }
 
     [Fact]
@@ -424,7 +424,8 @@ public sealed class AevatarInvocationToolSourceTests
             """);
 
         ErrorCodeOrNull(output).Should().BeNull(output);
-        ShouldCarryTrustedCallerValues(harness.TeamInvocation.Request!.Input.Headers);
+        ShouldNotCarryTrustedCallerValues(harness.TeamInvocation.Request!.Input.Headers);
+        harness.TeamInvocation.Request.Input.Caller!.TenantId.Should().Be("scope-1");
     }
 
     [Fact]


### PR DESCRIPTION
## 摘要

源自 #1333 Phase 9 r1 split first-slice → #1349 implement。

\`AevatarInvocationDispatcher.BuildStaticInvocationRequest\` 改为 **protected-key-filtered payload headers only**:
- 删除 \`BuildLegacyMetadata\` 对 trusted caller/control 数据的注入
- 保留 \`ServiceIdentity\` 和 \`ServiceInvocationCaller\` 作 typed identity surface

测试从 "assert trusted keys in Headers" 改为 "assert protected keys are absent"。

## 边界(no-new-core)

- 不新增 \`TeamToolContext\` / actor type / envelope kind / pipeline phase / proto field
- 不修改 \`docs/canon/*\`
- 不引入 canon vocabulary

## 验证

- \`dotnet build aevatar.slnx --nologo\`
- \`dotnet test aevatar.slnx --nologo --no-build\`

closes #1349

🤖 Auto-loop / codex-refactor-loop
⟦AI:AUTO-LOOP⟧