### PR TITLE
[refactor] #1357 first slice: 显式 scope one-shot draft member repair

### DIFF
--- a/src/Aevatar.Studio.Hosting/Endpoints/StudioWorkflowDraftMemberRepairEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/StudioWorkflowDraftMemberRepairEndpoints.cs
@@ -7,6 +7,11 @@ using Microsoft.AspNetCore.Routing;
 
 namespace Aevatar.Studio.Hosting.Endpoints;
 
+// Refactor (iter1357/cluster-explicit-scope-draft-member-repair):
+//   Old pattern: there was no explicit scoped HTTP entry point for repairing
+//   historical workflow-draft member authority gaps.
+//   New principle: Host only guards scope access and composes the one-shot
+//   repair service; repair orchestration stays in the projection service.
 internal static class StudioWorkflowDraftMemberRepairEndpoints
 {
     public static void Map(IEndpointRouteBuilder app)

--- a/src/Aevatar.Studio.Hosting/Endpoints/StudioWorkflowDraftMemberRepairEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/StudioWorkflowDraftMemberRepairEndpoints.cs
@@ -1,0 +1,46 @@
+using Aevatar.Hosting;
+using Aevatar.Studio.Projection.Repair;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Aevatar.Studio.Hosting.Endpoints;
+
+internal static class StudioWorkflowDraftMemberRepairEndpoints
+{
+    public static void Map(IEndpointRouteBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        app.MapPost(
+                "/api/scopes/{scopeId}/workflow-drafts:repair-members",
+                HandleRepairScopeAsync)
+            .WithTags("StudioWorkflowDraftRepair");
+    }
+
+    internal static async Task<IResult> HandleRepairScopeAsync(
+        HttpContext http,
+        string scopeId,
+        [FromServices] StudioWorkflowDraftMemberRepairService repairService,
+        CancellationToken ct)
+    {
+        if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+            return denied;
+
+        try
+        {
+            return Results.Accepted(
+                $"/api/scopes/{Uri.EscapeDataString(scopeId)}/workflow-drafts:repair-members",
+                await repairService.RepairScopeAsync(scopeId, ct).ConfigureAwait(false));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Results.BadRequest(new
+            {
+                code = "INVALID_STUDIO_WORKFLOW_DRAFT_MEMBER_REPAIR_REQUEST",
+                message = ex.Message,
+            });
+        }
+    }
+}

--- a/src/Aevatar.Studio.Hosting/StudioCapabilityExtensions.cs
+++ b/src/Aevatar.Studio.Hosting/StudioCapabilityExtensions.cs
@@ -61,6 +61,7 @@ public static class StudioCapabilityExtensions
                 StudioEndpoints.Map(app, embeddedWorkflowMode: true);
                 StudioMemberEndpoints.Map(app);
                 StudioTeamEndpoints.Map(app);
+                StudioWorkflowDraftMemberRepairEndpoints.Map(app);
                 Controllers.ChatHistoryEndpoints.MapChatHistoryEndpoints(app);
                 app.MapExplorerEndpoints();
             });

--- a/src/Aevatar.Studio.Projection/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Projection/DependencyInjection/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using Aevatar.Studio.Projection.Orchestration;
 using Aevatar.Studio.Projection.Projectors;
 using Aevatar.Studio.Projection.QueryPorts;
 using Aevatar.Studio.Projection.ReadModels;
+using Aevatar.Studio.Projection.Repair;
 using Aevatar.GAgents.StudioMember;
 using Aevatar.Studio.Workspace;
 using Microsoft.Extensions.Configuration;
@@ -41,6 +42,7 @@ public static class ServiceCollectionExtensions
 
         services.AddCqrsCore();
         services.AddStudioProjectionActorCommandDispatch();
+        services.TryAddSingleton<StudioWorkflowDraftMemberEnsureCommandFactory>();
 
         // Projection read-model runtime (write dispatcher + sink bindings)
         services.AddProjectionReadModelRuntime();
@@ -184,6 +186,11 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IStudioMemberCommandPort, ActorDispatchStudioMemberCommandService>();
         services.TryAddSingleton<IStudioMemberPlatformBindingCommandPort, ScopeBindingStudioMemberPlatformBindingCommandService>();
         services.TryAddSingleton<IStudioTeamCommandPort, ActorDispatchStudioTeamCommandService>();
+        services.TryAddSingleton(sp => new StudioWorkflowDraftMemberRepairService(
+            sp.GetRequiredService<IStudioWorkspaceQueryPort>(),
+            sp.GetRequiredService<IStudioActorBootstrap>(),
+            sp.GetRequiredService<StudioProjectionActorCommandDispatch>(),
+            sp.GetRequiredService<StudioWorkflowDraftMemberEnsureCommandFactory>()));
 
         return services;
     }

--- a/src/Aevatar.Studio.Projection/Projectors/StudioWorkflowDraftMemberEnsureCommandFactory.cs
+++ b/src/Aevatar.Studio.Projection/Projectors/StudioWorkflowDraftMemberEnsureCommandFactory.cs
@@ -1,0 +1,55 @@
+using Aevatar.GAgents.StudioMember;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Studio.Projection.Projectors;
+
+internal sealed record StudioWorkflowDraftMemberEnsureCommandPlan(
+    string ScopeId,
+    string MemberId,
+    string ActorId,
+    EnsureStudioMember Command,
+    string PublisherId,
+    string CommandId,
+    string DeduplicationOperationId);
+
+internal sealed class StudioWorkflowDraftMemberEnsureCommandFactory
+{
+    internal const string PublisherId = "aevatar.studio.projection.workflow-draft-member-ensure";
+
+    public StudioWorkflowDraftMemberEnsureCommandPlan? TryCreate(
+        string scopeId,
+        string workflowId,
+        string? displayName,
+        Timestamp? requestedAtUtc)
+    {
+        if (string.IsNullOrWhiteSpace(workflowId))
+            return null;
+
+        var normalizedScopeId = StudioMemberConventions.NormalizeScopeId(scopeId);
+        var memberId = StudioMemberConventions.NormalizeMemberId(workflowId);
+        var actorId = StudioMemberConventions.BuildActorId(normalizedScopeId, memberId);
+        var commandId = BuildCommandId(normalizedScopeId, memberId);
+        var command = new EnsureStudioMember
+        {
+            MemberId = memberId,
+            ScopeId = normalizedScopeId,
+            DisplayName = string.IsNullOrWhiteSpace(displayName)
+                ? memberId
+                : displayName.Trim(),
+            Description = string.Empty,
+            RequestedAtUtc = requestedAtUtc,
+        };
+
+        return new StudioWorkflowDraftMemberEnsureCommandPlan(
+            normalizedScopeId,
+            memberId,
+            actorId,
+            command,
+            PublisherId,
+            commandId,
+            commandId);
+    }
+
+    private static string BuildCommandId(string scopeId, string memberId) =>
+        $"{PublisherId}:{scopeId}:{memberId}";
+}

--- a/src/Aevatar.Studio.Projection/Projectors/StudioWorkflowDraftMemberEnsureCommandFactory.cs
+++ b/src/Aevatar.Studio.Projection/Projectors/StudioWorkflowDraftMemberEnsureCommandFactory.cs
@@ -12,6 +12,11 @@ internal sealed record StudioWorkflowDraftMemberEnsureCommandPlan(
     string CommandId,
     string DeduplicationOperationId);
 
+// Refactor (iter1357/cluster-explicit-scope-draft-member-repair):
+//   Old pattern: live committed-draft projection built EnsureStudioMember
+//   commands inline, leaving the explicit one-shot repair path free to drift.
+//   New principle: live projection and scoped repair share one typed command
+//   plan so actor identity, command id, and deduplication semantics stay equal.
 internal sealed class StudioWorkflowDraftMemberEnsureCommandFactory
 {
     internal const string PublisherId = "aevatar.studio.projection.workflow-draft-member-ensure";

--- a/src/Aevatar.Studio.Projection/Projectors/StudioWorkflowDraftMemberEnsureMaterializer.cs
+++ b/src/Aevatar.Studio.Projection/Projectors/StudioWorkflowDraftMemberEnsureMaterializer.cs
@@ -23,17 +23,18 @@ namespace Aevatar.Studio.Projection.Projectors;
 internal sealed class StudioWorkflowDraftMemberEnsureMaterializer
     : ICurrentStateProjectionMaterializer<StudioMaterializationContext>
 {
-    private const string PublisherId = "aevatar.studio.projection.workflow-draft-member-ensure";
-
     private readonly IStudioActorBootstrap _bootstrap;
     private readonly StudioProjectionActorCommandDispatch _commandDispatch;
+    private readonly StudioWorkflowDraftMemberEnsureCommandFactory _commandFactory;
 
     public StudioWorkflowDraftMemberEnsureMaterializer(
         IStudioActorBootstrap bootstrap,
-        StudioProjectionActorCommandDispatch commandDispatch)
+        StudioProjectionActorCommandDispatch commandDispatch,
+        StudioWorkflowDraftMemberEnsureCommandFactory commandFactory)
     {
         _bootstrap = bootstrap ?? throw new ArgumentNullException(nameof(bootstrap));
         _commandDispatch = commandDispatch ?? throw new ArgumentNullException(nameof(commandDispatch));
+        _commandFactory = commandFactory ?? throw new ArgumentNullException(nameof(commandFactory));
     }
 
     public async ValueTask ProjectAsync(
@@ -52,33 +53,20 @@ internal sealed class StudioWorkflowDraftMemberEnsureMaterializer
         }
 
         var evt = published.StateEvent.EventData.Unpack<StudioWorkflowDraftSaved>();
-        if (evt.Draft == null || string.IsNullOrWhiteSpace(evt.Draft.WorkflowId))
+        if (evt.Draft == null)
             return;
 
-        var scopeId = StudioMemberConventions.NormalizeScopeId(evt.ScopeId);
-        var memberId = StudioMemberConventions.NormalizeMemberId(evt.Draft.WorkflowId);
-        var actorId = StudioMemberConventions.BuildActorId(scopeId, memberId);
-        var actor = await _bootstrap.EnsureAsync<StudioMemberGAgent>(actorId, ct).ConfigureAwait(false);
-        var command = new EnsureStudioMember
-        {
-            MemberId = memberId,
-            ScopeId = scopeId,
-            DisplayName = string.IsNullOrWhiteSpace(evt.Draft.Name)
-                ? memberId
-                : evt.Draft.Name.Trim(),
-            Description = string.Empty,
-            RequestedAtUtc = evt.SavedAtUtc,
-        };
+        var plan = _commandFactory.TryCreate(evt.ScopeId, evt.Draft.WorkflowId, evt.Draft.Name, evt.SavedAtUtc);
+        if (plan == null)
+            return;
 
+        var actor = await _bootstrap.EnsureAsync<StudioMemberGAgent>(plan.ActorId, ct).ConfigureAwait(false);
         await _commandDispatch.DispatchAsync(
             actor,
-            command,
-            PublisherId,
-            commandId: BuildCommandId(scopeId, memberId),
-            deduplicationOperationId: BuildCommandId(scopeId, memberId),
+            plan.Command,
+            plan.PublisherId,
+            commandId: plan.CommandId,
+            deduplicationOperationId: plan.DeduplicationOperationId,
             ct: ct).ConfigureAwait(false);
     }
-
-    private static string BuildCommandId(string scopeId, string memberId) =>
-        $"{PublisherId}:{scopeId}:{memberId}";
 }

--- a/src/Aevatar.Studio.Projection/Repair/StudioWorkflowDraftMemberRepairService.cs
+++ b/src/Aevatar.Studio.Projection/Repair/StudioWorkflowDraftMemberRepairService.cs
@@ -1,0 +1,132 @@
+using Aevatar.GAgents.StudioMember;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Projection.CommandServices;
+using Aevatar.Studio.Projection.Projectors;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Studio.Projection.Repair;
+
+public sealed record StudioWorkflowDraftMemberRepairResult(
+    string ScopeId,
+    int DraftCount,
+    int AcceptedCount,
+    int SkippedCount,
+    int FailedCount,
+    IReadOnlyList<StudioWorkflowDraftMemberRepairItem> Items);
+
+public sealed record StudioWorkflowDraftMemberRepairItem(
+    string WorkflowId,
+    string MemberId,
+    string ActorId,
+    string Status,
+    string? CommandId = null,
+    string? Error = null)
+{
+    public const string Accepted = "accepted";
+    public const string Skipped = "skipped";
+    public const string Failed = "failed";
+}
+
+/// <summary>
+/// Explicit one-shot repair for historical scoped workflow drafts whose
+/// StudioMember authority may predate the committed-draft projection fanout.
+/// It keeps repair input on the workspace read model and writes only by
+/// dispatching the existing typed EnsureStudioMember command to the member
+/// actor. No progress, retry, or cross-request state is retained here.
+/// </summary>
+public sealed class StudioWorkflowDraftMemberRepairService
+{
+    private readonly IStudioWorkspaceQueryPort _workspaceQueryPort;
+    private readonly IStudioActorBootstrap _bootstrap;
+    private readonly StudioProjectionActorCommandDispatch _commandDispatch;
+    private readonly StudioWorkflowDraftMemberEnsureCommandFactory _commandFactory;
+
+    internal StudioWorkflowDraftMemberRepairService(
+        IStudioWorkspaceQueryPort workspaceQueryPort,
+        IStudioActorBootstrap bootstrap,
+        StudioProjectionActorCommandDispatch commandDispatch,
+        StudioWorkflowDraftMemberEnsureCommandFactory commandFactory)
+    {
+        _workspaceQueryPort = workspaceQueryPort ?? throw new ArgumentNullException(nameof(workspaceQueryPort));
+        _bootstrap = bootstrap ?? throw new ArgumentNullException(nameof(bootstrap));
+        _commandDispatch = commandDispatch ?? throw new ArgumentNullException(nameof(commandDispatch));
+        _commandFactory = commandFactory ?? throw new ArgumentNullException(nameof(commandFactory));
+    }
+
+    public async Task<StudioWorkflowDraftMemberRepairResult> RepairScopeAsync(
+        string scopeId,
+        CancellationToken ct = default)
+    {
+        var normalizedScopeId = StudioMemberConventions.NormalizeScopeId(scopeId);
+        var workspace = await _workspaceQueryPort.GetAsync(normalizedScopeId, ct).ConfigureAwait(false);
+        var requestedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
+        var items = new List<StudioWorkflowDraftMemberRepairItem>(workspace.Drafts.Count);
+        var accepted = 0;
+        var skipped = 0;
+        var failed = 0;
+
+        foreach (var draft in workspace.Drafts)
+        {
+            var plan = _commandFactory.TryCreate(
+                normalizedScopeId,
+                draft.WorkflowId,
+                draft.Name,
+                requestedAt);
+            if (plan == null)
+            {
+                skipped++;
+                items.Add(new StudioWorkflowDraftMemberRepairItem(
+                    draft.WorkflowId,
+                    string.Empty,
+                    string.Empty,
+                    StudioWorkflowDraftMemberRepairItem.Skipped,
+                    Error: "workflowId is required."));
+                continue;
+            }
+
+            try
+            {
+                var actor = await _bootstrap.EnsureAsync<StudioMemberGAgent>(plan.ActorId, ct)
+                    .ConfigureAwait(false);
+                await _commandDispatch.DispatchAsync(
+                    actor,
+                    plan.Command,
+                    plan.PublisherId,
+                    commandId: plan.CommandId,
+                    deduplicationOperationId: plan.DeduplicationOperationId,
+                    ct: ct).ConfigureAwait(false);
+
+                accepted++;
+                items.Add(new StudioWorkflowDraftMemberRepairItem(
+                    draft.WorkflowId,
+                    plan.MemberId,
+                    plan.ActorId,
+                    StudioWorkflowDraftMemberRepairItem.Accepted,
+                    CommandId: plan.CommandId));
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                failed++;
+                items.Add(new StudioWorkflowDraftMemberRepairItem(
+                    draft.WorkflowId,
+                    plan.MemberId,
+                    plan.ActorId,
+                    StudioWorkflowDraftMemberRepairItem.Failed,
+                    CommandId: plan.CommandId,
+                    Error: ex.Message));
+            }
+        }
+
+        return new StudioWorkflowDraftMemberRepairResult(
+            normalizedScopeId,
+            workspace.Drafts.Count,
+            accepted,
+            skipped,
+            failed,
+            items);
+    }
+}

--- a/src/Aevatar.Studio.Projection/Repair/StudioWorkflowDraftMemberRepairService.cs
+++ b/src/Aevatar.Studio.Projection/Repair/StudioWorkflowDraftMemberRepairService.cs
@@ -34,6 +34,11 @@ public sealed record StudioWorkflowDraftMemberRepairItem(
 /// dispatching the existing typed EnsureStudioMember command to the member
 /// actor. No progress, retry, or cross-request state is retained here.
 /// </summary>
+// Refactor (iter1357/cluster-explicit-scope-draft-member-repair):
+//   Old pattern: historical scoped workflow drafts could miss StudioMember
+//   authority creation until another committed draft event replayed.
+//   New principle: an explicit scope-bounded repair reads the workspace
+//   readmodel and reuses the committed-draft EnsureStudioMember command path.
 public sealed class StudioWorkflowDraftMemberRepairService
 {
     private readonly IStudioWorkspaceQueryPort _workspaceQueryPort;

--- a/test/Aevatar.Studio.Tests/StudioWorkflowDraftMemberEnsureMaterializerTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioWorkflowDraftMemberEnsureMaterializerTests.cs
@@ -24,11 +24,11 @@ public sealed class StudioWorkflowDraftMemberEnsureMaterializerTests
     [Fact]
     public async Task ProjectAsync_ShouldDispatchEnsureMember_ForCommittedDraftSaved()
     {
-        var bootstrap = new RecordingBootstrap();
-        var dispatch = new RecordingDispatchPort();
+        var bootstrap = new StudioWorkflowDraftMemberCommandDispatchTestHarness.RecordingBootstrap();
+        var dispatch = new StudioWorkflowDraftMemberCommandDispatchTestHarness.RecordingDispatchPort();
         var materializer = new StudioWorkflowDraftMemberEnsureMaterializer(
             bootstrap,
-            CreateCommandDispatch(dispatch),
+            StudioWorkflowDraftMemberCommandDispatchTestHarness.CreateCommandDispatch(dispatch),
             new StudioWorkflowDraftMemberEnsureCommandFactory());
 
         await materializer.ProjectAsync(
@@ -50,10 +50,10 @@ public sealed class StudioWorkflowDraftMemberEnsureMaterializerTests
     [Fact]
     public async Task ProjectAsync_ShouldUseMemberIdAsDisplayName_WhenDraftNameIsBlank()
     {
-        var dispatch = new RecordingDispatchPort();
+        var dispatch = new StudioWorkflowDraftMemberCommandDispatchTestHarness.RecordingDispatchPort();
         var materializer = new StudioWorkflowDraftMemberEnsureMaterializer(
-            new RecordingBootstrap(),
-            CreateCommandDispatch(dispatch),
+            new StudioWorkflowDraftMemberCommandDispatchTestHarness.RecordingBootstrap(),
+            StudioWorkflowDraftMemberCommandDispatchTestHarness.CreateCommandDispatch(dispatch),
             new StudioWorkflowDraftMemberEnsureCommandFactory());
 
         await materializer.ProjectAsync(
@@ -69,10 +69,10 @@ public sealed class StudioWorkflowDraftMemberEnsureMaterializerTests
     [Fact]
     public async Task ProjectAsync_ShouldUseStableCommandId_ForCommittedDraftReplay()
     {
-        var dispatch = new RecordingDispatchPort();
+        var dispatch = new StudioWorkflowDraftMemberCommandDispatchTestHarness.RecordingDispatchPort();
         var materializer = new StudioWorkflowDraftMemberEnsureMaterializer(
-            new RecordingBootstrap(),
-            CreateCommandDispatch(dispatch),
+            new StudioWorkflowDraftMemberCommandDispatchTestHarness.RecordingBootstrap(),
+            StudioWorkflowDraftMemberCommandDispatchTestHarness.CreateCommandDispatch(dispatch),
             new StudioWorkflowDraftMemberEnsureCommandFactory());
         var envelope = WrapCommitted(NewDraftSaved("workflow-1", "Workflow One"), version: 4, eventId: "evt-4");
 
@@ -88,10 +88,10 @@ public sealed class StudioWorkflowDraftMemberEnsureMaterializerTests
     [Fact]
     public async Task ProjectAsync_ShouldNoOp_WhenCommittedEventIsNotDraftSaved()
     {
-        var dispatch = new RecordingDispatchPort();
+        var dispatch = new StudioWorkflowDraftMemberCommandDispatchTestHarness.RecordingDispatchPort();
         var materializer = new StudioWorkflowDraftMemberEnsureMaterializer(
-            new RecordingBootstrap(),
-            CreateCommandDispatch(dispatch),
+            new StudioWorkflowDraftMemberCommandDispatchTestHarness.RecordingBootstrap(),
+            StudioWorkflowDraftMemberCommandDispatchTestHarness.CreateCommandDispatch(dispatch),
             new StudioWorkflowDraftMemberEnsureCommandFactory());
 
         await materializer.ProjectAsync(
@@ -109,11 +109,11 @@ public sealed class StudioWorkflowDraftMemberEnsureMaterializerTests
     [Fact]
     public async Task ProjectAsync_ShouldNoOp_WhenDraftIsMissingOrWorkflowIdIsBlank()
     {
-        var bootstrap = new RecordingBootstrap();
-        var dispatch = new RecordingDispatchPort();
+        var bootstrap = new StudioWorkflowDraftMemberCommandDispatchTestHarness.RecordingBootstrap();
+        var dispatch = new StudioWorkflowDraftMemberCommandDispatchTestHarness.RecordingDispatchPort();
         var materializer = new StudioWorkflowDraftMemberEnsureMaterializer(
             bootstrap,
-            CreateCommandDispatch(dispatch),
+            StudioWorkflowDraftMemberCommandDispatchTestHarness.CreateCommandDispatch(dispatch),
             new StudioWorkflowDraftMemberEnsureCommandFactory());
 
         await materializer.ProjectAsync(
@@ -181,64 +181,4 @@ public sealed class StudioWorkflowDraftMemberEnsureMaterializerTests
             }),
         };
 
-    private sealed class RecordingBootstrap : IStudioActorBootstrap
-    {
-        public List<string> EnsuredActorIds { get; } = [];
-
-        public Task<IActor> EnsureAsync<TAgent>(string actorId, CancellationToken ct = default)
-            where TAgent : IAgent, IProjectedActor
-        {
-            EnsuredActorIds.Add(actorId);
-            return Task.FromResult<IActor>(new StubActor(actorId));
-        }
-    }
-
-    private sealed class StubActor(string id) : IActor
-    {
-        public string Id { get; } = id;
-        public IAgent Agent => throw new NotSupportedException();
-        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
-        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
-        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) =>
-            Task.CompletedTask;
-        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
-        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() =>
-            Task.FromResult<IReadOnlyList<string>>([]);
-    }
-
-    private sealed class RecordingDispatchPort : IActorDispatchPort
-    {
-        public List<DispatchedCommand> Dispatches { get; } = [];
-
-        public Task<DispatchAdmission> DispatchAsync(
-            string actorId,
-            EventEnvelope envelope,
-            CancellationToken ct = default)
-        {
-            Dispatches.Add(new DispatchedCommand(actorId, envelope));
-            return Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
-        }
-
-        public sealed record DispatchedCommand(string ActorId, EventEnvelope Envelope);
-    }
-
-    private static StudioProjectionActorCommandDispatch CreateCommandDispatch(IActorDispatchPort dispatchPort)
-    {
-        var service = new DefaultCommandDispatchService<
-            StudioProjectionActorCommand,
-            StudioProjectionActorCommandTarget,
-            StudioProjectionActorCommandReceipt,
-            StudioProjectionActorCommandStartError>(
-            new DefaultCommandDispatchPipeline<
-                StudioProjectionActorCommand,
-                StudioProjectionActorCommandTarget,
-                StudioProjectionActorCommandReceipt,
-                StudioProjectionActorCommandStartError>(
-                new StudioProjectionActorCommandTargetResolver(),
-                new DefaultCommandContextPolicy(),
-                new StudioProjectionActorCommandEnvelopeFactory(),
-                new ActorCommandTargetDispatcher<StudioProjectionActorCommandTarget>(dispatchPort),
-                new StudioProjectionActorCommandReceiptFactory()));
-        return new StudioProjectionActorCommandDispatch(service);
-    }
 }

--- a/test/Aevatar.Studio.Tests/StudioWorkflowDraftMemberEnsureMaterializerTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioWorkflowDraftMemberEnsureMaterializerTests.cs
@@ -28,7 +28,8 @@ public sealed class StudioWorkflowDraftMemberEnsureMaterializerTests
         var dispatch = new RecordingDispatchPort();
         var materializer = new StudioWorkflowDraftMemberEnsureMaterializer(
             bootstrap,
-            CreateCommandDispatch(dispatch));
+            CreateCommandDispatch(dispatch),
+            new StudioWorkflowDraftMemberEnsureCommandFactory());
 
         await materializer.ProjectAsync(
             NewContext(),
@@ -52,7 +53,8 @@ public sealed class StudioWorkflowDraftMemberEnsureMaterializerTests
         var dispatch = new RecordingDispatchPort();
         var materializer = new StudioWorkflowDraftMemberEnsureMaterializer(
             new RecordingBootstrap(),
-            CreateCommandDispatch(dispatch));
+            CreateCommandDispatch(dispatch),
+            new StudioWorkflowDraftMemberEnsureCommandFactory());
 
         await materializer.ProjectAsync(
             NewContext(),
@@ -70,7 +72,8 @@ public sealed class StudioWorkflowDraftMemberEnsureMaterializerTests
         var dispatch = new RecordingDispatchPort();
         var materializer = new StudioWorkflowDraftMemberEnsureMaterializer(
             new RecordingBootstrap(),
-            CreateCommandDispatch(dispatch));
+            CreateCommandDispatch(dispatch),
+            new StudioWorkflowDraftMemberEnsureCommandFactory());
         var envelope = WrapCommitted(NewDraftSaved("workflow-1", "Workflow One"), version: 4, eventId: "evt-4");
 
         await materializer.ProjectAsync(NewContext(), envelope);
@@ -88,7 +91,8 @@ public sealed class StudioWorkflowDraftMemberEnsureMaterializerTests
         var dispatch = new RecordingDispatchPort();
         var materializer = new StudioWorkflowDraftMemberEnsureMaterializer(
             new RecordingBootstrap(),
-            CreateCommandDispatch(dispatch));
+            CreateCommandDispatch(dispatch),
+            new StudioWorkflowDraftMemberEnsureCommandFactory());
 
         await materializer.ProjectAsync(
             NewContext(),
@@ -109,7 +113,8 @@ public sealed class StudioWorkflowDraftMemberEnsureMaterializerTests
         var dispatch = new RecordingDispatchPort();
         var materializer = new StudioWorkflowDraftMemberEnsureMaterializer(
             bootstrap,
-            CreateCommandDispatch(dispatch));
+            CreateCommandDispatch(dispatch),
+            new StudioWorkflowDraftMemberEnsureCommandFactory());
 
         await materializer.ProjectAsync(
             NewContext(),

--- a/test/Aevatar.Studio.Tests/StudioWorkflowDraftMemberRepairEndpointsTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioWorkflowDraftMemberRepairEndpointsTests.cs
@@ -77,8 +77,9 @@ public sealed class StudioWorkflowDraftMemberRepairEndpointsTests
         IStudioWorkspaceQueryPort workspaceQueryPort) =>
         new(
             workspaceQueryPort,
-            new RecordingBootstrap(),
-            CreateCommandDispatch(new RecordingDispatchPort()),
+            new StudioWorkflowDraftMemberCommandDispatchTestHarness.RecordingBootstrap(),
+            StudioWorkflowDraftMemberCommandDispatchTestHarness.CreateCommandDispatch(
+                new StudioWorkflowDraftMemberCommandDispatchTestHarness.RecordingDispatchPort()),
             new StudioWorkflowDraftMemberEnsureCommandFactory());
 
     private sealed class StubWorkspaceQueryPort(IReadOnlyList<StudioWorkflowDraftRecord> drafts)
@@ -109,55 +110,6 @@ public sealed class StudioWorkflowDraftMemberRepairEndpointsTests
 
         public Task<StudioWorkspaceSnapshot> GetAsync(string scopeId, CancellationToken ct = default) =>
             Task.FromException<StudioWorkspaceSnapshot>(exception);
-    }
-
-    private sealed class RecordingBootstrap : IStudioActorBootstrap
-    {
-        public Task<IActor> EnsureAsync<TAgent>(string actorId, CancellationToken ct = default)
-            where TAgent : IAgent, IProjectedActor =>
-            Task.FromResult<IActor>(new StubActor(actorId));
-    }
-
-    private sealed class StubActor(string id) : IActor
-    {
-        public string Id { get; } = id;
-        public IAgent Agent => throw new NotSupportedException();
-        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
-        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
-        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) =>
-            Task.CompletedTask;
-        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
-        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() =>
-            Task.FromResult<IReadOnlyList<string>>([]);
-    }
-
-    private sealed class RecordingDispatchPort : IActorDispatchPort
-    {
-        public Task<DispatchAdmission> DispatchAsync(
-            string actorId,
-            EventEnvelope envelope,
-            CancellationToken ct = default) =>
-            Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
-    }
-
-    private static StudioProjectionActorCommandDispatch CreateCommandDispatch(IActorDispatchPort dispatchPort)
-    {
-        var service = new DefaultCommandDispatchService<
-            StudioProjectionActorCommand,
-            StudioProjectionActorCommandTarget,
-            StudioProjectionActorCommandReceipt,
-            StudioProjectionActorCommandStartError>(
-            new DefaultCommandDispatchPipeline<
-                StudioProjectionActorCommand,
-                StudioProjectionActorCommandTarget,
-                StudioProjectionActorCommandReceipt,
-                StudioProjectionActorCommandStartError>(
-                new StudioProjectionActorCommandTargetResolver(),
-                new DefaultCommandContextPolicy(),
-                new StudioProjectionActorCommandEnvelopeFactory(),
-                new ActorCommandTargetDispatcher<StudioProjectionActorCommandTarget>(dispatchPort),
-                new StudioProjectionActorCommandReceiptFactory()));
-        return new StudioProjectionActorCommandDispatch(service);
     }
 
     private static HttpContext CreateAuthenticatedContext(string claimedScopeId)

--- a/test/Aevatar.Studio.Tests/StudioWorkflowDraftMemberRepairEndpointsTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioWorkflowDraftMemberRepairEndpointsTests.cs
@@ -1,0 +1,224 @@
+using System.Reflection;
+using System.Security.Claims;
+using Aevatar.CQRS.Core.Commands;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Domain.Studio.Models;
+using Aevatar.Studio.Hosting.Endpoints;
+using Aevatar.Studio.Projection.CommandServices;
+using Aevatar.Studio.Projection.Projectors;
+using Aevatar.Studio.Projection.Repair;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Aevatar.Studio.Tests;
+
+public sealed class StudioWorkflowDraftMemberRepairEndpointsTests
+{
+    [Fact]
+    public async Task HandleRepairScopeAsync_ShouldReturnAccepted_ForExplicitScope()
+    {
+        var service = NewRepairService([]);
+
+        var result = await InvokeHandle<IResult>(
+            "HandleRepairScopeAsync",
+            CreateAuthenticatedContext("scope-1"),
+            "scope-1",
+            service,
+            CancellationToken.None);
+
+        var accepted = result.Should().BeOfType<Accepted<StudioWorkflowDraftMemberRepairResult>>().Subject;
+        accepted.Value!.ScopeId.Should().Be("scope-1");
+        accepted.Value.DraftCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task HandleRepairScopeAsync_ShouldReturnForbidden_WhenScopeAccessDenied()
+    {
+        var service = NewRepairService([]);
+
+        var result = await InvokeHandle<IResult>(
+            "HandleRepairScopeAsync",
+            CreateAuthenticatedContext("other-scope"),
+            "scope-1",
+            service,
+            CancellationToken.None);
+
+        AssertIsJsonStatus(result, StatusCodes.Status403Forbidden);
+    }
+
+    [Fact]
+    public async Task HandleRepairScopeAsync_ShouldReturnBadRequest_OnDomainError()
+    {
+        var service = NewRepairService(new ThrowingWorkspaceQueryPort(
+            new InvalidOperationException("scopeId is required.")));
+
+        var result = await InvokeHandle<IResult>(
+            "HandleRepairScopeAsync",
+            CreateAuthenticatedContext("scope-1"),
+            "scope-1",
+            service,
+            CancellationToken.None);
+
+        AssertBadRequestResult(
+            result,
+            "INVALID_STUDIO_WORKFLOW_DRAFT_MEMBER_REPAIR_REQUEST");
+    }
+
+    private static StudioWorkflowDraftMemberRepairService NewRepairService(
+        IReadOnlyList<StudioWorkflowDraftRecord> drafts) =>
+        NewRepairService(new StubWorkspaceQueryPort(drafts));
+
+    private static StudioWorkflowDraftMemberRepairService NewRepairService(
+        IStudioWorkspaceQueryPort workspaceQueryPort) =>
+        new(
+            workspaceQueryPort,
+            new RecordingBootstrap(),
+            CreateCommandDispatch(new RecordingDispatchPort()),
+            new StudioWorkflowDraftMemberEnsureCommandFactory());
+
+    private sealed class StubWorkspaceQueryPort(IReadOnlyList<StudioWorkflowDraftRecord> drafts)
+        : IStudioWorkspaceQueryPort
+    {
+        public Task<StudioWorkspaceSnapshot> GetAsync(CancellationToken ct = default) =>
+            throw new NotSupportedException("repair must use explicit scope.");
+
+        public Task<StudioWorkspaceSnapshot> GetAsync(string scopeId, CancellationToken ct = default) =>
+            Task.FromResult(new StudioWorkspaceSnapshot(
+                $"studio-workspace:{scopeId}",
+                scopeId,
+                new StudioWorkspaceSettings(
+                    RuntimeBaseUrl: string.Empty,
+                    Directories: [],
+                    AppearanceTheme: "blue",
+                    ColorMode: "light"),
+                Directories: [],
+                Drafts: drafts,
+                StateVersion: 11,
+                UpdatedAtUtc: DateTimeOffset.Parse("2026-05-25T00:00:00Z")));
+    }
+
+    private sealed class ThrowingWorkspaceQueryPort(Exception exception) : IStudioWorkspaceQueryPort
+    {
+        public Task<StudioWorkspaceSnapshot> GetAsync(CancellationToken ct = default) =>
+            Task.FromException<StudioWorkspaceSnapshot>(exception);
+
+        public Task<StudioWorkspaceSnapshot> GetAsync(string scopeId, CancellationToken ct = default) =>
+            Task.FromException<StudioWorkspaceSnapshot>(exception);
+    }
+
+    private sealed class RecordingBootstrap : IStudioActorBootstrap
+    {
+        public Task<IActor> EnsureAsync<TAgent>(string actorId, CancellationToken ct = default)
+            where TAgent : IAgent, IProjectedActor =>
+            Task.FromResult<IActor>(new StubActor(actorId));
+    }
+
+    private sealed class StubActor(string id) : IActor
+    {
+        public string Id { get; } = id;
+        public IAgent Agent => throw new NotSupportedException();
+        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) =>
+            Task.CompletedTask;
+        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
+        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class RecordingDispatchPort : IActorDispatchPort
+    {
+        public Task<DispatchAdmission> DispatchAsync(
+            string actorId,
+            EventEnvelope envelope,
+            CancellationToken ct = default) =>
+            Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
+    }
+
+    private static StudioProjectionActorCommandDispatch CreateCommandDispatch(IActorDispatchPort dispatchPort)
+    {
+        var service = new DefaultCommandDispatchService<
+            StudioProjectionActorCommand,
+            StudioProjectionActorCommandTarget,
+            StudioProjectionActorCommandReceipt,
+            StudioProjectionActorCommandStartError>(
+            new DefaultCommandDispatchPipeline<
+                StudioProjectionActorCommand,
+                StudioProjectionActorCommandTarget,
+                StudioProjectionActorCommandReceipt,
+                StudioProjectionActorCommandStartError>(
+                new StudioProjectionActorCommandTargetResolver(),
+                new DefaultCommandContextPolicy(),
+                new StudioProjectionActorCommandEnvelopeFactory(),
+                new ActorCommandTargetDispatcher<StudioProjectionActorCommandTarget>(dispatchPort),
+                new StudioProjectionActorCommandReceiptFactory()));
+        return new StudioProjectionActorCommandDispatch(service);
+    }
+
+    private static HttpContext CreateAuthenticatedContext(string claimedScopeId)
+    {
+        var identity = new ClaimsIdentity(
+            [new Claim("scope_id", claimedScopeId)],
+            "test");
+        var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Aevatar:Authentication:Enabled"] = "true",
+                })
+                .Build())
+            .AddSingleton<IHostEnvironment>(new TestHostEnvironment())
+            .BuildServiceProvider();
+        return new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(identity),
+            RequestServices = services,
+        };
+    }
+
+    private static async Task<TResult> InvokeHandle<TResult>(string methodName, params object?[] args)
+    {
+        var method = typeof(StudioWorkflowDraftMemberRepairEndpoints)
+            .GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException($"Method {methodName} not found.");
+        var task = (Task<IResult>)method.Invoke(null, args)!;
+        return (TResult)(object)await task;
+    }
+
+    private static void AssertIsJsonStatus(IResult result, int expectedStatus)
+    {
+        var statusCodeProperty = result.GetType().GetProperty("StatusCode");
+        var statusCode = statusCodeProperty?.GetValue(result) as int?;
+        statusCode.Should().Be(expectedStatus);
+    }
+
+    private static void AssertBadRequestResult(IResult result, string expectedCode)
+    {
+        result.GetType().Name.Should().StartWith("BadRequest");
+
+        var statusCodeProp = result.GetType().GetProperty("StatusCode");
+        var statusCode = statusCodeProp?.GetValue(result) as int?;
+        statusCode.Should().Be(StatusCodes.Status400BadRequest);
+
+        var valueProp = result.GetType().GetProperty("Value");
+        var value = valueProp?.GetValue(result);
+        value.Should().NotBeNull();
+
+        var codeProp = value!.GetType().GetProperty("code");
+        var code = codeProp?.GetValue(value) as string;
+        code.Should().Be(expectedCode);
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Production;
+        public string ApplicationName { get; set; } = "Aevatar.Studio.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } = null!;
+    }
+}

--- a/test/Aevatar.Studio.Tests/StudioWorkflowDraftMemberRepairEndpointsTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioWorkflowDraftMemberRepairEndpointsTests.cs
@@ -9,8 +9,10 @@ using Aevatar.Studio.Projection.CommandServices;
 using Aevatar.Studio.Projection.Projectors;
 using Aevatar.Studio.Projection.Repair;
 using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -67,6 +69,30 @@ public sealed class StudioWorkflowDraftMemberRepairEndpointsTests
         AssertBadRequestResult(
             result,
             "INVALID_STUDIO_WORKFLOW_DRAFT_MEMBER_REPAIR_REQUEST");
+    }
+
+    [Fact]
+    public async Task Map_ShouldRegisterPostRoute_WithServiceBinding()
+    {
+        var service = NewRepairService([]);
+        var app = BuildMappedApp(service);
+        var endpoint = GetRepairEndpoint(app);
+        var methodMetadata = endpoint.Metadata.GetMetadata<HttpMethodMetadata>();
+        var context = CreateAuthenticatedContext("scope-1");
+        context.RequestServices = app.Services;
+        context.Request.RouteValues["scopeId"] = "scope-1";
+        await using var body = new MemoryStream();
+        context.Response.Body = body;
+
+        await endpoint.RequestDelegate!(context);
+
+        endpoint.RoutePattern.RawText.Should().Be(
+            "/api/scopes/{scopeId}/workflow-drafts:repair-members");
+        methodMetadata.Should().NotBeNull();
+        methodMetadata!.HttpMethods.Should().Equal(HttpMethods.Post);
+        context.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        context.Response.Headers.Location.ToString().Should().Be(
+            "/api/scopes/scope-1/workflow-drafts:repair-members");
     }
 
     private static StudioWorkflowDraftMemberRepairService NewRepairService(
@@ -132,6 +158,34 @@ public sealed class StudioWorkflowDraftMemberRepairEndpointsTests
             RequestServices = services,
         };
     }
+
+    private static WebApplication BuildMappedApp(StudioWorkflowDraftMemberRepairService repairService)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddSingleton<IConfiguration>(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Aevatar:Authentication:Enabled"] = "true",
+            })
+            .Build());
+        builder.Services.AddSingleton<IHostEnvironment>(new TestHostEnvironment());
+        builder.Services.AddSingleton(repairService);
+        builder.Services.AddRouting();
+        var app = builder.Build();
+
+        StudioWorkflowDraftMemberRepairEndpoints.Map(app);
+
+        return app;
+    }
+
+    private static RouteEndpoint GetRepairEndpoint(WebApplication app) =>
+        ((IEndpointRouteBuilder)app).DataSources
+            .SelectMany(source => source.Endpoints)
+            .OfType<RouteEndpoint>()
+            .Single(endpoint => string.Equals(
+                endpoint.RoutePattern.RawText,
+                "/api/scopes/{scopeId}/workflow-drafts:repair-members",
+                StringComparison.Ordinal));
 
     private static async Task<TResult> InvokeHandle<TResult>(string methodName, params object?[] args)
     {

--- a/test/Aevatar.Studio.Tests/StudioWorkflowDraftMemberRepairServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioWorkflowDraftMemberRepairServiceTests.cs
@@ -94,6 +94,22 @@ public sealed class StudioWorkflowDraftMemberRepairServiceTests
     }
 
     [Fact]
+    public async Task RepairScopeAsync_ShouldRethrowCancellation_WithoutFailedItem()
+    {
+        var workspace = new StubWorkspaceQueryPort([
+            NewDraft("workflow-1", "Workflow One"),
+        ]);
+        var service = NewService(
+            workspace,
+            new StudioWorkflowDraftMemberCommandDispatchTestHarness.RecordingBootstrap(),
+            new CancelingDispatchPort());
+
+        var act = () => service.RepairScopeAsync("scope-1");
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
     public void EnsureCommandFactory_ShouldShareStableIdentity_ForLiveProjectionAndRepair()
     {
         var factory = new StudioWorkflowDraftMemberEnsureCommandFactory();
@@ -162,6 +178,15 @@ public sealed class StudioWorkflowDraftMemberRepairServiceTests
                 Drafts: drafts,
                 StateVersion: 11,
                 UpdatedAtUtc: DateTimeOffset.Parse("2026-05-25T00:00:00Z")));
+    }
+
+    private sealed class CancelingDispatchPort : IActorDispatchPort
+    {
+        public Task<DispatchAdmission> DispatchAsync(
+            string actorId,
+            EventEnvelope envelope,
+            CancellationToken ct = default) =>
+            throw new OperationCanceledException();
     }
 
 }

--- a/test/Aevatar.Studio.Tests/StudioWorkflowDraftMemberRepairServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioWorkflowDraftMemberRepairServiceTests.cs
@@ -20,8 +20,8 @@ public sealed class StudioWorkflowDraftMemberRepairServiceTests
             NewDraft("workflow-1", "Workflow One"),
             NewDraft("workflow-2", "Workflow Two"),
         ]);
-        var bootstrap = new RecordingBootstrap();
-        var dispatch = new RecordingDispatchPort();
+        var bootstrap = new StudioWorkflowDraftMemberCommandDispatchTestHarness.RecordingBootstrap();
+        var dispatch = new StudioWorkflowDraftMemberCommandDispatchTestHarness.RecordingDispatchPort();
         var service = NewService(workspace, bootstrap, dispatch);
 
         var result = await service.RepairScopeAsync("scope-1");
@@ -52,8 +52,11 @@ public sealed class StudioWorkflowDraftMemberRepairServiceTests
         var workspace = new StubWorkspaceQueryPort([
             NewDraft("   ", "Missing Id"),
         ]);
-        var dispatch = new RecordingDispatchPort();
-        var service = NewService(workspace, new RecordingBootstrap(), dispatch);
+        var dispatch = new StudioWorkflowDraftMemberCommandDispatchTestHarness.RecordingDispatchPort();
+        var service = NewService(
+            workspace,
+            new StudioWorkflowDraftMemberCommandDispatchTestHarness.RecordingBootstrap(),
+            dispatch);
 
         var result = await service.RepairScopeAsync("scope-1");
 
@@ -74,8 +77,8 @@ public sealed class StudioWorkflowDraftMemberRepairServiceTests
         ]);
         var service = NewService(
             workspace,
-            new RecordingBootstrap(),
-            new ThrowingDispatchPort());
+            new StudioWorkflowDraftMemberCommandDispatchTestHarness.RecordingBootstrap(),
+            new StudioWorkflowDraftMemberCommandDispatchTestHarness.ThrowingDispatchPort());
 
         var result = await service.RepairScopeAsync("scope-1");
 
@@ -123,7 +126,7 @@ public sealed class StudioWorkflowDraftMemberRepairServiceTests
         new(
             workspaceQueryPort,
             bootstrap,
-            CreateCommandDispatch(dispatchPort),
+            StudioWorkflowDraftMemberCommandDispatchTestHarness.CreateCommandDispatch(dispatchPort),
             new StudioWorkflowDraftMemberEnsureCommandFactory());
 
     private static StudioWorkflowDraftRecord NewDraft(string workflowId, string name) =>
@@ -161,7 +164,11 @@ public sealed class StudioWorkflowDraftMemberRepairServiceTests
                 UpdatedAtUtc: DateTimeOffset.Parse("2026-05-25T00:00:00Z")));
     }
 
-    private sealed class RecordingBootstrap : IStudioActorBootstrap
+}
+
+internal static class StudioWorkflowDraftMemberCommandDispatchTestHarness
+{
+    public class RecordingBootstrap : IStudioActorBootstrap
     {
         public List<string> EnsuredActorIds { get; } = [];
 
@@ -173,20 +180,7 @@ public sealed class StudioWorkflowDraftMemberRepairServiceTests
         }
     }
 
-    private sealed class StubActor(string id) : IActor
-    {
-        public string Id { get; } = id;
-        public IAgent Agent => throw new NotSupportedException();
-        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
-        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
-        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) =>
-            Task.CompletedTask;
-        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
-        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() =>
-            Task.FromResult<IReadOnlyList<string>>([]);
-    }
-
-    private sealed class RecordingDispatchPort : IActorDispatchPort
+    public class RecordingDispatchPort : IActorDispatchPort
     {
         public List<DispatchedCommand> Dispatches { get; } = [];
 
@@ -202,7 +196,7 @@ public sealed class StudioWorkflowDraftMemberRepairServiceTests
         public sealed record DispatchedCommand(string ActorId, EventEnvelope Envelope);
     }
 
-    private sealed class ThrowingDispatchPort : IActorDispatchPort
+    public class ThrowingDispatchPort : IActorDispatchPort
     {
         public Task<DispatchAdmission> DispatchAsync(
             string actorId,
@@ -211,7 +205,7 @@ public sealed class StudioWorkflowDraftMemberRepairServiceTests
             throw new InvalidOperationException("dispatch failed");
     }
 
-    private static StudioProjectionActorCommandDispatch CreateCommandDispatch(IActorDispatchPort dispatchPort)
+    public static StudioProjectionActorCommandDispatch CreateCommandDispatch(IActorDispatchPort dispatchPort)
     {
         var service = new DefaultCommandDispatchService<
             StudioProjectionActorCommand,
@@ -229,5 +223,18 @@ public sealed class StudioWorkflowDraftMemberRepairServiceTests
                 new ActorCommandTargetDispatcher<StudioProjectionActorCommandTarget>(dispatchPort),
                 new StudioProjectionActorCommandReceiptFactory()));
         return new StudioProjectionActorCommandDispatch(service);
+    }
+
+    private sealed class StubActor(string id) : IActor
+    {
+        public string Id { get; } = id;
+        public IAgent Agent => throw new NotSupportedException();
+        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) =>
+            Task.CompletedTask;
+        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
+        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() =>
+            Task.FromResult<IReadOnlyList<string>>([]);
     }
 }

--- a/test/Aevatar.Studio.Tests/StudioWorkflowDraftMemberRepairServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioWorkflowDraftMemberRepairServiceTests.cs
@@ -1,0 +1,233 @@
+using Aevatar.CQRS.Core.Commands;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.StudioMember;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Domain.Studio.Models;
+using Aevatar.Studio.Projection.CommandServices;
+using Aevatar.Studio.Projection.Projectors;
+using Aevatar.Studio.Projection.Repair;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Studio.Tests;
+
+public sealed class StudioWorkflowDraftMemberRepairServiceTests
+{
+    [Fact]
+    public async Task RepairScopeAsync_ShouldDispatchEnsureMember_ForEachExplicitScopeDraft()
+    {
+        var workspace = new StubWorkspaceQueryPort([
+            NewDraft("workflow-1", "Workflow One"),
+            NewDraft("workflow-2", "Workflow Two"),
+        ]);
+        var bootstrap = new RecordingBootstrap();
+        var dispatch = new RecordingDispatchPort();
+        var service = NewService(workspace, bootstrap, dispatch);
+
+        var result = await service.RepairScopeAsync("scope-1");
+
+        result.ScopeId.Should().Be("scope-1");
+        result.DraftCount.Should().Be(2);
+        result.AcceptedCount.Should().Be(2);
+        result.SkippedCount.Should().Be(0);
+        result.FailedCount.Should().Be(0);
+        bootstrap.EnsuredActorIds.Should().Equal(
+            "studio-member:scope-1:workflow-1",
+            "studio-member:scope-1:workflow-2");
+        dispatch.Dispatches.Should().HaveCount(2);
+        var first = dispatch.Dispatches[0];
+        first.ActorId.Should().Be("studio-member:scope-1:workflow-1");
+        var command = first.Envelope.Payload.Unpack<EnsureStudioMember>();
+        command.ScopeId.Should().Be("scope-1");
+        command.MemberId.Should().Be("workflow-1");
+        command.DisplayName.Should().Be("Workflow One");
+        first.Envelope.Id.Should().Be(
+            "aevatar.studio.projection.workflow-draft-member-ensure:scope-1:workflow-1");
+        first.Envelope.Runtime?.Deduplication?.OperationId.Should().Be(first.Envelope.Id);
+    }
+
+    [Fact]
+    public async Task RepairScopeAsync_ShouldReturnSkipped_ForDraftWithoutWorkflowId()
+    {
+        var workspace = new StubWorkspaceQueryPort([
+            NewDraft("   ", "Missing Id"),
+        ]);
+        var dispatch = new RecordingDispatchPort();
+        var service = NewService(workspace, new RecordingBootstrap(), dispatch);
+
+        var result = await service.RepairScopeAsync("scope-1");
+
+        result.DraftCount.Should().Be(1);
+        result.AcceptedCount.Should().Be(0);
+        result.SkippedCount.Should().Be(1);
+        result.FailedCount.Should().Be(0);
+        result.Items.Should().ContainSingle()
+            .Which.Status.Should().Be(StudioWorkflowDraftMemberRepairItem.Skipped);
+        dispatch.Dispatches.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RepairScopeAsync_ShouldSurfaceFailedItem_WithoutRetainedRetryState()
+    {
+        var workspace = new StubWorkspaceQueryPort([
+            NewDraft("workflow-1", "Workflow One"),
+        ]);
+        var service = NewService(
+            workspace,
+            new RecordingBootstrap(),
+            new ThrowingDispatchPort());
+
+        var result = await service.RepairScopeAsync("scope-1");
+
+        result.AcceptedCount.Should().Be(0);
+        result.SkippedCount.Should().Be(0);
+        result.FailedCount.Should().Be(1);
+        var failed = result.Items.Should().ContainSingle().Subject;
+        failed.Status.Should().Be(StudioWorkflowDraftMemberRepairItem.Failed);
+        failed.MemberId.Should().Be("workflow-1");
+        failed.CommandId.Should().Be(
+            "aevatar.studio.projection.workflow-draft-member-ensure:scope-1:workflow-1");
+        failed.Error.Should().Be("dispatch failed");
+    }
+
+    [Fact]
+    public void EnsureCommandFactory_ShouldShareStableIdentity_ForLiveProjectionAndRepair()
+    {
+        var factory = new StudioWorkflowDraftMemberEnsureCommandFactory();
+
+        var live = factory.TryCreate(
+            "scope-1",
+            "workflow-1",
+            "Workflow One",
+            Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-05-25T00:00:00Z")));
+        var repair = factory.TryCreate(
+            " scope-1 ",
+            " workflow-1 ",
+            "Workflow One",
+            Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-05-30T00:00:00Z")));
+
+        live.Should().NotBeNull();
+        repair.Should().NotBeNull();
+        repair!.ActorId.Should().Be(live!.ActorId);
+        repair.CommandId.Should().Be(live.CommandId);
+        repair.DeduplicationOperationId.Should().Be(live.DeduplicationOperationId);
+        repair.Command.ScopeId.Should().Be(live.Command.ScopeId);
+        repair.Command.MemberId.Should().Be(live.Command.MemberId);
+        repair.Command.DisplayName.Should().Be(live.Command.DisplayName);
+    }
+
+    private static StudioWorkflowDraftMemberRepairService NewService(
+        IStudioWorkspaceQueryPort workspaceQueryPort,
+        IStudioActorBootstrap bootstrap,
+        IActorDispatchPort dispatchPort) =>
+        new(
+            workspaceQueryPort,
+            bootstrap,
+            CreateCommandDispatch(dispatchPort),
+            new StudioWorkflowDraftMemberEnsureCommandFactory());
+
+    private static StudioWorkflowDraftRecord NewDraft(string workflowId, string name) =>
+        new(
+            workflowId,
+            name,
+            $"{workflowId}.yaml",
+            $"scope://scope-1/{workflowId}.yaml",
+            "scope:scope-1",
+            "scope-1",
+            "name: workflow\nsteps: []\n",
+            Layout: null,
+            DateTimeOffset.Parse("2026-05-25T00:00:00Z"),
+            DateTimeOffset.Parse("2026-05-25T00:00:00Z"),
+            1);
+
+    private sealed class StubWorkspaceQueryPort(IReadOnlyList<StudioWorkflowDraftRecord> drafts)
+        : IStudioWorkspaceQueryPort
+    {
+        public Task<StudioWorkspaceSnapshot> GetAsync(CancellationToken ct = default) =>
+            throw new NotSupportedException("repair must use explicit scope.");
+
+        public Task<StudioWorkspaceSnapshot> GetAsync(string scopeId, CancellationToken ct = default) =>
+            Task.FromResult(new StudioWorkspaceSnapshot(
+                $"studio-workspace:{scopeId}",
+                scopeId,
+                new StudioWorkspaceSettings(
+                    RuntimeBaseUrl: string.Empty,
+                    Directories: [],
+                    AppearanceTheme: "blue",
+                    ColorMode: "light"),
+                Directories: [],
+                Drafts: drafts,
+                StateVersion: 11,
+                UpdatedAtUtc: DateTimeOffset.Parse("2026-05-25T00:00:00Z")));
+    }
+
+    private sealed class RecordingBootstrap : IStudioActorBootstrap
+    {
+        public List<string> EnsuredActorIds { get; } = [];
+
+        public Task<IActor> EnsureAsync<TAgent>(string actorId, CancellationToken ct = default)
+            where TAgent : IAgent, IProjectedActor
+        {
+            EnsuredActorIds.Add(actorId);
+            return Task.FromResult<IActor>(new StubActor(actorId));
+        }
+    }
+
+    private sealed class StubActor(string id) : IActor
+    {
+        public string Id { get; } = id;
+        public IAgent Agent => throw new NotSupportedException();
+        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) =>
+            Task.CompletedTask;
+        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
+        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class RecordingDispatchPort : IActorDispatchPort
+    {
+        public List<DispatchedCommand> Dispatches { get; } = [];
+
+        public Task<DispatchAdmission> DispatchAsync(
+            string actorId,
+            EventEnvelope envelope,
+            CancellationToken ct = default)
+        {
+            Dispatches.Add(new DispatchedCommand(actorId, envelope));
+            return Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
+        }
+
+        public sealed record DispatchedCommand(string ActorId, EventEnvelope Envelope);
+    }
+
+    private sealed class ThrowingDispatchPort : IActorDispatchPort
+    {
+        public Task<DispatchAdmission> DispatchAsync(
+            string actorId,
+            EventEnvelope envelope,
+            CancellationToken ct = default) =>
+            throw new InvalidOperationException("dispatch failed");
+    }
+
+    private static StudioProjectionActorCommandDispatch CreateCommandDispatch(IActorDispatchPort dispatchPort)
+    {
+        var service = new DefaultCommandDispatchService<
+            StudioProjectionActorCommand,
+            StudioProjectionActorCommandTarget,
+            StudioProjectionActorCommandReceipt,
+            StudioProjectionActorCommandStartError>(
+            new DefaultCommandDispatchPipeline<
+                StudioProjectionActorCommand,
+                StudioProjectionActorCommandTarget,
+                StudioProjectionActorCommandReceipt,
+                StudioProjectionActorCommandStartError>(
+                new StudioProjectionActorCommandTargetResolver(),
+                new DefaultCommandContextPolicy(),
+                new StudioProjectionActorCommandEnvelopeFactory(),
+                new ActorCommandTargetDispatcher<StudioProjectionActorCommandTarget>(dispatchPort),
+                new StudioProjectionActorCommandReceiptFactory()));
+        return new StudioProjectionActorCommandDispatch(service);
+    }
+}


### PR DESCRIPTION
## 摘要

源自 #1346 Phase 9 r1 split first-slice → #1357 implement(无 durable backfill lifecycle 路径)。

显式 scope 的一次性 draft member repair:

- 输入: 明确 scope 列表
- 读: 已物化的 \`StudioWorkspaceCurrentStateDocument\` 当前 readmodel
- 复用: 与正路径一致的 typed \`EnsureStudioMember\` 命令 + 现有 actor dispatch
- 返回: \`accepted/skipped/failed\` 结果

## 边界(no-new-core)

- 不新增 actor type / envelope kind / pipeline phase / proto field
- 不保存跨请求 retry/progress 状态
- 不做 all-scope scan
- 不新增 \`StudioDraftMemberBackfillRunGAgent\` / rollback / tombstone / startup job
- 不读 event store 或 actor state 侧读

## 验证

- \`dotnet build aevatar.slnx --nologo\`
- \`dotnet test aevatar.slnx --nologo --no-build\`

closes #1357

🤖 Auto-loop / codex-refactor-loop
⟦AI:AUTO-LOOP⟧