### PR TITLE
[refactor] #1354 first slice: docs/canon/llm-streaming §7.1 identity table 更新 + 1 个 identity 分离测试

### DIFF
--- a/docs/canon/llm-streaming.md
+++ b/docs/canon/llm-streaming.md
@@ -269,9 +269,10 @@ flowchart LR
 
 | 标识 | 生成位置 | 语义范围 | 事实源 | 主要消费点 |
 |---|---|---|---|---|
-| `actorId` | `WorkflowRunActorResolver` | Workflow Actor 维度 | Actor Runtime | 投影上下文、查询接口 |
-| `commandId` | `DefaultCommandContextPolicy` | 一次 run 命令维度 | Application CommandContext | `workflow-run:{actorId}:{commandId}` 会话流 |
-| `correlationId` | `DefaultCommandContextPolicy` | 与 `commandId` 同步（默认同值） | Application CommandContext | `EventEnvelope.Propagation.CorrelationId` |
+| `actorId` | `WorkflowRunActorResolver` / run control request | Workflow Actor 地址维度；run control 中只用于定位目标 Actor | Actor Runtime / `WorkflowActorBinding.ActorId` | 投影上下文、查询接口、run control dispatch target |
+| `runId` | Workflow run binding / run control request | Workflow run 业务执行维度；不作为 Actor 地址或 command/session identity | `WorkflowActorBinding.RunId` | `WorkflowRunControlCommandTarget.RunId`、`WorkflowResumedEvent.RunId`、`SignalReceivedEvent.RunId`、`WorkflowStoppedEvent.RunId` |
+| `commandId` | `DefaultCommandContextPolicy` | 一次 run 命令维度；run control 中作为 accepted command / envelope identity | Application CommandContext | `workflow-run:{actorId}:{commandId}` 会话流、`WorkflowRunControlAcceptedReceipt.CommandId`、`EventEnvelope.Id` |
+| `correlationId` | `DefaultCommandContextPolicy` | 命令追踪维度；默认可与 `commandId` 同值，但语义独立 | Application CommandContext | `EventEnvelope.Propagation.CorrelationId`、`WorkflowRunControlAcceptedReceipt.CorrelationId` |
 | `sessionId` | `WorkflowChatRunRequest.SessionId` + `WorkflowChatRequestEnvelopeFactory` fallback | 本次 chat 会话维度 | Command payload | `ChatRequestEvent.SessionId` |
 | `chatSessionId` | `ChatSessionKeys.CreateWorkflowStepSessionId` | 单 workflow step 维度 | `scopeId:stepId` 规则 | `LLMCallModule` pending 匹配 |
 | `messageId` | run-event mapper | 单消息流维度 | `msg:{sessionId}` 或 `msg:{envelopeId}` | 文本增量拼装 |

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlIdentitySeparationTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlIdentitySeparationTests.cs
@@ -1,0 +1,73 @@
+using Aevatar.CQRS.Core.Abstractions.Commands;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.Workflow.Application.Runs;
+using Aevatar.Workflow.Abstractions;
+using FluentAssertions;
+
+namespace Aevatar.Workflow.Application.Tests;
+
+public sealed class WorkflowRunControlIdentitySeparationTests
+{
+    [Fact]
+    public async Task ResumeControlCommand_ShouldKeepActorRunCommandAndCorrelationIdentitiesSeparate()
+    {
+        // Refactor (issue1354): Old pattern: workflow run control could be read as sharing one identity across actor routing, run binding, command envelope, and tracing. New principle: actorId addresses the actor, runId names the bound workflow run fact, commandId names the accepted command/envelope, and correlationId remains propagation trace context.
+        const string actorId = "workflow-run-actor-1";
+        const string runId = "workflow-run-fact-1";
+        const string commandId = "resume-command-1";
+        const string correlationId = "resume-correlation-1";
+
+        var resolver = new WorkflowResumeCommandTargetResolver(new BindingReader(
+            new WorkflowActorBinding(
+                WorkflowActorKind.Run,
+                actorId,
+                "definition-1",
+                runId,
+                "direct",
+                "yaml",
+                new Dictionary<string, string>())));
+
+        var command = new WorkflowResumeCommand(
+            actorId,
+            runId,
+            "step-1",
+            commandId,
+            true,
+            "approved",
+            CorrelationId: correlationId);
+
+        var resolution = await resolver.ResolveAsync(command, CancellationToken.None);
+        resolution.Succeeded.Should().BeTrue();
+
+        var target = resolution.Target!;
+        var context = new CommandContext(target.TargetId, commandId, correlationId, new Dictionary<string, string>());
+        var receipt = new WorkflowRunControlAcceptedReceiptFactory().Create(target, context);
+        var envelope = new WorkflowResumeCommandEnvelopeFactory().CreateEnvelope(command, context);
+        var resumed = envelope.Payload.Unpack<WorkflowResumedEvent>();
+
+        target.ActorId.Should().Be(actorId);
+        target.TargetId.Should().Be(actorId);
+        target.RunId.Should().Be(runId);
+
+        receipt.ActorId.Should().Be(actorId);
+        receipt.RunId.Should().Be(runId);
+        receipt.CommandId.Should().Be(commandId);
+        receipt.CorrelationId.Should().Be(correlationId);
+
+        envelope.Id.Should().Be(commandId);
+        envelope.Route!.GetTargetActorId().Should().Be(actorId);
+        envelope.Propagation!.CorrelationId.Should().Be(correlationId);
+        resumed.RunId.Should().Be(runId);
+    }
+
+    private sealed class BindingReader(WorkflowActorBinding binding) : IWorkflowActorBindingReader
+    {
+        public Task<WorkflowActorBinding?> GetAsync(string actorId, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            actorId.Should().Be(binding.ActorId);
+            return Task.FromResult<WorkflowActorBinding?>(binding);
+        }
+    }
+}


### PR DESCRIPTION
## 摘要

#1354 first slice: docs/canon/llm-streaming.md §7.1 identity table 更新 + 1 个 WorkflowRunControlCommand identity 分离测试。

Phase 9 r3 consensus(3/3 unanimous after reflector retry-fix narrowing):
- minimal / structural / delete 三方一致于 `update §7.1 identity table + 1 identity separation behavior test, no new abstraction`
- reflector r2 ruling: canon §7.1 mechanical text patch + 1 behavior test 是 mechanical clarification of already-decided identity semantics,不触发 hardcoded trigger #3

## 范围

- 2 files changed (+77/-3)
- `docs/canon/llm-streaming.md` (§7.1 identity table clarification)
- `test/Aevatar.Workflow.Application.Tests/WorkflowRunControlIdentitySeparationTests.cs` (new, 1 behavior test)

## Stacked-PR

iter290 #1354 first slice。Base = `auto-refact-dev`。Rollup target = `dev`。

closes #1354

⟦AI:AUTO-LOOP⟧
