### PR TITLE
[refactor] #1363 first slice (#1335 split): 删除零调用 ChatRunToolCompletionResult + IChatRunToolCompletionSink

### DIFF
--- a/src/platform/Aevatar.GAgentService.Abstractions/Responses/ChatRunActorPorts.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Responses/ChatRunActorPorts.cs
@@ -38,13 +38,7 @@ public interface IChatRunToolCompletionControlExecutor
         CancellationToken ct = default);
 }
 
-public sealed record ChatRunToolCompletionResult(
-    string ActorId,
-    string RunId,
-    string ToolCallId,
-    string ToolName,
-    string ResultJson);
-
+// Refactor (issue1363): Removed unused symbols. Original cluster #1335 split into first-slice delete + later-slice design-pending.
 public interface IChatRunActorPort
 {
     Task<string> StartAsync(ChatRunStartRequest request, CancellationToken ct = default);
@@ -67,12 +61,5 @@ public interface IChatRunActorPort
     Task TerminateAsync(
         string chatRunActorId,
         string reason,
-        CancellationToken ct = default);
-}
-
-public interface IChatRunToolCompletionSink
-{
-    ValueTask OnToolResultReadyAsync(
-        ChatRunToolResultReady ready,
         CancellationToken ct = default);
 }


### PR DESCRIPTION
## 摘要

#1363 first slice (#1335 split): 删除零调用 ChatRunToolCompletionResult + IChatRunToolCompletionSink。

Phase 9 r2 unanimous (3/3) — minimal/structural/delete all proposed:
- first-slice = remove-two-zero-call-declarations-no-new-abstraction

无 replacement value object / sink / port / proto field / migration layer。无 new abstraction。

## 范围

- 1 file changed (+1/-14)
- `src/platform/Aevatar.GAgentService.Abstractions/Responses/ChatRunActorPorts.cs`

## Stacked-PR

iter290 #1335 split first-slice。Base = `auto-refact-dev`。Rollup target = `dev`。

closes #1363

⟦AI:AUTO-LOOP⟧
