### PR TITLE
[refactor] #1374 first slice (#415 split): 提取 ILarkOutboundDispatcher narrow scope

### DIFF
--- a/agents/Aevatar.GAgents.Authoring.Lark/FeishuCardHumanInteractionPort.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/FeishuCardHumanInteractionPort.cs
@@ -20,6 +20,7 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
 {
     private readonly IUserAgentDeliveryTargetReader _deliveryTargetReader;
     private readonly NyxIdApiClient _nyxIdApiClient;
+    private readonly ILarkOutboundDispatcher? _larkOutboundDispatcher;
     private readonly LarkMessageComposer _composer;
     private readonly ILogger<FeishuCardHumanInteractionPort> _logger;
 
@@ -27,10 +28,12 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
         IUserAgentDeliveryTargetReader deliveryTargetReader,
         NyxIdApiClient nyxIdApiClient,
         LarkMessageComposer composer,
-        ILogger<FeishuCardHumanInteractionPort> logger)
+        ILogger<FeishuCardHumanInteractionPort> logger,
+        ILarkOutboundDispatcher? larkOutboundDispatcher = null)
     {
         _deliveryTargetReader = deliveryTargetReader ?? throw new ArgumentNullException(nameof(deliveryTargetReader));
         _nyxIdApiClient = nyxIdApiClient ?? throw new ArgumentNullException(nameof(nyxIdApiClient));
+        _larkOutboundDispatcher = larkOutboundDispatcher;
         _composer = composer ?? throw new ArgumentNullException(nameof(composer));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -335,19 +338,11 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
         }
     }
 
-    private readonly record struct SendOutcome(bool Succeeded, int? LarkCode, string Detail)
-    {
-        public static SendOutcome Success() => new(true, null, string.Empty);
-        public static SendOutcome Failed(int? larkCode, string detail) => new(false, larkCode, detail);
-    }
-
     /// <summary>
-    /// Mirrors <c>SkillRunnerGAgent.TrySendWithFallbackAsync</c>: tries the typed primary
-    /// delivery target, then on a Lark <c>230002 bot not in chat</c> rejection retries once
-    /// with the fallback target persisted on <see cref="UserAgentCatalogEntry.LarkReceiveIdFallback"/>.
-    /// Returns success vs. failure (with Lark code+detail) so the caller can throw cleanly.
+    /// Sends via the shared Lark new-message dispatcher so proactive human-interaction cards
+    /// keep the same primary, fallback, and parser semantics as SkillRunner output.
     /// </summary>
-    private async Task<SendOutcome> TrySendWithFallbackAsync(
+    private async Task<LarkSendNewMessageResult> TrySendWithFallbackAsync(
         UserAgentDeliveryTarget target,
         string messageType,
         string contentJson,
@@ -355,57 +350,33 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
         string emptyResponseMessage,
         CancellationToken cancellationToken)
     {
-        var primaryResult = await SendOutboundAsync(target, messageType, contentJson, primary, cancellationToken);
-        if (string.IsNullOrWhiteSpace(primaryResult))
+        var result = await ResolveLarkOutboundDispatcher().SendNewMessageAsync(
+            new LarkSendNewMessageRequest(
+                target.NyxApiKey,
+                target.NyxProviderSlug,
+                messageType,
+                contentJson,
+                primary,
+                ResolveFallbackTarget(target)),
+            cancellationToken);
+
+        if (!result.Succeeded && string.IsNullOrWhiteSpace(result.Detail))
             throw new InvalidOperationException(emptyResponseMessage);
-        if (!LarkProxyResponse.TryGetError(primaryResult, out var larkCode, out var detail))
-            return SendOutcome.Success();
 
-        if (larkCode != LarkBotErrorCodes.BotNotInChat)
-            return SendOutcome.Failed(larkCode, detail);
+        return result;
+    }
 
+    private static LarkReceiveTarget? ResolveFallbackTarget(UserAgentDeliveryTarget target)
+    {
         var fallbackId = target.LarkReceiveIdFallback?.Trim();
         var fallbackType = target.LarkReceiveIdTypeFallback?.Trim();
-        if (string.IsNullOrEmpty(fallbackId) || string.IsNullOrEmpty(fallbackType))
-            return SendOutcome.Failed(larkCode, detail);
-
-        _logger.LogInformation(
-            "Feishu human interaction port primary delivery target rejected as `bot not in chat` (code 230002); retrying with fallback typed pair: agent={AgentId}, fallbackType={FallbackType}",
-            target.AgentId,
-            fallbackType);
-
-        var fallbackTarget = new LarkReceiveTarget(fallbackId, fallbackType, FellBackToPrefixInference: false);
-        var fallbackResult = await SendOutboundAsync(target, messageType, contentJson, fallbackTarget, cancellationToken);
-        if (string.IsNullOrWhiteSpace(fallbackResult))
-            throw new InvalidOperationException(emptyResponseMessage);
-        if (!LarkProxyResponse.TryGetError(fallbackResult, out var fallbackCode, out var fallbackDetail))
-            return SendOutcome.Success();
-        return SendOutcome.Failed(fallbackCode, fallbackDetail);
+        return string.IsNullOrEmpty(fallbackId) || string.IsNullOrEmpty(fallbackType)
+            ? null
+            : new LarkReceiveTarget(fallbackId, fallbackType, FellBackToPrefixInference: false);
     }
 
-    private async Task<string> SendOutboundAsync(
-        UserAgentDeliveryTarget target,
-        string messageType,
-        string contentJson,
-        LarkReceiveTarget receiveTarget,
-        CancellationToken cancellationToken)
-    {
-        var body = JsonSerializer.Serialize(new
-        {
-            receive_id = receiveTarget.ReceiveId,
-            msg_type = messageType,
-            content = contentJson,
-        });
-
-        return await _nyxIdApiClient.ProxyRequestAsync(
-            target.NyxApiKey,
-            target.NyxProviderSlug,
-            $"open-apis/im/v1/messages?receive_id_type={receiveTarget.ReceiveIdType}",
-            "POST",
-            body,
-            extraHeaders: null,
-            cancellationToken);
-    }
+    private ILarkOutboundDispatcher ResolveLarkOutboundDispatcher() =>
+        _larkOutboundDispatcher ?? new LarkOutboundDispatcher(_nyxIdApiClient, _logger);
 
     private static string BuildLarkRejectionMessage(string failurePrefix, int? larkCode, string detail)
     {

--- a/agents/Aevatar.GAgents.Scheduled/ILarkOutboundDispatcher.cs
+++ b/agents/Aevatar.GAgents.Scheduled/ILarkOutboundDispatcher.cs
@@ -1,0 +1,52 @@
+using Aevatar.GAgents.Platform.Lark;
+
+namespace Aevatar.GAgents.Scheduled;
+
+public interface ILarkOutboundDispatcher
+{
+    Task<LarkSendNewMessageResult> SendNewMessageAsync(
+        LarkSendNewMessageRequest request,
+        CancellationToken ct);
+}
+
+public sealed record LarkSendNewMessageRequest(
+    string NyxApiKey,
+    string NyxProviderSlug,
+    string MessageType,
+    string ContentJson,
+    LarkReceiveTarget PrimaryTarget,
+    LarkReceiveTarget? FallbackTarget = null);
+
+public sealed record LarkSendNewMessageResult(
+    bool Succeeded,
+    string? MessageId,
+    LarkReceiveTarget AttemptedTarget,
+    bool UsedFallback,
+    int? LarkCode,
+    string Detail)
+{
+    public static LarkSendNewMessageResult Sent(
+        string messageId,
+        LarkReceiveTarget attemptedTarget,
+        bool usedFallback) =>
+        new(
+            Succeeded: true,
+            MessageId: messageId,
+            AttemptedTarget: attemptedTarget,
+            UsedFallback: usedFallback,
+            LarkCode: null,
+            Detail: string.Empty);
+
+    public static LarkSendNewMessageResult Failed(
+        LarkReceiveTarget attemptedTarget,
+        bool usedFallback,
+        int? larkCode,
+        string detail) =>
+        new(
+            Succeeded: false,
+            MessageId: null,
+            AttemptedTarget: attemptedTarget,
+            UsedFallback: usedFallback,
+            LarkCode: larkCode,
+            Detail: detail);
+}

--- a/agents/Aevatar.GAgents.Scheduled/ILarkOutboundDispatcher.cs
+++ b/agents/Aevatar.GAgents.Scheduled/ILarkOutboundDispatcher.cs
@@ -2,6 +2,18 @@ using Aevatar.GAgents.Platform.Lark;
 
 namespace Aevatar.GAgents.Scheduled;
 
+/// <summary>
+/// Narrow boundary for posting new outbound Lark messages from actor-owned execution paths.
+/// </summary>
+/// <remarks>
+/// Refactor (iter166/cluster-415-lark-outbound-dispatcher):
+///   Old pattern: SkillRunnerGAgent, SkillRunnerStreamingReplySink, and FeishuCardHumanInteractionPort each owned their own Lark POST parser/fallback branch.
+///   New principle: one dispatcher owns new-message POST, primary/fallback retry, and response parsing while callers keep only target/content mapping.
+///
+/// This interface is intentionally narrow even with one production implementation: actor and
+/// human-interaction callers depend on the send contract, while tests can substitute transport
+/// outcomes without reaching into NyxID proxy HTTP details.
+/// </remarks>
 public interface ILarkOutboundDispatcher
 {
     Task<LarkSendNewMessageResult> SendNewMessageAsync(

--- a/agents/Aevatar.GAgents.Scheduled/LarkOutboundDispatcher.cs
+++ b/agents/Aevatar.GAgents.Scheduled/LarkOutboundDispatcher.cs
@@ -6,6 +6,14 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aevatar.GAgents.Scheduled;
 
+/// <summary>
+/// Sends new Lark messages through the NyxID proxy and returns typed delivery outcomes.
+/// </summary>
+/// <remarks>
+/// Refactor (iter166/cluster-415-lark-outbound-dispatcher):
+///   Old pattern: three callers duplicated Lark POST body construction, bot-not-in-chat fallback retry, and message_id parsing.
+///   New principle: this dispatcher centralizes new-message delivery so callers map business state into a request and handle the typed result.
+/// </remarks>
 public sealed class LarkOutboundDispatcher : ILarkOutboundDispatcher
 {
     private readonly NyxIdApiClient _client;

--- a/agents/Aevatar.GAgents.Scheduled/LarkOutboundDispatcher.cs
+++ b/agents/Aevatar.GAgents.Scheduled/LarkOutboundDispatcher.cs
@@ -1,0 +1,129 @@
+using System.Text.Json;
+using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.GAgents.Platform.Lark;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.GAgents.Scheduled;
+
+public sealed class LarkOutboundDispatcher : ILarkOutboundDispatcher
+{
+    private readonly NyxIdApiClient _client;
+    private readonly ILogger _logger;
+
+    public LarkOutboundDispatcher(
+        NyxIdApiClient client,
+        ILogger? logger = null)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _logger = logger ?? NullLogger.Instance;
+    }
+
+    public async Task<LarkSendNewMessageResult> SendNewMessageAsync(
+        LarkSendNewMessageRequest request,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        Validate(request);
+
+        var primaryResult = await SendPostAsync(
+            request,
+            request.PrimaryTarget,
+            usedFallback: false,
+            ct).ConfigureAwait(false);
+        if (primaryResult.Succeeded)
+            return primaryResult;
+
+        if (primaryResult.LarkCode != LarkBotErrorCodes.BotNotInChat ||
+            request.FallbackTarget is not { } fallbackTarget)
+        {
+            return primaryResult;
+        }
+
+        _logger.LogInformation(
+            "Lark outbound primary target rejected as `bot not in chat` (230002); retrying once with fallback receive_id_type={FallbackType}",
+            fallbackTarget.ReceiveIdType);
+
+        return await SendPostAsync(
+            request,
+            fallbackTarget,
+            usedFallback: true,
+            ct).ConfigureAwait(false);
+    }
+
+    private async Task<LarkSendNewMessageResult> SendPostAsync(
+        LarkSendNewMessageRequest request,
+        LarkReceiveTarget target,
+        bool usedFallback,
+        CancellationToken ct)
+    {
+        var body = JsonSerializer.Serialize(new
+        {
+            receive_id = target.ReceiveId,
+            msg_type = request.MessageType,
+            content = request.ContentJson,
+        });
+
+        var response = await _client.ProxyRequestAsync(
+            request.NyxApiKey,
+            request.NyxProviderSlug,
+            $"open-apis/im/v1/messages?receive_id_type={Uri.EscapeDataString(target.ReceiveIdType)}",
+            "POST",
+            body,
+            extraHeaders: null,
+            ct).ConfigureAwait(false);
+
+        return ParseSendResponse(response, target, usedFallback);
+    }
+
+    private static LarkSendNewMessageResult ParseSendResponse(
+        string? response,
+        LarkReceiveTarget target,
+        bool usedFallback)
+    {
+        if (LarkProxyResponse.TryGetError(response, out var larkCode, out var detail))
+            return LarkSendNewMessageResult.Failed(target, usedFallback, larkCode, detail);
+
+        if (string.IsNullOrWhiteSpace(response))
+            return LarkSendNewMessageResult.Failed(target, usedFallback, null, "empty_send_response");
+
+        try
+        {
+            using var document = JsonDocument.Parse(response);
+            var root = document.RootElement;
+            if (!root.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Object)
+                return LarkSendNewMessageResult.Failed(target, usedFallback, null, "missing_data");
+            if (!data.TryGetProperty("message_id", out var idProperty) ||
+                idProperty.ValueKind != JsonValueKind.String)
+            {
+                return LarkSendNewMessageResult.Failed(target, usedFallback, null, "missing_message_id");
+            }
+
+            var messageId = idProperty.GetString();
+            if (string.IsNullOrWhiteSpace(messageId))
+                return LarkSendNewMessageResult.Failed(target, usedFallback, null, "empty_message_id");
+
+            return LarkSendNewMessageResult.Sent(messageId, target, usedFallback);
+        }
+        catch (JsonException)
+        {
+            return LarkSendNewMessageResult.Failed(target, usedFallback, null, "invalid_send_response_json");
+        }
+    }
+
+    private static void Validate(LarkSendNewMessageRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.NyxApiKey))
+            throw new ArgumentException("NyxID API key is required.", nameof(request));
+        if (string.IsNullOrWhiteSpace(request.NyxProviderSlug))
+            throw new ArgumentException("NyxID provider slug is required.", nameof(request));
+        if (string.IsNullOrWhiteSpace(request.MessageType))
+            throw new ArgumentException("Lark message type is required.", nameof(request));
+        if (string.IsNullOrWhiteSpace(request.ContentJson))
+            throw new ArgumentException("Lark message content JSON is required.", nameof(request));
+        if (string.IsNullOrWhiteSpace(request.PrimaryTarget.ReceiveId))
+            throw new ArgumentException("Lark primary receive_id is required.", nameof(request));
+        if (string.IsNullOrWhiteSpace(request.PrimaryTarget.ReceiveIdType))
+            throw new ArgumentException("Lark primary receive_id_type is required.", nameof(request));
+    }
+}

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
@@ -26,6 +26,7 @@ namespace Aevatar.GAgents.Scheduled;
 public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
 {
     private readonly NyxIdApiClient? _nyxIdApiClient;
+    private readonly ILarkOutboundDispatcher? _larkOutboundDispatcher;
     private readonly IOwnerLlmConfigSource? _ownerLlmConfigSource;
     private readonly IClock _clock;
     private readonly ITimeZoneResolver _timeZoneResolver;
@@ -48,7 +49,8 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         IOwnerLlmConfigSource? ownerLlmConfigSource = null,
         IToolApprovalHandler? approvalHandler = null,
         IClock? clock = null,
-        ITimeZoneResolver? timeZoneResolver = null)
+        ITimeZoneResolver? timeZoneResolver = null,
+        ILarkOutboundDispatcher? larkOutboundDispatcher = null)
         : this(
             BuildToolMiddlewareChain(toolMiddlewares),
             llmProviderFactory,
@@ -60,7 +62,8 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             ownerLlmConfigSource,
             approvalHandler,
             clock,
-            timeZoneResolver)
+            timeZoneResolver,
+            larkOutboundDispatcher)
     {
     }
 
@@ -75,7 +78,8 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         IOwnerLlmConfigSource? ownerLlmConfigSource,
         IToolApprovalHandler? approvalHandler,
         IClock? clock,
-        ITimeZoneResolver? timeZoneResolver)
+        ITimeZoneResolver? timeZoneResolver,
+        ILarkOutboundDispatcher? larkOutboundDispatcher)
         : base(
             llmProviderFactory,
             additionalHooks,
@@ -86,6 +90,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             approvalHandler)
     {
         _nyxIdApiClient = nyxIdApiClient;
+        _larkOutboundDispatcher = larkOutboundDispatcher;
         _ownerLlmConfigSource = ownerLlmConfigSource;
         _clock = clock ?? new SystemClock();
         _timeZoneResolver = timeZoneResolver ?? new TimeZoneResolver();
@@ -480,20 +485,18 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             State.OutboundConfig.LarkReceiveIdType,
             State.OutboundConfig.ConversationId);
 
-        var fallbackId = State.OutboundConfig.LarkReceiveIdFallback?.Trim();
-        var fallbackType = State.OutboundConfig.LarkReceiveIdTypeFallback?.Trim();
-        LarkReceiveTarget? fallback = null;
-        if (!string.IsNullOrEmpty(fallbackId) && !string.IsNullOrEmpty(fallbackType))
-            fallback = new LarkReceiveTarget(fallbackId, fallbackType, FellBackToPrefixInference: false);
-
         return new SkillRunnerStreamingReplySink(
-            client,
-            State.OutboundConfig.NyxApiKey,
-            State.OutboundConfig.NyxProviderSlug,
-            primary,
-            fallback,
+            ResolveLarkOutboundDispatcher(client),
+            new LarkSendNewMessageRequest(
+                State.OutboundConfig.NyxApiKey,
+                State.OutboundConfig.NyxProviderSlug,
+                MessageType: "text",
+                ContentJson: string.Empty,
+                PrimaryTarget: primary,
+                FallbackTarget: ResolveFallbackTarget()),
             BuildLarkRejectionMessage,
-            Logger);
+            Logger,
+            client);
     }
 
     /// <summary>
@@ -670,7 +673,15 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
                 deliveryTarget.ReceiveIdType);
         }
 
-        var outcome = await TrySendWithFallbackAsync(client, output, slug, deliveryTarget, ct);
+        var outcome = await ResolveLarkOutboundDispatcher(client).SendNewMessageAsync(
+            new LarkSendNewMessageRequest(
+                State.OutboundConfig.NyxApiKey,
+                slug,
+                MessageType: "text",
+                ContentJson: JsonSerializer.Serialize(new { text = output }),
+                PrimaryTarget: deliveryTarget,
+                FallbackTarget: ResolveFallbackTarget()),
+            ct);
 
         if (!outcome.Succeeded)
         {
@@ -685,76 +696,17 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         }
     }
 
-    private readonly record struct SendOutcome(bool Succeeded, int? LarkCode, string Detail)
+    private LarkReceiveTarget? ResolveFallbackTarget()
     {
-        public static SendOutcome Success() => new(true, null, string.Empty);
-        public static SendOutcome Failed(int? larkCode, string detail) => new(false, larkCode, detail);
-    }
-
-    /// <summary>
-    /// Sends the outbound text via the typed primary delivery target, then on a Lark
-    /// <c>230002 bot not in chat</c> rejection retries once with the fallback target if one
-    /// was captured at agent-create time. The fallback covers cross-app same-tenant
-    /// deployments where the outbound app is not a member of the inbound DM chat — without
-    /// it, the chat_id-first priority would regress those deployments. Returns success vs.
-    /// failure (with Lark code+detail) so the caller can throw cleanly without re-parsing
-    /// the response.
-    /// </summary>
-    private async Task<SendOutcome> TrySendWithFallbackAsync(
-        NyxIdApiClient client,
-        string output,
-        string slug,
-        LarkReceiveTarget primary,
-        CancellationToken ct)
-    {
-        var primaryResponse = await SendOutboundAsync(client, output, slug, primary, ct);
-        if (!LarkProxyResponse.TryGetError(primaryResponse, out var larkCode, out var detail))
-            return SendOutcome.Success();
-
-        // Only Lark `bot not in chat` triggers the fallback. Nyx envelope errors (no Lark
-        // code) and other Lark business errors propagate directly so the user sees actionable
-        // recovery guidance for the actual failure mode.
-        if (larkCode != LarkBotErrorCodes.BotNotInChat)
-            return SendOutcome.Failed(larkCode, detail);
-
         var fallbackId = State.OutboundConfig.LarkReceiveIdFallback?.Trim();
         var fallbackType = State.OutboundConfig.LarkReceiveIdTypeFallback?.Trim();
-        if (string.IsNullOrEmpty(fallbackId) || string.IsNullOrEmpty(fallbackType))
-            return SendOutcome.Failed(larkCode, detail);
-
-        Logger.LogInformation(
-            "Skill runner {ActorId} primary delivery target rejected as `bot not in chat` (code 230002); retrying with fallback typed pair (receive_id_type={FallbackType})",
-            Id,
-            fallbackType);
-
-        var fallbackTarget = new LarkReceiveTarget(fallbackId, fallbackType, FellBackToPrefixInference: false);
-        var fallbackResponse = await SendOutboundAsync(client, output, slug, fallbackTarget, ct);
-        if (!LarkProxyResponse.TryGetError(fallbackResponse, out var fallbackCode, out var fallbackDetail))
-            return SendOutcome.Success();
-
-        return SendOutcome.Failed(fallbackCode, fallbackDetail);
+        return string.IsNullOrEmpty(fallbackId) || string.IsNullOrEmpty(fallbackType)
+            ? null
+            : new LarkReceiveTarget(fallbackId, fallbackType, FellBackToPrefixInference: false);
     }
 
-    private async Task<string> SendOutboundAsync(
-        NyxIdApiClient client,
-        string output,
-        string slug,
-        LarkReceiveTarget target,
-        CancellationToken ct)
-    {
-        var body = JsonSerializer.Serialize(new
-        {
-            receive_id = target.ReceiveId,
-            msg_type = "text",
-            content = JsonSerializer.Serialize(new { text = output }),
-        });
-
-        return await client.ProxyRequestAsync(
-            State.OutboundConfig.NyxApiKey,
-            slug,
-            $"open-apis/im/v1/messages?receive_id_type={target.ReceiveIdType}",
-            "POST", body, null, ct);
-    }
+    private ILarkOutboundDispatcher ResolveLarkOutboundDispatcher(NyxIdApiClient client) =>
+        _larkOutboundDispatcher ?? Services.GetService<ILarkOutboundDispatcher>() ?? new LarkOutboundDispatcher(client, Logger);
 
     private static string BuildLarkRejectionMessage(int? larkCode, string detail)
     {

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerStreamingReplySink.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerStreamingReplySink.cs
@@ -28,39 +28,29 @@ internal sealed class SkillRunnerStreamingReplySink : IDisposable
 
     private const string TruncationMarker = "\n\n…[truncated]";
 
-    private readonly NyxIdApiClient _client;
-    // Proxy-scoped agent API key. Treat as a secret: NEVER include it in log messages,
-    // exception messages, or anything that flows to the user.
-    private readonly string _nyxApiKey;
-    private readonly string _nyxProviderSlug;
-    private readonly LarkReceiveTarget _primaryTarget;
-    private readonly LarkReceiveTarget? _fallbackTarget;
+    private readonly ILarkOutboundDispatcher _outboundDispatcher;
+    private readonly LarkSendNewMessageRequest _initialMessageTemplate;
+    private readonly NyxIdApiClient _editClient;
     private readonly Func<int?, string, string> _rejectionMessageBuilder;
     private readonly ILogger? _logger;
     private string? _platformMessageId;
     private bool _disposed;
 
     public SkillRunnerStreamingReplySink(
-        NyxIdApiClient client,
-        string nyxApiKey,
-        string nyxProviderSlug,
-        LarkReceiveTarget primaryTarget,
-        LarkReceiveTarget? fallbackTarget,
+        ILarkOutboundDispatcher outboundDispatcher,
+        LarkSendNewMessageRequest initialMessageTemplate,
         Func<int?, string, string> rejectionMessageBuilder,
-        ILogger? logger = null)
+        ILogger? logger,
+        NyxIdApiClient editClient)
     {
-        ArgumentNullException.ThrowIfNull(client);
+        ArgumentNullException.ThrowIfNull(outboundDispatcher);
+        ArgumentNullException.ThrowIfNull(initialMessageTemplate);
         ArgumentNullException.ThrowIfNull(rejectionMessageBuilder);
-        if (string.IsNullOrWhiteSpace(nyxApiKey))
-            throw new ArgumentException("NyxID API key is required.", nameof(nyxApiKey));
-        if (string.IsNullOrWhiteSpace(nyxProviderSlug))
-            throw new ArgumentException("NyxID provider slug is required.", nameof(nyxProviderSlug));
+        ArgumentNullException.ThrowIfNull(editClient);
 
-        _client = client;
-        _nyxApiKey = nyxApiKey;
-        _nyxProviderSlug = nyxProviderSlug;
-        _primaryTarget = primaryTarget;
-        _fallbackTarget = fallbackTarget;
+        _outboundDispatcher = outboundDispatcher;
+        _initialMessageTemplate = initialMessageTemplate;
+        _editClient = editClient;
         _rejectionMessageBuilder = rejectionMessageBuilder;
         _logger = logger;
     }
@@ -88,7 +78,7 @@ internal sealed class SkillRunnerStreamingReplySink : IDisposable
 
         if (_platformMessageId is null)
         {
-            (string? messageId, int? larkCode, string detail) result;
+            LarkSendNewMessageResult result;
             try
             {
                 result = await SendInitialAsync(capped, ct).ConfigureAwait(false);
@@ -98,25 +88,25 @@ internal sealed class SkillRunnerStreamingReplySink : IDisposable
                 _logger?.LogWarning(
                     ex,
                     "SkillRunner streaming sink: initial Lark POST threw mid-stream; will retry on next actor-approved snapshot. slug={Slug}",
-                    _nyxProviderSlug);
+                    _initialMessageTemplate.NyxProviderSlug);
                 return;
             }
 
-            if (result.messageId is not null)
+            if (result.MessageId is not null)
             {
-                _platformMessageId = result.messageId;
+                _platformMessageId = result.MessageId;
                 ChunksEmitted++;
                 return;
             }
 
             if (isFinal)
-                throw new InvalidOperationException(_rejectionMessageBuilder(result.larkCode, result.detail));
+                throw new InvalidOperationException(_rejectionMessageBuilder(result.LarkCode, result.Detail));
 
             _logger?.LogWarning(
                 "SkillRunner streaming sink: initial Lark POST rejected mid-stream (lark_code={LarkCode}, detail={Detail}); next actor-approved snapshot will retry. slug={Slug}",
-                result.larkCode,
-                result.detail,
-                _nyxProviderSlug);
+                result.LarkCode,
+                result.Detail,
+                _initialMessageTemplate.NyxProviderSlug);
             return;
         }
 
@@ -130,7 +120,7 @@ internal sealed class SkillRunnerStreamingReplySink : IDisposable
             _logger?.LogWarning(
                 ex,
                 "SkillRunner streaming sink: Lark edit threw mid-stream; will retry on next actor-approved snapshot. slug={Slug}",
-                _nyxProviderSlug);
+                _initialMessageTemplate.NyxProviderSlug);
             return;
         }
 
@@ -151,51 +141,16 @@ internal sealed class SkillRunnerStreamingReplySink : IDisposable
             "SkillRunner streaming sink: Lark edit rejected mid-stream (lark_code={LarkCode}, detail={Detail}); next actor-approved snapshot will retry. slug={Slug}",
             edit.larkCode,
             edit.detail,
-            _nyxProviderSlug);
+            _initialMessageTemplate.NyxProviderSlug);
     }
 
-    /// <summary>
-    /// First-attempt POST to <c>open-apis/im/v1/messages</c>. On a Lark <c>230002 bot not in
-    /// chat</c> rejection retries once with the captured fallback target — same recovery
-    /// behavior as <c>SkillRunnerGAgent.TrySendWithFallbackAsync</c>, kept in this sink so a
-    /// streaming-edit run never regresses cross-app same-tenant deployments.
-    /// </summary>
-    private async Task<(string? MessageId, int? LarkCode, string Detail)> SendInitialAsync(string text, CancellationToken ct)
-    {
-        var primaryResponse = await SendPostAsync(_primaryTarget, text, ct).ConfigureAwait(false);
-        var primaryParsed = TryParseSendResponse(primaryResponse);
-        if (primaryParsed.MessageId is not null)
-            return primaryParsed;
-
-        if (primaryParsed.LarkCode != LarkBotErrorCodes.BotNotInChat || _fallbackTarget is null)
-            return primaryParsed;
-
-        _logger?.LogInformation(
-            "SkillRunner streaming sink: primary Lark POST rejected as `bot not in chat` (230002); retrying once with fallback receive_id_type={FallbackType}",
-            _fallbackTarget.Value.ReceiveIdType);
-
-        var fallbackResponse = await SendPostAsync(_fallbackTarget.Value, text, ct).ConfigureAwait(false);
-        return TryParseSendResponse(fallbackResponse);
-    }
-
-    private async Task<string> SendPostAsync(LarkReceiveTarget target, string text, CancellationToken ct)
-    {
-        var body = JsonSerializer.Serialize(new
-        {
-            receive_id = target.ReceiveId,
-            msg_type = "text",
-            content = JsonSerializer.Serialize(new { text }),
-        });
-
-        return await _client.ProxyRequestAsync(
-            _nyxApiKey,
-            _nyxProviderSlug,
-            $"open-apis/im/v1/messages?receive_id_type={target.ReceiveIdType}",
-            "POST",
-            body,
-            null,
+    private async Task<LarkSendNewMessageResult> SendInitialAsync(string text, CancellationToken ct) =>
+        await _outboundDispatcher.SendNewMessageAsync(
+            _initialMessageTemplate with
+            {
+                ContentJson = JsonSerializer.Serialize(new { text }),
+            },
             ct).ConfigureAwait(false);
-    }
 
     private async Task<(bool Succeeded, int? LarkCode, string Detail)> EditAsync(string platformMessageId, string text, CancellationToken ct)
     {
@@ -208,9 +163,9 @@ internal sealed class SkillRunnerStreamingReplySink : IDisposable
             content = JsonSerializer.Serialize(new { text }),
         });
 
-        var response = await _client.ProxyRequestAsync(
-            _nyxApiKey,
-            _nyxProviderSlug,
+        var response = await _editClient.ProxyRequestAsync(
+            _initialMessageTemplate.NyxApiKey,
+            _initialMessageTemplate.NyxProviderSlug,
             $"open-apis/im/v1/messages/{Uri.EscapeDataString(platformMessageId)}",
             "PUT",
             body,
@@ -221,30 +176,6 @@ internal sealed class SkillRunnerStreamingReplySink : IDisposable
             return (false, larkCode, detail);
 
         return (true, null, string.Empty);
-    }
-
-    private static (string? MessageId, int? LarkCode, string Detail) TryParseSendResponse(string response)
-    {
-        if (LarkProxyResponse.TryGetError(response, out var larkCode, out var detail))
-            return (null, larkCode, detail);
-
-        try
-        {
-            using var document = JsonDocument.Parse(response);
-            var root = document.RootElement;
-            if (!root.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Object)
-                return (null, null, "missing_data");
-            if (!data.TryGetProperty("message_id", out var idProp) || idProp.ValueKind != JsonValueKind.String)
-                return (null, null, "missing_message_id");
-            var id = idProp.GetString();
-            if (string.IsNullOrWhiteSpace(id))
-                return (null, null, "empty_message_id");
-            return (id, null, string.Empty);
-        }
-        catch (JsonException)
-        {
-            return (null, null, "invalid_send_response_json");
-        }
     }
 
     /// <summary>

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkOutboundDispatcherTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkOutboundDispatcherTests.cs
@@ -1,0 +1,156 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.GAgents.Platform.Lark;
+using Aevatar.GAgents.Scheduled;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+public sealed class LarkOutboundDispatcherTests
+{
+    private const string OkResponse = """{"code":0,"msg":"success","data":{"message_id":"om_1"}}""";
+
+    [Fact]
+    public async Task SendNewMessageAsync_PrimarySuccess_PostsExpectedBody()
+    {
+        var handler = new SequencedHandler(OkResponse);
+        var dispatcher = CreateDispatcher(handler);
+
+        var result = await dispatcher.SendNewMessageAsync(CreateRequest(), CancellationToken.None);
+
+        result.Succeeded.Should().BeTrue(result.Detail);
+        result.MessageId.Should().Be("om_1");
+        result.UsedFallback.Should().BeFalse();
+        handler.Requests.Should().ContainSingle();
+        handler.Requests[0].RequestUri!.AbsolutePath
+            .Should().Be("/api/v1/proxy/s/api-lark-bot/open-apis/im/v1/messages");
+        handler.Requests[0].RequestUri!.Query.Should().Contain("receive_id_type=chat_id");
+
+        using var body = JsonDocument.Parse(handler.Bodies[0]!);
+        body.RootElement.GetProperty("receive_id").GetString().Should().Be("oc_primary");
+        body.RootElement.GetProperty("msg_type").GetString().Should().Be("text");
+        body.RootElement.GetProperty("content").GetString().Should().Be("""{"text":"hello"}""");
+    }
+
+    [Fact]
+    public async Task SendNewMessageAsync_BotNotInChat_RetriesOnceWithFallback()
+    {
+        var handler = new SequencedHandler(
+            (HttpStatusCode.BadRequest, """{"code":230002,"msg":"Bot is not in the chat"}"""),
+            (HttpStatusCode.OK, """{"code":0,"msg":"success","data":{"message_id":"om_fallback"}}"""));
+        var dispatcher = CreateDispatcher(handler);
+
+        var result = await dispatcher.SendNewMessageAsync(
+            CreateRequest(fallback: new LarkReceiveTarget("on_user", "union_id", FellBackToPrefixInference: false)),
+            CancellationToken.None);
+
+        result.Succeeded.Should().BeTrue(result.Detail);
+        result.MessageId.Should().Be("om_fallback");
+        result.UsedFallback.Should().BeTrue();
+        handler.Requests.Should().HaveCount(2);
+        handler.Requests[0].RequestUri!.Query.Should().Contain("receive_id_type=chat_id");
+        handler.Requests[1].RequestUri!.Query.Should().Contain("receive_id_type=union_id");
+
+        using var body = JsonDocument.Parse(handler.Bodies[1]!);
+        body.RootElement.GetProperty("receive_id").GetString().Should().Be("on_user");
+    }
+
+    [Fact]
+    public async Task SendNewMessageAsync_NonRetryLarkError_DoesNotFallback()
+    {
+        var handler = new SequencedHandler("""{"code":99992364,"msg":"user id cross tenant"}""");
+        var dispatcher = CreateDispatcher(handler);
+
+        var result = await dispatcher.SendNewMessageAsync(
+            CreateRequest(fallback: new LarkReceiveTarget("on_user", "union_id", FellBackToPrefixInference: false)),
+            CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.LarkCode.Should().Be(LarkBotErrorCodes.UserIdCrossTenant);
+        result.Detail.Should().Contain("user id cross tenant");
+        handler.Requests.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task SendNewMessageAsync_IncompleteSuccess_ReturnsParserHint()
+    {
+        var handler = new SequencedHandler("""{"code":0,"msg":"success","data":{}}""");
+        var dispatcher = CreateDispatcher(handler);
+
+        var result = await dispatcher.SendNewMessageAsync(CreateRequest(), CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.LarkCode.Should().BeNull();
+        result.Detail.Should().Be("missing_message_id");
+        handler.Requests.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task SendNewMessageAsync_CrossAppError_ReturnsHintCodeWithoutRetry()
+    {
+        var handler = new SequencedHandler(
+            (HttpStatusCode.BadRequest, """{"code":99992361,"msg":"open_id cross app"}"""));
+        var dispatcher = CreateDispatcher(handler);
+
+        var result = await dispatcher.SendNewMessageAsync(
+            CreateRequest(fallback: new LarkReceiveTarget("on_user", "union_id", FellBackToPrefixInference: false)),
+            CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.LarkCode.Should().Be(LarkBotErrorCodes.OpenIdCrossApp);
+        result.Detail.Should().Contain("open_id cross app");
+        handler.Requests.Should().ContainSingle();
+    }
+
+    private static LarkOutboundDispatcher CreateDispatcher(HttpMessageHandler handler)
+    {
+        var client = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler) { BaseAddress = new Uri("https://nyx.example.com") });
+        return new LarkOutboundDispatcher(client, NullLogger<LarkOutboundDispatcher>.Instance);
+    }
+
+    private static LarkSendNewMessageRequest CreateRequest(LarkReceiveTarget? fallback = null) =>
+        new(
+            "nyx-api-key",
+            "api-lark-bot",
+            "text",
+            """{"text":"hello"}""",
+            new LarkReceiveTarget("oc_primary", "chat_id", FellBackToPrefixInference: false),
+            fallback);
+
+    private sealed class SequencedHandler : HttpMessageHandler
+    {
+        private readonly Queue<(HttpStatusCode Status, string Body)> _responses;
+        public List<HttpRequestMessage> Requests { get; } = [];
+        public List<string?> Bodies { get; } = [];
+
+        public SequencedHandler(params string[] responses)
+            : this(responses.Select(static response => (HttpStatusCode.OK, response)).ToArray())
+        {
+        }
+
+        public SequencedHandler(params (HttpStatusCode Status, string Body)[] responses)
+        {
+            _responses = new Queue<(HttpStatusCode, string)>(responses);
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            Bodies.Add(request.Content == null ? null : await request.Content.ReadAsStringAsync(cancellationToken));
+            var (status, body) = _responses.Count > 0
+                ? _responses.Dequeue()
+                : (HttpStatusCode.OK, OkResponse);
+            return new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            };
+        }
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkOutboundDispatcherTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkOutboundDispatcherTests.cs
@@ -88,6 +88,54 @@ public sealed class LarkOutboundDispatcherTests
         handler.Requests.Should().ContainSingle();
     }
 
+    [Theory]
+    [InlineData("", "empty_send_response")]
+    [InlineData("""{"code":0,"msg":"success"}""", "missing_data")]
+    [InlineData("""{"code":0,"msg":"success","data":{"message_id":"   "}}""", "empty_message_id")]
+    [InlineData("""{"code":0,"msg":"success","data":""", "invalid_send_response_json")]
+    public async Task SendNewMessageAsync_InvalidSuccessShape_ReturnsParserHint(
+        string response,
+        string expectedDetail)
+    {
+        var handler = new SequencedHandler(response);
+        var dispatcher = CreateDispatcher(handler);
+
+        var result = await dispatcher.SendNewMessageAsync(CreateRequest(), CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.LarkCode.Should().BeNull();
+        result.Detail.Should().Be(expectedDetail);
+        handler.Requests.Should().ContainSingle();
+    }
+
+    public static TheoryData<LarkSendNewMessageRequest, string> InvalidRequests => new()
+    {
+        { CreateRequest(nyxApiKey: " "), "NyxID API key is required." },
+        { CreateRequest(nyxProviderSlug: " "), "NyxID provider slug is required." },
+        { CreateRequest(messageType: " "), "Lark message type is required." },
+        { CreateRequest(contentJson: " "), "Lark message content JSON is required." },
+        { CreateRequest(primaryTarget: new LarkReceiveTarget(" ", "chat_id", FellBackToPrefixInference: false)), "Lark primary receive_id is required." },
+        { CreateRequest(primaryTarget: new LarkReceiveTarget("oc_primary", " ", FellBackToPrefixInference: false)), "Lark primary receive_id_type is required." },
+    };
+
+    [Theory]
+    [MemberData(nameof(InvalidRequests))]
+    public async Task SendNewMessageAsync_InvalidRequest_ThrowsBeforeHttpDispatch(
+        LarkSendNewMessageRequest request,
+        string expectedMessage)
+    {
+        var handler = new SequencedHandler(OkResponse);
+        var dispatcher = CreateDispatcher(handler);
+
+        var act = () => dispatcher.SendNewMessageAsync(request, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithParameterName("request")
+            .WithMessage(expectedMessage + "*");
+        handler.Requests.Should().BeEmpty();
+        handler.Bodies.Should().BeEmpty();
+    }
+
     [Fact]
     public async Task SendNewMessageAsync_CrossAppError_ReturnsHintCodeWithoutRetry()
     {
@@ -113,13 +161,19 @@ public sealed class LarkOutboundDispatcherTests
         return new LarkOutboundDispatcher(client, NullLogger<LarkOutboundDispatcher>.Instance);
     }
 
-    private static LarkSendNewMessageRequest CreateRequest(LarkReceiveTarget? fallback = null) =>
+    private static LarkSendNewMessageRequest CreateRequest(
+        LarkReceiveTarget? fallback = null,
+        string nyxApiKey = "nyx-api-key",
+        string nyxProviderSlug = "api-lark-bot",
+        string messageType = "text",
+        string contentJson = """{"text":"hello"}""",
+        LarkReceiveTarget? primaryTarget = null) =>
         new(
-            "nyx-api-key",
-            "api-lark-bot",
-            "text",
-            """{"text":"hello"}""",
-            new LarkReceiveTarget("oc_primary", "chat_id", FellBackToPrefixInference: false),
+            nyxApiKey,
+            nyxProviderSlug,
+            messageType,
+            contentJson,
+            primaryTarget ?? new LarkReceiveTarget("oc_primary", "chat_id", FellBackToPrefixInference: false),
             fallback);
 
     private sealed class SequencedHandler : HttpMessageHandler

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -3,21 +3,22 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
-using Aevatar.CQRS.Projection.Runtime.Abstractions;
-using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.CQRS.Projection.Runtime.Abstractions;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
+using Aevatar.GAgents.Platform.Lark;
+using Aevatar.GAgents.Scheduled;
 using FluentAssertions;
 using Google.Protobuf;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
-using Aevatar.GAgents.Scheduled;
-using Aevatar.GAgents.Platform.Lark;
 
 namespace Aevatar.GAgents.ChannelRuntime.Tests;
 
@@ -118,7 +119,7 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         // hallucinated text live before the guard ran, then repost it on each retry.
         // TryCreateStreamingSink must short-circuit so chunked dispatch (which only fires
         // AFTER the guard) is the only path that reaches Lark for fanout-gated runs.
-        AttachNyxIdApiClient(_agent, new RecordingHandler("""{"code":0,"msg":"success"}"""));
+        AttachNyxIdApiClient(_agent, new RecordingHandler("""{"code":0,"msg":"success","data":{"message_id":"om_success"}}"""));
         var command = CreateInitializeCommand();
         command.RequiresNyxidProxySuccess = true;
         await _agent.HandleInitializeAsync(command);
@@ -418,7 +419,7 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         };
         await _agent.HandleInitializeAsync(initialize);
 
-        var handler = new RecordingHandler("""{"code":0,"msg":"success"}""");
+        var handler = new RecordingHandler("""{"code":0,"msg":"success","data":{"message_id":"om_success"}}""");
         AttachNyxIdApiClient(_agent, handler);
 
         await InvokeSendOutputAsync(_agent, "legacy report body");
@@ -542,7 +543,7 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         // 230002. Second (fallback) attempt: clean success.
         var handler = new SequencedHandler(
             """{"error": true, "status": 400, "body": "{\"code\":230002,\"msg\":\"Bot is not in the chat\"}"}""",
-            """{"code":0,"msg":"success"}""");
+            """{"code":0,"msg":"success","data":{"message_id":"om_success"}}""");
         AttachNyxIdApiClient(_agent, handler);
 
         await InvokeSendOutputAsync(_agent, "report");
@@ -609,7 +610,7 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
 
         var handler = new SequencedHandler(
             """{"code":230002,"msg":"Bot is not in the chat"}""",
-            """{"code":0,"msg":"success"}""");
+            """{"code":0,"msg":"success","data":{"message_id":"om_success"}}""");
         AttachNyxIdApiClient(_agent, handler);
 
         await InvokeSendOutputAsync(_agent, "report");
@@ -777,7 +778,7 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         };
         await _agent.HandleInitializeAsync(initialize);
 
-        var handler = new RecordingHandler("""{"code":0,"msg":"success"}""");
+        var handler = new RecordingHandler("""{"code":0,"msg":"success","data":{"message_id":"om_success"}}""");
         AttachNyxIdApiClient(_agent, handler);
 
         await InvokeTrySendFailureAsync(_agent, "primary failed");
@@ -808,7 +809,7 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         };
         await _agent.HandleInitializeAsync(initialize);
 
-        var handler = new RecordingHandler("""{"code":0,"msg":"success"}""");
+        var handler = new RecordingHandler("""{"code":0,"msg":"success","data":{"message_id":"om_success"}}""");
         AttachNyxIdApiClient(_agent, handler);
 
         await InvokeTrySendFailureAsync(_agent, "primary failed");
@@ -942,7 +943,7 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         await agent.HandleInitializeAsync(initialize);
         var handler = new SequencedHandler(
             """{"code":0,"msg":"success","data":{"message_id":"om_stream"}}""",
-            """{"code":0,"msg":"success"}""");
+            """{"code":0,"msg":"success","data":{}}""");
         AttachNyxIdApiClient(agent, handler);
 
         var output = await InvokeExecuteSkillAsync(agent);
@@ -960,7 +961,7 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
     {
         var handler = new SequencedHandler(
             """{"code":0,"msg":"success","data":{"message_id":"om_stream"}}""",
-            """{"code":0,"msg":"success"}""");
+            """{"code":0,"msg":"success","data":{}}""");
         var sink = CreateStreamingSink(handler);
         var time = new FakeTimeProvider(new DateTimeOffset(2026, 5, 19, 9, 0, 0, TimeSpan.Zero));
         var runState = CreateStreamingRunState(sink, TimeSpan.FromMilliseconds(300), time);
@@ -1035,13 +1036,16 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
             new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
             new HttpClient(handler) { BaseAddress = new Uri("https://nyx.example.com") });
         return new SkillRunnerStreamingReplySink(
-            client,
-            "nyx-api-key",
-            "api-lark-bot",
-            new LarkReceiveTarget("oc_chat_1", "chat_id", FellBackToPrefixInference: false),
-            fallbackTarget: null,
+            new LarkOutboundDispatcher(client, NullLogger<LarkOutboundDispatcher>.Instance),
+            new LarkSendNewMessageRequest(
+                "nyx-api-key",
+                "api-lark-bot",
+                MessageType: "text",
+                ContentJson: string.Empty,
+                PrimaryTarget: new LarkReceiveTarget("oc_chat_1", "chat_id", FellBackToPrefixInference: false)),
             (_, detail) => detail,
-            logger: null);
+            logger: null,
+            editClient: client);
     }
 
     private static Task InvokeStreamingRunStateAsync(object runState, string methodName, string text)
@@ -1173,7 +1177,7 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         {
             Requests.Add(request);
             Bodies.Add(request.Content == null ? null : await request.Content.ReadAsStringAsync(cancellationToken));
-            var body = _responses.Count > 0 ? _responses.Dequeue() : """{"code":0,"msg":"success"}""";
+            var body = _responses.Count > 0 ? _responses.Dequeue() : """{"code":0,"msg":"success","data":{"message_id":"om_success"}}""";
             return new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent(body, Encoding.UTF8, "application/json"),

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerStreamingReplySinkTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerStreamingReplySinkTests.cs
@@ -308,13 +308,17 @@ public sealed class SkillRunnerStreamingReplySinkTests
             new HttpClient(handler) { BaseAddress = new Uri("https://nyx.example.com") });
 
         return new SkillRunnerStreamingReplySink(
-            client,
-            nyxApiKey: "nyx-api-key",
-            nyxProviderSlug: "api-lark-bot",
-            primaryTarget: primary,
-            fallbackTarget: fallback,
-            rejectionMessageBuilder: BuildRejectionMessage,
-            logger: NullLogger<SkillRunnerStreamingReplySink>.Instance);
+            new LarkOutboundDispatcher(client, NullLogger<LarkOutboundDispatcher>.Instance),
+            new LarkSendNewMessageRequest(
+                "nyx-api-key",
+                "api-lark-bot",
+                MessageType: "text",
+                ContentJson: string.Empty,
+                PrimaryTarget: primary,
+                FallbackTarget: fallback),
+            BuildRejectionMessage,
+            NullLogger<SkillRunnerStreamingReplySink>.Instance,
+            client);
     }
 
     /// <summary>
@@ -359,7 +363,7 @@ public sealed class SkillRunnerStreamingReplySinkTests
                 : await request.Content.ReadAsStringAsync(cancellationToken));
             var (status, body) = _responses.Count > 0
                 ? _responses.Dequeue()
-                : (HttpStatusCode.OK, """{"code":0,"msg":"success"}""");
+                : (HttpStatusCode.OK, """{"code":0,"msg":"success","data":{"message_id":"om_success"}}""");
             return new HttpResponseMessage(status)
             {
                 Content = new StringContent(body, Encoding.UTF8, "application/json"),


### PR DESCRIPTION
## 摘要

#1374 first-slice (#415 split): 提取 `ILarkOutboundDispatcher.SendNewMessageAsync` (narrow scope)。

#415 r2 3/3 unanimous narrow scope — Lark new-message + initial POST + 230002 fallback retry + parser hints,迁移 3 处 caller。

## 范围

- 8 files changed (new: ILarkOutboundDispatcher / LarkOutboundDispatcher / tests; modified: SkillRunnerGAgent / StreamingReplySink / FeishuCardHumanInteractionPort)
- 不动 streaming-edit / cross-tenant 路径
- 不新增 actor / envelope / proto / canon

## Stacked-PR

#415 split first-slice。Base = `auto-refact-dev`。Rollup = `dev`。

closes #1374

⟦AI:AUTO-LOOP⟧
