### PR TITLE
[refactor] #394: 删除 runner-side canonical TargetActorId placeholder

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -1519,6 +1519,7 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
             RunId = AgentRunId.New().Value,
             RegistrationId = registration.Id,
             Activity = requestActivity,
+            // Refactor (issue394): Old=runner filled a canonical TargetActorId placeholder; New=ConversationGAgent stamps its owning actor id before persistence/dispatch.
             RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
         };
 

--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -1517,7 +1517,6 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
             CorrelationId = activity.Id,
             // Refactor (iter98/cluster-002): Old=correlation_id doubled as run identity; New=run_id is explicit before persistence/dispatch.
             RunId = AgentRunId.New().Value,
-            TargetActorId = ConversationGAgent.BuildActorId(activity.Conversation!.CanonicalKey),
             RegistrationId = registration.Id,
             Activity = requestActivity,
             RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),

--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -1519,7 +1519,7 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
             RunId = AgentRunId.New().Value,
             RegistrationId = registration.Id,
             Activity = requestActivity,
-            // Refactor (issue394): Old=runner filled a canonical TargetActorId placeholder; New=ConversationGAgent stamps its owning actor id before persistence/dispatch.
+            // Refactor (iter394/cluster-issue-394-design): Old pattern: runner filled a canonical TargetActorId placeholder. New principle: ConversationGAgent stamps its owning actor id before persistence/dispatch.
             RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
         };
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
@@ -44,7 +44,7 @@ public sealed class ChannelConversationTurnRunnerTests
         result.LlmReplyRequest!.CorrelationId.Should().Be("msg-1");
         result.LlmReplyRequest.RunId.Should().StartWith("agent-run-");
         result.LlmReplyRequest.RunId.Should().NotBe(result.LlmReplyRequest.CorrelationId);
-        result.LlmReplyRequest.TargetActorId.Should().Be("channel-conversation:lark:group:oc_group_chat_1");
+        result.LlmReplyRequest.TargetActorId.Should().BeEmpty();
         result.LlmReplyRequest.Metadata[ChannelMetadataKeys.ChatType].Should().Be("group");
         adapter.Replies.Should().BeEmpty();
     }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationGAgentTargetActorIdTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationGAgentTargetActorIdTests.cs
@@ -1,0 +1,267 @@
+using System.Reflection;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Foundation.Core.EventSourcing;
+using Aevatar.GAgents.Channel.Abstractions;
+using Aevatar.GAgents.Channel.Runtime;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+public sealed class ConversationGAgentTargetActorIdTests
+{
+    [Fact]
+    public async Task HandleInboundActivityAsync_ShouldOwnerStampLlmReplyTargetActorIdBeforeDispatch()
+    {
+        var actorId = ConversationGAgent.BuildActorId("lark:group:oc_group_chat_1");
+        var runner = new DeferredReplyTurnRunner();
+        var dispatcher = new RecordingLlmReplyRunDispatcher();
+        var agent = CreateAgent(actorId, runner, dispatcher);
+
+        await agent.HandleInboundActivityAsync(BuildInboundActivity("msg-target-1"));
+
+        runner.Request.TargetActorId.Should().BeEmpty();
+        dispatcher.Requests.Should().ContainSingle();
+        dispatcher.Requests[0].TargetActorId.Should().Be(actorId);
+        agent.State.PendingLlmReplyRequests.Should().ContainSingle();
+        agent.State.PendingLlmReplyRequests[0].TargetActorId.Should().Be(actorId);
+    }
+
+    private static ConversationGAgent CreateAgent(
+        string id,
+        IConversationTurnRunner runner,
+        IChannelLlmReplyRunDispatcher dispatcher)
+    {
+        var services = new ServiceCollection()
+            .AddSingleton<IEventStore, InMemoryEventStore>()
+            .AddSingleton<IActorDispatchPort, NoopActorDispatchPort>()
+            .AddSingleton<IActorRuntimeCallbackScheduler, NoopCallbackScheduler>()
+            .AddSingleton(runner)
+            .AddSingleton(dispatcher)
+            .AddSingleton<EventSourcingRuntimeOptions>()
+            .AddTransient(typeof(IEventSourcingBehaviorFactory<>), typeof(DefaultEventSourcingBehaviorFactory<>))
+            .BuildServiceProvider();
+
+        var agent = new ConversationGAgent
+        {
+            Services = services,
+            EventPublisher = new RecordingEventPublisher(),
+            EventSourcingBehaviorFactory =
+                services.GetRequiredService<IEventSourcingBehaviorFactory<ConversationGAgentState>>(),
+        };
+        SetId(agent, id);
+        agent.ActivateAsync().GetAwaiter().GetResult();
+        return agent;
+    }
+
+    private static ChatActivity BuildInboundActivity(string messageId) =>
+        new()
+        {
+            Id = messageId,
+            Type = ActivityType.Message,
+            ChannelId = ChannelId.From("lark"),
+            Bot = BotInstanceId.From("reg-1"),
+            Conversation = ConversationReference.Create(
+                ChannelId.From("lark"),
+                BotInstanceId.From("reg-1"),
+                ConversationScope.Group,
+                "oc_group_chat_1",
+                "group",
+                "oc_group_chat_1"),
+            From = new ParticipantRef { CanonicalId = "ou_user_1" },
+            Content = new MessageContent { Text = "hello" },
+        };
+
+    private static void SetId(object agent, string id)
+    {
+        var current = agent.GetType();
+        while (current is not null)
+        {
+            var setIdMethod = current.GetMethod(
+                "SetId",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            if (setIdMethod is not null)
+            {
+                setIdMethod.Invoke(agent, [id]);
+                return;
+            }
+
+            current = current.BaseType;
+        }
+
+        throw new InvalidOperationException("Unable to set agent id via reflection.");
+    }
+
+    private sealed class DeferredReplyTurnRunner : IConversationTurnRunner
+    {
+        public NeedsLlmReplyEvent Request { get; } = new()
+        {
+            CorrelationId = "msg-target-1",
+            RunId = "agent-run-target-1",
+            RegistrationId = "reg-1",
+            Activity = BuildInboundActivity("msg-target-1"),
+            RequestedAtUnixMs = 10,
+        };
+
+        public Task<ConversationTurnResult> RunInboundAsync(
+            ChatActivity activity,
+            ConversationTurnRuntimeContext runtimeContext,
+            CancellationToken ct) =>
+            Task.FromResult(ConversationTurnResult.LlmReplyRequested(Request));
+
+        public Task<ConversationTurnResult> RunLlmReplyAsync(
+            LlmReplyReadyEvent reply,
+            ConversationTurnRuntimeContext runtimeContext,
+            CancellationToken ct) =>
+            Task.FromResult(ConversationTurnResult.Sent(
+                "sent",
+                reply.Outbound?.Clone() ?? new MessageContent(),
+                "bot"));
+
+        public Task<ConversationTurnResult> RunContinueAsync(
+            ConversationContinueRequestedEvent command,
+            CancellationToken ct) =>
+            Task.FromResult(ConversationTurnResult.Ignored("not-used", command.CommandId));
+
+        public Task<ConversationStreamChunkResult> RunStreamChunkAsync(
+            LlmReplyStreamChunkEvent chunk,
+            string? currentPlatformMessageId,
+            ConversationTurnRuntimeContext runtimeContext,
+            CancellationToken ct) =>
+            Task.FromResult(ConversationStreamChunkResult.Succeeded(currentPlatformMessageId));
+    }
+
+    private sealed class RecordingLlmReplyRunDispatcher : IChannelLlmReplyRunDispatcher
+    {
+        public List<NeedsLlmReplyEvent> Requests { get; } = [];
+
+        public Task DispatchAsync(NeedsLlmReplyEvent request, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            Requests.Add(request.Clone());
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class NoopActorDispatchPort : IActorDispatchPort
+    {
+        public Task<DispatchAdmission> DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default) =>
+            Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
+    }
+
+    private sealed class NoopCallbackScheduler : IActorRuntimeCallbackScheduler
+    {
+        public Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
+            RuntimeCallbackTimeoutRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                1,
+                RuntimeCallbackBackend.InMemory));
+
+        public Task<RuntimeCallbackLease> ScheduleTimerAsync(
+            RuntimeCallbackTimerRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                1,
+                RuntimeCallbackBackend.InMemory));
+
+        public Task CancelAsync(RuntimeCallbackLease lease, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task PurgeActorAsync(string actorId, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class RecordingEventPublisher : IEventPublisher
+    {
+        public Task PublishAsync<TEvent>(
+            TEvent evt,
+            TopologyAudience audience = TopologyAudience.Children,
+            CancellationToken ct = default,
+            EventEnvelope? sourceEnvelope = null,
+            EventEnvelopePublishOptions? options = null)
+            where TEvent : IMessage =>
+            Task.CompletedTask;
+
+        public Task SendToAsync<TEvent>(
+            string targetActorId,
+            TEvent evt,
+            CancellationToken ct = default,
+            EventEnvelope? sourceEnvelope = null,
+            EventEnvelopePublishOptions? options = null)
+            where TEvent : IMessage =>
+            Task.CompletedTask;
+    }
+
+    private sealed class InMemoryEventStore : IEventStore
+    {
+        private readonly Dictionary<string, List<StateEvent>> _events = new(StringComparer.Ordinal);
+
+        public Task<EventStoreCommitResult> AppendAsync(
+            string agentId,
+            IEnumerable<StateEvent> events,
+            long expectedVersion,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!_events.TryGetValue(agentId, out var stream))
+            {
+                stream = [];
+                _events[agentId] = stream;
+            }
+
+            var currentVersion = stream.Count == 0 ? 0 : stream[^1].Version;
+            if (currentVersion != expectedVersion)
+                throw new EventStoreOptimisticConcurrencyException(agentId, expectedVersion, currentVersion);
+
+            var appended = events.Select(x => x.Clone()).ToList();
+            stream.AddRange(appended);
+            return Task.FromResult(new EventStoreCommitResult
+            {
+                AgentId = agentId,
+                LatestVersion = stream.Count == 0 ? 0 : stream[^1].Version,
+                CommittedEvents = { appended.Select(x => x.Clone()) },
+            });
+        }
+
+        public Task<IReadOnlyList<StateEvent>> GetEventsAsync(
+            string agentId,
+            long? fromVersion = null,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!_events.TryGetValue(agentId, out var stream))
+                return Task.FromResult<IReadOnlyList<StateEvent>>([]);
+
+            IReadOnlyList<StateEvent> result = fromVersion.HasValue
+                ? stream.Where(x => x.Version > fromVersion.Value).Select(x => x.Clone()).ToList()
+                : stream.Select(x => x.Clone()).ToList();
+            return Task.FromResult(result);
+        }
+
+        public Task<long> GetVersionAsync(string agentId, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!_events.TryGetValue(agentId, out var stream) || stream.Count == 0)
+                return Task.FromResult(0L);
+            return Task.FromResult(stream[^1].Version);
+        }
+
+        public Task<long> DeleteEventsUpToAsync(string agentId, long toVersion, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (toVersion <= 0 || !_events.TryGetValue(agentId, out var stream))
+                return Task.FromResult(0L);
+
+            var before = stream.Count;
+            stream.RemoveAll(x => x.Version <= toVersion);
+            return Task.FromResult((long)(before - stream.Count));
+        }
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationGAgentTargetActorIdTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationGAgentTargetActorIdTests.cs
@@ -20,7 +20,7 @@ public sealed class ConversationGAgentTargetActorIdTests
         var actorId = ConversationGAgent.BuildActorId("lark:group:oc_group_chat_1");
         var runner = new DeferredReplyTurnRunner();
         var dispatcher = new RecordingLlmReplyRunDispatcher();
-        var agent = CreateAgent(actorId, runner, dispatcher);
+        var agent = await CreateAgentAsync(actorId, runner, dispatcher);
 
         await agent.HandleInboundActivityAsync(BuildInboundActivity("msg-target-1"));
 
@@ -31,7 +31,7 @@ public sealed class ConversationGAgentTargetActorIdTests
         agent.State.PendingLlmReplyRequests[0].TargetActorId.Should().Be(actorId);
     }
 
-    private static ConversationGAgent CreateAgent(
+    private static async Task<ConversationGAgent> CreateAgentAsync(
         string id,
         IConversationTurnRunner runner,
         IChannelLlmReplyRunDispatcher dispatcher)
@@ -54,7 +54,7 @@ public sealed class ConversationGAgentTargetActorIdTests
                 services.GetRequiredService<IEventSourcingBehaviorFactory<ConversationGAgentState>>(),
         };
         SetId(agent, id);
-        agent.ActivateAsync().GetAwaiter().GetResult();
+        await agent.ActivateAsync();
         return agent;
     }
 


### PR DESCRIPTION
## 摘要

#394 implement: 删除 runner-side canonical `TargetActorId` placeholder。

3/3 r1 consensus (delete framing) — keep `ConversationGAgent` owner-stamped target contract,无新抽象。

## 范围

- 3 files changed (+268/-2)
- `agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs`
- `test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs`
- `test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationGAgentTargetActorIdTests.cs` (new)

closes #394

⟦AI:AUTO-LOOP⟧
