### PR TITLE
iter343 cluster-001: NyxIdChat/StreamingProxy 命令身份解耦

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatInteraction.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatInteraction.cs
@@ -12,9 +12,9 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Aevatar.GAgents.NyxidChat;
 
-// Refactor (iter21/cluster-002-request-path-projection-session-priming):
-//   Old pattern: request handlers synchronously ensured projection/session leases and waited on live sinks.
-//   New principle: commands carry stable identity into a shared interaction pipeline; binders own observation.
+// Refactor (iter343/cluster-001-chat-session-command-identity):
+//   Old pattern: Chat interaction commands reuse SessionId as CommandId and CorrelationId.
+//   New principle: Generate or carry distinct command/correlation identifiers while keeping SessionId only as conversation/projection session identity.
 public sealed record NyxIdChatCommand(
     string ActorId,
     string ScopeId,
@@ -23,27 +23,27 @@ public sealed record NyxIdChatCommand(
     string AccessToken,
     IReadOnlyList<NyxIdChatEndpoints.ContentPartDto>? InputParts,
     IReadOnlyDictionary<string, string>? Metadata,
-    LLMControlContext? LlmControl = null)
+    LLMControlContext? LlmControl = null,
+    string? CommandId = null,
+    string? CorrelationId = null)
     : ICommandContextSeed
 {
-    public string? CommandId => SessionId;
-    public string? CorrelationId => SessionId;
     public IReadOnlyDictionary<string, string>? Headers => null;
 }
 
-// Refactor (iter21/cluster-002-request-path-projection-session-priming):
-//   Old pattern: approval endpoints built their own dispatch and projection wait flow.
-//   New principle: approval uses the same command interaction contract as chat execution.
+// Refactor (iter343/cluster-001-chat-session-command-identity):
+//   Old pattern: Chat interaction commands reuse SessionId as CommandId and CorrelationId.
+//   New principle: Generate or carry distinct command/correlation identifiers while keeping SessionId only as conversation/projection session identity.
 public sealed record NyxIdApprovalCommand(
     string ActorId,
     string RequestId,
     bool Approved,
     string Reason,
-    string SessionId)
+    string SessionId,
+    string? CommandId = null,
+    string? CorrelationId = null)
     : ICommandContextSeed
 {
-    public string? CommandId => SessionId;
-    public string? CorrelationId => SessionId;
     public IReadOnlyDictionary<string, string>? Headers => null;
 }
 
@@ -271,9 +271,9 @@ internal sealed class NyxIdChatCommandEnvelopeFactory : ICommandEnvelopeFactory<
 {
     public EventEnvelope CreateEnvelope(NyxIdChatCommand command, CommandContext context)
     {
-        // Refactor (iter21/cluster-002-request-path-projection-session-priming):
-        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
-        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
+        // Refactor (iter343/cluster-001-chat-session-command-identity):
+        //   Old pattern: Chat interaction commands reuse SessionId as CommandId and CorrelationId.
+        //   New principle: Generate or carry distinct command/correlation identifiers while keeping SessionId only as conversation/projection session identity.
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(context);
 
@@ -330,6 +330,9 @@ internal sealed class NyxIdApprovalCommandEnvelopeFactory : ICommandEnvelopeFact
 {
     public EventEnvelope CreateEnvelope(NyxIdApprovalCommand command, CommandContext context)
     {
+        // Refactor (iter343/cluster-001-chat-session-command-identity):
+        //   Old pattern: Chat interaction commands reuse SessionId as CommandId and CorrelationId.
+        //   New principle: Generate or carry distinct command/correlation identifiers while keeping SessionId only as conversation/projection session identity.
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(context);
 

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomInteraction.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomInteraction.cs
@@ -10,9 +10,9 @@ using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.GAgents.StreamingProxy;
 
-// Refactor (iter21/cluster-002-request-path-projection-session-priming):
-//   Old pattern: room chat endpoints created projection leases and inferred completion in handler code.
-//   New principle: room chat commands enter a shared interaction pipeline and bind observation by session.
+// Refactor (iter343/cluster-001-chat-session-command-identity):
+//   Old pattern: Chat interaction commands reuse SessionId as CommandId and CorrelationId.
+//   New principle: Generate or carry distinct command/correlation identifiers while keeping SessionId only as conversation/projection session identity.
 public sealed record StreamingProxyRoomChatCommand(
     string RoomId,
     string ScopeId,
@@ -20,11 +20,11 @@ public sealed record StreamingProxyRoomChatCommand(
     string SessionId,
     string? AccessToken = null,
     string? PreferredRoute = null,
-    string? DefaultModel = null)
+    string? DefaultModel = null,
+    string? CommandId = null,
+    string? CorrelationId = null)
     : ICommandContextSeed
 {
-    public string? CommandId => SessionId;
-    public string? CorrelationId => SessionId;
     public IReadOnlyDictionary<string, string>? Headers => null;
 }
 
@@ -245,9 +245,9 @@ internal sealed class StreamingProxyRoomChatCommandEnvelopeFactory
 {
     public EventEnvelope CreateEnvelope(StreamingProxyRoomChatCommand command, CommandContext context)
     {
-        // Refactor (iter21/cluster-002-request-path-projection-session-priming):
-        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
-        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
+        // Refactor (iter343/cluster-001-chat-session-command-identity):
+        //   Old pattern: Chat interaction commands reuse SessionId as CommandId and CorrelationId.
+        //   New principle: Generate or carry distinct command/correlation identifiers while keeping SessionId only as conversation/projection session identity.
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(context);
 

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -1330,6 +1330,59 @@ public class NyxIdChatEndpointsCoverageTests
     }
 
     [Fact]
+    public async Task NyxIdChatInteraction_ShouldPreserveExplicitCommandAndCorrelationIdentity()
+    {
+        var actor = new StubActor("actor-1");
+        var runtime = new StubActorRuntime();
+        runtime.Actors[actor.Id] = actor;
+        var projectionPort = new StubNyxIdChatSessionProjectionPort
+        {
+            Messages =
+            {
+                new AGUIEvent { RunFinished = new RunFinishedEvent() },
+            },
+        };
+        var dispatchPort = new StubActorDispatchPort(runtime);
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IActorRuntime>(runtime)
+            .AddSingleton<IActorDispatchPort>(dispatchPort)
+            .AddSingleton<INyxIdChatSessionProjectionPort>(projectionPort)
+            .AddNyxIdChat()
+            .BuildServiceProvider();
+        var interaction = services.GetRequiredService<
+            ICommandInteractionService<NyxIdChatCommand, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, NyxIdChatCompletionStatus>>();
+
+        var result = await interaction.ExecuteAsync(
+            new NyxIdChatCommand(
+                actor.Id,
+                "scope-a",
+                "hello",
+                "session-1",
+                "access-token",
+                null,
+                null,
+                CommandId: "command-explicit",
+                CorrelationId: "correlation-explicit"),
+            (_, _) => ValueTask.CompletedTask);
+
+        result.Succeeded.Should().BeTrue();
+        result.Receipt.Should().Be(new NyxIdChatAcceptedReceipt(
+            actor.Id,
+            "command-explicit",
+            "correlation-explicit",
+            "session-1"));
+        projectionPort.AttachExistingCalls.Should().ContainSingle(x =>
+            x.ActorId == actor.Id &&
+            x.SessionId == "session-1");
+        dispatchPort.Dispatches.Should().ContainSingle();
+        var envelope = dispatchPort.Dispatches.Single().Envelope;
+        envelope.Propagation?.CorrelationId.Should().Be("correlation-explicit");
+        var request = envelope.Payload.Unpack<ChatRequestEvent>();
+        request.SessionId.Should().Be("session-1");
+    }
+
+    [Fact]
     public async Task NyxIdChatInteraction_ShouldReturnProjectionUnavailableAndDisposeSink_WhenBinderCannotAttach()
     {
         var actor = new StubActor("actor-1");
@@ -1402,6 +1455,58 @@ public class NyxIdChatEndpointsCoverageTests
         decision.SessionId.Should().Be("session-1");
         decision.Approved.Should().BeFalse();
         decision.Reason.Should().Be("deny");
+    }
+
+    [Fact]
+    public async Task NyxIdApprovalInteraction_ShouldPreserveExplicitCommandAndCorrelationIdentity()
+    {
+        var actor = new StubActor("actor-1");
+        var runtime = new StubActorRuntime();
+        runtime.Actors[actor.Id] = actor;
+        var projectionPort = new StubNyxIdChatSessionProjectionPort
+        {
+            Messages =
+            {
+                new AGUIEvent { RunFinished = new RunFinishedEvent() },
+            },
+        };
+        var dispatchPort = new StubActorDispatchPort(runtime);
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IActorRuntime>(runtime)
+            .AddSingleton<IActorDispatchPort>(dispatchPort)
+            .AddSingleton<INyxIdChatSessionProjectionPort>(projectionPort)
+            .AddNyxIdChat()
+            .BuildServiceProvider();
+        var interaction = services.GetRequiredService<
+            ICommandInteractionService<NyxIdApprovalCommand, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, NyxIdChatCompletionStatus>>();
+
+        var result = await interaction.ExecuteAsync(
+            new NyxIdApprovalCommand(
+                actor.Id,
+                "request-1",
+                true,
+                "approved",
+                "session-1",
+                CommandId: "approval-command-explicit",
+                CorrelationId: "approval-correlation-explicit"),
+            (_, _) => ValueTask.CompletedTask);
+
+        result.Succeeded.Should().BeTrue();
+        result.Receipt.Should().Be(new NyxIdChatAcceptedReceipt(
+            actor.Id,
+            "approval-command-explicit",
+            "approval-correlation-explicit",
+            "session-1"));
+        projectionPort.AttachExistingCalls.Should().ContainSingle(x =>
+            x.ActorId == actor.Id &&
+            x.SessionId == "session-1");
+        dispatchPort.Dispatches.Should().ContainSingle();
+        var envelope = dispatchPort.Dispatches.Single().Envelope;
+        envelope.Propagation?.CorrelationId.Should().Be("approval-correlation-explicit");
+        var decision = envelope.Payload.Unpack<ToolApprovalDecisionEvent>();
+        decision.RequestId.Should().Be("request-1");
+        decision.SessionId.Should().Be("session-1");
     }
 
     [Fact]

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -1298,7 +1298,12 @@ public class NyxIdChatEndpointsCoverageTests
             CancellationToken.None);
 
         result.Succeeded.Should().BeTrue();
-        result.Receipt.Should().Be(new NyxIdChatAcceptedReceipt(actor.Id, "session-1", "session-1", "session-1"));
+        result.Receipt.Should().NotBeNull();
+        result.Receipt!.ActorId.Should().Be(actor.Id);
+        result.Receipt.CommandId.Should().NotBeNullOrWhiteSpace();
+        result.Receipt.CommandId.Should().NotBe("session-1");
+        result.Receipt.CorrelationId.Should().Be(result.Receipt.CommandId);
+        result.Receipt.SessionId.Should().Be("session-1");
         result.FinalizeResult.Should().NotBeNull();
         result.FinalizeResult!.Completed.Should().BeTrue();
         result.FinalizeResult.Completion.Should().Be(NyxIdChatCompletionStatus.Completed);
@@ -1309,7 +1314,7 @@ public class NyxIdChatEndpointsCoverageTests
         dispatchPort.Dispatches.Should().ContainSingle();
         var envelope = dispatchPort.Dispatches.Single().Envelope;
         envelope.Route?.Direct?.TargetActorId.Should().Be(actor.Id);
-        envelope.Propagation?.CorrelationId.Should().Be("session-1");
+        envelope.Propagation?.CorrelationId.Should().Be(result.Receipt.CorrelationId);
         var request = envelope.Payload.Unpack<ChatRequestEvent>();
         request.Prompt.Should().Be("hello");
         request.SessionId.Should().Be("session-1");

--- a/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
@@ -832,6 +832,58 @@ public class StreamingProxyCoverageTests
     }
 
     [Fact]
+    public async Task StreamingProxyRoomInteraction_ShouldPreserveExplicitCommandAndCorrelationIdentity()
+    {
+        var actor = new StubActor("room-a");
+        var runtime = new StubActorRuntime([actor]);
+        var projectionPort = new StubRoomSessionProjectionPort();
+        projectionPort.Messages.Add(new StreamingProxyRoomSessionEnvelope
+        {
+            Envelope = StreamingProxyRoomInteractionHelpers.CreateTerminalEnvelope(
+                actor.Id,
+                "session-123",
+                StreamingProxyChatSessionTerminalStatus.Completed,
+                null),
+        });
+        var dispatchPort = new StubActorDispatchPort(runtime);
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IActorRuntime>(runtime)
+            .AddSingleton<IActorDispatchPort>(dispatchPort)
+            .AddSingleton<IStreamingProxyRoomSessionProjectionPort>(projectionPort)
+            .AddSingleton<IStreamingProxyChatSessionTerminalQueryPort>(new StubTerminalQueryPort())
+            .AddStreamingProxy()
+            .BuildServiceProvider();
+        var interaction = services.GetRequiredService<
+            ICommandInteractionService<StreamingProxyRoomChatCommand, StreamingProxyRoomChatAcceptedReceipt, StreamingProxyRoomChatStartError, StreamingProxyRoomSessionEnvelope, StreamingProxyProjectionCompletionStatus>>();
+
+        var result = await interaction.ExecuteAsync(
+            new StreamingProxyRoomChatCommand(
+                actor.Id,
+                "scope-a",
+                "Discuss claims",
+                "session-123",
+                CommandId: "room-command-explicit",
+                CorrelationId: "room-correlation-explicit"),
+            (_, _) => ValueTask.CompletedTask);
+
+        result.Succeeded.Should().BeTrue();
+        result.Receipt.Should().Be(new StreamingProxyRoomChatAcceptedReceipt(
+            actor.Id,
+            "room-command-explicit",
+            "room-correlation-explicit",
+            "session-123"));
+        projectionPort.AttachExistingCalls.Should().ContainSingle(x =>
+            x.actorId == actor.Id &&
+            x.sessionId == "session-123");
+        dispatchPort.Dispatches.Should().ContainSingle();
+        var envelope = dispatchPort.Dispatches.Single().Envelope;
+        envelope.Propagation?.CorrelationId.Should().Be("room-correlation-explicit");
+        var request = envelope.Payload.Unpack<ChatRequestEvent>();
+        request.SessionId.Should().Be("session-123");
+    }
+
+    [Fact]
     public async Task StreamingProxyRoomInteraction_ShouldReturnProjectionUnavailableAndDisposeSink_WhenBinderCannotAttach()
     {
         var actor = new StubActor("room-a");

--- a/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
@@ -806,7 +806,12 @@ public class StreamingProxyCoverageTests
             });
 
         result.Succeeded.Should().BeTrue();
-        result.Receipt.Should().Be(new StreamingProxyRoomChatAcceptedReceipt(actor.Id, "session-123", "session-123", "session-123"));
+        result.Receipt.Should().NotBeNull();
+        result.Receipt!.ActorId.Should().Be(actor.Id);
+        result.Receipt.CommandId.Should().NotBeNullOrWhiteSpace();
+        result.Receipt.CommandId.Should().NotBe("session-123");
+        result.Receipt.CorrelationId.Should().Be(result.Receipt.CommandId);
+        result.Receipt.SessionId.Should().Be("session-123");
         result.FinalizeResult.Should().NotBeNull();
         result.FinalizeResult!.Completed.Should().BeTrue();
         result.FinalizeResult.Completion.Should().Be(StreamingProxyProjectionCompletionStatus.Completed);


### PR DESCRIPTION
## 摘要

iter343 cluster-001（medium，rule_ids: `CMD-TRACE-IDENTITY` + `API-FIELD-SINGLE-SEMA`）。

- **Old**：Chat 类交互命令（`NyxIdChatCommand` / `NyxIdApprovalCommand` / `StreamingProxyRoomChatCommand`）把 `SessionId` 同时作为 `CommandId` 与 `CorrelationId`，导致 envelope 分发链路的追踪标识与会话身份混用。
- **New**：生成或显式携带独立的 `CommandId` / `CorrelationId`；`SessionId` 仅保留 conversation / projection session 身份。

违反：

- CLAUDE.md 顶级架构约束「追踪标识与目标身份分离：`commandId/correlationId` 追踪请求，`actorId` 标识实体；禁止混用或假设一一对应」
- CLAUDE.md 顶级架构约束「API 字段单一语义：一个字段只表达一个含义」

## Scope / 范围

4 个文件改动（+40 / -27）：

- `agents/Aevatar.GAgents.NyxidChat/NyxIdChatInteraction.cs`（命令 seed 解耦）
- `agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomInteraction.cs`（命令 seed 解耦）
- `test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs`（断言更新）
- `test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs`（断言更新）

参见：
- [audit-iter-343.md](./.refactor-loop/runs/audit-iter-343.md#cluster-001-chat-session-command-identity)
- [implement summary](./.refactor-loop/runs/implement-cluster-001-chat-session-command-identity.md)

## Stacked-PR

iter343 单 cluster，base = `auto-refact-dev`。Rollup target = `dev`（reverse rollup PR #1167）。

🤖 Auto-loop / codex-refactor-loop iter343

⟦AI:AUTO-LOOP⟧
