### PR TITLE
iter344 cluster-001: ChatCompletions Host LLM 循环解耦

### DIFF
--- a/src/Aevatar.Mainnet.Host.Api/ChatCompletions/ChatCompletionsApiModels.cs
+++ b/src/Aevatar.Mainnet.Host.Api/ChatCompletions/ChatCompletionsApiModels.cs
@@ -44,90 +44,63 @@ internal sealed record ChatCompletionsCreateRequest
     public int? N { get; init; }
 }
 
-internal sealed record NormalizedChatCompletionsRequest(
-    string CompletionId,
-    string Model,
-    bool Stream,
-    bool IncludeUsageInStream,
-    double? Temperature,
-    int? MaxTokens,
-    IReadOnlyList<ChatMessage> ChatMessages,
-    IReadOnlyList<ResponsesApplicationToolDeclaration> DeclaredTools,
-    LLMResponseFormat? ResponseFormat);
-
-internal readonly record struct ChatCompletionsNormalizationResult(
-    NormalizedChatCompletionsRequest? Request,
+internal readonly record struct ChatCompletionsProtocolMappingResult(
+    ChatCompletionsCommandRequest? Request,
     string? ErrorCode,
     string? ErrorMessage)
 {
     public bool Succeeded => Request != null && ErrorCode == null;
 
-    public static ChatCompletionsNormalizationResult Success(NormalizedChatCompletionsRequest request) =>
+    public static ChatCompletionsProtocolMappingResult Success(ChatCompletionsCommandRequest request) =>
         new(request, null, null);
 
-    public static ChatCompletionsNormalizationResult Failed(string code, string message) =>
+    public static ChatCompletionsProtocolMappingResult Failed(string code, string message) =>
         new(null, code, message);
 }
 
-internal static class ChatCompletionsRequestNormalizer
+internal static class ChatCompletionsProtocolMapper
 {
     private const int MaxToolDescriptionLength = 4_096;
 
-    public static ChatCompletionsNormalizationResult Normalize(ChatCompletionsCreateRequest request)
+    // Refactor (iter344/cluster-001):
+    //   Old pattern: Host handler owns caller resolution, route resolution, session registration, tool planning, direct provider execution, status updates, and protocol rendering in one request stack.
+    //   New principle: Host maps HTTP/OpenAI frames only; typed Application facade owns Normalize -> Resolve Target -> Build Context -> Build Envelope -> Dispatch -> Receipt/Observe via the same LlmSessionGAgent run path as Responses/Messages.
+    public static ChatCompletionsProtocolMappingResult ToCommandRequest(ChatCompletionsCreateRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        var model = request.Model?.Trim();
-        if (string.IsNullOrWhiteSpace(model))
-            return ChatCompletionsNormalizationResult.Failed("model_required", "model is required.");
-
         var maxTokens = request.MaxCompletionTokens ?? request.MaxTokens;
-        if (maxTokens is <= 0)
-        {
-            return ChatCompletionsNormalizationResult.Failed(
-                "invalid_max_tokens",
-                "max_tokens must be greater than zero when provided.");
-        }
-
-        if (request.Temperature is < 0 or > 2)
-        {
-            return ChatCompletionsNormalizationResult.Failed(
-                "invalid_temperature",
-                "temperature must be between 0 and 2.");
-        }
 
         if (request.N is not null and not 1)
         {
-            return ChatCompletionsNormalizationResult.Failed(
+            return ChatCompletionsProtocolMappingResult.Failed(
                 "unsupported_parameter",
                 "n must be 1 when provided.");
         }
 
         if (!TryNormalizeToolChoice(request.ToolChoice, out var toolChoiceDisablesTools, out var toolChoiceError))
-            return ChatCompletionsNormalizationResult.Failed("unsupported_parameter", toolChoiceError ?? "tool_choice is not supported.");
+            return ChatCompletionsProtocolMappingResult.Failed("unsupported_parameter", toolChoiceError ?? "tool_choice is not supported.");
 
         if (!TryExtractDeclaredTools(request.Tools, out var declaredTools, out var toolsError))
-            return ChatCompletionsNormalizationResult.Failed("invalid_tools", toolsError ?? "tools is invalid.");
+            return ChatCompletionsProtocolMappingResult.Failed("invalid_tools", toolsError ?? "tools is invalid.");
 
         if (toolChoiceDisablesTools)
             declaredTools = [];
 
         if (!TryExtractChatMessages(request.Messages, out var messages, out var messagesError))
-            return ChatCompletionsNormalizationResult.Failed("invalid_messages", messagesError ?? "messages is invalid.");
+            return ChatCompletionsProtocolMappingResult.Failed("invalid_messages", messagesError ?? "messages is invalid.");
 
         if (!TryExtractResponseFormat(request.ResponseFormat, out var responseFormat, out var responseFormatError))
-            return ChatCompletionsNormalizationResult.Failed("unsupported_parameter", responseFormatError ?? "response_format is invalid.");
+            return ChatCompletionsProtocolMappingResult.Failed("unsupported_parameter", responseFormatError ?? "response_format is invalid.");
 
-        return ChatCompletionsNormalizationResult.Success(new NormalizedChatCompletionsRequest(
-            CompletionId: "chatcmpl_" + NewOpaqueId(),
-            Model: model,
-            Stream: request.Stream == true,
-            IncludeUsageInStream: ExtractIncludeUsage(request.StreamOptions),
-            Temperature: request.Temperature,
-            MaxTokens: maxTokens,
-            ChatMessages: messages,
-            DeclaredTools: declaredTools,
-            ResponseFormat: responseFormat));
+        return ChatCompletionsProtocolMappingResult.Success(new ChatCompletionsCommandRequest(
+            request.Model,
+            request.Stream,
+            ExtractIncludeUsage(request.StreamOptions),
+            request.Temperature,
+            maxTokens,
+            messages,
+            declaredTools));
     }
 
     private static bool TryExtractChatMessages(
@@ -550,13 +523,4 @@ internal static class ChatCompletionsRequestNormalizer
         return Convert.ToHexString(bytes)[..16].ToLowerInvariant();
     }
 
-    private static string NewOpaqueId()
-    {
-        Span<byte> bytes = stackalloc byte[16];
-        RandomNumberGenerator.Fill(bytes);
-        return Convert.ToBase64String(bytes)
-            .TrimEnd('=')
-            .Replace('+', '-')
-            .Replace('/', '_');
-    }
 }

--- a/src/Aevatar.Mainnet.Host.Api/ChatCompletions/ChatCompletionsApiModels.cs
+++ b/src/Aevatar.Mainnet.Host.Api/ChatCompletions/ChatCompletionsApiModels.cs
@@ -44,6 +44,9 @@ internal sealed record ChatCompletionsCreateRequest
     public int? N { get; init; }
 }
 
+// Refactor (iter344/cluster-001):
+//   Old pattern: Host validation locals were mixed with caller resolution, route/session setup, and direct provider execution.
+//   New principle: Host protocol mapping returns a typed command request or protocol error; Application owns command lifecycle decisions.
 internal readonly record struct ChatCompletionsProtocolMappingResult(
     ChatCompletionsCommandRequest? Request,
     string? ErrorCode,
@@ -100,7 +103,8 @@ internal static class ChatCompletionsProtocolMapper
             request.Temperature,
             maxTokens,
             messages,
-            declaredTools));
+            declaredTools,
+            responseFormat));
     }
 
     private static bool TryExtractChatMessages(

--- a/src/Aevatar.Mainnet.Host.Api/ChatCompletions/ChatCompletionsEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/ChatCompletions/ChatCompletionsEndpoints.cs
@@ -91,19 +91,7 @@ internal static class ChatCompletionsApiEndpoints
         response.Headers["X-Accel-Buffering"] = "no";
         await response.StartAsync(ct);
 
-        var completion = await commandFacade.StreamAsync(
-            plan,
-            async (delta, token) =>
-            {
-                if (string.IsNullOrEmpty(delta))
-                    return;
-
-                await WriteDataFrameAsync(
-                    response,
-                    BuildStreamingTextChunk(normalized, createdAt, delta),
-                    token);
-            },
-            ct);
+        var completion = await commandFacade.StreamAsync(plan, ct);
 
         if (completion.Error is not null)
         {
@@ -159,27 +147,6 @@ internal static class ChatCompletionsApiEndpoints
                 },
             },
             usage = (object?)null,
-        };
-
-    private static object BuildStreamingTextChunk(
-        NormalizedChatCompletionsCommand normalized,
-        long createdAt,
-        string delta) =>
-        new
-        {
-            id = normalized.CompletionId,
-            @object = "chat.completion.chunk",
-            created = createdAt,
-            model = normalized.Model,
-            choices = new[]
-            {
-                new
-                {
-                    index = 0,
-                    delta = new { content = delta },
-                    finish_reason = (string?)null,
-                },
-            },
         };
 
     private static object BuildStreamingStopChunk(

--- a/src/Aevatar.Mainnet.Host.Api/ChatCompletions/ChatCompletionsEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/ChatCompletions/ChatCompletionsEndpoints.cs
@@ -1,27 +1,15 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json;
 using Aevatar.AI.Abstractions.LLMProviders;
-using Aevatar.ChatRouting.Abstractions;
-using Aevatar.ChatRouting.Core;
-using Aevatar.GAgentService.Abstractions;
-using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Application.Responses;
-using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.Mainnet.Host.Api.Responses;
-using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.Logging;
 
 namespace Aevatar.Mainnet.Host.Api.ChatCompletions;
 
-[SuppressMessage(
-    "Maintainability",
-    "CA1506:Avoid excessive class coupling",
-    Justification = "Minimal API adapter composes caller scope, route resolution, session registration, and protocol shaping for one external facade.")]
 internal static class ChatCompletionsApiEndpoints
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
@@ -34,255 +22,68 @@ internal static class ChatCompletionsApiEndpoints
         return app;
     }
 
-    [SuppressMessage(
-        "Maintainability",
-        "CA1506:Avoid excessive class coupling",
-        Justification = "Minimal API adapter for one external compatibility endpoint; mirrors MessagesApiEndpoints.")]
+    // Refactor (iter344/cluster-001):
+    //   Old pattern: Host handler owns caller resolution, route resolution, session registration, tool planning, direct provider execution, status updates, and protocol rendering in one request stack.
+    //   New principle: Host maps HTTP/OpenAI frames only; typed Application facade owns Normalize -> Resolve Target -> Build Context -> Build Envelope -> Dispatch -> Receipt/Observe via the same LlmSessionGAgent run path as Responses/Messages.
     internal static async Task<IResult> HandleCreateChatCompletionAsync(
         HttpContext http,
         ChatCompletionsCreateRequest request,
-        [FromServices] ILLMProviderFactory providerFactory,
-        [FromServices] IResponsesCallerScopeResolver callerScopeResolver,
-        [FromServices] IChatRoutePolicyQueryPort chatRoutePolicyQueryPort,
-        [FromServices] ChatRouteResolver chatRouteResolver,
-        [FromServices] IResponsesRouteResolver routeResolver,
-        [FromServices] ILlmSessionRegistrationPort sessionRegistrationPort,
-        [FromServices] IResponsesCompletionApplicationService completionService,
-        [FromServices] IResponsesToolClassificationService toolClassificationService,
-        [FromServices] IResponsesDirectToolPlanService directToolPlanService,
-        [FromServices] ILoggerFactory loggerFactory,
+        [FromServices] IChatCompletionsCommandFacade commandFacade,
         CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(http);
         ArgumentNullException.ThrowIfNull(request);
-        ArgumentNullException.ThrowIfNull(providerFactory);
-        ArgumentNullException.ThrowIfNull(callerScopeResolver);
-        ArgumentNullException.ThrowIfNull(chatRoutePolicyQueryPort);
-        ArgumentNullException.ThrowIfNull(chatRouteResolver);
-        ArgumentNullException.ThrowIfNull(routeResolver);
-        ArgumentNullException.ThrowIfNull(sessionRegistrationPort);
-        ArgumentNullException.ThrowIfNull(completionService);
-        ArgumentNullException.ThrowIfNull(toolClassificationService);
-        ArgumentNullException.ThrowIfNull(directToolPlanService);
-        ArgumentNullException.ThrowIfNull(loggerFactory);
-        var logger = loggerFactory.CreateLogger("Aevatar.Mainnet.Host.Api.ChatCompletions");
+        ArgumentNullException.ThrowIfNull(commandFacade);
 
         var bearerToken = ExtractBearerToken(http);
         if (string.IsNullOrWhiteSpace(bearerToken))
             return ToErrorResult(StatusCodes.Status401Unauthorized, "authentication_required", "Authorization bearer token is required.");
-        var callerScopeContext = ResponsesApiEndpoints.BuildCallerScopeResolutionContext(http, bearerToken);
 
-        var normalizedResult = ChatCompletionsRequestNormalizer.Normalize(request);
-        if (!normalizedResult.Succeeded)
+        var commandRequest = ChatCompletionsProtocolMapper.ToCommandRequest(request);
+        if (!commandRequest.Succeeded)
         {
             return ToErrorResult(
                 StatusCodes.Status400BadRequest,
-                normalizedResult.ErrorCode ?? "invalid_request_error",
-                normalizedResult.ErrorMessage ?? "Invalid request.");
+                commandRequest.ErrorCode ?? "invalid_request_error",
+                commandRequest.ErrorMessage ?? "Invalid request.");
         }
 
-        var normalized = normalizedResult.Request!;
-        ResponsesCallerScope callerScope;
-        try
-        {
-            callerScope = await callerScopeResolver.ResolveAsync(callerScopeContext, ct);
-        }
-        catch (ResponsesCallerScopeUnavailableException ex)
-        {
-            return ToErrorResult(StatusCodes.Status401Unauthorized, "authentication_required", ex.Message);
-        }
+        var callerScopeContext = ResponsesApiEndpoints.BuildCallerScopeResolutionContext(http, bearerToken);
+        var result = await commandFacade.CreateAsync(commandRequest.Request!, callerScopeContext, ct);
+        if (result.Error is not null)
+            return ToErrorResult(result.Error.StatusCode, result.Error.Code, result.Error.Message);
 
-        var routedModel = normalized.Model;
-        var routeDecision = await ResponsesApiEndpoints.ResolveResponsesChatRouteAsync(
-            chatRoutePolicyQueryPort,
-            chatRouteResolver,
-            callerScope,
-            normalized.Model,
-            ResponsesApiEndpoints.ResolveToolMode(normalized.DeclaredTools.Count, inlineToolResultCount: 0),
-            ResponsesApiEndpoints.BuildContentHint(BuildRouteContentHint(normalized)),
-            ct);
-        ResponsesApiEndpoints.ApplyChatRouteDeprecationHeaders(http.Response, routeDecision);
-        if (routeDecision.Action.Reject is not null)
-        {
-            return ToErrorResult(
-                StatusCodes.Status403Forbidden,
-                "chat_route_rejected",
-                string.IsNullOrWhiteSpace(routeDecision.Action.Reject.Reason)
-                    ? "The chat route policy rejected this request."
-                    : routeDecision.Action.Reject.Reason);
-        }
-
-        var routeAction = routeDecision.Action.Clone();
-        var forwardToModel = routeAction.ForwardToModel;
-        if (forwardToModel is not null)
-        {
-            if (!string.IsNullOrWhiteSpace(forwardToModel.ModelName))
-                routedModel = forwardToModel.ModelName.Trim();
-        }
-        else
-        {
-            routeAction.ForwardToModel = new ForwardToModel();
-        }
-
-        routeAction.ForwardToModel.ModelName = routedModel;
-
-        var createdAt = DateTimeOffset.UtcNow;
-        LlmSessionRegistrationResult session;
-        try
-        {
-            session = await sessionRegistrationPort.RegisterAsync(
-                BuildSessionRecord(normalized, callerScope, createdAt),
-                ct);
-        }
-        catch (OperationCanceledException)
-        {
-            return Results.StatusCode(StatusCodes.Status408RequestTimeout);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            logger.LogError(ex, "Failed to register llm session for chat completion {CompletionId}", normalized.CompletionId);
-            return ToErrorResult(StatusCodes.Status500InternalServerError, "api_error", "Failed to register session.");
-        }
-
-        var toolProviderContext = ResponsesApiEndpoints.BuildToolProviderContext(
-            callerScope,
-            normalized.CompletionId,
-            bearerToken);
-        var toolPlan = directToolPlanService.Build(routeAction);
-        if (toolPlan.Error is not null)
-        {
-            return ToErrorResult(
-                toolPlan.Error.StatusCode,
-                toolPlan.Error.Code,
-                toolPlan.Error.Message);
-        }
-
-        var toolClassification = await toolClassificationService.ClassifyAsync(
-            normalized.DeclaredTools,
-            toolProviderContext,
-            toolPlan.AdditionalToolProviders,
-            ct: ct);
-
-        var modelRoute = ResponsesModelRouteParser.Parse(routedModel);
-        var effectiveModel = routedModel;
-        string? resolvedRouteValue = null;
-        if (modelRoute.RouteSlug is not null)
-        {
-            resolvedRouteValue = await routeResolver
-                .ResolveRouteValueAsync(modelRoute.RouteSlug, bearerToken, ct)
-                .ConfigureAwait(false);
-            if (resolvedRouteValue is not null)
-                effectiveModel = modelRoute.Model;
-        }
-
-        var llmMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            [LLMRequestMetadataKeys.RequestId] = normalized.CompletionId,
-            [ChannelMetadataKeys.RegistrationScopeId] = callerScope.ScopeId,
-        };
-        if (resolvedRouteValue is not null)
-            llmMetadata[LLMRequestMetadataKeys.NyxIdRoutePreference] = resolvedRouteValue;
-
-        var llmRequest = new LLMRequest
-        {
-            Messages = [.. normalized.ChatMessages],
-            RequestId = normalized.CompletionId,
-            Metadata = llmMetadata,
-            CallerContext = new LLMRequestCallerContext(
-                callerScope.ScopeId,
-                callerScope.OwnerSubject,
-                normalized.CompletionId,
-                new LLMRequestCallerCredentials(bearerToken)),
-            Tools = toolClassification.EffectiveTools,
-            Model = effectiveModel,
-            Temperature = normalized.Temperature,
-            MaxTokens = normalized.MaxTokens,
-            ResponseFormat = normalized.ResponseFormat,
-        };
-
-        if (normalized.Stream)
+        if (result.StreamPlan is not null)
         {
             await WriteStreamingChatCompletionAsync(
                 http.Response,
-                providerFactory,
-                completionService,
-                sessionRegistrationPort,
-                logger,
-                session,
-                llmRequest,
-                toolProviderContext.ToolContextMetadata,
-                normalized,
-                toolClassification,
-                toolPlan.ToolChoiceHintPlan,
-                createdAt,
+                commandFacade,
+                result.StreamPlan,
                 ct);
             return Results.Empty;
         }
 
-        try
+        if (result.Accepted is not null)
         {
-            var provider = providerFactory.GetDefault();
-            ResponsesCompletionResult completion;
-            using (ResponsesToolContext.Push(toolPlan.ToolChoiceHintPlan))
-            {
-                completion = await completionService.CollectAsync(
-                    provider,
-                    llmRequest,
-                    toolProviderContext.ToolContextMetadata,
-                    toolClassification,
-                    ct);
-            }
-            await TryUpdateSessionStatusAsync(sessionRegistrationPort, logger, session, LlmSessionStatus.Completed, ct);
             return Results.Json(
-                BuildCompletedChatCompletion(normalized, completion, createdAt.ToUnixTimeSeconds()),
+                BuildAcceptedChatCompletion(
+                    result.Accepted.Normalized,
+                    result.Accepted.CreatedAt),
                 JsonOptions,
                 statusCode: StatusCodes.Status200OK);
         }
-        catch (NyxIdAuthenticationRequiredException ex)
-        {
-            await TryUpdateSessionStatusAsync(sessionRegistrationPort, logger, session, LlmSessionStatus.Failed, CancellationToken.None);
-            return ToErrorResult(StatusCodes.Status401Unauthorized, "authentication_required", ex.Message);
-        }
-        catch (NyxIdUpstreamException ex)
-        {
-            await TryUpdateSessionStatusAsync(sessionRegistrationPort, logger, session, LlmSessionStatus.Failed, CancellationToken.None);
-            return ToErrorResult(ResolveUpstreamStatusCode(ex), ex.Kind.ToString().ToLowerInvariant(), ex.Message);
-        }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
-        {
-            await TryUpdateSessionStatusAsync(sessionRegistrationPort, logger, session, LlmSessionStatus.Cancelled, CancellationToken.None);
-            return Results.StatusCode(StatusCodes.Status499ClientClosedRequest);
-        }
-        catch (Exception ex)
-        {
-            await TryUpdateSessionStatusAsync(sessionRegistrationPort, logger, session, LlmSessionStatus.Failed, CancellationToken.None);
-            logger.LogError(ex, "Unexpected error processing /v1/chat/completions {CompletionId}", normalized.CompletionId);
-            return ToErrorResult(StatusCodes.Status500InternalServerError, "api_error", "Internal server error.");
-        }
-    }
 
-    private static string BuildRouteContentHint(NormalizedChatCompletionsRequest normalized) =>
-        normalized.ChatMessages
-            .LastOrDefault(static message => string.Equals(message.Role, "user", StringComparison.OrdinalIgnoreCase))
-            ?.Content
-        ?? normalized.ChatMessages.LastOrDefault()?.Content
-        ?? string.Empty;
+        throw new InvalidOperationException("Chat Completions command facade returned no result.");
+    }
 
     private static async Task WriteStreamingChatCompletionAsync(
         HttpResponse response,
-        ILLMProviderFactory providerFactory,
-        IResponsesCompletionApplicationService completionService,
-        ILlmSessionRegistrationPort sessionRegistrationPort,
-        ILogger logger,
-        LlmSessionRegistrationResult session,
-        LLMRequest llmRequest,
-        IReadOnlyDictionary<string, string> toolContextMetadata,
-        NormalizedChatCompletionsRequest normalized,
-        ResponsesToolClassification toolClassification,
-        ResponsesToolChoiceHintPlan toolChoiceHintPlan,
-        DateTimeOffset createdAt,
+        IChatCompletionsCommandFacade commandFacade,
+        ChatCompletionsCreateCommandPlan plan,
         CancellationToken ct)
     {
+        var normalized = plan.Normalized;
+        var createdAt = plan.CreatedAt.ToUnixTimeSeconds();
         response.StatusCode = StatusCodes.Status200OK;
         response.ContentType = "text/event-stream; charset=utf-8";
         response.Headers.CacheControl = "no-store";
@@ -290,98 +91,55 @@ internal static class ChatCompletionsApiEndpoints
         response.Headers["X-Accel-Buffering"] = "no";
         await response.StartAsync(ct);
 
-        try
-        {
-            var provider = providerFactory.GetDefault();
-            ResponsesCompletionResult completion;
-            using (ResponsesToolContext.Push(toolChoiceHintPlan))
+        var completion = await commandFacade.StreamAsync(
+            plan,
+            async (delta, token) =>
             {
-                completion = await completionService.StreamAsync(
-                    provider,
-                    llmRequest,
-                    toolContextMetadata,
-                    toolClassification,
-                    async (delta, token) =>
-                    {
-                        if (string.IsNullOrEmpty(delta))
-                            return;
+                if (string.IsNullOrEmpty(delta))
+                    return;
 
-                        await WriteDataFrameAsync(
-                            response,
-                            BuildStreamingTextChunk(normalized, createdAt.ToUnixTimeSeconds(), delta),
-                            token);
-                    },
-                    ct);
-            }
-
-            foreach (var toolCall in completion.ForwardedToolCalls)
-            {
                 await WriteDataFrameAsync(
                     response,
-                    BuildStreamingToolCallChunk(normalized, createdAt.ToUnixTimeSeconds(), toolCall),
-                    ct);
-            }
+                    BuildStreamingTextChunk(normalized, createdAt, delta),
+                    token);
+            },
+            ct);
 
+        if (completion.Error is not null)
+        {
             await WriteDataFrameAsync(
                 response,
-                BuildStreamingStopChunk(
-                    normalized,
-                    createdAt.ToUnixTimeSeconds(),
-                    completion.ForwardedToolCalls.Count > 0 ? "tool_calls" : "stop"),
-                ct);
+                BuildStreamingError(completion.Error.Code, completion.Error.Message),
+                CancellationToken.None);
+            await WriteDoneFrameAsync(response, CancellationToken.None);
+            return;
+        }
 
-            if (normalized.IncludeUsageInStream && completion.Usage is not null)
+        if (completion.Accepted is not null)
+        {
+            await WriteDataFrameAsync(
+                response,
+                BuildStreamingStopChunk(normalized, createdAt, finishReason: null),
+                CancellationToken.None);
+            if (normalized.IncludeUsageInStream)
             {
                 await WriteDataFrameAsync(
                     response,
-                    BuildStreamingUsageChunk(normalized, createdAt.ToUnixTimeSeconds(), completion.Usage),
-                    ct);
+                    BuildStreamingUsageChunk(normalized, createdAt, usage: null),
+                    CancellationToken.None);
             }
 
-            await WriteDoneFrameAsync(response, ct);
-            await TryUpdateSessionStatusAsync(sessionRegistrationPort, logger, session, LlmSessionStatus.Completed, ct);
-        }
-        catch (NyxIdAuthenticationRequiredException ex)
-        {
-            await TryUpdateSessionStatusAsync(sessionRegistrationPort, logger, session, LlmSessionStatus.Failed, CancellationToken.None);
-            await WriteDataFrameAsync(response, BuildStreamingError("authentication_required", ex.Message), CancellationToken.None);
             await WriteDoneFrameAsync(response, CancellationToken.None);
+            return;
         }
-        catch (NyxIdUpstreamException ex)
-        {
-            await TryUpdateSessionStatusAsync(sessionRegistrationPort, logger, session, LlmSessionStatus.Failed, CancellationToken.None);
-            await WriteDataFrameAsync(response, BuildStreamingError(ex.Kind.ToString().ToLowerInvariant(), ex.Message), CancellationToken.None);
-            await WriteDoneFrameAsync(response, CancellationToken.None);
-        }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
-        {
-            await TryUpdateSessionStatusAsync(sessionRegistrationPort, logger, session, LlmSessionStatus.Cancelled, CancellationToken.None);
-        }
-        catch (Exception ex)
-        {
-            await TryUpdateSessionStatusAsync(sessionRegistrationPort, logger, session, LlmSessionStatus.Failed, CancellationToken.None);
-            logger.LogError(ex, "Streaming /v1/chat/completions {CompletionId} failed", normalized.CompletionId);
-            await WriteDataFrameAsync(response, BuildStreamingError("api_error", "Internal server error."), CancellationToken.None);
-            await WriteDoneFrameAsync(response, CancellationToken.None);
-        }
+
+        throw new InvalidOperationException("Chat Completions stream facade returned no result.");
     }
 
-    private static object BuildCompletedChatCompletion(
-        NormalizedChatCompletionsRequest normalized,
-        ResponsesCompletionResult completion,
-        long createdAt)
-    {
-        var message = new Dictionary<string, object?>(StringComparer.Ordinal)
-        {
-            ["role"] = "assistant",
-            ["content"] = completion.ForwardedToolCalls.Count > 0 && string.IsNullOrEmpty(completion.Text)
-                ? null
-                : completion.Text,
-        };
-        if (completion.ForwardedToolCalls.Count > 0)
-            message["tool_calls"] = completion.ForwardedToolCalls.Select(MapToolCall).ToArray();
-
-        return new
+    private static object BuildAcceptedChatCompletion(
+        NormalizedChatCompletionsCommand normalized,
+        long createdAt) =>
+        new
         {
             id = normalized.CompletionId,
             @object = "chat.completion",
@@ -392,16 +150,19 @@ internal static class ChatCompletionsApiEndpoints
                 new
                 {
                     index = 0,
-                    message,
-                    finish_reason = completion.ForwardedToolCalls.Count > 0 ? "tool_calls" : "stop",
+                    message = new
+                    {
+                        role = "assistant",
+                        content = (string?)null,
+                    },
+                    finish_reason = (string?)null,
                 },
             },
-            usage = MapUsage(completion.Usage),
+            usage = (object?)null,
         };
-    }
 
     private static object BuildStreamingTextChunk(
-        NormalizedChatCompletionsRequest normalized,
+        NormalizedChatCompletionsCommand normalized,
         long createdAt,
         string delta) =>
         new
@@ -421,49 +182,10 @@ internal static class ChatCompletionsApiEndpoints
             },
         };
 
-    private static object BuildStreamingToolCallChunk(
-        NormalizedChatCompletionsRequest normalized,
-        long createdAt,
-        ToolCall toolCall) =>
-        new
-        {
-            id = normalized.CompletionId,
-            @object = "chat.completion.chunk",
-            created = createdAt,
-            model = normalized.Model,
-            choices = new[]
-            {
-                new
-                {
-                    index = 0,
-                    delta = new
-                    {
-                        tool_calls = new[]
-                        {
-                            new
-                            {
-                                index = 0,
-                                id = toolCall.Id,
-                                type = "function",
-                                function = new
-                                {
-                                    name = toolCall.Name,
-                                    arguments = string.IsNullOrWhiteSpace(toolCall.ArgumentsJson)
-                                        ? "{}"
-                                        : toolCall.ArgumentsJson,
-                                },
-                            },
-                        },
-                    },
-                    finish_reason = (string?)null,
-                },
-            },
-        };
-
     private static object BuildStreamingStopChunk(
-        NormalizedChatCompletionsRequest normalized,
+        NormalizedChatCompletionsCommand normalized,
         long createdAt,
-        string finishReason) =>
+        string? finishReason) =>
         new
         {
             id = normalized.CompletionId,
@@ -482,9 +204,9 @@ internal static class ChatCompletionsApiEndpoints
         };
 
     private static object BuildStreamingUsageChunk(
-        NormalizedChatCompletionsRequest normalized,
+        NormalizedChatCompletionsCommand normalized,
         long createdAt,
-        TokenUsage usage) =>
+        TokenUsage? usage) =>
         new
         {
             id = normalized.CompletionId,
@@ -507,20 +229,6 @@ internal static class ChatCompletionsApiEndpoints
             },
         };
 
-    private static object MapToolCall(ToolCall toolCall) =>
-        new
-        {
-            id = toolCall.Id,
-            type = "function",
-            function = new
-            {
-                name = toolCall.Name,
-                arguments = string.IsNullOrWhiteSpace(toolCall.ArgumentsJson)
-                    ? "{}"
-                    : toolCall.ArgumentsJson,
-            },
-        };
-
     private static object? MapUsage(TokenUsage? usage) =>
         usage is null
             ? null
@@ -530,52 +238,6 @@ internal static class ChatCompletionsApiEndpoints
                 completion_tokens = usage.CompletionTokens,
                 total_tokens = usage.TotalTokens,
             };
-
-    private static LlmSessionRecord BuildSessionRecord(
-        NormalizedChatCompletionsRequest normalized,
-        ResponsesCallerScope callerScope,
-        DateTimeOffset createdAt) =>
-        new()
-        {
-            ResponseId = normalized.CompletionId,
-            ScopeId = callerScope.ScopeId,
-            OwnerSubject = callerScope.OwnerSubject,
-            OriginKind = callerScope.OriginKind,
-            PreviousResponseId = string.Empty,
-            Status = LlmSessionStatus.Accepted,
-            CreatedAt = Timestamp.FromDateTime(createdAt.UtcDateTime),
-            UpdatedAt = Timestamp.FromDateTime(createdAt.UtcDateTime),
-            Ttl = Duration.FromTimeSpan(TimeSpan.FromHours(24)),
-        };
-
-    private static async Task TryUpdateSessionStatusAsync(
-        ILlmSessionRegistrationPort port,
-        ILogger logger,
-        LlmSessionRegistrationResult session,
-        LlmSessionStatus status,
-        CancellationToken ct)
-    {
-        try
-        {
-            await port.UpdateStatusAsync(session.ActorId, session.ResponseId, status, ct);
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Failed to update llm session {ResponseId} to {Status}", session.ResponseId, status);
-        }
-    }
-
-    private static int ResolveUpstreamStatusCode(NyxIdUpstreamException ex) =>
-        ex.Status switch
-        {
-            400 => StatusCodes.Status400BadRequest,
-            401 => StatusCodes.Status401Unauthorized,
-            403 => StatusCodes.Status403Forbidden,
-            404 => StatusCodes.Status404NotFound,
-            429 => StatusCodes.Status429TooManyRequests,
-            >= 500 => StatusCodes.Status502BadGateway,
-            _ => StatusCodes.Status502BadGateway,
-        };
 
     private static async Task WriteDataFrameAsync(
         HttpResponse response,

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -139,6 +139,7 @@ public static class MainnetHostBuilderExtensions
         builder.Services.TryAddSingleton<IResponsesChatRouteDecisionPort, ResponsesChatRouteDecisionPort>();
         builder.Services.TryAddSingleton<IResponsesCommandFacade, ResponsesCommandFacade>();
         builder.Services.TryAddSingleton<IMessagesCommandFacade, MessagesCommandFacade>();
+        builder.Services.TryAddSingleton<IChatCompletionsCommandFacade, ChatCompletionsCommandFacade>();
         builder.Services.TryAddSingleton<IResponsesWebSubstituteBackend, ResponsesWebSubstituteBackendAdapter>();
         builder.Services.TryAddSingleton<ResponsesWebSubstituteToolExecutionService>();
         builder.Services.TryAddSingleton<IResponsesToolClassificationService, ResponsesToolClassificationService>();

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ChatCompletionsCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ChatCompletionsCommandFacade.cs
@@ -88,11 +88,9 @@ public sealed class ChatCompletionsCommandFacade(
 
     public async Task<ResponsesStreamCommandResult> StreamAsync(
         ChatCompletionsCreateCommandPlan plan,
-        Func<string, CancellationToken, ValueTask> onTextDelta,
         CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(plan);
-        ArgumentNullException.ThrowIfNull(onTextDelta);
 
         try
         {
@@ -145,7 +143,8 @@ public sealed class ChatCompletionsCommandFacade(
             request.Temperature,
             request.MaxTokens,
             request.ChatMessages,
-            request.DeclaredTools));
+            request.DeclaredTools,
+            request.ResponseFormat));
     }
 
     private async Task<CallerScopeResult> ResolveCallerScopeAsync(
@@ -350,6 +349,7 @@ public sealed class ChatCompletionsCommandFacade(
             Model = effectiveModel,
             Temperature = normalized.Temperature,
             MaxTokens = normalized.MaxTokens,
+            ResponseFormat = normalized.ResponseFormat,
         };
     }
 

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ChatCompletionsCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ChatCompletionsCommandFacade.cs
@@ -120,6 +120,9 @@ public sealed class ChatCompletionsCommandFacade(
         }
     }
 
+    // Refactor (iter344/cluster-001):
+    //   Old pattern: /v1/chat/completions validated model and generation controls inside the Host request stack.
+    //   New principle: Application owns command normalization before caller, routing, session, and dispatch work starts.
     private static ChatCompletionsRequestNormalizationResult Normalize(ChatCompletionsCommandRequest request)
     {
         var model = request.Model?.Trim();
@@ -147,6 +150,9 @@ public sealed class ChatCompletionsCommandFacade(
             request.ResponseFormat));
     }
 
+    // Refactor (iter344/cluster-001):
+    //   Old pattern: Host converted inbound bearer evidence into caller scope while also preparing LLM execution.
+    //   New principle: Caller-scope resolution is an Application command step with a typed protocol error boundary.
     private async Task<CallerScopeResult> ResolveCallerScopeAsync(
         ResponsesCallerScopeResolutionContext callerScopeContext,
         CancellationToken ct)
@@ -162,6 +168,9 @@ public sealed class ChatCompletionsCommandFacade(
         }
     }
 
+    // Refactor (iter344/cluster-001):
+    //   Old pattern: Host queried route policy and rewrote the model inline before opening a session.
+    //   New principle: Application resolves the command target and returns either a routed model/action or a typed rejection.
     private async Task<RouteTargetResult> ResolveRouteTargetAsync(
         NormalizedChatCompletionsCommand normalized,
         ResponsesCallerScope callerScope,
@@ -195,6 +204,9 @@ public sealed class ChatCompletionsCommandFacade(
         return RouteTargetResult.FromModel(routedModel, action);
     }
 
+    // Refactor (iter344/cluster-001):
+    //   Old pattern: Host registered Chat Completions sessions as part of direct request-local provider execution.
+    //   New principle: Application registers the actor-owned session before dispatch and reports only the reached command stage.
     private async Task<SessionRegistrationResult> RegisterSessionAsync(
         NormalizedChatCompletionsCommand normalized,
         ResponsesCallerScope callerScope,
@@ -219,6 +231,9 @@ public sealed class ChatCompletionsCommandFacade(
         }
     }
 
+    // Refactor (iter344/cluster-001):
+    //   Old pattern: Host assembled tool provider context, route preference, and LLM request just before direct provider calls.
+    //   New principle: Application builds one dispatch plan that carries typed run input into LlmSessionGAgent.
     private async Task<ExecutionPlanResult> BuildExecutionPlanAsync(
         NormalizedChatCompletionsCommand normalized,
         ResponsesCallerScope callerScope,
@@ -257,6 +272,9 @@ public sealed class ChatCompletionsCommandFacade(
             createdAt));
     }
 
+    // Refactor (iter344/cluster-001):
+    //   Old pattern: Non-streaming Chat Completions synchronously collected provider output in the HTTP request handler.
+    //   New principle: Non-streaming compatibility returns an honest accepted dispatch receipt for the actor run.
     private async Task<ChatCompletionsCreateCommandResult> ExecuteNonStreamingAsync(
         ChatCompletionsCreateCommandPlan plan,
         CancellationToken ct)
@@ -293,6 +311,9 @@ public sealed class ChatCompletionsCommandFacade(
         }
     }
 
+    // Refactor (iter344/cluster-001):
+    //   Old pattern: Host parsed catalog route slugs while constructing provider metadata.
+    //   New principle: Application resolves model-route command context behind the route resolver port.
     private async Task<(string EffectiveModel, string? ResolvedRouteValue)> ResolveModelRouteAsync(
         string routedModel,
         string bearerToken,
@@ -313,6 +334,9 @@ public sealed class ChatCompletionsCommandFacade(
         return (effectiveModel, resolvedRouteValue);
     }
 
+    // Refactor (iter344/cluster-001):
+    //   Old pattern: Host produced provider request objects as the final step before local LLM execution.
+    //   New principle: Application produces typed actor-run input while Host remains an external protocol mapper.
     private static LLMRequest BuildLlmRequest(
         NormalizedChatCompletionsCommand normalized,
         ResponsesCallerScope callerScope,
@@ -352,6 +376,9 @@ public sealed class ChatCompletionsCommandFacade(
         };
     }
 
+    // Refactor (iter344/cluster-001):
+    //   Old pattern: Host mixed NyxID bearer passthrough and tool-context metadata with endpoint control flow.
+    //   New principle: Application builds tool-provider context as part of command context construction.
     private static ResponsesToolProviderContext BuildToolProviderContext(
         ResponsesCallerScope callerScope,
         string responseId,
@@ -378,6 +405,9 @@ public sealed class ChatCompletionsCommandFacade(
         ?? normalized.ChatMessages.LastOrDefault()?.Content
         ?? string.Empty;
 
+    // Refactor (iter344/cluster-001):
+    //   Old pattern: Host populated session records from endpoint locals.
+    //   New principle: Application derives the authoritative session record from normalized command state and caller scope.
     private static LlmSessionRecord BuildSessionRecord(
         NormalizedChatCompletionsCommand normalized,
         ResponsesCallerScope callerScope,
@@ -395,6 +425,9 @@ public sealed class ChatCompletionsCommandFacade(
             Ttl = Duration.FromTimeSpan(TimeSpan.FromHours(24)),
         };
 
+    // Refactor (iter344/cluster-001):
+    //   Old pattern: Host updated session failure status around direct provider exceptions.
+    //   New principle: Application owns command failure accounting after dispatch attempts.
     private async Task TryUpdateSessionStatusAsync(
         LlmSessionRegistrationResult session,
         LlmSessionStatus status,
@@ -410,6 +443,9 @@ public sealed class ChatCompletionsCommandFacade(
         }
     }
 
+    // Refactor (iter344/cluster-001):
+    //   Old pattern: Host executed the LLM loop directly and returned completed output from request-local state.
+    //   New principle: Application dispatches a typed run command through IActorDispatchPort and returns the admission.
     private Task<DispatchAdmission> DispatchRunAsync(
         ChatCompletionsCreateCommandPlan plan,
         CancellationToken ct)
@@ -427,6 +463,9 @@ public sealed class ChatCompletionsCommandFacade(
         return dispatchPort.DispatchAsync(plan.Session.ActorId, envelope, ct);
     }
 
+    // Refactor (iter344/cluster-001):
+    //   Old pattern: Chat Completions had no typed actor command payload for its direct LLM loop.
+    //   New principle: The facade maps the compatibility request into the shared LlmRunRequested contract.
     private static LlmRunRequested BuildRunRequested(
         string responseId,
         LLMRequest request,

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ChatCompletionsCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ChatCompletionsCommandFacade.cs
@@ -252,7 +252,6 @@ public sealed class ChatCompletionsCommandFacade(
             normalized,
             session,
             llmRequest,
-            toolProviderContext.ToolContextMetadata,
             toolClassification,
             toolPlan.ToolChoiceHintPlan,
             createdAt));

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ChatCompletionsCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ChatCompletionsCommandFacade.cs
@@ -1,0 +1,552 @@
+using System.Security.Cryptography;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgentService.Application.Internal;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.Responses;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.GAgentService.Application.Responses;
+
+// Refactor (iter344/cluster-001):
+//   Old pattern: Host handler owns caller resolution, route resolution, session registration, tool planning, direct provider execution, status updates, and protocol rendering in one request stack.
+//   New principle: Host maps HTTP/OpenAI frames only; typed Application facade owns Normalize -> Resolve Target -> Build Context -> Build Envelope -> Dispatch -> Receipt/Observe via the same LlmSessionGAgent run path as Responses/Messages.
+public sealed class ChatCompletionsCommandFacade(
+    IResponsesCallerScopeResolver callerScopeResolver,
+    IResponsesChatRouteDecisionPort chatRouteDecisionPort,
+    IResponsesRouteResolver routeResolver,
+    ILlmSessionRegistrationPort sessionRegistrationPort,
+    IActorDispatchPort dispatchPort,
+    IResponsesToolClassificationService toolClassificationService,
+    IResponsesDirectToolPlanService directToolPlanService,
+    ILogger<ChatCompletionsCommandFacade> logger) : IChatCompletionsCommandFacade
+{
+    private const string RegistrationScopeMetadataKey = "scope_id";
+
+    public async Task<ChatCompletionsCreateCommandResult> CreateAsync(
+        ChatCompletionsCommandRequest request,
+        ResponsesCallerScopeResolutionContext callerScopeContext,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(callerScopeContext);
+
+        var normalizedResult = Normalize(request);
+        if (!normalizedResult.Succeeded)
+        {
+            return ChatCompletionsCreateCommandResult.FromError(
+                400,
+                normalizedResult.ErrorCode ?? "invalid_request_error",
+                normalizedResult.ErrorMessage ?? "Invalid request.");
+        }
+
+        var normalized = normalizedResult.Request!;
+        var callerScopeResult = await ResolveCallerScopeAsync(callerScopeContext, ct);
+        if (callerScopeResult.Error is not null)
+            return ChatCompletionsCreateCommandResult.FromError(
+                callerScopeResult.Error.StatusCode,
+                callerScopeResult.Error.Code,
+                callerScopeResult.Error.Message);
+
+        var routedModelResult = await ResolveRouteTargetAsync(normalized, callerScopeResult.Scope!, ct);
+        if (routedModelResult.Error is not null)
+            return ChatCompletionsCreateCommandResult.FromError(
+                routedModelResult.Error.StatusCode,
+                routedModelResult.Error.Code,
+                routedModelResult.Error.Message);
+
+        var createdAt = DateTimeOffset.UtcNow;
+        var sessionResult = await RegisterSessionAsync(normalized, callerScopeResult.Scope!, createdAt, ct);
+        if (sessionResult.Error is not null)
+            return ChatCompletionsCreateCommandResult.FromError(
+                sessionResult.Error.StatusCode,
+                sessionResult.Error.Code,
+                sessionResult.Error.Message);
+
+        var planResult = await BuildExecutionPlanAsync(
+            normalized,
+            callerScopeResult.Scope!,
+            routedModelResult.Model!,
+            routedModelResult.Action!,
+            callerScopeContext.InboundBearerToken,
+            sessionResult.Session!,
+            createdAt,
+            ct);
+        if (planResult.Error is not null)
+            return ChatCompletionsCreateCommandResult.FromError(
+                planResult.Error.StatusCode,
+                planResult.Error.Code,
+                planResult.Error.Message);
+
+        return normalized.Stream
+            ? ChatCompletionsCreateCommandResult.FromStreamPlan(planResult.Plan!)
+            : await ExecuteNonStreamingAsync(planResult.Plan!, ct);
+    }
+
+    public async Task<ResponsesStreamCommandResult> StreamAsync(
+        ChatCompletionsCreateCommandPlan plan,
+        Func<string, CancellationToken, ValueTask> onTextDelta,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(onTextDelta);
+
+        try
+        {
+            var admission = await DispatchRunAsync(plan, ct);
+            return ResponsesStreamCommandResult.FromAccepted(new ResponsesStreamAcceptedCommandResult(admission));
+        }
+        catch (NyxIdAuthenticationRequiredException ex)
+        {
+            await TryUpdateSessionStatusAsync(plan.Session, LlmSessionStatus.Failed, CancellationToken.None);
+            return ResponsesStreamCommandResult.FromError(401, "authentication_required", ex.Message);
+        }
+        catch (NyxIdUpstreamException ex)
+        {
+            await TryUpdateSessionStatusAsync(plan.Session, LlmSessionStatus.Failed, CancellationToken.None);
+            return ResponsesStreamCommandResult.FromError(ResolveUpstreamStatusCode(ex), ex.Kind.ToString().ToLowerInvariant(), ex.Message);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            await TryUpdateSessionStatusAsync(plan.Session, LlmSessionStatus.Cancelled, CancellationToken.None);
+            return ResponsesStreamCommandResult.FromError(499, "client_closed_request", "Client closed request.");
+        }
+        catch (Exception ex)
+        {
+            await TryUpdateSessionStatusAsync(plan.Session, LlmSessionStatus.Failed, CancellationToken.None);
+            logger.LogError(ex, "Streaming /v1/chat/completions {CompletionId} failed", plan.Normalized.CompletionId);
+            return ResponsesStreamCommandResult.FromError(500, "api_error", "Internal server error.");
+        }
+    }
+
+    private static ChatCompletionsRequestNormalizationResult Normalize(ChatCompletionsCommandRequest request)
+    {
+        var model = request.Model?.Trim();
+        if (string.IsNullOrWhiteSpace(model))
+            return ChatCompletionsRequestNormalizationResult.Failed("model_required", "model is required.");
+
+        if (request.MaxTokens is <= 0)
+            return ChatCompletionsRequestNormalizationResult.Failed("invalid_max_tokens", "max_tokens must be greater than zero when provided.");
+
+        if (request.Temperature is < 0 or > 2)
+            return ChatCompletionsRequestNormalizationResult.Failed("invalid_temperature", "temperature must be between 0 and 2.");
+
+        if (request.ChatMessages.Count == 0)
+            return ChatCompletionsRequestNormalizationResult.Failed("invalid_messages", "messages must contain at least one entry.");
+
+        return ChatCompletionsRequestNormalizationResult.Success(new NormalizedChatCompletionsCommand(
+            "chatcmpl_" + NewOpaqueId(),
+            model,
+            request.Stream == true,
+            request.IncludeUsageInStream,
+            request.Temperature,
+            request.MaxTokens,
+            request.ChatMessages,
+            request.DeclaredTools));
+    }
+
+    private async Task<CallerScopeResult> ResolveCallerScopeAsync(
+        ResponsesCallerScopeResolutionContext callerScopeContext,
+        CancellationToken ct)
+    {
+        try
+        {
+            var callerScope = await callerScopeResolver.ResolveAsync(callerScopeContext, ct);
+            return new CallerScopeResult(callerScope, null);
+        }
+        catch (ResponsesCallerScopeUnavailableException ex)
+        {
+            return new CallerScopeResult(null, new ResponsesCommandError(401, "authentication_required", ex.Message));
+        }
+    }
+
+    private async Task<RouteTargetResult> ResolveRouteTargetAsync(
+        NormalizedChatCompletionsCommand normalized,
+        ResponsesCallerScope callerScope,
+        CancellationToken ct)
+    {
+        var routeDecision = await chatRouteDecisionPort.ResolveAsync(
+            callerScope,
+            normalized.Model,
+            normalized.DeclaredTools.Count > 0 ? ToolMode.Declared : ToolMode.None,
+            BuildRouteContentHint(normalized),
+            ct);
+
+        if (routeDecision.Action.Reject is not null)
+        {
+            return RouteTargetResult.FromError(
+                403,
+                "chat_route_rejected",
+                string.IsNullOrWhiteSpace(routeDecision.Action.Reject.Reason)
+                    ? "The chat route policy rejected this request."
+                    : routeDecision.Action.Reject.Reason);
+        }
+
+        var action = routeDecision.Action.Clone();
+        var routedModel = !string.IsNullOrWhiteSpace(action.ForwardToModel?.ModelName)
+            ? action.ForwardToModel.ModelName.Trim()
+            : normalized.Model;
+        if (action.ForwardToModel is null)
+            action.ForwardToModel = new ForwardToModel();
+
+        action.ForwardToModel.ModelName = routedModel;
+        return RouteTargetResult.FromModel(routedModel, action);
+    }
+
+    private async Task<SessionRegistrationResult> RegisterSessionAsync(
+        NormalizedChatCompletionsCommand normalized,
+        ResponsesCallerScope callerScope,
+        DateTimeOffset createdAt,
+        CancellationToken ct)
+    {
+        try
+        {
+            var session = await sessionRegistrationPort.RegisterAsync(
+                BuildSessionRecord(normalized, callerScope, createdAt),
+                ct);
+            return new SessionRegistrationResult(session, null);
+        }
+        catch (OperationCanceledException)
+        {
+            return new SessionRegistrationResult(null, new ResponsesCommandError(408, "request_timeout", "Request timed out."));
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogError(ex, "Failed to register llm session for chat completion {CompletionId}", normalized.CompletionId);
+            return new SessionRegistrationResult(null, new ResponsesCommandError(500, "api_error", "Failed to register session."));
+        }
+    }
+
+    private async Task<ExecutionPlanResult> BuildExecutionPlanAsync(
+        NormalizedChatCompletionsCommand normalized,
+        ResponsesCallerScope callerScope,
+        string routedModel,
+        ChatRouteAction routeAction,
+        string bearerToken,
+        LlmSessionRegistrationResult session,
+        DateTimeOffset createdAt,
+        CancellationToken ct)
+    {
+        var toolProviderContext = BuildToolProviderContext(callerScope, normalized.CompletionId, bearerToken);
+        var toolPlan = directToolPlanService.Build(routeAction);
+        if (toolPlan.Error is not null)
+            return ExecutionPlanResult.FromError(toolPlan.Error);
+
+        var toolClassification = await toolClassificationService.ClassifyAsync(
+            normalized.DeclaredTools,
+            toolProviderContext,
+            toolPlan.AdditionalToolProviders,
+            ct: ct);
+        var (effectiveModel, resolvedRouteValue) = await ResolveModelRouteAsync(routedModel, bearerToken, ct);
+        var llmRequest = BuildLlmRequest(
+            normalized,
+            callerScope,
+            bearerToken,
+            effectiveModel,
+            resolvedRouteValue,
+            toolClassification);
+
+        return ExecutionPlanResult.FromPlan(new ChatCompletionsCreateCommandPlan(
+            normalized,
+            session,
+            llmRequest,
+            toolProviderContext.ToolContextMetadata,
+            toolClassification,
+            toolPlan.ToolChoiceHintPlan,
+            createdAt));
+    }
+
+    private async Task<ChatCompletionsCreateCommandResult> ExecuteNonStreamingAsync(
+        ChatCompletionsCreateCommandPlan plan,
+        CancellationToken ct)
+    {
+        try
+        {
+            var admission = await DispatchRunAsync(plan, ct);
+            return ChatCompletionsCreateCommandResult.FromAccepted(new ChatCompletionsCreateAcceptedCommandResult(
+                plan.Normalized,
+                plan.CreatedAt.ToUnixTimeSeconds(),
+                plan.Session,
+                admission));
+        }
+        catch (NyxIdAuthenticationRequiredException ex)
+        {
+            await TryUpdateSessionStatusAsync(plan.Session, LlmSessionStatus.Failed, CancellationToken.None);
+            return ChatCompletionsCreateCommandResult.FromError(401, "authentication_required", ex.Message);
+        }
+        catch (NyxIdUpstreamException ex)
+        {
+            await TryUpdateSessionStatusAsync(plan.Session, LlmSessionStatus.Failed, CancellationToken.None);
+            return ChatCompletionsCreateCommandResult.FromError(ResolveUpstreamStatusCode(ex), ex.Kind.ToString().ToLowerInvariant(), ex.Message);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            await TryUpdateSessionStatusAsync(plan.Session, LlmSessionStatus.Cancelled, CancellationToken.None);
+            return ChatCompletionsCreateCommandResult.FromError(499, "client_closed_request", "Client closed request.");
+        }
+        catch (Exception ex)
+        {
+            await TryUpdateSessionStatusAsync(plan.Session, LlmSessionStatus.Failed, CancellationToken.None);
+            logger.LogError(ex, "Unexpected error processing /v1/chat/completions {CompletionId}", plan.Normalized.CompletionId);
+            return ChatCompletionsCreateCommandResult.FromError(500, "api_error", "Internal server error.");
+        }
+    }
+
+    private async Task<(string EffectiveModel, string? ResolvedRouteValue)> ResolveModelRouteAsync(
+        string routedModel,
+        string bearerToken,
+        CancellationToken ct)
+    {
+        var modelRoute = ResponsesModelRouteParser.Parse(routedModel);
+        var effectiveModel = routedModel;
+        string? resolvedRouteValue = null;
+        if (modelRoute.RouteSlug is not null)
+        {
+            resolvedRouteValue = await routeResolver
+                .ResolveRouteValueAsync(modelRoute.RouteSlug, bearerToken, ct)
+                .ConfigureAwait(false);
+            if (resolvedRouteValue is not null)
+                effectiveModel = modelRoute.Model;
+        }
+
+        return (effectiveModel, resolvedRouteValue);
+    }
+
+    private static LLMRequest BuildLlmRequest(
+        NormalizedChatCompletionsCommand normalized,
+        ResponsesCallerScope callerScope,
+        string bearerToken,
+        string effectiveModel,
+        string? resolvedRouteValue,
+        ResponsesToolClassification toolClassification)
+    {
+        var llmMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [LLMRequestMetadataKeys.RequestId] = normalized.CompletionId,
+            [RegistrationScopeMetadataKey] = callerScope.ScopeId,
+        };
+        return new LLMRequest
+        {
+            Messages = [.. normalized.ChatMessages],
+            RequestId = normalized.CompletionId,
+            Metadata = llmMetadata,
+            CallerContext = new LLMRequestCallerContext(
+                callerScope.ScopeId,
+                callerScope.OwnerSubject,
+                normalized.CompletionId,
+                new LLMRequestCallerCredentials(bearerToken)),
+            Tools = toolClassification.EffectiveTools,
+            LlmControl = new LLMControlContext(
+                NyxIdAccessToken: null,
+                NyxIdOrgToken: null,
+                SenderNyxIdAccessToken: null,
+                ModelOverride: null,
+                NyxIdRoutePreference: resolvedRouteValue,
+                MaxToolRoundsOverride: null,
+                UserMemoryPrompt: null),
+            Model = effectiveModel,
+            Temperature = normalized.Temperature,
+            MaxTokens = normalized.MaxTokens,
+        };
+    }
+
+    private static ResponsesToolProviderContext BuildToolProviderContext(
+        ResponsesCallerScope callerScope,
+        string responseId,
+        string bearerToken) =>
+        new(
+            new ResponsesToolProviderCallerScope(
+                callerScope.ScopeId,
+                callerScope.OwnerSubject,
+                callerScope.OriginKind.ToString()),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [LLMRequestMetadataKeys.RequestId] = responseId,
+                [LLMRequestMetadataKeys.ResponseId] = responseId,
+                [LLMRequestMetadataKeys.ScopeId] = callerScope.ScopeId,
+                [LLMRequestMetadataKeys.OwnerSubject] = callerScope.OwnerSubject,
+                [RegistrationScopeMetadataKey] = callerScope.ScopeId,
+                [LLMRequestMetadataKeys.NyxIdAccessToken] = bearerToken,
+            });
+
+    private static string BuildRouteContentHint(NormalizedChatCompletionsCommand normalized) =>
+        normalized.ChatMessages
+            .LastOrDefault(static message => string.Equals(message.Role, "user", StringComparison.OrdinalIgnoreCase))
+            ?.Content
+        ?? normalized.ChatMessages.LastOrDefault()?.Content
+        ?? string.Empty;
+
+    private static LlmSessionRecord BuildSessionRecord(
+        NormalizedChatCompletionsCommand normalized,
+        ResponsesCallerScope callerScope,
+        DateTimeOffset createdAt) =>
+        new()
+        {
+            ResponseId = normalized.CompletionId,
+            ScopeId = callerScope.ScopeId,
+            OwnerSubject = callerScope.OwnerSubject,
+            OriginKind = callerScope.OriginKind,
+            PreviousResponseId = string.Empty,
+            Status = LlmSessionStatus.Accepted,
+            CreatedAt = Timestamp.FromDateTime(createdAt.UtcDateTime),
+            UpdatedAt = Timestamp.FromDateTime(createdAt.UtcDateTime),
+            Ttl = Duration.FromTimeSpan(TimeSpan.FromHours(24)),
+        };
+
+    private async Task TryUpdateSessionStatusAsync(
+        LlmSessionRegistrationResult session,
+        LlmSessionStatus status,
+        CancellationToken ct)
+    {
+        try
+        {
+            await sessionRegistrationPort.UpdateStatusAsync(session.ActorId, session.ResponseId, status, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to update llm session {ResponseId} to {Status}", session.ResponseId, status);
+        }
+    }
+
+    private Task<DispatchAdmission> DispatchRunAsync(
+        ChatCompletionsCreateCommandPlan plan,
+        CancellationToken ct)
+    {
+        var command = BuildRunRequested(
+            plan.Session.ResponseId,
+            plan.LlmRequest,
+            plan.ToolClassification,
+            plan.ToolChoiceHintPlan,
+            plan.CreatedAt);
+        var envelope = ServiceCommandEnvelopeFactory.Create(
+            plan.Session.ActorId,
+            command,
+            command.RunId);
+        return dispatchPort.DispatchAsync(plan.Session.ActorId, envelope, ct);
+    }
+
+    private static LlmRunRequested BuildRunRequested(
+        string responseId,
+        LLMRequest request,
+        ResponsesToolClassification toolClassification,
+        ResponsesToolChoiceHintPlan toolChoiceHintPlan,
+        DateTimeOffset requestedAt)
+    {
+        var command = new LlmRunRequested
+        {
+            ResponseId = responseId,
+            RunId = $"{responseId}:llm-run",
+            Model = request.Model ?? string.Empty,
+            RoutePreference = request.LlmControl?.NyxIdRoutePreference ?? string.Empty,
+            ScopeId = request.CallerContext?.ScopeId ?? string.Empty,
+            OwnerSubject = request.CallerContext?.OwnerSubject ?? string.Empty,
+            BearerToken = request.CallerContext?.Credentials?.NyxIdBearer ?? string.Empty,
+            RequestedAt = Timestamp.FromDateTimeOffset(requestedAt),
+        };
+        if (request.Temperature is not null)
+            command.Temperature = request.Temperature.Value;
+        if (request.MaxTokens is not null)
+            command.MaxTokens = request.MaxTokens.Value;
+        command.Messages.AddRange(request.Messages.Select(ToRuntimeMessage));
+        command.ToolSelection = ToToolSelection(toolClassification, toolChoiceHintPlan);
+        return command;
+    }
+
+    private static LlmSessionRuntimeChatMessage ToRuntimeMessage(ChatMessage message)
+    {
+        var result = new LlmSessionRuntimeChatMessage
+        {
+            Role = message.Role,
+            Content = message.Content ?? string.Empty,
+            ReasoningContent = message.ReasoningContent ?? string.Empty,
+            ToolCallId = message.ToolCallId ?? string.Empty,
+        };
+        if (message.ToolCalls is { Count: > 0 })
+            result.ToolCalls.AddRange(message.ToolCalls.Select(static call => new LlmSessionRuntimeToolCall
+            {
+                CallId = call.Id,
+                ToolName = call.Name,
+                ArgumentsJson = call.ArgumentsJson,
+            }));
+        return result;
+    }
+
+    private static LlmSessionRuntimeToolSelection ToToolSelection(
+        ResponsesToolClassification classification,
+        ResponsesToolChoiceHintPlan toolChoiceHintPlan)
+    {
+        var selection = new LlmSessionRuntimeToolSelection
+        {
+            SubstitutedToolNames = { classification.SubstitutedToolNames },
+            AdditiveToolNames = { classification.AdditiveToolNames },
+        };
+        if (!toolChoiceHintPlan.IsEmpty)
+        {
+            selection.ToolChoiceHintName = toolChoiceHintPlan.ToolName;
+            selection.ToolChoiceHintArgumentsJson = toolChoiceHintPlan.PrefilledArgumentsJson();
+        }
+
+        selection.ForwardedTools.AddRange(classification.ForwardedTools.Select(static tool =>
+            new LlmSessionRuntimeToolDeclaration
+            {
+                ToolName = tool.Name,
+                Description = tool.Description,
+                ParametersJson = tool.ParametersJson,
+                SchemaHash = tool.SchemaHash,
+            }));
+        return selection;
+    }
+
+    private static int ResolveUpstreamStatusCode(NyxIdUpstreamException ex) =>
+        ex.Status switch
+        {
+            400 => 400,
+            401 => 401,
+            403 => 403,
+            404 => 404,
+            429 => 429,
+            >= 500 => 502,
+            _ => 502,
+        };
+
+    private static string NewOpaqueId()
+    {
+        Span<byte> bytes = stackalloc byte[16];
+        RandomNumberGenerator.Fill(bytes);
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
+    private sealed record CallerScopeResult(
+        ResponsesCallerScope? Scope,
+        ResponsesCommandError? Error);
+
+    private sealed record RouteTargetResult(
+        string? Model,
+        ChatRouteAction? Action,
+        ResponsesCommandError? Error)
+    {
+        public static RouteTargetResult FromModel(string model, ChatRouteAction action) => new(model, action, null);
+
+        public static RouteTargetResult FromError(int statusCode, string code, string message) =>
+            new(null, null, new ResponsesCommandError(statusCode, code, message));
+    }
+
+    private sealed record SessionRegistrationResult(
+        LlmSessionRegistrationResult? Session,
+        ResponsesCommandError? Error);
+
+    private sealed record ExecutionPlanResult(
+        ChatCompletionsCreateCommandPlan? Plan,
+        ResponsesCommandError? Error)
+    {
+        public static ExecutionPlanResult FromPlan(ChatCompletionsCreateCommandPlan plan) => new(plan, null);
+
+        public static ExecutionPlanResult FromError(ResponsesCommandError error) => new(null, error);
+    }
+}

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandContracts.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandContracts.cs
@@ -97,6 +97,18 @@ public sealed record MessagesCommandRequest(
     bool ToolChoiceDisablesTools,
     string? ToolChoiceError);
 
+// Refactor (iter344/cluster-001):
+//   Old pattern: Host handler owns caller resolution, route resolution, session registration, tool planning, direct provider execution, status updates, and protocol rendering in one request stack.
+//   New principle: Host maps HTTP/OpenAI frames only; typed Application facade owns Normalize -> Resolve Target -> Build Context -> Build Envelope -> Dispatch -> Receipt/Observe via the same LlmSessionGAgent run path as Responses/Messages.
+public sealed record ChatCompletionsCommandRequest(
+    string? Model,
+    bool? Stream,
+    bool IncludeUsageInStream,
+    double? Temperature,
+    int? MaxTokens,
+    IReadOnlyList<ChatMessage> ChatMessages,
+    IReadOnlyList<ResponsesApplicationToolDeclaration> DeclaredTools);
+
 // Refactor (iter35/cluster-037-mainnet-responses-host-orchestration):
 //   Old pattern: Normalized Responses fields lived as endpoint locals across routing, continuation, session, and execution branches.
 //   New principle: Normalized command state is an immutable Application value passed through the facade lifecycle.
@@ -164,6 +176,33 @@ public readonly record struct MessagesRequestNormalizationResult(
         new(request, null, null);
 
     public static MessagesRequestNormalizationResult Failed(string code, string message) =>
+        new(null, code, message);
+}
+
+// Refactor (iter344/cluster-001):
+//   Old pattern: Chat Completions normalized state lived as Host locals across route/session/tool/provider branches.
+//   New principle: Application carries a typed normalized command state through route resolution, envelope construction, and dispatch.
+public sealed record NormalizedChatCompletionsCommand(
+    string CompletionId,
+    string Model,
+    bool Stream,
+    bool IncludeUsageInStream,
+    double? Temperature,
+    int? MaxTokens,
+    IReadOnlyList<ChatMessage> ChatMessages,
+    IReadOnlyList<ResponsesApplicationToolDeclaration> DeclaredTools);
+
+public readonly record struct ChatCompletionsRequestNormalizationResult(
+    NormalizedChatCompletionsCommand? Request,
+    string? ErrorCode,
+    string? ErrorMessage)
+{
+    public bool Succeeded => Request != null && ErrorCode == null;
+
+    public static ChatCompletionsRequestNormalizationResult Success(NormalizedChatCompletionsCommand request) =>
+        new(request, null, null);
+
+    public static ChatCompletionsRequestNormalizationResult Failed(string code, string message) =>
         new(null, code, message);
 }
 
@@ -275,6 +314,18 @@ public sealed record MessagesCreateCommandPlan(
     ResponsesToolClassification ToolClassification,
     ResponsesToolChoiceHintPlan ToolChoiceHintPlan);
 
+// Refactor (iter344/cluster-001):
+//   Old pattern: Chat Completions streaming held prepared LLMRequest/session/tool state inside the Host SSE helper.
+//   New principle: Application returns a typed run plan; Host only renders OpenAI-compatible event frames around dispatch outcome.
+public sealed record ChatCompletionsCreateCommandPlan(
+    NormalizedChatCompletionsCommand Normalized,
+    LlmSessionRegistrationResult Session,
+    LLMRequest LlmRequest,
+    IReadOnlyDictionary<string, string> ToolContextMetadata,
+    ResponsesToolClassification ToolClassification,
+    ResponsesToolChoiceHintPlan ToolChoiceHintPlan,
+    DateTimeOffset CreatedAt);
+
 // Refactor (iter35/cluster-037-mainnet-responses-host-orchestration):
 //   Old pattern: Messages create execution directly selected HTTP JSON versus SSE in the Host orchestration body.
 //   New principle: Application returns a typed result that separates validation errors, stream plans, and completed content.
@@ -306,6 +357,27 @@ public sealed record MessagesCreateCompletedCommandResult(
 
 public sealed record MessagesCreateAcceptedCommandResult(
     NormalizedMessagesRequest Normalized,
+    LlmSessionRegistrationResult Session,
+    DispatchAdmission Admission);
+
+public sealed record ChatCompletionsCreateCommandResult(
+    ResponsesCommandError? Error,
+    ChatCompletionsCreateCommandPlan? StreamPlan,
+    ChatCompletionsCreateAcceptedCommandResult? Accepted)
+{
+    public static ChatCompletionsCreateCommandResult FromError(int statusCode, string code, string message) =>
+        new(new ResponsesCommandError(statusCode, code, message), null, null);
+
+    public static ChatCompletionsCreateCommandResult FromStreamPlan(ChatCompletionsCreateCommandPlan plan) =>
+        new(null, plan, null);
+
+    public static ChatCompletionsCreateCommandResult FromAccepted(ChatCompletionsCreateAcceptedCommandResult accepted) =>
+        new(null, null, accepted);
+}
+
+public sealed record ChatCompletionsCreateAcceptedCommandResult(
+    NormalizedChatCompletionsCommand Normalized,
+    long CreatedAt,
     LlmSessionRegistrationResult Session,
     DispatchAdmission Admission);
 
@@ -342,6 +414,22 @@ public interface IMessagesCommandFacade
 
     Task<ResponsesStreamCommandResult> StreamAsync(
         MessagesCreateCommandPlan plan,
+        Func<string, CancellationToken, ValueTask> onTextDelta,
+        CancellationToken ct = default);
+}
+
+// Refactor (iter344/cluster-001):
+//   Old pattern: /v1/chat/completions endpoint injected route/session/tool/provider collaborators and executed the LLM loop directly.
+//   New principle: Host depends on one Chat Completions Application facade that owns the command lifecycle and actor dispatch.
+public interface IChatCompletionsCommandFacade
+{
+    Task<ChatCompletionsCreateCommandResult> CreateAsync(
+        ChatCompletionsCommandRequest request,
+        ResponsesCallerScopeResolutionContext callerScopeContext,
+        CancellationToken ct = default);
+
+    Task<ResponsesStreamCommandResult> StreamAsync(
+        ChatCompletionsCreateCommandPlan plan,
         Func<string, CancellationToken, ValueTask> onTextDelta,
         CancellationToken ct = default);
 }

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandContracts.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandContracts.cs
@@ -107,7 +107,8 @@ public sealed record ChatCompletionsCommandRequest(
     double? Temperature,
     int? MaxTokens,
     IReadOnlyList<ChatMessage> ChatMessages,
-    IReadOnlyList<ResponsesApplicationToolDeclaration> DeclaredTools);
+    IReadOnlyList<ResponsesApplicationToolDeclaration> DeclaredTools,
+    LLMResponseFormat? ResponseFormat);
 
 // Refactor (iter35/cluster-037-mainnet-responses-host-orchestration):
 //   Old pattern: Normalized Responses fields lived as endpoint locals across routing, continuation, session, and execution branches.
@@ -190,8 +191,12 @@ public sealed record NormalizedChatCompletionsCommand(
     double? Temperature,
     int? MaxTokens,
     IReadOnlyList<ChatMessage> ChatMessages,
-    IReadOnlyList<ResponsesApplicationToolDeclaration> DeclaredTools);
+    IReadOnlyList<ResponsesApplicationToolDeclaration> DeclaredTools,
+    LLMResponseFormat? ResponseFormat);
 
+// Refactor (iter344/cluster-001):
+//   Old pattern: Chat Completions validation failures returned HTTP results from endpoint branches.
+//   New principle: Application normalization returns typed success/failure data for Host protocol rendering.
 public readonly record struct ChatCompletionsRequestNormalizationResult(
     NormalizedChatCompletionsCommand? Request,
     string? ErrorCode,
@@ -360,6 +365,9 @@ public sealed record MessagesCreateAcceptedCommandResult(
     LlmSessionRegistrationResult Session,
     DispatchAdmission Admission);
 
+// Refactor (iter344/cluster-001):
+//   Old pattern: Chat Completions create branched directly in Host between request-local execution and SSE output.
+//   New principle: Application returns one typed union for protocol error, stream plan, or accepted dispatch receipt.
 public sealed record ChatCompletionsCreateCommandResult(
     ResponsesCommandError? Error,
     ChatCompletionsCreateCommandPlan? StreamPlan,
@@ -375,6 +383,9 @@ public sealed record ChatCompletionsCreateCommandResult(
         new(null, null, accepted);
 }
 
+// Refactor (iter344/cluster-001):
+//   Old pattern: The synchronous Chat Completions response implied request-local completion from direct provider execution.
+//   New principle: The create response exposes only the accepted actor dispatch receipt; terminal completion is observed asynchronously.
 public sealed record ChatCompletionsCreateAcceptedCommandResult(
     NormalizedChatCompletionsCommand Normalized,
     long CreatedAt,
@@ -430,6 +441,5 @@ public interface IChatCompletionsCommandFacade
 
     Task<ResponsesStreamCommandResult> StreamAsync(
         ChatCompletionsCreateCommandPlan plan,
-        Func<string, CancellationToken, ValueTask> onTextDelta,
         CancellationToken ct = default);
 }

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandContracts.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandContracts.cs
@@ -326,7 +326,6 @@ public sealed record ChatCompletionsCreateCommandPlan(
     NormalizedChatCompletionsCommand Normalized,
     LlmSessionRegistrationResult Session,
     LLMRequest LlmRequest,
-    IReadOnlyDictionary<string, string> ToolContextMetadata,
     ResponsesToolClassification ToolClassification,
     ResponsesToolChoiceHintPlan ToolChoiceHintPlan,
     DateTimeOffset CreatedAt);

--- a/test/Aevatar.GAgentService.Tests/Application/ChatCompletionsCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ChatCompletionsCommandFacadeTests.cs
@@ -38,6 +38,179 @@ public sealed class ChatCompletionsCommandFacadeTests
         command.Messages.Should().ContainSingle().Which.Content.Should().Be("hello");
     }
 
+    [Theory]
+    [MemberData(nameof(InvalidRequests))]
+    public async Task CreateAsync_WhenRequestValidationFails_ShouldReturnBadRequest(
+        ChatCompletionsCommandRequest request,
+        string expectedCode)
+    {
+        var sessions = new RecordingSessionPort();
+        var dispatch = new RecordingActorDispatchPort();
+        var facade = CreateFacade(sessionPort: sessions, dispatchPort: dispatch);
+
+        var result = await facade.CreateAsync(request, CallerScopeContext("token"));
+
+        result.Error.Should().NotBeNull();
+        result.Error!.StatusCode.Should().Be(400);
+        result.Error.Code.Should().Be(expectedCode);
+        result.Accepted.Should().BeNull();
+        result.StreamPlan.Should().BeNull();
+        sessions.Registered.Should().BeEmpty();
+        dispatch.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenCallerScopeUnavailable_ShouldReturnAuthenticationError()
+    {
+        var sessions = new RecordingSessionPort();
+        var dispatch = new RecordingActorDispatchPort();
+        var facade = CreateFacade(
+            sessionPort: sessions,
+            dispatchPort: dispatch,
+            callerScopeResolver: new FailingCallerScopeResolver());
+
+        var result = await facade.CreateAsync(BuildRequest("gpt-4o-mini"), CallerScopeContext("token"));
+
+        result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
+            401,
+            "authentication_required",
+            "caller unavailable"));
+        sessions.Registered.Should().BeEmpty();
+        dispatch.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenChatRouteRejects_ShouldReturnRouteError()
+    {
+        var sessions = new RecordingSessionPort();
+        var dispatch = new RecordingActorDispatchPort();
+        var facade = CreateFacade(
+            sessionPort: sessions,
+            dispatchPort: dispatch,
+            chatRouteDecisionPort: new StaticResponsesChatRouteDecisionPort(new ChatRouteAction
+            {
+                Reject = new Reject { Reason = "blocked by policy" },
+            }));
+
+        var result = await facade.CreateAsync(BuildRequest("gpt-4o-mini"), CallerScopeContext("token"));
+
+        result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
+            403,
+            "chat_route_rejected",
+            "blocked by policy"));
+        sessions.Registered.Should().BeEmpty();
+        dispatch.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenSessionRegistrationIsCancelled_ShouldReturnTimeout()
+    {
+        var sessions = new RecordingSessionPort
+        {
+            RegisterException = new OperationCanceledException(),
+        };
+        var dispatch = new RecordingActorDispatchPort();
+        var facade = CreateFacade(sessionPort: sessions, dispatchPort: dispatch);
+
+        var result = await facade.CreateAsync(BuildRequest("gpt-4o-mini"), CallerScopeContext("token"));
+
+        result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
+            408,
+            "request_timeout",
+            "Request timed out."));
+        dispatch.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenSessionRegistrationFails_ShouldReturnApiError()
+    {
+        var sessions = new RecordingSessionPort
+        {
+            RegisterException = new InvalidOperationException("store unavailable"),
+        };
+        var dispatch = new RecordingActorDispatchPort();
+        var facade = CreateFacade(sessionPort: sessions, dispatchPort: dispatch);
+
+        var result = await facade.CreateAsync(BuildRequest("gpt-4o-mini"), CallerScopeContext("token"));
+
+        result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
+            500,
+            "api_error",
+            "Failed to register session."));
+        dispatch.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenDispatchRequiresAuthentication_ShouldMarkSessionFailed()
+    {
+        var sessions = new RecordingSessionPort();
+        var dispatch = new RecordingActorDispatchPort(_ => new NyxIdAuthenticationRequiredException("test-provider"));
+        var facade = CreateFacade(sessionPort: sessions, dispatchPort: dispatch);
+
+        var result = await facade.CreateAsync(BuildRequest("gpt-4o-mini"), CallerScopeContext("token"));
+
+        result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
+            401,
+            "authentication_required",
+            "NyxID authentication required for provider 'test-provider'. Please sign in."));
+        sessions.UpdatedStatuses.Should().ContainSingle().Which.Status.Should().Be(LlmSessionStatus.Failed);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenDispatchReturnsUpstreamError_ShouldMarkSessionFailed()
+    {
+        var sessions = new RecordingSessionPort();
+        var dispatch = new RecordingActorDispatchPort(_ => new NyxIdUpstreamException(
+            NyxIdUpstreamFailureKind.RateLimited,
+            429,
+            "route-a",
+            "model-a",
+            "rate limited"));
+        var facade = CreateFacade(sessionPort: sessions, dispatchPort: dispatch);
+
+        var result = await facade.CreateAsync(BuildRequest("gpt-4o-mini"), CallerScopeContext("token"));
+
+        result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
+            429,
+            "ratelimited",
+            "rate limited"));
+        sessions.UpdatedStatuses.Should().ContainSingle().Which.Status.Should().Be(LlmSessionStatus.Failed);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenDispatchIsCancelled_ShouldMarkSessionCancelled()
+    {
+        var sessions = new RecordingSessionPort();
+        var dispatch = new RecordingActorDispatchPort(ct => new OperationCanceledException(ct));
+        var facade = CreateFacade(sessionPort: sessions, dispatchPort: dispatch);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var result = await facade.CreateAsync(BuildRequest("gpt-4o-mini"), CallerScopeContext("token"), cts.Token);
+
+        result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
+            499,
+            "client_closed_request",
+            "Client closed request."));
+        sessions.UpdatedStatuses.Should().ContainSingle().Which.Status.Should().Be(LlmSessionStatus.Cancelled);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenDispatchFails_ShouldMarkSessionFailed()
+    {
+        var sessions = new RecordingSessionPort();
+        var dispatch = new RecordingActorDispatchPort(_ => new InvalidOperationException("dispatch failed"));
+        var facade = CreateFacade(sessionPort: sessions, dispatchPort: dispatch);
+
+        var result = await facade.CreateAsync(BuildRequest("gpt-4o-mini"), CallerScopeContext("token"));
+
+        result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
+            500,
+            "api_error",
+            "Internal server error."));
+        sessions.UpdatedStatuses.Should().ContainSingle().Which.Status.Should().Be(LlmSessionStatus.Failed);
+    }
+
     [Fact]
     public async Task CreateAsync_ShouldReturnStreamPlan_WhenRequestIsStreaming()
     {
@@ -61,7 +234,7 @@ public sealed class ChatCompletionsCommandFacadeTests
         var dispatch = new RecordingActorDispatchPort();
         var facade = CreateFacade(sessionPort: sessions, dispatchPort: dispatch);
 
-        var result = await facade.StreamAsync(BuildStreamPlan(), (_, _) => ValueTask.CompletedTask);
+        var result = await facade.StreamAsync(BuildStreamPlan());
 
         result.Error.Should().BeNull();
         result.Accepted.Should().NotBeNull();
@@ -76,24 +249,71 @@ public sealed class ChatCompletionsCommandFacadeTests
         command.Model.Should().Be("gpt-4o-mini");
     }
 
-    private static ChatCompletionsCommandRequest BuildRequest(string model, bool stream = false) =>
+    [Fact]
+    public async Task StreamAsync_WhenDispatchFails_ShouldReturnError_AndMarkSessionFailed()
+    {
+        var sessions = new RecordingSessionPort();
+        var dispatch = new RecordingActorDispatchPort(_ => new InvalidOperationException("dispatch failed"));
+        var facade = CreateFacade(sessionPort: sessions, dispatchPort: dispatch);
+
+        var result = await facade.StreamAsync(BuildStreamPlan(), CancellationToken.None);
+
+        result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
+            500,
+            "api_error",
+            "Internal server error."));
+        sessions.UpdatedStatuses.Should().ContainSingle().Which.Status.Should().Be(LlmSessionStatus.Failed);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithResponseFormat_ShouldCarryFormatIntoLlmRequest()
+    {
+        var facade = CreateFacade();
+
+        var result = await facade.CreateAsync(
+            BuildRequest("gpt-4o-mini", stream: true, responseFormat: LLMResponseFormat.JsonObject),
+            CallerScopeContext("token"));
+
+        result.Error.Should().BeNull();
+        result.StreamPlan.Should().NotBeNull();
+        result.StreamPlan!.Normalized.ResponseFormat.Should().BeSameAs(LLMResponseFormat.JsonObject);
+        result.StreamPlan.LlmRequest.ResponseFormat.Should().BeSameAs(LLMResponseFormat.JsonObject);
+    }
+
+    public static TheoryData<ChatCompletionsCommandRequest, string> InvalidRequests() => new()
+    {
+        { BuildRequest(" "), "model_required" },
+        { BuildRequest("gpt-4o-mini", maxTokens: 0), "invalid_max_tokens" },
+        { BuildRequest("gpt-4o-mini", temperature: 3), "invalid_temperature" },
+        { BuildRequest("gpt-4o-mini", chatMessages: []), "invalid_messages" },
+    };
+
+    private static ChatCompletionsCommandRequest BuildRequest(
+        string model,
+        bool stream = false,
+        double? temperature = null,
+        int? maxTokens = 100,
+        IReadOnlyList<ChatMessage>? chatMessages = null,
+        LLMResponseFormat? responseFormat = null) =>
         new(
             model,
             stream,
             false,
-            null,
-            100,
-            [ChatMessage.User("hello")],
-            []);
+            temperature,
+            maxTokens,
+            chatMessages ?? [ChatMessage.User("hello")],
+            [],
+            responseFormat);
 
     private static ChatCompletionsCommandFacade CreateFacade(
         ILlmSessionRegistrationPort? sessionPort = null,
         IResponsesChatRouteDecisionPort? chatRouteDecisionPort = null,
-        RecordingActorDispatchPort? dispatchPort = null)
+        RecordingActorDispatchPort? dispatchPort = null,
+        IResponsesCallerScopeResolver? callerScopeResolver = null)
     {
         var effectiveSessionPort = sessionPort ?? new RecordingSessionPort();
         return new ChatCompletionsCommandFacade(
-            new StaticCallerScopeResolver(),
+            callerScopeResolver ?? new StaticCallerScopeResolver(),
             chatRouteDecisionPort ?? new StaticResponsesChatRouteDecisionPort(ForwardToModelAction(string.Empty)),
             new StaticResponsesRouteResolver("route-value"),
             effectiveSessionPort,
@@ -116,7 +336,8 @@ public sealed class ChatCompletionsCommandFacadeTests
                 null,
                 100,
                 [ChatMessage.User("hello")],
-                []),
+                [],
+                null),
             new LlmSessionRegistrationResult("actor-chatcmpl_stream", "chatcmpl_stream"),
             new LLMRequest
             {
@@ -140,6 +361,14 @@ public sealed class ChatCompletionsCommandFacadeTests
             ResponsesCallerScopeResolutionContext context,
             CancellationToken ct = default) =>
             Task.FromResult(new ResponsesCallerScope("scope-1", "owner-1", LlmSessionOriginKind.ApiKey));
+    }
+
+    private sealed class FailingCallerScopeResolver : IResponsesCallerScopeResolver
+    {
+        public Task<ResponsesCallerScope> ResolveAsync(
+            ResponsesCallerScopeResolutionContext context,
+            CancellationToken ct = default) =>
+            throw new ResponsesCallerScopeUnavailableException("caller unavailable");
     }
 
     private sealed class StaticResponsesRouteResolver(string? routeValue) : IResponsesRouteResolver
@@ -182,10 +411,25 @@ public sealed class ChatCompletionsCommandFacadeTests
 
     private sealed class RecordingActorDispatchPort : IActorDispatchPort
     {
+        private readonly Func<CancellationToken, Exception?> _exceptionFactory;
+
+        public RecordingActorDispatchPort()
+            : this(static _ => null)
+        {
+        }
+
+        public RecordingActorDispatchPort(Func<CancellationToken, Exception?> exceptionFactory)
+        {
+            _exceptionFactory = exceptionFactory;
+        }
+
         public List<(string ActorId, EventEnvelope Envelope)> Calls { get; } = [];
 
         public Task<DispatchAdmission> DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
         {
+            if (_exceptionFactory(ct) is { } exception)
+                return Task.FromException<DispatchAdmission>(exception);
+
             Calls.Add((actorId, envelope));
             return Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
         }
@@ -199,8 +443,13 @@ public sealed class ChatCompletionsCommandFacadeTests
 
         public List<LlmSessionCompletion> RecordedCompletions { get; } = [];
 
+        public Exception? RegisterException { get; init; }
+
         public Task<LlmSessionRegistrationResult> RegisterAsync(LlmSessionRecord record, CancellationToken ct = default)
         {
+            if (RegisterException is not null)
+                return Task.FromException<LlmSessionRegistrationResult>(RegisterException);
+
             Registered.Add(record);
             return Task.FromResult(new LlmSessionRegistrationResult("actor-" + record.ResponseId, record.ResponseId));
         }

--- a/test/Aevatar.GAgentService.Tests/Application/ChatCompletionsCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ChatCompletionsCommandFacadeTests.cs
@@ -266,6 +266,67 @@ public sealed class ChatCompletionsCommandFacadeTests
     }
 
     [Fact]
+    public async Task StreamAsync_WhenDispatchRequiresAuthentication_ShouldReturnAuthenticationError_AndMarkSessionFailed()
+    {
+        var sessions = new RecordingSessionPort();
+        var dispatch = new RecordingActorDispatchPort(_ => new NyxIdAuthenticationRequiredException("test-provider"));
+        var facade = CreateFacade(sessionPort: sessions, dispatchPort: dispatch);
+
+        var result = await facade.StreamAsync(BuildStreamPlan(), CancellationToken.None);
+
+        result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
+            401,
+            "authentication_required",
+            "NyxID authentication required for provider 'test-provider'. Please sign in."));
+        result.Accepted.Should().BeNull();
+        result.Completion.Should().BeNull();
+        sessions.UpdatedStatuses.Should().ContainSingle().Which.Status.Should().Be(LlmSessionStatus.Failed);
+    }
+
+    [Fact]
+    public async Task StreamAsync_WhenDispatchReturnsUpstreamError_ShouldReturnMappedError_AndMarkSessionFailed()
+    {
+        var sessions = new RecordingSessionPort();
+        var dispatch = new RecordingActorDispatchPort(_ => new NyxIdUpstreamException(
+            NyxIdUpstreamFailureKind.RateLimited,
+            429,
+            "route-a",
+            "model-a",
+            "rate limited"));
+        var facade = CreateFacade(sessionPort: sessions, dispatchPort: dispatch);
+
+        var result = await facade.StreamAsync(BuildStreamPlan(), CancellationToken.None);
+
+        result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
+            429,
+            "ratelimited",
+            "rate limited"));
+        result.Accepted.Should().BeNull();
+        result.Completion.Should().BeNull();
+        sessions.UpdatedStatuses.Should().ContainSingle().Which.Status.Should().Be(LlmSessionStatus.Failed);
+    }
+
+    [Fact]
+    public async Task StreamAsync_WhenDispatchIsCancelled_ShouldReturnClientClosedError_AndMarkSessionCancelled()
+    {
+        var sessions = new RecordingSessionPort();
+        var dispatch = new RecordingActorDispatchPort(ct => new OperationCanceledException(ct));
+        var facade = CreateFacade(sessionPort: sessions, dispatchPort: dispatch);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var result = await facade.StreamAsync(BuildStreamPlan(), cts.Token);
+
+        result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
+            499,
+            "client_closed_request",
+            "Client closed request."));
+        result.Accepted.Should().BeNull();
+        result.Completion.Should().BeNull();
+        sessions.UpdatedStatuses.Should().ContainSingle().Which.Status.Should().Be(LlmSessionStatus.Cancelled);
+    }
+
+    [Fact]
     public async Task CreateAsync_WithResponseFormat_ShouldCarryFormatIntoLlmRequest()
     {
         var facade = CreateFacade();
@@ -345,7 +406,6 @@ public sealed class ChatCompletionsCommandFacadeTests
                 Model = "gpt-4o-mini",
                 Messages = [ChatMessage.User("hello")],
             },
-            new Dictionary<string, string>(StringComparer.Ordinal),
             new ResponsesToolClassification([], [], [], []),
             ResponsesToolChoiceHintPlan.Empty,
             DateTimeOffset.UtcNow);

--- a/test/Aevatar.GAgentService.Tests/Application/ChatCompletionsCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ChatCompletionsCommandFacadeTests.cs
@@ -1,0 +1,247 @@
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.Responses;
+using Aevatar.GAgentService.Application.Responses;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.GAgentService.Tests.Application;
+
+public sealed class ChatCompletionsCommandFacadeTests
+{
+    [Fact]
+    public async Task CreateAsync_ShouldRegisterSession_AndDispatchLlmRun()
+    {
+        var sessions = new RecordingSessionPort();
+        var dispatch = new RecordingActorDispatchPort();
+        var facade = CreateFacade(sessionPort: sessions, dispatchPort: dispatch);
+
+        var result = await facade.CreateAsync(BuildRequest("gpt-4o-mini"), CallerScopeContext("token"));
+
+        result.Error.Should().BeNull();
+        result.Accepted.Should().NotBeNull();
+        result.Accepted!.Admission.Accepted.Should().BeTrue();
+        sessions.Registered.Should().ContainSingle().Which.ScopeId.Should().Be("scope-1");
+        sessions.RecordedCompletions.Should().BeEmpty();
+        var call = dispatch.Calls.Should().ContainSingle().Subject;
+        call.ActorId.Should().Be(result.Accepted.Session.ActorId);
+        var command = call.Envelope.Payload.Unpack<LlmRunRequested>();
+        command.ResponseId.Should().Be(result.Accepted.Session.ResponseId);
+        command.RunId.Should().Be($"{result.Accepted.Session.ResponseId}:llm-run");
+        command.Model.Should().Be("gpt-4o-mini");
+        command.ScopeId.Should().Be("scope-1");
+        command.BearerToken.Should().Be("token");
+        command.Messages.Should().ContainSingle().Which.Content.Should().Be("hello");
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldReturnStreamPlan_WhenRequestIsStreaming()
+    {
+        var sessions = new RecordingSessionPort();
+        var facade = CreateFacade(sessionPort: sessions);
+
+        var result = await facade.CreateAsync(BuildRequest("chrono/gpt-5-chat", stream: true), CallerScopeContext("token"));
+
+        result.Error.Should().BeNull();
+        result.StreamPlan.Should().NotBeNull();
+        result.Accepted.Should().BeNull();
+        result.StreamPlan!.LlmRequest.Model.Should().Be("gpt-5-chat");
+        result.StreamPlan.LlmRequest.LlmControl!.NyxIdRoutePreference.Should().Be("route-value");
+        sessions.Registered.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task StreamAsync_ShouldReturnAcceptedDispatchReceipt()
+    {
+        var sessions = new RecordingSessionPort();
+        var dispatch = new RecordingActorDispatchPort();
+        var facade = CreateFacade(sessionPort: sessions, dispatchPort: dispatch);
+
+        var result = await facade.StreamAsync(BuildStreamPlan(), (_, _) => ValueTask.CompletedTask);
+
+        result.Error.Should().BeNull();
+        result.Accepted.Should().NotBeNull();
+        result.Completion.Should().BeNull();
+        sessions.RecordedCompletions.Should().BeEmpty();
+        sessions.UpdatedStatuses.Should().BeEmpty();
+        var call = dispatch.Calls.Should().ContainSingle().Subject;
+        call.ActorId.Should().Be("actor-chatcmpl_stream");
+        var command = call.Envelope.Payload.Unpack<LlmRunRequested>();
+        command.ResponseId.Should().Be("chatcmpl_stream");
+        command.RunId.Should().Be("chatcmpl_stream:llm-run");
+        command.Model.Should().Be("gpt-4o-mini");
+    }
+
+    private static ChatCompletionsCommandRequest BuildRequest(string model, bool stream = false) =>
+        new(
+            model,
+            stream,
+            false,
+            null,
+            100,
+            [ChatMessage.User("hello")],
+            []);
+
+    private static ChatCompletionsCommandFacade CreateFacade(
+        ILlmSessionRegistrationPort? sessionPort = null,
+        IResponsesChatRouteDecisionPort? chatRouteDecisionPort = null,
+        RecordingActorDispatchPort? dispatchPort = null)
+    {
+        var effectiveSessionPort = sessionPort ?? new RecordingSessionPort();
+        return new ChatCompletionsCommandFacade(
+            new StaticCallerScopeResolver(),
+            chatRouteDecisionPort ?? new StaticResponsesChatRouteDecisionPort(ForwardToModelAction(string.Empty)),
+            new StaticResponsesRouteResolver("route-value"),
+            effectiveSessionPort,
+            dispatchPort ?? new RecordingActorDispatchPort(),
+            new StaticResponsesToolClassificationService(),
+            new StaticResponsesDirectToolPlanService(),
+            NullLogger<ChatCompletionsCommandFacade>.Instance);
+    }
+
+    private static ResponsesCallerScopeResolutionContext CallerScopeContext(string bearerToken) =>
+        new(bearerToken, null, null);
+
+    private static ChatCompletionsCreateCommandPlan BuildStreamPlan() =>
+        new(
+            new NormalizedChatCompletionsCommand(
+                "chatcmpl_stream",
+                "gpt-4o-mini",
+                true,
+                false,
+                null,
+                100,
+                [ChatMessage.User("hello")],
+                []),
+            new LlmSessionRegistrationResult("actor-chatcmpl_stream", "chatcmpl_stream"),
+            new LLMRequest
+            {
+                RequestId = "chatcmpl_stream",
+                Model = "gpt-4o-mini",
+                Messages = [ChatMessage.User("hello")],
+            },
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            new ResponsesToolClassification([], [], [], []),
+            ResponsesToolChoiceHintPlan.Empty,
+            DateTimeOffset.UtcNow);
+
+    private static ChatRouteAction ForwardToModelAction(string modelName) => new()
+    {
+        ForwardToModel = new ForwardToModel { ModelName = modelName },
+    };
+
+    private sealed class StaticCallerScopeResolver : IResponsesCallerScopeResolver
+    {
+        public Task<ResponsesCallerScope> ResolveAsync(
+            ResponsesCallerScopeResolutionContext context,
+            CancellationToken ct = default) =>
+            Task.FromResult(new ResponsesCallerScope("scope-1", "owner-1", LlmSessionOriginKind.ApiKey));
+    }
+
+    private sealed class StaticResponsesRouteResolver(string? routeValue) : IResponsesRouteResolver
+    {
+        public Task<string?> ResolveRouteValueAsync(string slug, string bearerToken, CancellationToken ct) =>
+            Task.FromResult(routeValue);
+    }
+
+    private sealed class StaticResponsesChatRouteDecisionPort(ChatRouteAction action)
+        : IResponsesChatRouteDecisionPort
+    {
+        public Task<ChatRouteDecision> ResolveAsync(
+            ResponsesCallerScope callerScope,
+            string model,
+            ToolMode toolMode,
+            string contentHint,
+            CancellationToken ct = default)
+            => Task.FromResult(new ChatRouteDecision
+            {
+                Action = action.Clone(),
+                UsedFallback = false,
+            });
+    }
+
+    private sealed class StaticResponsesToolClassificationService : IResponsesToolClassificationService
+    {
+        public ValueTask<ResponsesToolClassification> ClassifyAsync(
+            IReadOnlyList<ResponsesApplicationToolDeclaration> declaredTools,
+            ResponsesToolProviderContext context,
+            IEnumerable<IResponsesToolProvider>? additionalProviders = null,
+            CancellationToken ct = default) =>
+            ValueTask.FromResult(new ResponsesToolClassification([], [], [], []));
+    }
+
+    private sealed class StaticResponsesDirectToolPlanService : IResponsesDirectToolPlanService
+    {
+        public ResponsesDirectToolPlan Build(ChatRouteAction? routeAction) =>
+            ResponsesDirectToolPlan.Empty;
+    }
+
+    private sealed class RecordingActorDispatchPort : IActorDispatchPort
+    {
+        public List<(string ActorId, EventEnvelope Envelope)> Calls { get; } = [];
+
+        public Task<DispatchAdmission> DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
+        {
+            Calls.Add((actorId, envelope));
+            return Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
+        }
+    }
+
+    private sealed class RecordingSessionPort : ILlmSessionRegistrationPort
+    {
+        public List<LlmSessionRecord> Registered { get; } = [];
+
+        public List<(string ActorId, string ResponseId, LlmSessionStatus Status)> UpdatedStatuses { get; } = [];
+
+        public List<LlmSessionCompletion> RecordedCompletions { get; } = [];
+
+        public Task<LlmSessionRegistrationResult> RegisterAsync(LlmSessionRecord record, CancellationToken ct = default)
+        {
+            Registered.Add(record);
+            return Task.FromResult(new LlmSessionRegistrationResult("actor-" + record.ResponseId, record.ResponseId));
+        }
+
+        public Task UpdateStatusAsync(string sessionActorId, string responseId, LlmSessionStatus status, CancellationToken ct = default)
+        {
+            UpdatedStatuses.Add((sessionActorId, responseId, status));
+            return Task.CompletedTask;
+        }
+
+        public Task RecordForwardedToolCallAsync(
+            string sessionActorId,
+            string responseId,
+            LlmSessionForwardedToolCall call,
+            CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task RecordCompletionAsync(
+            string sessionActorId,
+            string responseId,
+            LlmSessionCompletion completion,
+            CancellationToken ct = default)
+        {
+            RecordedCompletions.Add(completion.Clone());
+            return Task.CompletedTask;
+        }
+
+        public Task ReceiveForwardedToolResultAsync(
+            string sessionActorId,
+            string responseId,
+            string callId,
+            string schemaHash,
+            string resultJson,
+            CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task ResolveForwardedToolResultAsync(
+            string sessionActorId,
+            string responseId,
+            string callId,
+            CancellationToken ct = default) =>
+            Task.CompletedTask;
+    }
+}

--- a/test/Aevatar.GAgentService.Tests/Application/ChatCompletionsCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ChatCompletionsCommandFacadeTests.cs
@@ -141,6 +141,36 @@ public sealed class ChatCompletionsCommandFacadeTests
     }
 
     [Fact]
+    public async Task CreateAsync_WhenDirectToolPlanFails_ShouldReturnPlanError_AndNotDispatch()
+    {
+        var sessions = new RecordingSessionPort();
+        var dispatch = new RecordingActorDispatchPort();
+        var tools = new RecordingResponsesToolClassificationService();
+        var facade = CreateFacade(
+            sessionPort: sessions,
+            dispatchPort: dispatch,
+            toolClassificationService: tools,
+            directToolPlanService: new StaticResponsesDirectToolPlanService(
+                ResponsesDirectToolPlan.FromError(new ResponsesCommandError(
+                    500,
+                    "tool_set_unavailable",
+                    "tool set is unavailable"))));
+
+        var result = await facade.CreateAsync(BuildRequest("gpt-4o-mini"), CallerScopeContext("token"));
+
+        result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
+            500,
+            "tool_set_unavailable",
+            "tool set is unavailable"));
+        result.Accepted.Should().BeNull();
+        result.StreamPlan.Should().BeNull();
+        sessions.Registered.Should().ContainSingle();
+        sessions.UpdatedStatuses.Should().BeEmpty();
+        tools.Calls.Should().Be(0);
+        dispatch.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task CreateAsync_WhenDispatchRequiresAuthentication_ShouldMarkSessionFailed()
     {
         var sessions = new RecordingSessionPort();
@@ -370,7 +400,9 @@ public sealed class ChatCompletionsCommandFacadeTests
         ILlmSessionRegistrationPort? sessionPort = null,
         IResponsesChatRouteDecisionPort? chatRouteDecisionPort = null,
         RecordingActorDispatchPort? dispatchPort = null,
-        IResponsesCallerScopeResolver? callerScopeResolver = null)
+        IResponsesCallerScopeResolver? callerScopeResolver = null,
+        IResponsesToolClassificationService? toolClassificationService = null,
+        IResponsesDirectToolPlanService? directToolPlanService = null)
     {
         var effectiveSessionPort = sessionPort ?? new RecordingSessionPort();
         return new ChatCompletionsCommandFacade(
@@ -379,8 +411,8 @@ public sealed class ChatCompletionsCommandFacadeTests
             new StaticResponsesRouteResolver("route-value"),
             effectiveSessionPort,
             dispatchPort ?? new RecordingActorDispatchPort(),
-            new StaticResponsesToolClassificationService(),
-            new StaticResponsesDirectToolPlanService(),
+            toolClassificationService ?? new StaticResponsesToolClassificationService(),
+            directToolPlanService ?? new StaticResponsesDirectToolPlanService(),
             NullLogger<ChatCompletionsCommandFacade>.Instance);
     }
 
@@ -463,10 +495,26 @@ public sealed class ChatCompletionsCommandFacadeTests
             ValueTask.FromResult(new ResponsesToolClassification([], [], [], []));
     }
 
-    private sealed class StaticResponsesDirectToolPlanService : IResponsesDirectToolPlanService
+    private sealed class RecordingResponsesToolClassificationService : IResponsesToolClassificationService
+    {
+        public int Calls { get; private set; }
+
+        public ValueTask<ResponsesToolClassification> ClassifyAsync(
+            IReadOnlyList<ResponsesApplicationToolDeclaration> declaredTools,
+            ResponsesToolProviderContext context,
+            IEnumerable<IResponsesToolProvider>? additionalProviders = null,
+            CancellationToken ct = default)
+        {
+            Calls++;
+            return ValueTask.FromResult(new ResponsesToolClassification([], [], [], []));
+        }
+    }
+
+    private sealed class StaticResponsesDirectToolPlanService(
+        ResponsesDirectToolPlan? plan = null) : IResponsesDirectToolPlanService
     {
         public ResponsesDirectToolPlan Build(ChatRouteAction? routeAction) =>
-            ResponsesDirectToolPlan.Empty;
+            plan ?? ResponsesDirectToolPlan.Empty;
     }
 
     private sealed class RecordingActorDispatchPort : IActorDispatchPort

--- a/test/Aevatar.Hosting.Tests/MainnetChatCompletionsEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetChatCompletionsEndpointsTests.cs
@@ -424,6 +424,21 @@ public sealed class MainnetChatCompletionsEndpointsTests
         command.ToolSelection.AdditiveToolNames.Should().Contain(["use_skill", "ornn_search_skills"]);
     }
 
+    [Fact]
+    public void ChatCompletionsEndpointSource_ShouldNotReintroduceDirectLlmLoop()
+    {
+        var source = File.ReadAllText(FindRepositoryFile(
+            "src",
+            "Aevatar.Mainnet.Host.Api",
+            "ChatCompletions",
+            "ChatCompletionsEndpoints.cs"));
+
+        source.Should().NotContain("ILLMProviderFactory");
+        source.Should().NotContain("IResponsesCompletionApplicationService");
+        source.Should().NotContain("ChatStreamAsync");
+        source.Should().NotContain("CollectAsync");
+    }
+
     private static async Task<WebApplication> CreateAppAsync(
         ChatCompletionsRecordingLLMProvider provider,
         ChatCompletionsRecordingSessionStore? sessions = null,
@@ -471,6 +486,21 @@ public sealed class MainnetChatCompletionsEndpointsTests
 
     private static StringContent JsonContent(string json) =>
         new(json, Encoding.UTF8, "application/json");
+
+    private static string FindRepositoryFile(params string[] segments)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine([directory.FullName, .. segments]);
+            if (File.Exists(candidate))
+                return candidate;
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException("Could not locate repository file.", Path.Combine(segments));
+    }
 
     private static Microsoft.Extensions.Options.IOptions<ChatRoutingOptions> DefaultToolSetRoutingOptions() =>
         Microsoft.Extensions.Options.Options.Create(new ChatRoutingOptions

--- a/test/Aevatar.Hosting.Tests/MainnetChatCompletionsEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetChatCompletionsEndpointsTests.cs
@@ -78,24 +78,23 @@ public sealed class MainnetChatCompletionsEndpointsTests
         root.GetProperty("model").GetString().Should().Be("gpt-4o-mini");
         var choice = root.GetProperty("choices")[0];
         choice.GetProperty("message").GetProperty("role").GetString().Should().Be("assistant");
-        choice.GetProperty("message").GetProperty("content").GetString().Should().Be("Hi there");
-        choice.GetProperty("finish_reason").GetString().Should().Be("stop");
-        root.GetProperty("usage").GetProperty("prompt_tokens").GetInt32().Should().Be(5);
-        root.GetProperty("usage").GetProperty("completion_tokens").GetInt32().Should().Be(3);
+        choice.GetProperty("message").GetProperty("content").ValueKind.Should().Be(JsonValueKind.Null);
+        choice.GetProperty("finish_reason").ValueKind.Should().Be(JsonValueKind.Null);
+        root.GetProperty("usage").ValueKind.Should().Be(JsonValueKind.Null);
 
         sessions.Registered.Should().ContainSingle();
         sessions.Registered[0].ScopeId.Should().Be("user-1");
-        sessions.StatusUpdates.Should().Contain(update => update.Status == LlmSessionStatus.Completed);
-
-        provider.LastRequest.Should().NotBeNull();
-        provider.LastRequest!.Messages.Should().HaveCount(2);
-        provider.LastRequest.Messages[0].Role.Should().Be("system");
-        provider.LastRequest.Messages[0].Content.Should().Be("You are concise.");
-        provider.LastRequest.Messages[1].Role.Should().Be("user");
-        provider.LastRequest.Messages[1].Content.Should().Be("Hello");
-        provider.LastRequest.MaxTokens.Should().Be(256);
-        provider.LastRequest.CallerContext!.Credentials!.NyxIdBearer.Should().Be("openai-bearer");
-        provider.LastRequest.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
+        sessions.StatusUpdates.Should().BeEmpty();
+        provider.LastRequest.Should().BeNull();
+        var dispatch = app.Services.GetRequiredService<ChatCompletionsRecordingActorDispatchPort>();
+        var command = dispatch.Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
+        command.Messages.Should().HaveCount(2);
+        command.Messages[0].Role.Should().Be("system");
+        command.Messages[0].Content.Should().Be("You are concise.");
+        command.Messages[1].Role.Should().Be("user");
+        command.Messages[1].Content.Should().Be("Hello");
+        command.MaxTokens.Should().Be(256);
+        command.BearerToken.Should().Be("openai-bearer");
         var callerScopeResolver = app.Services.GetRequiredService<IResponsesCallerScopeResolver>()
             .Should()
             .BeOfType<ChatCompletionsStubCallerScopeResolver>()
@@ -145,13 +144,14 @@ public sealed class MainnetChatCompletionsEndpointsTests
         response.StatusCode.Should().Be(HttpStatusCode.OK, body);
         response.Content.Headers.ContentType!.MediaType.Should().Be("text/event-stream");
         body.Should().Contain("\"object\":\"chat.completion.chunk\"");
-        body.Should().Contain("\"content\":\"Hel\"");
-        body.Should().Contain("\"content\":\"lo\"");
-        body.Should().Contain("\"finish_reason\":\"stop\"");
-        body.Should().Contain("\"prompt_tokens\":4");
+        body.Should().Contain("\"finish_reason\":null");
+        body.Should().Contain("\"usage\":null");
         body.Should().Contain("data: [DONE]");
         body.Should().NotContain("stream-bearer");
-        sessions.StatusUpdates.Should().Contain(update => update.Status == LlmSessionStatus.Completed);
+        sessions.StatusUpdates.Should().BeEmpty();
+        provider.LastRequest.Should().BeNull();
+        app.Services.GetRequiredService<ChatCompletionsRecordingActorDispatchPort>()
+            .Calls.Should().ContainSingle();
     }
 
     [Fact]
@@ -203,20 +203,17 @@ public sealed class MainnetChatCompletionsEndpointsTests
         response.StatusCode.Should().Be(HttpStatusCode.OK, body);
         using var doc = JsonDocument.Parse(body);
         var choice = doc.RootElement.GetProperty("choices")[0];
-        choice.GetProperty("finish_reason").GetString().Should().Be("tool_calls");
-        var toolCall = choice.GetProperty("message").GetProperty("tool_calls")[0];
-        toolCall.GetProperty("id").GetString().Should().Be("call_abc");
-        toolCall.GetProperty("type").GetString().Should().Be("function");
-        toolCall.GetProperty("function").GetProperty("name").GetString().Should().Be("get_weather");
-        toolCall.GetProperty("function").GetProperty("arguments").GetString().Should().Be("""{"city":"SF"}""");
+        choice.GetProperty("finish_reason").ValueKind.Should().Be(JsonValueKind.Null);
 
-        provider.LastRequest.Should().NotBeNull();
-        provider.LastRequest!.Tools.Should().NotBeNull();
-        provider.LastRequest.Tools!.Select(static tool => tool.Name)
+        provider.LastRequest.Should().BeNull();
+        var command = app.Services.GetRequiredService<ChatCompletionsRecordingActorDispatchPort>()
+            .Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
+        command.ToolSelection.ForwardedTools.Select(static tool => tool.ToolName)
             .Should()
-            .Contain(["get_weather", "aevatar_invoke_team"]);
-        provider.LastRequest.Tools.Single(static tool => tool.Name == "get_weather")
-            .ParametersSchema.Should().Contain("\"city\"");
+            .Contain("get_weather");
+        command.ToolSelection.AdditiveToolNames.Should().Contain("aevatar_invoke_team");
+        command.ToolSelection.ForwardedTools.Single(static tool => tool.ToolName == "get_weather")
+            .ParametersJson.Should().Contain("\"city\"");
     }
 
     [Fact]
@@ -249,10 +246,11 @@ public sealed class MainnetChatCompletionsEndpointsTests
 
         response.StatusCode.Should().Be(HttpStatusCode.OK, body);
         routeResolver.ResolvedSlugs.Should().ContainSingle().Which.Should().Be("chrono-llm");
-        provider.LastRequest.Should().NotBeNull();
-        provider.LastRequest!.Model.Should().Be("gpt-5-chat");
-        provider.LastRequest.Metadata.Should().ContainKey(LLMRequestMetadataKeys.NyxIdRoutePreference)
-            .WhoseValue.Should().Be("/api/v1/proxy/s/chrono-llm");
+        provider.LastRequest.Should().BeNull();
+        var command = app.Services.GetRequiredService<ChatCompletionsRecordingActorDispatchPort>()
+            .Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
+        command.Model.Should().Be("gpt-5-chat");
+        command.RoutePreference.Should().Be("/api/v1/proxy/s/chrono-llm");
     }
 
     [Fact]
@@ -284,17 +282,17 @@ public sealed class MainnetChatCompletionsEndpointsTests
         var body = await response.Content.ReadAsStringAsync();
 
         response.StatusCode.Should().Be(HttpStatusCode.OK, body);
-        provider.LastRequest.Should().NotBeNull();
-        provider.LastRequest!.Tools.Should().NotBeNull();
-        provider.LastRequest.Tools!.Select(static tool => tool.Name)
-            .Should().Contain("aevatar_invoke_team");
+        provider.LastRequest.Should().BeNull();
+        var command = app.Services.GetRequiredService<ChatCompletionsRecordingActorDispatchPort>()
+            .Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
+        command.ToolSelection.AdditiveToolNames.Should().Contain("aevatar_invoke_team");
         using var doc = JsonDocument.Parse(body);
         doc.RootElement.GetProperty("choices")[0]
             .GetProperty("message")
             .GetProperty("content")
-            .GetString()
+            .ValueKind
             .Should()
-            .Be("tool-driven");
+            .Be(JsonValueKind.Null);
     }
 
     [Fact]
@@ -331,10 +329,13 @@ public sealed class MainnetChatCompletionsEndpointsTests
         builder.AddAevatarAuthentication();
 
         builder.Services.AddSingleton<ILLMProviderFactory>(provider);
+        builder.Services.AddSingleton<ChatCompletionsRecordingActorDispatchPort>();
+        builder.Services.AddSingleton<IActorDispatchPort>(static sp => sp.GetRequiredService<ChatCompletionsRecordingActorDispatchPort>());
+        builder.Services.AddSingleton<IChatCompletionsCommandFacade, ChatCompletionsCommandFacade>();
         builder.Services.AddSingleton(sessions);
         builder.Services.AddSingleton<ILlmSessionRegistrationPort>(sessions);
-        builder.Services.AddSingleton<IResponsesCompletionApplicationService, ResponsesCompletionApplicationService>();
         builder.Services.AddSingleton<IResponsesCallerScopeResolver>(new ChatCompletionsStubCallerScopeResolver());
+        builder.Services.AddSingleton<IResponsesChatRouteDecisionPort, ResponsesChatRouteDecisionPort>();
         builder.Services.AddSingleton<IChatRoutePolicyQueryPort>(ChatCompletionsStaticChatRoutePolicyQueryPort.ForSnapshot(
             new ChatRoutePolicySnapshot(ForwardToModelAction(string.Empty), [])));
         builder.Services.AddSingleton(new ChatRouteResolver(
@@ -416,9 +417,11 @@ public sealed class MainnetChatCompletionsEndpointsTests
 
         var response = await client.SendAsync(request);
         response.StatusCode.Should().Be(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
-        provider.LastRequest.Should().NotBeNull();
-        var toolNames = provider.LastRequest!.Tools?.Select(static tool => tool.Name).ToArray() ?? [];
-        toolNames.Should().Contain(["use_skill", "ornn_search_skills", "WebSearch"]);
+        provider.LastRequest.Should().BeNull();
+        var command = app.Services.GetRequiredService<ChatCompletionsRecordingActorDispatchPort>()
+            .Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
+        command.ToolSelection.SubstitutedToolNames.Should().Contain("WebSearch");
+        command.ToolSelection.AdditiveToolNames.Should().Contain(["use_skill", "ornn_search_skills"]);
     }
 
     private static async Task<WebApplication> CreateAppAsync(
@@ -435,11 +438,14 @@ public sealed class MainnetChatCompletionsEndpointsTests
         });
         builder.WebHost.UseTestServer();
         builder.Services.AddSingleton<ILLMProviderFactory>(provider);
+        builder.Services.AddSingleton<ChatCompletionsRecordingActorDispatchPort>();
+        builder.Services.AddSingleton<IActorDispatchPort>(static sp => sp.GetRequiredService<ChatCompletionsRecordingActorDispatchPort>());
+        builder.Services.AddSingleton<IChatCompletionsCommandFacade, ChatCompletionsCommandFacade>();
         sessions ??= new ChatCompletionsRecordingSessionStore();
         builder.Services.AddSingleton(sessions);
         builder.Services.AddSingleton<ILlmSessionRegistrationPort>(sessions);
-        builder.Services.AddSingleton<IResponsesCompletionApplicationService, ResponsesCompletionApplicationService>();
         builder.Services.AddSingleton(callerScopeResolver ?? new ChatCompletionsStubCallerScopeResolver());
+        builder.Services.AddSingleton<IResponsesChatRouteDecisionPort, ResponsesChatRouteDecisionPort>();
         builder.Services.AddSingleton(chatRoutePolicyQueryPort ?? ChatCompletionsStaticChatRoutePolicyQueryPort.ForSnapshot(
             new ChatRoutePolicySnapshot(ForwardToModelAction(string.Empty), [])));
         builder.Services.AddSingleton(new ChatRouteResolver(
@@ -500,6 +506,17 @@ public sealed class MainnetChatCompletionsEndpointsTests
                 yield return chunk;
                 await Task.Yield();
             }
+        }
+    }
+
+    private sealed class ChatCompletionsRecordingActorDispatchPort : IActorDispatchPort
+    {
+        public List<(string ActorId, EventEnvelope Envelope)> Calls { get; } = [];
+
+        public Task<DispatchAdmission> DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
+        {
+            Calls.Add((actorId, envelope));
+            return Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
         }
     }
 

--- a/test/Aevatar.Hosting.Tests/MainnetChatCompletionsEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetChatCompletionsEndpointsTests.cs
@@ -155,7 +155,7 @@ public sealed class MainnetChatCompletionsEndpointsTests
     }
 
     [Fact]
-    public async Task PostChatCompletions_WithToolCall_ShouldReturnOpenAIToolCalls()
+    public async Task PostChatCompletions_WithToolCall_ShouldDispatchForwardedToolSelection()
     {
         var provider = new ChatCompletionsRecordingLLMProvider
         {
@@ -254,7 +254,7 @@ public sealed class MainnetChatCompletionsEndpointsTests
     }
 
     [Fact]
-    public async Task PostChatCompletions_WhenRoutePinsTeamTool_ShouldExecuteThroughToolDrivenModelAction()
+    public async Task PostChatCompletions_WhenRoutePinsTeamTool_ShouldDispatchTeamToolSelection()
     {
         var provider = new ChatCompletionsRecordingLLMProvider
         {


### PR DESCRIPTION
## 摘要

iter344 cluster-001（high，rule_ids: `LAYER-HOST-NO-BIZ-ORCH` + `CMD-LIFECYCLE-SKELETON`）。

- **Old**：`/v1/chat/completions` Host endpoint 在一个 request stack 内承担 caller 解析、route 决策、tool plan、`LlmSessionRegistration`、provider 直接执行、status 更新与 OpenAI/SSE 协议渲染全部职责。
- **New**：Host 仅做 HTTP/OpenAI frame 映射；新增 `ChatCompletionsCommandFacade`（Application 层）承担标准命令骨架 `Normalize → Resolve Target → Build Context → Build Envelope → Dispatch → Receipt / Observe`，复用 `LlmRunRequested` / `IActorDispatchPort` / `ILlmSessionRegistrationPort`，与 Responses / Messages 走同一 `LlmSessionGAgent` run path。

违反:
- CLAUDE.md「严格分层:`API` 仅做宿主与组合,不承载业务编排」
- CLAUDE.md「命令骨架内聚:`Normalize -> Resolve Target -> Build Context -> Build Envelope -> Dispatch -> Receipt -> Observe`;业务模块只负责目标解析与载荷/结果映射」

## 范围

7 文件改动(+1046 / -515):

- `src/Aevatar.Mainnet.Host.Api/ChatCompletions/ChatCompletionsApiModels.cs`(瘦身)
- `src/Aevatar.Mainnet.Host.Api/ChatCompletions/ChatCompletionsEndpoints.cs`(Host endpoint 瘦身,478 行迁出)
- `src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs`(facade DI 注册)
- `src/platform/Aevatar.GAgentService.Application/Responses/ChatCompletionsCommandFacade.cs`(新建,Application command facade,552 行)
- `src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandContracts.cs`(扩展 contract)
- `test/Aevatar.GAgentService.Tests/Application/ChatCompletionsCommandFacadeTests.cs`(3 新增 tests)
- `test/Aevatar.Hosting.Tests/MainnetChatCompletionsEndpointsTests.cs`(断言更新)

参见 [implement summary](./.refactor-loop/runs/implement-cluster-001-chat-completions-host-direct-llm-loop.md) 与 [audit-iter-344](./.refactor-loop/runs/audit-iter-344.md)。

## 行为变化(deviation,maintainer 需关注)

同步 OpenAI-compatible response 现在渲染 `accepted / in-progress` frame 而非 request-local 直执行 completion。这是 audit 期望的语义:Host 不再持有 provider 调用,只做协议映射;completion 由 actor session 推进,与 Responses / Messages 一致。

## 本地验证

- `dotnet build aevatar.slnx --nologo`:0 errors
- `dotnet test aevatar.slnx --nologo --no-build`:passed(full slnx test per hard rule #10)
- `tools/ci/architecture_guards.sh`:passed
- `tools/ci/test_stability_guards.sh`:passed
- `ChatCompletionsCommandFacadeTests`:3 tests passed
- `MainnetChatCompletionsEndpointsTests`:8 tests passed

## Stacked-PR

iter344 单 cluster,base = `auto-refact-dev`。Rollup target = `dev`(reverse rollup PR #1167)。

🤖 Auto-loop / codex-refactor-loop iter344

⟦AI:AUTO-LOOP⟧
