### PR TITLE
#1412 first slice: provider-only typed workflow-start (删除 BuildLegacyMetadata)

### DIFF
--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -224,8 +224,10 @@ public sealed class AevatarInvocationDispatcher
         if (scope.Error != null)
             return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(scope.Error), scope.Error);
 
-        var metadata = BuildLegacyMetadata(scope.Value!, request.Inputs.Headers);
-        metadata[WorkflowRunCommandMetadataKeys.ScopeId] = scope.Value!.ScopeId;
+        // Refactor (iter348/cluster-003):
+        //   Old pattern: aevatar_start_workflow stamped trusted control into WorkflowChatRunRequest.Metadata via BuildLegacyMetadata
+        //   New principle: provider-only typed fields (ScopeId / ToolContext / LlmControl) carry trusted control
+        var metadata = BuildPayloadHeaders(request.Inputs.Headers);
         var workflowYamls = request.WorkflowYamls.Count == 0
             ? null
             : request.WorkflowYamls
@@ -245,7 +247,9 @@ public sealed class AevatarInvocationDispatcher
             SessionId: ResolveSessionId(),
             InputParts: ToWorkflowInputParts(request.Inputs),
             Metadata: metadata,
-            ScopeId: scope.Value.ScopeId);
+            ScopeId: scope.Value.ScopeId,
+            LlmControl: ToLlmControlContext(AgentToolRequestContext.Current),
+            ToolContext: AgentToolRequestContext.Current);
 
         var result = await _workflowDispatchService.DispatchAsync(command, ct);
         if (!result.Succeeded || result.Receipt == null)
@@ -887,66 +891,9 @@ public sealed class AevatarInvocationDispatcher
         return filteredHeaders;
     }
 
-    private static Dictionary<string, string> BuildLegacyMetadata(
-        InvocationCallerScope scope,
-        Google.Protobuf.Collections.MapField<string, string>? headers = null)
-    {
-        var metadata = AgentToolRequestContext.Current?.ToLegacyMetadata() is { } current
-            ? new Dictionary<string, string>(current, StringComparer.Ordinal)
-            : new Dictionary<string, string>(StringComparer.Ordinal);
-        RemoveProtectedCallerMetadata(metadata);
-        if (headers != null)
-        {
-            foreach (var (key, value) in headers)
-            {
-                var normalizedKey = Normalize(key);
-                if (normalizedKey != null && !IsProtectedCallerMetadataKey(normalizedKey))
-                    metadata[normalizedKey] = value ?? string.Empty;
-            }
-        }
-
-        StampTrustedCallerMetadata(metadata, scope);
-        return metadata;
-    }
-
-    private static void RemoveProtectedCallerMetadata(IDictionary<string, string> metadata)
-    {
-        foreach (var key in ProtectedCallerMetadataKeys)
-            metadata.Remove(key);
-    }
-
     private static bool IsProtectedCallerMetadataKey(string key) =>
         ProtectedCallerMetadataKeys.Any(protectedKey =>
             string.Equals(protectedKey, key, StringComparison.Ordinal));
-
-    private static void StampTrustedCallerMetadata(
-        IDictionary<string, string> metadata,
-        InvocationCallerScope scope)
-    {
-        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.ScopeId, scope.ScopeId);
-        SetTrustedMetadata(metadata, "scope_id", scope.ScopeId);
-        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.OwnerSubject, scope.OwnerSubject);
-        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.ResponseId, scope.ResponseId);
-        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.RequestId, AgentToolRequestContext.RequestId);
-        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.CallId, AgentToolRequestContext.CallId);
-        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.NyxIdAccessToken, AgentToolRequestContext.NyxIdAccessToken);
-        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.NyxIdOrgToken, AgentToolRequestContext.NyxIdOrgToken);
-        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.SenderNyxIdAccessToken, AgentToolRequestContext.SenderNyxIdAccessToken);
-        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.SenderBindingId, AgentToolRequestContext.SenderBindingId);
-        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.ModelOverride, AgentToolRequestContext.ModelOverride);
-        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.NyxIdRoutePreference, AgentToolRequestContext.NyxIdRoutePreference);
-        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.MaxToolRoundsOverride, AgentToolRequestContext.MaxToolRoundsOverride?.ToString());
-        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.ConnectedServicesContext, AgentToolRequestContext.ConnectedServicesContext);
-    }
-
-    private static void SetTrustedMetadata(
-        IDictionary<string, string> metadata,
-        string key,
-        string? value)
-    {
-        if (!string.IsNullOrWhiteSpace(value))
-            metadata[key] = value.Trim();
-    }
 
     private static void AppendMetadata(
         Google.Protobuf.Collections.MapField<string, string> destination,
@@ -1016,6 +963,15 @@ public sealed class AevatarInvocationDispatcher
     {
         // Refactor (issue1300-first): Old pattern: stamp trusted caller/control to Headers/Metadata. New principle: typed ScopeId/ToolContext/LlmControl are authority.
         context ??= AgentToolExecutionContext.Empty;
+        return ToLlmControlContext(context).ToPayload();
+    }
+
+    private static LLMControlContext ToLlmControlContext(AgentToolExecutionContext? context)
+    {
+        // Refactor (iter348/cluster-003):
+        //   Old pattern: aevatar_start_workflow stamped trusted control into WorkflowChatRunRequest.Metadata via BuildLegacyMetadata
+        //   New principle: provider-only typed fields (ScopeId / ToolContext / LlmControl) carry trusted control
+        context ??= AgentToolExecutionContext.Empty;
         return new LLMControlContext(
             context.Credentials.NyxIdAccessToken,
             context.Credentials.NyxIdOrgToken,
@@ -1023,7 +979,7 @@ public sealed class AevatarInvocationDispatcher
             context.Routing.ModelOverride,
             context.Routing.NyxIdRoutePreference,
             context.Routing.MaxToolRoundsOverride,
-            context.Routing.UserMemoryPrompt).ToPayload();
+            context.Routing.UserMemoryPrompt);
     }
 
     private CallerScopeResolution ResolveCallerScope(bool requireOwner = true)

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -501,8 +501,10 @@ public sealed class AevatarInvocationToolSourceTests
         harness.WorkflowDispatch.Command!.Source.WorkflowName.Should().Be("wf-main");
         harness.WorkflowDispatch.Command.Prompt.Should().Be("run workflow");
         harness.WorkflowDispatch.Command.ScopeId.Should().Be("scope-1");
-        harness.WorkflowDispatch.Command.Metadata.Should().Contain("scope_id", "scope-1");
+        ShouldNotCarryTrustedCallerValues(harness.WorkflowDispatch.Command.Metadata);
         harness.WorkflowDispatch.Command.Metadata.Should().Contain("x-workflow", "yes");
+        harness.WorkflowDispatch.Command.ToolContext.Should().NotBeNull();
+        ShouldCarryTypedTrustedCallerValues(harness.WorkflowDispatch.Command);
 
         var result = Read(output);
         result.GetProperty("run_id").GetString().Should().Be("wf-command");
@@ -545,6 +547,9 @@ public sealed class AevatarInvocationToolSourceTests
         result.CompletionObserved.Should().BeFalse();
         result.CompletionResultJson.Should().BeEmpty();
         result.ErrorCode.Should().BeEmpty();
+        harness.WorkflowDispatch.Command.Should().NotBeNull();
+        ShouldCarryTypedTrustedCallerValues(harness.WorkflowDispatch.Command!);
+        ShouldNotCarryTrustedCallerValues(harness.WorkflowDispatch.Command!.Metadata);
     }
 
     [Theory]
@@ -695,7 +700,8 @@ public sealed class AevatarInvocationToolSourceTests
             """);
 
         ErrorCodeOrNull(output).Should().BeNull(output);
-        ShouldCarryTrustedCallerValues(harness.WorkflowDispatch.Command!.Metadata);
+        ShouldNotCarryTrustedCallerValues(harness.WorkflowDispatch.Command!.Metadata);
+        ShouldCarryTypedTrustedCallerValues(harness.WorkflowDispatch.Command);
     }
 
     [Fact]
@@ -868,15 +874,33 @@ public sealed class AevatarInvocationToolSourceTests
             : null;
     }
 
-    private static void ShouldCarryTrustedCallerValues(IEnumerable<KeyValuePair<string, string>>? metadata)
+    private static void ShouldCarryTypedTrustedCallerValues(WorkflowChatRunRequest command)
     {
-        metadata.Should().NotBeNull();
-        var values = metadata!.ToDictionary(static item => item.Key, static item => item.Value, StringComparer.Ordinal);
-        values.Should().Contain(LLMRequestMetadataKeys.OwnerSubject, "owner-1");
-        values.Should().Contain(LLMRequestMetadataKeys.NyxIdAccessToken, "access-token");
-        values.Should().Contain(LLMRequestMetadataKeys.SenderNyxIdAccessToken, "sender-token");
-        values.Should().Contain(LLMRequestMetadataKeys.ScopeId, "scope-1");
-        values.Should().Contain("scope_id", "scope-1");
+        // Refactor (iter348/cluster-003):
+        //   Old pattern: aevatar_start_workflow stamped trusted control into WorkflowChatRunRequest.Metadata via BuildLegacyMetadata
+        //   New principle: provider-only typed fields (ScopeId / ToolContext / LlmControl) carry trusted control
+        command.ScopeId.Should().Be("scope-1");
+        command.ToolContext.Should().NotBeNull();
+        command.ToolContext!.Request.RequestId.Should().Be("request-1");
+        command.ToolContext.Request.CallId.Should().NotBeNullOrWhiteSpace();
+        command.ToolContext.Caller.ScopeId.Should().Be("scope-1");
+        command.ToolContext.Caller.OwnerSubject.Should().Be("owner-1");
+        command.ToolContext.Caller.ResponseId.Should().Be("response-1");
+        command.ToolContext.Credentials.NyxIdAccessToken.Should().Be("access-token");
+        command.ToolContext.Credentials.NyxIdOrgToken.Should().Be("org-token");
+        command.ToolContext.Credentials.SenderNyxIdAccessToken.Should().Be("sender-token");
+        command.ToolContext.SenderBinding.BindingId.Should().Be("binding-1");
+        command.ToolContext.Routing.ModelOverride.Should().Be("model-1");
+        command.ToolContext.Routing.NyxIdRoutePreference.Should().Be("route-1");
+        command.ToolContext.Routing.MaxToolRoundsOverride.Should().Be(4);
+        command.ToolContext.ConnectedServices.ContextJson.Should().Be("""{"service":"ctx"}""");
+        command.LlmControl.Should().NotBeNull();
+        command.LlmControl!.NyxIdAccessToken.Should().Be("access-token");
+        command.LlmControl.NyxIdOrgToken.Should().Be("org-token");
+        command.LlmControl.SenderNyxIdAccessToken.Should().Be("sender-token");
+        command.LlmControl.ModelOverride.Should().Be("model-1");
+        command.LlmControl.NyxIdRoutePreference.Should().Be("route-1");
+        command.LlmControl.MaxToolRoundsOverride.Should().Be(4);
     }
 
     private static void ShouldNotCarryTrustedCallerValues(IEnumerable<KeyValuePair<string, string>>? metadata)


### PR DESCRIPTION
## 摘要

closes #1412(由 Phase 9 r1 split first-slice 产生,parent #1403)

### Old
`aevatar_start_workflow` 在 `WorkflowChatRunRequest.Metadata` 中通过 `BuildLegacyMetadata` / `StampTrustedCallerMetadata` 携带 trusted control。

### New
Provider-only typed:用现有 `ScopeId` / `ToolContext` / `LlmControl` typed 字段承载 trusted control,删除 legacy helper 方法。**不动** reader fallback(later-slice / cluster-004 范围)。

### 违反

- CLAUDE.md「核心语义强类型」(影响业务语义的 trusted control 必须 typed,不进 bag)
- AGENTS.md「字段命名与 Metadata 决策树」

## 范围

2 文件改动(+51 / -71):
- `src/agents/Aevatar.Workflow.Application/Invocation/AevatarInvocationDispatcher.cs`(移除 BuildLegacyMetadata + StampTrustedCallerMetadata,改走 typed)
- `test/Aevatar.Workflow.Application.Tests/Invocation/AevatarInvocationToolSourceTests.cs`(验证 typed 路径)

## Stacked-PR

#1412 first-slice(由 #1403 split)。base = `auto-refact-dev`。

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
