### PR TITLE
#1422 first slice: typed ConnectorRequest.Authorization 取代 metadata auth carrier

### DIFF
--- a/src/Aevatar.Bootstrap/Connectors/HttpConnector.cs
+++ b/src/Aevatar.Bootstrap/Connectors/HttpConnector.cs
@@ -145,7 +145,7 @@ public sealed class HttpConnector : IConnector
             if (_authorizationProvider != null)
                 await _authorizationProvider.ApplyAsync(msg, timeoutCts.Token);
 
-            ApplyRequestMetadataAuthorization(msg, request.Metadata);
+            ApplyRequestAuthorization(msg, request.HttpAuthorization);
 
             if (request.Parameters.TryGetValue("content_type", out var contentType) &&
                 !string.IsNullOrWhiteSpace(contentType))
@@ -365,18 +365,15 @@ public sealed class HttpConnector : IConnector
         }
     }
 
-    private static void ApplyRequestMetadataAuthorization(
+    // Refactor (issue1422/phase9-first-slice):
+    //   Old pattern: HTTP connector recovered authorization from ConnectorRequest.Metadata string keys.
+    //   New principle: HTTP authorization is a typed connector request field; Metadata is not an auth carrier.
+    private static void ApplyRequestAuthorization(
         HttpRequestMessage request,
-        IReadOnlyDictionary<string, string>? metadata)
+        string? authorization)
     {
-        if (request.Headers.Authorization != null || metadata == null || metadata.Count == 0)
+        if (request.Headers.Authorization != null || string.IsNullOrWhiteSpace(authorization))
             return;
-
-        if (!metadata.TryGetValue(ConnectorRequest.HttpAuthorizationMetadataKey, out var authorization) ||
-            string.IsNullOrWhiteSpace(authorization))
-        {
-            return;
-        }
 
         if (!AuthenticationHeaderValue.TryParse(authorization.Trim(), out var parsed))
             return;

--- a/src/Aevatar.Foundation.Abstractions/Connectors/IConnector.cs
+++ b/src/Aevatar.Foundation.Abstractions/Connectors/IConnector.cs
@@ -27,11 +27,14 @@ public interface IConnector
 /// </summary>
 public sealed class ConnectorRequest
 {
-    /// <summary>Generic HTTP authorization metadata key consumed by HTTP connectors.</summary>
+    /// <summary>Legacy host adapter metadata key used only before workflow runtime typed state.</summary>
     public const string HttpAuthorizationMetadataKey = "connector.http.authorization";
 
-    /// <summary>Execution metadata propagated from workflow/runtime context.</summary>
+    /// <summary>Execution metadata propagated from workflow/runtime context, excluding connector authorization.</summary>
     public IReadOnlyDictionary<string, string> Metadata { get; init; } = new Dictionary<string, string>();
+
+    /// <summary>Typed HTTP Authorization header value for connector execution, e.g. "Bearer token".</summary>
+    public string HttpAuthorization { get; init; } = "";
 
     /// <summary>Workflow run id.</summary>
     public string RunId { get; init; } = "";

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.cs
@@ -335,7 +335,7 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
             ct);
         var connectorRequest = new ConnectorRequest
         {
-            Metadata = ExtractConnectorMetadata(ctx),
+            HttpAuthorization = ExtractConnectorHttpAuthorization(ctx),
             RunId = runId,
             StepId = request.StepId,
             Connector = connectorName,
@@ -823,18 +823,18 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
         string.Equals(raw, "true", StringComparison.OrdinalIgnoreCase) ||
         string.Equals(raw, "yes", StringComparison.OrdinalIgnoreCase);
 
-    private static IReadOnlyDictionary<string, string> ExtractConnectorMetadata(
+    // Refactor (issue1422/phase9-first-slice):
+    //   Old pattern: Connector execution rewrapped typed runtime authorization into Metadata.
+    //   New principle: Connector authorization crosses the execution boundary as a typed request field.
+    private static string ExtractConnectorHttpAuthorization(
         IWorkflowExecutionContext ctx)
     {
         if (ConnectorAuthorizationRuntimeContextAccess.TryGetAuthorization(ctx, out var authorization) &&
             !string.IsNullOrWhiteSpace(authorization))
         {
-            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            {
-                [ConnectorRequest.HttpAuthorizationMetadataKey] = authorization.Trim(),
-            };
+            return authorization.Trim();
         }
 
-        return new Dictionary<string, string>();
+        return string.Empty;
     }
 }

--- a/test/Aevatar.Bootstrap.Tests/ConnectorAndHostingCoverageTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/ConnectorAndHostingCoverageTests.cs
@@ -113,6 +113,71 @@ public class ConnectorAndHostingCoverageTests
     }
 
     [Fact]
+    public async Task HttpConnector_ShouldUseTypedAuthorizationAndIgnoreLegacyMetadataAuth()
+    {
+        var handler = new StubHttpMessageHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"ok\":true}", Encoding.UTF8, "application/json"),
+                ReasonPhrase = "OK",
+            });
+        var connector = new HttpConnector(
+            "auth-http",
+            "https://example.com",
+            allowedMethods: ["POST"],
+            allowedPaths: ["/invoke"],
+            client: new HttpClient(handler));
+
+        var response = await connector.ExecuteAsync(new ConnectorRequest
+        {
+            Operation = "/invoke",
+            HttpAuthorization = " Bearer typed-token ",
+            Metadata = new Dictionary<string, string>
+            {
+                [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer legacy-token",
+            },
+            Parameters = new Dictionary<string, string> { ["method"] = "POST" },
+        });
+
+        response.Success.Should().BeTrue();
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.Headers.Authorization.Should().NotBeNull();
+        handler.LastRequest.Headers.Authorization!.Scheme.Should().Be("Bearer");
+        handler.LastRequest.Headers.Authorization.Parameter.Should().Be("typed-token");
+    }
+
+    [Fact]
+    public async Task HttpConnector_ShouldNotUseLegacyMetadataAuthorization()
+    {
+        var handler = new StubHttpMessageHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"ok\":true}", Encoding.UTF8, "application/json"),
+                ReasonPhrase = "OK",
+            });
+        var connector = new HttpConnector(
+            "metadata-auth-http",
+            "https://example.com",
+            allowedMethods: ["POST"],
+            allowedPaths: ["/invoke"],
+            client: new HttpClient(handler));
+
+        var response = await connector.ExecuteAsync(new ConnectorRequest
+        {
+            Operation = "/invoke",
+            Metadata = new Dictionary<string, string>
+            {
+                [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer legacy-token",
+            },
+            Parameters = new Dictionary<string, string> { ["method"] = "POST" },
+        });
+
+        response.Success.Should().BeTrue();
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.Headers.Authorization.Should().BeNull();
+    }
+
+    [Fact]
     public async Task HttpConnector_ShouldAppendResponseDescriptionToErrorMessage()
     {
         var handler = new StubHttpMessageHandler(_ =>

--- a/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
@@ -2107,9 +2107,8 @@ public sealed class WorkflowAdditionalModulesCoverageTests
             CancellationToken.None);
 
         connector.LastRequest.Should().NotBeNull();
-        connector.LastRequest!.Metadata.Should().Contain(
-            ConnectorRequest.HttpAuthorizationMetadataKey,
-            "Bearer token-123");
+        connector.LastRequest!.HttpAuthorization.Should().Be("Bearer token-123");
+        connector.LastRequest.Metadata.Should().NotContainKey(ConnectorRequest.HttpAuthorizationMetadataKey);
     }
 
     [Fact]


### PR DESCRIPTION
## 摘要

closes #1422(由 Phase 9 r1 split first-slice 产生,parent #1410)

### Old
`ConnectorRequest` 用 generic `Metadata` 携带 `connector.http.authorization` HTTP bearer。

### New
新增 typed `Authorization` 字段于 `ConnectorRequest`,`ConnectorCallModule` 写 typed,`HttpConnector` 只读 typed,删除 metadata auth fallback。

### 违反

- CLAUDE.md「API 字段单一语义」(metadata key 携带 auth)
- CLAUDE.md「核心语义强类型」(影响业务语义的 auth 必须 typed)

## 范围

5 文件改动(+86 / -22)。

## Stacked-PR

#1422 first-slice(由 #1410 split)。base = `auto-refact-dev`。

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
