### PR TITLE
#1436 first slice: 删除 WorkflowActorBindingProjector readmodel self-read

### DIFF
--- a/src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowActorBindingProjector.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowActorBindingProjector.cs
@@ -9,19 +9,19 @@ public sealed class WorkflowActorBindingProjector
     : IProjectionArtifactMaterializer<WorkflowBindingProjectionContext>
 {
     private readonly IProjectionWriteDispatcher<WorkflowActorBindingDocument> _writeDispatcher;
-    private readonly IProjectionDocumentReader<WorkflowActorBindingDocument, string> _documentReader;
     private readonly IProjectionClock _clock;
 
     public WorkflowActorBindingProjector(
         IProjectionWriteDispatcher<WorkflowActorBindingDocument> writeDispatcher,
-        IProjectionDocumentReader<WorkflowActorBindingDocument, string> documentReader,
         IProjectionClock clock)
     {
         _writeDispatcher = writeDispatcher ?? throw new ArgumentNullException(nameof(writeDispatcher));
-        _documentReader = documentReader ?? throw new ArgumentNullException(nameof(documentReader));
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
     }
 
+    // Refactor (iter355/issue1436-first):
+    //   Old pattern: WorkflowActorBindingProjector reads target document during materialization to merge fields
+    //   New principle: Projector constructs full document from committed event payload only; overwrites without reading prior readmodel
     public async ValueTask ProjectAsync(
         WorkflowBindingProjectionContext context,
         EventEnvelope envelope,
@@ -38,16 +38,7 @@ public sealed class WorkflowActorBindingProjector
         if (payload.Is(BindWorkflowDefinitionEvent.Descriptor))
         {
             var evt = payload.Unpack<BindWorkflowDefinitionEvent>();
-            var document = await GetOrCreateAsync(context.RootActorId, ct);
-            document.Id = context.RootActorId;
-            document.ActorId = context.RootActorId;
-            document.ActorKind = WorkflowActorKind.Definition;
-            document.DefinitionActorId = context.RootActorId;
-            document.RunId = string.Empty;
-            document.WorkflowName = NormalizeWorkflowName(evt.WorkflowName);
-            document.WorkflowYaml = evt.WorkflowYaml ?? string.Empty;
-            document.ScopeId = evt.ScopeId?.Trim() ?? string.Empty;
-            ReplaceInlineWorkflowYamls(document.InlineWorkflowYamls, evt.InlineWorkflowYamls);
+            var document = CreateDefinitionDocument(context.RootActorId, evt);
             ApplyProjectionMetadata(document, eventId, stateVersion, updatedAt);
             await _writeDispatcher.UpsertAsync(document, ct);
             return;
@@ -57,18 +48,47 @@ public sealed class WorkflowActorBindingProjector
             return;
 
         var bindRun = payload.Unpack<BindWorkflowRunDefinitionEvent>();
-        var runDocument = await GetOrCreateAsync(context.RootActorId, ct);
-        runDocument.Id = context.RootActorId;
-        runDocument.ActorId = context.RootActorId;
-        runDocument.ActorKind = WorkflowActorKind.Run;
-        runDocument.DefinitionActorId = bindRun.DefinitionActorId?.Trim() ?? string.Empty;
-        runDocument.RunId = ResolveRunId(bindRun.RunId, context.RootActorId);
-        runDocument.WorkflowName = NormalizeWorkflowName(bindRun.WorkflowName);
-        runDocument.WorkflowYaml = bindRun.WorkflowYaml ?? string.Empty;
-        runDocument.ScopeId = bindRun.ScopeId?.Trim() ?? string.Empty;
-        ReplaceInlineWorkflowYamls(runDocument.InlineWorkflowYamls, bindRun.InlineWorkflowYamls);
+        var runDocument = CreateRunDocument(context.RootActorId, bindRun);
         ApplyProjectionMetadata(runDocument, eventId, stateVersion, updatedAt);
         await _writeDispatcher.UpsertAsync(runDocument, ct);
+    }
+
+    private static WorkflowActorBindingDocument CreateDefinitionDocument(
+        string actorId,
+        BindWorkflowDefinitionEvent evt)
+    {
+        var document = new WorkflowActorBindingDocument
+        {
+            Id = actorId,
+            ActorId = actorId,
+            ActorKind = WorkflowActorKind.Definition,
+            DefinitionActorId = actorId,
+            RunId = string.Empty,
+            WorkflowName = NormalizeWorkflowName(evt.WorkflowName),
+            WorkflowYaml = evt.WorkflowYaml ?? string.Empty,
+            ScopeId = evt.ScopeId?.Trim() ?? string.Empty,
+        };
+        ReplaceInlineWorkflowYamls(document.InlineWorkflowYamls, evt.InlineWorkflowYamls);
+        return document;
+    }
+
+    private static WorkflowActorBindingDocument CreateRunDocument(
+        string actorId,
+        BindWorkflowRunDefinitionEvent evt)
+    {
+        var document = new WorkflowActorBindingDocument
+        {
+            Id = actorId,
+            ActorId = actorId,
+            ActorKind = WorkflowActorKind.Run,
+            DefinitionActorId = evt.DefinitionActorId?.Trim() ?? string.Empty,
+            RunId = ResolveRunId(evt.RunId, actorId),
+            WorkflowName = NormalizeWorkflowName(evt.WorkflowName),
+            WorkflowYaml = evt.WorkflowYaml ?? string.Empty,
+            ScopeId = evt.ScopeId?.Trim() ?? string.Empty,
+        };
+        ReplaceInlineWorkflowYamls(document.InlineWorkflowYamls, evt.InlineWorkflowYamls);
+        return document;
     }
 
     private static void ApplyProjectionMetadata(
@@ -77,8 +97,7 @@ public sealed class WorkflowActorBindingProjector
         long stateVersion,
         DateTimeOffset updatedAt)
     {
-        if (document.CreatedAt == default)
-            document.CreatedAt = updatedAt;
+        document.CreatedAt = updatedAt;
         document.UpdatedAt = updatedAt;
         if (stateVersion > 0)
             document.StateVersion = stateVersion;
@@ -111,14 +130,5 @@ public sealed class WorkflowActorBindingProjector
 
             target[normalizedWorkflowName] = workflowYamlValue;
         }
-    }
-
-    private async Task<WorkflowActorBindingDocument> GetOrCreateAsync(string actorId, CancellationToken ct)
-    {
-        return await _documentReader.GetAsync(actorId, ct) ?? new WorkflowActorBindingDocument
-        {
-            Id = actorId,
-            ActorId = actorId,
-        };
     }
 }

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowBindingReaderCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowBindingReaderCoverageTests.cs
@@ -20,7 +20,6 @@ public sealed class WorkflowActorBindingProjectorTests
         var dispatcher = new FakeStoreDispatcher();
         var projector = new WorkflowActorBindingProjector(
             dispatcher,
-            dispatcher,
             new StaticClock(new DateTimeOffset(2026, 3, 14, 12, 0, 0, TimeSpan.Zero)));
         var context = new WorkflowBindingProjectionContext
         {
@@ -59,7 +58,7 @@ public sealed class WorkflowActorBindingProjectorTests
     public async Task ProjectAsync_ShouldCaptureRunBinding_AndNormalizeRunId()
     {
         var dispatcher = new FakeStoreDispatcher();
-        var projector = new WorkflowActorBindingProjector(dispatcher, dispatcher, new StaticClock(DateTimeOffset.UtcNow));
+        var projector = new WorkflowActorBindingProjector(dispatcher, new StaticClock(DateTimeOffset.UtcNow));
         var context = new WorkflowBindingProjectionContext
         {
             RootActorId = "actor-2",
@@ -96,7 +95,7 @@ public sealed class WorkflowActorBindingProjectorTests
     public async Task ProjectAsync_ShouldIgnoreUnrelatedEvents()
     {
         var dispatcher = new FakeStoreDispatcher();
-        var projector = new WorkflowActorBindingProjector(dispatcher, dispatcher, new StaticClock(DateTimeOffset.UtcNow));
+        var projector = new WorkflowActorBindingProjector(dispatcher, new StaticClock(DateTimeOffset.UtcNow));
         var context = new WorkflowBindingProjectionContext
         {
             RootActorId = "actor-3",
@@ -118,11 +117,67 @@ public sealed class WorkflowActorBindingProjectorTests
         dispatcher.Documents.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task ProjectAsync_ShouldOverwriteBindingDocument_FromCommittedPayloadOnly()
+    {
+        var dispatcher = new FakeStoreDispatcher();
+        var projector = new WorkflowActorBindingProjector(
+            dispatcher,
+            new StaticClock(new DateTimeOffset(2026, 3, 14, 13, 0, 0, TimeSpan.Zero)));
+        var context = new WorkflowBindingProjectionContext
+        {
+            RootActorId = "actor-4",
+            ProjectionKind = "workflow-binding",
+        };
+
+        await projector.ProjectAsync(
+            context,
+            WrapCommitted(
+                new BindWorkflowDefinitionEvent
+                {
+                    WorkflowName = " first ",
+                    WorkflowYaml = "name: first",
+                    ScopeId = " scope-a ",
+                    InlineWorkflowYamls =
+                    {
+                        ["kept-only-if-replayed"] = "old-yaml",
+                    },
+                },
+                version: 4,
+                id: "evt-first",
+                utcTimestamp: new DateTime(2026, 3, 14, 13, 0, 0, DateTimeKind.Utc)),
+            CancellationToken.None);
+
+        await projector.ProjectAsync(
+            context,
+            WrapCommitted(
+                new BindWorkflowDefinitionEvent
+                {
+                    WorkflowName = " second ",
+                    WorkflowYaml = "name: second",
+                    ScopeId = " scope-b ",
+                },
+                version: 5,
+                id: "evt-second",
+                utcTimestamp: new DateTime(2026, 3, 14, 13, 1, 0, DateTimeKind.Utc)),
+            CancellationToken.None);
+
+        var document = dispatcher.Documents["actor-4"];
+        document.WorkflowName.Should().Be("second");
+        document.WorkflowYaml.Should().Be("name: second");
+        document.ScopeId.Should().Be("scope-b");
+        document.InlineWorkflowYamls.Should().BeEmpty();
+        document.CreatedAt.Should().Be(new DateTimeOffset(2026, 3, 14, 13, 1, 0, TimeSpan.Zero));
+        document.UpdatedAt.Should().Be(new DateTimeOffset(2026, 3, 14, 13, 1, 0, TimeSpan.Zero));
+        document.LastEventId.Should().Be("evt-second");
+        dispatcher.ReadCount.Should().Be(0);
+    }
+
     private sealed class FakeStoreDispatcher
-        : IProjectionWriteDispatcher<WorkflowActorBindingDocument>,
-          IProjectionDocumentReader<WorkflowActorBindingDocument, string>
+        : IProjectionWriteDispatcher<WorkflowActorBindingDocument>
     {
         public Dictionary<string, WorkflowActorBindingDocument> Documents { get; } = new(StringComparer.Ordinal);
+        public int ReadCount { get; private set; }
 
         public Task<ProjectionWriteResult> UpsertAsync(WorkflowActorBindingDocument readModel, CancellationToken ct = default)
         {
@@ -138,26 +193,6 @@ public sealed class WorkflowActorBindingProjectorTests
             return Task.FromResult(removed
                 ? ProjectionWriteResult.Applied()
                 : ProjectionWriteResult.Duplicate());
-        }
-
-        public Task<WorkflowActorBindingDocument?> GetAsync(string key, CancellationToken ct = default)
-        {
-            ct.ThrowIfCancellationRequested();
-            return Task.FromResult(Documents.TryGetValue(key, out var document) ? document.Clone() : null);
-        }
-
-        public Task<ProjectionDocumentQueryResult<WorkflowActorBindingDocument>> QueryAsync(
-            ProjectionDocumentQuery query,
-            CancellationToken ct = default)
-        {
-            ct.ThrowIfCancellationRequested();
-            return Task.FromResult(new ProjectionDocumentQueryResult<WorkflowActorBindingDocument>
-            {
-                Items = Documents.Values
-                    .Take(query.Take <= 0 ? 50 : query.Take)
-                    .Select(static x => x.Clone())
-                    .ToList(),
-            });
         }
     }
 

--- a/tools/ci/projection_state_mirror_current_state_guard.sh
+++ b/tools/ci/projection_state_mirror_current_state_guard.sh
@@ -16,6 +16,7 @@ FILES=(
   "src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowExecutionCurrentStateProjector.cs"
 )
 MAPPED_CURRENT_STATE_HELPER="src/Aevatar.CQRS.Projection.Core/Orchestration/MappedCurrentStateProjectionMaterializer.cs"
+WORKFLOW_BINDING_PROJECTOR="src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowActorBindingProjector.cs"
 
 legacy_reader_hits="$(
   rg -n "IProjectionDocumentReader<|_documentReader|IProjectionEventReducer<|_reducersByType|EventEnvelopeTimestampResolver\\.Resolve\\(" \
@@ -26,6 +27,18 @@ legacy_reader_hits="$(
 if [[ -n "${legacy_reader_hits}" ]]; then
   echo "${legacy_reader_hits}"
   echo "Current-state projector paths must not read old readmodels, use reducers, or rely on raw envelope timestamp helpers."
+  exit 1
+fi
+
+binding_reader_hits="$(
+  rg -n "IProjectionDocumentReader<|_documentReader|GetOrCreateAsync|\\.GetAsync\\(" \
+    "${WORKFLOW_BINDING_PROJECTOR}" \
+    || true
+)"
+
+if [[ -n "${binding_reader_hits}" ]]; then
+  echo "${binding_reader_hits}"
+  echo "Workflow actor binding projector must construct full documents from committed event payloads without reading prior readmodels."
   exit 1
 fi
 


### PR DESCRIPTION
## 摘要

closes #1436(由 Phase 9 r1 split first-slice 产生,#1435 META_JUDGE_DONE:split)。

### Old
`WorkflowActorBindingProjector` 在 materialize 时通过 `IProjectionDocumentReader<WorkflowActorBindingDocument,string>` 读取目标 document 后合并字段。

### New
直接从 committed event payload + `context.RootActorId` + `eventId` + `stateVersion` + `timestamp` 构造完整 document,通过 `IProjectionWriteDispatcher` 覆盖写入。删除 reader 注入 + `GetOrCreateAsync` helper。

### 违反
- CLAUDE.md「projection 负责物化,不负责推导」
- CLAUDE.md「覆盖复制优先:readmodel 写入语义是基于权威源版本的单调覆盖」

## 范围

3 files changed:
- `src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowActorBindingProjector.cs`
- `test/Aevatar.Workflow.Host.Api.Tests/WorkflowBindingReaderCoverageTests.cs`
- `tools/ci/projection_state_mirror_current_state_guard.sh`

## Stacked-PR

base = `auto-refact-dev`

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
