### PR TITLE
#1438 first slice: GAgentService tool payload typed Struct/Value(切断 JSON write)

### DIFF
--- a/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
@@ -187,14 +187,22 @@ message LlmSessionRuntimeChatMessage {
 message LlmSessionRuntimeToolCall {
   string call_id = 1;
   string tool_name = 2;
+  // Refactor (iter355/issue1438-first):
+  //   Old pattern: durable LlmSession runtime tool calls persisted arguments only as arguments_json.
+  //   New principle: arguments is the typed write path; arguments_json remains legacy read fallback.
   string arguments_json = 3;
+  google.protobuf.Struct arguments = 4;
 }
 
 message LlmSessionRuntimeToolDeclaration {
   string tool_name = 1;
   string description = 2;
+  // Refactor (iter355/issue1438-first):
+  //   Old pattern: forwarded tool schemas entered actor commands as parameters_json.
+  //   New principle: parameters is the typed write path; parameters_json remains legacy read fallback.
   string parameters_json = 3;
   string schema_hash = 4;
+  google.protobuf.Struct parameters = 5;
 }
 
 message LlmSessionRuntimeToolSelection {
@@ -202,7 +210,11 @@ message LlmSessionRuntimeToolSelection {
   repeated string substituted_tool_names = 2;
   repeated string additive_tool_names = 3;
   string tool_choice_hint_name = 4;
+  // Refactor (iter355/issue1438-first):
+  //   Old pattern: server-trusted tool choice hints persisted prefilled args as JSON string.
+  //   New principle: typed Struct carries new writes; JSON is only legacy read fallback.
   string tool_choice_hint_arguments_json = 5;
+  google.protobuf.Struct tool_choice_hint_arguments = 6;
 }
 
 message LlmRunRequested {
@@ -236,8 +248,12 @@ message LlmToolCallObserved {
   int32 round = 3;
   LlmSessionRuntimeToolCall tool_call = 4;
   bool forwarded = 5;
+  // Refactor (iter355/issue1438-first):
+  //   Old pattern: local tool result facts persisted as local_result_json.
+  //   New principle: local_result is typed Value primary; local_result_json remains read fallback.
   string local_result_json = 6;
   google.protobuf.Timestamp observed_at = 7;
+  google.protobuf.Value local_result = 8;
 }
 
 message LlmRunCompleted {
@@ -298,10 +314,14 @@ message ChatRunToolCallRecord {
   string tool_call_id = 1;
   string tool_name = 2;
   google.protobuf.Struct arguments = 3;
+  // Refactor (iter355/issue1438-first):
+  //   Old pattern: ChatRun tool results persisted only as internal_result_json strings.
+  //   New principle: internal_result is typed Value primary; internal_result_json remains fallback.
   string internal_result_json = 4;
   int32 llm_round = 5;
   string run_id = 6;
   google.protobuf.Timestamp observed_at = 7;
+  google.protobuf.Value internal_result = 8;
 }
 
 message ChatRunSubRunSubscription {
@@ -365,6 +385,9 @@ message SubmitChatRunToolCallRequested {
   string tool_call_id = 1;
   string tool_name = 2;
   google.protobuf.Struct arguments = 3;
+  // Refactor (iter355/issue1438-first):
+  //   Old pattern: ChatRun submit command carried internal result as JSON string.
+  //   New principle: internal_result is typed Value primary; internal_result_json remains fallback.
   string internal_result_json = 4;
   string run_id = 5;
   ChatRunSubRunTargetKind target_kind = 6;
@@ -376,12 +399,16 @@ message SubmitChatRunToolCallRequested {
   string endpoint_id = 12;
   int32 llm_round = 13;
   google.protobuf.Timestamp observed_at = 14;
+  google.protobuf.Value internal_result = 15;
 }
 
 message ChatRunToolCallSubmittedEvent {
   string tool_call_id = 1;
   string tool_name = 2;
   google.protobuf.Struct arguments = 3;
+  // Refactor (iter355/issue1438-first):
+  //   Old pattern: ChatRun submitted event persisted internal result as JSON string.
+  //   New principle: internal_result is typed Value primary; internal_result_json remains fallback.
   string internal_result_json = 4;
   string run_id = 5;
   ChatRunSubRunTargetKind target_kind = 6;
@@ -393,6 +420,7 @@ message ChatRunToolCallSubmittedEvent {
   string endpoint_id = 12;
   int32 llm_round = 13;
   google.protobuf.Timestamp observed_at = 14;
+  google.protobuf.Value internal_result = 15;
 }
 
 message PrepareChatRunSubRunObservationRequested {
@@ -430,18 +458,25 @@ message ChatRunSubRunObservationStartedEvent {
 message ChatRunSubRunTerminalObserved {
   string run_id = 1;
   string status = 2;
+  // Refactor (iter355/issue1438-first):
+  //   Old pattern: ChatRun terminal observation carried folded payload as internal_result_json.
+  //   New principle: internal_result is typed Value primary; internal_result_json remains fallback.
   string internal_result_json = 3;
   string actor_id = 4;
   string service_id = 5;
   string endpoint_id = 6;
   google.protobuf.Timestamp observed_at = 7;
   bool completion_observed = 8;
+  google.protobuf.Value internal_result = 9;
 }
 
 message ChatRunSubRunTerminalFoldedEvent {
   string run_id = 1;
   string caller_tool_call_id = 2;
   string tool_name = 3;
+  // Refactor (iter355/issue1438-first):
+  //   Old pattern: folded ChatRun result event stored only internal_result_json.
+  //   New principle: internal_result is typed Value primary; internal_result_json remains fallback.
   string internal_result_json = 4;
   int32 llm_round = 5;
   google.protobuf.Timestamp observed_at = 6;
@@ -450,6 +485,7 @@ message ChatRunSubRunTerminalFoldedEvent {
   string service_id = 9;
   string endpoint_id = 10;
   bool completion_observed = 11;
+  google.protobuf.Value internal_result = 12;
 }
 
 message ChatRunToolResultReady {
@@ -457,6 +493,9 @@ message ChatRunToolResultReady {
   string run_id = 2;
   string caller_tool_call_id = 3;
   string tool_name = 4;
+  // Refactor (iter355/issue1438-first):
+  //   Old pattern: ChatRun readiness payload exposed only internal_result_json.
+  //   New principle: internal_result is typed Value primary; internal_result_json remains fallback.
   string internal_result_json = 5;
   int32 llm_round = 6;
   string status = 7;
@@ -464,6 +503,7 @@ message ChatRunToolResultReady {
   string service_id = 9;
   string endpoint_id = 10;
   bool completion_observed = 11;
+  google.protobuf.Value internal_result = 12;
 }
 
 message TerminateChatRunRequested {

--- a/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
@@ -187,9 +187,7 @@ message LlmSessionRuntimeChatMessage {
 message LlmSessionRuntimeToolCall {
   string call_id = 1;
   string tool_name = 2;
-  // Refactor (iter355/issue1438-first):
-  //   Old pattern: durable LlmSession runtime tool calls persisted arguments only as arguments_json.
-  //   New principle: arguments is the typed write path; arguments_json remains legacy read fallback.
+  // Refactor (iter355/issue1438-first): Old pattern: durable LlmSession runtime tool calls persisted arguments only as arguments_json. New principle: arguments is the typed write path; arguments_json remains legacy read fallback.
   string arguments_json = 3;
   google.protobuf.Struct arguments = 4;
 }
@@ -197,9 +195,7 @@ message LlmSessionRuntimeToolCall {
 message LlmSessionRuntimeToolDeclaration {
   string tool_name = 1;
   string description = 2;
-  // Refactor (iter355/issue1438-first):
-  //   Old pattern: forwarded tool schemas entered actor commands as parameters_json.
-  //   New principle: parameters is the typed write path; parameters_json remains legacy read fallback.
+  // Refactor (iter355/issue1438-first): Old pattern: forwarded tool schemas entered actor commands as parameters_json. New principle: parameters is the typed write path; parameters_json remains legacy read fallback.
   string parameters_json = 3;
   string schema_hash = 4;
   google.protobuf.Struct parameters = 5;
@@ -210,9 +206,7 @@ message LlmSessionRuntimeToolSelection {
   repeated string substituted_tool_names = 2;
   repeated string additive_tool_names = 3;
   string tool_choice_hint_name = 4;
-  // Refactor (iter355/issue1438-first):
-  //   Old pattern: server-trusted tool choice hints persisted prefilled args as JSON string.
-  //   New principle: typed Struct carries new writes; JSON is only legacy read fallback.
+  // Refactor (iter355/issue1438-first): Old pattern: server-trusted tool choice hints persisted prefilled args as JSON string. New principle: typed Struct carries new writes; JSON is only legacy read fallback.
   string tool_choice_hint_arguments_json = 5;
   google.protobuf.Struct tool_choice_hint_arguments = 6;
 }
@@ -248,9 +242,7 @@ message LlmToolCallObserved {
   int32 round = 3;
   LlmSessionRuntimeToolCall tool_call = 4;
   bool forwarded = 5;
-  // Refactor (iter355/issue1438-first):
-  //   Old pattern: local tool result facts persisted as local_result_json.
-  //   New principle: local_result is typed Value primary; local_result_json remains read fallback.
+  // Refactor (iter355/issue1438-first): Old pattern: local tool result facts persisted as local_result_json. New principle: local_result is typed Value primary; local_result_json remains read fallback.
   string local_result_json = 6;
   google.protobuf.Timestamp observed_at = 7;
   google.protobuf.Value local_result = 8;
@@ -314,9 +306,7 @@ message ChatRunToolCallRecord {
   string tool_call_id = 1;
   string tool_name = 2;
   google.protobuf.Struct arguments = 3;
-  // Refactor (iter355/issue1438-first):
-  //   Old pattern: ChatRun tool results persisted only as internal_result_json strings.
-  //   New principle: internal_result is typed Value primary; internal_result_json remains fallback.
+  // Refactor (iter355/issue1438-first): Old pattern: ChatRun tool results persisted only as internal_result_json strings. New principle: internal_result is typed Value primary; internal_result_json remains fallback.
   string internal_result_json = 4;
   int32 llm_round = 5;
   string run_id = 6;
@@ -385,9 +375,7 @@ message SubmitChatRunToolCallRequested {
   string tool_call_id = 1;
   string tool_name = 2;
   google.protobuf.Struct arguments = 3;
-  // Refactor (iter355/issue1438-first):
-  //   Old pattern: ChatRun submit command carried internal result as JSON string.
-  //   New principle: internal_result is typed Value primary; internal_result_json remains fallback.
+  // Refactor (iter355/issue1438-first): Old pattern: ChatRun submit command carried internal result as JSON string. New principle: internal_result is typed Value primary; internal_result_json remains fallback.
   string internal_result_json = 4;
   string run_id = 5;
   ChatRunSubRunTargetKind target_kind = 6;
@@ -406,9 +394,7 @@ message ChatRunToolCallSubmittedEvent {
   string tool_call_id = 1;
   string tool_name = 2;
   google.protobuf.Struct arguments = 3;
-  // Refactor (iter355/issue1438-first):
-  //   Old pattern: ChatRun submitted event persisted internal result as JSON string.
-  //   New principle: internal_result is typed Value primary; internal_result_json remains fallback.
+  // Refactor (iter355/issue1438-first): Old pattern: ChatRun submitted event persisted internal result as JSON string. New principle: internal_result is typed Value primary; internal_result_json remains fallback.
   string internal_result_json = 4;
   string run_id = 5;
   ChatRunSubRunTargetKind target_kind = 6;
@@ -458,9 +444,7 @@ message ChatRunSubRunObservationStartedEvent {
 message ChatRunSubRunTerminalObserved {
   string run_id = 1;
   string status = 2;
-  // Refactor (iter355/issue1438-first):
-  //   Old pattern: ChatRun terminal observation carried folded payload as internal_result_json.
-  //   New principle: internal_result is typed Value primary; internal_result_json remains fallback.
+  // Refactor (iter355/issue1438-first): Old pattern: ChatRun terminal observation carried folded payload as internal_result_json. New principle: internal_result is typed Value primary; internal_result_json remains fallback.
   string internal_result_json = 3;
   string actor_id = 4;
   string service_id = 5;
@@ -474,9 +458,7 @@ message ChatRunSubRunTerminalFoldedEvent {
   string run_id = 1;
   string caller_tool_call_id = 2;
   string tool_name = 3;
-  // Refactor (iter355/issue1438-first):
-  //   Old pattern: folded ChatRun result event stored only internal_result_json.
-  //   New principle: internal_result is typed Value primary; internal_result_json remains fallback.
+  // Refactor (iter355/issue1438-first): Old pattern: folded ChatRun result event stored only internal_result_json. New principle: internal_result is typed Value primary; internal_result_json remains fallback.
   string internal_result_json = 4;
   int32 llm_round = 5;
   google.protobuf.Timestamp observed_at = 6;
@@ -493,9 +475,7 @@ message ChatRunToolResultReady {
   string run_id = 2;
   string caller_tool_call_id = 3;
   string tool_name = 4;
-  // Refactor (iter355/issue1438-first):
-  //   Old pattern: ChatRun readiness payload exposed only internal_result_json.
-  //   New principle: internal_result is typed Value primary; internal_result_json remains fallback.
+  // Refactor (iter355/issue1438-first): Old pattern: ChatRun readiness payload exposed only internal_result_json. New principle: internal_result is typed Value primary; internal_result_json remains fallback.
   string internal_result_json = 5;
   int32 llm_round = 6;
   string status = 7;

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ChatCompletionsCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ChatCompletionsCommandFacade.cs
@@ -526,10 +526,14 @@ public sealed class ChatCompletionsCommandFacade(
                 CallId = call.Id,
                 ToolName = call.Name,
                 ArgumentsJson = call.ArgumentsJson,
+                Arguments = ResponsesProtoPayloads.ParseStruct(call.ArgumentsJson),
             }));
         return result;
     }
 
+    // Refactor (iter355/issue1438-first):
+    //   Old pattern: Chat Completions LlmRunRequested persisted tool schemas and hints as JSON strings.
+    //   New principle: typed Struct fields carry new writes; JSON strings remain legacy fallback.
     private static LlmSessionRuntimeToolSelection ToToolSelection(
         ResponsesToolClassification classification,
         ResponsesToolChoiceHintPlan toolChoiceHintPlan)
@@ -543,6 +547,7 @@ public sealed class ChatCompletionsCommandFacade(
         {
             selection.ToolChoiceHintName = toolChoiceHintPlan.ToolName;
             selection.ToolChoiceHintArgumentsJson = toolChoiceHintPlan.PrefilledArgumentsJson();
+            selection.ToolChoiceHintArguments = toolChoiceHintPlan.PrefilledArgumentsStruct();
         }
 
         selection.ForwardedTools.AddRange(classification.ForwardedTools.Select(static tool =>
@@ -551,6 +556,7 @@ public sealed class ChatCompletionsCommandFacade(
                 ToolName = tool.Name,
                 Description = tool.Description,
                 ParametersJson = tool.ParametersJson,
+                Parameters = ResponsesProtoPayloads.ParseStruct(tool.ParametersJson),
                 SchemaHash = tool.SchemaHash,
             }));
         return selection;

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ChatRunToolCompletionCoordinator.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ChatRunToolCompletionCoordinator.cs
@@ -35,9 +35,9 @@ public sealed class ChatRunToolCompletionCoordinator
     private readonly IServiceRunQueryPort _serviceRunQueryPort;
     private readonly IWorkflowExecutionQueryApplicationService _workflowQueryService;
 
-    // Refactor (iter1334/cluster-1334-chatrun-result-json-boundary-quarantine):
-    // Old pattern: ChatRun completion coordination named folded actor results as generic ResultJson.
-    // New principle: actor-internal terminal payloads use internal_result_json and only boundary dispatch JSON remains boundary-named.
+    // Refactor (iter355/issue1438-first):
+    //   Old pattern: ChatRun completion coordination handed durable actor events only JSON strings.
+    //   New principle: adapter/actor convert boundary JSON to typed Value; JSON remains boundary/fallback surface.
     public ChatRunToolCompletionCoordinator(
         IChatRunActorPort chatRunActorPort,
         IGAgentRunTerminalQueryPort gagentTerminalQueryPort,

--- a/src/platform/Aevatar.GAgentService.Application/Responses/MessagesCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/MessagesCommandFacade.cs
@@ -509,10 +509,14 @@ public sealed class MessagesCommandFacade(
                 CallId = call.Id,
                 ToolName = call.Name,
                 ArgumentsJson = call.ArgumentsJson,
+                Arguments = ResponsesProtoPayloads.ParseStruct(call.ArgumentsJson),
             }));
         return result;
     }
 
+    // Refactor (iter355/issue1438-first):
+    //   Old pattern: Messages LlmRunRequested persisted tool schemas and hints as JSON strings.
+    //   New principle: typed Struct fields carry new writes; JSON strings remain legacy fallback.
     private static LlmSessionRuntimeToolSelection ToToolSelection(
         ResponsesToolClassification classification,
         ResponsesToolChoiceHintPlan toolChoiceHintPlan)
@@ -526,6 +530,7 @@ public sealed class MessagesCommandFacade(
         {
             selection.ToolChoiceHintName = toolChoiceHintPlan.ToolName;
             selection.ToolChoiceHintArgumentsJson = toolChoiceHintPlan.PrefilledArgumentsJson();
+            selection.ToolChoiceHintArguments = toolChoiceHintPlan.PrefilledArgumentsStruct();
         }
 
         selection.ForwardedTools.AddRange(classification.ForwardedTools.Select(static tool =>
@@ -534,6 +539,7 @@ public sealed class MessagesCommandFacade(
                 ToolName = tool.Name,
                 Description = tool.Description,
                 ParametersJson = tool.ParametersJson,
+                Parameters = ResponsesProtoPayloads.ParseStruct(tool.ParametersJson),
                 SchemaHash = tool.SchemaHash,
             }));
         return selection;

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandFacade.cs
@@ -856,8 +856,12 @@ public sealed class ResponsesCommandFacade(
             CallId = call.Id,
             ToolName = call.Name,
             ArgumentsJson = call.ArgumentsJson,
+            Arguments = ResponsesProtoPayloads.ParseStruct(call.ArgumentsJson),
         };
 
+    // Refactor (iter355/issue1438-first):
+    //   Old pattern: durable LlmSession tool declarations and choice hints wrote only *_json strings.
+    //   New principle: typed Struct fields are the write path; legacy strings stay populated for fallback reads.
     private static LlmSessionRuntimeToolSelection ToToolSelection(
         ResponsesToolClassification classification,
         ResponsesToolChoiceHintPlan toolChoiceHintPlan)
@@ -871,6 +875,7 @@ public sealed class ResponsesCommandFacade(
         {
             selection.ToolChoiceHintName = toolChoiceHintPlan.ToolName;
             selection.ToolChoiceHintArgumentsJson = toolChoiceHintPlan.PrefilledArgumentsJson();
+            selection.ToolChoiceHintArguments = toolChoiceHintPlan.PrefilledArgumentsStruct();
         }
 
         selection.ForwardedTools.AddRange(classification.ForwardedTools.Select(static tool =>
@@ -879,6 +884,7 @@ public sealed class ResponsesCommandFacade(
                 ToolName = tool.Name,
                 Description = tool.Description,
                 ParametersJson = tool.ParametersJson,
+                Parameters = ResponsesProtoPayloads.ParseStruct(tool.ParametersJson),
                 SchemaHash = tool.SchemaHash,
             }));
         return selection;

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesProtoPayloads.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesProtoPayloads.cs
@@ -5,7 +5,9 @@ namespace Aevatar.GAgentService.Application.Responses;
 
 internal static class ResponsesProtoPayloads
 {
-    // refactor helper, no behavior change
+    // Refactor (iter355/issue1438-first):
+    //   Old pattern: Responses command builders persisted tool payload objects only as JSON strings.
+    //   New principle: typed Struct fields carry new writes; empty Struct is the legacy/invalid JSON fallback.
     public static Struct ParseStruct(string? json)
     {
         if (string.IsNullOrWhiteSpace(json))

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesProtoPayloads.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesProtoPayloads.cs
@@ -5,9 +5,7 @@ namespace Aevatar.GAgentService.Application.Responses;
 
 internal static class ResponsesProtoPayloads
 {
-    // Refactor (iter355/issue1438-first):
-    //   Old pattern: Responses command builders persisted tool payload objects only as JSON strings.
-    //   New principle: typed Struct fields carry new writes; empty Struct is the legacy/invalid JSON fallback.
+    // Refactor (iter355/issue1438-first): Old pattern: Responses command builders persisted tool payload objects only as JSON strings. New principle: typed Struct fields carry new writes; empty Struct is the legacy/invalid JSON fallback.
     public static Struct ParseStruct(string? json)
     {
         if (string.IsNullOrWhiteSpace(json))

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesProtoPayloads.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesProtoPayloads.cs
@@ -1,0 +1,23 @@
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgentService.Application.Responses;
+
+internal static class ResponsesProtoPayloads
+{
+    // refactor helper, no behavior change
+    public static Struct ParseStruct(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return new Struct();
+
+        try
+        {
+            return JsonParser.Default.Parse<Struct>(json);
+        }
+        catch
+        {
+            return new Struct();
+        }
+    }
+}

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesToolChoiceHints.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesToolChoiceHints.cs
@@ -61,6 +61,14 @@ public sealed class ResponsesToolChoiceHintPlan
                 .ToArray())
             .ToJsonString(new JsonSerializerOptions { WriteIndented = false });
 
+    // Refactor (iter355/issue1438-first):
+    //   Old pattern: durable LlmSession tool choice hint writes used only prefilled JSON strings.
+    //   New principle: command builders write typed Struct and keep JSON only as legacy fallback.
+    public Struct PrefilledArgumentsStruct() =>
+        string.IsNullOrWhiteSpace(PrefilledArgumentsJson())
+            ? new Struct()
+            : ResponsesProtoPayloads.ParseStruct(PrefilledArgumentsJson());
+
     public ToolCall Apply(ToolCall call)
     {
         ArgumentNullException.ThrowIfNull(call);

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/ChatRunActor.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/ChatRunActor.cs
@@ -508,6 +508,9 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
             state.ActiveSubRunSubscriptions.Add(subscription);
     }
 
+    // Refactor (iter355/issue1438-first):
+    //   Old pattern: ChatRun terminal tool results used internal_result_json as the durable authority.
+    //   New principle: typed Value is authoritative for new writes; internal_result_json remains read fallback.
     private static Value ResolveTerminalInternalResult(
         ChatRunSubRunSubscription pending,
         ChatRunSubRunTerminalObserved observed)

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/ChatRunActor.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/ChatRunActor.cs
@@ -17,9 +17,9 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
 {
     private static readonly Duration DefaultIdleTtl = Duration.FromTimeSpan(TimeSpan.FromMinutes(30));
 
-    // Refactor (iter1334/cluster-1334-chatrun-result-json-boundary-quarantine):
-    // Old pattern: ChatRun persisted folded tool results used generic ResultJson naming.
-    // New principle: ChatRun actor state and events quarantine that JSON as internal_result_json while boundary payload names remain explicit.
+    // Refactor (iter355/issue1438-first):
+    //   Old pattern: ChatRun tool contracts persisted internal results as internal_result_json strings.
+    //   New principle: typed Value fields are authoritative for new writes; legacy strings are read fallback only.
     public ChatRunActor()
     {
         InitializeId();
@@ -99,12 +99,14 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
         EnsureActive();
 
         var observedAt = command.ObservedAt ?? Timestamp.FromDateTime(DateTime.UtcNow);
+        var internalResult = ResolveInternalResult(command.InternalResult, command.InternalResultJson);
         await PersistDomainEventAsync(new ChatRunToolCallSubmittedEvent
         {
             ToolCallId = NormalizeRequired(command.ToolCallId, nameof(command.ToolCallId)),
             ToolName = NormalizeRequired(command.ToolName, nameof(command.ToolName)),
             Arguments = command.Arguments?.Clone() ?? new Struct(),
             InternalResultJson = command.InternalResultJson ?? string.Empty,
+            InternalResult = internalResult,
             RunId = command.RunId ?? string.Empty,
             TargetKind = command.TargetKind,
             TargetId = command.TargetId ?? string.Empty,
@@ -130,15 +132,15 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
         if (pending == null)
             return;
 
-        var internalResultJson = string.IsNullOrWhiteSpace(observed.InternalResultJson)
-            ? BuildDefaultInternalResultJson(pending, observed)
-            : observed.InternalResultJson;
+        var internalResult = ResolveTerminalInternalResult(pending, observed);
+        var internalResultJson = InternalResultJson(internalResult, observed.InternalResultJson);
         await PersistDomainEventAsync(new ChatRunSubRunTerminalFoldedEvent
         {
             RunId = runId,
             CallerToolCallId = pending.CallerToolCallId,
             ToolName = pending.ToolName,
             InternalResultJson = internalResultJson,
+            InternalResult = internalResult,
             LlmRound = pending.LlmRound,
             Status = observed.Status ?? string.Empty,
             ActorId = FirstNonEmpty(observed.ActorId, pending.ActorId),
@@ -156,6 +158,7 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
             CallerToolCallId = pending.CallerToolCallId,
             ToolName = pending.ToolName,
             InternalResultJson = internalResultJson,
+            InternalResult = internalResult.Clone(),
             LlmRound = pending.LlmRound,
             Status = observed.Status ?? string.Empty,
             ActorId = FirstNonEmpty(observed.ActorId, pending.ActorId),
@@ -194,11 +197,13 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
         if (pending == null)
             return;
 
+        var internalResult = BuildGAgentTerminalInternalResult(pending, completed);
         await HandleSubRunTerminalAsync(new ChatRunSubRunTerminalObserved
         {
             RunId = pending.RunId,
             Status = ResolveGAgentTerminalStatus(completed),
-            InternalResultJson = BuildGAgentTerminalInternalResultJson(pending, completed),
+            InternalResultJson = JsonFormatter.Default.Format(internalResult),
+            InternalResult = internalResult,
             ActorId = pending.ActorId,
             ServiceId = pending.ServiceId,
             EndpointId = pending.EndpointId,
@@ -270,7 +275,7 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
         var next = current.Clone();
         var existingHistory = next.ToolCallHistory
             .LastOrDefault(call => string.Equals(call.ToolCallId, evt.ToolCallId, StringComparison.Ordinal));
-        var alreadyFolded = existingHistory != null && !string.IsNullOrWhiteSpace(existingHistory.InternalResultJson);
+        var alreadyFolded = existingHistory != null && HasInternalResult(existingHistory);
         if (existingHistory == null)
         {
             next.ToolCallHistory.Add(new ChatRunToolCallRecord
@@ -279,6 +284,7 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
                 ToolName = evt.ToolName,
                 Arguments = evt.Arguments?.Clone() ?? new Struct(),
                 InternalResultJson = evt.InternalResultJson,
+                InternalResult = evt.InternalResult?.Clone(),
                 LlmRound = evt.LlmRound,
                 RunId = evt.RunId,
                 ObservedAt = evt.ObservedAt ?? Timestamp.FromDateTime(DateTime.UtcNow),
@@ -317,7 +323,7 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
         var next = current.Clone();
         var existingHistory = next.ToolCallHistory
             .LastOrDefault(call => string.Equals(call.ToolCallId, evt.ToolCallId, StringComparison.Ordinal));
-        if (existingHistory != null && !string.IsNullOrWhiteSpace(existingHistory.InternalResultJson))
+        if (existingHistory != null && HasInternalResult(existingHistory))
         {
             next.CurrentLlmRound = Math.Max(next.CurrentLlmRound, evt.LlmRound);
             next.LastActivityAt = evt.ObservedAt ?? Timestamp.FromDateTime(DateTime.UtcNow);
@@ -332,6 +338,7 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
                 ToolName = evt.ToolName,
                 Arguments = evt.Arguments?.Clone() ?? new Struct(),
                 InternalResultJson = string.Empty,
+                InternalResult = new Value { StructValue = new Struct() },
                 LlmRound = evt.LlmRound,
                 RunId = evt.RunId,
                 ObservedAt = evt.ObservedAt ?? Timestamp.FromDateTime(DateTime.UtcNow),
@@ -369,13 +376,17 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
         var history = next.ToolCallHistory
             .LastOrDefault(call => string.Equals(call.RunId, evt.RunId, StringComparison.Ordinal));
         if (history != null)
+        {
             history.InternalResultJson = evt.InternalResultJson;
+            history.InternalResult = evt.InternalResult?.Clone();
+        }
 
+        var internalResultJson = InternalResultJson(evt.InternalResult, evt.InternalResultJson);
         next.Messages.Add(new ChatRunMessageRecord
         {
             Role = "tool",
             ToolCallId = evt.CallerToolCallId,
-            Content = evt.InternalResultJson,
+            Content = internalResultJson,
         });
         next.CurrentLlmRound = evt.LlmRound + 1;
         next.LastActivityAt = evt.ObservedAt ?? Timestamp.FromDateTime(DateTime.UtcNow);
@@ -497,7 +508,33 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
             state.ActiveSubRunSubscriptions.Add(subscription);
     }
 
-    private static string BuildDefaultInternalResultJson(
+    private static Value ResolveTerminalInternalResult(
+        ChatRunSubRunSubscription pending,
+        ChatRunSubRunTerminalObserved observed)
+    {
+        if (IsMeaningfulValue(observed.InternalResult))
+        {
+            return observed.InternalResult.Clone();
+        }
+
+        if (!string.IsNullOrWhiteSpace(observed.InternalResultJson))
+            return ParseValue(observed.InternalResultJson);
+
+        return BuildDefaultInternalResult(pending, observed);
+    }
+
+    private static bool HasInternalResult(ChatRunToolCallRecord record) =>
+        IsMeaningfulValue(record.InternalResult) ||
+        !string.IsNullOrWhiteSpace(record.InternalResultJson);
+
+    private static Value ResolveInternalResult(Value? typed, string? legacyJson)
+    {
+        if (IsMeaningfulValue(typed))
+            return typed.Clone();
+        return ParseValue(legacyJson);
+    }
+
+    private static Value BuildDefaultInternalResult(
         ChatRunSubRunSubscription pending,
         ChatRunSubRunTerminalObserved observed)
     {
@@ -505,37 +542,69 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
         var actorId = FirstNonEmpty(observed.ActorId, pending.ActorId);
         var serviceId = FirstNonEmpty(observed.ServiceId, pending.ServiceId);
         var endpointId = FirstNonEmpty(observed.EndpointId, pending.EndpointId);
-        return System.Text.Json.JsonSerializer.Serialize(new
-        {
-            run_id = pending.RunId,
-            status,
-            actor_id = EmptyToNull(actorId),
-            service_id = EmptyToNull(serviceId),
-            endpoint_id = EmptyToNull(endpointId),
-            wait = "complete",
-        }, new System.Text.Json.JsonSerializerOptions
-        {
-            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
-        });
+        var result = new Struct();
+        SetString(result, "run_id", pending.RunId);
+        SetString(result, "status", status);
+        SetString(result, "actor_id", actorId);
+        SetString(result, "service_id", serviceId);
+        SetString(result, "endpoint_id", endpointId);
+        SetString(result, "wait", "complete");
+        return Value.ForStruct(result);
     }
 
-    private static string BuildGAgentTerminalInternalResultJson(
+    private static Value BuildGAgentTerminalInternalResult(
         ChatRunSubRunSubscription pending,
         RoleChatSessionCompletedEvent completed)
     {
-        return System.Text.Json.JsonSerializer.Serialize(new
+        var result = new Struct();
+        SetString(result, "run_id", pending.RunId);
+        SetString(result, "status", ResolveGAgentTerminalStatus(completed));
+        SetString(result, "actor_id", pending.ActorId);
+        SetString(result, "content", completed.Content ?? string.Empty);
+        SetString(result, "reasoning_content", completed.ReasoningContent ?? string.Empty);
+        result.Fields["content_emitted"] = Value.ForBool(completed.ContentEmitted);
+        SetString(result, "wait", "complete");
+        return Value.ForStruct(result);
+    }
+
+    private static string InternalResultJson(Value? typed, string? fallbackJson)
+    {
+        if (IsMeaningfulValue(typed))
+            return JsonFormatter.Default.Format(typed);
+        return fallbackJson ?? string.Empty;
+    }
+
+    private static bool IsMeaningfulValue(Value? value) =>
+        value?.KindCase switch
         {
-            run_id = pending.RunId,
-            status = ResolveGAgentTerminalStatus(completed),
-            actor_id = EmptyToNull(pending.ActorId),
-            content = EmptyToNull(completed.Content ?? string.Empty),
-            reasoning_content = EmptyToNull(completed.ReasoningContent ?? string.Empty),
-            content_emitted = completed.ContentEmitted,
-            wait = "complete",
-        }, new System.Text.Json.JsonSerializerOptions
+            Value.KindOneofCase.StructValue => value.StructValue.Fields.Count > 0,
+            Value.KindOneofCase.ListValue => value.ListValue.Values.Count > 0,
+            Value.KindOneofCase.StringValue => !string.IsNullOrWhiteSpace(value.StringValue),
+            Value.KindOneofCase.NumberValue => true,
+            Value.KindOneofCase.BoolValue => true,
+            Value.KindOneofCase.NullValue => true,
+            _ => false,
+        };
+
+    private static Value ParseValue(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return new Value { StructValue = new Struct() };
+
+        try
         {
-            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
-        });
+            return JsonParser.Default.Parse<Value>(json);
+        }
+        catch
+        {
+            return Value.ForString(json);
+        }
+    }
+
+    private static void SetString(Struct result, string key, string value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+            result.Fields[key] = Value.ForString(value);
     }
 
     private static string ResolveGAgentTerminalStatus(RoleChatSessionCompletedEvent completed)
@@ -560,6 +629,4 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
         !string.IsNullOrWhiteSpace(first) ? first.Trim() :
         !string.IsNullOrWhiteSpace(second) ? second.Trim() : string.Empty;
 
-    private static string? EmptyToNull(string value) =>
-        string.IsNullOrWhiteSpace(value) ? null : value;
 }

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/ChatRunActor.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/ChatRunActor.cs
@@ -17,9 +17,7 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
 {
     private static readonly Duration DefaultIdleTtl = Duration.FromTimeSpan(TimeSpan.FromMinutes(30));
 
-    // Refactor (iter355/issue1438-first):
-    //   Old pattern: ChatRun tool contracts persisted internal results as internal_result_json strings.
-    //   New principle: typed Value fields are authoritative for new writes; legacy strings are read fallback only.
+    // Refactor (iter355/issue1438-first): Old pattern: ChatRun tool contracts persisted internal results as internal_result_json strings. New principle: typed Value fields are authoritative for new writes; legacy strings are read fallback only.
     public ChatRunActor()
     {
         InitializeId();
@@ -508,9 +506,7 @@ public sealed class ChatRunActor : GAgentBase<ChatRunState>
             state.ActiveSubRunSubscriptions.Add(subscription);
     }
 
-    // Refactor (iter355/issue1438-first):
-    //   Old pattern: ChatRun terminal tool results used internal_result_json as the durable authority.
-    //   New principle: typed Value is authoritative for new writes; internal_result_json remains read fallback.
+    // Refactor (iter355/issue1438-first): Old pattern: ChatRun terminal tool results used internal_result_json as the durable authority. New principle: typed Value is authoritative for new writes; internal_result_json remains read fallback.
     private static Value ResolveTerminalInternalResult(
         ChatRunSubRunSubscription pending,
         ChatRunSubRunTerminalObserved observed)

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
@@ -16,9 +16,9 @@ namespace Aevatar.GAgentService.Core.GAgents;
 // Refactor (iter75/cluster-075-responses-agui-host-completion-state):
 //   Old pattern: direct route forwarding bypassed the LLM tool loop and forced Host-side completion synthesis
 //   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
-// Refactor (iter81/cluster-081-direct-response-completion-not-session-fact):
-//   Old pattern: direct Responses/Messages held terminal completion in request-local result; LlmSession only marked Completed
-//   New principle: record typed LlmSessionCompletion on session for direct paths; terminal protocol output renders from session contract/readmodel
+// Refactor (iter355/issue1438-first):
+//   Old pattern: durable LlmSession tool runtime contracts persisted arguments, schemas, hints, and results as *_json strings
+//   New principle: typed Struct/Value fields are authoritative for new writes; legacy *_json fields are read fallback only
 public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
 {
     private static readonly Duration DefaultTtl = Duration.FromTimeSpan(TimeSpan.FromHours(24));
@@ -510,8 +510,7 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
             {
                 CallId = call.CallId,
                 ToolName = call.ToolName,
-                Result = ResponsesJsonValues.ParseBoundaryPayload(
-                    string.IsNullOrWhiteSpace(call.ArgumentsJson) ? "{}" : call.ArgumentsJson),
+                Result = RuntimeToolArgumentsValue(call),
             });
         }
 
@@ -792,9 +791,12 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
             foreach (var toolCall in localToolCalls)
             {
                 using var _ = AgentToolContextScope.Push(toolContext.WithCallId(toolCall.Id));
+                var argumentsJson = string.IsNullOrWhiteSpace(toolCall.ArgumentsJson)
+                    ? "{}"
+                    : toolCall.ArgumentsJson;
                 var result = toolsByName.TryGetValue(toolCall.Name, out var tool)
                     ? await tool.ExecuteAsync(
-                        string.IsNullOrWhiteSpace(toolCall.ArgumentsJson) ? "{}" : toolCall.ArgumentsJson,
+                        argumentsJson,
                         ct)
                     : System.Text.Json.JsonSerializer.Serialize(new
                     {
@@ -810,6 +812,7 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
                     ToolCall = ToRuntimeToolCall(toolCall),
                     Forwarded = false,
                     LocalResultJson = result,
+                    LocalResult = ResponsesJsonValues.ParseBoundaryPayload(result),
                     ObservedAt = Timestamp.FromDateTime(DateTime.UtcNow),
                 });
                 messages.Add(ChatMessage.Tool(toolCall.Id, result));
@@ -855,7 +858,7 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
         {
             Id = call.CallId,
             Name = call.ToolName,
-            ArgumentsJson = call.ArgumentsJson,
+            ArgumentsJson = RuntimeToolArgumentsJson(call),
         };
 
     private static LlmSessionRuntimeToolCall ToRuntimeToolCall(ToolCall call) =>
@@ -864,6 +867,7 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
             CallId = call.Id,
             ToolName = call.Name,
             ArgumentsJson = call.ArgumentsJson,
+            Arguments = ParseStruct(call.ArgumentsJson),
         };
 
     private static LlmSessionTokenUsage ToSessionUsage(TokenUsage usage) =>
@@ -933,7 +937,7 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
         JsonObject prefilled;
         try
         {
-            prefilled = ParseJsonObject(selection.ToolChoiceHintArgumentsJson);
+            prefilled = ParseJsonObject(ToolChoiceHintArgumentsJson(selection));
         }
         catch (JsonException ex)
         {
@@ -995,6 +999,68 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
                ?? throw new JsonException("Root value must be an object.");
     }
 
+    // refactor helper, no behavior change
+    private static Struct ParseStruct(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return new Struct();
+
+        try
+        {
+            return JsonParser.Default.Parse<Struct>(json);
+        }
+        catch
+        {
+            return new Struct();
+        }
+    }
+
+    private static string RuntimeToolArgumentsJson(LlmSessionRuntimeToolCall call)
+    {
+        if (call.Arguments is { Fields.Count: > 0 })
+            return JsonFormatter.Default.Format(call.Arguments);
+        return string.IsNullOrWhiteSpace(call.ArgumentsJson) ? "{}" : call.ArgumentsJson;
+    }
+
+    private static Value RuntimeToolArgumentsValue(LlmSessionRuntimeToolCall call)
+    {
+        if (call.Arguments is { Fields.Count: > 0 })
+            return Value.ForStruct(call.Arguments.Clone());
+        return ResponsesJsonValues.ParseBoundaryPayload(
+            string.IsNullOrWhiteSpace(call.ArgumentsJson) ? "{}" : call.ArgumentsJson);
+    }
+
+    private static Value ToolCallArgumentsValue(ToolCall call)
+    {
+        var arguments = ParseStruct(call.ArgumentsJson);
+        if (arguments.Fields.Count > 0)
+            return Value.ForStruct(arguments);
+        return ResponsesJsonValues.ParseBoundaryPayload(
+            string.IsNullOrWhiteSpace(call.ArgumentsJson) ? "{}" : call.ArgumentsJson);
+    }
+
+    private static string ToolChoiceHintArgumentsJson(LlmSessionRuntimeToolSelection selection)
+    {
+        if (selection.ToolChoiceHintArguments is { Fields.Count: > 0 })
+            return JsonFormatter.Default.Format(selection.ToolChoiceHintArguments);
+        return selection.ToolChoiceHintArgumentsJson;
+    }
+
+    private static string ToolDeclarationParametersJson(LlmSessionRuntimeToolDeclaration declaration)
+    {
+        if (declaration.Parameters is { Fields.Count: > 0 })
+            return JsonFormatter.Default.Format(declaration.Parameters);
+        return declaration.ParametersJson;
+    }
+
+    private static Struct MergeStruct(Struct? existing, Struct incoming)
+    {
+        var merged = existing?.Clone() ?? new Struct();
+        foreach (var (key, value) in incoming.Fields)
+            merged.Fields[key] = value.Clone();
+        return merged;
+    }
+
     private static ToolCall CloneWithArguments(ToolCall call, string argumentsJson) =>
         new()
         {
@@ -1050,8 +1116,7 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
             CallId = toolCall.Id,
             ToolName = toolCall.Name,
             SchemaHash = declaration?.SchemaHash ?? string.Empty,
-            Arguments = ResponsesJsonValues.ParseBoundaryPayload(
-                string.IsNullOrWhiteSpace(toolCall.ArgumentsJson) ? "{}" : toolCall.ArgumentsJson),
+            Arguments = ToolCallArgumentsValue(toolCall),
             Status = LlmSessionForwardedToolCallStatus.Pending,
             EmittedAt = Timestamp.FromDateTime(DateTime.UtcNow),
             Expiry = Timestamp.FromDateTime(DateTime.UtcNow.Add(DefaultTtl.ToTimeSpan())),
@@ -1107,6 +1172,8 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
 
         if (!string.IsNullOrWhiteSpace(incoming.ToolName))
             existing.ToolName = incoming.ToolName;
+        if (incoming.Arguments is { Fields.Count: > 0 })
+            existing.Arguments = MergeStruct(existing.Arguments, incoming.Arguments);
         if (!string.IsNullOrEmpty(incoming.ArgumentsJson))
             existing.ArgumentsJson += incoming.ArgumentsJson;
     }
@@ -1126,7 +1193,7 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
             ArgumentNullException.ThrowIfNull(declaration);
             Name = declaration.ToolName;
             Description = declaration.Description;
-            ParametersSchema = declaration.ParametersJson;
+            ParametersSchema = ToolDeclarationParametersJson(declaration);
         }
 
         public string Name { get; }

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
@@ -999,7 +999,9 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
                ?? throw new JsonException("Root value must be an object.");
     }
 
-    // refactor helper, no behavior change
+    // Refactor (iter355/issue1438-first):
+    //   Old pattern: durable LlmSession tool arguments were reconstructed from *_json strings.
+    //   New principle: actor payload helpers prefer typed Struct writes and keep empty Struct as legacy fallback.
     private static Struct ParseStruct(string? json)
     {
         if (string.IsNullOrWhiteSpace(json))

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
@@ -16,9 +16,7 @@ namespace Aevatar.GAgentService.Core.GAgents;
 // Refactor (iter75/cluster-075-responses-agui-host-completion-state):
 //   Old pattern: direct route forwarding bypassed the LLM tool loop and forced Host-side completion synthesis
 //   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
-// Refactor (iter355/issue1438-first):
-//   Old pattern: durable LlmSession tool runtime contracts persisted arguments, schemas, hints, and results as *_json strings
-//   New principle: typed Struct/Value fields are authoritative for new writes; legacy *_json fields are read fallback only
+// Refactor (iter355/issue1438-first): Old pattern: durable LlmSession tool runtime contracts persisted arguments, schemas, hints, and results as *_json strings New principle: typed Struct/Value fields are authoritative for new writes; legacy *_json fields are read fallback only
 public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
 {
     private static readonly Duration DefaultTtl = Duration.FromTimeSpan(TimeSpan.FromHours(24));
@@ -999,9 +997,7 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
                ?? throw new JsonException("Root value must be an object.");
     }
 
-    // Refactor (iter355/issue1438-first):
-    //   Old pattern: durable LlmSession tool arguments were reconstructed from *_json strings.
-    //   New principle: actor payload helpers prefer typed Struct writes and keep empty Struct as legacy fallback.
+    // Refactor (iter355/issue1438-first): Old pattern: durable LlmSession tool arguments were reconstructed from *_json strings. New principle: actor payload helpers prefer typed Struct writes and keep empty Struct as legacy fallback.
     private static Struct ParseStruct(string? json)
     {
         if (string.IsNullOrWhiteSpace(json))

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/ChatRunActorAdapter.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/ChatRunActorAdapter.cs
@@ -237,7 +237,9 @@ public sealed class ChatRunActorAdapter : IChatRunActorPort
         }
     }
 
-    // refactor helper, no behavior change
+    // Refactor (iter355/issue1438-first):
+    //   Old pattern: ChatRun boundary adapter forwarded tool results only through internal_result_json.
+    //   New principle: typed Value carries new writes; legacy JSON falls back to parsed Value or string payload.
     private static Value ParseValue(string? json)
     {
         if (string.IsNullOrWhiteSpace(json))

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/ChatRunActorAdapter.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/ChatRunActorAdapter.cs
@@ -15,9 +15,9 @@ public sealed class ChatRunActorAdapter : IChatRunActorPort
     private readonly IActorRuntime _runtime;
     private readonly IActorDispatchPort _dispatchPort;
 
-    // Refactor (iter1334/cluster-1334-chatrun-result-json-boundary-quarantine):
-    // Old pattern: boundary ToolExecutionResultJson was written into ChatRun commands as generic ResultJson.
-    // New principle: adapter quarantines it into internal_result_json before actor persistence.
+    // Refactor (iter355/issue1438-first):
+    //   Old pattern: ChatRun adapter persisted tool results only as internal_result_json.
+    //   New principle: adapter writes typed Value first and keeps internal_result_json as read fallback.
     public ChatRunActorAdapter(
         IActorRuntime runtime,
         IActorDispatchPort dispatchPort)
@@ -67,6 +67,7 @@ public sealed class ChatRunActorAdapter : IChatRunActorPort
             ToolName = NormalizeRequired(request.ToolCall.Name, nameof(request.ToolCall.Name)),
             Arguments = ParseStruct(request.ArgumentsJson),
             InternalResultJson = request.ToolExecutionResultJson ?? string.Empty,
+            InternalResult = ParseValue(request.ToolExecutionResultJson),
             RunId = target.RunId,
             TargetKind = ResolveTargetKind(request.ToolCall.Name),
             TargetId = ResolveTargetId(target),
@@ -233,6 +234,22 @@ public sealed class ChatRunActorAdapter : IChatRunActorPort
         catch
         {
             return new Struct();
+        }
+    }
+
+    // refactor helper, no behavior change
+    private static Value ParseValue(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return new Value { StructValue = new Struct() };
+
+        try
+        {
+            return JsonParser.Default.Parse<Value>(json);
+        }
+        catch
+        {
+            return Value.ForString(json);
         }
     }
 

--- a/test/Aevatar.GAgentService.Tests/Application/ChatCompletionsCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ChatCompletionsCommandFacadeTests.cs
@@ -7,6 +7,7 @@ using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Responses;
 using Aevatar.GAgentService.Application.Responses;
 using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aevatar.GAgentService.Tests.Application;
@@ -376,6 +377,66 @@ public sealed class ChatCompletionsCommandFacadeTests
         result.StreamPlan.LlmRequest.ResponseFormat.Should().BeSameAs(LLMResponseFormat.JsonObject);
     }
 
+    [Fact]
+    public async Task CreateAsync_WithToolPayloads_ShouldWriteTypedToolArgumentsSchemaAndChoiceHint()
+    {
+        var dispatch = new RecordingActorDispatchPort();
+        var facade = CreateFacade(
+            dispatchPort: dispatch,
+            chatRouteDecisionPort: new StaticResponsesChatRouteDecisionPort(GAgentToolHintAction("member-1")),
+            toolClassificationService: new StaticResponsesToolClassificationService(
+                new ResponsesToolClassification(
+                    [
+                        new ResponsesApplicationToolDeclaration(
+                            "get_weather",
+                            "Get weather",
+                            """{"type":"object","properties":{"city":{"type":"string"}}}""",
+                            "schema-1"),
+                    ],
+                    [],
+                    [],
+                    [])));
+
+        var result = await facade.CreateAsync(
+            BuildRequest(
+                "gpt-4o-mini",
+                chatMessages:
+                [
+                    new ChatMessage
+                    {
+                        Role = "assistant",
+                        ToolCalls =
+                        [
+                            new ToolCall
+                            {
+                                Id = "call-1",
+                                Name = "get_weather",
+                                ArgumentsJson = """{"city":"Paris"}""",
+                            },
+                        ],
+                    },
+                ],
+                declaredTools:
+                [
+                    new ResponsesApplicationToolDeclaration(
+                        "get_weather",
+                        "Get weather",
+                        """{"type":"object","properties":{"city":{"type":"string"}}}""",
+                        "schema-1"),
+                ]),
+            CallerScopeContext("token"));
+
+        result.Error.Should().BeNull();
+        var command = dispatch.Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
+        command.Messages.Should().ContainSingle().Which.ToolCalls.Should().ContainSingle()
+            .Which.Arguments.Fields["city"].StringValue.Should().Be("Paris");
+        command.ToolSelection.ToolChoiceHintArguments.Fields["actor_id"].StringValue.Should().Be("member-1");
+        var declaration = command.ToolSelection.ForwardedTools.Should().ContainSingle().Subject;
+        declaration.Parameters.Fields["type"].StringValue.Should().Be("object");
+        declaration.Parameters.Fields["properties"].StructValue.Fields["city"].StructValue.Fields["type"]
+            .StringValue.Should().Be("string");
+    }
+
     public static TheoryData<ChatCompletionsCommandRequest, string> InvalidRequests() => new()
     {
         { BuildRequest(" "), "model_required" },
@@ -390,7 +451,8 @@ public sealed class ChatCompletionsCommandFacadeTests
         double? temperature = null,
         int? maxTokens = 100,
         IReadOnlyList<ChatMessage>? chatMessages = null,
-        LLMResponseFormat? responseFormat = null) =>
+        LLMResponseFormat? responseFormat = null,
+        IReadOnlyList<ResponsesApplicationToolDeclaration>? declaredTools = null) =>
         new(
             model,
             stream,
@@ -398,7 +460,7 @@ public sealed class ChatCompletionsCommandFacadeTests
             temperature,
             maxTokens,
             chatMessages ?? [ChatMessage.User("hello")],
-            [],
+            declaredTools ?? [],
             responseFormat);
 
     private static ChatCompletionsCommandFacade CreateFacade(
@@ -452,6 +514,25 @@ public sealed class ChatCompletionsCommandFacadeTests
         ForwardToModel = new ForwardToModel { ModelName = modelName },
     };
 
+    private static ChatRouteAction GAgentToolHintAction(string actorId) => new()
+    {
+        ForwardToModel = new ForwardToModel
+        {
+            ModelName = "gpt-4o-mini",
+            ToolChoiceHint = new ChatRouteToolChoiceHint
+            {
+                ToolName = "aevatar_invoke_gagent",
+                PrefilledArguments = new Struct
+                {
+                    Fields =
+                    {
+                        ["actor_id"] = Google.Protobuf.WellKnownTypes.Value.ForString(actorId),
+                    },
+                },
+            },
+        },
+    };
+
     private sealed class StaticCallerScopeResolver : IResponsesCallerScopeResolver
     {
         public Task<ResponsesCallerScope> ResolveAsync(
@@ -490,14 +571,15 @@ public sealed class ChatCompletionsCommandFacadeTests
             });
     }
 
-    private sealed class StaticResponsesToolClassificationService : IResponsesToolClassificationService
+    private sealed class StaticResponsesToolClassificationService(
+        ResponsesToolClassification? classification = null) : IResponsesToolClassificationService
     {
         public ValueTask<ResponsesToolClassification> ClassifyAsync(
             IReadOnlyList<ResponsesApplicationToolDeclaration> declaredTools,
             ResponsesToolProviderContext context,
             IEnumerable<IResponsesToolProvider>? additionalProviders = null,
             CancellationToken ct = default) =>
-            ValueTask.FromResult(new ResponsesToolClassification([], [], [], []));
+            ValueTask.FromResult(classification ?? new ResponsesToolClassification([], [], [], []));
     }
 
     private sealed class RecordingResponsesToolClassificationService : IResponsesToolClassificationService
@@ -519,7 +601,11 @@ public sealed class ChatCompletionsCommandFacadeTests
         ResponsesDirectToolPlan? plan = null) : IResponsesDirectToolPlanService
     {
         public ResponsesDirectToolPlan Build(ChatRouteAction? routeAction) =>
-            plan ?? ResponsesDirectToolPlan.Empty;
+            plan ?? ResponsesDirectToolPlan.Success(
+                [],
+                ResponsesToolChoiceHints.Create(
+                    routeAction?.ForwardToModel?.ToolChoiceHint?.ToolName,
+                    routeAction?.ForwardToModel?.ToolChoiceHint?.PrefilledArguments));
     }
 
     private sealed class RecordingActorDispatchPort : IActorDispatchPort

--- a/test/Aevatar.GAgentService.Tests/Application/MessagesCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/MessagesCommandFacadeTests.cs
@@ -7,6 +7,7 @@ using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Responses;
 using Aevatar.GAgentService.Application.Responses;
 using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aevatar.GAgentService.Tests.Application;
@@ -92,12 +93,76 @@ public sealed class MessagesCommandFacadeTests
         command.Model.Should().Be("claude-sonnet");
     }
 
-    private static MessagesCommandRequest BuildRequest(string model, bool stream = false) =>
+    [Fact]
+    public async Task CreateAsync_WithToolPayloads_ShouldWriteTypedToolArgumentsSchemaAndChoiceHint()
+    {
+        var dispatch = new RecordingActorDispatchPort();
+        var facade = CreateFacade(
+            dispatchPort: dispatch,
+            chatRouteDecisionPort: new StaticResponsesChatRouteDecisionPort(GAgentToolHintAction("member-1")),
+            toolClassificationService: new StaticResponsesToolClassificationService(
+                new ResponsesToolClassification(
+                    [
+                        new ResponsesApplicationToolDeclaration(
+                            "get_weather",
+                            "Get weather",
+                            """{"type":"object","properties":{"city":{"type":"string"}}}""",
+                            "schema-1"),
+                    ],
+                    [],
+                    [],
+                    [])));
+
+        var result = await facade.CreateAsync(
+            BuildRequest(
+                "claude-sonnet",
+                chatMessages:
+                [
+                    new ChatMessage
+                    {
+                        Role = "assistant",
+                        ToolCalls =
+                        [
+                            new ToolCall
+                            {
+                                Id = "call-1",
+                                Name = "get_weather",
+                                ArgumentsJson = """{"city":"Paris"}""",
+                            },
+                        ],
+                    },
+                ],
+                declaredTools:
+                [
+                    new ResponsesApplicationToolDeclaration(
+                        "get_weather",
+                        "Get weather",
+                        """{"type":"object","properties":{"city":{"type":"string"}}}""",
+                        "schema-1"),
+                ]),
+            CallerScopeContext("token"));
+
+        result.Error.Should().BeNull();
+        var command = dispatch.Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
+        command.Messages.Should().ContainSingle().Which.ToolCalls.Should().ContainSingle()
+            .Which.Arguments.Fields["city"].StringValue.Should().Be("Paris");
+        command.ToolSelection.ToolChoiceHintArguments.Fields["actor_id"].StringValue.Should().Be("member-1");
+        var declaration = command.ToolSelection.ForwardedTools.Should().ContainSingle().Subject;
+        declaration.Parameters.Fields["type"].StringValue.Should().Be("object");
+        declaration.Parameters.Fields["properties"].StructValue.Fields["city"].StructValue.Fields["type"]
+            .StringValue.Should().Be("string");
+    }
+
+    private static MessagesCommandRequest BuildRequest(
+        string model,
+        bool stream = false,
+        IReadOnlyList<ChatMessage>? chatMessages = null,
+        IReadOnlyList<ResponsesApplicationToolDeclaration>? declaredTools = null) =>
         new(
             model,
             100,
-            [ChatMessage.User("hello")],
-            [],
+            chatMessages ?? [ChatMessage.User("hello")],
+            declaredTools ?? [],
             false,
             null,
             null,
@@ -110,7 +175,8 @@ public sealed class MessagesCommandFacadeTests
     private static MessagesCommandFacade CreateFacade(
         ILlmSessionRegistrationPort? sessionPort = null,
         IResponsesChatRouteDecisionPort? chatRouteDecisionPort = null,
-        RecordingActorDispatchPort? dispatchPort = null)
+        RecordingActorDispatchPort? dispatchPort = null,
+        IResponsesToolClassificationService? toolClassificationService = null)
     {
         var effectiveSessionPort = sessionPort ?? new RecordingSessionPort();
         return new MessagesCommandFacade(
@@ -119,7 +185,7 @@ public sealed class MessagesCommandFacadeTests
             new StaticResponsesRouteResolver("route-value"),
             effectiveSessionPort,
             dispatchPort ?? new RecordingActorDispatchPort(),
-            new StaticResponsesToolClassificationService(),
+            toolClassificationService ?? new StaticResponsesToolClassificationService(),
             new StaticResponsesDirectToolPlanService(),
             NullLogger<MessagesCommandFacade>.Instance);
     }
@@ -161,6 +227,25 @@ public sealed class MessagesCommandFacadeTests
         ForwardToModel = new ForwardToModel { ModelName = modelName },
     };
 
+    private static ChatRouteAction GAgentToolHintAction(string actorId) => new()
+    {
+        ForwardToModel = new ForwardToModel
+        {
+            ModelName = "claude-sonnet",
+            ToolChoiceHint = new ChatRouteToolChoiceHint
+            {
+                ToolName = "aevatar_invoke_gagent",
+                PrefilledArguments = new Struct
+                {
+                    Fields =
+                    {
+                        ["actor_id"] = Google.Protobuf.WellKnownTypes.Value.ForString(actorId),
+                    },
+                },
+            },
+        },
+    };
+
     private sealed class StaticCallerScopeResolver : IResponsesCallerScopeResolver
     {
         public Task<ResponsesCallerScope> ResolveAsync(
@@ -191,20 +276,25 @@ public sealed class MessagesCommandFacadeTests
             });
     }
 
-    private sealed class StaticResponsesToolClassificationService : IResponsesToolClassificationService
+    private sealed class StaticResponsesToolClassificationService(
+        ResponsesToolClassification? classification = null) : IResponsesToolClassificationService
     {
         public ValueTask<ResponsesToolClassification> ClassifyAsync(
             IReadOnlyList<ResponsesApplicationToolDeclaration> declaredTools,
             ResponsesToolProviderContext context,
             IEnumerable<IResponsesToolProvider>? additionalProviders = null,
             CancellationToken ct = default) =>
-            ValueTask.FromResult(new ResponsesToolClassification([], [], [], []));
+            ValueTask.FromResult(classification ?? new ResponsesToolClassification([], [], [], []));
     }
 
     private sealed class StaticResponsesDirectToolPlanService : IResponsesDirectToolPlanService
     {
         public ResponsesDirectToolPlan Build(ChatRouteAction? routeAction) =>
-            ResponsesDirectToolPlan.Empty;
+            ResponsesDirectToolPlan.Success(
+                [],
+                ResponsesToolChoiceHints.Create(
+                    routeAction?.ForwardToModel?.ToolChoiceHint?.ToolName,
+                    routeAction?.ForwardToModel?.ToolChoiceHint?.PrefilledArguments));
     }
 
     private sealed class RecordingActorDispatchPort : IActorDispatchPort

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
@@ -129,7 +129,38 @@ public sealed class ResponsesCommandFacadeTests
         result.Accepted.Should().NotBeNull();
         var command = dispatch.Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
         command.ToolSelection.AdditiveToolNames.Should().Contain("aevatar_invoke_gagent");
+        command.ToolSelection.ToolChoiceHintArguments.Fields["actor_id"].StringValue.Should().Be("member-1");
         sessions.RecordedToolCalls.Should().BeEmpty("tool set tools execute locally and are not client-forwarded tools");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithForwardedClientTool_ShouldWriteTypedToolSchema()
+    {
+        var dispatch = new RecordingActorDispatchPort();
+        var facade = CreateFacade(dispatchPort: dispatch);
+
+        var result = await facade.CreateAsync(new ResponsesCommandRequest(
+            "client-model",
+            "hello",
+            [],
+            false,
+            null,
+            null,
+            null,
+            [
+                new ResponsesApplicationToolDeclaration(
+                    "get_weather",
+                    "Get weather",
+                    """{"type":"object","properties":{"city":{"type":"string"}}}""",
+                    "schema-1"),
+            ]), CallerScopeContext("token"));
+
+        result.Error.Should().BeNull();
+        var command = dispatch.Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
+        var declaration = command.ToolSelection.ForwardedTools.Should().ContainSingle().Subject;
+        declaration.Parameters.Fields["type"].StringValue.Should().Be("object");
+        declaration.Parameters.Fields["properties"].StructValue.Fields["city"].StructValue.Fields["type"]
+            .StringValue.Should().Be("string");
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
@@ -164,6 +164,26 @@ public sealed class ResponsesCommandFacadeTests
     }
 
     [Fact]
+    public void ToRuntimeToolCall_ShouldWriteTypedRuntimeToolArguments()
+    {
+        var method = typeof(ResponsesCommandFacade).GetMethod(
+            "ToRuntimeToolCall",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+        var converted = (LlmSessionRuntimeToolCall)method!.Invoke(null,
+        [
+            new ToolCall
+            {
+                Id = "call_1",
+                Name = "get_weather",
+                ArgumentsJson = """{"city":"Singapore"}""",
+            },
+        ])!;
+
+        converted.Arguments.Fields["city"].StringValue.Should().Be("Singapore");
+    }
+
+    [Fact]
     public async Task CreateAsync_ShouldReturnAuthenticationError_WhenCallerScopeCannotBeResolved()
     {
         var facade = CreateFacade(callerScopeResolver: new ThrowingCallerScopeResolver());

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesProtoPayloadsTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesProtoPayloadsTests.cs
@@ -1,0 +1,28 @@
+using Aevatar.GAgentService.Application.Responses;
+using FluentAssertions;
+
+namespace Aevatar.GAgentService.Tests.Application;
+
+public sealed class ResponsesProtoPayloadsTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not json {")]
+    public void ParseStruct_ShouldReturnEmptyStruct_ForBlankOrMalformedLegacyJson(string? payload)
+    {
+        var parsed = ResponsesProtoPayloads.ParseStruct(payload);
+
+        parsed.Fields.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseStruct_ShouldParseBoundaryJsonObject()
+    {
+        var parsed = ResponsesProtoPayloads.ParseStruct("""{"city":"Singapore","count":2}""");
+
+        parsed.Fields["city"].StringValue.Should().Be("Singapore");
+        parsed.Fields["count"].NumberValue.Should().Be(2);
+    }
+}

--- a/test/Aevatar.GAgentService.Tests/Core/ChatRunActorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ChatRunActorTests.cs
@@ -108,12 +108,12 @@ public sealed class ChatRunActorTests
         });
 
         actor.State.ActiveSubRunSubscriptions.Should().BeEmpty();
-        actor.State.ToolCallHistory.Should().ContainSingle()
-            .Which.InternalResultJson.Should().Contain("\"content\":\"done\"");
+        var history = actor.State.ToolCallHistory.Should().ContainSingle().Subject;
+        history.InternalResult.StructValue.Fields["content"].StringValue.Should().Be("done");
         actor.State.Messages.Should().ContainSingle(message =>
             message.Role == "tool" &&
             message.ToolCallId == "call_complete" &&
-            message.Content.Contains("\"content\":\"done\"", StringComparison.Ordinal));
+            message.Content.Contains("\"content\": \"done\"", StringComparison.Ordinal));
         actor.State.CurrentLlmRound.Should().Be(3);
     }
 
@@ -137,8 +137,8 @@ public sealed class ChatRunActorTests
         });
 
         var history = actor.State.ToolCallHistory.Should().ContainSingle().Subject;
-        history.InternalResultJson.Should().Contain("\"run_id\":\"run_default\"");
-        history.InternalResultJson.Should().Contain("\"actor_id\":\"actor-default\"");
+        history.InternalResult.StructValue.Fields["run_id"].StringValue.Should().Be("run_default");
+        history.InternalResult.StructValue.Fields["actor_id"].StringValue.Should().Be("actor-default");
         actor.State.Messages.Should().ContainSingle(message =>
             message.Role == "tool" &&
             message.ToolCallId == "call_default" &&
@@ -232,7 +232,7 @@ public sealed class ChatRunActorTests
     }
 
     [Fact]
-    public void ChatRunInternalMessages_ShouldExposeInternalResultJsonFieldNameOnly()
+    public void ChatRunInternalMessages_ShouldExposeTypedInternalResultAndLegacyJsonFallback()
     {
         var messageDescriptors = new[]
         {
@@ -249,6 +249,9 @@ public sealed class ChatRunActorTests
             descriptor.Fields.InFieldNumberOrder()
                 .Should()
                 .ContainSingle(field => field.Name == "internal_result_json");
+            descriptor.Fields.InFieldNumberOrder()
+                .Should()
+                .ContainSingle(field => field.Name == "internal_result");
             descriptor.Fields.InFieldNumberOrder()
                 .Should()
                 .NotContain(field => field.Name == "result_json");
@@ -494,6 +497,7 @@ public sealed class ChatRunActorTests
         command.ToolCallId.Should().Be("call_adapter");
         command.RunId.Should().Be("run_adapter");
         command.InternalResultJson.Should().Be(boundaryPayload);
+        command.InternalResult.StructValue.Fields["opaque"].StringValue.Should().Be("tool-output");
     }
 
     [Fact]
@@ -520,7 +524,7 @@ public sealed class ChatRunActorTests
         actor.State.ActiveSubRunSubscriptions.Should().BeEmpty();
         var folded = actor.State.ToolCallHistory.Should().ContainSingle().Subject;
         folded.RunId.Should().Be("run_forwarded");
-        folded.InternalResultJson.Should().Contain("\"content\":\"forwarded done\"");
+        folded.InternalResult.StructValue.Fields["content"].StringValue.Should().Be("forwarded done");
 
         var foldedEvent = (await eventStore.GetEventsAsync(actor.Id))
             .Select(static evt => evt.EventData)

--- a/test/Aevatar.GAgentService.Tests/Core/ChatRunActorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ChatRunActorTests.cs
@@ -85,6 +85,32 @@ public sealed class ChatRunActorTests
     }
 
     [Fact]
+    public async Task SubmitToolCall_ShouldPreferTypedInternalResult_WhenLegacyJsonAlsoExists()
+    {
+        var actor = await StartedActorAsync("resp_typed_submit");
+        var command = BuildSubmit(
+            toolCallId: "call_typed_submit",
+            runId: "run_typed_submit",
+            waitMode: ChatRunSubRunWaitMode.Stream,
+            resultJson: """{"content":"legacy"}""");
+        command.InternalResult = Google.Protobuf.WellKnownTypes.Value.ForStruct(new Struct
+        {
+            Fields =
+            {
+                ["content"] = Google.Protobuf.WellKnownTypes.Value.ForString("typed"),
+                ["ok"] = Google.Protobuf.WellKnownTypes.Value.ForBool(true),
+            },
+        });
+
+        await actor.HandleSubmitToolCallAsync(command);
+
+        var history = actor.State.ToolCallHistory.Should().ContainSingle().Subject;
+        history.InternalResult.StructValue.Fields["content"].StringValue.Should().Be("typed");
+        history.InternalResult.StructValue.Fields["ok"].BoolValue.Should().BeTrue();
+        history.InternalResultJson.Should().Be("""{"content":"legacy"}""");
+    }
+
+    [Fact]
     public async Task SubmitWaitCompleteThenTerminal_ShouldFoldToolResult_AndAdvanceRound()
     {
         var actor = await StartedActorAsync("resp_complete");
@@ -115,6 +141,53 @@ public sealed class ChatRunActorTests
             message.ToolCallId == "call_complete" &&
             message.Content.Contains("\"content\": \"done\"", StringComparison.Ordinal));
         actor.State.CurrentLlmRound.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task SubRunTerminal_ShouldFoldTypedInternalResult_AheadOfLegacyJsonFallback()
+    {
+        var eventStore = new InMemoryEventStore();
+        var actor = await StartedActorAsync("resp_typed_terminal", eventStore);
+
+        await actor.HandleSubmitToolCallAsync(BuildSubmit(
+            toolCallId: "call_typed_terminal",
+            runId: "run_typed_terminal",
+            waitMode: ChatRunSubRunWaitMode.Complete,
+            resultJson: """{"content":"initial"}"""));
+
+        await actor.HandleSubRunTerminalAsync(new ChatRunSubRunTerminalObserved
+        {
+            RunId = "run_typed_terminal",
+            Status = "RunFinished",
+            InternalResultJson = """{"content":"legacy-terminal"}""",
+            InternalResult = Google.Protobuf.WellKnownTypes.Value.ForStruct(new Struct
+            {
+                Fields =
+                {
+                    ["content"] = Google.Protobuf.WellKnownTypes.Value.ForString("typed-terminal"),
+                    ["status"] = Google.Protobuf.WellKnownTypes.Value.ForString("RunFinished"),
+                },
+            }),
+        });
+
+        var history = actor.State.ToolCallHistory.Should().ContainSingle().Subject;
+        history.InternalResult.StructValue.Fields["content"].StringValue.Should().Be("typed-terminal");
+        history.InternalResultJson.Should().Contain("typed-terminal");
+        history.InternalResultJson.Should().NotContain("legacy-terminal");
+        actor.State.Messages.Should().ContainSingle(message =>
+            message.Role == "tool" &&
+            message.ToolCallId == "call_typed_terminal" &&
+            message.Content.Contains("typed-terminal", StringComparison.Ordinal));
+
+        var foldedEvent = (await eventStore.GetEventsAsync(actor.Id))
+            .Select(static evt => evt.EventData)
+            .Where(static payload => payload.Is(ChatRunSubRunTerminalFoldedEvent.Descriptor))
+            .Select(static payload => payload.Unpack<ChatRunSubRunTerminalFoldedEvent>())
+            .Should()
+            .ContainSingle()
+            .Subject;
+        foldedEvent.InternalResult.StructValue.Fields["content"].StringValue.Should().Be("typed-terminal");
+        foldedEvent.InternalResultJson.Should().Be(history.InternalResultJson);
     }
 
     [Fact]
@@ -499,6 +572,37 @@ public sealed class ChatRunActorTests
         command.RunId.Should().Be("run_adapter");
         command.InternalResultJson.Should().Be(boundaryPayload);
         command.InternalResult.StructValue.Fields["opaque"].StringValue.Should().Be("tool-output");
+    }
+
+    [Fact]
+    public async Task AdapterSubmitToolCall_ShouldFallbackMalformedBoundaryPayloadToTypedStringValue()
+    {
+        var dispatchPort = new RecordingDispatchPort();
+        var adapter = new ChatRunActorAdapter(new RecordingActorRuntime(), dispatchPort);
+        const string malformedPayload = "not json {";
+
+        await adapter.SubmitToolCallAsync(
+            "chat-run:resp_adapter_malformed",
+            new ChatRunToolCompletionRequest(
+                "resp_adapter_malformed",
+                "gpt-test",
+                [ChatMessage.User("hello")],
+                new ToolCall
+                {
+                    Id = "call_adapter_malformed",
+                    Name = "custom_tool",
+                    ArgumentsJson = "not json {",
+                },
+                "not json {",
+                malformedPayload,
+                1));
+
+        var command = dispatchPort.Calls.Should().ContainSingle().Subject
+            .envelope.Payload.Unpack<SubmitChatRunToolCallRequested>();
+        command.Arguments.Fields.Should().BeEmpty();
+        command.InternalResultJson.Should().Be(malformedPayload);
+        command.InternalResult.StringValue.Should().Be(malformedPayload);
+        command.TargetKind.Should().Be(ChatRunSubRunTargetKind.Unspecified);
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Core/ChatRunActorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ChatRunActorTests.cs
@@ -455,6 +455,7 @@ public sealed class ChatRunActorTests
         published.RunId.Should().Be("run_publish");
         published.CallerToolCallId.Should().Be("call_publish");
         published.InternalResultJson.Should().Contain("published");
+        published.InternalResult.StructValue.Fields["content"].StringValue.Should().Be("published");
         published.Status.Should().Be("RunFinished");
         published.ActorId.Should().Be("actor-1");
         published.CompletionObserved.Should().BeTrue();

--- a/test/Aevatar.GAgentService.Tests/Core/ChatRunActorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ChatRunActorTests.cs
@@ -110,6 +110,59 @@ public sealed class ChatRunActorTests
         history.InternalResultJson.Should().Be("""{"content":"legacy"}""");
     }
 
+    [Theory]
+    [MemberData(nameof(MeaningfulInternalResults))]
+    public async Task SubmitToolCall_ShouldPersistMeaningfulTypedInternalResultKinds(
+        Google.Protobuf.WellKnownTypes.Value internalResult)
+    {
+        var actor = await StartedActorAsync("resp_typed_kind_" + Guid.NewGuid().ToString("N"));
+        var command = BuildSubmit(
+            toolCallId: "call_typed_kind",
+            runId: "run_typed_kind",
+            waitMode: ChatRunSubRunWaitMode.Stream,
+            resultJson: """{"content":"legacy"}""");
+        command.InternalResult = internalResult.Clone();
+
+        await actor.HandleSubmitToolCallAsync(command);
+
+        actor.State.ToolCallHistory.Should().ContainSingle()
+            .Which.InternalResult.ToByteArray().Should().Equal(internalResult.ToByteArray());
+    }
+
+    [Fact]
+    public async Task SubmitToolCall_WhenTypedResultIsEmptyAndLegacyJsonIsBlank_ShouldPersistEmptyStruct()
+    {
+        var actor = await StartedActorAsync("resp_empty_result");
+
+        await actor.HandleSubmitToolCallAsync(new SubmitChatRunToolCallRequested
+        {
+            ToolCallId = "call_empty_result",
+            ToolName = "custom_tool",
+            InternalResultJson = " ",
+            WaitMode = ChatRunSubRunWaitMode.Ack,
+        });
+
+        var history = actor.State.ToolCallHistory.Should().ContainSingle().Subject;
+        history.InternalResult.KindCase.Should().Be(Google.Protobuf.WellKnownTypes.Value.KindOneofCase.StructValue);
+        history.InternalResult.StructValue.Fields.Should().BeEmpty();
+        history.InternalResultJson.Should().Be(" ");
+    }
+
+    [Fact]
+    public async Task SubmitToolCall_WhenLegacyJsonIsMalformed_ShouldPersistStringInternalResult()
+    {
+        var actor = await StartedActorAsync("resp_malformed_result");
+
+        await actor.HandleSubmitToolCallAsync(BuildSubmit(
+            toolCallId: "call_malformed_result",
+            runId: "run_malformed_result",
+            waitMode: ChatRunSubRunWaitMode.Stream,
+            resultJson: "not json {"));
+
+        actor.State.ToolCallHistory.Should().ContainSingle()
+            .Which.InternalResult.StringValue.Should().Be("not json {");
+    }
+
     [Fact]
     public async Task SubmitWaitCompleteThenTerminal_ShouldFoldToolResult_AndAdvanceRound()
     {
@@ -606,6 +659,34 @@ public sealed class ChatRunActorTests
     }
 
     [Fact]
+    public async Task AdapterSubmitToolCall_WhenBoundaryPayloadIsBlank_ShouldMapTypedResultToEmptyStruct()
+    {
+        var dispatchPort = new RecordingDispatchPort();
+        var adapter = new ChatRunActorAdapter(new RecordingActorRuntime(), dispatchPort);
+
+        await adapter.SubmitToolCallAsync(
+            "chat-run:resp_adapter_blank",
+            new ChatRunToolCompletionRequest(
+                "resp_adapter_blank",
+                "gpt-test",
+                [ChatMessage.User("hello")],
+                new ToolCall
+                {
+                    Id = "call_adapter_blank",
+                    Name = "custom_tool",
+                    ArgumentsJson = "{}",
+                },
+                "{}",
+                " ",
+                1));
+
+        var command = dispatchPort.Calls.Should().ContainSingle().Subject
+            .envelope.Payload.Unpack<SubmitChatRunToolCallRequested>();
+        command.InternalResult.KindCase.Should().Be(Google.Protobuf.WellKnownTypes.Value.KindOneofCase.StructValue);
+        command.InternalResult.StructValue.Fields.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task ForwardedCommittedCompletion_ShouldPublishObservedToolResultReady()
     {
         var eventStore = new InMemoryEventStore();
@@ -764,6 +845,18 @@ public sealed class ChatRunActorTests
             ChatRunSubRunWaitMode.Complete => "complete",
             _ => "stream",
         };
+
+    public static TheoryData<Google.Protobuf.WellKnownTypes.Value> MeaningfulInternalResults() => new()
+    {
+        new Google.Protobuf.WellKnownTypes.Value
+        {
+            ListValue = new ListValue { Values = { Google.Protobuf.WellKnownTypes.Value.ForString("item") } },
+        },
+        Google.Protobuf.WellKnownTypes.Value.ForString("typed-string"),
+        Google.Protobuf.WellKnownTypes.Value.ForNumber(7),
+        Google.Protobuf.WellKnownTypes.Value.ForBool(false),
+        Google.Protobuf.WellKnownTypes.Value.ForNull(),
+    };
 
     private static void AssertInternalResultJsonRoundTrips<TMessage>(
         TMessage message,

--- a/test/Aevatar.GAgentService.Tests/Core/LlmSessionGAgentTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/LlmSessionGAgentTests.cs
@@ -109,6 +109,26 @@ public sealed class LlmSessionGAgentTests
     }
 
     [Fact]
+    public void RuntimeToolArgumentsValue_WithLegacyJsonOnly_ShouldParseArguments()
+    {
+        var method = typeof(LlmSessionGAgent).GetMethod(
+            "RuntimeToolArgumentsValue",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+        var result = (Google.Protobuf.WellKnownTypes.Value)method!.Invoke(null,
+        [
+            new LlmSessionRuntimeToolCall
+            {
+                CallId = "call_legacy",
+                ToolName = "get_weather",
+                ArgumentsJson = """{"city":"Paris"}""",
+            },
+        ])!;
+
+        result.StructValue.Fields["city"].StringValue.Should().Be("Paris");
+    }
+
+    [Fact]
     public async Task HandleReceiveForwardedToolResultAsync_ShouldPersistResult_AndIgnoreDuplicate()
     {
         var actor = CreateActor("resp_1");
@@ -766,6 +786,47 @@ public sealed class LlmSessionGAgentTests
     }
 
     [Fact]
+    public async Task HandleLlmRunRequestedAsync_ShouldUseLegacyRuntimeMessageToolArguments_WhenTypedArgumentsAreEmpty()
+    {
+        var provider = new ScriptedLlmProviderFactory([
+            [
+                new LLMStreamChunk
+                {
+                    DeltaContent = "done",
+                    IsLast = true,
+                },
+            ],
+        ]);
+        var actor = CreateActor("resp_legacy_runtime_message", services => services.AddSingleton<ILLMProviderFactory>(provider));
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_legacy_runtime_message"),
+        });
+        var request = BuildRunRequest("resp_legacy_runtime_message");
+        request.Messages.Clear();
+        request.Messages.Add(new LlmSessionRuntimeChatMessage
+        {
+            Role = "assistant",
+            ToolCalls =
+            {
+                new LlmSessionRuntimeToolCall
+                {
+                    CallId = "call_legacy_args",
+                    ToolName = "get_weather",
+                    ArgumentsJson = """{"city":"Paris"}""",
+                },
+            },
+        });
+
+        await actor.HandleLlmRunRequestedAsync(request);
+
+        var toolCall = provider.Requests.Should().ContainSingle().Subject.Messages
+            .Single(message => message.ToolCalls != null && message.ToolCalls.Count == 1)
+            .ToolCalls![0];
+        toolCall.ArgumentsJson.Should().Be("""{"city":"Paris"}""");
+    }
+
+    [Fact]
     public async Task HandleLlmRunRequestedAsync_ShouldUseTypedToolDeclarationParametersBeforeLegacyJson()
     {
         var provider = new ScriptedLlmProviderFactory([
@@ -799,6 +860,35 @@ public sealed class LlmSessionGAgentTests
             .Should()
             .ContainSingle(tool => tool.Name == "get_weather")
             .Which.ParametersSchema.Should().Contain("\"typed\": true");
+    }
+
+    [Fact]
+    public async Task HandleLlmRunRequestedAsync_ShouldUseLegacyToolDeclarationParameters_WhenTypedParametersAreEmpty()
+    {
+        var provider = new ScriptedLlmProviderFactory([
+            [
+                new LLMStreamChunk
+                {
+                    DeltaContent = "done",
+                    IsLast = true,
+                },
+            ],
+        ]);
+        var actor = CreateActor("resp_legacy_parameters", services => services.AddSingleton<ILLMProviderFactory>(provider));
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_legacy_parameters"),
+        });
+        var selection = BuildForwardedSelection();
+        selection.ForwardedTools[0].Parameters.Fields.Clear();
+        selection.ForwardedTools[0].ParametersJson = """{"type":"object","legacy":true}""";
+
+        await actor.HandleLlmRunRequestedAsync(BuildRunRequest("resp_legacy_parameters", selection));
+
+        provider.Requests.Should().ContainSingle().Subject.Tools
+            .Should()
+            .ContainSingle(tool => tool.Name == "get_weather")
+            .Which.ParametersSchema.Should().Be("""{"type":"object","legacy":true}""");
     }
 
     [Fact]
@@ -839,6 +929,78 @@ public sealed class LlmSessionGAgentTests
         var forwarded = actor.State.ForwardedToolCalls.Should().ContainSingle().Subject;
         forwarded.Arguments.StructValue.Fields["actor_id"].StringValue.Should().Be("actor-from-typed-hint");
         forwarded.Arguments.StructValue.Fields["city"].StringValue.Should().Be("Singapore");
+    }
+
+    [Fact]
+    public async Task HandleLlmRunRequestedAsync_ShouldUseLegacyToolChoiceHintArguments_WhenTypedArgumentsAreEmpty()
+    {
+        var provider = new ScriptedLlmProviderFactory([
+            [
+                new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "call_1",
+                        Name = "get_weather",
+                        ArgumentsJson = """{"city":"Singapore"}""",
+                    },
+                    IsLast = true,
+                },
+            ],
+        ]);
+        var actor = CreateActor("resp_legacy_hint", services => services.AddSingleton<ILLMProviderFactory>(provider));
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_legacy_hint"),
+        });
+        var selection = BuildForwardedSelection();
+        selection.ToolChoiceHintName = "get_weather";
+        selection.ToolChoiceHintArgumentsJson = """{"actor_id":"actor-from-legacy-hint"}""";
+
+        await actor.HandleLlmRunRequestedAsync(BuildRunRequest("resp_legacy_hint", selection));
+
+        var forwarded = actor.State.ForwardedToolCalls.Should().ContainSingle().Subject;
+        forwarded.Arguments.StructValue.Fields["actor_id"].StringValue.Should().Be("actor-from-legacy-hint");
+        forwarded.Arguments.StructValue.Fields["city"].StringValue.Should().Be("Singapore");
+    }
+
+    [Fact]
+    public async Task HandleLlmRunRequestedAsync_ShouldMergeTypedToolCallDeltasForSameCall()
+    {
+        var provider = new ScriptedLlmProviderFactory([
+            [
+                new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "call_1",
+                        Name = "get_weather",
+                        ArgumentsJson = "{\"city\":\"Singapore\",",
+                    },
+                },
+                new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "call_1",
+                        Name = "get_weather",
+                        ArgumentsJson = "\"unit\":\"celsius\"}",
+                    },
+                    IsLast = true,
+                },
+            ],
+        ]);
+        var actor = CreateActor("resp_merge_tool_deltas", services => services.AddSingleton<ILLMProviderFactory>(provider));
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_merge_tool_deltas"),
+        });
+
+        await actor.HandleLlmRunRequestedAsync(BuildRunRequest("resp_merge_tool_deltas", BuildForwardedSelection()));
+
+        var forwarded = actor.State.ForwardedToolCalls.Should().ContainSingle().Subject;
+        forwarded.Arguments.StructValue.Fields["city"].StringValue.Should().Be("Singapore");
+        forwarded.Arguments.StructValue.Fields["unit"].StringValue.Should().Be("celsius");
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Core/LlmSessionGAgentTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/LlmSessionGAgentTests.cs
@@ -708,8 +708,12 @@ public sealed class LlmSessionGAgentTests
         forwarded.SchemaHash.Should().Be("schema-1");
         forwarded.Status.Should().Be(LlmSessionForwardedToolCallStatus.Pending);
         ResponsesJsonValues.ToBoundaryJson(forwarded.Arguments).Should().Be("""{"city":"Singapore"}""");
+        actor.State.ActiveRun!.ObservedToolCalls.Should().ContainSingle()
+            .Which.Arguments.Fields["city"].StringValue.Should().Be("Singapore");
         actor.State.Completion!.ToolCalls.Should().ContainSingle()
             .Which.ToolName.Should().Be("get_weather");
+        ResponsesJsonValues.ToBoundaryJson(actor.State.Completion.ToolCalls[0].Result)
+            .Should().Be("""{"city":"Singapore"}""");
     }
 
     [Fact]
@@ -978,6 +982,13 @@ public sealed class LlmSessionGAgentTests
                     ToolName = "get_weather",
                     Description = "Get weather",
                     ParametersJson = """{"type":"object"}""",
+                    Parameters = new Struct
+                    {
+                        Fields =
+                        {
+                            ["type"] = Google.Protobuf.WellKnownTypes.Value.ForString("object"),
+                        },
+                    },
                     SchemaHash = "schema-1",
                 },
             },

--- a/test/Aevatar.GAgentService.Tests/Core/LlmSessionGAgentTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/LlmSessionGAgentTests.cs
@@ -717,6 +717,131 @@ public sealed class LlmSessionGAgentTests
     }
 
     [Fact]
+    public async Task HandleLlmRunRequestedAsync_ShouldPreferTypedRuntimeMessageToolArguments()
+    {
+        var provider = new ScriptedLlmProviderFactory([
+            [
+                new LLMStreamChunk
+                {
+                    DeltaContent = "done",
+                    IsLast = true,
+                },
+            ],
+        ]);
+        var actor = CreateActor("resp_typed_runtime_message", services => services.AddSingleton<ILLMProviderFactory>(provider));
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_typed_runtime_message"),
+        });
+        var request = BuildRunRequest("resp_typed_runtime_message");
+        request.Messages.Clear();
+        request.Messages.Add(new LlmSessionRuntimeChatMessage
+        {
+            Role = "assistant",
+            ToolCalls =
+            {
+                new LlmSessionRuntimeToolCall
+                {
+                    CallId = "call_typed_args",
+                    ToolName = "get_weather",
+                    ArgumentsJson = "not json {",
+                    Arguments = new Struct
+                    {
+                        Fields =
+                        {
+                            ["city"] = Google.Protobuf.WellKnownTypes.Value.ForString("Singapore"),
+                        },
+                    },
+                },
+            },
+        });
+
+        await actor.HandleLlmRunRequestedAsync(request);
+
+        var requestMessage = provider.Requests.Should().ContainSingle().Subject.Messages
+            .Single(message => message.ToolCalls != null && message.ToolCalls.Count == 1);
+        var toolCall = requestMessage.ToolCalls![0];
+        toolCall.ArgumentsJson.Should().Contain("Singapore");
+        toolCall.ArgumentsJson.Should().NotBe("not json {");
+    }
+
+    [Fact]
+    public async Task HandleLlmRunRequestedAsync_ShouldUseTypedToolDeclarationParametersBeforeLegacyJson()
+    {
+        var provider = new ScriptedLlmProviderFactory([
+            [
+                new LLMStreamChunk
+                {
+                    DeltaContent = "done",
+                    IsLast = true,
+                },
+            ],
+        ]);
+        var actor = CreateActor("resp_typed_parameters", services => services.AddSingleton<ILLMProviderFactory>(provider));
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_typed_parameters"),
+        });
+        var selection = BuildForwardedSelection();
+        selection.ForwardedTools[0].ParametersJson = "not json {";
+        selection.ForwardedTools[0].Parameters = new Struct
+        {
+            Fields =
+            {
+                ["type"] = Google.Protobuf.WellKnownTypes.Value.ForString("object"),
+                ["typed"] = Google.Protobuf.WellKnownTypes.Value.ForBool(true),
+            },
+        };
+
+        await actor.HandleLlmRunRequestedAsync(BuildRunRequest("resp_typed_parameters", selection));
+
+        provider.Requests.Should().ContainSingle().Subject.Tools
+            .Should()
+            .ContainSingle(tool => tool.Name == "get_weather")
+            .Which.ParametersSchema.Should().Contain("\"typed\": true");
+    }
+
+    [Fact]
+    public async Task HandleLlmRunRequestedAsync_ShouldUseTypedToolChoiceHintArgumentsBeforeLegacyJson()
+    {
+        var provider = new ScriptedLlmProviderFactory([
+            [
+                new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "call_1",
+                        Name = "get_weather",
+                        ArgumentsJson = """{"city":"Singapore"}""",
+                    },
+                    IsLast = true,
+                },
+            ],
+        ]);
+        var actor = CreateActor("resp_typed_hint", services => services.AddSingleton<ILLMProviderFactory>(provider));
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_typed_hint"),
+        });
+        var selection = BuildForwardedSelection();
+        selection.ToolChoiceHintName = "get_weather";
+        selection.ToolChoiceHintArgumentsJson = "not json {";
+        selection.ToolChoiceHintArguments = new Struct
+        {
+            Fields =
+            {
+                ["actor_id"] = Google.Protobuf.WellKnownTypes.Value.ForString("actor-from-typed-hint"),
+            },
+        };
+
+        await actor.HandleLlmRunRequestedAsync(BuildRunRequest("resp_typed_hint", selection));
+
+        var forwarded = actor.State.ForwardedToolCalls.Should().ContainSingle().Subject;
+        forwarded.Arguments.StructValue.Fields["actor_id"].StringValue.Should().Be("actor-from-typed-hint");
+        forwarded.Arguments.StructValue.Fields["city"].StringValue.Should().Be("Singapore");
+    }
+
+    [Fact]
     public async Task HandleLlmRunRequestedAsync_ShouldExecuteSubstitutedToolAndContinueNextRound()
     {
         var tool = new RecordingAgentTool("get_weather", """{"temperature":28}""");
@@ -766,6 +891,61 @@ public sealed class LlmSessionGAgentTests
         actor.State.ForwardedToolCalls.Should().BeEmpty();
         actor.State.ActiveRun!.Status.Should().Be(2);
         actor.State.Completion!.OutputText.Should().Be("local result accepted");
+    }
+
+    [Fact]
+    public async Task HandleLlmRunRequestedAsync_ShouldPersistTypedLocalToolResultPayload()
+    {
+        var eventStore = new InMemoryEventStore();
+        var tool = new RecordingAgentTool("get_weather", """{"temperature":28}""");
+        var toolProvider = new StaticResponsesToolProvider(substituteTools: [tool]);
+        var provider = new ScriptedLlmProviderFactory([
+            [
+                new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "call_1",
+                        Name = "get_weather",
+                        ArgumentsJson = """{"city":"Singapore"}""",
+                    },
+                    IsLast = true,
+                },
+            ],
+            [
+                new LLMStreamChunk
+                {
+                    DeltaContent = "local result accepted",
+                    IsLast = true,
+                },
+            ],
+        ]);
+        var actor = CreateActorWithStore(
+            "resp_typed_local_result",
+            eventStore,
+            services =>
+            {
+                services.AddSingleton<ILLMProviderFactory>(provider);
+                services.AddSingleton<IResponsesToolProvider>(toolProvider);
+            });
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_typed_local_result"),
+        });
+        var selection = BuildForwardedSelection();
+        selection.SubstitutedToolNames.Add("get_weather");
+
+        await actor.HandleLlmRunRequestedAsync(BuildRunRequest("resp_typed_local_result", selection));
+
+        var localObserved = (await eventStore.GetEventsAsync(actor.Id))
+            .Select(static evt => evt.EventData)
+            .Where(static payload => payload.Is(LlmToolCallObserved.Descriptor))
+            .Select(static payload => payload.Unpack<LlmToolCallObserved>())
+            .Should()
+            .ContainSingle(observed => !observed.Forwarded)
+            .Subject;
+        localObserved.LocalResultJson.Should().Be("""{"temperature":28}""");
+        localObserved.LocalResult.StructValue.Fields["temperature"].NumberValue.Should().Be(28);
     }
 
     [Fact]
@@ -901,6 +1081,16 @@ public sealed class LlmSessionGAgentTests
         Action<IServiceCollection>? configureServices = null) =>
         GAgentServiceTestKit.CreateStatefulAgent<LlmSessionGAgent, LlmSessionState>(
             new InMemoryEventStore(),
+            "response-session-actor-" + responseId,
+            static () => new LlmSessionGAgent(),
+            configureServices);
+
+    private static LlmSessionGAgent CreateActorWithStore(
+        string responseId,
+        InMemoryEventStore eventStore,
+        Action<IServiceCollection>? configureServices = null) =>
+        GAgentServiceTestKit.CreateStatefulAgent<LlmSessionGAgent, LlmSessionState>(
+            eventStore,
             "response-session-actor-" + responseId,
             static () => new LlmSessionGAgent(),
             configureServices);


### PR DESCRIPTION
## 摘要

closes #1438(由 Phase 9 r1 split first-slice 产生,#1434 META_JUDGE_DONE:split)。

### Old
Durable `LlmSession`/`ChatRun` tool 契约持久 arguments、schemas、hints、results 为 `*_json` strings。

### New
新增 typed Struct/Value proto 字段:`arguments`/`parameters`/`tool_choice_hint_arguments` 使用 `google.protobuf.Struct`,`local_result`/`internal_result` 系列使用 `google.protobuf.Value`。外部 JSON DTO 入边界时解析为 Protobuf,actor command/event/state/readiness/readmodel 只复制 typed payload,需要返回 provider/HTTP/query DTO 时再渲染 JSON。旧 `*_json` 字段保留作 legacy read-fallback,不在本 slice 决定 reserve timing。

### 违反
- CLAUDE.md「核心语义强类型」
- CLAUDE.md「序列化(强制)」

## 范围

13 files changed(+347/-61):
- `src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto`
- `src/platform/Aevatar.GAgentService.Application/Responses/ResponsesProtoPayloads.cs`(新建 helper)
- `src/platform/Aevatar.GAgentService.Application/Responses/ChatCompletionsCommandFacade.cs`
- `src/platform/Aevatar.GAgentService.Application/Responses/MessagesCommandFacade.cs`
- `src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandFacade.cs`
- `src/platform/Aevatar.GAgentService.Application/Responses/ChatRunToolCompletionCoordinator.cs`
- `src/platform/Aevatar.GAgentService.Application/Responses/ResponsesToolChoiceHints.cs`
- `src/platform/Aevatar.GAgentService.Core/GAgents/ChatRunActor.cs`
- `src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs`
- `src/platform/Aevatar.GAgentService.Infrastructure/Adapters/ChatRunActorAdapter.cs`
- `test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs`
- `test/Aevatar.GAgentService.Tests/Core/ChatRunActorTests.cs`

## Stacked-PR

base = `auto-refact-dev`

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
