### PR TITLE
feat(issue1444): Team workbench 状态诚实修正(first-slice)

### DIFF
--- a/.refactor-loop/runs/fix-pr1446-r2.md
+++ b/.refactor-loop/runs/fix-pr1446-r2.md
@@ -1,0 +1,34 @@
+# Fix PR 1446 r2
+
+## Context
+
+- PR: 1446
+- Branch: `refactor/issue1444-first`
+- Failed check: `console-web` in run `26685830195`
+- Failed step: `Test console-web`
+
+## Root Cause
+
+`ScriptsWorkbenchPage.test.tsx` still asserted the old single-probe behavior for save observation and promotion catalog reads. The current page correctly probes read-model visibility multiple times before reporting an accepted-but-not-observed operation as pending. In CI this produced four failures:
+
+- The save pending test could not find the pending observation notice.
+- The stale promotion test could not find the pending catalog notice.
+- The missing/rejected promotion tests expected exactly one `getScriptCatalog` call but the page made repeated visibility probes.
+
+## Fix
+
+- Added `waitForObservationProbeTick` to `ScriptsWorkbenchPage` so production keeps the existing 250 ms observation cadence while tests can inject a deterministic immediate tick.
+- Updated the save pending test to keep `observeSaveScript` pending across the full 8-probe window.
+- Updated promotion pending tests to assert user-visible pending behavior and no `getScript` fallback, instead of coupling to a single global catalog call count.
+
+## Verification
+
+- `corepack pnpm --dir apps/aevatar-console-web install --frozen-lockfile 2>&1 | tail -3` passed.
+- `corepack pnpm --dir apps/aevatar-console-web build 2>&1 | tail -5` passed.
+- `corepack pnpm --dir apps/aevatar-console-web test -- --selectProjects jsdom src/modules/studio/scripts/ScriptsWorkbenchPage.test.tsx --runInBand` passed: 18 tests.
+- `bash tools/ci/test_stability_guards.sh` passed.
+- `corepack pnpm --dir apps/aevatar-console-web test --runInBand 2>&1 | tail -10` passed: 106 suites, 686 tests.
+
+## Command Notes
+
+The console app declares `packageManager: pnpm@10.2.1` and has `pnpm-lock.yaml` rather than `yarn.lock`, so verification used pnpm, matching CI. The literal `pnpm test --run` form was checked and rejected by Jest because `--run` is not a valid Jest option for this project.

--- a/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.test.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.test.tsx
@@ -61,6 +61,8 @@ const mockedHistory = history as unknown as {
   push: jest.Mock;
 };
 
+const resolveObservationProbeTick = () => Promise.resolve();
+
 const appContext = {
   mode: 'proxy',
   scopeId: 'scope-1',
@@ -313,17 +315,23 @@ describe('ScriptsWorkbenchPage', () => {
   });
 
   it('keeps save observation pending when the read model is not visible yet', async () => {
-    mockedScriptsApi.observeSaveScript.mockRejectedValueOnce(
-      new Error('temporary timeout'),
-    );
+    mockedScriptsApi.observeSaveScript.mockResolvedValue({
+      scopeId: 'scope-1',
+      scriptId: 'script-1',
+      status: 'pending',
+      message:
+        'Save accepted for script-1; observation is not available yet.',
+      currentScript: null,
+      isTerminal: false,
+    });
 
-    renderPage();
+    renderPage({}, { waitForObservationProbeTick: resolveObservationProbeTick });
 
     await screen.findByLabelText('Script ID');
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
-      expect(mockedScriptsApi.observeSaveScript).toHaveBeenCalledTimes(1);
+      expect(mockedScriptsApi.observeSaveScript).toHaveBeenCalledTimes(8);
     });
     expect(
       await screen.findByText(
@@ -414,7 +422,7 @@ describe('ScriptsWorkbenchPage', () => {
       );
       arrangeCatalogRead();
 
-      renderPage();
+      renderPage({}, { waitForObservationProbeTick: resolveObservationProbeTick });
 
       await screen.findByLabelText('Script ID');
       fireEvent.click(screen.getByRole('button', { name: 'More script actions' }));
@@ -431,15 +439,13 @@ describe('ScriptsWorkbenchPage', () => {
           }),
         );
       });
-      await waitFor(() => {
-        expect(mockedScriptsApi.getScriptCatalog).toHaveBeenCalledTimes(1);
-      });
-      expect(mockedScriptsApi.getScript).not.toHaveBeenCalled();
       expect(
         await screen.findByText(
           'Promotion accepted for script-1 rev-2. Refresh the workspace catalog if the read model is still pending.',
         ),
       ).toBeTruthy();
+      expect(mockedScriptsApi.getScriptCatalog.mock.calls.length).toBeGreaterThan(0);
+      expect(mockedScriptsApi.getScript).not.toHaveBeenCalled();
     },
   );
 

--- a/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.test.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.test.tsx
@@ -420,11 +420,11 @@ describe('ScriptsWorkbenchPage', () => {
           },
         ]),
       );
-      arrangeCatalogRead();
-
       renderPage({}, { waitForObservationProbeTick: resolveObservationProbeTick });
 
       await screen.findByLabelText('Script ID');
+      mockedScriptsApi.getScriptCatalog.mockClear();
+      arrangeCatalogRead();
       fireEvent.click(screen.getByRole('button', { name: 'More script actions' }));
       fireEvent.click(await screen.findByText('Promote'));
       fireEvent.click(screen.getByRole('button', { name: 'Promote' }));
@@ -444,7 +444,7 @@ describe('ScriptsWorkbenchPage', () => {
           'Promotion accepted for script-1 rev-2. Refresh the workspace catalog if the read model is still pending.',
         ),
       ).toBeTruthy();
-      expect(mockedScriptsApi.getScriptCatalog.mock.calls.length).toBeGreaterThan(0);
+      expect(mockedScriptsApi.getScriptCatalog).toHaveBeenCalledTimes(8);
       expect(mockedScriptsApi.getScript).not.toHaveBeenCalled();
     },
   );

--- a/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.tsx
@@ -238,6 +238,7 @@ type ScriptsWorkbenchPageProps = {
   initialScriptId?: string;
   onRegisterLeaveGuard?: (guard: (() => Promise<boolean>) | null) => void;
   onSelectScriptId?: (scriptId: string) => void;
+  waitForObservationProbeTick?: () => Promise<void>;
 };
 
 let draftCounter = 0;
@@ -755,6 +756,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
   initialScriptId = '',
   onRegisterLeaveGuard,
   onSelectScriptId,
+  waitForObservationProbeTick = waitForAsyncOperationProbeTick,
 }) => {
   const queryClient = useQueryClient();
   const initialScriptIdRef = React.useRef(initialScriptId.trim());
@@ -1643,7 +1645,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
       isTerminal: (observation) =>
         normalizeScriptSaveOperationState(observation).terminal,
       canRetryError: () => true,
-      waitForNextAttempt: waitForAsyncOperationProbeTick,
+      waitForNextAttempt: waitForObservationProbeTick,
     });
 
     if (result.observation != null) {
@@ -1665,7 +1667,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
       currentScript: null,
       isTerminal: false,
     };
-  }, [resolvedScopeId]);
+  }, [resolvedScopeId, waitForObservationProbeTick]);
 
   const waitForPromotionCatalog = React.useCallback(async (
     decision: ScriptPromotionDecision,
@@ -1687,11 +1689,11 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
         // Ignore transient query failures while the catalog is catching up.
       }
 
-      await waitForAsyncOperationProbeTick();
+      await waitForObservationProbeTick();
     }
 
     return null;
-  }, [resolvedScopeId]);
+  }, [resolvedScopeId, waitForObservationProbeTick]);
 
   const handleSave = React.useCallback(async () => {
     setSavePending(true);

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -5716,10 +5716,8 @@ describe("StudioPage", () => {
     );
 
     expect(await screen.findByTestId("studio-bind-surface")).toBeTruthy();
-    await waitFor(() => {
-      expect(screen.getByText("candidate:draft1")).toBeTruthy();
-      expect(screen.getByText("service:no-service")).toBeTruthy();
-    });
+    expect(await screen.findByText("candidate:draft1")).toBeTruthy();
+    expect(await screen.findByText("service:no-service")).toBeTruthy();
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Bind current member" }));

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -879,6 +879,9 @@ describe("TeamDetailPage", () => {
     const configurationHeading = screen.getByText("配置明细");
     expect(screen.getByRole("button", { name: "测试团队" })).toBeTruthy();
     expect(currentPostureHeading).toBeTruthy();
+    expect(await screen.findByText(/ReadModel ·/)).toBeTruthy();
+    expect(await screen.findByText("版本 · 运行中")).toBeTruthy();
+    expect(await screen.findByText("运行 · 等待处理")).toBeTruthy();
     expect(compositionHeading).toBeTruthy();
     expect(configurationHeading).toBeTruthy();
     expect(screen.queryByLabelText("Team test prompt")).toBeNull();
@@ -907,6 +910,7 @@ describe("TeamDetailPage", () => {
     expect(screen.queryByRole("button", { name: "处理等待 Run" })).toBeNull();
     expect(screen.queryByRole("button", { name: "治理绑定" })).toBeNull();
     expect(screen.queryByRole("button", { name: "部署记录" })).toBeNull();
+    expect(screen.queryByText("稳定")).toBeNull();
     expect(studioApi.getTeam).toHaveBeenCalledWith("scope-1", "t-alpha");
   });
 
@@ -938,6 +942,9 @@ describe("TeamDetailPage", () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
     expect(await screen.findByText("当前态势")).toBeTruthy();
+    expect(await screen.findByText("已完成")).toBeTruthy();
+    expect(await screen.findByText("版本 · 运行中")).toBeTruthy();
+    expect(await screen.findByText(/ReadModel ·/)).toBeTruthy();
     expect(screen.queryByText("No successful baseline is available yet.")).toBeNull();
     expect(screen.queryByText("Comparing run run-current against baseline run-good.")).toBeNull();
     expect(scopeRuntimeApi.getServiceRunAudit).not.toHaveBeenCalled();

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -817,9 +817,12 @@ const TeamDetailPage: React.FC = () => {
     trimText(lens.currentService?.deploymentStatus) ||
     trimText(lens.activeRevision?.status) ||
     "--";
-  const currentHeaderStatus =
-    trimText(lens.currentRun?.completionStatus) || currentDeploymentStatus;
-  const currentHeaderStatusFriendly = formatFriendlyStatus(currentHeaderStatus);
+  // Refactor (iterv1/issue1444-first):
+  //   Old pattern: Team workbench rendered completed as stable and mixed run/deployment status.
+  //   New principle: expose run completion, deployment serving, and readmodel freshness as separate facts.
+  const currentHeaderStatusFriendly = teamSummaryQuery.data
+    ? `ReadModel · ${formatCompactTimestamp(latestVisibleUpdate)}`
+    : "ReadModel 暂不可见";
   const currentRevisionFriendly = formatFriendlyStatus(currentRevisionStatus);
   const currentDeploymentFriendly = formatFriendlyStatus(currentDeploymentStatus);
   const currentServiceKey =
@@ -1397,7 +1400,10 @@ const TeamDetailPage: React.FC = () => {
         currentDeploymentPillStyle={resolveStatusPillStyle(token, currentDeploymentStatus)}
         currentDeploymentPillText={currentDeploymentPillText}
         currentHeaderStatusFriendly={currentHeaderStatusFriendly}
-        currentHeaderStatusStyle={resolveStatusPillStyle(token, currentHeaderStatus)}
+        currentHeaderStatusStyle={{
+          background: token.colorFillQuaternary,
+          color: token.colorTextSecondary,
+        }}
         currentMemberCardCaption={currentMemberCardCaption}
         currentMemberCardTooltip={currentMemberCardTooltip}
         currentMemberLabel={currentMemberLabel}
@@ -1497,10 +1503,10 @@ const TeamDetailPage: React.FC = () => {
             style={resolveStatusPillStyle(token, teamLifecycleStatus)}
             text={teamLifecycleLabel}
           />
-        ) : currentHeaderStatusFriendly !== "--" ? (
+        ) : lens.currentRun?.completionStatus ? (
           <DetailPill
-            style={resolveStatusPillStyle(token, currentHeaderStatus)}
-            text={currentHeaderStatusFriendly}
+            style={resolveStatusPillStyle(token, lens.currentRun.completionStatus)}
+            text={formatFriendlyStatus(lens.currentRun.completionStatus)}
           />
         ) : null
       }

--- a/apps/aevatar-console-web/src/pages/teams/home.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.test.tsx
@@ -163,7 +163,8 @@ describe("TeamsHomePage", () => {
     expect(screen.queryByText("当前工作空间")).toBeNull();
     expect(screen.getByText("AI Team 总数")).toBeTruthy();
     expect(screen.getByText("待处理 Team")).toBeTruthy();
-    expect(screen.getByText("运行稳定")).toBeTruthy();
+    expect(screen.getByText("最近完成 Team")).toBeTruthy();
+    expect(screen.queryByText("运行稳定")).toBeNull();
     expect(screen.getByText("团队列表")).toBeTruthy();
     expect(
       screen.getByText("按 Team 聚合成员与最近运行信号，优先处理异常或待关注项。"),
@@ -186,6 +187,24 @@ describe("TeamsHomePage", () => {
     expect(screen.queryByText("进入 Studio")).toBeNull();
     expect(screen.queryByText("新增成员")).toBeNull();
     expect(screen.queryByText("查看默认成员运行")).toBeNull();
+  });
+
+  it("shows completed run status as completion, not stability", async () => {
+    (scopeRuntimeApi.listMemberRuns as jest.Mock).mockResolvedValueOnce({
+      ...buildMemberRunCatalog("member-alpha"),
+      runs: [
+        {
+          ...buildMemberRunCatalog("member-alpha").runs[0],
+          completionStatus: "completed",
+          lastSuccess: true,
+        },
+      ],
+    });
+
+    renderWithQueryClient(React.createElement(TeamsHomePage));
+
+    expect(await screen.findByText("已完成")).toBeTruthy();
+    expect(screen.queryByText("稳定")).toBeNull();
   });
 
   it("routes Create Team to the real create-team page", async () => {

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -113,7 +113,7 @@ function formatRunStatusLabel(status: string | null | undefined): string {
     case "error":
       return "异常";
     case "completed":
-      return "稳定";
+      return "已完成";
     default:
       return trimOptional(status) || "未知";
   }
@@ -1153,7 +1153,7 @@ const TeamsHomePage: React.FC = () => {
             >
               <SummaryStatCard accent label="AI Team 总数" value={visibleTeamCount} />
               <SummaryStatCard label="待处理 Team" value={actionableTeamCount} />
-              <SummaryStatCard label="运行稳定" value={healthyTeamCount} />
+              <SummaryStatCard label="最近完成 Team" value={healthyTeamCount} />
             </div>
 
             {teamsQuery.isLoading ? (

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -103,6 +103,9 @@ function pickMeaningfulLabel(
   return "";
 }
 
+// Refactor (v1/issue1444-first):
+//   Old: workflow run status labels leaked raw runtime terms directly into the teams UI.
+//   New: run status mapping keeps UI display labels stable while preserving the underlying status semantics.
 function formatRunStatusLabel(status: string | null | undefined): string {
   switch (trimOptional(status).toLowerCase()) {
     case "waiting":


### PR DESCRIPTION
closes #1444

## 摘要

Team workbench 状态诚实修正(first-slice)— `#1397` 共识 split 后的第一片实施。

## Old / New

- **Old**:Team workbench 把 `run completion` 显示成 `deployment serving stable`;`detail.tsx` 合成 `headerStatus` 来自 run completion OR deployment status
- **New**:`run completion` / `deployment serving state` / `readmodel freshness` 作为分离的 raw facts 各自展示,不再合成统一 status

## 违反

CLAUDE.md「查询诚实」+「权威状态 / ReadModel / Projection」:不在弱读结果上暗示强一致;不同维度事实分离呈现。

## Scope

- `apps/aevatar-console-web/src/pages/teams/home.tsx` + `home.test.tsx`
- `apps/aevatar-console-web/src/pages/teams/detail.tsx` + `detail.test.tsx`

⟦AI:AUTO-LOOP⟧
