### PR TITLE
feat(issue1450): StudioTeamEntryMemberResolver 边界契约诚实化(Phase 9 #1395 first-slice)

### DIFF
--- a/IMPLEMENT_REPORT.md
+++ b/IMPLEMENT_REPORT.md
@@ -1,0 +1,42 @@
+# Implement Report
+
+## Scope
+
+Phase 9 #1395 first slice: honest boundary contract for `StudioTeamEntryMemberResolver`.
+
+## Changes
+
+- Added XML contract documentation to `ITeamEntryMemberResolver` and `TeamEntryMemberResolution` clarifying that the resolver is command target resolution only.
+- Added XML documentation to `StudioTeamEntryMemberResolver` clarifying it reads team/member read models only for command admission and dispatch target selection.
+- Added resolver tests that assert:
+  - team and member read models are read only through direct `GetAsync` calls for command target admission;
+  - the resolution DTO remains limited to `ScopeId`, `TeamId`, `EntryMemberId`, and `PublishedServiceId`;
+  - no composite team status/readiness or invented freshness/version field is returned.
+
+## Boundary Notes
+
+- No `ScopeWorkflowSummary` changes.
+- No actor type, envelope kind, projection phase, aggregate actor, read model, or proto field was added.
+- Existing `UpdatedAt` fields on team/member responses were not copied into `TeamEntryMemberResolution`; there was no existing team/member `StateVersion` in this resolver path to pass through.
+- No `docs/canon/*` files were modified.
+
+## Verification
+
+```bash
+dotnet build aevatar.slnx --nologo 2>&1 | tail -3
+```
+
+Result: passed with `0 个错误`.
+
+```bash
+bash tools/ci/test_stability_guards.sh
+```
+
+Result: passed.
+
+```bash
+dotnet test aevatar.slnx --nologo --no-build 2>&1 | tail -30
+```
+
+Result: passed; the command exited with code 0 and the tailed output showed only passing test assemblies.
+⟦AI:AUTO-LOOP⟧

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioTeamEntryMemberResolver.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioTeamEntryMemberResolver.cs
@@ -4,6 +4,9 @@ using Aevatar.Studio.Application.Studio.Contracts;
 
 namespace Aevatar.Studio.Application.Studio.Services;
 
+// Refactor (iter-v1/issue1450-first):
+//   Old: implementation reads team and member read models and could be misused as composite status.
+//   New: implementation is only for command target admission and returns no composite team readiness.
 /// <summary>
 /// Command target resolver for Studio team entry-member invocation. It reads
 /// the team and member read models only to admit a command and select the

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioTeamEntryMemberResolver.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioTeamEntryMemberResolver.cs
@@ -4,6 +4,12 @@ using Aevatar.Studio.Application.Studio.Contracts;
 
 namespace Aevatar.Studio.Application.Studio.Services;
 
+/// <summary>
+/// Command target resolver for Studio team entry-member invocation. It reads
+/// the team and member read models only to admit a command and select the
+/// dispatch target; it does not expose stable team readiness/status for UI,
+/// reports, or other query consumers.
+/// </summary>
 public sealed class StudioTeamEntryMemberResolver : ITeamEntryMemberResolver
 {
     private readonly IStudioTeamQueryPort _teamQueryPort;

--- a/src/platform/Aevatar.GAgentService.Abstractions/Ports/ITeamEntryMemberResolver.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Ports/ITeamEntryMemberResolver.cs
@@ -1,5 +1,11 @@
 namespace Aevatar.GAgentService.Abstractions.Ports;
 
+/// <summary>
+/// Resolves the Studio team entry member for command target admission. This
+/// contract is not a stable team status/readiness read model and must not be
+/// reused by UI, reporting, or other query surfaces to display cross-actor
+/// authoritative state.
+/// </summary>
 public interface ITeamEntryMemberResolver
 {
     Task<TeamEntryMemberResolution> ResolveAsync(
@@ -8,6 +14,13 @@ public interface ITeamEntryMemberResolver
         CancellationToken ct = default);
 }
 
+/// <summary>
+/// Narrow command-target resolution result. It carries only the identifiers
+/// needed to dispatch to the selected entry member's published service; it is
+/// not a composite team readiness/status view. Freshness markers may only be
+/// added by passing through fields already exposed by the underlying team or
+/// member read models, never by inventing a resolver-local version.
+/// </summary>
 public sealed record TeamEntryMemberResolution(
     string ScopeId,
     string TeamId,

--- a/src/platform/Aevatar.GAgentService.Abstractions/Ports/ITeamEntryMemberResolver.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Ports/ITeamEntryMemberResolver.cs
@@ -1,5 +1,8 @@
 namespace Aevatar.GAgentService.Abstractions.Ports;
 
+// Refactor (iter-v1/issue1450-first):
+//   Old: resolver contract could be misread as a composite team readiness/status read model.
+//   New: resolver is only for InvokeTeam command target admission and exposes no cross-authority team status.
 /// <summary>
 /// Resolves the Studio team entry member for command target admission. This
 /// contract is not a stable team status/readiness read model and must not be

--- a/test/Aevatar.Studio.Tests/StudioTeamEntryMemberResolverTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamEntryMemberResolverTests.cs
@@ -29,6 +29,56 @@ public sealed class StudioTeamEntryMemberResolverTests
     }
 
     [Fact]
+    public async Task ResolveAsync_ShouldUseTeamAndMemberReadModelsOnlyForCommandTargetAdmission()
+    {
+        var teamPort = new TeamQueryPort(NewTeam());
+        var memberPort = new MemberQueryPort(NewMember());
+        var resolver = new StudioTeamEntryMemberResolver(teamPort, memberPort);
+
+        var result = await resolver.ResolveAsync(ScopeId, TeamId);
+
+        result.Should().Be(new TeamEntryMemberResolution(
+            ScopeId,
+            TeamId,
+            EntryMemberId,
+            PublishedServiceId));
+        teamPort.GetCalls.Should().Be(1);
+        teamPort.ListCalls.Should().Be(0);
+        memberPort.GetCalls.Should().Be(1);
+        memberPort.ListCalls.Should().Be(0);
+        teamPort.GetRequests.Should().ContainSingle()
+            .Which.Should().Be((ScopeId, TeamId));
+        memberPort.GetRequests.Should().ContainSingle()
+            .Which.Should().Be((ScopeId, EntryMemberId));
+    }
+
+    [Fact]
+    public void TeamEntryMemberResolution_ShouldRemainNarrowCommandTargetContract()
+    {
+        var propertyNames = typeof(TeamEntryMemberResolution)
+            .GetProperties()
+            .Select(static property => property.Name)
+            .ToArray();
+
+        propertyNames.Should().BeEquivalentTo(
+            [
+                nameof(TeamEntryMemberResolution.ScopeId),
+                nameof(TeamEntryMemberResolution.TeamId),
+                nameof(TeamEntryMemberResolution.EntryMemberId),
+                nameof(TeamEntryMemberResolution.PublishedServiceId),
+            ],
+            options => options.WithStrictOrdering(),
+            "this resolver is command target resolution, not a composite team readiness/status read model");
+        propertyNames.Should().NotContain(static name =>
+            name.Contains("Status", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("Readiness", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("Ready", StringComparison.OrdinalIgnoreCase)
+            || name.Contains("StateVersion", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("Version", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("UpdatedAt", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public async Task ResolveAsync_ShouldThrowTeamNotFound_WhenTeamMissing()
     {
         var resolver = new StudioTeamEntryMemberResolver(
@@ -160,31 +210,53 @@ public sealed class StudioTeamEntryMemberResolverTests
 
     private sealed class TeamQueryPort(StudioTeamSummaryResponse? team) : IStudioTeamQueryPort
     {
+        public int ListCalls { get; private set; }
+        public int GetCalls { get; private set; }
+        public List<(string ScopeId, string TeamId)> GetRequests { get; } = [];
+
         public Task<StudioTeamRosterResponse> ListAsync(
             string scopeId,
             StudioTeamRosterPageRequest? page = null,
-            CancellationToken ct = default) =>
-            Task.FromResult(new StudioTeamRosterResponse(scopeId, team == null ? [] : [team]));
+            CancellationToken ct = default)
+        {
+            ListCalls++;
+            return Task.FromResult(new StudioTeamRosterResponse(scopeId, team == null ? [] : [team]));
+        }
 
         public Task<StudioTeamSummaryResponse?> GetAsync(
             string scopeId,
             string teamId,
-            CancellationToken ct = default) =>
-            Task.FromResult(team);
+            CancellationToken ct = default)
+        {
+            GetCalls++;
+            GetRequests.Add((scopeId, teamId));
+            return Task.FromResult(team);
+        }
     }
 
     private sealed class MemberQueryPort(StudioMemberDetailResponse? member) : IStudioMemberQueryPort
     {
+        public int ListCalls { get; private set; }
+        public int GetCalls { get; private set; }
+        public List<(string ScopeId, string MemberId)> GetRequests { get; } = [];
+
         public Task<StudioMemberRosterResponse> ListAsync(
             string scopeId,
             StudioMemberRosterPageRequest? page = null,
-            CancellationToken ct = default) =>
-            Task.FromResult(new StudioMemberRosterResponse(scopeId, member == null ? [] : [member.Summary]));
+            CancellationToken ct = default)
+        {
+            ListCalls++;
+            return Task.FromResult(new StudioMemberRosterResponse(scopeId, member == null ? [] : [member.Summary]));
+        }
 
         public Task<StudioMemberDetailResponse?> GetAsync(
             string scopeId,
             string memberId,
-            CancellationToken ct = default) =>
-            Task.FromResult(member);
+            CancellationToken ct = default)
+        {
+            GetCalls++;
+            GetRequests.Add((scopeId, memberId));
+            return Task.FromResult(member);
+        }
     }
 }


### PR DESCRIPTION
closes #1450

## 摘要

`StudioTeamEntryMemberResolver` 边界契约诚实化 — `#1395` Phase 9 共识 split first-slice。

## Old / New

- **Old**:`StudioTeamEntryMemberResolver` 读取 team + member readmodel,但 contract 上没说清这只是 command target resolution,可能被误用为 cross-authority team status
- **New**:contract 明确**只用于** InvokeTeam command target admission;**不返回** composite team readiness;freshness 透传现有 source,不发明版本

## 违反

CLAUDE.md「事实源唯一」+「查询诚实」:resolver 不应隐式成为 cross-authority status readmodel。

## Scope

- `src/platform/Aevatar.GAgentService.Abstractions/Ports/ITeamEntryMemberResolver.cs`(contract)
- `src/Aevatar.Studio.Application/Studio/Services/StudioTeamEntryMemberResolver.cs`
- `test/Aevatar.Studio.Tests/StudioTeamEntryMemberResolverTests.cs`(断言不返回 composite status)

⟦AI:AUTO-LOOP⟧
