### PR TITLE
feat(issue1454): Directory.Build.props v0.1.0-beta + guard(Phase 9 #1449 first-slice)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,13 @@
   <PropertyGroup>
     <!-- Enable C# preview features (null conditional assignment, field keyword, etc.) -->
     <LangVersion>preview</LangVersion>
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionSuffix>beta</VersionSuffix>
+    <Version>0.1.0-beta</Version>
+    <PackageVersion>0.1.0-beta</PackageVersion>
+    <InformationalVersion>0.1.0-beta</InformationalVersion>
+    <AssemblyVersion>0.1.0.0</AssemblyVersion>
+    <FileVersion>0.1.0.0</FileVersion>
     <!-- Use system protoc on Apple Silicon (ARM64) to avoid "Bad CPU type" error -->
     <!-- This works for macOS with Homebrew-installed protoc -->
     <Protobuf_Protoc Condition="'$(OS)' == 'Unix' And Exists('/opt/homebrew/bin/protoc')">/opt/homebrew/bin/protoc</Protobuf_Protoc>

--- a/IMPLEMENT_REPORT.md
+++ b/IMPLEMENT_REPORT.md
@@ -1,0 +1,61 @@
+# Implementation Report
+
+## Scope
+
+- Added repository-wide .NET version properties to `Directory.Build.props`.
+- Added a fail-fast static guard in `tools/ci/architecture_guards.sh` to require:
+  - `<Version>0.1.0-beta</Version>`
+  - `<VersionPrefix>0.1.0</VersionPrefix>`
+  - `<VersionSuffix>beta</VersionSuffix>`
+
+## Files Changed
+
+- `Directory.Build.props`
+- `tools/ci/architecture_guards.sh`
+
+## Verification
+
+```bash
+dotnet build aevatar.slnx --nologo 2>&1 | tail -3
+```
+
+Result:
+
+```text
+    0 个错误
+
+已用时间 00:00:26.03
+```
+
+```bash
+dotnet test aevatar.slnx --nologo --no-build 2>&1 | tail -20
+```
+
+Result: passed. The output tail reported successful test assemblies, including:
+
+```text
+已通过! - 失败:     0，通过:   916，已跳过:     0，总计:   916，持续时间: 8 s - Aevatar.GAgents.ChannelRuntime.Tests.dll (net10.0)
+已通过! - 失败:     0，通过:   404，已跳过:     0，总计:   404，持续时间: 5 s - Aevatar.Workflow.Host.Api.Tests.dll (net10.0)
+已通过! - 失败:     0，通过:   696，已跳过:     0，总计:   696，持续时间: 35 s - Aevatar.AI.Tests.dll (net10.0)
+```
+
+```bash
+bash tools/ci/architecture_guards.sh 2>&1 | tail -10
+```
+
+Result:
+
+```text
+Scripting runtime snapshot guard passed.
+Running runtime callback guards...
+Runtime callback guards passed.
+Running channel card literal guard...
+channel_card_literal_guard: ok
+Running Nyx relay replay authority guard...
+Running docs lint guard...
+
+docs lint: PASSED — 50 file(s) checked, 0 errors
+Architecture guards passed.
+```
+
+⟦AI:AUTO-LOOP⟧

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -34,6 +34,27 @@ if [ -d "src/Aevatar.Host.Api" ] || [ -d "src/Aevatar.Host.Gateway" ]; then
   exit 1
 fi
 
+check_directory_build_version_guard() {
+  local props_file="Directory.Build.props"
+
+  if ! rg -q "<Version>0\.1\.0-beta</Version>" "${props_file}"; then
+    echo "Directory.Build.props must define <Version>0.1.0-beta</Version>."
+    exit 1
+  fi
+
+  if ! rg -q "<VersionPrefix>0\.1\.0</VersionPrefix>" "${props_file}"; then
+    echo "Directory.Build.props must define <VersionPrefix>0.1.0</VersionPrefix>."
+    exit 1
+  fi
+
+  if ! rg -q "<VersionSuffix>beta</VersionSuffix>" "${props_file}"; then
+    echo "Directory.Build.props must define <VersionSuffix>beta</VersionSuffix>."
+    exit 1
+  fi
+}
+
+check_directory_build_version_guard
+
 bash tools/ci/aevatar_oauth_client_es_acl_guard.sh
 bash tools/ci/static_service_activation_guard.sh || exit $?
 

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -34,6 +34,9 @@ if [ -d "src/Aevatar.Host.Api" ] || [ -d "src/Aevatar.Host.Gateway" ]; then
   exit 1
 fi
 
+# Refactor (v1/issue1454-first):
+#   Old: 无中央 .NET 版本源,各项目自带或默认 1.0.0.0,无中央事实
+#   New: Directory.Build.props 中央 v0.1.0-beta + guard 防回归
 check_directory_build_version_guard() {
   local props_file="Directory.Build.props"
 
@@ -49,6 +52,26 @@ check_directory_build_version_guard() {
 
   if ! rg -q "<VersionSuffix>beta</VersionSuffix>" "${props_file}"; then
     echo "Directory.Build.props must define <VersionSuffix>beta</VersionSuffix>."
+    exit 1
+  fi
+
+  if ! rg -q "<PackageVersion>0\.1\.0-beta</PackageVersion>" "${props_file}"; then
+    echo "Directory.Build.props must define <PackageVersion>0.1.0-beta</PackageVersion>."
+    exit 1
+  fi
+
+  if ! rg -q "<InformationalVersion>0\.1\.0-beta</InformationalVersion>" "${props_file}"; then
+    echo "Directory.Build.props must define <InformationalVersion>0.1.0-beta</InformationalVersion>."
+    exit 1
+  fi
+
+  if ! rg -q "<AssemblyVersion>0\.1\.0\.0</AssemblyVersion>" "${props_file}"; then
+    echo "Directory.Build.props must define <AssemblyVersion>0.1.0.0</AssemblyVersion>."
+    exit 1
+  fi
+
+  if ! rg -q "<FileVersion>0\.1\.0\.0</FileVersion>" "${props_file}"; then
+    echo "Directory.Build.props must define <FileVersion>0.1.0.0</FileVersion>."
     exit 1
   fi
 }


### PR DESCRIPTION
closes #1454

## 摘要

Directory.Build.props 加中央 .NET 版本 `v0.1.0-beta` + guard — `#1449` Phase 9 共识 split first-slice。

## 改动

### 1. `Directory.Build.props`

```xml
<VersionPrefix>0.1.0</VersionPrefix>
<VersionSuffix>beta</VersionSuffix>
<Version>0.1.0-beta</Version>
<PackageVersion>0.1.0-beta</PackageVersion>
<InformationalVersion>0.1.0-beta</InformationalVersion>
<AssemblyVersion>0.1.0.0</AssemblyVersion>
<FileVersion>0.1.0.0</FileVersion>
```

→ 所有 .NET 项目 build 出的 dll/nupkg 拥有统一 `0.1.0-beta` 中央版本事实。

### 2. `tools/ci/architecture_guards.sh`

加 static guard 校验 5 个版本属性存在 + 值 = `0.1.0-beta`(或 numeric `0.1.0.0`)。failure → exit 1。

## Out-of-scope(留给 #1455)

- `apps/aevatar-console-web/package.json` v6.0.0 保持独立产品轨道
- root `VERSION` / `CHANGELOG.md` 不引入
- weekly-release / docker tag / release script 不动

## 违反

CLAUDE.md「事实源唯一」:版本号缺中央权威源 → 本 PR 修。

⟦AI:AUTO-LOOP⟧
