### PR TITLE
feat(issue1457): 删除 trace identity → business/stream fallback(Phase 9 #1394 first-slice)

### DIFF
--- a/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/EventEnvelopeToWorkflowRunEventMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/EventEnvelopeToWorkflowRunEventMapper.cs
@@ -689,10 +689,13 @@ public sealed class WorkflowWaitingSignalRunEventEnvelopeMappingHandler : IWorkf
         }
 
         var evt = envelope.Payload.Unpack<WaitingForSignalEvent>();
+        if (string.IsNullOrWhiteSpace(evt.RunId))
+        {
+            events = [];
+            return true;
+        }
+
         var ts = AGUIEventEnvelopeMappingHelpers.ToUnixMs(envelope.Timestamp);
-        var runId = string.IsNullOrWhiteSpace(evt.RunId)
-            ? AGUIEventEnvelopeMappingHelpers.ResolveRunId(envelope, string.Empty)
-            : evt.RunId;
 
         events =
         [
@@ -704,7 +707,7 @@ public sealed class WorkflowWaitingSignalRunEventEnvelopeMappingHandler : IWorkf
                     Name = "aevatar.workflow.waiting_signal",
                     Payload = Any.Pack(new WorkflowWaitingSignalCustomPayload
                     {
-                        RunId = runId,
+                        RunId = evt.RunId,
                         StepId = evt.StepId,
                         SignalName = evt.SignalName,
                         Prompt = evt.Prompt,

--- a/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/WorkflowExecutionRunEventProjector.cs
+++ b/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/WorkflowExecutionRunEventProjector.cs
@@ -31,12 +31,9 @@ public sealed class WorkflowExecutionRunEventProjector
         EventEnvelope envelope)
     {
         // Keep streaming pinned to the projection session command id.
-        // Resume/signal events may arrive without (or with a different) correlation id,
-        // but they still belong to the same live run session.
-        var commandId = string.IsNullOrWhiteSpace(context.SessionId)
-            ? envelope.Propagation?.CorrelationId
-            : context.SessionId;
-        if (string.IsNullOrWhiteSpace(commandId))
+        // Missing session identity is fail-closed: trace correlation is not a stream key.
+        var streamCommandId = context.SessionId;
+        if (string.IsNullOrWhiteSpace(streamCommandId))
             return EmptyEntries;
 
         IReadOnlyList<WorkflowRunEventEnvelope> runEvents = _mapper.Map(envelope);
@@ -54,7 +51,7 @@ public sealed class WorkflowExecutionRunEventProjector
         {
             entries.Add(new ProjectionSessionEventEntry<WorkflowRunEventEnvelope>(
                 context.RootActorId,
-                commandId,
+                streamCommandId,
                 runEvent));
         }
 

--- a/test/Aevatar.Workflow.Host.Api.Tests/EventEnvelopeToAGUIEventMapperTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/EventEnvelopeToAGUIEventMapperTests.cs
@@ -391,9 +391,9 @@ public sealed class EventEnvelopeToAGUIEventMapperTests
     }
 
     [Fact]
-    public void WaitingForSignalEvent_WhenRunIdMissing_ShouldFallbackToCorrelationId()
+    public void WaitingForSignalEvent_WhenTypedRunIdMissing_ShouldNotMap()
     {
-        var envelope = WrapCommitted(new WaitingForSignalEvent
+        var envelope = WrapObserved(new WaitingForSignalEvent
         {
             StepId = "wait_gate",
             SignalName = "ops_window_open",
@@ -403,10 +403,12 @@ public sealed class EventEnvelopeToAGUIEventMapperTests
             CorrelationId = "corr-wait",
         };
 
-        var events = CreateMapper().Map(envelope);
+        var handler = new WorkflowWaitingSignalRunEventEnvelopeMappingHandler();
+        var mapped = CreateMapper().Map(envelope);
 
-        events.Should().ContainSingle();
-        events[0].Custom.Payload.Unpack<WorkflowWaitingSignalCustomPayload>().RunId.Should().Be("corr-wait");
+        handler.TryMap(envelope, out var events).Should().BeTrue();
+        events.Should().BeEmpty();
+        mapped.Should().BeEmpty();
     }
 
     [Fact]
@@ -509,7 +511,7 @@ public sealed class EventEnvelopeToAGUIEventMapperTests
     }
 
     [Fact]
-    public void PublicMappingPaths_ShouldCoverHelperFallbackBranches()
+    public void PublicMappingPaths_ShouldCoverRemainingHelperFallbackBranches()
     {
         var startEnvelope = new EventEnvelope
         {
@@ -540,8 +542,7 @@ public sealed class EventEnvelopeToAGUIEventMapperTests
                 includeStateEventTimestamp: false).Payload,
         };
         var waitingEvents = CreateMapper().Map(waitingEnvelope);
-        waitingEvents.Should().ContainSingle();
-        waitingEvents[0].Custom.Payload.Unpack<WorkflowWaitingSignalCustomPayload>().RunId.Should().BeEmpty();
+        waitingEvents.Should().BeEmpty();
 
         var reasoningEnvelope = WrapCommitted(new TextMessageReasoningEvent
         {

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionAGUIEventProjectorTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionAGUIEventProjectorTests.cs
@@ -175,7 +175,7 @@ public sealed class WorkflowExecutionAGUIEventProjectorTests
     }
 
     [Fact]
-    public async Task ProjectAsync_WhenContextCommandIdMissing_ShouldFallbackToEnvelopeCorrelationId()
+    public async Task ProjectAsync_WhenContextSessionIdMissing_ShouldNotPublish()
     {
         var streams = new InMemoryStreamProvider();
         var streamHub = new ProjectionSessionEventHub<WorkflowRunEventEnvelope>(
@@ -200,8 +200,7 @@ public sealed class WorkflowExecutionAGUIEventProjectorTests
             },
         });
 
-        await sink.WaitForCountAsync(1, TimeSpan.FromSeconds(2));
-        sink.SnapshotEvents().Should().ContainSingle();
+        sink.SnapshotEvents().Should().BeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
closes #1457

## 摘要

删除 trace identity → business/stream identity fallback — `#1394` Phase 9 共识 split first-slice。

## Old / New

- **Old**:`WorkflowExecutionRunEventProjector` 在 SessionId 缺失时回退用 CorrelationId;`EventEnvelopeToWorkflowRunEventMapper` waiting-signal 从 CorrelationId 合成 RunId
- **New**:SessionId 缺失 → **no publish**;typed RunId 缺失 → **no map(fail-closed)**

## 违反

CLAUDE.md「事实源唯一」:trace identity(CorrelationId)不应回退顶替业务/stream identity。

## Scope

- `src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/EventEnvelopeToWorkflowRunEventMapper.cs`
- `src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/WorkflowExecutionRunEventProjector.cs`
- `test/Aevatar.Workflow.Host.Api.Tests/EventEnvelopeToAGUIEventMapperTests.cs`
- `test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionAGUIEventProjectorTests.cs`

## Out-of-scope(留给 #1458)

Host legacy parent ActorId fallback / projection core SessionId contract / docs/canon vocabulary。

⟦AI:AUTO-LOOP⟧
