### PR TITLE
feat(issue1460): v1 device inbound contract 固化(Phase 9 #1393 first-slice)

### DIFF
--- a/agents/Aevatar.GAgents.Device/DeviceCommandFacades.cs
+++ b/agents/Aevatar.GAgents.Device/DeviceCommandFacades.cs
@@ -255,6 +255,7 @@ internal sealed class DeviceCallbackCommandEnvelopeFactory
         // Refactor (iter1281/cluster-001-device-inbound-typed-payload): Old pattern risk was adding a second callback envelope shape.
         // New principle: keep the existing command facade as the only dispatch skeleton.
         // DeviceInbound is packed once into the single EventEnvelope payload used by the actor system.
+        // The endpoint must have already rejected unknown adapter event_type values; this facade only dispatches typed inbound payloads.
         // Payload typing changes at the message contract, not by adding a new transport abstraction.
         return new EventEnvelope
         {

--- a/agents/Aevatar.GAgents.Device/DeviceEventEndpoints.cs
+++ b/agents/Aevatar.GAgents.Device/DeviceEventEndpoints.cs
@@ -43,8 +43,8 @@ public static class DeviceEventEndpoints
     /// Receives a device event callback from NyxID relay.
     /// 1. Lookup registration from projection read model.
     /// 2. HMAC verification (configurable).
-    /// 3. Parse CallbackPayload → DeviceInbound.
-    /// 4. Dispatch via typed device callback command facade.
+    /// 3. Parse CallbackPayload → DeviceInbound known typed payload.
+    /// 4. Reject unknown event_type values before command facade dispatch.
     /// 5. Return 202 Accepted (or 502 on dispatch failure — NyxID retries at transport level).
     /// </summary>
     // Refactor (iter47/issue-873-device-endpoint-direct-runtime-dispatch):
@@ -82,7 +82,8 @@ public static class DeviceEventEndpoints
             return Results.Unauthorized();
         }
 
-        // Parse callback payload
+        // Parse callback payload into the v1 typed DeviceInbound allowlist.
+        // Unknown event_type values are rejected here, before actor/read-model/projection dispatch.
         DeviceInbound inbound;
         try
         {
@@ -196,6 +197,7 @@ public static class DeviceEventEndpoints
         // New principle: terminate NyxID callback JSON at the Host/Adapter boundary.
         // Known device events are allowlisted and mapped to typed Protobuf payload cases.
         // Unknown or malformed content is rejected before any EventEnvelope dispatch can happen.
+        // This endpoint does not accept a raw payload bag for later actor-side interpretation.
         using var innerDoc = JsonDocument.Parse(contentText);
         var inner = innerDoc.RootElement;
         if (inner.ValueKind != JsonValueKind.Object)

--- a/agents/Aevatar.GAgents.Household/DeviceInbound.Partial.cs
+++ b/agents/Aevatar.GAgents.Household/DeviceInbound.Partial.cs
@@ -1,0 +1,7 @@
+namespace Aevatar.GAgents.Household;
+
+/// <summary>
+/// V1 device inbound contract: adapters admit known device event types as typed
+/// Protobuf payload cases and reject unknown event types before actor dispatch.
+/// </summary>
+public sealed partial class DeviceInbound;

--- a/agents/Aevatar.GAgents.Household/household_messages.proto
+++ b/agents/Aevatar.GAgents.Household/household_messages.proto
@@ -149,14 +149,14 @@ message SpeechDeviceInboundPayload {
   string text = 1;
 }
 
-// Normalized device event from NyxID relay's CallbackPayload.
+// V1 normalized device event from NyxID relay's CallbackPayload.
 // Defined in Household domain because it's the inbound contract for
 // HouseholdEntity; DeviceEventEndpoints (boundary layer) references
 // this project, keeping dependency direction correct (Host → Domain).
 // Refactor (iter1281/cluster-001-device-inbound-typed-payload): Old pattern: DeviceInbound carried payload_json across the actor boundary.
-// New principle: the Host/Adapter parses NyxID callback JSON and admits only known typed payloads.
+// New principle: the Host/Adapter parses NyxID callback JSON and admits only known typed device event payloads.
 // The actor receives Protobuf fields, while the old payload_json tag and name stay reserved.
-// Unknown third-party events remain outside this first slice instead of becoming an untyped bag.
+// Unknown adapter event_type values are rejected before dispatch instead of becoming an untyped raw payload bag.
 message DeviceInbound {
   reserved 5;
   reserved "payload_json";

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceEventEndpointsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceEventEndpointsTests.cs
@@ -3,6 +3,11 @@ using System.Text;
 using System.Text.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
 using Xunit;
 using Aevatar.GAgents.Device;
 
@@ -61,6 +66,34 @@ public class DeviceEventEndpointsTests
         inbound.Sensor.Humidity.Should().Be(65.0);
         inbound.Sensor.LightLevel.Should().Be(70.0);
         inbound.Sensor.MotionDetected.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("temperature_change", Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.Sensor)]
+    [InlineData("person_detected", Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.Camera)]
+    [InlineData("scene_summary", Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.Camera)]
+    [InlineData("motion_detected", Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.Motion)]
+    [InlineData("speech_detected", Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.Speech)]
+    public void ParseCallbackPayload_known_v1_event_types_map_to_typed_payload_cases(
+        string eventType,
+        Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase expectedPayloadCase)
+    {
+        var innerEvent = JsonSerializer.Serialize(new
+        {
+            event_id = $"evt-{eventType}",
+            source = "device-adapter",
+            event_type = eventType,
+            temperature = 22.5,
+            description = "Person near the front door",
+            detected = true,
+            text = "Lights on",
+        });
+
+        var payload = EncodeCallbackPayload(innerEvent, senderPlatformId: "device-v1");
+        var inbound = DeviceEventEndpoints.ParseCallbackPayload(Encoding.UTF8.GetBytes(payload));
+
+        inbound.EventType.Should().Be(eventType);
+        inbound.PayloadCase.Should().Be(expectedPayloadCase);
     }
 
     [Fact]
@@ -193,6 +226,50 @@ public class DeviceEventEndpointsTests
     }
 
     [Fact]
+    public void DeviceInbound_contract_should_not_expose_raw_payload_bag_fields()
+    {
+        var fieldNames = Aevatar.GAgents.Household.DeviceInbound.Descriptor.Fields.InDeclarationOrder()
+            .Select(static field => field.Name)
+            .ToArray();
+
+        fieldNames.Should().NotContain("payload_json");
+        fieldNames.Should().NotContain("raw_payload");
+        fieldNames.Should().NotContain("payload_bytes");
+        fieldNames.Should().NotContain("metadata");
+        Aevatar.GAgents.Household.DeviceInbound.Descriptor.Oneofs
+            .Should().ContainSingle(oneof => oneof.Name == "payload");
+    }
+
+    [Fact]
+    public async Task HandleDeviceCallbackAsync_unknown_event_type_returns_reject_status_and_does_not_dispatch()
+    {
+        var queryPort = Substitute.For<IDeviceRegistrationQueryPort>();
+        var callbackService = Substitute.For<IDeviceCallbackCommandService>();
+        queryPort.GetAsync("reg-unknown", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<DeviceRegistrationEntry?>(MakeRegistration()));
+
+        var innerEvent = JsonSerializer.Serialize(new
+        {
+            event_id = "evt-unknown",
+            event_type = "unknown_type",
+            payload = new { raw = "not admitted" },
+        });
+        var context = CreateJsonHttpContext(EncodeCallbackPayload(innerEvent));
+
+        var result = await InvokeHandleDeviceCallbackAsync(
+            context,
+            "reg-unknown",
+            queryPort,
+            callbackService);
+        var (statusCode, body) = await ExecuteResultAsync(result);
+
+        statusCode.Should().Be(StatusCodes.Status400BadRequest);
+        body.Should().Contain("Invalid callback payload");
+        await callbackService.DidNotReceiveWithAnyArgs()
+            .DispatchCallbackAsync(default!, default);
+    }
+
+    [Fact]
     public void ParseCallbackPayload_inner_json_array_throws_before_dispatch_mapping()
     {
         var payload = JsonSerializer.Serialize(new
@@ -287,6 +364,56 @@ public class DeviceEventEndpointsTests
             content = new { content_type = "text", text = innerEvent, attachments = Array.Empty<object>() },
             timestamp = "2026-04-09T10:00:00Z",
         });
+    }
+
+    private static HttpContext CreateJsonHttpContext(string body)
+    {
+        var builder = WebApplication.CreateBuilder();
+        var context = new DefaultHttpContext();
+        context.RequestServices = builder.Services.BuildServiceProvider();
+        context.Request.ContentType = "application/json";
+        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(body));
+        context.Response.Body = new MemoryStream();
+        return context;
+    }
+
+    private static async Task<IResult> InvokeHandleDeviceCallbackAsync(
+        HttpContext context,
+        string registrationId,
+        IDeviceRegistrationQueryPort queryPort,
+        IDeviceCallbackCommandService callbackCommandService)
+    {
+        var method = typeof(DeviceEventEndpoints)
+            .GetMethod("HandleDeviceCallbackAsync", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("HandleDeviceCallbackAsync was not found.");
+
+        var invocationResult = method.Invoke(null, new object[]
+        {
+            context,
+            registrationId,
+            queryPort,
+            callbackCommandService,
+            Options.Create(new DeviceEventOptions { SkipHmacVerification = true }),
+            LoggerFactory.Create(static _ => { }),
+            CancellationToken.None,
+        });
+
+        if (invocationResult is Task<IResult> resultTask)
+            return await resultTask;
+
+        throw new InvalidOperationException("HandleDeviceCallbackAsync did not return Task<IResult>.");
+    }
+
+    private static async Task<(int StatusCode, string Body)> ExecuteResultAsync(IResult result)
+    {
+        var builder = WebApplication.CreateBuilder();
+        var context = new DefaultHttpContext();
+        context.RequestServices = builder.Services.BuildServiceProvider();
+        context.Response.Body = new MemoryStream();
+        await result.ExecuteAsync(context);
+        context.Response.Body.Position = 0;
+        using var reader = new StreamReader(context.Response.Body, Encoding.UTF8);
+        return (context.Response.StatusCode, await reader.ReadToEndAsync());
     }
 
     private static (HttpContext context, byte[] bodyBytes) CreateContextWithSignature(


### PR DESCRIPTION
closes #1460

## 摘要

v1 device inbound contract 固化 — `#1393` Phase 9 共识 split first-slice。

## Old / New

- **Old**:`DeviceInbound` 在文档/测试上未明确"已知 typed + unknown reject"边界
- **New**:contract 注释 + 行为测试明确 v1 边界,unknown event_type adapter 边界 reject/no-dispatch

## 违反

CLAUDE.md「核心语义强类型」+「序列化」:typed payload 是边界事实源,unknown 应在 boundary 拒绝不混入。

## Scope

- `agents/Aevatar.GAgents.Household/household_messages.proto`(注释)
- `agents/Aevatar.GAgents.Device/DeviceCommandFacades.cs` / `DeviceEventEndpoints.cs`
- `test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceEventEndpointsTests.cs`

## Out-of-scope(留给 #1461)

accepted/queryable custom event registry / readmodel design。

⟦AI:AUTO-LOOP⟧
