### PR TITLE
feat(issue1463): lock non-blocking lifecycle + workflow topology(Phase 9 #1392 first-slice tests-only)

### DIFF
--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/RuntimePersistenceAndRoutingCoverageTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/RuntimePersistenceAndRoutingCoverageTests.cs
@@ -174,6 +174,9 @@ public sealed class RuntimePersistenceAndRoutingCoverageTests
             .Should().Be(typeof(CoverageTestAgent).AssemblyQualifiedName);
     }
 
+    // Refactor (v1/issue1463-first):
+    //   Old: non-blocking deactivation hook failure 无 regression test,行为可能被改成 blocking 而无人察觉
+    //   New: 锁定 hook 抛异常不阻塞 actor lifecycle 的当前行为
     [Fact]
     public async Task LocalActorRuntime_DestroyAsync_WhenDeactivationHookDispatchFails_ShouldStillRemoveActor()
     {

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/RuntimePersistenceAndRoutingCoverageTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/RuntimePersistenceAndRoutingCoverageTests.cs
@@ -1,6 +1,7 @@
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Abstractions.Streaming;
+using Aevatar.Foundation.Runtime.Actors;
 using Aevatar.Foundation.Runtime.Persistence;
 using Aevatar.Foundation.Runtime.Implementations.Local.Actors;
 using Aevatar.Foundation.Runtime.Observability;
@@ -173,6 +174,27 @@ public sealed class RuntimePersistenceAndRoutingCoverageTests
             .Should().Be(typeof(CoverageTestAgent).AssemblyQualifiedName);
     }
 
+    [Fact]
+    public async Task LocalActorRuntime_DestroyAsync_WhenDeactivationHookDispatchFails_ShouldStillRemoveActor()
+    {
+        var registry = new InMemoryStreamForwardingRegistry();
+        var streams = new InMemoryStreamProvider(new InMemoryStreamOptions(), NullLoggerFactory.Instance, registry);
+        var hookDispatcher = new FaultedDeactivationHookDispatcher();
+        var services = new ServiceCollection()
+            .AddSingleton<IActorDeactivationHookDispatcher>(hookDispatcher)
+            .BuildServiceProvider();
+        var runtime = new LocalActorRuntime(streams, services, streams);
+
+        await runtime.CreateAsync<CoverageTestAgent>("hook-failure-actor");
+
+        var act = async () => await runtime.DestroyAsync("hook-failure-actor");
+
+        await act.Should().NotThrowAsync();
+        hookDispatcher.ActorIds.Should().ContainSingle().Which.Should().Be("hook-failure-actor");
+        (await runtime.ExistsAsync("hook-failure-actor")).Should().BeFalse();
+        (await runtime.GetAsync("hook-failure-actor")).Should().BeNull();
+    }
+
     private sealed class TestState
     {
         public int Count { get; init; }
@@ -193,6 +215,17 @@ public sealed class RuntimePersistenceAndRoutingCoverageTests
         public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
 
         public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class FaultedDeactivationHookDispatcher : IActorDeactivationHookDispatcher
+    {
+        public ConcurrentQueue<string> ActorIds { get; } = new();
+
+        public Task DispatchAsync(string actorId, CancellationToken ct = default)
+        {
+            ActorIds.Enqueue(actorId);
+            return Task.FromException(new InvalidOperationException("hook-failed"));
+        }
     }
 }
 

--- a/test/Aevatar.Workflow.Core.Tests/Primitives/SubWorkflowOrchestratorBranchCoverageTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Primitives/SubWorkflowOrchestratorBranchCoverageTests.cs
@@ -179,6 +179,9 @@ public sealed class SubWorkflowOrchestratorBranchCoverageTests
         next.PendingChildRunIdsByParentRunId.Should().NotContainKey("parent-2");
     }
 
+    // Refactor (v1/issue1463-first):
+    //   Old: workflow run/session topology persistence 无 regression test,行为可能被改而无人察觉
+    //   New: 锁定 existing workflow topology persistence 行为不变
     [Fact]
     public void ApplySubWorkflowEvents_ShouldPersistExistingRunSessionTopologyInWorkflowRunState()
     {

--- a/test/Aevatar.Workflow.Core.Tests/Primitives/SubWorkflowOrchestratorBranchCoverageTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Primitives/SubWorkflowOrchestratorBranchCoverageTests.cs
@@ -178,4 +178,76 @@ public sealed class SubWorkflowOrchestratorBranchCoverageTests
         next.PendingChildRunIdsByParentRunId.Should().NotContainKey("parent-1");
         next.PendingChildRunIdsByParentRunId.Should().NotContainKey("parent-2");
     }
+
+    [Fact]
+    public void ApplySubWorkflowEvents_ShouldPersistExistingRunSessionTopologyInWorkflowRunState()
+    {
+        var state = new WorkflowRunState
+        {
+            RunId = "parent-run",
+            WorkflowName = "parent-workflow"
+        };
+
+        state = SubWorkflowOrchestrator.ApplySubWorkflowBindingUpserted(
+            state,
+            new SubWorkflowBindingUpsertedEvent
+            {
+                WorkflowName = " child-workflow ",
+                ChildActorId = " child-actor-1 ",
+                Lifecycle = "scope",
+                DefinitionActorId = " definition-1 ",
+                DefinitionVersion = 4
+            });
+
+        state = SubWorkflowOrchestrator.ApplySubWorkflowInvocationRegistered(
+            state,
+            new SubWorkflowInvocationRegisteredEvent
+            {
+                InvocationId = " invocation-1 ",
+                ParentRunId = " parent-run ",
+                ParentStepId = " step-call-child ",
+                WorkflowName = " child-workflow ",
+                ChildActorId = " child-actor-1 ",
+                ChildRunId = " child-run-1 ",
+                Lifecycle = "scope",
+                DefinitionActorId = " definition-1 ",
+                DefinitionVersion = 4,
+                HandoffPhase = (int)SubWorkflowInvocationHandoffPhase.Linked,
+                Input = "input-1",
+                DefinitionYaml = "name: child-workflow",
+                ScopeId = "scope-1",
+                InlineWorkflowYamls =
+                {
+                    ["grandchild"] = "name: grandchild"
+                }
+            });
+
+        state.SubWorkflowBindings.Should().ContainSingle();
+        state.SubWorkflowBindings[0].WorkflowName.Should().Be("child-workflow");
+        state.SubWorkflowBindings[0].ChildActorId.Should().Be("child-actor-1");
+        state.SubWorkflowBindings[0].Lifecycle.Should().Be("scope");
+        state.SubWorkflowBindings[0].DefinitionActorId.Should().Be("definition-1");
+        state.SubWorkflowBindings[0].DefinitionVersion.Should().Be(4);
+
+        state.PendingSubWorkflowInvocations.Should().ContainSingle();
+        var pending = state.PendingSubWorkflowInvocations[0];
+        pending.InvocationId.Should().Be("invocation-1");
+        pending.ParentRunId.Should().Be("parent-run");
+        pending.ParentStepId.Should().Be("step-call-child");
+        pending.WorkflowName.Should().Be("child-workflow");
+        pending.ChildActorId.Should().Be("child-actor-1");
+        pending.ChildRunId.Should().Be("child-run-1");
+        pending.Lifecycle.Should().Be("scope");
+        pending.DefinitionActorId.Should().Be("definition-1");
+        pending.DefinitionVersion.Should().Be(4);
+        pending.HandoffPhase.Should().Be(SubWorkflowInvocationHandoffPhase.Linked);
+        pending.Input.Should().Be("input-1");
+        pending.DefinitionYaml.Should().Be("name: child-workflow");
+        pending.ScopeId.Should().Be("scope-1");
+        pending.InlineWorkflowYamls.Should().Contain("grandchild", "name: grandchild");
+
+        state.PendingSubWorkflowInvocationIndexByChildRunId.Should().Contain("child-run-1", 0);
+        state.PendingChildRunIdsByParentRunId.Should().ContainKey("parent-run");
+        state.PendingChildRunIdsByParentRunId["parent-run"].ChildRunIds.Should().ContainSingle().Which.Should().Be("child-run-1");
+    }
 }


### PR DESCRIPTION
closes #1463

## 摘要

lock 当前 non-blocking lifecycle + 现有 workflow topology — `#1392` Phase 9 共识 split first-slice(tests-only)。

## 改动

仅补测试,不动 production:
- `RuntimePersistenceAndRoutingCoverageTests`:断言 non-blocking deactivation hook failure 不阻塞 actor lifecycle
- `SubWorkflowOrchestratorBranchCoverageTests`:断言 existing workflow run/session topology persistence 行为不变

## Out-of-scope(留给 #1464)

typed `DeactivationFailureContract` / `IWorkflowTopologyPort` abstraction / `docs/canon` 词汇变更。

⟦AI:AUTO-LOOP⟧
