### PR TITLE
feat(issue1466): reserve ChannelInboundEvent.registration_token + scrub guard(Phase 9 #1390 first-slice)

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/channel_bot_registration.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/channel_bot_registration.proto
@@ -114,6 +114,13 @@ message ChannelBotRegistrationDocument {
 // Normalized inbound callback payload used by relay-aware channel flows
 // (for example deterministic builder/tool routing in ChannelConversationTurnRunner).
 message ChannelInboundEvent {
+  // Refactor (v1/issue1466-first):
+  //   Old: registration_token made a runtime credential look like a durable inbound fact.
+  //   New: field 9 stays reserved; credentials remain transient runtime context only.
+  //   Principle: channel inbound durable facts are credential-free.
+  reserved 9;
+  reserved "registration_token";
+
   string text = 1;
   string sender_id = 2;
   string sender_name = 3;
@@ -122,7 +129,6 @@ message ChannelInboundEvent {
   string chat_type = 6;
   string platform = 7;
   string registration_id = 8;
-  string registration_token = 9;      // inbound-scoped token propagated to the LLM provider
   string registration_scope_id = 10;
   string nyx_provider_slug = 11;
   map<string, string> extra = 12;

--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -147,7 +147,7 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         if (await TryHandleLlmSelectionCardActionAsync(activity, inbound, registration, runtimeContext, senderBinding?.BindingId, ct).ConfigureAwait(false) is { } llmSelectionResult)
             return llmSelectionResult;
 
-        var inboundEvent = ToInboundEvent(activity, registration, inbound, ResolveUserAccessToken(activity, runtimeContext));
+        var inboundEvent = ToInboundEvent(activity, registration, inbound);
 
         if (await TryHandleAgentBuilderAsync(activity, inboundEvent, registration, runtimeContext, typingReactionTask, ct) is { } agentBuilderResult)
             return agentBuilderResult;
@@ -1479,9 +1479,12 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
     private static ChannelInboundEvent ToInboundEvent(
         ChatActivity activity,
         ChannelBotRegistrationEntry registration,
-        InboundMessage inbound,
-        string? userAccessToken)
+        InboundMessage inbound)
     {
+        // Refactor (v1/issue1466-first):
+        //   Old: ChannelInboundEvent copied userAccessToken into registration_token.
+        //   New: inbound durable facts carry only stable routing facts.
+        //   Principle: runtime credentials flow through transient context, not proto facts.
         var inboundEvent = new ChannelInboundEvent
         {
             Text = inbound.Text,
@@ -1492,7 +1495,6 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
             ChatType = inbound.ChatType ?? string.Empty,
             Platform = inbound.Platform,
             RegistrationId = registration.Id,
-            RegistrationToken = userAccessToken ?? string.Empty,
             RegistrationScopeId = registration.ScopeId,
             NyxProviderSlug = registration.NyxProviderSlug,
         };

--- a/docs/canon/daily-command-pipeline.md
+++ b/docs/canon/daily-command-pipeline.md
@@ -282,7 +282,7 @@ catch (Exception ex) {
 文件：`agents/Aevatar.GAgents.Channel.Runtime/protos/channel_bot_registration.proto`、`agents/Aevatar.GAgents.Scheduled/protos/skill_runner.proto`、`agents/Aevatar.GAgents.Scheduled/protos/user_agent_catalog.proto`
 
 ### `ChannelInboundEvent`（入站规范化消息）
-- `text`、`sender_id`、`sender_name`、`conversation_id`、`chat_type`、`platform`、`registration_token`、`nyx_provider_slug`、`registration_scope_id`
+- `text`、`sender_id`、`sender_name`、`conversation_id`、`chat_type`、`platform`、`nyx_provider_slug`、`registration_scope_id`
 - **重点**：`sender_id` 实质是 Lark `open_id`（`ou_*`），**只在单个 Lark App 内唯一**——同一个真人在不同 Lark app 下会有不同 `open_id`，跨 app 不能直接拿来对账（这是 PR #409 引入 `union_id`/`on_*` 入站和 `chat_id`-first delivery fallback 的原因，详见 [LarkConversationTargets.cs](../../agents/platforms/Aevatar.GAgents.Platform.Lark/LarkConversationTargets.cs)）。`registration_scope_id` 是 bot 维度。下面 issue #436/#437 的 cross-user leak bug 就源自只用 `registration_scope_id` 当 user-config key，丢了 `sender_id`。
 
 ### `SkillRunnerOutboundConfig`

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelBotRegistrationProtoCompatibilityTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelBotRegistrationProtoCompatibilityTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Google.Protobuf;
 using Xunit;
 using Aevatar.GAgents.Channel.Runtime;
 
@@ -53,5 +54,46 @@ public sealed class ChannelBotRegistrationProtoCompatibilityTests
         ChannelBotRegistrationDocument.Descriptor.FindFieldByName("nyx_agent_api_key_id")!.FieldNumber.Should().Be(11);
         ChannelBotRegistrationDocument.Descriptor.FindFieldByName("nyx_conversation_route_id")!.FieldNumber.Should().Be(12);
         ChannelBotRegistrationDocument.Descriptor.FindFieldByName("credential_ref").Should().BeNull();
+    }
+
+    [Fact]
+    public void ChannelInboundEvent_ShouldReserveRuntimeCredentialCarrier()
+    {
+        // Refactor (v1/issue1466-first):
+        //   Old: registration_token was a typed durable field on ChannelInboundEvent.
+        //   New: field 9 and registration_token are unavailable on the descriptor.
+        //   Principle: inbound protobuf facts must not carry runtime credentials.
+        ChannelInboundEvent.Descriptor.FindFieldByName("registration_token").Should().BeNull();
+        ChannelInboundEvent.Descriptor.Fields.InFieldNumberOrder()
+            .Should().NotContain(field => field.FieldNumber == 9);
+    }
+
+    [Fact]
+    public void ChannelInboundEvent_ShouldSerializeCredentialFreeDurableFacts()
+    {
+        // Refactor (v1/issue1466-first):
+        //   Old: durable inbound payloads could persist bearer-like registration_token bytes.
+        //   New: a complete inbound event serializes only stable channel/routing facts.
+        //   Principle: runtime tokens stay outside the durable channel inbound fact model.
+        var inboundEvent = new ChannelInboundEvent
+        {
+            Text = "hello",
+            SenderId = "ou_user_1",
+            SenderName = "User One",
+            ConversationId = "oc_group_chat_1",
+            MessageId = "msg-1",
+            ChatType = "group",
+            Platform = "lark",
+            RegistrationId = "reg-1",
+            RegistrationScopeId = "scope-1",
+            NyxProviderSlug = "provider-1",
+        };
+        inboundEvent.Extra["event_id"] = "evt-1";
+
+        var serialized = inboundEvent.ToByteArray();
+
+        serialized.Should().NotContain((byte)0x4a);
+        ChannelInboundEvent.Parser.ParseFrom(serialized).Should().BeEquivalentTo(inboundEvent);
+        ChannelInboundEvent.Descriptor.FindFieldByName("registration_token").Should().BeNull();
     }
 }

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -78,6 +78,49 @@ check_directory_build_version_guard() {
 
 check_directory_build_version_guard
 
+# Refactor (v1/issue1466-first):
+#   Old: ChannelInboundEvent.registration_token looked like a durable runtime credential carrier.
+#   New: proto field 9/name are reserved and mappers/docs stay credential-free.
+#   Principle: channel inbound durable facts must not contain runtime tokens.
+check_channel_inbound_no_runtime_credential() {
+  local proto_file="agents/Aevatar.GAgents.Channel.Runtime/protos/channel_bot_registration.proto"
+  local runner_file="agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs"
+  local canon_doc="docs/canon/daily-command-pipeline.md"
+
+  if ! awk '
+    /message ChannelInboundEvent[[:space:]]*\{/ { in_msg = 1 }
+    in_msg && /reserved[[:space:]]+9[[:space:]]*;/ { has_reserved_number = 1 }
+    in_msg && /reserved[[:space:]]+"registration_token"[[:space:]]*;/ { has_reserved_name = 1 }
+    in_msg && /^[[:space:]]*\}/ { in_msg = 0 }
+    END { exit(has_reserved_number && has_reserved_name ? 0 : 1) }
+  ' "${proto_file}"; then
+    echo "ChannelInboundEvent must reserve field 9 and name registration_token."
+    exit 1
+  fi
+
+  if awk '
+    /message ChannelInboundEvent[[:space:]]*\{/ { in_msg = 1; next }
+    in_msg && /^[[:space:]]*\}/ { in_msg = 0 }
+    in_msg && /^[[:space:]]*string[[:space:]]+registration_token[[:space:]]*=/ { print FILENAME ":" FNR ":" $0; found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "${proto_file}"; then
+    echo "ChannelInboundEvent.registration_token is forbidden; keep runtime credentials out of durable inbound facts."
+    exit 1
+  fi
+
+  if rg -n "RegistrationToken[[:space:]]*=" "${runner_file}"; then
+    echo "ToInboundEvent must not write RegistrationToken. Runtime tokens belong in transient context only."
+    exit 1
+  fi
+
+  if rg -n "registration_token" "${canon_doc}"; then
+    echo "Canonical channel inbound durable facts docs must not list registration_token."
+    exit 1
+  fi
+}
+
+check_channel_inbound_no_runtime_credential
+
 bash tools/ci/aevatar_oauth_client_es_acl_guard.sh
 bash tools/ci/static_service_activation_guard.sh || exit $?
 


### PR DESCRIPTION
## 摘要

iter v1 / Phase 9 #1390 first-slice(no-new-core)。

- **Old**:`ChannelInboundEvent.registration_token` 是 typed field 9,Channel inbound 事件链路把运行时注册凭证写入 durable facts payload。
- **New**:`registration_token` 降级为 `reserved 9`,ToInboundEvent / mapper 停止写凭证。加 channel inbound credential-scrub 测试 + `check_channel_inbound_no_runtime_credential` 窄 guard。

违反 CLAUDE.md「事实源唯一」与「权威状态 / ReadModel / Projection」边界——committed event payload 不应携带运行时短期凭证。

## 范围

5 个 file:proto field reserve + mapper stop write + 2 个新测试 + architecture_guards 加 narrow check。

Closes #1466

⟦AI:AUTO-LOOP⟧
