### PR TITLE
refactor(issue1470): 删除 InvokeTeam wait=complete frame folding(Phase 9 #1389 first-slice)

### DIFF
--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -182,9 +182,9 @@ public sealed class AevatarInvocationDispatcher
                 request.TeamId.Trim(),
                 ct);
             var invocation = BuildStaticInvocationRequest(resolution, request);
-            return wait == InvocationWaitMode.Complete
-                ? await InvokeTeamToCompletionAsync(chatRunRequest, invocation, resolution, request.EndpointId, wait, ct)
-                : await InvokeTeamToAcceptanceAsync(chatRunRequest, invocation, resolution, request.EndpointId, wait, ct);
+            // Refactor (v1/issue1470-first): InvokeTeam wait=complete must return the dispatch receipt only;
+            // terminal completion is observed through the service-run readmodel instead of folding live AGUI frames.
+            return await InvokeTeamToAcceptanceAsync(chatRunRequest, invocation, resolution, request.EndpointId, wait, ct);
         }
         catch (TeamEntryMemberResolutionException ex)
         {
@@ -421,44 +421,6 @@ public sealed class AevatarInvocationDispatcher
             wait), resolution.ScopeId);
     }
 
-    private async Task<ChatRunToolCompletionRequest> InvokeTeamToCompletionAsync(
-        ChatRunToolCompletionRequest? chatRunRequest,
-        StaticGAgentStreamInvocationRequest invocation,
-        TeamEntryMemberResolution resolution,
-        string endpointId,
-        InvocationWaitMode wait,
-        CancellationToken ct)
-    {
-        var frames = new List<AGUIEvent>();
-        var result = await _teamInvocationPort.InvokeAsync(
-            invocation,
-            (frame, _) =>
-            {
-                frames.Add(frame.Clone());
-                return ValueTask.CompletedTask;
-            },
-            null,
-            ct);
-
-        if (!result.Succeeded || result.Accepted == null)
-        {
-            var startError = Error(
-                result.StartError.ToString(),
-                $"Team invocation was not accepted: {result.StartError}");
-            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(startError), startError);
-        }
-
-        var accepted = BuildTeamAcceptedResult(resolution, endpointId, result.Accepted, wait);
-        accepted.Status = result.CompletionObserved ? result.CompletionStatus.ToString() : "accepted";
-        accepted.ResultJson = AevatarInvocationJson.ToJson(new
-        {
-            completion_status = result.CompletionStatus.ToString(),
-            completion_observed = result.CompletionObserved,
-            events = frames.Select(static frame => AevatarInvocationToolSchemas.ParseObject(ProtoJsonFormatter.Format(frame))).ToArray(),
-        });
-        return ToChatRunRequest(chatRunRequest, accepted, resolution.ScopeId);
-    }
-
     private InvocationToolResult BuildTeamAcceptedResult(
         TeamEntryMemberResolution resolution,
         string endpointId,
@@ -469,7 +431,7 @@ public sealed class AevatarInvocationDispatcher
         return new InvocationToolResult
         {
             RunId = runId,
-            Status = wait == InvocationWaitMode.Ack ? "accepted" : "streaming",
+            Status = wait == InvocationWaitMode.Stream ? "streaming" : "accepted",
             StreamTopic = wait == InvocationWaitMode.Stream
                 ? AevatarInvocationStreamTopics.ForServiceRun(resolution.ScopeId, resolution.PublishedServiceId, runId)
                 : string.Empty,

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSchemas.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSchemas.cs
@@ -1,5 +1,3 @@
-using System.Text.Json;
-
 namespace Aevatar.AI.ToolProviders.AevatarInvocation;
 
 internal static class AevatarInvocationToolSchemas
@@ -66,10 +64,4 @@ internal static class AevatarInvocationToolSchemas
         stringEnums: ReadModelValues);
 
     public static IReadOnlyList<string> ReadModelNames => ReadModelValues["readmodel_name"];
-
-    public static JsonElement ParseObject(string json)
-    {
-        using var doc = JsonDocument.Parse(json);
-        return doc.RootElement.Clone();
-    }
 }

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ChatRunToolCompletionCoordinator.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ChatRunToolCompletionCoordinator.cs
@@ -116,7 +116,7 @@ public sealed class ChatRunToolCompletionCoordinator
         if (!isGAgentInvocation || !hasInlineGAgentActorId)
             await _chatRunActorPort.BeginSubRunObservationAsync(actorId, completionRequest, ct);
 
-        var terminal = TryBuildTerminalFromDispatchResult(completionRequest) ??
+        var terminal = TryBuildTerminalFromDispatchResult(toolCall.Name, completionRequest) ??
                        await ResolveTerminalAsync(toolCall.Name, completionRequest, ct);
 
         terminal ??= BuildTerminal(
@@ -220,8 +220,15 @@ public sealed class ChatRunToolCompletionCoordinator
         return null;
     }
 
-    private static ChatRunSubRunTerminalObserved? TryBuildTerminalFromDispatchResult(ChatRunToolCompletionRequest dispatch)
+    private static ChatRunSubRunTerminalObserved? TryBuildTerminalFromDispatchResult(
+        string toolName,
+        ChatRunToolCompletionRequest dispatch)
     {
+        // Refactor (v1/issue1470-first): InvokeTeam wait=complete completion must come from the service-run
+        // readmodel, not from dispatcher-owned live AGUI frame folding.
+        if (string.Equals(toolName, "aevatar_invoke_team", StringComparison.Ordinal))
+            return null;
+
         if (string.IsNullOrWhiteSpace(dispatch.RunId) ||
             string.IsNullOrWhiteSpace(dispatch.CompletionResultJson) ||
             !IsTerminalDispatchStatus(dispatch.Status) ||

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -317,7 +317,7 @@ public sealed class AevatarInvocationToolSourceTests
     }
 
     [Fact]
-    public async Task InvokeTeamForChatRun_ShouldMapTypedCompletionControlFields()
+    public async Task InvokeTeamForChatRun_WaitComplete_ShouldReturnAcceptedReceiptWithoutFoldedCompletion()
     {
         var harness = new Harness();
         var dispatcher = harness.CreateDispatcher();
@@ -344,13 +344,20 @@ public sealed class AevatarInvocationToolSourceTests
         result.RunId.Should().Be("team-command");
         result.ScopeId.Should().Be("scope-1");
         result.WaitMode.Should().Be(ChatRunSubRunWaitMode.Complete);
-        result.Status.Should().Be(GAgentDraftRunCompletionStatus.RunFinished.ToString());
+        result.Status.Should().Be("accepted");
+        result.StreamTopic.Should().BeEmpty();
         result.ActorId.Should().Be("team-actor");
         result.ServiceId.Should().Be("service-1");
         result.EndpointId.Should().Be("entry");
-        result.CompletionObserved.Should().BeTrue();
-        result.CompletionResultJson.Should().Contain("\"completion_observed\":true");
+        result.CompletionObserved.Should().BeFalse();
+        result.CompletionResultJson.Should().BeEmpty();
         result.ErrorCode.Should().BeEmpty();
+
+        using var output = JsonDocument.Parse(result.ToolExecutionResultJson);
+        output.RootElement.GetProperty("status").GetString().Should().Be("accepted");
+        output.RootElement.GetProperty("wait").GetString().Should().Be("complete");
+        output.RootElement.TryGetProperty("result", out var foldedResult).Should().BeFalse();
+        foldedResult.ValueKind.Should().Be(JsonValueKind.Undefined);
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Application/ChatRunToolCompletionCoordinatorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ChatRunToolCompletionCoordinatorTests.cs
@@ -14,7 +14,7 @@ namespace Aevatar.GAgentService.Tests.Application;
 public sealed class ChatRunToolCompletionCoordinatorTests
 {
     [Fact]
-    public async Task ExecuteAsync_WaitCompleteTeam_ShouldFoldToolResultReturnedByDispatcher()
+    public async Task ExecuteAsync_WaitCompleteTeam_ShouldIgnoreFoldedDispatchResultAndUseReadModelObservation()
     {
         var harness = new Harness();
         var coordinator = harness.CreateCoordinator();
@@ -48,16 +48,17 @@ public sealed class ChatRunToolCompletionCoordinatorTests
             }),
             llmRound: 1);
 
-        using var resultDocument = System.Text.Json.JsonDocument.Parse(result);
-        resultDocument.RootElement.GetProperty("completion_observed").GetBoolean().Should().BeTrue();
-        resultDocument.RootElement.GetProperty("completion_status").GetString().Should().Be("RunFinished");
-        result.Should().NotContain("completion_not_observed");
+        result.Should().Contain("completion_not_observed");
+        result.Should().Contain("\"run_id\":\"team-command\"");
+        result.Should().Contain("\"service_id\":\"service-1\"");
+        result.Should().NotContain("\"completion_observed\": true");
         harness.ChatRunPort.ObservedTerminals.Should().ContainSingle().Which.Should().Match<ChatRunSubRunTerminalObserved>(
             terminal => terminal.RunId == "team-command" &&
-                        terminal.Status == "RunFinished" &&
+                        terminal.Status == "completion_not_observed" &&
                         terminal.ServiceId == "service-1" &&
                         terminal.EndpointId == "entry" &&
-                        terminal.InternalResultJson.Contains("\"completion_observed\": true", StringComparison.Ordinal));
+                        !terminal.CompletionObserved &&
+                        terminal.InternalResultJson.Contains("completion_not_observed", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesCompletionApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesCompletionApplicationServiceTests.cs
@@ -30,7 +30,8 @@ public sealed class ResponsesCompletionApplicationServiceTests
             BuildClassification(tool));
 
         result.Text.Should().Be("typed completion consumed");
-        provider.SecondRoundToolResult.Should().Contain("\"typed\":true");
+        provider.SecondRoundToolResult.Should().Contain("\"status\":2");
+        provider.SecondRoundToolResult.Should().Contain("\"service_id\":\"service-1\"");
         tool.TypedExecuteCount.Should().Be(1);
         tool.LegacyExecuteCount.Should().Be(0);
         harness.ChatRunPort.SubmittedToolCalls.Should().ContainSingle().Which.ToolExecutionResultJson
@@ -59,7 +60,8 @@ public sealed class ResponsesCompletionApplicationServiceTests
 
         result.Text.Should().Be("typed completion consumed");
         textDeltas.Should().Equal("typed completion consumed");
-        provider.SecondRoundToolResult.Should().Contain("\"typed\":true");
+        provider.SecondRoundToolResult.Should().Contain("\"status\":2");
+        provider.SecondRoundToolResult.Should().Contain("\"service_id\":\"service-1\"");
         tool.TypedExecuteCount.Should().Be(1);
         tool.LegacyExecuteCount.Should().Be(0);
         harness.ChatRunPort.SubmittedToolCalls.Should().ContainSingle().Which.ToolExecutionResultJson
@@ -153,13 +155,12 @@ public sealed class ResponsesCompletionApplicationServiceTests
             {
                 ToolExecutionResultJson = """{"dispatch":"typed"}""",
                 RunId = "team-command",
-                Status = "RunFinished",
-                CompletionResultJson = """{"typed":true,"status":"RunFinished"}""",
+                Status = "accepted",
                 ServiceId = "service-1",
                 EndpointId = "entry",
                 ScopeId = "scope-1",
                 WaitMode = ChatRunSubRunWaitMode.Complete,
-                CompletionObserved = true,
+                CompletionObserved = false,
             });
         }
     }
@@ -177,7 +178,7 @@ public sealed class ResponsesCompletionApplicationServiceTests
             new(
                 ChatRunPort,
                 new EmptyTerminalQueryPort(),
-                new EmptyServiceRunQueryPort(),
+                new StaticServiceRunQueryPort(),
                 new EmptyWorkflowQueryService());
     }
 
@@ -221,7 +222,7 @@ public sealed class ResponsesCompletionApplicationServiceTests
             Task.CompletedTask;
     }
 
-    private sealed class EmptyServiceRunQueryPort : IServiceRunQueryPort
+    private sealed class StaticServiceRunQueryPort : IServiceRunQueryPort
     {
         public Task<IReadOnlyList<ServiceRunSnapshot>> ListAsync(
             ServiceRunQuery query,
@@ -232,8 +233,33 @@ public sealed class ResponsesCompletionApplicationServiceTests
             string scopeId,
             string serviceId,
             string runId,
-            CancellationToken ct = default) =>
-            Task.FromResult<ServiceRunSnapshot?>(null);
+            CancellationToken ct = default)
+        {
+            ServiceRunSnapshot? snapshot = scopeId == "scope-1" && serviceId == "service-1" && runId == "team-command"
+                ? new ServiceRunSnapshot(
+                    "scope-1",
+                    "service-1",
+                    "service-key",
+                    "team-command",
+                    "team-command",
+                    "team-correlation",
+                    "entry",
+                    ServiceImplementationKind.Static,
+                    "target-actor",
+                    "revision-1",
+                    "deployment-1",
+                    ServiceRunStatus.Completed,
+                    "actor-1",
+                    "tenant-1",
+                    "app-1",
+                    "namespace-1",
+                    7,
+                    "event-7",
+                    DateTimeOffset.Parse("2026-05-23T00:00:00+00:00"),
+                    DateTimeOffset.Parse("2026-05-23T00:01:00+00:00"))
+                : null;
+            return Task.FromResult(snapshot);
+        }
 
         public Task<ServiceRunSnapshot?> GetByCommandIdAsync(
             string scopeId,


### PR DESCRIPTION
## 摘要

Phase 9 #1389 first-slice(no-new-core)。

- **Old**:InvokeTeam `wait=complete` 走 synchronous frame folding,把流式帧 fold 后 RPC 风格回包。
- **New**:删除 frame folding,caller 用 accepted receipt + 异步观察 readmodel `completion_not_observed`。

违反 CLAUDE.md「禁止 stream request-reply 冒充 RPC」与「Stream 用于事件分发与观察」。

## 范围

`src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs` 删 wait=complete 分支。

Closes #1470

⟦AI:AUTO-LOOP⟧
