### PR TITLE
feat(issue1468): v1 non-goal + query/read bootstrap guard(Phase 9 #1391 first-slice)

### DIFF
--- a/docs/canon/cqrs-projection.md
+++ b/docs/canon/cqrs-projection.md
@@ -117,6 +117,8 @@ CQRS 不应只提供零散 helper，而应定义所有 capability 复用的标�
 
 Projection-driven bootstrap 只服务 actor 事实拥有者变化的演进：split、merge、re-key、replace。它不是查询优化，也不是 lazy state migration 的替代品。完整 actor 演进判定树见 [actor-evolution.md](actor-evolution.md)。
 
+v1 non-goal：复杂 owner-change bootstrap（split / merge / re-key / replace 的生产级编排、批量迁移、回滚与清理策略）不在 v1 范围内，延后到 v2 设计。v1 只锁定边界：查询与 read adapter 不允许通过 query-time replay、临时 state rebuild、projection materialization 或 projection priming 来补齐这类 owner-change 场景。
+
 口径：
 
 1. Split：旧 actor 的 committed fact 通过 projection materialize 出 bootstrap 输入；新 actor 必须提交自己的 domain event 后才成为新事实拥有者。

--- a/test/Aevatar.Architecture.Tests/Rules/ForbiddenPatternTests.cs
+++ b/test/Aevatar.Architecture.Tests/Rules/ForbiddenPatternTests.cs
@@ -9,6 +9,21 @@ public class ForbiddenPatternTests
     private static readonly ArchitectureModel Arch = ArchitectureTestBase.ProductionArchitecture;
 
     [Fact]
+    public void QueryReadFiles_ShouldNot_Trigger_EventReplay_StateRebuild_OrProjectionMaterialization()
+    {
+        // Refactor (v1/issue1468-first):
+        // Query/read bootstrap is intentionally out of v1. Query ports and query services
+        // must read already materialized read models, not replay facts or prime projection work.
+        var forbiddenCalls = new[] { "ReadEventsAsync", "GetEventsAsync", "RebuildAsync", "MaterializeAsync" };
+        var violations = EnumerateProductionSourceFiles()
+            .Where(IsQueryReadFile)
+            .SelectMany(file => FindForbiddenQueryReplayCalls(file, forbiddenCalls))
+            .ToArray();
+
+        Assert.Empty(violations);
+    }
+
+    [Fact]
     public void MiddleLayer_ShouldNot_Declare_IdMappingDictionaries()
     {
         // Application/Projection middle layers must not maintain entity/actor/run/session ID
@@ -241,5 +256,77 @@ public class ForbiddenPatternTests
             .Because("runtime script provisioning must not query/poll definition snapshot read models")
             .WithoutRequiringPositiveResults();
         rule.Check(Arch);
+    }
+
+    private static IEnumerable<string> EnumerateProductionSourceFiles()
+    {
+        var roots = new[] { Path.Combine(FindRepoRoot(), "src"), Path.Combine(FindRepoRoot(), "agents") };
+
+        foreach (var root in roots)
+        {
+            if (!Directory.Exists(root))
+            {
+                continue;
+            }
+
+            foreach (var file in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+            {
+                var normalized = file.Replace('\\', '/');
+                if (normalized.Contains("/bin/", StringComparison.Ordinal)
+                    || normalized.Contains("/obj/", StringComparison.Ordinal)
+                    || normalized.EndsWith(".g.cs", StringComparison.Ordinal)
+                    || normalized.EndsWith(".designer.cs", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                yield return file;
+            }
+        }
+    }
+
+    private static bool IsQueryReadFile(string file)
+    {
+        var name = Path.GetFileName(file);
+        return name.EndsWith("QueryPort.cs", StringComparison.Ordinal)
+            || name.EndsWith("QueryService.cs", StringComparison.Ordinal)
+            || name.EndsWith("ApplicationService.cs", StringComparison.Ordinal);
+    }
+
+    private static IEnumerable<string> FindForbiddenQueryReplayCalls(string file, IReadOnlyCollection<string> forbiddenCalls)
+    {
+        var lines = File.ReadAllLines(file);
+        for (var index = 0; index < lines.Length; index++)
+        {
+            var line = lines[index];
+            if (line.TrimStart().StartsWith("//", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            foreach (var forbiddenCall in forbiddenCalls)
+            {
+                if (line.Contains(forbiddenCall + "(", StringComparison.Ordinal))
+                {
+                    yield return $"{file.Replace('\\', '/')}:{index + 1}: forbidden query-time call `{forbiddenCall}`";
+                }
+            }
+        }
+    }
+
+    private static string FindRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "aevatar.slnx")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root from test output directory.");
     }
 }

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -162,6 +162,63 @@ if rg -n "GetAwaiter\(\)\.GetResult\(\)" src; then
   exit 1
 fi
 
+# Refactor (v1/issue1468-first):
+#   Old pattern: query/read files could grow hidden event replay, state rebuild, or
+#   projection materialization calls in request paths.
+#   New principle: QueryPort/QueryService/ApplicationService files only read
+#   materialized read models; owner-change bootstrap is a v1 non-goal.
+check_no_query_time_replay() {
+  local query_read_files=()
+  while IFS= read -r -d '' query_read_file; do
+    query_read_files+=("${query_read_file}")
+  done < <(
+    find src agents \
+      -type f \
+      \( -name '*QueryPort.cs' -o -name '*QueryService.cs' -o -name '*ApplicationService.cs' \) \
+      -not -path '*/bin/*' \
+      -not -path '*/obj/*' \
+      -not -name '*.g.cs' \
+      -not -name '*.Designer.cs' \
+      -print0
+  )
+
+  if (( ${#query_read_files[@]} == 0 )); then
+    return
+  fi
+
+  set +e
+  local query_time_replay_report
+  query_time_replay_report="$(
+    rg -n "\b(ReadEventsAsync|GetEventsAsync|RebuildAsync|MaterializeAsync)\b" "${query_read_files[@]}" \
+      | awk -F: '
+{
+  file = $1;
+  line_no = $2;
+  text = substr($0, length(file) + length(line_no) + 3);
+
+  if (text ~ /^[[:space:]]*\/\/\/?/)
+    next;
+
+  print $0;
+}'
+  )"
+  local query_time_replay_status=$?
+  set -e
+
+  if [[ ${query_time_replay_status} -ne 0 && ${query_time_replay_status} -ne 1 ]]; then
+    echo "Query-time replay guard execution failed."
+    exit "${query_time_replay_status}"
+  fi
+
+  if [ -n "${query_time_replay_report}" ]; then
+    echo "${query_time_replay_report}"
+    echo "Query/read paths must not replay events, rebuild state, or materialize projections in request paths. Use committed projection/readmodel materialization outside the query call stack."
+    exit 1
+  fi
+}
+
+check_no_query_time_replay
+
 # Refactor (iter56/cluster-920-workflow-catalog-async-query):
 #   Old pattern: production workflow query ports could hide async readmodel I/O behind sync .Result/.Wait calls.
 #   New principle: catalog/capabilities query seams are async end-to-end, and query ports await readmodel readers.


### PR DESCRIPTION
## 摘要

Phase 9 #1391 first-slice(no-new-core)。

- **Old**:v1 release scope 未明确锁定 query/read 路径不可 query-time replay / projection priming;复杂 owner-change bootstrap 是否 v1 也未决。
- **New**:`docs/canon/cqrs-projection.md` 明确 v1 non-goal:复杂 owner-change bootstrap 延后 v2;`ForbiddenPatternTests` 锁 query path 禁 event replay / state rebuild;`architecture_guards.sh` 加 `check_no_query_time_replay` 窄 guard。

违反 CLAUDE.md「禁止 query-time replay/priming」。

## 范围

3 个 file:docs canon 更新 + 1 forbidden pattern test + architecture guard 窄 check。

Closes #1468

⟦AI:AUTO-LOOP⟧
