### PR TITLE
#674: typed ChatRouteVoiceAttachTarget(删 voice Struct contract)

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatServiceDefaults.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatServiceDefaults.cs
@@ -1,5 +1,8 @@
 namespace Aevatar.GAgents.NyxidChat;
 
+using System.Security.Cryptography;
+using System.Text;
+
 public static class NyxIdChatServiceDefaults
 {
     public const string ServiceId = "nyxid-chat";
@@ -12,4 +15,13 @@ public static class NyxIdChatServiceDefaults
 
     public static string GenerateActorId() =>
         $"{ActorIdPrefix}-{Guid.NewGuid():N}";
+
+    public static string BuildVoiceDemoActorId(string scopeId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(scopeId);
+
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(scopeId.Trim()));
+        var hash = Convert.ToHexString(bytes)[..16].ToLowerInvariant();
+        return $"{ActorIdPrefix}-voice-demo-{hash}";
+    }
 }

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatServiceDefaults.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatServiceDefaults.cs
@@ -16,6 +16,10 @@ public static class NyxIdChatServiceDefaults
     public static string GenerateActorId() =>
         $"{ActorIdPrefix}-{Guid.NewGuid():N}";
 
+    // Refactor (iter367/cluster-issue674): Old pattern: voice demo actor ids were
+    // derived ad hoc by bootstrap callers. New principle: the NyxID chat boundary
+    // owns deterministic voice demo actor identity, while typed ChatRouteVoiceAttachTarget
+    // carries that actor id to voice routing.
     public static string BuildVoiceDemoActorId(string scopeId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(scopeId);

--- a/agents/Aevatar.GAgents.NyxidChat/VoiceDemoAgentCommandPort.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/VoiceDemoAgentCommandPort.cs
@@ -1,5 +1,3 @@
-using System.Security.Cryptography;
-using System.Text;
 using Aevatar.AI.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Google.Protobuf;
@@ -39,7 +37,7 @@ internal sealed class VoiceDemoAgentCommandPort : IVoiceDemoAgentCommandPort
         if (string.IsNullOrWhiteSpace(voiceModuleName))
             throw new ArgumentException("voiceModuleName is required.", nameof(voiceModuleName));
 
-        var actorId = BuildDemoActorId(scopeId);
+        var actorId = NyxIdChatServiceDefaults.BuildVoiceDemoActorId(scopeId);
         var actor = await _actorRuntime.CreateAsync<NyxIdChatGAgent>(actorId, ct);
         var initialize = new InitializeRoleAgentEvent
         {
@@ -74,10 +72,4 @@ internal sealed class VoiceDemoAgentCommandPort : IVoiceDemoAgentCommandPort
         return new VoiceDemoAgentCommandAcceptedReceipt(actor.Id, commandId, commandId);
     }
 
-    private static string BuildDemoActorId(string scopeId)
-    {
-        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(scopeId.Trim()));
-        var hash = Convert.ToHexString(bytes)[..16].ToLowerInvariant();
-        return $"{NyxIdChatServiceDefaults.ActorIdPrefix}-voice-demo-{hash}";
-    }
 }

--- a/docs/adr/0025-voice-router-integration.md
+++ b/docs/adr/0025-voice-router-integration.md
@@ -6,9 +6,10 @@ owner: eanzhao
 
 # ADR-0025: Voice Router Integration - Policy-Aware WebSocket Boundary
 
-> Superseded for target encoding by ADR-0026 and narrowed by issue #1321.
-> Voice still resolves through `/ws/voice`, but ordinary policy-aware voice no
-> longer treats `ForwardToModel.tool_choice_hint` as actor addressing.
+> Superseded for target encoding by ADR-0026 and narrowed by issues #1321 and
+> #674. Voice still resolves through `/ws/voice`; attach targets are expressed
+> only by `ForwardToModel.tool_choice_hint.voice_attach_target`, not by tool
+> prefilled argument bags.
 
 ## Context
 
@@ -30,12 +31,15 @@ and provider state machines.
   before WebSocket upgrade.
 - ADR-0026 supersedes the old voice wire action, and issue #1321 removes the
   temporary compatibility path that read `actor_id` or `voice_module_name` from
-  `ForwardToModel.tool_choice_hint`. For ordinary `/ws/voice`, every
-  `ForwardToModel` decision now fails closed before WebSocket accept until a
-  route-scoped voice session actor contract exists.
+  `ForwardToModel.tool_choice_hint.prefilled_arguments`. Issue #674 restores
+  ordinary `/ws/voice` attach by adding typed
+  `ChatRouteToolChoiceHint.voice_attach_target { actor_id, voice_module_name }`.
+  A `ForwardToModel` without that typed target remains model forwarding and
+  still fails closed before WebSocket accept.
 - Route policy and authorization remain separate. Ordinary `/ws/voice` no
-  longer derives a target actor from tool prefill; explicit actor attach is
-  limited to the dev/admin bypass below.
+  longer derives a target actor from tool prefill; it attaches only when the
+  policy carries the typed voice attach target. Explicit actor attach through
+  the path remains limited to the dev/admin bypass below.
 - Explicit actorId bypass stays at `GET /ws/voice/{actorId}`, but Mainnet Host
   gates it with the `voice-dev` authorization policy (`voice:bypass` scope or
   admin/owner role).
@@ -57,9 +61,12 @@ and provider state machines.
 
 ## Verification
 
+- `/ws/voice` attaches to `voice_attach_target.actor_id` with optional
+  `voice_attach_target.voice_module_name` when the resolved `ForwardToModel`
+  carries that typed target.
 - `/ws/voice` returns `501` before WebSocket accept for `ForwardToModel`
-  decisions, including decisions that carry `tool_choice_hint` prefilled
-  arguments.
+  decisions that do not carry a typed voice attach target, including decisions
+  that carry only `tool_choice_hint.prefilled_arguments`.
 - `/ws/voice/{actorId}` rejects callers without `voice:bypass` or admin/owner.
 - Static checks show no ChatRouting dependency inside
   `Aevatar.Foundation.VoicePresence`.

--- a/docs/adr/0026-tool-first-chat-ingress.md
+++ b/docs/adr/0026-tool-first-chat-ingress.md
@@ -12,13 +12,14 @@ Accepted for the current `ChatRouteAction` contract: the active oneof variants
 are `ForwardToModel` and `Reject`; legacy
 `ForwardToGAgent`/`ForwardToTeam`/`ForwardToWorkflow`/`Bypass` names are
 reserved only. The `ForwardToModel.tool_set_ref + tool_choice_hint` fields
-express tool availability and tool prefill only; they must not be interpreted
-as actor addressing.
+express tool availability, tool prefill, and the typed voice attach target.
+Tool prefilled arguments must not be interpreted as actor addressing.
 
 D5/D6 describe the later session-owned execution topology. `ChatRunActor` and
-`VoiceSessionActor` are not implemented by this ADR slice, and ordinary
-`/ws/voice` `ForwardToModel` execution remains fail-closed until that topology
-exists.
+`VoiceSessionActor` are not implemented by this ADR slice. Until that topology
+exists, ordinary `/ws/voice` supports only typed
+`tool_choice_hint.voice_attach_target` attachment; pure model forwarding
+remains fail-closed.
 
 ## Context
 
@@ -89,8 +90,10 @@ ADR-0024 D1 is preserved. Only the action set narrows.
   outside the policy proto so the action stays small.
 - `tool_choice_hint` — optional pinning of a particular tool plus
   pre-filled named arguments. It configures the tool call input for ingress
-  paths that actually execute that tool loop; it is not actor addressing and
-  must not be used by `/ws/voice` to choose a WebSocket attach target.
+  paths that actually execute that tool loop. Its
+  `voice_attach_target { actor_id, voice_module_name }` sub-message is the
+  only `/ws/voice` attach target. `prefilled_arguments` is not actor addressing
+  and must not be used by `/ws/voice` to choose a WebSocket attach target.
 
 Per CLAUDE.md §"字段命名与 Metadata 决策树" step 1, both fields are typed
 sub-messages, not `map<string, string>` bags.
@@ -151,12 +154,16 @@ Per CLAUDE.md §"Actor 即业务实体", these are named for the business entity
 
 ### D6 — Voice converges on the same ingress shape
 
-`/ws/voice` no longer binds to an actor at WebSocket upgrade time. Until a
-route-scoped `VoiceSessionActor` exists, ordinary `/ws/voice` fails closed for
-`ForwardToModel` decisions before WebSocket accept. The later session actor can
-run `ChatRouteResolver` once at session establishment, declare the resolved
-tool set to the OpenAI Realtime provider, and feed function calls through the
-same `ToolCallLoop` without treating tool prefill as actor addressing.
+`/ws/voice` may attach to a voice-enabled actor at WebSocket upgrade time only
+when the resolved `ForwardToModel.tool_choice_hint.voice_attach_target` carries
+the typed attach target. `actor_id` and `voice_module_name` in
+`prefilled_arguments` are ignored for voice attachment. Until a route-scoped
+`VoiceSessionActor` exists, ordinary `/ws/voice` still fails closed for pure
+model-forward `ForwardToModel` decisions before WebSocket accept. The later
+session actor can run `ChatRouteResolver` once at session establishment,
+declare the resolved tool set to the OpenAI Realtime provider, and feed
+function calls through the same `ToolCallLoop` without treating tool prefill as
+actor addressing.
 
 `/ws/voice/{actorId}` (dev/admin bypass from ADR-0024 D4) stays. It
 short-circuits the resolver, so its semantics are unaffected.
@@ -251,10 +258,9 @@ Runtime checks:
   policy would have routed to `ForwardToGAgent` / `ForwardToTeam`. The
   Anthropic facade can host the same orchestration because the
   orchestration lives in the tool layer, not the wire shape.
-- `/ws/voice` resolves a policy, declares tools to the Realtime provider,
-  and the model can call `aevatar_invoke_gagent` mid-conversation; the
-  result lands as a backchannel `conversation.item.create` + `response.create`
-  and the model speaks it aloud.
+- `/ws/voice` resolves a policy and attaches when the decision carries typed
+  `voice_attach_target`; `ForwardToModel` decisions without that typed target
+  return HTTP 501 before WebSocket accept.
 - NyxID-direct caller (no Aevatar UI session) hits `/v1/responses` with
   a NyxID bearer that has a Lark connection in NyxID; says "push X to
   my Lark"; the Lark tool dispatches under caller scope; the message
@@ -279,7 +285,7 @@ Stage 1's tool sources are merged.
 | **2** | Extend `ForwardToModel` proto with `tool_set_ref` + `tool_choice_hint`. Policy authors express GAgent, team, and workflow targets directly as tool-first `ForwardToModel` actions. `ChatRunActor` introduced for SSE sessions. | No |
 | **3** | Delete legacy wire actions and migration path. Reserve old proto tags/names for `ForwardToGAgent`, `ForwardToTeam`, `ForwardToWorkflow`, and `Bypass`; no new policy writer may emit them. | Yes (clients still using legacy actions) |
 | **4** | Remove code paths: `ResponsesEndpoints.cs:779-927`, `AgentRunGAgent.cs:1108-1141`, resolver branches for legacy actions. `/v1/messages` 501 fallback for these actions deleted. | Yes (clients still using legacy actions) |
-| **5** | `VoiceSessionActor` implementation. `/ws/voice` switches to `ForwardToModel + tool_set_ref`. `/ws/voice/{actorId}` dev bypass unaffected. **Blocked by:** VoicePresence.OpenAI GA migration. | Yes (voice clients) |
+| **5** | `VoiceSessionActor` implementation. `/ws/voice` switches from typed attach target to session-owned `ForwardToModel + tool_set_ref` execution. `/ws/voice/{actorId}` dev bypass unaffected. **Blocked by:** VoicePresence.OpenAI GA migration. | Yes (voice clients) |
 
 ## Supersedes
 

--- a/src/Aevatar.ChatRouting.Abstractions/chat_route_policy.proto
+++ b/src/Aevatar.ChatRouting.Abstractions/chat_route_policy.proto
@@ -106,6 +106,15 @@ message ChatRouteToolChoiceHint {
   // LLM-supplied arguments that conflict on the same key; the prefilled values
   // are trusted policy input, not model-supplied data.
   google.protobuf.Struct prefilled_arguments = 2;
+  // Typed voice attach target for ChatSourceKind=VOICE. This keeps voice
+  // session attachment out of tool prefill bags while preserving the
+  // ForwardToModel/Reject action set.
+  ChatRouteVoiceAttachTarget voice_attach_target = 3;
+}
+
+message ChatRouteVoiceAttachTarget {
+  string actor_id = 1;
+  string voice_module_name = 2;
 }
 
 message ForwardToModel {

--- a/src/Aevatar.ChatRouting.Core/ChatRouteActionTargets.cs
+++ b/src/Aevatar.ChatRouting.Core/ChatRouteActionTargets.cs
@@ -2,6 +2,10 @@ using Aevatar.ChatRouting.Abstractions;
 
 namespace Aevatar.ChatRouting.Core;
 
+// Refactor (iter367/cluster-issue674): Old pattern: voice attach routing encoded
+// actor_id and voice_module_name inside ForwardToModel.ToolChoiceHint.PrefilledArguments.
+// New principle: typed ChatRouteVoiceAttachTarget is the only voice attach target
+// contract; ForwardToModel without it remains ordinary model forwarding.
 public static class ChatRouteActionTargets
 {
     private const string DefaultToolSetName = "workspace.default";

--- a/src/Aevatar.ChatRouting.Core/ChatRouteActionTargets.cs
+++ b/src/Aevatar.ChatRouting.Core/ChatRouteActionTargets.cs
@@ -1,0 +1,45 @@
+using Aevatar.ChatRouting.Abstractions;
+
+namespace Aevatar.ChatRouting.Core;
+
+public static class ChatRouteActionTargets
+{
+    private const string DefaultToolSetName = "workspace.default";
+
+    public static ChatRouteAction ForwardToVoiceAttachTarget(
+        string actorId,
+        string voiceModuleName = "",
+        string toolSetName = DefaultToolSetName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(actorId);
+
+        return new ChatRouteAction
+        {
+            ForwardToModel = new ForwardToModel
+            {
+                ToolSetRef = new ChatRouteToolSetRef { Name = toolSetName },
+                ToolChoiceHint = new ChatRouteToolChoiceHint
+                {
+                    VoiceAttachTarget = new ChatRouteVoiceAttachTarget
+                    {
+                        ActorId = actorId.Trim(),
+                        VoiceModuleName = voiceModuleName.Trim(),
+                    },
+                },
+            },
+        };
+    }
+
+    public static bool TryGetVoiceAttachTarget(
+        ChatRouteAction? action,
+        out ChatRouteVoiceAttachTarget target)
+    {
+        target = new ChatRouteVoiceAttachTarget();
+        var candidate = action?.ForwardToModel?.ToolChoiceHint?.VoiceAttachTarget;
+        if (candidate is null || string.IsNullOrWhiteSpace(candidate.ActorId))
+            return false;
+
+        target = candidate;
+        return true;
+    }
+}

--- a/src/Aevatar.Mainnet.Host.Api/Voice/PolicyAwareVoiceEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Voice/PolicyAwareVoiceEndpoints.cs
@@ -73,6 +73,10 @@ public static class PolicyAwareVoiceEndpoints
                 await http.Response.WriteAsync(action.Reject?.Reason ?? "Voice route rejected.", http.RequestAborted);
                 return;
             case ChatRouteAction.ActionOneofCase.ForwardToModel:
+                // Refactor (iter367/cluster-issue674): Old pattern: /ws/voice
+                // distinguished attach vs model forwarding by string keys inside
+                // PrefilledArguments. New principle: only typed ChatRouteVoiceAttachTarget
+                // may attach a voice transport; bare ForwardToModel still fails closed.
                 if (ChatRouteActionTargets.TryGetVoiceAttachTarget(action, out var voiceTarget))
                 {
                     await AttachVoiceTargetAsync(http, voiceSessionResolver, voiceTarget);

--- a/src/Aevatar.Mainnet.Host.Api/Voice/PolicyAwareVoiceEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Voice/PolicyAwareVoiceEndpoints.cs
@@ -2,6 +2,8 @@ using System.Security.Claims;
 using Aevatar.Authentication.Abstractions;
 using Aevatar.ChatRouting.Abstractions;
 using Aevatar.ChatRouting.Core;
+using Aevatar.Foundation.VoicePresence.Hosting;
+using Aevatar.Foundation.VoicePresence.Transport;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -13,6 +15,7 @@ public static class PolicyAwareVoiceEndpoints
 {
     private const string DefaultPattern = "/ws/voice";
     private const string ScopeClaimType = "scope";
+    private const string RemoteAudioTransportUnavailableReason = "remote_audio_transport_unavailable";
     private static readonly string[] RoleClaimTypes =
     [
         "scope_role",
@@ -39,7 +42,8 @@ public static class PolicyAwareVoiceEndpoints
     private static async Task HandlePolicyAwareVoiceAsync(
         HttpContext http,
         [FromServices] IChatRoutePolicyQueryPort queryPort,
-        [FromServices] ChatRouteResolver resolver)
+        [FromServices] ChatRouteResolver resolver,
+        [FromServices] IVoicePresenceSessionResolver voiceSessionResolver)
     {
         // Refactor (issue1321-first): reject unsupported policy-aware voice routes
         // before accepting the WebSocket.
@@ -69,8 +73,14 @@ public static class PolicyAwareVoiceEndpoints
                 await http.Response.WriteAsync(action.Reject?.Reason ?? "Voice route rejected.", http.RequestAborted);
                 return;
             case ChatRouteAction.ActionOneofCase.ForwardToModel:
-                // Refactor (issue1321-first): ForwardToModel.tool_choice_hint is tool prefill only,
-                // not a voice actor address. Ordinary policy-aware voice fails closed before accept.
+                if (ChatRouteActionTargets.TryGetVoiceAttachTarget(action, out var voiceTarget))
+                {
+                    await AttachVoiceTargetAsync(http, voiceSessionResolver, voiceTarget);
+                    return;
+                }
+
+                // ForwardToModel without a typed voice target is ordinary model forwarding,
+                // not voice attachment. Keep it fail-closed before WebSocket accept.
                 http.Response.StatusCode = StatusCodes.Status501NotImplemented;
                 await http.Response.WriteAsync("Voice ForwardToModel is not supported in v1.", http.RequestAborted);
                 return;
@@ -78,6 +88,124 @@ public static class PolicyAwareVoiceEndpoints
                 http.Response.StatusCode = StatusCodes.Status403Forbidden;
                 await http.Response.WriteAsync("Voice route did not resolve to a GAgent target.", http.RequestAborted);
                 return;
+        }
+    }
+
+    private static async Task AttachVoiceTargetAsync(
+        HttpContext http,
+        IVoicePresenceSessionResolver voiceSessionResolver,
+        ChatRouteVoiceAttachTarget voiceTarget)
+    {
+        var resolution = await voiceSessionResolver.ResolveAsync(
+            new VoicePresenceSessionRequest(
+                voiceTarget.ActorId.Trim(),
+                NormalizeOptional(voiceTarget.VoiceModuleName),
+                VoicePresenceSessionRequestPurpose.Attach),
+            http.RequestAborted);
+
+        var session = await WriteNonAcceptedResolutionAsync(http, resolution);
+        if (session is null)
+            return;
+
+        var ws = await http.WebSockets.AcceptWebSocketAsync();
+        var transport = new WebSocketVoiceTransport(ws);
+        var attached = false;
+        try
+        {
+            await session.AttachTransportAsync(transport, http.RequestAborted);
+            attached = true;
+            await WaitUntilClosedAsync(transport, http.RequestAborted);
+        }
+        catch (NotSupportedException ex) when (string.Equals(
+                   ex.Message,
+                   RemoteAudioTransportUnavailableReason,
+                   StringComparison.Ordinal))
+        {
+            await TryCloseAsync(ws, RemoteAudioTransportUnavailableReason);
+        }
+        catch (InvalidOperationException) when (!attached)
+        {
+            await TryCloseAsync(ws, "Voice transport already attached.");
+        }
+        finally
+        {
+            if (attached)
+                await session.DetachTransportAsync(transport, http.RequestAborted);
+        }
+    }
+
+    private static async Task<VoicePresenceSession?> WriteNonAcceptedResolutionAsync(
+        HttpContext http,
+        VoicePresenceSessionResolution resolution)
+    {
+        switch (resolution.Kind)
+        {
+            case VoicePresenceSessionResolutionKind.LeaseAcceptedPendingAttach:
+            case VoicePresenceSessionResolutionKind.LeaseAcceptedAttached:
+                return resolution.Session ?? throw new InvalidOperationException("Accepted voice session resolution requires a session.");
+            case VoicePresenceSessionResolutionKind.Unsupported:
+                http.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                await http.Response.WriteAsync(RemoteAudioTransportUnavailableReason, http.RequestAborted);
+                return null;
+            case VoicePresenceSessionResolutionKind.PreflightFailed:
+                await WritePreflightFailureAsync(http, resolution.PreflightFailure);
+                return null;
+            default:
+                http.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                await http.Response.WriteAsync("Voice session resolution failed.", http.RequestAborted);
+                return null;
+        }
+    }
+
+    private static async Task WritePreflightFailureAsync(
+        HttpContext http,
+        VoicePresencePreflightFailureKind? failure)
+    {
+        switch (failure)
+        {
+            case VoicePresencePreflightFailureKind.NotFound:
+                http.Response.StatusCode = StatusCodes.Status404NotFound;
+                await http.Response.WriteAsync("Voice session not found for this agent.", http.RequestAborted);
+                break;
+            case VoicePresencePreflightFailureKind.NotInitialized:
+                http.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                await http.Response.WriteAsync("Voice module not initialized.", http.RequestAborted);
+                break;
+            case VoicePresencePreflightFailureKind.TransportAlreadyAttached:
+                http.Response.StatusCode = StatusCodes.Status409Conflict;
+                await http.Response.WriteAsync("Voice transport already attached.", http.RequestAborted);
+                break;
+            default:
+                http.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                await http.Response.WriteAsync("Voice session preflight failed.", http.RequestAborted);
+                break;
+        }
+    }
+
+    private static async Task TryCloseAsync(System.Net.WebSockets.WebSocket ws, string reason)
+    {
+        if (ws.State is not System.Net.WebSockets.WebSocketState.Open and not System.Net.WebSockets.WebSocketState.CloseReceived)
+            return;
+
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            await ws.CloseAsync(System.Net.WebSockets.WebSocketCloseStatus.PolicyViolation, reason, cts.Token);
+        }
+        catch
+        {
+            // best effort close after websocket upgrade
+        }
+    }
+
+    private static async Task WaitUntilClosedAsync(WebSocketVoiceTransport transport, CancellationToken ct)
+    {
+        try
+        {
+            await transport.Completion.WaitAsync(ct);
+        }
+        catch (OperationCanceledException)
+        {
         }
     }
 

--- a/src/Aevatar.Mainnet.Host.Api/Voice/VoiceDemoBootstrapEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Voice/VoiceDemoBootstrapEndpoints.cs
@@ -62,6 +62,7 @@ internal static class VoiceDemoBootstrapEndpoints
         var routePolicyReceipt = await EnsureVoiceRoutePolicyAsync(
             scopeId,
             ownerScope,
+            actorId,
             routePolicyCommandPort,
             routePolicyQueryPort,
             ct);
@@ -85,6 +86,7 @@ internal static class VoiceDemoBootstrapEndpoints
     private static async Task<ChatRoutePolicyCommandAcceptedReceipt?> EnsureVoiceRoutePolicyAsync(
         string scopeId,
         OwnerScope ownerScope,
+        string actorId,
         IChatRoutePolicyCommandPort routePolicyCommandPort,
         IChatRoutePolicyQueryPort routePolicyQueryPort,
         CancellationToken ct)
@@ -98,9 +100,6 @@ internal static class VoiceDemoBootstrapEndpoints
             .Select(static rule => rule.Clone())
             .ToArray();
 
-        if (keptRules.Length == existing.Rules.Count)
-            return null;
-
         var command = new UpsertChatRoutePolicyRequested
         {
             OwnerScope = new OwnerScope
@@ -111,9 +110,17 @@ internal static class VoiceDemoBootstrapEndpoints
             DefaultTarget = existing.DefaultTarget.Clone(),
         };
 
-        // Refactor (issue1365-first): only remove the stale voice-demo route.
-        // Bootstrap no longer creates a voice.realtime default target placeholder.
         command.Rules.AddRange(keptRules);
+        command.Rules.Add(new ChatRouteRule
+        {
+            RuleId = RouteRuleId,
+            Priority = 900,
+            Match = new ChatRouteMatch { SourceKind = ChatSourceKind.Voice },
+            Action = ChatRouteActionTargets.ForwardToVoiceAttachTarget(
+                actorId,
+                VoiceModuleName),
+            Description = "Voice demo typed attach target.",
+        });
 
         return await routePolicyCommandPort.UpsertAsync(scopeId, command, ct);
     }

--- a/src/Aevatar.Mainnet.Host.Api/wwwroot/demo/voice/index.html
+++ b/src/Aevatar.Mainnet.Host.Api/wwwroot/demo/voice/index.html
@@ -111,12 +111,12 @@
       <article class="panel">
         <h2>2. Agent 要有 voice module</h2>
         <p>点击“开始说话”时，demo 会自动创建或复用当前用户的 voice demo agent，并挂上 `voice_presence_openai` 模块。Mainnet Host 的上游 URL 已固定为 NyxID proxy；请求里的 NyxID bearer 只用于向 NyxID proxy 鉴权，不会作为 OpenAI key 暴露给浏览器。</p>
-        <p>普通 `/ws/voice` 不再从 `tool_choice_hint` 推导目标 agent；`/ws/voice/{actorId}` 是调试直连入口，需要登录用户具备 `voice:bypass` scope 或 admin/owner 角色。</p>
+        <p>普通 `/ws/voice` 只从 typed `voice_attach_target` 读取目标 agent；`/ws/voice/{actorId}` 是调试直连入口，需要登录用户具备 `voice:bypass` scope 或 admin/owner 角色。</p>
       </article>
 
       <article class="panel wide">
         <h2>3. 调试直连</h2>
-        <p>demo 会调用 `POST /api/demo/voice/bootstrap`，在当前 NyxID scope 下登记 demo agent，并返回可用于调试直连的 `actor_id` 与 `voice_module_name`。普通 `/ws/voice` 会对 `ForwardToModel` fail closed；临时换目标 agent 时使用显式 bypass 路径。</p>
+        <p>demo 会调用 `POST /api/demo/voice/bootstrap`，在当前 NyxID scope 下登记 demo agent，并把 voice route 写成 typed `voice_attach_target`。返回的 `actor_id` 与 `voice_module_name` 可用于调试直连；临时换目标 agent 时使用显式 bypass 路径。</p>
         <pre><code>wss://MAINNET_HOST/ws/voice/YOUR_AGENT_ACTOR_ID?voice_module_name=voice_presence_openai</code></pre>
       </article>
 

--- a/test/Aevatar.ChatRouting.Core.Tests/ChatRouteActionTargetsTests.cs
+++ b/test/Aevatar.ChatRouting.Core.Tests/ChatRouteActionTargetsTests.cs
@@ -1,0 +1,103 @@
+using Aevatar.ChatRouting.Abstractions;
+using FluentAssertions;
+
+namespace Aevatar.ChatRouting.Core.Tests;
+
+public sealed class ChatRouteActionTargetsTests
+{
+    [Fact]
+    public void ForwardToVoiceAttachTarget_ShouldBuildTypedForwardToModelAction()
+    {
+        var action = ChatRouteActionTargets.ForwardToVoiceAttachTarget(
+            " voice-agent-1 ",
+            " voice_presence_openai ",
+            "workspace.voice");
+
+        action.ActionCase.Should().Be(ChatRouteAction.ActionOneofCase.ForwardToModel);
+        action.ForwardToModel.ToolSetRef.Name.Should().Be("workspace.voice");
+        action.ForwardToModel.ToolChoiceHint.PrefilledArguments.Should().BeNull();
+        action.ForwardToModel.ToolChoiceHint.VoiceAttachTarget.ActorId.Should().Be("voice-agent-1");
+        action.ForwardToModel.ToolChoiceHint.VoiceAttachTarget.VoiceModuleName.Should().Be("voice_presence_openai");
+    }
+
+    [Fact]
+    public void ForwardToVoiceAttachTarget_WhenOptionalArgumentsAreOmitted_ShouldUseDefaultToolSetAndEmptyModule()
+    {
+        var action = ChatRouteActionTargets.ForwardToVoiceAttachTarget("voice-agent-1");
+
+        action.ForwardToModel.ToolSetRef.Name.Should().Be("workspace.default");
+        action.ForwardToModel.ToolChoiceHint.VoiceAttachTarget.ActorId.Should().Be("voice-agent-1");
+        action.ForwardToModel.ToolChoiceHint.VoiceAttachTarget.VoiceModuleName.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ForwardToVoiceAttachTarget_WhenActorIdIsMissing_ShouldReject(string? actorId)
+    {
+        var act = () => ChatRouteActionTargets.ForwardToVoiceAttachTarget(actorId!);
+
+        act.Should().Throw<ArgumentException>()
+            .WithParameterName("actorId");
+    }
+
+    [Fact]
+    public void TryGetVoiceAttachTarget_WhenTypedTargetHasActorId_ShouldReturnTarget()
+    {
+        var action = ChatRouteActionTargets.ForwardToVoiceAttachTarget(
+            "voice-agent-1",
+            "voice_presence_openai");
+
+        var found = ChatRouteActionTargets.TryGetVoiceAttachTarget(action, out var target);
+
+        found.Should().BeTrue();
+        target.Should().BeSameAs(action.ForwardToModel.ToolChoiceHint.VoiceAttachTarget);
+        target.ActorId.Should().Be("voice-agent-1");
+        target.VoiceModuleName.Should().Be("voice_presence_openai");
+    }
+
+    [Theory]
+    [MemberData(nameof(ActionsWithoutVoiceAttachTarget))]
+    public void TryGetVoiceAttachTarget_WhenTypedTargetIsMissingOrBlank_ShouldReturnFalse(ChatRouteAction? action)
+    {
+        var found = ChatRouteActionTargets.TryGetVoiceAttachTarget(action, out var target);
+
+        found.Should().BeFalse();
+        target.ActorId.Should().BeEmpty();
+        target.VoiceModuleName.Should().BeEmpty();
+    }
+
+    public static IEnumerable<object?[]> ActionsWithoutVoiceAttachTarget()
+    {
+        yield return [null];
+        yield return [new ChatRouteAction()];
+        yield return
+        [
+            new ChatRouteAction
+            {
+                ForwardToModel = new ForwardToModel
+                {
+                    ToolChoiceHint = new ChatRouteToolChoiceHint(),
+                },
+            },
+        ];
+        yield return
+        [
+            new ChatRouteAction
+            {
+                ForwardToModel = new ForwardToModel
+                {
+                    ToolChoiceHint = new ChatRouteToolChoiceHint
+                    {
+                        VoiceAttachTarget = new ChatRouteVoiceAttachTarget
+                        {
+                            ActorId = "   ",
+                            VoiceModuleName = "voice_presence_openai",
+                        },
+                    },
+                },
+            },
+        ];
+    }
+}

--- a/test/Aevatar.ChatRouting.Core.Tests/ChatRoutePolicyProtoTests.cs
+++ b/test/Aevatar.ChatRouting.Core.Tests/ChatRoutePolicyProtoTests.cs
@@ -42,6 +42,11 @@ public sealed class ChatRoutePolicyProtoTests
                 ToolChoiceHint = new ChatRouteToolChoiceHint
                 {
                     ToolName = "aevatar_invoke_gagent",
+                    VoiceAttachTarget = new ChatRouteVoiceAttachTarget
+                    {
+                        ActorId = "voice-agent-1",
+                        VoiceModuleName = "voice_presence_openai",
+                    },
                     PrefilledArguments = new Struct
                     {
                         Fields =
@@ -63,5 +68,7 @@ public sealed class ChatRoutePolicyProtoTests
         parsed.ForwardToModel.ToolChoiceHint.PrefilledArguments.Fields["actor_id"].StringValue
             .Should()
             .Be("actor-1");
+        parsed.ForwardToModel.ToolChoiceHint.VoiceAttachTarget.ActorId.Should().Be("voice-agent-1");
+        parsed.ForwardToModel.ToolChoiceHint.VoiceAttachTarget.VoiceModuleName.Should().Be("voice_presence_openai");
     }
 }

--- a/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
+++ b/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
@@ -9,7 +9,6 @@ using Aevatar.Foundation.VoicePresence.Hosting;
 using Aevatar.Mainnet.Host.Api.Voice;
 using Aevatar.GAgents.Scheduled;
 using FluentAssertions;
-using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -34,7 +33,7 @@ public sealed class PolicyAwareVoiceEndpointsTests
     public async Task PolicyAwareVoice_WhenForwardToModelHasGAgentToolHint_ShouldReturnNotImplementedBeforeUpgrade()
     {
         var policyPort = StaticPolicyPort.For(new ChatRoutePolicySnapshot(
-            GAgentToolHint("voice-agent-default", "voice_presence_openai"),
+            GAgentToolHint("voice-agent-default"),
             []));
         var catalog = new RecordingCatalogQueryPort(allowedActorIds: ["voice-agent-default"]);
         var resolver = RecordingVoiceSessionResolver.Attached(CreateInitializedSession());
@@ -55,7 +54,7 @@ public sealed class PolicyAwareVoiceEndpointsTests
     }
 
     [Fact]
-    public async Task PolicyAwareVoice_WhenVoiceRuleForwardToModelHasGAgentToolHint_ShouldFailClosedBeforeUpgrade()
+    public async Task PolicyAwareVoice_WhenVoiceRuleForwardToModelHasTypedAttachTarget_ShouldAttach()
     {
         var policyPort = StaticPolicyPort.For(new ChatRoutePolicySnapshot(
             ForwardToModel("fallback-model"),
@@ -69,11 +68,11 @@ public sealed class PolicyAwareVoiceEndpointsTests
                         SourceKind = ChatSourceKind.Voice,
                         Channel = "lark",
                     },
-                    Action = GAgentToolHint("voice-agent-lark"),
+                    Action = VoiceAttachTarget("voice-agent-lark", "voice_presence_openai"),
                 },
             ]));
         var catalog = new RecordingCatalogQueryPort(allowedActorIds: ["voice-agent-lark"]);
-        var resolver = RecordingVoiceSessionResolver.Attached(CreateInitializedSession());
+        var resolver = RecordingVoiceSessionResolver.Attached(CreateSessionCompletingOnAttach());
         var socket = new FakeWebSocket(WebSocketState.Open);
         using var app = CreatePolicyAwareApp(policyPort, catalog, resolver);
         var context = CreateVoiceContext(app, "/ws/voice?channel=lark&registration_scope_id=bot-1&sender_id=sender-1");
@@ -82,10 +81,14 @@ public sealed class PolicyAwareVoiceEndpointsTests
 
         await GetEndpoint(app, "/ws/voice").RequestDelegate!(context);
 
-        context.Response.StatusCode.Should().Be(StatusCodes.Status501NotImplemented);
-        wsFeature.AcceptCalls.Should().Be(0);
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        wsFeature.AcceptCalls.Should().Be(1);
         catalog.Requests.Should().BeEmpty();
-        resolver.Requests.Should().BeEmpty();
+        resolver.Requests.Should().ContainSingle()
+            .Which.Should().Be(new VoicePresenceSessionRequest(
+                "voice-agent-lark",
+                "voice_presence_openai",
+                VoicePresenceSessionRequestPurpose.Attach));
     }
 
     [Fact]
@@ -141,14 +144,8 @@ public sealed class PolicyAwareVoiceEndpointsTests
         resolver.Requests.Should().BeEmpty();
     }
 
-    private static ChatRouteAction GAgentToolHint(string actorId, string voiceModuleName = "")
-    {
-        var arguments = new Struct();
-        arguments.Fields["actor_id"] = Google.Protobuf.WellKnownTypes.Value.ForString(actorId);
-        if (!string.IsNullOrWhiteSpace(voiceModuleName))
-            arguments.Fields["voice_module_name"] = Google.Protobuf.WellKnownTypes.Value.ForString(voiceModuleName);
-
-        return new ChatRouteAction
+    private static ChatRouteAction GAgentToolHint(string actorId) =>
+        new()
         {
             ForwardToModel = new ForwardToModel
             {
@@ -156,11 +153,12 @@ public sealed class PolicyAwareVoiceEndpointsTests
                 ToolChoiceHint = new ChatRouteToolChoiceHint
                 {
                     ToolName = "aevatar_invoke_gagent",
-                    PrefilledArguments = arguments,
                 },
             },
         };
-    }
+
+    private static ChatRouteAction VoiceAttachTarget(string actorId, string voiceModuleName) =>
+        ChatRouteActionTargets.ForwardToVoiceAttachTarget(actorId, voiceModuleName);
 
     private static ChatRouteAction ForwardToModel(string modelName) =>
         new()
@@ -256,14 +254,25 @@ public sealed class PolicyAwareVoiceEndpointsTests
             .OfType<RouteEndpoint>()
             .Single(endpoint => endpoint.RoutePattern.RawText == pattern);
 
-    private static Task InvokeEndpointWithTimeoutAsync(WebApplication app, DefaultHttpContext context) =>
-        GetEndpoint(app, "/ws/voice").RequestDelegate!(context).WaitAsync(TimeSpan.FromSeconds(5));
-
     private static VoicePresenceSession CreateInitializedSession() =>
         new(
             isInitialized: static () => true,
             isTransportAttached: static () => false,
             attachTransportAsync: static (_, _) => Task.CompletedTask,
+            detachTransportAsync: static (_, _) => Task.CompletedTask,
+            pcmSampleRateHz: 24000);
+
+    private static VoicePresenceSession CreateSessionCompletingOnAttach() =>
+        new(
+            isInitialized: static () => true,
+            isTransportAttached: static () => false,
+            attachTransportAsync: static (transport, _) =>
+            {
+                if (transport is IAsyncDisposable disposable)
+                    return disposable.DisposeAsync().AsTask();
+
+                return Task.CompletedTask;
+            },
             detachTransportAsync: static (_, _) => Task.CompletedTask,
             pcmSampleRateHz: 24000);
 

--- a/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
+++ b/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
@@ -91,6 +91,84 @@ public sealed class PolicyAwareVoiceEndpointsTests
                 VoicePresenceSessionRequestPurpose.Attach));
     }
 
+    [Theory]
+    [InlineData("unsupported", StatusCodes.Status503ServiceUnavailable, "remote_audio_transport_unavailable")]
+    [InlineData("not-found", StatusCodes.Status404NotFound, "Voice session not found for this agent.")]
+    [InlineData("not-initialized", StatusCodes.Status503ServiceUnavailable, "Voice module not initialized.")]
+    [InlineData("transport-attached", StatusCodes.Status409Conflict, "Voice transport already attached.")]
+    public async Task PolicyAwareVoice_WhenTypedAttachResolutionIsNotAccepted_ShouldReturnMappedFailureBeforeUpgrade(
+        string resolutionCase,
+        int expectedStatusCode,
+        string expectedBody)
+    {
+        var policyPort = StaticPolicyPort.For(new ChatRoutePolicySnapshot(
+            VoiceAttachTarget(" voice-agent-lark ", " voice_presence_openai "),
+            []));
+        var resolver = resolutionCase switch
+        {
+            "unsupported" => RecordingVoiceSessionResolver.Unsupported(),
+            "not-found" => RecordingVoiceSessionResolver.PreflightFailed(VoicePresencePreflightFailureKind.NotFound),
+            "not-initialized" => RecordingVoiceSessionResolver.PreflightFailed(VoicePresencePreflightFailureKind.NotInitialized),
+            "transport-attached" => RecordingVoiceSessionResolver.PreflightFailed(VoicePresencePreflightFailureKind.TransportAlreadyAttached),
+            _ => throw new ArgumentOutOfRangeException(nameof(resolutionCase), resolutionCase, null),
+        };
+        var socket = new FakeWebSocket(WebSocketState.Open);
+        using var app = CreatePolicyAwareApp(
+            policyPort,
+            new RecordingCatalogQueryPort(allowedActorIds: ["voice-agent-lark"]),
+            resolver);
+        var context = CreateVoiceContext(app, "/ws/voice?channel=lark");
+        var wsFeature = new FakeHttpWebSocketFeature(socket);
+        context.Features.Set<IHttpWebSocketFeature>(wsFeature);
+
+        await GetEndpoint(app, "/ws/voice").RequestDelegate!(context);
+
+        context.Response.StatusCode.Should().Be(expectedStatusCode);
+        (await ReadBodyAsync(context)).Should().Be(expectedBody);
+        wsFeature.AcceptCalls.Should().Be(0);
+        resolver.Requests.Should().ContainSingle()
+            .Which.Should().Be(new VoicePresenceSessionRequest(
+                "voice-agent-lark",
+                "voice_presence_openai",
+                VoicePresenceSessionRequestPurpose.Attach));
+    }
+
+    [Theory]
+    [InlineData("remote-audio-unavailable", "remote_audio_transport_unavailable")]
+    [InlineData("already-attached", "Voice transport already attached.")]
+    public async Task PolicyAwareVoice_WhenAttachFailsAfterUpgrade_ShouldCloseWebSocketWithPolicyReason(
+        string failureCase,
+        string expectedCloseReason)
+    {
+        var policyPort = StaticPolicyPort.For(new ChatRoutePolicySnapshot(
+            VoiceAttachTarget("voice-agent-lark", "voice_presence_openai"),
+            []));
+        var session = failureCase switch
+        {
+            "remote-audio-unavailable" => CreateSessionThrowingOnAttach(
+                new NotSupportedException("remote_audio_transport_unavailable")),
+            "already-attached" => CreateSessionThrowingOnAttach(
+                new InvalidOperationException("already attached")),
+            _ => throw new ArgumentOutOfRangeException(nameof(failureCase), failureCase, null),
+        };
+        var resolver = RecordingVoiceSessionResolver.Attached(session);
+        var socket = new FakeWebSocket(WebSocketState.Open);
+        using var app = CreatePolicyAwareApp(
+            policyPort,
+            new RecordingCatalogQueryPort(allowedActorIds: ["voice-agent-lark"]),
+            resolver);
+        var context = CreateVoiceContext(app, "/ws/voice?channel=lark");
+        var wsFeature = new FakeHttpWebSocketFeature(socket);
+        context.Features.Set<IHttpWebSocketFeature>(wsFeature);
+
+        await GetEndpoint(app, "/ws/voice").RequestDelegate!(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        wsFeature.AcceptCalls.Should().Be(1);
+        socket.CloseCalls.Should().ContainSingle()
+            .Which.Should().Be((WebSocketCloseStatus.PolicyViolation, expectedCloseReason));
+    }
+
     [Fact]
     public async Task BypassVoiceEndpoint_WithoutDevScope_ShouldReturnUnauthorized()
     {
@@ -273,6 +351,14 @@ public sealed class PolicyAwareVoiceEndpointsTests
 
                 return Task.CompletedTask;
             },
+            detachTransportAsync: static (_, _) => Task.CompletedTask,
+            pcmSampleRateHz: 24000);
+
+    private static VoicePresenceSession CreateSessionThrowingOnAttach(Exception exception) =>
+        new(
+            isInitialized: static () => true,
+            isTransportAttached: static () => false,
+            attachTransportAsync: (_, _) => Task.FromException(exception),
             detachTransportAsync: static (_, _) => Task.CompletedTask,
             pcmSampleRateHz: 24000);
 

--- a/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
+++ b/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
@@ -72,7 +72,11 @@ public sealed class PolicyAwareVoiceEndpointsTests
                 },
             ]));
         var catalog = new RecordingCatalogQueryPort(allowedActorIds: ["voice-agent-lark"]);
-        var resolver = RecordingVoiceSessionResolver.Attached(CreateSessionCompletingOnAttach());
+        var attachedTransports = new List<IVoiceTransport>();
+        var detachedTransports = new List<IVoiceTransport?>();
+        var resolver = RecordingVoiceSessionResolver.Attached(CreateSessionCompletingOnAttach(
+            attachedTransports,
+            detachedTransports));
         var socket = new FakeWebSocket(WebSocketState.Open);
         using var app = CreatePolicyAwareApp(policyPort, catalog, resolver);
         var context = CreateVoiceContext(app, "/ws/voice?channel=lark&registration_scope_id=bot-1&sender_id=sender-1");
@@ -89,6 +93,9 @@ public sealed class PolicyAwareVoiceEndpointsTests
                 "voice-agent-lark",
                 "voice_presence_openai",
                 VoicePresenceSessionRequestPurpose.Attach));
+        attachedTransports.Should().ContainSingle();
+        detachedTransports.Should().ContainSingle()
+            .Which.Should().BeSameAs(attachedTransports.Single());
     }
 
     [Theory]
@@ -340,18 +347,25 @@ public sealed class PolicyAwareVoiceEndpointsTests
             detachTransportAsync: static (_, _) => Task.CompletedTask,
             pcmSampleRateHz: 24000);
 
-    private static VoicePresenceSession CreateSessionCompletingOnAttach() =>
+    private static VoicePresenceSession CreateSessionCompletingOnAttach(
+        List<IVoiceTransport>? attachedTransports = null,
+        List<IVoiceTransport?>? detachedTransports = null) =>
         new(
             isInitialized: static () => true,
             isTransportAttached: static () => false,
-            attachTransportAsync: static (transport, _) =>
+            attachTransportAsync: (transport, _) =>
             {
+                attachedTransports?.Add(transport);
                 if (transport is IAsyncDisposable disposable)
                     return disposable.DisposeAsync().AsTask();
 
                 return Task.CompletedTask;
             },
-            detachTransportAsync: static (_, _) => Task.CompletedTask,
+            detachTransportAsync: (transport, _) =>
+            {
+                detachedTransports?.Add(transport);
+                return Task.CompletedTask;
+            },
             pcmSampleRateHz: 24000);
 
     private static VoicePresenceSession CreateSessionThrowingOnAttach(Exception exception) =>

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/VoiceDemoAgentCommandPortTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/VoiceDemoAgentCommandPortTests.cs
@@ -1,5 +1,3 @@
-using System.Security.Cryptography;
-using System.Text;
 using Aevatar.AI.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.NyxidChat;
@@ -23,7 +21,7 @@ public sealed class VoiceDemoAgentCommandPortTests
         var dispatchPort = new RecordingActorDispatchPort();
         using var provider = CreateProvider(actorRuntime, dispatchPort);
         var commandPort = provider.GetRequiredService<IVoiceDemoAgentCommandPort>();
-        var expectedActorId = BuildExpectedDemoActorId("scope-1");
+        var expectedActorId = NyxIdChatServiceDefaults.BuildVoiceDemoActorId("scope-1");
 
         var receipt = await commandPort.EnsureAsync(" scope-1 ", " voice_presence_openai ");
 
@@ -72,11 +70,28 @@ public sealed class VoiceDemoAgentCommandPortTests
             .WithParameterName(expectedParameterName);
     }
 
-    private static string BuildExpectedDemoActorId(string scopeId)
+    [Fact]
+    public void BuildVoiceDemoActorId_ShouldTrimScopeAndReturnDeterministicNyxIdChatActorId()
     {
-        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(scopeId.Trim()));
-        var hash = Convert.ToHexString(bytes)[..16].ToLowerInvariant();
-        return $"{NyxIdChatServiceDefaults.ActorIdPrefix}-voice-demo-{hash}";
+        var first = NyxIdChatServiceDefaults.BuildVoiceDemoActorId(" scope-1 ");
+        var second = NyxIdChatServiceDefaults.BuildVoiceDemoActorId("scope-1");
+
+        first.Should().Be(second);
+        first.Should().StartWith($"{NyxIdChatServiceDefaults.ActorIdPrefix}-voice-demo-");
+        first.Should().HaveLength($"{NyxIdChatServiceDefaults.ActorIdPrefix}-voice-demo-".Length + 16);
+        first.Should().MatchRegex("^nyxid-chat-voice-demo-[0-9a-f]{16}$");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BuildVoiceDemoActorId_ShouldRejectMissingScope(string? scopeId)
+    {
+        var act = () => NyxIdChatServiceDefaults.BuildVoiceDemoActorId(scopeId!);
+
+        act.Should().Throw<ArgumentException>()
+            .WithParameterName("scopeId");
     }
 
     private static ServiceProvider CreateProvider(

--- a/test/Aevatar.Hosting.Tests/VoiceDemoBootstrapEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/VoiceDemoBootstrapEndpointsTests.cs
@@ -47,7 +47,7 @@ public sealed class VoiceDemoBootstrapEndpointsTests
                     RuleId = "voice-demo",
                     Priority = 900,
                     Match = new ChatRouteMatch { SourceKind = ChatSourceKind.Voice },
-                    Action = GAgentToolHint("old-agent", "voice_presence_openai"),
+                    Action = TypedVoiceAttachTarget("old-agent", "voice_presence_openai"),
                     Description = "remove stale voice demo rule",
                 },
             ]);
@@ -122,21 +122,8 @@ public sealed class VoiceDemoBootstrapEndpointsTests
         body.Should().ContainKey("route_policy_command_id").WhoseValue.Should().BeNull();
     }
 
-    private static ChatRouteAction GAgentToolHint(string actorId, string voiceModuleName) => new()
-    {
-        ForwardToModel = new ForwardToModel
-        {
-            ToolSetRef = new ChatRouteToolSetRef { Name = "workspace.default" },
-                ToolChoiceHint = new ChatRouteToolChoiceHint
-                {
-                    VoiceAttachTarget = new ChatRouteVoiceAttachTarget
-                    {
-                        ActorId = actorId,
-                        VoiceModuleName = voiceModuleName,
-                    },
-                },
-            },
-    };
+    private static ChatRouteAction TypedVoiceAttachTarget(string actorId, string voiceModuleName) =>
+        ChatRouteActionTargets.ForwardToVoiceAttachTarget(actorId, voiceModuleName);
 
     private static async Task<WebApplication> CreateAppAsync(
         RecordingVoiceDemoAgentCommandPort voiceDemoCommandPort,

--- a/test/Aevatar.Hosting.Tests/VoiceDemoBootstrapEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/VoiceDemoBootstrapEndpointsTests.cs
@@ -9,7 +9,6 @@ using Aevatar.GAgents.Scheduled;
 using Aevatar.Hosting;
 using Aevatar.Mainnet.Host.Api.Voice;
 using FluentAssertions;
-using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -90,8 +89,10 @@ public sealed class VoiceDemoBootstrapEndpointsTests
         command.DefaultTarget.ForwardToModel.ModelName.Should().Be("existing-default");
         command.Rules.Should().ContainSingle(rule => rule.RuleId == "keep-chat")
             .Which.Action.ForwardToModel.ModelName.Should().Be("kept-model");
-        command.Rules.Should().NotContain(rule => rule.RuleId == "voice-demo",
-            "Refactor (issue1321-first): bootstrap removes the stale route that used tool_choice_hint as actor addressing");
+        var voiceRule = command.Rules.Should().ContainSingle(rule => rule.RuleId == "voice-demo").Subject;
+        voiceRule.Action.ForwardToModel.ToolChoiceHint.VoiceAttachTarget.ActorId.Should().Be(demoActorId);
+        voiceRule.Action.ForwardToModel.ToolChoiceHint.VoiceAttachTarget.VoiceModuleName.Should().Be("voice_presence_openai");
+        voiceRule.Action.ForwardToModel.ToolChoiceHint.PrefilledArguments.Should().BeNull();
     }
 
     [Fact]
@@ -116,8 +117,7 @@ public sealed class VoiceDemoBootstrapEndpointsTests
             .Which.Should().Be((Scope, "voice_presence_openai"));
         catalogCommandPort.Commands.Should().ContainSingle()
             .Which.AgentId.Should().Be(RecordingVoiceDemoAgentCommandPort.DemoActorId);
-        routePolicyCommandPort.Upserts.Should().BeEmpty(
-            "bootstrap must not create a placeholder route policy for unsupported voice realtime execution");
+        routePolicyCommandPort.Upserts.Should().BeEmpty();
         body.Should().ContainKey("route_policy_actor_id").WhoseValue.Should().BeNull();
         body.Should().ContainKey("route_policy_command_id").WhoseValue.Should().BeNull();
     }
@@ -127,19 +127,15 @@ public sealed class VoiceDemoBootstrapEndpointsTests
         ForwardToModel = new ForwardToModel
         {
             ToolSetRef = new ChatRouteToolSetRef { Name = "workspace.default" },
-            ToolChoiceHint = new ChatRouteToolChoiceHint
-            {
-                ToolName = "aevatar_invoke_gagent",
-                PrefilledArguments = new Struct
+                ToolChoiceHint = new ChatRouteToolChoiceHint
                 {
-                    Fields =
+                    VoiceAttachTarget = new ChatRouteVoiceAttachTarget
                     {
-                        ["actor_id"] = Google.Protobuf.WellKnownTypes.Value.ForString(actorId),
-                        ["voice_module_name"] = Google.Protobuf.WellKnownTypes.Value.ForString(voiceModuleName),
+                        ActorId = actorId,
+                        VoiceModuleName = voiceModuleName,
                     },
                 },
             },
-        },
     };
 
     private static async Task<WebApplication> CreateAppAsync(


### PR DESCRIPTION
## 摘要

closes #674(Phase 9 r3 hybrid-minimal-structural-delete 共识落地)。

### Old
`/ws/voice` 的 attach target(`actor_id + voice_module_name`)塞进 `ForwardToModel.ToolChoiceHint.PrefilledArguments` 的 `Struct` 字符串 key,voice endpoint 依赖 generic bag 判断 VoicePresence attach vs 真正 model forward。

### New
`ChatRouteToolChoiceHint` 新增 typed `ChatRouteVoiceAttachTarget voice_attach_target = 3`(actor_id + voice_module_name);`/ws/voice` endpoint + voice bootstrap writer + demo bootstrap typed-first,删 voice `Struct` actor/module key 路径。保持 ADR-0026 `ForwardToModel/Reject` action set,**不新增**顶层 route action / actor type / envelope kind / pipeline phase。

违反:CLAUDE.md「字段命名与 Metadata 决策树」:核心语义不应塞通用 bag。

## 范围

12 files changed (+299/-81)。包含 proto + Core helper + Voice endpoints(PolicyAware / Bootstrap)+ Demo bootstrap + NyxidChat agent commit port + ADR-0025/0026 docs sync。

## Stacked-PR

Base = `auto-refact-dev`。

🤖 Auto-loop / codex-refactor-loop Phase 9 r3 consensus #674

⟦AI:AUTO-LOOP⟧
