### PR TITLE
refactor(issue1378): 删除 Lark reply/react 当前消息 bypass(first-slice)

### DIFF
--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReactTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReactTool.cs
@@ -16,24 +16,30 @@ public sealed class LarkMessagesReactTool : AgentToolBase<LarkMessagesReactTool.
 
     public override string Description =>
         "Add an emoji reaction to a Lark message. " +
-        "On a channel relay turn you can omit message_id to react to the current inbound message. " +
+        "Requires an explicit external message_id; current relay replies must be sent as the final answer. " +
         "Defaults to emoji_type=OK (an acknowledgement like '了解').";
 
     public override ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;
 
+    // Refactor (issue1378/first-slice): Old: ResolveOrCurrent bypass for reply/react silently
+    // resolved missing message_id to "current message", masking caller errors.
+    // New: explicit structured error on missing message_id; explicit external tools path
+    // remains for legitimate cross-message replies.
     protected override async Task<string> ExecuteAsync(Parameters parameters, CancellationToken ct)
     {
         var token = AgentToolRequestContext.NyxIdAccessToken;
         if (string.IsNullOrWhiteSpace(token))
             return LarkProxyResponseParser.Serialize(new { success = false, error = "No NyxID access token available. User must be authenticated." });
 
-        var messageId = LarkMessageIdResolver.ResolveOrCurrent(parameters.MessageId, out var usedCurrentMessage, out var messageError);
+        var messageId = LarkMessageIdResolver.ResolveExplicit(parameters.MessageId, out var messageError);
         if (!string.IsNullOrWhiteSpace(messageError))
         {
             return LarkProxyResponseParser.Serialize(new
             {
                 success = false,
+                code = "missing_message_id",
                 error = messageError,
+                recommended_action = "final_answer",
             });
         }
 
@@ -64,7 +70,6 @@ public sealed class LarkMessagesReactTool : AgentToolBase<LarkMessagesReactTool.
             operator_id = result.OperatorId,
             operator_type = result.OperatorType,
             action_time = result.ActionTime,
-            used_current_message = usedCurrentMessage ? (bool?)true : null,
         });
     }
 

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReactTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReactTool.cs
@@ -21,11 +21,9 @@ public sealed class LarkMessagesReactTool : AgentToolBase<LarkMessagesReactTool.
 
     public override ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;
 
-    // Refactor (issue1378/first-slice): Old pattern: ResolveOrCurrent fell back to current
-    // message when reaction message_id was missing, masking caller errors silently.
-    // New principle: explicit structured error on missing message_id; explicit external
-    // tools path
-    // remains for legitimate cross-message replies.
+    // Refactor (issue1378/first-slice):
+    // Old: ResolveOrCurrent used current message when reaction message_id was missing.
+    // New: missing reaction message_id returns structured error; external tools path remains.
     protected override async Task<string> ExecuteAsync(Parameters parameters, CancellationToken ct)
     {
         var token = AgentToolRequestContext.NyxIdAccessToken;

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReactTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReactTool.cs
@@ -22,8 +22,8 @@ public sealed class LarkMessagesReactTool : AgentToolBase<LarkMessagesReactTool.
     public override ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;
 
     // Refactor (issue1378/first-slice):
-    // Old: ResolveOrCurrent used current message when reaction message_id was missing.
-    // New: missing reaction message_id returns structured error; external tools path remains.
+    //   Old pattern: ResolveOrCurrent used current message when reaction message_id was missing.
+    //   New principle: missing reaction message_id returns structured error; external tools path remains.
     protected override async Task<string> ExecuteAsync(Parameters parameters, CancellationToken ct)
     {
         var token = AgentToolRequestContext.NyxIdAccessToken;

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReactTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReactTool.cs
@@ -21,9 +21,10 @@ public sealed class LarkMessagesReactTool : AgentToolBase<LarkMessagesReactTool.
 
     public override ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;
 
-    // Refactor (issue1378/first-slice): Old: ResolveOrCurrent bypass for reply/react silently
-    // resolved missing message_id to "current message", masking caller errors.
-    // New: explicit structured error on missing message_id; explicit external tools path
+    // Refactor (issue1378/first-slice): Old pattern: ResolveOrCurrent fell back to current
+    // message when reaction message_id was missing, masking caller errors silently.
+    // New principle: explicit structured error on missing message_id; explicit external
+    // tools path
     // remains for legitimate cross-message replies.
     protected override async Task<string> ExecuteAsync(Parameters parameters, CancellationToken ct)
     {

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReplyTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReplyTool.cs
@@ -17,20 +17,32 @@ public sealed class LarkMessagesReplyTool : AgentToolBase<LarkMessagesReplyTool.
 
     public override string Description =>
         "Reply to a specific Lark message through Nyx-backed transport. " +
-        "On a channel relay turn you can omit message_id to reply to the current inbound Lark message. " +
+        "Requires an explicit external message_id; current relay replies must be sent as the final answer. " +
         "Supports text replies and interactive cards.";
 
     public override ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;
 
+    // Refactor (issue1378/first-slice): Old: ResolveOrCurrent bypass for reply/react silently
+    // resolved missing message_id to "current message", masking caller errors.
+    // New: explicit structured error on missing message_id; explicit external tools path
+    // remains for legitimate cross-message replies.
     protected override async Task<string> ExecuteAsync(Parameters parameters, CancellationToken ct)
     {
         var token = AgentToolRequestContext.NyxIdAccessToken;
         if (string.IsNullOrWhiteSpace(token))
             return LarkProxyResponseParser.Serialize(new { success = false, error = "No NyxID access token available. User must be authenticated." });
 
-        var messageId = LarkMessageIdResolver.ResolveOrCurrent(parameters.MessageId, out var usedCurrentMessage, out var messageError);
+        var messageId = LarkMessageIdResolver.ResolveExplicit(parameters.MessageId, out var messageError);
         if (!string.IsNullOrWhiteSpace(messageError))
-            return LarkProxyResponseParser.Serialize(new { success = false, error = messageError });
+        {
+            return LarkProxyResponseParser.Serialize(new
+            {
+                success = false,
+                code = "missing_message_id",
+                error = messageError,
+                recommended_action = "final_answer",
+            });
+        }
 
         var normalizedMessageType = NormalizeMessageType(parameters.MessageType);
         if (normalizedMessageType is null)
@@ -97,7 +109,6 @@ public sealed class LarkMessagesReplyTool : AgentToolBase<LarkMessagesReplyTool.
             chat_id = result.ChatId,
             create_time = result.CreateTime,
             reply_in_thread = parameters.ReplyInThread ?? false,
-            used_current_message = usedCurrentMessage ? (bool?)true : null,
         });
     }
 

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReplyTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReplyTool.cs
@@ -23,8 +23,8 @@ public sealed class LarkMessagesReplyTool : AgentToolBase<LarkMessagesReplyTool.
     public override ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;
 
     // Refactor (issue1378/first-slice):
-    // Old: ResolveOrCurrent used current message when reply message_id was missing.
-    // New: missing reply message_id returns structured error; external tools path remains.
+    //   Old pattern: ResolveOrCurrent used current message when reply message_id was missing.
+    //   New principle: missing reply message_id returns structured error; external tools path remains.
     protected override async Task<string> ExecuteAsync(Parameters parameters, CancellationToken ct)
     {
         var token = AgentToolRequestContext.NyxIdAccessToken;

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReplyTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReplyTool.cs
@@ -22,9 +22,10 @@ public sealed class LarkMessagesReplyTool : AgentToolBase<LarkMessagesReplyTool.
 
     public override ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;
 
-    // Refactor (issue1378/first-slice): Old: ResolveOrCurrent bypass for reply/react silently
-    // resolved missing message_id to "current message", masking caller errors.
-    // New: explicit structured error on missing message_id; explicit external tools path
+    // Refactor (issue1378/first-slice): Old pattern: ResolveOrCurrent fell back to current
+    // message when reply message_id was missing, masking caller errors silently.
+    // New principle: explicit structured error on missing message_id; explicit external
+    // tools path
     // remains for legitimate cross-message replies.
     protected override async Task<string> ExecuteAsync(Parameters parameters, CancellationToken ct)
     {

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReplyTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReplyTool.cs
@@ -22,11 +22,9 @@ public sealed class LarkMessagesReplyTool : AgentToolBase<LarkMessagesReplyTool.
 
     public override ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;
 
-    // Refactor (issue1378/first-slice): Old pattern: ResolveOrCurrent fell back to current
-    // message when reply message_id was missing, masking caller errors silently.
-    // New principle: explicit structured error on missing message_id; explicit external
-    // tools path
-    // remains for legitimate cross-message replies.
+    // Refactor (issue1378/first-slice):
+    // Old: ResolveOrCurrent used current message when reply message_id was missing.
+    // New: missing reply message_id returns structured error; external tools path remains.
     protected override async Task<string> ExecuteAsync(Parameters parameters, CancellationToken ct)
     {
         var token = AgentToolRequestContext.NyxIdAccessToken;

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkToolHelpers.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkToolHelpers.cs
@@ -9,8 +9,8 @@ internal static class LarkMessageIdResolver
     private const string ChannelPlatformMessageIdKey = "channel.platform_message_id";
 
     // Refactor (issue1378/first-slice):
-    // Old: ResolveOrCurrent used current message when explicit message_id was missing.
-    // New: ResolveExplicit returns structured error; external tools path remains.
+    //   Old pattern: ResolveOrCurrent used current message when explicit message_id was missing.
+    //   New principle: ResolveExplicit returns structured error; external tools path remains.
     public static string? ResolveExplicit(string? messageId, out string? error)
     {
         error = null;

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkToolHelpers.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkToolHelpers.cs
@@ -8,9 +8,10 @@ internal static class LarkMessageIdResolver
     private const string ChannelMessageIdKey = "channel.message_id";
     private const string ChannelPlatformMessageIdKey = "channel.platform_message_id";
 
-    // Refactor (issue1378/first-slice): Old: ResolveOrCurrent bypass for reply/react silently
-    // resolved missing message_id to "current message", masking caller errors.
-    // New: explicit structured error on missing message_id; explicit external tools path
+    // Refactor (issue1378/first-slice): Old pattern: ResolveOrCurrent fell back to current
+    // message when explicit-tool message_id was missing, masking caller errors silently.
+    // New principle: explicit structured error on missing message_id; explicit external
+    // tools path
     // remains for legitimate cross-message replies.
     public static string? ResolveExplicit(string? messageId, out string? error)
     {

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkToolHelpers.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkToolHelpers.cs
@@ -8,6 +8,23 @@ internal static class LarkMessageIdResolver
     private const string ChannelMessageIdKey = "channel.message_id";
     private const string ChannelPlatformMessageIdKey = "channel.platform_message_id";
 
+    // Refactor (issue1378/first-slice): Old: ResolveOrCurrent bypass for reply/react silently
+    // resolved missing message_id to "current message", masking caller errors.
+    // New: explicit structured error on missing message_id; explicit external tools path
+    // remains for legitimate cross-message replies.
+    public static string? ResolveExplicit(string? messageId, out string? error)
+    {
+        error = null;
+
+        if (TryValidate(messageId, out var explicitMessageId, out var explicitError))
+            return explicitMessageId;
+
+        error = !string.IsNullOrWhiteSpace(explicitError)
+            ? explicitError
+            : "message_id is required";
+        return null;
+    }
+
     public static string? ResolveOrCurrent(string? messageId, out bool usedCurrentMessage, out string? error)
     {
         usedCurrentMessage = false;

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkToolHelpers.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkToolHelpers.cs
@@ -8,11 +8,9 @@ internal static class LarkMessageIdResolver
     private const string ChannelMessageIdKey = "channel.message_id";
     private const string ChannelPlatformMessageIdKey = "channel.platform_message_id";
 
-    // Refactor (issue1378/first-slice): Old pattern: ResolveOrCurrent fell back to current
-    // message when explicit-tool message_id was missing, masking caller errors silently.
-    // New principle: explicit structured error on missing message_id; explicit external
-    // tools path
-    // remains for legitimate cross-message replies.
+    // Refactor (issue1378/first-slice):
+    // Old: ResolveOrCurrent used current message when explicit message_id was missing.
+    // New: ResolveExplicit returns structured error; external tools path remains.
     public static string? ResolveExplicit(string? messageId, out string? error)
     {
         error = null;

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
@@ -164,10 +164,9 @@ public class LarkToolsTests
     }
 
     [Fact]
-    // Refactor (issue1378/first-slice): Old: ResolveOrCurrent bypass for reply/react silently
-    // resolved missing message_id to "current message", masking caller errors.
-    // New: explicit structured error on missing message_id; explicit external tools path
-    // remains for legitimate cross-message replies.
+    // Refactor (issue1378/first-slice):
+    //   Old pattern: ResolveOrCurrent hid missing message_id by replying to the current message.
+    //   New principle: reply tests require structured error and explicit external message_id.
     public async Task LarkMessagesReplyTool_ShouldRejectMissingMessageId_AndKeepExplicitExternalReply()
     {
         var client = new StubLarkNyxClient
@@ -246,10 +245,9 @@ public class LarkToolsTests
     }
 
     [Fact]
-    // Refactor (issue1378/first-slice): Old: ResolveOrCurrent bypass for reply/react silently
-    // resolved missing message_id to "current message", masking caller errors.
-    // New: explicit structured error on missing message_id; explicit external tools path
-    // remains for legitimate cross-message replies.
+    // Refactor (issue1378/first-slice):
+    //   Old pattern: ResolveOrCurrent hid missing message_id by reacting to the current message.
+    //   New principle: reaction tests require structured error and explicit external message_id.
     public async Task LarkMessagesReactTool_ShouldRejectMissingMessageId_AndKeepExplicitExternalReaction()
     {
         var client = new StubLarkNyxClient

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
@@ -164,7 +164,11 @@ public class LarkToolsTests
     }
 
     [Fact]
-    public async Task LarkMessagesReplyTool_ShouldDefaultToCurrentMessage_AndReplyInThread()
+    // Refactor (issue1378/first-slice): Old: ResolveOrCurrent bypass for reply/react silently
+    // resolved missing message_id to "current message", masking caller errors.
+    // New: explicit structured error on missing message_id; explicit external tools path
+    // remains for legitimate cross-message replies.
+    public async Task LarkMessagesReplyTool_ShouldRejectMissingMessageId_AndKeepExplicitExternalReply()
     {
         var client = new StubLarkNyxClient
         {
@@ -179,15 +183,25 @@ public class LarkToolsTests
                 ["channel.platform_message_id"] = "om_current_2",
             });
 
-        var result = await tool.ExecuteAsync("""{"text":"收到，我继续看一下","reply_in_thread":true}""");
+        var missingResult = await tool.ExecuteAsync("""{"text":"收到，我继续看一下","reply_in_thread":true}""");
+        using (var missingDocument = JsonDocument.Parse(missingResult))
+        {
+            missingDocument.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+            missingDocument.RootElement.GetProperty("code").GetString().Should().Be("missing_message_id");
+            missingDocument.RootElement.GetProperty("error").GetString().Should().Be("message_id is required");
+            missingDocument.RootElement.GetProperty("recommended_action").GetString().Should().Be("final_answer");
+        }
+
+        client.LastReplyRequest.Should().BeNull();
+
+        var result = await tool.ExecuteAsync("""{"message_id":"om_external_2","text":"收到，我继续看一下","reply_in_thread":true}""");
 
         using var document = JsonDocument.Parse(result);
         document.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
         document.RootElement.GetProperty("message_id").GetString().Should().Be("om_reply_1");
         document.RootElement.GetProperty("reply_in_thread").GetBoolean().Should().BeTrue();
-        document.RootElement.GetProperty("used_current_message").GetBoolean().Should().BeTrue();
         client.LastReplyRequest.Should().NotBeNull();
-        client.LastReplyRequest!.MessageId.Should().Be("om_current_2");
+        client.LastReplyRequest!.MessageId.Should().Be("om_external_2");
         client.LastReplyRequest.ReplyInThread.Should().BeTrue();
         client.LastReplyRequest.MessageType.Should().Be("text");
     }
@@ -232,7 +246,11 @@ public class LarkToolsTests
     }
 
     [Fact]
-    public async Task LarkMessagesReactTool_ShouldDefaultToCurrentMessage_AndOkEmoji()
+    // Refactor (issue1378/first-slice): Old: ResolveOrCurrent bypass for reply/react silently
+    // resolved missing message_id to "current message", masking caller errors.
+    // New: explicit structured error on missing message_id; explicit external tools path
+    // remains for legitimate cross-message replies.
+    public async Task LarkMessagesReactTool_ShouldRejectMissingMessageId_AndKeepExplicitExternalReaction()
     {
         var client = new StubLarkNyxClient
         {
@@ -263,16 +281,26 @@ public class LarkToolsTests
                 ["channel.message_id"] = "om_current_1",
             });
 
-        var result = await tool.ExecuteAsync("""{}""");
+        var missingResult = await tool.ExecuteAsync("""{}""");
+        using (var missingDocument = JsonDocument.Parse(missingResult))
+        {
+            missingDocument.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+            missingDocument.RootElement.GetProperty("code").GetString().Should().Be("missing_message_id");
+            missingDocument.RootElement.GetProperty("error").GetString().Should().Be("message_id is required");
+            missingDocument.RootElement.GetProperty("recommended_action").GetString().Should().Be("final_answer");
+        }
+
+        client.LastReactionRequest.Should().BeNull();
+
+        var result = await tool.ExecuteAsync("""{"message_id":"om_external_1"}""");
 
         using var document = JsonDocument.Parse(result);
         document.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
-        document.RootElement.GetProperty("message_id").GetString().Should().Be("om_current_1");
+        document.RootElement.GetProperty("message_id").GetString().Should().Be("om_external_1");
         document.RootElement.GetProperty("emoji_type").GetString().Should().Be("OK");
         document.RootElement.GetProperty("reaction_id").GetString().Should().Be("reaction_123");
-        document.RootElement.GetProperty("used_current_message").GetBoolean().Should().BeTrue();
         client.LastReactionRequest.Should().NotBeNull();
-        client.LastReactionRequest!.MessageId.Should().Be("om_current_1");
+        client.LastReactionRequest!.MessageId.Should().Be("om_external_1");
         client.LastReactionRequest.EmojiType.Should().Be("OK");
     }
 
@@ -302,7 +330,7 @@ public class LarkToolsTests
                    }))
         {
             (await tool.ExecuteAsync("""{}"""))
-                .Should().Contain("Current turn metadata did not expose a Lark platform message_id");
+                .Should().Contain("message_id is required");
         }
 
         var errorTool = new LarkMessagesReactTool(new StubLarkNyxClient


### PR DESCRIPTION
## 摘要

来源:#393 Phase 9 r1 split first-slice consensus(3/3 unanimous propose)。

删除 Lark `reply` / `react` 工具对**当前消息**的 bypass:
- 之前 `ResolveOrCurrent` 在 `message_id` 缺失时默默 fallback 到当前消息 → 调用方错误被掩盖。
- 现在 `message_id` 缺失返回结构化 error(显式不允许),保留 explicit external tools 路径。

不新增 actor / envelope / proto / canon。`typed-reply-delivery-mode` 的 design 留 #393 later-slice 处理。

## 范围

4 files changed (+78/-17):
- `src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReplyTool.cs`
- `src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReactTool.cs`
- `src/Aevatar.AI.ToolProviders.Lark/Tools/LarkToolHelpers.cs`
- `test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs`

implement codex 本地 `dotnet build aevatar.slnx --nologo` 绿 + `dotnet test` 相关 module 通过(per SKILL hard rule 10)。

## 关联

- closes #1378
- refs #393(first-slice;later-slice typed-reply-delivery-mode 设计待 Phase 9)

## Stacked-PR

base = `auto-refact-dev`。本 PR merge 后 #1378 自动 close。

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
