### PR TITLE
refactor(issue1318): unbound sender disable tools + unknown slash gate /init(first-slice)

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
@@ -536,8 +536,12 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         if (stepState.PendingToolCalls.Count > 0)
             return false;
 
+        // Refactor (issue1318/first-slice): Old: unbound sender still saw tool dispatch + unknown
+        // slash silently consumed.
+        // New: unbound sender disables tool dispatch; unknown slash gates to /init bootstrap;
+        // non-slash text path unchanged (owner-LLM chat fallback).
         if (stepState.FinalNoToolsStep)
-            return true;
+            return isCompletedLlmStep;
 
         if (isCompletedLlmStep && string.IsNullOrWhiteSpace(stepState.AccumulatedText))
             return true;

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs
@@ -77,10 +77,11 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
             var generator = RequireStepGenerator();
             var plan = await generator.BuildStepPlanAsync(
                     replyRequest.Activity!,
-                    generationContext.Metadata,
-                    generationContext.LlmControl,
-                    generationContext.ToolContext,
-                    metadataCts.Token)
+                generationContext.Metadata,
+                generationContext.LlmControl,
+                generationContext.ToolContext,
+                forceDisableTools: false,
+                metadataCts.Token)
                 .ConfigureAwait(false);
 
             var state = new AgentRunReplyStepState
@@ -92,6 +93,11 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
                 NextStepIndex = 1,
                 Round = 0,
                 MaxToolRounds = plan.MaxToolRounds,
+                // Refactor (issue1318/first-slice): Old: unbound sender still saw tool dispatch + unknown
+                // slash silently consumed.
+                // New: unbound sender disables tool dispatch; unknown slash gates to /init bootstrap;
+                // non-slash text path unchanged (owner-LLM chat fallback).
+                FinalNoToolsStep = plan.DisableTools,
                 LlmControl = plan.LlmControl.ToPayload(),
                 ToolContext = plan.ToolContext.ToPayload(),
             };
@@ -167,11 +173,21 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
         using TurnStreamingReplySink? streamingSink = TryBuildStreamingSink(request, request.TargetActorId);
         var streamingState = TryBuildStreamingReplyState(streamingSink);
         var generator = RequireStepGenerator();
+        var planToolContext = AgentRunReplyStepMappers.ToolContextFromProto(workItem.StepState);
+        if (workItem.StepState.FinalNoToolsStep)
+        {
+            // Refactor (issue1318/first-slice): Old: unbound sender still saw tool dispatch + unknown
+            // slash silently consumed.
+            // New: unbound sender disables tool dispatch; unknown slash gates to /init bootstrap;
+            // non-slash text path unchanged (owner-LLM chat fallback).
+            planToolContext = planToolContext with { SenderBinding = AgentToolSenderBindingContext.Empty };
+        }
         var plan = await generator.BuildStepPlanAsync(
                 request.Activity!,
                 AgentRunReplyStepMappers.ToDictionary(workItem.StepState.ExternalMetadata),
                 AgentRunReplyStepMappers.LlmControlFromProto(workItem.StepState),
-                AgentRunReplyStepMappers.ToolContextFromProto(workItem.StepState),
+                planToolContext,
+                workItem.StepState.FinalNoToolsStep,
                 ct)
             .ConfigureAwait(false);
         var messages = workItem.StepState.Messages.Select(AgentRunReplyStepMappers.FromProto).ToList();
@@ -183,6 +199,28 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
             plan.LlmControl,
             workItem.StepState.Round,
             workItem.StepState.FinalNoToolsStep);
+        if (workItem.StepState.FinalNoToolsStep && llmRequest.Tools is { Count: > 0 })
+        {
+            // Refactor (issue1318/first-slice): Old: unbound sender still saw tool dispatch + unknown
+            // slash silently consumed.
+            // New: unbound sender disables tool dispatch; unknown slash gates to /init bootstrap;
+            // non-slash text path unchanged (owner-LLM chat fallback).
+            llmRequest = new LLMRequest
+            {
+                Messages = llmRequest.Messages,
+                RequestId = llmRequest.RequestId,
+                Metadata = llmRequest.Metadata,
+                CallerContext = llmRequest.CallerContext,
+                ToolContext = llmRequest.ToolContext,
+                RoutingContext = llmRequest.RoutingContext,
+                LlmControl = llmRequest.LlmControl,
+                Tools = null,
+                Model = llmRequest.Model,
+                Temperature = llmRequest.Temperature,
+                MaxTokens = llmRequest.MaxTokens,
+                ResponseFormat = llmRequest.ResponseFormat,
+            };
+        }
 
         var output = new StringBuilder(workItem.StepState.AccumulatedText ?? string.Empty);
         using var interactiveScope = TryBeginInteractiveScope(request);
@@ -202,8 +240,14 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
         if (streamingState is not null)
             await streamingState.FinalizeAsync(output.ToString(), ct).ConfigureAwait(false);
 
+        // Refactor (issue1318/first-slice): Old: unbound sender still saw tool dispatch + unknown
+        // slash silently consumed.
+        // New: unbound sender disables tool dispatch; unknown slash gates to /init bootstrap;
+        // non-slash text path unchanged (owner-LLM chat fallback).
         var effectiveContent = llmResult.Content;
-        var effectiveToolCalls = llmResult.ToolCalls;
+        var effectiveToolCalls = workItem.StepState.FinalNoToolsStep
+            ? []
+            : llmResult.ToolCalls;
         if (effectiveToolCalls is not { Count: > 0 } && !workItem.StepState.FinalNoToolsStep && effectiveContent is not null)
         {
             var parsed = TextToolCallParser.Parse(effectiveContent);
@@ -255,6 +299,7 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
                 AgentRunReplyStepMappers.ToDictionary(workItem.StepState.ExternalMetadata),
                 AgentRunReplyStepMappers.LlmControlFromProto(workItem.StepState),
                 AgentRunReplyStepMappers.ToolContextFromProto(workItem.StepState),
+                forceDisableTools: false,
                 ct)
             .ConfigureAwait(false);
         var toolCalls = workItem.StepState.PendingToolCalls.Select(AgentRunReplyStepMappers.FromProto).ToArray();

--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -49,6 +49,16 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
 
     private sealed record ResolvedSenderBinding(string BindingId, ExternalSubjectRef Subject);
 
+    // Refactor (issue1318/first-slice): Old: unbound sender still saw tool dispatch + unknown
+    // slash silently consumed.
+    // New: unbound sender disables tool dispatch; unknown slash gates to /init bootstrap;
+    // non-slash text path unchanged (owner-LLM chat fallback).
+    private sealed record SlashBindingLookup(
+        bool IdentityEnabled,
+        bool SubjectResolved,
+        ExternalSubjectRef? Subject,
+        BindingId? BindingId);
+
     private readonly IServiceProvider _toolServiceProvider;
     private readonly IChannelBotRegistrationQueryPort _registrationQueryPort;
     private readonly IChannelBotRegistrationQueryByNyxIdentityPort? _registrationQueryByNyxIdentityPort;
@@ -214,74 +224,33 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         }
 
         var handler = ResolveSlashCommandHandler(commandName);
+        var bindingLookup = await ResolveSlashBindingAsync(commandName, inbound, registration, queryPort, ct)
+            .ConfigureAwait(false);
+
         if (handler is null)
         {
-            // Unknown slash command — fall through to the LLM path to preserve
-            // the prior behaviour where /<unknown> just looked like a regular
-            // user message.
+            if (bindingLookup.IdentityEnabled && bindingLookup.SubjectResolved && bindingLookup.BindingId is null)
+                return await SendBindingPromptAsync(activity, inbound, registration, runtimeContext, ct).ConfigureAwait(false);
+
+            // Unknown slash command for bound senders falls through to the Ornn
+            // skill-discovery rewrite in BuildLlmReplyRequestAsync.
             return null;
         }
 
-        if (string.IsNullOrWhiteSpace(inbound.SenderId) || string.IsNullOrWhiteSpace(inbound.Platform))
-        {
-            _logger.LogWarning(
-                "Slash command rejected: missing sender_id or platform on inbound message");
-            return null;
-        }
-
-        // Tenant resolution priority (avoids cross-tenant identity collapse on
-        // multi-tenant platforms like Lark — see ADR-0018 §Actor Architecture):
-        //   1. Platform adapter populated `tenant` / `open_tenant_id` in
-        //      InboundMessage.Extra. Preferred — adapter knows its own scope.
-        //   2. Fall back to `registration.ScopeId` so the binding is at least
-        //      per-bot-scoped (each bot is registered to one tenant; same
-        //      sender across two bots in two tenants becomes two bindings).
-        //   3. As a last resort, refuse the slash command rather than commit
-        //      a tenant-collapsed binding — production deployments MUST
-        //      surface this as a configuration error.
-        var tenant = ResolveTenant(inbound, registration);
-        if (tenant is null)
-        {
-            _logger.LogWarning(
-                "Slash command rejected: cannot resolve tenant for platform={Platform}, sender={Sender}, registration={RegistrationId}",
-                inbound.Platform,
-                inbound.SenderId,
-                registration.Id);
-            return null;
-        }
-
-        var subject = new ExternalSubjectRef
-        {
-            Platform = inbound.Platform.Trim().ToLowerInvariant(),
-            Tenant = tenant,
-            ExternalUserId = inbound.SenderId.Trim(),
-        };
-
-        BindingId? existing;
-        try
-        {
-            existing = await queryPort.ResolveAsync(subject, ct).ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            // Fail closed: if we can't tell whether the sender is bound, treat
-            // them as unbound so commands that need binding don't proceed
-            // against bot-owner credentials.
-            _logger.LogError(ex, "Binding lookup for slash command {Command} failed; treating sender as unbound", commandName);
-            existing = null;
-        }
-
-        if (handler.RequiresBinding && existing is null)
+        if (handler.RequiresBinding && bindingLookup.BindingId is null)
         {
             return await SendBindingPromptAsync(activity, inbound, registration, runtimeContext, ct).ConfigureAwait(false);
         }
+
+        if (bindingLookup.Subject is null)
+            return null;
 
         var commandContext = new ChannelSlashCommandContext
         {
             CommandName = handler.Name,
             ArgumentText = argumentText,
-            Subject = subject,
-            BindingIdValue = existing?.Value,
+            Subject = bindingLookup.Subject,
+            BindingIdValue = bindingLookup.BindingId?.Value,
             RegistrationId = registration.Id,
             RegistrationScopeId = registration.ScopeId ?? string.Empty,
             SenderId = inbound.SenderId.Trim(),
@@ -680,6 +649,45 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         {
             return new MessageContent { Text = ex.Message };
         }
+    }
+
+    // Refactor (issue1318/first-slice): Old: unbound sender still saw tool dispatch + unknown
+    // slash silently consumed.
+    // New: unbound sender disables tool dispatch; unknown slash gates to /init bootstrap;
+    // non-slash text path unchanged (owner-LLM chat fallback).
+    private async Task<SlashBindingLookup> ResolveSlashBindingAsync(
+        string commandName,
+        InboundMessage inbound,
+        ChannelBotRegistrationEntry registration,
+        IExternalIdentityBindingQueryPort queryPort,
+        CancellationToken ct)
+    {
+        if (!TryResolveExternalSubject(inbound, registration, out var subject))
+        {
+            _logger.LogWarning(
+                "Slash command rejected: cannot resolve subject for command={Command}, platform={Platform}, sender={Sender}, registration={RegistrationId}",
+                commandName,
+                inbound.Platform,
+                inbound.SenderId,
+                registration.Id);
+            return new SlashBindingLookup(true, false, null, null);
+        }
+
+        BindingId? existing;
+        try
+        {
+            existing = await queryPort.ResolveAsync(subject, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Fail closed: if we can't tell whether the sender is bound, treat
+            // them as unbound so commands that need binding don't proceed
+            // against bot-owner credentials.
+            _logger.LogError(ex, "Binding lookup for slash command {Command} failed; treating sender as unbound", commandName);
+            existing = null;
+        }
+
+        return new SlashBindingLookup(true, true, subject, existing);
     }
 
     private static bool TryResolveLlmSelectionAction(
@@ -1513,7 +1521,10 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         ResolvedSenderBinding? senderBinding,
         CancellationToken ct)
     {
-        var requestActivity = BuildLlmRequestActivity(activity, inboundEvent.Text);
+        var requestActivity = BuildLlmRequestActivity(
+            activity,
+            inboundEvent.Text,
+            _identityBindingQueryPort is null || senderBinding is not null);
         var request = new NeedsLlmReplyEvent
         {
             CorrelationId = activity.Id,
@@ -1590,13 +1601,17 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
             .ConfigureAwait(false);
     }
 
-    private ChatActivity BuildLlmRequestActivity(ChatActivity activity, string? inboundText)
+    // Refactor (issue1318/first-slice): Old: unbound sender still saw tool dispatch + unknown
+    // slash silently consumed.
+    // New: unbound sender disables tool dispatch; unknown slash gates to /init bootstrap;
+    // non-slash text path unchanged (owner-LLM chat fallback).
+    private ChatActivity BuildLlmRequestActivity(ChatActivity activity, string? inboundText, bool allowSkillInvocationPrompt)
     {
         var requestActivity = activity.Clone();
         if (requestActivity.Content is null)
             return requestActivity;
 
-        if (TryBuildSkillInvocationPrompt(inboundText, out var prompt))
+        if (allowSkillInvocationPrompt && TryBuildSkillInvocationPrompt(inboundText, out var prompt))
             requestActivity.Content.Text = prompt;
 
         return requestActivity;

--- a/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
@@ -35,13 +35,18 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
     private readonly IUserMemoryStore? _userMemoryStore;
     private readonly ILogger<NyxIdConversationReplyGenerator> _logger;
 
+    // Refactor (issue1318/first-slice): Old: unbound sender still saw tool dispatch + unknown
+    // slash silently consumed.
+    // New: unbound sender disables tool dispatch; unknown slash gates to /init bootstrap;
+    // non-slash text path unchanged (owner-LLM chat fallback).
     private sealed record EffectiveReplyPlan(
         IReadOnlyDictionary<string, string> Primary,
         LLMControlContext PrimaryControl,
         AgentToolExecutionContext? PrimaryToolContext,
         IReadOnlyDictionary<string, string>? OwnerFallback,
         LLMControlContext? OwnerFallbackControl,
-        AgentToolExecutionContext? OwnerFallbackToolContext);
+        AgentToolExecutionContext? OwnerFallbackToolContext,
+        bool DisableTools);
 
     private sealed record SenderPreferenceApplication(bool AnyApplied, bool RouteApplied);
 
@@ -107,7 +112,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         }
 
         var replyPlan = await BuildEffectiveReplyPlanAsync(metadata, llmControl, toolContext, ct);
-        var primaryTools = await BuildTurnToolsAsync(ct);
+        var primaryTools = await BuildTurnToolsAsync(replyPlan.DisableTools, ct);
 
         try
         {
@@ -132,7 +137,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
                 "Sender LLM route failed; retrying with bot owner LLM config. activity={ActivityId}",
                 activity.Id);
 
-            var fallbackTools = await BuildTurnToolsAsync(ct);
+            var fallbackTools = await BuildTurnToolsAsync(disableTools: true, ct);
             return await GenerateWithMetadataAsync(
                     activity,
                     replyPlan.OwnerFallback,
@@ -150,13 +155,15 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         IReadOnlyDictionary<string, string> metadata,
         LLMControlContext? llmControl,
         AgentToolExecutionContext? toolContext,
+        bool forceDisableTools,
         CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(activity);
         ArgumentNullException.ThrowIfNull(metadata);
 
         var replyPlan = await BuildEffectiveReplyPlanAsync(metadata, llmControl, toolContext, ct);
-        var tools = await BuildTurnToolsAsync(ct);
+        var disableTools = forceDisableTools || replyPlan.DisableTools;
+        var tools = await BuildTurnToolsAsync(disableTools, ct);
         var effectiveToolContext = replyPlan.PrimaryControl.ToToolContext(
             replyPlan.PrimaryToolContext ?? AgentToolExecutionContextMapper.FromMetadata(replyPlan.Primary));
         var externalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(replyPlan.Primary);
@@ -179,7 +186,8 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
             replyPlan.PrimaryControl,
             effectiveToolContext,
             initialMessages,
-            ResolveMaxToolRounds(replyPlan.PrimaryControl));
+            ResolveMaxToolRounds(replyPlan.PrimaryControl),
+            disableTools);
     }
 
     /// <summary>
@@ -215,9 +223,16 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
                || lowered.Contains("proxy", StringComparison.Ordinal);
     }
 
-    private async Task<ToolManager> BuildTurnToolsAsync(CancellationToken ct)
+    // Refactor (issue1318/first-slice): Old: unbound sender still saw tool dispatch + unknown
+    // slash silently consumed.
+    // New: unbound sender disables tool dispatch; unknown slash gates to /init bootstrap;
+    // non-slash text path unchanged (owner-LLM chat fallback).
+    private async Task<ToolManager> BuildTurnToolsAsync(bool disableTools, CancellationToken ct)
     {
         var tools = new ToolManager();
+        if (disableTools)
+            return tools;
+
         foreach (var tool in await DiscoverToolsAsync(ct))
             tools.Register(tool);
 
@@ -388,6 +403,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         // the bot owner's route from the upstream-pinned metadata. If a
         // sender-owned attempt fails, we retry once with this owner snapshot.
         var senderBindingId = toolContext?.SenderBinding.BindingId?.Trim();
+        var disableTools = IsChannelTurn(effective) && string.IsNullOrWhiteSpace(senderBindingId);
         if (_preferencesStore is not null && !string.IsNullOrWhiteSpace(senderBindingId))
         {
             var ownerSnapshot = CreateOwnerFallbackSnapshot(effective);
@@ -455,7 +471,8 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
             effectiveToolContext,
             ownerFallback,
             ownerFallbackControl,
-            ownerFallbackToolContext);
+            ownerFallbackToolContext,
+            disableTools);
     }
 
     /// <summary>
@@ -514,6 +531,11 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         context == null
             ? null
             : context with { SenderBinding = AgentToolSenderBindingContext.Empty };
+
+    private static bool IsChannelTurn(IReadOnlyDictionary<string, string> metadata) =>
+        metadata.ContainsKey(ChannelMetadataKeys.Platform) &&
+        metadata.ContainsKey(ChannelMetadataKeys.SenderId) &&
+        metadata.ContainsKey(ChannelMetadataKeys.MessageId);
 
     private async Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct)
     {

--- a/agents/Aevatar.GAgents.NyxidChat/ITypedConversationReplyGenerator.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ITypedConversationReplyGenerator.cs
@@ -24,15 +24,21 @@ internal interface IAgentRunStepConversationReplyGenerator : ITypedConversationR
         IReadOnlyDictionary<string, string> metadata,
         LLMControlContext? llmControl,
         AgentToolExecutionContext? toolContext,
+        bool forceDisableTools,
         CancellationToken ct);
 
     MessageContent? TryTakeOutboundIntent() => null;
 }
 
+// Refactor (issue1318/first-slice): Old: unbound sender still saw tool dispatch + unknown
+// slash silently consumed.
+// New: unbound sender disables tool dispatch; unknown slash gates to /init bootstrap;
+// non-slash text path unchanged (owner-LLM chat fallback).
 public sealed record AgentRunReplyStepPlan(
     ChatRuntimeStepExecutor StepExecutor,
     IReadOnlyDictionary<string, string> Metadata,
     LLMControlContext LlmControl,
     AgentToolExecutionContext ToolContext,
     IReadOnlyList<ChatMessage> InitialMessages,
-    int MaxToolRounds);
+    int MaxToolRounds,
+    bool DisableTools = false);

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.ToolProviders.Skills;
 using Aevatar.ChatRouting.Abstractions;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.NyxIdRelay;
@@ -505,7 +506,7 @@ public sealed class AgentRunGAgentTests
             actorRuntime,
             replyGenerator,
             new AsyncLocalInteractiveReplyCollector(),
-            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true });
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = false });
 
         await runtime.HandleStartAsync(new NeedsLlmReplyEvent
         {
@@ -623,6 +624,58 @@ public sealed class AgentRunGAgentTests
         observedControl.NyxIdRoutePreference.Should().Be(
             "/api/v1/proxy/s/anthropic-via-bot-owner",
             "the route preference is independent from the model override");
+    }
+
+    // Refactor (issue1318/first-slice): Old: unbound sender still saw tool dispatch + unknown
+    // slash silently consumed.
+    // New: unbound sender disables tool dispatch; unknown slash gates to /init bootstrap;
+    // non-slash text path unchanged (owner-LLM chat fallback).
+    [Fact]
+    public async Task HandleStartAsync_WhenUnboundChannelTurnRequestsToolCall_CompletesWithoutToolDispatch()
+    {
+        var targetActor = Substitute.For<IActor>();
+        targetActor.Id.Returns("conversation:c");
+        targetActor.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var providerFactory = new ToolCallAttemptProviderFactory();
+        var toolSource = new CountingAgentRunToolSource(new AgentRunNoopTool());
+        var replyGenerator = new NyxIdConversationReplyGenerator(
+            providerFactory,
+            toolSources: [toolSource],
+            localSkillCatalog: new LocalSkillCatalog());
+        var actorRuntime = new DispatchingActorRuntime(("conversation:c", targetActor));
+        var runtime = CreateRunAgent(
+            actorRuntime,
+            replyGenerator,
+            new AsyncLocalInteractiveReplyCollector(),
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true });
+        var activity = BuildRelayActivity();
+
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-unbound-no-tools",
+            TargetActorId = "conversation:c",
+            RegistrationId = "reg-1",
+            Activity = activity,
+            ReplyToken = "relay-token-unbound-no-tools",
+            ToolContext = AgentToolExecutionContext.Empty.ToPayload(),
+            LlmControl = ControlForAgentRun("owner-model", "owner-route", 4).ToPayload(),
+            Metadata =
+            {
+                [ChannelMetadataKeys.Platform] = "lark",
+                [ChannelMetadataKeys.SenderId] = "ou_user_1",
+                [ChannelMetadataKeys.MessageId] = "msg-unbound-no-tools",
+            },
+        });
+
+        runtime.State.Status.Should().Be(AgentRunStatus.ReplyHandedOff);
+        runtime.State.GenerationStep.Should().NotBeNull();
+        runtime.State.GenerationStep!.FinalNoToolsStep.Should().BeTrue();
+        runtime.State.GenerationStep.PendingToolCalls.Should().BeEmpty();
+        runtime.State.ProducedReplyText.Should().Be("attempted tool");
+        providerFactory.Requests.Should().ContainSingle();
+        providerFactory.Requests[0].Tools.Should().BeNull();
+        toolSource.DiscoverCount.Should().Be(0);
     }
 
     [Fact]
@@ -2257,6 +2310,19 @@ public sealed class AgentRunGAgentTests
             },
         };
 
+    private static LLMControlContext ControlForAgentRun(
+        string? model = null,
+        string? route = null,
+        int? rounds = null) =>
+        new(
+            NyxIdAccessToken: null,
+            NyxIdOrgToken: null,
+            SenderNyxIdAccessToken: null,
+            ModelOverride: model,
+            NyxIdRoutePreference: route,
+            MaxToolRoundsOverride: rounds,
+            UserMemoryPrompt: null);
+
     private static ChatRouteAction GAgentToolHint(string actorId)
     {
         var arguments = new Struct();
@@ -3028,6 +3094,65 @@ public sealed class AgentRunGAgentTests
             }
             return new ConversationReplyResult(ReplyText, Usage: null, FinishReason: null);
         }
+    }
+
+    private sealed class ToolCallAttemptProviderFactory : ILLMProviderFactory, ILLMProvider
+    {
+        public string Name => "tool-call-attempt";
+
+        public List<LLMRequest> Requests { get; } = [];
+
+        public ILLMProvider GetProvider(string name) => this;
+
+        public ILLMProvider GetDefault() => this;
+
+        public IReadOnlyList<string> GetAvailableProviders() => [Name];
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            Requests.Add(request);
+            yield return new LLMStreamChunk { DeltaContent = "attempted tool" };
+            yield return new LLMStreamChunk
+            {
+                DeltaToolCall = new ToolCall
+                {
+                    Id = "call-unbound",
+                    Name = AgentRunNoopTool.ToolName,
+                    ArgumentsJson = "{}",
+                },
+            };
+            await Task.CompletedTask;
+            yield return new LLMStreamChunk { IsLast = true };
+        }
+    }
+
+    private sealed class CountingAgentRunToolSource(IAgentTool tool) : IAgentToolSource
+    {
+        public int DiscoverCount { get; private set; }
+
+        public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default)
+        {
+            DiscoverCount++;
+            return Task.FromResult<IReadOnlyList<IAgentTool>>([tool]);
+        }
+    }
+
+    private sealed class AgentRunNoopTool : IAgentTool
+    {
+        public const string ToolName = "agent_run_noop_tool";
+
+        public string Name => ToolName;
+
+        public string Description => "No-op test tool.";
+
+        public string ParametersSchema => "{}";
+
+        public ToolApprovalMode ApprovalMode => ToolApprovalMode.NeverRequire;
+
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
+            Task.FromResult("""{"executed":true}""");
     }
 
     private sealed class ThrowingReplyGenerator(Exception exception) : IConversationReplyGenerator

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
@@ -1203,15 +1203,86 @@ public sealed class ChannelConversationTurnRunnerTests
         adapter.Replies.Should().BeEmpty();
     }
 
+    // Refactor (issue1318/first-slice): Old: unbound sender still saw tool dispatch + unknown
+    // slash silently consumed.
+    // New: unbound sender disables tool dispatch; unknown slash gates to /init bootstrap;
+    // non-slash text path unchanged (owner-LLM chat fallback).
     [Fact]
-    public async Task RunInboundAsync_ShouldRouteUnknownSlashCommandToOrnnSkillDiscovery()
+    public async Task RunInboundAsync_ShouldGateUnknownSlashCommandToInit_WhenSenderUnbound()
     {
+        var broker = new InMemoryCapabilityBroker();
+        var services = new ServiceCollection()
+            .AddSingleton<IExternalIdentityBindingQueryPort>(broker)
+            .AddSingleton<INyxIdCapabilityBroker>(broker)
+            .BuildServiceProvider();
         var registrationQueryPort = BuildRegistrationQueryPort();
         var adapter = new RecordingPlatformAdapter();
-        var runner = CreateRunner(registrationQueryPort, adapter);
+        var runner = CreateRunner(registrationQueryPort, adapter, services);
 
         var result = await runner.RunInboundAsync(
             BuildInboundActivity("/foobar", "msg-unknown", ConversationScope.DirectMessage, "oc_p2p_chat_1"),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.LlmReplyRequest.Should().BeNull();
+        result.Outbound.Text.Should().Contain("/oauth/authorize");
+        adapter.Replies.Should().ContainSingle();
+        adapter.Replies[0].ReplyText.Should().Contain("/oauth/authorize");
+    }
+
+    // Refactor (issue1318/first-slice): Old: unbound sender still saw tool dispatch + unknown
+    // slash silently consumed.
+    // New: unbound sender disables tool dispatch; unknown slash gates to /init bootstrap;
+    // non-slash text path unchanged (owner-LLM chat fallback).
+    [Fact]
+    public async Task RunInboundAsync_ShouldGateDailySlashCommandToInit_WhenSenderUnbound()
+    {
+        var broker = new InMemoryCapabilityBroker();
+        var services = new ServiceCollection()
+            .AddSingleton<IExternalIdentityBindingQueryPort>(broker)
+            .AddSingleton<INyxIdCapabilityBroker>(broker)
+            .BuildServiceProvider();
+        var registrationQueryPort = BuildRegistrationQueryPort();
+        var adapter = new RecordingPlatformAdapter();
+        var runner = CreateRunner(registrationQueryPort, adapter, services);
+
+        var result = await runner.RunInboundAsync(
+            BuildInboundActivity("/daily alice", "msg-unbound-daily", ConversationScope.DirectMessage, "oc_p2p_chat_1"),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.LlmReplyRequest.Should().BeNull();
+        result.Outbound.Text.Should().Contain("/oauth/authorize");
+        adapter.Replies.Should().ContainSingle();
+        adapter.Replies[0].ReplyText.Should().Contain("/oauth/authorize");
+    }
+
+    // Refactor (issue1318/first-slice): Old: unbound sender still saw tool dispatch + unknown
+    // slash silently consumed.
+    // New: unbound sender disables tool dispatch; unknown slash gates to /init bootstrap;
+    // non-slash text path unchanged (owner-LLM chat fallback).
+    [Fact]
+    public async Task RunInboundAsync_ShouldRouteUnknownSlashCommandToOrnnSkillDiscovery_WhenSenderBound()
+    {
+        var broker = new InMemoryCapabilityBroker();
+        broker.SeedBinding(
+            new ExternalSubjectRef
+            {
+                Platform = "lark",
+                Tenant = "scope-1",
+                ExternalUserId = "ou_user_1",
+            },
+            new BindingId { Value = "bnd-user-1" });
+        var services = new ServiceCollection()
+            .AddSingleton<IExternalIdentityBindingQueryPort>(broker)
+            .AddSingleton<INyxIdCapabilityBroker>(broker)
+            .BuildServiceProvider();
+        var registrationQueryPort = BuildRegistrationQueryPort();
+        var adapter = new RecordingPlatformAdapter();
+        var runner = CreateRunner(registrationQueryPort, adapter, services);
+
+        var result = await runner.RunInboundAsync(
+            BuildInboundActivity("/foobar", "msg-bound-unknown", ConversationScope.DirectMessage, "oc_p2p_chat_1"),
             CancellationToken.None);
 
         result.Success.Should().BeTrue();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
@@ -403,6 +403,43 @@ public sealed class ConversationReplyGeneratorTests
         prefsStore.Lookups.Should().BeEmpty();
     }
 
+    // Refactor (issue1318/first-slice): Old: unbound sender still saw tool dispatch + unknown
+    // slash silently consumed.
+    // New: unbound sender disables tool dispatch; unknown slash gates to /init bootstrap;
+    // non-slash text path unchanged (owner-LLM chat fallback).
+    [Fact]
+    public async Task GenerateReplyAsync_DisablesTools_WhenChannelTurnHasNoSenderBinding()
+    {
+        var providerFactory = new RecordingProviderFactory();
+        var toolSource = new CountingToolSource(new ApprovalRequiredTool());
+        var generator = new NyxIdConversationReplyGenerator(
+            providerFactory,
+            toolSources: [toolSource],
+            localSkillCatalog: new LocalSkillCatalog());
+
+        await generator.GenerateReplyAsync(
+            new ChatActivity
+            {
+                Id = "msg-unbound-channel-tools",
+                Conversation = new ConversationReference { CanonicalKey = "lark:dm:user-1" },
+                Content = new MessageContent { Text = "hello" },
+            },
+            new Dictionary<string, string>
+            {
+                [ChannelMetadataKeys.Platform] = "lark",
+                [ChannelMetadataKeys.SenderId] = "ou_user_1",
+                [ChannelMetadataKeys.MessageId] = "msg-unbound-channel-tools",
+            },
+            Control("owner-only-model", "owner-route", 4),
+            toolContext: null,
+            streamingSink: null,
+            CancellationToken.None);
+
+        var request = providerFactory.Requests.Should().ContainSingle().Subject;
+        request.Tools.Should().BeNull();
+        toolSource.DiscoverCount.Should().Be(0);
+    }
+
     [Fact]
     public async Task GenerateReplyAsync_FallsBackToOwnerPrefsWhenSenderStoreThrows()
     {
@@ -816,6 +853,17 @@ public sealed class ConversationReplyGeneratorTests
     {
         public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default) =>
             Task.FromResult<IReadOnlyList<IAgentTool>>([tool]);
+    }
+
+    private sealed class CountingToolSource(IAgentTool tool) : IAgentToolSource
+    {
+        public int DiscoverCount { get; private set; }
+
+        public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default)
+        {
+            DiscoverCount++;
+            return Task.FromResult<IReadOnlyList<IAgentTool>>([tool]);
+        }
     }
 
     private sealed class ApprovalRequiredTool : IAgentTool


### PR DESCRIPTION
## 摘要

来源:#512 Phase 9 r1 split first-slice consensus(minimal+structural propose,delete abstain)。

unbound sender 行为收紧:
- 检测 sender unbound 后 **disable 工具调用**(不发 tool dispatch)
- **unknown slash command** → gate 到 `/init` 引导(初始化首选项)
- non-slash 纯文本 → 维持 owner-LLM chat fallback(无改动)

**禁止**新增:typed channel admission decision、`NeedsLlmReplyEvent.execution_mode`(那是 #512 later-slice 设计待 Phase 9)。**禁止**新增:actor / envelope / proto / canon。

## 范围

8 files changed (+411/-75):
- `agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs`
- `agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs`
- `agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs`
- `agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs`
- `agents/Aevatar.GAgents.NyxidChat/ITypedConversationReplyGenerator.cs`
- `test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs`
- `test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs`
- `test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs`

补 behavior test:unbound sender disable tools / unknown slash → /init gate / non-slash 维持 fallback。

implement codex 本地 `dotnet build aevatar.slnx --nologo` 绿 + `dotnet test` 相关 module 通过(per SKILL hard rule 10)。

## 关联

- closes #1318
- refs #512(first-slice;later-slice typed channel admission + execution_mode 设计待 Phase 9)

## Stacked-PR

base = `auto-refact-dev`。本 PR merge 后 #1318 自动 close。

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
