### PR TITLE
implement #1369: 删 dev_sync_daemon self-spawn + spawn-codex execution_id+ACCEPTED receipt

### DIFF
--- a/.claude/skills/codex-refactor-loop/SKILL.md
+++ b/.claude/skills/codex-refactor-loop/SKILL.md
@@ -300,6 +300,7 @@ Bash(
      --cd <worktree> --add-dir /Users/auric/aevatar \
      --prompt <prompt-file> --log <log-file> --timeout 5400
    ```
+   `spawn-codex.sh` 启动接受时输出 `ACCEPTED: execution_id=<id> ack_stage=accepted`,同 id 在 `.refactor-loop/markers/<execution_id>.running.json` 与 `.done.json` 中持续；未传 `--execution-id` 时由 wrapper 自动生成,旧 `SPAWN/DONE` banner 仍保留给 legacy reader。
 
 **反模式(❌ 已废,已删除见 #1242)`spawn_with_banner.py + Popen 自 detach`**:
 - 用 `Popen + start_new_session` 把 codex 脱离 python parent → harness 看不见 codex
@@ -937,9 +938,9 @@ Daemon 工作流(2026-05-30 重写 — PR-based 双向 sync):
 2. 每方向:计算 source ahead of target = N;N==0 → skip
 3. 没 open sync PR → 创 sync branch + open PR(forward 立即 enable auto-merge;reverse 等 maintainer review)
 4. 有 open sync PR + `mergeStateStatus`:
-   - **DIRTY** → spawn codex resolve in REVERSE_WT/FORWARD_WT
+   - **DIRTY** → daemon 物化 conflict-resolve prompt/log/worktree 并写 pending event;controller 下次 wakeup 用 `spawn-codex.sh` 派发
    - **BEHIND** → `gh api .../update-branch`(GitHub merge base into PR head)
-   - **CI fail** → spawn codex fix-ci
+   - **CI fail** → daemon 物化 fix-ci prompt/log/worktree 并写 pending event;controller 下次 wakeup 用 `spawn-codex.sh` 派发
    - **CLEAN + sync_branch behind source by N > 0**(stale)→ 自动 `git reset --hard origin/<source>` + `git push --force-with-lease`(2026-05-30 修复:之前会卡在 CLEAN 状态等 maintainer 看陈旧 PR)
    - **CLEAN + sync 同步** → 等 GitHub auto-merge(forward)/ maintainer review(reverse)
 5. Reverse gate:trunk 落后 dev > 0 → reverse 暂停(先完 forward 让 trunk superset of dev)
@@ -951,6 +952,7 @@ Daemon 工作流(2026-05-30 重写 — PR-based 双向 sync):
 | 任务 | 谁做 |
 |---|---|
 | dev → auto-refact-dev sync(常规 + 冲突解决) | **daemon**(600s 自主) |
+| sync conflict / CI fix codex dispatch | daemon 只写 `.refactor-loop/.controller-pending-events.log`;controller 用 `spawn-codex.sh` 派发 |
 | 处理 design issue / Phase 9 / Phase 8 fix loop | controller(wakeup) |
 | 派 reviewer / fix / implement codex | controller |
 | 监控 daemon liveness + restart | controller per-wakeup |
@@ -971,7 +973,7 @@ tail -10 .refactor-loop/logs/dev-sync-daemon.log | grep -E "(DEV_SYNC_BLOCKED|FA
 
 - ❌ controller 自己跑 `git merge dev` 同步(daemon 已做,会 race / 冲突)
 - ❌ daemon push 后 controller 不 fetch 就 commit(stale base bug)
-- ❌ Daemon 派 codex 自己 push(daemon 决定 push 时机,codex 只 resolve + merge --continue)
+- ❌ Daemon `nohup` / `Popen` / `disown` 自派 codex;daemon 只能物化 pending event,controller 负责 harness-tracked dispatch
 - ❌ 多 daemon 实例(`pgrep -c dev-sync-daemon` 必须 = 1)
 
 ### Sync procedure

--- a/.claude/skills/codex-refactor-loop/scripts/dev_sync_daemon.py
+++ b/.claude/skills/codex-refactor-loop/scripts/dev_sync_daemon.py
@@ -38,10 +38,10 @@ REVERSE_PREFIX = "chore/sync-trunk-to-dev-"
 FORWARD_WT = Path(os.environ.get("FORWARD_WT", "/Users/auric/aevatar-wt-sync-forward"))
 REVERSE_WT = Path(os.environ.get("REVERSE_WT", "/Users/auric/aevatar-wt-sync-reverse"))
 
-SPAWN_CODEX = MAIN_REPO / ".claude" / "skills" / "codex-refactor-loop" / "scripts" / "spawn-codex.sh"
 LOGS_DIR = MAIN_REPO / ".refactor-loop" / "logs"
 PROMPTS_DIR = MAIN_REPO / ".refactor-loop" / "prompts"
 LOCK_FILE = MAIN_REPO / ".refactor-loop" / "dev-sync-daemon.lock"
+PENDING_EVENTS = MAIN_REPO / ".refactor-loop" / ".controller-pending-events.log"
 
 # ===== utils =====
 
@@ -149,7 +149,8 @@ def create_sync_pr(source: str, target: str, branch_prefix: str, ahead: int, lab
         return
     log(f"{label}: pushed {new_branch} ({ahead} commits)")
     body = (f"daemon 双向同步 `{source}` → `{target}` 共 {ahead} commits。"
-            f"CI 绿后 GitHub auto-merge。冲突或 CI fail 由 daemon 派 codex 在独立 worktree 解决。"
+            f"CI 绿后 GitHub auto-merge。冲突或 CI fail 由 daemon 写 pending event,"
+            f"再由 controller 派 codex 在独立 worktree 解决。"
             f"\n\n⟦AI:AUTO-LOOP⟧\n")
     r = run(["gh", "pr", "create", "--base", target, "--head", new_branch,
              "--title", f"chore: {source} → {target} 自动同步 ({ahead} commits)",
@@ -175,7 +176,7 @@ def create_sync_pr(source: str, target: str, branch_prefix: str, ahead: int, lab
 
 def dispatch_codex(wt: Path, pr_num: int, sync_branch: str, source: str, target: str,
                    action: str, label: str) -> None:
-    """action: 'resolve-conflict' | 'fix-ci'. 派 codex 在 wt 上 work + push 回 sync_branch."""
+    """action: 'resolve-conflict' | 'fix-ci'. 物化 codex dispatch request for controller pickup."""
     if not ensure_worktree(wt, sync_branch):
         return
     ts = int(time.time())
@@ -264,13 +265,22 @@ sync 方向: `{source}` → `{target}`(PR base=`{target}`)
 所有 AI 生成的对外内容必须末尾独立一行加 sentinel `⟦AI:AUTO-LOOP⟧`。
 """
     prompt_file.write_text(body)
-    log(f"{label}: dispatch codex({action}) PR #{pr_num} wt={wt} prompt={prompt_file.name}")
-    subprocess.Popen(
-        ["bash", "-lc",
-         f"nohup {SPAWN_CODEX} --cd {wt} --add-dir {MAIN_REPO} "
-         f"--prompt {prompt_file} --log {log_file} --timeout 5400 "
-         f">/dev/null 2>&1 & disown"],
-        cwd=str(MAIN_REPO))
+    # Refactor (issue1369/first-slice):
+    #   Old pattern: daemon detached codex via nohup/Popen, bypassing harness tracking.
+    #   New principle: daemon writes pending event; controller dispatches via spawn-codex.sh; harness tracked + task-notification on exit.
+    event_action = "conflict-resolve" if action == "resolve-conflict" else "fix-ci"
+    event_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    PENDING_EVENTS.parent.mkdir(parents=True, exist_ok=True)
+    with PENDING_EVENTS.open("a", encoding="utf-8") as fp:
+        fp.write(
+            f"{event_ts} dispatch-codex action={event_action} "
+            f"prompt={prompt_file.resolve()} log={log_file.resolve()} worktree={wt.resolve()} "
+            f"add_dir={MAIN_REPO.resolve()} timeout=5400 issue_or_pr={pr_num}\n"
+        )
+    log(
+        f"{label}: queued codex({event_action}) PR #{pr_num} wt={wt} "
+        f"prompt={prompt_file.name} pending={PENDING_EVENTS}"
+    )
 
 
 def trigger_update_branch(pr_num: int, label: str) -> None:

--- a/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh
@@ -6,7 +6,8 @@
 #
 # Usage:
 #   spawn-codex.sh --cd <dir> --prompt <prompt-file> --log <log-file> --timeout <seconds>
-#                  [--model <model>] [--add-dir <dir>] [--prompt-text "..."] [--dry-run]
+#                  [--model <model>] [--add-dir <dir>] [--execution-id <id>]
+#                  [--prompt-text "..."] [--dry-run]
 #
 # Required flags: --cd, --prompt OR --prompt-text, --log, --timeout.
 #
@@ -14,8 +15,9 @@
 # 输出也输出到一个临时文件, 方便debug"):
 #   - Prompt is read from --prompt <file>, OR --prompt-text "..." writes a /tmp temp file.
 #   - Output is written to --log <file>. Caller chooses path (typically .refactor-loop/logs/).
-#   - At start, this wrapper prints `SPAWN: prompt=<path> log=<path> cd=<dir> timeout=<s>` to stderr
-#     so callers / `tail` see exact paths immediately. At end, prints `DONE: log=<path> exit=<N>`.
+#   - At accepted start, this wrapper prints
+#     `ACCEPTED: execution_id=<id> ack_stage=accepted prompt=<path> log=<path> timeout=<seconds>` to stdout,
+#     and also keeps legacy SPAWN/DONE stderr banners for existing readers.
 #   - Debug recipe: `cat <prompt-path>` to see what codex got; `cat <log-path>` to see what it did.
 #
 # Forbidden:
@@ -31,6 +33,7 @@ PROMPT_TEXT=""
 LOG=""
 TIMEOUT=""
 MODEL=""
+EXECUTION_ID=""
 ADD_DIRS=()
 DRY_RUN=0
 
@@ -42,6 +45,7 @@ while [[ $# -gt 0 ]]; do
     --log)         LOG="$2"; shift 2;;
     --timeout)     TIMEOUT="$2"; shift 2;;
     --model)       MODEL="$2"; shift 2;;
+    --execution-id) EXECUTION_ID="$2"; shift 2;;
     --add-dir)     ADD_DIRS+=("$2"); shift 2;;
     --dry-run)     DRY_RUN=1; shift;;
     *)             echo "unknown flag: $1" >&2; exit 2;;
@@ -122,36 +126,54 @@ else
 fi
 MARKER_DIR="$STATE_DIR/markers"
 BASE="$(basename "$LOG" .log)"
-RUNNING_MARKER="$MARKER_DIR/$BASE.running.json"
-DONE_MARKER="$MARKER_DIR/$BASE.done.json"
+if [[ -z "$EXECUTION_ID" ]]; then
+  if command -v uuidgen >/dev/null 2>&1; then
+    EXECUTION_ID="$(uuidgen | tr 'A-Z' 'a-z')"
+  elif python3 -c 'import ulid' >/dev/null 2>&1; then
+    EXECUTION_ID="$(python3 -c 'import ulid; print(ulid.new())')"
+  else
+    EXECUTION_ID="$(date -u +%s%N)"
+  fi
+fi
+RUNNING_MARKER="$MARKER_DIR/$EXECUTION_ID.running.json"
+DONE_MARKER="$MARKER_DIR/$EXECUTION_ID.done.json"
 
 if (( DRY_RUN == 1 )); then
-  echo "SPAWN: prompt=$RENDERED_PROMPT log=$LOG cd=$CD timeout=${TIMEOUT}s${MODEL:+ model=$MODEL} dry-run=1" >&2
+  echo "ACCEPTED: execution_id=$EXECUTION_ID ack_stage=accepted prompt=$RENDERED_PROMPT log=$LOG timeout=$TIMEOUT"
+  echo "SPAWN: prompt=$RENDERED_PROMPT log=$LOG cd=$CD timeout=${TIMEOUT}s${MODEL:+ model=$MODEL} execution_id=$EXECUTION_ID dry-run=1" >&2
   head -5 "$RENDERED_PROMPT"
   exit 0
 fi
 
 mkdir -p "$MARKER_DIR"
 STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-RUNNING_TMP="$MARKER_DIR/.$BASE.running.json.$$"
+RUNNING_TMP="$MARKER_DIR/.$EXECUTION_ID.running.json.$$"
 # Refactor (iter158/cluster-1172-markers-event-design):
 # Old: spawn-codex 只写 log,reporter 必须 tail log 末尾 grep EXIT marker 判断 finished;
 #      reporter 每 600s 扫 LOG_DIR/*.log 全部(~970 files),97% 浪费 CPU + IO。
-# New: spawn-codex 启动时写 .refactor-loop/markers/<base>.running.json,EXIT 后
-#      atomic rename → <base>.done.json(含 verdict from tail grep + exit_code + finished_at)。
+# New: spawn-codex 启动时写 .refactor-loop/markers/<execution_id>.running.json,EXIT 后
+#      atomic rename → <execution_id>.done.json(含 verdict from tail grep + exit_code + finished_at)。
 #      reporter 只扫 markers/(O(in-flight count)),不再 tail log。
+# Refactor (issue1369/first-slice):
+#   Old pattern: daemon detached codex via nohup/Popen, bypassing harness tracking.
+#   New principle: daemon writes pending event; controller dispatches via spawn-codex.sh; harness tracked + task-notification on exit.
 jq -n \
+  --arg execution_id "$EXECUTION_ID" \
+  --arg ack_stage "accepted" \
   --arg base "$BASE" \
+  --arg prompt "$RENDERED_PROMPT" \
   --arg log_path "$LOG" \
   --arg started_at "$STARTED_AT" \
-  '{base: $base, log_path: $log_path, started_at: $started_at, state: "running"}' \
+  --argjson timeout "$TIMEOUT" \
+  '{execution_id: $execution_id, ack_stage: $ack_stage, prompt: $prompt, log: $log_path, timeout: $timeout, started_at: $started_at, base: $base, log_path: $log_path, state: "running"}' \
   > "$RUNNING_TMP"
 mv "$RUNNING_TMP" "$RUNNING_MARKER"
 rm -f "$DONE_MARKER"
 
 # Debug banner — caller / `tail` sees exact paths immediately (per maintainer 2026-05-19).
 # Both prompt + log are real files on disk; debug by `cat <prompt-path>` and `cat <log-path>`.
-echo "SPAWN: prompt=$RENDERED_PROMPT source_prompt=$PROMPT log=$LOG cd=$CD timeout=${TIMEOUT}s${MODEL:+ model=$MODEL}" >&2
+echo "ACCEPTED: execution_id=$EXECUTION_ID ack_stage=accepted prompt=$RENDERED_PROMPT log=$LOG timeout=$TIMEOUT"
+echo "SPAWN: prompt=$RENDERED_PROMPT source_prompt=$PROMPT log=$LOG cd=$CD timeout=${TIMEOUT}s${MODEL:+ model=$MODEL} execution_id=$EXECUTION_ID" >&2
 
 # Standard args:
 # - --dangerously-bypass-approvals-and-sandbox: required for unattended mode (caller-supplied authorization).
@@ -189,19 +211,24 @@ set -e
 
 FINISHED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 VERDICT="$(tail -5 "$LOG" | grep -oE "^[A-Z_]+_DONE[:].*$|^REVIEW_DONE.*$|^META_JUDGE_DONE.*$|^META_RESOLVED.*$|^AUDIT_DONE.*$|^TRIAGE_DONE.*$|^FIX_DONE.*$" | tail -1 || true)"
-DONE_TMP="$MARKER_DIR/.$BASE.done.json.$$"
+DONE_TMP="$MARKER_DIR/.$EXECUTION_ID.done.json.$$"
 jq -n \
+  --arg execution_id "$EXECUTION_ID" \
+  --arg ack_stage "accepted" \
   --arg base "$BASE" \
+  --arg prompt "$RENDERED_PROMPT" \
   --arg log_path "$LOG" \
   --arg started_at "$STARTED_AT" \
+  --arg done_at "$FINISHED_AT" \
   --arg finished_at "$FINISHED_AT" \
+  --argjson timeout "$TIMEOUT" \
   --argjson exit_code "$EXIT" \
   --arg verdict "$VERDICT" \
-  '{base: $base, log_path: $log_path, started_at: $started_at, finished_at: $finished_at, exit_code: $exit_code, verdict: $verdict, state: "done"}' \
+  '{execution_id: $execution_id, ack_stage: $ack_stage, prompt: $prompt, log: $log_path, timeout: $timeout, started_at: $started_at, done_at: $done_at, exit_code: $exit_code, base: $base, log_path: $log_path, finished_at: $finished_at, verdict: $verdict, state: "done"}' \
   > "$DONE_TMP"
 mv "$DONE_TMP" "$RUNNING_MARKER"
 mv "$RUNNING_MARKER" "$DONE_MARKER"
 
-echo "DONE: log=$LOG exit=$EXIT prompt=$RENDERED_PROMPT source_prompt=$PROMPT" >&2
+echo "DONE: log=$LOG exit=$EXIT prompt=$RENDERED_PROMPT source_prompt=$PROMPT execution_id=$EXECUTION_ID" >&2
 
 exit "$EXIT"

--- a/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh
@@ -126,14 +126,11 @@ else
 fi
 MARKER_DIR="$STATE_DIR/markers"
 BASE="$(basename "$LOG" .log)"
+# Default execution_id to log basename for backward compatibility with legacy
+# marker readers + tests that expect markers/<base>.{running,done}.json.
+# Callers may override with --execution-id for distinct lineage tracking.
 if [[ -z "$EXECUTION_ID" ]]; then
-  if command -v uuidgen >/dev/null 2>&1; then
-    EXECUTION_ID="$(uuidgen | tr 'A-Z' 'a-z')"
-  elif python3 -c 'import ulid' >/dev/null 2>&1; then
-    EXECUTION_ID="$(python3 -c 'import ulid; print(ulid.new())')"
-  else
-    EXECUTION_ID="$(date -u +%s%N)"
-  fi
+  EXECUTION_ID="$BASE"
 fi
 RUNNING_MARKER="$MARKER_DIR/$EXECUTION_ID.running.json"
 DONE_MARKER="$MARKER_DIR/$EXECUTION_ID.done.json"

--- a/.refactor-loop/runs/implement-issue1369.md
+++ b/.refactor-loop/runs/implement-issue1369.md
@@ -1,0 +1,36 @@
+## implement #1369 run report
+
+### Changed files
+
+- `.claude/skills/codex-refactor-loop/scripts/dev_sync_daemon.py`
+  - Removed the detached `subprocess.Popen` + `nohup ... & disown` self-spawn path from `dispatch_codex()`.
+  - Kept prompt/log/worktree materialization and now appends one `dispatch-codex` line to `.refactor-loop/.controller-pending-events.log`.
+  - Pending event includes `action`, `prompt`, `log`, `worktree`, `add_dir`, `timeout`, and `issue_or_pr`.
+  - Updated sync PR body wording so conflicts/CI fixes are described as daemon pending event plus controller dispatch.
+
+- `.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh`
+  - Added optional `--execution-id <id>`.
+  - Generates a stable id when omitted.
+  - Emits `ACCEPTED: execution_id=<id> ack_stage=accepted prompt=<path> log=<path> timeout=<s>` on accepted start.
+  - Writes `.refactor-loop/markers/<execution_id>.running.json` and `<execution_id>.done.json` with `execution_id`, `ack_stage`, `prompt`, `log`, `timeout`, `started_at`, `done_at`, and `exit_code`.
+  - Preserves legacy `base`, `log_path`, `verdict`, `SPAWN`, and `DONE` fields/banners for existing readers.
+
+- `.claude/skills/codex-refactor-loop/SKILL.md`
+  - Updated the spawn section with `ACCEPTED` receipt and `execution_id` marker semantics.
+  - Updated Phase 6 dev-sync daemon notes so DIRTY/CI-fail paths are pending-event materialization, not daemon self-dispatch.
+  - Updated daemon/controller responsibility table and anti-pattern wording.
+
+### Smoke tests
+
+- `python3 -c 'import ast; ast.parse(open(".claude/skills/codex-refactor-loop/scripts/dev_sync_daemon.py").read())'`: pass.
+- `bash -n .claude/skills/codex-refactor-loop/scripts/spawn-codex.sh`: pass.
+- `bash .claude/skills/codex-refactor-loop/scripts/spawn-codex.sh --help 2>&1 | head -20 || true`: completed with existing legacy `unknown flag: --help` output.
+- `spawn-codex.sh --dry-run --execution-id issue1369-smoke`: printed `ACCEPTED` receipt with the provided execution id.
+- Fake local `codex` smoke: `spawn-codex.sh --execution-id issue1369-marker-smoke` wrote `<id>.done.json` with matching `execution_id`, `ack_stage=accepted`, `timeout=3600`, `done_at`, `exit_code=7`, and preserved `verdict`.
+
+### Deviation
+
+- `SCOPE_EXTEND` was printed before touching worktree-local copies of the three skill files because the task simultaneously required implementation in `/Users/auric/aevatar-wt-issue1369-impl` and listed absolute scope paths under `/Users/auric/aevatar`.
+- `SCOPE_EXTEND` was printed before creating this required run artifact because the artifact path is outside the three strict scope paths but explicitly required by procedure step 9.
+
+⟦AI:AUTO-LOOP⟧


### PR DESCRIPTION
## 摘要

来源:#1338 Phase 9 r2 split first-slice consensus(3/3 unanimous propose),skill-internal no-new-core cleanup。

**dev_sync_daemon.py 不再自派 codex,改写 pending event;spawn-codex.sh 加 execution_id + ACCEPTED receipt + marker JSON。**

## 范围

4 files changed (+102/-27)。**skill-internal,不触及 production code**(per SKILL "Skill 自身 bug 修复 — 走当前 skill PR branch 不走 Phase 8")。

- `.claude/skills/codex-refactor-loop/scripts/dev_sync_daemon.py`(+22/-8)
  - 删 `dispatch_codex()` 中 detached `subprocess.Popen + nohup ... & disown` self-spawn
  - 改为物化 prompt/log/worktree + 写一行到 `.refactor-loop/.controller-pending-events.log`(`dispatch-codex action=... prompt=... log=... worktree=... add_dir=... timeout=... issue_or_pr=...`)
  - controller 读 pending event 后用 `spawn-codex.sh` 派(harness 可见 + task-notification 工作)

- `.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh`(+45/-10)
  - 加可选 `--execution-id <id>`,缺省自动生成
  - 接受成功后 stdout 打印 `ACCEPTED: execution_id=<id> ack_stage=accepted prompt=<path> log=<path> timeout=<s>`
  - 创建 `.refactor-loop/markers/<id>.running.json` + 完成时 atomic-rename 为 `<id>.done.json`(含 `execution_id`/`ack_stage`/`prompt`/`log`/`timeout`/`started_at`/`done_at`/`exit_code`)
  - **legacy 兼容**:旧 SPAWN/DONE banner + `verdict`/`base`/`log_path` 字段保留,无 `--execution-id` 调用仍工作

- `.claude/skills/codex-refactor-loop/SKILL.md`(±8)
  - spawn section 加 ACCEPTED receipt + execution_id marker 语义
  - Phase 6 dev-sync daemon DIRTY/CI-fail 段:改为 pending event + controller dispatch
  - daemon/controller 责任表 + 反模式段同步

- `.refactor-loop/runs/implement-issue1369.md`(new +36)

## 验证

- `python3 -c 'import ast; ast.parse(...dev_sync_daemon.py...)'` ✓
- `bash -n spawn-codex.sh` ✓
- `spawn-codex.sh --dry-run --execution-id issue1369-smoke` → 打印 ACCEPTED receipt ✓
- fake codex smoke:`spawn-codex.sh --execution-id issue1369-marker-smoke` → 写 `<id>.done.json` 含 matching execution_id/ack_stage=accepted/timeout/done_at/exit_code/verdict ✓

## 关联

- closes #1369
- refs #1338(later-slice "package cli state contract design" 留 design-pending)

## Phase 8 跳过(per SKILL "Skill 自身 bug 修复")

本 PR 为 skill-internal change,**不走 Phase 8 multi-reviewer 共识**:skill 文件不是 production code,不需要 reviewer-architect 验 CLAUDE 合规;skill PR 等 Phase 8 几小时收敛会让 controller 继续 stuck。**直接等 CI 绿后 merge**。

**Merge 后立即重启 dev_sync_daemon** 让新 pending-event 代码生效。

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
