### PR TITLE
[refactor-impl] #1489 first-slice: GAgentBase OCC deactivation flush containment

### DIFF
--- a/src/Aevatar.Foundation.Core/GAgentBase.TState.cs
+++ b/src/Aevatar.Foundation.Core/GAgentBase.TState.cs
@@ -59,9 +59,25 @@ public abstract class GAgentBase<TState> : GAgentBase, IAgent<TState>, IEventSou
     {
         var eventSourcing = EnsureEventSourcingConfigured();
         await OnDeactivateAsync(ct);
-        await eventSourcing.ConfirmEventsAsync(ct);
-        await eventSourcing.PersistSnapshotAsync(_state, ct);
-        await base.DeactivateAsync(ct);
+        try
+        {
+            try
+            {
+                await eventSourcing.ConfirmEventsAsync(ct);
+            }
+            catch (EventStoreOptimisticConcurrencyException)
+            {
+                // Refactor (issue1489/first-slice): Old pattern: deactivation OCC escaped with stale pending events and could block base lifecycle. New principle: deactivation-only OCC containment drains stale pending events, skips snapshot, and still runs base shutdown.
+                eventSourcing.DiscardPendingEvents();
+                return;
+            }
+
+            await eventSourcing.PersistSnapshotAsync(_state, ct);
+        }
+        finally
+        {
+            await base.DeactivateAsync(ct);
+        }
     }
 
     /// <summary>Hook invoked after state changes, useful for CQRS projection.</summary>

--- a/src/Aevatar.Foundation.Core/GAgentBase.TState.cs
+++ b/src/Aevatar.Foundation.Core/GAgentBase.TState.cs
@@ -67,7 +67,7 @@ public abstract class GAgentBase<TState> : GAgentBase, IAgent<TState>, IEventSou
             }
             catch (EventStoreOptimisticConcurrencyException)
             {
-                // Refactor (issue1489/first-slice): Old pattern: deactivation OCC escaped with stale pending events and could block base lifecycle. New principle: deactivation-only OCC containment drains stale pending events, skips snapshot, and still runs base shutdown.
+                // Refactor (iter713/cluster-gagentbase-deactivation-occ-flush-containment): Old pattern: deactivation OCC escaped with stale pending events and could block base lifecycle. New principle: deactivation-only OCC containment drains stale pending events, skips snapshot, and still runs base shutdown.
                 eventSourcing.DiscardPendingEvents();
                 return;
             }

--- a/test/Aevatar.Foundation.Core.Tests/Bdd/AgentLifecycleBddTests.cs
+++ b/test/Aevatar.Foundation.Core.Tests/Bdd/AgentLifecycleBddTests.cs
@@ -4,6 +4,7 @@
 // ─────────────────────────────────────────────────────────────
 
 using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Abstractions.EventModules;
 using Aevatar.Foundation.Abstractions.Helpers;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Foundation.Core.Tests;
@@ -113,10 +114,89 @@ public class AgentLifecycleBddTests
         await act.ShouldThrowAsync<InvalidOperationException>();
     }
 
+    [Fact(DisplayName = "Given deactivation flush hits OCC, pending events should be discarded without snapshot and base lifecycle should complete")]
+    public async Task Given_DeactivationFlushHitsOcc_When_Deactivated_Then_DiscardsPendingSkipsSnapshotAndRunsBaseLifecycle()
+    {
+        // Given
+        var store = new InMemoryEventStore();
+        var snapshotStore = new RecordingSnapshotStore();
+        var behavior = new CounterReplayBehavior(
+            store,
+            "lifecycle-occ",
+            snapshotStore,
+            new IntervalSnapshotStrategy(1));
+        var module = new LifecycleTrackingModule();
+        var agent = new CounterAgent
+        {
+            EventSourcing = behavior,
+        };
+        agent.SetId("lifecycle-occ");
+        agent.Services = TestRuntimeServices.BuildProvider();
+        agent.RegisterModule(module);
+        await agent.ActivateAsync();
+        behavior.RaiseEvent(new IncrementEvent { Amount = 7 });
+
+        await store.AppendAsync(
+            "lifecycle-occ",
+            [new StateEvent
+            {
+                EventId = Guid.NewGuid().ToString("N"),
+                Timestamp = TimestampHelper.Now(),
+                Version = 1,
+                EventType = typeof(IncrementEvent).FullName ?? nameof(IncrementEvent),
+                EventData = Any.Pack(new IncrementEvent { Amount = 100 }),
+                AgentId = "lifecycle-occ",
+            }],
+            expectedVersion: 0);
+
+        // When
+        await agent.DeactivateAsync();
+
+        // Then
+        var events = await store.GetEventsAsync("lifecycle-occ");
+        events.Count.ShouldBe(1);
+        events[0].EventData.Unpack<IncrementEvent>().Amount.ShouldBe(100);
+        behavior.CurrentVersion.ShouldBe(1);
+        snapshotStore.SaveCount.ShouldBe(0);
+        module.DisposeCount.ShouldBe(1);
+
+        var noop = await behavior.ConfirmEventsAsync();
+        noop.LatestVersion.ShouldBe(1);
+        events = await store.GetEventsAsync("lifecycle-occ");
+        events.Count.ShouldBe(1);
+    }
+
+    [Fact(DisplayName = "Given deactivation flush fails with non OCC, failure should propagate and base lifecycle should still complete")]
+    public async Task Given_DeactivationFlushFailsWithNonOcc_When_Deactivated_Then_PropagatesAndRunsBaseLifecycle()
+    {
+        // Given
+        var behavior = new ThrowingConfirmBehavior(new InvalidOperationException("flush failed"));
+        var module = new LifecycleTrackingModule();
+        var agent = new CounterAgent
+        {
+            EventSourcing = behavior,
+        };
+        agent.SetId("lifecycle-non-occ");
+        agent.Services = TestRuntimeServices.BuildProvider();
+        agent.RegisterModule(module);
+        await agent.ActivateAsync();
+
+        // When / Then
+        var ex = await Should.ThrowAsync<InvalidOperationException>(() => agent.DeactivateAsync());
+        ex.Message.ShouldBe("flush failed");
+        behavior.DiscardPendingEventsCount.ShouldBe(0);
+        behavior.PersistSnapshotCount.ShouldBe(0);
+        module.DisposeCount.ShouldBe(1);
+    }
+
     private sealed class CounterReplayBehavior : EventSourcingBehavior<CounterState>
     {
-        public CounterReplayBehavior(IEventStore eventStore, string agentId)
-            : base(eventStore, agentId) { }
+        public CounterReplayBehavior(
+            IEventStore eventStore,
+            string agentId,
+            IEventSourcingSnapshotStore<CounterState>? snapshotStore = null,
+            ISnapshotStrategy? snapshotStrategy = null)
+            : base(eventStore, agentId, snapshotStore, snapshotStrategy) { }
 
         public override CounterState TransitionState(CounterState current, IMessage evt)
             => StateTransitionMatcher
@@ -127,5 +207,110 @@ public class AgentLifecycleBddTests
                     Name = state.Name,
                 })
                 .OrCurrent();
+    }
+
+    private sealed class RecordingSnapshotStore : IEventSourcingSnapshotStore<CounterState>
+    {
+        public int SaveCount { get; private set; }
+
+        public Task<EventSourcingSnapshot<CounterState>?> LoadAsync(
+            string agentId,
+            CancellationToken ct = default)
+        {
+            _ = agentId;
+            _ = ct;
+            return Task.FromResult<EventSourcingSnapshot<CounterState>?>(null);
+        }
+
+        public Task SaveAsync(
+            string agentId,
+            EventSourcingSnapshot<CounterState> snapshot,
+            CancellationToken ct = default)
+        {
+            _ = agentId;
+            _ = snapshot;
+            _ = ct;
+            SaveCount++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingConfirmBehavior(Exception exception) : IEventSourcingBehavior<CounterState>
+    {
+        public long CurrentVersion => 0;
+
+        public int DiscardPendingEventsCount { get; private set; }
+
+        public int PersistSnapshotCount { get; private set; }
+
+        public void RaiseEvent<TEvent>(TEvent evt)
+            where TEvent : IMessage
+        {
+            _ = evt;
+        }
+
+        public Task<EventStoreCommitResult> ConfirmEventsAsync(CancellationToken ct = default)
+        {
+            _ = ct;
+            return Task.FromException<EventStoreCommitResult>(exception);
+        }
+
+        public Task PersistSnapshotAsync(CounterState currentState, CancellationToken ct = default)
+        {
+            _ = currentState;
+            _ = ct;
+            PersistSnapshotCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task<CounterState?> ReplayAsync(string agentId, CancellationToken ct = default)
+        {
+            _ = agentId;
+            _ = ct;
+            return Task.FromResult<CounterState?>(null);
+        }
+
+        public void DiscardPendingEvents() => DiscardPendingEventsCount++;
+
+        public CounterState TransitionState(CounterState current, IMessage evt)
+        {
+            _ = evt;
+            return current;
+        }
+    }
+
+    private sealed class LifecycleTrackingModule : ILifecycleAwareEventModule
+    {
+        public string Name => "lifecycle";
+
+        public int Priority => 0;
+
+        public int DisposeCount { get; private set; }
+
+        public bool CanHandle(EventEnvelope envelope)
+        {
+            _ = envelope;
+            return false;
+        }
+
+        public Task HandleAsync(EventEnvelope envelope, IEventHandlerContext ctx, CancellationToken ct)
+        {
+            _ = envelope;
+            _ = ctx;
+            _ = ct;
+            return Task.CompletedTask;
+        }
+
+        public Task InitializeAsync(CancellationToken ct)
+        {
+            _ = ct;
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            return ValueTask.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
## 摘要

来源:#1381 Phase 9 r2 split first-slice。主题:GAgentBase OCC deactivation flush containment(限定 OCC-only,non-OCC propagation 仍走原路径)。

## 范围

2 files changed (+206/-5):
- `src/Aevatar.Foundation.Core/GAgentBase.TState.cs`(+22/-5)
- `test/Aevatar.Foundation.Core.Tests/Bdd/AgentLifecycleBddTests.cs`(+189 BDD 回归测试,OCC + non-OCC propagation 覆盖)

实施 codex 本地通过 `dotnet build aevatar.slnx --nologo` + `dotnet test aevatar.slnx --nologo --no-build` + `bash tools/ci/test_stability_guards.sh`。

## 关联

- closes #1489
- refs #1381(来源父 issue split)
- refs #1490(later-slice:runtime-wide deactivation failure contract,设计待定)

## Stacked-PR

base = `auto-refact-dev`。

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
