### PR TITLE
[refactor-impl] #1487 first-slice: typed first-pending tool context

### DIFF
--- a/src/Aevatar.AI.Core/RoleGAgent.cs
+++ b/src/Aevatar.AI.Core/RoleGAgent.cs
@@ -574,7 +574,9 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
 
     private static AgentToolExecutionContext ResolvePendingToolContext(PendingToolApprovalState pending)
     {
-        // Refactor (issue1487/first-slice): Old pattern: pending approval Metadata remained the primary resume context. New principle: pending ToolContext is authoritative, with metadata only as old-state fallback.
+        // Refactor (iter290/cluster-002-invocation-trusted-context-metadata-bag):
+        //   Old pattern: pending approval Metadata remained the primary resume context.
+        //   New principle: pending ToolContext is authoritative; metadata is only a scrubbed old-state annotation fallback.
         var context = pending.ToolContext != null
             ? AgentToolExecutionContextMapper.FromPayload(pending.ToolContext)
             : AgentToolExecutionContext.Empty with

--- a/src/Aevatar.AI.Core/RoleGAgent.cs
+++ b/src/Aevatar.AI.Core/RoleGAgent.cs
@@ -574,15 +574,19 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
 
     private static AgentToolExecutionContext ResolvePendingToolContext(PendingToolApprovalState pending)
     {
-        // Refactor (issue1414/cluster-004):
-        //   Old pattern: pending approval Metadata could rebuild caller, routing, and channel control.
-        //   New principle: pending approval control must already be present in typed ToolContext.
-        return pending.ToolContext != null
-            ? AgentToolExecutionContextMapper.FromPayload(pending.ToolContext) with
+        // Refactor (issue1487/first-slice): Old pattern: pending approval Metadata remained the primary resume context. New principle: pending ToolContext is authoritative, with metadata only as old-state fallback.
+        var context = pending.ToolContext != null
+            ? AgentToolExecutionContextMapper.FromPayload(pending.ToolContext)
+            : AgentToolExecutionContext.Empty with
             {
-                Credentials = AgentToolCredentials.Empty,
-            }
-            : AgentToolExecutionContext.Empty;
+                ExternalMetadata = ScrubPendingApprovalMetadata(pending.Metadata),
+            };
+
+        return context with
+        {
+            Credentials = AgentToolCredentials.Empty,
+            ExternalMetadata = ScrubPendingApprovalMetadata(context.ExternalMetadata),
+        };
     }
 
     private static string? NormalizeToolContextValue(string? value) =>

--- a/test/Aevatar.AI.Tests/RoleGAgentStateCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/RoleGAgentStateCoverageTests.cs
@@ -384,6 +384,144 @@ public sealed class RoleGAgentStateCoverageTests
     }
 
     [Fact]
+    public async Task HandleToolApprovalDecision_ShouldPreferTypedToolContext_WhenLegacyMetadataDiffers()
+    {
+        using var provider = BuildServiceProvider();
+        AgentToolExecutionContext? observedToolContext = null;
+        var agent = CreateRoleAgent(
+            provider,
+            "role-approval-typed-first",
+            toolSources:
+            [
+                new StaticToolSource(
+                [
+                    new DelegateTool("dangerous_tool", _ =>
+                    {
+                        observedToolContext = AgentToolRequestContext.Current;
+                        return "typed-first-result";
+                    })
+                ])
+            ]);
+        var publisher = new RecordingEventPublisher();
+        agent.EventPublisher = publisher;
+        await agent.ActivateAsync();
+        agent.State.PendingApproval = new PendingToolApprovalState
+        {
+            RequestId = "req-1",
+            SessionId = "session-a",
+            ToolName = "dangerous_tool",
+            ToolCallId = "call-1",
+            ArgumentsJson = "{}",
+            ToolContext = new AgentToolExecutionContext(
+                new AgentToolRequestIdentity("typed-request", "typed-call"),
+                new AgentToolCredentials("typed-token", null, null),
+                new AgentToolCallerContext("typed-scope", "typed-owner", "typed-response"),
+                new AgentToolChannelContext("typed-platform", "typed-sender", null, "typed-message", null),
+                AgentToolSenderBindingContext.Empty,
+                new LLMRequestRoutingContext("typed-model", "typed-route", 6, "typed-memory"),
+                AgentToolConnectedServicesContext.Empty,
+                new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["typed-trace"] = "typed-value",
+                    [LLMRequestMetadataKeys.NyxIdAccessToken] = "external-token",
+                }).ToPayload(),
+        };
+        agent.State.PendingApproval.Metadata[LLMRequestMetadataKeys.ScopeId] = "legacy-scope";
+        agent.State.PendingApproval.Metadata[LLMRequestMetadataKeys.ModelOverride] = "legacy-model";
+        agent.State.PendingApproval.Metadata["legacy-trace"] = "legacy-value";
+
+        await agent.HandleToolApprovalDecision(new ToolApprovalDecisionEvent
+        {
+            RequestId = "req-1",
+            Approved = true,
+        });
+
+        observedToolContext.Should().NotBeNull();
+        observedToolContext!.Request.RequestId.Should().Be("typed-request");
+        observedToolContext.Request.CallId.Should().Be("typed-call");
+        observedToolContext.Caller.ScopeId.Should().Be("typed-scope");
+        observedToolContext.Routing.ModelOverride.Should().Be("typed-model");
+        observedToolContext.Credentials.Should().Be(AgentToolCredentials.Empty);
+        observedToolContext.ExternalMetadata.Should().ContainKey("typed-trace").WhoseValue.Should().Be("typed-value");
+        observedToolContext.ExternalMetadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
+        var continuation = publisher.Published.OfType<ChatRequestEvent>().Should().ContainSingle().Which;
+        var continuationContext = AgentToolExecutionContextMapper.FromPayload(continuation.ToolContext);
+        continuationContext.Caller.ScopeId.Should().Be("typed-scope");
+        continuationContext.Routing.ModelOverride.Should().Be("typed-model");
+        continuationContext.Credentials.Should().Be(AgentToolCredentials.Empty);
+        continuationContext.ExternalMetadata.Should().ContainKey("typed-trace").WhoseValue.Should().Be("typed-value");
+        continuationContext.ExternalMetadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
+        continuation.Metadata.Should().ContainKey("legacy-trace").WhoseValue.Should().Be("legacy-value");
+        continuation.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.ScopeId);
+        continuation.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.ModelOverride);
+    }
+
+    [Fact]
+    public async Task HandleToolApprovalDecision_ShouldUseLegacyMetadataFallbackForAnnotationsOnly_WhenToolContextMissing()
+    {
+        using var provider = BuildServiceProvider();
+        AgentToolExecutionContext? observedToolContext = null;
+        var agent = CreateRoleAgent(
+            provider,
+            "role-approval-legacy-fallback",
+            toolSources:
+            [
+                new StaticToolSource(
+                [
+                    new DelegateTool("dangerous_tool", _ =>
+                    {
+                        observedToolContext = AgentToolRequestContext.Current;
+                        return "legacy-fallback-result";
+                    })
+                ])
+            ]);
+        var publisher = new RecordingEventPublisher();
+        agent.EventPublisher = publisher;
+        await agent.ActivateAsync();
+        agent.State.PendingApproval = new PendingToolApprovalState
+        {
+            RequestId = "req-1",
+            SessionId = "session-a",
+            ToolName = "dangerous_tool",
+            ToolCallId = "call-1",
+            ArgumentsJson = "{}",
+        };
+        agent.State.PendingApproval.Metadata[LLMRequestMetadataKeys.RequestId] = "legacy-request";
+        agent.State.PendingApproval.Metadata[LLMRequestMetadataKeys.CallId] = "legacy-call";
+        agent.State.PendingApproval.Metadata[LLMRequestMetadataKeys.ScopeId] = "legacy-scope";
+        agent.State.PendingApproval.Metadata[LLMRequestMetadataKeys.OwnerSubject] = "legacy-owner";
+        agent.State.PendingApproval.Metadata[LLMRequestMetadataKeys.ModelOverride] = "legacy-model";
+        agent.State.PendingApproval.Metadata[LLMRequestMetadataKeys.NyxIdRoutePreference] = "legacy-route";
+        agent.State.PendingApproval.Metadata[LLMRequestMetadataKeys.NyxIdAccessToken] = "legacy-token";
+        agent.State.PendingApproval.Metadata["trace-id"] = "trace-1";
+
+        await agent.HandleToolApprovalDecision(new ToolApprovalDecisionEvent
+        {
+            RequestId = "req-1",
+            Approved = true,
+        });
+
+        observedToolContext.Should().NotBeNull();
+        observedToolContext!.Request.RequestId.Should().BeNull();
+        observedToolContext.Request.CallId.Should().BeNull();
+        observedToolContext.Caller.ScopeId.Should().BeNull();
+        observedToolContext.Caller.OwnerSubject.Should().BeNull();
+        observedToolContext.Routing.ModelOverride.Should().BeNull();
+        observedToolContext.Routing.NyxIdRoutePreference.Should().BeNull();
+        observedToolContext.Credentials.Should().Be(AgentToolCredentials.Empty);
+        observedToolContext.ExternalMetadata.Should().ContainKey("trace-id").WhoseValue.Should().Be("trace-1");
+        var continuation = publisher.Published.OfType<ChatRequestEvent>().Should().ContainSingle().Which;
+        var continuationContext = AgentToolExecutionContextMapper.FromPayload(continuation.ToolContext);
+        continuationContext.Caller.ScopeId.Should().BeNull();
+        continuationContext.Routing.ModelOverride.Should().BeNull();
+        continuationContext.Credentials.Should().Be(AgentToolCredentials.Empty);
+        continuation.Metadata.Should().ContainKey("trace-id").WhoseValue.Should().Be("trace-1");
+        continuation.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
+        continuation.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.ScopeId);
+        continuation.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.ModelOverride);
+    }
+
+    [Fact]
     public async Task HandleToolApprovalDecision_ShouldClearPendingAndRethrow_WhenContinuationDispatchFails()
     {
         using var provider = BuildServiceProvider();


### PR DESCRIPTION
## 摘要

来源:#1254 Phase 9 r2 split first-slice。主题:typed first-pending tool context(RoleGAgent 替代字符串解析)。

## 范围

2 files changed (+150/-8):
- `src/Aevatar.AI.Core/RoleGAgent.cs`(+12/-8)
- `test/Aevatar.AI.Core.Tests/RoleGAgentStateCoverageTests.cs`(+138 LOC state coverage)

实施 codex 本地通过 full slnx test。

## 关联

- closes #1487
- refs #1254(来源父 issue split)
- refs #1488(later-slice:field 9 canon + credential whitelist + remote approval,设计待定)

## Stacked-PR

base = `auto-refact-dev`。

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
