### PR TITLE
[refactor-impl] #1495 first-slice: 删除 static team trusted legacy metadata 注入

### DIFF
--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -536,8 +536,8 @@ public sealed class AevatarInvocationDispatcher
         TeamEntryMemberResolution resolution,
         InvokeTeamToolRequest request)
     {
-        // Refactor (iter1353/cluster-001): Old pattern: team dispatch stamped trusted caller/control facts into Headers.
-        // New principle: Headers carries only filtered payload headers; typed ToolContext and LlmControl carry trusted facts.
+        // Refactor (issue1495/first-slice): Old pattern: static team dispatch accepted trusted caller/control facts through legacy Headers.
+        // New principle: static team Headers carry only filtered payload headers; service identity and caller fields remain the admission boundary.
         var headers = BuildPayloadHeaders(request.Payload.Headers);
         var identity = new ServiceIdentity
         {

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -442,6 +442,50 @@ public sealed class AevatarInvocationToolSourceTests
     }
 
     [Fact]
+    public async Task InvokeTeam_ShouldKeepProtectedTrustedKeysOutOfStaticInvocationHeaders()
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync("aevatar_invoke_team");
+
+        using var _ = PushContext(callId: "call-team-protected-headers");
+        var output = await tool.ExecuteAsync($$"""
+            {
+              "team_id": "team-1",
+              "endpoint_id": "entry",
+              "payload": {
+                "prompt": "go",
+                "headers": {
+                  "{{LLMRequestMetadataKeys.RequestId}}": "evil-request",
+                  "{{LLMRequestMetadataKeys.CallId}}": "evil-call",
+                  "{{LLMRequestMetadataKeys.OwnerSubject}}": "evil-owner",
+                  "{{LLMRequestMetadataKeys.ResponseId}}": "evil-response",
+                  "{{LLMRequestMetadataKeys.NyxIdAccessToken}}": "evil-access-token",
+                  "{{LLMRequestMetadataKeys.NyxIdOrgToken}}": "evil-org-token",
+                  "{{LLMRequestMetadataKeys.SenderNyxIdAccessToken}}": "evil-sender-token",
+                  "{{LLMRequestMetadataKeys.SenderBindingId}}": "evil-binding",
+                  "{{LLMRequestMetadataKeys.ScopeId}}": "evil-scope",
+                  "{{LLMRequestMetadataKeys.ModelOverride}}": "evil-model",
+                  "{{LLMRequestMetadataKeys.NyxIdRoutePreference}}": "evil-route",
+                  "{{LLMRequestMetadataKeys.MaxToolRoundsOverride}}": "99",
+                  "{{LLMRequestMetadataKeys.ConnectedServicesContext}}": "evil-services",
+                  "scope_id": "evil-legacy-scope",
+                  "client-note": "open-extension"
+                }
+              },
+              "wait": "stream"
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        harness.TeamInvocation.Request.Should().NotBeNull();
+        var request = harness.TeamInvocation.Request!;
+        request.Input.Headers.Should().Contain("client-note", "open-extension");
+        request.Identity.TenantId.Should().Be("scope-1");
+        request.Input.Caller!.TenantId.Should().Be("scope-1");
+        ShouldNotCarryTrustedCallerValues(request.Input.Headers);
+    }
+
+    [Fact]
     public async Task InvokeTeam_WhenInvocationReturnsFailureBeforeAcceptance_ShouldReturnStructuredError()
     {
         var harness = new Harness();


### PR DESCRIPTION
## 摘要

来源:#1350 Phase 9 r2 split first-slice。主题:删除 static team trusted legacy metadata 注入。

## 范围

2 files changed (+46/-2):
- `src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs`(+2/-2)
- `test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs`(+44 LOC)

实施 codex 本地通过 full slnx test。

## 关联

- closes #1495
- refs #1350(来源父 issue split)
- refs #1496(later-slice:static team AI context 继承决策,设计待定)

## Stacked-PR

base = `auto-refact-dev`。

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
