### PR TITLE
chore: dev → auto-refact-dev 自动同步 (1 commits)

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
@@ -20,6 +20,64 @@ import {
   StudioWorkflowBuildPanel,
 } from './StudioBuildPanels';
 
+type WorkflowPrimitiveParameterTestDescriptor = {
+  readonly name: string;
+  readonly type: string;
+  readonly required: boolean;
+  readonly description: string;
+  readonly default: string;
+  readonly enumValues: string[];
+};
+
+type WorkflowPrimitiveTestDescriptor = {
+  readonly name: string;
+  readonly aliases: string[];
+  readonly category: string;
+  readonly description: string;
+  readonly parameters: WorkflowPrimitiveParameterTestDescriptor[];
+  readonly exampleWorkflows: string[];
+};
+
+type WorkflowBuildHarnessRoleDocument = {
+  readonly id?: string;
+  readonly name?: string;
+  readonly systemPrompt?: string;
+  readonly provider?: string | null;
+  readonly model?: string | null;
+  readonly connectors?: unknown[];
+};
+
+type WorkflowBuildHarnessStepDocument = {
+  readonly id?: string;
+  readonly type?: string;
+  readonly originalType?: string;
+  readonly targetRole?: string | null;
+  readonly target_role?: string | null;
+  readonly parameters?: Record<string, unknown> | null;
+  readonly next?: string | null;
+  readonly branches?: Record<string, string> | null;
+};
+
+type WorkflowBuildHarnessDocument = {
+  readonly name?: string;
+  readonly description?: string;
+  readonly roles: WorkflowBuildHarnessRoleDocument[];
+  readonly steps: WorkflowBuildHarnessStepDocument[];
+};
+
+type AppliedStepDraft = {
+  readonly parametersText: string;
+};
+
+type BuildWorkflowYamlsForTest = (
+  draft?: {
+    readonly stepId: string;
+    readonly draft: {
+      readonly parametersText: string;
+    };
+  } | null,
+) => Promise<string[]>;
+
 jest.mock('@/shared/api/runtimeRunsApi', () => ({
   runtimeRunsApi: {
     streamDraftRun: jest.fn(),
@@ -130,7 +188,7 @@ const scriptDetail = {
   },
 };
 
-const initialDocument = {
+const initialDocument: WorkflowBuildHarnessDocument = {
   name: 'workflow-demo',
   description: 'Workflow demo',
   roles: [
@@ -171,7 +229,7 @@ function cloneValue<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
 
-function buildWorkflowYaml(document: typeof initialDocument): string {
+function buildWorkflowYaml(document: WorkflowBuildHarnessDocument): string {
   const roleLines = document.roles.flatMap((role) => {
     const lines = [`  - id: ${role.id}`];
     if (role.name) {
@@ -208,17 +266,24 @@ function buildWorkflowYaml(document: typeof initialDocument): string {
 }
 
 function WorkflowBuildHarness({
+  buildWorkflowYamlsOverride,
+  initialDocumentOverride,
   onApplyStepDraftOverride,
   onContinueToBind,
   onSaveDraft,
+  runtimePrimitivesOverride,
 }: {
+  readonly buildWorkflowYamlsOverride?: BuildWorkflowYamlsForTest;
+  readonly initialDocumentOverride?: WorkflowBuildHarnessDocument;
   readonly onApplyStepDraftOverride?: (draft: any) => Promise<void>;
   readonly onContinueToBind: jest.Mock;
   readonly onSaveDraft: jest.Mock;
+  readonly runtimePrimitivesOverride?: readonly WorkflowPrimitiveTestDescriptor[];
 }) {
-  const [document, setDocument] = React.useState(() => cloneValue(initialDocument));
+  const documentSeed = initialDocumentOverride ?? initialDocument;
+  const [document, setDocument] = React.useState(() => cloneValue(documentSeed));
   const [draftYaml, setDraftYaml] = React.useState(() =>
-    buildWorkflowYaml(initialDocument),
+    buildWorkflowYaml(documentSeed),
   );
   const [selectedGraphNodeId, setSelectedGraphNodeId] = React.useState(
     'step:draft_step',
@@ -232,7 +297,7 @@ function WorkflowBuildHarness({
 
   const commitDocument = React.useCallback(
     async (
-      nextDocument: typeof initialDocument,
+      nextDocument: WorkflowBuildHarnessDocument,
       options?: {
         readonly nextSelectedNodeId?: string;
       },
@@ -249,7 +314,7 @@ function WorkflowBuildHarness({
   return (
     <StudioWorkflowBuildPanel
       availableStepTypes={['llm_call', 'human_approval', 'connector_call']}
-      buildWorkflowYamls={async () => [draftYaml]}
+      buildWorkflowYamls={buildWorkflowYamlsOverride ?? (async () => [draftYaml])}
       canSaveWorkflow
       draftYaml={draftYaml}
       dryRunModelLabel="gpt-5.4-mini"
@@ -260,7 +325,7 @@ function WorkflowBuildHarness({
           : async (draft) => {
               const currentStepId = selectedGraphNodeId.replace(/^step:/, '');
               const result = applyStepInspectorDraft(document, currentStepId, draft);
-              await commitDocument(result.document as typeof initialDocument, {
+              await commitDocument(result.document as WorkflowBuildHarnessDocument, {
                 nextSelectedNodeId: result.nodeId,
               });
             }
@@ -279,7 +344,7 @@ function WorkflowBuildHarness({
             sourceStep?.branches || {},
           ),
         );
-        void commitDocument(result.document as typeof initialDocument, {
+        void commitDocument(result.document as WorkflowBuildHarnessDocument, {
           nextSelectedNodeId: result.nodeId,
         });
       }}
@@ -289,7 +354,7 @@ function WorkflowBuildHarness({
           afterStepId: selectedGraphNodeId.replace(/^step:/, ''),
           targetRoleId: 'assistant',
         });
-        await commitDocument(result.document as typeof initialDocument, {
+        await commitDocument(result.document as WorkflowBuildHarnessDocument, {
           nextSelectedNodeId: result.nodeId,
         });
       }}
@@ -305,7 +370,7 @@ function WorkflowBuildHarness({
       onRemoveSelectedStep={async () => {
         const currentStepId = selectedGraphNodeId.replace(/^step:/, '');
         const result = removeStep(document, currentStepId);
-        await commitDocument(result.document as typeof initialDocument, {
+        await commitDocument(result.document as WorkflowBuildHarnessDocument, {
           nextSelectedNodeId: result.nodeId,
         });
       }}
@@ -316,7 +381,7 @@ function WorkflowBuildHarness({
         }
 
         const result = removeStep(document, selectedNodeId);
-        await commitDocument(result.document as typeof initialDocument, {
+        await commitDocument(result.document as WorkflowBuildHarnessDocument, {
           nextSelectedNodeId: result.nodeId,
         });
       }}
@@ -325,9 +390,9 @@ function WorkflowBuildHarness({
         'nyxid.route_preference': '/api/v1/proxy/s/openai',
       }}
       onRunPromptChange={setRunPrompt}
-      onSaveDraft={() => onSaveDraft(draftYaml)}
+      onSaveDraft={(pendingDraft) => onSaveDraft(pendingDraft ?? draftYaml)}
       onSetDraftYaml={setDraftYaml}
-      runtimePrimitives={[
+      runtimePrimitives={runtimePrimitivesOverride ?? [
         {
           name: 'llm_call',
           aliases: [],
@@ -1125,6 +1190,9 @@ describe('StudioWorkflowBuildPanel', () => {
             'nyxid.route_preference': '/api/v1/proxy/s/openai',
           },
           prompt: 'Please triage the refund request.',
+          workflowYamls: [
+            expect.stringContaining('name: workflow-demo'),
+          ],
         }),
         expect.any(AbortSignal),
       );
@@ -1137,6 +1205,262 @@ describe('StudioWorkflowBuildPanel', () => {
     expect(handleContinueToBind).toHaveBeenCalledWith(
       expect.stringContaining('review_step'),
     );
+  });
+
+  it('writes llm_call prompt edits to prompt_prefix when runtime exposes prompt', async () => {
+    const handleApplyStepDraft = jest.fn<Promise<void>, [AppliedStepDraft]>(
+      async () => undefined,
+    );
+
+    render(
+      <WorkflowBuildHarness
+        initialDocumentOverride={{
+          ...initialDocument,
+          steps: [
+            {
+              ...initialDocument.steps[0],
+              parameters: {
+                prompt: 'Legacy prompt field',
+              },
+            },
+            initialDocument.steps[1],
+          ],
+        }}
+        onApplyStepDraftOverride={handleApplyStepDraft}
+        onContinueToBind={jest.fn()}
+        onSaveDraft={jest.fn()}
+        runtimePrimitivesOverride={[
+          {
+            name: 'llm_call',
+            aliases: [],
+            description: 'Call the LLM.',
+            category: 'ai',
+            parameters: [
+              {
+                name: 'prompt',
+                type: 'string',
+                required: false,
+                description: 'Prompt template or prompt override.',
+                default: '',
+                enumValues: [],
+              },
+            ],
+            exampleWorkflows: ['workflow-demo'],
+          },
+        ]}
+      />,
+    );
+
+    const promptPrefixInput = await screen.findByLabelText(
+      'Parameter Prompt instruction',
+    );
+    expect(promptPrefixInput).toHaveValue('Legacy prompt field');
+    expect(screen.getByText('Prompt instruction')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Parameter prompt')).not.toBeInTheDocument();
+    expect(screen.queryByText('prompt_prefix')).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/Instruction added before each workflow run input reaches the LLM/i),
+    ).toBeInTheDocument();
+
+    fireEvent.change(promptPrefixInput, {
+      target: {
+        value: 'Translate the input to Japanese.',
+      },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply changes' }));
+
+    await waitFor(() => {
+      expect(handleApplyStepDraft).toHaveBeenCalledTimes(1);
+    });
+    const appliedDraft = handleApplyStepDraft.mock.calls.at(0)?.[0];
+    if (!appliedDraft) {
+      throw new Error('Expected an applied step draft.');
+    }
+    expect(JSON.parse(appliedDraft.parametersText)).toEqual({
+      prompt_prefix: 'Translate the input to Japanese.',
+    });
+  });
+
+  it('passes unsaved llm_call prompt edits to save draft', async () => {
+    const handleSaveDraft = jest.fn();
+
+    render(
+      <WorkflowBuildHarness
+        onContinueToBind={jest.fn()}
+        onSaveDraft={handleSaveDraft}
+      />,
+    );
+
+    const promptPrefixInput = await screen.findByLabelText(
+      'Parameter Prompt instruction',
+    );
+    fireEvent.change(promptPrefixInput, {
+      target: {
+        value: 'Classify the refund request before answering.',
+      },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save draft' }));
+
+    await waitFor(() => {
+      expect(handleSaveDraft).toHaveBeenCalledTimes(1);
+    });
+    const pendingDraft = handleSaveDraft.mock.calls.at(0)?.[0];
+    if (!pendingDraft || typeof pendingDraft === 'string') {
+      throw new Error('Expected Save draft to receive the pending step draft.');
+    }
+    expect(pendingDraft.stepId).toBe('draft_step');
+    expect(JSON.parse(pendingDraft.draft.parametersText)).toEqual({
+      prompt_prefix: 'Classify the refund request before answering.',
+    });
+  });
+
+  it('passes unsaved llm_call prompt edits to workflow dry-run YAMLs', async () => {
+    const buildWorkflowYamls = jest.fn<
+      Promise<string[]>,
+      Parameters<BuildWorkflowYamlsForTest>
+    >(async () => ['name: workflow-demo']);
+
+    render(
+      <WorkflowBuildHarness
+        buildWorkflowYamlsOverride={buildWorkflowYamls}
+        onContinueToBind={jest.fn()}
+        onSaveDraft={jest.fn()}
+      />,
+    );
+
+    const promptPrefixInput = await screen.findByLabelText(
+      'Parameter Prompt instruction',
+    );
+    fireEvent.change(promptPrefixInput, {
+      target: {
+        value: 'Translate the input to English.',
+      },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    await waitFor(() => {
+      expect(buildWorkflowYamls).toHaveBeenCalledTimes(1);
+    });
+    const pendingDraft = buildWorkflowYamls.mock.calls.at(0)?.[0];
+    if (!pendingDraft) {
+      throw new Error('Expected Run to pass the pending step draft.');
+    }
+    expect(pendingDraft.stepId).toBe('draft_step');
+    expect(JSON.parse(pendingDraft.draft.parametersText)).toEqual({
+      prompt_prefix: 'Translate the input to English.',
+    });
+  });
+
+  it('does not show object defaults as llm prompt instructions', async () => {
+    render(
+      <WorkflowBuildHarness
+        initialDocumentOverride={{
+          ...initialDocument,
+          steps: [
+            {
+              ...initialDocument.steps[0],
+              parameters: {},
+            },
+            initialDocument.steps[1],
+          ],
+        }}
+        onContinueToBind={jest.fn()}
+        onSaveDraft={jest.fn()}
+        runtimePrimitivesOverride={[
+          {
+            name: 'llm_call',
+            aliases: [],
+            description: 'Call the LLM.',
+            category: 'ai',
+            parameters: [
+              {
+                name: 'prompt',
+                type: 'string',
+                required: false,
+                description: 'Prompt template or prompt override.',
+                default: '{}',
+                enumValues: [],
+              },
+            ],
+            exampleWorkflows: ['workflow-demo'],
+          },
+        ]}
+      />,
+    );
+
+    const promptPrefixInput = await screen.findByLabelText(
+      'Parameter Prompt instruction',
+    );
+    expect(promptPrefixInput).toHaveValue('');
+    expect(promptPrefixInput).toHaveAttribute(
+      'placeholder',
+      'e.g. Translate the user input to Japanese',
+    );
+  });
+
+  it('keeps human prompt edits on the prompt parameter', async () => {
+    const handleApplyStepDraft = jest.fn<Promise<void>, [AppliedStepDraft]>(
+      async () => undefined,
+    );
+
+    render(
+      <WorkflowBuildHarness
+        initialDocumentOverride={{
+          ...initialDocument,
+          steps: [
+            initialDocument.steps[0],
+            {
+              ...initialDocument.steps[1],
+              parameters: {
+                prompt: 'Approve this step?',
+              },
+            },
+          ],
+        }}
+        onApplyStepDraftOverride={handleApplyStepDraft}
+        onContinueToBind={jest.fn()}
+        onSaveDraft={jest.fn()}
+        runtimePrimitivesOverride={[
+          {
+            name: 'human_approval',
+            aliases: [],
+            description: 'Pause for approval.',
+            category: 'human',
+            parameters: [
+              {
+                name: 'prompt',
+                type: 'string',
+                required: false,
+                description: 'Prompt shown to the reviewer.',
+                default: '',
+                enumValues: [],
+              },
+            ],
+            exampleWorkflows: ['workflow-demo'],
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'approve_step' }));
+    const promptInput = await screen.findByLabelText('Parameter prompt');
+    fireEvent.change(promptInput, {
+      target: {
+        value: 'Approve the generated response?',
+      },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply changes' }));
+
+    await waitFor(() => {
+      expect(handleApplyStepDraft).toHaveBeenCalledTimes(1);
+    });
+    const appliedDraft = handleApplyStepDraft.mock.calls.at(0)?.[0];
+    if (!appliedDraft) {
+      throw new Error('Expected an applied step draft.');
+    }
+    expect(JSON.parse(appliedDraft.parametersText)).toEqual({
+      prompt: 'Approve the generated response?',
+    });
   });
 
   it('keeps runtime metadata out of output and only exposes it in debug details', async () => {

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
@@ -51,6 +51,9 @@ import {
 } from '@/shared/studio/scriptPackage';
 import {
   createStepInspectorDraft,
+  readStepParameterValue,
+  resolveStepParameterName,
+  normalizeStepParametersForType,
   parseInspectorParameters,
   type StudioStepInspectorDraft,
 } from '@/shared/studio/document';
@@ -574,6 +577,109 @@ function tryParseStepParameters(
   }
 }
 
+function normalizePrimitiveParameterDescriptor(
+  stepType: string,
+  parameter: WorkflowPrimitiveDescriptor['parameters'][number],
+): WorkflowPrimitiveDescriptor['parameters'][number] {
+  const resolvedName = resolveStepParameterName(stepType, parameter.name);
+  if (resolvedName === parameter.name) {
+    return parameter;
+  }
+
+  return {
+    ...parameter,
+    name: resolvedName,
+  };
+}
+
+function isLLMPromptInstructionParameter(
+  stepType: string,
+  parameterName: string,
+): boolean {
+  return (
+    stepType.trim().toLowerCase() === 'llm_call' &&
+    resolveStepParameterName(stepType, parameterName) === 'prompt_prefix'
+  );
+}
+
+function getParameterDisplayLabel(
+  stepType: string,
+  parameter: WorkflowPrimitiveDescriptor['parameters'][number],
+): string {
+  return isLLMPromptInstructionParameter(stepType, parameter.name)
+    ? 'Prompt instruction'
+    : parameter.name;
+}
+
+function getParameterDisplayDescription(
+  stepType: string,
+  parameter: WorkflowPrimitiveDescriptor['parameters'][number],
+): string {
+  if (isLLMPromptInstructionParameter(stepType, parameter.name)) {
+    return 'Instruction added before each workflow run input reaches the LLM.';
+  }
+
+  return parameter.description || `Type: ${parameter.type}`;
+}
+
+function getParameterPlaceholder(
+  stepType: string,
+  parameter: WorkflowPrimitiveDescriptor['parameters'][number],
+): string {
+  if (isLLMPromptInstructionParameter(stepType, parameter.name)) {
+    return 'e.g. Translate the user input to Japanese';
+  }
+
+  return parameter.default || parameter.type || 'Value';
+}
+
+function shouldUseParameterDefault(
+  stepType: string,
+  parameter: WorkflowPrimitiveDescriptor['parameters'][number],
+): boolean {
+  return !isLLMPromptInstructionParameter(stepType, parameter.name);
+}
+
+function normalizeParameterEditorSourceValue(
+  stepType: string,
+  parameterName: string,
+  value: unknown,
+): unknown {
+  if (
+    isLLMPromptInstructionParameter(stepType, parameterName) &&
+    value !== null &&
+    typeof value === 'object'
+  ) {
+    return '';
+  }
+
+  return value;
+}
+
+function normalizePrimitiveParameterDescriptors(
+  stepType: string,
+  parameters: readonly WorkflowPrimitiveDescriptor['parameters'][number][],
+): WorkflowPrimitiveDescriptor['parameters'][number][] {
+  const nextParameters: WorkflowPrimitiveDescriptor['parameters'][number][] = [];
+  const seenParameterNames = new Set<string>();
+
+  for (const parameter of parameters) {
+    const normalizedParameter = normalizePrimitiveParameterDescriptor(
+      stepType,
+      parameter,
+    );
+    const normalizedName = normalizedParameter.name.trim().toLowerCase();
+    if (!normalizedName || seenParameterNames.has(normalizedName)) {
+      continue;
+    }
+
+    seenParameterNames.add(normalizedName);
+    nextParameters.push(normalizedParameter);
+  }
+
+  return nextParameters;
+}
+
 function formatParameterEditorValue(value: unknown): string {
   if (value === null || value === undefined) {
     return '';
@@ -647,19 +753,44 @@ function updateStepDraftParameterValue(
   parameterType: string,
   rawValue: string,
 ): StudioStepInspectorDraft {
-  const nextParameters = tryParseStepParameters(draft.parametersText) ?? {};
+  const resolvedParameterName = resolveStepParameterName(draft.type, parameterName);
+  const nextParameters = normalizeStepParametersForType(
+    draft.type,
+    tryParseStepParameters(draft.parametersText) ?? {},
+  );
   const trimmed = rawValue.trim();
 
   if (!trimmed) {
-    delete nextParameters[parameterName];
+    delete nextParameters[resolvedParameterName];
   } else {
-    nextParameters[parameterName] = coerceParameterEditorValue(rawValue, parameterType);
+    nextParameters[resolvedParameterName] = coerceParameterEditorValue(
+      rawValue,
+      parameterType,
+    );
   }
 
   return {
     ...draft,
     parametersText: JSON.stringify(nextParameters, null, 2),
   };
+}
+
+function areStepInspectorDraftsEqual(
+  left: StudioStepInspectorDraft | null,
+  right: StudioStepInspectorDraft | null,
+): boolean {
+  if (!left || !right) {
+    return false;
+  }
+
+  return (
+    left.id === right.id &&
+    left.type === right.type &&
+    left.targetRole === right.targetRole &&
+    left.next === right.next &&
+    left.parametersText === right.parametersText &&
+    left.branchesText === right.branchesText
+  );
 }
 
 async function consumeAguiDraftRun(
@@ -854,7 +985,12 @@ function ScriptLeaveDialog(props: {
 export type StudioWorkflowBuildPanelProps = {
   readonly draftYaml: string;
   readonly onSetDraftYaml: (value: string) => void;
-  readonly onSaveDraft: () => void;
+  readonly onSaveDraft: (
+    draft?: {
+      readonly stepId: string;
+      readonly draft: StudioStepInspectorDraft;
+    } | null,
+  ) => void;
   readonly savePending: boolean;
   readonly canSaveWorkflow: boolean;
   readonly saveNotice?: { readonly type: 'success' | 'error'; readonly message: string } | null;
@@ -870,7 +1006,12 @@ export type StudioWorkflowBuildPanelProps = {
   readonly workflowName: string;
   readonly runPrompt: string;
   readonly onRunPromptChange: (value: string) => void;
-  readonly buildWorkflowYamls: () => Promise<string[]>;
+  readonly buildWorkflowYamls: (
+    draft?: {
+      readonly stepId: string;
+      readonly draft: StudioStepInspectorDraft;
+    } | null,
+  ) => Promise<string[]>;
   readonly runMetadata?: Record<string, string>;
   readonly dryRunRouteLabel?: string;
   readonly dryRunModelLabel?: string;
@@ -952,14 +1093,12 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
             current: StudioStepInspectorDraft | null,
           ) => StudioStepInspectorDraft | null),
     ) => {
-      setStepDraft((current) => {
-        const nextDraft =
-          typeof updater === 'function'
-            ? updater(current)
-            : updater;
-        stepDraftRef.current = nextDraft;
-        return nextDraft;
-      });
+      const nextDraft =
+        typeof updater === 'function'
+          ? updater(stepDraftRef.current)
+          : updater;
+      stepDraftRef.current = nextDraft;
+      setStepDraft(nextDraft);
     },
     [],
   );
@@ -1049,6 +1188,14 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
       }) ?? null,
     [runtimePrimitives, selectedStep?.type, stepDraft?.type],
   );
+  const selectedPrimitiveParameters = React.useMemo(
+    () =>
+      normalizePrimitiveParameterDescriptors(
+        stepDraft?.type || selectedStep?.type || '',
+        selectedPrimitiveDescriptor?.parameters ?? [],
+      ),
+    [selectedPrimitiveDescriptor, selectedStep?.type, stepDraft?.type],
+  );
   const parsedStepParameters = React.useMemo(
     () =>
       stepDraft
@@ -1090,6 +1237,8 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
       return;
     }
 
+    const currentStepDraft = stepDraftRef.current;
+
     if (!scopeId) {
       const visibleMessage = 'Resolve the current workspace before running the workflow draft.';
       setWorkflowRunError(visibleMessage);
@@ -1127,7 +1276,16 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
         {
           metadata: runMetadata,
           prompt: runPrompt,
-          workflowYamls: await buildWorkflowYamls(),
+          workflowYamls: await buildWorkflowYamls(
+            currentStepDraft &&
+              selectedStepDraftSeed &&
+              !areStepInspectorDraftsEqual(currentStepDraft, selectedStepDraftSeed)
+              ? {
+                  stepId: selectedStepId,
+                  draft: currentStepDraft,
+                }
+              : null,
+          ),
         },
         controller.signal,
       );
@@ -1173,6 +1331,8 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
     runMetadata,
     runPrompt,
     scopeId,
+    selectedStepDraftSeed,
+    selectedStepId,
   ]);
 
   const handleInsertStep = React.useCallback(async (stepType: string) => {
@@ -1216,6 +1376,20 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
       setStepMutationPending('');
     }
   }, [onApplyStepDraft]);
+
+  const handleSaveDraft = React.useCallback(() => {
+    const currentStepDraft = stepDraftRef.current;
+    onSaveDraft(
+      currentStepDraft &&
+        selectedStepDraftSeed &&
+        !areStepInspectorDraftsEqual(currentStepDraft, selectedStepDraftSeed)
+        ? {
+            stepId: selectedStepId,
+            draft: currentStepDraft,
+          }
+        : null,
+    );
+  }, [onSaveDraft, selectedStepDraftSeed, selectedStepId]);
 
   const handleRemoveStep = React.useCallback(async () => {
     if (stepMutationPendingRef.current) {
@@ -1316,7 +1490,7 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
               className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
               disabled={!canSaveWorkflow}
               loading={savePending}
-              onClick={onSaveDraft}
+              onClick={handleSaveDraft}
             >
               Save draft
             </Button>
@@ -1592,12 +1766,36 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
                 </div>
                 <div style={{ ...workflowFieldStyle, gridColumn: '1 / -1' }}>
                   <div style={workflowSectionHeadingStyle}>Parameters</div>
-                  {selectedPrimitiveDescriptor?.parameters.length ? (
+                  {selectedPrimitiveParameters.length ? (
                     <div style={{ display: 'grid', gap: 10 }}>
-                      {selectedPrimitiveDescriptor.parameters.map((parameter) => {
+                      {selectedPrimitiveParameters.map((parameter) => {
+                        const parameterDisplayLabel = getParameterDisplayLabel(
+                          stepDraft.type,
+                          parameter,
+                        );
+                        const parameterAriaLabel = `Parameter ${parameterDisplayLabel}`;
+                        const parameterPlaceholder = getParameterPlaceholder(
+                          stepDraft.type,
+                          parameter,
+                        );
+                        const parameterDescription = getParameterDisplayDescription(
+                          stepDraft.type,
+                          parameter,
+                        );
+                        const parameterValue = normalizeParameterEditorSourceValue(
+                          stepDraft.type,
+                          parameter.name,
+                          readStepParameterValue(
+                            parsedStepParameters,
+                            stepDraft.type,
+                            parameter.name,
+                          ),
+                        );
                         const currentValue = formatParameterEditorValue(
-                          parsedStepParameters?.[parameter.name] ??
-                            parameter.default,
+                          parameterValue ??
+                            (shouldUseParameterDefault(stepDraft.type, parameter)
+                              ? parameter.default
+                              : ''),
                         );
 
                         return (
@@ -1609,19 +1807,19 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
                               htmlFor={`workflow-step-parameter-${parameter.name}`}
                               style={workflowFieldLabelStyle}
                             >
-                              {parameter.name}
+                              {parameterDisplayLabel}
                               {parameter.required ? ' *' : ''}
                             </label>
                             {parameter.enumValues.length > 0 ? (
                               <Select
                                 allowClear={!parameter.required}
-                                aria-label={`Parameter ${parameter.name}`}
+                                aria-label={parameterAriaLabel}
                                 id={`workflow-step-parameter-${parameter.name}`}
                                 options={parameter.enumValues.map((value) => ({
                                   label: value,
                                   value,
                                 }))}
-                                placeholder={parameter.default || 'Select value'}
+                                placeholder={parameterPlaceholder}
                                 value={currentValue || undefined}
                                 onChange={(value) =>
                                   updateStepDraft((current) =>
@@ -1638,9 +1836,9 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
                               />
                             ) : (
                               <Input
-                                aria-label={`Parameter ${parameter.name}`}
+                                aria-label={parameterAriaLabel}
                                 id={`workflow-step-parameter-${parameter.name}`}
-                                placeholder={parameter.default || parameter.type || 'Value'}
+                                placeholder={parameterPlaceholder}
                                 value={currentValue}
                                 onChange={(event) =>
                                   updateStepDraft((current) =>
@@ -1657,7 +1855,7 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
                               />
                             )}
                             <div style={workflowInlineMetaStyle}>
-                              {parameter.description || `Type: ${parameter.type}`}
+                              {parameterDescription}
                             </div>
                           </div>
                         );
@@ -1759,7 +1957,7 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
             <Typography.Text strong>Workflow draft run</Typography.Text>
           </div>
           <span style={{ ...statusTagStyle, background: '#f6ffed', color: '#237804' }}>
-            seeded fixture
+            Draft input
           </span>
         </div>
         <div style={{ display: 'grid', gap: 8 }}>
@@ -1824,7 +2022,7 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
               )
             }
           >
-            Load fixture
+            Load sample input
           </Button>
         </Space>
         {workflowRunError ? (
@@ -3048,7 +3246,7 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
             <Typography.Text strong>Script draft run</Typography.Text>
           </div>
           <span style={{ ...statusTagStyle, background: '#fffbe6', color: '#ad6800' }}>
-            seeded fixture
+            Draft input
           </span>
         </div>
         <div style={sectionDescriptionStyle}>
@@ -3088,7 +3286,7 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
               )
             }
           >
-            Load fixture
+            Load sample input
           </Button>
         </Space>
         <div>
@@ -3489,7 +3687,7 @@ export const StudioGAgentBuildPanel: React.FC<StudioGAgentBuildPanelProps> = ({
             <Typography.Text strong>GAgent draft run</Typography.Text>
           </div>
           <span style={{ ...statusTagStyle, background: '#f6ffed', color: '#237804' }}>
-            seeded fixture
+            Draft input
           </span>
         </div>
         <div style={sectionDescriptionStyle}>
@@ -3517,7 +3715,7 @@ export const StudioGAgentBuildPanel: React.FC<StudioGAgentBuildPanelProps> = ({
               setRunPrompt('Classify this support ticket, keep the member state, and decide whether to escalate.')
             }
           >
-            Load fixture
+            Load sample input
           </Button>
         </Space>
         <div>

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -115,6 +115,13 @@ function mockBuildWorkflowYaml(document: typeof mockWorkflowDocument): string {
     if (step.targetRole) {
       lines.push(`    targetRole: ${step.targetRole}`);
     }
+    const parameterEntries = Object.entries(step.parameters ?? {});
+    if (parameterEntries.length > 0) {
+      lines.push("    parameters:");
+      for (const [key, value] of parameterEntries) {
+        lines.push(`      ${key}: ${String(value)}`);
+      }
+    }
     if (step.next) {
       lines.push(`    next: ${step.next}`);
     }
@@ -387,6 +394,7 @@ let mockConnectorDraftResponse: any;
 let mockRoleCatalog: any;
 let mockRoleDraftResponse: any;
 let mockSettings: any;
+let mockLastWorkflowBuildPanelProps: any;
 const defaultStudioAppContext = {
   mode: "proxy",
   scopeId: null,
@@ -1712,6 +1720,7 @@ jest.mock("./components/StudioBootstrapGate", () => ({
 jest.mock("./components/StudioBuildPanels", () => {
   const mockReact = require("react");
   const StudioWorkflowBuildPanel = (props: any) => {
+    mockLastWorkflowBuildPanelProps = props;
     const [detailsMode, setDetailsMode] = mockReact.useState("step");
     const [addStepType, setAddStepType] = mockReact.useState(
       props.availableStepTypes?.[0] || "llm_call"
@@ -1724,25 +1733,35 @@ jest.mock("./components/StudioBuildPanels", () => {
         null
       );
     }, [props.selectedGraphNodeId, props.workflowGraph?.steps]);
-    const [stepDraft, setStepDraft] = mockReact.useState(() => ({
+    const selectedStepDraftSeed = mockReact.useMemo(() => ({
+      kind: "step",
       id: selectedStep?.id || "",
       type: selectedStep?.type || "llm_call",
       targetRole: selectedStep?.targetRole || "",
       next: selectedStep?.next || "",
       parametersText: JSON.stringify(selectedStep?.parameters || {}, null, 2),
       branchesText: JSON.stringify(selectedStep?.branches || {}, null, 2),
-    }));
+    }), [
+      selectedStep?.id,
+      selectedStep?.type,
+      selectedStep?.targetRole,
+      selectedStep?.next,
+      JSON.stringify(selectedStep?.parameters || {}),
+      JSON.stringify(selectedStep?.branches || {}),
+    ]);
+    const [stepDraft, setStepDraft] = mockReact.useState(() => selectedStepDraftSeed);
+    const stepDraftRef = mockReact.useRef(stepDraft);
+
+    const updateStepDraft = mockReact.useCallback((updater: any) => {
+      const nextDraft =
+        typeof updater === "function" ? updater(stepDraftRef.current) : updater;
+      stepDraftRef.current = nextDraft;
+      setStepDraft(nextDraft);
+    }, []);
 
     mockReact.useEffect(() => {
-      setStepDraft({
-        id: selectedStep?.id || "",
-        type: selectedStep?.type || "llm_call",
-        targetRole: selectedStep?.targetRole || "",
-        next: selectedStep?.next || "",
-        parametersText: JSON.stringify(selectedStep?.parameters || {}, null, 2),
-        branchesText: JSON.stringify(selectedStep?.branches || {}, null, 2),
-      });
-    }, [selectedStep]);
+      updateStepDraft(selectedStepDraftSeed);
+    }, [selectedStepDraftSeed]);
 
     return mockReact.createElement("div", { "data-testid": "studio-workflow-build-panel" }, [
       mockReact.createElement("div", { key: "eyebrow" }, "DAG Canvas"),
@@ -1830,7 +1849,7 @@ jest.mock("./components/StudioBuildPanels", () => {
               "aria-label": "Step ID",
               value: stepDraft.id,
               onChange: (event: MockValueEvent) =>
-                setStepDraft((current: any) => ({ ...current, id: event.target.value })),
+                updateStepDraft((current: any) => ({ ...current, id: event.target.value })),
             }),
             mockReact.createElement(
               "select",
@@ -1838,7 +1857,7 @@ jest.mock("./components/StudioBuildPanels", () => {
                 "aria-label": "Step type",
                 value: stepDraft.type,
                 onChange: (event: MockValueEvent) =>
-                  setStepDraft((current: any) => ({ ...current, type: event.target.value })),
+                  updateStepDraft((current: any) => ({ ...current, type: event.target.value })),
               },
               (props.availableStepTypes || ["llm_call"]).map((stepType: string) =>
                 mockReact.createElement("option", { key: stepType, value: stepType }, stepType)
@@ -1848,7 +1867,7 @@ jest.mock("./components/StudioBuildPanels", () => {
               "aria-label": "Target role",
               value: stepDraft.targetRole,
               onChange: (event: MockValueEvent) =>
-                setStepDraft((current: any) => ({
+                updateStepDraft((current: any) => ({
                   ...current,
                   targetRole: event.target.value,
                 })),
@@ -1857,13 +1876,13 @@ jest.mock("./components/StudioBuildPanels", () => {
               "aria-label": "Next step",
               value: stepDraft.next,
               onChange: (event: MockValueEvent) =>
-                setStepDraft((current: any) => ({ ...current, next: event.target.value })),
+                updateStepDraft((current: any) => ({ ...current, next: event.target.value })),
             }),
             mockReact.createElement("textarea", {
               "aria-label": "Step parameters",
               value: stepDraft.parametersText,
               onChange: (event: MockValueEvent) =>
-                setStepDraft((current: any) => ({
+                updateStepDraft((current: any) => ({
                   ...current,
                   parametersText: event.target.value,
                 })),
@@ -1872,7 +1891,7 @@ jest.mock("./components/StudioBuildPanels", () => {
               "aria-label": "Step branches",
               value: stepDraft.branchesText,
               onChange: (event: MockValueEvent) =>
-                setStepDraft((current: any) => ({
+                updateStepDraft((current: any) => ({
                   ...current,
                   branchesText: event.target.value,
                 })),
@@ -1923,7 +1942,40 @@ jest.mock("./components/StudioBuildPanels", () => {
           key: "save",
           type: "button",
           disabled: !props.canSaveWorkflow,
-          onClick: () => props.onSaveDraft?.(),
+          onClick: () => {
+            const currentParametersText =
+              (
+                globalThis.document.querySelector(
+                  'textarea[aria-label="Step parameters"]'
+                ) as HTMLTextAreaElement | null
+              )?.value ?? stepDraftRef.current.parametersText;
+            const currentBranchesText =
+              (
+                globalThis.document.querySelector(
+                  'textarea[aria-label="Step branches"]'
+                ) as HTMLTextAreaElement | null
+              )?.value ?? stepDraftRef.current.branchesText;
+            const currentStepDraft = {
+              ...stepDraftRef.current,
+              parametersText: currentParametersText,
+              branchesText: currentBranchesText,
+            };
+            const currentHasPendingStepDraft =
+              currentStepDraft.id !== selectedStepDraftSeed.id ||
+              currentStepDraft.type !== selectedStepDraftSeed.type ||
+              currentStepDraft.targetRole !== selectedStepDraftSeed.targetRole ||
+              currentStepDraft.next !== selectedStepDraftSeed.next ||
+              currentStepDraft.parametersText !== selectedStepDraftSeed.parametersText ||
+              currentStepDraft.branchesText !== selectedStepDraftSeed.branchesText;
+            props.onSaveDraft?.(
+              currentHasPendingStepDraft
+                ? {
+                    stepId: selectedStep?.id || "",
+                    draft: currentStepDraft,
+                  }
+                : null
+            );
+          },
         },
         "Save draft"
       ),
@@ -4924,6 +4976,83 @@ describe("StudioPage", () => {
     });
   });
 
+  it("saves pending workflow step prompt edits without requiring Apply changes", async () => {
+    renderStudioPage("/studio?scopeId=scope-1&focus=workflow%3Aworkflow-1&tab=studio");
+
+    await waitFor(() => {
+      expect(mockLastWorkflowBuildPanelProps?.onSaveDraft).toEqual(expect.any(Function));
+      expect(mockLastWorkflowBuildPanelProps?.canSaveWorkflow).toBe(true);
+    });
+    const staleWorkflowDocument = mockCloneValue(mockWorkflowDocument) as any;
+    staleWorkflowDocument.steps[0].parameters = {};
+    const staleWorkflowResponse = {
+      ...mockWorkflowFile,
+      yaml: mockBuildWorkflowYaml(staleWorkflowDocument),
+      document: staleWorkflowDocument,
+    };
+    (studioApi.saveWorkflow as jest.Mock).mockResolvedValueOnce(staleWorkflowResponse);
+    (studioApi.serializeYaml as jest.Mock).mockClear();
+    await act(async () => {
+      await mockLastWorkflowBuildPanelProps.onSaveDraft({
+        stepId: "draft_step",
+        draft: {
+          kind: "step",
+          id: "draft_step",
+          type: "llm_call",
+          targetRole: "assistant",
+          next: "approve_step",
+          parametersText: JSON.stringify(
+            {
+              prompt_prefix: "Classify the refund request before answering.",
+            },
+            null,
+            2
+          ),
+          branchesText: "{}",
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(studioApi.serializeYaml).toHaveBeenCalledWith(
+        expect.objectContaining({
+          document: expect.objectContaining({
+            steps: expect.arrayContaining([
+              expect.objectContaining({
+                id: "draft_step",
+                parameters: expect.objectContaining({
+                  prompt_prefix: "Classify the refund request before answering.",
+                }),
+              }),
+            ]),
+          }),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(studioApi.saveWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scopeId: "scope-1",
+          yaml: expect.stringContaining(
+            "prompt_prefix: Classify the refund request before answering."
+          ),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockLastWorkflowBuildPanelProps?.draftYaml).toContain(
+        "prompt_prefix: Classify the refund request before answering."
+      );
+      expect(mockLastWorkflowBuildPanelProps?.workflowGraph.steps[0].parameters).toEqual(
+        expect.objectContaining({
+          prompt_prefix: "Classify the refund request before answering.",
+        })
+      );
+    });
+  });
+
   it("applies workflow step changes without requiring a manual graph selection first", async () => {
     renderStudioPage("/studio?scopeId=scope-1&focus=workflow%3Aworkflow-1&tab=studio");
 
@@ -5153,6 +5282,24 @@ describe("StudioPage", () => {
   });
 
   it("surfaces the current workflow as a bind candidate before any published service exists", async () => {
+    mockParsedDocument = {
+      ...mockParsedDocument,
+      steps: mockParsedDocument.steps.map((step) =>
+        step.type === "llm_call"
+          ? {
+              ...step,
+              parameters: {
+                prompt: "把用户输入的内容转成日语",
+              },
+            }
+          : step
+      ),
+    } as any;
+    mockWorkflowFile = {
+      ...mockWorkflowFile,
+      document: mockParsedDocument,
+      yaml: mockBuildWorkflowYaml(mockParsedDocument),
+    };
     mockScopeRuntimeApi.listServices.mockReset();
     mockScopeRuntimeApi.listServices
       .mockResolvedValueOnce([])
@@ -5202,6 +5349,15 @@ describe("StudioPage", () => {
         }),
       );
     });
+    const workflowYamls =
+      (studioApi.bindMemberWorkflow as jest.Mock).mock.calls.at(-1)?.[0]
+        ?.workflowYamls ?? [];
+    expect(workflowYamls.join("\n")).toContain(
+      "prompt_prefix: 把用户输入的内容转成日语"
+    );
+    expect(workflowYamls.join("\n")).not.toContain(
+      "prompt: 把用户输入的内容转成日语"
+    );
     await waitFor(() => {
       expect(screen.getByText("service:default")).toBeTruthy();
       expect(screen.getByText("services:default")).toBeTruthy();
@@ -6850,6 +7006,56 @@ describe("StudioPage", () => {
     expect(
       (await screen.findByLabelText("Workflow dry run input")) as HTMLTextAreaElement
     ).toHaveValue("Continue this workflow in Studio");
+  });
+
+  it("runs workflow dry-run with pending step prompt edits", async () => {
+    renderStudioPage("/studio?scopeId=scope-1&focus=workflow%3Aworkflow-1&tab=studio");
+
+    expect(await screen.findByText("DAG Canvas")).toBeTruthy();
+    await waitFor(() => {
+      expect(mockLastWorkflowBuildPanelProps?.buildWorkflowYamls).toEqual(
+        expect.any(Function)
+      );
+    });
+    (studioApi.serializeYaml as jest.Mock).mockClear();
+
+    const workflowYamls = await mockLastWorkflowBuildPanelProps.buildWorkflowYamls({
+      stepId: "draft_step",
+      draft: {
+        kind: "step",
+        id: "draft_step",
+        type: "llm_call",
+        targetRole: "assistant",
+        next: "approve_step",
+        parametersText: JSON.stringify(
+          {
+            prompt_prefix: "Translate the input to English.",
+          },
+          null,
+          2
+        ),
+        branchesText: "{}",
+      },
+    });
+
+    expect(workflowYamls).toEqual([
+      expect.stringContaining("prompt_prefix: Translate the input to English."),
+    ]);
+    expect(studioApi.serializeYaml).toHaveBeenCalledTimes(1);
+    expect(studioApi.serializeYaml).toHaveBeenCalledWith(
+      expect.objectContaining({
+        document: expect.objectContaining({
+          steps: expect.arrayContaining([
+            expect.objectContaining({
+              id: "draft_step",
+              parameters: expect.objectContaining({
+                prompt_prefix: "Translate the input to English.",
+              }),
+            }),
+          ]),
+        }),
+      })
+    );
   });
 
   it("shows the published template graph in the Studio editor", async () => {

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -62,6 +62,7 @@ import {
   cloneStudioWorkflowDocument,
   connectStepToTarget,
   insertStepByType,
+  normalizeStepParametersForType,
   removeStep,
   removeSteps,
   suggestBranchLabelForStep,
@@ -4242,8 +4243,126 @@ const StudioPage: React.FC = () => {
     [availableStepTypes, draftWorkflowName, workflowNames],
   );
 
-  const buildWorkflowYamlBundle = useCallback(async (): Promise<string[]> => {
-    const rootYaml = draftYaml.trim();
+  const normalizeWorkflowYamlForRuntime = useCallback(
+    async (
+      yaml: string,
+      document: StudioWorkflowDocument | null | undefined,
+      availableWorkflowNames: string[],
+    ): Promise<{
+      readonly yaml: string;
+      readonly document: StudioWorkflowDocument | null;
+    }> => {
+      const sourceYaml = yaml.trim();
+      if (!sourceYaml) {
+        return {
+          yaml: sourceYaml,
+          document: document ?? null,
+        };
+      }
+
+      let sourceDocument = cloneStudioWorkflowDocument(document);
+      if (!sourceDocument) {
+        sourceDocument =
+          cloneStudioWorkflowDocument(
+            (
+              await studioApi.parseYaml({
+                yaml: sourceYaml,
+                availableWorkflowNames,
+                availableStepTypes,
+              })
+            ).document,
+          ) ?? null;
+      }
+
+      if (!sourceDocument?.steps?.length) {
+        return {
+          yaml: sourceYaml,
+          document: sourceDocument,
+        };
+      }
+
+      const normalizedDocument: StudioWorkflowDocument = {
+        ...sourceDocument,
+        steps: sourceDocument.steps.map((step) => ({
+          ...step,
+          parameters: normalizeStepParametersForType(
+            trimOptional(step.type ?? step.originalType),
+            step.parameters && typeof step.parameters === 'object'
+              ? step.parameters
+              : {},
+          ),
+        })),
+      };
+
+      const serialized = await studioApi.serializeYaml({
+        document: normalizedDocument,
+        availableWorkflowNames,
+        availableStepTypes,
+      });
+
+      return {
+        yaml: serialized.yaml.trim() || sourceYaml,
+        document:
+          cloneStudioWorkflowDocument(serialized.document) ??
+          normalizedDocument,
+      };
+    },
+    [availableStepTypes],
+  );
+
+  const buildWorkflowYamlBundle = useCallback(async (
+    pendingStepDraft?: {
+      readonly stepId: string;
+      readonly draft: StudioStepInspectorDraft;
+    } | null,
+  ): Promise<string[]> => {
+    let rootYaml = draftYaml.trim();
+    let rootDocument: StudioWorkflowDocument | null | undefined =
+      activeWorkflowDocument;
+    let rootRuntimeYamlReady = false;
+
+    if (pendingStepDraft) {
+      const currentStepId = pendingStepDraft.stepId.trim();
+      if (!currentStepId) {
+        throw new Error('Select a workflow step before running its draft changes.');
+      }
+
+      const document =
+        cloneStudioWorkflowDocument(
+          activeWorkflowDocument ||
+            parsedWorkflowDocument ||
+            activeWorkflowFile?.document ||
+            null,
+        ) ||
+        cloneStudioWorkflowDocument(
+          (
+            await studioApi.parseYaml({
+              yaml: rootYaml,
+              availableWorkflowNames: workflowNames,
+              availableStepTypes,
+            })
+          ).document as StudioWorkflowDocument | null,
+        );
+      if (!document) {
+        throw new Error('Load a workflow draft before running its draft changes.');
+      }
+
+      const result = applyStepInspectorDraft(
+        document,
+        currentStepId,
+        pendingStepDraft.draft,
+      );
+      const serialized = await studioApi.serializeYaml({
+        document: result.document,
+        availableWorkflowNames: workflowNames,
+        availableStepTypes,
+      });
+
+      rootYaml = serialized.yaml.trim();
+      rootDocument = result.document;
+      rootRuntimeYamlReady = true;
+    }
+
     if (!rootYaml) {
       throw new Error('Workflow YAML is required.');
     }
@@ -4259,11 +4378,13 @@ const StudioPage: React.FC = () => {
       workflowName: string;
       yaml: string;
       document: StudioWorkflowDocument | null | undefined;
+      runtimeYamlReady?: boolean;
     }> = [
       {
         workflowName: activeWorkflowName.trim() || draftWorkflowName.trim(),
         yaml: rootYaml,
-        document: activeWorkflowDocument,
+        document: rootDocument,
+        runtimeYamlReady: rootRuntimeYamlReady,
       },
     ];
 
@@ -4281,9 +4402,29 @@ const StudioPage: React.FC = () => {
       if (normalizedWorkflowName) {
         seen.add(normalizedWorkflowName);
       }
-      bundle.push(current.yaml);
+      const normalizedCurrent = current.runtimeYamlReady
+        ? {
+            yaml: current.yaml,
+            document:
+              cloneStudioWorkflowDocument(current.document) ??
+              cloneStudioWorkflowDocument(
+                (
+                  await studioApi.parseYaml({
+                    yaml: current.yaml,
+                    availableWorkflowNames,
+                    availableStepTypes,
+                  })
+                ).document as StudioWorkflowDocument | null,
+              ),
+          }
+        : await normalizeWorkflowYamlForRuntime(
+            current.yaml,
+            current.document,
+            availableWorkflowNames,
+          );
+      bundle.push(normalizedCurrent.yaml);
 
-      for (const targetWorkflow of readWorkflowCallTargets(current.document)) {
+      for (const targetWorkflow of readWorkflowCallTargets(normalizedCurrent.document)) {
         if (seen.has(targetWorkflow)) {
           continue;
         }
@@ -4321,12 +4462,16 @@ const StudioPage: React.FC = () => {
     return bundle;
   }, [
     activeWorkflowDocument,
+    activeWorkflowFile?.document,
     activeWorkflowName,
     availableStepTypes,
     draftWorkflowName,
     draftYaml,
+    normalizeWorkflowYamlForRuntime,
+    parsedWorkflowDocument,
     resolvedStudioScopeId,
     visibleWorkflowSummaries,
+    workflowNames,
   ]);
   const recentPromptHistory = useMemo(
     () => promptHistory.slice(0, 3),
@@ -5143,35 +5288,53 @@ const StudioPage: React.FC = () => {
     async (
       savedWorkflow: StudioWorkflowFile,
       options?: {
+        readonly document?: StudioWorkflowDocument | null;
         readonly layout?: unknown;
+        readonly selectedNodeId?: string;
+        readonly yaml?: string;
       },
     ) => {
+      const hasDocumentOverride = options?.document !== undefined;
+      const nextWorkflow: StudioWorkflowFile = {
+        ...savedWorkflow,
+        document: hasDocumentOverride ? options.document ?? null : savedWorkflow.document,
+        yaml: options?.yaml ?? savedWorkflow.yaml,
+      };
+
       queryClient.setQueryData(
-        ['studio-workflow', workflowWorkspaceContextKey, savedWorkflow.workflowId],
-        savedWorkflow,
+        ['studio-workflow', workflowWorkspaceContextKey, nextWorkflow.workflowId],
+        nextWorkflow,
       );
       await queryClient.invalidateQueries({
         queryKey: ['studio-workspace-workflows', workflowWorkspaceContextKey],
       });
 
-      setSelectedWorkflowId(savedWorkflow.workflowId);
+      setSelectedWorkflowId(nextWorkflow.workflowId);
       setSelectedScriptId('');
       setTemplateWorkflow('');
       setBuildSurface('editor');
       setStudioSurface('build');
       setDraftSourceKey(
-        `workflow:${workflowWorkspaceContextKey}:${savedWorkflow.workflowId}`,
+        `workflow:${workflowWorkspaceContextKey}:${nextWorkflow.workflowId}`,
       );
-      setDraftYaml(savedWorkflow.yaml);
-      setDraftWorkflowName(savedWorkflow.name);
-      setDraftFileName(savedWorkflow.fileName);
-      setDraftDirectoryId(savedWorkflow.directoryId);
+      setDraftYaml(nextWorkflow.yaml);
+      setDraftWorkflowName(nextWorkflow.name);
+      setDraftFileName(nextWorkflow.fileName);
+      setDraftDirectoryId(nextWorkflow.directoryId);
       setDraftWorkflowLayout(
-        savedWorkflow.layout ||
+        nextWorkflow.layout ||
           options?.layout ||
           draftWorkflowLayout ||
-          buildStudioWorkflowLayout(savedWorkflow.name, workflowGraph.nodes),
+          buildStudioWorkflowLayout(nextWorkflow.name, workflowGraph.nodes),
       );
+      if (hasDocumentOverride) {
+        setEditableWorkflowDocument(
+          cloneStudioWorkflowDocument(options.document ?? null),
+        );
+      }
+      if (options?.selectedNodeId !== undefined) {
+        setSelectedGraphNodeId(options.selectedNodeId);
+      }
       setSaveNotice(null);
       setRunNotice(null);
     },
@@ -5191,7 +5354,86 @@ const StudioPage: React.FC = () => {
     return leaveGuard ? await leaveGuard() : true;
   }, [isBuildScriptsSurface]);
 
-  const handleSaveDraft = async () => {
+  const resolveWorkflowSavePayload = useCallback(
+    async (
+      pendingStepDraft?: {
+        readonly stepId: string;
+        readonly draft: StudioStepInspectorDraft;
+      } | null,
+    ): Promise<{
+      readonly document?: StudioWorkflowDocument | null;
+      readonly yaml: string;
+      readonly layout: unknown;
+      readonly selectedNodeId?: string;
+    } | null> => {
+      if (!pendingStepDraft) {
+        return {
+          yaml: draftYaml,
+          layout:
+            draftWorkflowLayout ||
+            activeWorkflowFile?.layout ||
+            buildStudioWorkflowLayout(activeWorkflowName, workflowGraph.nodes),
+        };
+      }
+
+      const currentStepId = pendingStepDraft.stepId.trim();
+      if (!currentStepId) {
+        setSaveNotice({
+          type: 'error',
+          message: 'Select a workflow step before saving its draft changes.',
+        });
+        return null;
+      }
+
+      const document = await resolveEditableWorkflowDocument();
+      if (!document) {
+        return null;
+      }
+
+      const result = applyStepInspectorDraft(
+        document,
+        currentStepId,
+        pendingStepDraft.draft,
+      );
+      const serialized = await studioApi.serializeYaml({
+        document: result.document,
+        availableWorkflowNames: workflowNames,
+        availableStepTypes,
+      });
+      const nextLayout =
+        draftWorkflowLayout ||
+        activeWorkflowFile?.layout ||
+        buildStudioWorkflowLayout(activeWorkflowName, workflowGraph.nodes);
+
+      setDraftYaml(serialized.yaml);
+      setEditableWorkflowDocument(cloneStudioWorkflowDocument(serialized.document));
+      setSelectedGraphNodeId(result.nodeId);
+
+      return {
+        document: serialized.document,
+        yaml: serialized.yaml,
+        layout: nextLayout,
+        selectedNodeId: result.nodeId,
+      };
+    },
+    [
+      activeWorkflowFile?.layout,
+      activeWorkflowName,
+      availableStepTypes,
+      draftWorkflowLayout,
+      draftYaml,
+      resolveEditableWorkflowDocument,
+      workflowGraph.nodes,
+      workflowNames,
+    ],
+  );
+
+  const handleSaveDraft = async (
+    pendingStepDraft?: {
+      readonly stepId: string;
+      readonly draft: StudioStepInspectorDraft;
+    } | null,
+  ) => {
     const directoryId = resolvedDraftDirectoryId;
     if (!directoryId) {
       setSaveNotice({
@@ -5214,6 +5456,11 @@ const StudioPage: React.FC = () => {
     setSaveNotice(null);
 
     try {
+      const savePayload = await resolveWorkflowSavePayload(pendingStepDraft);
+      if (!savePayload) {
+        return;
+      }
+
       const savedWorkflow = await studioApi.saveWorkflow({
         workflowId: activeWorkflowFile?.workflowId || undefined,
         draftExists: activeWorkflowFile?.draftExists,
@@ -5221,15 +5468,15 @@ const StudioPage: React.FC = () => {
         directoryId,
         workflowName,
         fileName: draftFileName,
-        yaml: draftYaml,
-        layout:
-          draftWorkflowLayout ||
-          activeWorkflowFile?.layout ||
-          buildStudioWorkflowLayout(activeWorkflowName, workflowGraph.nodes),
+        yaml: savePayload.yaml,
+        layout: savePayload.layout,
       });
 
       await applySavedWorkflowSelection(savedWorkflow, {
-        layout: draftWorkflowLayout,
+        document: savePayload.document,
+        layout: savePayload.layout,
+        selectedNodeId: savePayload.selectedNodeId,
+        yaml: savePayload.yaml,
       });
       const routeMemberSummary = resolveStudioMemberSummaryFromMemberKey(
         routeSelectedBackendMemberKey,
@@ -10063,7 +10310,7 @@ const StudioPage: React.FC = () => {
         setEditableWorkflowDocument(null);
         setSaveNotice(null);
       }}
-      onSaveDraft={() => void handleSaveDraft()}
+      onSaveDraft={(draft) => void handleSaveDraft(draft)}
       savePending={savePending}
       canSaveWorkflow={canSaveWorkflow}
       saveNotice={saveNotice}

--- a/apps/aevatar-console-web/src/shared/studio/document.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/document.test.ts
@@ -125,6 +125,76 @@ describe('studio document helpers', () => {
     ]);
   });
 
+  it('normalizes llm_call prompt parameters to prompt_prefix on apply', () => {
+    const document: StudioWorkflowDocument = {
+      name: 'workspace-demo',
+      roles: [],
+      steps: [
+        {
+          id: 'draft_step',
+          type: 'llm_call',
+          targetRole: 'assistant',
+          parameters: {
+            prompt: 'Legacy prompt field',
+          },
+          next: null,
+          branches: {},
+        },
+      ],
+    };
+
+    const result = applyStepInspectorDraft(document, 'draft_step', {
+      kind: 'step',
+      id: 'draft_step',
+      type: 'llm_call',
+      targetRole: 'assistant',
+      next: '',
+      branchesText: '{}',
+      parametersText: JSON.stringify({
+        prompt: 'Translate the input to Japanese.',
+      }),
+    });
+
+    expect(result.document.steps?.[0]?.parameters).toEqual({
+      prompt_prefix: 'Translate the input to Japanese.',
+    });
+  });
+
+  it('keeps human prompt parameters unchanged on apply', () => {
+    const document: StudioWorkflowDocument = {
+      name: 'workspace-demo',
+      roles: [],
+      steps: [
+        {
+          id: 'approval_step',
+          type: 'human_approval',
+          targetRole: null,
+          parameters: {
+            prompt: 'Approve this?',
+          },
+          next: null,
+          branches: {},
+        },
+      ],
+    };
+
+    const result = applyStepInspectorDraft(document, 'approval_step', {
+      kind: 'step',
+      id: 'approval_step',
+      type: 'human_approval',
+      targetRole: '',
+      next: '',
+      branchesText: '{}',
+      parametersText: JSON.stringify({
+        prompt: 'Approve the generated response?',
+      }),
+    });
+
+    expect(result.document.steps?.[0]?.parameters).toEqual({
+      prompt: 'Approve the generated response?',
+    });
+  });
+
   it('rejects non-object step parameters', () => {
     expect(() => parseInspectorParameters('["nope"]')).toThrow(
       'Step parameters must be a JSON object.',

--- a/apps/aevatar-console-web/src/shared/studio/document.ts
+++ b/apps/aevatar-console-web/src/shared/studio/document.ts
@@ -89,8 +89,72 @@ const DEFAULT_PARAMETERS_BY_STEP_TYPE: Record<string, Record<string, unknown>> =
   workflow_yaml_validate: {},
 };
 
+const LLM_CALL_STEP_TYPE = 'llm_call';
+const LLM_PROMPT_PARAMETER = 'prompt';
+const LLM_PROMPT_PREFIX_PARAMETER = 'prompt_prefix';
+
 function normalizeString(value: unknown): string {
   return String(value ?? '').trim();
+}
+
+function normalizeStepType(value: unknown): string {
+  return normalizeString(value).toLowerCase();
+}
+
+export function resolveStepParameterName(
+  stepType: string,
+  parameterName: string,
+): string {
+  const normalizedParameterName = normalizeString(parameterName);
+  if (
+    normalizeStepType(stepType) === LLM_CALL_STEP_TYPE &&
+    normalizedParameterName.toLowerCase() === LLM_PROMPT_PARAMETER
+  ) {
+    return LLM_PROMPT_PREFIX_PARAMETER;
+  }
+
+  return normalizedParameterName;
+}
+
+export function readStepParameterValue(
+  parameters: Record<string, unknown> | null | undefined,
+  stepType: string,
+  parameterName: string,
+): unknown {
+  const resolvedParameterName = resolveStepParameterName(stepType, parameterName);
+  const normalizedParameters =
+    parameters && typeof parameters === 'object' ? parameters : {};
+
+  if (
+    normalizeStepType(stepType) === LLM_CALL_STEP_TYPE &&
+    resolvedParameterName === LLM_PROMPT_PREFIX_PARAMETER
+  ) {
+    return (
+      normalizedParameters[LLM_PROMPT_PREFIX_PARAMETER] ??
+      normalizedParameters[LLM_PROMPT_PARAMETER]
+    );
+  }
+
+  return normalizedParameters[resolvedParameterName];
+}
+
+export function normalizeStepParametersForType(
+  stepType: string,
+  parameters: Record<string, unknown>,
+): Record<string, unknown> {
+  if (normalizeStepType(stepType) !== LLM_CALL_STEP_TYPE) {
+    return parameters;
+  }
+
+  const nextParameters = { ...parameters };
+  if (
+    nextParameters[LLM_PROMPT_PREFIX_PARAMETER] === undefined &&
+    nextParameters[LLM_PROMPT_PARAMETER] !== undefined
+  ) {
+    nextParameters[LLM_PROMPT_PREFIX_PARAMETER] = nextParameters[LLM_PROMPT_PARAMETER];
+  }
+  delete nextParameters[LLM_PROMPT_PARAMETER];
+  return nextParameters;
 }
 
 function cloneRecord<T>(value: T): T {
@@ -279,7 +343,10 @@ export function applyStepInspectorDraft(
   const nextTargetRole = normalizeString(draft.targetRole);
   const nextStepId = normalizeString(draft.next);
   const nextBranches = parseInspectorBranches(draft.branchesText);
-  const nextParameters = parseInspectorParameters(draft.parametersText);
+  const nextParameters = normalizeStepParametersForType(
+    nextType,
+    parseInspectorParameters(draft.parametersText),
+  );
 
   const steps = Array.isArray(document.steps) ? document.steps : [];
   const nextSteps = steps.map((entry) => {

--- a/apps/aevatar-console-web/src/shared/studio/graph.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/graph.test.ts
@@ -1,0 +1,41 @@
+import { buildStudioGraphElements } from './graph';
+
+describe('studio graph helpers', () => {
+  it('summarizes llm prompt prefixes with user-facing wording', () => {
+    const graph = buildStudioGraphElements({
+      name: 'workflow-demo',
+      steps: [
+        {
+          id: 'llm_call',
+          type: 'llm_call',
+          parameters: {
+            prompt_prefix: 'Translate the user input to Japanese.',
+          },
+        },
+      ],
+    });
+
+    expect(graph.nodes[0]?.data.parametersSummary).toBe(
+      'instruction: Translate the user input to Japanese.',
+    );
+  });
+
+  it('does not show empty llm prompt object defaults as configured prompts', () => {
+    const graph = buildStudioGraphElements({
+      name: 'workflow-demo',
+      steps: [
+        {
+          id: 'llm_call',
+          type: 'llm_call',
+          parameters: {
+            prompt_prefix: {},
+          },
+        },
+      ],
+    });
+
+    expect(graph.nodes[0]?.data.parametersSummary).toBe(
+      'No parameters configured',
+    );
+  });
+});

--- a/apps/aevatar-console-web/src/shared/studio/graph.ts
+++ b/apps/aevatar-console-web/src/shared/studio/graph.ts
@@ -241,29 +241,63 @@ function normalizeSteps(document: WorkflowDocumentLike): StudioGraphStep[] {
     .filter((step): step is StudioGraphStep => Boolean(step));
 }
 
-function summarizeStepParameters(parameters: Record<string, unknown>): string {
+function summarizeStepParameterEntry(
+  stepType: string,
+  key: string,
+  value: unknown,
+): string {
+  const displayKey =
+    stepType.trim().toLowerCase() === 'llm_call' && key === 'prompt_prefix'
+      ? 'instruction'
+      : key;
+
+  if (typeof value === 'string') {
+    return `${displayKey}: ${value}`;
+  }
+
+  if (
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    value === null
+  ) {
+    return `${displayKey}: ${String(value)}`;
+  }
+
+  return `${displayKey}: ${JSON.stringify(value)}`;
+}
+
+function getSummarizableStepParameterEntries(
+  stepType: string,
+  parameters: Record<string, unknown>,
+): Array<[string, unknown]> {
   const entries = Object.entries(parameters);
+  if (stepType.trim().toLowerCase() !== 'llm_call') {
+    return entries;
+  }
+
+  const promptPrefixValue = parameters.prompt_prefix ?? parameters.prompt;
+  const nextEntries = entries.filter(
+    ([key]) => key !== 'prompt_prefix' && key !== 'prompt',
+  );
+  if (typeof promptPrefixValue === 'string' && promptPrefixValue.trim()) {
+    return [['prompt_prefix', promptPrefixValue], ...nextEntries];
+  }
+
+  return nextEntries;
+}
+
+function summarizeStepParameters(
+  stepType: string,
+  parameters: Record<string, unknown>,
+): string {
+  const entries = getSummarizableStepParameterEntries(stepType, parameters);
   if (entries.length === 0) {
     return 'No parameters configured';
   }
 
   return entries
     .slice(0, 2)
-    .map(([key, value]) => {
-      if (typeof value === 'string') {
-        return `${key}: ${value}`;
-      }
-
-      if (
-        typeof value === 'number' ||
-        typeof value === 'boolean' ||
-        value === null
-      ) {
-        return `${key}: ${String(value)}`;
-      }
-
-      return `${key}: ${JSON.stringify(value)}`;
-    })
+    .map(([key, value]) => summarizeStepParameterEntry(stepType, key, value))
     .join(' · ');
 }
 
@@ -530,7 +564,7 @@ export function buildStudioGraphElements(
         stepId: step.id,
         stepType: step.type,
         targetRole: step.targetRole,
-        parametersSummary: summarizeStepParameters(step.parameters),
+        parametersSummary: summarizeStepParameters(step.type, step.parameters),
         branchCount: Object.keys(step.branches).length,
       },
     };


### PR DESCRIPTION
daemon 双向同步 `dev` → `auto-refact-dev` 共 1 commits。CI 绿后 GitHub auto-merge。冲突或 CI fail 由 daemon 写 pending event,再由 controller 派 codex 在独立 worktree 解决。

⟦AI:AUTO-LOOP⟧
