### PR TITLE
refactor(#1543): 精简 DefaultServiceInvocationDispatcher

### DIFF
--- a/src/platform/Aevatar.GAgentService.Infrastructure/Dispatch/DefaultServiceInvocationDispatcher.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Dispatch/DefaultServiceInvocationDispatcher.cs
@@ -4,7 +4,6 @@ using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.Scripting.Core.Ports;
 using Aevatar.Workflow.Application.Abstractions.Runs;
-using Google.Protobuf.Collections;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.GAgentService.Infrastructure.Dispatch;
@@ -206,41 +205,11 @@ public sealed class DefaultServiceInvocationDispatcher : IServiceInvocationDispa
     {
         if (!string.IsNullOrWhiteSpace(request.Identity?.TenantId))
             return request.Identity.TenantId.Trim();
-        return ResolveScopeId(chatRequest);
-    }
 
-    private static string ResolveScopeId(ChatRequestEvent chatRequest)
-    {
-        ArgumentNullException.ThrowIfNull(chatRequest);
-
+        // Refactor (issue1543): Old pattern: Headers/Metadata scope fallback could override workflow binding authority.  New principle: only typed identity or typed chat payload scope can bind a workflow run.
         if (!string.IsNullOrWhiteSpace(chatRequest.ScopeId))
             return chatRequest.ScopeId.Trim();
 
-        return TryResolveScopeId(chatRequest.Headers, out var scopeId) ||
-               TryResolveScopeId(chatRequest.Metadata, out scopeId)
-            ? scopeId
-            : string.Empty;
-    }
-
-    private static bool TryResolveScopeId(MapField<string, string> values, out string scopeId)
-    {
-        ArgumentNullException.ThrowIfNull(values);
-
-        if (values.TryGetValue(WorkflowRunCommandMetadataKeys.ScopeId, out var workflowScopeId) &&
-            !string.IsNullOrWhiteSpace(workflowScopeId))
-        {
-            scopeId = workflowScopeId.Trim();
-            return true;
-        }
-
-        if (values.TryGetValue("scope_id", out var legacyScopeId) &&
-            !string.IsNullOrWhiteSpace(legacyScopeId))
-        {
-            scopeId = legacyScopeId.Trim();
-            return true;
-        }
-
-        scopeId = string.Empty;
-        return false;
+        return string.Empty;
     }
 }

--- a/test/Aevatar.GAgentService.Tests/Infrastructure/DefaultServiceInvocationDispatcherTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Infrastructure/DefaultServiceInvocationDispatcherTests.cs
@@ -165,7 +165,7 @@ public sealed class DefaultServiceInvocationDispatcherTests
     }
 
     [Fact]
-    public async Task DispatchAsync_ShouldResolveScopeIdFromRequestScopeBeforeMetadataFallbacks()
+    public async Task DispatchAsync_ShouldResolveScopeIdFromTypedPayloadBeforeScopeAnnotations()
     {
         var workflowPort = new RecordingWorkflowRunActorPort();
         var dispatcher = new DefaultServiceInvocationDispatcher(
@@ -190,6 +190,11 @@ public sealed class DefaultServiceInvocationDispatcherTests
             {
                 Prompt = "hello",
                 ScopeId = "request-scope",
+                Headers =
+                {
+                    [WorkflowRunCommandMetadataKeys.ScopeId] = "workflow-header-scope",
+                    ["scope_id"] = "legacy-header-scope",
+                },
                 Metadata =
                 {
                     [WorkflowRunCommandMetadataKeys.ScopeId] = "workflow-metadata-scope",
@@ -205,7 +210,7 @@ public sealed class DefaultServiceInvocationDispatcherTests
     }
 
     [Fact]
-    public async Task DispatchAsync_ShouldResolveScopeIdFromWorkflowMetadataKey_WhenRequestScopeIsBlank()
+    public async Task DispatchAsync_ShouldIgnoreWorkflowScopeAnnotations_WhenTypedScopeIsBlank()
     {
         var workflowPort = new RecordingWorkflowRunActorPort();
         var dispatcher = new DefaultServiceInvocationDispatcher(
@@ -230,6 +235,11 @@ public sealed class DefaultServiceInvocationDispatcherTests
             Payload = Any.Pack(new ChatRequestEvent
             {
                 Prompt = "hello",
+                Headers =
+                {
+                    [WorkflowRunCommandMetadataKeys.ScopeId] = "workflow-header-scope",
+                    ["scope_id"] = "legacy-header-scope",
+                },
                 Metadata =
                 {
                     [WorkflowRunCommandMetadataKeys.ScopeId] = "workflow-metadata-scope",
@@ -239,11 +249,11 @@ public sealed class DefaultServiceInvocationDispatcherTests
         });
 
         workflowPort.CreateRunCalls.Should().ContainSingle();
-        workflowPort.CreateRunCalls[0].ScopeId.Should().Be("workflow-metadata-scope");
+        workflowPort.CreateRunCalls[0].ScopeId.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task DispatchAsync_ShouldResolveScopeIdFromLegacyMetadataKey_WhenOtherSourcesAreBlank()
+    public async Task DispatchAsync_ShouldIgnoreLegacyScopeMetadata_WhenTypedScopeIsBlank()
     {
         var workflowPort = new RecordingWorkflowRunActorPort();
         var dispatcher = new DefaultServiceInvocationDispatcher(
@@ -276,7 +286,7 @@ public sealed class DefaultServiceInvocationDispatcherTests
         });
 
         workflowPort.CreateRunCalls.Should().ContainSingle();
-        workflowPort.CreateRunCalls[0].ScopeId.Should().Be("legacy-scope");
+        workflowPort.CreateRunCalls[0].ScopeId.Should().BeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
## 摘要

实施 #1543 Phase 9 r1 三 solver + meta-judge consensus。

closes #1543

## 范围

- `src/platform/Aevatar.GAgentService.Infrastructure/Dispatch/DefaultServiceInvocationDispatcher.cs` 精简核心 invocation 职责
- `test/Aevatar.GAgentService.Tests/Infrastructure/DefaultServiceInvocationDispatcherTests.cs` 同步行为契约

2 files changed (+17/-38)。

## 共识来源

详见 #1543 上的 r1 三 solver + meta-judge 评论。

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
