### PR TITLE
refactor(#1559): typed connector HTTP authorization scalar + 删除 metadata authority

### DIFF
--- a/src/Aevatar.AI.Abstractions/ai_messages.proto
+++ b/src/Aevatar.AI.Abstractions/ai_messages.proto
@@ -35,7 +35,7 @@ message ChatRequestEvent  {
   // Narrow LLM-control carrier. Model routing, NyxID credentials and tool-round limits
   // belong here, not in metadata or tool_context.
   LLMControlContextPayload llm_control = 10;
-  // Refactor (issue1559): Old pattern: connector HTTP auth used Metadata["connector.http.authorization"] as authority. New principle: connector auth is a typed actor inbox field and Metadata is extension-only.
+  // Refactor (iter159/cluster-1559): Old pattern: connector HTTP auth used Metadata["connector.http.authorization"] as authority. New principle: connector auth is a typed actor inbox field and Metadata is extension-only.
   string connector_http_authorization = 11;
 }
 message ChatResponseEvent { string content = 1; string session_id = 2; }

--- a/src/Aevatar.AI.Abstractions/ai_messages.proto
+++ b/src/Aevatar.AI.Abstractions/ai_messages.proto
@@ -35,6 +35,8 @@ message ChatRequestEvent  {
   // Narrow LLM-control carrier. Model routing, NyxID credentials and tool-round limits
   // belong here, not in metadata or tool_context.
   LLMControlContextPayload llm_control = 10;
+  // Refactor (issue1559): Old pattern: connector HTTP auth used Metadata["connector.http.authorization"] as authority. New principle: connector auth is a typed actor inbox field and Metadata is extension-only.
+  string connector_http_authorization = 11;
 }
 message ChatResponseEvent { string content = 1; string session_id = 2; }
 

--- a/src/Aevatar.Studio.Hosting/Endpoints/StudioEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/StudioEndpoints.cs
@@ -1259,8 +1259,7 @@ internal static class StudioEndpoints
 
         var llmControl = LLMControlContext.Empty;
 
-        // Forward caller's Bearer token through typed LLM control. Metadata
-        // keeps only connector/tool authorization.
+        // Forward caller's Bearer token through typed LLM control.
         var bearerToken = ExtractBearerToken(http);
         if (!string.IsNullOrWhiteSpace(bearerToken))
         {
@@ -1269,7 +1268,6 @@ internal static class StudioEndpoints
                 NyxIdAccessToken = bearerToken,
                 NyxIdOrgToken = bearerToken,
             };
-            metadata[ConnectorRequest.HttpAuthorizationMetadataKey] = $"Bearer {bearerToken}";
         }
 
         // Forward the user's preferred model from their config.

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -4,7 +4,6 @@ using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.Foundation.Abstractions;
-using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Commands;
@@ -111,7 +110,7 @@ public static class ScopeServiceEndpoints
             if (request.WorkflowYamls == null || request.WorkflowYamls.Count == 0)
                 throw new InvalidOperationException("workflowYamls is required.");
 
-            var scopedHeaders = await BuildScopedHeadersAsync(scopeId, request.Headers, http, ct);
+            var scopedHeaders = BuildScopedHeaders(scopeId, request.Headers);
             if (!ScopeWorkflowEndpoints.TryParseEventFormat(request.EventFormat, out var eventFormat))
             {
                 await WriteJsonErrorResponseAsync(
@@ -129,7 +128,8 @@ public static class ScopeServiceEndpoints
                 SessionId: request.SessionId,
                 Metadata: scopedHeaders,
                 ScopeId: scopeId,
-                LlmControl: await BuildScopedLlmControlAsync(http, ct));
+                LlmControl: await BuildScopedLlmControlAsync(http, ct),
+                ConnectorHttpAuthorization: ExtractConnectorHttpAuthorization(http));
 
             if (eventFormat == ScopeWorkflowEndpoints.ScopeWorkflowStreamEventFormat.Agui)
             {
@@ -1495,7 +1495,7 @@ public static class ScopeServiceEndpoints
                 return;
 
             var normalizedPrompt = request.Prompt?.Trim() ?? string.Empty;
-            var scopedHeaders = await BuildScopedHeadersAsync(scopeId, request.Headers, http, ct);
+            var scopedHeaders = BuildScopedHeaders(scopeId, request.Headers);
             var invocationRequest = BuildStreamInvocationRequest(
                 options.Value,
                 scopeId,
@@ -2869,18 +2869,15 @@ const response = await fetch("{{invokePath}}", {
             throw new InvalidOperationException("Workflow service has no active definition actor.");
     }
 
-    private static async Task<Dictionary<string, string>> BuildScopedHeadersAsync(
+    private static Dictionary<string, string> BuildScopedHeaders(
         string scopeId,
-        IReadOnlyDictionary<string, string>? headers,
-        HttpContext? http = null,
-        CancellationToken cancellationToken = default)
+        IReadOnlyDictionary<string, string>? headers)
     {
         var scopedHeaders = headers == null
             ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             : new Dictionary<string, string>(headers, StringComparer.OrdinalIgnoreCase);
         scopedHeaders.Remove("scope_id");
         scopedHeaders.Remove(WorkflowRunCommandMetadataKeys.ScopeId);
-        InjectBearerToken(http, scopedHeaders);
         return scopedHeaders;
     }
 
@@ -2951,18 +2948,6 @@ const response = await fetch("{{invokePath}}", {
         return control == LLMControlContext.Empty ? null : control;
     }
 
-    private static void InjectBearerToken(HttpContext? http, Dictionary<string, string> metadata)
-    {
-        if (http == null)
-            return;
-        var auth = http.Request.Headers.Authorization.FirstOrDefault();
-        if (auth != null && auth.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
-        {
-            var bearerToken = auth["Bearer ".Length..].Trim();
-            metadata[ConnectorRequest.HttpAuthorizationMetadataKey] = $"Bearer {bearerToken}";
-        }
-    }
-
     private static string? ExtractBearerToken(HttpContext http)
     {
         var auth = http.Request.Headers.Authorization.FirstOrDefault();
@@ -2971,6 +2956,14 @@ const response = await fetch("{{invokePath}}", {
 
         var bearerToken = auth["Bearer ".Length..].Trim();
         return string.IsNullOrWhiteSpace(bearerToken) ? null : bearerToken;
+    }
+
+    private static string? ExtractConnectorHttpAuthorization(HttpContext http)
+    {
+        var bearerToken = ExtractBearerToken(http);
+        return string.IsNullOrWhiteSpace(bearerToken)
+            ? null
+            : $"Bearer {bearerToken.Trim()}";
     }
 
     private static void CopyHeaders(

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -4,6 +4,7 @@ using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Commands;
@@ -110,7 +111,7 @@ public static class ScopeServiceEndpoints
             if (request.WorkflowYamls == null || request.WorkflowYamls.Count == 0)
                 throw new InvalidOperationException("workflowYamls is required.");
 
-            var scopedHeaders = BuildScopedHeaders(scopeId, request.Headers);
+            var scopedHeaders = BuildScopedHeaders(request.Headers);
             if (!ScopeWorkflowEndpoints.TryParseEventFormat(request.EventFormat, out var eventFormat))
             {
                 await WriteJsonErrorResponseAsync(
@@ -129,7 +130,7 @@ public static class ScopeServiceEndpoints
                 Metadata: scopedHeaders,
                 ScopeId: scopeId,
                 LlmControl: await BuildScopedLlmControlAsync(http, ct),
-                ConnectorHttpAuthorization: ExtractConnectorHttpAuthorization(http));
+                ConnectorHttpAuthorization: WorkflowCapabilityEndpoints.ExtractConnectorHttpAuthorization(http));
 
             if (eventFormat == ScopeWorkflowEndpoints.ScopeWorkflowStreamEventFormat.Agui)
             {
@@ -1495,7 +1496,7 @@ public static class ScopeServiceEndpoints
                 return;
 
             var normalizedPrompt = request.Prompt?.Trim() ?? string.Empty;
-            var scopedHeaders = BuildScopedHeaders(scopeId, request.Headers);
+            var scopedHeaders = BuildScopedHeaders(request.Headers);
             var invocationRequest = BuildStreamInvocationRequest(
                 options.Value,
                 scopeId,
@@ -2869,15 +2870,15 @@ const response = await fetch("{{invokePath}}", {
             throw new InvalidOperationException("Workflow service has no active definition actor.");
     }
 
-    private static Dictionary<string, string> BuildScopedHeaders(
-        string scopeId,
-        IReadOnlyDictionary<string, string>? headers)
+    // Refactor (iter159/cluster-1559): Old pattern: scoped metadata helper injected connector bearer auth. New principle: scoped headers only carry extension entries; connector auth is typed separately.
+    private static Dictionary<string, string> BuildScopedHeaders(IReadOnlyDictionary<string, string>? headers)
     {
         var scopedHeaders = headers == null
             ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             : new Dictionary<string, string>(headers, StringComparer.OrdinalIgnoreCase);
         scopedHeaders.Remove("scope_id");
         scopedHeaders.Remove(WorkflowRunCommandMetadataKeys.ScopeId);
+        scopedHeaders.Remove(ConnectorRequest.HttpAuthorizationMetadataKey);
         return scopedHeaders;
     }
 
@@ -2956,14 +2957,6 @@ const response = await fetch("{{invokePath}}", {
 
         var bearerToken = auth["Bearer ".Length..].Trim();
         return string.IsNullOrWhiteSpace(bearerToken) ? null : bearerToken;
-    }
-
-    private static string? ExtractConnectorHttpAuthorization(HttpContext http)
-    {
-        var bearerToken = ExtractBearerToken(http);
-        return string.IsNullOrWhiteSpace(bearerToken)
-            ? null
-            : $"Bearer {bearerToken.Trim()}";
     }
 
     private static void CopyHeaders(

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
@@ -1,5 +1,6 @@
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
+using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
@@ -311,7 +312,7 @@ public static class ScopeWorkflowEndpoints
 
         if (resolvedEventFormat == ScopeWorkflowStreamEventFormat.Workflow)
         {
-            var scopedHeaders = BuildScopedHeaders(scopeId, headers);
+            var scopedHeaders = BuildScopedHeaders(headers);
             await WorkflowCapabilityEndpoints.HandleChat(
                 http,
                 new ChatInput
@@ -328,7 +329,7 @@ public static class ScopeWorkflowEndpoints
             return;
         }
 
-        var aguiHeaders = BuildScopedHeaders(scopeId, headers);
+        var aguiHeaders = BuildScopedHeaders(headers);
         await HandleAguiStreamAsync(
             http,
             scopeId,
@@ -337,7 +338,7 @@ public static class ScopeWorkflowEndpoints
             sessionId,
             aguiHeaders,
             await BuildScopedLlmControlAsync(http, ct),
-            ExtractConnectorHttpAuthorization(http),
+            WorkflowCapabilityEndpoints.ExtractConnectorHttpAuthorization(http),
             chatRunService,
             ct);
     }
@@ -539,15 +540,15 @@ public static class ScopeWorkflowEndpoints
         return false;
     }
 
-    private static Dictionary<string, string> BuildScopedHeaders(
-        string scopeId,
-        IReadOnlyDictionary<string, string>? headers)
+    // Refactor (iter159/cluster-1559): Old pattern: scoped metadata helper injected connector bearer auth. New principle: scoped headers only carry extension entries; connector auth is typed separately.
+    private static Dictionary<string, string> BuildScopedHeaders(IReadOnlyDictionary<string, string>? headers)
     {
         var scopedHeaders = headers == null
             ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             : new Dictionary<string, string>(headers, StringComparer.OrdinalIgnoreCase);
         scopedHeaders.Remove("scope_id");
         scopedHeaders.Remove(WorkflowRunCommandMetadataKeys.ScopeId);
+        scopedHeaders.Remove(ConnectorRequest.HttpAuthorizationMetadataKey);
         return scopedHeaders;
     }
 
@@ -626,14 +627,6 @@ public static class ScopeWorkflowEndpoints
 
         var bearerToken = auth["Bearer ".Length..].Trim();
         return string.IsNullOrWhiteSpace(bearerToken) ? null : bearerToken;
-    }
-
-    private static string? ExtractConnectorHttpAuthorization(HttpContext http)
-    {
-        var bearerToken = ExtractBearerToken(http);
-        return string.IsNullOrWhiteSpace(bearerToken)
-            ? null
-            : $"Bearer {bearerToken.Trim()}";
     }
 
     internal static (int StatusCode, string Code, string Message) MapRunStartError(WorkflowChatRunStartError error)

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
@@ -1,6 +1,5 @@
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
-using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
@@ -312,7 +311,7 @@ public static class ScopeWorkflowEndpoints
 
         if (resolvedEventFormat == ScopeWorkflowStreamEventFormat.Workflow)
         {
-            var scopedHeaders = await BuildScopedHeadersAsync(scopeId, headers, http, ct);
+            var scopedHeaders = BuildScopedHeaders(scopeId, headers);
             await WorkflowCapabilityEndpoints.HandleChat(
                 http,
                 new ChatInput
@@ -329,7 +328,7 @@ public static class ScopeWorkflowEndpoints
             return;
         }
 
-        var aguiHeaders = await BuildScopedHeadersAsync(scopeId, headers, http, ct);
+        var aguiHeaders = BuildScopedHeaders(scopeId, headers);
         await HandleAguiStreamAsync(
             http,
             scopeId,
@@ -338,6 +337,7 @@ public static class ScopeWorkflowEndpoints
             sessionId,
             aguiHeaders,
             await BuildScopedLlmControlAsync(http, ct),
+            ExtractConnectorHttpAuthorization(http),
             chatRunService,
             ct);
     }
@@ -425,6 +425,7 @@ public static class ScopeWorkflowEndpoints
         string? sessionId,
         IReadOnlyDictionary<string, string>? headers,
         LLMControlContext? llmControl,
+        string? connectorHttpAuthorization,
         ICommandInteractionService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowRunEventEnvelope, WorkflowProjectionCompletionStatus> chatRunService,
         CancellationToken ct)
     {
@@ -437,7 +438,8 @@ public static class ScopeWorkflowEndpoints
                 sessionId,
                 Metadata: headers,
                 ScopeId: NormalizeRequired(scopeId, nameof(scopeId)),
-                LlmControl: llmControl),
+                LlmControl: llmControl,
+                ConnectorHttpAuthorization: connectorHttpAuthorization),
             chatRunService,
             ct);
     }
@@ -537,27 +539,15 @@ public static class ScopeWorkflowEndpoints
         return false;
     }
 
-    private static async Task<Dictionary<string, string>> BuildScopedHeadersAsync(
+    private static Dictionary<string, string> BuildScopedHeaders(
         string scopeId,
-        IReadOnlyDictionary<string, string>? headers,
-        HttpContext? http = null,
-        CancellationToken cancellationToken = default)
+        IReadOnlyDictionary<string, string>? headers)
     {
         var scopedHeaders = headers == null
             ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             : new Dictionary<string, string>(headers, StringComparer.OrdinalIgnoreCase);
         scopedHeaders.Remove("scope_id");
         scopedHeaders.Remove(WorkflowRunCommandMetadataKeys.ScopeId);
-        if (http != null)
-        {
-            var auth = http.Request.Headers.Authorization.FirstOrDefault();
-            if (auth != null && auth.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
-            {
-                var bearerToken = auth["Bearer ".Length..].Trim();
-                scopedHeaders[ConnectorRequest.HttpAuthorizationMetadataKey] = $"Bearer {bearerToken}";
-            }
-        }
-
         return scopedHeaders;
     }
 
@@ -636,6 +626,14 @@ public static class ScopeWorkflowEndpoints
 
         var bearerToken = auth["Bearer ".Length..].Trim();
         return string.IsNullOrWhiteSpace(bearerToken) ? null : bearerToken;
+    }
+
+    private static string? ExtractConnectorHttpAuthorization(HttpContext http)
+    {
+        var bearerToken = ExtractBearerToken(http);
+        return string.IsNullOrWhiteSpace(bearerToken)
+            ? null
+            : $"Bearer {bearerToken.Trim()}";
     }
 
     internal static (int StatusCode, string Code, string Message) MapRunStartError(WorkflowChatRunStartError error)

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunModels.cs
@@ -129,7 +129,7 @@ public sealed record WorkflowChatRunRequest(
     LLMControlContext? LlmControl = null,
     // Refactor (issue1332): Old pattern: workflow chat commands could only carry tool controls through metadata/LlmControl. New principle: reuse typed AgentToolExecutionContext as the workflow ToolContext control surface.
     AgentToolExecutionContext? ToolContext = null,
-    // Refactor (issue1559): Old pattern: connector HTTP auth used Metadata["connector.http.authorization"] as authority. New principle: trusted connector auth is a typed command carrier.
+    // Refactor (iter159/cluster-1559): Old pattern: connector HTTP auth used Metadata["connector.http.authorization"] as authority. New principle: trusted connector auth is a typed command carrier.
     string? ConnectorHttpAuthorization = null);
 
 public enum WorkflowChatRunStartError

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunModels.cs
@@ -128,7 +128,9 @@ public sealed record WorkflowChatRunRequest(
     string? ScopeId = null,
     LLMControlContext? LlmControl = null,
     // Refactor (issue1332): Old pattern: workflow chat commands could only carry tool controls through metadata/LlmControl. New principle: reuse typed AgentToolExecutionContext as the workflow ToolContext control surface.
-    AgentToolExecutionContext? ToolContext = null);
+    AgentToolExecutionContext? ToolContext = null,
+    // Refactor (issue1559): Old pattern: connector HTTP auth used Metadata["connector.http.authorization"] as authority. New principle: trusted connector auth is a typed command carrier.
+    string? ConnectorHttpAuthorization = null);
 
 public enum WorkflowChatRunStartError
 {

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs
@@ -3,6 +3,7 @@ using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Google.Protobuf.WellKnownTypes;
 
@@ -21,6 +22,7 @@ internal sealed class WorkflowChatRequestEnvelopeFactory : ICommandEnvelopeFacto
             Prompt = command.Prompt,
             SessionId = sessionId,
             ScopeId = command.ScopeId ?? string.Empty,
+            ConnectorHttpAuthorization = NormalizeOptional(command.ConnectorHttpAuthorization) ?? string.Empty,
         };
         if (command.InputParts is { Count: > 0 })
             chatRequest.InputParts.Add(command.InputParts.Select(ToProto));
@@ -89,6 +91,8 @@ internal sealed class WorkflowChatRequestEnvelopeFactory : ICommandEnvelopeFacto
                 continue;
             if (IsScopeMetadataKey(normalizedKey))
                 continue;
+            if (IsConnectorAuthorizationMetadataKey(normalizedKey))
+                continue;
 
             destination[normalizedKey] = normalizedValue;
         }
@@ -97,6 +101,12 @@ internal sealed class WorkflowChatRequestEnvelopeFactory : ICommandEnvelopeFacto
     private static bool IsScopeMetadataKey(string key) =>
         string.Equals(key, "scope_id", StringComparison.Ordinal) ||
         string.Equals(key, WorkflowRunCommandMetadataKeys.ScopeId, StringComparison.Ordinal);
+
+    private static bool IsConnectorAuthorizationMetadataKey(string key) =>
+        string.Equals(key, ConnectorRequest.HttpAuthorizationMetadataKey, StringComparison.Ordinal);
+
+    private static string? NormalizeOptional(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
     // Refactor (iter159/cluster-613-first):
     //   Old pattern: NyxID bearer entered workflow durable + pending approval surface.

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunExecutionContextStateAccess.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunExecutionContextStateAccess.cs
@@ -60,15 +60,27 @@ internal static class WorkflowRunExecutionContextStateAccess
                 continue;
 
             if (string.Equals(key, ConnectorRequest.HttpAuthorizationMetadataKey, StringComparison.Ordinal))
-            {
-                delta.Connector = new WorkflowRunConnectorExecutionContextDelta
-                {
-                    HttpAuthorization = value,
-                };
                 continue;
-            }
         }
 
+        return delta;
+    }
+
+    public static WorkflowRunExecutionContextDelta BuildConnectorAuthorizationDelta(string? authorization)
+    {
+        var delta = new WorkflowRunExecutionContextDelta
+        {
+            ClearConnector = true,
+        };
+        var normalizedAuthorization = Normalize(authorization);
+        if (string.IsNullOrWhiteSpace(normalizedAuthorization))
+            return delta;
+
+        // Refactor (issue1559): Old pattern: Metadata promoted connector HTTP auth into actor state. New principle: only the typed ChatRequestEvent connector auth field can update connector execution context.
+        delta.Connector = new WorkflowRunConnectorExecutionContextDelta
+        {
+            HttpAuthorization = normalizedAuthorization,
+        };
         return delta;
     }
 

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunExecutionContextStateAccess.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunExecutionContextStateAccess.cs
@@ -76,7 +76,7 @@ internal static class WorkflowRunExecutionContextStateAccess
         if (string.IsNullOrWhiteSpace(normalizedAuthorization))
             return delta;
 
-        // Refactor (issue1559): Old pattern: Metadata promoted connector HTTP auth into actor state. New principle: only the typed ChatRequestEvent connector auth field can update connector execution context.
+        // Refactor (iter159/cluster-1559): Old pattern: Metadata promoted connector HTTP auth into actor state. New principle: only the typed ChatRequestEvent connector auth field can update connector execution context.
         delta.Connector = new WorkflowRunConnectorExecutionContextDelta
         {
             HttpAuthorization = normalizedAuthorization,

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
@@ -270,6 +270,8 @@ public sealed class WorkflowRunGAgent
         }
 
         var metadataDelta = WorkflowRunExecutionContextStateAccess.BuildRequestMetadataDelta(request.Metadata);
+        var connectorAuthorizationDelta = WorkflowRunExecutionContextStateAccess.BuildConnectorAuthorizationDelta(
+            request.ConnectorHttpAuthorization);
         _runtimeContext.ApplyRequestMetadata(request.Metadata);
         var llmControl = LLMControlContextMapper.FromPayload(request.LlmControl);
         var toolContext = llmControl.ToToolContext(AgentToolExecutionContextMapper.FromPayload(request.ToolContext));
@@ -280,7 +282,7 @@ public sealed class WorkflowRunGAgent
         var runId = string.IsNullOrWhiteSpace(State.RunId)
             ? WorkflowRunIdNormalizer.Normalize(Id)
             : WorkflowRunIdNormalizer.Normalize(State.RunId);
-        var executionContextDelta = MergeExecutionContextDeltas(metadataDelta, toolContextDelta);
+        var executionContextDelta = MergeExecutionContextDeltas(metadataDelta, connectorAuthorizationDelta, toolContextDelta);
         await PersistDomainEventAsync(new WorkflowRunExecutionStartedEvent
         {
             RunId = runId,

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
@@ -636,7 +636,8 @@ public static class WorkflowCapabilityEndpoints
             .Replace(':', '.');
     }
 
-    private static string? ExtractConnectorHttpAuthorization(HttpContext http)
+    // Refactor (iter159/cluster-1559): Old pattern: endpoint adapters each parsed Bearer auth before writing connector auth metadata. New principle: adapters share one trusted HTTP header to typed connector auth mapper.
+    public static string? ExtractConnectorHttpAuthorization(HttpContext http)
     {
         var bearerToken = ExtractBearerToken(http);
         return string.IsNullOrWhiteSpace(bearerToken)

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
@@ -51,7 +51,8 @@ public static class WorkflowCapabilityEndpoints
             var defaultMetadata = TryResolveRuntimeDefaultMetadata(serviceProvider, logger);
             var normalizedRequest = ChatRunRequestNormalizer.Normalize(
                 input,
-                defaultMetadata);
+                defaultMetadata,
+                connectorHttpAuthorization: ExtractConnectorHttpAuthorization(http));
             if (!normalizedRequest.Succeeded)
             {
                 var (code, message) = ChatRunStartErrorMapper.ToCommandError(normalizedRequest.Error);
@@ -114,12 +115,16 @@ public static class WorkflowCapabilityEndpoints
         ICommandDispatchService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError> chatRunService,
         ILoggerFactory loggerFactory,
         CancellationToken ct = default,
-        IReadOnlyDictionary<string, string>? defaultMetadata = null)
+        IReadOnlyDictionary<string, string>? defaultMetadata = null,
+        string? connectorHttpAuthorization = null)
     {
         using var scope = ApiRequestScope.BeginHttp();
         var logger = loggerFactory.CreateLogger("Aevatar.Workflow.Host.Api.Command");
 
-        var normalizedRequest = ChatRunRequestNormalizer.Normalize(input, defaultMetadata: defaultMetadata);
+        var normalizedRequest = ChatRunRequestNormalizer.Normalize(
+            input,
+            defaultMetadata: defaultMetadata,
+            connectorHttpAuthorization: connectorHttpAuthorization);
         if (!normalizedRequest.Succeeded)
         {
             var (code, message) = ChatRunStartErrorMapper.ToCommandError(normalizedRequest.Error);
@@ -549,7 +554,8 @@ public static class WorkflowCapabilityEndpoints
                 chatRunService,
                 scope,
                 ct,
-                defaultMetadata);
+                defaultMetadata,
+                connectorHttpAuthorization: ExtractConnectorHttpAuthorization(http));
         }
         catch (OperationCanceledException)
         {
@@ -628,6 +634,26 @@ public static class WorkflowCapabilityEndpoints
         return rawKey
             .Trim()
             .Replace(':', '.');
+    }
+
+    private static string? ExtractConnectorHttpAuthorization(HttpContext http)
+    {
+        var bearerToken = ExtractBearerToken(http);
+        return string.IsNullOrWhiteSpace(bearerToken)
+            ? null
+            : $"Bearer {bearerToken.Trim()}";
+    }
+
+    private static string? ExtractBearerToken(HttpContext http)
+    {
+        var auth = http.Request.Headers.Authorization.FirstOrDefault();
+        if (auth == null || !auth.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var bearerToken = auth["Bearer ".Length..].Trim();
+        return string.IsNullOrWhiteSpace(bearerToken)
+            ? null
+            : bearerToken;
     }
 
 }

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunRequestNormalizer.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunRequestNormalizer.cs
@@ -33,6 +33,7 @@ internal static class ChatRunRequestNormalizer
         IReadOnlyDictionary<string, string>? defaultMetadata = null,
         string? connectorHttpAuthorization = null)
     {
+        // Refactor (iter159/cluster-1559): Old pattern: connector HTTP auth could arrive through Metadata extension keys. New principle: only the trusted adapter parameter can populate typed connector auth.
         // Refactor (iter112/cluster-3): Old pattern: host passed normalized legacy mirror fields into Application commands. New principle: host normalizes wire aliases once into typed WorkflowChatSource.
         // Refactor (iter349/cluster-349):
         //   Old pattern: WorkflowAuthoringSkillPromptAugmentor rewrote chat prompt via hidden workflow.authoring.enabled metadata + AEVATAR_WORKFLOW_AUTHORING_AUTO_INJECT env
@@ -309,6 +310,9 @@ internal static class ChatRunRequestNormalizer
     // Refactor (iter15/cluster-029):
     //   Old pattern: scope metadata keys promoted into control-flow ScopeId or conflict errors.
     //   New principle: scope metadata keys are not control input and are not forwarded as extension metadata.
+    // Refactor (iter159/cluster-1559):
+    //   Old pattern: connector HTTP auth metadata could survive normalization as an open extension entry.
+    //   New principle: connector auth metadata is scrubbed; trusted auth enters through the typed command carrier only.
     private static void AddNormalizedMetadataEntry(
         IDictionary<string, string> metadata,
         string key,

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunRequestNormalizer.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunRequestNormalizer.cs
@@ -1,6 +1,7 @@
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Application.Runs;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.Foundation.Abstractions.Connectors;
 
 namespace Aevatar.Workflow.Infrastructure.CapabilityApi;
 
@@ -29,7 +30,8 @@ internal static class ChatRunRequestNormalizer
 
     public static ChatRunRequestNormalizationResult Normalize(
         ChatInput input,
-        IReadOnlyDictionary<string, string>? defaultMetadata = null)
+        IReadOnlyDictionary<string, string>? defaultMetadata = null,
+        string? connectorHttpAuthorization = null)
     {
         // Refactor (iter112/cluster-3): Old pattern: host passed normalized legacy mirror fields into Application commands. New principle: host normalizes wire aliases once into typed WorkflowChatSource.
         // Refactor (iter349/cluster-349):
@@ -60,7 +62,8 @@ internal static class ChatRunRequestNormalizer
                 Metadata: normalizedMetadata,
                 ScopeId: normalizedContext.ScopeId,
                 LlmControl: NormalizeLlmControl(input.LlmControl),
-                ToolContext: input.ToolContext));
+                ToolContext: input.ToolContext,
+                ConnectorHttpAuthorization: NormalizeOptional(connectorHttpAuthorization)));
     }
 
     private static LLMControlContext? NormalizeLlmControl(ChatLlmControlInput? source)
@@ -318,6 +321,8 @@ internal static class ChatRunRequestNormalizer
 
         if (IsScopeMetadataKey(normalizedKey))
             return;
+        if (IsConnectorAuthorizationMetadataKey(normalizedKey))
+            return;
 
         metadata[normalizedKey] = normalizedValue;
     }
@@ -325,6 +330,9 @@ internal static class ChatRunRequestNormalizer
     private static bool IsScopeMetadataKey(string key) =>
         string.Equals(key, "scope_id", StringComparison.OrdinalIgnoreCase) ||
         string.Equals(key, WorkflowRunCommandMetadataKeys.ScopeId, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsConnectorAuthorizationMetadataKey(string key) =>
+        string.Equals(key, ConnectorRequest.HttpAuthorizationMetadataKey, StringComparison.OrdinalIgnoreCase);
 
     private static string? NormalizeScopeId(string? scopeId) =>
         string.IsNullOrWhiteSpace(scopeId) ? null : scopeId.Trim();

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatWebSocketRunCoordinator.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatWebSocketRunCoordinator.cs
@@ -13,14 +13,18 @@ internal static class ChatWebSocketRunCoordinator
         ICommandInteractionService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowRunEventEnvelope, WorkflowProjectionCompletionStatus> chatRunService,
         ApiRequestScope scope,
         CancellationToken ct = default,
-        IReadOnlyDictionary<string, string>? defaultMetadata = null)
+        IReadOnlyDictionary<string, string>? defaultMetadata = null,
+        string? connectorHttpAuthorization = null)
     {
         var responseMessageType = ChatWebSocketProtocol.NormalizeMessageType(command.ResponseMessageType);
         var correlationId = string.Empty;
         CapabilityMessageTraceContext ResolveContext() =>
             CapabilityTraceContext.CreateMessageContext(correlationId, command.RequestId);
 
-        var normalizedRequest = ChatRunRequestNormalizer.Normalize(command.Input, defaultMetadata);
+        var normalizedRequest = ChatRunRequestNormalizer.Normalize(
+            command.Input,
+            defaultMetadata,
+            connectorHttpAuthorization);
         if (!normalizedRequest.Succeeded)
         {
             var (code, message) = ChatRunStartErrorMapper.ToCommandError(normalizedRequest.Error);

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeDraftRunWorkflowRunCurrentStateIntegrationTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeDraftRunWorkflowRunCurrentStateIntegrationTests.cs
@@ -5,6 +5,9 @@ using System.Text.Json;
 using Aevatar.Bootstrap.Hosting;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Runtime.Abstractions;
+using Aevatar.CQRS.Projection.Runtime.Runtime;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Hosting.Endpoints;
 using Aevatar.Studio.Application.Studio.Abstractions;
@@ -16,6 +19,7 @@ using Aevatar.Workflow.Extensions.Hosting;
 using Aevatar.Workflow.Infrastructure.CapabilityApi;
 using Aevatar.Workflow.Projection;
 using Aevatar.Workflow.Projection.Orchestration;
+using Aevatar.Workflow.Projection.ReadModels;
 using FluentAssertions;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
@@ -49,6 +53,8 @@ public sealed class ScopeDraftRunWorkflowActorCurrentStateIntegrationTests
 
         var actorId = ExtractRunContextActorId(body);
         actorId.Should().NotBeNullOrWhiteSpace();
+
+        await host.CurrentStateWriteObserver.WaitForCompletedAsync(actorId!, CancellationToken.None);
 
         using var snapshotResponse = await host.Client.GetAsync($"/api/workflow-actors/{Uri.EscapeDataString(actorId!)}/current-state");
         var snapshot = await snapshotResponse.Content.ReadFromJsonAsync<WorkflowActorCurrentStateHttpResponse>();
@@ -97,12 +103,18 @@ public sealed class ScopeDraftRunWorkflowActorCurrentStateIntegrationTests
     {
         private readonly WebApplication _app;
 
-        private DraftRunWorkflowActorCurrentStateHost(WebApplication app, HttpClient client, string repoRoot, string scopeId)
+        private DraftRunWorkflowActorCurrentStateHost(
+            WebApplication app,
+            HttpClient client,
+            string repoRoot,
+            string scopeId,
+            CompletedWorkflowCurrentStateWriteObserver currentStateWriteObserver)
         {
             _app = app;
             Client = client;
             RepoRoot = repoRoot;
             ScopeId = scopeId;
+            CurrentStateWriteObserver = currentStateWriteObserver;
         }
 
         public HttpClient Client { get; }
@@ -110,6 +122,8 @@ public sealed class ScopeDraftRunWorkflowActorCurrentStateIntegrationTests
         public string RepoRoot { get; }
 
         public string ScopeId { get; }
+
+        public CompletedWorkflowCurrentStateWriteObserver CurrentStateWriteObserver { get; }
 
         public static async Task<DraftRunWorkflowActorCurrentStateHost> StartAsync()
         {
@@ -151,6 +165,10 @@ public sealed class ScopeDraftRunWorkflowActorCurrentStateIntegrationTests
             builder.Services.AddSingleton<ITeamEntryMemberResolver, DraftRunWorkflowActorCurrentStateTeamEntryMemberResolver>();
             DraftRunProjectionActivationServiceCollectionExtensions.AddWorkflowRunProjectionActivatingInteractionService(
                 builder.Services);
+            var currentStateWriteObserver = new CompletedWorkflowCurrentStateWriteObserver();
+            WorkflowExecutionCurrentStateWriteDispatcherTestExtensions.DecorateWorkflowExecutionCurrentStateWriteDispatcher(
+                builder.Services,
+                currentStateWriteObserver);
             builder.Services.AddAuthentication("Test")
                 .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("Test", _ => { });
             builder.Services.AddAuthorization();
@@ -177,7 +195,7 @@ public sealed class ScopeDraftRunWorkflowActorCurrentStateIntegrationTests
                 BaseAddress = new Uri(addressFeature.Addresses.Single()),
             };
 
-            return new DraftRunWorkflowActorCurrentStateHost(app, client, repoRoot, scopeId);
+            return new DraftRunWorkflowActorCurrentStateHost(app, client, repoRoot, scopeId, currentStateWriteObserver);
         }
 
         public async ValueTask DisposeAsync()
@@ -412,6 +430,81 @@ public sealed class ScopeDraftRunWorkflowActorCurrentStateIntegrationTests
             var principal = new ClaimsPrincipal(identity);
             var ticket = new AuthenticationTicket(principal, Scheme.Name);
             return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+    }
+
+    private sealed class CompletedWorkflowCurrentStateWriteObserver
+    {
+        private readonly object _gate = new();
+        private readonly Dictionary<string, TaskCompletionSource<WorkflowExecutionCurrentStateDocument>> _waiters =
+            new(StringComparer.Ordinal);
+        private readonly HashSet<string> _completedActorIds = new(StringComparer.Ordinal);
+
+        public Task WaitForCompletedAsync(string actorId, CancellationToken ct)
+        {
+            lock (_gate)
+            {
+                if (_completedActorIds.Contains(actorId))
+                    return Task.CompletedTask;
+
+                if (!_waiters.TryGetValue(actorId, out var waiter))
+                {
+                    waiter = new TaskCompletionSource<WorkflowExecutionCurrentStateDocument>(
+                        TaskCreationOptions.RunContinuationsAsynchronously);
+                    _waiters[actorId] = waiter;
+                }
+
+                return waiter.Task.WaitAsync(ct);
+            }
+        }
+
+        public void Observe(WorkflowExecutionCurrentStateDocument document)
+        {
+            if (!string.Equals(document.Status, "completed", StringComparison.OrdinalIgnoreCase))
+                return;
+
+            TaskCompletionSource<WorkflowExecutionCurrentStateDocument>? waiter = null;
+            lock (_gate)
+            {
+                _completedActorIds.Add(document.ActorId);
+                if (_waiters.Remove(document.ActorId, out var existing))
+                    waiter = existing;
+            }
+
+            waiter?.TrySetResult(document);
+        }
+    }
+
+    private sealed class ObservingWorkflowExecutionCurrentStateWriteDispatcher(
+        IProjectionWriteDispatcher<WorkflowExecutionCurrentStateDocument> inner,
+        CompletedWorkflowCurrentStateWriteObserver observer)
+        : IProjectionWriteDispatcher<WorkflowExecutionCurrentStateDocument>
+    {
+        public async Task<ProjectionWriteResult> UpsertAsync(
+            WorkflowExecutionCurrentStateDocument readModel,
+            CancellationToken ct = default)
+        {
+            var result = await inner.UpsertAsync(readModel, ct);
+            if (result.IsApplied)
+                observer.Observe(readModel);
+            return result;
+        }
+
+        public Task<ProjectionWriteResult> DeleteAsync(string id, CancellationToken ct = default) =>
+            inner.DeleteAsync(id, ct);
+    }
+
+    private static class WorkflowExecutionCurrentStateWriteDispatcherTestExtensions
+    {
+        public static IServiceCollection DecorateWorkflowExecutionCurrentStateWriteDispatcher(
+            IServiceCollection services,
+            CompletedWorkflowCurrentStateWriteObserver observer)
+        {
+            services.AddSingleton<IProjectionWriteDispatcher<WorkflowExecutionCurrentStateDocument>>(provider =>
+                new ObservingWorkflowExecutionCurrentStateWriteDispatcher(
+                    provider.GetRequiredService<ProjectionStoreDispatcher<WorkflowExecutionCurrentStateDocument>>(),
+                    observer));
+            return services;
         }
     }
 }

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -3885,19 +3885,20 @@ public sealed class ScopeServiceEndpointsTests
         };
         successContext.Request.Headers.Authorization = "Bearer token-123";
 
-        var scopedHeaders = await InvokePrivateStaticTask<Dictionary<string, string>>(
-            "BuildScopedHeadersAsync",
+        var scopedHeaders = InvokePrivateStatic<Dictionary<string, string>>(
+            "BuildScopedHeaders",
             "scope-a",
-            explicitHeaders,
-            successContext,
-            CancellationToken.None);
+            explicitHeaders);
 
         scopedHeaders.Should().NotContainKey("scope_id");
         scopedHeaders.Should().NotContainKey(WorkflowRunCommandMetadataKeys.ScopeId);
         scopedHeaders[LLMRequestMetadataKeys.ModelOverride].Should().Be("existing-model");
         scopedHeaders.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdRoutePreference);
         scopedHeaders.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
-        scopedHeaders[ConnectorRequest.HttpAuthorizationMetadataKey].Should().Be("Bearer token-123");
+        scopedHeaders.Should().NotContainKey(ConnectorRequest.HttpAuthorizationMetadataKey);
+        InvokePrivateStatic<string?>("ExtractConnectorHttpAuthorization", successContext)
+            .Should()
+            .Be("Bearer token-123");
 
         var scopedControl = await InvokePrivateStaticTask<LLMControlContext?>(
             "BuildScopedLlmControlAsync",
@@ -3918,12 +3919,10 @@ public sealed class ScopeServiceEndpointsTests
                 .AddSingleton<IUserConfigQueryPort>(new ThrowingUserConfigStore())
                 .BuildServiceProvider(),
         };
-        var failedHeaders = await InvokePrivateStaticTask<Dictionary<string, string>>(
-            "BuildScopedHeadersAsync",
+        var failedHeaders = InvokePrivateStatic<Dictionary<string, string>>(
+            "BuildScopedHeaders",
             "scope-a",
-            null,
-            failingContext,
-            CancellationToken.None);
+            null);
         failedHeaders.Should().BeEmpty();
         var failedControl = await InvokePrivateStaticTask<LLMControlContext?>(
             "BuildScopedLlmControlAsync",

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -1309,10 +1309,17 @@ public sealed class ScopeServiceEndpointsTests
             return CommandInteractionResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
                 .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
         };
+        host.Client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "token-123");
 
         var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/workflow/draft-run", new
         {
             prompt = "run the draft",
+            headers = new Dictionary<string, string>
+            {
+                [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer body-secret",
+                ["trace-id"] = "trace-1",
+            },
             workflowYamls = new[]
             {
                 "name: main\nsteps:\n  - run: echo hello",
@@ -1327,6 +1334,9 @@ public sealed class ScopeServiceEndpointsTests
         host.InteractionService.LastRequest!.ScopeId.Should().Be("scope-a");
         host.InteractionService.LastRequest.Source.WorkflowYamls.Should().NotBeNull();
         host.InteractionService.LastRequest.Source.WorkflowYamls.Should().HaveCount(2);
+        host.InteractionService.LastRequest.ConnectorHttpAuthorization.Should().Be("Bearer token-123");
+        host.InteractionService.LastRequest.Metadata.Should().Contain("trace-id", "trace-1");
+        host.InteractionService.LastRequest.Metadata.Should().NotContainKey(ConnectorRequest.HttpAuthorizationMetadataKey);
     }
 
     [Fact]
@@ -1359,10 +1369,17 @@ public sealed class ScopeServiceEndpointsTests
             return CommandInteractionResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
                 .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
         };
+        host.Client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "token-123");
 
         var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/workflow/draft-run", new
         {
             prompt = "run the draft",
+            headers = new Dictionary<string, string>
+            {
+                [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer body-secret",
+                ["trace-id"] = "trace-agui",
+            },
             workflowYamls = new[]
             {
                 "name: main\nroles:\n  - id: assistant\n    name: Assistant\nsteps:\n  - id: reply\n    type: llm_call\n    target_role: assistant",
@@ -1376,6 +1393,9 @@ public sealed class ScopeServiceEndpointsTests
         body.Should().Contain("aevatar.run.context");
         host.InteractionService.LastRequest.Should().NotBeNull();
         host.InteractionService.LastRequest!.Source.WorkflowYamls.Should().HaveCount(1);
+        host.InteractionService.LastRequest.ConnectorHttpAuthorization.Should().Be("Bearer token-123");
+        host.InteractionService.LastRequest.Metadata.Should().Contain("trace-id", "trace-agui");
+        host.InteractionService.LastRequest.Metadata.Should().NotContainKey(ConnectorRequest.HttpAuthorizationMetadataKey);
     }
 
     [Fact]
@@ -3887,7 +3907,6 @@ public sealed class ScopeServiceEndpointsTests
 
         var scopedHeaders = InvokePrivateStatic<Dictionary<string, string>>(
             "BuildScopedHeaders",
-            "scope-a",
             explicitHeaders);
 
         scopedHeaders.Should().NotContainKey("scope_id");
@@ -3896,7 +3915,7 @@ public sealed class ScopeServiceEndpointsTests
         scopedHeaders.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdRoutePreference);
         scopedHeaders.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
         scopedHeaders.Should().NotContainKey(ConnectorRequest.HttpAuthorizationMetadataKey);
-        InvokePrivateStatic<string?>("ExtractConnectorHttpAuthorization", successContext)
+        WorkflowCapabilityEndpoints.ExtractConnectorHttpAuthorization(successContext)
             .Should()
             .Be("Bearer token-123");
 
@@ -3921,8 +3940,7 @@ public sealed class ScopeServiceEndpointsTests
         };
         var failedHeaders = InvokePrivateStatic<Dictionary<string, string>>(
             "BuildScopedHeaders",
-            "scope-a",
-            null);
+            new object?[] { null });
         failedHeaders.Should().BeEmpty();
         var failedControl = await InvokePrivateStaticTask<LLMControlContext?>(
             "BuildScopedLlmControlAsync",

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
+using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Commands;
 using Aevatar.GAgentService.Abstractions.Ports;
@@ -386,6 +387,7 @@ public sealed class ScopeWorkflowEndpointsTests
             },
         };
         var http = CreateHttpContext();
+        http.Request.Headers.Authorization = "Bearer token-123";
 
         await ScopeWorkflowEndpoints.HandleRunWorkflowByIdStreamAsync(
             http,
@@ -393,7 +395,11 @@ public sealed class ScopeWorkflowEndpointsTests
             "approval",
             new ScopeWorkflowEndpoints.RunScopeWorkflowByIdStreamHttpRequest(
                 "hello",
-                Headers: new Dictionary<string, string> { ["scope_id"] = "aevatar" },
+                Headers: new Dictionary<string, string>
+                {
+                    ["scope_id"] = "aevatar",
+                    [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer body-secret",
+                },
                 EventFormat: "agui"),
             BuildQueryPort(queryPort: queryPort),
             interactionService,
@@ -408,8 +414,10 @@ public sealed class ScopeWorkflowEndpointsTests
         interactionService.LastRequest.Should().NotBeNull();
         interactionService.LastRequest!.Source.ActorId.Should().Be("definition-actor-1");
         interactionService.LastRequest.ScopeId.Should().Be("user-1");
+        interactionService.LastRequest.ConnectorHttpAuthorization.Should().Be("Bearer token-123");
         interactionService.LastRequest.Metadata.Should().NotContainKey(WorkflowRunCommandMetadataKeys.ScopeId);
         interactionService.LastRequest.Metadata.Should().NotContainKey("scope_id");
+        interactionService.LastRequest.Metadata.Should().NotContainKey(ConnectorRequest.HttpAuthorizationMetadataKey);
     }
 
     [Fact]

--- a/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
@@ -2197,12 +2197,9 @@ public sealed class WorkflowAdditionalModulesCoverageTests
         var connector = new RecordingConnector("runtime-auth");
         var module = new ConnectorCallModule(new FixedWorkflowConnectorResolver(connector));
         var ctx = CreateContext();
-        await WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadataAsync(
+        await ConnectorAuthorizationRuntimeContextAccess.SetAuthorizationAsync(
             (IWorkflowExecutionStateHost)ctx.Agent,
-            new Dictionary<string, string>
-            {
-                [ConnectorRequest.HttpAuthorizationMetadataKey] = " Bearer token-123 ",
-            });
+            " Bearer token-123 ");
 
         await module.HandleAsync(
             Envelope(new StepRequestEvent

--- a/test/Aevatar.Integration.Tests/WorkflowGAgentCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowGAgentCoverageTests.cs
@@ -470,9 +470,9 @@ public class WorkflowGAgentCoverageTests
         {
             Prompt = "hello",
             SessionId = "s1",
+            ConnectorHttpAuthorization = " Bearer secret ",
             Metadata =
             {
-                [ConnectorRequest.HttpAuthorizationMetadataKey] = " Bearer secret ",
                 ["trace-id"] = " trace-abc ",
             },
             LlmControl = new LLMControlContext(
@@ -521,12 +521,9 @@ public class WorkflowGAgentCoverageTests
             "wf_redaction",
             runId: "run-redaction");
 
-        await WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadataAsync(
+        await ConnectorAuthorizationRuntimeContextAccess.SetAuthorizationAsync(
             agent,
-            new Dictionary<string, string>
-            {
-                [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer secret",
-            });
+            "Bearer secret");
         await WorkflowRequestMetadataRuntimeContextAccess.SetToolContextAsync(
             agent,
             AgentToolExecutionContext.Empty with

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationRegistrationAndExecutionTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationRegistrationAndExecutionTests.cs
@@ -8,6 +8,7 @@ using Aevatar.CQRS.Core.Commands;
 using Aevatar.CQRS.Core.Interactions;
 using Aevatar.CQRS.Core.Streaming;
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Application.Abstractions.Workflows;
@@ -415,6 +416,7 @@ public sealed class WorkflowApplicationRegistrationAndExecutionTests
             {
                 [WorkflowRunCommandMetadataKeys.ScopeId] = "evil-scope",
                 ["scope_id"] = "evil-legacy-scope",
+                [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer legacy-secret",
                 ["client-note"] = "open-extension",
             },
             ScopeId: "scope-typed",
@@ -436,7 +438,8 @@ public sealed class WorkflowApplicationRegistrationAndExecutionTests
                     MaxToolRoundsOverride = 5,
                     UserMemoryPrompt = "memory",
                 },
-            });
+            },
+            ConnectorHttpAuthorization: " Bearer typed-secret ");
 
         var envelope = factory.CreateEnvelope(command, new CommandContext(
             "actor-1",
@@ -452,9 +455,11 @@ public sealed class WorkflowApplicationRegistrationAndExecutionTests
         request.LlmControl.ModelOverride.Should().Be("model-a");
         request.LlmControl.NyxIdRoutePreference.Should().Be("route-a");
         request.LlmControl.MaxToolRoundsOverride.Should().Be(5);
+        request.ConnectorHttpAuthorization.Should().Be("Bearer typed-secret");
         request.Metadata.Should().Contain("client-note", "open-extension");
         request.Metadata.Should().NotContainKey(WorkflowRunCommandMetadataKeys.ScopeId);
         request.Metadata.Should().NotContainKey("scope_id");
+        request.Metadata.Should().NotContainKey(ConnectorRequest.HttpAuthorizationMetadataKey);
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
@@ -17,7 +17,7 @@ namespace Aevatar.Workflow.Core.Tests.Execution;
 public sealed class WorkflowExecutionRuntimeContextTests
 {
     [Fact]
-    public async Task SetRequestMetadata_ShouldPromoteControlValuesToTypedState_AndGuardPassthrough()
+    public async Task SetRequestMetadata_ShouldScrubControlValuesWithoutPromotingConnectorAuthorization()
     {
         var host = new RecordingStateHost();
 
@@ -34,7 +34,7 @@ public sealed class WorkflowExecutionRuntimeContextTests
                 ["empty"] = " ",
             });
 
-        host.ExecutionContextState.Connector!.HttpAuthorization.Should().Be("Bearer secret");
+        host.ExecutionContextState.Connector.Should().BeNull();
         host.ExecutionContextState.Llm.Should().BeNull();
         host.RuntimeContext.RequestPassthroughMetadata.Values.Should().ContainKey("trace-id");
         host.RuntimeContext.RequestPassthroughMetadata.Values["trace-id"].Should().Be("abc");
@@ -42,6 +42,19 @@ public sealed class WorkflowExecutionRuntimeContextTests
         host.RuntimeContext.RequestPassthroughMetadata.Values.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
         host.RuntimeContext.RequestPassthroughMetadata.Values.Should().NotContainKey(LLMRequestMetadataKeys.ModelOverride);
         host.RuntimeContext.RequestPassthroughMetadata.Values.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdRoutePreference);
+    }
+
+    [Fact]
+    public void BuildConnectorAuthorizationDelta_ShouldUseTypedAuthorizationOnly()
+    {
+        var delta = WorkflowRunExecutionContextStateAccess.BuildConnectorAuthorizationDelta(" Bearer secret ");
+
+        delta.ClearConnector.Should().BeTrue();
+        delta.Connector!.HttpAuthorization.Should().Be("Bearer secret");
+
+        var emptyDelta = WorkflowRunExecutionContextStateAccess.BuildConnectorAuthorizationDelta(" ");
+        emptyDelta.ClearConnector.Should().BeTrue();
+        emptyDelta.Connector.Should().BeNull();
     }
 
     [Fact]
@@ -73,12 +86,12 @@ public sealed class WorkflowExecutionRuntimeContextTests
     public async Task SetRequestMetadata_ShouldClearTypedConnectorAndPassthroughWhenMetadataIsNullEmptyOrInvalid()
     {
         var host = new RecordingStateHost();
+        await ConnectorAuthorizationRuntimeContextAccess.SetAuthorizationAsync(host, "Bearer secret");
         await WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadataAsync(
             host,
             new Dictionary<string, string>
             {
                 ["trace-id"] = "abc",
-                [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer secret",
             });
 
         await WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadataAsync(host, null);
@@ -101,12 +114,12 @@ public sealed class WorkflowExecutionRuntimeContextTests
     public async Task RemoveRequestMetadata_ShouldValidateAndClearTypedExecutionContext()
     {
         var host = new RecordingStateHost();
+        await ConnectorAuthorizationRuntimeContextAccess.SetAuthorizationAsync(host, "Bearer secret");
         await WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadataAsync(
             host,
             new Dictionary<string, string>
             {
                 ["trace-id"] = "abc",
-                [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer secret",
             });
         await WorkflowRequestMetadataRuntimeContextAccess.SetToolContextAsync(
             host,

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
@@ -70,6 +70,46 @@ public sealed class ChatEndpointsInternalTests
     }
 
     [Fact]
+    public async Task HandleCommand_ShouldPassTypedConnectorAuthorization_AndScrubMetadata()
+    {
+        var service = new FakeCommandDispatchService
+        {
+            Result = CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>.Success(
+                new WorkflowChatRunAcceptedReceipt("actor-1", "direct", "cmd-1", "corr-1")),
+        };
+
+        var result = await WorkflowCapabilityEndpoints.HandleCommand(
+            new ChatInput
+            {
+                Prompt = "hello",
+                Metadata = new Dictionary<string, string>
+                {
+                    [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer body-secret",
+                    ["trace-id"] = "trace-1",
+                },
+            },
+            service,
+            NullLoggerFactory.Instance,
+            CancellationToken.None,
+            defaultMetadata: new Dictionary<string, string>
+            {
+                [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer default-secret",
+                ["default-trace"] = "trace-default",
+            },
+            connectorHttpAuthorization: " Bearer command-secret ");
+
+        var http = CreateHttpContext();
+        await result.ExecuteAsync(http);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        service.LastCommand.Should().NotBeNull();
+        service.LastCommand!.ConnectorHttpAuthorization.Should().Be("Bearer command-secret");
+        service.LastCommand.Metadata.Should().Contain("trace-id", "trace-1");
+        service.LastCommand.Metadata.Should().Contain("default-trace", "trace-default");
+        service.LastCommand.Metadata.Should().NotContainKey(ConnectorRequest.HttpAuthorizationMetadataKey);
+    }
+
+    [Fact]
     public async Task HandleCommand_ShouldPreserveOpaqueActorIdInAcceptedLocationAndPayload()
     {
         const string opaqueActorId = "script-runtime:opaque-actor-9";

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
@@ -2,6 +2,7 @@ using System.Net.WebSockets;
 using System.Text;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
+using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Core;
@@ -359,6 +360,51 @@ public sealed class ChatEndpointsInternalTests
         http.Response.Headers["X-Correlation-Id"].ToString().Should().Be("corr-1");
         body.Should().Contain("aevatar.run.context");
         body.Should().Contain("\"delta\": \"hello\"");
+    }
+
+    [Fact]
+    public async Task HandleChat_ShouldPassTrustedBearerAsTypedConnectorAuthorization()
+    {
+        var interactionService = new FakeCommandInteractionService
+        {
+            ResultFactory = async (_, emitAsync, onAcceptedAsync, ct) =>
+            {
+                var receipt = new WorkflowChatRunAcceptedReceipt("actor-1", "direct", "cmd-1", "corr-1");
+                if (onAcceptedAsync != null)
+                    await onAcceptedAsync(receipt, ct);
+                await emitAsync(new WorkflowRunEventEnvelope
+                {
+                    TextMessageContent = new WorkflowTextMessageContentEventPayload
+                    {
+                        MessageId = "message-1",
+                        Delta = "hello",
+                    },
+                }, ct);
+                return CommandInteractionResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
+            },
+        };
+        var http = CreateHttpContext();
+        http.Request.Headers.Authorization = "Bearer token-123";
+
+        await WorkflowCapabilityEndpoints.HandleChat(
+            http,
+            new ChatInput
+            {
+                Prompt = "hello",
+                Metadata = new Dictionary<string, string>
+                {
+                    [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer body-secret",
+                    ["trace-id"] = "trace-1",
+                },
+            },
+            interactionService,
+            CancellationToken.None);
+
+        interactionService.LastRequest.Should().NotBeNull();
+        interactionService.LastRequest!.ConnectorHttpAuthorization.Should().Be("Bearer token-123");
+        interactionService.LastRequest.Metadata.Should().Contain("trace-id", "trace-1");
+        interactionService.LastRequest.Metadata.Should().NotContainKey(ConnectorRequest.HttpAuthorizationMetadataKey);
     }
 
     [Fact]
@@ -1084,12 +1130,17 @@ public sealed class ChatEndpointsInternalTests
                 CommandInteractionResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
                     .Failure(WorkflowChatRunStartError.AgentNotFound));
 
+        public WorkflowChatRunRequest? LastRequest { get; private set; }
+
         public Task<CommandInteractionResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>> ExecuteAsync(
             WorkflowChatRunRequest request,
             Func<WorkflowRunEventEnvelope, CancellationToken, ValueTask> emitAsync,
             Func<WorkflowChatRunAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
-            CancellationToken ct = default) =>
-            ResultFactory(request, emitAsync, onAcceptedAsync, ct);
+            CancellationToken ct = default)
+        {
+            LastRequest = request;
+            return ResultFactory(request, emitAsync, onAcceptedAsync, ct);
+        }
     }
 
     private sealed class FakeCommandDispatchService

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatWebSocketCoordinatorAndProtocolTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatWebSocketCoordinatorAndProtocolTests.cs
@@ -3,6 +3,7 @@ using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
+using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Infrastructure.CapabilityApi;
 using FluentAssertions;
@@ -130,6 +131,46 @@ public sealed class ChatWebSocketCoordinatorAndProtocolTests
         var metadata = command!.Metadata ?? throw new InvalidOperationException("Expected metadata capture.");
         metadata["telegram.chat_id"].Should().Be("-100-request");
         metadata["telegram.openclaw_bot_username"].Should().Be("openclaw_bot");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldPassTypedConnectorAuthorization_AndScrubMetadata()
+    {
+        var socket = new FakeWebSocket(WebSocketState.Open);
+        var service = new FakeCommandInteractionService
+        {
+            Handler = (_, _, _, _) => Task.FromResult(
+                CommandInteractionResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    .Failure(WorkflowChatRunStartError.AgentNotFound)),
+        };
+
+        await ChatWebSocketRunCoordinator.ExecuteAsync(
+            socket,
+            new ChatWebSocketCommandEnvelope(
+                "req-auth",
+                new ChatInput
+                {
+                    Prompt = "hello",
+                    Metadata = new Dictionary<string, string>
+                    {
+                        [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer body-secret",
+                        ["trace-id"] = "trace-1",
+                    },
+                },
+                WebSocketMessageType.Text),
+            service,
+            ApiRequestScope.BeginHttp(),
+            CancellationToken.None,
+            defaultMetadata: new Dictionary<string, string>
+            {
+                [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer default-secret",
+            },
+            connectorHttpAuthorization: " Bearer websocket-secret ");
+
+        service.LastRequest.Should().NotBeNull();
+        service.LastRequest!.ConnectorHttpAuthorization.Should().Be("Bearer websocket-secret");
+        service.LastRequest.Metadata.Should().Contain("trace-id", "trace-1");
+        service.LastRequest.Metadata.Should().NotContainKey(ConnectorRequest.HttpAuthorizationMetadataKey);
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowCapabilityEndpointsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowCapabilityEndpointsCoverageTests.cs
@@ -3,6 +3,7 @@ using Aevatar.Workflow.Application.Runs;
 using Aevatar.Workflow.Infrastructure.CapabilityApi;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.Foundation.Abstractions.Connectors;
 using FluentAssertions;
 
 namespace Aevatar.Workflow.Host.Api.Tests;
@@ -227,6 +228,36 @@ public sealed class WorkflowCapabilityEndpointsCoverageTests
         result.Succeeded.Should().BeTrue();
         result.Request!.ToolContext.Should().BeSameAs(toolContext);
         result.Request.LlmControl.Should().BeNull();
+    }
+
+    [Fact]
+    public void ChatRunRequestNormalizer_ShouldUseTrustedConnectorAuthorization_AndScrubMetadata()
+    {
+        var input = new ChatInput
+        {
+            Prompt = "hello",
+            Metadata = new Dictionary<string, string>
+            {
+                [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer body-secret",
+                ["trace-id"] = "trace-1",
+            },
+        };
+        var defaultMetadata = new Dictionary<string, string>
+        {
+            [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer default-secret",
+            ["default-note"] = "default",
+        };
+
+        var result = ChatRunRequestNormalizer.Normalize(
+            input,
+            defaultMetadata,
+            connectorHttpAuthorization: " Bearer trusted-secret ");
+
+        result.Succeeded.Should().BeTrue();
+        result.Request!.ConnectorHttpAuthorization.Should().Be("Bearer trusted-secret");
+        result.Request.Metadata.Should().Contain("trace-id", "trace-1");
+        result.Request.Metadata.Should().Contain("default-note", "default");
+        result.Request.Metadata.Should().NotContainKey(ConnectorRequest.HttpAuthorizationMetadataKey);
     }
 
     [Fact]


### PR DESCRIPTION
## 摘要

实施 #1559 Phase 9 r1 三 solver + meta-judge consensus(typed connector auth carrier)。

closes #1559

## 范围

- 新增 typed connector auth scalar:`WorkflowChatRunRequest.ConnectorHttpAuthorization` → `ChatRequestEvent.connector_http_authorization`
- 移除 `Metadata["connector.http.authorization"]` 作为权威 path,改 scrub-only
- 更新 Capability API / Scope Workflow / Scope Service / Studio preview

16 files changed (+151/-85)。

## 本地验证

- `dotnet build aevatar.slnx --nologo` 0 错误
- `dotnet test aevatar.slnx --nologo --no-build`:6982 pass / 24 skip / 0 fail
- `tools/ci/test_stability_guards.sh` 6 passed

## 共识来源

详见 #1559 r1 三 solver + meta-judge 评论。

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
