### PR TITLE
refactor(#1574): LLM tool request metadata scrub-only

### DIFF
--- a/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContextMapper.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContextMapper.cs
@@ -46,7 +46,12 @@ public static class AgentToolExecutionContextMapper
         if (request.ToolContext is { } typedContext)
             return request.LlmControl?.ToToolContext(typedContext) ?? typedContext;
 
-        var mapped = FromMetadata(request.Metadata);
+        // Refactor (issue1574): Old pattern: core request mapping promoted owned control keys from Metadata.
+        // New principle: core LLMRequest control is typed; Metadata contributes only scrubbed annotations.
+        var mapped = AgentToolExecutionContext.Empty with
+        {
+            ExternalMetadata = StripOwnedControlKeys(request.Metadata),
+        };
         mapped = request.LlmControl?.ToToolContext(mapped) ?? mapped;
         var caller = request.CallerContext;
         return mapped with

--- a/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
@@ -320,7 +320,6 @@ public sealed class ChatRuntime
 
             var streamingExecutor = new StreamingToolExecutor(
                 _toolLoop.Tools, _hooks, _toolLoop.ToolMiddlewares,
-                requestMetadata: baseRequest.Metadata,
                 toolContext: baseRequest.ToolContext ?? AgentToolExecutionContextMapper.FromRequest(baseRequest));
             using var streamingToolState = streamingExecutor.CreateExecutionState();
 
@@ -459,7 +458,6 @@ public sealed class ChatRuntime
 
                         var textToolExecutor = new StreamingToolExecutor(
                             _toolLoop.Tools, _hooks, _toolLoop.ToolMiddlewares,
-                            requestMetadata: baseRequest.Metadata,
                             toolContext: AgentToolExecutionContextMapper.FromRequest(roundRequest));
                         using var textToolState = textToolExecutor.CreateExecutionState();
                         foreach (var tc in parsed.ToolCalls)
@@ -584,7 +582,6 @@ public sealed class ChatRuntime
 
                 var finalToolExecutor = new StreamingToolExecutor(
                     _toolLoop.Tools, _hooks, _toolLoop.ToolMiddlewares,
-                    requestMetadata: baseRequest.Metadata,
                     toolContext: finalRequest.ToolContext);
                 using var finalToolState = finalToolExecutor.CreateExecutionState();
                 foreach (var tc in finalParsed.ToolCalls)
@@ -823,7 +820,6 @@ public sealed class ChatRuntime
 
     internal async Task<IReadOnlyList<ToolExecutionResult>> ExecuteSingleToolStepAsync(
         IReadOnlyList<ToolCall> toolCalls,
-        IReadOnlyDictionary<string, string>? requestMetadata,
         AgentToolExecutionContext? toolContext,
         CancellationToken ct)
     {
@@ -831,7 +827,6 @@ public sealed class ChatRuntime
             _toolLoop.Tools,
             _hooks,
             _toolLoop.ToolMiddlewares,
-            requestMetadata: requestMetadata,
             toolContext: toolContext);
         using var toolState = executor.CreateExecutionState();
         foreach (var toolCall in toolCalls)

--- a/src/Aevatar.AI.Core/Chat/ChatRuntimeStepExecutor.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntimeStepExecutor.cs
@@ -118,7 +118,9 @@ public sealed class ChatRuntimeStepExecutor
             _hooks,
             _requestBuilder,
             llmMiddlewares: _llmMiddlewares);
-        return await runtime.ExecuteSingleToolStepAsync(toolCalls, requestMetadata, toolContext, ct)
+        // Refactor (issue1574): Old pattern: core tool step accepted Metadata as a fallback control source.
+        // New principle: metadata is retained for outer legacy planning only; core tool execution uses typed context.
+        return await runtime.ExecuteSingleToolStepAsync(toolCalls, toolContext, ct)
             .ConfigureAwait(false);
     }
 

--- a/src/Aevatar.AI.Core/Tools/StreamingToolExecutor.cs
+++ b/src/Aevatar.AI.Core/Tools/StreamingToolExecutor.cs
@@ -38,15 +38,19 @@ public sealed class StreamingToolExecutor
         IReadOnlyDictionary<string, string>? requestMetadata = null,
         AgentToolExecutionContext? toolContext = null)
     {
-        // Refactor (iter24/cluster-002-agent-tool-context-generic-metadata-bag):
-        //   Old pattern: streaming tool execution received raw request Metadata.
-        //   New principle: tool control semantics are typed context fields; Metadata is not the internal control plane.
+        // Refactor (issue1574): Old pattern: streaming tool execution promoted request Metadata into tool control.
+        // New principle: streaming tool control is typed; request Metadata remains external annotations only.
         _tools = tools;
         _hooks = hooks;
         _toolMiddlewares = toolMiddlewares ?? [];
         _toolContext = toolContext
             ?? AgentToolRequestContext.Current
-            ?? AgentToolExecutionContextMapper.FromMetadata(requestMetadata);
+            ?? (requestMetadata == null
+                ? null
+                : AgentToolExecutionContext.Empty with
+                {
+                    ExternalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(requestMetadata),
+                });
     }
 
     public ExecutionState CreateExecutionState() => new();

--- a/src/Aevatar.AI.Core/Tools/ToolCallLoop.cs
+++ b/src/Aevatar.AI.Core/Tools/ToolCallLoop.cs
@@ -275,7 +275,12 @@ public sealed class ToolCallLoop
         IReadOnlyDictionary<string, string>? metadata,
         CancellationToken ct)
     {
-        using var _ = AgentToolContextScope.Push(AgentToolExecutionContextMapper.FromMetadata(metadata));
+        // Refactor (issue1574): Old pattern: standalone tool execution promoted Metadata into tool control.
+        // New principle: core tool execution receives typed control; Metadata only supplies scrubbed annotations.
+        using var _ = AgentToolContextScope.Push(AgentToolExecutionContext.Empty with
+        {
+            ExternalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(metadata),
+        });
         await ExecuteToolCallsCoreAsync(toolCalls, messages, ct);
     }
 

--- a/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
+++ b/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
@@ -95,6 +95,41 @@ public sealed class AgentToolExecutionContextMapperTests
     }
 
     [Fact]
+    public void FromRequest_WhenToolContextIsProvided_ShouldReturnTypedContextAndIgnoreMetadataFallback()
+    {
+        var typedContext = AgentToolExecutionContext.Empty with
+        {
+            Request = new AgentToolRequestIdentity("typed-request", "typed-call"),
+            Credentials = new AgentToolCredentials("typed-token", null, null),
+            ExternalMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["typed-note"] = "kept",
+            },
+        };
+        var request = new LLMRequest
+        {
+            Messages = [],
+            ToolContext = typedContext,
+            Metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [LLMRequestMetadataKeys.RequestId] = "metadata-request",
+                [LLMRequestMetadataKeys.CallId] = "metadata-call",
+                [LLMRequestMetadataKeys.NyxIdAccessToken] = "metadata-token",
+                ["external-trace"] = "trace-1",
+            },
+        };
+
+        var context = AgentToolExecutionContextMapper.FromRequest(request);
+
+        context.Should().BeSameAs(typedContext);
+        context.Request.RequestId.Should().Be("typed-request");
+        context.Request.CallId.Should().Be("typed-call");
+        context.Credentials.NyxIdAccessToken.Should().Be("typed-token");
+        context.ExternalMetadata.Should().ContainSingle("typed-note", "kept");
+        context.ExternalMetadata.Should().NotContainKey("external-trace");
+    }
+
+    [Fact]
     public void FromMetadata_WhenChannelCanonicalKeysAreAbsent_ShouldMapLegacyAliases()
     {
         var context = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>(StringComparer.Ordinal)

--- a/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
+++ b/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
@@ -10,7 +10,7 @@ namespace Aevatar.AI.Tests;
 public sealed class AgentToolExecutionContextMapperTests
 {
     [Fact]
-    public void FromRequest_WhenTypedFieldsAndLegacyMetadataOverlap_ShouldPreferTypedRequestCallerAndRouting()
+    public void FromRequest_WhenTypedFieldsAndLegacyMetadataOverlap_ShouldUseOnlyTypedControlAndScrubMetadata()
     {
         var request = new LLMRequest
         {
@@ -46,16 +46,50 @@ public sealed class AgentToolExecutionContextMapperTests
         var context = AgentToolExecutionContextMapper.FromRequest(request);
 
         context.Request.RequestId.Should().Be("typed-request");
-        context.Request.CallId.Should().Be("legacy-call");
+        context.Request.CallId.Should().BeNull();
         context.Caller.ScopeId.Should().Be("typed-scope");
         context.Caller.OwnerSubject.Should().Be("typed-owner");
         context.Caller.ResponseId.Should().Be("typed-response");
         context.Credentials.NyxIdAccessToken.Should().Be("typed-access");
-        context.Credentials.NyxIdOrgToken.Should().Be("legacy-org");
+        context.Credentials.NyxIdOrgToken.Should().BeNull();
         context.Routing.ModelOverride.Should().Be("typed-model");
         context.Routing.NyxIdRoutePreference.Should().Be("typed-route");
         context.Routing.MaxToolRoundsOverride.Should().Be(9);
         context.Routing.UserMemoryPrompt.Should().Be("typed-memory");
+        context.ExternalMetadata.Should().ContainSingle();
+        context.ExternalMetadata["external-trace"].Should().Be("trace-1");
+    }
+
+    [Fact]
+    public void FromRequest_WhenOnlyMetadataContainsOwnedControlKeys_ShouldNotPromoteThemToControlContext()
+    {
+        var request = new LLMRequest
+        {
+            Messages = [],
+            Metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [LLMRequestMetadataKeys.RequestId] = "legacy-request",
+                [LLMRequestMetadataKeys.CallId] = "legacy-call",
+                [LLMRequestMetadataKeys.ScopeId] = "legacy-scope",
+                [LLMRequestMetadataKeys.NyxIdAccessToken] = "legacy-access",
+                [LLMRequestMetadataKeys.NyxIdOrgToken] = "legacy-org",
+                [LLMRequestMetadataKeys.ModelOverride] = "legacy-model",
+                [LLMRequestMetadataKeys.NyxIdRoutePreference] = "legacy-route",
+                [LLMRequestMetadataKeys.MaxToolRoundsOverride] = "4",
+                ["external-trace"] = "trace-1",
+            },
+        };
+
+        var context = AgentToolExecutionContextMapper.FromRequest(request);
+
+        context.Request.RequestId.Should().BeNull();
+        context.Request.CallId.Should().BeNull();
+        context.Caller.ScopeId.Should().BeNull();
+        context.Credentials.NyxIdAccessToken.Should().BeNull();
+        context.Credentials.NyxIdOrgToken.Should().BeNull();
+        context.Routing.ModelOverride.Should().BeNull();
+        context.Routing.NyxIdRoutePreference.Should().BeNull();
+        context.Routing.MaxToolRoundsOverride.Should().BeNull();
         context.ExternalMetadata.Should().ContainSingle();
         context.ExternalMetadata["external-trace"].Should().Be("trace-1");
     }

--- a/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
+++ b/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
@@ -306,6 +306,48 @@ public sealed class ChatRuntimeStreamingBufferTests
     }
 
     [Fact]
+    public void CreateStepExecutor_BuildBaseRequest_ShouldMergeOverrideMetadataThenScrubOwnedKeys()
+    {
+        var provider = new RecordingStepProvider();
+        var runtime = CreateRuntime(
+            provider,
+            requestBuilder: () => new LLMRequest
+            {
+                Messages = [],
+                RequestId = "base-request",
+                Metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["safe"] = "base",
+                    ["override"] = "base",
+                    [LLMRequestMetadataKeys.NyxIdAccessToken] = "base-token",
+                    [LLMRequestMetadataKeys.ModelOverride] = "base-model",
+                },
+            });
+        var executor = runtime.CreateStepExecutor();
+
+        var request = executor.BuildBaseRequest(
+            " request-1 ",
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["override"] = "override",
+                [LLMRequestMetadataKeys.NyxIdAccessToken] = "override-token",
+                [LLMRequestMetadataKeys.CallId] = "override-call",
+            },
+            toolContext: null,
+            llmControl: null);
+
+        request.RequestId.Should().Be("request-1");
+        request.ToolContext!.Request.RequestId.Should().Be("request-1");
+        request.ToolContext.Credentials.NyxIdAccessToken.Should().BeNull();
+        request.ToolContext.Routing.ModelOverride.Should().BeNull();
+        request.Metadata.Should().BeEquivalentTo(new Dictionary<string, string>
+        {
+            ["safe"] = "base",
+            ["override"] = "override",
+        });
+    }
+
+    [Fact]
     public async Task ChatStreamAsync_WhenStreamReturnsToolCall_ShouldExecuteToolAndContinueWithFollowUpRound()
     {
         var provider = new QueuedStreamingProvider(

--- a/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
+++ b/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
@@ -270,6 +270,39 @@ public sealed class ChatRuntimeStreamingBufferTests
         tool.CapturedContext.Should().NotBeNull();
         tool.CapturedContext!.Request.CallId.Should().Be("tool-1");
         tool.CapturedContext.Request.RequestId.Should().Be("req-123");
+        tool.CapturedContext.Credentials.NyxIdAccessToken.Should().BeNull();
+        tool.CapturedContext.Routing.ModelOverride.Should().Be("model-a");
+        tool.CapturedContext.ExternalMetadata["safe"].Should().Be("tool-context");
+        tool.CapturedContext.ExternalMetadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
+        tool.CapturedContext.ExternalMetadata.Should().NotContainKey(LLMRequestMetadataKeys.ModelOverride);
+    }
+
+    [Fact]
+    public async Task ExecuteToolStepAsync_WhenToolContextIsNull_ShouldNotPromoteRequestMetadataToToolControl()
+    {
+        var provider = new RecordingStepProvider();
+        var tool = new CapturingTool();
+        var tools = new ToolManager();
+        tools.Register(tool);
+        var runtime = CreateRuntime(provider, tools);
+        var executor = runtime.CreateStepExecutor();
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "metadata-token",
+            [LLMRequestMetadataKeys.ModelOverride] = "metadata-model",
+            [LLMRequestMetadataKeys.CallId] = "metadata-call",
+            ["trace-id"] = "trace-1",
+        };
+
+        var toolResults = await executor.ExecuteToolStepAsync(
+            [new ToolCall { Id = "tool-1", Name = "capture", ArgumentsJson = "{}" }],
+            metadata,
+            toolContext: null,
+            CancellationToken.None);
+
+        toolResults.Should().ContainSingle();
+        tool.CapturedContext.Should().BeNull();
+        AgentToolRequestContext.Current.Should().BeNull();
     }
 
     [Fact]

--- a/test/Aevatar.AI.Tests/StreamingToolExecutorTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingToolExecutorTests.cs
@@ -428,6 +428,28 @@ public class StreamingToolExecutorTests
     }
 
     [Fact]
+    public async Task NullRequestMetadataAndContext_ShouldNotCreateImplicitToolExecutionContext()
+    {
+        AgentToolExecutionContext? capturedContext = AgentToolExecutionContext.Empty;
+        var tools = new ToolManager();
+        tools.Register(new DelegateAgentTool("meta-check", _ =>
+        {
+            capturedContext = AgentToolRequestContext.Current;
+            return "ok";
+        }));
+
+        var executor = new StreamingToolExecutor(tools);
+        using var executionState = executor.CreateExecutionState();
+
+        executor.AddTool(executionState, new ToolCall { Id = "tc-1", Name = "meta-check", ArgumentsJson = "{}" });
+
+        await foreach (var _ in executor.GetRemainingResultsAsync(executionState, CancellationToken.None)) { }
+
+        capturedContext.Should().BeNull();
+        AgentToolRequestContext.Current.Should().BeNull();
+    }
+
+    [Fact]
     public async Task GetCompletedResults_ShouldReturnNonBlocking()
     {
         var tools = new ToolManager();

--- a/test/Aevatar.AI.Tests/StreamingToolExecutorTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingToolExecutorTests.cs
@@ -428,6 +428,50 @@ public class StreamingToolExecutorTests
     }
 
     [Fact]
+    public async Task TypedContext_ShouldTakePrecedenceOverRequestMetadata()
+    {
+        string? capturedToken = null;
+        string? capturedExternal = null;
+        string? capturedCallId = null;
+        var tools = new ToolManager();
+        tools.Register(new DelegateAgentTool("meta-check", _ =>
+        {
+            capturedToken = AgentToolRequestContext.NyxIdAccessToken;
+            capturedExternal = AgentToolRequestContext.TryGetExternalMetadata("trace-id");
+            capturedCallId = AgentToolRequestContext.CallId;
+            return "ok";
+        }));
+
+        var typedContext = AgentToolExecutionContext.Empty with
+        {
+            Credentials = new AgentToolCredentials("typed-token", null, null),
+            ExternalMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["trace-id"] = "typed-trace",
+            },
+        };
+        var requestMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "metadata-token",
+            ["trace-id"] = "metadata-trace",
+        };
+        var executor = new StreamingToolExecutor(
+            tools,
+            requestMetadata: requestMetadata,
+            toolContext: typedContext);
+        using var executionState = executor.CreateExecutionState();
+
+        executor.AddTool(executionState, new ToolCall { Id = "tc-typed", Name = "meta-check", ArgumentsJson = "{}" });
+
+        await foreach (var _ in executor.GetRemainingResultsAsync(executionState, CancellationToken.None)) { }
+
+        capturedToken.Should().Be("typed-token");
+        capturedExternal.Should().Be("typed-trace");
+        capturedCallId.Should().Be("tc-typed");
+        AgentToolRequestContext.Current.Should().BeNull();
+    }
+
+    [Fact]
     public async Task NullRequestMetadataAndContext_ShouldNotCreateImplicitToolExecutionContext()
     {
         AgentToolExecutionContext? capturedContext = AgentToolExecutionContext.Empty;

--- a/test/Aevatar.AI.Tests/StreamingToolExecutorTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingToolExecutorTests.cs
@@ -367,14 +367,17 @@ public class StreamingToolExecutorTests
             return "ok";
         }));
 
-        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+        var toolContext = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "typed-secret",
-            ["auth_token"] = "secret-123",
+            Credentials = new AgentToolCredentials("typed-secret", null, null),
+            ExternalMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["auth_token"] = "secret-123",
+            },
         };
 
         var executor = new StreamingToolExecutor(
-            tools, requestMetadata: metadata);
+            tools, toolContext: toolContext);
         using var executionState = executor.CreateExecutionState();
 
         executor.AddTool(executionState, new ToolCall { Id = "tc-1", Name = "meta-check", ArgumentsJson = "{}" });
@@ -382,6 +385,43 @@ public class StreamingToolExecutorTests
         await foreach (var _ in executor.GetRemainingResultsAsync(executionState, CancellationToken.None)) { }
 
         capturedToken.Should().Be("typed-secret");
+        capturedExternal.Should().Be("secret-123");
+        capturedCallId.Should().Be("tc-1");
+        AgentToolRequestContext.Current.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RequestMetadata_ShouldNotPromoteOwnedControlKeysDuringToolExecution()
+    {
+        string? capturedToken = null;
+        string? capturedExternal = null;
+        string? capturedCallId = null;
+        var tools = new ToolManager();
+        tools.Register(new DelegateAgentTool("meta-check", _ =>
+        {
+            capturedToken = AgentToolRequestContext.NyxIdAccessToken;
+            capturedExternal = AgentToolRequestContext.TryGetExternalMetadata("auth_token");
+            capturedCallId = AgentToolRequestContext.CallId;
+            return "ok";
+        }));
+
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "metadata-secret",
+            [LLMRequestMetadataKeys.CallId] = "metadata-call",
+            ["auth_token"] = "secret-123",
+        };
+
+        var executor = new StreamingToolExecutor(
+            tools,
+            requestMetadata: metadata);
+        using var executionState = executor.CreateExecutionState();
+
+        executor.AddTool(executionState, new ToolCall { Id = "tc-1", Name = "meta-check", ArgumentsJson = "{}" });
+
+        await foreach (var _ in executor.GetRemainingResultsAsync(executionState, CancellationToken.None)) { }
+
+        capturedToken.Should().BeNull();
         capturedExternal.Should().Be("secret-123");
         capturedCallId.Should().Be("tc-1");
         AgentToolRequestContext.Current.Should().BeNull();

--- a/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
+++ b/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Reflection;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
@@ -188,6 +189,63 @@ public class ToolCallLoopTests
         capturedExternal.Should().Be("trace-1");
         capturedCallId.Should().Be("tool-call-1");
         messages.Should().ContainSingle(m => m.Role == "tool" && m.ToolCallId == "tool-call-1");
+        AgentToolRequestContext.Current.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteToolCallsAsync_WhenMetadataHasOwnedKeys_ShouldPushOnlyExternalAnnotations()
+    {
+        string? capturedToken = null;
+        string? capturedScope = null;
+        string? capturedExternal = null;
+        string? capturedCallId = null;
+        var tools = new ToolManager();
+        tools.Register(new DelegateTool("capture", _ =>
+        {
+            capturedToken = AgentToolRequestContext.NyxIdAccessToken;
+            capturedScope = AgentToolRequestContext.ScopeId;
+            capturedExternal = AgentToolRequestContext.TryGetExternalMetadata("trace-id");
+            capturedCallId = AgentToolRequestContext.CallId;
+            return """{"ok":true}""";
+        }));
+        var loop = new ToolCallLoop(tools);
+        var messages = new List<ChatMessage> { ChatMessage.User("hello") };
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "metadata-token",
+            [LLMRequestMetadataKeys.ScopeId] = "metadata-scope",
+            [LLMRequestMetadataKeys.CallId] = "metadata-call",
+            ["trace-id"] = "trace-standalone",
+        };
+        var method = typeof(ToolCallLoop).GetMethod(
+            "ExecuteToolCallsAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        var task = (Task)method!.Invoke(loop,
+        [
+            new List<ToolCall>
+            {
+                new()
+                {
+                    Id = "standalone-tool-call",
+                    Name = "capture",
+                    ArgumentsJson = "{}",
+                },
+            },
+            messages,
+            metadata,
+            CancellationToken.None,
+        ])!;
+
+        await task;
+
+        capturedToken.Should().BeNull();
+        capturedScope.Should().BeNull();
+        capturedExternal.Should().Be("trace-standalone");
+        capturedCallId.Should().Be("standalone-tool-call");
+        messages.Should().ContainSingle(m =>
+            m.Role == "tool" &&
+            m.ToolCallId == "standalone-tool-call" &&
+            m.Content == """{"ok":true}""");
         AgentToolRequestContext.Current.Should().BeNull();
     }
 

--- a/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
+++ b/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
@@ -136,6 +136,62 @@ public class ToolCallLoopTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_WhenMetadataHasOwnedKeys_ShouldKeepOnlyExternalAnnotationsForToolExecution()
+    {
+        string? capturedToken = null;
+        string? capturedScope = null;
+        string? capturedExternal = null;
+        string? capturedCallId = null;
+        var provider = new QueueLLMProvider(
+        [
+            new LLMResponse
+            {
+                ToolCalls =
+                [
+                    new ToolCall
+                    {
+                        Id = "tool-call-1",
+                        Name = "capture",
+                        ArgumentsJson = "{}",
+                    },
+                ],
+            },
+            new LLMResponse { Content = "done" },
+        ]);
+        var tools = new ToolManager();
+        tools.Register(new DelegateTool("capture", _ =>
+        {
+            capturedToken = AgentToolRequestContext.NyxIdAccessToken;
+            capturedScope = AgentToolRequestContext.ScopeId;
+            capturedExternal = AgentToolRequestContext.TryGetExternalMetadata("trace-id");
+            capturedCallId = AgentToolRequestContext.CallId;
+            return "{}";
+        }));
+        var loop = new ToolCallLoop(tools);
+        var messages = new List<ChatMessage> { ChatMessage.User("hello") };
+        var request = new LLMRequest
+        {
+            Messages = [],
+            Metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [LLMRequestMetadataKeys.NyxIdAccessToken] = "metadata-token",
+                [LLMRequestMetadataKeys.ScopeId] = "metadata-scope",
+                [LLMRequestMetadataKeys.CallId] = "metadata-call",
+                ["trace-id"] = "trace-1",
+            },
+        };
+
+        await loop.ExecuteAsync(provider, messages, request, maxRounds: 2, CancellationToken.None);
+
+        capturedToken.Should().BeNull();
+        capturedScope.Should().BeNull();
+        capturedExternal.Should().Be("trace-1");
+        capturedCallId.Should().Be("tool-call-1");
+        messages.Should().ContainSingle(m => m.Role == "tool" && m.ToolCallId == "tool-call-1");
+        AgentToolRequestContext.Current.Should().BeNull();
+    }
+
+    [Fact]
     public async Task ExecuteAsync_WhenBaseRequestIdPresent_ShouldExposeStableRequestIdAndPerCallIdToLlmMiddlewareMetadata()
     {
         var provider = new QueueLLMProvider(


### PR DESCRIPTION
## 摘要

实施 #1574 Phase 9 r1 三 solver + meta-judge consensus(typed connector auth carrier + 删除 metadata authority)。

closes #1574

## 范围

- LLMRequest.Metadata 不再在 FromRequest / StreamingToolExecutor / ToolCallLoop / ChatRuntime tool-step 路径中提升为 scope/token/route/call-id 控制语义
- 只保留 scrubbed external annotations

8 files changed (+159/-18)。

## 本地验证

- `dotnet build aevatar.slnx --nologo`:0 errors
- `dotnet test aevatar.slnx --nologo --no-build`:6984 pass / 24 skip / 0 fail
- `tools/ci/test_stability_guards.sh` passed

## 共识来源

详见 #1574 r1 三 solver + meta-judge 评论。

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
