### PR TITLE
skill: wakeup-check.sh META_JUDGE_DONE 取 tail -1 修 Phase 9 路由误判

### DIFF
--- a/.claude/skills/codex-refactor-loop/SKILL.md
+++ b/.claude/skills/codex-refactor-loop/SKILL.md
@@ -183,6 +183,8 @@ disown
 ```bash
 # 标准 merge 流程(必须 chain issue close 且 verify merge 成功)
 # 2026-05-30 修复:merge 失败仍 close issue 是严重 bug;必须 verify $? == 0
+# 2026-06-01 强制:PR 默认 draft,merge 前必须先 gh pr ready 转正(per Auric "提pr都提草稿")
+gh pr ready $PR 2>&1 | tail -1
 if gh pr merge $PR --squash --delete-branch 2>&1; then
   ISSUE=$(gh pr view $PR --json body --jq '.body' | grep -oE 'closes #[0-9]+' | grep -oE '[0-9]+' | head -1)
   if [ -n "$ISSUE" ]; then
@@ -817,11 +819,14 @@ For each `pass` cluster, serially:
     ```bash
     cd "$REPO_ROOT" && \
     gh pr create \
+      --draft \
       --base "<base_branch>" \
       --head "refactor/iterN-<cluster-id>" \
       --title "<cluster id>: <short imperative title — same English title; PR title is not bilingual since GitHub UI truncates>" \
       --body-file <generated_body_file>
     ```
+
+    **强制 `--draft`(per Auric 2026-06-01 "提pr都提草稿, 防止人工误合并")**:所有 controller 开的 PR 必须以 draft 状态创建,防止 maintainer 误手动 merge。Phase 8 reviewer 3/3 共识 + CI 绿后,controller **`gh pr ready <PR>`** 转出 draft 再 `gh pr merge`。`gh pr ready` 与 `gh pr merge` 必须 chain 在同一 controller turn 内 完成。
 
     Controller must run the equivalence test (SKILL.md Bilingual rule §"Equivalence test") on the generated body before `gh pr create`. If 中文 section is missing or visibly shorter than English, regenerate or fall back to a one-paragraph machine-translation as last resort (and PushNotification flagging the legacy fallback so operator can fix).
 
@@ -2690,6 +2695,28 @@ Bash(
     **例外**:`audit` codex 不跑 test(它只 inspect 不改 code)。`verify` codex 跑 full test 是 verify 职责本身。
 
 11. **controller commit 前 self-verify**(强制,per Auric 2026-05-27 与规则 10 同源). 即使 codex marker `tests-pass`,controller 在 `git commit --amend` / `git push --force-with-lease` 前**必须**自己跑一次 `dotnet test aevatar.slnx --nologo --no-build` 兜底。fail → 拒绝 push,派 r+1 fix。双保险防 codex marker 不诚实 / filter 窄漏 module。
+
+12. **所有 controller 开的 PR 必须 `--draft` 创建**(强制,per Auric 2026-06-01 "提pr都提草稿, 防止人工误合并"). 防止 maintainer 在 reviewer 共识达成 + CI 绿前手动 merge 不完整 PR。
+
+    适用范围:
+    - cluster PR(Phase 4b open)— 必须 `--draft`
+    - rollup PR(integration → review_base_branch)— 必须 `--draft`
+    - dev_sync_daemon reverse sync PR(auto-refact-dev → dev)— 必须 `--draft`(maintainer 手动 review)
+
+    例外:
+    - dev_sync_daemon forward sync PR(dev → auto-refact-dev)— **不** `--draft`,因 daemon 立即 `gh pr merge --auto`,draft 会阻塞 auto-merge
+
+    Merge 前必须 chain `gh pr ready <PR>` 再 `gh pr merge`,顺序固定:
+    ```bash
+    gh pr ready $PR 2>&1 | tail -1   # 转出 draft
+    gh pr merge $PR --squash --delete-branch  # 再 merge
+    ```
+    `controller_lib.sh` `merge_pr` 已封装此顺序。手写 merge 必须 `gh pr ready` 前置,否则 `gh pr merge` 报 "Pull request is not mergeable: it is in draft state"。
+
+    **反面禁止**:
+    - ❌ `gh pr create` 缺 `--draft`(除 forward sync 例外)
+    - ❌ `gh pr merge` 直接调用未先 `gh pr ready` → fail with "draft state" error
+    - ❌ controller 自己 `gh pr ready` 但不立即 merge → 留出 maintainer 误 merge 窗口;`gh pr ready` 必须与 `gh pr merge` 在同一 controller turn 内 chain
 
 ## 工作语言规则(默认中文)
 

--- a/.claude/skills/codex-refactor-loop/scripts/controller_lib.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/controller_lib.sh
@@ -45,9 +45,9 @@ merge_pr() {
     echo "merge_pr: missing pr number" >&2
     return 1
   fi
-  # Auto-extract Closes #N if linked_issue not provided
+  # Auto-extract Closes/Fixes/Resolves #N (case-insensitive — 2026-06-01 PR1643 lowercase "closes #1507" 漏 close 修复)
   if [ -z "$linked_issue" ]; then
-    linked_issue=$(gh pr view "$pr" --json body --jq '.body' 2>/dev/null | grep -oE "Closes #[0-9]+" | head -1 | grep -oE "[0-9]+")
+    linked_issue=$(gh pr view "$pr" --json body --jq '.body' 2>/dev/null | grep -oiE "(closes|fixes|resolves) #[0-9]+" | head -1 | grep -oE "[0-9]+")
   fi
   # gh pr ready 转出 draft 状态(per Auric 2026-06-01 "提pr都提草稿");忽略已是 ready 的 idempotent error
   gh pr ready "$pr" 2>&1 | tail -1

--- a/.claude/skills/codex-refactor-loop/scripts/controller_lib.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/controller_lib.sh
@@ -49,6 +49,8 @@ merge_pr() {
   if [ -z "$linked_issue" ]; then
     linked_issue=$(gh pr view "$pr" --json body --jq '.body' 2>/dev/null | grep -oE "Closes #[0-9]+" | head -1 | grep -oE "[0-9]+")
   fi
+  # gh pr ready 转出 draft 状态(per Auric 2026-06-01 "提pr都提草稿");忽略已是 ready 的 idempotent error
+  gh pr ready "$pr" 2>&1 | tail -1
   gh pr merge "$pr" --admin --squash --delete-branch 2>&1 | tail -1
   # Cleanup PR labels: in-flight → merged
   gh pr edit "$pr" \
@@ -91,7 +93,8 @@ open_pr_with_label() {
     return 1
   fi
   local pr_url
-  pr_url=$(gh pr create --base "$base" --head "$head" --title "$title" --body-file "$body_file" 2>&1 | tail -1)
+  # --draft per Auric 2026-06-01 "提pr都提草稿, 防止人工误合并"; controller 在 Phase 8 共识 + CI 绿后 gh pr ready 再 merge
+  pr_url=$(gh pr create --draft --base "$base" --head "$head" --title "$title" --body-file "$body_file" 2>&1 | tail -1)
   PR_NUM=$(echo "$pr_url" | grep -oE "pull/[0-9]+" | grep -oE "[0-9]+")
   if [ -z "$PR_NUM" ]; then
     echo "open_pr_with_label: failed to extract PR num from: $pr_url" >&2

--- a/.claude/skills/codex-refactor-loop/scripts/dev_sync_daemon.py
+++ b/.claude/skills/codex-refactor-loop/scripts/dev_sync_daemon.py
@@ -69,14 +69,19 @@ def count_ahead(base: str, head: str, cwd: Path = MAIN_REPO) -> int:
 
 
 def find_open_pr(base: str, head_prefix: str) -> tuple[int | None, str | None]:
+    """returns (pr_num, head). On API error returns ("API_ERROR", None) — caller
+    must skip the tick to avoid falsely creating a duplicate PR/branch when an
+    open one already exists. Fix for issue #1648 (2026-06-01)."""
     r = run(["gh", "pr", "list", "--state", "open", "--base", base,
              "--json", "number,headRefName"], cwd=MAIN_REPO)
     if r.returncode != 0:
-        return None, None
+        log(f"find_open_pr({base}): API error, skip: {r.stderr.strip()[:160]}")
+        return "API_ERROR", None
     try:
         prs = json.loads(r.stdout)
     except json.JSONDecodeError:
-        return None, None
+        log(f"find_open_pr({base}): json decode fail, skip: {r.stdout[:160]}")
+        return "API_ERROR", None
     for p in prs:
         if p.get("headRefName", "").startswith(head_prefix):
             return p["number"], p["headRefName"]
@@ -304,6 +309,10 @@ def sync_direction(source: str, target: str, wt: Path, branch_prefix: str, label
         return
 
     pr_num, sync_branch = find_open_pr(target, branch_prefix)
+
+    if pr_num == "API_ERROR":
+        log(f"{label}: skip tick — find_open_pr API error, wait for recovery")
+        return
 
     if pr_num is None:
         create_sync_pr(source, target, branch_prefix, ahead, label)

--- a/.claude/skills/codex-refactor-loop/scripts/dev_sync_daemon.py
+++ b/.claude/skills/codex-refactor-loop/scripts/dev_sync_daemon.py
@@ -152,9 +152,14 @@ def create_sync_pr(source: str, target: str, branch_prefix: str, ahead: int, lab
             f"CI 绿后 GitHub auto-merge。冲突或 CI fail 由 daemon 写 pending event,"
             f"再由 controller 派 codex 在独立 worktree 解决。"
             f"\n\n⟦AI:AUTO-LOOP⟧\n")
-    r = run(["gh", "pr", "create", "--base", target, "--head", new_branch,
-             "--title", f"chore: {source} → {target} 自动同步 ({ahead} commits)",
-             "--body", body], cwd=MAIN_REPO)
+    # forward(dev→trunk)非 draft 因 enable auto-merge;reverse(trunk→dev)用 draft 防止 maintainer 误手动 merge
+    # per Auric 2026-06-01 "提pr都提草稿, 防止人工误合并"
+    create_args = ["gh", "pr", "create", "--base", target, "--head", new_branch,
+                   "--title", f"chore: {source} → {target} 自动同步 ({ahead} commits)",
+                   "--body", body]
+    if label != "forward":
+        create_args.insert(3, "--draft")
+    r = run(create_args, cwd=MAIN_REPO)
     if r.returncode != 0:
         log(f"{label}: FAIL pr create: {r.stderr.strip()[:200]}")
         return

--- a/.claude/skills/codex-refactor-loop/scripts/wakeup-check.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/wakeup-check.sh
@@ -236,7 +236,7 @@ while IFS= read -r n; do
     # 之前 Step F 只检测 "judge log 缺失",漏判 split / converge / escalate / crashed / consensus 等
     # 已发现 7 个 design-solving issue 静默积压(部分 3 天)— per Auric "一堆issues没完成"
     if [ -f "$judge_log" ]; then
-        if ! grep -q "^META_JUDGE_DONE:" "$judge_log" 2>/dev/null; then
+        if ! grep -q "META_JUDGE_DONE:" "$judge_log" 2>/dev/null; then
             if grep -qE "^EXIT=" "$judge_log" 2>/dev/null; then
                 echo "#${n}: ${latest_round} judge has EXIT but NO META_JUDGE_DONE — ACTION: re-spawn judge (crashed)"
                 F_COUNT=$((F_COUNT+1))
@@ -247,7 +247,9 @@ while IFS= read -r n; do
         # 根因:judge codex 在 reasoning 阶段可能多次输出 META_JUDGE_DONE 假设(converge → split 等),
         # 最终决定是最后一个 marker。head -1 会取最早假设,导致 #1572 r2 实际 split 被报 converge,
         # controller 误派 r3 solvers 而不是 split admin。
-        marker=$(grep "^META_JUDGE_DONE:" "$judge_log" | tail -1)
+        # 2026-06-01 补修:去 `^` anchor(codex 偶尔以 `+META_JUDGE_DONE:` 前缀输出 diff context,
+        # 之前会全部漏读 → judge "crashed" 误报。#1528 r1 验证)。
+        marker=$(grep "META_JUDGE_DONE:" "$judge_log" | grep -oE "META_JUDGE_DONE:[^[:space:]]*" | tail -1)
         case "$marker" in
             META_JUDGE_DONE:split:*)
                 echo "#${n}: ${latest_round} judge=split — ACTION: controller close + open 2 sub-issues (first impl / later design)"

--- a/.claude/skills/codex-refactor-loop/scripts/wakeup-check.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/wakeup-check.sh
@@ -243,7 +243,11 @@ while IFS= read -r n; do
             fi
             continue
         fi
-        marker=$(grep "^META_JUDGE_DONE:" "$judge_log" | head -1)
+        # 2026-05-31 修(per Auric "有bug必须修"):取 tail -1 而非 head -1
+        # 根因:judge codex 在 reasoning 阶段可能多次输出 META_JUDGE_DONE 假设(converge → split 等),
+        # 最终决定是最后一个 marker。head -1 会取最早假设,导致 #1572 r2 实际 split 被报 converge,
+        # controller 误派 r3 solvers 而不是 split admin。
+        marker=$(grep "^META_JUDGE_DONE:" "$judge_log" | tail -1)
         case "$marker" in
             META_JUDGE_DONE:split:*)
                 echo "#${n}: ${latest_round} judge=split — ACTION: controller close + open 2 sub-issues (first impl / later design)"


### PR DESCRIPTION
## 摘要

修 `wakeup-check.sh` Step F 解析 `META_JUDGE_DONE:` marker 的方向 bug。

## 根因

Judge codex 在 reasoning 阶段可能多次输出 `META_JUDGE_DONE:` 假设(consensus → split / converge → consensus 等),最终决议是 log 中**最后**一次 marker。原代码:

```bash
marker=$(grep "^META_JUDGE_DONE:" "$judge_log" | head -1)
```

会取**最早**的假设 → controller 误判 phase。

## 实际事故(2026-06-01 本会话)

| Issue | First marker(head -1) | Final marker(tail -1) | 误派 |
|---|---|---|---|
| #1577 r4 | converge | consensus | implement 返 partial |
| #1601 r1 | consensus | split | implement 返 partial(应做 split admin) |
| #1529 r1 | consensus | converge | implement 返 partial(应派 r2 solver) |

每个误判浪费 1 个 implement codex 时长 + 后续 controller 手工恢复 1-2 wakeup。

## 修法

`grep ... | tail -1` 取最终决议,与 reasoning 阶段假设隔离。1 行修。

## 验证

- 之前 wakeup-check.sh 报 #1601 consensus → 本次 tail -1 报 split ✓
- 之前 wakeup-check.sh 报 #1529 consensus → 本次 tail -1 报 converge ✓

## Per Auric

2026-06-01 "有bug必须修"

⟦AI:AUTO-LOOP⟧

---

**追加 fix(2026-06-01)**: closes #1648 — dev_sync_daemon `find_open_pr` 区分 API 错误与无 PR(commit `e5ba25b38`)。防 rate-limit 时累积 orphan branch,清 17 个。

⟦AI:AUTO-LOOP⟧
