### PR TITLE
refactor(issue1602): Studio post-bind 路径清理(delete -505 LOC)

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx
@@ -313,6 +313,8 @@ describe('StudioMemberBindPanel', () => {
     expect(screen.queryByRole('button', { name: 'Open Runs' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Activate' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Retire' })).toBeNull();
+    expect(screen.queryByRole('button', { name: '设为入口并测试 Team' })).toBeNull();
+    expect(screen.queryByRole('button', { name: '测试 Team' })).toBeNull();
     expect(screen.queryByText('Need auth for a smoke test?')).toBeNull();
     expect(screen.getAllByText('Authorization').length).toBeGreaterThan(0);
     await waitFor(() => {

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -5363,6 +5363,27 @@ describe("StudioPage", () => {
     });
   });
 
+  it("does not expose post-bind Team entry or Team test actions from Studio bind", async () => {
+    renderStudioPage(
+      "/studio?scopeId=scope-1&teamId=t-alpha&member=member%3Aworkspace-demo&step=bind&tab=bindings"
+    );
+
+    expect(await screen.findByTestId("studio-bind-surface")).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "设为入口并测试 Team" })
+    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "测试 Team" })).toBeNull();
+    await waitFor(() =>
+      expect(screen.getByText("service:default")).toBeTruthy()
+    );
+    expect(studioApi.setTeamEntryMember).not.toHaveBeenCalled();
+    expect(window.location.pathname).toBe("/studio");
+    expect(new URLSearchParams(window.location.search).get("testTeam")).toBeNull();
+    expect(message.warning).not.toHaveBeenCalledWith(
+      expect.stringContaining("读模型还没有确认新入口成员"),
+    );
+  });
+
   it("keeps pending member binding from promoting the bind selection", async () => {
     mockScopeRuntimeApi.listServices.mockReset();
     mockScopeRuntimeApi.listServices


### PR DESCRIPTION
## 摘要

#1602 first-slice(from #1601 split)。

- **Old**:Studio post-bind 路径中存在 combined-entry test + CTA + polling 等冗余抽象
- **New**:删除整条 path,精简至最小可用 frontend

违反:CLAUDE.md「删除优先:空转发、重复抽象、无业务价值代码直接删除」

## 范围

4 files changed (+13/-505):
- `apps/aevatar-console-web/src/.../bind/StudioMemberBindPanel.tsx`
- `apps/aevatar-console-web/src/.../bind/StudioMemberBindPanel.test.tsx`
- `apps/aevatar-console-web/src/pages/studio/index.tsx`
- `apps/aevatar-console-web/src/pages/studio/index.test.tsx`

frontend 纯 deletion-heavy refactor,无 .NET 代码变更。

## Phase 9 共识

r1 meta-judge `consensus:hybrid-minimal-delete:delete-studio-post-bind-combined-entry-test-cta-and-polling`(3/3 unanimous)。

Closes #1602

⟦AI:AUTO-LOOP⟧
