### PR TITLE
refactor: impl issue #1577 — Phase 9 r4 hybrid consensus

### DIFF
--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRequestMetadataRuntimeContextAccess.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRequestMetadataRuntimeContextAccess.cs
@@ -3,18 +3,8 @@ using Aevatar.AI.Abstractions.ToolProviders;
 
 namespace Aevatar.Workflow.Core.Execution;
 
-// Refactor (iter16/cluster-031):
-//   Old pattern: request metadata was copied into the generic execution item
-//                bag as `workflow.request.metadata`, mixing control values with passthrough metadata.
-//   New principle: request metadata is filtered into same-turn passthrough metadata;
-//                  connector authorization and LLM routing use typed runtime sections.
 internal static class WorkflowRequestMetadataRuntimeContextAccess
 {
-    // Refactor (iter16/cluster-031):
-    //   Old pattern: request metadata writes stored a normalized dictionary
-    //                under `workflow.request.metadata` in the item bag.
-    //   New principle: request metadata writes keep only same-turn passthrough values;
-    //                  typed connector and LLM state are updated through explicit typed APIs.
     public static Task SetRequestMetadataAsync(
         IWorkflowExecutionStateHost stateHost,
         IReadOnlyDictionary<string, string>? metadata,

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRequestMetadataRuntimeContextAccess.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRequestMetadataRuntimeContextAccess.cs
@@ -3,16 +3,27 @@ using Aevatar.AI.Abstractions.ToolProviders;
 
 namespace Aevatar.Workflow.Core.Execution;
 
+// Refactor (iter16/cluster-031):
+//   Old pattern: request metadata was copied into the generic execution item
+//                bag as `workflow.request.metadata`, mixing control values with passthrough metadata.
+//   New principle: request metadata is filtered into same-turn passthrough metadata;
+//                  connector authorization and LLM routing use typed runtime sections.
 internal static class WorkflowRequestMetadataRuntimeContextAccess
 {
-    public static async Task SetRequestMetadataAsync(
+    // Refactor (iter16/cluster-031):
+    //   Old pattern: request metadata writes stored a normalized dictionary
+    //                under `workflow.request.metadata` in the item bag.
+    //   New principle: request metadata writes keep only same-turn passthrough values;
+    //                  typed connector and LLM state are updated through explicit typed APIs.
+    public static Task SetRequestMetadataAsync(
         IWorkflowExecutionStateHost stateHost,
         IReadOnlyDictionary<string, string>? metadata,
         CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(stateHost);
-        await WorkflowRunExecutionContextStateAccess.ApplyRequestMetadataAsync(stateHost, metadata, ct);
+        ct.ThrowIfCancellationRequested();
         stateHost.RuntimeContext.ApplyRequestMetadata(metadata);
+        return Task.CompletedTask;
     }
 
     public static Task SetToolContextAsync(

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunExecutionContextStateAccess.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunExecutionContextStateAccess.cs
@@ -32,28 +32,6 @@ internal static class WorkflowRunExecutionContextStateAccess
         return stateHost.ClearExecutionContextAsync(ct);
     }
 
-    public static Task ApplyRequestMetadataAsync(
-        IWorkflowExecutionStateHost stateHost,
-        IReadOnlyDictionary<string, string>? metadata,
-        CancellationToken ct = default)
-    {
-        ArgumentNullException.ThrowIfNull(stateHost);
-        var delta = BuildRequestMetadataDelta(metadata);
-        return stateHost.UpdateExecutionContextAsync(delta, ct);
-    }
-
-    public static WorkflowRunExecutionContextDelta BuildRequestMetadataDelta(
-        IReadOnlyDictionary<string, string>? metadata)
-    {
-        // Refactor (iter169/cluster-issue1551): Old pattern: Metadata["connector.http.authorization"] was promoted into connector state. New principle: request metadata is passthrough-only; connector auth uses BuildConnectorAuthorizationDelta.
-        var delta = new WorkflowRunExecutionContextDelta
-        {
-            ClearConnector = true,
-        };
-
-        return delta;
-    }
-
     public static WorkflowRunExecutionContextDelta BuildConnectorAuthorizationDelta(string? authorization)
     {
         var delta = new WorkflowRunExecutionContextDelta

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
@@ -99,6 +99,35 @@ public sealed class WorkflowExecutionRuntimeContextTests
     }
 
     [Fact]
+    public async Task SetRequestMetadata_ShouldThrowAndNotMutatePassthroughWhenCancellationRequested()
+    {
+        var host = new RecordingStateHost();
+        await WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadataAsync(
+            host,
+            new Dictionary<string, string>
+            {
+                ["trace-id"] = "abc",
+            });
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await FluentActions.Awaiting(() => WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadataAsync(
+                host,
+                new Dictionary<string, string>
+                {
+                    ["trace-id"] = "changed",
+                    ["request-id"] = "request-1",
+                },
+                cts.Token))
+            .Should()
+            .ThrowAsync<OperationCanceledException>();
+
+        host.RuntimeContext.RequestPassthroughMetadata.Values.Should().ContainSingle();
+        host.RuntimeContext.RequestPassthroughMetadata.Values["trace-id"].Should().Be("abc");
+        host.RuntimeContext.RequestPassthroughMetadata.Values.Should().NotContainKey("request-id");
+    }
+
+    [Fact]
     public async Task RemoveRequestMetadata_ShouldValidateAndClearTypedExecutionContext()
     {
         var host = new RecordingStateHost();

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
@@ -70,9 +70,10 @@ public sealed class WorkflowExecutionRuntimeContextTests
     }
 
     [Fact]
-    public async Task SetRequestMetadata_ShouldClearTypedConnectorAndPassthroughWhenMetadataIsNullEmptyOrInvalid()
+    public async Task SetRequestMetadata_ShouldOnlyClearPassthroughWhenMetadataIsNullEmptyOrInvalid()
     {
         var host = new RecordingStateHost();
+        await ConnectorAuthorizationRuntimeContextAccess.SetAuthorizationAsync(host, "Bearer typed");
         await WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadataAsync(
             host,
             new Dictionary<string, string>
@@ -83,7 +84,7 @@ public sealed class WorkflowExecutionRuntimeContextTests
 
         await WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadataAsync(host, null);
 
-        host.ExecutionContextState.Connector.Should().BeNull();
+        host.ExecutionContextState.Connector!.HttpAuthorization.Should().Be("Bearer typed");
         host.RuntimeContext.RequestPassthroughMetadata.Values.Should().BeEmpty();
 
         await WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadataAsync(
@@ -93,7 +94,7 @@ public sealed class WorkflowExecutionRuntimeContextTests
                 [" "] = " ",
             });
 
-        host.ExecutionContextState.Connector.Should().BeNull();
+        host.ExecutionContextState.Connector!.HttpAuthorization.Should().Be("Bearer typed");
         host.RuntimeContext.RequestPassthroughMetadata.Values.Should().BeEmpty();
     }
 


### PR DESCRIPTION
## 摘要

closes #1577

Phase 9 r4 共识达成(3/3 unanimous + meta-judge consensus:`hybrid-minimal-structural-delete:delete-empty-metadata-to-state-helper-exclude-public-const-and-workflow-parameter-bag`)后 implement。

| 项 | 值 |
|---|---|
| 变更文件 | 3 |
| LOC | +11 / -31 |
| 范围 | WorkflowRequestMetadataRuntimeContextAccess / WorkflowRunExecutionContextStateAccess + tests |

🤖 Auto-loop / codex-refactor-loop Phase 9 → 8 impl

⟦AI:AUTO-LOOP⟧