### PR TITLE
refactor: impl issue #1545 — Phase 9 r2 reflector retry-fix consensus

### DIFF
--- a/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
@@ -383,8 +383,7 @@ public static class ServiceCollectionExtensions
         };
 
     private static bool IsOpenAIVoiceConfigured(VoiceProviderConfig config) =>
-        !string.IsNullOrWhiteSpace(config.ApiKey) ||
-        !string.IsNullOrWhiteSpace(config.Endpoint);
+        !string.IsNullOrWhiteSpace(config.ApiKey);
 
     private static bool IsMiniCpmVoiceConfigured(VoiceProviderConfig config) =>
         !string.IsNullOrWhiteSpace(config.Endpoint);

--- a/src/Aevatar.Mainnet.Host.Api/Voice/VoiceDemoBootstrapEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Voice/VoiceDemoBootstrapEndpoints.cs
@@ -78,7 +78,6 @@ internal static class VoiceDemoBootstrapEndpoints
             agent_correlation_id = voiceDemoReceipt.CorrelationId,
             route_policy_command_id = routePolicyReceipt?.CommandId,
             route_policy_correlation_id = routePolicyReceipt?.CorrelationId,
-            nyxid_proxy = "https://nyx.chrono-ai.fun/api/v1/proxy/s/llm-openai",
             readiness = "query readmodels or subscribe to events; this POST only confirms dispatch acceptance",
         });
     }

--- a/src/Aevatar.Mainnet.Host.Api/appsettings.json
+++ b/src/Aevatar.Mainnet.Host.Api/appsettings.json
@@ -30,7 +30,6 @@
     },
     "VoicePresence": {
       "OpenAI": {
-        "Endpoint": "https://nyx.chrono-ai.fun/api/v1/proxy/s/llm-openai",
         "Model": "gpt-realtime",
         "Voice": "alloy",
         "Instructions": "你是一个简短自然的语音助手。"

--- a/src/Aevatar.Mainnet.Host.Api/wwwroot/demo/voice/app.js
+++ b/src/Aevatar.Mainnet.Host.Api/wwwroot/demo/voice/app.js
@@ -1,7 +1,5 @@
 const TARGET_SAMPLE_RATE = 24000;
 const FRAME_SAMPLES = 480;
-const NYXID_BASE_URL = "https://nyx.chrono-ai.fun";
-const NYXID_VOICE_PROXY_ENDPOINT = `${NYXID_BASE_URL}/api/v1/proxy/s/llm-openai`;
 const TOKEN_STORAGE_KEYS = [
   "aevatar.nyxid.access_token",
   "nyxid.access_token",
@@ -11,7 +9,6 @@ const TOKEN_STORAGE_KEYS = [
 const nyxidAccessToken = resolveNyxIdAccessToken();
 
 const els = {
-  nyxidEndpoint: document.getElementById("nyxidEndpoint"),
   endpointMode: document.getElementById("endpointMode"),
   actorField: document.getElementById("actorField"),
   actorId: document.getElementById("actorId"),
@@ -293,7 +290,6 @@ function createBlockResampler(fromRate, toRate) {
 function openSocket() {
   const url = buildWsUrl({ includeAccessToken: true });
   log(`连接 ${redactAccessToken(url)}`);
-  log(`上游 Realtime 固定走 NyxID proxy: ${NYXID_VOICE_PROXY_ENDPOINT}`);
   const ws = new WebSocket(url);
   ws.binaryType = "arraybuffer";
   state.ws = ws;
@@ -455,7 +451,4 @@ els.connectBtn.addEventListener("click", connect);
 els.disconnectBtn.addEventListener("click", disconnect);
 els.muteBtn.addEventListener("click", toggleMute);
 
-if (els.nyxidEndpoint) {
-  els.nyxidEndpoint.value = NYXID_VOICE_PROXY_ENDPOINT;
-}
 refreshUrl();

--- a/src/Aevatar.Mainnet.Host.Api/wwwroot/demo/voice/index.html
+++ b/src/Aevatar.Mainnet.Host.Api/wwwroot/demo/voice/index.html
@@ -14,7 +14,7 @@
         <h1>Voice to Agent Demo</h1>
         <p class="lede">
           浏览器采集麦克风音频，按 PCM16 24kHz 发送到当前主网 Host 的 voice endpoint。
-          上游 Realtime 固定通过 NyxID 主网 proxy 访问，浏览器不会接触 OpenAI key。
+          页面只连接当前 Host 的 bootstrap 与 `/ws/voice`，不会接触 provider credential。
         </p>
       </div>
       <div class="status-strip" aria-live="polite">
@@ -60,11 +60,6 @@
         </label>
 
         <label class="field">
-          <span>NyxID upstream</span>
-          <input id="nyxidEndpoint" readonly>
-        </label>
-
-        <label class="field">
           <span>WS URL</span>
           <input id="wsUrl" readonly>
         </label>
@@ -102,15 +97,13 @@
 
     <section class="setup-grid">
       <article class="panel">
-        <h2>1. NyxID 已写死</h2>
-        <p>这个 demo 固定走 NyxID 主网，不需要在页面或本地再填 OpenAI API key。Host 内置的 Realtime proxy endpoint 是：</p>
-        <pre><code>https://nyx.chrono-ai.fun/api/v1/proxy/s/llm-openai</code></pre>
-        <p>NyxID 负责注入真正的 OpenAI credential；demo 调试直连当前 Mainnet Host 的 `/ws/voice/{actorId}`。</p>
+        <h2>1. Host 负责 provider 配置</h2>
+        <p>这个 demo 只连接当前 Mainnet Host。Voice provider 是否可用由 Host 配置和 voice readmodel 决定，页面不会声明固定上游 endpoint。</p>
       </article>
 
       <article class="panel">
         <h2>2. Agent 要有 voice module</h2>
-        <p>点击“开始说话”时，demo 会自动创建或复用当前用户的 voice demo agent，并挂上 `voice_presence_openai` 模块。Mainnet Host 的上游 URL 已固定为 NyxID proxy；请求里的 NyxID bearer 只用于向 NyxID proxy 鉴权，不会作为 OpenAI key 暴露给浏览器。</p>
+        <p>点击“开始说话”时，demo 会自动创建或复用当前用户的 voice demo agent，并挂上 `voice_presence_openai` 模块。请求里的 NyxID bearer 只用于当前 Host 的身份认证，不会作为 provider credential 暴露给浏览器。</p>
         <p>普通 `/ws/voice` 只从 typed `voice_attach_target` 读取目标 agent；`/ws/voice/{actorId}` 是调试直连入口，需要登录用户具备 `voice:bypass` scope 或 admin/owner 角色。</p>
       </article>
 

--- a/test/Aevatar.Bootstrap.Tests/AIFeatureBootstrapCoverageTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/AIFeatureBootstrapCoverageTests.cs
@@ -189,6 +189,58 @@ public class AIFeatureBootstrapCoverageTests
     }
 
     [Fact]
+    public void AddAevatarAIFeatures_WhenVoicePresenceOpenAIEndpointOnlyConfigured_ShouldNotRegisterOpenAI()
+    {
+        using var envScope = new EnvironmentVariablesScope(new Dictionary<string, string?>
+        {
+            ["OPENAI_API_KEY"] = null,
+        });
+
+        var services = new ServiceCollection();
+        var config = new ConfigurationBuilder().Build();
+        services.AddLogging();
+        services.AddSingleton<IActorDispatchPort, NoOpActorDispatchPort>();
+        services.AddSingleton<IProjectionDocumentReader<VoicePresenceCapabilityReadModel, string>>(
+            new EmptyVoicePresenceCapabilityReader());
+
+        services.AddAevatarAIFeatures(config, options =>
+        {
+            options.EnableMEAIProviders = false;
+            options.VoicePresence.DefaultProvider = "minicpm";
+            options.VoicePresence.OpenAIProvider = new VoiceProviderConfig
+            {
+                ProviderName = "openai",
+                Endpoint = "https://nyx.example.com/api/v1/proxy/s/llm-openai",
+            };
+            options.VoicePresence.OpenAISession = new VoiceSessionConfig
+            {
+                Voice = "alloy",
+                SampleRateHz = 24000,
+            };
+            options.VoicePresence.MiniCPMProvider = new VoiceProviderConfig
+            {
+                ProviderName = "minicpm",
+                Endpoint = "https://minicpm.example.com",
+            };
+            options.VoicePresence.MiniCPMSession = new VoiceSessionConfig
+            {
+                SampleRateHz = 16000,
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var factory = provider.GetServices<IEventModuleFactory<IEventHandlerContext>>()
+            .OfType<VoicePresenceModuleFactory>()
+            .Single();
+
+        factory.TryCreate("voice_presence", out var defaultModule).Should().BeTrue();
+        defaultModule.Should().BeOfType<VoicePresenceModule>();
+
+        factory.TryCreate("voice_presence_openai", out var openAIModule).Should().BeFalse();
+        openAIModule.Should().BeNull();
+    }
+
+    [Fact]
     public void AddAevatarAIFeatures_WhenVoicePresenceMiniCpmConfiguredAsDefault_ShouldCreateDefaultAlias()
     {
         using var envScope = new EnvironmentVariablesScope(new Dictionary<string, string?>

--- a/test/Aevatar.Hosting.Tests/VoiceDemoBootstrapEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/VoiceDemoBootstrapEndpointsTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Security.Claims;
+using System.Text.Json;
 using Aevatar.Authentication.Abstractions;
 using Aevatar.ChatRouting.Abstractions;
 using Aevatar.ChatRouting.Core;
@@ -61,15 +62,18 @@ public sealed class VoiceDemoBootstrapEndpointsTests
         var client = app.GetTestClient();
 
         var response = await client.PostAsync("/api/demo/voice/bootstrap", content: null);
-        var body = await response.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        var responseText = await response.Content.ReadAsStringAsync();
+        var body = JsonSerializer.Deserialize<Dictionary<string, object>>(responseText);
 
-        response.StatusCode.Should().Be(HttpStatusCode.Accepted, await response.Content.ReadAsStringAsync());
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted, responseText);
         body.Should().ContainKey("status").WhoseValue.ToString().Should().Be("accepted");
         body.Should().ContainKey("actor_id");
         body.Should().ContainKey("route_policy_actor_id");
         body.Should().ContainKey("agent_command_id");
         body.Should().ContainKey("route_policy_command_id");
         body.Should().ContainKey("readiness");
+        body.Should().NotContainKey("nyxid_proxy");
+        responseText.Should().NotContain("https://nyx.chrono-ai.fun/api/v1/proxy/s/llm-openai");
         var demoActorId = body!["actor_id"].ToString()!;
         demoActorId.Should().Be(RecordingVoiceDemoAgentCommandPort.DemoActorId);
         body["route_policy_actor_id"].ToString().Should().Be($"chat-route-policy:{Scope}");


### PR DESCRIPTION
## 摘要

closes #1545

Phase 9 r2 reflector `META_RESOLVED:retry-fix` 后,implement codex 按 r2 consensus `delete` framing 实施(no-new-abstraction cleanup,不新增 actor/proto/readmodel/readiness service)。

| 项 | 值 |
|---|---|
| 变更文件 | 7 |
| LOC | +63 / -24 |

🤖 Auto-loop / codex-refactor-loop Phase 9 → 8 impl

⟦AI:AUTO-LOOP⟧