### PR TITLE
refactor(#1503): NyxId remote tool approval port 收敛(Phase 9 r5)

### DIFF
--- a/src/Aevatar.AI.Abstractions/ToolProviders/IRemoteToolApprovalPort.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/IRemoteToolApprovalPort.cs
@@ -17,8 +17,7 @@ public sealed record RemoteToolApprovalRequest(
     string ToolCallId,
     string ArgumentsJson,
     ToolApprovalMode ApprovalMode,
-    bool IsDestructive,
-    IReadOnlyDictionary<string, string> Items);
+    bool IsDestructive);
 
 public sealed record RemoteToolApprovalSubmission(
     string RemoteApprovalId,
@@ -26,8 +25,7 @@ public sealed record RemoteToolApprovalSubmission(
 
 public sealed record RemoteToolApprovalStatusQuery(
     string RequestId,
-    string RemoteApprovalId,
-    IReadOnlyDictionary<string, string> Items);
+    string RemoteApprovalId);
 
 public sealed record RemoteToolApprovalStatusSnapshot(
     RemoteToolApprovalStatus Status,

--- a/src/Aevatar.AI.Core/RoleGAgent.cs
+++ b/src/Aevatar.AI.Core/RoleGAgent.cs
@@ -240,11 +240,7 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
                     pending.ToolCallId,
                     pending.ArgumentsJson,
                     ToolApprovalMode.Auto,
-                    pending.IsDestructive,
-                    // Refactor (issue1253-first):
-                    //   Old pattern: Remote approval received scrubbed durable metadata that could include legacy control keys.
-                    //   New principle: Remote approval only receives open annotations.
-                    new Dictionary<string, string>(ScrubPendingApprovalMetadata(pending.Metadata), StringComparer.Ordinal)),
+                    pending.IsDestructive),
                 CancellationToken.None);
 
             var callbackId = BuildRemoteApprovalStatusCallbackId(pending.RequestId, submission.RemoteApprovalId, 1);
@@ -306,11 +302,7 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
             snapshot = await RemoteToolApprovalPort.GetStatusAsync(
                 new RemoteToolApprovalStatusQuery(
                     pending.RequestId,
-                    pending.RemoteApprovalId,
-                    // Refactor (issue1253-first):
-                    //   Old pattern: Status checks forwarded pending.Metadata as a control surface.
-                    //   New principle: Status checks forward annotations only.
-                    new Dictionary<string, string>(ScrubPendingApprovalMetadata(pending.Metadata), StringComparer.Ordinal)),
+                    pending.RemoteApprovalId),
                 CancellationToken.None);
         }
         catch (Exception ex)

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdRemoteToolApprovalPort.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdRemoteToolApprovalPort.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using System.Text.Json;
-using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -28,7 +27,7 @@ public sealed class NyxIdRemoteToolApprovalPort : IRemoteToolApprovalPort
         RemoteToolApprovalRequest request,
         CancellationToken ct)
     {
-        var token = ResolveToken(request.Items);
+        var token = AgentToolRequestContext.NyxIdAccessToken;
         if (string.IsNullOrWhiteSpace(token))
             throw new InvalidOperationException("NyxID authentication required for remote approval.");
 
@@ -58,7 +57,7 @@ public sealed class NyxIdRemoteToolApprovalPort : IRemoteToolApprovalPort
         RemoteToolApprovalStatusQuery query,
         CancellationToken ct)
     {
-        var token = ResolveToken(query.Items);
+        var token = AgentToolRequestContext.NyxIdAccessToken;
         if (string.IsNullOrWhiteSpace(token))
             throw new InvalidOperationException("NyxID authentication required for remote approval.");
 
@@ -67,13 +66,6 @@ public sealed class NyxIdRemoteToolApprovalPort : IRemoteToolApprovalPort
             MapStatus(ExtractString(response, "status")),
             ExtractString(response, "reason"),
             ExtractDateTimeOffset(response, "expires_at"));
-    }
-
-    private static string? ResolveToken(IReadOnlyDictionary<string, string> items)
-    {
-        return items.TryGetValue(LLMRequestMetadataKeys.NyxIdAccessToken, out var token)
-            ? token
-            : AgentToolRequestContext.NyxIdAccessToken;
     }
 
     private static RemoteToolApprovalStatus MapStatus(string? status)

--- a/test/Aevatar.AI.Tests/NyxIdRemoteToolApprovalPortTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdRemoteToolApprovalPortTests.cs
@@ -1,7 +1,6 @@
 using System.Net;
 using System.Text;
 using System.Text.Json;
-using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.ToolProviders.NyxId;
 using FluentAssertions;
@@ -23,6 +22,7 @@ public sealed class NyxIdRemoteToolApprovalPortTests
         });
         var port = CreatePort(handler);
 
+        using var _ = AgentToolContextScope.Push(WithNyxIdAccessToken("token-1"));
         var result = await port.SubmitAsync(
             new RemoteToolApprovalRequest(
                 "req-1",
@@ -30,11 +30,7 @@ public sealed class NyxIdRemoteToolApprovalPortTests
                 "call-1",
                 """{"command":"uptime"}""",
                 ToolApprovalMode.Auto,
-                true,
-                new Dictionary<string, string>
-                {
-                    [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-1",
-                }),
+                true),
             CancellationToken.None);
 
         result.RemoteApprovalId.Should().Be("approval-1");
@@ -70,14 +66,11 @@ public sealed class NyxIdRemoteToolApprovalPortTests
         });
         var port = CreatePort(handler);
 
+        using var _ = AgentToolContextScope.Push(WithNyxIdAccessToken("token-1"));
         var result = await port.GetStatusAsync(
             new RemoteToolApprovalStatusQuery(
                 "req-1",
-                "approval-1",
-                new Dictionary<string, string>
-                {
-                    [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-1",
-                }),
+                "approval-1"),
             CancellationToken.None);
 
         result.Status.Should().Be(expected);
@@ -87,7 +80,58 @@ public sealed class NyxIdRemoteToolApprovalPortTests
         handler.Requests[0].Method.Should().Be(HttpMethod.Get);
         handler.Requests[0].RequestUri!.AbsolutePath.Should()
             .Be("/api/v1/approvals/requests/approval-1/status");
+        handler.Requests[0].Headers.Authorization!.ToString().Should().Be("Bearer token-1");
     }
+
+    [Fact]
+    public async Task SubmitAsync_ShouldRequireTypedCredential()
+    {
+        var handler = new CaptureHandler(new HttpResponseMessage(HttpStatusCode.Created)
+        {
+            Content = new StringContent("""{"id":"approval-1"}""", Encoding.UTF8, "application/json"),
+        });
+        var port = CreatePort(handler);
+
+        using var _ = AgentToolContextScope.Push(null);
+        var act = () => port.SubmitAsync(
+            new RemoteToolApprovalRequest(
+                "req-1",
+                "ssh_exec",
+                "call-1",
+                "{}",
+                ToolApprovalMode.Auto,
+                false),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("NyxID authentication required for remote approval.");
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_ShouldRequireTypedCredential()
+    {
+        var handler = new CaptureHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"status":"pending"}""", Encoding.UTF8, "application/json"),
+        });
+        var port = CreatePort(handler);
+
+        using var _ = AgentToolContextScope.Push(null);
+        var act = () => port.GetStatusAsync(
+            new RemoteToolApprovalStatusQuery("req-1", "approval-1"),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("NyxID authentication required for remote approval.");
+        handler.Requests.Should().BeEmpty();
+    }
+
+    private static AgentToolExecutionContext WithNyxIdAccessToken(string token) =>
+        AgentToolExecutionContext.Empty with
+        {
+            Credentials = AgentToolCredentials.Empty with { NyxIdAccessToken = token },
+        };
 
     private static NyxIdRemoteToolApprovalPort CreatePort(CaptureHandler handler)
     {

--- a/test/Aevatar.AI.Tests/RoleGAgentStateCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/RoleGAgentStateCoverageTests.cs
@@ -642,9 +642,6 @@ public sealed class RoleGAgentStateCoverageTests
             ToolCallId = "call-1",
             ArgumentsJson = "{}",
         };
-        agent.State.PendingApproval.Metadata["nyxid.access_token"] = "token-1";
-        agent.State.PendingApproval.Metadata["trace-id"] = "trace-1";
-
         await agent.HandleToolApprovalTimeout(new ToolApprovalTimeoutFiredEvent
         {
             RequestId = "req-1",
@@ -657,8 +654,7 @@ public sealed class RoleGAgentStateCoverageTests
         agent.State.PendingApproval.RemoteApprovalExpiresAtUnixMs.Should()
             .Be(DateTimeOffset.FromUnixTimeSeconds(1_800).ToUnixTimeMilliseconds());
         remotePort.Submitted.Should().ContainSingle()
-            .Which.Items.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
-        remotePort.Submitted.Single().Items["trace-id"].Should().Be("trace-1");
+            .Which.RequestId.Should().Be("req-1");
         remotePort.StatusQueries.Should().BeEmpty();
         ((RecordingRuntimeCallbackScheduler)provider.GetRequiredService<IActorRuntimeCallbackScheduler>())
             .TimeoutRequests.Should().ContainSingle(x =>
@@ -812,7 +808,7 @@ public sealed class RoleGAgentStateCoverageTests
     }
 
     [Fact]
-    public async Task HandleRemoteApprovalStatusCheck_ShouldScrubOwnedKeysAndPreserveTraceMetadata()
+    public async Task HandleRemoteApprovalStatusCheck_ShouldIssueStatusQueryWithoutPortLevelCarrier()
     {
         using var provider = BuildServiceProvider();
         var remotePort = new StubRemoteApprovalPort(
@@ -833,27 +829,6 @@ public sealed class RoleGAgentStateCoverageTests
             RemoteStatusCheckAttempt = 1,
             RemoteApprovalExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeMilliseconds(),
         };
-        var ownedKeys = new[]
-        {
-            LLMRequestMetadataKeys.RequestId,
-            LLMRequestMetadataKeys.CallId,
-            LLMRequestMetadataKeys.ScopeId,
-            LLMRequestMetadataKeys.OwnerSubject,
-            LLMRequestMetadataKeys.ResponseId,
-            LLMRequestMetadataKeys.NyxIdAccessToken,
-            LLMRequestMetadataKeys.NyxIdOrgToken,
-            LLMRequestMetadataKeys.SenderNyxIdAccessToken,
-            LLMRequestMetadataKeys.SenderBindingId,
-            LLMRequestMetadataKeys.NyxIdRoutePreference,
-            LLMRequestMetadataKeys.ModelOverride,
-            LLMRequestMetadataKeys.MaxToolRoundsOverride,
-            LLMRequestMetadataKeys.UserMemoryPrompt,
-            LLMRequestMetadataKeys.ConnectedServicesContext,
-        };
-
-        foreach (var key in ownedKeys)
-            agent.State.PendingApproval.Metadata[key] = $"owned-{key}";
-        agent.State.PendingApproval.Metadata["trace-id"] = "trace-1";
 
         await agent.HandleRemoteApprovalStatusCheck(new ToolApprovalRemoteStatusCheckFiredEvent
         {
@@ -863,9 +838,9 @@ public sealed class RoleGAgentStateCoverageTests
             Attempt = 1,
         });
 
-        var items = remotePort.StatusQueries.Should().ContainSingle().Which.Items;
-        items.Should().NotContainKeys(ownedKeys);
-        items.Should().ContainKey("trace-id").WhoseValue.Should().Be("trace-1");
+        var query = remotePort.StatusQueries.Should().ContainSingle().Which;
+        query.RequestId.Should().Be("req-1");
+        query.RemoteApprovalId.Should().Be("remote-1");
     }
 
     [Fact]


### PR DESCRIPTION
## 摘要

实施 #1503 Phase 9 r5 三 solver + meta-judge 3/3 consensus delete framing。

closes #1503

## 范围

5 files / +66 -65。NyxId remote tool approval port 删除冗余 + 收敛 contract。本地 `dotnet build aevatar.slnx` 绿,`dotnet test` 7003 pass。

⟦AI:AUTO-LOOP⟧