### PR TITLE
refactor(#1525): chat/settings/studio 路径收敛(Phase 9 r3 hybrid)

### DIFF
--- a/apps/aevatar-console-web/src/pages/chat/chatConversationConfig.test.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatConversationConfig.test.ts
@@ -6,9 +6,9 @@ import {
 
 const llmSettings = {
   savedRoute: USER_LLM_ROUTE_GATEWAY,
-  savedRouteLabel: "NyxID Gateway",
+  savedRouteLabel: "Company LLM Gateway",
   effectiveRoute: USER_LLM_ROUTE_GATEWAY,
-  effectiveRouteLabel: "NyxID Gateway",
+  effectiveRouteLabel: "Company LLM Gateway",
   routeFallbackActive: false,
   fallbackReason: null,
   catalogStatus: "ready",
@@ -22,7 +22,7 @@ const llmSettings = {
   routeOptions: [
     {
       routeValue: USER_LLM_ROUTE_GATEWAY,
-      label: "NyxID Gateway",
+      label: "Company LLM Gateway",
       source: "gateway_provider",
       status: "ready",
       allowed: true,
@@ -68,9 +68,23 @@ const llmSettings = {
 describe("buildConversationRouteOptions", () => {
   it("uses backend route options without deriving routes from provider slugs", () => {
     expect(buildConversationRouteOptions(llmSettings).map((option) => option.label)).toEqual([
-      "NyxID Gateway",
+      "Company LLM Gateway",
       "Anthropic Team Service",
     ]);
+  });
+
+  it("uses a generic gateway label when backend sends a blank gateway label", () => {
+    expect(
+      buildConversationRouteOptions({
+        ...llmSettings,
+        routeOptions: [
+          {
+            ...llmSettings.routeOptions[0],
+            label: " ",
+          },
+        ],
+      }).map((option) => option.label)
+    ).toEqual(["Gateway"]);
   });
 });
 

--- a/apps/aevatar-console-web/src/pages/chat/chatConversationConfig.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatConversationConfig.ts
@@ -9,9 +9,11 @@ export const LLM_ROUTE_HEADER_KEY = "nyxid.route_preference";
 export const LLM_MODEL_HEADER_KEY = "aevatar.model_override";
 export const CONVERSATION_ROUTE_DEFAULT_VALUE = "__config_default__";
 export const CONVERSATION_ROUTE_GATEWAY_VALUE = "__gateway__";
-// Refactor (iter164/cluster-003-draft-run): Old: conversation route labels
-// hard-coded gateway branding when user settings did not provide a label.
-// New: backend route labels win, with only a neutral generic fallback.
+/**
+ * Refactor (issue1525): Old pattern: conversation route labels hard-coded
+ * gateway branding when user settings did not provide a label.
+ * New principle: backend route labels win, with only a neutral generic fallback.
+ */
 const USER_LLM_ROUTE_GATEWAY_LABEL = "Gateway";
 
 export type ConversationRouteOption = {
@@ -89,6 +91,12 @@ export function decodeConversationRouteSelectValue(
     : normalizeUserLlmRoute(value);
 }
 
+/**
+ * Refactor (issue1525): Old pattern: callers depended on route names or
+ * service-specific literals when a typed backend label was unavailable.
+ * New principle: resolve labels from backend route options first, then fall
+ * back to the route value or neutral gateway wording.
+ */
 export function describeConversationRoute(
   route: string | undefined,
   routeOptions: readonly ConversationRouteOption[]
@@ -102,6 +110,12 @@ export function describeConversationRoute(
     USER_LLM_ROUTE_GATEWAY_LABEL;
 }
 
+/**
+ * Refactor (issue1525): Old pattern: UI code derived gateway wording from
+ * route/provider details when building route choices.
+ * New principle: preserve backend option labels and synthesize only neutral
+ * labels for routes that are present locally but absent from backend options.
+ */
 export function buildConversationRouteOptions(
   settings: StudioUserLlmSettings | undefined,
   globalPreferredRoute?: string,

--- a/apps/aevatar-console-web/src/pages/chat/chatConversationConfig.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatConversationConfig.ts
@@ -9,6 +9,9 @@ export const LLM_ROUTE_HEADER_KEY = "nyxid.route_preference";
 export const LLM_MODEL_HEADER_KEY = "aevatar.model_override";
 export const CONVERSATION_ROUTE_DEFAULT_VALUE = "__config_default__";
 export const CONVERSATION_ROUTE_GATEWAY_VALUE = "__gateway__";
+// Refactor (iter164/cluster-003-draft-run): Old: conversation route labels
+// hard-coded gateway branding when user settings did not provide a label.
+// New: backend route labels win, with only a neutral generic fallback.
 const USER_LLM_ROUTE_GATEWAY_LABEL = "Gateway";
 
 export type ConversationRouteOption = {

--- a/apps/aevatar-console-web/src/pages/chat/chatConversationConfig.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatConversationConfig.ts
@@ -9,6 +9,7 @@ export const LLM_ROUTE_HEADER_KEY = "nyxid.route_preference";
 export const LLM_MODEL_HEADER_KEY = "aevatar.model_override";
 export const CONVERSATION_ROUTE_DEFAULT_VALUE = "__config_default__";
 export const CONVERSATION_ROUTE_GATEWAY_VALUE = "__gateway__";
+const USER_LLM_ROUTE_GATEWAY_LABEL = "Gateway";
 
 export type ConversationRouteOption = {
   label: string;
@@ -93,7 +94,9 @@ export function describeConversationRoute(
     return "Config default";
   }
 
-  return routeOptions.find((option) => option.value === route)?.label || route;
+  return routeOptions.find((option) => option.value === route)?.label ||
+    route ||
+    USER_LLM_ROUTE_GATEWAY_LABEL;
 }
 
 export function buildConversationRouteOptions(
@@ -111,7 +114,7 @@ export function buildConversationRouteOptions(
 
     seen.add(route);
     options.push({
-      label: option.label.trim() || route || "NyxID Gateway",
+      label: option.label.trim() || route || USER_LLM_ROUTE_GATEWAY_LABEL,
       value: route,
     });
   }
@@ -121,7 +124,10 @@ export function buildConversationRouteOptions(
       const normalizedRoute = normalizeUserLlmRoute(route);
       if (!seen.has(normalizedRoute)) {
         seen.add(normalizedRoute);
-        options.push({ label: normalizedRoute || "NyxID Gateway", value: normalizedRoute });
+        options.push({
+          label: normalizedRoute || USER_LLM_ROUTE_GATEWAY_LABEL,
+          value: normalizedRoute,
+        });
       }
     }
   }

--- a/apps/aevatar-console-web/src/pages/chat/chatConversationConfig.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatConversationConfig.ts
@@ -9,11 +9,7 @@ export const LLM_ROUTE_HEADER_KEY = "nyxid.route_preference";
 export const LLM_MODEL_HEADER_KEY = "aevatar.model_override";
 export const CONVERSATION_ROUTE_DEFAULT_VALUE = "__config_default__";
 export const CONVERSATION_ROUTE_GATEWAY_VALUE = "__gateway__";
-/**
- * Refactor (issue1525): Old pattern: conversation route labels hard-coded
- * gateway branding when user settings did not provide a label.
- * New principle: backend route labels win, with only a neutral generic fallback.
- */
+// Refactor (issue1525): Old pattern: conversation route labels hard-coded gateway branding when user settings did not provide a label。New principle: backend route labels win, with only a neutral generic fallback。
 const USER_LLM_ROUTE_GATEWAY_LABEL = "Gateway";
 
 export type ConversationRouteOption = {
@@ -91,12 +87,7 @@ export function decodeConversationRouteSelectValue(
     : normalizeUserLlmRoute(value);
 }
 
-/**
- * Refactor (issue1525): Old pattern: callers depended on route names or
- * service-specific literals when a typed backend label was unavailable.
- * New principle: resolve labels from backend route options first, then fall
- * back to the route value or neutral gateway wording.
- */
+// Refactor (issue1525): Old pattern: callers depended on route names or service-specific literals when a typed backend label was unavailable。New principle: resolve labels from backend route options first, then fall back to the route value or neutral gateway wording。
 export function describeConversationRoute(
   route: string | undefined,
   routeOptions: readonly ConversationRouteOption[]
@@ -110,12 +101,7 @@ export function describeConversationRoute(
     USER_LLM_ROUTE_GATEWAY_LABEL;
 }
 
-/**
- * Refactor (issue1525): Old pattern: UI code derived gateway wording from
- * route/provider details when building route choices.
- * New principle: preserve backend option labels and synthesize only neutral
- * labels for routes that are present locally but absent from backend options.
- */
+// Refactor (issue1525): Old pattern: UI code derived gateway wording from route/provider details when building route choices。New principle: preserve backend option labels and synthesize only neutral labels for routes that are present locally but absent from backend options。
 export function buildConversationRouteOptions(
   settings: StudioUserLlmSettings | undefined,
   globalPreferredRoute?: string,

--- a/apps/aevatar-console-web/src/pages/chat/chatConversationConfig.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatConversationConfig.ts
@@ -9,7 +9,6 @@ export const LLM_ROUTE_HEADER_KEY = "nyxid.route_preference";
 export const LLM_MODEL_HEADER_KEY = "aevatar.model_override";
 export const CONVERSATION_ROUTE_DEFAULT_VALUE = "__config_default__";
 export const CONVERSATION_ROUTE_GATEWAY_VALUE = "__gateway__";
-// Refactor (issue1525): Old pattern: conversation route labels hard-coded gateway branding when user settings did not provide a label。New principle: backend route labels win, with only a neutral generic fallback。
 const USER_LLM_ROUTE_GATEWAY_LABEL = "Gateway";
 
 export type ConversationRouteOption = {
@@ -87,7 +86,6 @@ export function decodeConversationRouteSelectValue(
     : normalizeUserLlmRoute(value);
 }
 
-// Refactor (issue1525): Old pattern: callers depended on route names or service-specific literals when a typed backend label was unavailable。New principle: resolve labels from backend route options first, then fall back to the route value or neutral gateway wording。
 export function describeConversationRoute(
   route: string | undefined,
   routeOptions: readonly ConversationRouteOption[]
@@ -101,7 +99,6 @@ export function describeConversationRoute(
     USER_LLM_ROUTE_GATEWAY_LABEL;
 }
 
-// Refactor (issue1525): Old pattern: UI code derived gateway wording from route/provider details when building route choices。New principle: preserve backend option labels and synthesize only neutral labels for routes that are present locally but absent from backend options。
 export function buildConversationRouteOptions(
   settings: StudioUserLlmSettings | undefined,
   globalPreferredRoute?: string,

--- a/apps/aevatar-console-web/src/pages/chat/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.test.tsx
@@ -91,9 +91,9 @@ jest.mock("@/shared/studio/api", () => ({
       })),
       getUserLlmSettings: jest.fn(async () => ({
         savedRoute: "",
-        savedRouteLabel: "NyxID Gateway",
+        savedRouteLabel: "Company LLM Gateway",
         effectiveRoute: "",
-        effectiveRouteLabel: "NyxID Gateway",
+        effectiveRouteLabel: "Company LLM Gateway",
         routeFallbackActive: false,
         fallbackReason: null,
         catalogStatus: "ready",
@@ -107,7 +107,7 @@ jest.mock("@/shared/studio/api", () => ({
         routeOptions: [
           {
             routeValue: "",
-            label: "NyxID Gateway",
+            label: "Company LLM Gateway",
             source: "gateway_provider",
             status: "ready",
             allowed: true,
@@ -887,7 +887,7 @@ describe("ChatPage", () => {
     expect(
       await screen.findByRole("button", { name: "Conversation model settings" })
     ).toHaveTextContent("Provider default");
-    expect(screen.getAllByText("NyxID Gateway").length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Company LLM Gateway")).length).toBeGreaterThan(0);
 
     fireEvent.click(
       await screen.findByRole("button", { name: "Conversation model settings" })

--- a/apps/aevatar-console-web/src/pages/chat/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.test.tsx
@@ -91,9 +91,9 @@ jest.mock("@/shared/studio/api", () => ({
       })),
       getUserLlmSettings: jest.fn(async () => ({
         savedRoute: "",
-        savedRouteLabel: "Company LLM Gateway",
+        savedRouteLabel: "Backend saved gateway",
         effectiveRoute: "",
-        effectiveRouteLabel: "Company LLM Gateway",
+        effectiveRouteLabel: "Backend effective gateway",
         routeFallbackActive: false,
         fallbackReason: null,
         catalogStatus: "ready",
@@ -107,7 +107,7 @@ jest.mock("@/shared/studio/api", () => ({
         routeOptions: [
           {
             routeValue: "",
-            label: "Company LLM Gateway",
+            label: "Gateway route option",
             source: "gateway_provider",
             status: "ready",
             allowed: true,
@@ -887,7 +887,7 @@ describe("ChatPage", () => {
     expect(
       await screen.findByRole("button", { name: "Conversation model settings" })
     ).toHaveTextContent("Provider default");
-    expect((await screen.findAllByText("Company LLM Gateway")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Backend effective gateway")).length).toBeGreaterThan(0);
 
     fireEvent.click(
       await screen.findByRole("button", { name: "Conversation model settings" })
@@ -895,6 +895,7 @@ describe("ChatPage", () => {
     fireEvent.change(await screen.findByLabelText("Conversation route"), {
       target: { value: "/api/v1/proxy/s/openai" },
     });
+    expect(await screen.findByText("via OpenAI")).toBeTruthy();
     fireEvent.click(await screen.findByRole("button", { name: "gpt-5.4-mini" }));
 
     fireEvent.change(await screen.findByPlaceholderText("Send a message..."), {

--- a/apps/aevatar-console-web/src/pages/chat/index.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.tsx
@@ -437,7 +437,6 @@ const ChatPage: React.FC = () => {
   const backendEffectiveRouteLabel = trimConversationValue(
     userLlmSettingsQuery.data?.effectiveRouteLabel
   );
-  // Refactor (issue1525): Old pattern: default conversation route display recalculated a UI label from route options even when backend supplied the effective label。New principle: when the conversation has no override, show the backend effective label as the source of truth and derive labels only for overrides。
   const effectiveRouteLabel = useMemo(
     () =>
       conversationRoute === undefined && backendEffectiveRouteLabel

--- a/apps/aevatar-console-web/src/pages/chat/index.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.tsx
@@ -437,6 +437,13 @@ const ChatPage: React.FC = () => {
   const backendEffectiveRouteLabel = trimConversationValue(
     userLlmSettingsQuery.data?.effectiveRouteLabel
   );
+  /**
+   * Refactor (issue1525): Old pattern: default conversation route display
+   * recalculated a UI label from route options even when backend supplied the
+   * effective label.
+   * New principle: when the conversation has no override, show the backend
+   * effective label as the source of truth and derive labels only for overrides.
+   */
   const effectiveRouteLabel = useMemo(
     () =>
       conversationRoute === undefined && backendEffectiveRouteLabel

--- a/apps/aevatar-console-web/src/pages/chat/index.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.tsx
@@ -434,9 +434,15 @@ const ChatPage: React.FC = () => {
   );
   const effectiveRoute =
     conversationRoute !== undefined ? conversationRoute : globalPreferredRoute;
+  const backendEffectiveRouteLabel = trimConversationValue(
+    userLlmSettingsQuery.data?.effectiveRouteLabel
+  );
   const effectiveRouteLabel = useMemo(
-    () => describeConversationRoute(effectiveRoute, routeOptions),
-    [effectiveRoute, routeOptions]
+    () =>
+      conversationRoute === undefined && backendEffectiveRouteLabel
+        ? backendEffectiveRouteLabel
+        : describeConversationRoute(effectiveRoute, routeOptions),
+    [backendEffectiveRouteLabel, conversationRoute, effectiveRoute, routeOptions]
   );
   const effectiveModel =
     trimConversationValue(conversationModel) ||

--- a/apps/aevatar-console-web/src/pages/chat/index.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.tsx
@@ -437,13 +437,7 @@ const ChatPage: React.FC = () => {
   const backendEffectiveRouteLabel = trimConversationValue(
     userLlmSettingsQuery.data?.effectiveRouteLabel
   );
-  /**
-   * Refactor (issue1525): Old pattern: default conversation route display
-   * recalculated a UI label from route options even when backend supplied the
-   * effective label.
-   * New principle: when the conversation has no override, show the backend
-   * effective label as the source of truth and derive labels only for overrides.
-   */
+  // Refactor (issue1525): Old pattern: default conversation route display recalculated a UI label from route options even when backend supplied the effective label。New principle: when the conversation has no override, show the backend effective label as the source of truth and derive labels only for overrides。
   const effectiveRouteLabel = useMemo(
     () =>
       conversationRoute === undefined && backendEffectiveRouteLabel

--- a/apps/aevatar-console-web/src/pages/settings/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/settings/index.test.tsx
@@ -30,9 +30,9 @@ const { studioApi: mockStudioApi } = jest.requireMock(
 function createLlmSettings(overrides: Record<string, unknown> = {}) {
   return {
     savedRoute: "",
-    savedRouteLabel: "NyxID Gateway",
+    savedRouteLabel: "Company LLM Gateway",
     effectiveRoute: "",
-    effectiveRouteLabel: "NyxID Gateway",
+    effectiveRouteLabel: "Company LLM Gateway",
     routeFallbackActive: false,
     fallbackReason: null,
     catalogStatus: "ready",
@@ -46,7 +46,7 @@ function createLlmSettings(overrides: Record<string, unknown> = {}) {
     routeOptions: [
       {
         routeValue: "",
-        label: "NyxID Gateway",
+        label: "Company LLM Gateway",
         source: "gateway_provider",
         status: "ready",
         allowed: true,
@@ -158,6 +158,7 @@ describe("SettingsPage", () => {
     expect(screen.getByText("How defaults work")).toBeTruthy();
     expect(screen.getByText("Technical preview")).toBeTruthy();
     expect(screen.getAllByText("Effective route").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Company LLM Gateway").length).toBeGreaterThan(0);
     expect(screen.getByText("Connected providers")).toBeTruthy();
     expect(screen.getAllByText("OpenAI Team Service").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Default model").length).toBeGreaterThan(0);

--- a/apps/aevatar-console-web/src/pages/settings/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/settings/index.test.tsx
@@ -30,9 +30,9 @@ const { studioApi: mockStudioApi } = jest.requireMock(
 function createLlmSettings(overrides: Record<string, unknown> = {}) {
   return {
     savedRoute: "",
-    savedRouteLabel: "Company LLM Gateway",
+    savedRouteLabel: "Backend saved gateway",
     effectiveRoute: "",
-    effectiveRouteLabel: "Company LLM Gateway",
+    effectiveRouteLabel: "Backend effective gateway",
     routeFallbackActive: false,
     fallbackReason: null,
     catalogStatus: "ready",
@@ -46,7 +46,7 @@ function createLlmSettings(overrides: Record<string, unknown> = {}) {
     routeOptions: [
       {
         routeValue: "",
-        label: "Company LLM Gateway",
+        label: "Gateway route option",
         source: "gateway_provider",
         status: "ready",
         allowed: true,
@@ -158,7 +158,8 @@ describe("SettingsPage", () => {
     expect(screen.getByText("How defaults work")).toBeTruthy();
     expect(screen.getByText("Technical preview")).toBeTruthy();
     expect(screen.getAllByText("Effective route").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Company LLM Gateway").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Backend effective gateway").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Backend saved gateway").length).toBeGreaterThan(0);
     expect(screen.getByText("Connected providers")).toBeTruthy();
     expect(screen.getAllByText("OpenAI Team Service").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Default model").length).toBeGreaterThan(0);

--- a/apps/aevatar-console-web/src/pages/settings/index.tsx
+++ b/apps/aevatar-console-web/src/pages/settings/index.tsx
@@ -481,11 +481,21 @@ const SettingsPage: React.FC = () => {
   const routeFallbackActive = draftsEqual(draft, loadedDraft)
     ? Boolean(userLlmSettingsQuery.data?.routeFallbackActive)
     : false;
-  const routeSummaryLabel = describeConversationRoute(effectiveRoute, routeOptions);
-  const preferredRouteLabel = describeConversationRoute(
-    draft.preferredLlmRoute,
-    routeOptions,
+  const draftMatchesLoaded = draftsEqual(draft, loadedDraft);
+  const backendEffectiveRouteLabel = trimConversationValue(
+    userLlmSettingsQuery.data?.effectiveRouteLabel,
   );
+  const backendSavedRouteLabel = trimConversationValue(
+    userLlmSettingsQuery.data?.savedRouteLabel,
+  );
+  const routeSummaryLabel =
+    draftMatchesLoaded && backendEffectiveRouteLabel
+      ? backendEffectiveRouteLabel
+      : describeConversationRoute(effectiveRoute, routeOptions);
+  const preferredRouteLabel =
+    draftMatchesLoaded && backendSavedRouteLabel
+      ? backendSavedRouteLabel
+      : describeConversationRoute(draft.preferredLlmRoute, routeOptions);
   const modelGroups = React.useMemo(
     () =>
       buildConversationModelGroups({
@@ -811,7 +821,7 @@ const SettingsPage: React.FC = () => {
               <SummaryMetric
                 label="Effective route"
                 tone={routeFallbackActive ? "warning" : "success"}
-                value={routeSummaryLabel || "NyxID Gateway"}
+                value={routeSummaryLabel}
               />
               <SummaryMetric
                 label="Default model"
@@ -945,7 +955,7 @@ const SettingsPage: React.FC = () => {
                         </div>
                         <Typography.Text type="secondary">
                           Current route resolves through{" "}
-                          {routeSummaryLabel || "NyxID Gateway"}.
+                          {routeSummaryLabel}.
                         </Typography.Text>
                         {providerDisplayList.length > 0 ? (
                           <div style={providerRailStyle}>
@@ -1041,7 +1051,7 @@ const SettingsPage: React.FC = () => {
                       <SummaryField label="Saved route" value={preferredRouteLabel} />
                       <SummaryField
                         label="Effective route"
-                        value={routeSummaryLabel || "NyxID Gateway"}
+                        value={routeSummaryLabel}
                       />
                       <SummaryField label="Runtime mode" value={runtimeModeLabel} />
                       <SummaryField

--- a/apps/aevatar-console-web/src/pages/settings/index.tsx
+++ b/apps/aevatar-console-web/src/pages/settings/index.tsx
@@ -488,13 +488,7 @@ const SettingsPage: React.FC = () => {
   const backendSavedRouteLabel = trimConversationValue(
     userLlmSettingsQuery.data?.savedRouteLabel,
   );
-  /**
-   * Refactor (issue1525): Old pattern: settings summaries recalculated saved
-   * and effective route labels from local route options even for unchanged
-   * loaded settings.
-   * New principle: unchanged settings display backend typed labels, while dirty
-   * drafts continue to use the current local route selection.
-   */
+  // Refactor (issue1525): Old pattern: settings summaries recalculated saved and effective route labels from local route options even for unchanged loaded settings。New principle: unchanged settings display backend typed labels, while dirty drafts continue to use the current local route selection。
   const routeSummaryLabel =
     draftMatchesLoaded && backendEffectiveRouteLabel
       ? backendEffectiveRouteLabel

--- a/apps/aevatar-console-web/src/pages/settings/index.tsx
+++ b/apps/aevatar-console-web/src/pages/settings/index.tsx
@@ -478,10 +478,10 @@ const SettingsPage: React.FC = () => {
         : draft.preferredLlmRoute,
     [draft, loadedDraft, userLlmSettingsQuery.data?.effectiveRoute],
   );
-  const routeFallbackActive = draftsEqual(draft, loadedDraft)
+  const draftMatchesLoaded = draftsEqual(draft, loadedDraft);
+  const routeFallbackActive = draftMatchesLoaded
     ? Boolean(userLlmSettingsQuery.data?.routeFallbackActive)
     : false;
-  const draftMatchesLoaded = draftsEqual(draft, loadedDraft);
   const backendEffectiveRouteLabel = trimConversationValue(
     userLlmSettingsQuery.data?.effectiveRouteLabel,
   );

--- a/apps/aevatar-console-web/src/pages/settings/index.tsx
+++ b/apps/aevatar-console-web/src/pages/settings/index.tsx
@@ -488,7 +488,6 @@ const SettingsPage: React.FC = () => {
   const backendSavedRouteLabel = trimConversationValue(
     userLlmSettingsQuery.data?.savedRouteLabel,
   );
-  // Refactor (issue1525): Old pattern: settings summaries recalculated saved and effective route labels from local route options even for unchanged loaded settings。New principle: unchanged settings display backend typed labels, while dirty drafts continue to use the current local route selection。
   const routeSummaryLabel =
     draftMatchesLoaded && backendEffectiveRouteLabel
       ? backendEffectiveRouteLabel

--- a/apps/aevatar-console-web/src/pages/settings/index.tsx
+++ b/apps/aevatar-console-web/src/pages/settings/index.tsx
@@ -488,6 +488,13 @@ const SettingsPage: React.FC = () => {
   const backendSavedRouteLabel = trimConversationValue(
     userLlmSettingsQuery.data?.savedRouteLabel,
   );
+  /**
+   * Refactor (issue1525): Old pattern: settings summaries recalculated saved
+   * and effective route labels from local route options even for unchanged
+   * loaded settings.
+   * New principle: unchanged settings display backend typed labels, while dirty
+   * drafts continue to use the current local route selection.
+   */
   const routeSummaryLabel =
     draftMatchesLoaded && backendEffectiveRouteLabel
       ? backendEffectiveRouteLabel

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -767,9 +767,9 @@ jest.mock("@/shared/studio/api", () => ({
     })),
     getUserLlmSettings: jest.fn(async () => ({
       savedRoute: "",
-      savedRouteLabel: "NyxID Gateway",
+      savedRouteLabel: "Company LLM Gateway",
       effectiveRoute: "",
-      effectiveRouteLabel: "NyxID Gateway",
+      effectiveRouteLabel: "Company LLM Gateway",
       routeFallbackActive: false,
       fallbackReason: null,
       catalogStatus: "ready",
@@ -783,7 +783,7 @@ jest.mock("@/shared/studio/api", () => ({
       routeOptions: [
         {
           routeValue: "",
-          label: "NyxID Gateway",
+          label: "Company LLM Gateway",
           source: "gateway_provider",
           status: "ready",
           allowed: true,
@@ -3454,7 +3454,7 @@ describe("StudioPage", () => {
       savedRoute: "/api/v1/proxy/s/stale-openai",
       savedRouteLabel: "/api/v1/proxy/s/stale-openai",
       effectiveRoute: "",
-      effectiveRouteLabel: "NyxID Gateway",
+      effectiveRouteLabel: "Company LLM Gateway",
       routeFallbackActive: true,
       fallbackReason: "saved_route_unavailable",
       catalogStatus: "ready",
@@ -3468,7 +3468,7 @@ describe("StudioPage", () => {
       routeOptions: [
         {
           routeValue: "",
-          label: "NyxID Gateway",
+          label: "Company LLM Gateway",
           source: "gateway_provider",
           status: "ready",
           allowed: true,
@@ -3503,7 +3503,7 @@ describe("StudioPage", () => {
 
     const routeLabel = await screen.findByTestId("workflow-dry-run-route");
     await waitFor(() => {
-      expect(routeLabel).toHaveTextContent("NyxID Gateway");
+      expect(routeLabel).toHaveTextContent("Company LLM Gateway");
     });
   });
 

--- a/apps/aevatar-console-web/src/shared/studio/api.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.test.ts
@@ -170,9 +170,9 @@ describe('studioApi host-session requests', () => {
       status: 200,
       json: async () => ({
         savedRoute: '',
-        savedRouteLabel: 'NyxID Gateway',
+        savedRouteLabel: 'Company LLM Gateway',
         effectiveRoute: '',
-        effectiveRouteLabel: 'NyxID Gateway',
+        effectiveRouteLabel: 'Company LLM Gateway',
         routeFallbackActive: false,
         fallbackReason: null,
         catalogStatus: 'ready',
@@ -186,7 +186,7 @@ describe('studioApi host-session requests', () => {
         routeOptions: [
           {
             routeValue: '',
-            label: 'NyxID Gateway',
+            label: 'Company LLM Gateway',
             source: 'gateway_provider',
             status: 'ready',
             allowed: true,
@@ -221,9 +221,9 @@ describe('studioApi host-session requests', () => {
 
     await expect(studioApi.getUserLlmSettings()).resolves.toEqual({
       savedRoute: '',
-      savedRouteLabel: 'NyxID Gateway',
+      savedRouteLabel: 'Company LLM Gateway',
       effectiveRoute: '',
-      effectiveRouteLabel: 'NyxID Gateway',
+      effectiveRouteLabel: 'Company LLM Gateway',
       routeFallbackActive: false,
       fallbackReason: null,
       catalogStatus: 'ready',
@@ -237,7 +237,7 @@ describe('studioApi host-session requests', () => {
       routeOptions: [
         {
           routeValue: '',
-          label: 'NyxID Gateway',
+          label: 'Company LLM Gateway',
           source: 'gateway_provider',
           status: 'ready',
           allowed: true,


### PR DESCRIPTION
## 摘要

实施 #1525 Phase 9 r3 三 solver + meta-judge consensus hybrid(minimal+structural+delete)framing。

closes #1525

## 范围

8 files / +72 -35。frontend chat/settings/studio 重复 useEffect / config 路径收敛。本地 build/test 4177 pass。

⟦AI:AUTO-LOOP⟧