### PR TITLE
refactor: impl issue #1628 — demote FromMetadata external-only + migrate production callers

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -1001,12 +1001,12 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         var replyContent = decision.ReplyContent ?? new MessageContent { Text = decision.ReplyPayload };
         if (decision.RequiresToolExecution)
         {
-            using (AgentToolContextScope.Push(AgentToolExecutionContextMapper.FromMetadata(
-                       await BuildAgentBuilderMetadataAsync(
-                    activity,
-                    inboundEvent,
-                    ResolveUserAccessToken(activity, runtimeContext),
-                    ct))))
+            var metadata = await BuildAgentBuilderMetadataAsync(
+                activity,
+                inboundEvent,
+                ResolveUserAccessToken(activity, runtimeContext),
+                ct);
+            using (AgentToolContextScope.Push(BuildAgentBuilderToolContext(metadata)))
             {
                 var tool = ActivatorUtilities.CreateInstance<AgentBuilderTool>(_toolServiceProvider);
                 var toolResult = await tool.ExecuteAsync(decision.ToolArgumentsJson!, ct);
@@ -1442,6 +1442,37 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         }
         return metadata;
     }
+
+    private static AgentToolExecutionContext BuildAgentBuilderToolContext(
+        IReadOnlyDictionary<string, string> metadata)
+    {
+        var userAccessToken = Resolve(metadata, LLMRequestMetadataKeys.NyxIdAccessToken);
+        return AgentToolExecutionContext.Empty with
+        {
+            Credentials = AgentToolCredentials.Empty with
+            {
+                NyxIdAccessToken = userAccessToken,
+                NyxIdOrgToken = Resolve(metadata, LLMRequestMetadataKeys.NyxIdOrgToken) ?? userAccessToken,
+            },
+            Caller = AgentToolCallerContext.Empty with
+            {
+                ScopeId = Resolve(metadata, "scope_id"),
+            },
+            Channel = AgentToolChannelContext.Empty with
+            {
+                Platform = Resolve(metadata, ChannelMetadataKeys.Platform),
+                SenderId = Resolve(metadata, ChannelMetadataKeys.SenderId),
+                MessageId = Resolve(metadata, ChannelMetadataKeys.MessageId),
+                PlatformMessageId = Resolve(metadata, ChannelMetadataKeys.PlatformMessageId),
+            },
+            ExternalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(metadata),
+        };
+    }
+
+    private static string? Resolve(IReadOnlyDictionary<string, string> metadata, string key) =>
+        metadata.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)
+            ? value.Trim()
+            : null;
 
     internal static InboundMessage ToInboundMessage(ChatActivity activity)
     {

--- a/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
@@ -165,7 +165,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         var disableTools = forceDisableTools || replyPlan.DisableTools;
         var tools = await BuildTurnToolsAsync(disableTools, ct);
         var effectiveToolContext = replyPlan.PrimaryControl.ToToolContext(
-            replyPlan.PrimaryToolContext ?? AgentToolExecutionContextMapper.FromMetadata(replyPlan.Primary));
+            replyPlan.PrimaryToolContext ?? BuildToolContextFromReplyMetadata(replyPlan.Primary));
         var externalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(replyPlan.Primary);
         var runtime = BuildRuntime(
             activity,
@@ -256,7 +256,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         IStreamingReplySink? streamingSink,
         CancellationToken ct)
     {
-        var toolContext = llmControl.ToToolContext(baseToolContext ?? AgentToolExecutionContextMapper.FromMetadata(effectiveMetadata));
+        var toolContext = llmControl.ToToolContext(baseToolContext ?? BuildToolContextFromReplyMetadata(effectiveMetadata));
         var externalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(effectiveMetadata);
 
         // Refactor (iter31/cluster-032-chatruntime-taskrun-business-loop):
@@ -536,6 +536,31 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         metadata.ContainsKey(ChannelMetadataKeys.Platform) &&
         metadata.ContainsKey(ChannelMetadataKeys.SenderId) &&
         metadata.ContainsKey(ChannelMetadataKeys.MessageId);
+
+    private static AgentToolExecutionContext BuildToolContextFromReplyMetadata(
+        IReadOnlyDictionary<string, string> metadata)
+    {
+        return AgentToolExecutionContext.Empty with
+        {
+            Caller = AgentToolCallerContext.Empty with
+            {
+                ScopeId = Resolve(metadata, "scope_id"),
+            },
+            Channel = AgentToolChannelContext.Empty with
+            {
+                Platform = Resolve(metadata, ChannelMetadataKeys.Platform),
+                SenderId = Resolve(metadata, ChannelMetadataKeys.SenderId),
+                MessageId = Resolve(metadata, ChannelMetadataKeys.MessageId),
+                PlatformMessageId = Resolve(metadata, ChannelMetadataKeys.PlatformMessageId),
+            },
+            ExternalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(metadata),
+        };
+    }
+
+    private static string? Resolve(IReadOnlyDictionary<string, string> metadata, string key) =>
+        metadata.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)
+            ? value.Trim()
+            : null;
 
     private async Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct)
     {

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
@@ -325,7 +325,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         var prompt = BuildExecutionPrompt(now, reason);
         var metadata = await BuildExecutionMetadataAsync(ct);
         var llmControl = await BuildExecutionLlmControlAsync(ct);
-        var toolContext = llmControl.ToToolContext(AgentToolExecutionContextMapper.FromMetadata(metadata));
+        var toolContext = llmControl.ToToolContext(BuildExecutionToolContext(metadata));
         var requestId = Guid.NewGuid().ToString("N");
         var content = new StringBuilder();
 
@@ -806,6 +806,24 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
 
         return metadata;
     }
+
+    private AgentToolExecutionContext BuildExecutionToolContext(IReadOnlyDictionary<string, string> metadata) =>
+        AgentToolExecutionContext.Empty with
+        {
+            Caller = new AgentToolCallerContext(
+                NormalizeToolContextValue(State.ScopeId),
+                OwnerSubject: null,
+                ResponseId: null),
+            Channel = AgentToolChannelContext.Empty with
+            {
+                Platform = NormalizeToolContextValue(State.OutboundConfig?.Platform),
+                SenderId = NormalizeToolContextValue(State.OutboundConfig?.ConversationId),
+            },
+            ExternalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(metadata),
+        };
+
+    private static string? NormalizeToolContextValue(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
     private async Task<LLMControlContext> BuildExecutionLlmControlAsync(CancellationToken ct)
     {

--- a/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContextMapper.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContextMapper.cs
@@ -2,9 +2,8 @@ using Aevatar.AI.Abstractions.LLMProviders;
 
 namespace Aevatar.AI.Abstractions.ToolProviders;
 
-// Refactor (iter24/cluster-002-agent-tool-context-generic-metadata-bag):
-//   Old pattern: any tool could parse control keys from Metadata directly.
-//   New principle: legacy metadata decoding is isolated here; tool control flow uses typed context.
+// Refactor (issue1628): Metadata is an external annotation surface only.
+//   Owned tool-control facts must arrive through typed request/tool contexts.
 public static class AgentToolExecutionContextMapper
 {
     private static readonly HashSet<string> OwnedControlKeys = new(StringComparer.Ordinal)
@@ -46,26 +45,25 @@ public static class AgentToolExecutionContextMapper
         if (request.ToolContext is { } typedContext)
             return request.LlmControl?.ToToolContext(typedContext) ?? typedContext;
 
-        var mapped = FromMetadata(request.Metadata);
+        var mapped = AgentToolExecutionContext.Empty;
         mapped = request.LlmControl?.ToToolContext(mapped) ?? mapped;
         var caller = request.CallerContext;
         return mapped with
         {
             Request = new AgentToolRequestIdentity(
-                AgentToolExecutionContext.Normalize(request.RequestId) ?? mapped.Request.RequestId,
+                AgentToolExecutionContext.Normalize(request.RequestId),
                 mapped.Request.CallId),
             Caller = caller == null
                 ? mapped.Caller
                 : new AgentToolCallerContext(
-                    AgentToolExecutionContext.Normalize(caller.ScopeId) ?? mapped.Caller.ScopeId,
-                    AgentToolExecutionContext.Normalize(caller.OwnerSubject) ?? mapped.Caller.OwnerSubject,
-                    AgentToolExecutionContext.Normalize(caller.ResponseId) ?? mapped.Caller.ResponseId),
+                    AgentToolExecutionContext.Normalize(caller.ScopeId),
+                    AgentToolExecutionContext.Normalize(caller.OwnerSubject),
+                    AgentToolExecutionContext.Normalize(caller.ResponseId)),
             Credentials = caller?.Credentials == null
                 ? mapped.Credentials
                 : mapped.Credentials with
                 {
                     NyxIdAccessToken = AgentToolExecutionContext.Normalize(caller.Credentials.NyxIdBearer)
-                        ?? mapped.Credentials.NyxIdAccessToken,
                 },
             Routing = request.RoutingContext ?? mapped.Routing,
             ExternalMetadata = StripOwnedControlKeys(request.Metadata),
@@ -173,33 +171,7 @@ public static class AgentToolExecutionContextMapper
         if (metadata == null || metadata.Count == 0)
             return AgentToolExecutionContext.Empty;
 
-        var maxToolRounds = TryGet(metadata, LLMRequestMetadataKeys.MaxToolRoundsOverride);
-        return new AgentToolExecutionContext(
-            new AgentToolRequestIdentity(
-                TryGet(metadata, LLMRequestMetadataKeys.RequestId),
-                TryGet(metadata, LLMRequestMetadataKeys.CallId)),
-            new AgentToolCredentials(
-                TryGet(metadata, LLMRequestMetadataKeys.NyxIdAccessToken),
-                TryGet(metadata, LLMRequestMetadataKeys.NyxIdOrgToken),
-                TryGet(metadata, LLMRequestMetadataKeys.SenderNyxIdAccessToken)),
-            new AgentToolCallerContext(
-                TryGet(metadata, LLMRequestMetadataKeys.ScopeId) ?? TryGet(metadata, "scope_id"),
-                TryGet(metadata, LLMRequestMetadataKeys.OwnerSubject),
-                TryGet(metadata, LLMRequestMetadataKeys.ResponseId)),
-            new AgentToolChannelContext(
-                TryGet(metadata, "channel.platform") ?? TryGet(metadata, "platform"),
-                TryGet(metadata, "channel.sender_id") ?? TryGet(metadata, "sender_id") ?? TryGet(metadata, "lark.open_id"),
-                TryGet(metadata, "registration_scope_id"),
-                TryGet(metadata, "channel.message_id") ?? TryGet(metadata, "message_id") ?? TryGet(metadata, "lark.message_id"),
-                TryGet(metadata, "channel.platform_message_id") ?? TryGet(metadata, "platform_message_id")),
-            new AgentToolSenderBindingContext(TryGet(metadata, LLMRequestMetadataKeys.SenderBindingId)),
-            new LLMRequestRoutingContext(
-                TryGet(metadata, LLMRequestMetadataKeys.ModelOverride),
-                TryGet(metadata, LLMRequestMetadataKeys.NyxIdRoutePreference),
-                int.TryParse(maxToolRounds, out var parsedMaxToolRounds) ? parsedMaxToolRounds : null,
-                TryGet(metadata, LLMRequestMetadataKeys.UserMemoryPrompt)),
-            new AgentToolConnectedServicesContext(TryGet(metadata, LLMRequestMetadataKeys.ConnectedServicesContext)),
-            StripOwnedControlKeys(metadata));
+        return AgentToolExecutionContext.Empty with { ExternalMetadata = StripOwnedControlKeys(metadata) };
     }
 
     public static IReadOnlyDictionary<string, string> StripOwnedControlKeys(IReadOnlyDictionary<string, string>? metadata)
@@ -219,6 +191,4 @@ public static class AgentToolExecutionContextMapper
         return result;
     }
 
-    private static string? TryGet(IReadOnlyDictionary<string, string> metadata, string key) =>
-        metadata.TryGetValue(key, out var value) ? AgentToolExecutionContext.Normalize(value) : null;
 }

--- a/src/Aevatar.AI.Core/Tools/StreamingToolExecutor.cs
+++ b/src/Aevatar.AI.Core/Tools/StreamingToolExecutor.cs
@@ -44,9 +44,30 @@ public sealed class StreamingToolExecutor
         _tools = tools;
         _hooks = hooks;
         _toolMiddlewares = toolMiddlewares ?? [];
-        _toolContext = toolContext
-            ?? AgentToolRequestContext.Current
-            ?? AgentToolExecutionContextMapper.FromMetadata(requestMetadata);
+        _toolContext = AttachExternalMetadata(
+            toolContext ?? AgentToolRequestContext.Current,
+            requestMetadata);
+    }
+
+    private static AgentToolExecutionContext AttachExternalMetadata(
+        AgentToolExecutionContext? context,
+        IReadOnlyDictionary<string, string>? requestMetadata)
+    {
+        var externalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(requestMetadata);
+        if (context is null)
+            return AgentToolExecutionContext.Empty with
+            {
+                ExternalMetadata = externalMetadata,
+            };
+
+        if (externalMetadata.Count == 0)
+            return context;
+
+        var merged = new Dictionary<string, string>(externalMetadata, StringComparer.Ordinal);
+        foreach (var pair in context.ExternalMetadata)
+            merged[pair.Key] = pair.Value;
+
+        return context with { ExternalMetadata = merged };
     }
 
     public ExecutionState CreateExecutionState() => new();

--- a/src/Aevatar.AI.Core/Tools/ToolCallLoop.cs
+++ b/src/Aevatar.AI.Core/Tools/ToolCallLoop.cs
@@ -275,7 +275,10 @@ public sealed class ToolCallLoop
         IReadOnlyDictionary<string, string>? metadata,
         CancellationToken ct)
     {
-        using var _ = AgentToolContextScope.Push(AgentToolExecutionContextMapper.FromMetadata(metadata));
+        using var _ = AgentToolContextScope.Push(AgentToolExecutionContext.Empty with
+        {
+            ExternalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(metadata),
+        });
         await ExecuteToolCallsCoreAsync(toolCalls, messages, ct);
     }
 

--- a/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
+++ b/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
@@ -10,7 +10,7 @@ namespace Aevatar.AI.Tests;
 public sealed class AgentToolExecutionContextMapperTests
 {
     [Fact]
-    public void FromRequest_WhenTypedFieldsAndLegacyMetadataOverlap_ShouldPreferTypedRequestCallerAndRouting()
+    public void FromRequest_WhenTypedFieldsAndMetadataOverlap_ShouldUseOnlyTypedRequestCallerAndRouting()
     {
         var request = new LLMRequest
         {
@@ -46,12 +46,12 @@ public sealed class AgentToolExecutionContextMapperTests
         var context = AgentToolExecutionContextMapper.FromRequest(request);
 
         context.Request.RequestId.Should().Be("typed-request");
-        context.Request.CallId.Should().Be("legacy-call");
+        context.Request.CallId.Should().BeNull();
         context.Caller.ScopeId.Should().Be("typed-scope");
         context.Caller.OwnerSubject.Should().Be("typed-owner");
         context.Caller.ResponseId.Should().Be("typed-response");
         context.Credentials.NyxIdAccessToken.Should().Be("typed-access");
-        context.Credentials.NyxIdOrgToken.Should().Be("legacy-org");
+        context.Credentials.NyxIdOrgToken.Should().BeNull();
         context.Routing.ModelOverride.Should().Be("typed-model");
         context.Routing.NyxIdRoutePreference.Should().Be("typed-route");
         context.Routing.MaxToolRoundsOverride.Should().Be(9);
@@ -61,35 +61,65 @@ public sealed class AgentToolExecutionContextMapperTests
     }
 
     [Fact]
-    public void FromMetadata_WhenChannelCanonicalKeysAreAbsent_ShouldMapLegacyAliases()
+    public void FromMetadata_ShouldNotPopulateOwnedControlFacts()
     {
         var context = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>(StringComparer.Ordinal)
         {
-            ["platform"] = "lark",
-            ["sender_id"] = "ou-legacy",
-            ["registration_scope_id"] = "scope-legacy",
-            ["message_id"] = "msg-legacy",
-            ["platform_message_id"] = "platform-msg-legacy",
+            [LLMRequestMetadataKeys.RequestId] = "legacy-request",
+            [LLMRequestMetadataKeys.CallId] = "legacy-call",
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "access-token",
+            [LLMRequestMetadataKeys.NyxIdOrgToken] = "org-token",
+            [LLMRequestMetadataKeys.ModelOverride] = "model-a",
+            [LLMRequestMetadataKeys.NyxIdRoutePreference] = "/preferred",
+            [LLMRequestMetadataKeys.MaxToolRoundsOverride] = "7",
+            [LLMRequestMetadataKeys.ConnectedServicesContext] = "{\"services\":[]}",
+            ["scope_id"] = "scope-a",
+            ["channel.platform"] = "lark",
+            ["channel.sender_id"] = "ou_1",
+            ["trace-id"] = "trace-1",
         });
 
-        context.Channel.Platform.Should().Be("lark");
-        context.Channel.SenderId.Should().Be("ou-legacy");
-        context.Channel.RegistrationScopeId.Should().Be("scope-legacy");
-        context.Channel.MessageId.Should().Be("msg-legacy");
-        context.Channel.PlatformMessageId.Should().Be("platform-msg-legacy");
+        context.Request.Should().Be(AgentToolRequestIdentity.Empty);
+        context.Credentials.Should().Be(AgentToolCredentials.Empty);
+        context.Caller.Should().Be(AgentToolCallerContext.Empty);
+        context.Channel.Should().Be(AgentToolChannelContext.Empty);
+        context.SenderBinding.Should().Be(AgentToolSenderBindingContext.Empty);
+        context.Routing.Should().Be(LLMRequestRoutingContext.Empty);
+        context.ConnectedServices.Should().Be(AgentToolConnectedServicesContext.Empty);
+        context.ExternalMetadata.Should().ContainSingle();
+        context.ExternalMetadata["trace-id"].Should().Be("trace-1");
     }
 
     [Fact]
-    public void FromMetadata_WhenLarkAliasesArePresent_ShouldMapSenderAndMessageFallbacks()
+    public void FromRequest_ShouldNotBackfillMissingTypedFactsFromMetadata()
     {
-        var context = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>(StringComparer.Ordinal)
+        var request = new LLMRequest
         {
-            ["lark.open_id"] = "ou-lark",
-            ["lark.message_id"] = "msg-lark",
-        });
+            Messages = [],
+            Metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [LLMRequestMetadataKeys.RequestId] = "legacy-request",
+                [LLMRequestMetadataKeys.CallId] = "legacy-call",
+                [LLMRequestMetadataKeys.ScopeId] = "legacy-scope",
+                [LLMRequestMetadataKeys.NyxIdAccessToken] = "legacy-access",
+                [LLMRequestMetadataKeys.NyxIdOrgToken] = "legacy-org",
+                [LLMRequestMetadataKeys.ModelOverride] = "legacy-model",
+                [LLMRequestMetadataKeys.NyxIdRoutePreference] = "legacy-route",
+                [LLMRequestMetadataKeys.MaxToolRoundsOverride] = "4",
+                ["lark.open_id"] = "ou-lark",
+                ["trace-id"] = "trace-1",
+            },
+        };
 
-        context.Channel.SenderId.Should().Be("ou-lark");
-        context.Channel.MessageId.Should().Be("msg-lark");
+        var context = AgentToolExecutionContextMapper.FromRequest(request);
+
+        context.Request.Should().Be(AgentToolRequestIdentity.Empty);
+        context.Credentials.Should().Be(AgentToolCredentials.Empty);
+        context.Caller.Should().Be(AgentToolCallerContext.Empty);
+        context.Channel.Should().Be(AgentToolChannelContext.Empty);
+        context.Routing.Should().Be(LLMRequestRoutingContext.Empty);
+        context.ExternalMetadata.Should().ContainSingle();
+        context.ExternalMetadata["trace-id"].Should().Be("trace-1");
     }
 
     [Fact]
@@ -142,20 +172,6 @@ public sealed class AgentToolExecutionContextMapperTests
         AgentToolExecutionContextMapper.FromPayload(null).Should().Be(AgentToolExecutionContext.Empty);
     }
 
-    [Theory]
-    [InlineData("")]
-    [InlineData("   ")]
-    [InlineData("not-a-number")]
-    public void FromMetadata_WhenMaxToolRoundsOverrideIsInvalid_ShouldLeaveTypedOverrideUnset(string maxRounds)
-    {
-        var context = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            [LLMRequestMetadataKeys.MaxToolRoundsOverride] = maxRounds,
-        });
-
-        context.Routing.MaxToolRoundsOverride.Should().BeNull();
-    }
-
     [Fact]
     public void ScopeDispose_WhenNestedScopesAreUsed_ShouldRestoreOuterContext()
     {
@@ -206,6 +222,7 @@ public sealed class AgentToolExecutionContextMapperTests
         source.Should().NotContain("AgentToolRequestContext.CurrentMetadata");
         source.Should().NotContain("AgentToolRequestContext.TryGet(");
         source.Should().NotContain(".ToLegacyMetadata(");
+        source.Should().NotContain("AgentToolExecutionContextMapper.FromMetadata(");
     }
 
     private static string FindRepositoryRoot()

--- a/test/Aevatar.AI.Tests/NyxIdApiClientCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdApiClientCoverageTests.cs
@@ -387,10 +387,10 @@ public sealed class NyxIdApiClientCoverageTests
                 new HttpClient(handler),
                 NullLogger<NyxIdApiClient>.Instance);
             var tool = new NyxIdLlmStatusTool(client);
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+            AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
             {
-                [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-1",
-            });
+                Credentials = AgentToolCredentials.Empty with { NyxIdAccessToken = "token-1" },
+            };
 
             var response = await tool.ExecuteAsync("{}", CancellationToken.None);
 

--- a/test/Aevatar.AI.Tests/NyxIdCodeExecuteToolTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdCodeExecuteToolTests.cs
@@ -101,13 +101,11 @@ public class NyxIdCodeExecuteToolTests
 
     private static void SetMetadata(string token, string? servicesContext)
     {
-        var metadata = new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = token,
+            Credentials = AgentToolCredentials.Empty with { NyxIdAccessToken = token },
+            ConnectedServices = AgentToolConnectedServicesContext.Empty with { ContextJson = servicesContext },
         };
-        if (servicesContext is not null)
-            metadata[LLMRequestMetadataKeys.ConnectedServicesContext] = servicesContext;
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(metadata);
     }
 
     private static void ClearMetadata()

--- a/test/Aevatar.AI.Tests/NyxIdRelayAndPairingTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdRelayAndPairingTests.cs
@@ -214,10 +214,14 @@ public class NyxIdChannelBotsToolTests
 
     private static void SetFakeToken()
     {
-        var key = Aevatar.AI.Abstractions.LLMProviders.LLMRequestMetadataKeys.NyxIdAccessToken;
         Aevatar.AI.Abstractions.ToolProviders.AgentToolRequestContext.Current =
-            Aevatar.AI.Abstractions.ToolProviders.AgentToolExecutionContextMapper.FromMetadata(
-                new Dictionary<string, string> { [key] = "fake-token" });
+            Aevatar.AI.Abstractions.ToolProviders.AgentToolExecutionContext.Empty with
+            {
+                Credentials = Aevatar.AI.Abstractions.ToolProviders.AgentToolCredentials.Empty with
+                {
+                    NyxIdAccessToken = "fake-token",
+                },
+            };
     }
 
     private static void ClearToken() =>

--- a/test/Aevatar.AI.Tests/NyxIdSshExecToolTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdSshExecToolTests.cs
@@ -542,10 +542,10 @@ public class NyxIdSshExecToolTests
 
     private static void SetMetadata(string token)
     {
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = token,
-        });
+            Credentials = AgentToolCredentials.Empty with { NyxIdAccessToken = token },
+        };
     }
 
     private static void ClearMetadata() => AgentToolRequestContext.Current = null;

--- a/test/Aevatar.AI.Tests/StreamingToolExecutorTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingToolExecutorTests.cs
@@ -353,7 +353,7 @@ public class StreamingToolExecutorTests
     }
 
     [Fact]
-    public async Task TypedContextPropagation_ShouldSetAsyncLocalDuringExecutionAndRestore()
+    public async Task TypedContextPropagation_ShouldUseTypedContextAndIgnoreMetadataControlKeys()
     {
         string? capturedToken = null;
         string? capturedExternal = null;
@@ -369,12 +369,18 @@ public class StreamingToolExecutorTests
 
         var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "typed-secret",
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "metadata-secret",
             ["auth_token"] = "secret-123",
+        };
+        var toolContext = AgentToolExecutionContext.Empty with
+        {
+            Credentials = AgentToolCredentials.Empty with { NyxIdAccessToken = "typed-secret" },
         };
 
         var executor = new StreamingToolExecutor(
-            tools, requestMetadata: metadata);
+            tools,
+            requestMetadata: metadata,
+            toolContext: toolContext);
         using var executionState = executor.CreateExecutionState();
 
         executor.AddTool(executionState, new ToolCall { Id = "tc-1", Name = "meta-check", ArgumentsJson = "{}" });

--- a/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
+++ b/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
@@ -106,7 +106,7 @@ public class ToolCallLoopTests
     }
 
     [Fact]
-    public void AgentToolExecutionContextMapper_ShouldPromoteOwnedKeysAndKeepExternalMetadataOnly()
+    public void AgentToolExecutionContextMapper_ShouldIgnoreOwnedMetadataControlKeys()
     {
         var context = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>(StringComparer.Ordinal)
         {
@@ -122,15 +122,11 @@ public class ToolCallLoopTests
             ["trace-id"] = "trace-1",
         });
 
-        context.Credentials.NyxIdAccessToken.Should().Be("access-token");
-        context.Credentials.NyxIdOrgToken.Should().Be("org-token");
-        context.Caller.ScopeId.Should().Be("scope-a");
-        context.Channel.Platform.Should().Be("lark");
-        context.Channel.SenderId.Should().Be("ou_1");
-        context.Routing.ModelOverride.Should().Be("model-a");
-        context.Routing.NyxIdRoutePreference.Should().Be("/preferred");
-        context.Routing.MaxToolRoundsOverride.Should().Be(7);
-        context.ConnectedServices.ContextJson.Should().Be("{\"services\":[]}");
+        context.Credentials.Should().Be(AgentToolCredentials.Empty);
+        context.Caller.Should().Be(AgentToolCallerContext.Empty);
+        context.Channel.Should().Be(AgentToolChannelContext.Empty);
+        context.Routing.Should().Be(LLMRequestRoutingContext.Empty);
+        context.ConnectedServices.Should().Be(AgentToolConnectedServicesContext.Empty);
         context.ExternalMetadata.Should().ContainSingle();
         context.ExternalMetadata["trace-id"].Should().Be("trace-1");
     }

--- a/test/Aevatar.AI.ToolProviders.Binding.Tests/BindingToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Binding.Tests/BindingToolsTests.cs
@@ -27,10 +27,7 @@ public class BindingToolsTests
         var tool = new BindingListTool(queryAdapter, options);
 
         // Set scope_id in request context
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            ["scope_id"] = "test-scope"
-        });
+        PushScope("test-scope");
 
         try
         {
@@ -79,10 +76,7 @@ public class BindingToolsTests
             "svc-1", "Service One", "workflow", "healthy", "actor-1", "actor-1", null, DateTimeOffset.UtcNow));
         var tool = new BindingStatusTool(queryAdapter);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            ["scope_id"] = "test-scope"
-        });
+        PushScope("test-scope");
 
         try
         {
@@ -110,10 +104,7 @@ public class BindingToolsTests
         var commandPort = new StubCommandPort(captureRequest: r => captured = r);
         var tool = new BindingBindTool(commandPort);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            ["scope_id"] = "scope-1"
-        });
+        PushScope("scope-1");
 
         try
         {
@@ -143,10 +134,7 @@ public class BindingToolsTests
         var commandPort = new StubCommandPort(captureRequest: r => captured = r);
         var tool = new BindingBindTool(commandPort);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            ["scope_id"] = "scope-2"
-        });
+        PushScope("scope-2");
 
         try
         {
@@ -180,10 +168,7 @@ public class BindingToolsTests
         var tool = new ScopeWorkflowsUpsertTool(new StubScopeWorkflowCommandPort(
             captureRequest: r => captured = r));
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            ["scope_id"] = "scope-workflows"
-        });
+        PushScope("scope-workflows");
 
         try
         {
@@ -230,10 +215,7 @@ public class BindingToolsTests
     {
         var tool = new ScopeWorkflowsUpsertTool(new StubScopeWorkflowCommandPort());
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            ["scope_id"] = "scope-workflows"
-        });
+        PushScope("scope-workflows");
 
         try
         {
@@ -259,10 +241,7 @@ public class BindingToolsTests
         var tool = new ScopeWorkflowsUpsertTool(new StubScopeWorkflowCommandPort(
             exception: new InvalidOperationException("bad request")));
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            ["scope_id"] = "scope-workflows"
-        });
+        PushScope("scope-workflows");
 
         try
         {
@@ -289,10 +268,7 @@ public class BindingToolsTests
             new StubScopeWorkflowQueryPort(listResult: workflows),
             new BindingToolOptions { MaxListResults = 1 });
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            ["scope_id"] = "scope-workflows"
-        });
+        PushScope("scope-workflows");
 
         try
         {
@@ -331,10 +307,7 @@ public class BindingToolsTests
             new StubScopeWorkflowQueryPort(exception: new InvalidOperationException("query failed")),
             new BindingToolOptions());
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            ["scope_id"] = "scope-workflows"
-        });
+        PushScope("scope-workflows");
 
         try
         {
@@ -355,10 +328,7 @@ public class BindingToolsTests
         var tool = new ScopeWorkflowsGetTool(new StubScopeWorkflowQueryPort(
             getResult: BuildWorkflowSummary("scope-workflows", "wf-1")));
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            ["scope_id"] = "scope-workflows"
-        });
+        PushScope("scope-workflows");
 
         try
         {
@@ -380,10 +350,7 @@ public class BindingToolsTests
     {
         var tool = new ScopeWorkflowsGetTool(new StubScopeWorkflowQueryPort());
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            ["scope_id"] = "scope-workflows"
-        });
+        PushScope("scope-workflows");
 
         try
         {
@@ -402,10 +369,7 @@ public class BindingToolsTests
     {
         var tool = new ScopeWorkflowsGetTool(new StubScopeWorkflowQueryPort(getResult: null));
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            ["scope_id"] = "scope-workflows"
-        });
+        PushScope("scope-workflows");
 
         try
         {
@@ -427,10 +391,7 @@ public class BindingToolsTests
         var tool = new ScopeWorkflowsGetTool(new StubScopeWorkflowQueryPort(
             exception: new InvalidOperationException("query failed")));
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            ["scope_id"] = "scope-workflows"
-        });
+        PushScope("scope-workflows");
 
         try
         {
@@ -473,10 +434,7 @@ public class BindingToolsTests
 
         var tool = new BindingUnbindTool(unbindAdapter);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            ["scope_id"] = "scope-unbind"
-        });
+        PushScope("scope-unbind");
 
         try
         {
@@ -687,6 +645,14 @@ public class BindingToolsTests
     {
         using var doc = JsonDocument.Parse(json);
         return doc.RootElement.GetProperty("error").GetString();
+    }
+
+    private static void PushScope(string scopeId)
+    {
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
+        {
+            Caller = AgentToolCallerContext.Empty with { ScopeId = scopeId },
+        };
     }
 
     #endregion

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
@@ -20,10 +20,7 @@ public class LarkToolsTests
             SendResponse = """{"code":0,"data":{"message_id":"om_123","chat_id":"oc_456","create_time":"1730000000"}}""",
         };
         var tool = new LarkMessagesSendTool(client);
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-123",
-        });
+        AgentToolRequestContext.Current = BuildTokenContext("token-123");
 
         try
         {
@@ -692,10 +689,7 @@ public class LarkToolsTests
                 """,
         };
         var tool = new LarkChatsLookupTool(client);
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-123",
-        });
+        AgentToolRequestContext.Current = BuildTokenContext("token-123");
 
         try
         {
@@ -786,10 +780,7 @@ public class LarkToolsTests
                 """,
         };
         var tool = new LarkSheetsAppendRowsTool(client);
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-123",
-        });
+        AgentToolRequestContext.Current = BuildTokenContext("token-123");
 
         try
         {
@@ -891,10 +882,7 @@ public class LarkToolsTests
                 """,
         };
         var tool = new LarkApprovalsListTool(client);
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-123",
-        });
+        AgentToolRequestContext.Current = BuildTokenContext("token-123");
 
         try
         {
@@ -996,10 +984,7 @@ public class LarkToolsTests
     public async Task LarkApprovalsActTool_ValidatesTransferTarget()
     {
         var tool = new LarkApprovalsActTool(new StubLarkNyxClient());
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-123",
-        });
+        AgentToolRequestContext.Current = BuildTokenContext("token-123");
 
         try
         {
@@ -1020,10 +1005,7 @@ public class LarkToolsTests
             ApprovalActionResponse = """{"code":0,"data":{}}""",
         };
         var tool = new LarkApprovalsActTool(client);
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-123",
-        });
+        AgentToolRequestContext.Current = BuildTokenContext("token-123");
 
         try
         {
@@ -1566,7 +1548,7 @@ public class LarkToolsTests
                     metadata[entry.Key] = entry.Value;
             }
 
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(metadata);
+            AgentToolRequestContext.Current = BuildTokenContext(accessToken, metadata);
         }
 
         public void Dispose()
@@ -1574,4 +1556,27 @@ public class LarkToolsTests
             AgentToolRequestContext.Current = _previous;
         }
     }
+
+    private static AgentToolExecutionContext BuildTokenContext(
+        string? accessToken,
+        IReadOnlyDictionary<string, string>? externalMetadata = null)
+    {
+        return AgentToolExecutionContext.Empty with
+        {
+            Credentials = AgentToolCredentials.Empty with
+            {
+                NyxIdAccessToken = string.IsNullOrWhiteSpace(accessToken) ? null : accessToken.Trim(),
+            },
+            Channel = AgentToolChannelContext.Empty with
+            {
+                PlatformMessageId = Resolve(externalMetadata, "channel.platform_message_id"),
+            },
+            ExternalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(externalMetadata),
+        };
+    }
+
+    private static string? Resolve(IReadOnlyDictionary<string, string>? metadata, string key) =>
+        metadata != null && metadata.TryGetValue(key, out var value) && !string.IsNullOrWhiteSpace(value)
+            ? value.Trim()
+            : null;
 }

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/LocalSkillCatalogTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/LocalSkillCatalogTests.cs
@@ -210,10 +210,10 @@ public sealed class LocalSkillCatalogTests
     private static IDisposable BeginTokenScope(string token)
     {
         var previous = AgentToolRequestContext.Current;
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = token,
-        });
+            Credentials = AgentToolCredentials.Empty with { NyxIdAccessToken = token },
+        };
 
         return new RestoreContextScope(previous);
     }

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnSearchSkillsToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnSearchSkillsToolTests.cs
@@ -46,10 +46,7 @@ public sealed class OrnnSearchSkillsToolTests
         var previous = AgentToolRequestContext.Current;
         try
         {
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-            {
-                [LLMRequestMetadataKeys.NyxIdAccessToken] = "access-token",
-            });
+            AgentToolRequestContext.Current = BuildTokenContext("access-token");
             var tool = CreateTool(handler);
 
             var result = await tool.ExecuteAsync("""{ "query": "translate", "scope": "private" }""");
@@ -76,10 +73,7 @@ public sealed class OrnnSearchSkillsToolTests
         var previous = AgentToolRequestContext.Current;
         try
         {
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-            {
-                [LLMRequestMetadataKeys.NyxIdAccessToken] = "access-token",
-            });
+            AgentToolRequestContext.Current = BuildTokenContext("access-token");
             var tool = CreateTool(OrnnTestHttpMessageHandler.ReturningJson(
                 """{ "error": "bad" }""",
                 System.Net.HttpStatusCode.BadGateway));
@@ -101,10 +95,7 @@ public sealed class OrnnSearchSkillsToolTests
         var previous = AgentToolRequestContext.Current;
         try
         {
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-            {
-                [LLMRequestMetadataKeys.NyxIdAccessToken] = "access-token",
-            });
+            AgentToolRequestContext.Current = BuildTokenContext("access-token");
             var tool = CreateTool(handler);
 
             var result = await tool.ExecuteAsync("not-json");
@@ -128,4 +119,10 @@ public sealed class OrnnSearchSkillsToolTests
 
         return new OrnnSearchSkillsTool(client);
     }
+
+    private static AgentToolExecutionContext BuildTokenContext(string token) =>
+        AgentToolExecutionContext.Empty with
+        {
+            Credentials = AgentToolCredentials.Empty with { NyxIdAccessToken = token },
+        };
 }

--- a/test/Aevatar.AI.ToolProviders.Telegram.Tests/TelegramToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Telegram.Tests/TelegramToolsTests.cs
@@ -464,10 +464,10 @@ public class TelegramToolsTests
                 return;
             }
 
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>(StringComparer.Ordinal)
+            AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
             {
-                [LLMRequestMetadataKeys.NyxIdAccessToken] = accessToken,
-            });
+                Credentials = AgentToolCredentials.Empty with { NyxIdAccessToken = accessToken },
+            };
         }
 
         public void Dispose() => AgentToolRequestContext.Current = _previous;

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -62,10 +62,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -149,10 +146,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -215,10 +209,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -286,10 +277,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -363,10 +351,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"list_agents"}""");
@@ -417,10 +402,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -477,10 +459,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -542,10 +521,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -604,10 +580,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -668,10 +641,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             await tool.ExecuteAsync("""{"action":"run_agent","agent_id":"skill-runner-1"}""");
@@ -744,10 +714,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"list_agents"}""");
@@ -790,10 +757,7 @@ public sealed class AgentBuilderToolTests
         tools.Should().ContainSingle();
         tools[0].Name.Should().Be("agent_builder");
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tools[0].ExecuteAsync("""{"action":"list_agents"}""");
@@ -821,6 +785,14 @@ public sealed class AgentBuilderToolTests
             provider.GetRequiredService<IUserAgentCatalogCommandPort>(),
             provider.GetRequiredService<ICallerScopeResolver>(),
             provider.GetService<ILogger<AgentBuilderTool>>());
+    }
+
+    private static void PushNyxToken(string token)
+    {
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
+        {
+            Credentials = AgentToolCredentials.Empty with { NyxIdAccessToken = token },
+        };
     }
 
     private sealed class TestNyxIdApiClientFactory : INyxIdApiClientFactory

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentDeliveryTargetToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentDeliveryTargetToolTests.cs
@@ -83,10 +83,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"list"}""");
@@ -118,10 +115,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"upsert"}""");
@@ -168,10 +162,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -236,10 +227,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"delete","agent_id":"agent-2"}""");
@@ -276,10 +264,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"delete","agent_id":"agent-2","confirm":true}""");
@@ -324,10 +309,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"delete","agent_id":"agent-3","confirm":true}""");
@@ -376,10 +358,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"delete","agent_id":"agent-7","confirm":true}""");
@@ -412,10 +391,7 @@ public sealed class AgentDeliveryTargetToolTests
         tools.Should().ContainSingle();
         tools[0].Name.Should().Be("agent_delivery_targets");
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tools[0].ExecuteAsync("""{"action":"list"}""");
@@ -450,10 +426,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(resolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"list"}""");
@@ -488,10 +461,7 @@ public sealed class AgentDeliveryTargetToolTests
     public async Task ExecuteAsync_Upsert_Requires_ConversationId()
     {
         var (tool, _, _) = BuildBasicHarness();
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"upsert","agent_id":"agent-1"}""");
@@ -508,10 +478,7 @@ public sealed class AgentDeliveryTargetToolTests
     public async Task ExecuteAsync_Upsert_Requires_NyxProviderSlug()
     {
         var (tool, _, _) = BuildBasicHarness();
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -549,10 +516,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(resolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -610,10 +574,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(resolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -641,10 +602,7 @@ public sealed class AgentDeliveryTargetToolTests
     public async Task ExecuteAsync_Delete_RequiresAgentId()
     {
         var (tool, _, _) = BuildBasicHarness();
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"delete"}""");
@@ -692,10 +650,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(resolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+        PushNyxToken("session-token");
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"delete","agent_id":"agent-slow","confirm":true}""");
@@ -748,5 +703,13 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(commandPort);
         services.AddSingleton(resolver);
         return (CreateTool(services), queryPort, commandPort);
+    }
+
+    private static void PushNyxToken(string token)
+    {
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
+        {
+            Credentials = AgentToolCredentials.Empty with { NyxIdAccessToken = token },
+        };
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
@@ -315,14 +315,11 @@ public sealed class ChannelRegistrationToolTests
     private static IDisposable PushNyxToken(string? scopeId = "scope-1")
     {
         var previous = AgentToolRequestContext.Current;
-        var next = new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "test-token",
+            Credentials = AgentToolCredentials.Empty with { NyxIdAccessToken = "test-token" },
+            Caller = AgentToolCallerContext.Empty with { ScopeId = scopeId },
         };
-        if (!string.IsNullOrWhiteSpace(scopeId))
-            next["scope_id"] = scopeId;
-
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(next);
 
         return new ResetMetadataScope(previous);
     }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/UnifyCallerScopeAcceptanceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/UnifyCallerScopeAcceptanceTests.cs
@@ -291,10 +291,10 @@ public sealed class UnifyCallerScopeAcceptanceTests
 
         var resolver = new NyxIdNativeCallerScopeResolver(inner);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "expired-token",
-        });
+            Credentials = AgentToolCredentials.Empty with { NyxIdAccessToken = "expired-token" },
+        };
         try
         {
             await Assert.ThrowsAsync<CallerScopeUnavailableException>(() => resolver.TryResolveAsync());
@@ -311,12 +311,11 @@ public sealed class UnifyCallerScopeAcceptanceTests
         var inner = Substitute.For<INyxIdCurrentUserResolver>();
         var resolver = new ChannelMetadataCallerScopeResolver(inner);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [ChannelMetadataKeys.Platform] = "lark",
-            // no sender_id
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = AgentToolCredentials.Empty with { NyxIdAccessToken = "session-token" },
+            Channel = AgentToolChannelContext.Empty with { Platform = "lark" },
+        };
         try
         {
             await Assert.ThrowsAsync<CallerScopeUnavailableException>(() => resolver.TryResolveAsync());
@@ -333,11 +332,11 @@ public sealed class UnifyCallerScopeAcceptanceTests
         var inner = Substitute.For<INyxIdCurrentUserResolver>();
         var resolver = new ChannelMetadataCallerScopeResolver(inner);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
             // no channel.platform
-        });
+            Credentials = AgentToolCredentials.Empty with { NyxIdAccessToken = "session-token" },
+        };
         try
         {
             (await resolver.TryResolveAsync()).Should().BeNull(

--- a/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
@@ -344,12 +344,6 @@ public sealed class MainnetResponsesEndpointsTests
         var commandPort = new RecordingResponsesAgentToolStatePort();
         var provider = CreateResponsesAevatarToolProvider(commandPort);
 
-        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            [LLMRequestMetadataKeys.ScopeId] = "scope-1",
-            [LLMRequestMetadataKeys.OwnerSubject] = "owner-1",
-            [LLMRequestMetadataKeys.ResponseId] = "resp_1",
-        };
         var previous = AgentToolRequestContext.Current;
         var context = BuildToolProviderContext(
             new ResponsesCallerScope("scope-1", "owner-1", LlmSessionOriginKind.ApiKey),
@@ -357,7 +351,7 @@ public sealed class MainnetResponsesEndpointsTests
             "token");
         try
         {
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(metadata);
+            AgentToolRequestContext.Current = BuildResponsesToolContext();
             var substituteTools = await provider.GetSubstituteToolsAsync(context);
             var todoTool = substituteTools.Single(x => x.Name == "TodoWrite");
             var todoResult = await todoTool.ExecuteAsync(
@@ -390,13 +384,6 @@ public sealed class MainnetResponsesEndpointsTests
             """{"url":"https://example.com/docs","content":"cached"}""");
         var provider = CreateResponsesAevatarToolProvider(commandPort);
 
-        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            [LLMRequestMetadataKeys.ScopeId] = "scope-1",
-            [LLMRequestMetadataKeys.OwnerSubject] = "owner-1",
-            [LLMRequestMetadataKeys.ResponseId] = "resp_1",
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "token",
-        };
         var previous = AgentToolRequestContext.Current;
         var context = BuildToolProviderContext(
             new ResponsesCallerScope("scope-1", "owner-1", LlmSessionOriginKind.ApiKey),
@@ -404,7 +391,7 @@ public sealed class MainnetResponsesEndpointsTests
             "token");
         try
         {
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(metadata);
+            AgentToolRequestContext.Current = BuildResponsesToolContext("token");
             var fetchTool = (await provider.GetSubstituteToolsAsync(context)).Single(x => x.Name == "WebFetch");
             var result = await fetchTool.ExecuteAsync("""{"url":"https://example.com/docs"}""");
 
@@ -430,13 +417,6 @@ public sealed class MainnetResponsesEndpointsTests
             """{"results":[{"title":"cached docs"}]}""");
         var provider = CreateResponsesAevatarToolProvider(commandPort);
 
-        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            [LLMRequestMetadataKeys.ScopeId] = "scope-1",
-            [LLMRequestMetadataKeys.OwnerSubject] = "owner-1",
-            [LLMRequestMetadataKeys.ResponseId] = "resp_1",
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "token",
-        };
         var previous = AgentToolRequestContext.Current;
         var context = BuildToolProviderContext(
             new ResponsesCallerScope("scope-1", "owner-1", LlmSessionOriginKind.ApiKey),
@@ -444,7 +424,7 @@ public sealed class MainnetResponsesEndpointsTests
             "token");
         try
         {
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(metadata);
+            AgentToolRequestContext.Current = BuildResponsesToolContext("token");
             var searchTool = (await provider.GetSubstituteToolsAsync(context)).Single(x => x.Name == "WebSearch");
             var result = await searchTool.ExecuteAsync("""{"query":"aevatar docs","max_results":3}""");
 
@@ -460,6 +440,13 @@ public sealed class MainnetResponsesEndpointsTests
         commandPort.WebTraces[0].Trace.Query.Should().Be("aevatar docs");
         commandPort.WebTraces[0].Trace.CacheHit.Should().BeTrue();
     }
+
+    private static AgentToolExecutionContext BuildResponsesToolContext(string? token = null) =>
+        AgentToolExecutionContext.Empty with
+        {
+            Credentials = AgentToolCredentials.Empty with { NyxIdAccessToken = token },
+            Caller = new AgentToolCallerContext("scope-1", "owner-1", "resp_1"),
+        };
 
     [Fact]
     public async Task ResponsesUserSkillsToolProvider_ShouldBridgeOnlySkillMainlineTools()


### PR DESCRIPTION
## 摘要

Phase 9 r1 共识(structural framing,#1620 split first-slice)实施 #1628。

## 改动

- **`AgentToolExecutionContextMapper.FromMetadata`** 改为 external-only(remove production owned-key promotion)
- **`StreamingToolExecutor` / `ToolCallLoop`** 改用 typed `AgentToolExecutionContext`(不再 metadata-derived control fallback)
- **6+ production caller** 迁移到 typed context:
  - NyxidChat: ChannelConversationTurnRunner / ConversationReplyGenerator
  - Scheduled: SkillRunnerGAgent
  - Mainnet endpoints
- 测试调整匹配新签名(8 test files)

## 文件

23 files changed, +335 / -360 LOC。

## verify

7004 tests pass(本地 full slnx test)。

closes #1628

⟦AI:AUTO-LOOP⟧