### PR TITLE
refactor: impl issue #1626 — no-new-core production-owned-metadata writer/caller cleanup

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -1001,12 +1001,13 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         var replyContent = decision.ReplyContent ?? new MessageContent { Text = decision.ReplyPayload };
         if (decision.RequiresToolExecution)
         {
-            using (AgentToolContextScope.Push(AgentToolExecutionContextMapper.FromMetadata(
-                       await BuildAgentBuilderMetadataAsync(
-                    activity,
-                    inboundEvent,
-                    ResolveUserAccessToken(activity, runtimeContext),
-                    ct))))
+            var metadata = await BuildAgentBuilderMetadataAsync(activity, inboundEvent, ct);
+            var toolContext = BuildAgentBuilderToolContext(
+                activity,
+                inboundEvent,
+                metadata,
+                ResolveUserAccessToken(activity, runtimeContext));
+            using (AgentToolContextScope.Push(toolContext))
             {
                 var tool = ActivatorUtilities.CreateInstance<AgentBuilderTool>(_toolServiceProvider);
                 var toolResult = await tool.ExecuteAsync(decision.ToolArgumentsJson!, ct);
@@ -1388,7 +1389,6 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
     {
         var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
         {
-            ["scope_id"] = inboundEvent.RegistrationScopeId,
             [ChannelMetadataKeys.Platform] = inboundEvent.Platform,
             [ChannelMetadataKeys.SenderId] = inboundEvent.SenderId,
             [ChannelMetadataKeys.SenderName] = inboundEvent.SenderName,
@@ -1426,7 +1426,6 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
     private async Task<IReadOnlyDictionary<string, string>> BuildAgentBuilderMetadataAsync(
         ChatActivity activity,
         ChannelInboundEvent inboundEvent,
-        string? userAccessToken,
         CancellationToken ct)
     {
         var metadata = new Dictionary<string, string>(
@@ -1435,12 +1434,32 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         {
             [ChannelMetadataKeys.ChatType] = ResolveConversationChatType(activity.Conversation),
         };
-        if (!string.IsNullOrWhiteSpace(userAccessToken))
-        {
-            metadata[LLMRequestMetadataKeys.NyxIdAccessToken] = userAccessToken.Trim();
-            metadata[LLMRequestMetadataKeys.NyxIdOrgToken] = userAccessToken.Trim();
-        }
         return metadata;
+    }
+
+    private static AgentToolExecutionContext BuildAgentBuilderToolContext(
+        ChatActivity activity,
+        ChannelInboundEvent inboundEvent,
+        IReadOnlyDictionary<string, string> metadata,
+        string? userAccessToken)
+    {
+        var normalizedToken = NormalizeOptional(userAccessToken);
+        var platformMessageId = NormalizeOptional(activity.TransportExtras?.NyxPlatformMessageId);
+        return AgentToolExecutionContext.Empty with
+        {
+            Credentials = new AgentToolCredentials(normalizedToken, normalizedToken, null),
+            Caller = new AgentToolCallerContext(
+                NormalizeOptional(inboundEvent.RegistrationScopeId),
+                null,
+                null),
+            Channel = new AgentToolChannelContext(
+                NormalizeOptional(inboundEvent.Platform),
+                NormalizeOptional(inboundEvent.SenderId),
+                NormalizeOptional(inboundEvent.RegistrationScopeId),
+                NormalizeOptional(inboundEvent.MessageId),
+                platformMessageId),
+            ExternalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(metadata),
+        };
     }
 
     internal static InboundMessage ToInboundMessage(ChatActivity activity)

--- a/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
@@ -165,7 +165,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         var disableTools = forceDisableTools || replyPlan.DisableTools;
         var tools = await BuildTurnToolsAsync(disableTools, ct);
         var effectiveToolContext = replyPlan.PrimaryControl.ToToolContext(
-            replyPlan.PrimaryToolContext ?? AgentToolExecutionContextMapper.FromMetadata(replyPlan.Primary));
+            WithExternalMetadata(replyPlan.PrimaryToolContext, replyPlan.Primary));
         var externalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(replyPlan.Primary);
         var runtime = BuildRuntime(
             activity,
@@ -256,7 +256,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         IStreamingReplySink? streamingSink,
         CancellationToken ct)
     {
-        var toolContext = llmControl.ToToolContext(baseToolContext ?? AgentToolExecutionContextMapper.FromMetadata(effectiveMetadata));
+        var toolContext = llmControl.ToToolContext(WithExternalMetadata(baseToolContext, effectiveMetadata));
         var externalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(effectiveMetadata);
 
         // Refactor (iter31/cluster-032-chatruntime-taskrun-business-loop):
@@ -531,6 +531,14 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         context == null
             ? null
             : context with { SenderBinding = AgentToolSenderBindingContext.Empty };
+
+    private static AgentToolExecutionContext WithExternalMetadata(
+        AgentToolExecutionContext? context,
+        IReadOnlyDictionary<string, string>? metadata) =>
+        (context ?? AgentToolExecutionContext.Empty) with
+        {
+            ExternalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(metadata),
+        };
 
     private static bool IsChannelTurn(IReadOnlyDictionary<string, string> metadata) =>
         metadata.ContainsKey(ChannelMetadataKeys.Platform) &&

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
@@ -325,7 +325,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         var prompt = BuildExecutionPrompt(now, reason);
         var metadata = await BuildExecutionMetadataAsync(ct);
         var llmControl = await BuildExecutionLlmControlAsync(ct);
-        var toolContext = llmControl.ToToolContext(AgentToolExecutionContextMapper.FromMetadata(metadata));
+        var toolContext = BuildExecutionToolContext(llmControl, metadata);
         var requestId = Guid.NewGuid().ToString("N");
         var content = new StringBuilder();
 
@@ -801,11 +801,28 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         {
             [ChannelMetadataKeys.ConversationId] = State.OutboundConfig?.ConversationId ?? string.Empty,
         };
-        if (!string.IsNullOrWhiteSpace(State.ScopeId))
-            metadata["scope_id"] = State.ScopeId;
 
         return metadata;
     }
+
+    private AgentToolExecutionContext BuildExecutionToolContext(
+        LLMControlContext llmControl,
+        IReadOnlyDictionary<string, string> metadata)
+    {
+        var context = AgentToolExecutionContext.Empty with
+        {
+            Caller = new AgentToolCallerContext(
+                NormalizeOptional(State.ScopeId),
+                null,
+                null),
+            ExternalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(metadata),
+        };
+
+        return llmControl.ToToolContext(context);
+    }
+
+    private static string? NormalizeOptional(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
     private async Task<LLMControlContext> BuildExecutionLlmControlAsync(CancellationToken ct)
     {

--- a/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContextMapper.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContextMapper.cs
@@ -4,7 +4,7 @@ namespace Aevatar.AI.Abstractions.ToolProviders;
 
 // Refactor (iter24/cluster-002-agent-tool-context-generic-metadata-bag):
 //   Old pattern: any tool could parse control keys from Metadata directly.
-//   New principle: legacy metadata decoding is isolated here; tool control flow uses typed context.
+//   New principle: Metadata is external annotation only; tool control flow uses typed context.
 public static class AgentToolExecutionContextMapper
 {
     private static readonly HashSet<string> OwnedControlKeys = new(StringComparer.Ordinal)
@@ -43,13 +43,9 @@ public static class AgentToolExecutionContextMapper
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        if (request.ToolContext is { } typedContext)
-            return request.LlmControl?.ToToolContext(typedContext) ?? typedContext;
-
-        var mapped = FromMetadata(request.Metadata);
-        mapped = request.LlmControl?.ToToolContext(mapped) ?? mapped;
+        var mapped = request.ToolContext ?? AgentToolExecutionContext.Empty;
         var caller = request.CallerContext;
-        return mapped with
+        mapped = mapped with
         {
             Request = new AgentToolRequestIdentity(
                 AgentToolExecutionContext.Normalize(request.RequestId) ?? mapped.Request.RequestId,
@@ -70,6 +66,8 @@ public static class AgentToolExecutionContextMapper
             Routing = request.RoutingContext ?? mapped.Routing,
             ExternalMetadata = StripOwnedControlKeys(request.Metadata),
         };
+
+        return request.LlmControl?.ToToolContext(mapped) ?? mapped;
     }
 
     public static AgentToolExecutionContext FromRequestWithCallId(LLMRequest request, string? callId)
@@ -173,33 +171,10 @@ public static class AgentToolExecutionContextMapper
         if (metadata == null || metadata.Count == 0)
             return AgentToolExecutionContext.Empty;
 
-        var maxToolRounds = TryGet(metadata, LLMRequestMetadataKeys.MaxToolRoundsOverride);
-        return new AgentToolExecutionContext(
-            new AgentToolRequestIdentity(
-                TryGet(metadata, LLMRequestMetadataKeys.RequestId),
-                TryGet(metadata, LLMRequestMetadataKeys.CallId)),
-            new AgentToolCredentials(
-                TryGet(metadata, LLMRequestMetadataKeys.NyxIdAccessToken),
-                TryGet(metadata, LLMRequestMetadataKeys.NyxIdOrgToken),
-                TryGet(metadata, LLMRequestMetadataKeys.SenderNyxIdAccessToken)),
-            new AgentToolCallerContext(
-                TryGet(metadata, LLMRequestMetadataKeys.ScopeId) ?? TryGet(metadata, "scope_id"),
-                TryGet(metadata, LLMRequestMetadataKeys.OwnerSubject),
-                TryGet(metadata, LLMRequestMetadataKeys.ResponseId)),
-            new AgentToolChannelContext(
-                TryGet(metadata, "channel.platform") ?? TryGet(metadata, "platform"),
-                TryGet(metadata, "channel.sender_id") ?? TryGet(metadata, "sender_id") ?? TryGet(metadata, "lark.open_id"),
-                TryGet(metadata, "registration_scope_id"),
-                TryGet(metadata, "channel.message_id") ?? TryGet(metadata, "message_id") ?? TryGet(metadata, "lark.message_id"),
-                TryGet(metadata, "channel.platform_message_id") ?? TryGet(metadata, "platform_message_id")),
-            new AgentToolSenderBindingContext(TryGet(metadata, LLMRequestMetadataKeys.SenderBindingId)),
-            new LLMRequestRoutingContext(
-                TryGet(metadata, LLMRequestMetadataKeys.ModelOverride),
-                TryGet(metadata, LLMRequestMetadataKeys.NyxIdRoutePreference),
-                int.TryParse(maxToolRounds, out var parsedMaxToolRounds) ? parsedMaxToolRounds : null,
-                TryGet(metadata, LLMRequestMetadataKeys.UserMemoryPrompt)),
-            new AgentToolConnectedServicesContext(TryGet(metadata, LLMRequestMetadataKeys.ConnectedServicesContext)),
-            StripOwnedControlKeys(metadata));
+        return AgentToolExecutionContext.Empty with
+        {
+            ExternalMetadata = StripOwnedControlKeys(metadata),
+        };
     }
 
     public static IReadOnlyDictionary<string, string> StripOwnedControlKeys(IReadOnlyDictionary<string, string>? metadata)
@@ -219,6 +194,4 @@ public static class AgentToolExecutionContextMapper
         return result;
     }
 
-    private static string? TryGet(IReadOnlyDictionary<string, string> metadata, string key) =>
-        metadata.TryGetValue(key, out var value) ? AgentToolExecutionContext.Normalize(value) : null;
 }

--- a/src/Aevatar.AI.Core/Tools/StreamingToolExecutor.cs
+++ b/src/Aevatar.AI.Core/Tools/StreamingToolExecutor.cs
@@ -46,7 +46,12 @@ public sealed class StreamingToolExecutor
         _toolMiddlewares = toolMiddlewares ?? [];
         _toolContext = toolContext
             ?? AgentToolRequestContext.Current
-            ?? AgentToolExecutionContextMapper.FromMetadata(requestMetadata);
+            ?? (requestMetadata is { Count: > 0 }
+                ? AgentToolExecutionContext.Empty with
+                {
+                    ExternalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(requestMetadata),
+                }
+                : null);
     }
 
     public ExecutionState CreateExecutionState() => new();

--- a/src/Aevatar.AI.Core/Tools/ToolCallLoop.cs
+++ b/src/Aevatar.AI.Core/Tools/ToolCallLoop.cs
@@ -275,7 +275,11 @@ public sealed class ToolCallLoop
         IReadOnlyDictionary<string, string>? metadata,
         CancellationToken ct)
     {
-        using var _ = AgentToolContextScope.Push(AgentToolExecutionContextMapper.FromMetadata(metadata));
+        var context = AgentToolExecutionContext.Empty with
+        {
+            ExternalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(metadata),
+        };
+        using var _ = AgentToolContextScope.Push(context);
         await ExecuteToolCallsCoreAsync(toolCalls, messages, ct);
     }
 

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ChatCompletionsCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ChatCompletionsCommandFacade.cs
@@ -25,8 +25,6 @@ public sealed class ChatCompletionsCommandFacade(
     IResponsesDirectToolPlanService directToolPlanService,
     ILogger<ChatCompletionsCommandFacade> logger) : IChatCompletionsCommandFacade
 {
-    private const string RegistrationScopeMetadataKey = "scope_id";
-
     public async Task<ChatCompletionsCreateCommandResult> CreateAsync(
         ChatCompletionsCommandRequest request,
         ResponsesCallerScopeResolutionContext callerScopeContext,
@@ -355,16 +353,11 @@ public sealed class ChatCompletionsCommandFacade(
         ResponsesToolClassification toolClassification,
         AgentToolExecutionContext toolContext)
     {
-        var llmMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            [LLMRequestMetadataKeys.RequestId] = normalized.CompletionId,
-            [RegistrationScopeMetadataKey] = callerScope.ScopeId,
-        };
         return new LLMRequest
         {
             Messages = [.. normalized.ChatMessages],
             RequestId = normalized.CompletionId,
-            Metadata = llmMetadata,
+            Metadata = new Dictionary<string, string>(StringComparer.Ordinal),
             CallerContext = new LLMRequestCallerContext(
                 callerScope.ScopeId,
                 callerScope.OwnerSubject,

--- a/src/platform/Aevatar.GAgentService.Application/Responses/MessagesCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/MessagesCommandFacade.cs
@@ -28,8 +28,6 @@ public sealed class MessagesCommandFacade(
     IResponsesDirectToolPlanService directToolPlanService,
     ILogger<MessagesCommandFacade> logger) : IMessagesCommandFacade
 {
-    private const string RegistrationScopeMetadataKey = "scope_id";
-
     public async Task<MessagesCreateCommandResult> CreateAsync(
         MessagesCommandRequest request,
         ResponsesCallerScopeResolutionContext callerScopeContext,
@@ -333,16 +331,11 @@ public sealed class MessagesCommandFacade(
         ResponsesToolClassification toolClassification,
         AgentToolExecutionContext toolContext)
     {
-        var llmMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            [LLMRequestMetadataKeys.RequestId] = normalized.MessageId,
-            [RegistrationScopeMetadataKey] = callerScope.ScopeId,
-        };
         return new LLMRequest
         {
             Messages = [.. normalized.ChatMessages],
             RequestId = normalized.MessageId,
-            Metadata = llmMetadata,
+            Metadata = new Dictionary<string, string>(StringComparer.Ordinal),
             CallerContext = new LLMRequestCallerContext(
                 callerScope.ScopeId,
                 callerScope.OwnerSubject,

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandFacade.cs
@@ -32,8 +32,6 @@ public sealed class ResponsesCommandFacade(
     IResponsesDirectToolPlanService directToolPlanService,
     ILogger<ResponsesCommandFacade> logger) : IResponsesCommandFacade
 {
-    private const string RegistrationScopeMetadataKey = "scope_id";
-
     public async Task<ResponsesCreateCommandResult> CreateAsync(
         ResponsesCommandRequest request,
         ResponsesCallerScopeResolutionContext callerScopeContext,
@@ -479,16 +477,11 @@ public sealed class ResponsesCommandFacade(
         ResponsesToolClassification toolClassification,
         AgentToolExecutionContext toolContext)
     {
-        var llmMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            [LLMRequestMetadataKeys.RequestId] = normalized.ResponseId,
-            [RegistrationScopeMetadataKey] = callerScope.ScopeId,
-        };
         return new LLMRequest
         {
             Messages = BuildLlmMessages(normalized, previousSnapshot),
             RequestId = normalized.ResponseId,
-            Metadata = llmMetadata,
+            Metadata = new Dictionary<string, string>(StringComparer.Ordinal),
             CallerContext = new LLMRequestCallerContext(
                 callerScope.ScopeId,
                 callerScope.OwnerSubject,

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
@@ -588,7 +588,7 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
             {
                 Messages = [.. messages],
                 RequestId = command.ResponseId,
-                Metadata = BuildProviderMetadata(command),
+                Metadata = new Dictionary<string, string>(StringComparer.Ordinal),
                 CallerContext = new LLMRequestCallerContext(
                     command.ScopeId,
                     command.OwnerSubject,
@@ -831,13 +831,6 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
             new LLMRequestRoutingContext(null, NormalizeOptional(command.RoutePreference), null, null),
             AgentToolConnectedServicesContext.Empty,
             new Dictionary<string, string>(StringComparer.Ordinal));
-
-    private static IReadOnlyDictionary<string, string> BuildProviderMetadata(LlmRunRequested command) =>
-        new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            [LLMRequestMetadataKeys.RequestId] = command.ResponseId,
-            ["scope_id"] = command.ScopeId,
-        };
 
     private static ChatMessage ToChatMessage(LlmSessionRuntimeChatMessage message) =>
         new()

--- a/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
+++ b/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
@@ -46,12 +46,12 @@ public sealed class AgentToolExecutionContextMapperTests
         var context = AgentToolExecutionContextMapper.FromRequest(request);
 
         context.Request.RequestId.Should().Be("typed-request");
-        context.Request.CallId.Should().Be("legacy-call");
+        context.Request.CallId.Should().BeNull();
         context.Caller.ScopeId.Should().Be("typed-scope");
         context.Caller.OwnerSubject.Should().Be("typed-owner");
         context.Caller.ResponseId.Should().Be("typed-response");
         context.Credentials.NyxIdAccessToken.Should().Be("typed-access");
-        context.Credentials.NyxIdOrgToken.Should().Be("legacy-org");
+        context.Credentials.NyxIdOrgToken.Should().BeNull();
         context.Routing.ModelOverride.Should().Be("typed-model");
         context.Routing.NyxIdRoutePreference.Should().Be("typed-route");
         context.Routing.MaxToolRoundsOverride.Should().Be(9);
@@ -61,35 +61,50 @@ public sealed class AgentToolExecutionContextMapperTests
     }
 
     [Fact]
-    public void FromMetadata_WhenChannelCanonicalKeysAreAbsent_ShouldMapLegacyAliases()
+    public void FromMetadata_WhenOwnedControlKeysArePresent_ShouldPreserveOnlyExternalAnnotations()
     {
         var context = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>(StringComparer.Ordinal)
         {
+            [LLMRequestMetadataKeys.RequestId] = "legacy-request",
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "legacy-token",
+            [LLMRequestMetadataKeys.NyxIdRoutePreference] = "legacy-route",
+            ["scope_id"] = "scope-legacy",
             ["platform"] = "lark",
             ["sender_id"] = "ou-legacy",
             ["registration_scope_id"] = "scope-legacy",
             ["message_id"] = "msg-legacy",
             ["platform_message_id"] = "platform-msg-legacy",
+            ["external-trace"] = "trace-1",
         });
 
-        context.Channel.Platform.Should().Be("lark");
-        context.Channel.SenderId.Should().Be("ou-legacy");
-        context.Channel.RegistrationScopeId.Should().Be("scope-legacy");
-        context.Channel.MessageId.Should().Be("msg-legacy");
-        context.Channel.PlatformMessageId.Should().Be("platform-msg-legacy");
+        context.Request.Should().Be(AgentToolRequestIdentity.Empty);
+        context.Credentials.Should().Be(AgentToolCredentials.Empty);
+        context.Caller.Should().Be(AgentToolCallerContext.Empty);
+        context.Channel.Should().Be(AgentToolChannelContext.Empty);
+        context.Routing.Should().Be(LLMRequestRoutingContext.Empty);
+        context.ExternalMetadata.Should().ContainSingle().Which.Should().Be(
+            new KeyValuePair<string, string>("external-trace", "trace-1"));
     }
 
     [Fact]
-    public void FromMetadata_WhenLarkAliasesArePresent_ShouldMapSenderAndMessageFallbacks()
+    public void FromMetadata_WhenOnlyExternalAnnotationsArePresent_ShouldPreserveAnnotations()
     {
         var context = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>(StringComparer.Ordinal)
         {
-            ["lark.open_id"] = "ou-lark",
-            ["lark.message_id"] = "msg-lark",
+            ["external-a"] = "one",
+            ["external-b"] = "two",
         });
 
-        context.Channel.SenderId.Should().Be("ou-lark");
-        context.Channel.MessageId.Should().Be("msg-lark");
+        context.Request.Should().Be(AgentToolRequestIdentity.Empty);
+        context.Credentials.Should().Be(AgentToolCredentials.Empty);
+        context.Caller.Should().Be(AgentToolCallerContext.Empty);
+        context.Channel.Should().Be(AgentToolChannelContext.Empty);
+        context.Routing.Should().Be(LLMRequestRoutingContext.Empty);
+        context.ExternalMetadata.Should().BeEquivalentTo(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["external-a"] = "one",
+            ["external-b"] = "two",
+        });
     }
 
     [Fact]
@@ -146,7 +161,7 @@ public sealed class AgentToolExecutionContextMapperTests
     [InlineData("")]
     [InlineData("   ")]
     [InlineData("not-a-number")]
-    public void FromMetadata_WhenMaxToolRoundsOverrideIsInvalid_ShouldLeaveTypedOverrideUnset(string maxRounds)
+    public void FromMetadata_WhenMaxToolRoundsOverrideIsPresent_ShouldTreatItAsOwnedControlKey(string maxRounds)
     {
         var context = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>(StringComparer.Ordinal)
         {
@@ -154,6 +169,7 @@ public sealed class AgentToolExecutionContextMapperTests
         });
 
         context.Routing.MaxToolRoundsOverride.Should().BeNull();
+        context.ExternalMetadata.Should().BeEmpty();
     }
 
     [Fact]
@@ -194,6 +210,9 @@ public sealed class AgentToolExecutionContextMapperTests
             .Where(static path => !path.EndsWith(
                 Path.Combine("ToolProviders", "AgentToolRequestContext.cs"),
                 StringComparison.Ordinal))
+            .Where(static path => !path.EndsWith(
+                Path.Combine("ToolProviders", "AgentToolExecutionContextMapper.cs"),
+                StringComparison.Ordinal))
             .Order(StringComparer.Ordinal)
             .ToArray();
 
@@ -206,6 +225,7 @@ public sealed class AgentToolExecutionContextMapperTests
         source.Should().NotContain("AgentToolRequestContext.CurrentMetadata");
         source.Should().NotContain("AgentToolRequestContext.TryGet(");
         source.Should().NotContain(".ToLegacyMetadata(");
+        source.Should().NotContain("AgentToolExecutionContextMapper.FromMetadata(");
     }
 
     private static string FindRepositoryRoot()

--- a/test/Aevatar.AI.Tests/NyxIdApiClientCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdApiClientCoverageTests.cs
@@ -387,10 +387,10 @@ public sealed class NyxIdApiClientCoverageTests
                 new HttpClient(handler),
                 NullLogger<NyxIdApiClient>.Instance);
             var tool = new NyxIdLlmStatusTool(client);
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+            AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
             {
-                [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-1",
-            });
+                Credentials = new AgentToolCredentials("token-1", null, null),
+            };
 
             var response = await tool.ExecuteAsync("{}", CancellationToken.None);
 

--- a/test/Aevatar.AI.Tests/NyxIdCodeExecuteToolTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdCodeExecuteToolTests.cs
@@ -101,13 +101,11 @@ public class NyxIdCodeExecuteToolTests
 
     private static void SetMetadata(string token, string? servicesContext)
     {
-        var metadata = new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = token,
+            Credentials = new AgentToolCredentials(token, null, null),
+            ConnectedServices = new AgentToolConnectedServicesContext(servicesContext),
         };
-        if (servicesContext is not null)
-            metadata[LLMRequestMetadataKeys.ConnectedServicesContext] = servicesContext;
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(metadata);
     }
 
     private static void ClearMetadata()

--- a/test/Aevatar.AI.Tests/NyxIdRelayAndPairingTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdRelayAndPairingTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Text;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.AI.ToolProviders.NyxId.Tools;
 using Aevatar.GAgents.NyxidChat;
@@ -214,14 +215,14 @@ public class NyxIdChannelBotsToolTests
 
     private static void SetFakeToken()
     {
-        var key = Aevatar.AI.Abstractions.LLMProviders.LLMRequestMetadataKeys.NyxIdAccessToken;
-        Aevatar.AI.Abstractions.ToolProviders.AgentToolRequestContext.Current =
-            Aevatar.AI.Abstractions.ToolProviders.AgentToolExecutionContextMapper.FromMetadata(
-                new Dictionary<string, string> { [key] = "fake-token" });
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
+        {
+            Credentials = new AgentToolCredentials("fake-token", null, null),
+        };
     }
 
     private static void ClearToken() =>
-        Aevatar.AI.Abstractions.ToolProviders.AgentToolRequestContext.Current = null;
+        AgentToolRequestContext.Current = null;
 
     internal sealed class CaptureHandler : DelegatingHandler
     {

--- a/test/Aevatar.AI.Tests/NyxIdSshExecToolTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdSshExecToolTests.cs
@@ -542,10 +542,10 @@ public class NyxIdSshExecToolTests
 
     private static void SetMetadata(string token)
     {
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = token,
-        });
+            Credentials = new AgentToolCredentials(token, null, null),
+        };
     }
 
     private static void ClearMetadata() => AgentToolRequestContext.Current = null;

--- a/test/Aevatar.AI.Tests/StreamingToolExecutorTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingToolExecutorTests.cs
@@ -353,9 +353,9 @@ public class StreamingToolExecutorTests
     }
 
     [Fact]
-    public async Task TypedContextPropagation_ShouldSetAsyncLocalDuringExecutionAndRestore()
+    public async Task MetadataFallback_ShouldExposeExternalAnnotationsOnlyDuringExecutionAndRestore()
     {
-        string? capturedToken = null;
+        string? capturedToken = "unset";
         string? capturedExternal = null;
         string? capturedCallId = null;
         var tools = new ToolManager();
@@ -369,7 +369,7 @@ public class StreamingToolExecutorTests
 
         var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "typed-secret",
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "metadata-secret",
             ["auth_token"] = "secret-123",
         };
 
@@ -381,7 +381,7 @@ public class StreamingToolExecutorTests
 
         await foreach (var _ in executor.GetRemainingResultsAsync(executionState, CancellationToken.None)) { }
 
-        capturedToken.Should().Be("typed-secret");
+        capturedToken.Should().BeNull();
         capturedExternal.Should().Be("secret-123");
         capturedCallId.Should().Be("tc-1");
         AgentToolRequestContext.Current.Should().BeNull();

--- a/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
+++ b/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
@@ -106,7 +106,7 @@ public class ToolCallLoopTests
     }
 
     [Fact]
-    public void AgentToolExecutionContextMapper_ShouldPromoteOwnedKeysAndKeepExternalMetadataOnly()
+    public void AgentToolExecutionContextMapper_ShouldTreatMetadataAsExternalAnnotationsOnly()
     {
         var context = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>(StringComparer.Ordinal)
         {
@@ -122,15 +122,11 @@ public class ToolCallLoopTests
             ["trace-id"] = "trace-1",
         });
 
-        context.Credentials.NyxIdAccessToken.Should().Be("access-token");
-        context.Credentials.NyxIdOrgToken.Should().Be("org-token");
-        context.Caller.ScopeId.Should().Be("scope-a");
-        context.Channel.Platform.Should().Be("lark");
-        context.Channel.SenderId.Should().Be("ou_1");
-        context.Routing.ModelOverride.Should().Be("model-a");
-        context.Routing.NyxIdRoutePreference.Should().Be("/preferred");
-        context.Routing.MaxToolRoundsOverride.Should().Be(7);
-        context.ConnectedServices.ContextJson.Should().Be("{\"services\":[]}");
+        context.Credentials.Should().Be(AgentToolCredentials.Empty);
+        context.Caller.Should().Be(AgentToolCallerContext.Empty);
+        context.Channel.Should().Be(AgentToolChannelContext.Empty);
+        context.Routing.Should().Be(LLMRequestRoutingContext.Empty);
+        context.ConnectedServices.Should().Be(AgentToolConnectedServicesContext.Empty);
         context.ExternalMetadata.Should().ContainSingle();
         context.ExternalMetadata["trace-id"].Should().Be("trace-1");
     }

--- a/test/Aevatar.AI.ToolProviders.Binding.Tests/BindingToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Binding.Tests/BindingToolsTests.cs
@@ -27,10 +27,10 @@ public class BindingToolsTests
         var tool = new BindingListTool(queryAdapter, options);
 
         // Set scope_id in request context
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            ["scope_id"] = "test-scope"
-        });
+            Caller = new AgentToolCallerContext("test-scope", null, null),
+        };
 
         try
         {
@@ -79,10 +79,10 @@ public class BindingToolsTests
             "svc-1", "Service One", "workflow", "healthy", "actor-1", "actor-1", null, DateTimeOffset.UtcNow));
         var tool = new BindingStatusTool(queryAdapter);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            ["scope_id"] = "test-scope"
-        });
+            Caller = new AgentToolCallerContext("test-scope", null, null),
+        };
 
         try
         {
@@ -110,10 +110,10 @@ public class BindingToolsTests
         var commandPort = new StubCommandPort(captureRequest: r => captured = r);
         var tool = new BindingBindTool(commandPort);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            ["scope_id"] = "scope-1"
-        });
+            Caller = new AgentToolCallerContext("scope-1", null, null),
+        };
 
         try
         {
@@ -143,10 +143,10 @@ public class BindingToolsTests
         var commandPort = new StubCommandPort(captureRequest: r => captured = r);
         var tool = new BindingBindTool(commandPort);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            ["scope_id"] = "scope-2"
-        });
+            Caller = new AgentToolCallerContext("scope-2", null, null),
+        };
 
         try
         {
@@ -180,10 +180,10 @@ public class BindingToolsTests
         var tool = new ScopeWorkflowsUpsertTool(new StubScopeWorkflowCommandPort(
             captureRequest: r => captured = r));
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            ["scope_id"] = "scope-workflows"
-        });
+            Caller = new AgentToolCallerContext("scope-workflows", null, null),
+        };
 
         try
         {
@@ -230,10 +230,10 @@ public class BindingToolsTests
     {
         var tool = new ScopeWorkflowsUpsertTool(new StubScopeWorkflowCommandPort());
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            ["scope_id"] = "scope-workflows"
-        });
+            Caller = new AgentToolCallerContext("scope-workflows", null, null),
+        };
 
         try
         {
@@ -259,10 +259,10 @@ public class BindingToolsTests
         var tool = new ScopeWorkflowsUpsertTool(new StubScopeWorkflowCommandPort(
             exception: new InvalidOperationException("bad request")));
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            ["scope_id"] = "scope-workflows"
-        });
+            Caller = new AgentToolCallerContext("scope-workflows", null, null),
+        };
 
         try
         {
@@ -289,10 +289,10 @@ public class BindingToolsTests
             new StubScopeWorkflowQueryPort(listResult: workflows),
             new BindingToolOptions { MaxListResults = 1 });
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            ["scope_id"] = "scope-workflows"
-        });
+            Caller = new AgentToolCallerContext("scope-workflows", null, null),
+        };
 
         try
         {
@@ -331,10 +331,10 @@ public class BindingToolsTests
             new StubScopeWorkflowQueryPort(exception: new InvalidOperationException("query failed")),
             new BindingToolOptions());
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            ["scope_id"] = "scope-workflows"
-        });
+            Caller = new AgentToolCallerContext("scope-workflows", null, null),
+        };
 
         try
         {
@@ -355,10 +355,10 @@ public class BindingToolsTests
         var tool = new ScopeWorkflowsGetTool(new StubScopeWorkflowQueryPort(
             getResult: BuildWorkflowSummary("scope-workflows", "wf-1")));
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            ["scope_id"] = "scope-workflows"
-        });
+            Caller = new AgentToolCallerContext("scope-workflows", null, null),
+        };
 
         try
         {
@@ -380,10 +380,10 @@ public class BindingToolsTests
     {
         var tool = new ScopeWorkflowsGetTool(new StubScopeWorkflowQueryPort());
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            ["scope_id"] = "scope-workflows"
-        });
+            Caller = new AgentToolCallerContext("scope-workflows", null, null),
+        };
 
         try
         {
@@ -402,10 +402,10 @@ public class BindingToolsTests
     {
         var tool = new ScopeWorkflowsGetTool(new StubScopeWorkflowQueryPort(getResult: null));
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            ["scope_id"] = "scope-workflows"
-        });
+            Caller = new AgentToolCallerContext("scope-workflows", null, null),
+        };
 
         try
         {
@@ -427,10 +427,10 @@ public class BindingToolsTests
         var tool = new ScopeWorkflowsGetTool(new StubScopeWorkflowQueryPort(
             exception: new InvalidOperationException("query failed")));
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            ["scope_id"] = "scope-workflows"
-        });
+            Caller = new AgentToolCallerContext("scope-workflows", null, null),
+        };
 
         try
         {
@@ -473,10 +473,10 @@ public class BindingToolsTests
 
         var tool = new BindingUnbindTool(unbindAdapter);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            ["scope_id"] = "scope-unbind"
-        });
+            Caller = new AgentToolCallerContext("scope-unbind", null, null),
+        };
 
         try
         {

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
@@ -20,10 +20,10 @@ public class LarkToolsTests
             SendResponse = """{"code":0,"data":{"message_id":"om_123","chat_id":"oc_456","create_time":"1730000000"}}""",
         };
         var tool = new LarkMessagesSendTool(client);
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-123",
-        });
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
+            {
+                Credentials = new AgentToolCredentials("token-123", null, null),
+            };
 
         try
         {
@@ -692,10 +692,10 @@ public class LarkToolsTests
                 """,
         };
         var tool = new LarkChatsLookupTool(client);
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-123",
-        });
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
+            {
+                Credentials = new AgentToolCredentials("token-123", null, null),
+            };
 
         try
         {
@@ -786,10 +786,10 @@ public class LarkToolsTests
                 """,
         };
         var tool = new LarkSheetsAppendRowsTool(client);
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-123",
-        });
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
+            {
+                Credentials = new AgentToolCredentials("token-123", null, null),
+            };
 
         try
         {
@@ -891,10 +891,10 @@ public class LarkToolsTests
                 """,
         };
         var tool = new LarkApprovalsListTool(client);
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-123",
-        });
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
+            {
+                Credentials = new AgentToolCredentials("token-123", null, null),
+            };
 
         try
         {
@@ -996,10 +996,10 @@ public class LarkToolsTests
     public async Task LarkApprovalsActTool_ValidatesTransferTarget()
     {
         var tool = new LarkApprovalsActTool(new StubLarkNyxClient());
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-123",
-        });
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
+            {
+                Credentials = new AgentToolCredentials("token-123", null, null),
+            };
 
         try
         {
@@ -1020,10 +1020,10 @@ public class LarkToolsTests
             ApprovalActionResponse = """{"code":0,"data":{}}""",
         };
         var tool = new LarkApprovalsActTool(client);
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-123",
-        });
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
+            {
+                Credentials = new AgentToolCredentials("token-123", null, null),
+            };
 
         try
         {
@@ -1557,16 +1557,11 @@ public class LarkToolsTests
                 return;
             }
 
-            var metadata = new Dictionary<string, string>(StringComparer.Ordinal);
-            if (!string.IsNullOrWhiteSpace(accessToken))
-                metadata[LLMRequestMetadataKeys.NyxIdAccessToken] = accessToken;
-            if (extraMetadata != null)
+            AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
             {
-                foreach (var entry in extraMetadata)
-                    metadata[entry.Key] = entry.Value;
-            }
-
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(metadata);
+                Credentials = new AgentToolCredentials(accessToken, null, null),
+                ExternalMetadata = extraMetadata ?? new Dictionary<string, string>(StringComparer.Ordinal),
+            };
         }
 
         public void Dispose()

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/LocalSkillCatalogTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/LocalSkillCatalogTests.cs
@@ -210,10 +210,10 @@ public sealed class LocalSkillCatalogTests
     private static IDisposable BeginTokenScope(string token)
     {
         var previous = AgentToolRequestContext.Current;
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = token,
-        });
+            Credentials = new AgentToolCredentials(token, null, null),
+        };
 
         return new RestoreContextScope(previous);
     }

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnSearchSkillsToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnSearchSkillsToolTests.cs
@@ -46,10 +46,10 @@ public sealed class OrnnSearchSkillsToolTests
         var previous = AgentToolRequestContext.Current;
         try
         {
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+            AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
             {
-                [LLMRequestMetadataKeys.NyxIdAccessToken] = "access-token",
-            });
+                Credentials = new AgentToolCredentials("access-token", null, null),
+            };
             var tool = CreateTool(handler);
 
             var result = await tool.ExecuteAsync("""{ "query": "translate", "scope": "private" }""");
@@ -76,10 +76,10 @@ public sealed class OrnnSearchSkillsToolTests
         var previous = AgentToolRequestContext.Current;
         try
         {
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+            AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
             {
-                [LLMRequestMetadataKeys.NyxIdAccessToken] = "access-token",
-            });
+                Credentials = new AgentToolCredentials("access-token", null, null),
+            };
             var tool = CreateTool(OrnnTestHttpMessageHandler.ReturningJson(
                 """{ "error": "bad" }""",
                 System.Net.HttpStatusCode.BadGateway));
@@ -101,10 +101,10 @@ public sealed class OrnnSearchSkillsToolTests
         var previous = AgentToolRequestContext.Current;
         try
         {
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+            AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
             {
-                [LLMRequestMetadataKeys.NyxIdAccessToken] = "access-token",
-            });
+                Credentials = new AgentToolCredentials("access-token", null, null),
+            };
             var tool = CreateTool(handler);
 
             var result = await tool.ExecuteAsync("not-json");

--- a/test/Aevatar.AI.ToolProviders.Telegram.Tests/TelegramToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Telegram.Tests/TelegramToolsTests.cs
@@ -464,10 +464,10 @@ public class TelegramToolsTests
                 return;
             }
 
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>(StringComparer.Ordinal)
+            AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
             {
-                [LLMRequestMetadataKeys.NyxIdAccessToken] = accessToken,
-            });
+                Credentials = new AgentToolCredentials(accessToken, null, null),
+            };
         }
 
         public void Dispose() => AgentToolRequestContext.Current = _previous;

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -62,10 +62,10 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -149,10 +149,10 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -215,10 +215,10 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -286,10 +286,10 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -363,10 +363,10 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"list_agents"}""");
@@ -417,10 +417,10 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -477,10 +477,10 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -542,10 +542,10 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -604,10 +604,10 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -668,10 +668,10 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             await tool.ExecuteAsync("""{"action":"run_agent","agent_id":"skill-runner-1"}""");
@@ -744,10 +744,10 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"list_agents"}""");
@@ -790,10 +790,10 @@ public sealed class AgentBuilderToolTests
         tools.Should().ContainSingle();
         tools[0].Name.Should().Be("agent_builder");
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tools[0].ExecuteAsync("""{"action":"list_agents"}""");

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentDeliveryTargetToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentDeliveryTargetToolTests.cs
@@ -83,10 +83,10 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"list"}""");
@@ -118,10 +118,10 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"upsert"}""");
@@ -168,10 +168,10 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -236,10 +236,10 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"delete","agent_id":"agent-2"}""");
@@ -276,10 +276,10 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"delete","agent_id":"agent-2","confirm":true}""");
@@ -324,10 +324,10 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"delete","agent_id":"agent-3","confirm":true}""");
@@ -376,10 +376,10 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"delete","agent_id":"agent-7","confirm":true}""");
@@ -412,10 +412,10 @@ public sealed class AgentDeliveryTargetToolTests
         tools.Should().ContainSingle();
         tools[0].Name.Should().Be("agent_delivery_targets");
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tools[0].ExecuteAsync("""{"action":"list"}""");
@@ -450,10 +450,10 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(resolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"list"}""");
@@ -488,10 +488,10 @@ public sealed class AgentDeliveryTargetToolTests
     public async Task ExecuteAsync_Upsert_Requires_ConversationId()
     {
         var (tool, _, _) = BuildBasicHarness();
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"upsert","agent_id":"agent-1"}""");
@@ -508,10 +508,10 @@ public sealed class AgentDeliveryTargetToolTests
     public async Task ExecuteAsync_Upsert_Requires_NyxProviderSlug()
     {
         var (tool, _, _) = BuildBasicHarness();
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -549,10 +549,10 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(resolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -610,10 +610,10 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(resolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""
@@ -641,10 +641,10 @@ public sealed class AgentDeliveryTargetToolTests
     public async Task ExecuteAsync_Delete_RequiresAgentId()
     {
         var (tool, _, _) = BuildBasicHarness();
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"delete"}""");
@@ -692,10 +692,10 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(resolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             var result = await tool.ExecuteAsync("""{"action":"delete","agent_id":"agent-slow","confirm":true}""");

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
@@ -315,14 +315,11 @@ public sealed class ChannelRegistrationToolTests
     private static IDisposable PushNyxToken(string? scopeId = "scope-1")
     {
         var previous = AgentToolRequestContext.Current;
-        var next = new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "test-token",
+            Credentials = new AgentToolCredentials("test-token", null, null),
+            Caller = new AgentToolCallerContext(scopeId, null, null),
         };
-        if (!string.IsNullOrWhiteSpace(scopeId))
-            next["scope_id"] = scopeId;
-
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(next);
 
         return new ResetMetadataScope(previous);
     }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/UnifyCallerScopeAcceptanceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/UnifyCallerScopeAcceptanceTests.cs
@@ -291,10 +291,10 @@ public sealed class UnifyCallerScopeAcceptanceTests
 
         var resolver = new NyxIdNativeCallerScopeResolver(inner);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "expired-token",
-        });
+            Credentials = new AgentToolCredentials("expired-token", null, null),
+        };
         try
         {
             await Assert.ThrowsAsync<CallerScopeUnavailableException>(() => resolver.TryResolveAsync());
@@ -311,12 +311,11 @@ public sealed class UnifyCallerScopeAcceptanceTests
         var inner = Substitute.For<INyxIdCurrentUserResolver>();
         var resolver = new ChannelMetadataCallerScopeResolver(inner);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [ChannelMetadataKeys.Platform] = "lark",
-            // no sender_id
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+            Channel = new AgentToolChannelContext("lark", null, null, null, null),
+        };
         try
         {
             await Assert.ThrowsAsync<CallerScopeUnavailableException>(() => resolver.TryResolveAsync());
@@ -333,11 +332,10 @@ public sealed class UnifyCallerScopeAcceptanceTests
         var inner = Substitute.For<INyxIdCurrentUserResolver>();
         var resolver = new ChannelMetadataCallerScopeResolver(inner);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
         {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-            // no channel.platform
-        });
+            Credentials = new AgentToolCredentials("session-token", null, null),
+        };
         try
         {
             (await resolver.TryResolveAsync()).Should().BeNull(

--- a/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
@@ -107,7 +107,8 @@ public sealed class MainnetResponsesEndpointsTests
         provider.LastRequest.Temperature.Should().Be(0.2);
         provider.LastRequest.Messages.Should().ContainSingle();
         provider.LastRequest.Messages[0].Content.Should().Be("ping");
-        provider.LastRequest.Metadata.Should().ContainKey(LLMRequestMetadataKeys.RequestId);
+        provider.LastRequest.RequestId.Should().Be(responseId);
+        provider.LastRequest.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.RequestId);
         provider.LastRequest.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.ScopeId);
         provider.LastRequest.CallerContext.Should().Be(new LLMRequestCallerContext(
             "user-1",
@@ -344,12 +345,6 @@ public sealed class MainnetResponsesEndpointsTests
         var commandPort = new RecordingResponsesAgentToolStatePort();
         var provider = CreateResponsesAevatarToolProvider(commandPort);
 
-        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            [LLMRequestMetadataKeys.ScopeId] = "scope-1",
-            [LLMRequestMetadataKeys.OwnerSubject] = "owner-1",
-            [LLMRequestMetadataKeys.ResponseId] = "resp_1",
-        };
         var previous = AgentToolRequestContext.Current;
         var context = BuildToolProviderContext(
             new ResponsesCallerScope("scope-1", "owner-1", LlmSessionOriginKind.ApiKey),
@@ -357,7 +352,7 @@ public sealed class MainnetResponsesEndpointsTests
             "token");
         try
         {
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(metadata);
+            AgentToolRequestContext.Current = context.ToolContext;
             var substituteTools = await provider.GetSubstituteToolsAsync(context);
             var todoTool = substituteTools.Single(x => x.Name == "TodoWrite");
             var todoResult = await todoTool.ExecuteAsync(
@@ -390,13 +385,6 @@ public sealed class MainnetResponsesEndpointsTests
             """{"url":"https://example.com/docs","content":"cached"}""");
         var provider = CreateResponsesAevatarToolProvider(commandPort);
 
-        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            [LLMRequestMetadataKeys.ScopeId] = "scope-1",
-            [LLMRequestMetadataKeys.OwnerSubject] = "owner-1",
-            [LLMRequestMetadataKeys.ResponseId] = "resp_1",
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "token",
-        };
         var previous = AgentToolRequestContext.Current;
         var context = BuildToolProviderContext(
             new ResponsesCallerScope("scope-1", "owner-1", LlmSessionOriginKind.ApiKey),
@@ -404,7 +392,7 @@ public sealed class MainnetResponsesEndpointsTests
             "token");
         try
         {
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(metadata);
+            AgentToolRequestContext.Current = context.ToolContext;
             var fetchTool = (await provider.GetSubstituteToolsAsync(context)).Single(x => x.Name == "WebFetch");
             var result = await fetchTool.ExecuteAsync("""{"url":"https://example.com/docs"}""");
 
@@ -430,13 +418,6 @@ public sealed class MainnetResponsesEndpointsTests
             """{"results":[{"title":"cached docs"}]}""");
         var provider = CreateResponsesAevatarToolProvider(commandPort);
 
-        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            [LLMRequestMetadataKeys.ScopeId] = "scope-1",
-            [LLMRequestMetadataKeys.OwnerSubject] = "owner-1",
-            [LLMRequestMetadataKeys.ResponseId] = "resp_1",
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "token",
-        };
         var previous = AgentToolRequestContext.Current;
         var context = BuildToolProviderContext(
             new ResponsesCallerScope("scope-1", "owner-1", LlmSessionOriginKind.ApiKey),
@@ -444,7 +425,7 @@ public sealed class MainnetResponsesEndpointsTests
             "token");
         try
         {
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(metadata);
+            AgentToolRequestContext.Current = context.ToolContext;
             var searchTool = (await provider.GetSubstituteToolsAsync(context)).Single(x => x.Name == "WebSearch");
             var result = await searchTool.ExecuteAsync("""{"query":"aevatar docs","max_results":3}""");
 

--- a/test/Aevatar.Hosting.Tests/WebFetchUrlGuardTests.cs
+++ b/test/Aevatar.Hosting.Tests/WebFetchUrlGuardTests.cs
@@ -164,10 +164,10 @@ public sealed class WebFetchUrlGuardTests
         var previous = AgentToolRequestContext.Current;
         try
         {
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+            AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
             {
-                [LLMRequestMetadataKeys.NyxIdAccessToken] = "secret-token",
-            });
+                Credentials = new AgentToolCredentials("secret-token", null, null),
+            };
 
             var result = await tool.ExecuteAsync("""{"url":"http://8.8.8.8/"}""");
 


### PR DESCRIPTION
## 摘要

Phase 9 r2 共识(hybrid framing,3/3 unanimous)实施 #1626。

## 改动

- **`AgentToolExecutionContextMapper.FromRequest`**:停止从 Metadata backfill 缺失 typed control facts
- **Responses/Messages/ChatCompletions Facades**:不再写 `LLMRequestMetadataKeys.RequestId` + `scope_id` 进 `LLMRequest.Metadata`
- **`LlmSessionGAgent.BuildProviderMetadata`**:不再 emit internal control authority(只保留 external telemetry)
- **NyxidChat / Scheduled production callers**:迁移到 typed `AgentToolExecutionContext`
- 测试调整 8 files

## 文件

28 files changed, +332 / -348 LOC。

## verify

6852 tests pass(本地 full slnx test)。

## 注

与 #1633(impl #1628)文件重叠;两个 PR 同 owner #1620 split,合并顺序需协调。

closes #1626

⟦AI:AUTO-LOOP⟧