### PR TITLE
refactor: impl issue #355 — Phase 9 r1 delete framing 共识

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/ChannelBotRegistrationStartupService.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/ChannelBotRegistrationStartupService.cs
@@ -43,12 +43,6 @@ internal sealed class ChannelBotRegistrationStartupService : IHostedService
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(
-                ex,
-                "Channel bot registration projection activation failed; registrations may not be visible until activation is re-triggered");
-        }
     }
 
     public Task StopAsync(CancellationToken ct) => Task.CompletedTask;

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelBotRegistrationStartupServiceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelBotRegistrationStartupServiceTests.cs
@@ -38,7 +38,7 @@ public sealed class ChannelBotRegistrationStartupServiceTests
     }
 
     [Fact]
-    public async Task StartAsync_WhenActivationFails_DispatchesOnlyOneActivationAttempt()
+    public async Task StartAsync_WhenActivationFails_PropagatesFailure_AndAttemptsOnce()
     {
         var activationService = Substitute.For<IProjectionScopeActivationService<ChannelBotRegistrationMaterializationRuntimeLease>>();
         activationService.EnsureAsync(Arg.Any<ProjectionScopeStartRequest>(), Arg.Any<CancellationToken>())
@@ -49,7 +49,10 @@ public sealed class ChannelBotRegistrationStartupServiceTests
             projectionActivator,
             NullLogger<ChannelBotRegistrationStartupService>.Instance);
 
-        await startupService.StartAsync(CancellationToken.None);
+        await startupService.Invoking(service => service.StartAsync(CancellationToken.None))
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("boom");
 
         await activationService.Received(1).EnsureAsync(
             Arg.Is<ProjectionScopeStartRequest>(request =>


### PR DESCRIPTION
## 摘要

Phase 9 r1 3/3 unanimous **delete** framing 共识(see issue #355)。

- **改动**:2 文件(+5/-8 LOC)
- **本地验证**:`dotnet test aevatar.slnx` → 7019 tests pass
- **scope**:`agents/Aevatar.GAgents.Channel.Runtime/ChannelBotRegistrationStartupService.cs` + 对应 test

closes #355

🤖 Auto-loop / codex-refactor-loop Phase 9 consensus

⟦AI:AUTO-LOOP⟧