### PR TITLE
refactor: FromMetadata reader external-only (#1621 first-slice)

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -1001,12 +1001,12 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         var replyContent = decision.ReplyContent ?? new MessageContent { Text = decision.ReplyPayload };
         if (decision.RequiresToolExecution)
         {
-            using (AgentToolContextScope.Push(AgentToolExecutionContextMapper.FromMetadata(
-                       await BuildAgentBuilderMetadataAsync(
+            var metadata = await BuildAgentBuilderMetadataAsync(
                     activity,
                     inboundEvent,
                     ResolveUserAccessToken(activity, runtimeContext),
-                    ct))))
+                    ct);
+            using (AgentToolContextScope.Push(BuildAgentBuilderToolContext(metadata)))
             {
                 var tool = ActivatorUtilities.CreateInstance<AgentBuilderTool>(_toolServiceProvider);
                 var toolResult = await tool.ExecuteAsync(decision.ToolArgumentsJson!, ct);
@@ -1421,6 +1421,32 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
             metadata[ChannelMetadataKeys.LarkChatId] = larkChatId;
 
         return metadata;
+    }
+
+    private static AgentToolExecutionContext BuildAgentBuilderToolContext(
+        IReadOnlyDictionary<string, string> metadata)
+    {
+        static string? Get(IReadOnlyDictionary<string, string> source, string key) =>
+            source.TryGetValue(key, out var value) ? NormalizeOptional(value) : null;
+
+        return AgentToolExecutionContext.Empty with
+        {
+            Credentials = new AgentToolCredentials(
+                Get(metadata, LLMRequestMetadataKeys.NyxIdAccessToken),
+                Get(metadata, LLMRequestMetadataKeys.NyxIdOrgToken),
+                null),
+            Caller = new AgentToolCallerContext(
+                Get(metadata, "scope_id"),
+                null,
+                null),
+            Channel = new AgentToolChannelContext(
+                Get(metadata, ChannelMetadataKeys.Platform),
+                Get(metadata, ChannelMetadataKeys.SenderId),
+                Get(metadata, "scope_id"),
+                Get(metadata, ChannelMetadataKeys.MessageId),
+                Get(metadata, ChannelMetadataKeys.PlatformMessageId)),
+            ExternalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(metadata),
+        };
     }
 
     private async Task<IReadOnlyDictionary<string, string>> BuildAgentBuilderMetadataAsync(

--- a/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContextMapper.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContextMapper.cs
@@ -4,7 +4,7 @@ namespace Aevatar.AI.Abstractions.ToolProviders;
 
 // Refactor (iter24/cluster-002-agent-tool-context-generic-metadata-bag):
 //   Old pattern: any tool could parse control keys from Metadata directly.
-//   New principle: legacy metadata decoding is isolated here; tool control flow uses typed context.
+//   New principle: Metadata contributes only external annotations; tool control flow uses typed context.
 public static class AgentToolExecutionContextMapper
 {
     private static readonly HashSet<string> OwnedControlKeys = new(StringComparer.Ordinal)
@@ -178,33 +178,10 @@ public static class AgentToolExecutionContextMapper
         if (metadata == null || metadata.Count == 0)
             return AgentToolExecutionContext.Empty;
 
-        var maxToolRounds = TryGet(metadata, LLMRequestMetadataKeys.MaxToolRoundsOverride);
-        return new AgentToolExecutionContext(
-            new AgentToolRequestIdentity(
-                TryGet(metadata, LLMRequestMetadataKeys.RequestId),
-                TryGet(metadata, LLMRequestMetadataKeys.CallId)),
-            new AgentToolCredentials(
-                TryGet(metadata, LLMRequestMetadataKeys.NyxIdAccessToken),
-                TryGet(metadata, LLMRequestMetadataKeys.NyxIdOrgToken),
-                TryGet(metadata, LLMRequestMetadataKeys.SenderNyxIdAccessToken)),
-            new AgentToolCallerContext(
-                TryGet(metadata, LLMRequestMetadataKeys.ScopeId) ?? TryGet(metadata, "scope_id"),
-                TryGet(metadata, LLMRequestMetadataKeys.OwnerSubject),
-                TryGet(metadata, LLMRequestMetadataKeys.ResponseId)),
-            new AgentToolChannelContext(
-                TryGet(metadata, "channel.platform") ?? TryGet(metadata, "platform"),
-                TryGet(metadata, "channel.sender_id") ?? TryGet(metadata, "sender_id") ?? TryGet(metadata, "lark.open_id"),
-                TryGet(metadata, "registration_scope_id"),
-                TryGet(metadata, "channel.message_id") ?? TryGet(metadata, "message_id") ?? TryGet(metadata, "lark.message_id"),
-                TryGet(metadata, "channel.platform_message_id") ?? TryGet(metadata, "platform_message_id")),
-            new AgentToolSenderBindingContext(TryGet(metadata, LLMRequestMetadataKeys.SenderBindingId)),
-            new LLMRequestRoutingContext(
-                TryGet(metadata, LLMRequestMetadataKeys.ModelOverride),
-                TryGet(metadata, LLMRequestMetadataKeys.NyxIdRoutePreference),
-                int.TryParse(maxToolRounds, out var parsedMaxToolRounds) ? parsedMaxToolRounds : null,
-                TryGet(metadata, LLMRequestMetadataKeys.UserMemoryPrompt)),
-            new AgentToolConnectedServicesContext(TryGet(metadata, LLMRequestMetadataKeys.ConnectedServicesContext)),
-            StripOwnedControlKeys(metadata));
+        return AgentToolExecutionContext.Empty with
+        {
+            ExternalMetadata = StripOwnedControlKeys(metadata),
+        };
     }
 
     public static IReadOnlyDictionary<string, string> StripOwnedControlKeys(IReadOnlyDictionary<string, string>? metadata)
@@ -224,6 +201,4 @@ public static class AgentToolExecutionContextMapper
         return result;
     }
 
-    private static string? TryGet(IReadOnlyDictionary<string, string> metadata, string key) =>
-        metadata.TryGetValue(key, out var value) ? AgentToolExecutionContext.Normalize(value) : null;
 }

--- a/test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj
+++ b/test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj
@@ -44,6 +44,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\TestAgentToolContexts.cs" Link="TestAgentToolContexts.cs" />
     <Compile Include="..\Shared\ProjectionActivationPlanProviderTestBase.cs" Link="Shared\ProjectionActivationPlanProviderTestBase.cs" />
   </ItemGroup>
 </Project>

--- a/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
+++ b/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
@@ -130,35 +130,80 @@ public sealed class AgentToolExecutionContextMapperTests
     }
 
     [Fact]
-    public void FromMetadata_WhenChannelCanonicalKeysAreAbsent_ShouldMapLegacyAliases()
+    public void FromMetadata_ShouldIgnoreOwnedControlKeysAndKeepExternalMetadata()
     {
         var context = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>(StringComparer.Ordinal)
         {
+            [LLMRequestMetadataKeys.RequestId] = "legacy-request",
+            [LLMRequestMetadataKeys.CallId] = "legacy-call",
+            [LLMRequestMetadataKeys.ScopeId] = "legacy-scope",
+            ["scope_id"] = "legacy-scope-alias",
+            [LLMRequestMetadataKeys.OwnerSubject] = "legacy-owner",
+            [LLMRequestMetadataKeys.ResponseId] = "legacy-response",
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "legacy-access",
+            [LLMRequestMetadataKeys.NyxIdOrgToken] = "legacy-org",
+            [LLMRequestMetadataKeys.SenderNyxIdAccessToken] = "legacy-sender-access",
+            [LLMRequestMetadataKeys.SenderBindingId] = "legacy-binding",
+            [LLMRequestMetadataKeys.ModelOverride] = "legacy-model",
+            [LLMRequestMetadataKeys.NyxIdRoutePreference] = "legacy-route",
+            [LLMRequestMetadataKeys.MaxToolRoundsOverride] = "7",
+            [LLMRequestMetadataKeys.UserMemoryPrompt] = "legacy-memory",
+            [LLMRequestMetadataKeys.ConnectedServicesContext] = """{"services":[]}""",
+            ["channel.platform"] = "canonical-lark",
             ["platform"] = "lark",
+            ["channel.sender_id"] = "ou-canonical",
             ["sender_id"] = "ou-legacy",
             ["registration_scope_id"] = "scope-legacy",
+            ["channel.message_id"] = "msg-canonical",
             ["message_id"] = "msg-legacy",
+            ["channel.platform_message_id"] = "platform-msg-canonical",
             ["platform_message_id"] = "platform-msg-legacy",
+            ["lark.open_id"] = "ou-lark",
+            ["lark.message_id"] = "msg-lark",
+            ["telegram.chat_id"] = "10001",
+            ["trace-id"] = "trace-1",
         });
 
-        context.Channel.Platform.Should().Be("lark");
-        context.Channel.SenderId.Should().Be("ou-legacy");
-        context.Channel.RegistrationScopeId.Should().Be("scope-legacy");
-        context.Channel.MessageId.Should().Be("msg-legacy");
-        context.Channel.PlatformMessageId.Should().Be("platform-msg-legacy");
+        context.Request.RequestId.Should().BeNull();
+        context.Request.CallId.Should().BeNull();
+        context.Caller.ScopeId.Should().BeNull();
+        context.Caller.OwnerSubject.Should().BeNull();
+        context.Caller.ResponseId.Should().BeNull();
+        context.Credentials.NyxIdAccessToken.Should().BeNull();
+        context.Credentials.NyxIdOrgToken.Should().BeNull();
+        context.Credentials.SenderNyxIdAccessToken.Should().BeNull();
+        context.Channel.Platform.Should().BeNull();
+        context.Channel.SenderId.Should().BeNull();
+        context.Channel.RegistrationScopeId.Should().BeNull();
+        context.Channel.MessageId.Should().BeNull();
+        context.Channel.PlatformMessageId.Should().BeNull();
+        context.SenderBinding.BindingId.Should().BeNull();
+        context.Routing.ModelOverride.Should().BeNull();
+        context.Routing.NyxIdRoutePreference.Should().BeNull();
+        context.Routing.MaxToolRoundsOverride.Should().BeNull();
+        context.Routing.UserMemoryPrompt.Should().BeNull();
+        context.ConnectedServices.ContextJson.Should().BeNull();
+        context.ExternalMetadata.Should().ContainSingle();
+        context.ExternalMetadata["trace-id"].Should().Be("trace-1");
     }
 
     [Fact]
-    public void FromMetadata_WhenLarkAliasesArePresent_ShouldMapSenderAndMessageFallbacks()
+    public void FromMetadata_WhenOnlyExternalMetadata_ShouldPreserveExternalAnnotations()
     {
         var context = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>(StringComparer.Ordinal)
         {
-            ["lark.open_id"] = "ou-lark",
-            ["lark.message_id"] = "msg-lark",
+            ["trace-id"] = "trace-1",
+            ["x-client-note"] = "external-note",
         });
 
-        context.Channel.SenderId.Should().Be("ou-lark");
-        context.Channel.MessageId.Should().Be("msg-lark");
+        context.Should().BeEquivalentTo(AgentToolExecutionContext.Empty with
+        {
+            ExternalMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["trace-id"] = "trace-1",
+                ["x-client-note"] = "external-note",
+            },
+        });
     }
 
     [Fact]
@@ -209,20 +254,6 @@ public sealed class AgentToolExecutionContextMapperTests
     public void FromPayload_WhenPayloadIsNull_ShouldReturnEmptyContext()
     {
         AgentToolExecutionContextMapper.FromPayload(null).Should().Be(AgentToolExecutionContext.Empty);
-    }
-
-    [Theory]
-    [InlineData("")]
-    [InlineData("   ")]
-    [InlineData("not-a-number")]
-    public void FromMetadata_WhenMaxToolRoundsOverrideIsInvalid_ShouldLeaveTypedOverrideUnset(string maxRounds)
-    {
-        var context = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            [LLMRequestMetadataKeys.MaxToolRoundsOverride] = maxRounds,
-        });
-
-        context.Routing.MaxToolRoundsOverride.Should().BeNull();
     }
 
     [Fact]

--- a/test/Aevatar.AI.Tests/NyxIdApiClientCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdApiClientCoverageTests.cs
@@ -387,7 +387,7 @@ public sealed class NyxIdApiClientCoverageTests
                 new HttpClient(handler),
                 NullLogger<NyxIdApiClient>.Instance);
             var tool = new NyxIdLlmStatusTool(client);
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+            AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
             {
                 [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-1",
             });

--- a/test/Aevatar.AI.Tests/NyxIdCodeExecuteToolTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdCodeExecuteToolTests.cs
@@ -107,7 +107,7 @@ public class NyxIdCodeExecuteToolTests
         };
         if (servicesContext is not null)
             metadata[LLMRequestMetadataKeys.ConnectedServicesContext] = servicesContext;
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(metadata);
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(metadata);
     }
 
     private static void ClearMetadata()

--- a/test/Aevatar.AI.Tests/NyxIdRelayAndPairingTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdRelayAndPairingTests.cs
@@ -216,7 +216,7 @@ public class NyxIdChannelBotsToolTests
     {
         var key = Aevatar.AI.Abstractions.LLMProviders.LLMRequestMetadataKeys.NyxIdAccessToken;
         Aevatar.AI.Abstractions.ToolProviders.AgentToolRequestContext.Current =
-            Aevatar.AI.Abstractions.ToolProviders.AgentToolExecutionContextMapper.FromMetadata(
+            global::TestAgentToolContexts.FromMetadata(
                 new Dictionary<string, string> { [key] = "fake-token" });
     }
 

--- a/test/Aevatar.AI.Tests/NyxIdSshExecToolTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdSshExecToolTests.cs
@@ -542,7 +542,7 @@ public class NyxIdSshExecToolTests
 
     private static void SetMetadata(string token)
     {
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = token,
         });

--- a/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
+++ b/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
@@ -107,31 +107,45 @@ public class ToolCallLoopTests
     }
 
     [Fact]
-    public void AgentToolExecutionContextMapper_ShouldPromoteOwnedKeysAndKeepExternalMetadataOnly()
+    public void AgentToolExecutionContextMapper_ShouldIgnoreOwnedKeysAndKeepExternalMetadataOnly()
     {
         var context = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>(StringComparer.Ordinal)
         {
+            [LLMRequestMetadataKeys.RequestId] = "request-a",
+            [LLMRequestMetadataKeys.CallId] = "call-a",
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "access-token",
             [LLMRequestMetadataKeys.NyxIdOrgToken] = "org-token",
+            [LLMRequestMetadataKeys.SenderNyxIdAccessToken] = "sender-token",
             [LLMRequestMetadataKeys.ModelOverride] = "model-a",
             [LLMRequestMetadataKeys.NyxIdRoutePreference] = "/preferred",
             [LLMRequestMetadataKeys.MaxToolRoundsOverride] = "7",
+            [LLMRequestMetadataKeys.UserMemoryPrompt] = "memory-a",
             [LLMRequestMetadataKeys.ConnectedServicesContext] = "{\"services\":[]}",
+            [LLMRequestMetadataKeys.OwnerSubject] = "owner-a",
+            [LLMRequestMetadataKeys.ResponseId] = "response-a",
+            [LLMRequestMetadataKeys.SenderBindingId] = "binding-a",
             ["scope_id"] = "scope-a",
             ["channel.platform"] = "lark",
             ["channel.sender_id"] = "ou_1",
             ["trace-id"] = "trace-1",
         });
 
-        context.Credentials.NyxIdAccessToken.Should().Be("access-token");
-        context.Credentials.NyxIdOrgToken.Should().Be("org-token");
-        context.Caller.ScopeId.Should().Be("scope-a");
-        context.Channel.Platform.Should().Be("lark");
-        context.Channel.SenderId.Should().Be("ou_1");
-        context.Routing.ModelOverride.Should().Be("model-a");
-        context.Routing.NyxIdRoutePreference.Should().Be("/preferred");
-        context.Routing.MaxToolRoundsOverride.Should().Be(7);
-        context.ConnectedServices.ContextJson.Should().Be("{\"services\":[]}");
+        context.Request.RequestId.Should().BeNull();
+        context.Request.CallId.Should().BeNull();
+        context.Credentials.NyxIdAccessToken.Should().BeNull();
+        context.Credentials.NyxIdOrgToken.Should().BeNull();
+        context.Credentials.SenderNyxIdAccessToken.Should().BeNull();
+        context.Caller.ScopeId.Should().BeNull();
+        context.Caller.OwnerSubject.Should().BeNull();
+        context.Caller.ResponseId.Should().BeNull();
+        context.Channel.Platform.Should().BeNull();
+        context.Channel.SenderId.Should().BeNull();
+        context.SenderBinding.BindingId.Should().BeNull();
+        context.Routing.ModelOverride.Should().BeNull();
+        context.Routing.NyxIdRoutePreference.Should().BeNull();
+        context.Routing.MaxToolRoundsOverride.Should().BeNull();
+        context.Routing.UserMemoryPrompt.Should().BeNull();
+        context.ConnectedServices.ContextJson.Should().BeNull();
         context.ExternalMetadata.Should().ContainSingle();
         context.ExternalMetadata["trace-id"].Should().Be("trace-1");
     }

--- a/test/Aevatar.AI.ToolProviders.Binding.Tests/Aevatar.AI.ToolProviders.Binding.Tests.csproj
+++ b/test/Aevatar.AI.ToolProviders.Binding.Tests/Aevatar.AI.ToolProviders.Binding.Tests.csproj
@@ -18,4 +18,7 @@
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\TestAgentToolContexts.cs" Link="TestAgentToolContexts.cs" />
+  </ItemGroup>
 </Project>

--- a/test/Aevatar.AI.ToolProviders.Binding.Tests/BindingToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Binding.Tests/BindingToolsTests.cs
@@ -27,7 +27,7 @@ public class BindingToolsTests
         var tool = new BindingListTool(queryAdapter, options);
 
         // Set scope_id in request context
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             ["scope_id"] = "test-scope"
         });
@@ -79,7 +79,7 @@ public class BindingToolsTests
             "svc-1", "Service One", "workflow", "healthy", "actor-1", "actor-1", null, DateTimeOffset.UtcNow));
         var tool = new BindingStatusTool(queryAdapter);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             ["scope_id"] = "test-scope"
         });
@@ -110,7 +110,7 @@ public class BindingToolsTests
         var commandPort = new StubCommandPort(captureRequest: r => captured = r);
         var tool = new BindingBindTool(commandPort);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             ["scope_id"] = "scope-1"
         });
@@ -143,7 +143,7 @@ public class BindingToolsTests
         var commandPort = new StubCommandPort(captureRequest: r => captured = r);
         var tool = new BindingBindTool(commandPort);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             ["scope_id"] = "scope-2"
         });
@@ -180,7 +180,7 @@ public class BindingToolsTests
         var tool = new ScopeWorkflowsUpsertTool(new StubScopeWorkflowCommandPort(
             captureRequest: r => captured = r));
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             ["scope_id"] = "scope-workflows"
         });
@@ -230,7 +230,7 @@ public class BindingToolsTests
     {
         var tool = new ScopeWorkflowsUpsertTool(new StubScopeWorkflowCommandPort());
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             ["scope_id"] = "scope-workflows"
         });
@@ -259,7 +259,7 @@ public class BindingToolsTests
         var tool = new ScopeWorkflowsUpsertTool(new StubScopeWorkflowCommandPort(
             exception: new InvalidOperationException("bad request")));
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             ["scope_id"] = "scope-workflows"
         });
@@ -289,7 +289,7 @@ public class BindingToolsTests
             new StubScopeWorkflowQueryPort(listResult: workflows),
             new BindingToolOptions { MaxListResults = 1 });
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             ["scope_id"] = "scope-workflows"
         });
@@ -331,7 +331,7 @@ public class BindingToolsTests
             new StubScopeWorkflowQueryPort(exception: new InvalidOperationException("query failed")),
             new BindingToolOptions());
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             ["scope_id"] = "scope-workflows"
         });
@@ -355,7 +355,7 @@ public class BindingToolsTests
         var tool = new ScopeWorkflowsGetTool(new StubScopeWorkflowQueryPort(
             getResult: BuildWorkflowSummary("scope-workflows", "wf-1")));
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             ["scope_id"] = "scope-workflows"
         });
@@ -380,7 +380,7 @@ public class BindingToolsTests
     {
         var tool = new ScopeWorkflowsGetTool(new StubScopeWorkflowQueryPort());
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             ["scope_id"] = "scope-workflows"
         });
@@ -402,7 +402,7 @@ public class BindingToolsTests
     {
         var tool = new ScopeWorkflowsGetTool(new StubScopeWorkflowQueryPort(getResult: null));
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             ["scope_id"] = "scope-workflows"
         });
@@ -427,7 +427,7 @@ public class BindingToolsTests
         var tool = new ScopeWorkflowsGetTool(new StubScopeWorkflowQueryPort(
             exception: new InvalidOperationException("query failed")));
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             ["scope_id"] = "scope-workflows"
         });
@@ -473,7 +473,7 @@ public class BindingToolsTests
 
         var tool = new BindingUnbindTool(unbindAdapter);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             ["scope_id"] = "scope-unbind"
         });

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/Aevatar.AI.ToolProviders.Lark.Tests.csproj
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/Aevatar.AI.ToolProviders.Lark.Tests.csproj
@@ -18,4 +18,7 @@
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\TestAgentToolContexts.cs" Link="TestAgentToolContexts.cs" />
+  </ItemGroup>
 </Project>

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
@@ -20,7 +20,7 @@ public class LarkToolsTests
             SendResponse = """{"code":0,"data":{"message_id":"om_123","chat_id":"oc_456","create_time":"1730000000"}}""",
         };
         var tool = new LarkMessagesSendTool(client);
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-123",
         });
@@ -692,7 +692,7 @@ public class LarkToolsTests
                 """,
         };
         var tool = new LarkChatsLookupTool(client);
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-123",
         });
@@ -786,7 +786,7 @@ public class LarkToolsTests
                 """,
         };
         var tool = new LarkSheetsAppendRowsTool(client);
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-123",
         });
@@ -891,7 +891,7 @@ public class LarkToolsTests
                 """,
         };
         var tool = new LarkApprovalsListTool(client);
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-123",
         });
@@ -996,7 +996,7 @@ public class LarkToolsTests
     public async Task LarkApprovalsActTool_ValidatesTransferTarget()
     {
         var tool = new LarkApprovalsActTool(new StubLarkNyxClient());
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-123",
         });
@@ -1020,7 +1020,7 @@ public class LarkToolsTests
             ApprovalActionResponse = """{"code":0,"data":{}}""",
         };
         var tool = new LarkApprovalsActTool(client);
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "token-123",
         });
@@ -1566,7 +1566,7 @@ public class LarkToolsTests
                     metadata[entry.Key] = entry.Value;
             }
 
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(metadata);
+            AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(metadata);
         }
 
         public void Dispose()

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/Aevatar.AI.ToolProviders.Ornn.Tests.csproj
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/Aevatar.AI.ToolProviders.Ornn.Tests.csproj
@@ -27,4 +27,7 @@
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\TestAgentToolContexts.cs" Link="TestAgentToolContexts.cs" />
+  </ItemGroup>
 </Project>

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/LocalSkillCatalogTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/LocalSkillCatalogTests.cs
@@ -210,7 +210,7 @@ public sealed class LocalSkillCatalogTests
     private static IDisposable BeginTokenScope(string token)
     {
         var previous = AgentToolRequestContext.Current;
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = token,
         });

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnSearchSkillsToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnSearchSkillsToolTests.cs
@@ -46,7 +46,7 @@ public sealed class OrnnSearchSkillsToolTests
         var previous = AgentToolRequestContext.Current;
         try
         {
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+            AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
             {
                 [LLMRequestMetadataKeys.NyxIdAccessToken] = "access-token",
             });
@@ -76,7 +76,7 @@ public sealed class OrnnSearchSkillsToolTests
         var previous = AgentToolRequestContext.Current;
         try
         {
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+            AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
             {
                 [LLMRequestMetadataKeys.NyxIdAccessToken] = "access-token",
             });
@@ -101,7 +101,7 @@ public sealed class OrnnSearchSkillsToolTests
         var previous = AgentToolRequestContext.Current;
         try
         {
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+            AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
             {
                 [LLMRequestMetadataKeys.NyxIdAccessToken] = "access-token",
             });

--- a/test/Aevatar.AI.ToolProviders.Telegram.Tests/Aevatar.AI.ToolProviders.Telegram.Tests.csproj
+++ b/test/Aevatar.AI.ToolProviders.Telegram.Tests/Aevatar.AI.ToolProviders.Telegram.Tests.csproj
@@ -19,4 +19,7 @@
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\TestAgentToolContexts.cs" Link="TestAgentToolContexts.cs" />
+  </ItemGroup>
 </Project>

--- a/test/Aevatar.AI.ToolProviders.Telegram.Tests/TelegramToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Telegram.Tests/TelegramToolsTests.cs
@@ -464,7 +464,7 @@ public class TelegramToolsTests
                 return;
             }
 
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>(StringComparer.Ordinal)
+            AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 [LLMRequestMetadataKeys.NyxIdAccessToken] = accessToken,
             });

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj
@@ -55,5 +55,6 @@
   <ItemGroup>
     <Compile Include="..\Shared\ProjectionActivationPlanProviderTestBase.cs" Link="Shared\ProjectionActivationPlanProviderTestBase.cs" />
     <Compile Include="..\Shared\SharedOrleansPortAllocator.cs" Link="Shared\SharedOrleansPortAllocator.cs" />
+    <Compile Include="..\TestAgentToolContexts.cs" Link="TestAgentToolContexts.cs" />
   </ItemGroup>
 </Project>

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -62,7 +62,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -149,7 +149,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -215,7 +215,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -286,7 +286,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -363,7 +363,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -417,7 +417,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -477,7 +477,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -542,7 +542,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -604,7 +604,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -668,7 +668,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -744,7 +744,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -790,7 +790,7 @@ public sealed class AgentBuilderToolTests
         tools.Should().ContainSingle();
         tools[0].Name.Should().Be("agent_builder");
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentDeliveryTargetToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentDeliveryTargetToolTests.cs
@@ -83,7 +83,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -118,7 +118,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -168,7 +168,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -236,7 +236,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -276,7 +276,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -324,7 +324,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -376,7 +376,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(callerScopeResolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -412,7 +412,7 @@ public sealed class AgentDeliveryTargetToolTests
         tools.Should().ContainSingle();
         tools[0].Name.Should().Be("agent_delivery_targets");
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -450,7 +450,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(resolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -488,7 +488,7 @@ public sealed class AgentDeliveryTargetToolTests
     public async Task ExecuteAsync_Upsert_Requires_ConversationId()
     {
         var (tool, _, _) = BuildBasicHarness();
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -508,7 +508,7 @@ public sealed class AgentDeliveryTargetToolTests
     public async Task ExecuteAsync_Upsert_Requires_NyxProviderSlug()
     {
         var (tool, _, _) = BuildBasicHarness();
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -549,7 +549,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(resolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -610,7 +610,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(resolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -641,7 +641,7 @@ public sealed class AgentDeliveryTargetToolTests
     public async Task ExecuteAsync_Delete_RequiresAgentId()
     {
         var (tool, _, _) = BuildBasicHarness();
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });
@@ -692,7 +692,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(resolver);
         var tool = CreateTool(services);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
         });

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
@@ -322,7 +322,7 @@ public sealed class ChannelRegistrationToolTests
         if (!string.IsNullOrWhiteSpace(scopeId))
             next["scope_id"] = scopeId;
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(next);
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(next);
 
         return new ResetMetadataScope(previous);
     }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/UnifyCallerScopeAcceptanceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/UnifyCallerScopeAcceptanceTests.cs
@@ -291,7 +291,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
 
         var resolver = new NyxIdNativeCallerScopeResolver(inner);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "expired-token",
         });
@@ -311,7 +311,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
         var inner = Substitute.For<INyxIdCurrentUserResolver>();
         var resolver = new ChannelMetadataCallerScopeResolver(inner);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [ChannelMetadataKeys.Platform] = "lark",
             // no sender_id
@@ -333,7 +333,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
         var inner = Substitute.For<INyxIdCurrentUserResolver>();
         var resolver = new ChannelMetadataCallerScopeResolver(inner);
 
-        AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
             // no channel.platform

--- a/test/Aevatar.Hosting.Tests/Aevatar.Hosting.Tests.csproj
+++ b/test/Aevatar.Hosting.Tests/Aevatar.Hosting.Tests.csproj
@@ -29,4 +29,7 @@
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\TestAgentToolContexts.cs" Link="TestAgentToolContexts.cs" />
+  </ItemGroup>
 </Project>

--- a/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
@@ -357,7 +357,7 @@ public sealed class MainnetResponsesEndpointsTests
             "token");
         try
         {
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(metadata);
+            AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(metadata);
             var substituteTools = await provider.GetSubstituteToolsAsync(context);
             var todoTool = substituteTools.Single(x => x.Name == "TodoWrite");
             var todoResult = await todoTool.ExecuteAsync(
@@ -404,7 +404,7 @@ public sealed class MainnetResponsesEndpointsTests
             "token");
         try
         {
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(metadata);
+            AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(metadata);
             var fetchTool = (await provider.GetSubstituteToolsAsync(context)).Single(x => x.Name == "WebFetch");
             var result = await fetchTool.ExecuteAsync("""{"url":"https://example.com/docs"}""");
 
@@ -444,7 +444,7 @@ public sealed class MainnetResponsesEndpointsTests
             "token");
         try
         {
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(metadata);
+            AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(metadata);
             var searchTool = (await provider.GetSubstituteToolsAsync(context)).Single(x => x.Name == "WebSearch");
             var result = await searchTool.ExecuteAsync("""{"query":"aevatar docs","max_results":3}""");
 

--- a/test/Aevatar.Hosting.Tests/WebFetchUrlGuardTests.cs
+++ b/test/Aevatar.Hosting.Tests/WebFetchUrlGuardTests.cs
@@ -164,7 +164,7 @@ public sealed class WebFetchUrlGuardTests
         var previous = AgentToolRequestContext.Current;
         try
         {
-            AgentToolRequestContext.Current = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>
+            AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
             {
                 [LLMRequestMetadataKeys.NyxIdAccessToken] = "secret-token",
             });

--- a/test/TestAgentToolContexts.cs
+++ b/test/TestAgentToolContexts.cs
@@ -1,0 +1,45 @@
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+
+internal static class TestAgentToolContexts
+{
+    public static AgentToolExecutionContext FromMetadata(IReadOnlyDictionary<string, string>? metadata)
+    {
+        if (metadata == null || metadata.Count == 0)
+            return AgentToolExecutionContext.Empty;
+
+        var maxToolRounds = Get(metadata, LLMRequestMetadataKeys.MaxToolRoundsOverride);
+        return new AgentToolExecutionContext(
+            new AgentToolRequestIdentity(
+                Get(metadata, LLMRequestMetadataKeys.RequestId),
+                Get(metadata, LLMRequestMetadataKeys.CallId)),
+            new AgentToolCredentials(
+                Get(metadata, LLMRequestMetadataKeys.NyxIdAccessToken),
+                Get(metadata, LLMRequestMetadataKeys.NyxIdOrgToken),
+                Get(metadata, LLMRequestMetadataKeys.SenderNyxIdAccessToken)),
+            new AgentToolCallerContext(
+                Get(metadata, LLMRequestMetadataKeys.ScopeId) ?? Get(metadata, "scope_id"),
+                Get(metadata, LLMRequestMetadataKeys.OwnerSubject),
+                Get(metadata, LLMRequestMetadataKeys.ResponseId)),
+            new AgentToolChannelContext(
+                Get(metadata, "channel.platform") ?? Get(metadata, "platform"),
+                Get(metadata, "channel.sender_id") ?? Get(metadata, "sender_id") ?? Get(metadata, "lark.open_id"),
+                Get(metadata, "registration_scope_id"),
+                Get(metadata, "channel.message_id") ?? Get(metadata, "message_id") ?? Get(metadata, "lark.message_id"),
+                Get(metadata, "channel.platform_message_id") ?? Get(metadata, "platform_message_id")),
+            new AgentToolSenderBindingContext(Get(metadata, LLMRequestMetadataKeys.SenderBindingId)),
+            new LLMRequestRoutingContext(
+                Get(metadata, LLMRequestMetadataKeys.ModelOverride),
+                Get(metadata, LLMRequestMetadataKeys.NyxIdRoutePreference),
+                int.TryParse(maxToolRounds, out var parsedMaxToolRounds) ? parsedMaxToolRounds : null,
+                Get(metadata, LLMRequestMetadataKeys.UserMemoryPrompt)),
+            new AgentToolConnectedServicesContext(Get(metadata, LLMRequestMetadataKeys.ConnectedServicesContext)),
+            AgentToolExecutionContextMapper.StripOwnedControlKeys(metadata));
+    }
+
+    private static string? Get(IReadOnlyDictionary<string, string> metadata, string key) =>
+        metadata.TryGetValue(key, out var value) ? Normalize(value) : null;
+
+    private static string? Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}


### PR DESCRIPTION
## 摘要

Phase 9 r1 meta-judge split first-slice 实施:`FromMetadata-reader-external-only`。
将 `FromMetadata` reader API 限制为外部 annotation only,production callers 改用 typed surfaces。

## 改动规模

- 27 files changed (+241 / -133)
- 新文件:`test/TestAgentToolContexts.cs`
- 修 production caller migration to typed surfaces

## 验证

- `dotnet build aevatar.slnx --nologo` ✓
- `dotnet test aevatar.slnx --nologo --no-build` ✓(7016 tests pass)

later-slice(`public-shim-writer-cleanup-and-production-caller-migration`)留下一步处理。

closes #1621

⟦AI:AUTO-LOOP⟧