### PR TITLE
test: dispatcher-only scope metadata fallback removal coverage (#1518 first-slice)

### DIFF
--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -226,6 +226,40 @@ public sealed class AevatarInvocationToolSourceTests
     }
 
     [Fact]
+    public async Task InvokeGAgent_ShouldNotResolveCallerScopeFromExternalMetadata()
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync("aevatar_invoke_gagent");
+
+        using var _ = AgentToolContextScope.Push(new AgentToolExecutionContext(
+            new AgentToolRequestIdentity("request-1", "call-gagent-no-scope"),
+            new AgentToolCredentials("access-token", "org-token", "sender-token"),
+            new AgentToolCallerContext(null, "owner-1", "response-1"),
+            new AgentToolChannelContext("telegram", "sender-1", "registration-scope-1", "message-1", "platform-message-1"),
+            new AgentToolSenderBindingContext("binding-1"),
+            new LLMRequestRoutingContext("model-1", "route-1", 4, "memory"),
+            new AgentToolConnectedServicesContext("""{"service":"ctx"}"""),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["scope_id"] = "metadata-scope",
+                [LLMRequestMetadataKeys.ScopeId] = "metadata-aevatar-scope",
+                ["external"] = "value",
+            }));
+
+        var output = await tool.ExecuteAsync("""
+            {
+              "actor_id": "actor-1",
+              "payload": { "prompt": "hello" },
+              "wait": "ack"
+            }
+            """);
+
+        ErrorCode(output).Should().Be("caller_scope_unavailable");
+        harness.ActorRegistry.LastScopeId.Should().BeNull();
+        harness.ActorDispatch.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task InvokeGAgent_ShouldRejectPayloadHeaderCredentialOverrides()
     {
         var harness = new Harness();


### PR DESCRIPTION
## 摘要

Phase 9 r1 meta-judge split first-slice 实施:`dispatcher-only-scope-metadata-fallback-removal`。
production code 已被早期 PR 实施,本 PR 仅补测试覆盖。

## 改动

- `test/Aevatar.AI.Tests/AevatarInvocationToolSourceTests.cs`:34 行新增测试

## 验证

- `dotnet build aevatar.slnx --nologo` ✓
- `dotnet test aevatar.slnx --nologo --no-build` ✓(7020 tests pass)

later-slice(`legacy-metadata-reader-migration-policy`)留下一步处理。

closes #1518

⟦AI:AUTO-LOOP⟧