### PR TITLE
refactor: impl issue #1507 first-slice (Phase 9 r1 split)

### DIFF
--- a/src/Aevatar.AI.Abstractions/ai_messages.proto
+++ b/src/Aevatar.AI.Abstractions/ai_messages.proto
@@ -264,10 +264,8 @@ message PendingToolApprovalState {
   //   Old pattern: Durable approval continuation restored typed context from metadata.
   //   New principle: Typed pending approval context is the durable control surface.
   AgentToolExecutionContextPayload tool_context = 14;
-  // Refactor (issue1253-first):
-  //   Old pattern: Metadata carried approval control keys.
-  //   New principle: Metadata is open annotations plus old-state legacy fallback only.
-  map<string, string> metadata = 9;
+  reserved 9;
+  reserved "metadata";
   string remote_approval_id = 10;
   reserved 11;
   reserved "remote_status_check_callback_id";

--- a/src/Aevatar.AI.Core/RoleGAgent.cs
+++ b/src/Aevatar.AI.Core/RoleGAgent.cs
@@ -129,11 +129,11 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
 
             // Refactor (issue1414/cluster-004):
             //   Old pattern: pending approval state could rehydrate stable tool/caller context from metadata.
-            //   New principle: typed ToolContext/LlmControl are the only tool control authority; metadata carries annotations only.
+            //   New principle: typed ToolContext/LlmControl are the only tool control authority.
             try
             {
                 // Refactor (issue1253-first):
-                //   Old pattern: Approval resume rebuilt control context from pending.Metadata.
+                //   Old pattern: Approval resume rebuilt control context from a durable annotation bag.
                 //   New principle: Use typed pending.ToolContext only; metadata is never a control source.
                 var pendingToolContext = ResolvePendingToolContext(pending);
                 using (AgentToolContextScope.Push(pendingToolContext))
@@ -170,9 +170,6 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
                         ScopeId = pending.SessionId,
                         ToolContext = pendingToolContext.ToPayload(),
                     };
-                    foreach (var kv in ScrubPendingApprovalMetadata(pending.Metadata))
-                        continuationRequest.Metadata[kv.Key] = kv.Value;
-
                     await SendToAsync(Id, continuationRequest);
 
                     Logger.LogInformation(
@@ -426,9 +423,6 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
                     IsDestructive = true,
                     ToolContext = ResolveToolContext(request, requestId, toolCallId).ToPayload(),
                 };
-                foreach (var kv in ScrubPendingApprovalMetadata(request.Metadata))
-                    pending.Metadata[kv.Key] = kv.Value;
-
                 return pending;
             }
             catch (JsonException)
@@ -568,13 +562,10 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
     {
         // Refactor (iter290/cluster-002-invocation-trusted-context-metadata-bag):
         //   Old pattern: pending approval Metadata remained the primary resume context.
-        //   New principle: pending ToolContext is authoritative; metadata is only a scrubbed old-state annotation fallback.
+        //   New principle: pending ToolContext is authoritative; missing legacy context resolves to empty.
         var context = pending.ToolContext != null
             ? AgentToolExecutionContextMapper.FromPayload(pending.ToolContext)
-            : AgentToolExecutionContext.Empty with
-            {
-                ExternalMetadata = ScrubPendingApprovalMetadata(pending.Metadata),
-            };
+            : AgentToolExecutionContext.Empty;
 
         return context with
         {

--- a/test/Aevatar.AI.Core.Tests/RoleGAgentTests.cs
+++ b/test/Aevatar.AI.Core.Tests/RoleGAgentTests.cs
@@ -10,7 +10,7 @@ namespace Aevatar.AI.Core.Tests;
 public class RoleGAgentTests
 {
     [Fact]
-    public void PendingApprovalMetadataControlKeys_DoNotPopulateToolRequestContext()
+    public void PendingApprovalToolContext_ShouldScrubCredentialsAndOwnedExternalControlKeys()
     {
         var previous = AgentToolRequestContext.Current;
         AgentToolRequestContext.Current = null;
@@ -24,30 +24,35 @@ public class RoleGAgentTests
                 ToolCallId = "tool-call-1",
                 ArgumentsJson = "{}",
                 IsDestructive = true,
+                ToolContext = (AgentToolExecutionContext.Empty with
+                {
+                    Request = new AgentToolRequestIdentity("approval-1", "tool-call-1"),
+                    Credentials = new AgentToolCredentials("typed-token", "typed-org", "typed-sender"),
+                    Caller = new AgentToolCallerContext("scope-1", "owner-1", "response-1"),
+                    Routing = new LLMRequestRoutingContext("model-1", "route-1", 3, "memory-1"),
+                    ExternalMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        [LLMRequestMetadataKeys.RequestId] = "metadata-request",
+                        [LLMRequestMetadataKeys.CallId] = "metadata-call",
+                        [LLMRequestMetadataKeys.NyxIdAccessToken] = "metadata-token",
+                        ["trace-id"] = "trace-1",
+                    },
+                }).ToPayload(),
             };
-            pending.Metadata.Add(LLMRequestMetadataKeys.RequestId, "metadata-request");
-            pending.Metadata.Add(LLMRequestMetadataKeys.CallId, "metadata-call");
-            pending.Metadata.Add(LLMRequestMetadataKeys.ScopeId, "metadata-scope");
-            pending.Metadata.Add(LLMRequestMetadataKeys.OwnerSubject, "metadata-owner");
-            pending.Metadata.Add(LLMRequestMetadataKeys.ResponseId, "metadata-response");
-            pending.Metadata.Add(LLMRequestMetadataKeys.NyxIdAccessToken, "metadata-token");
-            pending.Metadata.Add(LLMRequestMetadataKeys.ModelOverride, "metadata-model");
-            pending.Metadata.Add("channel.platform", "metadata-platform");
-            pending.Metadata.Add("channel.sender_id", "metadata-sender");
 
             var context = ResolvePendingToolContext(pending);
             using (AgentToolContextScope.Push(context))
             {
                 AgentToolRequestContext.Current.Should().NotBeNull();
-                AgentToolRequestContext.RequestId.Should().BeNull();
-                AgentToolRequestContext.CallId.Should().BeNull();
-                AgentToolRequestContext.ScopeId.Should().BeNull();
-                AgentToolRequestContext.OwnerSubject.Should().BeNull();
-                AgentToolRequestContext.ResponseId.Should().BeNull();
+                AgentToolRequestContext.RequestId.Should().Be("approval-1");
+                AgentToolRequestContext.CallId.Should().Be("tool-call-1");
+                AgentToolRequestContext.ScopeId.Should().Be("scope-1");
+                AgentToolRequestContext.OwnerSubject.Should().Be("owner-1");
+                AgentToolRequestContext.ResponseId.Should().Be("response-1");
                 AgentToolRequestContext.NyxIdAccessToken.Should().BeNull();
-                AgentToolRequestContext.ModelOverride.Should().BeNull();
-                AgentToolRequestContext.ChannelPlatform.Should().BeNull();
-                AgentToolRequestContext.ChannelSenderId.Should().BeNull();
+                AgentToolRequestContext.ModelOverride.Should().Be("model-1");
+                AgentToolRequestContext.Current!.ExternalMetadata.Should().ContainKey("trace-id").WhoseValue.Should().Be("trace-1");
+                AgentToolRequestContext.Current.ExternalMetadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
             }
         }
         finally

--- a/test/Aevatar.AI.Tests/AIAbstractionsProtoCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/AIAbstractionsProtoCoverageTests.cs
@@ -285,11 +285,6 @@ public sealed class AIAbstractionsProtoCoverageTests
                     {
                         ["trace-id"] = "trace-from-context",
                     }).ToPayload(),
-                Metadata =
-                {
-                    ["trace-id"] = "trace-1",
-                    ["open-annotation"] = "annotation-1",
-                },
             },
             VoicePresence =
             {
@@ -356,7 +351,6 @@ public sealed class AIAbstractionsProtoCoverageTests
         state.PendingApproval.ToolContext.Should().NotBeNull();
         state.PendingApproval.RemoteStatusCheckAttempt.Should().Be(2);
         state.PendingApproval.RemoteApprovalExpiresAtUnixMs.Should().Be(123456);
-        state.PendingApproval.Metadata.Should().ContainKey("open-annotation").WhoseValue.Should().Be("annotation-1");
         state.PendingApproval.ToolContext.Should().NotBeNull();
         var pendingContext = AgentToolExecutionContextMapper.FromPayload(state.PendingApproval.ToolContext);
         pendingContext.Request.RequestId.Should().Be("req-1");
@@ -374,7 +368,7 @@ public sealed class AIAbstractionsProtoCoverageTests
     }
 
     [Fact]
-    public void PendingToolApprovalState_ShouldRoundTripTypedToolContext_AndLegacyAnnotations()
+    public void PendingToolApprovalState_ShouldRoundTripTypedToolContextAndRemoteBinding()
     {
         var pending = RoundTrip(new PendingToolApprovalState
         {
@@ -383,6 +377,9 @@ public sealed class AIAbstractionsProtoCoverageTests
             ToolName = "dangerous_tool",
             ToolCallId = "call-typed",
             ArgumentsJson = "{}",
+            RemoteApprovalId = "remote-typed",
+            RemoteStatusCheckAttempt = 2,
+            RemoteApprovalExpiresAtUnixMs = 123_456,
             ToolContext = (AgentToolExecutionContext.Empty with
             {
                 Request = new AgentToolRequestIdentity("req-typed", "call-typed"),
@@ -397,10 +394,6 @@ public sealed class AIAbstractionsProtoCoverageTests
                     ["trace-id"] = "trace-typed",
                 },
             }).ToPayload(),
-            Metadata =
-            {
-                ["annotation"] = "value",
-            },
         }, PendingToolApprovalState.Parser);
 
         pending.ToolContext.Should().NotBeNull();
@@ -411,7 +404,9 @@ public sealed class AIAbstractionsProtoCoverageTests
         pending.ToolContext.Routing.MaxToolRoundsOverride.Should().Be(4);
         pending.ToolContext.ConnectedServices.ContextJson.Should().Be("{\"service\":\"ok\"}");
         pending.ToolContext.ExternalMetadata["trace-id"].Should().Be("trace-typed");
-        pending.Metadata["annotation"].Should().Be("value");
+        pending.RemoteApprovalId.Should().Be("remote-typed");
+        pending.RemoteStatusCheckAttempt.Should().Be(2);
+        pending.RemoteApprovalExpiresAtUnixMs.Should().Be(123_456);
     }
 
     [Fact]

--- a/test/Aevatar.AI.Tests/RoleGAgentStateCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/RoleGAgentStateCoverageTests.cs
@@ -343,8 +343,6 @@ public sealed class RoleGAgentStateCoverageTests
                     ["trace-id"] = "trace-1",
                 }).ToPayload(),
         };
-        agent.State.PendingApproval.Metadata["trace-id"] = "trace-1";
-
         await agent.HandleToolApprovalDecision(new ToolApprovalDecisionEvent
         {
             RequestId = "req-1",
@@ -366,12 +364,10 @@ public sealed class RoleGAgentStateCoverageTests
                 x.ScopeId == "session-a" &&
                 x.ToolContext != null &&
                 x.ToolContext.Caller.ScopeId == "scope-a" &&
-                !x.Metadata.ContainsKey("nyxid.access_token") &&
-                x.Metadata["trace-id"] == "trace-1" &&
                 x.Prompt.Contains("dangerous_tool") &&
                 x.Prompt.Contains("RESULT:{\"value\":1}"))
             .Which;
-        continuation.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
+        continuation.Metadata.Should().BeEmpty();
         continuation.ToolContext.Should().NotBeNull();
         var context = AgentToolExecutionContextMapper.FromPayload(continuation.ToolContext);
         context.Request.RequestId.Should().Be("req-1");
@@ -384,7 +380,7 @@ public sealed class RoleGAgentStateCoverageTests
     }
 
     [Fact]
-    public async Task HandleToolApprovalDecision_ShouldPreferTypedToolContext_WhenLegacyMetadataDiffers()
+    public async Task HandleToolApprovalDecision_ShouldUseTypedToolContextOnly()
     {
         using var provider = BuildServiceProvider();
         AgentToolExecutionContext? observedToolContext = null;
@@ -426,10 +422,6 @@ public sealed class RoleGAgentStateCoverageTests
                     [LLMRequestMetadataKeys.NyxIdAccessToken] = "external-token",
                 }).ToPayload(),
         };
-        agent.State.PendingApproval.Metadata[LLMRequestMetadataKeys.ScopeId] = "legacy-scope";
-        agent.State.PendingApproval.Metadata[LLMRequestMetadataKeys.ModelOverride] = "legacy-model";
-        agent.State.PendingApproval.Metadata["legacy-trace"] = "legacy-value";
-
         await agent.HandleToolApprovalDecision(new ToolApprovalDecisionEvent
         {
             RequestId = "req-1",
@@ -451,13 +443,11 @@ public sealed class RoleGAgentStateCoverageTests
         continuationContext.Credentials.Should().Be(AgentToolCredentials.Empty);
         continuationContext.ExternalMetadata.Should().ContainKey("typed-trace").WhoseValue.Should().Be("typed-value");
         continuationContext.ExternalMetadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
-        continuation.Metadata.Should().ContainKey("legacy-trace").WhoseValue.Should().Be("legacy-value");
-        continuation.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.ScopeId);
-        continuation.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.ModelOverride);
+        continuation.Metadata.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task HandleToolApprovalDecision_ShouldUseLegacyMetadataFallbackForAnnotationsOnly_WhenToolContextMissing()
+    public async Task HandleToolApprovalDecision_ShouldUseEmptyContext_WhenToolContextMissing()
     {
         using var provider = BuildServiceProvider();
         AgentToolExecutionContext? observedToolContext = null;
@@ -486,15 +476,6 @@ public sealed class RoleGAgentStateCoverageTests
             ToolCallId = "call-1",
             ArgumentsJson = "{}",
         };
-        agent.State.PendingApproval.Metadata[LLMRequestMetadataKeys.RequestId] = "legacy-request";
-        agent.State.PendingApproval.Metadata[LLMRequestMetadataKeys.CallId] = "legacy-call";
-        agent.State.PendingApproval.Metadata[LLMRequestMetadataKeys.ScopeId] = "legacy-scope";
-        agent.State.PendingApproval.Metadata[LLMRequestMetadataKeys.OwnerSubject] = "legacy-owner";
-        agent.State.PendingApproval.Metadata[LLMRequestMetadataKeys.ModelOverride] = "legacy-model";
-        agent.State.PendingApproval.Metadata[LLMRequestMetadataKeys.NyxIdRoutePreference] = "legacy-route";
-        agent.State.PendingApproval.Metadata[LLMRequestMetadataKeys.NyxIdAccessToken] = "legacy-token";
-        agent.State.PendingApproval.Metadata["trace-id"] = "trace-1";
-
         await agent.HandleToolApprovalDecision(new ToolApprovalDecisionEvent
         {
             RequestId = "req-1",
@@ -509,16 +490,13 @@ public sealed class RoleGAgentStateCoverageTests
         observedToolContext.Routing.ModelOverride.Should().BeNull();
         observedToolContext.Routing.NyxIdRoutePreference.Should().BeNull();
         observedToolContext.Credentials.Should().Be(AgentToolCredentials.Empty);
-        observedToolContext.ExternalMetadata.Should().ContainKey("trace-id").WhoseValue.Should().Be("trace-1");
+        observedToolContext.ExternalMetadata.Should().BeEmpty();
         var continuation = publisher.Published.OfType<ChatRequestEvent>().Should().ContainSingle().Which;
         var continuationContext = AgentToolExecutionContextMapper.FromPayload(continuation.ToolContext);
         continuationContext.Caller.ScopeId.Should().BeNull();
         continuationContext.Routing.ModelOverride.Should().BeNull();
         continuationContext.Credentials.Should().Be(AgentToolCredentials.Empty);
-        continuation.Metadata.Should().ContainKey("trace-id").WhoseValue.Should().Be("trace-1");
-        continuation.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
-        continuation.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.ScopeId);
-        continuation.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.ModelOverride);
+        continuation.Metadata.Should().BeEmpty();
     }
 
     [Fact]
@@ -1145,17 +1123,9 @@ public sealed class RoleGAgentStateCoverageTests
         context.ConnectedServices.ContextJson.Should().Be("""{"service":"telegram"}""");
         context.ExternalMetadata.Should().ContainKey("trace-id").WhoseValue.Should().Be("trace-from-context");
         context.ExternalMetadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
-        pending.Metadata["trace-id"].Should().Be("trace-1");
         pending.ToolContext.Credentials.NyxIdAccessToken.Should().BeEmpty();
         pending.ToolContext.Credentials.NyxIdOrgToken.Should().BeEmpty();
         pending.ToolContext.Credentials.SenderNyxIdAccessToken.Should().BeEmpty();
-        pending.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
-        pending.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdOrgToken);
-        pending.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.SenderNyxIdAccessToken);
-        pending.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.ModelOverride);
-        pending.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdRoutePreference);
-        pending.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.ScopeId);
-        pending.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.OwnerSubject);
     }
 
     [Fact]


### PR DESCRIPTION
Phase 9 r1 split first-slice: `remote-approval-stop-dictionary-bearer-fallback`。

- 5 files changed
- 7019 tests passing
- closes #1507

⟦AI:AUTO-LOOP⟧