### PR TITLE
Clarify Studio script launchpad

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
@@ -569,19 +569,25 @@ describe('StudioWorkflowBuildPanel', () => {
 
     expect(
       screen.getByText(
-        'Create or select a script first. Validation, save, bind, and dry-run unlock after there is a script to work on.',
+        'Create a script to start editing. Saved workspace scripts appear here when this catalog has one.',
       ),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
-        'Create a script capability or select a saved workspace script. After that, this panel will show validation, save, bind, and dry-run controls.',
-      ),
+      screen.getByText('No script is selected yet. Start a script draft to open the editor.'),
     ).toBeInTheDocument();
-    expect(screen.getByText('Create a script before running it')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Script ID')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Script lifecycle status')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Script dry run input')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Validation, save, bind/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/dry-run controls/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Bind becomes available/i)).not.toBeInTheDocument();
+    expect(screen.queryByText('Create a script before running it')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Validate' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Save script' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Run' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Load fixture' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Load sample input' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Continue to Bind' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Promotion')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Add script' }));
     expect(handleCreateScriptDraft).toHaveBeenCalled();

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
@@ -88,6 +88,14 @@ const buildWorkbenchGridStyle: React.CSSProperties = {
   minWidth: 0,
 };
 
+const scriptLaunchpadGridStyle: React.CSSProperties = {
+  display: 'grid',
+  gap: 16,
+  gridTemplateColumns: 'minmax(0, 1fr)',
+  minHeight: 0,
+  minWidth: 0,
+};
+
 const buildWorkbenchPrimaryColumnStyle: React.CSSProperties = {
   alignSelf: 'start',
   display: 'grid',
@@ -2846,7 +2854,10 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
   }
 
   return (
-    <div data-testid="studio-script-build-panel" style={buildWorkbenchGridStyle}>
+    <div
+      data-testid="studio-script-build-panel"
+      style={hasActiveScript ? buildWorkbenchGridStyle : scriptLaunchpadGridStyle}
+    >
       <div style={{ display: 'grid', gap: 16, minWidth: 0 }}>
         <section style={buildSurfaceCardStyle}>
           <div style={{ display: 'grid', gap: 4 }}>
@@ -2854,7 +2865,7 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
             <div style={sectionDescriptionStyle}>
               {hasActiveScript
                 ? 'Script mode 只做一件事：围绕当前 script draft 的 typed source、lints 和 dry-run 迭代实现。'
-                : 'Create or select a script first. Validation, save, bind, and dry-run unlock after there is a script to work on.'}
+                : 'Create a script to start editing. Saved workspace scripts appear here when this catalog has one.'}
             </div>
           </div>
           <div style={{ alignItems: 'center', display: 'flex', gap: 8, justifyContent: 'space-between' }}>
@@ -2867,40 +2878,42 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
                   </Tag>
                 </>
               ) : null}
-              <Select
-                aria-label="Script ID"
-                style={{ minWidth: 220 }}
-                placeholder="Create or select a script"
-                value={activeScript?.script?.scriptId || undefined}
-                onChange={onSelectScriptId}
-                options={[
-                  ...(pendingScriptDraft?.scriptId
-                    ? [
-                        {
-                          label: `${pendingScriptDraft.scriptId} (draft)`,
-                          value: pendingScriptDraft.scriptId,
-                        },
-                      ]
-                    : []),
-                  ...(observedAppliedScript?.script?.scriptId &&
-                  !pendingScriptDraft?.scriptId &&
-                  !availableScripts.some(
-                    (detail) =>
-                      detail.script?.scriptId === observedAppliedScript.script?.scriptId,
-                  )
-                    ? [
-                        {
-                          label: `${observedAppliedScript.script.scriptId} (applied)`,
-                          value: observedAppliedScript.script.scriptId,
-                        },
-                      ]
-                    : []),
-                  ...availableScripts.map((detail) => ({
-                    label: detail.script?.scriptId || 'script',
-                    value: detail.script?.scriptId || '',
-                  })),
-                ]}
-              />
+              {hasActiveScript ? (
+                <Select
+                  aria-label="Script ID"
+                  style={{ minWidth: 220 }}
+                  placeholder="Select a script"
+                  value={activeScript?.script?.scriptId || undefined}
+                  onChange={onSelectScriptId}
+                  options={[
+                    ...(pendingScriptDraft?.scriptId
+                      ? [
+                          {
+                            label: `${pendingScriptDraft.scriptId} (draft)`,
+                            value: pendingScriptDraft.scriptId,
+                          },
+                        ]
+                      : []),
+                    ...(observedAppliedScript?.script?.scriptId &&
+                    !pendingScriptDraft?.scriptId &&
+                    !availableScripts.some(
+                      (detail) =>
+                        detail.script?.scriptId === observedAppliedScript.script?.scriptId,
+                    )
+                      ? [
+                          {
+                            label: `${observedAppliedScript.script.scriptId} (applied)`,
+                            value: observedAppliedScript.script.scriptId,
+                          },
+                        ]
+                      : []),
+                    ...availableScripts.map((detail) => ({
+                      label: detail.script?.scriptId || 'script',
+                      value: detail.script?.scriptId || '',
+                    })),
+                  ]}
+                />
+              ) : null}
             </Space>
             {hasActiveScript ? (
               <Space wrap size={[8, 8]}>
@@ -3207,7 +3220,7 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
             </div>
           ) : (
             <Empty
-              description="Create a script capability or select a saved workspace script. After that, this panel will show validation, save, bind, and dry-run controls."
+              description="No script is selected yet. Start a script draft to open the editor."
             >
               <Button
                 className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
@@ -3236,21 +3249,7 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
               Continue to Bind
             </Button>
           </div>
-        ) : (
-          <div
-            style={{
-              background: '#fffdf8',
-              border: '1px solid #efe7da',
-              borderRadius: 16,
-              color: '#667085',
-              fontSize: 13,
-              lineHeight: '20px',
-              padding: '12px 14px',
-            }}
-          >
-            Start with Add script or select an existing script. Bind becomes available only after a saved catalog revision exists.
-          </div>
-        )}
+        ) : null}
 
         <ScriptLeaveDialog
           open={leaveDialogOpen}
@@ -3259,9 +3258,8 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
         />
       </div>
 
-      <aside style={dryRunAsideStyle}>
-        {hasActiveScript ? (
-          <>
+      {hasActiveScript ? (
+        <aside style={dryRunAsideStyle}>
             <div style={{ alignItems: 'center', display: 'flex', gap: 8, justifyContent: 'space-between' }}>
               <div style={{ display: 'grid', gap: 4 }}>
                 <div style={sectionEyebrowStyle}>Dry-run</div>
@@ -3345,19 +3343,6 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
               <div style={sectionEyebrowStyle}>Output</div>
               <pre style={dryRunOutputStyle}>{runOutput}</pre>
             </div>
-          </>
-        ) : (
-          <div style={{ display: 'grid', gap: 12 }}>
-            <div style={{ display: 'grid', gap: 4 }}>
-              <div style={sectionEyebrowStyle}>Dry-run</div>
-              <Typography.Text strong>Create a script before running it</Typography.Text>
-            </div>
-            <Typography.Text type="secondary">
-              The run input, fixture loader, and output stream appear after a script draft or saved script is selected.
-            </Typography.Text>
-          </div>
-        )}
-        {hasActiveScript ? (
           <details
             aria-label="Script promotion history"
             style={{
@@ -3428,8 +3413,8 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
               )}
             </div>
           </details>
-        ) : null}
-      </aside>
+        </aside>
+      ) : null}
     </div>
   );
 };

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioShell.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioShell.test.tsx
@@ -187,6 +187,28 @@ describe('StudioShell', () => {
     });
   });
 
+  it('can hide the member rail and lifecycle for focused launchpad empty states', () => {
+    render(
+      <StudioShell
+        currentLifecycleStep="build"
+        lifecycleSteps={lifecycleSteps}
+        members={members}
+        onSelectLifecycleStep={jest.fn()}
+        onSelectMember={jest.fn()}
+        pageTitle="Studio page"
+        selectedMemberKey="workflow:workspace-demo"
+        showLifecycle={false}
+        showMemberRail={false}
+      >
+        <div>Script launchpad</div>
+      </StudioShell>,
+    );
+
+    expect(screen.queryByLabelText('Team members')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('studio-lifecycle-section')).not.toBeInTheDocument();
+    expect(screen.getByText('Script launchpad')).toBeInTheDocument();
+  });
+
   it('lets page-scroll mode grow content in document flow while the main pane scrolls', () => {
     render(
       <StudioShell

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioShell.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioShell.tsx
@@ -61,6 +61,8 @@ type StudioShellProps = {
   readonly pageTitle: string;
   readonly pageToolbar?: React.ReactNode;
   readonly selectedMemberKey?: string;
+  readonly showLifecycle?: boolean;
+  readonly showMemberRail?: boolean;
   readonly showPageHeader?: boolean;
   readonly children: React.ReactNode;
 };
@@ -414,6 +416,8 @@ const StudioShell: React.FC<StudioShellProps> = ({
   pageTitle,
   pageToolbar,
   selectedMemberKey,
+  showLifecycle = true,
+  showMemberRail = true,
   showPageHeader = true,
   children,
 }) => {
@@ -501,6 +505,7 @@ const StudioShell: React.FC<StudioShellProps> = ({
 
   return (
     <div style={shellRootStyle}>
+      {showMemberRail ? (
       <aside style={railStyle} aria-label="Team members">
         <div style={railHeaderStyle}>
           <div
@@ -760,10 +765,11 @@ const StudioShell: React.FC<StudioShellProps> = ({
         </div>
 
       </aside>
+      ) : null}
 
       <div data-testid="studio-shell-main" style={mainStyle}>
         {contextBar}
-        {lifecycleSteps.length > 0 ? (
+        {showLifecycle && lifecycleSteps.length > 0 ? (
           <div data-testid="studio-lifecycle-section" style={lifecycleSectionStyle}>
             <div style={lifecycleHeaderStyle}>
               <Typography.Text

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -2013,6 +2013,11 @@ jest.mock("./components/StudioBuildPanels", () => {
     }, [dirty, props.onRegisterLeaveGuard]);
 
     mockReact.useEffect(() => {
+      if (!selectedScriptId) {
+        props.onScriptBuildStateChange?.(null);
+        return () => props.onScriptBuildStateChange?.(null);
+      }
+
       props.onScriptBuildStateChange?.({
         scriptId: selectedScriptId,
         displayName: selectedScriptId,
@@ -2027,20 +2032,29 @@ jest.mock("./components/StudioBuildPanels", () => {
       return () => props.onScriptBuildStateChange?.(null);
     }, [dirty, props.onScriptBuildStateChange, selectedScriptId]);
 
+    if (!selectedScriptId) {
+      return mockReact.createElement("div", { "data-testid": "studio-script-build-panel" }, [
+        mockReact.createElement("div", { key: "title" }, "Script source"),
+        mockReact.createElement(
+          "p",
+          { key: "empty-copy" },
+          "No script is selected yet. Start a script draft to open the editor."
+        ),
+        mockReact.createElement(
+          "button",
+          {
+            key: "add-script",
+            type: "button",
+            onClick: () => props.onCreateScriptDraft?.(),
+          },
+          "Add script"
+        ),
+      ]);
+    }
+
     return mockReact.createElement("div", { "data-testid": "studio-script-build-panel" }, [
       mockReact.createElement("div", { key: "title" }, "Script source"),
       mockReact.createElement("div", { key: "provenance" }, "lints · partial"),
-      !selectedScriptId
-        ? mockReact.createElement(
-            "button",
-            {
-              key: "add-script",
-              type: "button",
-              onClick: () => props.onCreateScriptDraft?.(),
-            },
-            "Add script"
-          )
-        : null,
       mockReact.createElement("input", {
         key: "script-id",
         "aria-label": "Script ID",
@@ -2207,6 +2221,8 @@ jest.mock("./components/StudioShell", () => ({
     onSelectMember,
     onSelectPage,
     selectedMemberKey,
+    showLifecycle = true,
+    showMemberRail = true,
   }: any) => {
     const React = require("react");
     const filterOptions = [
@@ -2232,7 +2248,7 @@ jest.mock("./components/StudioShell", () => ({
         React.createElement("div", { key: "workbench" }, "Workbench"),
         contextBar ? React.createElement("div", { key: "context-bar" }, contextBar) : null,
         alerts ? React.createElement("div", { key: "alerts" }, alerts) : null,
-        React.createElement(
+        showMemberRail ? React.createElement(
           "div",
           { key: "members", "aria-label": "Team members" },
           [
@@ -2272,8 +2288,8 @@ jest.mock("./components/StudioShell", () => ({
               )
             ),
           ]
-        ),
-        ...lifecycleSteps.map((step: any) =>
+        ) : null,
+        ...(showLifecycle ? lifecycleSteps : []).map((step: any) =>
           React.createElement(
             "button",
             {
@@ -3981,8 +3997,29 @@ describe("StudioPage", () => {
         scripts: true,
       },
     });
+    (scriptsApi.listScripts as jest.Mock).mockResolvedValueOnce([
+      {
+        available: true,
+        scopeId: "scope-1",
+        script: {
+          scopeId: "scope-1",
+          scriptId: "script-alpha",
+          catalogActorId: "catalog-1",
+          definitionActorId: "definition-1",
+          activeRevision: "rev-script-1",
+          activeSourceHash: "hash-1",
+          updatedAt: "2026-03-18T00:00:00Z",
+        },
+        source: {
+          sourceText: "using System;",
+          definitionActorId: "definition-1",
+          revision: "rev-script-1",
+          sourceHash: "hash-1",
+        },
+      },
+    ]);
 
-    renderStudioPage("/studio?tab=scripts");
+    renderStudioPage("/studio?scopeId=scope-1&focus=script%3Ascript-alpha&tab=scripts");
 
     await screen.findByLabelText("Script ID");
     fireEvent.change(screen.getByLabelText("Script source editor"), {
@@ -4596,6 +4633,16 @@ describe("StudioPage", () => {
     });
 
     renderStudioPage("/studio?tab=scripts");
+
+    expect(await screen.findByTestId("studio-script-build-panel")).toBeTruthy();
+    expect(screen.getByTestId("studio-context-title")).toHaveTextContent("Create a script");
+    expect(screen.getByText("No script is selected yet. Start a script draft to open the editor.")).toBeTruthy();
+    expect(screen.queryByLabelText("Team members")).toBeNull();
+    expect(screen.queryByTestId("studio-lifecycle-section")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Observe" })).toBeNull();
+    expect(screen.queryByLabelText("Script ID")).toBeNull();
+    expect(screen.queryByText("Script draft run")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Save draft" })).toBeNull();
 
     fireEvent.click(await screen.findByRole("button", { name: "Add script" }));
 

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -4524,6 +4524,16 @@ const StudioPage: React.FC = () => {
       : buildSurface === 'gagent'
         ? 'gagent'
         : 'workflow';
+  const isScriptBuildLaunchpadEmpty =
+    isBuildScriptsSurface &&
+    Boolean(resolvedStudioScopeId) &&
+    Boolean(appContextQuery.data?.features.scripts) &&
+    !scopeScriptsQuery.isLoading &&
+    !scopeScriptsQuery.isFetching &&
+    availableScopeScripts.length === 0 &&
+    !trimOptional(selectedScriptId) &&
+    !trimOptional(pendingScriptDraft?.scriptId) &&
+    !trimOptional(scriptBuildState?.scriptId);
   const buildPendingBindCandidate = useMemo(() => {
     if (!resolvedStudioScopeId) {
       return null;
@@ -9713,7 +9723,9 @@ const StudioPage: React.FC = () => {
     Boolean(invokeTargetServiceId) &&
     Boolean(invokeTargetDefaultEndpointId);
   const lifecycleSteps = useMemo<readonly StudioLifecycleStep[]>(
-    () => [
+    () => isScriptBuildLaunchpadEmpty
+      ? []
+      : [
       {
         key: 'build',
         label: 'Build',
@@ -9747,6 +9759,7 @@ const StudioPage: React.FC = () => {
     ],
     [
       currentLifecycleStep,
+      isScriptBuildLaunchpadEmpty,
       resolvedStudioScopeId,
       selectedMemberCanBind,
       selectedMemberCanInvoke,
@@ -9756,7 +9769,7 @@ const StudioPage: React.FC = () => {
     () => getDefaultBuildModeCards(Boolean(appContextQuery.data?.features.scripts)),
     [appContextQuery.data?.features.scripts],
   );
-  const buildModeCards = isBuildSurface ? (
+  const buildModeCards = isBuildSurface && !isScriptBuildLaunchpadEmpty ? (
     <div
       data-testid="studio-build-mode-switcher"
       style={{
@@ -10009,12 +10022,14 @@ const StudioPage: React.FC = () => {
         : 'Select a member'
       : isBuildEditorSurface
         ? activeWorkflowName || templateWorkflow || 'Workflow 构建'
-      : isBuildGAgentSurface
+        : isBuildGAgentSurface
           ? hasSelectedMemberFocus
             ? currentMemberLabel
             : 'GAgent 构建'
         : isBuildScriptsSurface
-          ? selectedScriptId || 'Script 构建'
+          ? isScriptBuildLaunchpadEmpty
+            ? 'Create a script'
+            : selectedScriptId || 'Script 构建'
         : isObserveSurface
           ? hasSelectedMemberFocus
             ? currentMemberLabel
@@ -10038,7 +10053,9 @@ const StudioPage: React.FC = () => {
         : isBuildGAgentSurface
           ? '在 Build 内定义 GAgent 类型、角色、初始 prompt、工具和状态持久化'
         : isBuildScriptsSurface
-          ? '围绕 script source、diagnostics 和 dry-run 继续迭代当前 member'
+          ? isScriptBuildLaunchpadEmpty
+            ? 'Start a script draft before Studio opens editing, validation, or run controls.'
+            : '围绕 script source、diagnostics 和 dry-run 继续迭代当前 member'
         : isObserveSurface
           ? '围绕当前 member 的最近运行、回放和基线继续观察'
           : isBindSurface
@@ -10617,6 +10634,8 @@ const StudioPage: React.FC = () => {
               onSelectMember={handleSelectStudioMember}
               pageTitle={pageTitle}
               selectedMemberKey={selectedRailMemberKey}
+              showLifecycle={!isScriptBuildLaunchpadEmpty}
+              showMemberRail={!isScriptBuildLaunchpadEmpty}
               showPageHeader={false}
             >
               {currentPageContent}


### PR DESCRIPTION
## Problem

Closes #1649.

The Studio Scripts empty state was partly fixed inside `StudioScriptBuildPanel`, but the first viewport still exposed unrelated product concepts before a script existed:

- shell rail stayed anchored on `Team members`
- lifecycle still showed `Build / Bind / Invoke / Observe`
- context copy talked about the current member, diagnostics, and dry-run
- the script panel repeated future `validation / save / bind / dry-run` concepts
- the right dry-run aside appeared before there was a script to run

This PR keeps the fix frontend-only and does not touch backend/proto/API/actor/projection/workflow/runtime/database/backend tests/backend config/architecture docs.

## Solution

- Add precise `StudioShell` presentation switches so a focused launchpad can hide the member rail and lifecycle stepper without changing the default Studio shell.
- Detect the true Scripts launchpad empty state only when the Scripts surface has no selected script, no pending draft, no script build state, and no loaded catalog script.
- Hide the rail, lifecycle, and construction mode switcher only in that launchpad state.
- Rewrite the empty Script panel to focus on `Add script`, remove early dry-run/bind/save/validation concepts, and keep full editing controls once a script exists.
- Update page-level and component tests to lock the new first-viewport contract.

## Impact paths

- `apps/aevatar-console-web/src/pages/studio/index.tsx`
- `apps/aevatar-console-web/src/pages/studio/index.test.tsx`
- `apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx`
- `apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx`
- `apps/aevatar-console-web/src/pages/studio/components/StudioShell.tsx`
- `apps/aevatar-console-web/src/pages/studio/components/StudioShell.test.tsx`

## Verification

- `git diff --check` — pass, no output
- `npm exec --yes --package pnpm@10.2.1 -- pnpm --dir apps/aevatar-console-web exec jest --runInBand src/pages/studio/components/StudioBuildPanels.test.tsx src/pages/studio/components/StudioShell.test.tsx src/pages/studio/index.test.tsx` — pass, 3 suites / 134 tests
- `npm exec --yes --package pnpm@10.2.1 -- pnpm --dir apps/aevatar-console-web tsc` — pass
- `bash tools/ci/test_stability_guards.sh` via local macOS timeout/envsubst wrappers — pass; pytest is not installed locally, so the guard skipped the optional Python suite after passing polling checks

## Notes

- Base branch is `feat/2026-05-29_ai-automation-pipeline`.
- This PR is not auto-merged and is waiting for user review/merge.
