### PR TITLE
Clarify platform inventory readiness

### DIFF
--- a/apps/aevatar-console-web/src/pages/Deployments/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/Deployments/index.test.tsx
@@ -310,6 +310,60 @@ describe("DeploymentsPage", () => {
     expect(await screen.findByText("发布服务列表")).toBeInTheDocument();
     expect(await screen.findByText("Trade Agent")).toBeInTheDocument();
     expect(screen.queryByText("发布摘要")).toBeNull();
+    expect(screen.queryByText("正在加载发布服务")).toBeNull();
+  });
+
+  it("keeps the deployment inventory in a loading state until the first response resolves", async () => {
+    let resolveServices: (value: unknown[]) => void = () => {};
+    mockServicesApi.listServices.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveServices = resolve;
+        }),
+    );
+
+    renderDeploymentsPage();
+
+    expect(await screen.findByText("正在加载发布服务")).toBeInTheDocument();
+    expect(
+      screen.getByText("发布对象清单仍在加载，返回前不会把当前范围误判为空。"),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(4);
+    expect(screen.queryByText("当前范围没有服务")).toBeNull();
+
+    resolveServices([]);
+
+    expect(await screen.findByText("当前范围没有服务")).toBeInTheDocument();
+  });
+
+  it("separates deployment inventory failures from a true empty scope", async () => {
+    mockServicesApi.listServices.mockRejectedValueOnce(
+      new Error("deployment inventory unavailable"),
+    );
+
+    renderDeploymentsPage();
+
+    expect(await screen.findByText("发布服务列表暂不可用")).toBeInTheDocument();
+    expect(screen.getByText("deployment inventory unavailable")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "重试发布列表" })).toBeInTheDocument();
+    expect(screen.queryByText("当前范围没有服务")).toBeNull();
+  });
+
+  it("shows an actionable deployment empty state only after an empty response", async () => {
+    mockServicesApi.listServices.mockResolvedValueOnce([]);
+
+    renderDeploymentsPage();
+
+    expect(await screen.findByText("当前范围没有服务")).toBeInTheDocument();
+    expect(
+      screen.getByText("当前 Team、App 和 Namespace 下没有可发布服务。可以调整范围后重新加载。"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "调整发布范围" }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe("/deployments");
+    });
   });
 
   it("warns when scope edits have not been loaded yet", async () => {

--- a/apps/aevatar-console-web/src/pages/Deployments/index.tsx
+++ b/apps/aevatar-console-web/src/pages/Deployments/index.tsx
@@ -64,6 +64,7 @@ import {
   aevatarMonoFontFamily,
   truncateMiddle,
 } from "@/shared/ui/compactText";
+import InventoryReadinessState from "@/shared/ui/InventoryReadinessState";
 import {
   aevatarDrawerBodyStyle,
   aevatarDrawerScrollStyle,
@@ -1253,6 +1254,8 @@ const DeploymentsPage: React.FC = () => {
     }),
     [servicesQuery.data],
   );
+  const deploymentInventoryReady =
+    servicesQuery.data !== undefined && !servicesQuery.error;
 
   const invalidateDetailQueries = useCallback(async () => {
     await invalidateServiceResourceQueries(queryClient);
@@ -1732,21 +1735,37 @@ const DeploymentsPage: React.FC = () => {
           <MetricCard
             label="可见服务"
             tone="info"
-            value={String(visibleServiceDigest.services)}
+            value={
+              deploymentInventoryReady
+                ? String(visibleServiceDigest.services)
+                : "—"
+            }
           />
           <MetricCard
             label="已挂 Serving"
             tone="success"
-            value={String(visibleServiceDigest.servingServices)}
+            value={
+              deploymentInventoryReady
+                ? String(visibleServiceDigest.servingServices)
+                : "—"
+            }
           />
           <MetricCard
             label="待挂 Serving"
             tone="warning"
-            value={String(visibleServiceDigest.waitingServices)}
+            value={
+              deploymentInventoryReady
+                ? String(visibleServiceDigest.waitingServices)
+                : "—"
+            }
           />
           <MetricCard
             label="有入口服务"
-            value={String(visibleServiceDigest.endpointServices)}
+            value={
+              deploymentInventoryReady
+                ? String(visibleServiceDigest.endpointServices)
+                : "—"
+            }
           />
         </div>
 
@@ -1799,19 +1818,29 @@ const DeploymentsPage: React.FC = () => {
             </Space>
           </div>
 
-          {servicesQuery.error ? (
-            <Alert
-              message={
+          {servicesQuery.isLoading ? (
+            <InventoryReadinessState
+              description="发布对象清单仍在加载，返回前不会把当前范围误判为空。"
+              kind="loading"
+              title="正在加载发布服务"
+            />
+          ) : servicesQuery.error ? (
+            <InventoryReadinessState
+              action={{
+                label: "重试发布列表",
+                onClick: () => {
+                  void servicesQuery.refetch();
+                },
+              }}
+              description={
                 servicesQuery.error instanceof Error
                   ? servicesQuery.error.message
-                  : "加载服务发布列表失败。"
+                  : "加载服务发布列表失败，请重试。"
               }
-              showIcon
-              type="error"
+              kind="error"
+              title="发布服务列表暂不可用"
             />
-          ) : null}
-
-          {servicesQuery.data?.length ? (
+          ) : servicesQuery.data?.length ? (
             <div style={{ overflowX: "auto" }}>
               <table
                 style={{
@@ -1957,10 +1986,11 @@ const DeploymentsPage: React.FC = () => {
               </table>
             </div>
           ) : (
-            <Empty
-              description="当前范围没有服务"
-              image={Empty.PRESENTED_IMAGE_SIMPLE}
-              style={{ padding: 24 }}
+            <InventoryReadinessState
+              action={{ label: "调整发布范围", onClick: handleReset }}
+              description="当前 Team、App 和 Namespace 下没有可发布服务。可以调整范围后重新加载。"
+              kind="empty"
+              title="当前范围没有服务"
             />
           )}
         </div>

--- a/apps/aevatar-console-web/src/pages/services/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/services/index.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { renderWithQueryClient } from '../../../tests/reactQueryTestUtils';
 import ServicesPage from './index';
@@ -103,6 +103,14 @@ jest.mock('@/shared/api/servicesApi', () => ({
   },
 }));
 
+const { servicesApi: mockServicesApi } = jest.requireMock(
+  '@/shared/api/servicesApi',
+) as {
+  servicesApi: {
+    listServices: jest.Mock;
+  };
+};
+
 jest.mock('@/shared/studio/api', () => ({
   studioApi: {
     getAuthSession: jest.fn(async () => ({
@@ -115,6 +123,7 @@ jest.mock('@/shared/studio/api', () => ({
 
 describe('ServicesPage', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     window.history.replaceState({}, '', '/services');
   });
 
@@ -141,6 +150,58 @@ describe('ServicesPage', () => {
     expect(screen.getByRole('button', { name: '打开治理' })).toBeTruthy();
     expect(screen.getByRole('button', { name: '筛选服务' })).toBeTruthy();
     expect(screen.queryByText('对象摘要')).toBeNull();
+    expect(screen.queryByText('当前范围没有服务')).toBeNull();
+  });
+
+  it('keeps the services inventory in a loading state until the first response resolves', async () => {
+    let resolveServices: (value: unknown[]) => void = () => {};
+    mockServicesApi.listServices.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveServices = resolve;
+        }),
+    );
+
+    renderWithQueryClient(React.createElement(ServicesPage));
+
+    expect(await screen.findByText('正在加载服务目录')).toBeTruthy();
+    expect(screen.getByText('服务目录请求仍在进行，指标会在返回后更新。')).toBeTruthy();
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(4);
+    expect(screen.queryByText('当前范围没有服务')).toBeNull();
+
+    resolveServices([]);
+
+    expect(await screen.findByText('当前范围没有服务')).toBeTruthy();
+  });
+
+  it('separates services inventory failures from a true empty scope', async () => {
+    mockServicesApi.listServices.mockRejectedValueOnce(
+      new Error('service catalog unavailable'),
+    );
+
+    renderWithQueryClient(React.createElement(ServicesPage));
+
+    expect(await screen.findByText('服务目录暂不可用')).toBeTruthy();
+    expect(screen.getByText('service catalog unavailable')).toBeTruthy();
+    expect(screen.getByRole('button', { name: '重试服务目录' })).toBeTruthy();
+    expect(screen.queryByText('当前范围没有服务')).toBeNull();
+  });
+
+  it('shows an actionable services empty state only after an empty response', async () => {
+    mockServicesApi.listServices.mockResolvedValueOnce([]);
+
+    renderWithQueryClient(React.createElement(ServicesPage));
+
+    expect(await screen.findByText('当前范围没有服务')).toBeTruthy();
+    expect(
+      screen.getByText('当前 Team、App 和 Namespace 下没有可见服务。可以调整范围后重新加载。'),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: '调整服务范围' }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/services');
+    });
   });
 
   it('renders authority detail in drawer after selecting a service', async () => {

--- a/apps/aevatar-console-web/src/pages/services/index.tsx
+++ b/apps/aevatar-console-web/src/pages/services/index.tsx
@@ -7,7 +7,7 @@ import {
   SafetyCertificateOutlined,
 } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
-import { Alert, Button, Empty, Space, Tabs, Tag, Typography, theme } from "antd";
+import { Button, Empty, Space, Tabs, Tag, Typography, theme } from "antd";
 import React, { useEffect, useMemo, useState } from "react";
 import ServiceQueryCard from "@/pages/services/components/ServiceQueryCard";
 import {
@@ -45,6 +45,7 @@ import {
 } from "@/shared/ui/aevatarPageShells";
 import { AevatarCompactText, aevatarMonoFontFamily } from "@/shared/ui/compactText";
 import ConsoleMenuPageShell from "@/shared/ui/ConsoleMenuPageShell";
+import InventoryReadinessState from "@/shared/ui/InventoryReadinessState";
 import {
   codeBlockStyle,
   embeddedPanelStyle,
@@ -540,6 +541,7 @@ const ServicesPage: React.FC = () => {
     () => buildServiceDigestMetrics(servicesQuery.data ?? []),
     [servicesQuery.data],
   );
+  const serviceInventoryReady = servicesQuery.data !== undefined && !servicesQuery.error;
 
   const selectedService = selectedServiceQuery.data;
   const selectedRevisions = revisionsQuery.data?.revisions ?? [];
@@ -613,28 +615,28 @@ const ServicesPage: React.FC = () => {
                 icon={<AppstoreOutlined />}
                 label="可见服务"
                 tone="info"
-                value={digest.services}
+                value={serviceInventoryReady ? digest.services : "—"}
               />
               <ServiceSignalCard
                 caption="已经挂到 serving 的服务"
                 icon={<DeploymentUnitOutlined />}
                 label="已挂 Serving"
                 tone="success"
-                value={digest.servingServices}
+                value={serviceInventoryReady ? digest.servingServices : "—"}
               />
               <ServiceSignalCard
                 caption="需要补主 Actor 的服务"
                 icon={<NodeIndexOutlined />}
                 label="缺主 Actor"
                 tone="warning"
-                value={digest.servicesWithoutOwner}
+                value={serviceInventoryReady ? digest.servicesWithoutOwner : "—"}
               />
               <ServiceSignalCard
                 caption="当前没有公开入口"
                 icon={<ApiOutlined />}
                 label="无公开入口"
                 tone="default"
-                value={digest.servicesWithoutEndpoints}
+                value={serviceInventoryReady ? digest.servicesWithoutEndpoints : "—"}
               />
             </div>
           </div>
@@ -646,19 +648,29 @@ const ServicesPage: React.FC = () => {
           padding={0}
           title="服务目录"
         >
-          {servicesQuery.error ? (
-            <Alert
-              title={
+          {servicesQuery.isLoading ? (
+            <InventoryReadinessState
+              description="服务目录请求仍在进行，指标会在返回后更新。"
+              kind="loading"
+              title="正在加载服务目录"
+            />
+          ) : servicesQuery.error ? (
+            <InventoryReadinessState
+              action={{
+                label: "重试服务目录",
+                onClick: () => {
+                  void servicesQuery.refetch();
+                },
+              }}
+              description={
                 servicesQuery.error instanceof Error
                   ? servicesQuery.error.message
-                  : "Failed to load services."
+                  : "服务目录请求失败，请重试。"
               }
-              showIcon
-              type="error"
+              kind="error"
+              title="服务目录暂不可用"
             />
-          ) : null}
-
-          {servicesQuery.data?.length ? (
+          ) : servicesQuery.data?.length ? (
             <div style={{ overflowX: "auto" }}>
               <table
                 style={{
@@ -809,10 +821,11 @@ const ServicesPage: React.FC = () => {
               </table>
             </div>
           ) : (
-            <Empty
-              description="当前范围没有服务"
-              image={Empty.PRESENTED_IMAGE_SIMPLE}
-              style={{ padding: 24 }}
+            <InventoryReadinessState
+              action={{ label: "调整服务范围", onClick: handleReset }}
+              description="当前 Team、App 和 Namespace 下没有可见服务。可以调整范围后重新加载。"
+              kind="empty"
+              title="当前范围没有服务"
             />
           )}
         </AevatarPanel>

--- a/apps/aevatar-console-web/src/shared/ui/InventoryReadinessState.test.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/InventoryReadinessState.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import InventoryReadinessState from "./InventoryReadinessState";
+
+describe("InventoryReadinessState", () => {
+  it("renders loading state without presenting an empty inventory", () => {
+    render(
+      <InventoryReadinessState
+        description="Keep the current inventory visible until the request resolves."
+        kind="loading"
+        title="Loading inventory"
+      />,
+    );
+
+    expect(screen.getByText("Loading inventory")).toBeTruthy();
+    expect(screen.getByText("Keep the current inventory visible until the request resolves.")).toBeTruthy();
+    expect(screen.getByText("Loading inventory").closest("[aria-busy='true']")).toBeTruthy();
+  });
+
+  it("renders error action without falling through to empty state", () => {
+    const retry = jest.fn();
+
+    render(
+      <InventoryReadinessState
+        action={{ label: "Retry inventory", onClick: retry }}
+        description="The inventory query failed."
+        kind="error"
+        title="Inventory unavailable"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry inventory" }));
+
+    expect(retry).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Inventory unavailable")).toBeTruthy();
+    expect(screen.queryByText("No inventory")).toBeNull();
+  });
+
+  it("renders empty state with an operator action", () => {
+    const refine = jest.fn();
+
+    render(
+      <InventoryReadinessState
+        action={{ label: "Refine scope", onClick: refine }}
+        description="Try a narrower Team, App, or Namespace."
+        kind="empty"
+        title="No inventory"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Refine scope" }));
+
+    expect(refine).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Try a narrower Team, App, or Namespace.")).toBeTruthy();
+  });
+});

--- a/apps/aevatar-console-web/src/shared/ui/InventoryReadinessState.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/InventoryReadinessState.tsx
@@ -1,0 +1,96 @@
+import {
+  Alert,
+  Button,
+  Empty,
+  Skeleton,
+  Space,
+  Typography,
+  theme,
+} from "antd";
+import React from "react";
+
+export type InventoryReadinessKind = "empty" | "error" | "loading";
+
+type InventoryReadinessAction = {
+  label: string;
+  onClick: () => void;
+};
+
+export type InventoryReadinessStateProps = {
+  action?: InventoryReadinessAction;
+  description: React.ReactNode;
+  kind: InventoryReadinessKind;
+  title: React.ReactNode;
+};
+
+export const InventoryReadinessState: React.FC<
+  InventoryReadinessStateProps
+> = ({ action, description, kind, title }) => {
+  const { token } = theme.useToken();
+
+  if (kind === "loading") {
+    return (
+      <div
+        aria-busy="true"
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 14,
+          padding: 24,
+        }}
+      >
+        <Space direction="vertical" size={4}>
+          <Typography.Text strong style={{ color: token.colorTextHeading }}>
+            {title}
+          </Typography.Text>
+          <Typography.Text style={{ color: token.colorTextSecondary }}>
+            {description}
+          </Typography.Text>
+        </Space>
+        <Skeleton active paragraph={{ rows: 4 }} title={false} />
+      </div>
+    );
+  }
+
+  if (kind === "error") {
+    return (
+      <div style={{ padding: 18 }}>
+        <Alert
+          action={
+            action ? (
+              <Button size="small" onClick={action.onClick}>
+                {action.label}
+              </Button>
+            ) : undefined
+          }
+          description={description}
+          message={title}
+          showIcon
+          type="error"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <Empty
+      description={
+        <Space direction="vertical" size={8}>
+          <Typography.Text strong>{title}</Typography.Text>
+          <Typography.Text style={{ color: token.colorTextSecondary }}>
+            {description}
+          </Typography.Text>
+          {action ? (
+            <Button size="small" type="primary" onClick={action.onClick}>
+              {action.label}
+            </Button>
+          ) : null}
+        </Space>
+      }
+      image={Empty.PRESENTED_IMAGE_SIMPLE}
+      style={{ padding: 24 }}
+    />
+  );
+};
+
+export default InventoryReadinessState;


### PR DESCRIPTION
## Problem

Services and Deployments are the first Platform inventory surfaces operators see before choosing a service to inspect or publish. Before this change, both pages could show zero-valued metrics and an empty scope message while the initial inventory query was still loading, and the failure path could still sit next to an empty-state interpretation. That made “loading”, “failed”, and “actually empty” look too similar.

## Solution

- Add a shared `InventoryReadinessState` UI for loading, error, and true empty inventory states.
- Use pending placeholders for Services and Deployments metrics until the inventory query has returned successfully.
- Render retry actions for failed inventory queries instead of falling through to a blank empty-state impression.
- Render actionable empty states only after an empty response arrives.
- Cover the shared component and both pages with focused tests.

## Impact Paths

- `apps/aevatar-console-web/src/shared/ui/InventoryReadinessState.tsx`
- `apps/aevatar-console-web/src/pages/services/index.tsx`
- `apps/aevatar-console-web/src/pages/Deployments/index.tsx`
- related frontend tests

## Verification

- `git diff --check` — pass, no output
- `npm exec --yes --package pnpm@10.2.1 -- pnpm --dir apps/aevatar-console-web exec jest --runInBand src/shared/ui/InventoryReadinessState.test.tsx src/pages/services/index.test.tsx src/pages/Deployments/index.test.tsx` — pass, 3 suites / 18 tests
- `npm exec --yes --package pnpm@10.2.1 -- pnpm --dir apps/aevatar-console-web tsc` — pass
- `bash tools/ci/test_stability_guards.sh` with macOS timeout/envsubst wrappers — pass; optional Python suite skipped because pytest is not installed

## Notes

- Base branch is `feat/2026-05-29_ai-automation-pipeline`.
- This PR only changes frontend UI/tests and does not touch backend/proto/API/actor/projection/workflow/runtime/database/backend tests/backend config/architecture docs.
- No auto-merge has been enabled or attempted.

Closes #1655
