### PR TITLE
Add governance release handoff

### DIFF
--- a/apps/aevatar-console-web/src/pages/Deployments/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/Deployments/index.test.tsx
@@ -348,6 +348,17 @@ describe("DeploymentsPage", () => {
     expect(await screen.findByRole("tab", { name: "Rollout" })).toBeInTheDocument();
   });
 
+  it("opens the selected deployment from a governance handoff URL", async () => {
+    renderDeploymentsPage(
+      "/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent&deploymentId=dep-1",
+    );
+
+    expect(await screen.findByText("发布摘要")).toBeInTheDocument();
+    expect(await screen.findByText("Deployment 数")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "部署候选版本" })).toBeInTheDocument();
+    expect(screen.getAllByText("dep-1").length).toBeGreaterThan(0);
+  });
+
   it("opens the service deployment drawer from the service list row", async () => {
     renderDeploymentsPage(
       "/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market",

--- a/apps/aevatar-console-web/src/pages/governance/components/GovernanceResultPanels.test.tsx
+++ b/apps/aevatar-console-web/src/pages/governance/components/GovernanceResultPanels.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import {
   formatGovernanceTimestamp,
@@ -15,9 +15,15 @@ describe('GovernanceResultPanels', () => {
 
   it('renders the selected governance scope and summary metrics', () => {
     const formattedSnapshot = formatGovernanceTimestamp('2026-03-25T08:00:00Z');
+    const openDeployments = jest.fn();
 
     render(
       <GovernanceSummaryPanel
+        actions={
+          <button type="button" onClick={openDeployments}>
+            打开 Deployments
+          </button>
+        }
         title="绑定目录"
         description="查看绑定目标和已挂接策略。"
         draft={{
@@ -49,14 +55,29 @@ describe('GovernanceResultPanels', () => {
     expect(screen.getByText('绑定')).toBeInTheDocument();
     expect(screen.getByText('8')).toBeInTheDocument();
     expect(screen.getByText('已加载')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '打开 Deployments' }));
+
+    expect(openDeployments).toHaveBeenCalledTimes(1);
   });
 
   it('renders a lightweight selection notice', () => {
+    const inspect = jest.fn();
+
     render(
-      <GovernanceSelectionNotice title="选择服务" />,
+      <GovernanceSelectionNotice
+        actions={
+          <button type="button" onClick={inspect}>
+            检查激活
+          </button>
+        }
+        title="选择服务"
+      />,
     );
 
     expect(screen.getByText('选择服务')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '检查激活' }));
+    expect(inspect).toHaveBeenCalledTimes(1);
   });
 
   it('can omit default identity fields when the context is already shown elsewhere', () => {

--- a/apps/aevatar-console-web/src/pages/governance/components/GovernanceResultPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/governance/components/GovernanceResultPanels.tsx
@@ -1,4 +1,4 @@
-import { Tag, Typography } from 'antd';
+import { Space, Tag, Typography } from 'antd';
 import React from 'react';
 import {
   cardStackStyle,
@@ -31,6 +31,7 @@ export type GovernanceSummaryMetric = {
 
 type GovernanceSummaryPanelProps = {
   title: string;
+  actions?: React.ReactNode;
   description?: string;
   draft: GovernanceDraft;
   revisionId?: string;
@@ -42,6 +43,7 @@ type GovernanceSummaryPanelProps = {
 
 type GovernanceSelectionNoticeProps = {
   title: string;
+  actions?: React.ReactNode;
   description?: string;
   highlights?: Array<{
     key?: string;
@@ -150,26 +152,41 @@ export function formatGovernanceTimestamp(value: string | undefined): string {
 
 export const GovernanceSelectionNotice: React.FC<
   GovernanceSelectionNoticeProps
-> = ({ title, description, highlights = [] }) => (
+> = ({ title, actions, description, highlights = [] }) => (
   <div style={governanceSurfaceStyle}>
     <div style={cardStackStyle}>
-      <div style={governanceHeaderStackStyle}>
-        <Typography.Text
-          strong
-          style={{ color: 'var(--ant-color-text-heading)', fontSize: 16 }}
-        >
-          {title}
-        </Typography.Text>
-        {description ? (
-          <span
-            style={{
-              color: 'var(--ant-color-text-secondary)',
-              fontSize: 14,
-              lineHeight: 1.6,
-            }}
+      <div
+        style={{
+          alignItems: 'flex-start',
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 12,
+          justifyContent: 'space-between',
+        }}
+      >
+        <div style={governanceHeaderStackStyle}>
+          <Typography.Text
+            strong
+            style={{ color: 'var(--ant-color-text-heading)', fontSize: 16 }}
           >
-            {description}
-          </span>
+            {title}
+          </Typography.Text>
+          {description ? (
+            <span
+              style={{
+                color: 'var(--ant-color-text-secondary)',
+                fontSize: 14,
+                lineHeight: 1.6,
+              }}
+            >
+              {description}
+            </span>
+          ) : null}
+        </div>
+        {actions ? (
+          <Space wrap size={[8, 8]} style={{ justifyContent: 'flex-end' }}>
+            {actions}
+          </Space>
         ) : null}
       </div>
       {highlights.length > 0 ? (
@@ -206,6 +223,7 @@ export const GovernanceSelectionNotice: React.FC<
 
 export const GovernanceSummaryPanel: React.FC<GovernanceSummaryPanelProps> = ({
   title,
+  actions,
   description,
   draft,
   revisionId,
@@ -283,6 +301,11 @@ export const GovernanceSummaryPanel: React.FC<GovernanceSummaryPanelProps> = ({
             >
               {status.label}
             </Tag>
+          ) : null}
+          {actions ? (
+            <Space wrap size={[8, 8]} style={{ justifyContent: 'flex-end' }}>
+              {actions}
+            </Space>
           ) : null}
         </div>
 

--- a/apps/aevatar-console-web/src/pages/governance/components/GovernanceWorkbench.tsx
+++ b/apps/aevatar-console-web/src/pages/governance/components/GovernanceWorkbench.tsx
@@ -18,6 +18,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { governanceApi } from "@/shared/api/governanceApi";
 import { servicesApi } from "@/shared/api/servicesApi";
 import { history } from "@/shared/navigation/history";
+import { buildPlatformDeploymentsHref } from "@/shared/navigation/platformRoutes";
 import { resolveStudioScopeContext } from "@/shared/scope/context";
 import { studioApi } from "@/shared/studio/api";
 import type {
@@ -825,6 +826,31 @@ const GovernanceWorkbench: React.FC = () => {
     [activeDraft],
   );
 
+  const openDeploymentsHandoff = useCallback(() => {
+    history.push(
+      buildPlatformDeploymentsHref({
+        appId: activeDraft.appId,
+        deploymentId: selectedService?.deploymentId || undefined,
+        namespace: activeDraft.namespace,
+        serviceId: activeDraft.serviceId,
+        tenantId: activeDraft.tenantId,
+      }),
+    );
+  }, [activeDraft, selectedService?.deploymentId]);
+
+  const releaseHandoffAction = useMemo(
+    () =>
+      hasSelectedServiceContext ? (
+        <Button icon={<DeploymentUnitOutlined />} onClick={openDeploymentsHandoff}>
+          打开 Deployments
+        </Button>
+      ) : null,
+    [hasSelectedServiceContext, openDeploymentsHandoff],
+  );
+
+  const headerReleaseHandoffAction =
+    view === "overview" || view === "activation" ? null : releaseHandoffAction;
+
   const governanceViewActions = useMemo<
     Partial<Record<GovernanceWorkbenchView, GovernanceViewActionConfig>>
   >(
@@ -1448,6 +1474,7 @@ const GovernanceWorkbench: React.FC = () => {
       return (
         <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
           <GovernanceSummaryPanel
+            actions={releaseHandoffAction}
             draft={activeDraft}
             includeDefaultFields={false}
             extraFields={[
@@ -1536,6 +1563,7 @@ const GovernanceWorkbench: React.FC = () => {
               ]}
             />
             <GovernanceSelectionNotice
+              actions={releaseHandoffAction}
               title="下一步建议"
               highlights={[
                 {
@@ -1709,6 +1737,7 @@ const GovernanceWorkbench: React.FC = () => {
     return (
       <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
         <GovernanceSummaryPanel
+          actions={releaseHandoffAction}
           draft={activeDraft}
           includeDefaultFields={false}
           metrics={[
@@ -1816,6 +1845,7 @@ const GovernanceWorkbench: React.FC = () => {
     policiesQuery.data,
     policiesQuery.isLoading,
     publicEndpoints,
+    releaseHandoffAction,
     selectedService?.serviceKey,
     bindingTableColumns,
     endpointTableColumns,
@@ -1952,15 +1982,18 @@ const GovernanceWorkbench: React.FC = () => {
                           minWidth: 172,
                         }}
                       >
-                        {activeAction ? (
-                          <Button
-                            icon={activeAction.icon}
-                            onClick={activeAction.onClick}
-                            type={activeAction.type}
-                          >
-                            {activeAction.label}
-                          </Button>
-                        ) : null}
+                        <Space wrap size={[8, 8]} style={{ justifyContent: "flex-end" }}>
+                          {headerReleaseHandoffAction}
+                          {activeAction ? (
+                            <Button
+                              icon={activeAction.icon}
+                              onClick={activeAction.onClick}
+                              type={activeAction.type}
+                            >
+                              {activeAction.label}
+                            </Button>
+                          ) : null}
+                        </Space>
                       </div>
                     </div>
                     <Tabs

--- a/apps/aevatar-console-web/src/pages/governance/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/governance/index.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { renderWithQueryClient } from '../../../tests/reactQueryTestUtils';
 import GovernanceIndexPage from './index';
@@ -91,6 +91,36 @@ describe('GovernanceIndexPage', () => {
 
     expect(await screen.findByText('Aevatar / Platform')).toBeTruthy();
     expect(screen.getAllByText('Governance').length).toBeGreaterThan(0);
+  });
+
+  it('hands off a governed service to Deployments with service and deployment focus', async () => {
+    renderWithQueryClient(React.createElement(GovernanceIndexPage));
+
+    fireEvent.click(await screen.findByRole('button', { name: '打开 Deployments' }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/deployments');
+    });
+
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get('tenantId')).toBe('tenant-a');
+    expect(params.get('appId')).toBe('app-a');
+    expect(params.get('namespace')).toBe('default');
+    expect(params.get('serviceId')).toBe('service-alpha');
+    expect(params.get('deploymentId')).toBe('deploy-1');
+  });
+
+  it('keeps create actions while showing a secondary deployments handoff in catalog views', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/governance?tenantId=tenant-a&appId=app-a&namespace=default&serviceId=service-alpha&view=bindings',
+    );
+
+    renderWithQueryClient(React.createElement(GovernanceIndexPage));
+
+    expect(await screen.findByRole('button', { name: '新建绑定' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: '打开 Deployments' })).toBeTruthy();
   });
 
   it('does not auto-select the first service when service context is missing', async () => {


### PR DESCRIPTION
## Problem

Governance can show policies, bindings, endpoints, activation, and readiness details for the selected service, but after a user finishes that review there is no direct release handoff into Deployments. The existing next-step guidance is text-only, which leaves the user to manually navigate and reselect tenant, app, namespace, service, and deployment context.

Closes #1657

## Solution

- Add a secondary `打开 Deployments` handoff action for governed service contexts.
- Reuse the existing `buildPlatformDeploymentsHref` route builder so the link carries tenant, app, namespace, service, and deployment focus already supported by Deployments.
- Add reusable action slots to Governance summary and selection notice panels without displacing primary create actions such as `新建绑定`.
- Keep the handoff frontend-only; no backend, proto, API, actor, projection, workflow, runtime, database, backend test, backend config, or architecture doc files are touched.

## Impact paths

- `apps/aevatar-console-web/src/pages/governance/components/GovernanceWorkbench.tsx`
- `apps/aevatar-console-web/src/pages/governance/components/GovernanceResultPanels.tsx`
- `apps/aevatar-console-web/src/pages/governance/index.test.tsx`
- `apps/aevatar-console-web/src/pages/governance/components/GovernanceResultPanels.test.tsx`
- `apps/aevatar-console-web/src/pages/Deployments/index.test.tsx`

## Verification

- `git diff --check` — pass, no output
- `npm exec --yes --package pnpm@10.2.1 -- pnpm --dir apps/aevatar-console-web install --frozen-lockfile` — pass
- `npm exec --yes --package pnpm@10.2.1 -- pnpm --dir apps/aevatar-console-web exec jest --runInBand src/pages/governance/index.test.tsx src/pages/governance/components/GovernanceResultPanels.test.tsx src/pages/Deployments/index.test.tsx` — pass, 3 suites / 17 tests
- `npm exec --yes --package pnpm@10.2.1 -- pnpm --dir apps/aevatar-console-web tsc` — pass
- `bash tools/ci/test_stability_guards.sh` with local macOS `timeout`/`envsubst` compatibility wrapper — pass

## Base / merge policy

- Base branch: `feat/2026-05-29_ai-automation-pipeline`
- This PR is not auto-merged. It is waiting for user review/merge.
