### PR TITLE
修复 workflow tool_call 审批中间件旁路

### DIFF
--- a/src/Aevatar.AI.Abstractions/Middleware/IToolCallMiddleware.cs
+++ b/src/Aevatar.AI.Abstractions/Middleware/IToolCallMiddleware.cs
@@ -11,6 +11,16 @@ public interface IToolCallMiddleware
     Task InvokeAsync(ToolCallContext context, Func<Task> next);
 }
 
+/// <summary>Closed middleware termination status for tool-call policy outcomes.</summary>
+public enum ToolCallTerminationKind
+{
+    None = 0,
+    ApprovalDenied = 1,
+    ApprovalTimedOut = 2,
+    ApprovalPending = 3,
+    MiddlewareTerminated = 4,
+}
+
 /// <summary>Context for tool call middleware.</summary>
 public sealed class ToolCallContext
 {
@@ -34,6 +44,12 @@ public sealed class ToolCallContext
 
     /// <summary>When true, tool execution is skipped and Result is returned as-is.</summary>
     public bool Terminate { get; set; }
+
+    /// <summary>Closed reason for middleware termination.</summary>
+    public ToolCallTerminationKind TerminationKind { get; set; }
+
+    /// <summary>Human-readable policy or middleware termination reason.</summary>
+    public string? TerminationReason { get; set; }
 
     /// <summary>Arbitrary items shared across the middleware chain.</summary>
     public IDictionary<string, object> Items { get; } = new Dictionary<string, object>();

--- a/src/Aevatar.AI.Abstractions/ToolProviders/IAgentToolExecutionPort.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/IAgentToolExecutionPort.cs
@@ -1,0 +1,38 @@
+namespace Aevatar.AI.Abstractions.ToolProviders;
+
+/// <summary>Executes agent tools through the configured tool-call policy pipeline.</summary>
+public interface IAgentToolExecutionPort
+{
+    Task<AgentToolExecutionResult> ExecuteAsync(
+        AgentToolExecutionRequest request,
+        CancellationToken ct);
+}
+
+public sealed record AgentToolExecutionRequest(
+    IAgentTool Tool,
+    string ToolName,
+    string ToolCallId,
+    string ArgumentsJson,
+    AgentToolExecutionContext ExecutionContext);
+
+public sealed record AgentToolExecutionResult(
+    AgentToolExecutionStatus Status,
+    string? ResultJson,
+    string? ErrorMessage)
+{
+    public static AgentToolExecutionResult Succeeded(string resultJson) =>
+        new(AgentToolExecutionStatus.Succeeded, resultJson, null);
+
+    public static AgentToolExecutionResult Failed(string errorMessage) =>
+        new(AgentToolExecutionStatus.Failed, null, errorMessage);
+}
+
+public enum AgentToolExecutionStatus
+{
+    Succeeded = 0,
+    ApprovalDenied = 1,
+    ApprovalTimedOut = 2,
+    ApprovalPending = 3,
+    MiddlewareTerminated = 4,
+    Failed = 5,
+}

--- a/src/Aevatar.AI.Core/AIGAgentBase.cs
+++ b/src/Aevatar.AI.Core/AIGAgentBase.cs
@@ -6,6 +6,7 @@
 using Aevatar.AI.Core.Chat;
 using Aevatar.AI.Core.Hooks;
 using Aevatar.AI.Core.Hooks.BuiltIn;
+using Aevatar.AI.Core.Middleware;
 using Aevatar.AI.Core.Tools;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.Middleware;
@@ -302,10 +303,10 @@ public abstract class AIGAgentBase<TState> : GAgentBase<TState, AIAgentConfig>
         }
 
         // 构建 Tool Call Middleware 链（审批中间件在最前面，不可绕过）
-        var effectiveToolMiddlewares = new List<IToolCallMiddleware>();
-        if (_approvalHandler != null)
-            effectiveToolMiddlewares.Add(new Middleware.ToolApprovalMiddleware(_approvalHandler, _hooks));
-        effectiveToolMiddlewares.AddRange(_toolMiddlewares);
+        var effectiveToolMiddlewares = ToolCallMiddlewareChainFactory.ForAgentRuntime(
+            _toolMiddlewares,
+            _approvalHandler,
+            _hooks);
 
         // 构建 Chat Runtime
         var toolLoop = new ToolCallLoop(Tools, _hooks, effectiveToolMiddlewares, _llmMiddlewares, History.Budget);

--- a/src/Aevatar.AI.Core/Middleware/ToolApprovalMiddleware.cs
+++ b/src/Aevatar.AI.Core/Middleware/ToolApprovalMiddleware.cs
@@ -73,9 +73,11 @@ public sealed class ToolApprovalMiddleware : IToolCallMiddleware
         var denialCount = GetRequestScopedDenialCount(context);
         if (denialCount >= MaxConsecutiveDenials)
         {
+            var reason = $"Tool '{context.ToolName}' has been denied {denialCount} times consecutively.";
             context.Terminate = true;
-            context.Result = $"Tool '{context.ToolName}' has been denied {denialCount} times consecutively. " +
-                             "Automatic block applied. Consider using a different approach.";
+            context.TerminationKind = ToolCallTerminationKind.ApprovalDenied;
+            context.TerminationReason = reason;
+            context.Result = $"{reason} Automatic block applied. Consider using a different approach.";
             return;
         }
 
@@ -119,6 +121,8 @@ public sealed class ToolApprovalMiddleware : IToolCallMiddleware
             case ToolApprovalDecision.Denied:
                 context.Items[DenialCountItemKey] = denialCount + 1;
                 context.Terminate = true;
+                context.TerminationKind = ToolCallTerminationKind.ApprovalDenied;
+                context.TerminationReason = result.Reason;
                 context.Result = !string.IsNullOrWhiteSpace(result.Reason)
                     ? $"Tool '{context.ToolName}' execution denied: {result.Reason}"
                     : $"Tool '{context.ToolName}' execution denied by approval handler.";
@@ -126,6 +130,8 @@ public sealed class ToolApprovalMiddleware : IToolCallMiddleware
 
             case ToolApprovalDecision.Timeout:
                 context.Terminate = true;
+                context.TerminationKind = ToolCallTerminationKind.ApprovalTimedOut;
+                context.TerminationReason = result.Reason;
                 context.Result = $"Tool '{context.ToolName}' approval timed out. " +
                                  "The tool was not executed. Please try again or approve when prompted.";
                 return;
@@ -134,6 +140,8 @@ public sealed class ToolApprovalMiddleware : IToolCallMiddleware
                 // 非阻塞 yield：返回 pending result，不增加 denial counter。
                 // Actor 层检测此 result 后持久化 pending state 并走事件化续传。
                 context.Terminate = true;
+                context.TerminationKind = ToolCallTerminationKind.ApprovalPending;
+                context.TerminationReason = result.Reason;
                 context.Result = BuildApprovalPendingResult(request);
                 return;
         }

--- a/src/Aevatar.AI.Core/Middleware/ToolCallMiddlewareChainFactory.cs
+++ b/src/Aevatar.AI.Core/Middleware/ToolCallMiddlewareChainFactory.cs
@@ -1,0 +1,66 @@
+using Aevatar.AI.Abstractions.Middleware;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.Hooks;
+
+namespace Aevatar.AI.Core.Middleware;
+
+public static class ToolCallMiddlewareChainFactory
+{
+    public static IReadOnlyList<IToolCallMiddleware> ForAgentRuntime(
+        IEnumerable<IToolCallMiddleware> toolMiddlewares,
+        IToolApprovalHandler? approvalHandler,
+        AgentHookPipeline? hooks)
+    {
+        ArgumentNullException.ThrowIfNull(toolMiddlewares);
+
+        return Build(
+            toolMiddlewares,
+            approvalHandler,
+            hooks,
+            failClosedWhenMissingApprovalHandler: false);
+    }
+
+    public static IReadOnlyList<IToolCallMiddleware> ForPort(
+        IEnumerable<IToolCallMiddleware> toolMiddlewares,
+        IToolApprovalHandler? approvalHandler,
+        AgentHookPipeline? hooks)
+    {
+        ArgumentNullException.ThrowIfNull(toolMiddlewares);
+
+        return Build(
+            toolMiddlewares,
+            approvalHandler,
+            hooks,
+            failClosedWhenMissingApprovalHandler: true);
+    }
+
+    private static IReadOnlyList<IToolCallMiddleware> Build(
+        IEnumerable<IToolCallMiddleware> toolMiddlewares,
+        IToolApprovalHandler? approvalHandler,
+        AgentHookPipeline? hooks,
+        bool failClosedWhenMissingApprovalHandler)
+    {
+        var effectiveToolMiddlewares = new List<IToolCallMiddleware>();
+        var effectiveApprovalHandler = approvalHandler
+                                       ?? (failClosedWhenMissingApprovalHandler
+                                           ? MissingApprovalHandler.Instance
+                                           : null);
+        if (effectiveApprovalHandler != null)
+            effectiveToolMiddlewares.Add(new ToolApprovalMiddleware(effectiveApprovalHandler, hooks));
+        effectiveToolMiddlewares.AddRange(toolMiddlewares);
+        return effectiveToolMiddlewares;
+    }
+
+    private sealed class MissingApprovalHandler : IToolApprovalHandler
+    {
+        public static readonly MissingApprovalHandler Instance = new();
+
+        public Task<ToolApprovalResult> RequestApprovalAsync(
+            ToolApprovalRequest request,
+            CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(ToolApprovalResult.Denied("approval handler is not configured"));
+        }
+    }
+}

--- a/src/Aevatar.AI.Core/Tools/AgentToolExecutionPort.cs
+++ b/src/Aevatar.AI.Core/Tools/AgentToolExecutionPort.cs
@@ -1,0 +1,91 @@
+using Aevatar.AI.Abstractions.Middleware;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.Middleware;
+
+namespace Aevatar.AI.Core.Tools;
+
+public sealed class AgentToolExecutionPort : IAgentToolExecutionPort
+{
+    private readonly IReadOnlyList<IToolCallMiddleware> _toolMiddlewares;
+
+    public AgentToolExecutionPort(IReadOnlyList<IToolCallMiddleware> toolMiddlewares)
+    {
+        _toolMiddlewares = toolMiddlewares ?? throw new ArgumentNullException(nameof(toolMiddlewares));
+    }
+
+    public AgentToolExecutionPort(IEnumerable<IToolCallMiddleware> toolMiddlewares)
+        : this(toolMiddlewares?.ToArray() ?? throw new ArgumentNullException(nameof(toolMiddlewares)))
+    {
+    }
+
+    public async Task<AgentToolExecutionResult> ExecuteAsync(
+        AgentToolExecutionRequest request,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        try
+        {
+            var context = new ToolCallContext
+            {
+                Tool = request.Tool,
+                ToolName = request.ToolName,
+                ToolCallId = request.ToolCallId,
+                ArgumentsJson = request.ArgumentsJson,
+                CancellationToken = ct,
+            };
+
+            using (AgentToolContextScope.Push(request.ExecutionContext))
+            {
+                await MiddlewarePipeline.RunToolCallAsync(_toolMiddlewares, context, async () =>
+                {
+                    if (context.Terminate)
+                        return;
+
+                    context.Result = await context.Tool.ExecuteAsync(context.ArgumentsJson, ct);
+                });
+            }
+
+            if (context.Terminate)
+            {
+                return new AgentToolExecutionResult(
+                    MapTerminationStatus(context.TerminationKind),
+                    context.Result,
+                    ResolveTerminationError(context));
+            }
+
+            if (context.Result == null)
+                return AgentToolExecutionResult.Failed($"Tool '{context.ToolName}' returned no result.");
+
+            return AgentToolExecutionResult.Succeeded(context.Result);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return AgentToolExecutionResult.Failed(ex.Message);
+        }
+    }
+
+    private static AgentToolExecutionStatus MapTerminationStatus(ToolCallTerminationKind kind) =>
+        kind switch
+        {
+            ToolCallTerminationKind.ApprovalDenied => AgentToolExecutionStatus.ApprovalDenied,
+            ToolCallTerminationKind.ApprovalTimedOut => AgentToolExecutionStatus.ApprovalTimedOut,
+            ToolCallTerminationKind.ApprovalPending => AgentToolExecutionStatus.ApprovalPending,
+            _ => AgentToolExecutionStatus.MiddlewareTerminated,
+        };
+
+    private static string? ResolveTerminationError(ToolCallContext context)
+    {
+        if (!string.IsNullOrWhiteSpace(context.TerminationReason))
+            return context.TerminationReason;
+
+        if (context.TerminationKind == ToolCallTerminationKind.None)
+            return "Tool execution was terminated by middleware.";
+
+        return context.Result;
+    }
+}

--- a/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
@@ -1,8 +1,13 @@
 using Aevatar.AI.Abstractions.Agents;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.Middleware;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.Core.Voice;
 using Aevatar.AI.Core.Agents;
+using Aevatar.AI.Core.Hooks;
 using Aevatar.AI.Core.LLMProviders;
+using Aevatar.AI.Core.Middleware;
+using Aevatar.AI.Core.Tools;
 using Aevatar.AI.LLMProviders.MEAI;
 using Aevatar.AI.LLMProviders.NyxId;
 using Aevatar.AI.LLMProviders.Tornado;
@@ -95,6 +100,12 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IRoleAgentTypeResolver, RoleGAgentTypeResolver>();
         services.TryAddSingleton<IVoiceToolInvoker, AgentToolVoiceInvoker>();
         services.TryAddSingleton<IVoiceToolCatalog, AgentToolVoiceCatalog>();
+        services.TryAddSingleton<IAgentToolExecutionPort>(sp =>
+            new AgentToolExecutionPort(
+                ToolCallMiddlewareChainFactory.ForPort(
+                    sp.GetServices<IToolCallMiddleware>(),
+                    sp.GetService<IToolApprovalHandler>(),
+                    sp.GetService<AgentHookPipeline>())));
         services.TryAddSingleton<IWorkflowYamlValidator, WorkflowYamlValidatorImpl>();
         services.TryAddSingleton<IWorkflowDefinitionCommandAdapter>(sp =>
             new LocalWorkflowDefinitionCommandAdapter(

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
@@ -17,14 +17,17 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
 {
     private readonly IEnumerable<IAgentToolSource> _toolSources;
     private readonly ILogger<ToolCallModule> _logger;
+    private readonly IAgentToolExecutionPort? _executionPort;
     private volatile Lazy<Task<IReadOnlyDictionary<string, IAgentTool>>>? _toolIndex;
 
     public ToolCallModule(
         IEnumerable<IAgentToolSource> toolSources,
-        ILogger<ToolCallModule> logger)
+        ILogger<ToolCallModule> logger,
+        IAgentToolExecutionPort? executionPort = null)
     {
         _toolSources = toolSources ?? throw new ArgumentNullException(nameof(toolSources));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _executionPort = executionPort;
     }
 
     public string Name => "tool_call";
@@ -76,20 +79,47 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
             return;
         }
 
+        if (_executionPort == null)
+        {
+            await PublishToolFailureAsync(
+                ctx,
+                request,
+                toolName,
+                "agent tool execution port is not configured",
+                ct);
+            return;
+        }
+
         try
         {
             var toolContext = BuildToolContext(ctx, callId);
-            string result;
-            using (AgentToolContextScope.Push(toolContext))
+            var result = await _executionPort.ExecuteAsync(
+                new AgentToolExecutionRequest(
+                    Tool: tool,
+                    ToolName: toolName,
+                    ToolCallId: callId,
+                    ArgumentsJson: argumentsJson,
+                    ExecutionContext: toolContext),
+                ct);
+
+            if (result.Status != AgentToolExecutionStatus.Succeeded)
             {
-                result = await tool.ExecuteAsync(argumentsJson, ct);
+                await PublishToolFailureAsync(
+                    ctx,
+                    request,
+                    toolName,
+                    BuildExecutionFailure(result),
+                    ct);
+                return;
             }
+
+            var resultJson = result.ResultJson ?? string.Empty;
 
             await ctx.PublishAsync(new ToolResultEvent
             {
                 CallId = callId,
                 Success = true,
-                ResultJson = result,
+                ResultJson = resultJson,
             }, TopologyAudience.Self, ct);
 
             await ctx.PublishAsync(new StepCompletedEvent
@@ -98,7 +128,7 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
                 RunId = request.RunId,
                 ExecutionId = request.ExecutionId,
                 Success = true,
-                Output = result,
+                Output = resultJson,
             }, TopologyAudience.Self, ct);
         }
         catch (Exception ex)
@@ -121,6 +151,22 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
             {
                 CallId = callId
             }
+        };
+    }
+
+    private static string BuildExecutionFailure(AgentToolExecutionResult result)
+    {
+        if (!string.IsNullOrWhiteSpace(result.ErrorMessage))
+            return result.ErrorMessage;
+
+        return result.Status switch
+        {
+            AgentToolExecutionStatus.ApprovalDenied => "tool execution denied by approval policy",
+            AgentToolExecutionStatus.ApprovalTimedOut => "tool approval timed out",
+            AgentToolExecutionStatus.ApprovalPending => "tool approval is pending",
+            AgentToolExecutionStatus.MiddlewareTerminated => "tool execution terminated by middleware",
+            AgentToolExecutionStatus.Failed => "tool execution failed",
+            _ => $"tool execution did not succeed: {result.Status}",
         };
     }
 

--- a/test/Aevatar.AI.Core.Tests/Middleware/ToolApprovalMiddlewareTests.cs
+++ b/test/Aevatar.AI.Core.Tests/Middleware/ToolApprovalMiddlewareTests.cs
@@ -165,6 +165,8 @@ public class ToolApprovalMiddlewareTests
 
         nextExecuted.Should().BeFalse();
         ctx.Terminate.Should().BeTrue();
+        ctx.TerminationKind.Should().Be(ToolCallTerminationKind.ApprovalDenied);
+        ctx.TerminationReason.Should().Be("blocked");
         ctx.Result.Should().Contain("Tool 'danger' execution denied: blocked");
     }
 
@@ -183,6 +185,7 @@ public class ToolApprovalMiddlewareTests
         await middleware.InvokeAsync(ctx, () => Task.CompletedTask);
 
         ctx.Terminate.Should().BeTrue();
+        ctx.TerminationKind.Should().Be(ToolCallTerminationKind.ApprovalTimedOut);
         ctx.Result.Should().Contain("approval timed out");
     }
 
@@ -201,6 +204,8 @@ public class ToolApprovalMiddlewareTests
         await middleware.InvokeAsync(ctx, () => Task.CompletedTask);
 
         ctx.Terminate.Should().BeTrue();
+        ctx.TerminationKind.Should().Be(ToolCallTerminationKind.ApprovalPending);
+        ctx.TerminationReason.Should().Be("req-1");
         ctx.Result.Should().Contain("\"approval_required\":true");
         ctx.Result.Should().Contain("\"request_id\":\"");
     }
@@ -217,6 +222,8 @@ public class ToolApprovalMiddlewareTests
         await middleware.InvokeAsync(ctx, () => Task.CompletedTask);
 
         ctx.Terminate.Should().BeTrue();
+        ctx.TerminationKind.Should().Be(ToolCallTerminationKind.ApprovalDenied);
+        ctx.TerminationReason.Should().Contain("denied 3 times");
         ctx.Result.Should().Contain("has been denied 3 times");
         handler.Requests.Should().BeEmpty();
     }

--- a/test/Aevatar.AI.Core.Tests/Tools/AgentToolExecutionPortTests.cs
+++ b/test/Aevatar.AI.Core.Tests/Tools/AgentToolExecutionPortTests.cs
@@ -3,6 +3,7 @@ using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.Core.Middleware;
 using Aevatar.AI.Core.Tools;
 using FluentAssertions;
+using System.Text.Json;
 
 namespace Aevatar.AI.Core.Tests.Tools;
 
@@ -78,6 +79,44 @@ public sealed class AgentToolExecutionPortTests
         result.Status.Should().Be(AgentToolExecutionStatus.ApprovalDenied);
         result.ErrorMessage.Should().Contain("approval handler is not configured");
         tool.ExecuteCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task TimedOutApproval_ShouldReturnTimedOutAndSkipTool()
+    {
+        var tool = new CountingAgentTool("danger", ToolApprovalMode.AlwaysRequire);
+        var approval = new ScriptedApprovalHandler(ToolApprovalResult.TimedOut("approval expired"));
+        var port = new AgentToolExecutionPort(
+            ToolCallMiddlewareChainFactory.ForPort([], approval, hooks: null));
+
+        var result = await port.ExecuteAsync(Request(tool), CancellationToken.None);
+
+        result.Status.Should().Be(AgentToolExecutionStatus.ApprovalTimedOut);
+        result.ErrorMessage.Should().Be("approval expired");
+        result.ResultJson.Should().Contain("approval timed out");
+        tool.ExecuteCalls.Should().Be(0);
+        approval.Requests.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task YieldedApproval_ShouldReturnPendingAndSkipTool()
+    {
+        var tool = new CountingAgentTool("danger", ToolApprovalMode.AlwaysRequire);
+        var approval = new ScriptedApprovalHandler(ToolApprovalResult.Yielded("approval-request-1"));
+        var port = new AgentToolExecutionPort(
+            ToolCallMiddlewareChainFactory.ForPort([], approval, hooks: null));
+
+        var result = await port.ExecuteAsync(Request(tool), CancellationToken.None);
+
+        result.Status.Should().Be(AgentToolExecutionStatus.ApprovalPending);
+        result.ErrorMessage.Should().Be("approval-request-1");
+        using var payload = JsonDocument.Parse(result.ResultJson!);
+        payload.RootElement.GetProperty("approval_required").GetBoolean().Should().BeTrue();
+        payload.RootElement.GetProperty("tool_name").GetString().Should().Be("danger");
+        payload.RootElement.GetProperty("tool_call_id").GetString().Should().Be("tc-1");
+        payload.RootElement.GetProperty("message").GetString().Should().Contain("requires user approval");
+        tool.ExecuteCalls.Should().Be(0);
+        approval.Requests.Should().ContainSingle();
     }
 
     [Fact]

--- a/test/Aevatar.AI.Core.Tests/Tools/AgentToolExecutionPortTests.cs
+++ b/test/Aevatar.AI.Core.Tests/Tools/AgentToolExecutionPortTests.cs
@@ -1,0 +1,166 @@
+using Aevatar.AI.Abstractions.Middleware;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.Middleware;
+using Aevatar.AI.Core.Tools;
+using FluentAssertions;
+
+namespace Aevatar.AI.Core.Tests.Tools;
+
+public sealed class AgentToolExecutionPortTests
+{
+    [Fact]
+    public async Task AlwaysRequireDenied_ShouldRequestApprovalAndSkipTool()
+    {
+        var tool = new CountingAgentTool("danger", ToolApprovalMode.AlwaysRequire);
+        var approval = new ScriptedApprovalHandler(ToolApprovalResult.Denied("blocked"));
+        var port = new AgentToolExecutionPort(
+            ToolCallMiddlewareChainFactory.ForPort([], approval, hooks: null));
+
+        var result = await port.ExecuteAsync(Request(tool), CancellationToken.None);
+
+        result.Status.Should().Be(AgentToolExecutionStatus.ApprovalDenied);
+        result.ErrorMessage.Should().Contain("blocked");
+        tool.ExecuteCalls.Should().Be(0);
+        approval.Requests.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task AutoRequiresApprovalTrue_ShouldRequestApproval()
+    {
+        var tool = new CountingAgentTool("dynamic", ToolApprovalMode.Auto)
+        {
+            RuntimeDecision = true,
+        };
+        var approval = new ScriptedApprovalHandler(ToolApprovalResult.Approved());
+        var port = new AgentToolExecutionPort(
+            ToolCallMiddlewareChainFactory.ForPort([], approval, hooks: null));
+
+        var result = await port.ExecuteAsync(Request(tool, argumentsJson: """{"method":"POST"}"""), CancellationToken.None);
+
+        result.Status.Should().Be(AgentToolExecutionStatus.Succeeded);
+        result.ResultJson.Should().Be("""{"ok":true}""");
+        tool.ExecuteCalls.Should().Be(1);
+        approval.Requests.Should().ContainSingle()
+            .Which.ArgumentsJson.Should().Be("""{"method":"POST"}""");
+    }
+
+    [Fact]
+    public async Task Approved_ShouldExecuteToolInsideAgentToolContextScope()
+    {
+        var tool = new ContextReadingTool("context_reader");
+        var approval = new ScriptedApprovalHandler(ToolApprovalResult.Approved());
+        var port = new AgentToolExecutionPort(
+            ToolCallMiddlewareChainFactory.ForPort([], approval, hooks: null));
+        var context = AgentToolExecutionContext.Empty with
+        {
+            Credentials = AgentToolCredentials.Empty with
+            {
+                NyxIdAccessToken = "token-123",
+            },
+        };
+
+        var result = await port.ExecuteAsync(Request(tool, context), CancellationToken.None);
+
+        result.Status.Should().Be(AgentToolExecutionStatus.Succeeded);
+        result.ResultJson.Should().Be("token-123");
+        tool.ExecuteCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task MissingApprovalHandler_ShouldDenyApprovalRequiredTool()
+    {
+        var tool = new CountingAgentTool("danger", ToolApprovalMode.AlwaysRequire);
+        var port = new AgentToolExecutionPort(
+            ToolCallMiddlewareChainFactory.ForPort([], approvalHandler: null, hooks: null));
+
+        var result = await port.ExecuteAsync(Request(tool), CancellationToken.None);
+
+        result.Status.Should().Be(AgentToolExecutionStatus.ApprovalDenied);
+        result.ErrorMessage.Should().Contain("approval handler is not configured");
+        tool.ExecuteCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task MiddlewareTerminateWithoutApprovalKind_ShouldReturnMiddlewareTerminated()
+    {
+        var tool = new CountingAgentTool("blocked", ToolApprovalMode.NeverRequire);
+        var port = new AgentToolExecutionPort(
+            [
+                new DelegateToolCallMiddleware((context, _) =>
+                {
+                    context.Terminate = true;
+                    context.Result = """{"blocked":true}""";
+                    return Task.CompletedTask;
+                }),
+            ]);
+
+        var result = await port.ExecuteAsync(Request(tool), CancellationToken.None);
+
+        result.Status.Should().Be(AgentToolExecutionStatus.MiddlewareTerminated);
+        result.ResultJson.Should().Be("""{"blocked":true}""");
+        tool.ExecuteCalls.Should().Be(0);
+    }
+
+    private static AgentToolExecutionRequest Request(
+        IAgentTool tool,
+        AgentToolExecutionContext? context = null,
+        string argumentsJson = "{}") =>
+        new(
+            Tool: tool,
+            ToolName: tool.Name,
+            ToolCallId: "tc-1",
+            ArgumentsJson: argumentsJson,
+            ExecutionContext: context ?? AgentToolExecutionContext.Empty);
+
+    private sealed class CountingAgentTool(string name, ToolApprovalMode approvalMode) : IAgentTool
+    {
+        public string Name { get; } = name;
+        public string Description => "fake";
+        public string ParametersSchema => "{}";
+        public ToolApprovalMode ApprovalMode { get; } = approvalMode;
+        public bool? RuntimeDecision { get; init; }
+        public int ExecuteCalls { get; private set; }
+
+        public bool? RequiresApproval(string argumentsJson) => RuntimeDecision;
+
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+        {
+            ExecuteCalls++;
+            return Task.FromResult("""{"ok":true}""");
+        }
+    }
+
+    private sealed class ContextReadingTool(string name) : IAgentTool
+    {
+        public string Name { get; } = name;
+        public string Description => "context reader";
+        public string ParametersSchema => "{}";
+        public ToolApprovalMode ApprovalMode => ToolApprovalMode.AlwaysRequire;
+        public int ExecuteCalls { get; private set; }
+
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+        {
+            ExecuteCalls++;
+            return Task.FromResult(AgentToolRequestContext.NyxIdAccessToken ?? string.Empty);
+        }
+    }
+
+    private sealed class ScriptedApprovalHandler(params ToolApprovalResult[] results) : IToolApprovalHandler
+    {
+        private readonly Queue<ToolApprovalResult> _results = new(results);
+
+        public List<ToolApprovalRequest> Requests { get; } = [];
+
+        public Task<ToolApprovalResult> RequestApprovalAsync(ToolApprovalRequest request, CancellationToken ct)
+        {
+            Requests.Add(request);
+            return Task.FromResult(_results.TryDequeue(out var result) ? result : ToolApprovalResult.Denied());
+        }
+    }
+
+    private sealed class DelegateToolCallMiddleware(
+        Func<ToolCallContext, Func<Task>, Task> handler) : IToolCallMiddleware
+    {
+        public Task InvokeAsync(ToolCallContext context, Func<Task> next) => handler(context, next);
+    }
+}

--- a/test/Aevatar.Bootstrap.Tests/AIFeatureBootstrapCoverageTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/AIFeatureBootstrapCoverageTests.cs
@@ -109,6 +109,7 @@ public class AIFeatureBootstrapCoverageTests
         using var provider = services.BuildServiceProvider();
         provider.GetService<IRoleAgentTypeResolver>().Should().NotBeNull();
         provider.GetService<IVoiceToolInvoker>().Should().NotBeNull();
+        provider.GetService<IAgentToolExecutionPort>().Should().NotBeNull();
 
         var llmFactory = provider.GetRequiredService<ILLMProviderFactory>();
         llmFactory.GetDefault().Name.Should().Be("deepseek");

--- a/test/Aevatar.Integration.Tests/WorkflowCoreModulesCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowCoreModulesCoverageTests.cs
@@ -78,7 +78,7 @@ public sealed class WorkflowCoreModulesCoverageTests
                 new FakeAgentTool("echo", args => args),
             ]);
         IAgentToolSource[] toolSources = [new ThrowingToolSource(), source];
-        var module = new ToolCallModule(toolSources, NullLogger<ToolCallModule>.Instance);
+        var module = CreateToolCallModule(toolSources);
         var ctx = CreateContext();
         var request = new StepRequestEvent
         {
@@ -103,7 +103,7 @@ public sealed class WorkflowCoreModulesCoverageTests
             [
                 new FakeAgentTool("cached_echo", args => args),
             ]);
-        var module = new ToolCallModule([source], NullLogger<ToolCallModule>.Instance);
+        var module = CreateToolCallModule([source]);
         var ctx = CreateContext();
 
         await module.HandleAsync(
@@ -139,7 +139,7 @@ public sealed class WorkflowCoreModulesCoverageTests
             [
                 new FakeAgentTool("parallel_echo", args => args),
             ]);
-        var module = new ToolCallModule([source], NullLogger<ToolCallModule>.Instance);
+        var module = CreateToolCallModule([source]);
         var ready = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var start = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var readyCount = 0;
@@ -188,7 +188,7 @@ public sealed class WorkflowCoreModulesCoverageTests
             [
                 new FakeAgentTool("delayed_echo", args => args),
             ]);
-        var module = new ToolCallModule([source], NullLogger<ToolCallModule>.Instance);
+        var module = CreateToolCallModule([source]);
         var cancelledContext = CreateContext();
         using var cts = new CancellationTokenSource();
 
@@ -233,7 +233,7 @@ public sealed class WorkflowCoreModulesCoverageTests
             [
                 new FakeAgentTool("explode", _ => throw new InvalidOperationException("boom")),
             ]);
-        var module = new ToolCallModule([source], NullLogger<ToolCallModule>.Instance);
+        var module = CreateToolCallModule([source]);
         var ctx = CreateContext();
 
         await module.HandleAsync(
@@ -249,6 +249,33 @@ public sealed class WorkflowCoreModulesCoverageTests
         var completed = ctx.Published.Select(x => x.evt).OfType<StepCompletedEvent>().Last();
         completed.Success.Should().BeFalse();
         completed.Error.Should().Contain("execution failed: boom");
+    }
+
+    [Fact]
+    public async Task ToolCallModule_WhenExecutionPortMissing_ShouldFailClosedAfterToolDiscovery()
+    {
+        var tool = new CountingFakeAgentTool("safe_echo", args => args);
+        var module = new ToolCallModule([new CountingToolSource([tool])], NullLogger<ToolCallModule>.Instance);
+        var ctx = CreateContext();
+
+        await module.HandleAsync(
+            Envelope(new StepRequestEvent
+            {
+                StepId = "step-no-port",
+                StepType = "tool_call",
+                Input = """{"msg":"blocked"}""",
+                Parameters = { ["tool"] = "safe_echo" },
+            }),
+            ctx,
+            CancellationToken.None);
+
+        tool.ExecuteCalls.Should().Be(0);
+        var toolResult = ctx.Published.Select(x => x.evt).OfType<ToolResultEvent>().Single();
+        toolResult.Success.Should().BeFalse();
+        toolResult.Error.Should().Contain("execution port is not configured");
+        var completed = ctx.Published.Select(x => x.evt).OfType<StepCompletedEvent>().Single();
+        completed.Success.Should().BeFalse();
+        completed.Error.Should().Contain("execution port is not configured");
     }
 
     [Fact]
@@ -1495,6 +1522,12 @@ public sealed class WorkflowCoreModulesCoverageTests
         };
     }
 
+    private static ToolCallModule CreateToolCallModule(IReadOnlyList<IAgentToolSource> toolSources) =>
+        new(
+            toolSources,
+            NullLogger<ToolCallModule>.Instance,
+            new DirectFakeExecutionPort());
+
     private sealed class FakeAgentTool(string name, Func<string, string> execute) : IAgentTool
     {
         public string Name { get; } = name;
@@ -1504,6 +1537,31 @@ public sealed class WorkflowCoreModulesCoverageTests
         public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
         {
             return Task.FromResult(execute(argumentsJson));
+        }
+    }
+
+    private sealed class CountingFakeAgentTool(string name, Func<string, string> execute) : IAgentTool
+    {
+        public string Name { get; } = name;
+        public string Description => "counting fake tool";
+        public string ParametersSchema => "{}";
+        public int ExecuteCalls { get; private set; }
+
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+        {
+            ExecuteCalls++;
+            return Task.FromResult(execute(argumentsJson));
+        }
+    }
+
+    private sealed class DirectFakeExecutionPort : IAgentToolExecutionPort
+    {
+        public async Task<AgentToolExecutionResult> ExecuteAsync(
+            AgentToolExecutionRequest request,
+            CancellationToken ct)
+        {
+            var result = await request.Tool.ExecuteAsync(request.ArgumentsJson, ct);
+            return AgentToolExecutionResult.Succeeded(result);
         }
     }
 

--- a/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
@@ -148,7 +148,8 @@ public sealed class ToolCallModuleContextTests
     public async Task ToolCallModule_ShouldSetExecutionIdOnFailureStepCompletion()
     {
         var tool = new FakeAgentTool("failing_tool", _ => throw new InvalidOperationException("boom"));
-        var module = CreateModule(tool);
+        var port = new FakeExecutionPort(AgentToolExecutionResult.Failed("boom"));
+        var module = CreateModule(tool, port);
         var ctx = new RecordingWorkflowContext();
 
         await ExecuteToolCallAsync(module, ctx, tool.Name, stepId: "call_proxy", executionId: "exec-1");
@@ -336,8 +337,97 @@ public sealed class ToolCallModuleContextTests
         LastCompleted(ctx).Output.Should().Be("""{"proxied":true}""");
     }
 
-    private static ToolCallModule CreateModule(IAgentTool tool) =>
-        new([new SingleToolSource(tool)], NullLogger<ToolCallModule>.Instance);
+    [Fact]
+    public async Task ToolCallModule_WhenExecutionPortMissing_ShouldFailClosedAndSkipRawToolExecution()
+    {
+        var tool = new CountingAgentTool("safe_tool", _ => """{"raw":true}""");
+        var module = new ToolCallModule(
+            [new SingleToolSource(tool)],
+            NullLogger<ToolCallModule>.Instance,
+            executionPort: null);
+        var ctx = new RecordingWorkflowContext();
+
+        await ExecuteToolCallAsync(module, ctx, tool.Name);
+
+        tool.ExecuteCalls.Should().Be(0);
+        var toolResult = ctx.Published.Select(x => x.Event).OfType<ToolResultEvent>().Single();
+        toolResult.Success.Should().BeFalse();
+        toolResult.Error.Should().Contain("execution port is not configured");
+        var completed = LastCompleted(ctx);
+        completed.Success.Should().BeFalse();
+        completed.Error.Should().Contain("execution port is not configured");
+    }
+
+    [Fact]
+    public async Task ToolCallModule_ShouldUseExecutionPortAndNotCallToolDirectly()
+    {
+        var tool = new CountingAgentTool("ported_tool", _ => """{"raw":true}""");
+        var port = new FakeExecutionPort(AgentToolExecutionResult.Succeeded("""{"ported":true}"""));
+        var module = CreateModule(tool, port);
+        var ctx = new RecordingWorkflowContext();
+        WorkflowToolExecutionRuntimeContextAccess.SetToolContext(
+            ctx,
+            AgentToolExecutionContext.Empty with
+            {
+                Credentials = AgentToolCredentials.Empty with
+                {
+                    NyxIdAccessToken = "token-123",
+                },
+            });
+
+        await ExecuteToolCallAsync(
+            module,
+            ctx,
+            tool.Name,
+            stepId: "ported_step",
+            input: """{"x":1}""",
+            executionId: "exec-ported");
+
+        tool.ExecuteCalls.Should().Be(0);
+        port.Requests.Should().ContainSingle();
+        var request = port.Requests.Single();
+        request.Tool.Should().BeSameAs(tool);
+        request.ToolName.Should().Be("ported_tool");
+        request.ToolCallId.Should().Be("workflow:run-1:ported_step:exec-ported");
+        request.ArgumentsJson.Should().Be("""{"x":1}""");
+        request.ExecutionContext.Credentials.NyxIdAccessToken.Should().Be("token-123");
+        request.ExecutionContext.Request.CallId.Should().Be("workflow:run-1:ported_step:exec-ported");
+        LastCompleted(ctx).Success.Should().BeTrue();
+        LastCompleted(ctx).Output.Should().Be("""{"ported":true}""");
+    }
+
+    [Theory]
+    [InlineData(AgentToolExecutionStatus.ApprovalDenied)]
+    [InlineData(AgentToolExecutionStatus.ApprovalTimedOut)]
+    [InlineData(AgentToolExecutionStatus.ApprovalPending)]
+    [InlineData(AgentToolExecutionStatus.MiddlewareTerminated)]
+    [InlineData(AgentToolExecutionStatus.Failed)]
+    public async Task ToolCallModule_WhenPortReturnsNonSuccessStatus_ShouldPublishFailedEvents(
+        AgentToolExecutionStatus status)
+    {
+        var tool = new CountingAgentTool("blocked_tool", _ => """{"raw":true}""");
+        var port = new FakeExecutionPort(new AgentToolExecutionResult(status, null, $"{status} blocked"));
+        var module = CreateModule(tool, port);
+        var ctx = new RecordingWorkflowContext();
+
+        await ExecuteToolCallAsync(module, ctx, tool.Name);
+
+        tool.ExecuteCalls.Should().Be(0);
+        var toolResult = ctx.Published.Select(x => x.Event).OfType<ToolResultEvent>().Single();
+        toolResult.Success.Should().BeFalse();
+        toolResult.Error.Should().Contain($"{status} blocked");
+        var completed = LastCompleted(ctx);
+        completed.Success.Should().BeFalse();
+        completed.Error.Should().Contain($"{status} blocked");
+    }
+
+    private static ToolCallModule CreateModule(
+        IAgentTool tool,
+        IAgentToolExecutionPort? executionPort = null) =>
+        new(
+            [new SingleToolSource(tool)],
+            NullLogger<ToolCallModule>.Instance,
+            executionPort ?? new DirectFakeExecutionPort());
 
     private static async Task ExecuteToolCallAsync(
         ToolCallModule module,
@@ -390,6 +480,24 @@ public sealed class ToolCallModuleContextTests
         }
     }
 
+    private sealed class CountingAgentTool(string name, Func<string, string> execute) : IAgentTool
+    {
+        public string Name { get; } = name;
+
+        public string Description => "counting fake tool";
+
+        public string ParametersSchema => "{}";
+
+        public int ExecuteCalls { get; private set; }
+
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            ExecuteCalls++;
+            return Task.FromResult(execute(argumentsJson));
+        }
+    }
+
     private sealed class NyxIdLikeTool : IAgentTool
     {
         public string Name => "nyxid_like_proxy";
@@ -421,6 +529,33 @@ public sealed class ToolCallModuleContextTests
         {
             ct.ThrowIfCancellationRequested();
             return Task.FromResult<IReadOnlyList<IAgentTool>>([tool]);
+        }
+    }
+
+    private sealed class DirectFakeExecutionPort : IAgentToolExecutionPort
+    {
+        public async Task<AgentToolExecutionResult> ExecuteAsync(
+            AgentToolExecutionRequest request,
+            CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            using var _ = AgentToolContextScope.Push(request.ExecutionContext);
+            var result = await request.Tool.ExecuteAsync(request.ArgumentsJson, ct);
+            return AgentToolExecutionResult.Succeeded(result);
+        }
+    }
+
+    private sealed class FakeExecutionPort(AgentToolExecutionResult result) : IAgentToolExecutionPort
+    {
+        public List<AgentToolExecutionRequest> Requests { get; } = [];
+
+        public Task<AgentToolExecutionResult> ExecuteAsync(
+            AgentToolExecutionRequest request,
+            CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            Requests.Add(request);
+            return Task.FromResult(result);
         }
     }
 


### PR DESCRIPTION
## 摘要

修复 workflow direct `tool_call` 直接执行工具、绕过 approval/middleware pipeline 的问题。

- 新增 `IAgentToolExecutionPort`，将 direct tool_call 执行收敛到审批优先的 middleware pipeline。
- 将 approval denied / pending / timeout / middleware short-circuit 映射为封闭 typed execution status。
- `ToolCallModule` 缺少 execution port 时 fail closed，并为非成功状态发布 failed workflow event。
- 补充 workflow、AI core、bootstrap 覆盖测试。

## 范围

修改 13 个文件，覆盖 AI tool execution port、middleware chain、workflow tool-call module、bootstrap registration 与对应测试。

## 验证

worker 已报告通过：

- `dotnet build aevatar.slnx --nologo`
- `dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --filter "FullyQualifiedName~ToolCallModule" --nologo`
- `dotnet test test/Aevatar.Integration.Tests/Aevatar.Integration.Tests.csproj --filter "FullyQualifiedName~WorkflowCoreModulesCoverageTests" --nologo`
- `dotnet test test/Aevatar.AI.Core.Tests/Aevatar.AI.Core.Tests.csproj --filter "FullyQualifiedName~AgentToolExecutionPort|FullyQualifiedName~ToolApprovalMiddleware" --nologo`
- `dotnet test test/Aevatar.Bootstrap.Tests/Aevatar.Bootstrap.Tests.csproj --filter "FullyQualifiedName~AIFeatureBootstrap" --nologo`
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/architecture_guards.sh`

Closes #1651

<details><summary>本机调试线索</summary>

- implement summary: `.refactor-loop/runs/implement-issue-1651.md`
- design consensus: `.refactor-loop/runs/phase9-issue1651-r2-judge.md`
- implement log: `.refactor-loop/logs/implement-issue-1651.log`

</details>

🤖 controller PR body

⟦AI:AUTO-LOOP⟧
