### PR TITLE
修复 workflow llm_call ToolContext 传播

### DIFF
--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionRuntimeContext.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionRuntimeContext.cs
@@ -1,4 +1,3 @@
-using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.Workflow.Core.Primitives;
@@ -22,8 +21,6 @@ internal interface IWorkflowExecutionRuntimeContextAccessor
 //                  runtime-only values stay non-durable, with no proto/state migration in this cluster.
 internal sealed class WorkflowExecutionRuntimeContext
 {
-    public WorkflowLlmRuntimeOverrides LlmOverrides { get; } = new();
-
     public WorkflowConnectorRuntimeContext Connector { get; } = new();
 
     public WorkflowRequestPassthroughMetadata RequestPassthroughMetadata { get; } = new();
@@ -34,7 +31,6 @@ internal sealed class WorkflowExecutionRuntimeContext
 
     public void Clear()
     {
-        LlmOverrides.Clear();
         Connector.Clear();
         RequestPassthroughMetadata.Clear();
         CapturedSecureInputs.Clear();
@@ -43,7 +39,6 @@ internal sealed class WorkflowExecutionRuntimeContext
 
     public void ApplyRequestMetadata(IReadOnlyDictionary<string, string>? metadata)
     {
-        LlmOverrides.Clear();
         Connector.Clear();
         RequestPassthroughMetadata.Clear();
 
@@ -72,39 +67,10 @@ internal sealed class WorkflowExecutionRuntimeContext
     public void ApplyToolContext(AgentToolExecutionContext? context)
     {
         ToolContext = context;
-        LlmOverrides.Clear();
-
-        if (context == null)
-            return;
-
-        LlmOverrides.NyxIdAccessToken = Normalize(context.Credentials.NyxIdAccessToken);
-        LlmOverrides.ModelOverride = Normalize(context.Routing.ModelOverride);
-        LlmOverrides.NyxIdRoutePreference = Normalize(context.Routing.NyxIdRoutePreference);
     }
 
     private static string Normalize(string? value) =>
         string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
-}
-
-// Refactor (iter16/cluster-031):
-//   Old pattern: LLM request overrides were stored as string-key entries in the
-//                generic workflow execution item bag.
-//   New principle: LLM override values live in a typed runtime section owned by
-//                  the run actor.
-internal sealed class WorkflowLlmRuntimeOverrides
-{
-    public string? NyxIdAccessToken { get; set; }
-
-    public string? ModelOverride { get; set; }
-
-    public string? NyxIdRoutePreference { get; set; }
-
-    public void Clear()
-    {
-        NyxIdAccessToken = null;
-        ModelOverride = null;
-        NyxIdRoutePreference = null;
-    }
 }
 
 // Refactor (iter16/cluster-031):

--- a/src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs
@@ -333,59 +333,74 @@ public sealed class LLMCallModule : IEventModule<IWorkflowExecutionContext>
         return true;
     }
 
-    // Refactor (iter16/cluster-031):
-    //   Old pattern: WorkflowRunGAgent kept Dictionary<string, object?> _executionItems
-    //                bag for request metadata, LLM overrides, authorization, secure values
-    //   New principle: typed non-durable actor-owned WorkflowExecutionRuntimeContext;
-    //                  runtime-only values stay non-durable, with no proto/state migration in this cluster.
-    private static void ApplyTypedLlmControl(
+    private static void ApplyWorkflowToolContext(
         IWorkflowExecutionContext ctx,
         ChatRequestEvent chatRequest)
     {
-        if (ctx is not IWorkflowExecutionRuntimeContextAccessor runtimeAccessor)
+        var toolContext = WorkflowToolExecutionRuntimeContextAccess.GetToolContext(ctx);
+        if (toolContext == null)
             return;
 
-        var overrides = runtimeAccessor.RuntimeContext.LlmOverrides;
-        if (string.IsNullOrWhiteSpace(overrides.NyxIdAccessToken) &&
-            string.IsNullOrWhiteSpace(overrides.ModelOverride) &&
-            string.IsNullOrWhiteSpace(overrides.NyxIdRoutePreference))
-        {
-            return;
-        }
+        var control = BuildLlmControlFromToolContext(toolContext);
+        if (HasNarrowLlmControl(control))
+            chatRequest.LlmControl = control.ToPayload();
 
-        chatRequest.LlmControl = new LLMControlContext(
-            NyxIdAccessToken: Normalize(overrides.NyxIdAccessToken),
-            NyxIdOrgToken: null,
-            SenderNyxIdAccessToken: null,
-            ModelOverride: Normalize(overrides.ModelOverride),
-            NyxIdRoutePreference: Normalize(overrides.NyxIdRoutePreference),
-            MaxToolRoundsOverride: null,
-            UserMemoryPrompt: null).ToPayload();
+        if (HasNonControlToolContext(toolContext))
+            chatRequest.ToolContext = toolContext.ToPayload();
     }
 
-    private static AgentToolExecutionContext BuildLlmControlToolContext(LLMControlContext control) =>
-        AgentToolExecutionContext.Empty with
-        {
-            Credentials = AgentToolCredentials.Empty with
-            {
-                NyxIdAccessToken = control.NyxIdAccessToken,
-                NyxIdOrgToken = control.NyxIdOrgToken,
-                SenderNyxIdAccessToken = control.SenderNyxIdAccessToken,
-            },
-            Routing = LLMRequestRoutingContext.Empty with
-            {
-                ModelOverride = control.ModelOverride,
-                NyxIdRoutePreference = control.NyxIdRoutePreference,
-                MaxToolRoundsOverride = control.MaxToolRoundsOverride,
-                UserMemoryPrompt = control.UserMemoryPrompt,
-            },
-        };
+    private static LLMControlContext BuildLlmControlFromToolContext(AgentToolExecutionContext toolContext) =>
+        new(
+            NyxIdAccessToken: Normalize(toolContext.Credentials.NyxIdAccessToken),
+            NyxIdOrgToken: Normalize(toolContext.Credentials.NyxIdOrgToken),
+            SenderNyxIdAccessToken: Normalize(toolContext.Credentials.SenderNyxIdAccessToken),
+            ModelOverride: Normalize(toolContext.Routing.ModelOverride),
+            NyxIdRoutePreference: Normalize(toolContext.Routing.NyxIdRoutePreference),
+            MaxToolRoundsOverride: toolContext.Routing.MaxToolRoundsOverride,
+            UserMemoryPrompt: Normalize(toolContext.Routing.UserMemoryPrompt));
 
-    // Refactor (iter16/cluster-031):
-    //   Old pattern: LLM override metadata was forwarded from generic execution
-    //                item values after string-key lookup.
-    //   New principle: LLM override metadata is copied from typed runtime
-    //                  override fields after blank-value filtering.
+    private static bool HasNarrowLlmControl(LLMControlContext control) =>
+        !string.IsNullOrWhiteSpace(control.NyxIdAccessToken) ||
+        !string.IsNullOrWhiteSpace(control.NyxIdOrgToken) ||
+        !string.IsNullOrWhiteSpace(control.SenderNyxIdAccessToken) ||
+        !string.IsNullOrWhiteSpace(control.ModelOverride) ||
+        !string.IsNullOrWhiteSpace(control.NyxIdRoutePreference) ||
+        control.MaxToolRoundsOverride.HasValue ||
+        !string.IsNullOrWhiteSpace(control.UserMemoryPrompt);
+
+    private static bool HasNonControlToolContext(AgentToolExecutionContext toolContext) =>
+        HasRequestIdentity(toolContext.Request) ||
+        HasCallerContext(toolContext.Caller) ||
+        HasChannelContext(toolContext.Channel) ||
+        !string.IsNullOrWhiteSpace(toolContext.SenderBinding.BindingId) ||
+        !string.IsNullOrWhiteSpace(toolContext.ConnectedServices.ContextJson) ||
+        toolContext.ExternalMetadata.Count > 0 ||
+        HasSkillRecoveryContext(toolContext.SkillRecovery);
+
+    private static bool HasRequestIdentity(AgentToolRequestIdentity request) =>
+        !string.IsNullOrWhiteSpace(request.RequestId) ||
+        !string.IsNullOrWhiteSpace(request.CallId);
+
+    private static bool HasCallerContext(AgentToolCallerContext caller) =>
+        !string.IsNullOrWhiteSpace(caller.ScopeId) ||
+        !string.IsNullOrWhiteSpace(caller.OwnerSubject) ||
+        !string.IsNullOrWhiteSpace(caller.ResponseId);
+
+    private static bool HasChannelContext(AgentToolChannelContext channel) =>
+        !string.IsNullOrWhiteSpace(channel.Platform) ||
+        !string.IsNullOrWhiteSpace(channel.SenderId) ||
+        !string.IsNullOrWhiteSpace(channel.RegistrationScopeId) ||
+        !string.IsNullOrWhiteSpace(channel.MessageId) ||
+        !string.IsNullOrWhiteSpace(channel.PlatformMessageId);
+
+    private static bool HasSkillRecoveryContext(AgentSkillRecoveryContext skillRecovery) =>
+        skillRecovery.RequireInitialOrnnSearch ||
+        skillRecovery.RequireOrnnSearchOnBlocker ||
+        !string.IsNullOrWhiteSpace(skillRecovery.CommandName) ||
+        !string.IsNullOrWhiteSpace(skillRecovery.OriginalCommand) ||
+        !string.IsNullOrWhiteSpace(skillRecovery.PrimarySkillName) ||
+        skillRecovery.MaxOrnnSearchAttempts != 0;
+
     private static void CopyParametersToChatRequest(
         StepRequestEvent request,
         ChatRequestEvent chatRequest,
@@ -637,7 +652,7 @@ public sealed class LLMCallModule : IEventModule<IWorkflowExecutionContext>
             TimeoutMs = timeoutMs,
             Telegram = new TelegramBridgeRequest(),
         };
-        ApplyTypedLlmControl(ctx, chatRequest);
+        ApplyWorkflowToolContext(ctx, chatRequest);
         CopyParametersToChatRequest(request, chatRequest, timeoutMs);
         chatRequest.Telegram.RunId = WorkflowRunIdNormalizer.Normalize(request.RunId);
         chatRequest.Telegram.StepId = stepId;

--- a/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
@@ -2012,14 +2012,39 @@ public sealed class WorkflowAdditionalModulesCoverageTests
             (IWorkflowExecutionStateHost)ctx.Agent,
             AgentToolExecutionContext.Empty with
             {
+                Request = new AgentToolRequestIdentity(" request-123 ", " call-456 "),
                 Credentials = AgentToolCredentials.Empty with
                 {
                     NyxIdAccessToken = " token-123 ",
+                    NyxIdOrgToken = " org-456 ",
+                    SenderNyxIdAccessToken = " sender-token-789 ",
                 },
+                Caller = new AgentToolCallerContext(" scope-abc ", " owner-subject ", " response-123 "),
+                Channel = new AgentToolChannelContext(
+                    " lark ",
+                    " sender-abc ",
+                    " registration-scope ",
+                    " message-123 ",
+                    " platform-message-456 "),
+                SenderBinding = new AgentToolSenderBindingContext(" binding-123 "),
                 Routing = LLMRequestRoutingContext.Empty with
                 {
                     ModelOverride = " model-main ",
                     NyxIdRoutePreference = " route-fast ",
+                    MaxToolRoundsOverride = 7,
+                    UserMemoryPrompt = " memory prompt ",
+                },
+                ConnectedServices = new AgentToolConnectedServicesContext("""{"service":"calendar"}"""),
+                SkillRecovery = new AgentSkillRecoveryContext(
+                    RequireInitialOrnnSearch: true,
+                    RequireOrnnSearchOnBlocker: true,
+                    CommandName: "command",
+                    OriginalCommand: "original command",
+                    PrimarySkillName: "primary-skill",
+                    MaxOrnnSearchAttempts: 3),
+                ExternalMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["external-key"] = "external-value",
                 },
             });
 
@@ -2036,9 +2061,73 @@ public sealed class WorkflowAdditionalModulesCoverageTests
 
         var chatRequest = ctx.Published.Select(x => x.evt).OfType<ChatRequestEvent>().Single();
         chatRequest.LlmControl.NyxIdAccessToken.Should().Be("token-123");
+        chatRequest.LlmControl.NyxIdOrgToken.Should().Be("org-456");
+        chatRequest.LlmControl.SenderNyxIdAccessToken.Should().Be("sender-token-789");
         chatRequest.LlmControl.ModelOverride.Should().Be("model-main");
         chatRequest.LlmControl.NyxIdRoutePreference.Should().Be("route-fast");
+        chatRequest.LlmControl.MaxToolRoundsOverride.Should().Be(7);
+        chatRequest.LlmControl.UserMemoryPrompt.Should().Be("memory prompt");
+        var childContext = AgentToolExecutionContextMapper.FromPayload(chatRequest.ToolContext);
+        childContext.Request.RequestId.Should().Be("request-123");
+        childContext.Request.CallId.Should().Be("call-456");
+        childContext.Caller.ScopeId.Should().Be("scope-abc");
+        childContext.Caller.OwnerSubject.Should().Be("owner-subject");
+        childContext.Caller.ResponseId.Should().Be("response-123");
+        childContext.Channel.Platform.Should().Be("lark");
+        childContext.Channel.SenderId.Should().Be("sender-abc");
+        childContext.Channel.RegistrationScopeId.Should().Be("registration-scope");
+        childContext.Channel.MessageId.Should().Be("message-123");
+        childContext.Channel.PlatformMessageId.Should().Be("platform-message-456");
+        childContext.SenderBinding.BindingId.Should().Be("binding-123");
+        childContext.ConnectedServices.ContextJson.Should().Be("""{"service":"calendar"}""");
+        childContext.ExternalMetadata.Should().Contain("external-key", "external-value");
+        childContext.SkillRecovery.RequireInitialOrnnSearch.Should().BeTrue();
+        childContext.SkillRecovery.RequireOrnnSearchOnBlocker.Should().BeTrue();
+        childContext.SkillRecovery.CommandName.Should().Be("command");
+        childContext.SkillRecovery.OriginalCommand.Should().Be("original command");
+        childContext.SkillRecovery.PrimarySkillName.Should().Be("primary-skill");
+        childContext.SkillRecovery.MaxOrnnSearchAttempts.Should().Be(3);
         chatRequest.Metadata["trace-id"].Should().Be("trace-abc");
+        chatRequest.Metadata.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task LlmCallModule_ShouldForwardControlOnlyRuntimeContextWithoutChildToolContext()
+    {
+        var module = new LLMCallModule();
+        var ctx = CreateContext();
+        var control = new LLMControlContext(
+            NyxIdAccessToken: "token-123",
+            NyxIdOrgToken: "org-456",
+            SenderNyxIdAccessToken: "sender-token-789",
+            ModelOverride: "model-main",
+            NyxIdRoutePreference: "route-fast",
+            MaxToolRoundsOverride: 7,
+            UserMemoryPrompt: "memory prompt");
+        WorkflowToolExecutionRuntimeContextAccess.SetToolContext(
+            (IWorkflowExecutionStateHost)ctx.Agent,
+            control.ToToolContext());
+
+        await module.HandleAsync(
+            Envelope(new StepRequestEvent
+            {
+                StepId = "llm-control-only",
+                StepType = "llm_call",
+                RunId = "run-control-only",
+                Input = "hello control only",
+            }),
+            ctx,
+            CancellationToken.None);
+
+        var chatRequest = ctx.Published.Select(x => x.evt).OfType<ChatRequestEvent>().Single();
+        chatRequest.LlmControl.NyxIdAccessToken.Should().Be("token-123");
+        chatRequest.LlmControl.NyxIdOrgToken.Should().Be("org-456");
+        chatRequest.LlmControl.SenderNyxIdAccessToken.Should().Be("sender-token-789");
+        chatRequest.LlmControl.ModelOverride.Should().Be("model-main");
+        chatRequest.LlmControl.NyxIdRoutePreference.Should().Be("route-fast");
+        chatRequest.LlmControl.MaxToolRoundsOverride.Should().Be(7);
+        chatRequest.LlmControl.UserMemoryPrompt.Should().Be("memory prompt");
+        chatRequest.ToolContext.Should().BeNull();
     }
 
     [Fact]

--- a/test/Aevatar.Integration.Tests/WorkflowGAgentCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowGAgentCoverageTests.cs
@@ -1,5 +1,7 @@
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.Agents;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.EventModules;
 using Aevatar.Foundation.Abstractions.Persistence;
@@ -1570,9 +1572,20 @@ public class WorkflowGAgentCoverageTests
     private static void SeedRuntimeContext(WorkflowRunGAgent agent)
     {
         var runtimeContext = ((IWorkflowExecutionStateHost)agent).RuntimeContext;
-        runtimeContext.LlmOverrides.NyxIdAccessToken = "token";
-        runtimeContext.LlmOverrides.ModelOverride = "model";
-        runtimeContext.LlmOverrides.NyxIdRoutePreference = "route";
+        WorkflowToolExecutionRuntimeContextAccess.SetToolContext(
+            (IWorkflowExecutionStateHost)agent,
+            AgentToolExecutionContext.Empty with
+            {
+                Credentials = AgentToolCredentials.Empty with
+                {
+                    NyxIdAccessToken = "token",
+                },
+                Routing = LLMRequestRoutingContext.Empty with
+                {
+                    ModelOverride = "model",
+                    NyxIdRoutePreference = "route",
+                },
+            });
         runtimeContext.Connector.Authorization = "Bearer secret";
         runtimeContext.RequestPassthroughMetadata.Set("trace-id", "abc");
         runtimeContext.CapturedSecureInputs.Set(agent.RunId, "api_key", "secret");
@@ -1581,9 +1594,7 @@ public class WorkflowGAgentCoverageTests
     private static void AssertRuntimeContextCleared(WorkflowRunGAgent agent)
     {
         var runtimeContext = ((IWorkflowExecutionStateHost)agent).RuntimeContext;
-        runtimeContext.LlmOverrides.NyxIdAccessToken.Should().BeNull();
-        runtimeContext.LlmOverrides.ModelOverride.Should().BeNull();
-        runtimeContext.LlmOverrides.NyxIdRoutePreference.Should().BeNull();
+        runtimeContext.ToolContext.Should().BeNull();
         runtimeContext.Connector.Authorization.Should().BeNull();
         runtimeContext.RequestPassthroughMetadata.Values.Should().BeEmpty();
         runtimeContext.CapturedSecureInputs.Values.Should().BeEmpty();

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionContextAdapterTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionContextAdapterTests.cs
@@ -1,6 +1,7 @@
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.EventModules;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Workflow.Core.Execution;
 using FluentAssertions;
 using Google.Protobuf;
@@ -30,12 +31,19 @@ public sealed class WorkflowExecutionContextAdapterTests
     public void RuntimeContext_ShouldExposeStateHostRuntimeContext()
     {
         var host = new RecordingStateHost();
-        host.RuntimeContext.LlmOverrides.ModelOverride = "model-x";
+        host.RuntimeContext.ApplyToolContext(AgentToolExecutionContext.Empty with
+        {
+            Credentials = AgentToolCredentials.Empty with
+            {
+                NyxIdAccessToken = "token-x",
+            },
+        });
 
         var adapter = WorkflowExecutionContextAdapter.Create(new RecordingEventHandlerContext(), host);
 
         adapter.RuntimeContext.Should().BeSameAs(host.RuntimeContext);
-        adapter.RuntimeContext.LlmOverrides.ModelOverride.Should().Be("model-x");
+        adapter.RuntimeContext.ToolContext.Should().BeSameAs(host.RuntimeContext.ToolContext);
+        adapter.RuntimeContext.ToolContext!.Credentials.NyxIdAccessToken.Should().Be("token-x");
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
@@ -33,9 +33,7 @@ public sealed class WorkflowExecutionRuntimeContextTests
                 ["empty"] = " ",
             });
 
-        host.RuntimeContext.LlmOverrides.NyxIdAccessToken.Should().BeNull();
-        host.RuntimeContext.LlmOverrides.ModelOverride.Should().BeNull();
-        host.RuntimeContext.LlmOverrides.NyxIdRoutePreference.Should().BeNull();
+        host.RuntimeContext.ToolContext.Should().BeNull();
         host.RuntimeContext.Connector.Authorization.Should().Be("Bearer secret");
         host.RuntimeContext.RequestPassthroughMetadata.Values.Should().ContainKeys(
             "trace-id",
@@ -47,7 +45,7 @@ public sealed class WorkflowExecutionRuntimeContextTests
     }
 
     [Fact]
-    public void SetToolContext_ShouldPromoteLlmRuntimeValuesFromTypedContext()
+    public void SetToolContext_ShouldStoreToolContextAsOnlyRuntimeFact()
     {
         var host = new RecordingStateHost();
         var toolContext = AgentToolExecutionContext.Empty with
@@ -69,9 +67,10 @@ public sealed class WorkflowExecutionRuntimeContextTests
             toolContext);
 
         host.RuntimeContext.ToolContext.Should().BeSameAs(toolContext);
-        host.RuntimeContext.LlmOverrides.NyxIdAccessToken.Should().Be("token");
-        host.RuntimeContext.LlmOverrides.ModelOverride.Should().Be("model");
-        host.RuntimeContext.LlmOverrides.NyxIdRoutePreference.Should().Be("route");
+        typeof(WorkflowExecutionRuntimeContext)
+            .GetProperty("LlmOverrides")
+            .Should()
+            .BeNull();
     }
 
     [Fact]
@@ -91,7 +90,6 @@ public sealed class WorkflowExecutionRuntimeContextTests
         WorkflowToolExecutionRuntimeContextAccess.SetToolContext(host, null);
 
         host.RuntimeContext.ToolContext.Should().BeNull();
-        host.RuntimeContext.LlmOverrides.NyxIdAccessToken.Should().BeNull();
     }
 
     [Fact]
@@ -128,7 +126,7 @@ public sealed class WorkflowExecutionRuntimeContextTests
 
         WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadata(host, null);
 
-        host.RuntimeContext.LlmOverrides.ModelOverride.Should().BeNull();
+        host.RuntimeContext.ToolContext.Should().BeNull();
         host.RuntimeContext.RequestPassthroughMetadata.Values.Should().BeEmpty();
 
         WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadata(
@@ -138,8 +136,32 @@ public sealed class WorkflowExecutionRuntimeContextTests
                 [" "] = " ",
             });
 
-        host.RuntimeContext.LlmOverrides.ModelOverride.Should().BeNull();
+        host.RuntimeContext.ToolContext.Should().BeNull();
         host.RuntimeContext.RequestPassthroughMetadata.Values.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SetRequestMetadata_ShouldNotMutateExistingToolContext()
+    {
+        var host = new RecordingStateHost();
+        var toolContext = AgentToolExecutionContext.Empty with
+        {
+            Credentials = AgentToolCredentials.Empty with
+            {
+                NyxIdAccessToken = "token",
+            },
+        };
+        WorkflowToolExecutionRuntimeContextAccess.SetToolContext(host, toolContext);
+
+        WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadata(
+            host,
+            new Dictionary<string, string>
+            {
+                ["trace-id"] = "abc",
+            });
+
+        host.RuntimeContext.ToolContext.Should().BeSameAs(toolContext);
+        host.RuntimeContext.RequestPassthroughMetadata.Values.Should().Contain("trace-id", "abc");
     }
 
     [Fact]


### PR DESCRIPTION
## 摘要

修复 #1652：`workflow llm_call` 子请求现在从 workflow runtime `ToolContext` 单一事实源派生上下文。

- 删除有损的 `WorkflowLlmRuntimeOverrides` / `LlmOverrides` runtime mirror。
- `LLMCallModule` 从 runtime `ToolContext` 派生 child `LlmControl` 七个窄字段。
- child `ToolContext` 只在存在 caller/channel/sender binding/connected services/external metadata/skill recovery 等非控制面工具执行语义时写入；LlmControl-only 场景不写 child `ToolContext`。
- 补充 runtime、adapter、full ToolContext、control-only 回归测试。

## Scope / 范围

6 files changed, 208 insertions, 97 deletions.

- `src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionRuntimeContext.cs`
- `src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs`
- `test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs`
- `test/Aevatar.Integration.Tests/WorkflowGAgentCoverageTests.cs`
- `test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionContextAdapterTests.cs`
- `test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs`

## 验证

- `dotnet build aevatar.slnx --nologo` — passed
- `dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --filter "FullyQualifiedName~WorkflowExecutionRuntimeContext|FullyQualifiedName~WorkflowExecutionContextAdapter|FullyQualifiedName~LLMCallModule" --nologo` — passed, 24 tests
- `dotnet test test/Aevatar.Integration.Tests/Aevatar.Integration.Tests.csproj --filter "FullyQualifiedName~LlmCallModule_ShouldForwardTypedRuntimeContextOverrides|FullyQualifiedName~WorkflowRunGAgent" --nologo` — passed, 36 tests
- `dotnet test test/Aevatar.Integration.Tests/Aevatar.Integration.Tests.csproj --filter "FullyQualifiedName~LlmCallModule_ShouldForwardControlOnlyRuntimeContextWithoutChildToolContext" --nologo` — passed, 1 test
- `bash tools/ci/test_stability_guards.sh` — passed
- `bash tools/ci/architecture_guards.sh` — passed

## Consensus-rnd

- Design decision: issue #1652 r6 consensus, framing `structural`
- Implement marker: `IMPLEMENT_DONE:issue-1652:ok`
- Corrected verify marker: `VERIFY_DONE:issue-1652:pass`

🤖 Auto-loop / codex-refactor-loop issue-1652

⟦AI:AUTO-LOOP⟧