### PR TITLE
Clarify Studio lifecycle recovery guidance

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
@@ -2,6 +2,7 @@ import { AGUIEventType } from '@aevatar-react-sdk/types';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import * as React from 'react';
 import { parseBackendSSEStream } from '@/shared/agui/sseFrameNormalizer';
+import { runtimeGAgentApi } from '@/shared/api/runtimeGAgentApi';
 import { runtimeRunsApi } from '@/shared/api/runtimeRunsApi';
 import { scriptsApi } from '@/shared/studio/scriptsApi';
 import {
@@ -16,6 +17,7 @@ import {
   buildStudioWorkflowLayout,
 } from '@/shared/studio/graph';
 import {
+  StudioGAgentBuildPanel,
   StudioScriptBuildPanel,
   StudioWorkflowBuildPanel,
 } from './StudioBuildPanels';
@@ -80,6 +82,12 @@ type BuildWorkflowYamlsForTest = (
 
 jest.mock('@/shared/api/runtimeRunsApi', () => ({
   runtimeRunsApi: {
+    streamDraftRun: jest.fn(),
+  },
+}));
+
+jest.mock('@/shared/api/runtimeGAgentApi', () => ({
+  runtimeGAgentApi: {
     streamDraftRun: jest.fn(),
   },
 }));
@@ -157,6 +165,9 @@ jest.mock('@/modules/studio/scripts/ScriptCodeEditor', () => ({
 }));
 
 const mockedRuntimeRunsApi = runtimeRunsApi as unknown as {
+  streamDraftRun: jest.Mock;
+};
+const mockedRuntimeGAgentApi = runtimeGAgentApi as unknown as {
   streamDraftRun: jest.Mock;
 };
 const mockedParseBackendSSEStream = parseBackendSSEStream as jest.Mock;
@@ -1582,6 +1593,43 @@ describe('StudioWorkflowBuildPanel', () => {
     expect(
       await screen.findByText(/provider 还没有连好/i),
     ).toBeInTheDocument();
+  });
+
+  it('keeps a GAgent draft-run failure inside Build with a recovery path', async () => {
+    mockedRuntimeGAgentApi.streamDraftRun.mockRejectedValueOnce(
+      new Error('GAgent draft run timed out before the backend returned any event.'),
+    );
+
+    render(
+      <StudioGAgentBuildPanel
+        scopeId="scope-1"
+        currentMemberLabel="gagent-1"
+        gAgentTypes={[
+          {
+            assemblyName: 'Aevatar.GAgents',
+            fullName: 'Aevatar.GAgents.TestGAgent',
+            typeName: 'TestGAgent',
+          },
+        ]}
+        gAgentTypesError={null}
+        gAgentTypesLoading={false}
+        selectedGAgentTypeName="Aevatar.GAgents.TestGAgent, Aevatar.GAgents"
+        onContinueToBind={jest.fn()}
+        onSelectGAgentTypeName={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    expect(
+      await screen.findByText('Build dry-run needs attention'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'This only failed the Build dry-run. Adjust the prompt or tools and retry, or continue to Bind when the member definition is ready to publish.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Continue to Bind' })).toBeEnabled();
   });
 
   it('locks apply changes while the step mutation is pending', async () => {

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
@@ -560,6 +560,22 @@ function renderRunSummary(state: DraftRunState): string {
   return getRunDebugLines(state).join('\n');
 }
 
+function getGAgentDraftRunRecoveryText(state: DraftRunState): string {
+  if (state.status === 'running') {
+    return 'Draft run is still waiting for backend events. Keep the Build definition visible while this request completes.';
+  }
+
+  if (state.status === 'error') {
+    return 'This only failed the Build dry-run. Adjust the prompt or tools and retry, or continue to Bind when the member definition is ready to publish.';
+  }
+
+  if (state.status === 'success') {
+    return 'Draft run finished. Continue to Bind when you are ready to publish the callable member contract.';
+  }
+
+  return '';
+}
+
 function extractRunFinishedOutput(result: unknown): string {
   if (typeof result === 'string') {
     return result;
@@ -3739,6 +3755,20 @@ export const StudioGAgentBuildPanel: React.FC<StudioGAgentBuildPanelProps> = ({
           <div style={sectionEyebrowStyle}>Output</div>
           <pre style={dryRunOutputStyle}>{renderRunOutput(runState)}</pre>
         </div>
+        {getGAgentDraftRunRecoveryText(runState) ? (
+          <Alert
+            showIcon
+            message={
+              runState.status === 'error'
+                ? 'Build dry-run needs attention'
+                : runState.status === 'success'
+                  ? 'Build dry-run is ready'
+                  : 'Build dry-run is running'
+            }
+            description={getGAgentDraftRunRecoveryText(runState)}
+            type={runState.status === 'error' ? 'warning' : 'info'}
+          />
+        ) : null}
         {renderRunSummary(runState) ? (
           <details style={dryRunDebugDetailsStyle}>
             <summary style={dryRunDebugSummaryStyle}>Debug details</summary>

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberCurrentRunPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberCurrentRunPanel.tsx
@@ -8,10 +8,11 @@ import {
 import { Button, Typography } from 'antd';
 import React, { useMemo } from 'react';
 import { RuntimeEventPreviewPanel } from '@/shared/agui/runtimeConversationPresentation';
-import type {
-  CurrentRunRequest,
-  InvokeResultState,
-  StudioInvokeChatMessage,
+import {
+  getStudioInvokeObserveHandoffText,
+  type CurrentRunRequest,
+  type InvokeResultState,
+  type StudioInvokeChatMessage,
 } from './StudioMemberInvokePanel.currentRun';
 import {
   contractValueStyle,
@@ -301,6 +302,17 @@ const errorActionsStyle: React.CSSProperties = {
   marginTop: 10,
 };
 
+const recoveryPathStyle: React.CSSProperties = {
+  background: studioInvokeColors.surfaceActive,
+  border: `1px solid ${studioInvokeColors.borderStrong}`,
+  borderRadius: 8,
+  color: studioInvokeColors.textSoft,
+  display: 'grid',
+  gap: 4,
+  minWidth: 0,
+  padding: '12px 14px',
+};
+
 const errorCardStyle: React.CSSProperties = {
   alignItems: 'flex-start',
   background: studioInvokeColors.dangerSoft,
@@ -520,6 +532,10 @@ const StudioMemberCurrentRunPanel: React.FC<
   const finishedAtLabel = activeRunCompletedAt
     ? formatHistoryTimestamp(activeRunCompletedAt)
     : '';
+  const observeHandoffText = getStudioInvokeObserveHandoffText({
+    runViewMode,
+    status: invokeResult.status,
+  });
 
   const timelineItems = useMemo(() => {
     if (!currentRunHasData) {
@@ -644,6 +660,14 @@ const StudioMemberCurrentRunPanel: React.FC<
               <p style={bodyTextStyle}>{outputText}</p>
             </div>
           ) : null}
+          <div data-testid="studio-invoke-recovery-path" style={recoveryPathStyle}>
+            <span style={sectionLabelStyle}>Recovery path</span>
+            <Typography.Text style={helperTextStyle}>
+              {isCancelled
+                ? 'This stopped run stays in history. Retry as a new run when you want fresh output, or switch to Observe to inspect the latest backend events.'
+                : 'This failed only the Invoke run. Retry with a smaller prompt, inspect Events for backend signals, or return to Build/Bind if the member contract needs changes.'}
+            </Typography.Text>
+          </div>
           <div style={errorActionsStyle}>
             <Button
               icon={<UnorderedListOutlined />}
@@ -698,6 +722,17 @@ const StudioMemberCurrentRunPanel: React.FC<
             </Typography.Text>
           )}
         </div>
+        {observeHandoffText ? (
+          <div
+            data-testid="studio-invoke-observe-handoff"
+            style={recoveryPathStyle}
+          >
+            <span style={sectionLabelStyle}>Observe handoff</span>
+            <Typography.Text style={helperTextStyle}>
+              {observeHandoffText}
+            </Typography.Text>
+          </div>
+        ) : null}
       </div>
     );
   };

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberCurrentRunPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberCurrentRunPanel.tsx
@@ -533,6 +533,7 @@ const StudioMemberCurrentRunPanel: React.FC<
     ? formatHistoryTimestamp(activeRunCompletedAt)
     : '';
   const observeHandoffText = getStudioInvokeObserveHandoffText({
+    mode: invokeResult.mode,
     runViewMode,
     status: invokeResult.status,
   });

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokeHistoryPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokeHistoryPanel.tsx
@@ -144,6 +144,17 @@ const historyActionsStyle: React.CSSProperties = {
   minWidth: 0,
 };
 
+const historySelectedNoticeStyle: React.CSSProperties = {
+  background: studioInvokeColors.surfaceActive,
+  border: `1px solid ${studioInvokeColors.borderStrong}`,
+  borderRadius: 8,
+  color: studioInvokeColors.textSoft,
+  display: 'grid',
+  gap: 2,
+  minWidth: 0,
+  padding: '8px 10px',
+};
+
 const StudioMemberInvokeHistoryPanel: React.FC<
   StudioMemberInvokeHistoryPanelProps
 > = ({
@@ -241,51 +252,62 @@ const StudioMemberInvokeHistoryPanel: React.FC<
                 </div>
               </button>
               {isSelected ? (
-                <div style={historyActionsStyle}>
-                  <Button
-                    disabled={!hasInput}
-                    icon={<CopyOutlined />}
-                    size="small"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onCopyInput(entry.id);
-                    }}
+                <>
+                  <div
+                    data-testid="studio-invoke-history-readonly-guidance"
+                    style={historySelectedNoticeStyle}
                   >
-                    Copy input
-                  </Button>
-                  <Button
-                    disabled={!hasOutput}
-                    icon={<CopyOutlined />}
-                    size="small"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onCopyOutput(entry.id);
-                    }}
-                  >
-                    Copy output
-                  </Button>
-                  <Button
-                    disabled={!runId}
-                    icon={<CopyOutlined />}
-                    size="small"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onCopyRunId(entry.id);
-                    }}
-                  >
-                    Copy run id
-                  </Button>
-                  <Button
-                    icon={<ReloadOutlined />}
-                    size="small"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onRetryAsNewRun(entry.id);
-                    }}
-                  >
-                    Retry as new run
-                  </Button>
-                </div>
+                    <Typography.Text style={helperTextStyle}>
+                      Historical run is read-only. Retry as new run restores the
+                      prompt without changing this record.
+                    </Typography.Text>
+                  </div>
+                  <div style={historyActionsStyle}>
+                    <Button
+                      disabled={!hasInput}
+                      icon={<CopyOutlined />}
+                      size="small"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onCopyInput(entry.id);
+                      }}
+                    >
+                      Copy input
+                    </Button>
+                    <Button
+                      disabled={!hasOutput}
+                      icon={<CopyOutlined />}
+                      size="small"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onCopyOutput(entry.id);
+                      }}
+                    >
+                      Copy output
+                    </Button>
+                    <Button
+                      disabled={!runId}
+                      icon={<CopyOutlined />}
+                      size="small"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onCopyRunId(entry.id);
+                      }}
+                    >
+                      Copy run id
+                    </Button>
+                    <Button
+                      icon={<ReloadOutlined />}
+                      size="small"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onRetryAsNewRun(entry.id);
+                      }}
+                    >
+                      Retry as new run
+                    </Button>
+                  </div>
+                </>
               ) : null}
             </div>
           );

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.currentRun.test.ts
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.currentRun.test.ts
@@ -1,6 +1,7 @@
 import {
   buildStudioInvokeCurrentRunViewModel,
   createIdleInvokeResult,
+  getStudioInvokeObserveHandoffText,
 } from './StudioMemberInvokePanel.currentRun';
 
 describe('StudioMemberInvokePanel current run model', () => {
@@ -89,5 +90,38 @@ describe('StudioMemberInvokePanel current run model', () => {
         status: 'success',
       }),
     );
+  });
+
+  it('describes when Invoke can hand the latest run to Observe', () => {
+    expect(
+      getStudioInvokeObserveHandoffText({
+        runViewMode: 'latest',
+        status: 'success',
+      }),
+    ).toBe(
+      'This run is ready for Observe. Switch to Observe to inspect backend events, audit frames, and the runtime trail for this member.',
+    );
+    expect(
+      getStudioInvokeObserveHandoffText({
+        runViewMode: 'latest',
+        status: 'running',
+      }),
+    ).toBe(
+      'Observe will follow the latest run context after backend events arrive. Keep Invoke open while this stream updates.',
+    );
+    expect(
+      getStudioInvokeObserveHandoffText({
+        runViewMode: 'historical',
+        status: 'success',
+      }),
+    ).toBe(
+      'Historical runs are read-only. Retry as a new run when you need a fresh Observe handoff.',
+    );
+    expect(
+      getStudioInvokeObserveHandoffText({
+        runViewMode: 'latest',
+        status: 'error',
+      }),
+    ).toBe('');
   });
 });

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.currentRun.test.ts
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.currentRun.test.ts
@@ -95,6 +95,7 @@ describe('StudioMemberInvokePanel current run model', () => {
   it('describes when Invoke can hand the latest run to Observe', () => {
     expect(
       getStudioInvokeObserveHandoffText({
+        mode: 'stream',
         runViewMode: 'latest',
         status: 'success',
       }),
@@ -103,6 +104,7 @@ describe('StudioMemberInvokePanel current run model', () => {
     );
     expect(
       getStudioInvokeObserveHandoffText({
+        mode: 'stream',
         runViewMode: 'latest',
         status: 'running',
       }),
@@ -111,6 +113,7 @@ describe('StudioMemberInvokePanel current run model', () => {
     );
     expect(
       getStudioInvokeObserveHandoffText({
+        mode: 'stream',
         runViewMode: 'historical',
         status: 'success',
       }),
@@ -119,9 +122,22 @@ describe('StudioMemberInvokePanel current run model', () => {
     );
     expect(
       getStudioInvokeObserveHandoffText({
+        mode: 'stream',
         runViewMode: 'latest',
         status: 'error',
       }),
     ).toBe('');
+  });
+
+  it('keeps non-stream invoke receipts honest about Observe freshness', () => {
+    expect(
+      getStudioInvokeObserveHandoffText({
+        mode: 'invoke',
+        runViewMode: 'latest',
+        status: 'success',
+      }),
+    ).toBe(
+      'Invoke receipt was captured. Switch to Observe to watch backend events and read-model materialization catch up for this member.',
+    );
   });
 });

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.currentRun.ts
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.currentRun.ts
@@ -73,6 +73,8 @@ export type StudioInvokeCurrentRunViewModel = {
   readonly rawOutput: string;
 };
 
+export type StudioInvokeRunViewMode = 'latest' | 'historical';
+
 function trimOptional(value: string | null | undefined): string {
   return value?.trim() ?? '';
 }
@@ -113,6 +115,25 @@ export function cloneInvokeResult(result: InvokeResultState): InvokeResultState 
     steps: [...result.steps],
     toolCalls: [...result.toolCalls],
   };
+}
+
+export function getStudioInvokeObserveHandoffText(input: {
+  readonly runViewMode: StudioInvokeRunViewMode;
+  readonly status: InvokeResultState['status'];
+}): string {
+  if (input.runViewMode === 'historical') {
+    return 'Historical runs are read-only. Retry as a new run when you need a fresh Observe handoff.';
+  }
+
+  if (input.status === 'running') {
+    return 'Observe will follow the latest run context after backend events arrive. Keep Invoke open while this stream updates.';
+  }
+
+  if (input.status === 'success') {
+    return 'This run is ready for Observe. Switch to Observe to inspect backend events, audit frames, and the runtime trail for this member.';
+  }
+
+  return '';
 }
 
 function hasCurrentRunData(input: {

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.currentRun.ts
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.currentRun.ts
@@ -118,6 +118,7 @@ export function cloneInvokeResult(result: InvokeResultState): InvokeResultState 
 }
 
 export function getStudioInvokeObserveHandoffText(input: {
+  readonly mode: InvokeResultState['mode'];
   readonly runViewMode: StudioInvokeRunViewMode;
   readonly status: InvokeResultState['status'];
 }): string {
@@ -130,6 +131,10 @@ export function getStudioInvokeObserveHandoffText(input: {
   }
 
   if (input.status === 'success') {
+    if (input.mode === 'invoke') {
+      return 'Invoke receipt was captured. Switch to Observe to watch backend events and read-model materialization catch up for this member.';
+    }
+
     return 'This run is ready for Observe. Switch to Observe to inspect backend events, audit frames, and the runtime trail for this member.';
   }
 

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.test.tsx
@@ -348,6 +348,9 @@ describe('StudioMemberInvokePanel', () => {
     });
 
     expect(await screen.findByText(/핵심 단어로 나누면/)).toBeTruthy();
+    expect(screen.getByTestId('studio-invoke-observe-handoff')).toHaveTextContent(
+      'This run is ready for Observe. Switch to Observe to inspect backend events, audit frames, and the runtime trail for this member.',
+    );
     expect(Element.prototype.scrollTo).toHaveBeenCalledWith(
       expect.objectContaining({ top: expect.any(Number) }),
     );
@@ -373,6 +376,54 @@ describe('StudioMemberInvokePanel', () => {
     expect(screen.getByTestId('studio-invoke-run-status-summary')).toHaveTextContent(
       'Succeeded',
     );
+  });
+
+  it('shows a recovery path when the latest Invoke run fails', async () => {
+    (runtimeRunsApi.streamChat as jest.Mock).mockRejectedValueOnce(
+      new Error('GAgent draft-run timed out.'),
+    );
+
+    render(
+      React.createElement(StudioMemberInvokePanel, {
+        memberId: 'gagent-1',
+        scopeId: 'scope-1',
+        services: [
+          {
+            deploymentStatus: 'Active',
+            displayName: 'gagent-1',
+            endpoints: [
+              {
+                description: 'Chat with gagent-1.',
+                displayName: 'Chat',
+                endpointId: 'chat',
+                kind: 'invoke',
+                requestTypeUrl: '',
+                responseTypeUrl: '',
+              },
+            ],
+            kind: 'service',
+            namespace: 'default',
+            primaryActorId: 'actor-gagent',
+            serviceId: 'gagent-1',
+          },
+        ],
+      }),
+    );
+
+    fireEvent.change(await screen.findByLabelText('调用请求输入'), {
+      target: {
+        value: 'Classify this support ticket.',
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Invoke' }));
+
+    expect(await screen.findByText('Run failed')).toBeTruthy();
+    expect(screen.getByText('GAgent draft-run timed out.')).toBeTruthy();
+    expect(screen.getByTestId('studio-invoke-recovery-path')).toHaveTextContent(
+      'This failed only the Invoke run. Retry with a smaller prompt, inspect Events for backend signals, or return to Build/Bind if the member contract needs changes.',
+    );
+    expect(screen.getByRole('button', { name: 'Retry as new run' })).toBeTruthy();
   });
 
   it('lets Run history expand in document flow when many runs are rendered', () => {
@@ -430,6 +481,11 @@ describe('StudioMemberInvokePanel', () => {
     expect(screen.getByRole('button', { name: 'Copy input' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Copy output' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Copy run id' })).toBeTruthy();
+    expect(
+      screen.getByTestId('studio-invoke-history-readonly-guidance'),
+    ).toHaveTextContent(
+      'Historical run is read-only. Retry as new run restores the prompt without changing this record.',
+    );
     expect(
       screen.getByRole('button', { name: 'Retry as new run' }),
     ).toBeTruthy();
@@ -770,6 +826,12 @@ describe('StudioMemberInvokePanel', () => {
     );
     expect(historyScroll).toBeTruthy();
     expect(screen.getByText('Historical run · Read-only')).toBeTruthy();
+    expect(screen.getByTestId('studio-invoke-observe-handoff')).toHaveTextContent(
+      'Historical runs are read-only. Retry as a new run when you need a fresh Observe handoff.',
+    );
+    expect(screen.getByTestId('studio-invoke-composer-guidance')).toHaveTextContent(
+      'Historical run is read-only. Sending this prompt creates a new independent Run and fresh Observe handoff.',
+    );
     expect(screen.getByRole('button', { name: 'Copy input' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Copy output' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Copy run id' })).toBeTruthy();

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.test.tsx
@@ -784,6 +784,9 @@ describe('StudioMemberInvokePanel', () => {
     });
 
     expect(await screen.findByText('Run history (1)')).toBeTruthy();
+    expect(screen.getByTestId('studio-invoke-observe-handoff')).toHaveTextContent(
+      'Invoke receipt was captured. Switch to Observe to watch backend events and read-model materialization catch up for this member.',
+    );
     expect(
       screen.getByTestId('studio-invoke-history-scroll').style.overflow,
     ).toBe('visible');

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokeSetupPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokeSetupPanels.tsx
@@ -96,6 +96,17 @@ const typedPayloadGridStyle: React.CSSProperties = {
   minWidth: 0,
 };
 
+const composerGuidanceStyle: React.CSSProperties = {
+  background: studioInvokeColors.surfaceActive,
+  border: `1px solid ${studioInvokeColors.borderStrong}`,
+  borderRadius: 8,
+  color: studioInvokeColors.textSoft,
+  display: 'grid',
+  gap: 2,
+  minWidth: 0,
+  padding: '8px 10px',
+};
+
 export const StudioMemberInvokeComposerPanel: React.FC<
   StudioMemberInvokeComposerPanelProps
 > = ({
@@ -197,16 +208,24 @@ export const StudioMemberInvokeComposerPanel: React.FC<
         {formError ? (
           <Typography.Text type="danger">{formError}</Typography.Text>
         ) : isHistoricalRunSelected ? (
-          <Typography.Text
-            style={layout === 'dock' ? promptDockHintStyle : helperTextStyle}
-            type="secondary"
+          <div
+            data-testid="studio-invoke-composer-guidance"
+            style={composerGuidanceStyle}
           >
-            Sending this prompt will create a new independent Run.
-          </Typography.Text>
+            <Typography.Text style={promptDockHintStyle} type="secondary">
+              Historical run is read-only. Sending this prompt creates a new
+              independent Run and fresh Observe handoff.
+            </Typography.Text>
+          </div>
         ) : !canInvoke ? (
-          <Typography.Text style={promptDockHintStyle} type="secondary">
-            {blockedReason || '请选择可调用的 Team member 和 endpoint。'}
-          </Typography.Text>
+          <div
+            data-testid="studio-invoke-composer-guidance"
+            style={composerGuidanceStyle}
+          >
+            <Typography.Text style={promptDockHintStyle} type="secondary">
+              {blockedReason || '请选择可调用的 Team member 和 endpoint。'}
+            </Typography.Text>
+          </div>
         ) : isChatEndpoint ? (
           <Typography.Text
             style={layout === 'dock' ? promptDockHintStyle : helperTextStyle}

--- a/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx
@@ -284,6 +284,14 @@ describe('StudioMemberBindPanel', () => {
     expect(screen.getByTestId('studio-bind-smoke-test-section')).toBeTruthy();
     expect(screen.getByTestId('studio-bind-snippet-section')).toBeTruthy();
     expect(screen.getByTestId('studio-bind-supporting-section')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId('studio-bind-flow-guidance')).toHaveTextContent(
+        'Bind is ready. Run a quick smoke test or continue to Invoke for the full transcript and Observe handoff.',
+      );
+    });
+    expect(screen.getByTestId('studio-bind-flow-guidance')).toHaveTextContent(
+      'ready',
+    );
     expect(screen.getByText('Current member publication')).toBeTruthy();
     expect(screen.getByText('member:default')).toBeTruthy();
     expect(screen.queryByRole('combobox')).toBeNull();
@@ -533,6 +541,12 @@ describe('StudioMemberBindPanel', () => {
     });
     expect(runtimeRunsApi.streamChat).not.toHaveBeenCalled();
     expect(await screen.findByText(/Smoke test passed in \d+ms/)).toBeTruthy();
+    expect(screen.getByTestId('studio-bind-flow-guidance')).toHaveTextContent(
+      'Smoke test passed. Continue to Invoke for a full run transcript, then use Observe for backend events.',
+    );
+    expect(screen.getByTestId('studio-bind-flow-guidance')).toHaveTextContent(
+      'ready',
+    );
     expect(screen.getByText('Run run-1')).toBeTruthy();
     expect(
       screen.queryByText('The current Studio draft accepted the request.'),
@@ -631,6 +645,7 @@ describe('StudioMemberBindPanel', () => {
           scopeId: 'scope-1',
           scopeSource: 'nyxid',
         },
+        memberId: 'script-4',
         scopeId: 'scope-1',
         preferredServiceId: 'script-4',
         onContinueToInvoke: handleContinueToInvoke,
@@ -656,6 +671,12 @@ describe('StudioMemberBindPanel', () => {
     );
 
     expect(await screen.findByText('No endpoint data available')).toBeTruthy();
+    expect(screen.getByTestId('studio-bind-flow-guidance')).toHaveTextContent(
+      'The member is published, but Studio has no callable endpoint yet. Wait for the contract to refresh before continuing.',
+    );
+    expect(screen.getByTestId('studio-bind-flow-guidance')).toHaveTextContent(
+      'waiting',
+    );
     const continueButton = screen.getByRole('button', {
       name: 'Continue to Invoke',
     });
@@ -712,6 +733,12 @@ describe('StudioMemberBindPanel', () => {
     );
 
     expect(await screen.findByText('Select a Team member before using Invoke.')).toBeTruthy();
+    expect(screen.getByTestId('studio-bind-flow-guidance')).toHaveTextContent(
+      'Bind can inspect this service, but Invoke stays blocked until Studio resolves a Team member target.',
+    );
+    expect(screen.getByTestId('studio-bind-flow-guidance')).toHaveTextContent(
+      'blocked',
+    );
     expect(screen.queryByTestId('studio-bind-contract-card')).toBeNull();
     expect(screen.getByRole('button', { name: 'Send smoke test' })).toBeDisabled();
     const continueButton = screen.getByRole('button', { name: 'Continue to Invoke' });
@@ -817,6 +844,12 @@ describe('StudioMemberBindPanel', () => {
     expect(
       screen.getByText('No published contract exists for draft yet.'),
     ).toBeTruthy();
+    expect(screen.getByTestId('studio-bind-flow-guidance')).toHaveTextContent(
+      'This member still needs Bind. Publish the current revision before trying Invoke or Observe.',
+    );
+    expect(screen.getByTestId('studio-bind-flow-guidance')).toHaveTextContent(
+      'blocked',
+    );
     expect(screen.getByText('Publish current member')).toBeTruthy();
 
     await act(async () => {
@@ -888,6 +921,191 @@ describe('StudioMemberBindPanel', () => {
         'Bind accepted the publication request. Stay here until Studio observes the published contract, then continue to Invoke.',
       );
     });
+  });
+
+  it('explains a failed bind run and keeps the previous published contract actions available', async () => {
+    const handleContinueToInvoke = jest.fn();
+    (studioApi.getMemberBinding as jest.Mock).mockResolvedValueOnce({
+      available: true,
+      scopeId: 'scope-1',
+      serviceId: 'default',
+      displayName: 'workspace-demo',
+      serviceKey: 'scope-1:default:workspace-demo',
+      defaultServingRevisionId: 'rev-2',
+      activeServingRevisionId: 'rev-2',
+      deploymentId: 'dep-2',
+      deploymentStatus: 'Active',
+      primaryActorId: 'actor-default',
+      updatedAt: '2026-03-26T08:00:00Z',
+      revisions: [],
+      lastBinding: {
+        boundAt: '2026-03-26T08:00:00Z',
+        implementationKind: 'workflow',
+        revisionId: 'rev-2',
+      },
+      currentBindingRun: {
+        bindingRunId: 'bind-member-failed',
+        completedAtUtc: '2026-06-02T03:32:00Z',
+        createdAtUtc: '2026-06-02T03:30:00Z',
+        failure: {
+          code: 'publish_failed',
+          message: 'Publication rejected by platform.',
+        },
+        memberId: 'default',
+        message: '',
+        scopeId: 'scope-1',
+        stateVersion: 5,
+        status: 'failed',
+        targetServiceId: 'default',
+        updatedAtUtc: '2026-06-02T03:32:00Z',
+      },
+    });
+
+    renderWithQueryClient(
+      React.createElement(StudioMemberBindPanel, {
+        authSession: {
+          enabled: true,
+          authenticated: true,
+          name: 'Abigail Deng',
+          scopeId: 'scope-1',
+          scopeSource: 'nyxid',
+        },
+        memberId: 'default',
+        scopeId: 'scope-1',
+        preferredServiceId: 'default',
+        onContinueToInvoke: handleContinueToInvoke,
+        services: [
+          {
+            serviceKey: 'scope-1:default:workspace-demo',
+            tenantId: 'scope-1',
+            appId: 'default',
+            namespace: 'default',
+            serviceId: 'default',
+            displayName: 'workspace-demo',
+            defaultServingRevisionId: 'rev-2',
+            activeServingRevisionId: 'rev-2',
+            deploymentId: 'dep-2',
+            primaryActorId: 'actor-default',
+            deploymentStatus: 'Active',
+            endpoints: [
+              {
+                endpointId: 'chat',
+                displayName: 'Chat',
+                kind: 'chat',
+                requestTypeUrl: '',
+                responseTypeUrl: '',
+                description: 'Chat with the previous workflow contract.',
+              },
+            ],
+            policyIds: [],
+            updatedAt: '2026-03-26T08:00:00Z',
+          },
+        ],
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('studio-bind-flow-guidance')).toHaveTextContent(
+        'Bind did not publish this member. Return to Build to adjust the member definition before retrying publication.',
+      );
+    });
+    expect(screen.getByTestId('studio-bind-flow-guidance')).toHaveTextContent(
+      'failed',
+    );
+    expect(screen.getByRole('button', { name: 'Send smoke test' })).toBeEnabled();
+    const continueButton = screen.getByRole('button', { name: 'Continue to Invoke' });
+    expect(continueButton).toBeEnabled();
+
+    fireEvent.click(continueButton);
+
+    expect(handleContinueToInvoke).toHaveBeenCalledWith('default', 'chat');
+  });
+
+  it('waits for endpoint data after a succeeded bind run materializes without a callable contract', async () => {
+    const handleContinueToInvoke = jest.fn();
+    (studioApi.getMemberBinding as jest.Mock).mockResolvedValueOnce({
+      available: true,
+      scopeId: 'scope-1',
+      serviceId: 'default',
+      displayName: 'workspace-demo',
+      serviceKey: 'scope-1:default:workspace-demo',
+      defaultServingRevisionId: 'rev-2',
+      activeServingRevisionId: 'rev-2',
+      deploymentId: 'dep-2',
+      deploymentStatus: 'Active',
+      primaryActorId: 'actor-default',
+      updatedAt: '2026-03-26T08:00:00Z',
+      revisions: [],
+      lastBinding: {
+        boundAt: '2026-03-26T08:00:00Z',
+        implementationKind: 'workflow',
+        revisionId: 'rev-2',
+      },
+      currentBindingRun: {
+        bindingRunId: 'bind-member-succeeded',
+        completedAtUtc: '2026-06-02T03:32:00Z',
+        createdAtUtc: '2026-06-02T03:30:00Z',
+        failure: null,
+        memberId: 'default',
+        message: '',
+        scopeId: 'scope-1',
+        stateVersion: 6,
+        status: 'succeeded',
+        targetServiceId: 'default',
+        updatedAtUtc: '2026-06-02T03:32:00Z',
+      },
+    });
+
+    renderWithQueryClient(
+      React.createElement(StudioMemberBindPanel, {
+        authSession: {
+          enabled: true,
+          authenticated: true,
+          name: 'Abigail Deng',
+          scopeId: 'scope-1',
+          scopeSource: 'nyxid',
+        },
+        memberId: 'default',
+        scopeId: 'scope-1',
+        preferredServiceId: 'default',
+        onContinueToInvoke: handleContinueToInvoke,
+        services: [
+          {
+            serviceKey: 'scope-1:default:workspace-demo',
+            tenantId: 'scope-1',
+            appId: 'default',
+            namespace: 'default',
+            serviceId: 'default',
+            displayName: 'workspace-demo',
+            defaultServingRevisionId: 'rev-2',
+            activeServingRevisionId: 'rev-2',
+            deploymentId: 'dep-2',
+            primaryActorId: 'actor-default',
+            deploymentStatus: 'Active',
+            endpoints: [],
+            policyIds: [],
+            updatedAt: '2026-03-26T08:00:00Z',
+          },
+        ],
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('studio-bind-flow-guidance')).toHaveTextContent(
+        'Bind completed, and Studio is refreshing the published contract. Continue to Invoke after endpoint data appears.',
+      );
+    });
+    expect(screen.getByTestId('studio-bind-flow-guidance')).toHaveTextContent(
+      'waiting',
+    );
+    expect(screen.getByRole('button', { name: 'Send smoke test' })).toBeDisabled();
+    const continueButton = screen.getByRole('button', { name: 'Continue to Invoke' });
+    expect(continueButton).toBeDisabled();
+
+    fireEvent.click(continueButton);
+
+    expect(handleContinueToInvoke).not.toHaveBeenCalled();
+    expect(runtimeRunsApi.streamChat).not.toHaveBeenCalled();
   });
 
   it('blocks smoke test and Invoke while a newer bind run is still publishing over an old contract', async () => {
@@ -990,6 +1208,68 @@ describe('StudioMemberBindPanel', () => {
 
     expect(runtimeRunsApi.streamChat).not.toHaveBeenCalled();
     expect(handleContinueToInvoke).not.toHaveBeenCalled();
+  });
+
+  it('explains that a smoke test failure is scoped to the contract check', async () => {
+    (runtimeRunsApi.streamChat as jest.Mock).mockRejectedValueOnce(
+      new Error('Backend rejected the smoke prompt.'),
+    );
+
+    renderWithQueryClient(
+      React.createElement(StudioMemberBindPanel, {
+        authSession: {
+          enabled: true,
+          authenticated: true,
+          name: 'Abigail Deng',
+          scopeId: 'scope-1',
+          scopeSource: 'nyxid',
+        },
+        memberId: 'default',
+        scopeId: 'scope-1',
+        preferredServiceId: 'default',
+        services: [
+          {
+            serviceKey: 'scope-1:default:workspace-demo',
+            tenantId: 'scope-1',
+            appId: 'default',
+            namespace: 'default',
+            serviceId: 'default',
+            displayName: 'workspace-demo',
+            defaultServingRevisionId: 'rev-2',
+            activeServingRevisionId: 'rev-2',
+            deploymentId: 'dep-2',
+            primaryActorId: 'actor-default',
+            deploymentStatus: 'Active',
+            endpoints: [
+              {
+                endpointId: 'chat',
+                displayName: 'Chat',
+                kind: 'chat',
+                requestTypeUrl: '',
+                responseTypeUrl: '',
+                description: 'Chat with the published workflow.',
+              },
+            ],
+            policyIds: [],
+            updatedAt: '2026-03-26T08:00:00Z',
+          },
+        ],
+      }),
+    );
+
+    await act(async () => {
+      fireEvent.click(await screen.findByRole('button', { name: 'Send smoke test' }));
+    });
+
+    expect(await screen.findByText('Smoke test failed')).toBeTruthy();
+    expect(screen.getByTestId('studio-bind-flow-guidance')).toHaveTextContent(
+      'Smoke test failed only this contract check. Retry here, or use Invoke when you need full events and typed payload debugging.',
+    );
+    expect(screen.getByTestId('studio-bind-flow-guidance')).toHaveTextContent(
+      'failed',
+    );
+    expect(screen.getByRole('button', { name: 'Send smoke test' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Continue to Invoke' })).toBeEnabled();
   });
 
   it('clears the previous member bind notice when the bind candidate changes', async () => {

--- a/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx
@@ -883,9 +883,113 @@ describe('StudioMemberBindPanel', () => {
         /Platform publication is still running; Invoke is not ready/,
       ),
     ).toBeTruthy();
-    expect(screen.getByTestId('studio-bind-flow-guidance')).toHaveTextContent(
-      'Bind accepted the publication request. Stay here until Studio observes the published contract, then continue to Invoke.',
+    await waitFor(() => {
+      expect(screen.getByTestId('studio-bind-flow-guidance')).toHaveTextContent(
+        'Bind accepted the publication request. Stay here until Studio observes the published contract, then continue to Invoke.',
+      );
+    });
+  });
+
+  it('blocks smoke test and Invoke while a newer bind run is still publishing over an old contract', async () => {
+    const handleContinueToInvoke = jest.fn();
+    (studioApi.getMemberBinding as jest.Mock).mockImplementationOnce(async () => ({
+      available: true,
+      scopeId: 'scope-1',
+      serviceId: 'default',
+      displayName: 'workspace-demo',
+      serviceKey: 'scope-1:default:workspace-demo',
+      defaultServingRevisionId: 'rev-2',
+      activeServingRevisionId: 'rev-2',
+      deploymentId: 'dep-2',
+      deploymentStatus: 'Active',
+      primaryActorId: 'actor-default',
+      updatedAt: '2026-03-26T08:00:00Z',
+      revisions: [],
+      lastBinding: {
+        boundAt: '2026-03-26T08:00:00Z',
+        implementationKind: 'workflow',
+        revisionId: 'rev-2',
+      },
+      currentBindingRun: {
+        bindingRunId: 'bind-member-2',
+        completedAtUtc: null,
+        createdAtUtc: '2026-06-02T03:30:00Z',
+        failure: null,
+        memberId: 'default',
+        message: '',
+        scopeId: 'scope-1',
+        stateVersion: 4,
+        status: 'platform_binding_pending',
+        targetServiceId: 'default',
+        updatedAtUtc: '2026-06-02T03:30:05Z',
+      },
+    }));
+
+    renderWithQueryClient(
+      React.createElement(StudioMemberBindPanel, {
+        authSession: {
+          enabled: true,
+          authenticated: true,
+          name: 'Abigail Deng',
+          scopeId: 'scope-1',
+          scopeSource: 'nyxid',
+        },
+        memberId: 'default',
+        scopeId: 'scope-1',
+        preferredServiceId: 'default',
+        onContinueToInvoke: handleContinueToInvoke,
+        services: [
+          {
+            serviceKey: 'scope-1:default:workspace-demo',
+            tenantId: 'scope-1',
+            appId: 'default',
+            namespace: 'default',
+            serviceId: 'default',
+            displayName: 'workspace-demo',
+            defaultServingRevisionId: 'rev-2',
+            activeServingRevisionId: 'rev-2',
+            deploymentId: 'dep-2',
+            primaryActorId: 'actor-default',
+            deploymentStatus: 'Active',
+            endpoints: [
+              {
+                endpointId: 'chat',
+                displayName: 'Chat',
+                kind: 'chat',
+                requestTypeUrl: '',
+                responseTypeUrl: '',
+                description: 'Chat with the previous workflow contract.',
+              },
+            ],
+            policyIds: [],
+            updatedAt: '2026-03-26T08:00:00Z',
+          },
+        ],
+      }),
     );
+
+    await waitFor(() => {
+      expect(studioApi.getMemberBinding).toHaveBeenCalledWith(
+        'scope-1',
+        'default',
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('studio-bind-flow-guidance')).toHaveTextContent(
+        'Bind accepted the publication request. Stay here until Studio observes the published contract, then continue to Invoke.',
+      );
+    });
+
+    const smokeButton = screen.getByRole('button', { name: 'Send smoke test' });
+    const continueButton = screen.getByRole('button', { name: 'Continue to Invoke' });
+    expect(smokeButton).toBeDisabled();
+    expect(continueButton).toBeDisabled();
+
+    fireEvent.click(smokeButton);
+    fireEvent.click(continueButton);
+
+    expect(runtimeRunsApi.streamChat).not.toHaveBeenCalled();
+    expect(handleContinueToInvoke).not.toHaveBeenCalled();
   });
 
   it('clears the previous member bind notice when the bind candidate changes', async () => {

--- a/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx
@@ -826,6 +826,68 @@ describe('StudioMemberBindPanel', () => {
     expect(handleBindPendingCandidate).toHaveBeenCalledTimes(1);
   });
 
+  it('explains that a pending bind is not ready for Invoke until the contract materializes', async () => {
+    (studioApi.getMemberBinding as jest.Mock).mockResolvedValueOnce({
+      available: false,
+      scopeId: 'scope-1',
+      serviceId: '',
+      displayName: '',
+      serviceKey: '',
+      defaultServingRevisionId: '',
+      activeServingRevisionId: '',
+      deploymentId: '',
+      deploymentStatus: '',
+      primaryActorId: '',
+      updatedAt: '',
+      revisions: [],
+      currentBindingRun: {
+        bindingRunId: 'bind-member-1',
+        completedAtUtc: null,
+        createdAtUtc: '2026-06-02T03:30:00Z',
+        failure: null,
+        memberId: 'draft',
+        message: '',
+        scopeId: 'scope-1',
+        stateVersion: null,
+        status: 'platform_binding_pending',
+        targetServiceId: null,
+        updatedAtUtc: '2026-06-02T03:30:05Z',
+      },
+    });
+
+    renderWithQueryClient(
+      React.createElement(StudioMemberBindPanel, {
+        authSession: {
+          enabled: true,
+          authenticated: true,
+          name: 'Abigail Deng',
+          scopeId: 'scope-1',
+          scopeSource: 'nyxid',
+        },
+        memberId: 'draft',
+        scopeId: 'scope-1',
+        pendingBindingCandidate: {
+          kind: 'workflow',
+          displayName: 'draft',
+          description:
+            'Publish the current workflow revision first, then Studio can reveal the invoke URL and endpoint contract for this member.',
+          actionLabel: 'Bind current revision',
+        },
+        onBindPendingCandidate: jest.fn(),
+        services: [],
+      }),
+    );
+
+    expect(
+      await screen.findByText(
+        /Platform publication is still running; Invoke is not ready/,
+      ),
+    ).toBeTruthy();
+    expect(screen.getByTestId('studio-bind-flow-guidance')).toHaveTextContent(
+      'Bind accepted the publication request. Stay here until Studio observes the published contract, then continue to Invoke.',
+    );
+  });
+
   it('clears the previous member bind notice when the bind candidate changes', async () => {
     const handleBindPendingCandidate = jest.fn().mockResolvedValue(undefined);
     const CandidateHarness = () => {

--- a/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx
@@ -97,6 +97,12 @@ type SmokeTestResult = {
   readonly status: 'idle' | 'running' | 'success' | 'error';
 };
 
+type BindFlowGuidance = {
+  readonly message: string;
+  readonly stage: 'waiting' | 'ready' | 'blocked' | 'failed';
+  readonly type: 'success' | 'info' | 'warning' | 'error';
+};
+
 function isStudioMemberBindingRunTerminal(
   run: StudioMemberBindingRunStatusResponse | null | undefined,
 ): boolean {
@@ -145,6 +151,101 @@ function describeStudioMemberBindingRunStatus(
   return {
     message:
       'Binding request accepted. Studio is waiting for the member authority; this does not mean the member is bound yet.',
+    type: 'info',
+  };
+}
+
+function buildBindFlowGuidance(input: {
+  readonly currentBindingRun: StudioMemberBindingRunStatusResponse | null;
+  readonly hasEndpointOptions: boolean;
+  readonly hasMember: boolean;
+  readonly hasPublishedService: boolean;
+  readonly pendingBindingCandidate:
+    | StudioMemberBindPanelProps['pendingBindingCandidate']
+    | null
+    | undefined;
+  readonly smokeTestStatus: SmokeTestResult['status'];
+}): BindFlowGuidance {
+  const { currentBindingRun } = input;
+  if (currentBindingRun && !isStudioMemberBindingRunTerminal(currentBindingRun)) {
+    return {
+      message:
+        'Bind accepted the publication request. Stay here until Studio observes the published contract, then continue to Invoke.',
+      stage: 'waiting',
+      type: 'info',
+    };
+  }
+
+  if (
+    currentBindingRun &&
+    (currentBindingRun.status === 'failed' || currentBindingRun.status === 'rejected')
+  ) {
+    return {
+      message:
+        'Bind did not publish this member. Return to Build to adjust the member definition before retrying publication.',
+      stage: 'failed',
+      type: 'error',
+    };
+  }
+
+  if (currentBindingRun?.status === 'succeeded' && !input.hasEndpointOptions) {
+    return {
+      message:
+        'Bind completed, and Studio is refreshing the published contract. Continue to Invoke after endpoint data appears.',
+      stage: 'waiting',
+      type: 'info',
+    };
+  }
+
+  if (input.pendingBindingCandidate && !input.hasPublishedService) {
+    return {
+      message:
+        'This member still needs Bind. Publish the current revision before trying Invoke or Observe.',
+      stage: 'blocked',
+      type: 'warning',
+    };
+  }
+
+  if (!input.hasMember) {
+    return {
+      message:
+        'Bind can inspect this service, but Invoke stays blocked until Studio resolves a Team member target.',
+      stage: 'blocked',
+      type: 'info',
+    };
+  }
+
+  if (!input.hasEndpointOptions) {
+    return {
+      message:
+        'The member is published, but Studio has no callable endpoint yet. Wait for the contract to refresh before continuing.',
+      stage: 'waiting',
+      type: 'warning',
+    };
+  }
+
+  if (input.smokeTestStatus === 'success') {
+    return {
+      message:
+        'Smoke test passed. Continue to Invoke for a full run transcript, then use Observe for backend events.',
+      stage: 'ready',
+      type: 'success',
+    };
+  }
+
+  if (input.smokeTestStatus === 'error') {
+    return {
+      message:
+        'Smoke test failed only this contract check. Retry here, or use Invoke when you need full events and typed payload debugging.',
+      stage: 'failed',
+      type: 'warning',
+    };
+  }
+
+  return {
+    message:
+      'Bind is ready. Run a quick smoke test or continue to Invoke for the full transcript and Observe handoff.',
+    stage: 'ready',
     type: 'info',
   };
 }
@@ -421,6 +522,23 @@ const smokeActionStackStyle: React.CSSProperties = {
   gap: 10,
   minWidth: 0,
   width: '100%',
+};
+
+const flowGuidanceCardStyle: React.CSSProperties = {
+  ...surfaceCardStyle,
+  background: '#f8fafc',
+  display: 'grid',
+  gap: 8,
+  padding: 12,
+};
+
+const flowGuidanceHeaderStyle: React.CSSProperties = {
+  alignItems: 'center',
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 8,
+  justifyContent: 'space-between',
+  minWidth: 0,
 };
 
 const contractUrlCardStyle: React.CSSProperties = {
@@ -892,6 +1010,14 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
     selectedService && !hasEndpointOptions
       ? 'This published service has no endpoint data available yet.'
       : '';
+  const bindFlowGuidance = buildBindFlowGuidance({
+    currentBindingRun,
+    hasEndpointOptions,
+    hasMember: Boolean(normalizedMemberId),
+    hasPublishedService: services.length > 0,
+    pendingBindingCandidate,
+    smokeTestStatus: smokeTestResult.status,
+  });
   const bindSurfaceIdentity = useMemo(() => {
     const pendingCandidateIdentity = pendingBindingCandidate
       ? `candidate:${scopeId}:${pendingBindingCandidate.kind}:${pendingBindingCandidate.displayName}`
@@ -1034,10 +1160,24 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
                 <Alert
                   showIcon
                   message={currentBindingRunNotice.message}
-                  description={`Run ${currentBindingRun?.bindingRunId}`}
+                  description={`Run ${currentBindingRun?.bindingRunId}. ${bindFlowGuidance.message}`}
                   type={currentBindingRunNotice.type}
                 />
               ) : null}
+              <div
+                data-testid="studio-bind-flow-guidance"
+                style={flowGuidanceCardStyle}
+              >
+                <div style={flowGuidanceHeaderStyle}>
+                  <Typography.Text strong>Lifecycle guidance</Typography.Text>
+                  <Tag color={bindFlowGuidance.stage === 'ready' ? 'green' : 'blue'}>
+                    {bindFlowGuidance.stage}
+                  </Tag>
+                </div>
+                <Typography.Text type="secondary">
+                  {bindFlowGuidance.message}
+                </Typography.Text>
+              </div>
               {postBindEntryActions ? (
                 <Alert
                   showIcon
@@ -1241,6 +1381,28 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
                 type="info"
               />
             ) : null}
+            <div
+              data-testid="studio-bind-flow-guidance"
+              style={flowGuidanceCardStyle}
+            >
+              <div style={flowGuidanceHeaderStyle}>
+                <Typography.Text strong>Lifecycle guidance</Typography.Text>
+                <Tag
+                  color={
+                    bindFlowGuidance.stage === 'ready'
+                      ? 'green'
+                      : bindFlowGuidance.stage === 'failed'
+                        ? 'red'
+                        : 'blue'
+                  }
+                >
+                  {bindFlowGuidance.stage}
+                </Tag>
+              </div>
+              <Typography.Text type="secondary">
+                {bindFlowGuidance.message}
+              </Typography.Text>
+            </div>
           </div>
         </AevatarPanel>
 
@@ -1377,6 +1539,16 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
                 />
               ) : null}
               <div style={smokeActionStackStyle}>
+                <Alert
+                  showIcon
+                  message="Next step"
+                  description={
+                    canUsePublishedMemberInvoke
+                      ? 'Continue to Invoke opens a full run transcript for the same member and endpoint. Observe will receive the latest run context after Invoke starts.'
+                      : bindFlowGuidance.message
+                  }
+                  type={bindFlowGuidance.type}
+                />
                 <Button
                   block
                   icon={<CheckCircleOutlined />}

--- a/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx
@@ -852,8 +852,14 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
   const publishedSmokeRequiresAuth =
     !runsCurrentWorkflowDraft &&
     Boolean(bindContract?.authEnabled && !bindContract.authAuthenticated);
+  const bindingPublicationReady = !currentBindingRun ||
+    isStudioMemberBindingRunTerminal(currentBindingRun);
   const canUsePublishedMemberInvoke = Boolean(
-    normalizedMemberId && selectedService && selectedEndpoint && bindContract,
+    normalizedMemberId &&
+      selectedService &&
+      selectedEndpoint &&
+      bindContract &&
+      bindingPublicationReady,
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Problem

Studio member flows expose Build, Bind, Invoke, and Observe, but failure or waiting states can still feel ambiguous from a user perspective. A failed GAgent dry-run looks similar to a publish failure, Bind accepted states do not clearly say Invoke is still waiting for publication/read-model materialization, and Invoke success/history states do not explain how Observe receives the latest run context.

## Solution

- Add lifecycle recovery guidance for GAgent Build dry-run running/success/failure states.
- Add Bind lifecycle guidance for pending publication, missing member target, missing endpoints, smoke-test success, and smoke-test failure.
- Add Invoke recovery guidance for failed/stopped runs.
- Add Observe handoff guidance for latest successful/running runs and read-only historical runs.
- Add history/composer guidance so selecting a historical run clearly creates a new run when retried.

## Impacted paths

- `apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx`
- `apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx`
- `apps/aevatar-console-web/src/pages/studio/components/StudioMemberCurrentRunPanel.tsx`
- `apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokeHistoryPanel.tsx`
- `apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokeSetupPanels.tsx`
- Studio component tests in the same frontend area

## Validation

- `git diff --check` -> no output
- `jest --runInBand src/pages/studio/components/StudioBuildPanels.test.tsx src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx src/pages/studio/components/StudioMemberInvokePanel.test.tsx src/pages/studio/components/StudioMemberInvokePanel.currentRun.test.ts` -> 4 suites / 50 tests passed
- `pnpm --dir apps/aevatar-console-web tsc` -> passed
- `bash tools/ci/test_stability_guards.sh` -> exit 127 with no output; guard delegates into repo-local `.claude/skills/codex-refactor-loop/scripts/test_spawn_codex.sh`, which this loop is forbidden to use or modify

## Boundaries

- Base branch: `feat/2026-05-29_ai-automation-pipeline`
- No backend/proto/API/actor/projection/workflow/runtime/database/backend tests/backend config/architecture docs changes
- No localization consistency work
- No merge or auto-merge attempted

Related issue: #1665