### PR TITLE
Clarify Mission Control intervention handoffs

### DIFF
--- a/apps/aevatar-console-web/src/pages/MissionControl/InspectorPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/MissionControl/InspectorPanel.tsx
@@ -22,6 +22,7 @@ import type {
   MissionRuntimeConnectionStatus,
   MissionTopologyNode,
 } from './models';
+import type { MissionOperatorHandoff } from './operatorHandoff';
 import {
   formatConnectionLabel,
   formatInspectorPresentationLabel,
@@ -44,6 +45,7 @@ type InspectorPanelProps = {
   connectionStatus: MissionRuntimeConnectionStatus;
   mode: MissionInspectorMode;
   onSubmitAction?: (action: MissionInterventionActionRequest) => Promise<void>;
+  operatorHandoff: MissionOperatorHandoff;
   presentation: MissionInspectorPresentation;
   selectedNode?: MissionTopologyNode;
   snapshot: MissionControlSnapshot;
@@ -55,6 +57,7 @@ const InspectorPanel: React.FC<InspectorPanelProps> = ({
   connectionStatus,
   mode,
   onSubmitAction,
+  operatorHandoff,
   presentation,
   selectedNode,
   snapshot,
@@ -130,6 +133,9 @@ const InspectorPanel: React.FC<InspectorPanelProps> = ({
         <Tag color={resolveConnectionTagColor(connectionStatus)}>
           Connection: {formatConnectionLabel(connectionStatus)}
         </Tag>
+        <Tag color={operatorHandoff.isActionable ? 'gold' : 'default'}>
+          {operatorHandoff.actionLabel}
+        </Tag>
         {actionFeedback ? (
           <Tag color={resolveFeedbackTagColor(actionFeedback.tone)}>
             {actionFeedback.message}
@@ -182,6 +188,31 @@ const InspectorPanel: React.FC<InspectorPanelProps> = ({
               <Typography.Text style={{ color: token.colorTextSecondary }}>
                 {showIntervention.summary}
               </Typography.Text>
+              <div
+                aria-label="Mission Control intervention handoff"
+                style={{
+                  background: token.colorBgContainer,
+                  border: `1px solid ${token.colorBorderSecondary}`,
+                  borderRadius: 4,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 8,
+                  padding: 12,
+                }}
+              >
+                <Typography.Text strong style={{ color: token.colorTextHeading }}>
+                  Operator handoff
+                </Typography.Text>
+                <Typography.Text style={{ color: token.colorTextSecondary }}>
+                  {operatorHandoff.inputLabel}
+                </Typography.Text>
+                <Typography.Text style={{ color: token.colorTextTertiary }}>
+                  {operatorHandoff.connectionDetail}
+                </Typography.Text>
+                <Typography.Text style={{ color: token.colorTextTertiary }}>
+                  {operatorHandoff.expectedResult}
+                </Typography.Text>
+              </div>
               <div
                 style={{
                   background: token.colorBgContainer,

--- a/apps/aevatar-console-web/src/pages/MissionControl/InspectorPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/MissionControl/InspectorPanel.tsx
@@ -25,12 +25,14 @@ import type {
 import type { MissionOperatorHandoff } from './operatorHandoff';
 import {
   formatConnectionLabel,
+  formatHandoffSeverityLabel,
   formatInspectorPresentationLabel,
   formatInterventionLabel,
   formatMissionLabel,
   renderMissionKindIcon,
   resolveConnectionTagColor,
   resolveFeedbackTagColor,
+  resolveHandoffTagColor,
   resolveMissionStatusTone,
   resolveObservationTone,
 } from './presentation';
@@ -323,6 +325,9 @@ const InspectorPanel: React.FC<InspectorPanelProps> = ({
                   <Tag color={resolveObservationTone(token, focusNode.observationStatus)}>
                     Observation: {formatMissionLabel(focusNode.observationStatus)}
                   </Tag>
+                  <Tag color={resolveHandoffTagColor(focusNode.handoff.severity)}>
+                    Handoff: {formatHandoffSeverityLabel(focusNode.handoff.severity)}
+                  </Tag>
                 </Space>
                 <div
                   style={{
@@ -361,6 +366,31 @@ const InspectorPanel: React.FC<InspectorPanelProps> = ({
                 <Typography.Text style={{ color: token.colorTextSecondary }}>
                   {focusNode.summary}
                 </Typography.Text>
+                <div
+                  aria-label="Mission Control node handoff"
+                  style={{
+                    background: token.colorFillQuaternary,
+                    border: `1px solid ${token.colorBorderSecondary}`,
+                    borderRadius: 4,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 6,
+                    padding: 12,
+                  }}
+                >
+                  <Typography.Text strong style={{ color: token.colorTextHeading }}>
+                    {focusNode.handoff.title}
+                  </Typography.Text>
+                  <Typography.Text style={{ color: token.colorTextSecondary }}>
+                    {focusNode.handoff.detail}
+                  </Typography.Text>
+                  <Typography.Text style={{ color: token.colorTextTertiary }}>
+                    Evidence: {focusNode.handoff.evidence}
+                  </Typography.Text>
+                  <Typography.Text style={{ color: token.colorTextTertiary }}>
+                    Next: {focusNode.handoff.nextStep}
+                  </Typography.Text>
+                </div>
               </Space>
             </Card>
 

--- a/apps/aevatar-console-web/src/pages/MissionControl/TopologyCanvas.tsx
+++ b/apps/aevatar-console-web/src/pages/MissionControl/TopologyCanvas.tsx
@@ -15,7 +15,7 @@ import {
   type NodeProps,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
-import { Tooltip, Typography, theme } from 'antd';
+import { Tag, Tooltip, Typography, theme } from 'antd';
 import React, { useMemo } from 'react';
 import type {
   MissionControlSnapshot,
@@ -26,8 +26,10 @@ import type {
 import {
   formatMissionLabel,
   formatConnectionLabel,
+  formatHandoffSeverityLabel,
   renderMissionKindIcon,
   resolveConnectionTagColor,
+  resolveHandoffTagColor,
   resolveMissionStatusTone,
   resolveObservationTone,
   type MissionThemeToken,
@@ -231,6 +233,39 @@ function TopologyNodeCard({
       >
         {node.summary}
       </Typography.Paragraph>
+      <Tooltip title={node.handoff.nextStep}>
+        <div
+          aria-label="Mission Control node handoff"
+          style={{
+            background: token.colorFillQuaternary,
+            border: `1px solid ${token.colorBorderSecondary}`,
+            borderRadius: 4,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 4,
+            marginBottom: 12,
+            padding: '8px 10px',
+          }}
+        >
+          <Typography.Text
+            style={{
+              color: token.colorTextHeading,
+              display: 'block',
+              fontSize: 12,
+              fontWeight: 700,
+              lineHeight: 1.25,
+            }}
+          >
+            {node.handoff.title}
+          </Typography.Text>
+          <Typography.Text
+            ellipsis
+            style={{ color: token.colorTextTertiary, fontSize: 11 }}
+          >
+            {node.handoff.evidence}
+          </Typography.Text>
+        </div>
+      </Tooltip>
       <div
         style={{
           borderTop: `1px solid ${token.colorBorderSecondary}`,
@@ -269,6 +304,17 @@ function TopologyNodeCard({
           >
             {node.freshnessLabel}
           </Typography.Text>
+        </div>
+        <div>
+          <Typography.Text style={{ color: token.colorTextTertiary, fontSize: 11 }}>
+            Handoff
+          </Typography.Text>
+          <Tag
+            color={resolveHandoffTagColor(node.handoff.severity)}
+            style={{ display: 'block', fontSize: 11, marginInlineEnd: 0, marginTop: 2 }}
+          >
+            {formatHandoffSeverityLabel(node.handoff.severity)}
+          </Tag>
         </div>
       </div>
       <Handle

--- a/apps/aevatar-console-web/src/pages/MissionControl/hooks/useMissionControlRuntime.ts
+++ b/apps/aevatar-console-web/src/pages/MissionControl/hooks/useMissionControlRuntime.ts
@@ -30,6 +30,7 @@ import {
   buildMissionRuntimePlaceholderSnapshot,
   buildMissionSnapshotFromRuntime,
 } from '../runtimeAdapter';
+import { buildMissionActionFeedbackMessage } from '../runtimeHandoff';
 import type { MissionControlRuntimeArtifacts } from '../services/api';
 import {
   fetchMissionControlRuntimeArtifacts,
@@ -139,37 +140,20 @@ function buildConnectionMessage(
 function buildAcceptedFeedback(
   kind: MissionInterventionActionKind,
   accepted: boolean,
+  commandId?: string,
+  runId?: string,
   signalName?: string,
 ): MissionActionFeedback {
-  if (!accepted) {
-      return {
-        message: 'Runtime did not accept the intervention request. Please try again.',
-        tone: 'warning',
-      };
-  }
-
-  switch (kind) {
-    case 'signal':
-      return {
-        message: `Signal ${signalName || 'continue'} was accepted. Waiting for runtime to continue.`,
-        tone: 'success',
-      };
-    case 'approve':
-      return {
-        message: 'Approval was accepted. Waiting for the run to advance.',
-        tone: 'success',
-      };
-    case 'reject':
-      return {
-        message: 'Rejection was submitted. Waiting for runtime to confirm stop or rollback.',
-        tone: 'warning',
-      };
-    default:
-      return {
-        message: 'Resume was accepted. Waiting for the next runtime snapshot.',
-        tone: 'success',
-      };
-  }
+  return {
+    message: buildMissionActionFeedbackMessage({
+      accepted,
+      commandId,
+      kind,
+      runId,
+      signalName,
+    }),
+    tone: !accepted || kind === 'reject' ? 'warning' : 'success',
+  };
 }
 
 export function useMissionControlRuntime(): UseMissionControlRuntimeResult {
@@ -471,7 +455,13 @@ export function useMissionControlRuntime(): UseMissionControlRuntimeResult {
           action,
         );
         setActionFeedback(
-          buildAcceptedFeedback(action.kind, result.accepted, result.signalName),
+          buildAcceptedFeedback(
+            action.kind,
+            result.accepted,
+            result.commandId,
+            result.runId,
+            result.signalName,
+          ),
         );
         await queryClient.invalidateQueries({
           queryKey: buildMissionControlQueryKey(runtimeContext),

--- a/apps/aevatar-console-web/src/pages/MissionControl/index.tsx
+++ b/apps/aevatar-console-web/src/pages/MissionControl/index.tsx
@@ -39,6 +39,10 @@ import type {
   MissionInterventionState,
 } from './models';
 import {
+  buildMissionOperatorHandoff,
+  type MissionOperatorHandoff,
+} from './operatorHandoff';
+import {
   formatInterventionLabel,
   formatConnectionLabel,
   formatMissionLabel,
@@ -244,6 +248,10 @@ function MissionHeaderBar({
 }) {
   const ui = useMissionControlUi();
   const { token } = theme.useToken();
+  const handoff = useMemo(
+    () => buildMissionOperatorHandoff(snapshot, connectionStatus),
+    [connectionStatus, snapshot],
+  );
 
   return (
     <div
@@ -297,6 +305,47 @@ function MissionHeaderBar({
             {connectionMessage}
           </Typography.Text>
         ) : null}
+        <div
+          aria-label="Mission Control operator handoff"
+          style={{
+            background: handoff.isActionable
+              ? token.colorWarningBg
+              : token.colorFillQuaternary,
+            border: `1px solid ${
+              handoff.isActionable
+                ? token.colorWarningBorder
+                : token.colorBorderSecondary
+            }`,
+            borderRadius: 4,
+            display: 'grid',
+            gap: 8,
+            gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+            marginTop: 4,
+            maxWidth: 760,
+            padding: '10px 12px',
+          }}
+        >
+          <div style={{ minWidth: 0 }}>
+            <Typography.Text
+              style={{
+                color: token.colorTextHeading,
+                display: 'block',
+                fontSize: 12,
+                fontWeight: 700,
+              }}
+            >
+              {handoff.actionLabel}
+            </Typography.Text>
+            <Typography.Text style={{ color: token.colorTextTertiary, fontSize: 12 }}>
+              {handoff.actionDetail}
+            </Typography.Text>
+          </div>
+          <div style={{ minWidth: 0 }}>
+            <Typography.Text style={{ color: token.colorTextSecondary, fontSize: 12 }}>
+              {handoff.connectionDetail}
+            </Typography.Text>
+          </div>
+        </div>
       </div>
       <Space wrap size={[8, 8]} style={{ justifyContent: 'flex-end' }}>
         <Segmented<MissionStageView>
@@ -582,10 +631,12 @@ function MissionStage({
 
 function MissionDock({
   activeTab,
+  handoff,
   onTabChange,
   snapshot,
 }: {
   activeTab: MissionDockTab;
+  handoff: MissionOperatorHandoff;
   onTabChange: (key: MissionDockTab) => void;
   snapshot: MissionControlSnapshot;
 }) {
@@ -701,6 +752,9 @@ function MissionDock({
         </Space>
         <Space wrap size={[8, 8]}>
           <Tag color="processing">{snapshot.events.length} events</Tag>
+          <Tag color={handoff.isActionable ? 'gold' : 'default'}>
+            {handoff.isActionable ? 'Evidence before action' : 'Read-only evidence'}
+          </Tag>
           <Button onClick={() => ui.setDockCollapsed(!ui.isDockCollapsed)}>
             {ui.isDockCollapsed ? 'Expand Dock' : 'Collapse Dock'}
           </Button>
@@ -708,6 +762,28 @@ function MissionDock({
       </div>
       {!ui.isDockCollapsed ? (
         <div style={{ ...scrollerStyle, flex: 1, padding: '12px 14px 14px' }}>
+          <Card
+            size="small"
+            styles={{ body: { padding: 12 } }}
+            style={{
+              background: token.colorFillQuaternary,
+              borderColor: token.colorBorderSecondary,
+              borderRadius: 4,
+              marginBottom: 12,
+            }}
+          >
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <Typography.Text strong style={{ color: token.colorTextHeading }}>
+                Evidence handoff
+              </Typography.Text>
+              <Typography.Text style={{ color: token.colorTextSecondary }}>
+                {handoff.evidenceDetail}
+              </Typography.Text>
+              <Typography.Text style={{ color: token.colorTextTertiary }}>
+                {handoff.expectedResult}
+              </Typography.Text>
+            </div>
+          </Card>
           {activeTab === 'timeline' ? (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
               {snapshot.events.map((event) => (
@@ -786,6 +862,10 @@ function MissionControlCanvas({
     () => snapshot.nodes.find((node) => node.id === ui.activeNodeId),
     [snapshot.nodes, ui.activeNodeId],
   );
+  const handoff = useMemo(
+    () => buildMissionOperatorHandoff(snapshot, runtime.connectionStatus),
+    [runtime.connectionStatus, snapshot],
+  );
 
   const shouldPushInspector =
     ui.isInspectorOpen && ui.inspectorPresentation === 'push';
@@ -849,6 +929,7 @@ function MissionControlCanvas({
             <InspectorPanel
               actionFeedback={runtime.actionFeedback}
               connectionStatus={runtime.connectionStatus}
+              operatorHandoff={handoff}
               mode={ui.inspectorMode}
               onSubmitAction={(action) => {
                 if (!snapshot.intervention) {
@@ -865,7 +946,12 @@ function MissionControlCanvas({
           </Card>
         ) : null}
       </div>
-      <MissionDock activeTab={dockTab} onTabChange={setDockTab} snapshot={snapshot} />
+      <MissionDock
+        activeTab={dockTab}
+        handoff={handoff}
+        onTabChange={setDockTab}
+        snapshot={snapshot}
+      />
       {!shouldPushInspector ? (
         <Drawer
           closable
@@ -887,6 +973,7 @@ function MissionControlCanvas({
           <InspectorPanel
             actionFeedback={runtime.actionFeedback}
             connectionStatus={runtime.connectionStatus}
+            operatorHandoff={handoff}
             mode={ui.inspectorMode}
             onSubmitAction={(action) => {
               if (!snapshot.intervention) {

--- a/apps/aevatar-console-web/src/pages/MissionControl/index.tsx
+++ b/apps/aevatar-console-web/src/pages/MissionControl/index.tsx
@@ -45,8 +45,10 @@ import {
 import {
   formatInterventionLabel,
   formatConnectionLabel,
+  formatHandoffSeverityLabel,
   formatMissionLabel,
   resolveConnectionTagColor,
+  resolveHandoffTagColor,
   resolveMissionStatusTone,
   resolveObservationTone,
   type MissionThemeToken,
@@ -618,7 +620,13 @@ function MissionStage({
                   <Space wrap size={[8, 8]}>
                     {event.stepId ? <Tag>{event.stepId}</Tag> : null}
                     {event.actorId ? <Tag color="cyan">{event.actorId}</Tag> : null}
+                    <Tag color={resolveHandoffTagColor(event.handoff.severity)}>
+                      {formatHandoffSeverityLabel(event.handoff.severity)}
+                    </Tag>
                   </Space>
+                  <Typography.Text style={{ color: token.colorTextTertiary }}>
+                    {event.handoff.title}: {event.handoff.nextStep}
+                  </Typography.Text>
                 </Card>
               ))}
             </div>

--- a/apps/aevatar-console-web/src/pages/MissionControl/models.ts
+++ b/apps/aevatar-console-web/src/pages/MissionControl/models.ts
@@ -91,6 +91,20 @@ export type MissionInterventionActionKind =
 
 export type MissionFeedbackTone = 'info' | 'success' | 'warning' | 'error';
 
+export type MissionHandoffSeverity =
+  | 'observe'
+  | 'action'
+  | 'blocked'
+  | 'confirming';
+
+export interface MissionHandoffCue {
+  detail: string;
+  evidence: string;
+  nextStep: string;
+  severity: MissionHandoffSeverity;
+  title: string;
+}
+
 export interface MissionMetric {
   key: string;
   label: string;
@@ -141,6 +155,7 @@ export interface MissionTopologyNode {
   observationStatus: MissionObservationStatus;
   freshnessLabel: string;
   freshnessSeconds: number;
+  handoff: MissionHandoffCue;
   summary: string;
   lastLatencyMs?: number;
   confidence?: number;
@@ -166,6 +181,7 @@ export interface MissionExecutionEvent {
   detail: string;
   stepId?: string;
   actorId?: string;
+  handoff: MissionHandoffCue;
   timestamp: string;
   severity: 'info' | 'success' | 'warning' | 'error';
 }

--- a/apps/aevatar-console-web/src/pages/MissionControl/operatorHandoff.test.ts
+++ b/apps/aevatar-console-web/src/pages/MissionControl/operatorHandoff.test.ts
@@ -1,0 +1,124 @@
+import type { MissionControlSnapshot } from './models';
+import { buildMissionOperatorHandoff } from './operatorHandoff';
+
+function createSnapshot(
+  overrides: Partial<MissionControlSnapshot> = {},
+): MissionControlSnapshot {
+  return {
+    edges: [],
+    events: [
+      {
+        detail: 'approval requested',
+        id: 'event-1',
+        severity: 'warning',
+        stepId: 'approval',
+        timestamp: '2026-03-30T08:00:20.000Z',
+        title: 'workflow.suspended',
+        type: 'workflow_suspended',
+      },
+    ],
+    liveLogs: [],
+    metrics: [],
+    nodes: [],
+    summary: {
+      activeStageLabel: 'Waiting for approval',
+      definitionActorId: 'actor-1',
+      observationStatus: 'streaming',
+      runId: 'run-1',
+      scopeId: 'scope-1',
+      startedAt: '2026-03-30T08:00:00.000Z',
+      status: 'waiting_approval',
+      updatedAt: '2026-03-30T08:00:20.000Z',
+      workflowName: 'mission-workflow',
+    },
+    ...overrides,
+  };
+}
+
+describe('buildMissionOperatorHandoff', () => {
+  it('describes observation-only runs as read-only evidence', () => {
+    const handoff = buildMissionOperatorHandoff(
+      createSnapshot({
+        events: [],
+        summary: {
+          activeStageLabel: 'Execution running',
+          definitionActorId: 'actor-1',
+          observationStatus: 'streaming',
+          runId: 'run-1',
+          scopeId: 'scope-1',
+          startedAt: '2026-03-30T08:00:00.000Z',
+          status: 'running',
+          updatedAt: '2026-03-30T08:00:20.000Z',
+          workflowName: 'mission-workflow',
+        },
+      }),
+      'live',
+    );
+
+    expect(handoff.isActionable).toBe(false);
+    expect(handoff.actionLabel).toBe('No operator action');
+    expect(handoff.evidenceDetail).toContain('read-only evidence');
+    expect(handoff.expectedResult).toContain('Continue observing');
+  });
+
+  it('blocks intervention actions while runtime is disconnected', () => {
+    const handoff = buildMissionOperatorHandoff(
+      createSnapshot({
+        intervention: {
+          key: 'waiting-approval/approval',
+          kind: 'human_approval',
+          nodeId: 'node-approval',
+          primaryActionLabel: 'Approve',
+          prompt: 'Approve guarded execution.',
+          required: true,
+          secondaryActionLabel: 'Reject',
+          stepId: 'approval',
+          summary: 'Runtime is paused for approval.',
+          title: 'Waiting for approval',
+        },
+      }),
+      'disconnected',
+    );
+
+    expect(handoff.isActionable).toBe(false);
+    expect(handoff.actionLabel).toBe('Approval Required');
+    expect(handoff.connectionDetail).toContain('blocked because runtime is disconnected');
+    expect(handoff.inputLabel).toContain('Approve or reject');
+  });
+
+  it('explains signal payload submission and waits for runtime confirmation', () => {
+    const handoff = buildMissionOperatorHandoff(
+      createSnapshot({
+        intervention: {
+          key: 'waiting-signal/risk-gate',
+          kind: 'waiting_signal',
+          nodeId: 'node-risk',
+          primaryActionLabel: 'Send Signal',
+          prompt: 'Send market open signal.',
+          required: true,
+          signalName: 'market-open',
+          stepId: 'risk-gate',
+          summary: 'Runtime is waiting for a signal.',
+          title: 'Waiting for market-open',
+        },
+        summary: {
+          activeStageLabel: 'Waiting for market-open',
+          definitionActorId: 'actor-1',
+          observationStatus: 'streaming',
+          runId: 'run-1',
+          scopeId: 'scope-1',
+          startedAt: '2026-03-30T08:00:00.000Z',
+          status: 'waiting_signal',
+          updatedAt: '2026-03-30T08:00:20.000Z',
+          workflowName: 'mission-workflow',
+        },
+      }),
+      'live',
+    );
+
+    expect(handoff.isActionable).toBe(true);
+    expect(handoff.actionLabel).toBe('Waiting for Signal');
+    expect(handoff.inputLabel).toContain('signal payload');
+    expect(handoff.expectedResult).toContain('next runtime snapshot');
+  });
+});

--- a/apps/aevatar-console-web/src/pages/MissionControl/operatorHandoff.test.ts
+++ b/apps/aevatar-console-web/src/pages/MissionControl/operatorHandoff.test.ts
@@ -9,6 +9,13 @@ function createSnapshot(
     events: [
       {
         detail: 'approval requested',
+        handoff: {
+          detail: 'Waiting for approval at step approval.',
+          evidence: 'approval requested',
+          nextStep: 'Open the intervention panel and decide with the latest event dock evidence.',
+          severity: 'action',
+          title: 'Action handoff',
+        },
         id: 'event-1',
         severity: 'warning',
         stepId: 'approval',

--- a/apps/aevatar-console-web/src/pages/MissionControl/operatorHandoff.ts
+++ b/apps/aevatar-console-web/src/pages/MissionControl/operatorHandoff.ts
@@ -17,7 +17,6 @@ export type MissionOperatorHandoff = {
   readonly expectedResult: string;
   readonly inputLabel: string;
   readonly isActionable: boolean;
-  readonly statusLabel: string;
 };
 
 function describeInterventionInput(kind: MissionInterventionKind): string {
@@ -98,7 +97,6 @@ export function buildMissionOperatorHandoff(
         'Continue observing. If a blocker appears, Mission Control will open the intervention panel.',
       inputLabel: 'Observation only',
       isActionable: false,
-      statusLabel: formatMissionLabel(snapshot.summary.status),
     };
   }
 
@@ -114,6 +112,5 @@ export function buildMissionOperatorHandoff(
     expectedResult: describeExpectedResult(intervention.kind),
     inputLabel: describeInterventionInput(intervention.kind),
     isActionable: !actionBlocked,
-    statusLabel: formatMissionLabel(snapshot.summary.status),
   };
 }

--- a/apps/aevatar-console-web/src/pages/MissionControl/operatorHandoff.ts
+++ b/apps/aevatar-console-web/src/pages/MissionControl/operatorHandoff.ts
@@ -1,0 +1,119 @@
+import type {
+  MissionControlSnapshot,
+  MissionInterventionKind,
+  MissionRuntimeConnectionStatus,
+} from './models';
+import {
+  formatConnectionLabel,
+  formatInterventionLabel,
+  formatMissionLabel,
+} from './presentation';
+
+export type MissionOperatorHandoff = {
+  readonly actionLabel: string;
+  readonly actionDetail: string;
+  readonly connectionDetail: string;
+  readonly evidenceDetail: string;
+  readonly expectedResult: string;
+  readonly inputLabel: string;
+  readonly isActionable: boolean;
+  readonly statusLabel: string;
+};
+
+function describeInterventionInput(kind: MissionInterventionKind): string {
+  switch (kind) {
+    case 'waiting_signal':
+      return 'Submit the signal payload requested by the paused step.';
+    case 'human_input':
+      return 'Add the missing operator context, then resume the run.';
+    case 'human_approval':
+      return 'Approve or reject with a short decision note.';
+    default:
+      return 'Review the operator prompt before acting.';
+  }
+}
+
+function describeExpectedResult(kind: MissionInterventionKind): string {
+  switch (kind) {
+    case 'waiting_signal':
+      return 'After the signal is accepted, Mission Control waits for the next runtime snapshot before showing progress.';
+    case 'human_input':
+      return 'After resume is accepted, the run should continue from the blocked step and new evidence will appear in the dock.';
+    case 'human_approval':
+      return 'After approve or reject is accepted, Mission Control waits for runtime confirmation of advance, stop, or rollback.';
+    default:
+      return 'After the action is accepted, wait for runtime confirmation before treating the run as advanced.';
+  }
+}
+
+function describeConnection(
+  status: MissionRuntimeConnectionStatus,
+  hasIntervention: boolean,
+): string {
+  if (!hasIntervention) {
+    if (status === 'idle') {
+      return 'Attach Mission Control to a live run before taking action.';
+    }
+
+    if (status === 'disconnected') {
+      return 'Runtime is disconnected; this view can show only the last known facts.';
+    }
+
+    if (status === 'degraded') {
+      return 'Live stream is degraded; use the snapshot and dock as eventually consistent evidence.';
+    }
+
+    return `Connection is ${formatConnectionLabel(status)}; no operator action is currently required.`;
+  }
+
+  if (status === 'disconnected') {
+    return 'Action is blocked because runtime is disconnected. Keep the evidence visible and retry after recovery.';
+  }
+
+  if (status === 'degraded') {
+    return 'Action is available, but evidence may lag because the live stream is degraded.';
+  }
+
+  if (status === 'connecting') {
+    return 'Mission Control is still connecting; wait for runtime state before submitting an action.';
+  }
+
+  return 'Runtime is reachable; submit only after checking the prompt and recent evidence.';
+}
+
+export function buildMissionOperatorHandoff(
+  snapshot: MissionControlSnapshot,
+  connectionStatus: MissionRuntimeConnectionStatus,
+): MissionOperatorHandoff {
+  const intervention = snapshot.intervention;
+  if (!intervention) {
+    return {
+      actionLabel: 'No operator action',
+      actionDetail: `${formatMissionLabel(snapshot.summary.status)} - ${snapshot.summary.activeStageLabel}`,
+      connectionDetail: describeConnection(connectionStatus, false),
+      evidenceDetail: `Use the event dock as read-only evidence. ${snapshot.events.length} recent event${
+        snapshot.events.length === 1 ? '' : 's'
+      } are available.`,
+      expectedResult:
+        'Continue observing. If a blocker appears, Mission Control will open the intervention panel.',
+      inputLabel: 'Observation only',
+      isActionable: false,
+      statusLabel: formatMissionLabel(snapshot.summary.status),
+    };
+  }
+
+  const actionBlocked =
+    connectionStatus === 'disconnected' || connectionStatus === 'connecting';
+
+  return {
+    actionLabel: formatInterventionLabel(intervention.kind),
+    actionDetail: `${intervention.title} - step ${intervention.stepId}`,
+    connectionDetail: describeConnection(connectionStatus, true),
+    evidenceDetail:
+      'Read the intervention prompt, selected node state, and event dock before submitting an action.',
+    expectedResult: describeExpectedResult(intervention.kind),
+    inputLabel: describeInterventionInput(intervention.kind),
+    isActionable: !actionBlocked,
+    statusLabel: formatMissionLabel(snapshot.summary.status),
+  };
+}

--- a/apps/aevatar-console-web/src/pages/MissionControl/presentation.tsx
+++ b/apps/aevatar-console-web/src/pages/MissionControl/presentation.tsx
@@ -12,6 +12,7 @@ import type { theme } from 'antd';
 import React from 'react';
 import type {
   MissionFeedbackTone,
+  MissionHandoffSeverity,
   MissionInterventionKind,
   MissionInspectorPresentation,
   MissionNodeStatus,
@@ -227,5 +228,33 @@ export function resolveFeedbackTagColor(
       return 'error';
     default:
       return 'processing';
+  }
+}
+
+export function formatHandoffSeverityLabel(severity: MissionHandoffSeverity) {
+  switch (severity) {
+    case 'action':
+      return 'Action';
+    case 'blocked':
+      return 'Blocked';
+    case 'confirming':
+      return 'Confirming';
+    default:
+      return 'Observe';
+  }
+}
+
+export function resolveHandoffTagColor(
+  severity: MissionHandoffSeverity,
+): 'default' | 'processing' | 'success' | 'warning' | 'error' {
+  switch (severity) {
+    case 'action':
+      return 'warning';
+    case 'blocked':
+      return 'error';
+    case 'confirming':
+      return 'processing';
+    default:
+      return 'default';
   }
 }

--- a/apps/aevatar-console-web/src/pages/MissionControl/runtimeAdapter.test.ts
+++ b/apps/aevatar-console-web/src/pages/MissionControl/runtimeAdapter.test.ts
@@ -249,9 +249,23 @@ describe('Mission Control runtimeAdapter', () => {
       (node) => node.id === 'step:root-actor:run-1:approval',
     );
     expect(approvalStep?.status).toBe('waiting');
+    expect(approvalStep?.handoff).toMatchObject({
+      severity: 'action',
+      title: 'Operator handoff',
+    });
+    expect(approvalStep?.handoff.nextStep).toContain('approve or reject');
     expect(approvalStep?.reasoningChain[0]).toMatchObject({
       title: 'Workflow suspended',
     });
+
+    const suspendedEvent = snapshot.events.find(
+      (event) => event.type === 'workflow_suspended',
+    );
+    expect(suspendedEvent?.handoff).toMatchObject({
+      severity: 'action',
+      title: 'Action handoff',
+    });
+    expect(suspendedEvent?.handoff.nextStep).toContain('intervention panel');
   });
 
   it('builds an honest empty snapshot when runtime context is missing', () => {

--- a/apps/aevatar-console-web/src/pages/MissionControl/runtimeAdapter.ts
+++ b/apps/aevatar-console-web/src/pages/MissionControl/runtimeAdapter.ts
@@ -23,6 +23,10 @@ import type {
   MissionTopologyNode,
   MissionTopologyNodeKind,
 } from './models';
+import {
+  buildMissionEventHandoffCue,
+  buildMissionNodeHandoffCue,
+} from './runtimeHandoff';
 
 type MissionSessionLike = {
   context?: {
@@ -927,6 +931,19 @@ export function buildMissionSnapshotFromRuntime(
         terminal && node.nodeType !== 'WorkflowStep',
       );
 
+      const status = nodeStatusFromRuntime(
+        node,
+        runStatus,
+        activityMap,
+        input.nowMs,
+        intervention,
+      );
+      const label =
+        node.properties.targetRole ||
+        node.properties.stepId ||
+        node.properties.workflowName ||
+        node.nodeId;
+
       return {
         id: node.nodeId,
         kind,
@@ -940,12 +957,17 @@ export function buildMissionSnapshotFromRuntime(
             : undefined,
         freshnessLabel: formatFreshness(ageSeconds),
         freshnessSeconds: ageSeconds ?? Number.POSITIVE_INFINITY,
+        handoff: buildMissionNodeHandoffCue({
+          connectionStatus: input.connectionStatus,
+          freshnessLabel: formatFreshness(ageSeconds),
+          isInterventionNode: intervention?.nodeId === node.nodeId,
+          kind,
+          label,
+          observationStatus,
+          status,
+        }),
         lane: laneForKind(kind),
-        label:
-          node.properties.targetRole ||
-          node.properties.stepId ||
-          node.properties.workflowName ||
-          node.nodeId,
+        label,
         lastLatencyMs:
           Number(
             relatedTimeline[relatedTimeline.length - 1]?.data.durationMs ||
@@ -958,7 +980,7 @@ export function buildMissionSnapshotFromRuntime(
         role:
           node.properties.stepType || node.properties.targetRole || node.nodeType,
         snapshot: buildNodeSnapshot(node, artifacts.graph, session),
-        status: nodeStatusFromRuntime(node, runStatus, activityMap, input.nowMs, intervention),
+        status,
         summary: buildNodeSummary(node, relatedTimeline, artifacts.graph.snapshot),
         toolCalls: buildToolCalls(node, relatedTimeline),
       } satisfies MissionTopologyNode;
@@ -995,16 +1017,29 @@ export function buildMissionSnapshotFromRuntime(
   });
 
   const timelineTail = artifacts.timeline.slice(-24);
-  const events: MissionExecutionEvent[] = timelineTail.map((item, index) => ({
-    id: `timeline-${index}-${item.timestamp}`,
-    actorId: item.agentId || undefined,
-    detail: item.message,
-    severity: mapTimelineSeverity(item.eventType),
-    stepId: item.stepId || undefined,
-    timestamp: item.timestamp,
-    title: item.stage || item.eventType || 'Runtime event',
-    type: mapTimelineEventType(item.eventType),
-  }));
+  const events: MissionExecutionEvent[] = timelineTail.map((item, index) => {
+    const type = mapTimelineEventType(item.eventType);
+    const actorId = item.agentId || undefined;
+    const stepId = item.stepId || undefined;
+    return {
+      id: `timeline-${index}-${item.timestamp}`,
+      actorId,
+      detail: item.message,
+      handoff: buildMissionEventHandoffCue({
+        actorId,
+        detail: item.message,
+        intervention,
+        runStatus,
+        stepId,
+        type,
+      }),
+      severity: mapTimelineSeverity(item.eventType),
+      stepId,
+      timestamp: item.timestamp,
+      title: item.stage || item.eventType || 'Runtime event',
+      type,
+    };
+  });
 
   return {
     summary: {

--- a/apps/aevatar-console-web/src/pages/MissionControl/runtimeHandoff.test.ts
+++ b/apps/aevatar-console-web/src/pages/MissionControl/runtimeHandoff.test.ts
@@ -37,6 +37,38 @@ describe('Mission Control runtime handoff cues', () => {
     expect(cue.nextStep).toContain('newer runtime snapshot');
   });
 
+  it('blocks connecting intervention nodes until runtime state is available', () => {
+    const cue = buildMissionNodeHandoffCue({
+      connectionStatus: 'connecting',
+      freshnessLabel: 'unavailable',
+      isInterventionNode: true,
+      kind: 'execution',
+      label: 'input',
+      observationStatus: 'unavailable',
+      status: 'waiting',
+    });
+
+    expect(cue.severity).toBe('blocked');
+    expect(cue.title).toBe('Operator handoff');
+    expect(cue.nextStep).toContain('signal or context');
+  });
+
+  it('marks active streaming nodes as awaiting runtime confirmation', () => {
+    const cue = buildMissionNodeHandoffCue({
+      connectionStatus: 'live',
+      freshnessLabel: '1s',
+      isInterventionNode: false,
+      kind: 'tool',
+      label: 'tool-call',
+      observationStatus: 'streaming',
+      status: 'active',
+    });
+
+    expect(cue.severity).toBe('confirming');
+    expect(cue.title).toBe('Runtime confirmation');
+    expect(cue.nextStep).toContain('next runtime event');
+  });
+
   it('turns blocking runtime events into event dock action handoffs', () => {
     const cue = buildMissionEventHandoffCue({
       detail: 'approval (human_approval)',
@@ -62,6 +94,66 @@ describe('Mission Control runtime handoff cues', () => {
     expect(cue.nextStep).toContain('intervention panel');
   });
 
+  it('keeps terminal runtime events as settled evidence', () => {
+    const cue = buildMissionEventHandoffCue({
+      detail: 'workflow completed',
+      runStatus: 'completed',
+      type: 'workflow_completed',
+    });
+
+    expect(cue.severity).toBe('observe');
+    expect(cue.title).toBe('Settled evidence');
+    expect(cue.nextStep).toContain('no operator action');
+  });
+
+  it('marks execution-start runtime events as awaiting confirmation', () => {
+    const cue = buildMissionEventHandoffCue({
+      detail: 'step requested',
+      runStatus: 'running',
+      stepId: 'research',
+      type: 'step_requested',
+    });
+
+    expect(cue.severity).toBe('confirming');
+    expect(cue.title).toBe('Await confirmation');
+    expect(cue.nextStep).toContain('matching completion');
+  });
+
+  it('keeps actor-linked non-blocking events observational', () => {
+    const cue = buildMissionEventHandoffCue({
+      actorId: 'actor-1',
+      detail: 'role reply recorded',
+      runStatus: 'running',
+      type: 'workflow_role_reply_recorded',
+    });
+
+    expect(cue.severity).toBe('observe');
+    expect(cue.title).toBe('Event evidence');
+    expect(cue.detail).toContain('actor actor-1');
+    expect(cue.nextStep).toContain('Keep observing');
+  });
+
+  it('keeps run-linked non-blocking events observational', () => {
+    const cue = buildMissionEventHandoffCue({
+      detail: 'signal buffered',
+      runStatus: 'running',
+      type: 'workflow_signal_buffered',
+    });
+
+    expect(cue.severity).toBe('observe');
+    expect(cue.detail).toContain('current run');
+  });
+
+  it('tells the operator when runtime rejects an action request', () => {
+    const message = buildMissionActionFeedbackMessage({
+      accepted: false,
+      kind: 'resume',
+    });
+
+    expect(message).toContain('did not accept');
+    expect(message).toContain('retry after checking connection state');
+  });
+
   it('keeps accepted actions honest until runtime publishes new evidence', () => {
     const message = buildMissionActionFeedbackMessage({
       accepted: true,
@@ -73,5 +165,36 @@ describe('Mission Control runtime handoff cues', () => {
     expect(message).toContain('Wait for runtime to confirm');
     expect(message).toContain('Command cmd-1');
     expect(message).toContain('Run run-1');
+  });
+
+  it('keeps accepted signals honest until a new runtime snapshot arrives', () => {
+    const message = buildMissionActionFeedbackMessage({
+      accepted: true,
+      kind: 'signal',
+      signalName: 'continue',
+    });
+
+    expect(message).toContain('Signal continue was accepted');
+    expect(message).toContain('next runtime snapshot');
+  });
+
+  it('keeps accepted rejections honest until runtime confirms stop or rollback', () => {
+    const message = buildMissionActionFeedbackMessage({
+      accepted: true,
+      kind: 'reject',
+    });
+
+    expect(message).toContain('Rejection was submitted');
+    expect(message).toContain('confirm stop or rollback');
+  });
+
+  it('keeps accepted resumes honest until the blocked step publishes evidence', () => {
+    const message = buildMissionActionFeedbackMessage({
+      accepted: true,
+      kind: 'resume',
+    });
+
+    expect(message).toContain('Resume was accepted');
+    expect(message).toContain('blocked step to publish new evidence');
   });
 });

--- a/apps/aevatar-console-web/src/pages/MissionControl/runtimeHandoff.test.ts
+++ b/apps/aevatar-console-web/src/pages/MissionControl/runtimeHandoff.test.ts
@@ -1,0 +1,77 @@
+import {
+  buildMissionActionFeedbackMessage,
+  buildMissionEventHandoffCue,
+  buildMissionNodeHandoffCue,
+} from './runtimeHandoff';
+
+describe('Mission Control runtime handoff cues', () => {
+  it('marks the intervention node as the actionable handoff', () => {
+    const cue = buildMissionNodeHandoffCue({
+      connectionStatus: 'live',
+      freshnessLabel: '2s',
+      isInterventionNode: true,
+      kind: 'approval',
+      label: 'approval',
+      observationStatus: 'streaming',
+      status: 'waiting',
+    });
+
+    expect(cue.severity).toBe('action');
+    expect(cue.title).toBe('Operator handoff');
+    expect(cue.nextStep).toContain('approve or reject');
+  });
+
+  it('keeps disconnected nodes blocked as last-known evidence', () => {
+    const cue = buildMissionNodeHandoffCue({
+      connectionStatus: 'disconnected',
+      freshnessLabel: '4m',
+      isInterventionNode: false,
+      kind: 'research',
+      label: 'research',
+      observationStatus: 'delayed',
+      status: 'active',
+    });
+
+    expect(cue.severity).toBe('blocked');
+    expect(cue.evidence).toContain('delayed');
+    expect(cue.nextStep).toContain('newer runtime snapshot');
+  });
+
+  it('turns blocking runtime events into event dock action handoffs', () => {
+    const cue = buildMissionEventHandoffCue({
+      detail: 'approval (human_approval)',
+      intervention: {
+        key: 'waiting-approval/approval',
+        kind: 'human_approval',
+        nodeId: 'node-approval',
+        primaryActionLabel: 'Approve',
+        prompt: 'Approve guarded execution.',
+        required: true,
+        secondaryActionLabel: 'Reject',
+        stepId: 'approval',
+        summary: 'Runtime is paused for approval.',
+        title: 'Waiting for approval',
+      },
+      runStatus: 'waiting_approval',
+      stepId: 'approval',
+      type: 'workflow_suspended',
+    });
+
+    expect(cue.severity).toBe('action');
+    expect(cue.title).toBe('Action handoff');
+    expect(cue.nextStep).toContain('intervention panel');
+  });
+
+  it('keeps accepted actions honest until runtime publishes new evidence', () => {
+    const message = buildMissionActionFeedbackMessage({
+      accepted: true,
+      commandId: 'cmd-1',
+      kind: 'approve',
+      runId: 'run-1',
+    });
+
+    expect(message).toContain('Wait for runtime to confirm');
+    expect(message).toContain('Command cmd-1');
+    expect(message).toContain('Run run-1');
+  });
+});

--- a/apps/aevatar-console-web/src/pages/MissionControl/runtimeHandoff.ts
+++ b/apps/aevatar-console-web/src/pages/MissionControl/runtimeHandoff.ts
@@ -1,0 +1,198 @@
+import type {
+  MissionExecutionEvent,
+  MissionHandoffCue,
+  MissionHandoffSeverity,
+  MissionInterventionActionKind,
+  MissionInterventionState,
+  MissionNodeStatus,
+  MissionObservationStatus,
+  MissionRuntimeConnectionStatus,
+  MissionRunStatus,
+  MissionTopologyNodeKind,
+  WorkflowExecutionEventType,
+} from './models';
+import { formatMissionLabel } from './presentation';
+
+function observationEvidence(status: MissionObservationStatus, freshnessLabel: string) {
+  switch (status) {
+    case 'streaming':
+      return `Live runtime evidence, fresh ${freshnessLabel}.`;
+    case 'snapshot_available':
+      return `Snapshot evidence is available, fresh ${freshnessLabel}.`;
+    case 'projection_settled':
+      return `Committed terminal evidence, fresh ${freshnessLabel}.`;
+    case 'delayed':
+      return `Last known evidence is delayed, fresh ${freshnessLabel}.`;
+    default:
+      return 'No runtime evidence is attached to this node yet.';
+  }
+}
+
+function severityForNode(
+  connectionStatus: MissionRuntimeConnectionStatus,
+  observationStatus: MissionObservationStatus,
+  nodeStatus: MissionNodeStatus,
+  isInterventionNode: boolean,
+): MissionHandoffSeverity {
+  if (connectionStatus === 'disconnected') {
+    return 'blocked';
+  }
+
+  if (isInterventionNode) {
+    return connectionStatus === 'connecting' ? 'blocked' : 'action';
+  }
+
+  if (nodeStatus === 'waiting' || observationStatus === 'delayed') {
+    return 'blocked';
+  }
+
+  if (nodeStatus === 'active' || observationStatus === 'streaming') {
+    return 'confirming';
+  }
+
+  return 'observe';
+}
+
+function nextStepForNode(
+  severity: MissionHandoffSeverity,
+  kind: MissionTopologyNodeKind,
+  isInterventionNode: boolean,
+) {
+  if (isInterventionNode) {
+    return kind === 'approval'
+      ? 'Open the intervention panel, review recent evidence, then approve or reject.'
+      : 'Open the intervention panel, provide the requested signal or context, then wait for runtime confirmation.';
+  }
+
+  switch (severity) {
+    case 'blocked':
+      return 'Keep this as evidence and wait for a newer runtime snapshot before acting.';
+    case 'confirming':
+      return 'Observe the next runtime event before treating this step as complete.';
+    default:
+      return 'Use this node as read-only evidence for the current run.';
+  }
+}
+
+export function buildMissionNodeHandoffCue(input: {
+  connectionStatus: MissionRuntimeConnectionStatus;
+  freshnessLabel: string;
+  isInterventionNode: boolean;
+  kind: MissionTopologyNodeKind;
+  label: string;
+  observationStatus: MissionObservationStatus;
+  status: MissionNodeStatus;
+}): MissionHandoffCue {
+  const severity = severityForNode(
+    input.connectionStatus,
+    input.observationStatus,
+    input.status,
+    input.isInterventionNode,
+  );
+  const title = input.isInterventionNode
+    ? 'Operator handoff'
+    : severity === 'blocked'
+      ? 'Evidence blocked'
+      : severity === 'confirming'
+        ? 'Runtime confirmation'
+        : 'Observation evidence';
+
+  return {
+    detail: `${input.label} is ${formatMissionLabel(input.status)} with ${formatMissionLabel(
+      input.observationStatus,
+    )} evidence.`,
+    evidence: observationEvidence(input.observationStatus, input.freshnessLabel),
+    nextStep: nextStepForNode(severity, input.kind, input.isInterventionNode),
+    severity,
+    title,
+  };
+}
+
+export function buildMissionEventHandoffCue(input: {
+  actorId?: string;
+  detail: string;
+  intervention?: MissionInterventionState;
+  runStatus: MissionRunStatus;
+  stepId?: string;
+  type: WorkflowExecutionEventType;
+}): MissionHandoffCue {
+  const isInterventionEvent =
+    input.type === 'waiting_for_signal' ||
+    input.type === 'workflow_suspended' ||
+    input.stepId === input.intervention?.stepId;
+  const terminal =
+    input.type === 'workflow_completed' ||
+    input.type === 'workflow_stopped' ||
+    input.runStatus === 'completed' ||
+    input.runStatus === 'failed' ||
+    input.runStatus === 'stopped';
+
+  if (isInterventionEvent && input.intervention) {
+    return {
+      detail: `${input.intervention.title} at step ${input.intervention.stepId}.`,
+      evidence: input.detail || 'Runtime published a blocking event.',
+      nextStep:
+        input.intervention.kind === 'human_approval'
+          ? 'Open the intervention panel and decide with the latest event dock evidence.'
+          : 'Open the intervention panel and submit the requested context or signal.',
+      severity: 'action',
+      title: 'Action handoff',
+    };
+  }
+
+  if (terminal) {
+    return {
+      detail: 'This event reflects a terminal or settled runtime fact.',
+      evidence: input.detail || 'Runtime emitted terminal evidence.',
+      nextStep: 'Use this event as committed evidence; no operator action is implied.',
+      severity: 'observe',
+      title: 'Settled evidence',
+    };
+  }
+
+  if (input.type === 'step_requested' || input.type === 'workflow_run_execution_started') {
+    return {
+      detail: 'Runtime accepted work and queued the next step.',
+      evidence: input.detail || 'Runtime emitted an execution start event.',
+      nextStep: 'Wait for the matching completion, suspension, or signal event.',
+      severity: 'confirming',
+      title: 'Await confirmation',
+    };
+  }
+
+  return {
+    detail: input.actorId
+      ? `Evidence is linked to actor ${input.actorId}.`
+      : 'Evidence is linked to the current run.',
+    evidence: input.detail || 'Runtime emitted an observable event.',
+    nextStep: 'Keep observing unless a blocker card appears.',
+    severity: 'observe',
+    title: 'Event evidence',
+  };
+}
+
+export function buildMissionActionFeedbackMessage(input: {
+  accepted: boolean;
+  commandId?: string;
+  kind: MissionInterventionActionKind;
+  runId?: string;
+  signalName?: string;
+}) {
+  if (!input.accepted) {
+    return 'Runtime did not accept the intervention request. Keep the blocker open and retry after checking connection state.';
+  }
+
+  const commandSuffix = input.commandId ? ` Command ${input.commandId} is pending observation.` : '';
+  const runSuffix = input.runId ? ` Run ${input.runId} remains the evidence source.` : '';
+
+  switch (input.kind) {
+    case 'signal':
+      return `Signal ${input.signalName || 'continue'} was accepted. Wait for the next runtime snapshot before marking the gate resolved.${commandSuffix}${runSuffix}`;
+    case 'approve':
+      return `Approval was accepted. Wait for runtime to confirm advance, stop, or rollback before treating the decision as complete.${commandSuffix}${runSuffix}`;
+    case 'reject':
+      return `Rejection was submitted. Wait for runtime to confirm stop or rollback before closing the blocker.${commandSuffix}${runSuffix}`;
+    default:
+      return `Resume was accepted. Wait for the blocked step to publish new evidence.${commandSuffix}${runSuffix}`;
+  }
+}

--- a/apps/aevatar-console-web/src/pages/MissionControl/runtimeHandoff.ts
+++ b/apps/aevatar-console-web/src/pages/MissionControl/runtimeHandoff.ts
@@ -1,5 +1,4 @@
 import type {
-  MissionExecutionEvent,
   MissionHandoffCue,
   MissionHandoffSeverity,
   MissionInterventionActionKind,


### PR DESCRIPTION
## Problem

Mission Control showed runtime state, blockers, and event dock evidence, but the user-facing handoff was still split across status colors, freshness labels, and inspector details. From an operator perspective, it was unclear which facts were read-only evidence, which node required action, and whether a submitted action meant the run was actually advanced or only accepted for runtime observation.

Related issue: #1667

## Solution

- Add a Mission Control operator handoff model for observation-only, approval, input, and signal states.
- Surface handoff details in the header, inspector, topology node cards, and event dock.
- Add runtime handoff cues so nodes and events explain evidence ownership, next step, and actionability.
- Make accepted intervention feedback honest: accepted actions wait for runtime confirmation and newer evidence.
- Keep the change frontend-only; no backend/API/proto/runtime changes.

## Impact Paths

- `apps/aevatar-console-web/src/pages/MissionControl/**`

## Validation

- `git diff --check` -> no output
- `npm exec --yes --package pnpm@10.2.1 -- pnpm --dir apps/aevatar-console-web jest --runInBand src/pages/MissionControl/operatorHandoff.test.ts src/pages/MissionControl/runtimeHandoff.test.ts src/pages/MissionControl/runtimeAdapter.test.ts` -> 3 suites / 9 tests passed
- `npm exec --yes --package pnpm@10.2.1 -- pnpm --dir apps/aevatar-console-web tsc` -> passed
- `bash tools/ci/test_stability_guards.sh` -> exit 127 with no output; recorded existing guard gap and did not modify repo-local skill paths

## Boundary

- Base branch: `feat/2026-05-29_ai-automation-pipeline`
- No backend/proto/API/actor/projection/workflow/runtime/database/backend tests/backend config/architecture docs changes
- No merge or auto-merge attempted
