### PR TITLE
refactor: impl issue #1673 — 删除 WorkflowRequestMetadataRuntimeContextAccess 过期注释块

### DIFF
--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRequestMetadataRuntimeContextAccess.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRequestMetadataRuntimeContextAccess.cs
@@ -3,18 +3,8 @@ using Aevatar.AI.Abstractions.ToolProviders;
 
 namespace Aevatar.Workflow.Core.Execution;
 
-// Refactor (iter16/cluster-031):
-//   Old pattern: request metadata was copied into the generic execution item
-//                bag as `workflow.request.metadata`, mixing control values with passthrough metadata.
-//   New principle: request metadata is normalized into typed runtime sections
-//                  for LLM overrides, connector authorization, and filtered passthrough metadata.
 internal static class WorkflowRequestMetadataRuntimeContextAccess
 {
-    // Refactor (iter16/cluster-031):
-    //   Old pattern: request metadata writes stored a normalized dictionary
-    //                under `workflow.request.metadata` in the item bag.
-    //   New principle: request metadata writes promote known control keys into
-    //                  typed runtime sections and keep only passthrough values.
     public static async Task SetRequestMetadataAsync(
         IWorkflowExecutionStateHost stateHost,
         IReadOnlyDictionary<string, string>? metadata,
@@ -34,11 +24,6 @@ internal static class WorkflowRequestMetadataRuntimeContextAccess
         return WorkflowRunExecutionContextStateAccess.ApplyToolContextAsync(stateHost, toolContext, ct);
     }
 
-    // Refactor (iter16/cluster-031):
-    //   Old pattern: request metadata cleanup removed the generic
-    //                `workflow.request.metadata` item.
-    //   New principle: request metadata cleanup clears the typed LLM,
-    //                  connector, and passthrough runtime sections.
     public static async Task RemoveRequestMetadataAsync(
         IWorkflowExecutionStateHost stateHost,
         CancellationToken ct = default)
@@ -48,11 +33,6 @@ internal static class WorkflowRequestMetadataRuntimeContextAccess
         stateHost.RuntimeContext.ApplyRequestMetadata(null);
     }
 
-    // Refactor (iter16/cluster-031):
-    //   Old pattern: LLM calls copied request metadata out of the generic item
-    //                bag, where control keys and passthrough keys were mixed.
-    //   New principle: LLM calls copy only the filtered passthrough runtime
-    //                  metadata section.
     public static int CopyRequestMetadata(
         IWorkflowExecutionContext ctx,
         IDictionary<string, string> target)


### PR DESCRIPTION
## 实施 issue #1673 — 删除过期 refactor 注释块（3/3 delete 共识）

**来源 issue**: #1673
**设计共识**: `delete` framing（meta-judge 3/3 一致，`.refactor-loop/runs/phase9-issue1673-r2-judge.md`）

### 改动
仅删除 `src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRequestMetadataRuntimeContextAccess.cs` 内 4 个过期 `Refactor(iter16/cluster-031)` 生产注释块（文件头、`SetRequestMetadataAsync` 前、`RemoveRequestMetadataAsync` 前、`CopyRequestMetadata` 前）。这些注释把 request metadata 失真描述为 LLM override / typed LLM / connector control plane，已超过当前代码事实。

**未改动**：helper 名 / 方法签名 / 行为 / 测试 / README / `LLMCallModule`。净 LOC ≈ -20（文件 58 行）。

### 验证
- `dotnet build aevatar.slnx --nologo`：通过（仅告警，0 error）。
- `dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --nologo`：266 passed / 0 failed / 0 skipped。
- `bash tools/ci/architecture_guards.sh`：通过。

将走 3-reviewer review-gate（architect / tests / quality）。

⟦AI:AUTO-LOOP⟧