### PR TITLE
refactor: impl issue #1671 — 工具审批 fail-closed（缺 handler 拒绝需审批工具）

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
@@ -472,12 +472,9 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
 
     private IReadOnlyList<IToolCallMiddleware> BuildToolMiddlewaresForTurn()
     {
-        if (_approvalHandler is null)
-            return _toolMiddlewares;
-
         var effective = new List<IToolCallMiddleware>(_toolMiddlewares.Count + 1)
         {
-            new ToolApprovalMiddleware(_approvalHandler),
+            new ToolApprovalMiddleware(_approvalHandler ?? MissingApprovalHandler.Instance),
         };
         effective.AddRange(_toolMiddlewares);
         return effective;

--- a/src/Aevatar.AI.Core/AIGAgentBase.cs
+++ b/src/Aevatar.AI.Core/AIGAgentBase.cs
@@ -302,9 +302,10 @@ public abstract class AIGAgentBase<TState> : GAgentBase<TState, AIAgentConfig>
         }
 
         // 构建 Tool Call Middleware 链（审批中间件在最前面，不可绕过）
-        var effectiveToolMiddlewares = new List<IToolCallMiddleware>();
-        if (_approvalHandler != null)
-            effectiveToolMiddlewares.Add(new Middleware.ToolApprovalMiddleware(_approvalHandler, _hooks));
+        var effectiveToolMiddlewares = new List<IToolCallMiddleware>(_toolMiddlewares.Count + 1)
+        {
+            new Middleware.ToolApprovalMiddleware(_approvalHandler ?? Middleware.MissingApprovalHandler.Instance, _hooks),
+        };
         effectiveToolMiddlewares.AddRange(_toolMiddlewares);
 
         // 构建 Chat Runtime

--- a/src/Aevatar.AI.Core/Middleware/MissingApprovalHandler.cs
+++ b/src/Aevatar.AI.Core/Middleware/MissingApprovalHandler.cs
@@ -1,0 +1,19 @@
+using Aevatar.AI.Abstractions.ToolProviders;
+
+namespace Aevatar.AI.Core.Middleware;
+
+/// <summary>refactor helper, no behavior change: fail-closed fallback when no approval handler is registered.</summary>
+public sealed class MissingApprovalHandler : IToolApprovalHandler
+{
+    public static MissingApprovalHandler Instance { get; } = new();
+
+    private MissingApprovalHandler()
+    {
+    }
+
+    public Task<ToolApprovalResult> RequestApprovalAsync(ToolApprovalRequest request, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        return Task.FromResult(ToolApprovalResult.Denied("No tool approval handler is registered."));
+    }
+}

--- a/src/Aevatar.AI.Core/Middleware/MissingApprovalHandler.cs
+++ b/src/Aevatar.AI.Core/Middleware/MissingApprovalHandler.cs
@@ -2,7 +2,6 @@ using Aevatar.AI.Abstractions.ToolProviders;
 
 namespace Aevatar.AI.Core.Middleware;
 
-/// <summary>refactor helper, no behavior change: fail-closed fallback when no approval handler is registered.</summary>
 public sealed class MissingApprovalHandler : IToolApprovalHandler
 {
     public static MissingApprovalHandler Instance { get; } = new();

--- a/test/Aevatar.AI.Tests/AIGAgentBaseToolRefreshTests.cs
+++ b/test/Aevatar.AI.Tests/AIGAgentBaseToolRefreshTests.cs
@@ -64,11 +64,40 @@ public class AIGAgentBaseToolRefreshTests
         agent.GetRegisteredToolNames().Should().Equal("manual-tool", "source-new");
     }
 
+    [Fact]
+    public async Task ChatStreamAsync_WhenApprovalHandlerMissingAndToolRequiresApproval_ShouldDenyWithoutExecutingTool()
+    {
+        var tool = new CountingApprovalRequiredTool();
+        var providerFactory = new ToolCallingLLMProviderFactory();
+        var services = new ServiceCollection();
+        services.AddSingleton<IEventStore, InMemoryEventStoreForTests>();
+        services.AddSingleton<EventSourcingRuntimeOptions>();
+        services.AddTransient(typeof(IEventSourcingBehaviorFactory<>), typeof(DefaultEventSourcingBehaviorFactory<>));
+        using var provider = services.BuildServiceProvider();
+        var agent = new TestAIGAgent([], providerFactory)
+        {
+            Services = provider,
+            EventSourcingBehaviorFactory = provider.GetRequiredService<IEventSourcingBehaviorFactory<RoleGAgentState>>(),
+        };
+
+        await agent.ActivateAsync();
+        agent.RegisterToolForTest(tool);
+
+        var chunks = await agent.StreamAsync("run tool");
+
+        chunks.Select(x => x.DeltaContent).Where(x => x is not null).Should()
+            .ContainSingle()
+            .Which.Should().Contain("No tool approval handler is registered.");
+        tool.ExecuteCount.Should().Be(0);
+    }
+
     private sealed class TestAIGAgent : AIGAgentBase<RoleGAgentState>
     {
-        public TestAIGAgent(IEnumerable<IAgentToolSource> toolSources)
+        public TestAIGAgent(
+            IEnumerable<IAgentToolSource> toolSources,
+            ILLMProviderFactory? llmProviderFactory = null)
             : base(
-                new StubLLMProviderFactory(),
+                llmProviderFactory ?? new StubLLMProviderFactory(),
                 Array.Empty<IAIGAgentExecutionHook>(),
                 Array.Empty<IAgentRunMiddleware>(),
                 Array.Empty<IToolCallMiddleware>(),
@@ -82,9 +111,19 @@ public class AIGAgentBaseToolRefreshTests
             .OrderBy(x => x, StringComparer.Ordinal)
             .ToList();
 
+        public void RegisterToolForTest(IAgentTool tool) => RegisterTool(tool);
+
         public void RegisterManualTool(string name) => RegisterTool(new NamedTool(name));
 
         public Task TriggerRuntimeRefreshAsync() => OnEffectiveConfigChangedAsync(EffectiveConfig, CancellationToken.None);
+
+        public async Task<IReadOnlyList<LLMStreamChunk>> StreamAsync(string userMessage)
+        {
+            var chunks = new List<LLMStreamChunk>();
+            await foreach (var chunk in ChatStreamAsync(userMessage))
+                chunks.Add(chunk);
+            return chunks;
+        }
 
         protected override AIAgentConfigStateOverrides ExtractStateConfigOverrides(RoleGAgentState state)
         {
@@ -135,6 +174,26 @@ public class AIGAgentBaseToolRefreshTests
         }
     }
 
+    private sealed class CountingApprovalRequiredTool : IAgentTool
+    {
+        public const string ToolName = "approval_required_tool";
+
+        public int ExecuteCount { get; private set; }
+
+        public string Name => ToolName;
+        public string Description => "Requires approval.";
+        public string ParametersSchema => "{}";
+        public ToolApprovalMode ApprovalMode => ToolApprovalMode.AlwaysRequire;
+        public bool IsDestructive => true;
+
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            ExecuteCount++;
+            return Task.FromResult("""{"executed":true}""");
+        }
+    }
+
     private sealed class StubLLMProviderFactory : ILLMProviderFactory
     {
         public ILLMProvider GetProvider(string name) => new StubLLMProvider(name);
@@ -157,4 +216,39 @@ public class AIGAgentBaseToolRefreshTests
         }
     }
 
+    private sealed class ToolCallingLLMProviderFactory : ILLMProviderFactory, ILLMProvider
+    {
+        public string Name => "tool-calling";
+
+        public ILLMProvider GetProvider(string name) => this;
+        public ILLMProvider GetDefault() => this;
+        public IReadOnlyList<string> GetAvailableProviders() => [Name];
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            var toolResult = request.Messages.LastOrDefault(static message => message.Role == "tool")?.Content;
+            if (toolResult is not null)
+            {
+                yield return new LLMStreamChunk { DeltaContent = toolResult };
+                yield return new LLMStreamChunk { IsLast = true };
+                await Task.CompletedTask;
+                yield break;
+            }
+
+            yield return new LLMStreamChunk
+            {
+                DeltaToolCall = new ToolCall
+                {
+                    Id = "call-approval",
+                    Name = CountingApprovalRequiredTool.ToolName,
+                    ArgumentsJson = "{}",
+                },
+            };
+            yield return new LLMStreamChunk { IsLast = true };
+            await Task.CompletedTask;
+        }
+    }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
@@ -374,6 +374,29 @@ public sealed class ConversationReplyGeneratorTests
     }
 
     [Fact]
+    public async Task GenerateReplyAsync_WhenApprovalHandlerMissingAndToolRequiresApproval_ShouldDenyWithoutExecutingTool()
+    {
+        var tool = new ApprovalRequiredTool();
+        var generator = new NyxIdConversationReplyGenerator(
+            new ToolResultEchoingProviderFactory(),
+            toolSources: [new SingleToolSource(tool)]);
+
+        var reply = await generator.GenerateReplyAsync(
+            new ChatActivity
+            {
+                Id = "msg-no-handler-approval",
+                Conversation = new ConversationReference { CanonicalKey = "lark:dm:user-no-handler" },
+                Content = new MessageContent { Text = "run tool" },
+            },
+            new Dictionary<string, string>(),
+            streamingSink: null,
+            CancellationToken.None);
+
+        reply.Text.Should().Contain("No tool approval handler is registered.");
+        tool.ExecuteCount.Should().Be(0);
+    }
+
+    [Fact]
     public async Task GenerateReplyAsync_WithLocalSkillCatalog_AddsLocalSkillsWithoutRemoteFetcherWarning()
     {
         var logger = new ListLogger<NyxIdConversationReplyGenerator>();
@@ -1259,6 +1282,43 @@ public sealed class ConversationReplyGeneratorTests
         }
     }
 
+    private sealed class ToolResultEchoingProviderFactory : ILLMProviderFactory, ILLMProvider
+    {
+        public string Name => "tool-result-echoing";
+
+        public ILLMProvider GetProvider(string name) => this;
+
+        public ILLMProvider GetDefault() => this;
+
+        public IReadOnlyList<string> GetAvailableProviders() => [Name];
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            var toolResult = request.Messages.LastOrDefault(static message => message.Role == "tool")?.Content;
+            if (toolResult is not null)
+            {
+                yield return new LLMStreamChunk { DeltaContent = toolResult };
+                yield return new LLMStreamChunk { IsLast = true };
+                await Task.CompletedTask;
+                yield break;
+            }
+
+            yield return new LLMStreamChunk
+            {
+                DeltaToolCall = new ToolCall
+                {
+                    Id = "call-approval",
+                    Name = ApprovalRequiredTool.ToolName,
+                    ArgumentsJson = "{}",
+                },
+            };
+            yield return new LLMStreamChunk { IsLast = true };
+            await Task.CompletedTask;
+        }
+    }
+
     private sealed class ToolCallingPreambleProviderFactory : ILLMProviderFactory, ILLMProvider
     {
         public string Name => "tool-calling-preamble";
@@ -1476,6 +1536,8 @@ public sealed class ConversationReplyGeneratorTests
     {
         public const string ToolName = "approval_required_tool";
 
+        public int ExecuteCount { get; private set; }
+
         public string Name => ToolName;
 
         public string Description => "Requires approval.";
@@ -1484,8 +1546,13 @@ public sealed class ConversationReplyGeneratorTests
 
         public ToolApprovalMode ApprovalMode => ToolApprovalMode.AlwaysRequire;
 
-        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
-            Task.FromResult("""{"executed":true}""");
+        public bool IsDestructive => true;
+
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+        {
+            ExecuteCount++;
+            return Task.FromResult("""{"executed":true}""");
+        }
     }
 
     private sealed class CountingApprovalHandler : IToolApprovalHandler


### PR DESCRIPTION
## 实施 issue #1671 — 工具审批 fail-closed（3/3 minimal 共识）

**来源 issue**: #1671
**设计共识**: `minimal` / no-new-abstraction fail-closed first slice（`.refactor-loop/runs/phase9-issue1671-r3-judge.md`）

### 改动
- 新增 sealed `MissingApprovalHandler`（`src/Aevatar.AI.Core/Middleware/`），实现 `IToolApprovalHandler`，默认 `Denied("No tool approval handler is registered.")`。
- `AIGAgentBase.RebuildRuntime()`：删除 `_approvalHandler != null` 分支，无条件前置 `ToolApprovalMiddleware(_approvalHandler ?? MissingApprovalHandler.Instance, _hooks)`。
- NyxID `ConversationReplyGenerator.BuildToolMiddlewaresForTurn()`：缺 handler 时以 `ToolApprovalMiddleware(... ?? MissingApprovalHandler.Instance)` 开头。
- 新增两条 no-handler 拒绝回归（`AIGAgentBaseToolRefreshTests`、`ConversationReplyGeneratorTests`）。

**收紧语义**：缺 handler + 需审批工具，从「直接执行」改为「拒绝」。`NeverRequire` / `RequiresApproval==false` / `BypassSshExecApproval` 等显式 bypass 不变。不新增 policy/options/builder/Host policy/docs/Tier。

### 验证
- `dotnet build aevatar.slnx --nologo`：通过。
- 两条新增回归（显式 filter）通过；`bash tools/ci/architecture_guards.sh` 通过。
- **已知预存失败（与本 PR 无关，scope 外）**：`AgentToolExecutionContextMapperTests.FromRequest_WhenToolContextIsProvided_ShouldReturnTypedContextAndIgnoreMetadataFallback`、`ChannelConversationTurnRunnerTests.RunInboundAsync_ShouldRouteGoalSlashCommandToOrnnSkillDiscovery` — 本 PR 仅触碰 tool approval middleware，未涉及上述区域。请 reviewer:tests 核实其为 base 分支预存问题。

将走 3-reviewer review-gate。

⟦AI:AUTO-LOOP⟧