### PR TITLE
Clarify Settings auth diagnostics

### DIFF
--- a/apps/aevatar-console-web/src/pages/settings/accountContent.tsx
+++ b/apps/aevatar-console-web/src/pages/settings/accountContent.tsx
@@ -2,19 +2,25 @@ import {
   LogoutOutlined,
   UserOutlined,
 } from "@ant-design/icons";
-import { Avatar, Button, Empty, Space, Typography, theme } from "antd";
+import { useQuery } from "@tanstack/react-query";
+import { Alert, Avatar, Button, Empty, Space, Typography, theme } from "antd";
 import React, { useMemo } from "react";
 import {
   clearStoredAuthSession,
+  hasActiveAccessToken,
   loadRestorableAuthSession,
 } from "@/shared/auth/session";
+import { studioApi } from "@/shared/studio/api";
 import { AevatarCompactText } from "@/shared/ui/compactText";
+import { describeError } from "@/shared/ui/errorText";
 import { AevatarPanel } from "@/shared/ui/aevatarPageShells";
 import {
   summaryFieldGridStyle,
   summaryMetricGridStyle,
 } from "@/shared/ui/proComponents";
 import { buildSettingsPanelStyle, SummaryField, SummaryMetric } from "./shared";
+
+type SessionTone = "default" | "error" | "info" | "success" | "warning";
 
 function formatSessionExpiry(value?: number): string {
   if (!value) {
@@ -27,6 +33,18 @@ function formatSessionExpiry(value?: number): string {
   }).format(value);
 }
 
+function formatOptionalText(value?: string | null): string {
+  return value?.trim() || "Unavailable";
+}
+
+function formatEmailVerified(value?: boolean): string {
+  if (value === undefined) {
+    return "Unavailable";
+  }
+
+  return value ? "Verified" : "Needs review";
+}
+
 type AccountSettingsContentProps = {
   readonly showInlineSignOut?: boolean;
 };
@@ -37,24 +55,81 @@ const AccountSettingsContent: React.FC<AccountSettingsContentProps> = ({
   const { token } = theme.useToken();
   const settingsPanelStyle = buildSettingsPanelStyle(token);
   const authSession = useMemo(() => loadRestorableAuthSession(), []);
+  const backendSessionQuery = useQuery({
+    queryKey: ["settings", "auth-session"],
+    queryFn: () => studioApi.getAuthSession(),
+    retry: false,
+  });
 
-  const accountDisplayName = useMemo(
-    () =>
-      authSession?.user.name ||
-      authSession?.user.email ||
-      authSession?.user.sub ||
-      "No active session",
-    [authSession],
-  );
-  const accountSecondaryText = useMemo(() => {
-    if (!authSession) {
-      return "This browser does not have a restorable sign-in session.";
+  const backendSession = backendSessionQuery.data;
+  const browserAccessTokenActive = hasActiveAccessToken(authSession?.tokens);
+  const browserSessionRestorable = Boolean(authSession);
+  const backendSessionStatus = (() => {
+    if (backendSessionQuery.isPending) {
+      return {
+        tone: "info" as SessionTone,
+        value: "Checking",
+      };
     }
 
-    return authSession.user.email || authSession.user.sub;
-  }, [authSession]);
+    if (backendSessionQuery.isError) {
+      return {
+        tone: "error" as SessionTone,
+        value: "Check failed",
+      };
+    }
+
+    if (!backendSession?.enabled) {
+      return {
+        tone: "default" as SessionTone,
+        value: "Disabled",
+      };
+    }
+
+    if (backendSession.authenticated) {
+      return {
+        tone: "success" as SessionTone,
+        value: "Authenticated",
+      };
+    }
+
+    return {
+      tone: "warning" as SessionTone,
+      value: "No backend session",
+    };
+  })();
+  const browserSessionStatus = browserAccessTokenActive
+    ? {
+        tone: "success" as SessionTone,
+        value: "Access token active",
+      }
+    : browserSessionRestorable
+      ? {
+          tone: "warning" as SessionTone,
+          value: "Refresh available",
+        }
+      : {
+          tone: "default" as SessionTone,
+          value: "No local session",
+        };
+  const accountDisplayName =
+    authSession?.user.name ||
+    authSession?.user.email ||
+    backendSession?.name ||
+    backendSession?.email ||
+    authSession?.user.sub ||
+    "Session diagnostics";
+  const accountSecondaryText = authSession
+    ? authSession.user.email || authSession.user.sub
+    : "No browser session is stored in this browser.";
   const rolesLabel = authSession?.user.roles?.join(", ") || "No roles";
   const groupsLabel = authSession?.user.groups?.join(", ") || "No groups";
+  const backendErrorMessage = backendSessionQuery.isError
+    ? describeError(
+        backendSessionQuery.error,
+        "Backend session could not be checked.",
+      )
+    : null;
 
   const handleSignOut = () => {
     clearStoredAuthSession();
@@ -72,40 +147,42 @@ const AccountSettingsContent: React.FC<AccountSettingsContentProps> = ({
           ) : null
         }
         style={settingsPanelStyle}
-        title="Profile"
+        title="Session overview"
       >
-        {authSession ? (
-          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-            <Space align="start" size={14}>
-              <Avatar
-                icon={<UserOutlined />}
-                size={52}
-                src={authSession.user.picture}
-              />
-              <div style={{ minWidth: 0 }}>
-                <Typography.Text
-                  strong
-                  style={{ display: "block", fontSize: 18 }}
-                >
-                  {accountDisplayName}
-                </Typography.Text>
-                <Typography.Text type="secondary">
-                  {accountSecondaryText}
-                </Typography.Text>
-              </div>
-            </Space>
-
-            <div style={summaryMetricGridStyle}>
-              <SummaryMetric label="Session" tone="success" value="Active" />
-              <SummaryMetric
-                label="Email"
-                tone={authSession.user.email_verified ? "success" : "warning"}
-                value={
-                  authSession.user.email_verified ? "Verified" : "Needs review"
-                }
-              />
+        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          <Space align="start" size={14}>
+            <Avatar
+              icon={<UserOutlined />}
+              size={52}
+              src={authSession?.user.picture || backendSession?.picture}
+            />
+            <div style={{ minWidth: 0 }}>
+              <Typography.Text
+                strong
+                style={{ display: "block", fontSize: 18 }}
+              >
+                {accountDisplayName}
+              </Typography.Text>
+              <Typography.Text type="secondary">
+                {accountSecondaryText}
+              </Typography.Text>
             </div>
+          </Space>
 
+          <div style={summaryMetricGridStyle}>
+            <SummaryMetric
+              label="Browser session"
+              tone={browserSessionStatus.tone}
+              value={browserSessionStatus.value}
+            />
+            <SummaryMetric
+              label="Backend session"
+              tone={backendSessionStatus.tone}
+              value={backendSessionStatus.value}
+            />
+          </div>
+
+          {authSession ? (
             <div style={summaryFieldGridStyle}>
               <SummaryField
                 label="User ID"
@@ -120,45 +197,128 @@ const AccountSettingsContent: React.FC<AccountSettingsContentProps> = ({
                   />
                 }
               />
+              <SummaryField
+                label="Browser email"
+                value={formatOptionalText(authSession.user.email)}
+              />
+              <SummaryField
+                label="Email check"
+                value={formatEmailVerified(authSession.user.email_verified)}
+              />
               <SummaryField label="Roles" value={rolesLabel} />
               <SummaryField label="Groups" value={groupsLabel} />
             </div>
-          </div>
-        ) : (
-          <Empty
-            description="This browser does not have a restorable sign-in session."
-            image={Empty.PRESENTED_IMAGE_SIMPLE}
-          >
-            <Button
-              type="primary"
-              onClick={() => window.location.replace("/login")}
-            >
-              Sign in
-            </Button>
-          </Empty>
-        )}
+          ) : null}
+        </div>
       </AevatarPanel>
 
-      <AevatarPanel style={settingsPanelStyle} title="Authentication">
-        <div style={summaryFieldGridStyle}>
-          <SummaryField
-            label="Access token expires"
-            value={formatSessionExpiry(authSession?.tokens.expiresAt)}
-          />
-          <SummaryField
-            label="Token type"
-            value={authSession?.tokens.tokenType || "Unavailable"}
-          />
-          <SummaryField
-            label="OAuth scope"
-            value={authSession?.tokens.scope || "Unavailable"}
-          />
-          <SummaryField
-            label="Refresh token"
-            value={
-              authSession?.tokens.refreshToken ? "Available" : "Unavailable"
-            }
-          />
+      <AevatarPanel style={settingsPanelStyle} title="Browser session">
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <Typography.Text type="secondary">
+            Stored in this browser and used to attach bearer tokens to frontend
+            API calls.
+          </Typography.Text>
+          {authSession ? (
+            <div style={summaryFieldGridStyle}>
+              <SummaryField
+                label="Access token"
+                value={browserAccessTokenActive ? "Active" : "Expired"}
+              />
+              <SummaryField
+                label="Access token expires"
+                value={formatSessionExpiry(authSession.tokens.expiresAt)}
+              />
+              <SummaryField
+                label="Token type"
+                value={formatOptionalText(authSession.tokens.tokenType)}
+              />
+              <SummaryField
+                label="OAuth scope"
+                value={formatOptionalText(authSession.tokens.scope)}
+              />
+              <SummaryField
+                label="Refresh token"
+                value={
+                  authSession.tokens.refreshToken ? "Available" : "Unavailable"
+                }
+              />
+            </div>
+          ) : (
+            <Empty
+              description="No restorable browser session is stored in this browser."
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+            >
+              <Button
+                type="primary"
+                onClick={() => window.location.replace("/login")}
+              >
+                Sign in
+              </Button>
+            </Empty>
+          )}
+        </div>
+      </AevatarPanel>
+
+      <AevatarPanel style={settingsPanelStyle} title="Backend session">
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <Typography.Text type="secondary">
+            Returned by the backend auth endpoint and used to confirm what the
+            server currently recognizes.
+          </Typography.Text>
+          {backendSessionQuery.isPending ? (
+            <Alert
+              description="The browser session has been read. The backend session is still loading from /api/auth/me."
+              showIcon
+              title="Checking backend session"
+              type="info"
+            />
+          ) : null}
+          {backendErrorMessage ? (
+            <Alert
+              description={backendErrorMessage}
+              showIcon
+              title="Backend session check failed"
+              type="error"
+            />
+          ) : null}
+          <div style={summaryFieldGridStyle}>
+            <SummaryField label="Status" value={backendSessionStatus.value} />
+            <SummaryField
+              label="Provider"
+              value={formatOptionalText(backendSession?.providerDisplayName)}
+            />
+            <SummaryField
+              label="Backend identity"
+              value={formatOptionalText(
+                backendSession?.name || backendSession?.email,
+              )}
+            />
+            <SummaryField
+              label="Scope"
+              value={formatOptionalText(backendSession?.scopeId)}
+            />
+            <SummaryField
+              label="Scope source"
+              value={formatOptionalText(backendSession?.scopeSource)}
+            />
+            <SummaryField
+              label="Invoke auth mode"
+              value={formatOptionalText(backendSession?.invokeAuthMode)}
+            />
+            <SummaryField
+              label="Backend error"
+              value={formatOptionalText(backendSession?.errorMessage)}
+            />
+          </div>
+          {!backendSessionQuery.isPending &&
+          !backendSessionQuery.isError &&
+          backendSession?.enabled &&
+          !backendSession.authenticated ? (
+            <Empty
+              description="The backend responded, but it does not recognize an authenticated session."
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+            />
+          ) : null}
         </div>
       </AevatarPanel>
     </>

--- a/apps/aevatar-console-web/src/pages/settings/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/settings/index.test.tsx
@@ -11,6 +11,7 @@ jest.mock("@/shared/studio/api", () => ({
   studioApi: {
     getUserConfig: jest.fn(),
     getUserConfigModels: jest.fn(),
+    getAuthSession: jest.fn(),
     saveUserConfig: jest.fn(),
   },
 }));
@@ -21,9 +22,24 @@ const { studioApi: mockStudioApi } = jest.requireMock(
   studioApi: {
     getUserConfig: jest.Mock;
     getUserConfigModels: jest.Mock;
+    getAuthSession: jest.Mock;
     saveUserConfig: jest.Mock;
   };
 };
+
+function mockBackendAuthSession(overrides = {}) {
+  mockStudioApi.getAuthSession.mockResolvedValue({
+    enabled: true,
+    authenticated: true,
+    providerDisplayName: "NyxID",
+    invokeAuthMode: "studio-session",
+    name: "Ada Lovelace",
+    email: "ada@example.com",
+    scopeId: "scope-123",
+    scopeSource: "nyxid",
+    ...overrides,
+  });
+}
 
 describe("SettingsPage", () => {
   beforeEach(() => {
@@ -94,6 +110,7 @@ describe("SettingsPage", () => {
       remoteRuntimeBaseUrl: "",
       maxToolRounds: 40,
     }));
+    mockBackendAuthSession();
   });
 
   afterEach(() => {
@@ -143,9 +160,116 @@ describe("SettingsPage", () => {
       expect(window.location.search).toBe("?section=account");
     });
     expect(screen.queryByRole("button", { name: "Save config" })).toBeNull();
-    expect(await screen.findByText("Profile")).toBeTruthy();
-    expect(screen.getByText("Ada Lovelace")).toBeTruthy();
-    expect(screen.getByText("Authentication")).toBeTruthy();
+    expect(await screen.findByText("Session overview")).toBeTruthy();
+    expect(screen.getAllByText("Ada Lovelace").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Browser session").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Backend session").length).toBeGreaterThan(0);
+    expect(await screen.findByText("Access token active")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getAllByText("Authenticated").length).toBeGreaterThan(0);
+    });
+    expect(
+      screen.getByText(
+        "Stored in this browser and used to attach bearer tokens to frontend API calls.",
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Returned by the backend auth endpoint and used to confirm what the server currently recognizes.",
+      ),
+    ).toBeTruthy();
+    expect(screen.getAllByText("NyxID").length).toBeGreaterThan(0);
+  });
+
+  it("separates a restorable browser session from an unauthenticated backend session", async () => {
+    mockBackendAuthSession({
+      authenticated: false,
+      name: undefined,
+      email: undefined,
+      scopeId: null,
+      scopeSource: null,
+    });
+    persistAuthSession({
+      tokens: {
+        accessToken: "expired-token",
+        tokenType: "Bearer",
+        expiresIn: 3600,
+        expiresAt: Date.now() - 60_000,
+        refreshToken: "refresh-token",
+      },
+      user: {
+        sub: "user-456",
+        email: "grace@example.com",
+        email_verified: false,
+        name: "Grace Hopper",
+      },
+    });
+
+    renderWithQueryClient(React.createElement(SettingsPage));
+
+    fireEvent.click(await screen.findByRole("tab", { name: "Account" }));
+
+    expect(await screen.findByText("Grace Hopper")).toBeTruthy();
+    expect(screen.getByText("Refresh available")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getAllByText("No backend session").length).toBeGreaterThan(
+        0,
+      );
+    });
+    expect(
+      screen.getByText(
+        "The backend responded, but it does not recognize an authenticated session.",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText("Expired")).toBeTruthy();
+  });
+
+  it("shows an empty browser session while still checking backend state", async () => {
+    renderWithQueryClient(React.createElement(SettingsPage));
+
+    fireEvent.click(await screen.findByRole("tab", { name: "Account" }));
+
+    expect(await screen.findByText("Session diagnostics")).toBeTruthy();
+    expect(
+      screen.getByText("No browser session is stored in this browser."),
+    ).toBeTruthy();
+    expect(screen.getByText("No local session")).toBeTruthy();
+    expect(
+      screen.getByText("No restorable browser session is stored in this browser."),
+    ).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getAllByText("Authenticated").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("shows a backend session error independently from the browser session", async () => {
+    mockStudioApi.getAuthSession.mockRejectedValue(
+      new Error("Auth service unavailable"),
+    );
+    persistAuthSession({
+      tokens: {
+        accessToken: "token",
+        tokenType: "Bearer",
+        expiresIn: 3600,
+        expiresAt: Date.now() + 60_000,
+      },
+      user: {
+        sub: "user-789",
+        email: "lin@example.com",
+        email_verified: true,
+        name: "Lin Chen",
+      },
+    });
+
+    renderWithQueryClient(React.createElement(SettingsPage));
+
+    fireEvent.click(await screen.findByRole("tab", { name: "Account" }));
+
+    expect(await screen.findByText("Lin Chen")).toBeTruthy();
+    expect(screen.getByText("Access token active")).toBeTruthy();
+    expect(await screen.findByText("Backend session check failed")).toBeTruthy();
+    expect(screen.getAllByText("Check failed").length).toBeGreaterThan(0);
+    expect(screen.getByText("Auth service unavailable")).toBeTruthy();
   });
 
   it("shows gateway models from every ready gateway provider", async () => {


### PR DESCRIPTION
## Problem

Settings Account diagnostics made the local browser auth token look like the whole authentication state. Users could not tell whether the browser had a restorable NyxID session, whether the backend currently recognized the request, or whether an error was only the backend session check failing.

## Solution

- Split the Account tab into a Session overview plus separate Browser session and Backend session panels.
- Show Browser session status from local stored auth, including active access token, refresh-only/restorable state, and empty state.
- Show Backend session status from the existing `/api/auth/me` frontend API call, including checking, check failed, disabled, authenticated, and unauthenticated states.
- Add copy that explicitly explains browser bearer tokens are attached to frontend API calls, while backend session is what the server recognizes.
- Keep the change frontend-only inside `apps/aevatar-console-web`.

## Impact Paths

- `apps/aevatar-console-web/src/pages/settings/accountContent.tsx`
- `apps/aevatar-console-web/src/pages/settings/index.test.tsx`

## Validation

- `npm exec --yes --package pnpm@10.2.1 -- pnpm --dir apps/aevatar-console-web exec jest --runInBand src/pages/settings/index.test.tsx` -> 10 tests passed
- `npm exec --yes --package pnpm@10.2.1 -- pnpm --dir apps/aevatar-console-web run tsc` -> passed
- `git diff --check` -> no output
- Browser QA PASS with real Google Chrome headless via puppeteer-core at `http://localhost:5173/settings?section=account`
  - desktop viewport: 1440x1000
  - mobile viewport: 390x844
  - console errors: none
  - failed network requests: none
  - local evidence: `apps/aevatar-console-web/docs/audit-scorecard/frontend-browser-qa/2026-06-02/settings-auth-diagnostics-clarity/browser-qa.json`

## Boundary

- Base branch: `auto-frontend-dev`
- No backend/API/proto/runtime/actor/projection/workflow changes
- No real bearer token, refresh token, or secret committed
- PR-only: no merge, no auto-merge, no FKST promoter path

⟦AI:AUTO-LOOP⟧
