### PR TITLE
Clarify Deployments release handoffs

### DIFF
--- a/apps/aevatar-console-web/src/pages/Deployments/deploymentActionAvailability.test.ts
+++ b/apps/aevatar-console-web/src/pages/Deployments/deploymentActionAvailability.test.ts
@@ -1,0 +1,46 @@
+import { buildDeploymentDeactivateAvailability } from './deploymentActionAvailability';
+
+describe('buildDeploymentDeactivateAvailability', () => {
+  const deployment = {
+    activatedAt: '2026-03-30T10:00:00Z',
+    deploymentId: 'dep-1',
+    primaryActorId: 'actor-1',
+    revisionId: 'rev-11',
+    status: 'active',
+    updatedAt: '2026-03-30T10:05:00Z',
+  };
+
+  it('disables deactivate when no deployment is selected', () => {
+    const availability = buildDeploymentDeactivateAvailability(null);
+
+    expect(availability.enabled).toBe(false);
+    expect(availability.reason).toContain('未选中 deployment');
+  });
+
+  it('allows deactivate for active deployments', () => {
+    const availability = buildDeploymentDeactivateAvailability(deployment);
+
+    expect(availability.enabled).toBe(true);
+    expect(availability.reason).toContain('仍需等待');
+  });
+
+  it('disables deactivate for inactive deployments', () => {
+    const availability = buildDeploymentDeactivateAvailability({
+      ...deployment,
+      status: 'inactive',
+    });
+
+    expect(availability.enabled).toBe(false);
+    expect(availability.reason).toContain('只适用于活动 deployment');
+  });
+
+  it('disables deactivate for retired deployments', () => {
+    const availability = buildDeploymentDeactivateAvailability({
+      ...deployment,
+      status: 'retired',
+    });
+
+    expect(availability.enabled).toBe(false);
+    expect(availability.summary).toContain('不可停用');
+  });
+});

--- a/apps/aevatar-console-web/src/pages/Deployments/deploymentActionAvailability.ts
+++ b/apps/aevatar-console-web/src/pages/Deployments/deploymentActionAvailability.ts
@@ -1,0 +1,53 @@
+import type { ServiceDeploymentSnapshot } from '@/shared/models/services';
+
+export type DeploymentActionAvailability = {
+  enabled: boolean;
+  reason: string;
+  summary: string;
+};
+
+function normalizeStatus(status: string | null | undefined): string {
+  return (status ?? '').replace(/[^a-z0-9]/gi, '').toLowerCase();
+}
+
+function isActiveDeploymentStatus(status: string | null | undefined): boolean {
+  const normalized = normalizeStatus(status);
+  if (normalized === 'inactive' || normalized === 'deactivated') {
+    return false;
+  }
+
+  return (
+    normalized === 'active' ||
+    normalized === 'activated' ||
+    normalized === 'canary' ||
+    normalized === 'ready' ||
+    normalized === 'running' ||
+    normalized.startsWith('active')
+  );
+}
+
+export function buildDeploymentDeactivateAvailability(
+  deployment: ServiceDeploymentSnapshot | null | undefined,
+): DeploymentActionAvailability {
+  if (!deployment?.deploymentId?.trim()) {
+    return {
+      enabled: false,
+      reason: '未选中 deployment，不能提交停用命令。',
+      summary: '未选中 deployment。',
+    };
+  }
+
+  if (!isActiveDeploymentStatus(deployment.status)) {
+    return {
+      enabled: false,
+      reason: `当前 deployment 状态为 ${deployment.status || 'unknown'}，停用命令只适用于活动 deployment。`,
+      summary: '当前 deployment 不可停用。',
+    };
+  }
+
+  return {
+    enabled: true,
+    reason: '停用会提交命令，仍需等待 catalog/serving/traffic 证据刷新。',
+    summary: '当前 deployment 可提交停用命令。',
+  };
+}

--- a/apps/aevatar-console-web/src/pages/Deployments/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/Deployments/index.test.tsx
@@ -1,12 +1,12 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
-import React from "react";
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import React from 'react';
 import {
   cleanupTestQueryClients,
   renderWithQueryClient,
-} from "../../../tests/reactQueryTestUtils";
-import DeploymentsPage from "./index";
+} from '../../../tests/reactQueryTestUtils';
+import DeploymentsPage from './index';
 
-jest.mock("@/shared/api/servicesApi", () => ({
+jest.mock('@/shared/api/servicesApi', () => ({
   servicesApi: {
     advanceRollout: jest.fn(),
     deactivateDeployment: jest.fn(),
@@ -25,18 +25,18 @@ jest.mock("@/shared/api/servicesApi", () => ({
   },
 }));
 
-jest.mock("@/shared/studio/api", () => ({
+jest.mock('@/shared/studio/api', () => ({
   studioApi: {
     getAuthSession: jest.fn(async () => ({
       scope: {
-        id: "scope-1",
+        id: 'scope-1',
       },
     })),
   },
 }));
 
 const { servicesApi: mockServicesApi } = jest.requireMock(
-  "@/shared/api/servicesApi",
+  '@/shared/api/servicesApi',
 ) as {
   servicesApi: {
     advanceRollout: jest.Mock;
@@ -56,10 +56,8 @@ const { servicesApi: mockServicesApi } = jest.requireMock(
   };
 };
 
-function renderDeploymentsPage(
-  path = "/deployments?tenantId=scope-1",
-) {
-  window.history.replaceState({}, "", path);
+function renderDeploymentsPage(path = '/deployments?tenantId=scope-1') {
+  window.history.replaceState({}, '', path);
   return renderWithQueryClient(React.createElement(DeploymentsPage));
 }
 
@@ -68,225 +66,225 @@ beforeEach(() => {
 
   mockServicesApi.listServices.mockResolvedValue([
     {
-      serviceKey: "scope-1:trade-agent",
-      tenantId: "scope-1",
-      appId: "trade-app",
-      namespace: "cn.market",
-      serviceId: "trade-agent",
-      displayName: "Trade Agent",
-      defaultServingRevisionId: "rev-11",
-      activeServingRevisionId: "rev-11",
-      deploymentId: "dep-1",
-      primaryActorId: "actor-1",
-      deploymentStatus: "active",
+      serviceKey: 'scope-1:trade-agent',
+      tenantId: 'scope-1',
+      appId: 'trade-app',
+      namespace: 'cn.market',
+      serviceId: 'trade-agent',
+      displayName: 'Trade Agent',
+      defaultServingRevisionId: 'rev-11',
+      activeServingRevisionId: 'rev-11',
+      deploymentId: 'dep-1',
+      primaryActorId: 'actor-1',
+      deploymentStatus: 'active',
       endpoints: [],
-      policyIds: ["policy-1"],
-      updatedAt: "2026-03-30T10:00:00Z",
+      policyIds: ['policy-1'],
+      updatedAt: '2026-03-30T10:00:00Z',
     },
   ]);
 
   mockServicesApi.getService.mockResolvedValue({
-    serviceKey: "scope-1:trade-agent",
-    tenantId: "scope-1",
-    appId: "trade-app",
-    namespace: "cn.market",
-    serviceId: "trade-agent",
-    displayName: "Trade Agent",
-    defaultServingRevisionId: "rev-11",
-    activeServingRevisionId: "rev-11",
-    deploymentId: "dep-1",
-    primaryActorId: "actor-1",
-    deploymentStatus: "active",
+    serviceKey: 'scope-1:trade-agent',
+    tenantId: 'scope-1',
+    appId: 'trade-app',
+    namespace: 'cn.market',
+    serviceId: 'trade-agent',
+    displayName: 'Trade Agent',
+    defaultServingRevisionId: 'rev-11',
+    activeServingRevisionId: 'rev-11',
+    deploymentId: 'dep-1',
+    primaryActorId: 'actor-1',
+    deploymentStatus: 'active',
     endpoints: [],
-    policyIds: ["policy-1"],
-    updatedAt: "2026-03-30T10:00:00Z",
+    policyIds: ['policy-1'],
+    updatedAt: '2026-03-30T10:00:00Z',
   });
 
   mockServicesApi.getRevisions.mockResolvedValue({
-    serviceKey: "scope-1:trade-agent",
+    serviceKey: 'scope-1:trade-agent',
     revisions: [
       {
-        revisionId: "rev-12",
-        implementationKind: "workflow",
-        status: "validated",
-        artifactHash: "hash-12",
-        failureReason: "",
+        revisionId: 'rev-12',
+        implementationKind: 'workflow',
+        status: 'validated',
+        artifactHash: 'hash-12',
+        failureReason: '',
         endpoints: [],
-        createdAt: "2026-03-30T10:00:00Z",
-        preparedAt: "2026-03-30T10:02:00Z",
-        publishedAt: "2026-03-30T10:05:00Z",
+        createdAt: '2026-03-30T10:00:00Z',
+        preparedAt: '2026-03-30T10:02:00Z',
+        publishedAt: '2026-03-30T10:05:00Z',
         retiredAt: null,
       },
       {
-        revisionId: "rev-11",
-        implementationKind: "workflow",
-        status: "active",
-        artifactHash: "hash-11",
-        failureReason: "",
+        revisionId: 'rev-11',
+        implementationKind: 'workflow',
+        status: 'active',
+        artifactHash: 'hash-11',
+        failureReason: '',
         endpoints: [],
-        createdAt: "2026-03-29T10:00:00Z",
-        preparedAt: "2026-03-29T10:02:00Z",
-        publishedAt: "2026-03-29T10:05:00Z",
+        createdAt: '2026-03-29T10:00:00Z',
+        preparedAt: '2026-03-29T10:02:00Z',
+        publishedAt: '2026-03-29T10:05:00Z',
         retiredAt: null,
       },
     ],
-    updatedAt: "2026-03-30T10:00:00Z",
+    updatedAt: '2026-03-30T10:00:00Z',
   });
 
   mockServicesApi.getDeployments.mockResolvedValue({
-    serviceKey: "scope-1:trade-agent",
+    serviceKey: 'scope-1:trade-agent',
     deployments: [
       {
-        deploymentId: "dep-1",
-        revisionId: "rev-11",
-        primaryActorId: "actor-1",
-        status: "active",
-        activatedAt: "2026-03-29T10:05:00Z",
-        updatedAt: "2026-03-30T10:00:00Z",
+        deploymentId: 'dep-1',
+        revisionId: 'rev-11',
+        primaryActorId: 'actor-1',
+        status: 'active',
+        activatedAt: '2026-03-29T10:05:00Z',
+        updatedAt: '2026-03-30T10:00:00Z',
       },
     ],
-    updatedAt: "2026-03-30T10:00:00Z",
+    updatedAt: '2026-03-30T10:00:00Z',
   });
 
   mockServicesApi.getServingSet.mockResolvedValue({
-    serviceKey: "scope-1:trade-agent",
+    serviceKey: 'scope-1:trade-agent',
     generation: 3,
-    activeRolloutId: "rollout-1",
+    activeRolloutId: 'rollout-1',
     targets: [
       {
-        deploymentId: "dep-1",
-        revisionId: "rev-11",
-        primaryActorId: "actor-1",
+        deploymentId: 'dep-1',
+        revisionId: 'rev-11',
+        primaryActorId: 'actor-1',
         allocationWeight: 90,
-        servingState: "active",
-        enabledEndpointIds: ["chat"],
+        servingState: 'active',
+        enabledEndpointIds: ['chat'],
       },
       {
-        deploymentId: "dep-2",
-        revisionId: "rev-12",
-        primaryActorId: "actor-2",
+        deploymentId: 'dep-2',
+        revisionId: 'rev-12',
+        primaryActorId: 'actor-2',
         allocationWeight: 10,
-        servingState: "canary",
-        enabledEndpointIds: ["chat"],
+        servingState: 'canary',
+        enabledEndpointIds: ['chat'],
       },
     ],
-    updatedAt: "2026-03-30T10:00:00Z",
+    updatedAt: '2026-03-30T10:00:00Z',
   });
 
   mockServicesApi.getRollout.mockResolvedValue({
-    serviceKey: "scope-1:trade-agent",
-    rolloutId: "rollout-1",
-    displayName: "March Canary",
-    status: "canary",
+    serviceKey: 'scope-1:trade-agent',
+    rolloutId: 'rollout-1',
+    displayName: 'March Canary',
+    status: 'canary',
     currentStageIndex: 1,
     stages: [
       {
-        stageId: "stage-0",
+        stageId: 'stage-0',
         stageIndex: 0,
         targets: [],
       },
       {
-        stageId: "stage-1",
+        stageId: 'stage-1',
         stageIndex: 1,
         targets: [
           {
-            deploymentId: "dep-1",
-            revisionId: "rev-11",
-            primaryActorId: "actor-1",
+            deploymentId: 'dep-1',
+            revisionId: 'rev-11',
+            primaryActorId: 'actor-1',
             allocationWeight: 90,
-            servingState: "active",
-            enabledEndpointIds: ["chat"],
+            servingState: 'active',
+            enabledEndpointIds: ['chat'],
           },
           {
-            deploymentId: "dep-2",
-            revisionId: "rev-12",
-            primaryActorId: "actor-2",
+            deploymentId: 'dep-2',
+            revisionId: 'rev-12',
+            primaryActorId: 'actor-2',
             allocationWeight: 10,
-            servingState: "canary",
-            enabledEndpointIds: ["chat"],
+            servingState: 'canary',
+            enabledEndpointIds: ['chat'],
           },
         ],
       },
     ],
     baselineTargets: [
       {
-        deploymentId: "dep-1",
-        revisionId: "rev-11",
-        primaryActorId: "actor-1",
+        deploymentId: 'dep-1',
+        revisionId: 'rev-11',
+        primaryActorId: 'actor-1',
         allocationWeight: 100,
-        servingState: "active",
-        enabledEndpointIds: ["chat"],
+        servingState: 'active',
+        enabledEndpointIds: ['chat'],
       },
     ],
-    failureReason: "",
-    startedAt: "2026-03-30T10:01:00Z",
-    updatedAt: "2026-03-30T10:05:00Z",
+    failureReason: '',
+    startedAt: '2026-03-30T10:01:00Z',
+    updatedAt: '2026-03-30T10:05:00Z',
   });
 
   mockServicesApi.getTraffic.mockResolvedValue({
-    serviceKey: "scope-1:trade-agent",
+    serviceKey: 'scope-1:trade-agent',
     generation: 3,
-    activeRolloutId: "rollout-1",
+    activeRolloutId: 'rollout-1',
     endpoints: [
       {
-        endpointId: "chat",
+        endpointId: 'chat',
         targets: [
           {
-            deploymentId: "dep-1",
-            revisionId: "rev-11",
-            primaryActorId: "actor-1",
+            deploymentId: 'dep-1',
+            revisionId: 'rev-11',
+            primaryActorId: 'actor-1',
             allocationWeight: 90,
-            servingState: "active",
+            servingState: 'active',
           },
           {
-            deploymentId: "dep-2",
-            revisionId: "rev-12",
-            primaryActorId: "actor-2",
+            deploymentId: 'dep-2',
+            revisionId: 'rev-12',
+            primaryActorId: 'actor-2',
             allocationWeight: 10,
-            servingState: "canary",
+            servingState: 'canary',
           },
         ],
       },
     ],
-    updatedAt: "2026-03-30T10:05:00Z",
+    updatedAt: '2026-03-30T10:05:00Z',
   });
 
   mockServicesApi.deployRevision.mockResolvedValue({
-    targetActorId: "actor-1",
-    commandId: "cmd-1",
-    correlationId: "corr-1",
+    targetActorId: 'actor-1',
+    commandId: 'cmd-1',
+    correlationId: 'corr-1',
   });
 
   mockServicesApi.replaceServingTargets.mockResolvedValue({
-    targetActorId: "actor-1",
-    commandId: "cmd-2",
-    correlationId: "corr-2",
+    targetActorId: 'actor-1',
+    commandId: 'cmd-2',
+    correlationId: 'corr-2',
   });
 
   mockServicesApi.advanceRollout.mockResolvedValue({
-    targetActorId: "actor-1",
-    commandId: "cmd-3",
-    correlationId: "corr-3",
+    targetActorId: 'actor-1',
+    commandId: 'cmd-3',
+    correlationId: 'corr-3',
   });
   mockServicesApi.pauseRollout.mockResolvedValue({
-    targetActorId: "actor-1",
-    commandId: "cmd-4",
-    correlationId: "corr-4",
+    targetActorId: 'actor-1',
+    commandId: 'cmd-4',
+    correlationId: 'corr-4',
   });
   mockServicesApi.resumeRollout.mockResolvedValue({
-    targetActorId: "actor-1",
-    commandId: "cmd-5",
-    correlationId: "corr-5",
+    targetActorId: 'actor-1',
+    commandId: 'cmd-5',
+    correlationId: 'corr-5',
   });
   mockServicesApi.rollbackRollout.mockResolvedValue({
-    targetActorId: "actor-1",
-    commandId: "cmd-6",
-    correlationId: "corr-6",
+    targetActorId: 'actor-1',
+    commandId: 'cmd-6',
+    correlationId: 'corr-6',
   });
   mockServicesApi.deactivateDeployment.mockResolvedValue({
-    targetActorId: "actor-1",
-    commandId: "cmd-7",
-    correlationId: "corr-7",
+    targetActorId: 'actor-1',
+    commandId: 'cmd-7',
+    correlationId: 'corr-7',
   });
 });
 
@@ -294,26 +292,26 @@ afterEach(() => {
   cleanupTestQueryClients();
 });
 
-describe("DeploymentsPage", () => {
-  it("shows the service deployment list before an operator opens a service", async () => {
+describe('DeploymentsPage', () => {
+  it('shows the service deployment list before an operator opens a service', async () => {
     renderDeploymentsPage();
 
-    expect(await screen.findByText("Aevatar / Platform")).toBeInTheDocument();
+    expect(await screen.findByText('Aevatar / Platform')).toBeInTheDocument();
     expect(
-      await screen.findByRole("heading", { name: "Deployments" }),
+      await screen.findByRole('heading', { name: 'Deployments' }),
     ).toBeInTheDocument();
     expect(
       await screen.findByText(
-        "Deployments 是 Platform 的发布工作台，聚焦当前 serving、rollout 进度和流量分配。",
+        'Deployments 是 Platform 的发布工作台，聚焦当前 serving、rollout 进度和流量分配。',
       ),
     ).toBeInTheDocument();
-    expect(await screen.findByText("发布服务列表")).toBeInTheDocument();
-    expect(await screen.findByText("Trade Agent")).toBeInTheDocument();
-    expect(screen.queryByText("发布摘要")).toBeNull();
-    expect(screen.queryByText("正在加载发布服务")).toBeNull();
+    expect(await screen.findByText('发布服务列表')).toBeInTheDocument();
+    expect(await screen.findByText('Trade Agent')).toBeInTheDocument();
+    expect(screen.queryByText('发布摘要')).toBeNull();
+    expect(screen.queryByText('正在加载发布服务')).toBeNull();
   });
 
-  it("keeps the deployment inventory in a loading state until the first response resolves", async () => {
+  it('keeps the deployment inventory in a loading state until the first response resolves', async () => {
     let resolveServices: (value: unknown[]) => void = () => {};
     mockServicesApi.listServices.mockImplementationOnce(
       () =>
@@ -324,207 +322,277 @@ describe("DeploymentsPage", () => {
 
     renderDeploymentsPage();
 
-    expect(await screen.findByText("正在加载发布服务")).toBeInTheDocument();
+    expect(await screen.findByText('正在加载发布服务')).toBeInTheDocument();
     expect(
-      screen.getByText("发布对象清单仍在加载，返回前不会把当前范围误判为空。"),
+      screen.getByText('发布对象清单仍在加载，返回前不会把当前范围误判为空。'),
     ).toBeInTheDocument();
-    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(4);
-    expect(screen.queryByText("当前范围没有服务")).toBeNull();
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(4);
+    expect(screen.queryByText('当前范围没有服务')).toBeNull();
 
     resolveServices([]);
 
-    expect(await screen.findByText("当前范围没有服务")).toBeInTheDocument();
+    expect(await screen.findByText('当前范围没有服务')).toBeInTheDocument();
   });
 
-  it("separates deployment inventory failures from a true empty scope", async () => {
+  it('separates deployment inventory failures from a true empty scope', async () => {
     mockServicesApi.listServices.mockRejectedValueOnce(
-      new Error("deployment inventory unavailable"),
+      new Error('deployment inventory unavailable'),
     );
 
     renderDeploymentsPage();
 
-    expect(await screen.findByText("发布服务列表暂不可用")).toBeInTheDocument();
-    expect(screen.getByText("deployment inventory unavailable")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "重试发布列表" })).toBeInTheDocument();
-    expect(screen.queryByText("当前范围没有服务")).toBeNull();
+    expect(await screen.findByText('发布服务列表暂不可用')).toBeInTheDocument();
+    expect(
+      screen.getByText('deployment inventory unavailable'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: '重试发布列表' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('当前范围没有服务')).toBeNull();
   });
 
-  it("shows an actionable deployment empty state only after an empty response", async () => {
+  it('shows an actionable deployment empty state only after an empty response', async () => {
     mockServicesApi.listServices.mockResolvedValueOnce([]);
 
     renderDeploymentsPage();
 
-    expect(await screen.findByText("当前范围没有服务")).toBeInTheDocument();
+    expect(await screen.findByText('当前范围没有服务')).toBeInTheDocument();
     expect(
-      screen.getByText("当前 Team、App 和 Namespace 下没有可发布服务。可以调整范围后重新加载。"),
+      screen.getByText(
+        '当前 Team、App 和 Namespace 下没有可发布服务。可以调整范围后重新加载。',
+      ),
     ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "调整发布范围" }));
+    fireEvent.click(screen.getByRole('button', { name: '调整发布范围' }));
 
     await waitFor(() => {
-      expect(window.location.pathname).toBe("/deployments");
+      expect(window.location.pathname).toBe('/deployments');
     });
   });
 
-  it("warns when scope edits have not been loaded yet", async () => {
+  it('warns when scope edits have not been loaded yet', async () => {
     renderDeploymentsPage();
 
-    expect(await screen.findByText("Trade Agent")).toBeInTheDocument();
-    fireEvent.change(screen.getByPlaceholderText("命名空间"), {
+    expect(await screen.findByText('Trade Agent')).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText('命名空间'), {
       target: {
-        value: "cn.changed",
+        value: 'cn.changed',
       },
     });
 
-    expect(await screen.findByText("范围已编辑但尚未加载")).toBeInTheDocument();
-    expect(screen.getByText("显示上次加载范围")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "加载范围变更" })).toBeInTheDocument();
-    expect(screen.getByText("Trade Agent")).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: "重置" }));
-
-    expect(await screen.findByText("已加载范围已锁定")).toBeInTheDocument();
-    expect(screen.getByText("显示已加载范围")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "加载发布列表" })).toBeInTheDocument();
-  });
-
-  it("renders the selected service workbench from URL context", async () => {
-    renderDeploymentsPage(
-      "/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent",
-    );
-
-    expect(await screen.findByText("发布摘要")).toBeInTheDocument();
-    expect(await screen.findByText("Deployment 数")).toBeInTheDocument();
+    expect(await screen.findByText('范围已编辑但尚未加载')).toBeInTheDocument();
+    expect(screen.getByText('显示上次加载范围')).toBeInTheDocument();
     expect(
-      await screen.findByRole("tab", { name: "部署目录", selected: true }),
+      screen.getByRole('button', { name: '加载范围变更' }),
     ).toBeInTheDocument();
-    expect(await screen.findByRole("tab", { name: "Serving" })).toBeInTheDocument();
-    expect(await screen.findByRole("tab", { name: "Rollout" })).toBeInTheDocument();
+    expect(screen.getByText('Trade Agent')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '重置' }));
+
+    expect(await screen.findByText('已加载范围已锁定')).toBeInTheDocument();
+    expect(screen.getByText('显示已加载范围')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: '加载发布列表' }),
+    ).toBeInTheDocument();
   });
 
-  it("opens the selected deployment from a governance handoff URL", async () => {
+  it('renders the selected service workbench from URL context', async () => {
     renderDeploymentsPage(
-      "/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent&deploymentId=dep-1",
+      '/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent',
     );
 
-    expect(await screen.findByText("发布摘要")).toBeInTheDocument();
-    expect(await screen.findByText("Deployment 数")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "部署候选版本" })).toBeInTheDocument();
-    expect(screen.getAllByText("dep-1").length).toBeGreaterThan(0);
+    expect(await screen.findByText('发布摘要')).toBeInTheDocument();
+    expect(await screen.findByText('Deployment 数')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('tab', { name: '部署目录', selected: true }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole('tab', { name: 'Serving' }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole('tab', { name: 'Rollout' }),
+    ).toBeInTheDocument();
   });
 
-  it("opens the service deployment drawer from the service list row", async () => {
+  it('opens the selected deployment from a governance handoff URL', async () => {
     renderDeploymentsPage(
-      "/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market",
+      '/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent&deploymentId=dep-1',
     );
 
-    fireEvent.click(await screen.findByText("Trade Agent"));
-
-    expect(await screen.findByText("发布摘要")).toBeInTheDocument();
-    expect(await screen.findByRole("button", { name: "部署候选版本" })).toBeInTheDocument();
+    expect(await screen.findByText('发布摘要')).toBeInTheDocument();
+    expect(await screen.findByText('Deployment 数')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: '部署候选版本' }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText('dep-1').length).toBeGreaterThan(0);
   });
 
-  it("opens the rollout control drawer from the workbench header", async () => {
+  it('opens the service deployment drawer from the service list row', async () => {
     renderDeploymentsPage(
-      "/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent",
+      '/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market',
     );
 
-    expect(await screen.findByText("发布摘要")).toBeInTheDocument();
-    fireEvent.click(await screen.findByRole("button", { name: "发布控制" }));
+    fireEvent.click(await screen.findByText('Trade Agent'));
 
-    expect(await screen.findByText("推进 rollout")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "回滚 rollout" })).toBeInTheDocument();
+    expect(await screen.findByText('发布摘要')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: '部署候选版本' }),
+    ).toBeInTheDocument();
   });
 
-  it("dispatches the candidate revision from the candidate drawer", async () => {
+  it('opens the rollout control drawer from the workbench header', async () => {
     renderDeploymentsPage(
-      "/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent",
+      '/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent',
     );
 
-    expect(await screen.findByText("发布摘要")).toBeInTheDocument();
+    expect(await screen.findByText('发布摘要')).toBeInTheDocument();
+    fireEvent.click(await screen.findByRole('button', { name: '发布控制' }));
+
+    expect(await screen.findByText('推进 rollout')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: '回滚 rollout' }),
+    ).toBeInTheDocument();
+  });
+
+  it('dispatches the candidate revision from the candidate drawer', async () => {
+    renderDeploymentsPage(
+      '/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent',
+    );
+
+    expect(await screen.findByText('发布摘要')).toBeInTheDocument();
     fireEvent.click(
-      await screen.findByRole("button", { name: "部署候选版本" }),
+      await screen.findByRole('button', { name: '部署候选版本' }),
     );
     fireEvent.click(
-      await screen.findByRole("button", { name: "发布候选版本" }),
+      await screen.findByRole('button', { name: '发布候选版本' }),
     );
 
     await waitFor(() => {
       expect(mockServicesApi.deployRevision).toHaveBeenCalledWith(
-        "trade-agent",
+        'trade-agent',
         expect.objectContaining({
-          revisionId: "rev-12",
+          revisionId: 'rev-12',
         }),
       );
     });
   });
 
-  it("keeps a release handoff after candidate submission without marking serving observed", async () => {
+  it('keeps a release handoff after candidate submission without marking serving observed', async () => {
+    mockServicesApi.getServingSet.mockResolvedValueOnce({
+      activeRolloutId: 'rollout-1',
+      generation: 3,
+      serviceKey: 'scope-1:trade-agent',
+      targets: [
+        {
+          allocationWeight: 100,
+          deploymentId: 'dep-1',
+          enabledEndpointIds: ['chat'],
+          primaryActorId: 'actor-1',
+          revisionId: 'rev-11',
+          servingState: 'active',
+        },
+      ],
+      updatedAt: '2026-03-30T10:00:00Z',
+    });
+    mockServicesApi.getTraffic.mockResolvedValueOnce({
+      activeRolloutId: 'rollout-1',
+      endpoints: [
+        {
+          endpointId: 'chat',
+          targets: [
+            {
+              allocationWeight: 100,
+              deploymentId: 'dep-1',
+              primaryActorId: 'actor-1',
+              revisionId: 'rev-11',
+              servingState: 'active',
+            },
+          ],
+        },
+      ],
+      generation: 3,
+      serviceKey: 'scope-1:trade-agent',
+      updatedAt: '2026-03-30T10:00:00Z',
+    });
+
     renderDeploymentsPage(
-      "/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent",
+      '/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent',
     );
 
-    expect(await screen.findByText("发布摘要")).toBeInTheDocument();
+    expect(await screen.findByText('发布摘要')).toBeInTheDocument();
     fireEvent.click(
-      await screen.findByRole("button", { name: "部署候选版本" }),
+      await screen.findByRole('button', { name: '部署候选版本' }),
     );
     fireEvent.click(
-      await screen.findByRole("button", { name: "发布候选版本" }),
+      await screen.findByRole('button', { name: '发布候选版本' }),
     );
 
+    expect(await screen.findByText('候选版本部署已提交')).toBeInTheDocument();
+    expect(screen.getByText('已提交，不代表已完成')).toBeInTheDocument();
     expect(
-      await screen.findByText("候选版本部署已提交"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("已提交，不代表已完成")).toBeInTheDocument();
-    expect(
-      screen.getByText("这只表示候选版本部署命令已接收，尚未说明候选 revision 已经被 serving 观察到。"),
+      screen.getByText(
+        '这只表示候选版本部署命令已接收，尚未说明候选 revision 已经被 serving 观察到。',
+      ),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("所有关键证据都已出现或需要人工核对。"),
+      screen.getByText(
+        '3 项证据需要人工核对，避免把旧 readmodel 当作本次完成。',
+      ),
     ).toBeInTheDocument();
-    expect(screen.getAllByText("已观察").length).toBeGreaterThanOrEqual(3);
-    expect(screen.getByText("Serving targets 已包含 rev-12")).toBeInTheDocument();
-    expect(screen.getByText("Traffic split 已包含 rev-12")).toBeInTheDocument();
-    expect(screen.getByText("候选 revision")).toBeInTheDocument();
-    expect(screen.getAllByText("rev-12").length).toBeGreaterThan(0);
-    expect(screen.queryByText("候选版本已在 serving 生效")).toBeNull();
+    expect(screen.queryByText('已观察')).toBeNull();
+    expect(screen.getAllByText('需核对').length).toBeGreaterThanOrEqual(3);
+    expect(
+      screen.getByText(/Serving targets 已包含 rev-12/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Traffic split 已包含 rev-12/)).toBeInTheDocument();
+    expect(screen.getByText('候选 revision')).toBeInTheDocument();
+    expect(screen.getAllByText('rev-12').length).toBeGreaterThan(0);
+    expect(screen.queryByText('候选版本已在 serving 生效')).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "查看Rollout证据" }));
+    fireEvent.click(screen.getByRole('button', { name: '查看Rollout证据' }));
 
     expect(
-      await screen.findByRole("tab", { name: "Rollout", selected: true }),
+      await screen.findByRole('tab', { name: 'Rollout', selected: true }),
     ).toBeInTheDocument();
   });
 
-  it("shows rollback as a pending baseline evidence handoff", async () => {
+  it('shows rollback as a pending baseline evidence handoff', async () => {
     renderDeploymentsPage(
-      "/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent",
+      '/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent',
     );
 
-    expect(await screen.findByText("发布摘要")).toBeInTheDocument();
-    fireEvent.click(await screen.findByRole("button", { name: "发布控制" }));
-    fireEvent.click(await screen.findByRole("button", { name: "回滚 rollout" }));
+    expect(await screen.findByText('发布摘要')).toBeInTheDocument();
+    fireEvent.click(await screen.findByRole('button', { name: '发布控制' }));
+    fireEvent.click(
+      await screen.findByRole('button', { name: '回滚 rollout' }),
+    );
 
-    expect(await screen.findByText("Rollout 回滚已提交")).toBeInTheDocument();
-    expect(screen.getByText("已提交，不代表已完成")).toBeInTheDocument();
+    expect(await screen.findByText('Rollout 回滚已提交')).toBeInTheDocument();
+    expect(screen.getByText('已提交，不代表已完成')).toBeInTheDocument();
     expect(
-      screen.getByText("这只表示回滚命令已接收，不代表 serving 已经回到 baseline。"),
+      screen.getByText(
+        '这只表示回滚命令已接收，不代表 serving 已经回到 baseline。',
+      ),
     ).toBeInTheDocument();
-    expect(screen.getByText("Rollout 回滚请求已提交，等待 baseline 证据刷新。")).toBeInTheDocument();
-    expect(screen.getAllByText("需核对").length).toBeGreaterThanOrEqual(3);
-    expect(screen.getByText("Traffic split")).toBeInTheDocument();
+    expect(
+      screen.getByText('Rollout 回滚请求已提交，等待 baseline 证据刷新。'),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText('待观察').length).toBeGreaterThanOrEqual(3);
+    expect(screen.getByText('Traffic split')).toBeInTheDocument();
   });
 
-  it("opens the deployment detail drawer from the catalog table", async () => {
+  it('opens the deployment detail drawer from the catalog table', async () => {
     renderDeploymentsPage(
-      "/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent",
+      '/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent',
     );
 
-    expect(await screen.findByText("发布摘要")).toBeInTheDocument();
-    fireEvent.click(await screen.findByRole("tab", { name: "部署目录" }));
-    fireEvent.click(await screen.findByRole("button", { name: "查看详情" }));
+    expect(await screen.findByText('发布摘要')).toBeInTheDocument();
+    fireEvent.click(await screen.findByRole('tab', { name: '部署目录' }));
+    fireEvent.click(await screen.findByRole('button', { name: '查看详情' }));
 
-    expect(await screen.findByText("Deployment 详情")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "停用 deployment" })).toBeInTheDocument();
+    expect(await screen.findByText('Deployment 详情')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: '停用 deployment' }),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/aevatar-console-web/src/pages/Deployments/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/Deployments/index.test.tsx
@@ -459,6 +459,62 @@ describe("DeploymentsPage", () => {
     });
   });
 
+  it("keeps a release handoff after candidate submission without marking serving observed", async () => {
+    renderDeploymentsPage(
+      "/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent",
+    );
+
+    expect(await screen.findByText("发布摘要")).toBeInTheDocument();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "部署候选版本" }),
+    );
+    fireEvent.click(
+      await screen.findByRole("button", { name: "发布候选版本" }),
+    );
+
+    expect(
+      await screen.findByText("候选版本部署已提交"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("已提交，不代表已完成")).toBeInTheDocument();
+    expect(
+      screen.getByText("这只表示候选版本部署命令已接收，尚未说明候选 revision 已经被 serving 观察到。"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("所有关键证据都已出现或需要人工核对。"),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("已观察").length).toBeGreaterThanOrEqual(3);
+    expect(screen.getByText("Serving targets 已包含 rev-12")).toBeInTheDocument();
+    expect(screen.getByText("Traffic split 已包含 rev-12")).toBeInTheDocument();
+    expect(screen.getByText("候选 revision")).toBeInTheDocument();
+    expect(screen.getAllByText("rev-12").length).toBeGreaterThan(0);
+    expect(screen.queryByText("候选版本已在 serving 生效")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "查看Rollout证据" }));
+
+    expect(
+      await screen.findByRole("tab", { name: "Rollout", selected: true }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows rollback as a pending baseline evidence handoff", async () => {
+    renderDeploymentsPage(
+      "/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent",
+    );
+
+    expect(await screen.findByText("发布摘要")).toBeInTheDocument();
+    fireEvent.click(await screen.findByRole("button", { name: "发布控制" }));
+    fireEvent.click(await screen.findByRole("button", { name: "回滚 rollout" }));
+
+    expect(await screen.findByText("Rollout 回滚已提交")).toBeInTheDocument();
+    expect(screen.getByText("已提交，不代表已完成")).toBeInTheDocument();
+    expect(
+      screen.getByText("这只表示回滚命令已接收，不代表 serving 已经回到 baseline。"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Rollout 回滚请求已提交，等待 baseline 证据刷新。")).toBeInTheDocument();
+    expect(screen.getAllByText("需核对").length).toBeGreaterThanOrEqual(3);
+    expect(screen.getByText("Traffic split")).toBeInTheDocument();
+  });
+
   it("opens the deployment detail drawer from the catalog table", async () => {
     renderDeploymentsPage(
       "/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent",

--- a/apps/aevatar-console-web/src/pages/Deployments/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/Deployments/index.test.tsx
@@ -454,6 +454,40 @@ describe('DeploymentsPage', () => {
     ).toBeInTheDocument();
   });
 
+  it('does not present rollout control as an action when no rollout is active', async () => {
+    mockServicesApi.getRollout.mockResolvedValueOnce(null);
+
+    renderDeploymentsPage(
+      '/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent',
+    );
+
+    expect(await screen.findByText('发布摘要')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '发布控制' })).toBeNull();
+    expect(
+      screen.getByRole('button', { name: '无活动控制' }),
+    ).toBeDisabled();
+  });
+
+  it('does not present traffic adjustment as an action when no serving targets exist', async () => {
+    mockServicesApi.getServingSet.mockResolvedValueOnce({
+      activeRolloutId: '',
+      generation: 0,
+      serviceKey: 'scope-1:trade-agent',
+      targets: [],
+      updatedAt: '2026-03-30T10:00:00Z',
+    });
+
+    renderDeploymentsPage(
+      '/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent',
+    );
+
+    expect(await screen.findByText('发布摘要')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '调整流量' })).toBeNull();
+    expect(
+      screen.getAllByRole('button', { name: '查看流量状态' })[0],
+    ).toBeDisabled();
+  });
+
   it('dispatches the candidate revision from the candidate drawer', async () => {
     renderDeploymentsPage(
       '/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent',
@@ -594,5 +628,34 @@ describe('DeploymentsPage', () => {
     expect(
       screen.getByRole('button', { name: '停用 deployment' }),
     ).toBeInTheDocument();
+  });
+
+  it('does not present deactivate as an action for inactive deployments', async () => {
+    mockServicesApi.getDeployments.mockResolvedValueOnce({
+      deployments: [
+        {
+          activatedAt: '2026-03-29T10:05:00Z',
+          deploymentId: 'dep-1',
+          primaryActorId: 'actor-1',
+          revisionId: 'rev-11',
+          status: 'inactive',
+          updatedAt: '2026-03-30T10:00:00Z',
+        },
+      ],
+      serviceKey: 'scope-1:trade-agent',
+      updatedAt: '2026-03-30T10:00:00Z',
+    });
+
+    renderDeploymentsPage(
+      '/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent&deploymentId=dep-1',
+    );
+
+    expect(await screen.findByText('发布摘要')).toBeInTheDocument();
+    fireEvent.click(await screen.findByRole('tab', { name: '部署目录' }));
+    fireEvent.click(await screen.findByRole('button', { name: '查看详情' }));
+
+    expect(await screen.findByText('Deployment 详情')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '停用 deployment' })).toBeNull();
+    expect(screen.getByRole('button', { name: '不可停用' })).toBeDisabled();
   });
 });

--- a/apps/aevatar-console-web/src/pages/Deployments/index.tsx
+++ b/apps/aevatar-console-web/src/pages/Deployments/index.tsx
@@ -5,12 +5,8 @@ import {
   RollbackOutlined,
   SendOutlined,
   StopOutlined,
-} from "@ant-design/icons";
-import {
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
+} from '@ant-design/icons';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   Alert,
   Button,
@@ -26,24 +22,24 @@ import {
   Tooltip,
   Typography,
   theme,
-} from "antd";
-import type { ColumnsType } from "antd/es/table";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+} from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   readServiceQueryDraft,
   trimServiceQuery,
   type ServiceQueryDraft,
-} from "@/pages/services/components/serviceQuery";
-import { servicesApi } from "@/shared/api/servicesApi";
-import { formatDateTime } from "@/shared/datetime/dateTime";
-import { history } from "@/shared/navigation/history";
-import { buildPlatformDeploymentsHref } from "@/shared/navigation/platformRoutes";
+} from '@/pages/services/components/serviceQuery';
+import { servicesApi } from '@/shared/api/servicesApi';
+import { formatDateTime } from '@/shared/datetime/dateTime';
+import { history } from '@/shared/navigation/history';
+import { buildPlatformDeploymentsHref } from '@/shared/navigation/platformRoutes';
 import {
   invalidateServiceResourceQueries,
   serviceResourceQueryKeys,
-} from "@/shared/query/serviceResourceQueryKeys";
-import { resolveStudioScopeContext } from "@/shared/scope/context";
-import { studioApi } from "@/shared/studio/api";
+} from '@/shared/query/serviceResourceQueryKeys';
+import { resolveStudioScopeContext } from '@/shared/scope/context';
+import { studioApi } from '@/shared/studio/api';
 import type {
   ServiceCatalogSnapshot,
   ServiceDeploymentSnapshot,
@@ -53,18 +49,18 @@ import type {
   ServiceServingTargetInput,
   ServiceServingTargetSnapshot,
   ServiceTrafficEndpointSnapshot,
-} from "@/shared/models/services";
+} from '@/shared/models/services';
 import {
   AevatarContextDrawer,
   AevatarInspectorEmpty,
-} from "@/shared/ui/aevatarPageShells";
+} from '@/shared/ui/aevatarPageShells';
 import {
   AevatarCompactTag,
   AevatarCompactText,
   aevatarMonoFontFamily,
   truncateMiddle,
-} from "@/shared/ui/compactText";
-import InventoryReadinessState from "@/shared/ui/InventoryReadinessState";
+} from '@/shared/ui/compactText';
+import InventoryReadinessState from '@/shared/ui/InventoryReadinessState';
 import {
   aevatarDrawerBodyStyle,
   aevatarDrawerScrollStyle,
@@ -75,36 +71,32 @@ import {
   resolveAevatarMetricVisual,
   type AevatarStatusDomain,
   type AevatarThemeSurfaceToken,
-} from "@/shared/ui/aevatarWorkbench";
-import ConsoleMenuPageShell from "@/shared/ui/ConsoleMenuPageShell";
+} from '@/shared/ui/aevatarWorkbench';
+import ConsoleMenuPageShell from '@/shared/ui/ConsoleMenuPageShell';
 import {
   cardStackStyle,
   summaryFieldLabelStyle,
   summaryMetricValueStyle,
-} from "@/shared/ui/proComponents";
+} from '@/shared/ui/proComponents';
 import {
   buildDeploymentReleaseHandoff,
   type DeploymentReleaseHandoff,
   type DeploymentReleaseHandoffAction,
-} from "./releaseHandoff";
+} from './releaseHandoff';
 import {
   buildDeploymentReleaseEvidenceSnapshot,
   type DeploymentReleaseEvidenceSnapshot,
   type DeploymentReleaseEvidenceStatus,
-} from "./releaseEvidence";
+} from './releaseEvidence';
 import {
   buildRolloutActionAvailability,
   type RolloutControlAction,
-} from "./releaseActionAvailability";
-import { buildServingTargetPlanStatus } from "./servingTargetPlan";
+} from './releaseActionAvailability';
+import { buildServingTargetPlanStatus } from './servingTargetPlan';
 
-type DeploymentWorkbenchView =
-  | "catalog"
-  | "serving"
-  | "rollout"
-  | "traffic";
+type DeploymentWorkbenchView = 'catalog' | 'serving' | 'rollout' | 'traffic';
 
-type DeploymentDrawerTab = "candidate" | "weights" | "control";
+type DeploymentDrawerTab = 'candidate' | 'weights' | 'control';
 
 type RolloutControlDefinition = {
   action: RolloutControlAction;
@@ -113,6 +105,25 @@ type RolloutControlDefinition = {
   label: string;
   primary?: boolean;
 };
+
+const servingStateOptions = [
+  {
+    label: 'Active',
+    value: 'active',
+  },
+  {
+    label: 'Paused',
+    value: 'paused',
+  },
+  {
+    label: 'Draining',
+    value: 'draining',
+  },
+  {
+    label: 'Disabled',
+    value: 'disabled',
+  },
+];
 
 type DeploymentDrawerState = {
   open: boolean;
@@ -124,24 +135,24 @@ type DeploymentInspectorState =
       open: false;
     }
   | {
-      kind: "serving";
+      kind: 'serving';
       key: string;
       open: true;
     }
   | {
-      kind: "traffic";
+      kind: 'traffic';
       key: string;
       open: true;
     }
   | {
-      kind: "deployment";
+      kind: 'deployment';
       key: string;
       open: true;
     };
 
 type DeploymentNotice = {
   message: string;
-  tone: "error" | "info" | "success" | "warning";
+  tone: 'error' | 'info' | 'success' | 'warning';
 };
 
 type DeploymentTrafficRow = {
@@ -149,27 +160,27 @@ type DeploymentTrafficRow = {
   key: string;
   splitSummary: string;
   targetCount: number;
-  targets: ReadonlyArray<ServiceTrafficEndpointSnapshot["targets"][number]>;
+  targets: ReadonlyArray<ServiceTrafficEndpointSnapshot['targets'][number]>;
 };
 
-const defaultScopeServiceAppId = "default";
-const defaultScopeServiceNamespace = "default";
+const defaultScopeServiceAppId = 'default';
+const defaultScopeServiceNamespace = 'default';
 const tableHeaderCellStyle: React.CSSProperties = {
-  background: "var(--ant-color-fill-alter)",
-  borderBottom: "1px solid var(--ant-color-border-secondary)",
-  color: "var(--ant-color-text-secondary)",
+  background: 'var(--ant-color-fill-alter)',
+  borderBottom: '1px solid var(--ant-color-border-secondary)',
+  color: 'var(--ant-color-text-secondary)',
   fontSize: 11,
   fontWeight: 700,
   letterSpacing: 0.24,
-  padding: "12px 14px",
-  textAlign: "left",
-  textTransform: "uppercase",
-  whiteSpace: "nowrap",
+  padding: '12px 14px',
+  textAlign: 'left',
+  textTransform: 'uppercase',
+  whiteSpace: 'nowrap',
 };
 const tableCellStyle: React.CSSProperties = {
-  borderBottom: "1px solid var(--ant-color-border-secondary)",
-  padding: "12px 14px",
-  verticalAlign: "top",
+  borderBottom: '1px solid var(--ant-color-border-secondary)',
+  padding: '12px 14px',
+  verticalAlign: 'top',
 };
 const compactHintTagStyle: React.CSSProperties = {
   borderRadius: 999,
@@ -177,35 +188,35 @@ const compactHintTagStyle: React.CSSProperties = {
   marginInlineEnd: 0,
 };
 const compactMonoValueStyle: React.CSSProperties = {
-  color: "var(--ant-color-text-secondary)",
+  color: 'var(--ant-color-text-secondary)',
   fontFamily: aevatarMonoFontFamily,
   fontSize: 10.5,
-  overflow: "hidden",
-  textOverflow: "ellipsis",
-  whiteSpace: "nowrap",
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
 };
 const rolloutControlDefinitions: RolloutControlDefinition[] = [
   {
-    action: "advance",
+    action: 'advance',
     icon: <SendOutlined />,
-    label: "推进 rollout",
+    label: '推进 rollout',
     primary: true,
   },
   {
-    action: "pause",
+    action: 'pause',
     icon: <PauseCircleOutlined />,
-    label: "暂停",
+    label: '暂停',
   },
   {
-    action: "resume",
+    action: 'resume',
     icon: <ReloadOutlined />,
-    label: "恢复",
+    label: '恢复',
   },
   {
-    action: "rollback",
+    action: 'rollback',
     danger: true,
     icon: <RollbackOutlined />,
-    label: "回滚 rollout",
+    label: '回滚 rollout',
   },
 ];
 
@@ -219,13 +230,13 @@ function buildScopePreview(
 
 function formatDeploymentScopeLabel(query: ServiceIdentityQuery): string {
   const segments = [
-    query.tenantId?.trim() || "未设置团队",
-    query.appId?.trim() || "未设置应用",
-    query.namespace?.trim() || "未设置命名空间",
+    query.tenantId?.trim() || '未设置团队',
+    query.appId?.trim() || '未设置应用',
+    query.namespace?.trim() || '未设置命名空间',
   ];
   const resultWindow = query.take && query.take > 0 ? query.take : 200;
 
-  return `${segments.join(" / ")} · ${resultWindow} 条`;
+  return `${segments.join(' / ')} · ${resultWindow} 条`;
 }
 
 function isSameDeploymentScope(
@@ -233,22 +244,22 @@ function isSameDeploymentScope(
   right: ServiceIdentityQuery,
 ): boolean {
   return (
-    (left.tenantId?.trim() ?? "") === (right.tenantId?.trim() ?? "") &&
-    (left.appId?.trim() ?? "") === (right.appId?.trim() ?? "") &&
-    (left.namespace?.trim() ?? "") === (right.namespace?.trim() ?? "") &&
+    (left.tenantId?.trim() ?? '') === (right.tenantId?.trim() ?? '') &&
+    (left.appId?.trim() ?? '') === (right.appId?.trim() ?? '') &&
+    (left.namespace?.trim() ?? '') === (right.namespace?.trim() ?? '') &&
     (left.take ?? 200) === (right.take ?? 200)
   );
 }
 
 const CompactIdentifierText: React.FC<{
   color?: string;
-  maxWidth?: React.CSSProperties["maxWidth"];
+  maxWidth?: React.CSSProperties['maxWidth'];
   singleLine?: boolean;
   strong?: boolean;
   value: string;
 }> = ({
   color,
-  maxWidth = "100%",
+  maxWidth = '100%',
   singleLine = false,
   strong = false,
   value,
@@ -279,7 +290,7 @@ const CompactIdentifierTag: React.FC<{
 const CompactLabelText: React.FC<{
   color?: string;
   maxChars?: number;
-  maxWidth?: React.CSSProperties["maxWidth"];
+  maxWidth?: React.CSSProperties['maxWidth'];
   strong?: boolean;
   value: string;
 }> = ({ color, maxChars = 20, maxWidth = 112, strong = false, value }) => {
@@ -297,22 +308,23 @@ const CompactLabelText: React.FC<{
 };
 
 function readSelectedServiceId(): string {
-  if (typeof window === "undefined") {
-    return "";
+  if (typeof window === 'undefined') {
+    return '';
   }
 
   return (
-    new URLSearchParams(window.location.search).get("serviceId")?.trim() ?? ""
+    new URLSearchParams(window.location.search).get('serviceId')?.trim() ?? ''
   );
 }
 
 function readSelectedDeploymentId(): string {
-  if (typeof window === "undefined") {
-    return "";
+  if (typeof window === 'undefined') {
+    return '';
   }
 
   return (
-    new URLSearchParams(window.location.search).get("deploymentId")?.trim() ?? ""
+    new URLSearchParams(window.location.search).get('deploymentId')?.trim() ??
+    ''
   );
 }
 
@@ -322,35 +334,35 @@ function buildRevisionSummary(
   if (!revision) {
     return [
       {
-        label: "版本",
-        value: "暂无",
+        label: '版本',
+        value: '暂无',
       },
     ];
   }
 
   return [
     {
-      label: "版本",
+      label: '版本',
       value: revision.revisionId,
     },
     {
-      label: "状态",
-      value: formatAevatarStatusLabel(revision.status || "unknown"),
+      label: '状态',
+      value: formatAevatarStatusLabel(revision.status || 'unknown'),
     },
     {
-      label: "入口数",
+      label: '入口数',
       value: String(revision.endpoints.length),
     },
     {
-      label: "制品",
-      value: revision.artifactHash || "n/a",
+      label: '制品',
+      value: revision.artifactHash || 'n/a',
     },
     {
-      label: "准备完成",
+      label: '准备完成',
       value: formatDateTime(revision.preparedAt),
     },
     {
-      label: "已发布",
+      label: '已发布',
       value: formatDateTime(revision.publishedAt),
     },
   ];
@@ -361,14 +373,14 @@ function pickPreferredCandidateRevision(
   activeRevisionId: string,
 ): string {
   if (!revisions.length) {
-    return "";
+    return '';
   }
 
   return (
     revisions.find((revision) => revision.revisionId !== activeRevisionId)
       ?.revisionId ??
     revisions[0]?.revisionId ??
-    ""
+    ''
   );
 }
 
@@ -381,7 +393,7 @@ function buildTrafficRows(
     splitSummary:
       endpoint.targets
         .map((target) => `${target.revisionId} ${target.allocationWeight}%`)
-        .join(" · ") || "暂无流量目标",
+        .join(' · ') || '暂无流量目标',
     targetCount: endpoint.targets.length,
     targets: endpoint.targets,
   }));
@@ -394,26 +406,26 @@ function buildServingTargetKey(target: ServiceServingTargetSnapshot): string {
 function describeTargets(
   targets:
     | ReadonlyArray<ServiceServingTargetSnapshot>
-    | ReadonlyArray<ServiceTrafficEndpointSnapshot["targets"][number]>,
+    | ReadonlyArray<ServiceTrafficEndpointSnapshot['targets'][number]>,
 ): string {
   if (!targets.length) {
-    return "暂无";
+    return '暂无';
   }
 
   return targets
     .map(
       (target) =>
         `${target.revisionId} · ${target.allocationWeight}% · ${formatAevatarStatusLabel(
-          target.servingState || "unknown",
+          target.servingState || 'unknown',
         )}`,
     )
-    .join(" / ");
+    .join(' / ');
 }
 
 const DeploymentStatusTag: React.FC<{
   domain?: AevatarStatusDomain;
   status: string;
-}> = ({ domain = "governance", status }) => {
+}> = ({ domain = 'governance', status }) => {
   const { token } = theme.useToken();
 
   return (
@@ -431,9 +443,9 @@ const DeploymentStatusTag: React.FC<{
 
 const MetricCard: React.FC<{
   label: string;
-  tone?: "default" | "info" | "success" | "warning";
+  tone?: 'default' | 'info' | 'success' | 'warning';
   value: string;
-}> = ({ label, tone = "default", value }) => {
+}> = ({ label, tone = 'default', value }) => {
   const { token } = theme.useToken();
   const visual = resolveAevatarMetricVisual(
     token as AevatarThemeSurfaceToken,
@@ -476,18 +488,18 @@ const WorkbenchSection: React.FC<{
     <div
       style={{
         ...buildAevatarPanelStyle(surfaceToken),
-        display: "flex",
-        flexDirection: "column",
+        display: 'flex',
+        flexDirection: 'column',
         gap: 16,
         padding: 18,
       }}
     >
       <div
         style={{
-          alignItems: "flex-start",
-          display: "flex",
+          alignItems: 'flex-start',
+          display: 'flex',
           gap: 12,
-          justifyContent: "space-between",
+          justifyContent: 'space-between',
         }}
       >
         <Typography.Text
@@ -513,19 +525,21 @@ const DetailFieldCard: React.FC<{
   const { token } = theme.useToken();
   const surfaceToken = token as AevatarThemeSurfaceToken;
   const primitiveValue =
-    typeof value === "string" || typeof value === "number" ? String(value) : null;
+    typeof value === 'string' || typeof value === 'number'
+      ? String(value)
+      : null;
 
   return (
     <div
       style={{
-        background: "rgba(248, 250, 252, 0.92)",
+        background: 'rgba(248, 250, 252, 0.92)',
         border: `1px solid ${surfaceToken.colorBorderSecondary}`,
         borderRadius: 14,
-        display: "flex",
-        flexDirection: "column",
+        display: 'flex',
+        flexDirection: 'column',
         gap: 8,
         minWidth: 0,
-        padding: "14px 16px",
+        padding: '14px 16px',
       }}
     >
       <Typography.Text style={summaryFieldLabelStyle}>{label}</Typography.Text>
@@ -536,16 +550,16 @@ const DetailFieldCard: React.FC<{
           fontWeight: 600,
           lineHeight: 1.5,
           minWidth: 0,
-          overflowWrap: "anywhere",
+          overflowWrap: 'anywhere',
         }}
       >
         {primitiveValue ? (
           <Typography.Text
             strong
             style={{
-              color: "inherit",
-              fontSize: "inherit",
-              lineHeight: "inherit",
+              color: 'inherit',
+              fontSize: 'inherit',
+              lineHeight: 'inherit',
             }}
           >
             {primitiveValue}
@@ -582,44 +596,44 @@ const DeploymentsScopeCard: React.FC<{
   <div
     style={{
       background:
-        "linear-gradient(180deg, rgba(255,255,255,0.98) 0%, rgba(248,250,252,0.92) 100%)",
-      border: "1px solid var(--ant-color-border-secondary)",
+        'linear-gradient(180deg, rgba(255,255,255,0.98) 0%, rgba(248,250,252,0.92) 100%)',
+      border: '1px solid var(--ant-color-border-secondary)',
       borderRadius: 14,
-      boxShadow: "0 12px 28px rgba(15, 23, 42, 0.04)",
-      display: "flex",
-      flexDirection: "column",
+      boxShadow: '0 12px 28px rgba(15, 23, 42, 0.04)',
+      display: 'flex',
+      flexDirection: 'column',
       gap: 12,
       padding: 16,
     }}
   >
     <div
       style={{
-        alignItems: "center",
-        display: "flex",
-        flexWrap: "wrap",
+        alignItems: 'center',
+        display: 'flex',
+        flexWrap: 'wrap',
         gap: 12,
-        justifyContent: "space-between",
+        justifyContent: 'space-between',
       }}
     >
       <Space
         orientation="vertical"
         size={2}
-        style={{ flex: "1 1 160px", minWidth: 160 }}
+        style={{ flex: '1 1 160px', minWidth: 160 }}
       >
         <span
           style={{
-            color: "var(--ant-color-primary)",
+            color: 'var(--ant-color-primary)',
             fontSize: 11,
             fontWeight: 700,
-            letterSpacing: "0.08em",
-            textTransform: "uppercase",
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
           }}
         >
           部署范围
         </span>
         <span
           style={{
-            color: "var(--ant-color-text)",
+            color: 'var(--ant-color-text)',
             fontSize: 16,
             fontWeight: 700,
             lineHeight: 1.2,
@@ -631,21 +645,21 @@ const DeploymentsScopeCard: React.FC<{
       <Tooltip title={scopeLabel}>
         <div
           style={{
-            alignItems: "center",
-            background: "rgba(24, 144, 255, 0.06)",
-            border: "1px solid rgba(24, 144, 255, 0.12)",
+            alignItems: 'center',
+            background: 'rgba(24, 144, 255, 0.06)',
+            border: '1px solid rgba(24, 144, 255, 0.12)',
             borderRadius: 999,
-            color: "var(--ant-color-primary)",
-            display: "inline-flex",
-            flex: "0 1 auto",
+            color: 'var(--ant-color-primary)',
+            display: 'inline-flex',
+            flex: '0 1 auto',
             fontSize: 12,
             fontWeight: 600,
-            maxWidth: "100%",
+            maxWidth: '100%',
             minHeight: 30,
-            overflowWrap: "anywhere",
-            padding: "0 12px",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
+            overflowWrap: 'anywhere',
+            padding: '0 12px',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
           }}
         >
           {scopeLabel}
@@ -655,13 +669,19 @@ const DeploymentsScopeCard: React.FC<{
 
     <div
       style={{
-        display: "grid",
+        display: 'grid',
         gap: 12,
-        gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+        gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
       }}
     >
-      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-        <span style={{ color: "var(--ant-color-text-secondary)", fontSize: 12, fontWeight: 600 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <span
+          style={{
+            color: 'var(--ant-color-text-secondary)',
+            fontSize: 12,
+            fontWeight: 600,
+          }}
+        >
           团队
         </span>
         <Input
@@ -676,8 +696,14 @@ const DeploymentsScopeCard: React.FC<{
         />
       </div>
 
-      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-        <span style={{ color: "var(--ant-color-text-secondary)", fontSize: 12, fontWeight: 600 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <span
+          style={{
+            color: 'var(--ant-color-text-secondary)',
+            fontSize: 12,
+            fontWeight: 600,
+          }}
+        >
           应用
         </span>
         <Input
@@ -692,8 +718,14 @@ const DeploymentsScopeCard: React.FC<{
         />
       </div>
 
-      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-        <span style={{ color: "var(--ant-color-text-secondary)", fontSize: 12, fontWeight: 600 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <span
+          style={{
+            color: 'var(--ant-color-text-secondary)',
+            fontSize: 12,
+            fontWeight: 600,
+          }}
+        >
           命名空间
         </span>
         <Input
@@ -707,7 +739,6 @@ const DeploymentsScopeCard: React.FC<{
           }
         />
       </div>
-
     </div>
 
     {isDirty ? (
@@ -728,27 +759,27 @@ const DeploymentsScopeCard: React.FC<{
 
     <div
       style={{
-        alignItems: "center",
-        display: "flex",
-        flexWrap: "wrap",
+        alignItems: 'center',
+        display: 'flex',
+        flexWrap: 'wrap',
         gap: 10,
-        justifyContent: "space-between",
+        justifyContent: 'space-between',
       }}
     >
       <div
         style={{
-          alignItems: "center",
-          display: "flex",
+          alignItems: 'center',
+          display: 'flex',
           gap: 8,
         }}
       >
         <span
           style={{
-            color: "var(--ant-color-text-secondary)",
+            color: 'var(--ant-color-text-secondary)',
             fontSize: 11,
             fontWeight: 600,
-            textTransform: "uppercase",
-            letterSpacing: "0.04em",
+            textTransform: 'uppercase',
+            letterSpacing: '0.04em',
           }}
         >
           结果窗口
@@ -779,7 +810,7 @@ const DeploymentsScopeCard: React.FC<{
           type="primary"
           onClick={onLoad}
         >
-          {isDirty ? "加载范围变更" : "加载发布列表"}
+          {isDirty ? '加载范围变更' : '加载发布列表'}
         </Button>
       </Space>
     </div>
@@ -796,11 +827,11 @@ const RevisionSummaryCard: React.FC<{
   return (
     <div
       style={{
-        background: "rgba(248, 250, 252, 0.92)",
+        background: 'rgba(248, 250, 252, 0.92)',
         border: `1px solid ${surfaceToken.colorBorderSecondary}`,
         borderRadius: 14,
-        display: "flex",
-        flexDirection: "column",
+        display: 'flex',
+        flexDirection: 'column',
         gap: 12,
         padding: 14,
       }}
@@ -816,9 +847,9 @@ const RevisionSummaryCard: React.FC<{
           </Space>
           <div
             style={{
-              display: "grid",
+              display: 'grid',
               gap: 10,
-              gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
+              gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
             }}
           >
             {buildRevisionSummary(revision).map((item) => (
@@ -849,11 +880,11 @@ const TargetGroupCard: React.FC<{
   return (
     <div
       style={{
-        background: "rgba(248, 250, 252, 0.92)",
+        background: 'rgba(248, 250, 252, 0.92)',
         border: `1px solid ${surfaceToken.colorBorderSecondary}`,
         borderRadius: 14,
-        display: "flex",
-        flexDirection: "column",
+        display: 'flex',
+        flexDirection: 'column',
         gap: 12,
         padding: 14,
       }}
@@ -867,8 +898,8 @@ const TargetGroupCard: React.FC<{
             key={`${label}-${target.deploymentId}-${target.revisionId}`}
             style={{
               borderTop: `1px solid ${surfaceToken.colorBorderSecondary}`,
-              display: "flex",
-              flexDirection: "column",
+              display: 'flex',
+              flexDirection: 'column',
               gap: 8,
               paddingTop: 12,
             }}
@@ -876,7 +907,7 @@ const TargetGroupCard: React.FC<{
             <Space wrap size={[8, 8]}>
               <CompactIdentifierTag value={target.revisionId} />
               <CompactIdentifierTag value={target.deploymentId} />
-              <DeploymentStatusTag status={target.servingState || "unknown"} />
+              <DeploymentStatusTag status={target.servingState || 'unknown'} />
               <Tag>{target.allocationWeight}%</Tag>
             </Space>
             <div style={{ color: surfaceToken.colorTextSecondary }}>
@@ -886,9 +917,9 @@ const TargetGroupCard: React.FC<{
                   value={target.primaryActorId}
                 />
               ) : (
-                "暂无 Actor"
-              )}{" "}
-              · {target.enabledEndpointIds.join(", ") || "所有入口"}
+                '暂无 Actor'
+              )}{' '}
+              · {target.enabledEndpointIds.join(', ') || '所有入口'}
             </div>
           </div>
         ))
@@ -912,8 +943,8 @@ const DrawerSection: React.FC<{
     <div
       style={{
         ...buildAevatarPanelStyle(surfaceToken),
-        display: "flex",
-        flexDirection: "column",
+        display: 'flex',
+        flexDirection: 'column',
         gap: 14,
         padding: 18,
       }}
@@ -945,16 +976,16 @@ const ReleaseHandoffPanel: React.FC<{
     }
   > = {
     observed: {
-      color: "green",
-      label: "已观察",
+      color: 'green',
+      label: '已观察',
     },
     pending: {
-      color: "gold",
-      label: "待观察",
+      color: 'gold',
+      label: '待观察',
     },
     review: {
-      color: "blue",
-      label: "需核对",
+      color: 'blue',
+      label: '需核对',
     },
   };
 
@@ -962,21 +993,21 @@ const ReleaseHandoffPanel: React.FC<{
     <section
       aria-label="release action handoff"
       style={{
-        background: "rgba(255, 251, 230, 0.72)",
+        background: 'rgba(255, 251, 230, 0.72)',
         border: `1px solid ${surfaceToken.colorWarningBorder}`,
         borderRadius: surfaceToken.borderRadiusLG,
-        display: "flex",
-        flexDirection: "column",
+        display: 'flex',
+        flexDirection: 'column',
         gap: 14,
         padding: 16,
       }}
     >
       <div
         style={{
-          alignItems: "flex-start",
-          display: "flex",
+          alignItems: 'flex-start',
+          display: 'flex',
           gap: 12,
-          justifyContent: "space-between",
+          justifyContent: 'space-between',
         }}
       >
         <Space orientation="vertical" size={4}>
@@ -1004,7 +1035,7 @@ const ReleaseHandoffPanel: React.FC<{
             {evidence.summary}
           </Typography.Text>
         </Space>
-        <Space wrap size={[8, 8]} style={{ justifyContent: "flex-end" }}>
+        <Space wrap size={[8, 8]} style={{ justifyContent: 'flex-end' }}>
           <Button size="small" onClick={onOpenEvidence}>
             查看{handoff.evidenceViewLabel}证据
           </Button>
@@ -1016,9 +1047,9 @@ const ReleaseHandoffPanel: React.FC<{
 
       <div
         style={{
-          display: "grid",
+          display: 'grid',
           gap: 8,
-          gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))",
+          gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
         }}
       >
         {handoff.summaryItems.map((item) => (
@@ -1029,7 +1060,7 @@ const ReleaseHandoffPanel: React.FC<{
               border: `1px solid ${surfaceToken.colorBorderSecondary}`,
               borderRadius: surfaceToken.borderRadius,
               minWidth: 0,
-              padding: "10px 12px",
+              padding: '10px 12px',
             }}
           >
             <Typography.Text style={summaryFieldLabelStyle}>
@@ -1047,25 +1078,30 @@ const ReleaseHandoffPanel: React.FC<{
         ))}
       </div>
 
-      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
         {evidence.checks.map((check) => (
           <div
             key={`${handoff.id}-${check.key}`}
             style={{
-              alignItems: "flex-start",
-              display: "grid",
+              alignItems: 'flex-start',
+              display: 'grid',
               gap: 8,
-              gridTemplateColumns: "auto minmax(0, 1fr)",
+              gridTemplateColumns: 'auto minmax(0, 1fr)',
             }}
           >
-            <Tag color={statusCopy[check.status].color} style={compactHintTagStyle}>
+            <Tag
+              color={statusCopy[check.status].color}
+              style={compactHintTagStyle}
+            >
               {statusCopy[check.status].label}
             </Tag>
             <Space orientation="vertical" size={2} style={{ minWidth: 0 }}>
               <Typography.Text strong style={{ color: surfaceToken.colorText }}>
                 {check.label}
               </Typography.Text>
-              <Typography.Text style={{ color: surfaceToken.colorTextSecondary }}>
+              <Typography.Text
+                style={{ color: surfaceToken.colorTextSecondary }}
+              >
                 {check.detail}
               </Typography.Text>
             </Space>
@@ -1093,26 +1129,26 @@ const DeploymentsPage: React.FC = () => {
   const [selectedDeploymentId, setSelectedDeploymentId] = useState(() =>
     readSelectedDeploymentId(),
   );
-  const [view, setView] = useState<DeploymentWorkbenchView>("catalog");
+  const [view, setView] = useState<DeploymentWorkbenchView>('catalog');
   const [drawerState, setDrawerState] = useState<DeploymentDrawerState>({
     open: false,
-    tab: "candidate",
+    tab: 'candidate',
   });
   const [inspectorState, setInspectorState] =
     useState<DeploymentInspectorState>({
       open: false,
     });
-  const [drawerReason, setDrawerReason] = useState("");
+  const [drawerReason, setDrawerReason] = useState('');
   const [editableTargets, setEditableTargets] = useState<
     ServiceServingTargetInput[]
   >([]);
-  const [candidateRevisionId, setCandidateRevisionId] = useState("");
+  const [candidateRevisionId, setCandidateRevisionId] = useState('');
   const [notice, setNotice] = useState<DeploymentNotice | null>(null);
   const [releaseHandoff, setReleaseHandoff] =
     useState<DeploymentReleaseHandoff | null>(null);
 
   const authSessionQuery = useQuery({
-    queryKey: ["deployments", "auth-session"],
+    queryKey: ['deployments', 'auth-session'],
     queryFn: () => studioApi.getAuthSession(),
     retry: false,
   });
@@ -1180,7 +1216,9 @@ const DeploymentsPage: React.FC = () => {
   const selectedService = useMemo(
     () =>
       serviceDetailQuery.data ??
-      servicesQuery.data?.find((service) => service.serviceId === selectedServiceId) ??
+      servicesQuery.data?.find(
+        (service) => service.serviceId === selectedServiceId,
+      ) ??
       null,
     [selectedServiceId, serviceDetailQuery.data, servicesQuery.data],
   );
@@ -1193,10 +1231,10 @@ const DeploymentsPage: React.FC = () => {
     const services = servicesQuery.data ?? [];
     if (!services.length) {
       if (selectedServiceId) {
-        setSelectedServiceId("");
+        setSelectedServiceId('');
       }
       if (selectedDeploymentId) {
-        setSelectedDeploymentId("");
+        setSelectedDeploymentId('');
       }
       return;
     }
@@ -1209,9 +1247,9 @@ const DeploymentsPage: React.FC = () => {
       return;
     }
 
-    setSelectedServiceId("");
+    setSelectedServiceId('');
     if (selectedDeploymentId) {
-      setSelectedDeploymentId("");
+      setSelectedDeploymentId('');
     }
   }, [selectedDeploymentId, selectedServiceId, servicesQuery.data]);
 
@@ -1236,7 +1274,7 @@ const DeploymentsPage: React.FC = () => {
     const deployments = deploymentsQuery.data?.deployments ?? [];
     if (!selectedServiceId.trim()) {
       if (selectedDeploymentId) {
-        setSelectedDeploymentId("");
+        setSelectedDeploymentId('');
       }
       return;
     }
@@ -1253,7 +1291,7 @@ const DeploymentsPage: React.FC = () => {
       return;
     }
 
-    setSelectedDeploymentId("");
+    setSelectedDeploymentId('');
   }, [
     deploymentsQuery.data?.deployments,
     selectedDeploymentId,
@@ -1274,7 +1312,7 @@ const DeploymentsPage: React.FC = () => {
   const activeRevisionId =
     serviceDetailQuery.data?.activeServingRevisionId ||
     serviceDetailQuery.data?.defaultServingRevisionId ||
-    "";
+    '';
 
   useEffect(() => {
     const revisions = revisionsQuery.data?.revisions ?? [];
@@ -1304,18 +1342,22 @@ const DeploymentsPage: React.FC = () => {
 
   const activeDeployment = useMemo(() => {
     const deployments = deploymentsQuery.data?.deployments ?? [];
-    const currentDeploymentId = serviceDetailQuery.data?.deploymentId?.trim() ?? "";
+    const currentDeploymentId =
+      serviceDetailQuery.data?.deploymentId?.trim() ?? '';
 
     return (
       deployments.find(
         (deployment) => deployment.deploymentId === currentDeploymentId,
       ) ??
       deployments.find((deployment) =>
-        deployment.status.toLowerCase().includes("active"),
+        deployment.status.toLowerCase().includes('active'),
       ) ??
       null
     );
-  }, [deploymentsQuery.data?.deployments, serviceDetailQuery.data?.deploymentId]);
+  }, [
+    deploymentsQuery.data?.deployments,
+    serviceDetailQuery.data?.deploymentId,
+  ]);
 
   const focusDeployment = selectedDeployment ?? activeDeployment;
 
@@ -1354,7 +1396,7 @@ const DeploymentsPage: React.FC = () => {
   );
 
   const selectedServingTarget = useMemo(() => {
-    if (!inspectorState.open || inspectorState.kind !== "serving") {
+    if (!inspectorState.open || inspectorState.kind !== 'serving') {
       return null;
     }
 
@@ -1366,7 +1408,7 @@ const DeploymentsPage: React.FC = () => {
   }, [inspectorState, servingQuery.data?.targets]);
 
   const selectedTrafficRow = useMemo(() => {
-    if (!inspectorState.open || inspectorState.kind !== "traffic") {
+    if (!inspectorState.open || inspectorState.kind !== 'traffic') {
       return null;
     }
 
@@ -1374,7 +1416,7 @@ const DeploymentsPage: React.FC = () => {
   }, [inspectorState, trafficRows]);
 
   const inspectedDeployment = useMemo(() => {
-    if (!inspectorState.open || inspectorState.kind !== "deployment") {
+    if (!inspectorState.open || inspectorState.kind !== 'deployment') {
       return null;
     }
 
@@ -1408,8 +1450,8 @@ const DeploymentsPage: React.FC = () => {
     ].filter(Boolean);
 
     return segments.length > 0
-      ? `当前范围 ${segments.join(" / ")}`
-      : "尚未锁定服务范围";
+      ? `当前范围 ${segments.join(' / ')}`
+      : '尚未锁定服务范围';
   }, [draft.appId, draft.namespace, draft.tenantId, query]);
 
   const deploymentDigest = useMemo(
@@ -1422,7 +1464,7 @@ const DeploymentsPage: React.FC = () => {
       stage:
         currentStage && rolloutQuery.data
           ? `${currentStage.stageIndex + 1}/${rolloutQuery.data.stages.length}`
-          : "无活动 rollout",
+          : '无活动 rollout',
       targets: servingQuery.data?.targets.length ?? 0,
     }),
     [
@@ -1494,7 +1536,7 @@ const DeploymentsPage: React.FC = () => {
 
   const openInspector = useCallback(
     (state: Exclude<DeploymentInspectorState, { open: false }>) => {
-      if (state.kind === "deployment") {
+      if (state.kind === 'deployment') {
         setSelectedDeploymentId(state.key);
       }
       setInspectorState(state);
@@ -1505,7 +1547,7 @@ const DeploymentsPage: React.FC = () => {
   const recordReleaseHandoff = useCallback(
     (
       action: DeploymentReleaseHandoffAction,
-      receipt: Parameters<typeof buildDeploymentReleaseHandoff>[0]["receipt"],
+      receipt: Parameters<typeof buildDeploymentReleaseHandoff>[0]['receipt'],
       options: {
         deploymentId?: string;
       } = {},
@@ -1514,7 +1556,8 @@ const DeploymentsPage: React.FC = () => {
         action,
         activeRevisionId,
         candidateRevisionId:
-          action === "deploy-candidate" ? candidateRevisionId : undefined,
+          action === 'deploy-candidate' ? candidateRevisionId : undefined,
+        createdAt: new Date().toISOString(),
         deploymentId:
           options.deploymentId ||
           focusDeployment?.deploymentId ||
@@ -1528,7 +1571,8 @@ const DeploymentsPage: React.FC = () => {
             ? `${currentStage.stageIndex + 1}/${rolloutQuery.data.stages.length}`
             : undefined,
         serviceId: selectedServiceId,
-        targetCount: servingQuery.data?.targets.length ?? editableTargets.length,
+        targetCount:
+          servingQuery.data?.targets.length ?? editableTargets.length,
       });
 
       setReleaseHandoff(handoff);
@@ -1554,7 +1598,7 @@ const DeploymentsPage: React.FC = () => {
   const deployMutation = useMutation({
     mutationFn: () => {
       if (!candidateRevisionId.trim()) {
-        throw new Error("请先选择候选版本。");
+        throw new Error('请先选择候选版本。');
       }
 
       return servicesApi.deployRevision(selectedServiceId, {
@@ -1565,12 +1609,12 @@ const DeploymentsPage: React.FC = () => {
     onError: (error: Error) => {
       setReleaseHandoff(null);
       setNotice({
-        message: error.message || "发布候选版本失败。",
-        tone: "error",
+        message: error.message || '发布候选版本失败。',
+        tone: 'error',
       });
     },
     onSuccess: async (receipt) => {
-      recordReleaseHandoff("deploy-candidate", receipt);
+      recordReleaseHandoff('deploy-candidate', receipt);
       await invalidateDetailQueries();
     },
   });
@@ -1591,18 +1635,18 @@ const DeploymentsPage: React.FC = () => {
     onError: (error: Error) => {
       setReleaseHandoff(null);
       setNotice({
-        message: error.message || "应用 serving targets 失败。",
-        tone: "error",
+        message: error.message || '应用 serving targets 失败。',
+        tone: 'error',
       });
     },
     onSuccess: async (receipt) => {
-      recordReleaseHandoff("replace-serving-targets", receipt);
+      recordReleaseHandoff('replace-serving-targets', receipt);
       await invalidateDetailQueries();
     },
   });
 
   const rolloutMutation = useMutation({
-    mutationFn: async (kind: "advance" | "pause" | "resume" | "rollback") => {
+    mutationFn: async (kind: 'advance' | 'pause' | 'resume' | 'rollback') => {
       const availability = rolloutActionAvailability[kind];
       if (!availability.enabled) {
         throw new Error(availability.reason);
@@ -1610,21 +1654,21 @@ const DeploymentsPage: React.FC = () => {
 
       const rolloutId = rolloutQuery.data?.rolloutId;
       if (!rolloutId) {
-        throw new Error("当前服务没有活动 rollout。");
+        throw new Error('当前服务没有活动 rollout。');
       }
 
-      if (kind === "advance") {
+      if (kind === 'advance') {
         return servicesApi.advanceRollout(selectedServiceId, rolloutId, query);
       }
 
-      if (kind === "pause") {
+      if (kind === 'pause') {
         return servicesApi.pauseRollout(selectedServiceId, rolloutId, {
           ...query,
           reason: drawerReason,
         });
       }
 
-      if (kind === "resume") {
+      if (kind === 'resume') {
         return servicesApi.resumeRollout(selectedServiceId, rolloutId, query);
       }
 
@@ -1636,8 +1680,8 @@ const DeploymentsPage: React.FC = () => {
     onError: (error: Error) => {
       setReleaseHandoff(null);
       setNotice({
-        message: error.message || "发布控制动作提交失败。",
-        tone: "error",
+        message: error.message || '发布控制动作提交失败。',
+        tone: 'error',
       });
     },
     onSuccess: async (receipt, kind) => {
@@ -1645,10 +1689,10 @@ const DeploymentsPage: React.FC = () => {
         RolloutControlAction,
         DeploymentReleaseHandoffAction
       > = {
-        advance: "advance-rollout",
-        pause: "pause-rollout",
-        resume: "resume-rollout",
-        rollback: "rollback-rollout",
+        advance: 'advance-rollout',
+        pause: 'pause-rollout',
+        resume: 'resume-rollout',
+        rollback: 'rollback-rollout',
       };
       recordReleaseHandoff(actionByKind[kind], receipt);
       await invalidateDetailQueries();
@@ -1658,7 +1702,7 @@ const DeploymentsPage: React.FC = () => {
   const deactivateMutation = useMutation({
     mutationFn: (deploymentId: string) => {
       if (!deploymentId.trim()) {
-        throw new Error("请选择 deployment。");
+        throw new Error('请选择 deployment。');
       }
 
       return servicesApi.deactivateDeployment(
@@ -1670,29 +1714,32 @@ const DeploymentsPage: React.FC = () => {
     onError: (error: Error) => {
       setReleaseHandoff(null);
       setNotice({
-        message: error.message || "停用 deployment 失败。",
-        tone: "error",
+        message: error.message || '停用 deployment 失败。',
+        tone: 'error',
       });
     },
     onSuccess: async (receipt, deploymentId) => {
-      recordReleaseHandoff("deactivate-deployment", receipt, {
+      recordReleaseHandoff('deactivate-deployment', receipt, {
         deploymentId,
       });
       await invalidateDetailQueries();
     },
   });
 
-  const servingColumns = useMemo<
-    ColumnsType<ServiceServingTargetSnapshot>
-  >(
+  const servingColumns = useMemo<ColumnsType<ServiceServingTargetSnapshot>>(
     () => [
       {
-        dataIndex: "revisionId",
-        key: "revisionId",
-        title: "Revision",
+        dataIndex: 'revisionId',
+        key: 'revisionId',
+        title: 'Revision',
         render: (value: string, record) => (
           <Space orientation="vertical" size={4}>
-            <CompactIdentifierText maxWidth={220} singleLine strong value={value} />
+            <CompactIdentifierText
+              maxWidth={220}
+              singleLine
+              strong
+              value={value}
+            />
             {record.deploymentId ? (
               <CompactIdentifierText
                 color="var(--ant-color-text-secondary)"
@@ -1701,46 +1748,54 @@ const DeploymentsPage: React.FC = () => {
                 value={record.deploymentId}
               />
             ) : (
-              <Typography.Text type="secondary">未绑定 deployment</Typography.Text>
+              <Typography.Text type="secondary">
+                未绑定 deployment
+              </Typography.Text>
             )}
           </Space>
         ),
       },
       {
-        dataIndex: "primaryActorId",
-        key: "primaryActorId",
-        title: "主 Actor",
+        dataIndex: 'primaryActorId',
+        key: 'primaryActorId',
+        title: '主 Actor',
         render: (value: string) =>
-          value ? <CompactIdentifierText maxWidth={160} singleLine value={value} /> : "暂无",
+          value ? (
+            <CompactIdentifierText maxWidth={160} singleLine value={value} />
+          ) : (
+            '暂无'
+          ),
       },
       {
-        dataIndex: "allocationWeight",
-        key: "allocationWeight",
-        title: "权重",
+        dataIndex: 'allocationWeight',
+        key: 'allocationWeight',
+        title: '权重',
         render: (value: number) => `${value}%`,
       },
       {
-        dataIndex: "servingState",
-        key: "servingState",
-        title: "Serving 状态",
-        render: (value: string) => <DeploymentStatusTag status={value || "unknown"} />,
+        dataIndex: 'servingState',
+        key: 'servingState',
+        title: 'Serving 状态',
+        render: (value: string) => (
+          <DeploymentStatusTag status={value || 'unknown'} />
+        ),
       },
       {
-        dataIndex: "enabledEndpointIds",
-        key: "enabledEndpointIds",
-        title: "入口",
+        dataIndex: 'enabledEndpointIds',
+        key: 'enabledEndpointIds',
+        title: '入口',
         render: (value: readonly string[]) =>
-          value.length > 0 ? value.join(", ") : "所有入口",
+          value.length > 0 ? value.join(', ') : '所有入口',
       },
       {
-        key: "actions",
-        title: "操作",
+        key: 'actions',
+        title: '操作',
         render: (_, record) => (
           <Button
             size="small"
             onClick={() =>
               openInspector({
-                kind: "serving",
+                kind: 'serving',
                 key: buildServingTargetKey(record),
                 open: true,
               })
@@ -1754,25 +1809,23 @@ const DeploymentsPage: React.FC = () => {
     [openInspector],
   );
 
-  const rolloutColumns = useMemo<
-    ColumnsType<ServiceRolloutStageSnapshot>
-  >(
+  const rolloutColumns = useMemo<ColumnsType<ServiceRolloutStageSnapshot>>(
     () => [
       {
-        dataIndex: "stageIndex",
-        key: "stageIndex",
-        title: "Stage",
+        dataIndex: 'stageIndex',
+        key: 'stageIndex',
+        title: 'Stage',
         render: (value: number) => `Stage ${value + 1}`,
       },
       {
-        dataIndex: "stageId",
-        key: "stageId",
-        title: "标识",
+        dataIndex: 'stageId',
+        key: 'stageId',
+        title: '标识',
       },
       {
-        dataIndex: "targets",
-        key: "targets",
-        title: "目标分配",
+        dataIndex: 'targets',
+        key: 'targets',
+        title: '目标分配',
         render: (targets: readonly ServiceServingTargetSnapshot[]) =>
           describeTargets(targets),
       },
@@ -1783,46 +1836,46 @@ const DeploymentsPage: React.FC = () => {
   const trafficColumns = useMemo<ColumnsType<DeploymentTrafficRow>>(
     () => [
       {
-        dataIndex: "endpointId",
-        key: "endpointId",
-        title: "Endpoint",
+        dataIndex: 'endpointId',
+        key: 'endpointId',
+        title: 'Endpoint',
         render: (value: string) => (
           <CompactIdentifierText maxWidth={180} singleLine value={value} />
         ),
       },
       {
-        dataIndex: "targetCount",
-        key: "targetCount",
-        title: "目标数",
+        dataIndex: 'targetCount',
+        key: 'targetCount',
+        title: '目标数',
       },
       {
-        dataIndex: "splitSummary",
-        key: "splitSummary",
-        title: "流量分配",
+        dataIndex: 'splitSummary',
+        key: 'splitSummary',
+        title: '流量分配',
       },
       {
-        dataIndex: "targets",
-        key: "states",
-        title: "Serving 状态",
-        render: (targets: DeploymentTrafficRow["targets"]) => (
+        dataIndex: 'targets',
+        key: 'states',
+        title: 'Serving 状态',
+        render: (targets: DeploymentTrafficRow['targets']) => (
           <Space wrap size={[8, 8]}>
             {targets.map((target) => (
               <Tag key={`${target.deploymentId}-${target.revisionId}`}>
-                {formatAevatarStatusLabel(target.servingState || "unknown")}
+                {formatAevatarStatusLabel(target.servingState || 'unknown')}
               </Tag>
             ))}
           </Space>
         ),
       },
       {
-        key: "actions",
-        title: "操作",
+        key: 'actions',
+        title: '操作',
         render: (_, record) => (
           <Button
             size="small"
             onClick={() =>
               openInspector({
-                kind: "traffic",
+                kind: 'traffic',
                 key: record.key,
                 open: true,
               })
@@ -1841,13 +1894,18 @@ const DeploymentsPage: React.FC = () => {
   >(
     () => [
       {
-        dataIndex: "deploymentId",
-        key: "deploymentId",
-        title: "Deployment",
+        dataIndex: 'deploymentId',
+        key: 'deploymentId',
+        title: 'Deployment',
         width: 220,
         render: (value: string, record) => (
           <Space orientation="vertical" size={2}>
-            <CompactIdentifierText maxWidth={180} singleLine strong value={value} />
+            <CompactIdentifierText
+              maxWidth={180}
+              singleLine
+              strong
+              value={value}
+            />
             <CompactIdentifierText
               color="var(--ant-color-text-secondary)"
               maxWidth={180}
@@ -1858,60 +1916,68 @@ const DeploymentsPage: React.FC = () => {
         ),
       },
       {
-        dataIndex: "primaryActorId",
-        key: "primaryActorId",
-        title: "主 Actor",
+        dataIndex: 'primaryActorId',
+        key: 'primaryActorId',
+        title: '主 Actor',
         width: 150,
         render: (value: string) =>
           value ? (
             <CompactIdentifierText maxWidth={116} singleLine value={value} />
           ) : (
-            "暂无"
+            '暂无'
           ),
       },
       {
-        dataIndex: "status",
-        key: "status",
-        title: "状态",
+        dataIndex: 'status',
+        key: 'status',
+        title: '状态',
         width: 104,
-        render: (value: string) => <DeploymentStatusTag status={value || "unknown"} />,
+        render: (value: string) => (
+          <DeploymentStatusTag status={value || 'unknown'} />
+        ),
       },
       {
-        dataIndex: "activatedAt",
-        key: "activatedAt",
-        title: "激活时间",
+        dataIndex: 'activatedAt',
+        key: 'activatedAt',
+        title: '激活时间',
         width: 148,
         render: (value: string | null) => (
           <Typography.Text
-            style={{ color: surfaceToken.colorTextSecondary, whiteSpace: "nowrap" }}
+            style={{
+              color: surfaceToken.colorTextSecondary,
+              whiteSpace: 'nowrap',
+            }}
           >
             {formatDateTime(value)}
           </Typography.Text>
         ),
       },
       {
-        dataIndex: "updatedAt",
-        key: "updatedAt",
-        title: "最近更新",
+        dataIndex: 'updatedAt',
+        key: 'updatedAt',
+        title: '最近更新',
         width: 148,
         render: (value: string) => (
           <Typography.Text
-            style={{ color: surfaceToken.colorTextSecondary, whiteSpace: "nowrap" }}
+            style={{
+              color: surfaceToken.colorTextSecondary,
+              whiteSpace: 'nowrap',
+            }}
           >
             {formatDateTime(value)}
           </Typography.Text>
         ),
       },
       {
-        key: "actions",
-        title: "操作",
+        key: 'actions',
+        title: '操作',
         width: 104,
         render: (_, record) => (
           <Button
             size="small"
             onClick={() =>
               openInspector({
-                kind: "deployment",
+                kind: 'deployment',
                 key: record.deploymentId,
                 open: true,
               })
@@ -1927,25 +1993,25 @@ const DeploymentsPage: React.FC = () => {
 
   const handleDraftChange = useCallback((nextDraft: ServiceQueryDraft) => {
     setDraft(nextDraft);
-    setSelectedServiceId("");
-    setSelectedDeploymentId("");
+    setSelectedServiceId('');
+    setSelectedDeploymentId('');
     setReleaseHandoff(null);
   }, []);
 
   const openServiceWorkbench = useCallback(
-    (service: Pick<ServiceCatalogSnapshot, "deploymentId" | "serviceId">) => {
+    (service: Pick<ServiceCatalogSnapshot, 'deploymentId' | 'serviceId'>) => {
       setSelectedServiceId(service.serviceId);
-      setSelectedDeploymentId(service.deploymentId || "");
+      setSelectedDeploymentId(service.deploymentId || '');
       setInspectorState({ open: false });
       setReleaseHandoff(null);
-      setView("catalog");
+      setView('catalog');
     },
     [],
   );
 
   const closeServiceWorkbench = useCallback(() => {
-    setSelectedServiceId("");
-    setSelectedDeploymentId("");
+    setSelectedServiceId('');
+    setSelectedDeploymentId('');
     setInspectorState({ open: false });
     setReleaseHandoff(null);
     setDrawerState((current) => ({
@@ -1957,34 +2023,34 @@ const DeploymentsPage: React.FC = () => {
   const handleReset = useCallback(() => {
     const nextDraft = isScopeDirty
       ? {
-          appId: query.appId?.trim() ?? "",
-          namespace: query.namespace?.trim() ?? "",
+          appId: query.appId?.trim() ?? '',
+          namespace: query.namespace?.trim() ?? '',
           take: query.take && query.take > 0 ? query.take : 200,
-          tenantId: query.tenantId?.trim() ?? "",
+          tenantId: query.tenantId?.trim() ?? '',
         }
       : resolvedScope?.scopeId?.trim()
         ? {
-            ...readServiceQueryDraft(""),
+            ...readServiceQueryDraft(''),
             appId: defaultScopeServiceAppId,
             namespace: defaultScopeServiceNamespace,
             tenantId: resolvedScope.scopeId.trim(),
           }
-        : readServiceQueryDraft("");
+        : readServiceQueryDraft('');
     setDraft(nextDraft);
     if (!isScopeDirty) {
       setQuery(trimServiceQuery(nextDraft));
     }
-    setSelectedServiceId("");
-    setSelectedDeploymentId("");
-    setCandidateRevisionId("");
-    setDrawerReason("");
+    setSelectedServiceId('');
+    setSelectedDeploymentId('');
+    setCandidateRevisionId('');
+    setDrawerReason('');
     setReleaseHandoff(null);
-    setView("catalog");
+    setView('catalog');
   }, [isScopeDirty, query, resolvedScope?.scopeId]);
 
   const drawerSubtitle = selectedService
     ? `${selectedService.tenantId}/${selectedService.appId}/${selectedService.namespace}`
-    : "发布工作区";
+    : '发布工作区';
 
   return (
     <ConsoleMenuPageShell
@@ -1992,7 +2058,7 @@ const DeploymentsPage: React.FC = () => {
       description="Deployments 是 Platform 的发布工作台，聚焦当前 serving、rollout 进度和流量分配。"
       title="Deployments"
     >
-      <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
         {notice ? (
           <Alert
             closable
@@ -2017,9 +2083,9 @@ const DeploymentsPage: React.FC = () => {
 
         <div
           style={{
-            display: "grid",
+            display: 'grid',
             gap: 12,
-            gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+            gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
           }}
         >
           <MetricCard
@@ -2028,7 +2094,7 @@ const DeploymentsPage: React.FC = () => {
             value={
               deploymentInventoryReady
                 ? String(visibleServiceDigest.services)
-                : "—"
+                : '—'
             }
           />
           <MetricCard
@@ -2037,7 +2103,7 @@ const DeploymentsPage: React.FC = () => {
             value={
               deploymentInventoryReady
                 ? String(visibleServiceDigest.servingServices)
-                : "—"
+                : '—'
             }
           />
           <MetricCard
@@ -2046,7 +2112,7 @@ const DeploymentsPage: React.FC = () => {
             value={
               deploymentInventoryReady
                 ? String(visibleServiceDigest.waitingServices)
-                : "—"
+                : '—'
             }
           />
           <MetricCard
@@ -2054,7 +2120,7 @@ const DeploymentsPage: React.FC = () => {
             value={
               deploymentInventoryReady
                 ? String(visibleServiceDigest.endpointServices)
-                : "—"
+                : '—'
             }
           />
         </div>
@@ -2062,28 +2128,28 @@ const DeploymentsPage: React.FC = () => {
         <div
           style={{
             ...buildAevatarPanelStyle(surfaceToken),
-            display: "flex",
-            flexDirection: "column",
+            display: 'flex',
+            flexDirection: 'column',
             gap: 16,
             padding: 18,
           }}
         >
           <div
             style={{
-              alignItems: "flex-start",
-              display: "flex",
+              alignItems: 'flex-start',
+              display: 'flex',
               gap: 16,
-              justifyContent: "space-between",
+              justifyContent: 'space-between',
             }}
           >
             <Space orientation="vertical" size={4}>
               <span
                 style={{
-                  color: "var(--ant-color-primary)",
+                  color: 'var(--ant-color-primary)',
                   fontSize: 12,
                   fontWeight: 700,
-                  letterSpacing: "0.08em",
-                  textTransform: "uppercase",
+                  letterSpacing: '0.08em',
+                  textTransform: 'uppercase',
                 }}
               >
                 发布服务列表
@@ -2094,14 +2160,18 @@ const DeploymentsPage: React.FC = () => {
               >
                 先从服务列表锁定发布对象
               </Typography.Text>
-              <Typography.Text style={{ color: surfaceToken.colorTextSecondary }}>
+              <Typography.Text
+                style={{ color: surfaceToken.colorTextSecondary }}
+              >
                 扫描 serving、deployment 和入口规模，再进入某个服务的发布详情。
               </Typography.Text>
               <Space wrap size={[8, 8]}>
-                <Tag color={isScopeDirty ? "gold" : "blue"}>
-                  {isScopeDirty ? "显示上次加载范围" : "显示已加载范围"}
+                <Tag color={isScopeDirty ? 'gold' : 'blue'}>
+                  {isScopeDirty ? '显示上次加载范围' : '显示已加载范围'}
                 </Tag>
-                <Typography.Text style={{ color: surfaceToken.colorTextSecondary }}>
+                <Typography.Text
+                  style={{ color: surfaceToken.colorTextSecondary }}
+                >
                   {loadedScopeLabel}
                 </Typography.Text>
               </Space>
@@ -2117,7 +2187,7 @@ const DeploymentsPage: React.FC = () => {
           ) : servicesQuery.error ? (
             <InventoryReadinessState
               action={{
-                label: "重试发布列表",
+                label: '重试发布列表',
                 onClick: () => {
                   void servicesQuery.refetch();
                 },
@@ -2125,30 +2195,37 @@ const DeploymentsPage: React.FC = () => {
               description={
                 servicesQuery.error instanceof Error
                   ? servicesQuery.error.message
-                  : "加载服务发布列表失败，请重试。"
+                  : '加载服务发布列表失败，请重试。'
               }
               kind="error"
               title="发布服务列表暂不可用"
             />
           ) : servicesQuery.data?.length ? (
-            <div style={{ overflowX: "auto" }}>
+            <div style={{ overflowX: 'auto' }}>
               <table
                 style={{
                   background: surfaceToken.colorBgContainer,
-                  borderCollapse: "separate",
+                  borderCollapse: 'separate',
                   borderSpacing: 0,
-                  width: "100%",
+                  width: '100%',
                 }}
               >
                 <thead>
                   <tr>
-                    {["状态", "服务", "范围", "当前 Serving", "当前 Deployment", "入口", "最近更新", "操作"].map(
-                      (label) => (
-                        <th key={label} style={tableHeaderCellStyle}>
-                          {label}
-                        </th>
-                      ),
-                    )}
+                    {[
+                      '状态',
+                      '服务',
+                      '范围',
+                      '当前 Serving',
+                      '当前 Deployment',
+                      '入口',
+                      '最近更新',
+                      '操作',
+                    ].map((label) => (
+                      <th key={label} style={tableHeaderCellStyle}>
+                        {label}
+                      </th>
+                    ))}
                   </tr>
                 </thead>
                 <tbody>
@@ -2162,12 +2239,12 @@ const DeploymentsPage: React.FC = () => {
                           background: selected
                             ? surfaceToken.colorPrimaryBg
                             : surfaceToken.colorBgContainer,
-                          cursor: "pointer",
+                          cursor: 'pointer',
                         }}
                       >
                         <td style={tableCellStyle}>
                           <DeploymentStatusTag
-                            status={service.deploymentStatus || "pending"}
+                            status={service.deploymentStatus || 'pending'}
                           />
                         </td>
                         <td
@@ -2177,7 +2254,13 @@ const DeploymentsPage: React.FC = () => {
                             width: 136,
                           }}
                         >
-                          <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                          <div
+                            style={{
+                              display: 'flex',
+                              flexDirection: 'column',
+                              gap: 4,
+                            }}
+                          >
                             <CompactLabelText
                               maxWidth={120}
                               strong
@@ -2226,7 +2309,10 @@ const DeploymentsPage: React.FC = () => {
                             />
                           ) : (
                             <Typography.Text
-                              style={{ color: surfaceToken.colorText, fontWeight: 600 }}
+                              style={{
+                                color: surfaceToken.colorText,
+                                fontWeight: 600,
+                              }}
                             >
                               未发布
                             </Typography.Text>
@@ -2247,14 +2333,18 @@ const DeploymentsPage: React.FC = () => {
                         </td>
                         <td style={tableCellStyle}>
                           <Tag
-                            color={service.endpoints.length > 0 ? "cyan" : "default"}
+                            color={
+                              service.endpoints.length > 0 ? 'cyan' : 'default'
+                            }
                             style={compactHintTagStyle}
                           >
                             {service.endpoints.length}
                           </Tag>
                         </td>
-                        <td style={{ ...tableCellStyle, whiteSpace: "nowrap" }}>
-                          <Typography.Text style={{ color: surfaceToken.colorTextSecondary }}>
+                        <td style={{ ...tableCellStyle, whiteSpace: 'nowrap' }}>
+                          <Typography.Text
+                            style={{ color: surfaceToken.colorTextSecondary }}
+                          >
                             {formatDateTime(service.updatedAt)}
                           </Typography.Text>
                         </td>
@@ -2277,7 +2367,7 @@ const DeploymentsPage: React.FC = () => {
             </div>
           ) : (
             <InventoryReadinessState
-              action={{ label: "调整发布范围", onClick: handleReset }}
+              action={{ label: '调整发布范围', onClick: handleReset }}
               description="当前 Team、App 和 Namespace 下没有可发布服务。可以调整范围后重新加载。"
               kind="empty"
               title="当前范围没有服务"
@@ -2292,20 +2382,20 @@ const DeploymentsPage: React.FC = () => {
             <Space wrap size={[8, 8]}>
               <Button
                 icon={<SendOutlined />}
-                onClick={() => openDrawer("candidate")}
+                onClick={() => openDrawer('candidate')}
                 type="primary"
               >
                 部署候选版本
               </Button>
               <Button
                 icon={<PercentageOutlined />}
-                onClick={() => openDrawer("weights")}
+                onClick={() => openDrawer('weights')}
               >
                 调整流量
               </Button>
               <Button
                 icon={<RollbackOutlined />}
-                onClick={() => openDrawer("control")}
+                onClick={() => openDrawer('control')}
               >
                 发布控制
               </Button>
@@ -2315,15 +2405,22 @@ const DeploymentsPage: React.FC = () => {
         onClose={closeServiceWorkbench}
         open={Boolean(selectedServiceId)}
         subtitle={drawerSubtitle}
-        title={selectedService?.displayName || selectedServiceId || "Deployment Service"}
+        title={
+          selectedService?.displayName ||
+          selectedServiceId ||
+          'Deployment Service'
+        }
         width={1080}
       >
         {serviceDetailQuery.isLoading && !selectedService ? (
-          <AevatarInspectorEmpty description="正在加载发布详情" title="Loading deployment" />
+          <AevatarInspectorEmpty
+            description="正在加载发布详情"
+            title="Loading deployment"
+          />
         ) : !selectedService ? (
           <AevatarInspectorEmpty description="选择一个服务" />
         ) : (
-          <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
             {releaseHandoff && releaseEvidence ? (
               <ReleaseHandoffPanel
                 evidence={releaseEvidence}
@@ -2334,13 +2431,17 @@ const DeploymentsPage: React.FC = () => {
             ) : null}
 
             <WorkbenchSection title="发布摘要">
-              <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+              <div
+                style={{ display: 'flex', flexDirection: 'column', gap: 14 }}
+              >
                 <Space wrap size={[8, 8]}>
                   <DeploymentStatusTag
-                    status={selectedService.deploymentStatus || "pending"}
+                    status={selectedService.deploymentStatus || 'pending'}
                   />
                   {focusDeployment?.deploymentId ? (
-                    <CompactIdentifierTag value={focusDeployment.deploymentId} />
+                    <CompactIdentifierTag
+                      value={focusDeployment.deploymentId}
+                    />
                   ) : null}
                   {rolloutQuery.data?.rolloutId ? (
                     <CompactIdentifierTag
@@ -2349,7 +2450,9 @@ const DeploymentsPage: React.FC = () => {
                     />
                   ) : null}
                   <Tag
-                    color={selectedService.endpoints.length > 0 ? "cyan" : "default"}
+                    color={
+                      selectedService.endpoints.length > 0 ? 'cyan' : 'default'
+                    }
                     style={compactHintTagStyle}
                   >
                     {selectedService.endpoints.length} 个入口
@@ -2358,18 +2461,22 @@ const DeploymentsPage: React.FC = () => {
 
                 <div
                   style={{
-                    display: "grid",
+                    display: 'grid',
                     gap: 10,
-                    gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+                    gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
                   }}
                 >
                   <DetailFieldCard
                     label="当前 serving"
                     value={
                       activeRevisionId ? (
-                        <CompactIdentifierText maxWidth="100%" singleLine value={activeRevisionId} />
+                        <CompactIdentifierText
+                          maxWidth="100%"
+                          singleLine
+                          value={activeRevisionId}
+                        />
                       ) : (
-                        "暂无 serving 版本"
+                        '暂无 serving 版本'
                       )
                     }
                   />
@@ -2383,7 +2490,7 @@ const DeploymentsPage: React.FC = () => {
                           value={focusDeployment.deploymentId}
                         />
                       ) : (
-                        "未挂 Serving"
+                        '未挂 Serving'
                       )
                     }
                   />
@@ -2397,7 +2504,7 @@ const DeploymentsPage: React.FC = () => {
                           value={selectedService.primaryActorId}
                         />
                       ) : (
-                        "未声明"
+                        '未声明'
                       )
                     }
                   />
@@ -2409,16 +2516,16 @@ const DeploymentsPage: React.FC = () => {
                           trafficQuery.data?.updatedAt ||
                           deploymentsQuery.data?.updatedAt ||
                           selectedService.updatedAt,
-                      ) || "待同步"
+                      ) || '待同步'
                     }
                   />
                 </div>
 
                 <div
                   style={{
-                    display: "grid",
+                    display: 'grid',
                     gap: 10,
-                    gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
+                    gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
                   }}
                 >
                   <MetricCard
@@ -2449,22 +2556,22 @@ const DeploymentsPage: React.FC = () => {
                 activeKey={view}
                 items={[
                   {
-                    key: "catalog",
-                    label: "部署目录",
+                    key: 'catalog',
+                    label: '部署目录',
                     children: (
                       <WorkbenchSection title="Deployment Catalog">
                         <Table<ServiceDeploymentSnapshot>
                           columns={drawerDeploymentColumns}
                           dataSource={deploymentsQuery.data?.deployments ?? []}
-                          locale={{ emptyText: "当前没有 deployment catalog" }}
+                          locale={{ emptyText: '当前没有 deployment catalog' }}
                           onRow={(record) => ({
                             onClick: () =>
                               openInspector({
-                                kind: "deployment",
+                                kind: 'deployment',
                                 key: record.deploymentId,
                                 open: true,
                               }),
-                            style: { cursor: "pointer" },
+                            style: { cursor: 'pointer' },
                           })}
                           pagination={false}
                           rowKey={(record) => record.deploymentId}
@@ -2476,14 +2583,16 @@ const DeploymentsPage: React.FC = () => {
                     ),
                   },
                   {
-                    key: "serving",
-                    label: "Serving",
+                    key: 'serving',
+                    label: 'Serving',
                     children: (
                       <WorkbenchSection
                         title="Serving Targets"
                         extra={
                           <Space wrap size={[8, 8]}>
-                            <Tag>Generation {servingQuery.data?.generation ?? 0}</Tag>
+                            <Tag>
+                              Generation {servingQuery.data?.generation ?? 0}
+                            </Tag>
                             {servingQuery.data?.activeRolloutId ? (
                               <Tag color="blue">
                                 {servingQuery.data.activeRolloutId}
@@ -2491,7 +2600,7 @@ const DeploymentsPage: React.FC = () => {
                             ) : null}
                             <Button
                               icon={<PercentageOutlined />}
-                              onClick={() => openDrawer("weights")}
+                              onClick={() => openDrawer('weights')}
                             >
                               调整流量
                             </Button>
@@ -2501,15 +2610,15 @@ const DeploymentsPage: React.FC = () => {
                         <Table<ServiceServingTargetSnapshot>
                           columns={servingColumns}
                           dataSource={servingQuery.data?.targets ?? []}
-                          locale={{ emptyText: "当前没有 serving targets" }}
+                          locale={{ emptyText: '当前没有 serving targets' }}
                           onRow={(record) => ({
                             onClick: () =>
                               openInspector({
-                                kind: "serving",
+                                kind: 'serving',
                                 key: buildServingTargetKey(record),
                                 open: true,
                               }),
-                            style: { cursor: "pointer" },
+                            style: { cursor: 'pointer' },
                           })}
                           pagination={false}
                           rowKey={buildServingTargetKey}
@@ -2519,8 +2628,8 @@ const DeploymentsPage: React.FC = () => {
                     ),
                   },
                   {
-                    key: "traffic",
-                    label: "Traffic",
+                    key: 'traffic',
+                    label: 'Traffic',
                     children: (
                       <WorkbenchSection
                         title="入口流量"
@@ -2532,10 +2641,12 @@ const DeploymentsPage: React.FC = () => {
                                 value={trafficQuery.data.activeRolloutId}
                               />
                             ) : null}
-                            <Tag>Generation {trafficQuery.data?.generation ?? 0}</Tag>
+                            <Tag>
+                              Generation {trafficQuery.data?.generation ?? 0}
+                            </Tag>
                             <Button
                               icon={<PercentageOutlined />}
-                              onClick={() => openDrawer("weights")}
+                              onClick={() => openDrawer('weights')}
                             >
                               调整流量
                             </Button>
@@ -2545,15 +2656,15 @@ const DeploymentsPage: React.FC = () => {
                         <Table<DeploymentTrafficRow>
                           columns={trafficColumns}
                           dataSource={trafficRows}
-                          locale={{ emptyText: "当前没有 traffic view" }}
+                          locale={{ emptyText: '当前没有 traffic view' }}
                           onRow={(record) => ({
                             onClick: () =>
                               openInspector({
-                                kind: "traffic",
+                                kind: 'traffic',
                                 key: record.key,
                                 open: true,
                               }),
-                            style: { cursor: "pointer" },
+                            style: { cursor: 'pointer' },
                           })}
                           pagination={false}
                           rowKey="key"
@@ -2563,19 +2674,23 @@ const DeploymentsPage: React.FC = () => {
                     ),
                   },
                   {
-                    key: "rollout",
-                    label: "Rollout",
+                    key: 'rollout',
+                    label: 'Rollout',
                     children: rolloutQuery.data ? (
                       <div style={cardStackStyle}>
                         <WorkbenchSection
                           title="Rollout 概况"
                           extra={
                             <Space wrap size={[8, 8]}>
-                              <DeploymentStatusTag status={rolloutQuery.data.status} />
-                              <CompactIdentifierTag value={rolloutQuery.data.rolloutId} />
+                              <DeploymentStatusTag
+                                status={rolloutQuery.data.status}
+                              />
+                              <CompactIdentifierTag
+                                value={rolloutQuery.data.rolloutId}
+                              />
                               <Button
                                 icon={<RollbackOutlined />}
-                                onClick={() => openDrawer("control")}
+                                onClick={() => openDrawer('control')}
                               >
                                 发布控制
                               </Button>
@@ -2584,39 +2699,47 @@ const DeploymentsPage: React.FC = () => {
                         >
                           <div
                             style={{
-                              display: "grid",
+                              display: 'grid',
                               gap: 12,
-                              gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+                              gridTemplateColumns:
+                                'repeat(auto-fit, minmax(220px, 1fr))',
                             }}
                           >
                             <DetailFieldCard
                               label="Rollout"
-                              value={rolloutQuery.data.displayName || rolloutQuery.data.rolloutId}
+                              value={
+                                rolloutQuery.data.displayName ||
+                                rolloutQuery.data.rolloutId
+                              }
                             />
                             <DetailFieldCard
                               label="当前 Stage"
                               value={
                                 currentStage
                                   ? `${currentStage.stageIndex + 1} / ${rolloutQuery.data.stages.length}`
-                                  : "暂无"
+                                  : '暂无'
                               }
                             />
                             <DetailFieldCard
                               label="开始时间"
-                              value={formatDateTime(rolloutQuery.data.startedAt)}
+                              value={formatDateTime(
+                                rolloutQuery.data.startedAt,
+                              )}
                             />
                             <DetailFieldCard
                               label="最近更新"
-                              value={formatDateTime(rolloutQuery.data.updatedAt)}
+                              value={formatDateTime(
+                                rolloutQuery.data.updatedAt,
+                              )}
                             />
                           </div>
                         </WorkbenchSection>
 
                         <div
                           style={{
-                            display: "grid",
+                            display: 'grid',
                             gap: 16,
-                            gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+                            gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
                           }}
                         >
                           <WorkbenchSection title="阶段计划">
@@ -2631,9 +2754,10 @@ const DeploymentsPage: React.FC = () => {
                           <WorkbenchSection title="基线与当前 Stage">
                             <div
                               style={{
-                                display: "grid",
+                                display: 'grid',
                                 gap: 12,
-                                gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+                                gridTemplateColumns:
+                                  'repeat(2, minmax(0, 1fr))',
                               }}
                             >
                               <TargetGroupCard
@@ -2676,7 +2800,7 @@ const DeploymentsPage: React.FC = () => {
         styles={{
           body: aevatarDrawerBodyStyle,
           wrapper: {
-            maxWidth: "94vw",
+            maxWidth: '94vw',
             width: 1040,
           },
         }}
@@ -2698,7 +2822,7 @@ const DeploymentsPage: React.FC = () => {
           >
             <Space wrap size={[8, 8]}>
               <DeploymentStatusTag
-                status={serviceDetailQuery.data?.deploymentStatus || "pending"}
+                status={serviceDetailQuery.data?.deploymentStatus || 'pending'}
               />
               {rolloutQuery.data?.rolloutId ? (
                 <CompactIdentifierTag
@@ -2720,17 +2844,27 @@ const DeploymentsPage: React.FC = () => {
             items={[
               {
                 children: (
-                  <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: 16,
+                    }}
+                  >
                     <div
                       style={{
-                        display: "grid",
+                        display: 'grid',
                         gap: 12,
                         gridTemplateColumns:
-                          "minmax(260px, 320px) repeat(auto-fit, minmax(220px, 1fr))",
+                          'minmax(260px, 320px) repeat(auto-fit, minmax(220px, 1fr))',
                       }}
                     >
                       <WorkbenchSection title="候选版本">
-                        <Space orientation="vertical" size={12} style={{ width: "100%" }}>
+                        <Space
+                          orientation="vertical"
+                          size={12}
+                          style={{ width: '100%' }}
+                        >
                           <Select
                             options={(revisionsQuery.data?.revisions ?? []).map(
                               (revision) => ({
@@ -2769,9 +2903,10 @@ const DeploymentsPage: React.FC = () => {
                     </div>
                     <div
                       style={{
-                        display: "grid",
+                        display: 'grid',
                         gap: 12,
-                        gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+                        gridTemplateColumns:
+                          'repeat(auto-fit, minmax(220px, 1fr))',
                       }}
                     >
                       <TargetGroupCard
@@ -2781,29 +2916,37 @@ const DeploymentsPage: React.FC = () => {
                       <TargetGroupCard
                         label="Current Stage"
                         targets={
-                          currentStage?.targets ?? servingQuery.data?.targets ?? []
+                          currentStage?.targets ??
+                          servingQuery.data?.targets ??
+                          []
                         }
                       />
                     </div>
                   </div>
                 ),
-                key: "candidate",
-                label: "候选版本",
+                key: 'candidate',
+                label: '候选版本',
               },
               {
                 children: (
-                  <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: 12,
+                    }}
+                  >
                     {editableTargets.length ? (
                       editableTargets.map((target, index) => (
                         <div
-                          key={`${target.revisionId}-${target.servingState || "unset"}`}
+                          key={`${target.revisionId}-${target.servingState || 'unset'}`}
                           style={{
                             background: surfaceToken.colorFillAlter,
                             border: `1px solid ${surfaceToken.colorBorderSecondary}`,
                             borderRadius: surfaceToken.borderRadiusLG,
-                            display: "grid",
+                            display: 'grid',
                             gap: 12,
-                            gridTemplateColumns: "minmax(0, 1fr) 140px 160px",
+                            gridTemplateColumns: 'minmax(0, 1fr) 140px 160px',
                             padding: 14,
                           }}
                         >
@@ -2821,7 +2964,8 @@ const DeploymentsPage: React.FC = () => {
                                 marginTop: 4,
                               }}
                             >
-                              {target.enabledEndpointIds?.join(", ") || "所有入口"}
+                              {target.enabledEndpointIds?.join(', ') ||
+                                '所有入口'}
                             </Typography.Paragraph>
                           </div>
                           <InputNumber
@@ -2841,15 +2985,16 @@ const DeploymentsPage: React.FC = () => {
                               )
                             }
                           />
-                          <Input
-                            value={target.servingState}
-                            onChange={(event) =>
+                          <Select
+                            options={servingStateOptions}
+                            value={target.servingState || 'active'}
+                            onChange={(value) =>
                               setEditableTargets((current) =>
                                 current.map((item, itemIndex) =>
                                   itemIndex === index
                                     ? {
                                         ...item,
-                                        servingState: event.target.value,
+                                        servingState: value,
                                       }
                                     : item,
                                 ),
@@ -2874,10 +3019,14 @@ const DeploymentsPage: React.FC = () => {
                       message={servingTargetPlanStatus.summary}
                       description={servingTargetPlanStatus.reason}
                       showIcon
-                      type={servingTargetPlanStatus.enabled ? "info" : "warning"}
+                      type={
+                        servingTargetPlanStatus.enabled ? 'info' : 'warning'
+                      }
                     />
                     <Tooltip title={servingTargetPlanStatus.reason}>
-                      <span style={{ display: "inline-flex", width: "fit-content" }}>
+                      <span
+                        style={{ display: 'inline-flex', width: 'fit-content' }}
+                      >
                         <Button
                           disabled={!servingTargetPlanStatus.enabled}
                           icon={<PercentageOutlined />}
@@ -2891,16 +3040,22 @@ const DeploymentsPage: React.FC = () => {
                     </Tooltip>
                   </div>
                 ),
-                key: "weights",
-                label: "流量权重",
+                key: 'weights',
+                label: '流量权重',
               },
               {
                 children: (
-                  <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: 12,
+                    }}
+                  >
                     <MetricCard
                       label="当前 rollout"
                       tone="warning"
-                      value={rolloutQuery.data?.rolloutId || "暂无活动 rollout"}
+                      value={rolloutQuery.data?.rolloutId || '暂无活动 rollout'}
                     />
                     <Input.TextArea
                       placeholder="说明本次暂停、恢复或回滚原因"
@@ -2911,16 +3066,16 @@ const DeploymentsPage: React.FC = () => {
                     <Alert
                       message={
                         rolloutQuery.data?.rolloutId
-                          ? `当前 rollout 状态：${formatAevatarStatusLabel(rolloutQuery.data.status || "unknown")}`
-                          : "当前没有活动 rollout"
+                          ? `当前 rollout 状态：${formatAevatarStatusLabel(rolloutQuery.data.status || 'unknown')}`
+                          : '当前没有活动 rollout'
                       }
                       description={
                         rolloutQuery.data?.rolloutId
-                          ? "只有与当前生命周期匹配的控制动作会保持可执行；提交后仍需等待证据刷新。"
-                          : "发布控制动作需要先存在活动 rollout。"
+                          ? '只有与当前生命周期匹配的控制动作会保持可执行；提交后仍需等待证据刷新。'
+                          : '发布控制动作需要先存在活动 rollout。'
                       }
                       showIcon
-                      type={rolloutQuery.data?.rolloutId ? "info" : "warning"}
+                      type={rolloutQuery.data?.rolloutId ? 'info' : 'warning'}
                     />
                     <Space wrap size={[8, 8]}>
                       {rolloutControlDefinitions.map((definition) => {
@@ -2941,7 +3096,9 @@ const DeploymentsPage: React.FC = () => {
                                 onClick={() =>
                                   rolloutMutation.mutate(definition.action)
                                 }
-                                type={definition.primary ? "primary" : "default"}
+                                type={
+                                  definition.primary ? 'primary' : 'default'
+                                }
                               >
                                 {definition.label}
                               </Button>
@@ -2952,8 +3109,8 @@ const DeploymentsPage: React.FC = () => {
                     </Space>
                   </div>
                 ),
-                key: "control",
-                label: "发布控制",
+                key: 'control',
+                label: '发布控制',
               },
             ]}
             onChange={(key) =>
@@ -2971,32 +3128,33 @@ const DeploymentsPage: React.FC = () => {
         size="default"
         title={
           inspectorState.open
-            ? inspectorState.kind === "serving"
-              ? "Serving Target 详情"
-              : inspectorState.kind === "traffic"
-                ? "Traffic Endpoint 详情"
-                : "Deployment 详情"
-            : "详情"
+            ? inspectorState.kind === 'serving'
+              ? 'Serving Target 详情'
+              : inspectorState.kind === 'traffic'
+                ? 'Traffic Endpoint 详情'
+                : 'Deployment 详情'
+            : '详情'
         }
         styles={{
           body: aevatarDrawerBodyStyle,
           wrapper: {
-            maxWidth: "92vw",
+            maxWidth: '92vw',
             width: 640,
           },
         }}
         onClose={() => setInspectorState({ open: false })}
       >
         <div style={aevatarDrawerScrollStyle}>
-          {inspectorState.open && inspectorState.kind === "serving" ? (
+          {inspectorState.open && inspectorState.kind === 'serving' ? (
             selectedServingTarget ? (
               <div style={cardStackStyle}>
                 <DrawerSection title="Target 摘要">
                   <div
                     style={{
-                      display: "grid",
+                      display: 'grid',
                       gap: 12,
-                      gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+                      gridTemplateColumns:
+                        'repeat(auto-fit, minmax(180px, 1fr))',
                     }}
                   >
                     <DetailFieldCard
@@ -3019,7 +3177,7 @@ const DeploymentsPage: React.FC = () => {
                             value={selectedServingTarget.deploymentId}
                           />
                         ) : (
-                          "未绑定"
+                          '未绑定'
                         )
                       }
                     />
@@ -3033,14 +3191,14 @@ const DeploymentsPage: React.FC = () => {
                             value={selectedServingTarget.primaryActorId}
                           />
                         ) : (
-                          "暂无"
+                          '暂无'
                         )
                       }
                     />
                     <DetailFieldCard
                       label="Serving 状态"
                       value={formatAevatarStatusLabel(
-                        selectedServingTarget.servingState || "unknown",
+                        selectedServingTarget.servingState || 'unknown',
                       )}
                     />
                     <DetailFieldCard
@@ -3050,8 +3208,8 @@ const DeploymentsPage: React.FC = () => {
                     <DetailFieldCard
                       label="入口"
                       value={
-                        selectedServingTarget.enabledEndpointIds.join(", ") ||
-                        "所有入口"
+                        selectedServingTarget.enabledEndpointIds.join(', ') ||
+                        '所有入口'
                       }
                     />
                   </div>
@@ -3062,7 +3220,7 @@ const DeploymentsPage: React.FC = () => {
                       icon={<PercentageOutlined />}
                       onClick={() => {
                         setInspectorState({ open: false });
-                        openDrawer("weights");
+                        openDrawer('weights');
                       }}
                     >
                       调整流量
@@ -3071,7 +3229,7 @@ const DeploymentsPage: React.FC = () => {
                       icon={<SendOutlined />}
                       onClick={() => {
                         setInspectorState({ open: false });
-                        openDrawer("candidate");
+                        openDrawer('candidate');
                       }}
                     >
                       部署候选版本
@@ -3080,19 +3238,23 @@ const DeploymentsPage: React.FC = () => {
                 </DrawerSection>
               </div>
             ) : (
-              <Empty description="未找到 serving target" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+              <Empty
+                description="未找到 serving target"
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+              />
             )
           ) : null}
 
-          {inspectorState.open && inspectorState.kind === "traffic" ? (
+          {inspectorState.open && inspectorState.kind === 'traffic' ? (
             selectedTrafficRow ? (
               <div style={cardStackStyle}>
                 <DrawerSection title="Endpoint 摘要">
                   <div
                     style={{
-                      display: "grid",
+                      display: 'grid',
                       gap: 12,
-                      gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+                      gridTemplateColumns:
+                        'repeat(auto-fit, minmax(180px, 1fr))',
                     }}
                   >
                     <DetailFieldCard
@@ -3115,36 +3277,46 @@ const DeploymentsPage: React.FC = () => {
                     />
                     <DetailFieldCard
                       label="活动 Rollout"
-                      value={trafficQuery.data?.activeRolloutId || "暂无"}
+                      value={trafficQuery.data?.activeRolloutId || '暂无'}
                     />
                   </div>
                 </DrawerSection>
                 <DrawerSection title="流量目标">
-                  <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: 12,
+                    }}
+                  >
                     {selectedTrafficRow.targets.map((target) => (
                       <DetailFieldCard
                         key={`${target.deploymentId}-${target.revisionId}`}
                         label={`${target.revisionId} · ${target.deploymentId}`}
-                        value={`${target.allocationWeight}% · ${formatAevatarStatusLabel(target.servingState || "unknown")} · ${target.primaryActorId || "暂无 Actor"}`}
+                        value={`${target.allocationWeight}% · ${formatAevatarStatusLabel(target.servingState || 'unknown')} · ${target.primaryActorId || '暂无 Actor'}`}
                       />
                     ))}
                   </div>
                 </DrawerSection>
               </div>
             ) : (
-              <Empty description="未找到 traffic endpoint" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+              <Empty
+                description="未找到 traffic endpoint"
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+              />
             )
           ) : null}
 
-          {inspectorState.open && inspectorState.kind === "deployment" ? (
+          {inspectorState.open && inspectorState.kind === 'deployment' ? (
             inspectedDeployment ? (
               <div style={cardStackStyle}>
                 <DrawerSection title="Deployment 摘要">
                   <div
                     style={{
-                      display: "grid",
+                      display: 'grid',
                       gap: 12,
-                      gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+                      gridTemplateColumns:
+                        'repeat(auto-fit, minmax(180px, 1fr))',
                     }}
                   >
                     <DetailFieldCard
@@ -3169,7 +3341,9 @@ const DeploymentsPage: React.FC = () => {
                     />
                     <DetailFieldCard
                       label="状态"
-                      value={formatAevatarStatusLabel(inspectedDeployment.status)}
+                      value={formatAevatarStatusLabel(
+                        inspectedDeployment.status,
+                      )}
                     />
                     <DetailFieldCard
                       label="主 Actor"
@@ -3181,7 +3355,7 @@ const DeploymentsPage: React.FC = () => {
                             value={inspectedDeployment.primaryActorId}
                           />
                         ) : (
-                          "暂无"
+                          '暂无'
                         )
                       }
                     />
@@ -3201,7 +3375,7 @@ const DeploymentsPage: React.FC = () => {
                       icon={<PercentageOutlined />}
                       onClick={() => {
                         setInspectorState({ open: false });
-                        openDrawer("weights");
+                        openDrawer('weights');
                       }}
                     >
                       调整流量
@@ -3211,10 +3385,13 @@ const DeploymentsPage: React.FC = () => {
                       icon={<StopOutlined />}
                       loading={
                         deactivateMutation.isPending &&
-                        deactivateMutation.variables === inspectedDeployment.deploymentId
+                        deactivateMutation.variables ===
+                          inspectedDeployment.deploymentId
                       }
                       onClick={() =>
-                        deactivateMutation.mutate(inspectedDeployment.deploymentId)
+                        deactivateMutation.mutate(
+                          inspectedDeployment.deploymentId,
+                        )
                       }
                     >
                       停用 deployment
@@ -3223,7 +3400,10 @@ const DeploymentsPage: React.FC = () => {
                 </DrawerSection>
               </div>
             ) : (
-              <Empty description="未找到 deployment" image={Empty.PRESENTED_IMAGE_SIMPLE} />
+              <Empty
+                description="未找到 deployment"
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+              />
             )
           ) : null}
         </div>

--- a/apps/aevatar-console-web/src/pages/Deployments/index.tsx
+++ b/apps/aevatar-console-web/src/pages/Deployments/index.tsx
@@ -88,6 +88,7 @@ import {
   type DeploymentReleaseEvidenceSnapshot,
   type DeploymentReleaseEvidenceStatus,
 } from './releaseEvidence';
+import { buildDeploymentDeactivateAvailability } from './deploymentActionAvailability';
 import {
   buildRolloutActionAvailability,
   type RolloutControlAction,
@@ -1522,6 +1523,33 @@ const DeploymentsPage: React.FC = () => {
     () => buildRolloutActionAvailability(rolloutQuery.data),
     [rolloutQuery.data],
   );
+  const servingEntryAvailability = useMemo(() => {
+    const targetCount = servingQuery.data?.targets.length ?? 0;
+
+    return {
+      enabled: targetCount > 0,
+      reason:
+        targetCount > 0
+          ? '打开流量权重后，提交前会校验权重合计和 serving 状态。'
+          : '当前没有 serving targets，不能提交流量调整。',
+    };
+  }, [servingQuery.data?.targets.length]);
+  const rolloutControlEntryAvailability = useMemo(() => {
+    const enabled = Object.values(rolloutActionAvailability).some(
+      (availability) => availability.enabled,
+    );
+
+    return {
+      enabled,
+      reason: enabled
+        ? '打开发布控制后，只会保留当前 rollout 生命周期允许的动作。'
+        : rolloutActionAvailability.advance.reason,
+    };
+  }, [rolloutActionAvailability]);
+  const deploymentDeactivateAvailability = useMemo(
+    () => buildDeploymentDeactivateAvailability(inspectedDeployment),
+    [inspectedDeployment],
+  );
 
   const invalidateDetailQueries = useCallback(async () => {
     await invalidateServiceResourceQueries(queryClient);
@@ -1703,6 +1731,13 @@ const DeploymentsPage: React.FC = () => {
     mutationFn: (deploymentId: string) => {
       if (!deploymentId.trim()) {
         throw new Error('请选择 deployment。');
+      }
+      const deployment = deploymentsQuery.data?.deployments.find(
+        (item) => item.deploymentId === deploymentId,
+      );
+      const availability = buildDeploymentDeactivateAvailability(deployment);
+      if (!availability.enabled) {
+        throw new Error(availability.reason);
       }
 
       return servicesApi.deactivateDeployment(
@@ -2387,18 +2422,32 @@ const DeploymentsPage: React.FC = () => {
               >
                 部署候选版本
               </Button>
-              <Button
-                icon={<PercentageOutlined />}
-                onClick={() => openDrawer('weights')}
-              >
-                调整流量
-              </Button>
-              <Button
-                icon={<RollbackOutlined />}
-                onClick={() => openDrawer('control')}
-              >
-                发布控制
-              </Button>
+              <Tooltip title={servingEntryAvailability.reason}>
+                <span>
+                  <Button
+                    disabled={!servingEntryAvailability.enabled}
+                    icon={<PercentageOutlined />}
+                    onClick={() => openDrawer('weights')}
+                  >
+                    {servingEntryAvailability.enabled
+                      ? '调整流量'
+                      : '查看流量状态'}
+                  </Button>
+                </span>
+              </Tooltip>
+              <Tooltip title={rolloutControlEntryAvailability.reason}>
+                <span>
+                  <Button
+                    disabled={!rolloutControlEntryAvailability.enabled}
+                    icon={<RollbackOutlined />}
+                    onClick={() => openDrawer('control')}
+                  >
+                    {rolloutControlEntryAvailability.enabled
+                      ? '发布控制'
+                      : '无活动控制'}
+                  </Button>
+                </span>
+              </Tooltip>
             </Space>
           ) : null
         }
@@ -2598,12 +2647,19 @@ const DeploymentsPage: React.FC = () => {
                                 {servingQuery.data.activeRolloutId}
                               </Tag>
                             ) : null}
-                            <Button
-                              icon={<PercentageOutlined />}
-                              onClick={() => openDrawer('weights')}
-                            >
-                              调整流量
-                            </Button>
+                            <Tooltip title={servingEntryAvailability.reason}>
+                              <span>
+                                <Button
+                                  disabled={!servingEntryAvailability.enabled}
+                                  icon={<PercentageOutlined />}
+                                  onClick={() => openDrawer('weights')}
+                                >
+                                  {servingEntryAvailability.enabled
+                                    ? '调整流量'
+                                    : '查看流量状态'}
+                                </Button>
+                              </span>
+                            </Tooltip>
                           </Space>
                         }
                       >
@@ -2644,12 +2700,19 @@ const DeploymentsPage: React.FC = () => {
                             <Tag>
                               Generation {trafficQuery.data?.generation ?? 0}
                             </Tag>
-                            <Button
-                              icon={<PercentageOutlined />}
-                              onClick={() => openDrawer('weights')}
-                            >
-                              调整流量
-                            </Button>
+                            <Tooltip title={servingEntryAvailability.reason}>
+                              <span>
+                                <Button
+                                  disabled={!servingEntryAvailability.enabled}
+                                  icon={<PercentageOutlined />}
+                                  onClick={() => openDrawer('weights')}
+                                >
+                                  {servingEntryAvailability.enabled
+                                    ? '调整流量'
+                                    : '查看流量状态'}
+                                </Button>
+                              </span>
+                            </Tooltip>
                           </Space>
                         }
                       >
@@ -3380,22 +3443,29 @@ const DeploymentsPage: React.FC = () => {
                     >
                       调整流量
                     </Button>
-                    <Button
-                      danger
-                      icon={<StopOutlined />}
-                      loading={
-                        deactivateMutation.isPending &&
-                        deactivateMutation.variables ===
-                          inspectedDeployment.deploymentId
-                      }
-                      onClick={() =>
-                        deactivateMutation.mutate(
-                          inspectedDeployment.deploymentId,
-                        )
-                      }
-                    >
-                      停用 deployment
-                    </Button>
+                    <Tooltip title={deploymentDeactivateAvailability.reason}>
+                      <span>
+                        <Button
+                          danger
+                          disabled={!deploymentDeactivateAvailability.enabled}
+                          icon={<StopOutlined />}
+                          loading={
+                            deactivateMutation.isPending &&
+                            deactivateMutation.variables ===
+                              inspectedDeployment.deploymentId
+                          }
+                          onClick={() =>
+                            deactivateMutation.mutate(
+                              inspectedDeployment.deploymentId,
+                            )
+                          }
+                        >
+                          {deploymentDeactivateAvailability.enabled
+                            ? '停用 deployment'
+                            : '不可停用'}
+                        </Button>
+                      </span>
+                    </Tooltip>
                   </Space>
                 </DrawerSection>
               </div>

--- a/apps/aevatar-console-web/src/pages/Deployments/index.tsx
+++ b/apps/aevatar-console-web/src/pages/Deployments/index.tsx
@@ -82,6 +82,21 @@ import {
   summaryFieldLabelStyle,
   summaryMetricValueStyle,
 } from "@/shared/ui/proComponents";
+import {
+  buildDeploymentReleaseHandoff,
+  type DeploymentReleaseHandoff,
+  type DeploymentReleaseHandoffAction,
+} from "./releaseHandoff";
+import {
+  buildDeploymentReleaseEvidenceSnapshot,
+  type DeploymentReleaseEvidenceSnapshot,
+  type DeploymentReleaseEvidenceStatus,
+} from "./releaseEvidence";
+import {
+  buildRolloutActionAvailability,
+  type RolloutControlAction,
+} from "./releaseActionAvailability";
+import { buildServingTargetPlanStatus } from "./servingTargetPlan";
 
 type DeploymentWorkbenchView =
   | "catalog"
@@ -90,6 +105,14 @@ type DeploymentWorkbenchView =
   | "traffic";
 
 type DeploymentDrawerTab = "candidate" | "weights" | "control";
+
+type RolloutControlDefinition = {
+  action: RolloutControlAction;
+  danger?: boolean;
+  icon: React.ReactNode;
+  label: string;
+  primary?: boolean;
+};
 
 type DeploymentDrawerState = {
   open: boolean;
@@ -161,6 +184,30 @@ const compactMonoValueStyle: React.CSSProperties = {
   textOverflow: "ellipsis",
   whiteSpace: "nowrap",
 };
+const rolloutControlDefinitions: RolloutControlDefinition[] = [
+  {
+    action: "advance",
+    icon: <SendOutlined />,
+    label: "推进 rollout",
+    primary: true,
+  },
+  {
+    action: "pause",
+    icon: <PauseCircleOutlined />,
+    label: "暂停",
+  },
+  {
+    action: "resume",
+    icon: <ReloadOutlined />,
+    label: "恢复",
+  },
+  {
+    action: "rollback",
+    danger: true,
+    icon: <RollbackOutlined />,
+    label: "回滚 rollout",
+  },
+];
 
 function buildScopePreview(
   tenantId: string,
@@ -882,6 +929,153 @@ const DrawerSection: React.FC<{
   );
 };
 
+const ReleaseHandoffPanel: React.FC<{
+  evidence: DeploymentReleaseEvidenceSnapshot;
+  handoff: DeploymentReleaseHandoff;
+  onClose: () => void;
+  onOpenEvidence: () => void;
+}> = ({ evidence, handoff, onClose, onOpenEvidence }) => {
+  const { token } = theme.useToken();
+  const surfaceToken = token as AevatarThemeSurfaceToken;
+  const statusCopy: Record<
+    DeploymentReleaseEvidenceStatus,
+    {
+      color: string;
+      label: string;
+    }
+  > = {
+    observed: {
+      color: "green",
+      label: "已观察",
+    },
+    pending: {
+      color: "gold",
+      label: "待观察",
+    },
+    review: {
+      color: "blue",
+      label: "需核对",
+    },
+  };
+
+  return (
+    <section
+      aria-label="release action handoff"
+      style={{
+        background: "rgba(255, 251, 230, 0.72)",
+        border: `1px solid ${surfaceToken.colorWarningBorder}`,
+        borderRadius: surfaceToken.borderRadiusLG,
+        display: "flex",
+        flexDirection: "column",
+        gap: 14,
+        padding: 16,
+      }}
+    >
+      <div
+        style={{
+          alignItems: "flex-start",
+          display: "flex",
+          gap: 12,
+          justifyContent: "space-between",
+        }}
+      >
+        <Space orientation="vertical" size={4}>
+          <Space wrap size={[8, 8]}>
+            <Tag color="gold" style={compactHintTagStyle}>
+              {handoff.pendingLabel}
+            </Tag>
+            <Tag color="blue" style={compactHintTagStyle}>
+              {handoff.evidenceViewLabel}
+            </Tag>
+          </Space>
+          <Typography.Text
+            strong
+            style={{
+              color: surfaceToken.colorTextHeading,
+              fontSize: 15,
+            }}
+          >
+            {handoff.title}
+          </Typography.Text>
+          <Typography.Text style={{ color: surfaceToken.colorTextSecondary }}>
+            {handoff.evidenceDescription}
+          </Typography.Text>
+          <Typography.Text strong style={{ color: surfaceToken.colorText }}>
+            {evidence.summary}
+          </Typography.Text>
+        </Space>
+        <Space wrap size={[8, 8]} style={{ justifyContent: "flex-end" }}>
+          <Button size="small" onClick={onOpenEvidence}>
+            查看{handoff.evidenceViewLabel}证据
+          </Button>
+          <Button size="small" type="text" onClick={onClose}>
+            关闭
+          </Button>
+        </Space>
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gap: 8,
+          gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))",
+        }}
+      >
+        {handoff.summaryItems.map((item) => (
+          <div
+            key={`${handoff.id}-${item.label}`}
+            style={{
+              background: surfaceToken.colorBgContainer,
+              border: `1px solid ${surfaceToken.colorBorderSecondary}`,
+              borderRadius: surfaceToken.borderRadius,
+              minWidth: 0,
+              padding: "10px 12px",
+            }}
+          >
+            <Typography.Text style={summaryFieldLabelStyle}>
+              {item.label}
+            </Typography.Text>
+            <div style={{ marginTop: 4, minWidth: 0 }}>
+              <CompactIdentifierText
+                color={surfaceToken.colorText}
+                maxWidth="100%"
+                singleLine
+                value={item.value}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {evidence.checks.map((check) => (
+          <div
+            key={`${handoff.id}-${check.key}`}
+            style={{
+              alignItems: "flex-start",
+              display: "grid",
+              gap: 8,
+              gridTemplateColumns: "auto minmax(0, 1fr)",
+            }}
+          >
+            <Tag color={statusCopy[check.status].color} style={compactHintTagStyle}>
+              {statusCopy[check.status].label}
+            </Tag>
+            <Space orientation="vertical" size={2} style={{ minWidth: 0 }}>
+              <Typography.Text strong style={{ color: surfaceToken.colorText }}>
+                {check.label}
+              </Typography.Text>
+              <Typography.Text style={{ color: surfaceToken.colorTextSecondary }}>
+                {check.detail}
+              </Typography.Text>
+            </Space>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};
+
 const DeploymentsPage: React.FC = () => {
   const { token } = theme.useToken();
   const surfaceToken = token as AevatarThemeSurfaceToken;
@@ -914,6 +1108,8 @@ const DeploymentsPage: React.FC = () => {
   >([]);
   const [candidateRevisionId, setCandidateRevisionId] = useState("");
   const [notice, setNotice] = useState<DeploymentNotice | null>(null);
+  const [releaseHandoff, setReleaseHandoff] =
+    useState<DeploymentReleaseHandoff | null>(null);
 
   const authSessionQuery = useQuery({
     queryKey: ["deployments", "auth-session"],
@@ -1257,6 +1453,34 @@ const DeploymentsPage: React.FC = () => {
   const deploymentInventoryReady =
     servicesQuery.data !== undefined && !servicesQuery.error;
 
+  const releaseEvidence = useMemo(
+    () =>
+      releaseHandoff
+        ? buildDeploymentReleaseEvidenceSnapshot({
+            deployments: deploymentsQuery.data?.deployments ?? [],
+            handoff: releaseHandoff,
+            rollout: rolloutQuery.data,
+            serving: servingQuery.data,
+            traffic: trafficQuery.data,
+          })
+        : null,
+    [
+      deploymentsQuery.data?.deployments,
+      releaseHandoff,
+      rolloutQuery.data,
+      servingQuery.data,
+      trafficQuery.data,
+    ],
+  );
+  const servingTargetPlanStatus = useMemo(
+    () => buildServingTargetPlanStatus(editableTargets),
+    [editableTargets],
+  );
+  const rolloutActionAvailability = useMemo(
+    () => buildRolloutActionAvailability(rolloutQuery.data),
+    [rolloutQuery.data],
+  );
+
   const invalidateDetailQueries = useCallback(async () => {
     await invalidateServiceResourceQueries(queryClient);
   }, [queryClient]);
@@ -1278,6 +1502,55 @@ const DeploymentsPage: React.FC = () => {
     [],
   );
 
+  const recordReleaseHandoff = useCallback(
+    (
+      action: DeploymentReleaseHandoffAction,
+      receipt: Parameters<typeof buildDeploymentReleaseHandoff>[0]["receipt"],
+      options: {
+        deploymentId?: string;
+      } = {},
+    ) => {
+      const handoff = buildDeploymentReleaseHandoff({
+        action,
+        activeRevisionId,
+        candidateRevisionId:
+          action === "deploy-candidate" ? candidateRevisionId : undefined,
+        deploymentId:
+          options.deploymentId ||
+          focusDeployment?.deploymentId ||
+          selectedDeploymentId ||
+          undefined,
+        endpointCount: trafficRows.length,
+        receipt,
+        rolloutId: rolloutQuery.data?.rolloutId,
+        rolloutStageLabel:
+          currentStage && rolloutQuery.data
+            ? `${currentStage.stageIndex + 1}/${rolloutQuery.data.stages.length}`
+            : undefined,
+        serviceId: selectedServiceId,
+        targetCount: servingQuery.data?.targets.length ?? editableTargets.length,
+      });
+
+      setReleaseHandoff(handoff);
+      setNotice({
+        message: handoff.noticeMessage,
+        tone: handoff.noticeTone,
+      });
+    },
+    [
+      activeRevisionId,
+      candidateRevisionId,
+      currentStage,
+      editableTargets.length,
+      focusDeployment?.deploymentId,
+      rolloutQuery.data,
+      selectedDeploymentId,
+      selectedServiceId,
+      servingQuery.data?.targets.length,
+      trafficRows.length,
+    ],
+  );
+
   const deployMutation = useMutation({
     mutationFn: () => {
       if (!candidateRevisionId.trim()) {
@@ -1290,45 +1563,51 @@ const DeploymentsPage: React.FC = () => {
       });
     },
     onError: (error: Error) => {
+      setReleaseHandoff(null);
       setNotice({
         message: error.message || "发布候选版本失败。",
         tone: "error",
       });
     },
-    onSuccess: async () => {
-      setNotice({
-        message: "候选版本已提交到发布控制面。",
-        tone: "success",
-      });
+    onSuccess: async (receipt) => {
+      recordReleaseHandoff("deploy-candidate", receipt);
       await invalidateDetailQueries();
     },
   });
 
   const weightsMutation = useMutation({
-    mutationFn: () =>
-      servicesApi.replaceServingTargets(selectedServiceId, {
+    mutationFn: () => {
+      if (!servingTargetPlanStatus.enabled) {
+        throw new Error(servingTargetPlanStatus.reason);
+      }
+
+      return servicesApi.replaceServingTargets(selectedServiceId, {
         ...query,
         reason: drawerReason,
         rolloutId: rolloutQuery.data?.rolloutId,
         targets: editableTargets,
-      }),
+      });
+    },
     onError: (error: Error) => {
+      setReleaseHandoff(null);
       setNotice({
         message: error.message || "应用 serving targets 失败。",
         tone: "error",
       });
     },
-    onSuccess: async () => {
-      setNotice({
-        message: "新的 serving targets 已提交。",
-        tone: "success",
-      });
+    onSuccess: async (receipt) => {
+      recordReleaseHandoff("replace-serving-targets", receipt);
       await invalidateDetailQueries();
     },
   });
 
   const rolloutMutation = useMutation({
     mutationFn: async (kind: "advance" | "pause" | "resume" | "rollback") => {
+      const availability = rolloutActionAvailability[kind];
+      if (!availability.enabled) {
+        throw new Error(availability.reason);
+      }
+
       const rolloutId = rolloutQuery.data?.rolloutId;
       if (!rolloutId) {
         throw new Error("当前服务没有活动 rollout。");
@@ -1355,16 +1634,23 @@ const DeploymentsPage: React.FC = () => {
       });
     },
     onError: (error: Error) => {
+      setReleaseHandoff(null);
       setNotice({
         message: error.message || "发布控制动作提交失败。",
         tone: "error",
       });
     },
-    onSuccess: async () => {
-      setNotice({
-        message: "发布控制动作已提交。",
-        tone: "success",
-      });
+    onSuccess: async (receipt, kind) => {
+      const actionByKind: Record<
+        RolloutControlAction,
+        DeploymentReleaseHandoffAction
+      > = {
+        advance: "advance-rollout",
+        pause: "pause-rollout",
+        resume: "resume-rollout",
+        rollback: "rollback-rollout",
+      };
+      recordReleaseHandoff(actionByKind[kind], receipt);
       await invalidateDetailQueries();
     },
   });
@@ -1382,15 +1668,15 @@ const DeploymentsPage: React.FC = () => {
       );
     },
     onError: (error: Error) => {
+      setReleaseHandoff(null);
       setNotice({
         message: error.message || "停用 deployment 失败。",
         tone: "error",
       });
     },
-    onSuccess: async () => {
-      setNotice({
-        message: "停用 deployment 的请求已提交。",
-        tone: "warning",
+    onSuccess: async (receipt, deploymentId) => {
+      recordReleaseHandoff("deactivate-deployment", receipt, {
+        deploymentId,
       });
       await invalidateDetailQueries();
     },
@@ -1643,6 +1929,7 @@ const DeploymentsPage: React.FC = () => {
     setDraft(nextDraft);
     setSelectedServiceId("");
     setSelectedDeploymentId("");
+    setReleaseHandoff(null);
   }, []);
 
   const openServiceWorkbench = useCallback(
@@ -1650,6 +1937,7 @@ const DeploymentsPage: React.FC = () => {
       setSelectedServiceId(service.serviceId);
       setSelectedDeploymentId(service.deploymentId || "");
       setInspectorState({ open: false });
+      setReleaseHandoff(null);
       setView("catalog");
     },
     [],
@@ -1659,6 +1947,7 @@ const DeploymentsPage: React.FC = () => {
     setSelectedServiceId("");
     setSelectedDeploymentId("");
     setInspectorState({ open: false });
+    setReleaseHandoff(null);
     setDrawerState((current) => ({
       ...current,
       open: false,
@@ -1689,6 +1978,7 @@ const DeploymentsPage: React.FC = () => {
     setSelectedDeploymentId("");
     setCandidateRevisionId("");
     setDrawerReason("");
+    setReleaseHandoff(null);
     setView("catalog");
   }, [isScopeDirty, query, resolvedScope?.scopeId]);
 
@@ -2034,6 +2324,15 @@ const DeploymentsPage: React.FC = () => {
           <AevatarInspectorEmpty description="选择一个服务" />
         ) : (
           <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            {releaseHandoff && releaseEvidence ? (
+              <ReleaseHandoffPanel
+                evidence={releaseEvidence}
+                handoff={releaseHandoff}
+                onClose={() => setReleaseHandoff(null)}
+                onOpenEvidence={() => setView(releaseHandoff.evidenceView)}
+              />
+            ) : null}
+
             <WorkbenchSection title="发布摘要">
               <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
                 <Space wrap size={[8, 8]}>
@@ -2571,14 +2870,25 @@ const DeploymentsPage: React.FC = () => {
                       value={drawerReason}
                       onChange={(event) => setDrawerReason(event.target.value)}
                     />
-                    <Button
-                      icon={<PercentageOutlined />}
-                      loading={weightsMutation.isPending}
-                      onClick={() => weightsMutation.mutate()}
-                      type="primary"
-                    >
-                      应用权重
-                    </Button>
+                    <Alert
+                      message={servingTargetPlanStatus.summary}
+                      description={servingTargetPlanStatus.reason}
+                      showIcon
+                      type={servingTargetPlanStatus.enabled ? "info" : "warning"}
+                    />
+                    <Tooltip title={servingTargetPlanStatus.reason}>
+                      <span style={{ display: "inline-flex", width: "fit-content" }}>
+                        <Button
+                          disabled={!servingTargetPlanStatus.enabled}
+                          icon={<PercentageOutlined />}
+                          loading={weightsMutation.isPending}
+                          onClick={() => weightsMutation.mutate()}
+                          type="primary"
+                        >
+                          应用权重
+                        </Button>
+                      </span>
+                    </Tooltip>
                   </div>
                 ),
                 key: "weights",
@@ -2598,37 +2908,47 @@ const DeploymentsPage: React.FC = () => {
                       value={drawerReason}
                       onChange={(event) => setDrawerReason(event.target.value)}
                     />
+                    <Alert
+                      message={
+                        rolloutQuery.data?.rolloutId
+                          ? `当前 rollout 状态：${formatAevatarStatusLabel(rolloutQuery.data.status || "unknown")}`
+                          : "当前没有活动 rollout"
+                      }
+                      description={
+                        rolloutQuery.data?.rolloutId
+                          ? "只有与当前生命周期匹配的控制动作会保持可执行；提交后仍需等待证据刷新。"
+                          : "发布控制动作需要先存在活动 rollout。"
+                      }
+                      showIcon
+                      type={rolloutQuery.data?.rolloutId ? "info" : "warning"}
+                    />
                     <Space wrap size={[8, 8]}>
-                      <Button
-                        icon={<SendOutlined />}
-                        loading={rolloutMutation.isPending}
-                        onClick={() => rolloutMutation.mutate("advance")}
-                        type="primary"
-                      >
-                        推进 rollout
-                      </Button>
-                      <Button
-                        icon={<PauseCircleOutlined />}
-                        loading={rolloutMutation.isPending}
-                        onClick={() => rolloutMutation.mutate("pause")}
-                      >
-                        暂停
-                      </Button>
-                      <Button
-                        icon={<ReloadOutlined />}
-                        loading={rolloutMutation.isPending}
-                        onClick={() => rolloutMutation.mutate("resume")}
-                      >
-                        恢复
-                      </Button>
-                      <Button
-                        danger
-                        icon={<RollbackOutlined />}
-                        loading={rolloutMutation.isPending}
-                        onClick={() => rolloutMutation.mutate("rollback")}
-                      >
-                        回滚 rollout
-                      </Button>
+                      {rolloutControlDefinitions.map((definition) => {
+                        const availability =
+                          rolloutActionAvailability[definition.action];
+
+                        return (
+                          <Tooltip
+                            key={definition.action}
+                            title={availability.reason}
+                          >
+                            <span>
+                              <Button
+                                danger={definition.danger}
+                                disabled={!availability.enabled}
+                                icon={definition.icon}
+                                loading={rolloutMutation.isPending}
+                                onClick={() =>
+                                  rolloutMutation.mutate(definition.action)
+                                }
+                                type={definition.primary ? "primary" : "default"}
+                              >
+                                {definition.label}
+                              </Button>
+                            </span>
+                          </Tooltip>
+                        );
+                      })}
                     </Space>
                   </div>
                 ),

--- a/apps/aevatar-console-web/src/pages/Deployments/releaseActionAvailability.test.ts
+++ b/apps/aevatar-console-web/src/pages/Deployments/releaseActionAvailability.test.ts
@@ -1,0 +1,60 @@
+import { buildRolloutActionAvailability } from "./releaseActionAvailability";
+
+describe("buildRolloutActionAvailability", () => {
+  const rollout = {
+    baselineTargets: [],
+    currentStageIndex: 0,
+    displayName: "March Canary",
+    failureReason: "",
+    rolloutId: "rollout-1",
+    serviceKey: "scope-1:trade-agent",
+    stages: [],
+    startedAt: "2026-03-30T10:00:00Z",
+    status: "canary",
+    updatedAt: "2026-03-30T10:05:00Z",
+  };
+
+  it("disables every control when there is no active rollout", () => {
+    const availability = buildRolloutActionAvailability(null);
+
+    expect(availability.advance.enabled).toBe(false);
+    expect(availability.pause.enabled).toBe(false);
+    expect(availability.resume.enabled).toBe(false);
+    expect(availability.rollback.enabled).toBe(false);
+    expect(availability.advance.reason).toContain("没有活动 rollout");
+  });
+
+  it("allows active rollout advance, pause, and rollback while keeping resume honest", () => {
+    const availability = buildRolloutActionAvailability(rollout);
+
+    expect(availability.advance.enabled).toBe(true);
+    expect(availability.pause.enabled).toBe(true);
+    expect(availability.resume.enabled).toBe(false);
+    expect(availability.rollback.enabled).toBe(true);
+    expect(availability.resume.reason).toContain("paused");
+  });
+
+  it("allows only resume and rollback when the rollout is paused", () => {
+    const availability = buildRolloutActionAvailability({
+      ...rollout,
+      status: "paused",
+    });
+
+    expect(availability.advance.enabled).toBe(false);
+    expect(availability.pause.enabled).toBe(false);
+    expect(availability.resume.enabled).toBe(true);
+    expect(availability.rollback.enabled).toBe(true);
+    expect(availability.advance.reason).toContain("先恢复");
+  });
+
+  it("disables controls for terminal rollout statuses", () => {
+    const availability = buildRolloutActionAvailability({
+      ...rollout,
+      status: "completed",
+    });
+
+    expect(availability.advance.enabled).toBe(false);
+    expect(availability.rollback.enabled).toBe(false);
+    expect(availability.rollback.reason).toContain("不可提交");
+  });
+});

--- a/apps/aevatar-console-web/src/pages/Deployments/releaseActionAvailability.test.ts
+++ b/apps/aevatar-console-web/src/pages/Deployments/releaseActionAvailability.test.ts
@@ -1,60 +1,73 @@
-import { buildRolloutActionAvailability } from "./releaseActionAvailability";
+import { buildRolloutActionAvailability } from './releaseActionAvailability';
 
-describe("buildRolloutActionAvailability", () => {
+describe('buildRolloutActionAvailability', () => {
   const rollout = {
     baselineTargets: [],
     currentStageIndex: 0,
-    displayName: "March Canary",
-    failureReason: "",
-    rolloutId: "rollout-1",
-    serviceKey: "scope-1:trade-agent",
+    displayName: 'March Canary',
+    failureReason: '',
+    rolloutId: 'rollout-1',
+    serviceKey: 'scope-1:trade-agent',
     stages: [],
-    startedAt: "2026-03-30T10:00:00Z",
-    status: "canary",
-    updatedAt: "2026-03-30T10:05:00Z",
+    startedAt: '2026-03-30T10:00:00Z',
+    status: 'canary',
+    updatedAt: '2026-03-30T10:05:00Z',
   };
 
-  it("disables every control when there is no active rollout", () => {
+  it('disables every control when there is no active rollout', () => {
     const availability = buildRolloutActionAvailability(null);
 
     expect(availability.advance.enabled).toBe(false);
     expect(availability.pause.enabled).toBe(false);
     expect(availability.resume.enabled).toBe(false);
     expect(availability.rollback.enabled).toBe(false);
-    expect(availability.advance.reason).toContain("没有活动 rollout");
+    expect(availability.advance.reason).toContain('没有活动 rollout');
   });
 
-  it("allows active rollout advance, pause, and rollback while keeping resume honest", () => {
+  it('allows active rollout advance, pause, and rollback while keeping resume honest', () => {
     const availability = buildRolloutActionAvailability(rollout);
 
     expect(availability.advance.enabled).toBe(true);
     expect(availability.pause.enabled).toBe(true);
     expect(availability.resume.enabled).toBe(false);
     expect(availability.rollback.enabled).toBe(true);
-    expect(availability.resume.reason).toContain("paused");
+    expect(availability.resume.reason).toContain('paused');
   });
 
-  it("allows only resume and rollback when the rollout is paused", () => {
+  it('allows only resume and rollback when the rollout is paused', () => {
     const availability = buildRolloutActionAvailability({
       ...rollout,
-      status: "paused",
+      status: 'paused',
     });
 
     expect(availability.advance.enabled).toBe(false);
     expect(availability.pause.enabled).toBe(false);
     expect(availability.resume.enabled).toBe(true);
     expect(availability.rollback.enabled).toBe(true);
-    expect(availability.advance.reason).toContain("先恢复");
+    expect(availability.advance.reason).toContain('先恢复');
   });
 
-  it("disables controls for terminal rollout statuses", () => {
+  it('disables controls for terminal rollout statuses', () => {
     const availability = buildRolloutActionAvailability({
       ...rollout,
-      status: "completed",
+      status: 'completed',
     });
 
     expect(availability.advance.enabled).toBe(false);
     expect(availability.rollback.enabled).toBe(false);
-    expect(availability.rollback.reason).toContain("不可提交");
+    expect(availability.rollback.reason).toContain('不可提交');
+  });
+
+  it('treats RolledBack as a terminal rollout status', () => {
+    const availability = buildRolloutActionAvailability({
+      ...rollout,
+      status: 'RolledBack',
+    });
+
+    expect(availability.advance.enabled).toBe(false);
+    expect(availability.pause.enabled).toBe(false);
+    expect(availability.resume.enabled).toBe(false);
+    expect(availability.rollback.enabled).toBe(false);
+    expect(availability.advance.reason).toContain('不可提交');
   });
 });

--- a/apps/aevatar-console-web/src/pages/Deployments/releaseActionAvailability.ts
+++ b/apps/aevatar-console-web/src/pages/Deployments/releaseActionAvailability.ts
@@ -1,6 +1,6 @@
-import type { ServiceRolloutSnapshot } from "@/shared/models/services";
+import type { ServiceRolloutSnapshot } from '@/shared/models/services';
 
-export type RolloutControlAction = "advance" | "pause" | "resume" | "rollback";
+export type RolloutControlAction = 'advance' | 'pause' | 'resume' | 'rollback';
 
 export type ReleaseActionAvailability = {
   enabled: boolean;
@@ -8,7 +8,7 @@ export type ReleaseActionAvailability = {
 };
 
 function normalizeStatus(status: string | null | undefined): string {
-  return (status ?? "").trim().toLowerCase();
+  return (status ?? '').replace(/[^a-z0-9]/gi, '').toLowerCase();
 }
 
 function hasAnyStatus(status: string, patterns: readonly string[]): boolean {
@@ -19,7 +19,7 @@ export function buildRolloutActionAvailability(
   rollout: ServiceRolloutSnapshot | null | undefined,
 ): Record<RolloutControlAction, ReleaseActionAvailability> {
   if (!rollout?.rolloutId?.trim()) {
-    const reason = "当前没有活动 rollout，不能提交 rollout 控制动作。";
+    const reason = '当前没有活动 rollout，不能提交 rollout 控制动作。';
     return {
       advance: { enabled: false, reason },
       pause: { enabled: false, reason },
@@ -30,19 +30,20 @@ export function buildRolloutActionAvailability(
 
   const status = normalizeStatus(rollout.status);
   const terminal = hasAnyStatus(status, [
-    "cancel",
-    "complete",
-    "done",
-    "fail",
-    "inactive",
-    "retire",
-    "success",
+    'cancel',
+    'complete',
+    'done',
+    'fail',
+    'inactive',
+    'rolledback',
+    'retire',
+    'success',
   ]);
-  const paused = hasAnyStatus(status, ["pause"]);
-  const rollbackActive = hasAnyStatus(status, ["rollback", "rolling-back"]);
+  const paused = hasAnyStatus(status, ['pause']);
+  const rollbackActive = hasAnyStatus(status, ['rollback', 'rollingback']);
 
   if (terminal) {
-    const reason = `当前 rollout 状态为 ${rollout.status || "terminal"}，控制动作已不可提交。`;
+    const reason = `当前 rollout 状态为 ${rollout.status || 'terminal'}，控制动作已不可提交。`;
     return {
       advance: { enabled: false, reason },
       pause: { enabled: false, reason },
@@ -52,7 +53,7 @@ export function buildRolloutActionAvailability(
   }
 
   if (rollbackActive) {
-    const reason = "当前 rollout 已在回滚流程中，等待回滚证据刷新后再操作。";
+    const reason = '当前 rollout 已在回滚流程中，等待回滚证据刷新后再操作。';
     return {
       advance: { enabled: false, reason },
       pause: { enabled: false, reason },
@@ -65,24 +66,24 @@ export function buildRolloutActionAvailability(
     advance: {
       enabled: !paused,
       reason: paused
-        ? "当前 rollout 已暂停；请先恢复，再推进到下一阶段。"
-        : "推进会提交命令，仍需等待 rollout/serving/traffic 证据刷新。",
+        ? '当前 rollout 已暂停；请先恢复，再推进到下一阶段。'
+        : '推进会提交命令，仍需等待 rollout/serving/traffic 证据刷新。',
     },
     pause: {
       enabled: !paused,
       reason: paused
-        ? "当前 rollout 已暂停，不需要再次暂停。"
-        : "暂停会提交命令，仍需等待 rollout 状态显示 paused。",
+        ? '当前 rollout 已暂停，不需要再次暂停。'
+        : '暂停会提交命令，仍需等待 rollout 状态显示 paused。',
     },
     resume: {
       enabled: paused,
       reason: paused
-        ? "恢复会提交命令，仍需等待 rollout 状态重新活动。"
-        : "只有 paused 状态的 rollout 才需要恢复。",
+        ? '恢复会提交命令，仍需等待 rollout 状态重新活动。'
+        : '只有 paused 状态的 rollout 才需要恢复。',
     },
     rollback: {
       enabled: true,
-      reason: "回滚会提交命令，仍需等待 serving 回到 baseline 证据。",
+      reason: '回滚会提交命令，仍需等待 serving 回到 baseline 证据。',
     },
   };
 }

--- a/apps/aevatar-console-web/src/pages/Deployments/releaseActionAvailability.ts
+++ b/apps/aevatar-console-web/src/pages/Deployments/releaseActionAvailability.ts
@@ -1,0 +1,88 @@
+import type { ServiceRolloutSnapshot } from "@/shared/models/services";
+
+export type RolloutControlAction = "advance" | "pause" | "resume" | "rollback";
+
+export type ReleaseActionAvailability = {
+  enabled: boolean;
+  reason: string;
+};
+
+function normalizeStatus(status: string | null | undefined): string {
+  return (status ?? "").trim().toLowerCase();
+}
+
+function hasAnyStatus(status: string, patterns: readonly string[]): boolean {
+  return patterns.some((pattern) => status.includes(pattern));
+}
+
+export function buildRolloutActionAvailability(
+  rollout: ServiceRolloutSnapshot | null | undefined,
+): Record<RolloutControlAction, ReleaseActionAvailability> {
+  if (!rollout?.rolloutId?.trim()) {
+    const reason = "当前没有活动 rollout，不能提交 rollout 控制动作。";
+    return {
+      advance: { enabled: false, reason },
+      pause: { enabled: false, reason },
+      resume: { enabled: false, reason },
+      rollback: { enabled: false, reason },
+    };
+  }
+
+  const status = normalizeStatus(rollout.status);
+  const terminal = hasAnyStatus(status, [
+    "cancel",
+    "complete",
+    "done",
+    "fail",
+    "inactive",
+    "retire",
+    "success",
+  ]);
+  const paused = hasAnyStatus(status, ["pause"]);
+  const rollbackActive = hasAnyStatus(status, ["rollback", "rolling-back"]);
+
+  if (terminal) {
+    const reason = `当前 rollout 状态为 ${rollout.status || "terminal"}，控制动作已不可提交。`;
+    return {
+      advance: { enabled: false, reason },
+      pause: { enabled: false, reason },
+      resume: { enabled: false, reason },
+      rollback: { enabled: false, reason },
+    };
+  }
+
+  if (rollbackActive) {
+    const reason = "当前 rollout 已在回滚流程中，等待回滚证据刷新后再操作。";
+    return {
+      advance: { enabled: false, reason },
+      pause: { enabled: false, reason },
+      resume: { enabled: false, reason },
+      rollback: { enabled: false, reason },
+    };
+  }
+
+  return {
+    advance: {
+      enabled: !paused,
+      reason: paused
+        ? "当前 rollout 已暂停；请先恢复，再推进到下一阶段。"
+        : "推进会提交命令，仍需等待 rollout/serving/traffic 证据刷新。",
+    },
+    pause: {
+      enabled: !paused,
+      reason: paused
+        ? "当前 rollout 已暂停，不需要再次暂停。"
+        : "暂停会提交命令，仍需等待 rollout 状态显示 paused。",
+    },
+    resume: {
+      enabled: paused,
+      reason: paused
+        ? "恢复会提交命令，仍需等待 rollout 状态重新活动。"
+        : "只有 paused 状态的 rollout 才需要恢复。",
+    },
+    rollback: {
+      enabled: true,
+      reason: "回滚会提交命令，仍需等待 serving 回到 baseline 证据。",
+    },
+  };
+}

--- a/apps/aevatar-console-web/src/pages/Deployments/releaseEvidence.test.ts
+++ b/apps/aevatar-console-web/src/pages/Deployments/releaseEvidence.test.ts
@@ -1,18 +1,19 @@
-import { buildDeploymentReleaseEvidenceSnapshot } from "./releaseEvidence";
-import { buildDeploymentReleaseHandoff } from "./releaseHandoff";
+import { buildDeploymentReleaseEvidenceSnapshot } from './releaseEvidence';
+import { buildDeploymentReleaseHandoff } from './releaseHandoff';
 
-describe("buildDeploymentReleaseEvidenceSnapshot", () => {
-  it("marks candidate deploy evidence observed only when rollout, serving, and traffic snapshots show it", () => {
+describe('buildDeploymentReleaseEvidenceSnapshot', () => {
+  it('marks candidate deploy evidence observed only when rollout, serving, and traffic snapshots show it', () => {
     const handoff = buildDeploymentReleaseHandoff({
-      action: "deploy-candidate",
-      activeRevisionId: "rev-11",
-      candidateRevisionId: "rev-12",
+      action: 'deploy-candidate',
+      activeRevisionId: 'rev-11',
+      candidateRevisionId: 'rev-12',
       receipt: {
-        commandId: "cmd-1",
-        correlationId: "corr-1",
+        commandId: 'cmd-1',
+        correlationId: 'corr-1',
       },
-      rolloutId: "rollout-1",
-      serviceId: "trade-agent",
+      createdAt: '2026-03-30T10:00:00Z',
+      rolloutId: 'rollout-1',
+      serviceId: 'trade-agent',
     });
 
     const evidence = buildDeploymentReleaseEvidenceSnapshot({
@@ -21,167 +22,383 @@ describe("buildDeploymentReleaseEvidenceSnapshot", () => {
       rollout: {
         baselineTargets: [],
         currentStageIndex: 0,
-        displayName: "Canary",
-        failureReason: "",
-        rolloutId: "rollout-1",
-        serviceKey: "scope-1:trade-agent",
+        displayName: 'Canary',
+        failureReason: '',
+        rolloutId: 'rollout-1',
+        serviceKey: 'scope-1:trade-agent',
         stages: [],
-        startedAt: "2026-03-30T10:00:00Z",
-        status: "canary",
-        updatedAt: "2026-03-30T10:05:00Z",
+        startedAt: '2026-03-30T10:00:00Z',
+        status: 'canary',
+        updatedAt: '2026-03-30T10:05:00Z',
       },
       serving: {
-        activeRolloutId: "rollout-1",
+        activeRolloutId: 'rollout-1',
         generation: 4,
-        serviceKey: "scope-1:trade-agent",
+        serviceKey: 'scope-1:trade-agent',
         targets: [
           {
             allocationWeight: 10,
-            deploymentId: "dep-2",
-            enabledEndpointIds: ["chat"],
-            primaryActorId: "actor-2",
-            revisionId: "rev-12",
-            servingState: "canary",
+            deploymentId: 'dep-2',
+            enabledEndpointIds: ['chat'],
+            primaryActorId: 'actor-2',
+            revisionId: 'rev-12',
+            servingState: 'canary',
           },
         ],
-        updatedAt: "2026-03-30T10:06:00Z",
+        updatedAt: '2026-03-30T10:06:00Z',
       },
       traffic: {
-        activeRolloutId: "rollout-1",
+        activeRolloutId: 'rollout-1',
         endpoints: [
           {
-            endpointId: "chat",
+            endpointId: 'chat',
             targets: [
               {
                 allocationWeight: 10,
-                deploymentId: "dep-2",
-                primaryActorId: "actor-2",
-                revisionId: "rev-12",
-                servingState: "canary",
+                deploymentId: 'dep-2',
+                primaryActorId: 'actor-2',
+                revisionId: 'rev-12',
+                servingState: 'canary',
               },
             ],
           },
         ],
         generation: 4,
-        serviceKey: "scope-1:trade-agent",
-        updatedAt: "2026-03-30T10:06:00Z",
+        serviceKey: 'scope-1:trade-agent',
+        updatedAt: '2026-03-30T10:06:00Z',
       },
     });
 
     expect(evidence.observedCount).toBe(3);
-    expect(evidence.summary).toBe("所有关键证据都已出现或需要人工核对。");
+    expect(evidence.summary).toBe('所有关键证据都已在本次提交后观察到。');
     expect(evidence.checks.map((check) => check.status)).toEqual([
-      "observed",
-      "observed",
-      "observed",
+      'observed',
+      'observed',
+      'observed',
     ]);
   });
 
-  it("keeps candidate deploy evidence pending when serving and traffic do not show the candidate", () => {
+  it('keeps candidate deploy evidence pending when serving and traffic do not show the candidate', () => {
     const handoff = buildDeploymentReleaseHandoff({
-      action: "deploy-candidate",
-      activeRevisionId: "rev-11",
-      candidateRevisionId: "rev-12",
+      action: 'deploy-candidate',
+      activeRevisionId: 'rev-11',
+      candidateRevisionId: 'rev-12',
       receipt: {
-        commandId: "cmd-1",
-        correlationId: "corr-1",
+        commandId: 'cmd-1',
+        correlationId: 'corr-1',
       },
-      serviceId: "trade-agent",
+      createdAt: '2026-03-30T10:10:00Z',
+      serviceId: 'trade-agent',
     });
 
     const evidence = buildDeploymentReleaseEvidenceSnapshot({
       deployments: [],
       handoff,
       serving: {
-        activeRolloutId: "rollout-1",
+        activeRolloutId: 'rollout-1',
         generation: 3,
-        serviceKey: "scope-1:trade-agent",
+        serviceKey: 'scope-1:trade-agent',
         targets: [
           {
             allocationWeight: 100,
-            deploymentId: "dep-1",
-            enabledEndpointIds: ["chat"],
-            primaryActorId: "actor-1",
-            revisionId: "rev-11",
-            servingState: "active",
+            deploymentId: 'dep-1',
+            enabledEndpointIds: ['chat'],
+            primaryActorId: 'actor-1',
+            revisionId: 'rev-11',
+            servingState: 'active',
           },
         ],
-        updatedAt: "2026-03-30T10:05:00Z",
+        updatedAt: '2026-03-30T10:05:00Z',
       },
       traffic: {
-        activeRolloutId: "rollout-1",
+        activeRolloutId: 'rollout-1',
         endpoints: [
           {
-            endpointId: "chat",
+            endpointId: 'chat',
             targets: [
               {
                 allocationWeight: 100,
-                deploymentId: "dep-1",
-                primaryActorId: "actor-1",
-                revisionId: "rev-11",
-                servingState: "active",
+                deploymentId: 'dep-1',
+                primaryActorId: 'actor-1',
+                revisionId: 'rev-11',
+                servingState: 'active',
               },
             ],
           },
         ],
         generation: 3,
-        serviceKey: "scope-1:trade-agent",
-        updatedAt: "2026-03-30T10:05:00Z",
+        serviceKey: 'scope-1:trade-agent',
+        updatedAt: '2026-03-30T10:05:00Z',
       },
     });
 
     expect(evidence.observedCount).toBe(0);
-    expect(evidence.summary).toContain("3 项证据仍待观察");
+    expect(evidence.summary).toContain('3 项证据仍待观察');
     expect(evidence.checks.map((check) => check.status)).toEqual([
-      "pending",
-      "pending",
-      "pending",
+      'pending',
+      'pending',
+      'pending',
     ]);
   });
 
-  it("marks deactivate evidence observed after catalog, serving, and traffic stop showing the deployment", () => {
+  it('keeps pre-submit candidate cache in review instead of observed', () => {
     const handoff = buildDeploymentReleaseHandoff({
-      action: "deactivate-deployment",
-      deploymentId: "dep-1",
+      action: 'deploy-candidate',
+      activeRevisionId: 'rev-11',
+      candidateRevisionId: 'rev-12',
+      createdAt: '2026-03-30T10:10:00Z',
       receipt: {
-        commandId: "cmd-7",
-        correlationId: "corr-7",
+        commandId: 'cmd-1',
+        correlationId: 'corr-1',
       },
-      serviceId: "trade-agent",
+      rolloutId: 'rollout-1',
+      serviceId: 'trade-agent',
+    });
+
+    const evidence = buildDeploymentReleaseEvidenceSnapshot({
+      deployments: [],
+      handoff,
+      rollout: {
+        baselineTargets: [],
+        currentStageIndex: 0,
+        displayName: 'Canary',
+        failureReason: '',
+        rolloutId: 'rollout-1',
+        serviceKey: 'scope-1:trade-agent',
+        stages: [],
+        startedAt: '2026-03-30T10:00:00Z',
+        status: 'InProgress',
+        updatedAt: '2026-03-30T10:05:00Z',
+      },
+      serving: {
+        activeRolloutId: 'rollout-1',
+        generation: 4,
+        serviceKey: 'scope-1:trade-agent',
+        targets: [
+          {
+            allocationWeight: 10,
+            deploymentId: 'dep-2',
+            enabledEndpointIds: ['chat'],
+            primaryActorId: 'actor-2',
+            revisionId: 'rev-12',
+            servingState: 'canary',
+          },
+        ],
+        updatedAt: '2026-03-30T10:05:00Z',
+      },
+      traffic: {
+        activeRolloutId: 'rollout-1',
+        endpoints: [
+          {
+            endpointId: 'chat',
+            targets: [
+              {
+                allocationWeight: 10,
+                deploymentId: 'dep-2',
+                primaryActorId: 'actor-2',
+                revisionId: 'rev-12',
+                servingState: 'canary',
+              },
+            ],
+          },
+        ],
+        generation: 4,
+        serviceKey: 'scope-1:trade-agent',
+        updatedAt: '2026-03-30T10:05:00Z',
+      },
+    });
+
+    expect(evidence.observedCount).toBe(0);
+    expect(evidence.summary).toBe(
+      '3 项证据需要人工核对，避免把旧 readmodel 当作本次完成。',
+    );
+    expect(evidence.checks.map((check) => check.status)).toEqual([
+      'review',
+      'review',
+      'review',
+    ]);
+    expect(evidence.checks[1].detail).toContain('早于本次提交');
+  });
+
+  it('marks deactivate evidence observed after catalog, serving, and traffic stop showing the deployment', () => {
+    const handoff = buildDeploymentReleaseHandoff({
+      action: 'deactivate-deployment',
+      deploymentId: 'dep-1',
+      receipt: {
+        commandId: 'cmd-7',
+        correlationId: 'corr-7',
+      },
+      createdAt: '2026-03-30T10:00:00Z',
+      serviceId: 'trade-agent',
     });
 
     const evidence = buildDeploymentReleaseEvidenceSnapshot({
       deployments: [
         {
-          activatedAt: "2026-03-30T10:00:00Z",
-          deploymentId: "dep-1",
-          primaryActorId: "actor-1",
-          revisionId: "rev-11",
-          status: "inactive",
-          updatedAt: "2026-03-30T10:10:00Z",
+          activatedAt: '2026-03-30T10:00:00Z',
+          deploymentId: 'dep-1',
+          primaryActorId: 'actor-1',
+          revisionId: 'rev-11',
+          status: 'inactive',
+          updatedAt: '2026-03-30T10:10:00Z',
         },
       ],
       handoff,
       serving: {
-        activeRolloutId: "",
+        activeRolloutId: '',
         generation: 5,
-        serviceKey: "scope-1:trade-agent",
+        serviceKey: 'scope-1:trade-agent',
         targets: [],
-        updatedAt: "2026-03-30T10:10:00Z",
+        updatedAt: '2026-03-30T10:10:00Z',
       },
       traffic: {
-        activeRolloutId: "",
+        activeRolloutId: '',
         endpoints: [],
         generation: 5,
-        serviceKey: "scope-1:trade-agent",
-        updatedAt: "2026-03-30T10:10:00Z",
+        serviceKey: 'scope-1:trade-agent',
+        updatedAt: '2026-03-30T10:10:00Z',
       },
     });
 
     expect(evidence.checks.map((check) => check.status)).toEqual([
-      "observed",
-      "observed",
-      "observed",
+      'observed',
+      'observed',
+      'observed',
     ]);
+  });
+
+  it('keeps deactivate catalog pending when the deployment is missing', () => {
+    const handoff = buildDeploymentReleaseHandoff({
+      action: 'deactivate-deployment',
+      createdAt: '2026-03-30T10:10:00Z',
+      deploymentId: 'dep-1',
+      receipt: {
+        commandId: 'cmd-7',
+        correlationId: 'corr-7',
+      },
+      serviceId: 'trade-agent',
+    });
+
+    const evidence = buildDeploymentReleaseEvidenceSnapshot({
+      deployments: [],
+      handoff,
+      serving: {
+        activeRolloutId: '',
+        generation: 5,
+        serviceKey: 'scope-1:trade-agent',
+        targets: [],
+        updatedAt: '2026-03-30T10:12:00Z',
+      },
+      traffic: {
+        activeRolloutId: '',
+        endpoints: [],
+        generation: 5,
+        serviceKey: 'scope-1:trade-agent',
+        updatedAt: '2026-03-30T10:12:00Z',
+      },
+    });
+
+    expect(evidence.checks[0]).toEqual(
+      expect.objectContaining({
+        key: 'deployment-inactive',
+        status: 'pending',
+      }),
+    );
+    expect(evidence.checks[0].detail).toContain('出现在 catalog');
+  });
+
+  it('keeps deactivate catalog pending while the deployment is still active', () => {
+    const handoff = buildDeploymentReleaseHandoff({
+      action: 'deactivate-deployment',
+      createdAt: '2026-03-30T10:10:00Z',
+      deploymentId: 'dep-1',
+      receipt: {
+        commandId: 'cmd-7',
+        correlationId: 'corr-7',
+      },
+      serviceId: 'trade-agent',
+    });
+
+    const evidence = buildDeploymentReleaseEvidenceSnapshot({
+      deployments: [
+        {
+          activatedAt: '2026-03-30T10:00:00Z',
+          deploymentId: 'dep-1',
+          primaryActorId: 'actor-1',
+          revisionId: 'rev-11',
+          status: 'active',
+          updatedAt: '2026-03-30T10:12:00Z',
+        },
+      ],
+      handoff,
+      serving: {
+        activeRolloutId: '',
+        generation: 5,
+        serviceKey: 'scope-1:trade-agent',
+        targets: [],
+        updatedAt: '2026-03-30T10:12:00Z',
+      },
+      traffic: {
+        activeRolloutId: '',
+        endpoints: [],
+        generation: 5,
+        serviceKey: 'scope-1:trade-agent',
+        updatedAt: '2026-03-30T10:12:00Z',
+      },
+    });
+
+    expect(evidence.checks[0].status).toBe('pending');
+    expect(evidence.checks[0].detail).toContain('状态离开 active');
+  });
+
+  it('observes rollback when rollout reaches RolledBack after the handoff', () => {
+    const handoff = buildDeploymentReleaseHandoff({
+      action: 'rollback-rollout',
+      createdAt: '2026-03-30T10:10:00Z',
+      receipt: {
+        commandId: 'cmd-6',
+        correlationId: 'corr-6',
+      },
+      rolloutId: 'rollout-1',
+      serviceId: 'trade-agent',
+    });
+
+    const evidence = buildDeploymentReleaseEvidenceSnapshot({
+      deployments: [],
+      handoff,
+      rollout: {
+        baselineTargets: [],
+        currentStageIndex: 0,
+        displayName: 'March Canary',
+        failureReason: '',
+        rolloutId: 'rollout-1',
+        serviceKey: 'scope-1:trade-agent',
+        stages: [],
+        startedAt: '2026-03-30T10:00:00Z',
+        status: 'RolledBack',
+        updatedAt: '2026-03-30T10:12:00Z',
+      },
+      serving: {
+        activeRolloutId: '',
+        generation: 5,
+        serviceKey: 'scope-1:trade-agent',
+        targets: [],
+        updatedAt: '2026-03-30T10:12:00Z',
+      },
+      traffic: {
+        activeRolloutId: '',
+        endpoints: [],
+        generation: 5,
+        serviceKey: 'scope-1:trade-agent',
+        updatedAt: '2026-03-30T10:12:00Z',
+      },
+    });
+
+    expect(evidence.checks[0]).toEqual(
+      expect.objectContaining({
+        key: 'rollout-status',
+        status: 'observed',
+      }),
+    );
   });
 });

--- a/apps/aevatar-console-web/src/pages/Deployments/releaseEvidence.test.ts
+++ b/apps/aevatar-console-web/src/pages/Deployments/releaseEvidence.test.ts
@@ -1,0 +1,187 @@
+import { buildDeploymentReleaseEvidenceSnapshot } from "./releaseEvidence";
+import { buildDeploymentReleaseHandoff } from "./releaseHandoff";
+
+describe("buildDeploymentReleaseEvidenceSnapshot", () => {
+  it("marks candidate deploy evidence observed only when rollout, serving, and traffic snapshots show it", () => {
+    const handoff = buildDeploymentReleaseHandoff({
+      action: "deploy-candidate",
+      activeRevisionId: "rev-11",
+      candidateRevisionId: "rev-12",
+      receipt: {
+        commandId: "cmd-1",
+        correlationId: "corr-1",
+      },
+      rolloutId: "rollout-1",
+      serviceId: "trade-agent",
+    });
+
+    const evidence = buildDeploymentReleaseEvidenceSnapshot({
+      deployments: [],
+      handoff,
+      rollout: {
+        baselineTargets: [],
+        currentStageIndex: 0,
+        displayName: "Canary",
+        failureReason: "",
+        rolloutId: "rollout-1",
+        serviceKey: "scope-1:trade-agent",
+        stages: [],
+        startedAt: "2026-03-30T10:00:00Z",
+        status: "canary",
+        updatedAt: "2026-03-30T10:05:00Z",
+      },
+      serving: {
+        activeRolloutId: "rollout-1",
+        generation: 4,
+        serviceKey: "scope-1:trade-agent",
+        targets: [
+          {
+            allocationWeight: 10,
+            deploymentId: "dep-2",
+            enabledEndpointIds: ["chat"],
+            primaryActorId: "actor-2",
+            revisionId: "rev-12",
+            servingState: "canary",
+          },
+        ],
+        updatedAt: "2026-03-30T10:06:00Z",
+      },
+      traffic: {
+        activeRolloutId: "rollout-1",
+        endpoints: [
+          {
+            endpointId: "chat",
+            targets: [
+              {
+                allocationWeight: 10,
+                deploymentId: "dep-2",
+                primaryActorId: "actor-2",
+                revisionId: "rev-12",
+                servingState: "canary",
+              },
+            ],
+          },
+        ],
+        generation: 4,
+        serviceKey: "scope-1:trade-agent",
+        updatedAt: "2026-03-30T10:06:00Z",
+      },
+    });
+
+    expect(evidence.observedCount).toBe(3);
+    expect(evidence.summary).toBe("所有关键证据都已出现或需要人工核对。");
+    expect(evidence.checks.map((check) => check.status)).toEqual([
+      "observed",
+      "observed",
+      "observed",
+    ]);
+  });
+
+  it("keeps candidate deploy evidence pending when serving and traffic do not show the candidate", () => {
+    const handoff = buildDeploymentReleaseHandoff({
+      action: "deploy-candidate",
+      activeRevisionId: "rev-11",
+      candidateRevisionId: "rev-12",
+      receipt: {
+        commandId: "cmd-1",
+        correlationId: "corr-1",
+      },
+      serviceId: "trade-agent",
+    });
+
+    const evidence = buildDeploymentReleaseEvidenceSnapshot({
+      deployments: [],
+      handoff,
+      serving: {
+        activeRolloutId: "rollout-1",
+        generation: 3,
+        serviceKey: "scope-1:trade-agent",
+        targets: [
+          {
+            allocationWeight: 100,
+            deploymentId: "dep-1",
+            enabledEndpointIds: ["chat"],
+            primaryActorId: "actor-1",
+            revisionId: "rev-11",
+            servingState: "active",
+          },
+        ],
+        updatedAt: "2026-03-30T10:05:00Z",
+      },
+      traffic: {
+        activeRolloutId: "rollout-1",
+        endpoints: [
+          {
+            endpointId: "chat",
+            targets: [
+              {
+                allocationWeight: 100,
+                deploymentId: "dep-1",
+                primaryActorId: "actor-1",
+                revisionId: "rev-11",
+                servingState: "active",
+              },
+            ],
+          },
+        ],
+        generation: 3,
+        serviceKey: "scope-1:trade-agent",
+        updatedAt: "2026-03-30T10:05:00Z",
+      },
+    });
+
+    expect(evidence.observedCount).toBe(0);
+    expect(evidence.summary).toContain("3 项证据仍待观察");
+    expect(evidence.checks.map((check) => check.status)).toEqual([
+      "pending",
+      "pending",
+      "pending",
+    ]);
+  });
+
+  it("marks deactivate evidence observed after catalog, serving, and traffic stop showing the deployment", () => {
+    const handoff = buildDeploymentReleaseHandoff({
+      action: "deactivate-deployment",
+      deploymentId: "dep-1",
+      receipt: {
+        commandId: "cmd-7",
+        correlationId: "corr-7",
+      },
+      serviceId: "trade-agent",
+    });
+
+    const evidence = buildDeploymentReleaseEvidenceSnapshot({
+      deployments: [
+        {
+          activatedAt: "2026-03-30T10:00:00Z",
+          deploymentId: "dep-1",
+          primaryActorId: "actor-1",
+          revisionId: "rev-11",
+          status: "inactive",
+          updatedAt: "2026-03-30T10:10:00Z",
+        },
+      ],
+      handoff,
+      serving: {
+        activeRolloutId: "",
+        generation: 5,
+        serviceKey: "scope-1:trade-agent",
+        targets: [],
+        updatedAt: "2026-03-30T10:10:00Z",
+      },
+      traffic: {
+        activeRolloutId: "",
+        endpoints: [],
+        generation: 5,
+        serviceKey: "scope-1:trade-agent",
+        updatedAt: "2026-03-30T10:10:00Z",
+      },
+    });
+
+    expect(evidence.checks.map((check) => check.status)).toEqual([
+      "observed",
+      "observed",
+      "observed",
+    ]);
+  });
+});

--- a/apps/aevatar-console-web/src/pages/Deployments/releaseEvidence.ts
+++ b/apps/aevatar-console-web/src/pages/Deployments/releaseEvidence.ts
@@ -3,13 +3,10 @@ import type {
   ServiceRolloutSnapshot,
   ServiceServingSetSnapshot,
   ServiceTrafficViewSnapshot,
-} from "@/shared/models/services";
-import type { DeploymentReleaseHandoff } from "./releaseHandoff";
+} from '@/shared/models/services';
+import type { DeploymentReleaseHandoff } from './releaseHandoff';
 
-export type DeploymentReleaseEvidenceStatus =
-  | "observed"
-  | "pending"
-  | "review";
+export type DeploymentReleaseEvidenceStatus = 'observed' | 'pending' | 'review';
 
 export type DeploymentReleaseEvidenceCheck = {
   detail: string;
@@ -32,8 +29,8 @@ export type DeploymentReleaseEvidenceInput = {
   traffic?: ServiceTrafficViewSnapshot | null;
 };
 
-function includesIgnoreCase(value: string | null | undefined, pattern: string): boolean {
-  return (value ?? "").toLowerCase().includes(pattern.toLowerCase());
+function normalizeStatus(value: string | null | undefined): string {
+  return (value ?? '').replace(/[^a-z0-9]/gi, '').toLowerCase();
 }
 
 function readSummaryValue(
@@ -41,7 +38,8 @@ function readSummaryValue(
   label: string,
 ): string {
   return (
-    handoff.summaryItems.find((item) => item.label === label)?.value.trim() ?? ""
+    handoff.summaryItems.find((item) => item.label === label)?.value.trim() ??
+    ''
   );
 }
 
@@ -81,17 +79,74 @@ function hasTrafficRevision(
   );
 }
 
+function occurredAfterHandoff(
+  observedAt: string | null | undefined,
+  handoff: DeploymentReleaseHandoff,
+): boolean {
+  if (!observedAt) {
+    return false;
+  }
+
+  const observedTime = Date.parse(observedAt);
+  const submittedTime = Date.parse(handoff.createdAt);
+  if (Number.isNaN(observedTime) || Number.isNaN(submittedTime)) {
+    return false;
+  }
+
+  return observedTime >= submittedTime;
+}
+
+function buildFreshStatus(
+  observed: boolean,
+  observedAt: string | null | undefined,
+  handoff: DeploymentReleaseHandoff,
+): DeploymentReleaseEvidenceStatus {
+  if (!observed) {
+    return 'pending';
+  }
+
+  return occurredAfterHandoff(observedAt, handoff) ? 'observed' : 'review';
+}
+
+function buildFreshDetail(
+  observed: boolean,
+  observedAt: string | null | undefined,
+  freshDetail: string,
+  staleDetail: string,
+  pendingDetail: string,
+  handoff: DeploymentReleaseHandoff,
+): string {
+  if (!observed) {
+    return pendingDetail;
+  }
+
+  if (occurredAfterHandoff(observedAt, handoff)) {
+    return freshDetail;
+  }
+
+  return staleDetail;
+}
+
 function deploymentIsInactive(
   deployments: readonly ServiceDeploymentSnapshot[],
   deploymentId: string,
 ): boolean {
-  const deployment = deployments.find((item) => item.deploymentId === deploymentId);
+  const deployment = deployments.find(
+    (item) => item.deploymentId === deploymentId,
+  );
   if (!deployment) {
-    return true;
+    return false;
   }
 
   const status = deployment.status.trim().toLowerCase();
-  return status !== "active";
+  return status !== 'active';
+}
+
+function findDeployment(
+  deployments: readonly ServiceDeploymentSnapshot[],
+  deploymentId: string,
+): ServiceDeploymentSnapshot | undefined {
+  return deployments.find((item) => item.deploymentId === deploymentId);
 }
 
 function servingExcludesDeployment(
@@ -125,130 +180,228 @@ export function buildDeploymentReleaseEvidenceSnapshot({
   serving,
   traffic,
 }: DeploymentReleaseEvidenceInput): DeploymentReleaseEvidenceSnapshot {
-  const candidateRevisionId = readSummaryValue(handoff, "候选 revision");
-  const deploymentId = readSummaryValue(handoff, "Deployment");
+  const candidateRevisionId = readSummaryValue(handoff, '候选 revision');
+  const deploymentId = readSummaryValue(handoff, 'Deployment');
   const checks: DeploymentReleaseEvidenceCheck[] = [];
 
-  if (handoff.action === "deploy-candidate") {
+  if (handoff.action === 'deploy-candidate') {
+    const rolloutMatchesHandoff =
+      Boolean(rollout?.rolloutId) &&
+      (!readSummaryValue(handoff, 'Rollout') ||
+        rollout?.rolloutId === readSummaryValue(handoff, 'Rollout'));
+    const rolloutStatus = buildFreshStatus(
+      rolloutMatchesHandoff,
+      rollout?.updatedAt,
+      handoff,
+    );
+    const servingHasCandidate = hasServingRevision(
+      serving,
+      candidateRevisionId,
+    );
+    const trafficHasCandidate = hasTrafficRevision(
+      traffic,
+      candidateRevisionId,
+    );
+
     checks.push(
       buildCheck(
-        "rollout-active",
-        "Rollout evidence",
-        rollout?.rolloutId ? "observed" : "pending",
-        rollout?.rolloutId
-          ? `活动 rollout ${rollout.rolloutId} 可见`
-          : "等待 rollout 出现或刷新",
+        'rollout-active',
+        'Rollout evidence',
+        rolloutStatus,
+        buildFreshDetail(
+          rolloutMatchesHandoff,
+          rollout?.updatedAt,
+          `活动 rollout ${rollout?.rolloutId} 已在本次提交后刷新`,
+          rollout?.rolloutId
+            ? `活动 rollout ${rollout.rolloutId} 可见，但 updatedAt 早于本次提交，请等待刷新`
+            : '等待本次 rollout 出现或刷新',
+          '等待本次 rollout 出现或刷新',
+          handoff,
+        ),
       ),
       buildCheck(
-        "serving-candidate",
-        "Serving evidence",
-        hasServingRevision(serving, candidateRevisionId) ? "observed" : "pending",
-        hasServingRevision(serving, candidateRevisionId)
-          ? `Serving targets 已包含 ${candidateRevisionId}`
-          : `等待 serving targets 出现 ${candidateRevisionId || "候选 revision"}`,
+        'serving-candidate',
+        'Serving evidence',
+        buildFreshStatus(servingHasCandidate, serving?.updatedAt, handoff),
+        buildFreshDetail(
+          servingHasCandidate,
+          serving?.updatedAt,
+          `Serving targets 已在本次提交后包含 ${candidateRevisionId}`,
+          `Serving targets 已包含 ${candidateRevisionId}，但 updatedAt 早于本次提交，请等待 readmodel 刷新`,
+          `等待 serving targets 出现 ${candidateRevisionId || '候选 revision'}`,
+          handoff,
+        ),
       ),
       buildCheck(
-        "traffic-candidate",
-        "Traffic evidence",
-        hasTrafficRevision(traffic, candidateRevisionId) ? "observed" : "pending",
-        hasTrafficRevision(traffic, candidateRevisionId)
-          ? `Traffic split 已包含 ${candidateRevisionId}`
-          : "等待 traffic split 指向候选 revision",
+        'traffic-candidate',
+        'Traffic evidence',
+        buildFreshStatus(trafficHasCandidate, traffic?.updatedAt, handoff),
+        buildFreshDetail(
+          trafficHasCandidate,
+          traffic?.updatedAt,
+          `Traffic split 已在本次提交后包含 ${candidateRevisionId}`,
+          `Traffic split 已包含 ${candidateRevisionId}，但 updatedAt 早于本次提交，请等待 readmodel 刷新`,
+          '等待 traffic split 指向候选 revision',
+          handoff,
+        ),
       ),
     );
-  } else if (handoff.action === "replace-serving-targets") {
+  } else if (handoff.action === 'replace-serving-targets') {
     checks.push(
       buildCheck(
-        "serving-generation",
-        "Serving generation",
-        serving?.updatedAt ? "review" : "pending",
-        serving?.updatedAt
-          ? `Serving updatedAt ${serving.updatedAt}，请确认是否晚于 command 提交`
-          : "等待 serving readmodel 刷新",
+        'serving-generation',
+        'Serving generation',
+        occurredAfterHandoff(serving?.updatedAt, handoff)
+          ? 'review'
+          : 'pending',
+        occurredAfterHandoff(serving?.updatedAt, handoff)
+          ? `Serving updatedAt ${serving?.updatedAt} 晚于本次提交，请确认权重是否匹配`
+          : '等待本次提交后的 serving readmodel 刷新',
       ),
       buildCheck(
-        "traffic-generation",
-        "Traffic split",
-        traffic?.updatedAt ? "review" : "pending",
-        traffic?.updatedAt
-          ? `Traffic updatedAt ${traffic.updatedAt}，请核对权重是否匹配`
-          : "等待 traffic readmodel 刷新",
+        'traffic-generation',
+        'Traffic split',
+        occurredAfterHandoff(traffic?.updatedAt, handoff)
+          ? 'review'
+          : 'pending',
+        occurredAfterHandoff(traffic?.updatedAt, handoff)
+          ? `Traffic updatedAt ${traffic?.updatedAt} 晚于本次提交，请核对权重是否匹配`
+          : '等待本次提交后的 traffic readmodel 刷新',
       ),
     );
-  } else if (handoff.action === "deactivate-deployment") {
+  } else if (handoff.action === 'deactivate-deployment') {
+    const deployment = findDeployment(deployments, deploymentId);
+    const inactive = deploymentIsInactive(deployments, deploymentId);
+    const catalogStatus = buildFreshStatus(
+      inactive,
+      deployment?.updatedAt,
+      handoff,
+    );
+    const servingExcludesTarget = servingExcludesDeployment(
+      serving,
+      deploymentId,
+    );
+    const trafficExcludesTarget = trafficExcludesDeployment(
+      traffic,
+      deploymentId,
+    );
+
     checks.push(
       buildCheck(
-        "deployment-inactive",
-        "Deployment catalog",
-        deploymentIsInactive(deployments, deploymentId) ? "observed" : "pending",
-        deploymentIsInactive(deployments, deploymentId)
-          ? `${deploymentId || "目标 deployment"} 已不再显示为 active`
-          : `等待 ${deploymentId || "目标 deployment"} 状态离开 active`,
+        'deployment-inactive',
+        'Deployment catalog',
+        catalogStatus,
+        buildFreshDetail(
+          inactive,
+          deployment?.updatedAt,
+          `${deploymentId || '目标 deployment'} 已在本次提交后离开 active`,
+          `${deploymentId || '目标 deployment'} 已不再显示为 active，但 updatedAt 早于本次提交，请等待 catalog 刷新`,
+          deployment
+            ? `等待 ${deploymentId || '目标 deployment'} 状态离开 active`
+            : `等待 ${deploymentId || '目标 deployment'} 出现在 catalog 并显示非 active 状态`,
+          handoff,
+        ),
       ),
       buildCheck(
-        "serving-excludes-deployment",
-        "Serving targets",
-        servingExcludesDeployment(serving, deploymentId) ? "observed" : "pending",
-        servingExcludesDeployment(serving, deploymentId)
-          ? "Serving targets 已不再包含该 deployment"
-          : "等待 serving targets 移除该 deployment",
+        'serving-excludes-deployment',
+        'Serving targets',
+        buildFreshStatus(servingExcludesTarget, serving?.updatedAt, handoff),
+        buildFreshDetail(
+          servingExcludesTarget,
+          serving?.updatedAt,
+          'Serving targets 已在本次提交后不再包含该 deployment',
+          'Serving targets 当前不包含该 deployment，但 updatedAt 早于本次提交，请等待 readmodel 刷新',
+          '等待 serving targets 移除该 deployment',
+          handoff,
+        ),
       ),
       buildCheck(
-        "traffic-excludes-deployment",
-        "Traffic split",
-        trafficExcludesDeployment(traffic, deploymentId) ? "observed" : "pending",
-        trafficExcludesDeployment(traffic, deploymentId)
-          ? "Traffic split 已不再包含该 deployment"
-          : "等待 traffic split 移除该 deployment",
+        'traffic-excludes-deployment',
+        'Traffic split',
+        buildFreshStatus(trafficExcludesTarget, traffic?.updatedAt, handoff),
+        buildFreshDetail(
+          trafficExcludesTarget,
+          traffic?.updatedAt,
+          'Traffic split 已在本次提交后不再包含该 deployment',
+          'Traffic split 当前不包含该 deployment，但 updatedAt 早于本次提交，请等待 readmodel 刷新',
+          '等待 traffic split 移除该 deployment',
+          handoff,
+        ),
       ),
     );
   } else {
-    const rolloutStatus = rollout?.status ?? "";
-    const actionStatusNeedle: Record<string, string> = {
-      "advance-rollout": "canary",
-      "pause-rollout": "pause",
-      "resume-rollout": "canary",
-      "rollback-rollout": "rollback",
+    const rolloutStatus = rollout?.status ?? '';
+    const actionStatusNeedle: Partial<Record<string, string>> = {
+      'advance-rollout': 'inprogress',
+      'pause-rollout': 'paused',
+      'resume-rollout': 'inprogress',
+      'rollback-rollout': 'rolledback',
     };
-    const needle = actionStatusNeedle[handoff.action] ?? "";
+    const needle = actionStatusNeedle[handoff.action] ?? '';
+    const rolloutHasExpectedStatus =
+      needle && normalizeStatus(rolloutStatus).includes(needle);
 
     checks.push(
       buildCheck(
-        "rollout-status",
-        "Rollout status",
-        needle && includesIgnoreCase(rolloutStatus, needle) ? "observed" : "review",
+        'rollout-status',
+        'Rollout status',
+        buildFreshStatus(
+          Boolean(rolloutHasExpectedStatus),
+          rollout?.updatedAt,
+          handoff,
+        ),
         rolloutStatus
-          ? `当前 rollout 状态为 ${rolloutStatus}`
-          : "等待 rollout 状态刷新",
+          ? buildFreshDetail(
+              Boolean(rolloutHasExpectedStatus),
+              rollout?.updatedAt,
+              `当前 rollout 状态已在本次提交后刷新为 ${rolloutStatus}`,
+              `当前 rollout 状态为 ${rolloutStatus}，但 updatedAt 早于本次提交，请等待刷新`,
+              `当前 rollout 状态为 ${rolloutStatus}，等待匹配本次命令的状态`,
+              handoff,
+            )
+          : '等待 rollout 状态刷新',
       ),
       buildCheck(
-        "serving-targets",
-        "Serving targets",
-        serving?.targets.length ? "review" : "pending",
-        serving?.targets.length
-          ? `当前可见 ${serving.targets.length} 个 serving targets`
-          : "等待 serving targets 刷新",
+        'serving-targets',
+        'Serving targets',
+        occurredAfterHandoff(serving?.updatedAt, handoff)
+          ? 'review'
+          : 'pending',
+        occurredAfterHandoff(serving?.updatedAt, handoff)
+          ? `当前可见 ${serving?.targets.length ?? 0} 个 serving targets，请核对是否匹配本次命令`
+          : '等待本次提交后的 serving targets 刷新',
       ),
       buildCheck(
-        "traffic-split",
-        "Traffic split",
-        traffic?.endpoints.length ? "review" : "pending",
-        traffic?.endpoints.length
-          ? `当前可见 ${traffic.endpoints.length} 个 traffic endpoints`
-          : "等待 traffic split 刷新",
+        'traffic-split',
+        'Traffic split',
+        occurredAfterHandoff(traffic?.updatedAt, handoff)
+          ? 'review'
+          : 'pending',
+        occurredAfterHandoff(traffic?.updatedAt, handoff)
+          ? `当前可见 ${traffic?.endpoints.length ?? 0} 个 traffic endpoints，请核对是否匹配本次命令`
+          : '等待本次提交后的 traffic split 刷新',
       ),
     );
   }
 
-  const observedCount = checks.filter((check) => check.status === "observed").length;
-  const pendingCount = checks.filter((check) => check.status === "pending").length;
+  const observedCount = checks.filter(
+    (check) => check.status === 'observed',
+  ).length;
+  const pendingCount = checks.filter(
+    (check) => check.status === 'pending',
+  ).length;
+  const reviewCount = checks.filter(
+    (check) => check.status === 'review',
+  ).length;
 
   return {
     checks,
     observedCount,
     summary:
-      pendingCount === 0
-        ? "所有关键证据都已出现或需要人工核对。"
-        : `${pendingCount} 项证据仍待观察，避免把 submitted 当作 completed。`,
+      pendingCount > 0
+        ? `${pendingCount} 项证据仍待观察，避免把 submitted 当作 completed。`
+        : reviewCount > 0
+          ? `${reviewCount} 项证据需要人工核对，避免把旧 readmodel 当作本次完成。`
+          : '所有关键证据都已在本次提交后观察到。',
   };
 }

--- a/apps/aevatar-console-web/src/pages/Deployments/releaseEvidence.ts
+++ b/apps/aevatar-console-web/src/pages/Deployments/releaseEvidence.ts
@@ -1,0 +1,254 @@
+import type {
+  ServiceDeploymentSnapshot,
+  ServiceRolloutSnapshot,
+  ServiceServingSetSnapshot,
+  ServiceTrafficViewSnapshot,
+} from "@/shared/models/services";
+import type { DeploymentReleaseHandoff } from "./releaseHandoff";
+
+export type DeploymentReleaseEvidenceStatus =
+  | "observed"
+  | "pending"
+  | "review";
+
+export type DeploymentReleaseEvidenceCheck = {
+  detail: string;
+  key: string;
+  label: string;
+  status: DeploymentReleaseEvidenceStatus;
+};
+
+export type DeploymentReleaseEvidenceSnapshot = {
+  checks: DeploymentReleaseEvidenceCheck[];
+  observedCount: number;
+  summary: string;
+};
+
+export type DeploymentReleaseEvidenceInput = {
+  deployments: readonly ServiceDeploymentSnapshot[];
+  handoff: DeploymentReleaseHandoff;
+  rollout?: ServiceRolloutSnapshot | null;
+  serving?: ServiceServingSetSnapshot | null;
+  traffic?: ServiceTrafficViewSnapshot | null;
+};
+
+function includesIgnoreCase(value: string | null | undefined, pattern: string): boolean {
+  return (value ?? "").toLowerCase().includes(pattern.toLowerCase());
+}
+
+function readSummaryValue(
+  handoff: DeploymentReleaseHandoff,
+  label: string,
+): string {
+  return (
+    handoff.summaryItems.find((item) => item.label === label)?.value.trim() ?? ""
+  );
+}
+
+function buildCheck(
+  key: string,
+  label: string,
+  status: DeploymentReleaseEvidenceStatus,
+  detail: string,
+): DeploymentReleaseEvidenceCheck {
+  return {
+    detail,
+    key,
+    label,
+    status,
+  };
+}
+
+function hasServingRevision(
+  serving: ServiceServingSetSnapshot | null | undefined,
+  revisionId: string,
+): boolean {
+  return Boolean(
+    revisionId &&
+      serving?.targets.some((target) => target.revisionId === revisionId),
+  );
+}
+
+function hasTrafficRevision(
+  traffic: ServiceTrafficViewSnapshot | null | undefined,
+  revisionId: string,
+): boolean {
+  return Boolean(
+    revisionId &&
+      traffic?.endpoints.some((endpoint) =>
+        endpoint.targets.some((target) => target.revisionId === revisionId),
+      ),
+  );
+}
+
+function deploymentIsInactive(
+  deployments: readonly ServiceDeploymentSnapshot[],
+  deploymentId: string,
+): boolean {
+  const deployment = deployments.find((item) => item.deploymentId === deploymentId);
+  if (!deployment) {
+    return true;
+  }
+
+  const status = deployment.status.trim().toLowerCase();
+  return status !== "active";
+}
+
+function servingExcludesDeployment(
+  serving: ServiceServingSetSnapshot | null | undefined,
+  deploymentId: string,
+): boolean {
+  return Boolean(
+    deploymentId &&
+      serving &&
+      !serving.targets.some((target) => target.deploymentId === deploymentId),
+  );
+}
+
+function trafficExcludesDeployment(
+  traffic: ServiceTrafficViewSnapshot | null | undefined,
+  deploymentId: string,
+): boolean {
+  return Boolean(
+    deploymentId &&
+      traffic &&
+      !traffic.endpoints.some((endpoint) =>
+        endpoint.targets.some((target) => target.deploymentId === deploymentId),
+      ),
+  );
+}
+
+export function buildDeploymentReleaseEvidenceSnapshot({
+  deployments,
+  handoff,
+  rollout,
+  serving,
+  traffic,
+}: DeploymentReleaseEvidenceInput): DeploymentReleaseEvidenceSnapshot {
+  const candidateRevisionId = readSummaryValue(handoff, "候选 revision");
+  const deploymentId = readSummaryValue(handoff, "Deployment");
+  const checks: DeploymentReleaseEvidenceCheck[] = [];
+
+  if (handoff.action === "deploy-candidate") {
+    checks.push(
+      buildCheck(
+        "rollout-active",
+        "Rollout evidence",
+        rollout?.rolloutId ? "observed" : "pending",
+        rollout?.rolloutId
+          ? `活动 rollout ${rollout.rolloutId} 可见`
+          : "等待 rollout 出现或刷新",
+      ),
+      buildCheck(
+        "serving-candidate",
+        "Serving evidence",
+        hasServingRevision(serving, candidateRevisionId) ? "observed" : "pending",
+        hasServingRevision(serving, candidateRevisionId)
+          ? `Serving targets 已包含 ${candidateRevisionId}`
+          : `等待 serving targets 出现 ${candidateRevisionId || "候选 revision"}`,
+      ),
+      buildCheck(
+        "traffic-candidate",
+        "Traffic evidence",
+        hasTrafficRevision(traffic, candidateRevisionId) ? "observed" : "pending",
+        hasTrafficRevision(traffic, candidateRevisionId)
+          ? `Traffic split 已包含 ${candidateRevisionId}`
+          : "等待 traffic split 指向候选 revision",
+      ),
+    );
+  } else if (handoff.action === "replace-serving-targets") {
+    checks.push(
+      buildCheck(
+        "serving-generation",
+        "Serving generation",
+        serving?.updatedAt ? "review" : "pending",
+        serving?.updatedAt
+          ? `Serving updatedAt ${serving.updatedAt}，请确认是否晚于 command 提交`
+          : "等待 serving readmodel 刷新",
+      ),
+      buildCheck(
+        "traffic-generation",
+        "Traffic split",
+        traffic?.updatedAt ? "review" : "pending",
+        traffic?.updatedAt
+          ? `Traffic updatedAt ${traffic.updatedAt}，请核对权重是否匹配`
+          : "等待 traffic readmodel 刷新",
+      ),
+    );
+  } else if (handoff.action === "deactivate-deployment") {
+    checks.push(
+      buildCheck(
+        "deployment-inactive",
+        "Deployment catalog",
+        deploymentIsInactive(deployments, deploymentId) ? "observed" : "pending",
+        deploymentIsInactive(deployments, deploymentId)
+          ? `${deploymentId || "目标 deployment"} 已不再显示为 active`
+          : `等待 ${deploymentId || "目标 deployment"} 状态离开 active`,
+      ),
+      buildCheck(
+        "serving-excludes-deployment",
+        "Serving targets",
+        servingExcludesDeployment(serving, deploymentId) ? "observed" : "pending",
+        servingExcludesDeployment(serving, deploymentId)
+          ? "Serving targets 已不再包含该 deployment"
+          : "等待 serving targets 移除该 deployment",
+      ),
+      buildCheck(
+        "traffic-excludes-deployment",
+        "Traffic split",
+        trafficExcludesDeployment(traffic, deploymentId) ? "observed" : "pending",
+        trafficExcludesDeployment(traffic, deploymentId)
+          ? "Traffic split 已不再包含该 deployment"
+          : "等待 traffic split 移除该 deployment",
+      ),
+    );
+  } else {
+    const rolloutStatus = rollout?.status ?? "";
+    const actionStatusNeedle: Record<string, string> = {
+      "advance-rollout": "canary",
+      "pause-rollout": "pause",
+      "resume-rollout": "canary",
+      "rollback-rollout": "rollback",
+    };
+    const needle = actionStatusNeedle[handoff.action] ?? "";
+
+    checks.push(
+      buildCheck(
+        "rollout-status",
+        "Rollout status",
+        needle && includesIgnoreCase(rolloutStatus, needle) ? "observed" : "review",
+        rolloutStatus
+          ? `当前 rollout 状态为 ${rolloutStatus}`
+          : "等待 rollout 状态刷新",
+      ),
+      buildCheck(
+        "serving-targets",
+        "Serving targets",
+        serving?.targets.length ? "review" : "pending",
+        serving?.targets.length
+          ? `当前可见 ${serving.targets.length} 个 serving targets`
+          : "等待 serving targets 刷新",
+      ),
+      buildCheck(
+        "traffic-split",
+        "Traffic split",
+        traffic?.endpoints.length ? "review" : "pending",
+        traffic?.endpoints.length
+          ? `当前可见 ${traffic.endpoints.length} 个 traffic endpoints`
+          : "等待 traffic split 刷新",
+      ),
+    );
+  }
+
+  const observedCount = checks.filter((check) => check.status === "observed").length;
+  const pendingCount = checks.filter((check) => check.status === "pending").length;
+
+  return {
+    checks,
+    observedCount,
+    summary:
+      pendingCount === 0
+        ? "所有关键证据都已出现或需要人工核对。"
+        : `${pendingCount} 项证据仍待观察，避免把 submitted 当作 completed。`,
+  };
+}

--- a/apps/aevatar-console-web/src/pages/Deployments/releaseHandoff.test.ts
+++ b/apps/aevatar-console-web/src/pages/Deployments/releaseHandoff.test.ts
@@ -1,96 +1,100 @@
-import { buildDeploymentReleaseHandoff } from "./releaseHandoff";
+import { buildDeploymentReleaseHandoff } from './releaseHandoff';
 
-describe("buildDeploymentReleaseHandoff", () => {
-  it("keeps submitted commands separate from observed serving state", () => {
+describe('buildDeploymentReleaseHandoff', () => {
+  it('keeps submitted commands separate from observed serving state', () => {
     const handoff = buildDeploymentReleaseHandoff({
-      action: "deploy-candidate",
-      activeRevisionId: "rev-11",
-      candidateRevisionId: "rev-12",
+      action: 'deploy-candidate',
+      activeRevisionId: 'rev-11',
+      candidateRevisionId: 'rev-12',
       receipt: {
-        commandId: "cmd-1",
-        correlationId: "corr-1",
-        targetActorId: "actor-1",
+        commandId: 'cmd-1',
+        correlationId: 'corr-1',
+        targetActorId: 'actor-1',
       },
-      rolloutId: "rollout-1",
-      rolloutStageLabel: "2/3",
-      serviceId: "trade-agent",
+      rolloutId: 'rollout-1',
+      rolloutStageLabel: '2/3',
+      serviceId: 'trade-agent',
       targetCount: 2,
     });
 
-    expect(handoff.pendingLabel).toBe("已提交，不代表已完成");
-    expect(handoff.noticeMessage).toContain("等待 rollout/serving 证据刷新");
-    expect(handoff.evidenceDescription).toContain("尚未说明候选 revision 已经被 serving 观察到");
-    expect(handoff.evidenceView).toBe("rollout");
+    expect(handoff.pendingLabel).toBe('已提交，不代表已完成');
+    expect(handoff.noticeMessage).toContain('等待 rollout/serving 证据刷新');
+    expect(handoff.evidenceDescription).toContain(
+      '尚未说明候选 revision 已经被 serving 观察到',
+    );
+    expect(handoff.evidenceView).toBe('rollout');
     expect(handoff.summaryItems).toEqual(
       expect.arrayContaining([
         {
-          label: "候选 revision",
-          value: "rev-12",
+          label: '候选 revision',
+          value: 'rev-12',
         },
         {
-          label: "当前 serving",
-          value: "rev-11",
+          label: '当前 serving',
+          value: 'rev-11',
         },
       ]),
     );
   });
 
-  it("routes serving replacement evidence to serving and traffic checks", () => {
+  it('routes serving replacement evidence to serving and traffic checks', () => {
     const handoff = buildDeploymentReleaseHandoff({
-      action: "replace-serving-targets",
-      activeRevisionId: "rev-11",
+      action: 'replace-serving-targets',
+      activeRevisionId: 'rev-11',
       endpointCount: 1,
       receipt: {
-        commandId: "cmd-2",
-        correlationId: "corr-2",
+        commandId: 'cmd-2',
+        correlationId: 'corr-2',
       },
-      serviceId: "trade-agent",
+      serviceId: 'trade-agent',
       targetCount: 2,
     });
 
-    expect(handoff.evidenceView).toBe("serving");
-    expect(handoff.evidenceItems.join(" ")).toContain("Serving generation");
-    expect(handoff.evidenceItems.join(" ")).toContain("Traffic");
-    expect(handoff.noticeMessage).toContain("等待 serving/traffic 证据刷新");
+    expect(handoff.evidenceView).toBe('serving');
+    expect(handoff.evidenceItems.join(' ')).toContain('Serving generation');
+    expect(handoff.evidenceItems.join(' ')).toContain('Traffic');
+    expect(handoff.noticeMessage).toContain('等待 serving/traffic 证据刷新');
   });
 
-  it("does not describe rollback as completed serving state", () => {
+  it('does not describe rollback as completed serving state', () => {
     const handoff = buildDeploymentReleaseHandoff({
-      action: "rollback-rollout",
-      activeRevisionId: "rev-12",
+      action: 'rollback-rollout',
+      activeRevisionId: 'rev-12',
       receipt: {
-        commandId: "cmd-6",
-        correlationId: "corr-6",
+        commandId: 'cmd-6',
+        correlationId: 'corr-6',
       },
-      rolloutId: "rollout-1",
-      serviceId: "trade-agent",
+      rolloutId: 'rollout-1',
+      serviceId: 'trade-agent',
     });
 
-    expect(handoff.noticeTone).toBe("warning");
-    expect(handoff.evidenceDescription).toContain("不代表 serving 已经回到 baseline");
-    expect(handoff.evidenceItems.join(" ")).toContain("baseline");
+    expect(handoff.noticeTone).toBe('warning');
+    expect(handoff.evidenceDescription).toContain(
+      '不代表 serving 已经回到 baseline',
+    );
+    expect(handoff.evidenceItems.join(' ')).toContain('baseline');
   });
 
-  it("keeps deactivate handoff pointed at catalog and serving evidence", () => {
+  it('keeps deactivate handoff pointed at catalog and serving evidence', () => {
     const handoff = buildDeploymentReleaseHandoff({
-      action: "deactivate-deployment",
-      deploymentId: "dep-1",
+      action: 'deactivate-deployment',
+      deploymentId: 'dep-1',
       receipt: {
-        commandId: "cmd-7",
-        correlationId: "corr-7",
+        commandId: 'cmd-7',
+        correlationId: 'corr-7',
       },
-      serviceId: "trade-agent",
+      serviceId: 'trade-agent',
     });
 
-    expect(handoff.evidenceView).toBe("catalog");
+    expect(handoff.evidenceView).toBe('catalog');
     expect(handoff.summaryItems).toEqual(
       expect.arrayContaining([
         {
-          label: "Deployment",
-          value: "dep-1",
+          label: 'Deployment',
+          value: 'dep-1',
         },
       ]),
     );
-    expect(handoff.evidenceItems.join(" ")).toContain("Serving targets");
+    expect(handoff.evidenceItems.join(' ')).toContain('Serving targets');
   });
 });

--- a/apps/aevatar-console-web/src/pages/Deployments/releaseHandoff.test.ts
+++ b/apps/aevatar-console-web/src/pages/Deployments/releaseHandoff.test.ts
@@ -1,0 +1,96 @@
+import { buildDeploymentReleaseHandoff } from "./releaseHandoff";
+
+describe("buildDeploymentReleaseHandoff", () => {
+  it("keeps submitted commands separate from observed serving state", () => {
+    const handoff = buildDeploymentReleaseHandoff({
+      action: "deploy-candidate",
+      activeRevisionId: "rev-11",
+      candidateRevisionId: "rev-12",
+      receipt: {
+        commandId: "cmd-1",
+        correlationId: "corr-1",
+        targetActorId: "actor-1",
+      },
+      rolloutId: "rollout-1",
+      rolloutStageLabel: "2/3",
+      serviceId: "trade-agent",
+      targetCount: 2,
+    });
+
+    expect(handoff.pendingLabel).toBe("已提交，不代表已完成");
+    expect(handoff.noticeMessage).toContain("等待 rollout/serving 证据刷新");
+    expect(handoff.evidenceDescription).toContain("尚未说明候选 revision 已经被 serving 观察到");
+    expect(handoff.evidenceView).toBe("rollout");
+    expect(handoff.summaryItems).toEqual(
+      expect.arrayContaining([
+        {
+          label: "候选 revision",
+          value: "rev-12",
+        },
+        {
+          label: "当前 serving",
+          value: "rev-11",
+        },
+      ]),
+    );
+  });
+
+  it("routes serving replacement evidence to serving and traffic checks", () => {
+    const handoff = buildDeploymentReleaseHandoff({
+      action: "replace-serving-targets",
+      activeRevisionId: "rev-11",
+      endpointCount: 1,
+      receipt: {
+        commandId: "cmd-2",
+        correlationId: "corr-2",
+      },
+      serviceId: "trade-agent",
+      targetCount: 2,
+    });
+
+    expect(handoff.evidenceView).toBe("serving");
+    expect(handoff.evidenceItems.join(" ")).toContain("Serving generation");
+    expect(handoff.evidenceItems.join(" ")).toContain("Traffic");
+    expect(handoff.noticeMessage).toContain("等待 serving/traffic 证据刷新");
+  });
+
+  it("does not describe rollback as completed serving state", () => {
+    const handoff = buildDeploymentReleaseHandoff({
+      action: "rollback-rollout",
+      activeRevisionId: "rev-12",
+      receipt: {
+        commandId: "cmd-6",
+        correlationId: "corr-6",
+      },
+      rolloutId: "rollout-1",
+      serviceId: "trade-agent",
+    });
+
+    expect(handoff.noticeTone).toBe("warning");
+    expect(handoff.evidenceDescription).toContain("不代表 serving 已经回到 baseline");
+    expect(handoff.evidenceItems.join(" ")).toContain("baseline");
+  });
+
+  it("keeps deactivate handoff pointed at catalog and serving evidence", () => {
+    const handoff = buildDeploymentReleaseHandoff({
+      action: "deactivate-deployment",
+      deploymentId: "dep-1",
+      receipt: {
+        commandId: "cmd-7",
+        correlationId: "corr-7",
+      },
+      serviceId: "trade-agent",
+    });
+
+    expect(handoff.evidenceView).toBe("catalog");
+    expect(handoff.summaryItems).toEqual(
+      expect.arrayContaining([
+        {
+          label: "Deployment",
+          value: "dep-1",
+        },
+      ]),
+    );
+    expect(handoff.evidenceItems.join(" ")).toContain("Serving targets");
+  });
+});

--- a/apps/aevatar-console-web/src/pages/Deployments/releaseHandoff.ts
+++ b/apps/aevatar-console-web/src/pages/Deployments/releaseHandoff.ts
@@ -1,19 +1,19 @@
-import type { ServiceCommandAcceptedReceipt } from "@/shared/models/services";
+import type { ServiceCommandAcceptedReceipt } from '@/shared/models/services';
 
 export type DeploymentReleaseHandoffAction =
-  | "deploy-candidate"
-  | "replace-serving-targets"
-  | "advance-rollout"
-  | "pause-rollout"
-  | "resume-rollout"
-  | "rollback-rollout"
-  | "deactivate-deployment";
+  | 'deploy-candidate'
+  | 'replace-serving-targets'
+  | 'advance-rollout'
+  | 'pause-rollout'
+  | 'resume-rollout'
+  | 'rollback-rollout'
+  | 'deactivate-deployment';
 
 export type DeploymentReleaseEvidenceView =
-  | "catalog"
-  | "serving"
-  | "rollout"
-  | "traffic";
+  | 'catalog'
+  | 'serving'
+  | 'rollout'
+  | 'traffic';
 
 export type DeploymentReleaseHandoff = {
   action: DeploymentReleaseHandoffAction;
@@ -21,13 +21,14 @@ export type DeploymentReleaseHandoff = {
   actionSummary: string;
   commandId: string;
   correlationId: string;
+  createdAt: string;
   evidenceDescription: string;
   evidenceItems: string[];
   evidenceView: DeploymentReleaseEvidenceView;
   evidenceViewLabel: string;
   id: string;
   noticeMessage: string;
-  noticeTone: "success" | "warning";
+  noticeTone: 'success' | 'warning';
   pendingLabel: string;
   summaryItems: Array<{
     label: string;
@@ -40,6 +41,7 @@ export type DeploymentReleaseHandoffInput = {
   action: DeploymentReleaseHandoffAction;
   activeRevisionId?: string;
   candidateRevisionId?: string;
+  createdAt?: string;
   deploymentId?: string;
   endpointCount?: number;
   receipt?: Partial<ServiceCommandAcceptedReceipt>;
@@ -53,128 +55,128 @@ const actionCopy: Record<
   DeploymentReleaseHandoffAction,
   Pick<
     DeploymentReleaseHandoff,
-    | "actionLabel"
-    | "actionSummary"
-    | "evidenceDescription"
-    | "evidenceItems"
-    | "evidenceView"
-    | "evidenceViewLabel"
-    | "noticeMessage"
-    | "noticeTone"
-    | "title"
+    | 'actionLabel'
+    | 'actionSummary'
+    | 'evidenceDescription'
+    | 'evidenceItems'
+    | 'evidenceView'
+    | 'evidenceViewLabel'
+    | 'noticeMessage'
+    | 'noticeTone'
+    | 'title'
   >
 > = {
-  "advance-rollout": {
-    actionLabel: "推进 rollout",
-    actionSummary: "推进请求已进入发布控制面",
+  'advance-rollout': {
+    actionLabel: '推进 rollout',
+    actionSummary: '推进请求已进入发布控制面',
     evidenceDescription:
-      "这只表示 rollout 推进命令已接收，仍要等待阶段和流量证据刷新后再判断是否完成。",
+      '这只表示 rollout 推进命令已接收，仍要等待阶段和流量证据刷新后再判断是否完成。',
     evidenceItems: [
-      "Rollout 当前 stage 或 updatedAt 发生变化",
-      "Serving targets 与当前 stage 目标一致",
-      "Traffic 分配反映新的 stage 权重",
+      'Rollout 当前 stage 或 updatedAt 发生变化',
+      'Serving targets 与当前 stage 目标一致',
+      'Traffic 分配反映新的 stage 权重',
     ],
-    evidenceView: "rollout",
-    evidenceViewLabel: "Rollout",
-    noticeMessage: "Rollout 推进请求已提交，等待阶段证据刷新。",
-    noticeTone: "success",
-    title: "Rollout 推进已提交",
+    evidenceView: 'rollout',
+    evidenceViewLabel: 'Rollout',
+    noticeMessage: 'Rollout 推进请求已提交，等待阶段证据刷新。',
+    noticeTone: 'success',
+    title: 'Rollout 推进已提交',
   },
-  "deactivate-deployment": {
-    actionLabel: "停用 deployment",
-    actionSummary: "停用请求已进入发布控制面",
+  'deactivate-deployment': {
+    actionLabel: '停用 deployment',
+    actionSummary: '停用请求已进入发布控制面',
     evidenceDescription:
-      "这只表示停用命令已接收，不代表该 deployment 已经从 serving 或 catalog 中消失。",
+      '这只表示停用命令已接收，不代表该 deployment 已经从 serving 或 catalog 中消失。',
     evidenceItems: [
-      "Deployment catalog 中目标 deployment 状态不再 active",
-      "Serving targets 不再路由到被停用 deployment",
-      "Traffic 入口不再把流量分配给该 revision/deployment",
+      'Deployment catalog 中目标 deployment 状态不再 active',
+      'Serving targets 不再路由到被停用 deployment',
+      'Traffic 入口不再把流量分配给该 revision/deployment',
     ],
-    evidenceView: "catalog",
-    evidenceViewLabel: "部署目录",
-    noticeMessage: "Deployment 停用请求已提交，等待 catalog/serving 证据刷新。",
-    noticeTone: "warning",
-    title: "Deployment 停用已提交",
+    evidenceView: 'catalog',
+    evidenceViewLabel: '部署目录',
+    noticeMessage: 'Deployment 停用请求已提交，等待 catalog/serving 证据刷新。',
+    noticeTone: 'warning',
+    title: 'Deployment 停用已提交',
   },
-  "deploy-candidate": {
-    actionLabel: "部署候选版本",
-    actionSummary: "候选版本请求已进入发布控制面",
+  'deploy-candidate': {
+    actionLabel: '部署候选版本',
+    actionSummary: '候选版本请求已进入发布控制面',
     evidenceDescription:
-      "这只表示候选版本部署命令已接收，尚未说明候选 revision 已经被 serving 观察到。",
+      '这只表示候选版本部署命令已接收，尚未说明候选 revision 已经被 serving 观察到。',
     evidenceItems: [
-      "Rollout 出现活动阶段或阶段目标变化",
-      "Serving targets 中出现候选 revision",
-      "Traffic 分配开始指向候选 revision 后再判断生效",
+      'Rollout 出现活动阶段或阶段目标变化',
+      'Serving targets 中出现候选 revision',
+      'Traffic 分配开始指向候选 revision 后再判断生效',
     ],
-    evidenceView: "rollout",
-    evidenceViewLabel: "Rollout",
-    noticeMessage: "候选版本已提交，等待 rollout/serving 证据刷新。",
-    noticeTone: "success",
-    title: "候选版本部署已提交",
+    evidenceView: 'rollout',
+    evidenceViewLabel: 'Rollout',
+    noticeMessage: '候选版本已提交，等待 rollout/serving 证据刷新。',
+    noticeTone: 'success',
+    title: '候选版本部署已提交',
   },
-  "pause-rollout": {
-    actionLabel: "暂停 rollout",
-    actionSummary: "暂停请求已进入发布控制面",
+  'pause-rollout': {
+    actionLabel: '暂停 rollout',
+    actionSummary: '暂停请求已进入发布控制面',
     evidenceDescription:
-      "这只表示暂停命令已接收，仍要等待 rollout 状态显示暂停后再停止后续操作。",
+      '这只表示暂停命令已接收，仍要等待 rollout 状态显示暂停后再停止后续操作。',
     evidenceItems: [
-      "Rollout 状态刷新为 paused 或等价暂停状态",
-      "Serving targets 保持在暂停前的最后稳定分配",
-      "Traffic 未继续推进到下一 stage",
+      'Rollout 状态刷新为 paused 或等价暂停状态',
+      'Serving targets 保持在暂停前的最后稳定分配',
+      'Traffic 未继续推进到下一 stage',
     ],
-    evidenceView: "rollout",
-    evidenceViewLabel: "Rollout",
-    noticeMessage: "Rollout 暂停请求已提交，等待状态证据刷新。",
-    noticeTone: "success",
-    title: "Rollout 暂停已提交",
+    evidenceView: 'rollout',
+    evidenceViewLabel: 'Rollout',
+    noticeMessage: 'Rollout 暂停请求已提交，等待状态证据刷新。',
+    noticeTone: 'success',
+    title: 'Rollout 暂停已提交',
   },
-  "replace-serving-targets": {
-    actionLabel: "应用权重",
-    actionSummary: "Serving target 替换请求已进入发布控制面",
+  'replace-serving-targets': {
+    actionLabel: '应用权重',
+    actionSummary: 'Serving target 替换请求已进入发布控制面',
     evidenceDescription:
-      "这只表示权重替换命令已接收，仍要等待 serving generation 和 traffic split 刷新。",
+      '这只表示权重替换命令已接收，仍要等待 serving generation 和 traffic split 刷新。',
     evidenceItems: [
-      "Serving generation 或 updatedAt 刷新",
-      "Serving targets 显示新的 revision/weight 分配",
-      "Traffic 入口 split 与新的 serving targets 对齐",
+      'Serving generation 或 updatedAt 刷新',
+      'Serving targets 显示新的 revision/weight 分配',
+      'Traffic 入口 split 与新的 serving targets 对齐',
     ],
-    evidenceView: "serving",
-    evidenceViewLabel: "Serving",
-    noticeMessage: "Serving targets 已提交，等待 serving/traffic 证据刷新。",
-    noticeTone: "success",
-    title: "Serving targets 替换已提交",
+    evidenceView: 'serving',
+    evidenceViewLabel: 'Serving',
+    noticeMessage: 'Serving targets 已提交，等待 serving/traffic 证据刷新。',
+    noticeTone: 'success',
+    title: 'Serving targets 替换已提交',
   },
-  "resume-rollout": {
-    actionLabel: "恢复 rollout",
-    actionSummary: "恢复请求已进入发布控制面",
+  'resume-rollout': {
+    actionLabel: '恢复 rollout',
+    actionSummary: '恢复请求已进入发布控制面',
     evidenceDescription:
-      "这只表示恢复命令已接收，仍要等待 rollout 状态重新进入活动推进状态。",
+      '这只表示恢复命令已接收，仍要等待 rollout 状态重新进入活动推进状态。',
     evidenceItems: [
-      "Rollout 状态不再停留在 paused",
-      "Current stage 或 updatedAt 继续刷新",
-      "Traffic 分配继续按 stage 计划推进",
+      'Rollout 状态不再停留在 paused',
+      'Current stage 或 updatedAt 继续刷新',
+      'Traffic 分配继续按 stage 计划推进',
     ],
-    evidenceView: "rollout",
-    evidenceViewLabel: "Rollout",
-    noticeMessage: "Rollout 恢复请求已提交，等待状态证据刷新。",
-    noticeTone: "success",
-    title: "Rollout 恢复已提交",
+    evidenceView: 'rollout',
+    evidenceViewLabel: 'Rollout',
+    noticeMessage: 'Rollout 恢复请求已提交，等待状态证据刷新。',
+    noticeTone: 'success',
+    title: 'Rollout 恢复已提交',
   },
-  "rollback-rollout": {
-    actionLabel: "回滚 rollout",
-    actionSummary: "回滚请求已进入发布控制面",
+  'rollback-rollout': {
+    actionLabel: '回滚 rollout',
+    actionSummary: '回滚请求已进入发布控制面',
     evidenceDescription:
-      "这只表示回滚命令已接收，不代表 serving 已经回到 baseline。",
+      '这只表示回滚命令已接收，不代表 serving 已经回到 baseline。',
     evidenceItems: [
-      "Rollout 状态显示回滚或回到基线阶段",
-      "Serving targets 与 baseline targets 对齐",
-      "Traffic 分配不再指向被回滚的候选 revision",
+      'Rollout 状态显示回滚或回到基线阶段',
+      'Serving targets 与 baseline targets 对齐',
+      'Traffic 分配不再指向被回滚的候选 revision',
     ],
-    evidenceView: "rollout",
-    evidenceViewLabel: "Rollout",
-    noticeMessage: "Rollout 回滚请求已提交，等待 baseline 证据刷新。",
-    noticeTone: "warning",
-    title: "Rollout 回滚已提交",
+    evidenceView: 'rollout',
+    evidenceViewLabel: 'Rollout',
+    noticeMessage: 'Rollout 回滚请求已提交，等待 baseline 证据刷新。',
+    noticeTone: 'warning',
+    title: 'Rollout 回滚已提交',
   },
 };
 
@@ -182,65 +184,67 @@ export function buildDeploymentReleaseHandoff(
   input: DeploymentReleaseHandoffInput,
 ): DeploymentReleaseHandoff {
   const copy = actionCopy[input.action];
-  const commandId = input.receipt?.commandId?.trim() || "pending-command";
-  const correlationId = input.receipt?.correlationId?.trim() || "pending-correlation";
+  const commandId = input.receipt?.commandId?.trim() || 'pending-command';
+  const correlationId =
+    input.receipt?.correlationId?.trim() || 'pending-correlation';
+  const createdAt = input.createdAt || new Date().toISOString();
   const summaryItems = [
     {
-      label: "Service",
-      value: input.serviceId || "未选择",
+      label: 'Service',
+      value: input.serviceId || '未选择',
     },
     {
-      label: "Command",
+      label: 'Command',
       value: commandId,
     },
     {
-      label: "Correlation",
+      label: 'Correlation',
       value: correlationId,
     },
     {
-      label: "当前 serving",
-      value: input.activeRevisionId || "暂无",
+      label: '当前 serving',
+      value: input.activeRevisionId || '暂无',
     },
   ];
 
   if (input.candidateRevisionId) {
     summaryItems.push({
-      label: "候选 revision",
+      label: '候选 revision',
       value: input.candidateRevisionId,
     });
   }
 
   if (input.deploymentId) {
     summaryItems.push({
-      label: "Deployment",
+      label: 'Deployment',
       value: input.deploymentId,
     });
   }
 
   if (input.rolloutId) {
     summaryItems.push({
-      label: "Rollout",
+      label: 'Rollout',
       value: input.rolloutId,
     });
   }
 
   if (input.rolloutStageLabel) {
     summaryItems.push({
-      label: "当前 stage",
+      label: '当前 stage',
       value: input.rolloutStageLabel,
     });
   }
 
-  if (typeof input.targetCount === "number") {
+  if (typeof input.targetCount === 'number') {
     summaryItems.push({
-      label: "Serving targets",
+      label: 'Serving targets',
       value: String(input.targetCount),
     });
   }
 
-  if (typeof input.endpointCount === "number") {
+  if (typeof input.endpointCount === 'number') {
     summaryItems.push({
-      label: "Traffic endpoints",
+      label: 'Traffic endpoints',
       value: String(input.endpointCount),
     });
   }
@@ -250,8 +254,9 @@ export function buildDeploymentReleaseHandoff(
     action: input.action,
     commandId,
     correlationId,
+    createdAt,
     id: `${input.action}:${commandId}:${correlationId}`,
-    pendingLabel: "已提交，不代表已完成",
+    pendingLabel: '已提交，不代表已完成',
     summaryItems,
   };
 }

--- a/apps/aevatar-console-web/src/pages/Deployments/releaseHandoff.ts
+++ b/apps/aevatar-console-web/src/pages/Deployments/releaseHandoff.ts
@@ -1,0 +1,257 @@
+import type { ServiceCommandAcceptedReceipt } from "@/shared/models/services";
+
+export type DeploymentReleaseHandoffAction =
+  | "deploy-candidate"
+  | "replace-serving-targets"
+  | "advance-rollout"
+  | "pause-rollout"
+  | "resume-rollout"
+  | "rollback-rollout"
+  | "deactivate-deployment";
+
+export type DeploymentReleaseEvidenceView =
+  | "catalog"
+  | "serving"
+  | "rollout"
+  | "traffic";
+
+export type DeploymentReleaseHandoff = {
+  action: DeploymentReleaseHandoffAction;
+  actionLabel: string;
+  actionSummary: string;
+  commandId: string;
+  correlationId: string;
+  evidenceDescription: string;
+  evidenceItems: string[];
+  evidenceView: DeploymentReleaseEvidenceView;
+  evidenceViewLabel: string;
+  id: string;
+  noticeMessage: string;
+  noticeTone: "success" | "warning";
+  pendingLabel: string;
+  summaryItems: Array<{
+    label: string;
+    value: string;
+  }>;
+  title: string;
+};
+
+export type DeploymentReleaseHandoffInput = {
+  action: DeploymentReleaseHandoffAction;
+  activeRevisionId?: string;
+  candidateRevisionId?: string;
+  deploymentId?: string;
+  endpointCount?: number;
+  receipt?: Partial<ServiceCommandAcceptedReceipt>;
+  rolloutId?: string;
+  rolloutStageLabel?: string;
+  serviceId: string;
+  targetCount?: number;
+};
+
+const actionCopy: Record<
+  DeploymentReleaseHandoffAction,
+  Pick<
+    DeploymentReleaseHandoff,
+    | "actionLabel"
+    | "actionSummary"
+    | "evidenceDescription"
+    | "evidenceItems"
+    | "evidenceView"
+    | "evidenceViewLabel"
+    | "noticeMessage"
+    | "noticeTone"
+    | "title"
+  >
+> = {
+  "advance-rollout": {
+    actionLabel: "推进 rollout",
+    actionSummary: "推进请求已进入发布控制面",
+    evidenceDescription:
+      "这只表示 rollout 推进命令已接收，仍要等待阶段和流量证据刷新后再判断是否完成。",
+    evidenceItems: [
+      "Rollout 当前 stage 或 updatedAt 发生变化",
+      "Serving targets 与当前 stage 目标一致",
+      "Traffic 分配反映新的 stage 权重",
+    ],
+    evidenceView: "rollout",
+    evidenceViewLabel: "Rollout",
+    noticeMessage: "Rollout 推进请求已提交，等待阶段证据刷新。",
+    noticeTone: "success",
+    title: "Rollout 推进已提交",
+  },
+  "deactivate-deployment": {
+    actionLabel: "停用 deployment",
+    actionSummary: "停用请求已进入发布控制面",
+    evidenceDescription:
+      "这只表示停用命令已接收，不代表该 deployment 已经从 serving 或 catalog 中消失。",
+    evidenceItems: [
+      "Deployment catalog 中目标 deployment 状态不再 active",
+      "Serving targets 不再路由到被停用 deployment",
+      "Traffic 入口不再把流量分配给该 revision/deployment",
+    ],
+    evidenceView: "catalog",
+    evidenceViewLabel: "部署目录",
+    noticeMessage: "Deployment 停用请求已提交，等待 catalog/serving 证据刷新。",
+    noticeTone: "warning",
+    title: "Deployment 停用已提交",
+  },
+  "deploy-candidate": {
+    actionLabel: "部署候选版本",
+    actionSummary: "候选版本请求已进入发布控制面",
+    evidenceDescription:
+      "这只表示候选版本部署命令已接收，尚未说明候选 revision 已经被 serving 观察到。",
+    evidenceItems: [
+      "Rollout 出现活动阶段或阶段目标变化",
+      "Serving targets 中出现候选 revision",
+      "Traffic 分配开始指向候选 revision 后再判断生效",
+    ],
+    evidenceView: "rollout",
+    evidenceViewLabel: "Rollout",
+    noticeMessage: "候选版本已提交，等待 rollout/serving 证据刷新。",
+    noticeTone: "success",
+    title: "候选版本部署已提交",
+  },
+  "pause-rollout": {
+    actionLabel: "暂停 rollout",
+    actionSummary: "暂停请求已进入发布控制面",
+    evidenceDescription:
+      "这只表示暂停命令已接收，仍要等待 rollout 状态显示暂停后再停止后续操作。",
+    evidenceItems: [
+      "Rollout 状态刷新为 paused 或等价暂停状态",
+      "Serving targets 保持在暂停前的最后稳定分配",
+      "Traffic 未继续推进到下一 stage",
+    ],
+    evidenceView: "rollout",
+    evidenceViewLabel: "Rollout",
+    noticeMessage: "Rollout 暂停请求已提交，等待状态证据刷新。",
+    noticeTone: "success",
+    title: "Rollout 暂停已提交",
+  },
+  "replace-serving-targets": {
+    actionLabel: "应用权重",
+    actionSummary: "Serving target 替换请求已进入发布控制面",
+    evidenceDescription:
+      "这只表示权重替换命令已接收，仍要等待 serving generation 和 traffic split 刷新。",
+    evidenceItems: [
+      "Serving generation 或 updatedAt 刷新",
+      "Serving targets 显示新的 revision/weight 分配",
+      "Traffic 入口 split 与新的 serving targets 对齐",
+    ],
+    evidenceView: "serving",
+    evidenceViewLabel: "Serving",
+    noticeMessage: "Serving targets 已提交，等待 serving/traffic 证据刷新。",
+    noticeTone: "success",
+    title: "Serving targets 替换已提交",
+  },
+  "resume-rollout": {
+    actionLabel: "恢复 rollout",
+    actionSummary: "恢复请求已进入发布控制面",
+    evidenceDescription:
+      "这只表示恢复命令已接收，仍要等待 rollout 状态重新进入活动推进状态。",
+    evidenceItems: [
+      "Rollout 状态不再停留在 paused",
+      "Current stage 或 updatedAt 继续刷新",
+      "Traffic 分配继续按 stage 计划推进",
+    ],
+    evidenceView: "rollout",
+    evidenceViewLabel: "Rollout",
+    noticeMessage: "Rollout 恢复请求已提交，等待状态证据刷新。",
+    noticeTone: "success",
+    title: "Rollout 恢复已提交",
+  },
+  "rollback-rollout": {
+    actionLabel: "回滚 rollout",
+    actionSummary: "回滚请求已进入发布控制面",
+    evidenceDescription:
+      "这只表示回滚命令已接收，不代表 serving 已经回到 baseline。",
+    evidenceItems: [
+      "Rollout 状态显示回滚或回到基线阶段",
+      "Serving targets 与 baseline targets 对齐",
+      "Traffic 分配不再指向被回滚的候选 revision",
+    ],
+    evidenceView: "rollout",
+    evidenceViewLabel: "Rollout",
+    noticeMessage: "Rollout 回滚请求已提交，等待 baseline 证据刷新。",
+    noticeTone: "warning",
+    title: "Rollout 回滚已提交",
+  },
+};
+
+export function buildDeploymentReleaseHandoff(
+  input: DeploymentReleaseHandoffInput,
+): DeploymentReleaseHandoff {
+  const copy = actionCopy[input.action];
+  const commandId = input.receipt?.commandId?.trim() || "pending-command";
+  const correlationId = input.receipt?.correlationId?.trim() || "pending-correlation";
+  const summaryItems = [
+    {
+      label: "Service",
+      value: input.serviceId || "未选择",
+    },
+    {
+      label: "Command",
+      value: commandId,
+    },
+    {
+      label: "Correlation",
+      value: correlationId,
+    },
+    {
+      label: "当前 serving",
+      value: input.activeRevisionId || "暂无",
+    },
+  ];
+
+  if (input.candidateRevisionId) {
+    summaryItems.push({
+      label: "候选 revision",
+      value: input.candidateRevisionId,
+    });
+  }
+
+  if (input.deploymentId) {
+    summaryItems.push({
+      label: "Deployment",
+      value: input.deploymentId,
+    });
+  }
+
+  if (input.rolloutId) {
+    summaryItems.push({
+      label: "Rollout",
+      value: input.rolloutId,
+    });
+  }
+
+  if (input.rolloutStageLabel) {
+    summaryItems.push({
+      label: "当前 stage",
+      value: input.rolloutStageLabel,
+    });
+  }
+
+  if (typeof input.targetCount === "number") {
+    summaryItems.push({
+      label: "Serving targets",
+      value: String(input.targetCount),
+    });
+  }
+
+  if (typeof input.endpointCount === "number") {
+    summaryItems.push({
+      label: "Traffic endpoints",
+      value: String(input.endpointCount),
+    });
+  }
+
+  return {
+    ...copy,
+    action: input.action,
+    commandId,
+    correlationId,
+    id: `${input.action}:${commandId}:${correlationId}`,
+    pendingLabel: "已提交，不代表已完成",
+    summaryItems,
+  };
+}

--- a/apps/aevatar-console-web/src/pages/Deployments/servingTargetPlan.test.ts
+++ b/apps/aevatar-console-web/src/pages/Deployments/servingTargetPlan.test.ts
@@ -1,0 +1,55 @@
+import { buildServingTargetPlanStatus } from "./servingTargetPlan";
+
+describe("buildServingTargetPlanStatus", () => {
+  it("disables empty serving target submissions", () => {
+    const status = buildServingTargetPlanStatus([]);
+
+    expect(status.enabled).toBe(false);
+    expect(status.reason).toContain("不能提交空的流量计划");
+  });
+
+  it("requires every target to identify a revision", () => {
+    const status = buildServingTargetPlanStatus([
+      {
+        allocationWeight: 100,
+        revisionId: "",
+      },
+    ]);
+
+    expect(status.enabled).toBe(false);
+    expect(status.reason).toContain("缺少 revision");
+  });
+
+  it("requires allocation weights to add up to 100 percent", () => {
+    const status = buildServingTargetPlanStatus([
+      {
+        allocationWeight: 60,
+        revisionId: "rev-1",
+      },
+      {
+        allocationWeight: 20,
+        revisionId: "rev-2",
+      },
+    ]);
+
+    expect(status.enabled).toBe(false);
+    expect(status.totalWeight).toBe(80);
+    expect(status.reason).toContain("80%");
+  });
+
+  it("allows a complete 100 percent serving target plan", () => {
+    const status = buildServingTargetPlanStatus([
+      {
+        allocationWeight: 90,
+        revisionId: "rev-1",
+      },
+      {
+        allocationWeight: 10,
+        revisionId: "rev-2",
+      },
+    ]);
+
+    expect(status.enabled).toBe(true);
+    expect(status.summary).toContain("100%");
+  });
+});

--- a/apps/aevatar-console-web/src/pages/Deployments/servingTargetPlan.test.ts
+++ b/apps/aevatar-console-web/src/pages/Deployments/servingTargetPlan.test.ts
@@ -1,55 +1,70 @@
-import { buildServingTargetPlanStatus } from "./servingTargetPlan";
+import { buildServingTargetPlanStatus } from './servingTargetPlan';
 
-describe("buildServingTargetPlanStatus", () => {
-  it("disables empty serving target submissions", () => {
+describe('buildServingTargetPlanStatus', () => {
+  it('disables empty serving target submissions', () => {
     const status = buildServingTargetPlanStatus([]);
 
     expect(status.enabled).toBe(false);
-    expect(status.reason).toContain("不能提交空的流量计划");
+    expect(status.reason).toContain('不能提交空的流量计划');
   });
 
-  it("requires every target to identify a revision", () => {
+  it('requires every target to identify a revision', () => {
     const status = buildServingTargetPlanStatus([
       {
         allocationWeight: 100,
-        revisionId: "",
+        revisionId: '',
       },
     ]);
 
     expect(status.enabled).toBe(false);
-    expect(status.reason).toContain("缺少 revision");
+    expect(status.reason).toContain('缺少 revision');
   });
 
-  it("requires allocation weights to add up to 100 percent", () => {
+  it('requires allocation weights to add up to 100 percent', () => {
     const status = buildServingTargetPlanStatus([
       {
         allocationWeight: 60,
-        revisionId: "rev-1",
+        revisionId: 'rev-1',
       },
       {
         allocationWeight: 20,
-        revisionId: "rev-2",
+        revisionId: 'rev-2',
       },
     ]);
 
     expect(status.enabled).toBe(false);
     expect(status.totalWeight).toBe(80);
-    expect(status.reason).toContain("80%");
+    expect(status.reason).toContain('80%');
   });
 
-  it("allows a complete 100 percent serving target plan", () => {
+  it('rejects serving states that the API would silently coerce to active', () => {
+    const status = buildServingTargetPlanStatus([
+      {
+        allocationWeight: 100,
+        revisionId: 'rev-1',
+        servingState: 'canary',
+      },
+    ]);
+
+    expect(status.enabled).toBe(false);
+    expect(status.reason).toContain('Serving 状态只能选择');
+  });
+
+  it('allows a complete 100 percent serving target plan', () => {
     const status = buildServingTargetPlanStatus([
       {
         allocationWeight: 90,
-        revisionId: "rev-1",
+        revisionId: 'rev-1',
+        servingState: 'active',
       },
       {
         allocationWeight: 10,
-        revisionId: "rev-2",
+        revisionId: 'rev-2',
+        servingState: 'draining',
       },
     ]);
 
     expect(status.enabled).toBe(true);
-    expect(status.summary).toContain("100%");
+    expect(status.summary).toContain('100%');
   });
 });

--- a/apps/aevatar-console-web/src/pages/Deployments/servingTargetPlan.ts
+++ b/apps/aevatar-console-web/src/pages/Deployments/servingTargetPlan.ts
@@ -1,4 +1,4 @@
-import type { ServiceServingTargetInput } from "@/shared/models/services";
+import type { ServiceServingTargetInput } from '@/shared/models/services';
 
 export type ServingTargetPlanStatus = {
   enabled: boolean;
@@ -6,6 +6,14 @@ export type ServingTargetPlanStatus = {
   summary: string;
   totalWeight: number;
 };
+
+const allowedServingStates = new Set([
+  '',
+  'active',
+  'paused',
+  'draining',
+  'disabled',
+]);
 
 export function buildServingTargetPlanStatus(
   targets: readonly ServiceServingTargetInput[],
@@ -18,8 +26,8 @@ export function buildServingTargetPlanStatus(
   if (!targets.length) {
     return {
       enabled: false,
-      reason: "当前没有 serving targets，不能提交空的流量计划。",
-      summary: "没有可提交的 serving targets。",
+      reason: '当前没有 serving targets，不能提交空的流量计划。',
+      summary: '没有可提交的 serving targets。',
       totalWeight,
     };
   }
@@ -28,7 +36,24 @@ export function buildServingTargetPlanStatus(
   if (missingRevision) {
     return {
       enabled: false,
-      reason: "每个 serving target 都需要 revision，不能提交缺少 revision 的计划。",
+      reason:
+        '每个 serving target 都需要 revision，不能提交缺少 revision 的计划。',
+      summary: `${targets.length} 个 target，权重合计 ${totalWeight}%。`,
+      totalWeight,
+    };
+  }
+
+  const invalidServingState = targets.some(
+    (target) =>
+      !allowedServingStates.has(
+        (target.servingState ?? '').trim().toLowerCase(),
+      ),
+  );
+  if (invalidServingState) {
+    return {
+      enabled: false,
+      reason:
+        'Serving 状态只能选择 active、paused、draining 或 disabled，避免提交后被后端静默改写。',
       summary: `${targets.length} 个 target，权重合计 ${totalWeight}%。`,
       totalWeight,
     };
@@ -45,7 +70,8 @@ export function buildServingTargetPlanStatus(
 
   return {
     enabled: true,
-    reason: "权重计划可提交；提交后仍需等待 serving/traffic readmodel 证据刷新。",
+    reason:
+      '权重计划可提交；提交后仍需等待 serving/traffic readmodel 证据刷新。',
     summary: `${targets.length} 个 target，权重合计 100%。`,
     totalWeight,
   };

--- a/apps/aevatar-console-web/src/pages/Deployments/servingTargetPlan.ts
+++ b/apps/aevatar-console-web/src/pages/Deployments/servingTargetPlan.ts
@@ -1,0 +1,52 @@
+import type { ServiceServingTargetInput } from "@/shared/models/services";
+
+export type ServingTargetPlanStatus = {
+  enabled: boolean;
+  reason: string;
+  summary: string;
+  totalWeight: number;
+};
+
+export function buildServingTargetPlanStatus(
+  targets: readonly ServiceServingTargetInput[],
+): ServingTargetPlanStatus {
+  const totalWeight = targets.reduce(
+    (total, target) => total + Number(target.allocationWeight || 0),
+    0,
+  );
+
+  if (!targets.length) {
+    return {
+      enabled: false,
+      reason: "当前没有 serving targets，不能提交空的流量计划。",
+      summary: "没有可提交的 serving targets。",
+      totalWeight,
+    };
+  }
+
+  const missingRevision = targets.some((target) => !target.revisionId.trim());
+  if (missingRevision) {
+    return {
+      enabled: false,
+      reason: "每个 serving target 都需要 revision，不能提交缺少 revision 的计划。",
+      summary: `${targets.length} 个 target，权重合计 ${totalWeight}%。`,
+      totalWeight,
+    };
+  }
+
+  if (totalWeight !== 100) {
+    return {
+      enabled: false,
+      reason: `当前权重合计 ${totalWeight}%，需要等于 100% 才能提交。`,
+      summary: `${targets.length} 个 target，权重合计 ${totalWeight}%。`,
+      totalWeight,
+    };
+  }
+
+  return {
+    enabled: true,
+    reason: "权重计划可提交；提交后仍需等待 serving/traffic readmodel 证据刷新。",
+    summary: `${targets.length} 个 target，权重合计 100%。`,
+    totalWeight,
+  };
+}


### PR DESCRIPTION
## Problem

Deployments release actions currently make submitted commands feel too close to observed completion. Candidate deployment, serving target replacement, rollout control, and deployment deactivation need a persistent handoff that tells operators which readmodel evidence should confirm the action.

The release control drawer also showed rollout actions as executable even when the current rollout lifecycle made them invalid, and serving target weight submission could look actionable even when the plan was empty or did not total 100%.

## Solution

- Add release handoff copy and evidence snapshots for Deployments actions.
- Keep command acceptance separate from observed rollout / serving / traffic / catalog evidence.
- Add rollout action availability derived from the current rollout state.
- Add serving target plan validation so empty or non-100% plans do not look like valid actions.
- Cover the helper logic and page behavior with focused console-web tests.

## Impact Paths

- `apps/aevatar-console-web/src/pages/Deployments/index.tsx`
- `apps/aevatar-console-web/src/pages/Deployments/index.test.tsx`
- `apps/aevatar-console-web/src/pages/Deployments/releaseActionAvailability.ts`
- `apps/aevatar-console-web/src/pages/Deployments/releaseActionAvailability.test.ts`
- `apps/aevatar-console-web/src/pages/Deployments/releaseEvidence.ts`
- `apps/aevatar-console-web/src/pages/Deployments/releaseEvidence.test.ts`
- `apps/aevatar-console-web/src/pages/Deployments/releaseHandoff.ts`
- `apps/aevatar-console-web/src/pages/Deployments/releaseHandoff.test.ts`
- `apps/aevatar-console-web/src/pages/Deployments/servingTargetPlan.ts`
- `apps/aevatar-console-web/src/pages/Deployments/servingTargetPlan.test.ts`

## Validation

- `git diff --check` -> no output
- `npm run biome:lint -- src/pages/Deployments/index.tsx src/pages/Deployments/index.test.tsx src/pages/Deployments/releaseActionAvailability.ts src/pages/Deployments/releaseActionAvailability.test.ts src/pages/Deployments/releaseEvidence.ts src/pages/Deployments/releaseEvidence.test.ts src/pages/Deployments/releaseHandoff.ts src/pages/Deployments/releaseHandoff.test.ts src/pages/Deployments/servingTargetPlan.ts src/pages/Deployments/servingTargetPlan.test.ts` -> passed
- `npm run jest -- src/pages/Deployments/releaseHandoff.test.ts src/pages/Deployments/releaseEvidence.test.ts src/pages/Deployments/releaseActionAvailability.test.ts src/pages/Deployments/servingTargetPlan.test.ts src/pages/Deployments/index.test.tsx --runInBand` -> 5 suites passed, 28 tests passed
- `npm run tsc` -> passed
- `bash tools/ci/test_stability_guards.sh` -> blocked by repo-local `.claude/skills/codex-refactor-loop/scripts/test_spawn_codex.sh` returning 127 before polling scan; direct polling scan found no disallowed test paths after comparing against `tools/ci/test_polling_allowlist.txt`.

## Boundaries

No backend/proto/API/actor/projection/workflow/runtime/database/backend tests/backend config/architecture docs were modified.

## Related Issue

Closes #1676

## Merge Policy

Auto-loop generated PR. Do not auto-merge. Waiting for user review/merge after checks and review.
