### PR TITLE
refactor: impl issue #1668 — workflow tool_call typed pending-approval suspension（first slice）

### DIFF
--- a/src/Aevatar.AI.Abstractions/Middleware/IToolCallMiddleware.cs
+++ b/src/Aevatar.AI.Abstractions/Middleware/IToolCallMiddleware.cs
@@ -11,6 +11,15 @@ public interface IToolCallMiddleware
     Task InvokeAsync(ToolCallContext context, Func<Task> next);
 }
 
+public sealed record ToolApprovalPendingContext(
+    string ApprovalRequestId,
+    string ToolName,
+    string ToolCallId,
+    string ArgumentsJson,
+    ToolApprovalMode ApprovalMode,
+    bool IsReadOnly,
+    bool IsDestructive);
+
 /// <summary>Context for tool call middleware.</summary>
 public sealed class ToolCallContext
 {
@@ -31,6 +40,9 @@ public sealed class ToolCallContext
 
     /// <summary>Tool execution result. Set after execution, or by middleware to override.</summary>
     public string? Result { get; set; }
+
+    /// <summary>Typed business keys for a tool approval yield.</summary>
+    public ToolApprovalPendingContext? PendingApproval { get; set; }
 
     /// <summary>When true, tool execution is skipped and Result is returned as-is.</summary>
     public bool Terminate { get; set; }

--- a/src/Aevatar.AI.Core/Middleware/ToolApprovalMiddleware.cs
+++ b/src/Aevatar.AI.Core/Middleware/ToolApprovalMiddleware.cs
@@ -134,6 +134,14 @@ public sealed class ToolApprovalMiddleware : IToolCallMiddleware
                 // 非阻塞 yield：返回 pending result，不增加 denial counter。
                 // Actor 层检测此 result 后持久化 pending state 并走事件化续传。
                 context.Terminate = true;
+                context.PendingApproval = new ToolApprovalPendingContext(
+                    request.RequestId,
+                    request.ToolName,
+                    request.ToolCallId,
+                    request.ArgumentsJson,
+                    request.ApprovalMode,
+                    request.IsReadOnly,
+                    request.IsDestructive);
                 context.Result = BuildApprovalPendingResult(request);
                 return;
         }

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.Core.Middleware;
 using Aevatar.AI.ToolProviders.AgentCatalog;
@@ -205,6 +206,7 @@ public static class MainnetHostBuilderExtensions
         // actor-owned remote continuation (NyxIdRemoteToolApprovalPort submit/status
         // -> RoleGAgent.HandleRemoteApprovalStatusCheck). See iter23/cluster-001.
         builder.Services.TryAddSingleton<IToolApprovalHandler, YieldApprovalHandler>();
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IToolCallMiddleware, ToolApprovalMiddleware>());
         builder.Services.AddLarkTools(o =>
         {
             o.ProviderSlug = builder.Configuration["Aevatar:Lark:NyxProviderSlug"] ?? "api-lark-bot";

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -214,6 +214,15 @@ message WorkflowSuspendedEvent
   string delivery_target_id = 9;
   bool secure = 10;
   string redacted_output = 11;
+  WorkflowToolApprovalSuspension tool_approval = 12;
+}
+message WorkflowToolApprovalSuspension
+{
+  string execution_id = 1;
+  string tool_name = 2;
+  string tool_call_id = 3;
+  string approval_request_id = 4;
+  string arguments_json = 5;
 }
 message WorkflowResumedEvent
 {

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/workflow_run_events.proto
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/workflow_run_events.proto
@@ -187,6 +187,16 @@ message WorkflowHumanInputRequestCustomPayload {
   string redacted_output = 12;
 }
 
+message WorkflowToolApprovalSuspensionCustomPayload {
+  string run_id = 1;
+  string step_id = 2;
+  string execution_id = 3;
+  string tool_name = 4;
+  string tool_call_id = 5;
+  string approval_request_id = 6;
+  string arguments_json = 7;
+}
+
 message WorkflowHumanInputResponseCustomPayload {
   string step_id = 1;
   string run_id = 2;

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
@@ -4,9 +4,11 @@
 // ─────────────────────────────────────────────────────────────
 
 using Aevatar.Foundation.Abstractions;
+using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Abstractions.EventModules;
+using Aevatar.Workflow.Core.Execution;
 using Microsoft.Extensions.Logging;
 
 namespace Aevatar.Workflow.Core.Modules;
@@ -14,15 +16,20 @@ namespace Aevatar.Workflow.Core.Modules;
 /// <summary>工具调用模块。处理 type=tool_call 的步骤。</summary>
 public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
 {
+    private const string ModuleStateKey = "tool_call";
+
     private readonly IEnumerable<IAgentToolSource> _toolSources;
+    private readonly IReadOnlyList<IToolCallMiddleware> _middlewares;
     private readonly ILogger<ToolCallModule> _logger;
     private volatile Lazy<Task<IReadOnlyDictionary<string, IAgentTool>>>? _toolIndex;
 
     public ToolCallModule(
         IEnumerable<IAgentToolSource> toolSources,
+        IEnumerable<IToolCallMiddleware> middlewares,
         ILogger<ToolCallModule> logger)
     {
         _toolSources = toolSources ?? throw new ArgumentNullException(nameof(toolSources));
+        _middlewares = (middlewares ?? throw new ArgumentNullException(nameof(middlewares))).ToList();
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -75,7 +82,29 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
 
         try
         {
-            var result = await tool.ExecuteAsync(argumentsJson, ct);
+            var toolContext = new ToolCallContext
+            {
+                Tool = tool,
+                ToolName = toolName,
+                ToolCallId = request.StepId,
+                ArgumentsJson = argumentsJson,
+                CancellationToken = ct,
+            };
+            await ExecuteWithMiddlewareAsync(toolContext);
+
+            if (toolContext.PendingApproval != null)
+            {
+                await PublishPendingApprovalAsync(ctx, request, toolContext.PendingApproval, argumentsJson, ct);
+                return;
+            }
+
+            if (toolContext.Terminate)
+            {
+                await PublishToolFailureAsync(ctx, request, toolName, toolContext.Result ?? "tool execution terminated", ct);
+                return;
+            }
+
+            var result = toolContext.Result ?? string.Empty;
 
             await ctx.PublishAsync(new ToolResultEvent
             {
@@ -195,4 +224,73 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
             Error = errorMessage,
         }, TopologyAudience.Self, ct);
     }
+
+    private Task ExecuteWithMiddlewareAsync(ToolCallContext context)
+    {
+        var index = -1;
+
+        Task InvokeNextAsync()
+        {
+            index++;
+            if (index < _middlewares.Count)
+                return _middlewares[index].InvokeAsync(context, InvokeNextAsync);
+
+            return ExecuteToolAsync(context);
+        }
+
+        return InvokeNextAsync();
+    }
+
+    private static async Task ExecuteToolAsync(ToolCallContext context)
+    {
+        if (context.Terminate)
+            return;
+
+        context.Result = await context.Tool.ExecuteAsync(context.ArgumentsJson, context.CancellationToken);
+    }
+
+    private static async Task PublishPendingApprovalAsync(
+        IWorkflowExecutionContext ctx,
+        StepRequestEvent request,
+        ToolApprovalPendingContext pending,
+        string input,
+        CancellationToken ct)
+    {
+        var runId = request.RunId ?? string.Empty;
+        var stepId = request.StepId ?? string.Empty;
+        var state = WorkflowExecutionStateAccess.Load<ToolCallModuleState>(ctx, ModuleStateKey);
+        state.PendingApprovals[BuildPendingApprovalKey(runId, stepId, pending)] = new PendingToolCallApprovalState
+        {
+            RunId = runId,
+            StepId = stepId,
+            ExecutionId = request.ExecutionId ?? string.Empty,
+            ToolName = pending.ToolName,
+            ToolCallId = pending.ToolCallId,
+            ApprovalRequestId = pending.ApprovalRequestId,
+            ArgumentsJson = pending.ArgumentsJson,
+            Input = input,
+        };
+        await WorkflowExecutionStateAccess.SaveAsync(ctx, ModuleStateKey, state, ct);
+
+        await ctx.PublishAsync(new WorkflowSuspendedEvent
+        {
+            RunId = runId,
+            StepId = stepId,
+            SuspensionType = "tool_approval",
+            ToolApproval = new WorkflowToolApprovalSuspension
+            {
+                ExecutionId = request.ExecutionId ?? string.Empty,
+                ToolName = pending.ToolName,
+                ToolCallId = pending.ToolCallId,
+                ApprovalRequestId = pending.ApprovalRequestId,
+                ArgumentsJson = pending.ArgumentsJson,
+            },
+        }, TopologyAudience.ParentAndChildren, ct);
+    }
+
+    private static string BuildPendingApprovalKey(
+        string runId,
+        string stepId,
+        ToolApprovalPendingContext pending) =>
+        $"{runId}:{stepId}:{pending.ToolCallId}:{pending.ApprovalRequestId}";
 }

--- a/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
+++ b/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
@@ -289,6 +289,23 @@ message SecureInputModuleState
   map<string, CapturedSecureInputState> captured = 2;
 }
 
+message PendingToolCallApprovalState
+{
+  string run_id = 1;
+  string step_id = 2;
+  string execution_id = 3;
+  string tool_name = 4;
+  string tool_call_id = 5;
+  string approval_request_id = 6;
+  string arguments_json = 7;
+  string input = 8;
+}
+
+message ToolCallModuleState
+{
+  map<string, PendingToolCallApprovalState> pending_approvals = 1;
+}
+
 message PendingApprovalState
 {
   string step_id = 1;

--- a/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/EventEnvelopeToWorkflowRunEventMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/EventEnvelopeToWorkflowRunEventMapper.cs
@@ -610,6 +610,32 @@ public sealed class WorkflowSuspendedRunEventEnvelopeMappingHandler : IWorkflowR
 
         var evt = envelope.Payload.Unpack<WorkflowSuspendedEvent>();
         var ts = AGUIEventEnvelopeMappingHelpers.ToUnixMs(envelope.Timestamp);
+        if (evt.SuspensionType == "tool_approval")
+        {
+            events =
+            [
+                new WorkflowRunEventEnvelope
+                {
+                    Timestamp = ts,
+                    Custom = new WorkflowCustomEventPayload
+                    {
+                        Name = "aevatar.tool_approval.pending",
+                        Payload = Any.Pack(new WorkflowToolApprovalSuspensionCustomPayload
+                        {
+                            RunId = evt.RunId,
+                            StepId = evt.StepId,
+                            ExecutionId = evt.ToolApproval?.ExecutionId ?? string.Empty,
+                            ToolName = evt.ToolApproval?.ToolName ?? string.Empty,
+                            ToolCallId = evt.ToolApproval?.ToolCallId ?? string.Empty,
+                            ApprovalRequestId = evt.ToolApproval?.ApprovalRequestId ?? string.Empty,
+                            ArgumentsJson = evt.ToolApproval?.ArgumentsJson ?? string.Empty,
+                        }),
+                    },
+                },
+            ];
+            return true;
+        }
+
         // Refactor (iter163/cluster-003-workflow-suspension-legacy-metadata):
         //   Old pattern: WorkflowSuspendedEvent.Metadata fallback for variable/secure/redacted_output reserved keys.
         //   New principle: typed suspension fields are the single source; Metadata is open extension data only.

--- a/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/WorkflowHumanInteractionProjector.cs
+++ b/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/WorkflowHumanInteractionProjector.cs
@@ -32,6 +32,9 @@ public sealed class WorkflowHumanInteractionProjector
             return;
 
         var evt = envelope.Payload.Unpack<WorkflowSuspendedEvent>();
+        if (evt.SuspensionType == "tool_approval")
+            return;
+
         if (string.IsNullOrWhiteSpace(evt.DeliveryTargetId))
             return;
 

--- a/test/Aevatar.AI.Core.Tests/Middleware/ToolApprovalMiddlewareTests.cs
+++ b/test/Aevatar.AI.Core.Tests/Middleware/ToolApprovalMiddlewareTests.cs
@@ -198,11 +198,25 @@ public class ToolApprovalMiddlewareTests
             ArgumentsJson = "{}",
         };
 
-        await middleware.InvokeAsync(ctx, () => Task.CompletedTask);
+        var nextExecuted = false;
+        await middleware.InvokeAsync(ctx, () =>
+        {
+            nextExecuted = true;
+            return Task.CompletedTask;
+        });
 
+        nextExecuted.Should().BeFalse();
         ctx.Terminate.Should().BeTrue();
         ctx.Result.Should().Contain("\"approval_required\":true");
         ctx.Result.Should().Contain("\"request_id\":\"");
+        ctx.PendingApproval.Should().NotBeNull();
+        ctx.PendingApproval!.ApprovalRequestId.Should().NotBeNullOrWhiteSpace();
+        ctx.PendingApproval.ToolCallId.Should().Be("tc-8");
+        ctx.PendingApproval.ToolName.Should().Be("danger");
+        ctx.PendingApproval.ArgumentsJson.Should().Be("{}");
+        ctx.PendingApproval.ApprovalMode.Should().Be(ToolApprovalMode.AlwaysRequire);
+        ctx.PendingApproval.IsReadOnly.Should().BeFalse();
+        ctx.PendingApproval.IsDestructive.Should().BeTrue();
     }
 
     [Fact]

--- a/test/Aevatar.Integration.Tests/WorkflowCoreModulesCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowCoreModulesCoverageTests.cs
@@ -1,5 +1,7 @@
 using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.Middleware;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Workflow.Core;
 using Aevatar.Workflow.Core.Modules;
@@ -22,7 +24,7 @@ public sealed class WorkflowCoreModulesCoverageTests
     [Fact]
     public async Task ToolCallModule_MissingToolParameter_ShouldPublishFailedStepCompleted()
     {
-        var module = new ToolCallModule([], NullLogger<ToolCallModule>.Instance);
+        var module = new ToolCallModule([], [], NullLogger<ToolCallModule>.Instance);
         var ctx = CreateContext();
         var request = new StepRequestEvent
         {
@@ -44,7 +46,7 @@ public sealed class WorkflowCoreModulesCoverageTests
     [Fact]
     public async Task ToolCallModule_ToolNotFound_ShouldPublishToolFailureEvents()
     {
-        var module = new ToolCallModule([], NullLogger<ToolCallModule>.Instance);
+        var module = new ToolCallModule([], [], NullLogger<ToolCallModule>.Instance);
         var ctx = CreateContext();
         var request = new StepRequestEvent
         {
@@ -79,7 +81,7 @@ public sealed class WorkflowCoreModulesCoverageTests
                 new FakeAgentTool("echo", args => args),
             ]);
         IAgentToolSource[] toolSources = [new ThrowingToolSource(), source];
-        var module = new ToolCallModule(toolSources, NullLogger<ToolCallModule>.Instance);
+        var module = new ToolCallModule(toolSources, [], NullLogger<ToolCallModule>.Instance);
         var ctx = CreateContext();
         var request = new StepRequestEvent
         {
@@ -104,7 +106,7 @@ public sealed class WorkflowCoreModulesCoverageTests
             [
                 new FakeAgentTool("cached_echo", args => args),
             ]);
-        var module = new ToolCallModule([source], NullLogger<ToolCallModule>.Instance);
+        var module = new ToolCallModule([source], [], NullLogger<ToolCallModule>.Instance);
         var ctx = CreateContext();
 
         await module.HandleAsync(
@@ -140,7 +142,7 @@ public sealed class WorkflowCoreModulesCoverageTests
             [
                 new FakeAgentTool("parallel_echo", args => args),
             ]);
-        var module = new ToolCallModule([source], NullLogger<ToolCallModule>.Instance);
+        var module = new ToolCallModule([source], [], NullLogger<ToolCallModule>.Instance);
         var ready = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var start = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var readyCount = 0;
@@ -189,7 +191,7 @@ public sealed class WorkflowCoreModulesCoverageTests
             [
                 new FakeAgentTool("delayed_echo", args => args),
             ]);
-        var module = new ToolCallModule([source], NullLogger<ToolCallModule>.Instance);
+        var module = new ToolCallModule([source], [], NullLogger<ToolCallModule>.Instance);
         var cancelledContext = CreateContext();
         using var cts = new CancellationTokenSource();
 
@@ -234,7 +236,7 @@ public sealed class WorkflowCoreModulesCoverageTests
             [
                 new FakeAgentTool("explode", _ => throw new InvalidOperationException("boom")),
             ]);
-        var module = new ToolCallModule([source], NullLogger<ToolCallModule>.Instance);
+        var module = new ToolCallModule([source], [], NullLogger<ToolCallModule>.Instance);
         var ctx = CreateContext();
 
         await module.HandleAsync(
@@ -250,6 +252,121 @@ public sealed class WorkflowCoreModulesCoverageTests
         var completed = ctx.Published.Select(x => x.evt).OfType<StepCompletedEvent>().Last();
         completed.Success.Should().BeFalse();
         completed.Error.Should().Contain("execution failed: boom");
+    }
+
+    [Fact]
+    public async Task ToolCallModule_WhenApprovalYields_ShouldPersistPendingStateAndSuspendWithoutExecutingTool()
+    {
+        var executeCalls = 0;
+        var source = new CountingToolSource(
+            [
+                new FakeAgentTool("approval_required", args =>
+                {
+                    executeCalls++;
+                    return args;
+                })
+                {
+                    ApprovalModeOverride = ToolApprovalMode.AlwaysRequire,
+                    IsDestructiveOverride = true,
+                },
+            ]);
+        var middleware = new ToolApprovalMiddleware(new ScriptedApprovalHandler(ToolApprovalResult.Yielded("ignored")));
+        var module = new ToolCallModule([source], [middleware], NullLogger<ToolCallModule>.Instance);
+        var ctx = CreateContext();
+
+        await module.HandleAsync(
+            Envelope(new StepRequestEvent
+            {
+                RunId = "run-tool-approval",
+                StepId = "step-tool-approval",
+                StepType = "tool_call",
+                Input = """{"danger":true}""",
+                ExecutionId = "exec-tool-approval",
+                Parameters = { ["tool"] = "approval_required" },
+            }),
+            ctx,
+            CancellationToken.None);
+
+        executeCalls.Should().Be(0);
+        ctx.Published.Select(x => x.evt).OfType<ToolCallEvent>().Should().ContainSingle();
+        ctx.Published.Select(x => x.evt).OfType<ToolResultEvent>().Should().BeEmpty();
+        ctx.Published.Select(x => x.evt).OfType<StepCompletedEvent>().Should().BeEmpty();
+
+        var suspended = ctx.Published.Select(x => x.evt).OfType<WorkflowSuspendedEvent>().Should().ContainSingle().Subject;
+        suspended.RunId.Should().Be("run-tool-approval");
+        suspended.StepId.Should().Be("step-tool-approval");
+        suspended.SuspensionType.Should().Be("tool_approval");
+        suspended.ToolApproval.Should().NotBeNull();
+        suspended.ToolApproval.ExecutionId.Should().Be("exec-tool-approval");
+        suspended.ToolApproval.ToolName.Should().Be("approval_required");
+        suspended.ToolApproval.ToolCallId.Should().Be("step-tool-approval");
+        suspended.ToolApproval.ApprovalRequestId.Should().NotBeNullOrWhiteSpace();
+        suspended.ToolApproval.ArgumentsJson.Should().Be("""{"danger":true}""");
+        suspended.Metadata.Should().BeEmpty();
+
+        var state = ctx.LoadState<ToolCallModuleState>("tool_call");
+        state.PendingApprovals.Should().ContainSingle();
+        var pending = state.PendingApprovals.Values.Single();
+        pending.RunId.Should().Be("run-tool-approval");
+        pending.StepId.Should().Be("step-tool-approval");
+        pending.ExecutionId.Should().Be("exec-tool-approval");
+        pending.ToolName.Should().Be("approval_required");
+        pending.ToolCallId.Should().Be("step-tool-approval");
+        pending.ApprovalRequestId.Should().Be(suspended.ToolApproval.ApprovalRequestId);
+        pending.ArgumentsJson.Should().Be("""{"danger":true}""");
+        pending.Input.Should().Be("""{"danger":true}""");
+    }
+
+    [Theory]
+    [InlineData("denied")]
+    [InlineData("timeout")]
+    [InlineData("exception")]
+    public async Task ToolCallModule_WhenApprovalFailsOrToolThrows_ShouldPublishFailureAndNotPersistPendingApproval(string scenario)
+    {
+        var source = new CountingToolSource(
+            [
+                new FakeAgentTool("guarded_tool", _ =>
+                {
+                    if (scenario == "exception")
+                        throw new InvalidOperationException("boom");
+
+                    return """{"ok":true}""";
+                })
+                {
+                    ApprovalModeOverride = ToolApprovalMode.AlwaysRequire,
+                    IsDestructiveOverride = true,
+                },
+            ]);
+        var approvalResult = scenario switch
+        {
+            "denied" => ToolApprovalResult.Denied("blocked"),
+            "timeout" => ToolApprovalResult.TimedOut(),
+            _ => ToolApprovalResult.Approved(),
+        };
+        var middleware = new ToolApprovalMiddleware(new ScriptedApprovalHandler(approvalResult));
+        var module = new ToolCallModule([source], [middleware], NullLogger<ToolCallModule>.Instance);
+        var ctx = CreateContext();
+
+        await module.HandleAsync(
+            Envelope(new StepRequestEvent
+            {
+                RunId = $"run-{scenario}",
+                StepId = $"step-{scenario}",
+                StepType = "tool_call",
+                Input = "{}",
+                ExecutionId = $"exec-{scenario}",
+                Parameters = { ["tool"] = "guarded_tool" },
+            }),
+            ctx,
+            CancellationToken.None);
+
+        ctx.Published.Select(x => x.evt).OfType<WorkflowSuspendedEvent>().Should().BeEmpty();
+        var toolResult = ctx.Published.Select(x => x.evt).OfType<ToolResultEvent>().Should().ContainSingle().Subject;
+        var completed = ctx.Published.Select(x => x.evt).OfType<StepCompletedEvent>().Should().ContainSingle().Subject;
+        toolResult.Success.Should().BeFalse();
+        completed.Success.Should().BeFalse();
+        completed.Error.Should().Contain("tool 'guarded_tool' execution failed");
+        ctx.LoadState<ToolCallModuleState>("tool_call").PendingApprovals.Should().BeEmpty();
     }
 
     [Fact]
@@ -1597,10 +1714,28 @@ public sealed class WorkflowCoreModulesCoverageTests
         public string Name { get; } = name;
         public string Description => "fake tool";
         public string ParametersSchema => "{}";
+        public ToolApprovalMode ApprovalMode => ApprovalModeOverride;
+        public bool IsReadOnly => IsReadOnlyOverride;
+        public bool IsDestructive => IsDestructiveOverride;
+        public ToolApprovalMode ApprovalModeOverride { get; init; } = ToolApprovalMode.NeverRequire;
+        public bool IsReadOnlyOverride { get; init; }
+        public bool IsDestructiveOverride { get; init; }
 
         public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
         {
             return Task.FromResult(execute(argumentsJson));
+        }
+    }
+
+    private sealed class ScriptedApprovalHandler(params ToolApprovalResult[] results) : IToolApprovalHandler
+    {
+        private readonly Queue<ToolApprovalResult> _results = new(results);
+
+        public Task<ToolApprovalResult> RequestApprovalAsync(ToolApprovalRequest request, CancellationToken ct)
+        {
+            return Task.FromResult(_results.TryDequeue(out var result)
+                ? result
+                : ToolApprovalResult.Denied("no scripted approval result"));
         }
     }
 

--- a/test/Aevatar.Workflow.Host.Api.Tests/EventEnvelopeToAGUIEventMapperTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/EventEnvelopeToAGUIEventMapperTests.cs
@@ -391,6 +391,41 @@ public sealed class EventEnvelopeToAGUIEventMapperTests
     }
 
     [Fact]
+    public void WorkflowSuspendedToolApproval_ShouldMapTypedPayloadWithoutMetadataRecoveryKeys()
+    {
+        var suspended = CreateMapper().Map(WrapCommitted(new WorkflowSuspendedEvent
+        {
+            RunId = "run-tool",
+            StepId = "step-tool",
+            SuspensionType = "tool_approval",
+            Metadata =
+            {
+                ["approval_request_id"] = "legacy-approval",
+                ["tool_call_id"] = "legacy-call",
+            },
+            ToolApproval = new WorkflowToolApprovalSuspension
+            {
+                ExecutionId = "exec-tool",
+                ToolName = "dangerous_tool",
+                ToolCallId = "call-tool",
+                ApprovalRequestId = "approval-tool",
+                ArgumentsJson = """{"danger":true}""",
+            },
+        }));
+
+        suspended.Should().ContainSingle();
+        suspended[0].Custom.Name.Should().Be("aevatar.tool_approval.pending");
+        var payload = suspended[0].Custom.Payload.Unpack<WorkflowToolApprovalSuspensionCustomPayload>();
+        payload.RunId.Should().Be("run-tool");
+        payload.StepId.Should().Be("step-tool");
+        payload.ExecutionId.Should().Be("exec-tool");
+        payload.ToolName.Should().Be("dangerous_tool");
+        payload.ToolCallId.Should().Be("call-tool");
+        payload.ApprovalRequestId.Should().Be("approval-tool");
+        payload.ArgumentsJson.Should().Be("""{"danger":true}""");
+    }
+
+    [Fact]
     public void WaitingForSignalEvent_WhenTypedRunIdMissing_ShouldNotMap()
     {
         var envelope = WrapObserved(new WaitingForSignalEvent

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowHumanInteractionProjectorTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowHumanInteractionProjectorTests.cs
@@ -129,6 +129,39 @@ public sealed class WorkflowHumanInteractionProjectorTests
     }
 
     [Fact]
+    public async Task ProjectAsync_ShouldNotDeliverActionableRequest_ForToolApprovalSuspension()
+    {
+        var port = new RecordingHumanInteractionPort();
+        var projector = new WorkflowHumanInteractionProjector(port);
+
+        await projector.ProjectAsync(
+            BuildContext(),
+            new EventEnvelope
+            {
+                Id = "evt-tool-approval",
+                Route = EnvelopeRouteSemantics.CreateObserverPublication("workflow-human-interaction-test"),
+                Payload = Any.Pack(new WorkflowSuspendedEvent
+                {
+                    RunId = "run-tool",
+                    StepId = "step-tool",
+                    SuspensionType = "tool_approval",
+                    DeliveryTargetId = "agent-delivery-tool",
+                    ToolApproval = new WorkflowToolApprovalSuspension
+                    {
+                        ExecutionId = "exec-tool",
+                        ToolName = "dangerous_tool",
+                        ToolCallId = "call-tool",
+                        ApprovalRequestId = "approval-tool",
+                        ArgumentsJson = "{}",
+                    },
+                }),
+            },
+            CancellationToken.None);
+
+        port.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task ProjectAsync_ShouldIgnoreNonProjectionRoute()
     {
         var port = new RecordingHumanInteractionPort();


### PR DESCRIPTION
## 实施 issue #1668 — workflow tool_call typed pending-approval suspension（first slice）

**来源**: #1668 · **设计共识**: design-consensus r4 `hybrid pending-only first slice`（`.refactor-loop/runs/phase9-issue1668-r4-judge.md`，4 轮收敛 3/3）

### 问题
`ToolCallModule` 直接 `tool.ExecuteAsync` 绕过审批 middleware；`ApprovalPending` 缺乏 typed 终态/suspension 语义。

### 改动（first slice，13 文件，~+210 LOC + proto regen）
- `IToolCallMiddleware.cs`：新增 `ToolApprovalPendingContext` typed record + `ToolCallContext.PendingApproval`
- `ToolApprovalMiddleware.cs`：`Yield` 分支设置 `PendingApproval`（保留 legacy JSON display payload）
- proto append：`WorkflowSuspendedEvent.tool_approval=12` + `WorkflowToolApprovalSuspension`、`PendingToolCallApprovalState` + `ToolCallModuleState.pending_approvals`、AGUI custom payload（`workflow_run_events.proto`，SCOPE_EXTEND，避免 Metadata 过载）。**恢复键全部 typed proto field，绝不入 `Metadata`/`Items`/`Annotations`**
- `ToolCallModule.cs`：模块内私有 runner 包 `tool.ExecuteAsync`（不依赖 `Aevatar.AI.Core.MiddlewarePipeline`）；pending 时持久化 state + 发 typed suspended event + return，不执行工具/不发完成事件；denied/timeout/exception 仍走失败事件
- mainnet 注册 `ToolApprovalMiddleware`；AGUI mapper 追加 typed `tool_approval` payload；projector guard `tool_approval`，typed resume 前不投普通 approve/reject card

**边界**：no-new-public-port / no-new-actor / no-new-envelope-kind / no-new-projection-pipeline-phase。**approved resume 回流 = later slice**。

### 验证
- `dotnet build aevatar.slnx --nologo` 通过
- `ToolApprovalMiddleware` 10 passed · `ToolCallModule` 11 passed · `EventEnvelopeToAGUIEventMapper`+`WorkflowHumanInteractionProjector` 28 passed
- `test_stability_guards.sh` + `architecture_guards.sh` 通过

将走 3-reviewer review-gate。

⟦AI:AUTO-LOOP⟧
