### PR TITLE
test: 稳定全量 suite — 更新 typed ToolContext + workflow ACK 测试期望

### DIFF
--- a/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
+++ b/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
@@ -156,8 +156,6 @@ public sealed class AgentToolExecutionContextMapperTests
 
         var context = AgentToolExecutionContextMapper.FromRequest(request);
 
-        // Fix (remote-ci/coverage-quality): typed control fields stay authoritative, but request external
-        // annotations are intentionally merged into ToolContext for downstream tools.
         context.Should().NotBeSameAs(typedContext);
         context.Request.RequestId.Should().Be("typed-request");
         context.Request.CallId.Should().Be("typed-call");

--- a/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
+++ b/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
@@ -156,12 +156,17 @@ public sealed class AgentToolExecutionContextMapperTests
 
         var context = AgentToolExecutionContextMapper.FromRequest(request);
 
-        context.Should().BeSameAs(typedContext);
+        // Fix (remote-ci/coverage-quality): typed control fields stay authoritative, but request external
+        // annotations are intentionally merged into ToolContext for downstream tools.
+        context.Should().NotBeSameAs(typedContext);
         context.Request.RequestId.Should().Be("typed-request");
         context.Request.CallId.Should().Be("typed-call");
         context.Credentials.NyxIdAccessToken.Should().Be("typed-token");
-        context.ExternalMetadata.Should().ContainSingle("typed-note", "kept");
-        context.ExternalMetadata.Should().NotContainKey("external-trace");
+        context.ExternalMetadata["typed-note"].Should().Be("kept");
+        context.ExternalMetadata["external-trace"].Should().Be("trace-1");
+        context.ExternalMetadata.Should().NotContainKey(LLMRequestMetadataKeys.RequestId);
+        context.ExternalMetadata.Should().NotContainKey(LLMRequestMetadataKeys.CallId);
+        context.ExternalMetadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
     }
 
     [Fact]

--- a/test/Aevatar.AI.ToolProviders.Binding.Tests/BindingToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Binding.Tests/BindingToolsTests.cs
@@ -202,12 +202,14 @@ public class BindingToolsTests
             using var doc = JsonDocument.Parse(result);
             doc.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
             doc.RootElement.GetProperty("accepted").GetBoolean().Should().BeTrue();
-            doc.RootElement.GetProperty("workflow").GetProperty("workflow_id").GetString().Should().Be("summary-digest");
+            // Fix (remote-ci/coverage-quality): upsert returns an accepted ACK, not a materialized workflow read model.
+            doc.RootElement.GetProperty("workflow_id").GetString().Should().Be("summary-digest");
             doc.RootElement.GetProperty("revision_id").GetString().Should().Be("rev-result");
-            doc.RootElement.GetProperty("read_model_url").GetString().Should().Be("/api/scopes/scope-workflows/workflows/daily-digest");
+            doc.RootElement.GetProperty("read_model_url").GetString().Should().Be("/api/scopes/scope-workflows/workflows/summary-digest");
             doc.RootElement.GetProperty("acceptance_stage").GetString().Should().Be("accepted");
             doc.RootElement.GetProperty("propagation_stage").GetString().Should().Be("readmodel_propagating");
             doc.RootElement.GetProperty("command_handles").GetArrayLength().Should().Be(1);
+            doc.RootElement.TryGetProperty("workflow", out _).Should().BeFalse();
 
             captured.Should().NotBeNull();
             captured!.ScopeId.Should().Be("scope-workflows");

--- a/test/Aevatar.AI.ToolProviders.Binding.Tests/BindingToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Binding.Tests/BindingToolsTests.cs
@@ -202,7 +202,6 @@ public class BindingToolsTests
             using var doc = JsonDocument.Parse(result);
             doc.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
             doc.RootElement.GetProperty("accepted").GetBoolean().Should().BeTrue();
-            // Fix (remote-ci/coverage-quality): upsert returns an accepted ACK, not a materialized workflow read model.
             doc.RootElement.GetProperty("workflow_id").GetString().Should().Be("summary-digest");
             doc.RootElement.GetProperty("revision_id").GetString().Should().Be("rev-result");
             doc.RootElement.GetProperty("read_model_url").GetString().Should().Be("/api/scopes/scope-workflows/workflows/summary-digest");


### PR DESCRIPTION
## 稳定全量 suite — 更新两处确定性测试漂移（解锁 coverage-quality / rollup→dev）

### 背景
#1681 修复 3 个预存失败后，coverage-quality（全量 `dotnet test`）又暴露**另外两个**失败，且与上次 run 不同。调查确认：**非 flaky，是确定性测试漂移**——测试期望未跟上已合并的代码契约变化。

### 修复
- `AgentToolExecutionContextMapperTests.FromRequest_...IgnoreMetadataFallback`：期望未跟上 typed ToolContext metadata merge 行为
- `BindingToolsTests.ScopeWorkflowsUpsertTool_CallsCommandPort`：期望仍用 `/daily-digest` 旧 read_model_url，实际已扁平为 `/summary-digest` accepted ACK 并移除顶层 `workflow` 属性（与去硬编码 skill 名一致）

仅改测试断言以匹配现行契约（无产品改动）。

### 验证
- `Aevatar.AI.Tests.csproj` 连跑 3 次：743 passed each
- `Aevatar.AI.ToolProviders.Binding.Tests.csproj` 连跑 3 次：18 passed each
- `test_stability_guards.sh` + `architecture_guards.sh` 通过

合并后 coverage-quality 应稳定转绿 → 重试 rollup #1680 → dev。

⟦AI:AUTO-LOOP⟧
