### PR TITLE
Clarify Governance affordances

### DIFF
--- a/apps/aevatar-console-web/src/pages/governance/components/GovernanceAuditTimeline.test.tsx
+++ b/apps/aevatar-console-web/src/pages/governance/components/GovernanceAuditTimeline.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import GovernanceAuditTimeline, {
+  type GovernanceAuditEvent,
+} from "./GovernanceAuditTimeline";
+
+const auditEvent: GovernanceAuditEvent = {
+  action: "Endpoint exposure updated",
+  actor: "governance-worker",
+  at: "2026-04-16T10:00:00Z",
+  id: "event-1",
+  status: "public",
+  summary: "Endpoint chat is now public after catalog update.",
+  targetId: "chat",
+  targetKind: "endpoint",
+  targetLabel: "Chat endpoint",
+};
+
+describe("GovernanceAuditTimeline", () => {
+  it("renders audit events as read-only facts when no selection handler is provided", () => {
+    render(<GovernanceAuditTimeline events={[auditEvent]} />);
+
+    expect(screen.getByText("Endpoint exposure updated")).toBeInTheDocument();
+    expect(screen.getByText("Endpoint chat is now public after catalog update.")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("renders audit events as selectable buttons when a selection handler is provided", () => {
+    const onSelect = jest.fn();
+
+    render(
+      <GovernanceAuditTimeline
+        events={[auditEvent]}
+        onSelect={onSelect}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Endpoint exposure updated/ }));
+
+    expect(onSelect).toHaveBeenCalledWith(auditEvent);
+  });
+});

--- a/apps/aevatar-console-web/src/pages/governance/components/GovernanceAuditTimeline.tsx
+++ b/apps/aevatar-console-web/src/pages/governance/components/GovernanceAuditTimeline.tsx
@@ -86,6 +86,68 @@ function renderEventIcon(kind: GovernanceAuditEventTargetKind) {
   return <ClockCircleOutlined />;
 }
 
+function renderEventCard(
+  surfaceToken: AevatarThemeSurfaceToken,
+  event: GovernanceAuditEvent,
+) {
+  return (
+    <div
+      style={{
+        ...buildAevatarPanelStyle(surfaceToken, {
+          background: surfaceToken.colorFillAlter,
+          padding: 14,
+        }),
+        boxShadow: "none",
+      }}
+    >
+      <Space
+        align="start"
+        orientation="vertical"
+        size={10}
+        style={{ display: "flex" }}
+      >
+        <Space
+          align="center"
+          style={{
+            justifyContent: "space-between",
+            width: "100%",
+          }}
+          wrap
+        >
+          <Space size={[8, 8]} wrap>
+            <Typography.Text strong>{event.action}</Typography.Text>
+            <span
+              style={buildAevatarTagStyle(
+                surfaceToken,
+                "governance" as AevatarStatusDomain,
+                event.status,
+              )}
+            >
+              {formatAevatarStatusLabel(event.status)}
+            </span>
+          </Space>
+          <Typography.Text type="secondary">
+            {formatDateTime(event.at)}
+          </Typography.Text>
+        </Space>
+
+        <Typography.Paragraph style={{ margin: 0 }}>
+          {event.summary}
+        </Typography.Paragraph>
+
+        <Space size={[8, 8]} wrap>
+          <Typography.Text type="secondary">
+            来源: {event.actor}
+          </Typography.Text>
+          <Typography.Text type="secondary">
+            对象: {event.targetLabel}
+          </Typography.Text>
+        </Space>
+      </Space>
+    </div>
+  );
+}
+
 const GovernanceAuditTimeline: React.FC<GovernanceAuditTimelineProps> = ({
   events,
   loading = false,
@@ -136,7 +198,7 @@ const GovernanceAuditTimeline: React.FC<GovernanceAuditTimelineProps> = ({
             pending={loading ? "加载中..." : null}
             items={events.map((event) => ({
               color: buildEventDotColor(surfaceToken, event.status),
-              dot: (
+              icon: (
                 <span
                   style={{
                     alignItems: "center",
@@ -149,14 +211,14 @@ const GovernanceAuditTimeline: React.FC<GovernanceAuditTimelineProps> = ({
                   {renderEventIcon(event.targetKind)}
                 </span>
               ),
-              children: (
+              content: onSelect ? (
                 <button
                   className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
-                  onClick={() => onSelect?.(event)}
+                  onClick={() => onSelect(event)}
                   style={{
                     background: "transparent",
                     border: "none",
-                    cursor: onSelect ? "pointer" : "default",
+                    cursor: "pointer",
                     display: "block",
                     padding: 0,
                     textAlign: "left",
@@ -164,61 +226,10 @@ const GovernanceAuditTimeline: React.FC<GovernanceAuditTimelineProps> = ({
                   }}
                   type="button"
                 >
-                  <div
-                    style={{
-                      ...buildAevatarPanelStyle(surfaceToken, {
-                        background: surfaceToken.colorFillAlter,
-                        padding: 14,
-                      }),
-                      boxShadow: "none",
-                    }}
-                  >
-                    <Space
-                      align="start"
-                      orientation="vertical"
-                      size={10}
-                      style={{ display: "flex" }}
-                    >
-                      <Space
-                        align="center"
-                        style={{
-                          justifyContent: "space-between",
-                          width: "100%",
-                        }}
-                        wrap
-                      >
-                        <Space size={[8, 8]} wrap>
-                          <Typography.Text strong>{event.action}</Typography.Text>
-                          <span
-                            style={buildAevatarTagStyle(
-                              surfaceToken,
-                              "governance" as AevatarStatusDomain,
-                              event.status,
-                            )}
-                          >
-                            {formatAevatarStatusLabel(event.status)}
-                          </span>
-                        </Space>
-                        <Typography.Text type="secondary">
-                          {formatDateTime(event.at)}
-                        </Typography.Text>
-                      </Space>
-
-                      <Typography.Paragraph style={{ margin: 0 }}>
-                        {event.summary}
-                      </Typography.Paragraph>
-
-                      <Space size={[8, 8]} wrap>
-                        <Typography.Text type="secondary">
-                          来源: {event.actor}
-                        </Typography.Text>
-                        <Typography.Text type="secondary">
-                          对象: {event.targetLabel}
-                        </Typography.Text>
-                      </Space>
-                    </Space>
-                  </div>
+                  {renderEventCard(surfaceToken, event)}
                 </button>
+              ) : (
+                renderEventCard(surfaceToken, event)
               ),
             }))}
           />

--- a/apps/aevatar-console-web/src/pages/governance/components/GovernanceInspectorDrawer.test.tsx
+++ b/apps/aevatar-console-web/src/pages/governance/components/GovernanceInspectorDrawer.test.tsx
@@ -213,4 +213,146 @@ describe("GovernanceInspectorDrawer", () => {
       });
     });
   });
+
+  it("renders retired policies as read-only facts instead of editable controls", () => {
+    render(
+      <GovernanceInspectorDrawer
+        busyAction={null}
+        endpointCatalog={null}
+        identity={{
+          tenantId: "tenant-a",
+          appId: "app-a",
+          namespace: "default",
+        }}
+        onClose={jest.fn()}
+        onCreateBinding={jest.fn(async () => undefined)}
+        onCreateEndpoint={jest.fn(async () => undefined)}
+        onCreatePolicy={jest.fn(async () => undefined)}
+        onRetireBinding={jest.fn(async () => undefined)}
+        onRetirePolicy={jest.fn(async () => undefined)}
+        onSetEndpointExposure={jest.fn(async () => undefined)}
+        onUpdateEndpoint={jest.fn(async () => undefined)}
+        onUpdateBinding={jest.fn(async () => undefined)}
+        onUpdatePolicy={jest.fn(async () => undefined)}
+        open
+        policyOptions={[]}
+        serviceId="service-alpha"
+        target={{
+          kind: "policy",
+          mode: "edit",
+          record: {
+            activationRequiredBindingIds: [],
+            displayName: "Retired Policy",
+            invokeAllowedCallerServiceKeys: [],
+            invokeRequiresActiveDeployment: false,
+            policyId: "policy-retired",
+            retired: true,
+          },
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText("这条策略已经退役，是治理目录中的历史事实，不能继续保存或再次下线。"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "保存策略" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "下线策略" })).toBeNull();
+  });
+
+  it("renders retired bindings as read-only facts instead of editable controls", () => {
+    render(
+      <GovernanceInspectorDrawer
+        busyAction={null}
+        endpointCatalog={null}
+        identity={{
+          tenantId: "tenant-a",
+          appId: "app-a",
+          namespace: "default",
+        }}
+        onClose={jest.fn()}
+        onCreateBinding={jest.fn(async () => undefined)}
+        onCreateEndpoint={jest.fn(async () => undefined)}
+        onCreatePolicy={jest.fn(async () => undefined)}
+        onRetireBinding={jest.fn(async () => undefined)}
+        onRetirePolicy={jest.fn(async () => undefined)}
+        onSetEndpointExposure={jest.fn(async () => undefined)}
+        onUpdateEndpoint={jest.fn(async () => undefined)}
+        onUpdateBinding={jest.fn(async () => undefined)}
+        onUpdatePolicy={jest.fn(async () => undefined)}
+        open
+        policyOptions={[]}
+        serviceId="service-alpha"
+        target={{
+          kind: "binding",
+          mode: "edit",
+          record: {
+            bindingId: "binding-retired",
+            bindingKind: "service",
+            connectorRef: null,
+            displayName: "Retired Binding",
+            policyIds: [],
+            retired: true,
+            secretRef: null,
+            serviceRef: null,
+          },
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText("这条绑定已经退役，是治理目录中的历史事实，不能继续保存或再次下线。"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "保存绑定" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "下线绑定" })).toBeNull();
+  });
+
+  it("does not offer a repeated public exposure action for an already-public endpoint", () => {
+    render(
+      <GovernanceInspectorDrawer
+        busyAction={null}
+        endpointCatalog={{
+          endpoints: [],
+          serviceKey: "tenant-a/app-a/default/service-alpha",
+          updatedAt: "2026-04-16T10:00:00Z",
+        }}
+        identity={{
+          tenantId: "tenant-a",
+          appId: "app-a",
+          namespace: "default",
+        }}
+        onClose={jest.fn()}
+        onCreateBinding={jest.fn(async () => undefined)}
+        onCreateEndpoint={jest.fn(async () => undefined)}
+        onCreatePolicy={jest.fn(async () => undefined)}
+        onRetireBinding={jest.fn(async () => undefined)}
+        onRetirePolicy={jest.fn(async () => undefined)}
+        onSetEndpointExposure={jest.fn(async () => undefined)}
+        onUpdateEndpoint={jest.fn(async () => undefined)}
+        onUpdateBinding={jest.fn(async () => undefined)}
+        onUpdatePolicy={jest.fn(async () => undefined)}
+        open
+        policyOptions={[]}
+        serviceId="service-alpha"
+        target={{
+          kind: "endpoint",
+          mode: "edit",
+          record: {
+            description: "",
+            displayName: "Public Invoke",
+            endpointId: "invoke",
+            exposureKind: "public",
+            kind: "command",
+            policyIds: [],
+            requestTypeUrl: "type.googleapis.com/demo.Invoke",
+            responseTypeUrl: "",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "已公开" })).toBeDisabled();
+    expect(
+      screen.getByText("当前 endpoint catalog 已经观察到 public 状态，不再显示重复的公开切换。"),
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/aevatar-console-web/src/pages/governance/components/GovernanceInspectorDrawer.tsx
+++ b/apps/aevatar-console-web/src/pages/governance/components/GovernanceInspectorDrawer.tsx
@@ -40,6 +40,12 @@ import {
 } from "@/shared/ui/aevatarWorkbench";
 import { AevatarCompactText } from "@/shared/ui/compactText";
 import type { GovernanceAuditEvent } from "./GovernanceAuditTimeline";
+import {
+  resolveBindingAffordance,
+  resolveEndpointAffordance,
+  resolveEndpointExposureAction,
+  resolvePolicyAffordance,
+} from "./governanceAffordance";
 
 export type GovernanceInspectorTarget =
   | {
@@ -184,6 +190,16 @@ function renderList(values: string[]) {
   );
 }
 
+function renderFactNotice(summary: string) {
+  return (
+    <Alert
+      message={summary}
+      showIcon
+      type="info"
+    />
+  );
+}
+
 function buildInspectorTitle(target: GovernanceInspectorTarget | null): React.ReactNode {
   if (!target) {
     return "治理详情";
@@ -310,6 +326,28 @@ const GovernanceInspectorDrawer: React.FC<GovernanceInspectorDrawerProps> = ({
 
   const canManage = Boolean(identity && serviceId.trim());
   const bindingKind = Form.useWatch("bindingKind", bindingForm) ?? "service";
+  const policyAffordance =
+    target?.kind === "policy" ? resolvePolicyAffordance(target.record) : null;
+  const bindingAffordance =
+    target?.kind === "binding" ? resolveBindingAffordance(target.record) : null;
+  const endpointAffordance =
+    target?.kind === "endpoint" && target.mode === "edit"
+      ? resolveEndpointAffordance(target.record, endpointCatalog)
+      : null;
+  const endpointExposureAction =
+    target?.kind === "endpoint" && target.mode === "edit"
+      ? resolveEndpointExposureAction(target.record, endpointCatalog)
+      : null;
+  const canEditPolicy =
+    canManage && (target?.kind !== "policy" || policyAffordance?.editMode === "writable");
+  const canEditBinding =
+    canManage &&
+    (target?.kind !== "binding" || bindingAffordance?.editMode === "writable");
+  const canEditEndpoint =
+    canManage &&
+    (target?.kind !== "endpoint" ||
+      target.mode === "create" ||
+      endpointAffordance?.editMode === "writable");
 
   const policyAction =
     target?.kind === "policy" && target.mode === "create"
@@ -469,18 +507,21 @@ const GovernanceInspectorDrawer: React.FC<GovernanceInspectorDrawerProps> = ({
                     style={buildAevatarTagStyle(
                       surfaceToken,
                       "governance",
-                      buildPolicyStatus(target.record),
+                      policyAffordance?.status ?? buildPolicyStatus(target.record),
                     )}
                   >
-                    {formatAevatarStatusLabel(buildPolicyStatus(target.record))}
+                    {policyAffordance?.statusLabel ??
+                      formatAevatarStatusLabel(buildPolicyStatus(target.record))}
                   </span>
                 ) : null}
               </Space>
 
+              {policyAffordance ? renderFactNotice(policyAffordance.summary) : null}
+
               <Form<PolicyFormValues>
                 form={policyForm}
                 layout="vertical"
-                disabled={!canManage}
+                disabled={!canEditPolicy}
               >
                 <Form.Item
                   label="策略 ID"
@@ -524,14 +565,16 @@ const GovernanceInspectorDrawer: React.FC<GovernanceInspectorDrawerProps> = ({
               </Form>
 
               <Space wrap>
-                <Button
-                  loading={busyAction === policyAction}
-                  onClick={() => void submitPolicy()}
-                  type="primary"
-                >
-                  {target.mode === "create" ? "创建策略" : "保存策略"}
-                </Button>
-                {target.mode === "edit" ? (
+                {canEditPolicy ? (
+                  <Button
+                    loading={busyAction === policyAction}
+                    onClick={() => void submitPolicy()}
+                    type="primary"
+                  >
+                    {target.mode === "create" ? "创建策略" : "保存策略"}
+                  </Button>
+                ) : null}
+                {target.mode === "edit" && canEditPolicy ? (
                   <Button
                     danger
                     loading={busyAction === "retire-policy"}
@@ -570,18 +613,21 @@ const GovernanceInspectorDrawer: React.FC<GovernanceInspectorDrawerProps> = ({
                     style={buildAevatarTagStyle(
                       surfaceToken,
                       "governance",
-                      buildBindingStatus(target.record),
+                      bindingAffordance?.status ?? buildBindingStatus(target.record),
                     )}
                   >
-                    {formatAevatarStatusLabel(buildBindingStatus(target.record))}
+                    {bindingAffordance?.statusLabel ??
+                      formatAevatarStatusLabel(buildBindingStatus(target.record))}
                   </span>
                 ) : null}
               </Space>
 
+              {bindingAffordance ? renderFactNotice(bindingAffordance.summary) : null}
+
               <Form<BindingFormValues>
                 form={bindingForm}
                 layout="vertical"
-                disabled={!canManage}
+                disabled={!canEditBinding}
               >
                 <div
                   style={{
@@ -727,14 +773,16 @@ const GovernanceInspectorDrawer: React.FC<GovernanceInspectorDrawerProps> = ({
               </Form>
 
               <Space wrap>
-                <Button
-                  loading={busyAction === bindingAction}
-                  onClick={() => void submitBinding()}
-                  type="primary"
-                >
-                  {target.mode === "create" ? "创建绑定" : "保存绑定"}
-                </Button>
-                {target.mode === "edit" ? (
+                {canEditBinding ? (
+                  <Button
+                    loading={busyAction === bindingAction}
+                    onClick={() => void submitBinding()}
+                    type="primary"
+                  >
+                    {target.mode === "create" ? "创建绑定" : "保存绑定"}
+                  </Button>
+                ) : null}
+                {target.mode === "edit" && canEditBinding ? (
                   <Button
                     danger
                     loading={busyAction === "retire-binding"}
@@ -773,18 +821,21 @@ const GovernanceInspectorDrawer: React.FC<GovernanceInspectorDrawerProps> = ({
                     style={buildAevatarTagStyle(
                       surfaceToken,
                       "governance",
-                      buildEndpointStatus(target.record),
+                      endpointAffordance?.status ?? buildEndpointStatus(target.record),
                     )}
                   >
-                    {formatAevatarStatusLabel(buildEndpointStatus(target.record))}
+                    {endpointAffordance?.statusLabel ??
+                      formatAevatarStatusLabel(buildEndpointStatus(target.record))}
                   </span>
                 ) : null}
               </Space>
 
+              {endpointAffordance ? renderFactNotice(endpointAffordance.summary) : null}
+
               <Form<EndpointFormValues>
                 form={endpointForm}
                 layout="vertical"
-                disabled={!canManage || (target.mode === "edit" && !endpointCatalog)}
+                disabled={!canEditEndpoint}
               >
                 <div
                   style={{
@@ -881,24 +932,33 @@ const GovernanceInspectorDrawer: React.FC<GovernanceInspectorDrawerProps> = ({
 
               <Space wrap>
                 <Button
-                  disabled={!canManage || (target.mode === "edit" && !endpointCatalog)}
+                  disabled={!canEditEndpoint}
                   loading={busyAction === endpointAction}
                   onClick={() => void submitEndpoint()}
                   type="primary"
                 >
                   {target.mode === "create" ? "创建入口" : "保存入口"}
                 </Button>
-                {target.mode === "edit" ? (
+                {target.mode === "edit" && endpointExposureAction ? (
                   <Button
+                    disabled={endpointExposureAction.disabled}
                     loading={busyAction === "set-endpoint-exposure:public"}
                     onClick={() =>
-                      void onSetEndpointExposure(target.record.endpointId, "public")
+                      void onSetEndpointExposure(
+                        target.record.endpointId,
+                        endpointExposureAction.nextExposureKind,
+                      )
                     }
                   >
-                    快速公开
+                    {endpointExposureAction.label}
                   </Button>
                 ) : null}
               </Space>
+              {target.mode === "edit" && endpointExposureAction ? (
+                <Typography.Text type="secondary">
+                  {endpointExposureAction.reason}
+                </Typography.Text>
+              ) : null}
             </Space>
           </div>
         ) : null}
@@ -914,6 +974,9 @@ const GovernanceInspectorDrawer: React.FC<GovernanceInspectorDrawerProps> = ({
             }}
           >
             <Space orientation="vertical" size={16} style={{ display: "flex" }}>
+              {renderFactNotice(
+                "激活校验是当前 revision 与治理目录的只读诊断事实；这里不提交配置变更。",
+              )}
               <Space size={8} wrap>
                 <Typography.Text strong>版本</Typography.Text>
                 {target.record.revisionId ? (

--- a/apps/aevatar-console-web/src/pages/governance/components/GovernanceWorkbench.tsx
+++ b/apps/aevatar-console-web/src/pages/governance/components/GovernanceWorkbench.tsx
@@ -36,7 +36,6 @@ import type {
   ServiceRevisionSnapshot,
 } from "@/shared/models/services";
 import {
-  AEVATAR_GLOBAL_UI_SPEC,
   buildAevatarPanelStyle,
   buildAevatarTagStyle,
   buildAevatarViewportStyle,
@@ -71,6 +70,12 @@ import {
   readGovernanceWorkbenchView,
   type GovernanceDraft,
 } from "./governanceQuery";
+import {
+  buildGovernanceCommandReceipt,
+  observeGovernanceReceipt,
+  type GovernanceCatalogKind,
+  type GovernanceCommandReceipt,
+} from "./governanceCommandReceipt";
 
 type GovernanceNotice = {
   message: string;
@@ -502,6 +507,8 @@ const GovernanceWorkbench: React.FC = () => {
   const [draft, setDraft] = useState<GovernanceDraft>(initialDraft);
   const [activeDraft, setActiveDraft] = useState<GovernanceDraft>(initialDraft);
   const [notice, setNotice] = useState<GovernanceNotice | null>(null);
+  const [commandReceipt, setCommandReceipt] =
+    useState<GovernanceCommandReceipt | null>(null);
   const [busyAction, setBusyAction] = useState<string | null>(null);
   const [drawerTarget, setDrawerTarget] = useState<GovernanceInspectorTarget | null>(
     null,
@@ -771,6 +778,26 @@ const GovernanceWorkbench: React.FC = () => {
       selectedService?.updatedAt,
     ],
   );
+  const commandReceiptObservation = useMemo(() => {
+    if (!commandReceipt) {
+      return null;
+    }
+
+    if (commandReceipt.catalogKind === "bindings") {
+      return observeGovernanceReceipt(commandReceipt, bindingsQuery.data);
+    }
+
+    if (commandReceipt.catalogKind === "endpoints") {
+      return observeGovernanceReceipt(commandReceipt, endpointsQuery.data);
+    }
+
+    return observeGovernanceReceipt(commandReceipt, policiesQuery.data);
+  }, [
+    bindingsQuery.data,
+    commandReceipt,
+    endpointsQuery.data,
+    policiesQuery.data,
+  ]);
 
   const governanceMetrics = useMemo(
     () => [
@@ -1003,7 +1030,7 @@ const GovernanceWorkbench: React.FC = () => {
               })
             }
           >
-            配置
+            {record.retired ? "查看" : "配置"}
           </Button>
         ),
       },
@@ -1079,7 +1106,7 @@ const GovernanceWorkbench: React.FC = () => {
               })
             }
           >
-            配置
+            {record.retired ? "查看" : "配置"}
           </Button>
         ),
       },
@@ -1178,6 +1205,8 @@ const GovernanceWorkbench: React.FC = () => {
   const runGovernanceAction = useCallback(
     async (
       action: string,
+      catalogKind: GovernanceCatalogKind,
+      targetId: string,
       successMessage: string,
       task: () => Promise<unknown>,
       closeDrawer = false,
@@ -1185,6 +1214,13 @@ const GovernanceWorkbench: React.FC = () => {
       setBusyAction(action);
       try {
         await task();
+        setCommandReceipt(
+          buildGovernanceCommandReceipt({
+            catalogKind,
+            commandLabel: successMessage,
+            targetId,
+          }),
+        );
         setNotice({
           message: successMessage,
           tone: resolveAevatarSemanticTone("governance", action).startsWith("error")
@@ -1214,6 +1250,8 @@ const GovernanceWorkbench: React.FC = () => {
     async (input: ServicePolicyInput) => {
       await runGovernanceAction(
         "create-policy",
+        "policies",
+        input.policyId,
         `Policy ${input.policyId} was accepted for governance creation.`,
         () => governanceApi.createPolicy(activeDraft.serviceId, input),
         true,
@@ -1226,6 +1264,8 @@ const GovernanceWorkbench: React.FC = () => {
     async (input: ServiceBindingInput) => {
       await runGovernanceAction(
         "create-binding",
+        "bindings",
+        input.bindingId,
         `Binding ${input.bindingId} was accepted for governance creation.`,
         () => governanceApi.createBinding(activeDraft.serviceId, input),
         true,
@@ -1238,6 +1278,8 @@ const GovernanceWorkbench: React.FC = () => {
     async (bindingId: string, input: ServiceBindingInput) => {
       await runGovernanceAction(
         "save-binding",
+        "bindings",
+        bindingId,
         `Binding ${bindingId} was accepted for update.`,
         () => governanceApi.updateBinding(activeDraft.serviceId, bindingId, input),
         true,
@@ -1250,6 +1292,8 @@ const GovernanceWorkbench: React.FC = () => {
     async (policyId: string, input: ServicePolicyInput) => {
       await runGovernanceAction(
         "save-policy",
+        "policies",
+        policyId,
         `Policy ${policyId} was accepted for update.`,
         () => governanceApi.updatePolicy(activeDraft.serviceId, policyId, input),
         true,
@@ -1266,6 +1310,8 @@ const GovernanceWorkbench: React.FC = () => {
 
       await runGovernanceAction(
         "retire-policy",
+        "policies",
+        policyId,
         `Policy ${policyId} was accepted for retirement.`,
         () => governanceApi.retirePolicy(activeDraft.serviceId, policyId, activeIdentity),
         true,
@@ -1282,6 +1328,8 @@ const GovernanceWorkbench: React.FC = () => {
 
       await runGovernanceAction(
         "retire-binding",
+        "bindings",
+        bindingId,
         `Binding ${bindingId} was accepted for retirement.`,
         () =>
           governanceApi.retireBinding(
@@ -1315,6 +1363,8 @@ const GovernanceWorkbench: React.FC = () => {
 
       await runGovernanceAction(
         `set-endpoint-exposure:${exposureKind}`,
+        "endpoints",
+        endpointId,
         `Endpoint ${endpointId} was accepted for ${formatAevatarStatusLabel(exposureKind).toLowerCase()} exposure.`,
         () => governanceApi.updateEndpointCatalog(activeDraft.serviceId, payload),
         true,
@@ -1337,6 +1387,8 @@ const GovernanceWorkbench: React.FC = () => {
 
       await runGovernanceAction(
         "create-endpoint",
+        "endpoints",
+        input.endpointId,
         `Endpoint ${input.endpointId} was accepted for governance creation.`,
         () =>
           endpointsQuery.data
@@ -1363,6 +1415,8 @@ const GovernanceWorkbench: React.FC = () => {
 
       await runGovernanceAction(
         "save-endpoint",
+        "endpoints",
+        endpointId,
         `Endpoint ${endpointId} was accepted for update.`,
         () => governanceApi.updateEndpointCatalog(activeDraft.serviceId, payload),
         true,
@@ -1869,6 +1923,16 @@ const GovernanceWorkbench: React.FC = () => {
             onClose={() => setNotice(null)}
           />
         ) : null}
+        {commandReceipt && commandReceiptObservation ? (
+          <Alert
+            closable
+            description={`${commandReceipt.commandLabel} 目标 ${commandReceipt.targetId}。${commandReceiptObservation.summary}`}
+            message="治理命令已接收"
+            showIcon
+            type={commandReceiptObservation.observed ? "success" : "info"}
+            onClose={() => setCommandReceipt(null)}
+          />
+        ) : null}
 
         <GovernanceQueryCard
           draft={draft}
@@ -1881,6 +1945,7 @@ const GovernanceWorkbench: React.FC = () => {
             const nextActiveDraft = normalizeGovernanceDraft(draft);
             setDraft(nextActiveDraft);
             setActiveDraft(nextActiveDraft);
+            setCommandReceipt(null);
             navigateToGovernanceView(view, nextActiveDraft);
           }}
           onReset={() => {
@@ -1894,6 +1959,7 @@ const GovernanceWorkbench: React.FC = () => {
               : readGovernanceDraft("");
             setDraft(nextDraft);
             setActiveDraft(nextDraft);
+            setCommandReceipt(null);
             navigateToGovernanceView(view, nextDraft);
           }}
           revisionOptions={revisionOptions}

--- a/apps/aevatar-console-web/src/pages/governance/components/governanceAffordance.test.ts
+++ b/apps/aevatar-console-web/src/pages/governance/components/governanceAffordance.test.ts
@@ -1,0 +1,101 @@
+import type {
+  ServiceBindingSnapshot,
+  ServiceEndpointCatalogSnapshot,
+  ServiceEndpointExposureSnapshot,
+  ServicePolicySnapshot,
+} from "@/shared/models/governance";
+import {
+  resolveBindingAffordance,
+  resolveEndpointAffordance,
+  resolveEndpointExposureAction,
+  resolvePolicyAffordance,
+} from "./governanceAffordance";
+
+const activePolicy: ServicePolicySnapshot = {
+  activationRequiredBindingIds: [],
+  displayName: "Active policy",
+  invokeAllowedCallerServiceKeys: [],
+  invokeRequiresActiveDeployment: false,
+  policyId: "policy-active",
+  retired: false,
+};
+
+const activeBinding: ServiceBindingSnapshot = {
+  bindingId: "binding-active",
+  bindingKind: "service",
+  connectorRef: null,
+  displayName: "Active binding",
+  policyIds: [],
+  retired: false,
+  secretRef: null,
+  serviceRef: null,
+};
+
+const endpoint: ServiceEndpointExposureSnapshot = {
+  description: "",
+  displayName: "Invoke",
+  endpointId: "invoke",
+  exposureKind: "internal",
+  kind: "command",
+  policyIds: [],
+  requestTypeUrl: "type.googleapis.com/demo.Invoke",
+  responseTypeUrl: "",
+};
+
+const endpointCatalog: ServiceEndpointCatalogSnapshot = {
+  endpoints: [endpoint],
+  serviceKey: "tenant/app/default/service",
+  updatedAt: "2026-06-02T08:00:00Z",
+};
+
+describe("governanceAffordance", () => {
+  it("treats retired policies and bindings as read-only facts", () => {
+    expect(resolvePolicyAffordance({ ...activePolicy, retired: true })).toMatchObject({
+      editMode: "readonly",
+      status: "retired",
+    });
+    expect(resolveBindingAffordance({ ...activeBinding, retired: true })).toMatchObject({
+      editMode: "readonly",
+      status: "retired",
+    });
+  });
+
+  it("keeps active policies and bindings writable", () => {
+    expect(resolvePolicyAffordance(activePolicy)).toMatchObject({
+      editMode: "writable",
+      status: "active",
+    });
+    expect(resolveBindingAffordance(activeBinding)).toMatchObject({
+      editMode: "writable",
+      status: "active",
+    });
+  });
+
+  it("only exposes a public endpoint action when it can submit a real catalog update", () => {
+    expect(resolveEndpointExposureAction(endpoint, endpointCatalog)).toMatchObject({
+      disabled: false,
+      label: "公开入口",
+      nextExposureKind: "public",
+    });
+    expect(
+      resolveEndpointExposureAction(
+        { ...endpoint, exposureKind: "public" },
+        endpointCatalog,
+      ),
+    ).toMatchObject({
+      disabled: true,
+      label: "已公开",
+    });
+    expect(resolveEndpointExposureAction(endpoint, null)).toMatchObject({
+      disabled: true,
+      reason: expect.stringContaining("endpoint catalog"),
+    });
+  });
+
+  it("marks endpoint facts read-only when the catalog is missing", () => {
+    expect(resolveEndpointAffordance(endpoint, null)).toMatchObject({
+      editMode: "readonly",
+      status: "internal",
+    });
+  });
+});

--- a/apps/aevatar-console-web/src/pages/governance/components/governanceAffordance.test.ts
+++ b/apps/aevatar-console-web/src/pages/governance/components/governanceAffordance.test.ts
@@ -90,6 +90,11 @@ describe("governanceAffordance", () => {
       disabled: true,
       reason: expect.stringContaining("endpoint catalog"),
     });
+    expect(resolveEndpointExposureAction({ ...endpoint, exposureKind: "public" }, null)).toMatchObject({
+      disabled: true,
+      label: "已公开",
+      reason: expect.stringContaining("确认或提交"),
+    });
   });
 
   it("marks endpoint facts read-only when the catalog is missing", () => {

--- a/apps/aevatar-console-web/src/pages/governance/components/governanceAffordance.ts
+++ b/apps/aevatar-console-web/src/pages/governance/components/governanceAffordance.ts
@@ -1,0 +1,104 @@
+import type {
+  ServiceBindingSnapshot,
+  ServiceEndpointCatalogSnapshot,
+  ServiceEndpointExposureSnapshot,
+  ServicePolicySnapshot,
+} from "@/shared/models/governance";
+import { formatAevatarStatusLabel } from "@/shared/ui/aevatarWorkbench";
+
+export type GovernanceFactKind = "binding" | "endpoint" | "policy";
+
+export type GovernanceEditMode = "readonly" | "writable";
+
+export type GovernanceFactAffordance = {
+  readonly editMode: GovernanceEditMode;
+  readonly status: string;
+  readonly statusLabel: string;
+  readonly summary: string;
+};
+
+export type EndpointExposureAction = {
+  readonly disabled: boolean;
+  readonly label: string;
+  readonly nextExposureKind: string;
+  readonly reason: string;
+};
+
+export function normalizeGovernanceStatus(value: string | null | undefined): string {
+  return value?.trim().toLowerCase() || "";
+}
+
+export function resolvePolicyAffordance(
+  policy: ServicePolicySnapshot,
+): GovernanceFactAffordance {
+  const status = policy.retired ? "retired" : "active";
+  return {
+    editMode: policy.retired ? "readonly" : "writable",
+    status,
+    statusLabel: formatAevatarStatusLabel(status),
+    summary: policy.retired
+      ? "这条策略已经退役，是治理目录中的历史事实，不能继续保存或再次下线。"
+      : "这条策略仍处于激活目录中，可以修改规则或提交下线请求。",
+  };
+}
+
+export function resolveBindingAffordance(
+  binding: ServiceBindingSnapshot,
+): GovernanceFactAffordance {
+  const status = binding.retired ? "retired" : "active";
+  return {
+    editMode: binding.retired ? "readonly" : "writable",
+    status,
+    statusLabel: formatAevatarStatusLabel(status),
+    summary: binding.retired
+      ? "这条绑定已经退役，是治理目录中的历史事实，不能继续保存或再次下线。"
+      : "这条绑定仍处于激活目录中，可以修改目标、挂载策略或提交下线请求。",
+  };
+}
+
+export function resolveEndpointAffordance(
+  endpoint: ServiceEndpointExposureSnapshot,
+  catalog: ServiceEndpointCatalogSnapshot | null,
+): GovernanceFactAffordance {
+  const status = normalizeGovernanceStatus(endpoint.exposureKind) || "internal";
+  const hasCatalog = Boolean(catalog);
+  return {
+    editMode: hasCatalog ? "writable" : "readonly",
+    status,
+    statusLabel: formatAevatarStatusLabel(status),
+    summary: hasCatalog
+      ? "暴露状态来自当前 endpoint catalog；保存入口会提交整份目录更新。"
+      : "当前无法读取 endpoint catalog，只能查看这条入口事实，不能提交修改。",
+  };
+}
+
+export function resolveEndpointExposureAction(
+  endpoint: ServiceEndpointExposureSnapshot,
+  catalog: ServiceEndpointCatalogSnapshot | null,
+): EndpointExposureAction | null {
+  const currentExposure = normalizeGovernanceStatus(endpoint.exposureKind) || "internal";
+  if (currentExposure === "public") {
+    return {
+      disabled: true,
+      label: "已公开",
+      nextExposureKind: "public",
+      reason: "当前 endpoint catalog 已经观察到 public 状态，不再显示重复的公开切换。",
+    };
+  }
+
+  if (!catalog) {
+    return {
+      disabled: true,
+      label: "公开入口",
+      nextExposureKind: "public",
+      reason: "需要先读取 endpoint catalog，才能提交暴露状态更新。",
+    };
+  }
+
+  return {
+    disabled: false,
+    label: "公开入口",
+    nextExposureKind: "public",
+    reason: "提交后需要等待 endpoint catalog 再次刷新，才表示 public 状态已被观察到。",
+  };
+}

--- a/apps/aevatar-console-web/src/pages/governance/components/governanceAffordance.ts
+++ b/apps/aevatar-console-web/src/pages/governance/components/governanceAffordance.ts
@@ -77,21 +77,21 @@ export function resolveEndpointExposureAction(
   catalog: ServiceEndpointCatalogSnapshot | null,
 ): EndpointExposureAction | null {
   const currentExposure = normalizeGovernanceStatus(endpoint.exposureKind) || "internal";
+  if (!catalog) {
+    return {
+      disabled: true,
+      label: currentExposure === "public" ? "已公开" : "公开入口",
+      nextExposureKind: "public",
+      reason: "需要先读取 endpoint catalog，才能确认或提交暴露状态更新。",
+    };
+  }
+
   if (currentExposure === "public") {
     return {
       disabled: true,
       label: "已公开",
       nextExposureKind: "public",
       reason: "当前 endpoint catalog 已经观察到 public 状态，不再显示重复的公开切换。",
-    };
-  }
-
-  if (!catalog) {
-    return {
-      disabled: true,
-      label: "公开入口",
-      nextExposureKind: "public",
-      reason: "需要先读取 endpoint catalog，才能提交暴露状态更新。",
     };
   }
 

--- a/apps/aevatar-console-web/src/pages/governance/components/governanceCommandReceipt.test.ts
+++ b/apps/aevatar-console-web/src/pages/governance/components/governanceCommandReceipt.test.ts
@@ -1,0 +1,50 @@
+import type { ServicePolicyCatalogSnapshot } from "@/shared/models/governance";
+import { observeGovernanceReceipt, type GovernanceCommandReceipt } from "./governanceCommandReceipt";
+
+const receipt: GovernanceCommandReceipt = {
+  acceptedAt: "2026-06-02T09:30:00Z",
+  catalogKind: "policies",
+  commandLabel: "Policy policy-a was accepted for update.",
+  targetId: "policy-a",
+};
+
+function buildPolicyCatalog(updatedAt: string): ServicePolicyCatalogSnapshot {
+  return {
+    policies: [],
+    serviceKey: "tenant/app/default/service",
+    updatedAt,
+  };
+}
+
+describe("governanceCommandReceipt", () => {
+  it("does not treat a stale catalog as observed evidence", () => {
+    expect(
+      observeGovernanceReceipt(
+        receipt,
+        buildPolicyCatalog("2026-06-02T09:29:59Z"),
+      ),
+    ).toMatchObject({
+      catalogLabel: "Policy catalog",
+      observed: false,
+    });
+  });
+
+  it("marks the receipt observed after the matching catalog refreshes", () => {
+    expect(
+      observeGovernanceReceipt(
+        receipt,
+        buildPolicyCatalog("2026-06-02T09:31:00Z"),
+      ),
+    ).toMatchObject({
+      catalogLabel: "Policy catalog",
+      observed: true,
+    });
+  });
+
+  it("keeps missing catalogs in accepted-only state", () => {
+    expect(observeGovernanceReceipt(receipt, null)).toMatchObject({
+      observed: false,
+      summary: expect.stringContaining("命令已接收"),
+    });
+  });
+});

--- a/apps/aevatar-console-web/src/pages/governance/components/governanceCommandReceipt.ts
+++ b/apps/aevatar-console-web/src/pages/governance/components/governanceCommandReceipt.ts
@@ -1,0 +1,76 @@
+import type {
+  ServiceBindingCatalogSnapshot,
+  ServiceEndpointCatalogSnapshot,
+  ServicePolicyCatalogSnapshot,
+} from "@/shared/models/governance";
+import { formatGovernanceTimestamp } from "./GovernanceResultPanels";
+
+export type GovernanceCatalogKind = "bindings" | "endpoints" | "policies";
+
+export type GovernanceCommandReceipt = {
+  readonly acceptedAt: string;
+  readonly catalogKind: GovernanceCatalogKind;
+  readonly commandLabel: string;
+  readonly targetId: string;
+};
+
+export type GovernanceReceiptObservation = {
+  readonly catalogLabel: string;
+  readonly observed: boolean;
+  readonly summary: string;
+  readonly updatedAt?: string;
+};
+
+type GovernanceCatalogSnapshot =
+  | ServiceBindingCatalogSnapshot
+  | ServiceEndpointCatalogSnapshot
+  | ServicePolicyCatalogSnapshot
+  | null
+  | undefined;
+
+const catalogLabels: Record<GovernanceCatalogKind, string> = {
+  bindings: "Binding catalog",
+  endpoints: "Endpoint catalog",
+  policies: "Policy catalog",
+};
+
+export function buildGovernanceCommandReceipt(input: {
+  readonly catalogKind: GovernanceCatalogKind;
+  readonly commandLabel: string;
+  readonly targetId: string;
+}): GovernanceCommandReceipt {
+  return {
+    ...input,
+    acceptedAt: new Date().toISOString(),
+  };
+}
+
+export function observeGovernanceReceipt(
+  receipt: GovernanceCommandReceipt,
+  catalog: GovernanceCatalogSnapshot,
+): GovernanceReceiptObservation {
+  const catalogLabel = catalogLabels[receipt.catalogKind];
+  const updatedAt = catalog?.updatedAt?.trim() || undefined;
+  if (!updatedAt) {
+    return {
+      catalogLabel,
+      observed: false,
+      summary: `${catalogLabel} 还没有返回更新时间；当前只知道命令已接收。`,
+    };
+  }
+
+  const acceptedTime = Date.parse(receipt.acceptedAt);
+  const observedTime = Date.parse(updatedAt);
+  const observed = Number.isFinite(acceptedTime) && Number.isFinite(observedTime)
+    ? observedTime >= acceptedTime
+    : false;
+
+  return {
+    catalogLabel,
+    observed,
+    summary: observed
+      ? `${catalogLabel} 已在 ${formatGovernanceTimestamp(updatedAt)} 之后刷新。`
+      : `${catalogLabel} 更新时间仍早于本次命令接收时间，暂不能当作已观察。`,
+    updatedAt,
+  };
+}

--- a/apps/aevatar-console-web/src/pages/governance/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/governance/index.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { renderWithQueryClient } from '../../../tests/reactQueryTestUtils';
 import GovernanceIndexPage from './index';
+import { governanceApi } from '@/shared/api/governanceApi';
 
 jest.mock('@/shared/api/servicesApi', () => ({
   servicesApi: {
@@ -67,12 +68,37 @@ jest.mock('@/shared/api/governanceApi', () => ({
     getEndpointCatalog: jest.fn(async () => ({
       serviceKey: 'tenant-a/app-a/default/service-alpha',
       updatedAt: '2026-03-25T10:00:00Z',
-      endpoints: [],
+      endpoints: [
+        {
+          description: 'Invoke command',
+          displayName: 'Invoke',
+          endpointId: 'invoke',
+          exposureKind: 'internal',
+          kind: 'command',
+          policyIds: [],
+          requestTypeUrl: 'type.googleapis.com/demo.Invoke',
+          responseTypeUrl: '',
+        },
+      ],
     })),
     getPolicies: jest.fn(async () => ({
       serviceKey: 'tenant-a/app-a/default/service-alpha',
       updatedAt: '2026-03-25T10:00:00Z',
-      policies: [],
+      policies: [
+        {
+          activationRequiredBindingIds: [],
+          displayName: 'Retired Policy',
+          invokeAllowedCallerServiceKeys: [],
+          invokeRequiresActiveDeployment: false,
+          policyId: 'policy-retired',
+          retired: true,
+        },
+      ],
+    })),
+    updateEndpointCatalog: jest.fn(async () => ({
+      commandId: 'command-1',
+      correlationId: 'correlation-1',
+      targetActorId: 'actor://governance',
     })),
   },
 }));
@@ -148,5 +174,39 @@ describe('GovernanceIndexPage', () => {
 
     expect(await screen.findByText('选择一个服务')).toBeTruthy();
     expect(screen.queryByRole('button', { name: '新建绑定' })).toBeNull();
+  });
+
+  it('labels retired policy rows as view-only entries', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/governance?tenantId=tenant-a&appId=app-a&namespace=default&serviceId=service-alpha&view=policies',
+    );
+
+    renderWithQueryClient(React.createElement(GovernanceIndexPage));
+
+    expect(await screen.findByText('Retired Policy')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '查看' })).toBeInTheDocument();
+  });
+
+  it('keeps endpoint update receipts separate from observed catalog refresh', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/governance?tenantId=tenant-a&appId=app-a&namespace=default&serviceId=service-alpha&view=endpoints',
+    );
+
+    renderWithQueryClient(React.createElement(GovernanceIndexPage));
+
+    fireEvent.click(await screen.findByRole('button', { name: '配置' }));
+    fireEvent.click(await screen.findByRole('button', { name: '保存入口' }));
+
+    await waitFor(() => {
+      expect(governanceApi.updateEndpointCatalog).toHaveBeenCalled();
+    });
+    expect(await screen.findByText('治理命令已接收')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Endpoint invoke was accepted for update.*暂不能当作已观察/),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Problem

Refs #1667.

Governance screens still showed several false affordances: retired policy and binding facts looked editable, endpoint exposure appeared as repeated quick-toggle UI even when already public, command acceptance looked too close to read-model observation, and audit timeline rows were rendered as buttons even when no selection behavior existed.

## Solution

- Add explicit affordance helpers for policy, binding, and endpoint lifecycle states.
- Render retired policy and binding records as read-only facts with save/retire actions removed.
- Separate accepted governance commands from observed catalog refresh state.
- Disable already-public endpoint exposure action and explain the persisted fact.
- Render audit timeline rows as static facts unless a real selection callback is provided.
- Update focused governance tests for the false-affordance paths.

## Impact Paths

- apps/aevatar-console-web/src/pages/governance/components/GovernanceInspectorDrawer.tsx
- apps/aevatar-console-web/src/pages/governance/components/GovernanceWorkbench.tsx
- apps/aevatar-console-web/src/pages/governance/components/GovernanceAuditTimeline.tsx
- apps/aevatar-console-web/src/pages/governance/components/governanceAffordance.ts
- apps/aevatar-console-web/src/pages/governance/components/governanceCommandReceipt.ts
- apps/aevatar-console-web/src/pages/governance/**/*.test.tsx

## Verification

- `git diff --check` -> passed, no output
- `npm run biome:lint -- src/pages/governance/components/GovernanceAuditTimeline.tsx src/pages/governance/components/GovernanceAuditTimeline.test.tsx src/pages/governance/components/GovernanceInspectorDrawer.tsx src/pages/governance/components/GovernanceInspectorDrawer.test.tsx src/pages/governance/components/GovernanceWorkbench.tsx src/pages/governance/components/governanceAffordance.ts src/pages/governance/components/governanceAffordance.test.ts src/pages/governance/components/governanceCommandReceipt.ts src/pages/governance/components/governanceCommandReceipt.test.ts src/pages/governance/index.test.tsx` -> passed
- `npm run jest -- src/pages/governance/components/GovernanceAuditTimeline.test.tsx src/pages/governance/components/governanceAffordance.test.ts src/pages/governance/components/governanceCommandReceipt.test.ts src/pages/governance/components/GovernanceInspectorDrawer.test.tsx src/pages/governance/index.test.tsx --runInBand` -> passed, 5 suites / 22 tests
- `npm run tsc` -> passed
- `bash tools/ci/test_stability_guards.sh` -> unavailable in this environment, returned EXIT:127

## Backend Boundary

No backend, proto, API, actor, projection, workflow, runtime, database, backend test, backend config, or architecture doc files were modified.

## Merge Policy

No auto-merge requested or attempted. This PR should stop at waiting for user review/merge.
