### PR TITLE
refactor(#1536): ConversationGAgent bounded actor-owned immediate retry for typed transient Nyx relay interim-update

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.NyxRelayStreaming.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.NyxRelayStreaming.cs
@@ -60,7 +60,8 @@ public sealed partial class ConversationGAgent
         string? PendingFinalizeText,
         string? PendingFinalizeCommandId,
         LlmReplyTerminalState PendingTerminalState,
-        IReadOnlyList<ConversationHistoryEntry> PendingAppendedHistory)
+        IReadOnlyList<ConversationHistoryEntry> PendingAppendedHistory,
+        int RetryAttempt)
     {
         public static NyxRelayStreamingState Initial { get; } =
             new(
@@ -75,7 +76,8 @@ public sealed partial class ConversationGAgent
                 PendingFinalizeText: null,
                 PendingFinalizeCommandId: null,
                 PendingTerminalState: LlmReplyTerminalState.Unspecified,
-                PendingAppendedHistory: []);
+                PendingAppendedHistory: [],
+                RetryAttempt: 0);
 
         public bool AllowsInterimEdit =>
             Phase is NyxRelayStreamingPhase.Idle
@@ -148,7 +150,8 @@ public sealed partial class ConversationGAgent
             NormalizeOptional(lifecycle.PendingFinalizeText),
             NormalizeOptional(lifecycle.PendingFinalizeCommandId),
             lifecycle.PendingNyxRelayTerminalState,
-            lifecycle.PendingAppendedHistory.Select(entry => entry.Clone()).ToArray());
+            lifecycle.PendingAppendedHistory.Select(entry => entry.Clone()).ToArray(),
+            lifecycle.NyxRelayRetryAttempt);
     }
 
     /// <summary>
@@ -212,6 +215,9 @@ public sealed partial class ConversationGAgent
             PendingTerminalState = IsTerminalNyxRelayStreamingPhase(next)
                 ? LlmReplyTerminalState.Unspecified
                 : carried.PendingTerminalState,
+            RetryAttempt = IsTerminalNyxRelayStreamingPhase(next)
+                ? 0
+                : carried.RetryAttempt,
             TerminalReason = IsTerminalNyxRelayStreamingPhase(next)
                 ? (terminalReason ?? carried.TerminalReason)
                 : carried.TerminalReason,
@@ -306,6 +312,8 @@ public sealed partial class ConversationGAgent
             evt.NyxRelayTerminalState = updated.PendingTerminalState;
         if (!HistoryEntriesEqual(current.PendingAppendedHistory, updated.PendingAppendedHistory))
             evt.AppendedHistory.AddRange(updated.PendingAppendedHistory.Select(entry => entry.Clone()));
+        if (current.RetryAttempt != updated.RetryAttempt)
+            evt.NyxRelayRetryAttempt = updated.RetryAttempt;
 
         return evt;
     }

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -65,6 +65,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
     private const int RelayReplayClaimsCap = 10000;
     private const int PendingRelayAdmissionsCap = 1000;
     private const int RetainedHistoryMessagesCap = 100;
+    private const int MaxNyxRelayInterimUpdateRetryCount = 2;
 
     /// <summary>
     /// Sliding window cap on retained processed ids. Keeps state size bounded while still
@@ -951,6 +952,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
                     generation),
                 OperationGeneration = generation,
                 PendingAccumulatedText = evt.AccumulatedText,
+                RetryAttempt = 0,
             });
         await ScheduleNyxRelayTextOperationTimeoutAsync(
             correlationId,
@@ -1063,6 +1065,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
                         sequence,
                         generation),
                     OperationGeneration = generation,
+                    RetryAttempt = 0,
                 });
             await ScheduleNyxRelayTextOperationTimeoutAsync(
                 correlationId,
@@ -1136,6 +1139,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
                         sequence,
                         generation),
                     OperationGeneration = generation,
+                    RetryAttempt = 0,
                 });
             await ScheduleNyxRelayTextOperationTimeoutAsync(
                 correlationId,
@@ -1513,6 +1517,37 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         var result = ToStreamChunkResult(evt);
         if (!result.Success)
         {
+            if (ShouldRetryNyxRelayInterimUpdate(result, state))
+            {
+                var retryAttempt = state.RetryAttempt + 1;
+                var retryGeneration = NextNyxRelayTextOperationGeneration(state);
+                await TransitionNyxRelayStreamingPhaseAsync(
+                    correlationId,
+                    state,
+                    state.Phase,
+                    fieldUpdate: s => s with
+                    {
+                        InFlight = new NyxRelayTextOperationInFlight(
+                            NyxRelayTextOperationKind.Interim,
+                            evt.Sequence,
+                            retryGeneration),
+                        OperationGeneration = retryGeneration,
+                        RetryAttempt = retryAttempt,
+                    });
+                await StartNyxRelayTextOperationAsync(
+                    NyxRelayTextOperationKind.Interim,
+                    evt.Chunk?.Clone() ?? new LlmReplyStreamChunkEvent(),
+                    correlationId,
+                    NormalizeOptional(evt.CurrentPlatformMessageId) ?? state.PlatformMessageId,
+                    commandId: string.Empty,
+                    finalText: string.Empty,
+                    lastFlushedText: state.LastFlushedText,
+                    editCount: state.EditCount,
+                    evt.Sequence,
+                    retryGeneration);
+                return;
+            }
+
             if (state.AllowsFinalEdit)
             {
                 Logger.LogInformation(
@@ -1525,7 +1560,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
                     state,
                     NyxRelayStreamingPhase.SuppressingInterim,
                     terminalReason: $"interim_edit_failed:{result.ErrorCode}",
-                    fieldUpdate: s => s with { InFlight = null });
+                    fieldUpdate: s => s with { InFlight = null, RetryAttempt = 0 });
             }
             else
             {
@@ -1539,7 +1574,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
                     state,
                     NyxRelayStreamingPhase.DisabledPreSend,
                     terminalReason: $"first_send_failed:{result.ErrorCode}",
-                    fieldUpdate: s => s with { InFlight = null });
+                    fieldUpdate: s => s with { InFlight = null, RetryAttempt = 0 });
             }
             return;
         }
@@ -1563,9 +1598,18 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
                 EditCount = isFirstChunk ? 0 : s.EditCount + 1,
                 InFlight = null,
                 PendingAccumulatedText = pendingText,
+                RetryAttempt = 0,
             });
         await ContinueNyxRelayTextCoalescedWorkAsync(correlationId, updated, evt.Chunk);
     }
+
+    private static bool ShouldRetryNyxRelayInterimUpdate(
+        ConversationStreamChunkResult result,
+        NyxRelayStreamingState state) =>
+        state.AllowsFinalEdit &&
+        result.FailureKind == FailureKind.TransientAdapterError &&
+        (result.RetryAfter is null || result.RetryAfter <= TimeSpan.Zero) &&
+        state.RetryAttempt < MaxNyxRelayInterimUpdateRetryCount;
 
     private async Task HandleNyxRelayTextFailureSelfHealCompletionAsync(
         string correlationId,
@@ -1587,7 +1631,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
                 state,
                 NyxRelayStreamingPhase.TerminalSucceeded,
                 terminalReason: "failed_self_heal",
-                fieldUpdate: s => s with { InFlight = null });
+                fieldUpdate: s => s with { InFlight = null, RetryAttempt = 0 });
             await PersistStreamedCompletionAsync(evt, commandId, platformMessageId, failureText, state.EditCount + 1);
             return;
         }
@@ -1602,7 +1646,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             state,
             NyxRelayStreamingPhase.TerminalPartial,
             terminalReason: $"failed_self_heal_edit_failed:{result.ErrorCode}",
-            fieldUpdate: s => s with { InFlight = null });
+            fieldUpdate: s => s with { InFlight = null, RetryAttempt = 0 });
         await PersistStreamedCompletionAsync(evt, commandId, platformMessageId, state.LastFlushedText, state.EditCount);
     }
 
@@ -1627,7 +1671,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
                 state,
                 NyxRelayStreamingPhase.TerminalPartial,
                 terminalReason: $"final_edit_failed:{result.ErrorCode}",
-                fieldUpdate: s => s with { InFlight = null });
+                fieldUpdate: s => s with { InFlight = null, RetryAttempt = 0 });
             await PersistStreamedCompletionAsync(evt, commandId, platformMessageId, state.LastFlushedText, state.EditCount);
             return;
         }
@@ -1642,6 +1686,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
                 LastFlushedText = finalText,
                 EditCount = state.EditCount + 1,
                 InFlight = null,
+                RetryAttempt = 0,
             });
         await PersistStreamedCompletionAsync(evt, commandId, platformMessageId, finalText, state.EditCount + 1);
     }
@@ -1668,7 +1713,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
                         state,
                         NyxRelayStreamingPhase.SuppressingInterim,
                         terminalReason: "interim_edit_timeout",
-                        fieldUpdate: s => s with { InFlight = null });
+                        fieldUpdate: s => s with { InFlight = null, RetryAttempt = 0 });
                 }
                 else
                 {
@@ -1677,7 +1722,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
                         state,
                         NyxRelayStreamingPhase.DisabledPreSend,
                         terminalReason: "first_send_timeout",
-                        fieldUpdate: s => s with { InFlight = null });
+                        fieldUpdate: s => s with { InFlight = null, RetryAttempt = 0 });
                 }
                 return;
             case NyxRelayTextOperationKind.FailureSelfHeal:
@@ -1686,7 +1731,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
                     state,
                     NyxRelayStreamingPhase.TerminalPartial,
                     terminalReason: "failed_self_heal_timeout",
-                    fieldUpdate: s => s with { InFlight = null });
+                    fieldUpdate: s => s with { InFlight = null, RetryAttempt = 0 });
                 await PersistStreamedCompletionAsync(
                     evt,
                     NormalizeOptional(evt.CommandId) ?? state.PendingFinalizeCommandId ?? BuildLlmReplyCommandId(correlationId),
@@ -1700,7 +1745,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
                     state,
                     NyxRelayStreamingPhase.TerminalPartial,
                     terminalReason: "final_edit_timeout",
-                    fieldUpdate: s => s with { InFlight = null });
+                    fieldUpdate: s => s with { InFlight = null, RetryAttempt = 0 });
                 await PersistStreamedCompletionAsync(
                     evt,
                     NormalizeOptional(evt.CommandId) ?? state.PendingFinalizeCommandId ?? BuildLlmReplyCommandId(correlationId),
@@ -2568,6 +2613,8 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             lifecycle.PendingFinalizeCommandId = evt.FinalizeCommandId ?? string.Empty;
         if (evt.HasNyxRelayTerminalState)
             lifecycle.PendingNyxRelayTerminalState = evt.NyxRelayTerminalState;
+        if (evt.HasNyxRelayRetryAttempt)
+            lifecycle.NyxRelayRetryAttempt = evt.NyxRelayRetryAttempt;
         if (evt.AppendedHistory.Count > 0)
         {
             lifecycle.PendingAppendedHistory.Clear();

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
@@ -219,6 +219,7 @@ message ConversationReplyLifecycleChangedEvent {
   optional string finalize_command_id = 41;
   optional LlmReplyTerminalState nyx_relay_terminal_state = 42;
   repeated ConversationHistoryEntry appended_history = 43;
+  optional int32 nyx_relay_retry_attempt = 44;
 }
 
 // Refactor (iter20/cluster-004):

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_state.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_state.proto
@@ -59,6 +59,7 @@ message ConversationReplyLifecycleState {
   int64 nyx_relay_operation_generation = 22;
   LlmReplyTerminalState pending_nyx_relay_terminal_state = 23;
   repeated ConversationHistoryEntry pending_appended_history = 24;
+  int32 nyx_relay_retry_attempt = 25;
 }
 
 // Channel-sink ack tracking for the most recent reply turn. Carries either

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelRuntimeProtoTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelRuntimeProtoTests.cs
@@ -61,6 +61,33 @@ public sealed class ChannelRuntimeProtoTests
     }
 
     [Fact]
+    public void ConversationReplyLifecycleStateAndEvent_ShouldRoundtripNyxRelayRetryAttempt()
+    {
+        var state = new ConversationReplyLifecycleState
+        {
+            CorrelationId = "corr-retry",
+            Mode = ConversationReplyLifecycleMode.NyxRelayText,
+            Phase = ConversationReplyLifecyclePhase.TextStreaming,
+            NyxRelayRetryAttempt = 2,
+        };
+        var evt = new ConversationReplyLifecycleChangedEvent
+        {
+            CorrelationId = "corr-retry",
+            Mode = ConversationReplyLifecycleMode.NyxRelayText,
+            PreviousPhase = ConversationReplyLifecyclePhase.TextStreaming,
+            Phase = ConversationReplyLifecyclePhase.TextStreaming,
+            NyxRelayRetryAttempt = 2,
+        };
+
+        var parsedState = ConversationReplyLifecycleState.Parser.ParseFrom(state.ToByteArray());
+        var parsedEvent = ConversationReplyLifecycleChangedEvent.Parser.ParseFrom(evt.ToByteArray());
+
+        parsedState.NyxRelayRetryAttempt.ShouldBe(2);
+        parsedEvent.HasNyxRelayRetryAttempt.ShouldBeTrue();
+        parsedEvent.NyxRelayRetryAttempt.ShouldBe(2);
+    }
+
+    [Fact]
     public void LeaseToken_ShouldKeepOwnerBytesAtFieldOneAndExpiryAtFieldTwo()
     {
         var ownerField = LeaseToken.Descriptor.FindFieldByNumber(1);

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -2143,6 +2143,179 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
+    public async Task HandleLlmReplyStreamChunkAsync_TransientInterimEditFailure_RetriesImmediateSelfOperation()
+    {
+        var callCount = 0;
+        var runner = new RecordingTurnRunner
+        {
+            StreamChunkResultFactory = (_, pmid) =>
+            {
+                callCount++;
+                return callCount switch
+                {
+                    1 => ConversationStreamChunkResult.Succeeded("om_retry_success"),
+                    2 => ConversationStreamChunkResult.Failed(
+                        "relay_reply_update_rejected",
+                        "transient",
+                        failureKind: FailureKind.TransientAdapterError),
+                    _ => ConversationStreamChunkResult.Succeeded(pmid ?? "om_retry_success"),
+                };
+            },
+        };
+        var dispatch = new RecordingActorDispatchPort();
+        var (agent, _) = CreateAgent(runner, "conv-stream-interim-retry", dispatchPort: dispatch);
+
+        await agent.HandleLlmReplyStreamChunkAsync(
+            CreateStreamChunk("act-stream-interim-retry", "relay-msg-1", "hello"));
+        await CompleteNextNyxRelayTextOperationAsync(agent, dispatch);
+
+        await agent.HandleLlmReplyStreamChunkAsync(
+            CreateStreamChunk("act-stream-interim-retry", "relay-msg-1", "hello world"));
+        var failed = await CompleteNextNyxRelayTextOperationAsync(agent, dispatch);
+        var lifecycleAfterRetryQueued = agent.State.ActiveReplyLifecycles.ShouldHaveSingleItem();
+        lifecycleAfterRetryQueued.NyxRelayRetryAttempt.ShouldBe(1);
+        lifecycleAfterRetryQueued.NyxRelayOperationGeneration.ShouldBe(failed.OperationGeneration + 1);
+        lifecycleAfterRetryQueued.NyxRelayInFlightSequence.ShouldBe(failed.Sequence);
+
+        await CompleteNextNyxRelayTextOperationAsync(agent, dispatch);
+
+        callCount.ShouldBe(3);
+        var lifecycle = agent.State.ActiveReplyLifecycles.ShouldHaveSingleItem();
+        lifecycle.Phase.ShouldBe(ConversationReplyLifecyclePhase.TextStreaming);
+        lifecycle.LastFlushedText.ShouldBe("hello world");
+        lifecycle.NyxRelayRetryAttempt.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task HandleLlmReplyStreamChunkAsync_TransientInterimEditRetryExhaustion_SuppressesInterimButAllowsFinalEdit()
+    {
+        var callCount = 0;
+        var runner = new RecordingTurnRunner
+        {
+            StreamChunkResultFactory = (_, pmid) =>
+            {
+                callCount++;
+                if (callCount == 1)
+                    return ConversationStreamChunkResult.Succeeded("om_retry_exhaust");
+                if (callCount <= 4)
+                    return ConversationStreamChunkResult.Failed(
+                        "relay_reply_update_rejected",
+                        "transient",
+                        failureKind: FailureKind.TransientAdapterError);
+                return ConversationStreamChunkResult.Succeeded(pmid ?? "om_retry_exhaust");
+            },
+        };
+        var dispatch = new RecordingActorDispatchPort();
+        var (agent, store) = CreateAgent(runner, "conv-stream-interim-retry-exhaust", dispatchPort: dispatch);
+
+        await agent.HandleLlmReplyStreamChunkAsync(
+            CreateStreamChunk("act-stream-interim-retry-exhaust", "relay-msg-1", "hello"));
+        await CompleteNextNyxRelayTextOperationAsync(agent, dispatch);
+
+        await agent.HandleLlmReplyStreamChunkAsync(
+            CreateStreamChunk("act-stream-interim-retry-exhaust", "relay-msg-1", "hello world"));
+        await CompleteNextNyxRelayTextOperationAsync(agent, dispatch);
+        await CompleteNextNyxRelayTextOperationAsync(agent, dispatch);
+        await CompleteNextNyxRelayTextOperationAsync(agent, dispatch);
+
+        var suppressed = agent.State.ActiveReplyLifecycles.ShouldHaveSingleItem();
+        suppressed.Phase.ShouldBe(ConversationReplyLifecyclePhase.TextSuppressingInterim);
+        suppressed.NyxRelayRetryAttempt.ShouldBe(0);
+        await agent.HandleLlmReplyStreamChunkAsync(
+            CreateStreamChunk("act-stream-interim-retry-exhaust", "relay-msg-1", "hello dropped"));
+        callCount.ShouldBe(4);
+
+        await agent.HandleLlmReplyReadyAsync(new LlmReplyReadyEvent
+        {
+            CorrelationId = "act-stream-interim-retry-exhaust",
+            RegistrationId = "reg-1",
+            RunId = "act-stream-interim-retry-exhaust",
+            SourceActorId = "agent-run",
+            Activity = CreateRelayActivity("act-stream-interim-retry-exhaust", "relay-msg-1"),
+            Outbound = new MessageContent { Text = "hello final" },
+            TerminalState = LlmReplyTerminalState.Completed,
+            ReadyAtUnixMs = 100,
+        });
+        await CompleteNextNyxRelayTextOperationAsync(agent, dispatch);
+
+        runner.LlmReplyCount.ShouldBe(0);
+        callCount.ShouldBe(5);
+        var completed = ConversationTurnCompletedEvent.Parser.ParseFrom(
+            (await store.GetEventsAsync(agent.Id)).Last().EventData.Value);
+        completed.Outbound.Text.ShouldBe("hello final");
+    }
+
+    [Fact]
+    public async Task HandleLlmReplyStreamChunkAsync_PermanentInterimEditFailure_DoesNotRetry()
+    {
+        var callCount = 0;
+        var runner = new RecordingTurnRunner
+        {
+            StreamChunkResultFactory = (_, pmid) =>
+            {
+                callCount++;
+                if (callCount == 1)
+                    return ConversationStreamChunkResult.Succeeded("om_permanent_no_retry");
+                return ConversationStreamChunkResult.Failed(
+                    "relay_reply_edit_unsupported",
+                    "edit unsupported",
+                    editUnsupported: true,
+                    failureKind: FailureKind.PermanentAdapterError,
+                    rawErrorKey: "edit_unsupported");
+            },
+        };
+        var dispatch = new RecordingActorDispatchPort();
+        var (agent, _) = CreateAgent(runner, "conv-stream-permanent-no-retry", dispatchPort: dispatch);
+
+        await agent.HandleLlmReplyStreamChunkAsync(
+            CreateStreamChunk("act-stream-permanent-no-retry", "relay-msg-1", "hello"));
+        await CompleteNextNyxRelayTextOperationAsync(agent, dispatch);
+        await agent.HandleLlmReplyStreamChunkAsync(
+            CreateStreamChunk("act-stream-permanent-no-retry", "relay-msg-1", "hello world"));
+        await CompleteNextNyxRelayTextOperationAsync(agent, dispatch);
+
+        callCount.ShouldBe(2);
+        var lifecycle = agent.State.ActiveReplyLifecycles.ShouldHaveSingleItem();
+        lifecycle.Phase.ShouldBe(ConversationReplyLifecyclePhase.TextSuppressingInterim);
+        lifecycle.NyxRelayRetryAttempt.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task HandleLlmReplyStreamChunkAsync_TransientInterimEditFailureWithPositiveRetryAfter_DoesNotScheduleRetry()
+    {
+        var callCount = 0;
+        var runner = new RecordingTurnRunner
+        {
+            StreamChunkResultFactory = (_, pmid) =>
+            {
+                callCount++;
+                if (callCount == 1)
+                    return ConversationStreamChunkResult.Succeeded("om_retry_after_no_retry");
+                return ConversationStreamChunkResult.Failed(
+                    "relay_reply_update_rejected",
+                    "rate limited",
+                    failureKind: FailureKind.TransientAdapterError,
+                    retryAfter: TimeSpan.FromSeconds(4),
+                    rawErrorKey: "rate_limited");
+            },
+        };
+        var dispatch = new RecordingActorDispatchPort();
+        var (agent, _) = CreateAgent(runner, "conv-stream-retry-after-no-retry", dispatchPort: dispatch);
+
+        await agent.HandleLlmReplyStreamChunkAsync(
+            CreateStreamChunk("act-stream-retry-after-no-retry", "relay-msg-1", "hello"));
+        await CompleteNextNyxRelayTextOperationAsync(agent, dispatch);
+        await agent.HandleLlmReplyStreamChunkAsync(
+            CreateStreamChunk("act-stream-retry-after-no-retry", "relay-msg-1", "hello world"));
+        await CompleteNextNyxRelayTextOperationAsync(agent, dispatch);
+
+        callCount.ShouldBe(2);
+        var lifecycle = agent.State.ActiveReplyLifecycles.ShouldHaveSingleItem();
+        lifecycle.Phase.ShouldBe(ConversationReplyLifecyclePhase.TextSuppressingInterim);
+        lifecycle.NyxRelayRetryAttempt.ShouldBe(0);
+    }
+
+    [Fact]
     public async Task HandleLlmReplyReadyAsync_WhenTokenAlreadyConsumedAndInterimEditFailed_RetriesFinalEditInsteadOfReusingToken()
     {
         // Regression for PR#374 P1 review: final LlmReplyReady must try the final /reply/update
@@ -2306,6 +2479,7 @@ public sealed class ConversationGAgentDedupTests
         // Two RunStreamChunkAsync calls: first chunk + failure-edit.
         callCount.ShouldBe(2);
         // The placeholder was edited with the classified failure text.
+        lastEditedText.ShouldNotBeNull();
         lastEditedText.ShouldContain("rate limited");
 
         var events = await store.GetEventsAsync(agent.Id);


### PR DESCRIPTION
## 摘要

实施 #1536(#371-later: actor-owned-streaming-update-retry-backoff),design-consensus r2 3/3 propose(structural framing)。

- **Old**:ConversationGAgent 对 typed transient Nyx relay interim-update 失败无 actor-owned 重试,瞬时失败直接丢更新。
- **New**:ConversationGAgent 内 **bounded actor-owned immediate retry**(仅 typed transient interim-update 失败);**排除** delayed backoff / token lease / generic retry scope。新增 typed retry 状态/事件(proto)+ 行为测试。

违反:CLAUDE.md「单线程事实源 / 业务推进内聚」——重试推进应在 actor 事件处理流程内完成。

## 范围

6 文件:ConversationGAgent.NyxRelayStreaming.cs / ConversationGAgent.cs / conversation_events.proto / conversation_state.proto + 2 测试。build 0 错误,architecture guards 绿。

closes #1536

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
