### PR TITLE
refactor(#1586): 删除前端 LLM route/model 本地合成第二 truth(canonical settings only)

### DIFF
--- a/apps/aevatar-console-web/src/pages/chat/chatConversationConfig.test.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatConversationConfig.test.ts
@@ -86,6 +86,23 @@ describe("buildConversationRouteOptions", () => {
       }).map((option) => option.label)
     ).toEqual(["Gateway"]);
   });
+
+  it("does not add saved global or conversation routes when backend omits them", () => {
+    const options = buildConversationRouteOptions({
+      ...llmSettings,
+      routeOptions: [llmSettings.routeOptions[0]],
+    });
+
+    expect(options).toEqual([
+      {
+        label: "Company LLM Gateway",
+        value: USER_LLM_ROUTE_GATEWAY,
+      },
+    ]);
+    expect(options.map((option) => option.value)).not.toContain(
+      "/api/v1/proxy/s/retired-team"
+    );
+  });
 });
 
 describe("buildConversationModelGroups", () => {
@@ -103,6 +120,19 @@ describe("buildConversationModelGroups", () => {
       buildConversationModelGroups({
         effectiveRoute: "/api/v1/proxy/s/missing",
         settings: llmSettings,
+      })
+    ).toEqual([]);
+  });
+
+  it("does not emit a current group from selected or default models outside backend groups", () => {
+    expect(
+      buildConversationModelGroups({
+        effectiveRoute: USER_LLM_ROUTE_GATEWAY,
+        settings: {
+          ...llmSettings,
+          defaultModel: "retired-default-model",
+          modelGroupsByRoute: [],
+        },
       })
     ).toEqual([]);
   });

--- a/apps/aevatar-console-web/src/pages/chat/chatConversationConfig.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatConversationConfig.ts
@@ -100,9 +100,7 @@ export function describeConversationRoute(
 }
 
 export function buildConversationRouteOptions(
-  settings: StudioUserLlmSettings | undefined,
-  globalPreferredRoute?: string,
-  conversationRoute?: string
+  settings: StudioUserLlmSettings | undefined
 ): ConversationRouteOption[] {
   const options: ConversationRouteOption[] = [];
   const seen = new Set<string>();
@@ -119,30 +117,15 @@ export function buildConversationRouteOptions(
     });
   }
 
-  for (const route of [globalPreferredRoute, conversationRoute]) {
-    if (route !== undefined) {
-      const normalizedRoute = normalizeUserLlmRoute(route);
-      if (!seen.has(normalizedRoute)) {
-        seen.add(normalizedRoute);
-        options.push({
-          label: normalizedRoute || USER_LLM_ROUTE_GATEWAY_LABEL,
-          value: normalizedRoute,
-        });
-      }
-    }
-  }
-
   return options;
 }
 
 export function buildConversationModelGroups(input: {
-  conversationModel?: string;
   effectiveRoute: string;
-  globalDefaultModel?: string;
   settings: StudioUserLlmSettings | undefined;
 }): ConversationLlmModelGroup[] {
   const normalizedRoute = normalizeUserLlmRoute(input.effectiveRoute);
-  const groups = (input.settings?.modelGroupsByRoute ?? [])
+  return (input.settings?.modelGroupsByRoute ?? [])
     .filter((group: StudioUserLlmModelGroup) =>
       normalizeUserLlmRoute(group.routeValue) === normalizedRoute
     )
@@ -152,22 +135,6 @@ export function buildConversationModelGroups(input: {
       models: Array.from(new Set(group.models.filter(Boolean))),
     }))
     .filter((group) => group.models.length > 0);
-  const selectedModel =
-    trimConversationValue(input.conversationModel) ||
-    trimConversationValue(input.globalDefaultModel);
-
-  if (
-    selectedModel &&
-    !groups.some((group) => group.models.includes(selectedModel))
-  ) {
-    groups.unshift({
-      id: "__current__",
-      label: "Current",
-      models: [selectedModel],
-    });
-  }
-
-  return groups;
 }
 
 export function findConversationRouteOption(

--- a/apps/aevatar-console-web/src/pages/chat/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.test.tsx
@@ -892,7 +892,10 @@ describe("ChatPage", () => {
     fireEvent.click(
       await screen.findByRole("button", { name: "Conversation model settings" })
     );
-    fireEvent.change(await screen.findByLabelText("Conversation route"), {
+    const routeSelect = await screen.findByLabelText("Conversation route");
+    expect(routeSelect).toHaveTextContent("Gateway route option");
+    expect(routeSelect).toHaveTextContent("OpenAI");
+    fireEvent.change(routeSelect, {
       target: { value: "/api/v1/proxy/s/openai" },
     });
     expect(await screen.findByText("via OpenAI")).toBeTruthy();

--- a/apps/aevatar-console-web/src/pages/chat/index.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.tsx
@@ -424,13 +424,8 @@ const ChatPage: React.FC = () => {
     userLlmSettingsQuery.data?.effectiveRoute
   );
   const routeOptions = useMemo(
-    () =>
-      buildConversationRouteOptions(
-        userLlmSettingsQuery.data,
-        globalPreferredRoute,
-        conversationRoute
-      ),
-    [conversationRoute, globalPreferredRoute, userLlmSettingsQuery.data]
+    () => buildConversationRouteOptions(userLlmSettingsQuery.data),
+    [userLlmSettingsQuery.data]
   );
   const effectiveRoute =
     conversationRoute !== undefined ? conversationRoute : globalPreferredRoute;
@@ -451,16 +446,10 @@ const ChatPage: React.FC = () => {
   const modelGroups = useMemo(
     () =>
       buildConversationModelGroups({
-        conversationModel,
         effectiveRoute,
-        globalDefaultModel: userLlmSettingsQuery.data?.defaultModel,
         settings: userLlmSettingsQuery.data,
       }),
-    [
-      conversationModel,
-      effectiveRoute,
-      userLlmSettingsQuery.data,
-    ]
+    [effectiveRoute, userLlmSettingsQuery.data]
   );
   const conversationHeaders = useMemo(
     () => buildConversationHeaders(conversationRoute, conversationModel),

--- a/apps/aevatar-console-web/src/pages/settings/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/settings/index.test.tsx
@@ -250,6 +250,41 @@ describe("SettingsPage", () => {
     expect(screen.queryByRole("combobox", { name: "Default model" })).toBeNull();
   });
 
+  it("excludes stale saved routes and models that are not in the backend catalog", async () => {
+    mockStudioApi.getUserLlmSettings.mockResolvedValueOnce(
+      createLlmSettings({
+        defaultModel: "retired-model",
+        effectiveRoute: "/api/v1/proxy/s/retired-team",
+        effectiveRouteLabel: "Retired Team",
+        routeOptions: [
+          {
+            routeValue: "",
+            label: "NyxID Gateway",
+            source: "gateway_provider",
+            status: "ready",
+            allowed: true,
+            ready: true,
+            serviceId: null,
+            serviceSlug: null,
+            description: null,
+          },
+        ],
+        savedRoute: "/api/v1/proxy/s/retired-team",
+        savedRouteLabel: "Retired Team",
+      })
+    );
+
+    renderWithQueryClient(React.createElement(SettingsPage));
+
+    fireEvent.mouseDown(await screen.findByRole("combobox", { name: "Preferred route" }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText("NyxID Gateway").length).toBeGreaterThan(1);
+    });
+    expect(screen.queryByRole("option", { name: "Retired Team" })).toBeNull();
+    expect(screen.queryByRole("option", { name: "retired-model" })).toBeNull();
+  });
+
   it("saves canonical LLM settings", async () => {
     mockStudioApi.getUserLlmSettings.mockResolvedValueOnce(
       createLlmSettings({

--- a/apps/aevatar-console-web/src/pages/settings/index.tsx
+++ b/apps/aevatar-console-web/src/pages/settings/index.tsx
@@ -454,17 +454,8 @@ const SettingsPage: React.FC = () => {
 
   const routeCatalogOptions = userLlmSettingsQuery.data?.routeOptions ?? [];
   const routeOptions = React.useMemo(
-    () =>
-      buildConversationRouteOptions(
-        userLlmSettingsQuery.data,
-        loadedDraft.preferredLlmRoute,
-        draft.preferredLlmRoute,
-      ),
-    [
-      draft.preferredLlmRoute,
-      loadedDraft.preferredLlmRoute,
-      userLlmSettingsQuery.data,
-    ],
+    () => buildConversationRouteOptions(userLlmSettingsQuery.data),
+    [userLlmSettingsQuery.data],
   );
   const savedRouteOption = React.useMemo(
     () => findConversationRouteOption(userLlmSettingsQuery.data, draft.preferredLlmRoute),
@@ -499,26 +490,21 @@ const SettingsPage: React.FC = () => {
   const modelGroups = React.useMemo(
     () =>
       buildConversationModelGroups({
-        conversationModel: draft.defaultModel,
         effectiveRoute: draft.preferredLlmRoute,
         settings: userLlmSettingsQuery.data,
       }),
-    [draft.defaultModel, draft.preferredLlmRoute, userLlmSettingsQuery.data],
-  );
-  const liveModelGroups = React.useMemo(
-    () => modelGroups.filter((group) => group.id !== "__current__"),
-    [modelGroups],
+    [draft.preferredLlmRoute, userLlmSettingsQuery.data],
   );
   const modelOptions = React.useMemo<SelectProps["options"]>(
     () =>
-      (liveModelGroups.length > 0 ? modelGroups : []).map((group) => ({
+      modelGroups.map((group) => ({
         label: group.label,
         options: group.models.map((model) => ({
           label: model,
           value: model,
         })),
       })),
-    [liveModelGroups.length, modelGroups],
+    [modelGroups],
   );
   const displayedRuntimeBaseUrl = React.useMemo(
     () => userRuntimeQuery.data?.activeRuntimeBaseUrl ?? "",
@@ -600,31 +586,13 @@ const SettingsPage: React.FC = () => {
         label: option.label,
         value: encodeConversationRouteSelectValue(normalizeUserLlmRoute(option.routeValue)),
       }));
-    const hasDraftRoute = readyOptions.some(
-      (option) =>
-        decodeConversationRouteSelectValue(String(option.value)) === draft.preferredLlmRoute,
-    );
-
     return [
       {
         label: "Routes",
         options: readyOptions,
       },
-      ...(draft.preferredLlmRoute && !hasDraftRoute
-        ? [
-            {
-              label: "Current saved route",
-              options: [
-                {
-                  label: `${preferredRouteLabel} (unavailable)`,
-                  value: encodeConversationRouteSelectValue(draft.preferredLlmRoute),
-                },
-              ],
-            },
-          ]
-        : []),
     ];
-  }, [draft.preferredLlmRoute, preferredRouteLabel, routeCatalogOptions]);
+  }, [routeCatalogOptions]);
 
   const advancedItems = React.useMemo<CollapseProps["items"]>(
     () => [
@@ -711,18 +679,14 @@ const SettingsPage: React.FC = () => {
         decodeConversationRouteSelectValue(nextValue),
       );
       const nextRouteGroups = buildConversationModelGroups({
-        conversationModel: draft.defaultModel,
         effectiveRoute: nextRoute,
         settings: userLlmSettingsQuery.data,
       });
       const currentModel = trimConversationValue(draft.defaultModel);
-      const nextLiveRouteGroups = nextRouteGroups.filter(
-        (group) => group.id !== "__current__",
-      );
       const shouldClearModel =
         Boolean(currentModel) &&
-        nextLiveRouteGroups.length > 0 &&
-        !nextLiveRouteGroups.some((group) => group.models.includes(currentModel!));
+        nextRouteGroups.length > 0 &&
+        !nextRouteGroups.some((group) => group.models.includes(currentModel!));
 
       setDraft((currentDraft) => ({
         ...currentDraft,
@@ -980,7 +944,7 @@ const SettingsPage: React.FC = () => {
                           <FieldMetaPill
                             label={
                               modelOptions && modelOptions.length > 0
-                                ? `${liveModelGroups.reduce(
+                                ? `${modelGroups.reduce(
                                     (count, group) => count + group.models.length,
                                     0,
                                   )} live`
@@ -1152,7 +1116,7 @@ const SettingsPage: React.FC = () => {
       canEditRoute,
       catalogUnavailable,
       llmLoadError,
-      liveModelGroups,
+      modelGroups,
       modelOptions,
       insetCardStyle,
       preferredRouteAvailable,


### PR DESCRIPTION
## 摘要

#1530 拆出 first slice — canonical LLM settings,前端不再合成第二 truth。

- **Old**:Console 前端把本地 saved/global/conversation route 与 current/default model 合成为 selectable options(`buildConversationRouteOptions` 的 `globalPreferredRoute/conversationRoute` 参数 + `buildConversationModelGroups` 的 `conversationModel/globalDefaultModel/__current__` 注入)→ 第二 truth,违反单一权威主链路。
- **New**:selectable route/model 只能来自后端 canonical `/api/user-config/llm` 的 `routeOptions/modelGroupsByRoute`;删除前端合成输入使违规状态不可表达。`conversationRoute/conversationModel` 仅作当前覆盖值/header/提交值,不作 option source。

不新增 `CanonicalUserLlmChoiceCatalog`,不改 backend / proto / shared API client test。`proxy_service` selectable/display-only/product policy 归 #1587。

依据:#1586 design-consensus r3 **3/3 unanimous**(framing `structural`,完整 plan 见 issue 共识卡片)。

## 范围

5 files(+80 / −92),全部 `apps/aevatar-console-web` 前端:
- `src/pages/chat/chatConversationConfig.ts`(删合成输入)
- `src/pages/chat/index.tsx`(收窄调用点)
- `src/pages/settings/index.tsx`(删 `liveModelGroups` / `__current__` 过滤)
- `src/pages/chat/chatConversationConfig.test.ts`(回归:stale 不进 options)
- `src/pages/settings/index.test.tsx`(回归:stale saved route/model 不出现在 combobox)

Closes #1586

🤖 Auto-loop / codex-refactor-loop

⟦AI:AUTO-LOOP⟧
