### PR TITLE
chore: rollup auto-refact-dev → dev (0baa3380)

### DIFF
--- a/apps/aevatar-console-web/src/pages/chat/chatConversationConfig.test.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatConversationConfig.test.ts
@@ -6,9 +6,9 @@ import {
 
 const llmSettings = {
   savedRoute: USER_LLM_ROUTE_GATEWAY,
-  savedRouteLabel: "NyxID Gateway",
+  savedRouteLabel: "Company LLM Gateway",
   effectiveRoute: USER_LLM_ROUTE_GATEWAY,
-  effectiveRouteLabel: "NyxID Gateway",
+  effectiveRouteLabel: "Company LLM Gateway",
   routeFallbackActive: false,
   fallbackReason: null,
   catalogStatus: "ready",
@@ -22,7 +22,7 @@ const llmSettings = {
   routeOptions: [
     {
       routeValue: USER_LLM_ROUTE_GATEWAY,
-      label: "NyxID Gateway",
+      label: "Company LLM Gateway",
       source: "gateway_provider",
       status: "ready",
       allowed: true,
@@ -68,9 +68,23 @@ const llmSettings = {
 describe("buildConversationRouteOptions", () => {
   it("uses backend route options without deriving routes from provider slugs", () => {
     expect(buildConversationRouteOptions(llmSettings).map((option) => option.label)).toEqual([
-      "NyxID Gateway",
+      "Company LLM Gateway",
       "Anthropic Team Service",
     ]);
+  });
+
+  it("uses a generic gateway label when backend sends a blank gateway label", () => {
+    expect(
+      buildConversationRouteOptions({
+        ...llmSettings,
+        routeOptions: [
+          {
+            ...llmSettings.routeOptions[0],
+            label: " ",
+          },
+        ],
+      }).map((option) => option.label)
+    ).toEqual(["Gateway"]);
   });
 });
 

--- a/apps/aevatar-console-web/src/pages/chat/chatConversationConfig.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatConversationConfig.ts
@@ -9,6 +9,7 @@ export const LLM_ROUTE_HEADER_KEY = "nyxid.route_preference";
 export const LLM_MODEL_HEADER_KEY = "aevatar.model_override";
 export const CONVERSATION_ROUTE_DEFAULT_VALUE = "__config_default__";
 export const CONVERSATION_ROUTE_GATEWAY_VALUE = "__gateway__";
+const USER_LLM_ROUTE_GATEWAY_LABEL = "Gateway";
 
 export type ConversationRouteOption = {
   label: string;
@@ -93,7 +94,9 @@ export function describeConversationRoute(
     return "Config default";
   }
 
-  return routeOptions.find((option) => option.value === route)?.label || route;
+  return routeOptions.find((option) => option.value === route)?.label ||
+    route ||
+    USER_LLM_ROUTE_GATEWAY_LABEL;
 }
 
 export function buildConversationRouteOptions(
@@ -111,7 +114,7 @@ export function buildConversationRouteOptions(
 
     seen.add(route);
     options.push({
-      label: option.label.trim() || route || "NyxID Gateway",
+      label: option.label.trim() || route || USER_LLM_ROUTE_GATEWAY_LABEL,
       value: route,
     });
   }
@@ -121,7 +124,10 @@ export function buildConversationRouteOptions(
       const normalizedRoute = normalizeUserLlmRoute(route);
       if (!seen.has(normalizedRoute)) {
         seen.add(normalizedRoute);
-        options.push({ label: normalizedRoute || "NyxID Gateway", value: normalizedRoute });
+        options.push({
+          label: normalizedRoute || USER_LLM_ROUTE_GATEWAY_LABEL,
+          value: normalizedRoute,
+        });
       }
     }
   }

--- a/apps/aevatar-console-web/src/pages/chat/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.test.tsx
@@ -91,9 +91,9 @@ jest.mock("@/shared/studio/api", () => ({
       })),
       getUserLlmSettings: jest.fn(async () => ({
         savedRoute: "",
-        savedRouteLabel: "NyxID Gateway",
+        savedRouteLabel: "Backend saved gateway",
         effectiveRoute: "",
-        effectiveRouteLabel: "NyxID Gateway",
+        effectiveRouteLabel: "Backend effective gateway",
         routeFallbackActive: false,
         fallbackReason: null,
         catalogStatus: "ready",
@@ -107,7 +107,7 @@ jest.mock("@/shared/studio/api", () => ({
         routeOptions: [
           {
             routeValue: "",
-            label: "NyxID Gateway",
+            label: "Gateway route option",
             source: "gateway_provider",
             status: "ready",
             allowed: true,
@@ -887,7 +887,7 @@ describe("ChatPage", () => {
     expect(
       await screen.findByRole("button", { name: "Conversation model settings" })
     ).toHaveTextContent("Provider default");
-    expect(screen.getAllByText("NyxID Gateway").length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Backend effective gateway")).length).toBeGreaterThan(0);
 
     fireEvent.click(
       await screen.findByRole("button", { name: "Conversation model settings" })
@@ -895,6 +895,7 @@ describe("ChatPage", () => {
     fireEvent.change(await screen.findByLabelText("Conversation route"), {
       target: { value: "/api/v1/proxy/s/openai" },
     });
+    expect(await screen.findByText("via OpenAI")).toBeTruthy();
     fireEvent.click(await screen.findByRole("button", { name: "gpt-5.4-mini" }));
 
     fireEvent.change(await screen.findByPlaceholderText("Send a message..."), {

--- a/apps/aevatar-console-web/src/pages/chat/index.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.tsx
@@ -434,9 +434,15 @@ const ChatPage: React.FC = () => {
   );
   const effectiveRoute =
     conversationRoute !== undefined ? conversationRoute : globalPreferredRoute;
+  const backendEffectiveRouteLabel = trimConversationValue(
+    userLlmSettingsQuery.data?.effectiveRouteLabel
+  );
   const effectiveRouteLabel = useMemo(
-    () => describeConversationRoute(effectiveRoute, routeOptions),
-    [effectiveRoute, routeOptions]
+    () =>
+      conversationRoute === undefined && backendEffectiveRouteLabel
+        ? backendEffectiveRouteLabel
+        : describeConversationRoute(effectiveRoute, routeOptions),
+    [backendEffectiveRouteLabel, conversationRoute, effectiveRoute, routeOptions]
   );
   const effectiveModel =
     trimConversationValue(conversationModel) ||

--- a/apps/aevatar-console-web/src/pages/settings/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/settings/index.test.tsx
@@ -30,9 +30,9 @@ const { studioApi: mockStudioApi } = jest.requireMock(
 function createLlmSettings(overrides: Record<string, unknown> = {}) {
   return {
     savedRoute: "",
-    savedRouteLabel: "NyxID Gateway",
+    savedRouteLabel: "Backend saved gateway",
     effectiveRoute: "",
-    effectiveRouteLabel: "NyxID Gateway",
+    effectiveRouteLabel: "Backend effective gateway",
     routeFallbackActive: false,
     fallbackReason: null,
     catalogStatus: "ready",
@@ -46,7 +46,7 @@ function createLlmSettings(overrides: Record<string, unknown> = {}) {
     routeOptions: [
       {
         routeValue: "",
-        label: "NyxID Gateway",
+        label: "Gateway route option",
         source: "gateway_provider",
         status: "ready",
         allowed: true,
@@ -158,6 +158,8 @@ describe("SettingsPage", () => {
     expect(screen.getByText("How defaults work")).toBeTruthy();
     expect(screen.getByText("Technical preview")).toBeTruthy();
     expect(screen.getAllByText("Effective route").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Backend effective gateway").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Backend saved gateway").length).toBeGreaterThan(0);
     expect(screen.getByText("Connected providers")).toBeTruthy();
     expect(screen.getAllByText("OpenAI Team Service").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Default model").length).toBeGreaterThan(0);

--- a/apps/aevatar-console-web/src/pages/settings/index.tsx
+++ b/apps/aevatar-console-web/src/pages/settings/index.tsx
@@ -478,14 +478,24 @@ const SettingsPage: React.FC = () => {
         : draft.preferredLlmRoute,
     [draft, loadedDraft, userLlmSettingsQuery.data?.effectiveRoute],
   );
-  const routeFallbackActive = draftsEqual(draft, loadedDraft)
+  const draftMatchesLoaded = draftsEqual(draft, loadedDraft);
+  const routeFallbackActive = draftMatchesLoaded
     ? Boolean(userLlmSettingsQuery.data?.routeFallbackActive)
     : false;
-  const routeSummaryLabel = describeConversationRoute(effectiveRoute, routeOptions);
-  const preferredRouteLabel = describeConversationRoute(
-    draft.preferredLlmRoute,
-    routeOptions,
+  const backendEffectiveRouteLabel = trimConversationValue(
+    userLlmSettingsQuery.data?.effectiveRouteLabel,
   );
+  const backendSavedRouteLabel = trimConversationValue(
+    userLlmSettingsQuery.data?.savedRouteLabel,
+  );
+  const routeSummaryLabel =
+    draftMatchesLoaded && backendEffectiveRouteLabel
+      ? backendEffectiveRouteLabel
+      : describeConversationRoute(effectiveRoute, routeOptions);
+  const preferredRouteLabel =
+    draftMatchesLoaded && backendSavedRouteLabel
+      ? backendSavedRouteLabel
+      : describeConversationRoute(draft.preferredLlmRoute, routeOptions);
   const modelGroups = React.useMemo(
     () =>
       buildConversationModelGroups({
@@ -811,7 +821,7 @@ const SettingsPage: React.FC = () => {
               <SummaryMetric
                 label="Effective route"
                 tone={routeFallbackActive ? "warning" : "success"}
-                value={routeSummaryLabel || "NyxID Gateway"}
+                value={routeSummaryLabel}
               />
               <SummaryMetric
                 label="Default model"
@@ -945,7 +955,7 @@ const SettingsPage: React.FC = () => {
                         </div>
                         <Typography.Text type="secondary">
                           Current route resolves through{" "}
-                          {routeSummaryLabel || "NyxID Gateway"}.
+                          {routeSummaryLabel}.
                         </Typography.Text>
                         {providerDisplayList.length > 0 ? (
                           <div style={providerRailStyle}>
@@ -1041,7 +1051,7 @@ const SettingsPage: React.FC = () => {
                       <SummaryField label="Saved route" value={preferredRouteLabel} />
                       <SummaryField
                         label="Effective route"
-                        value={routeSummaryLabel || "NyxID Gateway"}
+                        value={routeSummaryLabel}
                       />
                       <SummaryField label="Runtime mode" value={runtimeModeLabel} />
                       <SummaryField

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -767,9 +767,9 @@ jest.mock("@/shared/studio/api", () => ({
     })),
     getUserLlmSettings: jest.fn(async () => ({
       savedRoute: "",
-      savedRouteLabel: "NyxID Gateway",
+      savedRouteLabel: "Company LLM Gateway",
       effectiveRoute: "",
-      effectiveRouteLabel: "NyxID Gateway",
+      effectiveRouteLabel: "Company LLM Gateway",
       routeFallbackActive: false,
       fallbackReason: null,
       catalogStatus: "ready",
@@ -783,7 +783,7 @@ jest.mock("@/shared/studio/api", () => ({
       routeOptions: [
         {
           routeValue: "",
-          label: "NyxID Gateway",
+          label: "Company LLM Gateway",
           source: "gateway_provider",
           status: "ready",
           allowed: true,
@@ -3441,7 +3441,7 @@ describe("StudioPage", () => {
       savedRoute: "/api/v1/proxy/s/stale-openai",
       savedRouteLabel: "/api/v1/proxy/s/stale-openai",
       effectiveRoute: "",
-      effectiveRouteLabel: "NyxID Gateway",
+      effectiveRouteLabel: "Company LLM Gateway",
       routeFallbackActive: true,
       fallbackReason: "saved_route_unavailable",
       catalogStatus: "ready",
@@ -3455,7 +3455,7 @@ describe("StudioPage", () => {
       routeOptions: [
         {
           routeValue: "",
-          label: "NyxID Gateway",
+          label: "Company LLM Gateway",
           source: "gateway_provider",
           status: "ready",
           allowed: true,
@@ -3490,7 +3490,7 @@ describe("StudioPage", () => {
 
     const routeLabel = await screen.findByTestId("workflow-dry-run-route");
     await waitFor(() => {
-      expect(routeLabel).toHaveTextContent("NyxID Gateway");
+      expect(routeLabel).toHaveTextContent("Company LLM Gateway");
     });
   });
 

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -3,7 +3,6 @@ import { message } from "antd";
 import React from "react";
 import { scopesApi } from "@/shared/api/scopesApi";
 import { scopeRuntimeApi } from "@/shared/api/scopeRuntimeApi";
-import { runtimeGAgentApi } from "@/shared/api/runtimeGAgentApi";
 import { runtimeRunsApi } from "@/shared/api/runtimeRunsApi";
 import { studioApi } from "@/shared/studio/api";
 import {
@@ -12,10 +11,6 @@ import {
 } from "../../../tests/reactQueryTestUtils";
 import TeamDetailPage from "./detail";
 
-// Refactor (iter2/cluster-issue1593): Old pattern: Team detail tests kept stale
-// actor-graph mocks and legacy event-tab deep links after the Team surface narrowed
-// to overview/members. New principle: keep coverage on observable unknown-tab
-// fallback behavior without preserving removed topology/event dependencies.
 async function openTeamTestDialog() {
   fireEvent.click(await screen.findByRole("button", { name: "测试团队" }));
   await screen.findByLabelText("测试问题");
@@ -271,7 +266,6 @@ function mockCreateRunAudit(scopeId: string, runId: string) {
     audit: {
       reportVersion: "1",
       projectionScope: "service",
-      topologySource: "audit",
       completionStatus: runId === "run-current" ? "waiting_approval" : "completed",
       workflowName: "support-triage",
       rootActorId: "actor-intake",
@@ -287,24 +281,6 @@ function mockCreateRunAudit(scopeId: string, runId: string) {
       input: "hello",
       finalOutput: runId === "run-current" ? "" : "Resolved",
       finalError: runId === "run-current" ? "Waiting on approval" : "",
-      topology:
-        runId === "run-current"
-          ? [
-              {
-                parent: "actor-intake",
-                child: "actor-risk",
-              },
-              {
-                parent: "actor-risk",
-                child: "actor-ops",
-              },
-            ]
-          : [
-              {
-                parent: "actor-intake-v1",
-                child: "actor-risk",
-              },
-            ],
       steps: [
         {
           stepId: "risk_review",
@@ -419,21 +395,6 @@ jest.mock("@/shared/api/scopesApi", () => ({
     listScripts: jest.fn(async () => [
       {
         scriptId: "script-1",
-      },
-    ]),
-  },
-}));
-
-jest.mock("@/shared/api/runtimeGAgentApi", () => ({
-  runtimeGAgentApi: {
-    listActors: jest.fn(async () => [
-      {
-        gAgentType: "IntakeAgent",
-        actorIds: ["actor-intake"],
-      },
-      {
-        gAgentType: "RiskReviewAgent",
-        actorIds: ["actor-risk"],
       },
     ]),
   },
@@ -711,7 +672,6 @@ describe("TeamDetailPage", () => {
     window.history.replaceState({}, "", "/teams/scope-1/t-alpha");
     (scopesApi.listWorkflows as jest.Mock).mockClear();
     (scopesApi.listScripts as jest.Mock).mockClear();
-    (runtimeGAgentApi.listActors as jest.Mock).mockClear();
     (scopeRuntimeApi.getServiceRevisions as jest.Mock).mockReset();
     (scopeRuntimeApi.getServiceRevisions as jest.Mock).mockImplementation(
       async () => mockCreateServiceRevisionCatalog(),
@@ -792,7 +752,6 @@ describe("TeamDetailPage", () => {
       expect(scopesApi.listWorkflows).not.toHaveBeenCalled();
       expect(scopesApi.listScripts).not.toHaveBeenCalled();
       expect(scopeRuntimeApi.listServices).not.toHaveBeenCalled();
-      expect(runtimeGAgentApi.listActors).not.toHaveBeenCalled();
       expect(scopeRuntimeApi.getServiceRevisions).not.toHaveBeenCalled();
       expect(scopeRuntimeApi.listServiceRuns).not.toHaveBeenCalled();
       expect(scopeRuntimeApi.listMemberRuns).not.toHaveBeenCalled();
@@ -837,8 +796,6 @@ describe("TeamDetailPage", () => {
     expect(screen.queryByText("治理快照")).toBeNull();
     expect(screen.queryByText("Run Compare / Change Diff")).toBeNull();
     expect(screen.queryByText("运行摘要")).toBeNull();
-    expect(screen.queryByText("连接器引用")).toBeNull();
-    expect(screen.queryByText("服务能力")).toBeNull();
     expect(await screen.findByRole("button", { name: "编辑团队" })).toBeEnabled();
     expect(await screen.findByRole("button", { name: "团队更多操作" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "服务映射" })).toBeNull();
@@ -1043,7 +1000,7 @@ describe("TeamDetailPage", () => {
     window.history.replaceState(
       {},
       "",
-      "/teams/scope-1/t-alpha?serviceId=default&tab=legacy-tab",
+      "/teams/scope-1/t-alpha?serviceId=default&tab=not-real",
     );
 
     renderWithQueryClient(React.createElement(TeamDetailPage));
@@ -1074,8 +1031,6 @@ describe("TeamDetailPage", () => {
     expect(screen.getAllByText("绑定方式").length).toBeGreaterThan(0);
     expect(screen.getAllByText("主服务入口").length).toBeGreaterThan(0);
     expect(screen.getAllByText("版本标识").length).toBeGreaterThan(0);
-    expect(screen.queryByText("连接器引用")).toBeNull();
-    expect(screen.queryByText("服务能力")).toBeNull();
   });
 
   it("shows a readable team members view", async () => {
@@ -1092,9 +1047,6 @@ describe("TeamDetailPage", () => {
     expect(screen.getByRole("link", { name: "Build" })).toBeTruthy();
     expect(screen.queryByRole("link", { name: "Test member" })).toBeNull();
     expect(screen.queryByRole("link", { name: "View runs" })).toBeNull();
-    expect(screen.queryByText("参与者结构")).toBeNull();
-    expect(screen.queryByText("运行时参与者身份")).toBeNull();
-    expect(screen.queryByRole("button", { name: "打开 Services" })).toBeNull();
   });
 
   it("marks the route-selected member in the members tab", async () => {

--- a/apps/aevatar-console-web/src/shared/navigation/teamRoutes.test.ts
+++ b/apps/aevatar-console-web/src/shared/navigation/teamRoutes.test.ts
@@ -6,10 +6,6 @@ import {
   readTeamDetailRouteState,
 } from "./teamRoutes";
 
-// Refactor (iter2/cluster-issue1593): Old pattern: route tests named retired
-// connectors/events/topology Team tabs as explicit compatibility cases. New principle:
-// unknown Team tabs are covered by one neutral fallback case so tests do not preserve
-// removed Team topology vocabulary as a product contract.
 describe("teamRoutes", () => {
   it("builds a canonical team detail href and trims empty values", () => {
     expect(

--- a/apps/aevatar-console-web/src/shared/studio/api.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.test.ts
@@ -170,9 +170,9 @@ describe('studioApi host-session requests', () => {
       status: 200,
       json: async () => ({
         savedRoute: '',
-        savedRouteLabel: 'NyxID Gateway',
+        savedRouteLabel: 'Company LLM Gateway',
         effectiveRoute: '',
-        effectiveRouteLabel: 'NyxID Gateway',
+        effectiveRouteLabel: 'Company LLM Gateway',
         routeFallbackActive: false,
         fallbackReason: null,
         catalogStatus: 'ready',
@@ -186,7 +186,7 @@ describe('studioApi host-session requests', () => {
         routeOptions: [
           {
             routeValue: '',
-            label: 'NyxID Gateway',
+            label: 'Company LLM Gateway',
             source: 'gateway_provider',
             status: 'ready',
             allowed: true,
@@ -221,9 +221,9 @@ describe('studioApi host-session requests', () => {
 
     await expect(studioApi.getUserLlmSettings()).resolves.toEqual({
       savedRoute: '',
-      savedRouteLabel: 'NyxID Gateway',
+      savedRouteLabel: 'Company LLM Gateway',
       effectiveRoute: '',
-      effectiveRouteLabel: 'NyxID Gateway',
+      effectiveRouteLabel: 'Company LLM Gateway',
       routeFallbackActive: false,
       fallbackReason: null,
       catalogStatus: 'ready',
@@ -237,7 +237,7 @@ describe('studioApi host-session requests', () => {
       routeOptions: [
         {
           routeValue: '',
-          label: 'NyxID Gateway',
+          label: 'Company LLM Gateway',
           source: 'gateway_provider',
           status: 'ready',
           allowed: true,


### PR DESCRIPTION
## 摘要

rollup auto-refact-dev → dev(integration `0baa3380`)。

本批含 2 个已审已合的 auto-loop 改动:
- **#1624**(closes #1525):chat/settings/studio LLM route label 路径收敛(3/3 review approve)。
- **#1706**(closes #1541):删除 Console Team topology 测试残影(tests-only,3/3 approve)。

等 dev required checks(fast-gates / console-web / coverage-quality)全绿后合并。

🤖 Auto-loop / codex-refactor-loop rollup
⟦AI:AUTO-LOOP⟧
