### PR TITLE
feat(scripting/skills): use_skill 可选 mount_workflows 挂载 skill workflows

### DIFF
--- a/src/Aevatar.AI.ToolProviders.Skills/Aevatar.AI.ToolProviders.Skills.csproj
+++ b/src/Aevatar.AI.ToolProviders.Skills/Aevatar.AI.ToolProviders.Skills.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Aevatar.AI.Abstractions\Aevatar.AI.Abstractions.csproj" />
+    <ProjectReference Include="..\platform\Aevatar.GAgentService.Abstractions\Aevatar.GAgentService.Abstractions.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />

--- a/src/Aevatar.AI.ToolProviders.Skills/SkillsAgentToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/SkillsAgentToolSource.cs
@@ -4,6 +4,7 @@
 // ─────────────────────────────────────────────────────────────
 
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.GAgentService.Abstractions.Ports;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -21,6 +22,7 @@ public sealed class SkillsAgentToolSource : IAgentToolSource
     private readonly SkillDiscovery _discovery;
     private readonly LocalSkillCatalog _localCatalog;
     private readonly IRemoteSkillFetcher? _remoteFetcher;
+    private readonly IScopeWorkflowCommandPort? _scopeWorkflowCommandPort;
     private readonly ILogger _logger;
 
     public SkillsAgentToolSource(
@@ -28,12 +30,14 @@ public sealed class SkillsAgentToolSource : IAgentToolSource
         SkillDiscovery discovery,
         LocalSkillCatalog localCatalog,
         IRemoteSkillFetcher? remoteFetcher = null,
+        IScopeWorkflowCommandPort? scopeWorkflowCommandPort = null,
         ILogger<SkillsAgentToolSource>? logger = null)
     {
         _options = options;
         _discovery = discovery;
         _localCatalog = localCatalog;
         _remoteFetcher = remoteFetcher;
+        _scopeWorkflowCommandPort = scopeWorkflowCommandPort;
         _logger = logger ?? NullLogger<SkillsAgentToolSource>.Instance;
     }
 
@@ -57,7 +61,7 @@ public sealed class SkillsAgentToolSource : IAgentToolSource
         }
 
         // 2. 返回统一的 UseSkillTool（单个工具）
-        IReadOnlyList<IAgentTool> tools = [new UseSkillTool(_localCatalog, _remoteFetcher)];
+        IReadOnlyList<IAgentTool> tools = [new UseSkillTool(_localCatalog, _remoteFetcher, _scopeWorkflowCommandPort)];
         return Task.FromResult(tools);
     }
 }

--- a/src/Aevatar.AI.ToolProviders.Skills/UseSkillTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/UseSkillTool.cs
@@ -8,6 +8,8 @@ using System.Text;
 using System.Text.Json;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
 
 namespace Aevatar.AI.ToolProviders.Skills;
 
@@ -22,11 +24,16 @@ public sealed class UseSkillTool : IAgentTool
 {
     private readonly LocalSkillCatalog _localCatalog;
     private readonly IRemoteSkillFetcher? _remoteFetcher;
+    private readonly IScopeWorkflowCommandPort? _scopeWorkflowCommandPort;
 
-    public UseSkillTool(LocalSkillCatalog localCatalog, IRemoteSkillFetcher? remoteFetcher = null)
+    public UseSkillTool(
+        LocalSkillCatalog localCatalog,
+        IRemoteSkillFetcher? remoteFetcher = null,
+        IScopeWorkflowCommandPort? scopeWorkflowCommandPort = null)
     {
         _localCatalog = localCatalog;
         _remoteFetcher = remoteFetcher;
+        _scopeWorkflowCommandPort = scopeWorkflowCommandPort;
     }
 
     public string Name => "use_skill";
@@ -42,27 +49,23 @@ public sealed class UseSkillTool : IAgentTool
           "type": "object",
           "properties": {
             "skill": { "type": "string", "description": "The skill name to invoke" },
-            "args": { "type": "string", "description": "Optional arguments for the skill" }
+            "args": { "type": "string", "description": "Optional arguments for the skill" },
+            "mount_workflows": { "type": "boolean", "description": "When true, upsert all workflow YAML descriptors from the skill into the current scope workflow command pipeline" }
           },
           "required": ["skill"]
         }
         """;
 
+    public ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;
+
+    public bool? RequiresApproval(string argumentsJson) => ParseArguments(argumentsJson).MountWorkflows;
+
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {
-        // ─── 解析参数 ───
-        string skillName = "";
-        string args = "";
-
-        try
-        {
-            using var doc = JsonDocument.Parse(argumentsJson);
-            if (doc.RootElement.TryGetProperty("skill", out var s))
-                skillName = s.GetString() ?? "";
-            if (doc.RootElement.TryGetProperty("args", out var a))
-                args = a.GetString() ?? "";
-        }
-        catch { /* use defaults */ }
+        var arguments = ParseArguments(argumentsJson);
+        var skillName = arguments.SkillName;
+        var args = arguments.Args;
+        var mountWorkflows = arguments.MountWorkflows;
 
         if (string.IsNullOrWhiteSpace(skillName))
             return BuildErrorWithAvailableSkills("Error: skill name is required.");
@@ -74,7 +77,7 @@ public sealed class UseSkillTool : IAgentTool
         //   Old pattern: SkillRegistry 暴露混合 local + remote skill 注册并用 5min TTL process-wide cache 缓存 remote skill,违反读写分离 + 多用户 token 共享 + 进程内事实状态
         //   New principle: 删 SkillRegistry + TTL tests + 5min cache;新建 local-only LocalSkillCatalog;remote skill 每次 use_skill 调用 IRemoteSkillFetcher.FetchSkillAsync(currentToken, ...) 不缓存;docs/canon factual sync
         if (_localCatalog.TryGet(skillName, out skill) && skill != null)
-            return BuildSkillResponse(skill, args);
+            return await BuildSkillResponseAsync(skill, args, mountWorkflows, ct);
 
         if (_remoteFetcher != null)
         {
@@ -84,12 +87,50 @@ public sealed class UseSkillTool : IAgentTool
                 skill = await _remoteFetcher.FetchSkillAsync(token, skillName, ct);
                 if (skill != null)
                 {
-                    return BuildSkillResponse(skill, args);
+                    return await BuildSkillResponseAsync(skill, args, mountWorkflows, ct);
                 }
             }
         }
 
         return BuildErrorWithAvailableSkills($"Skill '{skillName}' not found.");
+    }
+
+    private static UseSkillArguments ParseArguments(string argumentsJson)
+    {
+        string skillName = "";
+        string args = "";
+        var mountWorkflows = false;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(argumentsJson);
+            if (doc.RootElement.TryGetProperty("skill", out var s))
+                skillName = s.GetString() ?? "";
+            if (doc.RootElement.TryGetProperty("args", out var a))
+                args = a.GetString() ?? "";
+            if (doc.RootElement.TryGetProperty("mount_workflows", out var m) &&
+                (m.ValueKind == JsonValueKind.True || m.ValueKind == JsonValueKind.False))
+            {
+                mountWorkflows = m.GetBoolean();
+            }
+        }
+        catch { /* use defaults */ }
+
+        return new UseSkillArguments(skillName, args, mountWorkflows);
+    }
+
+    private async Task<string> BuildSkillResponseAsync(
+        SkillDefinition skill,
+        string args,
+        bool mountWorkflows,
+        CancellationToken ct)
+    {
+        var response = BuildSkillResponse(skill, args);
+        if (!mountWorkflows)
+            return response;
+
+        var mountedWorkflows = await MountWorkflowsAsync(skill, ct);
+        return response + Environment.NewLine + mountedWorkflows;
     }
 
     private static string BuildSkillResponse(SkillDefinition skill, string args)
@@ -171,6 +212,100 @@ public sealed class UseSkillTool : IAgentTool
         return sb.ToString();
     }
 
+    private async Task<string> MountWorkflowsAsync(SkillDefinition skill, CancellationToken ct)
+    {
+        var scopeId = AgentToolRequestContext.ScopeId;
+        if (string.IsNullOrWhiteSpace(scopeId))
+            return BuildMountedWorkflowsError("scope_id not available in request context");
+
+        if (_scopeWorkflowCommandPort == null)
+            return BuildMountedWorkflowsError("scope workflow command port is not available in this host");
+
+        if (skill.Workflows.Count == 0)
+            return BuildMountedWorkflowsError("skill has no workflow descriptors to mount");
+
+        var mounted = new List<object>(skill.Workflows.Count);
+        foreach (var workflow in skill.Workflows)
+        {
+            if (string.IsNullOrWhiteSpace(workflow.WorkflowId))
+                return BuildMountedWorkflowsError("skill workflow descriptor has no workflow_id");
+
+            var workflowYamls = workflow.WorkflowYamls
+                .Where(yaml => !string.IsNullOrWhiteSpace(yaml))
+                .ToArray();
+            if (workflowYamls.Length == 0)
+                return BuildMountedWorkflowsError($"skill workflow '{workflow.WorkflowId}' has no workflow YAML");
+
+            var result = await _scopeWorkflowCommandPort.UpsertAsync(new ScopeWorkflowUpsertRequest(
+                scopeId.Trim(),
+                workflow.WorkflowId.Trim(),
+                workflowYamls[0],
+                WorkflowName: workflow.WorkflowId.Trim(),
+                DisplayName: workflow.WorkflowId.Trim(),
+                InlineWorkflowYamls: BuildInlineWorkflowYamls(workflowYamls)), ct);
+
+            mounted.Add(ToMountedWorkflowPayload(result));
+        }
+
+        return BuildMountedWorkflowsPayload(mounted);
+    }
+
+    private static IReadOnlyDictionary<string, string>? BuildInlineWorkflowYamls(IReadOnlyList<string> workflowYamls)
+    {
+        if (workflowYamls.Count <= 1)
+            return null;
+
+        var inlineWorkflowYamls = new Dictionary<string, string>(StringComparer.Ordinal);
+        for (var i = 1; i < workflowYamls.Count; i++)
+            inlineWorkflowYamls[$"workflow_{i}"] = workflowYamls[i];
+        return inlineWorkflowYamls;
+    }
+
+    private static object ToMountedWorkflowPayload(ScopeWorkflowUpsertResult result) => new
+    {
+        success = true,
+        accepted = true,
+        scope_id = result.ScopeId,
+        workflow_id = result.WorkflowId,
+        service_key = result.ServiceKey,
+        revision_id = result.RevisionId,
+        expected_actor_id = result.ExpectedActorId,
+        expected_deployment_id = result.ExpectedDeploymentId,
+        acceptance_stage = result.AcceptanceStage,
+        propagation_stage = result.PropagationStage,
+        read_model_url = result.ReadModelUrl,
+        command_handles = result.CommandHandles,
+    };
+
+    private static string BuildMountedWorkflowsPayload(IReadOnlyList<object> mounted)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("## Mounted Workflows");
+        sb.AppendLine();
+        sb.AppendLine("Workflow mount commands were accepted for dispatch; read models may still be propagating.");
+        sb.AppendLine();
+        sb.AppendLine("```json");
+        sb.AppendLine(JsonSerializer.Serialize(new { workflows = mounted }, SnakeCaseJson));
+        sb.AppendLine("```");
+        return sb.ToString();
+    }
+
+    private static string BuildMountedWorkflowsError(string message)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("## Mounted Workflows");
+        sb.AppendLine();
+        sb.AppendLine("```json");
+        sb.AppendLine(JsonSerializer.Serialize(new
+        {
+            success = false,
+            accepted = false,
+            error = message,
+        }, SnakeCaseJson));
+        sb.AppendLine("```");
+        return sb.ToString();
+    }
+
     private string BuildErrorWithAvailableSkills(string errorMessage)
     {
         var sb = new StringBuilder();
@@ -199,4 +334,12 @@ public sealed class UseSkillTool : IAgentTool
 
         return sb.ToString();
     }
+
+    private readonly record struct UseSkillArguments(string SkillName, string Args, bool MountWorkflows);
+
+    private static readonly JsonSerializerOptions SnakeCaseJson = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+    };
 }

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/Aevatar.AI.ToolProviders.Ornn.Tests.csproj
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/Aevatar.AI.ToolProviders.Ornn.Tests.csproj
@@ -10,6 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Aevatar.AI.ToolProviders.Ornn\Aevatar.AI.ToolProviders.Ornn.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.AI.ToolProviders.Skills\Aevatar.AI.ToolProviders.Skills.csproj" />
+    <ProjectReference Include="..\..\src\platform\Aevatar.GAgentService.Abstractions\Aevatar.GAgentService.Abstractions.csproj" />
     <!--
       Explicit reference: tests instantiate NyxIdApiClient / NyxIdToolOptions directly
       (not just through OrnnSkillClient), so depending on transitive flow-through from

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/SkillWorkflowsWiringTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/SkillWorkflowsWiringTests.cs
@@ -208,6 +208,68 @@ public sealed class SkillWorkflowsWiringTests
     }
 
     [Fact]
+    public async Task UseSkillTool_MountWorkflowsTrueWithBlankWorkflowId_ReturnsErrorAndDoesNotUpsert()
+    {
+        using var _ = BeginContextScope(scopeId: "scope-1");
+        var catalog = new LocalSkillCatalog();
+        catalog.Register(new SkillDefinition
+        {
+            Name = "translator",
+            Description = "Translates text",
+            Instructions = "Follow these steps.",
+            Source = SkillSource.Local,
+            Workflows =
+            [
+                new SkillWorkflowDescriptor
+                {
+                    WorkflowId = " ",
+                    WorkflowYamls = ["name: translate_flow\nsteps: []\n"],
+                },
+            ],
+        });
+        var commandPort = new RecordingScopeWorkflowCommandPort();
+        var tool = new UseSkillTool(catalog, scopeWorkflowCommandPort: commandPort);
+
+        var output = await tool.ExecuteAsync("""{"skill":"translator","mount_workflows":true}""");
+
+        output.Should().Contain("## Mounted Workflows");
+        output.Should().Contain("\"success\": false");
+        output.Should().Contain("skill workflow descriptor has no workflow_id");
+        commandPort.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task UseSkillTool_MountWorkflowsTrueWithBlankWorkflowYamls_ReturnsErrorAndDoesNotUpsert()
+    {
+        using var _ = BeginContextScope(scopeId: "scope-1");
+        var catalog = new LocalSkillCatalog();
+        catalog.Register(new SkillDefinition
+        {
+            Name = "translator",
+            Description = "Translates text",
+            Instructions = "Follow these steps.",
+            Source = SkillSource.Local,
+            Workflows =
+            [
+                new SkillWorkflowDescriptor
+                {
+                    WorkflowId = "translate_flow",
+                    WorkflowYamls = ["", "   ", "\t"],
+                },
+            ],
+        });
+        var commandPort = new RecordingScopeWorkflowCommandPort();
+        var tool = new UseSkillTool(catalog, scopeWorkflowCommandPort: commandPort);
+
+        var output = await tool.ExecuteAsync("""{"skill":"translator","mount_workflows":true}""");
+
+        output.Should().Contain("## Mounted Workflows");
+        output.Should().Contain("\"success\": false");
+        output.Should().Contain(@"skill workflow \u0027translate_flow\u0027 has no workflow YAML");
+        commandPort.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task UseSkillTool_MountWorkflowsTrue_UpsertsAllSkillWorkflowsThroughScopeWorkflowCommandPort()
     {
         using var _ = BeginContextScope(scopeId: "scope-1");

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/SkillWorkflowsWiringTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/SkillWorkflowsWiringTests.cs
@@ -2,6 +2,8 @@ using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.AI.ToolProviders.Skills;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
 using FluentAssertions;
 
 namespace Aevatar.AI.ToolProviders.Ornn.Tests;
@@ -122,6 +124,149 @@ public sealed class SkillWorkflowsWiringTests
     }
 
     [Fact]
+    public async Task UseSkillTool_MountWorkflowsFalse_DoesNotRequireApprovalAndDoesNotCallCommandPort()
+    {
+        var catalog = CreateCatalogWithWorkflowSkill();
+        var commandPort = new RecordingScopeWorkflowCommandPort();
+        var tool = new UseSkillTool(catalog, scopeWorkflowCommandPort: commandPort);
+
+        tool.ApprovalMode.Should().Be(ToolApprovalMode.Auto);
+        tool.RequiresApproval("""{"skill":"translator"}""").Should().BeFalse();
+        tool.RequiresApproval("""{"skill":"translator","mount_workflows":false}""").Should().BeFalse();
+
+        var output = await tool.ExecuteAsync("""{"skill":"translator"}""");
+
+        output.Should().Contain("## aevatar_start_workflow Handoff");
+        output.Should().NotContain("## Mounted Workflows");
+        commandPort.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void UseSkillTool_MountWorkflowsTrue_RequiresApproval()
+    {
+        var tool = new UseSkillTool(new LocalSkillCatalog());
+
+        tool.ApprovalMode.Should().Be(ToolApprovalMode.Auto);
+        tool.RequiresApproval("""{"skill":"translator","mount_workflows":true}""").Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task UseSkillTool_MountWorkflowsTrueWithoutScope_ReturnsErrorAndDoesNotUpsert()
+    {
+        var previous = AgentToolRequestContext.Current;
+        try
+        {
+            AgentToolRequestContext.Current = null;
+            var commandPort = new RecordingScopeWorkflowCommandPort();
+            var tool = new UseSkillTool(CreateCatalogWithWorkflowSkill(), scopeWorkflowCommandPort: commandPort);
+
+            var output = await tool.ExecuteAsync("""{"skill":"translator","mount_workflows":true}""");
+
+            output.Should().Contain("## Mounted Workflows");
+            output.Should().Contain("\"success\": false");
+            output.Should().Contain("scope_id not available in request context");
+            commandPort.Requests.Should().BeEmpty();
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = previous;
+        }
+    }
+
+    [Fact]
+    public async Task UseSkillTool_MountWorkflowsTrueWithoutCommandPort_ReturnsErrorAfterLoadingSkill()
+    {
+        using var _ = BeginContextScope(scopeId: "scope-1");
+        var tool = new UseSkillTool(CreateCatalogWithWorkflowSkill());
+
+        var output = await tool.ExecuteAsync("""{"skill":"translator","mount_workflows":true}""");
+
+        output.Should().Contain("# translator");
+        output.Should().Contain("## Mounted Workflows");
+        output.Should().Contain("scope workflow command port is not available in this host");
+    }
+
+    [Fact]
+    public async Task UseSkillTool_MountWorkflowsTrueWithNoWorkflows_ReturnsErrorAndDoesNotUpsert()
+    {
+        using var _ = BeginContextScope(scopeId: "scope-1");
+        var catalog = new LocalSkillCatalog();
+        catalog.Register(new SkillDefinition
+        {
+            Name = "plain",
+            Description = "no workflows",
+            Instructions = "body",
+            Source = SkillSource.Local,
+        });
+        var commandPort = new RecordingScopeWorkflowCommandPort();
+        var tool = new UseSkillTool(catalog, scopeWorkflowCommandPort: commandPort);
+
+        var output = await tool.ExecuteAsync("""{"skill":"plain","mount_workflows":true}""");
+
+        output.Should().Contain("skill has no workflow descriptors to mount");
+        commandPort.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task UseSkillTool_MountWorkflowsTrue_UpsertsAllSkillWorkflowsThroughScopeWorkflowCommandPort()
+    {
+        using var _ = BeginContextScope(scopeId: "scope-1");
+        var commandPort = new RecordingScopeWorkflowCommandPort();
+        var tool = new UseSkillTool(CreateCatalogWithWorkflowSkill(), scopeWorkflowCommandPort: commandPort);
+
+        var output = await tool.ExecuteAsync("""{"skill":"translator","mount_workflows":true}""");
+
+        commandPort.Requests.Should().HaveCount(2);
+        commandPort.Requests[0].ScopeId.Should().Be("scope-1");
+        commandPort.Requests[0].WorkflowId.Should().Be("translate_flow");
+        commandPort.Requests[0].WorkflowYaml.Should().Be("name: translate_flow\nsteps: []\n");
+        commandPort.Requests[0].WorkflowName.Should().Be("translate_flow");
+        commandPort.Requests[0].DisplayName.Should().Be("translate_flow");
+        commandPort.Requests[0].InlineWorkflowYamls.Should().ContainSingle()
+            .Which.Should().Be(new KeyValuePair<string, string>("workflow_1", "name: helper_flow\nsteps: []\n"));
+        commandPort.Requests[1].WorkflowId.Should().Be("qa_flow");
+        output.Should().Contain("## Mounted Workflows");
+        output.Should().Contain("Workflow mount commands were accepted for dispatch; read models may still be propagating.");
+        output.Should().Contain("\"accepted\": true");
+        output.Should().Contain("\"acceptance_stage\": \"accepted\"");
+        output.Should().Contain("\"propagation_stage\": \"readmodel_propagating\"");
+        output.Should().Contain("\"read_model_url\": \"/api/scopes/scope-1/workflows/translate_flow\"");
+        output.Should().Contain("\"command_handles\"");
+        output.Should().NotContain("already visible");
+        output.Should().NotContain("strongly consistent");
+    }
+
+    [Fact]
+    public async Task UseSkillTool_MountWorkflowsTrueForRemoteSkill_UsesCurrentTokenAndMountsFetchedDescriptors()
+    {
+        using var _ = BeginContextScope(scopeId: "scope-1", token: "current-token");
+        var fetcher = new RecordingRemoteSkillFetcher(new SkillDefinition
+        {
+            Name = "remote-translator",
+            Description = "remote skill",
+            Instructions = "remote body",
+            Source = SkillSource.Remote,
+            Workflows =
+            [
+                new SkillWorkflowDescriptor
+                {
+                    WorkflowId = "remote_flow",
+                    WorkflowYamls = ["name: remote_flow\nsteps: []\n"],
+                },
+            ],
+        });
+        var commandPort = new RecordingScopeWorkflowCommandPort();
+        var tool = new UseSkillTool(new LocalSkillCatalog(), fetcher, commandPort);
+
+        var output = await tool.ExecuteAsync("""{"skill":"remote-translator","mount_workflows":true}""");
+
+        fetcher.Requests.Should().ContainSingle().Which.Should().Be(("current-token", "remote-translator"));
+        commandPort.Requests.Should().ContainSingle().Which.WorkflowId.Should().Be("remote_flow");
+        output.Should().Contain("# remote-translator");
+        output.Should().Contain("\"workflow_id\": \"remote_flow\"");
+    }
+
+    [Fact]
     public void SkillDiscovery_PicksUpWorkflowsFromSkillDirectory()
     {
         using var tempDir = new TempDirectory();
@@ -162,6 +307,93 @@ public sealed class SkillWorkflowsWiringTests
             new HttpClient(handler));
         var options = new OrnnOptions { NyxIdSlug = "ornn" };
         return new OrnnSkillClient(options, nyxClient);
+    }
+
+    private static LocalSkillCatalog CreateCatalogWithWorkflowSkill()
+    {
+        var catalog = new LocalSkillCatalog();
+        catalog.Register(new SkillDefinition
+        {
+            Name = "translator",
+            Description = "Translates text",
+            Instructions = "Follow these steps.",
+            Source = SkillSource.Local,
+            Workflows =
+            [
+                new SkillWorkflowDescriptor
+                {
+                    WorkflowId = "translate_flow",
+                    WorkflowYamls =
+                    [
+                        "name: translate_flow\nsteps: []\n",
+                        "name: helper_flow\nsteps: []\n",
+                    ],
+                },
+                new SkillWorkflowDescriptor
+                {
+                    WorkflowId = "qa_flow",
+                    WorkflowYamls = ["name: qa_flow\nsteps: []\n"],
+                },
+            ],
+        });
+        return catalog;
+    }
+
+    private static AgentToolRequestContextScope BeginContextScope(string? scopeId = null, string? token = null)
+    {
+        var metadata = new Dictionary<string, string>();
+        if (!string.IsNullOrWhiteSpace(scopeId))
+            metadata[LLMRequestMetadataKeys.ScopeId] = scopeId;
+        if (!string.IsNullOrWhiteSpace(token))
+            metadata[LLMRequestMetadataKeys.NyxIdAccessToken] = token;
+        return new AgentToolRequestContextScope(global::TestAgentToolContexts.FromMetadata(metadata));
+    }
+
+    private sealed class AgentToolRequestContextScope : IDisposable
+    {
+        private readonly AgentToolExecutionContext? _previous;
+
+        public AgentToolRequestContextScope(AgentToolExecutionContext context)
+        {
+            _previous = AgentToolRequestContext.Current;
+            AgentToolRequestContext.Current = context;
+        }
+
+        public void Dispose() => AgentToolRequestContext.Current = _previous;
+    }
+
+    private sealed class RecordingRemoteSkillFetcher(SkillDefinition skill) : IRemoteSkillFetcher
+    {
+        public List<(string AccessToken, string NameOrId)> Requests { get; } = [];
+
+        public Task<SkillDefinition?> FetchSkillAsync(string accessToken, string nameOrId, CancellationToken ct = default)
+        {
+            Requests.Add((accessToken, nameOrId));
+            return Task.FromResult<SkillDefinition?>(skill);
+        }
+    }
+
+    private sealed class RecordingScopeWorkflowCommandPort : IScopeWorkflowCommandPort
+    {
+        public List<ScopeWorkflowUpsertRequest> Requests { get; } = [];
+
+        public Task<ScopeWorkflowUpsertResult> UpsertAsync(
+            ScopeWorkflowUpsertRequest request,
+            CancellationToken ct = default)
+        {
+            Requests.Add(request);
+            return Task.FromResult(new ScopeWorkflowUpsertResult(
+                request.ScopeId,
+                request.WorkflowId,
+                $"service-key-{request.WorkflowId}",
+                $"revision-{request.WorkflowId}",
+                "definition-prefix",
+                $"actor-{request.WorkflowId}",
+                $"deployment-{request.WorkflowId}",
+                DateTimeOffset.UnixEpoch,
+                [new ScopeWorkflowCommandAcceptedHandle("create_revision", "target-actor", "cmd-1", "corr-1")],
+                $"/api/scopes/{request.ScopeId}/workflows/{request.WorkflowId}"));
+        }
     }
 
     private sealed class TempDirectory : IDisposable


### PR DESCRIPTION
## 摘要

#1695:`use_skill` 自动挂载 skill 的 `assets/*.yaml` 为 scope 内可 invoke 的 workflow。

- **Old**:`use_skill` 只注入 skill 内容为模型上下文;带 workflow 的 `assets/*.yaml` 不注册为可调用 workflow,只能走 binding API 手工绑定。
- **New**:`use_skill` 增加可选 `mount_workflows=true` 显式触发,直接可选依赖现有 `IScopeWorkflowCommandPort` 把全部 skill workflow descriptor 写入既有 scope workflow command 主链,只返回 `accepted/readmodel_propagating`。默认不挂载/不审批/不写状态。

**首片不新增** `ISkillWorkflowMountPort`、`mount_skill_workflows` 工具、catalog/registry;不改 proto;不要求 NyxID/chrono-* 变更。

依据:#1695 design-consensus r3 **3/3 unanimous**(structural)。

## 范围

5 files（+400 / -18）:`UseSkillTool.cs`、`SkillsAgentToolSource.cs`、`Skills.csproj`(+Abstractions ref)、`Ornn.Tests.csproj`、`SkillWorkflowsWiringTests.cs`(7 个 mount 行为测试)。

Closes #1695

🤖 Auto-loop / codex-refactor-loop
⟦AI:AUTO-LOOP⟧
