### PR TITLE
refactor(#1529): 删除 UseExistingService synthetic route 兜底 + 后端契约测试

### DIFF
--- a/src/Aevatar.Studio.Application/Studio/Services/UserLlmPreferenceWriter.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/UserLlmPreferenceWriter.cs
@@ -238,21 +238,8 @@ public sealed class UserLlmPreferenceWriter
             string.Equals(candidate.ServiceId, existing.ServiceId, StringComparison.OrdinalIgnoreCase) ||
             string.Equals(candidate.RouteValue, existing.RouteValue, StringComparison.OrdinalIgnoreCase));
         if (option is null)
-        {
-            var serviceId = existing.ServiceId.Trim();
-            var routeValue = UserConfigLlmRoute.Normalize(existing.RouteValue);
-            return new UserLlmOption(
-                ServiceId: serviceId,
-                ServiceSlug: serviceId,
-                DisplayName: serviceId,
-                RouteValue: routeValue,
-                DefaultModel: existing.DefaultModel,
-                AvailableModels: [],
-                Status: UserLlmRouteStatus.Ready,
-                Source: UserLlmRouteSource.UserService,
-                Allowed: true,
-                Description: null);
-        }
+            throw new InvalidOperationException(
+                $"LLM preset service '{existing.ServiceId}' is not routable for this user.");
 
         UserLlmPreferenceWriteCore.EnsureSelectable(option);
         return option with { DefaultModel = existing.DefaultModel ?? option.DefaultModel };

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ModelSlashCommandHandlerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ModelSlashCommandHandlerTests.cs
@@ -450,7 +450,7 @@ public sealed class ModelSlashCommandHandlerTests
     [Fact]
     public async Task Preset_UseExistingService_WritesRouteAndModel()
     {
-        var catalog = new StubCatalogClient { Services = [] };
+        var catalog = new StubCatalogClient { Services = [ChronoLlm] };
         var commandService = new StubUserConfigCommandService();
         var handler = CreateHandler(catalog, commandService: commandService);
 

--- a/test/Aevatar.Studio.Tests/UserConfigControllerSettingsTests.cs
+++ b/test/Aevatar.Studio.Tests/UserConfigControllerSettingsTests.cs
@@ -226,6 +226,128 @@ public sealed class UserConfigControllerSettingsTests
     }
 
     [Fact]
+    public async Task GetLlmSettings_LegacyStatusWithoutSource_ShouldRemainGatewayProviderAndNotBecomeUserServiceRoute()
+    {
+        var httpHandler = new RecordingHttpHandler(
+            (HttpStatusCode.NotFound, """{"message":"not found"}"""),
+            (HttpStatusCode.OK, """
+            {
+              "providers": [
+                {
+                  "provider_slug": "openai",
+                  "provider_name": "OpenAI Gateway",
+                  "status": "ready",
+                  "proxy_url": "/api/v1/llm/openai/v1"
+                }
+              ],
+              "supported_models": ["gpt-5.4"]
+            }
+            """),
+            (HttpStatusCode.OK, """{"services":[]}"""));
+        var controller = CreateController(
+            current: new UserConfig("gpt-5.4", "/api/v1/llm/openai/v1"),
+            httpHandler: httpHandler,
+            bearerToken: "user-token-1");
+
+        var response = await controller.GetLlmSettings(CancellationToken.None);
+
+        var ok = response.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var payload = ok.Value.Should().BeOfType<UserLlmSettingsResponse>().Subject;
+        payload.RouteOptions.Should().NotContain(option => option.RouteValue == "/api/v1/llm/openai/v1");
+        payload.RouteOptions.Should()
+            .ContainSingle(option => option.RouteValue == UserConfigLlmRouteDefaults.Gateway)
+            .Which.Should().Match<UserLlmRouteOptionResponse>(option =>
+                option.Source == UserLlmRouteSource.GatewayProvider &&
+                option.Status == UserLlmRouteStatus.Ready &&
+                option.Allowed &&
+                option.Ready);
+        payload.ModelGroupsByRoute.Should()
+            .Contain(group =>
+                group.RouteValue == UserConfigLlmRouteDefaults.Gateway &&
+                group.GroupId == "openai" &&
+                group.Models.Contains("gpt-5.4"));
+        payload.EffectiveRoute.Should().Be(UserConfigLlmRouteDefaults.Gateway);
+        httpHandler.Requests.Select(request => request.Path)
+            .Should()
+            .Equal("/api/v1/llm/services", "/api/v1/llm/status", "/api/v1/proxy/services?per_page=100");
+    }
+
+    [Fact]
+    public async Task GetLlmSettings_ServicesArrayWithoutSource_ShouldDefaultToUserServiceRouteWhenAllowedAndReady()
+    {
+        var controller = CreateController(
+            current: new UserConfig("gpt-5.4", "/api/v1/proxy/s/openai-work"),
+            httpHandler: new RecordingHttpHandler("""
+            {
+              "services": [
+                {
+                  "user_service_id": "svc-openai",
+                  "service_slug": "openai-work",
+                  "display_name": "OpenAI Work",
+                  "route_value": "/api/v1/proxy/s/openai-work",
+                  "default_model": "gpt-5.4",
+                  "models": ["gpt-5.4"],
+                  "status": "ready",
+                  "allowed": true
+                }
+              ]
+            }
+            """),
+            bearerToken: "user-token-1");
+
+        var response = await controller.GetLlmSettings(CancellationToken.None);
+
+        var ok = response.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var payload = ok.Value.Should().BeOfType<UserLlmSettingsResponse>().Subject;
+        payload.RouteOptions.Should()
+            .ContainSingle(option => option.RouteValue == "/api/v1/proxy/s/openai-work")
+            .Which.Should().Match<UserLlmRouteOptionResponse>(option =>
+                option.Source == UserLlmRouteSource.UserService &&
+                option.Status == UserLlmRouteStatus.Ready &&
+                option.Allowed &&
+                option.Ready);
+        payload.EffectiveRoute.Should().Be("/api/v1/proxy/s/openai-work");
+        payload.Capabilities.CanSave.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetLlmSettings_ServicesArrayWithoutAllowed_ShouldDefaultClosed()
+    {
+        var controller = CreateController(
+            current: new UserConfig("gpt-5.4", "/api/v1/proxy/s/openai-work"),
+            httpHandler: new RecordingHttpHandler("""
+            {
+              "services": [
+                {
+                  "user_service_id": "svc-openai",
+                  "service_slug": "openai-work",
+                  "display_name": "OpenAI Work",
+                  "route_value": "/api/v1/proxy/s/openai-work",
+                  "default_model": "gpt-5.4",
+                  "models": ["gpt-5.4"],
+                  "status": "ready"
+                }
+              ]
+            }
+            """),
+            bearerToken: "user-token-1");
+
+        var response = await controller.GetLlmSettings(CancellationToken.None);
+
+        var ok = response.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var payload = ok.Value.Should().BeOfType<UserLlmSettingsResponse>().Subject;
+        payload.RouteOptions.Should()
+            .ContainSingle(option => option.RouteValue == "/api/v1/proxy/s/openai-work")
+            .Which.Should().Match<UserLlmRouteOptionResponse>(option =>
+                option.Source == UserLlmRouteSource.UserService &&
+                option.Status == UserLlmRouteStatus.Ready &&
+                !option.Allowed &&
+                !option.Ready);
+        payload.EffectiveRoute.Should().Be(UserConfigLlmRouteDefaults.Gateway);
+        payload.RouteFallbackActive.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task SaveLlmSettings_WithGatewayRoute_ShouldPersistEmptyRoute()
     {
         var commandService = new RecordingUserConfigCommandService();

--- a/test/Aevatar.Studio.Tests/UserConfigServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/UserConfigServiceTests.cs
@@ -121,6 +121,61 @@ public sealed class UserConfigServiceTests
             config.PreferredLlmRoute == ChronoLlm.RouteValue);
     }
 
+    [Fact]
+    public async Task Preset_UseExistingService_WhenCatalogDoesNotContainService_ShouldRejectInsteadOfFabricatingReadyUserService()
+    {
+        var commandService = new RecordingUserConfigCommandService();
+        var missingPreset = new UserLlmPreset(
+            "chrono-shared",
+            "Use chrono",
+            "Use shared service",
+            new UseExistingService(
+                "missing-chrono-service",
+                "/api/v1/proxy/s/missing-chrono",
+                "gpt-5.4"));
+        var service = CreateService(
+            commandService: commandService,
+            catalogResult: new NyxIdLlmServicesResult(
+                [ChronoLlm],
+                new UserLlmSetupHint("https://nyxid.example/services", [missingPreset])));
+
+        var act = async () => await service.SaveLlmPreferenceAsync(
+            "bearer",
+            new SaveUserLlmPreferenceCommand(PresetId: "chrono-shared"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("LLM preset service 'missing-chrono-service' is not routable for this user.");
+        commandService.Saved.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Preset_UseExistingService_WhenCatalogContainsSelectableService_ShouldWriteCatalogRouteAndModel()
+    {
+        var commandService = new RecordingUserConfigCommandService();
+        var preset = new UserLlmPreset(
+            "chrono-shared",
+            "Use chrono",
+            "Use shared service",
+            new UseExistingService(
+                "chrono-llm-service",
+                "/api/v1/proxy/s/chrono-llm",
+                "gpt-5.5"));
+        var service = CreateService(
+            commandService: commandService,
+            catalogResult: new NyxIdLlmServicesResult(
+                [ChronoLlm],
+                new UserLlmSetupHint("https://nyxid.example/services", [preset])));
+
+        var receipt = await service.SaveLlmPreferenceAsync(
+            "bearer",
+            new SaveUserLlmPreferenceCommand(PresetId: "chrono-shared"));
+
+        receipt.AckStage.Should().Be(UserConfigCommandAckStage.Accepted);
+        commandService.Saved.Should().ContainSingle().Which.Should().Match<UserConfig>(config =>
+            config.PreferredLlmRoute == ChronoLlm.RouteValue &&
+            config.DefaultModel == "gpt-5.5");
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData("cloud")]
@@ -167,11 +222,12 @@ public sealed class UserConfigServiceTests
 
     private static UserConfigService CreateService(
         UserConfig? current = null,
-        RecordingUserConfigCommandService? commandService = null)
+        RecordingUserConfigCommandService? commandService = null,
+        NyxIdLlmServicesResult? catalogResult = null)
     {
         var queryPort = new StubUserConfigQueryPort(current ?? new UserConfig(DefaultModel: string.Empty));
         commandService ??= new RecordingUserConfigCommandService();
-        var catalogPort = new StubUserLlmCatalogPort(new NyxIdLlmServicesResult([ChronoLlm], null));
+        var catalogPort = new StubUserLlmCatalogPort(catalogResult ?? new NyxIdLlmServicesResult([ChronoLlm], null));
         var writer = new UserLlmPreferenceWriter(queryPort, commandService, catalogPort);
         return new UserConfigService(queryPort, commandService, writer);
     }


### PR DESCRIPTION
## 摘要

#1529(#775 first slice):`legacy-status-user-service-route-options-contract`。

- **Old**:`UserLlmPreferenceWriter.ActivateExistingPreset` 在 catalog 无匹配 service/route 时合成一个 ready user-service route(synthetic fallback),制造前端可选 route 的第二 truth。
- **New**:删除该 synthetic fallback,无匹配时抛 `InvalidOperationException`;`UseExistingService` 只接受 catalog-backed selectable option。新增后端 `/api/user-config/llm` 的 `source/status/allowed/ready` 契约测试锁住 `NyxIdLlmServiceCatalogParser` 现有映射。

不新增 mapper/abstraction;不改 proto;不要求 NyxID/chrono-* 变更。

依据:#1529 design-consensus r3 **3/3 unanimous**(structural)。

## 范围

4 files（+183 / -18）:`UserLlmPreferenceWriter.cs`(删兜底)、`UserConfigControllerSettingsTests.cs`(+契约测试)、`UserConfigServiceTests.cs`(+preset 测试)、`ModelSlashCommandHandlerTests.cs`(回归守护)。

Closes #1529

🤖 Auto-loop / codex-refactor-loop
⟦AI:AUTO-LOOP⟧
