### PR TITLE
chore: rollup auto-refact-dev → dev (e6beabef)

### DIFF
--- a/docs/canon/nyxid-llm-integration.md
+++ b/docs/canon/nyxid-llm-integration.md
@@ -28,7 +28,9 @@ NyxID 验证 Token → 查找该用户的 API Key → 注入 → 转发给上游
 
 ## Responses 直连路由
 
-外部客户端通过 NyxID proxy 调 Aevatar `/v1/responses` 或 `/v1/messages` 时，模型路由采用 OpenRouter 风格：
+外部客户端通过 NyxID proxy 调 Aevatar `/v1/responses`、`/v1/messages` 或 `/v1/chat/completions` 时，调用者身份与下游委托凭据分开处理。`X-NyxID-Identity-Token` 若存在，Host 先用 NyxID JWKS 校验该 RS256 assertion；校验通过后用 `sub` 作为 caller scope，不再调用 `/me`。该 header 存在但校验失败时 fail closed。只有缺失 identity assertion 时，才使用 inbound bearer 调 NyxID `/me` fallback。`X-NyxID-Delegation-Token` 只作为 downstream delegated credential，永远不作为 caller identity 输入。
+
+模型路由采用 OpenRouter 风格：
 
 ```text
 <service-slug>/<model>

--- a/docs/canon/nyxid-responses-direct.md
+++ b/docs/canon/nyxid-responses-direct.md
@@ -48,6 +48,10 @@ Authorization: Bearer nyx_...
 
 Aevatar endpoint 本身标记为 anonymous，不是因为免鉴权，而是因为 NyxID API key 是 opaque token，不是 Host 的 JWT。handler 会手动取出 bearer token，并通过 NyxID 当前用户接口解析调用者。
 
+如果 NyxID proxy 同时转发 `X-NyxID-Identity-Token`，Aevatar 会先在 Host 内用 NyxID JWKS 校验该 RS256 identity assertion。校验通过时，caller identity 直接取 token 的 `sub`，不会再调用 NyxID `/me`。该 header 一旦存在但签名、issuer、audience、有效期、`sub`、`jti` 或配置的 service id 校验失败，请求 fail closed，不回退 `/me`。只有 `X-NyxID-Identity-Token` 缺失时，才保留 bearer `/me` fallback。
+
+`X-NyxID-Delegation-Token` 只是传给下游 NyxID/LLM/工具调用的 delegated credential，永远不作为 caller identity 输入；delegation-only 请求仍按 bearer `/me` fallback 解析调用者。
+
 解析结果会落到 Responses caller scope：
 
 - `scopeId`：NyxID user id

--- a/src/Aevatar.Mainnet.Host.Api/Aevatar.Mainnet.Host.Api.csproj
+++ b/src/Aevatar.Mainnet.Host.Api/Aevatar.Mainnet.Host.Api.csproj
@@ -11,6 +11,8 @@
     <InternalsVisibleTo Include="Aevatar.ChatRouting.Voice.Integration.Tests" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     <ProjectReference Include="..\Aevatar.Bootstrap\Aevatar.Bootstrap.csproj" />
     <ProjectReference Include="..\Aevatar.Authentication.Hosting\Aevatar.Authentication.Hosting.csproj" />
     <ProjectReference Include="..\Aevatar.Authentication.Providers.NyxId\Aevatar.Authentication.Providers.NyxId.csproj" />

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -137,6 +137,9 @@ public static class MainnetHostBuilderExtensions
             });
         });
         builder.Services.TryAddSingleton<IResponsesCallerScopeResolver, NyxIdResponsesCallerScopeResolver>();
+        builder.Services.Configure<ResponsesNyxIdIdentityAssertionOptions>(
+            builder.Configuration.GetSection(ResponsesNyxIdIdentityAssertionOptions.SectionName));
+        builder.Services.TryAddSingleton<NyxIdIdentityAssertionValidator>();
         builder.Services.TryAddSingleton<IResponsesChatRouteDecisionPort, ResponsesChatRouteDecisionPort>();
         builder.Services.TryAddSingleton<IResponsesCommandFacade, ResponsesCommandFacade>();
         builder.Services.TryAddSingleton<IMessagesCommandFacade, MessagesCommandFacade>();

--- a/src/Aevatar.Mainnet.Host.Api/Responses/NyxIdIdentityAssertionValidator.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/NyxIdIdentityAssertionValidator.cs
@@ -1,0 +1,319 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text.Json;
+using Aevatar.AI.ToolProviders.NyxId;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Aevatar.Mainnet.Host.Api.Responses;
+
+internal sealed record NyxIdIdentityAssertionValidationResult(
+    bool Succeeded,
+    string? Subject = null,
+    string? ErrorCode = null,
+    string? ErrorSummary = null);
+
+internal sealed record NyxIdJwksCacheEntry(
+    string Issuer,
+    string Audience,
+    IReadOnlyList<SecurityKey> SigningKeys,
+    DateTimeOffset ExpiresAtUtc);
+
+/// <summary>refactor helper, no behavior change</summary>
+internal sealed class NyxIdIdentityAssertionValidator
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ResponsesNyxIdIdentityAssertionOptions _options;
+    private readonly NyxIdToolOptions? _nyxIdOptions;
+    private readonly ILogger<NyxIdIdentityAssertionValidator> _logger;
+    private readonly SemaphoreSlim _refreshLock = new(1, 1);
+    private NyxIdJwksCacheEntry? _cachedKeys;
+    private DateTimeOffset _lastForcedRefreshUtc = DateTimeOffset.MinValue;
+
+    public NyxIdIdentityAssertionValidator(
+        IHttpClientFactory httpClientFactory,
+        IOptions<ResponsesNyxIdIdentityAssertionOptions> options,
+        IOptions<NyxIdToolOptions>? nyxIdOptions = null,
+        ILogger<NyxIdIdentityAssertionValidator>? logger = null)
+    {
+        _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _nyxIdOptions = nyxIdOptions?.Value;
+        _logger = logger ?? NullLogger<NyxIdIdentityAssertionValidator>.Instance;
+    }
+
+    public async Task<NyxIdIdentityAssertionValidationResult> ValidateAsync(
+        string identityToken,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(identityToken))
+            return Fail("identity_assertion_missing", "NyxID identity assertion is missing.");
+
+        try
+        {
+            var keys = await GetKeysAsync(forceRefresh: false, ct);
+            var initial = ValidateCore(identityToken.Trim(), keys);
+            if (initial.Succeeded)
+                return initial;
+
+            if (!string.Equals(initial.ErrorCode, "identity_assertion_kid_not_found", StringComparison.Ordinal))
+                return initial;
+
+            var refreshed = await RefreshKeysAfterKidMissAsync(ct);
+            return ValidateCore(identityToken.Trim(), refreshed);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "NyxID identity assertion validation failed unexpectedly");
+            return Fail("identity_assertion_invalid", ex.Message);
+        }
+    }
+
+    private NyxIdIdentityAssertionValidationResult ValidateCore(
+        string identityToken,
+        NyxIdJwksCacheEntry keys)
+    {
+        var handler = new JwtSecurityTokenHandler
+        {
+            MapInboundClaims = false,
+        };
+        var parameters = new TokenValidationParameters
+        {
+            RequireSignedTokens = true,
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKeys = keys.SigningKeys,
+            ValidAlgorithms = [SecurityAlgorithms.RsaSha256],
+            ValidateIssuer = true,
+            ValidIssuer = keys.Issuer,
+            ValidateAudience = true,
+            ValidAudience = keys.Audience,
+            ValidateLifetime = true,
+            ClockSkew = TimeSpan.FromSeconds(Math.Max(0, _options.ClockSkewSeconds)),
+        };
+
+        try
+        {
+            var principal = handler.ValidateToken(identityToken, parameters, out _);
+            var subject = NormalizeOptional(principal.FindFirstValue(JwtRegisteredClaimNames.Sub)) ??
+                          NormalizeOptional(principal.FindFirstValue("sub"));
+            var jti = NormalizeOptional(principal.FindFirstValue(JwtRegisteredClaimNames.Jti)) ??
+                      NormalizeOptional(principal.FindFirstValue("jti"));
+
+            if (subject is null)
+                return Fail("identity_assertion_sub_missing", "NyxID identity assertion is missing sub.");
+
+            if (jti is null)
+                return Fail("identity_assertion_jti_missing", "NyxID identity assertion is missing jti.");
+
+            var expectedServiceId = NormalizeOptional(_options.ExpectedServiceId);
+            if (expectedServiceId is not null)
+            {
+                var actualServiceId = NormalizeOptional(principal.FindFirstValue("nyx_service_id"));
+                if (!string.Equals(actualServiceId, expectedServiceId, StringComparison.Ordinal))
+                {
+                    return Fail(
+                        "identity_assertion_service_id_mismatch",
+                        "NyxID identity assertion service id does not match the expected service.");
+                }
+            }
+
+            return new NyxIdIdentityAssertionValidationResult(true, Subject: subject);
+        }
+        catch (SecurityTokenSignatureKeyNotFoundException ex)
+        {
+            _logger.LogWarning(ex, "NyxID identity assertion signing key not found");
+            return Fail("identity_assertion_kid_not_found", ex.Message);
+        }
+        catch (SecurityTokenInvalidIssuerException ex)
+        {
+            _logger.LogWarning(ex, "NyxID identity assertion issuer mismatch");
+            return Fail("identity_assertion_issuer_mismatch", ex.Message);
+        }
+        catch (SecurityTokenInvalidAudienceException ex)
+        {
+            _logger.LogWarning(ex, "NyxID identity assertion audience mismatch");
+            return Fail("identity_assertion_audience_mismatch", ex.Message);
+        }
+        catch (SecurityTokenExpiredException ex)
+        {
+            _logger.LogWarning(ex, "NyxID identity assertion expired");
+            return Fail("identity_assertion_lifetime_invalid", ex.Message);
+        }
+        catch (SecurityTokenNotYetValidException ex)
+        {
+            _logger.LogWarning(ex, "NyxID identity assertion not yet valid");
+            return Fail("identity_assertion_lifetime_invalid", ex.Message);
+        }
+        catch (SecurityTokenInvalidLifetimeException ex)
+        {
+            _logger.LogWarning(ex, "NyxID identity assertion lifetime invalid");
+            return Fail("identity_assertion_lifetime_invalid", ex.Message);
+        }
+        catch (SecurityTokenInvalidAlgorithmException ex)
+        {
+            _logger.LogWarning(ex, "NyxID identity assertion algorithm invalid");
+            return Fail("identity_assertion_signature_invalid", ex.Message);
+        }
+        catch (SecurityTokenInvalidSignatureException ex)
+        {
+            _logger.LogWarning(ex, "NyxID identity assertion signature invalid");
+            return Fail("identity_assertion_signature_invalid", ex.Message);
+        }
+        catch (SecurityTokenMalformedException ex)
+        {
+            _logger.LogWarning(ex, "NyxID identity assertion malformed");
+            return Fail("identity_assertion_malformed", ex.Message);
+        }
+        catch (SecurityTokenException ex)
+        {
+            _logger.LogWarning(ex, "NyxID identity assertion validation failed");
+            return Fail("identity_assertion_invalid", ex.Message);
+        }
+    }
+
+    private async Task<NyxIdJwksCacheEntry> GetKeysAsync(bool forceRefresh, CancellationToken ct)
+    {
+        var cached = _cachedKeys;
+        if (!forceRefresh && cached is not null && cached.ExpiresAtUtc > DateTimeOffset.UtcNow)
+            return cached;
+
+        await _refreshLock.WaitAsync(ct);
+        try
+        {
+            cached = _cachedKeys;
+            if (!forceRefresh && cached is not null && cached.ExpiresAtUtc > DateTimeOffset.UtcNow)
+                return cached;
+
+            return await LoadKeysAsync(ct);
+        }
+        finally
+        {
+            _refreshLock.Release();
+        }
+    }
+
+    private async Task<NyxIdJwksCacheEntry> RefreshKeysAfterKidMissAsync(CancellationToken ct)
+    {
+        await _refreshLock.WaitAsync(ct);
+        try
+        {
+            var now = DateTimeOffset.UtcNow;
+            var cooldown = TimeSpan.FromSeconds(Math.Max(0, _options.KidMissRefreshCooldownSeconds));
+            if (cooldown > TimeSpan.Zero &&
+                now - _lastForcedRefreshUtc < cooldown &&
+                _cachedKeys is { } cached)
+            {
+                return cached;
+            }
+
+            _lastForcedRefreshUtc = now;
+            return await LoadKeysAsync(ct);
+        }
+        finally
+        {
+            _refreshLock.Release();
+        }
+    }
+
+    private async Task<NyxIdJwksCacheEntry> LoadKeysAsync(CancellationToken ct)
+    {
+        var issuer = ResolveIssuer();
+        var audience = ResolveAudience();
+        var jwksUri = await ResolveJwksUriAsync(ct);
+
+        var http = _httpClientFactory.CreateClient();
+        using var jwksResponse = await http.GetAsync(jwksUri, ct);
+        jwksResponse.EnsureSuccessStatusCode();
+        var jwksJson = await jwksResponse.Content.ReadAsStringAsync(ct);
+
+        var keys = new NyxIdJwksCacheEntry(
+            issuer,
+            audience,
+            new JsonWebKeySet(jwksJson).GetSigningKeys().ToArray(),
+            DateTimeOffset.UtcNow.AddSeconds(Math.Max(30, _options.JwksCacheTtlSeconds)));
+
+        _cachedKeys = keys;
+        return keys;
+    }
+
+    private async Task<string> ResolveJwksUriAsync(CancellationToken ct)
+    {
+        var configuredJwksUri = NormalizeOptional(_options.JwksUri);
+        if (configuredJwksUri is not null)
+            return configuredJwksUri;
+
+        var discoveryUrl = ResolveDiscoveryUrl();
+        var http = _httpClientFactory.CreateClient();
+        using var discoveryResponse = await http.GetAsync(discoveryUrl, ct);
+        discoveryResponse.EnsureSuccessStatusCode();
+        var discoveryJson = await discoveryResponse.Content.ReadAsStringAsync(ct);
+        using var document = JsonDocument.Parse(discoveryJson);
+
+        return RequireString(document.RootElement, "jwks_uri");
+    }
+
+    private string ResolveIssuer()
+    {
+        var issuer = NormalizeOptional(_options.Issuer);
+        if (issuer is not null)
+            return issuer;
+
+        var authority = ResolveNyxIdAuthority();
+        if (authority is not null)
+            return authority;
+
+        throw new InvalidOperationException("NyxID identity assertion issuer is not configured.");
+    }
+
+    private string ResolveAudience()
+    {
+        var audience = NormalizeOptional(_options.ExpectedAudience);
+        if (audience is not null)
+            return audience;
+
+        throw new InvalidOperationException("NyxID identity assertion audience is not configured.");
+    }
+
+    private string ResolveDiscoveryUrl()
+    {
+        var discoveryUrl = NormalizeOptional(_options.OidcDiscoveryUrl);
+        if (discoveryUrl is not null)
+            return discoveryUrl;
+
+        var authority = ResolveNyxIdAuthority();
+        if (authority is null)
+            throw new InvalidOperationException("NyxID identity assertion discovery URL is not configured.");
+
+        return $"{authority}/.well-known/openid-configuration";
+    }
+
+    private string? ResolveNyxIdAuthority() =>
+        NormalizeOptional(_nyxIdOptions?.BaseUrl)?.TrimEnd('/');
+
+    private static NyxIdIdentityAssertionValidationResult Fail(string code, string? summary) =>
+        new(false, ErrorCode: code, ErrorSummary: summary);
+
+    private static string? NormalizeOptional(string? value)
+    {
+        var normalized = value?.Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
+    private static string RequireString(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property) || property.ValueKind != JsonValueKind.String)
+        {
+            throw new InvalidOperationException(
+                $"NyxID identity assertion discovery document is missing required string property '{propertyName}'.");
+        }
+
+        return property.GetString() ?? throw new InvalidOperationException(
+            $"NyxID identity assertion discovery property '{propertyName}' is null.");
+    }
+}

--- a/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesCallerScope.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesCallerScope.cs
@@ -7,18 +7,38 @@ namespace Aevatar.Mainnet.Host.Api.Responses;
 internal sealed class NyxIdResponsesCallerScopeResolver : IResponsesCallerScopeResolver
 {
     private readonly INyxIdCurrentUserResolver _currentUserResolver;
+    private readonly NyxIdIdentityAssertionValidator _identityAssertionValidator;
 
-    public NyxIdResponsesCallerScopeResolver(INyxIdCurrentUserResolver currentUserResolver)
+    public NyxIdResponsesCallerScopeResolver(
+        INyxIdCurrentUserResolver currentUserResolver,
+        NyxIdIdentityAssertionValidator identityAssertionValidator)
     {
         _currentUserResolver = currentUserResolver ?? throw new ArgumentNullException(nameof(currentUserResolver));
+        _identityAssertionValidator = identityAssertionValidator ??
+                                      throw new ArgumentNullException(nameof(identityAssertionValidator));
     }
 
-    // Refactor (iter159/cluster-640-first): Old: ResolveAsync(string bearer)  New: ResolveAsync(ResponsesCallerScopeResolutionContext)
     public async Task<ResponsesCallerScope> ResolveAsync(
         ResponsesCallerScopeResolutionContext context,
         CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(context);
+
+        if (!string.IsNullOrWhiteSpace(context.NyxIdIdentityToken))
+        {
+            var validation = await _identityAssertionValidator.ValidateAsync(context.NyxIdIdentityToken, ct);
+            if (!validation.Succeeded || string.IsNullOrWhiteSpace(validation.Subject))
+            {
+                throw new ResponsesCallerScopeUnavailableException(
+                    $"NyxID identity assertion is invalid: {validation.ErrorCode ?? "identity_assertion_invalid"}.");
+            }
+
+            var normalizedSubject = validation.Subject.Trim();
+            return new ResponsesCallerScope(
+                ScopeId: normalizedSubject,
+                OwnerSubject: normalizedSubject,
+                OriginKind: LlmSessionOriginKind.ApiKey);
+        }
 
         var nyxIdAccessToken = context.InboundBearerToken;
         if (string.IsNullOrWhiteSpace(nyxIdAccessToken))

--- a/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesNyxIdIdentityAssertionOptions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesNyxIdIdentityAssertionOptions.cs
@@ -1,0 +1,23 @@
+namespace Aevatar.Mainnet.Host.Api.Responses;
+
+/// <summary>refactor helper, no behavior change</summary>
+internal sealed class ResponsesNyxIdIdentityAssertionOptions
+{
+    public const string SectionName = "Aevatar:Responses:NyxIdIdentityAssertion";
+
+    public string? OidcDiscoveryUrl { get; set; }
+
+    public string? JwksUri { get; set; }
+
+    public string? Issuer { get; set; }
+
+    public string? ExpectedAudience { get; set; }
+
+    public string? ExpectedServiceId { get; set; }
+
+    public int ClockSkewSeconds { get; set; } = 60;
+
+    public int JwksCacheTtlSeconds { get; set; } = 300;
+
+    public int KidMissRefreshCooldownSeconds { get; set; } = 30;
+}

--- a/test/Aevatar.Hosting.Tests/ResponsesCallerScopeResolverTests.cs
+++ b/test/Aevatar.Hosting.Tests/ResponsesCallerScopeResolverTests.cs
@@ -1,8 +1,15 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text.Json;
 using Aevatar.GAgents.Scheduled;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Application.Responses;
 using Aevatar.Mainnet.Host.Api.Responses;
 using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Aevatar.Hosting.Tests;
 
@@ -11,15 +18,28 @@ public sealed class ResponsesCallerScopeResolverTests
     [Fact]
     public void Constructor_ShouldRejectNullResolver()
     {
-        ((Action)(() => new NyxIdResponsesCallerScopeResolver(null!)))
+        using var fixture = new IdentityAssertionFixture();
+
+        ((Action)(() => new NyxIdResponsesCallerScopeResolver(null!, fixture.CreateValidator())))
             .Should().Throw<ArgumentNullException>()
             .WithMessage("*currentUserResolver*");
     }
 
     [Fact]
+    public void Constructor_ShouldRejectNullIdentityAssertionValidator()
+    {
+        ((Action)(() => new NyxIdResponsesCallerScopeResolver(new StubUserResolver(returnUserId: "user-1"), null!)))
+            .Should().Throw<ArgumentNullException>()
+            .WithMessage("*identityAssertionValidator*");
+    }
+
+    [Fact]
     public async Task ResolveAsync_ShouldThrow_WhenAccessTokenMissing()
     {
-        var resolver = new NyxIdResponsesCallerScopeResolver(new StubUserResolver(returnUserId: "user-1"));
+        using var fixture = new IdentityAssertionFixture();
+        var resolver = new NyxIdResponsesCallerScopeResolver(
+            new StubUserResolver(returnUserId: "user-1"),
+            fixture.CreateValidator());
 
         var act = () => resolver.ResolveAsync(CreateContext(""));
 
@@ -30,7 +50,10 @@ public sealed class ResponsesCallerScopeResolverTests
     [Fact]
     public async Task ResolveAsync_ShouldThrow_WhenAccessTokenWhitespace()
     {
-        var resolver = new NyxIdResponsesCallerScopeResolver(new StubUserResolver(returnUserId: "user-1"));
+        using var fixture = new IdentityAssertionFixture();
+        var resolver = new NyxIdResponsesCallerScopeResolver(
+            new StubUserResolver(returnUserId: "user-1"),
+            fixture.CreateValidator());
 
         var act = () => resolver.ResolveAsync(CreateContext("   "));
 
@@ -40,7 +63,10 @@ public sealed class ResponsesCallerScopeResolverTests
     [Fact]
     public async Task ResolveAsync_ShouldThrow_WhenUpstreamReturnsNull()
     {
-        var resolver = new NyxIdResponsesCallerScopeResolver(new StubUserResolver(returnUserId: null));
+        using var fixture = new IdentityAssertionFixture();
+        var resolver = new NyxIdResponsesCallerScopeResolver(
+            new StubUserResolver(returnUserId: null),
+            fixture.CreateValidator());
 
         var act = () => resolver.ResolveAsync(CreateContext("some-token"));
 
@@ -51,7 +77,10 @@ public sealed class ResponsesCallerScopeResolverTests
     [Fact]
     public async Task ResolveAsync_ShouldThrow_WhenUpstreamReturnsBlank()
     {
-        var resolver = new NyxIdResponsesCallerScopeResolver(new StubUserResolver(returnUserId: "   "));
+        using var fixture = new IdentityAssertionFixture();
+        var resolver = new NyxIdResponsesCallerScopeResolver(
+            new StubUserResolver(returnUserId: "   "),
+            fixture.CreateValidator());
 
         var act = () => resolver.ResolveAsync(CreateContext("some-token"));
 
@@ -61,7 +90,10 @@ public sealed class ResponsesCallerScopeResolverTests
     [Fact]
     public async Task ResolveAsync_ShouldReturnTrimmedScope_WithApiKeyOrigin()
     {
-        var resolver = new NyxIdResponsesCallerScopeResolver(new StubUserResolver(returnUserId: "  alice-1  "));
+        using var fixture = new IdentityAssertionFixture();
+        var resolver = new NyxIdResponsesCallerScopeResolver(
+            new StubUserResolver(returnUserId: "  alice-1  "),
+            fixture.CreateValidator());
 
         var scope = await resolver.ResolveAsync(CreateContext("token"));
 
@@ -71,30 +103,167 @@ public sealed class ResponsesCallerScopeResolverTests
     }
 
     [Fact]
-    public async Task ResolveAsync_ShouldPropagateCancellation()
+    public async Task ResolveAsync_WithValidIdentityAssertion_ShouldResolveScopeWithoutCurrentUserLookup()
     {
-        var resolver = new NyxIdResponsesCallerScopeResolver(new StubUserResolver(returnUserId: "alice"));
+        using var fixture = new IdentityAssertionFixture();
+        var currentUserResolver = new StubUserResolver(returnUserId: "fallback-user");
+        var resolver = new NyxIdResponsesCallerScopeResolver(currentUserResolver, fixture.CreateValidator());
+
+        var scope = await resolver.ResolveAsync(CreateContext(
+            "bearer-token",
+            identityToken: fixture.CreateToken(subject: "identity-user"),
+            delegationToken: "delegation-token"));
+
+        scope.ScopeId.Should().Be("identity-user");
+        scope.OwnerSubject.Should().Be("identity-user");
+        scope.OriginKind.Should().Be(LlmSessionOriginKind.ApiKey);
+        currentUserResolver.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WithMalformedIdentityAssertion_ShouldFailClosedWithoutCurrentUserLookup()
+    {
+        using var fixture = new IdentityAssertionFixture();
+        var currentUserResolver = new StubUserResolver(returnUserId: "fallback-user");
+        var resolver = new NyxIdResponsesCallerScopeResolver(currentUserResolver, fixture.CreateValidator());
+
+        var act = () => resolver.ResolveAsync(CreateContext("bearer-token", identityToken: "not-a-jwt"));
+
+        await act.Should().ThrowAsync<ResponsesCallerScopeUnavailableException>()
+            .WithMessage("*identity assertion is invalid*");
+        currentUserResolver.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WithExpiredIdentityAssertion_ShouldFailClosed()
+    {
+        using var fixture = new IdentityAssertionFixture(clockSkewSeconds: 0);
+        var currentUserResolver = new StubUserResolver(returnUserId: "fallback-user");
+        var resolver = new NyxIdResponsesCallerScopeResolver(currentUserResolver, fixture.CreateValidator());
+
+        var act = () => resolver.ResolveAsync(CreateContext(
+            "bearer-token",
+            identityToken: fixture.CreateToken(
+                subject: "identity-user",
+                notBeforeUtc: DateTime.UtcNow.AddMinutes(-10),
+                expiresAtUtc: DateTime.UtcNow.AddMinutes(-5))));
+
+        await act.Should().ThrowAsync<ResponsesCallerScopeUnavailableException>();
+        currentUserResolver.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WithWrongAudienceOrIssuer_ShouldFailClosed()
+    {
+        using var fixture = new IdentityAssertionFixture();
+        var currentUserResolver = new StubUserResolver(returnUserId: "fallback-user");
+        var resolver = new NyxIdResponsesCallerScopeResolver(currentUserResolver, fixture.CreateValidator());
+
+        var wrongAudience = () => resolver.ResolveAsync(CreateContext(
+            "bearer-token",
+            identityToken: fixture.CreateToken(subject: "identity-user", audience: "wrong-audience")));
+        var wrongIssuer = () => resolver.ResolveAsync(CreateContext(
+            "bearer-token",
+            identityToken: fixture.CreateToken(subject: "identity-user", issuer: "https://wrong-issuer.example")));
+
+        await wrongAudience.Should().ThrowAsync<ResponsesCallerScopeUnavailableException>();
+        await wrongIssuer.Should().ThrowAsync<ResponsesCallerScopeUnavailableException>();
+        currentUserResolver.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WithMissingSubOrJti_ShouldFailClosed()
+    {
+        using var fixture = new IdentityAssertionFixture();
+        var currentUserResolver = new StubUserResolver(returnUserId: "fallback-user");
+        var resolver = new NyxIdResponsesCallerScopeResolver(currentUserResolver, fixture.CreateValidator());
+
+        var missingSub = () => resolver.ResolveAsync(CreateContext(
+            "bearer-token",
+            identityToken: fixture.CreateToken(subject: null)));
+        var missingJti = () => resolver.ResolveAsync(CreateContext(
+            "bearer-token",
+            identityToken: fixture.CreateToken(subject: "identity-user", jti: null)));
+
+        await missingSub.Should().ThrowAsync<ResponsesCallerScopeUnavailableException>();
+        await missingJti.Should().ThrowAsync<ResponsesCallerScopeUnavailableException>();
+        currentUserResolver.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WithWrongServiceId_ShouldFailClosed_WhenExpectedServiceIdConfigured()
+    {
+        using var fixture = new IdentityAssertionFixture(expectedServiceId: "aevatar-service");
+        var currentUserResolver = new StubUserResolver(returnUserId: "fallback-user");
+        var resolver = new NyxIdResponsesCallerScopeResolver(currentUserResolver, fixture.CreateValidator());
+
+        var act = () => resolver.ResolveAsync(CreateContext(
+            "bearer-token",
+            identityToken: fixture.CreateToken(subject: "identity-user", serviceId: "other-service")));
+
+        await act.Should().ThrowAsync<ResponsesCallerScopeUnavailableException>();
+        currentUserResolver.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WithMissingIdentityAssertion_ShouldFallbackToCurrentUserLookup()
+    {
+        using var fixture = new IdentityAssertionFixture();
+        var currentUserResolver = new StubUserResolver(returnUserId: "fallback-user");
+        var resolver = new NyxIdResponsesCallerScopeResolver(currentUserResolver, fixture.CreateValidator());
+
+        var scope = await resolver.ResolveAsync(CreateContext("bearer-token"));
+
+        scope.ScopeId.Should().Be("fallback-user");
+        scope.OwnerSubject.Should().Be("fallback-user");
+        currentUserResolver.LastAccessToken.Should().Be("bearer-token");
+        currentUserResolver.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WithDelegationTokenOnly_ShouldNotResolveCallerIdentityFromDelegationToken()
+    {
+        using var fixture = new IdentityAssertionFixture();
+        var currentUserResolver = new StubUserResolver(returnUserId: "fallback-user");
+        var resolver = new NyxIdResponsesCallerScopeResolver(currentUserResolver, fixture.CreateValidator());
+
+        var scope = await resolver.ResolveAsync(CreateContext("bearer-token", delegationToken: "delegation-token"));
+
+        scope.ScopeId.Should().Be("fallback-user");
+        currentUserResolver.LastAccessToken.Should().Be("bearer-token");
+        currentUserResolver.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldPropagateCancellation_WhenUsingMeFallback()
+    {
+        using var fixture = new IdentityAssertionFixture();
+        var resolver = new NyxIdResponsesCallerScopeResolver(
+            new StubUserResolver(returnUserId: "alice"),
+            fixture.CreateValidator());
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
         var act = () => resolver.ResolveAsync(CreateContext("token"), cts.Token);
 
-        // Stub honors cancellation token; ensures the resolver passes ct through.
         await act.Should().ThrowAsync<OperationCanceledException>();
     }
 
     [Fact]
-    public async Task ResolveAsync_ShouldContinueUsingInboundBearerForMeFallback()
+    public async Task ResolveAsync_ShouldPropagateCancellation_WhenUsingIdentityAssertion()
     {
-        var currentUserResolver = new StubUserResolver(returnUserId: "alice");
-        var resolver = new NyxIdResponsesCallerScopeResolver(currentUserResolver);
+        using var fixture = new IdentityAssertionFixture();
+        var resolver = new NyxIdResponsesCallerScopeResolver(
+            new StubUserResolver(returnUserId: "alice"),
+            fixture.CreateValidator());
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
 
-        _ = await resolver.ResolveAsync(CreateContext(
+        var act = () => resolver.ResolveAsync(CreateContext(
             "bearer-token",
-            identityToken: "identity-token",
-            delegationToken: "delegation-token"));
+            identityToken: fixture.CreateToken(subject: "identity-user")), cts.Token);
 
-        currentUserResolver.LastAccessToken.Should().Be("bearer-token");
+        await act.Should().ThrowAsync<OperationCanceledException>();
     }
 
     private static ResponsesCallerScopeResolutionContext CreateContext(
@@ -111,11 +280,118 @@ public sealed class ResponsesCallerScopeResolverTests
 
         public string? LastAccessToken { get; private set; }
 
+        public int CallCount { get; private set; }
+
         public Task<string?> ResolveCurrentUserIdAsync(string nyxIdAccessToken, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
+            CallCount++;
             LastAccessToken = nyxIdAccessToken;
             return Task.FromResult(_returnUserId);
+        }
+    }
+
+    private sealed class IdentityAssertionFixture : IDisposable
+    {
+        private const string KeyId = "test-key";
+        private readonly RSA _rsa = RSA.Create(2048);
+        private readonly RsaSecurityKey _signingKey;
+        private readonly string _jwksJson;
+        private readonly int _clockSkewSeconds;
+        private readonly string? _expectedServiceId;
+
+        public IdentityAssertionFixture(int clockSkewSeconds = 60, string? expectedServiceId = null)
+        {
+            _signingKey = new RsaSecurityKey(_rsa)
+            {
+                KeyId = KeyId,
+            };
+            _jwksJson = JsonSerializer.Serialize(new
+            {
+                keys = new[] { JsonWebKeyConverter.ConvertFromSecurityKey(_signingKey) },
+            });
+            _clockSkewSeconds = clockSkewSeconds;
+            _expectedServiceId = expectedServiceId;
+        }
+
+        public string Issuer { get; } = "https://nyxid.example";
+
+        public string Audience { get; } = "aevatar/responses";
+
+        public NyxIdIdentityAssertionValidator CreateValidator()
+        {
+            var options = Options.Create(new ResponsesNyxIdIdentityAssertionOptions
+            {
+                Issuer = Issuer,
+                ExpectedAudience = Audience,
+                JwksUri = "https://nyxid.example/jwks",
+                ExpectedServiceId = _expectedServiceId,
+                ClockSkewSeconds = _clockSkewSeconds,
+            });
+            return new NyxIdIdentityAssertionValidator(
+                new StaticHttpClientFactory(_jwksJson),
+                options);
+        }
+
+        public string CreateToken(
+            string? subject,
+            string? issuer = null,
+            string? audience = null,
+            string? jti = "jti-1",
+            string? serviceId = null,
+            DateTime? notBeforeUtc = null,
+            DateTime? expiresAtUtc = null)
+        {
+            var claims = new List<Claim>();
+            if (!string.IsNullOrWhiteSpace(subject))
+                claims.Add(new Claim(JwtRegisteredClaimNames.Sub, subject));
+            if (!string.IsNullOrWhiteSpace(jti))
+                claims.Add(new Claim(JwtRegisteredClaimNames.Jti, jti));
+            if (!string.IsNullOrWhiteSpace(serviceId))
+                claims.Add(new Claim("nyx_service_id", serviceId));
+
+            var descriptor = new SecurityTokenDescriptor
+            {
+                Issuer = issuer ?? Issuer,
+                Audience = audience ?? Audience,
+                Subject = new ClaimsIdentity(claims),
+                NotBefore = notBeforeUtc ?? DateTime.UtcNow.AddMinutes(-1),
+                Expires = expiresAtUtc ?? DateTime.UtcNow.AddMinutes(5),
+                SigningCredentials = new SigningCredentials(_signingKey, SecurityAlgorithms.RsaSha256),
+            };
+
+            return new JwtSecurityTokenHandler().CreateEncodedJwt(descriptor);
+        }
+
+        public void Dispose() => _rsa.Dispose();
+    }
+
+    private sealed class StaticHttpClientFactory : IHttpClientFactory
+    {
+        private readonly string _jwksJson;
+
+        public StaticHttpClientFactory(string jwksJson) => _jwksJson = jwksJson;
+
+        public HttpClient CreateClient(string name) =>
+            new(new StaticJwksHandler(_jwksJson))
+            {
+                BaseAddress = new Uri("https://nyxid.example"),
+            };
+    }
+
+    private sealed class StaticJwksHandler : HttpMessageHandler
+    {
+        private readonly string _jwksJson;
+
+        public StaticJwksHandler(string jwksJson) => _jwksJson = jwksJson;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_jwksJson),
+            });
         }
     }
 }


### PR DESCRIPTION
## 摘要

rollup auto-refact-dev → dev(integration `e6beabef`)。

含已审已合的 auto-loop 改动:
- **#1713**(closes #1484):NyxID signed-assertion-first caller scope(Host-internal RS256/JWKS 验证;r1 3/3 approve+comment)。

等 dev required(fast-gates/console-web/coverage-quality)全绿后合并。

🤖 Auto-loop / codex-refactor-loop rollup
⟦AI:AUTO-LOOP⟧
