### PR TITLE
refactor(#1628): demote FromMetadata external-only — migrate production callers

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
@@ -196,7 +196,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         var disableTools = forceDisableTools || replyPlan.DisableTools;
         var tools = await BuildTurnToolsAsync(disableTools, ct);
         var effectiveToolContext = replyPlan.PrimaryControl.ToToolContext(
-            replyPlan.PrimaryToolContext ?? AgentToolExecutionContextMapper.FromMetadata(replyPlan.Primary));
+            replyPlan.PrimaryToolContext ?? BuildExternalOnlyToolContext(replyPlan.Primary));
         var externalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(replyPlan.Primary);
         var runtime = BuildRuntime(
             activity,
@@ -290,7 +290,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         CancellationToken ct)
     {
         var externalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(effectiveMetadata);
-        var toolContext = llmControl.ToToolContext(baseToolContext ?? AgentToolExecutionContextMapper.FromMetadata(effectiveMetadata));
+        var toolContext = llmControl.ToToolContext(baseToolContext ?? BuildExternalOnlyToolContext(effectiveMetadata));
 
         // Refactor (iter31/cluster-032-chatruntime-taskrun-business-loop):
         //   Old pattern: NyxID reply construction passed stream_buffer_capacity into ChatRuntime after the stream loop moved to Task.Run + Channel.
@@ -454,6 +454,13 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
             ? null
             : $"正在处理 `/{commandLabel}`, 加载技能并扫描数据中...";
     }
+
+    private static AgentToolExecutionContext BuildExternalOnlyToolContext(
+        IReadOnlyDictionary<string, string>? metadata) =>
+        AgentToolExecutionContext.Empty with
+        {
+            ExternalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(metadata),
+        };
 
     // ADR-0021 §6 / canon §8 cross-round usage aggregation — each provider round
     // reports its own Usage; the actor-edge closeout carries the sum.

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
@@ -325,7 +325,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         var prompt = BuildExecutionPrompt(now, reason);
         var metadata = await BuildExecutionMetadataAsync(ct);
         var llmControl = await BuildExecutionLlmControlAsync(ct);
-        var toolContext = llmControl.ToToolContext(AgentToolExecutionContextMapper.FromMetadata(metadata));
+        var toolContext = llmControl.ToToolContext(BuildExternalOnlyToolContext(metadata));
         var requestId = Guid.NewGuid().ToString("N");
         var content = new StringBuilder();
 
@@ -624,6 +624,13 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
                 "Refusing to record this run as a successful execution.");
         }
     }
+
+    private static AgentToolExecutionContext BuildExternalOnlyToolContext(
+        IReadOnlyDictionary<string, string>? metadata) =>
+        AgentToolExecutionContext.Empty with
+        {
+            ExternalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(metadata),
+        };
 
     private Task SendOutputAsync(string output, CancellationToken ct) =>
         SendOutputAsync(output, providerSlugOverride: null, ct);

--- a/test/Aevatar.AI.Core.Tests/RoleGAgentTests.cs
+++ b/test/Aevatar.AI.Core.Tests/RoleGAgentTests.cs
@@ -62,12 +62,25 @@ public class RoleGAgentTests
     }
 
     [Fact]
-    public void RoleGAgentSource_DoesNotUseLegacyMetadataContextMapper()
+    public void ProductionSources_ShouldNotCallAgentToolExecutionContextMapperFromMetadata()
     {
-        var source = File.ReadAllText(FindRepoFile("src/Aevatar.AI.Core/RoleGAgent.cs"));
-        var executableSource = StripSingleLineComments(source);
+        var root = FindRepoRoot();
+        var productionFiles = new[] { "src", "agents" }
+            .Select(path => Path.Combine(root, path))
+            .Where(Directory.Exists)
+            .SelectMany(path => Directory.EnumerateFiles(path, "*.cs", SearchOption.AllDirectories))
+            .Where(path => !IsGeneratedOrBuildOutput(path))
+            .Where(path => !Path.GetFileName(path).Equals("AgentToolExecutionContextMapper.cs", StringComparison.Ordinal))
+            .ToArray();
 
-        executableSource.Should().NotContain("AgentToolExecutionContextMapper.FromMetadata(");
+        productionFiles.Should().NotBeEmpty();
+        var offenders = productionFiles
+            .Where(path => StripSingleLineComments(File.ReadAllText(path))
+                .Contains("AgentToolExecutionContextMapper.FromMetadata(", StringComparison.Ordinal))
+            .Select(path => Path.GetRelativePath(root, path))
+            .ToArray();
+
+        offenders.Should().BeEmpty();
     }
 
     private static AgentToolExecutionContext ResolvePendingToolContext(PendingToolApprovalState pending)
@@ -84,17 +97,35 @@ public class RoleGAgentTests
 
     private static string FindRepoFile(string relativePath)
     {
+        var root = FindRepoRoot();
+        var candidate = Path.Combine(root, relativePath);
+        if (File.Exists(candidate))
+            return candidate;
+
+        throw new FileNotFoundException($"Could not find repository file '{relativePath}'.");
+    }
+
+    private static string FindRepoRoot()
+    {
         var current = new DirectoryInfo(AppContext.BaseDirectory);
         while (current != null)
         {
-            var candidate = Path.Combine(current.FullName, relativePath);
-            if (File.Exists(candidate))
-                return candidate;
+            if (File.Exists(Path.Combine(current.FullName, "aevatar.slnx")))
+                return current.FullName;
 
             current = current.Parent;
         }
 
-        throw new FileNotFoundException($"Could not find repository file '{relativePath}'.");
+        throw new DirectoryNotFoundException("Could not find repository root.");
+    }
+
+    private static bool IsGeneratedOrBuildOutput(string path)
+    {
+        var normalized = path.Replace(Path.DirectorySeparatorChar, '/');
+        return normalized.Contains("/bin/", StringComparison.Ordinal)
+               || normalized.Contains("/obj/", StringComparison.Ordinal)
+               || normalized.EndsWith(".g.cs", StringComparison.Ordinal)
+               || normalized.EndsWith(".Designer.cs", StringComparison.Ordinal);
     }
 
     private static string StripSingleLineComments(string source)

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
@@ -860,6 +860,52 @@ public sealed class ConversationReplyGeneratorTests
         prefsStore.Lookups.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task GenerateReplyAsync_ShouldNotPromoteMetadataOwnedKeysIntoToolContext()
+    {
+        var providerFactory = new RecordingProviderFactory();
+        var generator = new NyxIdConversationReplyGenerator(providerFactory);
+
+        await generator.GenerateReplyAsync(
+            new ChatActivity
+            {
+                Id = "msg-owned-metadata",
+                Conversation = new ConversationReference { CanonicalKey = "lark:dm:user-owned-metadata" },
+                Content = new MessageContent { Text = "hello" },
+            },
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [LLMRequestMetadataKeys.ScopeId] = "metadata-scope",
+                ["scope_id"] = "metadata-scope-alias",
+                [LLMRequestMetadataKeys.NyxIdAccessToken] = "metadata-access-token",
+                [LLMRequestMetadataKeys.NyxIdRoutePreference] = "metadata-route",
+                [LLMRequestMetadataKeys.ModelOverride] = "metadata-model",
+                ["channel.platform"] = "lark",
+                ["channel.sender_id"] = "ou_metadata_sender",
+                ["channel.message_id"] = "metadata-message",
+                ["trace-id"] = "trace-1",
+            },
+            Control(model: "typed-model", route: "typed-route", rounds: 6, token: "typed-token"),
+            toolContext: null,
+            streamingSink: null,
+            CancellationToken.None);
+
+        var request = providerFactory.Requests.Should().ContainSingle().Subject;
+        request.Metadata.Should().ContainSingle().Which.Should().Be(new KeyValuePair<string, string>("trace-id", "trace-1"));
+
+        var toolContext = request.ToolContext!;
+        toolContext.Caller.ScopeId.Should().BeNull();
+        toolContext.Channel.Platform.Should().BeNull();
+        toolContext.Channel.SenderId.Should().BeNull();
+        toolContext.Channel.MessageId.Should().BeNull();
+        toolContext.Credentials.NyxIdAccessToken.Should().Be("typed-token");
+        toolContext.Credentials.NyxIdOrgToken.Should().Be("typed-token");
+        toolContext.Routing.ModelOverride.Should().Be("typed-model");
+        toolContext.Routing.NyxIdRoutePreference.Should().Be("typed-route");
+        toolContext.Routing.MaxToolRoundsOverride.Should().Be(6);
+        toolContext.ExternalMetadata.Should().ContainSingle().Which.Should().Be(new KeyValuePair<string, string>("trace-id", "trace-1"));
+    }
+
     // Refactor (issue1318/first-slice): Old: unbound sender still saw tool dispatch + unknown
     // slash silently consumed.
     // New: unbound sender disables tool dispatch; unknown slash gates to /init bootstrap;


### PR DESCRIPTION
## 摘要

#1628(#1620-first):demote FromMetadata external-only。

- **Old**:生产 caller 通过 `AgentToolExecutionContextMapper.FromMetadata(metadata)` 从通用 metadata 重建 tool execution context,绕过 typed control context。
- **New**:迁移生产 caller 到 typed 路径;public shim 保留 external-only(later slice 再议删除);加生产源扫描 guard。

不新增抽象;不改 proto。依据:#1628 design-consensus r2 **3/3 unanimous**(structural)。注:旧 impl PR #1633 因落后 59 commit 已关,本 PR 对当前 trunk 重核验后重做。

范围:ConversationReplyGenerator.cs / SkillRunnerGAgent.cs(迁 caller)+ RoleGAgentTests.cs(源扫描 guard)+ ConversationReplyGeneratorTests.cs(行为测试)。+102/-11。

Closes #1628

🤖 Auto-loop / codex-refactor-loop
⟦AI:AUTO-LOOP⟧
