### PR TITLE
chore: rollup auto-refact-dev → dev (f949b7e0)

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/DependencyInjection/ChannelRuntimeServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/DependencyInjection/ChannelRuntimeServiceCollectionExtensions.cs
@@ -77,14 +77,12 @@ public static class ChannelRuntimeServiceCollectionExtensions
             IProjectionActivationPlanProvider,
             ChannelBotRegistrationCommittedStateProjectionActivationPlanProvider>());
 
-        // Detect projection store provider from configuration. The helper logs a
-        // misconfiguration warning (Console.Error during SCE composition; structured
-        // log when a real logger is wired in tests) when configuration is present
-        // but Endpoints/Enabled are both empty, so operators see the InMemory
-        // fallback instead of discovering it after a restart wipes the replica.
-        var useElasticsearch = ElasticsearchProjectionConfiguration.IsEnabled(
-            configuration,
-            storeName: "ChannelRuntime");
+        var documentProvider = configuration is null
+            ? new ProjectionDocumentProviderSelection(
+                ProjectionDocumentProviderKind.InMemory,
+                ElasticsearchEnabled: false,
+                InMemoryEnabled: true)
+            : ProjectionDocumentProviderConfiguration.Resolve(configuration, "ChannelRuntime");
 
         // ─── Channel Bot Registration projection pipeline ───
         services.AddProjectionMaterializationRuntimeCore<
@@ -108,15 +106,15 @@ public static class ChannelRuntimeServiceCollectionExtensions
         services.TryAddSingleton<ChannelBotRegistrationProjectionBootstrapActivator>();
         services.AddHostedService<ChannelBotRegistrationStartupService>();
 
-        if (useElasticsearch)
+        if (documentProvider.ElasticsearchEnabled)
         {
             services.AddElasticsearchDocumentProjectionStore<ChannelBotRegistrationDocument, string>(
-                optionsFactory: _ => ElasticsearchProjectionConfiguration.BindOptions(configuration!),
+                optionsFactory: _ => ProjectionDocumentProviderConfiguration.BindRequiredElasticsearchOptions(configuration!),
                 metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<ChannelBotRegistrationDocument>>().Metadata,
                 keySelector: static doc => doc.Id,
                 keyFormatter: static key => key);
             services.AddElasticsearchDocumentProjectionStore<ProjectionScopeStatusDocument, string>(
-                optionsFactory: _ => ElasticsearchProjectionConfiguration.BindOptions(configuration!),
+                optionsFactory: _ => ProjectionDocumentProviderConfiguration.BindRequiredElasticsearchOptions(configuration!),
                 metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<ProjectionScopeStatusDocument>>().Metadata,
                 keySelector: static doc => doc.Id,
                 keyFormatter: static key => key);

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ServiceCollectionExtensionsTests.cs
@@ -2,6 +2,8 @@ using Aevatar.AI.ToolProviders.Channel;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.CQRS.Projection.Providers.Elasticsearch.Stores;
+using Aevatar.CQRS.Projection.Providers.InMemory.Stores;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.GAgents.Channel.Abstractions;
@@ -44,6 +46,12 @@ public sealed class ServiceCollectionExtensionsTests
             descriptor.ServiceType == typeof(IProjectionDocumentMetadataProvider<ProjectionScopeStatusDocument>));
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(IProjectionDocumentReader<ProjectionScopeStatusDocument, string>));
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(InMemoryProjectionDocumentStore<ChannelBotRegistrationDocument, string>));
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(InMemoryProjectionDocumentStore<ProjectionScopeStatusDocument, string>));
+        services.Should().NotContain(descriptor =>
+            descriptor.ServiceType == typeof(ElasticsearchProjectionDocumentStore<ChannelBotRegistrationDocument, string>));
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(IProjectionScopeWatermarkQueryPort) &&
             descriptor.ImplementationType == typeof(ProjectionScopeStatusQueryPort));
@@ -152,6 +160,61 @@ public sealed class ServiceCollectionExtensionsTests
     }
 
     [Fact]
+    public void AddChannelRuntime_WithConfiguredInMemoryDenied_ShouldFailFast()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Projection:Document:Providers:Elasticsearch:Enabled"] = "false",
+                ["Projection:Document:Providers:InMemory:Enabled"] = "true",
+                ["Projection:Policies:DenyInMemoryDocumentReadStore"] = "true",
+            })
+            .Build();
+        var services = new ServiceCollection();
+
+        var act = () => services.AddChannelRuntime(configuration);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*InMemory document provider is not allowed by projection policy*");
+    }
+
+    [Fact]
+    public void AddChannelRuntime_WithProductionConfigurationAndImplicitInMemory_ShouldFailFast()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Projection:Policies:Environment"] = "Production",
+            })
+            .Build();
+        var services = new ServiceCollection();
+
+        var act = () => services.AddChannelRuntime(configuration);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*InMemory document provider is not allowed by projection policy*");
+    }
+
+    [Fact]
+    public void AddChannelRuntime_WithElasticsearchEnabledButMissingEndpoints_ShouldFailOnStoreResolution()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Projection:Document:Providers:Elasticsearch:Enabled"] = "true",
+            })
+            .Build();
+        var services = new ServiceCollection();
+
+        services.AddChannelRuntime(configuration);
+        using var provider = services.BuildServiceProvider();
+        var act = () => provider.GetRequiredService<IProjectionDocumentReader<ChannelBotRegistrationDocument, string>>();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Projection:Document:Providers:Elasticsearch is enabled but Endpoints is empty*");
+    }
+
+    [Fact]
     public void AddChannelRuntime_RegistersOnlyPublicRegistrationProjectionServices_ForElasticsearchStore()
     {
         var configuration = new ConfigurationBuilder()
@@ -178,6 +241,12 @@ public sealed class ServiceCollectionExtensionsTests
             descriptor.ServiceType == typeof(IProjectionDocumentMetadataProvider<ProjectionScopeStatusDocument>));
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(IProjectionDocumentReader<ProjectionScopeStatusDocument, string>));
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(ElasticsearchProjectionDocumentStore<ChannelBotRegistrationDocument, string>));
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(ElasticsearchProjectionDocumentStore<ProjectionScopeStatusDocument, string>));
+        services.Should().NotContain(descriptor =>
+            descriptor.ServiceType == typeof(InMemoryProjectionDocumentStore<ChannelBotRegistrationDocument, string>));
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(IProjectionScopeWatermarkQueryPort) &&
             descriptor.ImplementationType == typeof(ProjectionScopeStatusQueryPort));


### PR DESCRIPTION
## 摘要

rollup auto-refact-dev → dev(`f949b7e0`)。含 #1719(closes #354):fail-fast ChannelRuntime provider policy(删重复 provider-selection 复用 Resolve)。

等 dev required 全绿后合并。

🤖 Auto-loop rollup
⟦AI:AUTO-LOOP⟧
