### PR TITLE
refactor(#347): collapse AgentBuilderCardFlow command branches into private spec table

### DIFF
--- a/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderCardFlow.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderCardFlow.cs
@@ -25,7 +25,6 @@ public static class AgentBuilderCardFlow
     private const string EnableAgentCommand = "/enable-agent";
     private const string DeleteAgentCommand = "/delete-agent";
 
-    // refactor helper, no behavior change
     private sealed record AgentBuilderCommandSpec(
         string TextCommand,
         string CardAction,

--- a/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderCardFlow.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderCardFlow.cs
@@ -25,6 +25,98 @@ public static class AgentBuilderCardFlow
     private const string EnableAgentCommand = "/enable-agent";
     private const string DeleteAgentCommand = "/delete-agent";
 
+    // refactor helper, no behavior change
+    private sealed record AgentBuilderCommandSpec(
+        string TextCommand,
+        string CardAction,
+        string ToolAction,
+        string Usage,
+        bool RequiresAgentId,
+        Func<IReadOnlyList<string>, AgentBuilderCommandSpec, AgentBuilderFlowDecision> BuildFromText,
+        Func<ChannelInboundEvent, AgentBuilderCommandSpec, AgentBuilderFlowDecision> BuildFromCard,
+        Func<JsonElement, MessageContent>? FormatResult);
+
+    private static readonly AgentBuilderCommandSpec[] CommandSpecs =
+    [
+        new(
+            ListAgentsCommand,
+            ListAgentsAction,
+            ListAgentsAction,
+            string.Empty,
+            RequiresAgentId: false,
+            BuildListAgentsTextDecision,
+            BuildListAgentsCardDecision,
+            root => AgentBuilderCardContent.FormatListAgentsResult(root)),
+        new(
+            AgentStatusCommand,
+            AgentStatusAction,
+            AgentStatusAction,
+            $"Usage: {AgentStatusCommand} <agent_id>",
+            RequiresAgentId: true,
+            BuildSimpleAgentTextDecision,
+            BuildAgentScopedCardDecision,
+            FormatAgentStatusResult),
+        new(
+            RunAgentCommand,
+            RunAgentAction,
+            RunAgentAction,
+            $"Usage: {RunAgentCommand} <agent_id>",
+            RequiresAgentId: true,
+            BuildSimpleAgentTextDecision,
+            BuildAgentScopedCardDecision,
+            FormatRunAgentResult),
+        new(
+            DisableAgentCommand,
+            DisableAgentAction,
+            DisableAgentAction,
+            $"Usage: {DisableAgentCommand} <agent_id>",
+            RequiresAgentId: true,
+            BuildSimpleAgentTextDecision,
+            BuildAgentScopedCardDecision,
+            FormatDisableAgentResult),
+        new(
+            EnableAgentCommand,
+            EnableAgentAction,
+            EnableAgentAction,
+            $"Usage: {EnableAgentCommand} <agent_id>",
+            RequiresAgentId: true,
+            BuildSimpleAgentTextDecision,
+            BuildAgentScopedCardDecision,
+            FormatEnableAgentResult),
+        new(
+            DeleteAgentCommand,
+            DeleteAgentAction,
+            DeleteAgentAction,
+            $"Usage: {DeleteAgentCommand} <agent_id>",
+            RequiresAgentId: true,
+            BuildDeleteAgentTextDecision,
+            BuildDeleteAgentCardDecision,
+            FormatDeleteAgentResultAsList),
+    ];
+
+    private static readonly AgentBuilderCommandSpec ConfirmDeleteSpec = new(
+        TextCommand: string.Empty,
+        CardAction: ConfirmDeleteAgentAction,
+        ToolAction: ConfirmDeleteAgentAction,
+        Usage: string.Empty,
+        RequiresAgentId: true,
+        BuildFromText: static (_, _) => throw new InvalidOperationException("confirm_delete_agent has no text command."),
+        BuildFromCard: BuildConfirmDeleteCardDecision,
+        FormatResult: null);
+
+    private static readonly IReadOnlyDictionary<string, AgentBuilderCommandSpec> SpecsByTextCommand =
+        CommandSpecs.ToDictionary(static spec => spec.TextCommand, StringComparer.OrdinalIgnoreCase);
+
+    private static readonly IReadOnlyDictionary<string, AgentBuilderCommandSpec> SpecsByCardAction =
+        CommandSpecs
+            .Append(ConfirmDeleteSpec)
+            .ToDictionary(static spec => spec.CardAction, StringComparer.OrdinalIgnoreCase);
+
+    private static readonly IReadOnlyDictionary<string, AgentBuilderCommandSpec> SpecsByToolAction =
+        CommandSpecs
+            .Where(static spec => spec.FormatResult is not null)
+            .ToDictionary(static spec => spec.ToolAction, StringComparer.OrdinalIgnoreCase);
+
     public static bool TryResolve(ChannelInboundEvent evt, out AgentBuilderFlowDecision? decision) =>
         TryResolve(evt, preferredGithubUsername: null, out decision);
 
@@ -59,79 +151,12 @@ public static class AgentBuilderCardFlow
         if (!evt.Extra.TryGetValue("agent_builder_action", out var action))
             return false;
 
-        string? argumentsJson;
-        string? validationError;
-        switch ((action ?? string.Empty).Trim())
-        {
-            case ListAgentsAction:
-                decision = AgentBuilderFlowDecision.ToolCall(ListAgentsAction, """{"action":"list_agents"}""");
-                return true;
+        var normalizedAction = (action ?? string.Empty).Trim();
+        if (!SpecsByCardAction.TryGetValue(normalizedAction, out var spec))
+            return false;
 
-            case AgentStatusAction:
-                if (!TryBuildAgentActionArguments(evt, "agent_status", out argumentsJson, out validationError))
-                {
-                    decision = AgentBuilderFlowDecision.DirectReply(validationError!);
-                    return true;
-                }
-
-                decision = AgentBuilderFlowDecision.ToolCall(AgentStatusAction, argumentsJson!);
-                return true;
-
-            case RunAgentAction:
-                if (!TryBuildAgentActionArguments(evt, "run_agent", out argumentsJson, out validationError))
-                {
-                    decision = AgentBuilderFlowDecision.DirectReply(validationError!);
-                    return true;
-                }
-
-                decision = AgentBuilderFlowDecision.ToolCall(RunAgentAction, argumentsJson!);
-                return true;
-
-            case DisableAgentAction:
-                if (!TryBuildAgentActionArguments(evt, "disable_agent", out argumentsJson, out validationError))
-                {
-                    decision = AgentBuilderFlowDecision.DirectReply(validationError!);
-                    return true;
-                }
-
-                decision = AgentBuilderFlowDecision.ToolCall(DisableAgentAction, argumentsJson!);
-                return true;
-
-            case EnableAgentAction:
-                if (!TryBuildAgentActionArguments(evt, "enable_agent", out argumentsJson, out validationError))
-                {
-                    decision = AgentBuilderFlowDecision.DirectReply(validationError!);
-                    return true;
-                }
-
-                decision = AgentBuilderFlowDecision.ToolCall(EnableAgentAction, argumentsJson!);
-                return true;
-
-            case ConfirmDeleteAgentAction:
-                if (!TryGetRequiredExtra(evt, "agent_id", out var agentId))
-                {
-                    decision = AgentBuilderFlowDecision.DirectReply("agent_id is required for delete confirmation.");
-                    return true;
-                }
-
-                decision = AgentBuilderFlowDecision.DirectReply(BuildDeleteConfirmationCard(
-                    agentId,
-                    evt.Extra.TryGetValue("template", out var template) ? template : null));
-                return true;
-
-            case DeleteAgentAction:
-                if (!TryBuildAgentActionArguments(evt, "delete_agent", out argumentsJson, out validationError, confirm: true))
-                {
-                    decision = AgentBuilderFlowDecision.DirectReply(validationError!);
-                    return true;
-                }
-
-                decision = AgentBuilderFlowDecision.ToolCall(DeleteAgentAction, argumentsJson!);
-                return true;
-
-            default:
-                return false;
-        }
+        decision = spec.BuildFromCard(evt, spec);
+        return true;
     }
 
     private static bool TryResolveTextCommand(
@@ -151,80 +176,44 @@ public static class AgentBuilderCardFlow
             return false;
 
         var command = tokens[0];
-        if (!IsKnownTextCommand(command))
+        if (!SpecsByTextCommand.TryGetValue(command, out var spec))
             return false;
 
-        // Refactor (iter9/cluster-1305-hybrid-minimal-delete):
-        // Old pattern: agent-builder routing split across a retired relay flow and AgentBuilderCardFlow.
-        // New principle: single AgentBuilderCardFlow routes all agent-builder slash commands via TryResolveSimpleAgentAction.
         if (!IsPrivateChat(evt.ChatType))
         {
             decision = AgentBuilderFlowDecision.DirectReply(BuildPrivateChatRestrictionReply(command));
             return true;
         }
 
-        return TryResolveKnownTextCommand(command, tokens, out decision);
+        decision = spec.BuildFromText(tokens, spec);
+        return true;
     }
 
-    private static bool IsKnownTextCommand(string command) =>
-        string.Equals(command, ListAgentsCommand, StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(command, AgentStatusCommand, StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(command, RunAgentCommand, StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(command, DisableAgentCommand, StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(command, EnableAgentCommand, StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(command, DeleteAgentCommand, StringComparison.OrdinalIgnoreCase);
-
-    private static bool TryResolveKnownTextCommand(
-        string command,
+    private static AgentBuilderFlowDecision BuildListAgentsTextDecision(
         IReadOnlyList<string> tokens,
-        out AgentBuilderFlowDecision? decision)
+        AgentBuilderCommandSpec spec)
     {
-        if (string.Equals(command, ListAgentsCommand, StringComparison.OrdinalIgnoreCase))
+        _ = tokens;
+        return AgentBuilderFlowDecision.ToolCall(spec.ToolAction, JsonSerializer.Serialize(new
         {
-            decision = AgentBuilderFlowDecision.ToolCall(ListAgentsAction, """{"action":"list_agents"}""");
-            return true;
-        }
-
-        if (string.Equals(command, AgentStatusCommand, StringComparison.OrdinalIgnoreCase))
-            return TryResolveSimpleAgentAction(tokens, AgentStatusAction, $"Usage: {AgentStatusCommand} <agent_id>", out decision);
-
-        if (string.Equals(command, RunAgentCommand, StringComparison.OrdinalIgnoreCase))
-            return TryResolveSimpleAgentAction(tokens, RunAgentAction, $"Usage: {RunAgentCommand} <agent_id>", out decision);
-
-        if (string.Equals(command, DisableAgentCommand, StringComparison.OrdinalIgnoreCase))
-            return TryResolveSimpleAgentAction(tokens, DisableAgentAction, $"Usage: {DisableAgentCommand} <agent_id>", out decision);
-
-        if (string.Equals(command, EnableAgentCommand, StringComparison.OrdinalIgnoreCase))
-            return TryResolveSimpleAgentAction(tokens, EnableAgentAction, $"Usage: {EnableAgentCommand} <agent_id>", out decision);
-
-        if (string.Equals(command, DeleteAgentCommand, StringComparison.OrdinalIgnoreCase))
-            return TryResolveDeleteAgentTextCommand(tokens, out decision);
-
-        decision = null;
-        return false;
+            action = spec.ToolAction,
+        }));
     }
 
-    private static bool TryResolveSimpleAgentAction(
+    private static AgentBuilderFlowDecision BuildSimpleAgentTextDecision(
         IReadOnlyList<string> tokens,
-        string action,
-        string usage,
-        out AgentBuilderFlowDecision? decision)
+        AgentBuilderCommandSpec spec)
     {
-        decision = null;
         if (tokens.Count < 2 || string.IsNullOrWhiteSpace(tokens[1]))
-        {
-            decision = AgentBuilderFlowDecision.DirectReply(usage);
-            return true;
-        }
+            return AgentBuilderFlowDecision.DirectReply(spec.Usage);
 
-        decision = AgentBuilderFlowDecision.ToolCall(
-            action,
+        return AgentBuilderFlowDecision.ToolCall(
+            spec.ToolAction,
             JsonSerializer.Serialize(new
             {
-                action,
+                action = spec.ToolAction,
                 agent_id = tokens[1].Trim(),
             }));
-        return true;
     }
 
     /// <summary>
@@ -240,16 +229,11 @@ public static class AgentBuilderCardFlow
         try
         {
             using var doc = JsonDocument.Parse(toolResultJson);
-            return decision.ToolAction switch
-            {
-                ListAgentsAction => AgentBuilderCardContent.FormatListAgentsResult(doc.RootElement),
-                AgentStatusAction => FormatAgentStatusResult(doc.RootElement),
-                RunAgentAction => FormatRunAgentResult(doc.RootElement),
-                DisableAgentAction => FormatDisableAgentResult(doc.RootElement),
-                EnableAgentAction => FormatEnableAgentResult(doc.RootElement),
-                DeleteAgentAction => FormatDeleteAgentResultAsList(doc.RootElement),
-                _ => ToTextContent(toolResultJson),
-            };
+            return decision.ToolAction is not null &&
+                   SpecsByToolAction.TryGetValue(decision.ToolAction, out var spec) &&
+                   spec.FormatResult is not null
+                ? spec.FormatResult(doc.RootElement)
+                : ToTextContent(toolResultJson);
         }
         catch (JsonException)
         {
@@ -268,9 +252,53 @@ public static class AgentBuilderCardFlow
             : evt.ChatType;
     }
 
+    private static AgentBuilderFlowDecision BuildListAgentsCardDecision(
+        ChannelInboundEvent evt,
+        AgentBuilderCommandSpec spec)
+    {
+        _ = evt;
+        return AgentBuilderFlowDecision.ToolCall(spec.ToolAction, JsonSerializer.Serialize(new
+        {
+            action = spec.ToolAction,
+        }));
+    }
+
+    private static AgentBuilderFlowDecision BuildAgentScopedCardDecision(
+        ChannelInboundEvent evt,
+        AgentBuilderCommandSpec spec)
+    {
+        if (!TryBuildAgentActionArguments(evt, spec, out var argumentsJson, out var validationError))
+            return AgentBuilderFlowDecision.DirectReply(validationError!);
+
+        return AgentBuilderFlowDecision.ToolCall(spec.ToolAction, argumentsJson!);
+    }
+
+    private static AgentBuilderFlowDecision BuildConfirmDeleteCardDecision(
+        ChannelInboundEvent evt,
+        AgentBuilderCommandSpec spec)
+    {
+        _ = spec;
+        if (!TryGetRequiredExtra(evt, "agent_id", out var agentId))
+            return AgentBuilderFlowDecision.DirectReply("agent_id is required for delete confirmation.");
+
+        return AgentBuilderFlowDecision.DirectReply(BuildDeleteConfirmationCard(
+            agentId,
+            evt.Extra.TryGetValue("template", out var template) ? template : null));
+    }
+
+    private static AgentBuilderFlowDecision BuildDeleteAgentCardDecision(
+        ChannelInboundEvent evt,
+        AgentBuilderCommandSpec spec)
+    {
+        if (!TryBuildAgentActionArguments(evt, spec, out var argumentsJson, out var validationError, confirm: true))
+            return AgentBuilderFlowDecision.DirectReply(validationError!);
+
+        return AgentBuilderFlowDecision.ToolCall(spec.ToolAction, argumentsJson!);
+    }
+
     private static bool TryBuildAgentActionArguments(
         ChannelInboundEvent evt,
-        string action,
+        AgentBuilderCommandSpec spec,
         out string? argumentsJson,
         out string? validationError,
         bool confirm = false)
@@ -278,13 +306,14 @@ public static class AgentBuilderCardFlow
         argumentsJson = null;
         validationError = null;
 
-        if (!TryGetRequiredExtra(evt, "agent_id", out var agentId))
+        string? agentId = null;
+        if (spec.RequiresAgentId && !TryGetRequiredExtra(evt, "agent_id", out agentId!))
         {
             validationError = "agent_id is required. Send /agents and retry from the latest card.";
             return false;
         }
 
-        var revisionFeedback = string.Equals(action, "run_agent", StringComparison.Ordinal)
+        var revisionFeedback = string.Equals(spec.ToolAction, RunAgentAction, StringComparison.Ordinal)
             ? NormalizeOptional(evt.Extra.TryGetValue("revision_feedback", out var rawRevisionFeedback)
                 ? rawRevisionFeedback
                 : (evt.Extra.TryGetValue("user_input", out var rawUserInput) ? rawUserInput : null))
@@ -292,7 +321,7 @@ public static class AgentBuilderCardFlow
 
         argumentsJson = JsonSerializer.Serialize(new
         {
-            action,
+            action = spec.ToolAction,
             agent_id = agentId,
             confirm,
             revision_feedback = revisionFeedback,
@@ -304,16 +333,12 @@ public static class AgentBuilderCardFlow
     /// Parses <c>/delete-agent &lt;agent_id&gt; [confirm]</c>. Without the trailing keyword the
     /// card flow keeps its explicit confirmation card; with it, the command dispatches directly.
     /// </summary>
-    private static bool TryResolveDeleteAgentTextCommand(
+    private static AgentBuilderFlowDecision BuildDeleteAgentTextDecision(
         IReadOnlyList<string> tokens,
-        out AgentBuilderFlowDecision? decision)
+        AgentBuilderCommandSpec spec)
     {
-        decision = null;
         if (tokens.Count < 2 || string.IsNullOrWhiteSpace(tokens[1]))
-        {
-            decision = AgentBuilderFlowDecision.DirectReply($"Usage: {DeleteAgentCommand} <agent_id>");
-            return true;
-        }
+            return AgentBuilderFlowDecision.DirectReply(spec.Usage);
 
         var agentId = tokens[1].Trim();
         var confirmed = tokens.Count > 2 &&
@@ -321,19 +346,17 @@ public static class AgentBuilderCardFlow
 
         if (confirmed)
         {
-            decision = AgentBuilderFlowDecision.ToolCall(
-                DeleteAgentAction,
+            return AgentBuilderFlowDecision.ToolCall(
+                spec.ToolAction,
                 JsonSerializer.Serialize(new
                 {
-                    action = DeleteAgentAction,
+                    action = spec.ToolAction,
                     agent_id = agentId,
                     confirm = true,
                 }));
-            return true;
         }
 
-        decision = AgentBuilderFlowDecision.DirectReply(BuildDeleteConfirmationCard(agentId, null));
-        return true;
+        return AgentBuilderFlowDecision.DirectReply(BuildDeleteConfirmationCard(agentId, null));
     }
 
     private static bool TryGetRequiredExtra(ChannelInboundEvent evt, string key, out string value)

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderCardFlowTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderCardFlowTests.cs
@@ -10,6 +10,204 @@ namespace Aevatar.GAgents.ChannelRuntime.Tests;
 
 public sealed class AgentBuilderCardFlowTests
 {
+    public static TheoryData<string, string, string?, string> TextAndCardToolActionCases()
+    {
+        return new TheoryData<string, string, string?, string>
+        {
+            { "/agents", "list_agents", null, "list_agents" },
+            { "/agent-status skill-runner-1", "agent_status", "skill-runner-1", "agent_status" },
+            { "/run-agent skill-runner-2", "run_agent", "skill-runner-2", "run_agent" },
+            { "/disable-agent skill-runner-3", "disable_agent", "skill-runner-3", "disable_agent" },
+            { "/enable-agent skill-runner-4", "enable_agent", "skill-runner-4", "enable_agent" },
+            { "/delete-agent skill-runner-5 confirm", "delete_agent", "skill-runner-5", "delete_agent" },
+        };
+    }
+
+    public static TheoryData<string, string, string> KnownTextCommandCases()
+    {
+        return new TheoryData<string, string, string>
+        {
+            { "/agents", "list_agents", "{}" },
+            { "/agent-status skill-runner-1", "agent_status", "{}" },
+            { "/run-agent skill-runner-2", "run_agent", "{}" },
+            { "/disable-agent skill-runner-3", "disable_agent", "{}" },
+            { "/enable-agent skill-runner-4", "enable_agent", "{}" },
+            { "/delete-agent skill-runner-5", string.Empty, "{}" },
+            { "/delete-agent skill-runner-5 confirm", "delete_agent", "{}" },
+        };
+    }
+
+    public static TheoryData<string, string> FormatterCases()
+    {
+        return new TheoryData<string, string>
+        {
+            {
+                "list_agents",
+                """
+                {
+                  "agents": [
+                    {
+                      "agent_id": "skill-runner-list-1",
+                      "template": "summary",
+                      "status": "running",
+                      "next_scheduled_run": "2026-04-23T09:00:00Z"
+                    }
+                  ]
+                }
+                """
+            },
+            {
+                "agent_status",
+                """
+                {
+                  "agent_id": "skill-runner-status-1",
+                  "template": "summary",
+                  "status": "running",
+                  "schedule_cron": "0 9 * * *",
+                  "schedule_timezone": "UTC",
+                  "last_run_at": "2026-04-25T05:30:00Z",
+                  "next_scheduled_run": "2026-04-26T09:00:00Z",
+                  "error_count": "0"
+                }
+                """
+            },
+            {
+                "run_agent",
+                """
+                {
+                  "agent_id": "skill-runner-run-1",
+                  "template": "summary",
+                  "status": "running",
+                  "note": "Manual run dispatched."
+                }
+                """
+            },
+            {
+                "disable_agent",
+                """
+                {
+                  "agent_id": "skill-runner-disable-1",
+                  "template": "summary",
+                  "status": "disabled",
+                  "schedule_cron": "0 9 * * *",
+                  "schedule_timezone": "UTC",
+                  "last_run_at": "2026-04-25T05:30:00Z",
+                  "next_scheduled_run": "n/a",
+                  "error_count": "0"
+                }
+                """
+            },
+            {
+                "enable_agent",
+                """
+                {
+                  "agent_id": "skill-runner-enable-1",
+                  "template": "summary",
+                  "status": "running",
+                  "schedule_cron": "0 9 * * *",
+                  "schedule_timezone": "UTC",
+                  "last_run_at": "2026-04-25T05:30:00Z",
+                  "next_scheduled_run": "2026-04-26T09:00:00Z",
+                  "error_count": "0"
+                }
+                """
+            },
+            {
+                "delete_agent",
+                """
+                {
+                  "status": "deleted",
+                  "agent_id": "skill-runner-delete-1",
+                  "revoked_api_key_id": "key-1",
+                  "agents": []
+                }
+                """
+            },
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(TextAndCardToolActionCases))]
+    public async Task TryResolveAsync_TextAndCardSpecs_MapToSameToolAction(
+        string textCommand,
+        string cardAction,
+        string? agentId,
+        string expectedAction)
+    {
+        var textInbound = new ChannelInboundEvent
+        {
+            ChatType = "p2p",
+            RegistrationScopeId = "scope-1",
+            Text = textCommand,
+        };
+        var cardInbound = new ChannelInboundEvent
+        {
+            ChatType = "card_action",
+            RegistrationScopeId = "scope-1",
+        };
+        cardInbound.Extra["agent_builder_action"] = cardAction;
+        if (agentId is not null)
+            cardInbound.Extra["agent_id"] = agentId;
+
+        var textDecision = await AgentBuilderCardFlow.TryResolveAsync(textInbound, userConfigQueryPort: null);
+        var cardDecision = await AgentBuilderCardFlow.TryResolveAsync(cardInbound, userConfigQueryPort: null);
+
+        textDecision.Should().NotBeNull();
+        cardDecision.Should().NotBeNull();
+        textDecision!.RequiresToolExecution.Should().BeTrue();
+        cardDecision!.RequiresToolExecution.Should().BeTrue();
+        textDecision.ToolAction.Should().Be(cardDecision.ToolAction);
+        textDecision.ToolAction.Should().Be(expectedAction);
+
+        using var textBody = JsonDocument.Parse(textDecision.ToolArgumentsJson!);
+        using var cardBody = JsonDocument.Parse(cardDecision.ToolArgumentsJson!);
+        textBody.RootElement.GetProperty("action").GetString().Should().Be(expectedAction);
+        cardBody.RootElement.GetProperty("action").GetString().Should().Be(expectedAction);
+        if (agentId is not null)
+        {
+            textBody.RootElement.GetProperty("agent_id").GetString().Should().Be(agentId);
+            cardBody.RootElement.GetProperty("agent_id").GetString().Should().Be(agentId);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(KnownTextCommandCases))]
+    public async Task TryResolveAsync_AllKnownTextCommands_ArePrivateChatRestricted(
+        string textCommand,
+        string expectedToolAction,
+        string _)
+    {
+        var inbound = new ChannelInboundEvent
+        {
+            ChatType = "group",
+            Text = textCommand,
+        };
+
+        var decision = await AgentBuilderCardFlow.TryResolveAsync(inbound, userConfigQueryPort: null);
+
+        decision.Should().NotBeNull();
+        decision!.RequiresToolExecution.Should().BeFalse();
+        decision.ReplyPayload.Should().Contain("private chat");
+        decision.ReplyPayload.Should().Contain(textCommand.Split(' ')[0]);
+        expectedToolAction.Should().NotBeNull();
+    }
+
+    [Theory]
+    [MemberData(nameof(FormatterCases))]
+    public void FormatToolResult_KnownToolActions_UseRegisteredFormatter(string toolAction, string toolResultJson)
+    {
+        var decision = AgentBuilderFlowDecision.ToolCall(toolAction, JsonSerializer.Serialize(new
+        {
+            action = toolAction,
+        }));
+
+        var result = AgentBuilderCardFlow.FormatToolResult(decision, toolResultJson);
+
+        result.Text.Should().BeNullOrEmpty();
+        result.Cards.Should().NotBeEmpty();
+        result.Cards.Select(card => card.Text).Should().NotContain(text => text.Contains("\"config\""));
+    }
+
     [Fact]
     public void FormatToolResult_ListAgents_ReturnsStructuredCardNotJsonText()
     {
@@ -47,9 +245,6 @@ public sealed class AgentBuilderCardFlowTests
     [Fact]
     public void FormatToolResult_ListAgents_ReturnsSingleCardWithoutPerAgentButtons()
     {
-        // Refactor (iter9/cluster-1305-hybrid-minimal-delete):
-        // Old pattern: a retired relay builder flow had separate list rendering semantics.
-        // New principle: unified AgentBuilderCardFlow keeps the consolidated `/agents` card contract.
         var decision = AgentBuilderFlowDecision.ToolCall("list_agents", """{"action":"list_agents"}""");
         var result = AgentBuilderCardFlow.FormatToolResult(
             decision,


### PR DESCRIPTION
## 摘要

#347:make Day One command flow registry-driven —— first slice。

- **Old**:`AgentBuilderCardFlow` 内 text/card/tool/formatter 各有重复 OR 链与 switch,分支 drift。
- **New**:折叠为一个私有 `AgentBuilderCommandSpec` record 表(Dictionary lookup),删重复分支;保留 public static facade 兼容入口。

first slice only:不引入 Lark-local catalog/dispatcher、不做 runner DI 解耦(推迟 later slice)、不新增 public abstraction/DI、不改 proto。依据:#347 design-consensus r4 **3/3 unanimous**(structural,经 r1-r3+reflector re-design 收窄 first slice 后达成)。

范围:`AgentBuilderCardFlow.cs` + `AgentBuilderCardFlowTests.cs`(table parity 测试)。

Closes #347

🤖 Auto-loop / codex-refactor-loop
⟦AI:AUTO-LOOP⟧
