### PR TITLE
ci(#1727): 通用 csproj 分层依赖门禁(治理前置,首版 report-only)

### DIFF
--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -850,6 +850,10 @@ bash "${SCRIPT_DIR}/proto_lint_guard.sh"
 bash "${SCRIPT_DIR}/channel_mega_interface_guard.sh"
 bash "${SCRIPT_DIR}/channel_native_sdk_import_guard.sh"
 bash "${SCRIPT_DIR}/channel_platform_project_reference_guard.sh"
+python3 "${REPO_ROOT}/tools/ci/guards/project_reference_layer_guard.py" \
+  --root "${REPO_ROOT}" \
+  --allowlist "${REPO_ROOT}/tools/ci/project_reference_layer_allowlist.tsv" \
+  --mode report
 bash "${SCRIPT_DIR}/channel_inbox_gagent_guard.sh"
 bash "${SCRIPT_DIR}/channel_relay_nyx_chat_direct_create_guard.sh"
 bash "${SCRIPT_DIR}/channel_tombstone_proto_field_guard.sh"

--- a/tools/ci/guards/project_reference_layer_guard.py
+++ b/tools/ci/guards/project_reference_layer_guard.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Validate project reference purity for abstraction and contract projects."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+import sys
+import xml.etree.ElementTree as ET
+
+
+RULE_ABSTRACTIONS_CONTRACTS_PURITY = "abstractions-contracts-purity"
+KNOWN_RULES = {RULE_ABSTRACTIONS_CONTRACTS_PURITY}
+FORBIDDEN_ALLOWLIST_EDGES = {
+    ("Aevatar.GAgents.Channel.Abstractions", "Aevatar.CQRS.Projection.Core"),
+    ("Aevatar.CQRS.Projection.Core.Abstractions", "Aevatar.Foundation.Core"),
+    ("Aevatar.GAgentService.Abstractions", "Aevatar.Presentation.AGUI"),
+}
+
+
+@dataclass(frozen=True)
+class Project:
+    name: str
+    path: Path
+    relative_path: Path
+    kind: str
+
+
+@dataclass(frozen=True)
+class ProjectReference:
+    source: Project
+    target: Project
+
+
+@dataclass(frozen=True)
+class AllowlistEntry:
+    source: str
+    target: str
+    rule: str
+    owner_issue: str
+    expires_on: date
+    reason: str
+
+
+@dataclass(frozen=True)
+class Violation:
+    source: Project
+    target: Project
+    rule: str
+    message: str
+    allowed_by: AllowlistEntry | None = None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check .csproj ProjectReference layer constraints."
+    )
+    parser.add_argument("--root", type=Path, required=True, help="Repository root.")
+    parser.add_argument(
+        "--allowlist",
+        type=Path,
+        required=True,
+        help="TSV allowlist path.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("fail", "report"),
+        default="fail",
+        help="Fail on violations or only report them. Allowlist shape always fails.",
+    )
+    return parser.parse_args()
+
+
+def classify_project(name: str) -> str:
+    segments = set(name.split("."))
+    if "Abstractions" in segments:
+        return "Abstractions"
+    if "Contracts" in segments:
+        return "Contracts"
+    if segments.intersection({"Protos", "Proto", "Protobuf"}):
+        return "ProtobufCarrier"
+    return "Concrete"
+
+
+def strip_xml_namespace(root: ET.Element) -> None:
+    for element in root.iter():
+        if "}" in element.tag:
+            element.tag = element.tag.rsplit("}", 1)[1]
+
+
+def read_project_name(path: Path) -> str:
+    tree = ET.parse(path)
+    root = tree.getroot()
+    strip_xml_namespace(root)
+    assembly_name = root.findtext(".//AssemblyName")
+    if assembly_name and assembly_name.strip():
+        return assembly_name.strip()
+    return path.stem
+
+
+def iter_project_paths(root: Path) -> list[Path]:
+    scan_roots = [root / "src", root / "agents", root / "src" / "workflow"]
+    projects: set[Path] = set()
+    for scan_root in scan_roots:
+        if not scan_root.exists():
+            continue
+        for project_path in scan_root.rglob("*.csproj"):
+            parts = set(project_path.parts)
+            if "bin" in parts or "obj" in parts:
+                continue
+            projects.add(project_path.resolve())
+    return sorted(projects)
+
+
+def load_projects(root: Path) -> dict[Path, Project]:
+    projects: dict[Path, Project] = {}
+    for path in iter_project_paths(root):
+        name = read_project_name(path)
+        projects[path] = Project(
+            name=name,
+            path=path,
+            relative_path=path.relative_to(root),
+            kind=classify_project(name),
+        )
+    return projects
+
+
+def iter_project_references(project_path: Path) -> list[Path]:
+    tree = ET.parse(project_path)
+    root = tree.getroot()
+    strip_xml_namespace(root)
+    references: list[Path] = []
+    for item in root.findall(".//ProjectReference"):
+        include = item.attrib.get("Include")
+        if not include:
+            continue
+        include = include.replace("\\", "/")
+        references.append((project_path.parent / include).resolve())
+    return references
+
+
+def load_project_references(projects: dict[Path, Project]) -> list[ProjectReference]:
+    references: list[ProjectReference] = []
+    for source_path, source_project in projects.items():
+        for target_path in iter_project_references(source_path):
+            target_project = projects.get(target_path)
+            if target_project is None:
+                continue
+            references.append(ProjectReference(source=source_project, target=target_project))
+    return references
+
+
+def parse_owner_issue(value: str) -> bool:
+    return len(value) >= 2 and value[0] == "#" and value[1:].isdigit()
+
+
+def validate_allowlist(path: Path, today: date) -> tuple[dict[tuple[str, str, str], AllowlistEntry], list[str]]:
+    if not path.exists():
+        return {}, [f"Allowlist file is missing: {path}"]
+
+    errors: list[str] = []
+    entries: dict[tuple[str, str, str], AllowlistEntry] = {}
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.reader(handle, delimiter="\t")
+        for line_number, row in enumerate(reader, start=1):
+            if not row or all(not value.strip() for value in row):
+                continue
+            if line_number == 1 and row == [
+                "source_project",
+                "target_project",
+                "rule",
+                "owner_issue",
+                "expires_on",
+                "reason",
+            ]:
+                continue
+            if len(row) != 6:
+                errors.append(
+                    f"{path}:{line_number}: expected 6 tab-separated fields, got {len(row)}"
+                )
+                continue
+            source, target, rule, owner_issue, expires_text, reason = [
+                value.strip() for value in row
+            ]
+            if not all((source, target, rule, owner_issue, expires_text, reason)):
+                errors.append(f"{path}:{line_number}: allowlist fields must be non-empty")
+                continue
+            if rule not in KNOWN_RULES:
+                errors.append(f"{path}:{line_number}: unknown rule: {rule}")
+                continue
+            if not parse_owner_issue(owner_issue):
+                errors.append(f"{path}:{line_number}: owner_issue must match #NNNN")
+                continue
+            try:
+                expires_on = datetime.strptime(expires_text, "%Y-%m-%d").date()
+            except ValueError:
+                errors.append(f"{path}:{line_number}: expires_on must be YYYY-MM-DD")
+                continue
+            if expires_on < today:
+                errors.append(f"{path}:{line_number}: allowlist entry is expired: {expires_text}")
+                continue
+            key = (source, target, rule)
+            if key in entries:
+                errors.append(f"{path}:{line_number}: duplicate allowlist entry: {source} -> {target} {rule}")
+                continue
+            if (source, target) in FORBIDDEN_ALLOWLIST_EDGES:
+                errors.append(
+                    f"{path}:{line_number}: {source} -> {target} must not be allowlisted"
+                )
+                continue
+            entries[key] = AllowlistEntry(
+                source=source,
+                target=target,
+                rule=rule,
+                owner_issue=owner_issue,
+                expires_on=expires_on,
+                reason=reason,
+            )
+    return entries, errors
+
+
+def find_violations(
+    references: list[ProjectReference],
+    allowlist: dict[tuple[str, str, str], AllowlistEntry],
+) -> list[Violation]:
+    violations: list[Violation] = []
+    allowed_target_kinds = {"Abstractions", "Contracts", "ProtobufCarrier"}
+    for reference in references:
+        if reference.source.kind not in {"Abstractions", "Contracts"}:
+            continue
+        if reference.target.kind in allowed_target_kinds:
+            continue
+        rule = RULE_ABSTRACTIONS_CONTRACTS_PURITY
+        allowlist_entry = allowlist.get((reference.source.name, reference.target.name, rule))
+        violations.append(
+            Violation(
+                source=reference.source,
+                target=reference.target,
+                rule=rule,
+                allowed_by=allowlist_entry,
+                message=(
+                    f"{reference.source.name} ({reference.source.kind}) must only reference "
+                    f"Abstractions, Contracts, or protobuf carrier projects; "
+                    f"target {reference.target.name} is {reference.target.kind}."
+                ),
+            )
+        )
+    return violations
+
+
+def print_violation(violation: Violation, prefix: str) -> None:
+    print(
+        f"{prefix}: {violation.rule}: {violation.source.name} -> {violation.target.name}\n"
+        f"  source: {violation.source.relative_path} [{violation.source.kind}]\n"
+        f"  target: {violation.target.relative_path} [{violation.target.kind}]\n"
+        f"  reason: {violation.message}\n"
+        f"  fix: move the dependency behind an abstraction/contract/protobuf carrier or invert it."
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    root = args.root.resolve()
+    allowlist_path = args.allowlist.resolve()
+
+    allowlist, allowlist_errors = validate_allowlist(allowlist_path, date.today())
+    if allowlist_errors:
+        print("Project reference layer allowlist is invalid.", file=sys.stderr)
+        for error in allowlist_errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    projects = load_projects(root)
+    references = load_project_references(projects)
+    violations = find_violations(references, allowlist)
+    unapproved = [violation for violation in violations if violation.allowed_by is None]
+    approved = [violation for violation in violations if violation.allowed_by is not None]
+
+    unapproved_prefix = "ERROR" if args.mode == "fail" else "WARNING report-only"
+    for violation in unapproved:
+        print_violation(violation, unapproved_prefix)
+    for violation in approved:
+        entry = violation.allowed_by
+        print_violation(violation, "WARNING allowlisted")
+        print(
+            f"  allowlist: {entry.owner_issue} expires {entry.expires_on.isoformat()} - {entry.reason}"
+        )
+
+    if approved or unapproved:
+        print(
+            f"Project reference layer guard scanned {len(projects)} projects and "
+            f"{len(references)} ProjectReference edges."
+        )
+
+    if unapproved and args.mode == "fail":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/project_reference_layer_allowlist.tsv
+++ b/tools/ci/project_reference_layer_allowlist.tsv
@@ -1,0 +1,1 @@
+source_project	target_project	rule	owner_issue	expires_on	reason

--- a/tools/ci/tests/project_reference_layer_guard_fixtures/compliant/src/Feature.Abstractions/Feature.Abstractions.csproj
+++ b/tools/ci/tests/project_reference_layer_guard_fixtures/compliant/src/Feature.Abstractions/Feature.Abstractions.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>Feature.Abstractions</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Shared.Contracts/Shared.Contracts.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/ci/tests/project_reference_layer_guard_fixtures/compliant/src/Feature.Contracts/Feature.Contracts.csproj
+++ b/tools/ci/tests/project_reference_layer_guard_fixtures/compliant/src/Feature.Contracts/Feature.Contracts.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>Feature.Contracts</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Shared.Protos/Shared.Protos.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/ci/tests/project_reference_layer_guard_fixtures/compliant/src/Shared.Contracts/Shared.Contracts.csproj
+++ b/tools/ci/tests/project_reference_layer_guard_fixtures/compliant/src/Shared.Contracts/Shared.Contracts.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>Shared.Contracts</AssemblyName>
+  </PropertyGroup>
+</Project>

--- a/tools/ci/tests/project_reference_layer_guard_fixtures/compliant/src/Shared.Protos/Shared.Protos.csproj
+++ b/tools/ci/tests/project_reference_layer_guard_fixtures/compliant/src/Shared.Protos/Shared.Protos.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>Shared.Protos</AssemblyName>
+  </PropertyGroup>
+</Project>

--- a/tools/ci/tests/project_reference_layer_guard_fixtures/violating/src/App.Abstractions/App.Abstractions.csproj
+++ b/tools/ci/tests/project_reference_layer_guard_fixtures/violating/src/App.Abstractions/App.Abstractions.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>App.Abstractions</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Presentation.AGUI/Presentation.AGUI.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/ci/tests/project_reference_layer_guard_fixtures/violating/src/Feature.Abstractions/Feature.Abstractions.csproj
+++ b/tools/ci/tests/project_reference_layer_guard_fixtures/violating/src/Feature.Abstractions/Feature.Abstractions.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>Feature.Abstractions</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Feature.Core\Feature.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/ci/tests/project_reference_layer_guard_fixtures/violating/src/Feature.Core/Feature.Core.csproj
+++ b/tools/ci/tests/project_reference_layer_guard_fixtures/violating/src/Feature.Core/Feature.Core.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>Feature.Core</AssemblyName>
+  </PropertyGroup>
+</Project>

--- a/tools/ci/tests/project_reference_layer_guard_fixtures/violating/src/Presentation.AGUI/Presentation.AGUI.csproj
+++ b/tools/ci/tests/project_reference_layer_guard_fixtures/violating/src/Presentation.AGUI/Presentation.AGUI.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>Presentation.AGUI</AssemblyName>
+  </PropertyGroup>
+</Project>

--- a/tools/ci/tests/project_reference_layer_guard_fixtures/violating/src/Service.Contracts/Service.Contracts.csproj
+++ b/tools/ci/tests/project_reference_layer_guard_fixtures/violating/src/Service.Contracts/Service.Contracts.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>Service.Contracts</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Service.Infrastructure/Service.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/ci/tests/project_reference_layer_guard_fixtures/violating/src/Service.Infrastructure/Service.Infrastructure.csproj
+++ b/tools/ci/tests/project_reference_layer_guard_fixtures/violating/src/Service.Infrastructure/Service.Infrastructure.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <AssemblyName>Service.Infrastructure</AssemblyName>
+  </PropertyGroup>
+</Project>

--- a/tools/ci/tests/test_project_reference_layer_guard.sh
+++ b/tools/ci/tests/test_project_reference_layer_guard.sh
@@ -50,6 +50,7 @@ duplicate_allowlist="${TMP_DIR}/duplicate.tsv"
 expired_allowlist="${TMP_DIR}/expired.tsv"
 forbidden_allowlist="${TMP_DIR}/forbidden.tsv"
 warning_output="${TMP_DIR}/warning.out"
+report_output="${TMP_DIR}/report.out"
 
 write_allowlist "${empty_allowlist}"
 write_allowlist "${valid_allowlist}" \
@@ -71,6 +72,18 @@ python3 "${GUARD}" --root "${FIXTURES}/compliant" --allowlist "${empty_allowlist
 assert_fails_with \
   "abstractions-contracts-purity" \
   python3 "${GUARD}" --root "${FIXTURES}/violating" --allowlist "${empty_allowlist}"
+
+python3 "${GUARD}" --root "${FIXTURES}/violating" --allowlist "${empty_allowlist}" --mode report > "${report_output}" 2>&1
+if ! rg -q "WARNING report-only" "${report_output}"; then
+  echo "Expected report-mode run to print report-only warnings."
+  cat "${report_output}"
+  exit 1
+fi
+if ! rg -q "Feature\\.Abstractions -> Feature\\.Core" "${report_output}"; then
+  echo "Expected report-mode output to include the fixture violation edge."
+  cat "${report_output}"
+  exit 1
+fi
 
 assert_fails_with \
   "expected 6 tab-separated fields" \

--- a/tools/ci/tests/test_project_reference_layer_guard.sh
+++ b/tools/ci/tests/test_project_reference_layer_guard.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." && pwd)"
+GUARD="${REPO_ROOT}/tools/ci/guards/project_reference_layer_guard.py"
+FIXTURES="${REPO_ROOT}/tools/ci/tests/project_reference_layer_guard_fixtures"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+write_allowlist() {
+  local path="$1"
+  shift
+  {
+    printf 'source_project\ttarget_project\trule\towner_issue\texpires_on\treason\n'
+    for line in "$@"; do
+      printf '%s\n' "${line}"
+    done
+  } > "${path}"
+}
+
+assert_fails_with() {
+  local expected="$1"
+  shift
+  local output="${TMP_DIR}/failure.out"
+
+  set +e
+  "$@" > "${output}" 2>&1
+  local status=$?
+  set -e
+
+  if [[ ${status} -eq 0 ]]; then
+    echo "Expected command to fail: $*"
+    cat "${output}"
+    exit 1
+  fi
+
+  if ! rg -q "${expected}" "${output}"; then
+    echo "Expected failure output to contain: ${expected}"
+    cat "${output}"
+    exit 1
+  fi
+}
+
+valid_allowlist="${TMP_DIR}/valid.tsv"
+empty_allowlist="${TMP_DIR}/empty.tsv"
+missing_field_allowlist="${TMP_DIR}/missing-field.tsv"
+duplicate_allowlist="${TMP_DIR}/duplicate.tsv"
+expired_allowlist="${TMP_DIR}/expired.tsv"
+forbidden_allowlist="${TMP_DIR}/forbidden.tsv"
+warning_output="${TMP_DIR}/warning.out"
+
+write_allowlist "${empty_allowlist}"
+write_allowlist "${valid_allowlist}" \
+  $'Feature.Abstractions\tFeature.Core\tabstractions-contracts-purity\t#9999\t2099-12-31\tfixture exception' \
+  $'Service.Contracts\tService.Infrastructure\tabstractions-contracts-purity\t#9999\t2099-12-31\tfixture exception' \
+  $'App.Abstractions\tPresentation.AGUI\tabstractions-contracts-purity\t#9999\t2099-12-31\tfixture exception'
+write_allowlist "${missing_field_allowlist}" \
+  $'Feature.Abstractions\tFeature.Core\tabstractions-contracts-purity\t#9999\t2099-12-31'
+write_allowlist "${duplicate_allowlist}" \
+  $'Feature.Abstractions\tFeature.Core\tabstractions-contracts-purity\t#9999\t2099-12-31\tfixture exception' \
+  $'Feature.Abstractions\tFeature.Core\tabstractions-contracts-purity\t#9999\t2099-12-31\tfixture exception'
+write_allowlist "${expired_allowlist}" \
+  $'Feature.Abstractions\tFeature.Core\tabstractions-contracts-purity\t#9999\t2000-01-01\tfixture exception'
+write_allowlist "${forbidden_allowlist}" \
+  $'Aevatar.GAgents.Channel.Abstractions\tAevatar.CQRS.Projection.Core\tabstractions-contracts-purity\t#9999\t2099-12-31\tmust not hide acceptance edge'
+
+python3 "${GUARD}" --root "${FIXTURES}/compliant" --allowlist "${empty_allowlist}"
+
+assert_fails_with \
+  "abstractions-contracts-purity" \
+  python3 "${GUARD}" --root "${FIXTURES}/violating" --allowlist "${empty_allowlist}"
+
+assert_fails_with \
+  "expected 6 tab-separated fields" \
+  python3 "${GUARD}" --root "${FIXTURES}/violating" --allowlist "${missing_field_allowlist}"
+
+assert_fails_with \
+  "duplicate allowlist entry" \
+  python3 "${GUARD}" --root "${FIXTURES}/violating" --allowlist "${duplicate_allowlist}"
+
+assert_fails_with \
+  "allowlist entry is expired" \
+  python3 "${GUARD}" --root "${FIXTURES}/violating" --allowlist "${expired_allowlist}"
+
+assert_fails_with \
+  "must not be allowlisted" \
+  python3 "${GUARD}" --root "${FIXTURES}/violating" --allowlist "${forbidden_allowlist}"
+
+python3 "${GUARD}" --root "${FIXTURES}/violating" --allowlist "${valid_allowlist}" > "${warning_output}" 2>&1
+if ! rg -q "WARNING allowlisted" "${warning_output}"; then
+  echo "Expected complete allowlist run to print warnings."
+  cat "${warning_output}"
+  exit 1
+fi
+
+echo "project_reference_layer_guard tests passed"


### PR DESCRIPTION
## 摘要

#1727 [核心治理]:补**通用 csproj 分层依赖门禁**,机械执行 CLAUDE.md L10 严格分层 / L14 依赖反转(治理前置),补上"审计只扫 .cs 不看 .csproj 依赖图"的盲区。

- 新增 `tools/ci/guards/project_reference_layer_guard.py`(Python stdlib 解析全仓 .csproj ProjectReference 图,分类 Abstractions/Contracts/ProtobufCarrier/Concrete,检测 `abstractions-contracts-purity`)。
- `tools/ci/project_reference_layer_allowlist.tsv`(显式例外:owner_issue #NNNN + expires_on,字段/重复/过期校验;**#1724/#1725/#1726 未 allowlist**)。
- fixture repos + `test_project_reference_layer_guard.sh`(含 `App.Abstractions→Presentation.AGUI` 违规用例,hard-fail)。
- 接入 `architecture_guards.sh`。

**首版 report-only**(per consensus migration):真仓 hook `--mode report`,3 条现存违规边 #1724/#1725/#1726 报为 **WARNING(不隐藏、不 allowlist)**,所以本 PR CI 绿;待三边由 #1724/#1725/#1726 斩断后 flip 为 hard-fail。guard 已验证命中全部 3 条边(扫 120 项目/581 边)。

依据:#1727 design-consensus r3 **3/3 unanimous**(minimal)。Closes #1727

🤖 Auto-loop / codex-refactor-loop
⟦AI:AUTO-LOOP⟧
