### PR TITLE
fix(#110): 修复 YAML save/activate 路径校验绕过(写边界强制 parse+validate)

### DIFF
--- a/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
+++ b/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
@@ -1,6 +1,7 @@
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
 using Aevatar.Studio.Domain.Studio.Models;
+using Aevatar.Workflow.Application.Abstractions.Runs;
 using Microsoft.Extensions.Logging;
 
 using Aevatar.Studio.Application.Studio;
@@ -13,6 +14,7 @@ namespace Aevatar.Studio.Application;
 public sealed class AppScopedWorkflowService
 {
     private readonly IWorkflowYamlDocumentService _yamlDocumentService;
+    private readonly IWorkflowDefinitionParser _workflowDefinitionParser;
     private readonly IStudioWorkspaceQueryPort? _workspaceQueryPort;
     private readonly IStudioWorkspaceCommandPort? _workspaceCommandPort;
     private readonly IStudioMemberCommandPort? _memberCommandPort;
@@ -20,12 +22,14 @@ public sealed class AppScopedWorkflowService
 
     public AppScopedWorkflowService(
         IWorkflowYamlDocumentService yamlDocumentService,
+        IWorkflowDefinitionParser workflowDefinitionParser,
         IStudioWorkspaceQueryPort? workspaceQueryPort = null,
         IStudioWorkspaceCommandPort? workspaceCommandPort = null,
         IStudioMemberCommandPort? memberCommandPort = null,
         ILogger<AppScopedWorkflowService>? logger = null)
     {
         _yamlDocumentService = yamlDocumentService ?? throw new ArgumentNullException(nameof(yamlDocumentService));
+        _workflowDefinitionParser = workflowDefinitionParser ?? throw new ArgumentNullException(nameof(workflowDefinitionParser));
         _workspaceQueryPort = workspaceQueryPort;
         _workspaceCommandPort = workspaceCommandPort;
         _memberCommandPort = memberCommandPort;
@@ -91,6 +95,10 @@ public sealed class AppScopedWorkflowService
         {
             normalizedYaml = AlignWorkflowYamlName(normalizedYaml, requestedWorkflowName);
         }
+
+        var validation = await _workflowDefinitionParser.ParseWorkflowYamlAsync(normalizedYaml, ct);
+        if (!validation.Succeeded)
+            throw new InvalidOperationException(validation.Error);
 
         var parsed = _yamlDocumentService.Parse(normalizedYaml);
         var workflowName = !string.IsNullOrWhiteSpace(requestedWorkflowName)

--- a/src/Aevatar.Studio.Hosting/StudioHostingServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Hosting/StudioHostingServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using Aevatar.Studio.Hosting.NyxId;
 using Aevatar.Studio.Infrastructure.DependencyInjection;
 using Aevatar.Studio.Infrastructure.ScopeResolution; // DefaultAppScopeResolver
 using Aevatar.Studio.Projection.DependencyInjection;
+using Aevatar.Workflow.Application.Abstractions.Runs;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -52,6 +53,7 @@ internal static class StudioHostingServiceCollectionExtensions
     {
         services.AddSingleton(sp => new AppScopedWorkflowService(
             sp.GetRequiredService<IWorkflowYamlDocumentService>(),
+            sp.GetRequiredService<IWorkflowDefinitionParser>(),
             sp.GetService<IStudioWorkspaceQueryPort>(),
             sp.GetService<IStudioWorkspaceCommandPort>(),
             sp.GetService<IStudioMemberCommandPort>(),

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/WorkflowServiceImplementationAdapter.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/WorkflowServiceImplementationAdapter.cs
@@ -26,14 +26,18 @@ public sealed class WorkflowServiceImplementationAdapter : IServiceImplementatio
         if (string.IsNullOrWhiteSpace(spec.WorkflowYaml))
             throw new InvalidOperationException("workflow_yaml is required.");
 
-        var resolvedWorkflowName = spec.WorkflowName;
+        var parse = await _workflowDefinitionParser.ParseWorkflowYamlAsync(spec.WorkflowYaml, ct);
+        if (!parse.Succeeded)
+            throw new InvalidOperationException(parse.Error);
+
+        var resolvedWorkflowName = spec.WorkflowName?.Trim() ?? string.Empty;
         if (string.IsNullOrWhiteSpace(resolvedWorkflowName))
         {
-            var parse = await _workflowDefinitionParser.ParseWorkflowYamlAsync(spec.WorkflowYaml, ct);
-            if (!parse.Succeeded)
-                throw new InvalidOperationException(parse.Error);
-
             resolvedWorkflowName = parse.WorkflowName;
+        }
+        else if (!string.Equals(resolvedWorkflowName, parse.WorkflowName, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("workflow_name must match workflow_yaml name.");
         }
 
         return new PreparedServiceRevisionArtifact

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowRunPorts.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowRunPorts.cs
@@ -132,6 +132,9 @@ public interface IWorkflowRunProvisioningPort
 
 public interface IWorkflowDefinitionParser
 {
+    /// <summary>
+    /// Parses and validates workflow YAML, returning the validated workflow name declared by the YAML.
+    /// </summary>
     Task<WorkflowYamlParseResult> ParseWorkflowYamlAsync(
         string workflowYaml,
         CancellationToken ct = default);

--- a/test/Aevatar.GAgentService.Tests/Infrastructure/ServiceImplementationAdaptersTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Infrastructure/ServiceImplementationAdaptersTests.cs
@@ -548,9 +548,12 @@ public sealed class ServiceImplementationAdaptersTests
     }
 
     [Fact]
-    public async Task WorkflowAdapter_ShouldUseProvidedWorkflowNameWithoutParsing()
+    public async Task WorkflowAdapter_ShouldUseProvidedWorkflowNameAndStillParseAndValidate()
     {
-        var workflowPort = new RecordingWorkflowRunActorPort();
+        var workflowPort = new RecordingWorkflowRunActorPort
+        {
+            ParseResult = WorkflowYamlParseResult.Success("provided-workflow"),
+        };
         var adapter = new WorkflowServiceImplementationAdapter(workflowPort);
 
         var artifact = await adapter.PrepareRevisionAsync(new PrepareServiceRevisionRequest
@@ -572,7 +575,61 @@ public sealed class ServiceImplementationAdaptersTests
 
         artifact.DeploymentPlan.WorkflowPlan.WorkflowName.Should().Be("provided-workflow");
         artifact.DeploymentPlan.WorkflowPlan.InlineWorkflowYamls.Should().ContainKey("child.yaml");
-        workflowPort.ParseCalls.Should().BeEmpty();
+        workflowPort.ParseCalls.Should().ContainSingle("name: ignored");
+    }
+
+    [Fact]
+    public async Task WorkflowAdapter_ShouldRejectInvalidWorkflowYaml_WhenWorkflowNameProvided()
+    {
+        var adapter = new WorkflowServiceImplementationAdapter(new RecordingWorkflowRunActorPort
+        {
+            ParseResult = WorkflowYamlParseResult.Invalid("invalid yaml"),
+        });
+
+        var act = () => adapter.PrepareRevisionAsync(new PrepareServiceRevisionRequest
+        {
+            Spec = new ServiceRevisionSpec
+            {
+                Identity = GAgentServiceTestKit.CreateIdentity(),
+                RevisionId = "r1",
+                ImplementationKind = ServiceImplementationKind.Workflow,
+                WorkflowSpec = new WorkflowServiceRevisionSpec
+                {
+                    WorkflowName = "provided-workflow",
+                    WorkflowYaml = "invalid",
+                },
+            },
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("invalid yaml");
+    }
+
+    [Fact]
+    public async Task WorkflowAdapter_ShouldRejectWorkflowNameMismatch()
+    {
+        var adapter = new WorkflowServiceImplementationAdapter(new RecordingWorkflowRunActorPort
+        {
+            ParseResult = WorkflowYamlParseResult.Success("yaml-workflow"),
+        });
+
+        var act = () => adapter.PrepareRevisionAsync(new PrepareServiceRevisionRequest
+        {
+            Spec = new ServiceRevisionSpec
+            {
+                Identity = GAgentServiceTestKit.CreateIdentity(),
+                RevisionId = "r1",
+                ImplementationKind = ServiceImplementationKind.Workflow,
+                WorkflowSpec = new WorkflowServiceRevisionSpec
+                {
+                    WorkflowName = "provided-workflow",
+                    WorkflowYaml = "name: yaml-workflow",
+                },
+            },
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("workflow_name must match workflow_yaml name.");
     }
 
     [Fact]

--- a/test/Aevatar.Studio.Tests/AppScopedWorkflowServiceDeleteDraftTests.cs
+++ b/test/Aevatar.Studio.Tests/AppScopedWorkflowServiceDeleteDraftTests.cs
@@ -6,6 +6,7 @@ using Aevatar.Studio.Application.Studio.Contracts;
 using Aevatar.Studio.Application.Studio.Services;
 using Aevatar.Studio.Domain.Studio.Models;
 using Aevatar.Studio.Tests.Shared;
+using Aevatar.Workflow.Application.Abstractions.Runs;
 using FluentAssertions;
 
 namespace Aevatar.Studio.Tests;
@@ -311,6 +312,38 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
     }
 
     [Fact]
+    public async Task CreateDraftAsync_WhenWorkflowYamlInvalid_ShouldRejectBeforeWorkspaceSaveAndMemberAuthority()
+    {
+        using var environment = new ScopedWorkflowEnvironment();
+        var workflowDefinitionParser = new RecordingWorkflowDefinitionParser
+        {
+            Result = WorkflowYamlParseResult.Invalid("invalid yaml"),
+        };
+        var workspacePort = new RecordingStudioWorkspacePorts();
+        var memberCommandPort = new RecordingMemberCommandPort();
+        var service = environment.CreateService(
+            workflowDefinitionParser: workflowDefinitionParser,
+            workspaceQueryPort: workspacePort,
+            workspaceCommandPort: workspacePort,
+            memberCommandPort: memberCommandPort);
+
+        var act = () => service.CreateDraftAsync(
+            "scope-1",
+            new SaveWorkflowDraftRequest(
+                DirectoryId: "scope:scope-1",
+                WorkflowName: "workflow-1",
+                FileName: null,
+                Yaml: "name: workflow-1\nsteps: []\n"));
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("invalid yaml");
+        workflowDefinitionParser.ParseCalls.Should().ContainSingle("name: workflow-1\nsteps: []\n");
+        workspacePort.QueriedScopes.Should().BeEmpty();
+        workspacePort.SavedDrafts.Should().BeEmpty();
+        memberCommandPort.CreatedMembers.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task DeleteDraftAsync_WhenCancelled_ShouldPropagateOperationCanceledException()
     {
         using var environment = new ScopedWorkflowEnvironment();
@@ -340,12 +373,14 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
         public string HomeDirectory { get; }
 
         public AppScopedWorkflowService CreateService(
+            IWorkflowDefinitionParser? workflowDefinitionParser = null,
             IStudioWorkspaceQueryPort? workspaceQueryPort = null,
             IStudioWorkspaceCommandPort? workspaceCommandPort = null,
             IStudioMemberCommandPort? memberCommandPort = null)
         {
             return new AppScopedWorkflowService(
                 new StubWorkflowYamlDocumentService(),
+                workflowDefinitionParser ?? new RecordingWorkflowDefinitionParser(),
                 workspaceQueryPort,
                 workspaceCommandPort,
                 memberCommandPort);
@@ -394,6 +429,21 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
             }
 
             return null;
+        }
+    }
+
+    private sealed class RecordingWorkflowDefinitionParser : IWorkflowDefinitionParser
+    {
+        public WorkflowYamlParseResult Result { get; init; } = WorkflowYamlParseResult.Success("workflow");
+
+        public List<string> ParseCalls { get; } = [];
+
+        public Task<WorkflowYamlParseResult> ParseWorkflowYamlAsync(
+            string workflowYaml,
+            CancellationToken ct = default)
+        {
+            ParseCalls.Add(workflowYaml);
+            return Task.FromResult(Result);
         }
     }
 

--- a/test/Shared/RecordingStudioWorkspacePorts.cs
+++ b/test/Shared/RecordingStudioWorkspacePorts.cs
@@ -33,6 +33,8 @@ internal sealed class RecordingStudioWorkspacePorts : IStudioWorkspaceQueryPort,
 
     public List<ScopedWorkflowDelete> DeletedDrafts { get; } = [];
 
+    public List<string> QueriedScopes { get; } = [];
+
     public ScopedWorkflowUpload? LastUpload => SavedDrafts.LastOrDefault();
 
     public IReadOnlyList<ScopedWorkflowUpload> SavedWorkflows => SavedDrafts;
@@ -45,6 +47,7 @@ internal sealed class RecordingStudioWorkspacePorts : IStudioWorkspaceQueryPort,
     public Task<StudioWorkspaceSnapshot> GetAsync(string scopeId, CancellationToken ct = default)
     {
         var normalizedScopeId = NormalizeScopeId(scopeId);
+        QueriedScopes.Add(normalizedScopeId);
         _drafts.TryGetValue(normalizedScopeId, out var scopeDrafts);
         return Task.FromResult(new StudioWorkspaceSnapshot(
             $"studio-workspace:{normalizedScopeId}",


### PR DESCRIPTION
## 修复 YAML save-path validation bypass(#110)

修真 bug:工作流保存(`SaveDraftAsync`)与预设名激活(`PrepareRevisionAsync`)路径跳过 `WorkflowValidator`,invalid workflow 静默落盘+激活,仅 run-start 才报错。

按 design-consensus r5(3/3 structural,无新抽象):
- `WorkflowServiceImplementationAdapter.PrepareRevisionAsync`:**总是** parse+validate(无论是否提供 WorkflowName);失败 throw;名称与 YAML name 不一致 throw `"workflow_name must match workflow_yaml name."`。
- `AppScopedWorkflowService`:写边界(workspace save/member authority 前)强制 parse+validate。
- 测试:invalid YAML 拒绝、name-mismatch 拒绝、save 前拒绝。

解 #111 前置阻塞。本地 build + 全量测试通过。

Closes #110

⟦AI:AUTO-LOOP⟧
