### PR TITLE
ci(#1727): flip 分层 guard report-only→hard-fail(治理闭环)

### DIFF
--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -853,7 +853,7 @@ bash "${SCRIPT_DIR}/channel_platform_project_reference_guard.sh"
 python3 "${REPO_ROOT}/tools/ci/guards/project_reference_layer_guard.py" \
   --root "${REPO_ROOT}" \
   --allowlist "${REPO_ROOT}/tools/ci/project_reference_layer_allowlist.tsv" \
-  --mode report
+  --mode fail
 bash "${SCRIPT_DIR}/channel_inbox_gagent_guard.sh"
 bash "${SCRIPT_DIR}/channel_relay_nyx_chat_direct_create_guard.sh"
 bash "${SCRIPT_DIR}/channel_tombstone_proto_field_guard.sh"

--- a/tools/ci/test_stability_guards.sh
+++ b/tools/ci/test_stability_guards.sh
@@ -8,6 +8,11 @@ cd "${REPO_ROOT}"
 
 allowlist_file="tools/ci/test_polling_allowlist.txt"
 
+run_guard_meta_tests() {
+  bash "${SCRIPT_DIR}/tests/test_project_reference_layer_guard.sh"
+  bash "${SCRIPT_DIR}/tests/test_architecture_guards_enforces_layer_guard.sh"
+}
+
 if [[ ! -f "${allowlist_file}" ]]; then
   echo "Missing allowlist: ${allowlist_file}"
   exit 1
@@ -16,6 +21,7 @@ fi
 hits="$(rg -n "Task\\.Delay\\(|WaitUntilAsync\\(" test -g '*.cs' || true)"
 if [[ -z "${hits}" ]]; then
   echo "No polling waits found in tests."
+  run_guard_meta_tests
   exit 0
 fi
 
@@ -37,3 +43,4 @@ if [[ -n "${disallowed}" ]]; then
 fi
 
 echo "Test stability guard passed (polling waits constrained by allowlist)."
+run_guard_meta_tests

--- a/tools/ci/tests/test_architecture_guards_enforces_layer_guard.sh
+++ b/tools/ci/tests/test_architecture_guards_enforces_layer_guard.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." && pwd)"
+ARCHITECTURE_GUARDS="${REPO_ROOT}/tools/ci/architecture_guards.sh"
+
+call_block="$(
+  awk '
+    /project_reference_layer_guard\.py/ { capture = 1 }
+    capture {
+      print
+      if ($0 !~ /\\[[:space:]]*$/) {
+        exit
+      }
+    }
+  ' "${ARCHITECTURE_GUARDS}"
+)"
+
+if [[ -z "${call_block}" ]]; then
+  echo "Expected architecture_guards.sh to invoke project_reference_layer_guard.py."
+  exit 1
+fi
+
+if ! printf '%s\n' "${call_block}" | rg -q -- '--mode[[:space:]]+fail'; then
+  echo "Expected project_reference_layer_guard.py invocation to use --mode fail."
+  printf '%s\n' "${call_block}"
+  exit 1
+fi
+
+if printf '%s\n' "${call_block}" | rg -q -- '--mode[[:space:]]+report'; then
+  echo "project_reference_layer_guard.py invocation must not use --mode report."
+  printf '%s\n' "${call_block}"
+  exit 1
+fi
+
+echo "architecture_guards layer guard enforcement test passed"


### PR DESCRIPTION
## flip 分层 guard report-only → hard-fail(#1727 治理闭环收尾)

`#1727` 通用 csproj 分层依赖门禁(`project_reference_layer_guard.py`)自落地起为 report-only,等三条反向依赖边修复。现三边全部修复并进 dev:
- #1724 `GAgentService.Abstractions → Presentation.AGUI`(AGUI 合同下沉 Aevatar.AGUI.Contracts)
- #1725 `Channel.Abstractions → CQRS.Projection.Core`(CommittedStateEventEnvelope 下沉)
- #1726 `Projection.Core.Abstractions → Foundation.Core`(committed-state publication contract 下沉)
- 配套 #1745(namespace 纯化)+ #1732(删 Presentation.AGUI 项目)

已验证 `--mode fail` 在 auto-refact-dev EXIT=0(零违规,allowlist 空)。本 PR 把调用从 `--mode report` 改为 `--mode fail`,分层反向依赖违规自此 **CI 硬拦截**。

`channel_platform_project_reference_guard.sh` **保留**(经评估:通用 guard 未覆盖 concrete channel → src/platform 直接引用这一特定边,不冗余)。

关联 #1727 #1399。本地 architecture_guards.sh PASS。

⟦AI:AUTO-LOOP⟧
