### PR TITLE
feat(skill): 跨客户端 ::name 显式 skill 触发 ingress (#1762)

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -1639,15 +1639,7 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
 
         if (trigger.IsDiscovery)
         {
-            context = new AgentSkillRecoveryContext(
-                RequireInitialOrnnSearch: true,
-                RequireOrnnSearchOnBlocker: false,
-                CommandName: null,
-                OriginalCommand: trigger.OriginalText,
-                PrimarySkillName: null,
-                MaxOrnnSearchAttempts: 1,
-                CommandArguments: null,
-                DiscoveryRequested: true);
+            context = AgentSkillRecoveryContextBuilder.FromTrigger(trigger);
             return true;
         }
 
@@ -1662,15 +1654,11 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
             return false;
         }
 
-        context = new AgentSkillRecoveryContext(
-            RequireInitialOrnnSearch: true,
-            RequireOrnnSearchOnBlocker: true,
-            CommandName: normalizedCommand,
-            OriginalCommand: trigger.OriginalText,
-            PrimarySkillName: normalizedCommand,
-            MaxOrnnSearchAttempts: 2,
-            CommandArguments: trigger.Arguments,
-            DiscoveryRequested: false);
+        context = AgentSkillRecoveryContextBuilder.FromTrigger(trigger) with
+        {
+            CommandName = normalizedCommand,
+            PrimarySkillName = normalizedCommand,
+        };
         return true;
     }
 

--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -1,6 +1,7 @@
 using System.Net.Http;
 using System.Text.Json;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.SkillInvocations;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.Core.LLMProviders;
 using Aevatar.AI.ToolProviders.NyxId;
@@ -1560,6 +1561,7 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         var requestActivity = BuildLlmRequestActivity(
             activity,
             inboundEvent.Text,
+            inboundEvent.Platform,
             _identityBindingQueryPort is null || senderBinding is not null);
         var request = new NeedsLlmReplyEvent
         {
@@ -1587,7 +1589,7 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         foreach (var pair in await BuildReplyMetadataAsync(inboundEvent, activity, ct))
             request.Metadata[pair.Key] = pair.Value;
 
-        if (TryBuildSkillRecoveryContext(inboundEvent.Text, out var skillRecovery))
+        if (TryBuildSkillRecoveryContext(inboundEvent.Text, inboundEvent.Platform, out var skillRecovery))
         {
             request.ToolContext = (AgentToolExecutionContextMapper.FromPayload(request.ToolContext) with
             {
@@ -1629,18 +1631,33 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         return request;
     }
 
-    private bool TryBuildSkillRecoveryContext(string? text, out AgentSkillRecoveryContext context)
+    private bool TryBuildSkillRecoveryContext(string? text, string? platform, out AgentSkillRecoveryContext context)
     {
         context = AgentSkillRecoveryContext.Empty;
-        if (!TryParseSlashCommand(text, out var commandName, out _))
+        if (!SkillInvocationTriggerParser.TryParse(text, platform, out var trigger))
             return false;
 
-        var normalizedCommand = commandName.Trim().TrimStart('/');
+        if (trigger.IsDiscovery)
+        {
+            context = new AgentSkillRecoveryContext(
+                RequireInitialOrnnSearch: true,
+                RequireOrnnSearchOnBlocker: false,
+                CommandName: null,
+                OriginalCommand: trigger.OriginalText,
+                PrimarySkillName: null,
+                MaxOrnnSearchAttempts: 1,
+                CommandArguments: null,
+                DiscoveryRequested: true);
+            return true;
+        }
+
+        var normalizedCommand = trigger.Name?.Trim();
         if (string.IsNullOrWhiteSpace(normalizedCommand))
             return false;
 
-        if (LocalSlashCommands.Contains(normalizedCommand) ||
-            ResolveSlashCommandHandler(normalizedCommand) is not null)
+        if (trigger.TriggerToken == "/" &&
+            (LocalSlashCommands.Contains(normalizedCommand) ||
+             ResolveSlashCommandHandler(normalizedCommand) is not null))
         {
             return false;
         }
@@ -1649,9 +1666,11 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
             RequireInitialOrnnSearch: true,
             RequireOrnnSearchOnBlocker: true,
             CommandName: normalizedCommand,
-            OriginalCommand: (text ?? string.Empty).Trim(),
-            PrimarySkillName: null,
-            MaxOrnnSearchAttempts: 2);
+            OriginalCommand: trigger.OriginalText,
+            PrimarySkillName: normalizedCommand,
+            MaxOrnnSearchAttempts: 2,
+            CommandArguments: trigger.Arguments,
+            DiscoveryRequested: false);
         return true;
     }
 
@@ -1675,40 +1694,45 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
     // slash silently consumed.
     // New: unbound sender disables tool dispatch; unknown slash gates to /init bootstrap;
     // non-slash text path unchanged (owner-LLM chat fallback).
-    private ChatActivity BuildLlmRequestActivity(ChatActivity activity, string? inboundText, bool allowSkillInvocationPrompt)
+    private ChatActivity BuildLlmRequestActivity(
+        ChatActivity activity,
+        string? inboundText,
+        string? platform,
+        bool allowSkillInvocationPrompt)
     {
         var requestActivity = activity.Clone();
         if (requestActivity.Content is null)
             return requestActivity;
 
-        if (allowSkillInvocationPrompt && TryBuildSkillInvocationPrompt(inboundText, out var prompt))
+        if (allowSkillInvocationPrompt && TryBuildSkillInvocationPrompt(inboundText, platform, out var prompt))
             requestActivity.Content.Text = prompt;
 
         return requestActivity;
     }
 
-    private bool TryBuildSkillInvocationPrompt(string? text, out string prompt)
+    private bool TryBuildSkillInvocationPrompt(string? text, string? platform, out string prompt)
     {
         prompt = string.Empty;
-        if (!TryParseSlashCommand(text, out var commandName, out var argumentText))
+        if (!SkillInvocationTriggerParser.TryParse(text, platform, out var trigger) ||
+            trigger.IsDiscovery)
         {
             return false;
         }
 
         // Refactor (iter1/cluster-issue1553): Old pattern: hardcoded /daily skill name. New principle: generic skill discovery, no skill-name in routing logic.
-        return TryBuildSlashSkillDiscoveryPrompt(text, commandName, argumentText, out prompt);
+        return TryBuildSlashSkillDiscoveryPrompt(trigger, out prompt);
     }
 
     private bool TryBuildSlashSkillDiscoveryPrompt(
-        string? text,
-        string commandName,
-        string argumentText,
+        SkillInvocationTrigger trigger,
         out string prompt)
     {
         prompt = string.Empty;
+        var commandName = trigger.Name ?? string.Empty;
         if (string.IsNullOrWhiteSpace(commandName) ||
-            LocalSlashCommands.Contains(commandName) ||
-            ResolveSlashCommandHandler(commandName) is not null)
+            (trigger.TriggerToken == "/" &&
+             (LocalSlashCommands.Contains(commandName) ||
+              ResolveSlashCommandHandler(commandName) is not null)))
         {
             return false;
         }
@@ -1718,13 +1742,13 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         if (string.IsNullOrWhiteSpace(skillQuery))
             return false;
 
-        var queryJson = JsonSerializer.Serialize(skillQuery);
-        var argsJson = JsonSerializer.Serialize(argumentText);
-        var originalJson = JsonSerializer.Serialize((text ?? string.Empty).Trim());
+        var argsJson = JsonSerializer.Serialize(trigger.Arguments);
+        var originalJson = JsonSerializer.Serialize(trigger.OriginalText);
+        var triggerLabel = trigger.TriggerToken == "/" ? "/" : trigger.TriggerToken;
         prompt =
-            $"The user invoked the Lark `/{normalizedCommand}` shortcut.\n" +
-            "This slash command is not handled by Aevatar's local relay commands. Treat it as an Ornn skill-backed command, not an open-ended chat answer.\n" +
-            $"Aevatar has already executed `ornn_search_skills` (query = {queryJson}) and `use_skill` for the best matching skill before this turn (their tool results are in the messages above); the loaded skill's instructions are the only source of truth for this command.\n" +
+            $"The user invoked the `{triggerLabel}{normalizedCommand}` skill trigger.\n" +
+            "This command is not handled by Aevatar's local relay commands. Treat it as an Ornn skill-backed command, not an open-ended chat answer.\n" +
+            "Aevatar has already attempted `use_skill` for this command before this turn. If that load failed, use the tool results above and the recovery rules to search for the best matching skill before giving up.\n" +
             $"Follow those skill instructions exactly, with `args` = {argsJson}, until the command's final result is ready.\n" +
             "Stick to the data sources the loaded skill names. Do NOT invent repository/path guesses, do NOT call `/api/v1/skills/.../files` (skill files are already inlined in the `use_skill` response above), and do NOT fall back to generic `nyxid_proxy` discovery when the loaded skill did not point you there.\n" +
             "If no matching skill was actually loaded above, or every matching skill fails to load, give one concise actionable failure that names the command and the Ornn lookup/load problem.\n" +

--- a/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
@@ -449,16 +449,21 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
     private static string? BuildSkillRecoveryStreamingStatus(AgentToolExecutionContext? toolContext)
     {
         var recovery = toolContext?.SkillRecovery;
-        if (recovery is not { RequireInitialOrnnSearch: true } ||
-            string.IsNullOrWhiteSpace(recovery.CommandName))
+        if (recovery is not { RequireInitialOrnnSearch: true })
         {
             return null;
         }
 
-        var commandLabel = recovery.CommandName.Trim().TrimStart('/');
+        if (recovery.DiscoveryRequested)
+            return "正在查找可用技能...";
+
+        var commandLabel = recovery.OriginalCommand?.Trim();
+        if (string.IsNullOrWhiteSpace(commandLabel))
+            commandLabel = recovery.CommandName?.Trim();
+
         return string.IsNullOrWhiteSpace(commandLabel)
             ? null
-            : $"正在处理 `/{commandLabel}`, 加载技能并扫描数据中...";
+            : $"正在处理 `{commandLabel}`, 加载技能并扫描数据中...";
     }
 
     // ADR-0021 §6 / canon §8 cross-round usage aggregation — each provider round

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatInteraction.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatInteraction.cs
@@ -307,44 +307,18 @@ internal sealed class NyxIdChatCommandEnvelopeFactory : ICommandEnvelopeFactory<
 
     private static AgentToolExecutionContext BuildToolContext(NyxIdChatCommand command, LLMControlContext effectiveControl)
     {
+        var skillRecovery = SkillInvocationTriggerParser.TryParse(command.Prompt, platform: "cli", out var trigger)
+            ? AgentSkillRecoveryContextBuilder.FromTrigger(trigger)
+            : AgentSkillRecoveryContext.Empty;
         var toolContext = AgentToolExecutionContext.Empty with
         {
             Request = new AgentToolRequestIdentity(command.SessionId, null),
             Credentials = new AgentToolCredentials(command.AccessToken, null, null),
             Caller = new AgentToolCallerContext(command.ScopeId, command.ScopeId, command.SessionId),
             Channel = new AgentToolChannelContext("nyxid-chat", null, command.ScopeId, null, null),
-            SkillRecovery = BuildSkillRecoveryContext(command.Prompt),
+            SkillRecovery = skillRecovery,
         };
         return effectiveControl.ToToolContext(toolContext);
-    }
-
-    private static AgentSkillRecoveryContext BuildSkillRecoveryContext(string? prompt)
-    {
-        if (!SkillInvocationTriggerParser.TryParse(prompt, platform: "cli", out var trigger))
-            return AgentSkillRecoveryContext.Empty;
-
-        if (trigger.IsDiscovery)
-        {
-            return new AgentSkillRecoveryContext(
-                RequireInitialOrnnSearch: true,
-                RequireOrnnSearchOnBlocker: false,
-                CommandName: null,
-                OriginalCommand: trigger.OriginalText,
-                PrimarySkillName: null,
-                MaxOrnnSearchAttempts: 1,
-                CommandArguments: null,
-                DiscoveryRequested: true);
-        }
-
-        return new AgentSkillRecoveryContext(
-            RequireInitialOrnnSearch: true,
-            RequireOrnnSearchOnBlocker: true,
-            CommandName: trigger.Name,
-            OriginalCommand: trigger.OriginalText,
-            PrimarySkillName: trigger.Name,
-            MaxOrnnSearchAttempts: 2,
-            CommandArguments: trigger.Arguments,
-            DiscoveryRequested: false);
     }
 
     private static void AppendMetadata(

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatInteraction.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatInteraction.cs
@@ -1,6 +1,8 @@
 using System.Runtime.ExceptionServices;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.SkillInvocations;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
@@ -290,15 +292,59 @@ internal sealed class NyxIdChatCommandEnvelopeFactory : ICommandEnvelopeFactory<
         }
 
         var control = command.LlmControl ?? LLMControlContext.Empty;
-        chatRequest.LlmControl = (control with
+        var effectiveControl = control with
         {
             NyxIdAccessToken = string.IsNullOrWhiteSpace(command.AccessToken)
                 ? control.NyxIdAccessToken
                 : command.AccessToken.Trim(),
-        }).ToPayload();
+        };
+        chatRequest.LlmControl = effectiveControl.ToPayload();
         AppendMetadata(chatRequest.Metadata, command.Metadata);
+        chatRequest.ToolContext = BuildToolContext(command, effectiveControl).ToPayload();
 
         return CreateDirectEnvelope(context, chatRequest);
+    }
+
+    private static AgentToolExecutionContext BuildToolContext(NyxIdChatCommand command, LLMControlContext effectiveControl)
+    {
+        var toolContext = AgentToolExecutionContext.Empty with
+        {
+            Request = new AgentToolRequestIdentity(command.SessionId, null),
+            Credentials = new AgentToolCredentials(command.AccessToken, null, null),
+            Caller = new AgentToolCallerContext(command.ScopeId, command.ScopeId, command.SessionId),
+            Channel = new AgentToolChannelContext("nyxid-chat", null, command.ScopeId, null, null),
+            SkillRecovery = BuildSkillRecoveryContext(command.Prompt),
+        };
+        return effectiveControl.ToToolContext(toolContext);
+    }
+
+    private static AgentSkillRecoveryContext BuildSkillRecoveryContext(string? prompt)
+    {
+        if (!SkillInvocationTriggerParser.TryParse(prompt, platform: "cli", out var trigger))
+            return AgentSkillRecoveryContext.Empty;
+
+        if (trigger.IsDiscovery)
+        {
+            return new AgentSkillRecoveryContext(
+                RequireInitialOrnnSearch: true,
+                RequireOrnnSearchOnBlocker: false,
+                CommandName: null,
+                OriginalCommand: trigger.OriginalText,
+                PrimarySkillName: null,
+                MaxOrnnSearchAttempts: 1,
+                CommandArguments: null,
+                DiscoveryRequested: true);
+        }
+
+        return new AgentSkillRecoveryContext(
+            RequireInitialOrnnSearch: true,
+            RequireOrnnSearchOnBlocker: true,
+            CommandName: trigger.Name,
+            OriginalCommand: trigger.OriginalText,
+            PrimarySkillName: trigger.Name,
+            MaxOrnnSearchAttempts: 2,
+            CommandArguments: trigger.Arguments,
+            DiscoveryRequested: false);
     }
 
     private static void AppendMetadata(

--- a/docs/canon/nyxid-responses-direct.md
+++ b/docs/canon/nyxid-responses-direct.md
@@ -142,7 +142,31 @@ llm-anthropic/claude-haiku-4-5
 
 chat-route policy 指定 `tool_set_ref` 或 `tool_choice_hint` 时，三条直连入口都会使用同一个 direct tool plan：同一个 tool set 会被注入，同一个 trusted prefilled arguments 合并规则会生效。不要为 `/v1/messages` 或 `/v1/chat/completions` 另建工具白名单。
 
-## 6. Messages 门面
+## 6. 显式 Skill 触发
+
+直连入口支持同一套显式 skill 触发语法：
+
+```text
+::skill-name optional arguments
+```
+
+触发只能出现在输入开头，或后续某一行的行首；句中普通文本例如 `please run ::skill` 不会触发。`skill-name` 会归一化为小写 route token，后面的文本原样作为 `command_arguments` 进入 skill recovery context。三条 `/v1/responses`、`/v1/messages`、`/v1/chat/completions` 入口只在 Application 层解析一次：`CommandName` 只给 chat-route policy 做命令匹配，arguments 和 discovery 只进入 `AgentSkillRecoveryContext`。
+
+裸 `::` 表示请求 skill discovery。它不会伪造 route command 或 skill 名称，chat-route `CommandName` 为空，skill recovery 会触发 `ornn_search_skills`。`:: ` 这类只有触发符和空白的输入按普通文本处理。
+
+Channel relay 入口也使用同一 parser。默认平台别名为：
+
+| 平台 | 触发符 |
+|---|---|
+| CLI / direct `/v1/*` / direct `nyxid-chat` | `::` |
+| Lark / Web channel | `::`、`/` |
+| 其它 channel | `::` |
+
+`/name` 只是在 Lark/Web channel 上保留的兼容别名，且本地注册 slash command（如 `/init`、`/model`）仍优先走本地确定性处理。canonical `::name` 不会被这些本地 slash command 吞掉；例如 `::model args` 表示名为 `model` 的 skill 触发，而不是 `/model` 本地模型配置命令。
+
+命名触发会优先调用 `use_skill` 加载同名 skill；如果加载失败或后续出现 blocker，再按 recovery 规则使用 `ornn_search_skills` 查找更合适的 skill。`use_skill` 与 `ornn_search_skills` 仍然使用当前调用者的 NyxID/Ornn 可见性，和普通工具调用一致。
+
+## 7. Messages 门面
 
 `POST /v1/messages` 已经上线，但它不是 `/v1/responses` 的完整替代品。它的定位是让只会说 Anthropic Messages 的客户端，例如 Claude Code，能通过同一条 NyxID proxy 链路访问 Aevatar。
 
@@ -164,7 +188,7 @@ chat-route policy 指定 `tool_set_ref` 或 `tool_choice_hint` 时，三条直�
 
 需要完整异步编排和 continuation 时，用 `/v1/responses`。
 
-## 7. Chat Completions 门面
+## 8. Chat Completions 门面
 
 `POST /v1/chat/completions` 是 OpenAI Chat Completions 兼容窄门面，适合只支持 `OPENAI_BASE_URL` + `/chat/completions` 的客户端通过 NyxID proxy 直连 Aevatar。
 
@@ -185,7 +209,7 @@ chat-route policy 指定 `tool_set_ref` 或 `tool_choice_hint` 时，三条直�
 
 需要完整异步编排和 continuation 时，用 `/v1/responses`。
 
-## 8. API Key 要求
+## 9. API Key 要求
 
 NyxID slug proxy 路由是 REST proxy plane：
 
@@ -197,7 +221,7 @@ NyxID slug proxy 路由是 REST proxy plane：
 
 `--allowed-services` 必须填 `nyxid service list --output json` 里的 UserService id，不是 catalog id。填错时常见错误是 `api_key_scope_forbidden_legacy`。
 
-## 9. 代码锚点
+## 10. 代码锚点
 
 主机端入口：
 

--- a/src/Aevatar.AI.Abstractions/SkillInvocations/AgentSkillRecoveryContextBuilder.cs
+++ b/src/Aevatar.AI.Abstractions/SkillInvocations/AgentSkillRecoveryContextBuilder.cs
@@ -1,0 +1,35 @@
+using Aevatar.AI.Abstractions.ToolProviders;
+
+namespace Aevatar.AI.Abstractions.SkillInvocations;
+
+public static class AgentSkillRecoveryContextBuilder
+{
+    public static AgentSkillRecoveryContext FromTrigger(SkillInvocationTrigger? trigger)
+    {
+        if (trigger is null)
+            return AgentSkillRecoveryContext.Empty;
+
+        if (trigger.IsDiscovery)
+        {
+            return new AgentSkillRecoveryContext(
+                RequireInitialOrnnSearch: true,
+                RequireOrnnSearchOnBlocker: false,
+                CommandName: null,
+                OriginalCommand: trigger.OriginalText,
+                PrimarySkillName: null,
+                MaxOrnnSearchAttempts: 1,
+                CommandArguments: null,
+                DiscoveryRequested: true);
+        }
+
+        return new AgentSkillRecoveryContext(
+            RequireInitialOrnnSearch: true,
+            RequireOrnnSearchOnBlocker: true,
+            CommandName: trigger.Name,
+            OriginalCommand: trigger.OriginalText,
+            PrimarySkillName: trigger.Name,
+            MaxOrnnSearchAttempts: 2,
+            CommandArguments: trigger.Arguments,
+            DiscoveryRequested: false);
+    }
+}

--- a/src/Aevatar.AI.Abstractions/SkillInvocations/SkillInvocationTrigger.cs
+++ b/src/Aevatar.AI.Abstractions/SkillInvocations/SkillInvocationTrigger.cs
@@ -1,0 +1,9 @@
+namespace Aevatar.AI.Abstractions.SkillInvocations;
+
+public sealed record SkillInvocationTrigger(
+    string? Name,
+    string Arguments,
+    bool IsDiscovery,
+    string OriginalText,
+    string TriggerToken,
+    string Platform);

--- a/src/Aevatar.AI.Abstractions/SkillInvocations/SkillInvocationTriggerOptions.cs
+++ b/src/Aevatar.AI.Abstractions/SkillInvocations/SkillInvocationTriggerOptions.cs
@@ -1,0 +1,45 @@
+namespace Aevatar.AI.Abstractions.SkillInvocations;
+
+public sealed class SkillInvocationTriggerOptions
+{
+    public const string CanonicalTriggerToken = "::";
+
+    private readonly Dictionary<string, string[]> _tokensByPlatform = new(StringComparer.OrdinalIgnoreCase);
+
+    public SkillInvocationTriggerOptions()
+    {
+        SetPlatformTokens("default", [CanonicalTriggerToken]);
+        SetPlatformTokens("lark", [CanonicalTriggerToken, "/"]);
+        SetPlatformTokens("web", [CanonicalTriggerToken, "/"]);
+        SetPlatformTokens("cli", [CanonicalTriggerToken]);
+    }
+
+    public IReadOnlyList<string> GetTokens(string? platform)
+    {
+        if (!string.IsNullOrWhiteSpace(platform) &&
+            _tokensByPlatform.TryGetValue(platform.Trim(), out var platformTokens))
+        {
+            return platformTokens;
+        }
+
+        return _tokensByPlatform["default"];
+    }
+
+    public void SetPlatformTokens(string platform, IEnumerable<string> tokens)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(platform);
+        ArgumentNullException.ThrowIfNull(tokens);
+
+        var normalized = tokens
+            .Select(static token => token.Trim())
+            .Where(static token => !string.IsNullOrWhiteSpace(token))
+            .Distinct(StringComparer.Ordinal)
+            .OrderByDescending(static token => token.Length)
+            .ThenBy(static token => token, StringComparer.Ordinal)
+            .ToArray();
+
+        _tokensByPlatform[platform.Trim()] = normalized.Length == 0
+            ? [CanonicalTriggerToken]
+            : normalized;
+    }
+}

--- a/src/Aevatar.AI.Abstractions/SkillInvocations/SkillInvocationTriggerParser.cs
+++ b/src/Aevatar.AI.Abstractions/SkillInvocations/SkillInvocationTriggerParser.cs
@@ -1,0 +1,114 @@
+namespace Aevatar.AI.Abstractions.SkillInvocations;
+
+public static class SkillInvocationTriggerParser
+{
+    public static bool TryParse(
+        string? text,
+        string? platform,
+        out SkillInvocationTrigger trigger,
+        SkillInvocationTriggerOptions? options = null)
+    {
+        trigger = default!;
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        options ??= new SkillInvocationTriggerOptions();
+        var effectivePlatform = string.IsNullOrWhiteSpace(platform) ? "default" : platform.Trim();
+        foreach (var line in EnumerateLines(text.TrimStart()))
+        {
+            var candidate = line.TrimStart();
+            var candidateWithoutTrailingWhitespace = candidate.TrimEnd();
+            if (candidate.Length == 0)
+                continue;
+
+            foreach (var token in options.GetTokens(effectivePlatform))
+            {
+                if (!candidate.StartsWith(token, StringComparison.Ordinal))
+                    continue;
+
+                if (!TryParseCandidate(candidate, candidateWithoutTrailingWhitespace, token, effectivePlatform, out trigger))
+                    continue;
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryParseCandidate(
+        string candidate,
+        string candidateWithoutTrailingWhitespace,
+        string token,
+        string platform,
+        out SkillInvocationTrigger trigger)
+    {
+        trigger = default!;
+        var tail = candidate[token.Length..];
+        if (token == SkillInvocationTriggerOptions.CanonicalTriggerToken &&
+            tail.Length == 0 &&
+            candidate.Length == candidateWithoutTrailingWhitespace.Length)
+        {
+            trigger = new SkillInvocationTrigger(
+                Name: null,
+                Arguments: string.Empty,
+                IsDiscovery: true,
+                OriginalText: candidate,
+                TriggerToken: token,
+                Platform: platform);
+            return true;
+        }
+
+        if (tail.Length == 0 || char.IsWhiteSpace(tail[0]))
+            return false;
+
+        var nameEnd = 0;
+        while (nameEnd < tail.Length && !char.IsWhiteSpace(tail[nameEnd]))
+            nameEnd++;
+
+        var rawName = tail[..nameEnd];
+        if (!IsValidName(rawName))
+            return false;
+
+        var arguments = nameEnd >= tail.Length ? string.Empty : tail[nameEnd..].Trim();
+        trigger = new SkillInvocationTrigger(
+            rawName.ToLowerInvariant(),
+            arguments,
+            IsDiscovery: false,
+            OriginalText: candidate,
+            TriggerToken: token,
+            Platform: platform);
+        return true;
+    }
+
+    private static bool IsValidName(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        foreach (var ch in value)
+        {
+            if (char.IsLetterOrDigit(ch) || ch is '-' or '_' or '.')
+                continue;
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private static IEnumerable<string> EnumerateLines(string text)
+    {
+        var start = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (text[i] != '\n')
+                continue;
+
+            yield return text[start..i].TrimEnd('\r');
+            start = i + 1;
+        }
+
+        yield return text[start..].TrimEnd('\r');
+    }
+}

--- a/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContext.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContext.cs
@@ -78,7 +78,9 @@ public sealed record AgentSkillRecoveryContext(
     string? CommandName,
     string? OriginalCommand,
     string? PrimarySkillName,
-    int MaxOrnnSearchAttempts)
+    int MaxOrnnSearchAttempts,
+    string? CommandArguments = null,
+    bool DiscoveryRequested = false)
 {
     public static AgentSkillRecoveryContext Empty { get; } = new(
         RequireInitialOrnnSearch: false,
@@ -86,5 +88,7 @@ public sealed record AgentSkillRecoveryContext(
         CommandName: null,
         OriginalCommand: null,
         PrimarySkillName: null,
-        MaxOrnnSearchAttempts: 0);
+        MaxOrnnSearchAttempts: 0,
+        CommandArguments: null,
+        DiscoveryRequested: false);
 }

--- a/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContextMapper.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContextMapper.cs
@@ -217,7 +217,9 @@ public static class AgentToolExecutionContextMapper
             AgentToolExecutionContext.Normalize(payload.CommandName),
             AgentToolExecutionContext.Normalize(payload.OriginalCommand),
             AgentToolExecutionContext.Normalize(payload.PrimarySkillName),
-            payload.MaxOrnnSearchAttempts);
+            payload.MaxOrnnSearchAttempts,
+            AgentToolExecutionContext.Normalize(payload.CommandArguments),
+            payload.DiscoveryRequested);
     }
 
     private static AgentSkillRecoveryContextPayload ToSkillRecoveryPayload(AgentSkillRecoveryContext context) =>
@@ -229,6 +231,8 @@ public static class AgentToolExecutionContextMapper
             OriginalCommand = context.OriginalCommand ?? string.Empty,
             PrimarySkillName = context.PrimarySkillName ?? string.Empty,
             MaxOrnnSearchAttempts = context.MaxOrnnSearchAttempts,
+            CommandArguments = context.CommandArguments ?? string.Empty,
+            DiscoveryRequested = context.DiscoveryRequested,
         };
 
     public static IReadOnlyDictionary<string, string> StripOwnedControlKeys(IReadOnlyDictionary<string, string>? metadata)

--- a/src/Aevatar.AI.Abstractions/ai_messages.proto
+++ b/src/Aevatar.AI.Abstractions/ai_messages.proto
@@ -108,6 +108,8 @@ message AgentSkillRecoveryContextPayload {
   string original_command = 4;
   string primary_skill_name = 5;
   int32 max_ornn_search_attempts = 6;
+  string command_arguments = 7;
+  bool discovery_requested = 8;
 }
 
 message AgentToolRequestIdentityPayload {

--- a/src/Aevatar.AI.Core/Chat/SkillRecoveryPlanner.cs
+++ b/src/Aevatar.AI.Core/Chat/SkillRecoveryPlanner.cs
@@ -100,19 +100,6 @@ internal static class SkillRecoveryPlanner
             ? recovery.MaxOrnnSearchAttempts
             : 1;
 
-        if (recovery.RequireInitialOrnnSearch &&
-            !HasToolCall(messages, OrnnSearchSkillsToolName))
-        {
-            if (recoveryAttempts >= maxAttempts)
-                return false;
-
-            directive = new RecoveryDirective(
-                BuildOrnnSearchToolCall(BuildCallId(callIdPrefix, OrnnSearchSkillsToolName), BuildInitialSearchQuery(recovery)),
-                ConsumesOrnnSearchAttempt: true,
-                Nudge: null);
-            return true;
-        }
-
         if (!string.IsNullOrWhiteSpace(recovery.PrimarySkillName) &&
             !HasUseSkillFor(messages, recovery.PrimarySkillName))
         {
@@ -122,6 +109,19 @@ internal static class SkillRecoveryPlanner
                     recovery.PrimarySkillName,
                     ExtractCommandArguments(recovery)),
                 ConsumesOrnnSearchAttempt: false,
+                Nudge: null);
+            return true;
+        }
+
+        if (recovery.RequireInitialOrnnSearch &&
+            !HasToolCall(messages, OrnnSearchSkillsToolName))
+        {
+            if (recoveryAttempts >= maxAttempts)
+                return false;
+
+            directive = new RecoveryDirective(
+                BuildOrnnSearchToolCall(BuildCallId(callIdPrefix, OrnnSearchSkillsToolName), BuildInitialSearchQuery(recovery)),
+                ConsumesOrnnSearchAttempt: true,
                 Nudge: null);
             return true;
         }
@@ -202,7 +202,7 @@ internal static class SkillRecoveryPlanner
     }
 
     private static bool IsEnabled(AgentSkillRecoveryContext recovery) =>
-        recovery.RequireInitialOrnnSearch || recovery.RequireOrnnSearchOnBlocker;
+        recovery.RequireInitialOrnnSearch || recovery.RequireOrnnSearchOnBlocker || recovery.DiscoveryRequested;
 
     private static bool HasToolCall(IReadOnlyList<ChatMessage> messages, string toolName) =>
         messages.Any(message =>
@@ -373,6 +373,9 @@ internal static class SkillRecoveryPlanner
 
     private static string ExtractCommandArguments(AgentSkillRecoveryContext recovery)
     {
+        if (!string.IsNullOrWhiteSpace(recovery.CommandArguments))
+            return recovery.CommandArguments.Trim();
+
         var original = recovery.OriginalCommand?.Trim();
         var command = recovery.CommandName?.Trim().TrimStart('/');
         if (string.IsNullOrWhiteSpace(original) || string.IsNullOrWhiteSpace(command))
@@ -422,7 +425,7 @@ internal static class SkillRecoveryPlanner
         if (!string.IsNullOrWhiteSpace(recovery.PrimarySkillName))
             return recovery.PrimarySkillName.Trim();
 
-        return "the slash command";
+        return recovery.DiscoveryRequested ? "skill discovery" : "the skill command";
     }
 
     private static string BuildInitialSearchQuery(AgentSkillRecoveryContext recovery)
@@ -432,6 +435,9 @@ internal static class SkillRecoveryPlanner
 
         if (!string.IsNullOrWhiteSpace(recovery.CommandName))
             return recovery.CommandName.Trim().TrimStart('/');
+
+        if (recovery.DiscoveryRequested)
+            return "skill discovery";
 
         return DescribeCommand(recovery);
     }

--- a/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesEndpoints.cs
@@ -599,17 +599,14 @@ internal static partial class ResponsesApiEndpoints
     internal static async Task<ChatRouteDecision> ResolveResponsesChatRouteAsync(
         IChatRoutePolicyQueryPort queryPort,
         ChatRouteResolver resolver,
-        ResponsesCallerScope callerScope,
-        string model,
-        ToolMode toolMode,
-        string contentHint,
+        ResponsesChatRouteDecisionRequest request,
         CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(queryPort);
         ArgumentNullException.ThrowIfNull(resolver);
-        ArgumentNullException.ThrowIfNull(callerScope);
+        ArgumentNullException.ThrowIfNull(request);
 
-        var ownerScope = OwnerScope.ForNyxIdNative(callerScope.ScopeId);
+        var ownerScope = OwnerScope.ForNyxIdNative(request.CallerScope.ScopeId);
         var snapshot = await queryPort.LookupForCallerAsync(ownerScope, ct);
         return resolver.Resolve(snapshot, new ChatRouteInput
         {
@@ -622,10 +619,10 @@ internal static partial class ResponsesApiEndpoints
                 SenderId = ownerScope.SenderId,
             },
             Channel = string.Empty,
-            CommandName = string.Empty,
-            ContentHint = contentHint,
-            ToolMode = toolMode,
-            Model = model,
+            CommandName = request.CommandName,
+            ContentHint = request.ContentHint,
+            ToolMode = request.ToolMode,
+            Model = request.Model,
         });
     }
 

--- a/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesRouteResolver.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesRouteResolver.cs
@@ -96,23 +96,22 @@ internal sealed class ResponsesChatRouteDecisionPort(
     ChatRouteResolver resolver) : IResponsesChatRouteDecisionPort
 {
     public async Task<ChatRouteDecision> ResolveAsync(
-        ResponsesCallerScope callerScope,
-        string model,
-        ToolMode toolMode,
-        string contentHint,
+        ResponsesChatRouteDecisionRequest request,
         CancellationToken ct = default)
     {
-        var ownerScope = OwnerScope.ForNyxIdNative(callerScope.ScopeId);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var ownerScope = OwnerScope.ForNyxIdNative(request.CallerScope.ScopeId);
         var snapshot = await queryPort.LookupForCallerAsync(ownerScope, ct);
         return resolver.Resolve(snapshot, new ChatRouteInput
         {
             SourceKind = ChatSourceKind.NyxResponses,
             CallerScope = ownerScope.Clone(),
             Channel = string.Empty,
-            CommandName = string.Empty,
-            ContentHint = contentHint,
-            ToolMode = toolMode,
-            Model = model,
+            CommandName = request.CommandName,
+            ContentHint = request.ContentHint,
+            ToolMode = request.ToolMode,
+            Model = request.Model,
         });
     }
 }

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ChatCompletionsCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ChatCompletionsCommandFacade.cs
@@ -292,7 +292,7 @@ public sealed class ChatCompletionsCommandFacade(
             {
                 NyxIdRoutePreference = resolvedRouteValue,
             },
-            SkillRecovery = BuildSkillRecoveryContext(trigger),
+            SkillRecovery = AgentSkillRecoveryContextBuilder.FromTrigger(trigger),
         };
         var llmRequest = BuildLlmRequest(
             normalized,
@@ -576,35 +576,6 @@ public sealed class ChatCompletionsCommandFacade(
         SkillInvocationTriggerParser.TryParse(text, platform: "cli", out var trigger)
             ? trigger
             : null;
-
-    private static AgentSkillRecoveryContext BuildSkillRecoveryContext(SkillInvocationTrigger? trigger)
-    {
-        if (trigger is null)
-            return AgentSkillRecoveryContext.Empty;
-
-        if (trigger.IsDiscovery)
-        {
-            return new AgentSkillRecoveryContext(
-                RequireInitialOrnnSearch: true,
-                RequireOrnnSearchOnBlocker: false,
-                CommandName: null,
-                OriginalCommand: trigger.OriginalText,
-                PrimarySkillName: null,
-                MaxOrnnSearchAttempts: 1,
-                CommandArguments: null,
-                DiscoveryRequested: true);
-        }
-
-        return new AgentSkillRecoveryContext(
-            RequireInitialOrnnSearch: true,
-            RequireOrnnSearchOnBlocker: true,
-            CommandName: trigger.Name,
-            OriginalCommand: trigger.OriginalText,
-            PrimarySkillName: trigger.Name,
-            MaxOrnnSearchAttempts: 2,
-            CommandArguments: trigger.Arguments,
-            DiscoveryRequested: false);
-    }
 
     private static string NormalizeRouteCommandName(string? commandName) =>
         string.IsNullOrWhiteSpace(commandName)

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ChatCompletionsCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ChatCompletionsCommandFacade.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.SkillInvocations;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.ChatRouting.Abstractions;
@@ -57,7 +58,8 @@ public sealed class ChatCompletionsCommandFacade(
                 callerScopeResult.Error.Code,
                 callerScopeResult.Error.Message);
 
-        var routedModelResult = await ResolveRouteTargetAsync(normalized, callerScopeResult.Scope!, ct);
+        var trigger = ParseSkillInvocationTrigger(BuildRouteContentHint(normalized));
+        var routedModelResult = await ResolveRouteTargetAsync(normalized, callerScopeResult.Scope!, trigger, ct);
         if (routedModelResult.Error is not null)
             return ChatCompletionsCreateCommandResult.FromError(
                 routedModelResult.Error.StatusCode,
@@ -77,6 +79,7 @@ public sealed class ChatCompletionsCommandFacade(
             callerScopeResult.Scope!,
             routedModelResult.Model!,
             routedModelResult.Action!,
+            trigger,
             callerScopeContext.InboundBearerToken,
             sessionResult.Session!,
             createdAt,
@@ -198,13 +201,16 @@ public sealed class ChatCompletionsCommandFacade(
     private async Task<RouteTargetResult> ResolveRouteTargetAsync(
         NormalizedChatCompletionsCommand normalized,
         ResponsesCallerScope callerScope,
+        SkillInvocationTrigger? trigger,
         CancellationToken ct)
     {
         var routeDecision = await chatRouteDecisionPort.ResolveAsync(
-            callerScope,
-            normalized.Model,
-            normalized.DeclaredTools.Count > 0 ? ToolMode.Declared : ToolMode.None,
-            BuildRouteContentHint(normalized),
+            new ResponsesChatRouteDecisionRequest(
+                callerScope,
+                normalized.Model,
+                normalized.DeclaredTools.Count > 0 ? ToolMode.Declared : ToolMode.None,
+                BuildRouteContentHint(normalized),
+                NormalizeRouteCommandName(trigger?.Name)),
             ct);
 
         if (routeDecision.Action.Reject is not null)
@@ -263,6 +269,7 @@ public sealed class ChatCompletionsCommandFacade(
         ResponsesCallerScope callerScope,
         string routedModel,
         ChatRouteAction routeAction,
+        SkillInvocationTrigger? trigger,
         string bearerToken,
         LlmSessionRegistrationResult session,
         DateTimeOffset createdAt,
@@ -285,6 +292,7 @@ public sealed class ChatCompletionsCommandFacade(
             {
                 NyxIdRoutePreference = resolvedRouteValue,
             },
+            SkillRecovery = BuildSkillRecoveryContext(trigger),
         };
         var llmRequest = BuildLlmRequest(
             normalized,
@@ -563,6 +571,45 @@ public sealed class ChatCompletionsCommandFacade(
             ?.Content
         ?? normalized.ChatMessages.LastOrDefault()?.Content
         ?? string.Empty;
+
+    private static SkillInvocationTrigger? ParseSkillInvocationTrigger(string? text) =>
+        SkillInvocationTriggerParser.TryParse(text, platform: "cli", out var trigger)
+            ? trigger
+            : null;
+
+    private static AgentSkillRecoveryContext BuildSkillRecoveryContext(SkillInvocationTrigger? trigger)
+    {
+        if (trigger is null)
+            return AgentSkillRecoveryContext.Empty;
+
+        if (trigger.IsDiscovery)
+        {
+            return new AgentSkillRecoveryContext(
+                RequireInitialOrnnSearch: true,
+                RequireOrnnSearchOnBlocker: false,
+                CommandName: null,
+                OriginalCommand: trigger.OriginalText,
+                PrimarySkillName: null,
+                MaxOrnnSearchAttempts: 1,
+                CommandArguments: null,
+                DiscoveryRequested: true);
+        }
+
+        return new AgentSkillRecoveryContext(
+            RequireInitialOrnnSearch: true,
+            RequireOrnnSearchOnBlocker: true,
+            CommandName: trigger.Name,
+            OriginalCommand: trigger.OriginalText,
+            PrimarySkillName: trigger.Name,
+            MaxOrnnSearchAttempts: 2,
+            CommandArguments: trigger.Arguments,
+            DiscoveryRequested: false);
+    }
+
+    private static string NormalizeRouteCommandName(string? commandName) =>
+        string.IsNullOrWhiteSpace(commandName)
+            ? string.Empty
+            : commandName.Trim().TrimStart('/').ToLowerInvariant();
 
     // Refactor (iter344/cluster-001):
     //   Old pattern: Host populated session records from endpoint locals.

--- a/src/platform/Aevatar.GAgentService.Application/Responses/MessagesCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/MessagesCommandFacade.cs
@@ -244,7 +244,7 @@ public sealed class MessagesCommandFacade(
             {
                 NyxIdRoutePreference = resolvedRouteValue,
             },
-            SkillRecovery = BuildSkillRecoveryContext(trigger),
+            SkillRecovery = AgentSkillRecoveryContextBuilder.FromTrigger(trigger),
         };
         var llmRequest = BuildLlmRequest(
             normalized,
@@ -429,35 +429,6 @@ public sealed class MessagesCommandFacade(
         SkillInvocationTriggerParser.TryParse(text, platform: "cli", out var trigger)
             ? trigger
             : null;
-
-    private static AgentSkillRecoveryContext BuildSkillRecoveryContext(SkillInvocationTrigger? trigger)
-    {
-        if (trigger is null)
-            return AgentSkillRecoveryContext.Empty;
-
-        if (trigger.IsDiscovery)
-        {
-            return new AgentSkillRecoveryContext(
-                RequireInitialOrnnSearch: true,
-                RequireOrnnSearchOnBlocker: false,
-                CommandName: null,
-                OriginalCommand: trigger.OriginalText,
-                PrimarySkillName: null,
-                MaxOrnnSearchAttempts: 1,
-                CommandArguments: null,
-                DiscoveryRequested: true);
-        }
-
-        return new AgentSkillRecoveryContext(
-            RequireInitialOrnnSearch: true,
-            RequireOrnnSearchOnBlocker: true,
-            CommandName: trigger.Name,
-            OriginalCommand: trigger.OriginalText,
-            PrimarySkillName: trigger.Name,
-            MaxOrnnSearchAttempts: 2,
-            CommandArguments: trigger.Arguments,
-            DiscoveryRequested: false);
-    }
 
     private static string NormalizeRouteCommandName(string? commandName) =>
         string.IsNullOrWhiteSpace(commandName)

--- a/src/platform/Aevatar.GAgentService.Application/Responses/MessagesCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/MessagesCommandFacade.cs
@@ -1,4 +1,5 @@
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.SkillInvocations;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.ChatRouting.Abstractions;
 using Aevatar.Foundation.Abstractions;
@@ -53,7 +54,8 @@ public sealed class MessagesCommandFacade(
                 "authentication_error",
                 callerScopeResult.Error.Message);
 
-        var routedModelResult = await ResolveRouteTargetAsync(normalized, callerScopeResult.Scope!, ct);
+        var trigger = ParseSkillInvocationTrigger(BuildRouteContentHint(normalized));
+        var routedModelResult = await ResolveRouteTargetAsync(normalized, callerScopeResult.Scope!, trigger, ct);
         if (routedModelResult.Error is not null)
             return MessagesCreateCommandResult.FromError(
                 routedModelResult.Error.StatusCode,
@@ -72,6 +74,7 @@ public sealed class MessagesCommandFacade(
             callerScopeResult.Scope!,
             routedModelResult.Model!,
             routedModelResult.Action!,
+            trigger,
             callerScopeContext.InboundBearerToken,
             sessionResult.Session!,
             ct);
@@ -141,6 +144,7 @@ public sealed class MessagesCommandFacade(
     private async Task<RouteTargetResult> ResolveRouteTargetAsync(
         NormalizedMessagesRequest normalized,
         ResponsesCallerScope callerScope,
+        SkillInvocationTrigger? trigger,
         CancellationToken ct)
     {
         var routeDecision = await ResolveResponsesChatRouteAsync(
@@ -148,6 +152,7 @@ public sealed class MessagesCommandFacade(
             normalized.Model,
             ResolveToolMode(normalized.DeclaredTools.Count, inlineToolResultCount: 0),
             BuildRouteContentHint(normalized),
+            trigger?.Name ?? string.Empty,
             ct);
 
         if (routeDecision.Action.Reject is not null)
@@ -217,6 +222,7 @@ public sealed class MessagesCommandFacade(
         ResponsesCallerScope callerScope,
         string routedModel,
         ChatRouteAction routeAction,
+        SkillInvocationTrigger? trigger,
         string bearerToken,
         LlmSessionRegistrationResult session,
         CancellationToken ct)
@@ -238,6 +244,7 @@ public sealed class MessagesCommandFacade(
             {
                 NyxIdRoutePreference = resolvedRouteValue,
             },
+            SkillRecovery = BuildSkillRecoveryContext(trigger),
         };
         var llmRequest = BuildLlmRequest(
             normalized,
@@ -407,8 +414,55 @@ public sealed class MessagesCommandFacade(
         string model,
         ToolMode toolMode,
         string contentHint,
+        string commandName,
         CancellationToken ct)
-        => chatRouteDecisionPort.ResolveAsync(callerScope, model, toolMode, contentHint, ct);
+        => chatRouteDecisionPort.ResolveAsync(
+            new ResponsesChatRouteDecisionRequest(
+                callerScope,
+                model,
+                toolMode,
+                contentHint,
+                NormalizeRouteCommandName(commandName)),
+            ct);
+
+    private static SkillInvocationTrigger? ParseSkillInvocationTrigger(string? text) =>
+        SkillInvocationTriggerParser.TryParse(text, platform: "cli", out var trigger)
+            ? trigger
+            : null;
+
+    private static AgentSkillRecoveryContext BuildSkillRecoveryContext(SkillInvocationTrigger? trigger)
+    {
+        if (trigger is null)
+            return AgentSkillRecoveryContext.Empty;
+
+        if (trigger.IsDiscovery)
+        {
+            return new AgentSkillRecoveryContext(
+                RequireInitialOrnnSearch: true,
+                RequireOrnnSearchOnBlocker: false,
+                CommandName: null,
+                OriginalCommand: trigger.OriginalText,
+                PrimarySkillName: null,
+                MaxOrnnSearchAttempts: 1,
+                CommandArguments: null,
+                DiscoveryRequested: true);
+        }
+
+        return new AgentSkillRecoveryContext(
+            RequireInitialOrnnSearch: true,
+            RequireOrnnSearchOnBlocker: true,
+            CommandName: trigger.Name,
+            OriginalCommand: trigger.OriginalText,
+            PrimarySkillName: trigger.Name,
+            MaxOrnnSearchAttempts: 2,
+            CommandArguments: trigger.Arguments,
+            DiscoveryRequested: false);
+    }
+
+    private static string NormalizeRouteCommandName(string? commandName) =>
+        string.IsNullOrWhiteSpace(commandName)
+            ? string.Empty
+            : commandName.Trim().TrimStart('/').ToLowerInvariant();
 
     private static ToolMode ResolveToolMode(int declaredToolCount, int inlineToolResultCount)
     {

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandContracts.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandContracts.cs
@@ -58,13 +58,17 @@ public interface IResponsesRouteResolver
 // Refactor (iter35/cluster-037-mainnet-responses-host-orchestration):
 //   Old pattern: Responses/Messages Application facades constructed chat route snapshots with the concrete ChatRouting.Core resolver.
 //   New principle: Application depends on a business route-decision port; Host composes that port with the current readmodel query and resolver implementation.
+public sealed record ResponsesChatRouteDecisionRequest(
+    ResponsesCallerScope CallerScope,
+    string Model,
+    ToolMode ToolMode,
+    string ContentHint,
+    string CommandName);
+
 public interface IResponsesChatRouteDecisionPort
 {
     Task<ChatRouteDecision> ResolveAsync(
-        ResponsesCallerScope callerScope,
-        string model,
-        ToolMode toolMode,
-        string contentHint,
+        ResponsesChatRouteDecisionRequest request,
         CancellationToken ct = default);
 }
 

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandFacade.cs
@@ -1,4 +1,5 @@
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.SkillInvocations;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.ChatRouting.Abstractions;
 using Aevatar.Foundation.Abstractions;
@@ -58,7 +59,8 @@ public sealed class ResponsesCommandFacade(
                 callerScopeResult.Error.Message);
 
         var callerScope = callerScopeResult.Scope!;
-        var routedModelResult = await ResolveRouteTargetAsync(normalized, callerScope, ct);
+        var trigger = ParseSkillInvocationTrigger(normalized.Prompt);
+        var routedModelResult = await ResolveRouteTargetAsync(normalized, callerScope, trigger, ct);
         if (routedModelResult.Error is not null)
             return ResponsesCreateCommandResult.FromError(
                 routedModelResult.Error.StatusCode,
@@ -100,6 +102,7 @@ public sealed class ResponsesCommandFacade(
             continuation.PreviousSnapshot,
             callerScope,
             routedModelResult.Action!,
+            trigger,
             callerScopeContext.InboundBearerToken,
             sessionResult.Session!,
             createdAt,
@@ -229,6 +232,7 @@ public sealed class ResponsesCommandFacade(
     private async Task<RouteTargetResult> ResolveRouteTargetAsync(
         NormalizedResponsesRequest normalized,
         ResponsesCallerScope callerScope,
+        SkillInvocationTrigger? trigger,
         CancellationToken ct)
     {
         var routeDecision = await ResolveResponsesChatRouteAsync(
@@ -236,6 +240,7 @@ public sealed class ResponsesCommandFacade(
             normalized.Model,
             ResolveToolMode(normalized.DeclaredTools.Count, normalized.ToolResults.Count),
             BuildContentHint(normalized.Prompt),
+            trigger?.Name ?? string.Empty,
             ct);
 
         if (routeDecision.Action.Reject is not null)
@@ -361,6 +366,7 @@ public sealed class ResponsesCommandFacade(
         LlmSessionSnapshot? previousSnapshot,
         ResponsesCallerScope callerScope,
         ChatRouteAction routeAction,
+        SkillInvocationTrigger? trigger,
         string bearerToken,
         LlmSessionRegistrationResult responseSession,
         DateTimeOffset createdAt,
@@ -387,6 +393,7 @@ public sealed class ResponsesCommandFacade(
             {
                 NyxIdRoutePreference = resolvedRouteValue,
             },
+            SkillRecovery = BuildSkillRecoveryContext(trigger),
         };
         var llmRequest = BuildLlmRequest(
             normalized,
@@ -554,8 +561,55 @@ public sealed class ResponsesCommandFacade(
         string model,
         ToolMode toolMode,
         string contentHint,
+        string commandName,
         CancellationToken ct)
-        => chatRouteDecisionPort.ResolveAsync(callerScope, model, toolMode, contentHint, ct);
+        => chatRouteDecisionPort.ResolveAsync(
+            new ResponsesChatRouteDecisionRequest(
+                callerScope,
+                model,
+                toolMode,
+                contentHint,
+                NormalizeRouteCommandName(commandName)),
+            ct);
+
+    private static SkillInvocationTrigger? ParseSkillInvocationTrigger(string? text) =>
+        SkillInvocationTriggerParser.TryParse(text, platform: "cli", out var trigger)
+            ? trigger
+            : null;
+
+    private static AgentSkillRecoveryContext BuildSkillRecoveryContext(SkillInvocationTrigger? trigger)
+    {
+        if (trigger is null)
+            return AgentSkillRecoveryContext.Empty;
+
+        if (trigger.IsDiscovery)
+        {
+            return new AgentSkillRecoveryContext(
+                RequireInitialOrnnSearch: true,
+                RequireOrnnSearchOnBlocker: false,
+                CommandName: null,
+                OriginalCommand: trigger.OriginalText,
+                PrimarySkillName: null,
+                MaxOrnnSearchAttempts: 1,
+                CommandArguments: null,
+                DiscoveryRequested: true);
+        }
+
+        return new AgentSkillRecoveryContext(
+            RequireInitialOrnnSearch: true,
+            RequireOrnnSearchOnBlocker: true,
+            CommandName: trigger.Name,
+            OriginalCommand: trigger.OriginalText,
+            PrimarySkillName: trigger.Name,
+            MaxOrnnSearchAttempts: 2,
+            CommandArguments: trigger.Arguments,
+            DiscoveryRequested: false);
+    }
+
+    private static string NormalizeRouteCommandName(string? commandName) =>
+        string.IsNullOrWhiteSpace(commandName)
+            ? string.Empty
+            : commandName.Trim().TrimStart('/').ToLowerInvariant();
 
     private static ToolMode ResolveToolMode(int declaredToolCount, int inlineToolResultCount)
     {

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandFacade.cs
@@ -393,7 +393,7 @@ public sealed class ResponsesCommandFacade(
             {
                 NyxIdRoutePreference = resolvedRouteValue,
             },
-            SkillRecovery = BuildSkillRecoveryContext(trigger),
+            SkillRecovery = AgentSkillRecoveryContextBuilder.FromTrigger(trigger),
         };
         var llmRequest = BuildLlmRequest(
             normalized,
@@ -576,35 +576,6 @@ public sealed class ResponsesCommandFacade(
         SkillInvocationTriggerParser.TryParse(text, platform: "cli", out var trigger)
             ? trigger
             : null;
-
-    private static AgentSkillRecoveryContext BuildSkillRecoveryContext(SkillInvocationTrigger? trigger)
-    {
-        if (trigger is null)
-            return AgentSkillRecoveryContext.Empty;
-
-        if (trigger.IsDiscovery)
-        {
-            return new AgentSkillRecoveryContext(
-                RequireInitialOrnnSearch: true,
-                RequireOrnnSearchOnBlocker: false,
-                CommandName: null,
-                OriginalCommand: trigger.OriginalText,
-                PrimarySkillName: null,
-                MaxOrnnSearchAttempts: 1,
-                CommandArguments: null,
-                DiscoveryRequested: true);
-        }
-
-        return new AgentSkillRecoveryContext(
-            RequireInitialOrnnSearch: true,
-            RequireOrnnSearchOnBlocker: true,
-            CommandName: trigger.Name,
-            OriginalCommand: trigger.OriginalText,
-            PrimarySkillName: trigger.Name,
-            MaxOrnnSearchAttempts: 2,
-            CommandArguments: trigger.Arguments,
-            DiscoveryRequested: false);
-    }
 
     private static string NormalizeRouteCommandName(string? commandName) =>
         string.IsNullOrWhiteSpace(commandName)

--- a/test/Aevatar.AI.Tests/AgentSkillRecoveryContextBuilderTests.cs
+++ b/test/Aevatar.AI.Tests/AgentSkillRecoveryContextBuilderTests.cs
@@ -1,0 +1,41 @@
+using Aevatar.AI.Abstractions.SkillInvocations;
+using FluentAssertions;
+
+namespace Aevatar.AI.Tests;
+
+public sealed class AgentSkillRecoveryContextBuilderTests
+{
+    [Fact]
+    public void FromTrigger_WhenNamedTrigger_ShouldBuildSkillRecoveryContext()
+    {
+        SkillInvocationTriggerParser.TryParse("::Goal ship today", "cli", out var trigger).Should().BeTrue();
+
+        var context = AgentSkillRecoveryContextBuilder.FromTrigger(trigger);
+
+        context.RequireInitialOrnnSearch.Should().BeTrue();
+        context.RequireOrnnSearchOnBlocker.Should().BeTrue();
+        context.CommandName.Should().Be("goal");
+        context.OriginalCommand.Should().Be("::Goal ship today");
+        context.PrimarySkillName.Should().Be("goal");
+        context.MaxOrnnSearchAttempts.Should().Be(2);
+        context.CommandArguments.Should().Be("ship today");
+        context.DiscoveryRequested.Should().BeFalse();
+    }
+
+    [Fact]
+    public void FromTrigger_WhenDiscoveryTrigger_ShouldBuildDiscoveryRecoveryContext()
+    {
+        SkillInvocationTriggerParser.TryParse("::", "cli", out var trigger).Should().BeTrue();
+
+        var context = AgentSkillRecoveryContextBuilder.FromTrigger(trigger);
+
+        context.RequireInitialOrnnSearch.Should().BeTrue();
+        context.RequireOrnnSearchOnBlocker.Should().BeFalse();
+        context.CommandName.Should().BeNull();
+        context.OriginalCommand.Should().Be("::");
+        context.PrimarySkillName.Should().BeNull();
+        context.MaxOrnnSearchAttempts.Should().Be(1);
+        context.CommandArguments.Should().BeNull();
+        context.DiscoveryRequested.Should().BeTrue();
+    }
+}

--- a/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
+++ b/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
@@ -261,7 +261,9 @@ public sealed class AgentToolExecutionContextMapperTests
                 CommandName: " goal ",
                 OriginalCommand: " /goal ship ",
                 PrimarySkillName: " goal-skill ",
-                MaxOrnnSearchAttempts: 2),
+                MaxOrnnSearchAttempts: 2,
+                CommandArguments: " ship ",
+                DiscoveryRequested: true),
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 ["external-trace"] = "trace-1",
@@ -298,7 +300,29 @@ public sealed class AgentToolExecutionContextMapperTests
         copy.SkillRecovery.OriginalCommand.Should().Be("/goal ship");
         copy.SkillRecovery.PrimarySkillName.Should().Be("goal-skill");
         copy.SkillRecovery.MaxOrnnSearchAttempts.Should().Be(2);
+        copy.SkillRecovery.CommandArguments.Should().Be("ship");
+        copy.SkillRecovery.DiscoveryRequested.Should().BeTrue();
         copy.ExternalMetadata.Should().ContainSingle().Which.Should().Be(new KeyValuePair<string, string>("external-trace", "trace-1"));
+    }
+
+    [Fact]
+    public void FromPayload_WhenSkillRecoveryNewFieldsAreMissing_ShouldUseDefaults()
+    {
+        var payload = new AgentToolExecutionContextPayload
+        {
+            SkillRecovery = new AgentSkillRecoveryContextPayload
+            {
+                RequireInitialOrnnSearch = true,
+                CommandName = "goal",
+            },
+        };
+
+        var context = AgentToolExecutionContextMapper.FromPayload(
+            AgentToolExecutionContextPayload.Parser.ParseFrom(payload.ToByteArray()));
+
+        context.SkillRecovery.CommandName.Should().Be("goal");
+        context.SkillRecovery.CommandArguments.Should().BeNull();
+        context.SkillRecovery.DiscoveryRequested.Should().BeFalse();
     }
 
     [Fact]

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.Authentication.Abstractions;
 using Aevatar.ChatRouting.Abstractions;
@@ -1331,6 +1332,104 @@ public class NyxIdChatEndpointsCoverageTests
         emitted.Select(x => x.EventCase).Should().ContainInOrder(
             AGUIEvent.EventOneofCase.TextMessageContent,
             AGUIEvent.EventOneofCase.RunFinished);
+    }
+
+    [Fact]
+    public async Task NyxIdChatInteraction_ShouldAttachSkillRecoveryForCanonicalTrigger()
+    {
+        var actor = new StubActor("actor-1");
+        var runtime = new StubActorRuntime();
+        runtime.Actors[actor.Id] = actor;
+        var projectionPort = new StubNyxIdChatSessionProjectionPort
+        {
+            Messages =
+            {
+                new AGUIEvent { RunFinished = new RunFinishedEvent() },
+            },
+        };
+        var dispatchPort = new StubActorDispatchPort(runtime);
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IActorRuntime>(runtime)
+            .AddSingleton<IActorDispatchPort>(dispatchPort)
+            .AddSingleton<INyxIdChatSessionProjectionPort>(projectionPort)
+            .AddNyxIdChat()
+            .BuildServiceProvider();
+        var interaction = services.GetRequiredService<
+            ICommandInteractionService<NyxIdChatCommand, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, NyxIdChatCompletionStatus>>();
+
+        var result = await interaction.ExecuteAsync(
+            new NyxIdChatCommand(
+                actor.Id,
+                "scope-a",
+                "::Goal ship today",
+                "session-1",
+                "access-token",
+                null,
+                null),
+            (_, _) => ValueTask.CompletedTask);
+
+        result.Succeeded.Should().BeTrue();
+        dispatchPort.Dispatches.Should().ContainSingle();
+        var request = dispatchPort.Dispatches.Single().Envelope.Payload.Unpack<ChatRequestEvent>();
+        request.Prompt.Should().Be("::Goal ship today");
+        var recovery = AgentToolExecutionContextMapper.FromPayload(request.ToolContext).SkillRecovery;
+        recovery.RequireInitialOrnnSearch.Should().BeTrue();
+        recovery.RequireOrnnSearchOnBlocker.Should().BeTrue();
+        recovery.CommandName.Should().Be("goal");
+        recovery.PrimarySkillName.Should().Be("goal");
+        recovery.CommandArguments.Should().Be("ship today");
+        recovery.OriginalCommand.Should().Be("::Goal ship today");
+        recovery.DiscoveryRequested.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task NyxIdChatInteraction_ShouldAttachDiscoveryRecoveryForBareCanonicalTrigger()
+    {
+        var actor = new StubActor("actor-1");
+        var runtime = new StubActorRuntime();
+        runtime.Actors[actor.Id] = actor;
+        var projectionPort = new StubNyxIdChatSessionProjectionPort
+        {
+            Messages =
+            {
+                new AGUIEvent { RunFinished = new RunFinishedEvent() },
+            },
+        };
+        var dispatchPort = new StubActorDispatchPort(runtime);
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IActorRuntime>(runtime)
+            .AddSingleton<IActorDispatchPort>(dispatchPort)
+            .AddSingleton<INyxIdChatSessionProjectionPort>(projectionPort)
+            .AddNyxIdChat()
+            .BuildServiceProvider();
+        var interaction = services.GetRequiredService<
+            ICommandInteractionService<NyxIdChatCommand, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, NyxIdChatCompletionStatus>>();
+
+        var result = await interaction.ExecuteAsync(
+            new NyxIdChatCommand(
+                actor.Id,
+                "scope-a",
+                "::",
+                "session-1",
+                "access-token",
+                null,
+                null),
+            (_, _) => ValueTask.CompletedTask);
+
+        result.Succeeded.Should().BeTrue();
+        dispatchPort.Dispatches.Should().ContainSingle();
+        var request = dispatchPort.Dispatches.Single().Envelope.Payload.Unpack<ChatRequestEvent>();
+        request.Prompt.Should().Be("::");
+        var recovery = AgentToolExecutionContextMapper.FromPayload(request.ToolContext).SkillRecovery;
+        recovery.RequireInitialOrnnSearch.Should().BeTrue();
+        recovery.RequireOrnnSearchOnBlocker.Should().BeFalse();
+        recovery.CommandName.Should().BeNull();
+        recovery.PrimarySkillName.Should().BeNull();
+        recovery.CommandArguments.Should().BeNull();
+        recovery.OriginalCommand.Should().Be("::");
+        recovery.DiscoveryRequested.Should().BeTrue();
     }
 
     [Fact]

--- a/test/Aevatar.AI.Tests/SkillInvocationTriggerParserTests.cs
+++ b/test/Aevatar.AI.Tests/SkillInvocationTriggerParserTests.cs
@@ -1,0 +1,110 @@
+using Aevatar.AI.Abstractions.SkillInvocations;
+using FluentAssertions;
+
+namespace Aevatar.AI.Tests;
+
+public sealed class SkillInvocationTriggerParserTests
+{
+    [Fact]
+    public void TryParse_WhenCanonicalNameAtStart_ShouldReturnNameAndArguments()
+    {
+        SkillInvocationTriggerParser.TryParse("::Goal ship today", "cli", out var trigger).Should().BeTrue();
+
+        trigger.Name.Should().Be("goal");
+        trigger.Arguments.Should().Be("ship today");
+        trigger.IsDiscovery.Should().BeFalse();
+        trigger.OriginalText.Should().Be("::Goal ship today");
+        trigger.TriggerToken.Should().Be("::");
+        trigger.Platform.Should().Be("cli");
+    }
+
+    [Fact]
+    public void TryParse_WhenTriggerStartsLaterLine_ShouldReturnFirstLegalTrigger()
+    {
+        var text = "please inspect this\n::alpha first\n::beta second";
+
+        SkillInvocationTriggerParser.TryParse(text, "cli", out var trigger).Should().BeTrue();
+
+        trigger.Name.Should().Be("alpha");
+        trigger.Arguments.Should().Be("first");
+    }
+
+    [Fact]
+    public void TryParse_WhenFirstLineHasIllegalTrigger_ShouldReturnFirstLegalLaterTrigger()
+    {
+        var text = "please run ::goal today\n::alpha first";
+
+        SkillInvocationTriggerParser.TryParse(text, "cli", out var trigger).Should().BeTrue();
+
+        trigger.Name.Should().Be("alpha");
+        trigger.Arguments.Should().Be("first");
+    }
+
+    [Fact]
+    public void TryParse_WhenTriggerAppearsInsideSentence_ShouldIgnoreIt()
+    {
+        SkillInvocationTriggerParser.TryParse("please run ::goal today", "cli", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryParse_WhenCanonicalBareToken_ShouldRequestDiscovery()
+    {
+        SkillInvocationTriggerParser.TryParse("::", "cli", out var trigger).Should().BeTrue();
+
+        trigger.IsDiscovery.Should().BeTrue();
+        trigger.Name.Should().BeNull();
+        trigger.Arguments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TryParse_WhenCanonicalTokenHasTrailingWhitespace_ShouldIgnoreIt()
+    {
+        SkillInvocationTriggerParser.TryParse(":: ", "cli", out _).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("lark")]
+    [InlineData("web")]
+    public void TryParse_WhenSlashAliasAllowedForPlatform_ShouldReturnName(string platform)
+    {
+        SkillInvocationTriggerParser.TryParse("/Goal args", platform, out var trigger).Should().BeTrue();
+
+        trigger.Name.Should().Be("goal");
+        trigger.Arguments.Should().Be("args");
+        trigger.TriggerToken.Should().Be("/");
+    }
+
+    [Fact]
+    public void TryParse_WhenSlashAliasOnCli_ShouldReject()
+    {
+        SkillInvocationTriggerParser.TryParse("/goal args", "cli", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryParse_WhenSlashAliasOnDefaultPlatform_ShouldReject()
+    {
+        SkillInvocationTriggerParser.TryParse("/goal args", null, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryParse_WhenOptionsCustomizePlatformAliases_ShouldUseConfiguredTokens()
+    {
+        var options = new SkillInvocationTriggerOptions();
+        options.SetPlatformTokens("custom", ["!!"]);
+
+        SkillInvocationTriggerParser.TryParse("!!Goal args", "custom", out var trigger, options).Should().BeTrue();
+
+        trigger.Name.Should().Be("goal");
+        trigger.Arguments.Should().Be("args");
+        trigger.TriggerToken.Should().Be("!!");
+    }
+
+    [Fact]
+    public void TryParse_WhenNameLooksLikeConcreteFixture_ShouldStillUseGenericNameParsing()
+    {
+        SkillInvocationTriggerParser.TryParse("::chrono-ai-daily alice", "cli", out var trigger).Should().BeTrue();
+
+        trigger.Name.Should().Be("chrono-ai-daily");
+        trigger.Arguments.Should().Be("alice");
+    }
+}

--- a/test/Aevatar.AI.Tests/SkillRecoveryPlannerTests.cs
+++ b/test/Aevatar.AI.Tests/SkillRecoveryPlannerTests.cs
@@ -119,7 +119,32 @@ public sealed class SkillRecoveryPlannerTests
             out var directive);
 
         forced.Should().BeTrue();
+        directive.ToolCall!.Name.Should().Be("use_skill");
+    }
+
+    [Fact]
+    public void TryPlanNextDirective_WhenDiscoveryRequested_ShouldBuildSearchWithoutFakeSkill()
+    {
+        var forced = SkillRecoveryPlanner.TryPlanNextDirective(
+            new AgentSkillRecoveryContext(
+                RequireInitialOrnnSearch: true,
+                RequireOrnnSearchOnBlocker: false,
+                CommandName: null,
+                OriginalCommand: "::",
+                PrimarySkillName: null,
+                MaxOrnnSearchAttempts: 1,
+                CommandArguments: null,
+                DiscoveryRequested: true),
+            [ChatMessage.User("::")],
+            finalContent: null,
+            recoveryAttempts: 0,
+            callIdPrefix: "req-discovery",
+            out var directive);
+
+        forced.Should().BeTrue();
         directive.ToolCall!.Name.Should().Be("ornn_search_skills");
+        directive.ToolCall.ArgumentsJson.Should().Contain("skill discovery");
+        directive.ToolCall.ArgumentsJson.Should().NotContain("\"skill\"");
     }
 
     [Fact]
@@ -139,7 +164,7 @@ public sealed class SkillRecoveryPlannerTests
         };
 
         var forced = SkillRecoveryPlanner.TryPlanNextDirective(
-            Recovery(originalCommand: "/goal ship today", primarySkillName: "project-summary"),
+            Recovery(originalCommand: "/goal ship today", primarySkillName: "project-summary", commandArguments: "typed args"),
             messages,
             finalContent: "done",
             recoveryAttempts: 1,
@@ -149,7 +174,7 @@ public sealed class SkillRecoveryPlannerTests
         forced.Should().BeTrue();
         using var document = JsonDocument.Parse(directive.ToolCall!.ArgumentsJson);
         document.RootElement.GetProperty("skill").GetString().Should().Be("project-summary");
-        document.RootElement.GetProperty("args").GetString().Should().Be("ship today");
+        document.RootElement.GetProperty("args").GetString().Should().Be("typed args");
     }
 
     [Fact]
@@ -391,14 +416,17 @@ public sealed class SkillRecoveryPlannerTests
         bool requireInitialSearch = true,
         string originalCommand = "/goal ship",
         string? primarySkillName = "project-summary",
-        int maxAttempts = 2) =>
+        int maxAttempts = 2,
+        string? commandArguments = null) =>
         new(
             RequireInitialOrnnSearch: requireInitialSearch,
             RequireOrnnSearchOnBlocker: true,
             CommandName: "goal",
             OriginalCommand: originalCommand,
             PrimarySkillName: primarySkillName,
-            MaxOrnnSearchAttempts: maxAttempts);
+            MaxOrnnSearchAttempts: maxAttempts,
+            CommandArguments: commandArguments,
+            DiscoveryRequested: false);
 
     private static ChatMessage AssistantToolCall(string id, string name, string argumentsJson) =>
         new()

--- a/test/Aevatar.GAgentService.Tests/Application/ChatCompletionsCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ChatCompletionsCommandFacadeTests.cs
@@ -52,6 +52,69 @@ public sealed class ChatCompletionsCommandFacadeTests
         toolContext.Routing.NyxIdRoutePreference.Should().Be("route-value");
     }
 
+    [Fact]
+    public async Task CreateAsync_WhenNamedSkillTriggerProvided_ShouldRouteCommandAndCarryRecoveryContext()
+    {
+        var sessions = new RecordingSessionPort();
+        var observation = ObservationScenarioBuilder.ForResponse("chatcmpl_skill")
+            .WithCompletedText("ok")
+            .Build();
+        var dispatch = new RecordingActorDispatchPort(observation);
+        var routeDecisionPort = new StaticResponsesChatRouteDecisionPort(ForwardToModelAction("chrono/gpt-5-chat"));
+        var facade = CreateFacade(
+            sessionPort: sessions,
+            dispatchPort: dispatch,
+            chatRouteDecisionPort: routeDecisionPort,
+            observationRuntime: observation);
+
+        var result = await facade.CreateAsync(
+            BuildRequest("gpt-4o-mini", chatMessages: [ChatMessage.User("::Goal ship today")]),
+            CallerScopeContext("token"));
+
+        result.Error.Should().BeNull();
+        routeDecisionPort.LastRequest.Should().NotBeNull();
+        routeDecisionPort.LastRequest!.CommandName.Should().Be("goal");
+        var command = dispatch.Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
+        var recovery = AgentToolExecutionContextMapper.FromPayload(command.ToolContext).SkillRecovery;
+        recovery.RequireInitialOrnnSearch.Should().BeTrue();
+        recovery.RequireOrnnSearchOnBlocker.Should().BeTrue();
+        recovery.CommandName.Should().Be("goal");
+        recovery.PrimarySkillName.Should().Be("goal");
+        recovery.CommandArguments.Should().Be("ship today");
+        recovery.OriginalCommand.Should().Be("::Goal ship today");
+        recovery.DiscoveryRequested.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenDiscoveryTriggerProvided_ShouldKeepRouteCommandEmptyAndRequestDiscovery()
+    {
+        var sessions = new RecordingSessionPort();
+        var observation = ObservationScenarioBuilder.ForResponse("chatcmpl_discovery")
+            .WithCompletedText("ok")
+            .Build();
+        var dispatch = new RecordingActorDispatchPort(observation);
+        var routeDecisionPort = new StaticResponsesChatRouteDecisionPort(ForwardToModelAction("chrono/gpt-5-chat"));
+        var facade = CreateFacade(
+            sessionPort: sessions,
+            dispatchPort: dispatch,
+            chatRouteDecisionPort: routeDecisionPort,
+            observationRuntime: observation);
+
+        var result = await facade.CreateAsync(
+            BuildRequest("gpt-4o-mini", chatMessages: [ChatMessage.User("::")]),
+            CallerScopeContext("token"));
+
+        result.Error.Should().BeNull();
+        routeDecisionPort.LastRequest.Should().NotBeNull();
+        routeDecisionPort.LastRequest!.CommandName.Should().BeEmpty();
+        var command = dispatch.Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
+        var recovery = AgentToolExecutionContextMapper.FromPayload(command.ToolContext).SkillRecovery;
+        recovery.DiscoveryRequested.Should().BeTrue();
+        recovery.CommandName.Should().BeNull();
+        recovery.PrimarySkillName.Should().BeNull();
+        recovery.OriginalCommand.Should().Be("::");
+    }
+
     [Theory]
     [MemberData(nameof(InvalidRequests))]
     public async Task CreateAsync_WhenRequestValidationFails_ShouldReturnBadRequest(
@@ -690,17 +753,19 @@ public sealed class ChatCompletionsCommandFacadeTests
     private sealed class StaticResponsesChatRouteDecisionPort(ChatRouteAction action)
         : IResponsesChatRouteDecisionPort
     {
+        public ResponsesChatRouteDecisionRequest? LastRequest { get; private set; }
+
         public Task<ChatRouteDecision> ResolveAsync(
-            ResponsesCallerScope callerScope,
-            string model,
-            ToolMode toolMode,
-            string contentHint,
+            ResponsesChatRouteDecisionRequest request,
             CancellationToken ct = default)
-            => Task.FromResult(new ChatRouteDecision
+        {
+            LastRequest = request;
+            return Task.FromResult(new ChatRouteDecision
             {
                 Action = action.Clone(),
                 UsedFallback = false,
             });
+        }
     }
 
     private sealed class StaticResponsesToolClassificationService(

--- a/test/Aevatar.GAgentService.Tests/Application/MessagesCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/MessagesCommandFacadeTests.cs
@@ -84,6 +84,53 @@ public sealed class MessagesCommandFacadeTests
     }
 
     [Fact]
+    public async Task CreateAsync_WhenNamedSkillTriggerProvided_ShouldRouteCommandAndCarryRecoveryContext()
+    {
+        var dispatch = new RecordingActorDispatchPort();
+        var routeDecisionPort = new StaticResponsesChatRouteDecisionPort(ForwardToModelAction("anthropic/claude"));
+        var facade = CreateFacade(dispatchPort: dispatch, chatRouteDecisionPort: routeDecisionPort);
+
+        var result = await facade.CreateAsync(
+            BuildRequest("claude-sonnet", chatMessages: [ChatMessage.User("::Goal ship today")]),
+            CallerScopeContext("token"));
+
+        result.Error.Should().BeNull();
+        routeDecisionPort.LastRequest.Should().NotBeNull();
+        routeDecisionPort.LastRequest!.CommandName.Should().Be("goal");
+        var command = dispatch.Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
+        var recovery = AgentToolExecutionContextMapper.FromPayload(command.ToolContext).SkillRecovery;
+        recovery.RequireInitialOrnnSearch.Should().BeTrue();
+        recovery.RequireOrnnSearchOnBlocker.Should().BeTrue();
+        recovery.CommandName.Should().Be("goal");
+        recovery.PrimarySkillName.Should().Be("goal");
+        recovery.CommandArguments.Should().Be("ship today");
+        recovery.OriginalCommand.Should().Be("::Goal ship today");
+        recovery.DiscoveryRequested.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenDiscoveryTriggerProvided_ShouldKeepRouteCommandEmptyAndRequestDiscovery()
+    {
+        var dispatch = new RecordingActorDispatchPort();
+        var routeDecisionPort = new StaticResponsesChatRouteDecisionPort(ForwardToModelAction("anthropic/claude"));
+        var facade = CreateFacade(dispatchPort: dispatch, chatRouteDecisionPort: routeDecisionPort);
+
+        var result = await facade.CreateAsync(
+            BuildRequest("claude-sonnet", chatMessages: [ChatMessage.User("::")]),
+            CallerScopeContext("token"));
+
+        result.Error.Should().BeNull();
+        routeDecisionPort.LastRequest.Should().NotBeNull();
+        routeDecisionPort.LastRequest!.CommandName.Should().BeEmpty();
+        var command = dispatch.Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
+        var recovery = AgentToolExecutionContextMapper.FromPayload(command.ToolContext).SkillRecovery;
+        recovery.DiscoveryRequested.Should().BeTrue();
+        recovery.CommandName.Should().BeNull();
+        recovery.PrimarySkillName.Should().BeNull();
+        recovery.OriginalCommand.Should().Be("::");
+    }
+
+    [Fact]
     public async Task StreamAsync_ShouldReturnAcceptedDispatchReceipt()
     {
         var sessions = new RecordingSessionPort();
@@ -279,18 +326,20 @@ public sealed class MessagesCommandFacadeTests
         string matchedRuleId = "")
         : IResponsesChatRouteDecisionPort
     {
+        public ResponsesChatRouteDecisionRequest? LastRequest { get; private set; }
+
         public Task<ChatRouteDecision> ResolveAsync(
-            ResponsesCallerScope callerScope,
-            string model,
-            ToolMode toolMode,
-            string contentHint,
+            ResponsesChatRouteDecisionRequest request,
             CancellationToken ct = default)
-            => Task.FromResult(new ChatRouteDecision
+        {
+            LastRequest = request;
+            return Task.FromResult(new ChatRouteDecision
             {
                 Action = action.Clone(),
                 UsedFallback = usedFallback,
                 MatchedRuleId = matchedRuleId,
             });
+        }
     }
 
     private sealed class StaticResponsesToolClassificationService(

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
@@ -481,6 +481,70 @@ public sealed class ResponsesCommandFacadeTests
     }
 
     [Fact]
+    public async Task CreateAsync_WhenNamedSkillTriggerProvided_ShouldRouteCommandAndCarryRecoveryContext()
+    {
+        var dispatch = new RecordingActorDispatchPort();
+        var routeDecisionPort = new StaticResponsesChatRouteDecisionPort(ForwardToModelAction("openai/gpt-5"));
+        var facade = CreateFacade(
+            dispatchPort: dispatch,
+            routeResolver: new StaticResponsesRouteResolver("route-value"),
+            chatRouteDecisionPort: routeDecisionPort);
+
+        var result = await facade.CreateAsync(new ResponsesCommandRequest(
+            "client-model",
+            "::Goal ship today",
+            [],
+            false,
+            null,
+            null,
+            null,
+            []), CallerScopeContext("token"));
+
+        result.Error.Should().BeNull();
+        routeDecisionPort.LastRequest.Should().NotBeNull();
+        routeDecisionPort.LastRequest!.CommandName.Should().Be("goal");
+        var command = dispatch.Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
+        var recovery = AgentToolExecutionContextMapper.FromPayload(command.ToolContext).SkillRecovery;
+        recovery.RequireInitialOrnnSearch.Should().BeTrue();
+        recovery.RequireOrnnSearchOnBlocker.Should().BeTrue();
+        recovery.CommandName.Should().Be("goal");
+        recovery.PrimarySkillName.Should().Be("goal");
+        recovery.CommandArguments.Should().Be("ship today");
+        recovery.OriginalCommand.Should().Be("::Goal ship today");
+        recovery.DiscoveryRequested.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenDiscoveryTriggerProvided_ShouldKeepRouteCommandEmptyAndRequestDiscovery()
+    {
+        var dispatch = new RecordingActorDispatchPort();
+        var routeDecisionPort = new StaticResponsesChatRouteDecisionPort(ForwardToModelAction("openai/gpt-5"));
+        var facade = CreateFacade(
+            dispatchPort: dispatch,
+            chatRouteDecisionPort: routeDecisionPort);
+
+        var result = await facade.CreateAsync(new ResponsesCommandRequest(
+            "client-model",
+            "::",
+            [],
+            false,
+            null,
+            null,
+            null,
+            []), CallerScopeContext("token"));
+
+        result.Error.Should().BeNull();
+        routeDecisionPort.LastRequest.Should().NotBeNull();
+        routeDecisionPort.LastRequest!.CommandName.Should().BeEmpty();
+        var command = dispatch.Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
+        var recovery = AgentToolExecutionContextMapper.FromPayload(command.ToolContext).SkillRecovery;
+        recovery.DiscoveryRequested.Should().BeTrue();
+        recovery.CommandName.Should().BeNull();
+        recovery.PrimarySkillName.Should().BeNull();
+        recovery.OriginalCommand.Should().Be("::");
+    }
+
+    [Fact]
     public async Task StreamAsync_ShouldReturnUpstreamError_AndMarkSessionFailed()
     {
         var sessions = new RecordingSessionPort();
@@ -672,18 +736,20 @@ public sealed class ResponsesCommandFacadeTests
         string matchedRuleId = "")
         : IResponsesChatRouteDecisionPort
     {
+        public ResponsesChatRouteDecisionRequest? LastRequest { get; private set; }
+
         public Task<ChatRouteDecision> ResolveAsync(
-            ResponsesCallerScope callerScope,
-            string model,
-            ToolMode toolMode,
-            string contentHint,
+            ResponsesChatRouteDecisionRequest request,
             CancellationToken ct = default)
-            => Task.FromResult(new ChatRouteDecision
+        {
+            LastRequest = request;
+            return Task.FromResult(new ChatRouteDecision
             {
                 Action = action.Clone(),
                 UsedFallback = usedFallback,
                 MatchedRuleId = matchedRuleId,
             });
+        }
     }
 
     private sealed class EmptyToolSetRegistry : IToolSetRegistry

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
@@ -943,7 +943,6 @@ public sealed class ChannelConversationTurnRunnerTests
         result.LlmReplyRequest.Should().NotBeNull();
         result.LlmReplyRequest!.ReplyToken.Should().Be("relay-token-goal-1");
         result.LlmReplyRequest.Activity.Content.Text.Should().Contain("Ornn skill-backed command");
-        result.LlmReplyRequest.Activity.Content.Text.Should().Contain("ornn_search_skills");
         result.LlmReplyRequest.Activity.Content.Text.Should().Contain("use_skill");
         result.LlmReplyRequest.Activity.Content.Text.Should().Contain("goal");
         result.LlmReplyRequest.Activity.Content.Text.Should().Contain("ship command fix");
@@ -953,13 +952,16 @@ public sealed class ChannelConversationTurnRunnerTests
         recovery.RequireOrnnSearchOnBlocker.Should().BeTrue();
         recovery.CommandName.Should().Be("goal");
         recovery.OriginalCommand.Should().Be("/goal ship command fix");
+        recovery.PrimarySkillName.Should().Be("goal");
+        recovery.CommandArguments.Should().Be("ship command fix");
+        recovery.DiscoveryRequested.Should().BeFalse();
         recovery.MaxOrnnSearchAttempts.Should().Be(2);
         adapter.Replies.Should().BeEmpty();
         relayHandler.Requests.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task RunInboundAsync_ShouldRouteDailySlashCommandThroughGenericSkillDiscovery()
+    public async Task RunInboundAsync_ShouldRouteSlashAliasThroughGenericSkillRecovery()
     {
         var registrationQueryPort = BuildRegistrationQueryPort();
         var adapter = new RecordingPlatformAdapter();
@@ -994,14 +996,116 @@ public sealed class ChannelConversationTurnRunnerTests
         result.LlmReplyRequest.Should().NotBeNull();
         result.LlmReplyRequest!.ReplyToken.Should().Be("relay-token-daily-1");
         result.LlmReplyRequest.Activity.Content.Text.Should().Contain("Ornn skill-backed command");
-        result.LlmReplyRequest.Activity.Content.Text.Should().Contain("ornn_search_skills");
         result.LlmReplyRequest.Activity.Content.Text.Should().Contain("use_skill");
         result.LlmReplyRequest.Activity.Content.Text.Should().Contain("daily");
         result.LlmReplyRequest.Activity.Content.Text.Should().Contain("alice");
         result.LlmReplyRequest.Activity.Content.Text.Should().Contain("/daily alice");
         result.LlmReplyRequest.Activity.Content.Text.Should().NotContain("chrono-ai-daily");
+        var recovery = AgentToolExecutionContextMapper.FromPayload(result.LlmReplyRequest.ToolContext).SkillRecovery;
+        recovery.CommandName.Should().Be("daily");
+        recovery.PrimarySkillName.Should().Be("daily");
+        recovery.CommandArguments.Should().Be("alice");
+        recovery.OriginalCommand.Should().Be("/daily alice");
         adapter.Replies.Should().BeEmpty();
         relayHandler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RunInboundAsync_ShouldRouteCanonicalSkillTriggerAcrossChannels()
+    {
+        var registrationQueryPort = BuildRegistrationQueryPort();
+        var adapter = new RecordingPlatformAdapter();
+        var runner = CreateRunner(registrationQueryPort, adapter);
+
+        var result = await runner.RunInboundAsync(
+            BuildInboundActivity(
+                "::Goal ship command fix",
+                "msg-canonical-skill-1",
+                ConversationScope.DirectMessage,
+                "oc_p2p_chat_1",
+                transportExtras: new TransportExtras
+                {
+                    NyxPlatform = "telegram",
+                }),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.LlmReplyRequest.Should().NotBeNull();
+        result.LlmReplyRequest!.Activity.Content.Text.Should().Contain("`::goal`");
+        result.LlmReplyRequest.Activity.Content.Text.Should().Contain("use_skill");
+        result.LlmReplyRequest.Activity.Content.Text.Should().Contain("ship command fix");
+        var recovery = AgentToolExecutionContextMapper.FromPayload(result.LlmReplyRequest.ToolContext).SkillRecovery;
+        recovery.RequireInitialOrnnSearch.Should().BeTrue();
+        recovery.RequireOrnnSearchOnBlocker.Should().BeTrue();
+        recovery.CommandName.Should().Be("goal");
+        recovery.PrimarySkillName.Should().Be("goal");
+        recovery.CommandArguments.Should().Be("ship command fix");
+        recovery.OriginalCommand.Should().Be("::Goal ship command fix");
+        recovery.DiscoveryRequested.Should().BeFalse();
+        adapter.Replies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RunInboundAsync_ShouldAttachDiscoveryRecoveryForBareCanonicalTrigger()
+    {
+        var registrationQueryPort = BuildRegistrationQueryPort();
+        var adapter = new RecordingPlatformAdapter();
+        var runner = CreateRunner(registrationQueryPort, adapter);
+
+        var result = await runner.RunInboundAsync(
+            BuildInboundActivity(
+                "::",
+                "msg-canonical-discovery-1",
+                ConversationScope.DirectMessage,
+                "oc_p2p_chat_1",
+                transportExtras: new TransportExtras
+                {
+                    NyxPlatform = "telegram",
+                }),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.LlmReplyRequest.Should().NotBeNull();
+        result.LlmReplyRequest!.Activity.Content.Text.Should().Be("::");
+        var recovery = AgentToolExecutionContextMapper.FromPayload(result.LlmReplyRequest.ToolContext).SkillRecovery;
+        recovery.RequireInitialOrnnSearch.Should().BeTrue();
+        recovery.RequireOrnnSearchOnBlocker.Should().BeFalse();
+        recovery.CommandName.Should().BeNull();
+        recovery.PrimarySkillName.Should().BeNull();
+        recovery.CommandArguments.Should().BeNull();
+        recovery.OriginalCommand.Should().Be("::");
+        recovery.DiscoveryRequested.Should().BeTrue();
+        adapter.Replies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RunInboundAsync_ShouldTreatCanonicalModelTriggerAsSkillInvocation()
+    {
+        var registrationQueryPort = BuildRegistrationQueryPort();
+        var adapter = new RecordingPlatformAdapter();
+        var runner = CreateRunner(registrationQueryPort, adapter);
+
+        var result = await runner.RunInboundAsync(
+            BuildInboundActivity(
+                "::model status",
+                "msg-canonical-model-skill-1",
+                ConversationScope.DirectMessage,
+                "oc_p2p_chat_1",
+                transportExtras: new TransportExtras
+                {
+                    NyxPlatform = "lark",
+                }),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.LlmReplyRequest.Should().NotBeNull();
+        result.LlmReplyRequest!.Activity.Content.Text.Should().Contain("`::model`");
+        var recovery = AgentToolExecutionContextMapper.FromPayload(result.LlmReplyRequest.ToolContext).SkillRecovery;
+        recovery.CommandName.Should().Be("model");
+        recovery.PrimarySkillName.Should().Be("model");
+        recovery.CommandArguments.Should().Be("status");
+        recovery.OriginalCommand.Should().Be("::model status");
+        adapter.Replies.Should().BeEmpty();
     }
 
     [Fact]
@@ -1371,12 +1475,13 @@ public sealed class ChannelConversationTurnRunnerTests
 
         result.Success.Should().BeTrue();
         result.LlmReplyRequest.Should().NotBeNull();
-        result.LlmReplyRequest!.Activity.Content.Text.Should().Contain("ornn_search_skills");
+        result.LlmReplyRequest!.Activity.Content.Text.Should().Contain("use_skill");
         result.LlmReplyRequest.Activity.Content.Text.Should().Contain("foobar");
         var recovery = AgentToolExecutionContextMapper.FromPayload(result.LlmReplyRequest.ToolContext).SkillRecovery;
         recovery.RequireInitialOrnnSearch.Should().BeTrue();
         recovery.RequireOrnnSearchOnBlocker.Should().BeTrue();
         recovery.CommandName.Should().Be("foobar");
+        recovery.PrimarySkillName.Should().Be("foobar");
         adapter.Replies.Should().BeEmpty();
     }
 


### PR DESCRIPTION
## 问题
nyxid 直连 aevatar / codex 等 CLI 客户端，需要像 Lark `/daily` 一样用显式指令触发保存在 ornn 的 skill；但 `/` 被 codex 等 CLI 保留、`@` 被文件引用占用，且 `ChatRouteInput.command_name` 一直恒空（`ResponsesChatRouteDecisionPort` 硬编码 `string.Empty`）。显式 skill 调用此前仅靠 NyxID channel 的 slash-only 解析，直连 nyxid-chat 与 Responses/Messages/ChatCompletions 无统一入口。

## 方案（design-consensus structural framing）
canonical `::name` 触发约定，跨客户端一套语法；折叠进现有 skill 调用链，不开第二套主干：
- **typed 解析核心**（`src/Aevatar.AI.Abstractions/SkillInvocations/`）：`SkillInvocationTrigger` value object + 纯 `SkillInvocationTriggerParser` + `SkillInvocationTriggerOptions`（canonical `::`；channel alias：lark/web 含 `/`，cli 仅 `::`）。
- **typed/proto 字段**：`AgentSkillRecoveryContextPayload` 增 additive `command_arguments = 7`、`discovery_requested = 8`（保留 tag 1-6），避免 `OriginalCommand` 兼任“原文 + 参数 + discovery 信号”三义。
- **边界分离**：Application 解析一次，route-decision port 只收归一化 `string CommandName`（→ 填 `ChatRouteInput.command_name`）；args/discovery 进 `AgentSkillRecoveryContext` → `SkillRecoveryPlanner` → `use_skill` → `ornn_search_skills`。`::` discovery 时 route command 为空。
- 三入口 facades + channel relay（`ChannelConversationTurnRunner`）+ 直连 nyxid-chat（`NyxIdChatInteraction`）复用同一 parser；Lark/Web `/name` 保留为别名，注册的本地 slash command 仍优先。
- **零** NyxID/chrono-ornn 改动，**零**硬编码 skill 名，不把 `.refactor-loop/host.env` 当 SSOT。

## 影响路径
新增 `SkillInvocations/{SkillInvocationTrigger,SkillInvocationTriggerOptions,SkillInvocationTriggerParser}.cs`；改 `ai_messages.proto`、`AgentToolExecutionContext(.Mapper).cs`、`SkillRecoveryPlanner.cs`、`Responses/{ResponsesCommandContracts,Responses/Messages/ChatCompletionsCommandFacade}.cs`、`Host.Api/Responses/{ResponsesRouteResolver,ResponsesEndpoints}.cs`、NyxidChat 三文件、`docs/canon/nyxid-responses-direct.md`。共 25 文件（含测试）`+1093 / -109`。

## 验证
- `dotnet build aevatar.slnx --nologo`：**0 errors**。
- 测试：Aevatar.AI.Tests 780 · GAgentService.Tests 713 · ChannelRuntime.Tests 987 · Hosting.Tests 259 · ChatRouting.Core.Tests 45 · GAgents.ChatRouting.Tests 29 = **2813 passed / 0 failed**（含新增 `SkillInvocationTriggerParserTests` + mapper proto round-trip）。
- `tools/ci/test_stability_guards.sh` ✅、`tools/ci/architecture_guards.sh`（含 docs lint）✅、`git diff --check` ✅。

## 偏差（scope-respecting）
- 未改 `chat_route_policy.proto`（consensus 仅列注释级澄清，超出硬作用域）。
- 未在 composition root 注册 `SkillInvocationTriggerOptions`（默认值即可工作；host 配置化留作后续）。

## 设计来源
经 consensus-rnd design-consensus（minimal/structural/delete × 3 轮 + 3 meta-judge）收敛产出，全过程记录见 #1762 评论。

Closes #1762 （注：base 为 `feature/integrate` 非默认分支，合并不会自动关闭，仅作关联）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
