### PR TITLE
feat(#1766): skill 自带 C# script 资产发现/编译/执行桥接

### DIFF
--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnRemoteSkillFetcher.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnRemoteSkillFetcher.cs
@@ -50,6 +50,10 @@ public sealed class OrnnRemoteSkillFetcher : IRemoteSkillFetcher
         var workflows = DiscoverWorkflows(skill.Files, parsed.WorkflowEntry);
         if (workflows.Count == 0)
             workflows = extraction.Workflows;
+        var scriptExtraction = new SkillScriptExtractor().ExtractFromFiles(
+            parsed.Name ?? skill.Name ?? nameOrId,
+            parsed.ScriptEntry,
+            extraction.RemainingFiles);
 
         return new SkillDefinition
         {
@@ -62,8 +66,9 @@ public sealed class OrnnRemoteSkillFetcher : IRemoteSkillFetcher
             WhenToUse = parsed.WhenToUse,
             IsModelInvocable = parsed.IsModelInvocable,
             IsUserInvocable = parsed.IsUserInvocable,
-            AssociatedFiles = extraction.RemainingFiles,
+            AssociatedFiles = scriptExtraction.RemainingFiles,
             Workflows = workflows,
+            Scripts = scriptExtraction.Scripts,
         };
     }
 

--- a/src/Aevatar.AI.ToolProviders.Scripting/Ports/IScriptCompilationPort.cs
+++ b/src/Aevatar.AI.ToolProviders.Scripting/Ports/IScriptCompilationPort.cs
@@ -22,6 +22,9 @@ public sealed record ScriptCompilationRequest
 
     /// <summary>Optional protobuf files keyed by filename.</summary>
     public IReadOnlyDictionary<string, string>? ProtoFiles { get; init; }
+
+    /// <summary>Optional behavior type name used to select the script package entry behavior.</summary>
+    public string? EntryBehaviorTypeName { get; init; }
 }
 
 /// <summary>Result of a script compilation.</summary>

--- a/src/Aevatar.AI.ToolProviders.Scripting/Tools/ScriptCompileTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Scripting/Tools/ScriptCompileTool.cs
@@ -45,6 +45,10 @@ public sealed class ScriptCompileTool : IAgentTool
               "type": "object",
               "description": "Optional protobuf files keyed by filename",
               "additionalProperties": { "type": "string" }
+            },
+            "entry_behavior_type_name": {
+              "type": "string",
+              "description": "Optional behavior type name to use as the script package entry."
             }
           },
           "required": ["script_id", "source_files"]
@@ -79,6 +83,7 @@ public sealed class ScriptCompileTool : IAgentTool
                 ScriptId = scriptId,
                 SourceFiles = sourceFiles,
                 ProtoFiles = args.StrDict("proto_files"),
+                EntryBehaviorTypeName = args.Str("entry_behavior_type_name"),
             };
 
             var result = await _compilationPort.CompileAsync(request, ct);

--- a/src/Aevatar.AI.ToolProviders.Skills/SkillDefinition.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/SkillDefinition.cs
@@ -61,6 +61,9 @@ public sealed class SkillDefinition
 
     /// <summary>技能附带的可运行 workflow YAML 描述。</summary>
     public IReadOnlyList<SkillWorkflowDescriptor> Workflows { get; init; } = [];
+
+    /// <summary>技能附带的可编译 C# script 描述。</summary>
+    public IReadOnlyList<SkillScriptDescriptor> Scripts { get; init; } = [];
 }
 
 /// <summary>
@@ -73,4 +76,22 @@ public sealed class SkillWorkflowDescriptor
 
     /// <summary>Workflow YAML bundle passed to aevatar_start_workflow.workflow_yamls in stable path order.</summary>
     public required IReadOnlyList<string> WorkflowYamls { get; init; }
+}
+
+/// <summary>
+/// Skill package C# script handoff descriptor.
+/// </summary>
+public sealed class SkillScriptDescriptor
+{
+    /// <summary>Script identifier passed to script_compile.script_id and script_execute.script_id.</summary>
+    public required string ScriptId { get; init; }
+
+    /// <summary>C# source files passed to script_compile.source_files in stable path order.</summary>
+    public required IReadOnlyDictionary<string, string> SourceFiles { get; init; }
+
+    /// <summary>Protobuf files passed to script_compile.proto_files in stable path order.</summary>
+    public required IReadOnlyDictionary<string, string> ProtoFiles { get; init; }
+
+    /// <summary>Optional behavior type name passed to script_compile.entry_behavior_type_name.</summary>
+    public string EntryBehaviorTypeName { get; init; } = "";
 }

--- a/src/Aevatar.AI.ToolProviders.Skills/SkillDiscovery.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/SkillDiscovery.cs
@@ -16,15 +16,18 @@ public sealed class SkillDiscovery
 {
     private readonly SkillFrontmatterParser _parser;
     private readonly SkillWorkflowExtractor _workflowExtractor;
+    private readonly SkillScriptExtractor _scriptExtractor;
     private readonly ILogger _logger;
 
     public SkillDiscovery(
         SkillFrontmatterParser? parser = null,
         SkillWorkflowExtractor? workflowExtractor = null,
+        SkillScriptExtractor? scriptExtractor = null,
         ILogger? logger = null)
     {
         _parser = parser ?? new SkillFrontmatterParser();
         _workflowExtractor = workflowExtractor ?? new SkillWorkflowExtractor();
+        _scriptExtractor = scriptExtractor ?? new SkillScriptExtractor();
         _logger = logger ?? NullLogger.Instance;
     }
 
@@ -95,6 +98,9 @@ public sealed class SkillDiscovery
         var workflows = string.IsNullOrEmpty(skillDir)
             ? []
             : _workflowExtractor.ExtractFromDirectory(skillDir);
+        var scripts = string.IsNullOrEmpty(skillDir)
+            ? []
+            : _scriptExtractor.ExtractFromDirectory(skillDir, name, parsed.ScriptEntry);
 
         return new SkillDefinition
         {
@@ -108,6 +114,7 @@ public sealed class SkillDiscovery
             IsModelInvocable = parsed.IsModelInvocable,
             IsUserInvocable = parsed.IsUserInvocable,
             Workflows = workflows,
+            Scripts = scripts,
         };
     }
 }

--- a/src/Aevatar.AI.ToolProviders.Skills/SkillFrontmatterParser.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/SkillFrontmatterParser.cs
@@ -34,6 +34,9 @@ public sealed class SkillParseResult
     /// <summary>Frontmatter 中的 workflow entry hint.</summary>
     public string? WorkflowEntry { get; init; }
 
+    /// <summary>Frontmatter 中的 script entry behavior type hint.</summary>
+    public string? ScriptEntry { get; init; }
+
     /// <summary>是否存在 frontmatter。</summary>
     public bool HasFrontmatter { get; init; }
 }
@@ -86,7 +89,7 @@ public sealed class SkillFrontmatterParser
         var body = bodyStart < rest.Length ? rest[bodyStart..].TrimStart('\n') : "";
 
         // 解析 frontmatter 键值对
-        string? name = null, description = null, arguments = null, whenToUse = null, workflowEntry = null;
+        string? name = null, description = null, arguments = null, whenToUse = null, workflowEntry = null, scriptEntry = null;
         var isModelInvocable = true;
         var isUserInvocable = true;
 
@@ -128,6 +131,9 @@ public sealed class SkillFrontmatterParser
                 case "workflow" or "workflow-id" or "workflow_id":
                     workflowEntry = value;
                     break;
+                case "script" or "script-entry" or "script_entry" or "scriptentry":
+                    scriptEntry = value;
+                    break;
                 case "disable-model-invocation" or "disable_model_invocation":
                     isModelInvocable = !ParseBool(value);
                     break;
@@ -146,6 +152,7 @@ public sealed class SkillFrontmatterParser
             IsModelInvocable = isModelInvocable,
             IsUserInvocable = isUserInvocable,
             WorkflowEntry = workflowEntry,
+            ScriptEntry = scriptEntry,
             Body = body,
             HasFrontmatter = true,
         };

--- a/src/Aevatar.AI.ToolProviders.Skills/SkillScriptExtractor.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/SkillScriptExtractor.cs
@@ -1,0 +1,206 @@
+namespace Aevatar.AI.ToolProviders.Skills;
+
+/// <summary>
+/// C# script extraction result plus files that should remain generic attachments.
+/// </summary>
+public sealed class SkillScriptExtractionResult
+{
+    public required IReadOnlyList<SkillScriptDescriptor> Scripts { get; init; }
+
+    /// <summary>
+    /// Files not consumed as script source or protobuf input; null when no files remain.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? RemainingFiles { get; init; }
+}
+
+/// <summary>
+/// Extracts typed C# script assets from skill packages.
+/// </summary>
+public sealed class SkillScriptExtractor
+{
+    private const string ScriptsDir = "scripts";
+    private const string AssetsDir = "assets";
+    private static readonly char[] PathSeparators = ['/', '\\'];
+
+    public SkillScriptExtractionResult ExtractFromFiles(
+        string skillName,
+        string? scriptEntry,
+        IReadOnlyDictionary<string, string>? files)
+    {
+        if (files == null || files.Count == 0)
+            return new SkillScriptExtractionResult { Scripts = [], RemainingFiles = files };
+
+        var scriptCandidates = GetCandidateScriptFiles(files, ScriptsDir);
+        var protoBoundary = ScriptsDir;
+        if (scriptCandidates.Count == 0)
+        {
+            scriptCandidates = GetCandidateScriptFiles(files, AssetsDir);
+            protoBoundary = AssetsDir;
+        }
+
+        if (scriptCandidates.Count == 0)
+            return new SkillScriptExtractionResult { Scripts = [], RemainingFiles = files };
+
+        var protoFiles = files
+            .Where(kv => IsDirectChildOf(kv.Key, protoBoundary) && IsProtoFile(kv.Key))
+            .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+            .ToDictionary(kv => NormalizePath(kv.Key), kv => kv.Value.Trim(), StringComparer.Ordinal);
+
+        var sourceFiles = scriptCandidates
+            .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+            .ToDictionary(kv => NormalizePath(kv.Key), kv => kv.Value, StringComparer.Ordinal);
+
+        var consumedKeys = scriptCandidates
+            .Select(kv => kv.Key)
+            .Concat(files
+                .Where(kv => IsDirectChildOf(kv.Key, protoBoundary) && IsProtoFile(kv.Key))
+                .Select(kv => kv.Key))
+            .ToHashSet(StringComparer.Ordinal);
+
+        return new SkillScriptExtractionResult
+        {
+            Scripts =
+            [
+                new SkillScriptDescriptor
+                {
+                    ScriptId = BuildScriptId(skillName, sourceFiles.Keys.First()),
+                    SourceFiles = sourceFiles,
+                    ProtoFiles = protoFiles,
+                    EntryBehaviorTypeName = scriptEntry?.Trim() ?? string.Empty,
+                }
+            ],
+            RemainingFiles = BuildRemainingFiles(files, consumedKeys),
+        };
+    }
+
+    public IReadOnlyList<SkillScriptDescriptor> ExtractFromDirectory(
+        string skillDir,
+        string skillName,
+        string? scriptEntry)
+    {
+        if (string.IsNullOrWhiteSpace(skillDir) || !Directory.Exists(skillDir))
+            return [];
+
+        var extraction = ExtractFromFiles(skillName, scriptEntry, ReadDirectoryFiles(skillDir, ScriptsDir));
+        if (extraction.Scripts.Count > 0)
+            return extraction.Scripts;
+
+        return ExtractFromFiles(skillName, scriptEntry, ReadDirectoryFiles(skillDir, AssetsDir)).Scripts;
+    }
+
+    private static List<KeyValuePair<string, string>> GetCandidateScriptFiles(
+        IReadOnlyDictionary<string, string> files,
+        string dirName)
+    {
+        return files
+            .Where(kv => IsDirectChildOf(kv.Key, dirName) &&
+                         IsCSharpFile(kv.Key) &&
+                         !string.IsNullOrWhiteSpace(kv.Value))
+            .ToList();
+    }
+
+    private static IReadOnlyDictionary<string, string> ReadDirectoryFiles(string skillDir, string dirName)
+    {
+        var dir = Path.Combine(skillDir, dirName);
+        if (!Directory.Exists(dir))
+            return new Dictionary<string, string>(StringComparer.Ordinal);
+
+        var files = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var path in Directory.EnumerateFiles(dir, "*", SearchOption.TopDirectoryOnly))
+        {
+            if (!IsCSharpFile(path) && !IsProtoFile(path))
+                continue;
+
+            var relativePath = Path.GetRelativePath(skillDir, path).Replace('\\', '/');
+            try
+            {
+                files[relativePath] = File.ReadAllText(path);
+            }
+            catch
+            {
+                // Local discovery should ignore unreadable optional assets.
+            }
+        }
+
+        return files;
+    }
+
+    private static IReadOnlyDictionary<string, string>? BuildRemainingFiles(
+        IReadOnlyDictionary<string, string> files,
+        HashSet<string> consumedKeys)
+    {
+        if (consumedKeys.Count >= files.Count)
+            return null;
+
+        var remaining = files
+            .Where(kv => !consumedKeys.Contains(kv.Key))
+            .ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.Ordinal);
+
+        return remaining.Count == 0 ? null : remaining;
+    }
+
+    private static string BuildScriptId(string skillName, string entryFilePath)
+    {
+        var normalizedSkill = Slugify(skillName);
+        var entryFileId = Slugify(Path.GetFileNameWithoutExtension(
+            entryFilePath.Split(PathSeparators, StringSplitOptions.RemoveEmptyEntries).LastOrDefault() ?? entryFilePath));
+
+        if (string.IsNullOrEmpty(normalizedSkill))
+            normalizedSkill = "skill";
+        if (string.IsNullOrEmpty(entryFileId))
+            entryFileId = "script";
+
+        return $"{normalizedSkill}-{entryFileId}";
+    }
+
+    private static string Slugify(string value)
+    {
+        var chars = new List<char>(value.Length);
+        var previousDash = false;
+
+        foreach (var c in value.Trim())
+        {
+            if (char.IsLetterOrDigit(c))
+            {
+                chars.Add(char.ToLowerInvariant(c));
+                previousDash = false;
+            }
+            else if (!previousDash && chars.Count > 0)
+            {
+                chars.Add('-');
+                previousDash = true;
+            }
+        }
+
+        if (chars.Count > 0 && chars[^1] == '-')
+            chars.RemoveAt(chars.Count - 1);
+
+        return new string(chars.ToArray());
+    }
+
+    private static bool IsDirectChildOf(string key, string dirName)
+    {
+        if (string.IsNullOrEmpty(key))
+            return false;
+
+        var normalized = NormalizePath(key);
+        var prefixLen = dirName.Length;
+        if (normalized.Length <= prefixLen)
+            return false;
+        if (!normalized.AsSpan(0, prefixLen).Equals(dirName, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (normalized[prefixLen] != '/')
+            return false;
+
+        return !normalized[(prefixLen + 1)..].Contains('/');
+    }
+
+    private static bool IsCSharpFile(string path) =>
+        path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsProtoFile(string path) =>
+        path.EndsWith(".proto", StringComparison.OrdinalIgnoreCase);
+
+    private static string NormalizePath(string path) => path.Replace('\\', '/');
+}

--- a/src/Aevatar.AI.ToolProviders.Skills/UseSkillTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/UseSkillTool.cs
@@ -398,6 +398,42 @@ public sealed class UseSkillTool : IAgentTool
             }
         }
 
+        if (skill.Scripts.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("## script_compile/script_execute Handoff");
+            sb.AppendLine();
+            sb.AppendLine("Call `script_compile` with the inline script package before calling `script_execute` for the user task.");
+
+            foreach (var script in skill.Scripts)
+            {
+                var compilePayload = new
+                {
+                    script_id = script.ScriptId,
+                    source_files = script.SourceFiles,
+                    proto_files = script.ProtoFiles,
+                    entry_behavior_type_name = script.EntryBehaviorTypeName,
+                };
+
+                var executePayload = new
+                {
+                    script_id = script.ScriptId,
+                    input = "Use the current user request and skill arguments.",
+                };
+
+                sb.AppendLine();
+                sb.AppendLine("### script_compile");
+                sb.AppendLine("```json");
+                sb.AppendLine(JsonSerializer.Serialize(compilePayload, new JsonSerializerOptions { WriteIndented = true }));
+                sb.AppendLine("```");
+                sb.AppendLine();
+                sb.AppendLine("### script_execute");
+                sb.AppendLine("```json");
+                sb.AppendLine(JsonSerializer.Serialize(executePayload, new JsonSerializerOptions { WriteIndented = true }));
+                sb.AppendLine("```");
+            }
+        }
+
         // 附带关联文件
         if (skill.AssociatedFiles is { Count: > 0 })
         {

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/Aevatar.AI.ToolProviders.Ornn.Tests.csproj
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/Aevatar.AI.ToolProviders.Ornn.Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Aevatar.AI.ToolProviders.Ornn\Aevatar.AI.ToolProviders.Ornn.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.AI.ToolProviders.Skills\Aevatar.AI.ToolProviders.Skills.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.AI.ToolProviders.Scripting\Aevatar.AI.ToolProviders.Scripting.csproj" />
     <ProjectReference Include="..\..\src\platform\Aevatar.GAgentService.Abstractions\Aevatar.GAgentService.Abstractions.csproj" />
     <!--
       Explicit reference: tests instantiate NyxIdApiClient / NyxIdToolOptions directly

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnSkillClientTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnSkillClientTests.cs
@@ -196,6 +196,47 @@ public sealed class OrnnSkillClientTests
     }
 
     [Fact]
+    public async Task RemoteSkillFetcher_LiftsScriptsIntoTypedDescriptorAndKeepsCallerToken()
+    {
+        var handler = OrnnTestHttpMessageHandler.ReturningJson("""
+            {
+              "data": {
+                "name": "Script Skill",
+                "description": "Runs script",
+                "files": {
+                  "SKILL.md": "---\nname: script-skill\nscriptEntry: Zeta.EntryBehavior\n---\nRun it.",
+                  "scripts/a-helper.cs": "public sealed class HelperBehavior {}",
+                  "scripts/z-entry.cs": "public sealed class EntryBehavior {}",
+                  "scripts/contract.proto": "syntax = \"proto3\";",
+                  "assets/fallback.cs": "public sealed class FallbackBehavior {}",
+                  "docs/readme.md": "reference"
+                }
+              }
+            }
+            """);
+        var fetcher = new OrnnRemoteSkillFetcher(CreateClient(handler));
+
+        var skill = await fetcher.FetchSkillAsync("access-token", "Script Skill");
+
+        skill.Should().NotBeNull();
+        var script = skill!.Scripts.Should().ContainSingle().Subject;
+        script.ScriptId.Should().Be("script-skill-a-helper");
+        script.SourceFiles.Keys.Should().Equal("scripts/a-helper.cs", "scripts/z-entry.cs");
+        script.ProtoFiles.Should().ContainSingle()
+            .Which.Should().Be(new KeyValuePair<string, string>(
+                "scripts/contract.proto",
+                "syntax = \"proto3\";"));
+        script.EntryBehaviorTypeName.Should().Be("Zeta.EntryBehavior");
+        skill.AssociatedFiles.Should().ContainKeys("assets/fallback.cs", "docs/readme.md");
+        skill.AssociatedFiles.Should().NotContainKey("scripts/a-helper.cs");
+        skill.AssociatedFiles.Should().NotContainKey("scripts/z-entry.cs");
+        skill.AssociatedFiles.Should().NotContainKey("scripts/contract.proto");
+
+        handler.Requests.Should().ContainSingle()
+            .Which.Authorization!.Parameter.Should().Be("access-token");
+    }
+
+    [Fact]
     public async Task RemoteSkillFetcher_DefaultsWorkflowIdToFirstSortedWorkflowFileNameWithoutFrontmatterEntry()
     {
         var handler = OrnnTestHttpMessageHandler.ReturningJson("""

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/ScriptCompileToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/ScriptCompileToolTests.cs
@@ -46,7 +46,6 @@ public sealed class ScriptCompileToolTests
             .Should().Be("scripts/Main.cs(1,1): error CS1002: ; expected");
     }
 
-    // refactor helper, no behavior change
     private sealed class RecordingCompilationAdapter : IScriptToolCompilationAdapter
     {
         public List<ScriptCompilationRequest> Requests { get; } = [];

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/ScriptCompileToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/ScriptCompileToolTests.cs
@@ -1,0 +1,67 @@
+using Aevatar.AI.ToolProviders.Scripting;
+using Aevatar.AI.ToolProviders.Scripting.Ports;
+using Aevatar.AI.ToolProviders.Scripting.Tools;
+using FluentAssertions;
+using System.Text.Json;
+
+namespace Aevatar.AI.ToolProviders.Ornn.Tests;
+
+public sealed class ScriptCompileToolTests
+{
+    [Fact]
+    public async Task ExecuteAsync_ForwardsEntryBehaviorTypeNameAndReturnsFileDiagnostics()
+    {
+        var adapter = new RecordingCompilationAdapter();
+        var tool = new ScriptCompileTool(adapter, new ScriptingToolOptions());
+
+        var output = await tool.ExecuteAsync("""
+            {
+              "script_id": "scripted-main",
+              "source_files": {
+                "scripts/Main.cs": "public sealed class MainBehavior {}"
+              },
+              "proto_files": {
+                "scripts/contract.proto": "syntax = \"proto3\";"
+              },
+              "entry_behavior_type_name": "MainBehavior"
+            }
+            """);
+
+        adapter.Requests.Should().ContainSingle();
+        var request = adapter.Requests[0];
+        request.ScriptId.Should().Be("scripted-main");
+        request.SourceFiles.Should().ContainSingle()
+            .Which.Should().Be(new KeyValuePair<string, string>(
+                "scripts/Main.cs",
+                "public sealed class MainBehavior {}"));
+        request.ProtoFiles.Should().ContainSingle()
+            .Which.Should().Be(new KeyValuePair<string, string>(
+                "scripts/contract.proto",
+                "syntax = \"proto3\";"));
+        request.EntryBehaviorTypeName.Should().Be("MainBehavior");
+
+        using var doc = JsonDocument.Parse(output);
+        doc.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+        doc.RootElement.GetProperty("diagnostics")[0].GetString()
+            .Should().Be("scripts/Main.cs(1,1): error CS1002: ; expected");
+    }
+
+    // refactor helper, no behavior change
+    private sealed class RecordingCompilationAdapter : IScriptToolCompilationAdapter
+    {
+        public List<ScriptCompilationRequest> Requests { get; } = [];
+
+        public Task<ScriptCompilationResult> CompileAsync(
+            ScriptCompilationRequest request,
+            CancellationToken ct = default)
+        {
+            Requests.Add(request);
+            return Task.FromResult(new ScriptCompilationResult
+            {
+                Success = false,
+                ScriptId = request.ScriptId,
+                Diagnostics = ["scripts/Main.cs(1,1): error CS1002: ; expected"],
+            });
+        }
+    }
+}

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/SkillScriptExtractorTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/SkillScriptExtractorTests.cs
@@ -159,7 +159,6 @@ public sealed class SkillScriptExtractorTests
         script.EntryBehaviorTypeName.Should().Be("Local.EntryBehavior");
     }
 
-    // refactor helper, no behavior change
     private sealed class TempDirectory : IDisposable
     {
         public string Path { get; }

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/SkillScriptExtractorTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/SkillScriptExtractorTests.cs
@@ -1,0 +1,185 @@
+using Aevatar.AI.ToolProviders.Skills;
+using FluentAssertions;
+
+namespace Aevatar.AI.ToolProviders.Ornn.Tests;
+
+public sealed class SkillScriptExtractorTests
+{
+    [Fact]
+    public void ExtractFromFiles_PrefersScriptsDirectoryOverAssets()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["scripts/Main.cs"] = "public sealed class MainBehavior {}",
+            ["scripts/model.proto"] = "syntax = \"proto3\";",
+            ["assets/Legacy.cs"] = "public sealed class LegacyBehavior {}",
+            ["assets/model.proto"] = "syntax = \"proto3\";",
+            ["docs/readme.md"] = "reference",
+        };
+
+        var result = new SkillScriptExtractor().ExtractFromFiles("Daily Skill", null, files);
+
+        var script = result.Scripts.Should().ContainSingle().Subject;
+        script.ScriptId.Should().Be("daily-skill-main");
+        script.SourceFiles.Should().ContainSingle()
+            .Which.Should().Be(new KeyValuePair<string, string>(
+                "scripts/Main.cs",
+                "public sealed class MainBehavior {}"));
+        script.ProtoFiles.Should().ContainSingle()
+            .Which.Should().Be(new KeyValuePair<string, string>(
+                "scripts/model.proto",
+                "syntax = \"proto3\";"));
+        result.RemainingFiles.Should().ContainKeys(
+            "assets/Legacy.cs",
+            "assets/model.proto",
+            "docs/readme.md");
+        result.RemainingFiles.Should().NotContainKey("scripts/Main.cs");
+        result.RemainingFiles.Should().NotContainKey("scripts/model.proto");
+    }
+
+    [Fact]
+    public void ExtractFromFiles_FallsBackToAssetsWhenScriptsDirectoryHasNoSource()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["scripts/README.md"] = "docs",
+            ["assets/Run.cs"] = "public sealed class RunBehavior {}",
+            ["assets/run.proto"] = "syntax = \"proto3\";",
+            ["assets/nested/Ignored.cs"] = "public sealed class NestedBehavior {}",
+        };
+
+        var result = new SkillScriptExtractor().ExtractFromFiles("Skill Name", null, files);
+
+        var script = result.Scripts.Should().ContainSingle().Subject;
+        script.ScriptId.Should().Be("skill-name-run");
+        script.SourceFiles.Should().ContainSingle().Which.Key.Should().Be("assets/Run.cs");
+        script.ProtoFiles.Should().ContainSingle().Which.Key.Should().Be("assets/run.proto");
+        result.RemainingFiles.Should().ContainKeys("scripts/README.md", "assets/nested/Ignored.cs");
+        result.RemainingFiles.Should().NotContainKey("assets/Run.cs");
+        result.RemainingFiles.Should().NotContainKey("assets/run.proto");
+    }
+
+    [Fact]
+    public void ExtractFromFiles_IgnoresBlankCSharpAndDoesNotConsumeItsProto()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["scripts/Blank.cs"] = " \n\t ",
+            ["scripts/model.proto"] = "syntax = \"proto3\";",
+            ["assets/Fallback.cs"] = "public sealed class FallbackBehavior {}",
+            ["assets/fallback.proto"] = "syntax = \"proto3\";",
+        };
+
+        var result = new SkillScriptExtractor().ExtractFromFiles("Blank Skill", null, files);
+
+        var script = result.Scripts.Should().ContainSingle().Subject;
+        script.SourceFiles.Should().ContainSingle().Which.Key.Should().Be("assets/Fallback.cs");
+        script.ProtoFiles.Should().ContainSingle().Which.Key.Should().Be("assets/fallback.proto");
+        result.RemainingFiles.Should().ContainKeys("scripts/Blank.cs", "scripts/model.proto");
+    }
+
+    [Fact]
+    public void ExtractFromFiles_PropagatesScriptEntry()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["scripts/Entry.cs"] = "public sealed class EntryBehavior {}",
+        };
+
+        var result = new SkillScriptExtractor().ExtractFromFiles("Entry Skill", "My.Namespace.EntryBehavior", files);
+
+        result.Scripts.Should().ContainSingle()
+            .Which.EntryBehaviorTypeName.Should().Be("My.Namespace.EntryBehavior");
+    }
+
+    [Fact]
+    public void ExtractFromFiles_ReturnsNullRemainingWhenAllFilesAreConsumed()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["scripts/Main.cs"] = "public sealed class MainBehavior {}",
+            ["scripts/model.proto"] = "syntax = \"proto3\";",
+        };
+
+        var result = new SkillScriptExtractor().ExtractFromFiles("Skill", null, files);
+
+        result.Scripts.Should().ContainSingle();
+        result.RemainingFiles.Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractFromDirectory_ReadsScriptsDirectoryAndEntryHint()
+    {
+        using var tempDir = new TempDirectory();
+        var scriptsDir = Path.Combine(tempDir.Path, "scripts");
+        Directory.CreateDirectory(scriptsDir);
+        File.WriteAllText(
+            Path.Combine(scriptsDir, "Main.cs"),
+            "public sealed class MainBehavior {}");
+        File.WriteAllText(
+            Path.Combine(scriptsDir, "contract.proto"),
+            "syntax = \"proto3\";");
+
+        var scripts = new SkillScriptExtractor().ExtractFromDirectory(
+            tempDir.Path,
+            "Local Skill",
+            "MainBehavior");
+
+        var script = scripts.Should().ContainSingle().Subject;
+        script.ScriptId.Should().Be("local-skill-main");
+        script.SourceFiles.Should().ContainSingle().Which.Key.Should().Be("scripts/Main.cs");
+        script.ProtoFiles.Should().ContainSingle().Which.Key.Should().Be("scripts/contract.proto");
+        script.EntryBehaviorTypeName.Should().Be("MainBehavior");
+    }
+
+    [Fact]
+    public void SkillDiscovery_PopulatesScriptsFromSkillDirectory()
+    {
+        using var tempDir = new TempDirectory();
+        var skillDir = Path.Combine(tempDir.Path, "skill");
+        Directory.CreateDirectory(skillDir);
+        File.WriteAllText(Path.Combine(skillDir, "SKILL.md"), """
+            ---
+            name: local-script
+            scriptEntry: Local.EntryBehavior
+            ---
+            Use script.
+            """);
+        var scriptsDir = Path.Combine(skillDir, "scripts");
+        Directory.CreateDirectory(scriptsDir);
+        File.WriteAllText(
+            Path.Combine(scriptsDir, "Entry.cs"),
+            "public sealed class EntryBehavior {}");
+
+        var skills = new SkillDiscovery().ScanDirectory(tempDir.Path);
+
+        var script = skills.Should().ContainSingle().Subject.Scripts.Should().ContainSingle().Subject;
+        script.ScriptId.Should().Be("local-script-entry");
+        script.SourceFiles.Should().ContainSingle().Which.Key.Should().Be("scripts/Entry.cs");
+        script.EntryBehaviorTypeName.Should().Be("Local.EntryBehavior");
+    }
+
+    // refactor helper, no behavior change
+    private sealed class TempDirectory : IDisposable
+    {
+        public string Path { get; }
+
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+            catch
+            {
+                // best effort
+            }
+        }
+    }
+}

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/SkillWorkflowsWiringTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/SkillWorkflowsWiringTests.cs
@@ -127,6 +127,88 @@ public sealed class SkillWorkflowsWiringTests
     }
 
     [Fact]
+    public async Task UseSkillTool_RendersScriptHandoffAfterWorkflowAndBeforeAssociatedFiles()
+    {
+        var catalog = new LocalSkillCatalog();
+        catalog.Register(new SkillDefinition
+        {
+            Name = "scripted",
+            Description = "Runs script",
+            Instructions = "Follow these steps.",
+            Source = SkillSource.Local,
+            Workflows =
+            [
+                new SkillWorkflowDescriptor
+                {
+                    WorkflowId = "prepare",
+                    WorkflowYamls = ["name: prepare\nsteps: []\n"],
+                },
+            ],
+            Scripts =
+            [
+                new SkillScriptDescriptor
+                {
+                    ScriptId = "scripted-main",
+                    SourceFiles = new Dictionary<string, string>
+                    {
+                        ["scripts/Main.cs"] = "public sealed class MainBehavior {}",
+                    },
+                    ProtoFiles = new Dictionary<string, string>
+                    {
+                        ["scripts/contract.proto"] = "syntax = \"proto3\";",
+                    },
+                    EntryBehaviorTypeName = "MainBehavior",
+                },
+            ],
+            AssociatedFiles = new Dictionary<string, string>
+            {
+                ["docs/readme.md"] = "reference",
+            },
+        });
+
+        var tool = new UseSkillTool(catalog);
+        var output = await tool.ExecuteAsync("""{"skill":"scripted"}""");
+        var text = ExtractText(output);
+
+        text.Should().Contain("## script_compile/script_execute Handoff");
+        text.Should().Contain("Call `script_compile`");
+        text.Should().Contain("### script_compile");
+        text.Should().Contain("\"script_id\": \"scripted-main\"");
+        text.Should().Contain("\"source_files\"");
+        text.Should().Contain("\"scripts/Main.cs\"");
+        text.Should().Contain("\"proto_files\"");
+        text.Should().Contain("\"scripts/contract.proto\"");
+        text.Should().Contain("\"entry_behavior_type_name\": \"MainBehavior\"");
+        text.Should().Contain("### script_execute");
+        text.Should().Contain("\"input\": \"Use the current user request and skill arguments.\"");
+
+        text.IndexOf("## aevatar_start_workflow Handoff", StringComparison.Ordinal)
+            .Should().BeLessThan(text.IndexOf("## script_compile/script_execute Handoff", StringComparison.Ordinal));
+        text.IndexOf("## script_compile/script_execute Handoff", StringComparison.Ordinal)
+            .Should().BeLessThan(text.IndexOf("## Associated Files", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task UseSkillTool_OmitsScriptHandoffWhenSkillHasNoScripts()
+    {
+        var catalog = new LocalSkillCatalog();
+        catalog.Register(new SkillDefinition
+        {
+            Name = "plain",
+            Description = "no scripts",
+            Instructions = "body",
+            Source = SkillSource.Local,
+        });
+
+        var tool = new UseSkillTool(catalog);
+        var output = await tool.ExecuteAsync("""{"skill":"plain"}""");
+        var text = ExtractText(output);
+
+        text.Should().NotContain("## script_compile/script_execute Handoff");
+        text.Should().NotContain("script_compile");
+    }
+
+    [Fact]
     public async Task UseSkillTool_MountWorkflowsFalse_DoesNotRequireApprovalAndDoesNotCallCommandPort()
     {
         var catalog = CreateCatalogWithWorkflowSkill();


### PR DESCRIPTION
## 摘要

skill 自带 C# script 资产（`scripts/*.cs`，回退 `assets/*.cs`）现可被**发现 → 编译 → 执行**，对称 #1761 的 workflow 侧。

- **Old**：skill 的 `.cs` 被 ornn 当 generic files 原样返回，aevatar 侧无环节识别为可执行脚本（不抬升 descriptor、不在 `use_skill` 呈现、不编译/执行）。
- **New**：抬升为强类型 `SkillScriptDescriptor` + `SkillDefinition.Scripts`；本地/远程共用 `SkillScriptExtractor`；`use_skill` 渲染 `script_compile`/`script_execute` handoff；复用现有 Roslyn scripting tools，**不新造运行时**。

经 consensus-rnd design-consensus r1 共识（minimal framing；structural 同主线，delete abstain）。

## 范围（13 files, +668/-2）

- `src/Aevatar.AI.ToolProviders.Skills/`：`SkillDefinition` / `SkillFrontmatterParser` / `SkillScriptExtractor`(新) / `SkillDiscovery` / `UseSkillTool`
- `src/Aevatar.AI.ToolProviders.Ornn/OrnnRemoteSkillFetcher.cs`
- `src/Aevatar.AI.ToolProviders.Scripting/`：`Ports/IScriptCompilationPort` / `Tools/ScriptCompileTool`（optional `entry_behavior_type_name`）
- `test/Aevatar.AI.ToolProviders.Ornn.Tests/`：`SkillScriptExtractorTests`(新) / `ScriptCompileToolTests`(新) / `OrnnSkillClientTests` / `SkillWorkflowsWiringTests`

## 验证

- `dotnet build aevatar.slnx --nologo` ✓
- Ornn.Tests：62 passed / 0 failed
- `dotnet test aevatar.slnx` ✓（一处 transient 集成超时 rerun 通过）
- `architecture_guards.sh` ✓ · `test_stability_guards.sh` ✓

## 合规

强类型 proto field（`SkillScriptDescriptor`）不塞 bag；不硬编码 skill 名；不改 NyxID/chrono-ornn；复用既有 Roslyn 编译/沙箱。

## Deviation

planned `test/Aevatar.AI.ToolProviders.Scripting.Tests` 不存在 → `ScriptCompileTool` 测试置于现有 `Ornn.Tests` + 加 scripting 项目引用（已记 `SCOPE_EXTEND`）。

Closes #1766

🤖 consensus-rnd codex-refactor-loop / design-consensus → implement → review

⟦AI:AUTO-LOOP⟧
