### PR TITLE
feat(#1771): 超长回复自动落地为飞书云文档（LLM 判定 + 回链接）

### DIFF
--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
@@ -27,6 +27,8 @@ namespace Aevatar.GAgents.Scheduled;
 [GAgent("scheduled.skill-runner")]
 public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
 {
+    private static readonly TimeSpan LongOutputDocumentDecisionTimeout = TimeSpan.FromSeconds(45);
+
     private readonly NyxIdApiClient? _nyxIdApiClient;
     private readonly ILarkOutboundDispatcher? _larkOutboundDispatcher;
     private readonly IOwnerLlmConfigSource? _ownerLlmConfigSource;
@@ -348,7 +350,8 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
                 if (string.IsNullOrEmpty(chunk.DeltaContent))
                     continue;
                 content.Append(chunk.DeltaContent);
-                if (streamingState is not null)
+                if (streamingState is not null &&
+                    content.Length <= SkillRunnerStreamingReplySink.MaxLarkTextLength)
                     // Per-delta `content.ToString()` is O(n) per call → O(n²) for the whole
                     // turn. Acceptable for bounded skill output (≤30 KB capped, and the
                     // actor-owned streaming state dedupes against `_lastEmittedText` so most allocations don't even
@@ -383,13 +386,16 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
                 _toolFailureCounter.SuccessCount,
                 State.RequiresNyxidProxySuccess);
 
-            // Issue #423 §C — chunked delivery for outputs that exceed the Lark body cap.
-            // For ≤30 KB outputs the chunker returns a single-element list and the dispatch
-            // loop below collapses to the existing single-message path. Larger outputs split
-            // at `\n\n` boundaries (or hard-split for no-paragraph inputs) so the full report
-            // lands as a sequence of "[part k/N]" messages instead of being silently truncated
-            // at the cap.
-            var chunks = SkillRunnerOutputChunker.Split(output);
+            var docReply = await TryCreateLongOutputDocumentReplyAsync(
+                output,
+                requestId,
+                llmControl,
+                toolContext,
+                metadata,
+                ct);
+            var chunks = docReply is not null
+                ? [docReply]
+                : SkillRunnerOutputChunker.Split(output);
             await DispatchOutputChunksAsync(streamingState, chunks, ct);
 
             return output;
@@ -643,6 +649,101 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             ExternalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(metadata),
         };
 
+    private async Task<string?> TryCreateLongOutputDocumentReplyAsync(
+        string output,
+        string requestId,
+        LLMControlContext llmControl,
+        AgentToolExecutionContext toolContext,
+        IReadOnlyDictionary<string, string> metadata,
+        CancellationToken ct)
+    {
+        if (output.Length <= SkillRunnerStreamingReplySink.MaxLarkTextLength)
+            return null;
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(LongOutputDocumentDecisionTimeout);
+        try
+        {
+            var decisionText = new StringBuilder();
+            await foreach (var chunk in ChatStreamAsync(
+                               [ContentPart.TextPart(BuildLongOutputDocumentDecisionPrompt(output))],
+                               $"{requestId}:lark-docx",
+                               llmControl with { MaxToolRoundsOverride = 2 },
+                               toolContext with
+                               {
+                                   Request = toolContext.Request with { RequestId = $"{requestId}:lark-docx", CallId = null },
+                               },
+                               metadata,
+                               timeoutCts.Token))
+            {
+                if (!string.IsNullOrEmpty(chunk.DeltaContent))
+                    decisionText.Append(chunk.DeltaContent);
+            }
+
+            var reply = decisionText.ToString().Trim();
+            if (TryAcceptLongOutputDocumentReply(reply, out var accepted))
+                return accepted;
+
+            Logger.LogWarning(
+                "Skill runner {ActorId} long-output document decision did not produce an accepted doc link; falling back to chunked delivery.",
+                Id);
+            return null;
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            Logger.LogWarning(
+                "Skill runner {ActorId} long-output document decision timed out; falling back to chunked delivery.",
+                Id);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(
+                ex,
+                "Skill runner {ActorId} long-output document decision failed; falling back to chunked delivery.",
+                Id);
+            return null;
+        }
+    }
+
+    private static string BuildLongOutputDocumentDecisionPrompt(string output) =>
+        $"""
+        The scheduled skill output below is too long for one Lark message.
+
+        Decide whether the full content should be delivered as a Lark cloud document.
+        If yes, call the lark_docx_create tool exactly once with:
+        - title: a concise title for this report
+        - markdown_text: the complete output exactly as provided
+        - visibility: readable
+
+        If the tool result reports success=true with document_url, answer with one short user-facing Lark message that includes the document URL.
+        If you do not call the tool, if the tool fails, or if there is no document_url, answer with DOCX_FALLBACK.
+        Do not summarize, omit, or rewrite the report body in the final message.
+
+        Output:
+        {output}
+        """;
+
+    private static bool TryAcceptLongOutputDocumentReply(string reply, out string accepted)
+    {
+        accepted = string.Empty;
+        if (string.IsNullOrWhiteSpace(reply))
+            return false;
+        if (reply.Contains("DOCX_FALLBACK", StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (!ContainsDocumentLink(reply))
+            return false;
+        if (reply.Length > SkillRunnerStreamingReplySink.MaxLarkTextLength)
+            return false;
+
+        accepted = reply;
+        return true;
+    }
+
+    private static bool ContainsDocumentLink(string reply) =>
+        reply.Contains("http://", StringComparison.OrdinalIgnoreCase) ||
+        reply.Contains("https://", StringComparison.OrdinalIgnoreCase);
+
     private Task SendOutputAsync(string output, CancellationToken ct) =>
         SendOutputAsync(output, providerSlugOverride: null, ct);
 
@@ -819,8 +920,17 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         {
             [ChannelMetadataKeys.ConversationId] = State.OutboundConfig?.ConversationId ?? string.Empty,
         };
+        AddIfNotEmpty(metadata, ChannelMetadataKeys.LarkReceiveId, State.OutboundConfig?.LarkReceiveId);
+        AddIfNotEmpty(metadata, ChannelMetadataKeys.LarkReceiveIdType, State.OutboundConfig?.LarkReceiveIdType);
+        AddIfNotEmpty(metadata, ChannelMetadataKeys.LarkOutboundProxySlug, State.OutboundConfig?.NyxProviderSlug);
 
         return metadata;
+    }
+
+    private static void AddIfNotEmpty(IDictionary<string, string> metadata, string key, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+            metadata[key] = value.Trim();
     }
 
     private async Task<LLMControlContext> BuildExecutionLlmControlAsync(CancellationToken ct)

--- a/src/Aevatar.AI.ToolProviders.Lark/ILarkNyxClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/ILarkNyxClient.cs
@@ -13,14 +13,9 @@ public interface ILarkNyxClient
     Task<string> AppendSheetRowsAsync(string token, LarkSheetAppendRowsRequest request, CancellationToken ct);
     Task<string> ListApprovalTasksAsync(string token, LarkApprovalTaskQueryRequest request, CancellationToken ct);
     Task<string> ActOnApprovalTaskAsync(string token, LarkApprovalTaskActionRequest request, CancellationToken ct);
-    Task<string> CreateDocxDocumentAsync(string token, LarkDocxCreateRequest request, CancellationToken ct) =>
-        throw new NotSupportedException();
-
-    Task<string> AppendDocxTextBlocksAsync(string token, LarkDocxAppendBlocksRequest request, CancellationToken ct) =>
-        throw new NotSupportedException();
-
-    Task<string> SetDrivePermissionAsync(string token, LarkDrivePermissionRequest request, CancellationToken ct) =>
-        throw new NotSupportedException();
+    Task<string> CreateDocxDocumentAsync(string token, LarkDocxCreateRequest request, CancellationToken ct);
+    Task<string> AppendDocxTextBlocksAsync(string token, LarkDocxAppendBlocksRequest request, CancellationToken ct);
+    Task<string> SetDrivePermissionAsync(string token, LarkDrivePermissionRequest request, CancellationToken ct);
 }
 
 public sealed record LarkSendMessageRequest(

--- a/src/Aevatar.AI.ToolProviders.Lark/ILarkNyxClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/ILarkNyxClient.cs
@@ -13,6 +13,14 @@ public interface ILarkNyxClient
     Task<string> AppendSheetRowsAsync(string token, LarkSheetAppendRowsRequest request, CancellationToken ct);
     Task<string> ListApprovalTasksAsync(string token, LarkApprovalTaskQueryRequest request, CancellationToken ct);
     Task<string> ActOnApprovalTaskAsync(string token, LarkApprovalTaskActionRequest request, CancellationToken ct);
+    Task<string> CreateDocxDocumentAsync(string token, LarkDocxCreateRequest request, CancellationToken ct) =>
+        throw new NotSupportedException();
+
+    Task<string> AppendDocxTextBlocksAsync(string token, LarkDocxAppendBlocksRequest request, CancellationToken ct) =>
+        throw new NotSupportedException();
+
+    Task<string> SetDrivePermissionAsync(string token, LarkDrivePermissionRequest request, CancellationToken ct) =>
+        throw new NotSupportedException();
 }
 
 public sealed record LarkSendMessageRequest(
@@ -92,3 +100,22 @@ public sealed record LarkApprovalTaskActionRequest(
     string? FormJson,
     string? TransferUserId,
     string? UserIdType);
+
+public enum LarkDocxVisibility
+{
+    Readable,
+    Editable,
+}
+
+public sealed record LarkDocxCreateRequest(
+    string Title);
+
+public sealed record LarkDocxAppendBlocksRequest(
+    string DocumentId,
+    string MarkdownText);
+
+public sealed record LarkDrivePermissionRequest(
+    string DocumentToken,
+    LarkDocxVisibility Visibility,
+    string? ReceiveId,
+    string? ReceiveIdType);

--- a/src/Aevatar.AI.ToolProviders.Lark/LarkAgentToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/LarkAgentToolSource.cs
@@ -62,6 +62,8 @@ public sealed class LarkAgentToolSource : IAgentToolSource
             tools.Add(new LarkApprovalsListTool(_client));
         if (_options.EnableApprovalsAct)
             tools.Add(new LarkApprovalsActTool(_client));
+        if (_options.EnableDocxCreate)
+            tools.Add(new LarkDocxCreateTool(_client));
 
         return Task.FromResult<IReadOnlyList<IAgentTool>>(tools);
     }

--- a/src/Aevatar.AI.ToolProviders.Lark/LarkNyxClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/LarkNyxClient.cs
@@ -6,6 +6,8 @@ namespace Aevatar.AI.ToolProviders.Lark;
 
 public sealed class LarkNyxClient : ILarkNyxClient
 {
+    internal const int MaxDocxBlockTextLength = 2_000;
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
@@ -303,11 +305,117 @@ public sealed class LarkNyxClient : ILarkNyxClient
             ct);
     }
 
+    public Task<string> CreateDocxDocumentAsync(string token, LarkDocxCreateRequest request, CancellationToken ct)
+    {
+        var body = new Dictionary<string, object?>
+        {
+            ["title"] = request.Title,
+        };
+
+        return _nyxClient.ProxyRequestAsync(
+            token,
+            _options.ProviderSlug,
+            "open-apis/docx/v1/documents",
+            "POST",
+            JsonSerializer.Serialize(body, JsonOptions),
+            extraHeaders: null,
+            ct);
+    }
+
+    public Task<string> AppendDocxTextBlocksAsync(string token, LarkDocxAppendBlocksRequest request, CancellationToken ct)
+    {
+        var body = new Dictionary<string, object?>
+        {
+            ["children"] = BuildTextBlocks(request.MarkdownText),
+        };
+
+        return _nyxClient.ProxyRequestAsync(
+            token,
+            _options.ProviderSlug,
+            $"open-apis/docx/v1/documents/{Uri.EscapeDataString(request.DocumentId)}/blocks/{Uri.EscapeDataString(request.DocumentId)}/children",
+            "POST",
+            JsonSerializer.Serialize(body, JsonOptions),
+            extraHeaders: null,
+            ct);
+    }
+
+    public Task<string> SetDrivePermissionAsync(string token, LarkDrivePermissionRequest request, CancellationToken ct)
+    {
+        var linkShareEntity = request.Visibility == LarkDocxVisibility.Editable
+            ? "tenant_editable"
+            : "tenant_readable";
+        var body = new Dictionary<string, object?>
+        {
+            ["link_share_entity"] = linkShareEntity,
+            ["external_access"] = false,
+            ["security_entity"] = "anyone_can_view",
+            ["comment_entity"] = "anyone_can_view",
+            ["share_entity"] = "anyone_can_view",
+            ["copy_entity"] = "anyone_can_view",
+        };
+
+        if (!string.IsNullOrWhiteSpace(request.ReceiveId) &&
+            !string.IsNullOrWhiteSpace(request.ReceiveIdType))
+        {
+            body["target"] = new Dictionary<string, object?>
+            {
+                ["receive_id"] = request.ReceiveId.Trim(),
+                ["receive_id_type"] = request.ReceiveIdType.Trim(),
+            };
+        }
+
+        return _nyxClient.ProxyRequestAsync(
+            token,
+            _options.ProviderSlug,
+            $"open-apis/drive/v1/permissions/{Uri.EscapeDataString(request.DocumentToken)}/public?type=docx",
+            "PATCH",
+            JsonSerializer.Serialize(body, JsonOptions),
+            extraHeaders: null,
+            ct);
+    }
+
     private static string BuildTransferPath(string? userIdType)
     {
         if (string.IsNullOrWhiteSpace(userIdType))
             return "open-apis/approval/v4/tasks/forward";
         return $"open-apis/approval/v4/tasks/forward?user_id_type={Uri.EscapeDataString(userIdType.Trim())}";
+    }
+
+    private static IReadOnlyList<Dictionary<string, object?>> BuildTextBlocks(string markdownText)
+    {
+        var normalized = string.IsNullOrEmpty(markdownText) ? " " : markdownText;
+        var blocks = new List<Dictionary<string, object?>>();
+        foreach (var chunk in SplitBlockText(normalized))
+        {
+            blocks.Add(new Dictionary<string, object?>
+            {
+                ["block_type"] = 2,
+                ["text"] = new Dictionary<string, object?>
+                {
+                    ["elements"] = new[]
+                    {
+                        new Dictionary<string, object?>
+                        {
+                            ["text_run"] = new Dictionary<string, object?>
+                            {
+                                ["content"] = chunk,
+                            },
+                        },
+                    },
+                },
+            });
+        }
+
+        return blocks;
+    }
+
+    private static IEnumerable<string> SplitBlockText(string text)
+    {
+        for (var offset = 0; offset < text.Length; offset += MaxDocxBlockTextLength)
+        {
+            var length = Math.Min(MaxDocxBlockTextLength, text.Length - offset);
+            yield return text.Substring(offset, length);
+        }
     }
 
     internal static string NormalizeChatSearchQuery(string query)

--- a/src/Aevatar.AI.ToolProviders.Lark/LarkProxyResponseParser.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/LarkProxyResponseParser.cs
@@ -289,6 +289,38 @@ internal static class LarkProxyResponseParser
             PageToken: TryReadString(data, "page_token"));
     }
 
+    public static LarkDocxCreateResult ParseDocxCreateSuccess(string response)
+    {
+        using var document = JsonDocument.Parse(response);
+        var data = ResolveDataRoot(document.RootElement);
+        var documentData = data.TryGetProperty("document", out var documentProp) &&
+                           documentProp.ValueKind == JsonValueKind.Object
+            ? documentProp
+            : data;
+
+        var token = TryReadString(documentData, "document_id") ??
+                    TryReadString(documentData, "document_token") ??
+                    TryReadString(documentData, "token");
+        return new LarkDocxCreateResult(
+            DocumentToken: token,
+            DocumentId: TryReadString(documentData, "document_id") ?? token,
+            DocumentUrl: TryReadString(documentData, "url") ??
+                         TryReadString(documentData, "document_url") ??
+                         TryReadString(documentData, "share_url"));
+    }
+
+    public static LarkDrivePermissionResult ParseDrivePermissionSuccess(string response)
+    {
+        using var document = JsonDocument.Parse(response);
+        var data = ResolveDataRoot(document.RootElement);
+        return new LarkDrivePermissionResult(
+            LinkShareEntity: TryReadString(data, "link_share_entity"),
+            ExternalAccess: TryReadBool(data, "external_access"),
+            ShareUrl: TryReadString(data, "share_url") ??
+                      TryReadString(data, "url") ??
+                      TryReadString(data, "document_url"));
+    }
+
     private static JsonElement ResolveDataRoot(JsonElement root) =>
         root.TryGetProperty("data", out var dataProp) && dataProp.ValueKind == JsonValueKind.Object
             ? dataProp
@@ -469,3 +501,13 @@ internal sealed record LarkApprovalTaskQueryResult(
     int Count,
     bool HasMore,
     string? PageToken);
+
+internal sealed record LarkDocxCreateResult(
+    string? DocumentToken,
+    string? DocumentId,
+    string? DocumentUrl);
+
+internal sealed record LarkDrivePermissionResult(
+    string? LinkShareEntity,
+    bool? ExternalAccess,
+    string? ShareUrl);

--- a/src/Aevatar.AI.ToolProviders.Lark/LarkToolOptions.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/LarkToolOptions.cs
@@ -14,4 +14,5 @@ public sealed class LarkToolOptions
     public bool EnableSheetsAppendRows { get; set; } = true;
     public bool EnableApprovalsList { get; set; } = true;
     public bool EnableApprovalsAct { get; set; } = true;
+    public bool EnableDocxCreate { get; set; } = true;
 }

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkDocxCreateTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkDocxCreateTool.cs
@@ -35,29 +35,61 @@ public sealed class LarkDocxCreateTool : AgentToolBase<LarkDocxCreateTool.Parame
 
     protected override async Task<string> ExecuteAsync(Parameters parameters, CancellationToken ct)
     {
+        if (!TryBuildRequest(parameters, out var request, out var error))
+            return LarkProxyResponseParser.Serialize(new { success = false, error });
+
+        return await CreateAppendAndShareAsync(request, ct);
+    }
+
+    private static bool TryBuildRequest(
+        Parameters parameters,
+        out ValidatedDocxCreateRequest request,
+        out string? error)
+    {
         var token = AgentToolRequestContext.NyxIdAccessToken;
+        request = default;
         if (string.IsNullOrWhiteSpace(token))
-            return LarkProxyResponseParser.Serialize(new { success = false, error = "No NyxID access token available. User must be authenticated." });
+        {
+            error = "No NyxID access token available. User must be authenticated.";
+            return false;
+        }
 
         var title = parameters.Title?.Trim();
         if (string.IsNullOrWhiteSpace(title))
-            return LarkProxyResponseParser.Serialize(new { success = false, error = "title is required." });
+        {
+            error = "title is required.";
+            return false;
+        }
+
         if (title.Length > 200)
-            return LarkProxyResponseParser.Serialize(new { success = false, error = "title exceeds the maximum of 200 characters." });
+        {
+            error = "title exceeds the maximum of 200 characters.";
+            return false;
+        }
 
         var markdownText = parameters.MarkdownText;
         if (string.IsNullOrWhiteSpace(markdownText))
-            return LarkProxyResponseParser.Serialize(new { success = false, error = "markdown_text is required." });
+        {
+            error = "markdown_text is required.";
+            return false;
+        }
 
-        if (!TryNormalizeVisibility(parameters.Visibility, out var visibility, out var visibilityError))
-            return LarkProxyResponseParser.Serialize(new { success = false, error = visibilityError });
+        if (!TryNormalizeVisibility(parameters.Visibility, out var visibility, out error))
+            return false;
 
-        if (!TryResolveReceiveTarget(parameters, out var receiveId, out var receiveIdType, out var targetError))
-            return LarkProxyResponseParser.Serialize(new { success = false, error = targetError });
+        if (!TryResolveReceiveTarget(parameters, out var receiveId, out var receiveIdType, out error))
+            return false;
 
+        request = new ValidatedDocxCreateRequest(token, title, markdownText, visibility, receiveId, receiveIdType);
+        error = null;
+        return true;
+    }
+
+    private async Task<string> CreateAppendAndShareAsync(ValidatedDocxCreateRequest request, CancellationToken ct)
+    {
         var createResponse = await _client.CreateDocxDocumentAsync(
-            token,
-            new LarkDocxCreateRequest(title),
+            request.Token,
+            new LarkDocxCreateRequest(request.Title),
             ct);
         if (LarkProxyResponseParser.TryParseError(createResponse, out var createError))
             return LarkProxyResponseParser.Serialize(new { success = false, error = createError });
@@ -74,8 +106,8 @@ public sealed class LarkDocxCreateTool : AgentToolBase<LarkDocxCreateTool.Parame
         }
 
         var appendResponse = await _client.AppendDocxTextBlocksAsync(
-            token,
-            new LarkDocxAppendBlocksRequest(createResult.DocumentId, markdownText),
+            request.Token,
+            new LarkDocxAppendBlocksRequest(createResult.DocumentId, request.MarkdownText),
             ct);
         if (LarkProxyResponseParser.TryParseError(appendResponse, out var appendError))
         {
@@ -89,12 +121,12 @@ public sealed class LarkDocxCreateTool : AgentToolBase<LarkDocxCreateTool.Parame
         }
 
         var permissionResponse = await _client.SetDrivePermissionAsync(
-            token,
+            request.Token,
             new LarkDrivePermissionRequest(
                 createResult.DocumentToken,
-                visibility,
-                receiveId,
-                receiveIdType),
+                request.Visibility,
+                request.ReceiveId,
+                request.ReceiveIdType),
             ct);
         if (LarkProxyResponseParser.TryParseError(permissionResponse, out var permissionError))
         {
@@ -127,7 +159,7 @@ public sealed class LarkDocxCreateTool : AgentToolBase<LarkDocxCreateTool.Parame
             document_token = createResult.DocumentToken,
             document_url = documentUrl,
             visibility_applied = true,
-            visibility = visibility == LarkDocxVisibility.Editable ? "editable" : "readable",
+            visibility = request.Visibility == LarkDocxVisibility.Editable ? "editable" : "readable",
         });
     }
 
@@ -186,6 +218,14 @@ public sealed class LarkDocxCreateTool : AgentToolBase<LarkDocxCreateTool.Parame
         error = null;
         return true;
     }
+
+    private readonly record struct ValidatedDocxCreateRequest(
+        string Token,
+        string Title,
+        string MarkdownText,
+        LarkDocxVisibility Visibility,
+        string? ReceiveId,
+        string? ReceiveIdType);
 
     public sealed class Parameters
     {

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkDocxCreateTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkDocxCreateTool.cs
@@ -1,0 +1,198 @@
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+
+namespace Aevatar.AI.ToolProviders.Lark.Tools;
+
+public sealed class LarkDocxCreateTool : AgentToolBase<LarkDocxCreateTool.Parameters>
+{
+    private static readonly HashSet<string> AllowedVisibility =
+    [
+        "readable",
+        "editable",
+    ];
+
+    private static readonly HashSet<string> AllowedReceiveIdTypes =
+    [
+        "chat_id",
+        "open_id",
+        "union_id",
+        "user_id",
+    ];
+
+    private readonly ILarkNyxClient _client;
+
+    public LarkDocxCreateTool(ILarkNyxClient client)
+    {
+        _client = client;
+    }
+
+    public override string Name => "lark_docx_create";
+
+    public override string Description =>
+        "Create a Lark cloud document through Nyx-backed bot transport, append the complete markdown text, apply sharing visibility, and return the document link.";
+
+    public override ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;
+
+    protected override async Task<string> ExecuteAsync(Parameters parameters, CancellationToken ct)
+    {
+        var token = AgentToolRequestContext.NyxIdAccessToken;
+        if (string.IsNullOrWhiteSpace(token))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "No NyxID access token available. User must be authenticated." });
+
+        var title = parameters.Title?.Trim();
+        if (string.IsNullOrWhiteSpace(title))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "title is required." });
+        if (title.Length > 200)
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "title exceeds the maximum of 200 characters." });
+
+        var markdownText = parameters.MarkdownText;
+        if (string.IsNullOrWhiteSpace(markdownText))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "markdown_text is required." });
+
+        if (!TryNormalizeVisibility(parameters.Visibility, out var visibility, out var visibilityError))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = visibilityError });
+
+        if (!TryResolveReceiveTarget(parameters, out var receiveId, out var receiveIdType, out var targetError))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = targetError });
+
+        var createResponse = await _client.CreateDocxDocumentAsync(
+            token,
+            new LarkDocxCreateRequest(title),
+            ct);
+        if (LarkProxyResponseParser.TryParseError(createResponse, out var createError))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = createError });
+
+        var createResult = LarkProxyResponseParser.ParseDocxCreateSuccess(createResponse);
+        if (string.IsNullOrWhiteSpace(createResult.DocumentToken) ||
+            string.IsNullOrWhiteSpace(createResult.DocumentId))
+        {
+            return LarkProxyResponseParser.Serialize(new
+            {
+                success = false,
+                error = "docx_create_missing_token",
+            });
+        }
+
+        var appendResponse = await _client.AppendDocxTextBlocksAsync(
+            token,
+            new LarkDocxAppendBlocksRequest(createResult.DocumentId, markdownText),
+            ct);
+        if (LarkProxyResponseParser.TryParseError(appendResponse, out var appendError))
+        {
+            return LarkProxyResponseParser.Serialize(new
+            {
+                success = false,
+                document_token = createResult.DocumentToken,
+                document_url = createResult.DocumentUrl,
+                error = appendError,
+            });
+        }
+
+        var permissionResponse = await _client.SetDrivePermissionAsync(
+            token,
+            new LarkDrivePermissionRequest(
+                createResult.DocumentToken,
+                visibility,
+                receiveId,
+                receiveIdType),
+            ct);
+        if (LarkProxyResponseParser.TryParseError(permissionResponse, out var permissionError))
+        {
+            return LarkProxyResponseParser.Serialize(new
+            {
+                success = false,
+                document_token = createResult.DocumentToken,
+                document_url = createResult.DocumentUrl,
+                visibility_applied = false,
+                error = permissionError,
+            });
+        }
+
+        var permissionResult = LarkProxyResponseParser.ParseDrivePermissionSuccess(permissionResponse);
+        var documentUrl = createResult.DocumentUrl ?? permissionResult.ShareUrl;
+        if (string.IsNullOrWhiteSpace(documentUrl))
+        {
+            return LarkProxyResponseParser.Serialize(new
+            {
+                success = false,
+                document_token = createResult.DocumentToken,
+                visibility_applied = true,
+                error = "docx_create_missing_url",
+            });
+        }
+
+        return LarkProxyResponseParser.Serialize(new
+        {
+            success = true,
+            document_token = createResult.DocumentToken,
+            document_url = documentUrl,
+            visibility_applied = true,
+            visibility = visibility == LarkDocxVisibility.Editable ? "editable" : "readable",
+        });
+    }
+
+    private static bool TryNormalizeVisibility(
+        string? raw,
+        out LarkDocxVisibility visibility,
+        out string? error)
+    {
+        var normalized = string.IsNullOrWhiteSpace(raw)
+            ? "readable"
+            : raw.Trim().ToLowerInvariant();
+        if (!AllowedVisibility.Contains(normalized))
+        {
+            visibility = LarkDocxVisibility.Readable;
+            error = "visibility must be one of: readable, editable";
+            return false;
+        }
+
+        visibility = normalized == "editable" ? LarkDocxVisibility.Editable : LarkDocxVisibility.Readable;
+        error = null;
+        return true;
+    }
+
+    private static bool TryResolveReceiveTarget(
+        Parameters parameters,
+        out string? receiveId,
+        out string? receiveIdType,
+        out string? error)
+    {
+        receiveId = parameters.ReceiveId?.Trim();
+        receiveIdType = parameters.ReceiveIdType?.Trim().ToLowerInvariant();
+
+        if (string.IsNullOrWhiteSpace(receiveId))
+            receiveId = AgentToolRequestContext.TryGetExternalMetadata("channel.lark.receive_id")?.Trim();
+        if (string.IsNullOrWhiteSpace(receiveIdType))
+            receiveIdType = AgentToolRequestContext.TryGetExternalMetadata("channel.lark.receive_id_type")?.Trim().ToLowerInvariant();
+
+        if (string.IsNullOrWhiteSpace(receiveId) && string.IsNullOrWhiteSpace(receiveIdType))
+        {
+            error = null;
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(receiveId) || string.IsNullOrWhiteSpace(receiveIdType))
+        {
+            error = "receive_id and receive_id_type must be provided together.";
+            return false;
+        }
+
+        if (!AllowedReceiveIdTypes.Contains(receiveIdType))
+        {
+            error = "receive_id_type must be one of: chat_id, open_id, union_id, user_id";
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    public sealed class Parameters
+    {
+        public string? Title { get; set; }
+        public string? MarkdownText { get; set; }
+        public string? Visibility { get; set; }
+        public string? ReceiveId { get; set; }
+        public string? ReceiveIdType { get; set; }
+    }
+}

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkCoverageTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkCoverageTests.cs
@@ -76,6 +76,11 @@ public sealed class LarkCoverageTests
         sheetsTool.Name.Should().Be("lark_sheets_append_rows");
         sheetsTool.Description.Should().Contain("Append rows to a known Lark spreadsheet");
         sheetsTool.ApprovalMode.Should().Be(ToolApprovalMode.Auto);
+
+        var docxTool = new LarkDocxCreateTool(client);
+        docxTool.Name.Should().Be("lark_docx_create");
+        docxTool.Description.Should().Contain("Create a Lark cloud document");
+        docxTool.ApprovalMode.Should().Be(ToolApprovalMode.Auto);
     }
 
     [Fact]
@@ -89,6 +94,19 @@ public sealed class LarkCoverageTests
         var tools = await source.DiscoverToolsAsync();
 
         tools.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LarkAgentToolSource_ShouldSkipDocxTool_WhenDisabled()
+    {
+        var source = new LarkAgentToolSource(
+            new LarkToolOptions { EnableDocxCreate = false },
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new StubLarkNyxClient());
+
+        var tools = await source.DiscoverToolsAsync();
+
+        tools.Should().NotContain(tool => tool.Name == "lark_docx_create");
     }
 
     [Fact]
@@ -138,6 +156,29 @@ public sealed class LarkCoverageTests
 
         InvokeTryParseError("""{"code":0}""").Should().Be((false, string.Empty));
         InvokeTryParseError("not-json").Should().Be((true, "invalid_lark_response_json"));
+    }
+
+    [Fact]
+    public void LarkProxyResponseParser_ShouldHandleDocxAndPermissionShapes()
+    {
+        var parserType = typeof(LarkAgentToolSource).Assembly.GetType("Aevatar.AI.ToolProviders.Lark.LarkProxyResponseParser")!;
+        var parseDocx = parserType.GetMethod("ParseDocxCreateSuccess", BindingFlags.Public | BindingFlags.Static)!;
+        var parsePermission = parserType.GetMethod("ParseDrivePermissionSuccess", BindingFlags.Public | BindingFlags.Static)!;
+
+        var docxResult = parseDocx.Invoke(
+            null,
+            ["""{"code":0,"data":{"document":{"document_id":"doccn_123","url":"https://example.feishu.cn/docx/doccn_123"}}}"""]);
+        docxResult.Should().NotBeNull();
+        docxResult!.GetType().GetProperty("DocumentToken")!.GetValue(docxResult).Should().Be("doccn_123");
+        docxResult.GetType().GetProperty("DocumentUrl")!.GetValue(docxResult).Should().Be("https://example.feishu.cn/docx/doccn_123");
+
+        var permissionResult = parsePermission.Invoke(
+            null,
+            ["""{"code":0,"data":{"link_share_entity":"tenant_readable","external_access":false,"share_url":"https://share.example/doc"}}"""]);
+        permissionResult.Should().NotBeNull();
+        permissionResult!.GetType().GetProperty("LinkShareEntity")!.GetValue(permissionResult).Should().Be("tenant_readable");
+        permissionResult.GetType().GetProperty("ExternalAccess")!.GetValue(permissionResult).Should().Be(false);
+        permissionResult.GetType().GetProperty("ShareUrl")!.GetValue(permissionResult).Should().Be("https://share.example/doc");
     }
 
     [Fact]
@@ -344,6 +385,30 @@ public sealed class LarkCoverageTests
         }
 
         public Task<string> ActOnApprovalTaskAsync(string token, LarkApprovalTaskActionRequest request, CancellationToken ct)
+        {
+            _ = token;
+            _ = request;
+            _ = ct;
+            return Task.FromResult("""{"code":0,"data":{}}""");
+        }
+
+        public Task<string> CreateDocxDocumentAsync(string token, LarkDocxCreateRequest request, CancellationToken ct)
+        {
+            _ = token;
+            _ = request;
+            _ = ct;
+            return Task.FromResult("""{"code":0,"data":{"document":{"document_id":"doccn_123","url":"https://example.feishu.cn/docx/doccn_123"}}}""");
+        }
+
+        public Task<string> AppendDocxTextBlocksAsync(string token, LarkDocxAppendBlocksRequest request, CancellationToken ct)
+        {
+            _ = token;
+            _ = request;
+            _ = ct;
+            return Task.FromResult("""{"code":0,"data":{}}""");
+        }
+
+        public Task<string> SetDrivePermissionAsync(string token, LarkDrivePermissionRequest request, CancellationToken ct)
         {
             _ = token;
             _ = request;

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
@@ -111,6 +111,70 @@ public class LarkToolsTests
     }
 
     [Fact]
+    public async Task LarkDocxCreateTool_ShouldFail_WhenCreateReturnsProxyError()
+    {
+        using var _ = new AgentToolRequestMetadataScope("token-123");
+        var client = new StubLarkNyxClient
+        {
+            DocxCreateResponse = """{"error":true,"status":503,"message":"docx unavailable"}""",
+        };
+        var tool = new LarkDocxCreateTool(client);
+
+        var result = await tool.ExecuteAsync(
+            """{"title":"Daily report","markdown_text":"full text"}""");
+
+        result.Should().Contain("\"success\":false");
+        result.Should().Contain("nyx_proxy_error status=503");
+        result.Should().Contain("docx unavailable");
+        client.LastDocxCreateRequest.Should().Be(new LarkDocxCreateRequest("Daily report"));
+        client.LastDocxAppendRequest.Should().BeNull();
+        client.LastDrivePermissionRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task LarkDocxCreateTool_ShouldFail_WhenCreateOmitsDocumentToken()
+    {
+        using var _ = new AgentToolRequestMetadataScope("token-123");
+        var client = new StubLarkNyxClient
+        {
+            DocxCreateResponse = """{"code":0,"data":{"document":{"url":"https://example.feishu.cn/docx/missing-token"}}}""",
+        };
+        var tool = new LarkDocxCreateTool(client);
+
+        var result = await tool.ExecuteAsync(
+            """{"title":"Daily report","markdown_text":"full text"}""");
+
+        result.Should().Contain("\"success\":false");
+        result.Should().Contain("docx_create_missing_token");
+        client.LastDocxCreateRequest.Should().Be(new LarkDocxCreateRequest("Daily report"));
+        client.LastDocxAppendRequest.Should().BeNull();
+        client.LastDrivePermissionRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task LarkDocxCreateTool_ShouldFail_WhenAppendReturnsProxyError()
+    {
+        using var _ = new AgentToolRequestMetadataScope("token-123");
+        var client = new StubLarkNyxClient
+        {
+            DocxCreateResponse = """{"code":0,"data":{"document":{"document_id":"doccn_123","url":"https://example.feishu.cn/docx/doccn_123"}}}""",
+            DocxAppendResponse = """{"code":999,"msg":"append rejected"}""",
+        };
+        var tool = new LarkDocxCreateTool(client);
+
+        var result = await tool.ExecuteAsync(
+            """{"title":"Daily report","markdown_text":"full text"}""");
+
+        result.Should().Contain("\"success\":false");
+        result.Should().Contain("\"document_token\":\"doccn_123\"");
+        result.Should().Contain("\"document_url\":\"https://example.feishu.cn/docx/doccn_123\"");
+        result.Should().Contain("lark_code=999");
+        result.Should().Contain("append rejected");
+        client.LastDocxAppendRequest.Should().Be(new LarkDocxAppendBlocksRequest("doccn_123", "full text"));
+        client.LastDrivePermissionRequest.Should().BeNull();
+    }
+
+    [Fact]
     public async Task LarkDocxCreateTool_ShouldValidateInputs()
     {
         var tool = new LarkDocxCreateTool(new StubLarkNyxClient());
@@ -124,6 +188,12 @@ public class LarkToolsTests
         {
             (await tool.ExecuteAsync("""{"markdown_text":"body"}"""))
                 .Should().Contain("title is required");
+            (await tool.ExecuteAsync(JsonSerializer.Serialize(new
+            {
+                title = new string('t', 201),
+                markdown_text = "body",
+            })))
+                .Should().Contain("title exceeds the maximum of 200 characters");
             (await tool.ExecuteAsync("""{"title":"t","markdown_text":" "}"""))
                 .Should().Contain("markdown_text is required");
             (await tool.ExecuteAsync("""{"title":"t","markdown_text":"body","visibility":"public"}"""))

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
@@ -46,6 +46,96 @@ public class LarkToolsTests
     }
 
     [Fact]
+    public async Task LarkDocxCreateTool_ShouldCreateAppendPermission_AndReturnLink()
+    {
+        var client = new StubLarkNyxClient
+        {
+            DocxCreateResponse = """{"code":0,"data":{"document":{"document_id":"doccn_123","url":"https://example.feishu.cn/docx/doccn_123"}}}""",
+            DocxAppendResponse = """{"code":0,"data":{"children":[]}}""",
+            DrivePermissionResponse = """{"code":0,"data":{"link_share_entity":"tenant_readable"}}""",
+        };
+        var tool = new LarkDocxCreateTool(client);
+
+        using var _ = new AgentToolRequestMetadataScope(
+            "token-123",
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["channel.lark.receive_id"] = "oc_chat_1",
+                ["channel.lark.receive_id_type"] = "chat_id",
+            });
+
+        var result = await tool.ExecuteAsync(
+            """{"title":"Daily report","markdown_text":"# Daily\n\nFull text","visibility":"readable"}""");
+
+        using var document = JsonDocument.Parse(result);
+        document.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+        document.RootElement.GetProperty("document_token").GetString().Should().Be("doccn_123");
+        document.RootElement.GetProperty("document_url").GetString().Should().Be("https://example.feishu.cn/docx/doccn_123");
+        document.RootElement.GetProperty("visibility_applied").GetBoolean().Should().BeTrue();
+        client.LastDocxCreateToken.Should().Be("token-123");
+        client.LastDocxCreateRequest.Should().Be(new LarkDocxCreateRequest("Daily report"));
+        client.LastDocxAppendRequest.Should().Be(new LarkDocxAppendBlocksRequest("doccn_123", "# Daily\n\nFull text"));
+        client.LastDrivePermissionRequest.Should().Be(new LarkDrivePermissionRequest("doccn_123", LarkDocxVisibility.Readable, "oc_chat_1", "chat_id"));
+    }
+
+    [Fact]
+    public async Task LarkDocxCreateTool_ShouldFail_WhenPermissionOrUrlMissing()
+    {
+        using var _ = new AgentToolRequestMetadataScope("token-123");
+        var permissionFailure = new LarkDocxCreateTool(new StubLarkNyxClient
+        {
+            DocxCreateResponse = """{"code":0,"data":{"document":{"document_id":"doccn_123","url":"https://example.feishu.cn/docx/doccn_123"}}}""",
+            DocxAppendResponse = """{"code":0,"data":{}}""",
+            DrivePermissionResponse = """{"code":999,"msg":"permission denied"}""",
+        });
+
+        var permissionResult = await permissionFailure.ExecuteAsync(
+            """{"title":"Daily report","markdown_text":"full text"}""");
+
+        permissionResult.Should().Contain("\"success\":false");
+        permissionResult.Should().Contain("\"visibility_applied\":false");
+        permissionResult.Should().Contain("lark_code=999");
+
+        var missingUrl = new LarkDocxCreateTool(new StubLarkNyxClient
+        {
+            DocxCreateResponse = """{"code":0,"data":{"document":{"document_id":"doccn_123"}}}""",
+            DocxAppendResponse = """{"code":0,"data":{}}""",
+            DrivePermissionResponse = """{"code":0,"data":{}}""",
+        });
+
+        var missingUrlResult = await missingUrl.ExecuteAsync(
+            """{"title":"Daily report","markdown_text":"full text"}""");
+
+        missingUrlResult.Should().Contain("\"success\":false");
+        missingUrlResult.Should().Contain("docx_create_missing_url");
+    }
+
+    [Fact]
+    public async Task LarkDocxCreateTool_ShouldValidateInputs()
+    {
+        var tool = new LarkDocxCreateTool(new StubLarkNyxClient());
+        using (new AgentToolRequestMetadataScope())
+        {
+            (await tool.ExecuteAsync("""{"title":"t","markdown_text":"body"}"""))
+                .Should().Contain("No NyxID access token available");
+        }
+
+        using (new AgentToolRequestMetadataScope("token-123"))
+        {
+            (await tool.ExecuteAsync("""{"markdown_text":"body"}"""))
+                .Should().Contain("title is required");
+            (await tool.ExecuteAsync("""{"title":"t","markdown_text":" "}"""))
+                .Should().Contain("markdown_text is required");
+            (await tool.ExecuteAsync("""{"title":"t","markdown_text":"body","visibility":"public"}"""))
+                .Should().Contain("visibility must be one of");
+            (await tool.ExecuteAsync("""{"title":"t","markdown_text":"body","receive_id":"oc_1"}"""))
+                .Should().Contain("receive_id and receive_id_type must be provided together");
+            (await tool.ExecuteAsync("""{"title":"t","markdown_text":"body","receive_id":"oc_1","receive_id_type":"email"}"""))
+                .Should().Contain("receive_id_type must be one of");
+        }
+    }
+
+    [Fact]
     public async Task LarkMessagesSendTool_PropagatesTypedCallerScope()
     {
         var client = new StubLarkNyxClient
@@ -1169,7 +1259,7 @@ public class LarkToolsTests
 
         var tools = await source.DiscoverToolsAsync();
 
-        tools.Should().HaveCount(11);
+        tools.Should().HaveCount(12);
         tools.Should().Contain(tool => tool is LarkMessagesSendTool);
         tools.Should().Contain(tool => tool is LarkMessagesReplyTool);
         tools.Should().Contain(tool => tool is LarkMessagesReactTool);
@@ -1181,6 +1271,7 @@ public class LarkToolsTests
         tools.Should().Contain(tool => tool is LarkSheetsAppendRowsTool);
         tools.Should().Contain(tool => tool is LarkApprovalsListTool);
         tools.Should().Contain(tool => tool is LarkApprovalsActTool);
+        tools.Should().Contain(tool => tool is LarkDocxCreateTool);
     }
 
     [Fact]
@@ -1471,6 +1562,61 @@ public class LarkToolsTests
     }
 
     [Fact]
+    public async Task LarkNyxClient_DocxCreateAppendPermission_ShapesProxyRequests()
+    {
+        var handler = new RecordingHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"code":0,"data":{}}""", Encoding.UTF8, "application/json"),
+            });
+        var client = new LarkNyxClient(
+            new LarkToolOptions { ProviderSlug = "api-lark-bot" },
+            new NyxIdApiClient(
+                new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+                new HttpClient(handler)));
+
+        await client.CreateDocxDocumentAsync(
+            "token-123",
+            new LarkDocxCreateRequest("Daily report"),
+            CancellationToken.None);
+
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.RequestUri!.ToString()
+            .Should().Be("https://nyx.example.com/api/v1/proxy/s/api-lark-bot/open-apis/docx/v1/documents");
+        handler.LastBody.Should().Contain("\"title\":\"Daily report\"");
+
+        const int ExpectedDocxBlockTextLength = 2_000;
+        var longText = new string('x', ExpectedDocxBlockTextLength + 5);
+        await client.AppendDocxTextBlocksAsync(
+            "token-123",
+            new LarkDocxAppendBlocksRequest("doccn_123", longText),
+            CancellationToken.None);
+
+        handler.LastRequest!.RequestUri!.ToString()
+            .Should().Be("https://nyx.example.com/api/v1/proxy/s/api-lark-bot/open-apis/docx/v1/documents/doccn_123/blocks/doccn_123/children");
+        using (var appendBody = JsonDocument.Parse(handler.LastBody!))
+        {
+            var children = appendBody.RootElement.GetProperty("children");
+            children.GetArrayLength().Should().Be(2);
+            children[0].GetProperty("text").GetProperty("elements")[0].GetProperty("text_run").GetProperty("content").GetString()!
+                .Length.Should().Be(ExpectedDocxBlockTextLength);
+            children[1].GetProperty("text").GetProperty("elements")[0].GetProperty("text_run").GetProperty("content").GetString()!
+                .Length.Should().Be(5);
+        }
+
+        await client.SetDrivePermissionAsync(
+            "token-123",
+            new LarkDrivePermissionRequest("doccn_123", LarkDocxVisibility.Editable, "oc_chat_1", "chat_id"),
+            CancellationToken.None);
+
+        handler.LastRequest!.Method.Method.Should().Be("PATCH");
+        handler.LastRequest.RequestUri!.ToString()
+            .Should().Be("https://nyx.example.com/api/v1/proxy/s/api-lark-bot/open-apis/drive/v1/permissions/doccn_123/public?type=docx");
+        handler.LastBody.Should().Contain("\"link_share_entity\":\"tenant_editable\"");
+        handler.LastBody.Should().Contain("\"receive_id\":\"oc_chat_1\"");
+    }
+
+    [Fact]
     public void LarkNyxClient_NormalizeChatSearchQuery_ShouldKeepOriginalWhenUnquotingFails()
     {
         var method = typeof(LarkNyxClient).GetMethod(
@@ -1495,8 +1641,12 @@ public class LarkToolsTests
         public string AppendSheetResponse { get; set; } = """{"code":0,"data":{"updates":{}}}""";
         public string ApprovalListResponse { get; set; } = """{"code":0,"data":{"tasks":[],"count":0}}""";
         public string ApprovalActionResponse { get; set; } = """{"code":0,"data":{}}""";
+        public string DocxCreateResponse { get; set; } = """{"code":0,"data":{"document":{"document_id":"doccn_default","url":"https://example.feishu.cn/docx/doccn_default"}}}""";
+        public string DocxAppendResponse { get; set; } = """{"code":0,"data":{}}""";
+        public string DrivePermissionResponse { get; set; } = """{"code":0,"data":{}}""";
 
         public string? LastSendToken { get; private set; }
+        public string? LastDocxCreateToken { get; private set; }
         public LarkSendMessageRequest? LastSendRequest { get; private set; }
         public LarkReplyMessageRequest? LastReplyRequest { get; private set; }
         public LarkMessageReactionRequest? LastReactionRequest { get; private set; }
@@ -1508,6 +1658,9 @@ public class LarkToolsTests
         public LarkSheetAppendRowsRequest? LastSheetAppendRequest { get; private set; }
         public LarkApprovalTaskQueryRequest? LastApprovalQueryRequest { get; private set; }
         public LarkApprovalTaskActionRequest? LastApprovalActionRequest { get; private set; }
+        public LarkDocxCreateRequest? LastDocxCreateRequest { get; private set; }
+        public LarkDocxAppendBlocksRequest? LastDocxAppendRequest { get; private set; }
+        public LarkDrivePermissionRequest? LastDrivePermissionRequest { get; private set; }
 
         public Task<string> SendMessageAsync(string token, LarkSendMessageRequest request, CancellationToken ct)
         {
@@ -1574,6 +1727,25 @@ public class LarkToolsTests
         {
             LastApprovalActionRequest = request;
             return Task.FromResult(ApprovalActionResponse);
+        }
+
+        public Task<string> CreateDocxDocumentAsync(string token, LarkDocxCreateRequest request, CancellationToken ct)
+        {
+            LastDocxCreateToken = token;
+            LastDocxCreateRequest = request;
+            return Task.FromResult(DocxCreateResponse);
+        }
+
+        public Task<string> AppendDocxTextBlocksAsync(string token, LarkDocxAppendBlocksRequest request, CancellationToken ct)
+        {
+            LastDocxAppendRequest = request;
+            return Task.FromResult(DocxAppendResponse);
+        }
+
+        public Task<string> SetDrivePermissionAsync(string token, LarkDrivePermissionRequest request, CancellationToken ct)
+        {
+            LastDrivePermissionRequest = request;
+            return Task.FromResult(DrivePermissionResponse);
         }
     }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCardConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCardConversationTurnRunnerTests.cs
@@ -219,5 +219,14 @@ public sealed class ChannelCardConversationTurnRunnerTests
 
         public Task<string> ActOnApprovalTaskAsync(string token, LarkApprovalTaskActionRequest request, CancellationToken ct) =>
             throw new NotSupportedException();
+
+        public Task<string> CreateDocxDocumentAsync(string token, LarkDocxCreateRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<string> AppendDocxTextBlocksAsync(string token, LarkDocxAppendBlocksRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<string> SetDrivePermissionAsync(string token, LarkDrivePermissionRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.CQRS.Projection.Runtime.Abstractions;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
@@ -981,6 +982,106 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ExecuteSkillAsync_OverLimitOutput_ShouldUseDocxDecisionReply_WhenLinkReturned()
+    {
+        var output = new string('x', SkillRunnerStreamingReplySink.MaxLarkTextLength + 100);
+        var provider = new StubStreamingProviderFactory(
+            new StubStreamingTurn([output]),
+            new StubStreamingTurn(
+                [],
+                [
+                    new ToolCall
+                    {
+                        Id = "call-docx",
+                        Name = "lark_docx_create",
+                        ArgumentsJson = "{}",
+                    },
+                ]),
+            new StubStreamingTurn(["Full output moved to https://example.feishu.cn/docx/doccn_123"]));
+        var handler = new SequencedHandler("""{"code":0,"msg":"success","data":{"message_id":"om_doc_link"}}""");
+        var docxTool = new FixedResultTool(
+            "lark_docx_create",
+            """{"success":true,"document_token":"doccn_123","document_url":"https://example.feishu.cn/docx/doccn_123","visibility_applied":true}""");
+        var agent = CreateAgent(
+            "skill-runner-docx-success",
+            providerFactory: provider,
+            toolSources: [new SingleToolSource(docxTool)]);
+        await agent.ActivateAsync();
+        var initialize = CreateInitializeCommand();
+        initialize.OutboundConfig.LarkReceiveId = "oc_chat_1";
+        initialize.OutboundConfig.LarkReceiveIdType = "chat_id";
+        await agent.HandleInitializeAsync(initialize);
+        AttachNyxIdApiClient(agent, handler);
+
+        var result = await InvokeExecuteSkillAsync(agent);
+
+        result.Should().Be(output);
+        provider.Requests.Should().HaveCount(3);
+        provider.Requests[1].RequestId.Should().EndWith(":lark-docx");
+        provider.Requests[1].ToolContext.Should().NotBeNull();
+        var docxToolContext = provider.Requests[1].ToolContext!;
+        docxToolContext.Routing.MaxToolRoundsOverride.Should().Be(2);
+        docxToolContext.ExternalMetadata.Should().Contain(ChannelMetadataKeys.LarkReceiveId, "oc_chat_1");
+        docxToolContext.ExternalMetadata.Should().Contain(ChannelMetadataKeys.LarkReceiveIdType, "chat_id");
+        docxToolContext.ExternalMetadata.Should().Contain(ChannelMetadataKeys.LarkOutboundProxySlug, "api-lark-bot");
+        provider.Requests[2].Messages.Any(message =>
+            message.Role == "tool" &&
+            message.Content is not null &&
+            message.Content.Contains("https://example.feishu.cn/docx/doccn_123", StringComparison.Ordinal))
+            .Should().BeTrue();
+        handler.Requests.Should().ContainSingle();
+        ExtractLarkText(handler.Bodies[0]!).Should().Be("Full output moved to https://example.feishu.cn/docx/doccn_123");
+    }
+
+    [Fact]
+    public async Task ExecuteSkillAsync_OverLimitOutput_ShouldFallBackToChunks_WhenDocDecisionHasNoLink()
+    {
+        var output = string.Join("\n\n", Enumerable.Repeat(
+            new string('x', SkillRunnerStreamingReplySink.MaxLarkTextLength - 1_000),
+            2));
+        var expectedChunks = SkillRunnerOutputChunker.Split(output);
+        var provider = new StubStreamingProviderFactory(
+            new StubStreamingTurn([output]),
+            new StubStreamingTurn(["DOCX_FALLBACK"]));
+        var handler = new SequencedHandler(
+            """{"code":0,"msg":"success","data":{"message_id":"om_part_1"}}""",
+            """{"code":0,"msg":"success","data":{"message_id":"om_part_2"}}""");
+        var agent = CreateAgent("skill-runner-docx-fallback", providerFactory: provider);
+        await agent.ActivateAsync();
+        var initialize = CreateInitializeCommand();
+        initialize.OutboundConfig.LarkReceiveId = "oc_chat_1";
+        initialize.OutboundConfig.LarkReceiveIdType = "chat_id";
+        await agent.HandleInitializeAsync(initialize);
+        AttachNyxIdApiClient(agent, handler);
+
+        var result = await InvokeExecuteSkillAsync(agent);
+
+        result.Should().Be(output);
+        provider.Requests.Should().HaveCount(2);
+        handler.Requests.Should().HaveCount(expectedChunks.Count);
+        ExtractLarkText(handler.Bodies[0]!).Should().Be(expectedChunks[0]);
+        ExtractLarkText(handler.Bodies[1]!).Should().Be(expectedChunks[1]);
+    }
+
+    [Fact]
+    public async Task ExecuteSkillAsync_BelowLimitOutput_ShouldNotInvokeDocDecision()
+    {
+        var provider = new StubStreamingProviderFactory("short output");
+        var handler = new SequencedHandler("""{"code":0,"msg":"success","data":{"message_id":"om_short"}}""");
+        var agent = CreateAgent("skill-runner-docx-not-needed", providerFactory: provider);
+        await agent.ActivateAsync();
+        await agent.HandleInitializeAsync(CreateInitializeCommand());
+        AttachNyxIdApiClient(agent, handler);
+
+        var result = await InvokeExecuteSkillAsync(agent);
+
+        result.Should().Be("short output");
+        provider.Requests.Should().ContainSingle();
+        handler.Requests.Should().ContainSingle();
+        ExtractLarkText(handler.Bodies[0]!).Should().Be("short output");
+    }
+
+    [Fact]
     public async Task SkillRunnerStreamingRunState_CoalescesInsideThrottleAndDispatchesAfterThrottle()
     {
         var handler = new SequencedHandler(
@@ -1213,12 +1314,14 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         string actorId,
         ServiceProvider? serviceProvider = null,
         IOwnerLlmConfigSource? ownerLlmConfigSource = null,
-        ILLMProviderFactory? providerFactory = null)
+        ILLMProviderFactory? providerFactory = null,
+        IEnumerable<IAgentToolSource>? toolSources = null)
     {
         var resolvedServices = serviceProvider ?? _serviceProvider;
         var agent = new SkillRunnerGAgent(
             llmProviderFactory: providerFactory,
-            ownerLlmConfigSource: ownerLlmConfigSource)
+            ownerLlmConfigSource: ownerLlmConfigSource,
+            toolSources: toolSources)
         {
             Services = resolvedServices,
             EventSourcingBehaviorFactory =
@@ -1270,8 +1373,40 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         setIdMethod!.Invoke(agent, [actorId]);
     }
 
-    private sealed class StubStreamingProviderFactory(params string[] deltas) : ILLMProviderFactory, ILLMProvider
+    private sealed record StubStreamingTurn(
+        IReadOnlyList<string> Deltas,
+        IReadOnlyList<ToolCall>? ToolCalls = null);
+
+    private sealed class SingleToolSource(IAgentTool tool) : IAgentToolSource
     {
+        public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<IAgentTool>>([tool]);
+    }
+
+    private sealed class FixedResultTool(string name, string result) : IAgentTool
+    {
+        public string Name => name;
+        public string Description => "Fixed result test tool";
+        public string ParametersSchema => "{}";
+        public ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
+            Task.FromResult(result);
+    }
+
+    private sealed class StubStreamingProviderFactory : ILLMProviderFactory, ILLMProvider
+    {
+        private readonly Queue<StubStreamingTurn> _turns;
+
+        public StubStreamingProviderFactory(params string[] deltas)
+            : this(new StubStreamingTurn(deltas))
+        {
+        }
+
+        public StubStreamingProviderFactory(params StubStreamingTurn[] turns)
+        {
+            _turns = new Queue<StubStreamingTurn>(turns);
+        }
+
         public string Name => "stub";
         public List<LLMRequest> Requests { get; } = [];
 
@@ -1280,11 +1415,20 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
             [EnumeratorCancellation] CancellationToken ct = default)
         {
             Requests.Add(request);
-            foreach (var delta in deltas)
+            var turn = _turns.Count > 0
+                ? _turns.Dequeue()
+                : new StubStreamingTurn([]);
+            foreach (var delta in turn.Deltas)
             {
                 ct.ThrowIfCancellationRequested();
                 await Task.Yield();
                 yield return new LLMStreamChunk { DeltaContent = delta };
+            }
+
+            if (turn.ToolCalls is { Count: > 0 })
+            {
+                foreach (var toolCall in turn.ToolCalls)
+                    yield return new LLMStreamChunk { DeltaToolCall = toolCall };
             }
 
             yield return new LLMStreamChunk { IsLast = true, FinishReason = "stop" };

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -1064,6 +1064,33 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ExecuteSkillAsync_OverLimitOutput_ShouldFallBackToChunks_WhenDocDecisionThrows()
+    {
+        var output = string.Join("\n\n", Enumerable.Repeat(
+            new string('x', SkillRunnerStreamingReplySink.MaxLarkTextLength - 1_000),
+            2));
+        var expectedChunks = SkillRunnerOutputChunker.Split(output);
+        var provider = new StubStreamingProviderFactory(
+            new StubStreamingTurn([output]),
+            new StubStreamingTurn(new InvalidOperationException("docx decision failed")));
+        var handler = new SequencedHandler(
+            """{"code":0,"msg":"success","data":{"message_id":"om_part_1"}}""",
+            """{"code":0,"msg":"success","data":{"message_id":"om_part_2"}}""");
+        var agent = CreateAgent("skill-runner-docx-exception-fallback", providerFactory: provider);
+        await agent.ActivateAsync();
+        await agent.HandleInitializeAsync(CreateInitializeCommand());
+        AttachNyxIdApiClient(agent, handler);
+
+        var result = await InvokeExecuteSkillAsync(agent);
+
+        result.Should().Be(output);
+        provider.Requests.Should().HaveCount(2);
+        handler.Requests.Should().HaveCount(expectedChunks.Count);
+        ExtractLarkText(handler.Bodies[0]!).Should().Be(expectedChunks[0]);
+        ExtractLarkText(handler.Bodies[1]!).Should().Be(expectedChunks[1]);
+    }
+
+    [Fact]
     public async Task ExecuteSkillAsync_BelowLimitOutput_ShouldNotInvokeDocDecision()
     {
         var provider = new StubStreamingProviderFactory("short output");
@@ -1375,7 +1402,14 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
 
     private sealed record StubStreamingTurn(
         IReadOnlyList<string> Deltas,
-        IReadOnlyList<ToolCall>? ToolCalls = null);
+        IReadOnlyList<ToolCall>? ToolCalls = null,
+        Exception? Error = null)
+    {
+        public StubStreamingTurn(Exception error)
+            : this([], null, error)
+        {
+        }
+    }
 
     private sealed class SingleToolSource(IAgentTool tool) : IAgentToolSource
     {
@@ -1418,6 +1452,8 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
             var turn = _turns.Count > 0
                 ? _turns.Dequeue()
                 : new StubStreamingTurn([]);
+            if (turn.Error is not null)
+                throw turn.Error;
             foreach (var delta in turn.Deltas)
             {
                 ct.ThrowIfCancellationRequested();


### PR DESCRIPTION
Closes #1771

## 摘要

解决 #1771：Lark bot 超长回复不再硬截断丢失内容。

- **Old**：回复超过 `SkillRunnerStreamingReplySink.MaxLarkTextLength`(30000) 时由 `TruncateForLark` 砍尾 + `…[truncated]`，用户可见内容丢失（`/daily` 等聚合长输出尤甚）。
- **New**：`SkillRunnerGAgent` 对超长 output 经同一 `ChatStreamAsync` 工具路径做一次有界二次判定，由 LLM 决定是否将完整内容写入飞书云文档（新增 `lark_docx_create` 工具，走现有 NyxID `api-lark-bot` 透传、应用身份）并回链接；任意 LLM/tool/docx/permission/timeout/no-link 失败一律回退 `SkillRunnerOutputChunker.Split(output)` 分块投递。保留 `TruncateForLark` 作单条消息硬 cap。

## 设计共识

Consensus-rnd Phase design-consensus r4 达成共识（framing=minimal）：minimal `propose` + structural `propose`（让步，四项扩展判 optional）+ delete `abstain`（Path-A 中立）。详见 #1771 共识卡片。

不改 NyxID（纯透传）/ 不引入 proto/readmodel / 不用 `ChatAsync` / 不硬编码具体 skill 名 / 无 CLAUDE.md·SPEC·Tier 变更。

## 范围（10 文件，+882/−13）

- 新增 `src/Aevatar.AI.ToolProviders.Lark/Tools/LarkDocxCreateTool.cs`（`lark_docx_create` 工具）
- `ILarkNyxClient` / `LarkNyxClient`：新增 docx create / append-blocks / permission 方法 + typed 请求/结果记录
- `LarkAgentToolSource`（注册）/ `LarkToolOptions`（`EnableDocxCreate`）/ `LarkProxyResponseParser`（解析 docx·permission 响应）
- `agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs`：超长输出二次判定 helper + 失败回退分块
- 测试：`LarkToolsTests` / `LarkCoverageTests` / `SkillRunnerGAgentTests`

## 验证

- `dotnet build aevatar.slnx --nologo`：**0 Errors**（52 NU1510 预存警告）
- `Aevatar.AI.ToolProviders.Lark.Tests`：**69 passed / 0 failed**
- `Aevatar.GAgents.ChannelRuntime.Tests`：**996 passed / 0 failed**

> 飞书云文档权限『已申请、待发布』，本 PR 以编译 + 单测（mock client / 失败回退路径）为验收，未做真实 Lark 端到端联调。

🤖 Auto-loop / consensus-rnd（manual scoped run, issue #1771）

⟦AI:AUTO-LOOP⟧
