### PR TITLE
实现 #1781 workflow tool typed request 收口

### DIFF
--- a/src/workflow/Aevatar.Workflow.Abstractions/Execution/IWorkflowExecutionContext.cs
+++ b/src/workflow/Aevatar.Workflow.Abstractions/Execution/IWorkflowExecutionContext.cs
@@ -10,6 +10,8 @@ public interface IWorkflowExecutionContext
 {
     string RunId { get; }
 
+    string ScopeId => string.Empty;
+
     // Refactor (iter89/cluster-089-workflow-module-clock-state):
     //   Old: Workflow modules read process wall clock directly for TTLs,
     //        timeout stamps, buffered signal eviction, and elapsed metrics.

--- a/src/workflow/Aevatar.Workflow.Core/Execution/IWorkflowExecutionStateHost.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/IWorkflowExecutionStateHost.cs
@@ -11,6 +11,8 @@ internal interface IWorkflowExecutionStateHost
 {
     string RunId { get; }
 
+    string ScopeId => string.Empty;
+
     WorkflowExecutionRuntimeContext RuntimeContext { get; }
 
     WorkflowRunExecutionContextState ExecutionContextSnapshot { get; }

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionContextAdapter.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionContextAdapter.cs
@@ -32,6 +32,8 @@ internal sealed class WorkflowExecutionContextAdapter :
 
     public string RunId => _stateHost.RunId;
 
+    public string ScopeId => _stateHost.ScopeId;
+
     public WorkflowExecutionRuntimeContext RuntimeContext => _stateHost.RuntimeContext;
 
     public IWorkflowExecutionStateHost StateHost => _stateHost;

--- a/src/workflow/Aevatar.Workflow.Core/Modules/IWorkflowToolSource.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/IWorkflowToolSource.cs
@@ -6,7 +6,7 @@ public interface IWorkflowTool
 {
     string Name { get; }
 
-    Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default);
+    Task<string> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default);
 }
 
 public sealed record WorkflowToolExecutionRequest(
@@ -17,11 +17,6 @@ public sealed record WorkflowToolExecutionRequest(
     string CallId,
     string ScopeId,
     WorkflowCallerCredential CallerCredential);
-
-public interface IWorkflowContextualTool : IWorkflowTool
-{
-    Task<string> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default);
-}
 
 public interface IWorkflowToolSource
 {

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
@@ -114,20 +114,17 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
         IWorkflowExecutionContext ctx,
         CancellationToken ct)
     {
-        if (tool is not IWorkflowContextualTool contextualTool)
-            return tool.ExecuteAsync(argumentsJson, ct);
-
         var callerCredential = WorkflowRunExecutionContextStateAccess.TryGetCallerCredential(ctx, out var credential)
             ? credential
             : new WorkflowCallerCredential();
-        return contextualTool.ExecuteAsync(
+        return tool.ExecuteAsync(
             new WorkflowToolExecutionRequest(
                 ArgumentsJson: argumentsJson,
                 RunId: request.RunId ?? string.Empty,
                 StepId: request.StepId ?? string.Empty,
                 ExecutionId: request.ExecutionId ?? string.Empty,
                 CallId: callId,
-                ScopeId: string.Empty,
+                ScopeId: ctx.ScopeId ?? string.Empty,
                 CallerCredential: callerCredential),
             ct);
     }

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
@@ -99,6 +99,8 @@ public sealed class WorkflowRunGAgent
         ? Id
         : State.RunId;
 
+    public string ScopeId => State.ScopeId ?? string.Empty;
+
     WorkflowExecutionRuntimeContext IWorkflowExecutionStateHost.RuntimeContext => _runtimeContext;
 
     // Refactor (iter115/cluster-3): Old pattern: callers received the mutable

--- a/src/workflow/Aevatar.Workflow.Integration.AI/AgentWorkflowToolSourceAdapter.cs
+++ b/src/workflow/Aevatar.Workflow.Integration.AI/AgentWorkflowToolSourceAdapter.cs
@@ -21,22 +21,33 @@ public sealed class AgentWorkflowToolSourceAdapter(IEnumerable<IAgentToolSource>
         return workflowTools;
     }
 
-    private sealed class AgentWorkflowToolAdapter(IAgentTool tool) : IWorkflowContextualTool
+    private sealed class AgentWorkflowToolAdapter(IAgentTool tool) : IWorkflowTool
     {
         private readonly IAgentTool _tool = tool ?? throw new ArgumentNullException(nameof(tool));
 
         public string Name => _tool.Name;
 
-        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
-            _tool.ExecuteAsync(argumentsJson, ct);
-
         public async Task<string> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
         {
             ArgumentNullException.ThrowIfNull(request);
 
-            var toolContext = WorkflowCallerCredentialToolContextMapper.FromCredential(request.CallerCredential);
+            var credentialContext = WorkflowCallerCredentialToolContextMapper.FromCredential(request.CallerCredential);
+            var toolContext = credentialContext with
+            {
+                Request = credentialContext.Request with
+                {
+                    CallId = Normalize(request.CallId),
+                },
+                Caller = credentialContext.Caller with
+                {
+                    ScopeId = Normalize(request.ScopeId),
+                },
+            };
             using var scope = AgentToolContextScope.Push(toolContext);
             return await _tool.ExecuteAsync(request.ArgumentsJson, ct).ConfigureAwait(false);
         }
+
+        private static string? Normalize(string? value) =>
+            string.IsNullOrWhiteSpace(value) ? null : value.Trim();
     }
 }

--- a/test/Aevatar.Bootstrap.Tests/AIFeatureBootstrapCoverageTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/AIFeatureBootstrapCoverageTests.cs
@@ -24,6 +24,7 @@ using Aevatar.Foundation.VoicePresence.Abstractions;
 using Aevatar.Foundation.VoicePresence.Abstractions.Sessions;
 using Aevatar.Foundation.VoicePresence.Hosting;
 using Aevatar.Foundation.VoicePresence.Modules;
+using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Core.Modules;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
@@ -560,7 +561,15 @@ public class AIFeatureBootstrapCoverageTests
             .Subject;
 
         tool.Name.Should().Be("demo_tool");
-        (await tool.ExecuteAsync("{}")).Should().Be("""{"ok":true}""");
+        (await tool.ExecuteAsync(
+            new WorkflowToolExecutionRequest(
+                ArgumentsJson: "{}",
+                RunId: "run-1",
+                StepId: "step-1",
+                ExecutionId: "exec-1",
+                CallId: "call-1",
+                ScopeId: "scope-1",
+                CallerCredential: new WorkflowCallerCredential()))).Should().Be("""{"ok":true}""");
     }
 
     [Fact]

--- a/test/Aevatar.Integration.Tests/WorkflowCoreModulesCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowCoreModulesCoverageTests.cs
@@ -1445,9 +1445,10 @@ public sealed class WorkflowCoreModulesCoverageTests
     {
         public string Name { get; } = name;
 
-        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+        public Task<string> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
         {
-            return Task.FromResult(execute(argumentsJson));
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(execute(request.ArgumentsJson));
         }
     }
 
@@ -1456,10 +1457,11 @@ public sealed class WorkflowCoreModulesCoverageTests
         public string Name { get; } = name;
         public int ExecuteCalls { get; private set; }
 
-        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+        public Task<string> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
         {
+            ct.ThrowIfCancellationRequested();
             ExecuteCalls++;
-            return Task.FromResult(execute(argumentsJson));
+            return Task.FromResult(execute(request.ArgumentsJson));
         }
     }
 

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionContextAdapterTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionContextAdapterTests.cs
@@ -1,13 +1,19 @@
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.EventModules;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Foundation.Core;
+using Aevatar.Foundation.Core.EventSourcing;
+using Aevatar.Workflow.Abstractions.Execution;
+using Aevatar.Workflow.Core.Composition;
 using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Core.Execution;
+using Aevatar.Workflow.Core.Modules;
 using FluentAssertions;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Reflection;
 
 namespace Aevatar.Workflow.Core.Tests.Execution;
 
@@ -37,6 +43,42 @@ public sealed class WorkflowExecutionContextAdapterTests
 
         adapter.RuntimeContext.Should().BeSameAs(host.RuntimeContext);
         adapter.RuntimeContext.RequestPassthroughMetadata.Values["trace-id"].Should().Be("abc");
+    }
+
+    [Fact]
+    public void ScopeId_ShouldExposeStateHostScopeId()
+    {
+        var host = new RecordingStateHost { ScopeId = "scope-1" };
+
+        var adapter = WorkflowExecutionContextAdapter.Create(new RecordingEventHandlerContext(), host);
+
+        adapter.ScopeId.Should().Be("scope-1");
+    }
+
+    [Fact]
+    public async Task ScopeId_ShouldFlowFromWorkflowRunStateHostToAdapter()
+    {
+        var agent = new WorkflowRunGAgent(
+            new UnsupportedActorRuntime(),
+            new UnsupportedActorRuntime(),
+            new EmptyEventModuleFactory(),
+            [])
+        {
+            EventSourcingBehaviorFactory = new InMemoryEventSourcingBehaviorFactory<WorkflowRunState>(),
+        };
+        SetAgentId(agent, "workflow-run-scope-bridge");
+
+        await agent.BindWorkflowRunDefinitionAsync(
+            definitionActorId: "definition-1",
+            workflowYaml: "",
+            workflowName: "wf_scope",
+            runId: "run-1",
+            scopeId: " scope-1 ");
+        var stateHost = (IWorkflowExecutionStateHost)agent;
+        var adapter = WorkflowExecutionContextAdapter.Create(new RecordingEventHandlerContext(), stateHost);
+
+        stateHost.ScopeId.Should().Be("scope-1");
+        adapter.ScopeId.Should().Be("scope-1");
     }
 
     [Fact]
@@ -279,6 +321,8 @@ public sealed class WorkflowExecutionContextAdapterTests
     {
         public string RunId { get; set; } = "run-1";
 
+        public string ScopeId { get; set; } = string.Empty;
+
         public WorkflowExecutionRuntimeContext RuntimeContext { get; } = new();
 
         public WorkflowRunExecutionContextState ExecutionContextState { get; } = new();
@@ -406,4 +450,116 @@ public sealed class WorkflowExecutionContextAdapterTests
         TimeSpan Period,
         Any Event,
         EventEnvelopePublishOptions? Options);
+
+    private static void SetAgentId(GAgentBase agent, string agentId)
+    {
+        var setIdMethod = typeof(GAgentBase).GetMethod(
+            "SetId",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        setIdMethod.Should().NotBeNull();
+        setIdMethod!.Invoke(agent, [agentId]);
+    }
+
+    private sealed class InMemoryEventSourcingBehaviorFactory<TState>
+        : IEventSourcingBehaviorFactory<TState>
+        where TState : class, IMessage<TState>, new()
+    {
+        public IEventSourcingBehavior<TState> Create(
+            string agentId,
+            global::System.Type actorType,
+            Func<TState, IMessage, TState> transitionState)
+        {
+            _ = actorType;
+            return new InMemoryEventSourcingBehavior<TState>(agentId, transitionState);
+        }
+    }
+
+    private sealed class InMemoryEventSourcingBehavior<TState>(
+        string agentId,
+        Func<TState, IMessage, TState> transitionState)
+        : IEventSourcingBehavior<TState>
+        where TState : class, IMessage<TState>, new()
+    {
+        private readonly List<IMessage> _pending = [];
+        private TState _state = new();
+
+        public long CurrentVersion { get; private set; }
+
+        public void RaiseEvent<TEvent>(TEvent evt)
+            where TEvent : IMessage =>
+            _pending.Add(evt);
+
+        public Task<EventStoreCommitResult> ConfirmEventsAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            foreach (var evt in _pending)
+            {
+                _state = transitionState(_state, evt);
+                CurrentVersion++;
+            }
+
+            var result = new EventStoreCommitResult
+            {
+                AgentId = agentId,
+                LatestVersion = CurrentVersion,
+            };
+            _pending.Clear();
+            return Task.FromResult(result);
+        }
+
+        public Task PersistSnapshotAsync(TState currentState, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public Task<TState?> ReplayAsync(string replayAgentId, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult<TState?>(_state.Clone());
+        }
+
+        public void DiscardPendingEvents() => _pending.Clear();
+
+        public TState TransitionState(TState current, IMessage evt) =>
+            transitionState(current, evt);
+    }
+
+    private sealed class EmptyEventModuleFactory : IEventModuleFactory<IWorkflowExecutionContext>
+    {
+        public bool TryCreate(string name, out IEventModule<IWorkflowExecutionContext>? module)
+        {
+            _ = name;
+            module = null;
+            return false;
+        }
+    }
+
+    private sealed class UnsupportedActorRuntime : IActorRuntime, IActorDispatchPort
+    {
+        public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
+            where TAgent : IAgent =>
+            throw new NotSupportedException();
+
+        public Task<IActor> CreateAsync(global::System.Type agentType, string? id = null, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task DestroyAsync(string id, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<IActor?> GetAsync(string id) =>
+            throw new NotSupportedException();
+
+        public Task<bool> ExistsAsync(string id) =>
+            throw new NotSupportedException();
+
+        public Task LinkAsync(string parentId, string childId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task UnlinkAsync(string childId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<DispatchAdmission> DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
 }

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionContextAdapterTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionContextAdapterTests.cs
@@ -56,6 +56,17 @@ public sealed class WorkflowExecutionContextAdapterTests
     }
 
     [Fact]
+    public void ScopeId_ShouldDefaultToEmptyWhenStateHostDoesNotOverride()
+    {
+        IWorkflowExecutionStateHost host = new DefaultScopeStateHost();
+
+        var adapter = WorkflowExecutionContextAdapter.Create(new RecordingEventHandlerContext(), host);
+
+        host.ScopeId.Should().BeEmpty();
+        adapter.ScopeId.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task ScopeId_ShouldFlowFromWorkflowRunStateHostToAdapter()
     {
         var agent = new WorkflowRunGAgent(
@@ -67,6 +78,11 @@ public sealed class WorkflowExecutionContextAdapterTests
             EventSourcingBehaviorFactory = new InMemoryEventSourcingBehaviorFactory<WorkflowRunState>(),
         };
         SetAgentId(agent, "workflow-run-scope-bridge");
+        var stateHost = (IWorkflowExecutionStateHost)agent;
+        var adapterBeforeBind = WorkflowExecutionContextAdapter.Create(new RecordingEventHandlerContext(), stateHost);
+
+        stateHost.ScopeId.Should().BeEmpty();
+        adapterBeforeBind.ScopeId.Should().BeEmpty();
 
         await agent.BindWorkflowRunDefinitionAsync(
             definitionActorId: "definition-1",
@@ -74,7 +90,6 @@ public sealed class WorkflowExecutionContextAdapterTests
             workflowName: "wf_scope",
             runId: "run-1",
             scopeId: " scope-1 ");
-        var stateHost = (IWorkflowExecutionStateHost)agent;
         var adapter = WorkflowExecutionContextAdapter.Create(new RecordingEventHandlerContext(), stateHost);
 
         stateHost.ScopeId.Should().Be("scope-1");
@@ -361,6 +376,51 @@ public sealed class WorkflowExecutionContextAdapterTests
         {
             ct.ThrowIfCancellationRequested();
             States.Remove(scopeKey);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class DefaultScopeStateHost : IWorkflowExecutionStateHost
+    {
+        public string RunId => "run-1";
+
+        public WorkflowExecutionRuntimeContext RuntimeContext { get; } = new();
+
+        public WorkflowRunExecutionContextState ExecutionContextSnapshot { get; } = new();
+
+        public Task UpdateExecutionContextAsync(WorkflowRunExecutionContextDelta delta, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            _ = delta;
+            return Task.CompletedTask;
+        }
+
+        public Task ClearExecutionContextAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public Any? GetExecutionState(string scopeKey)
+        {
+            _ = scopeKey;
+            return null;
+        }
+
+        public IReadOnlyList<KeyValuePair<string, Any>> GetExecutionStates() => [];
+
+        public Task UpsertExecutionStateAsync(string scopeKey, Any state, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            _ = scopeKey;
+            _ = state;
+            return Task.CompletedTask;
+        }
+
+        public Task ClearExecutionStateAsync(string scopeKey, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            _ = scopeKey;
             return Task.CompletedTask;
         }
     }

--- a/test/Aevatar.Workflow.Core.Tests/Modules/AgentWorkflowToolSourceAdapterTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/AgentWorkflowToolSourceAdapterTests.cs
@@ -37,6 +37,37 @@ public sealed class AgentWorkflowToolSourceAdapterTests
     }
 
     [Theory]
+    [InlineData(null, null, null, null)]
+    [InlineData("", "", null, null)]
+    [InlineData("  ", "\t", null, null)]
+    [InlineData(" call-1 ", " scope-1 ", "call-1", "scope-1")]
+    public async Task WorkflowTool_ShouldNormalizeWorkflowCallAndScopeIdsForAgentToolContext(
+        string? callId,
+        string? scopeId,
+        string? expectedCallId,
+        string? expectedScopeId)
+    {
+        var agentTool = new CapturingAgentTool();
+        var adapter = new AgentWorkflowToolSourceAdapter([new SingleAgentToolSource(agentTool)]);
+        var tool = (await adapter.GetToolsAsync(CancellationToken.None)).Single();
+
+        await tool.ExecuteAsync(
+            new WorkflowToolExecutionRequest(
+                ArgumentsJson: "{}",
+                RunId: "run-1",
+                StepId: "step-1",
+                ExecutionId: "exec-1",
+                CallId: callId!,
+                ScopeId: scopeId!,
+                CallerCredential: new WorkflowCallerCredential()),
+            CancellationToken.None);
+
+        agentTool.ObservedCallId.Should().Be(expectedCallId);
+        agentTool.ObservedScopeId.Should().Be(expectedScopeId);
+        AgentToolRequestContext.Current.Should().BeNull();
+    }
+
+    [Theory]
     [InlineData("")]
     [InlineData("Basic token-123")]
     [InlineData("Bearer token-123")]

--- a/test/Aevatar.Workflow.Core.Tests/Modules/AgentWorkflowToolSourceAdapterTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/AgentWorkflowToolSourceAdapterTests.cs
@@ -9,14 +9,13 @@ namespace Aevatar.Workflow.Core.Tests.Modules;
 public sealed class AgentWorkflowToolSourceAdapterTests
 {
     [Fact]
-    public async Task ContextualTool_ShouldMapWorkflowCallerTokenToAgentToolContext()
+    public async Task WorkflowTool_ShouldMapWorkflowRequestToAgentToolExecutionContext()
     {
         var agentTool = new CapturingAgentTool();
         var adapter = new AgentWorkflowToolSourceAdapter([new SingleAgentToolSource(agentTool)]);
         var tool = (await adapter.GetToolsAsync(CancellationToken.None)).Single();
-        var contextualTool = tool.Should().BeAssignableTo<IWorkflowContextualTool>().Subject;
 
-        var result = await contextualTool.ExecuteAsync(
+        var result = await tool.ExecuteAsync(
             new WorkflowToolExecutionRequest(
                 ArgumentsJson: """{"ok":true}""",
                 RunId: "run-1",
@@ -31,6 +30,9 @@ public sealed class AgentWorkflowToolSourceAdapterTests
         agentTool.ObservedArgumentsJson.Should().Be("""{"ok":true}""");
         agentTool.ObservedAccessToken.Should().Be("token-123");
         agentTool.ObservedOrgToken.Should().Be("token-123");
+        agentTool.ObservedScopeId.Should().Be("scope-1");
+        agentTool.ObservedCallId.Should().Be("call-1");
+        agentTool.ObservedExternalMetadata.Should().NotContainKey("ExecutionId");
         AgentToolRequestContext.Current.Should().BeNull();
     }
 
@@ -39,13 +41,13 @@ public sealed class AgentWorkflowToolSourceAdapterTests
     [InlineData("Basic token-123")]
     [InlineData("Bearer token-123")]
     [InlineData("Bearer ")]
-    public async Task ContextualTool_ShouldIgnoreMalformedWorkflowCredential(string authorization)
+    public async Task WorkflowTool_ShouldIgnoreMalformedWorkflowCredential(string authorization)
     {
         var agentTool = new CapturingAgentTool();
         var adapter = new AgentWorkflowToolSourceAdapter([new SingleAgentToolSource(agentTool)]);
-        var contextualTool = (IWorkflowContextualTool)(await adapter.GetToolsAsync(CancellationToken.None)).Single();
+        var workflowTool = (await adapter.GetToolsAsync(CancellationToken.None)).Single();
 
-        await contextualTool.ExecuteAsync(
+        await workflowTool.ExecuteAsync(
             new WorkflowToolExecutionRequest(
                 ArgumentsJson: "{}",
                 RunId: "run-1",
@@ -55,20 +57,6 @@ public sealed class AgentWorkflowToolSourceAdapterTests
                 ScopeId: "scope-1",
                 CallerCredential: new WorkflowCallerCredential { BearerToken = authorization }),
             CancellationToken.None);
-
-        agentTool.ObservedAccessToken.Should().BeNull();
-        agentTool.ObservedOrgToken.Should().BeNull();
-        AgentToolRequestContext.Current.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task PlainToolExecution_ShouldNotPushWorkflowAuthorization()
-    {
-        var agentTool = new CapturingAgentTool();
-        var adapter = new AgentWorkflowToolSourceAdapter([new SingleAgentToolSource(agentTool)]);
-        var tool = (await adapter.GetToolsAsync(CancellationToken.None)).Single();
-
-        await tool.ExecuteAsync("{}", CancellationToken.None);
 
         agentTool.ObservedAccessToken.Should().BeNull();
         agentTool.ObservedOrgToken.Should().BeNull();
@@ -89,12 +77,18 @@ public sealed class AgentWorkflowToolSourceAdapterTests
 
         public string? ObservedOrgToken { get; private set; }
 
+        public string? ObservedScopeId { get; private set; }
+
+        public string? ObservedCallId { get; private set; }
+
+        public IReadOnlyDictionary<string, string> ObservedExternalMetadata { get; private set; } =
+            new Dictionary<string, string>(StringComparer.Ordinal);
+
         public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
             ObservedArgumentsJson = argumentsJson;
-            ObservedAccessToken = AgentToolRequestContext.NyxIdAccessToken;
-            ObservedOrgToken = AgentToolRequestContext.NyxIdOrgToken;
+            CaptureContext();
             return ExecuteAsyncCore(ct);
         }
 
@@ -102,9 +96,18 @@ public sealed class AgentWorkflowToolSourceAdapterTests
         {
             await Task.Yield();
             ct.ThrowIfCancellationRequested();
+            CaptureContext();
+            return """{"observed":true}""";
+        }
+
+        private void CaptureContext()
+        {
             ObservedAccessToken = AgentToolRequestContext.NyxIdAccessToken;
             ObservedOrgToken = AgentToolRequestContext.NyxIdOrgToken;
-            return """{"observed":true}""";
+            ObservedScopeId = AgentToolRequestContext.ScopeId;
+            ObservedCallId = AgentToolRequestContext.CallId;
+            ObservedExternalMetadata = AgentToolRequestContext.Current?.ExternalMetadata
+                ?? new Dictionary<string, string>(StringComparer.Ordinal);
         }
     }
 

--- a/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
@@ -94,27 +94,9 @@ public sealed class ToolCallModuleContextTests
     }
 
     [Fact]
-    public async Task ToolCallModule_ShouldExecuteWorkflowToolDirectly()
+    public async Task ToolCallModule_ShouldPassTypedWorkflowToolExecutionRequestToDirectTool()
     {
-        var tool = new CountingAgentTool("safe_tool", _ => """{"raw":true}""");
-        var module = CreateModule(tool);
-        var ctx = new RecordingWorkflowContext();
-
-        await ExecuteToolCallAsync(module, ctx, tool.Name);
-
-        tool.ExecuteCalls.Should().Be(1);
-        var toolResult = ctx.Published.Select(x => x.Event).OfType<WorkflowToolCallCompletedEvent>().Single();
-        toolResult.Success.Should().BeTrue();
-        toolResult.ResultJson.Should().Be("""{"raw":true}""");
-        var completed = LastCompleted(ctx);
-        completed.Success.Should().BeTrue();
-        completed.Output.Should().Be("""{"raw":true}""");
-    }
-
-    [Fact]
-    public async Task ToolCallModule_ShouldPassActorOwnedCallerCredentialToContextualTool()
-    {
-        var tool = new CapturingContextualTool("nyxid_tool");
+        var tool = new CapturingWorkflowTool("nyxid_tool");
         var module = CreateModule(tool);
         var ctx = new RecordingWorkflowContext();
         ctx.ExecutionContextState.CallerCredential = new WorkflowCallerCredentialState
@@ -139,14 +121,15 @@ public sealed class ToolCallModuleContextTests
         tool.LastRequest.StepId.Should().Be("call_proxy");
         tool.LastRequest.ExecutionId.Should().Be("exec-1");
         tool.LastRequest.CallId.Should().Be("workflow:run-1:call_proxy:exec-1");
+        tool.LastRequest.ScopeId.Should().Be("scope-1");
         tool.LastRequest.CallerCredential.BearerToken.Should().Be("typed-token");
         LastCompleted(ctx).Success.Should().BeTrue();
     }
 
     [Fact]
-    public async Task ToolCallModule_ShouldIgnoreMetadataOnlyCallerCredentialForContextualTool()
+    public async Task ToolCallModule_ShouldNotUseRequestMetadataAsCallerCredential()
     {
-        var tool = new CapturingContextualTool("nyxid_tool");
+        var tool = new CapturingWorkflowTool("nyxid_tool");
         var module = CreateModule(tool);
         var ctx = new RecordingWorkflowContext();
         ctx.RuntimeContext.ApplyRequestMetadata(new Dictionary<string, string>(StringComparer.Ordinal)
@@ -159,6 +142,19 @@ public sealed class ToolCallModuleContextTests
         tool.LastRequest.Should().NotBeNull();
         tool.LastRequest!.CallerCredential.BearerToken.Should().BeEmpty();
         LastCompleted(ctx).Success.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IWorkflowTool_ShouldExposeOnlyTypedWorkflowExecutionMethod()
+    {
+        var executeMethods = typeof(IWorkflowTool)
+            .GetMethods()
+            .Where(method => method.Name == nameof(IWorkflowTool.ExecuteAsync))
+            .ToList();
+
+        executeMethods.Should().ContainSingle();
+        executeMethods[0].GetParameters().First().ParameterType.Should().Be(typeof(WorkflowToolExecutionRequest));
+        executeMethods[0].GetParameters().Should().NotContain(parameter => parameter.ParameterType == typeof(string));
     }
 
     private static ToolCallModule CreateModule(IWorkflowTool tool) =>
@@ -206,10 +202,10 @@ public sealed class ToolCallModuleContextTests
     {
         public string Name { get; } = name;
 
-        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+        public Task<string> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
-            return Task.FromResult(execute(argumentsJson));
+            return Task.FromResult(execute(request.ArgumentsJson));
         }
     }
 
@@ -219,28 +215,25 @@ public sealed class ToolCallModuleContextTests
 
         public int ExecuteCalls { get; private set; }
 
-        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+        public Task<string> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
             ExecuteCalls++;
-            return Task.FromResult(execute(argumentsJson));
+            return Task.FromResult(execute(request.ArgumentsJson));
         }
     }
 
-    private sealed class CapturingContextualTool(string name) : IWorkflowContextualTool
+    private sealed class CapturingWorkflowTool(string name) : IWorkflowTool
     {
         public string Name { get; } = name;
 
         public WorkflowToolExecutionRequest? LastRequest { get; private set; }
 
-        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
-            throw new InvalidOperationException("Contextual execution is required.");
-
         public Task<string> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
             LastRequest = request;
-            return Task.FromResult("""{"contextual":true}""");
+            return Task.FromResult("""{"typed":true}""");
         }
     }
 
@@ -267,6 +260,8 @@ public sealed class ToolCallModuleContextTests
         public string AgentId => "agent-1";
 
         public string RunId => "run-1";
+
+        public string ScopeId => "scope-1";
 
         public IServiceProvider Services { get; } = new EmptyServiceProvider();
 

--- a/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
@@ -127,6 +127,20 @@ public sealed class ToolCallModuleContextTests
     }
 
     [Fact]
+    public async Task ToolCallModule_ShouldFallbackToEmptyScopeIdWhenContextScopeIdIsNull()
+    {
+        var tool = new CapturingWorkflowTool("nyxid_tool");
+        var module = CreateModule(tool);
+        var ctx = new RecordingWorkflowContext { ScopeIdOverride = null };
+
+        await ExecuteToolCallAsync(module, ctx, tool.Name);
+
+        tool.LastRequest.Should().NotBeNull();
+        tool.LastRequest!.ScopeId.Should().BeEmpty();
+        LastCompleted(ctx).Success.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task ToolCallModule_ShouldNotUseRequestMetadataAsCallerCredential()
     {
         var tool = new CapturingWorkflowTool("nyxid_tool");
@@ -261,7 +275,9 @@ public sealed class ToolCallModuleContextTests
 
         public string RunId => "run-1";
 
-        public string ScopeId => "scope-1";
+        public string? ScopeIdOverride { get; init; } = "scope-1";
+
+        public string ScopeId => ScopeIdOverride!;
 
         public IServiceProvider Services { get; } = new EmptyServiceProvider();
 


### PR DESCRIPTION
## Summary / 摘要

实现 #1781：将 workflow tool execution 从 plain/contextual 双轨收敛到单一 `WorkflowToolExecutionRequest` 强类型入口。

- **Old**：`IWorkflowTool.ExecuteAsync(string argumentsJson)` 与可选 `IWorkflowContextualTool` 并存，`ToolCallModule` 可以回退到丢失 run/step/execution/call/scope/caller credential 的 plain path。
- **New**：`IWorkflowTool.ExecuteAsync(WorkflowToolExecutionRequest, ...)` 是唯一 workflow-owned contract；direct `tool_call` 永远传 typed request；`AgentWorkflowToolSourceAdapter` 只在 AI 边界映射 `ScopeId`、`CallId` 与 caller credential。

## Scope / 范围

- 删除 workflow tool contextual/plain 双轨接口形态。
- 为 workflow execution context 暴露 actor-owned `ScopeId`。
- 更新 `ToolCallModule`、AI tool adapter 和相关测试 double。
- 补充 direct tool call typed request、AI adapter mapping、ScopeId production bridge 测试。

## Replacement note / 替代说明

此 PR 替代 #1784。#1784 的远端 head 被非目标提交推进，包含与 #1781 无关的 console UI / skill 文件改动；为避免把非目标改动带入本目标 PR，保留该远端分支不覆盖，并用本 clean target branch 重新开 PR。

## Verification / 验证

Implement/fix workers 已完成：

- focused workflow tests：通过，22 passed。
- Workflow Core tests：通过，306 passed。
- `bash -lc "$BUILD_CMD"`：通过，0 errors。
- `bash -lc "$TEST_CMD"`：通过，process exit 0。
- `bash tools/ci/architecture_guards.sh`：通过。
- `bash tools/ci/test_stability_guards.sh`：通过。
- `git diff --check`：通过。

Closes #1781

🤖 controller status banner

⟦AI:AUTO-LOOP⟧
