### PR TITLE
实现 workflow caller credential 后续收口

### DIFF
--- a/docs/canon/nyxid-llm-integration.md
+++ b/docs/canon/nyxid-llm-integration.md
@@ -54,6 +54,16 @@ llm-anthropic/claude-haiku-4-5
 
 ---
 
+## Workflow caller credential 边界
+
+Workflow 层只承载 provider-neutral 调用者凭据与路由偏好。`WorkflowCallerCredential.BearerToken` 保存的是已经规范化的 raw bearer token，不包含 HTTP `Authorization` scheme；`WorkflowLlmControl.RoutePreference` / workflow proto `route_preference` 表达的是 workflow 自身的路由偏好，不使用 NyxID 专有字段名。
+
+Host/Infrastructure 只负责从 HTTP header 提取 bearer scheme，并把 raw token 交给 workflow-owned `WorkflowCallerCredentialTokens.ParseOptional` 做一次规范化与 fail-closed 校验。进入 Workflow Application/Core 后，调用者凭据继续作为 typed workflow credential 在 command、actor state 与 LLM execution intent 中传递；不得在 workflow 中间层通过 headers、metadata 或 provider-specific 字段回填身份语义。
+
+NyxID 专有映射只发生在 `Workflow.Integration.AI` 边界：workflow raw token 分别映射到 LLM provider auth 与 tool execution credentials，workflow `RoutePreference` 在这里映射为 provider-specific `NyxIdRoutePreference`。NyxID provider 本身继续读取 typed provider auth，不从 tool context 或 workflow headers 兜底推断身份。
+
+---
+
 ## Channel Route 选择
 
 Lark bot 等 channel surface 通过 `/model`、`/models`、`/llm`、`/route` 暴露同一组 LLM route 命令：

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -2967,16 +2967,18 @@ const response = await fetch("{{invokePath}}", {
 
         var model = NormalizeOptional(control.ModelOverride);
         var userMemoryPrompt = NormalizeOptional(control.UserMemoryPrompt);
+        var routePreference = NormalizeOptional(control.NyxIdRoutePreference);
         var maxToolRounds = control.MaxToolRoundsOverride is > 0
             ? control.MaxToolRoundsOverride
             : null;
-        if (model == null && userMemoryPrompt == null && maxToolRounds == null)
+        if (model == null && userMemoryPrompt == null && routePreference == null && maxToolRounds == null)
             return null;
 
         return new WorkflowLlmControl(
             model,
             maxToolRounds,
-            userMemoryPrompt);
+            userMemoryPrompt,
+            routePreference);
     }
 
     private static async Task<LLMControlContext?> BuildScopedLlmControlAsync(

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -124,13 +124,21 @@ public static class ScopeServiceEndpoints
                 return;
             }
 
+            var callerCredential = WorkflowCallerCredentialExtractor.Extract(http);
+            if (!callerCredential.Succeeded)
+            {
+                var (statusCode, code, message) = ScopeWorkflowEndpoints.MapRunStartError(callerCredential.Error);
+                await WriteJsonErrorResponseAsync(http, statusCode, code, message, ct);
+                return;
+            }
+
             var chatRequest = new WorkflowChatRunRequest(
                 Prompt: request.Prompt?.Trim() ?? string.Empty,
                 Source: WorkflowChatSource.InlineYamlBundle(request.WorkflowYamls),
                 SessionId: request.SessionId,
                 Metadata: scopedHeaders,
                 ScopeId: scopeId,
-                CallerCredential: WorkflowCallerCredentialExtractor.Extract(http),
+                CallerCredential: callerCredential.Credential,
                 LlmControl: ToWorkflowLlmControl(await BuildScopedLlmControlAsync(http, ct)),
                 Headers: scopedHeaders);
 
@@ -1499,6 +1507,14 @@ public static class ScopeServiceEndpoints
 
             var normalizedPrompt = request.Prompt?.Trim() ?? string.Empty;
             var scopedHeaders = BuildScopedHeaders(request.Headers);
+            var callerCredential = WorkflowCallerCredentialExtractor.Extract(http);
+            if (!callerCredential.Succeeded)
+            {
+                var (statusCode, code, message) = ScopeWorkflowEndpoints.MapRunStartError(callerCredential.Error);
+                await WriteJsonErrorResponseAsync(http, statusCode, code, message, ct);
+                return;
+            }
+
             var invocationRequest = BuildStreamInvocationRequest(
                 options.Value,
                 scopeId,
@@ -1506,7 +1522,7 @@ public static class ScopeServiceEndpoints
                 endpointId,
                 normalizedPrompt,
                 scopedHeaders,
-                WorkflowCallerCredentialExtractor.Extract(http),
+                callerCredential.Credential,
                 request.RevisionId,
                 appId);
             var target = await resolutionService.ResolveAsync(invocationRequest, ct);

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
@@ -439,6 +439,14 @@ public static class ScopeWorkflowEndpoints
         CancellationToken ct)
     {
         prompt = string.IsNullOrWhiteSpace(prompt) ? string.Empty : prompt.Trim();
+        var callerCredential = WorkflowCallerCredentialExtractor.Extract(http);
+        if (!callerCredential.Succeeded)
+        {
+            var (statusCode, code, message) = MapRunStartError(callerCredential.Error);
+            await WriteJsonErrorResponseAsync(http, statusCode, code, message, ct);
+            return;
+        }
+
         await HandleAguiStreamAsync(
             http,
             new WorkflowChatRunRequest(
@@ -447,7 +455,7 @@ public static class ScopeWorkflowEndpoints
                 sessionId,
                 Metadata: headers,
                 ScopeId: NormalizeRequired(scopeId, nameof(scopeId)),
-                CallerCredential: WorkflowCallerCredentialExtractor.Extract(http),
+                CallerCredential: callerCredential.Credential,
                 LlmControl: ToWorkflowLlmControl(llmControl),
                 Headers: headers),
             chatRunService,
@@ -662,6 +670,7 @@ public static class ScopeWorkflowEndpoints
             WorkflowChatRunStartError.InvalidWorkflowYaml => (StatusCodes.Status400BadRequest, "INVALID_WORKFLOW_YAML", "Workflow YAML is invalid."),
             WorkflowChatRunStartError.WorkflowNameMismatch => (StatusCodes.Status400BadRequest, "WORKFLOW_NAME_MISMATCH", "Workflow name does not match workflow YAML."),
             WorkflowChatRunStartError.PromptRequired => (StatusCodes.Status400BadRequest, "PROMPT_REQUIRED", "Prompt is required."),
+            WorkflowChatRunStartError.InvalidCallerCredential => (StatusCodes.Status400BadRequest, "INVALID_CALLER_CREDENTIAL", "Caller credential is invalid."),
             _ => (StatusCodes.Status400BadRequest, "RUN_START_FAILED", "Failed to resolve actor."),
         };
     }

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
@@ -594,16 +594,18 @@ public static class ScopeWorkflowEndpoints
 
         var model = NormalizeOptional(control.ModelOverride);
         var userMemoryPrompt = NormalizeOptional(control.UserMemoryPrompt);
+        var routePreference = NormalizeOptional(control.NyxIdRoutePreference);
         var maxToolRounds = control.MaxToolRoundsOverride is > 0
             ? control.MaxToolRoundsOverride
             : null;
-        if (model == null && userMemoryPrompt == null && maxToolRounds == null)
+        if (model == null && userMemoryPrompt == null && routePreference == null && maxToolRounds == null)
             return null;
 
         return new WorkflowLlmControl(
             model,
             maxToolRounds,
-            userMemoryPrompt);
+            userMemoryPrompt,
+            routePreference);
     }
 
     internal static async Task<LLMControlContext?> BuildScopedLlmControlAsync(

--- a/src/workflow/Aevatar.Workflow.Abstractions/WorkflowCallerCredentialTokens.cs
+++ b/src/workflow/Aevatar.Workflow.Abstractions/WorkflowCallerCredentialTokens.cs
@@ -1,6 +1,5 @@
 namespace Aevatar.Workflow.Abstractions;
 
-// refactor helper, no behavior change
 public enum WorkflowCallerCredentialTokenParseStatus
 {
     Missing = 0,
@@ -8,7 +7,6 @@ public enum WorkflowCallerCredentialTokenParseStatus
     Invalid = 2,
 }
 
-// refactor helper, no behavior change
 public readonly record struct WorkflowCallerCredentialTokenParseResult(
     WorkflowCallerCredentialTokenParseStatus Status,
     string? NormalizedBearerToken)
@@ -20,7 +18,6 @@ public readonly record struct WorkflowCallerCredentialTokenParseResult(
     public bool IsInvalid => Status == WorkflowCallerCredentialTokenParseStatus.Invalid;
 }
 
-// refactor helper, no behavior change
 public static class WorkflowCallerCredentialTokens
 {
     public static WorkflowCallerCredentialTokenParseResult ParseOptional(string? rawBearerToken)

--- a/src/workflow/Aevatar.Workflow.Abstractions/WorkflowCallerCredentialTokens.cs
+++ b/src/workflow/Aevatar.Workflow.Abstractions/WorkflowCallerCredentialTokens.cs
@@ -1,0 +1,58 @@
+namespace Aevatar.Workflow.Abstractions;
+
+// refactor helper, no behavior change
+public enum WorkflowCallerCredentialTokenParseStatus
+{
+    Missing = 0,
+    Valid = 1,
+    Invalid = 2,
+}
+
+// refactor helper, no behavior change
+public readonly record struct WorkflowCallerCredentialTokenParseResult(
+    WorkflowCallerCredentialTokenParseStatus Status,
+    string? NormalizedBearerToken)
+{
+    public bool IsMissing => Status == WorkflowCallerCredentialTokenParseStatus.Missing;
+
+    public bool IsValid => Status == WorkflowCallerCredentialTokenParseStatus.Valid;
+
+    public bool IsInvalid => Status == WorkflowCallerCredentialTokenParseStatus.Invalid;
+}
+
+// refactor helper, no behavior change
+public static class WorkflowCallerCredentialTokens
+{
+    public static WorkflowCallerCredentialTokenParseResult ParseOptional(string? rawBearerToken)
+    {
+        if (string.IsNullOrWhiteSpace(rawBearerToken))
+            return new WorkflowCallerCredentialTokenParseResult(
+                WorkflowCallerCredentialTokenParseStatus.Missing,
+                null);
+
+        var normalized = rawBearerToken.Trim();
+        if (string.Equals(normalized, "Bearer", StringComparison.OrdinalIgnoreCase) ||
+            normalized.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase) ||
+            ContainsWhitespace(normalized))
+        {
+            return new WorkflowCallerCredentialTokenParseResult(
+                WorkflowCallerCredentialTokenParseStatus.Invalid,
+                null);
+        }
+
+        return new WorkflowCallerCredentialTokenParseResult(
+            WorkflowCallerCredentialTokenParseStatus.Valid,
+            normalized);
+    }
+
+    private static bool ContainsWhitespace(string value)
+    {
+        foreach (var c in value)
+        {
+            if (char.IsWhiteSpace(c))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -25,6 +25,7 @@ message WorkflowLlmControlContext {
   string model_override = 1;
   optional int32 max_tool_rounds_override = 2;
   string user_memory_prompt = 3;
+  string route_preference = 4;
 }
 
 message WorkflowCallerCredential {
@@ -88,6 +89,7 @@ message WorkflowRunLlmExecutionContextDelta
   string model_override = 2;
   optional int32 max_tool_rounds_override = 4;
   string user_memory_prompt = 5;
+  string route_preference = 7;
 }
 message WorkflowRunExecutionContextUpdatedEvent
 {
@@ -341,6 +343,7 @@ message WorkflowLlmExecutionIntent
   map<string, string> headers = 9;
   map<string, string> annotations = 10;
   WorkflowCallerCredential caller_credential = 12;
+  string route_preference = 13;
 }
 
 message WorkflowLlmInvocationStartedEvent

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunModels.cs
@@ -25,7 +25,8 @@ public sealed record WorkflowChatInputPart
 public sealed record WorkflowLlmControl(
     string? ModelOverride = null,
     int? MaxToolRoundsOverride = null,
-    string? UserMemoryPrompt = null);
+    string? UserMemoryPrompt = null,
+    string? RoutePreference = null);
 
 public sealed record WorkflowCallerCredential(string? BearerToken = null);
 
@@ -166,6 +167,7 @@ public enum WorkflowChatRunStartError
     WorkflowNameMismatch = 8,
     PromptRequired = 9,
     ProjectionUnavailable = 10,
+    InvalidCallerCredential = 11,
 }
 
 public enum WorkflowProjectionCompletionStatus

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs
@@ -78,6 +78,7 @@ internal sealed class WorkflowChatRequestEnvelopeFactory : ICommandEnvelopeFacto
         {
             ModelOverride = source.ModelOverride ?? string.Empty,
             UserMemoryPrompt = source.UserMemoryPrompt ?? string.Empty,
+            RoutePreference = source.RoutePreference ?? string.Empty,
         };
         if (source.MaxToolRoundsOverride.HasValue)
             payload.MaxToolRoundsOverride = source.MaxToolRoundsOverride.Value;
@@ -85,11 +86,17 @@ internal sealed class WorkflowChatRequestEnvelopeFactory : ICommandEnvelopeFacto
     }
 
     private static Aevatar.Workflow.Abstractions.WorkflowCallerCredential ToProto(
-        Application.Abstractions.Runs.WorkflowCallerCredential? source) =>
-        new()
+        Application.Abstractions.Runs.WorkflowCallerCredential? source)
+    {
+        var parsed = WorkflowCallerCredentialTokens.ParseOptional(source?.BearerToken);
+        if (parsed.IsInvalid)
+            throw new ArgumentException("Workflow caller credential bearer token is invalid.", nameof(source));
+
+        return new Aevatar.Workflow.Abstractions.WorkflowCallerCredential
         {
-            BearerToken = Normalize(source?.BearerToken),
+            BearerToken = parsed.NormalizedBearerToken ?? string.Empty,
         };
+    }
 
     private static void AppendMetadata(
         Google.Protobuf.Collections.MapField<string, string> destination,

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs
@@ -126,6 +126,4 @@ internal sealed class WorkflowChatRequestEnvelopeFactory : ICommandEnvelopeFacto
         string.Equals(key, "scope_id", StringComparison.Ordinal) ||
         string.Equals(key, WorkflowRunCommandMetadataKeys.ScopeId, StringComparison.Ordinal);
 
-    private static string Normalize(string? value) =>
-        string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
 }

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRunInteractionService.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRunInteractionService.cs
@@ -1,4 +1,5 @@
 using Aevatar.CQRS.Core.Abstractions.Interactions;
+using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Projections;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 
@@ -88,6 +89,9 @@ internal sealed class WorkflowChatRunInteractionService : IWorkflowChatRunIntera
     {
         if (!_projectionPort.ProjectionEnabled)
             return AttemptStartResult.Failure(WorkflowChatRunStartError.ProjectionDisabled);
+
+        if (WorkflowCallerCredentialTokens.ParseOptional(request.CallerCredential?.BearerToken).IsInvalid)
+            return AttemptStartResult.Failure(WorkflowChatRunStartError.InvalidCallerCredential);
 
         var actorResolution = await _actorResolver.ResolveOrCreateAsync(request, ct).ConfigureAwait(false);
         if (actorResolution.Error != WorkflowChatRunStartError.None || actorResolution.Target == null)

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunAcceptedCommandTargetResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunAcceptedCommandTargetResolver.cs
@@ -1,4 +1,5 @@
 using Aevatar.CQRS.Core.Abstractions.Commands;
+using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 
 namespace Aevatar.Workflow.Application.Runs;
@@ -28,6 +29,10 @@ internal sealed class WorkflowRunAcceptedCommandTargetResolver
         //   Old pattern: accepted-only dispatch reused interaction targets that owned live sinks
         //   New principle: accepted-only target split + NoOp binder default + receipt-only(no live sink acquired)
         ArgumentNullException.ThrowIfNull(command);
+
+        if (WorkflowCallerCredentialTokens.ParseOptional(command.CallerCredential?.BearerToken).IsInvalid)
+            return CommandTargetResolution<WorkflowRunAcceptedCommandTarget, WorkflowChatRunStartError>.Failure(
+                WorkflowChatRunStartError.InvalidCallerCredential);
 
         var actorResolution = await _actorResolver.ResolveOrCreateAsync(command, ct);
         if (actorResolution.Error != WorkflowChatRunStartError.None || actorResolution.Target == null)

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunCommandTargetResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunCommandTargetResolver.cs
@@ -1,4 +1,5 @@
 using Aevatar.CQRS.Core.Abstractions.Commands;
+using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Projections;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 
@@ -33,6 +34,10 @@ internal sealed class WorkflowRunCommandTargetResolver
         if (!_projectionPort.ProjectionEnabled)
             return CommandTargetResolution<WorkflowRunCommandTarget, WorkflowChatRunStartError>.Failure(
                 WorkflowChatRunStartError.ProjectionDisabled);
+
+        if (WorkflowCallerCredentialTokens.ParseOptional(command.CallerCredential?.BearerToken).IsInvalid)
+            return CommandTargetResolution<WorkflowRunCommandTarget, WorkflowChatRunStartError>.Failure(
+                WorkflowChatRunStartError.InvalidCallerCredential);
 
         if (command.TargetSeed != null)
             return ResolveSeededTarget(command, command.TargetSeed);

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowCallerCredentialRuntimeContextAccess.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowCallerCredentialRuntimeContextAccess.cs
@@ -10,7 +10,10 @@ internal static class WorkflowCallerCredentialRuntimeContextAccess
         CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(stateHost);
-        if (string.IsNullOrWhiteSpace(credential?.BearerToken))
+        var parsed = WorkflowCallerCredentialTokens.ParseOptional(credential?.BearerToken);
+        if (parsed.IsInvalid)
+            throw new ArgumentException("Workflow caller credential bearer token is invalid.", nameof(credential));
+        if (parsed.IsMissing)
         {
             return stateHost.UpdateExecutionContextAsync(
                 new WorkflowRunExecutionContextDelta
@@ -26,7 +29,7 @@ internal static class WorkflowCallerCredentialRuntimeContextAccess
                 ClearCallerCredential = true,
                 CallerCredential = new WorkflowCallerCredential
                 {
-                    BearerToken = credential.BearerToken.Trim(),
+                    BearerToken = parsed.NormalizedBearerToken ?? string.Empty,
                 },
             },
             ct);

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunExecutionContextStateAccess.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunExecutionContextStateAccess.cs
@@ -38,13 +38,15 @@ internal static class WorkflowRunExecutionContextStateAccess
         {
             ClearCallerCredential = true,
         };
-        var normalized = Normalize(credential?.BearerToken);
-        if (string.IsNullOrWhiteSpace(normalized))
+        var parsed = WorkflowCallerCredentialTokens.ParseOptional(credential?.BearerToken);
+        if (parsed.IsInvalid)
+            throw new ArgumentException("Workflow caller credential bearer token is invalid.", nameof(credential));
+        if (parsed.IsMissing)
             return delta;
 
         delta.CallerCredential = new WorkflowCallerCredential
         {
-            BearerToken = normalized,
+            BearerToken = parsed.NormalizedBearerToken ?? string.Empty,
         };
 
         return delta;
@@ -73,12 +75,14 @@ internal static class WorkflowRunExecutionContextStateAccess
         {
             ModelOverride = Normalize(llmControl.ModelOverride),
             UserMemoryPrompt = Normalize(llmControl.UserMemoryPrompt),
+            RoutePreference = Normalize(llmControl.RoutePreference),
         };
         if (llmControl.HasMaxToolRoundsOverride)
             llm.MaxToolRoundsOverride = llmControl.MaxToolRoundsOverride;
 
         if (string.IsNullOrWhiteSpace(llm.ModelOverride) &&
             string.IsNullOrWhiteSpace(llm.UserMemoryPrompt) &&
+            string.IsNullOrWhiteSpace(llm.RoutePreference) &&
             !llm.HasMaxToolRoundsOverride)
         {
             return delta;
@@ -93,11 +97,12 @@ internal static class WorkflowRunExecutionContextStateAccess
         out WorkflowCallerCredential credential)
     {
         var callerCredential = Get(ctx).CallerCredential;
-        if (!string.IsNullOrWhiteSpace(callerCredential?.BearerToken))
+        var parsed = WorkflowCallerCredentialTokens.ParseOptional(callerCredential?.BearerToken);
+        if (parsed.IsValid)
         {
             credential = new WorkflowCallerCredential
             {
-                BearerToken = callerCredential.BearerToken.Trim(),
+                BearerToken = parsed.NormalizedBearerToken ?? string.Empty,
             };
             return true;
         }
@@ -113,6 +118,7 @@ internal static class WorkflowRunExecutionContextStateAccess
         llm = Get(ctx).Llm ?? new WorkflowLlmExecutionContextState();
         return !string.IsNullOrWhiteSpace(llm.ModelOverride) ||
                !string.IsNullOrWhiteSpace(llm.UserMemoryPrompt) ||
+               !string.IsNullOrWhiteSpace(llm.RoutePreference) ||
                llm.HasMaxToolRoundsOverride;
     }
 

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.cs
@@ -829,7 +829,8 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
         if (WorkflowCallerCredentialRuntimeContextAccess.TryGetCredential(ctx, out var credential) &&
             !string.IsNullOrWhiteSpace(credential.BearerToken))
         {
-            return $"Bearer {credential.BearerToken.Trim()}";
+            var parsed = WorkflowCallerCredentialTokens.ParseOptional(credential.BearerToken);
+            return parsed.IsValid ? $"Bearer {parsed.NormalizedBearerToken}" : string.Empty;
         }
 
         return string.Empty;

--- a/src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs
@@ -390,6 +390,7 @@ public sealed class LLMCallModule : IEventModule<IWorkflowExecutionContext>
         {
             intent.Model = Normalize(llm.ModelOverride) ?? string.Empty;
             intent.UserMemoryPrompt = Normalize(llm.UserMemoryPrompt) ?? string.Empty;
+            intent.RoutePreference = Normalize(llm.RoutePreference) ?? string.Empty;
             if (llm.HasMaxToolRoundsOverride)
                 intent.MaxToolRounds = llm.MaxToolRoundsOverride;
         }

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
@@ -859,6 +859,7 @@ public sealed class WorkflowRunGAgent
             {
                 ModelOverride = delta.Llm.ModelOverride?.Trim() ?? string.Empty,
                 UserMemoryPrompt = delta.Llm.UserMemoryPrompt?.Trim() ?? string.Empty,
+                RoutePreference = delta.Llm.RoutePreference?.Trim() ?? string.Empty,
             };
             if (delta.Llm.HasMaxToolRoundsOverride)
                 state.Llm.MaxToolRoundsOverride = delta.Llm.MaxToolRoundsOverride;
@@ -866,9 +867,10 @@ public sealed class WorkflowRunGAgent
 
         if (delta.CallerCredential != null)
         {
+            var parsed = WorkflowCallerCredentialTokens.ParseOptional(delta.CallerCredential.BearerToken);
             state.CallerCredential = new WorkflowCallerCredentialState
             {
-                BearerToken = delta.CallerCredential.BearerToken?.Trim() ?? string.Empty,
+                BearerToken = parsed.IsValid ? parsed.NormalizedBearerToken ?? string.Empty : string.Empty,
             };
         }
     }

--- a/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
+++ b/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
@@ -158,6 +158,7 @@ message WorkflowLlmExecutionContextState
   string model_override = 2;
   optional int32 max_tool_rounds_override = 4;
   string user_memory_prompt = 5;
+  string route_preference = 6;
 }
 
 message WorkflowCallerCredentialState

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
@@ -50,10 +50,19 @@ public static class WorkflowCapabilityEndpoints
         {
             var defaultMetadata = TryResolveRuntimeDefaultMetadata(serviceProvider, logger);
             var callerCredential = WorkflowCallerCredentialExtractor.Extract(http);
+            if (!callerCredential.Succeeded)
+            {
+                var (code, message) = ChatRunStartErrorMapper.ToCommandError(callerCredential.Error);
+                var statusCode = ChatRunStartErrorMapper.ToHttpStatusCode(callerCredential.Error);
+                scope.MarkResult(statusCode);
+                await WriteJsonErrorResponseAsync(http, statusCode, code, message, ct);
+                return;
+            }
+
             var normalizedRequest = ChatRunRequestNormalizer.Normalize(
                 input,
                 defaultMetadata,
-                trustedCallerCredential: callerCredential);
+                trustedCallerCredential: callerCredential.Credential);
             if (!normalizedRequest.Succeeded)
             {
                 var (code, message) = ChatRunStartErrorMapper.ToCommandError(normalizedRequest.Error);

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunRequestNormalizer.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunRequestNormalizer.cs
@@ -1,5 +1,6 @@
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Application.Runs;
+using WorkflowProtocol = Aevatar.Workflow.Abstractions;
 
 namespace Aevatar.Workflow.Infrastructure.CapabilityApi;
 
@@ -54,6 +55,10 @@ internal static class ChatRunRequestNormalizer
         if (rawPrompt.Length == 0)
             return ChatRunRequestNormalizationResult.Failed(WorkflowChatRunStartError.PromptRequired);
 
+        var callerCredentialResult = NormalizeCallerCredential(trustedCallerCredential);
+        if (callerCredentialResult.Error != WorkflowChatRunStartError.None)
+            return ChatRunRequestNormalizationResult.Failed(callerCredentialResult.Error);
+
         return ChatRunRequestNormalizationResult.Success(
             new WorkflowChatRunRequest(
                 Prompt: rawPrompt,
@@ -63,14 +68,22 @@ internal static class ChatRunRequestNormalizer
                 Metadata: normalizedMetadata,
                 ScopeId: normalizedContext.ScopeId,
                 LlmControl: NormalizeLlmControl(input.LlmControl),
-                CallerCredential: NormalizeCallerCredential(trustedCallerCredential),
+                CallerCredential: callerCredentialResult.Credential,
                 Headers: normalizedContext.Headers));
     }
 
-    private static WorkflowCallerCredential? NormalizeCallerCredential(WorkflowCallerCredential? source)
+    private readonly record struct CallerCredentialNormalizationResult(
+        WorkflowCallerCredential? Credential,
+        WorkflowChatRunStartError Error);
+
+    private static CallerCredentialNormalizationResult NormalizeCallerCredential(WorkflowCallerCredential? source)
     {
-        var bearer = NormalizeOptional(source?.BearerToken);
-        return bearer == null ? null : new WorkflowCallerCredential(bearer);
+        var parsed = WorkflowProtocol.WorkflowCallerCredentialTokens.ParseOptional(source?.BearerToken);
+        if (parsed.IsInvalid)
+            return new CallerCredentialNormalizationResult(null, WorkflowChatRunStartError.InvalidCallerCredential);
+        return new CallerCredentialNormalizationResult(
+            parsed.IsMissing ? null : new WorkflowCallerCredential(parsed.NormalizedBearerToken),
+            WorkflowChatRunStartError.None);
     }
 
     private static WorkflowLlmControl? NormalizeLlmControl(ChatLlmControlInput? source)
@@ -81,7 +94,8 @@ internal static class ChatRunRequestNormalizer
         return new WorkflowLlmControl(
             NormalizeOptional(source.ModelOverride),
             source.MaxToolRoundsOverride is > 0 ? source.MaxToolRoundsOverride : null,
-            NormalizeOptional(source.UserMemoryPrompt));
+            NormalizeOptional(source.UserMemoryPrompt),
+            NormalizeOptional(source.NyxIdRoutePreference));
     }
 
     private static string? NormalizeOptional(string? value) =>

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunStartErrorMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunStartErrorMapper.cs
@@ -19,6 +19,7 @@ internal static class ChatRunStartErrorMapper
             WorkflowChatRunStartError.InvalidWorkflowYaml => StatusCodes.Status400BadRequest,
             WorkflowChatRunStartError.WorkflowNameMismatch => StatusCodes.Status400BadRequest,
             WorkflowChatRunStartError.PromptRequired => StatusCodes.Status400BadRequest,
+            WorkflowChatRunStartError.InvalidCallerCredential => StatusCodes.Status400BadRequest,
             _ => StatusCodes.Status400BadRequest,
         };
     }
@@ -37,6 +38,7 @@ internal static class ChatRunStartErrorMapper
             WorkflowChatRunStartError.InvalidWorkflowYaml => ("INVALID_WORKFLOW_YAML", "Workflow YAML is invalid."),
             WorkflowChatRunStartError.WorkflowNameMismatch => ("WORKFLOW_NAME_MISMATCH", "Workflow name does not match workflow YAML."),
             WorkflowChatRunStartError.PromptRequired => ("PROMPT_REQUIRED", "Prompt is required."),
+            WorkflowChatRunStartError.InvalidCallerCredential => ("INVALID_CALLER_CREDENTIAL", "Caller credential is invalid."),
             _ => ("RUN_START_FAILED", "Failed to resolve actor."),
         };
     }

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowCallerCredentialExtractor.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowCallerCredentialExtractor.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Aevatar.Workflow.Application.Abstractions.Runs;
+using WorkflowProtocol = Aevatar.Workflow.Abstractions;
 
 namespace Aevatar.Workflow.Infrastructure.CapabilityApi;
 
@@ -10,12 +11,20 @@ public static class WorkflowCallerCredentialExtractor
     public static WorkflowCallerCredential? Extract(HttpContext? http)
     {
         var auth = http?.Request.Headers.Authorization.FirstOrDefault();
-        if (auth == null || !auth.StartsWith(BearerPrefix, StringComparison.OrdinalIgnoreCase))
+        if (auth == null)
+            return null;
+        if (string.Equals(auth.Trim(), "Bearer", StringComparison.OrdinalIgnoreCase))
+            return new WorkflowCallerCredential("Bearer");
+        if (!auth.StartsWith(BearerPrefix, StringComparison.OrdinalIgnoreCase))
             return null;
 
         var bearerToken = auth[BearerPrefix.Length..].Trim();
-        return string.IsNullOrWhiteSpace(bearerToken)
-            ? null
-            : new WorkflowCallerCredential(bearerToken);
+        var parsed = WorkflowProtocol.WorkflowCallerCredentialTokens.ParseOptional(bearerToken);
+        if (parsed.IsValid)
+            return new WorkflowCallerCredential(parsed.NormalizedBearerToken);
+        if (parsed.IsInvalid)
+            return new WorkflowCallerCredential(bearerToken);
+
+        return new WorkflowCallerCredential("Bearer");
     }
 }

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowCallerCredentialExtractor.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowCallerCredentialExtractor.cs
@@ -8,23 +8,35 @@ public static class WorkflowCallerCredentialExtractor
 {
     private const string BearerPrefix = "Bearer ";
 
-    public static WorkflowCallerCredential? Extract(HttpContext? http)
+    public static WorkflowCallerCredentialExtractionResult Extract(HttpContext? http)
     {
         var auth = http?.Request.Headers.Authorization.FirstOrDefault();
         if (auth == null)
-            return null;
+            return WorkflowCallerCredentialExtractionResult.Success(null);
         if (string.Equals(auth.Trim(), "Bearer", StringComparison.OrdinalIgnoreCase))
-            return new WorkflowCallerCredential("Bearer");
+            return WorkflowCallerCredentialExtractionResult.Failure(WorkflowChatRunStartError.InvalidCallerCredential);
         if (!auth.StartsWith(BearerPrefix, StringComparison.OrdinalIgnoreCase))
-            return null;
+            return WorkflowCallerCredentialExtractionResult.Success(null);
 
         var bearerToken = auth[BearerPrefix.Length..].Trim();
         var parsed = WorkflowProtocol.WorkflowCallerCredentialTokens.ParseOptional(bearerToken);
         if (parsed.IsValid)
-            return new WorkflowCallerCredential(parsed.NormalizedBearerToken);
-        if (parsed.IsInvalid)
-            return new WorkflowCallerCredential(bearerToken);
+            return WorkflowCallerCredentialExtractionResult.Success(
+                new WorkflowCallerCredential(parsed.NormalizedBearerToken));
 
-        return new WorkflowCallerCredential("Bearer");
+        return WorkflowCallerCredentialExtractionResult.Failure(WorkflowChatRunStartError.InvalidCallerCredential);
     }
+}
+
+public readonly record struct WorkflowCallerCredentialExtractionResult(
+    WorkflowCallerCredential? Credential,
+    WorkflowChatRunStartError Error)
+{
+    public bool Succeeded => Error == WorkflowChatRunStartError.None;
+
+    public static WorkflowCallerCredentialExtractionResult Success(WorkflowCallerCredential? credential) =>
+        new(credential, WorkflowChatRunStartError.None);
+
+    public static WorkflowCallerCredentialExtractionResult Failure(WorkflowChatRunStartError error) =>
+        new(null, error);
 }

--- a/src/workflow/Aevatar.Workflow.Integration.AI/WorkflowCallerCredentialToolContextMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Integration.AI/WorkflowCallerCredentialToolContextMapper.cs
@@ -7,42 +7,19 @@ internal static class WorkflowCallerCredentialToolContextMapper
 {
     public static AgentToolExecutionContext FromCredential(WorkflowCallerCredential? credential)
     {
-        var token = NormalizeToken(credential?.BearerToken);
-        if (token == null)
+        var token = WorkflowCallerCredentialTokens.ParseOptional(credential?.BearerToken);
+        if (token.IsMissing)
             return AgentToolExecutionContext.Empty;
+        if (token.IsInvalid)
+            throw new ArgumentException("Workflow caller credential bearer token is invalid.", nameof(credential));
 
         return AgentToolExecutionContext.Empty with
         {
             Credentials = AgentToolCredentials.Empty with
             {
-                NyxIdAccessToken = token,
-                NyxIdOrgToken = token,
+                NyxIdAccessToken = token.NormalizedBearerToken,
+                NyxIdOrgToken = token.NormalizedBearerToken,
             },
         };
-    }
-
-    private static string? NormalizeToken(string? rawToken)
-    {
-        var normalized = string.IsNullOrWhiteSpace(rawToken) ? string.Empty : rawToken.Trim();
-        if (normalized.Length == 0 ||
-            string.Equals(normalized, "Bearer", StringComparison.OrdinalIgnoreCase) ||
-            normalized.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase) ||
-            ContainsWhitespace(normalized))
-        {
-            return null;
-        }
-
-        return normalized;
-    }
-
-    private static bool ContainsWhitespace(string value)
-    {
-        foreach (var c in value)
-        {
-            if (char.IsWhiteSpace(c))
-                return true;
-        }
-
-        return false;
     }
 }

--- a/src/workflow/Aevatar.Workflow.Integration.AI/WorkflowRoleGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Integration.AI/WorkflowRoleGAgent.cs
@@ -129,16 +129,29 @@ public class WorkflowRoleGAgent(
 
     private static ChatRequestEvent BuildChatRequestFromWorkflowIntent(WorkflowLlmExecutionIntent intent)
     {
+        var toolContext = WorkflowCallerCredentialToolContextMapper.FromCredential(intent.CallerCredential);
+        if (!string.IsNullOrWhiteSpace(intent.RoutePreference))
+        {
+            toolContext = toolContext with
+            {
+                Routing = toolContext.Routing with
+                {
+                    NyxIdRoutePreference = intent.RoutePreference.Trim(),
+                },
+            };
+        }
+
         var request = new ChatRequestEvent
         {
             Prompt = intent.Prompt ?? string.Empty,
             SessionId = intent.SessionId ?? string.Empty,
             TimeoutMs = intent.TimeoutMs,
-            ToolContext = AgentToolExecutionContextMapper.ToPayload(
-                WorkflowCallerCredentialToolContextMapper.FromCredential(intent.CallerCredential)),
+            ToolContext = AgentToolExecutionContextMapper.ToPayload(toolContext),
             LlmControl = new LLMControlContextPayload
             {
+                NyxIdAccessToken = toolContext.Credentials.NyxIdAccessToken ?? string.Empty,
                 ModelOverride = intent.Model ?? string.Empty,
+                NyxIdRoutePreference = toolContext.Routing.NyxIdRoutePreference ?? string.Empty,
                 UserMemoryPrompt = intent.UserMemoryPrompt ?? string.Empty,
             },
         };

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -1428,6 +1428,33 @@ public sealed class ScopeServiceEndpointsTests
     }
 
     [Fact]
+    public async Task ScopeDraftRunEndpoint_ShouldReturnInvalidCallerCredential_WhenBearerIsMalformed()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, "/api/scopes/scope-a/workflow/draft-run")
+        {
+            Content = JsonContent.Create(new
+            {
+                prompt = "run the draft",
+                workflowYamls = new[]
+                {
+                    "name: main\nroles:\n  - id: assistant\n    name: Assistant\nsteps:\n  - id: reply\n    type: llm_call\n    target_role: assistant",
+                },
+            }),
+        };
+        httpRequest.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "token 123");
+
+        var response = await host.Client.SendAsync(httpRequest);
+        var body = await response.Content.ReadFromJsonAsync<Dictionary<string, string>>();
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        body.Should().NotBeNull();
+        body!["code"].Should().Be("INVALID_CALLER_CREDENTIAL");
+        body["message"].Should().Be("Caller credential is invalid.");
+        host.InteractionService.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
     public async Task ScopeInvokeStreamEndpoint_ShouldResolveDefaultServiceAndDelegateToWorkflowPipeline()
     {
         await using var host = await ScopeServiceEndpointTestHost.StartAsync();
@@ -1527,6 +1554,30 @@ public sealed class ScopeServiceEndpointsTests
         host.ServiceRunRegistrationPort.RegisterCalls[0].CommandId.Should().Be("cmd-1");
         host.ServiceRunRegistrationPort.RegisterCalls[0].TargetActorId.Should().Be("run-actor-1");
         host.ServiceRunRegistrationPort.RegisterCalls[0].ImplementationKind.Should().Be(ServiceImplementationKind.Workflow);
+    }
+
+    [Fact]
+    public async Task ScopeInvokeStreamEndpoint_ShouldReturnInvalidCallerCredential_WhenBearerIsMalformed()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, "/api/scopes/scope-a/invoke/chat:stream")
+        {
+            Content = JsonContent.Create(new
+            {
+                prompt = "hello",
+            }),
+        };
+        httpRequest.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "token 123");
+
+        var response = await host.Client.SendAsync(httpRequest);
+        var body = await response.Content.ReadFromJsonAsync<Dictionary<string, string>>();
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        body.Should().NotBeNull();
+        body!["code"].Should().Be("INVALID_CALLER_CREDENTIAL");
+        body["message"].Should().Be("Caller credential is invalid.");
+        host.ServiceCatalogReader.Service.Should().BeNull();
+        host.InteractionService.LastRequest.Should().BeNull();
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -1390,6 +1390,39 @@ public sealed class ScopeServiceEndpointsTests
     }
 
     [Fact]
+    public async Task ScopeDraftRunEndpoint_ShouldPropagateScopedPreferredLlmRouteToAguiRequest()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync(
+            userConfigQueryPort: new StubUserConfigStore(
+                new UserConfig(DefaultModel: string.Empty, PreferredLlmRoute: "/preferred-route")));
+        host.InteractionService.ResultFactory = async (_, _, onAcceptedAsync, ct) =>
+        {
+            var receipt = new WorkflowChatRunAcceptedReceipt("run-actor-1", "main", "cmd-1", "corr-1");
+            if (onAcceptedAsync != null)
+                await onAcceptedAsync(receipt, ct);
+
+            return CommandInteractionResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
+        };
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/workflow/draft-run", new
+        {
+            prompt = "run the draft",
+            workflowYamls = new[]
+            {
+                "name: main\nroles:\n  - id: assistant\n    name: Assistant\nsteps:\n  - id: reply\n    type: llm_call\n    target_role: assistant",
+            },
+            eventFormat = "agui",
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        host.InteractionService.LastRequest.Should().NotBeNull();
+        host.InteractionService.LastRequest!.LlmControl.Should().NotBeNull();
+        host.InteractionService.LastRequest.LlmControl!.RoutePreference.Should().Be("/preferred-route");
+        host.InteractionService.LastRequest.LlmControl.ModelOverride.Should().BeNull();
+    }
+
+    [Fact]
     public async Task ScopeDraftRunEndpoint_ShouldReturnBadRequest_WhenEventFormatIsInvalid()
     {
         await using var host = await ScopeServiceEndpointTestHost.StartAsync();
@@ -4759,7 +4792,9 @@ public sealed class ScopeServiceEndpointsTests
 
         public FakeServiceRunQueryPort ServiceRunQueryPort { get; }
 
-        public static async Task<ScopeServiceEndpointTestHost> StartAsync(bool authenticationEnabled = true)
+        public static async Task<ScopeServiceEndpointTestHost> StartAsync(
+            bool authenticationEnabled = true,
+            IUserConfigQueryPort? userConfigQueryPort = null)
         {
             var builder = WebApplication.CreateBuilder(new WebApplicationOptions
             {
@@ -4832,6 +4867,8 @@ public sealed class ScopeServiceEndpointsTests
             builder.Services.AddSingleton<IActorEventSubscriptionProvider>(eventSubscriptionProvider);
             builder.Services.AddSingleton<IServiceRunRegistrationPort>(serviceRunRegistrationPort);
             builder.Services.AddSingleton<IServiceRunQueryPort>(serviceRunQueryPort);
+            if (userConfigQueryPort != null)
+                builder.Services.AddSingleton(userConfigQueryPort);
             builder.Services.AddSingleton<IOptions<ScopeWorkflowCapabilityOptions>>(
                 Options.Create(new ScopeWorkflowCapabilityOptions
                 {

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
@@ -10,6 +10,7 @@ using Aevatar.GAgentService.Governance.Abstractions;
 using Aevatar.GAgentService.Governance.Abstractions.Ports;
 using Aevatar.GAgentService.Governance.Abstractions.Queries;
 using Aevatar.GAgentService.Hosting.Endpoints;
+using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.Workflow.Abstractions;
@@ -426,6 +427,63 @@ public sealed class ScopeWorkflowEndpointsTests
     }
 
     [Fact]
+    public async Task HandleRunWorkflowByIdStreamAsync_ShouldPropagateScopedPreferredLlmRouteToAguiRequest()
+    {
+        var snapshot = new ServiceCatalogSnapshot(
+            "tenant-a:workflow-app:user:token:approval",
+            "tenant-a",
+            "workflow-app",
+            "user:user-1-token",
+            "approval",
+            "Approval",
+            "rev-1",
+            "rev-1",
+            "dep-1",
+            "definition-actor-1",
+            "active",
+            [],
+            [],
+            DateTimeOffset.UtcNow);
+        var queryPort = new FakeServiceLifecycleQueryPort
+        {
+            ListServicesResult = [snapshot],
+        };
+        queryPort.GetServiceResults.Enqueue(snapshot);
+        var interactionService = new FakeCommandInteractionService
+        {
+            ResultFactory = async (_, _, onAcceptedAsync, ct) =>
+            {
+                var receipt = new WorkflowChatRunAcceptedReceipt("definition-actor-1", "approval", "cmd-1", "corr-1");
+                if (onAcceptedAsync != null)
+                    await onAcceptedAsync(receipt, ct);
+
+                return CommandInteractionResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
+            },
+        };
+        var http = CreateHttpContext(
+            userConfigQueryPort: new StubUserConfigStore(
+                new UserConfig(DefaultModel: string.Empty, PreferredLlmRoute: "/preferred-route")));
+
+        await ScopeWorkflowEndpoints.HandleRunWorkflowByIdStreamAsync(
+            http,
+            "user-1",
+            "approval",
+            new ScopeWorkflowEndpoints.RunScopeWorkflowByIdStreamHttpRequest(
+                "hello",
+                EventFormat: "agui"),
+            BuildQueryPort(queryPort: queryPort),
+            interactionService,
+            CancellationToken.None);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        interactionService.LastRequest.Should().NotBeNull();
+        interactionService.LastRequest!.LlmControl.Should().NotBeNull();
+        interactionService.LastRequest.LlmControl!.RoutePreference.Should().Be("/preferred-route");
+        interactionService.LastRequest.LlmControl.ModelOverride.Should().BeNull();
+    }
+
+    [Fact]
     public async Task HandleRunWorkflowByIdStreamAsync_ShouldReturnInvalidCallerCredential_WhenBearerIsMalformed()
     {
         var snapshot = new ServiceCatalogSnapshot(
@@ -766,11 +824,13 @@ public sealed class ScopeWorkflowEndpointsTests
             }));
     }
 
-    private static DefaultHttpContext CreateHttpContext(string scopeId = "user-1")
+    private static DefaultHttpContext CreateHttpContext(
+        string scopeId = "user-1",
+        IUserConfigQueryPort? userConfigQueryPort = null)
     {
         var http = new DefaultHttpContext
         {
-            RequestServices = BuildRequestServices(),
+            RequestServices = BuildRequestServices(userConfigQueryPort),
         };
         http.Response.Body = new MemoryStream();
         http.User = new ClaimsPrincipal(
@@ -792,13 +852,18 @@ public sealed class ScopeWorkflowEndpointsTests
         return http;
     }
 
-    private static ServiceProvider BuildRequestServices() =>
-        new ServiceCollection()
+    private static ServiceProvider BuildRequestServices(IUserConfigQueryPort? userConfigQueryPort = null)
+    {
+        var services = new ServiceCollection()
             .AddLogging()
             .AddOptions()
             .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
-            .AddSingleton<IHostEnvironment>(new TestHostEnvironment())
-            .BuildServiceProvider();
+            .AddSingleton<IHostEnvironment>(new TestHostEnvironment());
+        if (userConfigQueryPort != null)
+            services.AddSingleton(userConfigQueryPort);
+
+        return services.BuildServiceProvider();
+    }
 
     private sealed class TestHostEnvironment : IHostEnvironment
     {
@@ -861,6 +926,13 @@ public sealed class ScopeWorkflowEndpointsTests
             LastRequest = request;
             return ResultFactory(request, emitAsync, onAcceptedAsync, ct);
         }
+    }
+
+    private sealed class StubUserConfigStore(UserConfig config) : IUserConfigQueryPort
+    {
+        public Task<UserConfig> GetAsync(CancellationToken ct = default) => Task.FromResult(config);
+
+        public Task<UserConfig> GetAsync(string scopeId, CancellationToken ct = default) => GetAsync(ct);
     }
 
     private sealed class FakeServiceCommandPort : IServiceCommandPort

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
@@ -426,6 +426,51 @@ public sealed class ScopeWorkflowEndpointsTests
     }
 
     [Fact]
+    public async Task HandleRunWorkflowByIdStreamAsync_ShouldReturnInvalidCallerCredential_WhenBearerIsMalformed()
+    {
+        var snapshot = new ServiceCatalogSnapshot(
+            "tenant-a:workflow-app:user:token:approval",
+            "tenant-a",
+            "workflow-app",
+            "user:user-1-token",
+            "approval",
+            "Approval",
+            "rev-1",
+            "rev-1",
+            "dep-1",
+            "definition-actor-1",
+            "active",
+            [],
+            [],
+            DateTimeOffset.UtcNow);
+        var queryPort = new FakeServiceLifecycleQueryPort
+        {
+            ListServicesResult = [snapshot],
+        };
+        queryPort.GetServiceResults.Enqueue(snapshot);
+        var interactionService = new FakeCommandInteractionService();
+        var http = CreateHttpContext();
+        http.Request.Headers.Authorization = "Bearer token 123";
+
+        await ScopeWorkflowEndpoints.HandleRunWorkflowByIdStreamAsync(
+            http,
+            "user-1",
+            "approval",
+            new ScopeWorkflowEndpoints.RunScopeWorkflowByIdStreamHttpRequest(
+                "hello",
+                EventFormat: "agui"),
+            BuildQueryPort(queryPort: queryPort),
+            interactionService,
+            CancellationToken.None);
+
+        var body = await ReadBodyAsync(http.Response);
+        http.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        body.Should().Contain("INVALID_CALLER_CREDENTIAL");
+        body.Should().Contain("Caller credential is invalid.");
+        interactionService.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
     public async Task HandleRunWorkflowByIdStreamAsync_ShouldSerializeRawObservedWorkflowExecutionStartedPayload()
     {
         var snapshot = new ServiceCatalogSnapshot(

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationRegistrationAndExecutionTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationRegistrationAndExecutionTests.cs
@@ -347,7 +347,8 @@ public sealed class WorkflowApplicationRegistrationAndExecutionTests
             LlmControl: new WorkflowLlmControl(
                 ModelOverride: " model-a ",
                 MaxToolRoundsOverride: 3,
-                UserMemoryPrompt: " memory "));
+                UserMemoryPrompt: " memory ",
+                RoutePreference: " route-a "));
 
         var envelope = factory.CreateEnvelope(command, new CommandContext(
             "actor-1",
@@ -359,6 +360,7 @@ public sealed class WorkflowApplicationRegistrationAndExecutionTests
         request.LlmControl.ModelOverride.Should().Be(" model-a ");
         request.LlmControl.MaxToolRoundsOverride.Should().Be(3);
         request.LlmControl.UserMemoryPrompt.Should().Be(" memory ");
+        request.LlmControl.RoutePreference.Should().Be(" route-a ");
     }
 
     [Fact]
@@ -381,7 +383,8 @@ public sealed class WorkflowApplicationRegistrationAndExecutionTests
             LlmControl: new WorkflowLlmControl(
                 ModelOverride: "model-a",
                 MaxToolRoundsOverride: 5,
-                UserMemoryPrompt: "memory"));
+                UserMemoryPrompt: "memory",
+                RoutePreference: "route-a"));
 
         var envelope = factory.CreateEnvelope(command, new CommandContext(
             "actor-1",
@@ -394,9 +397,32 @@ public sealed class WorkflowApplicationRegistrationAndExecutionTests
         request.LlmControl.ModelOverride.Should().Be("model-a");
         request.LlmControl.MaxToolRoundsOverride.Should().Be(5);
         request.LlmControl.UserMemoryPrompt.Should().Be("memory");
+        request.LlmControl.RoutePreference.Should().Be("route-a");
         request.Metadata.Should().Contain("client-note", "open-extension");
         request.Metadata.Should().NotContainKey(WorkflowRunCommandMetadataKeys.ScopeId);
         request.Metadata.Should().NotContainKey("scope_id");
+    }
+
+    [Fact]
+    public void EnvelopeFactory_ShouldRejectMalformedDirectCallerCredential()
+    {
+        var services = new ServiceCollection();
+        services.AddWorkflowApplication();
+        using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<ICommandEnvelopeFactory<WorkflowChatRunRequest>>();
+        var command = new WorkflowChatRunRequest(
+            "hello",
+            WorkflowChatSource.DefinitionActor("actor-1", "direct"),
+            CallerCredential: new Aevatar.Workflow.Application.Abstractions.Runs.WorkflowCallerCredential("Bearer token-123"));
+
+        FluentActions.Invoking(() => factory.CreateEnvelope(command, new CommandContext(
+                "actor-1",
+                "cmd-1",
+                "corr-1",
+                new Dictionary<string, string>())))
+            .Should()
+            .Throw<ArgumentException>()
+            .WithMessage("*caller credential*invalid*");
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowCallerCredentialTokensTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowCallerCredentialTokensTests.cs
@@ -1,0 +1,55 @@
+using Aevatar.Workflow.Abstractions;
+using FluentAssertions;
+
+namespace Aevatar.Workflow.Application.Tests;
+
+public sealed class WorkflowCallerCredentialTokensTests
+{
+    [Theory]
+    [InlineData("token-123", "token-123")]
+    [InlineData(" token-123 ", "token-123")]
+    [InlineData("Bearerfoo", "Bearerfoo")]
+    public void ParseOptional_ShouldReturnValidNormalizedRawToken(string rawToken, string expectedToken)
+    {
+        var result = WorkflowCallerCredentialTokens.ParseOptional(rawToken);
+
+        result.Status.Should().Be(WorkflowCallerCredentialTokenParseStatus.Valid);
+        result.IsValid.Should().BeTrue();
+        result.IsMissing.Should().BeFalse();
+        result.IsInvalid.Should().BeFalse();
+        result.NormalizedBearerToken.Should().Be(expectedToken);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void ParseOptional_ShouldReturnMissingForAbsentToken(string? rawToken)
+    {
+        var result = WorkflowCallerCredentialTokens.ParseOptional(rawToken);
+
+        result.Status.Should().Be(WorkflowCallerCredentialTokenParseStatus.Missing);
+        result.IsMissing.Should().BeTrue();
+        result.IsValid.Should().BeFalse();
+        result.IsInvalid.Should().BeFalse();
+        result.NormalizedBearerToken.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("Bearer")]
+    [InlineData("Bearer token-123")]
+    [InlineData("token 123")]
+    [InlineData("token\t123")]
+    [InlineData("token\n123")]
+    public void ParseOptional_ShouldReturnInvalidForMalformedRawToken(string rawToken)
+    {
+        var result = WorkflowCallerCredentialTokens.ParseOptional(rawToken);
+
+        result.Status.Should().Be(WorkflowCallerCredentialTokenParseStatus.Invalid);
+        result.IsInvalid.Should().BeTrue();
+        result.IsMissing.Should().BeFalse();
+        result.IsValid.Should().BeFalse();
+        result.NormalizedBearerToken.Should().BeNull();
+    }
+}

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowChatRunInteractionServiceTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowChatRunInteractionServiceTests.cs
@@ -38,6 +38,36 @@ public sealed class WorkflowChatRunInteractionServiceTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_ShouldReturnInvalidCallerCredential_BeforeActorResolutionOrActivation()
+    {
+        var actorResolver = new RecordingActorResolver();
+        var activationPort = new RecordingActivationPort();
+        var runProvisioningPort = new RecordingRunProvisioningPort();
+        var inner = new RecordingInteractionService();
+        var service = CreateService(
+            actorResolver,
+            new RecordingProjectionPort(),
+            activationPort,
+            runProvisioningPort,
+            inner);
+
+        var result = await service.ExecuteAsync(
+            new WorkflowChatRunRequest(
+                "hello",
+                WorkflowChatSource.CatalogWorkflow("direct"),
+                CallerCredential: new WorkflowCallerCredential("Bearer token-123")),
+            static (_, _) => ValueTask.CompletedTask);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(WorkflowChatRunStartError.InvalidCallerCredential);
+        actorResolver.Requests.Should().BeEmpty();
+        activationPort.Activations.Should().BeEmpty();
+        activationPort.Releases.Should().BeEmpty();
+        inner.Requests.Should().BeEmpty();
+        runProvisioningPort.DestroyCalls.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task ExecuteAsync_ShouldResolveActivateAndInvokeInnerWithSeedsAndTargetSeed()
     {
         var actorResolver = new RecordingActorResolver

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
@@ -106,6 +106,33 @@ public sealed class WorkflowRunOrchestrationComponentTests
     }
 
     [Fact]
+    public async Task WorkflowRunCommandTargetResolver_ShouldRejectInvalidCallerCredential_BeforeTargetResolution()
+    {
+        var actorResolver = new FakeWorkflowRunActorResolver(
+            new WorkflowActorResolutionResult(new WorkflowRunCreationReceipt("unexpected", string.Empty, []), "auto", WorkflowChatRunStartError.None));
+        var resolver = new WorkflowRunCommandTargetResolver(
+            actorResolver,
+            new FakeProjectionPort(),
+            new FakeWorkflowRunActorPort(),
+            new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
+        var request = new WorkflowChatRunRequest(
+            "hello",
+            WorkflowChatSource.CatalogWorkflow("direct"),
+            CallerCredential: new WorkflowCallerCredential("Bearer token-123"),
+            TargetSeed: new WorkflowRunTargetSeed(
+                ActorId: "run-1",
+                WorkflowNameForRun: "direct",
+                CreatedActorIds: ["definition-1", "run-1"],
+                Source: WorkflowChatSource.CatalogWorkflow("direct")));
+
+        var result = await resolver.ResolveAsync(request);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(WorkflowChatRunStartError.InvalidCallerCredential);
+        actorResolver.ResolveCallCount.Should().Be(0);
+    }
+
+    [Fact]
     public async Task WorkflowRunCommandTargetResolver_ShouldRejectSeed_WhenWorkflowNameDiffersFromRequest()
     {
         var resolver = new WorkflowRunCommandTargetResolver(
@@ -204,6 +231,27 @@ public sealed class WorkflowRunOrchestrationComponentTests
         result.Error.Should().Be(WorkflowChatRunStartError.WorkflowNotFound);
         result.Target.Should().BeNull();
         actorResolver.ResolveCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task WorkflowRunAcceptedCommandTargetResolver_ShouldRejectInvalidCallerCredential_BeforeActorResolution()
+    {
+        var actorResolver = new FakeWorkflowRunActorResolver(
+            new WorkflowActorResolutionResult(new WorkflowRunCreationReceipt("unexpected", string.Empty, []), "auto", WorkflowChatRunStartError.None));
+        var resolver = new WorkflowRunAcceptedCommandTargetResolver(
+            actorResolver,
+            new FakeWorkflowRunActorPort());
+
+        var result = await resolver.ResolveAsync(
+            new WorkflowChatRunRequest(
+                "hello",
+                WorkflowChatSource.CatalogWorkflow("auto"),
+                CallerCredential: new WorkflowCallerCredential("Bearer token-123")));
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(WorkflowChatRunStartError.InvalidCallerCredential);
+        result.Target.Should().BeNull();
+        actorResolver.ResolveCallCount.Should().Be(0);
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Core.Tests/Execution/IdempotentStepExecutionTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/IdempotentStepExecutionTests.cs
@@ -460,6 +460,7 @@ public sealed class IdempotentStepExecutionTests
             {
                 ModelOverride = delta.Llm.ModelOverride,
                 UserMemoryPrompt = delta.Llm.UserMemoryPrompt,
+                RoutePreference = delta.Llm.RoutePreference,
             };
             if (delta.Llm.HasMaxToolRoundsOverride)
                 state.Llm.MaxToolRoundsOverride = delta.Llm.MaxToolRoundsOverride;

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionContextAdapterTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionContextAdapterTests.cs
@@ -460,6 +460,7 @@ public sealed class WorkflowExecutionContextAdapterTests
             {
                 ModelOverride = delta.Llm.ModelOverride,
                 UserMemoryPrompt = delta.Llm.UserMemoryPrompt,
+                RoutePreference = delta.Llm.RoutePreference,
             };
             if (delta.Llm.HasMaxToolRoundsOverride)
                 state.Llm.MaxToolRoundsOverride = delta.Llm.MaxToolRoundsOverride;

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
@@ -56,11 +56,13 @@ public sealed class WorkflowExecutionRuntimeContextTests
                 ModelOverride = " model ",
                 MaxToolRoundsOverride = 3,
                 UserMemoryPrompt = " memory ",
+                RoutePreference = " route-a ",
             });
 
         host.ExecutionContextState.Llm.ModelOverride.Should().Be("model");
         host.ExecutionContextState.Llm.MaxToolRoundsOverride.Should().Be(3);
         host.ExecutionContextState.Llm.UserMemoryPrompt.Should().Be("memory");
+        host.ExecutionContextState.Llm.RoutePreference.Should().Be("route-a");
     }
 
     [Fact]
@@ -165,6 +167,12 @@ public sealed class WorkflowExecutionRuntimeContextTests
             new WorkflowCallerCredential { BearerToken = " " });
         emptyDelta.ClearCallerCredential.Should().BeTrue();
         emptyDelta.CallerCredential.Should().BeNull();
+
+        FluentActions.Invoking(() => WorkflowRunExecutionContextStateAccess.BuildCallerCredentialDelta(
+                new WorkflowCallerCredential { BearerToken = "Bearer secret" }))
+            .Should()
+            .Throw<ArgumentException>()
+            .WithMessage("*caller credential*invalid*");
     }
 
     [Fact]
@@ -190,6 +198,14 @@ public sealed class WorkflowExecutionRuntimeContextTests
         await WorkflowCallerCredentialRuntimeContextAccess.RemoveCredentialAsync(host);
 
         host.ExecutionContextState.CallerCredential.Should().BeNull();
+
+        await FluentActions.Awaiting(() => WorkflowCallerCredentialRuntimeContextAccess.SetCredentialAsync(
+                host,
+                new WorkflowCallerCredential { BearerToken = "Bearer secret" }))
+            .Should()
+            .ThrowAsync<ArgumentException>()
+            .WithMessage("*caller credential*invalid*");
+
         await FluentActions.Awaiting(() => WorkflowCallerCredentialRuntimeContextAccess.SetCredentialAsync(
                 null!,
                 new WorkflowCallerCredential { BearerToken = "secret" }))
@@ -215,6 +231,12 @@ public sealed class WorkflowExecutionRuntimeContextTests
         credential.BearerToken.Should().Be("secret");
 
         context.ExecutionContextState.CallerCredential.BearerToken = " ";
+        WorkflowCallerCredentialRuntimeContextAccess.TryGetCredential(context, out credential)
+            .Should()
+            .BeFalse();
+        credential.BearerToken.Should().BeEmpty();
+
+        context.ExecutionContextState.CallerCredential.BearerToken = "Bearer secret";
         WorkflowCallerCredentialRuntimeContextAccess.TryGetCredential(context, out credential)
             .Should()
             .BeFalse();
@@ -461,6 +483,7 @@ public sealed class WorkflowExecutionRuntimeContextTests
             {
                 ModelOverride = delta.Llm.ModelOverride,
                 UserMemoryPrompt = delta.Llm.UserMemoryPrompt,
+                RoutePreference = delta.Llm.RoutePreference,
             };
             if (delta.Llm.HasMaxToolRoundsOverride)
                 state.Llm.MaxToolRoundsOverride = delta.Llm.MaxToolRoundsOverride;

--- a/test/Aevatar.Workflow.Core.Tests/Modules/AgentWorkflowToolSourceAdapterTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/AgentWorkflowToolSourceAdapterTests.cs
@@ -69,10 +69,8 @@ public sealed class AgentWorkflowToolSourceAdapterTests
 
     [Theory]
     [InlineData("")]
-    [InlineData("Basic token-123")]
-    [InlineData("Bearer token-123")]
-    [InlineData("Bearer ")]
-    public async Task WorkflowTool_ShouldIgnoreMalformedWorkflowCredential(string authorization)
+    [InlineData("  ")]
+    public async Task WorkflowTool_ShouldUseEmptyAgentToolContextWhenWorkflowCredentialIsMissing(string authorization)
     {
         var agentTool = new CapturingAgentTool();
         var adapter = new AgentWorkflowToolSourceAdapter([new SingleAgentToolSource(agentTool)]);
@@ -91,6 +89,34 @@ public sealed class AgentWorkflowToolSourceAdapterTests
 
         agentTool.ObservedAccessToken.Should().BeNull();
         agentTool.ObservedOrgToken.Should().BeNull();
+        AgentToolRequestContext.Current.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("Basic token-123")]
+    [InlineData("Bearer token-123")]
+    [InlineData("Bearer ")]
+    [InlineData("token 123")]
+    public async Task WorkflowTool_ShouldRejectMalformedWorkflowCredential(string authorization)
+    {
+        var agentTool = new CapturingAgentTool();
+        var adapter = new AgentWorkflowToolSourceAdapter([new SingleAgentToolSource(agentTool)]);
+        var workflowTool = (await adapter.GetToolsAsync(CancellationToken.None)).Single();
+
+        await FluentActions.Awaiting(() => workflowTool.ExecuteAsync(
+                new WorkflowToolExecutionRequest(
+                    ArgumentsJson: "{}",
+                    RunId: "run-1",
+                    StepId: "step-1",
+                    ExecutionId: "exec-1",
+                    CallId: "call-1",
+                    ScopeId: "scope-1",
+                    CallerCredential: new WorkflowCallerCredential { BearerToken = authorization }),
+                CancellationToken.None))
+            .Should()
+            .ThrowAsync<ArgumentException>()
+            .WithMessage("*caller credential*invalid*");
+
         AgentToolRequestContext.Current.Should().BeNull();
     }
 

--- a/test/Aevatar.Workflow.Core.Tests/Modules/RuntimeCallbackEventizationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/RuntimeCallbackEventizationTests.cs
@@ -1485,6 +1485,7 @@ public class RuntimeCallbackEventizationTests
             {
                 ModelOverride = delta.Llm.ModelOverride,
                 UserMemoryPrompt = delta.Llm.UserMemoryPrompt,
+                RoutePreference = delta.Llm.RoutePreference,
             };
             if (delta.Llm.HasMaxToolRoundsOverride)
                 state.Llm.MaxToolRoundsOverride = delta.Llm.MaxToolRoundsOverride;

--- a/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
@@ -80,7 +80,7 @@ public sealed class ToolCallModuleContextTests
     }
 
     [Fact]
-    public async Task ToolCallModule_ShouldExecuteToolsThroughExecutionPort()
+    public async Task ToolCallModule_ShouldExecuteTypedWorkflowToolRequest()
     {
         var tool = new FakeAgentTool("echo", argumentsJson => argumentsJson);
         var module = CreateModule(tool);
@@ -354,6 +354,7 @@ public sealed class ToolCallModuleContextTests
                 {
                     ModelOverride = delta.Llm.ModelOverride,
                     UserMemoryPrompt = delta.Llm.UserMemoryPrompt,
+                    RoutePreference = delta.Llm.RoutePreference,
                 };
                 if (delta.Llm.HasMaxToolRoundsOverride)
                     ExecutionContextState.Llm.MaxToolRoundsOverride = delta.Llm.MaxToolRoundsOverride;

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowLoopModuleExpressionEvaluationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowLoopModuleExpressionEvaluationTests.cs
@@ -261,6 +261,7 @@ public class WorkflowLoopModuleExpressionEvaluationTests
             {
                 ModelOverride = delta.Llm.ModelOverride,
                 UserMemoryPrompt = delta.Llm.UserMemoryPrompt,
+                RoutePreference = delta.Llm.RoutePreference,
             };
             if (delta.Llm.HasMaxToolRoundsOverride)
                 state.Llm.MaxToolRoundsOverride = delta.Llm.MaxToolRoundsOverride;

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRoleGAgentMappingTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRoleGAgentMappingTests.cs
@@ -1,0 +1,122 @@
+using System.Runtime.CompilerServices;
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Integration.AI;
+using FluentAssertions;
+using Google.Protobuf;
+
+namespace Aevatar.Workflow.Core.Tests.Modules;
+
+public sealed class WorkflowRoleGAgentMappingTests
+{
+    [Fact]
+    public async Task WorkflowRoleGAgent_ShouldMapWorkflowCredentialAndRouteAtAiBoundary()
+    {
+        var provider = new RecordingLlmProvider();
+        var publisher = new RecordingEventPublisher();
+        var agent = new WorkflowRoleGAgent(provider)
+        {
+            EventPublisher = publisher,
+        };
+
+        await agent.HandleWorkflowLlmExecutionIntent(new WorkflowLlmExecutionIntent
+        {
+            RunId = "run-1",
+            StepId = "reply",
+            SessionId = "session-1",
+            Prompt = "hello",
+            Model = "model-a",
+            UserMemoryPrompt = "memory",
+            RoutePreference = " route-a ",
+            CallerCredential = new WorkflowCallerCredential
+            {
+                BearerToken = " raw-token ",
+            },
+        });
+
+        provider.LastRequest.Should().NotBeNull();
+        provider.LastRequest!.LlmControl.Should().NotBeNull();
+        provider.LastRequest.LlmControl!.NyxIdAccessToken.Should().Be("raw-token");
+        provider.LastRequest.LlmControl.NyxIdRoutePreference.Should().Be("route-a");
+        provider.LastRequest.ToolContext.Should().NotBeNull();
+        provider.LastRequest.ToolContext!.Credentials.NyxIdAccessToken.Should().Be("raw-token");
+        provider.LastRequest.ToolContext.Credentials.NyxIdOrgToken.Should().Be("raw-token");
+        provider.LastRequest.ToolContext.Routing.NyxIdRoutePreference.Should().Be("route-a");
+        (provider.LastRequest.Metadata ?? new Dictionary<string, string>(StringComparer.Ordinal))
+            .Should()
+            .BeEmpty();
+        publisher.Published.OfType<WorkflowLlmInvocationCompletedEvent>()
+            .Should()
+            .ContainSingle(x => x.Success);
+    }
+
+    private sealed class RecordingLlmProvider : ILLMProviderFactory, ILLMProvider
+    {
+        public LLMRequest? LastRequest { get; private set; }
+
+        public string Name => "recording";
+
+        public ILLMProvider GetProvider(string name)
+        {
+            _ = name;
+            return this;
+        }
+
+        public ILLMProvider GetDefault() => this;
+
+        public IReadOnlyList<string> GetAvailableProviders() => [Name];
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            LastRequest = request;
+            await Task.Yield();
+            yield return new LLMStreamChunk
+            {
+                DeltaContent = "ok",
+            };
+            yield return new LLMStreamChunk
+            {
+                IsLast = true,
+                FinishReason = "stop",
+            };
+        }
+    }
+
+    private sealed class RecordingEventPublisher : IEventPublisher
+    {
+        public List<IMessage> Published { get; } = [];
+
+        public Task PublishAsync<TEvent>(
+            TEvent evt,
+            TopologyAudience audience = TopologyAudience.Children,
+            CancellationToken ct = default,
+            EventEnvelope? sourceEnvelope = null,
+            EventEnvelopePublishOptions? options = null)
+            where TEvent : IMessage
+        {
+            _ = audience;
+            _ = ct;
+            _ = sourceEnvelope;
+            _ = options;
+            Published.Add(evt);
+            return Task.CompletedTask;
+        }
+
+        public Task SendToAsync<TEvent>(
+            string targetActorId,
+            TEvent evt,
+            CancellationToken ct = default,
+            EventEnvelope? sourceEnvelope = null,
+            EventEnvelopePublishOptions? options = null)
+            where TEvent : IMessage
+        {
+            _ = targetActorId;
+            return PublishAsync(evt, TopologyAudience.Children, ct, sourceEnvelope, options);
+        }
+    }
+}

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRuntimeModuleBranchTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRuntimeModuleBranchTests.cs
@@ -245,6 +245,10 @@ public sealed class WorkflowRuntimeModuleBranchTests
                 {
                     BearerToken = " typed-token ",
                 },
+                Llm = new WorkflowLlmExecutionContextState
+                {
+                    RoutePreference = " route-a ",
+                },
             },
         };
         ctx.RuntimeContext.ApplyRequestMetadata(new Dictionary<string, string>(StringComparer.Ordinal)
@@ -266,6 +270,7 @@ public sealed class WorkflowRuntimeModuleBranchTests
 
         var intent = DispatchedLlmIntent(ctx);
         intent.CallerCredential.BearerToken.Should().Be("typed-token");
+        intent.RoutePreference.Should().Be("route-a");
         intent.Headers.Should().Contain("trace-id", "trace-1");
         intent.Headers.Should().NotContainKey("connector.http.authorization");
     }
@@ -1022,6 +1027,7 @@ public sealed class WorkflowRuntimeModuleBranchTests
                 {
                     ModelOverride = delta.Llm.ModelOverride,
                     UserMemoryPrompt = delta.Llm.UserMemoryPrompt,
+                    RoutePreference = delta.Llm.RoutePreference,
                 };
                 if (delta.Llm.HasMaxToolRoundsOverride)
                     ExecutionContextState.Llm.MaxToolRoundsOverride = delta.Llm.MaxToolRoundsOverride;

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
@@ -362,6 +362,72 @@ public sealed class ChatEndpointsInternalTests
     }
 
     [Fact]
+    public async Task HandleChat_ShouldReturnInvalidCallerCredential_WhenAuthorizationBearerIsMalformed()
+    {
+        var called = false;
+        var interactionService = new FakeCommandInteractionService
+        {
+            ResultFactory = (_, _, _, _) =>
+            {
+                called = true;
+                return Task.FromResult(
+                    CommandInteractionResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                        .Failure(WorkflowChatRunStartError.AgentNotFound));
+            },
+        };
+        var http = CreateHttpContext();
+        http.Request.Headers.Authorization = "Bearer token 123";
+
+        await WorkflowCapabilityEndpoints.HandleChat(
+            http,
+            new ChatInput { Prompt = "hello" },
+            interactionService,
+            CancellationToken.None);
+
+        var body = await ReadBodyAsync(http.Response);
+        http.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        body.Should().Contain("INVALID_CALLER_CREDENTIAL");
+        body.Should().Contain("Caller credential is invalid.");
+        called.Should().BeFalse();
+    }
+
+    [Fact]
+    public void WorkflowCallerCredentialExtractor_ShouldExposeMissingValidAndInvalidStatus()
+    {
+        var missingHttpContext = WorkflowCallerCredentialExtractor.Extract(null);
+        var missingHttp = CreateHttpContext();
+        var unsupportedSchemeHttp = CreateHttpContext();
+        unsupportedSchemeHttp.Request.Headers.Authorization = "Basic token-123";
+        var validHttp = CreateHttpContext();
+        validHttp.Request.Headers.Authorization = "Bearer token-123";
+        var bareBearerHttp = CreateHttpContext();
+        bareBearerHttp.Request.Headers.Authorization = "Bearer";
+        var invalidHttp = CreateHttpContext();
+        invalidHttp.Request.Headers.Authorization = "Bearer token 123";
+
+        var missing = WorkflowCallerCredentialExtractor.Extract(missingHttp);
+        var unsupportedScheme = WorkflowCallerCredentialExtractor.Extract(unsupportedSchemeHttp);
+        var valid = WorkflowCallerCredentialExtractor.Extract(validHttp);
+        var bareBearer = WorkflowCallerCredentialExtractor.Extract(bareBearerHttp);
+        var invalid = WorkflowCallerCredentialExtractor.Extract(invalidHttp);
+
+        missingHttpContext.Succeeded.Should().BeTrue();
+        missingHttpContext.Credential.Should().BeNull();
+        missing.Succeeded.Should().BeTrue();
+        missing.Credential.Should().BeNull();
+        unsupportedScheme.Succeeded.Should().BeTrue();
+        unsupportedScheme.Credential.Should().BeNull();
+        valid.Succeeded.Should().BeTrue();
+        valid.Credential!.BearerToken.Should().Be("token-123");
+        bareBearer.Succeeded.Should().BeFalse();
+        bareBearer.Error.Should().Be(WorkflowChatRunStartError.InvalidCallerCredential);
+        bareBearer.Credential.Should().BeNull();
+        invalid.Succeeded.Should().BeFalse();
+        invalid.Error.Should().Be(WorkflowChatRunStartError.InvalidCallerCredential);
+        invalid.Credential.Should().BeNull();
+    }
+
+    [Fact]
     public async Task HandleChat_ShouldWriteSseFramesAndCorrelationHeader_WhenExecutionSucceeds()
     {
         var interactionService = new FakeCommandInteractionService

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatRunStartErrorMapperTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatRunStartErrorMapperTests.cs
@@ -17,6 +17,7 @@ public class ChatRunStartErrorMapperTests
     [InlineData(WorkflowChatRunStartError.AgentWorkflowNotConfigured, StatusCodes.Status409Conflict)]
     [InlineData(WorkflowChatRunStartError.InvalidWorkflowYaml, StatusCodes.Status400BadRequest)]
     [InlineData(WorkflowChatRunStartError.WorkflowNameMismatch, StatusCodes.Status400BadRequest)]
+    [InlineData(WorkflowChatRunStartError.InvalidCallerCredential, StatusCodes.Status400BadRequest)]
     [InlineData(WorkflowChatRunStartError.None, StatusCodes.Status400BadRequest)]
     public void ToHttpStatusCode_ShouldMapExpectedCode(
         WorkflowChatRunStartError error,
@@ -59,5 +60,14 @@ public class ChatRunStartErrorMapperTests
 
         mapped.Code.Should().Be("WORKFLOW_PROJECTION_UNAVAILABLE");
         mapped.Message.Should().Be("Workflow projection is unavailable.");
+    }
+
+    [Fact]
+    public void ToCommandError_InvalidCallerCredential_ShouldMapExpectedPayload()
+    {
+        var mapped = ChatRunStartErrorMapper.ToCommandError(WorkflowChatRunStartError.InvalidCallerCredential);
+
+        mapped.Code.Should().Be("INVALID_CALLER_CREDENTIAL");
+        mapped.Message.Should().Be("Caller credential is invalid.");
     }
 }

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowCapabilityEndpointsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowCapabilityEndpointsCoverageTests.cs
@@ -190,7 +190,8 @@ public sealed class WorkflowCapabilityEndpointsCoverageTests
         result.Request.LlmControl.Should().Be(new WorkflowLlmControl(
             "model",
             3,
-            UserMemoryPrompt: null));
+            UserMemoryPrompt: null,
+            RoutePreference: "route"));
         result.Request.Metadata.Should().BeEmpty();
     }
 
@@ -829,6 +830,22 @@ public sealed class WorkflowCapabilityEndpointsCoverageTests
         result.Request!.CallerCredential!.BearerToken.Should().Be("trusted");
         result.Request.Metadata.Should().Contain("trace", "trace-1");
         result.Request.Metadata.Should().NotContainKey("connector.http.authorization");
+    }
+
+    [Fact]
+    public void ChatRunRequestNormalizer_ShouldRejectMalformedTrustedCallerCredential()
+    {
+        var input = new ChatInput
+        {
+            Prompt = "hello",
+        };
+
+        var result = ChatRunRequestNormalizer.Normalize(
+            input,
+            trustedCallerCredential: new Aevatar.Workflow.Application.Abstractions.Runs.WorkflowCallerCredential("Bearer trusted"));
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(WorkflowChatRunStartError.InvalidCallerCredential);
     }
 
     [Fact]


### PR DESCRIPTION
## 摘要

- 收口 `WorkflowCallerCredential.BearerToken` 的 raw bearer 语义，新增 workflow-owned 解析状态，非法 `Bearer ` 前缀在入口处 fail-closed。
- 补齐 provider-neutral `RoutePreference` 在 workflow DTO、proto state/command、execution intent 与 AI boundary 的传递。
- 将 provider auth 与 tool credential 映射限定在 `Workflow.Integration.AI` 边界，并补充 workflow / AI / host 相关测试。

Closes #1792

## 验证

- `dotnet build aevatar.slnx --nologo`
- `dotnet test test/Aevatar.Workflow.Host.Api.Tests/ --nologo`
- `dotnet test test/Aevatar.Workflow.Application.Tests/ --nologo`
- `dotnet test test/Aevatar.Workflow.Core.Tests/ --nologo`
- `dotnet test test/Aevatar.AI.Tests/ --nologo`
- `bash tools/ci/architecture_guards.sh`
- `bash tools/ci/test_stability_guards.sh`
- `git diff --check`
- `git diff --cached --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

⟦AI:AUTO-LOOP⟧