### PR TITLE
fix(workflow): tool_call 注入调用方 NyxID 凭证，删除可伪造的 public ChatInput.ToolContext

### DIFF
--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -255,6 +255,7 @@ public sealed class AevatarInvocationDispatcher
             InputParts: ToWorkflowInputParts(request.Inputs),
             Metadata: metadata,
             ScopeId: scope.Value!.ScopeId,
+            ToolContext: AgentToolRequestContext.Current ?? AgentToolExecutionContext.Empty,
             LlmControl: ToWorkflowLlmControl(AgentToolRequestContext.Current));
 
         var result = await _workflowDispatchService.DispatchAsync(command, ct);

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -114,13 +114,13 @@ public static class ScopeServiceEndpoints
                 throw new InvalidOperationException("workflowYamls is required.");
 
             var scopedHeaders = BuildScopedHeaders(request.Headers);
-            var trustedToolContext = await ScopedWorkflowToolContextFactory.BuildAsync(
+            var scopedLlmControl = await BuildScopedLlmControlAsync(http, ct);
+            var trustedToolContext = ScopedWorkflowToolContextFactory.Build(
                 http,
                 scopeId,
                 request.SessionId,
-                requestId: null,
                 scopedHeaders,
-                ct);
+                scopedLlmControl);
             if (!ScopeWorkflowEndpoints.TryParseEventFormat(request.EventFormat, out var eventFormat))
             {
                 await WriteJsonErrorResponseAsync(
@@ -139,7 +139,7 @@ public static class ScopeServiceEndpoints
                 Metadata: scopedHeaders,
                 ScopeId: scopeId,
                 ConnectorHttpAuthorization: ConnectorHttpAuthorizationExtractor.Extract(http),
-                LlmControl: ToWorkflowLlmControl(await BuildScopedLlmControlAsync(http, ct)),
+                LlmControl: ToWorkflowLlmControl(scopedLlmControl),
                 ToolContext: trustedToolContext,
                 Headers: scopedHeaders);
 
@@ -164,7 +164,7 @@ public static class ScopeServiceEndpoints
                     SessionId = chatRequest.SessionId,
                     ScopeId = scopeId,
                     Headers = scopedHeaders,
-                    LlmControl = await BuildScopedLlmControlInputAsync(http, ct),
+                    LlmControl = ToChatLlmControlInput(scopedLlmControl),
                 },
                 chatRunService,
                 ct,
@@ -1517,13 +1517,13 @@ public static class ScopeServiceEndpoints
 
             var normalizedPrompt = request.Prompt?.Trim() ?? string.Empty;
             var scopedHeaders = BuildScopedHeaders(request.Headers);
-            var trustedToolContext = await ScopedWorkflowToolContextFactory.BuildAsync(
+            var scopedLlmControl = await BuildScopedLlmControlAsync(http, ct);
+            var trustedToolContext = ScopedWorkflowToolContextFactory.Build(
                 http,
                 scopeId,
                 request.SessionId,
-                requestId: null,
                 scopedHeaders,
-                ct);
+                scopedLlmControl);
             var invocationRequest = BuildStreamInvocationRequest(
                 options.Value,
                 scopeId,
@@ -1564,7 +1564,7 @@ public static class ScopeServiceEndpoints
                             ScopeId = scopeId,
                             Metadata = scopedHeaders,
                             Headers = scopedHeaders,
-                            LlmControl = await BuildScopedLlmControlInputAsync(http, ct),
+                            LlmControl = ToChatLlmControlInput(scopedLlmControl),
                         },
                         chatRunService,
                         ct,
@@ -2969,11 +2969,8 @@ const response = await fetch("{{invokePath}}", {
         return scopedHeaders;
     }
 
-    private static async Task<ChatLlmControlInput?> BuildScopedLlmControlInputAsync(
-        HttpContext? http,
-        CancellationToken cancellationToken = default)
+    private static ChatLlmControlInput? ToChatLlmControlInput(LLMControlContext? control)
     {
-        var control = await BuildScopedLlmControlAsync(http, cancellationToken);
         if (control == null)
             return null;
 

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -34,6 +34,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Aevatar.GAgentService.Hosting.Endpoints;
 
@@ -113,6 +114,13 @@ public static class ScopeServiceEndpoints
                 throw new InvalidOperationException("workflowYamls is required.");
 
             var scopedHeaders = BuildScopedHeaders(request.Headers);
+            var trustedToolContext = await ScopedWorkflowToolContextFactory.BuildAsync(
+                http,
+                scopeId,
+                request.SessionId,
+                requestId: null,
+                scopedHeaders,
+                ct);
             if (!ScopeWorkflowEndpoints.TryParseEventFormat(request.EventFormat, out var eventFormat))
             {
                 await WriteJsonErrorResponseAsync(
@@ -132,6 +140,7 @@ public static class ScopeServiceEndpoints
                 ScopeId: scopeId,
                 ConnectorHttpAuthorization: ConnectorHttpAuthorizationExtractor.Extract(http),
                 LlmControl: ToWorkflowLlmControl(await BuildScopedLlmControlAsync(http, ct)),
+                ToolContext: trustedToolContext,
                 Headers: scopedHeaders);
 
             if (eventFormat == ScopeWorkflowEndpoints.ScopeWorkflowStreamEventFormat.Agui)
@@ -158,7 +167,8 @@ public static class ScopeServiceEndpoints
                     LlmControl = await BuildScopedLlmControlInputAsync(http, ct),
                 },
                 chatRunService,
-                ct);
+                ct,
+                trustedToolContext: trustedToolContext);
         }
         catch (InvalidOperationException ex)
         {
@@ -1507,6 +1517,13 @@ public static class ScopeServiceEndpoints
 
             var normalizedPrompt = request.Prompt?.Trim() ?? string.Empty;
             var scopedHeaders = BuildScopedHeaders(request.Headers);
+            var trustedToolContext = await ScopedWorkflowToolContextFactory.BuildAsync(
+                http,
+                scopeId,
+                request.SessionId,
+                requestId: null,
+                scopedHeaders,
+                ct);
             var invocationRequest = BuildStreamInvocationRequest(
                 options.Value,
                 scopeId,
@@ -1563,7 +1580,8 @@ public static class ScopeServiceEndpoints
                             commandId: receipt.CommandId,
                             correlationId: receipt.CorrelationId,
                             targetActorId: receipt.ActorId,
-                            token));
+                            token),
+                        trustedToolContext: trustedToolContext);
                     break;
 
                 case ServiceImplementationKind.Static:
@@ -3310,6 +3328,7 @@ const response = await fetch("{{invokePath}}", {
         string? RevisionId = null,
         string? PayloadJson = null);
 
+    [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
     public sealed record ScopeDraftRunHttpRequest(
         string Prompt,
         IReadOnlyList<string>? WorkflowYamls,
@@ -3351,6 +3370,7 @@ const response = await fetch("{{invokePath}}", {
                 string.Equals(key, "ActorTypeName", StringComparison.Ordinal)) == true;
     }
 
+    [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
     public sealed record StreamScopeServiceHttpRequest(
         string? Prompt,
         string? ActorId = null,

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
@@ -318,13 +318,13 @@ public static class ScopeWorkflowEndpoints
         if (resolvedEventFormat == ScopeWorkflowStreamEventFormat.Workflow)
         {
             var scopedHeaders = BuildScopedHeaders(headers);
-            var trustedToolContext = await ScopedWorkflowToolContextFactory.BuildAsync(
+            var scopedLlmControl = await BuildScopedLlmControlAsync(http, ct);
+            var trustedToolContext = ScopedWorkflowToolContextFactory.Build(
                 http,
                 scopeId,
                 sessionId,
-                requestId: null,
                 scopedHeaders,
-                ct);
+                scopedLlmControl);
             await WorkflowCapabilityEndpoints.HandleChat(
                 http,
                 new ChatInput
@@ -341,7 +341,7 @@ public static class ScopeWorkflowEndpoints
                     SessionId = sessionId,
                     ScopeId = NormalizeRequired(scopeId, nameof(scopeId)),
                     Headers = scopedHeaders,
-                    LlmControl = await BuildScopedLlmControlInputAsync(http, ct),
+                    LlmControl = ToChatLlmControlInput(scopedLlmControl),
                 },
                 chatRunService,
                 ct,
@@ -350,13 +350,13 @@ public static class ScopeWorkflowEndpoints
         }
 
         var aguiHeaders = BuildScopedHeaders(headers);
-        var aguiToolContext = await ScopedWorkflowToolContextFactory.BuildAsync(
+        var aguiLlmControl = await BuildScopedLlmControlAsync(http, ct);
+        var aguiToolContext = ScopedWorkflowToolContextFactory.Build(
             http,
             scopeId,
             sessionId,
-            requestId: null,
             aguiHeaders,
-            ct);
+            aguiLlmControl);
         await HandleAguiStreamAsync(
             http,
             scopeId,
@@ -364,7 +364,7 @@ public static class ScopeWorkflowEndpoints
             prompt,
             sessionId,
             aguiHeaders,
-            await BuildScopedLlmControlAsync(http, ct),
+            aguiLlmControl,
             aguiToolContext,
             chatRunService,
             ct);
@@ -583,11 +583,8 @@ public static class ScopeWorkflowEndpoints
         return scopedHeaders;
     }
 
-    internal static async Task<ChatLlmControlInput?> BuildScopedLlmControlInputAsync(
-        HttpContext? http,
-        CancellationToken cancellationToken = default)
+    internal static ChatLlmControlInput? ToChatLlmControlInput(LLMControlContext? control)
     {
-        var control = await BuildScopedLlmControlAsync(http, cancellationToken);
         if (control == null)
             return null;
 

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
@@ -1,4 +1,5 @@
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.GAgentService.Abstractions;
@@ -18,6 +19,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using System.Text.Json.Serialization;
 
 namespace Aevatar.GAgentService.Hosting.Endpoints;
 
@@ -316,6 +318,13 @@ public static class ScopeWorkflowEndpoints
         if (resolvedEventFormat == ScopeWorkflowStreamEventFormat.Workflow)
         {
             var scopedHeaders = BuildScopedHeaders(headers);
+            var trustedToolContext = await ScopedWorkflowToolContextFactory.BuildAsync(
+                http,
+                scopeId,
+                sessionId,
+                requestId: null,
+                scopedHeaders,
+                ct);
             await WorkflowCapabilityEndpoints.HandleChat(
                 http,
                 new ChatInput
@@ -335,11 +344,19 @@ public static class ScopeWorkflowEndpoints
                     LlmControl = await BuildScopedLlmControlInputAsync(http, ct),
                 },
                 chatRunService,
-                ct);
+                ct,
+                trustedToolContext: trustedToolContext);
             return;
         }
 
         var aguiHeaders = BuildScopedHeaders(headers);
+        var aguiToolContext = await ScopedWorkflowToolContextFactory.BuildAsync(
+            http,
+            scopeId,
+            sessionId,
+            requestId: null,
+            aguiHeaders,
+            ct);
         await HandleAguiStreamAsync(
             http,
             scopeId,
@@ -348,6 +365,7 @@ public static class ScopeWorkflowEndpoints
             sessionId,
             aguiHeaders,
             await BuildScopedLlmControlAsync(http, ct),
+            aguiToolContext,
             chatRunService,
             ct);
     }
@@ -435,6 +453,7 @@ public static class ScopeWorkflowEndpoints
         string? sessionId,
         IReadOnlyDictionary<string, string>? headers,
         LLMControlContext? llmControl,
+        AgentToolExecutionContext? trustedToolContext,
         IWorkflowChatRunInteractionPort chatRunService,
         CancellationToken ct)
     {
@@ -449,6 +468,7 @@ public static class ScopeWorkflowEndpoints
                 ScopeId: NormalizeRequired(scopeId, nameof(scopeId)),
                 ConnectorHttpAuthorization: ConnectorHttpAuthorizationExtractor.Extract(http),
                 LlmControl: ToWorkflowLlmControl(llmControl),
+                ToolContext: trustedToolContext,
                 Headers: headers),
             chatRunService,
             ct);
@@ -708,12 +728,14 @@ public static class ScopeWorkflowEndpoints
         Dictionary<string, string>? InlineWorkflowYamls = null,
         string? RevisionId = null);
 
+    [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
     public sealed record RunScopeWorkflowByIdStreamHttpRequest(
         string Prompt,
         string? SessionId = null,
         Dictionary<string, string>? Headers = null,
         string? EventFormat = null);
 
+    [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
     public sealed record RunScopeWorkflowStreamHttpRequest(
         string ActorId,
         string Prompt,

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopedWorkflowToolContextFactory.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopedWorkflowToolContextFactory.cs
@@ -1,0 +1,85 @@
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.GAgentService.Hosting.Endpoints;
+
+internal static class ScopedWorkflowToolContextFactory
+{
+    // refactor helper, no behavior change
+    public static async Task<AgentToolExecutionContext?> BuildAsync(
+        HttpContext? http,
+        string? scopeId,
+        string? sessionId,
+        string? requestId,
+        IReadOnlyDictionary<string, string>? headers,
+        CancellationToken cancellationToken = default)
+    {
+        if (http == null)
+            return null;
+
+        var normalizedScopeId = Normalize(scopeId);
+        var bearerToken = ExtractBearerToken(http);
+        var userConfigStore = http.RequestServices.GetService<IUserConfigQueryPort>();
+        var model = (string?)null;
+        var route = (string?)null;
+        if (userConfigStore != null)
+        {
+            try
+            {
+                var userConfig = await userConfigStore.GetAsync(cancellationToken);
+                model = Normalize(userConfig.DefaultModel);
+                route = Normalize(userConfig.PreferredLlmRoute);
+                (model, route) = await UserLlmRouteModelResolver
+                    .ResolveAsync(http, model, route, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch
+            {
+                model = null;
+                route = null;
+            }
+        }
+
+        var effectiveRequestId = Normalize(requestId) ?? Normalize(sessionId);
+        return AgentToolExecutionContext.Empty with
+        {
+            Request = new AgentToolRequestIdentity(effectiveRequestId, null),
+            Credentials = new AgentToolCredentials(bearerToken, bearerToken, null),
+            Caller = new AgentToolCallerContext(
+                normalizedScopeId,
+                ResolveOwnerSubject(http),
+                Normalize(sessionId) ?? effectiveRequestId),
+            Channel = new AgentToolChannelContext(
+                "scope-workflow",
+                null,
+                normalizedScopeId,
+                null,
+                null),
+            Routing = new LLMRequestRoutingContext(model, route, null, null),
+            ExternalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(headers),
+        };
+    }
+
+    private static string? ResolveOwnerSubject(HttpContext http) =>
+        Normalize(
+            http.User.FindFirst("uid")?.Value ??
+            http.User.FindFirst("sub")?.Value ??
+            http.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value);
+
+    private static string? ExtractBearerToken(HttpContext http)
+    {
+        var auth = http.Request.Headers.Authorization.FirstOrDefault();
+        if (auth == null || !auth.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        var bearerToken = auth["Bearer ".Length..].Trim();
+        return string.IsNullOrWhiteSpace(bearerToken) ? null : bearerToken;
+    }
+
+    private static string? Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopedWorkflowToolContextFactory.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopedWorkflowToolContextFactory.cs
@@ -1,49 +1,27 @@
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
-using Aevatar.GAgentService.Abstractions.Ports;
-using Aevatar.Studio.Application.Studio.Abstractions;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Aevatar.GAgentService.Hosting.Endpoints;
 
 internal static class ScopedWorkflowToolContextFactory
 {
-    public static async Task<AgentToolExecutionContext?> BuildAsync(
+    public static AgentToolExecutionContext? Build(
         HttpContext? http,
         string? scopeId,
         string? sessionId,
-        string? requestId,
         IReadOnlyDictionary<string, string>? headers,
-        CancellationToken cancellationToken = default)
+        LLMControlContext? llmControl)
     {
         if (http == null)
             return null;
 
         var normalizedScopeId = Normalize(scopeId);
         var bearerToken = ExtractBearerToken(http);
-        var userConfigStore = http.RequestServices.GetService<IUserConfigQueryPort>();
-        var model = (string?)null;
-        var route = (string?)null;
-        if (userConfigStore != null)
-        {
-            try
-            {
-                var userConfig = await userConfigStore.GetAsync(cancellationToken);
-                model = Normalize(userConfig.DefaultModel);
-                route = Normalize(userConfig.PreferredLlmRoute);
-                (model, route) = await UserLlmRouteModelResolver
-                    .ResolveAsync(http, model, route, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            catch
-            {
-                model = null;
-                route = null;
-            }
-        }
+        var model = Normalize(llmControl?.ModelOverride);
+        var route = Normalize(llmControl?.NyxIdRoutePreference);
 
-        var effectiveRequestId = Normalize(requestId) ?? Normalize(sessionId);
+        var effectiveRequestId = Normalize(sessionId);
         return AgentToolExecutionContext.Empty with
         {
             Request = new AgentToolRequestIdentity(effectiveRequestId, null),

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopedWorkflowToolContextFactory.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopedWorkflowToolContextFactory.cs
@@ -9,7 +9,6 @@ namespace Aevatar.GAgentService.Hosting.Endpoints;
 
 internal static class ScopedWorkflowToolContextFactory
 {
-    // refactor helper, no behavior change
     public static async Task<AgentToolExecutionContext?> BuildAsync(
         HttpContext? http,
         string? scopeId,

--- a/src/workflow/Aevatar.Workflow.Abstractions/Aevatar.Workflow.Abstractions.csproj
+++ b/src/workflow/Aevatar.Workflow.Abstractions/Aevatar.Workflow.Abstractions.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>Aevatar.Workflow.Abstractions</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\Aevatar.AI.Abstractions\Aevatar.AI.Abstractions.csproj" />
     <ProjectReference Include="..\..\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
   </ItemGroup>
   <ItemGroup>
@@ -17,6 +18,6 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <Protobuf Include="workflow_execution_messages.proto" GrpcServices="None" />
+    <Protobuf Include="workflow_execution_messages.proto" GrpcServices="None" AdditionalImportDirs="..\..\Aevatar.AI.Abstractions;..\..\Aevatar.Foundation.VoicePresence.Abstractions" />
   </ItemGroup>
 </Project>

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -3,6 +3,7 @@ package aevatar.workflow;
 option csharp_namespace = "Aevatar.Workflow.Abstractions";
 
 import "google/protobuf/any.proto";
+import "ai_messages.proto";
 
 enum WorkflowChatInputPartKind {
   WORKFLOW_CHAT_INPUT_PART_KIND_UNSPECIFIED = 0;
@@ -37,6 +38,7 @@ message WorkflowChatRequestEvent {
   map<string, string> metadata = 7;
   WorkflowLlmControlContext llm_control = 8;
   string connector_http_authorization = 9;
+  aevatar.ai.AgentToolExecutionContextPayload tool_context = 10;
 }
 
 message StartWorkflowEvent    { string workflow_name = 1; string input = 2; map<string, string> parameters = 3; string run_id = 4; }

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Aevatar.Workflow.Application.Abstractions.csproj
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Aevatar.Workflow.Application.Abstractions.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>Aevatar.Workflow.Application.Abstractions</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\Aevatar.AI.Abstractions\Aevatar.AI.Abstractions.csproj" />
     <ProjectReference Include="..\..\Aevatar.CQRS.Core.Abstractions\Aevatar.CQRS.Core.Abstractions.csproj" />
     <ProjectReference Include="..\..\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
   </ItemGroup>

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunModels.cs
@@ -1,3 +1,4 @@
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using System.Text.Json.Serialization;
 
@@ -132,6 +133,7 @@ public sealed record WorkflowChatRunRequest(
     //   New principle: stable business semantics use typed proto field; metadata bag only for genuine open extension.
     string? ScopeId = null,
     WorkflowLlmControl? LlmControl = null,
+    AgentToolExecutionContext? ToolContext = null,
     // Refactor (iter169/cluster-issue1551): Old pattern: trusted connector bearer was smuggled through Metadata. New principle: Host/Application pass connector HTTP authorization as a typed command scalar.
     string? ConnectorHttpAuthorization = null,
     IReadOnlyDictionary<string, string>? Headers = null,

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs
@@ -1,3 +1,4 @@
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Workflow.Abstractions;
@@ -29,6 +30,8 @@ internal sealed class WorkflowChatRequestEnvelopeFactory : ICommandEnvelopeFacto
         AppendMetadata(chatRequest.Metadata, command.Metadata);
         if (command.LlmControl != null)
             chatRequest.LlmControl = ToProto(command.LlmControl);
+        if (command.ToolContext != null)
+            chatRequest.ToolContext = command.ToolContext.ToPayload();
         chatRequest.ConnectorHttpAuthorization = Normalize(command.ConnectorHttpAuthorization);
 
         var envelope = new EventEnvelope
@@ -91,7 +94,7 @@ internal sealed class WorkflowChatRequestEnvelopeFactory : ICommandEnvelopeFacto
         if (source == null || source.Count == 0)
             return;
 
-        foreach (var (key, value) in source)
+        foreach (var (key, value) in AgentToolExecutionContextMapper.StripOwnedControlKeys(source))
         {
             var normalizedKey = string.IsNullOrWhiteSpace(key) ? string.Empty : key.Trim();
             var normalizedValue = string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();

--- a/src/workflow/Aevatar.Workflow.Core/Aevatar.Workflow.Core.csproj
+++ b/src/workflow/Aevatar.Workflow.Core/Aevatar.Workflow.Core.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>Aevatar.Workflow.Core</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\Aevatar.AI.Abstractions\Aevatar.AI.Abstractions.csproj" />
     <ProjectReference Include="..\..\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
     <ProjectReference Include="..\..\Aevatar.Foundation.Core\Aevatar.Foundation.Core.csproj" />
     <ProjectReference Include="..\Aevatar.Workflow.Abstractions\Aevatar.Workflow.Abstractions.csproj" />

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionRuntimeContext.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionRuntimeContext.cs
@@ -1,3 +1,5 @@
+using Aevatar.AI.Abstractions.ToolProviders;
+
 namespace Aevatar.Workflow.Core.Execution;
 
 // Refactor (iter16/cluster-031):
@@ -19,7 +21,13 @@ internal sealed class WorkflowExecutionRuntimeContext
 {
     public WorkflowRequestPassthroughMetadata RequestPassthroughMetadata { get; } = new();
 
-    public void Clear() => RequestPassthroughMetadata.Clear();
+    public AgentToolExecutionContext? ToolContext { get; set; }
+
+    public void Clear()
+    {
+        RequestPassthroughMetadata.Clear();
+        ToolContext = null;
+    }
 
     public void ApplyRequestMetadata(IReadOnlyDictionary<string, string>? metadata)
     {

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowToolExecutionContextAccess.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowToolExecutionContextAccess.cs
@@ -1,0 +1,64 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.Workflow.Abstractions;
+
+namespace Aevatar.Workflow.Core.Execution;
+
+internal static class WorkflowToolExecutionContextAccess
+{
+    public static void ApplyFromCommand(
+        WorkflowExecutionRuntimeContext runtimeContext,
+        AgentToolExecutionContextPayload? payload,
+        string? commandId,
+        string? scopeId,
+        string? sessionId)
+    {
+        ArgumentNullException.ThrowIfNull(runtimeContext);
+
+        runtimeContext.ToolContext = payload == null
+            ? null
+            : NormalizeCommandContext(
+                AgentToolExecutionContextMapper.FromPayload(payload),
+                commandId,
+                scopeId,
+                sessionId);
+    }
+
+    public static AgentToolExecutionContext? GetForStep(
+        IWorkflowExecutionContext executionContext,
+        string? stepId)
+    {
+        ArgumentNullException.ThrowIfNull(executionContext);
+
+        return executionContext is IWorkflowExecutionRuntimeContextAccessor accessor
+            ? accessor.RuntimeContext.ToolContext?.WithCallId(stepId)
+            : null;
+    }
+
+    private static AgentToolExecutionContext NormalizeCommandContext(
+        AgentToolExecutionContext context,
+        string? commandId,
+        string? scopeId,
+        string? sessionId)
+    {
+        var normalizedCommandId = Normalize(commandId);
+        var normalizedScopeId = Normalize(scopeId) ?? context.Caller.ScopeId;
+        var normalizedSessionId = Normalize(sessionId);
+
+        return context with
+        {
+            Request = context.Request with
+            {
+                RequestId = context.Request.RequestId ?? normalizedCommandId,
+            },
+            Caller = context.Caller with
+            {
+                ScopeId = normalizedScopeId,
+                ResponseId = context.Caller.ResponseId ?? normalizedSessionId ?? normalizedCommandId,
+            },
+        };
+    }
+
+    private static string? Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
@@ -3,9 +3,11 @@
 // 在工作流步骤中调用 Agent 的注册工具
 // ─────────────────────────────────────────────────────────────
 
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Abstractions.EventModules;
+using Aevatar.Workflow.Core.Execution;
 using Microsoft.Extensions.Logging;
 
 namespace Aevatar.Workflow.Core.Modules;
@@ -76,6 +78,8 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
 
         try
         {
+            using var toolContextScope = AgentToolContextScope.Push(
+                WorkflowToolExecutionContextAccess.GetForStep(ctx, request.StepId));
             var result = await tool.ExecuteAsync(argumentsJson, ct);
 
             await ctx.PublishAsync(new WorkflowToolCallCompletedEvent

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
@@ -264,6 +264,12 @@ public sealed class WorkflowRunGAgent
         // Refactor (iter169/cluster-issue1551): Old pattern: connector auth was promoted from request.Metadata. New principle: connector auth is carried by WorkflowChatRequestEvent.ConnectorHttpAuthorization.
         var connectorAuthorizationDelta = WorkflowRunExecutionContextStateAccess.BuildConnectorAuthorizationDelta(request.ConnectorHttpAuthorization);
         _runtimeContext.ApplyRequestMetadata(request.Metadata);
+        WorkflowToolExecutionContextAccess.ApplyFromCommand(
+            _runtimeContext,
+            request.ToolContext,
+            commandId,
+            request.ScopeId,
+            request.SessionId);
         var llmControlDelta = WorkflowRunExecutionContextStateAccess.BuildLlmControlDelta(request.LlmControl);
 
         await EnsureAgentTreeAsync();

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatCapabilityModels.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatCapabilityModels.cs
@@ -1,4 +1,3 @@
-using Aevatar.AI.Abstractions.ToolProviders;
 using System.Text.Json.Serialization;
 
 namespace Aevatar.Workflow.Infrastructure.CapabilityApi;
@@ -65,8 +64,6 @@ public sealed record ChatInput
 
     public ChatLlmControlInput? LlmControl { get; init; }
 
-    // Refactor (issue1332): Old pattern: workflow chat control used metadata or LlmControl only. New principle: reuse AgentToolExecutionContext as typed ToolContext without adding a workflow-specific abstraction.
-    public AgentToolExecutionContext? ToolContext { get; init; }
 }
 
 public sealed record ChatLlmControlInput

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Net.WebSockets;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.Foundation.Abstractions;
@@ -38,7 +39,8 @@ public static class WorkflowCapabilityEndpoints
         ChatInput input,
         IWorkflowChatRunInteractionPort chatRunService,
         CancellationToken ct = default,
-        Func<WorkflowChatRunAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedHook = null)
+        Func<WorkflowChatRunAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedHook = null,
+        AgentToolExecutionContext? trustedToolContext = null)
     {
         using var scope = ApiRequestScope.BeginHttp();
         var writer = new ChatSseResponseWriter(http.Response);
@@ -53,7 +55,8 @@ public static class WorkflowCapabilityEndpoints
             var normalizedRequest = ChatRunRequestNormalizer.Normalize(
                 input,
                 defaultMetadata,
-                trustedConnectorHttpAuthorization: connectorAuthorization);
+                trustedConnectorHttpAuthorization: connectorAuthorization,
+                trustedToolContext: trustedToolContext);
             if (!normalizedRequest.Succeeded)
             {
                 var (code, message) = ChatRunStartErrorMapper.ToCommandError(normalizedRequest.Error);
@@ -116,12 +119,16 @@ public static class WorkflowCapabilityEndpoints
         ICommandDispatchService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError> chatRunService,
         ILoggerFactory loggerFactory,
         CancellationToken ct = default,
-        IReadOnlyDictionary<string, string>? defaultMetadata = null)
+        IReadOnlyDictionary<string, string>? defaultMetadata = null,
+        AgentToolExecutionContext? trustedToolContext = null)
     {
         using var scope = ApiRequestScope.BeginHttp();
         var logger = loggerFactory.CreateLogger("Aevatar.Workflow.Host.Api.Command");
 
-        var normalizedRequest = ChatRunRequestNormalizer.Normalize(input, defaultMetadata: defaultMetadata);
+        var normalizedRequest = ChatRunRequestNormalizer.Normalize(
+            input,
+            defaultMetadata: defaultMetadata,
+            trustedToolContext: trustedToolContext);
         if (!normalizedRequest.Succeeded)
         {
             var (code, message) = ChatRunStartErrorMapper.ToCommandError(normalizedRequest.Error);

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunRequestNormalizer.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunRequestNormalizer.cs
@@ -1,3 +1,4 @@
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Application.Runs;
 
@@ -32,7 +33,8 @@ internal static class ChatRunRequestNormalizer
     public static ChatRunRequestNormalizationResult Normalize(
         ChatInput input,
         IReadOnlyDictionary<string, string>? defaultMetadata = null,
-        string? trustedConnectorHttpAuthorization = null)
+        string? trustedConnectorHttpAuthorization = null,
+        AgentToolExecutionContext? trustedToolContext = null)
     {
         // Refactor (iter112/cluster-3): Old pattern: host passed normalized legacy mirror fields into Application commands. New principle: host normalizes wire aliases once into typed WorkflowChatSource.
         // Refactor (iter349/cluster-349):
@@ -63,6 +65,7 @@ internal static class ChatRunRequestNormalizer
                 Metadata: normalizedMetadata,
                 ScopeId: normalizedContext.ScopeId,
                 LlmControl: NormalizeLlmControl(input.LlmControl),
+                ToolContext: trustedToolContext,
                 ConnectorHttpAuthorization: NormalizeOptional(trustedConnectorHttpAuthorization),
                 Headers: normalizedContext.Headers));
     }
@@ -292,19 +295,19 @@ internal static class ChatRunRequestNormalizer
         var normalizedScopeId = NormalizeScopeId(explicitScopeId);
         if (defaultMetadata is { Count: > 0 })
         {
-            foreach (var (key, value) in defaultMetadata)
+            foreach (var (key, value) in AgentToolExecutionContextMapper.StripOwnedControlKeys(defaultMetadata))
                 AddNormalizedMetadataEntry(normalized, key, value);
         }
 
         if (metadata is { Count: > 0 })
         {
-            foreach (var (key, value) in metadata)
+            foreach (var (key, value) in StripOwnedControlKeys(metadata))
                 AddNormalizedMetadataEntry(normalized, key, value);
         }
 
         if (headers is { Count: > 0 })
         {
-            foreach (var (key, value) in headers)
+            foreach (var (key, value) in StripOwnedControlKeys(headers))
                 AddNormalizedMetadataEntry(normalizedHeaders, key, value);
         }
 
@@ -341,6 +344,11 @@ internal static class ChatRunRequestNormalizer
     private static bool IsScopeMetadataKey(string key) =>
         string.Equals(key, "scope_id", StringComparison.OrdinalIgnoreCase) ||
         string.Equals(key, WorkflowRunCommandMetadataKeys.ScopeId, StringComparison.OrdinalIgnoreCase);
+
+    private static IReadOnlyDictionary<string, string> StripOwnedControlKeys(IDictionary<string, string> metadata) =>
+        AgentToolExecutionContextMapper.StripOwnedControlKeys(
+            metadata as IReadOnlyDictionary<string, string> ??
+            metadata.ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal));
 
     private static string? NormalizeScopeId(string? scopeId) =>
         string.IsNullOrWhiteSpace(scopeId) ? null : scopeId.Trim();

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatWebSocketRunCoordinator.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatWebSocketRunCoordinator.cs
@@ -1,5 +1,4 @@
 using System.Net.WebSockets;
-using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Google.Protobuf.WellKnownTypes;
 
@@ -13,18 +12,14 @@ internal static class ChatWebSocketRunCoordinator
         IWorkflowChatRunInteractionPort chatRunService,
         ApiRequestScope scope,
         CancellationToken ct = default,
-        IReadOnlyDictionary<string, string>? defaultMetadata = null,
-        AgentToolExecutionContext? trustedToolContext = null)
+        IReadOnlyDictionary<string, string>? defaultMetadata = null)
     {
         var responseMessageType = ChatWebSocketProtocol.NormalizeMessageType(command.ResponseMessageType);
         var correlationId = string.Empty;
         CapabilityMessageTraceContext ResolveContext() =>
             CapabilityTraceContext.CreateMessageContext(correlationId, command.RequestId);
 
-        var normalizedRequest = ChatRunRequestNormalizer.Normalize(
-            command.Input,
-            defaultMetadata,
-            trustedToolContext: trustedToolContext);
+        var normalizedRequest = ChatRunRequestNormalizer.Normalize(command.Input, defaultMetadata);
         if (!normalizedRequest.Succeeded)
         {
             var (code, message) = ChatRunStartErrorMapper.ToCommandError(normalizedRequest.Error);

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatWebSocketRunCoordinator.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatWebSocketRunCoordinator.cs
@@ -1,4 +1,5 @@
 using System.Net.WebSockets;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Google.Protobuf.WellKnownTypes;
 
@@ -12,14 +13,18 @@ internal static class ChatWebSocketRunCoordinator
         IWorkflowChatRunInteractionPort chatRunService,
         ApiRequestScope scope,
         CancellationToken ct = default,
-        IReadOnlyDictionary<string, string>? defaultMetadata = null)
+        IReadOnlyDictionary<string, string>? defaultMetadata = null,
+        AgentToolExecutionContext? trustedToolContext = null)
     {
         var responseMessageType = ChatWebSocketProtocol.NormalizeMessageType(command.ResponseMessageType);
         var correlationId = string.Empty;
         CapabilityMessageTraceContext ResolveContext() =>
             CapabilityTraceContext.CreateMessageContext(correlationId, command.RequestId);
 
-        var normalizedRequest = ChatRunRequestNormalizer.Normalize(command.Input, defaultMetadata);
+        var normalizedRequest = ChatRunRequestNormalizer.Normalize(
+            command.Input,
+            defaultMetadata,
+            trustedToolContext: trustedToolContext);
         if (!normalizedRequest.Succeeded)
         {
             var (code, message) = ChatRunStartErrorMapper.ToCommandError(normalizedRequest.Error);

--- a/src/workflow/README.md
+++ b/src/workflow/README.md
@@ -81,6 +81,9 @@ flowchart LR
 补充约束：
 
 - 通用 actor 发送态使用 `ActorSendState`（`target_actor_id + payload`）。
+- `WorkflowChatRequestEvent.tool_context` 只用于 command-time trusted tool execution context。它由 Host 或内部 tool invocation 派生，进入 run actor 后仅保存在 volatile runtime context 中，用于 workflow `tool_call` 执行期间建立 `AgentToolContextScope`。
+- Public `ChatInput` 不暴露 `toolContext`；strict JSON 边界会拒绝客户端提交的同名字段。
+- `WorkflowRunState.ExecutionContext`、committed started delta、Projection/readmodel 不持有 bearer 或 tool context credential。
 
 这个 typed wrapper 定义在 `src/workflow/Aevatar.Workflow.Core/workflow_state.proto`，并通过 `WorkflowRunState.ExecutionStates` 持久化。
 

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -1065,6 +1065,14 @@ public sealed class AevatarInvocationToolSourceTests
     private static void ShouldCarryTypedTrustedCallerValues(WorkflowChatRunRequest command)
     {
         command.ScopeId.Should().Be("scope-1");
+        command.ToolContext.Should().NotBeNull();
+        command.ToolContext!.Caller.ScopeId.Should().Be("scope-1");
+        command.ToolContext.Caller.OwnerSubject.Should().Be("owner-1");
+        command.ToolContext.Credentials.NyxIdAccessToken.Should().Be("access-token");
+        command.ToolContext.Credentials.SenderNyxIdAccessToken.Should().Be("sender-token");
+        command.ToolContext.Routing.ModelOverride.Should().Be("model-1");
+        command.ToolContext.Routing.NyxIdRoutePreference.Should().Be("route-1");
+        command.ToolContext.Routing.MaxToolRoundsOverride.Should().Be(4);
         ShouldCarryWorkflowLlmControlValues(command.LlmControl);
     }
 

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -1632,6 +1632,15 @@ public sealed class ScopeServiceEndpointsTests
         host.InteractionService.LastRequest.Metadata.Should().ContainKey("source").WhoseValue.Should().Be("tests");
         host.InteractionService.LastRequest.Metadata.Should().NotContainKey("connector.http.authorization");
         host.InteractionService.LastRequest.Headers.Should().ContainKey("source").WhoseValue.Should().Be("tests");
+        host.InteractionService.LastRequest.ToolContext.Should().NotBeNull();
+        host.InteractionService.LastRequest.ToolContext!.Credentials.NyxIdAccessToken.Should().Be("token-123");
+        host.InteractionService.LastRequest.ToolContext.Credentials.NyxIdOrgToken.Should().Be("token-123");
+        host.InteractionService.LastRequest.ToolContext.Caller.ScopeId.Should().Be("scope-a");
+        host.InteractionService.LastRequest.ToolContext.Caller.ResponseId.Should().BeNull();
+        host.InteractionService.LastRequest.ToolContext.Channel.Platform.Should().Be("scope-workflow");
+        host.InteractionService.LastRequest.ToolContext.Channel.RegistrationScopeId.Should().Be("scope-a");
+        host.InteractionService.LastRequest.ToolContext.ExternalMetadata.Should().ContainKey("source").WhoseValue.Should().Be("tests");
+        host.InteractionService.LastRequest.ToolContext.ExternalMetadata.Should().NotContainKey("connector.http.authorization");
         // Service-run registry receives the actual workflow run actor id as the run id, so
         // /runs/{runId} can resolve the same id the SSE RunStarted frame carries.
         host.ServiceRunRegistrationPort.RegisterCalls.Should().ContainSingle();
@@ -2310,6 +2319,15 @@ public sealed class ScopeServiceEndpointsTests
         host.InteractionService.LastRequest.Metadata.Should().ContainKey("channel").WhoseValue.Should().Be("tests");
         host.InteractionService.LastRequest.Metadata.Should().NotContainKey("connector.http.authorization");
         host.InteractionService.LastRequest.Headers.Should().ContainKey("channel").WhoseValue.Should().Be("tests");
+        host.InteractionService.LastRequest.ToolContext.Should().NotBeNull();
+        host.InteractionService.LastRequest.ToolContext!.Credentials.NyxIdAccessToken.Should().Be("token-orders");
+        host.InteractionService.LastRequest.ToolContext.Credentials.NyxIdOrgToken.Should().Be("token-orders");
+        host.InteractionService.LastRequest.ToolContext.Caller.ScopeId.Should().Be("scope-a");
+        host.InteractionService.LastRequest.ToolContext.Caller.ResponseId.Should().BeNull();
+        host.InteractionService.LastRequest.ToolContext.Channel.Platform.Should().Be("scope-workflow");
+        host.InteractionService.LastRequest.ToolContext.Channel.RegistrationScopeId.Should().Be("scope-a");
+        host.InteractionService.LastRequest.ToolContext.ExternalMetadata.Should().ContainKey("channel").WhoseValue.Should().Be("tests");
+        host.InteractionService.LastRequest.ToolContext.ExternalMetadata.Should().NotContainKey("connector.http.authorization");
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -1353,6 +1353,95 @@ public sealed class ScopeServiceEndpointsTests
     }
 
     [Fact]
+    public async Task ScopeDraftRunEndpoint_ShouldInjectServerDerivedToolContextFromBearer()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.InteractionService.ResultFactory = async (_, emitAsync, onAcceptedAsync, ct) =>
+        {
+            var receipt = new WorkflowChatRunAcceptedReceipt("run-actor-1", "main", "cmd-1", "corr-1");
+            if (onAcceptedAsync != null)
+                await onAcceptedAsync(receipt, ct);
+
+            await emitAsync(new WorkflowRunEventEnvelope
+            {
+                TextMessageContent = new WorkflowTextMessageContentEventPayload
+                {
+                    MessageId = "msg-1",
+                    Delta = "hello",
+                },
+            }, ct);
+            return CommandInteractionResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
+        };
+
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, "/api/scopes/scope-a/workflow/draft-run")
+        {
+            Content = JsonContent.Create(new
+            {
+                prompt = "run the draft",
+                sessionId = "session-1",
+                workflowYamls = new[]
+                {
+                    "name: main\nsteps:\n  - run: echo hello",
+                },
+                headers = new Dictionary<string, string>
+                {
+                    ["source"] = "draft-test",
+                    ["scope_id"] = "client-scope",
+                    ["connector.http.authorization"] = "Bearer stale-metadata-token",
+                },
+            }),
+        };
+        httpRequest.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "token-123");
+
+        var response = await host.Client.SendAsync(httpRequest);
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, "stream body: {0}", body);
+        host.InteractionService.LastRequest.Should().NotBeNull();
+        var request = host.InteractionService.LastRequest!;
+        request.ToolContext.Should().NotBeNull();
+        request.ToolContext!.Credentials.NyxIdAccessToken.Should().Be("token-123");
+        request.ToolContext.Credentials.NyxIdOrgToken.Should().Be("token-123");
+        request.ToolContext.Caller.ScopeId.Should().Be("scope-a");
+        request.ToolContext.Caller.ResponseId.Should().Be("session-1");
+        request.ToolContext.Channel.Platform.Should().Be("scope-workflow");
+        request.ToolContext.Channel.RegistrationScopeId.Should().Be("scope-a");
+        request.ToolContext.ExternalMetadata.Should().ContainKey("source").WhoseValue.Should().Be("draft-test");
+        request.ToolContext.ExternalMetadata.Should().NotContainKey("scope_id");
+        request.ToolContext.ExternalMetadata.Should().NotContainKey("connector.http.authorization");
+        request.Metadata.Should().BeNullOrEmpty();
+        request.Headers.Should().ContainKey("source").WhoseValue.Should().Be("draft-test");
+        request.Headers.Should().NotContainKey("scope_id");
+        request.Headers.Should().NotContainKey("connector.http.authorization");
+    }
+
+    [Fact]
+    public async Task ScopeDraftRunEndpoint_ShouldRejectClientToolContext()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/workflow/draft-run", new
+        {
+            prompt = "run the draft",
+            workflowYamls = new[]
+            {
+                "name: main\nsteps:\n  - run: echo hello",
+            },
+            toolContext = new
+            {
+                credentials = new
+                {
+                    nyxIdAccessToken = "client-token",
+                },
+            },
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        host.InteractionService.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
     public async Task ScopeDraftRunEndpoint_ShouldEmitAguiEvents_WhenRequested()
     {
         await using var host = await ScopeServiceEndpointTestHost.StartAsync();

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
@@ -323,6 +323,80 @@ public sealed class ScopeWorkflowEndpointsTests
     }
 
     [Fact]
+    public async Task HandleRunWorkflowStreamAsync_ShouldInjectServerDerivedToolContextFromBearer()
+    {
+        var queryPort = new FakeServiceLifecycleQueryPort
+        {
+            ListServicesResult =
+            [
+                new ServiceCatalogSnapshot(
+                    "tenant-a:workflow-app:user:token:approval",
+                    "tenant-a",
+                    "workflow-app",
+                    "user:user-1-token",
+                    "approval",
+                    "Approval",
+                    "rev-1",
+                    "rev-1",
+                    "dep-1",
+                    "definition-actor-1",
+                    "active",
+                    [],
+                    [],
+                    DateTimeOffset.UtcNow),
+            ],
+        };
+        var interactionService = new FakeCommandInteractionService
+        {
+            ResultFactory = async (_, _, onAcceptedAsync, ct) =>
+            {
+                var receipt = new WorkflowChatRunAcceptedReceipt("run-actor-1", "approval", "cmd-1", "corr-1");
+                if (onAcceptedAsync != null)
+                    await onAcceptedAsync(receipt, ct);
+                return CommandInteractionResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
+            },
+        };
+        var http = CreateAuthenticatedHttpContext("user-1");
+        http.Request.Headers.Authorization = "Bearer token-123";
+
+        await ScopeWorkflowEndpoints.HandleRunWorkflowStreamAsync(
+            http,
+            "user-1",
+            new ScopeWorkflowEndpoints.RunScopeWorkflowStreamHttpRequest(
+                "definition-actor-1",
+                "hello",
+                "session-1",
+                new Dictionary<string, string>
+                {
+                    ["source"] = "tests",
+                    ["scope_id"] = "client-scope",
+                    ["connector.http.authorization"] = "Bearer client-token",
+                }),
+            BuildQueryPort(queryPort: queryPort),
+            interactionService,
+            CancellationToken.None);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        interactionService.LastRequest.Should().NotBeNull();
+        var toolContext = interactionService.LastRequest!.ToolContext;
+        toolContext.Should().NotBeNull();
+        toolContext!.Credentials.NyxIdAccessToken.Should().Be("token-123");
+        toolContext.Credentials.NyxIdOrgToken.Should().Be("token-123");
+        toolContext.Caller.ScopeId.Should().Be("user-1");
+        toolContext.Caller.ResponseId.Should().Be("session-1");
+        toolContext.Channel.Platform.Should().Be("scope-workflow");
+        toolContext.Channel.RegistrationScopeId.Should().Be("user-1");
+        toolContext.ExternalMetadata.Should().Contain("source", "tests");
+        toolContext.ExternalMetadata.Should().NotContainKey("scope_id");
+        toolContext.ExternalMetadata.Should().NotContainKey("connector.http.authorization");
+        interactionService.LastRequest.Metadata.Should().BeNullOrEmpty();
+        interactionService.LastRequest.Headers.Should().Contain("source", "tests");
+        interactionService.LastRequest.Headers.Should().NotContainKey("scope_id");
+        interactionService.LastRequest.Headers.Should().NotContainKey("connector.http.authorization");
+    }
+
+    [Fact]
     public async Task HandleRunWorkflowByIdStreamAsync_ShouldStreamAguiEvents_WhenRequested()
     {
         var snapshot = new ServiceCatalogSnapshot(

--- a/test/Aevatar.Integration.Tests/WorkflowCoreModulesCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowCoreModulesCoverageTests.cs
@@ -1,4 +1,5 @@
 using Aevatar.Foundation.Abstractions;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Workflow.Core.Modules;
 using FluentAssertions;
 using Google.Protobuf;
@@ -92,6 +93,52 @@ public sealed class WorkflowCoreModulesCoverageTests
         var toolResult = ctx.Published.Select(x => x.evt).OfType<WorkflowToolCallCompletedEvent>().Single();
         toolResult.Success.Should().BeTrue();
         toolResult.ResultJson.Should().Be("""{"msg":"ok"}""");
+    }
+
+    [Fact]
+    public async Task ToolCallModule_ShouldPushWorkflowToolContextDuringToolExecution()
+    {
+        var previous = AgentToolRequestContext.Current;
+        AgentToolRequestContext.Current = null;
+        try
+        {
+            AgentToolExecutionContext? observedDuringExecution = null;
+            var tool = new FakeAgentTool("capture_context", _ =>
+            {
+                observedDuringExecution = AgentToolRequestContext.Current;
+                return "{}";
+            });
+            var module = new ToolCallModule([new CountingToolSource([tool])], NullLogger<ToolCallModule>.Instance);
+            var ctx = CreateContext();
+            ctx.RuntimeContext.ToolContext = AgentToolExecutionContext.Empty with
+            {
+                Request = new AgentToolRequestIdentity("cmd-1", null),
+                Credentials = new AgentToolCredentials("token-1", null, null),
+                Caller = new AgentToolCallerContext("scope-1", "owner-1", "response-1"),
+            };
+
+            await module.HandleAsync(
+                Envelope(new StepRequestEvent
+                {
+                    StepId = "step-context",
+                    StepType = "tool_call",
+                    Input = "{}",
+                    Parameters = { ["tool"] = "capture_context" },
+                }),
+                ctx,
+                CancellationToken.None);
+
+            observedDuringExecution.Should().NotBeNull();
+            observedDuringExecution!.Credentials.NyxIdAccessToken.Should().Be("token-1");
+            observedDuringExecution.Caller.ScopeId.Should().Be("scope-1");
+            observedDuringExecution.Request.RequestId.Should().Be("cmd-1");
+            observedDuringExecution.Request.CallId.Should().Be("step-context");
+            AgentToolRequestContext.Current.Should().BeNull();
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = previous;
+        }
     }
 
     [Fact]

--- a/test/Aevatar.Integration.Tests/WorkflowGAgentCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowGAgentCoverageTests.cs
@@ -507,14 +507,26 @@ public class WorkflowGAgentCoverageTests
                 MaxToolRoundsOverride = 4,
                 UserMemoryPrompt = " memory-main ",
             },
+            ToolContext = (AgentToolExecutionContext.Empty with
+            {
+                Credentials = new AgentToolCredentials("nyx-token-1", "org-token-1", null),
+                Caller = new AgentToolCallerContext("scope-1", "owner-1", "response-1"),
+            }).ToPayload(),
         });
 
         agent1.State.ExecutionContext.Connector!.HttpAuthorization.Should().Be("Bearer secret");
         agent1.State.ExecutionContext.Llm!.ModelOverride.Should().Be("model-main");
+        agent1.State.ToByteString().ToStringUtf8().Should().NotContain("nyx-token-1");
         await agent1.DeactivateAsync();
 
         var persisted = await eventStore.GetEventsAsync(agent1.Id);
-        persisted.Should().ContainSingle(x => x.EventType.Contains(nameof(WorkflowRunExecutionStartedEvent), StringComparison.Ordinal));
+        var startedRecord = persisted.Should()
+            .ContainSingle(x => x.EventType.Contains(nameof(WorkflowRunExecutionStartedEvent), StringComparison.Ordinal))
+            .Subject;
+        var started = startedRecord.EventData.Unpack<WorkflowRunExecutionStartedEvent>();
+        started.ExecutionContextDelta.ToByteString().ToStringUtf8().Should().NotContain("nyx-token-1");
+        started.ExecutionContextDelta.Llm.ModelOverride.Should().Be("model-main");
+        started.ExecutionContextDelta.Connector.HttpAuthorization.Should().Be("Bearer secret");
 
         var agent2 = CreateRunAgent(runtime: runtime, eventStore: eventStore);
         SetAgentId(agent2, "workflow-run-context-replay");
@@ -524,6 +536,7 @@ public class WorkflowGAgentCoverageTests
         agent2.State.ExecutionContext.Llm!.ModelOverride.Should().Be("model-main");
         agent2.State.ExecutionContext.Llm.MaxToolRoundsOverride.Should().Be(4);
         agent2.State.ExecutionContext.Llm.UserMemoryPrompt.Should().Be("memory-main");
+        agent2.State.ToByteString().ToStringUtf8().Should().NotContain("nyx-token-1");
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationRegistrationAndExecutionTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationRegistrationAndExecutionTests.cs
@@ -4,6 +4,8 @@ using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Core.Commands;
 using Aevatar.CQRS.Core.Interactions;
 using Aevatar.CQRS.Core.Streaming;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.Workflow.Abstractions;
@@ -397,6 +399,60 @@ public sealed class WorkflowApplicationRegistrationAndExecutionTests
         request.Metadata.Should().Contain("client-note", "open-extension");
         request.Metadata.Should().NotContainKey(WorkflowRunCommandMetadataKeys.ScopeId);
         request.Metadata.Should().NotContainKey("scope_id");
+    }
+
+    [Fact]
+    public void EnvelopeFactory_ShouldCarryTrustedToolContextAsTypedProtoField()
+    {
+        var services = new ServiceCollection();
+        services.AddWorkflowApplication();
+        using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<ICommandEnvelopeFactory<WorkflowChatRunRequest>>();
+        var toolContext = AgentToolExecutionContext.Empty with
+        {
+            Request = new AgentToolRequestIdentity("req-1", null),
+            Credentials = new AgentToolCredentials("token-1", "org-token-1", null),
+            Caller = new AgentToolCallerContext("scope-1", "owner-1", "response-1"),
+            Routing = new LLMRequestRoutingContext("model-1", "route-1", 4, "memory-1"),
+            ExternalMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [LLMRequestMetadataKeys.NyxIdAccessToken] = "metadata-token",
+                ["trace-id"] = "trace-1",
+            },
+        };
+        var command = new WorkflowChatRunRequest(
+            "hello",
+            WorkflowChatSource.DefinitionActor("actor-1", "direct"),
+            Metadata: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [LLMRequestMetadataKeys.NyxIdAccessToken] = "metadata-token",
+                [LLMRequestMetadataKeys.ScopeId] = "metadata-scope",
+                ["client-note"] = "open-extension",
+            },
+            ScopeId: "scope-1",
+            ToolContext: toolContext);
+
+        var envelope = factory.CreateEnvelope(command, new CommandContext(
+            "actor-1",
+            "cmd-1",
+            "corr-1",
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [LLMRequestMetadataKeys.NyxIdAccessToken] = "header-token",
+            }));
+        var request = envelope.Payload.Unpack<WorkflowChatRequestEvent>();
+
+        request.ToolContext.Credentials.NyxIdAccessToken.Should().Be("token-1");
+        request.ToolContext.Credentials.NyxIdOrgToken.Should().Be("org-token-1");
+        request.ToolContext.Caller.ScopeId.Should().Be("scope-1");
+        request.ToolContext.Caller.OwnerSubject.Should().Be("owner-1");
+        request.ToolContext.Routing.ModelOverride.Should().Be("model-1");
+        request.ToolContext.ExternalMetadata.Should().Contain("trace-id", "trace-1");
+        request.ToolContext.ExternalMetadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
+        request.Metadata.Should().Contain("client-note", "open-extension");
+        request.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
+        request.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.ScopeId);
+        request.Headers.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
@@ -1,6 +1,7 @@
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Abstractions.Execution;
 using Aevatar.Workflow.Core.Execution;
@@ -42,6 +43,57 @@ public sealed class WorkflowExecutionRuntimeContextTests
         host.RuntimeContext.RequestPassthroughMetadata.Values.Should().NotContainKey("model_override");
         host.RuntimeContext.RequestPassthroughMetadata.Values.Should().NotContainKey("llm.max_tool_rounds");
         host.RuntimeContext.RequestPassthroughMetadata.Values.Should().NotContainKey("llm.user_memory_prompt");
+    }
+
+    [Fact]
+    public void Clear_ShouldClearToolContext()
+    {
+        var context = new WorkflowExecutionRuntimeContext();
+        context.ToolContext = AgentToolExecutionContext.Empty with
+        {
+            Credentials = new AgentToolCredentials("token-1", null, null),
+        };
+        context.ApplyRequestMetadata(new Dictionary<string, string>
+        {
+            ["trace-id"] = "trace-1",
+        });
+
+        context.Clear();
+
+        context.ToolContext.Should().BeNull();
+        context.RequestPassthroughMetadata.Values.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void WorkflowToolExecutionContextAccess_ShouldApplyCommandContextAndStepCallId()
+    {
+        var runtimeContext = new WorkflowExecutionRuntimeContext();
+        var payload = (AgentToolExecutionContext.Empty with
+        {
+            Credentials = new AgentToolCredentials("token-1", null, null),
+            Caller = new AgentToolCallerContext(null, "owner-1", null),
+        }).ToPayload();
+        var executionContext = new RecordingWorkflowExecutionContext
+        {
+            RuntimeContext = runtimeContext,
+        };
+
+        WorkflowToolExecutionContextAccess.ApplyFromCommand(
+            runtimeContext,
+            payload,
+            "cmd-1",
+            "scope-1",
+            "session-1");
+        var stepContext = WorkflowToolExecutionContextAccess.GetForStep(executionContext, "step-1");
+
+        runtimeContext.ToolContext.Should().NotBeNull();
+        runtimeContext.ToolContext!.Request.RequestId.Should().Be("cmd-1");
+        runtimeContext.ToolContext.Caller.ScopeId.Should().Be("scope-1");
+        runtimeContext.ToolContext.Caller.ResponseId.Should().Be("session-1");
+        stepContext.Should().NotBeNull();
+        stepContext!.Credentials.NyxIdAccessToken.Should().Be("token-1");
+        stepContext.Request.CallId.Should().Be("step-1");
+        runtimeContext.ToolContext.Request.CallId.Should().BeNull();
     }
 
     [Fact]
@@ -312,7 +364,7 @@ public sealed class WorkflowExecutionRuntimeContextTests
 
         public string RunId => "run-1";
 
-        public WorkflowExecutionRuntimeContext RuntimeContext { get; } = new();
+        public WorkflowExecutionRuntimeContext RuntimeContext { get; init; } = new();
 
         public WorkflowRunExecutionContextState ExecutionContextState { get; } = new();
 
@@ -358,7 +410,7 @@ public sealed class WorkflowExecutionRuntimeContextTests
     {
         private readonly Dictionary<string, Any> _states = new(StringComparer.Ordinal);
 
-        public WorkflowExecutionRuntimeContext RuntimeContext { get; } = new();
+        public WorkflowExecutionRuntimeContext RuntimeContext { get; init; } = new();
 
         public WorkflowRunExecutionContextState ExecutionContextState { get; } = new();
 

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
@@ -208,16 +208,9 @@ public sealed class ChatEndpointsInternalTests
           }
         }
         """;
-        var interactionService = new FakeCommandInteractionService
-        {
-            ResultFactory = (_, _, _, _) =>
-                throw new InvalidOperationException("handler should not run after strict JSON rejection"),
-        };
-
         var act = () => JsonSerializer.Deserialize<ChatInput>(json, ChatWebSocketProtocol.JsonOptions);
 
         act.Should().Throw<JsonException>();
-        interactionService.CallCount.Should().Be(0);
     }
 
     [Fact]
@@ -1165,17 +1158,12 @@ public sealed class ChatEndpointsInternalTests
                 CommandInteractionResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
                     .Failure(WorkflowChatRunStartError.AgentNotFound));
 
-        public int CallCount { get; private set; }
-
         public Task<CommandInteractionResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>> ExecuteAsync(
             WorkflowChatRunRequest request,
             Func<WorkflowRunEventEnvelope, CancellationToken, ValueTask> emitAsync,
             Func<WorkflowChatRunAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
-            CancellationToken ct = default)
-        {
-            CallCount++;
-            return ResultFactory(request, emitAsync, onAcceptedAsync, ct);
-        }
+            CancellationToken ct = default) =>
+            ResultFactory(request, emitAsync, onAcceptedAsync, ct);
     }
 
     private sealed class FakeCommandDispatchService

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
@@ -1,5 +1,6 @@
 using System.Net.WebSockets;
 using System.Text;
+using System.Text.Json;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.Workflow.Abstractions;
@@ -173,6 +174,50 @@ public sealed class ChatEndpointsInternalTests
         service.LastCommand.InputParts.Should().ContainSingle();
         service.LastCommand.InputParts![0].Kind.Should()
             .Be(Aevatar.Workflow.Application.Abstractions.Runs.WorkflowChatInputPartKind.Image);
+    }
+
+    [Fact]
+    public void HandleCommandJsonBinding_ShouldRejectHttpBodyToolContext()
+    {
+        const string json = """
+        {
+          "prompt": "hello",
+          "toolContext": {
+            "credentials": {
+              "nyxIdAccessToken": "client-token"
+            }
+          }
+        }
+        """;
+
+        var act = () => JsonSerializer.Deserialize<ChatInput>(json, ChatWebSocketProtocol.JsonOptions);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void HandleChatJsonBinding_ShouldRejectHttpBodyToolContext()
+    {
+        const string json = """
+        {
+          "prompt": "hello",
+          "toolContext": {
+            "caller": {
+              "scopeId": "client-scope"
+            }
+          }
+        }
+        """;
+        var interactionService = new FakeCommandInteractionService
+        {
+            ResultFactory = (_, _, _, _) =>
+                throw new InvalidOperationException("handler should not run after strict JSON rejection"),
+        };
+
+        var act = () => JsonSerializer.Deserialize<ChatInput>(json, ChatWebSocketProtocol.JsonOptions);
+
+        act.Should().Throw<JsonException>();
+        interactionService.CallCount.Should().Be(0);
     }
 
     [Fact]
@@ -1120,12 +1165,17 @@ public sealed class ChatEndpointsInternalTests
                 CommandInteractionResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
                     .Failure(WorkflowChatRunStartError.AgentNotFound));
 
+        public int CallCount { get; private set; }
+
         public Task<CommandInteractionResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>> ExecuteAsync(
             WorkflowChatRunRequest request,
             Func<WorkflowRunEventEnvelope, CancellationToken, ValueTask> emitAsync,
             Func<WorkflowChatRunAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
-            CancellationToken ct = default) =>
-            ResultFactory(request, emitAsync, onAcceptedAsync, ct);
+            CancellationToken ct = default)
+        {
+            CallCount++;
+            return ResultFactory(request, emitAsync, onAcceptedAsync, ct);
+        }
     }
 
     private sealed class FakeCommandDispatchService

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatWebSocketCommandParserTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatWebSocketCommandParserTests.cs
@@ -116,6 +116,31 @@ public class ChatWebSocketCommandParserTests
     }
 
     [Fact]
+    public void TryParse_ClientToolContext_ShouldReturnInvalidCommand()
+    {
+        var frame = TextFrame("""
+        {
+          "type": "chat.command",
+          "requestId": "req-tool",
+          "payload": {
+            "prompt": "hello",
+            "toolContext": {
+              "credentials": {
+                "nyxIdAccessToken": "client-token"
+              }
+            }
+          }
+        }
+        """);
+
+        var ok = ChatWebSocketCommandParser.TryParse(frame, out _, out var error);
+
+        ok.Should().BeFalse();
+        error.Code.Should().Be("INVALID_COMMAND");
+        error.Message.Should().NotContain("toolContext");
+    }
+
+    [Fact]
     public void TryParse_BinaryFrame_ShouldKeepBinaryResponseType()
     {
         var frame = new ChatWebSocketInboundFrame(

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatWebSocketCoordinatorAndProtocolTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatWebSocketCoordinatorAndProtocolTests.cs
@@ -128,7 +128,7 @@ public sealed class ChatWebSocketCoordinatorAndProtocolTests
         var command = service.LastRequest;
         command.Should().NotBeNull();
         var metadata = command!.Metadata ?? throw new InvalidOperationException("Expected metadata capture.");
-        metadata["telegram.chat_id"].Should().Be("-100-request");
+        metadata.Should().NotContainKey("telegram.chat_id");
         metadata["telegram.openclaw_bot_username"].Should().Be("openclaw_bot");
     }
 

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowCapabilityEndpointsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowCapabilityEndpointsCoverageTests.cs
@@ -195,16 +195,36 @@ public sealed class WorkflowCapabilityEndpointsCoverageTests
     }
 
     [Fact]
-    public void ChatRunRequestNormalizer_ShouldKeepToolContextOutOfWorkflowCommand()
+    public void ChatInputJson_ShouldRejectClientToolContext()
+    {
+        const string json = """
+        {
+          "prompt": "hello",
+          "toolContext": {
+            "credentials": {
+              "nyxIdAccessToken": "client-token"
+            }
+          }
+        }
+        """;
+
+        var act = () => JsonSerializer.Deserialize<ChatInput>(json, ChatWebSocketProtocol.JsonOptions);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void ChatRunRequestNormalizer_ShouldUseOnlyTrustedToolContextArgument()
     {
         var toolContext = AgentToolExecutionContext.Empty with
         {
-            Request = new AgentToolRequestIdentity(" req-1 ", " call-1 "),
-            Caller = new AgentToolCallerContext(" scope-1 ", " owner-1 ", " response-1 "),
+            Request = new AgentToolRequestIdentity("req-1", "call-1"),
+            Credentials = new AgentToolCredentials("token-1", "org-token-1", null),
+            Caller = new AgentToolCallerContext("scope-1", "owner-1", "response-1"),
             Routing = LLMRequestRoutingContext.Empty with
             {
-                ModelOverride = " model-a ",
-                NyxIdRoutePreference = " route-a ",
+                ModelOverride = "model-a",
+                NyxIdRoutePreference = "route-a",
                 MaxToolRoundsOverride = 2,
             },
             ExternalMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
@@ -215,15 +235,32 @@ public sealed class WorkflowCapabilityEndpointsCoverageTests
         var input = new ChatInput
         {
             Prompt = "hello",
-            ToolContext = toolContext,
+            Metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [LLMRequestMetadataKeys.NyxIdAccessToken] = "client-token",
+                [LLMRequestMetadataKeys.ScopeId] = "client-scope",
+                ["trace-id"] = "trace-2",
+            },
+            Headers = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [LLMRequestMetadataKeys.NyxIdAccessToken] = "header-token",
+            },
+            LlmControl = new ChatLlmControlInput
+            {
+                NyxIdAccessToken = "ignored-control-token",
+                ModelOverride = "model-b",
+            },
         };
 
-        var result = ChatRunRequestNormalizer.Normalize(input);
+        var result = ChatRunRequestNormalizer.Normalize(input, trustedToolContext: toolContext);
 
         result.Succeeded.Should().BeTrue();
-        result.Request!.ScopeId.Should().BeNull();
-        result.Request.LlmControl.Should().BeNull();
-        result.Request.Metadata.Should().BeEmpty();
+        result.Request!.ToolContext.Should().BeSameAs(toolContext);
+        result.Request.LlmControl.Should().Be(new WorkflowLlmControl("model-b", null, null));
+        result.Request.Metadata.Should().Contain("trace-id", "trace-2");
+        result.Request.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
+        result.Request.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.ScopeId);
+        result.Request.Headers.Should().BeNullOrEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
## 摘要

修复 #1791：workflow `tool_call` 调用需要 NyxID 凭证的工具（`nyxid_proxy` / `code_execute` / `lark_*`）时全部返回 `"No NyxID access token available"`。

- **Old**：workflow tool_call 执行路径从不建立 `AgentToolContextScope`，调用方 NyxID 凭证（AsyncLocal `AgentToolRequestContext`）不跨 actor 进入 workflow run actor；同时 public `ChatInput.ToolContext` 是 client-forgeable 且未被消费的死字段。
- **New**：删除 public `ChatInput.ToolContext`（strict JSON 拒绝客户端 `toolContext`），新增内部 typed 命令通道，凭证仅由 Host 可信来源派生并在 tool 执行期经 `AgentToolContextScope` 注入；全程 volatile，不落 durable / projection / log。

直接解锁 `#1695`（技能内置 workflow 做真实 I/O），按「删除优先 / API 字段单一语义 / 读写分离」收紧可信边界。

## 变更要点

1. **删除** `ChatInput.ToolContext`；保留 `JsonUnmappedMemberHandling.Disallow` → 客户端提交 `toolContext` 被 **400 / `INVALID_COMMAND` 拒绝**（不是静默忽略）。
2. 新增内部通道：`WorkflowChatRunRequest.ToolContext` → proto `WorkflowChatRequestEvent.tool_context = 10`（additive，import `ai_messages.proto`）→ volatile `WorkflowExecutionRuntimeContext` → `ToolCallModule` `AgentToolContextScope.Push(...WithCallId(stepId))`。
3. `ChatRunRequestNormalizer` 增 `trustedToolContext` 参数（仅此写入命令，并 strip metadata/headers 中的 owned control keys）；Host wrapper 经新 `ScopedWorkflowToolContextFactory` 从 bearer/scope/session 派生；`aevatar_start_workflow` 从 `AgentToolRequestContext.Current` 透传。
4. 凭证不落 `Metadata` / `Headers` / `WorkflowLlmControl` / durable state / projection / readmodel / log；`nyxid_access_token` 保持 reserved；`Workflow.Core → AI.Abstractions`（未引 `AI.Core`）。

## 范围

30 files changed, **+726 / -35**。新增 2 个非 port helper（`ScopedWorkflowToolContextFactory`、`WorkflowToolExecutionContextAccess`）。10+ 回归测试覆盖：HTTP/WS 客户端 `toolContext` 拒绝、Host 派生注入、tool 执行期 `AgentToolRequestContext.NyxIdAccessToken == 注入值`、持久化排除。

## 验证

- `dotnet build aevatar.slnx --nologo`：**成功**
- `Aevatar.Workflow.Host.Api.Tests`：**424/424 通过**
- `Aevatar.Workflow.Core.Tests`：**304/304 通过**
- `Aevatar.Workflow.Application.Tests` / `Aevatar.GAgentService.Integration.Tests` / `Aevatar.AI.ToolProviders.AevatarInvocation.Tests` / `Aevatar.Integration.Tests`（相关 filter）/ `tools/ci/test_stability_guards.sh` / `tools/ci/architecture_guards.sh`：implement 阶段验证通过；CI 复核。

## 设计共识

consensus-rnd design-consensus **r3** 达成（minimal / structural / delete 三 solver 一致 `propose`）。完整决策记录见 #1791 评论串。

Closes #1791

🤖 Auto-loop / consensus-rnd codex-refactor-loop

⟦AI:AUTO-LOOP⟧
