### PR TITLE
fix(#1826): receipt-grounded 工具完成语义（AgentToolReceipt wire 契约）

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
@@ -61,6 +61,7 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
     private readonly IActorRuntimeCallbackScheduler? _callbackScheduler;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<AgentRunGAgent> _logger;
+    private readonly IAgentToolReceiptRenderer _toolReceiptRenderer;
 
     public AgentRunGAgent(
         IActorRuntime actorRuntime,
@@ -68,7 +69,8 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions? relayOptions,
         ILogger<AgentRunGAgent> logger,
         IActorRuntimeCallbackScheduler? callbackScheduler = null,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        IAgentToolReceiptRenderer? toolReceiptRenderer = null)
     {
         _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
         _generationExecutor = generationExecutor ?? throw new ArgumentNullException(nameof(generationExecutor));
@@ -76,6 +78,7 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         _callbackScheduler = callbackScheduler;
         _timeProvider = timeProvider ?? TimeProvider.System;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _toolReceiptRenderer = toolReceiptRenderer ?? new AgentToolReceiptRenderer();
     }
 
     protected override AgentRunGAgentState TransitionState(AgentRunGAgentState current, IMessage evt) =>
@@ -547,7 +550,9 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
             hasReplyText ? LlmReplyTerminalState.Completed : LlmReplyTerminalState.Failed,
             hasReplyText ? string.Empty : "empty_reply",
             hasReplyText ? string.Empty : $"Reply generator returned an empty response ({emptyReplyDiagnostics}).",
-            stepState.AppendedHistory.ToArray());
+            stepState.AppendedHistory.ToArray(),
+            stepState.ToolReceipts.ToArray(),
+            stepState.PendingToolCalls.ToArray());
     }
 
     // Diagnostic context for the otherwise-silent empty-reply terminal path. Reads only
@@ -778,6 +783,7 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         next.Messages.AddRange(result.ResultMessages.Select(message => message.Clone()));
         next.AppendedHistory.AddRange(
             result.ResultMessages.Select(AgentRunReplyStepMappers.ToConversationHistoryEntry));
+        next.ToolReceipts.AddRange(result.ToolReceipts.Select(receipt => receipt.Clone()));
         if (result.AdvanceRound)
             next.Round++;
         return next;
@@ -813,22 +819,26 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         LlmReplyTerminalState terminalState,
         string errorCode,
         string errorSummary,
-        IReadOnlyList<ConversationHistoryEntry>? appendedHistory = null)
+        IReadOnlyList<ConversationHistoryEntry>? appendedHistory = null,
+        IReadOnlyList<Aevatar.AI.Abstractions.AgentToolReceipt>? toolReceipts = null,
+        IReadOnlyList<AgentRunToolCall>? toolCalls = null)
     {
+        var renderedReplyText = RenderReplyWithReceipts(replyText, toolReceipts, toolCalls);
         await PersistReplyProducedAsync(
             request,
             runId,
-            replyText,
+            renderedReplyText,
             outboundIntent,
             terminalState,
             errorCode,
             errorSummary,
-            appendedHistory);
+            appendedHistory,
+            toolReceipts);
 
         await DispatchReadyEventAsync(
             request,
             runId,
-            replyText,
+            renderedReplyText,
             outboundIntent,
             terminalState,
             errorCode,
@@ -948,7 +958,8 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         LlmReplyTerminalState terminalState,
         string errorCode,
         string errorSummary,
-        IReadOnlyList<ConversationHistoryEntry>? appendedHistory)
+        IReadOnlyList<ConversationHistoryEntry>? appendedHistory,
+        IReadOnlyList<Aevatar.AI.Abstractions.AgentToolReceipt>? toolReceipts)
     {
         var evt = new AgentRunReplyProducedEvent
         {
@@ -964,7 +975,26 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         if (outbound is not null)
             evt.Outbound = outbound.Clone();
         evt.AppendedHistory.AddRange((appendedHistory ?? []).Select(entry => entry.Clone()));
+        evt.ToolReceipts.AddRange((toolReceipts ?? []).Select(receipt => receipt.Clone()));
         await PersistDomainEventAsync(evt);
+    }
+
+    private string RenderReplyWithReceipts(
+        string replyText,
+        IReadOnlyList<Aevatar.AI.Abstractions.AgentToolReceipt>? toolReceipts,
+        IReadOnlyList<AgentRunToolCall>? toolCalls)
+    {
+        if (toolReceipts is not { Count: > 0 })
+            return replyText ?? string.Empty;
+
+        var rendered = _toolReceiptRenderer.Render(toolReceipts, toolCalls ?? []);
+        if (string.IsNullOrWhiteSpace(rendered))
+            return replyText ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(replyText))
+            return rendered;
+
+        return $"{replyText.TrimEnd()}\n\n{rendered}";
     }
 
     private async Task PersistReplyDispatchedAsync(NeedsLlmReplyEvent request, string runId)
@@ -1640,6 +1670,8 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         next.ProducedTerminalState = evt.TerminalState;
         next.ProducedAppendedHistory.Clear();
         next.ProducedAppendedHistory.AddRange(evt.AppendedHistory.Select(entry => entry.Clone()));
+        next.ToolReceipts.Clear();
+        next.ToolReceipts.AddRange(evt.ToolReceipts.Select(receipt => receipt.Clone()));
         // Backward-compat: AgentRunReplyProducedEvents persisted by the pre-refactor
         // codepath have no reply_text / outbound / terminal_state fields (proto3 defaults
         // on deserialize). Historically, Status=ReplyProduced was only written *after* the

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs
@@ -317,6 +317,8 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
         {
             toolStepResult.ResultMessages.Add(AgentRunReplyStepMappers.ToProto(
                 ToolCallLoop.BuildToolResultMessage(toolResult.CallId, toolResult.ToolName, toolResult.Result)));
+            if (toolResult.Receipt is not null)
+                toolStepResult.ToolReceipts.Add(toolResult.Receipt.Clone());
         }
 
         // Defense-in-depth complement to the Kafka transport fix (commit f2c2319e7):

--- a/agents/Aevatar.GAgents.NyxidChat/AgentToolReceiptRenderer.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentToolReceiptRenderer.cs
@@ -1,0 +1,145 @@
+using System.Text;
+using System.Text.Json;
+using Aevatar.AI.Abstractions;
+
+namespace Aevatar.GAgents.NyxidChat;
+
+public sealed class AgentToolReceiptRenderer : IAgentToolReceiptRenderer
+{
+    public string Render(IReadOnlyList<AgentToolReceipt> receipts, IReadOnlyList<AgentRunToolCall> toolCalls)
+    {
+        ArgumentNullException.ThrowIfNull(receipts);
+        if (receipts.Count == 0)
+            return string.Empty;
+
+        var toolCallById = toolCalls
+            .Where(static call => !string.IsNullOrWhiteSpace(call.Id))
+            .GroupBy(static call => call.Id, StringComparer.Ordinal)
+            .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.Ordinal);
+        var builder = new StringBuilder();
+        foreach (var receipt in receipts)
+        {
+            var line = RenderLine(receipt, toolCallById);
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            if (builder.Length == 0)
+                builder.AppendLine();
+            builder.AppendLine(line);
+        }
+
+        return builder.ToString().TrimEnd();
+    }
+
+    private static string RenderLine(
+        AgentToolReceipt receipt,
+        IReadOnlyDictionary<string, AgentRunToolCall> toolCallById)
+    {
+        var status = receipt.Status switch
+        {
+            AgentToolReceiptStatus.Success => "Completed",
+            AgentToolReceiptStatus.ApprovalRequired => "Approval required",
+            AgentToolReceiptStatus.Denied => "Denied",
+            AgentToolReceiptStatus.Error => "Failed",
+            _ => string.Empty,
+        };
+        if (string.IsNullOrEmpty(status))
+            return string.Empty;
+
+        var subject = ResolveSubject(receipt, toolCallById);
+        var evidence = ResolveEvidence(receipt);
+        var builder = new StringBuilder();
+        builder.Append("[tool receipt] ");
+        builder.Append(status);
+        if (!string.IsNullOrWhiteSpace(subject))
+        {
+            builder.Append(": ");
+            builder.Append(subject);
+        }
+
+        if (!string.IsNullOrWhiteSpace(evidence))
+        {
+            builder.Append(" (");
+            builder.Append(evidence);
+            builder.Append(')');
+        }
+
+        if (receipt.Status is AgentToolReceiptStatus.Error or AgentToolReceiptStatus.Denied &&
+            !string.IsNullOrWhiteSpace(receipt.ErrorMessage))
+        {
+            builder.Append(" - ");
+            builder.Append(receipt.ErrorMessage.Trim());
+        }
+
+        return builder.ToString();
+    }
+
+    private static string ResolveSubject(
+        AgentToolReceipt receipt,
+        IReadOnlyDictionary<string, AgentRunToolCall> toolCallById)
+    {
+        var kind = Normalize(receipt.SubjectKind);
+        var id = Normalize(receipt.SubjectId);
+        if (kind is not null || id is not null)
+            return string.Join(" ", new[] { kind, id }.Where(static value => !string.IsNullOrWhiteSpace(value)));
+
+        if (!toolCallById.TryGetValue(receipt.CallId ?? string.Empty, out var toolCall))
+            return Normalize(receipt.ToolName) ?? string.Empty;
+
+        return TryGetDisplayNameFromArguments(toolCall.ArgumentsJson) ??
+               Normalize(receipt.ToolName) ??
+               string.Empty;
+    }
+
+    private static string ResolveEvidence(AgentToolReceipt receipt)
+    {
+        var parts = new List<string>();
+        if (!string.IsNullOrWhiteSpace(receipt.SubjectVersion))
+            parts.Add($"version={receipt.SubjectVersion.Trim()}");
+        if (!string.IsNullOrWhiteSpace(receipt.SubjectHash))
+            parts.Add($"hash={receipt.SubjectHash.Trim()}");
+        if (!string.IsNullOrWhiteSpace(receipt.ApprovalRequestId) &&
+            receipt.Status == AgentToolReceiptStatus.ApprovalRequired)
+        {
+            parts.Add($"approval={receipt.ApprovalRequestId.Trim()}");
+        }
+
+        return string.Join(", ", parts);
+    }
+
+    private static string? TryGetDisplayNameFromArguments(string? argumentsJson)
+    {
+        if (string.IsNullOrWhiteSpace(argumentsJson))
+            return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(argumentsJson);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+                return null;
+
+            return TryGetString(doc.RootElement, "name", "skill_name", "skillName", "title");
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? TryGetString(JsonElement element, params string[] keys)
+    {
+        foreach (var key in keys)
+        {
+            if (!element.TryGetProperty(key, out var value))
+                continue;
+
+            if (value.ValueKind == JsonValueKind.String)
+                return Normalize(value.GetString());
+        }
+
+        return null;
+    }
+
+    private static string? Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/agents/Aevatar.GAgents.NyxidChat/IAgentToolReceiptRenderer.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/IAgentToolReceiptRenderer.cs
@@ -1,0 +1,8 @@
+using Aevatar.AI.Abstractions;
+
+namespace Aevatar.GAgents.NyxidChat;
+
+public interface IAgentToolReceiptRenderer
+{
+    string Render(IReadOnlyList<AgentToolReceipt> receipts, IReadOnlyList<AgentRunToolCall> toolCalls);
+}

--- a/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
@@ -84,6 +84,7 @@ public static class ServiceCollectionExtensions
         }
         services.TryAddSingleton<IConversationReplyGenerator, NyxIdConversationReplyGenerator>();
         services.TryAddSingleton<IAgentRunReplyGenerationExecutorPort, AgentRunReplyGenerationExecutor>();
+        services.TryAddSingleton<IAgentToolReceiptRenderer, AgentToolReceiptRenderer>();
         services.TryAddSingleton<IVoiceDemoAgentCommandPort, VoiceDemoAgentCommandPort>();
 
         // ─── LLM-call middleware that injects channel context into LLM requests ───

--- a/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
+++ b/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
@@ -78,6 +78,7 @@ message AgentRunGAgentState {
   // Immutable history entries produced by the LLM run. Output-dispatch retries
   // re-deliver these entries without re-running the LLM/tool chain.
   repeated aevatar.gagents.channel.runtime.ConversationHistoryEntry produced_appended_history = 23;
+  repeated aevatar.ai.AgentToolReceipt tool_receipts = 24;
 }
 
 enum AgentRunReplyStepKind {
@@ -129,6 +130,7 @@ message AgentRunReplyStepState {
   map<string, string> external_metadata = 19;
   aevatar.gagents.channel.abstractions.MessageContent outbound_intent = 20;
   repeated aevatar.gagents.channel.runtime.ConversationHistoryEntry appended_history = 21;
+  repeated aevatar.ai.AgentToolReceipt tool_receipts = 22;
 }
 
 // Typed LLM IO facts returned by the executor. The run actor reconciles these
@@ -150,6 +152,7 @@ message AgentRunLlmStepResult {
 message AgentRunToolStepResult {
   repeated AgentRunChatMessage result_messages = 1;
   bool advance_round = 2;
+  repeated aevatar.ai.AgentToolReceipt tool_receipts = 3;
 }
 
 // Transient command for the run actor. The nested NeedsLlmReplyEvent may carry
@@ -217,6 +220,7 @@ message AgentRunReplyProducedEvent {
   string reply_text = 8;
   aevatar.gagents.channel.abstractions.MessageContent outbound = 9;
   repeated aevatar.gagents.channel.runtime.ConversationHistoryEntry appended_history = 10;
+  repeated aevatar.ai.AgentToolReceipt tool_receipts = 11;
 }
 
 // Persisted after admission gates pass and before the transient generation

--- a/src/Aevatar.AI.Abstractions/LLMProviders/LLMResponse.cs
+++ b/src/Aevatar.AI.Abstractions/LLMProviders/LLMResponse.cs
@@ -3,6 +3,8 @@
 // 封装 Chat API 返回的文本、tool_calls、Token 用量
 // ─────────────────────────────────────────────────────────────
 
+using Aevatar.AI.Abstractions;
+
 namespace Aevatar.AI.Abstractions.LLMProviders;
 
 /// <summary>LLM 同步 Chat 响应 DTO。</summary>
@@ -53,6 +55,9 @@ public sealed class LLMStreamChunk
 
     /// <summary>Token 用量（通常最后一块才有）。</summary>
     public TokenUsage? Usage { get; init; }
+
+    /// <summary>Typed authority receipt produced by a completed receipt-worthy tool call.</summary>
+    public AgentToolReceipt? ToolReceipt { get; init; }
 }
 
 /// <summary>Token 用量统计。</summary>

--- a/src/Aevatar.AI.Abstractions/Middleware/IToolCallMiddleware.cs
+++ b/src/Aevatar.AI.Abstractions/Middleware/IToolCallMiddleware.cs
@@ -1,3 +1,4 @@
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.ToolProviders;
 
 namespace Aevatar.AI.Abstractions.Middleware;
@@ -40,6 +41,9 @@ public sealed class ToolCallContext
 
     /// <summary>Tool execution result. Set after execution, or by middleware to override.</summary>
     public string? Result { get; set; }
+
+    /// <summary>Typed receipt for receipt-worthy tool execution or approval yield.</summary>
+    public AgentToolReceipt? Receipt { get; set; }
 
     /// <summary>Typed business keys for a tool approval yield.</summary>
     public ToolApprovalPendingContext? PendingApproval { get; set; }

--- a/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolBase.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolBase.cs
@@ -7,6 +7,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Aevatar.AI.Abstractions;
 
 namespace Aevatar.AI.Abstractions.ToolProviders;
 
@@ -46,6 +47,9 @@ public abstract class AgentToolBase<TParams> : IAgentTool where TParams : class
 
     /// <inheritdoc />
     public virtual string SideEffectKind => "";
+
+    /// <inheritdoc />
+    public virtual AgentToolReceipt? CreateSuccessReceipt(string callId, string toolName, string resultJson) => null;
 
     /// <inheritdoc />
     public virtual bool? RequiresApproval(string argumentsJson) => null;

--- a/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolBase.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolBase.cs
@@ -45,6 +45,9 @@ public abstract class AgentToolBase<TParams> : IAgentTool where TParams : class
     public virtual bool IsDestructive => false;
 
     /// <inheritdoc />
+    public virtual string SideEffectKind => "";
+
+    /// <inheritdoc />
     public virtual bool? RequiresApproval(string argumentsJson) => null;
 
     /// <summary>Type-safe execution method.</summary>

--- a/src/Aevatar.AI.Abstractions/ToolProviders/IAgentTool.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/IAgentTool.cs
@@ -1,3 +1,5 @@
+using Aevatar.AI.Abstractions;
+
 namespace Aevatar.AI.Abstractions.ToolProviders;
 
 /// <summary>Agent 可调用工具接口。LLM 通过 tool_call 触发执行。</summary>
@@ -23,6 +25,9 @@ public interface IAgentTool
 
     /// <summary>Stable side-effect kind for receipt-worthy tool calls; empty means no declared side effect.</summary>
     string SideEffectKind => "";
+
+    /// <summary>Optional provider-owned typed success receipt; return null to use the generic receipt.</summary>
+    AgentToolReceipt? CreateSuccessReceipt(string callId, string toolName, string resultJson) => null;
 
     /// <summary>
     /// Runtime approval check: given the actual call arguments, does this specific

--- a/src/Aevatar.AI.Abstractions/ToolProviders/IAgentTool.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/IAgentTool.cs
@@ -21,6 +21,9 @@ public interface IAgentTool
     /// <summary>工具是否有破坏性（删除、覆写等不可逆操作）。Auto 模式下破坏性工具要求审批。</summary>
     bool IsDestructive => false;
 
+    /// <summary>Stable side-effect kind for receipt-worthy tool calls; empty means no declared side effect.</summary>
+    string SideEffectKind => "";
+
     /// <summary>
     /// Runtime approval check: given the actual call arguments, does this specific
     /// invocation require approval? Returns null to fall back to the static

--- a/src/Aevatar.AI.Abstractions/ai_messages.proto
+++ b/src/Aevatar.AI.Abstractions/ai_messages.proto
@@ -159,7 +159,46 @@ message MediaContentEvent { string session_id = 1; string agent_id = 2; ChatCont
 message TextMessageEndEvent     { string content = 1; string session_id = 2; }
 
 message ToolCallEvent   { string tool_name = 1; string arguments_json = 2; string call_id = 3; }
-message ToolResultEvent { string call_id = 1; string result_json = 2; bool success = 3; string error = 4; }
+
+enum AgentToolReceiptStatus {
+  AGENT_TOOL_RECEIPT_STATUS_UNSPECIFIED = 0;
+  AGENT_TOOL_RECEIPT_STATUS_SUCCESS = 1;
+  AGENT_TOOL_RECEIPT_STATUS_APPROVAL_REQUIRED = 2;
+  AGENT_TOOL_RECEIPT_STATUS_DENIED = 3;
+  AGENT_TOOL_RECEIPT_STATUS_ERROR = 4;
+}
+
+enum AgentToolReceiptApprovalMode {
+  AGENT_TOOL_RECEIPT_APPROVAL_MODE_UNSPECIFIED = 0;
+  AGENT_TOOL_RECEIPT_APPROVAL_MODE_NEVER_REQUIRE = 1;
+  AGENT_TOOL_RECEIPT_APPROVAL_MODE_ALWAYS_REQUIRE = 2;
+  AGENT_TOOL_RECEIPT_APPROVAL_MODE_AUTO = 3;
+}
+
+message AgentToolReceipt {
+  string call_id = 1;
+  string tool_name = 2;
+  AgentToolReceiptStatus status = 3;
+  AgentToolReceiptApprovalMode approval_mode = 4;
+  bool is_destructive = 5;
+  string side_effect_kind = 6;
+  string subject_kind = 7;
+  string subject_id = 8;
+  string subject_version = 9;
+  string subject_hash = 10;
+  string approval_request_id = 11;
+  string error_code = 12;
+  string error_message = 13;
+  string result_json = 14;
+}
+
+message ToolResultEvent {
+  string call_id = 1;
+  string result_json = 2;
+  bool success = 3;
+  string error = 4;
+  AgentToolReceipt receipt = 5;
+}
 message TokenUsagePayload {
   int32 prompt_tokens = 1;
   int32 completion_tokens = 2;
@@ -186,6 +225,7 @@ message RoleChatSessionCompletedEvent {
   string role_id = 8;
   TokenUsagePayload usage = 9;
   string model = 10;
+  repeated AgentToolReceipt tool_receipts = 11;
 }
 
 message InitializeRoleAgentEvent {
@@ -260,6 +300,7 @@ message RoleChatSessionState {
   repeated ChatContentPart output_parts = 9;
   TokenUsagePayload usage = 10;
   string model = 11;
+  repeated AgentToolReceipt tool_receipts = 12;
 }
 
 message RoleGAgentState {

--- a/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
@@ -491,6 +491,8 @@ public sealed class ChatRuntime
                             textToolExecutor.AddTool(textToolState, tc);
                         await foreach (var result in textToolExecutor.GetRemainingResultsAsync(textToolState, runToken))
                         {
+                            if (result.Receipt is not null)
+                                yield return new LLMStreamChunk { ToolReceipt = result.Receipt.Clone() };
                             var toolMsg = ToolCallLoop.BuildToolResultMessage(result.CallId, result.ToolName, result.Result);
                             messages.Add(toolMsg);
                             pendingHistoryMessages.Add(toolMsg);
@@ -568,6 +570,8 @@ public sealed class ChatRuntime
 
             await foreach (var result in streamingExecutor.GetRemainingResultsAsync(streamingToolState, runToken))
             {
+                if (result.Receipt is not null)
+                    yield return new LLMStreamChunk { ToolReceipt = result.Receipt.Clone() };
                 var toolMsg = ToolCallLoop.BuildToolResultMessage(result.CallId, result.ToolName, result.Result);
                 messages.Add(toolMsg);
                 pendingHistoryMessages.Add(toolMsg);
@@ -627,6 +631,8 @@ public sealed class ChatRuntime
                     finalToolExecutor.AddTool(finalToolState, tc);
                 await foreach (var result in finalToolExecutor.GetRemainingResultsAsync(finalToolState, runToken))
                 {
+                    if (result.Receipt is not null)
+                        yield return new LLMStreamChunk { ToolReceipt = result.Receipt.Clone() };
                     var toolMsg = ToolCallLoop.BuildToolResultMessage(result.CallId, result.ToolName, result.Result);
                     messages.Add(toolMsg);
                     pendingHistoryMessages.Add(toolMsg);

--- a/src/Aevatar.AI.Core/Middleware/ToolApprovalMiddleware.cs
+++ b/src/Aevatar.AI.Core/Middleware/ToolApprovalMiddleware.cs
@@ -7,6 +7,7 @@
 using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.Core.Hooks;
+using Aevatar.AI.Core.Tools;
 
 namespace Aevatar.AI.Core.Middleware;
 
@@ -122,12 +123,27 @@ public sealed class ToolApprovalMiddleware : IToolCallMiddleware
                 context.Result = !string.IsNullOrWhiteSpace(result.Reason)
                     ? $"Tool '{context.ToolName}' execution denied: {result.Reason}"
                     : $"Tool '{context.ToolName}' execution denied by approval handler.";
+                context.Receipt = AgentToolReceiptFactory.CreateDenied(
+                    context.Tool,
+                    context.ToolCallId,
+                    context.ToolName,
+                    context.Result,
+                    request.RequestId,
+                    result.Reason ?? "Tool approval denied.");
                 return;
 
             case ToolApprovalDecision.Timeout:
                 context.Terminate = true;
                 context.Result = $"Tool '{context.ToolName}' approval timed out. " +
                                  "The tool was not executed. Please try again or approve when prompted.";
+                context.Receipt = AgentToolReceiptFactory.CreateApprovalError(
+                    context.Tool,
+                    context.ToolCallId,
+                    context.ToolName,
+                    context.Result,
+                    request.RequestId,
+                    "approval_timeout",
+                    "Tool approval timed out.");
                 return;
 
             case ToolApprovalDecision.Yield:
@@ -143,6 +159,12 @@ public sealed class ToolApprovalMiddleware : IToolCallMiddleware
                     request.IsReadOnly,
                     request.IsDestructive);
                 context.Result = BuildApprovalPendingResult(request);
+                context.Receipt = AgentToolReceiptFactory.CreateApprovalRequired(
+                    context.Tool,
+                    context.ToolCallId,
+                    context.ToolName,
+                    context.Result,
+                    request.RequestId);
                 return;
         }
     }

--- a/src/Aevatar.AI.Core/RoleGAgent.cs
+++ b/src/Aevatar.AI.Core/RoleGAgent.cs
@@ -8,7 +8,6 @@
 // ─────────────────────────────────────────────────────────────
 
 using System.Text;
-using System.Text.Json;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.Agents;
 using Aevatar.AI.Abstractions.LLMProviders;
@@ -382,58 +381,38 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
         SessionReplayRecord replayRecord,
         ChatRequestEvent request)
     {
-        return DetectPendingApprovalFromHistory(request);
+        var receipt = replayRecord.ToolReceipts
+            .LastOrDefault(static candidate =>
+                candidate.Status == AgentToolReceiptStatus.ApprovalRequired &&
+                !string.IsNullOrWhiteSpace(candidate.ApprovalRequestId));
+        if (receipt is null)
+            return null;
+
+        return new PendingToolApprovalState
+        {
+            RequestId = receipt.ApprovalRequestId,
+            SessionId = request.SessionId ?? string.Empty,
+            ToolName = receipt.ToolName ?? string.Empty,
+            ToolCallId = receipt.CallId ?? string.Empty,
+            ArgumentsJson = ResolveToolArguments(replayRecord.ToolCalls, receipt.CallId),
+            IsDestructive = receipt.IsDestructive,
+            ToolContext = ResolveToolContext(
+                request,
+                receipt.ApprovalRequestId,
+                receipt.CallId ?? string.Empty).ToPayload(),
+        };
     }
 
-    private PendingToolApprovalState? DetectPendingApprovalFromHistory(ChatRequestEvent request)
+    private static string ResolveToolArguments(IReadOnlyList<ToolCall> toolCalls, string? callId)
     {
-        // Scan recent history messages for approval_required marker
-        for (var i = History.Messages.Count - 1; i >= 0; i--)
-        {
-            var msg = History.Messages[i];
-            if (msg.Role != "tool" || string.IsNullOrWhiteSpace(msg.Content))
-                continue;
+        if (string.IsNullOrWhiteSpace(callId))
+            return "{}";
 
-            if (!msg.Content.Contains(Middleware.ToolApprovalMiddleware.ApprovalRequiredKey))
-                continue;
-
-            try
-            {
-                using var doc = JsonDocument.Parse(msg.Content);
-                if (doc.RootElement.ValueKind != JsonValueKind.Object)
-                    continue;
-                if (!doc.RootElement.TryGetProperty("approval_required", out var ar) || !ar.GetBoolean())
-                    continue;
-
-                var requestId = doc.RootElement.TryGetProperty("request_id", out var rid)
-                    ? rid.GetString() ?? Guid.NewGuid().ToString("N")
-                    : Guid.NewGuid().ToString("N");
-                var toolName = doc.RootElement.TryGetProperty("tool_name", out var tn)
-                    ? tn.GetString() ?? "" : "";
-                var toolCallId = doc.RootElement.TryGetProperty("tool_call_id", out var tcid)
-                    ? tcid.GetString() ?? "" : "";
-                var args = doc.RootElement.TryGetProperty("arguments", out var a)
-                    ? a.GetString() ?? "{}" : "{}";
-
-                var pending = new PendingToolApprovalState
-                {
-                    RequestId = requestId,
-                    SessionId = request.SessionId ?? "",
-                    ToolName = toolName,
-                    ToolCallId = toolCallId,
-                    ArgumentsJson = args,
-                    IsDestructive = true,
-                    ToolContext = ResolveToolContext(request, requestId, toolCallId).ToPayload(),
-                };
-                return pending;
-            }
-            catch (JsonException)
-            {
-                // Not valid JSON, skip
-            }
-        }
-
-        return null;
+        var toolCall = toolCalls.FirstOrDefault(candidate =>
+            string.Equals(candidate.Id, callId, StringComparison.Ordinal));
+        return string.IsNullOrWhiteSpace(toolCall?.ArgumentsJson)
+            ? "{}"
+            : toolCall.ArgumentsJson;
     }
 
     // Stored lease from the last scheduled timeout, kept in-memory for cancellation.
@@ -842,6 +821,7 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
         var fullReasoning = new StringBuilder();
         var toolCalls = new StreamingToolCallAccumulator();
         var contentParts = new List<ContentPart>();
+        var toolReceipts = new List<AgentToolReceipt>();
         TokenUsage? usage = null;
         // Refactor (iter56/cluster-917-workflow-llm-control-metadata): old=Headers/Metadata bag for control fields, new=typed ChatRequestEvent.Telegram
         IReadOnlyDictionary<string, string>? metadata = request.Metadata.Count > 0
@@ -890,6 +870,9 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
 
             if (chunk.DeltaToolCall != null)
                 toolCalls.TrackDelta(chunk.DeltaToolCall);
+
+            if (chunk.ToolReceipt != null)
+                toolReceipts.Add(chunk.ToolReceipt.Clone());
         }
 
         var appendedHistoryMessages = History.Messages
@@ -914,14 +897,19 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
                 continue;
             }
 
-            var (success, error) = ClassifyToolResult(toolResult.Content);
-            await PublishAsync(new ToolResultEvent
+            var receipt = toolReceipts
+                .LastOrDefault(candidate => string.Equals(candidate.CallId, toolResult.ToolCallId, StringComparison.Ordinal));
+            var toolResultEvent = new ToolResultEvent
             {
                 CallId = toolResult.ToolCallId,
                 ResultJson = toolResult.Content ?? string.Empty,
-                Success = success,
-                Error = error ?? string.Empty,
-            }, TopologyAudience.Parent);
+                Success = receipt?.Status is null or AgentToolReceiptStatus.Success or AgentToolReceiptStatus.ApprovalRequired,
+                Error = receipt?.ErrorMessage ?? string.Empty,
+            };
+            if (receipt is not null)
+                toolResultEvent.Receipt = receipt.Clone();
+
+            await PublishAsync(toolResultEvent, TopologyAudience.Parent);
         }
 
         var response = fullContent.ToString();
@@ -948,6 +936,7 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
             fullReasoning.ToString(),
             toolCalls.BuildToolCalls(),
             contentParts,
+            toolReceipts,
             Usage: usage,
             Model: EffectiveConfig.Model ?? string.Empty,
             ContentEmitted: fullContent.Length > 0);
@@ -962,7 +951,8 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
             replayRecord.ContentParts,
             replayRecord.ContentEmitted,
             replayRecord.Usage,
-            replayRecord.Model);
+            replayRecord.Model,
+            replayRecord.ToolReceipts);
 
     protected Task PersistRoleChatSessionCompletionAsync(
         ChatRequestEvent request,
@@ -972,7 +962,8 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
         IReadOnlyList<ContentPart> contentParts,
         bool contentEmitted,
         TokenUsage? usage = null,
-        string? model = null)
+        string? model = null,
+        IReadOnlyList<AgentToolReceipt>? toolReceipts = null)
     {
         if (string.IsNullOrWhiteSpace(request.SessionId))
             return Task.CompletedTask;
@@ -990,6 +981,7 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
             ContentEmitted = contentEmitted,
             ToolCalls = { ToToolCallEvents(toolCalls) },
             OutputParts = { ContentPartProtoMapper.ToProtoList(contentParts) },
+            ToolReceipts = { (toolReceipts ?? []).Select(receipt => receipt.Clone()) },
             Usage = ToTokenUsagePayload(usage),
             Model = model ?? string.Empty,
         });
@@ -1099,6 +1091,19 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
                 ToolName = toolCall.ToolName,
                 ArgumentsJson = toolCall.ArgumentsJson,
             }, TopologyAudience.Parent);
+        }
+
+        foreach (var receipt in trackedSession.ToolReceipts)
+        {
+            var toolResultEvent = new ToolResultEvent
+            {
+                CallId = receipt.CallId ?? string.Empty,
+                ResultJson = receipt.ResultJson ?? string.Empty,
+                Success = receipt.Status is AgentToolReceiptStatus.Success or AgentToolReceiptStatus.ApprovalRequired,
+                Error = receipt.ErrorMessage ?? string.Empty,
+                Receipt = receipt.Clone(),
+            };
+            await PublishAsync(toolResultEvent, TopologyAudience.Parent);
         }
 
         foreach (var contentPart in trackedSession.OutputParts)
@@ -1291,6 +1296,8 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
         session.ToolCalls.Add(evt.ToolCalls);
         session.OutputParts.Clear();
         session.OutputParts.Add(evt.OutputParts);
+        session.ToolReceipts.Clear();
+        session.ToolReceipts.Add(evt.ToolReceipts.Select(receipt => receipt.Clone()));
         session.Usage = evt.Usage?.Clone();
         session.Model = evt.Model ?? string.Empty;
         next.Sessions[evt.SessionId] = session;
@@ -1308,36 +1315,6 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
                 ToolName = toolCall.Name,
                 ArgumentsJson = toolCall.ArgumentsJson,
             };
-        }
-    }
-
-    private static (bool Success, string? Error) ClassifyToolResult(string? resultJson)
-    {
-        if (string.IsNullOrWhiteSpace(resultJson))
-            return (true, null);
-
-        try
-        {
-            using var doc = JsonDocument.Parse(resultJson);
-            if (doc.RootElement.ValueKind != JsonValueKind.Object ||
-                !doc.RootElement.TryGetProperty("error", out var errorElement))
-            {
-                return (true, null);
-            }
-
-            var error = errorElement.ValueKind switch
-            {
-                JsonValueKind.String => errorElement.GetString(),
-                JsonValueKind.Null or JsonValueKind.Undefined => null,
-                _ => errorElement.ToString(),
-            };
-            return string.IsNullOrWhiteSpace(error)
-                ? (true, null)
-                : (false, error.Trim());
-        }
-        catch (JsonException)
-        {
-            return (true, null);
         }
     }
 
@@ -1444,12 +1421,13 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
         string ReasoningContent,
         IReadOnlyList<ToolCall> ToolCalls,
         IReadOnlyList<ContentPart> ContentParts,
+        IReadOnlyList<AgentToolReceipt> ToolReceipts,
         TokenUsage? Usage,
         string? Model,
         bool ContentEmitted)
     {
         public static SessionReplayRecord FromFailure(string content) =>
-            new(content, string.Empty, [], [], Usage: null, Model: null, ContentEmitted: false);
+            new(content, string.Empty, [], [], [], Usage: null, Model: null, ContentEmitted: false);
     }
 
     private static TokenUsagePayload? ToTokenUsagePayload(TokenUsage? usage) =>

--- a/src/Aevatar.AI.Core/Tools/AgentToolReceiptFactory.cs
+++ b/src/Aevatar.AI.Core/Tools/AgentToolReceiptFactory.cs
@@ -1,10 +1,8 @@
-using System.Text.Json;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.ToolProviders;
 
 namespace Aevatar.AI.Core.Tools;
 
-// refactor helper, no behavior change: centralizes typed receipt construction for tool side-effect authority.
 internal static class AgentToolReceiptFactory
 {
     public static bool IsReceiptWorthy(IAgentTool tool)
@@ -24,9 +22,12 @@ internal static class AgentToolReceiptFactory
         if (!IsReceiptWorthy(tool))
             return null;
 
+        var providerReceipt = tool.CreateSuccessReceipt(callId, toolName, resultJson ?? string.Empty);
+        if (providerReceipt is not null)
+            return NormalizeProviderSuccessReceipt(tool, callId, toolName, resultJson, providerReceipt);
+
         var receipt = CreateBase(tool, callId, toolName, AgentToolReceiptStatus.Success);
         receipt.ResultJson = resultJson ?? string.Empty;
-        ApplySubject(receipt, resultJson);
         return receipt;
     }
 
@@ -121,45 +122,27 @@ internal static class AgentToolReceiptFactory
     private static string NormalizeSideEffectKind(string? sideEffectKind) =>
         string.IsNullOrWhiteSpace(sideEffectKind) ? string.Empty : sideEffectKind.Trim().ToLowerInvariant();
 
-    private static void ApplySubject(AgentToolReceipt receipt, string? resultJson)
+    private static AgentToolReceipt NormalizeProviderSuccessReceipt(
+        IAgentTool tool,
+        string callId,
+        string toolName,
+        string? resultJson,
+        AgentToolReceipt receipt)
     {
-        if (!string.Equals(receipt.SideEffectKind, "ornn.publish.skill", StringComparison.Ordinal) ||
-            string.IsNullOrWhiteSpace(resultJson))
-        {
-            return;
-        }
-
-        try
-        {
-            using var doc = JsonDocument.Parse(resultJson);
-            if (doc.RootElement.ValueKind != JsonValueKind.Object)
-                return;
-
-            receipt.SubjectKind = "ornn.skill";
-            receipt.SubjectId = TryGetString(doc.RootElement, "guid", "id", "skill_id", "skillId") ?? string.Empty;
-            receipt.SubjectVersion = TryGetString(doc.RootElement, "version", "subject_version", "subjectVersion") ?? string.Empty;
-            receipt.SubjectHash = TryGetString(doc.RootElement, "skillHash", "skill_hash", "hash", "subject_hash") ?? string.Empty;
-        }
-        catch (JsonException)
-        {
-            return;
-        }
-    }
-
-    private static string? TryGetString(JsonElement element, params string[] keys)
-    {
-        foreach (var key in keys)
-        {
-            if (!element.TryGetProperty(key, out var value))
-                continue;
-
-            if (value.ValueKind == JsonValueKind.String)
-                return value.GetString();
-
-            if (value.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined)
-                return value.ToString();
-        }
-
-        return null;
+        var normalized = receipt.Clone();
+        normalized.CallId = string.IsNullOrWhiteSpace(normalized.CallId) ? callId ?? string.Empty : normalized.CallId;
+        normalized.ToolName = string.IsNullOrWhiteSpace(normalized.ToolName)
+            ? string.IsNullOrWhiteSpace(toolName) ? tool.Name ?? string.Empty : toolName
+            : normalized.ToolName;
+        normalized.Status = AgentToolReceiptStatus.Success;
+        if (normalized.ApprovalMode == AgentToolReceiptApprovalMode.Unspecified)
+            normalized.ApprovalMode = MapApprovalMode(tool.ApprovalMode);
+        normalized.IsDestructive = normalized.IsDestructive || tool.IsDestructive;
+        normalized.SideEffectKind = string.IsNullOrWhiteSpace(normalized.SideEffectKind)
+            ? NormalizeSideEffectKind(tool.SideEffectKind)
+            : NormalizeSideEffectKind(normalized.SideEffectKind);
+        if (string.IsNullOrWhiteSpace(normalized.ResultJson))
+            normalized.ResultJson = resultJson ?? string.Empty;
+        return normalized;
     }
 }

--- a/src/Aevatar.AI.Core/Tools/AgentToolReceiptFactory.cs
+++ b/src/Aevatar.AI.Core/Tools/AgentToolReceiptFactory.cs
@@ -1,0 +1,165 @@
+using System.Text.Json;
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.ToolProviders;
+
+namespace Aevatar.AI.Core.Tools;
+
+// refactor helper, no behavior change: centralizes typed receipt construction for tool side-effect authority.
+internal static class AgentToolReceiptFactory
+{
+    public static bool IsReceiptWorthy(IAgentTool tool)
+    {
+        ArgumentNullException.ThrowIfNull(tool);
+        return tool.ApprovalMode != ToolApprovalMode.NeverRequire ||
+               tool.IsDestructive ||
+               !string.IsNullOrWhiteSpace(tool.SideEffectKind);
+    }
+
+    public static AgentToolReceipt? CreateSuccess(
+        IAgentTool tool,
+        string callId,
+        string toolName,
+        string resultJson)
+    {
+        if (!IsReceiptWorthy(tool))
+            return null;
+
+        var receipt = CreateBase(tool, callId, toolName, AgentToolReceiptStatus.Success);
+        receipt.ResultJson = resultJson ?? string.Empty;
+        ApplySubject(receipt, resultJson);
+        return receipt;
+    }
+
+    public static AgentToolReceipt? CreateError(
+        IAgentTool tool,
+        string callId,
+        string toolName,
+        string resultJson,
+        string errorCode,
+        string errorMessage)
+    {
+        if (!IsReceiptWorthy(tool))
+            return null;
+
+        var receipt = CreateBase(tool, callId, toolName, AgentToolReceiptStatus.Error);
+        receipt.ResultJson = resultJson ?? string.Empty;
+        receipt.ErrorCode = errorCode ?? string.Empty;
+        receipt.ErrorMessage = errorMessage ?? string.Empty;
+        return receipt;
+    }
+
+    public static AgentToolReceipt CreateApprovalRequired(
+        IAgentTool tool,
+        string callId,
+        string toolName,
+        string resultJson,
+        string approvalRequestId)
+    {
+        var receipt = CreateBase(tool, callId, toolName, AgentToolReceiptStatus.ApprovalRequired);
+        receipt.ResultJson = resultJson ?? string.Empty;
+        receipt.ApprovalRequestId = approvalRequestId ?? string.Empty;
+        return receipt;
+    }
+
+    public static AgentToolReceipt CreateDenied(
+        IAgentTool tool,
+        string callId,
+        string toolName,
+        string resultJson,
+        string approvalRequestId,
+        string reason)
+    {
+        var receipt = CreateBase(tool, callId, toolName, AgentToolReceiptStatus.Denied);
+        receipt.ResultJson = resultJson ?? string.Empty;
+        receipt.ApprovalRequestId = approvalRequestId ?? string.Empty;
+        receipt.ErrorCode = "approval_denied";
+        receipt.ErrorMessage = reason ?? string.Empty;
+        return receipt;
+    }
+
+    public static AgentToolReceipt CreateApprovalError(
+        IAgentTool tool,
+        string callId,
+        string toolName,
+        string resultJson,
+        string approvalRequestId,
+        string errorCode,
+        string errorMessage)
+    {
+        var receipt = CreateBase(tool, callId, toolName, AgentToolReceiptStatus.Error);
+        receipt.ResultJson = resultJson ?? string.Empty;
+        receipt.ApprovalRequestId = approvalRequestId ?? string.Empty;
+        receipt.ErrorCode = errorCode ?? string.Empty;
+        receipt.ErrorMessage = errorMessage ?? string.Empty;
+        return receipt;
+    }
+
+    public static AgentToolReceiptApprovalMode MapApprovalMode(ToolApprovalMode mode) =>
+        mode switch
+        {
+            ToolApprovalMode.NeverRequire => AgentToolReceiptApprovalMode.NeverRequire,
+            ToolApprovalMode.AlwaysRequire => AgentToolReceiptApprovalMode.AlwaysRequire,
+            ToolApprovalMode.Auto => AgentToolReceiptApprovalMode.Auto,
+            _ => AgentToolReceiptApprovalMode.Unspecified,
+        };
+
+    private static AgentToolReceipt CreateBase(
+        IAgentTool tool,
+        string callId,
+        string toolName,
+        AgentToolReceiptStatus status) =>
+        new()
+        {
+            CallId = callId ?? string.Empty,
+            ToolName = string.IsNullOrWhiteSpace(toolName) ? tool.Name ?? string.Empty : toolName,
+            Status = status,
+            ApprovalMode = MapApprovalMode(tool.ApprovalMode),
+            IsDestructive = tool.IsDestructive,
+            SideEffectKind = NormalizeSideEffectKind(tool.SideEffectKind),
+        };
+
+    private static string NormalizeSideEffectKind(string? sideEffectKind) =>
+        string.IsNullOrWhiteSpace(sideEffectKind) ? string.Empty : sideEffectKind.Trim().ToLowerInvariant();
+
+    private static void ApplySubject(AgentToolReceipt receipt, string? resultJson)
+    {
+        if (!string.Equals(receipt.SideEffectKind, "ornn.publish.skill", StringComparison.Ordinal) ||
+            string.IsNullOrWhiteSpace(resultJson))
+        {
+            return;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(resultJson);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+                return;
+
+            receipt.SubjectKind = "ornn.skill";
+            receipt.SubjectId = TryGetString(doc.RootElement, "guid", "id", "skill_id", "skillId") ?? string.Empty;
+            receipt.SubjectVersion = TryGetString(doc.RootElement, "version", "subject_version", "subjectVersion") ?? string.Empty;
+            receipt.SubjectHash = TryGetString(doc.RootElement, "skillHash", "skill_hash", "hash", "subject_hash") ?? string.Empty;
+        }
+        catch (JsonException)
+        {
+            return;
+        }
+    }
+
+    private static string? TryGetString(JsonElement element, params string[] keys)
+    {
+        foreach (var key in keys)
+        {
+            if (!element.TryGetProperty(key, out var value))
+                continue;
+
+            if (value.ValueKind == JsonValueKind.String)
+                return value.GetString();
+
+            if (value.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined)
+                return value.ToString();
+        }
+
+        return null;
+    }
+}

--- a/src/Aevatar.AI.Core/Tools/StreamingToolExecutor.cs
+++ b/src/Aevatar.AI.Core/Tools/StreamingToolExecutor.cs
@@ -8,6 +8,7 @@
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Core.Hooks;
 using Aevatar.AI.Core.Middleware;
 using System.Diagnostics;
@@ -16,7 +17,12 @@ using System.Runtime.CompilerServices;
 namespace Aevatar.AI.Core.Tools;
 
 /// <summary>Tool execution result with call-id for message pairing.</summary>
-public readonly record struct ToolExecutionResult(string CallId, string ToolName, string Result, bool IsError);
+public readonly record struct ToolExecutionResult(
+    string CallId,
+    string ToolName,
+    string Result,
+    bool IsError,
+    AgentToolReceipt? Receipt = null);
 
 /// <summary>
 /// Streaming tool executor that starts executing tools as soon as they appear,
@@ -332,14 +338,31 @@ public sealed class StreamingToolExecutor
                     ArgumentsJson = toolCallContext.ArgumentsJson,
                 };
 
-                var result = await _tools.ExecuteToolCallAsync(resolvedCall, ct);
-                toolCallContext.Result = result.Content;
+                var (result, error) = await _tools.ExecuteToolCallRawAsync(resolvedCall, ct);
+                toolCallContext.Result = result;
+                if (error is not null)
+                {
+                    toolCallContext.Receipt = AgentToolReceiptFactory.CreateError(
+                        effectiveTool,
+                        toolCallContext.ToolCallId,
+                        toolCallContext.ToolName,
+                        result,
+                        "tool_execution_error",
+                        error.Message);
+                }
             });
 
             var toolResult = toolCallContext.Result
                 ?? (toolCallContext.Terminate
                     ? "Tool call terminated by middleware"
                     : $"Tool '{toolCallContext.ToolName}' returned no result");
+            var receipt = toolCallContext.Receipt ??
+                          AgentToolReceiptFactory.CreateSuccess(
+                              effectiveTool,
+                              toolCallContext.ToolCallId,
+                              toolCallContext.ToolName,
+                              toolResult);
+            var isErrorReceipt = receipt?.Status is AgentToolReceiptStatus.Error or AgentToolReceiptStatus.Denied;
 
             toolCtx.ToolResult = toolResult;
             toolCtx.Duration = Stopwatch.GetElapsedTime(toolStartedAt);
@@ -352,7 +375,12 @@ public sealed class StreamingToolExecutor
                     SchedulerFault: false);
 
             return new ToolExecutionCompletion(
-                new ToolExecutionResult(call.Id, call.Name, toolResult, IsError: false),
+                new ToolExecutionResult(
+                    call.Id,
+                    call.Name,
+                    toolResult,
+                    IsError: isErrorReceipt,
+                    Receipt: receipt),
                 SchedulerFault: false);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnPublishSkillTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnPublishSkillTool.cs
@@ -32,6 +32,8 @@ public sealed class OrnnPublishSkillTool : IAgentTool
 
     public ToolApprovalMode ApprovalMode => ToolApprovalMode.AlwaysRequire;
 
+    public string SideEffectKind => "ornn.publish.skill";
+
     public string ParametersSchema => """
         {
           "type": "object",
@@ -136,11 +138,15 @@ public sealed class OrnnPublishSkillTool : IAgentTool
         if (!publish.Succeeded)
             return BuildResult("error", publish.Error ?? "Ornn publish failed.");
 
+        var published = ExtractPublishedSkill(publish.RawResponse);
         return JsonSerializer.Serialize(new
         {
             result_type = "ornn_publish_skill",
             status = "success",
             skill_name = request.Name,
+            guid = published.Guid,
+            version = published.Version ?? request.Version,
+            skillHash = published.SkillHash,
             package_bytes = package.ZipBytes.Length,
             response = publish.RawResponse,
         });
@@ -163,4 +169,78 @@ public sealed class OrnnPublishSkillTool : IAgentTool
             status,
             error,
         });
+
+    private static PublishedSkillSubject ExtractPublishedSkill(string? rawResponse)
+    {
+        if (string.IsNullOrWhiteSpace(rawResponse))
+            return new PublishedSkillSubject(null, null, null);
+
+        try
+        {
+            using var doc = JsonDocument.Parse(rawResponse);
+            return ExtractPublishedSkill(doc.RootElement);
+        }
+        catch (JsonException)
+        {
+            return new PublishedSkillSubject(null, null, null);
+        }
+    }
+
+    private static PublishedSkillSubject ExtractPublishedSkill(JsonElement root)
+    {
+        var subject = ExtractPublishedSkillFromObject(root);
+        if (subject.HasAny)
+            return subject;
+
+        if (root.ValueKind != JsonValueKind.Object)
+            return subject;
+
+        foreach (var propertyName in new[] { "data", "result", "skill" })
+        {
+            if (!root.TryGetProperty(propertyName, out var nested) || nested.ValueKind != JsonValueKind.Object)
+                continue;
+
+            subject = ExtractPublishedSkillFromObject(nested);
+            if (subject.HasAny)
+                return subject;
+        }
+
+        return subject;
+    }
+
+    private static PublishedSkillSubject ExtractPublishedSkillFromObject(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+            return new PublishedSkillSubject(null, null, null);
+
+        return new PublishedSkillSubject(
+            TryGetString(element, "guid", "id", "skill_id", "skillId"),
+            TryGetString(element, "version", "subject_version", "subjectVersion"),
+            TryGetString(element, "skillHash", "skill_hash", "hash", "subject_hash"));
+    }
+
+    private static string? TryGetString(JsonElement element, params string[] keys)
+    {
+        foreach (var key in keys)
+        {
+            if (!element.TryGetProperty(key, out var value))
+                continue;
+
+            if (value.ValueKind == JsonValueKind.String)
+                return value.GetString();
+
+            if (value.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined)
+                return value.ToString();
+        }
+
+        return null;
+    }
+
+    private sealed record PublishedSkillSubject(string? Guid, string? Version, string? SkillHash)
+    {
+        public bool HasAny =>
+            !string.IsNullOrWhiteSpace(Guid) ||
+            !string.IsNullOrWhiteSpace(Version) ||
+            !string.IsNullOrWhiteSpace(SkillHash);
+    }
 }

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnPublishSkillTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnPublishSkillTool.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.ToolProviders.Ornn.Publishing;
 
@@ -33,6 +34,28 @@ public sealed class OrnnPublishSkillTool : IAgentTool
     public ToolApprovalMode ApprovalMode => ToolApprovalMode.AlwaysRequire;
 
     public string SideEffectKind => "ornn.publish.skill";
+
+    public AgentToolReceipt? CreateSuccessReceipt(string callId, string toolName, string resultJson)
+    {
+        var published = ExtractPublishedSkill(resultJson);
+        if (!published.HasAny)
+            return null;
+
+        return new AgentToolReceipt
+        {
+            CallId = callId ?? string.Empty,
+            ToolName = string.IsNullOrWhiteSpace(toolName) ? Name : toolName,
+            Status = AgentToolReceiptStatus.Success,
+            ApprovalMode = AgentToolReceiptApprovalMode.AlwaysRequire,
+            IsDestructive = false,
+            SideEffectKind = SideEffectKind,
+            SubjectKind = "ornn.skill",
+            SubjectId = published.Guid ?? string.Empty,
+            SubjectVersion = published.Version ?? string.Empty,
+            SubjectHash = published.SkillHash ?? string.Empty,
+            ResultJson = resultJson ?? string.Empty,
+        };
+    }
 
     public string ParametersSchema => """
         {

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnSearchSkillsTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnSearchSkillsTool.cs
@@ -39,6 +39,10 @@ public sealed class OrnnSearchSkillsTool : IAgentTool
         }
         """;
 
+    public bool IsReadOnly => true;
+
+    public string SideEffectKind => "";
+
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {
         var token = AgentToolRequestContext.NyxIdAccessToken;

--- a/test/Aevatar.AI.Core.Tests/Middleware/ToolApprovalMiddlewareTests.cs
+++ b/test/Aevatar.AI.Core.Tests/Middleware/ToolApprovalMiddlewareTests.cs
@@ -1,5 +1,6 @@
 using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Core.Hooks;
 using Aevatar.AI.Core.Middleware;
 using FluentAssertions;
@@ -166,6 +167,14 @@ public class ToolApprovalMiddlewareTests
         nextExecuted.Should().BeFalse();
         ctx.Terminate.Should().BeTrue();
         ctx.Result.Should().Contain("Tool 'danger' execution denied: blocked");
+        ctx.Receipt.Should().NotBeNull();
+        ctx.Receipt!.Status.Should().Be(AgentToolReceiptStatus.Denied);
+        ctx.Receipt.ToolName.Should().Be("danger");
+        ctx.Receipt.CallId.Should().Be("tc-6");
+        ctx.Receipt.ApprovalMode.Should().Be(AgentToolReceiptApprovalMode.AlwaysRequire);
+        ctx.Receipt.ApprovalRequestId.Should().NotBeNullOrWhiteSpace();
+        ctx.Receipt.ErrorCode.Should().Be("approval_denied");
+        ctx.Receipt.ErrorMessage.Should().Be("blocked");
     }
 
     [Fact]
@@ -184,6 +193,11 @@ public class ToolApprovalMiddlewareTests
 
         ctx.Terminate.Should().BeTrue();
         ctx.Result.Should().Contain("approval timed out");
+        ctx.Receipt.Should().NotBeNull();
+        ctx.Receipt!.Status.Should().Be(AgentToolReceiptStatus.Error);
+        ctx.Receipt.ErrorCode.Should().Be("approval_timeout");
+        ctx.Receipt.ErrorMessage.Should().Be("Tool approval timed out.");
+        ctx.Receipt.ApprovalRequestId.Should().NotBeNullOrWhiteSpace();
     }
 
     [Fact]
@@ -209,8 +223,17 @@ public class ToolApprovalMiddlewareTests
         ctx.Terminate.Should().BeTrue();
         ctx.Result.Should().Contain("\"approval_required\":true");
         ctx.Result.Should().Contain("\"request_id\":\"");
+        ctx.Receipt.Should().NotBeNull();
+        ctx.Receipt!.Status.Should().Be(AgentToolReceiptStatus.ApprovalRequired);
+        ctx.Receipt.ToolName.Should().Be("danger");
+        ctx.Receipt.CallId.Should().Be("tc-8");
+        ctx.Receipt.ApprovalMode.Should().Be(AgentToolReceiptApprovalMode.AlwaysRequire);
+        ctx.Receipt.IsDestructive.Should().BeTrue();
+        ctx.Receipt.ApprovalRequestId.Should().NotBeNullOrWhiteSpace();
+        ctx.Receipt.ResultJson.Should().Be(ctx.Result);
         ctx.PendingApproval.Should().NotBeNull();
         ctx.PendingApproval!.ApprovalRequestId.Should().NotBeNullOrWhiteSpace();
+        ctx.Receipt.ApprovalRequestId.Should().Be(ctx.PendingApproval.ApprovalRequestId);
         ctx.PendingApproval.ToolCallId.Should().Be("tc-8");
         ctx.PendingApproval.ToolName.Should().Be("danger");
         ctx.PendingApproval.ArgumentsJson.Should().Be("{}");

--- a/test/Aevatar.AI.Tests/AIAbstractionsProtoCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/AIAbstractionsProtoCoverageTests.cs
@@ -87,6 +87,27 @@ public sealed class AIAbstractionsProtoCoverageTests
     [Fact]
     public void ProtoMessages_ShouldRoundTripAndClone()
     {
+        var receipt = new AgentToolReceipt
+        {
+            CallId = "call-1",
+            ToolName = "ornn_publish_skill",
+            Status = AgentToolReceiptStatus.Success,
+            ApprovalMode = AgentToolReceiptApprovalMode.AlwaysRequire,
+            IsDestructive = false,
+            SideEffectKind = "ornn.publish.skill",
+            SubjectKind = "ornn.skill",
+            SubjectId = "skill-1",
+            SubjectVersion = "1.0",
+            SubjectHash = "hash-1",
+            ApprovalRequestId = "approval-1",
+            ErrorCode = "",
+            ErrorMessage = "",
+            ResultJson = """{"guid":"skill-1","version":"1.0","skillHash":"hash-1"}""",
+        };
+        var receiptRoundTrip = RoundTrip(receipt, AgentToolReceipt.Parser);
+        receiptRoundTrip.SubjectId.Should().Be("skill-1");
+        receiptRoundTrip.SubjectHash.Should().Be("hash-1");
+
         var request = RoundTrip(new ChatRequestEvent
         {
             Prompt = "hello",
@@ -175,8 +196,10 @@ public sealed class AIAbstractionsProtoCoverageTests
             ResultJson = "{\"ok\":true}",
             Success = true,
             Error = "",
+            Receipt = receipt.Clone(),
         }, ToolResultEvent.Parser);
         toolResult.Success.Should().BeTrue();
+        toolResult.Receipt.SubjectId.Should().Be("skill-1");
 
         var tokenUsage = RoundTrip(new TokenUsagePayload
         {
@@ -240,6 +263,7 @@ public sealed class AIAbstractionsProtoCoverageTests
                     CallId = "call-1",
                 },
             },
+            ToolReceipts = { receipt.Clone() },
             OutputParts =
             {
                 new ChatContentPart
@@ -256,6 +280,7 @@ public sealed class AIAbstractionsProtoCoverageTests
         sessionCompleted.Usage.TotalTokens.Should().Be(36);
         sessionCompleted.Model.Should().Be("nyxid-model");
         sessionCompleted.ToolCalls.Should().ContainSingle();
+        sessionCompleted.ToolReceipts.Should().ContainSingle(x => x.SubjectHash == "hash-1");
         sessionCompleted.OutputParts.Should().ContainSingle();
 
         var initialize = RoundTrip(new InitializeRoleAgentEvent
@@ -367,6 +392,7 @@ public sealed class AIAbstractionsProtoCoverageTests
                             CallId = "call-1",
                         },
                     },
+                    ToolReceipts = { receipt.Clone() },
                 },
             },
         }, RoleGAgentState.Parser);
@@ -379,6 +405,7 @@ public sealed class AIAbstractionsProtoCoverageTests
         state.Sessions["session-1"].InputParts.Should().ContainSingle();
         state.Sessions["session-1"].OutputParts.Should().ContainSingle();
         state.Sessions["session-1"].ToolCalls.Should().ContainSingle();
+        state.Sessions["session-1"].ToolReceipts.Should().ContainSingle(x => x.SubjectId == "skill-1");
         state.PendingApproval.Should().NotBeNull();
         state.PendingApproval!.RemoteApprovalId.Should().Be("remote-1");
         state.PendingApproval.ToolContext.Should().NotBeNull();
@@ -398,6 +425,64 @@ public sealed class AIAbstractionsProtoCoverageTests
         pendingContext.ExternalMetadata.Should().ContainKey("trace-id").WhoseValue.Should().Be("trace-from-context");
         state.VoicePresence["voice_presence"].CurrentResponseId.Should().Be(12);
         state.VoicePresence["voice_presence"].ActiveProviderResponseId.Should().Be("provider-response-12");
+    }
+
+    [Fact]
+    public void AgentToolReceipt_ShouldUseCanonicalWireContract()
+    {
+        ((int)AgentToolReceiptStatus.Unspecified).Should().Be(0);
+        ((int)AgentToolReceiptStatus.Success).Should().Be(1);
+        ((int)AgentToolReceiptStatus.ApprovalRequired).Should().Be(2);
+        ((int)AgentToolReceiptStatus.Denied).Should().Be(3);
+        ((int)AgentToolReceiptStatus.Error).Should().Be(4);
+
+        ((int)AgentToolReceiptApprovalMode.Unspecified).Should().Be(0);
+        ((int)AgentToolReceiptApprovalMode.NeverRequire).Should().Be(1);
+        ((int)AgentToolReceiptApprovalMode.AlwaysRequire).Should().Be(2);
+        ((int)AgentToolReceiptApprovalMode.Auto).Should().Be(3);
+
+        AgentToolReceipt.Descriptor.Fields.InFieldNumberOrder()
+            .Select(field => (field.FieldNumber, field.Name))
+            .Should()
+            .Equal(
+                (1, "call_id"),
+                (2, "tool_name"),
+                (3, "status"),
+                (4, "approval_mode"),
+                (5, "is_destructive"),
+                (6, "side_effect_kind"),
+                (7, "subject_kind"),
+                (8, "subject_id"),
+                (9, "subject_version"),
+                (10, "subject_hash"),
+                (11, "approval_request_id"),
+                (12, "error_code"),
+                (13, "error_message"),
+                (14, "result_json"));
+
+        AgentToolReceipt.Descriptor.Fields.InFieldNumberOrder()
+            .Select(field => field.Name)
+            .Should()
+            .NotContain(["observed_at_unix_ms", "subject_name", "is_read_only"]);
+
+        ToolResultEvent.Descriptor.Fields.InFieldNumberOrder()
+            .Select(field => (field.FieldNumber, field.Name))
+            .Should()
+            .Contain((5, "receipt"))
+            .And.NotContain((5, "tool_name"));
+        ToolResultEvent.Descriptor.Fields.InFieldNumberOrder()
+            .Select(field => field.Name)
+            .Should()
+            .NotContain("tool_name");
+
+        RoleChatSessionCompletedEvent.Descriptor.Fields.InFieldNumberOrder()
+            .Select(field => (field.FieldNumber, field.Name))
+            .Should()
+            .Contain((11, "tool_receipts"));
+        RoleChatSessionState.Descriptor.Fields.InFieldNumberOrder()
+            .Select(field => (field.FieldNumber, field.Name))
+            .Should()
+            .Contain((12, "tool_receipts"));
     }
 
     [Fact]

--- a/test/Aevatar.AI.Tests/NyxIdChatServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatServiceCollectionExtensionsTests.cs
@@ -28,5 +28,8 @@ public sealed class NyxIdChatServiceCollectionExtensionsTests
             .Should().BeFalse();
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(NyxIdRelayAuthValidator));
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(IAgentToolReceiptRenderer) &&
+            descriptor.ImplementationType == typeof(AgentToolReceiptRenderer));
     }
 }

--- a/test/Aevatar.AI.Tests/RoleGAgentReplayContractTests.cs
+++ b/test/Aevatar.AI.Tests/RoleGAgentReplayContractTests.cs
@@ -897,6 +897,7 @@ public class RoleGAgentReplayContractTests
             string.Empty,
             Array.Empty<ToolCall>(),
             Array.Empty<ContentPart>(),
+            Array.Empty<AgentToolReceipt>(),
             null, // Usage (added by #1700)
             null, // Model (added by #1700)
             contentEmitted)!;

--- a/test/Aevatar.AI.Tests/RoleGAgentStateCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/RoleGAgentStateCoverageTests.cs
@@ -31,10 +31,6 @@ public sealed class RoleGAgentStateCoverageTests
         .GetMethod("ApplyChatSessionCompleted", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("ApplyChatSessionCompleted not found.");
 
-    private static readonly MethodInfo ClassifyToolResultMethod = typeof(RoleGAgent)
-        .GetMethod("ClassifyToolResult", BindingFlags.NonPublic | BindingFlags.Static)
-        ?? throw new InvalidOperationException("ClassifyToolResult not found.");
-
     private static readonly MethodInfo ResolveRequestInputPartsMethod = typeof(RoleGAgent)
         .GetMethod("ResolveRequestInputParts", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("ResolveRequestInputParts not found.");
@@ -42,10 +38,6 @@ public sealed class RoleGAgentStateCoverageTests
     private static readonly MethodInfo BuildRequestLogSummaryMethod = typeof(RoleGAgent)
         .GetMethod("BuildRequestLogSummary", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("BuildRequestLogSummary not found.");
-
-    private static readonly MethodInfo DetectPendingApprovalFromHistoryMethod = typeof(RoleGAgent)
-        .GetMethod("DetectPendingApprovalFromHistory", BindingFlags.NonPublic | BindingFlags.Instance)
-        ?? throw new InvalidOperationException("DetectPendingApprovalFromHistory not found.");
 
     private static readonly MethodInfo BuildContinuationPromptMethod = typeof(RoleGAgent)
         .GetMethod("BuildContinuationPrompt", BindingFlags.NonPublic | BindingFlags.Static)
@@ -1032,6 +1024,22 @@ public sealed class RoleGAgentStateCoverageTests
                         ArgumentsJson = "{}",
                     },
                 },
+                ToolReceipts =
+                {
+                    new AgentToolReceipt
+                    {
+                        CallId = "call-1",
+                        ToolName = "ornn_publish_skill",
+                        Status = AgentToolReceiptStatus.Success,
+                        ApprovalMode = AgentToolReceiptApprovalMode.AlwaysRequire,
+                        SideEffectKind = "ornn.publish.skill",
+                        SubjectKind = "ornn.skill",
+                        SubjectId = "skill-1",
+                        SubjectVersion = "1.0",
+                        SubjectHash = "hash-1",
+                        ResultJson = """{"guid":"skill-1","version":"1.0","skillHash":"hash-1"}""",
+                    },
+                },
                 OutputParts =
                 {
                     new ChatContentPart
@@ -1047,88 +1055,12 @@ public sealed class RoleGAgentStateCoverageTests
         completed.Sessions["session-a"].FinalContent.Should().Be("done");
         completed.Sessions["session-a"].FinalReasoningContent.Should().Be("because");
         completed.Sessions["session-a"].ToolCalls.Should().ContainSingle(x => x.CallId == "call-1");
+        completed.Sessions["session-a"].ToolReceipts.Should().ContainSingle(x =>
+            x.CallId == "call-1" &&
+            x.Status == AgentToolReceiptStatus.Success &&
+            x.SubjectId == "skill-1" &&
+            x.SubjectHash == "hash-1");
         completed.Sessions["session-a"].OutputParts.Should().ContainSingle(x => x.Text == "done");
-    }
-
-    [Fact]
-    public void DetectPendingApprovalFromHistory_ShouldParseApprovalPayload_AndStoreTypedToolContextWithOpenAnnotations()
-    {
-        using var provider = BuildServiceProvider();
-        var agent = CreateRoleAgent(provider, "role-history-approval");
-        var history = GetHistory(agent);
-        history.Add(new ChatMessage
-        {
-            Role = "tool",
-            Content = "{\"approval_required\":true,\"request_id\":\"req-1\",\"tool_name\":\"dangerous_tool\",\"tool_call_id\":\"call-1\",\"arguments\":\"{\\\"x\\\":1}\"}",
-        });
-
-        var request = new ChatRequestEvent
-        {
-            SessionId = "session-a",
-            ToolContext = new AgentToolExecutionContext(
-                new AgentToolRequestIdentity("request-before-approval", "call-before-approval"),
-                new AgentToolCredentials("token-1", "org-1", "sender-token-1"),
-                new AgentToolCallerContext("scope-a", "owner-a", "response-a"),
-                new AgentToolChannelContext("telegram", "sender-a", "registration-a", "message-a", "platform-message-a"),
-                new AgentToolSenderBindingContext("binding-a"),
-                new LLMRequestRoutingContext("model-a", "route-a", 5, "remember-a"),
-                new AgentToolConnectedServicesContext("""{"service":"telegram"}"""),
-                AgentSkillRecoveryContext.Empty,
-                new Dictionary<string, string>(StringComparer.Ordinal)
-                {
-                    ["trace-id"] = "trace-from-context",
-                    [LLMRequestMetadataKeys.NyxIdAccessToken] = "legacy-token",
-                }).ToPayload(),
-        };
-        request.Metadata["trace-id"] = "trace-1";
-        request.Metadata[LLMRequestMetadataKeys.NyxIdAccessToken] = "token-1";
-        request.Metadata[LLMRequestMetadataKeys.NyxIdOrgToken] = "org-1";
-        request.Metadata[LLMRequestMetadataKeys.SenderNyxIdAccessToken] = "sender-token-1";
-        request.Metadata[LLMRequestMetadataKeys.ModelOverride] = "model-a";
-        request.Metadata[LLMRequestMetadataKeys.NyxIdRoutePreference] = "route-a";
-        request.Metadata[LLMRequestMetadataKeys.ScopeId] = "scope-a";
-        request.Metadata[LLMRequestMetadataKeys.OwnerSubject] = "owner-a";
-        request.LlmControl = new LLMControlContextPayload
-        {
-            NyxIdAccessToken = "control-token",
-            NyxIdOrgToken = "control-org",
-            SenderNyxIdAccessToken = "control-sender-token",
-            ModelOverride = "model-from-control",
-            NyxIdRoutePreference = "route-from-control",
-            MaxToolRoundsOverride = 7,
-            UserMemoryPrompt = "memory-from-control",
-        };
-
-        var pending = InvokePrivateInstance<PendingToolApprovalState?>(
-            DetectPendingApprovalFromHistoryMethod,
-            agent,
-            request);
-
-        pending.Should().NotBeNull();
-        pending!.RequestId.Should().Be("req-1");
-        pending.SessionId.Should().Be("session-a");
-        pending.ToolName.Should().Be("dangerous_tool");
-        pending.ToolCallId.Should().Be("call-1");
-        pending.ArgumentsJson.Should().Be("{\"x\":1}");
-        pending.IsDestructive.Should().BeTrue();
-        pending.ToolContext.Should().NotBeNull();
-        var context = AgentToolExecutionContextMapper.FromPayload(pending.ToolContext);
-        context.Request.RequestId.Should().Be("req-1");
-        context.Request.CallId.Should().Be("call-1");
-        context.Credentials.Should().Be(AgentToolCredentials.Empty);
-        context.Caller.ScopeId.Should().Be("scope-a");
-        context.Channel.Platform.Should().Be("telegram");
-        context.SenderBinding.BindingId.Should().Be("binding-a");
-        context.Routing.ModelOverride.Should().Be("model-from-control");
-        context.Routing.NyxIdRoutePreference.Should().Be("route-from-control");
-        context.Routing.MaxToolRoundsOverride.Should().Be(7);
-        context.Routing.UserMemoryPrompt.Should().Be("memory-from-control");
-        context.ConnectedServices.ContextJson.Should().Be("""{"service":"telegram"}""");
-        context.ExternalMetadata.Should().ContainKey("trace-id").WhoseValue.Should().Be("trace-from-context");
-        context.ExternalMetadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
-        pending.ToolContext.Credentials.NyxIdAccessToken.Should().BeEmpty();
-        pending.ToolContext.Credentials.NyxIdOrgToken.Should().BeEmpty();
-        pending.ToolContext.Credentials.SenderNyxIdAccessToken.Should().BeEmpty();
     }
 
     [Fact]
@@ -1157,76 +1089,6 @@ public sealed class RoleGAgentStateCoverageTests
         next.PendingApproval!.RemoteApprovalId.Should().Be("remote-1");
         next.PendingApproval.RemoteStatusCheckAttempt.Should().Be(3);
         next.PendingApproval.RemoteApprovalExpiresAtUnixMs.Should().Be(1234);
-    }
-
-    [Fact]
-    public void DetectPendingApprovalFromHistory_ShouldIgnoreInvalidOrNonApprovalToolMessages()
-    {
-        using var provider = BuildServiceProvider();
-        var agent = CreateRoleAgent(provider, "role-history-ignore");
-        var history = GetHistory(agent);
-        history.Add(new ChatMessage
-        {
-            Role = "assistant",
-            Content = "not a tool result",
-        });
-        history.Add(new ChatMessage
-        {
-            Role = "tool",
-            Content = "not-json",
-        });
-        history.Add(new ChatMessage
-        {
-            Role = "tool",
-            Content = "{\"approval_required\":false}",
-        });
-
-        InvokePrivateInstance<PendingToolApprovalState?>(
-                DetectPendingApprovalFromHistoryMethod,
-                agent,
-                new ChatRequestEvent { SessionId = "session-a" })
-            .Should()
-            .BeNull();
-    }
-
-    [Fact]
-    public void ClassifyToolResult_ShouldHandleNullStructuredErrorsAndInvalidJson()
-    {
-        InvokePrivateStatic<(bool Success, string? Error)>(
-            ClassifyToolResultMethod,
-            (object?)null)
-            .Should()
-            .Be((true, null));
-
-        InvokePrivateStatic<(bool Success, string? Error)>(
-            ClassifyToolResultMethod,
-            "{\"ok\":true}")
-            .Should()
-            .Be((true, null));
-
-        InvokePrivateStatic<(bool Success, string? Error)>(
-            ClassifyToolResultMethod,
-            "{\"error\":\"  boom  \"}")
-            .Should()
-            .Be((false, "boom"));
-
-        InvokePrivateStatic<(bool Success, string? Error)>(
-            ClassifyToolResultMethod,
-            "{\"error\":{\"code\":\"boom\"}}")
-            .Should()
-            .Be((false, "{\"code\":\"boom\"}"));
-
-        InvokePrivateStatic<(bool Success, string? Error)>(
-            ClassifyToolResultMethod,
-            "{\"error\":null}")
-            .Should()
-            .Be((true, null));
-
-        InvokePrivateStatic<(bool Success, string? Error)>(
-            ClassifyToolResultMethod,
-            "{not-json")
-            .Should()
-            .Be((true, null));
     }
 
     [Fact]

--- a/test/Aevatar.AI.Tests/StreamingToolExecutorTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingToolExecutorTests.cs
@@ -1,3 +1,4 @@
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
@@ -611,6 +612,93 @@ public class StreamingToolExecutorTests
         results[0].Result.Should().Contain("not found");
     }
 
+    [Fact]
+    public async Task ReceiptWorthyFormula_ShouldIgnoreNonReadOnlyAlone_AndEmitForApprovalDestructiveOrSideEffect()
+    {
+        var tools = new ToolManager();
+        tools.Register(new ConcurrencyTrackingTool("plain-write", isReadOnly: false, _ => """{"ok":true}"""));
+        tools.Register(new ConcurrencyTrackingTool("approval", isReadOnly: true, _ => """{"ok":true}""")
+        {
+            ApprovalMode = ToolApprovalMode.AlwaysRequire,
+        });
+        tools.Register(new ConcurrencyTrackingTool("destructive", isReadOnly: true, _ => """{"ok":true}""")
+        {
+            IsDestructive = true,
+        });
+        tools.Register(new ConcurrencyTrackingTool("side-effect", isReadOnly: true, _ => """{"id":"side-1"}""")
+        {
+            SideEffectKind = "Example.Publish",
+        });
+
+        var executor = new StreamingToolExecutor(tools);
+        using var executionState = executor.CreateExecutionState();
+        executor.AddTool(executionState, new ToolCall { Id = "tc-write", Name = "plain-write", ArgumentsJson = "{}" });
+        executor.AddTool(executionState, new ToolCall { Id = "tc-approval", Name = "approval", ArgumentsJson = "{}" });
+        executor.AddTool(executionState, new ToolCall { Id = "tc-destructive", Name = "destructive", ArgumentsJson = "{}" });
+        executor.AddTool(executionState, new ToolCall { Id = "tc-side", Name = "side-effect", ArgumentsJson = "{}" });
+
+        var results = new List<ToolExecutionResult>();
+        await foreach (var result in executor.GetRemainingResultsAsync(executionState, CancellationToken.None))
+            results.Add(result);
+
+        results.Should().HaveCount(4);
+        results[0].Receipt.Should().BeNull("non-read-only alone is not a receipt-worthy side effect");
+        results[1].Receipt.Should().NotBeNull();
+        results[1].Receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+        results[1].Receipt.ApprovalMode.Should().Be(AgentToolReceiptApprovalMode.AlwaysRequire);
+        results[2].Receipt.Should().NotBeNull();
+        results[2].Receipt!.IsDestructive.Should().BeTrue();
+        results[3].Receipt.Should().NotBeNull();
+        results[3].Receipt!.SideEffectKind.Should().Be("example.publish");
+    }
+
+    [Fact]
+    public async Task ReceiptWorthyReadOnlySearchTool_ShouldNotEmitReceipt()
+    {
+        var tools = new ToolManager();
+        tools.Register(new ConcurrencyTrackingTool("ornn_search_skills", isReadOnly: true, _ => """{"status":"success"}""")
+        {
+            SideEffectKind = "",
+        });
+
+        var executor = new StreamingToolExecutor(tools);
+        using var executionState = executor.CreateExecutionState();
+        executor.AddTool(executionState, new ToolCall { Id = "tc-search", Name = "ornn_search_skills", ArgumentsJson = "{}" });
+
+        var results = new List<ToolExecutionResult>();
+        await foreach (var result in executor.GetRemainingResultsAsync(executionState, CancellationToken.None))
+            results.Add(result);
+
+        results.Should().ContainSingle();
+        results[0].IsError.Should().BeFalse();
+        results[0].Receipt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ToolExecutionError_ShouldEmitErrorReceiptForReceiptWorthyTool()
+    {
+        var tools = new ToolManager();
+        tools.Register(new ConcurrencyTrackingTool("publish", isReadOnly: true, _ => Task.FromException<string>(new InvalidOperationException("boom")))
+        {
+            SideEffectKind = "ornn.publish.skill",
+        });
+
+        var executor = new StreamingToolExecutor(tools);
+        using var executionState = executor.CreateExecutionState();
+        executor.AddTool(executionState, new ToolCall { Id = "tc-publish", Name = "publish", ArgumentsJson = "{}" });
+
+        var results = new List<ToolExecutionResult>();
+        await foreach (var result in executor.GetRemainingResultsAsync(executionState, CancellationToken.None))
+            results.Add(result);
+
+        results.Should().ContainSingle();
+        results[0].IsError.Should().BeTrue();
+        results[0].Receipt.Should().NotBeNull();
+        results[0].Receipt!.Status.Should().Be(AgentToolReceiptStatus.Error);
+        results[0].Receipt.ErrorCode.Should().Be("tool_execution_error");
+        results[0].Receipt.ErrorMessage.Should().Contain("boom");
+    }
+
     // ─── Test helpers ───
 
     private sealed class ConcurrencyTrackingTool : IAgentTool
@@ -633,6 +721,9 @@ public class StreamingToolExecutorTests
         public string Description => "test";
         public string ParametersSchema => "{}";
         public bool IsReadOnly { get; }
+        public ToolApprovalMode ApprovalMode { get; init; } = ToolApprovalMode.NeverRequire;
+        public bool IsDestructive { get; init; }
+        public string SideEffectKind { get; init; } = "";
 
         public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) => _execute(ct);
     }

--- a/test/Aevatar.AI.Tests/StreamingToolExecutorTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingToolExecutorTests.cs
@@ -643,13 +643,16 @@ public class StreamingToolExecutorTests
 
         results.Should().HaveCount(4);
         results[0].Receipt.Should().BeNull("non-read-only alone is not a receipt-worthy side effect");
-        results[1].Receipt.Should().NotBeNull();
-        results[1].Receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
-        results[1].Receipt.ApprovalMode.Should().Be(AgentToolReceiptApprovalMode.AlwaysRequire);
-        results[2].Receipt.Should().NotBeNull();
-        results[2].Receipt!.IsDestructive.Should().BeTrue();
-        results[3].Receipt.Should().NotBeNull();
-        results[3].Receipt!.SideEffectKind.Should().Be("example.publish");
+        var approvalReceipt = results[1].Receipt;
+        approvalReceipt.Should().NotBeNull();
+        approvalReceipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+        approvalReceipt.ApprovalMode.Should().Be(AgentToolReceiptApprovalMode.AlwaysRequire);
+        var destructiveReceipt = results[2].Receipt;
+        destructiveReceipt.Should().NotBeNull();
+        destructiveReceipt!.IsDestructive.Should().BeTrue();
+        var sideEffectReceipt = results[3].Receipt;
+        sideEffectReceipt.Should().NotBeNull();
+        sideEffectReceipt!.SideEffectKind.Should().Be("example.publish");
     }
 
     [Fact]
@@ -675,6 +678,37 @@ public class StreamingToolExecutorTests
     }
 
     [Fact]
+    public async Task ReceiptWorthyOrnnPublishResult_ShouldUseToolSuppliedSubjectReceipt()
+    {
+        var tools = new ToolManager();
+        tools.Register(new OrnnPublishSubjectReceiptTool(
+            """{"id":"skill-2","version":"1.0","hash":"hash-2"}"""));
+
+        var executor = new StreamingToolExecutor(tools);
+        using var executionState = executor.CreateExecutionState();
+        executor.AddTool(executionState, new ToolCall
+        {
+            Id = "tc-publish",
+            Name = "ornn_publish_skill",
+            ArgumentsJson = "{}",
+        });
+
+        var results = new List<ToolExecutionResult>();
+        await foreach (var result in executor.GetRemainingResultsAsync(executionState, CancellationToken.None))
+            results.Add(result);
+
+        results.Should().ContainSingle();
+        var receipt = results[0].Receipt;
+        receipt.Should().NotBeNull();
+        receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+        receipt.SideEffectKind.Should().Be("ornn.publish.skill");
+        receipt.SubjectKind.Should().Be("ornn.skill");
+        receipt.SubjectId.Should().Be("skill-2");
+        receipt.SubjectVersion.Should().Be("1.0");
+        receipt.SubjectHash.Should().Be("hash-2");
+    }
+
+    [Fact]
     public async Task ToolExecutionError_ShouldEmitErrorReceiptForReceiptWorthyTool()
     {
         var tools = new ToolManager();
@@ -693,10 +727,11 @@ public class StreamingToolExecutorTests
 
         results.Should().ContainSingle();
         results[0].IsError.Should().BeTrue();
-        results[0].Receipt.Should().NotBeNull();
-        results[0].Receipt!.Status.Should().Be(AgentToolReceiptStatus.Error);
-        results[0].Receipt.ErrorCode.Should().Be("tool_execution_error");
-        results[0].Receipt.ErrorMessage.Should().Contain("boom");
+        var receipt = results[0].Receipt;
+        receipt.Should().NotBeNull();
+        receipt!.Status.Should().Be(AgentToolReceiptStatus.Error);
+        receipt.ErrorCode.Should().Be("tool_execution_error");
+        receipt.ErrorMessage.Should().Contain("boom");
     }
 
     // ─── Test helpers ───
@@ -726,6 +761,37 @@ public class StreamingToolExecutorTests
         public string SideEffectKind { get; init; } = "";
 
         public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) => _execute(ct);
+    }
+
+    private sealed class OrnnPublishSubjectReceiptTool(string resultJson) : IAgentTool
+    {
+        public string Name => "ornn_publish_skill";
+        public string Description => "publish fixture";
+        public string ParametersSchema => "{}";
+        public ToolApprovalMode ApprovalMode => ToolApprovalMode.AlwaysRequire;
+        public string SideEffectKind => "ornn.publish.skill";
+
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
+            Task.FromResult(resultJson);
+
+        public AgentToolReceipt? CreateSuccessReceipt(string callId, string toolName, string successResultJson)
+        {
+            using var document = System.Text.Json.JsonDocument.Parse(successResultJson);
+            var root = document.RootElement;
+            return new AgentToolReceipt
+            {
+                CallId = callId,
+                ToolName = toolName,
+                Status = AgentToolReceiptStatus.Success,
+                ApprovalMode = AgentToolReceiptApprovalMode.AlwaysRequire,
+                SideEffectKind = SideEffectKind,
+                SubjectKind = "ornn.skill",
+                SubjectId = root.GetProperty("id").GetString() ?? string.Empty,
+                SubjectVersion = root.GetProperty("version").GetString() ?? string.Empty,
+                SubjectHash = root.GetProperty("hash").GetString() ?? string.Empty,
+                ResultJson = successResultJson,
+            };
+        }
     }
 
     private sealed class DelegateAgentTool(string name, Func<string, string> execute) : IAgentTool

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnPublishSkillToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnPublishSkillToolTests.cs
@@ -17,6 +17,7 @@ public sealed class OrnnPublishSkillToolTests
 
         tool.Name.Should().Be("ornn_publish_skill");
         tool.ApprovalMode.Should().Be(ToolApprovalMode.AlwaysRequire);
+        tool.SideEffectKind.Should().Be("ornn.publish.skill");
         using var schema = JsonDocument.Parse(tool.ParametersSchema);
         var root = schema.RootElement;
         root.GetProperty("additionalProperties").GetBoolean().Should().BeFalse();
@@ -252,7 +253,7 @@ public sealed class OrnnPublishSkillToolTests
     {
         var handler = new CapturingHandler(
             """{ "data": { "valid": true, "violations": [] } }""",
-            """{ "data": { "guid": "skill-1" } }""");
+            """{ "data": { "guid": "skill-1", "version": "1.1", "skillHash": "hash-1" } }""");
         var tool = CreateTool(handler);
 
         using var _ = BeginTokenScope();
@@ -260,9 +261,32 @@ public sealed class OrnnPublishSkillToolTests
 
         result.Should().Contain("success");
         result.Should().Contain("skill-1");
+        using var document = JsonDocument.Parse(result);
+        var root = document.RootElement;
+        root.GetProperty("guid").GetString().Should().Be("skill-1");
+        root.GetProperty("version").GetString().Should().Be("1.1");
+        root.GetProperty("skillHash").GetString().Should().Be("hash-1");
         handler.Requests.Select(x => x.RequestUri!.AbsolutePath).Should().Equal(
             "/api/v1/proxy/s/ornn/api/v1/skill-format/validate",
             "/api/v1/proxy/s/ornn/api/v1/skills");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenPublishResponseOmitsVersion_ShouldUseRequestedVersionForReceiptSubject()
+    {
+        var handler = new CapturingHandler(
+            """{ "data": { "valid": true, "violations": [] } }""",
+            """{ "data": { "id": "skill-2", "hash": "hash-2" } }""");
+        var tool = CreateTool(handler);
+
+        using var _ = BeginTokenScope();
+        var result = await tool.ExecuteAsync(ValidArguments());
+
+        using var document = JsonDocument.Parse(result);
+        var root = document.RootElement;
+        root.GetProperty("guid").GetString().Should().Be("skill-2");
+        root.GetProperty("version").GetString().Should().Be("1.0");
+        root.GetProperty("skillHash").GetString().Should().Be("hash-2");
     }
 
     private static string ValidArguments(string? extraFields = null)

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnPublishSkillToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnPublishSkillToolTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text.Json;
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.ToolProviders.NyxId;
@@ -287,6 +288,27 @@ public sealed class OrnnPublishSkillToolTests
         root.GetProperty("guid").GetString().Should().Be("skill-2");
         root.GetProperty("version").GetString().Should().Be("1.0");
         root.GetProperty("skillHash").GetString().Should().Be("hash-2");
+    }
+
+    [Fact]
+    public async Task CreateSuccessReceipt_ShouldMapPublishedSkillSubjectFromToolResult()
+    {
+        var handler = new CapturingHandler(
+            """{ "data": { "valid": true, "violations": [] } }""",
+            """{ "data": { "id": "skill-3", "hash": "hash-3" } }""");
+        var tool = CreateTool(handler);
+
+        using var _ = BeginTokenScope();
+        var result = await tool.ExecuteAsync(ValidArguments());
+        var receipt = tool.CreateSuccessReceipt("call-1", tool.Name, result);
+
+        receipt.Should().NotBeNull();
+        receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+        receipt.SideEffectKind.Should().Be("ornn.publish.skill");
+        receipt.SubjectKind.Should().Be("ornn.skill");
+        receipt.SubjectId.Should().Be("skill-3");
+        receipt.SubjectVersion.Should().Be("1.0");
+        receipt.SubjectHash.Should().Be("hash-3");
     }
 
     private static string ValidArguments(string? extraFields = null)

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnSearchSkillsToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnSearchSkillsToolTests.cs
@@ -12,6 +12,8 @@ public sealed class OrnnSearchSkillsToolTests
     {
         var tool = CreateTool(OrnnTestHttpMessageHandler.ReturningJson("""{ "data": { "items": [] } }"""));
 
+        tool.IsReadOnly.Should().BeTrue();
+        tool.SideEffectKind.Should().BeEmpty();
         tool.Description.Should().Contain("asks which Ornn skills they have");
         tool.Description.Should().Contain("empty or omitted query");
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
@@ -265,6 +265,37 @@ public sealed class AgentRunGAgentTests
     }
 
     [Fact]
+    public void ApplyReplyProduced_ShouldPersistTypedToolReceiptsToRunState()
+    {
+        var runtime = CreateRunAgent(
+            new DispatchingActorRuntime(),
+            new RecordingReplyGenerator(() => false),
+            new AsyncLocalInteractiveReplyCollector(),
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true });
+
+        var receipt = NewPublishReceipt(status: Aevatar.AI.Abstractions.AgentToolReceiptStatus.Success);
+        var evt = new AgentRunReplyProducedEvent
+        {
+            RunId = "run-receipts",
+            CorrelationId = "corr-receipts",
+            TargetActorId = "actor-1",
+            ProducedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            TerminalState = LlmReplyTerminalState.Completed,
+            ReplyText = "done",
+            ToolReceipts = { receipt },
+        };
+
+        var next = InvokeAgentTransition(runtime, new AgentRunGAgentState(), evt);
+
+        next.Status.Should().Be(AgentRunStatus.ReplyProduced);
+        next.ToolReceipts.Should().ContainSingle(x =>
+            x.CallId == "call-1" &&
+            x.Status == Aevatar.AI.Abstractions.AgentToolReceiptStatus.Success &&
+            x.SubjectId == "skill-1" &&
+            x.SubjectHash == "hash-1");
+    }
+
+    [Fact]
     public async Task HandleStartAsync_WhenAccepted_PersistsGenerationRequestedAndHandsOffToExecutor()
     {
         var actor = Substitute.For<IActor>();
@@ -480,6 +511,53 @@ public sealed class AgentRunGAgentTests
         // eviction — acceptable trade-off vs. delivering a duplicate user-visible fallback.
         runtime.State.Status.Should().Be(AgentRunStatus.ReplyProduced);
         runtime.State.ProducedReplyText.Should().Be("the real reply");
+    }
+
+    [Fact]
+    public async Task HandleStartAsync_WhenReplyProducedWithReceipt_ShouldRedispatchPersistedReceiptRenderedTextWithoutRerunningLlm()
+    {
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns("actor-1");
+        var handled = new List<EventEnvelope>();
+        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
+            .Do(call => handled.Add(call.Arg<EventEnvelope>()));
+        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
+        var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "should not run" };
+        var runtime = CreateRunAgent(
+            actorRuntime,
+            replyGenerator,
+            new AsyncLocalInteractiveReplyCollector(),
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions
+            {
+                InteractiveRepliesEnabled = true,
+                StreamingRepliesEnabled = false,
+            });
+        SetState(runtime, new AgentRunGAgentState
+        {
+            RunId = "run-produced-retry",
+            CorrelationId = "corr-produced-retry",
+            TargetActorId = "actor-1",
+            Status = AgentRunStatus.ReplyProduced,
+            ProducedReplyText = "Done.\n[tool receipt] Completed: ornn.skill skill-1 (version=1.0, hash=hash-1)",
+            ProducedTerminalState = LlmReplyTerminalState.Completed,
+            ToolReceipts = { NewPublishReceipt(status: Aevatar.AI.Abstractions.AgentToolReceiptStatus.Success) },
+        });
+
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-produced-retry",
+            RunId = "run-produced-retry",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = BuildRelayActivity(),
+            ReplyToken = "relay-token-produced-retry",
+        });
+
+        replyGenerator.CallCount.Should().Be(0);
+        handled.Should().ContainSingle(e => e.Payload.Is(LlmReplyReadyEvent.Descriptor));
+        var ready = handled.Single().Payload.Unpack<LlmReplyReadyEvent>();
+        ready.Outbound.Text.Should().Be(runtime.State.ProducedReplyText);
+        ready.Outbound.Text.Should().Contain("[tool receipt] Completed: ornn.skill skill-1");
     }
 
     [Fact]
@@ -2293,6 +2371,15 @@ public sealed class AgentRunGAgentTests
         throw new InvalidOperationException("Unable to set agent id via reflection.");
     }
 
+    private static void SetState(AgentRunGAgent agent, AgentRunGAgentState state)
+    {
+        var stateField = typeof(Aevatar.Foundation.Core.GAgentBase<AgentRunGAgentState>).GetField(
+            "_state",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        stateField.Should().NotBeNull();
+        stateField!.SetValue(agent, state);
+    }
+
     private static string ExpectedRunActorId(string runId) => $"channel-agent-run:{runId}";
 
     private static ChatActivity BuildRelayActivity() =>
@@ -2313,6 +2400,22 @@ public sealed class AgentRunGAgentTests
                 ReplyMessageId = "relay-msg-1",
                 CorrelationId = "corr-1",
             },
+        };
+
+    private static Aevatar.AI.Abstractions.AgentToolReceipt NewPublishReceipt(
+        Aevatar.AI.Abstractions.AgentToolReceiptStatus status) =>
+        new()
+        {
+            CallId = "call-1",
+            ToolName = "ornn_publish_skill",
+            Status = status,
+            ApprovalMode = Aevatar.AI.Abstractions.AgentToolReceiptApprovalMode.AlwaysRequire,
+            SideEffectKind = "ornn.publish.skill",
+            SubjectKind = "ornn.skill",
+            SubjectId = "skill-1",
+            SubjectVersion = "1.0",
+            SubjectHash = "hash-1",
+            ResultJson = """{"status":"spoofed","subject_id":"wrong"}""",
         };
 
     private static LLMControlContext ControlForAgentRun(

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentToolReceiptRendererTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentToolReceiptRendererTests.cs
@@ -1,0 +1,112 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.GAgents.NyxidChat;
+using FluentAssertions;
+using Xunit;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+public sealed class AgentToolReceiptRendererTests
+{
+    [Fact]
+    public void Render_WhenNoReceipts_ShouldReturnEmptyEvenIfToolArgsOrProseClaimCompletion()
+    {
+        var renderer = new AgentToolReceiptRenderer();
+        var toolCalls = new[]
+        {
+            new AgentRunToolCall
+            {
+                Id = "call-1",
+                Name = "ornn_publish_skill",
+                ArgumentsJson = """{"name":"claimed-skill","markdown":"已提交 / approval required"}""",
+            },
+        };
+
+        renderer.Render([], toolCalls).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Render_ShouldUseTypedReceiptSubjectInsteadOfSpoofedResultJson()
+    {
+        var renderer = new AgentToolReceiptRenderer();
+        var rendered = renderer.Render(
+            [
+                new AgentToolReceipt
+                {
+                    CallId = "call-1",
+                    ToolName = "ornn_publish_skill",
+                    Status = AgentToolReceiptStatus.Success,
+                    SideEffectKind = "ornn.publish.skill",
+                    SubjectKind = "ornn.skill",
+                    SubjectId = "typed-skill",
+                    SubjectVersion = "1.0",
+                    SubjectHash = "typed-hash",
+                    ResultJson = """{"subject_id":"spoofed-skill","status":"approval_required"}""",
+                },
+            ],
+            [
+                new AgentRunToolCall
+                {
+                    Id = "call-1",
+                    Name = "ornn_publish_skill",
+                    ArgumentsJson = """{"name":"argument-skill"}""",
+                },
+            ]);
+
+        rendered.Should().Contain("[tool receipt] Completed: ornn.skill typed-skill");
+        rendered.Should().Contain("version=1.0");
+        rendered.Should().Contain("hash=typed-hash");
+        rendered.Should().NotContain("spoofed-skill");
+        rendered.Should().NotContain("argument-skill");
+        rendered.Should().NotContain("approval_required");
+    }
+
+    [Fact]
+    public void Render_ShouldAllowApprovalAndArgumentFallbackPresentationOnly()
+    {
+        var renderer = new AgentToolReceiptRenderer();
+        var rendered = renderer.Render(
+            [
+                new AgentToolReceipt
+                {
+                    CallId = "call-2",
+                    ToolName = "ornn_publish_skill",
+                    Status = AgentToolReceiptStatus.ApprovalRequired,
+                    ApprovalRequestId = "approval-1",
+                },
+            ],
+            [
+                new AgentRunToolCall
+                {
+                    Id = "call-2",
+                    Name = "ornn_publish_skill",
+                    ArgumentsJson = """{"name":"draft-skill"}""",
+                },
+            ]);
+
+        rendered.Should().Contain("[tool receipt] Approval required: draft-skill");
+        rendered.Should().Contain("approval=approval-1");
+    }
+
+    [Theory]
+    [InlineData(AgentToolReceiptStatus.Denied, "Denied")]
+    [InlineData(AgentToolReceiptStatus.Error, "Failed")]
+    public void Render_ShouldRenderTypedNegativeStatuses(AgentToolReceiptStatus status, string expectedLabel)
+    {
+        var renderer = new AgentToolReceiptRenderer();
+
+        var rendered = renderer.Render(
+            [
+                new AgentToolReceipt
+                {
+                    CallId = "call-3",
+                    ToolName = "dangerous_tool",
+                    Status = status,
+                    ErrorMessage = "blocked",
+                },
+            ],
+            []);
+
+        rendered.Should().Contain($"[tool receipt] {expectedLabel}: dangerous_tool");
+        rendered.Should().Contain("blocked");
+    }
+}


### PR DESCRIPTION
## 摘要

解决 #1826：模型伪造 side-effecting 工具完成（声称已发布 Ornn skill 却从未调用 `ornn_publish_skill`）。

- **Old**：工具完成判定依赖模型自述 / JSON / history / prose，可被伪造。
- **New**：receipt-grounded 完成语义——工具执行产出 canonical 14-field `AgentToolReceipt`（`DENIED=3`/`ERROR=4`，排除 `observed_at_unix_ms`），`ToolResultEvent` 仅追加 `receipt`，NyxID Chat 侧 renderer 呈现；删除旧完成 authority 路径。

经 consensus-rnd 设计共识 r6（3/3 propose，structural framing）。

## 范围

24 files (+667/-260)：`ai_messages.proto`（14-field receipt）、`RoleGAgent`、`StreamingToolExecutor`、`ToolApprovalMiddleware`、`OrnnPublishSkillTool`、新增 `AgentToolReceiptFactory`/`Renderer`/`IAgentToolReceiptRenderer` + 测试。

独立验证：build 0 err；Aevatar.AI.Tests 818/818；ChannelRuntime.Tests 1004/1004；guards 走 CI。

🤖 Auto-loop / consensus-rnd

⟦AI:AUTO-LOOP⟧
