### PR TITLE
feat(#1788): scheduled_agent_creator — 对话注册定时 Ornn skill agent

### DIFF
--- a/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTool.cs
@@ -49,7 +49,7 @@ public sealed class AgentBuilderTool : IAgentTool
     public string Description =>
         "List and manage the caller's persistent automation agents. " +
         "Actions: list_agents, agent_status, run_agent, disable_agent, enable_agent, delete_agent. " +
-        "Agent creation is not handled here — recipes for new agents live as Ornn skills.";
+        "Agent creation is handled by scheduled_agent_creator.";
 
     // Note (issue #466): no `owner_nyx_user_id` parameter is exposed. The tool always
     // operates on the caller's own agents; the resolver derives ownership from the

--- a/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderToolSource.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderToolSource.cs
@@ -17,16 +17,22 @@ public sealed class AgentBuilderToolSource : IAgentToolSource
     private readonly ISkillRunnerCommandPort _skillRunnerPort;
     private readonly IUserAgentCatalogCommandPort _catalogCommandPort;
     private readonly ICallerScopeResolver _callerScopeResolver;
+    private readonly ScheduledAgentCreateRequestMapper _scheduledAgentMapper;
+    private readonly ScheduledAgentApiKeyIssuer _scheduledAgentApiKeyIssuer;
     private readonly ILogger<AgentBuilderTool>? _toolLogger;
+    private readonly ILogger<ScheduledAgentCreatorTool>? _creatorToolLogger;
 
-    public AgentBuilderToolSource(
+    internal AgentBuilderToolSource(
         IUserAgentCatalogQueryPort queryPort,
         ISkillRunnerExecutionQueryPort executionQueryPort,
         INyxIdApiClientFactory nyxClientFactory,
         ISkillRunnerCommandPort skillRunnerPort,
         IUserAgentCatalogCommandPort catalogCommandPort,
         ICallerScopeResolver callerScopeResolver,
-        ILogger<AgentBuilderTool>? toolLogger = null)
+        ScheduledAgentCreateRequestMapper scheduledAgentMapper,
+        ScheduledAgentApiKeyIssuer scheduledAgentApiKeyIssuer,
+        ILogger<AgentBuilderTool>? toolLogger = null,
+        ILogger<ScheduledAgentCreatorTool>? creatorToolLogger = null)
     {
         _queryPort = queryPort ?? throw new ArgumentNullException(nameof(queryPort));
         _executionQueryPort = executionQueryPort ?? throw new ArgumentNullException(nameof(executionQueryPort));
@@ -34,7 +40,10 @@ public sealed class AgentBuilderToolSource : IAgentToolSource
         _skillRunnerPort = skillRunnerPort ?? throw new ArgumentNullException(nameof(skillRunnerPort));
         _catalogCommandPort = catalogCommandPort ?? throw new ArgumentNullException(nameof(catalogCommandPort));
         _callerScopeResolver = callerScopeResolver ?? throw new ArgumentNullException(nameof(callerScopeResolver));
+        _scheduledAgentMapper = scheduledAgentMapper ?? throw new ArgumentNullException(nameof(scheduledAgentMapper));
+        _scheduledAgentApiKeyIssuer = scheduledAgentApiKeyIssuer ?? throw new ArgumentNullException(nameof(scheduledAgentApiKeyIssuer));
         _toolLogger = toolLogger;
+        _creatorToolLogger = creatorToolLogger;
     }
 
     public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default)
@@ -50,6 +59,12 @@ public sealed class AgentBuilderToolSource : IAgentToolSource
                 _catalogCommandPort,
                 _callerScopeResolver,
                 _toolLogger),
+            new ScheduledAgentCreatorTool(
+                _skillRunnerPort,
+                _callerScopeResolver,
+                _scheduledAgentMapper,
+                _scheduledAgentApiKeyIssuer,
+                _creatorToolLogger),
         ];
         return Task.FromResult(tools);
     }

--- a/agents/Aevatar.GAgents.Authoring.Lark/DependencyInjection/AuthoringServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/DependencyInjection/AuthoringServiceCollectionExtensions.cs
@@ -1,7 +1,11 @@
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.Foundation.Abstractions.HumanInteraction;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgents.Scheduled;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 
 namespace Aevatar.GAgents.Authoring.Lark;
 
@@ -17,6 +21,8 @@ namespace Aevatar.GAgents.Authoring.Lark;
 /// </remarks>
 public static class AuthoringServiceCollectionExtensions
 {
+    private static readonly Func<IServiceProvider, object> AgentToolSourceFactory = CreateAgentBuilderToolSource;
+
     /// <summary>
     /// Replaces the default <see cref="IHumanInteractionPort"/> with the Feishu-card
     /// implementation and registers the AgentBuilder tool source so LLM turns can author
@@ -30,8 +36,27 @@ public static class AuthoringServiceCollectionExtensions
         services.TryAddSingleton<ScheduledAgentCreatorOptions>();
         services.TryAddSingleton<ScheduledAgentCreateRequestMapper>();
         services.TryAddSingleton<ScheduledAgentApiKeyIssuer>();
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IAgentToolSource, AgentBuilderToolSource>());
+        if (!services.Any(IsAgentBuilderToolSourceRegistration))
+            services.Add(ServiceDescriptor.Singleton(typeof(IAgentToolSource), AgentToolSourceFactory));
 
         return services;
     }
+
+    private static bool IsAgentBuilderToolSourceRegistration(ServiceDescriptor descriptor) =>
+        descriptor.ServiceType == typeof(IAgentToolSource) &&
+        (descriptor.ImplementationType == typeof(AgentBuilderToolSource) ||
+         descriptor.ImplementationFactory == AgentToolSourceFactory);
+
+    private static object CreateAgentBuilderToolSource(IServiceProvider sp) =>
+        new AgentBuilderToolSource(
+            sp.GetRequiredService<IUserAgentCatalogQueryPort>(),
+            sp.GetRequiredService<ISkillRunnerExecutionQueryPort>(),
+            sp.GetRequiredService<INyxIdApiClientFactory>(),
+            sp.GetRequiredService<ISkillRunnerCommandPort>(),
+            sp.GetRequiredService<IUserAgentCatalogCommandPort>(),
+            sp.GetRequiredService<ICallerScopeResolver>(),
+            sp.GetRequiredService<ScheduledAgentCreateRequestMapper>(),
+            sp.GetRequiredService<ScheduledAgentApiKeyIssuer>(),
+            sp.GetService<ILogger<AgentBuilderTool>>(),
+            sp.GetService<ILogger<ScheduledAgentCreatorTool>>());
 }

--- a/agents/Aevatar.GAgents.Authoring.Lark/DependencyInjection/AuthoringServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/DependencyInjection/AuthoringServiceCollectionExtensions.cs
@@ -27,6 +27,9 @@ public static class AuthoringServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.Replace(ServiceDescriptor.Singleton<IHumanInteractionPort, FeishuCardHumanInteractionPort>());
+        services.TryAddSingleton<ScheduledAgentCreatorOptions>();
+        services.TryAddSingleton<ScheduledAgentCreateRequestMapper>();
+        services.TryAddSingleton<ScheduledAgentApiKeyIssuer>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IAgentToolSource, AgentBuilderToolSource>());
 
         return services;

--- a/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentApiKeyIssuer.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentApiKeyIssuer.cs
@@ -1,0 +1,240 @@
+using System.Text.Json;
+using Aevatar.AI.ToolProviders.NyxId;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.GAgents.Authoring.Lark;
+
+internal sealed class ScheduledAgentApiKeyIssuer
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly INyxIdApiClientFactory _nyxClientFactory;
+    private readonly ScheduledAgentCreatorOptions _options;
+    private readonly ILogger<ScheduledAgentApiKeyIssuer>? _logger;
+
+    public ScheduledAgentApiKeyIssuer(
+        INyxIdApiClientFactory nyxClientFactory,
+        ScheduledAgentCreatorOptions options,
+        ILogger<ScheduledAgentApiKeyIssuer>? logger = null)
+    {
+        _nyxClientFactory = nyxClientFactory ?? throw new ArgumentNullException(nameof(nyxClientFactory));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger;
+    }
+
+    public async Task<ScheduledAgentApiKeyIssueResult> IssueAsync(
+        string token,
+        ScheduledAgentServiceSlugs serviceSlugs,
+        string agentId,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(token);
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentId);
+        ArgumentNullException.ThrowIfNull(serviceSlugs);
+
+        var slugs = RequiredSlugs(serviceSlugs).Distinct(StringComparer.Ordinal).ToArray();
+        if (slugs.Length == 0)
+            return ScheduledAgentApiKeyIssueResult.Failed("missing_required_service_slugs");
+
+        var client = _nyxClientFactory.CreateClient();
+        var servicesJson = await client.ListUserServicesAsync(token, ct);
+        var resolution = ResolveServiceIds(servicesJson, slugs);
+        if (resolution.Error is not null)
+            return ScheduledAgentApiKeyIssueResult.Failed(resolution.Error);
+
+        var response = await client.CreateApiKeyAsync(
+            token,
+            JsonSerializer.Serialize(new
+            {
+                name = $"aevatar-scheduled-agent-{agentId}",
+                scopes = "read write",
+                platform = "generic",
+                allow_all_services = false,
+                allow_all_nodes = true,
+                allowed_service_ids = resolution.ServiceIds,
+            }, JsonOptions),
+            ct);
+
+        return ExtractIssuedKey(response);
+    }
+
+    public async Task TryRevokeAsync(string token, string apiKeyId, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(token) || string.IsNullOrWhiteSpace(apiKeyId))
+            return;
+
+        try
+        {
+            var response = await _nyxClientFactory.CreateClient().DeleteApiKeyAsync(token, apiKeyId.Trim(), ct);
+            if (LooksLikeErrorEnvelope(response))
+            {
+                _logger?.LogWarning(
+                    "Scheduled agent API key rollback returned an error envelope: apiKeyId={ApiKeyId}, response={Response}",
+                    apiKeyId,
+                    response);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Scheduled agent API key rollback failed: apiKeyId={ApiKeyId}", apiKeyId);
+        }
+    }
+
+    private IEnumerable<string> RequiredSlugs(ScheduledAgentServiceSlugs serviceSlugs)
+    {
+        var ornnSlug = Normalize(_options.OrnnServiceSlug) ?? ScheduledAgentCreatorOptions.DefaultOrnnServiceSlug;
+        yield return ornnSlug;
+        yield return serviceSlugs.PrimaryOutboundSlug;
+
+        if (!string.IsNullOrWhiteSpace(serviceSlugs.FailureNotificationSlug) &&
+            !string.Equals(serviceSlugs.FailureNotificationSlug, serviceSlugs.PrimaryOutboundSlug, StringComparison.Ordinal))
+        {
+            yield return serviceSlugs.FailureNotificationSlug;
+        }
+    }
+
+    private static ScheduledAgentServiceResolution ResolveServiceIds(string json, IReadOnlyCollection<string> requiredSlugs)
+    {
+        if (LooksLikeErrorEnvelope(json))
+            return ScheduledAgentServiceResolution.Failed("service_resolution_failed");
+
+        var matches = requiredSlugs
+            .Select(static slug => (slug, ids: new List<string>()))
+            .ToDictionary(static x => x.slug, static x => x.ids, StringComparer.Ordinal);
+
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            foreach (var item in EnumerateServiceItems(document.RootElement))
+            {
+                if (item.ValueKind != JsonValueKind.Object)
+                    continue;
+
+                var slug = ReadString(item, "slug") ?? ReadString(item, "service_slug");
+                if (slug is null || !matches.TryGetValue(slug, out var ids))
+                    continue;
+
+                var id = ReadString(item, "id") ?? ReadString(item, "service_id") ?? ReadString(item, "user_service_id");
+                if (!string.IsNullOrWhiteSpace(id))
+                    ids.Add(id.Trim());
+            }
+        }
+        catch (JsonException)
+        {
+            return ScheduledAgentServiceResolution.Failed("service_resolution_invalid_json");
+        }
+
+        var resolved = new List<string>();
+        foreach (var slug in requiredSlugs.Distinct(StringComparer.Ordinal))
+        {
+            var ids = matches[slug].Distinct(StringComparer.Ordinal).ToArray();
+            if (ids.Length == 0)
+                return ScheduledAgentServiceResolution.Failed($"required_service_not_found:{slug}");
+            if (ids.Length > 1)
+                return ScheduledAgentServiceResolution.Failed($"required_service_ambiguous:{slug}");
+
+            resolved.Add(ids[0]);
+        }
+
+        return resolved.Count == 0
+            ? ScheduledAgentServiceResolution.Failed("required_service_ids_empty")
+            : new ScheduledAgentServiceResolution(resolved, null);
+    }
+
+    private static ScheduledAgentApiKeyIssueResult ExtractIssuedKey(string response)
+    {
+        if (LooksLikeErrorEnvelope(response))
+            return ScheduledAgentApiKeyIssueResult.Failed("api_key_create_failed");
+
+        try
+        {
+            using var document = JsonDocument.Parse(response);
+            var root = document.RootElement;
+            var id = ReadString(root, "id");
+            var fullKey = ReadString(root, "full_key");
+            if (string.IsNullOrWhiteSpace(id))
+                return ScheduledAgentApiKeyIssueResult.Failed("api_key_create_missing_id");
+            if (string.IsNullOrWhiteSpace(fullKey))
+                return ScheduledAgentApiKeyIssueResult.Failed("api_key_create_missing_full_key");
+
+            return ScheduledAgentApiKeyIssueResult.Succeeded(id.Trim(), fullKey.Trim());
+        }
+        catch (JsonException)
+        {
+            return ScheduledAgentApiKeyIssueResult.Failed("api_key_create_invalid_json");
+        }
+    }
+
+    private static IEnumerable<JsonElement> EnumerateServiceItems(JsonElement root)
+    {
+        if (root.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in root.EnumerateArray())
+                yield return item;
+            yield break;
+        }
+
+        if (root.ValueKind != JsonValueKind.Object)
+            yield break;
+
+        foreach (var propertyName in new[] { "services", "user_services", "keys", "data" })
+        {
+            if (!root.TryGetProperty(propertyName, out var array) || array.ValueKind != JsonValueKind.Array)
+                continue;
+
+            foreach (var item in array.EnumerateArray())
+                yield return item;
+        }
+    }
+
+    private static bool LooksLikeErrorEnvelope(string? response)
+    {
+        if (string.IsNullOrWhiteSpace(response))
+            return true;
+
+        try
+        {
+            using var document = JsonDocument.Parse(response);
+            return document.RootElement.ValueKind == JsonValueKind.Object &&
+                   document.RootElement.TryGetProperty("error", out var error) &&
+                   error.ValueKind is not (JsonValueKind.False or JsonValueKind.Null);
+        }
+        catch (JsonException)
+        {
+            return true;
+        }
+    }
+
+    private static string? ReadString(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? Normalize(value.GetString())
+            : null;
+
+    private static string? Normalize(string? value)
+    {
+        var trimmed = value?.Trim();
+        return string.IsNullOrEmpty(trimmed) ? null : trimmed;
+    }
+
+    private sealed record ScheduledAgentServiceResolution(IReadOnlyList<string> ServiceIds, string? Error)
+    {
+        public static ScheduledAgentServiceResolution Failed(string error) => new([], error);
+    }
+}
+
+internal sealed record ScheduledAgentServiceSlugs(
+    string PrimaryOutboundSlug,
+    string? FailureNotificationSlug);
+
+internal sealed record ScheduledAgentApiKeyIssueResult(
+    bool Success,
+    string? ApiKeyId,
+    string? FullKey,
+    string? Error)
+{
+    public static ScheduledAgentApiKeyIssueResult Succeeded(string apiKeyId, string fullKey) =>
+        new(true, apiKeyId, fullKey, null);
+
+    public static ScheduledAgentApiKeyIssueResult Failed(string error) =>
+        new(false, null, null, error);
+}

--- a/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentApiKeyIssuer.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentApiKeyIssuer.cs
@@ -201,7 +201,7 @@ internal sealed class ScheduledAgentApiKeyIssuer
         }
         catch (JsonException)
         {
-            return true;
+            return false;
         }
     }
 

--- a/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentCreateRequestMapper.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentCreateRequestMapper.cs
@@ -1,0 +1,311 @@
+using System.Text.Json;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.Channel.Runtime;
+using Aevatar.GAgents.Platform.Lark;
+using Aevatar.GAgents.Scheduled;
+
+namespace Aevatar.GAgents.Authoring.Lark;
+
+internal sealed class ScheduledAgentCreateRequestMapper
+{
+    private static readonly HashSet<string> AllowedProperties = new(StringComparer.Ordinal)
+    {
+        "skill_ref",
+        "schedule_cron",
+        "schedule_timezone",
+        "display_name",
+        "execution_prompt",
+        "provider_name",
+        "model",
+        "temperature",
+        "max_tokens",
+        "max_tool_rounds",
+        "max_history_messages",
+        "requires_nyxid_proxy_success",
+        "run_immediately",
+    };
+
+    public ScheduledAgentCreatePlanResult Plan(string argumentsJson, OwnerScope caller, string agentId)
+    {
+        ArgumentNullException.ThrowIfNull(caller);
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentId);
+
+        var args = CreatorArgs.Parse(argumentsJson);
+        if (args.Error is not null)
+            return ScheduledAgentCreatePlanResult.JsonError(args.Error);
+
+        var unknown = args.Properties.Keys.Where(key => !AllowedProperties.Contains(key)).Order(StringComparer.Ordinal).ToArray();
+        if (unknown.Length > 0)
+            return ScheduledAgentCreatePlanResult.Failed($"unsupported_fields:{string.Join(",", unknown)}");
+
+        var referenceParse = ScheduledSkillReference.Parse(args.Str("skill_ref"));
+        if (referenceParse.ErrorJson is not null)
+            return ScheduledAgentCreatePlanResult.RawError(referenceParse.ErrorJson);
+
+        var reference = referenceParse.Reference!;
+        var cron = Normalize(args.Str("schedule_cron"));
+        if (cron is null)
+            return ScheduledAgentCreatePlanResult.Failed("schedule_cron is required");
+
+        var timezone = Normalize(args.Str("schedule_timezone"));
+        if (timezone is null)
+            return ScheduledAgentCreatePlanResult.Failed("schedule_timezone is required");
+
+        var scopeId = Normalize(AgentToolRequestContext.ScopeId ?? AgentToolRequestContext.ChannelRegistrationScopeId);
+        if (scopeId is null)
+            return ScheduledAgentCreatePlanResult.Failed("scope_id_unavailable");
+
+        var conversationId = Normalize(AgentToolRequestContext.TryGetExternalMetadata(ChannelMetadataKeys.ConversationId));
+        if (conversationId is null)
+            return ScheduledAgentCreatePlanResult.Failed("conversation_id_unavailable");
+
+        var primarySlug = Normalize(AgentToolRequestContext.TryGetExternalMetadata(ChannelMetadataKeys.LarkOutboundProxySlug));
+        if (primarySlug is null)
+            return ScheduledAgentCreatePlanResult.Failed("lark_outbound_provider_slug_unavailable");
+
+        var target = LarkConversationTargets.BuildFromInboundWithFallback(
+            AgentToolRequestContext.TryGetExternalMetadata(ChannelMetadataKeys.ChatType),
+            conversationId,
+            AgentToolRequestContext.ChannelSenderId,
+            AgentToolRequestContext.TryGetExternalMetadata(ChannelMetadataKeys.LarkUnionId),
+            AgentToolRequestContext.TryGetExternalMetadata(ChannelMetadataKeys.LarkChatId));
+
+        if (string.IsNullOrWhiteSpace(target.Primary.ReceiveId) ||
+            string.IsNullOrWhiteSpace(target.Primary.ReceiveIdType))
+        {
+            return ScheduledAgentCreatePlanResult.Failed("lark_receive_target_unavailable");
+        }
+
+        var failureSlug = Normalize(AgentToolRequestContext.TryGetExternalMetadata(ChannelMetadataKeys.InboundChannelBotProxySlug));
+        if (string.Equals(failureSlug, primarySlug, StringComparison.Ordinal))
+            failureSlug = null;
+
+        return new ScheduledAgentCreatePlanResult(
+            Success: true,
+            Request: new ScheduledAgentCreatePlannedRequest(
+                Reference: reference,
+                DisplayName: Normalize(args.Str("display_name")),
+                ExecutionPrompt: Normalize(args.Str("execution_prompt")),
+                ScheduleCron: cron,
+                ScheduleTimezone: timezone,
+                ScopeId: scopeId,
+                ProviderName: Normalize(args.Str("provider_name")),
+                Model: Normalize(args.Str("model")),
+                Temperature: args.TryDouble("temperature", out var temperature) ? temperature : null,
+                MaxTokens: args.TryInt("max_tokens", out var maxTokens) ? maxTokens : null,
+                MaxToolRounds: args.TryInt("max_tool_rounds", out var maxToolRounds) ? maxToolRounds : null,
+                MaxHistoryMessages: args.TryInt("max_history_messages", out var maxHistoryMessages) ? maxHistoryMessages : null,
+                RequiresNyxidProxySuccess: args.Bool("requires_nyxid_proxy_success") ?? false,
+                RunImmediately: args.Bool("run_immediately") ?? false,
+                ConversationId: conversationId,
+                PrimaryOutboundSlug: primarySlug,
+                FailureNotificationSlug: failureSlug,
+                ReceiveTarget: target,
+                Caller: caller.Clone()),
+            ServiceSlugs: new ScheduledAgentServiceSlugs(primarySlug, failureSlug),
+            ErrorJson: null);
+    }
+
+    public ScheduledAgentCreateMapResult Map(
+        ScheduledAgentCreatePlannedRequest request,
+        ScheduledAgentApiKeyIssueResult issuedKey)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(issuedKey);
+
+        if (!issuedKey.Success || string.IsNullOrWhiteSpace(issuedKey.ApiKeyId) || string.IsNullOrWhiteSpace(issuedKey.FullKey))
+            return ScheduledAgentCreateMapResult.Failed("api_key_unavailable");
+
+        var command = new InitializeSkillRunnerCommand
+        {
+            SkillName = request.Reference.Name,
+            TemplateName = request.DisplayName ?? request.Reference.Name,
+            SkillContent = BuildOrnnReferenceBootstrap(request.Reference.Name),
+            ExecutionPrompt = request.ExecutionPrompt ??
+                              "Execute the configured Ornn skill and return plain text only.",
+            ScheduleCron = request.ScheduleCron,
+            ScheduleTimezone = request.ScheduleTimezone,
+            Enabled = true,
+            ScopeId = request.ScopeId,
+            ProviderName = request.ProviderName ?? string.Empty,
+            Model = request.Model ?? string.Empty,
+            RequiresNyxidProxySuccess = request.RequiresNyxidProxySuccess,
+            OutboundConfig = new SkillRunnerOutboundConfig
+            {
+                ConversationId = request.ConversationId,
+                NyxProviderSlug = request.PrimaryOutboundSlug,
+                NyxApiKey = issuedKey.FullKey,
+                ApiKeyId = issuedKey.ApiKeyId,
+                LarkReceiveId = request.ReceiveTarget.Primary.ReceiveId,
+                LarkReceiveIdType = request.ReceiveTarget.Primary.ReceiveIdType,
+                LarkReceiveIdFallback = request.ReceiveTarget.Fallback?.ReceiveId ?? string.Empty,
+                LarkReceiveIdTypeFallback = request.ReceiveTarget.Fallback?.ReceiveIdType ?? string.Empty,
+                OwnerScope = request.Caller.Clone(),
+                FailureNotificationProviderSlug = request.FailureNotificationSlug ?? string.Empty,
+            },
+        };
+
+        if (request.Temperature.HasValue)
+            command.Temperature = request.Temperature.Value;
+        if (request.MaxTokens.HasValue)
+            command.MaxTokens = request.MaxTokens.Value;
+        if (request.MaxToolRounds.HasValue)
+            command.MaxToolRounds = request.MaxToolRounds.Value;
+        if (request.MaxHistoryMessages.HasValue)
+            command.MaxHistoryMessages = request.MaxHistoryMessages.Value;
+
+        return new ScheduledAgentCreateMapResult(
+            Success: true,
+            Command: command,
+            RunImmediately: request.RunImmediately,
+            ErrorJson: null);
+    }
+
+    internal static string BuildOrnnReferenceBootstrap(string skillName) =>
+        $"Scheduled Ornn skill reference bootstrap.\nskill_ref: {skillName}\nThis is not inline skill content. Resolve the referenced Ornn skill through the standard scheduled-skill execution path; issue 1789 will replace this compatibility bootstrap with typed SkillReference execution.";
+
+    private static string? Normalize(string? value)
+    {
+        var trimmed = value?.Trim();
+        return string.IsNullOrEmpty(trimmed) ? null : trimmed;
+    }
+
+    private sealed class CreatorArgs
+    {
+        private CreatorArgs(Dictionary<string, JsonElement> properties, string? error)
+        {
+            Properties = properties;
+            Error = error;
+        }
+
+        public IReadOnlyDictionary<string, JsonElement> Properties { get; }
+        public string? Error { get; }
+
+        public static CreatorArgs Parse(string? json)
+        {
+            try
+            {
+                using var document = JsonDocument.Parse(string.IsNullOrWhiteSpace(json) ? "{}" : json);
+                if (document.RootElement.ValueKind != JsonValueKind.Object)
+                    return new CreatorArgs([], "arguments must be a JSON object");
+
+                var properties = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+                foreach (var property in document.RootElement.EnumerateObject())
+                    properties[property.Name] = property.Value.Clone();
+
+                return new CreatorArgs(properties, null);
+            }
+            catch (JsonException ex)
+            {
+                return new CreatorArgs([], ex.Message);
+            }
+        }
+
+        public string? Str(string name)
+        {
+            if (!Properties.TryGetValue(name, out var value))
+                return null;
+
+            return value.ValueKind switch
+            {
+                JsonValueKind.String => value.GetString(),
+                JsonValueKind.Number => value.GetRawText(),
+                JsonValueKind.True => "true",
+                JsonValueKind.False => "false",
+                _ => null,
+            };
+        }
+
+        public bool? Bool(string name)
+        {
+            if (!Properties.TryGetValue(name, out var value))
+                return null;
+
+            return value.ValueKind switch
+            {
+                JsonValueKind.True => true,
+                JsonValueKind.False => false,
+                JsonValueKind.String when bool.TryParse(value.GetString(), out var parsed) => parsed,
+                _ => null,
+            };
+        }
+
+        public bool TryInt(string name, out int value)
+        {
+            value = 0;
+            if (!Properties.TryGetValue(name, out var element))
+                return false;
+
+            if (element.ValueKind == JsonValueKind.Number && element.TryGetInt32(out value))
+                return true;
+
+            return element.ValueKind == JsonValueKind.String && int.TryParse(element.GetString(), out value);
+        }
+
+        public bool TryDouble(string name, out double value)
+        {
+            value = 0;
+            if (!Properties.TryGetValue(name, out var element))
+                return false;
+
+            if (element.ValueKind == JsonValueKind.Number && element.TryGetDouble(out value))
+                return true;
+
+            return element.ValueKind == JsonValueKind.String && double.TryParse(element.GetString(), out value);
+        }
+    }
+}
+
+internal sealed record ScheduledAgentCreateMapResult(
+    bool Success,
+    InitializeSkillRunnerCommand? Command,
+    bool RunImmediately,
+    string? ErrorJson)
+{
+    public static ScheduledAgentCreateMapResult Failed(string error) =>
+        new(false, null, false, JsonSerializer.Serialize(new { error = "validation_error", detail = error }));
+
+    public static ScheduledAgentCreateMapResult JsonError(string error) =>
+        new(false, null, false, JsonSerializer.Serialize(new { error = error }));
+
+    public static ScheduledAgentCreateMapResult RawError(string json) =>
+        new(false, null, false, json);
+}
+
+internal sealed record ScheduledAgentCreatePlanResult(
+    bool Success,
+    ScheduledAgentCreatePlannedRequest? Request,
+    ScheduledAgentServiceSlugs? ServiceSlugs,
+    string? ErrorJson)
+{
+    public static ScheduledAgentCreatePlanResult Failed(string error) =>
+        new(false, null, null, JsonSerializer.Serialize(new { error = "validation_error", detail = error }));
+
+    public static ScheduledAgentCreatePlanResult JsonError(string error) =>
+        new(false, null, null, JsonSerializer.Serialize(new { error = error }));
+
+    public static ScheduledAgentCreatePlanResult RawError(string json) =>
+        new(false, null, null, json);
+}
+
+internal sealed record ScheduledAgentCreatePlannedRequest(
+    ScheduledSkillReference Reference,
+    string? DisplayName,
+    string? ExecutionPrompt,
+    string ScheduleCron,
+    string ScheduleTimezone,
+    string ScopeId,
+    string? ProviderName,
+    string? Model,
+    double? Temperature,
+    int? MaxTokens,
+    int? MaxToolRounds,
+    int? MaxHistoryMessages,
+    bool RequiresNyxidProxySuccess,
+    bool RunImmediately,
+    string ConversationId,
+    string PrimaryOutboundSlug,
+    string? FailureNotificationSlug,
+    LarkReceiveTargetWithFallback ReceiveTarget,
+    OwnerScope Caller);

--- a/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentCreatorOptions.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentCreatorOptions.cs
@@ -1,0 +1,8 @@
+namespace Aevatar.GAgents.Authoring.Lark;
+
+public sealed class ScheduledAgentCreatorOptions
+{
+    public const string DefaultOrnnServiceSlug = "ornn-api";
+
+    public string OrnnServiceSlug { get; set; } = DefaultOrnnServiceSlug;
+}

--- a/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentCreatorTool.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentCreatorTool.cs
@@ -1,0 +1,161 @@
+using System.Text.Json;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.Scheduled;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.GAgents.Authoring.Lark;
+
+public sealed class ScheduledAgentCreatorTool : IAgentTool
+{
+    private readonly ISkillRunnerCommandPort _skillRunnerPort;
+    private readonly ICallerScopeResolver _callerScopeResolver;
+    private readonly ScheduledAgentCreateRequestMapper _mapper;
+    private readonly ScheduledAgentApiKeyIssuer _apiKeyIssuer;
+    private readonly ILogger<ScheduledAgentCreatorTool>? _logger;
+
+    internal ScheduledAgentCreatorTool(
+        ISkillRunnerCommandPort skillRunnerPort,
+        ICallerScopeResolver callerScopeResolver,
+        ScheduledAgentCreateRequestMapper mapper,
+        ScheduledAgentApiKeyIssuer apiKeyIssuer,
+        ILogger<ScheduledAgentCreatorTool>? logger = null)
+    {
+        _skillRunnerPort = skillRunnerPort ?? throw new ArgumentNullException(nameof(skillRunnerPort));
+        _callerScopeResolver = callerScopeResolver ?? throw new ArgumentNullException(nameof(callerScopeResolver));
+        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        _apiKeyIssuer = apiKeyIssuer ?? throw new ArgumentNullException(nameof(apiKeyIssuer));
+        _logger = logger;
+    }
+
+    public string Name => "scheduled_agent_creator";
+
+    public string Description =>
+        "Create a caller-owned scheduled automation agent from an Ornn skill reference. " +
+        "Requires skill_ref, schedule_cron, and schedule_timezone. " +
+        "Creation mints a scoped NyxID API key and returns an accepted dispatch receipt only.";
+
+    public string ParametersSchema => """
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "skill_ref": {
+              "type": "string",
+              "description": "Unversioned Ornn skill name. name@version is not supported yet."
+            },
+            "schedule_cron": {
+              "type": "string",
+              "description": "Cron expression for scheduled execution."
+            },
+            "schedule_timezone": {
+              "type": "string",
+              "description": "IANA timezone name for schedule evaluation."
+            },
+            "display_name": {
+              "type": "string",
+              "description": "Optional display name for the created agent."
+            },
+            "execution_prompt": {
+              "type": "string",
+              "description": "Optional extra execution instruction for the runner."
+            },
+            "provider_name": {
+              "type": "string",
+              "description": "Optional LLM provider route name."
+            },
+            "model": {
+              "type": "string",
+              "description": "Optional model name."
+            },
+            "temperature": {
+              "type": "number",
+              "description": "Optional model temperature."
+            },
+            "max_tokens": {
+              "type": "integer",
+              "description": "Optional max output tokens."
+            },
+            "max_tool_rounds": {
+              "type": "integer",
+              "description": "Optional max tool rounds."
+            },
+            "max_history_messages": {
+              "type": "integer",
+              "description": "Optional max retained history messages."
+            },
+            "requires_nyxid_proxy_success": {
+              "type": "boolean",
+              "description": "When true, the run must observe a successful NyxID proxy call."
+            },
+            "run_immediately": {
+              "type": "boolean",
+              "description": "When true, trigger the first run after initialization is accepted."
+            }
+          },
+          "required": ["skill_ref", "schedule_cron", "schedule_timezone"]
+        }
+        """;
+
+    public ToolApprovalMode ApprovalMode => ToolApprovalMode.AlwaysRequire;
+    public bool IsReadOnly => false;
+    public bool IsDestructive => false;
+
+    public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+    {
+        var token = AgentToolRequestContext.NyxIdAccessToken;
+        if (string.IsNullOrWhiteSpace(token))
+            return """{"error":"No NyxID access token available. User must be authenticated."}""";
+
+        OwnerScope caller;
+        try
+        {
+            caller = await _callerScopeResolver.RequireAsync(ct);
+        }
+        catch (CallerScopeUnavailableException ex)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                error = "caller_scope_unavailable",
+                detail = ex.Message,
+                hint = "Re-authenticate (cli/web) or ensure the channel relay propagates platform/sender_id metadata.",
+            });
+        }
+
+        var agentId = SkillRunnerDefaults.GenerateActorId();
+        var plan = _mapper.Plan(argumentsJson, caller, agentId);
+        if (!plan.Success)
+            return plan.ErrorJson ?? """{"error":"validation_error"}""";
+
+        var key = await _apiKeyIssuer.IssueAsync(token, plan.ServiceSlugs!, agentId, ct);
+        if (!key.Success)
+            return JsonSerializer.Serialize(new { error = key.Error ?? "api_key_issue_failed" });
+
+        var mapped = _mapper.Map(plan.Request!, key);
+        if (!mapped.Success)
+        {
+            await _apiKeyIssuer.TryRevokeAsync(token, key.ApiKeyId ?? string.Empty, ct);
+            return mapped.ErrorJson ?? """{"error":"validation_error"}""";
+        }
+
+        try
+        {
+            await _skillRunnerPort.InitializeAsync(agentId, mapped.Command!, mapped.RunImmediately, ct);
+        }
+        catch (Exception ex)
+        {
+            await _apiKeyIssuer.TryRevokeAsync(token, key.ApiKeyId ?? string.Empty, CancellationToken.None);
+            _logger?.LogWarning(ex, "Scheduled agent create dispatch failed after key issue: agentId={AgentId}", agentId);
+            return JsonSerializer.Serialize(new { error = "initialize_failed" });
+        }
+
+        return JsonSerializer.Serialize(new
+        {
+            status = "accepted",
+            agent_id = agentId,
+            api_key_id = key.ApiKeyId,
+            note = "Scheduled agent create accepted for dispatch. Use agent_builder agent_status to observe projection state.",
+        });
+    }
+}

--- a/agents/Aevatar.GAgents.Authoring.Lark/ScheduledSkillReference.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/ScheduledSkillReference.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Aevatar.GAgents.Authoring.Lark;
+
+internal sealed record ScheduledSkillReference(string Name)
+{
+    private static readonly Regex VersionPattern = new(@"^\d+\.\d+$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public static ScheduledSkillReferenceParseResult Parse(string? value)
+    {
+        var trimmed = Normalize(value);
+        if (trimmed is null)
+            return ScheduledSkillReferenceParseResult.ValidationError("skill_ref is required");
+
+        var atIndex = trimmed.LastIndexOf('@');
+        if (atIndex >= 0)
+        {
+            var name = trimmed[..atIndex].Trim();
+            var version = trimmed[(atIndex + 1)..].Trim();
+            if (name.Length == 0 || version.Length == 0)
+                return ScheduledSkillReferenceParseResult.ValidationError("skill_ref version syntax is invalid");
+
+            if (VersionPattern.IsMatch(version))
+                return ScheduledSkillReferenceParseResult.VersionedUnsupported(trimmed);
+
+            return ScheduledSkillReferenceParseResult.ValidationError("skill_ref version syntax is invalid");
+        }
+
+        return new ScheduledSkillReferenceParseResult(new ScheduledSkillReference(trimmed), null, null);
+    }
+
+    private static string? Normalize(string? value)
+    {
+        var trimmed = value?.Trim();
+        return string.IsNullOrEmpty(trimmed) ? null : trimmed;
+    }
+}
+
+internal sealed record ScheduledSkillReferenceParseResult(
+    ScheduledSkillReference? Reference,
+    string? Error,
+    string? ErrorJson)
+{
+    public static ScheduledSkillReferenceParseResult ValidationError(string error) =>
+        new(null, error, JsonSerializer.Serialize(new { error = "validation_error", detail = error }));
+
+    public static ScheduledSkillReferenceParseResult VersionedUnsupported(string skillRef) =>
+        new(
+            null,
+            "versioned_skill_ref_not_supported_yet",
+            JsonSerializer.Serialize(new
+            {
+                error = "versioned_skill_ref_not_supported_yet",
+                skill_ref = skillRef,
+            }));
+}

--- a/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
+++ b/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
@@ -127,14 +127,20 @@ Workflow `human_approval`, `human_input`, `secure_input` steps can send Feishu d
 
 Bind `agent_id` to the real outbound route:
 - `agent_delivery_targets action=list`
-- `agent_delivery_targets action=upsert agent_id=<agent_id> conversation_id=<chat_id> nyx_provider_slug=<lark_slug, e.g. api-lark-bot> nyx_api_key=<key>`
+- `agent_delivery_targets action=upsert agent_id=<agent_id> conversation_id=<chat_id> nyx_provider_slug=<lark_slug, e.g. api-lark-bot>`
 - `agent_delivery_targets action=delete agent_id=<agent_id> confirm=true`
 
 `channel_registrations` configures inbound bot callbacks; `agent_delivery_targets` configures outbound agent delivery. Today the human-interaction delivery path supports `lark`.
 
+### scheduled_agent_creator (scheduled Ornn skill agents)
+
+Use `scheduled_agent_creator` to create a new caller-owned scheduled automation agent from an Ornn skill reference. Required fields are `skill_ref`, `schedule_cron`, and `schedule_timezone`; optional LLM tuning fields are allowed. Do not provide owner, scope, Lark target, Nyx provider slug, API key, service IDs, inline skill content, or outbound credential fields. The tool derives those from the current authenticated/channel context, mints a scoped NyxID key, and returns only an accepted receipt.
+
+`skill_ref` must be unversioned for now. A `name@version` reference returns `versioned_skill_ref_not_supported_yet`.
+
 ### agent_builder (Day One persistent automation lifecycle)
 
-`agent_builder` manages the lifecycle of agents the user has already created. Recipes for *new* agents live as Ornn skills — match the user's intent against `ornn_search_skills` and follow the SKILL.md verbatim. `agent_builder` itself does not create agents.
+`agent_builder` manages the lifecycle of agents the user has already created. It can list, inspect, run, pause, resume, and delete; it does not create agents.
 
 | Intent | Slash command |
 |---|---|

--- a/src/Aevatar.AI.ToolProviders.AgentCatalog/AgentDeliveryTargetTool.cs
+++ b/src/Aevatar.AI.ToolProviders.AgentCatalog/AgentDeliveryTargetTool.cs
@@ -17,7 +17,7 @@ namespace Aevatar.AI.ToolProviders.AgentCatalog;
 /// and are not surfaced through any LLM tool. Issue #466 §D.
 ///
 /// Upsert is rebind-only: rejects when no existing entry exists for the caller. Real
-/// agent creation (which mints credentials) lives in <c>AgentBuilderTool</c>.
+/// agent creation (which mints credentials) lives in <c>scheduled_agent_creator</c>.
 /// </summary>
 public sealed class AgentDeliveryTargetTool : IAgentTool
 {
@@ -44,7 +44,7 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
         "Manage agent delivery targets for workflow human interaction cards and outbound channel delivery. " +
         "Actions: list, upsert (rebind existing only), delete. " +
         "Use this to rebind an agent_id/delivery_target_id to a different Lark conversation or Nyx provider slug; " +
-        "creating new delivery targets (which mints credentials) is the agent_builder tool's job. " +
+        "creating new delivery targets (which mints credentials) is the scheduled_agent_creator tool's job. " +
         "Operations are scoped to the caller's own delivery targets.";
 
     // Note (issue #466): no `owner_nyx_user_id` and no `nyx_api_key` parameters. Owner
@@ -212,7 +212,7 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
             return JsonSerializer.Serialize(new
             {
                 error = "delivery_target_not_found_for_caller",
-                hint = "agent_delivery_targets.upsert is a rebind operation only — it preserves the existing API key. To create a new agent (which mints credentials), use the agent_builder tool instead.",
+                hint = "agent_delivery_targets.upsert is a rebind operation only — it preserves the existing API key. To create a new agent (which mints credentials), use the scheduled_agent_creator tool instead.",
             });
         }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -19,6 +19,31 @@ namespace Aevatar.GAgents.ChannelRuntime.Tests;
 public sealed class AgentBuilderToolTests
 {
     [Fact]
+    public void ParametersSchema_Remains_ManagementOnly()
+    {
+        var tool = new AgentBuilderTool(
+            Substitute.For<IUserAgentCatalogQueryPort>(),
+            Substitute.For<ISkillRunnerExecutionQueryPort>(),
+            Substitute.For<INyxIdApiClientFactory>(),
+            Substitute.For<ISkillRunnerCommandPort>(),
+            Substitute.For<IUserAgentCatalogCommandPort>(),
+            Substitute.For<ICallerScopeResolver>());
+
+        using var document = JsonDocument.Parse(tool.ParametersSchema);
+        var actions = document.RootElement
+            .GetProperty("properties")
+            .GetProperty("action")
+            .GetProperty("enum")
+            .EnumerateArray()
+            .Select(static item => item.GetString())
+            .ToArray();
+
+        actions.Should().NotContain("create_agent");
+        tool.Description.Should().Contain("scheduled_agent_creator");
+        tool.Description.Should().NotContain("Agent creation is not handled here");
+    }
+
+    [Fact]
     public async Task ExecuteAsync_DeleteAgent_DisablesActor_RevokesApiKey_AndTombstonesRegistry()
     {
         var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
@@ -700,6 +725,10 @@ public sealed class AgentBuilderToolTests
         var skillRunnerPort = Substitute.For<ISkillRunnerCommandPort>();
         var catalogCommandPort = Substitute.For<IUserAgentCatalogCommandPort>();
         var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
+        var scheduledAgentMapper = new ScheduledAgentCreateRequestMapper();
+        var scheduledAgentApiKeyIssuer = new ScheduledAgentApiKeyIssuer(
+            nyxClientFactory,
+            new ScheduledAgentCreatorOptions());
 
         var missingQuery = () => new AgentBuilderTool(null!, executionQueryPort, nyxClientFactory, skillRunnerPort, catalogCommandPort, callerScopeResolver);
         var missingExecutionQuery = () => new AgentBuilderTool(queryPort, null!, nyxClientFactory, skillRunnerPort, catalogCommandPort, callerScopeResolver);
@@ -707,12 +736,14 @@ public sealed class AgentBuilderToolTests
         var missingSkillRunner = () => new AgentBuilderTool(queryPort, executionQueryPort, nyxClientFactory, null!, catalogCommandPort, callerScopeResolver);
         var missingCatalogCommand = () => new AgentBuilderTool(queryPort, executionQueryPort, nyxClientFactory, skillRunnerPort, null!, callerScopeResolver);
         var missingCallerScope = () => new AgentBuilderTool(queryPort, executionQueryPort, nyxClientFactory, skillRunnerPort, catalogCommandPort, null!);
-        var missingSourceQuery = () => new AgentBuilderToolSource(null!, executionQueryPort, nyxClientFactory, skillRunnerPort, catalogCommandPort, callerScopeResolver);
-        var missingSourceExecutionQuery = () => new AgentBuilderToolSource(queryPort, null!, nyxClientFactory, skillRunnerPort, catalogCommandPort, callerScopeResolver);
-        var missingSourceNyxFactory = () => new AgentBuilderToolSource(queryPort, executionQueryPort, null!, skillRunnerPort, catalogCommandPort, callerScopeResolver);
-        var missingSourceSkillRunner = () => new AgentBuilderToolSource(queryPort, executionQueryPort, nyxClientFactory, null!, catalogCommandPort, callerScopeResolver);
-        var missingSourceCatalogCommand = () => new AgentBuilderToolSource(queryPort, executionQueryPort, nyxClientFactory, skillRunnerPort, null!, callerScopeResolver);
-        var missingSourceCallerScope = () => new AgentBuilderToolSource(queryPort, executionQueryPort, nyxClientFactory, skillRunnerPort, catalogCommandPort, null!);
+        var missingSourceQuery = () => new AgentBuilderToolSource(null!, executionQueryPort, nyxClientFactory, skillRunnerPort, catalogCommandPort, callerScopeResolver, scheduledAgentMapper, scheduledAgentApiKeyIssuer);
+        var missingSourceExecutionQuery = () => new AgentBuilderToolSource(queryPort, null!, nyxClientFactory, skillRunnerPort, catalogCommandPort, callerScopeResolver, scheduledAgentMapper, scheduledAgentApiKeyIssuer);
+        var missingSourceNyxFactory = () => new AgentBuilderToolSource(queryPort, executionQueryPort, null!, skillRunnerPort, catalogCommandPort, callerScopeResolver, scheduledAgentMapper, scheduledAgentApiKeyIssuer);
+        var missingSourceSkillRunner = () => new AgentBuilderToolSource(queryPort, executionQueryPort, nyxClientFactory, null!, catalogCommandPort, callerScopeResolver, scheduledAgentMapper, scheduledAgentApiKeyIssuer);
+        var missingSourceCatalogCommand = () => new AgentBuilderToolSource(queryPort, executionQueryPort, nyxClientFactory, skillRunnerPort, null!, callerScopeResolver, scheduledAgentMapper, scheduledAgentApiKeyIssuer);
+        var missingSourceCallerScope = () => new AgentBuilderToolSource(queryPort, executionQueryPort, nyxClientFactory, skillRunnerPort, catalogCommandPort, null!, scheduledAgentMapper, scheduledAgentApiKeyIssuer);
+        var missingSourceMapper = () => new AgentBuilderToolSource(queryPort, executionQueryPort, nyxClientFactory, skillRunnerPort, catalogCommandPort, callerScopeResolver, null!, scheduledAgentApiKeyIssuer);
+        var missingSourceIssuer = () => new AgentBuilderToolSource(queryPort, executionQueryPort, nyxClientFactory, skillRunnerPort, catalogCommandPort, callerScopeResolver, scheduledAgentMapper, null!);
 
         missingQuery.Should().Throw<ArgumentNullException>().WithParameterName("queryPort");
         missingExecutionQuery.Should().Throw<ArgumentNullException>().WithParameterName("executionQueryPort");
@@ -726,6 +757,8 @@ public sealed class AgentBuilderToolTests
         missingSourceSkillRunner.Should().Throw<ArgumentNullException>().WithParameterName("skillRunnerPort");
         missingSourceCatalogCommand.Should().Throw<ArgumentNullException>().WithParameterName("catalogCommandPort");
         missingSourceCallerScope.Should().Throw<ArgumentNullException>().WithParameterName("callerScopeResolver");
+        missingSourceMapper.Should().Throw<ArgumentNullException>().WithParameterName("scheduledAgentMapper");
+        missingSourceIssuer.Should().Throw<ArgumentNullException>().WithParameterName("scheduledAgentApiKeyIssuer");
     }
 
     [Fact]
@@ -784,11 +817,17 @@ public sealed class AgentBuilderToolTests
             nyxClientFactory,
             skillRunnerPort,
             catalogCommandPort,
-            callerScopeResolver);
+            callerScopeResolver,
+            new ScheduledAgentCreateRequestMapper(),
+            new ScheduledAgentApiKeyIssuer(nyxClientFactory, new ScheduledAgentCreatorOptions()));
         var tools = await source.DiscoverToolsAsync();
 
-        tools.Should().ContainSingle();
-        tools[0].Name.Should().Be("agent_builder");
+        tools.Select(tool => tool.Name).Should().BeEquivalentTo("agent_builder", "scheduled_agent_creator");
+        var managementTool = tools.Single(tool => tool.Name == "agent_builder");
+        var creatorTool = tools.Single(tool => tool.Name == "scheduled_agent_creator");
+        creatorTool.ApprovalMode.Should().Be(ToolApprovalMode.AlwaysRequire);
+        creatorTool.IsReadOnly.Should().BeFalse();
+        creatorTool.IsDestructive.Should().BeFalse();
 
         AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
         {
@@ -796,7 +835,7 @@ public sealed class AgentBuilderToolTests
         });
         try
         {
-            var result = await tools[0].ExecuteAsync("""{"action":"list_agents"}""");
+            var result = await managementTool.ExecuteAsync("""{"action":"list_agents"}""");
             using var doc = JsonDocument.Parse(result);
             doc.RootElement.GetProperty("total").GetInt32().Should().Be(0);
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -8,11 +8,15 @@ using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Xunit;
 using Aevatar.GAgents.Authoring.Lark;
 using Aevatar.GAgents.Scheduled;
+using Aevatar.Foundation.Abstractions.HumanInteraction;
+using Aevatar.GAgents.Platform.Lark;
 
 namespace Aevatar.GAgents.ChannelRuntime.Tests;
 
@@ -847,6 +851,44 @@ public sealed class AgentBuilderToolTests
         {
             AgentToolRequestContext.Current = null;
         }
+    }
+
+    [Fact]
+    public async Task AddLarkAgentAuthoring_ShouldResolveToolSource_AndDiscoverRegisteredTools()
+    {
+        var handler = new RoutingJsonHandler();
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler) { BaseAddress = new Uri("https://nyx.example.com") });
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        var executionQueryPort = Substitute.For<ISkillRunnerExecutionQueryPort>();
+        var skillRunnerPort = Substitute.For<ISkillRunnerCommandPort>();
+        var catalogCommandPort = Substitute.For<IUserAgentCatalogCommandPort>();
+        var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
+        var services = new ServiceCollection();
+        services.AddSingleton(queryPort);
+        services.AddSingleton(executionQueryPort);
+        services.AddSingleton(skillRunnerPort);
+        services.AddSingleton(catalogCommandPort);
+        services.AddSingleton<INyxIdApiClientFactory>(new TestNyxIdApiClientFactory(nyxClient));
+        services.AddSingleton(nyxClient);
+        services.AddSingleton(Substitute.For<IUserAgentDeliveryTargetReader>());
+        services.AddSingleton<LarkMessageComposer>();
+        services.TryAddSingleton<ILogger<FeishuCardHumanInteractionPort>>(NullLogger<FeishuCardHumanInteractionPort>.Instance);
+        services.AddSingleton(callerScopeResolver);
+
+        services.AddLarkAgentAuthoring();
+
+        await using var provider = services.BuildServiceProvider();
+        var source = provider.GetServices<IAgentToolSource>().Should().ContainSingle().Subject;
+        source.Should().BeOfType<AgentBuilderToolSource>();
+        provider.GetRequiredService<IHumanInteractionPort>().Should().BeOfType<FeishuCardHumanInteractionPort>();
+
+        var tools = await source.DiscoverToolsAsync();
+
+        tools.Select(tool => tool.Name).Should().BeEquivalentTo("agent_builder", "scheduled_agent_creator");
+        tools.Single(tool => tool.Name == "scheduled_agent_creator").ApprovalMode
+            .Should().Be(ToolApprovalMode.AlwaysRequire);
     }
 
     private static AgentBuilderTool CreateTool(IServiceCollection services)

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -854,7 +854,7 @@ public sealed class AgentBuilderToolTests
     }
 
     [Fact]
-    public async Task AddLarkAgentAuthoring_ShouldResolveToolSource_AndDiscoverRegisteredTools()
+    public async Task AddLarkAgentAuthoring_WhenCalledTwice_ShouldResolveSingleToolSource_AndDiscoverRegisteredTools()
     {
         var handler = new RoutingJsonHandler();
         var nyxClient = new NyxIdApiClient(
@@ -877,6 +877,7 @@ public sealed class AgentBuilderToolTests
         services.TryAddSingleton<ILogger<FeishuCardHumanInteractionPort>>(NullLogger<FeishuCardHumanInteractionPort>.Instance);
         services.AddSingleton(callerScopeResolver);
 
+        services.AddLarkAgentAuthoring();
         services.AddLarkAgentAuthoring();
 
         await using var provider = services.BuildServiceProvider();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentDeliveryTargetToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentDeliveryTargetToolTests.cs
@@ -26,6 +26,14 @@ public sealed class AgentDeliveryTargetToolTests
         var tool = CreateTool();
         var act = () => JsonDocument.Parse(tool.ParametersSchema);
         act.Should().NotThrow();
+
+        using var document = JsonDocument.Parse(tool.ParametersSchema);
+        var properties = document.RootElement.GetProperty("properties");
+        properties.TryGetProperty("nyx_api_key", out _).Should().BeFalse();
+        properties.TryGetProperty("api_key_id", out _).Should().BeFalse();
+        properties.TryGetProperty("allowed_service_ids", out _).Should().BeFalse();
+        tool.Description.Should().Contain("scheduled_agent_creator");
+        tool.Description.Should().NotContain("agent_builder tool's job");
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentCreatorToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentCreatorToolTests.cs
@@ -140,6 +140,32 @@ public sealed class ScheduledAgentCreatorToolTests
         });
     }
 
+    [Theory]
+    [InlineData("missing_scope", "scope_id_unavailable")]
+    [InlineData("missing_conversation", "conversation_id_unavailable")]
+    [InlineData("missing_receive_target", "lark_receive_target_unavailable")]
+    public async Task ExecuteAsync_WhenTrustedContextIncomplete_ShouldFailClosedBeforeKeyCreation(
+        string caseName,
+        string expectedDetail)
+    {
+        var harness = CreateHarness();
+
+        await WithToolContext(CreateContextForValidationCase(caseName), async () =>
+        {
+            var result = await harness.Tool.ExecuteAsync(BaseArgs);
+
+            using var document = JsonDocument.Parse(result);
+            document.RootElement.GetProperty("error").GetString().Should().Be("validation_error");
+            document.RootElement.GetProperty("detail").GetString().Should().Be(expectedDetail);
+            harness.Handler.Requests.Should().BeEmpty();
+            await harness.SkillRunnerPort.DidNotReceive().InitializeAsync(
+                Arg.Any<string>(),
+                Arg.Any<InitializeSkillRunnerCommand>(),
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>());
+        });
+    }
+
     [Fact]
     public async Task ExecuteAsync_WhenRequiredServiceMissing_ShouldFailClosedWithoutBroadKey()
     {
@@ -180,6 +206,35 @@ public sealed class ScheduledAgentCreatorToolTests
             using var document = JsonDocument.Parse(result);
             document.RootElement.GetProperty("error").GetString().Should().Be("required_service_ambiguous:ornn-api");
             handler.Requests.Should().NotContain(request => request.Method == HttpMethod.Post);
+        });
+    }
+
+    [Theory]
+    [InlineData("""{"error":true,"message":"create failed"}""", "api_key_create_failed")]
+    [InlineData("not-json", "api_key_create_invalid_json")]
+    [InlineData("""{"full_key":"full-secret-key"}""", "api_key_create_missing_id")]
+    [InlineData("""{"id":"key-created"}""", "api_key_create_missing_full_key")]
+    public async Task ExecuteAsync_WhenApiKeyCreateResponseInvalid_ShouldFailWithoutDispatch(
+        string createResponseJson,
+        string expectedError)
+    {
+        var handler = CreateSuccessHandler(createResponseJson);
+        var harness = CreateHarness(handler: handler);
+
+        await WithToolContext(async () =>
+        {
+            var result = await harness.Tool.ExecuteAsync(BaseArgs);
+
+            using var document = JsonDocument.Parse(result);
+            document.RootElement.GetProperty("error").GetString().Should().Be(expectedError);
+            handler.Requests.Should().ContainSingle(request => request.Method == HttpMethod.Get);
+            handler.Requests.Should().ContainSingle(request => request.Method == HttpMethod.Post);
+            handler.Requests.Should().NotContain(request => request.Method == HttpMethod.Delete);
+            await harness.SkillRunnerPort.DidNotReceive().InitializeAsync(
+                Arg.Any<string>(),
+                Arg.Any<InitializeSkillRunnerCommand>(),
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>());
         });
     }
 
@@ -365,7 +420,7 @@ public sealed class ScheduledAgentCreatorToolTests
         return new CreatorHarness(tool, handler, skillRunnerPort, queryPort);
     }
 
-    private static RoutingJsonHandler CreateSuccessHandler()
+    private static RoutingJsonHandler CreateSuccessHandler(string createApiKeyResponse = """{"id":"key-created","full_key":"full-secret-key"}""")
     {
         var handler = new RoutingJsonHandler();
         handler.Add(HttpMethod.Get, "/api/v1/user-services", """
@@ -377,20 +432,17 @@ public sealed class ScheduledAgentCreatorToolTests
               ]
             }
             """);
-        handler.Add(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-created","full_key":"full-secret-key"}""");
+        handler.Add(HttpMethod.Post, "/api/v1/api-keys", createApiKeyResponse);
         handler.Add(HttpMethod.Delete, "/api/v1/api-keys/key-created", """{"ok":true}""");
         return handler;
     }
 
-    private static async Task WithToolContext(Func<Task> action)
+    private static async Task WithToolContext(Func<Task> action) =>
+        await WithToolContext(CreateToolContext(), action);
+
+    private static async Task WithToolContext(AgentToolExecutionContext context, Func<Task> action)
     {
-        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
-        {
-            Credentials = new AgentToolCredentials("session-token", "session-token", null),
-            Caller = new AgentToolCallerContext("scope-bot-1", null, "message-1"),
-            Channel = new AgentToolChannelContext("lark", "ou_sender", "scope-bot-1", "message-1", "om_1"),
-            ExternalMetadata = BaseExternalMetadata(),
-        };
+        AgentToolRequestContext.Current = context;
         try
         {
             await action();
@@ -401,16 +453,48 @@ public sealed class ScheduledAgentCreatorToolTests
         }
     }
 
-    private static IReadOnlyDictionary<string, string> BaseExternalMetadata(bool includeOutboundSlug = true)
+    private static AgentToolExecutionContext CreateContextForValidationCase(string caseName) =>
+        caseName switch
+        {
+            "missing_scope" => CreateToolContext(callerScopeId: null, channelRegistrationScopeId: null),
+            "missing_conversation" => CreateToolContext(
+                externalMetadata: BaseExternalMetadata(includeConversationId: false)),
+            "missing_receive_target" => CreateToolContext(
+                channelSenderId: null,
+                externalMetadata: BaseExternalMetadata(includeChatId: false, includeUnionId: false)),
+            _ => throw new ArgumentOutOfRangeException(nameof(caseName), caseName, null),
+        };
+
+    private static AgentToolExecutionContext CreateToolContext(
+        string? callerScopeId = "scope-bot-1",
+        string? channelRegistrationScopeId = "scope-bot-1",
+        string? channelSenderId = "ou_sender",
+        IReadOnlyDictionary<string, string>? externalMetadata = null) =>
+        AgentToolExecutionContext.Empty with
+        {
+            Credentials = new AgentToolCredentials("session-token", "session-token", null),
+            Caller = new AgentToolCallerContext(callerScopeId, null, "message-1"),
+            Channel = new AgentToolChannelContext("lark", channelSenderId, channelRegistrationScopeId, "message-1", "om_1"),
+            ExternalMetadata = externalMetadata ?? BaseExternalMetadata(),
+        };
+
+    private static IReadOnlyDictionary<string, string> BaseExternalMetadata(
+        bool includeOutboundSlug = true,
+        bool includeConversationId = true,
+        bool includeChatId = true,
+        bool includeUnionId = true)
     {
         var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
         {
-            [ChannelMetadataKeys.ConversationId] = "oc_conversation",
             [ChannelMetadataKeys.ChatType] = "p2p",
-            [ChannelMetadataKeys.LarkChatId] = "oc_chat",
-            [ChannelMetadataKeys.LarkUnionId] = "on_union",
             [ChannelMetadataKeys.InboundChannelBotProxySlug] = "api-lark-bot-inbound",
         };
+        if (includeConversationId)
+            metadata[ChannelMetadataKeys.ConversationId] = "oc_conversation";
+        if (includeChatId)
+            metadata[ChannelMetadataKeys.LarkChatId] = "oc_chat";
+        if (includeUnionId)
+            metadata[ChannelMetadataKeys.LarkUnionId] = "on_union";
         if (includeOutboundSlug)
             metadata[ChannelMetadataKeys.LarkOutboundProxySlug] = "api-lark-bot";
         return metadata;

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentCreatorToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentCreatorToolTests.cs
@@ -1,0 +1,469 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.Authoring.Lark;
+using Aevatar.GAgents.Channel.Runtime;
+using Aevatar.GAgents.Scheduled;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+public sealed class ScheduledAgentCreatorToolTests
+{
+    [Fact]
+    public void ToolContract_ShouldRequireApproval_AndExposeClosedSchema()
+    {
+        var tool = CreateHarness().Tool;
+
+        tool.Name.Should().Be("scheduled_agent_creator");
+        tool.ApprovalMode.Should().Be(ToolApprovalMode.AlwaysRequire);
+        tool.IsReadOnly.Should().BeFalse();
+        tool.IsDestructive.Should().BeFalse();
+
+        using var schema = JsonDocument.Parse(tool.ParametersSchema);
+        schema.RootElement.GetProperty("additionalProperties").GetBoolean().Should().BeFalse();
+        var properties = schema.RootElement.GetProperty("properties");
+        properties.TryGetProperty("scope_id", out _).Should().BeFalse();
+        properties.TryGetProperty("owner_scope", out _).Should().BeFalse();
+        properties.TryGetProperty("nyx_api_key", out _).Should().BeFalse();
+        properties.TryGetProperty("nyx_provider_slug", out _).Should().BeFalse();
+        properties.TryGetProperty("allowed_service_ids", out _).Should().BeFalse();
+        properties.TryGetProperty("skill_content", out _).Should().BeFalse();
+        properties.TryGetProperty("provider_base_url", out _).Should().BeFalse();
+        schema.RootElement.GetProperty("required").EnumerateArray().Select(static x => x.GetString())
+            .Should().BeEquivalentTo("skill_ref", "schedule_cron", "schedule_timezone");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenNoToken_ShouldFailClosed()
+    {
+        var harness = CreateHarness();
+
+        var result = await harness.Tool.ExecuteAsync(BaseArgs);
+
+        using var document = JsonDocument.Parse(result);
+        document.RootElement.GetProperty("error").GetString().Should().Contain("access token");
+        harness.Handler.Requests.Should().BeEmpty();
+        await harness.SkillRunnerPort.DidNotReceive().InitializeAsync(
+            Arg.Any<string>(),
+            Arg.Any<InitializeSkillRunnerCommand>(),
+            Arg.Any<bool>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenCallerScopeUnavailable_ShouldFailClosedBeforeNyxCalls()
+    {
+        var harness = CreateHarness(callerScopeUnavailable: true);
+
+        await WithToolContext(async () =>
+        {
+            var result = await harness.Tool.ExecuteAsync(BaseArgs);
+
+            using var document = JsonDocument.Parse(result);
+            document.RootElement.GetProperty("error").GetString().Should().Be("caller_scope_unavailable");
+            harness.Handler.Requests.Should().BeEmpty();
+        });
+    }
+
+    [Theory]
+    [InlineData("""{"skill_ref":"","schedule_cron":"0 9 * * *","schedule_timezone":"UTC"}""")]
+    [InlineData("""{"skill_ref":"daily","schedule_cron":"","schedule_timezone":"UTC"}""")]
+    [InlineData("""{"skill_ref":"daily","schedule_cron":"0 9 * * *","schedule_timezone":""}""")]
+    [InlineData("""{"skill_ref":"daily","schedule_cron":"0 9 * * *","schedule_timezone":"UTC","nyx_api_key":"bad"}""")]
+    public async Task ExecuteAsync_InvalidRequests_ShouldFailBeforeKeyCreation(string argumentsJson)
+    {
+        var harness = CreateHarness();
+
+        await WithToolContext(async () =>
+        {
+            var result = await harness.Tool.ExecuteAsync(argumentsJson);
+
+            using var document = JsonDocument.Parse(result);
+            document.RootElement.GetProperty("error").GetString().Should().Be("validation_error");
+            harness.Handler.Requests.Should().BeEmpty();
+            await harness.SkillRunnerPort.DidNotReceive().InitializeAsync(
+                Arg.Any<string>(),
+                Arg.Any<InitializeSkillRunnerCommand>(),
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>());
+        });
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_VersionedSkillRef_ShouldReturnTypedErrorBeforeSideEffects()
+    {
+        var harness = CreateHarness();
+
+        await WithToolContext(async () =>
+        {
+            var result = await harness.Tool.ExecuteAsync("""
+                {
+                  "skill_ref": "daily@1.2",
+                  "schedule_cron": "0 9 * * *",
+                  "schedule_timezone": "UTC"
+                }
+                """);
+
+            using var document = JsonDocument.Parse(result);
+            document.RootElement.GetProperty("error").GetString().Should().Be("versioned_skill_ref_not_supported_yet");
+            document.RootElement.GetProperty("skill_ref").GetString().Should().Be("daily@1.2");
+            harness.Handler.Requests.Should().BeEmpty();
+        });
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenTrustedOutboundSlugMissing_ShouldFailClosedBeforeKeyCreation()
+    {
+        var harness = CreateHarness();
+
+        await WithToolContext(async () =>
+        {
+            AgentToolRequestContext.Current = AgentToolRequestContext.Current! with
+            {
+                ExternalMetadata = BaseExternalMetadata(includeOutboundSlug: false),
+            };
+
+            var result = await harness.Tool.ExecuteAsync(BaseArgs);
+
+            using var document = JsonDocument.Parse(result);
+            document.RootElement.GetProperty("error").GetString().Should().Be("validation_error");
+            document.RootElement.GetProperty("detail").GetString().Should().Be("lark_outbound_provider_slug_unavailable");
+            harness.Handler.Requests.Should().BeEmpty();
+        });
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenRequiredServiceMissing_ShouldFailClosedWithoutBroadKey()
+    {
+        var handler = new RoutingJsonHandler();
+        handler.Add(HttpMethod.Get, "/api/v1/user-services", """{"user_services":[{"id":"svc-lark","slug":"api-lark-bot"}]}""");
+        var harness = CreateHarness(handler: handler);
+
+        await WithToolContext(async () =>
+        {
+            var result = await harness.Tool.ExecuteAsync(BaseArgs);
+
+            using var document = JsonDocument.Parse(result);
+            document.RootElement.GetProperty("error").GetString().Should().Be("required_service_not_found:ornn-api");
+            handler.Requests.Should().ContainSingle(request => request.Method == HttpMethod.Get);
+            handler.Requests.Should().NotContain(request => request.Method == HttpMethod.Post);
+        });
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenRequiredServiceAmbiguous_ShouldFailClosedWithoutKeyCreation()
+    {
+        var handler = new RoutingJsonHandler();
+        handler.Add(HttpMethod.Get, "/api/v1/user-services", """
+            {
+              "user_services": [
+                {"id":"svc-ornn-1","slug":"ornn-api"},
+                {"id":"svc-ornn-2","slug":"ornn-api"},
+                {"id":"svc-lark","slug":"api-lark-bot"}
+              ]
+            }
+            """);
+        var harness = CreateHarness(handler: handler);
+
+        await WithToolContext(async () =>
+        {
+            var result = await harness.Tool.ExecuteAsync(BaseArgs);
+
+            using var document = JsonDocument.Parse(result);
+            document.RootElement.GetProperty("error").GetString().Should().Be("required_service_ambiguous:ornn-api");
+            handler.Requests.Should().NotContain(request => request.Method == HttpMethod.Post);
+        });
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Success_ShouldMintScopedKey_MapCommand_AndReturnAcceptedOnly()
+    {
+        var caller = OwnerScope.ForChannel("nyx-user-1", "lark", "scope-bot-1", "ou_sender");
+        var harness = CreateHarness(scope: caller);
+        InitializeSkillRunnerCommand? captured = null;
+        string? capturedAgentId = null;
+        bool? capturedRunImmediately = null;
+        harness.SkillRunnerPort.InitializeAsync(
+                Arg.Do<string>(value => capturedAgentId = value),
+                Arg.Do<InitializeSkillRunnerCommand>(value => captured = value),
+                Arg.Do<bool>(value => capturedRunImmediately = value),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        await WithToolContext(async () =>
+        {
+            var result = await harness.Tool.ExecuteAsync("""
+                {
+                  "skill_ref": "daily-report",
+                  "schedule_cron": "0 9 * * *",
+                  "schedule_timezone": "Asia/Singapore",
+                  "display_name": "Daily Report",
+                  "execution_prompt": "Send concise bullets.",
+                  "provider_name": "nyxid",
+                  "model": "gpt-5.1",
+                  "temperature": 0.2,
+                  "max_tokens": 1200,
+                  "max_tool_rounds": 6,
+                  "max_history_messages": 12,
+                  "requires_nyxid_proxy_success": true,
+                  "run_immediately": true
+                }
+                """);
+
+            using var document = JsonDocument.Parse(result);
+            document.RootElement.GetProperty("status").GetString().Should().Be("accepted");
+            document.RootElement.GetProperty("api_key_id").GetString().Should().Be("key-created");
+            document.RootElement.TryGetProperty("full_key", out _).Should().BeFalse();
+            document.RootElement.TryGetProperty("committed", out _).Should().BeFalse();
+
+            capturedAgentId.Should().StartWith("skill-runner-");
+            capturedRunImmediately.Should().BeTrue();
+            captured.Should().NotBeNull();
+            captured!.SkillName.Should().Be("daily-report");
+            captured.TemplateName.Should().Be("Daily Report");
+            captured.SkillContent.Should().Contain("Scheduled Ornn skill reference bootstrap.");
+            captured.SkillContent.Should().Contain("skill_ref: daily-report");
+            captured.ExecutionPrompt.Should().Be("Send concise bullets.");
+            captured.ScheduleCron.Should().Be("0 9 * * *");
+            captured.ScheduleTimezone.Should().Be("Asia/Singapore");
+            captured.Enabled.Should().BeTrue();
+            captured.ScopeId.Should().Be("scope-bot-1");
+            captured.ProviderName.Should().Be("nyxid");
+            captured.Model.Should().Be("gpt-5.1");
+            captured.Temperature.Should().Be(0.2);
+            captured.MaxTokens.Should().Be(1200);
+            captured.MaxToolRounds.Should().Be(6);
+            captured.MaxHistoryMessages.Should().Be(12);
+            captured.RequiresNyxidProxySuccess.Should().BeTrue();
+            captured.OutboundConfig.NyxApiKey.Should().Be("full-secret-key");
+            captured.OutboundConfig.ApiKeyId.Should().Be("key-created");
+            captured.OutboundConfig.NyxProviderSlug.Should().Be("api-lark-bot");
+            captured.OutboundConfig.FailureNotificationProviderSlug.Should().Be("api-lark-bot-inbound");
+            captured.OutboundConfig.ConversationId.Should().Be("oc_conversation");
+            captured.OutboundConfig.LarkReceiveId.Should().Be("oc_chat");
+            captured.OutboundConfig.LarkReceiveIdType.Should().Be("chat_id");
+            captured.OutboundConfig.LarkReceiveIdFallback.Should().Be("on_union");
+            captured.OutboundConfig.LarkReceiveIdTypeFallback.Should().Be("union_id");
+            captured.OutboundConfig.OwnerScope.MatchesStrictly(caller).Should().BeTrue();
+            captured.OutboundConfig.OwnerNyxUserId.Should().BeEmpty();
+            captured.OutboundConfig.Platform.Should().BeEmpty();
+
+            var createRequest = harness.Handler.Requests.Single(request => request.Method == HttpMethod.Post);
+            using var createBody = JsonDocument.Parse(createRequest.Body!);
+            createBody.RootElement.GetProperty("allow_all_services").GetBoolean().Should().BeFalse();
+            createBody.RootElement.GetProperty("allowed_service_ids").EnumerateArray().Select(static x => x.GetString())
+                .Should().BeEquivalentTo("svc-ornn", "svc-lark", "svc-lark-failure");
+        });
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenInitializeFails_ShouldBestEffortDeleteIssuedKey()
+    {
+        var harness = CreateHarness();
+        harness.SkillRunnerPort.InitializeAsync(
+                Arg.Any<string>(),
+                Arg.Any<InitializeSkillRunnerCommand>(),
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("dispatch failed"));
+
+        await WithToolContext(async () =>
+        {
+            var result = await harness.Tool.ExecuteAsync(BaseArgs);
+
+            using var document = JsonDocument.Parse(result);
+            document.RootElement.GetProperty("error").GetString().Should().Be("initialize_failed");
+            harness.Handler.Requests.Should().Contain(request =>
+                request.Method == HttpMethod.Delete &&
+                request.Path == "/api/v1/api-keys/key-created");
+        });
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldNotQueryCatalogOrPollReadModels()
+    {
+        var harness = CreateHarness();
+
+        await WithToolContext(async () =>
+        {
+            _ = await harness.Tool.ExecuteAsync(BaseArgs);
+
+            await harness.CatalogQueryPort.DidNotReceive().QueryByCallerAsync(
+                Arg.Any<OwnerScope>(),
+                Arg.Any<CancellationToken>());
+            await harness.CatalogQueryPort.DidNotReceive().GetForCallerAsync(
+                Arg.Any<string>(),
+                Arg.Any<OwnerScope>(),
+                Arg.Any<CancellationToken>());
+            await harness.CatalogQueryPort.DidNotReceive().GetStateVersionForCallerAsync(
+                Arg.Any<string>(),
+                Arg.Any<OwnerScope>(),
+                Arg.Any<CancellationToken>());
+        });
+    }
+
+    private const string BaseArgs = """
+        {
+          "skill_ref": "daily-report",
+          "schedule_cron": "0 9 * * *",
+          "schedule_timezone": "UTC"
+        }
+        """;
+
+    private static CreatorHarness CreateHarness(
+        RoutingJsonHandler? handler = null,
+        OwnerScope? scope = null,
+        bool callerScopeUnavailable = false)
+    {
+        handler ??= CreateSuccessHandler();
+
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler) { BaseAddress = new Uri("https://nyx.example.com") });
+        var nyxClientFactory = new TestNyxIdApiClientFactory(nyxClient);
+        var skillRunnerPort = Substitute.For<ISkillRunnerCommandPort>();
+        skillRunnerPort.InitializeAsync(
+                Arg.Any<string>(),
+                Arg.Any<InitializeSkillRunnerCommand>(),
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var resolver = Substitute.For<ICallerScopeResolver>();
+        var resolvedScope = callerScopeUnavailable
+            ? null
+            : scope ?? OwnerScope.ForChannel("nyx-user-1", "lark", "scope-bot-1", "ou_sender");
+        resolver.TryResolveAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<OwnerScope?>(resolvedScope));
+
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<INyxIdApiClientFactory>(nyxClientFactory);
+        services.AddSingleton(skillRunnerPort);
+        services.AddSingleton(resolver);
+        services.AddSingleton(queryPort);
+        services.AddSingleton(new ScheduledAgentCreatorOptions());
+        services.AddSingleton<ScheduledAgentCreateRequestMapper>();
+        services.AddSingleton<ScheduledAgentApiKeyIssuer>();
+
+        var provider = services.BuildServiceProvider();
+        var tool = new ScheduledAgentCreatorTool(
+            provider.GetRequiredService<ISkillRunnerCommandPort>(),
+            provider.GetRequiredService<ICallerScopeResolver>(),
+            provider.GetRequiredService<ScheduledAgentCreateRequestMapper>(),
+            provider.GetRequiredService<ScheduledAgentApiKeyIssuer>());
+
+        return new CreatorHarness(tool, handler, skillRunnerPort, queryPort);
+    }
+
+    private static RoutingJsonHandler CreateSuccessHandler()
+    {
+        var handler = new RoutingJsonHandler();
+        handler.Add(HttpMethod.Get, "/api/v1/user-services", """
+            {
+              "user_services": [
+                {"id":"svc-ornn","slug":"ornn-api"},
+                {"id":"svc-lark","slug":"api-lark-bot"},
+                {"id":"svc-lark-failure","slug":"api-lark-bot-inbound"}
+              ]
+            }
+            """);
+        handler.Add(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-created","full_key":"full-secret-key"}""");
+        handler.Add(HttpMethod.Delete, "/api/v1/api-keys/key-created", """{"ok":true}""");
+        return handler;
+    }
+
+    private static async Task WithToolContext(Func<Task> action)
+    {
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
+        {
+            Credentials = new AgentToolCredentials("session-token", "session-token", null),
+            Caller = new AgentToolCallerContext("scope-bot-1", null, "message-1"),
+            Channel = new AgentToolChannelContext("lark", "ou_sender", "scope-bot-1", "message-1", "om_1"),
+            ExternalMetadata = BaseExternalMetadata(),
+        };
+        try
+        {
+            await action();
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = null;
+        }
+    }
+
+    private static IReadOnlyDictionary<string, string> BaseExternalMetadata(bool includeOutboundSlug = true)
+    {
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [ChannelMetadataKeys.ConversationId] = "oc_conversation",
+            [ChannelMetadataKeys.ChatType] = "p2p",
+            [ChannelMetadataKeys.LarkChatId] = "oc_chat",
+            [ChannelMetadataKeys.LarkUnionId] = "on_union",
+            [ChannelMetadataKeys.InboundChannelBotProxySlug] = "api-lark-bot-inbound",
+        };
+        if (includeOutboundSlug)
+            metadata[ChannelMetadataKeys.LarkOutboundProxySlug] = "api-lark-bot";
+        return metadata;
+    }
+
+    private sealed record CreatorHarness(
+        ScheduledAgentCreatorTool Tool,
+        RoutingJsonHandler Handler,
+        ISkillRunnerCommandPort SkillRunnerPort,
+        IUserAgentCatalogQueryPort CatalogQueryPort);
+
+    private sealed class TestNyxIdApiClientFactory : INyxIdApiClientFactory
+    {
+        private readonly NyxIdApiClient _client;
+
+        public TestNyxIdApiClientFactory(NyxIdApiClient client)
+        {
+            _client = client;
+        }
+
+        public NyxIdApiClient CreateClient() => _client;
+    }
+
+    private sealed class RoutingJsonHandler : HttpMessageHandler
+    {
+        private readonly Dictionary<string, string> _responses = new(StringComparer.OrdinalIgnoreCase);
+
+        public List<RecordedRequest> Requests { get; } = [];
+
+        public void Add(HttpMethod method, string path, string json)
+        {
+            _responses[$"{method.Method}:{path}"] = json;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri?.PathAndQuery ?? string.Empty;
+            var body = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            Requests.Add(new RecordedRequest(request.Method, path, body));
+
+            return _responses.TryGetValue($"{request.Method.Method}:{path}", out var json)
+                ? new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json"),
+                }
+                : new HttpResponseMessage(HttpStatusCode.NotFound)
+                {
+                    Content = new StringContent("""{"error":true,"message":"not found"}""", Encoding.UTF8, "application/json"),
+                };
+        }
+    }
+
+    private sealed record RecordedRequest(HttpMethod Method, string Path, string? Body);
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentCreatorToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentCreatorToolTests.cs
@@ -97,6 +97,30 @@ public sealed class ScheduledAgentCreatorToolTests
         });
     }
 
+    [Theory]
+    [InlineData("not-json", "invalid JSON literal")]
+    [InlineData("""["daily","0 9 * * *","UTC"]""", "arguments must be a JSON object")]
+    public async Task ExecuteAsync_WhenArgumentsMalformed_ShouldFailBeforeKeyCreation(
+        string argumentsJson,
+        string expectedErrorFragment)
+    {
+        var harness = CreateHarness();
+
+        await WithToolContext(async () =>
+        {
+            var result = await harness.Tool.ExecuteAsync(argumentsJson);
+
+            using var document = JsonDocument.Parse(result);
+            document.RootElement.GetProperty("error").GetString().Should().Contain(expectedErrorFragment);
+            harness.Handler.Requests.Should().BeEmpty();
+            await harness.SkillRunnerPort.DidNotReceive().InitializeAsync(
+                Arg.Any<string>(),
+                Arg.Any<InitializeSkillRunnerCommand>(),
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>());
+        });
+    }
+
     [Fact]
     public async Task ExecuteAsync_VersionedSkillRef_ShouldReturnTypedErrorBeforeSideEffects()
     {
@@ -158,6 +182,34 @@ public sealed class ScheduledAgentCreatorToolTests
             document.RootElement.GetProperty("error").GetString().Should().Be("validation_error");
             document.RootElement.GetProperty("detail").GetString().Should().Be(expectedDetail);
             harness.Handler.Requests.Should().BeEmpty();
+            await harness.SkillRunnerPort.DidNotReceive().InitializeAsync(
+                Arg.Any<string>(),
+                Arg.Any<InitializeSkillRunnerCommand>(),
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>());
+        });
+    }
+
+    [Theory]
+    [InlineData("""{"error":true,"message":"service lookup denied"}""", "service_resolution_failed")]
+    [InlineData("not-json", "service_resolution_invalid_json")]
+    public async Task ExecuteAsync_WhenUserServicesResponseInvalid_ShouldFailClosedWithoutKeyCreation(
+        string servicesResponseJson,
+        string expectedError)
+    {
+        var handler = new RoutingJsonHandler();
+        handler.Add(HttpMethod.Get, "/api/v1/user-services", servicesResponseJson);
+        var harness = CreateHarness(handler: handler);
+
+        await WithToolContext(async () =>
+        {
+            var result = await harness.Tool.ExecuteAsync(BaseArgs);
+
+            using var document = JsonDocument.Parse(result);
+            document.RootElement.GetProperty("error").GetString().Should().Be(expectedError);
+            handler.Requests.Should().ContainSingle(request => request.Method == HttpMethod.Get);
+            handler.Requests.Should().NotContain(request => request.Method == HttpMethod.Post);
+            handler.Requests.Should().NotContain(request => request.Method == HttpMethod.Delete);
             await harness.SkillRunnerPort.DidNotReceive().InitializeAsync(
                 Arg.Any<string>(),
                 Arg.Any<InitializeSkillRunnerCommand>(),


### PR DESCRIPTION
## 摘要

解决 #1788：通过对话把 Ornn skill 注册为定时运行的 user agent（补 creation 入口）。

- **Gap**：现有 scheduled runner / command port / catalog / 管理工具已存在，但没有生产 caller 构造并 dispatch `InitializeSkillRunnerCommand`。
- **New**：独立 `scheduled_agent_creator` 工具（`ApprovalMode=AlwaysRequire`，不塞进 `agent_builder`），caller-scope 拥有；NyxID scoped API key（`allow_all_services=false`）；`name@version` typed unsupported error；不内联 skill_content / 不 fetch Ornn skill / 不改 proto / 不改外部仓库。

经 consensus-rnd 设计共识 r4（structural framing）。

## 范围
新增 `ScheduledAgentCreatorTool` / `ScheduledAgentCreateRequestMapper` / `ScheduledSkillReference` / `ScheduledAgentApiKeyIssuer` / `ScheduledAgentCreatorOptions` + 测试；改 `AgentBuilderToolSource`/`AuthoringServiceCollectionExtensions`/`AgentBuilderTool`/`AgentDeliveryTargetTool`/`system-prompt.md`。

独立验证：build 0 err；ChannelRuntime.Tests 1012/1012；guards 走 CI。

🤖 Auto-loop / consensus-rnd

⟦AI:AUTO-LOOP⟧
