### PR TITLE
fix(#1829): Lark 群 @ 群内回复（relay group identity + CardKit threaded reply）

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/ChannelCardConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelCardConversationTurnRunner.cs
@@ -10,8 +10,8 @@ namespace Aevatar.GAgents.NyxidChat;
 /// <summary>
 /// Production <see cref="IConversationCardTurnRunner"/> for the Lark CardKit streaming
 /// path. Composes <see cref="ILarkCardKitClient"/> (cardkit/v1/* endpoints) with
-/// <see cref="ILarkNyxClient.SendMessageAsync"/> (im/v1/messages with msg_type=interactive)
-/// to drive the create → send → stream → finalize lifecycle. Auth: bot owner's NyxID
+/// <see cref="ILarkNyxClient.SendMessageAsync"/> or <see cref="ILarkNyxClient.ReplyToMessageAsync"/>
+/// (im/v1/messages with msg_type=interactive) to drive the create → bind → stream → finalize lifecycle. Auth: bot owner's NyxID
 /// access token from <c>activity.TransportExtras.NyxUserAccessToken</c>; receive target:
 /// <c>nyx_lark_chat_id</c> for groups, falling back to <c>nyx_lark_union_id</c> for p2p
 /// DMs (cross-app safe per the proto's documented invariants).
@@ -48,10 +48,6 @@ public sealed class ChannelCardConversationTurnRunner : IConversationCardTurnRun
         if (token is null)
             return ConversationCardCreateResult.Failed("token_missing", "NyxID user access token is missing on the activity's TransportExtras.");
 
-        var receiveTarget = ResolveReceiveTarget(chunk.Activity);
-        if (receiveTarget is null)
-            return ConversationCardCreateResult.Failed("receive_target_missing", "Lark chat_id and union_id are both missing on TransportExtras.");
-
         // 1. Allocate a CardKit entity holding an empty streaming element. The first chunk's
         //    text lands via StreamElementContentAsync (step 3) so the card_json schema and
         //    the streaming wire format stay decoupled.
@@ -77,34 +73,16 @@ public sealed class ChannelCardConversationTurnRunner : IConversationCardTurnRun
         if (string.IsNullOrWhiteSpace(cardId))
             return ConversationCardCreateResult.Failed("card_id_missing", "card.create response did not include data.card_id.");
 
-        // 2. Bind the card to the chat by sending an interactive message that references it.
+        // 2. Bind the card to the chat by sending or replying with an interactive message
+        //    that references it.
         var contentJson = JsonSerializer.Serialize(
             new { type = "card", data = new { card_id = cardId } },
             JsonOptions);
-        string sendResponse;
-        try
-        {
-            sendResponse = await _larkClient.SendMessageAsync(
-                token,
-                new LarkSendMessageRequest(
-                    TargetType: receiveTarget.Value.ReceiveIdType,
-                    TargetId: receiveTarget.Value.ReceiveId,
-                    MessageType: "interactive",
-                    ContentJson: contentJson,
-                    IdempotencyKey: chunk.CorrelationId),
-                ct);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Card send-to-chat threw for correlation={CorrelationId}, card_id={CardId}", chunk.CorrelationId, cardId);
-            return ConversationCardCreateResult.Failed("card_send_threw", ex.Message);
-        }
+        var bindResult = await BindCardToConversationAsync(token, chunk, cardId, contentJson, ct);
+        if (!bindResult.Success)
+            return bindResult;
 
-        if (LarkProxyResponseParser.TryParseError(sendResponse, out var sendError))
-            return ClassifyCreateFailure("card_send_failed", sendError);
-
-        var cardMessageId = LarkProxyResponseParser.ParseSendSuccess(sendResponse).MessageId
-            ?? string.Empty;
+        var cardMessageId = bindResult.CardMessageId ?? string.Empty;
 
         // 3. Write the first chunk's text into the streaming element. Sequence = 1 (the
         //    grain pre-allocates this value; subsequent chunks pass sequence+1 each call).
@@ -316,6 +294,76 @@ public sealed class ChannelCardConversationTurnRunner : IConversationCardTurnRun
             return ("chat_id", chatId);
 
         return null;
+    }
+
+    private async Task<ConversationCardCreateResult> BindCardToConversationAsync(
+        string token,
+        LlmReplyCardStreamChunkEvent chunk,
+        string cardId,
+        string contentJson,
+        CancellationToken ct)
+    {
+        var inboundMessageId = ResolveInboundMessageId(chunk.Activity);
+        var isGroupLike = chunk.Activity?.Conversation?.Scope is ConversationScope.Group
+                                                        or ConversationScope.Channel
+                                                        or ConversationScope.Thread;
+        var shouldReplyInThread = isGroupLike && !string.IsNullOrWhiteSpace(inboundMessageId);
+        string response;
+        try
+        {
+            if (shouldReplyInThread)
+            {
+                response = await _larkClient.ReplyToMessageAsync(
+                    token,
+                    new LarkReplyMessageRequest(
+                        MessageId: inboundMessageId!,
+                        MessageType: "interactive",
+                        ContentJson: contentJson,
+                        ReplyInThread: true,
+                        IdempotencyKey: chunk.CorrelationId),
+                    ct);
+            }
+            else
+            {
+                var receiveTarget = ResolveReceiveTarget(chunk.Activity!);
+                if (receiveTarget is null)
+                    return ConversationCardCreateResult.Failed("receive_target_missing", "Lark chat_id and union_id are both missing on TransportExtras.");
+
+                response = await _larkClient.SendMessageAsync(
+                    token,
+                    new LarkSendMessageRequest(
+                        TargetType: receiveTarget.Value.ReceiveIdType,
+                        TargetId: receiveTarget.Value.ReceiveId,
+                        MessageType: "interactive",
+                        ContentJson: contentJson,
+                        IdempotencyKey: chunk.CorrelationId),
+                    ct);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Card bind-to-chat threw for correlation={CorrelationId}, card_id={CardId}", chunk.CorrelationId, cardId);
+            return ConversationCardCreateResult.Failed("card_send_threw", ex.Message);
+        }
+
+        if (LarkProxyResponseParser.TryParseError(response, out var sendError))
+            return ClassifyCreateFailure("card_send_failed", sendError);
+
+        var cardMessageId = LarkProxyResponseParser.ParseSendSuccess(response).MessageId
+            ?? string.Empty;
+        return ConversationCardCreateResult.Succeeded(cardId, cardMessageId);
+    }
+
+    private static string? ResolveInboundMessageId(ChatActivity? activity)
+    {
+        var platformMessageId = activity?.TransportExtras?.NyxPlatformMessageId?.Trim();
+        if (string.IsNullOrWhiteSpace(platformMessageId) ||
+            !platformMessageId.StartsWith("om_", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return platformMessageId;
     }
 
     /// <summary>

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
@@ -164,7 +164,6 @@ public sealed class NyxIdRelayTransport
 
     private const string CardActionContentType = "card_action";
 
-    // refactor helper, no behavior change
     private readonly record struct LarkRelayConversationFacts(
         ConversationScope? Scope,
         string? GroupConversationIdentity,

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
@@ -54,8 +54,16 @@ public sealed class NyxIdRelayTransport
             }
         }
 
+        var platform = NormalizePlatform(payload.Platform);
+        var larkFacts = ResolveLarkRelayConversationFacts(platform, payload, isCardAction);
+
         var conversationType = payload.Conversation?.Type ?? payload.Conversation?.ConversationType;
-        if (!NyxIdRelayConversationTypeMap.TryMap(conversationType, out var scope))
+        ConversationScope scope;
+        if (larkFacts.Scope is { } resolvedLarkScope)
+        {
+            scope = resolvedLarkScope;
+        }
+        else if (!NyxIdRelayConversationTypeMap.TryMap(conversationType, out scope))
         {
             if (!isCardAction)
             {
@@ -73,14 +81,27 @@ public sealed class NyxIdRelayTransport
             scope = ConversationScope.Unspecified;
         }
 
-        var platform = NormalizePlatform(payload.Platform);
         var conversationIdentity = ResolveConversationIdentity(platform, payload);
+        if (IsLark(platform) && !isCardAction && IsGroupLike(scope))
+        {
+            conversationIdentity = NormalizeOptional(larkFacts.GroupConversationIdentity)
+                ?? NormalizeOptional(payload.Conversation?.PlatformId)
+                ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(conversationIdentity))
+            {
+                return NyxIdRelayParseResult.IgnoredPayload(
+                    payload,
+                    "missing_lark_group_chat_identity",
+                    "Lark group relay payload is missing raw event.message.chat_id and conversation.platform_id.");
+            }
+        }
+
         var senderId = payload.Sender?.PlatformId?.Trim();
         var canonicalKey = BuildCanonicalKey(platform, scope, conversationIdentity, senderId);
         var partition = conversationIdentity;
         var timestamp = ParseTimestamp(payload.Timestamp);
         var botId = payload.Agent?.ApiKeyId?.Trim();
-        var platformMessageId = ResolvePlatformMessageId(payload, platform);
+        var platformMessageId = ResolvePlatformMessageId(payload, platform, larkFacts);
         var correlationId = string.IsNullOrWhiteSpace(payload.CorrelationId)
             ? payload.MessageId.Trim()
             : payload.CorrelationId.Trim();
@@ -125,13 +146,15 @@ public sealed class NyxIdRelayTransport
                 NyxMessageId = payload.MessageId.Trim(),
                 NyxAgentApiKeyId = payload.Agent?.ApiKeyId?.Trim() ?? string.Empty,
                 NyxPlatform = platform,
-                NyxConversationId = payload.Conversation?.Id?.Trim() ?? conversationIdentity,
+                NyxConversationId = NormalizeOptional(payload.Conversation?.Id) ?? conversationIdentity,
                 NyxPlatformMessageId = platformMessageId,
-                NyxLarkUnionId = ExtractLarkUnionId(platform, payload, isCardAction),
-                NyxLarkChatId = ExtractLarkChatId(platform, payload, isCardAction),
-                NyxLarkOperatorUserId = ExtractLarkOperatorId(platform, payload, "user_id"),
-                NyxLarkOperatorOpenId = ExtractLarkOperatorId(platform, payload, "open_id"),
-                NyxLarkOperatorUnionId = ExtractLarkOperatorId(platform, payload, "union_id"),
+                NyxLarkUnionId = NormalizeOptional(larkFacts.SenderUnionId)
+                    ?? NormalizeOptional(larkFacts.OperatorUnionId)
+                    ?? string.Empty,
+                NyxLarkChatId = NormalizeOptional(larkFacts.ChatId) ?? string.Empty,
+                NyxLarkOperatorUserId = NormalizeOptional(larkFacts.OperatorUserId) ?? string.Empty,
+                NyxLarkOperatorOpenId = NormalizeOptional(larkFacts.OperatorOpenId) ?? string.Empty,
+                NyxLarkOperatorUnionId = NormalizeOptional(larkFacts.OperatorUnionId) ?? string.Empty,
             },
         };
 
@@ -140,6 +163,17 @@ public sealed class NyxIdRelayTransport
     }
 
     private const string CardActionContentType = "card_action";
+
+    // refactor helper, no behavior change
+    private readonly record struct LarkRelayConversationFacts(
+        ConversationScope? Scope,
+        string? GroupConversationIdentity,
+        string? ChatId,
+        string? PlatformMessageId,
+        string? SenderUnionId,
+        string? OperatorUserId,
+        string? OperatorOpenId,
+        string? OperatorUnionId);
 
     private static string NormalizeContentType(NyxIdRelayContentPayload? content)
     {
@@ -378,58 +412,90 @@ public sealed class NyxIdRelayTransport
     private static string NormalizePlatform(string? platform) =>
         string.IsNullOrWhiteSpace(platform) ? "unknown" : platform.Trim().ToLowerInvariant();
 
-    private static string ResolvePlatformMessageId(NyxIdRelayCallbackPayload payload, string platform)
+    private static string ResolvePlatformMessageId(
+        NyxIdRelayCallbackPayload payload,
+        string platform,
+        LarkRelayConversationFacts larkFacts)
     {
         var directPlatformId = payload.PlatformMessageId?.Trim();
         if (!string.IsNullOrWhiteSpace(directPlatformId))
             return directPlatformId;
 
-        if (payload.RawPlatformData is not { } rawPlatformData)
-            return string.Empty;
-
         return platform switch
         {
-            "lark" or "feishu" => ResolveLarkPlatformMessageId(rawPlatformData),
+            "lark" or "feishu" => NormalizeOptional(larkFacts.PlatformMessageId) ?? string.Empty,
             _ => string.Empty,
         };
     }
 
-    private static string ResolveLarkPlatformMessageId(JsonElement rawPlatformData)
+    private static LarkRelayConversationFacts ResolveLarkRelayConversationFacts(
+        string platform,
+        NyxIdRelayCallbackPayload payload,
+        bool isCardAction)
     {
-        if (TryReadJsonString(rawPlatformData, out var replyTarget, "event", "context", "open_message_id"))
-            return replyTarget;
+        if (!IsLark(platform) || payload.RawPlatformData is not { } raw || raw.ValueKind != JsonValueKind.Object)
+            return default;
 
-        if (TryReadJsonString(rawPlatformData, out var messageId, "event", "message", "message_id"))
-            return messageId;
+        if (!raw.TryGetProperty("event", out var evt) || evt.ValueKind != JsonValueKind.Object)
+            return default;
 
-        return string.Empty;
-    }
-
-    private static bool TryReadJsonString(
-        JsonElement element,
-        out string value,
-        params string[] path)
-    {
-        value = string.Empty;
-        var current = element;
-        foreach (var segment in path)
+        if (isCardAction)
         {
-            if (current.ValueKind != JsonValueKind.Object ||
-                !current.TryGetProperty(segment, out current))
+            var cardChatId = string.Empty;
+            var cardPlatformMessageId = string.Empty;
+            if (evt.TryGetProperty("context", out var ctx) && ctx.ValueKind == JsonValueKind.Object)
             {
-                return false;
+                cardChatId = ReadStringProperty(ctx, "open_chat_id");
+                cardPlatformMessageId = ReadStringProperty(ctx, "open_message_id");
             }
+
+            var operatorUserId = string.Empty;
+            var operatorOpenId = string.Empty;
+            var operatorUnionId = string.Empty;
+            if (evt.TryGetProperty("operator", out var op) && op.ValueKind == JsonValueKind.Object)
+            {
+                operatorUserId = ReadStringProperty(op, "user_id");
+                operatorOpenId = ReadStringProperty(op, "open_id");
+                operatorUnionId = ReadStringProperty(op, "union_id");
+            }
+
+            return new LarkRelayConversationFacts(
+                Scope: null,
+                GroupConversationIdentity: null,
+                ChatId: cardChatId,
+                PlatformMessageId: cardPlatformMessageId,
+                SenderUnionId: null,
+                OperatorUserId: operatorUserId,
+                OperatorOpenId: operatorOpenId,
+                OperatorUnionId: operatorUnionId);
         }
 
-        if (current.ValueKind != JsonValueKind.String)
-            return false;
+        var chatId = string.Empty;
+        var platformMessageId = string.Empty;
+        ConversationScope? scope = null;
+        if (evt.TryGetProperty("message", out var message) && message.ValueKind == JsonValueKind.Object)
+        {
+            chatId = ReadStringProperty(message, "chat_id");
+            platformMessageId = ReadStringProperty(message, "message_id");
+            scope = MapLarkChatType(ReadStringProperty(message, "chat_type"));
+        }
 
-        var parsed = current.GetString()?.Trim();
-        if (string.IsNullOrWhiteSpace(parsed))
-            return false;
+        var senderUnionId = string.Empty;
+        if (evt.TryGetProperty("sender", out var sender) && sender.ValueKind == JsonValueKind.Object &&
+            sender.TryGetProperty("sender_id", out var senderId) && senderId.ValueKind == JsonValueKind.Object)
+        {
+            senderUnionId = ReadStringProperty(senderId, "union_id");
+        }
 
-        value = parsed;
-        return true;
+        return new LarkRelayConversationFacts(
+            Scope: scope,
+            GroupConversationIdentity: chatId,
+            ChatId: chatId,
+            PlatformMessageId: platformMessageId,
+            SenderUnionId: senderUnionId,
+            OperatorUserId: null,
+            OperatorOpenId: null,
+            OperatorUnionId: null);
     }
 
     private static string ResolveConversationIdentity(string platform, NyxIdRelayCallbackPayload payload)
@@ -449,88 +515,33 @@ public sealed class NyxIdRelayTransport
         return $"{platform}-conversation";
     }
 
-    /// <summary>
-    /// Extracts the Lark <c>union_id</c> (<c>on_*</c>) of the inbound sender from the relay's
-    /// <c>raw_platform_data</c>. <c>union_id</c> is tenant-stable and cross-app safe — outbound
-    /// senders running under a different Lark app than the relay-side ingress app must use this
-    /// to avoid <c>open_id cross app</c> rejections from Lark. Returns empty when the platform
-    /// is not Lark or the original event did not surface a <c>union_id</c> at the well-known
-    /// path. The empty case is normal for non-Lark traffic and for misconfigured Lark apps that
-    /// have not enabled <c>union_id</c> emission.
-    /// </summary>
-    private static string ExtractLarkUnionId(string platform, NyxIdRelayCallbackPayload payload, bool isCardAction)
-    {
-        if (!IsLark(platform) || payload.RawPlatformData is not { } raw || raw.ValueKind != JsonValueKind.Object)
-            return string.Empty;
-
-        if (!raw.TryGetProperty("event", out var evt) || evt.ValueKind != JsonValueKind.Object)
-            return string.Empty;
-
-        // Lark `im.message.receive_v1` puts sender ids under `event.sender.sender_id`. Card
-        // submissions (`card.action.trigger`) put the operator's union_id directly under
-        // `event.operator`, since there is no `sender_id` envelope on that event shape.
-        if (isCardAction)
-        {
-            if (evt.TryGetProperty("operator", out var op) && op.ValueKind == JsonValueKind.Object)
-                return ReadStringProperty(op, "union_id");
-            return string.Empty;
-        }
-
-        if (!evt.TryGetProperty("sender", out var sender) || sender.ValueKind != JsonValueKind.Object)
-            return string.Empty;
-        if (!sender.TryGetProperty("sender_id", out var senderId) || senderId.ValueKind != JsonValueKind.Object)
-            return string.Empty;
-
-        return ReadStringProperty(senderId, "union_id");
-    }
-
-    /// <summary>
-    /// Extracts the Lark <c>chat_id</c> (<c>oc_*</c>) of the inbound conversation from the
-    /// relay's <c>raw_platform_data</c>. Cross-app safe within the tenant for groups/threads/
-    /// channels — any app added to the chat can address it via <c>receive_id_type=chat_id</c>.
-    /// For p2p DMs the chat_id is bot-specific (each Lark app has its own DM thread with the
-    /// user) and not cross-app safe; downstream senders must prefer <see cref="ExtractLarkUnionId"/>
-    /// for p2p targets. Returns empty when the platform is not Lark or the event did not carry
-    /// a <c>chat_id</c> at the well-known path.
-    /// </summary>
-    private static string ExtractLarkChatId(string platform, NyxIdRelayCallbackPayload payload, bool isCardAction)
-    {
-        if (!IsLark(platform) || payload.RawPlatformData is not { } raw || raw.ValueKind != JsonValueKind.Object)
-            return string.Empty;
-
-        if (!raw.TryGetProperty("event", out var evt) || evt.ValueKind != JsonValueKind.Object)
-            return string.Empty;
-
-        if (isCardAction)
-        {
-            if (evt.TryGetProperty("context", out var ctx) && ctx.ValueKind == JsonValueKind.Object)
-                return ReadStringProperty(ctx, "open_chat_id");
-            return string.Empty;
-        }
-
-        if (!evt.TryGetProperty("message", out var message) || message.ValueKind != JsonValueKind.Object)
-            return string.Empty;
-
-        return ReadStringProperty(message, "chat_id");
-    }
-
-    private static string ExtractLarkOperatorId(string platform, NyxIdRelayCallbackPayload payload, string propertyName)
-    {
-        if (!IsLark(platform) || payload.RawPlatformData is not { } raw || raw.ValueKind != JsonValueKind.Object)
-            return string.Empty;
-
-        if (!raw.TryGetProperty("event", out var evt) || evt.ValueKind != JsonValueKind.Object)
-            return string.Empty;
-
-        if (!evt.TryGetProperty("operator", out var op) || op.ValueKind != JsonValueKind.Object)
-            return string.Empty;
-
-        return ReadStringProperty(op, propertyName);
-    }
-
     private static bool IsLark(string platform) =>
         string.Equals(platform, "lark", StringComparison.OrdinalIgnoreCase) ||
         string.Equals(platform, "feishu", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsGroupLike(ConversationScope scope) =>
+        scope is ConversationScope.Group
+              or ConversationScope.Channel
+              or ConversationScope.Thread;
+
+    private static ConversationScope? MapLarkChatType(string? chatType)
+    {
+        var normalized = NormalizeOptional(chatType)?.ToLowerInvariant();
+        return normalized switch
+        {
+            "p2p" or "private" or "dm" => ConversationScope.DirectMessage,
+            "group" => ConversationScope.Group,
+            "topic" or "thread" => ConversationScope.Thread,
+            "channel" => ConversationScope.Channel,
+            _ => null,
+        };
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        var trimmed = value?.Trim();
+        return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
+    }
 
     private static string ReadStringProperty(JsonElement element, string propertyName)
     {

--- a/docs/canon/aevatar-channel-architecture.md
+++ b/docs/canon/aevatar-channel-architecture.md
@@ -445,6 +445,8 @@ Canonical key 规则：
 | Discord Guild Channel | Channel | `discord:{guild}:{channel}` |
 | Discord Thread | Thread | `discord:{guild}:{channel}:thread:{thread_id}` |
 
+Production note: for Lark relay callbacks, `conversation.id` is the NyxID route record id; group actor identity must use platform `chat_id` from raw `event.message.chat_id` or callback `conversation.platform_id`.
+
 `ConversationGAgent` 以 `CanonicalKey` 作为 Orleans grain primary key 持久化。
 
 **为什么不用 sender 做 key（legacy 基线）**：历史上的 `ChannelUserGAgent` 以 sender id 为 key，对 Lark 1-1 能跑。一旦迁到 group / Slack thread / Discord guild，多条会话的 state 会串到同一个 actor。这是**正确性 bug**，不是优化空间。issue `#308` 已把这条 sender-keyed runtime 路径整体删除；这里保留它只是为了说明为什么后续若重建多会话 actor，仍必须坚持 canonical conversation key。

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCardConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCardConversationTurnRunnerTests.cs
@@ -137,6 +137,32 @@ public sealed class ChannelCardConversationTurnRunnerTests
     }
 
     [Fact]
+    public async Task RunCardCreateAsync_ShouldSendToChatId_WhenGroupActivityPlatformMessageIdIsNotLarkMessageId()
+    {
+        var cardKit = new RecordingCardKitClient();
+        var lark = new RecordingLarkNyxClient();
+        var runner = new ChannelCardConversationTurnRunner(
+            cardKit,
+            lark,
+            NullLogger<ChannelCardConversationTurnRunner>.Instance);
+
+        var result = await runner.RunCardCreateAsync(
+            BuildChunk(
+                "corr-card-group-route-id-1",
+                BuildSanitizedActivity(platformMessageId: "route-uuid")),
+            "streaming_main",
+            RuntimeContext("runtime-card-token-group-route-id"),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        lark.ReplyCalls.Should().BeEmpty();
+        lark.SendCalls.Should().ContainSingle();
+        lark.SendCalls[0].Request.TargetType.Should().Be("chat_id");
+        lark.SendCalls[0].Request.TargetId.Should().Be("oc_group_chat_1");
+        lark.SendCalls[0].Request.MessageType.Should().Be("interactive");
+    }
+
+    [Fact]
     public async Task RunCardCreateAsync_ShouldSendToUnionId_ForDirectMessageActivity()
     {
         var cardKit = new RecordingCardKitClient();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCardConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCardConversationTurnRunnerTests.cs
@@ -46,10 +46,125 @@ public sealed class ChannelCardConversationTurnRunnerTests
         result.ErrorCode.Should().BeEmpty();
         cardKit.CreateCalls.Should().ContainSingle();
         cardKit.CreateCalls[0].Token.Should().Be("runtime-card-token-1");
-        lark.SendCalls.Should().ContainSingle();
-        lark.SendCalls[0].Token.Should().Be("runtime-card-token-1");
+        lark.ReplyCalls.Should().ContainSingle();
+        lark.ReplyCalls[0].Token.Should().Be("runtime-card-token-1");
         cardKit.StreamCalls.Should().ContainSingle();
         cardKit.StreamCalls[0].Token.Should().Be("runtime-card-token-1");
+    }
+
+    [Fact]
+    public async Task RunCardCreateAsync_ShouldReplyInThread_ForGroupActivityWithInboundPlatformMessageId()
+    {
+        var cardKit = new RecordingCardKitClient();
+        var lark = new RecordingLarkNyxClient();
+        var runner = new ChannelCardConversationTurnRunner(
+            cardKit,
+            lark,
+            NullLogger<ChannelCardConversationTurnRunner>.Instance);
+
+        var result = await runner.RunCardCreateAsync(
+            BuildChunk("corr-card-reply-1"),
+            "streaming_main",
+            RuntimeContext("runtime-card-token-reply"),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.CardMessageId.Should().Be("om_card_reply_1");
+        lark.ReplyCalls.Should().ContainSingle();
+        lark.SendCalls.Should().BeEmpty();
+
+        var reply = lark.ReplyCalls[0];
+        reply.Token.Should().Be("runtime-card-token-reply");
+        reply.Request.MessageId.Should().Be("om_inbound_1");
+        reply.Request.MessageType.Should().Be("interactive");
+        reply.Request.ReplyInThread.Should().BeTrue();
+        reply.Request.IdempotencyKey.Should().Be("corr-card-reply-1");
+        reply.Request.ContentJson.Should().Contain("card-runtime-1");
+        cardKit.StreamCalls.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task RunCardCreateAsync_ShouldReturnCardSendFailed_WhenThreadedReplyFails()
+    {
+        var cardKit = new RecordingCardKitClient();
+        var lark = new RecordingLarkNyxClient
+        {
+            ReplyResponse = """{"code":230001,"msg":"reply rejected"}""",
+        };
+        var runner = new ChannelCardConversationTurnRunner(
+            cardKit,
+            lark,
+            NullLogger<ChannelCardConversationTurnRunner>.Instance);
+
+        var result = await runner.RunCardCreateAsync(
+            BuildChunk("corr-card-reply-fail-1"),
+            "streaming_main",
+            RuntimeContext("runtime-card-token-reply-fail"),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be("card_send_failed");
+        result.ErrorSummary.Should().Contain("lark_code=230001");
+        lark.ReplyCalls.Should().ContainSingle();
+        lark.SendCalls.Should().BeEmpty();
+        cardKit.StreamCalls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RunCardCreateAsync_ShouldSendToChatId_WhenGroupActivityHasNoInboundPlatformMessageId()
+    {
+        var cardKit = new RecordingCardKitClient();
+        var lark = new RecordingLarkNyxClient();
+        var runner = new ChannelCardConversationTurnRunner(
+            cardKit,
+            lark,
+            NullLogger<ChannelCardConversationTurnRunner>.Instance);
+
+        var result = await runner.RunCardCreateAsync(
+            BuildChunk(
+                "corr-card-group-send-1",
+                BuildSanitizedActivity(platformMessageId: string.Empty)),
+            "streaming_main",
+            RuntimeContext("runtime-card-token-group-send"),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        lark.ReplyCalls.Should().BeEmpty();
+        lark.SendCalls.Should().ContainSingle();
+        lark.SendCalls[0].Request.TargetType.Should().Be("chat_id");
+        lark.SendCalls[0].Request.TargetId.Should().Be("oc_group_chat_1");
+        lark.SendCalls[0].Request.MessageType.Should().Be("interactive");
+    }
+
+    [Fact]
+    public async Task RunCardCreateAsync_ShouldSendToUnionId_ForDirectMessageActivity()
+    {
+        var cardKit = new RecordingCardKitClient();
+        var lark = new RecordingLarkNyxClient();
+        var runner = new ChannelCardConversationTurnRunner(
+            cardKit,
+            lark,
+            NullLogger<ChannelCardConversationTurnRunner>.Instance);
+
+        var result = await runner.RunCardCreateAsync(
+            BuildChunk(
+                "corr-card-dm-send-1",
+                BuildSanitizedActivity(
+                    scope: ConversationScope.DirectMessage,
+                    partition: "route-dm-1",
+                    scopeSegment: "dm",
+                    conversationIdentity: "ou_user_1",
+                    platformMessageId: "om_dm_1")),
+            "streaming_main",
+            RuntimeContext("runtime-card-token-dm-send"),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        lark.ReplyCalls.Should().BeEmpty();
+        lark.SendCalls.Should().ContainSingle();
+        lark.SendCalls[0].Request.TargetType.Should().Be("union_id");
+        lark.SendCalls[0].Request.TargetId.Should().Be("on_union_1");
+        lark.SendCalls[0].Request.MessageType.Should().Be("interactive");
     }
 
     [Fact]
@@ -110,17 +225,22 @@ public sealed class ChannelCardConversationTurnRunnerTests
         throw new InvalidOperationException("Could not locate repository root.");
     }
 
-    private static LlmReplyCardStreamChunkEvent BuildChunk(string correlationId) =>
+    private static LlmReplyCardStreamChunkEvent BuildChunk(string correlationId, ChatActivity? activity = null) =>
         new()
         {
             CorrelationId = correlationId,
             RegistrationId = "reg-1",
-            Activity = BuildSanitizedActivity(),
+            Activity = activity ?? BuildSanitizedActivity(),
             AccumulatedText = "hello card",
             ChunkAtUnixMs = 42,
         };
 
-    private static ChatActivity BuildSanitizedActivity() =>
+    private static ChatActivity BuildSanitizedActivity(
+        ConversationScope scope = ConversationScope.Group,
+        string partition = "oc_group_chat_1",
+        string scopeSegment = "group",
+        string conversationIdentity = "oc_group_chat_1",
+        string platformMessageId = "om_inbound_1") =>
         new()
         {
             Id = "msg-card-runtime-token-1",
@@ -130,10 +250,10 @@ public sealed class ChannelCardConversationTurnRunnerTests
             Conversation = ConversationReference.Create(
                 ChannelId.From("lark"),
                 BotInstanceId.From("reg-1"),
-                ConversationScope.Group,
-                "oc_group_chat_1",
-                "group",
-                "oc_group_chat_1"),
+                scope,
+                partition,
+                scopeSegment,
+                conversationIdentity),
             From = new ParticipantRef
             {
                 CanonicalId = "ou_user_1",
@@ -144,6 +264,7 @@ public sealed class ChannelCardConversationTurnRunnerTests
             {
                 NyxPlatform = "lark",
                 NyxUserAccessToken = string.Empty,
+                NyxPlatformMessageId = platformMessageId,
                 NyxLarkChatId = "oc_group_chat_1",
                 NyxLarkUnionId = "on_union_1",
             },
@@ -183,15 +304,22 @@ public sealed class ChannelCardConversationTurnRunnerTests
     private sealed class RecordingLarkNyxClient : ILarkNyxClient
     {
         public List<(string Token, LarkSendMessageRequest Request)> SendCalls { get; } = [];
+        public List<(string Token, LarkReplyMessageRequest Request)> ReplyCalls { get; } = [];
+
+        public string SendResponse { get; set; } = """{"code":0,"data":{"message_id":"om_card_runtime_1"}}""";
+        public string ReplyResponse { get; set; } = """{"code":0,"data":{"message_id":"om_card_reply_1"}}""";
 
         public Task<string> SendMessageAsync(string token, LarkSendMessageRequest request, CancellationToken ct)
         {
             SendCalls.Add((token, request));
-            return Task.FromResult("""{"code":0,"data":{"message_id":"om_card_runtime_1"}}""");
+            return Task.FromResult(SendResponse);
         }
 
-        public Task<string> ReplyToMessageAsync(string token, LarkReplyMessageRequest request, CancellationToken ct) =>
-            throw new NotSupportedException();
+        public Task<string> ReplyToMessageAsync(string token, LarkReplyMessageRequest request, CancellationToken ct)
+        {
+            ReplyCalls.Add((token, request));
+            return Task.FromResult(ReplyResponse);
+        }
 
         public Task<string> CreateMessageReactionAsync(string token, LarkMessageReactionRequest request, CancellationToken ct) =>
             throw new NotSupportedException();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayTransportTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayTransportTests.cs
@@ -62,7 +62,7 @@ public sealed class NyxIdRelayTransportTests
               "platform": "lark",
               "reply_token": "  relay-access-token-xyz  ",
               "agent": { "api_key_id": "api-key-1" },
-              "conversation": { "id": "conv-1", "type": "group" },
+              "conversation": { "id": "conv-1", "platform_id": "oc_corr_1", "type": "group" },
               "sender": { "platform_id": "user-1" },
               "content": { "type": "text", "text": "hi" }
             }
@@ -76,65 +76,105 @@ public sealed class NyxIdRelayTransportTests
     }
 
     [Fact]
-    public void Parse_ShouldFallbackToConversationPlatformId_WhenConversationIdMissing()
+    public void Parse_ShouldFallbackToConversationPlatformId_ForLarkGroupIdentity_WhenRawChatIdMissing()
     {
         var body = """
             {
               "message_id": "msg-1",
               "platform": "lark",
               "agent": { "api_key_id": "api-key-1" },
-              "conversation": { "platform_id": "oc_platform_123", "type": "group" },
+              "conversation": { "id": "route-uuid", "platform_id": "oc_platform_1", "type": "private" },
               "sender": { "platform_id": "user-1" },
-              "content": { "type": "text", "text": "hi" }
+              "content": { "type": "text", "text": "hi" },
+              "raw_platform_data": {
+                "event": {
+                  "message": {
+                    "message_id": "om_group_1",
+                    "chat_type": "group"
+                  }
+                }
+              }
             }
             """;
 
         var parsed = _transport.Parse(Encoding.UTF8.GetBytes(body));
 
         parsed.Success.Should().BeTrue();
-        parsed.Activity!.Conversation.CanonicalKey.Should().Be("lark:group:oc_platform_123");
-        parsed.Activity.TransportExtras.NyxConversationId.Should().Be("oc_platform_123");
+        parsed.Activity!.Conversation.Scope.Should().Be(ConversationScope.Group);
+        parsed.Activity.Conversation.CanonicalKey.Should().Be("lark:group:oc_platform_1");
+        parsed.Activity.Conversation.Partition.Should().Be("oc_platform_1");
+        parsed.Activity.TransportExtras.NyxConversationId.Should().Be("route-uuid");
     }
 
     [Fact]
-    public void Parse_ShouldFallbackToSenderId_WhenConversationIdentityAbsentAndScopeIsGroup()
+    public void Parse_ShouldUseLarkRawChatId_AsGroupCanonicalIdentity_WhenRouteConversationIsDefaultOrPrivate()
     {
         var body = """
             {
               "message_id": "msg-1",
               "platform": "lark",
               "agent": { "api_key_id": "api-key-1" },
-              "conversation": { "type": "group" },
+              "conversation": { "id": "route-default-uuid", "type": "private" },
               "sender": { "platform_id": "user-42" },
-              "content": { "type": "text", "text": "hi" }
+              "content": { "type": "text", "text": "hi" },
+              "raw_platform_data": {
+                "event": {
+                  "sender": {
+                    "sender_id": {
+                      "union_id": "on_user_42"
+                    }
+                  },
+                  "message": {
+                    "message_id": "om_group_1",
+                    "chat_id": "oc_group_1",
+                    "chat_type": "group"
+                  }
+                }
+              }
             }
             """;
 
         var parsed = _transport.Parse(Encoding.UTF8.GetBytes(body));
 
         parsed.Success.Should().BeTrue();
-        parsed.Activity!.Conversation.CanonicalKey.Should().Be("lark:group:user-42");
+        parsed.Activity!.Conversation.Scope.Should().Be(ConversationScope.Group);
+        parsed.Activity.Conversation.CanonicalKey.Should().Be("lark:group:oc_group_1");
+        parsed.Activity.Conversation.Partition.Should().Be("oc_group_1");
+        parsed.Activity.TransportExtras.NyxConversationId.Should().Be("route-default-uuid");
+        parsed.Activity.TransportExtras.NyxPlatformMessageId.Should().Be("om_group_1");
+        parsed.Activity.TransportExtras.NyxLarkChatId.Should().Be("oc_group_1");
+        parsed.Activity.TransportExtras.NyxLarkUnionId.Should().Be("on_user_42");
+        parsed.Activity.Conversation.CanonicalKey.Should().NotContain("route-default-uuid");
+        parsed.Activity.Conversation.CanonicalKey.Should().NotContain("user-42");
     }
 
     [Fact]
-    public void Parse_ShouldProduceNonEmptyCanonicalKey_WhenAllConversationIdentitiesMissing()
+    public void Parse_ShouldRejectLarkGroup_WhenPlatformChatIdentityMissing()
     {
         var body = """
             {
               "message_id": "msg-1",
               "platform": "lark",
               "agent": { "api_key_id": "api-key-1" },
-              "conversation": { "type": "group" },
+              "conversation": { "id": "route-uuid", "type": "private" },
               "sender": {},
-              "content": { "type": "text", "text": "hi" }
+              "content": { "type": "text", "text": "hi" },
+              "raw_platform_data": {
+                "event": {
+                  "message": {
+                    "message_id": "om_group_missing",
+                    "chat_type": "group"
+                  }
+                }
+              }
             }
             """;
 
         var parsed = _transport.Parse(Encoding.UTF8.GetBytes(body));
 
-        parsed.Success.Should().BeTrue();
-        parsed.Activity!.Conversation.CanonicalKey.Should().NotBeNullOrWhiteSpace();
-        parsed.Activity.Conversation.CanonicalKey.Should().StartWith("lark:group:");
+        parsed.Success.Should().BeFalse();
+        parsed.Ignored.Should().BeTrue();
+        parsed.ErrorCode.Should().Be("missing_lark_group_chat_identity");
     }
 
     [Fact]
@@ -145,7 +185,7 @@ public sealed class NyxIdRelayTransportTests
               "message_id": "msg-1",
               "platform": "lark",
               "agent": { "api_key_id": "api-key-1" },
-              "conversation": { "id": "conv-1", "type": "group" },
+              "conversation": { "id": "conv-1", "platform_id": "oc_123", "type": "group" },
               "sender": { "platform_id": "user-1" },
               "content": { "type": "text", "text": "   " }
             }
@@ -180,6 +220,46 @@ public sealed class NyxIdRelayTransportTests
     }
 
     [Fact]
+    public void Parse_ShouldKeepDirectMessageCanonicalIdentity_WhenLarkChatTypeIsP2P()
+    {
+        var body = """
+            {
+              "message_id": "msg-dm-1",
+              "platform": "lark",
+              "agent": { "api_key_id": "api-key-1" },
+              "conversation": { "id": "route-dm-uuid", "platform_id": "oc_dm_chat_1", "type": "private" },
+              "sender": { "platform_id": "ou_user_1", "display_name": "User One" },
+              "content": { "type": "text", "text": "hello" },
+              "raw_platform_data": {
+                "event": {
+                  "sender": {
+                    "sender_id": {
+                      "union_id": "on_user_1"
+                    }
+                  },
+                  "message": {
+                    "message_id": "om_dm_1",
+                    "chat_id": "oc_dm_chat_1",
+                    "chat_type": "p2p"
+                  }
+                }
+              }
+            }
+            """;
+
+        var parsed = _transport.Parse(Encoding.UTF8.GetBytes(body));
+
+        parsed.Success.Should().BeTrue();
+        parsed.Activity!.Conversation.Scope.Should().Be(ConversationScope.DirectMessage);
+        parsed.Activity.Conversation.CanonicalKey.Should().Be("lark:dm:ou_user_1");
+        parsed.Activity.Conversation.Partition.Should().Be("route-dm-uuid");
+        parsed.Activity.TransportExtras.NyxConversationId.Should().Be("route-dm-uuid");
+        parsed.Activity.TransportExtras.NyxPlatformMessageId.Should().Be("om_dm_1");
+        parsed.Activity.TransportExtras.NyxLarkChatId.Should().Be("oc_dm_chat_1");
+        parsed.Activity.TransportExtras.NyxLarkUnionId.Should().Be("on_user_1");
+    }
+
+    [Fact]
     public void Parse_ShouldExposeLarkPlatformMessageId_FromRawPlatformData()
     {
         var body = """
@@ -203,6 +283,8 @@ public sealed class NyxIdRelayTransportTests
         var parsed = _transport.Parse(Encoding.UTF8.GetBytes(body));
 
         parsed.Success.Should().BeTrue();
+        parsed.Activity!.Conversation.Scope.Should().Be(ConversationScope.Group);
+        parsed.Activity.Conversation.CanonicalKey.Should().Be("lark:group:oc_123");
         parsed.Activity!.TransportExtras.NyxPlatformMessageId.Should().Be("om_123");
     }
 
@@ -451,6 +533,45 @@ public sealed class NyxIdRelayTransportTests
         cardAction.WorkflowResume.RunId.Should().Be("run-1");
         cardAction.WorkflowResume.StepId.Should().Be("step-1");
         cardAction.Arguments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_ShouldNotLetCardActionMessageChatTypeOverrideConversationScope()
+    {
+        var body = """
+            {
+              "message_id": "msg-card-chat-type",
+              "platform": "lark",
+              "agent": { "api_key_id": "api-key-1" },
+              "conversation": { "id": "conv-card-1", "platform_id": "oc_card_chat_1", "type": "private" },
+              "sender": { "platform_id": "ou_1", "display_name": "User One" },
+              "content": {
+                "content_type": "card_action",
+                "text": "{\"value\":{\"actor_id\":\"actor-1\",\"run_id\":\"run-1\",\"step_id\":\"step-1\"}}"
+              },
+              "raw_platform_data": {
+                "event": {
+                  "context": {
+                    "open_chat_id": "oc_card_chat_1",
+                    "open_message_id": "om_card_1"
+                  },
+                  "message": {
+                    "chat_id": "oc_wrong_group_1",
+                    "chat_type": "group"
+                  }
+                }
+              }
+            }
+            """;
+
+        var parsed = _transport.Parse(Encoding.UTF8.GetBytes(body));
+
+        parsed.Success.Should().BeTrue();
+        parsed.Activity!.Type.Should().Be(ActivityType.CardAction);
+        parsed.Activity.Conversation.Scope.Should().Be(ConversationScope.DirectMessage);
+        parsed.Activity.Conversation.CanonicalKey.Should().Be("lark:dm:ou_1");
+        parsed.Activity.TransportExtras.NyxLarkChatId.Should().Be("oc_card_chat_1");
+        parsed.Activity.TransportExtras.NyxPlatformMessageId.Should().Be("om_card_1");
     }
 
     [Fact]


### PR DESCRIPTION
## 摘要
解决 #1829：群里被 @ 时不在群内回复（群消息被误判为 DM，CardKit 流式卡片误发到私聊）。
- **Old**：NyxID relay 默认 `conversation.type='private'` + relay 用 NyxID `conversation.id` 作群 identity → 误判 DM。
- **New**：relay 用 raw `event.message.chat_id`（回退 `conversation.platform_id`）作群 canonical identity（`lark:group:{chat_id}`），缺失则拒绝；DM 不变；CardKit group-like + `om_*` 走 `ReplyToMessageAsync`(threaded) 回群。
经 consensus-rnd 设计共识 r2（structural）。验证：build 0 err；ChannelRuntime.Tests 1010/1010。
无 proto/外部仓库改动。

🤖 Auto-loop / consensus-rnd

⟦AI:AUTO-LOOP⟧
