### PR TITLE
feat(#1789): SkillRunner 按 Ornn 引用解析执行 skill

### DIFF
--- a/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentCreateRequestMapper.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentCreateRequestMapper.cs
@@ -121,7 +121,11 @@ internal sealed class ScheduledAgentCreateRequestMapper
         {
             SkillName = request.Reference.Name,
             TemplateName = request.DisplayName ?? request.Reference.Name,
-            SkillContent = BuildOrnnReferenceBootstrap(request.Reference.Name),
+            SkillRef = new SkillRunnerSkillReference
+            {
+                Name = request.Reference.Name,
+                Source = SkillRunnerSkillSource.Ornn,
+            },
             ExecutionPrompt = request.ExecutionPrompt ??
                               "Execute the configured Ornn skill and return plain text only.",
             ScheduleCron = request.ScheduleCron,
@@ -161,9 +165,6 @@ internal sealed class ScheduledAgentCreateRequestMapper
             RunImmediately: request.RunImmediately,
             ErrorJson: null);
     }
-
-    internal static string BuildOrnnReferenceBootstrap(string skillName) =>
-        $"Scheduled Ornn skill reference bootstrap.\nskill_ref: {skillName}\nThis is not inline skill content. Resolve the referenced Ornn skill through the standard scheduled-skill execution path; issue 1789 will replace this compatibility bootstrap with typed SkillReference execution.";
 
     private static string? Normalize(string? value)
     {

--- a/agents/Aevatar.GAgents.Scheduled/Aevatar.GAgents.Scheduled.csproj
+++ b/agents/Aevatar.GAgents.Scheduled/Aevatar.GAgents.Scheduled.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\..\src\Aevatar.AI.Abstractions\Aevatar.AI.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.AI.Core\Aevatar.AI.Core.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.AI.ToolProviders.NyxId\Aevatar.AI.ToolProviders.NyxId.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.AI.ToolProviders.Skills\Aevatar.AI.ToolProviders.Skills.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.CQRS.Core.Abstractions\Aevatar.CQRS.Core.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Core\Aevatar.CQRS.Projection.Core.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Core.Abstractions\Aevatar.CQRS.Projection.Core.Abstractions.csproj" />

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
@@ -549,8 +549,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             plan.SkillName,
             plan.SkillVersion);
         var selection = BuildWorkflowSelection(workflow);
-        var dispatchService = _workflowDispatchService ??
-                              Services.GetService<ICommandDispatchService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>>();
+        var dispatchService = _workflowDispatchService;
         if (dispatchService is null)
         {
             throw new SkillRunnerExecutionException(
@@ -891,7 +890,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
                 workflowId: normalized.WorkflowId);
         }
 
-        var fetcher = _remoteSkillFetcher ?? Services.GetService<IRemoteSkillFetcher>();
+        var fetcher = _remoteSkillFetcher;
         if (fetcher is null)
         {
             if (normalized.AllowInlineFallback && !string.IsNullOrWhiteSpace(State.SkillContent))

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
@@ -7,6 +7,8 @@ using Aevatar.AI.Core;
 using Aevatar.AI.Core.Hooks;
 using Aevatar.AI.Core.LLMProviders;
 using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.AI.ToolProviders.Skills;
+using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Attributes;
 using Aevatar.Foundation.Abstractions.TypeSystem;
@@ -14,6 +16,7 @@ using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.GAgents.Platform.Lark;
+using Aevatar.Workflow.Application.Abstractions.Runs;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
@@ -32,6 +35,8 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
     private readonly NyxIdApiClient? _nyxIdApiClient;
     private readonly ILarkOutboundDispatcher? _larkOutboundDispatcher;
     private readonly IOwnerLlmConfigSource? _ownerLlmConfigSource;
+    private readonly IRemoteSkillFetcher? _remoteSkillFetcher;
+    private readonly ICommandDispatchService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>? _workflowDispatchService;
     private readonly IClock _clock;
     private readonly ITimeZoneResolver _timeZoneResolver;
     // Per-run counter for nyxid_proxy outcomes, populated by the instance-owned
@@ -39,6 +44,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
     // The runner reads it after each ChatStreamAsync to enforce the safety net for issue
     // #439 — see EnsureToolStatusAllowsCompletion.
     private readonly SkillRunnerToolFailureCounter _toolFailureCounter;
+    private string? _systemPromptOverride;
     private ChannelScheduleRunner? _scheduler;
     private Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease? _retryLease;
 
@@ -51,6 +57,8 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         IEnumerable<IAgentToolSource>? toolSources = null,
         NyxIdApiClient? nyxIdApiClient = null,
         IOwnerLlmConfigSource? ownerLlmConfigSource = null,
+        IRemoteSkillFetcher? remoteSkillFetcher = null,
+        ICommandDispatchService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>? workflowDispatchService = null,
         IToolApprovalHandler? approvalHandler = null,
         IClock? clock = null,
         ITimeZoneResolver? timeZoneResolver = null,
@@ -64,6 +72,8 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             toolSources,
             nyxIdApiClient,
             ownerLlmConfigSource,
+            remoteSkillFetcher,
+            workflowDispatchService,
             approvalHandler,
             clock,
             timeZoneResolver,
@@ -80,6 +90,8 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         IEnumerable<IAgentToolSource>? toolSources,
         NyxIdApiClient? nyxIdApiClient,
         IOwnerLlmConfigSource? ownerLlmConfigSource,
+        IRemoteSkillFetcher? remoteSkillFetcher,
+        ICommandDispatchService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>? workflowDispatchService,
         IToolApprovalHandler? approvalHandler,
         IClock? clock,
         ITimeZoneResolver? timeZoneResolver,
@@ -96,6 +108,8 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         _nyxIdApiClient = nyxIdApiClient;
         _larkOutboundDispatcher = larkOutboundDispatcher;
         _ownerLlmConfigSource = ownerLlmConfigSource;
+        _remoteSkillFetcher = remoteSkillFetcher;
+        _workflowDispatchService = workflowDispatchService;
         _clock = clock ?? new SystemClock();
         _timeZoneResolver = timeZoneResolver ?? new TimeZoneResolver();
         _toolFailureCounter = toolMiddlewareChain.Counter;
@@ -104,6 +118,75 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
     private readonly record struct ToolMiddlewareChain(
         IReadOnlyList<IToolCallMiddleware> Middlewares,
         SkillRunnerToolFailureCounter Counter);
+
+    private sealed record SkillRunnerExecutionPlan(
+        SkillRunnerExecutionKind Kind,
+        string SkillName,
+        string SkillVersion,
+        string Instructions,
+        SkillWorkflowDescriptor? Workflow,
+        SkillRunnerSkillReference? SkillRef);
+
+    private sealed record WorkflowSelection(
+        string WorkflowId,
+        IReadOnlyList<WorkflowChatInlineYamlDocument> Documents);
+
+    private sealed record SkillRunnerExecutionResult(
+        string Output,
+        SkillRunnerExecutionKind ExecutionKind,
+        string SkillName,
+        string SkillVersion,
+        string WorkflowId,
+        WorkflowChatRunAcceptedReceipt? WorkflowReceipt)
+    {
+        public static SkillRunnerExecutionResult Prompt(
+            string output,
+            SkillRunnerExecutionPlan plan) =>
+            new(
+                output,
+                SkillRunnerExecutionKind.Prompt,
+                plan.SkillName,
+                plan.SkillVersion,
+                string.Empty,
+                null);
+
+        public static SkillRunnerExecutionResult Workflow(
+            string output,
+            SkillRunnerExecutionPlan plan,
+            WorkflowChatRunAcceptedReceipt receipt) =>
+            new(
+                output,
+                SkillRunnerExecutionKind.Workflow,
+                plan.SkillName,
+                plan.SkillVersion,
+                plan.Workflow?.WorkflowId ?? string.Empty,
+                receipt);
+    }
+
+    private sealed class SkillRunnerExecutionException : InvalidOperationException
+    {
+        public SkillRunnerExecutionException(
+            string message,
+            SkillRunnerExecutionErrorCode errorCode,
+            SkillRunnerExecutionKind executionKind = SkillRunnerExecutionKind.Unspecified,
+            string skillName = "",
+            string skillVersion = "",
+            string workflowId = "")
+            : base(message)
+        {
+            ErrorCode = errorCode;
+            ExecutionKind = executionKind;
+            SkillName = skillName;
+            SkillVersion = skillVersion;
+            WorkflowId = workflowId;
+        }
+
+        public SkillRunnerExecutionErrorCode ErrorCode { get; }
+        public SkillRunnerExecutionKind ExecutionKind { get; }
+        public string SkillName { get; }
+        public string SkillVersion { get; }
+        public string WorkflowId { get; }
+    }
 
     /// <summary>Test-only accessor for the per-run nyxid_proxy counter.</summary>
     internal SkillRunnerToolFailureCounter ToolFailureCounterForTesting => _toolFailureCounter;
@@ -146,7 +229,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             ProviderName = state.ProviderName,
             HasModel = !string.IsNullOrWhiteSpace(state.Model),
             Model = state.Model,
-            HasSystemPrompt = !string.IsNullOrWhiteSpace(state.SkillContent),
+            HasSystemPrompt = !HasSkillReference(state.SkillRef) && !string.IsNullOrWhiteSpace(state.SkillContent),
             SystemPrompt = state.SkillContent,
             HasTemperature = state.HasTemperature,
             Temperature = state.HasTemperature ? state.Temperature : null,
@@ -174,9 +257,22 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
     [EventHandler]
     public async Task HandleInitializeAsync(InitializeSkillRunnerCommand command)
     {
-        if (string.IsNullOrWhiteSpace(command.SkillContent))
+        var skillRef = NormalizeSkillReference(command.SkillRef ?? new SkillRunnerSkillReference());
+        var hasSkillRef = HasSkillReference(skillRef) && !string.IsNullOrWhiteSpace(skillRef.Name);
+        var hasInlineSkillContent = !string.IsNullOrWhiteSpace(command.SkillContent);
+        if (!hasSkillRef && !hasInlineSkillContent)
         {
-            Logger.LogWarning("Skill runner {ActorId} initialization ignored because skill_content is empty", Id);
+            Logger.LogWarning(
+                "Skill runner {ActorId} initialization ignored because skill_ref.name and legacy skill_content are both empty",
+                Id);
+            return;
+        }
+
+        if (hasSkillRef && hasInlineSkillContent && !skillRef.AllowInlineFallback)
+        {
+            Logger.LogWarning(
+                "Skill runner {ActorId} initialization ignored because skill_ref.name and skill_content were both provided without allow_inline_fallback",
+                Id);
             return;
         }
 
@@ -184,7 +280,10 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         {
             SkillName = command.SkillName?.Trim() ?? string.Empty,
             TemplateName = command.TemplateName?.Trim() ?? string.Empty,
-            SkillContent = command.SkillContent,
+            SkillContent = hasSkillRef && !skillRef.AllowInlineFallback
+                ? string.Empty
+                : command.SkillContent,
+            SkillRef = hasSkillRef ? skillRef : null,
             ExecutionPrompt = command.ExecutionPrompt?.Trim() ?? string.Empty,
             ScheduleCron = command.ScheduleCron?.Trim() ?? string.Empty,
             ScheduleTimezone = NormalizeTimezone(command.ScheduleTimezone),
@@ -231,7 +330,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         var now = _clock.UtcNow;
         try
         {
-            var output = await ExecuteSkillAsync(now, command.Reason, CancellationToken.None);
+            var result = await ExecuteSkillAsync(now, command.Reason, CancellationToken.None);
             // Streaming-edit delivery happens in-line during ExecuteSkillAsync via the
             // SkillRunnerStreamingReplySink (POST initial + PUT each delta — Lark's text-edit
             // verb; PATCH on the same path is reserved for cards). When streaming can't be
@@ -241,7 +340,15 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             await PersistDomainEventAsync(new SkillRunnerExecutionCompletedEvent
             {
                 CompletedAt = Timestamp.FromDateTimeOffset(now),
-                Output = output,
+                Output = result.Output,
+                ExecutionKind = result.ExecutionKind,
+                SkillName = result.SkillName,
+                SkillVersion = result.SkillVersion,
+                WorkflowId = result.WorkflowId,
+                WorkflowActorId = result.WorkflowReceipt?.ActorId ?? string.Empty,
+                WorkflowName = result.WorkflowReceipt?.WorkflowName ?? string.Empty,
+                WorkflowCommandId = result.WorkflowReceipt?.CommandId ?? string.Empty,
+                WorkflowCorrelationId = result.WorkflowReceipt?.CorrelationId ?? string.Empty,
             });
 
             await CancelRetryLeaseAsync(CancellationToken.None);
@@ -261,10 +368,16 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
                 return;
             }
 
+            var executionFailure = ex as SkillRunnerExecutionException;
             await PersistDomainEventAsync(new SkillRunnerExecutionFailedEvent
             {
                 FailedAt = Timestamp.FromDateTimeOffset(now),
                 Error = ex.Message,
+                ExecutionKind = executionFailure?.ExecutionKind ?? SkillRunnerExecutionKind.Unspecified,
+                SkillName = executionFailure?.SkillName ?? string.Empty,
+                SkillVersion = executionFailure?.SkillVersion ?? string.Empty,
+                WorkflowId = executionFailure?.WorkflowId ?? string.Empty,
+                ErrorCode = executionFailure?.ErrorCode ?? SkillRunnerExecutionErrorCode.Unspecified,
             });
 
             await TrySendFailureAsync(ex.Message, CancellationToken.None);
@@ -319,13 +432,28 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         await Scheduler.ScheduleNextRunAsync(CancellationToken.None);
     }
 
-    private async Task<string> ExecuteSkillAsync(DateTimeOffset now, string? reason, CancellationToken ct)
+    private async Task<SkillRunnerExecutionResult> ExecuteSkillAsync(DateTimeOffset now, string? reason, CancellationToken ct)
     {
         // Reset before each run so retries / scheduled triggers each see a clean slate.
         // The counter is populated by NyxIdProxyToolFailureCountingMiddleware as the LLM
         // fans out nyxid_proxy calls inside the ChatStreamAsync loop.
         _toolFailureCounter.Reset();
 
+        var plan = await BuildExecutionPlanAsync(ct);
+        if (plan.Kind == SkillRunnerExecutionKind.Workflow)
+            return await ExecuteWorkflowSkillAsync(plan, now, reason, ct);
+
+        return SkillRunnerExecutionResult.Prompt(
+            await ExecutePromptSkillAsync(plan, now, reason, ct),
+            plan);
+    }
+
+    private async Task<string> ExecutePromptSkillAsync(
+        SkillRunnerExecutionPlan plan,
+        DateTimeOffset now,
+        string? reason,
+        CancellationToken ct)
+    {
         var prompt = BuildExecutionPrompt(now, reason);
         var metadata = await BuildExecutionMetadataAsync(ct);
         var llmControl = await BuildExecutionLlmControlAsync(ct);
@@ -339,6 +467,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             : new SkillRunnerStreamingRunState(sink, SkillRunnerDefaults.StreamingEditThrottle, TimeProvider.System);
         try
         {
+            _systemPromptOverride = plan.Instructions;
             await foreach (var chunk in ChatStreamAsync(
                                [ContentPart.TextPart(prompt)],
                                requestId,
@@ -402,8 +531,69 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         }
         finally
         {
+            _systemPromptOverride = null;
             sink?.Dispose();
         }
+    }
+
+    private async Task<SkillRunnerExecutionResult> ExecuteWorkflowSkillAsync(
+        SkillRunnerExecutionPlan plan,
+        DateTimeOffset now,
+        string? reason,
+        CancellationToken ct)
+    {
+        var workflow = plan.Workflow ?? throw new SkillRunnerExecutionException(
+            "Workflow execution plan is missing a selected workflow.",
+            SkillRunnerExecutionErrorCode.WorkflowSelectionRequired,
+            SkillRunnerExecutionKind.Workflow,
+            plan.SkillName,
+            plan.SkillVersion);
+        var selection = BuildWorkflowSelection(workflow);
+        var dispatchService = _workflowDispatchService ??
+                              Services.GetService<ICommandDispatchService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>>();
+        if (dispatchService is null)
+        {
+            throw new SkillRunnerExecutionException(
+                "Workflow dispatch service is not available for scheduled skill runner.",
+                SkillRunnerExecutionErrorCode.WorkflowDispatchUnavailable,
+                SkillRunnerExecutionKind.Workflow,
+                plan.SkillName,
+                plan.SkillVersion,
+                workflow.WorkflowId);
+        }
+
+        var requestId = Guid.NewGuid().ToString("N");
+        var prompt = BuildExecutionPrompt(now, reason);
+        var command = new WorkflowChatRunRequest(
+            Prompt: prompt,
+            Source: WorkflowChatSource.InlineYamlBundle(
+                null,
+                selection.Documents),
+            SessionId: requestId,
+            Metadata: await BuildExecutionMetadataAsync(ct),
+            ScopeId: State.ScopeId,
+            LlmControl: ToWorkflowLlmControl(await BuildExecutionLlmControlAsync(ct)),
+            CallerCredential: new WorkflowCallerCredential(State.OutboundConfig?.NyxApiKey),
+            CommandIdSeed: requestId,
+            CorrelationIdSeed: requestId);
+
+        var result = await dispatchService.DispatchAsync(command, ct);
+        if (!result.Succeeded || result.Receipt is null)
+        {
+            throw new SkillRunnerExecutionException(
+                $"Workflow start failed: {result.Error}",
+                SkillRunnerExecutionErrorCode.WorkflowDispatchRejected,
+                SkillRunnerExecutionKind.Workflow,
+                plan.SkillName,
+                plan.SkillVersion,
+                workflow.WorkflowId);
+        }
+
+        var receipt = result.Receipt;
+        var output =
+            $"Workflow start accepted: workflow_id={workflow.WorkflowId}, actor_id={receipt.ActorId}, command_id={receipt.CommandId}, correlation_id={receipt.CorrelationId}.";
+        await SendOutputAsync(output, ct);
+        return SkillRunnerExecutionResult.Workflow(output, plan, receipt);
     }
 
     /// <summary>
@@ -632,6 +822,225 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
                 "Refusing to record this run as a successful execution.");
         }
     }
+
+    protected override string DecorateSystemPrompt(string basePrompt) =>
+        _systemPromptOverride ?? base.DecorateSystemPrompt(basePrompt);
+
+    private async Task<SkillRunnerExecutionPlan> BuildExecutionPlanAsync(CancellationToken ct)
+    {
+        var skillRef = State.SkillRef;
+        if (HasSkillReference(skillRef))
+            return await BuildRemoteExecutionPlanAsync(skillRef, ct);
+
+        if (string.IsNullOrWhiteSpace(State.SkillContent))
+        {
+            throw new SkillRunnerExecutionException(
+                "Skill runner requires either skill_ref.name or legacy skill_content.",
+                SkillRunnerExecutionErrorCode.SkillReferenceRequired);
+        }
+
+        return new SkillRunnerExecutionPlan(
+            SkillRunnerExecutionKind.Prompt,
+            State.SkillName ?? string.Empty,
+            string.Empty,
+            State.SkillContent,
+            null,
+            null);
+    }
+
+    private async Task<SkillRunnerExecutionPlan> BuildRemoteExecutionPlanAsync(
+        SkillRunnerSkillReference skillRef,
+        CancellationToken ct)
+    {
+        var normalized = NormalizeSkillReference(skillRef);
+        if (!string.IsNullOrEmpty(normalized.Version))
+        {
+            throw new SkillRunnerExecutionException(
+                "Versioned scheduled skill references are not supported yet.",
+                SkillRunnerExecutionErrorCode.SkillVersionUnsupported,
+                skillName: normalized.Name,
+                skillVersion: normalized.Version,
+                workflowId: normalized.WorkflowId);
+        }
+
+        if (string.IsNullOrWhiteSpace(normalized.Name))
+        {
+            if (normalized.AllowInlineFallback && !string.IsNullOrWhiteSpace(State.SkillContent))
+            {
+                return new SkillRunnerExecutionPlan(
+                    SkillRunnerExecutionKind.Prompt,
+                    State.SkillName ?? string.Empty,
+                    string.Empty,
+                    State.SkillContent,
+                    null,
+                    normalized);
+            }
+
+            throw new SkillRunnerExecutionException(
+                "Scheduled skill reference name is required.",
+                SkillRunnerExecutionErrorCode.SkillReferenceRequired);
+        }
+
+        if (normalized.Source != SkillRunnerSkillSource.Ornn)
+        {
+            throw new SkillRunnerExecutionException(
+                "Scheduled skill runner only supports Ornn skill references.",
+                SkillRunnerExecutionErrorCode.SkillReferenceRequired,
+                skillName: normalized.Name,
+                skillVersion: normalized.Version,
+                workflowId: normalized.WorkflowId);
+        }
+
+        var fetcher = _remoteSkillFetcher ?? Services.GetService<IRemoteSkillFetcher>();
+        if (fetcher is null)
+        {
+            if (normalized.AllowInlineFallback && !string.IsNullOrWhiteSpace(State.SkillContent))
+            {
+                return new SkillRunnerExecutionPlan(
+                    SkillRunnerExecutionKind.Prompt,
+                    normalized.Name,
+                    string.Empty,
+                    State.SkillContent,
+                    null,
+                    normalized);
+            }
+
+            throw new SkillRunnerExecutionException(
+                "Remote skill fetcher is not available for scheduled skill runner.",
+                SkillRunnerExecutionErrorCode.SkillFetcherUnavailable,
+                skillName: normalized.Name,
+                skillVersion: normalized.Version,
+                workflowId: normalized.WorkflowId);
+        }
+
+        var skill = await fetcher.FetchSkillAsync(State.OutboundConfig?.NyxApiKey ?? string.Empty, normalized.Name, ct);
+        if (skill is null)
+        {
+            if (normalized.AllowInlineFallback && !string.IsNullOrWhiteSpace(State.SkillContent))
+            {
+                return new SkillRunnerExecutionPlan(
+                    SkillRunnerExecutionKind.Prompt,
+                    normalized.Name,
+                    string.Empty,
+                    State.SkillContent,
+                    null,
+                    normalized);
+            }
+
+            throw new SkillRunnerExecutionException(
+                $"Scheduled skill '{normalized.Name}' was not found.",
+                SkillRunnerExecutionErrorCode.SkillNotFound,
+                skillName: normalized.Name,
+                skillVersion: normalized.Version,
+                workflowId: normalized.WorkflowId);
+        }
+
+        var selectedWorkflow = SelectWorkflow(skill, normalized);
+        var instructions = string.IsNullOrWhiteSpace(skill.Instructions)
+            ? State.SkillContent
+            : skill.Instructions;
+        return new SkillRunnerExecutionPlan(
+            selectedWorkflow is null ? SkillRunnerExecutionKind.Prompt : SkillRunnerExecutionKind.Workflow,
+            string.IsNullOrWhiteSpace(skill.Name) ? normalized.Name : skill.Name.Trim(),
+            normalized.Version,
+            instructions ?? string.Empty,
+            selectedWorkflow,
+            normalized);
+    }
+
+    private static SkillRunnerSkillReference NormalizeSkillReference(SkillRunnerSkillReference skillRef)
+    {
+        var normalized = skillRef.Clone();
+        normalized.Name = normalized.Name?.Trim() ?? string.Empty;
+        normalized.Version = normalized.Version?.Trim() ?? string.Empty;
+        normalized.WorkflowId = normalized.WorkflowId?.Trim() ?? string.Empty;
+        if (normalized.Source == SkillRunnerSkillSource.Unspecified)
+            normalized.Source = SkillRunnerSkillSource.Ornn;
+        return normalized;
+    }
+
+    private SkillWorkflowDescriptor? SelectWorkflow(
+        SkillDefinition skill,
+        SkillRunnerSkillReference skillRef)
+    {
+        var workflows = skill.Workflows?
+            .Where(static workflow => workflow.WorkflowYamls.Any(static yaml => !string.IsNullOrWhiteSpace(yaml)))
+            .ToArray() ?? [];
+        if (workflows.Length == 0)
+            return null;
+
+        if (!string.IsNullOrWhiteSpace(skillRef.WorkflowId))
+        {
+            var selected = workflows.FirstOrDefault(workflow =>
+                string.Equals(workflow.WorkflowId?.Trim(), skillRef.WorkflowId, StringComparison.OrdinalIgnoreCase));
+            if (selected is null)
+            {
+                throw new SkillRunnerExecutionException(
+                    $"Workflow '{skillRef.WorkflowId}' was not found in scheduled skill '{skillRef.Name}'.",
+                    SkillRunnerExecutionErrorCode.WorkflowNotFound,
+                    SkillRunnerExecutionKind.Workflow,
+                    skill.Name,
+                    skillRef.Version,
+                    skillRef.WorkflowId);
+            }
+
+            return selected;
+        }
+
+        if (workflows.Length > 1)
+        {
+            throw new SkillRunnerExecutionException(
+                $"Scheduled skill '{skillRef.Name}' has multiple workflows; skill_ref.workflow_id is required.",
+                SkillRunnerExecutionErrorCode.WorkflowSelectionRequired,
+                SkillRunnerExecutionKind.Workflow,
+                skill.Name,
+                skillRef.Version);
+        }
+
+        return workflows[0];
+    }
+
+    private static WorkflowSelection BuildWorkflowSelection(SkillWorkflowDescriptor workflow)
+    {
+        var workflowId = workflow.WorkflowId?.Trim() ?? string.Empty;
+        if (string.IsNullOrEmpty(workflowId))
+        {
+            throw new SkillRunnerExecutionException(
+                "Selected workflow descriptor has no workflow_id.",
+                SkillRunnerExecutionErrorCode.WorkflowSelectionRequired,
+                SkillRunnerExecutionKind.Workflow);
+        }
+
+        var documents = workflow.WorkflowYamls
+            .Where(static yaml => !string.IsNullOrWhiteSpace(yaml))
+            .Select(static yaml => new WorkflowChatInlineYamlDocument(string.Empty, yaml.Trim()))
+            .ToArray();
+        if (documents.Length == 0)
+        {
+            throw new SkillRunnerExecutionException(
+                $"Selected workflow '{workflowId}' has no workflow YAML.",
+                SkillRunnerExecutionErrorCode.WorkflowNotFound,
+                SkillRunnerExecutionKind.Workflow,
+                workflowId: workflowId);
+        }
+
+        return new WorkflowSelection(workflowId, documents);
+    }
+
+    private static WorkflowLlmControl ToWorkflowLlmControl(LLMControlContext llmControl) =>
+        new(
+            ModelOverride: llmControl.ModelOverride,
+            MaxToolRoundsOverride: llmControl.MaxToolRoundsOverride,
+            UserMemoryPrompt: llmControl.UserMemoryPrompt,
+            RoutePreference: llmControl.NyxIdRoutePreference);
+
+    private static bool HasSkillReference(SkillRunnerSkillReference? skillRef) =>
+        skillRef is not null &&
+        (!string.IsNullOrWhiteSpace(skillRef.Name) ||
+         !string.IsNullOrWhiteSpace(skillRef.Version) ||
+         !string.IsNullOrWhiteSpace(skillRef.WorkflowId) ||
+         skillRef.Source != SkillRunnerSkillSource.Unspecified ||
+         skillRef.AllowInlineFallback);
 
     private AgentToolExecutionContext BuildExecutionToolContext(
         string requestId,
@@ -1024,6 +1433,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         next.SkillName = evt.SkillName ?? string.Empty;
         next.TemplateName = evt.TemplateName ?? string.Empty;
         next.SkillContent = evt.SkillContent ?? string.Empty;
+        next.SkillRef = evt.SkillRef?.Clone();
         next.ExecutionPrompt = evt.ExecutionPrompt ?? string.Empty;
         next.ScheduleCron = evt.ScheduleCron ?? string.Empty;
         next.ScheduleTimezone = NormalizeTimezone(evt.ScheduleTimezone);

--- a/agents/Aevatar.GAgents.Scheduled/protos/skill_runner.proto
+++ b/agents/Aevatar.GAgents.Scheduled/protos/skill_runner.proto
@@ -9,6 +9,38 @@ import "agent_messages.proto";
 
 // ─── Skill Runner (persistent scheduled agent) ───
 
+enum SkillRunnerSkillSource {
+  SKILL_RUNNER_SKILL_SOURCE_UNSPECIFIED = 0;
+  SKILL_RUNNER_SKILL_SOURCE_ORNN = 1;
+}
+
+enum SkillRunnerExecutionKind {
+  SKILL_RUNNER_EXECUTION_KIND_UNSPECIFIED = 0;
+  SKILL_RUNNER_EXECUTION_KIND_PROMPT = 1;
+  SKILL_RUNNER_EXECUTION_KIND_WORKFLOW = 2;
+}
+
+enum SkillRunnerExecutionErrorCode {
+  SKILL_RUNNER_EXECUTION_ERROR_CODE_UNSPECIFIED = 0;
+  SKILL_RUNNER_EXECUTION_ERROR_CODE_SKILL_REFERENCE_REQUIRED = 1;
+  SKILL_RUNNER_EXECUTION_ERROR_CODE_INLINE_FALLBACK_DISABLED = 2;
+  SKILL_RUNNER_EXECUTION_ERROR_CODE_SKILL_FETCHER_UNAVAILABLE = 3;
+  SKILL_RUNNER_EXECUTION_ERROR_CODE_SKILL_NOT_FOUND = 4;
+  SKILL_RUNNER_EXECUTION_ERROR_CODE_SKILL_VERSION_UNSUPPORTED = 5;
+  SKILL_RUNNER_EXECUTION_ERROR_CODE_WORKFLOW_SELECTION_REQUIRED = 6;
+  SKILL_RUNNER_EXECUTION_ERROR_CODE_WORKFLOW_NOT_FOUND = 7;
+  SKILL_RUNNER_EXECUTION_ERROR_CODE_WORKFLOW_DISPATCH_UNAVAILABLE = 8;
+  SKILL_RUNNER_EXECUTION_ERROR_CODE_WORKFLOW_DISPATCH_REJECTED = 9;
+}
+
+message SkillRunnerSkillReference {
+  string name = 1;
+  string version = 2;
+  SkillRunnerSkillSource source = 3;
+  string workflow_id = 4;
+  bool allow_inline_fallback = 5;
+}
+
 message SkillRunnerOutboundConfig {
   string conversation_id = 1;
   string nyx_provider_slug = 2;
@@ -74,6 +106,7 @@ message SkillRunnerState {
   // by the original safety net, which only fired when ≥1 nyxid_proxy call had
   // failed. Skills that don't fan out to nyxid_proxy at all leave this false.
   bool requires_nyxid_proxy_success = 21;
+  SkillRunnerSkillReference skill_ref = 22;
 }
 
 message SkillRunnerExecutionDocument {
@@ -112,6 +145,7 @@ message InitializeSkillRunnerCommand {
   optional int32 max_history_messages = 15;
   // See SkillRunnerState.requires_nyxid_proxy_success for semantics.
   bool requires_nyxid_proxy_success = 16;
+  SkillRunnerSkillReference skill_ref = 17;
 }
 
 message SkillRunnerInitializedEvent {
@@ -132,6 +166,7 @@ message SkillRunnerInitializedEvent {
   optional int32 max_history_messages = 15;
   // See SkillRunnerState.requires_nyxid_proxy_success for semantics.
   bool requires_nyxid_proxy_success = 16;
+  SkillRunnerSkillReference skill_ref = 17;
 }
 
 message TriggerSkillRunnerExecutionCommand {
@@ -149,11 +184,24 @@ message SkillRunnerNextRunScheduledEvent {
 message SkillRunnerExecutionCompletedEvent {
   google.protobuf.Timestamp completed_at = 1;
   string output = 2;
+  SkillRunnerExecutionKind execution_kind = 3;
+  string skill_name = 4;
+  string skill_version = 5;
+  string workflow_id = 6;
+  string workflow_actor_id = 7;
+  string workflow_name = 8;
+  string workflow_command_id = 9;
+  string workflow_correlation_id = 10;
 }
 
 message SkillRunnerExecutionFailedEvent {
   google.protobuf.Timestamp failed_at = 1;
   string error = 2;
+  SkillRunnerExecutionKind execution_kind = 3;
+  string skill_name = 4;
+  string skill_version = 5;
+  string workflow_id = 6;
+  SkillRunnerExecutionErrorCode error_code = 7;
 }
 
 message SkillRunnerExecutionRejectedEvent {

--- a/docs/canon/aevatar-channel-architecture.md
+++ b/docs/canon/aevatar-channel-architecture.md
@@ -1264,6 +1264,14 @@ public static class GAgentSchedulingExtensions {
 
 **为什么不继承**：Orleans `GAgentBase<TState, TEvent>` 的继承链已经够深。再加一层中间基类会让诊断/反射/序列化复杂化。composition over inheritance：`ISchedulable` 做 capability 标记，extension method 提供共享逻辑，`ScheduleState` 做数据容器。
 
+### 7.2.1 Scheduled SkillRunner remote skill contract
+
+Scheduled SkillRunner stores the executable remote identity as typed `skill_ref` instead of encoding an Ornn lookup hint inside `skill_content`. `skill_ref.name` and legacy inline `skill_content` are mutually exclusive by default; inline fallback is a compatibility path only when `allow_inline_fallback=true`.
+
+For `skill_ref.source=ORNN` with empty `version`, every trigger fetches the current `SkillDefinition` through `IRemoteSkillFetcher` using the owner Nyx token from the runner outbound configuration. The runner does not keep a service cache, registry, or versioned package download layer. Non-empty `skill_ref.version` fails before fetch; this avoids silently treating a versioned request as latest.
+
+Prompt-only skills continue through `ChatStreamAsync`, with the fetched instructions used only as the current run's system prompt override. Workflow-bearing skills do not ask the LLM to decide workflow startup; `SkillRunnerGAgent` maps the selected descriptor to `WorkflowChatSource.InlineYamlBundle` and dispatches `WorkflowChatRunRequest` through the existing workflow command dispatch service. The returned workflow receipt is accepted-only: it means the workflow run command was accepted for dispatch, not that the workflow completed or its read model is visible.
+
 ### 7.3 `AgentRegistry → UserAgentCatalog` 改名
 
 ChannelRuntime 里的 `AgentRegistryGAgent` 和平台级 `Aevatar.GAgents.Registry.GAgentRegistryGAgent` 命名冲突——前者是"用户所有 SkillRunner/WorkflowAgent 的执行状态目录"，后者是"平台 actor 类型注册表"。两者职责本来就不同，原命名是历史遗留。

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnRemoteSkillFetcher.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnRemoteSkillFetcher.cs
@@ -30,7 +30,10 @@ public sealed class OrnnRemoteSkillFetcher : IRemoteSkillFetcher
 
         if (skill.Files != null && skill.Files.Count > 0)
         {
-            if (skill.Files.TryGetValue("SKILL.md", out var skillMd))
+            var skillMd = skill.Files
+                .FirstOrDefault(f => f.Key.Equals("SKILL.md", StringComparison.OrdinalIgnoreCase))
+                .Value;
+            if (skillMd is not null)
                 instructions = skillMd;
 
             var others = skill.Files

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/SkillWorkflowsWiringTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/SkillWorkflowsWiringTests.cs
@@ -72,6 +72,33 @@ public sealed class SkillWorkflowsWiringTests
     }
 
     [Fact]
+    public async Task OrnnRemoteSkillFetcher_ReadsSkillMarkdownCaseInsensitively()
+    {
+        var handler = OrnnTestHttpMessageHandler.ReturningJson("""
+            {
+              "data": {
+                "name": "Translator",
+                "files": {
+                  "skill.md": "---\nname: translator\n---\nUse lowercase file name.",
+                  "workflows/translate.yaml": "name: translate_flow\nsteps:\n  - id: do\n",
+                  "docs/readme.md": "reference"
+                }
+              }
+            }
+            """);
+        var client = CreateClient(handler);
+        var fetcher = new OrnnRemoteSkillFetcher(client);
+
+        var skill = await fetcher.FetchSkillAsync("token", "Translator");
+
+        skill.Should().NotBeNull();
+        skill!.Name.Should().Be("translator");
+        skill.Instructions.Should().Be("Use lowercase file name.");
+        skill.AssociatedFiles.Should().NotContainKey("skill.md");
+        skill.AssociatedFiles.Should().ContainKey("docs/readme.md");
+    }
+
+    [Fact]
     public async Task UseSkillTool_RendersWorkflowsSectionWithStartWorkflowInstructions()
     {
         var catalog = new LocalSkillCatalog();

--- a/test/Aevatar.Architecture.Tests/Rules/LayerDependencyTests.cs
+++ b/test/Aevatar.Architecture.Tests/Rules/LayerDependencyTests.cs
@@ -43,6 +43,27 @@ public class LayerDependencyTests
     }
 
     [Fact]
+    public void ScheduledAgents_ShouldUseSkillsAbstractionWithoutDependingOnOrnnProvider()
+    {
+        var root = FindRepositoryRoot();
+        var projectPath = Path.Combine(root, "agents", "Aevatar.GAgents.Scheduled", "Aevatar.GAgents.Scheduled.csproj");
+        var project = File.ReadAllText(projectPath);
+
+        Assert.Contains(
+            "Aevatar.AI.ToolProviders.Skills.csproj",
+            project,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "Aevatar.Workflow.Application.Abstractions.csproj",
+            project,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "Aevatar.AI.ToolProviders.Ornn.csproj",
+            project,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void WorkflowCore_ShouldNot_DependOn_AICore()
     {
         IArchRule rule = Types().That()

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentCreatorToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentCreatorToolTests.cs
@@ -336,8 +336,12 @@ public sealed class ScheduledAgentCreatorToolTests
             captured.Should().NotBeNull();
             captured!.SkillName.Should().Be("daily-report");
             captured.TemplateName.Should().Be("Daily Report");
-            captured.SkillContent.Should().Contain("Scheduled Ornn skill reference bootstrap.");
-            captured.SkillContent.Should().Contain("skill_ref: daily-report");
+            captured.SkillContent.Should().BeEmpty();
+            captured.SkillRef.Should().NotBeNull();
+            captured.SkillRef.Name.Should().Be("daily-report");
+            captured.SkillRef.Source.Should().Be(SkillRunnerSkillSource.Ornn);
+            captured.SkillRef.Version.Should().BeEmpty();
+            captured.SkillRef.AllowInlineFallback.Should().BeFalse();
             captured.ExecutionPrompt.Should().Be("Send concise bullets.");
             captured.ScheduleCron.Should().Be("0 9 * * *");
             captured.ScheduleTimezone.Should().Be("Asia/Singapore");

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerCommandPortTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerCommandPortTests.cs
@@ -40,6 +40,34 @@ public sealed class SkillRunnerCommandPortTests
     }
 
     [Fact]
+    public async Task InitializeAsync_WithSkillRef_PreservesTypedReferenceInEnvelope()
+    {
+        var fixture = new Fixture();
+        fixture.Runtime.GetAsync(AgentId).Returns(Task.FromResult<IActor?>(Substitute.For<IActor>()));
+
+        var command = new InitializeSkillRunnerCommand
+        {
+            SkillName = "demo",
+            SkillRef = new SkillRunnerSkillReference
+            {
+                Name = "daily-report",
+                Source = SkillRunnerSkillSource.Ornn,
+                WorkflowId = "daily_flow",
+            },
+        };
+
+        await fixture.Port.InitializeAsync(AgentId, command, runImmediately: false, CancellationToken.None);
+
+        fixture.Captured.Should().ContainSingle();
+        var initialized = fixture.Captured[0].Payload.Unpack<InitializeSkillRunnerCommand>();
+        initialized.SkillRef.Should().NotBeNull();
+        initialized.SkillRef.Name.Should().Be("daily-report");
+        initialized.SkillRef.Source.Should().Be(SkillRunnerSkillSource.Ornn);
+        initialized.SkillRef.WorkflowId.Should().Be("daily_flow");
+        initialized.SkillContent.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task InitializeAsync_WhenRunImmediatelyTrue_DispatchesInitializeThenTrigger_WithCreateAgentReason()
     {
         var fixture = new Fixture();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -6,6 +6,8 @@ using System.Text.Json;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.AI.ToolProviders.Skills;
+using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Projection.Runtime.Abstractions;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.Foundation.Abstractions;
@@ -15,6 +17,7 @@ using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.GAgents.Platform.Lark;
 using Aevatar.GAgents.Scheduled;
+using Aevatar.Workflow.Application.Abstractions.Runs;
 using FluentAssertions;
 using Google.Protobuf;
 using Microsoft.Extensions.DependencyInjection;
@@ -96,6 +99,76 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         _agent.State.HasMaxTokens.Should().BeTrue();
         _agent.State.MaxTokens.Should().Be(0);
         _agent.EffectiveConfig.MaxTokens.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandleInitializeAsync_WithSkillRefOnly_ShouldPersistTypedReferenceAndNoInlineContent()
+    {
+        var command = CreateInitializeCommand();
+        command.SkillContent = string.Empty;
+        command.SkillRef = new SkillRunnerSkillReference
+        {
+            Name = "daily-report",
+            Source = SkillRunnerSkillSource.Ornn,
+        };
+
+        await _agent.HandleInitializeAsync(command);
+
+        var persisted = await _store.GetEventsAsync("skill-runner-test");
+        var initialized = persisted.Should().ContainSingle().Subject.EventData.Unpack<SkillRunnerInitializedEvent>();
+        initialized.SkillRef.Should().NotBeNull();
+        initialized.SkillRef.Name.Should().Be("daily-report");
+        initialized.SkillRef.Source.Should().Be(SkillRunnerSkillSource.Ornn);
+        initialized.SkillContent.Should().BeEmpty();
+        _agent.State.SkillRef.Name.Should().Be("daily-report");
+        _agent.State.SkillContent.Should().BeEmpty();
+        _agent.EffectiveConfig.SystemPrompt.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleInitializeAsync_WithLegacyInlineOnly_ShouldStillInitialize()
+    {
+        await _agent.HandleInitializeAsync(CreateInitializeCommand());
+
+        _agent.State.SkillRef.Should().BeNull();
+        _agent.State.SkillContent.Should().Be("You are a summary report runner.");
+        _agent.EffectiveConfig.SystemPrompt.Should().Be("You are a summary report runner.");
+    }
+
+    [Fact]
+    public async Task HandleInitializeAsync_WithSkillRefAndInlineContentWithoutFallback_ShouldReject()
+    {
+        var command = CreateInitializeCommand();
+        command.SkillRef = new SkillRunnerSkillReference
+        {
+            Name = "daily-report",
+            Source = SkillRunnerSkillSource.Ornn,
+        };
+
+        await _agent.HandleInitializeAsync(command);
+
+        var persisted = await _store.GetEventsAsync("skill-runner-test");
+        persisted.Should().BeEmpty();
+        _agent.State.Enabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HandleInitializeAsync_WithSkillRefAndInlineFallback_ShouldPersistBoth()
+    {
+        var command = CreateInitializeCommand();
+        command.SkillRef = new SkillRunnerSkillReference
+        {
+            Name = "daily-report",
+            Source = SkillRunnerSkillSource.Ornn,
+            AllowInlineFallback = true,
+        };
+
+        await _agent.HandleInitializeAsync(command);
+
+        _agent.State.SkillRef.Name.Should().Be("daily-report");
+        _agent.State.SkillRef.AllowInlineFallback.Should().BeTrue();
+        _agent.State.SkillContent.Should().Be("You are a summary report runner.");
+        _agent.EffectiveConfig.SystemPrompt.Should().BeEmpty();
     }
 
     [Fact]
@@ -982,6 +1055,233 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ExecuteSkillAsync_RemotePromptSkill_ShouldFetchAndUseInstructionsAsSystemPromptWithoutPersisting()
+    {
+        var fetcher = new SequencedRemoteSkillFetcher(
+            RemotePromptSkill("daily-report", "Remote system prompt."));
+        var provider = new StubStreamingProviderFactory("remote output");
+        var agent = CreateAgent(
+            "skill-runner-remote-prompt",
+            providerFactory: provider,
+            remoteSkillFetcher: fetcher);
+        await agent.ActivateAsync();
+        await agent.HandleInitializeAsync(CreateSkillRefCommand("daily-report"));
+        AttachNyxIdApiClient(agent, new RecordingHandler("""{"code":0,"msg":"success","data":{"message_id":"om_remote"}}"""));
+
+        var result = await InvokeExecuteSkillResultAsync(agent);
+
+        result.Output.Should().Be("remote output");
+        result.ExecutionKind.Should().Be(SkillRunnerExecutionKind.Prompt);
+        fetcher.Requests.Should().ContainSingle().Which.Should().Be(("nyx-api-key", "daily-report"));
+        provider.Requests.Should().ContainSingle();
+        provider.Requests[0].Messages[0].Content.Should().Be("Remote system prompt.");
+        agent.State.SkillContent.Should().BeEmpty();
+        agent.EffectiveConfig.SystemPrompt.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExecuteSkillAsync_RemotePromptSkill_ShouldFetchEachTriggerAndNotCacheInstructions()
+    {
+        var fetcher = new SequencedRemoteSkillFetcher(
+            RemotePromptSkill("daily-report", "Remote prompt v1."),
+            RemotePromptSkill("daily-report", "Remote prompt v2."));
+        var provider = new StubStreamingProviderFactory(
+            new StubStreamingTurn(["first"]),
+            new StubStreamingTurn(["second"]));
+        var agent = CreateAgent(
+            "skill-runner-remote-no-cache",
+            providerFactory: provider,
+            remoteSkillFetcher: fetcher);
+        await agent.ActivateAsync();
+        await agent.HandleInitializeAsync(CreateSkillRefCommand("daily-report"));
+        AttachNyxIdApiClient(agent, new SequencedHandler(
+            """{"code":0,"msg":"success","data":{"message_id":"om_1"}}""",
+            """{"code":0,"msg":"success","data":{"message_id":"om_2"}}"""));
+
+        await agent.HandleTriggerAsync(new TriggerSkillRunnerExecutionCommand { Reason = "manual" });
+        await agent.HandleTriggerAsync(new TriggerSkillRunnerExecutionCommand { Reason = "manual" });
+
+        fetcher.Requests.Should().HaveCount(2);
+        provider.Requests.Should().HaveCount(2);
+        provider.Requests[0].Messages[0].Content.Should().Be("Remote prompt v1.");
+        provider.Requests[1].Messages[0].Content.Should().Be("Remote prompt v2.");
+        agent.State.SkillContent.Should().BeEmpty();
+        var completed = (await _store.GetEventsAsync("skill-runner-remote-no-cache"))
+            .Select(x => x.EventData)
+            .Where(x => x.Is(SkillRunnerExecutionCompletedEvent.Descriptor))
+            .Select(x => x.Unpack<SkillRunnerExecutionCompletedEvent>())
+            .ToArray();
+        completed.Should().HaveCount(2);
+        completed.Should().OnlyContain(x =>
+            x.ExecutionKind == SkillRunnerExecutionKind.Prompt &&
+            x.SkillName == "daily-report" &&
+            string.IsNullOrEmpty(x.SkillVersion));
+    }
+
+    [Fact]
+    public async Task ExecuteSkillAsync_RemoteWorkflowSkill_ShouldDispatchWorkflowAndSkipLlm()
+    {
+        var fetcher = new SequencedRemoteSkillFetcher(new SkillDefinition
+        {
+            Name = "workflow-skill",
+            Description = "workflow",
+            Instructions = "Do not use LLM.",
+            Source = SkillSource.Remote,
+            Workflows =
+            [
+                new SkillWorkflowDescriptor
+                {
+                    WorkflowId = "daily_flow",
+                    WorkflowYamls =
+                    [
+                        "name: daily_flow\nsteps: []\n",
+                    ],
+                },
+            ],
+        });
+        var provider = new StubStreamingProviderFactory("should-not-run");
+        var workflowDispatch = new RecordingWorkflowDispatchService(
+            CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>.Success(
+                new WorkflowChatRunAcceptedReceipt("workflow-run-1", "daily_flow", "cmd-1", "corr-1")));
+        var agent = CreateAgent(
+            "skill-runner-remote-workflow",
+            providerFactory: provider,
+            remoteSkillFetcher: fetcher,
+            workflowDispatchService: workflowDispatch);
+        await agent.ActivateAsync();
+        var command = CreateSkillRefCommand("workflow-skill");
+        command.SkillRef.WorkflowId = "daily_flow";
+        await agent.HandleInitializeAsync(command);
+        AttachNyxIdApiClient(agent, new RecordingHandler("""{"code":0,"msg":"success","data":{"message_id":"om_workflow"}}"""));
+
+        var result = await InvokeExecuteSkillResultAsync(agent);
+
+        provider.Requests.Should().BeEmpty("workflow-bearing remote skills dispatch workflow directly");
+        workflowDispatch.Commands.Should().ContainSingle();
+        var dispatched = workflowDispatch.Commands[0];
+        dispatched.Source.Kind.Should().Be(WorkflowChatSourceKind.InlineYamlBundle);
+        dispatched.Source.InlineBundle!.YamlDocuments.Should().ContainSingle()
+            .Which.Yaml.Should().Contain("name: daily_flow");
+        dispatched.Prompt.Should().Contain("Run the report.");
+        dispatched.ScopeId.Should().Be("scope-1");
+        dispatched.CallerCredential!.BearerToken.Should().Be("nyx-api-key");
+        result.ExecutionKind.Should().Be(SkillRunnerExecutionKind.Workflow);
+        result.WorkflowReceipt.Should().NotBeNull();
+        result.WorkflowReceipt!.CommandId.Should().Be("cmd-1");
+        result.Output.Should().Contain("Workflow start accepted");
+    }
+
+    [Fact]
+    public async Task ExecuteSkillAsync_VersionedSkillRef_ShouldFailBeforeFetch()
+    {
+        var fetcher = new SequencedRemoteSkillFetcher(RemotePromptSkill("daily-report", "unused"));
+        var agent = CreateAgent("skill-runner-versioned", remoteSkillFetcher: fetcher);
+        await agent.ActivateAsync();
+        var command = CreateSkillRefCommand("daily-report");
+        command.SkillRef.Version = "1.2";
+        await agent.HandleInitializeAsync(command);
+
+        var act = () => InvokeExecuteSkillResultAsync(agent);
+
+        var assertion = await act.Should().ThrowAsync<InvalidOperationException>();
+        assertion.WithMessage("*Versioned scheduled skill references are not supported yet*");
+        fetcher.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExecuteSkillAsync_MultipleWorkflowsWithoutWorkflowId_ShouldFailClosed()
+    {
+        var fetcher = new SequencedRemoteSkillFetcher(new SkillDefinition
+        {
+            Name = "workflow-skill",
+            Description = "workflow",
+            Instructions = "body",
+            Source = SkillSource.Remote,
+            Workflows =
+            [
+                new SkillWorkflowDescriptor
+                {
+                    WorkflowId = "one",
+                    WorkflowYamls = ["name: one\nsteps: []\n"],
+                },
+                new SkillWorkflowDescriptor
+                {
+                    WorkflowId = "two",
+                    WorkflowYamls = ["name: two\nsteps: []\n"],
+                },
+            ],
+        });
+        var workflowDispatch = new RecordingWorkflowDispatchService(
+            CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>.Success(
+                new WorkflowChatRunAcceptedReceipt("actor", "one", "cmd", "corr")));
+        var agent = CreateAgent(
+            "skill-runner-multi-workflow",
+            remoteSkillFetcher: fetcher,
+            workflowDispatchService: workflowDispatch);
+        await agent.ActivateAsync();
+        await agent.HandleInitializeAsync(CreateSkillRefCommand("workflow-skill"));
+
+        var act = () => InvokeExecuteSkillResultAsync(agent);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*has multiple workflows*workflow_id is required*");
+        workflowDispatch.Commands.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExecuteSkillAsync_UnknownWorkflowId_ShouldFailClosed()
+    {
+        var fetcher = new SequencedRemoteSkillFetcher(new SkillDefinition
+        {
+            Name = "workflow-skill",
+            Description = "workflow",
+            Instructions = "body",
+            Source = SkillSource.Remote,
+            Workflows =
+            [
+                new SkillWorkflowDescriptor
+                {
+                    WorkflowId = "known",
+                    WorkflowYamls = ["name: known\nsteps: []\n"],
+                },
+            ],
+        });
+        var agent = CreateAgent("skill-runner-unknown-workflow", remoteSkillFetcher: fetcher);
+        await agent.ActivateAsync();
+        var command = CreateSkillRefCommand("workflow-skill");
+        command.SkillRef.WorkflowId = "missing";
+        await agent.HandleInitializeAsync(command);
+
+        var act = () => InvokeExecuteSkillResultAsync(agent);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Workflow 'missing' was not found*");
+    }
+
+    [Fact]
+    public async Task ExecuteSkillAsync_InlineFallback_ShouldOnlyRunWhenExplicitlyAllowed()
+    {
+        var provider = new StubStreamingProviderFactory("fallback output");
+        var agent = CreateAgent("skill-runner-inline-fallback", providerFactory: provider);
+        await agent.ActivateAsync();
+        var command = CreateInitializeCommand();
+        command.SkillRef = new SkillRunnerSkillReference
+        {
+            Name = "remote-down",
+            Source = SkillRunnerSkillSource.Ornn,
+            AllowInlineFallback = true,
+        };
+        await agent.HandleInitializeAsync(command);
+        AttachNyxIdApiClient(agent, new RecordingHandler("""{"code":0,"msg":"success","data":{"message_id":"om_fallback"}}"""));
+
+        var result = await InvokeExecuteSkillResultAsync(agent);
+
+        result.Output.Should().Be("fallback output");
+        provider.Requests.Should().ContainSingle();
+        provider.Requests[0].Messages[0].Content.Should().Be("You are a summary report runner.");
+    }
+
+    [Fact]
     public async Task ExecuteSkillAsync_OverLimitOutput_ShouldUseDocxDecisionReply_WhenLinkReturned()
     {
         var output = new string('x', SkillRunnerStreamingReplySink.MaxLarkTextLength + 100);
@@ -1158,15 +1458,56 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
 
     private static async Task<string> InvokeExecuteSkillAsync(SkillRunnerGAgent agent)
     {
+        var result = await InvokeExecuteSkillResultObjectAsync(agent);
+        return ReadRequiredProperty<string>(result, "Output");
+    }
+
+    private static async Task<SkillRunnerExecutionResultSnapshot> InvokeExecuteSkillResultAsync(
+        SkillRunnerGAgent agent)
+    {
+        var result = await InvokeExecuteSkillResultObjectAsync(agent);
+        return new SkillRunnerExecutionResultSnapshot(
+            ReadRequiredProperty<string>(result, "Output"),
+            ReadRequiredProperty<SkillRunnerExecutionKind>(result, "ExecutionKind"),
+            ReadRequiredProperty<string>(result, "SkillName"),
+            ReadRequiredProperty<string>(result, "SkillVersion"),
+            ReadRequiredProperty<string>(result, "WorkflowId"),
+            ReadProperty<WorkflowChatRunAcceptedReceipt>(result, "WorkflowReceipt"));
+    }
+
+    private static async Task<object> InvokeExecuteSkillResultObjectAsync(SkillRunnerGAgent agent)
+    {
         var method = typeof(SkillRunnerGAgent).GetMethod(
             "ExecuteSkillAsync",
             BindingFlags.Instance | BindingFlags.NonPublic);
         method.Should().NotBeNull();
-        var task = (Task<string>)method!.Invoke(
+        var task = (Task)method!.Invoke(
             agent,
             [new DateTimeOffset(2026, 5, 19, 9, 0, 0, TimeSpan.Zero), "test", CancellationToken.None])!;
-        return await task;
+        await task;
+        var resultProperty = task.GetType().GetProperty("Result");
+        resultProperty.Should().NotBeNull();
+        return resultProperty!.GetValue(task)!;
     }
+
+    private static T ReadRequiredProperty<T>(object instance, string propertyName) =>
+        ReadProperty<T>(instance, propertyName)
+        ?? throw new InvalidOperationException($"Property {propertyName} was null.");
+
+    private static T? ReadProperty<T>(object instance, string propertyName)
+    {
+        var property = instance.GetType().GetProperty(propertyName);
+        property.Should().NotBeNull();
+        return (T?)property!.GetValue(instance);
+    }
+
+    private sealed record SkillRunnerExecutionResultSnapshot(
+        string Output,
+        SkillRunnerExecutionKind ExecutionKind,
+        string SkillName,
+        string SkillVersion,
+        string WorkflowId,
+        WorkflowChatRunAcceptedReceipt? WorkflowReceipt);
 
     private static object CreateStreamingRunState(
         SkillRunnerStreamingReplySink sink,
@@ -1342,13 +1683,17 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         ServiceProvider? serviceProvider = null,
         IOwnerLlmConfigSource? ownerLlmConfigSource = null,
         ILLMProviderFactory? providerFactory = null,
-        IEnumerable<IAgentToolSource>? toolSources = null)
+        IEnumerable<IAgentToolSource>? toolSources = null,
+        IRemoteSkillFetcher? remoteSkillFetcher = null,
+        ICommandDispatchService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>? workflowDispatchService = null)
     {
         var resolvedServices = serviceProvider ?? _serviceProvider;
         var agent = new SkillRunnerGAgent(
             llmProviderFactory: providerFactory,
             ownerLlmConfigSource: ownerLlmConfigSource,
-            toolSources: toolSources)
+            toolSources: toolSources,
+            remoteSkillFetcher: remoteSkillFetcher,
+            workflowDispatchService: workflowDispatchService)
         {
             Services = resolvedServices,
             EventSourcingBehaviorFactory =
@@ -1391,6 +1736,28 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         },
     };
 
+    private static InitializeSkillRunnerCommand CreateSkillRefCommand(string name)
+    {
+        var command = CreateInitializeCommand();
+        command.SkillContent = string.Empty;
+        command.SkillName = name;
+        command.TemplateName = name;
+        command.SkillRef = new SkillRunnerSkillReference
+        {
+            Name = name,
+            Source = SkillRunnerSkillSource.Ornn,
+        };
+        return command;
+    }
+
+    private static SkillDefinition RemotePromptSkill(string name, string instructions) => new()
+    {
+        Name = name,
+        Description = "remote prompt skill",
+        Instructions = instructions,
+        Source = SkillSource.Remote,
+    };
+
     private static void AssignActorId(GAgentBase agent, string actorId)
     {
         var setIdMethod = typeof(GAgentBase).GetMethod(
@@ -1425,6 +1792,37 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         public ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;
         public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
             Task.FromResult(result);
+    }
+
+    private sealed class SequencedRemoteSkillFetcher(params SkillDefinition?[] skills) : IRemoteSkillFetcher
+    {
+        private readonly Queue<SkillDefinition?> _skills = new(skills);
+
+        public List<(string AccessToken, string NameOrId)> Requests { get; } = [];
+
+        public Task<SkillDefinition?> FetchSkillAsync(
+            string accessToken,
+            string nameOrId,
+            CancellationToken ct = default)
+        {
+            Requests.Add((accessToken, nameOrId));
+            return Task.FromResult(_skills.Count == 0 ? null : _skills.Dequeue());
+        }
+    }
+
+    private sealed class RecordingWorkflowDispatchService(
+        CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError> result)
+        : ICommandDispatchService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>
+    {
+        public List<WorkflowChatRunRequest> Commands { get; } = [];
+
+        public Task<CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>> DispatchAsync(
+            WorkflowChatRunRequest command,
+            CancellationToken ct = default)
+        {
+            Commands.Add(command);
+            return Task.FromResult(result);
+        }
     }
 
     private sealed class StubStreamingProviderFactory : ILLMProviderFactory, ILLMProvider

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -1282,6 +1282,143 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task HandleTriggerAsync_RemoteSkillWithoutFetcher_ShouldPersistFetcherUnavailableFailure()
+    {
+        var provider = new StubStreamingProviderFactory("should-not-run");
+        var agent = CreateAgent("skill-runner-missing-fetcher", providerFactory: provider);
+        await agent.ActivateAsync();
+        await agent.HandleInitializeAsync(CreateSkillRefCommand("daily-report"));
+
+        var failed = await TriggerExhaustedAndReadFailureAsync(
+            _store,
+            "skill-runner-missing-fetcher",
+            agent);
+
+        failed.ErrorCode.Should().Be(SkillRunnerExecutionErrorCode.SkillFetcherUnavailable);
+        failed.SkillName.Should().Be("daily-report");
+        failed.SkillVersion.Should().BeEmpty();
+        failed.WorkflowId.Should().BeEmpty();
+        provider.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleTriggerAsync_RemoteSkillNotFound_ShouldPersistSkillNotFoundFailure()
+    {
+        var fetcher = new SequencedRemoteSkillFetcher((SkillDefinition?)null);
+        var provider = new StubStreamingProviderFactory("should-not-run");
+        var agent = CreateAgent(
+            "skill-runner-skill-not-found",
+            providerFactory: provider,
+            remoteSkillFetcher: fetcher);
+        await agent.ActivateAsync();
+        await agent.HandleInitializeAsync(CreateSkillRefCommand("daily-report"));
+
+        var failed = await TriggerExhaustedAndReadFailureAsync(
+            _store,
+            "skill-runner-skill-not-found",
+            agent);
+
+        failed.ErrorCode.Should().Be(SkillRunnerExecutionErrorCode.SkillNotFound);
+        failed.SkillName.Should().Be("daily-report");
+        failed.SkillVersion.Should().BeEmpty();
+        failed.WorkflowId.Should().BeEmpty();
+        fetcher.Requests.Should().ContainSingle().Which.Should().Be(("nyx-api-key", "daily-report"));
+        provider.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleTriggerAsync_WorkflowSkillWithoutDispatchService_ShouldPersistDispatchUnavailableFailure()
+    {
+        var fetcher = new SequencedRemoteSkillFetcher(RemoteWorkflowSkill("workflow-skill", "daily_flow"));
+        var provider = new StubStreamingProviderFactory("should-not-run");
+        var agent = CreateAgent(
+            "skill-runner-workflow-dispatch-missing",
+            providerFactory: provider,
+            remoteSkillFetcher: fetcher);
+        await agent.ActivateAsync();
+        var command = CreateSkillRefCommand("workflow-skill");
+        command.SkillRef.WorkflowId = "daily_flow";
+        await agent.HandleInitializeAsync(command);
+
+        var failed = await TriggerExhaustedAndReadFailureAsync(
+            _store,
+            "skill-runner-workflow-dispatch-missing",
+            agent);
+
+        failed.ErrorCode.Should().Be(SkillRunnerExecutionErrorCode.WorkflowDispatchUnavailable);
+        failed.ExecutionKind.Should().Be(SkillRunnerExecutionKind.Workflow);
+        failed.SkillName.Should().Be("workflow-skill");
+        failed.WorkflowId.Should().Be("daily_flow");
+        provider.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleTriggerAsync_WorkflowDispatchRejected_ShouldPersistDispatchRejectedFailure()
+    {
+        var fetcher = new SequencedRemoteSkillFetcher(RemoteWorkflowSkill("workflow-skill", "daily_flow"));
+        var provider = new StubStreamingProviderFactory("should-not-run");
+        var workflowDispatch = new RecordingWorkflowDispatchService(
+            CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>.Failure(
+                WorkflowChatRunStartError.WorkflowNotFound));
+        var agent = CreateAgent(
+            "skill-runner-workflow-dispatch-rejected",
+            providerFactory: provider,
+            remoteSkillFetcher: fetcher,
+            workflowDispatchService: workflowDispatch);
+        await agent.ActivateAsync();
+        var command = CreateSkillRefCommand("workflow-skill");
+        command.SkillRef.WorkflowId = "daily_flow";
+        await agent.HandleInitializeAsync(command);
+
+        var failed = await TriggerExhaustedAndReadFailureAsync(
+            _store,
+            "skill-runner-workflow-dispatch-rejected",
+            agent);
+
+        failed.ErrorCode.Should().Be(SkillRunnerExecutionErrorCode.WorkflowDispatchRejected);
+        failed.ExecutionKind.Should().Be(SkillRunnerExecutionKind.Workflow);
+        failed.SkillName.Should().Be("workflow-skill");
+        failed.WorkflowId.Should().Be("daily_flow");
+        failed.Error.Should().Contain(nameof(WorkflowChatRunStartError.WorkflowNotFound));
+        workflowDispatch.Commands.Should().ContainSingle();
+        provider.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleTriggerAsync_WorkflowDispatchAccepted_ShouldPersistWorkflowReceiptFields()
+    {
+        var fetcher = new SequencedRemoteSkillFetcher(RemoteWorkflowSkill("workflow-skill", "daily_flow"));
+        var provider = new StubStreamingProviderFactory("should-not-run");
+        var workflowDispatch = new RecordingWorkflowDispatchService(
+            CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>.Success(
+                new WorkflowChatRunAcceptedReceipt("workflow-run-1", "daily_flow", "cmd-1", "corr-1")));
+        var agent = CreateAgent(
+            "skill-runner-workflow-trigger-success",
+            providerFactory: provider,
+            remoteSkillFetcher: fetcher,
+            workflowDispatchService: workflowDispatch);
+        await agent.ActivateAsync();
+        var command = CreateSkillRefCommand("workflow-skill");
+        command.SkillRef.WorkflowId = "daily_flow";
+        await agent.HandleInitializeAsync(command);
+        AttachNyxIdApiClient(agent, new RecordingHandler("""{"code":0,"msg":"success","data":{"message_id":"om_workflow"}}"""));
+
+        await agent.HandleTriggerAsync(new TriggerSkillRunnerExecutionCommand { Reason = "manual" });
+
+        var completed = await ReadSingleCompletedEventAsync(_store, "skill-runner-workflow-trigger-success");
+        completed.ExecutionKind.Should().Be(SkillRunnerExecutionKind.Workflow);
+        completed.SkillName.Should().Be("workflow-skill");
+        completed.WorkflowId.Should().Be("daily_flow");
+        completed.WorkflowActorId.Should().Be("workflow-run-1");
+        completed.WorkflowName.Should().Be("daily_flow");
+        completed.WorkflowCommandId.Should().Be("cmd-1");
+        completed.WorkflowCorrelationId.Should().Be("corr-1");
+        completed.Output.Should().Contain("Workflow start accepted");
+        workflowDispatch.Commands.Should().ContainSingle();
+        provider.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task ExecuteSkillAsync_OverLimitOutput_ShouldUseDocxDecisionReply_WhenLinkReturned()
     {
         var output = new string('x', SkillRunnerStreamingReplySink.MaxLarkTextLength + 100);
@@ -1473,6 +1610,47 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
             ReadRequiredProperty<string>(result, "SkillVersion"),
             ReadRequiredProperty<string>(result, "WorkflowId"),
             ReadProperty<WorkflowChatRunAcceptedReceipt>(result, "WorkflowReceipt"));
+    }
+
+    private static async Task<SkillRunnerExecutionFailedEvent> TriggerExhaustedAndReadFailureAsync(
+        InMemoryEventStore store,
+        string actorId,
+        SkillRunnerGAgent agent)
+    {
+        await agent.HandleTriggerAsync(new TriggerSkillRunnerExecutionCommand
+        {
+            Reason = "manual",
+            RetryAttempt = SkillRunnerDefaults.MaxRetryAttempts,
+        });
+        return await ReadSingleFailedEventAsync(store, actorId);
+    }
+
+    private static async Task<SkillRunnerExecutionFailedEvent> ReadSingleFailedEventAsync(
+        InMemoryEventStore store,
+        string actorId)
+    {
+        var persisted = await store.GetEventsAsync(actorId);
+        return persisted
+            .Select(x => x.EventData)
+            .Where(x => x.Is(SkillRunnerExecutionFailedEvent.Descriptor))
+            .Select(x => x.Unpack<SkillRunnerExecutionFailedEvent>())
+            .Should()
+            .ContainSingle()
+            .Subject;
+    }
+
+    private static async Task<SkillRunnerExecutionCompletedEvent> ReadSingleCompletedEventAsync(
+        InMemoryEventStore store,
+        string actorId)
+    {
+        var persisted = await store.GetEventsAsync(actorId);
+        return persisted
+            .Select(x => x.EventData)
+            .Where(x => x.Is(SkillRunnerExecutionCompletedEvent.Descriptor))
+            .Select(x => x.Unpack<SkillRunnerExecutionCompletedEvent>())
+            .Should()
+            .ContainSingle()
+            .Subject;
     }
 
     private static async Task<object> InvokeExecuteSkillResultObjectAsync(SkillRunnerGAgent agent)
@@ -1756,6 +1934,22 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         Description = "remote prompt skill",
         Instructions = instructions,
         Source = SkillSource.Remote,
+    };
+
+    private static SkillDefinition RemoteWorkflowSkill(string name, string workflowId) => new()
+    {
+        Name = name,
+        Description = "remote workflow skill",
+        Instructions = "workflow instructions",
+        Source = SkillSource.Remote,
+        Workflows =
+        [
+            new SkillWorkflowDescriptor
+            {
+                WorkflowId = workflowId,
+                WorkflowYamls = [$"name: {workflowId}\nsteps: []\n"],
+            },
+        ],
     };
 
     private static void AssignActorId(GAgentBase agent, string actorId)


### PR DESCRIPTION
## 摘要
解决 #1789：SkillRunner 按 Ornn 引用解析执行 skill（去内联 skill_content；workflow 型确定性执行）。
- **Old**：scheduled SkillRunner 要求内联 skill_content，无法按引用解析。
- **New**：skill_runner.proto 增 SkillReference/Source/ExecutionKind + typed 执行观测；SkillRunnerGAgent per-trigger FetchSkillAsync；prompt branch system-prompt override；workflow branch **inline private mapper 直接 dispatch**（不新增 Starter 类）；version 非空 fail-before-fetch；不依赖 Ornn ToolProvider。
经 consensus-rnd 设计共识 r4（structural）。验证：build 0 err；ChannelRuntime 1050/1050；Architecture 125/126；Ornn 132/132。

🤖 Auto-loop / consensus-rnd

⟦AI:AUTO-LOOP⟧
