### PR TITLE
fix(#1759): scope-services invoke-readiness catalog（actor-owned + canonical reason）

### DIFF
--- a/src/platform/Aevatar.GAgentService.Abstractions/Aevatar.GAgentService.Abstractions.csproj
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Aevatar.GAgentService.Abstractions.csproj
@@ -28,6 +28,7 @@
     <Protobuf Include="Protos/service_revision.proto" GrpcServices="None" ProtoRoot="Protos" />
     <Protobuf Include="Protos/service_deployment.proto" GrpcServices="None" ProtoRoot="Protos" />
     <Protobuf Include="Protos/service_serving.proto" GrpcServices="None" ProtoRoot="Protos" />
+    <Protobuf Include="Protos/service_invocation_catalog.proto" GrpcServices="None" ProtoRoot="Protos" />
     <Protobuf Include="Protos/service_runs.proto" GrpcServices="None" ProtoRoot="Protos" />
     <Protobuf Include="Protos/llm_sessions.proto" GrpcServices="None" ProtoRoot="Protos" AdditionalImportDirs="..\..\Aevatar.AI.Abstractions;..\..\Aevatar.Foundation.VoicePresence.Abstractions" />
   </ItemGroup>

--- a/src/platform/Aevatar.GAgentService.Abstractions/Ports/IServiceCommandTargetProvisioner.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Ports/IServiceCommandTargetProvisioner.cs
@@ -23,4 +23,8 @@ public interface IServiceCommandTargetProvisioner
     Task<string> EnsureRolloutTargetAsync(
         ServiceIdentity identity,
         CancellationToken ct = default);
+
+    Task<string> EnsureInvocationCatalogTargetAsync(
+        ServiceIdentity identity,
+        CancellationToken ct = default);
 }

--- a/src/platform/Aevatar.GAgentService.Abstractions/Ports/IServiceInvocationCatalogQueryReader.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Ports/IServiceInvocationCatalogQueryReader.cs
@@ -1,0 +1,10 @@
+using Aevatar.GAgentService.Abstractions.Queries;
+
+namespace Aevatar.GAgentService.Abstractions.Ports;
+
+public interface IServiceInvocationCatalogQueryReader
+{
+    Task<ServiceInvocationCatalogSnapshot?> GetAsync(
+        ServiceIdentity identity,
+        CancellationToken ct = default);
+}

--- a/src/platform/Aevatar.GAgentService.Abstractions/Protos/service_invocation_catalog.proto
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Protos/service_invocation_catalog.proto
@@ -1,0 +1,79 @@
+syntax = "proto3";
+
+package aevatar.gagentservice;
+
+option csharp_namespace = "Aevatar.GAgentService.Abstractions";
+
+import "google/protobuf/timestamp.proto";
+import "service_endpoint.proto";
+import "service_revision.proto";
+import "service_serving.proto";
+
+enum ServiceInvokeReadinessStatus {
+  SERVICE_INVOKE_READINESS_STATUS_UNSPECIFIED = 0;
+  SERVICE_INVOKE_READINESS_STATUS_READY = 1;
+  SERVICE_INVOKE_READINESS_STATUS_UNAVAILABLE = 2;
+}
+
+enum ServiceInvokeUnavailableReason {
+  SERVICE_INVOKE_UNAVAILABLE_REASON_UNSPECIFIED = 0;
+  SERVICE_INVOKE_UNAVAILABLE_REASON_SERVING_TARGET_MISSING = 1;
+  SERVICE_INVOKE_UNAVAILABLE_REASON_PREPARED_ARTIFACT_MISSING = 2;
+  SERVICE_INVOKE_UNAVAILABLE_REASON_REVISION_NOT_PREPARED = 3;
+}
+
+message ServiceInvocationCatalogEntryState {
+  string endpoint_id = 1;
+  ServiceInvokeReadinessStatus readiness_status = 2;
+  ServiceInvokeUnavailableReason unavailable_reason = 3;
+  string selected_revision_id = 4;
+  string selected_deployment_id = 5;
+  string selected_actor_id = 6;
+}
+
+message ServiceInvocationCatalogState {
+  ServiceIdentity identity = 1;
+  repeated ServiceEndpointDescriptor service_endpoints = 2;
+  repeated ServiceServingTargetSpec serving_targets = 3;
+  map<string, ServiceRevisionRecordState> revisions = 4;
+  repeated ServiceInvocationCatalogEntryState entries = 5;
+  int64 source_catalog_version = 6;
+  int64 source_serving_version = 7;
+  int64 source_revision_version = 8;
+  google.protobuf.Timestamp observed_at = 9;
+  int64 last_applied_event_version = 10;
+  string last_event_id = 11;
+}
+
+message ObserveServiceInvocationCatalogCommand {
+  ServiceIdentity identity = 1;
+  repeated ServiceEndpointDescriptor service_endpoints = 2;
+  int64 source_catalog_version = 3;
+  google.protobuf.Timestamp observed_at = 4;
+}
+
+message ObserveServiceInvocationServingCommand {
+  ServiceIdentity identity = 1;
+  repeated ServiceServingTargetSpec serving_targets = 2;
+  int64 source_serving_version = 3;
+  google.protobuf.Timestamp observed_at = 4;
+}
+
+message ObserveServiceInvocationRevisionsCommand {
+  ServiceIdentity identity = 1;
+  map<string, ServiceRevisionRecordState> revisions = 2;
+  int64 source_revision_version = 3;
+  google.protobuf.Timestamp observed_at = 4;
+}
+
+message ServiceInvocationCatalogObservedEvent {
+  ServiceIdentity identity = 1;
+  repeated ServiceEndpointDescriptor service_endpoints = 2;
+  repeated ServiceServingTargetSpec serving_targets = 3;
+  map<string, ServiceRevisionRecordState> revisions = 4;
+  repeated ServiceInvocationCatalogEntryState entries = 5;
+  int64 source_catalog_version = 6;
+  int64 source_serving_version = 7;
+  int64 source_revision_version = 8;
+  google.protobuf.Timestamp observed_at = 9;
+}

--- a/src/platform/Aevatar.GAgentService.Abstractions/Queries/ServiceInvokeReadinessSnapshot.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Queries/ServiceInvokeReadinessSnapshot.cs
@@ -1,0 +1,26 @@
+namespace Aevatar.GAgentService.Abstractions.Queries;
+
+public sealed record ServiceInvocationCatalogSnapshot(
+    string ServiceKey,
+    IReadOnlyList<ServiceInvokeReadinessSnapshot> Entries,
+    DateTimeOffset ObservedAt,
+    long AggregateStateVersion,
+    string LastEventId,
+    long SourceCatalogVersion,
+    long SourceServingVersion,
+    long SourceRevisionVersion);
+
+public sealed record ServiceInvokeReadinessSnapshot(
+    string ServiceKey,
+    string EndpointId,
+    ServiceInvokeReadinessStatus ReadinessStatus,
+    ServiceInvokeUnavailableReason UnavailableReason,
+    string SelectedRevisionId,
+    string SelectedDeploymentId,
+    string SelectedActorId,
+    DateTimeOffset ObservedAt,
+    long AggregateStateVersion,
+    string LastEventId,
+    long SourceCatalogVersion,
+    long SourceServingVersion,
+    long SourceRevisionVersion);

--- a/src/platform/Aevatar.GAgentService.Abstractions/Services/ServiceActorIds.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Services/ServiceActorIds.cs
@@ -20,6 +20,8 @@ public static class ServiceActorIds
 
     public static string Rollout(ServiceIdentity identity) => Build("rollout", identity);
 
+    public static string InvocationCatalog(ServiceIdentity identity) => Build("invocation-catalog", identity);
+
     private static string Build(string prefix, ServiceIdentity identity) =>
         $"gagent-service:{prefix}:{ServiceKeys.Build(identity)}";
 }

--- a/src/platform/Aevatar.GAgentService.Application/Services/ServiceCommandApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Services/ServiceCommandApplicationService.cs
@@ -26,6 +26,7 @@ public sealed class ServiceCommandApplicationService : IServiceCommandPort
         CancellationToken ct = default)
     {
         var actorId = await _targetProvisioner.EnsureDefinitionTargetAsync(command.Spec.Identity, ct);
+        await _targetProvisioner.EnsureInvocationCatalogTargetAsync(command.Spec.Identity, ct);
         return await DispatchAsync(actorId, command, CorrelationForService(command.Spec.Identity), ct);
     }
 
@@ -34,6 +35,7 @@ public sealed class ServiceCommandApplicationService : IServiceCommandPort
         CancellationToken ct = default)
     {
         var actorId = await _targetProvisioner.EnsureDefinitionTargetAsync(command.Spec.Identity, ct);
+        await _targetProvisioner.EnsureInvocationCatalogTargetAsync(command.Spec.Identity, ct);
         return await DispatchAsync(actorId, command, CorrelationForService(command.Spec.Identity), ct);
     }
 
@@ -42,6 +44,7 @@ public sealed class ServiceCommandApplicationService : IServiceCommandPort
         CancellationToken ct = default)
     {
         var actorId = await _targetProvisioner.EnsureRevisionCatalogTargetAsync(command.Spec.Identity, ct);
+        await _targetProvisioner.EnsureInvocationCatalogTargetAsync(command.Spec.Identity, ct);
         return await DispatchAsync(actorId, command, CorrelationForRevision(command.Spec.Identity, command.Spec.RevisionId), ct);
     }
 
@@ -50,6 +53,7 @@ public sealed class ServiceCommandApplicationService : IServiceCommandPort
         CancellationToken ct = default)
     {
         var actorId = await _targetProvisioner.EnsureRevisionCatalogTargetAsync(command.Identity, ct);
+        await _targetProvisioner.EnsureInvocationCatalogTargetAsync(command.Identity, ct);
         return await DispatchAsync(actorId, command, CorrelationForRevision(command.Identity, command.RevisionId), ct);
     }
 
@@ -58,6 +62,7 @@ public sealed class ServiceCommandApplicationService : IServiceCommandPort
         CancellationToken ct = default)
     {
         var actorId = await _targetProvisioner.EnsureRevisionCatalogTargetAsync(command.Identity, ct);
+        await _targetProvisioner.EnsureInvocationCatalogTargetAsync(command.Identity, ct);
         return await DispatchAsync(actorId, command, CorrelationForRevision(command.Identity, command.RevisionId), ct);
     }
 
@@ -66,6 +71,7 @@ public sealed class ServiceCommandApplicationService : IServiceCommandPort
         CancellationToken ct = default)
     {
         var actorId = await _targetProvisioner.EnsureRevisionCatalogTargetAsync(command.Identity, ct);
+        await _targetProvisioner.EnsureInvocationCatalogTargetAsync(command.Identity, ct);
         return await DispatchAsync(actorId, command, CorrelationForRevision(command.Identity, command.RevisionId), ct);
     }
 
@@ -74,6 +80,7 @@ public sealed class ServiceCommandApplicationService : IServiceCommandPort
         CancellationToken ct = default)
     {
         var actorId = await _targetProvisioner.EnsureDefinitionTargetAsync(command.Identity, ct);
+        await _targetProvisioner.EnsureInvocationCatalogTargetAsync(command.Identity, ct);
         return await DispatchAsync(actorId, command, CorrelationForRevision(command.Identity, command.RevisionId), ct);
     }
 
@@ -83,6 +90,7 @@ public sealed class ServiceCommandApplicationService : IServiceCommandPort
     {
         var actorId = await _targetProvisioner.EnsureDeploymentTargetAsync(command.Identity, ct);
         await _targetProvisioner.EnsureServingSetTargetAsync(command.Identity, ct);
+        await _targetProvisioner.EnsureInvocationCatalogTargetAsync(command.Identity, ct);
         return await DispatchAsync(actorId, command, CorrelationForRevision(command.Identity, command.RevisionId), ct);
     }
 
@@ -99,6 +107,7 @@ public sealed class ServiceCommandApplicationService : IServiceCommandPort
         CancellationToken ct = default)
     {
         var actorId = await _targetProvisioner.EnsureServingSetTargetAsync(command.Identity, ct);
+        await _targetProvisioner.EnsureInvocationCatalogTargetAsync(command.Identity, ct);
         return await DispatchAsync(actorId, command, CorrelationForService(command.Identity!), ct);
     }
 
@@ -109,6 +118,7 @@ public sealed class ServiceCommandApplicationService : IServiceCommandPort
         ArgumentNullException.ThrowIfNull(command.Plan);
         var actorId = await _targetProvisioner.EnsureRolloutTargetAsync(command.Identity, ct);
         await _targetProvisioner.EnsureServingSetTargetAsync(command.Identity, ct);
+        await _targetProvisioner.EnsureInvocationCatalogTargetAsync(command.Identity, ct);
         return await DispatchAsync(actorId, command, $"{CorrelationForService(command.Identity!)}:{command.Plan.RolloutId}", ct);
     }
 
@@ -118,6 +128,7 @@ public sealed class ServiceCommandApplicationService : IServiceCommandPort
     {
         var actorId = await _targetProvisioner.EnsureRolloutTargetAsync(command.Identity, ct);
         await _targetProvisioner.EnsureServingSetTargetAsync(command.Identity, ct);
+        await _targetProvisioner.EnsureInvocationCatalogTargetAsync(command.Identity, ct);
         return await DispatchAsync(actorId, command, $"{CorrelationForService(command.Identity)}:{command.RolloutId}", ct);
     }
 
@@ -135,6 +146,7 @@ public sealed class ServiceCommandApplicationService : IServiceCommandPort
     {
         var actorId = await _targetProvisioner.EnsureRolloutTargetAsync(command.Identity, ct);
         await _targetProvisioner.EnsureServingSetTargetAsync(command.Identity, ct);
+        await _targetProvisioner.EnsureInvocationCatalogTargetAsync(command.Identity, ct);
         return await DispatchAsync(actorId, command, $"{CorrelationForService(command.Identity)}:{command.RolloutId}", ct);
     }
 
@@ -144,6 +156,7 @@ public sealed class ServiceCommandApplicationService : IServiceCommandPort
     {
         var actorId = await _targetProvisioner.EnsureRolloutTargetAsync(command.Identity, ct);
         await _targetProvisioner.EnsureServingSetTargetAsync(command.Identity, ct);
+        await _targetProvisioner.EnsureInvocationCatalogTargetAsync(command.Identity, ct);
         return await DispatchAsync(actorId, command, $"{CorrelationForService(command.Identity)}:{command.RolloutId}", ct);
     }
 

--- a/src/platform/Aevatar.GAgentService.Application/Services/ServiceInvocationResolutionService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Services/ServiceInvocationResolutionService.cs
@@ -8,27 +8,16 @@ namespace Aevatar.GAgentService.Application.Services;
 public sealed class ServiceInvocationResolutionService
 {
     private readonly IServiceCatalogQueryReader _catalogQueryReader;
-    private readonly IServiceTrafficViewQueryReader _trafficViewQueryReader;
-    private readonly IServiceServingSetQueryReader? _servingSetQueryReader;
+    private readonly IServiceInvocationCatalogQueryReader _invocationCatalogQueryReader;
     private readonly IServiceRevisionCatalogQueryReader _revisionCatalogQueryReader;
 
     public ServiceInvocationResolutionService(
         IServiceCatalogQueryReader catalogQueryReader,
-        IServiceTrafficViewQueryReader trafficViewQueryReader,
-        IServiceRevisionCatalogQueryReader revisionCatalogQueryReader)
-        : this(catalogQueryReader, trafficViewQueryReader, null, revisionCatalogQueryReader)
-    {
-    }
-
-    public ServiceInvocationResolutionService(
-        IServiceCatalogQueryReader catalogQueryReader,
-        IServiceTrafficViewQueryReader trafficViewQueryReader,
-        IServiceServingSetQueryReader? servingSetQueryReader,
+        IServiceInvocationCatalogQueryReader invocationCatalogQueryReader,
         IServiceRevisionCatalogQueryReader revisionCatalogQueryReader)
     {
         _catalogQueryReader = catalogQueryReader ?? throw new ArgumentNullException(nameof(catalogQueryReader));
-        _trafficViewQueryReader = trafficViewQueryReader ?? throw new ArgumentNullException(nameof(trafficViewQueryReader));
-        _servingSetQueryReader = servingSetQueryReader;
+        _invocationCatalogQueryReader = invocationCatalogQueryReader ?? throw new ArgumentNullException(nameof(invocationCatalogQueryReader));
         _revisionCatalogQueryReader = revisionCatalogQueryReader ?? throw new ArgumentNullException(nameof(revisionCatalogQueryReader));
     }
 
@@ -52,143 +41,119 @@ public sealed class ServiceInvocationResolutionService
         var serviceKey = ServiceKeys.Build(request.Identity);
         var definition = await _catalogQueryReader.GetAsync(request.Identity, ct)
             ?? throw new InvalidOperationException($"Service '{serviceKey}' was not found.");
-        var trafficView = await _trafficViewQueryReader.GetAsync(request.Identity, ct);
-        var endpointView = trafficView?.Endpoints.FirstOrDefault(x =>
-            string.Equals(x.EndpointId, request.EndpointId, StringComparison.Ordinal));
-        if (endpointView == null || endpointView.Targets.Count == 0)
-        {
-            endpointView = await BuildFallbackEndpointViewAsync(request, trafficView != null, ct);
-        }
-        if (endpointView == null || endpointView.Targets.Count == 0)
-            throw new InvalidOperationException($"Endpoint '{request.EndpointId}' has no serving target on service '{serviceKey}'.");
-
-        var selectedTarget = SelectTarget(endpointView.Targets, request, serviceKey);
+        var readiness = await ResolveReadinessAsync(request, serviceKey, ct);
         var revisionCatalog = await _revisionCatalogQueryReader.GetAsync(request.Identity, ct);
-        // Refactor (iter100/cluster-100): Old invocation resolved artifacts from a process-local store. / New invocation resolves prepared artifacts from the revision readmodel catalog.
-        var artifact = revisionCatalog.GetRequiredPreparedArtifact(request.Identity, selectedTarget.RevisionId);
+        var artifact = ResolvePreparedArtifact(
+            revisionCatalog,
+            request.Identity,
+            readiness.SelectedRevisionId,
+            readiness);
         var endpoint = artifact.Endpoints.FirstOrDefault(x =>
             string.Equals(x.EndpointId, request.EndpointId, StringComparison.Ordinal));
         if (endpoint == null)
-            throw new InvalidOperationException($"Endpoint '{request.EndpointId}' was not found on service '{serviceKey}'.");
+            throw CreateUnavailable(
+                readiness with
+                {
+                    UnavailableReason = ServiceInvokeUnavailableReason.PreparedArtifactMissing,
+                    ReadinessStatus = ServiceInvokeReadinessStatus.Unavailable,
+                },
+                $"Endpoint '{request.EndpointId}' was not found on prepared artifact for service '{serviceKey}'.");
 
         return new ServiceInvocationResolvedTarget(
             new ServiceInvocationResolvedService(
                 serviceKey,
-                selectedTarget.RevisionId,
-                selectedTarget.DeploymentId,
-                selectedTarget.PrimaryActorId,
-                selectedTarget.ServingState,
+                readiness.SelectedRevisionId,
+                readiness.SelectedDeploymentId,
+                readiness.SelectedActorId,
+                ServiceServingState.Active.ToString(),
                 definition.PolicyIds),
             artifact,
             endpoint);
     }
 
-    private async Task<ServiceTrafficEndpointSnapshot?> BuildFallbackEndpointViewAsync(
+    private async Task<ServiceInvokeReadinessSnapshot> ResolveReadinessAsync(
         ServiceInvocationRequest request,
-        bool hasTrafficView,
+        string serviceKey,
         CancellationToken ct)
     {
-        if (_servingSetQueryReader == null)
-        {
-            if (hasTrafficView)
-                return null;
+        var catalog = await _invocationCatalogQueryReader.GetAsync(request.Identity!, ct);
+        if (catalog == null)
+            throw CreateUnavailable(CreateUnspecifiedSnapshot(serviceKey, request.EndpointId), $"Service '{serviceKey}' has no invocation catalog readmodel.");
 
-            throw new InvalidOperationException($"Service '{ServiceKeys.Build(request.Identity!)}' has no serving traffic view.");
-        }
-
-        var servingSet = await _servingSetQueryReader.GetAsync(request.Identity!, ct);
-        if (servingSet == null)
-        {
-            if (hasTrafficView)
-                return null;
-
-            throw new InvalidOperationException($"Service '{ServiceKeys.Build(request.Identity!)}' has no serving traffic view.");
-        }
-
-        var targets = servingSet.Targets
-            .Where(x => IsEndpointEnabled(x, request.EndpointId))
-            .Select(x => new ServiceTrafficTargetSnapshot(
-                x.DeploymentId,
-                x.RevisionId,
-                x.PrimaryActorId,
-                x.AllocationWeight,
-                x.ServingState))
-            .ToList();
-
-        return new ServiceTrafficEndpointSnapshot(request.EndpointId, targets);
-    }
-
-    private static bool IsEndpointEnabled(ServiceServingTargetSnapshot target, string endpointId)
-    {
-        if (target.EnabledEndpointIds.Count == 0)
-            return true;
-
-        return target.EnabledEndpointIds.Any(x => string.Equals(x, endpointId, StringComparison.Ordinal));
-    }
-
-    private static ServiceTrafficTargetSnapshot SelectTarget(
-        IReadOnlyList<ServiceTrafficTargetSnapshot> targets,
-        ServiceInvocationRequest request,
-        string serviceKey)
-    {
         var requestedRevisionId = request.RevisionId?.Trim() ?? string.Empty;
-        var selectedCandidates = targets;
-        if (!string.IsNullOrWhiteSpace(requestedRevisionId))
-        {
-            selectedCandidates = targets
-                .Where(x => string.Equals(x.RevisionId, requestedRevisionId, StringComparison.Ordinal))
-                .ToList();
-            if (selectedCandidates.Count == 0)
-            {
-                throw new InvalidOperationException(
-                    $"Revision '{requestedRevisionId}' has no serving target on service '{serviceKey}'.");
-            }
-        }
+        var readiness = catalog.Entries.FirstOrDefault(x =>
+            string.Equals(x.EndpointId, request.EndpointId, StringComparison.Ordinal) &&
+            (string.IsNullOrWhiteSpace(requestedRevisionId) ||
+             string.Equals(x.SelectedRevisionId, requestedRevisionId, StringComparison.Ordinal)));
+        if (readiness == null)
+            throw CreateUnavailable(CreateUnspecifiedSnapshot(catalog, request.EndpointId), $"Endpoint '{request.EndpointId}' has no invocation readiness on service '{serviceKey}'.");
 
-        var activeTargets = selectedCandidates
-            .Where(x => x.AllocationWeight > 0 && string.Equals(x.ServingState, ServiceServingState.Active.ToString(), StringComparison.Ordinal))
-            .ToList();
-        if (activeTargets.Count == 0)
-        {
-            if (!string.IsNullOrWhiteSpace(requestedRevisionId))
-            {
-                throw new InvalidOperationException(
-                    $"Revision '{requestedRevisionId}' is not active on service '{serviceKey}'.");
-            }
+        if (readiness.ReadinessStatus != ServiceInvokeReadinessStatus.Ready)
+            throw CreateUnavailable(readiness, $"Service '{serviceKey}' endpoint '{request.EndpointId}' is not ready for invoke.");
 
-            throw new InvalidOperationException("No active serving targets are available.");
-        }
-
-        var totalWeight = activeTargets.Sum(x => x.AllocationWeight);
-        var seed = request.CommandId;
-        if (string.IsNullOrWhiteSpace(seed))
-            seed = request.CorrelationId;
-        if (string.IsNullOrWhiteSpace(seed))
-            seed = request.EndpointId;
-
-        var slot = (int)(ComputeDeterministicHash(seed ?? string.Empty) % (uint)totalWeight);
-        var cumulative = 0;
-        foreach (var target in activeTargets)
-        {
-            cumulative += target.AllocationWeight;
-            if (slot < cumulative)
-                return target;
-        }
-
-        return activeTargets[^1];
+        return readiness;
     }
 
-    private static uint ComputeDeterministicHash(string value)
+    private static PreparedServiceRevisionArtifact ResolvePreparedArtifact(
+        ServiceRevisionCatalogSnapshot? revisionCatalog,
+        ServiceIdentity identity,
+        string revisionId,
+        ServiceInvokeReadinessSnapshot readiness)
     {
-        const uint offsetBasis = 2166136261;
-        const uint prime = 16777619;
-        var hash = offsetBasis;
-        foreach (var ch in value)
+        try
         {
-            hash ^= ch;
-            hash *= prime;
+            return revisionCatalog.GetRequiredPreparedArtifact(identity, revisionId);
         }
-
-        return hash;
+        catch (InvalidOperationException ex)
+        {
+            throw CreateUnavailable(
+                readiness with
+                {
+                    UnavailableReason = ServiceInvokeUnavailableReason.PreparedArtifactMissing,
+                    ReadinessStatus = ServiceInvokeReadinessStatus.Unavailable,
+                },
+                ex.Message);
+        }
     }
+
+    private static ServiceInvokeReadinessException CreateUnavailable(
+        ServiceInvokeReadinessSnapshot snapshot,
+        string message) =>
+        new(message, snapshot);
+
+    private static ServiceInvokeReadinessSnapshot CreateUnspecifiedSnapshot(
+        ServiceInvocationCatalogSnapshot catalog,
+        string endpointId) =>
+        new(
+            catalog.ServiceKey,
+            endpointId,
+            ServiceInvokeReadinessStatus.Unspecified,
+            ServiceInvokeUnavailableReason.Unspecified,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            catalog.ObservedAt,
+            catalog.AggregateStateVersion,
+            catalog.LastEventId,
+            catalog.SourceCatalogVersion,
+            catalog.SourceServingVersion,
+            catalog.SourceRevisionVersion);
+
+    private static ServiceInvokeReadinessSnapshot CreateUnspecifiedSnapshot(
+        string serviceKey,
+        string endpointId) =>
+        new(
+            serviceKey,
+            endpointId,
+            ServiceInvokeReadinessStatus.Unspecified,
+            ServiceInvokeUnavailableReason.Unspecified,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            DateTimeOffset.UnixEpoch,
+            0,
+            string.Empty,
+            0,
+            0,
+            0);
 }

--- a/src/platform/Aevatar.GAgentService.Application/Services/ServiceInvokeReadinessErrorMapper.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Services/ServiceInvokeReadinessErrorMapper.cs
@@ -1,0 +1,62 @@
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Queries;
+
+namespace Aevatar.GAgentService.Application.Services;
+
+public sealed class ServiceInvokeReadinessException : InvalidOperationException
+{
+    public ServiceInvokeReadinessException(
+        string message,
+        ServiceInvokeReadinessSnapshot snapshot)
+        : base(message)
+    {
+        Snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
+    }
+
+    public ServiceInvokeReadinessSnapshot Snapshot { get; }
+}
+
+public sealed class ServiceInvokeReadinessErrorMapper
+{
+    public ServiceInvokeErrorBody Map(ServiceInvokeReadinessException exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        return Map(exception.Snapshot, exception.Message);
+    }
+
+    public ServiceInvokeErrorBody Map(ServiceInvokeReadinessSnapshot snapshot, string message)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        return new ServiceInvokeErrorBody(
+            Code: "SERVICE_INVOKE_UNAVAILABLE",
+            Message: message ?? string.Empty,
+            ReadinessStatus: snapshot.ReadinessStatus.ToString(),
+            Reason: snapshot.UnavailableReason == ServiceInvokeUnavailableReason.Unspecified
+                ? null
+                : snapshot.UnavailableReason.ToString(),
+            ServiceKey: snapshot.ServiceKey,
+            RevisionId: snapshot.SelectedRevisionId,
+            EndpointId: snapshot.EndpointId,
+            DeploymentId: snapshot.SelectedDeploymentId,
+            ObservedAt: snapshot.ObservedAt,
+            AggregateStateVersion: snapshot.AggregateStateVersion,
+            SourceCatalogVersion: snapshot.SourceCatalogVersion,
+            SourceServingVersion: snapshot.SourceServingVersion,
+            SourceRevisionVersion: snapshot.SourceRevisionVersion);
+    }
+}
+
+public sealed record ServiceInvokeErrorBody(
+    string Code,
+    string Message,
+    string ReadinessStatus,
+    string? Reason,
+    string ServiceKey,
+    string RevisionId,
+    string EndpointId,
+    string DeploymentId,
+    DateTimeOffset ObservedAt,
+    long AggregateStateVersion,
+    long SourceCatalogVersion,
+    long SourceServingVersion,
+    long SourceRevisionVersion);

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/ServiceDefinitionGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/ServiceDefinitionGAgent.cs
@@ -1,3 +1,4 @@
+using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Attributes;
 using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.Foundation.Core;
@@ -5,14 +6,18 @@ using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Services;
 using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.GAgentService.Core.GAgents;
 
 [GAgent("gagent.service.definition")]
 public sealed class ServiceDefinitionGAgent : GAgentBase<ServiceDefinitionState>
 {
-    public ServiceDefinitionGAgent()
+    private readonly IActorDispatchPort _dispatchPort;
+
+    public ServiceDefinitionGAgent(IActorDispatchPort dispatchPort)
     {
+        _dispatchPort = dispatchPort ?? throw new ArgumentNullException(nameof(dispatchPort));
         InitializeId();
     }
 
@@ -29,6 +34,7 @@ public sealed class ServiceDefinitionGAgent : GAgentBase<ServiceDefinitionState>
         {
             Spec = command.Spec.Clone(),
         });
+        await DispatchInvocationCatalogObservationAsync(CancellationToken.None);
     }
 
     [EventHandler]
@@ -41,6 +47,7 @@ public sealed class ServiceDefinitionGAgent : GAgentBase<ServiceDefinitionState>
         {
             Spec = command.Spec.Clone(),
         });
+        await DispatchInvocationCatalogObservationAsync(CancellationToken.None);
     }
 
     [EventHandler]
@@ -56,6 +63,7 @@ public sealed class ServiceDefinitionGAgent : GAgentBase<ServiceDefinitionState>
             Identity = command.Identity.Clone(),
             RevisionId = command.RevisionId,
         });
+        await DispatchInvocationCatalogObservationAsync(CancellationToken.None);
     }
 
     protected override ServiceDefinitionState TransitionState(ServiceDefinitionState current, IMessage evt) =>
@@ -122,4 +130,46 @@ public sealed class ServiceDefinitionGAgent : GAgentBase<ServiceDefinitionState>
         var serviceKey = identity == null ? "unbound" : ServiceKeys.Build(identity);
         return $"{serviceKey}:{suffix}";
     }
+
+    private Task DispatchInvocationCatalogObservationAsync(CancellationToken ct)
+    {
+        var identity = State.Spec?.Identity;
+        if (identity == null || string.IsNullOrWhiteSpace(identity.ServiceId))
+            return Task.CompletedTask;
+
+        var actorId = ServiceActorIds.InvocationCatalog(identity);
+        return _dispatchPort.DispatchAsync(
+            actorId,
+            CreateEnvelope(
+                actorId,
+                new ObserveServiceInvocationCatalogCommand
+                {
+                    Identity = identity.Clone(),
+                    ServiceEndpoints = { State.Spec.Endpoints.Select(ToDescriptor) },
+                    SourceCatalogVersion = State.LastAppliedEventVersion,
+                    ObservedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+                }),
+            ct);
+    }
+
+    private static ServiceEndpointDescriptor ToDescriptor(ServiceEndpointSpec endpoint) =>
+        new()
+        {
+            EndpointId = endpoint.EndpointId ?? string.Empty,
+            DisplayName = endpoint.DisplayName ?? string.Empty,
+            Kind = endpoint.Kind,
+            RequestTypeUrl = endpoint.RequestTypeUrl ?? string.Empty,
+            ResponseTypeUrl = endpoint.ResponseTypeUrl ?? string.Empty,
+            Description = endpoint.Description ?? string.Empty,
+        };
+
+    private static EventEnvelope CreateEnvelope(string actorId, IMessage payload) =>
+        new()
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(payload),
+            Route = EnvelopeRouteSemantics.CreateDirect("gagent-service.definition", actorId),
+            Propagation = new EnvelopePropagation(),
+        };
 }

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/ServiceInvocationCatalogGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/ServiceInvocationCatalogGAgent.cs
@@ -1,0 +1,167 @@
+using Aevatar.Foundation.Abstractions.Attributes;
+using Aevatar.Foundation.Abstractions.TypeSystem;
+using Aevatar.Foundation.Core;
+using Aevatar.Foundation.Core.EventSourcing;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Services;
+using Aevatar.GAgentService.Core.Services;
+using Google.Protobuf;
+using Google.Protobuf.Collections;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgentService.Core.GAgents;
+
+[GAgent("gagent.service.invocation-catalog")]
+public sealed class ServiceInvocationCatalogGAgent : GAgentBase<ServiceInvocationCatalogState>
+{
+    private readonly ServiceInvokeReadinessEvaluator _evaluator;
+
+    public ServiceInvocationCatalogGAgent(ServiceInvokeReadinessEvaluator evaluator)
+    {
+        _evaluator = evaluator ?? throw new ArgumentNullException(nameof(evaluator));
+        InitializeId();
+    }
+
+    [EventHandler]
+    public Task HandleCatalogObservationAsync(ObserveServiceInvocationCatalogCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        EnsureIdentity(command.Identity, allowInitialize: true);
+        if (command.SourceCatalogVersion < State.SourceCatalogVersion)
+            return Task.CompletedTask;
+
+        var next = State.Clone();
+        next.Identity = command.Identity.Clone();
+        next.ServiceEndpoints.Clear();
+        next.ServiceEndpoints.Add(command.ServiceEndpoints.Select(CloneEndpoint));
+        next.SourceCatalogVersion = command.SourceCatalogVersion;
+        next.ObservedAt = ResolveObservedAt(command.ObservedAt);
+        return PersistObservationAsync(next);
+    }
+
+    [EventHandler]
+    public Task HandleServingObservationAsync(ObserveServiceInvocationServingCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        EnsureIdentity(command.Identity, allowInitialize: true);
+        if (command.SourceServingVersion < State.SourceServingVersion)
+            return Task.CompletedTask;
+
+        var next = State.Clone();
+        next.Identity = command.Identity.Clone();
+        next.ServingTargets.Clear();
+        next.ServingTargets.Add(command.ServingTargets.Select(CloneTarget));
+        next.SourceServingVersion = command.SourceServingVersion;
+        next.ObservedAt = ResolveObservedAt(command.ObservedAt);
+        return PersistObservationAsync(next);
+    }
+
+    [EventHandler]
+    public Task HandleRevisionObservationAsync(ObserveServiceInvocationRevisionsCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        EnsureIdentity(command.Identity, allowInitialize: true);
+        if (command.SourceRevisionVersion < State.SourceRevisionVersion)
+            return Task.CompletedTask;
+
+        var next = State.Clone();
+        next.Identity = command.Identity.Clone();
+        next.Revisions.Clear();
+        foreach (var (revisionId, revision) in command.Revisions)
+            next.Revisions[revisionId] = revision.Clone();
+        next.SourceRevisionVersion = command.SourceRevisionVersion;
+        next.ObservedAt = ResolveObservedAt(command.ObservedAt);
+        return PersistObservationAsync(next);
+    }
+
+    protected override ServiceInvocationCatalogState TransitionState(ServiceInvocationCatalogState current, IMessage evt) =>
+        StateTransitionMatcher
+            .Match(current, evt)
+            .On<ServiceInvocationCatalogObservedEvent>(ApplyObserved)
+            .OrCurrent();
+
+    private async Task PersistObservationAsync(ServiceInvocationCatalogState next)
+    {
+        var entries = _evaluator.Evaluate(
+            next.ServiceEndpoints,
+            next.ServingTargets,
+            next.Revisions);
+
+        await PersistDomainEventAsync(new ServiceInvocationCatalogObservedEvent
+        {
+            Identity = next.Identity?.Clone(),
+            ServiceEndpoints = { next.ServiceEndpoints.Select(CloneEndpoint) },
+            ServingTargets = { next.ServingTargets.Select(CloneTarget) },
+            Revisions = { CloneRevisions(next.Revisions) },
+            Entries = { entries.Select(CloneEntry) },
+            SourceCatalogVersion = next.SourceCatalogVersion,
+            SourceServingVersion = next.SourceServingVersion,
+            SourceRevisionVersion = next.SourceRevisionVersion,
+            ObservedAt = next.ObservedAt?.Clone() ?? Timestamp.FromDateTime(DateTime.UtcNow),
+        });
+    }
+
+    private static ServiceInvocationCatalogState ApplyObserved(
+        ServiceInvocationCatalogState state,
+        ServiceInvocationCatalogObservedEvent evt)
+    {
+        var next = state.Clone();
+        next.Identity = evt.Identity?.Clone() ?? new ServiceIdentity();
+        next.ServiceEndpoints.Clear();
+        next.ServiceEndpoints.Add(evt.ServiceEndpoints.Select(CloneEndpoint));
+        next.ServingTargets.Clear();
+        next.ServingTargets.Add(evt.ServingTargets.Select(CloneTarget));
+        next.Revisions.Clear();
+        foreach (var (revisionId, revision) in evt.Revisions)
+            next.Revisions[revisionId] = revision.Clone();
+        next.Entries.Clear();
+        next.Entries.Add(evt.Entries.Select(CloneEntry));
+        next.SourceCatalogVersion = evt.SourceCatalogVersion;
+        next.SourceServingVersion = evt.SourceServingVersion;
+        next.SourceRevisionVersion = evt.SourceRevisionVersion;
+        next.ObservedAt = evt.ObservedAt?.Clone() ?? Timestamp.FromDateTime(DateTime.UtcNow);
+        next.LastAppliedEventVersion = state.LastAppliedEventVersion + 1;
+        next.LastEventId = BuildEventId(evt.Identity, next.LastAppliedEventVersion);
+        return next;
+    }
+
+    private void EnsureIdentity(ServiceIdentity identity, bool allowInitialize)
+    {
+        ArgumentNullException.ThrowIfNull(identity);
+        var requested = ServiceKeys.Build(identity);
+        var currentIdentity = State.Identity?.Clone();
+        if (currentIdentity == null || string.IsNullOrWhiteSpace(currentIdentity.ServiceId))
+        {
+            if (allowInitialize)
+                return;
+
+            throw new InvalidOperationException($"Service invocation catalog '{requested}' does not exist.");
+        }
+
+        var existing = ServiceKeys.Build(currentIdentity);
+        if (!string.Equals(existing, requested, StringComparison.Ordinal))
+            throw new InvalidOperationException($"Service invocation catalog actor '{Id}' is bound to '{existing}', but got '{requested}'.");
+    }
+
+    private static Timestamp ResolveObservedAt(Timestamp? observedAt) =>
+        observedAt?.Clone() ?? Timestamp.FromDateTime(DateTime.UtcNow);
+
+    private static string BuildEventId(ServiceIdentity? identity, long version)
+    {
+        var serviceKey = identity == null ? "unbound" : ServiceKeys.Build(identity);
+        return $"{serviceKey}:invocation-catalog:{version}";
+    }
+
+    private static IDictionary<string, ServiceRevisionRecordState> CloneRevisions(
+        MapField<string, ServiceRevisionRecordState> revisions) =>
+        revisions.ToDictionary(x => x.Key, x => x.Value.Clone(), StringComparer.Ordinal);
+
+    private static ServiceEndpointDescriptor CloneEndpoint(ServiceEndpointDescriptor source) =>
+        source.Clone();
+
+    private static ServiceServingTargetSpec CloneTarget(ServiceServingTargetSpec source) =>
+        source.Clone();
+
+    private static ServiceInvocationCatalogEntryState CloneEntry(ServiceInvocationCatalogEntryState source) =>
+        source.Clone();
+}

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/ServiceRevisionCatalogGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/ServiceRevisionCatalogGAgent.cs
@@ -1,3 +1,4 @@
+using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Attributes;
 using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.Foundation.Core;
@@ -14,13 +15,16 @@ namespace Aevatar.GAgentService.Core.GAgents;
 [GAgent("gagent.service.revision-catalog")]
 public sealed class ServiceRevisionCatalogGAgent : GAgentBase<ServiceRevisionCatalogState>
 {
+    private readonly IActorDispatchPort _dispatchPort;
     private readonly IReadOnlyDictionary<ServiceImplementationKind, IServiceImplementationAdapter> _adapters;
     private readonly PreparedServiceRevisionArtifactAssembler _artifactAssembler;
 
     public ServiceRevisionCatalogGAgent(
+        IActorDispatchPort dispatchPort,
         IEnumerable<IServiceImplementationAdapter> adapters,
         PreparedServiceRevisionArtifactAssembler artifactAssembler)
     {
+        _dispatchPort = dispatchPort ?? throw new ArgumentNullException(nameof(dispatchPort));
         _artifactAssembler = artifactAssembler ?? throw new ArgumentNullException(nameof(artifactAssembler));
         _adapters = (adapters ?? throw new ArgumentNullException(nameof(adapters)))
             .ToDictionary(x => x.ImplementationKind, x => x);
@@ -43,6 +47,7 @@ public sealed class ServiceRevisionCatalogGAgent : GAgentBase<ServiceRevisionCat
             Spec = command.Spec.Clone(),
             CreatedAt = Timestamp.FromDateTime(DateTime.UtcNow),
         });
+        await DispatchInvocationRevisionObservationAsync(CancellationToken.None);
     }
 
     [EventHandler]
@@ -77,6 +82,7 @@ public sealed class ServiceRevisionCatalogGAgent : GAgentBase<ServiceRevisionCat
                 // Refactor (iter100/cluster-100): Old callers rehydrated this from a process-local artifact store. / New the committed prepared event is the artifact authority.
                 PreparedArtifact = assembled.Clone(),
             });
+            await DispatchInvocationRevisionObservationAsync(CancellationToken.None);
         }
         catch (Exception ex)
         {
@@ -87,6 +93,7 @@ public sealed class ServiceRevisionCatalogGAgent : GAgentBase<ServiceRevisionCat
                 FailureReason = ex.Message,
                 OccurredAt = Timestamp.FromDateTime(DateTime.UtcNow),
             });
+            await DispatchInvocationRevisionObservationAsync(CancellationToken.None);
             throw;
         }
     }
@@ -109,6 +116,7 @@ public sealed class ServiceRevisionCatalogGAgent : GAgentBase<ServiceRevisionCat
             RevisionId = command.RevisionId ?? string.Empty,
             PublishedAt = Timestamp.FromDateTime(DateTime.UtcNow),
         });
+        await DispatchInvocationRevisionObservationAsync(CancellationToken.None);
     }
 
     [EventHandler]
@@ -123,6 +131,7 @@ public sealed class ServiceRevisionCatalogGAgent : GAgentBase<ServiceRevisionCat
             RevisionId = command.RevisionId ?? string.Empty,
             RetiredAt = Timestamp.FromDateTime(DateTime.UtcNow),
         });
+        await DispatchInvocationRevisionObservationAsync(CancellationToken.None);
     }
 
     protected override ServiceRevisionCatalogState TransitionState(ServiceRevisionCatalogState current, IMessage evt) =>
@@ -255,4 +264,35 @@ public sealed class ServiceRevisionCatalogGAgent : GAgentBase<ServiceRevisionCat
         var serviceKey = identity == null ? "unbound" : ServiceKeys.Build(identity);
         return $"{serviceKey}:{revisionId ?? "unknown"}:{suffix}";
     }
+
+    private Task DispatchInvocationRevisionObservationAsync(CancellationToken ct)
+    {
+        var identity = State.Identity;
+        if (identity == null || string.IsNullOrWhiteSpace(identity.ServiceId))
+            return Task.CompletedTask;
+
+        var actorId = ServiceActorIds.InvocationCatalog(identity);
+        return _dispatchPort.DispatchAsync(
+            actorId,
+            CreateEnvelope(
+                actorId,
+                new ObserveServiceInvocationRevisionsCommand
+                {
+                    Identity = identity.Clone(),
+                    Revisions = { State.Revisions.ToDictionary(x => x.Key, x => x.Value.Clone(), StringComparer.Ordinal) },
+                    SourceRevisionVersion = State.LastAppliedEventVersion,
+                    ObservedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+                }),
+            ct);
+    }
+
+    private static EventEnvelope CreateEnvelope(string actorId, IMessage payload) =>
+        new()
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(payload),
+            Route = EnvelopeRouteSemantics.CreateDirect("gagent-service.revisions", actorId),
+            Propagation = new EnvelopePropagation(),
+        };
 }

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/ServiceServingSetManagerGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/ServiceServingSetManagerGAgent.cs
@@ -1,3 +1,4 @@
+using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Attributes;
 using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.Foundation.Core;
@@ -13,10 +14,14 @@ namespace Aevatar.GAgentService.Core.GAgents;
 [GAgent("gagent.service.serving-set-manager")]
 public sealed class ServiceServingSetManagerGAgent : GAgentBase<ServiceServingSetState>
 {
+    private readonly IActorDispatchPort _dispatchPort;
     private readonly IServiceServingTargetResolver _targetResolver;
 
-    public ServiceServingSetManagerGAgent(IServiceServingTargetResolver targetResolver)
+    public ServiceServingSetManagerGAgent(
+        IActorDispatchPort dispatchPort,
+        IServiceServingTargetResolver targetResolver)
     {
+        _dispatchPort = dispatchPort ?? throw new ArgumentNullException(nameof(dispatchPort));
         _targetResolver = targetResolver ?? throw new ArgumentNullException(nameof(targetResolver));
         InitializeId();
     }
@@ -38,6 +43,7 @@ public sealed class ServiceServingSetManagerGAgent : GAgentBase<ServiceServingSe
             Reason = command.Reason ?? string.Empty,
             UpdatedAt = Timestamp.FromDateTime(DateTime.UtcNow),
         });
+        await DispatchInvocationServingObservationAsync(CancellationToken.None);
     }
 
     [EventHandler]
@@ -56,6 +62,7 @@ public sealed class ServiceServingSetManagerGAgent : GAgentBase<ServiceServingSe
             Reason = command.Reason ?? string.Empty,
             UpdatedAt = Timestamp.FromDateTime(DateTime.UtcNow),
         });
+        await DispatchInvocationServingObservationAsync(CancellationToken.None);
     }
 
     protected override ServiceServingSetState TransitionState(ServiceServingSetState current, IMessage evt) =>
@@ -126,5 +133,36 @@ public sealed class ServiceServingSetManagerGAgent : GAgentBase<ServiceServingSe
             AllocationWeight = source.AllocationWeight,
             ServingState = source.ServingState,
             EnabledEndpointIds = { source.EnabledEndpointIds },
+        };
+
+    private Task DispatchInvocationServingObservationAsync(CancellationToken ct)
+    {
+        var identity = State.Identity;
+        if (identity == null || string.IsNullOrWhiteSpace(identity.ServiceId))
+            return Task.CompletedTask;
+
+        var actorId = ServiceActorIds.InvocationCatalog(identity);
+        return _dispatchPort.DispatchAsync(
+            actorId,
+            CreateEnvelope(
+                actorId,
+                new ObserveServiceInvocationServingCommand
+                {
+                    Identity = identity.Clone(),
+                    ServingTargets = { State.Targets.Select(CloneTarget) },
+                    SourceServingVersion = State.LastAppliedEventVersion,
+                    ObservedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+                }),
+            ct);
+    }
+
+    private static EventEnvelope CreateEnvelope(string actorId, IMessage payload) =>
+        new()
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(payload),
+            Route = EnvelopeRouteSemantics.CreateDirect("gagent-service.serving-set", actorId),
+            Propagation = new EnvelopePropagation(),
         };
 }

--- a/src/platform/Aevatar.GAgentService.Core/Services/ServiceInvokeReadinessEvaluator.cs
+++ b/src/platform/Aevatar.GAgentService.Core/Services/ServiceInvokeReadinessEvaluator.cs
@@ -1,0 +1,102 @@
+using Aevatar.GAgentService.Abstractions;
+
+namespace Aevatar.GAgentService.Core.Services;
+
+public sealed class ServiceInvokeReadinessEvaluator
+{
+    public IReadOnlyList<ServiceInvocationCatalogEntryState> Evaluate(
+        IReadOnlyList<ServiceEndpointDescriptor> endpoints,
+        IReadOnlyList<ServiceServingTargetSpec> servingTargets,
+        IReadOnlyDictionary<string, ServiceRevisionRecordState> revisions)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+        ArgumentNullException.ThrowIfNull(servingTargets);
+        ArgumentNullException.ThrowIfNull(revisions);
+
+        return endpoints
+            .OrderBy(x => x.EndpointId ?? string.Empty, StringComparer.Ordinal)
+            .Select(endpoint => EvaluateEndpoint(endpoint, servingTargets, revisions))
+            .ToList();
+    }
+
+    private static ServiceInvocationCatalogEntryState EvaluateEndpoint(
+        ServiceEndpointDescriptor endpoint,
+        IReadOnlyList<ServiceServingTargetSpec> servingTargets,
+        IReadOnlyDictionary<string, ServiceRevisionRecordState> revisions)
+    {
+        var endpointId = endpoint.EndpointId?.Trim() ?? string.Empty;
+        var selectedTarget = SelectTarget(endpointId, servingTargets);
+        if (selectedTarget == null)
+        {
+            return Unavailable(
+                endpointId,
+                ServiceInvokeUnavailableReason.ServingTargetMissing);
+        }
+
+        if (!revisions.TryGetValue(selectedTarget.RevisionId ?? string.Empty, out var revision) ||
+            revision.Status is not (ServiceRevisionStatus.Prepared or ServiceRevisionStatus.Published))
+        {
+            return Unavailable(
+                endpointId,
+                ServiceInvokeUnavailableReason.RevisionNotPrepared,
+                selectedTarget);
+        }
+
+        var artifact = revision.PreparedArtifact;
+        if (artifact == null ||
+            string.IsNullOrWhiteSpace(artifact.RevisionId) ||
+            artifact.Endpoints.All(x => !string.Equals(x.EndpointId, endpointId, StringComparison.Ordinal)))
+        {
+            return Unavailable(
+                endpointId,
+                ServiceInvokeUnavailableReason.PreparedArtifactMissing,
+                selectedTarget);
+        }
+
+        return new ServiceInvocationCatalogEntryState
+        {
+            EndpointId = endpointId,
+            ReadinessStatus = ServiceInvokeReadinessStatus.Ready,
+            UnavailableReason = ServiceInvokeUnavailableReason.Unspecified,
+            SelectedRevisionId = selectedTarget.RevisionId ?? string.Empty,
+            SelectedDeploymentId = selectedTarget.DeploymentId ?? string.Empty,
+            SelectedActorId = selectedTarget.PrimaryActorId ?? string.Empty,
+        };
+    }
+
+    private static ServiceServingTargetSpec? SelectTarget(
+        string endpointId,
+        IReadOnlyList<ServiceServingTargetSpec> servingTargets)
+    {
+        return servingTargets
+            .Where(x =>
+                x.AllocationWeight > 0 &&
+                x.ServingState == ServiceServingState.Active &&
+                IsEndpointEnabled(x, endpointId))
+            .OrderByDescending(x => x.AllocationWeight)
+            .ThenBy(x => x.RevisionId ?? string.Empty, StringComparer.Ordinal)
+            .FirstOrDefault();
+    }
+
+    private static bool IsEndpointEnabled(ServiceServingTargetSpec target, string endpointId)
+    {
+        if (target.EnabledEndpointIds.Count == 0)
+            return true;
+
+        return target.EnabledEndpointIds.Any(x => string.Equals(x, endpointId, StringComparison.Ordinal));
+    }
+
+    private static ServiceInvocationCatalogEntryState Unavailable(
+        string endpointId,
+        ServiceInvokeUnavailableReason reason,
+        ServiceServingTargetSpec? target = null) =>
+        new()
+        {
+            EndpointId = endpointId,
+            ReadinessStatus = ServiceInvokeReadinessStatus.Unavailable,
+            UnavailableReason = reason,
+            SelectedRevisionId = target?.RevisionId ?? string.Empty,
+            SelectedDeploymentId = target?.DeploymentId ?? string.Empty,
+            SelectedActorId = target?.PrimaryActorId ?? string.Empty,
+        };
+}

--- a/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -72,6 +72,7 @@ public static class ServiceCollectionExtensions
         services.AddGAgentServiceProjectionReadModelProviders(configuration);
         services.AddGAgentServiceGovernanceCapability(configuration);
         services.TryAddSingleton<PreparedServiceRevisionArtifactAssembler>();
+        services.TryAddSingleton<ServiceInvokeReadinessEvaluator>();
         services.TryAddSingleton<IServiceServingTargetResolver, DefaultServiceServingTargetResolver>();
         services.TryAddSingleton<IServiceCommandTargetProvisioner, DefaultServiceCommandTargetProvisioner>();
         services.TryAddSingleton<IServiceRuntimeActivator, DefaultServiceRuntimeActivator>();
@@ -90,6 +91,7 @@ public static class ServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IServiceImplementationAdapter, ScriptingServiceImplementationAdapter>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IServiceImplementationAdapter, WorkflowServiceImplementationAdapter>());
         services.TryAddSingleton<ServiceInvocationResolutionService>();
+        services.TryAddSingleton<ServiceInvokeReadinessErrorMapper>();
         services.TryAddSingleton<IServiceCommandPort, ServiceCommandApplicationService>();
         services.TryAddSingleton<IServiceLifecycleQueryPort, ServiceLifecycleQueryApplicationService>();
         services.TryAddSingleton<IServiceServingQueryPort, ServiceServingQueryApplicationService>();
@@ -134,6 +136,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IServiceServingTargetResolver, DefaultServiceServingTargetResolver>();
         services.TryAddSingleton<IServiceRunRegistrationPort, ServiceRunRegistrationAdapter>();
         services.TryAddSingleton<ServiceInvocationResolutionService>();
+        services.TryAddSingleton<ServiceInvokeReadinessErrorMapper>();
         services.TryAddSingleton<IInvokeAdmissionAuthorizer, ScheduledDispatchInvokeAdmissionAuthorizer>();
         services.TryAddSingleton<IServiceInvocationDispatcher, DefaultServiceInvocationDispatcher>();
         services.TryAddSingleton<IServiceInvocationPort, ServiceInvocationApplicationService>();
@@ -169,6 +172,7 @@ public static class ServiceCollectionExtensions
             TryAddElasticsearchDocumentProjectionStore<ServiceRolloutReadModel>(services, configuration, static readModel => readModel.Id);
             TryAddElasticsearchDocumentProjectionStore<ServiceRolloutCommandObservationReadModel>(services, configuration, static readModel => readModel.Id);
             TryAddElasticsearchDocumentProjectionStore<ServiceTrafficViewReadModel>(services, configuration, static readModel => readModel.Id);
+            TryAddElasticsearchDocumentProjectionStore<ServiceInvocationCatalogReadModel>(services, configuration, static readModel => readModel.Id);
             TryAddElasticsearchDocumentProjectionStore<ServiceRunCurrentStateReadModel>(services, configuration, static readModel => readModel.Id);
             TryAddElasticsearchDocumentProjectionStore<GAgentRunTerminalReadModel>(services, configuration, static readModel => readModel.Id);
             TryAddElasticsearchDocumentProjectionStore<LlmSessionCurrentStateReadModel>(services, configuration, static readModel => readModel.Id);
@@ -186,6 +190,7 @@ public static class ServiceCollectionExtensions
             TryAddInMemoryDocumentProjectionStore<ServiceRolloutReadModel>(services, static readModel => readModel.Id);
             TryAddInMemoryDocumentProjectionStore<ServiceRolloutCommandObservationReadModel>(services, static readModel => readModel.Id);
             TryAddInMemoryDocumentProjectionStore<ServiceTrafficViewReadModel>(services, static readModel => readModel.Id);
+            TryAddInMemoryDocumentProjectionStore<ServiceInvocationCatalogReadModel>(services, static readModel => readModel.Id);
             TryAddInMemoryDocumentProjectionStore<ServiceRunCurrentStateReadModel>(services, static readModel => readModel.Id);
             TryAddInMemoryDocumentProjectionStore<GAgentRunTerminalReadModel>(services, static readModel => readModel.Id);
             TryAddInMemoryDocumentProjectionStore<LlmSessionCurrentStateReadModel>(services, static readModel => readModel.Id);
@@ -209,6 +214,7 @@ public static class ServiceCollectionExtensions
                && HasProjectionDocumentReaderForProvider<ServiceRolloutReadModel>(services, providerKind)
                && HasProjectionDocumentReaderForProvider<ServiceRolloutCommandObservationReadModel>(services, providerKind)
                && HasProjectionDocumentReaderForProvider<ServiceTrafficViewReadModel>(services, providerKind)
+               && HasProjectionDocumentReaderForProvider<ServiceInvocationCatalogReadModel>(services, providerKind)
                && HasProjectionDocumentReaderForProvider<ServiceRunCurrentStateReadModel>(services, providerKind)
                && HasProjectionDocumentReaderForProvider<GAgentRunTerminalReadModel>(services, providerKind)
                && HasProjectionDocumentReaderForProvider<LlmSessionCurrentStateReadModel>(services, providerKind)

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -246,6 +246,7 @@ public static class ScopeServiceEndpoints
         string? appId,
         int? take,
         [FromServices] IServiceLifecycleQueryPort lifecycleQueryPort,
+        [FromServices] IServiceInvocationCatalogQueryReader invocationCatalogQueryReader,
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
         CancellationToken ct)
     {
@@ -268,7 +269,7 @@ public static class ScopeServiceEndpoints
             take.GetValueOrDefault(200),
             ct);
 
-        return Results.Ok(services);
+        return Results.Ok(await JoinScopeInvokeReadinessAsync(services, invocationCatalogQueryReader, ct));
     }
 
     private static async Task<IResult> HandleGetBindingAsync(
@@ -594,6 +595,7 @@ public static class ScopeServiceEndpoints
         string scopeId,
         StreamScopeServiceHttpRequest request,
         [FromServices] ServiceInvocationResolutionService resolutionService,
+        [FromServices] ServiceInvokeReadinessErrorMapper readinessErrorMapper,
         [FromServices] IInvokeAdmissionAuthorizer admissionAuthorizer,
         [FromServices] IServiceRunRegistrationPort serviceRunRegistrationPort,
         [FromServices] IWorkflowChatRunInteractionPort chatRunService,
@@ -614,6 +616,7 @@ public static class ScopeServiceEndpoints
             request,
             appId: null,
             resolutionService,
+            readinessErrorMapper,
             admissionAuthorizer,
             serviceRunRegistrationPort,
             chatRunService,
@@ -631,6 +634,7 @@ public static class ScopeServiceEndpoints
         [FromServices] IServiceInvocationPort invocationPort,
         [FromServices] IServiceCatalogQueryReader catalogReader,
         [FromServices] IServiceRevisionCatalogQueryReader revisionCatalogReader,
+        [FromServices] ServiceInvokeReadinessErrorMapper readinessErrorMapper,
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
         CancellationToken ct) =>
         HandleInvokeAsync(
@@ -643,6 +647,7 @@ public static class ScopeServiceEndpoints
             invocationPort,
             catalogReader,
             revisionCatalogReader,
+            readinessErrorMapper,
             options,
             ct);
 
@@ -654,6 +659,7 @@ public static class ScopeServiceEndpoints
         StreamScopeServiceHttpRequest request,
         [FromServices] IMemberPublishedServiceResolver memberPublishedServiceResolver,
         [FromServices] ServiceInvocationResolutionService resolutionService,
+        [FromServices] ServiceInvokeReadinessErrorMapper readinessErrorMapper,
         [FromServices] IInvokeAdmissionAuthorizer admissionAuthorizer,
         [FromServices] IServiceRunRegistrationPort serviceRunRegistrationPort,
         [FromServices] IWorkflowChatRunInteractionPort chatRunService,
@@ -681,6 +687,7 @@ public static class ScopeServiceEndpoints
                 request,
                 null,
                 resolutionService,
+                readinessErrorMapper,
                 admissionAuthorizer,
                 serviceRunRegistrationPort,
                 chatRunService,
@@ -710,6 +717,7 @@ public static class ScopeServiceEndpoints
         [FromServices] IServiceInvocationPort invocationPort,
         [FromServices] IServiceCatalogQueryReader catalogReader,
         [FromServices] IServiceRevisionCatalogQueryReader revisionCatalogReader,
+        [FromServices] ServiceInvokeReadinessErrorMapper readinessErrorMapper,
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
         CancellationToken ct)
     {
@@ -735,6 +743,7 @@ public static class ScopeServiceEndpoints
                 invocationPort,
                 catalogReader,
                 revisionCatalogReader,
+                readinessErrorMapper,
                 options,
                 ct);
         }
@@ -752,6 +761,7 @@ public static class ScopeServiceEndpoints
         StreamScopeServiceHttpRequest request,
         [FromServices] ITeamEntryMemberResolver teamEntryMemberResolver,
         [FromServices] ServiceInvocationResolutionService resolutionService,
+        [FromServices] ServiceInvokeReadinessErrorMapper readinessErrorMapper,
         [FromServices] IInvokeAdmissionAuthorizer admissionAuthorizer,
         [FromServices] IServiceRunRegistrationPort serviceRunRegistrationPort,
         [FromServices] IWorkflowChatRunInteractionPort chatRunService,
@@ -774,6 +784,7 @@ public static class ScopeServiceEndpoints
                 request,
                 null,
                 resolutionService,
+                readinessErrorMapper,
                 admissionAuthorizer,
                 serviceRunRegistrationPort,
                 chatRunService,
@@ -812,6 +823,7 @@ public static class ScopeServiceEndpoints
         [FromServices] IServiceInvocationPort invocationPort,
         [FromServices] IServiceCatalogQueryReader catalogReader,
         [FromServices] IServiceRevisionCatalogQueryReader revisionCatalogReader,
+        [FromServices] ServiceInvokeReadinessErrorMapper readinessErrorMapper,
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
         CancellationToken ct)
     {
@@ -832,6 +844,7 @@ public static class ScopeServiceEndpoints
                 invocationPort,
                 catalogReader,
                 revisionCatalogReader,
+                readinessErrorMapper,
                 options,
                 ct);
         }
@@ -1500,6 +1513,7 @@ public static class ScopeServiceEndpoints
         StreamScopeServiceHttpRequest request,
         string? appId,
         [FromServices] ServiceInvocationResolutionService resolutionService,
+        [FromServices] ServiceInvokeReadinessErrorMapper readinessErrorMapper,
         [FromServices] IInvokeAdmissionAuthorizer admissionAuthorizer,
         [FromServices] IServiceRunRegistrationPort serviceRunRegistrationPort,
         [FromServices] IWorkflowChatRunInteractionPort chatRunService,
@@ -1614,6 +1628,14 @@ public static class ScopeServiceEndpoints
                     throw new InvalidOperationException(
                         $"Service implementation '{target.Artifact.ImplementationKind}' does not support SSE stream invocation.");
             }
+        }
+        catch (ServiceInvokeReadinessException ex)
+        {
+            await WriteJsonErrorResponseAsync(
+                http,
+                StatusCodes.Status400BadRequest,
+                readinessErrorMapper.Map(ex),
+                ct);
         }
         catch (NyxIdAuthenticationRequiredException ex)
         {
@@ -1891,6 +1913,7 @@ public static class ScopeServiceEndpoints
         [FromServices] IServiceInvocationPort invocationPort,
         [FromServices] IServiceCatalogQueryReader catalogReader,
         [FromServices] IServiceRevisionCatalogQueryReader revisionCatalogReader,
+        [FromServices] ServiceInvokeReadinessErrorMapper readinessErrorMapper,
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
         CancellationToken ct) =>
         await HandleInvokeAsyncCore(
@@ -1904,6 +1927,7 @@ public static class ScopeServiceEndpoints
             invocationPort,
             catalogReader,
             revisionCatalogReader,
+            readinessErrorMapper,
             options,
             ct);
 
@@ -1918,6 +1942,7 @@ public static class ScopeServiceEndpoints
         IServiceInvocationPort invocationPort,
         IServiceCatalogQueryReader catalogReader,
         IServiceRevisionCatalogQueryReader revisionCatalogReader,
+        ServiceInvokeReadinessErrorMapper readinessErrorMapper,
         IOptions<ScopeWorkflowCapabilityOptions> options,
         CancellationToken ct)
     {
@@ -1962,7 +1987,9 @@ public static class ScopeServiceEndpoints
         }
         catch (Exception ex) when (ex is FormatException or InvalidOperationException)
         {
-            return CreateScopeInvokeFailureResult(ex);
+            return ex is ServiceInvokeReadinessException readinessException
+                ? Results.BadRequest(readinessErrorMapper.Map(readinessException))
+                : CreateScopeInvokeFailureResult(ex);
         }
     }
 
@@ -2384,6 +2411,56 @@ public static class ScopeServiceEndpoints
             revisionSnapshots,
             revisions?.StateVersion ?? 0,
             revisions?.LastEventId ?? string.Empty);
+    }
+
+    private static async Task<IReadOnlyList<ScopeServiceHttpResponse>> JoinScopeInvokeReadinessAsync(
+        IReadOnlyList<ServiceCatalogSnapshot> services,
+        IServiceInvocationCatalogQueryReader invocationCatalogQueryReader,
+        CancellationToken ct)
+    {
+        var responses = new List<ScopeServiceHttpResponse>(services.Count);
+        foreach (var service in services)
+        {
+            var catalog = await invocationCatalogQueryReader.GetAsync(new ServiceIdentity
+            {
+                TenantId = service.TenantId,
+                AppId = service.AppId,
+                Namespace = service.Namespace,
+                ServiceId = service.ServiceId,
+            }, ct);
+            var entries = catalog?.Entries ?? [];
+            var ready = entries.Count > 0 &&
+                        entries.All(x => x.ReadinessStatus == ServiceInvokeReadinessStatus.Ready);
+            var status = entries.Count == 0
+                ? ServiceInvokeReadinessStatus.Unspecified
+                : ready
+                    ? ServiceInvokeReadinessStatus.Ready
+                    : ServiceInvokeReadinessStatus.Unavailable;
+            var reason = status == ServiceInvokeReadinessStatus.Unavailable
+                ? entries.FirstOrDefault(x => x.UnavailableReason != ServiceInvokeUnavailableReason.Unspecified)?.UnavailableReason.ToString()
+                : null;
+
+            responses.Add(new ScopeServiceHttpResponse(
+                service.ServiceKey,
+                service.TenantId,
+                service.AppId,
+                service.Namespace,
+                service.ServiceId,
+                service.DisplayName,
+                service.DefaultServingRevisionId,
+                service.ActiveServingRevisionId,
+                service.DeploymentId,
+                service.PrimaryActorId,
+                service.DeploymentStatus,
+                service.Endpoints,
+                service.PolicyIds,
+                service.UpdatedAt,
+                ready,
+                status.ToString(),
+                reason));
+        }
+
+        return responses;
     }
 
     private static MemberPublishedServiceHttpResponse BuildMemberPublishedServiceResponse(
@@ -3313,6 +3390,17 @@ const response = await fetch("{{invokePath}}", {
         await http.Response.WriteAsJsonAsync(new { code, message }, cancellationToken: ct);
     }
 
+    private static async Task WriteJsonErrorResponseAsync(
+        HttpContext http,
+        int statusCode,
+        object body,
+        CancellationToken ct)
+    {
+        http.Response.StatusCode = statusCode;
+        http.Response.ContentType = "application/json";
+        await http.Response.WriteAsJsonAsync(body, cancellationToken: ct);
+    }
+
     public sealed record InvokeScopeServiceHttpRequest(
         string? CommandId,
         string? CorrelationId,
@@ -3485,6 +3573,25 @@ const response = await fetch("{{invokePath}}", {
         string ServiceId,
         string DisplayName,
         string RevisionId);
+
+    public sealed record ScopeServiceHttpResponse(
+        string ServiceKey,
+        string TenantId,
+        string AppId,
+        string Namespace,
+        string ServiceId,
+        string DisplayName,
+        string DefaultServingRevisionId,
+        string ActiveServingRevisionId,
+        string DeploymentId,
+        string PrimaryActorId,
+        string DeploymentStatus,
+        IReadOnlyList<ServiceEndpointSnapshot> Endpoints,
+        IReadOnlyList<string> PolicyIds,
+        DateTimeOffset UpdatedAt,
+        bool InvokeReady,
+        string InvokeReadinessStatus,
+        string? InvokeUnavailableReason);
 
     public sealed record ScopeServiceRevisionCatalogHttpResponse(
         string ScopeId,

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ServiceEndpoints.cs
@@ -525,8 +525,9 @@ public static partial class ServiceEndpoints
         IServiceInvocationCatalogQueryReader invocationCatalogQueryReader,
         CancellationToken ct)
     {
-        var identity = ToIdentity(service.TenantId, service.AppId, service.Namespace, service.ServiceId);
-        var catalog = await invocationCatalogQueryReader.GetAsync(identity, ct);
+        var catalog = HasCompleteInvocationIdentity(service)
+            ? await invocationCatalogQueryReader.GetAsync(ToIdentity(service.TenantId, service.AppId, service.Namespace, service.ServiceId), ct)
+            : null;
         var entries = catalog?.Entries ?? [];
         var ready = entries.Count > 0 &&
                     entries.All(x => x.ReadinessStatus == ServiceInvokeReadinessStatus.Ready);
@@ -558,6 +559,12 @@ public static partial class ServiceEndpoints
             status.ToString(),
             reason);
     }
+
+    private static bool HasCompleteInvocationIdentity(ServiceCatalogSnapshot service) =>
+        !string.IsNullOrWhiteSpace(service.TenantId) &&
+        !string.IsNullOrWhiteSpace(service.AppId) &&
+        !string.IsNullOrWhiteSpace(service.Namespace) &&
+        !string.IsNullOrWhiteSpace(service.ServiceId);
 
     internal static ServiceIdentity ToIdentity(string? tenantId, string? appId, string? @namespace, string serviceId)
     {

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ServiceEndpoints.cs
@@ -2,6 +2,7 @@ using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
 using Aevatar.GAgentService.Abstractions.Services;
+using Aevatar.GAgentService.Application.Services;
 using Aevatar.GAgentService.Governance.Hosting.Endpoints;
 using Aevatar.GAgentService.Governance.Hosting.Identity;
 using Aevatar.GAgentService.Hosting.Endpoints.Schedules;
@@ -293,6 +294,7 @@ public static partial class ServiceEndpoints
         [AsParameters] ServiceIdentityQuery query,
         [FromServices] IServiceIdentityContextResolver identityResolver,
         [FromServices] IServiceLifecycleQueryPort queryPort,
+        [FromServices] IServiceInvocationCatalogQueryReader invocationCatalogQueryReader,
         CancellationToken ct)
     {
         if (!ServiceIdentityEndpointAccess.TryResolveContext(
@@ -307,7 +309,7 @@ public static partial class ServiceEndpoints
         }
 
         var services = await queryPort.ListServicesAsync(context.TenantId, context.AppId, context.Namespace, query.Take, ct);
-        return JsonOrNull(services);
+        return Results.Json(await JoinInvokeReadinessAsync(services, invocationCatalogQueryReader, ct));
     }
 
     private static async Task<IResult> HandleGetServiceAsync(
@@ -316,6 +318,7 @@ public static partial class ServiceEndpoints
         [AsParameters] ServiceIdentityQuery query,
         [FromServices] IServiceIdentityContextResolver identityResolver,
         [FromServices] IServiceLifecycleQueryPort queryPort,
+        [FromServices] IServiceInvocationCatalogQueryReader invocationCatalogQueryReader,
         CancellationToken ct)
     {
         if (!ServiceIdentityEndpointAccess.TryResolveIdentity(
@@ -330,7 +333,11 @@ public static partial class ServiceEndpoints
             return denied;
         }
 
-        return JsonOrNull(await queryPort.GetServiceAsync(identity, ct));
+        var service = await queryPort.GetServiceAsync(identity, ct);
+        if (service == null)
+            return JsonOrNull<ServiceWithInvokeReadinessHttpResponse>(null);
+
+        return Results.Json(await JoinInvokeReadinessAsync(service, invocationCatalogQueryReader, ct));
     }
 
     private static async Task<IResult> HandleGetRevisionsAsync(
@@ -365,6 +372,7 @@ public static partial class ServiceEndpoints
         [FromServices] IServiceInvocationPort invocationPort,
         [FromServices] IServiceCatalogQueryReader catalogReader,
         [FromServices] IServiceRevisionCatalogQueryReader revisionCatalogReader,
+        [FromServices] ServiceInvokeReadinessErrorMapper readinessErrorMapper,
         CancellationToken ct)
     {
         if (!ServiceIdentityEndpointAccess.TryResolveIdentity(
@@ -399,16 +407,24 @@ public static partial class ServiceEndpoints
             });
         }
 
-        var receipt = await invocationPort.InvokeAsync(new ServiceInvocationRequest
+        ServiceInvocationAcceptedReceipt receipt;
+        try
         {
-            Identity = identity,
-            EndpointId = endpointId,
-            CommandId = request.CommandId ?? string.Empty,
-            CorrelationId = request.CorrelationId ?? string.Empty,
-            RevisionId = revisionId,
-            Payload = payload,
-            Caller = ResolveInvocationCaller(identityResolver, request),
-        }, ct);
+            receipt = await invocationPort.InvokeAsync(new ServiceInvocationRequest
+            {
+                Identity = identity,
+                EndpointId = endpointId,
+                CommandId = request.CommandId ?? string.Empty,
+                CorrelationId = request.CorrelationId ?? string.Empty,
+                RevisionId = revisionId,
+                Payload = payload,
+                Caller = ResolveInvocationCaller(identityResolver, request),
+            }, ct);
+        }
+        catch (ServiceInvokeReadinessException ex)
+        {
+            return Results.BadRequest(readinessErrorMapper.Map(ex));
+        }
         // Refactor (iter56/cluster-891-endpoint-ack-honesty): old=200-shaped accepted, new=202 + Location
         //   Service invoke is accepted for dispatch; the run resource is the status surface for outcome.
         //   Never point Location at the service definition root because that is not the command/run status.
@@ -492,6 +508,57 @@ public static partial class ServiceEndpoints
             ? Results.Text("null", "application/json")
             : Results.Json(value);
 
+    private static async Task<IReadOnlyList<ServiceWithInvokeReadinessHttpResponse>> JoinInvokeReadinessAsync(
+        IReadOnlyList<ServiceCatalogSnapshot> services,
+        IServiceInvocationCatalogQueryReader invocationCatalogQueryReader,
+        CancellationToken ct)
+    {
+        var responses = new List<ServiceWithInvokeReadinessHttpResponse>(services.Count);
+        foreach (var service in services)
+            responses.Add(await JoinInvokeReadinessAsync(service, invocationCatalogQueryReader, ct));
+
+        return responses;
+    }
+
+    private static async Task<ServiceWithInvokeReadinessHttpResponse> JoinInvokeReadinessAsync(
+        ServiceCatalogSnapshot service,
+        IServiceInvocationCatalogQueryReader invocationCatalogQueryReader,
+        CancellationToken ct)
+    {
+        var identity = ToIdentity(service.TenantId, service.AppId, service.Namespace, service.ServiceId);
+        var catalog = await invocationCatalogQueryReader.GetAsync(identity, ct);
+        var entries = catalog?.Entries ?? [];
+        var ready = entries.Count > 0 &&
+                    entries.All(x => x.ReadinessStatus == ServiceInvokeReadinessStatus.Ready);
+        var status = entries.Count == 0
+            ? ServiceInvokeReadinessStatus.Unspecified
+            : ready
+                ? ServiceInvokeReadinessStatus.Ready
+                : ServiceInvokeReadinessStatus.Unavailable;
+        var reason = status == ServiceInvokeReadinessStatus.Unavailable
+            ? entries.FirstOrDefault(x => x.UnavailableReason != ServiceInvokeUnavailableReason.Unspecified)?.UnavailableReason.ToString()
+            : null;
+
+        return new ServiceWithInvokeReadinessHttpResponse(
+            service.ServiceKey,
+            service.TenantId,
+            service.AppId,
+            service.Namespace,
+            service.ServiceId,
+            service.DisplayName,
+            service.DefaultServingRevisionId,
+            service.ActiveServingRevisionId,
+            service.DeploymentId,
+            service.PrimaryActorId,
+            service.DeploymentStatus,
+            service.Endpoints,
+            service.PolicyIds,
+            service.UpdatedAt,
+            ready,
+            status.ToString(),
+            reason);
+    }
+
     internal static ServiceIdentity ToIdentity(string? tenantId, string? appId, string? @namespace, string serviceId)
     {
         return new ServiceIdentity
@@ -551,6 +618,25 @@ public static partial class ServiceEndpoints
         string? AppId,
         string? Namespace,
         int Take = 200);
+
+    public sealed record ServiceWithInvokeReadinessHttpResponse(
+        string ServiceKey,
+        string TenantId,
+        string AppId,
+        string Namespace,
+        string ServiceId,
+        string DisplayName,
+        string DefaultServingRevisionId,
+        string ActiveServingRevisionId,
+        string DeploymentId,
+        string PrimaryActorId,
+        string DeploymentStatus,
+        IReadOnlyList<ServiceEndpointSnapshot> Endpoints,
+        IReadOnlyList<string> PolicyIds,
+        DateTimeOffset UpdatedAt,
+        bool InvokeReady,
+        string InvokeReadinessStatus,
+        string? InvokeUnavailableReason);
 
     public sealed record ServiceIdentityHttpRequest(
         string TenantId,

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Activation/DefaultServiceCommandTargetProvisioner.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Activation/DefaultServiceCommandTargetProvisioner.cs
@@ -27,4 +27,7 @@ public sealed class DefaultServiceCommandTargetProvisioner : ActorTargetProvisio
 
     public Task<string> EnsureRolloutTargetAsync(ServiceIdentity identity, CancellationToken ct = default) =>
         EnsureActorAsync<ServiceRolloutManagerGAgent>(ServiceActorIds.Rollout(identity), ct);
+
+    public Task<string> EnsureInvocationCatalogTargetAsync(ServiceIdentity identity, CancellationToken ct = default) =>
+        EnsureActorAsync<ServiceInvocationCatalogGAgent>(ServiceActorIds.InvocationCatalog(identity), ct);
 }

--- a/src/platform/Aevatar.GAgentService.Projection/Contexts/ServiceInvocationCatalogProjectionContext.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Contexts/ServiceInvocationCatalogProjectionContext.cs
@@ -1,0 +1,9 @@
+namespace Aevatar.GAgentService.Projection.Contexts;
+
+public sealed class ServiceInvocationCatalogProjectionContext
+    : IProjectionMaterializationContext
+{
+    public required string RootActorId { get; init; }
+
+    public required string ProjectionKind { get; init; }
+}

--- a/src/platform/Aevatar.GAgentService.Projection/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/DependencyInjection/ServiceCollectionExtensions.cs
@@ -82,6 +82,13 @@ public static class ServiceCollectionExtensions
                 ProjectionKind = scopeKey.ProjectionKind,
             },
             static context => new ServiceProjectionRuntimeLease<ServiceRunCurrentStateProjectionContext>(context.RootActorId, context));
+        services.AddServiceProjectionRuntime<ServiceInvocationCatalogProjectionContext, ProjectionMaterializationScopeGAgent<ServiceInvocationCatalogProjectionContext>>(
+            static scopeKey => new ServiceInvocationCatalogProjectionContext
+            {
+                RootActorId = scopeKey.RootActorId,
+                ProjectionKind = scopeKey.ProjectionKind,
+            },
+            static context => new ServiceProjectionRuntimeLease<ServiceInvocationCatalogProjectionContext>(context.RootActorId, context));
         services.AddServiceProjectionRuntime<GAgentRunTerminalProjectionContext, ProjectionMaterializationScopeGAgent<GAgentRunTerminalProjectionContext>>(
             static scopeKey => new GAgentRunTerminalProjectionContext
             {
@@ -173,6 +180,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IProjectionDocumentMetadataProvider<ServiceRolloutCommandObservationReadModel>, ServiceRolloutCommandObservationReadModelMetadataProvider>();
         services.TryAddSingleton<IProjectionDocumentMetadataProvider<ServiceTrafficViewReadModel>, ServiceTrafficViewReadModelMetadataProvider>();
         services.TryAddSingleton<IProjectionDocumentMetadataProvider<ServiceRevisionCatalogReadModel>, ServiceRevisionCatalogReadModelMetadataProvider>();
+        services.TryAddSingleton<IProjectionDocumentMetadataProvider<ServiceInvocationCatalogReadModel>, ServiceInvocationCatalogReadModelMetadataProvider>();
         services.TryAddSingleton<IProjectionDocumentMetadataProvider<ServiceRunCurrentStateReadModel>, ServiceRunCurrentStateReadModelMetadataProvider>();
         services.TryAddSingleton<IProjectionDocumentMetadataProvider<GAgentRunTerminalReadModel>, GAgentRunTerminalReadModelMetadataProvider>();
         services.TryAddSingleton<IProjectionDocumentMetadataProvider<LlmSessionCurrentStateReadModel>, LlmSessionCurrentStateReadModelMetadataProvider>();
@@ -185,6 +193,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IServiceRolloutCommandObservationQueryReader, ServiceRolloutCommandObservationQueryReader>();
         services.TryAddSingleton<IServiceTrafficViewQueryReader, ServiceTrafficViewQueryReader>();
         services.TryAddSingleton<IServiceRevisionCatalogQueryReader, ServiceRevisionCatalogQueryReader>();
+        services.TryAddSingleton<IServiceInvocationCatalogQueryReader, ServiceInvocationCatalogQueryReader>();
         services.TryAddSingleton<IServiceScriptingRepublishCandidateQueryReader, ServiceScriptingRepublishCandidateQueryReader>();
         services.TryAddSingleton<IServiceRunQueryPort, ServiceRunQueryReader>();
         services.TryAddSingleton<IGAgentRunTerminalQueryPort, GAgentRunTerminalQueryReader>();
@@ -213,6 +222,9 @@ public static class ServiceCollectionExtensions
         services.AddProjectionArtifactMaterializer<
             ServiceRevisionCatalogProjectionContext,
             ServiceRevisionCatalogProjector>();
+        services.AddProjectionArtifactMaterializer<
+            ServiceInvocationCatalogProjectionContext,
+            ServiceInvocationCatalogProjector>();
         services.AddCurrentStateProjectionMaterializer<
             ServiceRunCurrentStateProjectionContext,
             ServiceRunCurrentStateProjector>();

--- a/src/platform/Aevatar.GAgentService.Projection/Metadata/ServiceInvocationCatalogReadModelMetadataProvider.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Metadata/ServiceInvocationCatalogReadModelMetadataProvider.cs
@@ -1,0 +1,14 @@
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.GAgentService.Projection.ReadModels;
+
+namespace Aevatar.GAgentService.Projection.Metadata;
+
+public sealed class ServiceInvocationCatalogReadModelMetadataProvider
+    : IProjectionDocumentMetadataProvider<ServiceInvocationCatalogReadModel>
+{
+    public DocumentIndexMetadata Metadata { get; } = new(
+        "gagent-service-invocation-catalog",
+        Mappings: new Dictionary<string, object?>(),
+        Settings: new Dictionary<string, object?>(),
+        Aliases: new Dictionary<string, object?>());
+}

--- a/src/platform/Aevatar.GAgentService.Projection/Orchestration/ServiceCommittedStateProjectionActivationPlanProvider.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Orchestration/ServiceCommittedStateProjectionActivationPlanProvider.cs
@@ -34,6 +34,7 @@ public sealed class ServiceCommittedStateProjectionActivationPlanProvider : IPro
             var type when type == typeof(ServiceDeploymentManagerGAgent) => DeploymentPlans(context.ActorId, payload),
             var type when type == typeof(ServiceServingSetManagerGAgent) => ServingSetPlans(context.ActorId, payload),
             var type when type == typeof(ServiceRolloutManagerGAgent) => RolloutPlans(context.ActorId),
+            var type when type == typeof(ServiceInvocationCatalogGAgent) => InvocationCatalogPlans(context.ActorId),
             var type when type == typeof(ServiceRunGAgent) => ServiceRunPlans(context.ActorId),
             _ when payload.Is(RoleChatSessionCompletedEvent.Descriptor) => GAgentRunTerminalPlans(context),
             var type when type == typeof(LlmSessionGAgent) => LlmSessionPlans(context.ActorId),
@@ -115,6 +116,13 @@ public sealed class ServiceCommittedStateProjectionActivationPlanProvider : IPro
         DurablePlan<ServiceRolloutProjectionContext>(
             actorId,
             ServiceProjectionKinds.Rollouts),
+    ];
+
+    private static IEnumerable<ProjectionActivationPlan> InvocationCatalogPlans(string actorId) =>
+    [
+        DurablePlan<ServiceInvocationCatalogProjectionContext>(
+            actorId,
+            ServiceProjectionKinds.InvocationCatalog),
     ];
 
     private static IEnumerable<ProjectionActivationPlan> ServiceRunPlans(string actorId) =>

--- a/src/platform/Aevatar.GAgentService.Projection/Orchestration/ServiceProjectionNames.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Orchestration/ServiceProjectionNames.cs
@@ -8,6 +8,7 @@ internal static class ServiceProjectionKinds
     public const string Serving = "service-serving";
     public const string Rollouts = "service-rollouts";
     public const string Traffic = "service-traffic";
+    public const string InvocationCatalog = "service-invocation-catalog";
     public const string DraftRunSession = "service-draft-run-session";
     public const string ScriptServiceAguiSession = "script-service-agui-session";
     public const string LlmSessionObservation = "llm-session-observation";

--- a/src/platform/Aevatar.GAgentService.Projection/Projectors/ServiceInvocationCatalogProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Projectors/ServiceInvocationCatalogProjector.cs
@@ -1,0 +1,85 @@
+using Aevatar.CQRS.Projection.Core.Abstractions.Orchestration;
+using Aevatar.CQRS.Projection.Runtime.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Services;
+using Aevatar.GAgentService.Projection.Contexts;
+using Aevatar.GAgentService.Projection.ReadModels;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgentService.Projection.Projectors;
+
+public sealed class ServiceInvocationCatalogProjector
+    : IProjectionArtifactMaterializer<ServiceInvocationCatalogProjectionContext>
+{
+    private readonly IProjectionWriteDispatcher<ServiceInvocationCatalogReadModel> _storeDispatcher;
+    private readonly IProjectionClock _clock;
+
+    public ServiceInvocationCatalogProjector(
+        IProjectionWriteDispatcher<ServiceInvocationCatalogReadModel> storeDispatcher,
+        IProjectionClock clock)
+    {
+        _storeDispatcher = storeDispatcher ?? throw new ArgumentNullException(nameof(storeDispatcher));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    }
+
+    public async ValueTask ProjectAsync(
+        ServiceInvocationCatalogProjectionContext context,
+        EventEnvelope envelope,
+        CancellationToken ct = default)
+    {
+        if (!CommittedStateEventEnvelope.TryUnpackState<ServiceInvocationCatalogState>(
+                envelope,
+                out _,
+                out var stateEvent,
+                out var state) ||
+            stateEvent == null ||
+            state == null ||
+            state.Identity == null)
+        {
+            return;
+        }
+
+        var serviceKey = ServiceKeys.Build(state.Identity);
+        if (string.IsNullOrWhiteSpace(serviceKey))
+            return;
+
+        var readModel = new ServiceInvocationCatalogReadModel
+        {
+            Id = serviceKey,
+            ActorId = context.RootActorId,
+            StateVersion = stateEvent.Version,
+            LastEventId = stateEvent.EventId ?? string.Empty,
+            TenantId = state.Identity.TenantId ?? string.Empty,
+            AppId = state.Identity.AppId ?? string.Empty,
+            Namespace = state.Identity.Namespace ?? string.Empty,
+            ServiceId = state.Identity.ServiceId ?? string.Empty,
+            ServiceKey = serviceKey,
+            ObservedAt = state.ObservedAt == null
+                ? CommittedStateEventEnvelope.ResolveTimestamp(envelope, _clock.UtcNow)
+                : state.ObservedAt.ToDateTimeOffset(),
+            SourceCatalogVersion = state.SourceCatalogVersion,
+            SourceServingVersion = state.SourceServingVersion,
+            SourceRevisionVersion = state.SourceRevisionVersion,
+            Entries = state.Entries
+                .OrderBy(x => x.EndpointId ?? string.Empty, StringComparer.Ordinal)
+                .Select(x => MapEntry(serviceKey, x))
+                .ToList(),
+        };
+        await _storeDispatcher.UpsertAsync(readModel, ct);
+    }
+
+    private static ServiceInvocationReadinessEntryReadModel MapEntry(
+        string serviceKey,
+        ServiceInvocationCatalogEntryState entry) =>
+        new()
+        {
+            ServiceKey = serviceKey,
+            EndpointId = entry.EndpointId ?? string.Empty,
+            ReadinessStatus = entry.ReadinessStatus,
+            UnavailableReason = entry.UnavailableReason,
+            SelectedRevisionId = entry.SelectedRevisionId ?? string.Empty,
+            SelectedDeploymentId = entry.SelectedDeploymentId ?? string.Empty,
+            SelectedActorId = entry.SelectedActorId ?? string.Empty,
+        };
+}

--- a/src/platform/Aevatar.GAgentService.Projection/Queries/ServiceInvocationCatalogQueryReader.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Queries/ServiceInvocationCatalogQueryReader.cs
@@ -1,0 +1,61 @@
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.GAgentService.Abstractions.Services;
+using Aevatar.GAgentService.Projection.Configuration;
+using Aevatar.GAgentService.Projection.ReadModels;
+
+namespace Aevatar.GAgentService.Projection.Queries;
+
+public sealed class ServiceInvocationCatalogQueryReader : IServiceInvocationCatalogQueryReader
+{
+    private readonly IProjectionDocumentReader<ServiceInvocationCatalogReadModel, string> _documentStore;
+    private readonly bool _enabled;
+
+    public ServiceInvocationCatalogQueryReader(
+        IProjectionDocumentReader<ServiceInvocationCatalogReadModel, string> documentStore,
+        ServiceProjectionOptions? options = null)
+    {
+        _documentStore = documentStore ?? throw new ArgumentNullException(nameof(documentStore));
+        _enabled = options?.Enabled ?? true;
+    }
+
+    public async Task<ServiceInvocationCatalogSnapshot?> GetAsync(
+        ServiceIdentity identity,
+        CancellationToken ct = default)
+    {
+        if (!_enabled)
+            return null;
+
+        var readModel = await _documentStore.GetAsync(ServiceKeys.Build(identity), ct);
+        if (readModel == null)
+            return null;
+
+        return new ServiceInvocationCatalogSnapshot(
+            readModel.ServiceKey,
+            readModel.Entries
+                .OrderBy(x => x.EndpointId, StringComparer.Ordinal)
+                .Select(x => new ServiceInvokeReadinessSnapshot(
+                    readModel.ServiceKey,
+                    x.EndpointId,
+                    x.ReadinessStatus,
+                    x.UnavailableReason,
+                    x.SelectedRevisionId,
+                    x.SelectedDeploymentId,
+                    x.SelectedActorId,
+                    readModel.ObservedAt,
+                    readModel.StateVersion,
+                    readModel.LastEventId,
+                    readModel.SourceCatalogVersion,
+                    readModel.SourceServingVersion,
+                    readModel.SourceRevisionVersion))
+                .ToList(),
+            readModel.ObservedAt,
+            readModel.StateVersion,
+            readModel.LastEventId,
+            readModel.SourceCatalogVersion,
+            readModel.SourceServingVersion,
+            readModel.SourceRevisionVersion);
+    }
+}

--- a/src/platform/Aevatar.GAgentService.Projection/ReadModels/ServiceProjectionReadModels.Partial.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/ReadModels/ServiceProjectionReadModels.Partial.cs
@@ -202,6 +202,27 @@ public sealed partial class ServiceTrafficEndpointReadModel
     }
 }
 
+public sealed partial class ServiceInvocationCatalogReadModel : IProjectionReadModel<ServiceInvocationCatalogReadModel>
+{
+    public DateTimeOffset UpdatedAt
+    {
+        get => ObservedAt;
+        set => ObservedAt = value;
+    }
+
+    public DateTimeOffset ObservedAt
+    {
+        get => ServiceProjectionReadModelSupport.ToDateTimeOffset(ObservedAtUtcValue);
+        set => ObservedAtUtcValue = ServiceProjectionReadModelSupport.ToTimestamp(value);
+    }
+
+    public IList<ServiceInvocationReadinessEntryReadModel> Entries
+    {
+        get => EntryEntries;
+        set => ServiceProjectionReadModelSupport.ReplaceCollection(EntryEntries, value);
+    }
+}
+
 public sealed partial class ServiceRunCurrentStateReadModel : IProjectionReadModel<ServiceRunCurrentStateReadModel>
 {
     public DateTimeOffset CreatedAt

--- a/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
+++ b/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
@@ -7,6 +7,7 @@ option csharp_namespace = "Aevatar.GAgentService.Projection.ReadModels";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/struct.proto";
 import "llm_sessions.proto";
+import "service_invocation_catalog.proto";
 import "service_revision.proto";
 
 // --- ServiceCatalogReadModel ---
@@ -176,6 +177,35 @@ message ServiceTrafficTargetReadModel {
   string primary_actor_id = 3;
   int32 allocation_weight = 4;
   string serving_state = 5;
+}
+
+// --- ServiceInvocationCatalogReadModel ---
+
+message ServiceInvocationCatalogReadModel {
+  string id = 1;
+  string actor_id = 2;
+  int64 state_version = 3;
+  string last_event_id = 4;
+  string tenant_id = 5;
+  string app_id = 6;
+  string namespace = 7;
+  string service_id = 8;
+  string service_key = 9;
+  google.protobuf.Timestamp observed_at_utc_value = 10;
+  int64 source_catalog_version = 11;
+  int64 source_serving_version = 12;
+  int64 source_revision_version = 13;
+  repeated ServiceInvocationReadinessEntryReadModel entry_entries = 14;
+}
+
+message ServiceInvocationReadinessEntryReadModel {
+  string service_key = 1;
+  string endpoint_id = 2;
+  aevatar.gagentservice.ServiceInvokeReadinessStatus readiness_status = 3;
+  aevatar.gagentservice.ServiceInvokeUnavailableReason unavailable_reason = 4;
+  string selected_revision_id = 5;
+  string selected_deployment_id = 6;
+  string selected_actor_id = 7;
 }
 
 // --- ServiceRunCurrentStateReadModel ---

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -313,16 +313,123 @@ public sealed class ScopeServiceEndpointsTests
                 ],
                 [],
                 DateTimeOffset.UtcNow),
+            new ServiceCatalogSnapshot(
+                "scope-a:default:default:billing",
+                "scope-a",
+                "default",
+                "default",
+                "billing",
+                "Billing",
+                "rev-2",
+                "rev-2",
+                "dep-2",
+                "billing-actor",
+                "Active",
+                [
+                    new ServiceEndpointSnapshot(
+                        "charge",
+                        "Charge",
+                        "command",
+                        Any.Pack(new StringValue()).TypeUrl,
+                        string.Empty,
+                        "Charge command"),
+                ],
+                [],
+                DateTimeOffset.UtcNow),
+            new ServiceCatalogSnapshot(
+                "scope-a:default:default:search",
+                "scope-a",
+                "default",
+                "default",
+                "search",
+                "Search",
+                "rev-3",
+                "rev-3",
+                "dep-3",
+                "search-actor",
+                "Active",
+                [
+                    new ServiceEndpointSnapshot(
+                        "query",
+                        "Query",
+                        "command",
+                        Any.Pack(new StringValue()).TypeUrl,
+                        string.Empty,
+                        "Query command"),
+                ],
+                [],
+                DateTimeOffset.UtcNow),
+            new ServiceCatalogSnapshot(
+                "scope-a:default:default:audit",
+                "scope-a",
+                "default",
+                "default",
+                "audit",
+                "Audit",
+                "rev-4",
+                "rev-4",
+                "dep-4",
+                "audit-actor",
+                "Active",
+                [
+                    new ServiceEndpointSnapshot(
+                        "archive",
+                        "Archive",
+                        "command",
+                        Any.Pack(new StringValue()).TypeUrl,
+                        string.Empty,
+                        "Archive command"),
+                ],
+                [],
+                DateTimeOffset.UtcNow),
         ];
+        host.InvocationCatalogReader.CatalogsByServiceKey["scope-a:default:default:orders"] = BuildScopeInvocationCatalog(
+            "scope-a:default:default:orders",
+            "run",
+            ServiceInvokeReadinessStatus.Ready,
+            ServiceInvokeUnavailableReason.Unspecified,
+            "rev-1",
+            "dep-1",
+            "orders-actor",
+            31);
+        host.InvocationCatalogReader.CatalogsByServiceKey["scope-a:default:default:billing"] = BuildScopeInvocationCatalog(
+            "scope-a:default:default:billing",
+            "charge",
+            ServiceInvokeReadinessStatus.Unavailable,
+            ServiceInvokeUnavailableReason.RevisionNotPrepared,
+            "rev-2",
+            "dep-2",
+            "billing-actor",
+            32);
+        host.InvocationCatalogReader.CatalogsByServiceKey["scope-a:default:default:audit"] = new ServiceInvocationCatalogSnapshot(
+            "scope-a:default:default:audit",
+            [],
+            DateTimeOffset.Parse("2026-03-14T00:06:00+00:00"),
+            33,
+            "evt-33",
+            30,
+            31,
+            32);
 
         var response = await host.Client.GetAsync("/api/scopes/scope-a/services?take=25");
-        var body = await response.Content.ReadFromJsonAsync<IReadOnlyList<ServiceCatalogSnapshot>>();
+        var body = await response.Content.ReadFromJsonAsync<IReadOnlyList<ScopeServiceEndpoints.ScopeServiceHttpResponse>>();
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         body.Should().NotBeNull();
-        body!.Should().ContainSingle();
-        body[0].ServiceId.Should().Be("orders");
-        body[0].Endpoints.Should().ContainSingle(x => x.EndpointId == "run");
+        body!.Should().HaveCount(4);
+        body.Single(x => x.ServiceId == "orders").Endpoints.Should().ContainSingle(x => x.EndpointId == "run");
+        body.Single(x => x.ServiceId == "orders").InvokeReady.Should().BeTrue();
+        body.Single(x => x.ServiceId == "orders").InvokeReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Ready.ToString());
+        body.Single(x => x.ServiceId == "orders").InvokeUnavailableReason.Should().BeNull();
+        body.Single(x => x.ServiceId == "billing").InvokeReady.Should().BeFalse();
+        body.Single(x => x.ServiceId == "billing").InvokeReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Unavailable.ToString());
+        body.Single(x => x.ServiceId == "billing").InvokeUnavailableReason.Should().Be(ServiceInvokeUnavailableReason.RevisionNotPrepared.ToString());
+        body.Single(x => x.ServiceId == "search").InvokeReady.Should().BeFalse();
+        body.Single(x => x.ServiceId == "search").InvokeReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Unspecified.ToString());
+        body.Single(x => x.ServiceId == "search").InvokeUnavailableReason.Should().BeNull();
+        body.Single(x => x.ServiceId == "audit").InvokeReady.Should().BeFalse();
+        body.Single(x => x.ServiceId == "audit").InvokeReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Unspecified.ToString());
+        body.Single(x => x.ServiceId == "audit").InvokeUnavailableReason.Should().BeNull();
         host.LifecycleQueryPort.LastListTenantId.Should().Be("scope-a");
         host.LifecycleQueryPort.LastListAppId.Should().Be("default");
         host.LifecycleQueryPort.LastListNamespace.Should().Be("default");
@@ -4787,6 +4894,40 @@ public sealed class ScopeServiceEndpointsTests
             ],
             DateTimeOffset.UtcNow);
 
+    private static ServiceInvocationCatalogSnapshot BuildScopeInvocationCatalog(
+        string serviceKey,
+        string endpointId,
+        ServiceInvokeReadinessStatus status,
+        ServiceInvokeUnavailableReason reason,
+        string revisionId,
+        string deploymentId,
+        string actorId,
+        long stateVersion) =>
+        new(
+            serviceKey,
+            [
+                new ServiceInvokeReadinessSnapshot(
+                    serviceKey,
+                    endpointId,
+                    status,
+                    reason,
+                    revisionId,
+                    deploymentId,
+                    actorId,
+                    DateTimeOffset.Parse("2026-03-14T00:05:00+00:00"),
+                    stateVersion,
+                    $"evt-{stateVersion}",
+                    stateVersion - 2,
+                    stateVersion - 1,
+                    stateVersion),
+            ],
+            DateTimeOffset.Parse("2026-03-14T00:05:00+00:00"),
+            stateVersion,
+            $"evt-{stateVersion}",
+            stateVersion - 2,
+            stateVersion - 1,
+            stateVersion);
+
     private static HttpRequestMessage CreateAuthenticatedJsonRequest(
         HttpMethod method,
         string requestUri,
@@ -5711,12 +5852,18 @@ public sealed class ScopeServiceEndpointsTests
         FakeServiceCatalogQueryReader catalogReader,
         FakeServiceTrafficViewQueryReader trafficViewReader) : IServiceInvocationCatalogQueryReader
     {
+        public Dictionary<string, ServiceInvocationCatalogSnapshot?> CatalogsByServiceKey { get; } = new(StringComparer.Ordinal);
+
         public ServiceInvocationCatalogSnapshot? Catalog { get; set; }
 
         public Task<ServiceInvocationCatalogSnapshot?> GetAsync(ServiceIdentity identity, CancellationToken ct = default)
         {
             if (Catalog != null)
                 return Task.FromResult<ServiceInvocationCatalogSnapshot?>(Catalog);
+
+            var serviceKey = ServiceKeys.Build(identity);
+            if (CatalogsByServiceKey.TryGetValue(serviceKey, out var configuredCatalog))
+                return Task.FromResult(configuredCatalog);
 
             var service = catalogReader.Service;
             var trafficEndpoint = trafficViewReader.View?.Endpoints.FirstOrDefault();
@@ -5726,7 +5873,6 @@ public sealed class ScopeServiceEndpointsTests
             if (service == null && target == null)
                 return Task.FromResult<ServiceInvocationCatalogSnapshot?>(null);
 
-            var serviceKey = ServiceKeys.Build(identity);
             return Task.FromResult<ServiceInvocationCatalogSnapshot?>(new ServiceInvocationCatalogSnapshot(
                 serviceKey,
                 [

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -4848,6 +4848,7 @@ public sealed class ScopeServiceEndpointsTests
             RecordingServiceServingQueryPort servingQueryPort,
             FakeServiceCatalogQueryReader serviceCatalogReader,
             FakeServiceTrafficViewQueryReader trafficViewReader,
+            FakeServiceInvocationCatalogQueryReader invocationCatalogReader,
             FakeServiceRevisionCatalogQueryReader revisionCatalog,
             FakeTeamEntryMemberResolver teamEntryMemberResolver,
             FakeCommandInteractionService interactionService,
@@ -4871,6 +4872,7 @@ public sealed class ScopeServiceEndpointsTests
             ServingQueryPort = servingQueryPort;
             ServiceCatalogReader = serviceCatalogReader;
             TrafficViewReader = trafficViewReader;
+            InvocationCatalogReader = invocationCatalogReader;
             RevisionCatalog = revisionCatalog;
             TeamEntryMemberResolver = teamEntryMemberResolver;
             InteractionService = interactionService;
@@ -4911,6 +4913,8 @@ public sealed class ScopeServiceEndpointsTests
         public FakeServiceCatalogQueryReader ServiceCatalogReader { get; }
 
         public FakeServiceTrafficViewQueryReader TrafficViewReader { get; }
+
+        public FakeServiceInvocationCatalogQueryReader InvocationCatalogReader { get; }
 
         public FakeServiceRevisionCatalogQueryReader RevisionCatalog { get; }
 
@@ -4954,6 +4958,7 @@ public sealed class ScopeServiceEndpointsTests
             var servingQueryPort = new RecordingServiceServingQueryPort();
             var serviceCatalogReader = new FakeServiceCatalogQueryReader();
             var trafficViewReader = new FakeServiceTrafficViewQueryReader();
+            var invocationCatalogReader = new FakeServiceInvocationCatalogQueryReader(serviceCatalogReader, trafficViewReader);
             var revisionCatalog = new FakeServiceRevisionCatalogQueryReader();
             var teamEntryMemberResolver = new FakeTeamEntryMemberResolver();
             var interactionService = new FakeCommandInteractionService();
@@ -4992,9 +4997,11 @@ public sealed class ScopeServiceEndpointsTests
             builder.Services.AddSingleton<IMemberPublishedServiceResolver, DefaultMemberPublishedServiceResolver>();
             builder.Services.AddSingleton<IServiceCatalogQueryReader>(serviceCatalogReader);
             builder.Services.AddSingleton<IServiceTrafficViewQueryReader>(trafficViewReader);
+            builder.Services.AddSingleton<IServiceInvocationCatalogQueryReader>(invocationCatalogReader);
             builder.Services.AddSingleton<IServiceRevisionCatalogQueryReader>(revisionCatalog);
             builder.Services.AddSingleton<ITeamEntryMemberResolver>(teamEntryMemberResolver);
             builder.Services.AddSingleton<ServiceInvocationResolutionService>();
+            builder.Services.AddSingleton<ServiceInvokeReadinessErrorMapper>();
             builder.Services.AddSingleton<IInvokeAdmissionAuthorizer, AllowAllInvokeAdmissionAuthorizer>();
             builder.Services.AddSingleton<IWorkflowChatRunInteractionPort>(interactionService);
             builder.Services.AddSingleton<IGAgentDraftRunInteractionPort>(gagentDraftRunInteractionService);
@@ -5112,6 +5119,7 @@ public sealed class ScopeServiceEndpointsTests
                 servingQueryPort,
                 serviceCatalogReader,
                 trafficViewReader,
+                invocationCatalogReader,
                 revisionCatalog,
                 teamEntryMemberResolver,
                 interactionService,
@@ -5649,6 +5657,53 @@ public sealed class ScopeServiceEndpointsTests
 
         public Task<ServiceTrafficViewSnapshot?> GetAsync(ServiceIdentity identity, CancellationToken ct = default) =>
             Task.FromResult(View);
+    }
+
+    private sealed class FakeServiceInvocationCatalogQueryReader(
+        FakeServiceCatalogQueryReader catalogReader,
+        FakeServiceTrafficViewQueryReader trafficViewReader) : IServiceInvocationCatalogQueryReader
+    {
+        public ServiceInvocationCatalogSnapshot? Catalog { get; set; }
+
+        public Task<ServiceInvocationCatalogSnapshot?> GetAsync(ServiceIdentity identity, CancellationToken ct = default)
+        {
+            if (Catalog != null)
+                return Task.FromResult<ServiceInvocationCatalogSnapshot?>(Catalog);
+
+            var service = catalogReader.Service;
+            var trafficEndpoint = trafficViewReader.View?.Endpoints.FirstOrDefault();
+            var target = trafficEndpoint?.Targets.FirstOrDefault(x =>
+                string.Equals(x.ServingState, ServiceServingState.Active.ToString(), StringComparison.Ordinal) &&
+                x.AllocationWeight > 0);
+            if (service == null && target == null)
+                return Task.FromResult<ServiceInvocationCatalogSnapshot?>(null);
+
+            var serviceKey = ServiceKeys.Build(identity);
+            return Task.FromResult<ServiceInvocationCatalogSnapshot?>(new ServiceInvocationCatalogSnapshot(
+                serviceKey,
+                [
+                    new ServiceInvokeReadinessSnapshot(
+                        serviceKey,
+                        trafficEndpoint?.EndpointId ?? service?.Endpoints.FirstOrDefault()?.EndpointId ?? "chat",
+                        ServiceInvokeReadinessStatus.Ready,
+                        ServiceInvokeUnavailableReason.Unspecified,
+                        target?.RevisionId ?? service?.ActiveServingRevisionId ?? "rev-active",
+                        target?.DeploymentId ?? service?.DeploymentId ?? "dep-1",
+                        target?.PrimaryActorId ?? service?.PrimaryActorId ?? "actor-1",
+                        DateTimeOffset.UtcNow,
+                        1,
+                        $"{serviceKey}:invocation-catalog:1",
+                        1,
+                        1,
+                        1),
+                ],
+                DateTimeOffset.UtcNow,
+                1,
+                $"{serviceKey}:invocation-catalog:1",
+                1,
+                1,
+                1));
+        }
     }
 
     private sealed class FakeServiceRevisionCatalogQueryReader : IServiceRevisionCatalogQueryReader

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Reflection;
 using System.Security.Claims;
+using System.Text.Json;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.CQRS.Core.Abstractions.Commands;
@@ -3081,6 +3082,53 @@ public sealed class ScopeServiceEndpointsTests
         response.StatusCode.Should().Be(HttpStatusCode.Conflict);
         body.Should().NotBeNull();
         body!["code"].Should().Be("SCOPE_SERVICE_INVOKE_TARGET_UNAVAILABLE");
+    }
+
+    [Fact]
+    public async Task InvokeEndpoint_ShouldReturnInvokeUnavailableBody_WhenReadinessRejectsInvocation()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.InvocationPort.ExceptionFactory = _ => new ServiceInvokeReadinessException(
+            "Endpoint 'chat' is not invoke-ready.",
+            new ServiceInvokeReadinessSnapshot(
+                "scope-a:default:default:orders",
+                "chat",
+                ServiceInvokeReadinessStatus.Unavailable,
+                ServiceInvokeUnavailableReason.RevisionNotPrepared,
+                "rev-2",
+                "dep-2",
+                "actor-2",
+                DateTimeOffset.Parse("2026-06-05T03:00:00+00:00"),
+                13,
+                "evt-13",
+                11,
+                12,
+                13));
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/services/orders/invoke/chat", new
+        {
+            payloadTypeUrl = "type.googleapis.com/google.protobuf.Empty",
+            payloadBase64 = "",
+        });
+        var body = await response.Content.ReadFromJsonAsync<Dictionary<string, JsonElement>>();
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        body.Should().NotBeNull();
+        body!["code"].GetString().Should().Be("SERVICE_INVOKE_UNAVAILABLE");
+        body["message"].GetString().Should().Be("Endpoint 'chat' is not invoke-ready.");
+        body["readinessStatus"].GetString().Should().Be(ServiceInvokeReadinessStatus.Unavailable.ToString());
+        body["reason"].GetString().Should().Be(ServiceInvokeUnavailableReason.RevisionNotPrepared.ToString());
+        body["serviceKey"].GetString().Should().Be("scope-a:default:default:orders");
+        body["revisionId"].GetString().Should().Be("rev-2");
+        body["endpointId"].GetString().Should().Be("chat");
+        body["deploymentId"].GetString().Should().Be("dep-2");
+        body["observedAt"].GetDateTimeOffset().Should().Be(DateTimeOffset.Parse("2026-06-05T03:00:00+00:00"));
+        body["aggregateStateVersion"].GetInt64().Should().Be(13);
+        body["sourceCatalogVersion"].GetInt64().Should().Be(11);
+        body["sourceServingVersion"].GetInt64().Should().Be(12);
+        body["sourceRevisionVersion"].GetInt64().Should().Be(13);
+        host.InvocationPort.LastRequest.Should().NotBeNull();
+        host.InvocationPort.LastRequest!.Identity.ServiceId.Should().Be("orders");
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Integration.Tests/ServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ServiceEndpointsTests.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using Aevatar.Authentication.Abstractions;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Commands;
@@ -612,6 +613,54 @@ public sealed class ServiceEndpointsTests
         host.InvocationPort.LastRequest!.Payload.Value.Length.Should().Be(0);
         host.InvocationPort.LastRequest.CommandId.Should().Be("cmd-2");
         host.InvocationPort.LastRequest.CorrelationId.Should().Be("corr-2");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ShouldReturnInvokeUnavailableBody_WhenReadinessRejectsInvocation()
+    {
+        await using var host = await EndpointTestHost.StartAsync();
+        host.InvocationPort.ExceptionFactory = _ => new ServiceInvokeReadinessException(
+            "Endpoint 'chat' is not invoke-ready.",
+            new ServiceInvokeReadinessSnapshot(
+                "tenant:app:ns:orders",
+                "chat",
+                ServiceInvokeReadinessStatus.Unavailable,
+                ServiceInvokeUnavailableReason.PreparedArtifactMissing,
+                "rev-1",
+                "dep-1",
+                "actor-1",
+                DateTimeOffset.Parse("2026-06-05T02:00:00+00:00"),
+                8,
+                "evt-8",
+                3,
+                5,
+                7));
+
+        var response = await host.Client.PostAsJsonAsync("/api/services/orders/invoke/chat", new ServiceEndpoints.InvokeServiceHttpRequest(
+            "tenant",
+            "app",
+            "ns",
+            null,
+            null,
+            "type.googleapis.com/google.protobuf.Empty",
+            null));
+        var body = await response.Content.ReadFromJsonAsync<Dictionary<string, JsonElement>>();
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        body.Should().NotBeNull();
+        body!["code"].GetString().Should().Be("SERVICE_INVOKE_UNAVAILABLE");
+        body["message"].GetString().Should().Be("Endpoint 'chat' is not invoke-ready.");
+        body["readinessStatus"].GetString().Should().Be(ServiceInvokeReadinessStatus.Unavailable.ToString());
+        body["reason"].GetString().Should().Be(ServiceInvokeUnavailableReason.PreparedArtifactMissing.ToString());
+        body["serviceKey"].GetString().Should().Be("tenant:app:ns:orders");
+        body["revisionId"].GetString().Should().Be("rev-1");
+        body["endpointId"].GetString().Should().Be("chat");
+        body["deploymentId"].GetString().Should().Be("dep-1");
+        body["observedAt"].GetDateTimeOffset().Should().Be(DateTimeOffset.Parse("2026-06-05T02:00:00+00:00"));
+        body["aggregateStateVersion"].GetInt64().Should().Be(8);
+        body["sourceCatalogVersion"].GetInt64().Should().Be(3);
+        body["sourceServingVersion"].GetInt64().Should().Be(5);
+        body["sourceRevisionVersion"].GetInt64().Should().Be(7);
     }
 
     [Fact]
@@ -1505,9 +1554,14 @@ public sealed class ServiceEndpointsTests
     {
         public ServiceInvocationRequest? LastRequest { get; private set; }
 
+        public Func<ServiceInvocationRequest, Exception?>? ExceptionFactory { get; set; }
+
         public Task<ServiceInvocationAcceptedReceipt> InvokeAsync(ServiceInvocationRequest request, CancellationToken ct = default)
         {
             LastRequest = request;
+            var exception = ExceptionFactory?.Invoke(request);
+            if (exception != null)
+                throw exception;
             return Task.FromResult(new ServiceInvocationAcceptedReceipt
             {
                 RequestId = "request-1",

--- a/test/Aevatar.GAgentService.Integration.Tests/ServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ServiceEndpointsTests.cs
@@ -6,6 +6,7 @@ using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Commands;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Services;
+using Aevatar.GAgentService.Application.Services;
 using Aevatar.GAgentService.Governance.Hosting.Identity;
 using Aevatar.GAgentService.Abstractions.Queries;
 using Aevatar.GAgentService.Hosting.Endpoints;
@@ -1188,6 +1189,7 @@ public sealed class ServiceEndpointsTests
             RecordingServiceQueryPort queryPort,
             RecordingServiceInvocationPort invocationPort,
             FakeServiceCatalogQueryReader catalogReader,
+            FakeServiceInvocationCatalogQueryReader invocationCatalogReader,
             FakeServiceRevisionCatalogQueryReader revisionCatalog)
         {
             _app = app;
@@ -1196,6 +1198,7 @@ public sealed class ServiceEndpointsTests
             QueryPort = queryPort;
             InvocationPort = invocationPort;
             CatalogReader = catalogReader;
+            InvocationCatalogReader = invocationCatalogReader;
             RevisionCatalog = revisionCatalog;
         }
 
@@ -1208,6 +1211,8 @@ public sealed class ServiceEndpointsTests
         public RecordingServiceInvocationPort InvocationPort { get; }
 
         public FakeServiceCatalogQueryReader CatalogReader { get; }
+
+        public FakeServiceInvocationCatalogQueryReader InvocationCatalogReader { get; }
 
         public FakeServiceRevisionCatalogQueryReader RevisionCatalog { get; }
 
@@ -1223,6 +1228,7 @@ public sealed class ServiceEndpointsTests
             var queryPort = new RecordingServiceQueryPort();
             var invocationPort = new RecordingServiceInvocationPort();
             var catalogReader = new FakeServiceCatalogQueryReader();
+            var invocationCatalogReader = new FakeServiceInvocationCatalogQueryReader(catalogReader);
             var revisionCatalog = new FakeServiceRevisionCatalogQueryReader();
             builder.Services.AddHttpContextAccessor();
             builder.Services.AddSingleton<IServiceCommandPort>(commandPort);
@@ -1230,7 +1236,9 @@ public sealed class ServiceEndpointsTests
             builder.Services.AddSingleton<IServiceServingQueryPort>(queryPort);
             builder.Services.AddSingleton<IServiceInvocationPort>(invocationPort);
             builder.Services.AddSingleton<IServiceCatalogQueryReader>(catalogReader);
+            builder.Services.AddSingleton<IServiceInvocationCatalogQueryReader>(invocationCatalogReader);
             builder.Services.AddSingleton<IServiceRevisionCatalogQueryReader>(revisionCatalog);
+            builder.Services.AddSingleton<ServiceInvokeReadinessErrorMapper>();
             builder.Services.AddSingleton<IServiceIdentityContextResolver, DefaultServiceIdentityContextResolver>();
 
             var app = builder.Build();
@@ -1263,7 +1271,7 @@ public sealed class ServiceEndpointsTests
                 BaseAddress = new Uri(address),
             };
 
-            return new EndpointTestHost(app, client, commandPort, queryPort, invocationPort, catalogReader, revisionCatalog);
+            return new EndpointTestHost(app, client, commandPort, queryPort, invocationPort, catalogReader, invocationCatalogReader, revisionCatalog);
         }
 
         public async ValueTask DisposeAsync()
@@ -1526,6 +1534,58 @@ public sealed class ServiceEndpointsTests
 
         public Task<IReadOnlyList<ServiceCatalogSnapshot>> QueryByScopeAsync(string tenantId, string appId, string @namespace, int take = 200, CancellationToken ct = default) =>
             Task.FromResult<IReadOnlyList<ServiceCatalogSnapshot>>(Service == null ? [] : [Service]);
+    }
+
+    private sealed class FakeServiceInvocationCatalogQueryReader(FakeServiceCatalogQueryReader catalogReader) : IServiceInvocationCatalogQueryReader
+    {
+        public ServiceInvocationCatalogSnapshot? Catalog { get; set; }
+
+        public Task<ServiceInvocationCatalogSnapshot?> GetAsync(ServiceIdentity identity, CancellationToken ct = default)
+        {
+            if (Catalog != null)
+                return Task.FromResult<ServiceInvocationCatalogSnapshot?>(Catalog);
+
+            var service = catalogReader.Service;
+            if (service == null)
+                return Task.FromResult<ServiceInvocationCatalogSnapshot?>(null);
+
+            var endpointId = service.Endpoints.FirstOrDefault()?.EndpointId;
+            if (string.IsNullOrWhiteSpace(endpointId))
+                endpointId = "chat";
+            var revisionId = string.IsNullOrWhiteSpace(service.ActiveServingRevisionId)
+                ? "rev-active"
+                : service.ActiveServingRevisionId;
+            var deploymentId = string.IsNullOrWhiteSpace(service.DeploymentId)
+                ? "dep-1"
+                : service.DeploymentId;
+            var actorId = string.IsNullOrWhiteSpace(service.PrimaryActorId)
+                ? "actor-1"
+                : service.PrimaryActorId;
+            return Task.FromResult<ServiceInvocationCatalogSnapshot?>(new ServiceInvocationCatalogSnapshot(
+                ServiceKeys.Build(identity),
+                [
+                    new ServiceInvokeReadinessSnapshot(
+                        ServiceKeys.Build(identity),
+                        endpointId,
+                        ServiceInvokeReadinessStatus.Ready,
+                        ServiceInvokeUnavailableReason.Unspecified,
+                        revisionId,
+                        deploymentId,
+                        actorId,
+                        DateTimeOffset.UtcNow,
+                        1,
+                        $"{ServiceKeys.Build(identity)}:invocation-catalog:1",
+                        1,
+                        1,
+                        1),
+                ],
+                DateTimeOffset.UtcNow,
+                1,
+                $"{ServiceKeys.Build(identity)}:invocation-catalog:1",
+                1,
+                1,
+                1));
+        }
     }
 
     private sealed class FakeServiceRevisionCatalogQueryReader : IServiceRevisionCatalogQueryReader

--- a/test/Aevatar.GAgentService.Integration.Tests/ServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ServiceEndpointsTests.cs
@@ -493,8 +493,60 @@ public sealed class ServiceEndpointsTests
                 ],
                 [],
                 DateTimeOffset.Parse("2026-03-14T00:00:00+00:00")),
+            new ServiceCatalogSnapshot(
+                "tenant/app/ns/billing",
+                "tenant",
+                "app",
+                "ns",
+                "billing",
+                "Billing",
+                "rev-2",
+                "rev-2",
+                "dep-2",
+                "actor-2",
+                "active",
+                [
+                    new ServiceEndpointSnapshot("charge", "Charge", "command", "req", string.Empty, "charge"),
+                ],
+                [],
+                DateTimeOffset.Parse("2026-03-14T00:10:00+00:00")),
+            new ServiceCatalogSnapshot(
+                "tenant/app/ns/search",
+                "tenant",
+                "app",
+                "ns",
+                "search",
+                "Search",
+                "rev-3",
+                "rev-3",
+                "dep-3",
+                "actor-3",
+                "active",
+                [
+                    new ServiceEndpointSnapshot("query", "Query", "command", "req", string.Empty, "query"),
+                ],
+                [],
+                DateTimeOffset.Parse("2026-03-14T00:20:00+00:00")),
         ];
         host.QueryPort.GetServiceResult = host.QueryPort.ListServicesResult[0];
+        host.InvocationCatalogReader.CatalogsByServiceKey["tenant:app:ns:orders"] = BuildInvocationCatalog(
+            "tenant:app:ns:orders",
+            "submit",
+            ServiceInvokeReadinessStatus.Ready,
+            ServiceInvokeUnavailableReason.Unspecified,
+            "rev-1",
+            "dep-1",
+            "actor-1",
+            21);
+        host.InvocationCatalogReader.CatalogsByServiceKey["tenant:app:ns:billing"] = BuildInvocationCatalog(
+            "tenant:app:ns:billing",
+            "charge",
+            ServiceInvokeReadinessStatus.Unavailable,
+            ServiceInvokeUnavailableReason.PreparedArtifactMissing,
+            "rev-2",
+            "dep-2",
+            "actor-2",
+            22);
         host.QueryPort.GetServiceRevisionsResult = new ServiceRevisionCatalogSnapshot(
             "tenant/app/ns/orders",
             [
@@ -514,12 +566,24 @@ public sealed class ServiceEndpointsTests
             ],
             DateTimeOffset.Parse("2026-03-14T00:03:00+00:00"));
 
-        var listResponse = await host.Client.GetFromJsonAsync<List<ServiceCatalogSnapshot>>("/api/services/?take=10");
-        var getResponse = await host.Client.GetFromJsonAsync<ServiceCatalogSnapshot>("/api/services/orders?tenantId=tenant&appId=app&namespace=ns");
+        var listResponse = await host.Client.GetFromJsonAsync<List<ServiceEndpoints.ServiceWithInvokeReadinessHttpResponse>>("/api/services/?take=10");
+        var getResponse = await host.Client.GetFromJsonAsync<ServiceEndpoints.ServiceWithInvokeReadinessHttpResponse>("/api/services/orders?tenantId=tenant&appId=app&namespace=ns");
         var revisionResponse = await host.Client.GetFromJsonAsync<ServiceRevisionCatalogSnapshot>("/api/services/orders/revisions?tenantId=tenant&appId=app&namespace=ns");
 
-        listResponse.Should().ContainSingle();
+        listResponse.Should().HaveCount(3);
+        listResponse!.Single(x => x.ServiceId == "orders").InvokeReady.Should().BeTrue();
+        listResponse.Single(x => x.ServiceId == "orders").InvokeReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Ready.ToString());
+        listResponse.Single(x => x.ServiceId == "orders").InvokeUnavailableReason.Should().BeNull();
+        listResponse.Single(x => x.ServiceId == "billing").InvokeReady.Should().BeFalse();
+        listResponse.Single(x => x.ServiceId == "billing").InvokeReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Unavailable.ToString());
+        listResponse.Single(x => x.ServiceId == "billing").InvokeUnavailableReason.Should().Be(ServiceInvokeUnavailableReason.PreparedArtifactMissing.ToString());
+        listResponse.Single(x => x.ServiceId == "search").InvokeReady.Should().BeFalse();
+        listResponse.Single(x => x.ServiceId == "search").InvokeReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Unspecified.ToString());
+        listResponse.Single(x => x.ServiceId == "search").InvokeUnavailableReason.Should().BeNull();
         getResponse!.ServiceId.Should().Be("orders");
+        getResponse.InvokeReady.Should().BeTrue();
+        getResponse.InvokeReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Ready.ToString());
+        getResponse.InvokeUnavailableReason.Should().BeNull();
         revisionResponse!.Revisions.Should().ContainSingle();
         host.QueryPort.LastListServicesTake.Should().Be(10);
         host.QueryPort.LastGetServiceIdentity!.ServiceId.Should().Be("orders");
@@ -562,6 +626,47 @@ public sealed class ServiceEndpointsTests
             Namespace = "ns-claim",
             ServiceId = "orders",
         });
+    }
+
+    [Fact]
+    public async Task GetServiceAsync_ShouldReturnUnspecifiedInvokeReadiness_WhenInvocationCatalogHasNoEntries()
+    {
+        await using var host = await EndpointTestHost.StartAsync();
+        host.QueryPort.GetServiceResult = new ServiceCatalogSnapshot(
+            "tenant/app/ns/orders",
+            "tenant",
+            "app",
+            "ns",
+            "orders",
+            "Orders",
+            "rev-1",
+            "rev-1",
+            "dep-1",
+            "actor-1",
+            "active",
+            [
+                new ServiceEndpointSnapshot("submit", "Submit", "command", "req", string.Empty, "desc"),
+            ],
+            [],
+            DateTimeOffset.Parse("2026-03-14T00:00:00+00:00"));
+        host.InvocationCatalogReader.CatalogsByServiceKey["tenant:app:ns:orders"] = new ServiceInvocationCatalogSnapshot(
+            "tenant:app:ns:orders",
+            [],
+            DateTimeOffset.Parse("2026-03-14T00:05:00+00:00"),
+            5,
+            "evt-5",
+            2,
+            3,
+            4);
+
+        var response = await host.Client.GetFromJsonAsync<ServiceEndpoints.ServiceWithInvokeReadinessHttpResponse>(
+            "/api/services/orders?tenantId=tenant&appId=app&namespace=ns");
+
+        response.Should().NotBeNull();
+        response!.ServiceId.Should().Be("orders");
+        response.InvokeReady.Should().BeFalse();
+        response.InvokeReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Unspecified.ToString());
+        response.InvokeUnavailableReason.Should().BeNull();
     }
 
     [Fact]
@@ -977,12 +1082,15 @@ public sealed class ServiceEndpointsTests
             [],
             DateTimeOffset.UtcNow);
 
-        var listResponse = await host.Client.GetFromJsonAsync<List<ServiceCatalogSnapshot>>("/api/services");
-        var getResponse = await host.Client.GetFromJsonAsync<ServiceCatalogSnapshot>("/api/services/orders");
+        var listResponse = await host.Client.GetFromJsonAsync<List<ServiceEndpoints.ServiceWithInvokeReadinessHttpResponse>>("/api/services");
+        var getResponse = await host.Client.GetFromJsonAsync<ServiceEndpoints.ServiceWithInvokeReadinessHttpResponse>("/api/services/orders");
         var revisionsResponse = await host.Client.GetFromJsonAsync<ServiceRevisionCatalogSnapshot>("/api/services/orders/revisions");
 
         listResponse.Should().BeEmpty();
         getResponse.Should().NotBeNull();
+        getResponse!.InvokeReady.Should().BeFalse();
+        getResponse.InvokeReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Unspecified.ToString());
+        getResponse.InvokeUnavailableReason.Should().BeNull();
         revisionsResponse.Should().NotBeNull();
         host.QueryPort.LastListServicesTake.Should().Be(200);
         host.QueryPort.LastGetServiceIdentity.Should().BeEquivalentTo(new ServiceIdentity
@@ -1592,12 +1700,18 @@ public sealed class ServiceEndpointsTests
 
     private sealed class FakeServiceInvocationCatalogQueryReader(FakeServiceCatalogQueryReader catalogReader) : IServiceInvocationCatalogQueryReader
     {
+        public Dictionary<string, ServiceInvocationCatalogSnapshot?> CatalogsByServiceKey { get; } = new(StringComparer.Ordinal);
+
         public ServiceInvocationCatalogSnapshot? Catalog { get; set; }
 
         public Task<ServiceInvocationCatalogSnapshot?> GetAsync(ServiceIdentity identity, CancellationToken ct = default)
         {
             if (Catalog != null)
                 return Task.FromResult<ServiceInvocationCatalogSnapshot?>(Catalog);
+
+            var serviceKey = ServiceKeys.Build(identity);
+            if (CatalogsByServiceKey.TryGetValue(serviceKey, out var configuredCatalog))
+                return Task.FromResult(configuredCatalog);
 
             var service = catalogReader.Service;
             if (service == null)
@@ -1616,10 +1730,10 @@ public sealed class ServiceEndpointsTests
                 ? "actor-1"
                 : service.PrimaryActorId;
             return Task.FromResult<ServiceInvocationCatalogSnapshot?>(new ServiceInvocationCatalogSnapshot(
-                ServiceKeys.Build(identity),
+                serviceKey,
                 [
                     new ServiceInvokeReadinessSnapshot(
-                        ServiceKeys.Build(identity),
+                        serviceKey,
                         endpointId,
                         ServiceInvokeReadinessStatus.Ready,
                         ServiceInvokeUnavailableReason.Unspecified,
@@ -1628,19 +1742,53 @@ public sealed class ServiceEndpointsTests
                         actorId,
                         DateTimeOffset.UtcNow,
                         1,
-                        $"{ServiceKeys.Build(identity)}:invocation-catalog:1",
+                        $"{serviceKey}:invocation-catalog:1",
                         1,
                         1,
                         1),
                 ],
                 DateTimeOffset.UtcNow,
                 1,
-                $"{ServiceKeys.Build(identity)}:invocation-catalog:1",
+                $"{serviceKey}:invocation-catalog:1",
                 1,
                 1,
                 1));
         }
     }
+
+    private static ServiceInvocationCatalogSnapshot BuildInvocationCatalog(
+        string serviceKey,
+        string endpointId,
+        ServiceInvokeReadinessStatus status,
+        ServiceInvokeUnavailableReason reason,
+        string revisionId,
+        string deploymentId,
+        string actorId,
+        long stateVersion) =>
+        new(
+            serviceKey,
+            [
+                new ServiceInvokeReadinessSnapshot(
+                    serviceKey,
+                    endpointId,
+                    status,
+                    reason,
+                    revisionId,
+                    deploymentId,
+                    actorId,
+                    DateTimeOffset.Parse("2026-03-14T00:04:00+00:00"),
+                    stateVersion,
+                    $"evt-{stateVersion}",
+                    stateVersion - 2,
+                    stateVersion - 1,
+                    stateVersion),
+            ],
+            DateTimeOffset.Parse("2026-03-14T00:04:00+00:00"),
+            stateVersion,
+            $"evt-{stateVersion}",
+            stateVersion - 2,
+            stateVersion - 1,
+            stateVersion);
 
     private sealed class FakeServiceRevisionCatalogQueryReader : IServiceRevisionCatalogQueryReader
     {

--- a/test/Aevatar.GAgentService.Tests/Application/ApplicationServiceGuardTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ApplicationServiceGuardTests.cs
@@ -40,14 +40,14 @@ public sealed class ApplicationServiceGuardTests
         Action nullAuthorizer = () => new ServiceInvocationApplicationService(
             new ServiceInvocationResolutionService(
                 new NoOpCatalogQueryReader(),
-                new NoOpTrafficViewQueryReader(),
+                new NoOpInvocationCatalogQueryReader(),
                 new FakeServiceRevisionCatalogQueryReader()),
             null!,
             new NoOpInvocationDispatcher());
         Action nullDispatcher = () => new ServiceInvocationApplicationService(
             new ServiceInvocationResolutionService(
                 new NoOpCatalogQueryReader(),
-                new NoOpTrafficViewQueryReader(),
+                new NoOpInvocationCatalogQueryReader(),
                 new FakeServiceRevisionCatalogQueryReader()),
             new NoOpInvokeAdmissionAuthorizer(),
             null!);
@@ -241,6 +241,7 @@ public sealed class ApplicationServiceGuardTests
         public Task<string> EnsureDeploymentTargetAsync(ServiceIdentity identity, CancellationToken ct = default) => Task.FromResult("deployment");
         public Task<string> EnsureServingSetTargetAsync(ServiceIdentity identity, CancellationToken ct = default) => Task.FromResult("serving");
         public Task<string> EnsureRolloutTargetAsync(ServiceIdentity identity, CancellationToken ct = default) => Task.FromResult("rollout");
+        public Task<string> EnsureInvocationCatalogTargetAsync(ServiceIdentity identity, CancellationToken ct = default) => Task.FromResult("invocation");
     }
 
     private sealed class NoOpGovernanceCommandTargetProvisioner : IServiceGovernanceCommandTargetProvisioner
@@ -288,6 +289,12 @@ public sealed class ApplicationServiceGuardTests
     {
         public Task<ServiceTrafficViewSnapshot?> GetAsync(ServiceIdentity identity, CancellationToken ct = default) =>
             Task.FromResult<ServiceTrafficViewSnapshot?>(null);
+    }
+
+    private sealed class NoOpInvocationCatalogQueryReader : IServiceInvocationCatalogQueryReader
+    {
+        public Task<ServiceInvocationCatalogSnapshot?> GetAsync(ServiceIdentity identity, CancellationToken ct = default) =>
+            Task.FromResult<ServiceInvocationCatalogSnapshot?>(null);
     }
 
     private sealed class NoOpRolloutCommandObservationQueryReader : IServiceRolloutCommandObservationQueryReader

--- a/test/Aevatar.GAgentService.Tests/Application/ServiceCommandApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ServiceCommandApplicationServiceTests.cs
@@ -40,6 +40,9 @@ public sealed class ServiceCommandApplicationServiceTests
         provisioner.RevisionCatalogRequests.Should().ContainSingle();
         provisioner.DeploymentRequests.Should().ContainSingle();
         provisioner.ServingSetRequests.Should().ContainSingle();
+        provisioner.InvocationCatalogRequests.Should().HaveCount(3);
+        provisioner.InvocationCatalogRequests.Should().OnlyContain(x =>
+            ServiceKeys.Build(x) == ServiceKeys.Build(identity));
         dispatchPort.Calls.Should().HaveCount(3);
     }
 
@@ -70,6 +73,9 @@ public sealed class ServiceCommandApplicationServiceTests
         defaultReceipt.TargetActorId.Should().Be(ServiceActorIds.Definition(identity));
         defaultReceipt.CorrelationId.Should().Be($"{ServiceKeys.Build(identity)}:rev-1");
         provisioner.DefinitionRequests.Should().HaveCount(3);
+        provisioner.InvocationCatalogRequests.Should().HaveCount(3);
+        provisioner.InvocationCatalogRequests.Should().OnlyContain(x =>
+            ServiceKeys.Build(x) == ServiceKeys.Build(identity));
         dispatchPort.Calls.Select(x => x.envelope.Payload.TypeUrl).Should().Contain([
             AnyTypeUrl<CreateServiceDefinitionCommand>(),
             AnyTypeUrl<UpdateServiceDefinitionCommand>(),
@@ -110,6 +116,9 @@ public sealed class ServiceCommandApplicationServiceTests
         publishReceipt.CorrelationId.Should().Be($"{ServiceKeys.Build(identity)}:r3");
         retireReceipt.CorrelationId.Should().Be($"{ServiceKeys.Build(identity)}:r4");
         provisioner.RevisionCatalogRequests.Should().HaveCount(4);
+        provisioner.InvocationCatalogRequests.Should().HaveCount(4);
+        provisioner.InvocationCatalogRequests.Should().OnlyContain(x =>
+            ServiceKeys.Build(x) == ServiceKeys.Build(identity));
         dispatchPort.Calls.Select(x => x.actorId).Should().OnlyContain(x => x == ServiceActorIds.RevisionCatalog(identity));
         dispatchPort.Calls.Select(x => x.envelope.Payload.TypeUrl).Should().Contain([
             AnyTypeUrl<CreateServiceRevisionCommand>(),
@@ -143,6 +152,8 @@ public sealed class ServiceCommandApplicationServiceTests
         deactivateReceipt.CorrelationId.Should().Be($"{ServiceKeys.Build(identity)}:dep-1");
         provisioner.DeploymentRequests.Should().HaveCount(2);
         provisioner.ServingSetRequests.Should().ContainSingle();
+        provisioner.InvocationCatalogRequests.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(identity);
         dispatchPort.Calls.Select(x => x.envelope.Payload.TypeUrl).Should().Contain([
             AnyTypeUrl<ActivateServiceRevisionCommand>(),
             AnyTypeUrl<DeactivateServiceDeploymentCommand>(),
@@ -186,6 +197,9 @@ public sealed class ServiceCommandApplicationServiceTests
         rolloutReceipt.TargetActorId.Should().Be(ServiceActorIds.Rollout(identity));
         provisioner.ServingSetRequests.Should().HaveCount(2);
         provisioner.RolloutRequests.Should().ContainSingle();
+        provisioner.InvocationCatalogRequests.Should().HaveCount(2);
+        provisioner.InvocationCatalogRequests.Should().OnlyContain(x =>
+            ServiceKeys.Build(x) == ServiceKeys.Build(identity));
         dispatchPort.Calls.Should().HaveCount(2);
         dispatchPort.Calls[0].envelope.Payload.Unpack<ReplaceServiceServingTargetsCommand>()
             .Targets.Should().ContainSingle();
@@ -224,6 +238,9 @@ public sealed class ServiceCommandApplicationServiceTests
         rollbackReceipt.CorrelationId.Should().Be($"{ServiceKeys.Build(identity)}:rollout-1");
         provisioner.RolloutRequests.Should().HaveCount(3);
         provisioner.ServingSetRequests.Should().HaveCount(2);
+        provisioner.InvocationCatalogRequests.Should().HaveCount(2);
+        provisioner.InvocationCatalogRequests.Should().OnlyContain(x =>
+            ServiceKeys.Build(x) == ServiceKeys.Build(identity));
         dispatchPort.Calls.Select(x => x.actorId).Should().OnlyContain(x => x == ServiceActorIds.Rollout(identity));
         dispatchPort.Calls.Select(x => x.envelope.Payload.TypeUrl).Should().Contain([
             AnyTypeUrl<AdvanceServiceRolloutCommand>(),

--- a/test/Aevatar.GAgentService.Tests/Application/ServiceCommandApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ServiceCommandApplicationServiceTests.cs
@@ -309,6 +309,8 @@ public sealed class ServiceCommandApplicationServiceTests
 
         public List<ServiceIdentity> RolloutRequests { get; } = [];
 
+        public List<ServiceIdentity> InvocationCatalogRequests { get; } = [];
+
         public Task<string> EnsureDefinitionTargetAsync(ServiceIdentity identity, CancellationToken ct = default)
         {
             DefinitionRequests.Add(identity.Clone());
@@ -337,6 +339,12 @@ public sealed class ServiceCommandApplicationServiceTests
         {
             RolloutRequests.Add(identity.Clone());
             return Task.FromResult(ServiceActorIds.Rollout(identity));
+        }
+
+        public Task<string> EnsureInvocationCatalogTargetAsync(ServiceIdentity identity, CancellationToken ct = default)
+        {
+            InvocationCatalogRequests.Add(identity.Clone());
+            return Task.FromResult(ServiceActorIds.InvocationCatalog(identity));
         }
     }
 

--- a/test/Aevatar.GAgentService.Tests/Application/ServiceInvocationApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ServiceInvocationApplicationServiceTests.cs
@@ -42,25 +42,9 @@ public sealed class ServiceInvocationApplicationServiceTests
                     ["service-policy"],
                     DateTimeOffset.UtcNow),
             },
-            new RecordingTrafficViewQueryReader
+            new RecordingInvocationCatalogQueryReader
             {
-                GetResult = new ServiceTrafficViewSnapshot(
-                    ServiceKeys.Build(identity),
-                    1,
-                    string.Empty,
-                    [
-                        new ServiceTrafficEndpointSnapshot(
-                            "chat",
-                            [
-                                new ServiceTrafficTargetSnapshot(
-                                    "dep-1",
-                                    "r1",
-                                    "actor-1",
-                                    100,
-                                    ServiceServingState.Active.ToString()),
-                            ]),
-                    ],
-                    DateTimeOffset.UtcNow),
+                GetResult = CreateInvocationCatalogSnapshot(identity, Ready(identity, "chat", "r1", "dep-1", "actor-1")),
             },
             revisionCatalog);
         var authorizer = new RecordingAuthorizer();
@@ -116,31 +100,9 @@ public sealed class ServiceInvocationApplicationServiceTests
                     [],
                     DateTimeOffset.UtcNow),
             },
-            new RecordingTrafficViewQueryReader
+            new RecordingInvocationCatalogQueryReader
             {
-                GetResult = new ServiceTrafficViewSnapshot(
-                    ServiceKeys.Build(identity),
-                    1,
-                    string.Empty,
-                    [
-                        new ServiceTrafficEndpointSnapshot(
-                            "chat",
-                            [
-                                new ServiceTrafficTargetSnapshot(
-                                    "dep-1",
-                                    "r1",
-                                    "actor-1",
-                                    50,
-                                    ServiceServingState.Active.ToString()),
-                                new ServiceTrafficTargetSnapshot(
-                                    "dep-2",
-                                    "r1",
-                                    "actor-2",
-                                    50,
-                                    ServiceServingState.Active.ToString()),
-                            ]),
-                    ],
-                    DateTimeOffset.UtcNow),
+                GetResult = CreateInvocationCatalogSnapshot(identity, Ready(identity, "chat", "r1", "dep-1", "actor-1")),
             },
             revisionCatalog);
         var authorizer = new RecordingAuthorizer();
@@ -171,7 +133,7 @@ public sealed class ServiceInvocationApplicationServiceTests
         var revisionCatalog = new FakeServiceRevisionCatalogQueryReader();
         var resolutionService = new ServiceInvocationResolutionService(
             new RecordingCatalogQueryReader { GetResult = null },
-            new RecordingTrafficViewQueryReader { GetResult = null },
+            new RecordingInvocationCatalogQueryReader { GetResult = null },
             revisionCatalog);
         var service = new ServiceInvocationApplicationService(
             resolutionService, new RecordingAuthorizer(), new RecordingDispatcher());
@@ -188,7 +150,7 @@ public sealed class ServiceInvocationApplicationServiceTests
     }
 
     [Fact]
-    public async Task InvokeAsync_ShouldThrow_WhenNoTrafficView()
+    public async Task InvokeAsync_ShouldThrow_WhenNoInvocationCatalogReadModel()
     {
         var identity = GAgentServiceTestKit.CreateIdentity();
         var revisionCatalog = new FakeServiceRevisionCatalogQueryReader();
@@ -211,7 +173,7 @@ public sealed class ServiceInvocationApplicationServiceTests
                     [],
                     DateTimeOffset.UtcNow),
             },
-            new RecordingTrafficViewQueryReader { GetResult = null },
+            new RecordingInvocationCatalogQueryReader { GetResult = null },
             revisionCatalog);
         var service = new ServiceInvocationApplicationService(
             resolutionService, new RecordingAuthorizer(), new RecordingDispatcher());
@@ -224,11 +186,11 @@ public sealed class ServiceInvocationApplicationServiceTests
         });
 
         await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*has no serving traffic view*");
+            .WithMessage("*has no invocation catalog readmodel*");
     }
 
     [Fact]
-    public async Task InvokeAsync_ShouldThrow_WhenEndpointNotInTrafficView()
+    public async Task InvokeAsync_ShouldThrow_WhenEndpointNotInInvocationCatalog()
     {
         var identity = GAgentServiceTestKit.CreateIdentity();
         var revisionCatalog = new FakeServiceRevisionCatalogQueryReader();
@@ -251,25 +213,9 @@ public sealed class ServiceInvocationApplicationServiceTests
                     [],
                     DateTimeOffset.UtcNow),
             },
-            new RecordingTrafficViewQueryReader
+            new RecordingInvocationCatalogQueryReader
             {
-                GetResult = new ServiceTrafficViewSnapshot(
-                    ServiceKeys.Build(identity),
-                    1,
-                    string.Empty,
-                    [
-                        new ServiceTrafficEndpointSnapshot(
-                            "other-endpoint",
-                            [
-                                new ServiceTrafficTargetSnapshot(
-                                    "dep-1",
-                                    "r1",
-                                    "actor-1",
-                                    100,
-                                    ServiceServingState.Active.ToString()),
-                            ]),
-                    ],
-                    DateTimeOffset.UtcNow),
+                GetResult = CreateInvocationCatalogSnapshot(identity, Ready(identity, "other-endpoint", "r1", "dep-1", "actor-1")),
             },
             revisionCatalog);
         var service = new ServiceInvocationApplicationService(
@@ -282,12 +228,12 @@ public sealed class ServiceInvocationApplicationServiceTests
             Payload = Any.Pack(new StringValue { Value = "payload" }),
         });
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*has no serving target*");
+        await act.Should().ThrowAsync<ServiceInvokeReadinessException>()
+            .WithMessage("*has no invocation readiness*");
     }
 
     [Fact]
-    public async Task InvokeAsync_ShouldThrow_WhenNoActiveTargetsOnEndpoint()
+    public async Task InvokeAsync_ShouldThrow_WhenEndpointIsUnavailable()
     {
         var identity = GAgentServiceTestKit.CreateIdentity();
         var revisionCatalog = new FakeServiceRevisionCatalogQueryReader();
@@ -310,31 +256,14 @@ public sealed class ServiceInvocationApplicationServiceTests
                     [],
                     DateTimeOffset.UtcNow),
             },
-            new RecordingTrafficViewQueryReader
+            new RecordingInvocationCatalogQueryReader
             {
-                GetResult = new ServiceTrafficViewSnapshot(
-                    ServiceKeys.Build(identity),
-                    1,
-                    string.Empty,
-                    [
-                        new ServiceTrafficEndpointSnapshot(
-                            "chat",
-                            [
-                                new ServiceTrafficTargetSnapshot(
-                                    "dep-1",
-                                    "r1",
-                                    "actor-1",
-                                    0,
-                                    ServiceServingState.Active.ToString()),
-                                new ServiceTrafficTargetSnapshot(
-                                    "dep-2",
-                                    "r1",
-                                    "actor-2",
-                                    100,
-                                    ServiceServingState.Draining.ToString()),
-                            ]),
-                    ],
-                    DateTimeOffset.UtcNow),
+                GetResult = CreateInvocationCatalogSnapshot(
+                    identity,
+                    Unavailable(
+                        identity,
+                        "chat",
+                        ServiceInvokeUnavailableReason.ServingTargetMissing)),
             },
             revisionCatalog);
         var service = new ServiceInvocationApplicationService(
@@ -347,9 +276,73 @@ public sealed class ServiceInvocationApplicationServiceTests
             Payload = Any.Pack(new StringValue { Value = "payload" }),
         });
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*No active serving targets*");
+        var ex = await act.Should().ThrowAsync<ServiceInvokeReadinessException>();
+        ex.Which.Snapshot.UnavailableReason.Should().Be(ServiceInvokeUnavailableReason.ServingTargetMissing);
     }
+
+    private static ServiceInvocationCatalogSnapshot CreateInvocationCatalogSnapshot(
+        ServiceIdentity identity,
+        params ServiceInvokeReadinessSnapshot[] entries) =>
+        new(
+            ServiceKeys.Build(identity),
+            entries,
+            DateTimeOffset.Parse("2026-06-05T00:00:00+00:00"),
+            7,
+            $"{ServiceKeys.Build(identity)}:invocation-catalog:7",
+            1,
+            2,
+            3);
+
+    private static ServiceInvokeReadinessSnapshot Ready(
+        ServiceIdentity identity,
+        string endpointId,
+        string revisionId,
+        string deploymentId,
+        string actorId) =>
+        Snapshot(
+            identity,
+            endpointId,
+            ServiceInvokeReadinessStatus.Ready,
+            ServiceInvokeUnavailableReason.Unspecified,
+            revisionId,
+            deploymentId,
+            actorId);
+
+    private static ServiceInvokeReadinessSnapshot Unavailable(
+        ServiceIdentity identity,
+        string endpointId,
+        ServiceInvokeUnavailableReason reason) =>
+        Snapshot(
+            identity,
+            endpointId,
+            ServiceInvokeReadinessStatus.Unavailable,
+            reason,
+            string.Empty,
+            string.Empty,
+            string.Empty);
+
+    private static ServiceInvokeReadinessSnapshot Snapshot(
+        ServiceIdentity identity,
+        string endpointId,
+        ServiceInvokeReadinessStatus status,
+        ServiceInvokeUnavailableReason reason,
+        string revisionId,
+        string deploymentId,
+        string actorId) =>
+        new(
+            ServiceKeys.Build(identity),
+            endpointId,
+            status,
+            reason,
+            revisionId,
+            deploymentId,
+            actorId,
+            DateTimeOffset.Parse("2026-06-05T00:00:00+00:00"),
+            7,
+            $"{ServiceKeys.Build(identity)}:invocation-catalog:7",
+            1,
+            2,
+            3);
 
     private sealed class RecordingCatalogQueryReader : IServiceCatalogQueryReader
     {
@@ -370,11 +363,11 @@ public sealed class ServiceInvocationApplicationServiceTests
             Task.FromResult<IReadOnlyList<ServiceCatalogSnapshot>>([]);
     }
 
-    private sealed class RecordingTrafficViewQueryReader : IServiceTrafficViewQueryReader
+    private sealed class RecordingInvocationCatalogQueryReader : IServiceInvocationCatalogQueryReader
     {
-        public ServiceTrafficViewSnapshot? GetResult { get; init; }
+        public ServiceInvocationCatalogSnapshot? GetResult { get; init; }
 
-        public Task<ServiceTrafficViewSnapshot?> GetAsync(ServiceIdentity identity, CancellationToken ct = default) =>
+        public Task<ServiceInvocationCatalogSnapshot?> GetAsync(ServiceIdentity identity, CancellationToken ct = default) =>
             Task.FromResult(GetResult);
     }
 

--- a/test/Aevatar.GAgentService.Tests/Application/ServiceInvocationResolutionServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ServiceInvocationResolutionServiceTests.cs
@@ -12,7 +12,7 @@ namespace Aevatar.GAgentService.Tests.Application;
 public sealed class ServiceInvocationResolutionServiceTests
 {
     [Fact]
-    public async Task ResolveAsync_ShouldUseTrafficViewTargetAndArtifactEndpoint()
+    public async Task ResolveAsync_ShouldUseInvocationCatalogReadinessAndPreparedArtifact()
     {
         var identity = GAgentServiceTestKit.CreateIdentity();
         var revisionCatalog = new FakeServiceRevisionCatalogQueryReader();
@@ -23,32 +23,11 @@ public sealed class ServiceInvocationResolutionServiceTests
                 identity,
                 "r2",
                 GAgentServiceTestKit.CreateEndpointDescriptor(endpointId: "chat")));
-        var service = new ServiceInvocationResolutionService(
-            new RecordingCatalogQueryReader
-            {
-                GetResult = CreateCatalogSnapshot(identity, policyIds: ["policy-a"]),
-            },
-            new RecordingTrafficViewQueryReader
-            {
-                GetResult = new ServiceTrafficViewSnapshot(
-                    ServiceKeys.Build(identity),
-                    2,
-                    "rollout-1",
-                    [
-                        new ServiceTrafficEndpointSnapshot(
-                            "chat",
-                            [
-                                new ServiceTrafficTargetSnapshot(
-                                    "dep-2",
-                                    "r2",
-                                    "actor-2",
-                                    100,
-                                    ServiceServingState.Active.ToString()),
-                            ]),
-                    ],
-                    DateTimeOffset.UtcNow),
-            },
-            revisionCatalog);
+        var service = CreateService(
+            identity,
+            revisionCatalog,
+            readiness: Ready(identity, "chat", "r2", "dep-2", "actor-2"),
+            policyIds: ["policy-a"]);
 
         var resolved = await service.ResolveAsync(new ServiceInvocationRequest
         {
@@ -66,43 +45,9 @@ public sealed class ServiceInvocationResolutionServiceTests
     }
 
     [Fact]
-    public async Task ResolveAsync_ShouldRejectMissingServingTargetForEndpoint()
-    {
-        var identity = GAgentServiceTestKit.CreateIdentity();
-        var service = new ServiceInvocationResolutionService(
-            new RecordingCatalogQueryReader
-            {
-                GetResult = CreateCatalogSnapshot(identity),
-            },
-            new RecordingTrafficViewQueryReader
-            {
-                GetResult = new ServiceTrafficViewSnapshot(
-                    ServiceKeys.Build(identity),
-                    1,
-                    string.Empty,
-                    [],
-                    DateTimeOffset.UtcNow),
-            },
-            new FakeServiceRevisionCatalogQueryReader());
-
-        var act = () => service.ResolveAsync(new ServiceInvocationRequest
-        {
-            Identity = identity.Clone(),
-            EndpointId = "missing",
-            Payload = Any.Pack(new StringValue { Value = "payload" }),
-        });
-
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*has no serving target*");
-    }
-
-    [Fact]
     public async Task ResolveAsync_ShouldRejectMissingIdentity()
     {
-        var service = new ServiceInvocationResolutionService(
-            new RecordingCatalogQueryReader(),
-            new RecordingTrafficViewQueryReader(),
-            new FakeServiceRevisionCatalogQueryReader());
+        var service = CreateService(GAgentServiceTestKit.CreateIdentity(), new FakeServiceRevisionCatalogQueryReader());
 
         var act = () => service.ResolveAsync(new ServiceInvocationRequest
         {
@@ -117,10 +62,7 @@ public sealed class ServiceInvocationResolutionServiceTests
     [Fact]
     public async Task ResolveAsync_ShouldRejectBlankEndpointId()
     {
-        var service = new ServiceInvocationResolutionService(
-            new RecordingCatalogQueryReader(),
-            new RecordingTrafficViewQueryReader(),
-            new FakeServiceRevisionCatalogQueryReader());
+        var service = CreateService(GAgentServiceTestKit.CreateIdentity(), new FakeServiceRevisionCatalogQueryReader());
 
         var act = () => service.ResolveAsync(new ServiceInvocationRequest
         {
@@ -139,22 +81,17 @@ public sealed class ServiceInvocationResolutionServiceTests
         var identity = GAgentServiceTestKit.CreateIdentity();
         var service = new ServiceInvocationResolutionService(
             new RecordingCatalogQueryReader(),
-            new RecordingTrafficViewQueryReader(),
+            new RecordingInvocationCatalogQueryReader(),
             new FakeServiceRevisionCatalogQueryReader());
 
-        var act = () => service.ResolveAsync(new ServiceInvocationRequest
-        {
-            Identity = identity.Clone(),
-            EndpointId = "chat",
-            Payload = Any.Pack(new StringValue { Value = "payload" }),
-        });
+        var act = () => service.ResolveAsync(NewRequest(identity, "chat"));
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*was not found*");
     }
 
     [Fact]
-    public async Task ResolveAsync_ShouldRejectMissingTrafficView()
+    public async Task ResolveAsync_ShouldRejectMissingInvocationCatalogReadModel_AsUnspecified()
     {
         var identity = GAgentServiceTestKit.CreateIdentity();
         var service = new ServiceInvocationResolutionService(
@@ -162,116 +99,54 @@ public sealed class ServiceInvocationResolutionServiceTests
             {
                 GetResult = CreateCatalogSnapshot(identity),
             },
-            new RecordingTrafficViewQueryReader(),
+            new RecordingInvocationCatalogQueryReader(),
             new FakeServiceRevisionCatalogQueryReader());
 
-        var act = () => service.ResolveAsync(new ServiceInvocationRequest
-        {
-            Identity = identity.Clone(),
-            EndpointId = "chat",
-            Payload = Any.Pack(new StringValue { Value = "payload" }),
-        });
+        var act = () => service.ResolveAsync(NewRequest(identity, "chat"));
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*has no serving traffic view*");
+        var ex = await act.Should().ThrowAsync<ServiceInvokeReadinessException>();
+        ex.Which.Snapshot.ReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Unspecified);
+        ex.Which.Snapshot.UnavailableReason.Should().Be(ServiceInvokeUnavailableReason.Unspecified);
     }
 
-    [Fact]
-    public async Task ResolveAsync_ShouldFallbackToServingSet_WhenTrafficViewIsMissing()
+    [Theory]
+    [InlineData(ServiceInvokeUnavailableReason.ServingTargetMissing)]
+    [InlineData(ServiceInvokeUnavailableReason.RevisionNotPrepared)]
+    [InlineData(ServiceInvokeUnavailableReason.PreparedArtifactMissing)]
+    public async Task ResolveAsync_ShouldRejectUnavailableReadiness_WithCanonicalReason(ServiceInvokeUnavailableReason reason)
     {
         var identity = GAgentServiceTestKit.CreateIdentity();
-        var revisionCatalog = new FakeServiceRevisionCatalogQueryReader();
-        await revisionCatalog.UpsertRevisionAsync(
-            ServiceKeys.Build(identity),
-            "r2",
-            GAgentServiceTestKit.CreatePreparedStaticArtifact(
-                identity,
-                "r2",
-                GAgentServiceTestKit.CreateEndpointDescriptor(endpointId: "chat")));
-        var service = new ServiceInvocationResolutionService(
-            new RecordingCatalogQueryReader
-            {
-                GetResult = CreateCatalogSnapshot(identity, policyIds: ["policy-a"]),
-            },
-            new RecordingTrafficViewQueryReader(),
-            new RecordingServingSetQueryReader
-            {
-                GetResult = new ServiceServingSetSnapshot(
-                    ServiceKeys.Build(identity),
-                    2,
-                    "rollout-1",
-                    [
-                        new ServiceServingTargetSnapshot(
-                            "dep-2",
-                            "r2",
-                            "actor-2",
-                            100,
-                            ServiceServingState.Active.ToString(),
-                            []),
-                    ],
-                    DateTimeOffset.UtcNow),
-            },
-            revisionCatalog);
+        var service = CreateService(
+            identity,
+            new FakeServiceRevisionCatalogQueryReader(),
+            readiness: Unavailable(identity, "chat", reason, "r1", "dep-1", "actor-1"));
 
-        var resolved = await service.ResolveAsync(new ServiceInvocationRequest
-        {
-            Identity = identity.Clone(),
-            EndpointId = "chat",
-            Payload = Any.Pack(new StringValue { Value = "payload" }),
-        });
+        var act = () => service.ResolveAsync(NewRequest(identity, "chat"));
 
-        resolved.Service.RevisionId.Should().Be("r2");
-        resolved.Service.DeploymentId.Should().Be("dep-2");
-        resolved.Service.PrimaryActorId.Should().Be("actor-2");
-        resolved.Service.PolicyIds.Should().ContainSingle("policy-a");
-        resolved.Artifact.RevisionId.Should().Be("r2");
-        resolved.Endpoint.EndpointId.Should().Be("chat");
+        var ex = await act.Should().ThrowAsync<ServiceInvokeReadinessException>();
+        ex.Which.Snapshot.ReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Unavailable);
+        ex.Which.Snapshot.UnavailableReason.Should().Be(reason);
     }
 
     [Fact]
-    public async Task ResolveAsync_ShouldRejectMissingPreparedArtifact()
+    public async Task ResolveAsync_ShouldRejectMissingEndpointReadiness_AsUnspecified()
     {
         var identity = GAgentServiceTestKit.CreateIdentity();
-        var service = new ServiceInvocationResolutionService(
-            new RecordingCatalogQueryReader
-            {
-                GetResult = CreateCatalogSnapshot(identity),
-            },
-            new RecordingTrafficViewQueryReader
-            {
-                GetResult = new ServiceTrafficViewSnapshot(
-                    ServiceKeys.Build(identity),
-                    2,
-                    string.Empty,
-                    [
-                        new ServiceTrafficEndpointSnapshot(
-                            "chat",
-                            [
-                                new ServiceTrafficTargetSnapshot(
-                                    "dep-1",
-                                    "r1",
-                                    "actor-1",
-                                    100,
-                                    ServiceServingState.Active.ToString()),
-                            ]),
-                    ],
-                    DateTimeOffset.UtcNow),
-            },
-            new FakeServiceRevisionCatalogQueryReader());
+        var service = CreateService(
+            identity,
+            new FakeServiceRevisionCatalogQueryReader(),
+            readiness: Ready(identity, "other", "r1", "dep-1", "actor-1"));
 
-        var act = () => service.ResolveAsync(new ServiceInvocationRequest
-        {
-            Identity = identity.Clone(),
-            EndpointId = "chat",
-            Payload = Any.Pack(new StringValue { Value = "payload" }),
-        });
+        var act = () => service.ResolveAsync(NewRequest(identity, "chat"));
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*Prepared artifact*was not found*");
+        var ex = await act.Should().ThrowAsync<ServiceInvokeReadinessException>();
+        ex.Which.Snapshot.ReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Unspecified);
+        ex.Which.Snapshot.UnavailableReason.Should().Be(ServiceInvokeUnavailableReason.Unspecified);
+        ex.Which.Snapshot.AggregateStateVersion.Should().Be(7);
     }
 
     [Fact]
-    public async Task ResolveAsync_ShouldHonorExplicitRevisionSelection()
+    public async Task ResolveAsync_ShouldHonorExplicitRevisionSelection_FromReadinessEntry()
     {
         var identity = GAgentServiceTestKit.CreateIdentity();
         var revisionCatalog = new FakeServiceRevisionCatalogQueryReader();
@@ -289,38 +164,14 @@ public sealed class ServiceInvocationResolutionServiceTests
                 identity,
                 "r2",
                 GAgentServiceTestKit.CreateEndpointDescriptor(endpointId: "chat")));
-        var service = new ServiceInvocationResolutionService(
-            new RecordingCatalogQueryReader
-            {
-                GetResult = CreateCatalogSnapshot(identity),
-            },
-            new RecordingTrafficViewQueryReader
-            {
-                GetResult = new ServiceTrafficViewSnapshot(
-                    ServiceKeys.Build(identity),
-                    2,
-                    string.Empty,
-                    [
-                        new ServiceTrafficEndpointSnapshot(
-                            "chat",
-                            [
-                                new ServiceTrafficTargetSnapshot(
-                                    "dep-1",
-                                    "r1",
-                                    "actor-1",
-                                    100,
-                                    ServiceServingState.Active.ToString()),
-                                new ServiceTrafficTargetSnapshot(
-                                    "dep-2",
-                                    "r2",
-                                    "actor-2",
-                                    100,
-                                    ServiceServingState.Active.ToString()),
-                            ]),
-                    ],
-                    DateTimeOffset.UtcNow),
-            },
-            revisionCatalog);
+        var service = CreateService(
+            identity,
+            revisionCatalog,
+            readinessEntries:
+            [
+                Ready(identity, "chat", "r1", "dep-1", "actor-1"),
+                Ready(identity, "chat", "r2", "dep-2", "actor-2"),
+            ]);
 
         var resolved = await service.ResolveAsync(new ServiceInvocationRequest
         {
@@ -336,47 +187,113 @@ public sealed class ServiceInvocationResolutionServiceTests
     }
 
     [Fact]
-    public async Task ResolveAsync_ShouldRejectExplicitRevisionWhenTargetIsNotActive()
+    public async Task ResolveAsync_ShouldMapReadyDriftMissingArtifact_ToPreparedArtifactMissing()
     {
         var identity = GAgentServiceTestKit.CreateIdentity();
-        var service = new ServiceInvocationResolutionService(
-            new RecordingCatalogQueryReader
-            {
-                GetResult = CreateCatalogSnapshot(identity),
-            },
-            new RecordingTrafficViewQueryReader
-            {
-                GetResult = new ServiceTrafficViewSnapshot(
-                    ServiceKeys.Build(identity),
-                    2,
-                    string.Empty,
-                    [
-                        new ServiceTrafficEndpointSnapshot(
-                            "chat",
-                            [
-                                new ServiceTrafficTargetSnapshot(
-                                    "dep-1",
-                                    "r1",
-                                    "actor-1",
-                                    100,
-                                    ServiceServingState.Paused.ToString()),
-                            ]),
-                    ],
-                    DateTimeOffset.UtcNow),
-            },
-            new FakeServiceRevisionCatalogQueryReader());
+        var service = CreateService(
+            identity,
+            new FakeServiceRevisionCatalogQueryReader(),
+            readiness: Ready(identity, "chat", "r1", "dep-1", "actor-1"));
 
-        var act = () => service.ResolveAsync(new ServiceInvocationRequest
+        var act = () => service.ResolveAsync(NewRequest(identity, "chat"));
+
+        var ex = await act.Should().ThrowAsync<ServiceInvokeReadinessException>();
+        ex.Which.Snapshot.ReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Unavailable);
+        ex.Which.Snapshot.UnavailableReason.Should().Be(ServiceInvokeUnavailableReason.PreparedArtifactMissing);
+    }
+
+    private static ServiceInvocationRequest NewRequest(ServiceIdentity identity, string endpointId) =>
+        new()
         {
             Identity = identity.Clone(),
-            EndpointId = "chat",
-            RevisionId = "r1",
+            EndpointId = endpointId,
             Payload = Any.Pack(new StringValue { Value = "payload" }),
-        });
+        };
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage($"*Revision 'r1' is not active on service '{ServiceKeys.Build(identity)}'.*");
+    private static ServiceInvocationResolutionService CreateService(
+        ServiceIdentity identity,
+        IServiceRevisionCatalogQueryReader revisionCatalog,
+        ServiceInvokeReadinessSnapshot? readiness = null,
+        ServiceInvocationCatalogSnapshot? readinessCatalog = default,
+        IReadOnlyList<ServiceInvokeReadinessSnapshot>? readinessEntries = null,
+        IReadOnlyList<string>? policyIds = null)
+    {
+        var serviceKey = ServiceKeys.Build(identity);
+        readinessCatalog ??= new ServiceInvocationCatalogSnapshot(
+            serviceKey,
+            readinessEntries ?? (readiness == null ? [] : [readiness]),
+            DateTimeOffset.Parse("2026-06-05T00:00:00+00:00"),
+            7,
+            $"{serviceKey}:invocation-catalog:7",
+            1,
+            2,
+            3);
+
+        return new ServiceInvocationResolutionService(
+            new RecordingCatalogQueryReader
+            {
+                GetResult = CreateCatalogSnapshot(identity, policyIds),
+            },
+            new RecordingInvocationCatalogQueryReader
+            {
+                GetResult = readinessCatalog,
+            },
+            revisionCatalog);
     }
+
+    private static ServiceInvokeReadinessSnapshot Ready(
+        ServiceIdentity identity,
+        string endpointId,
+        string revisionId,
+        string deploymentId,
+        string actorId) =>
+        Snapshot(
+            identity,
+            endpointId,
+            ServiceInvokeReadinessStatus.Ready,
+            ServiceInvokeUnavailableReason.Unspecified,
+            revisionId,
+            deploymentId,
+            actorId);
+
+    private static ServiceInvokeReadinessSnapshot Unavailable(
+        ServiceIdentity identity,
+        string endpointId,
+        ServiceInvokeUnavailableReason reason,
+        string revisionId = "",
+        string deploymentId = "",
+        string actorId = "") =>
+        Snapshot(
+            identity,
+            endpointId,
+            ServiceInvokeReadinessStatus.Unavailable,
+            reason,
+            revisionId,
+            deploymentId,
+            actorId);
+
+    private static ServiceInvokeReadinessSnapshot Snapshot(
+        ServiceIdentity identity,
+        string endpointId,
+        ServiceInvokeReadinessStatus status,
+        ServiceInvokeUnavailableReason reason,
+        string revisionId,
+        string deploymentId,
+        string actorId) =>
+        new(
+            ServiceKeys.Build(identity),
+            endpointId,
+            status,
+            reason,
+            revisionId,
+            deploymentId,
+            actorId,
+            DateTimeOffset.Parse("2026-06-05T00:00:00+00:00"),
+            7,
+            $"{ServiceKeys.Build(identity)}:invocation-catalog:7",
+            1,
+            2,
+            3);
 
     private static ServiceCatalogSnapshot CreateCatalogSnapshot(
         ServiceIdentity identity,
@@ -416,19 +333,11 @@ public sealed class ServiceInvocationResolutionServiceTests
             Task.FromResult<IReadOnlyList<ServiceCatalogSnapshot>>([]);
     }
 
-    private sealed class RecordingTrafficViewQueryReader : IServiceTrafficViewQueryReader
+    private sealed class RecordingInvocationCatalogQueryReader : IServiceInvocationCatalogQueryReader
     {
-        public ServiceTrafficViewSnapshot? GetResult { get; init; }
+        public ServiceInvocationCatalogSnapshot? GetResult { get; init; }
 
-        public Task<ServiceTrafficViewSnapshot?> GetAsync(ServiceIdentity identity, CancellationToken ct = default) =>
-            Task.FromResult(GetResult);
-    }
-
-    private sealed class RecordingServingSetQueryReader : IServiceServingSetQueryReader
-    {
-        public ServiceServingSetSnapshot? GetResult { get; init; }
-
-        public Task<ServiceServingSetSnapshot?> GetAsync(ServiceIdentity identity, CancellationToken ct = default) =>
+        public Task<ServiceInvocationCatalogSnapshot?> GetAsync(ServiceIdentity identity, CancellationToken ct = default) =>
             Task.FromResult(GetResult);
     }
 }

--- a/test/Aevatar.GAgentService.Tests/Application/StaticGAgentStreamInvocationApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/StaticGAgentStreamInvocationApplicationServiceTests.cs
@@ -373,7 +373,7 @@ public sealed class StaticGAgentStreamInvocationApplicationServiceTests
 
         var resolutionService = new ServiceInvocationResolutionService(
             new CatalogQueryReader(identity),
-            new TrafficViewQueryReader(identity),
+            new InvocationCatalogQueryReader(identity),
             revisionCatalog);
 
         return new StaticGAgentStreamInvocationApplicationService(
@@ -469,26 +469,33 @@ public sealed class StaticGAgentStreamInvocationApplicationServiceTests
             Task.FromResult<IReadOnlyList<ServiceCatalogSnapshot>>([]);
     }
 
-    private sealed class TrafficViewQueryReader(ServiceIdentity identity) : IServiceTrafficViewQueryReader
+    private sealed class InvocationCatalogQueryReader(ServiceIdentity identity) : IServiceInvocationCatalogQueryReader
     {
-        public Task<ServiceTrafficViewSnapshot?> GetAsync(ServiceIdentity requestedIdentity, CancellationToken ct = default) =>
-            Task.FromResult<ServiceTrafficViewSnapshot?>(new ServiceTrafficViewSnapshot(
+        public Task<ServiceInvocationCatalogSnapshot?> GetAsync(ServiceIdentity requestedIdentity, CancellationToken ct = default) =>
+            Task.FromResult<ServiceInvocationCatalogSnapshot?>(new ServiceInvocationCatalogSnapshot(
                 ServiceKeys.Build(identity),
-                1,
-                string.Empty,
                 [
-                    new ServiceTrafficEndpointSnapshot(
+                    new ServiceInvokeReadinessSnapshot(
+                        ServiceKeys.Build(identity),
                         "chat",
-                        [
-                            new ServiceTrafficTargetSnapshot(
-                                "dep-1",
-                                "r1",
-                                "primary-actor-1",
-                                100,
-                                ServiceServingState.Active.ToString()),
-                        ]),
+                        ServiceInvokeReadinessStatus.Ready,
+                        ServiceInvokeUnavailableReason.Unspecified,
+                        "r1",
+                        "dep-1",
+                        "primary-actor-1",
+                        DateTimeOffset.Parse("2026-06-05T00:00:00+00:00"),
+                        1,
+                        $"{ServiceKeys.Build(identity)}:invocation-catalog:1",
+                        1,
+                        1,
+                        1),
                 ],
-                DateTimeOffset.UtcNow));
+                DateTimeOffset.Parse("2026-06-05T00:00:00+00:00"),
+                1,
+                $"{ServiceKeys.Build(identity)}:invocation-catalog:1",
+                1,
+                1,
+                1));
     }
 
     private sealed class NoOpInvokeAdmissionAuthorizer : IInvokeAdmissionAuthorizer

--- a/test/Aevatar.GAgentService.Tests/Core/ServiceDefinitionGAgentTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ServiceDefinitionGAgentTests.cs
@@ -71,10 +71,11 @@ public sealed class ServiceDefinitionGAgentTests
     public async Task HandleUpdateAndSetDefaultServingRevisionAsync_ShouldMutateExistingDefinition()
     {
         var identity = GAgentServiceTestKit.CreateIdentity();
+        var dispatchPort = new RecordingActorDispatchPort();
         var agent = GAgentServiceTestKit.CreateStatefulAgent<ServiceDefinitionGAgent, ServiceDefinitionState>(
             new InMemoryEventStore(),
             ServiceActorIds.Definition(identity),
-            static () => new ServiceDefinitionGAgent(GAgentServiceTestKit.NoOpDispatchPort));
+            () => new ServiceDefinitionGAgent(dispatchPort));
 
         await agent.HandleCreateAsync(new CreateServiceDefinitionCommand
         {
@@ -100,6 +101,17 @@ public sealed class ServiceDefinitionGAgentTests
         agent.State.Spec.Endpoints.Should().ContainSingle(x => x.EndpointId == "chat");
         agent.State.DefaultServingRevisionId.Should().Be("r2");
         agent.State.LastAppliedEventVersion.Should().Be(3);
+        dispatchPort.Calls.Should().HaveCount(3);
+        dispatchPort.Calls.Should().OnlyContain(x =>
+            x.ActorId == ServiceActorIds.InvocationCatalog(identity));
+        var updateObservation = dispatchPort.Calls[1].Envelope.Payload.Unpack<ObserveServiceInvocationCatalogCommand>();
+        updateObservation.SourceCatalogVersion.Should().Be(2);
+        updateObservation.Identity.Should().BeEquivalentTo(identity);
+        updateObservation.ServiceEndpoints.Should().ContainSingle(x => x.EndpointId == "chat");
+        updateObservation.ServiceEndpoints[0].Kind.Should().Be(ServiceEndpointKind.Chat);
+        updateObservation.ServiceEndpoints[0].RequestTypeUrl.Should().Be("type.googleapis.com/test.chat");
+        var defaultObservation = dispatchPort.Calls[2].Envelope.Payload.Unpack<ObserveServiceInvocationCatalogCommand>();
+        defaultObservation.SourceCatalogVersion.Should().Be(3);
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Core/ServiceDefinitionGAgentTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ServiceDefinitionGAgentTests.cs
@@ -18,7 +18,7 @@ public sealed class ServiceDefinitionGAgentTests
         var agent = GAgentServiceTestKit.CreateStatefulAgent<ServiceDefinitionGAgent, ServiceDefinitionState>(
             eventStore,
             actorId,
-            static () => new ServiceDefinitionGAgent());
+            static () => new ServiceDefinitionGAgent(GAgentServiceTestKit.NoOpDispatchPort));
         await agent.ActivateAsync();
 
         await agent.HandleCreateAsync(new CreateServiceDefinitionCommand
@@ -34,7 +34,7 @@ public sealed class ServiceDefinitionGAgentTests
         var replayed = GAgentServiceTestKit.CreateStatefulAgent<ServiceDefinitionGAgent, ServiceDefinitionState>(
             eventStore,
             actorId,
-            static () => new ServiceDefinitionGAgent());
+            static () => new ServiceDefinitionGAgent(GAgentServiceTestKit.NoOpDispatchPort));
         await replayed.ActivateAsync();
 
         replayed.State.Spec.Identity.ServiceId.Should().Be("svc");
@@ -49,7 +49,7 @@ public sealed class ServiceDefinitionGAgentTests
         var agent = GAgentServiceTestKit.CreateStatefulAgent<ServiceDefinitionGAgent, ServiceDefinitionState>(
             new InMemoryEventStore(),
             ServiceActorIds.Definition(identity),
-            static () => new ServiceDefinitionGAgent());
+            static () => new ServiceDefinitionGAgent(GAgentServiceTestKit.NoOpDispatchPort));
 
         await agent.HandleCreateAsync(new CreateServiceDefinitionCommand
         {
@@ -74,7 +74,7 @@ public sealed class ServiceDefinitionGAgentTests
         var agent = GAgentServiceTestKit.CreateStatefulAgent<ServiceDefinitionGAgent, ServiceDefinitionState>(
             new InMemoryEventStore(),
             ServiceActorIds.Definition(identity),
-            static () => new ServiceDefinitionGAgent());
+            static () => new ServiceDefinitionGAgent(GAgentServiceTestKit.NoOpDispatchPort));
 
         await agent.HandleCreateAsync(new CreateServiceDefinitionCommand
         {
@@ -109,7 +109,7 @@ public sealed class ServiceDefinitionGAgentTests
         var agent = GAgentServiceTestKit.CreateStatefulAgent<ServiceDefinitionGAgent, ServiceDefinitionState>(
             new InMemoryEventStore(),
             ServiceActorIds.Definition(identity),
-            static () => new ServiceDefinitionGAgent());
+            static () => new ServiceDefinitionGAgent(GAgentServiceTestKit.NoOpDispatchPort));
 
         var act = () => agent.HandleUpdateAsync(new UpdateServiceDefinitionCommand
         {
@@ -128,7 +128,7 @@ public sealed class ServiceDefinitionGAgentTests
         var agent = GAgentServiceTestKit.CreateStatefulAgent<ServiceDefinitionGAgent, ServiceDefinitionState>(
             new InMemoryEventStore(),
             ServiceActorIds.Definition(identity),
-            static () => new ServiceDefinitionGAgent());
+            static () => new ServiceDefinitionGAgent(GAgentServiceTestKit.NoOpDispatchPort));
         await agent.HandleCreateAsync(new CreateServiceDefinitionCommand
         {
             Spec = GAgentServiceTestKit.CreateDefinitionSpec(identity),
@@ -150,7 +150,7 @@ public sealed class ServiceDefinitionGAgentTests
         var agent = GAgentServiceTestKit.CreateStatefulAgent<ServiceDefinitionGAgent, ServiceDefinitionState>(
             new InMemoryEventStore(),
             ServiceActorIds.Definition(identity),
-            static () => new ServiceDefinitionGAgent());
+            static () => new ServiceDefinitionGAgent(GAgentServiceTestKit.NoOpDispatchPort));
         await agent.HandleCreateAsync(new CreateServiceDefinitionCommand
         {
             Spec = GAgentServiceTestKit.CreateDefinitionSpec(identity),
@@ -172,7 +172,7 @@ public sealed class ServiceDefinitionGAgentTests
         var agent = GAgentServiceTestKit.CreateStatefulAgent<ServiceDefinitionGAgent, ServiceDefinitionState>(
             new InMemoryEventStore(),
             "service-definition:missing-identity",
-            static () => new ServiceDefinitionGAgent());
+            static () => new ServiceDefinitionGAgent(GAgentServiceTestKit.NoOpDispatchPort));
 
         var act = () => agent.HandleCreateAsync(new CreateServiceDefinitionCommand
         {
@@ -197,7 +197,7 @@ public sealed class ServiceDefinitionGAgentTests
         var agent = GAgentServiceTestKit.CreateStatefulAgent<ServiceDefinitionGAgent, ServiceDefinitionState>(
             new InMemoryEventStore(),
             ServiceActorIds.Definition(identity),
-            static () => new ServiceDefinitionGAgent());
+            static () => new ServiceDefinitionGAgent(GAgentServiceTestKit.NoOpDispatchPort));
 
         var act = () => agent.HandleCreateAsync(new CreateServiceDefinitionCommand
         {

--- a/test/Aevatar.GAgentService.Tests/Core/ServiceInvocationCatalogGAgentTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ServiceInvocationCatalogGAgentTests.cs
@@ -1,0 +1,162 @@
+using Aevatar.Foundation.Runtime.Persistence;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Services;
+using Aevatar.GAgentService.Core.GAgents;
+using Aevatar.GAgentService.Core.Services;
+using Aevatar.GAgentService.Tests.TestSupport;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgentService.Tests.Core;
+
+public sealed class ServiceInvocationCatalogGAgentTests
+{
+    [Fact]
+    public async Task Observations_ShouldConvergeToReady_InAnyOrder()
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var agent = CreateAgent(identity);
+
+        await agent.HandleServingObservationAsync(new ObserveServiceInvocationServingCommand
+        {
+            Identity = identity.Clone(),
+            ServingTargets = { Target("dep-1", "r1", "actor-1", "chat") },
+            SourceServingVersion = 2,
+            ObservedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-06-05T00:02:00+00:00")),
+        });
+        await agent.HandleRevisionObservationAsync(new ObserveServiceInvocationRevisionsCommand
+        {
+            Identity = identity.Clone(),
+            Revisions = { { "r1", PreparedRevision(identity, "r1", "chat") } },
+            SourceRevisionVersion = 3,
+            ObservedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-06-05T00:03:00+00:00")),
+        });
+        await agent.HandleCatalogObservationAsync(new ObserveServiceInvocationCatalogCommand
+        {
+            Identity = identity.Clone(),
+            ServiceEndpoints = { GAgentServiceTestKit.CreateEndpointDescriptor(endpointId: "chat") },
+            SourceCatalogVersion = 1,
+            ObservedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-06-05T00:01:00+00:00")),
+        });
+
+        agent.State.Entries.Should().ContainSingle();
+        agent.State.Entries[0].ReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Ready);
+        agent.State.Entries[0].UnavailableReason.Should().Be(ServiceInvokeUnavailableReason.Unspecified);
+        agent.State.SourceCatalogVersion.Should().Be(1);
+        agent.State.SourceServingVersion.Should().Be(2);
+        agent.State.SourceRevisionVersion.Should().Be(3);
+    }
+
+    [Theory]
+    [InlineData(ServiceInvokeUnavailableReason.ServingTargetMissing)]
+    [InlineData(ServiceInvokeUnavailableReason.RevisionNotPrepared)]
+    [InlineData(ServiceInvokeUnavailableReason.PreparedArtifactMissing)]
+    public async Task Observations_ShouldProduceCanonicalUnavailableReasons(ServiceInvokeUnavailableReason reason)
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var agent = CreateAgent(identity);
+
+        await agent.HandleCatalogObservationAsync(new ObserveServiceInvocationCatalogCommand
+        {
+            Identity = identity.Clone(),
+            ServiceEndpoints = { GAgentServiceTestKit.CreateEndpointDescriptor(endpointId: "chat") },
+            SourceCatalogVersion = 1,
+        });
+
+        if (reason != ServiceInvokeUnavailableReason.ServingTargetMissing)
+        {
+            await agent.HandleServingObservationAsync(new ObserveServiceInvocationServingCommand
+            {
+                Identity = identity.Clone(),
+                ServingTargets = { Target("dep-1", "r1", "actor-1", "chat") },
+                SourceServingVersion = 1,
+            });
+        }
+
+        if (reason == ServiceInvokeUnavailableReason.RevisionNotPrepared)
+        {
+            await agent.HandleRevisionObservationAsync(new ObserveServiceInvocationRevisionsCommand
+            {
+                Identity = identity.Clone(),
+                Revisions = { { "r1", new ServiceRevisionRecordState { Status = ServiceRevisionStatus.Created } } },
+                SourceRevisionVersion = 1,
+            });
+        }
+        else if (reason == ServiceInvokeUnavailableReason.PreparedArtifactMissing)
+        {
+            await agent.HandleRevisionObservationAsync(new ObserveServiceInvocationRevisionsCommand
+            {
+                Identity = identity.Clone(),
+                Revisions = { { "r1", PreparedRevision(identity, "r1", "other") } },
+                SourceRevisionVersion = 1,
+            });
+        }
+
+        agent.State.Entries.Should().ContainSingle();
+        agent.State.Entries[0].ReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Unavailable);
+        agent.State.Entries[0].UnavailableReason.Should().Be(reason);
+    }
+
+    [Fact]
+    public async Task Observation_ShouldIgnoreOlderSourceVersion()
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var agent = CreateAgent(identity);
+
+        await agent.HandleCatalogObservationAsync(new ObserveServiceInvocationCatalogCommand
+        {
+            Identity = identity.Clone(),
+            ServiceEndpoints = { GAgentServiceTestKit.CreateEndpointDescriptor(endpointId: "chat") },
+            SourceCatalogVersion = 2,
+        });
+        await agent.HandleCatalogObservationAsync(new ObserveServiceInvocationCatalogCommand
+        {
+            Identity = identity.Clone(),
+            ServiceEndpoints = { GAgentServiceTestKit.CreateEndpointDescriptor(endpointId: "stale") },
+            SourceCatalogVersion = 1,
+        });
+
+        agent.State.SourceCatalogVersion.Should().Be(2);
+        agent.State.ServiceEndpoints.Should().ContainSingle(x => x.EndpointId == "chat");
+    }
+
+    private static ServiceInvocationCatalogGAgent CreateAgent(ServiceIdentity identity) =>
+        GAgentServiceTestKit.CreateStatefulAgent<ServiceInvocationCatalogGAgent, ServiceInvocationCatalogState>(
+            new InMemoryEventStore(),
+            ServiceActorIds.InvocationCatalog(identity),
+            static () => new ServiceInvocationCatalogGAgent(new ServiceInvokeReadinessEvaluator()));
+
+    private static ServiceServingTargetSpec Target(
+        string deploymentId,
+        string revisionId,
+        string actorId,
+        params string[] endpointIds)
+    {
+        var target = new ServiceServingTargetSpec
+        {
+            DeploymentId = deploymentId,
+            RevisionId = revisionId,
+            PrimaryActorId = actorId,
+            AllocationWeight = 100,
+            ServingState = ServiceServingState.Active,
+        };
+        target.EnabledEndpointIds.Add(endpointIds);
+        return target;
+    }
+
+    private static ServiceRevisionRecordState PreparedRevision(
+        ServiceIdentity identity,
+        string revisionId,
+        params string[] endpointIds) =>
+        new()
+        {
+            Spec = GAgentServiceTestKit.CreateStaticRevisionSpec(identity, revisionId),
+            Status = ServiceRevisionStatus.Prepared,
+            PreparedArtifact = GAgentServiceTestKit.CreatePreparedStaticArtifact(
+                identity,
+                revisionId,
+                endpointIds
+                    .Select(endpointId => GAgentServiceTestKit.CreateEndpointDescriptor(endpointId: endpointId))
+                    .ToArray()),
+        };
+}

--- a/test/Aevatar.GAgentService.Tests/Core/ServiceInvokeReadinessEvaluatorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ServiceInvokeReadinessEvaluatorTests.cs
@@ -1,0 +1,136 @@
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Core.Services;
+using Aevatar.GAgentService.Tests.TestSupport;
+using FluentAssertions;
+
+namespace Aevatar.GAgentService.Tests.Core;
+
+public sealed class ServiceInvokeReadinessEvaluatorTests
+{
+    private readonly ServiceInvokeReadinessEvaluator _evaluator = new();
+
+    [Fact]
+    public void Evaluate_ShouldReturnReady_WhenActiveTargetRevisionAndPreparedEndpointExist()
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var entries = _evaluator.Evaluate(
+            [GAgentServiceTestKit.CreateEndpointDescriptor(endpointId: "chat")],
+            [Target("dep-1", "r1", "actor-1", "chat")],
+            new Dictionary<string, ServiceRevisionRecordState>(StringComparer.Ordinal)
+            {
+                ["r1"] = PreparedRevision(identity, "r1", "chat"),
+            });
+
+        entries.Should().ContainSingle();
+        entries[0].ReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Ready);
+        entries[0].UnavailableReason.Should().Be(ServiceInvokeUnavailableReason.Unspecified);
+        entries[0].SelectedRevisionId.Should().Be("r1");
+        entries[0].SelectedDeploymentId.Should().Be("dep-1");
+        entries[0].SelectedActorId.Should().Be("actor-1");
+    }
+
+    [Fact]
+    public void Evaluate_ShouldReturnServingTargetMissing_WhenNoActiveTargetMatchesEndpoint()
+    {
+        var entries = _evaluator.Evaluate(
+            [GAgentServiceTestKit.CreateEndpointDescriptor(endpointId: "chat")],
+            [Target("dep-1", "r1", "actor-1", "other")],
+            new Dictionary<string, ServiceRevisionRecordState>(StringComparer.Ordinal));
+
+        entries.Should().ContainSingle();
+        entries[0].ReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Unavailable);
+        entries[0].UnavailableReason.Should().Be(ServiceInvokeUnavailableReason.ServingTargetMissing);
+        entries[0].SelectedRevisionId.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(ServiceRevisionStatus.Created)]
+    [InlineData(ServiceRevisionStatus.PreparationFailed)]
+    [InlineData(ServiceRevisionStatus.Retired)]
+    public void Evaluate_ShouldReturnRevisionNotPrepared_WhenSelectedRevisionIsNotPrepared(ServiceRevisionStatus status)
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var entries = _evaluator.Evaluate(
+            [GAgentServiceTestKit.CreateEndpointDescriptor(endpointId: "chat")],
+            [Target("dep-1", "r1", "actor-1", "chat")],
+            new Dictionary<string, ServiceRevisionRecordState>(StringComparer.Ordinal)
+            {
+                ["r1"] = new()
+                {
+                    Spec = GAgentServiceTestKit.CreateStaticRevisionSpec(identity, "r1"),
+                    Status = status,
+                },
+            });
+
+        entries.Should().ContainSingle();
+        entries[0].ReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Unavailable);
+        entries[0].UnavailableReason.Should().Be(ServiceInvokeUnavailableReason.RevisionNotPrepared);
+        entries[0].SelectedRevisionId.Should().Be("r1");
+    }
+
+    [Fact]
+    public void Evaluate_ShouldReturnPreparedArtifactMissing_WhenArtifactDoesNotContainEndpoint()
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var entries = _evaluator.Evaluate(
+            [GAgentServiceTestKit.CreateEndpointDescriptor(endpointId: "chat")],
+            [Target("dep-1", "r1", "actor-1", "chat")],
+            new Dictionary<string, ServiceRevisionRecordState>(StringComparer.Ordinal)
+            {
+                ["r1"] = PreparedRevision(identity, "r1", "other"),
+            });
+
+        entries.Should().ContainSingle();
+        entries[0].ReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Unavailable);
+        entries[0].UnavailableReason.Should().Be(ServiceInvokeUnavailableReason.PreparedArtifactMissing);
+        entries[0].SelectedRevisionId.Should().Be("r1");
+    }
+
+    [Fact]
+    public void Evaluate_ShouldOnlyUseCanonicalStatusesAndReasons()
+    {
+        var statuses = Enum.GetNames<ServiceInvokeReadinessStatus>();
+        var reasons = Enum.GetNames<ServiceInvokeUnavailableReason>();
+
+        statuses.Should().BeEquivalentTo("Unspecified", "Ready", "Unavailable");
+        reasons.Should().BeEquivalentTo(
+            "Unspecified",
+            "ServingTargetMissing",
+            "PreparedArtifactMissing",
+            "RevisionNotPrepared");
+    }
+
+    private static ServiceServingTargetSpec Target(
+        string deploymentId,
+        string revisionId,
+        string actorId,
+        params string[] endpointIds)
+    {
+        var target = new ServiceServingTargetSpec
+        {
+            DeploymentId = deploymentId,
+            RevisionId = revisionId,
+            PrimaryActorId = actorId,
+            AllocationWeight = 100,
+            ServingState = ServiceServingState.Active,
+        };
+        target.EnabledEndpointIds.Add(endpointIds);
+        return target;
+    }
+
+    private static ServiceRevisionRecordState PreparedRevision(
+        ServiceIdentity identity,
+        string revisionId,
+        params string[] endpointIds) =>
+        new()
+        {
+            Spec = GAgentServiceTestKit.CreateStaticRevisionSpec(identity, revisionId),
+            Status = ServiceRevisionStatus.Prepared,
+            PreparedArtifact = GAgentServiceTestKit.CreatePreparedStaticArtifact(
+                identity,
+                revisionId,
+                endpointIds
+                    .Select(endpointId => GAgentServiceTestKit.CreateEndpointDescriptor(endpointId: endpointId))
+                    .ToArray()),
+        };
+}

--- a/test/Aevatar.GAgentService.Tests/Core/ServiceRevisionCatalogGAgentTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ServiceRevisionCatalogGAgentTests.cs
@@ -251,6 +251,7 @@ public sealed class ServiceRevisionCatalogGAgentTests
             new InMemoryEventStore(),
             ServiceActorIds.RevisionCatalog(identity),
             () => new ServiceRevisionCatalogGAgent(
+                GAgentServiceTestKit.NoOpDispatchPort,
                 [],
                 new PreparedServiceRevisionArtifactAssembler()));
 
@@ -327,6 +328,7 @@ public sealed class ServiceRevisionCatalogGAgentTests
             eventStore,
             actorId,
             () => new ServiceRevisionCatalogGAgent(
+                GAgentServiceTestKit.NoOpDispatchPort,
                 [adapter],
                 new PreparedServiceRevisionArtifactAssembler()));
     }

--- a/test/Aevatar.GAgentService.Tests/Core/ServiceRevisionCatalogGAgentTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ServiceRevisionCatalogGAgentTests.cs
@@ -28,9 +28,10 @@ public sealed class ServiceRevisionCatalogGAgentTests
         var eventStore = new InMemoryEventStore();
         var identity = GAgentServiceTestKit.CreateIdentity();
         var actorId = ServiceActorIds.RevisionCatalog(identity);
+        var dispatchPort = new RecordingActorDispatchPort();
         var adapter = new RecordingAdapter(_ => Task.FromResult(
             GAgentServiceTestKit.CreatePreparedStaticArtifact(identity, "r1")));
-        var agent = CreateAgent(eventStore, adapter, actorId);
+        var agent = CreateAgent(eventStore, adapter, actorId, dispatchPort);
         await agent.ActivateAsync();
 
         await agent.HandleCreateRevisionAsync(new CreateServiceRevisionCommand
@@ -54,6 +55,22 @@ public sealed class ServiceRevisionCatalogGAgentTests
         record.Endpoints.Should().ContainSingle(x => x.EndpointId == "run");
         record.PreparedArtifact.Should().NotBeNull();
         record.PreparedArtifact.RevisionId.Should().Be("r1");
+        dispatchPort.Calls.Should().HaveCount(3);
+        dispatchPort.Calls.Should().OnlyContain(x =>
+            x.ActorId == ServiceActorIds.InvocationCatalog(identity));
+        var createObservation = dispatchPort.Calls[0].Envelope.Payload.Unpack<ObserveServiceInvocationRevisionsCommand>();
+        createObservation.SourceRevisionVersion.Should().Be(1);
+        createObservation.Revisions.Should().ContainKey("r1")
+            .WhoseValue.Status.Should().Be(ServiceRevisionStatus.Created);
+        var prepareObservation = dispatchPort.Calls[1].Envelope.Payload.Unpack<ObserveServiceInvocationRevisionsCommand>();
+        prepareObservation.SourceRevisionVersion.Should().Be(2);
+        prepareObservation.Revisions["r1"].Status.Should().Be(ServiceRevisionStatus.Prepared);
+        prepareObservation.Revisions["r1"].PreparedArtifact.Should().NotBeNull();
+        prepareObservation.Revisions["r1"].PreparedArtifact.Endpoints.Should().ContainSingle(x => x.EndpointId == "run");
+        var publishObservation = dispatchPort.Calls[2].Envelope.Payload.Unpack<ObserveServiceInvocationRevisionsCommand>();
+        publishObservation.SourceRevisionVersion.Should().Be(3);
+        publishObservation.Identity.Should().BeEquivalentTo(identity);
+        publishObservation.Revisions["r1"].Status.Should().Be(ServiceRevisionStatus.Published);
 
         await agent.DeactivateAsync();
 
@@ -322,13 +339,14 @@ public sealed class ServiceRevisionCatalogGAgentTests
     private static ServiceRevisionCatalogGAgent CreateAgent(
         InMemoryEventStore eventStore,
         IServiceImplementationAdapter adapter,
-        string actorId)
+        string actorId,
+        IActorDispatchPort? dispatchPort = null)
     {
         return GAgentServiceTestKit.CreateStatefulAgent<ServiceRevisionCatalogGAgent, ServiceRevisionCatalogState>(
             eventStore,
             actorId,
             () => new ServiceRevisionCatalogGAgent(
-                GAgentServiceTestKit.NoOpDispatchPort,
+                dispatchPort ?? GAgentServiceTestKit.NoOpDispatchPort,
                 [adapter],
                 new PreparedServiceRevisionArtifactAssembler()));
     }

--- a/test/Aevatar.GAgentService.Tests/Core/ServiceServingRolloutGAgentTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ServiceServingRolloutGAgentTests.cs
@@ -568,7 +568,11 @@ public sealed class ServiceServingRolloutGAgentTests
     public async Task ServiceServingSetManager_ShouldAcceptResolvedServingTargetsWithoutResolverLookup()
     {
         var identity = GAgentServiceTestKit.CreateIdentity();
-        var agent = CreateServingSetAgent(new InMemoryEventStore(), ServiceActorIds.ServingSet(identity));
+        var dispatchPort = new RecordingActorDispatchPort();
+        var agent = CreateServingSetAgent(
+            new InMemoryEventStore(),
+            ServiceActorIds.ServingSet(identity),
+            dispatchPort: dispatchPort);
         await agent.ActivateAsync();
 
         await agent.HandleReplaceResolvedAsync(new ReplaceResolvedServiceServingTargetsCommand
@@ -596,6 +600,16 @@ public sealed class ServiceServingRolloutGAgentTests
         agent.State.Targets[0].PrimaryActorId.Should().Be("actor-1");
         agent.State.Targets[0].AllocationWeight.Should().Be(100);
         agent.State.Targets[0].EnabledEndpointIds.Should().Equal("chat");
+        dispatchPort.Calls.Should().ContainSingle();
+        dispatchPort.Calls[0].ActorId.Should().Be(ServiceActorIds.InvocationCatalog(identity));
+        var observation = dispatchPort.Calls[0].Envelope.Payload.Unpack<ObserveServiceInvocationServingCommand>();
+        observation.Identity.Should().BeEquivalentTo(identity);
+        observation.SourceServingVersion.Should().Be(1);
+        observation.ServingTargets.Should().ContainSingle();
+        observation.ServingTargets[0].DeploymentId.Should().Be("dep-1");
+        observation.ServingTargets[0].RevisionId.Should().Be("rev-1");
+        observation.ServingTargets[0].PrimaryActorId.Should().Be("actor-1");
+        observation.ServingTargets[0].EnabledEndpointIds.Should().Equal("chat");
     }
 
     [Fact]
@@ -1127,13 +1141,14 @@ public sealed class ServiceServingRolloutGAgentTests
     private static ServiceServingSetManagerGAgent CreateServingSetAgent(
         InMemoryEventStore eventStore,
         string actorId,
-        IServiceServingTargetResolver? targetResolver = null)
+        IServiceServingTargetResolver? targetResolver = null,
+        IActorDispatchPort? dispatchPort = null)
     {
         return GAgentServiceTestKit.CreateStatefulAgent<ServiceServingSetManagerGAgent, ServiceServingSetState>(
             eventStore,
             actorId,
             () => new ServiceServingSetManagerGAgent(
-                GAgentServiceTestKit.NoOpDispatchPort,
+                dispatchPort ?? GAgentServiceTestKit.NoOpDispatchPort,
                 targetResolver ?? new PassthroughServingTargetResolver()));
     }
 

--- a/test/Aevatar.GAgentService.Tests/Core/ServiceServingRolloutGAgentTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ServiceServingRolloutGAgentTests.cs
@@ -1132,7 +1132,9 @@ public sealed class ServiceServingRolloutGAgentTests
         return GAgentServiceTestKit.CreateStatefulAgent<ServiceServingSetManagerGAgent, ServiceServingSetState>(
             eventStore,
             actorId,
-            () => new ServiceServingSetManagerGAgent(targetResolver ?? new PassthroughServingTargetResolver()));
+            () => new ServiceServingSetManagerGAgent(
+                GAgentServiceTestKit.NoOpDispatchPort,
+                targetResolver ?? new PassthroughServingTargetResolver()));
     }
 
     private static ServiceRolloutPlanSpec CreateRolloutPlan(string rolloutId, params ServiceRolloutStageSpec[] stages)

--- a/test/Aevatar.GAgentService.Tests/Infrastructure/ServiceInfrastructureTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Infrastructure/ServiceInfrastructureTests.cs
@@ -19,22 +19,27 @@ public sealed class ServiceInfrastructureTests
         var definitionTarget = await provisioner.EnsureDefinitionTargetAsync(identity);
         var revisionTarget = await provisioner.EnsureRevisionCatalogTargetAsync(identity);
         var deploymentTarget = await provisioner.EnsureDeploymentTargetAsync(identity);
+        var invocationCatalogTarget = await provisioner.EnsureInvocationCatalogTargetAsync(identity);
 
         definitionTarget.Should().Be(ServiceActorIds.Definition(identity));
         revisionTarget.Should().Be(ServiceActorIds.RevisionCatalog(identity));
         deploymentTarget.Should().Be(ServiceActorIds.Deployment(identity));
+        invocationCatalogTarget.Should().Be(ServiceActorIds.InvocationCatalog(identity));
         runtime.CreateCalls.Should().Contain((typeof(ServiceDefinitionGAgent), ServiceActorIds.Definition(identity)));
         runtime.CreateCalls.Should().Contain((typeof(ServiceRevisionCatalogGAgent), ServiceActorIds.RevisionCatalog(identity)));
         runtime.CreateCalls.Should().Contain((typeof(ServiceDeploymentManagerGAgent), ServiceActorIds.Deployment(identity)));
+        runtime.CreateCalls.Should().Contain((typeof(ServiceInvocationCatalogGAgent), ServiceActorIds.InvocationCatalog(identity)));
 
         runtime.MarkExisting(ServiceActorIds.Definition(identity));
         runtime.MarkExisting(ServiceActorIds.RevisionCatalog(identity));
         runtime.MarkExisting(ServiceActorIds.Deployment(identity));
+        runtime.MarkExisting(ServiceActorIds.InvocationCatalog(identity));
         runtime.CreateCalls.Clear();
 
         await provisioner.EnsureDefinitionTargetAsync(identity);
         await provisioner.EnsureRevisionCatalogTargetAsync(identity);
         await provisioner.EnsureDeploymentTargetAsync(identity);
+        await provisioner.EnsureInvocationCatalogTargetAsync(identity);
 
         runtime.CreateCalls.Should().BeEmpty();
     }

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceCommittedStateProjectionActivationPlanProviderTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceCommittedStateProjectionActivationPlanProviderTests.cs
@@ -52,6 +52,22 @@ public sealed class ServiceCommittedStateProjectionActivationPlanProviderTests
     }
 
     [Fact]
+    public void GetPlans_ShouldMapInvocationCatalogEventsToInvocationCatalogScope()
+    {
+        var provider = new ServiceCommittedStateProjectionActivationPlanProvider();
+
+        var plan = provider.GetPlans(BuildContext(
+                typeof(ServiceInvocationCatalogGAgent),
+                new ServiceInvocationCatalogObservedEvent { Identity = Identity() }))
+            .Should().ContainSingle().Subject;
+
+        plan.LeaseType.Should().Be(typeof(ServiceProjectionRuntimeLease<ServiceInvocationCatalogProjectionContext>));
+        plan.StartRequest.RootActorId.Should().Be("service-actor");
+        plan.StartRequest.ProjectionKind.Should().Be("service-invocation-catalog");
+        plan.StartRequest.Mode.Should().Be(ProjectionRuntimeMode.DurableMaterialization);
+    }
+
+    [Fact]
     public void GetPlans_ShouldMapCurrentStateActorsToTheirCurrentStateScopes()
     {
         var provider = new ServiceCommittedStateProjectionActivationPlanProvider();

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceInvocationCatalogProjectorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceInvocationCatalogProjectorTests.cs
@@ -1,0 +1,199 @@
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Services;
+using Aevatar.GAgentService.Projection.Contexts;
+using Aevatar.GAgentService.Projection.Projectors;
+using Aevatar.GAgentService.Projection.Queries;
+using Aevatar.GAgentService.Projection.ReadModels;
+using Aevatar.GAgentService.Tests.TestSupport;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgentService.Tests.Projection;
+
+public sealed class ServiceInvocationCatalogProjectorTests
+{
+    [Fact]
+    public async Task ProjectAsync_ShouldCloneAggregateStateUsingCommittedVersion()
+    {
+        var observedAt = DateTimeOffset.Parse("2026-06-05T01:00:00+00:00");
+        var store = new RecordingDocumentStore<ServiceInvocationCatalogReadModel>(x => x.Id);
+        var projector = new ServiceInvocationCatalogProjector(store, new FixedProjectionClock(DateTimeOffset.Parse("2026-06-05T00:00:00+00:00")));
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var context = new ServiceInvocationCatalogProjectionContext
+        {
+            RootActorId = "tenant:app:default:svc:invocation-catalog",
+            ProjectionKind = "service-invocation-catalog",
+        };
+        var state = new ServiceInvocationCatalogState
+        {
+            Identity = identity.Clone(),
+            SourceCatalogVersion = 11,
+            SourceServingVersion = 12,
+            SourceRevisionVersion = 13,
+            ObservedAt = Timestamp.FromDateTimeOffset(observedAt),
+            Entries =
+            {
+                new ServiceInvocationCatalogEntryState
+                {
+                    EndpointId = "chat",
+                    ReadinessStatus = ServiceInvokeReadinessStatus.Ready,
+                    UnavailableReason = ServiceInvokeUnavailableReason.Unspecified,
+                    SelectedRevisionId = "r1",
+                    SelectedDeploymentId = "dep-1",
+                    SelectedActorId = "actor-1",
+                },
+            },
+        };
+
+        await projector.ProjectAsync(
+            context,
+            BuildCommittedEnvelope(
+                new ServiceInvocationCatalogObservedEvent
+                {
+                    Identity = identity.Clone(),
+                },
+                state,
+                eventId: "evt-invocation-observed",
+                stateVersion: 42,
+                observedAt: observedAt));
+
+        var readModel = await store.GetAsync(ServiceKeys.Build(identity));
+        readModel.Should().NotBeNull();
+        readModel!.ActorId.Should().Be(context.RootActorId);
+        readModel.StateVersion.Should().Be(42);
+        readModel.LastEventId.Should().Be("evt-invocation-observed");
+        readModel.ObservedAt.Should().Be(observedAt);
+        readModel.SourceCatalogVersion.Should().Be(11);
+        readModel.SourceServingVersion.Should().Be(12);
+        readModel.SourceRevisionVersion.Should().Be(13);
+        readModel.Entries.Should().ContainSingle();
+        readModel.Entries[0].ReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Ready);
+    }
+
+    [Fact]
+    public async Task ProjectAsync_ShouldOverwriteIdempotently_WithoutLocalVersionCounter()
+    {
+        var store = new RecordingDocumentStore<ServiceInvocationCatalogReadModel>(x => x.Id);
+        var projector = new ServiceInvocationCatalogProjector(store, new FixedProjectionClock(DateTimeOffset.UtcNow));
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var context = new ServiceInvocationCatalogProjectionContext
+        {
+            RootActorId = "tenant:app:default:svc:invocation-catalog",
+            ProjectionKind = "service-invocation-catalog",
+        };
+
+        await projector.ProjectAsync(
+            context,
+            BuildCommittedEnvelope(
+                new ServiceInvocationCatalogObservedEvent { Identity = identity.Clone() },
+                State(identity, ServiceInvokeReadinessStatus.Unavailable, ServiceInvokeUnavailableReason.PreparedArtifactMissing),
+                "evt-1",
+                5,
+                DateTimeOffset.Parse("2026-06-05T01:00:00+00:00")));
+        await projector.ProjectAsync(
+            context,
+            BuildCommittedEnvelope(
+                new ServiceInvocationCatalogObservedEvent { Identity = identity.Clone() },
+                State(identity, ServiceInvokeReadinessStatus.Ready, ServiceInvokeUnavailableReason.Unspecified),
+                "evt-2",
+                9,
+                DateTimeOffset.Parse("2026-06-05T01:05:00+00:00")));
+
+        var readModel = await store.GetAsync(ServiceKeys.Build(identity));
+        readModel.Should().NotBeNull();
+        readModel!.StateVersion.Should().Be(9);
+        readModel.LastEventId.Should().Be("evt-2");
+        readModel.Entries.Should().ContainSingle();
+        readModel.Entries[0].ReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Ready);
+        (await store.ReadItemsAsync()).Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task QueryReader_ShouldReturnSnapshotFromReadModel()
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var store = new RecordingDocumentStore<ServiceInvocationCatalogReadModel>(x => x.Id);
+        await store.UpsertAsync(new ServiceInvocationCatalogReadModel
+        {
+            Id = ServiceKeys.Build(identity),
+            ServiceKey = ServiceKeys.Build(identity),
+            TenantId = identity.TenantId,
+            AppId = identity.AppId,
+            Namespace = identity.Namespace,
+            ServiceId = identity.ServiceId,
+            StateVersion = 7,
+            LastEventId = "evt-7",
+            ObservedAt = DateTimeOffset.Parse("2026-06-05T02:00:00+00:00"),
+            SourceCatalogVersion = 1,
+            SourceServingVersion = 2,
+            SourceRevisionVersion = 3,
+            Entries =
+            {
+                new ServiceInvocationReadinessEntryReadModel
+                {
+                    ServiceKey = ServiceKeys.Build(identity),
+                    EndpointId = "chat",
+                    ReadinessStatus = ServiceInvokeReadinessStatus.Unavailable,
+                    UnavailableReason = ServiceInvokeUnavailableReason.RevisionNotPrepared,
+                    SelectedRevisionId = "r1",
+                    SelectedDeploymentId = "dep-1",
+                    SelectedActorId = "actor-1",
+                },
+            },
+        });
+        var reader = new ServiceInvocationCatalogQueryReader(store);
+
+        var snapshot = await reader.GetAsync(identity);
+
+        snapshot.Should().NotBeNull();
+        snapshot!.AggregateStateVersion.Should().Be(7);
+        snapshot.Entries.Should().ContainSingle();
+        snapshot.Entries[0].UnavailableReason.Should().Be(ServiceInvokeUnavailableReason.RevisionNotPrepared);
+    }
+
+    private static ServiceInvocationCatalogState State(
+        ServiceIdentity identity,
+        ServiceInvokeReadinessStatus status,
+        ServiceInvokeUnavailableReason reason) =>
+        new()
+        {
+            Identity = identity.Clone(),
+            Entries =
+            {
+                new ServiceInvocationCatalogEntryState
+                {
+                    EndpointId = "chat",
+                    ReadinessStatus = status,
+                    UnavailableReason = reason,
+                    SelectedRevisionId = status == ServiceInvokeReadinessStatus.Ready ? "r1" : string.Empty,
+                    SelectedDeploymentId = status == ServiceInvokeReadinessStatus.Ready ? "dep-1" : string.Empty,
+                    SelectedActorId = status == ServiceInvokeReadinessStatus.Ready ? "actor-1" : string.Empty,
+                },
+            },
+        };
+
+    private static EventEnvelope BuildCommittedEnvelope<T>(
+        T evt,
+        ServiceInvocationCatalogState state,
+        string eventId,
+        long stateVersion,
+        DateTimeOffset observedAt)
+        where T : Google.Protobuf.IMessage =>
+        new()
+        {
+            Id = $"outer-{eventId}",
+            Timestamp = Timestamp.FromDateTimeOffset(observedAt),
+            Payload = Any.Pack(new CommittedStateEventPublished
+            {
+                StateEvent = new StateEvent
+                {
+                    EventId = eventId,
+                    Version = stateVersion,
+                    Timestamp = Timestamp.FromDateTimeOffset(observedAt),
+                    EventData = Any.Pack(evt),
+                },
+                StateRoot = Any.Pack(state),
+            }),
+        };
+}

--- a/test/Aevatar.GAgentService.Tests/TestSupport/GAgentServiceTestKit.cs
+++ b/test/Aevatar.GAgentService.Tests/TestSupport/GAgentServiceTestKit.cs
@@ -161,6 +161,20 @@ internal static class GAgentServiceTestKit
     }
 }
 
+internal sealed class RecordingActorDispatchPort : IActorDispatchPort
+{
+    public List<(string ActorId, EventEnvelope Envelope)> Calls { get; } = [];
+
+    public Task<DispatchAdmission> DispatchAsync(
+        string actorId,
+        EventEnvelope envelope,
+        CancellationToken ct = default)
+    {
+        Calls.Add((actorId, envelope));
+        return Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
+    }
+}
+
 [GAgent(GAgentServiceTestKit.TestStaticServiceAgentKind)]
 internal sealed class TestStaticServiceAgent : IAgent
 {

--- a/test/Aevatar.GAgentService.Tests/TestSupport/GAgentServiceTestKit.cs
+++ b/test/Aevatar.GAgentService.Tests/TestSupport/GAgentServiceTestKit.cs
@@ -17,6 +17,7 @@ namespace Aevatar.GAgentService.Tests.TestSupport;
 internal static class GAgentServiceTestKit
 {
     public const string TestStaticServiceAgentKind = "tests.static-service-agent";
+    public static IActorDispatchPort NoOpDispatchPort { get; } = new NoOpActorDispatchPort();
 
     private static readonly MethodInfo SetIdMethod = typeof(GAgentBase)
         .GetMethod("SetId", BindingFlags.Instance | BindingFlags.NonPublic)
@@ -148,6 +149,15 @@ internal static class GAgentServiceTestKit
         ArgumentNullException.ThrowIfNull(agent);
         ArgumentException.ThrowIfNullOrWhiteSpace(actorId);
         SetIdMethod.Invoke(agent, [actorId]);
+    }
+
+    private sealed class NoOpActorDispatchPort : IActorDispatchPort
+    {
+        public Task<DispatchAdmission> DispatchAsync(
+            string actorId,
+            EventEnvelope envelope,
+            CancellationToken ct = default) =>
+            Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
     }
 }
 


### PR DESCRIPTION
## 摘要
解决 #1759：scope-services stream invoke 在无 prepared artifact 时失败。
- **Old**：缺面向消费者的权威 invoke-readiness；各处即兴判定，缺 prepared artifact 直接失败。
- **New**：actor-owned `ServiceInvocationCatalogGAgent` + projection readiness readmodel（聚合必须 actor 化，不 query-time priming）；canonical proto enum `ServiceInvokeReadinessStatus`/`ServiceInvokeUnavailableReason`（含 `PREPARED_ARTIFACT_MISSING`）；`/services` 与 stream/sync invoke error 统一 reason。
经 consensus-rnd 设计共识 r7（minimal）。验证：build 0 err；GAgentService.Tests 794/794。

🤖 Auto-loop / consensus-rnd

⟦AI:AUTO-LOOP⟧
