### PR TITLE
feat(#1737): workflow cross-run singleton lease（WorkflowLeaseGAgent + LeaseModule）

### DIFF
--- a/docs/canon/workflow-primitives.md
+++ b/docs/canon/workflow-primitives.md
@@ -225,6 +225,45 @@ steps:
       duration_ms: "1500"
 ```
 
+### `lease`（别名：`mutex`）
+
+- 作用：在多个 workflow run 之间协调同一个单例资源的持有权。
+- 事实源：每个 canonical `key` 对应一个 `WorkflowLeaseGAgent` actor；run actor 只发请求并等待 continuation event。
+- v1 action：`acquire`、`renew`、`release`。缺省 action 为 `acquire`。
+- 常用参数：`key`、`on_conflict`、`ttl_ms`、`wait_timeout_ms`、`holder_token`、`generation`、`holder_token_variable`。
+- TTL 默认 `300000` ms，范围 `1000..3600000`；wait timeout 默认 `300000` ms，范围 `1000..3600000`。
+- `on_conflict` 仅 `fail|wait`；`wait` 使用固定 FIFO 队列，队列上限固定 32。
+- acquire 成功输出为 `holder_token`，并写入 `lease.*` annotations；renew/release 必须显式传回 `holder_token + generation`。
+- v1 不支持 `with_lease` 或自动持凭据。
+
+```yaml
+steps:
+  - id: acquire_lease
+    type: lease
+    parameters:
+      key: "billing/export"
+      on_conflict: wait
+      ttl_ms: "300000"
+      wait_timeout_ms: "120000"
+      holder_token_variable: billing_export_lease_token
+    next: do_singleton_work
+
+  - id: do_singleton_work
+    type: connector_call
+    parameters:
+      connector: billing_export
+      operation: run
+    next: release_lease
+
+  - id: release_lease
+    type: lease
+    parameters:
+      action: release
+      key: "billing/export"
+      holder_token: "${steps.acquire_lease.annotations.lease.holder_token}"
+      generation: "${steps.acquire_lease.annotations.lease.generation}"
+```
+
 ### `wait_signal`（别名：`wait`）
 
 - 作用：等待外部信号（可设置超时）。

--- a/docs/canon/workflow-runtime.md
+++ b/docs/canon/workflow-runtime.md
@@ -117,6 +117,21 @@ BindWorkflowDefinition(yaml)
 - timezone 为空时默认为 `UTC`，非空时必须能被 runtime `TimeZoneInfo` 解析。
 - `Headers` 是 command dispatch headers，不用于承载 schedule 核心语义。
 
+### Workflow Lease
+
+`WorkflowLeaseGAgent` 是 workflow 跨 run 单例 lease 的唯一事实源。一个 canonical `lease_key` 对应一个 deterministic lease actor；`WorkflowRunGAgent` 与 `LeaseModule` 只是 client，不保存可复用 credential，也不把进程内状态当成互斥事实。
+
+运行语义：
+
+- canonical key = trim 后 lower-invariant；actor id 由 `workflow.lease:` 加 key hash 生成，真实 key 保存在 actor state 和 typed event 中，调用方不得解析 actor id。
+- acquire 空闲或已过期时生成新的 `holder_token`，`generation += 1`，并基于 actor state 持久化 holder、expiry 和 callback intent。
+- renew/release 必须显式带 `holder_token + generation`；generation 不匹配、token 不匹配或 holder run 不匹配时返回 typed rejection，不修改 holder。
+- renew 只延长 `expires_at_unix_ms`，不提升 generation。
+- conflict policy v1 只支持 `fail` 或 FIFO `wait`；wait queue 上限固定为 32，不从 DSL 配置。
+- TTL expiry 与 wait timeout 都通过 durable self callback 事件化；callback 回到 lease actor 后再次按 token/generation/request_id 对账，陈旧 callback 被忽略。
+- release 或 TTL 清 holder 后由同一个 lease actor 授予 FIFO waiter；grant/reject 作为 continuation event 发送回请求方 run actor。
+- `.refactor-loop/host.env` 不是生产事实源，不保存 branch topology、machine path、ledger authority 或 workflow lease 常量。
+
 ### WorkflowModuleFactory
 
 按名称创建模块实例。DI 注册时每个模块有一个或多个名称：
@@ -182,6 +197,7 @@ roles:
 | | `while` | `WhileModule` | 循环执行（别名 `loop`） |
 | | `workflow_call` | `WorkflowCallModule` | 调用子工作流（别名 `sub_workflow`，支持 `lifecycle=singleton/transient/scope`） |
 | | `dynamic_workflow` | `DynamicWorkflowModule` | 从 LLM 输出提取 YAML，动态重配后继续执行 |
+| | `lease` | `LeaseModule` | 跨 run 显式 acquire/renew/release 单例 lease（别名 `mutex`） |
 | | `assign` | `AssignModule` | 变量赋值 |
 | | `checkpoint` | `CheckpointModule` | 检查点 |
 | **数据** | `transform` | `TransformModule` | 纯函数变换（count/take/join/split/distinct 等） |

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -492,6 +492,130 @@ message WorkflowToolCallCompletedEvent
   string error = 6;
 }
 
+enum WorkflowLeaseConflictPolicy {
+  WORKFLOW_LEASE_CONFLICT_POLICY_UNSPECIFIED = 0;
+  WORKFLOW_LEASE_CONFLICT_POLICY_FAIL = 1;
+  WORKFLOW_LEASE_CONFLICT_POLICY_WAIT = 2;
+}
+
+enum WorkflowLeaseOperation {
+  WORKFLOW_LEASE_OPERATION_UNSPECIFIED = 0;
+  WORKFLOW_LEASE_OPERATION_ACQUIRE = 1;
+  WORKFLOW_LEASE_OPERATION_RENEW = 2;
+  WORKFLOW_LEASE_OPERATION_RELEASE = 3;
+}
+
+enum WorkflowLeaseRejectionReason {
+  WORKFLOW_LEASE_REJECTION_REASON_UNSPECIFIED = 0;
+  WORKFLOW_LEASE_REJECTION_REASON_LEASE_BUSY = 1;
+  WORKFLOW_LEASE_REJECTION_REASON_WAIT_QUEUE_FULL = 2;
+  WORKFLOW_LEASE_REJECTION_REASON_WAIT_TIMEOUT = 3;
+  WORKFLOW_LEASE_REJECTION_REASON_STALE_HOLDER = 4;
+  WORKFLOW_LEASE_REJECTION_REASON_INVALID_REQUEST = 5;
+}
+
+message WorkflowLeaseAcquireRequestedEvent
+{
+  string lease_key = 1;
+  string request_id = 2;
+  string requester_run_id = 3;
+  string requester_actor_id = 4;
+  string requester_step_id = 5;
+  int32 ttl_ms = 6;
+  WorkflowLeaseConflictPolicy on_conflict = 7;
+  int32 wait_timeout_ms = 8;
+}
+
+message WorkflowLeaseAcquiredEvent
+{
+  string lease_key = 1;
+  string request_id = 2;
+  string requester_run_id = 3;
+  string requester_actor_id = 4;
+  string requester_step_id = 5;
+  string holder_token = 6;
+  int64 generation = 7;
+  int64 expires_at_unix_ms = 8;
+  int32 ttl_ms = 9;
+}
+
+message WorkflowLeaseRenewRequestedEvent
+{
+  string lease_key = 1;
+  string request_id = 2;
+  string requester_run_id = 3;
+  string requester_actor_id = 4;
+  string requester_step_id = 5;
+  string holder_token = 6;
+  int64 generation = 7;
+  int32 ttl_ms = 8;
+}
+
+message WorkflowLeaseRenewedEvent
+{
+  string lease_key = 1;
+  string request_id = 2;
+  string requester_run_id = 3;
+  string requester_actor_id = 4;
+  string requester_step_id = 5;
+  string holder_token = 6;
+  int64 generation = 7;
+  int64 expires_at_unix_ms = 8;
+  int32 ttl_ms = 9;
+}
+
+message WorkflowLeaseReleaseRequestedEvent
+{
+  string lease_key = 1;
+  string request_id = 2;
+  string requester_run_id = 3;
+  string requester_actor_id = 4;
+  string requester_step_id = 5;
+  string holder_token = 6;
+  int64 generation = 7;
+}
+
+message WorkflowLeaseReleasedEvent
+{
+  string lease_key = 1;
+  string request_id = 2;
+  string requester_run_id = 3;
+  string requester_actor_id = 4;
+  string requester_step_id = 5;
+  string holder_token = 6;
+  int64 generation = 7;
+}
+
+message WorkflowLeaseRejectedEvent
+{
+  string lease_key = 1;
+  string request_id = 2;
+  string requester_run_id = 3;
+  string requester_actor_id = 4;
+  string requester_step_id = 5;
+  WorkflowLeaseOperation operation = 6;
+  WorkflowLeaseRejectionReason reason = 7;
+  string current_holder_run_id = 8;
+  string error = 9;
+}
+
+message WorkflowLeaseExpirationFiredEvent
+{
+  string lease_key = 1;
+  string holder_token = 2;
+  int64 generation = 3;
+  int64 expires_at_unix_ms = 4;
+}
+
+message WorkflowLeaseWaitTimeoutFiredEvent
+{
+  string lease_key = 1;
+  string request_id = 2;
+  string requester_run_id = 3;
+  string requester_actor_id = 4;
+  string requester_step_id = 5;
+}
+
 // Replaces an existing workflow actor's definition using runtime-provided YAML and starts execution immediately.
 message ReplaceWorkflowDefinitionAndExecuteEvent { string workflow_yaml = 1; string input = 2; }
 

--- a/src/workflow/Aevatar.Workflow.Core/Modules/LeaseModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/LeaseModule.cs
@@ -1,3 +1,4 @@
+using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Workflow.Core.Primitives;
@@ -10,6 +11,12 @@ public sealed class LeaseModule : IEventModule<IWorkflowExecutionContext>
     private const string ActionAcquire = "acquire";
     private const string ActionRenew = "renew";
     private const string ActionRelease = "release";
+    private readonly IActorRuntime _actorRuntime;
+
+    public LeaseModule(IActorRuntime actorRuntime)
+    {
+        _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
+    }
 
     public string Name => "lease";
 
@@ -348,30 +355,23 @@ public sealed class LeaseModule : IEventModule<IWorkflowExecutionContext>
         return true;
     }
 
-    private static async Task<bool> TryEnsureLeaseActorAsync(
+    private async Task<bool> TryEnsureLeaseActorAsync(
         StepRequestEvent request,
         PendingWorkflowLeaseOperationState pending,
         IWorkflowExecutionContext ctx,
         CancellationToken ct)
     {
-        var runtime = ctx.Services.GetService(typeof(IActorRuntime)) as IActorRuntime;
-        if (runtime == null)
-        {
-            await PublishFailureAsync(request, ctx, "lease step requires IActorRuntime", ct);
-            return false;
-        }
-
-        if (await runtime.GetAsync(pending.LeaseActorId) != null)
+        if (await _actorRuntime.GetAsync(pending.LeaseActorId) != null)
             return true;
 
         try
         {
-            await runtime.CreateAsync(typeof(WorkflowLeaseGAgent), pending.LeaseActorId, ct);
+            await _actorRuntime.CreateAsync(typeof(WorkflowLeaseGAgent), pending.LeaseActorId, ct);
             return true;
         }
         catch (Exception ex)
         {
-            if (await runtime.GetAsync(pending.LeaseActorId) != null)
+            if (await _actorRuntime.GetAsync(pending.LeaseActorId) != null)
                 return true;
 
             await PublishFailureAsync(

--- a/src/workflow/Aevatar.Workflow.Core/Modules/LeaseModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/LeaseModule.cs
@@ -1,0 +1,508 @@
+using Aevatar.Foundation.Abstractions.TypeSystem;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Workflow.Core.Primitives;
+
+namespace Aevatar.Workflow.Core.Modules;
+
+public sealed class LeaseModule : IEventModule<IWorkflowExecutionContext>
+{
+    private const string ModuleStateKey = "lease";
+    private const string ActionAcquire = "acquire";
+    private const string ActionRenew = "renew";
+    private const string ActionRelease = "release";
+
+    public string Name => "lease";
+
+    public int Priority => 5;
+
+    public bool CanHandle(EventEnvelope envelope)
+    {
+        var payload = envelope.Payload;
+        return payload != null &&
+               (payload.Is(StepRequestEvent.Descriptor) ||
+                payload.Is(WorkflowLeaseAcquiredEvent.Descriptor) ||
+                payload.Is(WorkflowLeaseRenewedEvent.Descriptor) ||
+                payload.Is(WorkflowLeaseReleasedEvent.Descriptor) ||
+                payload.Is(WorkflowLeaseRejectedEvent.Descriptor));
+    }
+
+    public async Task HandleAsync(EventEnvelope envelope, IWorkflowExecutionContext ctx, CancellationToken ct)
+    {
+        var payload = envelope.Payload;
+        if (payload == null)
+            return;
+
+        if (payload.Is(StepRequestEvent.Descriptor))
+        {
+            await HandleStepRequestAsync(payload.Unpack<StepRequestEvent>(), envelope, ctx, ct);
+            return;
+        }
+
+        if (payload.Is(WorkflowLeaseAcquiredEvent.Descriptor))
+        {
+            await HandleAcquiredAsync(payload.Unpack<WorkflowLeaseAcquiredEvent>(), ctx, ct);
+            return;
+        }
+
+        if (payload.Is(WorkflowLeaseRenewedEvent.Descriptor))
+        {
+            await HandleRenewedAsync(payload.Unpack<WorkflowLeaseRenewedEvent>(), ctx, ct);
+            return;
+        }
+
+        if (payload.Is(WorkflowLeaseReleasedEvent.Descriptor))
+        {
+            await HandleReleasedAsync(payload.Unpack<WorkflowLeaseReleasedEvent>(), ctx, ct);
+            return;
+        }
+
+        await HandleRejectedAsync(payload.Unpack<WorkflowLeaseRejectedEvent>(), ctx, ct);
+    }
+
+    private async Task HandleStepRequestAsync(
+        StepRequestEvent request,
+        EventEnvelope envelope,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        if (!string.Equals(request.StepType, Name, StringComparison.Ordinal))
+            return;
+
+        var runId = WorkflowRunIdNormalizer.Normalize(request.RunId);
+        var stepId = request.StepId?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(runId) || string.IsNullOrWhiteSpace(stepId))
+        {
+            await PublishFailureAsync(request, ctx, "lease step requires non-empty run_id and step_id", ct);
+            return;
+        }
+
+        var action = NormalizeAction(WorkflowParameterValueParser.GetString(request.Parameters, ActionAcquire, "action"));
+        if (action is not ActionAcquire and not ActionRenew and not ActionRelease)
+        {
+            await PublishFailureAsync(request, ctx, $"lease action '{action}' is not supported", ct);
+            return;
+        }
+
+        var leaseKey = WorkflowParameterValueParser.GetString(request.Parameters, string.Empty, "key", "lease_key");
+        if (!TryResolveLeaseIdentity(leaseKey, out var canonicalKey, out var leaseActorId, out var keyError))
+        {
+            await PublishFailureAsync(request, ctx, keyError, ct);
+            return;
+        }
+
+        var pending = new PendingWorkflowLeaseOperationState
+        {
+            RequestId = BuildRequestId(runId, stepId, ResolveOriginEnvelopeId(envelope)),
+            RunId = runId,
+            StepId = stepId,
+            LeaseKey = canonicalKey,
+            LeaseActorId = leaseActorId,
+            Action = action,
+            Input = request.Input ?? string.Empty,
+            HolderTokenVariable = WorkflowParameterValueParser.GetString(
+                request.Parameters,
+                string.Empty,
+                "holder_token_variable"),
+        };
+
+        if (action == ActionAcquire)
+        {
+            await StartAcquireAsync(request, pending, ctx, ct);
+            return;
+        }
+
+        if (!TryParseCredential(request, out var holderToken, out var generation, out var credentialError))
+        {
+            await PublishFailureAsync(request, ctx, credentialError, ct);
+            return;
+        }
+
+        if (action == ActionRenew)
+        {
+            await StartRenewAsync(request, pending, holderToken, generation, ctx, ct);
+            return;
+        }
+
+        await StartReleaseAsync(request, pending, holderToken, generation, ctx, ct);
+    }
+
+    private async Task StartAcquireAsync(
+        StepRequestEvent request,
+        PendingWorkflowLeaseOperationState pending,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var onConflict = NormalizeOnConflict(WorkflowParameterValueParser.GetString(request.Parameters, "fail", "on_conflict"));
+        var ttlMs = WorkflowParameterValueParser.GetBoundedInt(
+            request.Parameters,
+            WorkflowLeaseGAgent.DefaultLeaseTtlMs,
+            WorkflowLeaseGAgent.MinLeaseTtlMs,
+            WorkflowLeaseGAgent.MaxLeaseTtlMs,
+            "ttl_ms");
+        var waitTimeoutMs = WorkflowParameterValueParser.GetBoundedInt(
+            request.Parameters,
+            WorkflowLeaseGAgent.DefaultWaitTimeoutMs,
+            WorkflowLeaseGAgent.MinWaitTimeoutMs,
+            WorkflowLeaseGAgent.MaxWaitTimeoutMs,
+            "wait_timeout_ms");
+
+        if (!await TryEnsureLeaseActorAsync(request, pending, ctx, ct))
+            return;
+
+        await UpsertPendingAsync(pending, ctx, ct);
+        await ctx.SendToAsync(
+            pending.LeaseActorId,
+            new WorkflowLeaseAcquireRequestedEvent
+            {
+                LeaseKey = pending.LeaseKey,
+                RequestId = pending.RequestId,
+                RequesterRunId = pending.RunId,
+                RequesterActorId = ctx.AgentId,
+                RequesterStepId = pending.StepId,
+                TtlMs = ttlMs,
+                WaitTimeoutMs = waitTimeoutMs,
+                OnConflict = onConflict == "wait"
+                    ? WorkflowLeaseConflictPolicy.Wait
+                    : WorkflowLeaseConflictPolicy.Fail,
+            },
+            ct);
+    }
+
+    private async Task StartRenewAsync(
+        StepRequestEvent request,
+        PendingWorkflowLeaseOperationState pending,
+        string holderToken,
+        long generation,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var ttlMs = WorkflowParameterValueParser.GetBoundedInt(
+            request.Parameters,
+            WorkflowLeaseGAgent.DefaultLeaseTtlMs,
+            WorkflowLeaseGAgent.MinLeaseTtlMs,
+            WorkflowLeaseGAgent.MaxLeaseTtlMs,
+            "ttl_ms");
+
+        if (!await TryEnsureLeaseActorAsync(request, pending, ctx, ct))
+            return;
+
+        await UpsertPendingAsync(pending, ctx, ct);
+        await ctx.SendToAsync(
+            pending.LeaseActorId,
+            new WorkflowLeaseRenewRequestedEvent
+            {
+                LeaseKey = pending.LeaseKey,
+                RequestId = pending.RequestId,
+                RequesterRunId = pending.RunId,
+                RequesterActorId = ctx.AgentId,
+                RequesterStepId = pending.StepId,
+                HolderToken = holderToken,
+                Generation = generation,
+                TtlMs = ttlMs,
+            },
+            ct);
+    }
+
+    private async Task StartReleaseAsync(
+        StepRequestEvent request,
+        PendingWorkflowLeaseOperationState pending,
+        string holderToken,
+        long generation,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        if (!await TryEnsureLeaseActorAsync(request, pending, ctx, ct))
+            return;
+
+        await UpsertPendingAsync(pending, ctx, ct);
+        await ctx.SendToAsync(
+            pending.LeaseActorId,
+            new WorkflowLeaseReleaseRequestedEvent
+            {
+                LeaseKey = pending.LeaseKey,
+                RequestId = pending.RequestId,
+                RequesterRunId = pending.RunId,
+                RequesterActorId = ctx.AgentId,
+                RequesterStepId = pending.StepId,
+                HolderToken = holderToken,
+                Generation = generation,
+            },
+            ct);
+    }
+
+    private async Task HandleAcquiredAsync(
+        WorkflowLeaseAcquiredEvent acquired,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        if (!TryTakePending(acquired.RequestId, acquired.RequesterRunId, acquired.RequesterStepId, ctx, out var state, out var pending))
+            return;
+
+        var completed = new StepCompletedEvent
+        {
+            StepId = pending.StepId,
+            RunId = pending.RunId,
+            Success = true,
+            Output = acquired.HolderToken ?? string.Empty,
+            AssignedVariable = pending.HolderTokenVariable ?? string.Empty,
+            AssignedValue = acquired.HolderToken ?? string.Empty,
+        };
+        FillSuccessAnnotations(completed, pending, acquired.HolderToken ?? string.Empty, acquired.Generation, acquired.ExpiresAtUnixMs);
+        await ctx.PublishAsync(completed, TopologyAudience.Self, ct);
+        await SaveStateAsync(state, ctx, ct);
+    }
+
+    private async Task HandleRenewedAsync(
+        WorkflowLeaseRenewedEvent renewed,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        if (!TryTakePending(renewed.RequestId, renewed.RequesterRunId, renewed.RequesterStepId, ctx, out var state, out var pending))
+            return;
+
+        var completed = new StepCompletedEvent
+        {
+            StepId = pending.StepId,
+            RunId = pending.RunId,
+            Success = true,
+            Output = renewed.HolderToken ?? string.Empty,
+        };
+        FillSuccessAnnotations(completed, pending, renewed.HolderToken ?? string.Empty, renewed.Generation, renewed.ExpiresAtUnixMs);
+        await ctx.PublishAsync(completed, TopologyAudience.Self, ct);
+        await SaveStateAsync(state, ctx, ct);
+    }
+
+    private async Task HandleReleasedAsync(
+        WorkflowLeaseReleasedEvent released,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        if (!TryTakePending(released.RequestId, released.RequesterRunId, released.RequesterStepId, ctx, out var state, out var pending))
+            return;
+
+        var completed = new StepCompletedEvent
+        {
+            StepId = pending.StepId,
+            RunId = pending.RunId,
+            Success = true,
+            Output = released.HolderToken ?? string.Empty,
+        };
+        completed.Annotations["lease.key"] = pending.LeaseKey;
+        completed.Annotations["lease.actor_id"] = pending.LeaseActorId;
+        completed.Annotations["lease.holder_token"] = released.HolderToken ?? string.Empty;
+        completed.Annotations["lease.generation"] = released.Generation.ToString("D");
+        await ctx.PublishAsync(completed, TopologyAudience.Self, ct);
+        await SaveStateAsync(state, ctx, ct);
+    }
+
+    private async Task HandleRejectedAsync(
+        WorkflowLeaseRejectedEvent rejected,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        if (!TryTakePending(rejected.RequestId, rejected.RequesterRunId, rejected.RequesterStepId, ctx, out var state, out var pending))
+            return;
+
+        var completed = new StepCompletedEvent
+        {
+            StepId = pending.StepId,
+            RunId = pending.RunId,
+            Success = false,
+            Error = string.IsNullOrWhiteSpace(rejected.Error)
+                ? $"lease {pending.Action} rejected: {rejected.Reason}"
+                : rejected.Error,
+        };
+        completed.Annotations["lease.key"] = pending.LeaseKey;
+        completed.Annotations["lease.actor_id"] = pending.LeaseActorId;
+        completed.Annotations["lease.rejection_reason"] = rejected.Reason.ToString();
+        completed.Annotations["lease.operation"] = rejected.Operation.ToString();
+        if (!string.IsNullOrWhiteSpace(rejected.CurrentHolderRunId))
+            completed.Annotations["lease.current_holder_run_id"] = rejected.CurrentHolderRunId;
+
+        await ctx.PublishAsync(completed, TopologyAudience.Self, ct);
+        await SaveStateAsync(state, ctx, ct);
+    }
+
+    private static bool TryTakePending(
+        string requestId,
+        string runId,
+        string stepId,
+        IWorkflowExecutionContext ctx,
+        out WorkflowLeaseModuleState state,
+        out PendingWorkflowLeaseOperationState pending)
+    {
+        state = WorkflowExecutionStateAccess.Load<WorkflowLeaseModuleState>(ctx, ModuleStateKey);
+        pending = new PendingWorkflowLeaseOperationState();
+        var key = BuildPendingKey(runId, stepId, requestId);
+        if (!state.Pending.Remove(key, out var candidate))
+            return false;
+
+        if (!string.Equals(candidate.RequestId, requestId, StringComparison.Ordinal) ||
+            !string.Equals(candidate.RunId, WorkflowRunIdNormalizer.Normalize(runId), StringComparison.Ordinal) ||
+            !string.Equals(candidate.StepId, stepId?.Trim() ?? string.Empty, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        pending = candidate;
+        return true;
+    }
+
+    private static async Task<bool> TryEnsureLeaseActorAsync(
+        StepRequestEvent request,
+        PendingWorkflowLeaseOperationState pending,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var runtime = ctx.Services.GetService(typeof(IActorRuntime)) as IActorRuntime;
+        if (runtime == null)
+        {
+            await PublishFailureAsync(request, ctx, "lease step requires IActorRuntime", ct);
+            return false;
+        }
+
+        if (await runtime.GetAsync(pending.LeaseActorId) != null)
+            return true;
+
+        try
+        {
+            await runtime.CreateAsync(typeof(WorkflowLeaseGAgent), pending.LeaseActorId, ct);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            if (await runtime.GetAsync(pending.LeaseActorId) != null)
+                return true;
+
+            await PublishFailureAsync(
+                request,
+                ctx,
+                $"lease actor '{pending.LeaseActorId}' could not be created: {ex.Message}",
+                ct);
+            return false;
+        }
+    }
+
+    private static async Task UpsertPendingAsync(
+        PendingWorkflowLeaseOperationState pending,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var state = WorkflowExecutionStateAccess.Load<WorkflowLeaseModuleState>(ctx, ModuleStateKey);
+        state.Pending[BuildPendingKey(pending.RunId, pending.StepId, pending.RequestId)] = pending;
+        await SaveStateAsync(state, ctx, ct);
+    }
+
+    private static Task SaveStateAsync(
+        WorkflowLeaseModuleState state,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        if (state.Pending.Count == 0)
+            return WorkflowExecutionStateAccess.ClearAsync(ctx, ModuleStateKey, ct);
+
+        return WorkflowExecutionStateAccess.SaveAsync(ctx, ModuleStateKey, state, ct);
+    }
+
+    private static void FillSuccessAnnotations(
+        StepCompletedEvent completed,
+        PendingWorkflowLeaseOperationState pending,
+        string holderToken,
+        long generation,
+        long expiresAtUnixMs)
+    {
+        completed.Annotations["lease.key"] = pending.LeaseKey;
+        completed.Annotations["lease.actor_id"] = pending.LeaseActorId;
+        completed.Annotations["lease.holder_token"] = holderToken ?? string.Empty;
+        completed.Annotations["lease.generation"] = generation.ToString("D");
+        completed.Annotations["lease.expires_at_unix_ms"] = expiresAtUnixMs.ToString("D");
+    }
+
+    private static bool TryResolveLeaseIdentity(
+        string rawKey,
+        out string canonicalKey,
+        out string actorId,
+        out string error)
+    {
+        canonicalKey = string.Empty;
+        actorId = string.Empty;
+        error = string.Empty;
+        try
+        {
+            canonicalKey = WorkflowLeaseActorId.NormalizeKey(rawKey);
+            actorId = WorkflowLeaseActorId.FromKey(canonicalKey);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            error = "lease step requires non-empty key";
+            return false;
+        }
+    }
+
+    private static bool TryParseCredential(
+        StepRequestEvent request,
+        out string holderToken,
+        out long generation,
+        out string error)
+    {
+        var action = NormalizeAction(request.Parameters.GetValueOrDefault("action", string.Empty));
+        holderToken = WorkflowParameterValueParser.GetString(request.Parameters, string.Empty, "holder_token");
+        generation = 0;
+        error = string.Empty;
+        if (string.IsNullOrWhiteSpace(holderToken))
+        {
+            error = $"lease {action} requires holder_token";
+            return false;
+        }
+
+        var generationRaw = WorkflowParameterValueParser.GetString(request.Parameters, string.Empty, "generation");
+        if (!long.TryParse(generationRaw.Trim(), out generation) || generation <= 0)
+        {
+            error = $"lease {action} requires positive integer generation";
+            return false;
+        }
+
+        holderToken = holderToken.Trim();
+        return true;
+    }
+
+    private static string NormalizeAction(string? raw)
+    {
+        var normalized = raw?.Trim().ToLowerInvariant() ?? string.Empty;
+        return string.IsNullOrWhiteSpace(normalized) ? ActionAcquire : normalized;
+    }
+
+    private static string NormalizeOnConflict(string? raw)
+    {
+        var normalized = raw?.Trim().ToLowerInvariant() ?? string.Empty;
+        return normalized == "wait" ? "wait" : "fail";
+    }
+
+    private static string BuildRequestId(string runId, string stepId, string originEnvelopeId) =>
+        RuntimeCallbackKeyComposer.BuildCallbackId("workflow-lease-request", runId, stepId, originEnvelopeId);
+
+    private static string BuildPendingKey(string runId, string stepId, string requestId) =>
+        $"{WorkflowRunIdNormalizer.Normalize(runId)}:{stepId?.Trim() ?? string.Empty}:{requestId?.Trim() ?? string.Empty}";
+
+    private static string ResolveOriginEnvelopeId(EventEnvelope envelope) =>
+        string.IsNullOrWhiteSpace(envelope.Id)
+            ? Guid.NewGuid().ToString("N")
+            : envelope.Id.Trim();
+
+    private static Task PublishFailureAsync(
+        StepRequestEvent request,
+        IWorkflowExecutionContext ctx,
+        string error,
+        CancellationToken ct) =>
+        ctx.PublishAsync(
+            new StepCompletedEvent
+            {
+                StepId = request.StepId ?? string.Empty,
+                RunId = WorkflowRunIdNormalizer.Normalize(request.RunId),
+                Success = false,
+                Error = error,
+            },
+            TopologyAudience.Self,
+            ct);
+}

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowLeaseActorId.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowLeaseActorId.cs
@@ -1,0 +1,30 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Aevatar.Workflow.Core.Primitives;
+
+public static class WorkflowLeaseActorId
+{
+    private const string Prefix = "workflow.lease:";
+
+    public static string NormalizeKey(string? leaseKey)
+    {
+        var normalized = leaseKey?.Trim().ToLowerInvariant() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(normalized))
+            throw new ArgumentException("workflow lease key is required.", nameof(leaseKey));
+
+        return normalized;
+    }
+
+    public static string FromKey(string? leaseKey)
+    {
+        var canonicalKey = NormalizeKey(leaseKey);
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(canonicalKey));
+        var builder = new StringBuilder(Prefix.Length + 24);
+        builder.Append(Prefix);
+        for (var i = 0; i < 12; i++)
+            builder.Append(bytes[i].ToString("x2"));
+
+        return builder.ToString();
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowParser.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowParser.cs
@@ -63,6 +63,14 @@ public sealed class WorkflowParser
         ("on_rejected", static step => step.OnRejected),
         ("on_inconclusive", static step => step.OnInconclusive),
         ("winner_policy", static step => step.WinnerPolicy),
+        ("action", static step => step.Action),
+        ("key", static step => step.Key),
+        ("on_conflict", static step => step.OnConflict),
+        ("ttl_ms", static step => step.TtlMs),
+        ("wait_timeout_ms", static step => step.WaitTimeoutMs),
+        ("holder_token", static step => step.HolderToken),
+        ("generation", static step => step.Generation),
+        ("holder_token_variable", static step => step.HolderTokenVariable),
     ];
 
     /// <summary>
@@ -462,6 +470,14 @@ public sealed class WorkflowParser
         public string? OnRejected { get; set; }
         public string? OnInconclusive { get; set; }
         public string? WinnerPolicy { get; set; }
+        public string? Action { get; set; }
+        public string? Key { get; set; }
+        public string? OnConflict { get; set; }
+        public object? TtlMs { get; set; }
+        public object? WaitTimeoutMs { get; set; }
+        public string? HolderToken { get; set; }
+        public object? Generation { get; set; }
+        public string? HolderTokenVariable { get; set; }
         public Dictionary<string, object?>? Parameters { get; set; }
         public string? Next { get; set; }
         public List<RawStep>? Children { get; set; }

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowPrimitiveCatalog.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowPrimitiveCatalog.cs
@@ -36,6 +36,7 @@ public static class WorkflowPrimitiveCatalog
             ["secure_connector"] = "secure_connector_call",
             ["secret_input"] = "secure_input",
             ["vote_consensus"] = "vote",
+            ["mutex"] = "lease",
         };
 
     private static readonly string[] IdentityPrimitives =
@@ -50,7 +51,7 @@ public static class WorkflowPrimitiveCatalog
         "llm_call", "tool_call", "connector_call", "secure_connector_call",
         "evaluate", "reflect", "human_input", "secure_input",
         "human_approval", "wait_signal", "emit", "parallel", "race",
-        "map_reduce", "vote", "foreach", "dynamic_workflow",
+        "map_reduce", "vote", "foreach", "dynamic_workflow", "lease",
     ];
 
     public static IReadOnlySet<string> BuiltInCanonicalTypes { get; } = DeriveBuiltInCanonicalTypes();

--- a/src/workflow/Aevatar.Workflow.Core/Validation/WorkflowValidator.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Validation/WorkflowValidator.cs
@@ -226,6 +226,12 @@ public static class WorkflowValidator
             return;
         }
 
+        if (stepType == "lease")
+        {
+            ValidateLeaseStep(step, errors);
+            return;
+        }
+
         if (stepType == "parallel")
         {
             ValidateParallelVoteAgreement(step, errors);
@@ -262,6 +268,73 @@ public static class WorkflowValidator
 
         if (!VoteAgreementRuleConfigurationParser.TryParse(voteParameters, out _, out var error))
             errors.Add($"步骤 '{step.Id}'（parallel.vote）{error}");
+    }
+
+    private static void ValidateLeaseStep(StepDefinition step, List<string> errors)
+    {
+        var action = GetParameterOrDefault(step.Parameters, "action", "acquire").Trim().ToLowerInvariant();
+        if (action is not "acquire" and not "renew" and not "release")
+            errors.Add($"步骤 '{step.Id}'（lease）action 仅支持 acquire|renew|release，当前值 '{action}'");
+
+        if (!TryGetParameter(step.Parameters, "key", out var key) || string.IsNullOrWhiteSpace(key))
+            errors.Add($"步骤 '{step.Id}'（lease）缺少 key 参数");
+
+        ValidateOptionalBoundedInt(
+            step,
+            "ttl_ms",
+            WorkflowLeaseGAgent.MinLeaseTtlMs,
+            WorkflowLeaseGAgent.MaxLeaseTtlMs,
+            errors);
+        ValidateOptionalBoundedInt(
+            step,
+            "wait_timeout_ms",
+            WorkflowLeaseGAgent.MinWaitTimeoutMs,
+            WorkflowLeaseGAgent.MaxWaitTimeoutMs,
+            errors);
+
+        if (TryGetParameter(step.Parameters, "on_conflict", out var onConflict) &&
+            !string.IsNullOrWhiteSpace(onConflict) &&
+            !string.Equals(onConflict.Trim(), "fail", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(onConflict.Trim(), "wait", StringComparison.OrdinalIgnoreCase))
+        {
+            errors.Add($"步骤 '{step.Id}'（lease）on_conflict 仅支持 fail|wait，当前值 '{onConflict}'");
+        }
+
+        var hasHolderToken = TryGetParameter(step.Parameters, "holder_token", out var holderToken) &&
+                             !string.IsNullOrWhiteSpace(holderToken);
+        var hasGeneration = TryGetParameter(step.Parameters, "generation", out var generation) &&
+                            !string.IsNullOrWhiteSpace(generation);
+        if (action is "renew" or "release")
+        {
+            if (!hasHolderToken)
+                errors.Add($"步骤 '{step.Id}'（lease）{action} 必须声明 holder_token");
+            if (!hasGeneration)
+                errors.Add($"步骤 '{step.Id}'（lease）{action} 必须声明 generation");
+        }
+        else
+        {
+            if (hasHolderToken)
+                errors.Add($"步骤 '{step.Id}'（lease）acquire 不允许声明 holder_token");
+            if (hasGeneration)
+                errors.Add($"步骤 '{step.Id}'（lease）acquire 不允许声明 generation");
+        }
+    }
+
+    private static void ValidateOptionalBoundedInt(
+        StepDefinition step,
+        string parameterName,
+        int min,
+        int max,
+        List<string> errors)
+    {
+        if (!TryGetParameter(step.Parameters, parameterName, out var raw) ||
+            string.IsNullOrWhiteSpace(raw))
+        {
+            return;
+        }
+
+        if (!int.TryParse(raw.Trim(), out var value) || value < min || value > max)
+            errors.Add($"步骤 '{step.Id}'（lease）{parameterName} 必须是 {min}..{max} 范围内的整数");
     }
 
     private static void ValidateConfiguredDecisionBranches(
@@ -315,6 +388,14 @@ public static class WorkflowValidator
         value = string.Empty;
         return false;
     }
+
+    private static string GetParameterOrDefault(
+        IReadOnlyDictionary<string, string> parameters,
+        string key,
+        string fallback) =>
+        TryGetParameter(parameters, key, out var value) && !string.IsNullOrWhiteSpace(value)
+            ? value
+            : fallback;
 
     public sealed class WorkflowValidationOptions
     {

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowCoreModulePack.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowCoreModulePack.cs
@@ -36,6 +36,7 @@ public sealed class WorkflowCoreModulePack : IWorkflowModulePack
         WorkflowModuleRegistration.Create<SecureInputModule>("secure_input", "secret_input"),
         WorkflowModuleRegistration.Create<WorkflowYamlValidateModule>("workflow_yaml_validate"),
         WorkflowModuleRegistration.Create<DynamicWorkflowModule>("dynamic_workflow"),
+        WorkflowModuleRegistration.Create<LeaseModule>("lease", "mutex"),
     ];
 
     private static readonly IReadOnlyList<IWorkflowModuleDependencyExpander> DependencyExpanderRegistrations =

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowLeaseGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowLeaseGAgent.cs
@@ -1,0 +1,819 @@
+using Aevatar.Foundation.Abstractions.Attributes;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Foundation.Abstractions.TypeSystem;
+using Aevatar.Foundation.Core;
+using Aevatar.Foundation.Core.EventSourcing;
+using Aevatar.Workflow.Core.Primitives;
+using Google.Protobuf;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.Workflow.Core;
+
+[GAgent("workflow.lease")]
+public sealed class WorkflowLeaseGAgent : GAgentBase<WorkflowLeaseState>
+{
+    public const int DefaultLeaseTtlMs = 300_000;
+    public const int MinLeaseTtlMs = 1_000;
+    public const int MaxLeaseTtlMs = 3_600_000;
+    public const int DefaultWaitTimeoutMs = 300_000;
+    public const int MinWaitTimeoutMs = 1_000;
+    public const int MaxWaitTimeoutMs = 3_600_000;
+    public const int MaxWaiters = 32;
+
+    protected override async Task OnActivateAsync(CancellationToken ct)
+    {
+        await base.OnActivateAsync(ct);
+        await RecoverCallbackIntentsAsync(ct);
+    }
+
+    public override Task<string> GetDescriptionAsync()
+    {
+        var key = string.IsNullOrWhiteSpace(State.LeaseKey) ? Id : State.LeaseKey;
+        var status = HasActiveHolder(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()) ? "held" : "available";
+        return Task.FromResult($"WorkflowLeaseGAgent[{key}] {status} generation={State.Generation}");
+    }
+
+    [EventHandler]
+    public Task HandleAcquireAsync(WorkflowLeaseAcquireRequestedEvent request) =>
+        HandleAcquireAsync(request, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), CancellationToken.None);
+
+    [EventHandler]
+    public Task HandleRenewAsync(WorkflowLeaseRenewRequestedEvent request) =>
+        HandleRenewAsync(request, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), CancellationToken.None);
+
+    [EventHandler]
+    public Task HandleReleaseAsync(WorkflowLeaseReleaseRequestedEvent request) =>
+        HandleReleaseAsync(request, CancellationToken.None);
+
+    [EventHandler(AllowSelfHandling = true, OnlySelfHandling = true)]
+    public Task HandleExpirationFiredAsync(WorkflowLeaseExpirationFiredEvent fired) =>
+        HandleExpirationFiredAsync(fired, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), CancellationToken.None);
+
+    [EventHandler(AllowSelfHandling = true, OnlySelfHandling = true)]
+    public Task HandleWaitTimeoutFiredAsync(WorkflowLeaseWaitTimeoutFiredEvent fired) =>
+        HandleWaitTimeoutFiredAsync(fired, CancellationToken.None);
+
+    internal async Task HandleAcquireAsync(
+        WorkflowLeaseAcquireRequestedEvent request,
+        long nowUnixMs,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!TryNormalizeAcquire(request, out var normalized, out var error))
+        {
+            await ReplyRejectedAsync(
+                request,
+                WorkflowLeaseOperation.Acquire,
+                WorkflowLeaseRejectionReason.InvalidRequest,
+                error,
+                ct);
+            return;
+        }
+
+        await ExpireHolderIfNeededAsync(nowUnixMs, ct);
+        if (!HasActiveHolder(nowUnixMs))
+        {
+            await GrantAsync(normalized, nowUnixMs, ct);
+            return;
+        }
+
+        if (normalized.OnConflict != WorkflowLeaseConflictPolicy.Wait)
+        {
+            await ReplyRejectedAsync(
+                normalized,
+                WorkflowLeaseOperation.Acquire,
+                WorkflowLeaseRejectionReason.LeaseBusy,
+                $"workflow lease '{normalized.LeaseKey}' is held by run '{State.HolderRunId}'.",
+                ct);
+            return;
+        }
+
+        if (HasWaiter(normalized.RequestId))
+            return;
+
+        if (State.Waiters.Count >= MaxWaiters)
+        {
+            await ReplyRejectedAsync(
+                normalized,
+                WorkflowLeaseOperation.Acquire,
+                WorkflowLeaseRejectionReason.WaitQueueFull,
+                $"workflow lease '{normalized.LeaseKey}' wait queue is full.",
+                ct);
+            return;
+        }
+
+        var timeoutCallbackId = BuildWaitTimeoutCallbackId(normalized.LeaseKey, normalized.RequestId);
+        var waiter = new WorkflowLeaseWaiterState
+        {
+            RequestId = normalized.RequestId,
+            RequesterRunId = normalized.RequesterRunId,
+            RequesterActorId = normalized.RequesterActorId,
+            RequesterStepId = normalized.RequesterStepId,
+            TtlMs = normalized.TtlMs,
+            WaitTimeoutMs = normalized.WaitTimeoutMs,
+            EnqueuedAtUnixMs = nowUnixMs,
+            TimeoutCallbackId = timeoutCallbackId,
+        };
+
+        var waitTimeoutLease = await ScheduleSelfDurableTimeoutAsync(
+            timeoutCallbackId,
+            TimeSpan.FromMilliseconds(normalized.WaitTimeoutMs),
+            new WorkflowLeaseWaitTimeoutFiredEvent
+            {
+                LeaseKey = normalized.LeaseKey,
+                RequestId = normalized.RequestId,
+                RequesterRunId = normalized.RequesterRunId,
+                RequesterActorId = normalized.RequesterActorId,
+                RequesterStepId = normalized.RequesterStepId,
+            },
+            ct: ct);
+        waiter.TimeoutLease = WorkflowRuntimeCallbackLeaseStateCodec.ToState(waitTimeoutLease);
+
+        await PersistDomainEventAsync(BuildStateUpsertedEvent(State, addWaiter: waiter), ct);
+    }
+
+    internal async Task HandleRenewAsync(
+        WorkflowLeaseRenewRequestedEvent request,
+        long nowUnixMs,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!TryNormalizeRenew(request, out var normalized, out var error))
+        {
+            await ReplyRejectedAsync(
+                request,
+                WorkflowLeaseOperation.Renew,
+                WorkflowLeaseRejectionReason.InvalidRequest,
+                error,
+                ct);
+            return;
+        }
+
+        await ExpireHolderIfNeededAsync(nowUnixMs, ct);
+        if (!MatchesHolder(normalized.HolderToken, normalized.Generation, normalized.RequesterRunId))
+        {
+            await ReplyRejectedAsync(
+                normalized,
+                WorkflowLeaseOperation.Renew,
+                WorkflowLeaseRejectionReason.StaleHolder,
+                $"workflow lease '{normalized.LeaseKey}' renew token or generation is stale.",
+                ct);
+            return;
+        }
+
+        var expiresAt = nowUnixMs + normalized.TtlMs;
+        var previousLease = WorkflowRuntimeCallbackLeaseStateCodec.ToRuntime(State.ExpirationLease);
+        await PersistDomainEventAsync(
+            BuildStateUpsertedEvent(
+                State,
+                holderRunId: normalized.RequesterRunId,
+                holderActorId: normalized.RequesterActorId,
+                holderStepId: normalized.RequesterStepId,
+                holderToken: normalized.HolderToken,
+                generation: normalized.Generation,
+                expiresAtUnixMs: expiresAt,
+                expirationCallbackId: BuildExpirationCallbackId(normalized.LeaseKey, normalized.Generation)),
+            ct);
+        await CancelLeaseBestEffortAsync(previousLease, CancellationToken.None);
+        await ActivateExpirationIntentAsync(ct);
+
+        await SendToAsync(
+            normalized.RequesterActorId,
+            new WorkflowLeaseRenewedEvent
+            {
+                LeaseKey = normalized.LeaseKey,
+                RequestId = normalized.RequestId,
+                RequesterRunId = normalized.RequesterRunId,
+                RequesterActorId = normalized.RequesterActorId,
+                RequesterStepId = normalized.RequesterStepId,
+                HolderToken = normalized.HolderToken,
+                Generation = normalized.Generation,
+                ExpiresAtUnixMs = expiresAt,
+                TtlMs = normalized.TtlMs,
+            },
+            ct);
+    }
+
+    internal async Task HandleReleaseAsync(WorkflowLeaseReleaseRequestedEvent request, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!TryNormalizeRelease(request, out var normalized, out var error))
+        {
+            await ReplyRejectedAsync(
+                request,
+                WorkflowLeaseOperation.Release,
+                WorkflowLeaseRejectionReason.InvalidRequest,
+                error,
+                ct);
+            return;
+        }
+
+        if (!MatchesHolder(normalized.HolderToken, normalized.Generation, normalized.RequesterRunId))
+        {
+            await ReplyRejectedAsync(
+                normalized,
+                WorkflowLeaseOperation.Release,
+                WorkflowLeaseRejectionReason.StaleHolder,
+                $"workflow lease '{normalized.LeaseKey}' release token or generation is stale.",
+                ct);
+            return;
+        }
+
+        var previousLease = WorkflowRuntimeCallbackLeaseStateCodec.ToRuntime(State.ExpirationLease);
+        await ClearHolderAsync(ct);
+        await CancelLeaseBestEffortAsync(previousLease, CancellationToken.None);
+
+        await SendToAsync(
+            normalized.RequesterActorId,
+            new WorkflowLeaseReleasedEvent
+            {
+                LeaseKey = normalized.LeaseKey,
+                RequestId = normalized.RequestId,
+                RequesterRunId = normalized.RequesterRunId,
+                RequesterActorId = normalized.RequesterActorId,
+                RequesterStepId = normalized.RequesterStepId,
+                HolderToken = normalized.HolderToken,
+                Generation = normalized.Generation,
+            },
+            ct);
+
+        await GrantNextWaiterAsync(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(), ct);
+    }
+
+    internal async Task HandleExpirationFiredAsync(
+        WorkflowLeaseExpirationFiredEvent fired,
+        long nowUnixMs,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(fired);
+        var leaseKey = TryNormalizeKey(fired.LeaseKey, out var normalizedKey)
+            ? normalizedKey
+            : State.LeaseKey;
+
+        if (!string.Equals(State.LeaseKey, leaseKey, StringComparison.Ordinal) ||
+            !string.Equals(State.HolderToken, fired.HolderToken, StringComparison.Ordinal) ||
+            State.Generation != fired.Generation ||
+            State.ExpiresAtUnixMs != fired.ExpiresAtUnixMs ||
+            State.ExpiresAtUnixMs > nowUnixMs)
+        {
+            return;
+        }
+
+        await ClearHolderAsync(ct);
+        await GrantNextWaiterAsync(nowUnixMs, ct);
+    }
+
+    internal async Task HandleWaitTimeoutFiredAsync(
+        WorkflowLeaseWaitTimeoutFiredEvent fired,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(fired);
+        if (string.IsNullOrWhiteSpace(fired.RequestId))
+            return;
+
+        var state = State.Clone();
+        var index = FindWaiterIndex(state, fired.RequestId);
+        if (index < 0)
+            return;
+
+        var waiter = state.Waiters[index];
+        state.Waiters.RemoveAt(index);
+        await PersistDomainEventAsync(BuildStateUpsertedEvent(state), ct);
+
+        await SendToAsync(
+            waiter.RequesterActorId,
+            BuildRejected(
+                waiter,
+                WorkflowLeaseOperation.Acquire,
+                WorkflowLeaseRejectionReason.WaitTimeout,
+                $"workflow lease '{State.LeaseKey}' wait timed out."),
+            ct);
+    }
+
+    protected override WorkflowLeaseState TransitionState(WorkflowLeaseState current, IMessage evt) =>
+        StateTransitionMatcher
+            .Match(current, evt)
+            .On<WorkflowLeaseStateUpsertedEvent>(ApplyStateUpserted)
+            .OrCurrent();
+
+    private async Task RecoverCallbackIntentsAsync(CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(State.LeaseKey))
+            return;
+
+        if (!string.IsNullOrWhiteSpace(State.HolderToken) && State.ExpiresAtUnixMs > DateTimeOffset.UtcNow.ToUnixTimeMilliseconds())
+            await ActivateExpirationIntentAsync(ct);
+
+        foreach (var waiter in State.Waiters.ToList())
+            await ActivateWaitTimeoutIntentAsync(waiter, ct);
+    }
+
+    private async Task ExpireHolderIfNeededAsync(long nowUnixMs, CancellationToken ct)
+    {
+        if (!HasActiveHolder(nowUnixMs) &&
+            !string.IsNullOrWhiteSpace(State.HolderToken))
+        {
+            var previousLease = WorkflowRuntimeCallbackLeaseStateCodec.ToRuntime(State.ExpirationLease);
+            await ClearHolderAsync(ct);
+            await CancelLeaseBestEffortAsync(previousLease, CancellationToken.None);
+        }
+    }
+
+    private async Task GrantNextWaiterAsync(long nowUnixMs, CancellationToken ct)
+    {
+        while (State.Waiters.Count > 0 && !HasActiveHolder(nowUnixMs))
+        {
+            var waiter = State.Waiters[0];
+            var state = State.Clone();
+            state.Waiters.RemoveAt(0);
+            await PersistDomainEventAsync(BuildStateUpsertedEvent(state), ct);
+
+            await CancelWaiterTimeoutAsync(waiter, CancellationToken.None);
+            await GrantAsync(
+                new WorkflowLeaseAcquireRequestedEvent
+                {
+                    LeaseKey = State.LeaseKey,
+                    RequestId = waiter.RequestId,
+                    RequesterRunId = waiter.RequesterRunId,
+                    RequesterActorId = waiter.RequesterActorId,
+                    RequesterStepId = waiter.RequesterStepId,
+                    TtlMs = waiter.TtlMs,
+                    WaitTimeoutMs = waiter.WaitTimeoutMs,
+                    OnConflict = WorkflowLeaseConflictPolicy.Wait,
+                },
+                nowUnixMs,
+                ct);
+        }
+    }
+
+    private async Task GrantAsync(
+        WorkflowLeaseAcquireRequestedEvent request,
+        long nowUnixMs,
+        CancellationToken ct)
+    {
+        var generation = State.Generation + 1;
+        var holderToken = Guid.NewGuid().ToString("N");
+        var expiresAt = nowUnixMs + request.TtlMs;
+        var previousLease = WorkflowRuntimeCallbackLeaseStateCodec.ToRuntime(State.ExpirationLease);
+        await PersistDomainEventAsync(
+            BuildStateUpsertedEvent(
+                State,
+                leaseKey: request.LeaseKey,
+                holderRunId: request.RequesterRunId,
+                holderActorId: request.RequesterActorId,
+                holderStepId: request.RequesterStepId,
+                holderToken: holderToken,
+                generation: generation,
+                expiresAtUnixMs: expiresAt,
+                expirationCallbackId: BuildExpirationCallbackId(request.LeaseKey, generation)),
+            ct);
+        await CancelLeaseBestEffortAsync(previousLease, CancellationToken.None);
+        await ActivateExpirationIntentAsync(ct);
+
+        await SendToAsync(
+            request.RequesterActorId,
+            new WorkflowLeaseAcquiredEvent
+            {
+                LeaseKey = request.LeaseKey,
+                RequestId = request.RequestId,
+                RequesterRunId = request.RequesterRunId,
+                RequesterActorId = request.RequesterActorId,
+                RequesterStepId = request.RequesterStepId,
+                HolderToken = holderToken,
+                Generation = generation,
+                ExpiresAtUnixMs = expiresAt,
+                TtlMs = request.TtlMs,
+            },
+            ct);
+    }
+
+    private async Task ActivateExpirationIntentAsync(CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(State.HolderToken) ||
+            string.IsNullOrWhiteSpace(State.ExpirationCallbackId) ||
+            State.ExpiresAtUnixMs <= 0)
+        {
+            return;
+        }
+
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var dueMs = Math.Max(1, State.ExpiresAtUnixMs - now);
+        var lease = await ScheduleSelfDurableTimeoutAsync(
+            State.ExpirationCallbackId,
+            TimeSpan.FromMilliseconds(dueMs),
+            new WorkflowLeaseExpirationFiredEvent
+            {
+                LeaseKey = State.LeaseKey,
+                HolderToken = State.HolderToken,
+                Generation = State.Generation,
+                ExpiresAtUnixMs = State.ExpiresAtUnixMs,
+            },
+            ct: ct);
+
+        await PersistDomainEventAsync(
+            BuildStateUpsertedEvent(
+                State,
+                expirationLease: WorkflowRuntimeCallbackLeaseStateCodec.ToState(lease)),
+            ct);
+    }
+
+    private async Task ActivateWaitTimeoutIntentAsync(WorkflowLeaseWaiterState waiter, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(waiter.TimeoutCallbackId))
+            return;
+
+        var elapsedMs = Math.Max(0, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - waiter.EnqueuedAtUnixMs);
+        var dueMs = Math.Max(1, waiter.WaitTimeoutMs - elapsedMs);
+        var lease = await ScheduleSelfDurableTimeoutAsync(
+            waiter.TimeoutCallbackId,
+            TimeSpan.FromMilliseconds(dueMs),
+            new WorkflowLeaseWaitTimeoutFiredEvent
+            {
+                LeaseKey = State.LeaseKey,
+                RequestId = waiter.RequestId,
+                RequesterRunId = waiter.RequesterRunId,
+                RequesterActorId = waiter.RequesterActorId,
+                RequesterStepId = waiter.RequesterStepId,
+            },
+            ct: ct);
+
+        var state = State.Clone();
+        var index = FindWaiterIndex(state, waiter.RequestId);
+        if (index < 0)
+            return;
+
+        state.Waiters[index].TimeoutLease = WorkflowRuntimeCallbackLeaseStateCodec.ToState(lease);
+        await PersistDomainEventAsync(BuildStateUpsertedEvent(state), ct);
+    }
+
+    private async Task ClearHolderAsync(CancellationToken ct)
+    {
+        await PersistDomainEventAsync(
+            BuildStateUpsertedEvent(
+                State,
+                holderRunId: string.Empty,
+                holderActorId: string.Empty,
+                holderStepId: string.Empty,
+                holderToken: string.Empty,
+                expiresAtUnixMs: 0,
+                expirationCallbackId: string.Empty,
+                expirationLease: null,
+                replaceExpirationLease: true),
+            ct);
+    }
+
+    private Task ReplyRejectedAsync(
+        WorkflowLeaseAcquireRequestedEvent request,
+        WorkflowLeaseOperation operation,
+        WorkflowLeaseRejectionReason reason,
+        string error,
+        CancellationToken ct) =>
+        SendToAsync(request.RequesterActorId, BuildRejected(request, operation, reason, error), ct);
+
+    private Task ReplyRejectedAsync(
+        WorkflowLeaseRenewRequestedEvent request,
+        WorkflowLeaseOperation operation,
+        WorkflowLeaseRejectionReason reason,
+        string error,
+        CancellationToken ct) =>
+        SendToAsync(request.RequesterActorId, BuildRejected(request, operation, reason, error), ct);
+
+    private Task ReplyRejectedAsync(
+        WorkflowLeaseReleaseRequestedEvent request,
+        WorkflowLeaseOperation operation,
+        WorkflowLeaseRejectionReason reason,
+        string error,
+        CancellationToken ct) =>
+        SendToAsync(request.RequesterActorId, BuildRejected(request, operation, reason, error), ct);
+
+    private bool HasActiveHolder(long nowUnixMs) =>
+        !string.IsNullOrWhiteSpace(State.HolderToken) && State.ExpiresAtUnixMs > nowUnixMs;
+
+    private bool MatchesHolder(string holderToken, long generation, string requesterRunId) =>
+        !string.IsNullOrWhiteSpace(holderToken) &&
+        string.Equals(State.HolderToken, holderToken, StringComparison.Ordinal) &&
+        State.Generation == generation &&
+        string.Equals(State.HolderRunId, requesterRunId, StringComparison.Ordinal);
+
+    private bool HasWaiter(string requestId) =>
+        State.Waiters.Any(x => string.Equals(x.RequestId, requestId, StringComparison.Ordinal));
+
+    private static WorkflowLeaseState ApplyStateUpserted(
+        WorkflowLeaseState current,
+        WorkflowLeaseStateUpsertedEvent evt) =>
+        evt.State?.Clone() ?? current;
+
+    private static int FindWaiterIndex(WorkflowLeaseState state, string requestId)
+    {
+        for (var i = 0; i < state.Waiters.Count; i++)
+        {
+            if (string.Equals(state.Waiters[i].RequestId, requestId, StringComparison.Ordinal))
+                return i;
+        }
+
+        return -1;
+    }
+
+    private static WorkflowLeaseStateUpsertedEvent BuildStateUpsertedEvent(
+        WorkflowLeaseState state,
+        string? leaseKey = null,
+        string? holderRunId = null,
+        string? holderActorId = null,
+        string? holderStepId = null,
+        string? holderToken = null,
+        long? generation = null,
+        long? expiresAtUnixMs = null,
+        string? expirationCallbackId = null,
+        WorkflowRuntimeCallbackLeaseState? expirationLease = null,
+        bool replaceExpirationLease = false,
+        WorkflowLeaseWaiterState? addWaiter = null)
+    {
+        var next = state.Clone();
+        if (leaseKey != null)
+            next.LeaseKey = leaseKey;
+        if (holderRunId != null)
+            next.HolderRunId = holderRunId;
+        if (holderActorId != null)
+            next.HolderActorId = holderActorId;
+        if (holderStepId != null)
+            next.HolderStepId = holderStepId;
+        if (holderToken != null)
+            next.HolderToken = holderToken;
+        if (generation.HasValue)
+            next.Generation = generation.Value;
+        if (expiresAtUnixMs.HasValue)
+            next.ExpiresAtUnixMs = expiresAtUnixMs.Value;
+        if (expirationCallbackId != null)
+            next.ExpirationCallbackId = expirationCallbackId;
+        if (replaceExpirationLease || expirationLease != null)
+            next.ExpirationLease = expirationLease?.Clone();
+        if (addWaiter != null)
+            next.Waiters.Add(addWaiter.Clone());
+
+        return new WorkflowLeaseStateUpsertedEvent
+        {
+            State = next,
+        };
+    }
+
+    private static WorkflowLeaseStateUpsertedEvent BuildStateUpsertedEvent(WorkflowLeaseState state) =>
+        new()
+        {
+            State = state.Clone(),
+        };
+
+    private static bool TryNormalizeAcquire(
+        WorkflowLeaseAcquireRequestedEvent request,
+        out WorkflowLeaseAcquireRequestedEvent normalized,
+        out string error)
+    {
+        normalized = request.Clone();
+        error = string.Empty;
+        if (!TryNormalizeRequestBasics(
+                request.LeaseKey,
+                request.RequestId,
+                request.RequesterRunId,
+                request.RequesterActorId,
+                request.RequesterStepId,
+                out var leaseKey,
+                out error))
+        {
+            return false;
+        }
+
+        normalized.LeaseKey = leaseKey;
+        normalized.RequestId = request.RequestId.Trim();
+        normalized.RequesterRunId = WorkflowRunIdNormalizer.Normalize(request.RequesterRunId);
+        normalized.RequesterActorId = request.RequesterActorId.Trim();
+        normalized.RequesterStepId = request.RequesterStepId.Trim();
+        normalized.TtlMs = NormalizeDuration(request.TtlMs, DefaultLeaseTtlMs, MinLeaseTtlMs, MaxLeaseTtlMs);
+        normalized.WaitTimeoutMs = NormalizeDuration(request.WaitTimeoutMs, DefaultWaitTimeoutMs, MinWaitTimeoutMs, MaxWaitTimeoutMs);
+        normalized.OnConflict = request.OnConflict == WorkflowLeaseConflictPolicy.Wait
+            ? WorkflowLeaseConflictPolicy.Wait
+            : WorkflowLeaseConflictPolicy.Fail;
+        return true;
+    }
+
+    private static bool TryNormalizeRenew(
+        WorkflowLeaseRenewRequestedEvent request,
+        out WorkflowLeaseRenewRequestedEvent normalized,
+        out string error)
+    {
+        normalized = request.Clone();
+        if (!TryNormalizeRequestBasics(
+                request.LeaseKey,
+                request.RequestId,
+                request.RequesterRunId,
+                request.RequesterActorId,
+                request.RequesterStepId,
+                out var leaseKey,
+                out error))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(request.HolderToken) || request.Generation <= 0)
+        {
+            error = "workflow lease renew requires holder_token and positive generation.";
+            return false;
+        }
+
+        normalized.LeaseKey = leaseKey;
+        normalized.RequestId = request.RequestId.Trim();
+        normalized.RequesterRunId = WorkflowRunIdNormalizer.Normalize(request.RequesterRunId);
+        normalized.RequesterActorId = request.RequesterActorId.Trim();
+        normalized.RequesterStepId = request.RequesterStepId.Trim();
+        normalized.HolderToken = request.HolderToken.Trim();
+        normalized.TtlMs = NormalizeDuration(request.TtlMs, DefaultLeaseTtlMs, MinLeaseTtlMs, MaxLeaseTtlMs);
+        return true;
+    }
+
+    private static bool TryNormalizeRelease(
+        WorkflowLeaseReleaseRequestedEvent request,
+        out WorkflowLeaseReleaseRequestedEvent normalized,
+        out string error)
+    {
+        normalized = request.Clone();
+        if (!TryNormalizeRequestBasics(
+                request.LeaseKey,
+                request.RequestId,
+                request.RequesterRunId,
+                request.RequesterActorId,
+                request.RequesterStepId,
+                out var leaseKey,
+                out error))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(request.HolderToken) || request.Generation <= 0)
+        {
+            error = "workflow lease release requires holder_token and positive generation.";
+            return false;
+        }
+
+        normalized.LeaseKey = leaseKey;
+        normalized.RequestId = request.RequestId.Trim();
+        normalized.RequesterRunId = WorkflowRunIdNormalizer.Normalize(request.RequesterRunId);
+        normalized.RequesterActorId = request.RequesterActorId.Trim();
+        normalized.RequesterStepId = request.RequesterStepId.Trim();
+        normalized.HolderToken = request.HolderToken.Trim();
+        return true;
+    }
+
+    private static bool TryNormalizeRequestBasics(
+        string leaseKey,
+        string requestId,
+        string requesterRunId,
+        string requesterActorId,
+        string requesterStepId,
+        out string normalizedLeaseKey,
+        out string error)
+    {
+        normalizedLeaseKey = string.Empty;
+        error = string.Empty;
+        if (!TryNormalizeKey(leaseKey, out normalizedLeaseKey))
+        {
+            error = "workflow lease key is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(requestId) ||
+            string.IsNullOrWhiteSpace(requesterRunId) ||
+            string.IsNullOrWhiteSpace(requesterActorId) ||
+            string.IsNullOrWhiteSpace(requesterStepId))
+        {
+            error = "workflow lease request requires request_id, requester_run_id, requester_actor_id, and requester_step_id.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryNormalizeKey(string leaseKey, out string normalizedLeaseKey)
+    {
+        try
+        {
+            normalizedLeaseKey = WorkflowLeaseActorId.NormalizeKey(leaseKey);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            normalizedLeaseKey = string.Empty;
+            return false;
+        }
+    }
+
+    private static int NormalizeDuration(int raw, int fallback, int min, int max)
+    {
+        var value = raw <= 0 ? fallback : raw;
+        return Math.Clamp(value, min, max);
+    }
+
+    private WorkflowLeaseRejectedEvent BuildRejected(
+        WorkflowLeaseAcquireRequestedEvent request,
+        WorkflowLeaseOperation operation,
+        WorkflowLeaseRejectionReason reason,
+        string error) =>
+        new()
+        {
+            LeaseKey = request.LeaseKey ?? string.Empty,
+            RequestId = request.RequestId ?? string.Empty,
+            RequesterRunId = request.RequesterRunId ?? string.Empty,
+            RequesterActorId = request.RequesterActorId ?? string.Empty,
+            RequesterStepId = request.RequesterStepId ?? string.Empty,
+            Operation = operation,
+            Reason = reason,
+            CurrentHolderRunId = State.HolderRunId ?? string.Empty,
+            Error = error ?? string.Empty,
+        };
+
+    private WorkflowLeaseRejectedEvent BuildRejected(
+        WorkflowLeaseRenewRequestedEvent request,
+        WorkflowLeaseOperation operation,
+        WorkflowLeaseRejectionReason reason,
+        string error) =>
+        new()
+        {
+            LeaseKey = request.LeaseKey ?? string.Empty,
+            RequestId = request.RequestId ?? string.Empty,
+            RequesterRunId = request.RequesterRunId ?? string.Empty,
+            RequesterActorId = request.RequesterActorId ?? string.Empty,
+            RequesterStepId = request.RequesterStepId ?? string.Empty,
+            Operation = operation,
+            Reason = reason,
+            CurrentHolderRunId = State.HolderRunId ?? string.Empty,
+            Error = error ?? string.Empty,
+        };
+
+    private WorkflowLeaseRejectedEvent BuildRejected(
+        WorkflowLeaseReleaseRequestedEvent request,
+        WorkflowLeaseOperation operation,
+        WorkflowLeaseRejectionReason reason,
+        string error) =>
+        new()
+        {
+            LeaseKey = request.LeaseKey ?? string.Empty,
+            RequestId = request.RequestId ?? string.Empty,
+            RequesterRunId = request.RequesterRunId ?? string.Empty,
+            RequesterActorId = request.RequesterActorId ?? string.Empty,
+            RequesterStepId = request.RequesterStepId ?? string.Empty,
+            Operation = operation,
+            Reason = reason,
+            CurrentHolderRunId = State.HolderRunId ?? string.Empty,
+            Error = error ?? string.Empty,
+        };
+
+    private WorkflowLeaseRejectedEvent BuildRejected(
+        WorkflowLeaseWaiterState waiter,
+        WorkflowLeaseOperation operation,
+        WorkflowLeaseRejectionReason reason,
+        string error) =>
+        new()
+        {
+            LeaseKey = State.LeaseKey ?? string.Empty,
+            RequestId = waiter.RequestId ?? string.Empty,
+            RequesterRunId = waiter.RequesterRunId ?? string.Empty,
+            RequesterActorId = waiter.RequesterActorId ?? string.Empty,
+            RequesterStepId = waiter.RequesterStepId ?? string.Empty,
+            Operation = operation,
+            Reason = reason,
+            CurrentHolderRunId = State.HolderRunId ?? string.Empty,
+            Error = error ?? string.Empty,
+        };
+
+    private static string BuildExpirationCallbackId(string leaseKey, long generation) =>
+        RuntimeCallbackKeyComposer.BuildCallbackId("workflow-lease-expiration", leaseKey, generation.ToString("D"));
+
+    private static string BuildWaitTimeoutCallbackId(string leaseKey, string requestId) =>
+        RuntimeCallbackKeyComposer.BuildCallbackId("workflow-lease-wait-timeout", leaseKey, requestId);
+
+    private async Task CancelWaiterTimeoutAsync(WorkflowLeaseWaiterState waiter, CancellationToken ct)
+    {
+        var lease = WorkflowRuntimeCallbackLeaseStateCodec.ToRuntime(waiter.TimeoutLease);
+        await CancelLeaseBestEffortAsync(lease, ct);
+    }
+
+    private async Task CancelLeaseBestEffortAsync(RuntimeCallbackLease? lease, CancellationToken ct)
+    {
+        if (lease == null)
+            return;
+
+        try
+        {
+            await CancelDurableCallbackAsync(lease, ct);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(
+                ex,
+                "Workflow lease {ActorId}: failed to cancel callback {CallbackId} generation={Generation}.",
+                Id,
+                lease.CallbackId,
+                lease.Generation);
+        }
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
+++ b/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
@@ -199,6 +199,55 @@ message WorkflowRuntimeCallbackLeaseState
   int32 slot_epoch = 5;
 }
 
+message WorkflowLeaseWaiterState
+{
+  string request_id = 1;
+  string requester_run_id = 2;
+  string requester_actor_id = 3;
+  string requester_step_id = 4;
+  int32 ttl_ms = 5;
+  int32 wait_timeout_ms = 6;
+  int64 enqueued_at_unix_ms = 7;
+  WorkflowRuntimeCallbackLeaseState timeout_lease = 8;
+  string timeout_callback_id = 9;
+}
+
+message WorkflowLeaseState
+{
+  string lease_key = 1;
+  string holder_run_id = 2;
+  string holder_actor_id = 3;
+  string holder_step_id = 4;
+  string holder_token = 5;
+  int64 generation = 6;
+  int64 expires_at_unix_ms = 7;
+  WorkflowRuntimeCallbackLeaseState expiration_lease = 8;
+  string expiration_callback_id = 9;
+  repeated WorkflowLeaseWaiterState waiters = 10;
+}
+
+message WorkflowLeaseStateUpsertedEvent
+{
+  WorkflowLeaseState state = 1;
+}
+
+message PendingWorkflowLeaseOperationState
+{
+  string request_id = 1;
+  string run_id = 2;
+  string step_id = 3;
+  string lease_key = 4;
+  string lease_actor_id = 5;
+  string action = 6;
+  string input = 7;
+  string holder_token_variable = 8;
+}
+
+message WorkflowLeaseModuleState
+{
+  map<string, PendingWorkflowLeaseOperationState> pending = 1;
+}
+
 message RetryBackoffState
 {
   WorkflowRuntimeCallbackLeaseState lease = 1;

--- a/test/Aevatar.Workflow.Core.Tests/Modules/LeaseModuleTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/LeaseModuleTests.cs
@@ -19,7 +19,7 @@ public sealed class LeaseModuleTests
     {
         var runtime = new RecordingActorRuntime();
         var ctx = new RecordingWorkflowContext(runtime);
-        var module = new LeaseModule();
+        var module = new LeaseModule(runtime);
 
         await module.HandleAsync(
             Envelope(new StepRequestEvent
@@ -55,7 +55,7 @@ public sealed class LeaseModuleTests
     {
         var runtime = new RecordingActorRuntime();
         var ctx = new RecordingWorkflowContext(runtime);
-        var module = new LeaseModule();
+        var module = new LeaseModule(runtime);
 
         await module.HandleAsync(
             Envelope(new StepRequestEvent
@@ -106,8 +106,9 @@ public sealed class LeaseModuleTests
     [Fact]
     public async Task HandleAsync_WhenReplyDoesNotMatchPending_ShouldIgnore()
     {
-        var ctx = new RecordingWorkflowContext(new RecordingActorRuntime());
-        var module = new LeaseModule();
+        var runtime = new RecordingActorRuntime();
+        var ctx = new RecordingWorkflowContext(runtime);
+        var module = new LeaseModule(runtime);
 
         await module.HandleAsync(
             Envelope(new StepRequestEvent
@@ -143,8 +144,9 @@ public sealed class LeaseModuleTests
     [InlineData("release", "generation")]
     public async Task HandleAsync_WhenRenewOrReleaseCredentialMissing_ShouldFailLocally(string action, string missing)
     {
-        var ctx = new RecordingWorkflowContext(new RecordingActorRuntime());
-        var module = new LeaseModule();
+        var runtime = new RecordingActorRuntime();
+        var ctx = new RecordingWorkflowContext(runtime);
+        var module = new LeaseModule(runtime);
         var request = new StepRequestEvent
         {
             StepId = $"{action}-1",
@@ -172,8 +174,9 @@ public sealed class LeaseModuleTests
     [Fact]
     public async Task HandleAsync_WhenGenerationMalformed_ShouldFailLocally()
     {
-        var ctx = new RecordingWorkflowContext(new RecordingActorRuntime());
-        var module = new LeaseModule();
+        var runtime = new RecordingActorRuntime();
+        var ctx = new RecordingWorkflowContext(runtime);
+        var module = new LeaseModule(runtime);
 
         await module.HandleAsync(
             Envelope(new StepRequestEvent
@@ -204,7 +207,7 @@ public sealed class LeaseModuleTests
     {
         var runtime = new RecordingActorRuntime();
         var ctx = new RecordingWorkflowContext(runtime);
-        var module = new LeaseModule();
+        var module = new LeaseModule(runtime);
 
         await module.HandleAsync(Envelope(new StepRequestEvent
         {
@@ -267,8 +270,9 @@ public sealed class LeaseModuleTests
     [Fact]
     public async Task HandleAsync_WhenRejectedMatchesPending_ShouldFailWithTypedReason()
     {
-        var ctx = new RecordingWorkflowContext(new RecordingActorRuntime());
-        var module = new LeaseModule();
+        var runtime = new RecordingActorRuntime();
+        var ctx = new RecordingWorkflowContext(runtime);
+        var module = new LeaseModule(runtime);
         await module.HandleAsync(Envelope(new StepRequestEvent
         {
             StepId = "acquire-1",

--- a/test/Aevatar.Workflow.Core.Tests/Modules/LeaseModuleTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/LeaseModuleTests.cs
@@ -1,0 +1,475 @@
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Abstractions.Execution;
+using Aevatar.Workflow.Core.Modules;
+using Aevatar.Workflow.Core.Primitives;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.Workflow.Core.Tests.Modules;
+
+public sealed class LeaseModuleTests
+{
+    [Fact]
+    public async Task HandleAsync_WhenAcquireRequested_ShouldCreateLeaseActorRecordPendingAndNotCompleteSameTurn()
+    {
+        var runtime = new RecordingActorRuntime();
+        var ctx = new RecordingWorkflowContext(runtime);
+        var module = new LeaseModule();
+
+        await module.HandleAsync(
+            Envelope(new StepRequestEvent
+            {
+                StepId = "acquire-1",
+                StepType = "lease",
+                RunId = "run-1",
+                Input = "payload",
+                Parameters =
+                {
+                    ["key"] = " Shared/Resource ",
+                    ["on_conflict"] = "wait",
+                    ["ttl_ms"] = "60000",
+                    ["holder_token_variable"] = "lease_token",
+                },
+            }, id: "origin-1"),
+            ctx,
+            CancellationToken.None);
+
+        ctx.Published.Should().BeEmpty();
+        runtime.Created.Should().ContainSingle().Which.Id.Should().Be(WorkflowLeaseActorId.FromKey("shared/resource"));
+        ctx.Sent.Should().ContainSingle();
+        var request = ctx.Sent[0].Event.Should().BeOfType<WorkflowLeaseAcquireRequestedEvent>().Subject;
+        request.LeaseKey.Should().Be("shared/resource");
+        request.OnConflict.Should().Be(WorkflowLeaseConflictPolicy.Wait);
+        request.TtlMs.Should().Be(60_000);
+        var state = ctx.LoadState<WorkflowLeaseModuleState>("lease");
+        state.Pending.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenAcquireGrantMatchesPending_ShouldCompleteWithAnnotationsAndAssignedToken()
+    {
+        var runtime = new RecordingActorRuntime();
+        var ctx = new RecordingWorkflowContext(runtime);
+        var module = new LeaseModule();
+
+        await module.HandleAsync(
+            Envelope(new StepRequestEvent
+            {
+                StepId = "acquire-1",
+                StepType = "lease",
+                RunId = "run-1",
+                Input = "payload",
+                Parameters =
+                {
+                    ["key"] = "shared",
+                    ["holder_token_variable"] = "lease_token",
+                },
+            }, id: "origin-1"),
+            ctx,
+            CancellationToken.None);
+        var request = ctx.Sent.Select(x => x.Event).OfType<WorkflowLeaseAcquireRequestedEvent>().Single();
+
+        await module.HandleAsync(
+            Envelope(new WorkflowLeaseAcquiredEvent
+            {
+                LeaseKey = request.LeaseKey,
+                RequestId = request.RequestId,
+                RequesterRunId = request.RequesterRunId,
+                RequesterActorId = request.RequesterActorId,
+                RequesterStepId = request.RequesterStepId,
+                HolderToken = "token-1",
+                Generation = 4,
+                ExpiresAtUnixMs = 123456,
+            }),
+            ctx,
+            CancellationToken.None);
+
+        var completed = ctx.Published.Should().ContainSingle().Subject.Event
+            .Should().BeOfType<StepCompletedEvent>().Subject;
+        completed.Success.Should().BeTrue();
+        completed.Output.Should().Be("token-1");
+        completed.AssignedVariable.Should().Be("lease_token");
+        completed.AssignedValue.Should().Be("token-1");
+        completed.Annotations["lease.key"].Should().Be("shared");
+        completed.Annotations["lease.actor_id"].Should().Be(WorkflowLeaseActorId.FromKey("shared"));
+        completed.Annotations["lease.holder_token"].Should().Be("token-1");
+        completed.Annotations["lease.generation"].Should().Be("4");
+        completed.Annotations["lease.expires_at_unix_ms"].Should().Be("123456");
+        ctx.LoadState<WorkflowLeaseModuleState>("lease").Pending.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenReplyDoesNotMatchPending_ShouldIgnore()
+    {
+        var ctx = new RecordingWorkflowContext(new RecordingActorRuntime());
+        var module = new LeaseModule();
+
+        await module.HandleAsync(
+            Envelope(new StepRequestEvent
+            {
+                StepId = "acquire-1",
+                StepType = "lease",
+                RunId = "run-1",
+                Parameters = { ["key"] = "shared" },
+            }, id: "origin-1"),
+            ctx,
+            CancellationToken.None);
+
+        await module.HandleAsync(
+            Envelope(new WorkflowLeaseAcquiredEvent
+            {
+                LeaseKey = "shared",
+                RequestId = "wrong",
+                RequesterRunId = "run-1",
+                RequesterActorId = ctx.AgentId,
+                RequesterStepId = "acquire-1",
+                HolderToken = "token-1",
+                Generation = 1,
+            }),
+            ctx,
+            CancellationToken.None);
+
+        ctx.Published.Should().BeEmpty();
+        ctx.LoadState<WorkflowLeaseModuleState>("lease").Pending.Should().ContainSingle();
+    }
+
+    [Theory]
+    [InlineData("renew", "holder_token")]
+    [InlineData("release", "generation")]
+    public async Task HandleAsync_WhenRenewOrReleaseCredentialMissing_ShouldFailLocally(string action, string missing)
+    {
+        var ctx = new RecordingWorkflowContext(new RecordingActorRuntime());
+        var module = new LeaseModule();
+        var request = new StepRequestEvent
+        {
+            StepId = $"{action}-1",
+            StepType = "lease",
+            RunId = "run-1",
+            Parameters =
+            {
+                ["action"] = action,
+                ["key"] = "shared",
+                ["holder_token"] = "token-1",
+                ["generation"] = "7",
+            },
+        };
+        request.Parameters.Remove(missing);
+
+        await module.HandleAsync(Envelope(request), ctx, CancellationToken.None);
+
+        var completed = ctx.Published.Should().ContainSingle().Subject.Event
+            .Should().BeOfType<StepCompletedEvent>().Subject;
+        completed.Success.Should().BeFalse();
+        completed.Error.Should().Contain(missing);
+        ctx.Sent.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenGenerationMalformed_ShouldFailLocally()
+    {
+        var ctx = new RecordingWorkflowContext(new RecordingActorRuntime());
+        var module = new LeaseModule();
+
+        await module.HandleAsync(
+            Envelope(new StepRequestEvent
+            {
+                StepId = "renew-1",
+                StepType = "lease",
+                RunId = "run-1",
+                Parameters =
+                {
+                    ["action"] = "renew",
+                    ["key"] = "shared",
+                    ["holder_token"] = "token-1",
+                    ["generation"] = "not-number",
+                },
+            }),
+            ctx,
+            CancellationToken.None);
+
+        var completed = ctx.Published.Should().ContainSingle().Subject.Event
+            .Should().BeOfType<StepCompletedEvent>().Subject;
+        completed.Success.Should().BeFalse();
+        completed.Error.Should().Contain("generation");
+        ctx.Sent.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenRenewAndReleaseRepliesMatch_ShouldComplete()
+    {
+        var runtime = new RecordingActorRuntime();
+        var ctx = new RecordingWorkflowContext(runtime);
+        var module = new LeaseModule();
+
+        await module.HandleAsync(Envelope(new StepRequestEvent
+        {
+            StepId = "renew-1",
+            StepType = "lease",
+            RunId = "run-1",
+            Parameters =
+            {
+                ["action"] = "renew",
+                ["key"] = "shared",
+                ["holder_token"] = "token-1",
+                ["generation"] = "7",
+            },
+        }, id: "renew-origin"), ctx, CancellationToken.None);
+        var renewRequest = ctx.Sent.Select(x => x.Event).OfType<WorkflowLeaseRenewRequestedEvent>().Single();
+
+        await module.HandleAsync(Envelope(new WorkflowLeaseRenewedEvent
+        {
+            LeaseKey = "shared",
+            RequestId = renewRequest.RequestId,
+            RequesterRunId = "run-1",
+            RequesterActorId = ctx.AgentId,
+            RequesterStepId = "renew-1",
+            HolderToken = "token-1",
+            Generation = 7,
+            ExpiresAtUnixMs = 555,
+        }), ctx, CancellationToken.None);
+
+        await module.HandleAsync(Envelope(new StepRequestEvent
+        {
+            StepId = "release-1",
+            StepType = "lease",
+            RunId = "run-1",
+            Parameters =
+            {
+                ["action"] = "release",
+                ["key"] = "shared",
+                ["holder_token"] = "token-1",
+                ["generation"] = "7",
+            },
+        }, id: "release-origin"), ctx, CancellationToken.None);
+        var releaseRequest = ctx.Sent.Select(x => x.Event).OfType<WorkflowLeaseReleaseRequestedEvent>().Single();
+
+        await module.HandleAsync(Envelope(new WorkflowLeaseReleasedEvent
+        {
+            LeaseKey = "shared",
+            RequestId = releaseRequest.RequestId,
+            RequesterRunId = "run-1",
+            RequesterActorId = ctx.AgentId,
+            RequesterStepId = "release-1",
+            HolderToken = "token-1",
+            Generation = 7,
+        }), ctx, CancellationToken.None);
+
+        ctx.Published.Select(x => x.Event).OfType<StepCompletedEvent>()
+            .Should().HaveCount(2)
+            .And.OnlyContain(x => x.Success);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenRejectedMatchesPending_ShouldFailWithTypedReason()
+    {
+        var ctx = new RecordingWorkflowContext(new RecordingActorRuntime());
+        var module = new LeaseModule();
+        await module.HandleAsync(Envelope(new StepRequestEvent
+        {
+            StepId = "acquire-1",
+            StepType = "lease",
+            RunId = "run-1",
+            Parameters = { ["key"] = "shared" },
+        }, id: "origin-1"), ctx, CancellationToken.None);
+        var request = ctx.Sent.Select(x => x.Event).OfType<WorkflowLeaseAcquireRequestedEvent>().Single();
+
+        await module.HandleAsync(Envelope(new WorkflowLeaseRejectedEvent
+        {
+            LeaseKey = "shared",
+            RequestId = request.RequestId,
+            RequesterRunId = "run-1",
+            RequesterActorId = ctx.AgentId,
+            RequesterStepId = "acquire-1",
+            Operation = WorkflowLeaseOperation.Acquire,
+            Reason = WorkflowLeaseRejectionReason.LeaseBusy,
+            CurrentHolderRunId = "run-holder",
+            Error = "busy",
+        }), ctx, CancellationToken.None);
+
+        var completed = ctx.Published.Should().ContainSingle().Subject.Event
+            .Should().BeOfType<StepCompletedEvent>().Subject;
+        completed.Success.Should().BeFalse();
+        completed.Error.Should().Be("busy");
+        completed.Annotations["lease.rejection_reason"].Should().Be(WorkflowLeaseRejectionReason.LeaseBusy.ToString());
+        completed.Annotations["lease.current_holder_run_id"].Should().Be("run-holder");
+    }
+
+    private static EventEnvelope Envelope(IMessage evt, string? id = null) =>
+        new()
+        {
+            Id = id ?? Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(evt),
+            Route = EnvelopeRouteSemantics.CreateTopologyPublication("test", TopologyAudience.Self),
+        };
+
+    private sealed class RecordingWorkflowContext(IActorRuntime runtime) : IWorkflowExecutionContext
+    {
+        private readonly Dictionary<string, Any> _states = new(StringComparer.Ordinal);
+
+        public EventEnvelope InboundEnvelope { get; } = new();
+
+        public string AgentId => "workflow-run-actor";
+
+        public string RunId => "run-1";
+
+        public IServiceProvider Services { get; } = new TestServiceProvider(runtime);
+
+        public ILogger Logger { get; } = NullLogger.Instance;
+
+        public List<(IMessage Event, TopologyAudience Direction)> Published { get; } = [];
+
+        public List<(string TargetActorId, IMessage Event)> Sent { get; } = [];
+
+        public TState LoadState<TState>(string scopeKey)
+            where TState : class, IMessage<TState>, new()
+        {
+            if (!_states.TryGetValue(scopeKey, out var packed) || !packed.Is(new TState().Descriptor))
+                return new TState();
+
+            return packed.Unpack<TState>() ?? new TState();
+        }
+
+        public IReadOnlyList<KeyValuePair<string, TState>> LoadStates<TState>(string scopeKeyPrefix = "")
+            where TState : class, IMessage<TState>, new() =>
+            [];
+
+        public Task SaveStateAsync<TState>(string scopeKey, TState state, CancellationToken ct = default)
+            where TState : class, IMessage<TState>
+        {
+            _states[scopeKey] = Any.Pack(state);
+            return Task.CompletedTask;
+        }
+
+        public Task ClearStateAsync(string scopeKey, CancellationToken ct = default)
+        {
+            _states.Remove(scopeKey);
+            return Task.CompletedTask;
+        }
+
+        public Task PublishAsync<TEvent>(
+            TEvent evt,
+            TopologyAudience audience = TopologyAudience.Children,
+            CancellationToken ct = default,
+            EventEnvelopePublishOptions? options = null)
+            where TEvent : IMessage
+        {
+            Published.Add((evt, audience));
+            return Task.CompletedTask;
+        }
+
+        public Task SendToAsync<TEvent>(
+            string targetActorId,
+            TEvent evt,
+            CancellationToken ct = default,
+            EventEnvelopePublishOptions? options = null)
+            where TEvent : IMessage
+        {
+            Sent.Add((targetActorId, evt));
+            return Task.CompletedTask;
+        }
+
+        public Task<RuntimeCallbackLease> ScheduleSelfDurableTimeoutAsync(
+            string callbackId,
+            TimeSpan dueTime,
+            IMessage evt,
+            EventEnvelopePublishOptions? options = null,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<RuntimeCallbackLease> ScheduleSelfDurableTimerAsync(
+            string callbackId,
+            TimeSpan dueTime,
+            TimeSpan period,
+            IMessage evt,
+            EventEnvelopePublishOptions? options = null,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task CancelDurableCallbackAsync(RuntimeCallbackLease lease, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class RecordingActorRuntime : IActorRuntime
+    {
+        private readonly Dictionary<string, IActor> _actors = new(StringComparer.Ordinal);
+
+        public List<(System.Type Type, string Id)> Created { get; } = [];
+
+        public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
+            where TAgent : IAgent =>
+            CreateAsync(typeof(TAgent), id, ct);
+
+        public Task<IActor> CreateAsync(System.Type agentType, string? id = null, CancellationToken ct = default)
+        {
+            var actorId = id ?? $"{agentType.Name}:{Guid.NewGuid():N}";
+            var actor = new StubActor(actorId);
+            _actors[actorId] = actor;
+            Created.Add((agentType, actorId));
+            return Task.FromResult<IActor>(actor);
+        }
+
+        public Task DestroyAsync(string id, CancellationToken ct = default)
+        {
+            _actors.Remove(id);
+            return Task.CompletedTask;
+        }
+
+        public Task<IActor?> GetAsync(string id) =>
+            Task.FromResult(_actors.GetValueOrDefault(id));
+
+        public Task<bool> ExistsAsync(string id) =>
+            Task.FromResult(_actors.ContainsKey(id));
+
+        public Task LinkAsync(string parentId, string childId, CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task UnlinkAsync(string childId, CancellationToken ct = default) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class StubActor(string id) : IActor
+    {
+        public string Id { get; } = id;
+
+        public IAgent Agent { get; } = new StubAgent(id);
+
+        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
+
+        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() => Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class StubAgent(string id) : IAgent
+    {
+        public string Id { get; } = id;
+
+        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task<string> GetDescriptionAsync() => Task.FromResult("stub");
+
+        public Task<IReadOnlyList<System.Type>> GetSubscribedEventTypesAsync() => Task.FromResult<IReadOnlyList<System.Type>>([]);
+
+        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class TestServiceProvider(IActorRuntime runtime) : IServiceProvider
+    {
+        public object? GetService(System.Type serviceType) =>
+            serviceType == typeof(IActorRuntime)
+                ? runtime
+                : null;
+    }
+}

--- a/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowParserConfigurationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowParserConfigurationTests.cs
@@ -146,6 +146,35 @@ public class WorkflowParserConfigurationTests
     }
 
     [Fact]
+    public void Parse_WhenLeaseRootParametersProvided_ShouldLiftToParameters()
+    {
+        var yaml = """
+            name: lease_root_parameters
+            roles: []
+            steps:
+              - id: acquire
+                type: mutex
+                action: acquire
+                key: Shared/Resource
+                on_conflict: wait
+                ttl_ms: 60000
+                wait_timeout_ms: 120000
+                holder_token_variable: lease_token
+            """;
+
+        var workflow = new WorkflowParser().Parse(yaml);
+        var step = workflow.Steps.Should().ContainSingle().Subject;
+
+        step.Type.Should().Be("lease");
+        step.Parameters["action"].Should().Be("acquire");
+        step.Parameters["key"].Should().Be("Shared/Resource");
+        step.Parameters["on_conflict"].Should().Be("wait");
+        step.Parameters["ttl_ms"].Should().Be("60000");
+        step.Parameters["wait_timeout_ms"].Should().Be("120000");
+        step.Parameters["holder_token_variable"].Should().Be("lease_token");
+    }
+
+    [Fact]
     public void Parse_WhenUsingErgonomicAliases_ShouldCanonicalizeAndApplyDefaults()
     {
         var yaml = """

--- a/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowPrimitiveCatalogTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowPrimitiveCatalogTests.cs
@@ -1,0 +1,14 @@
+using Aevatar.Workflow.Core.Primitives;
+using FluentAssertions;
+
+namespace Aevatar.Workflow.Core.Tests.Primitives;
+
+public sealed class WorkflowPrimitiveCatalogTests
+{
+    [Fact]
+    public void BuiltInCanonicalTypes_ShouldIncludeLeaseAndCanonicalizeMutex()
+    {
+        WorkflowPrimitiveCatalog.ToCanonicalType("mutex").Should().Be("lease");
+        WorkflowPrimitiveCatalog.BuiltInCanonicalTypes.Should().Contain("lease");
+    }
+}

--- a/test/Aevatar.Workflow.Core.Tests/Validation/WorkflowValidatorTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Validation/WorkflowValidatorTests.cs
@@ -1,0 +1,102 @@
+using Aevatar.Workflow.Core.Primitives;
+using Aevatar.Workflow.Core.Validation;
+using FluentAssertions;
+
+namespace Aevatar.Workflow.Core.Tests.Validation;
+
+public sealed class WorkflowValidatorTests
+{
+    [Fact]
+    public void Validate_WhenLeaseAcquireUsesDefaults_ShouldAccept()
+    {
+        var errors = WorkflowValidator.Validate(WorkflowWith(Step("acquire", "lease", new()
+        {
+            ["key"] = "shared",
+        })));
+
+        errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Validate_WhenLeaseRenewOrReleaseMissingCredential_ShouldReject()
+    {
+        var renewErrors = WorkflowValidator.Validate(WorkflowWith(Step("renew", "lease", new()
+        {
+            ["action"] = "renew",
+            ["key"] = "shared",
+            ["holder_token"] = "token",
+        })));
+        var releaseErrors = WorkflowValidator.Validate(WorkflowWith(Step("release", "lease", new()
+        {
+            ["action"] = "release",
+            ["key"] = "shared",
+            ["generation"] = "1",
+        })));
+
+        renewErrors.Should().Contain(x => x.Contains("generation", StringComparison.Ordinal));
+        releaseErrors.Should().Contain(x => x.Contains("holder_token", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("action", "invalid")]
+    [InlineData("ttl_ms", "999")]
+    [InlineData("ttl_ms", "3600001")]
+    [InlineData("ttl_ms", "not-int")]
+    [InlineData("wait_timeout_ms", "999")]
+    [InlineData("on_conflict", "block")]
+    public void Validate_WhenLeaseParametersInvalid_ShouldReject(string key, string value)
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["key"] = "shared",
+            [key] = value,
+        };
+
+        var errors = WorkflowValidator.Validate(WorkflowWith(Step("lease-1", "lease", parameters)));
+
+        errors.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Validate_WhenLeaseAcquireDeclaresCredential_ShouldReject()
+    {
+        var errors = WorkflowValidator.Validate(WorkflowWith(Step("acquire", "lease", new()
+        {
+            ["key"] = "shared",
+            ["holder_token"] = "token",
+            ["generation"] = "1",
+        })));
+
+        errors.Should().Contain(x => x.Contains("acquire", StringComparison.Ordinal) &&
+                                     x.Contains("holder_token", StringComparison.Ordinal));
+        errors.Should().Contain(x => x.Contains("acquire", StringComparison.Ordinal) &&
+                                     x.Contains("generation", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_WhenLeaseKeyMissing_ShouldReject()
+    {
+        var errors = WorkflowValidator.Validate(WorkflowWith(Step("lease-1", "lease", new())));
+
+        errors.Should().Contain(x => x.Contains("key", StringComparison.Ordinal));
+    }
+
+    private static WorkflowDefinition WorkflowWith(StepDefinition step) =>
+        new()
+        {
+            Name = "lease_validation",
+            Roles = [],
+            Steps = [step],
+        };
+
+    private static StepDefinition Step(
+        string id,
+        string type,
+        Dictionary<string, string> parameters) =>
+        new()
+        {
+            Id = id,
+            Type = type,
+            Parameters = parameters,
+        };
+}

--- a/test/Aevatar.Workflow.Core.Tests/WorkflowLeaseGAgentTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/WorkflowLeaseGAgentTests.cs
@@ -3,11 +3,13 @@ using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Hooks;
 using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Workflow.Abstractions;
 using FluentAssertions;
 using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.Workflow.Core.Tests;
 
@@ -226,6 +228,153 @@ public sealed class WorkflowLeaseGAgentTests
         agent.State.HolderToken.Should().Be(holder.HolderToken);
     }
 
+    [Fact]
+    public async Task ActivateAsync_WhenPersistedHolderActive_ShouldRescheduleExpirationAndPersistRecoveredLease()
+    {
+        var eventStore = new TestEventStore();
+        await SeedStateAsync(eventStore, new WorkflowLeaseState
+        {
+            LeaseKey = "shared",
+            HolderRunId = "run-holder",
+            HolderActorId = "actor-run-holder",
+            HolderStepId = "step-holder",
+            HolderToken = "token-holder",
+            Generation = 8,
+            ExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(10).ToUnixTimeMilliseconds(),
+            ExpirationCallbackId = RuntimeCallbackKeyComposer.BuildCallbackId("workflow-lease-expiration", "shared", "8"),
+        });
+        var scheduler = new RecordingRuntimeCallbackScheduler();
+        var agent = CreateAgent(new RecordingSender(), scheduler, eventStore);
+
+        await agent.ActivateAsync();
+
+        scheduler.TimeoutRequests.Should().ContainSingle();
+        var request = scheduler.TimeoutRequests[0];
+        request.ActorId.Should().Be(LeaseActorId);
+        request.CallbackId.Should().Be(RuntimeCallbackKeyComposer.BuildCallbackId("workflow-lease-expiration", "shared", "8"));
+        request.TriggerEnvelope.Payload.Should().NotBeNull();
+        var fired = request.TriggerEnvelope.Payload!.Unpack<WorkflowLeaseExpirationFiredEvent>();
+        fired.HolderToken.Should().Be("token-holder");
+        fired.Generation.Should().Be(8);
+        agent.State.ExpirationLease.Should().NotBeNull();
+        agent.State.ExpirationLease!.CallbackId.Should().Be(request.CallbackId);
+        agent.State.ExpirationLease.Generation.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ActivateAsync_WhenPersistedWaitersExist_ShouldRescheduleTimeoutsAndPersistRecoveredLeases()
+    {
+        var eventStore = new TestEventStore();
+        var firstTimeoutId = RuntimeCallbackKeyComposer.BuildCallbackId("workflow-lease-wait-timeout", "shared", "wait-1");
+        var secondTimeoutId = RuntimeCallbackKeyComposer.BuildCallbackId("workflow-lease-wait-timeout", "shared", "wait-2");
+        await SeedStateAsync(eventStore, new WorkflowLeaseState
+        {
+            LeaseKey = "shared",
+            HolderRunId = "run-holder",
+            HolderActorId = "actor-run-holder",
+            HolderStepId = "step-holder",
+            HolderToken = "token-holder",
+            Generation = 2,
+            ExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(10).ToUnixTimeMilliseconds(),
+            ExpirationCallbackId = RuntimeCallbackKeyComposer.BuildCallbackId("workflow-lease-expiration", "shared", "2"),
+            Waiters =
+            {
+                new WorkflowLeaseWaiterState
+                {
+                    RequestId = "wait-1",
+                    RequesterRunId = "run-wait-1",
+                    RequesterActorId = "actor-run-wait-1",
+                    RequesterStepId = "step-wait-1",
+                    TtlMs = 10_000,
+                    WaitTimeoutMs = 60_000,
+                    EnqueuedAtUnixMs = DateTimeOffset.UtcNow.AddSeconds(-5).ToUnixTimeMilliseconds(),
+                    TimeoutCallbackId = firstTimeoutId,
+                },
+                new WorkflowLeaseWaiterState
+                {
+                    RequestId = "wait-2",
+                    RequesterRunId = "run-wait-2",
+                    RequesterActorId = "actor-run-wait-2",
+                    RequesterStepId = "step-wait-2",
+                    TtlMs = 20_000,
+                    WaitTimeoutMs = 120_000,
+                    EnqueuedAtUnixMs = DateTimeOffset.UtcNow.AddSeconds(-10).ToUnixTimeMilliseconds(),
+                    TimeoutCallbackId = secondTimeoutId,
+                },
+            },
+        });
+        var scheduler = new RecordingRuntimeCallbackScheduler();
+        var agent = CreateAgent(new RecordingSender(), scheduler, eventStore);
+
+        await agent.ActivateAsync();
+
+        scheduler.TimeoutRequests.Select(x => x.CallbackId)
+            .Should()
+            .Contain([firstTimeoutId, secondTimeoutId]);
+        var waiterRequests = scheduler.TimeoutRequests
+            .Where(x => x.CallbackId.StartsWith("workflow-lease-wait-timeout", StringComparison.Ordinal))
+            .OrderBy(x => x.CallbackId, StringComparer.Ordinal)
+            .ToArray();
+        waiterRequests.Should().HaveCount(2);
+        waiterRequests[0].TriggerEnvelope.Payload.Should().NotBeNull();
+        waiterRequests[0].TriggerEnvelope.Payload!.Unpack<WorkflowLeaseWaitTimeoutFiredEvent>()
+            .RequestId.Should().Be("wait-1");
+        waiterRequests[1].TriggerEnvelope.Payload.Should().NotBeNull();
+        waiterRequests[1].TriggerEnvelope.Payload!.Unpack<WorkflowLeaseWaitTimeoutFiredEvent>()
+            .RequestId.Should().Be("wait-2");
+        agent.State.Waiters.Select(x => x.TimeoutLease?.CallbackId)
+            .Should()
+            .Equal(firstTimeoutId, secondTimeoutId);
+        agent.State.Waiters.Select(x => x.TimeoutLease?.Generation)
+            .Should()
+            .OnlyContain(x => x > 0);
+    }
+
+    [Fact]
+    public async Task ActivateAsync_WhenHolderExpiredAndWaiterStale_ShouldOnlyRecoverWaiterTimeoutDeterministically()
+    {
+        var eventStore = new TestEventStore();
+        var timeoutId = RuntimeCallbackKeyComposer.BuildCallbackId("workflow-lease-wait-timeout", "shared", "wait-stale");
+        await SeedStateAsync(eventStore, new WorkflowLeaseState
+        {
+            LeaseKey = "shared",
+            HolderRunId = "run-expired",
+            HolderActorId = "actor-run-expired",
+            HolderStepId = "step-expired",
+            HolderToken = "token-expired",
+            Generation = 3,
+            ExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(-1).ToUnixTimeMilliseconds(),
+            ExpirationCallbackId = RuntimeCallbackKeyComposer.BuildCallbackId("workflow-lease-expiration", "shared", "3"),
+            Waiters =
+            {
+                new WorkflowLeaseWaiterState
+                {
+                    RequestId = "wait-stale",
+                    RequesterRunId = "run-wait-stale",
+                    RequesterActorId = "actor-run-wait-stale",
+                    RequesterStepId = "step-wait-stale",
+                    TtlMs = 5_000,
+                    WaitTimeoutMs = 1_000,
+                    EnqueuedAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(-5).ToUnixTimeMilliseconds(),
+                    TimeoutCallbackId = timeoutId,
+                },
+            },
+        });
+        var scheduler = new RecordingRuntimeCallbackScheduler();
+        var agent = CreateAgent(new RecordingSender(), scheduler, eventStore);
+
+        await agent.ActivateAsync();
+
+        scheduler.TimeoutRequests.Select(x => x.CallbackId)
+            .Should()
+            .Equal(timeoutId);
+        scheduler.TimeoutRequests[0].DueTime.Should().BeGreaterThan(TimeSpan.Zero);
+        agent.State.ExpirationLease.Should().BeNull();
+        agent.State.Waiters.Should().ContainSingle();
+        agent.State.Waiters[0].TimeoutLease.Should().NotBeNull();
+        agent.State.Waiters[0].TimeoutLease!.CallbackId.Should().Be(timeoutId);
+    }
+
     private static WorkflowLeaseAcquireRequestedEvent Acquire(
         string requestId,
         string runId,
@@ -244,17 +393,39 @@ public sealed class WorkflowLeaseGAgentTests
 
     private static WorkflowLeaseGAgent CreateAgent(
         RecordingSender sender,
-        RecordingRuntimeCallbackScheduler scheduler)
+        RecordingRuntimeCallbackScheduler scheduler,
+        TestEventStore? eventStore = null)
     {
         var agent = new WorkflowLeaseGAgent
         {
             Services = new TestServiceProvider(scheduler),
             EventPublisher = sender,
-            EventSourcingBehaviorFactory = new DefaultEventSourcingBehaviorFactory<WorkflowLeaseState>(new TestEventStore()),
+            EventSourcingBehaviorFactory = new DefaultEventSourcingBehaviorFactory<WorkflowLeaseState>(
+                eventStore ?? new TestEventStore()),
         };
         SetAgentId(agent, LeaseActorId);
         return agent;
     }
+
+    private static Task SeedStateAsync(TestEventStore eventStore, WorkflowLeaseState state) =>
+        eventStore.AppendAsync(
+            LeaseActorId,
+            [
+                new StateEvent
+                {
+                    AgentId = LeaseActorId,
+                    EventId = Guid.NewGuid().ToString("N"),
+                    Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+                    Version = 1,
+                    EventType = WorkflowLeaseStateUpsertedEvent.Descriptor.FullName,
+                    EventData = Any.Pack(new WorkflowLeaseStateUpsertedEvent
+                    {
+                        State = state,
+                    }),
+                },
+            ],
+            0,
+            CancellationToken.None);
 
     private static void SetAgentId(GAgentBase agent, string agentId)
     {
@@ -335,7 +506,7 @@ public sealed class WorkflowLeaseGAgentTests
 
     private sealed class TestServiceProvider(RecordingRuntimeCallbackScheduler scheduler) : IServiceProvider
     {
-        public object? GetService(Type serviceType)
+        public object? GetService(System.Type serviceType)
         {
             if (serviceType == typeof(IEnumerable<IGAgentExecutionHook>))
                 return Array.Empty<IGAgentExecutionHook>();

--- a/test/Aevatar.Workflow.Core.Tests/WorkflowLeaseGAgentTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/WorkflowLeaseGAgentTests.cs
@@ -1,0 +1,398 @@
+using System.Reflection;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Hooks;
+using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Foundation.Core;
+using Aevatar.Foundation.Core.EventSourcing;
+using Aevatar.Workflow.Abstractions;
+using FluentAssertions;
+using Google.Protobuf;
+
+namespace Aevatar.Workflow.Core.Tests;
+
+public sealed class WorkflowLeaseGAgentTests
+{
+    private const string LeaseActorId = "workflow.lease:test";
+
+    [Fact]
+    public async Task HandleAcquireAsync_WhenIdle_ShouldGrantTokenAndGeneration()
+    {
+        var sender = new RecordingSender();
+        var scheduler = new RecordingRuntimeCallbackScheduler();
+        var agent = CreateAgent(sender, scheduler);
+        await agent.ActivateAsync();
+
+        await agent.HandleAcquireAsync(Acquire("req-1", "run-1"), 1_000, CancellationToken.None);
+
+        var granted = sender.Sent.Should().ContainSingle().Subject.Event
+            .Should().BeOfType<WorkflowLeaseAcquiredEvent>().Subject;
+        granted.HolderToken.Should().NotBeNullOrWhiteSpace();
+        granted.Generation.Should().Be(1);
+        granted.ExpiresAtUnixMs.Should().Be(301_000);
+        agent.State.HolderRunId.Should().Be("run-1");
+        agent.State.Generation.Should().Be(1);
+        scheduler.TimeoutRequests.Should().ContainSingle();
+        scheduler.TimeoutRequests[0].CallbackId.Should().Contain("workflow-lease-expiration");
+    }
+
+    [Fact]
+    public async Task HandleAcquireAsync_WhenBusyAndFailPolicy_ShouldReject()
+    {
+        var sender = new RecordingSender();
+        var agent = CreateAgent(sender, new RecordingRuntimeCallbackScheduler());
+        await agent.ActivateAsync();
+        await agent.HandleAcquireAsync(Acquire("req-1", "run-1"), 1_000, CancellationToken.None);
+        sender.Sent.Clear();
+
+        await agent.HandleAcquireAsync(Acquire("req-2", "run-2"), 2_000, CancellationToken.None);
+
+        var rejected = sender.Sent.Should().ContainSingle().Subject.Event
+            .Should().BeOfType<WorkflowLeaseRejectedEvent>().Subject;
+        rejected.Reason.Should().Be(WorkflowLeaseRejectionReason.LeaseBusy);
+        rejected.CurrentHolderRunId.Should().Be("run-1");
+        agent.State.HolderRunId.Should().Be("run-1");
+    }
+
+    [Fact]
+    public async Task HandleAcquireAsync_WhenBusyAndWaitPolicy_ShouldQueueUntilReleaseThenGrantFifo()
+    {
+        var sender = new RecordingSender();
+        var scheduler = new RecordingRuntimeCallbackScheduler();
+        var agent = CreateAgent(sender, scheduler);
+        await agent.ActivateAsync();
+        await agent.HandleAcquireAsync(Acquire("req-1", "run-1"), 1_000, CancellationToken.None);
+        var firstGrant = sender.Sent.Select(x => x.Event).OfType<WorkflowLeaseAcquiredEvent>().Single();
+        sender.Sent.Clear();
+
+        await agent.HandleAcquireAsync(Acquire("req-2", "run-2", WorkflowLeaseConflictPolicy.Wait), 2_000, CancellationToken.None);
+        await agent.HandleAcquireAsync(Acquire("req-3", "run-3", WorkflowLeaseConflictPolicy.Wait), 3_000, CancellationToken.None);
+
+        agent.State.Waiters.Select(x => x.RequestId).Should().Equal("req-2", "req-3");
+        sender.Sent.Should().BeEmpty();
+
+        await agent.HandleReleaseAsync(new WorkflowLeaseReleaseRequestedEvent
+        {
+            LeaseKey = "shared",
+            RequestId = "rel-1",
+            RequesterRunId = "run-1",
+            RequesterActorId = "actor-run-1",
+            RequesterStepId = "release-step",
+            HolderToken = firstGrant.HolderToken,
+            Generation = firstGrant.Generation,
+        }, CancellationToken.None);
+
+        sender.Sent.Select(x => x.Event).OfType<WorkflowLeaseReleasedEvent>().Should().ContainSingle();
+        var secondGrant = sender.Sent.Select(x => x.Event).OfType<WorkflowLeaseAcquiredEvent>().Single();
+        secondGrant.RequestId.Should().Be("req-2");
+        secondGrant.RequesterRunId.Should().Be("run-2");
+        agent.State.HolderRunId.Should().Be("run-2");
+        agent.State.Generation.Should().Be(2);
+        agent.State.Waiters.Select(x => x.RequestId).Should().Equal("req-3");
+        scheduler.Canceled.Should().Contain(x => x.CallbackId.Contains("workflow-lease-wait-timeout", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task HandleAcquireAsync_WhenWaitQueueFull_ShouldReject()
+    {
+        var sender = new RecordingSender();
+        var agent = CreateAgent(sender, new RecordingRuntimeCallbackScheduler());
+        await agent.ActivateAsync();
+        await agent.HandleAcquireAsync(Acquire("holder", "run-holder"), 1_000, CancellationToken.None);
+        sender.Sent.Clear();
+
+        for (var i = 0; i < WorkflowLeaseGAgent.MaxWaiters; i++)
+        {
+            await agent.HandleAcquireAsync(
+                Acquire($"wait-{i}", $"run-wait-{i}", WorkflowLeaseConflictPolicy.Wait),
+                2_000 + i,
+                CancellationToken.None);
+        }
+
+        await agent.HandleAcquireAsync(
+            Acquire("overflow", "run-overflow", WorkflowLeaseConflictPolicy.Wait),
+            5_000,
+            CancellationToken.None);
+
+        var rejected = sender.Sent.Select(x => x.Event).OfType<WorkflowLeaseRejectedEvent>().Single();
+        rejected.Reason.Should().Be(WorkflowLeaseRejectionReason.WaitQueueFull);
+        agent.State.Waiters.Should().HaveCount(WorkflowLeaseGAgent.MaxWaiters);
+    }
+
+    [Fact]
+    public async Task HandleWaitTimeoutFiredAsync_ShouldRemoveWaiterAndReject()
+    {
+        var sender = new RecordingSender();
+        var agent = CreateAgent(sender, new RecordingRuntimeCallbackScheduler());
+        await agent.ActivateAsync();
+        await agent.HandleAcquireAsync(Acquire("holder", "run-holder"), 1_000, CancellationToken.None);
+        await agent.HandleAcquireAsync(Acquire("wait-1", "run-wait", WorkflowLeaseConflictPolicy.Wait), 2_000, CancellationToken.None);
+        sender.Sent.Clear();
+
+        await agent.HandleWaitTimeoutFiredAsync(new WorkflowLeaseWaitTimeoutFiredEvent
+        {
+            LeaseKey = "shared",
+            RequestId = "wait-1",
+            RequesterRunId = "run-wait",
+            RequesterActorId = "actor-run-wait",
+            RequesterStepId = "step-wait",
+        }, CancellationToken.None);
+
+        agent.State.Waiters.Should().BeEmpty();
+        var rejected = sender.Sent.Should().ContainSingle().Subject.Event
+            .Should().BeOfType<WorkflowLeaseRejectedEvent>().Subject;
+        rejected.Reason.Should().Be(WorkflowLeaseRejectionReason.WaitTimeout);
+    }
+
+    [Fact]
+    public async Task HandleExpirationFiredAsync_ShouldFenceStaleCallbacksAndGrantCurrentWaiter()
+    {
+        var sender = new RecordingSender();
+        var agent = CreateAgent(sender, new RecordingRuntimeCallbackScheduler());
+        await agent.ActivateAsync();
+        await agent.HandleAcquireAsync(Acquire("holder", "run-holder"), 1_000, CancellationToken.None);
+        var holder = sender.Sent.Select(x => x.Event).OfType<WorkflowLeaseAcquiredEvent>().Single();
+        await agent.HandleAcquireAsync(Acquire("wait-1", "run-wait", WorkflowLeaseConflictPolicy.Wait), 2_000, CancellationToken.None);
+        sender.Sent.Clear();
+
+        await agent.HandleExpirationFiredAsync(new WorkflowLeaseExpirationFiredEvent
+        {
+            LeaseKey = "shared",
+            HolderToken = "stale",
+            Generation = holder.Generation,
+            ExpiresAtUnixMs = holder.ExpiresAtUnixMs,
+        }, 400_000, CancellationToken.None);
+
+        agent.State.HolderRunId.Should().Be("run-holder");
+        sender.Sent.Should().BeEmpty();
+
+        await agent.HandleExpirationFiredAsync(new WorkflowLeaseExpirationFiredEvent
+        {
+            LeaseKey = "shared",
+            HolderToken = holder.HolderToken,
+            Generation = holder.Generation,
+            ExpiresAtUnixMs = holder.ExpiresAtUnixMs,
+        }, 400_000, CancellationToken.None);
+
+        var granted = sender.Sent.Should().ContainSingle().Subject.Event
+            .Should().BeOfType<WorkflowLeaseAcquiredEvent>().Subject;
+        granted.RequestId.Should().Be("wait-1");
+        agent.State.HolderRunId.Should().Be("run-wait");
+    }
+
+    [Fact]
+    public async Task HandleRenewAsync_ShouldExtendExpiryWithoutGenerationBumpAndFenceStaleRelease()
+    {
+        var sender = new RecordingSender();
+        var agent = CreateAgent(sender, new RecordingRuntimeCallbackScheduler());
+        await agent.ActivateAsync();
+        await agent.HandleAcquireAsync(Acquire("holder", "run-holder"), 1_000, CancellationToken.None);
+        var holder = sender.Sent.Select(x => x.Event).OfType<WorkflowLeaseAcquiredEvent>().Single();
+        sender.Sent.Clear();
+
+        await agent.HandleRenewAsync(new WorkflowLeaseRenewRequestedEvent
+        {
+            LeaseKey = "shared",
+            RequestId = "renew-1",
+            RequesterRunId = "run-holder",
+            RequesterActorId = "actor-run-holder",
+            RequesterStepId = "renew-step",
+            HolderToken = holder.HolderToken,
+            Generation = holder.Generation,
+            TtlMs = 60_000,
+        }, 10_000, CancellationToken.None);
+
+        var renewed = sender.Sent.Should().ContainSingle().Subject.Event
+            .Should().BeOfType<WorkflowLeaseRenewedEvent>().Subject;
+        renewed.Generation.Should().Be(holder.Generation);
+        renewed.ExpiresAtUnixMs.Should().Be(70_000);
+        agent.State.Generation.Should().Be(holder.Generation);
+        sender.Sent.Clear();
+
+        await agent.HandleReleaseAsync(new WorkflowLeaseReleaseRequestedEvent
+        {
+            LeaseKey = "shared",
+            RequestId = "release-stale",
+            RequesterRunId = "run-holder",
+            RequesterActorId = "actor-run-holder",
+            RequesterStepId = "release-step",
+            HolderToken = "stale-token",
+            Generation = holder.Generation,
+        }, CancellationToken.None);
+
+        var rejected = sender.Sent.Should().ContainSingle().Subject.Event
+            .Should().BeOfType<WorkflowLeaseRejectedEvent>().Subject;
+        rejected.Reason.Should().Be(WorkflowLeaseRejectionReason.StaleHolder);
+        agent.State.HolderToken.Should().Be(holder.HolderToken);
+    }
+
+    private static WorkflowLeaseAcquireRequestedEvent Acquire(
+        string requestId,
+        string runId,
+        WorkflowLeaseConflictPolicy onConflict = WorkflowLeaseConflictPolicy.Fail) =>
+        new()
+        {
+            LeaseKey = "shared",
+            RequestId = requestId,
+            RequesterRunId = runId,
+            RequesterActorId = $"actor-{runId}",
+            RequesterStepId = $"step-{requestId}",
+            TtlMs = WorkflowLeaseGAgent.DefaultLeaseTtlMs,
+            WaitTimeoutMs = WorkflowLeaseGAgent.DefaultWaitTimeoutMs,
+            OnConflict = onConflict,
+        };
+
+    private static WorkflowLeaseGAgent CreateAgent(
+        RecordingSender sender,
+        RecordingRuntimeCallbackScheduler scheduler)
+    {
+        var agent = new WorkflowLeaseGAgent
+        {
+            Services = new TestServiceProvider(scheduler),
+            EventPublisher = sender,
+            EventSourcingBehaviorFactory = new DefaultEventSourcingBehaviorFactory<WorkflowLeaseState>(new TestEventStore()),
+        };
+        SetAgentId(agent, LeaseActorId);
+        return agent;
+    }
+
+    private static void SetAgentId(GAgentBase agent, string agentId)
+    {
+        var setIdMethod = typeof(GAgentBase).GetMethod(
+            "SetId",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        setIdMethod.Should().NotBeNull();
+        setIdMethod!.Invoke(agent, [agentId]);
+    }
+
+    private sealed class RecordingSender : IEventPublisher
+    {
+        public List<(string TargetActorId, IMessage Event)> Sent { get; } = [];
+
+        public Task PublishAsync<T>(
+            T evt,
+            TopologyAudience audience,
+            CancellationToken ct,
+            EventEnvelope? sourceEnvelope,
+            EventEnvelopePublishOptions? options)
+            where T : IMessage =>
+            Task.CompletedTask;
+
+        public Task SendToAsync<T>(
+            string targetActorId,
+            T evt,
+            CancellationToken ct,
+            EventEnvelope? sourceEnvelope,
+            EventEnvelopePublishOptions? options)
+            where T : IMessage
+        {
+            Sent.Add((targetActorId, evt));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingRuntimeCallbackScheduler : IActorRuntimeCallbackScheduler
+    {
+        private long _generation;
+
+        public List<RuntimeCallbackTimeoutRequest> TimeoutRequests { get; } = [];
+
+        public List<RuntimeCallbackLease> Canceled { get; } = [];
+
+        public Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
+            RuntimeCallbackTimeoutRequest request,
+            CancellationToken ct = default)
+        {
+            TimeoutRequests.Add(new RuntimeCallbackTimeoutRequest
+            {
+                ActorId = request.ActorId,
+                CallbackId = request.CallbackId,
+                DueTime = request.DueTime,
+                TriggerEnvelope = request.TriggerEnvelope.Clone(),
+                DeliveryMode = request.DeliveryMode,
+            });
+            return Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                Interlocked.Increment(ref _generation),
+                RuntimeCallbackBackend.Dedicated));
+        }
+
+        public Task<RuntimeCallbackLease> ScheduleTimerAsync(
+            RuntimeCallbackTimerRequest request,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task CancelAsync(RuntimeCallbackLease lease, CancellationToken ct = default)
+        {
+            Canceled.Add(lease);
+            return Task.CompletedTask;
+        }
+
+        public Task PurgeActorAsync(string actorId, CancellationToken ct = default) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class TestServiceProvider(RecordingRuntimeCallbackScheduler scheduler) : IServiceProvider
+    {
+        public object? GetService(Type serviceType)
+        {
+            if (serviceType == typeof(IEnumerable<IGAgentExecutionHook>))
+                return Array.Empty<IGAgentExecutionHook>();
+            if (serviceType == typeof(IActorRuntimeCallbackScheduler))
+                return scheduler;
+
+            return null;
+        }
+    }
+
+    private sealed class TestEventStore : IEventStore
+    {
+        private readonly Dictionary<string, List<StateEvent>> _streams = new(StringComparer.Ordinal);
+
+        public Task<EventStoreCommitResult> AppendAsync(
+            string agentId,
+            IEnumerable<StateEvent> events,
+            long expectedVersion,
+            CancellationToken ct = default)
+        {
+            var stream = _streams.GetValueOrDefault(agentId) ?? [];
+            var currentVersion = stream.Count == 0 ? 0 : stream[^1].Version;
+            currentVersion.Should().Be(expectedVersion);
+
+            var committed = events.Select(x => x.Clone()).ToList();
+            stream.AddRange(committed);
+            _streams[agentId] = stream;
+            return Task.FromResult(new EventStoreCommitResult
+            {
+                AgentId = agentId,
+                LatestVersion = stream.Count == 0 ? 0 : stream[^1].Version,
+                CommittedEvents = { committed },
+            });
+        }
+
+        public Task<IReadOnlyList<StateEvent>> GetEventsAsync(
+            string agentId,
+            long? fromVersion = null,
+            CancellationToken ct = default)
+        {
+            var events = _streams.GetValueOrDefault(agentId) ?? [];
+            return Task.FromResult<IReadOnlyList<StateEvent>>(
+                events.Where(x => !fromVersion.HasValue || x.Version >= fromVersion.Value)
+                    .Select(x => x.Clone())
+                    .ToArray());
+        }
+
+        public Task<long> GetVersionAsync(string agentId, CancellationToken ct = default)
+        {
+            var stream = _streams.GetValueOrDefault(agentId) ?? [];
+            return Task.FromResult(stream.Count == 0 ? 0 : stream[^1].Version);
+        }
+
+        public Task<long> DeleteEventsUpToAsync(
+            string agentId,
+            long toVersion,
+            CancellationToken ct = default) =>
+            Task.FromResult(0L);
+    }
+}


### PR DESCRIPTION
## 摘要
解决 #1737：workflow cross-run singleton lease。
- **New**：actor-owned `WorkflowLeaseGAgent` v1（显式 holder_token + generation fencing）；`LeaseModule`（workflow `lease` node）acquire/renew/release + wait/timeout + max_waiters + typed rejection event。聚合 actor 化。
经 consensus-rnd 设计共识 r2（minimal）。验证：build 0 err；Workflow.Core.Tests 418/418。

🤖 Auto-loop / consensus-rnd

⟦AI:AUTO-LOOP⟧
