### PR TITLE
feat(#1790): Ornn skill 非 cron 触发（external trigger admission + webhook）

### DIFF
--- a/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTool.cs
@@ -5,6 +5,7 @@ using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.GAgents.Scheduled;
 using Microsoft.Extensions.Logging;
 
@@ -235,7 +236,17 @@ public sealed class AgentBuilderTool : IAgentTool
             return JsonSerializer.Serialize(new { error = $"Agent '{entry.AgentId}' does not support run_agent" });
 
         var revisionFeedback = NormalizeOptional(args.Str("revision_feedback"));
-        var dispatch = await TryDispatchLifecycleAsync(entry, "run_agent", LifecycleAction.Run, revisionFeedback, skillRunnerPort, ct);
+        var channelAdmission = TryBuildChannelExternalTriggerAdmission(entry);
+        var dispatch = channelAdmission is null
+            ? await TryDispatchLifecycleAsync(entry, "run_agent", LifecycleAction.Run, revisionFeedback, skillRunnerPort, ct)
+            : await TryDispatchLifecycleAsync(
+                entry,
+                "run_agent",
+                LifecycleAction.Run,
+                revisionFeedback,
+                skillRunnerPort,
+                ct,
+                channelAdmission);
         if (dispatch.error != null)
             return dispatch.error;
 
@@ -435,7 +446,8 @@ public sealed class AgentBuilderTool : IAgentTool
         LifecycleAction action,
         string? revisionFeedback,
         ISkillRunnerCommandPort skillRunnerPort,
-        CancellationToken ct)
+        CancellationToken ct,
+        AdmitSkillRunnerExternalTriggerCommand? externalAdmission = null)
     {
         if (!string.Equals(entry.AgentType, SkillRunnerDefaults.AgentType, StringComparison.Ordinal))
         {
@@ -445,7 +457,10 @@ public sealed class AgentBuilderTool : IAgentTool
         switch (action)
         {
             case LifecycleAction.Run:
-                await skillRunnerPort.TriggerAsync(entry.AgentId, reason, ct);
+                if (externalAdmission is null)
+                    await skillRunnerPort.TriggerAsync(entry.AgentId, reason, ct);
+                else
+                    await skillRunnerPort.AdmitExternalTriggerAsync(entry.AgentId, externalAdmission, ct);
                 break;
             case LifecycleAction.Disable:
                 await skillRunnerPort.DisableAsync(entry.AgentId, reason, ct);
@@ -460,8 +475,50 @@ public sealed class AgentBuilderTool : IAgentTool
         return (true, null);
     }
 
+    private static AdmitSkillRunnerExternalTriggerCommand? TryBuildChannelExternalTriggerAdmission(
+        UserAgentCatalogReadModelEntry entry)
+    {
+        var platform = NormalizeOptional(AgentToolRequestContext.ChannelPlatform) ??
+                       NormalizeOptional(AgentToolRequestContext.TryGetExternalMetadata(ChannelMetadataKeys.Platform));
+        var registrationScopeId = NormalizeOptional(AgentToolRequestContext.ChannelRegistrationScopeId) ??
+                                  NormalizeOptional(AgentToolRequestContext.TryGetExternalMetadata(ChannelMetadataKeys.RegistrationScopeId)) ??
+                                  NormalizeOptional(entry.ScopeId);
+        var deliveryId = NormalizeOptional(AgentToolRequestContext.ChannelMessageId) ??
+                         NormalizeOptional(AgentToolRequestContext.ChannelPlatformMessageId) ??
+                         NormalizeOptional(AgentToolRequestContext.RequestId) ??
+                         NormalizeOptional(AgentToolRequestContext.CallId);
+
+        if (platform is null || registrationScopeId is null || deliveryId is null)
+            return null;
+
+        var sourceId = $"channel:{NormalizeToken(platform)}:{NormalizeToken(registrationScopeId)}";
+        var admissionId = $"channel:{NormalizeToken(deliveryId)}:{Guid.NewGuid():N}";
+        return new AdmitSkillRunnerExternalTriggerCommand
+        {
+            Identity = new SkillRunnerExternalTriggerIdentity
+            {
+                SourceId = sourceId,
+                DeliveryId = deliveryId,
+                AdmissionId = admissionId,
+                Kind = ExternalTriggerSourceKind.ChannelInbound,
+                ReceivedAt = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                PayloadSummary = "channel run_agent",
+                PayloadRef = NormalizeOptional(AgentToolRequestContext.ChannelPlatformMessageId) ??
+                             NormalizeOptional(AgentToolRequestContext.ChannelMessageId) ??
+                             string.Empty,
+            },
+        };
+    }
+
     private static bool SupportsManagedLifecycle(string? agentType) =>
         string.Equals(agentType, SkillRunnerDefaults.AgentType, StringComparison.Ordinal);
+
+    private static string NormalizeToken(string value)
+    {
+        var chars = value.Trim().ToLowerInvariant().Select(static c =>
+            char.IsLetterOrDigit(c) || c is '-' or '_' or ':' or '.' ? c : '-');
+        return string.Concat(chars);
+    }
 
     private static string? NormalizeOptional(string? value)
     {

--- a/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentCreateRequestMapper.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentCreateRequestMapper.cs
@@ -23,6 +23,7 @@ internal sealed class ScheduledAgentCreateRequestMapper
         "max_tool_rounds",
         "max_history_messages",
         "requires_nyxid_proxy_success",
+        "external_trigger_sources",
         "run_immediately",
     };
 
@@ -97,6 +98,7 @@ internal sealed class ScheduledAgentCreateRequestMapper
                 MaxToolRounds: args.TryInt("max_tool_rounds", out var maxToolRounds) ? maxToolRounds : null,
                 MaxHistoryMessages: args.TryInt("max_history_messages", out var maxHistoryMessages) ? maxHistoryMessages : null,
                 RequiresNyxidProxySuccess: args.Bool("requires_nyxid_proxy_success") ?? false,
+                ExternalTriggerSources: args.ExternalTriggerSources("external_trigger_sources"),
                 RunImmediately: args.Bool("run_immediately") ?? false,
                 ConversationId: conversationId,
                 PrimaryOutboundSlug: primarySlug,
@@ -158,6 +160,7 @@ internal sealed class ScheduledAgentCreateRequestMapper
             command.MaxToolRounds = request.MaxToolRounds.Value;
         if (request.MaxHistoryMessages.HasValue)
             command.MaxHistoryMessages = request.MaxHistoryMessages.Value;
+        command.ExternalTriggerSources.AddRange(request.ExternalTriggerSources);
 
         return new ScheduledAgentCreateMapResult(
             Success: true,
@@ -255,6 +258,73 @@ internal sealed class ScheduledAgentCreateRequestMapper
 
             return element.ValueKind == JsonValueKind.String && double.TryParse(element.GetString(), out value);
         }
+
+        public IReadOnlyList<ExternalTriggerSource> ExternalTriggerSources(string name)
+        {
+            if (!Properties.TryGetValue(name, out var element) ||
+                element.ValueKind != JsonValueKind.Array)
+            {
+                return [];
+            }
+
+            var sources = new List<ExternalTriggerSource>();
+            foreach (var sourceElement in element.EnumerateArray())
+            {
+                if (sourceElement.ValueKind != JsonValueKind.Object)
+                    continue;
+
+                var sourceId = ReadString(sourceElement, "source_id")?.Trim();
+                if (string.IsNullOrWhiteSpace(sourceId))
+                    continue;
+
+                sources.Add(new ExternalTriggerSource
+                {
+                    SourceId = sourceId,
+                    Kind = ParseKind(ReadString(sourceElement, "kind")),
+                    Enabled = ReadBool(sourceElement, "enabled") ?? true,
+                    DisplayName = ReadString(sourceElement, "display_name")?.Trim() ?? string.Empty,
+                });
+            }
+
+            return sources;
+        }
+
+        private static ExternalTriggerSourceKind ParseKind(string? value) =>
+            value?.Trim().ToLowerInvariant() switch
+            {
+                "channel_inbound" or "channel-inbound" => ExternalTriggerSourceKind.ChannelInbound,
+                "webhook" => ExternalTriggerSourceKind.Webhook,
+                _ => ExternalTriggerSourceKind.Webhook,
+            };
+
+        private static string? ReadString(JsonElement element, string name)
+        {
+            if (!element.TryGetProperty(name, out var value))
+                return null;
+
+            return value.ValueKind switch
+            {
+                JsonValueKind.String => value.GetString(),
+                JsonValueKind.Number => value.GetRawText(),
+                JsonValueKind.True => "true",
+                JsonValueKind.False => "false",
+                _ => null,
+            };
+        }
+
+        private static bool? ReadBool(JsonElement element, string name)
+        {
+            if (!element.TryGetProperty(name, out var value))
+                return null;
+
+            return value.ValueKind switch
+            {
+                JsonValueKind.True => true,
+                JsonValueKind.False => false,
+                JsonValueKind.String when bool.TryParse(value.GetString(), out var parsed) => parsed,
+                _ => null,
+            };
+        }
     }
 }
 
@@ -304,6 +374,7 @@ internal sealed record ScheduledAgentCreatePlannedRequest(
     int? MaxToolRounds,
     int? MaxHistoryMessages,
     bool RequiresNyxidProxySuccess,
+    IReadOnlyList<ExternalTriggerSource> ExternalTriggerSources,
     bool RunImmediately,
     string ConversationId,
     string PrimaryOutboundSlug,

--- a/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentCreatorTool.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentCreatorTool.cs
@@ -89,6 +89,30 @@ public sealed class ScheduledAgentCreatorTool : IAgentTool
               "type": "boolean",
               "description": "When true, the run must observe a successful NyxID proxy call."
             },
+            "external_trigger_sources": {
+              "type": "array",
+              "description": "Optional external trigger source declarations. For channel run_agent, use source_id channel:<platform>:<registration_scope_id> and kind channel_inbound.",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "source_id": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": ["webhook", "channel_inbound"]
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "display_name": {
+                    "type": "string"
+                  }
+                },
+                "required": ["source_id", "kind"]
+              }
+            },
             "run_immediately": {
               "type": "boolean",
               "description": "When true, trigger the first run after initialization is accepted."

--- a/agents/Aevatar.GAgents.Scheduled/ISkillRunnerCommandPort.cs
+++ b/agents/Aevatar.GAgents.Scheduled/ISkillRunnerCommandPort.cs
@@ -29,4 +29,13 @@ public interface ISkillRunnerCommandPort
 
     /// <summary>Dispatches an <see cref="EnableSkillRunnerCommand"/> to an existing SkillRunner.</summary>
     Task EnableAsync(string agentId, string reason, CancellationToken ct = default);
+
+    /// <summary>
+    /// Admits an external delivery command to an existing SkillRunner. The returned receipt
+    /// only confirms accepted-for-dispatch and never implies source validation or execution.
+    /// </summary>
+    Task<SkillRunnerExternalTriggerAdmissionReceipt> AdmitExternalTriggerAsync(
+        string agentId,
+        AdmitSkillRunnerExternalTriggerCommand command,
+        CancellationToken ct = default);
 }

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerCommandPort.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerCommandPort.cs
@@ -62,22 +62,77 @@ internal sealed class SkillRunnerCommandPort : ISkillRunnerCommandPort
         await DispatchAsync(agentId, new EnableSkillRunnerCommand { Reason = reason ?? string.Empty }, ct);
     }
 
+    public async Task<SkillRunnerExternalTriggerAdmissionReceipt> AdmitExternalTriggerAsync(
+        string agentId,
+        AdmitSkillRunnerExternalTriggerCommand command,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentId);
+        ArgumentNullException.ThrowIfNull(command);
+
+        var actor = await _actorRuntime.GetAsync(agentId);
+        if (actor is null)
+        {
+            throw new SkillRunnerExternalTriggerAdmissionException(
+                SkillRunnerExternalTriggerAdmissionError.RunnerNotFound,
+                agentId);
+        }
+
+        NormalizeExternalTriggerAdmission(command);
+        var admission = await DispatchAsync(agentId, command, ct);
+        return new SkillRunnerExternalTriggerAdmissionReceipt(
+            admission.ActorId,
+            admission.CommandId,
+            admission.CorrelationId,
+            command.Identity.AdmissionId,
+            command.Identity.SourceId,
+            command.Identity.DeliveryId);
+    }
+
     private async Task EnsureSkillRunnerActorAsync(string agentId, CancellationToken ct)
     {
         _ = await _actorRuntime.GetAsync(agentId)
             ?? await _actorRuntime.CreateAsync<SkillRunnerGAgent>(agentId, ct);
     }
 
-    private Task DispatchAsync<TCommand>(string agentId, TCommand command, CancellationToken ct)
+    private async Task<DispatchAdmission> DispatchAsync<TCommand>(string agentId, TCommand command, CancellationToken ct)
         where TCommand : class, IMessage
     {
+        var commandId = ResolveCommandId(command);
         var envelope = new EventEnvelope
         {
-            Id = Guid.NewGuid().ToString("N"),
+            Id = commandId,
             Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
             Payload = Any.Pack(command),
             Route = EnvelopeRouteSemantics.CreateDirect(PublisherActorId, agentId),
+            Propagation = new EnvelopePropagation { CorrelationId = commandId },
         };
-        return _actorDispatchPort.DispatchAsync(agentId, envelope, ct);
+        return await _actorDispatchPort.DispatchAsync(agentId, envelope, ct);
+    }
+
+    private static string ResolveCommandId<TCommand>(TCommand command)
+        where TCommand : class, IMessage
+    {
+        if (command is AdmitSkillRunnerExternalTriggerCommand externalCommand &&
+            !string.IsNullOrWhiteSpace(externalCommand.Identity?.AdmissionId))
+        {
+            return externalCommand.Identity.AdmissionId.Trim();
+        }
+
+        return Guid.NewGuid().ToString("N");
+    }
+
+    private static void NormalizeExternalTriggerAdmission(AdmitSkillRunnerExternalTriggerCommand command)
+    {
+        command.Identity ??= new SkillRunnerExternalTriggerIdentity();
+        command.Identity.SourceId = command.Identity.SourceId?.Trim() ?? string.Empty;
+        command.Identity.DeliveryId = command.Identity.DeliveryId?.Trim() ?? string.Empty;
+        command.Identity.AdmissionId = string.IsNullOrWhiteSpace(command.Identity.AdmissionId)
+            ? Guid.NewGuid().ToString("N")
+            : command.Identity.AdmissionId.Trim();
+        command.Identity.PayloadSummary = command.Identity.PayloadSummary?.Trim() ?? string.Empty;
+        command.Identity.PayloadRef = command.Identity.PayloadRef?.Trim() ?? string.Empty;
+        if (command.Identity.ReceivedAt is null)
+            command.Identity.ReceivedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
     }
 }

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerDefaults.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerDefaults.cs
@@ -13,10 +13,19 @@ public static class SkillRunnerDefaults
     public const string StatusError = "error";
     public const string StatusDisabled = "disabled";
     public const string RejectionReasonRunnerDisabled = "runner_disabled";
+    public const string ExternalTriggerReason = "external_trigger";
+    public const string ExternalTriggerRejectedReasonUnknownSource = "unknown";
+    public const string ExternalTriggerRejectedReasonDisabledSource = "disabled";
+    public const string ExternalTriggerRejectedReasonMalformedDelivery = "malformed_delivery";
+    public const string ExternalTriggerRejectedReasonDispatchAttemptsExhausted = "dispatch_attempts_exhausted";
+    public const string ExternalTriggerDuplicateReasonAlreadyAdmitted = "duplicate_delivery";
     public const string TriggerCallbackId = "skill-runner-next-fire";
     public const string RetryCallbackId = "skill-runner-retry";
     public const int MaxRetryAttempts = 1;
+    public const int ExternalTriggerMaxDispatchAttempts = 3;
+    public const int ExternalTriggerTerminalDeliveryRetention = 1000;
     public static readonly TimeSpan RetryBackoff = TimeSpan.FromSeconds(30);
+    public static readonly TimeSpan ExternalTriggerTerminalDeliveryRetentionAge = TimeSpan.FromDays(30);
 
     /// <summary>
     /// Throttle for streaming-edit (Lark <c>PUT /open-apis/im/v1/messages/{id}</c>) deltas.

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerExternalTriggerAdmissionReceipt.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerExternalTriggerAdmissionReceipt.cs
@@ -1,0 +1,39 @@
+namespace Aevatar.GAgents.Scheduled;
+
+public sealed record SkillRunnerExternalTriggerAdmissionReceipt(
+    string ActorId,
+    string CommandId,
+    string CorrelationId,
+    string AdmissionId,
+    string SourceId,
+    string DeliveryId);
+
+public enum SkillRunnerExternalTriggerAdmissionError
+{
+    Unspecified = 0,
+    RunnerNotFound = 1,
+}
+
+public sealed class SkillRunnerExternalTriggerAdmissionException : InvalidOperationException
+{
+    public SkillRunnerExternalTriggerAdmissionException(
+        SkillRunnerExternalTriggerAdmissionError error,
+        string agentId)
+        : base(BuildMessage(error, agentId))
+    {
+        Error = error;
+        AgentId = agentId;
+    }
+
+    public SkillRunnerExternalTriggerAdmissionError Error { get; }
+
+    public string AgentId { get; }
+
+    private static string BuildMessage(SkillRunnerExternalTriggerAdmissionError error, string agentId) =>
+        error switch
+        {
+            SkillRunnerExternalTriggerAdmissionError.RunnerNotFound =>
+                $"Skill runner '{agentId}' was not found.",
+            _ => $"Skill runner external trigger admission failed for '{agentId}'.",
+        };
+}

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
@@ -219,6 +219,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
     {
         await base.OnActivateAsync(ct);
         await Scheduler.BootstrapOnActivateAsync(ct);
+        await RecoverExternalTriggerDeliveriesAsync(ct);
     }
 
     protected override AIAgentConfigStateOverrides ExtractStateConfigOverrides(SkillRunnerState state)
@@ -250,6 +251,11 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             .On<SkillRunnerExecutionCompletedEvent>(ApplyCompleted)
             .On<SkillRunnerExecutionFailedEvent>(ApplyFailed)
             .On<SkillRunnerExecutionRejectedEvent>(ApplyRejected)
+            .On<SkillRunnerExternalTriggerAdmittedEvent>(ApplyExternalTriggerAdmitted)
+            .On<SkillRunnerExternalTriggerDispatchRequestedEvent>(ApplyExternalTriggerDispatchRequested)
+            .On<SkillRunnerExternalTriggerRejectedEvent>(ApplyExternalTriggerRejected)
+            .On<SkillRunnerExternalTriggerDuplicateIgnoredEvent>(ApplyExternalTriggerDuplicateIgnored)
+            .On<ExternalTriggerSourceEnabledEvent>(ApplyExternalTriggerSourceEnabled)
             .On<SkillRunnerDisabledEvent>(ApplyDisabled)
             .On<SkillRunnerEnabledEvent>(ApplyEnabled)
             .OrCurrent();
@@ -304,6 +310,10 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         if (command.HasMaxHistoryMessages)
             initialized.MaxHistoryMessages = command.MaxHistoryMessages;
 
+        initialized.ExternalTriggerSources.AddRange(command.ExternalTriggerSources
+            .Select(NormalizeExternalTriggerSource)
+            .Where(static source => !string.IsNullOrWhiteSpace(source.SourceId)));
+
         await PersistDomainEventAsync(initialized);
 
         // Refactor (iter89/cluster-089-scheduled-runner-wall-clock):
@@ -313,9 +323,82 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         await UpsertRegistryAsync(CancellationToken.None);
     }
 
+    [EventHandler]
+    public async Task HandleAdmitExternalTriggerAsync(AdmitSkillRunnerExternalTriggerCommand command)
+    {
+        var now = _clock.UtcNow;
+        var identity = NormalizeExternalTriggerIdentity(command.Identity, now);
+        if (!IsValidExternalTriggerIdentity(identity))
+        {
+            await PersistDomainEventAsync(new SkillRunnerExternalTriggerRejectedEvent
+            {
+                Identity = identity,
+                RejectedAt = Timestamp.FromDateTimeOffset(now),
+                Reason = SkillRunnerDefaults.ExternalTriggerRejectedReasonMalformedDelivery,
+            });
+            return;
+        }
+
+        var source = State.FindExternalTriggerSource(identity.SourceId);
+        if (source is null)
+        {
+            await PersistDomainEventAsync(new SkillRunnerExternalTriggerRejectedEvent
+            {
+                Identity = identity,
+                RejectedAt = Timestamp.FromDateTimeOffset(now),
+                Reason = SkillRunnerDefaults.ExternalTriggerRejectedReasonUnknownSource,
+            });
+            return;
+        }
+
+        if (!source.Enabled)
+        {
+            await PersistDomainEventAsync(new SkillRunnerExternalTriggerRejectedEvent
+            {
+                Identity = NormalizeExternalTriggerIdentity(identity, source, now),
+                RejectedAt = Timestamp.FromDateTimeOffset(now),
+                Reason = SkillRunnerDefaults.ExternalTriggerRejectedReasonDisabledSource,
+            });
+            return;
+        }
+
+        identity = NormalizeExternalTriggerIdentity(identity, source, now);
+        if (State.FindExternalTriggerDelivery(identity) is not null)
+        {
+            await PersistDomainEventAsync(new SkillRunnerExternalTriggerDuplicateIgnoredEvent
+            {
+                Identity = identity,
+                IgnoredAt = Timestamp.FromDateTimeOffset(now),
+                Reason = SkillRunnerDefaults.ExternalTriggerDuplicateReasonAlreadyAdmitted,
+            });
+            return;
+        }
+
+        await PersistDomainEventAsync(new SkillRunnerExternalTriggerAdmittedEvent
+        {
+            Identity = identity,
+            AdmittedAt = Timestamp.FromDateTimeOffset(now),
+        });
+
+        await DispatchExternalTriggerExecutionAsync(identity, dispatchAttempt: 1, ct: CancellationToken.None);
+    }
+
     [EventHandler(AllowSelfHandling = true)]
     public async Task HandleTriggerAsync(TriggerSkillRunnerExecutionCommand command)
     {
+        var externalIdentity = NormalizeExternalTriggerIdentity(command.ExternalTriggerIdentity, _clock.UtcNow);
+        var hasExternalTrigger = IsValidExternalTriggerIdentity(externalIdentity);
+        if (hasExternalTrigger && State.IsExternalTriggerTerminal(externalIdentity))
+        {
+            await PersistDomainEventAsync(new SkillRunnerExternalTriggerDuplicateIgnoredEvent
+            {
+                Identity = externalIdentity,
+                IgnoredAt = Timestamp.FromDateTimeOffset(_clock.UtcNow),
+                Reason = SkillRunnerDefaults.ExternalTriggerDuplicateReasonAlreadyAdmitted,
+            });
+            return;
+        }
+
         if (!State.Enabled)
         {
             Logger.LogInformation("Skill runner {ActorId} ignored trigger because it is disabled", Id);
@@ -323,6 +406,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             {
                 RejectedAt = Timestamp.FromDateTimeOffset(_clock.UtcNow),
                 Reason = SkillRunnerDefaults.RejectionReasonRunnerDisabled,
+                ExternalTriggerIdentity = hasExternalTrigger ? externalIdentity : null,
             });
             return;
         }
@@ -349,6 +433,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
                 WorkflowName = result.WorkflowReceipt?.WorkflowName ?? string.Empty,
                 WorkflowCommandId = result.WorkflowReceipt?.CommandId ?? string.Empty,
                 WorkflowCorrelationId = result.WorkflowReceipt?.CorrelationId ?? string.Empty,
+                ExternalTriggerIdentity = hasExternalTrigger ? externalIdentity : null,
             });
 
             await CancelRetryLeaseAsync(CancellationToken.None);
@@ -364,7 +449,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
 
             if (command.RetryAttempt < SkillRunnerDefaults.MaxRetryAttempts)
             {
-                await ScheduleRetryAsync(command.RetryAttempt + 1, CancellationToken.None);
+                await ScheduleRetryAsync(command, command.RetryAttempt + 1, CancellationToken.None);
                 return;
             }
 
@@ -378,6 +463,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
                 SkillVersion = executionFailure?.SkillVersion ?? string.Empty,
                 WorkflowId = executionFailure?.WorkflowId ?? string.Empty,
                 ErrorCode = executionFailure?.ErrorCode ?? SkillRunnerExecutionErrorCode.Unspecified,
+                ExternalTriggerIdentity = hasExternalTrigger ? externalIdentity : null,
             });
 
             await TrySendFailureAsync(ex.Message, CancellationToken.None);
@@ -385,13 +471,29 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         }
     }
 
-    private async Task ScheduleRetryAsync(int retryAttempt, CancellationToken ct)
+    [EventHandler]
+    public async Task HandleSetExternalTriggerSourceEnabledAsync(SetExternalTriggerSourceEnabledCommand command)
+    {
+        var sourceId = command.SourceId?.Trim();
+        if (string.IsNullOrWhiteSpace(sourceId) || State.FindExternalTriggerSource(sourceId) is null)
+            return;
+
+        await PersistDomainEventAsync(new ExternalTriggerSourceEnabledEvent
+        {
+            SourceId = sourceId,
+            Enabled = command.Enabled,
+        });
+    }
+
+    private async Task ScheduleRetryAsync(TriggerSkillRunnerExecutionCommand command, int retryAttempt, CancellationToken ct)
     {
         await CancelRetryLeaseAsync(ct);
+        var retryCommand = command.Clone();
+        retryCommand.RetryAttempt = retryAttempt;
         _retryLease = await ScheduleSelfDurableTimeoutAsync(
             SkillRunnerDefaults.RetryCallbackId,
             SkillRunnerDefaults.RetryBackoff,
-            new TriggerSkillRunnerExecutionCommand { Reason = "retry", RetryAttempt = retryAttempt },
+            retryCommand,
             ct: ct);
         Logger.LogInformation(
             "Skill runner {ActorId} scheduled retry attempt {Attempt} in {Backoff}",
@@ -430,6 +532,52 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         }
 
         await Scheduler.ScheduleNextRunAsync(CancellationToken.None);
+    }
+
+    private async Task RecoverExternalTriggerDeliveriesAsync(CancellationToken ct)
+    {
+        foreach (var record in State.RecoverableExternalTriggerDeliveries())
+        {
+            var identity = NormalizeExternalTriggerIdentity(record.Identity, _clock.UtcNow);
+            if (!IsValidExternalTriggerIdentity(identity))
+                continue;
+
+            var nextAttempt = record.DispatchAttempt + 1;
+            if (nextAttempt > SkillRunnerDefaults.ExternalTriggerMaxDispatchAttempts)
+            {
+                await PersistDomainEventAsync(new SkillRunnerExternalTriggerRejectedEvent
+                {
+                    Identity = identity,
+                    RejectedAt = Timestamp.FromDateTimeOffset(_clock.UtcNow),
+                    Reason = SkillRunnerDefaults.ExternalTriggerRejectedReasonDispatchAttemptsExhausted,
+                }, ct);
+                continue;
+            }
+
+            await DispatchExternalTriggerExecutionAsync(identity, nextAttempt, ct);
+        }
+    }
+
+    private async Task DispatchExternalTriggerExecutionAsync(
+        SkillRunnerExternalTriggerIdentity identity,
+        int dispatchAttempt,
+        CancellationToken ct)
+    {
+        await SendToAsync(
+            Id,
+            new TriggerSkillRunnerExecutionCommand
+            {
+                Reason = SkillRunnerDefaults.ExternalTriggerReason,
+                ExternalTriggerIdentity = identity.Clone(),
+            },
+            ct);
+
+        await PersistDomainEventAsync(new SkillRunnerExternalTriggerDispatchRequestedEvent
+        {
+            Identity = identity.Clone(),
+            RequestedAt = Timestamp.FromDateTimeOffset(_clock.UtcNow),
+            DispatchAttempt = dispatchAttempt,
+        }, ct);
     }
 
     private async Task<SkillRunnerExecutionResult> ExecuteSkillAsync(DateTimeOffset now, string? reason, CancellationToken ct)
@@ -1464,6 +1612,11 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
 
         next.MaxToolRounds = evt.HasMaxToolRounds ? evt.MaxToolRounds : SkillRunnerDefaults.DefaultMaxToolRounds;
         next.MaxHistoryMessages = evt.HasMaxHistoryMessages ? evt.MaxHistoryMessages : SkillRunnerDefaults.DefaultMaxHistoryMessages;
+        next.ExternalTriggerSources.Clear();
+        next.ExternalTriggerSources.AddRange(evt.ExternalTriggerSources
+            .Select(NormalizeExternalTriggerSource)
+            .Where(static source => !string.IsNullOrWhiteSpace(source.SourceId)));
+        next.RecentExternalTriggerDeliveries.Clear();
         return next;
     }
 
@@ -1481,6 +1634,15 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         next.LastOutput = evt.Output ?? string.Empty;
         next.LastError = string.Empty;
         next.ErrorCount = 0;
+        if (IsValidExternalTriggerIdentity(evt.ExternalTriggerIdentity))
+        {
+            next.UpsertExternalTriggerDelivery(
+                evt.ExternalTriggerIdentity,
+                SkillRunnerExternalTriggerDeliveryStatus.Completed,
+                evt.CompletedAt ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow));
+            next.TrimExternalTriggerDeliveries(ToDateTimeOffset(evt.CompletedAt));
+        }
+
         return next;
     }
 
@@ -1490,6 +1652,16 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         next.LastRunAt = evt.FailedAt;
         next.LastError = evt.Error ?? string.Empty;
         next.ErrorCount += 1;
+        if (IsValidExternalTriggerIdentity(evt.ExternalTriggerIdentity))
+        {
+            next.UpsertExternalTriggerDelivery(
+                evt.ExternalTriggerIdentity,
+                SkillRunnerExternalTriggerDeliveryStatus.Failed,
+                evt.FailedAt ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                evt.Error ?? string.Empty);
+            next.TrimExternalTriggerDeliveries(ToDateTimeOffset(evt.FailedAt));
+        }
+
         return next;
     }
 
@@ -1499,6 +1671,97 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         next.LastRunAt = evt.RejectedAt;
         next.LastError = evt.Reason ?? string.Empty;
         next.ErrorCount += 1;
+        if (IsValidExternalTriggerIdentity(evt.ExternalTriggerIdentity))
+        {
+            next.UpsertExternalTriggerDelivery(
+                evt.ExternalTriggerIdentity,
+                SkillRunnerExternalTriggerDeliveryStatus.Rejected,
+                evt.RejectedAt ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                evt.Reason ?? string.Empty);
+            next.TrimExternalTriggerDeliveries(ToDateTimeOffset(evt.RejectedAt));
+        }
+
+        return next;
+    }
+
+    private static SkillRunnerState ApplyExternalTriggerAdmitted(
+        SkillRunnerState current,
+        SkillRunnerExternalTriggerAdmittedEvent evt)
+    {
+        var next = current.Clone();
+        if (IsValidExternalTriggerIdentity(evt.Identity))
+        {
+            next.UpsertExternalTriggerDelivery(
+                evt.Identity,
+                SkillRunnerExternalTriggerDeliveryStatus.Admitted,
+                evt.AdmittedAt ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow));
+        }
+
+        return next;
+    }
+
+    private static SkillRunnerState ApplyExternalTriggerDispatchRequested(
+        SkillRunnerState current,
+        SkillRunnerExternalTriggerDispatchRequestedEvent evt)
+    {
+        var next = current.Clone();
+        if (IsValidExternalTriggerIdentity(evt.Identity))
+        {
+            next.UpsertExternalTriggerDelivery(
+                evt.Identity,
+                SkillRunnerExternalTriggerDeliveryStatus.DispatchRequested,
+                evt.RequestedAt ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                dispatchAttempt: evt.DispatchAttempt);
+        }
+
+        return next;
+    }
+
+    private static SkillRunnerState ApplyExternalTriggerRejected(
+        SkillRunnerState current,
+        SkillRunnerExternalTriggerRejectedEvent evt)
+    {
+        var next = current.Clone();
+        if (IsValidExternalTriggerIdentity(evt.Identity))
+        {
+            next.UpsertExternalTriggerDelivery(
+                evt.Identity,
+                SkillRunnerExternalTriggerDeliveryStatus.Rejected,
+                evt.RejectedAt ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                evt.Reason ?? string.Empty);
+            next.TrimExternalTriggerDeliveries(ToDateTimeOffset(evt.RejectedAt));
+        }
+
+        return next;
+    }
+
+    private static SkillRunnerState ApplyExternalTriggerDuplicateIgnored(
+        SkillRunnerState current,
+        SkillRunnerExternalTriggerDuplicateIgnoredEvent evt)
+    {
+        var next = current.Clone();
+        if (IsValidExternalTriggerIdentity(evt.Identity))
+        {
+            if (next.FindExternalTriggerDelivery(evt.Identity) is null)
+            {
+                next.UpsertExternalTriggerDelivery(
+                    evt.Identity,
+                    SkillRunnerExternalTriggerDeliveryStatus.DuplicateIgnored,
+                    evt.IgnoredAt ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                    evt.Reason ?? string.Empty);
+                next.TrimExternalTriggerDeliveries(ToDateTimeOffset(evt.IgnoredAt));
+            }
+        }
+
+        return next;
+    }
+
+    private static SkillRunnerState ApplyExternalTriggerSourceEnabled(
+        SkillRunnerState current,
+        ExternalTriggerSourceEnabledEvent evt)
+    {
+        var next = current.Clone();
+        next.SetExternalTriggerSourceEnabled(evt.SourceId, evt.Enabled);
         return next;
     }
 
@@ -1539,4 +1802,52 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
 
     private static string ResolvePlatform(string? platform) =>
         string.IsNullOrWhiteSpace(platform) ? SkillRunnerDefaults.DefaultPlatform : platform.Trim();
+
+    private static ExternalTriggerSource NormalizeExternalTriggerSource(ExternalTriggerSource source)
+    {
+        var normalized = source.Clone();
+        normalized.SourceId = normalized.SourceId?.Trim() ?? string.Empty;
+        normalized.DisplayName = normalized.DisplayName?.Trim() ?? string.Empty;
+        if (normalized.Kind == ExternalTriggerSourceKind.Unspecified)
+            normalized.Kind = ExternalTriggerSourceKind.Webhook;
+        return normalized;
+    }
+
+    private static SkillRunnerExternalTriggerIdentity NormalizeExternalTriggerIdentity(
+        SkillRunnerExternalTriggerIdentity? identity,
+        DateTimeOffset now)
+    {
+        var normalized = identity?.Clone() ?? new SkillRunnerExternalTriggerIdentity();
+        normalized.SourceId = normalized.SourceId?.Trim() ?? string.Empty;
+        normalized.DeliveryId = normalized.DeliveryId?.Trim() ?? string.Empty;
+        normalized.AdmissionId = string.IsNullOrWhiteSpace(normalized.AdmissionId)
+            ? Guid.NewGuid().ToString("N")
+            : normalized.AdmissionId.Trim();
+        normalized.PayloadSummary = normalized.PayloadSummary?.Trim() ?? string.Empty;
+        normalized.PayloadRef = normalized.PayloadRef?.Trim() ?? string.Empty;
+        if (normalized.Kind == ExternalTriggerSourceKind.Unspecified)
+            normalized.Kind = ExternalTriggerSourceKind.Webhook;
+        normalized.ReceivedAt ??= Timestamp.FromDateTimeOffset(now);
+        return normalized;
+    }
+
+    private static SkillRunnerExternalTriggerIdentity NormalizeExternalTriggerIdentity(
+        SkillRunnerExternalTriggerIdentity identity,
+        ExternalTriggerSource source,
+        DateTimeOffset now)
+    {
+        var normalized = NormalizeExternalTriggerIdentity(identity, now);
+        normalized.Kind = source.Kind == ExternalTriggerSourceKind.Unspecified
+            ? ExternalTriggerSourceKind.Webhook
+            : source.Kind;
+        return normalized;
+    }
+
+    private static bool IsValidExternalTriggerIdentity(SkillRunnerExternalTriggerIdentity? identity) =>
+        identity is not null &&
+        !string.IsNullOrWhiteSpace(identity.SourceId) &&
+        !string.IsNullOrWhiteSpace(identity.DeliveryId);
+
+    private static DateTimeOffset ToDateTimeOffset(Timestamp? timestamp) =>
+        timestamp?.ToDateTimeOffset() ?? DateTimeOffset.UtcNow;
 }

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
@@ -255,7 +255,6 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             .On<SkillRunnerExternalTriggerDispatchRequestedEvent>(ApplyExternalTriggerDispatchRequested)
             .On<SkillRunnerExternalTriggerRejectedEvent>(ApplyExternalTriggerRejected)
             .On<SkillRunnerExternalTriggerDuplicateIgnoredEvent>(ApplyExternalTriggerDuplicateIgnored)
-            .On<ExternalTriggerSourceEnabledEvent>(ApplyExternalTriggerSourceEnabled)
             .On<SkillRunnerDisabledEvent>(ApplyDisabled)
             .On<SkillRunnerEnabledEvent>(ApplyEnabled)
             .OrCurrent();
@@ -469,20 +468,6 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             await TrySendFailureAsync(ex.Message, CancellationToken.None);
             await Scheduler.ScheduleNextRunAsync(now, CancellationToken.None);
         }
-    }
-
-    [EventHandler]
-    public async Task HandleSetExternalTriggerSourceEnabledAsync(SetExternalTriggerSourceEnabledCommand command)
-    {
-        var sourceId = command.SourceId?.Trim();
-        if (string.IsNullOrWhiteSpace(sourceId) || State.FindExternalTriggerSource(sourceId) is null)
-            return;
-
-        await PersistDomainEventAsync(new ExternalTriggerSourceEnabledEvent
-        {
-            SourceId = sourceId,
-            Enabled = command.Enabled,
-        });
     }
 
     private async Task ScheduleRetryAsync(TriggerSkillRunnerExecutionCommand command, int retryAttempt, CancellationToken ct)
@@ -1753,15 +1738,6 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             }
         }
 
-        return next;
-    }
-
-    private static SkillRunnerState ApplyExternalTriggerSourceEnabled(
-        SkillRunnerState current,
-        ExternalTriggerSourceEnabledEvent evt)
-    {
-        var next = current.Clone();
-        next.SetExternalTriggerSourceEnabled(evt.SourceId, evt.Enabled);
         return next;
     }
 

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerState.Partial.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerState.Partial.cs
@@ -50,8 +50,7 @@ public sealed partial class SkillRunnerState : ISchedulable
             .Where(static record => record.Identity is not null)
             .Where(static record => record.Status is
                 SkillRunnerExternalTriggerDeliveryStatus.Admitted or
-                SkillRunnerExternalTriggerDeliveryStatus.DispatchRequested or
-                SkillRunnerExternalTriggerDeliveryStatus.Running)
+                SkillRunnerExternalTriggerDeliveryStatus.DispatchRequested)
             .ToArray();
 
     internal void UpsertExternalTriggerDelivery(
@@ -84,15 +83,6 @@ public sealed partial class SkillRunnerState : ISchedulable
             RecentExternalTriggerDeliveries[existingIndex] = next;
         else
             RecentExternalTriggerDeliveries.Add(next);
-    }
-
-    internal void SetExternalTriggerSourceEnabled(string sourceId, bool enabled)
-    {
-        var source = FindExternalTriggerSource(sourceId);
-        if (source is not null)
-        {
-            source.Enabled = enabled;
-        }
     }
 
     internal void TrimExternalTriggerDeliveries(DateTimeOffset now)

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerState.Partial.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerState.Partial.cs
@@ -1,4 +1,5 @@
 using Aevatar.GAgents.Channel.Abstractions;
+using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.GAgents.Scheduled;
 
@@ -14,4 +15,139 @@ public sealed partial class SkillRunnerState : ISchedulable
         LastRunAt = LastRunAt,
         ErrorCount = ErrorCount,
     };
+
+    public ExternalTriggerSource? FindExternalTriggerSource(string? sourceId)
+    {
+        var normalized = sourceId?.Trim();
+        if (string.IsNullOrEmpty(normalized))
+            return null;
+
+        return ExternalTriggerSources.FirstOrDefault(source =>
+            string.Equals(source.SourceId?.Trim(), normalized, StringComparison.Ordinal));
+    }
+
+    public SkillRunnerExternalTriggerDeliveryRecord? FindExternalTriggerDelivery(
+        SkillRunnerExternalTriggerIdentity? identity)
+    {
+        var sourceId = identity?.SourceId?.Trim();
+        var deliveryId = identity?.DeliveryId?.Trim();
+        if (string.IsNullOrEmpty(sourceId) || string.IsNullOrEmpty(deliveryId))
+            return null;
+
+        return RecentExternalTriggerDeliveries.FirstOrDefault(record =>
+            string.Equals(record.Identity?.SourceId?.Trim(), sourceId, StringComparison.Ordinal) &&
+            string.Equals(record.Identity?.DeliveryId?.Trim(), deliveryId, StringComparison.Ordinal));
+    }
+
+    public bool IsExternalTriggerTerminal(SkillRunnerExternalTriggerIdentity? identity)
+    {
+        var record = FindExternalTriggerDelivery(identity);
+        return record is not null && IsTerminalExternalTriggerStatus(record.Status);
+    }
+
+    public IReadOnlyList<SkillRunnerExternalTriggerDeliveryRecord> RecoverableExternalTriggerDeliveries() =>
+        RecentExternalTriggerDeliveries
+            .Where(static record => record.Identity is not null)
+            .Where(static record => record.Status is
+                SkillRunnerExternalTriggerDeliveryStatus.Admitted or
+                SkillRunnerExternalTriggerDeliveryStatus.DispatchRequested or
+                SkillRunnerExternalTriggerDeliveryStatus.Running)
+            .ToArray();
+
+    internal void UpsertExternalTriggerDelivery(
+        SkillRunnerExternalTriggerIdentity identity,
+        SkillRunnerExternalTriggerDeliveryStatus status,
+        Timestamp updatedAt,
+        string reason = "",
+        int? dispatchAttempt = null)
+    {
+        ArgumentNullException.ThrowIfNull(identity);
+        ArgumentNullException.ThrowIfNull(updatedAt);
+
+        var existingIndex = FindExternalTriggerDeliveryIndex(identity);
+        var existing = existingIndex >= 0
+            ? RecentExternalTriggerDeliveries[existingIndex]
+            : null;
+        var next = existing?.Clone() ?? new SkillRunnerExternalTriggerDeliveryRecord
+        {
+            Identity = identity.Clone(),
+            AdmittedAt = updatedAt,
+        };
+        next.Identity = identity.Clone();
+        next.Status = status;
+        next.UpdatedAt = updatedAt;
+        next.Reason = reason ?? string.Empty;
+        if (dispatchAttempt.HasValue)
+            next.DispatchAttempt = dispatchAttempt.Value;
+
+        if (existingIndex >= 0)
+            RecentExternalTriggerDeliveries[existingIndex] = next;
+        else
+            RecentExternalTriggerDeliveries.Add(next);
+    }
+
+    internal void SetExternalTriggerSourceEnabled(string sourceId, bool enabled)
+    {
+        var source = FindExternalTriggerSource(sourceId);
+        if (source is not null)
+        {
+            source.Enabled = enabled;
+        }
+    }
+
+    internal void TrimExternalTriggerDeliveries(DateTimeOffset now)
+    {
+        var cutoff = now - SkillRunnerDefaults.ExternalTriggerTerminalDeliveryRetentionAge;
+        var terminal = RecentExternalTriggerDeliveries
+            .Where(static record => IsTerminalExternalTriggerRecord(record))
+            .OrderByDescending(static record => ToDateTimeOffset(record.UpdatedAt))
+            .ToArray();
+        var terminalToRemove = terminal
+            .Skip(SkillRunnerDefaults.ExternalTriggerTerminalDeliveryRetention)
+            .Concat(terminal.Where(record => ToDateTimeOffset(record.UpdatedAt) < cutoff))
+            .DistinctBy(static record => BuildDeliveryKey(record.Identity))
+            .Select(static record => BuildDeliveryKey(record.Identity))
+            .ToHashSet(StringComparer.Ordinal);
+
+        if (terminalToRemove.Count == 0)
+            return;
+
+        var kept = RecentExternalTriggerDeliveries
+            .Where(record => !terminalToRemove.Contains(BuildDeliveryKey(record.Identity)))
+            .Select(static record => record.Clone())
+            .ToArray();
+        RecentExternalTriggerDeliveries.Clear();
+        RecentExternalTriggerDeliveries.AddRange(kept);
+    }
+
+    private int FindExternalTriggerDeliveryIndex(SkillRunnerExternalTriggerIdentity identity)
+    {
+        for (var i = 0; i < RecentExternalTriggerDeliveries.Count; i++)
+        {
+            var record = RecentExternalTriggerDeliveries[i];
+            if (string.Equals(record.Identity?.SourceId?.Trim(), identity.SourceId?.Trim(), StringComparison.Ordinal) &&
+                string.Equals(record.Identity?.DeliveryId?.Trim(), identity.DeliveryId?.Trim(), StringComparison.Ordinal))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static bool IsTerminalExternalTriggerRecord(SkillRunnerExternalTriggerDeliveryRecord record) =>
+        IsTerminalExternalTriggerStatus(record.Status);
+
+    private static bool IsTerminalExternalTriggerStatus(SkillRunnerExternalTriggerDeliveryStatus status) =>
+        status is
+            SkillRunnerExternalTriggerDeliveryStatus.Completed or
+            SkillRunnerExternalTriggerDeliveryStatus.Failed or
+            SkillRunnerExternalTriggerDeliveryStatus.Rejected or
+            SkillRunnerExternalTriggerDeliveryStatus.DuplicateIgnored;
+
+    private static DateTimeOffset ToDateTimeOffset(Timestamp? timestamp) =>
+        timestamp?.ToDateTimeOffset() ?? DateTimeOffset.MinValue;
+
+    private static string BuildDeliveryKey(SkillRunnerExternalTriggerIdentity? identity) =>
+        $"{identity?.SourceId?.Trim() ?? string.Empty}\n{identity?.DeliveryId?.Trim() ?? string.Empty}";
 }

--- a/agents/Aevatar.GAgents.Scheduled/protos/skill_runner.proto
+++ b/agents/Aevatar.GAgents.Scheduled/protos/skill_runner.proto
@@ -33,12 +33,55 @@ enum SkillRunnerExecutionErrorCode {
   SKILL_RUNNER_EXECUTION_ERROR_CODE_WORKFLOW_DISPATCH_REJECTED = 9;
 }
 
+enum ExternalTriggerSourceKind {
+  EXTERNAL_TRIGGER_SOURCE_KIND_UNSPECIFIED = 0;
+  EXTERNAL_TRIGGER_SOURCE_KIND_WEBHOOK = 1;
+  EXTERNAL_TRIGGER_SOURCE_KIND_CHANNEL_INBOUND = 2;
+}
+
+enum SkillRunnerExternalTriggerDeliveryStatus {
+  SKILL_RUNNER_EXTERNAL_TRIGGER_DELIVERY_STATUS_UNSPECIFIED = 0;
+  SKILL_RUNNER_EXTERNAL_TRIGGER_DELIVERY_STATUS_ADMITTED = 1;
+  SKILL_RUNNER_EXTERNAL_TRIGGER_DELIVERY_STATUS_DISPATCH_REQUESTED = 2;
+  SKILL_RUNNER_EXTERNAL_TRIGGER_DELIVERY_STATUS_RUNNING = 3;
+  SKILL_RUNNER_EXTERNAL_TRIGGER_DELIVERY_STATUS_COMPLETED = 4;
+  SKILL_RUNNER_EXTERNAL_TRIGGER_DELIVERY_STATUS_FAILED = 5;
+  SKILL_RUNNER_EXTERNAL_TRIGGER_DELIVERY_STATUS_REJECTED = 6;
+  SKILL_RUNNER_EXTERNAL_TRIGGER_DELIVERY_STATUS_DUPLICATE_IGNORED = 7;
+}
+
 message SkillRunnerSkillReference {
   string name = 1;
   string version = 2;
   SkillRunnerSkillSource source = 3;
   string workflow_id = 4;
   bool allow_inline_fallback = 5;
+}
+
+message ExternalTriggerSource {
+  string source_id = 1;
+  ExternalTriggerSourceKind kind = 2;
+  bool enabled = 3;
+  string display_name = 4;
+}
+
+message SkillRunnerExternalTriggerIdentity {
+  string source_id = 1;
+  string delivery_id = 2;
+  string admission_id = 3;
+  ExternalTriggerSourceKind kind = 4;
+  google.protobuf.Timestamp received_at = 5;
+  string payload_summary = 6;
+  string payload_ref = 7;
+}
+
+message SkillRunnerExternalTriggerDeliveryRecord {
+  SkillRunnerExternalTriggerIdentity identity = 1;
+  SkillRunnerExternalTriggerDeliveryStatus status = 2;
+  google.protobuf.Timestamp admitted_at = 3;
+  google.protobuf.Timestamp updated_at = 4;
+  string reason = 5;
+  int32 dispatch_attempt = 6;
 }
 
 message SkillRunnerOutboundConfig {
@@ -107,6 +150,8 @@ message SkillRunnerState {
   // failed. Skills that don't fan out to nyxid_proxy at all leave this false.
   bool requires_nyxid_proxy_success = 21;
   SkillRunnerSkillReference skill_ref = 22;
+  repeated ExternalTriggerSource external_trigger_sources = 23;
+  repeated SkillRunnerExternalTriggerDeliveryRecord recent_external_trigger_deliveries = 24;
 }
 
 message SkillRunnerExecutionDocument {
@@ -146,6 +191,7 @@ message InitializeSkillRunnerCommand {
   // See SkillRunnerState.requires_nyxid_proxy_success for semantics.
   bool requires_nyxid_proxy_success = 16;
   SkillRunnerSkillReference skill_ref = 17;
+  repeated ExternalTriggerSource external_trigger_sources = 18;
 }
 
 message SkillRunnerInitializedEvent {
@@ -167,6 +213,7 @@ message SkillRunnerInitializedEvent {
   // See SkillRunnerState.requires_nyxid_proxy_success for semantics.
   bool requires_nyxid_proxy_success = 16;
   SkillRunnerSkillReference skill_ref = 17;
+  repeated ExternalTriggerSource external_trigger_sources = 18;
 }
 
 message TriggerSkillRunnerExecutionCommand {
@@ -175,6 +222,11 @@ message TriggerSkillRunnerExecutionCommand {
   // Bounded by SkillRunnerDefaults.MaxRetryAttempts; retries are event-ified
   // via ScheduleSelfDurableTimeoutAsync and never block the actor turn.
   int32 retry_attempt = 2;
+  SkillRunnerExternalTriggerIdentity external_trigger_identity = 3;
+}
+
+message AdmitSkillRunnerExternalTriggerCommand {
+  SkillRunnerExternalTriggerIdentity identity = 1;
 }
 
 message SkillRunnerNextRunScheduledEvent {
@@ -192,6 +244,7 @@ message SkillRunnerExecutionCompletedEvent {
   string workflow_name = 8;
   string workflow_command_id = 9;
   string workflow_correlation_id = 10;
+  SkillRunnerExternalTriggerIdentity external_trigger_identity = 11;
 }
 
 message SkillRunnerExecutionFailedEvent {
@@ -202,11 +255,46 @@ message SkillRunnerExecutionFailedEvent {
   string skill_version = 5;
   string workflow_id = 6;
   SkillRunnerExecutionErrorCode error_code = 7;
+  SkillRunnerExternalTriggerIdentity external_trigger_identity = 8;
 }
 
 message SkillRunnerExecutionRejectedEvent {
   google.protobuf.Timestamp rejected_at = 1;
   string reason = 2;
+  SkillRunnerExternalTriggerIdentity external_trigger_identity = 3;
+}
+
+message SkillRunnerExternalTriggerAdmittedEvent {
+  SkillRunnerExternalTriggerIdentity identity = 1;
+  google.protobuf.Timestamp admitted_at = 2;
+}
+
+message SkillRunnerExternalTriggerDispatchRequestedEvent {
+  SkillRunnerExternalTriggerIdentity identity = 1;
+  google.protobuf.Timestamp requested_at = 2;
+  int32 dispatch_attempt = 3;
+}
+
+message SkillRunnerExternalTriggerRejectedEvent {
+  SkillRunnerExternalTriggerIdentity identity = 1;
+  google.protobuf.Timestamp rejected_at = 2;
+  string reason = 3;
+}
+
+message SkillRunnerExternalTriggerDuplicateIgnoredEvent {
+  SkillRunnerExternalTriggerIdentity identity = 1;
+  google.protobuf.Timestamp ignored_at = 2;
+  string reason = 3;
+}
+
+message SetExternalTriggerSourceEnabledCommand {
+  string source_id = 1;
+  bool enabled = 2;
+}
+
+message ExternalTriggerSourceEnabledEvent {
+  string source_id = 1;
+  bool enabled = 2;
 }
 
 message DisableSkillRunnerCommand {

--- a/agents/Aevatar.GAgents.Scheduled/protos/skill_runner.proto
+++ b/agents/Aevatar.GAgents.Scheduled/protos/skill_runner.proto
@@ -40,10 +40,12 @@ enum ExternalTriggerSourceKind {
 }
 
 enum SkillRunnerExternalTriggerDeliveryStatus {
+  reserved 3;
+  reserved "SKILL_RUNNER_EXTERNAL_TRIGGER_DELIVERY_STATUS_RUNNING";
+
   SKILL_RUNNER_EXTERNAL_TRIGGER_DELIVERY_STATUS_UNSPECIFIED = 0;
   SKILL_RUNNER_EXTERNAL_TRIGGER_DELIVERY_STATUS_ADMITTED = 1;
   SKILL_RUNNER_EXTERNAL_TRIGGER_DELIVERY_STATUS_DISPATCH_REQUESTED = 2;
-  SKILL_RUNNER_EXTERNAL_TRIGGER_DELIVERY_STATUS_RUNNING = 3;
   SKILL_RUNNER_EXTERNAL_TRIGGER_DELIVERY_STATUS_COMPLETED = 4;
   SKILL_RUNNER_EXTERNAL_TRIGGER_DELIVERY_STATUS_FAILED = 5;
   SKILL_RUNNER_EXTERNAL_TRIGGER_DELIVERY_STATUS_REJECTED = 6;
@@ -285,16 +287,6 @@ message SkillRunnerExternalTriggerDuplicateIgnoredEvent {
   SkillRunnerExternalTriggerIdentity identity = 1;
   google.protobuf.Timestamp ignored_at = 2;
   string reason = 3;
-}
-
-message SetExternalTriggerSourceEnabledCommand {
-  string source_id = 1;
-  bool enabled = 2;
-}
-
-message ExternalTriggerSourceEnabledEvent {
-  string source_id = 1;
-  bool enabled = 2;
 }
 
 message DisableSkillRunnerCommand {

--- a/docs/canon/scheduled-skill-runners.md
+++ b/docs/canon/scheduled-skill-runners.md
@@ -33,7 +33,7 @@ delivery ledger 保存在 runner state 的 `recent_external_trigger_deliveries`�
 
 ## Wake And Recovery
 
-accepted delivery 先提交 `SkillRunnerExternalTriggerAdmittedEvent`，再通过 self-message 请求执行，随后提交 `SkillRunnerExternalTriggerDispatchRequestedEvent`。runner activation 会扫描未 terminal 的 admitted / dispatch-requested / running delivery，并按 bounded dispatch attempts 恢复 self-dispatch；超过上限后提交 terminal rejected event，避免无限恢复循环。
+accepted delivery 先提交 `SkillRunnerExternalTriggerAdmittedEvent`，再通过 self-message 请求执行，随后提交 `SkillRunnerExternalTriggerDispatchRequestedEvent`。runner activation 会扫描未 terminal 的 admitted / dispatch-requested delivery，并按 bounded dispatch attempts 恢复 self-dispatch；超过上限后提交 terminal rejected event，避免无限恢复循环。
 
 ## Boundary With Creation And Ornn Execution
 

--- a/docs/canon/scheduled-skill-runners.md
+++ b/docs/canon/scheduled-skill-runners.md
@@ -1,0 +1,42 @@
+---
+title: "Scheduled Skill Runners"
+status: active
+owner: eanzhao
+---
+
+# Scheduled Skill Runners
+
+本文固化 scheduled skill runner 的触发与所有权边界。`SkillRunnerGAgent` 是 runner 配置、trigger source declaration、delivery ledger、执行结果事实的唯一权威 actor。
+
+## External Trigger Admission
+
+外部触发只通过 `ISkillRunnerCommandPort.AdmitExternalTriggerAsync` 进入已有 runner。该端口只检查 runner 是否存在并投递 `AdmitSkillRunnerExternalTriggerCommand`；它不创建 runner、不校验 source 是否声明或启用、不读 read model、不启动 projection priming，也不维护 delivery cache。
+
+同步返回的 `SkillRunnerExternalTriggerAdmissionReceipt` 只表示 `accepted for dispatch`。它提供稳定 `command_id / correlation_id / admission_id / source_id / delivery_id`，不得暗示 source validation、execution committed 或 read model observed。
+
+## Runner-Owned Source Facts
+
+创建 runner 时，`InitializeSkillRunnerCommand.external_trigger_sources` 声明允许的 external trigger source。source 的启用状态、未知 source、disabled source、duplicate delivery 都由 `SkillRunnerGAgent` 在 actor turn 内判定，并通过 committed events 表达：
+
+- `SkillRunnerExternalTriggerAdmittedEvent`
+- `SkillRunnerExternalTriggerDispatchRequestedEvent`
+- `SkillRunnerExternalTriggerRejectedEvent`
+- `SkillRunnerExternalTriggerDuplicateIgnoredEvent`
+
+已有 runner 的 unknown 或 disabled source 不是同步 HTTP `409`。Host/webhook caller 收到 `202 Accepted` 后，runner 自己提交 `SkillRunnerExternalTriggerRejectedEvent`，原因分别为 `unknown` 或 `disabled`。
+
+## Identity And Ledger
+
+每个 external delivery 使用 `SkillRunnerExternalTriggerIdentity` 表达 `source_id`、`delivery_id`、`admission_id`、`kind`、`received_at`、`payload_summary`、`payload_ref`。这些字段随 admission、self-dispatch command、terminal execution event 和 ledger record 传递，避免在多个消息形状里复制散落字段。
+
+delivery ledger 保存在 runner state 的 `recent_external_trigger_deliveries`。默认只承诺 retained window 内去重：terminal delivery 保留最多 `1000` 条或 `30 days`；non-terminal delivery 不被窗口裁剪。
+
+## Wake And Recovery
+
+accepted delivery 先提交 `SkillRunnerExternalTriggerAdmittedEvent`，再通过 self-message 请求执行，随后提交 `SkillRunnerExternalTriggerDispatchRequestedEvent`。runner activation 会扫描未 terminal 的 admitted / dispatch-requested / running delivery，并按 bounded dispatch attempts 恢复 self-dispatch；超过上限后提交 terminal rejected event，避免无限恢复循环。
+
+## Boundary With Creation And Ornn Execution
+
+`scheduled_agent_creator` 是 runner creation surface；它可以声明 `external_trigger_sources`，但不引入第二套 runner 创建工具。Ornn skill reference / workflow execution 仍按 Ornn skill fetch 与 workflow dispatch 的既有链路执行；external trigger admission 只决定“何时请求已有 runner 执行”，不改变 Ornn repository、Ornn runtime 或外部仓库能力。
+
+Channel-originated `agent_builder.run_agent` uses the same admission command instead of the manual trigger path when the typed tool context carries a stable channel message id. The channel source id is deterministic: `channel:<platform>:<registration_scope_id>`. Creation must declare that id with `kind=channel_inbound`; if it is missing or disabled, the runner accepts the delivery command and then commits `SkillRunnerExternalTriggerRejectedEvent`.

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -43,6 +43,7 @@ using Aevatar.Mainnet.Host.Api.ChatCompletions;
 using Aevatar.Mainnet.Host.Api.ChatRouting;
 using Aevatar.Mainnet.Host.Api.Messages;
 using Aevatar.Mainnet.Host.Api.Responses;
+using Aevatar.Mainnet.Host.Api.Scheduled;
 using Aevatar.Mainnet.Host.Api.Status;
 using Aevatar.Mainnet.Host.Api.Voice;
 using Aevatar.Studio.Hosting;
@@ -327,6 +328,7 @@ public static class MainnetHostBuilderExtensions
         app.MapChannelCallbackEndpoints();
         app.MapDeviceEventEndpoints();
         app.MapIdentityOAuthEndpoints();
+        app.MapSkillRunnerExternalTriggerEndpoints();
         app.MapVoiceDemoBootstrapEndpoints();
         app.MapPolicyAwareVoiceEndpoint();
         app.MapStatusEndpoints();

--- a/src/Aevatar.Mainnet.Host.Api/Scheduled/SkillRunnerExternalTriggerEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Scheduled/SkillRunnerExternalTriggerEndpoints.cs
@@ -1,0 +1,147 @@
+using System.Text.Json;
+using Aevatar.GAgents.Scheduled;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Aevatar.Mainnet.Host.Api.Scheduled;
+
+internal static class SkillRunnerExternalTriggerEndpoints
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public static IEndpointRouteBuilder MapSkillRunnerExternalTriggerEndpoints(this IEndpointRouteBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        app.MapPost(
+                "/api/skill-runners/{agentId}/external-trigger-sources/{sourceId}/deliveries",
+                HandleDeliveryAsync)
+            .WithTags("SkillRunnerExternalTriggers")
+            .AllowAnonymous();
+
+        return app;
+    }
+
+    private static async Task<IResult> HandleDeliveryAsync(
+        HttpContext http,
+        string agentId,
+        string sourceId,
+        [FromServices] ISkillRunnerCommandPort commandPort,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(http);
+        ArgumentNullException.ThrowIfNull(commandPort);
+
+        if (!HasAdmissionAuthentication(http))
+            return Results.Unauthorized();
+
+        var deliveryId = ResolveDeliveryId(http);
+        if (string.IsNullOrWhiteSpace(deliveryId))
+        {
+            return Results.BadRequest(new
+            {
+                error = "missing_event_id",
+                detail = "A stable X-Aevatar-Event-Id or X-Event-Id header is required.",
+            });
+        }
+
+        SkillRunnerExternalTriggerDeliveryRequest? request;
+        try
+        {
+            request = await http.Request.ReadFromJsonAsync<SkillRunnerExternalTriggerDeliveryRequest>(JsonOptions, ct)
+                      ?? new SkillRunnerExternalTriggerDeliveryRequest();
+        }
+        catch (JsonException)
+        {
+            return Results.BadRequest(new { error = "invalid_json" });
+        }
+
+        var command = new AdmitSkillRunnerExternalTriggerCommand
+        {
+            Identity = new SkillRunnerExternalTriggerIdentity
+            {
+                SourceId = sourceId?.Trim() ?? string.Empty,
+                DeliveryId = deliveryId.Trim(),
+                AdmissionId = NormalizeOptional(request.AdmissionId) ?? Guid.NewGuid().ToString("N"),
+                Kind = ResolveKind(request.Kind),
+                ReceivedAt = request.ReceivedAtUtc is { } receivedAt
+                    ? Timestamp.FromDateTimeOffset(receivedAt)
+                    : Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                PayloadSummary = Truncate(NormalizeOptional(request.PayloadSummary) ?? string.Empty, 256),
+                PayloadRef = NormalizeOptional(request.PayloadRef) ?? string.Empty,
+            },
+        };
+
+        try
+        {
+            var receipt = await commandPort.AdmitExternalTriggerAsync(agentId, command, ct);
+            return Results.Accepted(value: new
+            {
+                status = "accepted",
+                actor_id = receipt.ActorId,
+                command_id = receipt.CommandId,
+                correlation_id = receipt.CorrelationId,
+                admission_id = receipt.AdmissionId,
+                source_id = receipt.SourceId,
+                delivery_id = receipt.DeliveryId,
+            });
+        }
+        catch (SkillRunnerExternalTriggerAdmissionException ex)
+            when (ex.Error == SkillRunnerExternalTriggerAdmissionError.RunnerNotFound)
+        {
+            return Results.NotFound(new
+            {
+                error = "runner_not_found",
+                agent_id = ex.AgentId,
+            });
+        }
+    }
+
+    private static bool HasAdmissionAuthentication(HttpContext http)
+    {
+        var authorization = http.Request.Headers.Authorization.ToString();
+        if (authorization.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase) &&
+            !string.IsNullOrWhiteSpace(authorization["Bearer ".Length..]))
+        {
+            return true;
+        }
+
+        return !string.IsNullOrWhiteSpace(http.Request.Headers["X-Aevatar-External-Trigger-Signature"].ToString());
+    }
+
+    private static string? ResolveDeliveryId(HttpContext http) =>
+        NormalizeOptional(http.Request.Headers["X-Aevatar-Event-Id"].ToString()) ??
+        NormalizeOptional(http.Request.Headers["X-Event-Id"].ToString());
+
+    private static ExternalTriggerSourceKind ResolveKind(string? value) =>
+        NormalizeOptional(value)?.ToLowerInvariant() switch
+        {
+            "channel_inbound" or "channel-inbound" => ExternalTriggerSourceKind.ChannelInbound,
+            "webhook" => ExternalTriggerSourceKind.Webhook,
+            _ => ExternalTriggerSourceKind.Webhook,
+        };
+
+    private static string? NormalizeOptional(string? value)
+    {
+        var normalized = value?.Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
+    private static string Truncate(string value, int maxLength) =>
+        value.Length <= maxLength ? value : value[..maxLength];
+
+    private sealed record SkillRunnerExternalTriggerDeliveryRequest
+    {
+        public string? AdmissionId { get; init; }
+
+        public string? Kind { get; init; }
+
+        public DateTimeOffset? ReceivedAtUtc { get; init; }
+
+        public string? PayloadSummary { get; init; }
+
+        public string? PayloadRef { get; init; }
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -276,6 +276,83 @@ public sealed class AgentBuilderToolTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_RunAgent_FromChannelInbound_AdmitsExternalTrigger()
+    {
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.GetForCallerAsync("skill-runner-1", Arg.Any<OwnerScope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<UserAgentCatalogReadModelEntry?>(new UserAgentCatalogReadModelEntry
+            {
+                AgentId = "skill-runner-1",
+                AgentType = SkillRunnerDefaults.AgentType,
+                TemplateName = "summary",
+                ScopeId = "scope-1",
+            }));
+
+        var captured = new List<AdmitSkillRunnerExternalTriggerCommand>();
+        var skillRunnerPort = Substitute.For<ISkillRunnerCommandPort>();
+        skillRunnerPort.AdmitExternalTriggerAsync(
+                "skill-runner-1",
+                Arg.Do<AdmitSkillRunnerExternalTriggerCommand>(command => captured.Add(command.Clone())),
+                Arg.Any<CancellationToken>())
+            .Returns(call => Task.FromResult(new SkillRunnerExternalTriggerAdmissionReceipt(
+                "skill-runner-1",
+                call.ArgAt<AdmitSkillRunnerExternalTriggerCommand>(1).Identity.AdmissionId,
+                call.ArgAt<AdmitSkillRunnerExternalTriggerCommand>(1).Identity.AdmissionId,
+                call.ArgAt<AdmitSkillRunnerExternalTriggerCommand>(1).Identity.AdmissionId,
+                call.ArgAt<AdmitSkillRunnerExternalTriggerCommand>(1).Identity.SourceId,
+                call.ArgAt<AdmitSkillRunnerExternalTriggerCommand>(1).Identity.DeliveryId)));
+        var catalogCommandPort = Substitute.For<IUserAgentCatalogCommandPort>();
+
+        var services = new ServiceCollection();
+        services.AddSingleton(queryPort);
+        services.AddSingleton(skillRunnerPort);
+        services.AddSingleton(catalogCommandPort);
+        services.AddSingleton<INyxIdApiClientFactory>(new TestNyxIdApiClientFactory());
+        var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
+        callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForChannel("nyx-user-1", "lark", "scope-1", "ou-user")));
+        services.AddSingleton(callerScopeResolver);
+        var tool = CreateTool(services);
+
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+            ["channel.platform"] = "lark",
+            ["registration_scope_id"] = "scope-1",
+            ["channel.message_id"] = "activity-1",
+            ["channel.platform_message_id"] = "om_1",
+        });
+        try
+        {
+            var result = await tool.ExecuteAsync("""
+                {
+                  "action": "run_agent",
+                  "agent_id": "skill-runner-1"
+                }
+                """);
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("status").GetString().Should().Be("accepted");
+            captured.Should().ContainSingle();
+            var identity = captured[0].Identity;
+            identity.Kind.Should().Be(ExternalTriggerSourceKind.ChannelInbound);
+            identity.SourceId.Should().Be("channel:lark:scope-1");
+            identity.DeliveryId.Should().Be("activity-1");
+            identity.PayloadSummary.Should().Be("channel run_agent");
+            identity.PayloadRef.Should().Be("om_1");
+
+            await skillRunnerPort.DidNotReceive().TriggerAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = null;
+        }
+    }
+
+    [Fact]
     public async Task ExecuteAsync_AgentStatus_JoinsPerIdCatalogAndExecutionAtToolBoundary()
     {
         var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentCreatorToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentCreatorToolTests.cs
@@ -37,6 +37,13 @@ public sealed class ScheduledAgentCreatorToolTests
         properties.TryGetProperty("allowed_service_ids", out _).Should().BeFalse();
         properties.TryGetProperty("skill_content", out _).Should().BeFalse();
         properties.TryGetProperty("provider_base_url", out _).Should().BeFalse();
+        properties.TryGetProperty("external_trigger_sources", out var externalSources).Should().BeTrue();
+        externalSources.GetProperty("items").GetProperty("properties")
+            .GetProperty("kind")
+            .GetProperty("enum")
+            .EnumerateArray()
+            .Select(static x => x.GetString())
+            .Should().BeEquivalentTo("webhook", "channel_inbound");
         schema.RootElement.GetProperty("required").EnumerateArray().Select(static x => x.GetString())
             .Should().BeEquivalentTo("skill_ref", "schedule_cron", "schedule_timezone");
     }
@@ -321,6 +328,19 @@ public sealed class ScheduledAgentCreatorToolTests
                   "max_tool_rounds": 6,
                   "max_history_messages": 12,
                   "requires_nyxid_proxy_success": true,
+                  "external_trigger_sources": [
+                    {
+                      "source_id": " webhook-main ",
+                      "kind": "webhook",
+                      "enabled": true,
+                      "display_name": " Main webhook "
+                    },
+                    {
+                      "source_id": "channel-lark",
+                      "kind": "channel_inbound",
+                      "enabled": false
+                    }
+                  ],
                   "run_immediately": true
                 }
                 """);
@@ -354,6 +374,14 @@ public sealed class ScheduledAgentCreatorToolTests
             captured.MaxToolRounds.Should().Be(6);
             captured.MaxHistoryMessages.Should().Be(12);
             captured.RequiresNyxidProxySuccess.Should().BeTrue();
+            captured.ExternalTriggerSources.Should().HaveCount(2);
+            captured.ExternalTriggerSources[0].SourceId.Should().Be("webhook-main");
+            captured.ExternalTriggerSources[0].Kind.Should().Be(ExternalTriggerSourceKind.Webhook);
+            captured.ExternalTriggerSources[0].Enabled.Should().BeTrue();
+            captured.ExternalTriggerSources[0].DisplayName.Should().Be("Main webhook");
+            captured.ExternalTriggerSources[1].SourceId.Should().Be("channel-lark");
+            captured.ExternalTriggerSources[1].Kind.Should().Be(ExternalTriggerSourceKind.ChannelInbound);
+            captured.ExternalTriggerSources[1].Enabled.Should().BeFalse();
             captured.OutboundConfig.NyxApiKey.Should().Be("full-secret-key");
             captured.OutboundConfig.ApiKeyId.Should().Be("key-created");
             captured.OutboundConfig.NyxProviderSlug.Should().Be("api-lark-bot");

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerCommandPortTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerCommandPortTests.cs
@@ -151,6 +151,104 @@ public sealed class SkillRunnerCommandPortTests
         env.Route.Direct.TargetActorId.Should().Be(AgentId);
     }
 
+    [Fact]
+    public async Task AdmitExternalTriggerAsync_WhenRunnerExists_DispatchesAdmissionAndReturnsAcceptedOnlyReceipt()
+    {
+        var fixture = new Fixture();
+        fixture.Runtime.GetAsync(AgentId).Returns(Task.FromResult<IActor?>(Substitute.For<IActor>()));
+        var command = CreateExternalTriggerAdmission("webhook-main", "delivery-1", "admission-1");
+
+        var receipt = await fixture.Port.AdmitExternalTriggerAsync(AgentId, command, CancellationToken.None);
+
+        fixture.Captured.Should().ContainSingle();
+        var envelope = fixture.Captured[0];
+        envelope.Id.Should().Be("admission-1");
+        envelope.Propagation.CorrelationId.Should().Be("admission-1");
+        envelope.Payload.Is(AdmitSkillRunnerExternalTriggerCommand.Descriptor).Should().BeTrue();
+        envelope.Route.PublisherActorId.Should().Be(ExpectedPublisher);
+        envelope.Route.Direct.TargetActorId.Should().Be(AgentId);
+        var dispatched = envelope.Payload.Unpack<AdmitSkillRunnerExternalTriggerCommand>();
+        dispatched.Identity.SourceId.Should().Be("webhook-main");
+        dispatched.Identity.DeliveryId.Should().Be("delivery-1");
+
+        receipt.ActorId.Should().Be(AgentId);
+        receipt.CommandId.Should().Be("admission-1");
+        receipt.CorrelationId.Should().Be("admission-1");
+        receipt.AdmissionId.Should().Be("admission-1");
+        receipt.SourceId.Should().Be("webhook-main");
+        receipt.DeliveryId.Should().Be("delivery-1");
+    }
+
+    [Fact]
+    public async Task AdmitExternalTriggerAsync_WhenRunnerMissing_ShouldThrowTypedNotFoundAndNotCreateRunner()
+    {
+        var fixture = new Fixture();
+        fixture.Runtime.GetAsync(AgentId).Returns(Task.FromResult<IActor?>(null));
+        var command = CreateExternalTriggerAdmission("webhook-main", "delivery-1", "admission-1");
+
+        var act = () => fixture.Port.AdmitExternalTriggerAsync(AgentId, command, CancellationToken.None);
+
+        var assertion = await act.Should().ThrowAsync<SkillRunnerExternalTriggerAdmissionException>();
+        assertion.Which.Error.Should().Be(SkillRunnerExternalTriggerAdmissionError.RunnerNotFound);
+        assertion.Which.AgentId.Should().Be(AgentId);
+        await fixture.Runtime.DidNotReceive()
+            .CreateAsync<SkillRunnerGAgent>(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await fixture.Dispatch.DidNotReceive()
+            .DispatchAsync(Arg.Any<string>(), Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AdmitExternalTriggerAsync_WithUnknownSource_ShouldStillReturnAcceptedDispatch()
+    {
+        var fixture = new Fixture();
+        fixture.Runtime.GetAsync(AgentId).Returns(Task.FromResult<IActor?>(Substitute.For<IActor>()));
+        var command = CreateExternalTriggerAdmission("unknown-source", "delivery-unknown", "admission-unknown");
+
+        var receipt = await fixture.Port.AdmitExternalTriggerAsync(AgentId, command, CancellationToken.None);
+
+        receipt.CommandId.Should().Be("admission-unknown");
+        receipt.SourceId.Should().Be("unknown-source");
+        fixture.Captured.Should().ContainSingle();
+        fixture.Captured[0].Payload.Unpack<AdmitSkillRunnerExternalTriggerCommand>()
+            .Identity.SourceId.Should().Be("unknown-source");
+        await fixture.Runtime.DidNotReceive()
+            .CreateAsync<SkillRunnerGAgent>(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task AdmitExternalTriggerAsync_WithInvalidAgentId_Throws(string? agentId)
+    {
+        var fixture = new Fixture();
+        var command = CreateExternalTriggerAdmission("webhook-main", "delivery-1", "admission-1");
+
+        var act = () => fixture.Port.AdmitExternalTriggerAsync(agentId!, command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task AdmitExternalTriggerAsync_WithMissingAdmissionId_ShouldGenerateStableEnvelopeIdAndNormalizeIdentity()
+    {
+        var fixture = new Fixture();
+        fixture.Runtime.GetAsync(AgentId).Returns(Task.FromResult<IActor?>(Substitute.For<IActor>()));
+        var command = CreateExternalTriggerAdmission(" webhook-main ", " delivery-2 ", admissionId: string.Empty);
+
+        var receipt = await fixture.Port.AdmitExternalTriggerAsync(AgentId, command, CancellationToken.None);
+
+        receipt.CommandId.Should().NotBeNullOrWhiteSpace();
+        receipt.CommandId.Should().Be(receipt.CorrelationId);
+        receipt.CommandId.Should().Be(receipt.AdmissionId);
+        receipt.SourceId.Should().Be("webhook-main");
+        receipt.DeliveryId.Should().Be("delivery-2");
+        fixture.Captured.Should().ContainSingle();
+        fixture.Captured[0].Id.Should().Be(receipt.CommandId);
+        fixture.Captured[0].Payload.Unpack<AdmitSkillRunnerExternalTriggerCommand>()
+            .Identity.AdmissionId.Should().Be(receipt.CommandId);
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]
@@ -216,6 +314,20 @@ public sealed class SkillRunnerCommandPortTests
         ctor1.Should().Throw<ArgumentNullException>();
         ctor2.Should().Throw<ArgumentNullException>();
     }
+
+    private static AdmitSkillRunnerExternalTriggerCommand CreateExternalTriggerAdmission(
+        string sourceId,
+        string deliveryId,
+        string? admissionId) => new()
+    {
+        Identity = new SkillRunnerExternalTriggerIdentity
+        {
+            SourceId = sourceId,
+            DeliveryId = deliveryId,
+            AdmissionId = admissionId ?? string.Empty,
+            Kind = ExternalTriggerSourceKind.Webhook,
+        },
+    };
 
     private sealed class Fixture
     {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -12,6 +12,7 @@ using Aevatar.CQRS.Projection.Runtime.Abstractions;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.GAgents.Channel.Runtime;
@@ -317,6 +318,227 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         _agent.State.Enabled.Should().BeFalse();
         _agent.State.LastError.Should().Be(SkillRunnerDefaults.RejectionReasonRunnerDisabled);
         _agent.State.ErrorCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task HandleInitializeAsync_WithExternalTriggerSource_ShouldPersistSourceDeclaration()
+    {
+        var command = CreateInitializeCommand();
+        command.ExternalTriggerSources.Add(new ExternalTriggerSource
+        {
+            SourceId = " webhook-main ",
+            Kind = ExternalTriggerSourceKind.Webhook,
+            Enabled = true,
+            DisplayName = " Main webhook ",
+        });
+
+        await _agent.HandleInitializeAsync(command);
+
+        var persisted = await _store.GetEventsAsync("skill-runner-test");
+        var initialized = persisted
+            .Select(x => x.EventData)
+            .Where(x => x.Is(SkillRunnerInitializedEvent.Descriptor))
+            .Select(x => x.Unpack<SkillRunnerInitializedEvent>())
+            .Should()
+            .ContainSingle()
+            .Subject;
+        initialized.ExternalTriggerSources.Should().ContainSingle()
+            .Which.SourceId.Should().Be("webhook-main");
+        _agent.State.ExternalTriggerSources.Should().ContainSingle()
+            .Which.DisplayName.Should().Be("Main webhook");
+    }
+
+    [Fact]
+    public async Task HandleAdmitExternalTriggerAsync_FirstDelivery_ShouldPersistAdmittedThenDispatchRequested()
+    {
+        await _agent.HandleInitializeAsync(CreateInitializeCommandWithExternalSource());
+
+        await _agent.HandleAdmitExternalTriggerAsync(new AdmitSkillRunnerExternalTriggerCommand
+        {
+            Identity = CreateExternalIdentity("delivery-1"),
+        });
+
+        var persisted = await _store.GetEventsAsync("skill-runner-test");
+        var externalEvents = persisted
+            .Select(x => x.EventData)
+            .Where(x =>
+                x.Is(SkillRunnerExternalTriggerAdmittedEvent.Descriptor) ||
+                x.Is(SkillRunnerExternalTriggerDispatchRequestedEvent.Descriptor))
+            .ToArray();
+        externalEvents.Should().HaveCount(2);
+        externalEvents[0].Is(SkillRunnerExternalTriggerAdmittedEvent.Descriptor).Should().BeTrue();
+        externalEvents[1].Is(SkillRunnerExternalTriggerDispatchRequestedEvent.Descriptor).Should().BeTrue();
+        var dispatchRequested = externalEvents[1].Unpack<SkillRunnerExternalTriggerDispatchRequestedEvent>();
+        dispatchRequested.DispatchAttempt.Should().Be(1);
+        dispatchRequested.Identity.DeliveryId.Should().Be("delivery-1");
+
+        var record = _agent.State.FindExternalTriggerDelivery(CreateExternalIdentity("delivery-1"));
+        record.Should().NotBeNull();
+        record!.Status.Should().Be(SkillRunnerExternalTriggerDeliveryStatus.DispatchRequested);
+    }
+
+    [Theory]
+    [InlineData("missing-source", SkillRunnerDefaults.ExternalTriggerRejectedReasonUnknownSource)]
+    [InlineData("disabled-source", SkillRunnerDefaults.ExternalTriggerRejectedReasonDisabledSource)]
+    public async Task HandleAdmitExternalTriggerAsync_UnknownOrDisabledSource_ShouldCommitRejectedWithoutDispatch(
+        string sourceId,
+        string expectedReason)
+    {
+        var command = CreateInitializeCommandWithExternalSource();
+        command.ExternalTriggerSources.Add(new ExternalTriggerSource
+        {
+            SourceId = "disabled-source",
+            Kind = ExternalTriggerSourceKind.Webhook,
+            Enabled = false,
+        });
+        await _agent.HandleInitializeAsync(command);
+
+        await _agent.HandleAdmitExternalTriggerAsync(new AdmitSkillRunnerExternalTriggerCommand
+        {
+            Identity = CreateExternalIdentity("delivery-rejected", sourceId),
+        });
+
+        var persisted = await _store.GetEventsAsync("skill-runner-test");
+        var rejected = persisted
+            .Select(x => x.EventData)
+            .Where(x => x.Is(SkillRunnerExternalTriggerRejectedEvent.Descriptor))
+            .Select(x => x.Unpack<SkillRunnerExternalTriggerRejectedEvent>())
+            .Should()
+            .ContainSingle()
+            .Subject;
+        rejected.Reason.Should().Be(expectedReason);
+        persisted.Select(x => x.EventData)
+            .Should()
+            .NotContain(x => x.Is(SkillRunnerExternalTriggerDispatchRequestedEvent.Descriptor));
+    }
+
+    [Fact]
+    public async Task HandleAdmitExternalTriggerAsync_DuplicateDelivery_ShouldCommitDuplicateIgnoredWithoutSecondDispatch()
+    {
+        await _agent.HandleInitializeAsync(CreateInitializeCommandWithExternalSource());
+        var command = new AdmitSkillRunnerExternalTriggerCommand
+        {
+            Identity = CreateExternalIdentity("delivery-dup"),
+        };
+
+        await _agent.HandleAdmitExternalTriggerAsync(command);
+        await _agent.HandleAdmitExternalTriggerAsync(command.Clone());
+
+        var persisted = await _store.GetEventsAsync("skill-runner-test");
+        persisted.Select(x => x.EventData)
+            .Count(x => x.Is(SkillRunnerExternalTriggerDispatchRequestedEvent.Descriptor))
+            .Should()
+            .Be(1);
+        persisted.Select(x => x.EventData)
+            .Count(x => x.Is(SkillRunnerExternalTriggerDuplicateIgnoredEvent.Descriptor))
+            .Should()
+            .Be(1);
+    }
+
+    [Fact]
+    public async Task HandleTriggerAsync_ExternalCompleted_ShouldPreserveIdentityAndMarkTerminal()
+    {
+        var provider = new StubStreamingProviderFactory("external output");
+        var agent = CreateAgent("skill-runner-external-complete", providerFactory: provider);
+        await agent.ActivateAsync();
+        await agent.HandleInitializeAsync(CreateInitializeCommandWithExternalSource());
+        var identity = CreateExternalIdentity("delivery-complete");
+        await agent.HandleAdmitExternalTriggerAsync(new AdmitSkillRunnerExternalTriggerCommand { Identity = identity });
+
+        await agent.HandleTriggerAsync(new TriggerSkillRunnerExecutionCommand
+        {
+            Reason = SkillRunnerDefaults.ExternalTriggerReason,
+            ExternalTriggerIdentity = identity.Clone(),
+        });
+
+        var completed = await ReadSingleCompletedEventAsync(_store, "skill-runner-external-complete");
+        completed.ExternalTriggerIdentity.Should().NotBeNull();
+        completed.ExternalTriggerIdentity.DeliveryId.Should().Be("delivery-complete");
+        agent.State.FindExternalTriggerDelivery(identity)!.Status
+            .Should()
+            .Be(SkillRunnerExternalTriggerDeliveryStatus.Completed);
+    }
+
+    [Fact]
+    public async Task HandleTriggerAsync_DisabledExternalDelivery_ShouldPreserveIdentityInExecutionRejected()
+    {
+        await _agent.HandleInitializeAsync(CreateInitializeCommandWithExternalSource());
+        var identity = CreateExternalIdentity("delivery-disabled-runner");
+        await _agent.HandleAdmitExternalTriggerAsync(new AdmitSkillRunnerExternalTriggerCommand { Identity = identity });
+        await _agent.HandleDisableAsync(new DisableSkillRunnerCommand { Reason = "operator" });
+
+        await _agent.HandleTriggerAsync(new TriggerSkillRunnerExecutionCommand
+        {
+            Reason = SkillRunnerDefaults.ExternalTriggerReason,
+            ExternalTriggerIdentity = identity.Clone(),
+        });
+
+        var persisted = await _store.GetEventsAsync("skill-runner-test");
+        var rejected = persisted
+            .Select(x => x.EventData)
+            .Where(x => x.Is(SkillRunnerExecutionRejectedEvent.Descriptor))
+            .Select(x => x.Unpack<SkillRunnerExecutionRejectedEvent>())
+            .Should()
+            .ContainSingle()
+            .Subject;
+        rejected.ExternalTriggerIdentity.DeliveryId.Should().Be("delivery-disabled-runner");
+        _agent.State.FindExternalTriggerDelivery(identity)!.Status
+            .Should()
+            .Be(SkillRunnerExternalTriggerDeliveryStatus.Rejected);
+    }
+
+    [Fact]
+    public async Task HandleTriggerAsync_ExternalRetry_ShouldPreserveIdentityInRetryCommand()
+    {
+        var scheduler = new RecordingCallbackScheduler();
+        using var provider = BuildServiceProvider(
+            new InMemoryEventStore(),
+            services => services.AddSingleton<Foundation.Abstractions.Runtime.Callbacks.IActorRuntimeCallbackScheduler>(scheduler));
+        var agent = CreateAgent(
+            "skill-runner-external-retry",
+            provider,
+            providerFactory: new StubStreamingProviderFactory(new StubStreamingTurn(new InvalidOperationException("fail once"))));
+        await agent.ActivateAsync();
+        await agent.HandleInitializeAsync(CreateInitializeCommandWithExternalSource());
+        var identity = CreateExternalIdentity("delivery-retry");
+        await agent.HandleAdmitExternalTriggerAsync(new AdmitSkillRunnerExternalTriggerCommand { Identity = identity });
+
+        await agent.HandleTriggerAsync(new TriggerSkillRunnerExecutionCommand
+        {
+            Reason = SkillRunnerDefaults.ExternalTriggerReason,
+            ExternalTriggerIdentity = identity.Clone(),
+        });
+
+        scheduler.Timeouts.Should().ContainSingle();
+        var retry = scheduler.Timeouts[0].TriggerEnvelope.Payload.Unpack<TriggerSkillRunnerExecutionCommand>();
+        retry.RetryAttempt.Should().Be(1);
+        retry.ExternalTriggerIdentity.DeliveryId.Should().Be("delivery-retry");
+    }
+
+    [Fact]
+    public async Task OnActivateAsync_RecoverableExternalDelivery_ShouldRedispatchWithBoundedAttempt()
+    {
+        var store = new InMemoryEventStore();
+        using var provider = BuildServiceProvider(store);
+        var first = CreateAgent("skill-runner-external-recover", provider);
+        await first.ActivateAsync();
+        await first.HandleInitializeAsync(CreateInitializeCommandWithExternalSource());
+        await first.HandleAdmitExternalTriggerAsync(new AdmitSkillRunnerExternalTriggerCommand
+        {
+            Identity = CreateExternalIdentity("delivery-recover"),
+        });
+
+        var recovered = CreateAgent("skill-runner-external-recover", provider);
+        await recovered.ActivateAsync();
+
+        var persisted = await store.GetEventsAsync("skill-runner-external-recover");
+        var dispatches = persisted
+            .Select(x => x.EventData)
+            .Where(x => x.Is(SkillRunnerExternalTriggerDispatchRequestedEvent.Descriptor))
+            .Select(x => x.Unpack<SkillRunnerExternalTriggerDispatchRequestedEvent>())
+            .ToArray();
+        dispatches.Should().HaveCount(2);
+        dispatches[^1].DispatchAttempt.Should().Be(2);
     }
 
     [Fact]
@@ -1828,6 +2050,47 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         public DateTimeOffset UtcNow => now;
     }
 
+    private sealed class RecordingCallbackScheduler : IActorRuntimeCallbackScheduler
+    {
+        public List<RuntimeCallbackTimeoutRequest> Timeouts { get; } = [];
+
+        public Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
+            RuntimeCallbackTimeoutRequest request,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Timeouts.Add(request);
+            return Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                Timeouts.Count,
+                RuntimeCallbackBackend.InMemory));
+        }
+
+        public Task<RuntimeCallbackLease> ScheduleTimerAsync(
+            RuntimeCallbackTimerRequest request,
+            CancellationToken ct = default)
+        {
+            _ = request;
+            ct.ThrowIfCancellationRequested();
+            throw new NotSupportedException("Timer scheduling is not required for this test.");
+        }
+
+        public Task CancelAsync(RuntimeCallbackLease lease, CancellationToken ct = default)
+        {
+            _ = lease;
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public Task PurgeActorAsync(string actorId, CancellationToken ct = default)
+        {
+            _ = actorId;
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+    }
+
     /// <summary>
     /// Returns a different response per request in the order given. Used to simulate the
     /// `bot not in chat` rejection on the primary attempt followed by a successful fallback
@@ -1912,6 +2175,34 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
             NyxProviderSlug = "api-lark-bot",
             NyxApiKey = "nyx-api-key",
         },
+    };
+
+    private static InitializeSkillRunnerCommand CreateInitializeCommandWithExternalSource(
+        string sourceId = "webhook-main")
+    {
+        var command = CreateInitializeCommand();
+        command.ExternalTriggerSources.Add(new ExternalTriggerSource
+        {
+            SourceId = sourceId,
+            Kind = ExternalTriggerSourceKind.Webhook,
+            Enabled = true,
+            DisplayName = "Webhook main",
+        });
+        return command;
+    }
+
+    private static SkillRunnerExternalTriggerIdentity CreateExternalIdentity(
+        string deliveryId,
+        string sourceId = "webhook-main") => new()
+    {
+        SourceId = sourceId,
+        DeliveryId = deliveryId,
+        AdmissionId = $"admit-{deliveryId}",
+        Kind = ExternalTriggerSourceKind.Webhook,
+        ReceivedAt = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset(
+            new DateTimeOffset(2026, 6, 6, 8, 0, 0, TimeSpan.Zero)),
+        PayloadSummary = "test delivery",
+        PayloadRef = $"test://deliveries/{deliveryId}",
     };
 
     private static InitializeSkillRunnerCommand CreateSkillRefCommand(string name)

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -21,6 +21,7 @@ using Aevatar.GAgents.Scheduled;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using FluentAssertions;
 using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
@@ -471,6 +472,72 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
             .Be(1);
     }
 
+    [Theory]
+    [InlineData(SkillRunnerExternalTriggerDeliveryStatus.Completed)]
+    [InlineData(SkillRunnerExternalTriggerDeliveryStatus.Failed)]
+    [InlineData(SkillRunnerExternalTriggerDeliveryStatus.Rejected)]
+    public async Task HandleTriggerAsync_TerminalExternalDelivery_ShouldCommitDuplicateIgnoredWithoutExecutingAgain(
+        SkillRunnerExternalTriggerDeliveryStatus terminalStatus)
+    {
+        var actorId = $"skill-runner-external-terminal-{terminalStatus.ToString().ToLowerInvariant()}";
+        var provider = terminalStatus == SkillRunnerExternalTriggerDeliveryStatus.Failed
+            ? new StubStreamingProviderFactory(
+                new StubStreamingTurn(new InvalidOperationException("terminal failure")),
+                new StubStreamingTurn(["should-not-run"]))
+            : new StubStreamingProviderFactory("terminal output", "should-not-run");
+        var agent = CreateAgent(actorId, providerFactory: provider);
+        await agent.ActivateAsync();
+        await agent.HandleInitializeAsync(CreateInitializeCommandWithExternalSource());
+        var identity = CreateExternalIdentity($"delivery-terminal-{terminalStatus.ToString().ToLowerInvariant()}");
+        await agent.HandleAdmitExternalTriggerAsync(new AdmitSkillRunnerExternalTriggerCommand { Identity = identity });
+
+        if (terminalStatus == SkillRunnerExternalTriggerDeliveryStatus.Rejected)
+        {
+            await agent.HandleDisableAsync(new DisableSkillRunnerCommand { Reason = "operator" });
+        }
+
+        await agent.HandleTriggerAsync(new TriggerSkillRunnerExecutionCommand
+        {
+            Reason = SkillRunnerDefaults.ExternalTriggerReason,
+            RetryAttempt = terminalStatus == SkillRunnerExternalTriggerDeliveryStatus.Failed
+                ? SkillRunnerDefaults.MaxRetryAttempts
+                : 0,
+            ExternalTriggerIdentity = identity.Clone(),
+        });
+        var executionRequestsBeforeDuplicate = provider.Requests.Count;
+        var persistedBeforeDuplicate = await _store.GetEventsAsync(actorId);
+        persistedBeforeDuplicate
+            .Select(x => x.EventData)
+            .Count(IsExternalExecutionTerminalEvent)
+            .Should()
+            .Be(1);
+        agent.State.FindExternalTriggerDelivery(identity)!.Status.Should().Be(terminalStatus);
+
+        await agent.HandleTriggerAsync(new TriggerSkillRunnerExecutionCommand
+        {
+            Reason = SkillRunnerDefaults.ExternalTriggerReason,
+            ExternalTriggerIdentity = identity.Clone(),
+        });
+
+        var persisted = await _store.GetEventsAsync(actorId);
+        provider.Requests.Should().HaveCount(executionRequestsBeforeDuplicate);
+        persisted
+            .Select(x => x.EventData)
+            .Count(IsExternalExecutionTerminalEvent)
+            .Should()
+            .Be(1);
+        var duplicate = persisted
+            .Select(x => x.EventData)
+            .Where(x => x.Is(SkillRunnerExternalTriggerDuplicateIgnoredEvent.Descriptor))
+            .Select(x => x.Unpack<SkillRunnerExternalTriggerDuplicateIgnoredEvent>())
+            .Should()
+            .ContainSingle()
+            .Subject;
+        duplicate.Identity.DeliveryId.Should().Be(identity.DeliveryId);
+        duplicate.Reason.Should().Be(SkillRunnerDefaults.ExternalTriggerDuplicateReasonAlreadyAdmitted);
+        agent.State.FindExternalTriggerDelivery(identity)!.Status.Should().Be(terminalStatus);
+    }
+
     [Fact]
     public async Task HandleTriggerAsync_ExternalCompleted_ShouldPreserveIdentityAndMarkTerminal()
     {
@@ -549,6 +616,34 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         var retry = scheduler.Timeouts[0].TriggerEnvelope.Payload.Unpack<TriggerSkillRunnerExecutionCommand>();
         retry.RetryAttempt.Should().Be(1);
         retry.ExternalTriggerIdentity.DeliveryId.Should().Be("delivery-retry");
+    }
+
+    [Fact]
+    public async Task HandleTriggerAsync_ExternalFailureAtExhaustedRetry_ShouldPreserveIdentityAndMarkFailed()
+    {
+        var provider = new StubStreamingProviderFactory(new StubStreamingTurn(
+            new InvalidOperationException("terminal external failure")));
+        var agent = CreateAgent("skill-runner-external-failed", providerFactory: provider);
+        await agent.ActivateAsync();
+        await agent.HandleInitializeAsync(CreateInitializeCommandWithExternalSource());
+        var identity = CreateExternalIdentity("delivery-failed");
+        await agent.HandleAdmitExternalTriggerAsync(new AdmitSkillRunnerExternalTriggerCommand { Identity = identity });
+
+        await agent.HandleTriggerAsync(new TriggerSkillRunnerExecutionCommand
+        {
+            Reason = SkillRunnerDefaults.ExternalTriggerReason,
+            RetryAttempt = SkillRunnerDefaults.MaxRetryAttempts,
+            ExternalTriggerIdentity = identity.Clone(),
+        });
+
+        var failed = await ReadSingleFailedEventAsync(_store, "skill-runner-external-failed");
+        failed.Error.Should().Be("terminal external failure");
+        failed.ExternalTriggerIdentity.Should().NotBeNull();
+        failed.ExternalTriggerIdentity.DeliveryId.Should().Be("delivery-failed");
+        var record = agent.State.FindExternalTriggerDelivery(identity);
+        record.Should().NotBeNull();
+        record!.Status.Should().Be(SkillRunnerExternalTriggerDeliveryStatus.Failed);
+        record.Reason.Should().Be("terminal external failure");
     }
 
     [Fact]
@@ -2021,6 +2116,16 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         var property = instance.GetType().GetProperty(propertyName);
         property.Should().NotBeNull();
         return (T?)property!.GetValue(instance);
+    }
+
+    private static bool IsExternalExecutionTerminalEvent(Any evt)
+    {
+        if (evt.Is(SkillRunnerExecutionCompletedEvent.Descriptor))
+            return evt.Unpack<SkillRunnerExecutionCompletedEvent>().ExternalTriggerIdentity is not null;
+        if (evt.Is(SkillRunnerExecutionFailedEvent.Descriptor))
+            return evt.Unpack<SkillRunnerExecutionFailedEvent>().ExternalTriggerIdentity is not null;
+        return evt.Is(SkillRunnerExecutionRejectedEvent.Descriptor) &&
+               evt.Unpack<SkillRunnerExecutionRejectedEvent>().ExternalTriggerIdentity is not null;
     }
 
     private sealed record SkillRunnerExecutionResultSnapshot(

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -378,6 +378,42 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
     }
 
     [Theory]
+    [InlineData(" ", "delivery-malformed-source")]
+    [InlineData("webhook-main", " ")]
+    public async Task HandleAdmitExternalTriggerAsync_MalformedIdentity_ShouldCommitRejectedWithoutDispatch(
+        string sourceId,
+        string deliveryId)
+    {
+        await _agent.HandleInitializeAsync(CreateInitializeCommandWithExternalSource());
+
+        await _agent.HandleAdmitExternalTriggerAsync(new AdmitSkillRunnerExternalTriggerCommand
+        {
+            Identity = new SkillRunnerExternalTriggerIdentity
+            {
+                SourceId = sourceId,
+                DeliveryId = deliveryId,
+                AdmissionId = "admission-malformed",
+                Kind = ExternalTriggerSourceKind.Webhook,
+            },
+        });
+
+        var persisted = await _store.GetEventsAsync("skill-runner-test");
+        var rejected = persisted
+            .Select(x => x.EventData)
+            .Where(x => x.Is(SkillRunnerExternalTriggerRejectedEvent.Descriptor))
+            .Select(x => x.Unpack<SkillRunnerExternalTriggerRejectedEvent>())
+            .Should()
+            .ContainSingle()
+            .Subject;
+        rejected.Reason.Should().Be(SkillRunnerDefaults.ExternalTriggerRejectedReasonMalformedDelivery);
+        rejected.Identity.SourceId.Should().Be(sourceId.Trim());
+        rejected.Identity.DeliveryId.Should().Be(deliveryId.Trim());
+        persisted.Select(x => x.EventData)
+            .Should()
+            .NotContain(x => x.Is(SkillRunnerExternalTriggerDispatchRequestedEvent.Descriptor));
+    }
+
+    [Theory]
     [InlineData("missing-source", SkillRunnerDefaults.ExternalTriggerRejectedReasonUnknownSource)]
     [InlineData("disabled-source", SkillRunnerDefaults.ExternalTriggerRejectedReasonDisabledSource)]
     public async Task HandleAdmitExternalTriggerAsync_UnknownOrDisabledSource_ShouldCommitRejectedWithoutDispatch(
@@ -539,6 +575,92 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
             .ToArray();
         dispatches.Should().HaveCount(2);
         dispatches[^1].DispatchAttempt.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task OnActivateAsync_RecoverableExternalDelivery_WhenAttemptsExhausted_ShouldCommitTerminalRejectedWithoutRedispatch()
+    {
+        var store = new InMemoryEventStore();
+        using var provider = BuildServiceProvider(store);
+        var first = CreateAgent("skill-runner-external-exhausted", provider);
+        await first.ActivateAsync();
+        await first.HandleInitializeAsync(CreateInitializeCommandWithExternalSource());
+        var identity = CreateExternalIdentity("delivery-exhausted");
+        await first.HandleAdmitExternalTriggerAsync(new AdmitSkillRunnerExternalTriggerCommand
+        {
+            Identity = identity,
+        });
+
+        for (var attempt = 2; attempt <= SkillRunnerDefaults.ExternalTriggerMaxDispatchAttempts; attempt++)
+        {
+            var recovered = CreateAgent("skill-runner-external-exhausted", provider);
+            await recovered.ActivateAsync();
+        }
+
+        var exhausted = CreateAgent("skill-runner-external-exhausted", provider);
+        await exhausted.ActivateAsync();
+
+        var persisted = await store.GetEventsAsync("skill-runner-external-exhausted");
+        persisted
+            .Select(x => x.EventData)
+            .Count(x => x.Is(SkillRunnerExternalTriggerDispatchRequestedEvent.Descriptor))
+            .Should()
+            .Be(SkillRunnerDefaults.ExternalTriggerMaxDispatchAttempts);
+        var rejected = persisted
+            .Select(x => x.EventData)
+            .Where(x => x.Is(SkillRunnerExternalTriggerRejectedEvent.Descriptor))
+            .Select(x => x.Unpack<SkillRunnerExternalTriggerRejectedEvent>())
+            .Should()
+            .ContainSingle()
+            .Subject;
+        rejected.Reason.Should().Be(SkillRunnerDefaults.ExternalTriggerRejectedReasonDispatchAttemptsExhausted);
+        rejected.Identity.DeliveryId.Should().Be("delivery-exhausted");
+        var record = exhausted.State.FindExternalTriggerDelivery(identity);
+        record.Should().NotBeNull();
+        record!.Status.Should().Be(SkillRunnerExternalTriggerDeliveryStatus.Rejected);
+        record.Reason.Should().Be(SkillRunnerDefaults.ExternalTriggerRejectedReasonDispatchAttemptsExhausted);
+    }
+
+    [Fact]
+    public void TrimExternalTriggerDeliveries_ShouldTrimTerminalByCountAndAgeWhilePreservingNonTerminal()
+    {
+        var state = new SkillRunnerState();
+        var now = new DateTimeOffset(2026, 6, 6, 8, 0, 0, TimeSpan.Zero);
+        Func<DateTimeOffset, Google.Protobuf.WellKnownTypes.Timestamp> timestamp =
+            Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset;
+
+        for (var i = 0; i <= SkillRunnerDefaults.ExternalTriggerTerminalDeliveryRetention; i++)
+        {
+            state.UpsertExternalTriggerDelivery(
+                CreateExternalIdentity($"recent-terminal-{i:0000}"),
+                SkillRunnerExternalTriggerDeliveryStatus.Completed,
+                timestamp(now - TimeSpan.FromMinutes(i)));
+        }
+
+        var oldTerminal = CreateExternalIdentity("old-terminal");
+        state.UpsertExternalTriggerDelivery(
+            oldTerminal,
+            SkillRunnerExternalTriggerDeliveryStatus.Completed,
+            timestamp(now - SkillRunnerDefaults.ExternalTriggerTerminalDeliveryRetentionAge - TimeSpan.FromDays(1)));
+        var oldNonTerminal = CreateExternalIdentity("old-nonterminal");
+        state.UpsertExternalTriggerDelivery(
+            oldNonTerminal,
+            SkillRunnerExternalTriggerDeliveryStatus.DispatchRequested,
+            timestamp(now - SkillRunnerDefaults.ExternalTriggerTerminalDeliveryRetentionAge - TimeSpan.FromDays(1)),
+            dispatchAttempt: 1);
+
+        state.TrimExternalTriggerDeliveries(now);
+
+        state.RecentExternalTriggerDeliveries
+            .Count(record => record.Status == SkillRunnerExternalTriggerDeliveryStatus.Completed)
+            .Should()
+            .Be(SkillRunnerDefaults.ExternalTriggerTerminalDeliveryRetention);
+        state.FindExternalTriggerDelivery(oldTerminal).Should().BeNull();
+        state.FindExternalTriggerDelivery(CreateExternalIdentity("recent-terminal-1000")).Should().BeNull();
+        state.FindExternalTriggerDelivery(CreateExternalIdentity("recent-terminal-0000")).Should().NotBeNull();
+        var nonTerminal = state.FindExternalTriggerDelivery(oldNonTerminal);
+        nonTerminal.Should().NotBeNull();
+        nonTerminal!.Status.Should().Be(SkillRunnerExternalTriggerDeliveryStatus.DispatchRequested);
     }
 
     [Fact]

--- a/test/Aevatar.Hosting.Tests/MainnetHostCompositionTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetHostCompositionTests.cs
@@ -107,6 +107,7 @@ public sealed class MainnetHostCompositionTests
         routePatterns.Should().Contain("/api/channels/registrations");
         routePatterns.Should().Contain("/api/oauth/nyxid-callback");
         routePatterns.Should().Contain("/api/services/");
+        routePatterns.Should().Contain("/api/skill-runners/{agentId}/external-trigger-sources/{sourceId}/deliveries");
         routePatterns.Should().Contain("/v1/responses");
         routePatterns.Should().Contain("/v1/chat/completions");
         routePatterns.Should().NotContain("/v1/chat/completion");

--- a/test/Aevatar.Hosting.Tests/SkillRunnerExternalTriggerEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/SkillRunnerExternalTriggerEndpointsTests.cs
@@ -1,0 +1,231 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Aevatar.GAgents.Scheduled;
+using Aevatar.Mainnet.Host.Api.Scheduled;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Aevatar.Hosting.Tests;
+
+public sealed class SkillRunnerExternalTriggerEndpointsTests
+{
+    [Fact]
+    public async Task PostDelivery_WithoutAdmissionAuth_ShouldReturnUnauthorizedAndNotDispatch()
+    {
+        var port = new RecordingSkillRunnerCommandPort();
+        await using var app = await CreateAppAsync(port);
+
+        var response = await app.GetTestClient().PostAsync(
+            DeliveryPath("runner-1", "webhook-main"),
+            JsonContent("""{"payloadSummary":"ignored"}"""));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        port.Admissions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task PostDelivery_WithoutStableEventId_ShouldReturnBadRequestAndNotDispatch()
+    {
+        var port = new RecordingSkillRunnerCommandPort();
+        await using var app = await CreateAppAsync(port);
+        using var request = new HttpRequestMessage(HttpMethod.Post, DeliveryPath("runner-1", "webhook-main"))
+        {
+            Content = JsonContent("""{"payloadSummary":"ignored"}"""),
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "delivery-token");
+
+        var response = await app.GetTestClient().SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("missing_event_id");
+        port.Admissions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task PostDelivery_WhenRunnerMissing_ShouldReturnNotFound()
+    {
+        var port = new RecordingSkillRunnerCommandPort
+        {
+            MissingRunnerId = "runner-missing",
+        };
+        await using var app = await CreateAppAsync(port);
+
+        var response = await app.GetTestClient().SendAsync(CreateAuthenticatedRequest(
+            DeliveryPath("runner-missing", "webhook-main"),
+            "event-1",
+            """{"admissionId":"admission-1"}"""));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("runner_not_found");
+        port.Admissions.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task PostDelivery_WithValidWebhook_ShouldReturnAcceptedOnlyReceipt()
+    {
+        var port = new RecordingSkillRunnerCommandPort();
+        await using var app = await CreateAppAsync(port);
+
+        var response = await app.GetTestClient().SendAsync(CreateAuthenticatedRequest(
+            DeliveryPath("runner-1", "webhook-main"),
+            "event-1",
+            """
+            {
+              "admissionId": "admission-1",
+              "kind": "webhook",
+              "receivedAtUtc": "2026-06-06T08:00:00Z",
+              "payloadSummary": "delivery summary",
+              "payloadRef": "blob://payloads/event-1"
+            }
+            """));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        var body = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(body);
+        document.RootElement.GetProperty("status").GetString().Should().Be("accepted");
+        document.RootElement.GetProperty("actor_id").GetString().Should().Be("runner-1");
+        document.RootElement.GetProperty("command_id").GetString().Should().Be("admission-1");
+        document.RootElement.TryGetProperty("execution_result", out _).Should().BeFalse();
+        document.RootElement.TryGetProperty("committed", out _).Should().BeFalse();
+
+        var admitted = port.Admissions.Should().ContainSingle().Subject;
+        admitted.AgentId.Should().Be("runner-1");
+        admitted.Command.Identity.SourceId.Should().Be("webhook-main");
+        admitted.Command.Identity.DeliveryId.Should().Be("event-1");
+        admitted.Command.Identity.AdmissionId.Should().Be("admission-1");
+        admitted.Command.Identity.Kind.Should().Be(ExternalTriggerSourceKind.Webhook);
+        admitted.Command.Identity.PayloadSummary.Should().Be("delivery summary");
+        admitted.Command.Identity.PayloadRef.Should().Be("blob://payloads/event-1");
+    }
+
+    [Fact]
+    public async Task PostDelivery_WithUnknownOrDisabledSource_ShouldStillReturnAcceptedReceipt()
+    {
+        var port = new RecordingSkillRunnerCommandPort();
+        await using var app = await CreateAppAsync(port);
+
+        var response = await app.GetTestClient().SendAsync(CreateAuthenticatedRequest(
+            DeliveryPath("runner-1", "unknown-source"),
+            "event-unknown",
+            """{"admissionId":"admission-unknown","kind":"channel_inbound"}"""));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        var admitted = port.Admissions.Should().ContainSingle().Subject;
+        admitted.Command.Identity.SourceId.Should().Be("unknown-source");
+        admitted.Command.Identity.Kind.Should().Be(ExternalTriggerSourceKind.ChannelInbound);
+    }
+
+    [Fact]
+    public void EndpointSource_ShouldNotInjectRuntimeDispatchOrKeepDeliveryCache()
+    {
+        var source = File.ReadAllText(GetEndpointSourcePath());
+
+        source.Should().NotContain("IActorRuntime");
+        source.Should().NotContain("IActorDispatchPort");
+        source.Should().NotContain("ConcurrentDictionary");
+        source.Should().NotContain("Dictionary<");
+    }
+
+    private static async Task<WebApplication> CreateAppAsync(RecordingSkillRunnerCommandPort port)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Development,
+        });
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton<ISkillRunnerCommandPort>(port);
+
+        var app = builder.Build();
+        app.MapSkillRunnerExternalTriggerEndpoints();
+        await app.StartAsync();
+        return app;
+    }
+
+    private static HttpRequestMessage CreateAuthenticatedRequest(string path, string eventId, string json)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, path)
+        {
+            Content = JsonContent(json),
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "delivery-token");
+        request.Headers.Add("X-Aevatar-Event-Id", eventId);
+        return request;
+    }
+
+    private static string DeliveryPath(string runnerId, string sourceId) =>
+        $"/api/skill-runners/{runnerId}/external-trigger-sources/{sourceId}/deliveries";
+
+    private static StringContent JsonContent(string json) =>
+        new(json, Encoding.UTF8, "application/json");
+
+    private static string GetEndpointSourcePath()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(
+                dir.FullName,
+                "src",
+                "Aevatar.Mainnet.Host.Api",
+                "Scheduled",
+                "SkillRunnerExternalTriggerEndpoints.cs");
+            if (File.Exists(candidate))
+                return candidate;
+            dir = dir.Parent;
+        }
+
+        throw new FileNotFoundException("Could not locate SkillRunnerExternalTriggerEndpoints.cs.");
+    }
+
+    private sealed class RecordingSkillRunnerCommandPort : ISkillRunnerCommandPort
+    {
+        public string? MissingRunnerId { get; init; }
+        public List<(string AgentId, AdmitSkillRunnerExternalTriggerCommand Command)> Admissions { get; } = [];
+
+        public Task InitializeAsync(
+            string agentId,
+            InitializeSkillRunnerCommand command,
+            bool runImmediately,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task TriggerAsync(string agentId, string reason, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task DisableAsync(string agentId, string reason, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task EnableAsync(string agentId, string reason, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<SkillRunnerExternalTriggerAdmissionReceipt> AdmitExternalTriggerAsync(
+            string agentId,
+            AdmitSkillRunnerExternalTriggerCommand command,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Admissions.Add((agentId, command.Clone()));
+            if (string.Equals(agentId, MissingRunnerId, StringComparison.Ordinal))
+            {
+                throw new SkillRunnerExternalTriggerAdmissionException(
+                    SkillRunnerExternalTriggerAdmissionError.RunnerNotFound,
+                    agentId);
+            }
+
+            return Task.FromResult(new SkillRunnerExternalTriggerAdmissionReceipt(
+                agentId,
+                command.Identity.AdmissionId,
+                command.Identity.AdmissionId,
+                command.Identity.AdmissionId,
+                command.Identity.SourceId,
+                command.Identity.DeliveryId));
+        }
+    }
+}


### PR DESCRIPTION
## 摘要
解决 #1790：Ornn skill 运行的非 cron 触发（事件 / webhook 触发源）。
- **New**：runner-owned external trigger admission——skill_runner.proto 增 `SkillRunnerExternalTriggerIdentity`/`ExternalTriggerSource`/delivery ledger + Admitted/DispatchRequested/Rejected/DuplicateIgnored events；`AdmitSkillRunnerExternalTriggerCommand`；`ISkillRunnerCommandPort.AdmitExternalTriggerAsync`（accepted-only receipt，不 GetOrCreate）；Host webhook endpoint，unknown/disabled source → 202 + committed rejected event（不同步 409）；committed-before-wake + bounded retry recovery。
经 consensus-rnd 设计共识 r4（structural）。验证：build 0 err；ChannelRuntime 1072；Hosting 264。

🤖 Auto-loop / consensus-rnd

⟦AI:AUTO-LOOP⟧
