### PR TITLE
feat(scheduled): user-selectable output_format (text/feishu_doc) for scheduled skill runs (#1847)

### DIFF
--- a/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderCardContent.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderCardContent.cs
@@ -75,12 +75,14 @@ public static class AgentBuilderCardContent
             var status = TryReadString(agent, "status") ?? "unknown";
             var nextRun = TryReadString(agent, "next_scheduled_run") ?? "pending";
             var lastRun = TryReadOptional(agent, "last_run_at");
+            var outputFormat = TryReadString(agent, "output_format") ?? "auto";
 
             if (index > 1)
                 bodyBuilder.Append("\n\n");
 
             bodyBuilder.Append($"**{index}. `{template}`** · {status}\n");
             bodyBuilder.Append($"- Agent ID: `{agentId}`\n");
+            bodyBuilder.Append($"- Output: `{outputFormat}`\n");
             bodyBuilder.Append($"- Next run: `{nextRun}`");
             if (lastRun is not null)
             {

--- a/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderCardFlow.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderCardFlow.cs
@@ -390,6 +390,7 @@ public static class AgentBuilderCardFlow
         var status = ReadString(root, "status") ?? "unknown";
         var scheduleCron = ReadString(root, "schedule_cron") ?? "n/a";
         var scheduleTimezone = ReadString(root, "schedule_timezone") ?? "n/a";
+        var outputFormat = ReadString(root, "output_format") ?? "auto";
         var lastRunAt = ReadString(root, "last_run_at") ?? "n/a";
         var nextRunAt = ReadString(root, "next_scheduled_run") ?? "n/a";
         var errorCount = ReadString(root, "error_count") ?? "0";
@@ -401,6 +402,7 @@ public static class AgentBuilderCardFlow
         body.Append($"- Template: `{template}`\n");
         body.Append($"- Status: `{status}`\n");
         body.Append($"- Schedule: `{scheduleCron}` ({scheduleTimezone})\n");
+        body.Append($"- Output: `{outputFormat}`\n");
         body.Append($"- Last run: `{lastRunAt}`\n");
         body.Append($"- Next run: `{nextRunAt}`\n");
         body.Append($"- Error count: `{errorCount}`");

--- a/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTool.cs
@@ -314,6 +314,7 @@ public sealed class AgentBuilderTool : IAgentTool
             scope_id = entry.ScopeId,
             schedule_cron = entry.ScheduleCron,
             schedule_timezone = entry.ScheduleTimezone,
+            output_format = ToOutputFormatJsonValue(entry.OutputFormat),
             last_run_at = entry.LastRunAt,
             next_scheduled_run = entry.NextRunAt,
             error_count = entry.ErrorCount,
@@ -343,6 +344,7 @@ public sealed class AgentBuilderTool : IAgentTool
                 status = x.Status,
                 schedule_cron = x.ScheduleCron,
                 schedule_timezone = x.ScheduleTimezone,
+                output_format = ToOutputFormatJsonValue(x.OutputFormat),
                 last_run_at = x.LastRunAt,
                 next_scheduled_run = x.NextRunAt,
                 error_count = x.ErrorCount,
@@ -432,6 +434,7 @@ public sealed class AgentBuilderTool : IAgentTool
             LarkReceiveIdType = catalog.LarkReceiveIdType,
             LarkReceiveIdFallback = catalog.LarkReceiveIdFallback,
             LarkReceiveIdTypeFallback = catalog.LarkReceiveIdTypeFallback,
+            OutputFormat = catalog.OutputFormat,
             OwnerScope = catalog.OwnerScope,
             CatalogAuthorityStateVersion = catalog.CatalogAuthorityStateVersion,
             CatalogLastEventId = catalog.CatalogLastEventId,
@@ -439,6 +442,14 @@ public sealed class AgentBuilderTool : IAgentTool
             RunnerLastEventId = execution.LastEventId ?? string.Empty,
         };
     }
+
+    private static string ToOutputFormatJsonValue(SkillRunnerOutputFormat outputFormat) =>
+        outputFormat switch
+        {
+            SkillRunnerOutputFormat.Text => "text",
+            SkillRunnerOutputFormat.FeishuDoc => "feishu_doc",
+            _ => "auto",
+        };
 
     private static async Task<(bool success, string? error)> TryDispatchLifecycleAsync(
         UserAgentCatalogReadModelEntry entry,

--- a/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentCreateRequestMapper.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentCreateRequestMapper.cs
@@ -23,6 +23,7 @@ internal sealed class ScheduledAgentCreateRequestMapper
         "max_tool_rounds",
         "max_history_messages",
         "requires_nyxid_proxy_success",
+        "output_format",
         "external_trigger_sources",
         "run_immediately",
     };
@@ -56,6 +57,9 @@ internal sealed class ScheduledAgentCreateRequestMapper
         var scopeId = Normalize(AgentToolRequestContext.ScopeId ?? AgentToolRequestContext.ChannelRegistrationScopeId);
         if (scopeId is null)
             return ScheduledAgentCreatePlanResult.Failed("scope_id_unavailable");
+
+        if (!TryParseOutputFormat(args.Str("output_format"), out var outputFormat, out var outputFormatError))
+            return ScheduledAgentCreatePlanResult.Failed(outputFormatError);
 
         var conversationId = Normalize(AgentToolRequestContext.TryGetExternalMetadata(ChannelMetadataKeys.ConversationId));
         if (conversationId is null)
@@ -98,6 +102,7 @@ internal sealed class ScheduledAgentCreateRequestMapper
                 MaxToolRounds: args.TryInt("max_tool_rounds", out var maxToolRounds) ? maxToolRounds : null,
                 MaxHistoryMessages: args.TryInt("max_history_messages", out var maxHistoryMessages) ? maxHistoryMessages : null,
                 RequiresNyxidProxySuccess: args.Bool("requires_nyxid_proxy_success") ?? false,
+                OutputFormat: outputFormat,
                 ExternalTriggerSources: args.ExternalTriggerSources("external_trigger_sources"),
                 RunImmediately: args.Bool("run_immediately") ?? false,
                 ConversationId: conversationId,
@@ -137,6 +142,7 @@ internal sealed class ScheduledAgentCreateRequestMapper
             ProviderName = request.ProviderName ?? string.Empty,
             Model = request.Model ?? string.Empty,
             RequiresNyxidProxySuccess = request.RequiresNyxidProxySuccess,
+            OutputFormat = request.OutputFormat,
             OutboundConfig = new SkillRunnerOutboundConfig
             {
                 ConversationId = request.ConversationId,
@@ -149,6 +155,7 @@ internal sealed class ScheduledAgentCreateRequestMapper
                 LarkReceiveIdTypeFallback = request.ReceiveTarget.Fallback?.ReceiveIdType ?? string.Empty,
                 OwnerScope = request.Caller.Clone(),
                 FailureNotificationProviderSlug = request.FailureNotificationSlug ?? string.Empty,
+                OutputFormat = request.OutputFormat,
             },
         };
 
@@ -173,6 +180,35 @@ internal sealed class ScheduledAgentCreateRequestMapper
     {
         var trimmed = value?.Trim();
         return string.IsNullOrEmpty(trimmed) ? null : trimmed;
+    }
+
+    private static bool TryParseOutputFormat(
+        string? value,
+        out SkillRunnerOutputFormat outputFormat,
+        out string error)
+    {
+        outputFormat = SkillRunnerOutputFormat.Auto;
+        error = string.Empty;
+        var normalized = Normalize(value);
+        if (normalized is null)
+            return true;
+
+        switch (normalized.ToLowerInvariant())
+        {
+            case "auto":
+                outputFormat = SkillRunnerOutputFormat.Auto;
+                return true;
+            case "text":
+                outputFormat = SkillRunnerOutputFormat.Text;
+                return true;
+            case "feishu_doc":
+            case "feishu-doc":
+                outputFormat = SkillRunnerOutputFormat.FeishuDoc;
+                return true;
+            default:
+                error = "output_format must be one of: auto, text, feishu_doc";
+                return false;
+        }
     }
 
     private sealed class CreatorArgs
@@ -374,6 +410,7 @@ internal sealed record ScheduledAgentCreatePlannedRequest(
     int? MaxToolRounds,
     int? MaxHistoryMessages,
     bool RequiresNyxidProxySuccess,
+    SkillRunnerOutputFormat OutputFormat,
     IReadOnlyList<ExternalTriggerSource> ExternalTriggerSources,
     bool RunImmediately,
     string ConversationId,

--- a/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentCreatorTool.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentCreatorTool.cs
@@ -89,6 +89,11 @@ public sealed class ScheduledAgentCreatorTool : IAgentTool
               "type": "boolean",
               "description": "When true, the run must observe a successful NyxID proxy call."
             },
+            "output_format": {
+              "type": "string",
+              "enum": ["auto", "text", "feishu_doc"],
+              "description": "Optional scheduled-run output format. auto keeps length-based delivery, text forces chat text chunks, feishu_doc forces Feishu cloud document delivery."
+            },
             "external_trigger_sources": {
               "type": "array",
               "description": "Optional external trigger source declarations. For channel run_agent, use source_id channel:<platform>:<registration_scope_id> and kind channel_inbound.",

--- a/agents/Aevatar.GAgents.Scheduled/IUserAgentDeliveryTargetReader.cs
+++ b/agents/Aevatar.GAgents.Scheduled/IUserAgentDeliveryTargetReader.cs
@@ -33,5 +33,6 @@ public sealed record UserAgentDeliveryTarget(
     string LarkReceiveIdType,
     string LarkReceiveIdFallback,
     string LarkReceiveIdTypeFallback,
+    SkillRunnerOutputFormat OutputFormat,
     string TemplateName,
     string AgentType);

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
@@ -31,6 +31,7 @@ namespace Aevatar.GAgents.Scheduled;
 public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
 {
     private static readonly TimeSpan LongOutputDocumentDecisionTimeout = TimeSpan.FromSeconds(45);
+    private const string LarkDocxCreateToolName = "lark_docx_create";
 
     private readonly NyxIdApiClient? _nyxIdApiClient;
     private readonly ILarkOutboundDispatcher? _larkOutboundDispatcher;
@@ -281,6 +282,10 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             return;
         }
 
+        var outboundConfig = command.OutboundConfig?.Clone() ?? new SkillRunnerOutboundConfig();
+        if (command.OutputFormat != SkillRunnerOutputFormat.Auto || outboundConfig.OutputFormat == SkillRunnerOutputFormat.Auto)
+            outboundConfig.OutputFormat = command.OutputFormat;
+
         var initialized = new SkillRunnerInitializedEvent
         {
             SkillName = command.SkillName?.Trim() ?? string.Empty,
@@ -292,7 +297,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             ExecutionPrompt = command.ExecutionPrompt?.Trim() ?? string.Empty,
             ScheduleCron = command.ScheduleCron?.Trim() ?? string.Empty,
             ScheduleTimezone = NormalizeTimezone(command.ScheduleTimezone),
-            OutboundConfig = command.OutboundConfig?.Clone() ?? new SkillRunnerOutboundConfig(),
+            OutboundConfig = outboundConfig,
             Enabled = command.Enabled,
             ScopeId = command.ScopeId?.Trim() ?? string.Empty,
             ProviderName = NormalizeProviderName(command.ProviderName),
@@ -648,16 +653,13 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
                 _toolFailureCounter.SuccessCount,
                 State.RequiresNyxidProxySuccess);
 
-            var docReply = await TryCreateLongOutputDocumentReplyAsync(
+            var chunks = await BuildOutputChunksAsync(
                 output,
                 requestId,
                 llmControl,
                 toolContext,
                 metadata,
                 ct);
-            var chunks = docReply is not null
-                ? [docReply]
-                : SkillRunnerOutputChunker.Split(output);
             await DispatchOutputChunksAsync(streamingState, chunks, ct);
 
             return output;
@@ -757,10 +759,10 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             // No streaming sink (no NyxID client, missing outbound config, or tests injecting
             // a null client). Fall back to a one-shot send so the user still receives the
             // report and tests that don't construct a sink keep working.
-            await SendOutputAsync(chunks[0], ct);
+            await SendTextOutputAsync(chunks[0], ct);
 
         for (var i = 1; i < chunks.Count; i++)
-            await SendOutputAsync(chunks[i], ct);
+            await SendTextOutputAsync(chunks[i], ct);
     }
 
     /// <summary>
@@ -785,6 +787,9 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         // user no longer sees the report grow live, but output integrity wins over the
         // streaming-edit UX for fetch-and-summarize skills.
         if (State.RequiresNyxidProxySuccess)
+            return null;
+
+        if (State.OutboundConfig?.OutputFormat == SkillRunnerOutputFormat.FeishuDoc)
             return null;
 
         var client = _nyxIdApiClient ?? Services.GetService<NyxIdApiClient>();
@@ -1198,6 +1203,11 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         IReadOnlyDictionary<string, string> metadata,
         CancellationToken ct)
     {
+        var outputFormat = State.OutboundConfig?.OutputFormat ?? SkillRunnerOutputFormat.Auto;
+        if (outputFormat == SkillRunnerOutputFormat.Text)
+            return null;
+        if (outputFormat == SkillRunnerOutputFormat.FeishuDoc)
+            return await CreateRequiredFeishuDocumentReplyAsync(output, requestId, toolContext, ct);
         if (output.Length <= SkillRunnerStreamingReplySink.MaxLarkTextLength)
             return null;
 
@@ -1252,7 +1262,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         The scheduled skill output below is too long for one Lark message.
 
         Decide whether the full content should be delivered as a Lark cloud document.
-        If yes, call the lark_docx_create tool exactly once with:
+        If yes, call the {LarkDocxCreateToolName} tool exactly once with:
         - title: a concise title for this report
         - markdown_text: the complete output exactly as provided
         - visibility: readable
@@ -1264,6 +1274,101 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         Output:
         {output}
         """;
+
+    private async Task<IReadOnlyList<string>> BuildOutputChunksAsync(
+        string output,
+        string requestId,
+        LLMControlContext llmControl,
+        AgentToolExecutionContext toolContext,
+        IReadOnlyDictionary<string, string> metadata,
+        CancellationToken ct)
+    {
+        var docReply = await TryCreateLongOutputDocumentReplyAsync(
+            output,
+            requestId,
+            llmControl,
+            toolContext,
+            metadata,
+            ct);
+        if (docReply is not null)
+            return [docReply];
+
+        return SkillRunnerOutputChunker.Split(output);
+    }
+
+    private async Task<string> CreateRequiredFeishuDocumentReplyAsync(
+        string output,
+        string requestId,
+        AgentToolExecutionContext toolContext,
+        CancellationToken ct)
+    {
+        var title = string.IsNullOrWhiteSpace(State.TemplateName)
+            ? "Scheduled run output"
+            : State.TemplateName.Trim();
+        var arguments = JsonSerializer.Serialize(new
+        {
+            title,
+            markdown_text = output,
+            visibility = "readable",
+        });
+        var scopedToolContext = toolContext with
+        {
+            Request = toolContext.Request with { RequestId = $"{requestId}:lark-docx", CallId = "required-lark-docx" },
+        };
+
+        using var _ = AgentToolContextScope.Push(scopedToolContext);
+        var result = await Tools.ExecuteToolCallAsync(
+            new ToolCall
+            {
+                Id = "required-lark-docx",
+                Name = LarkDocxCreateToolName,
+                ArgumentsJson = arguments,
+            },
+            ct);
+
+        if (!TryExtractSuccessfulDocumentUrl(result.Content, out var documentUrl))
+        {
+            throw new InvalidOperationException(
+                "Feishu document output was requested, but document creation did not return a usable link.");
+        }
+
+        return $"Full output moved to {documentUrl}";
+    }
+
+    private static bool TryExtractSuccessfulDocumentUrl(string? resultJson, out string documentUrl)
+    {
+        documentUrl = string.Empty;
+        if (string.IsNullOrWhiteSpace(resultJson))
+            return false;
+
+        try
+        {
+            using var document = JsonDocument.Parse(resultJson);
+            var root = document.RootElement;
+            if (!root.TryGetProperty("success", out var success) ||
+                success.ValueKind != JsonValueKind.True)
+            {
+                return false;
+            }
+
+            if (!root.TryGetProperty("document_url", out var urlElement) ||
+                urlElement.ValueKind != JsonValueKind.String)
+            {
+                return false;
+            }
+
+            var url = urlElement.GetString()?.Trim();
+            if (string.IsNullOrWhiteSpace(url) || !ContainsDocumentLink(url))
+                return false;
+
+            documentUrl = url;
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
 
     private static bool TryAcceptLongOutputDocumentReply(string reply, out string accepted)
     {
@@ -1285,8 +1390,18 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         reply.Contains("http://", StringComparison.OrdinalIgnoreCase) ||
         reply.Contains("https://", StringComparison.OrdinalIgnoreCase);
 
-    private Task SendOutputAsync(string output, CancellationToken ct) =>
-        SendOutputAsync(output, providerSlugOverride: null, ct);
+    private async Task SendOutputAsync(string output, CancellationToken ct)
+    {
+        var requestId = Guid.NewGuid().ToString("N");
+        var metadata = await BuildExecutionMetadataAsync(ct);
+        var llmControl = await BuildExecutionLlmControlAsync(ct);
+        var toolContext = llmControl.ToToolContext(BuildExecutionToolContext(requestId, metadata));
+        var chunks = await BuildOutputChunksAsync(output, requestId, llmControl, toolContext, metadata, ct);
+        await DispatchOutputChunksAsync(streamingState: null, chunks, ct);
+    }
+
+    private Task SendTextOutputAsync(string output, CancellationToken ct) =>
+        SendTextOutputAsync(output, providerSlugOverride: null, ct);
 
     /// <summary>
     /// Posts <paramref name="output"/> as a Lark text message. <paramref name="providerSlugOverride"/>
@@ -1296,7 +1411,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
     /// rejected (e.g. cross-tenant <c>99992364</c>). All other call sites — main report send,
     /// chunked overflow continuations — pass <c>null</c> and stay on the primary slug.
     /// </summary>
-    private async Task SendOutputAsync(string output, string? providerSlugOverride, CancellationToken ct)
+    private async Task SendTextOutputAsync(string output, string? providerSlugOverride, CancellationToken ct)
     {
         var client = _nyxIdApiClient ?? Services.GetService<NyxIdApiClient>();
         if (client is null)
@@ -1433,7 +1548,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         {
             try
             {
-                await SendOutputAsync(message, providerSlugOverride: failureSlug, ct);
+                await SendTextOutputAsync(message, providerSlugOverride: failureSlug, ct);
                 return;
             }
             catch (Exception ex)
@@ -1447,7 +1562,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
 
         try
         {
-            await SendOutputAsync(message, providerSlugOverride: null, ct);
+            await SendTextOutputAsync(message, providerSlugOverride: null, ct);
         }
         catch (Exception ex)
         {
@@ -1533,6 +1648,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             LarkReceiveIdType = State.OutboundConfig?.LarkReceiveIdType ?? string.Empty,
             LarkReceiveIdFallback = State.OutboundConfig?.LarkReceiveIdFallback ?? string.Empty,
             LarkReceiveIdTypeFallback = State.OutboundConfig?.LarkReceiveIdTypeFallback ?? string.Empty,
+            OutputFormat = State.OutboundConfig?.OutputFormat ?? SkillRunnerOutputFormat.Auto,
         };
 
         // Refactor (iter92/cluster-092):

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogGAgent.cs
@@ -56,6 +56,9 @@ public sealed class UserAgentCatalogGAgent : GAgentBase<UserAgentCatalogState>
             LarkReceiveIdType = MergeNonEmpty(command.LarkReceiveIdType, existing?.LarkReceiveIdType),
             LarkReceiveIdFallback = MergeNonEmpty(command.LarkReceiveIdFallback, existing?.LarkReceiveIdFallback),
             LarkReceiveIdTypeFallback = MergeNonEmpty(command.LarkReceiveIdTypeFallback, existing?.LarkReceiveIdTypeFallback),
+            OutputFormat = command.OutputFormat == SkillRunnerOutputFormat.Auto
+                ? existing?.OutputFormat ?? SkillRunnerOutputFormat.Auto
+                : command.OutputFormat,
         };
 
         // Issue #466 critical: copy OwnerScope from the command (or inherit existing on

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogProjector.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogProjector.cs
@@ -100,6 +100,7 @@ public sealed class UserAgentCatalogProjector
         document.LarkReceiveIdType = entry.LarkReceiveIdType ?? string.Empty;
         document.LarkReceiveIdFallback = entry.LarkReceiveIdFallback ?? string.Empty;
         document.LarkReceiveIdTypeFallback = entry.LarkReceiveIdTypeFallback ?? string.Empty;
+        document.OutputFormat = entry.OutputFormat;
 
         // Project owner_scope verbatim from the upserted entry. Per issue #466 the entry
         // is the authoritative source for ownership; the projector materializes it for

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogQueryPort.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogQueryPort.cs
@@ -201,6 +201,7 @@ public sealed class UserAgentCatalogQueryPort : IUserAgentCatalogQueryPort
             LarkReceiveIdType = document.LarkReceiveIdType ?? string.Empty,
             LarkReceiveIdFallback = document.LarkReceiveIdFallback ?? string.Empty,
             LarkReceiveIdTypeFallback = document.LarkReceiveIdTypeFallback ?? string.Empty,
+            OutputFormat = document.OutputFormat,
             OwnerScope = documentScope,
             CatalogAuthorityStateVersion = document.StateVersion,
             CatalogLastEventId = document.LastEventId ?? string.Empty,

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogReadModelEntry.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogReadModelEntry.cs
@@ -30,6 +30,7 @@ public sealed class UserAgentCatalogReadModelEntry
     public string LarkReceiveIdType { get; init; } = string.Empty;
     public string LarkReceiveIdFallback { get; init; } = string.Empty;
     public string LarkReceiveIdTypeFallback { get; init; } = string.Empty;
+    public SkillRunnerOutputFormat OutputFormat { get; init; } = SkillRunnerOutputFormat.Auto;
     public OwnerScope? OwnerScope { get; init; }
     public long CatalogAuthorityStateVersion { get; init; }
     public string CatalogLastEventId { get; init; } = string.Empty;

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentDeliveryTargetReader.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentDeliveryTargetReader.cs
@@ -65,6 +65,7 @@ public sealed class UserAgentDeliveryTargetReader : IUserAgentDeliveryTargetRead
             LarkReceiveIdType: document.LarkReceiveIdType ?? string.Empty,
             LarkReceiveIdFallback: document.LarkReceiveIdFallback ?? string.Empty,
             LarkReceiveIdTypeFallback: document.LarkReceiveIdTypeFallback ?? string.Empty,
+            OutputFormat: document.OutputFormat,
             TemplateName: document.TemplateName ?? string.Empty,
             AgentType: document.AgentType ?? string.Empty);
     }

--- a/agents/Aevatar.GAgents.Scheduled/protos/skill_runner.proto
+++ b/agents/Aevatar.GAgents.Scheduled/protos/skill_runner.proto
@@ -20,6 +20,12 @@ enum SkillRunnerExecutionKind {
   SKILL_RUNNER_EXECUTION_KIND_WORKFLOW = 2;
 }
 
+enum SkillRunnerOutputFormat {
+  SKILL_RUNNER_OUTPUT_FORMAT_AUTO = 0;
+  SKILL_RUNNER_OUTPUT_FORMAT_TEXT = 1;
+  SKILL_RUNNER_OUTPUT_FORMAT_FEISHU_DOC = 2;
+}
+
 enum SkillRunnerExecutionErrorCode {
   SKILL_RUNNER_EXECUTION_ERROR_CODE_UNSPECIFIED = 0;
   SKILL_RUNNER_EXECUTION_ERROR_CODE_SKILL_REFERENCE_REQUIRED = 1;
@@ -121,6 +127,7 @@ message SkillRunnerOutboundConfig {
   // SkillRunnerGAgent.TrySendFailureAsync attempts the failure-notification
   // slug FIRST when set, then falls back to the primary slug.
   string failure_notification_provider_slug = 12;
+  SkillRunnerOutputFormat output_format = 13;
 }
 
 message SkillRunnerState {
@@ -194,6 +201,7 @@ message InitializeSkillRunnerCommand {
   bool requires_nyxid_proxy_success = 16;
   SkillRunnerSkillReference skill_ref = 17;
   repeated ExternalTriggerSource external_trigger_sources = 18;
+  SkillRunnerOutputFormat output_format = 19;
 }
 
 message SkillRunnerInitializedEvent {

--- a/agents/Aevatar.GAgents.Scheduled/protos/user_agent_catalog.proto
+++ b/agents/Aevatar.GAgents.Scheduled/protos/user_agent_catalog.proto
@@ -6,6 +6,7 @@ option csharp_namespace = "Aevatar.GAgents.Scheduled";
 
 import "google/protobuf/timestamp.proto";
 import "agent_messages.proto";
+import "skill_runner.proto";
 
 // Refactor (iter91/cluster-091-owner-scope-foundation):
 //   Old: this proto declared OwnerScope locally even though the tuple is foundational caller identity.
@@ -65,6 +66,7 @@ message UserAgentCatalogEntry {
   // the deprecated platform/owner_nyx_user_id fields are kept readable for
   // legacy state (issue #466 migration plan).
   aevatar.OwnerScope owner_scope = 26;
+  SkillRunnerOutputFormat output_format = 27;
 }
 
 message UserAgentCatalogState {
@@ -97,6 +99,7 @@ message UserAgentCatalogUpsertCommand {
   string lark_receive_id_type_fallback = 17;
   // Caller scope captured at create time. Required for new writes.
   aevatar.OwnerScope owner_scope = 18;
+  SkillRunnerOutputFormat output_format = 19;
 }
 
 message UserAgentCatalogTombstoneCommand {
@@ -162,6 +165,7 @@ message UserAgentCatalogDocument {
   aevatar.OwnerScope owner_scope = 28;
   reserved 29, 30, 31, 32;
   reserved "catalog_source_version", "catalog_last_event_id", "runner_source_version", "runner_last_event_id";
+  SkillRunnerOutputFormat output_format = 33;
 }
 
 // Runtime-only Nyx credential read model for delivery-target execution paths.

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderCardFlowTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderCardFlowTests.cs
@@ -255,6 +255,7 @@ public sealed class AgentBuilderCardFlowTests
                   "agent_id": "skill-runner-94d754dfdfbb416aa5a676cecd0d7a71",
                   "template": "legacy-template",
                   "status": "running",
+                  "output_format": "text",
                   "next_scheduled_run": "2026-04-23T09:00:00Z",
                   "last_run_at": "2026-04-22T09:00:00Z"
                 }
@@ -269,6 +270,7 @@ public sealed class AgentBuilderCardFlowTests
         card.Text.Should().Contain("legacy-template");
         card.Text.Should().Contain("skill-runner-94d754dfdfbb416aa5a676cecd0d7a71");
         card.Text.Should().Contain("running");
+        card.Text.Should().Contain("Output: `text`");
         card.Text.Should().Contain("/agent-status <id>");
         card.Text.Should().Contain("/run-agent <id>");
         card.Text.Should().Contain("/delete-agent <id> confirm");
@@ -368,6 +370,7 @@ public sealed class AgentBuilderCardFlowTests
               "status": "running",
               "schedule_cron": "0 9 * * *",
               "schedule_timezone": "UTC",
+              "output_format": "feishu_doc",
               "last_run_at": "2026-04-25T05:30:00Z",
               "next_scheduled_run": "2026-04-26T09:00:00Z",
               "error_count": "0"
@@ -377,6 +380,7 @@ public sealed class AgentBuilderCardFlowTests
         result.Text.Should().BeNullOrEmpty();
         result.Cards.Should().ContainSingle(card => card.BlockId == "agent_status:skill-runner-1");
         result.Cards.Single().Text.Should().Contain("Status: `running`");
+        result.Cards.Single().Text.Should().Contain("Output: `feishu_doc`");
         // Lifecycle buttons render as actions, not as embedded JSON in MessageContent.Text.
         result.Actions.Should().Contain(a => a.ActionId == "run_agent");
         result.Actions.Should().Contain(a => a.ActionId == "disable_agent");

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -362,6 +362,7 @@ public sealed class AgentBuilderToolTests
                 AgentId = "skill-runner-join",
                 AgentType = SkillRunnerDefaults.AgentType,
                 TemplateName = "summary",
+                OutputFormat = SkillRunnerOutputFormat.FeishuDoc,
                 Status = string.Empty,
                 ErrorCount = 0,
                 CatalogAuthorityStateVersion = 7,
@@ -408,6 +409,7 @@ public sealed class AgentBuilderToolTests
             using var doc = JsonDocument.Parse(result);
             doc.RootElement.GetProperty("agent_id").GetString().Should().Be("skill-runner-join");
             doc.RootElement.GetProperty("status").GetString().Should().Be(SkillRunnerDefaults.StatusError);
+            doc.RootElement.GetProperty("output_format").GetString().Should().Be("feishu_doc");
             doc.RootElement.GetProperty("error_count").GetInt32().Should().Be(2);
             doc.RootElement.GetProperty("last_error").GetString().Should().Be("tool failed");
 
@@ -437,6 +439,7 @@ public sealed class AgentBuilderToolTests
                     AgentId = "skill-runner-list",
                     AgentType = SkillRunnerDefaults.AgentType,
                     TemplateName = "summary",
+                    OutputFormat = SkillRunnerOutputFormat.Text,
                 },
             ]));
 
@@ -481,6 +484,7 @@ public sealed class AgentBuilderToolTests
             var agent = doc.RootElement.GetProperty("agents").EnumerateArray().Should().ContainSingle().Subject;
             agent.GetProperty("agent_id").GetString().Should().Be("skill-runner-list");
             agent.GetProperty("status").GetString().Should().Be(SkillRunnerDefaults.StatusRunning);
+            agent.GetProperty("output_format").GetString().Should().Be("text");
             agent.GetProperty("error_count").GetInt32().Should().Be(1);
 
             await queryPort.Received(1).QueryByCallerAsync(

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/FeishuCardHumanInteractionPortTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/FeishuCardHumanInteractionPortTests.cs
@@ -30,6 +30,7 @@ public sealed class FeishuCardHumanInteractionPortTests
                 LarkReceiveIdType: string.Empty,
                 LarkReceiveIdFallback: string.Empty,
                 LarkReceiveIdTypeFallback: string.Empty,
+                OutputFormat: SkillRunnerOutputFormat.Auto,
                 TemplateName: "social_media",
                 AgentType: string.Empty)));
 
@@ -98,6 +99,7 @@ public sealed class FeishuCardHumanInteractionPortTests
                 LarkReceiveIdType: "chat_id",
                 LarkReceiveIdFallback: "on_user_1",
                 LarkReceiveIdTypeFallback: "union_id",
+                OutputFormat: SkillRunnerOutputFormat.Auto,
                 TemplateName: "social_media",
                 AgentType: string.Empty)));
 
@@ -157,6 +159,7 @@ public sealed class FeishuCardHumanInteractionPortTests
                 LarkReceiveIdType: string.Empty,
                 LarkReceiveIdFallback: string.Empty,
                 LarkReceiveIdTypeFallback: string.Empty,
+                OutputFormat: SkillRunnerOutputFormat.Auto,
                 TemplateName: string.Empty,
                 AgentType: string.Empty)));
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentCreatorToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentCreatorToolTests.cs
@@ -37,6 +37,9 @@ public sealed class ScheduledAgentCreatorToolTests
         properties.TryGetProperty("allowed_service_ids", out _).Should().BeFalse();
         properties.TryGetProperty("skill_content", out _).Should().BeFalse();
         properties.TryGetProperty("provider_base_url", out _).Should().BeFalse();
+        properties.TryGetProperty("output_format", out var outputFormat).Should().BeTrue();
+        outputFormat.GetProperty("enum").EnumerateArray().Select(static x => x.GetString())
+            .Should().BeEquivalentTo("auto", "text", "feishu_doc");
         properties.TryGetProperty("external_trigger_sources", out var externalSources).Should().BeTrue();
         externalSources.GetProperty("items").GetProperty("properties")
             .GetProperty("kind")
@@ -95,6 +98,34 @@ public sealed class ScheduledAgentCreatorToolTests
 
             using var document = JsonDocument.Parse(result);
             document.RootElement.GetProperty("error").GetString().Should().Be("validation_error");
+            harness.Handler.Requests.Should().BeEmpty();
+            await harness.SkillRunnerPort.DidNotReceive().InitializeAsync(
+                Arg.Any<string>(),
+                Arg.Any<InitializeSkillRunnerCommand>(),
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>());
+        });
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_InvalidOutputFormat_ShouldFailBeforeKeyCreation()
+    {
+        var harness = CreateHarness();
+
+        await WithToolContext(async () =>
+        {
+            var result = await harness.Tool.ExecuteAsync("""
+                {
+                  "skill_ref": "daily",
+                  "schedule_cron": "0 9 * * *",
+                  "schedule_timezone": "UTC",
+                  "output_format": "pdf"
+                }
+                """);
+
+            using var document = JsonDocument.Parse(result);
+            document.RootElement.GetProperty("error").GetString().Should().Be("validation_error");
+            document.RootElement.GetProperty("detail").GetString().Should().Contain("output_format");
             harness.Handler.Requests.Should().BeEmpty();
             await harness.SkillRunnerPort.DidNotReceive().InitializeAsync(
                 Arg.Any<string>(),
@@ -328,6 +359,7 @@ public sealed class ScheduledAgentCreatorToolTests
                   "max_tool_rounds": 6,
                   "max_history_messages": 12,
                   "requires_nyxid_proxy_success": true,
+                  "output_format": "feishu_doc",
                   "external_trigger_sources": [
                     {
                       "source_id": " webhook-main ",
@@ -374,6 +406,7 @@ public sealed class ScheduledAgentCreatorToolTests
             captured.MaxToolRounds.Should().Be(6);
             captured.MaxHistoryMessages.Should().Be(12);
             captured.RequiresNyxidProxySuccess.Should().BeTrue();
+            captured.OutputFormat.Should().Be(SkillRunnerOutputFormat.FeishuDoc);
             captured.ExternalTriggerSources.Should().HaveCount(2);
             captured.ExternalTriggerSources[0].SourceId.Should().Be("webhook-main");
             captured.ExternalTriggerSources[0].Kind.Should().Be(ExternalTriggerSourceKind.Webhook);
@@ -391,6 +424,7 @@ public sealed class ScheduledAgentCreatorToolTests
             captured.OutboundConfig.LarkReceiveIdType.Should().Be("chat_id");
             captured.OutboundConfig.LarkReceiveIdFallback.Should().Be("on_union");
             captured.OutboundConfig.LarkReceiveIdTypeFallback.Should().Be("union_id");
+            captured.OutboundConfig.OutputFormat.Should().Be(SkillRunnerOutputFormat.FeishuDoc);
             captured.OutboundConfig.OwnerScope.MatchesStrictly(caller).Should().BeTrue();
             captured.OutboundConfig.OwnerNyxUserId.Should().BeEmpty();
             captured.OutboundConfig.Platform.Should().BeEmpty();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -104,6 +104,20 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task HandleInitializeAsync_ShouldPersistOutputFormatIntoOutboundConfig()
+    {
+        var command = CreateInitializeCommand();
+        command.OutputFormat = SkillRunnerOutputFormat.FeishuDoc;
+
+        await _agent.HandleInitializeAsync(command);
+
+        var persisted = await _store.GetEventsAsync("skill-runner-test");
+        var initialized = persisted.Should().ContainSingle().Subject.EventData.Unpack<SkillRunnerInitializedEvent>();
+        initialized.OutboundConfig.OutputFormat.Should().Be(SkillRunnerOutputFormat.FeishuDoc);
+        _agent.State.OutboundConfig.OutputFormat.Should().Be(SkillRunnerOutputFormat.FeishuDoc);
+    }
+
+    [Fact]
     public async Task HandleInitializeAsync_WithSkillRefOnly_ShouldPersistTypedReferenceAndNoInlineContent()
     {
         var command = CreateInitializeCommand();
@@ -823,6 +837,7 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
 
         var ownerScope = OwnerScope.ForNyxIdNative("user-1");
         var initialize = CreateInitializeCommand();
+        initialize.OutputFormat = SkillRunnerOutputFormat.Text;
         initialize.OutboundConfig.OwnerScope = ownerScope;
 #pragma warning disable CS0612 // stale legacy fields must not be emitted when owner_scope exists
         initialize.OutboundConfig.Platform = "nyxid";
@@ -836,6 +851,7 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         var command = captured[0].Payload.Unpack<UserAgentCatalogUpsertCommand>();
         command.OwnerScope.Should().NotBeNull();
         command.OwnerScope!.MatchesStrictly(ownerScope).Should().BeTrue();
+        command.OutputFormat.Should().Be(SkillRunnerOutputFormat.Text);
 #pragma warning disable CS0612
         command.Platform.Should().BeEmpty();
         command.OwnerNyxUserId.Should().BeEmpty();
@@ -1858,7 +1874,7 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task ExecuteSkillAsync_OverLimitOutput_ShouldUseDocxDecisionReply_WhenLinkReturned()
+    public async Task ExecuteSkillAsync_AutoOverLimitOutput_ShouldUseDocxDecisionReply_WhenLinkReturned()
     {
         var output = new string('x', SkillRunnerStreamingReplySink.MaxLarkTextLength + 100);
         var provider = new StubStreamingProviderFactory(
@@ -1907,6 +1923,89 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
             .Should().BeTrue();
         handler.Requests.Should().ContainSingle();
         ExtractLarkText(handler.Bodies[0]!).Should().Be("Full output moved to https://example.feishu.cn/docx/doccn_123");
+    }
+
+    [Fact]
+    public async Task ExecuteSkillAsync_FeishuDocOutputFormat_ShouldUseDocxDecisionReply_EvenWhenOutputFitsText()
+    {
+        var output = "short scheduled report";
+        var provider = new StubStreamingProviderFactory(
+            new StubStreamingTurn([output]),
+            new StubStreamingTurn(
+                [],
+                [
+                    new ToolCall
+                    {
+                        Id = "call-docx",
+                        Name = "lark_docx_create",
+                        ArgumentsJson = "{}",
+                    },
+                ]),
+            new StubStreamingTurn(["Full output moved to https://example.feishu.cn/docx/doccn_forced"]));
+        var handler = new SequencedHandler("""{"code":0,"msg":"success","data":{"message_id":"om_doc_link"}}""");
+        var docxTool = new FixedResultTool(
+            "lark_docx_create",
+            """{"success":true,"document_token":"doccn_forced","document_url":"https://example.feishu.cn/docx/doccn_forced","visibility_applied":true}""");
+        var agent = CreateAgent(
+            "skill-runner-docx-forced",
+            providerFactory: provider,
+            toolSources: [new SingleToolSource(docxTool)]);
+        await agent.ActivateAsync();
+        var initialize = CreateInitializeCommand();
+        initialize.OutputFormat = SkillRunnerOutputFormat.FeishuDoc;
+        initialize.OutboundConfig.OutputFormat = SkillRunnerOutputFormat.FeishuDoc;
+        initialize.OutboundConfig.LarkReceiveId = "oc_chat_1";
+        initialize.OutboundConfig.LarkReceiveIdType = "chat_id";
+        await agent.HandleInitializeAsync(initialize);
+        AttachNyxIdApiClient(agent, handler);
+
+        var result = await InvokeExecuteSkillAsync(agent);
+
+        result.Should().Be(output);
+        provider.Requests.Should().ContainSingle("FEISHU_DOC mode should create the document by direct tool execution, not by a second LLM decision round");
+        docxTool.LastArgumentsJson.Should().NotBeNull();
+        using (var arguments = JsonDocument.Parse(docxTool.LastArgumentsJson!))
+        {
+            arguments.RootElement.GetProperty("title").GetString().Should().Be("summary");
+            arguments.RootElement.GetProperty("markdown_text").GetString().Should().Be(output);
+            arguments.RootElement.GetProperty("visibility").GetString().Should().Be("readable");
+        }
+        docxTool.LastContext.Should().NotBeNull();
+        docxTool.LastContext!.Request.RequestId.Should().EndWith(":lark-docx");
+        docxTool.LastContext.ExternalMetadata.Should().Contain(ChannelMetadataKeys.LarkReceiveId, "oc_chat_1");
+        docxTool.LastContext.ExternalMetadata.Should().Contain(ChannelMetadataKeys.LarkReceiveIdType, "chat_id");
+        handler.Requests.Should().ContainSingle();
+        ExtractLarkText(handler.Bodies[0]!).Should().Be("Full output moved to https://example.feishu.cn/docx/doccn_forced");
+    }
+
+    [Fact]
+    public async Task ExecuteSkillAsync_TextOutputFormat_ShouldChunkLongOutput_AndSkipDocDecision()
+    {
+        var output = string.Join("\n\n", Enumerable.Repeat(
+            new string('x', SkillRunnerStreamingReplySink.MaxLarkTextLength - 1_000),
+            2));
+        var expectedChunks = SkillRunnerOutputChunker.Split(output);
+        var provider = new StubStreamingProviderFactory(new StubStreamingTurn([output]));
+        var handler = new SequencedHandler(
+            """{"code":0,"msg":"success","data":{"message_id":"om_part_1"}}""",
+            """{"code":0,"msg":"success","data":{"message_id":"om_part_2"}}""");
+        var agent = CreateAgent("skill-runner-text-forced", providerFactory: provider);
+        await agent.ActivateAsync();
+        var initialize = CreateInitializeCommand();
+        initialize.OutputFormat = SkillRunnerOutputFormat.Text;
+        initialize.OutboundConfig.OutputFormat = SkillRunnerOutputFormat.Text;
+        initialize.OutboundConfig.LarkReceiveId = "oc_chat_1";
+        initialize.OutboundConfig.LarkReceiveIdType = "chat_id";
+        await agent.HandleInitializeAsync(initialize);
+        AttachNyxIdApiClient(agent, handler);
+
+        var result = await InvokeExecuteSkillAsync(agent);
+
+        result.Should().Be(output);
+        provider.Requests.Should().ContainSingle("text mode must not spend a second LLM/tool round deciding doc creation");
+        handler.Requests.Should().HaveCount(expectedChunks.Count);
+        ExtractLarkText(handler.Bodies[0]!).Should().Be(expectedChunks[0]);
+        ExtractLarkText(handler.Bodies[1]!).Should().Be(expectedChunks[1]);
     }
 
     [Fact]
@@ -2502,8 +2601,15 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         public string Description => "Fixed result test tool";
         public string ParametersSchema => "{}";
         public ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;
-        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
-            Task.FromResult(result);
+        public string? LastArgumentsJson { get; private set; }
+        public AgentToolExecutionContext? LastContext { get; private set; }
+
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+        {
+            LastArgumentsJson = argumentsJson;
+            LastContext = AgentToolRequestContext.Current;
+            return Task.FromResult(result);
+        }
     }
 
     private sealed class SequencedRemoteSkillFetcher(params SkillDefinition?[] skills) : IRemoteSkillFetcher

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentCatalogGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentCatalogGAgentTests.cs
@@ -133,6 +133,26 @@ public sealed class UserAgentCatalogGAgentTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task HandleUpsertAsync_PartialUpsertWithDefaultOutputFormat_PreservesExistingFormat()
+    {
+        await _agent.HandleUpsertAsync(new UserAgentCatalogUpsertCommand
+        {
+            AgentId = "format-agent",
+            ConversationId = "oc_chat_1",
+            OutputFormat = SkillRunnerOutputFormat.FeishuDoc,
+        });
+
+        await _agent.HandleUpsertAsync(new UserAgentCatalogUpsertCommand
+        {
+            AgentId = "format-agent",
+            ScheduleCron = "0 9 * * *",
+        });
+
+        _agent.State.Entries.Should().ContainSingle();
+        _agent.State.Entries[0].OutputFormat.Should().Be(SkillRunnerOutputFormat.FeishuDoc);
+    }
+
+    [Fact]
     public async Task HandleCompactTombstonesAsync_RemovesOnlyWatermarkSafeEntries()
     {
         await _agent.HandleUpsertAsync(new UserAgentCatalogUpsertCommand

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentCatalogProjectorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentCatalogProjectorTests.cs
@@ -54,6 +54,7 @@ public sealed class UserAgentCatalogProjectorTests
                     LarkReceiveIdType = "chat_id",
                     LarkReceiveIdFallback = "on_user_1",
                     LarkReceiveIdTypeFallback = "union_id",
+                    OutputFormat = SkillRunnerOutputFormat.FeishuDoc,
                 },
             },
         };
@@ -89,6 +90,7 @@ public sealed class UserAgentCatalogProjectorTests
         document.LarkReceiveIdType.Should().Be("chat_id");
         document.LarkReceiveIdFallback.Should().Be("on_user_1");
         document.LarkReceiveIdTypeFallback.Should().Be("union_id");
+        document.OutputFormat.Should().Be(SkillRunnerOutputFormat.FeishuDoc);
     }
 
     [Fact]
@@ -203,6 +205,7 @@ public sealed class UserAgentCatalogProjectorTests
             LarkReceiveIdType = "chat_id",
             LarkReceiveIdFallback = "on_user_1",
             LarkReceiveIdTypeFallback = "union_id",
+            OutputFormat = SkillRunnerOutputFormat.Text,
         };
 
         var entry = UserAgentCatalogQueryPort.ToEntry(document);
@@ -211,6 +214,7 @@ public sealed class UserAgentCatalogProjectorTests
         entry.LarkReceiveIdType.Should().Be("chat_id");
         entry.LarkReceiveIdFallback.Should().Be("on_user_1");
         entry.LarkReceiveIdTypeFallback.Should().Be("union_id");
+        entry.OutputFormat.Should().Be(SkillRunnerOutputFormat.Text);
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentDeliveryTargetReaderTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentDeliveryTargetReaderTests.cs
@@ -20,6 +20,7 @@ public sealed class UserAgentDeliveryTargetReaderTests
                 Id = "agent-1",
                 ConversationId = "oc_chat_1",
                 NyxProviderSlug = "api-lark-bot",
+                OutputFormat = SkillRunnerOutputFormat.Text,
             });
         credentialReader.GetAsync("agent-1", Arg.Any<CancellationToken>())
             .Returns(new UserAgentCatalogNyxCredentialDocument
@@ -35,6 +36,7 @@ public sealed class UserAgentDeliveryTargetReaderTests
         target.Should().NotBeNull();
         target!.NyxApiKey.Should().Be("live-key");
         target.ConversationId.Should().Be("oc_chat_1");
+        target.OutputFormat.Should().Be(SkillRunnerOutputFormat.Text);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #1847 — part of epic #1848 (Lark NL → auto-skill → negotiate → 24×7).

## What
User-selectable **output format** for scheduled Ornn-skill runs: plain text vs Feishu cloud doc (previously only an automatic length-trigger).

- `skill_runner.proto`: new `SkillRunnerOutputFormat` enum (AUTO/TEXT/FEISHU_DOC) on `SkillRunnerOutboundConfig` + `InitializeSkillRunnerCommand`.
- `scheduled_agent_creator` schema gains optional `output_format`; mapped via `ScheduledAgentCreateRequestMapper`.
- `SkillRunnerGAgent` output branches on it: FEISHU_DOC → always a Feishu doc + link; TEXT → always chunked text; AUTO → existing length-based behavior.
- `user_agent_catalog` proto + projector + readers + delivery-target reader carry/show `output_format`.

## Verified
- builds: Scheduled + Authoring.Lark + ChannelRuntime.Tests projects.
- `dotnet test ChannelRuntime.Tests`: **1085/1085 pass**.
- test_stability_guards + query/projection/state-version guards pass; `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

⟦AI:AUTO-LOOP⟧
