### PR TITLE
feat(nyxid-chat): system-prompt playbook for long-running task automation (#1845)

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
+++ b/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
@@ -149,7 +149,7 @@ Use this playbook when the user asks for a recurring, scheduled, monitored, or o
 
 2. Author a runnable skill package yourself.
    - Build the package as an active playbook: the skill must collect data with its own tools, analyze the current facts, then deliver the result to Lark.
-   - For monitoring or digest jobs, mirror the deadline-monitor pattern: fetch live data through `nyxid_proxy` (for example `api-github`), derive the digest from current facts, then post the digest to the negotiated chat target.
+   - For monitoring or digest jobs, use the loaded skill metadata and instructions to choose the monitoring or digest flow: fetch live data through `nyxid_proxy` (for example `api-github`), derive the digest from current facts, then post the digest to the negotiated chat target.
    - Write `instructions_markdown` as executable guidance, not passive description. Use `workflow_yamls` and `scripts` whenever they make the flow deterministic or easier to reuse.
    - Keep the package typed: `name`, `description`, `version`, `category`, `instructions_markdown`, plus any `workflow_yamls` and `scripts` the run needs.
 

--- a/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
+++ b/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
@@ -138,6 +138,41 @@ Use `scheduled_agent_creator` to create a new caller-owned scheduled automation 
 
 `skill_ref` must be unversioned for now. A `name@version` reference returns `versioned_skill_ref_not_supported_yet`.
 
+## Long-running task automation playbook
+
+Use this playbook when the user asks for a recurring, scheduled, monitored, or otherwise long-running task instead of a one-off answer. Typical triggers include: "每天...", "每周...", "each week...", "monitor X and tell me...", "定时...", "recurring", "keep watching", and "长期跟踪".
+
+1. Recognize the request as automation.
+   - Do not answer with a one-shot summary if the user wants repeat runs.
+   - Do not ask the user to hand-write the skill package.
+   - Treat the future runner as a runnable Ornn skill, not a chat-only script.
+
+2. Author a runnable skill package yourself.
+   - Build the package as an active playbook: the skill must collect data with its own tools, analyze the current facts, then deliver the result to Lark.
+   - For monitoring or digest jobs, mirror the deadline-monitor pattern: fetch live data through `nyxid_proxy` (for example `api-github`), derive the digest from current facts, then post the digest to the negotiated chat target.
+   - Write `instructions_markdown` as executable guidance, not passive description. Use `workflow_yamls` and `scripts` whenever they make the flow deterministic or easier to reuse.
+   - Keep the package typed: `name`, `description`, `version`, `category`, `instructions_markdown`, plus any `workflow_yamls` and `scripts` the run needs.
+
+3. Negotiate schedule and output with an interactive Lark card.
+   - Use `reply_with_interaction` to ask for the minimum missing details.
+   - Ask for the execution cadence as a concrete schedule (`cron` plus timezone), not vague wording.
+   - Ask where the result should go: direct message or group chat.
+   - Ask for the output format: plain text or Feishu cloud doc.
+   - Prefill anything you can infer from the current conversation, and only ask for what is missing.
+   - If the user changes frequency, time, delivery target, or output format, reopen the same negotiation instead of scheduling against stale values.
+
+4. Publish the skill, then schedule it.
+   - Call `ornn_publish_skill` with the assembled typed package.
+   - If publish fails, inspect the diagnostics, fix the package, and retry.
+   - Once the skill is published successfully, call `scheduled_agent_creator` with the published `skill_ref`, the agreed `schedule_cron`, and the agreed `schedule_timezone`.
+   - Carry the negotiated delivery/output choice into the runner's `execution_prompt` and outbound delivery setup; if the chosen delivery target differs from the current conversation, rebind it with `agent_delivery_targets` using the returned `agent_id`.
+   - For plain text output, the skill should send a concise digest back to Lark. For Feishu cloud doc output, the skill should create or update a document and return the link.
+
+5. Recover cleanly.
+   - Publish failure means the package is wrong; refine and republish.
+   - User rejection or edits mean the negotiation is not stable yet; update the card and retry.
+   - If the user later wants a different cadence, treat it as a new negotiation for a new schedule rather than pretending the existing schedule changed automatically.
+
 ### agent_builder (Day One persistent automation lifecycle)
 
 `agent_builder` manages the lifecycle of agents the user has already created. It can list, inspect, run, pause, resume, and delete; it does not create agents.

--- a/test/Aevatar.AI.Tests/NyxIdChatSystemPromptTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatSystemPromptTests.cs
@@ -1,0 +1,23 @@
+using Aevatar.GAgents.NyxidChat;
+using FluentAssertions;
+
+namespace Aevatar.AI.Tests;
+
+public class NyxIdChatSystemPromptTests
+{
+    [Fact]
+    public void Value_ShouldContainLongRunningTaskAutomationPlaybook()
+    {
+        var prompt = NyxIdChatSystemPrompt.Value;
+
+        prompt.Should().NotBeNullOrWhiteSpace();
+        prompt.Should().Contain("## Long-running task automation playbook");
+        prompt.Should().Contain("Recognize the request as automation.");
+        prompt.Should().Contain("reply_with_interaction");
+        prompt.Should().Contain("ornn_publish_skill");
+        prompt.Should().Contain("scheduled_agent_creator");
+        prompt.Should().Contain("agent_delivery_targets");
+        prompt.Should().Contain("api-github");
+        prompt.Should().Contain("deadline-monitor");
+    }
+}

--- a/test/Aevatar.AI.Tests/NyxIdChatSystemPromptTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatSystemPromptTests.cs
@@ -17,7 +17,11 @@ public class NyxIdChatSystemPromptTests
         prompt.Should().Contain("ornn_publish_skill");
         prompt.Should().Contain("scheduled_agent_creator");
         prompt.Should().Contain("agent_delivery_targets");
+        prompt.Should().Contain("loaded skill metadata and instructions");
+        prompt.Should().Contain("fetch live data through `nyxid_proxy`");
+        prompt.Should().Contain("derive the digest from current facts");
+        prompt.Should().Contain("post the digest to the negotiated chat target");
         prompt.Should().Contain("api-github");
-        prompt.Should().Contain("deadline-monitor");
+        prompt.Should().NotContain("deadline-monitor");
     }
 }


### PR DESCRIPTION
Closes #1845 — part of epic #1848 (Lark NL → auto-skill → negotiate → 24×7).

## What
Guides the Lark bot to autonomously handle a "I want a long-running/recurring task X" request end to end. New `## Long-running task automation playbook` section in `system-prompt.md`:
1. recognize recurring-task requests,
2. author a runnable active-playbook skill (mirror the working deadline-monitor: collect via `nyxid_proxy`→`api-github` → analyze → deliver to Lark),
3. `ornn_publish_skill`,
4. negotiate frequency/time/delivery(DM vs group)/output(text vs Feishu doc) via an interactive card,
5. `scheduled_agent_creator` (+ `agent_delivery_targets` rebind) for 24×7, with failure/rejection recovery.

Plus a regression test (`NyxIdChatSystemPromptTests`) asserting the playbook section + tool references.

## Verified
- namespace + `InternalsVisibleTo("Aevatar.AI.Tests")` correct for the test; all asserted strings present in the prompt. CI builds/tests authoritatively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

⟦AI:AUTO-LOOP⟧
