### PR TITLE
Add Orleans reminder workflow schedule wakeups

### DIFF
--- a/src/Aevatar.Foundation.Runtime.Implementations.Orleans.Streaming/Streaming/Topology/StreamTopologyGrain.cs
+++ b/src/Aevatar.Foundation.Runtime.Implementations.Orleans.Streaming/Streaming/Topology/StreamTopologyGrain.cs
@@ -1,5 +1,6 @@
 using Aevatar.Foundation.Abstractions.Streaming;
 using Orleans.Runtime;
+using Orleans.Storage;
 
 namespace Aevatar.Foundation.Runtime.Implementations.Orleans.Streaming.Topology;
 
@@ -7,6 +8,8 @@ public sealed class StreamTopologyGrain(
     [PersistentState("stream-topology", OrleansRuntimeConstants.GrainStateStorageName)]
     IPersistentState<StreamTopologyGrainState> state) : Grain, IStreamTopologyGrain
 {
+    private const int MaxStorageWriteAttempts = 3;
+
     private IReadOnlyList<StreamForwardingBindingEntry> _readSnapshot = Array.Empty<StreamForwardingBindingEntry>();
     private bool _initialized;
 
@@ -22,31 +25,15 @@ public sealed class StreamTopologyGrain(
         ArgumentException.ThrowIfNullOrWhiteSpace(binding.SourceStreamId);
         ArgumentException.ThrowIfNullOrWhiteSpace(binding.TargetStreamId);
 
-        EnsureInitialized();
         var entry = CloneEntry(binding);
-        if (state.State.BindingsByTarget.TryGetValue(binding.TargetStreamId, out var existing) &&
-            EntryEquals(existing, entry))
-        {
-            return;
-        }
-
-        state.State.BindingsByTarget[binding.TargetStreamId] = entry;
-        state.State.Revision++;
-        RebuildReadSnapshot();
-        await state.WriteStateAsync();
+        await WriteWithConflictRetryAsync(() => UpsertEntry(entry));
     }
 
     public async Task RemoveAsync(string targetStreamId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(targetStreamId);
 
-        EnsureInitialized();
-        if (!state.State.BindingsByTarget.Remove(targetStreamId))
-            return;
-
-        state.State.Revision++;
-        RebuildReadSnapshot();
-        await state.WriteStateAsync();
+        await WriteWithConflictRetryAsync(() => RemoveEntry(targetStreamId));
     }
 
     public Task<IReadOnlyList<StreamForwardingBindingEntry>> ListAsync()
@@ -63,14 +50,64 @@ public sealed class StreamTopologyGrain(
 
     public async Task ClearAsync()
     {
+        await WriteWithConflictRetryAsync(ClearEntries);
+    }
+
+    private async Task WriteWithConflictRetryAsync(Func<bool> applyMutation)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            if (!applyMutation())
+                return;
+
+            RebuildReadSnapshot();
+
+            try
+            {
+                await state.WriteStateAsync();
+                return;
+            }
+            catch (InconsistentStateException) when (attempt < MaxStorageWriteAttempts)
+            {
+                await state.ReadStateAsync();
+                _initialized = false;
+            }
+        }
+    }
+
+    private bool UpsertEntry(StreamForwardingBindingEntry entry)
+    {
+        EnsureInitialized();
+        if (state.State.BindingsByTarget.TryGetValue(entry.TargetStreamId, out var existing) &&
+            EntryEquals(existing, entry))
+        {
+            return false;
+        }
+
+        state.State.BindingsByTarget[entry.TargetStreamId] = CloneEntry(entry);
+        state.State.Revision++;
+        return true;
+    }
+
+    private bool RemoveEntry(string targetStreamId)
+    {
+        EnsureInitialized();
+        if (!state.State.BindingsByTarget.Remove(targetStreamId))
+            return false;
+
+        state.State.Revision++;
+        return true;
+    }
+
+    private bool ClearEntries()
+    {
         EnsureInitialized();
         if (state.State.BindingsByTarget.Count == 0)
-            return;
+            return false;
 
         state.State.BindingsByTarget.Clear();
         state.State.Revision++;
-        RebuildReadSnapshot();
-        await state.WriteStateAsync();
+        return true;
     }
 
     private void EnsureInitialized()

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Aevatar.Workflow.Application.Abstractions.csproj
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Aevatar.Workflow.Application.Abstractions.csproj
@@ -21,5 +21,6 @@
   <ItemGroup>
     <Protobuf Include="Queries/workflow_projection_query_models.proto" GrpcServices="None" />
     <Protobuf Include="Runs/workflow_run_events.proto" GrpcServices="None" />
+    <Protobuf Include="Schedules/workflow_schedule_events.proto" GrpcServices="None" />
   </ItemGroup>
 </Project>

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Schedules/WorkflowScheduleModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Schedules/WorkflowScheduleModels.cs
@@ -1,0 +1,175 @@
+using Aevatar.Workflow.Application.Abstractions.Runs;
+
+namespace Aevatar.Workflow.Application.Abstractions.Schedules;
+
+public enum WorkflowScheduleStatus
+{
+    Disabled = 0,
+    Enabled = 1,
+}
+
+public enum WorkflowScheduleFireStatus
+{
+    Accepted = 0,
+    Duplicate = 1,
+    Rejected = 2,
+}
+
+public sealed record WorkflowScheduleTarget(
+    string Prompt,
+    WorkflowChatSource Source,
+    string? SessionId = null,
+    IReadOnlyList<WorkflowChatInputPart>? InputParts = null,
+    IReadOnlyDictionary<string, string>? Annotations = null,
+    string? ScopeId = null,
+    IReadOnlyDictionary<string, string>? Headers = null);
+
+public sealed record WorkflowScheduleDefinition(
+    string ScheduleId,
+    string Name,
+    string Cron,
+    string Timezone,
+    WorkflowScheduleStatus Status,
+    WorkflowScheduleTarget Target,
+    DateTimeOffset CreatedAtUtc,
+    DateTimeOffset UpdatedAtUtc,
+    DateTimeOffset? NextFireAtUtc,
+    WorkflowScheduleWakeupLease? WakeupLease = null);
+
+public sealed record WorkflowScheduleWakeupLease(
+    string ActorId,
+    string CallbackId,
+    long Generation,
+    WorkflowScheduleWakeupBackend Backend,
+    int SlotEpoch);
+
+public enum WorkflowScheduleWakeupBackend
+{
+    InMemory = 0,
+    Dedicated = 1,
+}
+
+public sealed record WorkflowScheduleRunRecord(
+    string RunRecordId,
+    string ScheduleId,
+    DateTimeOffset ScheduledFireAtUtc,
+    DateTimeOffset FiredAtUtc,
+    string IdempotencyKey,
+    WorkflowScheduleFireStatus Status,
+    string? AcceptedCommandId = null,
+    string? CorrelationId = null,
+    string? ActorId = null,
+    string? Error = null);
+
+public sealed record WorkflowSchedulePreview(
+    string Cron,
+    string Timezone,
+    DateTimeOffset FromUtc,
+    IReadOnlyList<DateTimeOffset> FireTimesUtc);
+
+public sealed record WorkflowScheduleCreateCommand(
+    string? ScheduleId,
+    string Name,
+    string Cron,
+    string Timezone,
+    WorkflowScheduleTarget Target,
+    bool Enabled = true);
+
+public sealed record WorkflowScheduleUpdateCommand(
+    string? Name = null,
+    string? Cron = null,
+    string? Timezone = null,
+    WorkflowScheduleTarget? Target = null);
+
+public sealed record WorkflowScheduleListQuery(
+    WorkflowScheduleStatus? Status = null,
+    int Skip = 0,
+    int Take = 100);
+
+public sealed record WorkflowScheduleListResult(
+    IReadOnlyList<WorkflowScheduleDefinition> Items,
+    int Total);
+
+public sealed record WorkflowScheduleFireRequest(
+    string ScheduleId,
+    DateTimeOffset? ScheduledFireAtUtc = null,
+    bool Force = false,
+    bool AdvanceSchedule = false);
+
+public sealed record WorkflowScheduleFireResult(
+    WorkflowScheduleFireStatus Status,
+    WorkflowScheduleRunRecord Run,
+    string? StatusUrl = null);
+
+public enum WorkflowScheduleErrorCode
+{
+    None = 0,
+    InvalidScheduleId = 1,
+    InvalidName = 2,
+    InvalidCron = 3,
+    InvalidTimezone = 4,
+    InvalidTarget = 5,
+    NotFound = 6,
+    AlreadyExists = 7,
+    Disabled = 8,
+    DispatchRejected = 9,
+}
+
+public sealed record WorkflowScheduleError(
+    WorkflowScheduleErrorCode Code,
+    string Message)
+{
+    public static WorkflowScheduleError None { get; } = new(WorkflowScheduleErrorCode.None, string.Empty);
+}
+
+public sealed record WorkflowScheduleResult<T>(
+    T? Value,
+    WorkflowScheduleError Error)
+{
+    public bool Succeeded => Error.Code == WorkflowScheduleErrorCode.None;
+
+    public static WorkflowScheduleResult<T> Success(T value) =>
+        new(value, WorkflowScheduleError.None);
+
+    public static WorkflowScheduleResult<T> Failure(WorkflowScheduleErrorCode code, string message) =>
+        new(default, new WorkflowScheduleError(code, message));
+}
+
+public interface IWorkflowScheduleApplicationService
+{
+    Task<WorkflowScheduleResult<WorkflowScheduleDefinition>> CreateAsync(
+        WorkflowScheduleCreateCommand command,
+        CancellationToken ct = default);
+
+    Task<WorkflowScheduleResult<WorkflowScheduleDefinition>> UpdateAsync(
+        string scheduleId,
+        WorkflowScheduleUpdateCommand command,
+        CancellationToken ct = default);
+
+    Task<WorkflowScheduleResult<WorkflowScheduleDefinition>> EnableAsync(
+        string scheduleId,
+        CancellationToken ct = default);
+
+    Task<WorkflowScheduleResult<WorkflowScheduleDefinition>> DisableAsync(
+        string scheduleId,
+        CancellationToken ct = default);
+
+    Task<WorkflowScheduleResult<WorkflowScheduleDefinition>> GetAsync(
+        string scheduleId,
+        CancellationToken ct = default);
+
+    Task<WorkflowScheduleListResult> ListAsync(
+        WorkflowScheduleListQuery query,
+        CancellationToken ct = default);
+
+    Task<WorkflowScheduleResult<WorkflowSchedulePreview>> PreviewAsync(
+        string cron,
+        string timezone,
+        DateTimeOffset? fromUtc,
+        int count,
+        CancellationToken ct = default);
+
+    Task<WorkflowScheduleResult<WorkflowScheduleFireResult>> RunNowAsync(
+        WorkflowScheduleFireRequest request,
+        CancellationToken ct = default);
+}

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Schedules/workflow_schedule_events.proto
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Schedules/workflow_schedule_events.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package aevatar.workflow.schedules;
+
+option csharp_namespace = "Aevatar.Workflow.Application.Abstractions.Schedules";
+
+message WorkflowScheduleDueEvent {
+  string schedule_id = 1;
+  int64 scheduled_fire_at_unix_time_ms = 2;
+}

--- a/src/workflow/Aevatar.Workflow.Application/Aevatar.Workflow.Application.csproj
+++ b/src/workflow/Aevatar.Workflow.Application/Aevatar.Workflow.Application.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Cronos" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>

--- a/src/workflow/Aevatar.Workflow.Application/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/workflow/Aevatar.Workflow.Application/DependencyInjection/ServiceCollectionExtensions.cs
@@ -8,10 +8,12 @@ using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Projections;
 using Aevatar.Workflow.Application.Abstractions.Reporting;
 using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.Workflow.Application.Abstractions.Schedules;
 using Aevatar.Workflow.Application.Abstractions.Workflows;
 using Aevatar.Workflow.Application.Queries;
 using Aevatar.Workflow.Application.Reporting;
 using Aevatar.Workflow.Application.Runs;
+using Aevatar.Workflow.Application.Schedules;
 using Aevatar.Workflow.Application.Workflows;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -119,6 +121,8 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IWorkflowCapabilitiesPort>(sp =>
             sp.GetRequiredService<RegistryBackedWorkflowCatalogPort>());
         services.AddSingleton<IWorkflowExecutionQueryApplicationService, WorkflowExecutionQueryApplicationService>();
+        services.TryAddSingleton<IWorkflowScheduleWakeupScheduler, NoopWorkflowScheduleWakeupScheduler>();
+        services.AddSingleton<IWorkflowScheduleApplicationService, WorkflowScheduleApplicationService>();
         return services;
     }
 }

--- a/src/workflow/Aevatar.Workflow.Application/Schedules/WorkflowScheduleApplicationService.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Schedules/WorkflowScheduleApplicationService.cs
@@ -1,0 +1,412 @@
+using Aevatar.CQRS.Core.Abstractions.Commands;
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.Workflow.Application.Abstractions.Schedules;
+
+namespace Aevatar.Workflow.Application.Schedules;
+
+public sealed class WorkflowScheduleApplicationService : IWorkflowScheduleApplicationService
+{
+    private const int DefaultPreviewCount = 10;
+    private const int MaxListTake = 500;
+
+    private readonly IWorkflowScheduleStore _store;
+    private readonly IWorkflowScheduleWakeupScheduler _wakeupScheduler;
+    private readonly ICommandDispatchService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError> _dispatchService;
+    private readonly TimeProvider _clock;
+
+    public WorkflowScheduleApplicationService(
+        IWorkflowScheduleStore store,
+        IWorkflowScheduleWakeupScheduler wakeupScheduler,
+        ICommandDispatchService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError> dispatchService,
+        TimeProvider? clock = null)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _wakeupScheduler = wakeupScheduler ?? throw new ArgumentNullException(nameof(wakeupScheduler));
+        _dispatchService = dispatchService ?? throw new ArgumentNullException(nameof(dispatchService));
+        _clock = clock ?? TimeProvider.System;
+    }
+
+    public async Task<WorkflowScheduleResult<WorkflowScheduleDefinition>> CreateAsync(
+        WorkflowScheduleCreateCommand command,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        var normalizedId = NormalizeScheduleId(command.ScheduleId) ?? Guid.NewGuid().ToString("N");
+        var validation = ValidateDefinitionInputs(
+            normalizedId,
+            command.Name,
+            command.Cron,
+            command.Timezone,
+            command.Target);
+        if (validation != null)
+            return WorkflowScheduleResult<WorkflowScheduleDefinition>.Failure(validation.Code, validation.Message);
+
+        if (await _store.GetAsync(normalizedId, ct) != null)
+        {
+            return WorkflowScheduleResult<WorkflowScheduleDefinition>.Failure(
+                WorkflowScheduleErrorCode.AlreadyExists,
+                $"Schedule '{normalizedId}' already exists.");
+        }
+
+        var now = _clock.GetUtcNow();
+        var status = command.Enabled
+            ? WorkflowScheduleStatus.Enabled
+            : WorkflowScheduleStatus.Disabled;
+        var next = status == WorkflowScheduleStatus.Enabled
+            ? ComputeNextFireOrFailure(command.Cron, command.Timezone, now)
+            : WorkflowScheduleResult<DateTimeOffset?>.Success(null);
+        if (!next.Succeeded)
+            return WorkflowScheduleResult<WorkflowScheduleDefinition>.Failure(next.Error.Code, next.Error.Message);
+
+        var definition = new WorkflowScheduleDefinition(
+            normalizedId,
+            command.Name.Trim(),
+            command.Cron.Trim(),
+            NormalizeTimezone(command.Timezone),
+            status,
+            command.Target,
+            now,
+            now,
+            next.Value);
+
+        await _store.AddAsync(definition, ct);
+        await ScheduleWakeupAsync(definition, ct);
+        return WorkflowScheduleResult<WorkflowScheduleDefinition>.Success(definition);
+    }
+
+    public async Task<WorkflowScheduleResult<WorkflowScheduleDefinition>> UpdateAsync(
+        string scheduleId,
+        WorkflowScheduleUpdateCommand command,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        var existing = await GetExistingAsync(scheduleId, ct);
+        if (!existing.Succeeded)
+            return existing;
+
+        var current = existing.Value!;
+        var name = string.IsNullOrWhiteSpace(command.Name) ? current.Name : command.Name.Trim();
+        var cron = string.IsNullOrWhiteSpace(command.Cron) ? current.Cron : command.Cron.Trim();
+        var timezone = string.IsNullOrWhiteSpace(command.Timezone) ? current.Timezone : NormalizeTimezone(command.Timezone);
+        var target = command.Target ?? current.Target;
+        var validation = ValidateDefinitionInputs(current.ScheduleId, name, cron, timezone, target);
+        if (validation != null)
+            return WorkflowScheduleResult<WorkflowScheduleDefinition>.Failure(validation.Code, validation.Message);
+
+        var next = current.Status == WorkflowScheduleStatus.Enabled
+            ? ComputeNextFireOrFailure(cron, timezone, _clock.GetUtcNow())
+            : WorkflowScheduleResult<DateTimeOffset?>.Success(null);
+        if (!next.Succeeded)
+            return WorkflowScheduleResult<WorkflowScheduleDefinition>.Failure(next.Error.Code, next.Error.Message);
+
+        var updated = current with
+        {
+            Name = name,
+            Cron = cron,
+            Timezone = timezone,
+            Target = target,
+            UpdatedAtUtc = _clock.GetUtcNow(),
+            NextFireAtUtc = next.Value,
+        };
+
+        await _store.UpdateAsync(updated, ct);
+        await ScheduleWakeupAsync(updated, ct);
+        return WorkflowScheduleResult<WorkflowScheduleDefinition>.Success(updated);
+    }
+
+    public async Task<WorkflowScheduleResult<WorkflowScheduleDefinition>> EnableAsync(
+        string scheduleId,
+        CancellationToken ct = default)
+    {
+        var existing = await GetExistingAsync(scheduleId, ct);
+        if (!existing.Succeeded)
+            return existing;
+
+        var current = existing.Value!;
+        var next = ComputeNextFireOrFailure(current.Cron, current.Timezone, _clock.GetUtcNow());
+        if (!next.Succeeded)
+            return WorkflowScheduleResult<WorkflowScheduleDefinition>.Failure(next.Error.Code, next.Error.Message);
+
+        var updated = current with
+        {
+            Status = WorkflowScheduleStatus.Enabled,
+            UpdatedAtUtc = _clock.GetUtcNow(),
+            NextFireAtUtc = next.Value,
+        };
+        await _store.UpdateAsync(updated, ct);
+        await _wakeupScheduler.ScheduleAsync(updated, ct);
+        return WorkflowScheduleResult<WorkflowScheduleDefinition>.Success(updated);
+    }
+
+    public async Task<WorkflowScheduleResult<WorkflowScheduleDefinition>> DisableAsync(
+        string scheduleId,
+        CancellationToken ct = default)
+    {
+        var existing = await GetExistingAsync(scheduleId, ct);
+        if (!existing.Succeeded)
+            return existing;
+
+        var updated = existing.Value! with
+        {
+            Status = WorkflowScheduleStatus.Disabled,
+            UpdatedAtUtc = _clock.GetUtcNow(),
+            NextFireAtUtc = null,
+        };
+        await _store.UpdateAsync(updated, ct);
+        await _wakeupScheduler.CancelAsync(updated.ScheduleId, ct);
+        return WorkflowScheduleResult<WorkflowScheduleDefinition>.Success(updated);
+    }
+
+    public Task<WorkflowScheduleResult<WorkflowScheduleDefinition>> GetAsync(
+        string scheduleId,
+        CancellationToken ct = default) =>
+        GetExistingAsync(scheduleId, ct);
+
+    public async Task<WorkflowScheduleListResult> ListAsync(
+        WorkflowScheduleListQuery query,
+        CancellationToken ct = default)
+    {
+        var skip = Math.Max(0, query.Skip);
+        var take = Math.Clamp(query.Take <= 0 ? 100 : query.Take, 1, MaxListTake);
+        var all = await _store.ListAsync(ct);
+        var filtered = all
+            .Where(x => query.Status == null || x.Status == query.Status)
+            .OrderBy(x => x.ScheduleId, StringComparer.Ordinal)
+            .ToList();
+
+        return new WorkflowScheduleListResult(
+            filtered.Skip(skip).Take(take).ToList(),
+            filtered.Count);
+    }
+
+    public Task<WorkflowScheduleResult<WorkflowSchedulePreview>> PreviewAsync(
+        string cron,
+        string timezone,
+        DateTimeOffset? fromUtc,
+        int count,
+        CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        var start = (fromUtc ?? _clock.GetUtcNow()).ToUniversalTime();
+        var boundedCount = count <= 0 ? DefaultPreviewCount : count;
+        var result = WorkflowScheduleCalculator.GetNextFireTimes(cron, timezone, start, boundedCount);
+        if (!result.Succeeded)
+        {
+            return Task.FromResult(WorkflowScheduleResult<WorkflowSchedulePreview>.Failure(
+                result.Error.Code,
+                result.Error.Message));
+        }
+
+        return Task.FromResult(WorkflowScheduleResult<WorkflowSchedulePreview>.Success(
+            new WorkflowSchedulePreview(
+                cron.Trim(),
+                NormalizeTimezone(timezone),
+                start,
+                result.Value ?? [])));
+    }
+
+    public async Task<WorkflowScheduleResult<WorkflowScheduleFireResult>> RunNowAsync(
+        WorkflowScheduleFireRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var existing = await GetExistingAsync(request.ScheduleId, ct);
+        if (!existing.Succeeded)
+        {
+            return WorkflowScheduleResult<WorkflowScheduleFireResult>.Failure(
+                existing.Error.Code,
+                existing.Error.Message);
+        }
+
+        var definition = existing.Value!;
+        if (definition.Status != WorkflowScheduleStatus.Enabled && !request.Force)
+        {
+            return WorkflowScheduleResult<WorkflowScheduleFireResult>.Failure(
+                WorkflowScheduleErrorCode.Disabled,
+                $"Schedule '{definition.ScheduleId}' is disabled.");
+        }
+
+        var scheduledFireAtUtc = (request.ScheduledFireAtUtc ?? _clock.GetUtcNow()).ToUniversalTime();
+        var idempotencyKey = WorkflowScheduleCalculator.BuildIdempotencyKey(definition.ScheduleId, scheduledFireAtUtc);
+        var duplicate = await _store.GetRunAsync(idempotencyKey, ct);
+        if (duplicate != null)
+        {
+            if (request.AdvanceSchedule)
+                await AdvanceScheduleAfterFireAsync(definition, scheduledFireAtUtc, ct);
+
+            return WorkflowScheduleResult<WorkflowScheduleFireResult>.Success(
+                new WorkflowScheduleFireResult(WorkflowScheduleFireStatus.Duplicate, duplicate));
+        }
+
+        var run = new WorkflowScheduleRunRecord(
+            RunRecordId: Guid.NewGuid().ToString("N"),
+            ScheduleId: definition.ScheduleId,
+            ScheduledFireAtUtc: scheduledFireAtUtc,
+            FiredAtUtc: _clock.GetUtcNow(),
+            IdempotencyKey: idempotencyKey,
+            Status: WorkflowScheduleFireStatus.Rejected);
+        await _store.AddRunAsync(run, ct);
+
+        var dispatch = await _dispatchService.DispatchAsync(
+            BuildRunRequest(definition, idempotencyKey),
+            ct);
+
+        if (!dispatch.Succeeded || dispatch.Receipt == null)
+        {
+            run = run with
+            {
+                Status = WorkflowScheduleFireStatus.Rejected,
+                Error = dispatch.Error.ToString(),
+            };
+            await _store.UpdateRunAsync(run, ct);
+            if (request.AdvanceSchedule)
+                await AdvanceScheduleAfterFireAsync(definition, scheduledFireAtUtc, ct);
+
+            return WorkflowScheduleResult<WorkflowScheduleFireResult>.Failure(
+                WorkflowScheduleErrorCode.DispatchRejected,
+                $"Schedule '{definition.ScheduleId}' dispatch was rejected: {dispatch.Error}.");
+        }
+
+        var receipt = dispatch.Receipt;
+        run = run with
+        {
+            Status = WorkflowScheduleFireStatus.Accepted,
+            AcceptedCommandId = receipt.CommandId,
+            CorrelationId = receipt.CorrelationId,
+            ActorId = receipt.ActorId,
+        };
+        await _store.UpdateRunAsync(run, ct);
+
+        if (request.AdvanceSchedule)
+            await AdvanceScheduleAfterFireAsync(definition, scheduledFireAtUtc, ct);
+
+        return WorkflowScheduleResult<WorkflowScheduleFireResult>.Success(
+            new WorkflowScheduleFireResult(
+                WorkflowScheduleFireStatus.Accepted,
+                run,
+                $"/api/actors/{Uri.EscapeDataString(receipt.ActorId)}"));
+    }
+
+    private async Task<WorkflowScheduleResult<WorkflowScheduleDefinition>> GetExistingAsync(
+        string scheduleId,
+        CancellationToken ct)
+    {
+        var normalized = NormalizeScheduleId(scheduleId);
+        if (normalized == null)
+        {
+            return WorkflowScheduleResult<WorkflowScheduleDefinition>.Failure(
+                WorkflowScheduleErrorCode.InvalidScheduleId,
+                "Schedule id is required.");
+        }
+
+        var definition = await _store.GetAsync(normalized, ct);
+        if (definition == null)
+        {
+            return WorkflowScheduleResult<WorkflowScheduleDefinition>.Failure(
+                WorkflowScheduleErrorCode.NotFound,
+                $"Schedule '{normalized}' was not found.");
+        }
+
+        return WorkflowScheduleResult<WorkflowScheduleDefinition>.Success(definition);
+    }
+
+    private async Task ScheduleWakeupAsync(
+        WorkflowScheduleDefinition definition,
+        CancellationToken ct)
+    {
+        if (definition.Status != WorkflowScheduleStatus.Enabled || definition.NextFireAtUtc == null)
+        {
+            await _wakeupScheduler.CancelAsync(definition.ScheduleId, ct);
+            return;
+        }
+
+        await _wakeupScheduler.ScheduleAsync(definition, ct);
+    }
+
+    private async Task AdvanceScheduleAfterFireAsync(
+        WorkflowScheduleDefinition definition,
+        DateTimeOffset scheduledFireAtUtc,
+        CancellationToken ct)
+    {
+        if (definition.Status != WorkflowScheduleStatus.Enabled)
+            return;
+
+        var nextResult = ComputeNextFireOrFailure(definition.Cron, definition.Timezone, scheduledFireAtUtc);
+        if (!nextResult.Succeeded)
+            return;
+
+        var updated = definition with
+        {
+            UpdatedAtUtc = _clock.GetUtcNow(),
+            NextFireAtUtc = nextResult.Value,
+        };
+        await _store.UpdateAsync(updated, ct);
+        await ScheduleWakeupAsync(updated, ct);
+    }
+
+    private WorkflowScheduleResult<DateTimeOffset?> ComputeNextFireOrFailure(
+        string cron,
+        string timezone,
+        DateTimeOffset fromUtc) =>
+        WorkflowScheduleCalculator.GetNextFireTime(cron, timezone, fromUtc.ToUniversalTime());
+
+    private static WorkflowChatRunRequest BuildRunRequest(
+        WorkflowScheduleDefinition definition,
+        string idempotencyKey)
+    {
+        var target = definition.Target;
+        return new WorkflowChatRunRequest(
+            Prompt: target.Prompt,
+            WorkflowName: target.Source.WorkflowName,
+            ActorId: target.Source.ActorId,
+            SessionId: target.SessionId,
+            InputParts: target.InputParts,
+            WorkflowYamls: target.Source.WorkflowYamls,
+            Metadata: target.Annotations,
+            ScopeId: target.ScopeId,
+            Source: target.Source,
+            Headers: target.Headers,
+            CommandIdSeed: idempotencyKey,
+            CorrelationIdSeed: idempotencyKey);
+    }
+
+    private static WorkflowScheduleError? ValidateDefinitionInputs(
+        string scheduleId,
+        string name,
+        string cron,
+        string timezone,
+        WorkflowScheduleTarget? target)
+    {
+        if (NormalizeScheduleId(scheduleId) == null)
+            return new WorkflowScheduleError(WorkflowScheduleErrorCode.InvalidScheduleId, "Schedule id is required.");
+        if (string.IsNullOrWhiteSpace(name))
+            return new WorkflowScheduleError(WorkflowScheduleErrorCode.InvalidName, "Schedule name is required.");
+        if (target == null || string.IsNullOrWhiteSpace(target.Prompt))
+            return new WorkflowScheduleError(WorkflowScheduleErrorCode.InvalidTarget, "Schedule target prompt is required.");
+
+        var preview = WorkflowScheduleCalculator.GetNextFireTimes(cron, timezone, DateTimeOffset.UtcNow, 1);
+        if (!preview.Succeeded)
+            return preview.Error;
+
+        return null;
+    }
+
+    private static string? NormalizeScheduleId(string? scheduleId)
+    {
+        var normalized = scheduleId?.Trim();
+        if (string.IsNullOrWhiteSpace(normalized))
+            return null;
+
+        return normalized.All(IsScheduleIdChar)
+            ? normalized
+            : null;
+    }
+
+    private static bool IsScheduleIdChar(char value) =>
+        char.IsLetterOrDigit(value) || value is '-' or '_' or ':' or '.';
+
+    private static string NormalizeTimezone(string? timezone) =>
+        string.IsNullOrWhiteSpace(timezone)
+            ? "UTC"
+            : timezone.Trim();
+}

--- a/src/workflow/Aevatar.Workflow.Application/Schedules/WorkflowScheduleCalculator.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Schedules/WorkflowScheduleCalculator.cs
@@ -1,0 +1,109 @@
+using Aevatar.Workflow.Application.Abstractions.Schedules;
+using Cronos;
+
+namespace Aevatar.Workflow.Application.Schedules;
+
+internal static class WorkflowScheduleCalculator
+{
+    public const int MaxPreviewCount = 50;
+
+    public static WorkflowScheduleResult<IReadOnlyList<DateTimeOffset>> GetNextFireTimes(
+        string cron,
+        string timezone,
+        DateTimeOffset fromUtc,
+        int count)
+    {
+        var normalizedCron = NormalizeOptional(cron);
+        if (normalizedCron == null)
+            return WorkflowScheduleResult<IReadOnlyList<DateTimeOffset>>.Failure(
+                WorkflowScheduleErrorCode.InvalidCron,
+                "Cron expression is required.");
+
+        if (!TryResolveTimezone(timezone, out var timeZone, out var timezoneError))
+            return WorkflowScheduleResult<IReadOnlyList<DateTimeOffset>>.Failure(
+                WorkflowScheduleErrorCode.InvalidTimezone,
+                timezoneError);
+
+        CronExpression expression;
+        try
+        {
+            expression = CronExpression.Parse(normalizedCron, CronFormat.Standard);
+        }
+        catch (CronFormatException ex)
+        {
+            return WorkflowScheduleResult<IReadOnlyList<DateTimeOffset>>.Failure(
+                WorkflowScheduleErrorCode.InvalidCron,
+                $"Cron expression is invalid: {ex.Message}");
+        }
+
+        var boundedCount = Math.Clamp(count, 1, MaxPreviewCount);
+        var results = new List<DateTimeOffset>(boundedCount);
+        var cursor = fromUtc.ToUniversalTime();
+        for (var i = 0; i < boundedCount; i++)
+        {
+            var next = expression.GetNextOccurrence(cursor, timeZone, inclusive: false);
+            if (next == null)
+                break;
+
+            var utc = next.Value.ToUniversalTime();
+            results.Add(utc);
+            cursor = utc;
+        }
+
+        return WorkflowScheduleResult<IReadOnlyList<DateTimeOffset>>.Success(results);
+    }
+
+    public static WorkflowScheduleResult<DateTimeOffset?> GetNextFireTime(
+        string cron,
+        string timezone,
+        DateTimeOffset fromUtc)
+    {
+        var result = GetNextFireTimes(cron, timezone, fromUtc, 1);
+        if (!result.Succeeded)
+            return WorkflowScheduleResult<DateTimeOffset?>.Failure(result.Error.Code, result.Error.Message);
+
+        var next = result.Value is { Count: > 0 }
+            ? result.Value[0]
+            : (DateTimeOffset?)null;
+        return WorkflowScheduleResult<DateTimeOffset?>.Success(next);
+    }
+
+    public static bool TryResolveTimezone(
+        string timezone,
+        out TimeZoneInfo timeZone,
+        out string error)
+    {
+        var normalized = NormalizeOptional(timezone) ?? "UTC";
+        try
+        {
+            timeZone = TimeZoneInfo.FindSystemTimeZoneById(normalized);
+            error = string.Empty;
+            return true;
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            timeZone = TimeZoneInfo.Utc;
+            error = $"Timezone '{normalized}' was not found.";
+            return false;
+        }
+        catch (InvalidTimeZoneException)
+        {
+            timeZone = TimeZoneInfo.Utc;
+            error = $"Timezone '{normalized}' is invalid.";
+            return false;
+        }
+    }
+
+    public static string BuildIdempotencyKey(
+        string scheduleId,
+        DateTimeOffset scheduledFireAtUtc) =>
+        $"schedule:{scheduleId}:fire:{scheduledFireAtUtc.ToUniversalTime():o}";
+
+    private static string? NormalizeOptional(string? value)
+    {
+        var normalized = value?.Trim();
+        return string.IsNullOrWhiteSpace(normalized)
+            ? null
+            : normalized;
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Application/Schedules/WorkflowSchedulePorts.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Schedules/WorkflowSchedulePorts.cs
@@ -1,0 +1,65 @@
+using Aevatar.Workflow.Application.Abstractions.Schedules;
+
+namespace Aevatar.Workflow.Application.Schedules;
+
+public interface IWorkflowScheduleStore
+{
+    Task<WorkflowScheduleDefinition?> GetAsync(
+        string scheduleId,
+        CancellationToken ct = default);
+
+    Task<IReadOnlyList<WorkflowScheduleDefinition>> ListAsync(
+        CancellationToken ct = default);
+
+    Task AddAsync(
+        WorkflowScheduleDefinition definition,
+        CancellationToken ct = default);
+
+    Task UpdateAsync(
+        WorkflowScheduleDefinition definition,
+        CancellationToken ct = default);
+
+    Task<WorkflowScheduleRunRecord?> GetRunAsync(
+        string idempotencyKey,
+        CancellationToken ct = default);
+
+    Task AddRunAsync(
+        WorkflowScheduleRunRecord run,
+        CancellationToken ct = default);
+
+    Task UpdateRunAsync(
+        WorkflowScheduleRunRecord run,
+        CancellationToken ct = default);
+}
+
+public interface IWorkflowScheduleWakeupScheduler
+{
+    Task ScheduleAsync(
+        WorkflowScheduleDefinition definition,
+        CancellationToken ct = default);
+
+    Task CancelAsync(
+        string scheduleId,
+        CancellationToken ct = default);
+}
+
+public sealed class NoopWorkflowScheduleWakeupScheduler : IWorkflowScheduleWakeupScheduler
+{
+    public Task ScheduleAsync(
+        WorkflowScheduleDefinition definition,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ct.ThrowIfCancellationRequested();
+        return Task.CompletedTask;
+    }
+
+    public Task CancelAsync(
+        string scheduleId,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(scheduleId);
+        ct.ThrowIfCancellationRequested();
+        return Task.CompletedTask;
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Core/Schedules/IWorkflowScheduleDueEventHandlerPort.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Schedules/IWorkflowScheduleDueEventHandlerPort.cs
@@ -1,0 +1,22 @@
+using Aevatar.Workflow.Application.Abstractions.Schedules;
+
+namespace Aevatar.Workflow.Core.Schedules;
+
+public interface IWorkflowScheduleDueEventHandlerPort
+{
+    Task HandleDueAsync(
+        WorkflowScheduleDueEvent due,
+        CancellationToken ct = default);
+}
+
+public sealed class NoopWorkflowScheduleDueEventHandlerPort : IWorkflowScheduleDueEventHandlerPort
+{
+    public Task HandleDueAsync(
+        WorkflowScheduleDueEvent due,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(due);
+        ct.ThrowIfCancellationRequested();
+        return Task.CompletedTask;
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Core/Schedules/WorkflowScheduleWakeupGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Schedules/WorkflowScheduleWakeupGAgent.cs
@@ -1,0 +1,15 @@
+using Aevatar.Foundation.Abstractions.Attributes;
+using Aevatar.Foundation.Core;
+using Aevatar.Workflow.Application.Abstractions.Schedules;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.Workflow.Core.Schedules;
+
+public sealed class WorkflowScheduleWakeupGAgent : GAgentBase
+{
+    [EventHandler]
+    public Task HandleWorkflowScheduleDue(WorkflowScheduleDueEvent request) =>
+        Services
+            .GetRequiredService<IWorkflowScheduleDueEventHandlerPort>()
+            .HandleDueAsync(request, CancellationToken.None);
+}

--- a/src/workflow/Aevatar.Workflow.Core/ServiceCollectionExtensions.cs
+++ b/src/workflow/Aevatar.Workflow.Core/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.Foundation.Abstractions.EventModules;
 using Aevatar.Workflow.Abstractions.Execution;
 using Aevatar.Workflow.Core.Primitives;
+using Aevatar.Workflow.Core.Schedules;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -25,6 +26,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IConnectorRegistry, ConfiguredConnectorRegistry>();
         services.TryAddSingleton<IWorkflowConnectorResolver, RegistryBackedWorkflowConnectorResolver>();
         services.TryAddSingleton<WorkflowStepTargetAgentResolver>();
+        services.TryAddSingleton<IWorkflowScheduleDueEventHandlerPort, NoopWorkflowScheduleDueEventHandlerPort>();
         return services;
     }
 

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Aevatar.Workflow.Infrastructure.csproj
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Aevatar.Workflow.Infrastructure.csproj
@@ -19,4 +19,14 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.Tools">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Protobuf Include="Schedules/workflow_schedule_store.proto" GrpcServices="None" />
+  </ItemGroup>
 </Project>

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
@@ -25,6 +25,7 @@ public static class WorkflowCapabilityEndpoints
     {
         var group = app.MapGroup("/api").WithTags("Chat");
         ChatQueryEndpoints.Map(group);
+        group.MapWorkflowScheduleEndpoints();
 
         return app;
     }

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowScheduleEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowScheduleEndpoints.cs
@@ -1,0 +1,246 @@
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.Workflow.Application.Abstractions.Schedules;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Aevatar.Workflow.Infrastructure.CapabilityApi;
+
+public static class WorkflowScheduleEndpoints
+{
+    public static IEndpointRouteBuilder MapWorkflowScheduleEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/workflow-schedules").WithTags("Workflow Schedules");
+
+        group.MapPost("", HandleCreateAsync);
+        group.MapGet("", HandleListAsync);
+        group.MapGet("/{scheduleId}", HandleGetAsync);
+        group.MapPut("/{scheduleId}", HandleUpdateAsync);
+        group.MapPost("/{scheduleId}:enable", HandleEnableAsync);
+        group.MapPost("/{scheduleId}:disable", HandleDisableAsync);
+        group.MapPost("/preview", HandlePreviewAsync);
+        group.MapPost("/{scheduleId}:run-now", HandleRunNowAsync);
+
+        return app;
+    }
+
+    internal static async Task<IResult> HandleCreateAsync(
+        WorkflowScheduleCreateInput input,
+        [FromServices] IWorkflowScheduleApplicationService service,
+        CancellationToken ct = default)
+    {
+        var target = NormalizeTarget(input.Target);
+        if (target == null)
+            return Results.BadRequest(new { error = "Schedule target is required." });
+
+        var result = await service.CreateAsync(
+            new WorkflowScheduleCreateCommand(
+                input.ScheduleId,
+                input.Name ?? string.Empty,
+                input.Cron ?? string.Empty,
+                input.Timezone ?? "UTC",
+                target,
+                input.Enabled),
+            ct);
+        if (!result.Succeeded)
+            return MapError(result.Error);
+
+        return Results.Created(
+            $"/api/workflow-schedules/{Uri.EscapeDataString(result.Value!.ScheduleId)}",
+            result.Value);
+    }
+
+    internal static async Task<IResult> HandleUpdateAsync(
+        string scheduleId,
+        WorkflowScheduleUpdateInput input,
+        [FromServices] IWorkflowScheduleApplicationService service,
+        CancellationToken ct = default)
+    {
+        var result = await service.UpdateAsync(
+            scheduleId,
+            new WorkflowScheduleUpdateCommand(
+                input.Name,
+                input.Cron,
+                input.Timezone,
+                input.Target == null ? null : NormalizeTarget(input.Target)),
+            ct);
+        return result.Succeeded ? Results.Ok(result.Value) : MapError(result.Error);
+    }
+
+    internal static async Task<IResult> HandleEnableAsync(
+        string scheduleId,
+        [FromServices] IWorkflowScheduleApplicationService service,
+        CancellationToken ct = default)
+    {
+        var result = await service.EnableAsync(scheduleId, ct);
+        return result.Succeeded ? Results.Ok(result.Value) : MapError(result.Error);
+    }
+
+    internal static async Task<IResult> HandleDisableAsync(
+        string scheduleId,
+        [FromServices] IWorkflowScheduleApplicationService service,
+        CancellationToken ct = default)
+    {
+        var result = await service.DisableAsync(scheduleId, ct);
+        return result.Succeeded ? Results.Ok(result.Value) : MapError(result.Error);
+    }
+
+    internal static async Task<IResult> HandleGetAsync(
+        string scheduleId,
+        [FromServices] IWorkflowScheduleApplicationService service,
+        CancellationToken ct = default)
+    {
+        var result = await service.GetAsync(scheduleId, ct);
+        return result.Succeeded ? Results.Ok(result.Value) : MapError(result.Error);
+    }
+
+    internal static async Task<IResult> HandleListAsync(
+        [FromServices] IWorkflowScheduleApplicationService service,
+        [FromQuery] string? status = null,
+        [FromQuery] int skip = 0,
+        [FromQuery] int take = 100,
+        CancellationToken ct = default)
+    {
+        var parsedStatus = ParseStatus(status);
+        var result = await service.ListAsync(new WorkflowScheduleListQuery(parsedStatus, skip, take), ct);
+        return Results.Ok(result);
+    }
+
+    internal static async Task<IResult> HandlePreviewAsync(
+        WorkflowSchedulePreviewInput input,
+        [FromServices] IWorkflowScheduleApplicationService service,
+        CancellationToken ct = default)
+    {
+        var result = await service.PreviewAsync(
+            input.Cron ?? string.Empty,
+            input.Timezone ?? "UTC",
+            input.FromUtc,
+            input.Count,
+            ct);
+        return result.Succeeded ? Results.Ok(result.Value) : MapError(result.Error);
+    }
+
+    internal static async Task<IResult> HandleRunNowAsync(
+        string scheduleId,
+        WorkflowScheduleRunNowInput? input,
+        [FromServices] IWorkflowScheduleApplicationService service,
+        CancellationToken ct = default)
+    {
+        var result = await service.RunNowAsync(
+            new WorkflowScheduleFireRequest(
+                scheduleId,
+                input?.ScheduledFireAtUtc,
+                input?.Force ?? false),
+            ct);
+        if (!result.Succeeded)
+            return MapError(result.Error);
+
+        var value = result.Value!;
+        return value.Status == WorkflowScheduleFireStatus.Accepted
+            ? Results.Accepted(value.StatusUrl, value)
+            : Results.Ok(value);
+    }
+
+    private static WorkflowScheduleTarget? NormalizeTarget(WorkflowScheduleTargetInput? input)
+    {
+        if (input == null)
+            return null;
+
+        return new WorkflowScheduleTarget(
+            input.Prompt ?? string.Empty,
+            NormalizeSource(input.Source),
+            NormalizeOptional(input.SessionId),
+            InputParts: null,
+            Annotations: NormalizeMap(input.Annotations),
+            ScopeId: NormalizeOptional(input.ScopeId),
+            Headers: NormalizeMap(input.Headers));
+    }
+
+    private static WorkflowChatSource NormalizeSource(WorkflowChatSourceInput? input)
+    {
+        if (input == null)
+            return WorkflowChatSource.Direct();
+
+        var kind = NormalizeSourceKind(input.Kind);
+        var workflowName = NormalizeOptional(input.WorkflowName);
+        var actorId = NormalizeOptional(input.ActorId);
+        var workflowYamls = input.WorkflowYamls?.Where(x => !string.IsNullOrWhiteSpace(x)).ToList() ?? [];
+        return kind switch
+        {
+            WorkflowChatSourceKind.CatalogWorkflow =>
+                WorkflowChatSource.CatalogWorkflow(workflowName ?? string.Empty),
+            WorkflowChatSourceKind.DefinitionActor =>
+                WorkflowChatSource.DefinitionActor(actorId ?? string.Empty, workflowName),
+            WorkflowChatSourceKind.InlineYamlBundle =>
+                WorkflowChatSource.InlineYamlBundle(workflowYamls, workflowName, actorId),
+            WorkflowChatSourceKind.Direct =>
+                WorkflowChatSource.Direct(actorId),
+            _ => WorkflowChatSource.Direct(actorId),
+        };
+    }
+
+    private static WorkflowChatSourceKind NormalizeSourceKind(string? kind) =>
+        kind?.Trim().ToLowerInvariant() switch
+        {
+            "catalog_workflow" or "catalog-workflow" or "catalog" or "workflow" =>
+                WorkflowChatSourceKind.CatalogWorkflow,
+            "definition_actor" or "definition-actor" or "actor" =>
+                WorkflowChatSourceKind.DefinitionActor,
+            "inline_yaml_bundle" or "inline-yaml-bundle" or "inline_yaml" or "inline-yaml" =>
+                WorkflowChatSourceKind.InlineYamlBundle,
+            "direct" => WorkflowChatSourceKind.Direct,
+            _ => WorkflowChatSourceKind.Direct,
+        };
+
+    private static WorkflowScheduleStatus? ParseStatus(string? status) =>
+        System.Enum.TryParse<WorkflowScheduleStatus>(status, ignoreCase: true, out var parsed)
+            ? parsed
+            : null;
+
+    private static IReadOnlyDictionary<string, string>? NormalizeMap(IDictionary<string, string>? source)
+    {
+        if (source is not { Count: > 0 })
+            return null;
+
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (key, value) in source)
+        {
+            var normalizedKey = NormalizeOptional(key);
+            if (normalizedKey != null)
+                result[normalizedKey] = value?.Trim() ?? string.Empty;
+        }
+
+        return result.Count == 0 ? null : result;
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        var normalized = value?.Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
+    private static IResult MapError(WorkflowScheduleError error)
+    {
+        var statusCode = error.Code switch
+        {
+            WorkflowScheduleErrorCode.InvalidScheduleId or
+                WorkflowScheduleErrorCode.InvalidName or
+                WorkflowScheduleErrorCode.InvalidCron or
+                WorkflowScheduleErrorCode.InvalidTimezone or
+                WorkflowScheduleErrorCode.InvalidTarget => StatusCodes.Status400BadRequest,
+            WorkflowScheduleErrorCode.NotFound => StatusCodes.Status404NotFound,
+            WorkflowScheduleErrorCode.AlreadyExists => StatusCodes.Status409Conflict,
+            WorkflowScheduleErrorCode.Disabled or
+                WorkflowScheduleErrorCode.DispatchRejected => StatusCodes.Status409Conflict,
+            _ => StatusCodes.Status500InternalServerError,
+        };
+        return Results.Json(
+            new
+            {
+                code = error.Code.ToString(),
+                message = error.Message,
+            },
+            statusCode: statusCode);
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowScheduleModels.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowScheduleModels.cs
@@ -1,0 +1,43 @@
+namespace Aevatar.Workflow.Infrastructure.CapabilityApi;
+
+public sealed record WorkflowScheduleTargetInput
+{
+    public string? Prompt { get; init; }
+    public WorkflowChatSourceInput? Source { get; init; }
+    public string? SessionId { get; init; }
+    public string? ScopeId { get; init; }
+    public IDictionary<string, string>? Annotations { get; init; }
+    public IDictionary<string, string>? Headers { get; init; }
+}
+
+public sealed record WorkflowScheduleCreateInput
+{
+    public string? ScheduleId { get; init; }
+    public string? Name { get; init; }
+    public string? Cron { get; init; }
+    public string? Timezone { get; init; }
+    public bool Enabled { get; init; } = true;
+    public WorkflowScheduleTargetInput? Target { get; init; }
+}
+
+public sealed record WorkflowScheduleUpdateInput
+{
+    public string? Name { get; init; }
+    public string? Cron { get; init; }
+    public string? Timezone { get; init; }
+    public WorkflowScheduleTargetInput? Target { get; init; }
+}
+
+public sealed record WorkflowSchedulePreviewInput
+{
+    public string? Cron { get; init; }
+    public string? Timezone { get; init; }
+    public DateTimeOffset? FromUtc { get; init; }
+    public int Count { get; init; } = 10;
+}
+
+public sealed record WorkflowScheduleRunNowInput
+{
+    public DateTimeOffset? ScheduledFireAtUtc { get; init; }
+    public bool Force { get; init; }
+}

--- a/src/workflow/Aevatar.Workflow.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -2,8 +2,11 @@ using Aevatar.Workflow.Application.Abstractions.Reporting;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Application.Schedules;
+using Aevatar.Workflow.Core.Schedules;
 using Aevatar.Workflow.Infrastructure.Reporting;
 using Aevatar.Workflow.Infrastructure.Runs;
+using Aevatar.Workflow.Infrastructure.Schedules;
 using Aevatar.Workflow.Infrastructure.Workflows;
 using Aevatar.Workflow.Projection.Workflows;
 using Microsoft.Extensions.DependencyInjection;
@@ -32,6 +35,34 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IWorkflowDefinitionParser>(sp =>
             sp.GetRequiredService<WorkflowRunActorPort>());
         services.TryAddSingleton<IWorkflowDefinitionResolver, RegistryWorkflowDefinitionResolver>();
+        return services;
+    }
+
+    public static IServiceCollection AddWorkflowScheduleInfrastructure(
+        this IServiceCollection services,
+        Action<WorkflowScheduleStoreOptions>? configureStore = null,
+        Action<WorkflowScheduleWakeupOptions>? configureWakeup = null)
+    {
+        services.AddOptions<WorkflowScheduleStoreOptions>();
+        if (configureStore != null)
+            services.Configure(configureStore);
+
+        services.AddOptions<WorkflowScheduleWakeupOptions>();
+        if (configureWakeup != null)
+            services.Configure(configureWakeup);
+
+        services.TryAddSingleton<IWorkflowScheduleStore, FileWorkflowScheduleStore>();
+        services.Replace(ServiceDescriptor.Singleton<IWorkflowScheduleDueEventHandlerPort, WorkflowScheduleDueEventHandlerPort>());
+        services.Replace(ServiceDescriptor.Singleton<IWorkflowScheduleWakeupScheduler>(sp =>
+        {
+            var options = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<WorkflowScheduleWakeupOptions>>().Value;
+            var callbacks = sp.GetService<Aevatar.Foundation.Abstractions.Runtime.Callbacks.IActorRuntimeCallbackScheduler>();
+            var runtime = sp.GetService<Aevatar.Foundation.Abstractions.IActorRuntime>();
+            return options.UseOrleansReminders && callbacks != null && runtime != null
+                ? ActivatorUtilities.CreateInstance<OrleansReminderWorkflowScheduleWakeupScheduler>(sp)
+                : new NoopWorkflowScheduleWakeupScheduler();
+        }));
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, WorkflowScheduleDispatcherHostedService>());
         return services;
     }
 

--- a/src/workflow/Aevatar.Workflow.Infrastructure/DependencyInjection/WorkflowCapabilityServiceCollectionExtensions.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/DependencyInjection/WorkflowCapabilityServiceCollectionExtensions.cs
@@ -47,6 +47,9 @@ public static class WorkflowCapabilityServiceCollectionExtensions
         });
         services.AddWorkflowInfrastructure(options =>
             configuration.GetSection("WorkflowRunReportExport").Bind(options));
+        services.AddWorkflowScheduleInfrastructure(
+            options => configuration.GetSection("WorkflowSchedules:Store").Bind(options),
+            options => configuration.GetSection("WorkflowSchedules:Wakeup").Bind(options));
         services.TryAddSingleton<WorkflowCapabilityRegistrationsMarker>();
         return services;
     }

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Schedules/FileWorkflowScheduleStore.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Schedules/FileWorkflowScheduleStore.cs
@@ -1,0 +1,439 @@
+using System.Text;
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.Workflow.Application.Abstractions.Schedules;
+using Aevatar.Workflow.Application.Schedules;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Aevatar.Workflow.Infrastructure.Schedules;
+
+public sealed class FileWorkflowScheduleStore : IWorkflowScheduleStore
+{
+    private const int StoreFormatMagic = 0x53574641; // AFWS
+    private const int StoreFormatVersion = 1;
+
+    private readonly string _storePath;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly ILogger<FileWorkflowScheduleStore> _logger;
+
+    public FileWorkflowScheduleStore(
+        IOptions<WorkflowScheduleStoreOptions>? options = null,
+        ILogger<FileWorkflowScheduleStore>? logger = null)
+    {
+        var value = options?.Value ?? new WorkflowScheduleStoreOptions();
+        if (string.IsNullOrWhiteSpace(value.StorePath))
+            throw new InvalidOperationException("Workflow schedule store path is required.");
+
+        _storePath = Path.GetFullPath(value.StorePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(_storePath) ?? ".");
+        _logger = logger ?? NullLogger<FileWorkflowScheduleStore>.Instance;
+    }
+
+    public async Task<WorkflowScheduleDefinition?> GetAsync(
+        string scheduleId,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(scheduleId);
+        await _gate.WaitAsync(ct);
+        try
+        {
+            var document = ReadDocument(ct);
+            var record = document.Schedules.FirstOrDefault(x =>
+                string.Equals(x.ScheduleId, scheduleId, StringComparison.Ordinal));
+            return record == null ? null : ToDefinition(record);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<IReadOnlyList<WorkflowScheduleDefinition>> ListAsync(
+        CancellationToken ct = default)
+    {
+        await _gate.WaitAsync(ct);
+        try
+        {
+            return ReadDocument(ct).Schedules.Select(ToDefinition).ToList();
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task AddAsync(
+        WorkflowScheduleDefinition definition,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        await _gate.WaitAsync(ct);
+        try
+        {
+            var document = ReadDocument(ct);
+            if (document.Schedules.Any(x => string.Equals(x.ScheduleId, definition.ScheduleId, StringComparison.Ordinal)))
+                throw new InvalidOperationException($"Schedule '{definition.ScheduleId}' already exists.");
+
+            document.Schedules.Add(ToRecord(definition));
+            WriteDocument(document, ct);
+            _logger.LogDebug("Workflow schedule added. scheduleId={ScheduleId}", definition.ScheduleId);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task UpdateAsync(
+        WorkflowScheduleDefinition definition,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        await _gate.WaitAsync(ct);
+        try
+        {
+            var document = ReadDocument(ct);
+            var index = FindScheduleIndex(document, definition.ScheduleId);
+            if (index < 0)
+                throw new InvalidOperationException($"Schedule '{definition.ScheduleId}' does not exist.");
+
+            document.Schedules[index] = ToRecord(definition);
+            WriteDocument(document, ct);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task<WorkflowScheduleRunRecord?> GetRunAsync(
+        string idempotencyKey,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(idempotencyKey);
+        await _gate.WaitAsync(ct);
+        try
+        {
+            var record = ReadDocument(ct).Runs.FirstOrDefault(x =>
+                string.Equals(x.IdempotencyKey, idempotencyKey, StringComparison.Ordinal));
+            return record == null ? null : ToRun(record);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task AddRunAsync(
+        WorkflowScheduleRunRecord run,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(run);
+        await _gate.WaitAsync(ct);
+        try
+        {
+            var document = ReadDocument(ct);
+            if (document.Runs.Any(x => string.Equals(x.IdempotencyKey, run.IdempotencyKey, StringComparison.Ordinal)))
+                throw new InvalidOperationException($"Schedule run '{run.IdempotencyKey}' already exists.");
+
+            document.Runs.Add(ToRecord(run));
+            WriteDocument(document, ct);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task UpdateRunAsync(
+        WorkflowScheduleRunRecord run,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(run);
+        await _gate.WaitAsync(ct);
+        try
+        {
+            var document = ReadDocument(ct);
+            var index = FindRunIndex(document, run.IdempotencyKey);
+            if (index < 0)
+                throw new InvalidOperationException($"Schedule run '{run.IdempotencyKey}' does not exist.");
+
+            document.Runs[index] = ToRecord(run);
+            WriteDocument(document, ct);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private WorkflowScheduleStoreDocument ReadDocument(CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        if (!File.Exists(_storePath))
+            return new WorkflowScheduleStoreDocument();
+
+        using var stream = new FileStream(_storePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        if (stream.Length == 0)
+            return new WorkflowScheduleStoreDocument();
+
+        using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: false);
+        var magic = reader.ReadInt32();
+        if (magic != StoreFormatMagic)
+            throw new InvalidOperationException("Workflow schedule store has an invalid header.");
+
+        var version = reader.ReadInt32();
+        if (version != StoreFormatVersion)
+            throw new InvalidOperationException($"Unsupported workflow schedule store format version {version}.");
+
+        var payloadLength = reader.ReadInt32();
+        if (payloadLength < 0)
+            throw new InvalidOperationException("Workflow schedule store has an invalid payload length.");
+
+        var payload = reader.ReadBytes(payloadLength);
+        if (payload.Length != payloadLength)
+            throw new InvalidOperationException("Workflow schedule store payload is truncated.");
+
+        return WorkflowScheduleStoreDocument.Parser.ParseFrom(payload);
+    }
+
+    private void WriteDocument(
+        WorkflowScheduleStoreDocument document,
+        CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        var payload = document.ToByteArray();
+        var tempPath = _storePath + ".tmp";
+
+        using (var fileStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
+        using (var writer = new BinaryWriter(fileStream, Encoding.UTF8, leaveOpen: false))
+        {
+            writer.Write(StoreFormatMagic);
+            writer.Write(StoreFormatVersion);
+            writer.Write(payload.Length);
+            writer.Write(payload);
+        }
+
+        File.Move(tempPath, _storePath, overwrite: true);
+    }
+
+    private static int FindScheduleIndex(
+        WorkflowScheduleStoreDocument document,
+        string scheduleId)
+    {
+        for (var i = 0; i < document.Schedules.Count; i++)
+        {
+            if (string.Equals(document.Schedules[i].ScheduleId, scheduleId, StringComparison.Ordinal))
+                return i;
+        }
+
+        return -1;
+    }
+
+    private static int FindRunIndex(
+        WorkflowScheduleStoreDocument document,
+        string idempotencyKey)
+    {
+        for (var i = 0; i < document.Runs.Count; i++)
+        {
+            if (string.Equals(document.Runs[i].IdempotencyKey, idempotencyKey, StringComparison.Ordinal))
+                return i;
+        }
+
+        return -1;
+    }
+
+    private static WorkflowScheduleDefinition ToDefinition(WorkflowScheduleDefinitionRecord record)
+    {
+        return new WorkflowScheduleDefinition(
+            record.ScheduleId,
+            record.Name,
+            record.Cron,
+            record.Timezone,
+            ParseStatus(record.Status),
+            ToTarget(record.Target),
+            record.CreatedAtUtc?.ToDateTimeOffset() ?? DateTimeOffset.UnixEpoch,
+            record.UpdatedAtUtc?.ToDateTimeOffset() ?? DateTimeOffset.UnixEpoch,
+            record.NextFireAtUtc == null ? null : record.NextFireAtUtc.ToDateTimeOffset(),
+            ToWakeupLease(record.WakeupLease));
+    }
+
+    private static WorkflowScheduleDefinitionRecord ToRecord(WorkflowScheduleDefinition definition)
+    {
+        var record = new WorkflowScheduleDefinitionRecord
+        {
+            ScheduleId = definition.ScheduleId,
+            Name = definition.Name,
+            Cron = definition.Cron,
+            Timezone = definition.Timezone,
+            Status = definition.Status.ToString(),
+            Target = ToRecord(definition.Target),
+            CreatedAtUtc = Timestamp.FromDateTimeOffset(definition.CreatedAtUtc.ToUniversalTime()),
+            UpdatedAtUtc = Timestamp.FromDateTimeOffset(definition.UpdatedAtUtc.ToUniversalTime()),
+        };
+        if (definition.NextFireAtUtc != null)
+            record.NextFireAtUtc = Timestamp.FromDateTimeOffset(definition.NextFireAtUtc.Value.ToUniversalTime());
+        if (definition.WakeupLease != null)
+            record.WakeupLease = ToRecord(definition.WakeupLease);
+
+        return record;
+    }
+
+    private static WorkflowScheduleWakeupLease? ToWakeupLease(WorkflowScheduleWakeupLeaseRecord? record)
+    {
+        if (record == null || string.IsNullOrWhiteSpace(record.ActorId) || string.IsNullOrWhiteSpace(record.CallbackId))
+            return null;
+
+        return new WorkflowScheduleWakeupLease(
+            record.ActorId,
+            record.CallbackId,
+            record.Generation,
+            ParseWakeupBackend(record.Backend),
+            record.SlotEpoch);
+    }
+
+    private static WorkflowScheduleWakeupLeaseRecord ToRecord(WorkflowScheduleWakeupLease lease)
+    {
+        return new WorkflowScheduleWakeupLeaseRecord
+        {
+            ActorId = lease.ActorId,
+            CallbackId = lease.CallbackId,
+            Generation = lease.Generation,
+            Backend = lease.Backend.ToString(),
+            SlotEpoch = lease.SlotEpoch,
+        };
+    }
+
+    private static WorkflowScheduleTarget ToTarget(WorkflowScheduleTargetRecord? record)
+    {
+        record ??= new WorkflowScheduleTargetRecord();
+        return new WorkflowScheduleTarget(
+            record.Prompt,
+            ToSource(record.Source),
+            NormalizeEmpty(record.SessionId),
+            InputParts: null,
+            Annotations: new Dictionary<string, string>(record.Annotations, StringComparer.Ordinal),
+            ScopeId: NormalizeEmpty(record.ScopeId),
+            Headers: new Dictionary<string, string>(record.Headers, StringComparer.Ordinal));
+    }
+
+    private static WorkflowScheduleTargetRecord ToRecord(WorkflowScheduleTarget target)
+    {
+        var record = new WorkflowScheduleTargetRecord
+        {
+            Prompt = target.Prompt,
+            Source = ToRecord(target.Source),
+            SessionId = target.SessionId ?? string.Empty,
+            ScopeId = target.ScopeId ?? string.Empty,
+        };
+        AppendMap(record.Annotations, target.Annotations);
+        AppendMap(record.Headers, target.Headers);
+        return record;
+    }
+
+    private static WorkflowChatSource ToSource(WorkflowScheduleSourceRecord? record)
+    {
+        record ??= new WorkflowScheduleSourceRecord();
+        var workflowName = NormalizeEmpty(record.WorkflowName);
+        var actorId = NormalizeEmpty(record.ActorId);
+        var workflowYamls = record.WorkflowYamls.Count == 0 ? null : record.WorkflowYamls.ToList();
+        return ParseSourceKind(record.Kind) switch
+        {
+            WorkflowChatSourceKind.CatalogWorkflow =>
+                WorkflowChatSource.CatalogWorkflow(workflowName ?? string.Empty),
+            WorkflowChatSourceKind.DefinitionActor =>
+                WorkflowChatSource.DefinitionActor(actorId ?? string.Empty, workflowName),
+            WorkflowChatSourceKind.InlineYamlBundle =>
+                WorkflowChatSource.InlineYamlBundle(workflowYamls ?? [], workflowName, actorId),
+            WorkflowChatSourceKind.Direct =>
+                WorkflowChatSource.Direct(actorId),
+            _ => WorkflowChatSource.Direct(actorId),
+        };
+    }
+
+    private static WorkflowScheduleSourceRecord ToRecord(WorkflowChatSource source)
+    {
+        var record = new WorkflowScheduleSourceRecord
+        {
+            Kind = source.Kind.ToString(),
+            WorkflowName = source.WorkflowName ?? string.Empty,
+            ActorId = source.ActorId ?? string.Empty,
+        };
+        if (source.WorkflowYamls is { Count: > 0 })
+            record.WorkflowYamls.Add(source.WorkflowYamls);
+
+        return record;
+    }
+
+    private static WorkflowScheduleRunRecord ToRun(WorkflowScheduleRunRecordEntry record)
+    {
+        return new WorkflowScheduleRunRecord(
+            record.RunRecordId,
+            record.ScheduleId,
+            record.ScheduledFireAtUtc?.ToDateTimeOffset() ?? DateTimeOffset.UnixEpoch,
+            record.FiredAtUtc?.ToDateTimeOffset() ?? DateTimeOffset.UnixEpoch,
+            record.IdempotencyKey,
+            ParseFireStatus(record.Status),
+            NormalizeEmpty(record.AcceptedCommandId),
+            NormalizeEmpty(record.CorrelationId),
+            NormalizeEmpty(record.ActorId),
+            NormalizeEmpty(record.Error));
+    }
+
+    private static WorkflowScheduleRunRecordEntry ToRecord(WorkflowScheduleRunRecord run)
+    {
+        return new WorkflowScheduleRunRecordEntry
+        {
+            RunRecordId = run.RunRecordId,
+            ScheduleId = run.ScheduleId,
+            ScheduledFireAtUtc = Timestamp.FromDateTimeOffset(run.ScheduledFireAtUtc.ToUniversalTime()),
+            FiredAtUtc = Timestamp.FromDateTimeOffset(run.FiredAtUtc.ToUniversalTime()),
+            IdempotencyKey = run.IdempotencyKey,
+            Status = run.Status.ToString(),
+            AcceptedCommandId = run.AcceptedCommandId ?? string.Empty,
+            CorrelationId = run.CorrelationId ?? string.Empty,
+            ActorId = run.ActorId ?? string.Empty,
+            Error = run.Error ?? string.Empty,
+        };
+    }
+
+    private static WorkflowScheduleStatus ParseStatus(string? value) =>
+        System.Enum.TryParse<WorkflowScheduleStatus>(value, ignoreCase: true, out var status)
+            ? status
+            : WorkflowScheduleStatus.Disabled;
+
+    private static WorkflowScheduleFireStatus ParseFireStatus(string? value) =>
+        System.Enum.TryParse<WorkflowScheduleFireStatus>(value, ignoreCase: true, out var status)
+            ? status
+            : WorkflowScheduleFireStatus.Rejected;
+
+    private static WorkflowScheduleWakeupBackend ParseWakeupBackend(string? value) =>
+        System.Enum.TryParse<WorkflowScheduleWakeupBackend>(value, ignoreCase: true, out var status)
+            ? status
+            : WorkflowScheduleWakeupBackend.InMemory;
+
+    private static WorkflowChatSourceKind ParseSourceKind(string? value) =>
+        System.Enum.TryParse<WorkflowChatSourceKind>(value, ignoreCase: true, out var status)
+            ? status
+            : WorkflowChatSourceKind.Direct;
+
+    private static void AppendMap(
+        Google.Protobuf.Collections.MapField<string, string> destination,
+        IReadOnlyDictionary<string, string>? source)
+    {
+        if (source is not { Count: > 0 })
+            return;
+
+        foreach (var (key, value) in source)
+        {
+            if (!string.IsNullOrWhiteSpace(key))
+                destination[key] = value ?? string.Empty;
+        }
+    }
+
+    private static string? NormalizeEmpty(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
+}

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Schedules/InMemoryWorkflowScheduleStore.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Schedules/InMemoryWorkflowScheduleStore.cs
@@ -1,0 +1,107 @@
+using Aevatar.Workflow.Application.Abstractions.Schedules;
+using Aevatar.Workflow.Application.Schedules;
+
+namespace Aevatar.Workflow.Infrastructure.Schedules;
+
+public sealed class InMemoryWorkflowScheduleStore : IWorkflowScheduleStore
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<string, WorkflowScheduleDefinition> _schedules = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, WorkflowScheduleRunRecord> _runsByIdempotencyKey = new(StringComparer.Ordinal);
+
+    public Task<WorkflowScheduleDefinition?> GetAsync(
+        string scheduleId,
+        CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        lock (_gate)
+        {
+            return Task.FromResult(_schedules.GetValueOrDefault(scheduleId));
+        }
+    }
+
+    public Task<IReadOnlyList<WorkflowScheduleDefinition>> ListAsync(
+        CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        lock (_gate)
+        {
+            return Task.FromResult<IReadOnlyList<WorkflowScheduleDefinition>>(_schedules.Values.ToList());
+        }
+    }
+
+    public Task AddAsync(
+        WorkflowScheduleDefinition definition,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ct.ThrowIfCancellationRequested();
+        lock (_gate)
+        {
+            if (!_schedules.TryAdd(definition.ScheduleId, definition))
+                throw new InvalidOperationException($"Schedule '{definition.ScheduleId}' already exists.");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateAsync(
+        WorkflowScheduleDefinition definition,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ct.ThrowIfCancellationRequested();
+        lock (_gate)
+        {
+            if (!_schedules.ContainsKey(definition.ScheduleId))
+                throw new InvalidOperationException($"Schedule '{definition.ScheduleId}' does not exist.");
+
+            _schedules[definition.ScheduleId] = definition;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<WorkflowScheduleRunRecord?> GetRunAsync(
+        string idempotencyKey,
+        CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        lock (_gate)
+        {
+            return Task.FromResult(_runsByIdempotencyKey.GetValueOrDefault(idempotencyKey));
+        }
+    }
+
+    public Task AddRunAsync(
+        WorkflowScheduleRunRecord run,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(run);
+        ct.ThrowIfCancellationRequested();
+        lock (_gate)
+        {
+            if (!_runsByIdempotencyKey.TryAdd(run.IdempotencyKey, run))
+                throw new InvalidOperationException($"Schedule run '{run.IdempotencyKey}' already exists.");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateRunAsync(
+        WorkflowScheduleRunRecord run,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(run);
+        ct.ThrowIfCancellationRequested();
+        lock (_gate)
+        {
+            if (!_runsByIdempotencyKey.ContainsKey(run.IdempotencyKey))
+                throw new InvalidOperationException($"Schedule run '{run.IdempotencyKey}' does not exist.");
+
+            _runsByIdempotencyKey[run.IdempotencyKey] = run;
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Schedules/OrleansReminderWorkflowScheduleWakeupScheduler.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Schedules/OrleansReminderWorkflowScheduleWakeupScheduler.cs
@@ -1,0 +1,153 @@
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Workflow.Application.Abstractions.Schedules;
+using Aevatar.Workflow.Application.Schedules;
+using Aevatar.Workflow.Core.Schedules;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Workflow.Infrastructure.Schedules;
+
+public sealed class OrleansReminderWorkflowScheduleWakeupScheduler : IWorkflowScheduleWakeupScheduler
+{
+    private const string CallbackIdPrefix = "workflow-schedule-due";
+    private const string ActorIdPrefix = "workflow-schedule-wakeup";
+
+    private readonly IActorRuntimeCallbackScheduler _callbacks;
+    private readonly IActorRuntime _runtime;
+    private readonly IWorkflowScheduleStore _store;
+    private readonly TimeProvider _clock;
+
+    public OrleansReminderWorkflowScheduleWakeupScheduler(
+        IActorRuntimeCallbackScheduler callbacks,
+        IActorRuntime runtime,
+        IWorkflowScheduleStore store,
+        TimeProvider? clock = null)
+    {
+        _callbacks = callbacks ?? throw new ArgumentNullException(nameof(callbacks));
+        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _clock = clock ?? TimeProvider.System;
+    }
+
+    public async Task ScheduleAsync(
+        WorkflowScheduleDefinition definition,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ct.ThrowIfCancellationRequested();
+
+        if (definition.Status != WorkflowScheduleStatus.Enabled || definition.NextFireAtUtc == null)
+        {
+            await CancelAsync(definition.ScheduleId, ct);
+            return;
+        }
+
+        await CancelLeaseAsync(definition.WakeupLease, ct);
+
+        var fireAtUtc = definition.NextFireAtUtc.Value.ToUniversalTime();
+        var dueTime = fireAtUtc - _clock.GetUtcNow().ToUniversalTime();
+        if (dueTime <= TimeSpan.Zero)
+            dueTime = TimeSpan.FromMilliseconds(1);
+
+        var callbackId = BuildCallbackId(definition.ScheduleId);
+        var actorId = BuildActorId(definition.ScheduleId);
+        await EnsureWakeupActorAsync(actorId, ct);
+        var lease = await _callbacks.ScheduleTimeoutAsync(
+            new RuntimeCallbackTimeoutRequest
+            {
+                ActorId = actorId,
+                CallbackId = callbackId,
+                DueTime = dueTime,
+                TriggerEnvelope = CreateDueEnvelope(actorId, definition.ScheduleId, fireAtUtc),
+                DeliveryMode = RuntimeCallbackDeliveryMode.EnvelopeRedelivery,
+            },
+            ct);
+
+        await _store.UpdateAsync(definition with { WakeupLease = ToScheduleLease(lease) }, ct);
+    }
+
+    private async Task EnsureWakeupActorAsync(
+        string actorId,
+        CancellationToken ct)
+    {
+        if (await _runtime.ExistsAsync(actorId))
+            return;
+
+        await _runtime.CreateAsync(typeof(WorkflowScheduleWakeupGAgent), actorId, ct);
+    }
+
+    public async Task CancelAsync(
+        string scheduleId,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(scheduleId);
+        ct.ThrowIfCancellationRequested();
+
+        var definition = await _store.GetAsync(scheduleId, ct);
+        if (definition?.WakeupLease == null)
+            return;
+
+        await CancelLeaseAsync(definition.WakeupLease, ct);
+        await _store.UpdateAsync(definition with { WakeupLease = null }, ct);
+    }
+
+    private async Task CancelLeaseAsync(
+        WorkflowScheduleWakeupLease? lease,
+        CancellationToken ct)
+    {
+        if (lease == null)
+            return;
+
+        await _callbacks.CancelAsync(ToRuntimeLease(lease), ct);
+    }
+
+    private static EventEnvelope CreateDueEnvelope(
+        string actorId,
+        string scheduleId,
+        DateTimeOffset fireAtUtc)
+    {
+        return new EventEnvelope
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            Payload = Any.Pack(new WorkflowScheduleDueEvent
+            {
+                ScheduleId = scheduleId,
+                ScheduledFireAtUnixTimeMs = fireAtUtc.ToUnixTimeMilliseconds(),
+            }),
+            Route = EnvelopeRouteSemantics.CreateTopologyPublication(actorId, TopologyAudience.Self),
+        };
+    }
+
+    private static string BuildCallbackId(string scheduleId) =>
+        RuntimeCallbackKeyComposer.BuildCallbackId(CallbackIdPrefix, scheduleId);
+
+    private static string BuildActorId(string scheduleId) =>
+        RuntimeCallbackKeyComposer.BuildCallbackId(ActorIdPrefix, scheduleId);
+
+    private static WorkflowScheduleWakeupLease ToScheduleLease(RuntimeCallbackLease lease)
+    {
+        return new WorkflowScheduleWakeupLease(
+            lease.ActorId,
+            lease.CallbackId,
+            lease.Generation,
+            lease.Backend == RuntimeCallbackBackend.Dedicated
+                ? WorkflowScheduleWakeupBackend.Dedicated
+                : WorkflowScheduleWakeupBackend.InMemory,
+            lease.SlotEpoch);
+    }
+
+    private static RuntimeCallbackLease ToRuntimeLease(WorkflowScheduleWakeupLease lease)
+    {
+        return new RuntimeCallbackLease(
+            lease.ActorId,
+            lease.CallbackId,
+            lease.Generation,
+            lease.Backend == WorkflowScheduleWakeupBackend.Dedicated
+                ? RuntimeCallbackBackend.Dedicated
+                : RuntimeCallbackBackend.InMemory)
+        {
+            SlotEpoch = lease.SlotEpoch,
+        };
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Schedules/WorkflowScheduleDispatcherHostedService.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Schedules/WorkflowScheduleDispatcherHostedService.cs
@@ -1,0 +1,102 @@
+using Aevatar.Workflow.Application.Abstractions.Schedules;
+using Aevatar.Workflow.Application.Schedules;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Aevatar.Workflow.Infrastructure.Schedules;
+
+internal sealed class WorkflowScheduleDispatcherHostedService : BackgroundService
+{
+    private static readonly TimeSpan MinimumPollInterval = TimeSpan.FromSeconds(1);
+
+    private readonly IWorkflowScheduleStore _store;
+    private readonly IWorkflowScheduleApplicationService _schedules;
+    private readonly WorkflowScheduleStoreOptions _storeOptions;
+    private readonly WorkflowScheduleWakeupOptions _wakeupOptions;
+    private readonly TimeProvider _clock;
+    private readonly ILogger<WorkflowScheduleDispatcherHostedService> _logger;
+
+    public WorkflowScheduleDispatcherHostedService(
+        IWorkflowScheduleStore store,
+        IWorkflowScheduleApplicationService schedules,
+        IOptions<WorkflowScheduleStoreOptions> storeOptions,
+        IOptions<WorkflowScheduleWakeupOptions> wakeupOptions,
+        ILogger<WorkflowScheduleDispatcherHostedService> logger,
+        TimeProvider? clock = null)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _schedules = schedules ?? throw new ArgumentNullException(nameof(schedules));
+        _storeOptions = storeOptions?.Value ?? new WorkflowScheduleStoreOptions();
+        _wakeupOptions = wakeupOptions?.Value ?? new WorkflowScheduleWakeupOptions();
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _clock = clock ?? TimeProvider.System;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_storeOptions.EnableDispatcher || _wakeupOptions.UseOrleansReminders)
+            return;
+
+        await DispatchDueSchedulesAsync(stoppingToken);
+
+        using var timer = new PeriodicTimer(GetPollInterval());
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            await DispatchDueSchedulesAsync(stoppingToken);
+        }
+    }
+
+    internal async Task DispatchDueSchedulesAsync(CancellationToken ct = default)
+    {
+        var now = _clock.GetUtcNow().ToUniversalTime();
+        var maxDueSchedules = Math.Max(1, _storeOptions.MaxDueSchedulesPerTick);
+        var definitions = await _store.ListAsync(ct);
+        var dueSchedules = definitions
+            .Where(x =>
+                x.Status == WorkflowScheduleStatus.Enabled &&
+                x.NextFireAtUtc != null &&
+                x.NextFireAtUtc.Value.ToUniversalTime() <= now)
+            .OrderBy(x => x.NextFireAtUtc)
+            .ThenBy(x => x.ScheduleId, StringComparer.Ordinal)
+            .Take(maxDueSchedules)
+            .ToList();
+
+        foreach (var definition in dueSchedules)
+        {
+            ct.ThrowIfCancellationRequested();
+            var scheduledFireAtUtc = definition.NextFireAtUtc!.Value.ToUniversalTime();
+            try
+            {
+                var result = await _schedules.RunNowAsync(
+                    new WorkflowScheduleFireRequest(
+                        definition.ScheduleId,
+                        scheduledFireAtUtc,
+                        Force: false,
+                        AdvanceSchedule: true),
+                    ct);
+                if (!result.Succeeded)
+                {
+                    _logger.LogWarning(
+                        "Workflow schedule fire was rejected. scheduleId={ScheduleId} scheduledFireAtUtc={ScheduledFireAtUtc} errorCode={ErrorCode}",
+                        definition.ScheduleId,
+                        scheduledFireAtUtc,
+                        result.Error.Code);
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogError(
+                    ex,
+                    "Workflow schedule fire failed. scheduleId={ScheduleId} scheduledFireAtUtc={ScheduledFireAtUtc}",
+                    definition.ScheduleId,
+                    scheduledFireAtUtc);
+            }
+        }
+    }
+
+    private TimeSpan GetPollInterval() =>
+        _storeOptions.DispatcherPollInterval < MinimumPollInterval
+            ? MinimumPollInterval
+            : _storeOptions.DispatcherPollInterval;
+}

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Schedules/WorkflowScheduleDueEventHandlerPort.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Schedules/WorkflowScheduleDueEventHandlerPort.cs
@@ -1,0 +1,33 @@
+using Aevatar.Workflow.Application.Abstractions.Schedules;
+using Aevatar.Workflow.Core.Schedules;
+
+namespace Aevatar.Workflow.Infrastructure.Schedules;
+
+public sealed class WorkflowScheduleDueEventHandlerPort : IWorkflowScheduleDueEventHandlerPort
+{
+    private readonly IWorkflowScheduleApplicationService _schedules;
+
+    public WorkflowScheduleDueEventHandlerPort(IWorkflowScheduleApplicationService schedules)
+    {
+        _schedules = schedules ?? throw new ArgumentNullException(nameof(schedules));
+    }
+
+    public Task HandleDueAsync(
+        WorkflowScheduleDueEvent due,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(due);
+        var scheduleId = due.ScheduleId?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(scheduleId))
+            return Task.CompletedTask;
+
+        var scheduledFireAtUtc = DateTimeOffset.FromUnixTimeMilliseconds(due.ScheduledFireAtUnixTimeMs);
+        return _schedules.RunNowAsync(
+            new WorkflowScheduleFireRequest(
+                scheduleId,
+                scheduledFireAtUtc,
+                Force: false,
+                AdvanceSchedule: true),
+            ct);
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Schedules/WorkflowScheduleStoreOptions.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Schedules/WorkflowScheduleStoreOptions.cs
@@ -1,0 +1,15 @@
+using Aevatar.Configuration;
+
+namespace Aevatar.Workflow.Infrastructure.Schedules;
+
+public sealed class WorkflowScheduleStoreOptions
+{
+    public string StorePath { get; set; } =
+        Path.Combine(AevatarPaths.Root, "workflow-schedules.pb");
+
+    public bool EnableDispatcher { get; set; } = true;
+
+    public TimeSpan DispatcherPollInterval { get; set; } = TimeSpan.FromSeconds(30);
+
+    public int MaxDueSchedulesPerTick { get; set; } = 100;
+}

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Schedules/WorkflowScheduleWakeupOptions.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Schedules/WorkflowScheduleWakeupOptions.cs
@@ -1,0 +1,6 @@
+namespace Aevatar.Workflow.Infrastructure.Schedules;
+
+public sealed class WorkflowScheduleWakeupOptions
+{
+    public bool UseOrleansReminders { get; set; }
+}

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Schedules/workflow_schedule_store.proto
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Schedules/workflow_schedule_store.proto
@@ -1,0 +1,62 @@
+syntax = "proto3";
+
+package aevatar.workflow.schedules;
+
+option csharp_namespace = "Aevatar.Workflow.Infrastructure.Schedules";
+
+import "google/protobuf/timestamp.proto";
+
+message WorkflowScheduleStoreDocument {
+  repeated WorkflowScheduleDefinitionRecord schedules = 1;
+  repeated WorkflowScheduleRunRecordEntry runs = 2;
+}
+
+message WorkflowScheduleDefinitionRecord {
+  string schedule_id = 1;
+  string name = 2;
+  string cron = 3;
+  string timezone = 4;
+  string status = 5;
+  WorkflowScheduleTargetRecord target = 6;
+  google.protobuf.Timestamp created_at_utc = 7;
+  google.protobuf.Timestamp updated_at_utc = 8;
+  google.protobuf.Timestamp next_fire_at_utc = 9;
+  WorkflowScheduleWakeupLeaseRecord wakeup_lease = 10;
+}
+
+message WorkflowScheduleWakeupLeaseRecord {
+  string actor_id = 1;
+  string callback_id = 2;
+  int64 generation = 3;
+  string backend = 4;
+  int32 slot_epoch = 5;
+}
+
+message WorkflowScheduleTargetRecord {
+  string prompt = 1;
+  WorkflowScheduleSourceRecord source = 2;
+  string session_id = 3;
+  string scope_id = 4;
+  map<string, string> annotations = 5;
+  map<string, string> headers = 6;
+}
+
+message WorkflowScheduleSourceRecord {
+  string kind = 1;
+  string workflow_name = 2;
+  string actor_id = 3;
+  repeated string workflow_yamls = 4;
+}
+
+message WorkflowScheduleRunRecordEntry {
+  string run_record_id = 1;
+  string schedule_id = 2;
+  google.protobuf.Timestamp scheduled_fire_at_utc = 3;
+  google.protobuf.Timestamp fired_at_utc = 4;
+  string idempotency_key = 5;
+  string status = 6;
+  string accepted_command_id = 7;
+  string correlation_id = 8;
+  string actor_id = 9;
+  string error = 10;
+}

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansDistributedCoverageTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansDistributedCoverageTests.cs
@@ -10,6 +10,7 @@ using Google.Protobuf;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans;
 using Orleans.Runtime;
+using Orleans.Storage;
 
 namespace Aevatar.Foundation.Runtime.Hosting.Tests;
 
@@ -384,6 +385,93 @@ public sealed class OrleansDistributedCoverageTests
     }
 
     [Fact]
+    public async Task StreamTopologyGrain_ShouldRefreshAndRetryUpsertAfterStorageConflict()
+    {
+        var state = DispatchProxy.Create<IPersistentState<StreamTopologyGrainState>, StreamTopologyPersistentStateProxy>();
+        var stateProxy = (StreamTopologyPersistentStateProxy)(object)state;
+        stateProxy.ConflictsBeforeWriteSuccess = 1;
+        stateProxy.StateAfterRead = new StreamTopologyGrainState
+        {
+            Revision = 5,
+            BindingsByTarget =
+            {
+                ["target-existing"] = CreateEntry("source-1", "target-existing", 4, "lease-existing"),
+            },
+        };
+        var grain = new StreamTopologyGrain(state);
+
+        await grain.UpsertAsync(CreateBinding("source-1", "target-new", 6, "lease-new"));
+
+        stateProxy.ReadCount.Should().Be(1);
+        stateProxy.WriteCount.Should().Be(2);
+        stateProxy.State.Revision.Should().Be(6);
+        var listed = await grain.ListAsync();
+        listed.Should().Contain(x => x.TargetStreamId == "target-existing");
+        listed.Should().Contain(x => x.TargetStreamId == "target-new" && x.LeaseId == "lease-new");
+    }
+
+    [Fact]
+    public async Task StreamTopologyGrain_ShouldSkipRetryWriteWhenRefreshedStateAlreadyContainsUpsert()
+    {
+        var state = DispatchProxy.Create<IPersistentState<StreamTopologyGrainState>, StreamTopologyPersistentStateProxy>();
+        var stateProxy = (StreamTopologyPersistentStateProxy)(object)state;
+        stateProxy.ConflictsBeforeWriteSuccess = 1;
+        stateProxy.StateAfterRead = new StreamTopologyGrainState
+        {
+            Revision = 9,
+            BindingsByTarget =
+            {
+                ["target-1"] = CreateEntry("source-1", "target-1", 1, "lease-1"),
+            },
+        };
+        var grain = new StreamTopologyGrain(state);
+
+        await grain.UpsertAsync(CreateBinding("source-1", "target-1", 1, "lease-1"));
+
+        stateProxy.ReadCount.Should().Be(1);
+        stateProxy.WriteCount.Should().Be(1);
+        stateProxy.State.Revision.Should().Be(9);
+        (await grain.ListAsync()).Should().ContainSingle(x => x.TargetStreamId == "target-1");
+    }
+
+    [Fact]
+    public async Task StreamTopologyGrain_ShouldSkipRetryWriteWhenRefreshedStateAlreadyRemovedTarget()
+    {
+        var state = DispatchProxy.Create<IPersistentState<StreamTopologyGrainState>, StreamTopologyPersistentStateProxy>();
+        var stateProxy = (StreamTopologyPersistentStateProxy)(object)state;
+        stateProxy.State.BindingsByTarget["target-1"] = CreateEntry("source-1", "target-1", 1, "lease-1");
+        stateProxy.State.Revision = 1;
+        stateProxy.ConflictsBeforeWriteSuccess = 1;
+        stateProxy.StateAfterRead = new StreamTopologyGrainState
+        {
+            Revision = 2,
+        };
+        var grain = new StreamTopologyGrain(state);
+
+        await grain.RemoveAsync("target-1");
+
+        stateProxy.ReadCount.Should().Be(1);
+        stateProxy.WriteCount.Should().Be(1);
+        stateProxy.State.Revision.Should().Be(2);
+        (await grain.ListAsync()).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task StreamTopologyGrain_ShouldPropagateNonConflictStorageFailures()
+    {
+        var state = DispatchProxy.Create<IPersistentState<StreamTopologyGrainState>, StreamTopologyPersistentStateProxy>();
+        var stateProxy = (StreamTopologyPersistentStateProxy)(object)state;
+        stateProxy.WriteFailure = new InvalidOperationException("storage unavailable");
+        var grain = new StreamTopologyGrain(state);
+
+        var act = () => grain.UpsertAsync(CreateBinding("source-1", "target-1", 1, "lease-1"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("storage unavailable");
+        stateProxy.ReadCount.Should().Be(0);
+        stateProxy.WriteCount.Should().Be(1);
+    }
+
+    [Fact]
     public async Task StreamTopologyGrain_ShouldSupportLegacyListState()
     {
         var state = DispatchProxy.Create<IPersistentState<StreamTopologyGrainState>, StreamTopologyPersistentStateProxy>();
@@ -556,6 +644,22 @@ public sealed class OrleansDistributedCoverageTests
             ForwardingMode = StreamForwardingMode.HandleThenForward,
             DirectionFilter = new HashSet<TopologyAudience> { TopologyAudience.Children, TopologyAudience.ParentAndChildren },
             EventTypeFilter = new HashSet<string>(StringComparer.Ordinal) { "evt" },
+            Version = version,
+            LeaseId = leaseId,
+        };
+
+    private static StreamForwardingBindingEntry CreateEntry(
+        string source,
+        string target,
+        long version,
+        string? leaseId) =>
+        new()
+        {
+            SourceStreamId = source,
+            TargetStreamId = target,
+            ForwardingMode = StreamForwardingMode.HandleThenForward,
+            DirectionFilter = [TopologyAudience.Children, TopologyAudience.ParentAndChildren],
+            EventTypeFilter = ["evt"],
             Version = version,
             LeaseId = leaseId,
         };
@@ -741,6 +845,14 @@ public sealed class OrleansDistributedCoverageTests
     {
         public StreamTopologyGrainState State { get; set; } = new();
 
+        public StreamTopologyGrainState? StateAfterRead { get; set; }
+
+        public Exception? WriteFailure { get; set; }
+
+        public int ConflictsBeforeWriteSuccess { get; set; }
+
+        public int ReadCount { get; private set; }
+
         public int WriteCount { get; private set; }
 
         protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
@@ -756,9 +868,29 @@ public sealed class OrleansDistributedCoverageTests
             if (name == "WriteStateAsync")
             {
                 WriteCount++;
+                if (WriteFailure != null)
+                    return Task.FromException(WriteFailure);
+
+                if (ConflictsBeforeWriteSuccess > 0)
+                {
+                    ConflictsBeforeWriteSuccess--;
+                    return Task.FromException(new InconsistentStateException(
+                        "Version conflict while writing stream topology state.",
+                        "stored-etag",
+                        "current-etag"));
+                }
+
                 return Task.CompletedTask;
             }
-            if (name == "ReadStateAsync" || name == "ClearStateAsync")
+            if (name == "ReadStateAsync")
+            {
+                ReadCount++;
+                if (StateAfterRead != null)
+                    State = StateAfterRead;
+
+                return Task.CompletedTask;
+            }
+            if (name == "ClearStateAsync")
                 return Task.CompletedTask;
             if (name == "get_RecordExists")
                 return true;

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowScheduleApplicationServiceTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowScheduleApplicationServiceTests.cs
@@ -1,0 +1,330 @@
+using Aevatar.CQRS.Core.Abstractions.Commands;
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.Workflow.Application.Abstractions.Schedules;
+using Aevatar.Workflow.Application.DependencyInjection;
+using Aevatar.Workflow.Application.Schedules;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.Workflow.Application.Tests;
+
+public sealed class WorkflowScheduleApplicationServiceTests
+{
+    [Fact]
+    public async Task CreateAsync_ShouldValidateCronAndComputeNextFire()
+    {
+        var service = CreateService();
+
+        var result = await service.CreateAsync(new WorkflowScheduleCreateCommand(
+            "morning",
+            "Morning run",
+            "0 9 * * *",
+            "UTC",
+            Target()));
+
+        result.Succeeded.Should().BeTrue();
+        result.Value!.ScheduleId.Should().Be("morning");
+        result.Value.Status.Should().Be(WorkflowScheduleStatus.Enabled);
+        result.Value.NextFireAtUtc.Should().Be(DateTimeOffset.Parse("2026-01-01T09:00:00+00:00"));
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldRejectInvalidCron()
+    {
+        var service = CreateService();
+
+        var result = await service.CreateAsync(new WorkflowScheduleCreateCommand(
+            "bad",
+            "Bad run",
+            "bad cron",
+            "UTC",
+            Target()));
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Code.Should().Be(WorkflowScheduleErrorCode.InvalidCron);
+    }
+
+    [Fact]
+    public async Task PreviewAsync_ShouldReturnBoundedUtcOccurrences()
+    {
+        var service = CreateService();
+
+        var result = await service.PreviewAsync(
+            "*/15 * * * *",
+            "UTC",
+            DateTimeOffset.Parse("2026-01-01T00:00:00+00:00"),
+            3);
+
+        result.Succeeded.Should().BeTrue();
+        result.Value!.FireTimesUtc.Should().Equal(
+            DateTimeOffset.Parse("2026-01-01T00:15:00+00:00"),
+            DateTimeOffset.Parse("2026-01-01T00:30:00+00:00"),
+            DateTimeOffset.Parse("2026-01-01T00:45:00+00:00"));
+    }
+
+    [Fact]
+    public async Task RunNowAsync_ShouldDispatchWithScheduleIdempotencyKey()
+    {
+        var dispatch = new RecordingDispatchService();
+        var service = CreateService(dispatch: dispatch);
+        await service.CreateAsync(new WorkflowScheduleCreateCommand(
+            "morning",
+            "Morning run",
+            "0 9 * * *",
+            "UTC",
+            Target()));
+
+        var scheduledFireAt = DateTimeOffset.Parse("2026-01-01T09:00:00+00:00");
+        var result = await service.RunNowAsync(new WorkflowScheduleFireRequest("morning", scheduledFireAt));
+
+        result.Succeeded.Should().BeTrue();
+        result.Value!.Status.Should().Be(WorkflowScheduleFireStatus.Accepted);
+        var expectedKey = "schedule:morning:fire:2026-01-01T09:00:00.0000000+00:00";
+        result.Value.Run.IdempotencyKey.Should().Be(expectedKey);
+        result.Value.Run.AcceptedCommandId.Should().Be(expectedKey);
+        dispatch.Requests.Should().ContainSingle();
+        dispatch.Requests[0].CommandIdSeed.Should().Be(expectedKey);
+        dispatch.Requests[0].CorrelationIdSeed.Should().Be(expectedKey);
+        dispatch.Requests[0].Prompt.Should().Be("run the morning workflow");
+        dispatch.Requests[0].Source!.Kind.Should().Be(WorkflowChatSourceKind.CatalogWorkflow);
+    }
+
+    [Fact]
+    public async Task RunNowAsync_ShouldReturnDuplicateForSameScheduledFire()
+    {
+        var dispatch = new RecordingDispatchService();
+        var service = CreateService(dispatch: dispatch);
+        await service.CreateAsync(new WorkflowScheduleCreateCommand(
+            "morning",
+            "Morning run",
+            "0 9 * * *",
+            "UTC",
+            Target()));
+
+        var scheduledFireAt = DateTimeOffset.Parse("2026-01-01T09:00:00+00:00");
+        await service.RunNowAsync(new WorkflowScheduleFireRequest("morning", scheduledFireAt));
+        var duplicate = await service.RunNowAsync(new WorkflowScheduleFireRequest("morning", scheduledFireAt));
+
+        duplicate.Succeeded.Should().BeTrue();
+        duplicate.Value!.Status.Should().Be(WorkflowScheduleFireStatus.Duplicate);
+        dispatch.Requests.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task RunNowAsync_ShouldNotAdvanceScheduleByDefault()
+    {
+        var store = new MemoryStore();
+        var service = CreateService(store: store);
+        await service.CreateAsync(new WorkflowScheduleCreateCommand(
+            "morning",
+            "Morning run",
+            "0 9 * * *",
+            "UTC",
+            Target()));
+
+        var scheduledFireAt = DateTimeOffset.Parse("2026-01-01T09:00:00+00:00");
+        await service.RunNowAsync(new WorkflowScheduleFireRequest("morning", scheduledFireAt));
+
+        var definition = await store.GetAsync("morning");
+        definition!.NextFireAtUtc.Should().Be(DateTimeOffset.Parse("2026-01-01T09:00:00+00:00"));
+    }
+
+    [Fact]
+    public async Task RunNowAsync_ShouldAdvanceScheduleWhenRequested()
+    {
+        var store = new MemoryStore();
+        var service = CreateService(store: store);
+        await service.CreateAsync(new WorkflowScheduleCreateCommand(
+            "morning",
+            "Morning run",
+            "0 9 * * *",
+            "UTC",
+            Target()));
+
+        var scheduledFireAt = DateTimeOffset.Parse("2026-01-01T09:00:00+00:00");
+        await service.RunNowAsync(new WorkflowScheduleFireRequest(
+            "morning",
+            scheduledFireAt,
+            AdvanceSchedule: true));
+
+        var definition = await store.GetAsync("morning");
+        definition!.NextFireAtUtc.Should().Be(DateTimeOffset.Parse("2026-01-02T09:00:00+00:00"));
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldScheduleWakeupForEnabledSchedule()
+    {
+        var wakeup = new RecordingWakeupScheduler();
+        var service = CreateService(wakeupScheduler: wakeup);
+
+        await service.CreateAsync(new WorkflowScheduleCreateCommand(
+            "morning",
+            "Morning run",
+            "0 9 * * *",
+            "UTC",
+            Target()));
+
+        wakeup.Scheduled.Should().ContainSingle(x => x.ScheduleId == "morning");
+    }
+
+    [Fact]
+    public void AddWorkflowApplication_ShouldRegisterScheduleApplicationService()
+    {
+        var services = new ServiceCollection();
+
+        services.AddWorkflowApplication();
+
+        services.Should().Contain(x =>
+            x.ServiceType == typeof(IWorkflowScheduleApplicationService) &&
+            x.ImplementationType == typeof(WorkflowScheduleApplicationService));
+        services.Should().Contain(x =>
+            x.ServiceType == typeof(IWorkflowScheduleWakeupScheduler) &&
+            x.ImplementationType == typeof(NoopWorkflowScheduleWakeupScheduler));
+    }
+
+    private static WorkflowScheduleApplicationService CreateService(
+        IWorkflowScheduleStore? store = null,
+        IWorkflowScheduleWakeupScheduler? wakeupScheduler = null,
+        RecordingDispatchService? dispatch = null) =>
+        new(
+            store ?? new MemoryStore(),
+            wakeupScheduler ?? new NoopWorkflowScheduleWakeupScheduler(),
+            dispatch ?? new RecordingDispatchService(),
+            new FakeTimeProvider(DateTimeOffset.Parse("2026-01-01T00:00:00+00:00")));
+
+    private static WorkflowScheduleTarget Target() =>
+        new(
+            "run the morning workflow",
+            WorkflowChatSource.CatalogWorkflow("direct"),
+            Annotations: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["source"] = "schedule",
+            });
+
+    private sealed class FakeTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+
+    private sealed class RecordingDispatchService
+        : ICommandDispatchService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>
+    {
+        public List<WorkflowChatRunRequest> Requests { get; } = [];
+
+        public Task<CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>> DispatchAsync(
+            WorkflowChatRunRequest command,
+            CancellationToken ct = default)
+        {
+            Requests.Add(command);
+            return Task.FromResult(CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>.Success(
+                new WorkflowChatRunAcceptedReceipt(
+                    "actor-1",
+                    command.WorkflowName ?? "direct",
+                    command.CommandIdSeed ?? "cmd",
+                    command.CorrelationIdSeed ?? "corr")));
+        }
+    }
+
+    private sealed class RecordingWakeupScheduler : IWorkflowScheduleWakeupScheduler
+    {
+        public List<WorkflowScheduleDefinition> Scheduled { get; } = [];
+
+        public List<string> Canceled { get; } = [];
+
+        public Task ScheduleAsync(
+            WorkflowScheduleDefinition definition,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Scheduled.Add(definition);
+            return Task.CompletedTask;
+        }
+
+        public Task CancelAsync(
+            string scheduleId,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Canceled.Add(scheduleId);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class MemoryStore : IWorkflowScheduleStore
+    {
+        private readonly InMemoryStoreInner _inner = new();
+
+        public Task<WorkflowScheduleDefinition?> GetAsync(string scheduleId, CancellationToken ct = default) =>
+            _inner.GetAsync(scheduleId, ct);
+
+        public Task<IReadOnlyList<WorkflowScheduleDefinition>> ListAsync(CancellationToken ct = default) =>
+            _inner.ListAsync(ct);
+
+        public Task AddAsync(WorkflowScheduleDefinition definition, CancellationToken ct = default) =>
+            _inner.AddAsync(definition, ct);
+
+        public Task UpdateAsync(WorkflowScheduleDefinition definition, CancellationToken ct = default) =>
+            _inner.UpdateAsync(definition, ct);
+
+        public Task<WorkflowScheduleRunRecord?> GetRunAsync(string idempotencyKey, CancellationToken ct = default) =>
+            _inner.GetRunAsync(idempotencyKey, ct);
+
+        public Task AddRunAsync(WorkflowScheduleRunRecord run, CancellationToken ct = default) =>
+            _inner.AddRunAsync(run, ct);
+
+        public Task UpdateRunAsync(WorkflowScheduleRunRecord run, CancellationToken ct = default) =>
+            _inner.UpdateRunAsync(run, ct);
+    }
+
+    private sealed class InMemoryStoreInner
+    {
+        private readonly Dictionary<string, WorkflowScheduleDefinition> _schedules = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, WorkflowScheduleRunRecord> _runs = new(StringComparer.Ordinal);
+
+        public Task<WorkflowScheduleDefinition?> GetAsync(string scheduleId, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(_schedules.GetValueOrDefault(scheduleId));
+        }
+
+        public Task<IReadOnlyList<WorkflowScheduleDefinition>> ListAsync(CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult<IReadOnlyList<WorkflowScheduleDefinition>>(_schedules.Values.ToList());
+        }
+
+        public Task AddAsync(WorkflowScheduleDefinition definition, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            _schedules.Add(definition.ScheduleId, definition);
+            return Task.CompletedTask;
+        }
+
+        public Task UpdateAsync(WorkflowScheduleDefinition definition, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            _schedules[definition.ScheduleId] = definition;
+            return Task.CompletedTask;
+        }
+
+        public Task<WorkflowScheduleRunRecord?> GetRunAsync(string idempotencyKey, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(_runs.GetValueOrDefault(idempotencyKey));
+        }
+
+        public Task AddRunAsync(WorkflowScheduleRunRecord run, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            _runs.Add(run.IdempotencyKey, run);
+            return Task.CompletedTask;
+        }
+
+        public Task UpdateRunAsync(WorkflowScheduleRunRecord run, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            _runs[run.IdempotencyKey] = run;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowScheduleInfrastructureTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowScheduleInfrastructureTests.cs
@@ -1,0 +1,462 @@
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.Workflow.Application.Abstractions.Schedules;
+using Aevatar.Workflow.Application.Schedules;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Workflow.Core.Schedules;
+using Aevatar.Workflow.Infrastructure.CapabilityApi;
+using Aevatar.Workflow.Infrastructure.DependencyInjection;
+using Aevatar.Workflow.Infrastructure.Schedules;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Aevatar.Workflow.Host.Api.Tests;
+
+public sealed class WorkflowScheduleInfrastructureTests
+{
+    [Fact]
+    public void MapWorkflowCapabilityEndpoints_ShouldRegisterScheduleRoutes()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Development,
+        });
+        using var app = builder.Build();
+
+        app.MapGroup("/api").MapWorkflowScheduleEndpoints();
+
+        var routes = ((IEndpointRouteBuilder)app).DataSources
+            .SelectMany(x => x.Endpoints)
+            .OfType<RouteEndpoint>()
+            .Select(x => x.RoutePattern.RawText)
+            .Where(x => x != null)
+            .ToHashSet(StringComparer.Ordinal);
+
+        routes.Should().Contain("/api/workflow-schedules/");
+        routes.Should().Contain("/api/workflow-schedules/{scheduleId}");
+        routes.Should().Contain("/api/workflow-schedules/{scheduleId}:enable");
+        routes.Should().Contain("/api/workflow-schedules/{scheduleId}:disable");
+        routes.Should().Contain("/api/workflow-schedules/{scheduleId}:run-now");
+        routes.Should().Contain("/api/workflow-schedules/preview");
+    }
+
+    [Fact]
+    public void AddWorkflowCapabilityServices_ShouldRegisterScheduleStore()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["WorkflowSchedules:Store:StorePath"] = "/tmp/aevatar-workflow-schedules.pb",
+            })
+            .Build();
+
+        services.AddWorkflowCapability(configuration);
+
+        services.Should().Contain(x =>
+            x.ServiceType == typeof(IWorkflowScheduleStore) &&
+            x.ImplementationType == typeof(FileWorkflowScheduleStore));
+        services.Should().Contain(x =>
+            x.ServiceType == typeof(IWorkflowScheduleApplicationService) &&
+            x.ImplementationType == typeof(WorkflowScheduleApplicationService));
+        services.Should().Contain(x =>
+            x.ServiceType == typeof(IHostedService) &&
+            x.ImplementationType == typeof(WorkflowScheduleDispatcherHostedService));
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IOptions<WorkflowScheduleStoreOptions>>().Value.StorePath
+            .Should().Be("/tmp/aevatar-workflow-schedules.pb");
+    }
+
+    [Fact]
+    public async Task FileWorkflowScheduleStore_ShouldRoundTripDefinitionsAndRuns()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"workflow-schedules-{Guid.NewGuid():N}.pb");
+        try
+        {
+            var store = new FileWorkflowScheduleStore(
+                Options.Create(new WorkflowScheduleStoreOptions { StorePath = path }));
+            var definition = new WorkflowScheduleDefinition(
+                "schedule-1",
+                "Schedule One",
+                "0 9 * * *",
+                "UTC",
+                WorkflowScheduleStatus.Enabled,
+                new WorkflowScheduleTarget(
+                    "hello",
+                    WorkflowChatSource.CatalogWorkflow("direct"),
+                    Annotations: new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        ["source"] = "test",
+                    }),
+                DateTimeOffset.Parse("2026-01-01T00:00:00+00:00"),
+                DateTimeOffset.Parse("2026-01-01T00:00:00+00:00"),
+                DateTimeOffset.Parse("2026-01-01T09:00:00+00:00"),
+                new WorkflowScheduleWakeupLease(
+                    "workflow-schedule-wakeup:schedule-1",
+                    "workflow-schedule-due:schedule-1",
+                    7,
+                    WorkflowScheduleWakeupBackend.Dedicated,
+                    2));
+            var run = new WorkflowScheduleRunRecord(
+                "run-1",
+                "schedule-1",
+                DateTimeOffset.Parse("2026-01-01T09:00:00+00:00"),
+                DateTimeOffset.Parse("2026-01-01T09:00:01+00:00"),
+                "schedule:schedule-1:fire:2026-01-01T09:00:00.0000000+00:00",
+                WorkflowScheduleFireStatus.Accepted,
+                "cmd-1",
+                "corr-1",
+                "actor-1");
+
+            await store.AddAsync(definition);
+            await store.AddRunAsync(run);
+
+            var reloaded = new FileWorkflowScheduleStore(
+                Options.Create(new WorkflowScheduleStoreOptions { StorePath = path }));
+            var storedDefinition = await reloaded.GetAsync("schedule-1");
+            var storedRun = await reloaded.GetRunAsync(run.IdempotencyKey);
+
+            storedDefinition.Should().BeEquivalentTo(definition, options => options
+                .Excluding(x => x.Path.EndsWith(".Headers", StringComparison.Ordinal)));
+            storedDefinition!.Target.Headers.Should().BeEmpty();
+            storedRun.Should().BeEquivalentTo(run);
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task OrleansReminderWakeupScheduler_ShouldScheduleDueEventAndPersistLease()
+    {
+        var store = new InMemoryWorkflowScheduleStore();
+        var callbacks = new RecordingRuntimeCallbackScheduler();
+        var runtime = new RecordingActorRuntime();
+        var scheduler = new OrleansReminderWorkflowScheduleWakeupScheduler(
+            callbacks,
+            runtime,
+            store,
+            new FakeTimeProvider(DateTimeOffset.Parse("2026-01-01T08:00:00+00:00")));
+        var definition = Definition("schedule-1") with
+        {
+            NextFireAtUtc = DateTimeOffset.Parse("2026-01-01T09:00:00+00:00"),
+        };
+        await store.AddAsync(definition);
+
+        await scheduler.ScheduleAsync(definition);
+
+        callbacks.Timeouts.Should().ContainSingle();
+        var request = callbacks.Timeouts[0];
+        request.ActorId.Should().Be("workflow-schedule-wakeup:schedule-1");
+        runtime.Created.Should().ContainSingle().Which.Should().Be((
+            typeof(WorkflowScheduleWakeupGAgent),
+            "workflow-schedule-wakeup:schedule-1"));
+        request.CallbackId.Should().Be("workflow-schedule-due:schedule-1");
+        request.DueTime.Should().Be(TimeSpan.FromHours(1));
+        request.DeliveryMode.Should().Be(RuntimeCallbackDeliveryMode.EnvelopeRedelivery);
+        request.TriggerEnvelope.Payload.Should().NotBeNull();
+        request.TriggerEnvelope.Payload!.Is(WorkflowScheduleDueEvent.Descriptor).Should().BeTrue();
+        var due = request.TriggerEnvelope.Payload.Unpack<WorkflowScheduleDueEvent>();
+        due.ScheduleId.Should().Be("schedule-1");
+        due.ScheduledFireAtUnixTimeMs.Should().Be(DateTimeOffset.Parse("2026-01-01T09:00:00+00:00").ToUnixTimeMilliseconds());
+
+        var stored = await store.GetAsync("schedule-1");
+        stored!.WakeupLease.Should().BeEquivalentTo(new WorkflowScheduleWakeupLease(
+            "workflow-schedule-wakeup:schedule-1",
+            "workflow-schedule-due:schedule-1",
+            1,
+            WorkflowScheduleWakeupBackend.Dedicated,
+            2));
+    }
+
+    [Fact]
+    public async Task OrleansReminderWakeupScheduler_ShouldCancelPersistedLease()
+    {
+        var store = new InMemoryWorkflowScheduleStore();
+        var callbacks = new RecordingRuntimeCallbackScheduler();
+        var runtime = new RecordingActorRuntime();
+        var scheduler = new OrleansReminderWorkflowScheduleWakeupScheduler(
+            callbacks,
+            runtime,
+            store,
+            new FakeTimeProvider(DateTimeOffset.Parse("2026-01-01T08:00:00+00:00")));
+        var definition = Definition("schedule-1") with
+        {
+            WakeupLease = new WorkflowScheduleWakeupLease(
+                "workflow-schedule-wakeup:schedule-1",
+                "workflow-schedule-due:schedule-1",
+                4,
+                WorkflowScheduleWakeupBackend.Dedicated,
+                2),
+        };
+        await store.AddAsync(definition);
+
+        await scheduler.CancelAsync("schedule-1");
+
+        callbacks.Cancelled.Should().ContainSingle().Which.Should().BeEquivalentTo(new RuntimeCallbackLease(
+            "workflow-schedule-wakeup:schedule-1",
+            "workflow-schedule-due:schedule-1",
+            4,
+            RuntimeCallbackBackend.Dedicated)
+        {
+            SlotEpoch = 2,
+        });
+        var stored = await store.GetAsync("schedule-1");
+        stored!.WakeupLease.Should().BeNull();
+    }
+
+    [Fact]
+    public void AddWorkflowScheduleInfrastructure_ShouldUseNoopWakeupByDefault()
+    {
+        var services = new ServiceCollection();
+        services.AddWorkflowScheduleInfrastructure();
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IWorkflowScheduleWakeupScheduler>()
+            .Should().BeOfType<NoopWorkflowScheduleWakeupScheduler>();
+    }
+
+    [Fact]
+    public void AddWorkflowScheduleInfrastructure_ShouldUseOrleansWakeupWhenEnabled()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IActorRuntimeCallbackScheduler, RecordingRuntimeCallbackScheduler>();
+        services.AddSingleton<IActorRuntime, RecordingActorRuntime>();
+        services.AddWorkflowScheduleInfrastructure(
+            configureWakeup: options => options.UseOrleansReminders = true);
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IWorkflowScheduleWakeupScheduler>()
+            .Should().BeOfType<OrleansReminderWorkflowScheduleWakeupScheduler>();
+    }
+
+    [Fact]
+    public async Task WorkflowScheduleDueEventHandlerPort_ShouldFireAndAdvanceSchedule()
+    {
+        var schedules = new RecordingScheduleApplicationService();
+        var handler = new WorkflowScheduleDueEventHandlerPort(schedules);
+
+        await handler.HandleDueAsync(new WorkflowScheduleDueEvent
+        {
+            ScheduleId = "schedule-1",
+            ScheduledFireAtUnixTimeMs = DateTimeOffset.Parse("2026-01-01T09:00:00+00:00").ToUnixTimeMilliseconds(),
+        });
+
+        schedules.FireRequests.Should().ContainSingle().Which.Should().BeEquivalentTo(
+            new WorkflowScheduleFireRequest(
+                "schedule-1",
+                DateTimeOffset.Parse("2026-01-01T09:00:00+00:00"),
+                Force: false,
+                AdvanceSchedule: true));
+    }
+
+    private static WorkflowScheduleDefinition Definition(string scheduleId) =>
+        new(
+            scheduleId,
+            "Schedule One",
+            "0 9 * * *",
+            "UTC",
+            WorkflowScheduleStatus.Enabled,
+            new WorkflowScheduleTarget("hello", WorkflowChatSource.CatalogWorkflow("direct")),
+            DateTimeOffset.Parse("2026-01-01T00:00:00+00:00"),
+            DateTimeOffset.Parse("2026-01-01T00:00:00+00:00"),
+            DateTimeOffset.Parse("2026-01-01T09:00:00+00:00"));
+
+    private sealed class FakeTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+
+    private sealed class RecordingRuntimeCallbackScheduler : IActorRuntimeCallbackScheduler
+    {
+        public List<RuntimeCallbackTimeoutRequest> Timeouts { get; } = [];
+
+        public List<RuntimeCallbackLease> Cancelled { get; } = [];
+
+        public Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
+            RuntimeCallbackTimeoutRequest request,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Timeouts.Add(request);
+            return Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                Timeouts.Count,
+                RuntimeCallbackBackend.Dedicated)
+            {
+                SlotEpoch = 2,
+            });
+        }
+
+        public Task<RuntimeCallbackLease> ScheduleTimerAsync(
+            RuntimeCallbackTimerRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                1,
+                RuntimeCallbackBackend.Dedicated)
+            {
+                SlotEpoch = 2,
+            });
+
+        public Task CancelAsync(
+            RuntimeCallbackLease lease,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Cancelled.Add(lease);
+            return Task.CompletedTask;
+        }
+
+        public Task PurgeActorAsync(
+            string actorId,
+            CancellationToken ct = default) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class RecordingActorRuntime : IActorRuntime
+    {
+        private readonly HashSet<string> _actors = new(StringComparer.Ordinal);
+
+        public List<(Type AgentType, string ActorId)> Created { get; } = [];
+
+        public Task<IActor> CreateAsync<TAgent>(
+            string? id = null,
+            CancellationToken ct = default)
+            where TAgent : IAgent =>
+            CreateAsync(typeof(TAgent), id, ct);
+
+        public Task<IActor> CreateAsync(
+            Type agentType,
+            string? id = null,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            var actorId = id ?? Guid.NewGuid().ToString("N");
+            Created.Add((agentType, actorId));
+            _actors.Add(actorId);
+            return Task.FromResult<IActor>(new RecordingActor(actorId));
+        }
+
+        public Task<IActor> CreateByKindAsync(
+            string agentKind,
+            string? id = null,
+            CancellationToken ct = default) =>
+            CreateAsync(typeof(WorkflowScheduleWakeupGAgent), id, ct);
+
+        public Task DestroyAsync(
+            string id,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            _actors.Remove(id);
+            return Task.CompletedTask;
+        }
+
+        public Task<IActor?> GetAsync(string id) =>
+            Task.FromResult<IActor?>(_actors.Contains(id) ? new RecordingActor(id) : null);
+
+        public Task<bool> ExistsAsync(string id) =>
+            Task.FromResult(_actors.Contains(id));
+
+        public Task LinkAsync(
+            string parentId,
+            string childId,
+            CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task UnlinkAsync(
+            string childId,
+            CancellationToken ct = default) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class RecordingActor(string id) : IActor
+    {
+        public string Id { get; } = id;
+
+        public IAgent Agent { get; } = new RecordingAgent(id);
+
+        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
+
+        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() => Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class RecordingAgent(string id) : IAgent
+    {
+        public string Id { get; } = id;
+
+        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task<string> GetDescriptionAsync() => Task.FromResult(Id);
+
+        public Task<IReadOnlyList<Type>> GetSubscribedEventTypesAsync() =>
+            Task.FromResult<IReadOnlyList<Type>>([]);
+    }
+
+    private sealed class RecordingScheduleApplicationService : IWorkflowScheduleApplicationService
+    {
+        public List<WorkflowScheduleFireRequest> FireRequests { get; } = [];
+
+        public Task<WorkflowScheduleResult<WorkflowScheduleFireResult>> RunNowAsync(
+            WorkflowScheduleFireRequest request,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            FireRequests.Add(request);
+            return Task.FromResult(WorkflowScheduleResult<WorkflowScheduleFireResult>.Success(
+                new WorkflowScheduleFireResult(
+                    WorkflowScheduleFireStatus.Accepted,
+                    new WorkflowScheduleRunRecord(
+                        "run-1",
+                        request.ScheduleId,
+                        request.ScheduledFireAtUtc ?? DateTimeOffset.UnixEpoch,
+                        DateTimeOffset.Parse("2026-01-01T09:00:01+00:00"),
+                        "key",
+                        WorkflowScheduleFireStatus.Accepted))));
+        }
+
+        public Task<WorkflowScheduleResult<WorkflowScheduleDefinition>> CreateAsync(WorkflowScheduleCreateCommand command, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<WorkflowScheduleResult<WorkflowScheduleDefinition>> UpdateAsync(string scheduleId, WorkflowScheduleUpdateCommand command, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<WorkflowScheduleResult<WorkflowScheduleDefinition>> EnableAsync(string scheduleId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<WorkflowScheduleResult<WorkflowScheduleDefinition>> DisableAsync(string scheduleId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<WorkflowScheduleResult<WorkflowScheduleDefinition>> GetAsync(string scheduleId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<WorkflowScheduleListResult> ListAsync(WorkflowScheduleListQuery query, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<WorkflowScheduleResult<WorkflowSchedulePreview>> PreviewAsync(string cron, string timezone, DateTimeOffset? fromUtc, int count, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
## Summary
- Add workflow schedule API/application/store surface with protobuf-backed file persistence.
- Add Orleans reminder wakeup mode through `IActorRuntimeCallbackScheduler` and a dedicated wakeup GAgent.
- Persist callback leases and disable polling when Orleans reminder wakeup mode is enabled.

## Test plan
- [x] `dotnet build src/workflow/Aevatar.Workflow.Infrastructure/Aevatar.Workflow.Infrastructure.csproj --nologo`
- [x] `dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo`
- [x] `dotnet test test/Aevatar.Workflow.Application.Tests/Aevatar.Workflow.Application.Tests.csproj --nologo`
- [x] `bash tools/ci/test_stability_guards.sh`

Closes #1852

🤖 Generated with [Claude Code](https://claude.com/claude-code)