### PR TITLE
feat(#1855): workflow run resume proto contracts + read-model seed query

### DIFF
--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -46,7 +46,29 @@ message WorkflowChatRequestEvent {
   WorkflowCallerCredential caller_credential = 10;
 }
 
-message StartWorkflowEvent    { string workflow_name = 1; string input = 2; map<string, string> parameters = 3; string run_id = 4; }
+message WorkflowRunResumeSeed
+{
+  string source_run_id = 1;
+  string start_at_step_id = 2;
+  map<string, string> variables = 3;
+}
+
+message WorkflowRunForkRequestedEvent
+{
+  string source_run_id = 1;
+  string start_at_step_id = 2;
+  int32 attempt = 3;
+  string scope_id = 4;
+}
+
+message StartWorkflowEvent
+{
+  string workflow_name = 1;
+  string input = 2;
+  map<string, string> parameters = 3;
+  string run_id = 4;
+  WorkflowRunResumeSeed resume_seed = 5;
+}
 message BindWorkflowRunDefinitionEvent
 {
   string definition_actor_id = 1;

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowRunPorts.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowRunPorts.cs
@@ -80,6 +80,30 @@ public sealed record WorkflowRunBindingQuery(
     IReadOnlyList<string> DefinitionActorIds,
     int Take = 50);
 
+public sealed record WorkflowRunResumeSeedView(
+    string RunId,
+    string Status,
+    string WorkflowYaml,
+    IReadOnlyDictionary<string, string> InlineWorkflowYamls,
+    IReadOnlyDictionary<string, string> Variables,
+    IReadOnlyList<string> CompletedStepIds,
+    string LastFailedStepId,
+    string FinalError)
+{
+    public WorkflowRunResumeSeedView()
+        : this(
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            new Dictionary<string, string>(StringComparer.Ordinal),
+            [],
+            string.Empty,
+            string.Empty)
+    {
+    }
+}
+
 /// <summary>
 /// Narrow read contract for resolving workflow actor bindings without exposing raw actor state.
 /// </summary>
@@ -100,6 +124,13 @@ public interface IWorkflowRunBindingReader
 
     Task<IReadOnlyList<WorkflowActorBinding>> QueryAsync(
         WorkflowRunBindingQuery query,
+        CancellationToken ct = default);
+}
+
+public interface IWorkflowRunSeedQueryPort
+{
+    Task<WorkflowRunResumeSeedView?> GetResumeSeedAsync(
+        string runId,
         CancellationToken ct = default);
 }
 

--- a/src/workflow/Aevatar.Workflow.Projection/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/DependencyInjection/ServiceCollectionExtensions.cs
@@ -80,6 +80,8 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IProjectionSessionEventHub<WorkflowRunEventEnvelope>, ProjectionSessionEventHub<WorkflowRunEventEnvelope>>();
         services.TryAddSingleton<WorkflowExecutionCurrentStateQueryPort>();
         services.TryAddSingleton<WorkflowExecutionArtifactQueryPort>();
+        services.TryAddSingleton<WorkflowRunResumeSeedReadModelMapper>();
+        services.TryAddSingleton<WorkflowRunSeedQueryPort>();
         services.TryAddSingleton<WorkflowExecutionProjectionPort>();
         services.TryAddSingleton<ProjectionActivationPlanDispatcher>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<
@@ -97,6 +99,8 @@ public static class ServiceCollectionExtensions
             sp.GetRequiredService<WorkflowExecutionProjectionPort>());
         services.TryAddSingleton<IWorkflowExecutionCurrentStateQueryPort>(sp =>
             sp.GetRequiredService<WorkflowExecutionCurrentStateQueryPort>());
+        services.TryAddSingleton<IWorkflowRunSeedQueryPort>(sp =>
+            sp.GetRequiredService<WorkflowRunSeedQueryPort>());
         services.TryAddSingleton<IWorkflowExecutionArtifactQueryPort>(sp =>
             sp.GetRequiredService<WorkflowExecutionArtifactQueryPort>());
         services.TryAddSingleton<IWorkflowChatRunObservationScopeLeasePreparationPort, WorkflowChatRunObservationScopeLeasePreparationPort>();

--- a/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowRunSeedQueryPort.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowRunSeedQueryPort.cs
@@ -1,0 +1,51 @@
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.Workflow.Core.Primitives;
+using Aevatar.Workflow.Projection.Configuration;
+using Aevatar.Workflow.Projection.ReadModels;
+
+namespace Aevatar.Workflow.Projection.Orchestration;
+
+public sealed class WorkflowRunSeedQueryPort : IWorkflowRunSeedQueryPort
+{
+    private readonly IProjectionDocumentReader<WorkflowExecutionCurrentStateDocument, string> _currentStateReader;
+    private readonly IWorkflowRunBindingReader _runBindingReader;
+    private readonly WorkflowRunResumeSeedReadModelMapper _mapper;
+    private readonly bool _queryEnabled;
+
+    public WorkflowRunSeedQueryPort(
+        IProjectionDocumentReader<WorkflowExecutionCurrentStateDocument, string> currentStateReader,
+        IWorkflowRunBindingReader runBindingReader,
+        WorkflowRunResumeSeedReadModelMapper mapper,
+        WorkflowExecutionProjectionOptions? options = null)
+    {
+        _currentStateReader = currentStateReader ?? throw new ArgumentNullException(nameof(currentStateReader));
+        _runBindingReader = runBindingReader ?? throw new ArgumentNullException(nameof(runBindingReader));
+        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        _queryEnabled = options == null || (options.Enabled && options.WorkflowActorCurrentStateQueryEnabled);
+    }
+
+    public async Task<WorkflowRunResumeSeedView?> GetResumeSeedAsync(
+        string runId,
+        CancellationToken ct = default)
+    {
+        if (!_queryEnabled || string.IsNullOrWhiteSpace(runId))
+            return null;
+
+        var normalizedRunId = WorkflowRunIdNormalizer.Normalize(runId);
+        var bindings = await _runBindingReader.ListByRunIdAsync(normalizedRunId, take: 20, ct);
+        foreach (var binding in bindings)
+        {
+            if (binding.ActorKind != WorkflowActorKind.Run || string.IsNullOrWhiteSpace(binding.ActorId))
+                continue;
+
+            var currentState = await _currentStateReader.GetAsync(binding.ActorId, ct);
+            if (currentState == null)
+                continue;
+
+            return _mapper.ToSeedView(currentState);
+        }
+
+        return null;
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowExecutionCurrentStateProjector.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowExecutionCurrentStateProjector.cs
@@ -10,6 +10,8 @@ public sealed class WorkflowExecutionCurrentStateProjector
         WorkflowRunState,
         WorkflowExecutionCurrentStateDocument>
 {
+    private readonly WorkflowRunResumeSeedReadModelMapper _resumeSeedMapper = new();
+
     public WorkflowExecutionCurrentStateProjector(
         IProjectionWriteDispatcher<WorkflowExecutionCurrentStateDocument> writeDispatcher,
         IProjectionClock clock)
@@ -31,6 +33,7 @@ public sealed class WorkflowExecutionCurrentStateProjector
 
         var stateEvent = input.StateEvent;
         var state = input.State;
+        var seedSnapshot = _resumeSeedMapper.ToProjectionSnapshot(state);
 
         // Refactor (iter97/cluster-591): Old/New
         //   Old: every current-state projector hand-rolled committed-state unpack, timestamp resolution, and upsert.
@@ -54,6 +57,17 @@ public sealed class WorkflowExecutionCurrentStateProjector
             StateVersion = stateEvent.Version,
             LastEventId = stateEvent.EventId ?? string.Empty,
             UpdatedAt = input.ObservedAt,
+            WorkflowYaml = seedSnapshot.WorkflowYaml,
+            InlineWorkflowYamls = seedSnapshot.InlineWorkflowYamls.ToDictionary(
+                x => x.Key,
+                x => x.Value,
+                StringComparer.Ordinal),
+            ResumeSeedVariables = seedSnapshot.Variables.ToDictionary(
+                x => x.Key,
+                x => x.Value,
+                StringComparer.Ordinal),
+            ResumeSeedCompletedStepIds = seedSnapshot.CompletedStepIds.ToList(),
+            ResumeSeedLastFailedStepId = seedSnapshot.LastFailedStepId,
         };
     }
 

--- a/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowRunReadModels.Partial.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowRunReadModels.Partial.cs
@@ -175,6 +175,24 @@ public sealed partial class WorkflowExecutionCurrentStateDocument : IProjectionR
         get => SuccessWrapper;
         set => SuccessWrapper = value;
     }
+
+    public IDictionary<string, string> InlineWorkflowYamls
+    {
+        get => InlineWorkflowYamlEntries;
+        set => WorkflowExecutionReadModelCollections.ReplaceMap(InlineWorkflowYamlEntries, value);
+    }
+
+    public IDictionary<string, string> ResumeSeedVariables
+    {
+        get => ResumeSeedVariableEntries;
+        set => WorkflowExecutionReadModelCollections.ReplaceMap(ResumeSeedVariableEntries, value);
+    }
+
+    public IList<string> ResumeSeedCompletedStepIds
+    {
+        get => ResumeSeedCompletedStepIdEntries;
+        set => WorkflowExecutionReadModelCollections.ReplaceCollection(ResumeSeedCompletedStepIdEntries, value);
+    }
 }
 
 public sealed partial class WorkflowExecutionSummary

--- a/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowRunResumeSeedReadModelMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowRunResumeSeedReadModelMapper.cs
@@ -1,0 +1,90 @@
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.Workflow.Core;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Workflow.Projection.ReadModels;
+
+public sealed class WorkflowRunResumeSeedReadModelMapper
+{
+    private const string InputVariableKey = "input";
+    private const string WorkflowCallInvocationIdVariableKey = "workflow_call.invocation_id";
+    private const string WorkflowUsageVariablePrefix = "workflow.usage.";
+    private const string StepMirrorVariablePrefix = "steps.";
+    private const string FailedStatus = "failed";
+
+    public WorkflowRunResumeSeedView ToSeedView(WorkflowExecutionCurrentStateDocument source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        return new WorkflowRunResumeSeedView(
+            source.RunId ?? string.Empty,
+            source.Status ?? string.Empty,
+            source.WorkflowYaml ?? string.Empty,
+            CopyMap(source.InlineWorkflowYamls),
+            CopyMap(source.ResumeSeedVariables),
+            source.ResumeSeedCompletedStepIds.ToList(),
+            source.ResumeSeedLastFailedStepId ?? string.Empty,
+            source.FinalError ?? string.Empty);
+    }
+
+    public WorkflowRunResumeSeedProjectionSnapshot ToProjectionSnapshot(WorkflowRunState state)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+
+        var kernelState = TryReadKernelState(state);
+        var variables = kernelState == null
+            ? new Dictionary<string, string>(StringComparer.Ordinal)
+            : CopyMap(kernelState.Variables);
+        var completedStepIds = ResolveCompletedStepIds(variables);
+        var lastFailedStepId = string.Equals(state.Status, FailedStatus, StringComparison.OrdinalIgnoreCase)
+            ? kernelState?.CurrentStepId?.Trim() ?? string.Empty
+            : string.Empty;
+
+        return new WorkflowRunResumeSeedProjectionSnapshot(
+            state.WorkflowYaml ?? string.Empty,
+            CopyMap(state.InlineWorkflowYamls),
+            variables,
+            completedStepIds,
+            lastFailedStepId);
+    }
+
+    private static WorkflowExecutionKernelState? TryReadKernelState(WorkflowRunState state)
+    {
+        foreach (var packedState in state.ExecutionStates.Values)
+        {
+            if (packedState?.Is(WorkflowExecutionKernelState.Descriptor) == true)
+                return packedState.Unpack<WorkflowExecutionKernelState>();
+        }
+
+        return null;
+    }
+
+    private static IReadOnlyList<string> ResolveCompletedStepIds(IReadOnlyDictionary<string, string> variables) =>
+        variables.Keys
+            .Where(IsCompletedStepVariableKey)
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToList();
+
+    private static bool IsCompletedStepVariableKey(string key)
+    {
+        var trimmed = key.Trim();
+        return !string.IsNullOrWhiteSpace(trimmed) &&
+               !string.Equals(trimmed, InputVariableKey, StringComparison.Ordinal) &&
+               !string.Equals(trimmed, WorkflowCallInvocationIdVariableKey, StringComparison.Ordinal) &&
+               !trimmed.StartsWith(WorkflowUsageVariablePrefix, StringComparison.Ordinal) &&
+               !trimmed.StartsWith(StepMirrorVariablePrefix, StringComparison.Ordinal);
+    }
+
+    private static Dictionary<string, string> CopyMap(IDictionary<string, string> source) =>
+        source.ToDictionary(
+            x => x.Key,
+            x => x.Value,
+            StringComparer.Ordinal);
+}
+
+public sealed record WorkflowRunResumeSeedProjectionSnapshot(
+    string WorkflowYaml,
+    IReadOnlyDictionary<string, string> InlineWorkflowYamls,
+    IReadOnlyDictionary<string, string> Variables,
+    IReadOnlyList<string> CompletedStepIds,
+    string LastFailedStepId);

--- a/src/workflow/Aevatar.Workflow.Projection/workflow_projection_transport.proto
+++ b/src/workflow/Aevatar.Workflow.Projection/workflow_projection_transport.proto
@@ -51,6 +51,11 @@ message WorkflowExecutionCurrentStateDocument {
   string final_error = 15;
   int32 execution_state_count = 16;
   google.protobuf.BoolValue success_wrapper = 17;
+  string workflow_yaml = 18;
+  map<string, string> inline_workflow_yaml_entries = 19;
+  map<string, string> resume_seed_variable_entries = 20;
+  repeated string resume_seed_completed_step_id_entries = 21;
+  string resume_seed_last_failed_step_id = 22;
 }
 
 message WorkflowExecutionTopologyEdge {

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunSeedQueryPortTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunSeedQueryPortTests.cs
@@ -1,0 +1,185 @@
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.Foundation.Projection.ReadModels;
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.Workflow.Core;
+using Aevatar.Workflow.Projection.Orchestration;
+using Aevatar.Workflow.Projection.ReadModels;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Workflow.Application.Tests;
+
+public sealed class WorkflowRunSeedQueryPortTests
+{
+    [Fact]
+    public void ResumeSeedReadModelMapper_ShouldMapCompletedRunSeed()
+    {
+        var state = BuildWorkflowRunState("run-completed", "completed", finalError: string.Empty);
+        state.ExecutionStates["kernel-state"] = Any.Pack(new WorkflowExecutionKernelState
+        {
+            CurrentStepId = string.Empty,
+            Variables =
+            {
+                ["input"] = "latest-input",
+                ["step-a"] = "alpha",
+                ["step-b"] = "bravo",
+                ["workflow.usage.total_tokens"] = "12",
+                ["steps.step-a.output"] = "alpha",
+                ["steps.step-a.success"] = "true",
+                ["workflow_call.invocation_id"] = "call-1",
+            },
+        });
+
+        var mapper = new WorkflowRunResumeSeedReadModelMapper();
+        var snapshot = mapper.ToProjectionSnapshot(state);
+        var document = BuildDocument(state, snapshot);
+        var view = mapper.ToSeedView(document);
+
+        view.RunId.Should().Be("run-completed");
+        view.Status.Should().Be("completed");
+        view.WorkflowYaml.Should().Be("name: demo\nsteps: []");
+        view.InlineWorkflowYamls.Should().Contain("child", "name: child");
+        view.Variables.Should().Contain("step-a", "alpha");
+        view.Variables.Should().Contain("workflow.usage.total_tokens", "12");
+        view.CompletedStepIds.Should().Equal("step-a", "step-b");
+        view.LastFailedStepId.Should().BeEmpty();
+        view.FinalError.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetResumeSeedAsync_ShouldReadFailedRunSeedThroughCurrentStateReadModel()
+    {
+        var state = BuildWorkflowRunState("run-failed", "failed", "step boom");
+        state.ExecutionStates["kernel-state"] = Any.Pack(new WorkflowExecutionKernelState
+        {
+            CurrentStepId = "step-failed",
+            Variables =
+            {
+                ["input"] = "failed-input",
+                ["step-a"] = "alpha",
+                ["step-b"] = "bravo",
+                ["steps.step-b.error"] = string.Empty,
+            },
+        });
+
+        var mapper = new WorkflowRunResumeSeedReadModelMapper();
+        var currentStateReader = new RecordingDocumentReader<WorkflowExecutionCurrentStateDocument>
+        {
+            Item = BuildDocument(state, mapper.ToProjectionSnapshot(state)),
+        };
+        var bindingReader = new FakeWorkflowRunBindingReader(
+            new WorkflowActorBinding(
+                WorkflowActorKind.Run,
+                "actor-run-failed",
+                "definition-1",
+                "run-failed",
+                "demo",
+                "name: demo\nsteps: []",
+                new Dictionary<string, string>(StringComparer.Ordinal)));
+        var port = new WorkflowRunSeedQueryPort(
+            currentStateReader,
+            bindingReader,
+            mapper);
+
+        var view = await port.GetResumeSeedAsync("run-failed", CancellationToken.None);
+
+        view.Should().NotBeNull();
+        view!.Status.Should().Be("failed");
+        view.WorkflowYaml.Should().Be("name: demo\nsteps: []");
+        view.Variables.Should().Contain("step-a", "alpha");
+        view.Variables.Should().Contain("step-b", "bravo");
+        view.CompletedStepIds.Should().Equal("step-a", "step-b");
+        view.LastFailedStepId.Should().Be("step-failed");
+        view.FinalError.Should().Be("step boom");
+        bindingReader.RequestedRunIds.Should().ContainSingle().Which.Should().Be("run-failed");
+        currentStateReader.GetKeys.Should().ContainSingle().Which.Should().Be("actor-run-failed");
+    }
+
+    private static WorkflowRunState BuildWorkflowRunState(
+        string runId,
+        string status,
+        string finalError) =>
+        new()
+        {
+            RunId = runId,
+            Status = status,
+            WorkflowName = "demo",
+            WorkflowYaml = "name: demo\nsteps: []",
+            FinalError = finalError,
+            InlineWorkflowYamls = { ["child"] = "name: child" },
+        };
+
+    private static WorkflowExecutionCurrentStateDocument BuildDocument(
+        WorkflowRunState state,
+        WorkflowRunResumeSeedProjectionSnapshot seedSnapshot) =>
+        new()
+        {
+            Id = $"actor-{state.RunId}",
+            RootActorId = $"actor-{state.RunId}",
+            RunId = state.RunId,
+            WorkflowName = state.WorkflowName,
+            Status = state.Status,
+            FinalError = state.FinalError,
+            WorkflowYaml = seedSnapshot.WorkflowYaml,
+            InlineWorkflowYamls = seedSnapshot.InlineWorkflowYamls.ToDictionary(
+                x => x.Key,
+                x => x.Value,
+                StringComparer.Ordinal),
+            ResumeSeedVariables = seedSnapshot.Variables.ToDictionary(
+                x => x.Key,
+                x => x.Value,
+                StringComparer.Ordinal),
+            ResumeSeedCompletedStepIds = seedSnapshot.CompletedStepIds.ToList(),
+            ResumeSeedLastFailedStepId = seedSnapshot.LastFailedStepId,
+        };
+
+    private sealed class FakeWorkflowRunBindingReader(params WorkflowActorBinding[] bindings)
+        : IWorkflowRunBindingReader
+    {
+        private readonly IReadOnlyList<WorkflowActorBinding> _bindings = bindings;
+
+        public List<string> RequestedRunIds { get; } = [];
+
+        public Task<IReadOnlyList<WorkflowActorBinding>> ListByRunIdAsync(
+            string runId,
+            int take = 20,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            RequestedRunIds.Add(runId);
+            return Task.FromResult(_bindings);
+        }
+
+        public Task<IReadOnlyList<WorkflowActorBinding>> QueryAsync(
+            WorkflowRunBindingQuery query,
+            CancellationToken ct = default)
+        {
+            _ = query;
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult<IReadOnlyList<WorkflowActorBinding>>([]);
+        }
+    }
+
+    private sealed class RecordingDocumentReader<TReadModel> : IProjectionDocumentReader<TReadModel, string>
+        where TReadModel : class, IProjectionReadModel
+    {
+        public TReadModel? Item { get; init; }
+        public List<string> GetKeys { get; } = [];
+
+        public Task<TReadModel?> GetAsync(string key, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            GetKeys.Add(key);
+            return Task.FromResult(Item);
+        }
+
+        public Task<ProjectionDocumentQueryResult<TReadModel>> QueryAsync(
+            ProjectionDocumentQuery query,
+            CancellationToken ct = default)
+        {
+            _ = query;
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(ProjectionDocumentQueryResult<TReadModel>.Empty);
+        }
+    }
+}

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowAbstractionsProtoCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowAbstractionsProtoCoverageTests.cs
@@ -13,8 +13,14 @@ public class WorkflowAbstractionsProtoCoverageTests
         {
             WorkflowName = "wf",
             Input = "{\"a\":1}",
+            ResumeSeed = new WorkflowRunResumeSeed
+            {
+                SourceRunId = "run-source",
+                StartAtStepId = "step-b",
+            },
         };
         evt.Parameters["k"] = "v";
+        evt.ResumeSeed.Variables["step-a"] = "alpha";
 
         var clone = evt.Clone();
         clone.Should().BeEquivalentTo(evt);
@@ -23,6 +29,35 @@ public class WorkflowAbstractionsProtoCoverageTests
         parsed.WorkflowName.Should().Be("wf");
         parsed.Input.Should().Contain("a");
         parsed.Parameters["k"].Should().Be("v");
+        parsed.ResumeSeed.SourceRunId.Should().Be("run-source");
+        parsed.ResumeSeed.StartAtStepId.Should().Be("step-b");
+        parsed.ResumeSeed.Variables["step-a"].Should().Be("alpha");
+    }
+
+    [Fact]
+    public void WorkflowRunResumeSeedAndForkRequestedEvent_ShouldRoundtrip()
+    {
+        var seed = new WorkflowRunResumeSeed
+        {
+            SourceRunId = "run-source",
+            StartAtStepId = "step-b",
+        };
+        seed.Variables["step-a"] = "alpha";
+
+        var parsedSeed = WorkflowRunResumeSeed.Parser.ParseFrom(seed.ToByteArray());
+        parsedSeed.Should().BeEquivalentTo(seed);
+
+        var requested = new WorkflowRunForkRequestedEvent
+        {
+            SourceRunId = "run-source",
+            StartAtStepId = "step-b",
+            Attempt = 2,
+            ScopeId = "scope-1",
+        };
+        var parsedRequested = WorkflowRunForkRequestedEvent.Parser.ParseFrom(requested.ToByteArray());
+        parsedRequested.Should().BeEquivalentTo(requested);
+        ((IMessage)parsedSeed).Descriptor.Name.Should().Be(nameof(WorkflowRunResumeSeed));
+        ((IMessage)parsedRequested).Descriptor.Name.Should().Be(nameof(WorkflowRunForkRequestedEvent));
     }
 
     [Fact]
@@ -275,6 +310,8 @@ public class WorkflowAbstractionsProtoCoverageTests
     {
         WorkflowExecutionMessagesReflection.Descriptor.Should().NotBeNull();
         WorkflowExecutionMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(StartWorkflowEvent));
+        WorkflowExecutionMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(WorkflowRunResumeSeed));
+        WorkflowExecutionMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(WorkflowRunForkRequestedEvent));
         WorkflowExecutionMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(WorkflowCompletedEvent));
         WorkflowExecutionMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(StepRequestEvent));
         WorkflowExecutionMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(StepCompletedEvent));


### PR DESCRIPTION
S1 of epic #1854（workflow run 失败恢复 / fork-from-step）。承接 #1855。

设计 spec：`docs/design/2026-06-08-workflow-run-resume-from-step-design.md`（§5 proto、§6 Unit 1）。

## 内容
- **proto 契约**：`WorkflowRunResumeSeed`、`WorkflowRunForkRequestedEvent`、`StartWorkflowEvent.resume_seed`（field 5）。
- **读侧 seed 查询**：`IWorkflowRunSeedQueryPort` + `WorkflowRunResumeSeedView`（Application.Abstractions）。
- **实现走 read-model（CQRS 正路，非 actor 侧读）**：projection transport 字段 18-22 + projector 物化 + `WorkflowRunResumeSeedReadModelMapper` + `WorkflowRunSeedQueryPort`（经 `IProjectionDocumentReader` + `IWorkflowRunBindingReader`，不 replay、不侧读 event store）。

> 注：spec §6 原写"由 WorkflowRunGAgent 暴露"，实现改为 read-model 查询路径——更符合 CLAUDE.md「查询始终走 readmodel」。契约 `IWorkflowRunSeedQueryPort` 不变，下游 S3 不受影响。

## 验证
build 0 error；Core.Tests 427 ✓、Application.Tests 255 ✓、Host.Api proto-coverage 10 ✓；architecture_guards + test_stability_guards 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)