### PR TITLE
feat(#1856): execution kernel start-from-step + resume seed hydration

### DIFF
--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
@@ -122,15 +122,28 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
         state.Usage = new WorkflowUsageMetricsState();
         state.CurrentStepDispatchPending = false;
         state.CurrentStepTimeoutCallbackId = string.Empty;
+        var resumeSeed = evt.ResumeSeed;
+        var hasResumeSeedStart = resumeSeed != null && !string.IsNullOrWhiteSpace(resumeSeed.StartAtStepId);
+        if (hasResumeSeedStart)
+        {
+            foreach (var (key, value) in resumeSeed!.Variables)
+                state.Variables[key] = value ?? string.Empty;
+        }
+
         state.Variables["input"] = evt.Input ?? string.Empty;
         MirrorRunUsageVariables(state);
         MergeStartParametersIntoVariables(state.Variables, evt.Parameters);
         await SaveStateAsync(state, ctx, ct);
 
-        var entry = _workflow.Steps.FirstOrDefault();
+        var entry = hasResumeSeedStart
+            ? _workflow.Steps.FirstOrDefault(s => string.Equals(s.Id, resumeSeed!.StartAtStepId, StringComparison.Ordinal))
+            : _workflow.Steps.FirstOrDefault();
         if (entry == null)
         {
             await CleanupRunAsync(state, ctx, ct);
+            var error = hasResumeSeedStart
+                ? $"resume start step '{resumeSeed!.StartAtStepId}' not found in workflow"
+                : "无步骤";
             await PublishWorkflowCompletedAsync(
                 ctx,
                 new WorkflowCompletedEvent
@@ -138,13 +151,16 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                     WorkflowName = _workflow.Name,
                     RunId = runId,
                     Success = false,
-                    Error = "无步骤",
+                    Error = error,
                 },
                 ct);
             return;
         }
 
-        await DispatchStepAsync(entry, evt.Input ?? string.Empty, state, ctx, ct);
+        var startInput = hasResumeSeedStart && resumeSeed!.Variables.TryGetValue("input", out var seedInput)
+            ? seedInput
+            : evt.Input ?? string.Empty;
+        await DispatchStepAsync(entry, startInput ?? string.Empty, state, ctx, ct);
     }
 
     private async Task HandleTimeoutFiredAsync(

--- a/test/Aevatar.Workflow.Core.Tests/Execution/IdempotentStepExecutionTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/IdempotentStepExecutionTests.cs
@@ -21,6 +21,27 @@ public sealed class IdempotentStepExecutionTests
         Steps = [new StepDefinition { Id = stepId, Type = "llm_call", TargetRole = "worker" }],
     };
 
+    private static WorkflowDefinition ThreeStepWorkflow() => new()
+    {
+        Name = "test-resume-workflow",
+        Roles = [new RoleDefinition { Id = "worker", Name = "Worker" }],
+        Steps =
+        [
+            new StepDefinition { Id = "step-a", Type = "transform" },
+            new StepDefinition
+            {
+                Id = "step-b",
+                Type = "transform",
+                Parameters =
+                {
+                    ["summary"] = "${concat(step_a_output, ':', topic, ':', input)}",
+                    ["topic_value"] = "${topic}",
+                },
+            },
+            new StepDefinition { Id = "step-c", Type = "transform" },
+        ],
+    };
+
     private static EventEnvelope Wrap(IMessage msg) => new()
     {
         Id = Guid.NewGuid().ToString("N"),
@@ -363,7 +384,156 @@ public sealed class IdempotentStepExecutionTests
         state.Variables["steps.step-1.usage.model"].Should().Be("gpt-5.4");
     }
 
+    [Fact]
+    public async Task StartWorkflow_WithResumeSeed_ShouldDispatchSeedStartStepAndHydrateVariables()
+    {
+        var ctx = new RecordingEventHandlerContext();
+        var host = new RecordingStateHost();
+        var kernel = new WorkflowExecutionKernel(ThreeStepWorkflow(), host);
+        var start = new StartWorkflowEvent
+        {
+            RunId = "run-resume",
+            Input = "fresh-input",
+            ResumeSeed = new WorkflowRunResumeSeed
+            {
+                SourceRunId = "run-source",
+                StartAtStepId = "step-b",
+            },
+        };
+        start.ResumeSeed.Variables["input"] = "seed-input";
+        start.ResumeSeed.Variables["step_a_output"] = "alpha";
+        start.ResumeSeed.Variables["topic"] = "seed-topic";
+
+        await kernel.HandleAsync(Wrap(start), ctx, CancellationToken.None);
+
+        var requests = StepRequests(ctx);
+        requests.Should().ContainSingle();
+        requests[0].StepId.Should().Be("step-b");
+        requests[0].Input.Should().Be("seed-input");
+        requests[0].Parameters["summary"].Should().Be("alpha:seed-topic:seed-input");
+        requests.Should().NotContain(x => x.StepId == "step-a");
+
+        var state = LoadKernelState(host);
+        state.CurrentStepId.Should().Be("step-b");
+        state.CurrentStepInput.Should().Be("seed-input");
+        state.Variables["step_a_output"].Should().Be("alpha");
+        state.Variables["topic"].Should().Be("seed-topic");
+    }
+
+    [Fact]
+    public async Task StartWorkflow_WithResumeSeedMissingStartStep_ShouldPublishFailureWithoutDispatch()
+    {
+        var ctx = new RecordingEventHandlerContext();
+        var host = new RecordingStateHost();
+        var kernel = new WorkflowExecutionKernel(ThreeStepWorkflow(), host);
+        var start = new StartWorkflowEvent
+        {
+            RunId = "run-resume",
+            Input = "fresh-input",
+            ResumeSeed = new WorkflowRunResumeSeed
+            {
+                SourceRunId = "run-source",
+                StartAtStepId = "missing-step",
+            },
+        };
+        start.ResumeSeed.Variables["step_a_output"] = "alpha";
+
+        await kernel.HandleAsync(Wrap(start), ctx, CancellationToken.None);
+
+        StepRequests(ctx).Should().BeEmpty();
+        var completions = WorkflowCompletions(ctx);
+        completions.Should().HaveCount(2);
+        completions.Should().OnlyContain(x => !x.Success);
+        completions.Should().OnlyContain(
+            x => x.Error == "resume start step 'missing-step' not found in workflow");
+        host.GetExecutionState("workflow_execution_kernel").Should().BeNull();
+    }
+
+    [Fact]
+    public async Task StartWorkflow_WithResumeSeed_ShouldLetStartParametersOverrideSeedVariables()
+    {
+        var ctx = new RecordingEventHandlerContext();
+        var host = new RecordingStateHost();
+        var kernel = new WorkflowExecutionKernel(ThreeStepWorkflow(), host);
+        var start = new StartWorkflowEvent
+        {
+            RunId = "run-resume",
+            Input = "fresh-input",
+            ResumeSeed = new WorkflowRunResumeSeed
+            {
+                SourceRunId = "run-source",
+                StartAtStepId = "step-b",
+            },
+        };
+        start.ResumeSeed.Variables["input"] = "seed-input";
+        start.ResumeSeed.Variables["step_a_output"] = "alpha";
+        start.ResumeSeed.Variables["topic"] = "seed-topic";
+        start.Parameters["topic"] = "parameter-topic";
+
+        await kernel.HandleAsync(Wrap(start), ctx, CancellationToken.None);
+
+        var request = StepRequests(ctx).Single();
+        request.StepId.Should().Be("step-b");
+        request.Input.Should().Be("seed-input");
+        request.Parameters["topic_value"].Should().Be("parameter-topic");
+
+        var state = LoadKernelState(host);
+        state.Variables["topic"].Should().Be("parameter-topic");
+        state.Variables["step_a_output"].Should().Be("alpha");
+    }
+
+    [Fact]
+    public async Task StartWorkflow_WithoutResumeSeed_ShouldDispatchFirstStepWithFreshVariables()
+    {
+        var ctx = new RecordingEventHandlerContext();
+        var host = new RecordingStateHost();
+        var kernel = new WorkflowExecutionKernel(ThreeStepWorkflow(), host);
+
+        await kernel.HandleAsync(
+            Wrap(new StartWorkflowEvent { RunId = "run-plain", Input = "fresh-input" }),
+            ctx,
+            CancellationToken.None);
+
+        var requests = StepRequests(ctx);
+        requests.Should().ContainSingle();
+        requests[0].StepId.Should().Be("step-a");
+        requests[0].Input.Should().Be("fresh-input");
+
+        var state = LoadKernelState(host);
+        state.Variables["input"].Should().Be("fresh-input");
+        state.Variables.Should().NotContainKey("step_a_output");
+        state.Variables.Keys.Should().BeEquivalentTo(DefaultStartVariableKeys);
+    }
+
     // ──── Test infrastructure ────
+
+    private static readonly string[] DefaultStartVariableKeys =
+    [
+        "input",
+        "workflow.usage.prompt_tokens",
+        "workflow.usage.completion_tokens",
+        "workflow.usage.total_tokens",
+        "workflow.usage.model",
+        "workflow.usage.cost",
+        "workflow.usage.latency_ms",
+    ];
+
+    private static IReadOnlyList<StepRequestEvent> StepRequests(RecordingEventHandlerContext ctx) =>
+        ctx.Published
+            .Select(p => p.Event)
+            .Where(e => e.Is(StepRequestEvent.Descriptor))
+            .Select(e => e.Unpack<StepRequestEvent>())
+            .ToList();
+
+    private static IReadOnlyList<WorkflowCompletedEvent> WorkflowCompletions(RecordingEventHandlerContext ctx) =>
+        ctx.Published
+            .Select(p => p.Event)
+            .Where(e => e.Is(WorkflowCompletedEvent.Descriptor))
+            .Select(e => e.Unpack<WorkflowCompletedEvent>())
+            .ToList();
+
+    private static WorkflowExecutionKernelState LoadKernelState(RecordingStateHost host) =>
+        host.GetExecutionState("workflow_execution_kernel")!.Unpack<WorkflowExecutionKernelState>();
 
     private sealed class RecordingEventHandlerContext : IEventHandlerContext
     {


### PR DESCRIPTION
S2 of epic #1854。承接 #1856。spec §8。

## 内容
`WorkflowExecutionKernel.HandleStartWorkflowAsync` 处理 `StartWorkflowEvent.resume_seed`：
- 注入 seed.variables（优先级 seed → input → start params）。
- 从 `resume_seed.start_at_step_id` 起跑（非第一步）；该 step 不存在 → loud fail（`WorkflowCompletedEvent.Success=false`, error 指明缺失 step）。
- start step input = seed `input`（有则）否则 `evt.Input`。
- **不复用** `WorkflowResumedEvent`（挂起恢复是独立路径）。

seed 经 `StartWorkflowEvent` 到达（S3 fork service 直接 dispatch start-with-seed，不走 bind）。

## 验证
build 0 err；Core.Tests 431 ✓（+4 新测试：valid seed dispatch+hydrate / missing step 失败 / 优先级 / no-seed 回归）；architecture_guards + test_stability_guards 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)