### PR TITLE
feat(#1861): typed InteractionSpec 契约 (Foundation) + InteractionSpecMapper + workflow typed lift

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Abstractions/InteractionSpecMapper.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/InteractionSpecMapper.cs
@@ -49,17 +49,6 @@ public static class InteractionSpecMapper
         return content;
     }
 
-    /// <summary>
-    /// Returns true when the interaction contract contains visible text or controls.
-    /// </summary>
-    public static bool HasVisibleContent(InteractionSpec? spec) =>
-        spec is not null &&
-        (!string.IsNullOrWhiteSpace(spec.Title) ||
-         !string.IsNullOrWhiteSpace(spec.Body) ||
-         spec.Actions.Count > 0 ||
-         spec.Fields.Count > 0 ||
-         spec.Cards.Count > 0);
-
     private static bool ShouldBuildTopLevelCard(InteractionSpec spec) =>
         !string.IsNullOrWhiteSpace(spec.Title) &&
         spec.Cards.Count == 0 &&

--- a/agents/Aevatar.GAgents.Channel.Abstractions/InteractionSpecMapper.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/InteractionSpecMapper.cs
@@ -1,0 +1,198 @@
+using Aevatar.Foundation.Abstractions.Interactions;
+
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Maps channel-neutral interaction contracts onto outbound channel message content.
+/// </summary>
+public static class InteractionSpecMapper
+{
+    /// <summary>
+    /// Converts a typed interaction contract into composer-ready message content.
+    /// </summary>
+    public static MessageContent ToMessageContent(InteractionSpec spec)
+    {
+        ArgumentNullException.ThrowIfNull(spec);
+
+        var content = new MessageContent
+        {
+            Text = BuildTopLevelText(spec.Title, spec.Body),
+            Disposition = MapDisposition(spec.Disposition),
+        };
+
+        foreach (var action in spec.Actions)
+        {
+            var mapped = MapAction(action);
+            if (mapped is not null)
+                content.Actions.Add(mapped);
+        }
+
+        if (ShouldBuildTopLevelCard(spec))
+        {
+            var card = new CardBlock
+            {
+                Kind = CardBlockKind.Section,
+                Title = spec.Title ?? string.Empty,
+                Text = spec.Body ?? string.Empty,
+            };
+            AppendFields(card, spec.Fields);
+            content.Cards.Add(card);
+        }
+
+        foreach (var card in spec.Cards)
+        {
+            var mapped = MapCard(card);
+            if (mapped is not null)
+                content.Cards.Add(mapped);
+        }
+
+        return content;
+    }
+
+    /// <summary>
+    /// Returns true when the interaction contract contains visible text or controls.
+    /// </summary>
+    public static bool HasVisibleContent(InteractionSpec? spec) =>
+        spec is not null &&
+        (!string.IsNullOrWhiteSpace(spec.Title) ||
+         !string.IsNullOrWhiteSpace(spec.Body) ||
+         spec.Actions.Count > 0 ||
+         spec.Fields.Count > 0 ||
+         spec.Cards.Count > 0);
+
+    private static bool ShouldBuildTopLevelCard(InteractionSpec spec) =>
+        !string.IsNullOrWhiteSpace(spec.Title) &&
+        spec.Cards.Count == 0 &&
+        spec.Fields.Count > 0;
+
+    private static string BuildTopLevelText(string? title, string? body)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+            return body ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(body))
+            return title;
+
+        return $"{title}\n{body}";
+    }
+
+    private static MessageDisposition MapDisposition(InteractionDisposition disposition) =>
+        disposition switch
+        {
+            InteractionDisposition.Normal => MessageDisposition.Normal,
+            InteractionDisposition.Ephemeral => MessageDisposition.Ephemeral,
+            InteractionDisposition.Silent => MessageDisposition.Silent,
+            InteractionDisposition.Pinned => MessageDisposition.Pinned,
+            _ => MessageDisposition.Normal,
+        };
+
+    private static ActionElement? MapAction(InteractionAction? action)
+    {
+        if (action is null)
+            return null;
+
+        if (string.IsNullOrWhiteSpace(action.ActionId) &&
+            string.IsNullOrWhiteSpace(action.Label) &&
+            string.IsNullOrWhiteSpace(action.Value) &&
+            action.Options.Count == 0)
+        {
+            return null;
+        }
+
+        var element = new ActionElement
+        {
+            Kind = MapActionKind(action.Kind, action.Options.Count),
+            ActionId = action.ActionId ?? string.Empty,
+            Label = string.IsNullOrWhiteSpace(action.Label)
+                ? action.ActionId ?? string.Empty
+                : action.Label,
+            Value = action.Value ?? string.Empty,
+            Placeholder = action.Placeholder ?? string.Empty,
+            IsPrimary = action.Style == InteractionActionStyle.Primary,
+            IsDanger = action.Style == InteractionActionStyle.Danger,
+            IsDisabled = action.Disabled,
+        };
+
+        foreach (var option in action.Options)
+        {
+            if (string.IsNullOrWhiteSpace(option.Label) && string.IsNullOrWhiteSpace(option.Value))
+                continue;
+
+            element.Options.Add(new ActionOption
+            {
+                Label = option.Label ?? string.Empty,
+                Value = option.Value ?? string.Empty,
+            });
+        }
+
+        return element;
+    }
+
+    private static ActionElementKind MapActionKind(InteractionActionKind kind, int optionCount) =>
+        kind switch
+        {
+            InteractionActionKind.Button => ActionElementKind.Button,
+            InteractionActionKind.Select => ActionElementKind.Select,
+            InteractionActionKind.FormSubmit => ActionElementKind.FormSubmit,
+            InteractionActionKind.Link => ActionElementKind.Link,
+            InteractionActionKind.TextInput => ActionElementKind.TextInput,
+            _ => optionCount > 0 ? ActionElementKind.Select : ActionElementKind.Button,
+        };
+
+    private static CardBlock? MapCard(InteractionCard? card)
+    {
+        if (card is null)
+            return null;
+
+        var block = new CardBlock
+        {
+            Kind = MapCardKind(card.Kind),
+            BlockId = card.BlockId ?? string.Empty,
+            Title = card.Title ?? string.Empty,
+            Text = card.Text ?? string.Empty,
+            ImageUrl = card.ImageUrl ?? string.Empty,
+        };
+
+        AppendFields(block, card.Fields);
+        foreach (var action in card.Actions)
+        {
+            var mapped = MapAction(action);
+            if (mapped is not null)
+                block.Actions.Add(mapped);
+        }
+
+        return string.IsNullOrWhiteSpace(block.BlockId) &&
+               string.IsNullOrWhiteSpace(block.Title) &&
+               string.IsNullOrWhiteSpace(block.Text) &&
+               string.IsNullOrWhiteSpace(block.ImageUrl) &&
+               block.Fields.Count == 0 &&
+               block.Actions.Count == 0
+            ? null
+            : block;
+    }
+
+    private static CardBlockKind MapCardKind(InteractionCardKind kind) =>
+        kind switch
+        {
+            InteractionCardKind.Actions => CardBlockKind.Actions,
+            InteractionCardKind.Image => CardBlockKind.Image,
+            InteractionCardKind.Context => CardBlockKind.Context,
+            InteractionCardKind.Divider => CardBlockKind.Divider,
+            _ => CardBlockKind.Section,
+        };
+
+    private static void AppendFields(CardBlock block, IEnumerable<InteractionField> fields)
+    {
+        foreach (var field in fields)
+        {
+            if (string.IsNullOrWhiteSpace(field.Title) && string.IsNullOrWhiteSpace(field.Text))
+                continue;
+
+            block.Fields.Add(new CardField
+            {
+                Title = field.Title ?? string.Empty,
+                Text = field.Text ?? string.Empty,
+                IsShort = field.IsShort,
+            });
+        }
+    }
+}

--- a/docs/design/2026-06-08-aevatar-lark-interaction-protocol-design.md
+++ b/docs/design/2026-06-08-aevatar-lark-interaction-protocol-design.md
@@ -1,0 +1,22 @@
+---
+title: "Aevatar Lark Interaction Protocol Design"
+status: active
+owner: eanzhao
+---
+
+# Aevatar Lark Interaction Protocol Design
+
+Workflow interaction requests use the Foundation-owned `InteractionSpec` proto as their stable contract. The contract is channel-neutral: it describes title/body text, actions, fields, cards, and delivery disposition without exposing Lark JSON, `MessageContent`, or composer-specific types to Workflow Core.
+
+## Contract Flow
+
+1. Workflow YAML may define `interaction_spec` at step root, under `presentation.interaction_spec`, or as inline `presentation` fields.
+2. `WorkflowParser` lifts that structure into `StepPresentation.InteractionSpec` during parsing.
+3. `WorkflowExecutionKernel` evaluates workflow expressions in visible text/value fields and writes the result to `StepRequestEvent.StepParameters.InteractionSpec`.
+4. Channel boundary code maps `InteractionSpec` to existing `MessageContent` through `InteractionSpecMapper`.
+
+## Boundary Rules
+
+- `Aevatar.Workflow.Core` must not reference `MessageContent`, `LarkMessageComposer`, or raw Lark card JSON.
+- Workflow step parameters remain for primitive configuration, not for stable interaction semantics.
+- Channel adapters and composers continue to consume `MessageContent`; the only typed-contract bridge is `InteractionSpecMapper`.

--- a/src/Aevatar.Foundation.Abstractions/Aevatar.Foundation.Abstractions.csproj
+++ b/src/Aevatar.Foundation.Abstractions/Aevatar.Foundation.Abstractions.csproj
@@ -21,6 +21,7 @@
     <ItemGroup>
         <Protobuf Include="agent_messages.proto" GrpcServices="None" />
         <Protobuf Include="ExternalLinks/external_link_messages.proto" GrpcServices="None" />
+        <Protobuf Include="Interactions/interaction_spec.proto" GrpcServices="None" />
         <Protobuf Include="runtime_actor_identity.proto" GrpcServices="None" />
     </ItemGroup>
 

--- a/src/Aevatar.Foundation.Abstractions/Interactions/interaction_spec.proto
+++ b/src/Aevatar.Foundation.Abstractions/Interactions/interaction_spec.proto
@@ -1,0 +1,77 @@
+syntax = "proto3";
+package aevatar.foundation.interactions;
+option csharp_namespace = "Aevatar.Foundation.Abstractions.Interactions";
+
+enum InteractionDisposition {
+  INTERACTION_DISPOSITION_UNSPECIFIED = 0;
+  INTERACTION_DISPOSITION_NORMAL = 1;
+  INTERACTION_DISPOSITION_EPHEMERAL = 2;
+  INTERACTION_DISPOSITION_SILENT = 3;
+  INTERACTION_DISPOSITION_PINNED = 4;
+}
+
+enum InteractionActionKind {
+  INTERACTION_ACTION_KIND_UNSPECIFIED = 0;
+  INTERACTION_ACTION_KIND_BUTTON = 1;
+  INTERACTION_ACTION_KIND_SELECT = 2;
+  INTERACTION_ACTION_KIND_FORM_SUBMIT = 3;
+  INTERACTION_ACTION_KIND_LINK = 4;
+  INTERACTION_ACTION_KIND_TEXT_INPUT = 5;
+}
+
+enum InteractionActionStyle {
+  INTERACTION_ACTION_STYLE_UNSPECIFIED = 0;
+  INTERACTION_ACTION_STYLE_DEFAULT = 1;
+  INTERACTION_ACTION_STYLE_PRIMARY = 2;
+  INTERACTION_ACTION_STYLE_DANGER = 3;
+}
+
+enum InteractionCardKind {
+  INTERACTION_CARD_KIND_UNSPECIFIED = 0;
+  INTERACTION_CARD_KIND_SECTION = 1;
+  INTERACTION_CARD_KIND_ACTIONS = 2;
+  INTERACTION_CARD_KIND_IMAGE = 3;
+  INTERACTION_CARD_KIND_CONTEXT = 4;
+  INTERACTION_CARD_KIND_DIVIDER = 5;
+}
+
+message InteractionOption {
+  string label = 1;
+  string value = 2;
+}
+
+message InteractionAction {
+  InteractionActionKind kind = 1;
+  string action_id = 2;
+  string label = 3;
+  string value = 4;
+  string placeholder = 5;
+  repeated InteractionOption options = 6;
+  InteractionActionStyle style = 7;
+  bool disabled = 8;
+}
+
+message InteractionField {
+  string title = 1;
+  string text = 2;
+  bool is_short = 3;
+}
+
+message InteractionCard {
+  InteractionCardKind kind = 1;
+  string block_id = 2;
+  string title = 3;
+  string text = 4;
+  string image_url = 5;
+  repeated InteractionField fields = 6;
+  repeated InteractionAction actions = 7;
+}
+
+message InteractionSpec {
+  string title = 1;
+  string body = 2;
+  repeated InteractionAction actions = 3;
+  repeated InteractionField fields = 4;
+  repeated InteractionCard cards = 5;
+  InteractionDisposition disposition = 6;
+}

--- a/src/workflow/Aevatar.Workflow.Abstractions/Aevatar.Workflow.Abstractions.csproj
+++ b/src/workflow/Aevatar.Workflow.Abstractions/Aevatar.Workflow.Abstractions.csproj
@@ -17,6 +17,6 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <Protobuf Include="workflow_execution_messages.proto" GrpcServices="None" />
+    <Protobuf Include="workflow_execution_messages.proto" GrpcServices="None" AdditionalImportDirs="..\..\Aevatar.Foundation.Abstractions" />
   </ItemGroup>
 </Project>

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -3,6 +3,7 @@ package aevatar.workflow;
 option csharp_namespace = "Aevatar.Workflow.Abstractions";
 
 import "google/protobuf/any.proto";
+import "Interactions/interaction_spec.proto";
 
 enum WorkflowChatInputPartKind {
   WORKFLOW_CHAT_INPUT_PART_KIND_UNSPECIFIED = 0;
@@ -220,6 +221,7 @@ message WorkflowStepParameters
   map<string, string> parameters = 1;
   VoteAgreementCandidateSet vote_agreement_candidates = 2;
   VoteAgreementRule vote_agreement_rule = 3;
+  aevatar.foundation.interactions.InteractionSpec interaction_spec = 4;
 }
 message StepRequestEvent
 {

--- a/src/workflow/Aevatar.Workflow.Core/Aevatar.Workflow.Core.csproj
+++ b/src/workflow/Aevatar.Workflow.Core/Aevatar.Workflow.Core.csproj
@@ -23,6 +23,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
   <ItemGroup>
-    <Protobuf Include="workflow_state.proto" GrpcServices="None" AdditionalImportDirs="..\Aevatar.Workflow.Abstractions" />
+    <Protobuf Include="workflow_state.proto" GrpcServices="None" AdditionalImportDirs="..\Aevatar.Workflow.Abstractions;..\..\Aevatar.Foundation.Abstractions" />
   </ItemGroup>
 </Project>

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
@@ -1166,7 +1166,68 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                 request.Parameters["allowed_connectors"] = string.Join(",", role.Connectors);
         }
 
+        ApplyInteractionSpec(request, step.Presentation, state);
+
         return request;
+    }
+
+    private void ApplyInteractionSpec(
+        StepRequestEvent request,
+        StepPresentation? presentation,
+        WorkflowExecutionKernelState state)
+    {
+        if (!StepPresentation.HasInteractionSpec(presentation?.InteractionSpec))
+            return;
+
+        var spec = presentation!.InteractionSpec!.Clone();
+        spec.Title = _expressionEvaluator.Evaluate(spec.Title, state.Variables);
+        spec.Body = _expressionEvaluator.Evaluate(spec.Body, state.Variables);
+        EvaluateActions(spec.Actions, state);
+        EvaluateFields(spec.Fields, state);
+        EvaluateCards(spec.Cards, state);
+        (request.StepParameters ??= new WorkflowStepParameters()).InteractionSpec = spec;
+    }
+
+    private void EvaluateActions(
+        IEnumerable<Aevatar.Foundation.Abstractions.Interactions.InteractionAction> actions,
+        WorkflowExecutionKernelState state)
+    {
+        foreach (var action in actions)
+        {
+            action.Label = _expressionEvaluator.Evaluate(action.Label, state.Variables);
+            action.Value = _expressionEvaluator.Evaluate(action.Value, state.Variables);
+            action.Placeholder = _expressionEvaluator.Evaluate(action.Placeholder, state.Variables);
+            foreach (var option in action.Options)
+            {
+                option.Label = _expressionEvaluator.Evaluate(option.Label, state.Variables);
+                option.Value = _expressionEvaluator.Evaluate(option.Value, state.Variables);
+            }
+        }
+    }
+
+    private void EvaluateFields(
+        IEnumerable<Aevatar.Foundation.Abstractions.Interactions.InteractionField> fields,
+        WorkflowExecutionKernelState state)
+    {
+        foreach (var field in fields)
+        {
+            field.Title = _expressionEvaluator.Evaluate(field.Title, state.Variables);
+            field.Text = _expressionEvaluator.Evaluate(field.Text, state.Variables);
+        }
+    }
+
+    private void EvaluateCards(
+        IEnumerable<Aevatar.Foundation.Abstractions.Interactions.InteractionCard> cards,
+        WorkflowExecutionKernelState state)
+    {
+        foreach (var card in cards)
+        {
+            card.Title = _expressionEvaluator.Evaluate(card.Title, state.Variables);
+            card.Text = _expressionEvaluator.Evaluate(card.Text, state.Variables);
+            card.ImageUrl = _expressionEvaluator.Evaluate(card.ImageUrl, state.Variables);
+            EvaluateFields(card.Fields, state);
+            EvaluateActions(card.Actions, state);
+        }
     }
 
     private async Task ResumePendingCurrentStepDispatchAsync(

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/StepDefinition.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/StepDefinition.cs
@@ -26,6 +26,11 @@ public sealed class StepDefinition
     public Dictionary<string, string> Parameters { get; init; } = [];
 
     /// <summary>
+    /// Presentation contract rendered outside the workflow core boundary.
+    /// </summary>
+    public StepPresentation? Presentation { get; init; }
+
+    /// <summary>
     /// 下一步骤 ID，用于线性流程控制。
     /// </summary>
     public string? Next { get; init; }

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/StepPresentation.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/StepPresentation.cs
@@ -1,0 +1,17 @@
+using Aevatar.Foundation.Abstractions.Interactions;
+
+namespace Aevatar.Workflow.Core.Primitives;
+
+public sealed class StepPresentation
+{
+    public InteractionSpec? InteractionSpec { get; init; }
+
+    public static bool HasInteractionSpec(InteractionSpec? spec) =>
+        spec is not null &&
+        (!string.IsNullOrWhiteSpace(spec.Title) ||
+         !string.IsNullOrWhiteSpace(spec.Body) ||
+         spec.Actions.Count > 0 ||
+         spec.Fields.Count > 0 ||
+         spec.Cards.Count > 0 ||
+         spec.Disposition != InteractionDisposition.Unspecified);
+}

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowParser.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowParser.cs
@@ -5,6 +5,7 @@
 
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
+using Aevatar.Foundation.Abstractions.Interactions;
 using Aevatar.Workflow.Core.Agreement;
 using System.Collections;
 using System.Globalization;
@@ -143,7 +144,11 @@ public sealed class WorkflowParser
         var rawType = s.Type ?? "llm_call";
         var normalizedRawType = rawType.Trim().ToLowerInvariant();
         var canonicalType = WorkflowPrimitiveCatalog.ToCanonicalType(rawType);
-        var parameters = NormalizeParameters(s.Parameters);
+        var rawParameters = s.Parameters is null
+            ? null
+            : new Dictionary<string, object?>(s.Parameters, StringComparer.Ordinal);
+        var presentation = MapPresentation(s, rawParameters);
+        var parameters = NormalizeParameters(rawParameters);
 
         ApplyErgonomicDefaults(normalizedRawType, parameters);
         LiftRootPrimitiveParameters(canonicalType, s, parameters);
@@ -154,6 +159,7 @@ public sealed class WorkflowParser
             Type = canonicalType,
             TargetRole = s.TargetRole ?? s.Role,
             Parameters = WorkflowPrimitiveCatalog.CanonicalizeStepTypeParameters(parameters),
+            Presentation = presentation,
             Next = s.Next,
             Children = s.Children?.Select(MapStep).ToList(),
             Branches = NormalizeBranches(s.Branches),
@@ -162,6 +168,409 @@ public sealed class WorkflowParser
             TimeoutMs = s.TimeoutMs,
         };
     }
+
+    private static StepPresentation? MapPresentation(
+        RawStep step,
+        IDictionary<string, object?>? rawParameters)
+    {
+        var source = ResolveInteractionSpecSource(step, rawParameters);
+        var interactionSpec = MapInteractionSpec(source);
+        return StepPresentation.HasInteractionSpec(interactionSpec)
+            ? new StepPresentation { InteractionSpec = interactionSpec }
+            : null;
+    }
+
+    private static object? ResolveInteractionSpecSource(
+        RawStep step,
+        IDictionary<string, object?>? rawParameters)
+    {
+        if (step.InteractionSpec is not null)
+            return step.InteractionSpec;
+
+        if (step.Presentation?.InteractionSpec is not null)
+            return step.Presentation.InteractionSpec;
+
+        if (step.Presentation?.HasInlineSpec() == true)
+            return step.Presentation;
+
+        if (rawParameters is null)
+            return null;
+
+        foreach (var key in new[] { "interaction_spec", "interactionSpec" })
+        {
+            if (!rawParameters.TryGetValue(key, out var source))
+                continue;
+
+            rawParameters.Remove(key);
+            return source;
+        }
+
+        return null;
+    }
+
+    private static InteractionSpec? MapInteractionSpec(object? source)
+    {
+        if (source is null)
+            return null;
+
+        if (source is InteractionSpec spec)
+            return spec.Clone();
+
+        if (source is RawStepPresentation presentation)
+            return MapInteractionSpecFromAccessor(
+                key => key switch
+                {
+                    "title" => presentation.Title,
+                    "body" => presentation.Body,
+                    "actions" => presentation.Actions,
+                    "fields" => presentation.Fields,
+                    "cards" => presentation.Cards,
+                    "disposition" => presentation.Disposition,
+                    _ => null,
+                });
+
+        if (source is string text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+                return null;
+
+            using var document = JsonDocument.Parse(text);
+            return MapInteractionSpec(document.RootElement);
+        }
+
+        if (source is JsonElement element)
+            return MapInteractionSpecFromJson(element);
+
+        if (source is IDictionary mapping)
+            return MapInteractionSpecFromAccessor(key => TryReadMappingObject(mapping, KeyCandidates(key)));
+
+        return null;
+    }
+
+    private static InteractionSpec? MapInteractionSpecFromJson(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+            return null;
+
+        return MapInteractionSpecFromAccessor(key => TryReadJsonProperty(element, KeyCandidates(key)));
+    }
+
+    private static InteractionSpec? MapInteractionSpecFromAccessor(Func<string, object?> read)
+    {
+        var spec = new InteractionSpec
+        {
+            Title = ConvertValueToString(read("title")).Trim(),
+            Body = ConvertValueToString(read("body")).Trim(),
+            Disposition = ParseDisposition(ConvertValueToString(read("disposition"))),
+        };
+
+        foreach (var action in MapActions(read("actions")))
+            spec.Actions.Add(action);
+        foreach (var field in MapFields(read("fields")))
+            spec.Fields.Add(field);
+        foreach (var card in MapCards(read("cards")))
+            spec.Cards.Add(card);
+
+        return StepPresentation.HasInteractionSpec(spec) ? spec : null;
+    }
+
+    private static IEnumerable<InteractionAction> MapActions(object? source)
+    {
+        foreach (var item in EnumerateItems(source))
+        {
+            var action = MapAction(item);
+            if (action is not null)
+                yield return action;
+        }
+    }
+
+    private static InteractionAction? MapAction(object? source)
+    {
+        var action = MapFromObject(
+            source,
+            read =>
+            {
+                var mapped = new InteractionAction
+                {
+                    ActionId = ConvertValueToString(read("action_id")).Trim(),
+                    Label = ConvertValueToString(read("label")).Trim(),
+                    Value = ConvertValueToString(read("value")).Trim(),
+                    Placeholder = ConvertValueToString(read("placeholder")).Trim(),
+                    Kind = ParseActionKind(ConvertValueToString(read("kind"))),
+                    Style = ParseActionStyle(ConvertValueToString(read("style"))),
+                    Disabled = ParseBool(read("disabled")) || ParseBool(read("is_disabled")),
+                };
+
+                foreach (var option in MapOptions(read("options")))
+                    mapped.Options.Add(option);
+
+                if (mapped.Kind == InteractionActionKind.Unspecified &&
+                    (!string.IsNullOrWhiteSpace(mapped.ActionId) ||
+                     !string.IsNullOrWhiteSpace(mapped.Label)))
+                {
+                    mapped.Kind = mapped.Options.Count > 0
+                        ? InteractionActionKind.Select
+                        : InteractionActionKind.Button;
+                }
+
+                return mapped;
+            });
+
+        return action is not null &&
+               (!string.IsNullOrWhiteSpace(action.ActionId) ||
+                !string.IsNullOrWhiteSpace(action.Label) ||
+                !string.IsNullOrWhiteSpace(action.Value) ||
+                action.Options.Count > 0)
+            ? action
+            : null;
+    }
+
+    private static IEnumerable<InteractionOption> MapOptions(object? source)
+    {
+        foreach (var item in EnumerateItems(source))
+        {
+            var option = MapFromObject(
+                item,
+                read => new InteractionOption
+                {
+                    Label = ConvertValueToString(read("label")).Trim(),
+                    Value = ConvertValueToString(read("value")).Trim(),
+                });
+
+            if (option is not null &&
+                (!string.IsNullOrWhiteSpace(option.Label) ||
+                 !string.IsNullOrWhiteSpace(option.Value)))
+            {
+                yield return option;
+            }
+        }
+    }
+
+    private static IEnumerable<InteractionField> MapFields(object? source)
+    {
+        foreach (var item in EnumerateItems(source))
+        {
+            var field = MapField(item);
+            if (field is not null)
+                yield return field;
+        }
+    }
+
+    private static InteractionField? MapField(object? source)
+    {
+        var field = MapFromObject(
+            source,
+            read => new InteractionField
+            {
+                Title = ConvertValueToString(read("title")).Trim(),
+                Text = ConvertValueToString(read("text")).Trim(),
+                IsShort = ParseBool(read("is_short")),
+            });
+
+        return field is not null &&
+               (!string.IsNullOrWhiteSpace(field.Title) ||
+                !string.IsNullOrWhiteSpace(field.Text))
+            ? field
+            : null;
+    }
+
+    private static IEnumerable<InteractionCard> MapCards(object? source)
+    {
+        foreach (var item in EnumerateItems(source))
+        {
+            var card = MapCard(item);
+            if (card is not null)
+                yield return card;
+        }
+    }
+
+    private static InteractionCard? MapCard(object? source)
+    {
+        var card = MapFromObject(
+            source,
+            read =>
+            {
+                var mapped = new InteractionCard
+                {
+                    BlockId = ConvertValueToString(read("block_id")).Trim(),
+                    Title = ConvertValueToString(read("title")).Trim(),
+                    Text = ConvertValueToString(read("text")).Trim(),
+                    ImageUrl = ConvertValueToString(read("image_url")).Trim(),
+                    Kind = ParseCardKind(ConvertValueToString(read("kind"))),
+                };
+
+                foreach (var field in MapFields(read("fields")))
+                    mapped.Fields.Add(field);
+                foreach (var action in MapActions(read("actions")))
+                    mapped.Actions.Add(action);
+
+                if (mapped.Kind == InteractionCardKind.Unspecified &&
+                    (!string.IsNullOrWhiteSpace(mapped.Title) ||
+                     !string.IsNullOrWhiteSpace(mapped.Text) ||
+                     mapped.Fields.Count > 0 ||
+                     mapped.Actions.Count > 0))
+                {
+                    mapped.Kind = InteractionCardKind.Section;
+                }
+
+                return mapped;
+            });
+
+        return card is not null &&
+               (!string.IsNullOrWhiteSpace(card.BlockId) ||
+                !string.IsNullOrWhiteSpace(card.Title) ||
+                !string.IsNullOrWhiteSpace(card.Text) ||
+                !string.IsNullOrWhiteSpace(card.ImageUrl) ||
+                card.Fields.Count > 0 ||
+                card.Actions.Count > 0)
+            ? card
+            : null;
+    }
+
+    private static T? MapFromObject<T>(object? source, Func<Func<string, object?>, T> map)
+        where T : class
+    {
+        if (source is null)
+            return null;
+
+        if (source is JsonElement element)
+        {
+            if (element.ValueKind != JsonValueKind.Object)
+                return null;
+
+            return map(key => TryReadJsonProperty(element, KeyCandidates(key)));
+        }
+
+        if (source is IDictionary mapping)
+            return map(key => TryReadMappingObject(mapping, KeyCandidates(key)));
+
+        if (source is string text && !string.IsNullOrWhiteSpace(text))
+        {
+            using var document = JsonDocument.Parse(text);
+            return MapFromObject(document.RootElement.Clone(), map);
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<object?> EnumerateItems(object? source)
+    {
+        if (source is null)
+            yield break;
+
+        if (source is JsonElement element)
+        {
+            if (element.ValueKind != JsonValueKind.Array)
+                yield break;
+
+            foreach (var item in element.EnumerateArray())
+                yield return item.Clone();
+            yield break;
+        }
+
+        if (source is string text && !string.IsNullOrWhiteSpace(text))
+        {
+            using var document = JsonDocument.Parse(text);
+            foreach (var item in EnumerateItems(document.RootElement.Clone()))
+                yield return item;
+            yield break;
+        }
+
+        if (source is IEnumerable sequence && source is not string)
+        {
+            foreach (var item in sequence)
+                yield return item;
+        }
+    }
+
+    private static object? TryReadMappingObject(IDictionary mapping, params string[] candidates)
+    {
+        foreach (DictionaryEntry entry in mapping)
+        {
+            var key = ConvertValueToString(entry.Key);
+            if (candidates.Any(candidate => string.Equals(candidate, key, StringComparison.OrdinalIgnoreCase)))
+                return entry.Value;
+        }
+
+        return null;
+    }
+
+    private static object? TryReadJsonProperty(JsonElement element, params string[] candidates)
+    {
+        foreach (var property in element.EnumerateObject())
+        {
+            if (candidates.Any(candidate => string.Equals(candidate, property.Name, StringComparison.OrdinalIgnoreCase)))
+                return property.Value.Clone();
+        }
+
+        return null;
+    }
+
+    private static string[] KeyCandidates(string key) =>
+        key switch
+        {
+            "action_id" => ["action_id", "actionId", "id"],
+            "block_id" => ["block_id", "blockId", "id"],
+            "image_url" => ["image_url", "imageUrl"],
+            "is_short" => ["is_short", "isShort", "short"],
+            "is_disabled" => ["is_disabled", "isDisabled"],
+            _ => [key],
+        };
+
+    private static InteractionDisposition ParseDisposition(string? value) =>
+        NormalizeEnumToken(value) switch
+        {
+            "normal" => InteractionDisposition.Normal,
+            "ephemeral" => InteractionDisposition.Ephemeral,
+            "silent" => InteractionDisposition.Silent,
+            "pinned" => InteractionDisposition.Pinned,
+            _ => InteractionDisposition.Unspecified,
+        };
+
+    private static InteractionActionKind ParseActionKind(string? value) =>
+        NormalizeEnumToken(value) switch
+        {
+            "button" => InteractionActionKind.Button,
+            "select" => InteractionActionKind.Select,
+            "formsubmit" => InteractionActionKind.FormSubmit,
+            "link" => InteractionActionKind.Link,
+            "textinput" => InteractionActionKind.TextInput,
+            _ => InteractionActionKind.Unspecified,
+        };
+
+    private static InteractionActionStyle ParseActionStyle(string? value) =>
+        NormalizeEnumToken(value) switch
+        {
+            "default" => InteractionActionStyle.Default,
+            "primary" => InteractionActionStyle.Primary,
+            "danger" => InteractionActionStyle.Danger,
+            _ => InteractionActionStyle.Unspecified,
+        };
+
+    private static InteractionCardKind ParseCardKind(string? value) =>
+        NormalizeEnumToken(value) switch
+        {
+            "section" => InteractionCardKind.Section,
+            "actions" => InteractionCardKind.Actions,
+            "image" => InteractionCardKind.Image,
+            "context" => InteractionCardKind.Context,
+            "divider" => InteractionCardKind.Divider,
+            _ => InteractionCardKind.Unspecified,
+        };
+
+    private static string NormalizeEnumToken(string? value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? string.Empty
+            : value.Trim().Replace("_", string.Empty, StringComparison.Ordinal).Replace("-", string.Empty, StringComparison.Ordinal).ToLowerInvariant();
+
+    private static bool ParseBool(object? value) =>
+        value switch
+        {
+            bool flag => flag,
+            JsonElement { ValueKind: JsonValueKind.True } => true,
+            JsonElement { ValueKind: JsonValueKind.False } => false,
+            _ => bool.TryParse(ConvertValueToString(value), out var parsed) && parsed,
+        };
 
     private static void ApplyErgonomicDefaults(string normalizedRawType, IDictionary<string, string> parameters)
     {
@@ -495,6 +904,8 @@ public sealed class WorkflowParser
         public string? HolderToken { get; set; }
         public object? Generation { get; set; }
         public string? HolderTokenVariable { get; set; }
+        public object? InteractionSpec { get; set; }
+        public RawStepPresentation? Presentation { get; set; }
         public Dictionary<string, object?>? Parameters { get; set; }
         public string? Next { get; set; }
         public List<RawStep>? Children { get; set; }
@@ -502,6 +913,24 @@ public sealed class WorkflowParser
         public RawRetry? Retry { get; set; }
         public RawOnError? OnError { get; set; }
         public int? TimeoutMs { get; set; }
+    }
+    private sealed class RawStepPresentation
+    {
+        public object? InteractionSpec { get; set; }
+        public string? Title { get; set; }
+        public string? Body { get; set; }
+        public object? Actions { get; set; }
+        public object? Fields { get; set; }
+        public object? Cards { get; set; }
+        public string? Disposition { get; set; }
+
+        public bool HasInlineSpec() =>
+            !string.IsNullOrWhiteSpace(Title) ||
+            !string.IsNullOrWhiteSpace(Body) ||
+            Actions is not null ||
+            Fields is not null ||
+            Cards is not null ||
+            !string.IsNullOrWhiteSpace(Disposition);
     }
     private sealed class RawRetry { public int? MaxAttempts { get; set; } public string? Backoff { get; set; } public int? DelayMs { get; set; } }
     private sealed class RawOnError

--- a/test/Aevatar.Foundation.Abstractions.Tests/FoundationAbstractionsProtoCoverageTests.cs
+++ b/test/Aevatar.Foundation.Abstractions.Tests/FoundationAbstractionsProtoCoverageTests.cs
@@ -1,5 +1,6 @@
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
+using Aevatar.Foundation.Abstractions.Interactions;
 using Shouldly;
 
 namespace Aevatar.Foundation.Abstractions.Tests;
@@ -131,6 +132,49 @@ public class FoundationAbstractionsProtoCoverageTests
         names.ShouldContain(nameof(ChildAddedEvent));
         names.ShouldContain(nameof(ChildRemovedEvent));
         names.ShouldContain(nameof(ParentChangedEvent));
+    }
+
+    [Fact]
+    public void InteractionSpec_ShouldRoundtripTypedContract()
+    {
+        var spec = new InteractionSpec
+        {
+            Title = "Deploy",
+            Body = "Choose a route",
+            Disposition = InteractionDisposition.Ephemeral,
+        };
+        spec.Actions.Add(new InteractionAction
+        {
+            Kind = InteractionActionKind.Button,
+            ActionId = "approve",
+            Label = "Approve",
+            Value = "yes",
+            Style = InteractionActionStyle.Primary,
+        });
+        spec.Fields.Add(new InteractionField
+        {
+            Title = "Run",
+            Text = "run-1",
+            IsShort = true,
+        });
+        spec.Cards.Add(new InteractionCard
+        {
+            Kind = InteractionCardKind.Section,
+            BlockId = "summary",
+            Title = "Summary",
+            Text = "Ready",
+        });
+
+        var parsed = InteractionSpec.Parser.ParseFrom(spec.ToByteArray());
+
+        parsed.ShouldBe(spec);
+        parsed.Actions[0].Style.ShouldBe(InteractionActionStyle.Primary);
+        parsed.Fields[0].IsShort.ShouldBeTrue();
+        parsed.Cards[0].BlockId.ShouldBe("summary");
+        InteractionSpecReflection.Descriptor.MessageTypes.Select(x => x.Name)
+            .ShouldContain(nameof(InteractionSpec));
+        InteractionSpecReflection.Descriptor.EnumTypes.Select(x => x.Name)
+            .ShouldContain(nameof(InteractionActionKind));
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelAbstractionsProtoTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelAbstractionsProtoTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Aevatar.Foundation.Abstractions.Interactions;
 using Aevatar.GAgents.Channel.Abstractions;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
@@ -201,5 +202,41 @@ public sealed class ChannelAbstractionsProtoTests
             .ShouldContain(nameof(ChannelTransportBinding));
         ScheduleReflection.Descriptor.EnumTypes.Select(x => x.Name)
             .ShouldContain(nameof(ProjectionVerdict));
+    }
+
+    [Fact]
+    public void InteractionSpecMapper_ShouldProjectTypedSpecToMessageContent()
+    {
+        var spec = new InteractionSpec
+        {
+            Title = "Review",
+            Body = "Deploy v1?",
+            Disposition = InteractionDisposition.Ephemeral,
+        };
+        spec.Actions.Add(new InteractionAction
+        {
+            Kind = InteractionActionKind.Select,
+            ActionId = "route",
+            Label = "Route",
+            Style = InteractionActionStyle.Primary,
+            Options =
+            {
+                new InteractionOption { Label = "Canary", Value = "canary" },
+            },
+        });
+        spec.Fields.Add(new InteractionField
+        {
+            Title = "Env",
+            Text = "prod",
+            IsShort = true,
+        });
+
+        var content = InteractionSpecMapper.ToMessageContent(spec);
+
+        content.Text.ShouldBe("Review\nDeploy v1?");
+        content.Disposition.ShouldBe(MessageDisposition.Ephemeral);
+        content.Actions.ShouldHaveSingleItem().Kind.ShouldBe(ActionElementKind.Select);
+        content.Actions[0].Options.ShouldHaveSingleItem().Value.ShouldBe("canary");
+        content.Cards.ShouldHaveSingleItem().Fields.ShouldHaveSingleItem().IsShort.ShouldBeTrue();
     }
 }

--- a/test/Aevatar.Workflow.Core.Tests/Execution/IdempotentStepExecutionTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/IdempotentStepExecutionTests.cs
@@ -1,5 +1,6 @@
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.EventModules;
+using Aevatar.Foundation.Abstractions.Interactions;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Core.Execution;
@@ -503,6 +504,61 @@ public sealed class IdempotentStepExecutionTests
         state.Variables["input"].Should().Be("fresh-input");
         state.Variables.Should().NotContainKey("step_a_output");
         state.Variables.Keys.Should().BeEquivalentTo(DefaultStartVariableKeys);
+    }
+
+    [Fact]
+    public async Task StartWorkflow_WithStepPresentation_ShouldDispatchTypedInteractionSpec()
+    {
+        var ctx = new RecordingEventHandlerContext();
+        var host = new RecordingStateHost();
+        var workflow = new WorkflowDefinition
+        {
+            Name = "interaction-workflow",
+            Roles = [new RoleDefinition { Id = "worker", Name = "Worker" }],
+            Steps =
+            [
+                new StepDefinition
+                {
+                    Id = "approval",
+                    Type = "human_approval",
+                    TargetRole = "worker",
+                    Presentation = new StepPresentation
+                    {
+                        InteractionSpec = new InteractionSpec
+                        {
+                            Title = "Approve ${input}",
+                            Body = "Release ${release}",
+                            Disposition = InteractionDisposition.Ephemeral,
+                            Actions =
+                            {
+                                new InteractionAction
+                                {
+                                    Kind = InteractionActionKind.Button,
+                                    ActionId = "approve",
+                                    Label = "Approve ${release}",
+                                    Value = "${release}",
+                                    Style = InteractionActionStyle.Primary,
+                                },
+                            },
+                        },
+                    },
+                },
+            ],
+        };
+        var kernel = new WorkflowExecutionKernel(workflow, host);
+        var start = new StartWorkflowEvent { RunId = "run-interaction", Input = "deploy" };
+        start.Parameters["release"] = "v1";
+
+        await kernel.HandleAsync(Wrap(start), ctx, CancellationToken.None);
+
+        var request = StepRequests(ctx).Single();
+        request.Parameters.Should().NotContainKey("interaction_spec");
+        request.StepParameters.InteractionSpec.Title.Should().Be("Approve deploy");
+        request.StepParameters.InteractionSpec.Body.Should().Be("Release v1");
+        request.StepParameters.InteractionSpec.Disposition.Should().Be(InteractionDisposition.Ephemeral);
+        request.StepParameters.InteractionSpec.Actions[0].Label.Should().Be("Approve v1");
+        request.StepParameters.InteractionSpec.Actions[0].Value.Should().Be("v1");
+        request.StepParameters.InteractionSpec.Actions[0].Style.Should().Be(InteractionActionStyle.Primary);
     }
 
     // ──── Test infrastructure ────

--- a/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowParserCoverageTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowParserCoverageTests.cs
@@ -1,4 +1,5 @@
 using Aevatar.Workflow.Core.Primitives;
+using Aevatar.Foundation.Abstractions.Interactions;
 using FluentAssertions;
 
 namespace Aevatar.Workflow.Core.Tests.Primitives;
@@ -122,6 +123,75 @@ public sealed class WorkflowParserCoverageTests
         workflow.Steps[0].Parameters["ratio"].Should().Be("1.5");
         workflow.Steps[0].Parameters["tags"].Should().Be("""["alpha","2"]""");
         workflow.Steps[0].Parameters["config"].Should().Be("""{"enabled":"false","retries":"3"}""");
+    }
+
+    [Fact]
+    public void Parse_WhenInteractionSpecIsPresent_ShouldLiftTypedPresentation()
+    {
+        var workflow = new WorkflowParser().Parse(
+            """
+            name: interaction
+            roles: []
+            steps:
+              - id: approve
+                type: human_approval
+                presentation:
+                  interaction_spec:
+                    title: "Approve ${input}"
+                    body: "Review release"
+                    disposition: ephemeral
+                    actions:
+                      - action_id: approve
+                        label: Approve
+                        style: primary
+                      - action_id: reject
+                        label: Reject
+                        style: danger
+                    fields:
+                      - title: Environment
+                        text: prod
+                        is_short: true
+            """);
+
+        var spec = workflow.Steps[0].Presentation?.InteractionSpec;
+
+        spec.Should().NotBeNull();
+        spec!.Title.Should().Be("Approve ${input}");
+        spec.Disposition.Should().Be(InteractionDisposition.Ephemeral);
+        spec.Actions.Should().HaveCount(2);
+        spec.Actions[0].Kind.Should().Be(InteractionActionKind.Button);
+        spec.Actions[0].Style.Should().Be(InteractionActionStyle.Primary);
+        spec.Actions[1].Style.Should().Be(InteractionActionStyle.Danger);
+        spec.Fields.Should().ContainSingle(x => x.Title == "Environment" && x.IsShort);
+        workflow.Steps[0].Parameters.Should().NotContainKey("interaction_spec");
+    }
+
+    [Fact]
+    public void Parse_WhenInteractionSpecIsUnderParameters_ShouldPromoteAndRemoveBagEntry()
+    {
+        var workflow = new WorkflowParser().Parse(
+            """
+            name: interaction_parameter
+            roles: []
+            steps:
+              - id: approve
+                type: human_approval
+                parameters:
+                  prompt: "Approve?"
+                  interaction_spec:
+                    title: "Approval"
+                    actions:
+                      - action_id: approve
+                        label: Approve
+            """);
+
+        var step = workflow.Steps[0];
+
+        step.Presentation?.InteractionSpec.Should().NotBeNull();
+        step.Presentation!.InteractionSpec!.Title.Should().Be("Approval");
+        step.Presentation.InteractionSpec.Actions.Should().ContainSingle(x => x.ActionId == "approve");
+        step.Parameters.Should().ContainKey("prompt");
+        step.Parameters.Should().NotContainKey("interaction_spec");
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowParserCoverageTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowParserCoverageTests.cs
@@ -195,6 +195,93 @@ public sealed class WorkflowParserCoverageTests
     }
 
     [Fact]
+    public void Parse_WhenInteractionSpecIsAtStepRoot_ShouldLiftTypedPresentation()
+    {
+        var workflow = new WorkflowParser().Parse(
+            """
+            name: interaction_root
+            roles: []
+            steps:
+              - id: approve
+                type: human_approval
+                interaction_spec:
+                  title: "Root approval"
+                  body: "Choose a route"
+                  actions:
+                    - kind: select
+                      action_id: route
+                      label: Route
+                      options:
+                        - label: Canary
+                          value: canary
+                  cards:
+                    - block_id: summary
+                      title: Summary
+                      fields:
+                        - title: Release
+                          text: v1
+            """);
+
+        var step = workflow.Steps[0];
+        var spec = step.Presentation?.InteractionSpec;
+
+        spec.Should().NotBeNull();
+        spec!.Title.Should().Be("Root approval");
+        spec.Body.Should().Be("Choose a route");
+        spec.Actions.Should().ContainSingle();
+        spec.Actions[0].Kind.Should().Be(InteractionActionKind.Select);
+        spec.Actions[0].Options.Should().ContainSingle(x => x.Label == "Canary" && x.Value == "canary");
+        spec.Cards.Should().ContainSingle();
+        spec.Cards[0].BlockId.Should().Be("summary");
+        spec.Cards[0].Fields.Should().ContainSingle(x => x.Title == "Release" && x.Text == "v1");
+        step.Parameters.Should().NotContainKey("interaction_spec");
+    }
+
+    [Fact]
+    public void Parse_WhenPresentationContainsInlineSpec_ShouldLiftTypedPresentation()
+    {
+        var workflow = new WorkflowParser().Parse(
+            """
+            name: interaction_inline_presentation
+            roles: []
+            steps:
+              - id: approve
+                type: human_approval
+                presentation:
+                  title: Inline approval
+                  body: Pick an action
+                  disposition: pinned
+                  actions:
+                    - action_id: approve
+                      label: Approve
+                      style: primary
+                  fields:
+                    - title: Environment
+                      text: prod
+                      is_short: true
+                  cards:
+                    - kind: actions
+                      title: Escalation
+                      actions:
+                        - action_id: escalate
+                          label: Escalate
+                          style: danger
+            """);
+
+        var spec = workflow.Steps[0].Presentation?.InteractionSpec;
+
+        spec.Should().NotBeNull();
+        spec!.Title.Should().Be("Inline approval");
+        spec.Body.Should().Be("Pick an action");
+        spec.Disposition.Should().Be(InteractionDisposition.Pinned);
+        spec.Actions.Should().ContainSingle(x => x.ActionId == "approve" && x.Style == InteractionActionStyle.Primary);
+        spec.Fields.Should().ContainSingle(x => x.Title == "Environment" && x.IsShort);
+        spec.Cards.Should().ContainSingle();
+        spec.Cards[0].Kind.Should().Be(InteractionCardKind.Actions);
+        spec.Cards[0].Actions.Should().ContainSingle(x => x.ActionId == "escalate" && x.Style == InteractionActionStyle.Danger);
+    }
+
+    [Fact]
     public void Parse_WhenRoleAgentKindIsPresent_ShouldMapTrimmedAgentKind()
     {
         var workflow = new WorkflowParser().Parse(

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowAbstractionsProtoCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowAbstractionsProtoCoverageTests.cs
@@ -1,4 +1,5 @@
 using Aevatar.Workflow.Abstractions;
+using Aevatar.Foundation.Abstractions.Interactions;
 using FluentAssertions;
 using Google.Protobuf;
 
@@ -92,6 +93,18 @@ public class WorkflowAbstractionsProtoCoverageTests
             TargetRole = "assistant",
         };
         request.Parameters["temperature"] = "0.1";
+        request.StepParameters.InteractionSpec = new InteractionSpec
+        {
+            Title = "Review",
+            Body = "Approve?",
+        };
+        request.StepParameters.InteractionSpec.Actions.Add(new InteractionAction
+        {
+            Kind = InteractionActionKind.Button,
+            ActionId = "approve",
+            Label = "Approve",
+            Style = InteractionActionStyle.Primary,
+        });
 
         var completed = new StepCompletedEvent
         {
@@ -107,6 +120,8 @@ public class WorkflowAbstractionsProtoCoverageTests
         parsedRequest.StepType.Should().Be("llm_call");
         parsedRequest.Parameters["temperature"].Should().Be("0.1");
         parsedRequest.StepParameters.Parameters["temperature"].Should().Be("0.1");
+        parsedRequest.StepParameters.InteractionSpec.Title.Should().Be("Review");
+        parsedRequest.StepParameters.InteractionSpec.Actions[0].Style.Should().Be(InteractionActionStyle.Primary);
 
         var parsedCompleted = StepCompletedEvent.Parser.ParseFrom(completed.ToByteArray());
         parsedCompleted.WorkerId.Should().Be("worker-1");
@@ -131,10 +146,12 @@ public class WorkflowAbstractionsProtoCoverageTests
         };
         request.StepParameters.Parameters["op"] = "trim";
         request.Parameters["target"] = "result";
+        request.StepParameters.InteractionSpec = new InteractionSpec { Body = "Continue?" };
 
         var parsed = StepRequestEvent.Parser.ParseFrom(request.ToByteArray());
         parsed.StepParameters.Parameters.Should().Contain(new KeyValuePair<string, string>("op", "trim"));
         parsed.Parameters.Should().Contain(new KeyValuePair<string, string>("target", "result"));
+        parsed.StepParameters.InteractionSpec.Body.Should().Be("Continue?");
         parsed.ToString().Should().Contain("stepParameters");
         ((IMessage)parsed.StepParameters).Descriptor.Name.Should().Be(nameof(WorkflowStepParameters));
     }

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -121,6 +121,35 @@ check_channel_inbound_no_runtime_credential() {
 
 check_channel_inbound_no_runtime_credential
 
+check_workflow_core_interaction_boundary() {
+  local workflow_core_dir="src/workflow/Aevatar.Workflow.Core"
+  local report
+
+  set +e
+  report="$(
+    rg -n "MessageContent|LarkMessageComposer|interactive_card|card JSON|raw Lark" "${workflow_core_dir}" \
+      -g '!**/bin/**' \
+      -g '!**/obj/**' \
+      -g '!*.g.cs' \
+      -g '!*.Designer.cs'
+  )"
+  local status=$?
+  set -e
+
+  if [[ ${status} -ne 0 && ${status} -ne 1 ]]; then
+    echo "Workflow Core interaction boundary guard execution failed."
+    exit "${status}"
+  fi
+
+  if [ -n "${report}" ]; then
+    echo "${report}"
+    echo "Workflow Core must carry typed InteractionSpec only; channel content and raw card payloads belong at the channel boundary."
+    exit 1
+  fi
+}
+
+check_workflow_core_interaction_boundary
+
 bash tools/ci/aevatar_oauth_client_es_acl_guard.sh
 bash tools/ci/static_service_activation_guard.sh || exit $?
 


### PR DESCRIPTION
## Summary / 摘要

实现 #1861（交互协议基础件，属于 #1853 umbrella）：在 Foundation 层引入 typed `InteractionSpec` proto 契约，并把 workflow 执行链对交互的承载从 bag/字符串提升为 typed 字段。

- **新增** `Aevatar.Foundation.Abstractions/Interactions/interaction_spec.proto`：typed `InteractionSpec`（Select / TextInput / Form 等交互原语的强类型描述）。
- **新增** `InteractionSpecMapper`（Channel.Abstractions）：proto ↔ 领域 typed 边界互转。
- **workflow typed lift**：`StepDefinition` / `StepPresentation` / `WorkflowParser` / `WorkflowExecutionKernel` 增加 typed interaction surface；`workflow_execution_messages.proto` 加 typed 字段。
- **`ReplyWithInteractionIntentMapper`**（ToolProviders.Channel）：reply_with_interaction 意图的 typed 映射。
- 配套 proto coverage / parser / tool 测试。

## Scope / 范围

19 files (+1147/-52)。仅 Foundation typed 契约 + workflow typed lift + 配套测试；**已清理**先前混入的 console UI / skill 改动（那些属于 PR #1776/#1867）。base = `crnd/integrate-1854`（当前 tip，已含 feature/integrate sync）。

## 依赖关系

#1853 umbrella 基础件；**#1862 / #1863 依赖本 PR 提供的 typed surface**。

🤖 controller (consensus-rnd loop) — cleaned + rebased onto current staging tip

⟦AI:AUTO-LOOP⟧
