### PR TITLE
feat(#1846): reply_with_interaction Select/TextInput/Form 原语 + Lark 表单渲染 + typed CardActionSubmission.action_kind gate

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
@@ -288,6 +288,8 @@ message CardActionSubmission {
   WorkflowResumeActionPayload workflow_resume = 6;
   // Repository-owned LLM selection payload submitted by this action.
   LlmSelectionActionPayload llm_selection = 7;
+  // The kind of action element that produced this callback.
+  ActionElementKind action_kind = 8;
 }
 
 // Carries the channel-agnostic message content used for send, update, and reply operations.

--- a/agents/Aevatar.GAgents.NyxidChat/ChannelCardActionRouting.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelCardActionRouting.cs
@@ -28,7 +28,10 @@ public static class ChannelCardActionRouting
         {
             CopyWorkflowResumePayload(payload, values);
             foreach (var pair in inbound.CardAction!.FormFields)
-                values[pair.Key] = pair.Value;
+            {
+                if (IsWorkflowFormField(pair.Key))
+                    values[pair.Key] = pair.Value;
+            }
         }
         else if (TryBuildDeprecatedWorkflowResumeValues(inbound.Extra, values))
         {
@@ -74,6 +77,9 @@ public static class ChannelCardActionRouting
         !string.IsNullOrWhiteSpace(payload.ActorId) &&
         !string.IsNullOrWhiteSpace(payload.RunId) &&
         !string.IsNullOrWhiteSpace(payload.StepId);
+
+    private static bool IsWorkflowFormField(string key) =>
+        key is "user_input" or "edited_content" or "feedback" or "comment" or "input";
 
     private static void CopyWorkflowResumePayload(
         WorkflowResumeActionPayload payload,
@@ -179,6 +185,9 @@ public static class ChannelCardActionRouting
     {
         if (approved)
         {
+            if (values.TryGetValue("feedback", out var approvedFeedback))
+                return NormalizeOptional(approvedFeedback);
+
             if (values.TryGetValue("user_input", out var approvedRaw))
                 return NormalizeOptional(approvedRaw);
 

--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -145,7 +145,8 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         if (await TryHandleWorkflowResumeAsync(inbound, ct) is { } workflowResumeResult)
             return workflowResumeResult;
 
-        if (await TryHandleSlashCommandAsync(activity, inbound, registration, runtimeContext, ct) is { } slashResult)
+        if (activity.Type != ActivityType.CardAction &&
+            await TryHandleSlashCommandAsync(activity, inbound, registration, runtimeContext, ct) is { } slashResult)
             return slashResult;
 
         // Normal LLM messages do not force /init. If the sender is bound we
@@ -164,6 +165,24 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
 
         if (activity.Type == ActivityType.CardAction)
         {
+            if (TryBuildGenericFormSubmitLlmText(activity.Content?.CardAction, out var formSubmitText))
+            {
+                var formInbound = WithText(inbound, formSubmitText);
+                var formSubmitInboundEvent = ToInboundEvent(
+                    activity,
+                    registration,
+                    formInbound);
+                return ConversationTurnResult.LlmReplyRequested(
+                    await BuildLlmReplyRequestAsync(
+                            activity,
+                            registration,
+                            formSubmitInboundEvent,
+                            runtimeContext,
+                            senderBinding,
+                            ct)
+                        .ConfigureAwait(false));
+            }
+
             // A card_action that survived both routers has no actionable meaning for this
             // bot: promoting it into an LLM turn would send a blank user message and waste
             // a model call. Return a no-reply completion instead of falling through.
@@ -1521,6 +1540,44 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         };
     }
 
+    private static bool TryBuildGenericFormSubmitLlmText(CardActionSubmission? cardAction, out string text)
+    {
+        text = string.Empty;
+        if (cardAction is null ||
+            cardAction.ActionKind != ActionElementKind.FormSubmit ||
+            cardAction.FormFields.Count == 0)
+        {
+            return false;
+        }
+
+        var lines = cardAction.FormFields
+            .Where(static pair => !string.IsNullOrWhiteSpace(pair.Key))
+            .OrderBy(static pair => pair.Key, StringComparer.Ordinal)
+            .Select(static pair => $"{pair.Key}: {pair.Value}")
+            .ToArray();
+        if (lines.Length == 0)
+            return false;
+
+        text = string.Join("\n", lines);
+        return true;
+    }
+
+    private static InboundMessage WithText(InboundMessage inbound, string text) =>
+        new()
+        {
+            Platform = inbound.Platform,
+            ConversationId = inbound.ConversationId,
+            SenderId = inbound.SenderId,
+            SenderName = inbound.SenderName,
+            Text = text,
+            MessageId = inbound.MessageId,
+            ChatType = inbound.ChatType,
+            OutboundDelivery = inbound.OutboundDelivery?.Clone(),
+            TransportExtras = inbound.TransportExtras?.Clone(),
+            CardAction = inbound.CardAction?.Clone(),
+            Extra = inbound.Extra,
+        };
+
     private static ChannelInboundEvent ToInboundEvent(
         ChatActivity activity,
         ChannelBotRegistrationEntry registration,
@@ -1692,6 +1749,7 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         if (requestActivity.Content is null)
             return requestActivity;
 
+        requestActivity.Content.Text = inboundText ?? string.Empty;
         if (allowSkillInvocationPrompt && TryBuildSkillInvocationPrompt(inboundText, platform, out var prompt))
             requestActivity.Content.Text = prompt;
 

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayOutboundPort.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayOutboundPort.cs
@@ -202,19 +202,6 @@ public sealed class NyxIdRelayOutboundPort
                 $"Relay outbound composer for platform '{normalizedPlatform}' cannot express the requested message content.");
         }
 
-        if (ShouldUseLarkTextOnlyFallback(normalizedPlatform, content))
-        {
-            replyText = NyxIdRelayInteractiveReplyDispatcher.BuildTextFallback(content);
-            if (string.IsNullOrWhiteSpace(replyText))
-            {
-                return EmitResult.Failed(
-                    "empty_reply",
-                    "Relay outbound could not render a non-empty reply payload.");
-            }
-
-            return null;
-        }
-
         if (composer.Compose(content, composeContext) is not IPlainTextComposedMessage plainTextPayload)
         {
             return EmitResult.Failed(
@@ -237,8 +224,4 @@ public sealed class NyxIdRelayOutboundPort
         string.IsNullOrWhiteSpace(value)
             ? string.Empty
             : value.Trim().ToLowerInvariant();
-
-    private static bool ShouldUseLarkTextOnlyFallback(string normalizedPlatform, MessageContent content) =>
-        string.Equals(normalizedPlatform, "lark", StringComparison.OrdinalIgnoreCase) &&
-        (content.Actions.Count > 0 || content.Cards.Count > 0);
 }

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
@@ -234,6 +234,9 @@ public sealed class NyxIdRelayTransport
         if (root.TryGetProperty("form_fields", out var formFieldsElement))
             CopyScalarMap(formFieldsElement, submission.FormFields);
 
+        submission.ActionKind = ResolveActionKind(root, submission.Arguments);
+        submission.Arguments.Remove("action_kind");
+
         MapKnownPayloads(submission);
 
         if (string.IsNullOrEmpty(submission.ActionId) &&
@@ -272,6 +275,59 @@ public sealed class NyxIdRelayTransport
                 "service_id",
                 "preset_id");
         }
+    }
+
+    private static ActionElementKind ResolveActionKind(
+        JsonElement root,
+        Google.Protobuf.Collections.MapField<string, string> arguments)
+    {
+        if (arguments.TryGetValue("action_kind", out var actionKind) &&
+            TryMapActionKind(actionKind, out var mappedFromValue))
+        {
+            return mappedFromValue;
+        }
+
+        if (TryReadString(root, "action_kind", out var rootActionKind) &&
+            TryMapActionKind(rootActionKind, out var mappedFromRoot))
+        {
+            return mappedFromRoot;
+        }
+
+        if (TryReadString(root, "tag", out var tag) &&
+            TryMapLarkActionTag(tag, out var mappedFromTag))
+        {
+            return mappedFromTag;
+        }
+
+        return ActionElementKind.Unspecified;
+    }
+
+    private static bool TryMapActionKind(string? value, out ActionElementKind kind)
+    {
+        var normalized = (value ?? string.Empty).Trim().ToLowerInvariant();
+        kind = normalized switch
+        {
+            "button" => ActionElementKind.Button,
+            "select" or "select_static" => ActionElementKind.Select,
+            "text_input" or "input" => ActionElementKind.TextInput,
+            "form_submit" or "submit" => ActionElementKind.FormSubmit,
+            "link" => ActionElementKind.Link,
+            _ => ActionElementKind.Unspecified,
+        };
+        return kind != ActionElementKind.Unspecified;
+    }
+
+    private static bool TryMapLarkActionTag(string? value, out ActionElementKind kind)
+    {
+        var normalized = (value ?? string.Empty).Trim().ToLowerInvariant();
+        kind = normalized switch
+        {
+            "button" => ActionElementKind.Button,
+            "select_static" => ActionElementKind.Select,
+            "input" => ActionElementKind.TextInput,
+            _ => ActionElementKind.Unspecified,
+        };
+        return kind != ActionElementKind.Unspecified;
     }
 
     private static bool TryBuildWorkflowResumePayload(

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/Outbound/NyxIdRelayInteractiveReplyDispatcher.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/Outbound/NyxIdRelayInteractiveReplyDispatcher.cs
@@ -65,19 +65,6 @@ public sealed class NyxIdRelayInteractiveReplyDispatcher : IInteractiveReplyDisp
             return await SendTextFallbackAsync(relayToken, messageId, BuildTextFallback(intent), capability, cancellationToken);
         }
 
-        if (ShouldUseTextOnlyFallback(channel, intent))
-        {
-            _logger.LogInformation(
-                "Interactive reply dispatcher is degrading action card intent to text for channel {Channel}.",
-                channel.Value);
-            return await SendTextFallbackAsync(
-                relayToken,
-                messageId,
-                BuildTextFallback(intent),
-                capability,
-                cancellationToken);
-        }
-
         var native = producer.Produce(intent, context);
         var body = new ChannelRelayReplyBody(
             Text: native.Text,
@@ -92,20 +79,6 @@ public sealed class NyxIdRelayInteractiveReplyDispatcher : IInteractiveReplyDisp
             FellBackToText: !native.IsInteractive,
             Detail: delivery.Detail);
     }
-
-    private static bool ShouldUseTextOnlyFallback(
-        ChannelId channel,
-        MessageContent intent)
-    {
-        if (!string.Equals(channel.Value, "lark", StringComparison.OrdinalIgnoreCase))
-            return false;
-
-        return HasUserVisibleActions(intent.Actions) ||
-               intent.Cards.Count > 0;
-    }
-
-    private static bool HasUserVisibleActions(IEnumerable<ActionElement> actions) =>
-        actions.Any(action => action.Kind != ActionElementKind.TextInput || action.Options.Count > 0);
 
     private async Task<InteractiveReplyDispatchResult> SendTextFallbackAsync(
         string relayToken,

--- a/agents/platforms/Aevatar.GAgents.Platform.Lark/LarkMessageComposer.cs
+++ b/agents/platforms/Aevatar.GAgents.Platform.Lark/LarkMessageComposer.cs
@@ -56,7 +56,7 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
             if (leading is not null)
                 formElements.Add(leading);
 
-            var actionElements = intent.Actions.SelectMany(BuildFormChildElements).ToArray();
+            var actionElements = EnumerateActions(intent).SelectMany(BuildFormChildElements).ToArray();
             formElements.Add(new
             {
                 tag = "form",
@@ -127,10 +127,10 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
             });
         }
 
-        if (intent.Actions.Count > 0)
+        if (EnumerateActions(intent).Any())
         {
-            elements.AddRange(intent.Actions
-                .Where(action => action.Kind != ActionElementKind.TextInput)
+            elements.AddRange(EnumerateActions(intent)
+                .Where(action => action.Kind is not ActionElementKind.TextInput and not ActionElementKind.Select)
                 .Select(BuildAction));
         }
 
@@ -177,7 +177,7 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
         if (intent.Attachments.Count > 0 && !(context.Capabilities?.SupportsFiles ?? DefaultCapabilities.SupportsFiles))
             return ComposeCapability.Unsupported;
 
-        if (intent.Actions.Count > 0 && !(context.Capabilities?.SupportsActionButtons ?? DefaultCapabilities.SupportsActionButtons))
+        if (EnumerateActions(intent).Any() && !(context.Capabilities?.SupportsActionButtons ?? DefaultCapabilities.SupportsActionButtons))
             return ComposeCapability.Degraded;
 
         return ComposeCapability.Exact;
@@ -186,7 +186,7 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
     private const string DefaultFormName = "card_form";
 
     private static bool RequiresFormWrapping(MessageContent intent) =>
-        intent.Actions.Any(a => a.Kind == ActionElementKind.TextInput);
+        EnumerateActions(intent).Any(a => a.Kind is ActionElementKind.TextInput or ActionElementKind.Select or ActionElementKind.FormSubmit);
 
     private static string ResolveHeaderTitle(MessageContent intent, string effectiveText)
     {
@@ -201,7 +201,18 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
     }
 
     private static string ResolveHeaderTemplate(MessageContent intent) =>
-        intent.Actions.Any(a => a.IsDanger) ? "orange" : "blue";
+        EnumerateActions(intent).Any(a => a.IsDanger) ? "orange" : "blue";
+
+    private static IEnumerable<ActionElement> EnumerateActions(MessageContent intent)
+    {
+        foreach (var action in intent.Actions)
+            yield return action;
+        foreach (var card in intent.Cards)
+        {
+            foreach (var action in card.Actions)
+                yield return action;
+        }
+    }
 
     private static object? BuildLeadingMarkdown(string effectiveText, MessageContent intent)
     {
@@ -232,23 +243,25 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
 
     private static IEnumerable<object> BuildFormChildElements(ActionElement action)
     {
-        if (action.Kind != ActionElementKind.TextInput)
+        if (action.Kind is ActionElementKind.TextInput or ActionElementKind.Select)
         {
-            yield return BuildFormButton(action);
-            yield break;
-        }
-
-        var label = string.IsNullOrWhiteSpace(action.Label) ? action.ActionId : action.Label;
-        if (!string.IsNullOrWhiteSpace(label))
-        {
-            yield return new
+            var label = string.IsNullOrWhiteSpace(action.Label) ? action.ActionId : action.Label;
+            if (!string.IsNullOrWhiteSpace(label))
             {
-                tag = "markdown",
-                content = $"**{label}**",
-            };
+                yield return new
+                {
+                    tag = "markdown",
+                    content = $"**{label}**",
+                };
+            }
         }
 
-        yield return BuildFormInput(action);
+        yield return action.Kind switch
+        {
+            ActionElementKind.TextInput => BuildFormInput(action),
+            ActionElementKind.Select => BuildFormSelect(action),
+            _ => BuildFormButton(action),
+        };
     }
 
     private static object BuildFormInput(ActionElement action)
@@ -273,19 +286,59 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
         return input;
     }
 
-    private static object BuildFormButton(ActionElement action) => new
+    private static object BuildFormSelect(ActionElement action)
     {
-        tag = "button",
-        type = ResolveButtonType(action),
-        name = action.ActionId,
-        form_action_type = "submit",
-        text = new
+        var select = new Dictionary<string, object?>(StringComparer.Ordinal)
         {
-            tag = "plain_text",
-            content = string.IsNullOrWhiteSpace(action.Label) ? action.ActionId : action.Label,
-        },
-        behaviors = BuildButtonBehaviors(action),
-    };
+            ["tag"] = "select_static",
+            ["name"] = action.ActionId,
+            ["type"] = "default",
+            ["width"] = "default",
+            ["placeholder"] = new
+            {
+                tag = "plain_text",
+                content = ResolvePlaceholder(action),
+            },
+            ["options"] = action.Options.Select(static option => new
+            {
+                text = new
+                {
+                    tag = "plain_text",
+                    content = string.IsNullOrWhiteSpace(option.Label) ? option.Value : option.Label,
+                },
+                value = option.Value,
+            }).ToArray(),
+            ["value"] = BuildActionValueObject(action),
+        };
+        if (!string.IsNullOrWhiteSpace(action.Value))
+            select["initial_option"] = action.Value;
+        if (action.IsDisabled)
+            select["disabled"] = true;
+        return select;
+    }
+
+    private static object BuildFormButton(ActionElement action)
+    {
+        var button = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["tag"] = "button",
+            ["type"] = ResolveButtonType(action),
+            ["text"] = new
+            {
+                tag = "plain_text",
+                content = string.IsNullOrWhiteSpace(action.Label) ? action.ActionId : action.Label,
+            },
+            ["behaviors"] = BuildButtonBehaviors(action),
+        };
+        if (action.Kind != ActionElementKind.Link)
+        {
+            button["name"] = action.ActionId;
+            button["form_action_type"] = "submit";
+        }
+        if (action.IsDisabled)
+            button["disabled"] = true;
+        return button;
+    }
 
     private static object BuildAction(ActionElement action) => new
     {
@@ -298,6 +351,15 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
         type = ResolveButtonType(action),
         behaviors = BuildButtonBehaviors(action),
     };
+
+    private static string ResolvePlaceholder(ActionElement action)
+    {
+        if (!string.IsNullOrWhiteSpace(action.Placeholder))
+            return action.Placeholder;
+        if (!string.IsNullOrWhiteSpace(action.Label))
+            return action.Label;
+        return action.ActionId;
+    }
 
     private static string ResolveButtonType(ActionElement action)
     {
@@ -336,6 +398,7 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
         {
             ["action_id"] = action.ActionId,
             ["value"] = action.Value,
+            ["action_kind"] = ToBoundaryActionKind(action.Kind),
         };
         CopyWorkflowResumePayload(action.WorkflowResume, map);
         CopyLlmSelectionPayload(action.LlmSelection, map);
@@ -343,7 +406,8 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
         foreach (var argument in action.Arguments)
         {
             if (string.Equals(argument.Key, "action_id", StringComparison.Ordinal) ||
-                string.Equals(argument.Key, "value", StringComparison.Ordinal))
+                string.Equals(argument.Key, "value", StringComparison.Ordinal) ||
+                string.Equals(argument.Key, "action_kind", StringComparison.Ordinal))
                 continue;
 
             map[argument.Key] = CoerceArgumentValue(argument.Value);
@@ -351,6 +415,17 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
 
         return map;
     }
+
+    private static string ToBoundaryActionKind(ActionElementKind kind) =>
+        kind switch
+        {
+            ActionElementKind.Select => "select",
+            ActionElementKind.TextInput => "text_input",
+            ActionElementKind.FormSubmit => "form_submit",
+            ActionElementKind.Link => "link",
+            ActionElementKind.Button => "button",
+            _ => "unspecified",
+        };
 
     private static void CopyWorkflowResumePayload(
         WorkflowResumeActionPayload? payload,

--- a/src/Aevatar.AI.ToolProviders.Channel/ReplyWithInteractionIntentMapper.cs
+++ b/src/Aevatar.AI.ToolProviders.Channel/ReplyWithInteractionIntentMapper.cs
@@ -69,6 +69,20 @@ public static class ReplyWithInteractionIntentMapper
         return $"{title}\n{body}";
     }
 
+    private static ActionElementKind MapActionKind(string? kind)
+    {
+        var normalized = (kind ?? string.Empty).Trim().ToLowerInvariant();
+        return normalized switch
+        {
+            "" or "button" => ActionElementKind.Button,
+            "select" => ActionElementKind.Select,
+            "text_input" or "text-input" or "input" => ActionElementKind.TextInput,
+            "form_submit" or "form-submit" or "submit" => ActionElementKind.FormSubmit,
+            "link" => ActionElementKind.Link,
+            _ => ActionElementKind.Button,
+        };
+    }
+
     private static ActionElement? MapAction(ReplyActionArgument? action)
     {
         if (action is null)
@@ -76,15 +90,35 @@ public static class ReplyWithInteractionIntentMapper
         if (string.IsNullOrWhiteSpace(action.ActionId))
             return null;
 
-        return new ActionElement
+        var mapped = new ActionElement
         {
-            Kind = ActionElementKind.Button,
+            Kind = MapActionKind(action.Kind),
             ActionId = action.ActionId!,
             Label = action.Label ?? action.ActionId!,
             Value = action.Value ?? string.Empty,
+            Placeholder = action.Placeholder ?? string.Empty,
             IsPrimary = string.Equals(action.Style, "primary", StringComparison.OrdinalIgnoreCase),
             IsDanger = string.Equals(action.Style, "danger", StringComparison.OrdinalIgnoreCase),
         };
+
+        if (action.Options is { Count: > 0 })
+        {
+            foreach (var option in action.Options)
+            {
+                if (option is null)
+                    continue;
+                if (string.IsNullOrWhiteSpace(option.Label) && string.IsNullOrWhiteSpace(option.Value))
+                    continue;
+
+                mapped.Options.Add(new ActionOption
+                {
+                    Label = option.Label ?? option.Value ?? string.Empty,
+                    Value = option.Value ?? option.Label ?? string.Empty,
+                });
+            }
+        }
+
+        return mapped;
     }
 
     private static CardBlock? MapCard(ReplyCardArgument? card)

--- a/src/Aevatar.AI.ToolProviders.Channel/ReplyWithInteractionTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Channel/ReplyWithInteractionTool.cs
@@ -32,7 +32,7 @@ public sealed class ReplyWithInteractionTool : IAgentTool
     public string Name => "reply_with_interaction";
 
     public string Description =>
-        "Reply to the current user turn with an interactive message (title, body, buttons, cards). " +
+        "Reply to the current user turn with an interactive message (title, body, actions, cards). " +
         "Use this when the user would benefit from a rich card with selectable actions. " +
         "Returns a short confirmation; the reply is delivered when the turn completes. " +
         "If the channel does not support cards the runtime automatically degrades to plain text.";
@@ -88,16 +88,34 @@ public sealed class ReplyWithInteractionTool : IAgentTool
             },
             "actions": {
               "type": "array",
-              "description": "Optional top-level interactive actions (buttons).",
+              "description": "Optional top-level interactive actions.",
               "items": {
                 "type": "object",
                 "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": ["button", "select", "text_input", "form_submit", "link"],
+                    "description": "Action element kind. Defaults to button."
+                  },
                   "action_id": { "type": "string" },
                   "label": { "type": "string" },
                   "value": { "type": "string" },
+                  "placeholder": { "type": "string" },
                   "style": {
                     "type": "string",
                     "enum": ["default", "primary", "danger"]
+                  },
+                  "options": {
+                    "type": "array",
+                    "description": "Selectable options for select actions.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "label": { "type": "string" },
+                        "value": { "type": "string" }
+                      },
+                      "required": ["label", "value"]
+                    }
                   }
                 },
                 "required": ["action_id", "label"]
@@ -137,12 +155,29 @@ public sealed class ReplyWithInteractionTool : IAgentTool
                     "items": {
                       "type": "object",
                       "properties": {
+                        "kind": {
+                          "type": "string",
+                          "enum": ["button", "select", "text_input", "form_submit", "link"],
+                          "description": "Action element kind. Defaults to button."
+                        },
                         "action_id": { "type": "string" },
                         "label": { "type": "string" },
                         "value": { "type": "string" },
+                        "placeholder": { "type": "string" },
                         "style": {
                           "type": "string",
                           "enum": ["default", "primary", "danger"]
+                        },
+                        "options": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "label": { "type": "string" },
+                              "value": { "type": "string" }
+                            },
+                            "required": ["label", "value"]
+                          }
                         }
                       },
                       "required": ["action_id", "label"]
@@ -178,6 +213,9 @@ public sealed class ReplyWithInteractionArguments
 /// <summary>Card-level action parameter.</summary>
 public sealed class ReplyActionArgument
 {
+    [JsonPropertyName("kind")]
+    public string? Kind { get; set; }
+
     [JsonPropertyName("action_id")]
     public string? ActionId { get; set; }
 
@@ -189,6 +227,22 @@ public sealed class ReplyActionArgument
 
     [JsonPropertyName("style")]
     public string? Style { get; set; }
+
+    [JsonPropertyName("placeholder")]
+    public string? Placeholder { get; set; }
+
+    [JsonPropertyName("options")]
+    public List<ReplyActionOptionArgument>? Options { get; set; }
+}
+
+/// <summary>Selectable action option parameter.</summary>
+public sealed class ReplyActionOptionArgument
+{
+    [JsonPropertyName("label")]
+    public string? Label { get; set; }
+
+    [JsonPropertyName("value")]
+    public string? Value { get; set; }
 }
 
 /// <summary>Card field parameter (title/text pair).</summary>

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelAbstractionsProtoTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelAbstractionsProtoTests.cs
@@ -63,6 +63,7 @@ public sealed class ChannelAbstractionsProtoTests
                     ActionId = "approve",
                     SubmittedValue = "true",
                     SourceMessageId = "om_123",
+                    ActionKind = ActionElementKind.FormSubmit,
                 },
             },
             ReplyToActivityId = "orig-1",
@@ -116,6 +117,7 @@ public sealed class ChannelAbstractionsProtoTests
 
         parsed.ShouldBe(activity);
         parsed.Content.CardAction.ActionId.ShouldBe("approve");
+        parsed.Content.CardAction.ActionKind.ShouldBe(ActionElementKind.FormSubmit);
         parsed.Content.Actions[0].Kind.ShouldBe(ActionElementKind.Button);
         parsed.Conversation.Scope.ShouldBe(ConversationScope.Thread);
         parsed.OutboundDelivery.ReplyMessageId.ShouldBe("relay-msg-1");

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCardActionRoutingTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCardActionRoutingTests.cs
@@ -160,6 +160,41 @@ public sealed class ChannelCardActionRoutingTests
     }
 
     [Fact]
+    public void TryBuildWorkflowResumeCommand_should_ignore_unowned_form_fields_for_typed_workflow_payload()
+    {
+        var cardAction = new CardActionSubmission
+        {
+            WorkflowResume = new WorkflowResumeActionPayload
+            {
+                ActorId = "run-actor-1",
+                RunId = "run-1",
+                StepId = "approval-1",
+                Approved = true,
+            },
+        };
+        cardAction.FormFields["environment"] = "prod";
+        cardAction.FormFields["feedback"] = "looks good";
+        var inbound = new InboundMessage
+        {
+            Platform = "lark",
+            ConversationId = "oc_chat_1",
+            SenderId = "ou_user_1",
+            SenderName = string.Empty,
+            Text = "{}",
+            MessageId = "evt-card-owned-fields-1",
+            ChatType = "card_action",
+            CardAction = cardAction,
+        };
+
+        var matched = ChannelCardActionRouting.TryBuildWorkflowResumeCommand(inbound, out var command);
+
+        matched.Should().BeTrue();
+        command.Should().NotBeNull();
+        command!.Feedback.Should().Be("looks good");
+        command.UserInput.Should().BeNull();
+    }
+
+    [Fact]
     public void TryBuildWorkflowResumeCommand_should_require_actor_run_and_step_ids()
     {
         var inbound = new InboundMessage

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
@@ -708,6 +708,47 @@ public sealed class ChannelConversationTurnRunnerTests
     }
 
     [Fact]
+    public async Task RunInboundAsync_ShouldContinueGenericFormSubmitToLlm_WhenTypedFormSubmitCarriesFields()
+    {
+        var registrationQueryPort = BuildRegistrationQueryPort();
+        var adapter = new RecordingPlatformAdapter();
+        var runner = CreateRunner(registrationQueryPort, adapter);
+        var activity = BuildCardActionActivity(
+            "evt-card-form-submit-1",
+            ("environment", "prod"),
+            ("reason", "deploy ready"));
+        activity.Content.CardAction.ActionKind = ActionElementKind.FormSubmit;
+
+        var result = await runner.RunInboundAsync(activity, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.LlmReplyRequest.Should().NotBeNull();
+        result.SentActivityId.Should().BeEmpty();
+        result.LlmReplyRequest!.Activity.Content.Text.Should().Be("environment: prod\nreason: deploy ready");
+        result.LlmReplyRequest.Activity.Content.CardAction.ActionKind.Should().Be(ActionElementKind.FormSubmit);
+        adapter.Replies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RunInboundAsync_ShouldIgnoreCardAction_WhenFormFieldsExistButActionKindIsNotFormSubmit()
+    {
+        var registrationQueryPort = BuildRegistrationQueryPort();
+        var adapter = new RecordingPlatformAdapter();
+        var runner = CreateRunner(registrationQueryPort, adapter);
+        var activity = BuildCardActionActivity(
+            "evt-card-select-fields-1",
+            ("environment", "prod"));
+        activity.Content.CardAction.ActionKind = ActionElementKind.Select;
+
+        var result = await runner.RunInboundAsync(activity, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.SentActivityId.Should().Be("ignored:unrecognized_card_action:evt-card-select-fields-1");
+        result.LlmReplyRequest.Should().BeNull();
+        adapter.Replies.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task RunInboundAsync_ShouldRouteLlmSelectionCardAction_WhenPayloadCarriesLlmAction()
     {
         var subject = new ExternalSubjectRef

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayInteractiveReplyDispatcherTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayInteractiveReplyDispatcherTests.cs
@@ -117,7 +117,7 @@ public sealed class NyxIdRelayInteractiveReplyDispatcherTests
     }
 
     [Fact]
-    public async Task DispatchAsync_lark_action_card_sends_text_only_fallback()
+    public async Task DispatchAsync_lark_action_card_forwards_card_metadata()
     {
         var handler = new RecordingHandler(HttpStatusCode.OK,
             JsonSerializer.Serialize(new { message_id = "mid", platform_message_id = "pmid" }));
@@ -162,7 +162,7 @@ public sealed class NyxIdRelayInteractiveReplyDispatcherTests
             new ComposeContext());
 
         result.Succeeded.Should().BeTrue();
-        result.FellBackToText.Should().BeTrue();
+        result.FellBackToText.Should().BeFalse();
         result.Capability.Should().Be(ComposeCapability.Exact);
         handler.LastRequestBody.Should().NotBeNull();
         using var document = JsonDocument.Parse(handler.LastRequestBody!);
@@ -171,9 +171,15 @@ public sealed class NyxIdRelayInteractiveReplyDispatcherTests
             .GetProperty("text")
             .GetString()
             .Should()
-            .Be("Pick one\n• Approve\n• Reject");
-        handler.LastRequestBody.Should().NotContain("metadata");
-        handler.LastRequestBody.Should().NotContain("card");
+            .Be("Pick one");
+        document.RootElement
+            .GetProperty("reply")
+            .GetProperty("metadata")
+            .GetProperty("card")
+            .GetProperty("schema")
+            .GetString()
+            .Should()
+            .Be("2.0");
     }
 
     [Fact]
@@ -219,14 +225,14 @@ public sealed class NyxIdRelayInteractiveReplyDispatcherTests
 
         result.Succeeded.Should().BeTrue();
         result.FellBackToText.Should().BeTrue();
-        producer.DidNotReceive().Produce(Arg.Any<MessageContent>(), Arg.Any<ComposeContext>());
+        producer.Received(1).Produce(Arg.Any<MessageContent>(), Arg.Any<ComposeContext>());
         using var document = JsonDocument.Parse(handler.LastRequestBody!);
         document.RootElement
             .GetProperty("reply")
             .GetProperty("text")
             .GetString()
             .Should()
-            .Be("Pick one\nRouting\nChoose a route\nCurrent: gpt-4.1\n• Use fast model");
+            .Be("Pick one");
         handler.LastRequestBody.Should().NotContain("metadata");
         handler.LastRequestBody.Should().NotContain("card");
     }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayOutboundPortTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayOutboundPortTests.cs
@@ -58,7 +58,7 @@ public sealed class NyxIdRelayOutboundPortTests
     }
 
     [Fact]
-    public async Task SendAsync_LarkInteractiveContent_ShouldPostTextFallbackWithCardsAndOptions()
+    public async Task SendAsync_LarkInteractiveContent_ShouldUseComposerPlainText()
     {
         var handler = new RecordingJsonHandler();
         var port = CreatePort(handler, new StubComposer("lark", text: "composer only kept top text"));
@@ -96,13 +96,8 @@ public sealed class NyxIdRelayOutboundPortTests
         handler.Requests[0].Body.Should().Contain("\"message_id\":\"msg-lark-options-1\"");
         using var document = JsonDocument.Parse(handler.Requests[0].Body);
         var text = document.RootElement.GetProperty("reply").GetProperty("text").GetString();
-        text.Should().Contain("Choose route");
-        text.Should().Contain("Model settings");
-        text.Should().Contain("Service: openai");
-        text.Should().Contain("Select service");
-        text.Should().Contain("OpenAI");
-        text.Should().Contain("Azure OpenAI");
-        handler.Requests[0].Body.Should().NotContain("composer only kept top text");
+        text.Should().Be("composer only kept top text");
+        handler.Requests[0].Body.Should().NotContain("metadata");
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayTransportTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayTransportTests.cs
@@ -359,7 +359,7 @@ public sealed class NyxIdRelayTransportTests
               "sender": { "platform_id": "ou_1", "display_name": "User One" },
               "content": {
                 "content_type": "card_action",
-                "text": "{\"value\":{\"agent_builder_action\":\"create_daily\"},\"form_value\":{\"github_username\":\"eanzhao\",\"schedule_time\":\"09:00\"}}"
+                "text": "{\"value\":{\"agent_builder_action\":\"create_daily\",\"action_kind\":\"form_submit\"},\"form_value\":{\"github_username\":\"eanzhao\",\"schedule_time\":\"09:00\"}}"
               }
             }
             """;
@@ -373,11 +373,40 @@ public sealed class NyxIdRelayTransportTests
         cardAction.Should().NotBeNull();
         cardAction!.Arguments.Should().ContainKey("agent_builder_action")
             .WhoseValue.Should().Be("create_daily");
+        cardAction.Arguments.Should().NotContainKey("action_kind");
+        cardAction.ActionKind.Should().Be(ActionElementKind.FormSubmit);
         cardAction.FormFields.Should().ContainKey("github_username")
             .WhoseValue.Should().Be("eanzhao");
         cardAction.FormFields.Should().ContainKey("schedule_time")
             .WhoseValue.Should().Be("09:00");
         cardAction.ActionId.Should().Be("create_daily");
+    }
+
+    [Fact]
+    public void Parse_ShouldMapLarkBoundaryTagToTypedActionKind_WhenValueDoesNotCarryActionKind()
+    {
+        var body = """
+            {
+              "message_id": "msg-card-select-kind",
+              "platform": "lark",
+              "agent": { "api_key_id": "api-key-1" },
+              "conversation": { "id": "conv-1", "platform_id": "oc_chat_1", "type": "private" },
+              "sender": { "platform_id": "ou_1", "display_name": "User One" },
+              "content": {
+                "content_type": "card_action",
+                "text": "{\"tag\":\"select_static\",\"value\":{\"action_id\":\"environment\"},\"form_value\":{\"environment\":\"prod\"}}"
+              }
+            }
+            """;
+
+        var parsed = _transport.Parse(Encoding.UTF8.GetBytes(body));
+
+        parsed.Success.Should().BeTrue();
+        var cardAction = parsed.Activity!.Content.CardAction;
+        cardAction.Should().NotBeNull();
+        cardAction!.ActionKind.Should().Be(ActionElementKind.Select);
+        cardAction.FormFields.Should().ContainKey("environment")
+            .WhoseValue.Should().Be("prod");
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ReplyWithInteractionToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ReplyWithInteractionToolTests.cs
@@ -62,6 +62,42 @@ public sealed class ReplyWithInteractionToolTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_maps_non_button_actions_and_options_into_intent_actions()
+    {
+        var collector = new AsyncLocalInteractiveReplyCollector();
+        using var scope = collector.BeginScope();
+        var tool = new ReplyWithInteractionTool(collector);
+
+        await tool.ExecuteAsync(
+            """
+            {"body":"configure","actions":[
+                {"kind":"select","action_id":"environment","label":"Environment","placeholder":"Choose env","options":[
+                    {"label":"Production","value":"prod"},
+                    {"label":"Staging","value":"stage"}
+                ]},
+                {"kind":"text_input","action_id":"reason","label":"Reason","placeholder":"Why?"},
+                {"kind":"form_submit","action_id":"submit","label":"Submit","style":"primary"},
+                {"kind":"link","action_id":"docs","label":"Docs","value":"https://example.test/docs"}
+            ]}
+            """);
+
+        var captured = collector.TryTake();
+
+        captured.Should().NotBeNull();
+        captured!.Actions.Should().HaveCount(4);
+        captured.Actions[0].Kind.Should().Be(ActionElementKind.Select);
+        captured.Actions[0].Placeholder.Should().Be("Choose env");
+        captured.Actions[0].Options.Should().HaveCount(2);
+        captured.Actions[0].Options[0].Value.Should().Be("prod");
+        captured.Actions[1].Kind.Should().Be(ActionElementKind.TextInput);
+        captured.Actions[1].Placeholder.Should().Be("Why?");
+        captured.Actions[2].Kind.Should().Be(ActionElementKind.FormSubmit);
+        captured.Actions[2].IsPrimary.Should().BeTrue();
+        captured.Actions[3].Kind.Should().Be(ActionElementKind.Link);
+        captured.Actions[3].Value.Should().Be("https://example.test/docs");
+    }
+
+    [Fact]
     public async Task ExecuteAsync_maps_cards_into_intent_cards()
     {
         var collector = new AsyncLocalInteractiveReplyCollector();

--- a/test/Aevatar.GAgents.Platform.Lark.Tests/LarkMessageComposerTests.cs
+++ b/test/Aevatar.GAgents.Platform.Lark.Tests/LarkMessageComposerTests.cs
@@ -178,6 +178,7 @@ public sealed class LarkMessageComposerTests : MessageComposerUnitTests<LarkMess
         var behavior = button.GetProperty("behaviors")[0];
         behavior.GetProperty("type").GetString().ShouldBe("callback");
         behavior.GetProperty("value").GetProperty("action_id").GetString().ShouldBe("status");
+        behavior.GetProperty("value").GetProperty("action_kind").GetString().ShouldBe("button");
     }
 
     [Fact]
@@ -373,6 +374,123 @@ public sealed class LarkMessageComposerTests : MessageComposerUnitTests<LarkMess
         behavior.GetProperty("type").GetString().ShouldBe("callback");
         var value = behavior.GetProperty("value");
         value.GetProperty("action_id").GetString().ShouldBe("submit_daily");
+        value.GetProperty("action_kind").GetString().ShouldBe("form_submit");
         value.GetProperty("agent_builder_action").GetString().ShouldBe("create_daily");
+    }
+
+    [Fact]
+    public void Compose_WhenRenderingSelectAndFormSubmit_UsesLarkFormCardPrimitives()
+    {
+        var intent = new MessageContent { Text = "Configure deployment" };
+        var select = new ActionElement
+        {
+            Kind = ActionElementKind.Select,
+            ActionId = "environment",
+            Label = "Environment",
+            Placeholder = "Choose environment",
+            Value = "prod",
+        };
+        select.Options.Add(new ActionOption { Label = "Production", Value = "prod" });
+        select.Options.Add(new ActionOption { Label = "Staging", Value = "stage" });
+        intent.Actions.Add(select);
+        intent.Actions.Add(new ActionElement
+        {
+            Kind = ActionElementKind.TextInput,
+            ActionId = "reason",
+            Label = "Reason",
+            Placeholder = "Why now?",
+        });
+        intent.Actions.Add(new ActionElement
+        {
+            Kind = ActionElementKind.FormSubmit,
+            ActionId = "submit_deploy",
+            Label = "Submit",
+            IsPrimary = true,
+        });
+
+        var payload = CreateComposer().Compose(
+            intent,
+            new ComposeContext
+            {
+                Conversation = ConversationReference.Create(
+                    ChannelId.From("lark"),
+                    BotInstanceId.From("bot-1"),
+                    ConversationScope.DirectMessage,
+                    partition: null,
+                    "user-1"),
+                Capabilities = LarkMessageComposer.DefaultCapabilities.Clone(),
+            });
+
+        payload.MessageType.ShouldBe("interactive");
+        using var document = JsonDocument.Parse(payload.ContentJson);
+        var formElement = document.RootElement
+            .GetProperty("body")
+            .GetProperty("elements")
+            .EnumerateArray()
+            .First(e => e.TryGetProperty("tag", out var tag) && tag.GetString() == "form");
+        var formChildren = formElement.GetProperty("elements");
+        var selectElement = formChildren
+            .EnumerateArray()
+            .First(e => e.TryGetProperty("tag", out var tag) && tag.GetString() == "select_static");
+        selectElement.GetProperty("name").GetString().ShouldBe("environment");
+        selectElement.GetProperty("placeholder").GetProperty("content").GetString().ShouldBe("Choose environment");
+        selectElement.GetProperty("initial_option").GetString().ShouldBe("prod");
+        selectElement.GetProperty("options").GetArrayLength().ShouldBe(2);
+        selectElement.GetProperty("value").GetProperty("action_kind").GetString().ShouldBe("select");
+
+        var submitButton = formChildren
+            .EnumerateArray()
+            .First(e => e.TryGetProperty("tag", out var tag) &&
+                        tag.GetString() == "button" &&
+                        e.GetProperty("name").GetString() == "submit_deploy");
+        submitButton.GetProperty("form_action_type").GetString().ShouldBe("submit");
+        submitButton.GetProperty("behaviors")[0]
+            .GetProperty("value")
+            .GetProperty("action_kind")
+            .GetString()
+            .ShouldBe("form_submit");
+    }
+
+    [Fact]
+    public void Compose_WhenCardContainsActions_RendersThoseActions()
+    {
+        var intent = new MessageContent();
+        var card = new CardBlock
+        {
+            Title = "Report",
+            Text = "Ready",
+        };
+        card.Actions.Add(new ActionElement
+        {
+            Kind = ActionElementKind.Button,
+            ActionId = "open_report",
+            Label = "Open",
+        });
+        intent.Cards.Add(card);
+
+        var payload = CreateComposer().Compose(
+            intent,
+            new ComposeContext
+            {
+                Conversation = ConversationReference.Create(
+                    ChannelId.From("lark"),
+                    BotInstanceId.From("bot-1"),
+                    ConversationScope.DirectMessage,
+                    partition: null,
+                    "user-1"),
+                Capabilities = LarkMessageComposer.DefaultCapabilities.Clone(),
+            });
+
+        using var document = JsonDocument.Parse(payload.ContentJson);
+        var button = document.RootElement
+            .GetProperty("body")
+            .GetProperty("elements")
+            .EnumerateArray()
+            .First(e => e.TryGetProperty("tag", out var tag) && tag.GetString() == "button");
+        button.GetProperty("behaviors")[0]
+            .GetProperty("value")
+            .GetProperty("action_id")
+            .GetString()
+            .ShouldBe("open_report");
     }
 }

--- a/test/Aevatar.GAgents.Platform.Lark.Tests/LarkMessageComposerTests.cs
+++ b/test/Aevatar.GAgents.Platform.Lark.Tests/LarkMessageComposerTests.cs
@@ -452,6 +452,62 @@ public sealed class LarkMessageComposerTests : MessageComposerUnitTests<LarkMess
     }
 
     [Fact]
+    public void Compose_WhenRenderingDisabledSelectAndFormSubmit_EmitsLarkDisabledFlags()
+    {
+        var intent = new MessageContent { Text = "Configure deployment" };
+        var select = new ActionElement
+        {
+            Kind = ActionElementKind.Select,
+            ActionId = "environment",
+            Label = "Environment",
+            Placeholder = "Choose environment",
+            IsDisabled = true,
+        };
+        select.Options.Add(new ActionOption { Label = "Production", Value = "prod" });
+        intent.Actions.Add(select);
+        intent.Actions.Add(new ActionElement
+        {
+            Kind = ActionElementKind.FormSubmit,
+            ActionId = "submit_deploy",
+            Label = "Submit",
+            IsDisabled = true,
+        });
+
+        var payload = CreateComposer().Compose(
+            intent,
+            new ComposeContext
+            {
+                Conversation = ConversationReference.Create(
+                    ChannelId.From("lark"),
+                    BotInstanceId.From("bot-1"),
+                    ConversationScope.DirectMessage,
+                    partition: null,
+                    "user-1"),
+                Capabilities = LarkMessageComposer.DefaultCapabilities.Clone(),
+            });
+
+        using var document = JsonDocument.Parse(payload.ContentJson);
+        var formChildren = document.RootElement
+            .GetProperty("body")
+            .GetProperty("elements")
+            .EnumerateArray()
+            .First(e => e.TryGetProperty("tag", out var tag) && tag.GetString() == "form")
+            .GetProperty("elements");
+        var selectElement = formChildren
+            .EnumerateArray()
+            .First(e => e.TryGetProperty("tag", out var tag) && tag.GetString() == "select_static");
+        selectElement.GetProperty("name").GetString().ShouldBe("environment");
+        selectElement.GetProperty("disabled").GetBoolean().ShouldBeTrue();
+
+        var submitButton = formChildren
+            .EnumerateArray()
+            .First(e => e.TryGetProperty("tag", out var tag) &&
+                        tag.GetString() == "button" &&
+                        e.GetProperty("name").GetString() == "submit_deploy");
+        submitButton.GetProperty("disabled").GetBoolean().ShouldBeTrue();
+    }
+
+    [Fact]
     public void Compose_WhenCardContainsActions_RendersThoseActions()
     {
         var intent = new MessageContent();


### PR DESCRIPTION
## Summary / 摘要

实现 #1846（aevatar–Lark 交互协议 · channel 层，属于 #1853 umbrella）：`reply_with_interaction` 原语支持 Select / TextInput / Form 表单，LLM 协商的下拉/多字段交互通过 Lark 卡片渲染并 typed 回流。

- **`ReplyWithInteractionTool` / `ReplyWithInteractionIntentMapper`**：reply_with_interaction 工具与意图 typed 映射。
- **`LarkMessageComposer`**：Select / TextInput / Form 的 Lark 卡片渲染。
- **typed `CardActionSubmission.action_kind` gate**：FormSubmit 回流只消费 typed `action_kind`，不走 presence / 字符串路由。
- **NyxIdRelay 出站交互链**：`NyxIdRelayInteractiveReplyDispatcher` / `NyxIdRelayOutboundPort` / transport 投递交互回复。
- 配套 Channel / Lark / Relay 测试 + disabled-action 分支测试（review-fix）。

## Scope / 范围

17 files (+604/-98) + 1 review-fix commit。已 rebase 到 `crnd/integrate-1854` 当前 tip，清理先前混入的 stream-topology commit。

## 评审历史

旧 head 上 architect + quality 已 approve，tests reject（缺 disabled-action 分支测试）→ 已补 fix（本 PR 含）。因 rebase 换 head，本轮重跑 3 reviewer 确认。

## 依赖关系

#1853 umbrella channel 层；**#1862 回流消费本 PR 的 typed `action_kind`**。

🤖 controller (consensus-rnd loop) — cleaned + rebased

⟦AI:AUTO-LOOP⟧
