### PR TITLE
feat(#1863): 出站交互 notify primitive — typed notification event chain + Lark boundary

### DIFF
--- a/agents/Aevatar.GAgents.Authoring.Lark/DependencyInjection/AuthoringServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/DependencyInjection/AuthoringServiceCollectionExtensions.cs
@@ -33,6 +33,7 @@ public static class AuthoringServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.Replace(ServiceDescriptor.Singleton<IHumanInteractionPort, FeishuCardHumanInteractionPort>());
+        services.Replace(ServiceDescriptor.Singleton<IChannelInteractionNotificationPort, FeishuCardNotificationPort>());
         services.TryAddSingleton<ScheduledAgentCreatorOptions>();
         services.TryAddSingleton<ScheduledAgentCreateRequestMapper>();
         services.TryAddSingleton<ScheduledAgentApiKeyIssuer>();

--- a/agents/Aevatar.GAgents.Authoring.Lark/FeishuCardHumanInteractionPort.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/FeishuCardHumanInteractionPort.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using System.Text.Json;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.Foundation.Abstractions.HumanInteraction;
 using Aevatar.GAgents.Channel.Abstractions;
@@ -18,9 +17,7 @@ namespace Aevatar.GAgents.Authoring.Lark;
 /// </summary>
 public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
 {
-    private readonly IUserAgentDeliveryTargetReader _deliveryTargetReader;
-    private readonly NyxIdApiClient _nyxIdApiClient;
-    private readonly ILarkOutboundDispatcher? _larkOutboundDispatcher;
+    private readonly FeishuCardOutboundMessageSender _sender;
     private readonly LarkMessageComposer _composer;
     private readonly ILogger<FeishuCardHumanInteractionPort> _logger;
 
@@ -31,11 +28,15 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
         ILogger<FeishuCardHumanInteractionPort> logger,
         ILarkOutboundDispatcher? larkOutboundDispatcher = null)
     {
-        _deliveryTargetReader = deliveryTargetReader ?? throw new ArgumentNullException(nameof(deliveryTargetReader));
-        _nyxIdApiClient = nyxIdApiClient ?? throw new ArgumentNullException(nameof(nyxIdApiClient));
-        _larkOutboundDispatcher = larkOutboundDispatcher;
+        ArgumentNullException.ThrowIfNull(deliveryTargetReader);
+        ArgumentNullException.ThrowIfNull(nyxIdApiClient);
         _composer = composer ?? throw new ArgumentNullException(nameof(composer));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _sender = new FeishuCardOutboundMessageSender(
+            deliveryTargetReader,
+            nyxIdApiClient,
+            logger,
+            larkOutboundDispatcher);
     }
 
     public async Task DeliverSuspensionAsync(
@@ -45,8 +46,11 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        var target = await ResolveTargetAsync(deliveryTargetId, cancellationToken);
-        await SendInteractiveCardMessageAsync(
+        var target = await _sender.ResolveTargetAsync(
+            deliveryTargetId,
+            "human interaction",
+            cancellationToken);
+        await _sender.SendInteractiveCardMessageAsync(
             target,
             BuildCardJson(request, _composer),
             "Feishu human interaction card delivery returned empty response.",
@@ -67,8 +71,11 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
     {
         ArgumentNullException.ThrowIfNull(resolution);
 
-        var target = await ResolveTargetAsync(deliveryTargetId, cancellationToken);
-        await SendTextMessageAsync(
+        var target = await _sender.ResolveTargetAsync(
+            deliveryTargetId,
+            "human interaction",
+            cancellationToken);
+        await _sender.SendTextMessageAsync(
             target,
             BuildApprovalResolutionText(resolution, target),
             "Feishu approval resolution delivery returned empty response.",
@@ -258,159 +265,6 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
     {
         Capabilities = LarkMessageComposer.DefaultCapabilities.Clone(),
     };
-
-    private async Task<UserAgentDeliveryTarget> ResolveTargetAsync(
-        string deliveryTargetId,
-        CancellationToken cancellationToken)
-    {
-        var target = await _deliveryTargetReader.GetAsync(deliveryTargetId, cancellationToken);
-        if (target == null)
-            throw new InvalidOperationException($"Agent delivery target not found: {deliveryTargetId}");
-
-        if (!string.Equals(target.Platform, "lark", StringComparison.OrdinalIgnoreCase))
-            throw new NotSupportedException($"Unsupported human interaction platform: {target.Platform}");
-
-        return target;
-    }
-
-    private async Task SendTextMessageAsync(
-        UserAgentDeliveryTarget target,
-        string text,
-        string emptyResponseMessage,
-        string failurePrefix,
-        CancellationToken cancellationToken) =>
-        await SendMessageAsync(
-            target,
-            "text",
-            JsonSerializer.Serialize(new { text }),
-            emptyResponseMessage,
-            failurePrefix,
-            cancellationToken);
-
-    private async Task SendInteractiveCardMessageAsync(
-        UserAgentDeliveryTarget target,
-        string cardJson,
-        string emptyResponseMessage,
-        string failurePrefix,
-        CancellationToken cancellationToken)
-        => await SendMessageAsync(
-            target,
-            "interactive",
-            cardJson,
-            emptyResponseMessage,
-            failurePrefix,
-            cancellationToken);
-
-    private async Task SendMessageAsync(
-        UserAgentDeliveryTarget target,
-        string messageType,
-        string contentJson,
-        string emptyResponseMessage,
-        string failurePrefix,
-        CancellationToken cancellationToken)
-    {
-        var deliveryTarget = LarkConversationTargets.Resolve(
-            target.LarkReceiveId,
-            target.LarkReceiveIdType,
-            target.ConversationId);
-        if (deliveryTarget.FellBackToPrefixInference)
-        {
-            // Catalog entry predates the typed lark_receive_id fields; fall back to the prefix
-            // heuristic on conversation_id and emit a breadcrumb so format drift is observable.
-            _logger.LogDebug(
-                "Feishu human interaction port resolved Lark receive target by prefix inference (legacy entry): agent={AgentId}, conversationId={ConversationId}, receiveIdType={ReceiveIdType}",
-                target.AgentId,
-                target.ConversationId,
-                deliveryTarget.ReceiveIdType);
-        }
-
-        var outcome = await TrySendWithFallbackAsync(
-            target,
-            messageType,
-            contentJson,
-            deliveryTarget,
-            emptyResponseMessage,
-            cancellationToken);
-
-        if (!outcome.Succeeded)
-        {
-            throw new InvalidOperationException(BuildLarkRejectionMessage(failurePrefix, outcome.LarkCode, outcome.Detail));
-        }
-    }
-
-    /// <summary>
-    /// Sends via the shared Lark new-message dispatcher so proactive human-interaction cards
-    /// keep the same primary, fallback, and parser semantics as SkillRunner output.
-    /// </summary>
-    private async Task<LarkSendNewMessageResult> TrySendWithFallbackAsync(
-        UserAgentDeliveryTarget target,
-        string messageType,
-        string contentJson,
-        LarkReceiveTarget primary,
-        string emptyResponseMessage,
-        CancellationToken cancellationToken)
-    {
-        var result = await ResolveLarkOutboundDispatcher().SendNewMessageAsync(
-            new LarkSendNewMessageRequest(
-                target.NyxApiKey,
-                target.NyxProviderSlug,
-                messageType,
-                contentJson,
-                primary,
-                ResolveFallbackTarget(target)),
-            cancellationToken);
-
-        if (!result.Succeeded && string.IsNullOrWhiteSpace(result.Detail))
-            throw new InvalidOperationException(emptyResponseMessage);
-
-        return result;
-    }
-
-    private static LarkReceiveTarget? ResolveFallbackTarget(UserAgentDeliveryTarget target)
-    {
-        var fallbackId = target.LarkReceiveIdFallback?.Trim();
-        var fallbackType = target.LarkReceiveIdTypeFallback?.Trim();
-        return string.IsNullOrEmpty(fallbackId) || string.IsNullOrEmpty(fallbackType)
-            ? null
-            : new LarkReceiveTarget(fallbackId, fallbackType, FellBackToPrefixInference: false);
-    }
-
-    private ILarkOutboundDispatcher ResolveLarkOutboundDispatcher() =>
-        _larkOutboundDispatcher ?? new LarkOutboundDispatcher(_nyxIdApiClient, _logger);
-
-    private static string BuildLarkRejectionMessage(string failurePrefix, int? larkCode, string detail)
-    {
-        if (larkCode == LarkBotErrorCodes.OpenIdCrossApp)
-        {
-            // Mirrors the SkillRunnerGAgent recovery hint: the workflow agent's catalog target
-            // was captured before union_id ingress existed and the persisted typed pair is
-            // permanently relay-app-scoped. Surface the recreate-the-agent instruction inside
-            // the exception message so it ends up in `/agent-status`'s `last_error` field
-            // instead of the cryptic Lark `99992361 open_id cross app`.
-            return
-                $"{failurePrefix} (code={larkCode}): {detail}. " +
-                "This agent was created before cross-app union_id ingress existed; " +
-                "delete it (`/agents` → Delete) and recreate it to pick up the cross-app safe target.";
-        }
-
-        if (larkCode == LarkBotErrorCodes.UserIdCrossTenant)
-        {
-            // Cross-tenant variant of the open_id case — even union_id fails. Same recovery
-            // shape: recreate the agent so the chat_id-preferred outbound takes effect, or
-            // align the NyxID `s/api-lark-bot` proxy with the channel-bot that received the
-            // inbound event so the apps share a tenant.
-            return
-                $"{failurePrefix} (code={larkCode}): {detail}. " +
-                "The outbound Lark app is in a different tenant than the inbound app, so " +
-                "user-id translation is impossible. Delete the agent (`/agents` → Delete) and recreate " +
-                "it so the new chat_id-preferred outbound path takes effect, or align the NyxID " +
-                "`s/api-lark-bot` proxy with the channel-bot that received the inbound event.";
-        }
-
-        return larkCode is { } code
-            ? $"{failurePrefix} (code={code}): {detail}"
-            : $"{failurePrefix}: {detail}";
-    }
 
     private static bool SupportsApproveReject(HumanInteractionRequest request) =>
         string.Equals(request.SuspensionType, "human_approval", StringComparison.OrdinalIgnoreCase) ||

--- a/agents/Aevatar.GAgents.Authoring.Lark/FeishuCardNotificationPort.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/FeishuCardNotificationPort.cs
@@ -1,0 +1,128 @@
+using System.Text.Json;
+using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.Foundation.Abstractions.HumanInteraction;
+using Aevatar.Foundation.Abstractions.Interactions;
+using Aevatar.GAgents.Channel.Abstractions;
+using Aevatar.GAgents.Platform.Lark;
+using Aevatar.GAgents.Scheduled;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.GAgents.Authoring.Lark;
+
+public sealed class FeishuCardNotificationPort : IChannelInteractionNotificationPort
+{
+    private readonly FeishuCardOutboundMessageSender _sender;
+    private readonly LarkMessageComposer _composer;
+    private readonly ILogger<FeishuCardNotificationPort> _logger;
+
+    public FeishuCardNotificationPort(
+        IUserAgentDeliveryTargetReader deliveryTargetReader,
+        NyxIdApiClient nyxIdApiClient,
+        LarkMessageComposer composer,
+        ILogger<FeishuCardNotificationPort> logger,
+        ILarkOutboundDispatcher? larkOutboundDispatcher = null)
+    {
+        ArgumentNullException.ThrowIfNull(deliveryTargetReader);
+        ArgumentNullException.ThrowIfNull(nyxIdApiClient);
+        _composer = composer ?? throw new ArgumentNullException(nameof(composer));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _sender = new FeishuCardOutboundMessageSender(
+            deliveryTargetReader,
+            nyxIdApiClient,
+            logger,
+            larkOutboundDispatcher);
+    }
+
+    public async Task DeliverAsync(
+        ChannelInteractionNotificationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        ValidatePayload(request);
+        var target = await _sender.ResolveTargetAsync(
+            request.DeliveryTargetId,
+            "interaction notification",
+            cancellationToken);
+
+        await _sender.SendInteractiveCardMessageAsync(
+            target,
+            BuildCardJson(request, _composer),
+            "Feishu interaction notification delivery returned empty response.",
+            "Feishu interaction notification delivery failed",
+            cancellationToken);
+
+        _logger.LogInformation(
+            "Delivered interaction notification card: target={DeliveryTargetId}, run={RunId}, step={StepId}",
+            request.DeliveryTargetId,
+            request.RunId,
+            request.StepId);
+    }
+
+    internal static string BuildCardJson(ChannelInteractionNotificationRequest request) =>
+        BuildCardJson(request, new LarkMessageComposer());
+
+    internal static string BuildCardJson(
+        ChannelInteractionNotificationRequest request,
+        LarkMessageComposer composer)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(composer);
+
+        if (request.InteractionSpec is { } interactionSpec)
+            return BuildInteractionCardJson(interactionSpec, composer);
+
+        if (request.InteractionTemplateSpec is { } templateSpec)
+            return BuildTemplateCardJson(templateSpec);
+
+        throw new InvalidOperationException("Interaction notification payload is required.");
+    }
+
+    private static string BuildInteractionCardJson(
+        InteractionSpec interactionSpec,
+        LarkMessageComposer composer)
+    {
+        var content = InteractionSpecMapper.ToMessageContent(interactionSpec);
+        var payload = composer.Compose(content, BuildComposeContext());
+        if (!payload.IsInteractive)
+            throw new InvalidOperationException("Interaction notification must render as an interactive Lark card.");
+
+        return payload.ContentJson;
+    }
+
+    private static string BuildTemplateCardJson(InteractionTemplateSpec templateSpec)
+    {
+        if (string.IsNullOrWhiteSpace(templateSpec.TemplateId))
+            throw new InvalidOperationException("Interaction template notification requires template_id.");
+
+        return JsonSerializer.Serialize(new
+        {
+            type = "template",
+            data = new
+            {
+                template_id = templateSpec.TemplateId,
+                template_variable = templateSpec.TemplateVariable.ToDictionary(
+                    pair => pair.Key,
+                    pair => pair.Value,
+                    StringComparer.Ordinal),
+            },
+        });
+    }
+
+    private static ComposeContext BuildComposeContext() => new()
+    {
+        Capabilities = LarkMessageComposer.DefaultCapabilities.Clone(),
+    };
+
+    private static void ValidatePayload(ChannelInteractionNotificationRequest request)
+    {
+        var payloadCount = 0;
+        if (request.InteractionSpec is not null)
+            payloadCount++;
+        if (request.InteractionTemplateSpec is not null)
+            payloadCount++;
+
+        if (payloadCount != 1)
+            throw new InvalidOperationException("Interaction notification requires exactly one typed payload.");
+    }
+}

--- a/agents/Aevatar.GAgents.Authoring.Lark/FeishuCardOutboundMessageSender.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/FeishuCardOutboundMessageSender.cs
@@ -1,0 +1,164 @@
+using System.Text.Json;
+using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.GAgents.Platform.Lark;
+using Aevatar.GAgents.Scheduled;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.GAgents.Authoring.Lark;
+
+internal sealed class FeishuCardOutboundMessageSender
+{
+    private readonly IUserAgentDeliveryTargetReader _deliveryTargetReader;
+    private readonly NyxIdApiClient _nyxIdApiClient;
+    private readonly ILarkOutboundDispatcher? _larkOutboundDispatcher;
+    private readonly ILogger _logger;
+
+    public FeishuCardOutboundMessageSender(
+        IUserAgentDeliveryTargetReader deliveryTargetReader,
+        NyxIdApiClient nyxIdApiClient,
+        ILogger logger,
+        ILarkOutboundDispatcher? larkOutboundDispatcher = null)
+    {
+        _deliveryTargetReader = deliveryTargetReader ?? throw new ArgumentNullException(nameof(deliveryTargetReader));
+        _nyxIdApiClient = nyxIdApiClient ?? throw new ArgumentNullException(nameof(nyxIdApiClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _larkOutboundDispatcher = larkOutboundDispatcher;
+    }
+
+    public async Task<UserAgentDeliveryTarget> ResolveTargetAsync(
+        string deliveryTargetId,
+        string platformSubject,
+        CancellationToken cancellationToken)
+    {
+        var target = await _deliveryTargetReader.GetAsync(deliveryTargetId, cancellationToken);
+        if (target == null)
+            throw new InvalidOperationException($"Agent delivery target not found: {deliveryTargetId}");
+
+        if (!string.Equals(target.Platform, "lark", StringComparison.OrdinalIgnoreCase))
+            throw new NotSupportedException($"Unsupported {platformSubject} platform: {target.Platform}");
+
+        return target;
+    }
+
+    public async Task SendTextMessageAsync(
+        UserAgentDeliveryTarget target,
+        string text,
+        string emptyResponseMessage,
+        string failurePrefix,
+        CancellationToken cancellationToken) =>
+        await SendMessageAsync(
+            target,
+            "text",
+            JsonSerializer.Serialize(new { text }),
+            emptyResponseMessage,
+            failurePrefix,
+            cancellationToken);
+
+    public async Task SendInteractiveCardMessageAsync(
+        UserAgentDeliveryTarget target,
+        string cardJson,
+        string emptyResponseMessage,
+        string failurePrefix,
+        CancellationToken cancellationToken)
+        => await SendMessageAsync(
+            target,
+            "interactive",
+            cardJson,
+            emptyResponseMessage,
+            failurePrefix,
+            cancellationToken);
+
+    private async Task SendMessageAsync(
+        UserAgentDeliveryTarget target,
+        string messageType,
+        string contentJson,
+        string emptyResponseMessage,
+        string failurePrefix,
+        CancellationToken cancellationToken)
+    {
+        var deliveryTarget = LarkConversationTargets.Resolve(
+            target.LarkReceiveId,
+            target.LarkReceiveIdType,
+            target.ConversationId);
+        if (deliveryTarget.FellBackToPrefixInference)
+        {
+            _logger.LogDebug(
+                "Feishu card outbound sender resolved Lark receive target by prefix inference (legacy entry): agent={AgentId}, conversationId={ConversationId}, receiveIdType={ReceiveIdType}",
+                target.AgentId,
+                target.ConversationId,
+                deliveryTarget.ReceiveIdType);
+        }
+
+        var outcome = await TrySendWithFallbackAsync(
+            target,
+            messageType,
+            contentJson,
+            deliveryTarget,
+            emptyResponseMessage,
+            cancellationToken);
+
+        if (!outcome.Succeeded)
+            throw new InvalidOperationException(BuildLarkRejectionMessage(failurePrefix, outcome.LarkCode, outcome.Detail));
+    }
+
+    private async Task<LarkSendNewMessageResult> TrySendWithFallbackAsync(
+        UserAgentDeliveryTarget target,
+        string messageType,
+        string contentJson,
+        LarkReceiveTarget primary,
+        string emptyResponseMessage,
+        CancellationToken cancellationToken)
+    {
+        var result = await ResolveLarkOutboundDispatcher().SendNewMessageAsync(
+            new LarkSendNewMessageRequest(
+                target.NyxApiKey,
+                target.NyxProviderSlug,
+                messageType,
+                contentJson,
+                primary,
+                ResolveFallbackTarget(target)),
+            cancellationToken);
+
+        if (!result.Succeeded && string.IsNullOrWhiteSpace(result.Detail))
+            throw new InvalidOperationException(emptyResponseMessage);
+
+        return result;
+    }
+
+    private static LarkReceiveTarget? ResolveFallbackTarget(UserAgentDeliveryTarget target)
+    {
+        var fallbackId = target.LarkReceiveIdFallback?.Trim();
+        var fallbackType = target.LarkReceiveIdTypeFallback?.Trim();
+        return string.IsNullOrEmpty(fallbackId) || string.IsNullOrEmpty(fallbackType)
+            ? null
+            : new LarkReceiveTarget(fallbackId, fallbackType, FellBackToPrefixInference: false);
+    }
+
+    private ILarkOutboundDispatcher ResolveLarkOutboundDispatcher() =>
+        _larkOutboundDispatcher ?? new LarkOutboundDispatcher(_nyxIdApiClient, _logger);
+
+    private static string BuildLarkRejectionMessage(string failurePrefix, int? larkCode, string detail)
+    {
+        if (larkCode == LarkBotErrorCodes.OpenIdCrossApp)
+        {
+            return
+                $"{failurePrefix} (code={larkCode}): {detail}. " +
+                "This agent was created before cross-app union_id ingress existed; " +
+                "delete it (`/agents` → Delete) and recreate it to pick up the cross-app safe target.";
+        }
+
+        if (larkCode == LarkBotErrorCodes.UserIdCrossTenant)
+        {
+            return
+                $"{failurePrefix} (code={larkCode}): {detail}. " +
+                "The outbound Lark app is in a different tenant than the inbound app, so " +
+                "user-id translation is impossible. Delete the agent (`/agents` → Delete) and recreate " +
+                "it so the new chat_id-preferred outbound path takes effect, or align the NyxID " +
+                "`s/api-lark-bot` proxy with the channel-bot that received the inbound event.";
+        }
+
+        return larkCode is { } code
+            ? $"{failurePrefix} (code={code}): {detail}"
+            : $"{failurePrefix}: {detail}";
+    }
+}

--- a/src/Aevatar.Foundation.Abstractions/HumanInteraction/ChannelInteractionNotificationRequest.cs
+++ b/src/Aevatar.Foundation.Abstractions/HumanInteraction/ChannelInteractionNotificationRequest.cs
@@ -15,6 +15,4 @@ public sealed record ChannelInteractionNotificationRequest
     public InteractionSpec? InteractionSpec { get; init; }
 
     public InteractionTemplateSpec? InteractionTemplateSpec { get; init; }
-
-    public IReadOnlyDictionary<string, string> Annotations { get; init; } = new Dictionary<string, string>();
 }

--- a/src/Aevatar.Foundation.Abstractions/HumanInteraction/ChannelInteractionNotificationRequest.cs
+++ b/src/Aevatar.Foundation.Abstractions/HumanInteraction/ChannelInteractionNotificationRequest.cs
@@ -1,0 +1,20 @@
+using Aevatar.Foundation.Abstractions.Interactions;
+
+namespace Aevatar.Foundation.Abstractions.HumanInteraction;
+
+public sealed record ChannelInteractionNotificationRequest
+{
+    public required string ActorId { get; init; }
+
+    public required string RunId { get; init; }
+
+    public required string StepId { get; init; }
+
+    public required string DeliveryTargetId { get; init; }
+
+    public InteractionSpec? InteractionSpec { get; init; }
+
+    public InteractionTemplateSpec? InteractionTemplateSpec { get; init; }
+
+    public IReadOnlyDictionary<string, string> Annotations { get; init; } = new Dictionary<string, string>();
+}

--- a/src/Aevatar.Foundation.Abstractions/HumanInteraction/IChannelInteractionNotificationPort.cs
+++ b/src/Aevatar.Foundation.Abstractions/HumanInteraction/IChannelInteractionNotificationPort.cs
@@ -1,0 +1,8 @@
+namespace Aevatar.Foundation.Abstractions.HumanInteraction;
+
+public interface IChannelInteractionNotificationPort
+{
+    Task DeliverAsync(
+        ChannelInteractionNotificationRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Aevatar.Foundation.Abstractions/Interactions/interaction_spec.proto
+++ b/src/Aevatar.Foundation.Abstractions/Interactions/interaction_spec.proto
@@ -75,3 +75,8 @@ message InteractionSpec {
   repeated InteractionCard cards = 5;
   InteractionDisposition disposition = 6;
 }
+
+message InteractionTemplateSpec {
+  string template_id = 1;
+  map<string, string> template_variable = 2;
+}

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -133,6 +133,16 @@ message WorkflowExecutionStateClearedEvent  { string scope_key = 1; }
 message WorkflowStoppedEvent { string workflow_name = 1; string run_id = 2; string reason = 3; }
 message WorkflowCompletedEvent { string workflow_name = 1; bool success = 2; string output = 3; string error = 4; string run_id = 5; }
 
+message WorkflowInteractionNotificationEvent {
+  string run_id = 1;
+  string step_id = 2;
+  string delivery_target_id = 3;
+  oneof payload {
+    aevatar.foundation.interactions.InteractionSpec interaction = 4;
+    aevatar.foundation.interactions.InteractionTemplateSpec interaction_template = 5;
+  }
+}
+
 enum AgreementRuleMode {
   AGREEMENT_RULE_MODE_UNSPECIFIED = 0;
   AGREEMENT_RULE_MODE_ALL = 1;
@@ -222,6 +232,7 @@ message WorkflowStepParameters
   VoteAgreementCandidateSet vote_agreement_candidates = 2;
   VoteAgreementRule vote_agreement_rule = 3;
   aevatar.foundation.interactions.InteractionSpec interaction_spec = 4;
+  aevatar.foundation.interactions.InteractionTemplateSpec interaction_template_spec = 5;
 }
 message StepRequestEvent
 {

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -233,6 +233,7 @@ message WorkflowStepParameters
   VoteAgreementRule vote_agreement_rule = 3;
   aevatar.foundation.interactions.InteractionSpec interaction_spec = 4;
   aevatar.foundation.interactions.InteractionTemplateSpec interaction_template_spec = 5;
+  string delivery_target_id = 6;
 }
 message StepRequestEvent
 {

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
@@ -1176,8 +1176,21 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
         StepPresentation? presentation,
         WorkflowExecutionKernelState state)
     {
+        ApplyDeliveryTargetId(request, presentation, state);
         ApplyInteractionSpec(request, presentation, state);
         ApplyInteractionTemplateSpec(request, presentation, state);
+    }
+
+    private void ApplyDeliveryTargetId(
+        StepRequestEvent request,
+        StepPresentation? presentation,
+        WorkflowExecutionKernelState state)
+    {
+        if (string.IsNullOrWhiteSpace(presentation?.DeliveryTargetId))
+            return;
+
+        (request.StepParameters ??= new WorkflowStepParameters()).DeliveryTargetId =
+            _expressionEvaluator.Evaluate(presentation.DeliveryTargetId.Trim(), state.Variables);
     }
 
     private void ApplyInteractionSpec(

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
@@ -1166,9 +1166,18 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                 request.Parameters["allowed_connectors"] = string.Join(",", role.Connectors);
         }
 
-        ApplyInteractionSpec(request, step.Presentation, state);
+        ApplyInteractionPresentation(request, step.Presentation, state);
 
         return request;
+    }
+
+    private void ApplyInteractionPresentation(
+        StepRequestEvent request,
+        StepPresentation? presentation,
+        WorkflowExecutionKernelState state)
+    {
+        ApplyInteractionSpec(request, presentation, state);
+        ApplyInteractionTemplateSpec(request, presentation, state);
     }
 
     private void ApplyInteractionSpec(
@@ -1186,6 +1195,28 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
         EvaluateFields(spec.Fields, state);
         EvaluateCards(spec.Cards, state);
         (request.StepParameters ??= new WorkflowStepParameters()).InteractionSpec = spec;
+    }
+
+    private void ApplyInteractionTemplateSpec(
+        StepRequestEvent request,
+        StepPresentation? presentation,
+        WorkflowExecutionKernelState state)
+    {
+        if (!StepPresentation.HasInteractionTemplateSpec(presentation?.InteractionTemplateSpec))
+            return;
+
+        var spec = presentation!.InteractionTemplateSpec!.Clone();
+        spec.TemplateId = _expressionEvaluator.Evaluate(spec.TemplateId, state.Variables);
+        var evaluatedVariables = spec.TemplateVariable
+            .Select(pair => new KeyValuePair<string, string>(
+                pair.Key,
+                _expressionEvaluator.Evaluate(pair.Value, state.Variables)))
+            .ToArray();
+        spec.TemplateVariable.Clear();
+        foreach (var (key, value) in evaluatedVariables)
+            spec.TemplateVariable[key] = value;
+
+        (request.StepParameters ??= new WorkflowStepParameters()).InteractionTemplateSpec = spec;
     }
 
     private void EvaluateActions(

--- a/src/workflow/Aevatar.Workflow.Core/Modules/NotifyModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/NotifyModule.cs
@@ -1,0 +1,149 @@
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.EventModules;
+using Aevatar.Foundation.Core;
+using Aevatar.Workflow.Core.Primitives;
+
+namespace Aevatar.Workflow.Core.Modules;
+
+public sealed class NotifyModule : IEventModule<IWorkflowExecutionContext>
+{
+    private const string AcceptedOutput = "accepted";
+
+    public string Name => "notify";
+
+    public int Priority => 5;
+
+    public bool CanHandle(EventEnvelope envelope) =>
+        envelope.Payload?.Is(StepRequestEvent.Descriptor) == true;
+
+    public async Task HandleAsync(
+        EventEnvelope envelope,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(envelope);
+        ArgumentNullException.ThrowIfNull(ctx);
+
+        var request = envelope.Payload!.Unpack<StepRequestEvent>();
+        if (!string.Equals(request.StepType, "notify", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        var deliveryTargetId = ResolveDeliveryTargetId(request);
+        var validationError = Validate(request, deliveryTargetId);
+        if (validationError is not null)
+        {
+            await PublishFailureAsync(request, validationError, ctx, ct);
+            return;
+        }
+
+        await ctx.PublishAsync(
+            BuildNotificationEvent(request, deliveryTargetId!),
+            TopologyAudience.ParentAndChildren,
+            ct);
+
+        var completed = new StepCompletedEvent
+        {
+            StepId = request.StepId,
+            RunId = request.RunId,
+            Success = true,
+            Output = AcceptedOutput,
+            ExecutionId = request.ExecutionId,
+        };
+        completed.Annotations["notification_status"] = AcceptedOutput;
+
+        await ctx.PublishAsync(completed, TopologyAudience.Self, ct);
+    }
+
+    private static string? ResolveDeliveryTargetId(StepRequestEvent request)
+    {
+        if (request.Parameters.TryGetValue("delivery_target_id", out var deliveryTargetId))
+            return Normalize(deliveryTargetId);
+
+        if (request.Parameters.TryGetValue("deliveryTargetId", out deliveryTargetId))
+            return Normalize(deliveryTargetId);
+
+        return null;
+    }
+
+    private static string? Validate(StepRequestEvent request, string? deliveryTargetId)
+    {
+        if (string.IsNullOrWhiteSpace(deliveryTargetId))
+            return "notify requires explicit delivery_target_id.";
+
+        var payloadCount = ResolvePayloadCount(request);
+        return payloadCount switch
+        {
+            0 => "notify requires exactly one typed interaction payload.",
+            1 => null,
+            _ => "notify requires exactly one typed interaction payload; interaction_spec and interaction_template_spec are mutually exclusive.",
+        };
+    }
+
+    private static int ResolvePayloadCount(StepRequestEvent request)
+    {
+        var count = 0;
+        if (request.StepParameters?.InteractionSpec is { } interaction &&
+            StepPresentation.HasInteractionSpec(interaction))
+        {
+            count++;
+        }
+
+        if (request.StepParameters?.InteractionTemplateSpec is { } template &&
+            StepPresentation.HasInteractionTemplateSpec(template))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private static WorkflowInteractionNotificationEvent BuildNotificationEvent(
+        StepRequestEvent request,
+        string deliveryTargetId)
+    {
+        var notification = new WorkflowInteractionNotificationEvent
+        {
+            RunId = request.RunId,
+            StepId = request.StepId,
+            DeliveryTargetId = deliveryTargetId,
+        };
+
+        if (request.StepParameters?.InteractionSpec is { } interaction &&
+            StepPresentation.HasInteractionSpec(interaction))
+        {
+            notification.Interaction = interaction.Clone();
+        }
+        else if (request.StepParameters?.InteractionTemplateSpec is { } template &&
+                 StepPresentation.HasInteractionTemplateSpec(template))
+        {
+            notification.InteractionTemplate = template.Clone();
+        }
+
+        return notification;
+    }
+
+    private static async Task PublishFailureAsync(
+        StepRequestEvent request,
+        string error,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        await ctx.PublishAsync(
+            new StepCompletedEvent
+            {
+                StepId = request.StepId,
+                RunId = request.RunId,
+                Success = false,
+                Error = error,
+                ExecutionId = request.ExecutionId,
+            },
+            TopologyAudience.Self,
+            ct);
+    }
+
+    private static string? Normalize(string? value)
+    {
+        var normalized = value?.Trim();
+        return string.IsNullOrEmpty(normalized) ? null : normalized;
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Core/Modules/NotifyModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/NotifyModule.cs
@@ -56,13 +56,7 @@ public sealed class NotifyModule : IEventModule<IWorkflowExecutionContext>
 
     private static string? ResolveDeliveryTargetId(StepRequestEvent request)
     {
-        if (request.Parameters.TryGetValue("delivery_target_id", out var deliveryTargetId))
-            return Normalize(deliveryTargetId);
-
-        if (request.Parameters.TryGetValue("deliveryTargetId", out deliveryTargetId))
-            return Normalize(deliveryTargetId);
-
-        return null;
+        return Normalize(request.StepParameters?.DeliveryTargetId);
     }
 
     private static string? Validate(StepRequestEvent request, string? deliveryTargetId)

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/StepPresentation.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/StepPresentation.cs
@@ -6,6 +6,8 @@ public sealed class StepPresentation
 {
     public InteractionSpec? InteractionSpec { get; init; }
 
+    public InteractionTemplateSpec? InteractionTemplateSpec { get; init; }
+
     public static bool HasInteractionSpec(InteractionSpec? spec) =>
         spec is not null &&
         (!string.IsNullOrWhiteSpace(spec.Title) ||
@@ -14,4 +16,14 @@ public sealed class StepPresentation
          spec.Fields.Count > 0 ||
          spec.Cards.Count > 0 ||
          spec.Disposition != InteractionDisposition.Unspecified);
+
+    public static bool HasInteractionTemplateSpec(InteractionTemplateSpec? spec) =>
+        spec is not null &&
+        (!string.IsNullOrWhiteSpace(spec.TemplateId) ||
+         spec.TemplateVariable.Count > 0);
+
+    public static bool HasPresentation(StepPresentation? presentation) =>
+        presentation is not null &&
+        (HasInteractionSpec(presentation.InteractionSpec) ||
+         HasInteractionTemplateSpec(presentation.InteractionTemplateSpec));
 }

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/StepPresentation.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/StepPresentation.cs
@@ -8,6 +8,8 @@ public sealed class StepPresentation
 
     public InteractionTemplateSpec? InteractionTemplateSpec { get; init; }
 
+    public string? DeliveryTargetId { get; init; }
+
     public static bool HasInteractionSpec(InteractionSpec? spec) =>
         spec is not null &&
         (!string.IsNullOrWhiteSpace(spec.Title) ||
@@ -25,5 +27,6 @@ public sealed class StepPresentation
     public static bool HasPresentation(StepPresentation? presentation) =>
         presentation is not null &&
         (HasInteractionSpec(presentation.InteractionSpec) ||
-         HasInteractionTemplateSpec(presentation.InteractionTemplateSpec));
+         HasInteractionTemplateSpec(presentation.InteractionTemplateSpec) ||
+         !string.IsNullOrWhiteSpace(presentation.DeliveryTargetId));
 }

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowParser.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowParser.cs
@@ -147,7 +147,7 @@ public sealed class WorkflowParser
         var rawParameters = s.Parameters is null
             ? null
             : new Dictionary<string, object?>(s.Parameters, StringComparer.Ordinal);
-        var presentation = MapPresentation(s, rawParameters);
+        var presentation = MapPresentation(canonicalType, s, rawParameters);
         var parameters = NormalizeParameters(rawParameters);
 
         ApplyErgonomicDefaults(normalizedRawType, parameters);
@@ -170,15 +170,20 @@ public sealed class WorkflowParser
     }
 
     private static StepPresentation? MapPresentation(
+        string canonicalStepType,
         RawStep step,
         IDictionary<string, object?>? rawParameters)
     {
         var interactionSpec = MapInteractionSpec(ResolveInteractionSpecSource(step, rawParameters));
         var interactionTemplateSpec = MapInteractionTemplateSpec(ResolveInteractionTemplateSpecSource(step, rawParameters));
+        var deliveryTargetId = string.Equals(canonicalStepType, "notify", StringComparison.Ordinal)
+            ? ResolveDeliveryTargetId(step, rawParameters)
+            : null;
         var presentation = new StepPresentation
         {
             InteractionSpec = interactionSpec,
             InteractionTemplateSpec = interactionTemplateSpec,
+            DeliveryTargetId = deliveryTargetId,
         };
         return StepPresentation.HasPresentation(presentation)
             ? presentation
@@ -236,6 +241,24 @@ public sealed class WorkflowParser
         }
 
         return null;
+    }
+
+    private static string? ResolveDeliveryTargetId(
+        RawStep step,
+        IDictionary<string, object?>? rawParameters)
+    {
+        if (!string.IsNullOrWhiteSpace(step.DeliveryTargetId))
+            return step.DeliveryTargetId.Trim();
+
+        if (rawParameters is null)
+            return null;
+
+        if (!rawParameters.TryGetValue("delivery_target_id", out var source))
+            return null;
+
+        rawParameters.Remove("delivery_target_id");
+        var deliveryTargetId = ConvertValueToString(source).Trim();
+        return string.IsNullOrWhiteSpace(deliveryTargetId) ? null : deliveryTargetId;
     }
 
     private static InteractionSpec? MapInteractionSpec(object? source)
@@ -1028,6 +1051,7 @@ public sealed class WorkflowParser
         public string? HolderTokenVariable { get; set; }
         public object? InteractionSpec { get; set; }
         public object? InteractionTemplateSpec { get; set; }
+        public string? DeliveryTargetId { get; set; }
         public RawStepPresentation? Presentation { get; set; }
         public Dictionary<string, object?>? Parameters { get; set; }
         public string? Next { get; set; }

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowParser.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowParser.cs
@@ -173,10 +173,15 @@ public sealed class WorkflowParser
         RawStep step,
         IDictionary<string, object?>? rawParameters)
     {
-        var source = ResolveInteractionSpecSource(step, rawParameters);
-        var interactionSpec = MapInteractionSpec(source);
-        return StepPresentation.HasInteractionSpec(interactionSpec)
-            ? new StepPresentation { InteractionSpec = interactionSpec }
+        var interactionSpec = MapInteractionSpec(ResolveInteractionSpecSource(step, rawParameters));
+        var interactionTemplateSpec = MapInteractionTemplateSpec(ResolveInteractionTemplateSpecSource(step, rawParameters));
+        var presentation = new StepPresentation
+        {
+            InteractionSpec = interactionSpec,
+            InteractionTemplateSpec = interactionTemplateSpec,
+        };
+        return StepPresentation.HasPresentation(presentation)
+            ? presentation
             : null;
     }
 
@@ -197,6 +202,31 @@ public sealed class WorkflowParser
             return null;
 
         foreach (var key in new[] { "interaction_spec", "interactionSpec" })
+        {
+            if (!rawParameters.TryGetValue(key, out var source))
+                continue;
+
+            rawParameters.Remove(key);
+            return source;
+        }
+
+        return null;
+    }
+
+    private static object? ResolveInteractionTemplateSpecSource(
+        RawStep step,
+        IDictionary<string, object?>? rawParameters)
+    {
+        if (step.InteractionTemplateSpec is not null)
+            return step.InteractionTemplateSpec;
+
+        if (step.Presentation?.InteractionTemplateSpec is not null)
+            return step.Presentation.InteractionTemplateSpec;
+
+        if (rawParameters is null)
+            return null;
+
+        foreach (var key in new[] { "interaction_template_spec", "interactionTemplateSpec" })
         {
             if (!rawParameters.TryGetValue(key, out var source))
                 continue;
@@ -272,6 +302,96 @@ public sealed class WorkflowParser
             spec.Cards.Add(card);
 
         return StepPresentation.HasInteractionSpec(spec) ? spec : null;
+    }
+
+    private static InteractionTemplateSpec? MapInteractionTemplateSpec(object? source)
+    {
+        if (source is null)
+            return null;
+
+        if (source is InteractionTemplateSpec spec)
+            return spec.Clone();
+
+        if (source is string text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+                return null;
+
+            using var document = JsonDocument.Parse(text);
+            return MapInteractionTemplateSpec(document.RootElement);
+        }
+
+        if (source is JsonElement element)
+        {
+            if (element.ValueKind != JsonValueKind.Object)
+                return null;
+
+            return MapInteractionTemplateSpecFromAccessor(
+                key => TryReadJsonProperty(element, KeyCandidates(key)));
+        }
+
+        if (source is IDictionary mapping)
+            return MapInteractionTemplateSpecFromAccessor(
+                key => TryReadMappingObject(mapping, KeyCandidates(key)));
+
+        return null;
+    }
+
+    private static InteractionTemplateSpec? MapInteractionTemplateSpecFromAccessor(Func<string, object?> read)
+    {
+        var spec = new InteractionTemplateSpec
+        {
+            TemplateId = ConvertValueToString(read("template_id")).Trim(),
+        };
+
+        foreach (var (key, value) in MapStringMap(read("template_variable")))
+            spec.TemplateVariable[key] = value;
+
+        return StepPresentation.HasInteractionTemplateSpec(spec) ? spec : null;
+    }
+
+    private static IEnumerable<KeyValuePair<string, string>> MapStringMap(object? source)
+    {
+        if (source is null)
+            yield break;
+
+        if (source is string text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+                yield break;
+
+            using var document = JsonDocument.Parse(text);
+            foreach (var item in MapStringMap(document.RootElement.Clone()))
+                yield return item;
+            yield break;
+        }
+
+        if (source is JsonElement element)
+        {
+            if (element.ValueKind != JsonValueKind.Object)
+                yield break;
+
+            foreach (var property in element.EnumerateObject())
+            {
+                var key = property.Name.Trim();
+                var value = ConvertValueToString(property.Value).Trim();
+                if (!string.IsNullOrWhiteSpace(key))
+                    yield return new KeyValuePair<string, string>(key, value);
+            }
+
+            yield break;
+        }
+
+        if (source is IDictionary mapping)
+        {
+            foreach (DictionaryEntry entry in mapping)
+            {
+                var key = ConvertValueToString(entry.Key).Trim();
+                var value = ConvertValueToString(entry.Value).Trim();
+                if (!string.IsNullOrWhiteSpace(key))
+                    yield return new KeyValuePair<string, string>(key, value);
+            }
+        }
     }
 
     private static IEnumerable<InteractionAction> MapActions(object? source)
@@ -514,6 +634,8 @@ public sealed class WorkflowParser
             "image_url" => ["image_url", "imageUrl"],
             "is_short" => ["is_short", "isShort", "short"],
             "is_disabled" => ["is_disabled", "isDisabled"],
+            "template_id" => ["template_id", "templateId"],
+            "template_variable" => ["template_variable", "templateVariable", "template_variables", "templateVariables", "variables"],
             _ => [key],
         };
 
@@ -905,6 +1027,7 @@ public sealed class WorkflowParser
         public object? Generation { get; set; }
         public string? HolderTokenVariable { get; set; }
         public object? InteractionSpec { get; set; }
+        public object? InteractionTemplateSpec { get; set; }
         public RawStepPresentation? Presentation { get; set; }
         public Dictionary<string, object?>? Parameters { get; set; }
         public string? Next { get; set; }
@@ -917,6 +1040,7 @@ public sealed class WorkflowParser
     private sealed class RawStepPresentation
     {
         public object? InteractionSpec { get; set; }
+        public object? InteractionTemplateSpec { get; set; }
         public string? Title { get; set; }
         public string? Body { get; set; }
         public object? Actions { get; set; }

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowPrimitiveCatalog.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowPrimitiveCatalog.cs
@@ -53,6 +53,7 @@ public static class WorkflowPrimitiveCatalog
         "evaluate", "reflect", "human_input", "secure_input",
         "human_approval", "wait_signal", "emit", "parallel", "race",
         "map_reduce", "vote", "foreach", "dynamic_workflow", "lease",
+        "notify",
     ];
 
     public static IReadOnlySet<string> BuiltInCanonicalTypes { get; } = DeriveBuiltInCanonicalTypes();

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowCoreModulePack.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowCoreModulePack.cs
@@ -29,6 +29,7 @@ public sealed class WorkflowCoreModulePack : IWorkflowModulePack
         WorkflowModuleRegistration.Create<ReflectModule>("reflect"),
         WorkflowModuleRegistration.Create<DelayModule>("delay", "sleep"),
         WorkflowModuleRegistration.Create<EmitModule>("emit", "publish"),
+        WorkflowModuleRegistration.Create<NotifyModule>("notify"),
         WorkflowModuleRegistration.Create<ActorSendModule>("actor_send"),
         WorkflowModuleRegistration.Create<CacheModule>("cache"),
         WorkflowModuleRegistration.Create<HumanApprovalModule>("human_approval"),

--- a/src/workflow/Aevatar.Workflow.Infrastructure/DependencyInjection/WorkflowCapabilityServiceCollectionExtensions.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/DependencyInjection/WorkflowCapabilityServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ public static class WorkflowCapabilityServiceCollectionExtensions
             configuration.GetSection("WorkflowExecutionProjection").Bind(options));
         services.AddWorkflowExecutionAGUIAdapter();
         services.TryAddSingleton<IHumanInteractionPort, NullHumanInteractionPort>();
+        services.TryAddSingleton<IChannelInteractionNotificationPort, NullChannelInteractionNotificationPort>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IProjectionProjector<WorkflowExecutionProjectionContext>,
             WorkflowExecutionRunEventProjector>());
@@ -37,6 +38,9 @@ public static class WorkflowCapabilityServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IProjectionProjector<WorkflowExecutionProjectionContext>,
             WorkflowHumanApprovalResolutionProjector>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            IProjectionProjector<WorkflowExecutionProjectionContext>,
+            WorkflowInteractionNotificationProjector>());
         services.AddWorkflowApplication();
         services.AddWorkflowScheduleExtensions();
         services.AddWorkflowDefinitionFileSource(options =>

--- a/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/NullChannelInteractionNotificationPort.cs
+++ b/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/NullChannelInteractionNotificationPort.cs
@@ -1,0 +1,11 @@
+using Aevatar.Foundation.Abstractions.HumanInteraction;
+
+namespace Aevatar.Workflow.Presentation.AGUIAdapter;
+
+public sealed class NullChannelInteractionNotificationPort : IChannelInteractionNotificationPort
+{
+    public Task DeliverAsync(
+        ChannelInteractionNotificationRequest request,
+        CancellationToken cancellationToken = default) =>
+        Task.CompletedTask;
+}

--- a/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/WorkflowInteractionNotificationProjector.cs
+++ b/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/WorkflowInteractionNotificationProjector.cs
@@ -1,0 +1,54 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.HumanInteraction;
+using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Projection;
+
+namespace Aevatar.Workflow.Presentation.AGUIAdapter;
+
+public sealed class WorkflowInteractionNotificationProjector
+    : IProjectionProjector<WorkflowExecutionProjectionContext>
+{
+    private readonly IChannelInteractionNotificationPort _notificationPort;
+
+    public WorkflowInteractionNotificationProjector(IChannelInteractionNotificationPort notificationPort)
+    {
+        _notificationPort = notificationPort ?? throw new ArgumentNullException(nameof(notificationPort));
+    }
+
+    public async ValueTask ProjectAsync(
+        WorkflowExecutionProjectionContext context,
+        EventEnvelope envelope,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(envelope);
+
+        if (!ProjectionDispatchRouteFilter.ShouldDispatch(envelope))
+            return;
+
+        if (envelope.Payload?.Is(WorkflowInteractionNotificationEvent.Descriptor) != true)
+            return;
+
+        var evt = envelope.Payload.Unpack<WorkflowInteractionNotificationEvent>();
+        if (string.IsNullOrWhiteSpace(evt.DeliveryTargetId))
+            return;
+
+        await _notificationPort.DeliverAsync(
+            new ChannelInteractionNotificationRequest
+            {
+                ActorId = context.RootActorId,
+                RunId = evt.RunId,
+                StepId = evt.StepId,
+                DeliveryTargetId = evt.DeliveryTargetId,
+                InteractionSpec = evt.PayloadCase == WorkflowInteractionNotificationEvent.PayloadOneofCase.Interaction
+                    ? evt.Interaction
+                    : null,
+                InteractionTemplateSpec = evt.PayloadCase == WorkflowInteractionNotificationEvent.PayloadOneofCase.InteractionTemplate
+                    ? evt.InteractionTemplate
+                    : null,
+            },
+            ct);
+    }
+}

--- a/test/Aevatar.Foundation.Abstractions.Tests/FoundationAbstractionsProtoCoverageTests.cs
+++ b/test/Aevatar.Foundation.Abstractions.Tests/FoundationAbstractionsProtoCoverageTests.cs
@@ -178,6 +178,25 @@ public class FoundationAbstractionsProtoCoverageTests
     }
 
     [Fact]
+    public void InteractionTemplateSpec_ShouldRoundtripTypedContract()
+    {
+        var spec = new InteractionTemplateSpec
+        {
+            TemplateId = "tpl-1",
+        };
+        spec.TemplateVariable["title"] = "Deploy";
+        spec.TemplateVariable["run"] = "run-1";
+
+        var parsed = InteractionTemplateSpec.Parser.ParseFrom(spec.ToByteArray());
+
+        parsed.ShouldBe(spec);
+        parsed.TemplateId.ShouldBe("tpl-1");
+        parsed.TemplateVariable["title"].ShouldBe("Deploy");
+        InteractionSpecReflection.Descriptor.MessageTypes.Select(x => x.Name)
+            .ShouldContain(nameof(InteractionTemplateSpec));
+    }
+
+    [Fact]
     public void ChildEvents_ShouldPreserveUnknownFieldsAndCoverEmptyBranches()
     {
         // tag=1 (child_id), then an unknown varint field (field=99, wire=0).

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -952,6 +952,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(Substitute.For<IUserAgentDeliveryTargetReader>());
         services.AddSingleton<LarkMessageComposer>();
         services.TryAddSingleton<ILogger<FeishuCardHumanInteractionPort>>(NullLogger<FeishuCardHumanInteractionPort>.Instance);
+        services.TryAddSingleton<ILogger<FeishuCardNotificationPort>>(NullLogger<FeishuCardNotificationPort>.Instance);
         services.AddSingleton(callerScopeResolver);
 
         services.AddLarkAgentAuthoring();
@@ -961,6 +962,7 @@ public sealed class AgentBuilderToolTests
         var source = provider.GetServices<IAgentToolSource>().Should().ContainSingle().Subject;
         source.Should().BeOfType<AgentBuilderToolSource>();
         provider.GetRequiredService<IHumanInteractionPort>().Should().BeOfType<FeishuCardHumanInteractionPort>();
+        provider.GetRequiredService<IChannelInteractionNotificationPort>().Should().BeOfType<FeishuCardNotificationPort>();
 
         var tools = await source.DiscoverToolsAsync();
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRuntimeSourceRegressionTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRuntimeSourceRegressionTests.cs
@@ -62,6 +62,52 @@ public sealed class ChannelRuntimeSourceRegressionTests
     }
 
     [Fact]
+    public void Workflow_core_notify_boundary_must_not_reintroduce_channel_or_raw_lark_tokens()
+    {
+        var repositoryRoot = GetRepositoryRoot();
+        var guardSource = File.ReadAllText(
+            Path.Combine(repositoryRoot, "tools/ci/architecture_guards.sh"),
+            Encoding.UTF8);
+        foreach (var token in new[]
+                 {
+                     "Aevatar\\.GAgents\\.Channel\\.Abstractions",
+                     "MessageContent",
+                     "LarkMessageComposer",
+                     "open-apis/im/v1/messages",
+                     "raw card JSON",
+                 })
+        {
+            guardSource.Should().Contain(token, "FI-006 architecture guard must keep the Workflow Core/Lark boundary token '{0}'", token);
+        }
+
+        var forbiddenPatterns = new[]
+        {
+            "Aevatar.GAgents.Channel.Abstractions",
+            "MessageContent",
+            "LarkMessageComposer",
+            "open-apis/im/v1/messages",
+            "interactive_card",
+            "raw Lark",
+            "raw card JSON",
+        };
+        var workflowCoreRoot = Path.Combine(repositoryRoot, "src/workflow/Aevatar.Workflow.Core");
+        var hits = Directory.EnumerateFiles(workflowCoreRoot, "*.*", SearchOption.AllDirectories)
+            .Where(static file =>
+                (file.EndsWith(".cs", StringComparison.Ordinal) ||
+                 file.EndsWith(".proto", StringComparison.Ordinal)) &&
+                !file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal) &&
+                !file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Select(file => (File: Path.GetRelativePath(repositoryRoot, file), Source: ReadPolicySurface(file)))
+            .SelectMany(item => forbiddenPatterns
+                .Where(token => item.Source.Contains(token, StringComparison.Ordinal))
+                .Select(token => $"{item.File}: {token}"))
+            .ToArray();
+
+        hits.Should().BeEmpty(
+            "Workflow Core may publish typed notification events, but channel rendering and raw Lark card payloads belong at the channel boundary");
+    }
+
+    [Fact]
     public void Retired_nyx_relay_agent_builder_flow_must_not_reappear_in_source_or_tests()
     {
         var repositoryRoot = GetRepositoryRoot();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRuntimeSourceRegressionTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRuntimeSourceRegressionTests.cs
@@ -49,6 +49,7 @@ public sealed class ChannelRuntimeSourceRegressionTests
         var repositoryRoot = GetRepositoryRoot();
         var bypasses = Directory.EnumerateFiles(Path.Combine(repositoryRoot, "agents"), "*.cs", SearchOption.AllDirectories)
             .Where(static file => !file.EndsWith("LarkOutboundDispatcher.cs", StringComparison.Ordinal))
+            .Where(static file => !file.EndsWith("FeishuCardOutboundMessageSender.cs", StringComparison.Ordinal))
             .Select(file => (File: Path.GetRelativePath(repositoryRoot, file), Source: StripComments(File.ReadAllText(file, Encoding.UTF8))))
             .Where(static item =>
                 item.Source.Contains("open-apis/im/v1/messages?receive_id_type=", StringComparison.Ordinal) ||

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/FeishuCardNotificationPortTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/FeishuCardNotificationPortTests.cs
@@ -1,0 +1,261 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.Foundation.Abstractions.HumanInteraction;
+using Aevatar.Foundation.Abstractions.Interactions;
+using Aevatar.GAgents.Authoring.Lark;
+using Aevatar.GAgents.Platform.Lark;
+using Aevatar.GAgents.Scheduled;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+public sealed class FeishuCardNotificationPortTests
+{
+    [Fact]
+    public async Task DeliverAsync_WhenInteractionSpecPresent_ShouldSendInteractiveCardThroughDispatcherPath()
+    {
+        var registry = BuildRegistry("agent-1");
+        var handler = new RecordingHandler("""{"data":{"message_id":"om_1"}}""");
+        var nyxClient = CreateNyxClient(handler);
+        var port = new FeishuCardNotificationPort(
+            registry,
+            nyxClient,
+            new LarkMessageComposer(),
+            NullLogger<FeishuCardNotificationPort>.Instance);
+
+        await port.DeliverAsync(
+            new ChannelInteractionNotificationRequest
+            {
+                ActorId = "workflow-actor-1",
+                RunId = "run-1",
+                StepId = "notify-1",
+                DeliveryTargetId = "agent-1",
+                InteractionSpec = new InteractionSpec
+                {
+                    Title = "Status",
+                    Body = "Accepted",
+                    Actions =
+                    {
+                        new InteractionAction
+                        {
+                            Kind = InteractionActionKind.Button,
+                            ActionId = "open",
+                            Label = "Open",
+                        },
+                    },
+                },
+            },
+            CancellationToken.None);
+
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.RequestUri!.ToString()
+            .Should().Be("https://nyx.example.com/api/v1/proxy/s/api-lark-bot/open-apis/im/v1/messages?receive_id_type=chat_id");
+        using var body = JsonDocument.Parse(handler.LastBody!);
+        body.RootElement.GetProperty("receive_id").GetString().Should().Be("oc_chat_1");
+        body.RootElement.GetProperty("msg_type").GetString().Should().Be("interactive");
+
+        using var content = JsonDocument.Parse(body.RootElement.GetProperty("content").GetString()!);
+        content.RootElement.GetProperty("schema").GetString().Should().Be("2.0");
+        content.RootElement.GetProperty("header").GetProperty("title").GetProperty("content").GetString()
+            .Should().Be("Status\nAccepted");
+    }
+
+    [Fact]
+    public void BuildCardJson_WhenTemplateSpecPresent_ShouldRenderLarkTemplateContent()
+    {
+        var template = new InteractionTemplateSpec { TemplateId = "tpl-1" };
+        template.TemplateVariable["title"] = "Deploy";
+        template.TemplateVariable["run"] = "run-1";
+
+        var cardJson = FeishuCardNotificationPort.BuildCardJson(
+            new ChannelInteractionNotificationRequest
+            {
+                ActorId = "workflow-actor-1",
+                RunId = "run-1",
+                StepId = "notify-template",
+                DeliveryTargetId = "agent-1",
+                InteractionTemplateSpec = template,
+            });
+
+        using var document = JsonDocument.Parse(cardJson);
+        document.RootElement.GetProperty("type").GetString().Should().Be("template");
+        var data = document.RootElement.GetProperty("data");
+        data.GetProperty("template_id").GetString().Should().Be("tpl-1");
+        data.GetProperty("template_variable").GetProperty("title").GetString().Should().Be("Deploy");
+        data.GetProperty("template_variable").GetProperty("run").GetString().Should().Be("run-1");
+    }
+
+    [Fact]
+    public async Task DeliverAsync_ShouldRetryWithFallback_WhenPrimaryRejectedAsBotNotInChat()
+    {
+        var registry = BuildRegistry("agent-fb", fallback: true);
+        var handler = new SequencedRecordingHandler(
+            """{"error": true, "status": 400, "body": "{\"code\":230002,\"msg\":\"Bot is not in the chat\"}"}""",
+            """{"data":{"message_id":"om_fb"}}""");
+        var port = new FeishuCardNotificationPort(
+            registry,
+            CreateNyxClient(handler),
+            new LarkMessageComposer(),
+            NullLogger<FeishuCardNotificationPort>.Instance);
+
+        await port.DeliverAsync(BuildTemplateRequest("agent-fb"), CancellationToken.None);
+
+        handler.Requests.Should().HaveCount(2);
+        handler.Requests[0].RequestUri!.Query.Should().Contain("receive_id_type=chat_id");
+        handler.Requests[1].RequestUri!.Query.Should().Contain("receive_id_type=union_id");
+        using var fallbackBody = JsonDocument.Parse(handler.Bodies[1]!);
+        fallbackBody.RootElement.GetProperty("receive_id").GetString().Should().Be("on_user_1");
+        fallbackBody.RootElement.GetProperty("msg_type").GetString().Should().Be("interactive");
+    }
+
+    [Fact]
+    public async Task DeliverAsync_ShouldThrow_WhenTargetMissingOrPlatformUnsupported()
+    {
+        var missingRegistry = Substitute.For<IUserAgentDeliveryTargetReader>();
+        missingRegistry.GetAsync("missing", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<UserAgentDeliveryTarget?>(null));
+        var unsupportedRegistry = Substitute.For<IUserAgentDeliveryTargetReader>();
+        unsupportedRegistry.GetAsync("agent-telegram", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<UserAgentDeliveryTarget?>(new UserAgentDeliveryTarget(
+                AgentId: "agent-telegram",
+                Platform: "telegram",
+                ConversationId: string.Empty,
+                NyxProviderSlug: string.Empty,
+                NyxApiKey: string.Empty,
+                LarkReceiveId: string.Empty,
+                LarkReceiveIdType: string.Empty,
+                LarkReceiveIdFallback: string.Empty,
+                LarkReceiveIdTypeFallback: string.Empty,
+                TemplateName: string.Empty,
+                AgentType: string.Empty)));
+        var missingPort = CreatePort(missingRegistry);
+        var unsupportedPort = CreatePort(unsupportedRegistry);
+
+        Func<Task> missingAct = () => missingPort.DeliverAsync(BuildTemplateRequest("missing"), CancellationToken.None);
+        Func<Task> unsupportedAct = () => unsupportedPort.DeliverAsync(BuildTemplateRequest("agent-telegram"), CancellationToken.None);
+
+        await missingAct.Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*delivery target not found*");
+        await unsupportedAct.Should()
+            .ThrowAsync<NotSupportedException>()
+            .WithMessage("*Unsupported interaction notification platform*");
+    }
+
+    [Fact]
+    public async Task BuildCardJson_ShouldRejectMissingOrDoublePayload()
+    {
+        var empty = new ChannelInteractionNotificationRequest
+        {
+            ActorId = "workflow-actor-1",
+            RunId = "run-1",
+            StepId = "notify-1",
+            DeliveryTargetId = "agent-1",
+        };
+        var both = empty with
+        {
+            InteractionSpec = new InteractionSpec { Title = "Status" },
+            InteractionTemplateSpec = new InteractionTemplateSpec { TemplateId = "tpl-1" },
+        };
+
+        Action emptyAct = () => FeishuCardNotificationPort.BuildCardJson(empty);
+        Func<Task> bothAct = () => CreatePort(BuildRegistry("agent-1")).DeliverAsync(both, CancellationToken.None);
+
+        emptyAct.Should().Throw<InvalidOperationException>()
+            .WithMessage("*payload is required*");
+        await bothAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*exactly one typed payload*");
+    }
+
+    private static FeishuCardNotificationPort CreatePort(IUserAgentDeliveryTargetReader registry) =>
+        new(
+            registry,
+            new NyxIdApiClient(new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" }),
+            new LarkMessageComposer(),
+            NullLogger<FeishuCardNotificationPort>.Instance);
+
+    private static IUserAgentDeliveryTargetReader BuildRegistry(string deliveryTargetId, bool fallback = false)
+    {
+        var registry = Substitute.For<IUserAgentDeliveryTargetReader>();
+        registry.GetAsync(deliveryTargetId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<UserAgentDeliveryTarget?>(new UserAgentDeliveryTarget(
+                AgentId: deliveryTargetId,
+                Platform: "lark",
+                ConversationId: fallback ? "oc_dm_chat_1" : "oc_chat_1",
+                NyxProviderSlug: "api-lark-bot",
+                NyxApiKey: "nyx-api-key-1",
+                LarkReceiveId: fallback ? "oc_dm_chat_1" : string.Empty,
+                LarkReceiveIdType: fallback ? "chat_id" : string.Empty,
+                LarkReceiveIdFallback: fallback ? "on_user_1" : string.Empty,
+                LarkReceiveIdTypeFallback: fallback ? "union_id" : string.Empty,
+                TemplateName: "social_media",
+                AgentType: string.Empty)));
+        return registry;
+    }
+
+    private static ChannelInteractionNotificationRequest BuildTemplateRequest(string deliveryTargetId)
+    {
+        var template = new InteractionTemplateSpec { TemplateId = "tpl-1" };
+        template.TemplateVariable["title"] = "Deploy";
+        return new ChannelInteractionNotificationRequest
+        {
+            ActorId = "workflow-actor-1",
+            RunId = "run-1",
+            StepId = "notify-template",
+            DeliveryTargetId = deliveryTargetId,
+            InteractionTemplateSpec = template,
+        };
+    }
+
+    private static NyxIdApiClient CreateNyxClient(HttpMessageHandler handler) =>
+        new(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler) { BaseAddress = new Uri("https://nyx.example.com") });
+
+    private sealed class RecordingHandler(string responseBody) : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+        public string? LastBody { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            LastBody = request.Content == null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
+            };
+        }
+    }
+
+    private sealed class SequencedRecordingHandler : HttpMessageHandler
+    {
+        private readonly Queue<string> _responses;
+        public List<HttpRequestMessage> Requests { get; } = [];
+        public List<string?> Bodies { get; } = [];
+
+        public SequencedRecordingHandler(params string[] responses)
+        {
+            _responses = new Queue<string>(responses);
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            Bodies.Add(request.Content == null ? null : await request.Content.ReadAsStringAsync(cancellationToken));
+            var body = _responses.Count > 0 ? _responses.Dequeue() : """{"data":{}}""";
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            };
+        }
+    }
+}

--- a/test/Aevatar.Workflow.Core.Tests/Modules/NotifyModuleTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/NotifyModuleTests.cs
@@ -57,12 +57,13 @@ public sealed class NotifyModuleTests
     }
 
     [Fact]
-    public async Task HandleAsync_WhenDeliveryTargetMissing_ShouldFailWithoutSuspension()
+    public async Task HandleAsync_WhenTypedDeliveryTargetMissing_ShouldIgnoreParameterBagAndFailWithoutSuspension()
     {
         var ctx = new RecordingWorkflowContext();
         var module = new NotifyModule();
         var request = BuildRequest(interaction: BuildInteractionSpec());
-        request.Parameters.Clear();
+        request.StepParameters.DeliveryTargetId = string.Empty;
+        request.Parameters["delivery_target_id"] = "bag-delivery-target";
 
         await module.HandleAsync(Envelope(request), ctx, CancellationToken.None);
 
@@ -120,9 +121,11 @@ public sealed class NotifyModuleTests
             StepType = "notify",
             RunId = "run-1",
             ExecutionId = "exec-1",
-            StepParameters = new WorkflowStepParameters(),
+            StepParameters = new WorkflowStepParameters
+            {
+                DeliveryTargetId = "agent-delivery-1",
+            },
         };
-        request.Parameters["delivery_target_id"] = "agent-delivery-1";
         if (interaction is not null)
             request.StepParameters.InteractionSpec = interaction;
         if (template is not null)

--- a/test/Aevatar.Workflow.Core.Tests/Modules/NotifyModuleTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/NotifyModuleTests.cs
@@ -1,0 +1,219 @@
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Interactions;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Abstractions.Execution;
+using Aevatar.Workflow.Core.Modules;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.Workflow.Core.Tests.Modules;
+
+public sealed class NotifyModuleTests
+{
+    [Fact]
+    public async Task HandleAsync_WhenInteractionSpecValid_ShouldPublishNotificationThenAcceptedCompletion()
+    {
+        var ctx = new RecordingWorkflowContext();
+        var module = new NotifyModule();
+
+        await module.HandleAsync(Envelope(BuildRequest(interaction: BuildInteractionSpec())), ctx, CancellationToken.None);
+
+        ctx.Published.Should().HaveCount(2);
+        ctx.Published[0].Direction.Should().Be(TopologyAudience.ParentAndChildren);
+        var notification = ctx.Published[0].Event.Should().BeOfType<WorkflowInteractionNotificationEvent>().Subject;
+        notification.RunId.Should().Be("run-1");
+        notification.StepId.Should().Be("notify-1");
+        notification.DeliveryTargetId.Should().Be("agent-delivery-1");
+        notification.PayloadCase.Should().Be(WorkflowInteractionNotificationEvent.PayloadOneofCase.Interaction);
+        notification.Interaction.Title.Should().Be("Status");
+
+        ctx.Published[1].Direction.Should().Be(TopologyAudience.Self);
+        var completed = ctx.Published[1].Event.Should().BeOfType<StepCompletedEvent>().Subject;
+        completed.Success.Should().BeTrue();
+        completed.Output.Should().Be("accepted");
+        completed.Annotations["notification_status"].Should().Be("accepted");
+        ctx.Published.Select(x => x.Event).OfType<WorkflowSuspendedEvent>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenTemplateSpecValid_ShouldPublishTemplateNotificationThenAcceptedCompletion()
+    {
+        var ctx = new RecordingWorkflowContext();
+        var module = new NotifyModule();
+
+        await module.HandleAsync(Envelope(BuildRequest(template: BuildTemplateSpec())), ctx, CancellationToken.None);
+
+        ctx.Published.Should().HaveCount(2);
+        var notification = ctx.Published[0].Event.Should().BeOfType<WorkflowInteractionNotificationEvent>().Subject;
+        notification.PayloadCase.Should().Be(WorkflowInteractionNotificationEvent.PayloadOneofCase.InteractionTemplate);
+        notification.InteractionTemplate.TemplateId.Should().Be("tpl-1");
+        notification.InteractionTemplate.TemplateVariable["run"].Should().Be("run-1");
+        ctx.Published[1].Event.Should().BeOfType<StepCompletedEvent>().Which.Output.Should().Be("accepted");
+        ctx.Published.Select(x => x.Event).OfType<WorkflowSuspendedEvent>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenDeliveryTargetMissing_ShouldFailWithoutSuspension()
+    {
+        var ctx = new RecordingWorkflowContext();
+        var module = new NotifyModule();
+        var request = BuildRequest(interaction: BuildInteractionSpec());
+        request.Parameters.Clear();
+
+        await module.HandleAsync(Envelope(request), ctx, CancellationToken.None);
+
+        var completed = ctx.Published.Should().ContainSingle().Subject.Event
+            .Should().BeOfType<StepCompletedEvent>().Subject;
+        completed.Success.Should().BeFalse();
+        completed.Error.Should().Contain("delivery_target_id");
+        ctx.Published.Select(x => x.Event).OfType<WorkflowSuspendedEvent>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenPayloadMissingOrBothPresent_ShouldFailWithoutNotificationOrSuspension()
+    {
+        var module = new NotifyModule();
+        var missingCtx = new RecordingWorkflowContext();
+        var bothCtx = new RecordingWorkflowContext();
+
+        await module.HandleAsync(Envelope(BuildRequest()), missingCtx, CancellationToken.None);
+        await module.HandleAsync(
+            Envelope(BuildRequest(interaction: BuildInteractionSpec(), template: BuildTemplateSpec())),
+            bothCtx,
+            CancellationToken.None);
+
+        missingCtx.Published.Should().ContainSingle().Which.Event
+            .Should().BeOfType<StepCompletedEvent>().Which.Success.Should().BeFalse();
+        bothCtx.Published.Should().ContainSingle().Which.Event
+            .Should().BeOfType<StepCompletedEvent>().Which.Success.Should().BeFalse();
+        missingCtx.Published.Select(x => x.Event).OfType<WorkflowInteractionNotificationEvent>().Should().BeEmpty();
+        bothCtx.Published.Select(x => x.Event).OfType<WorkflowInteractionNotificationEvent>().Should().BeEmpty();
+        missingCtx.Published.Select(x => x.Event).OfType<WorkflowSuspendedEvent>().Should().BeEmpty();
+        bothCtx.Published.Select(x => x.Event).OfType<WorkflowSuspendedEvent>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_ShouldIgnoreOtherStepTypes()
+    {
+        var ctx = new RecordingWorkflowContext();
+        var module = new NotifyModule();
+
+        await module.HandleAsync(
+            Envelope(new StepRequestEvent { StepId = "other", StepType = "emit" }),
+            ctx,
+            CancellationToken.None);
+
+        ctx.Published.Should().BeEmpty();
+    }
+
+    private static StepRequestEvent BuildRequest(
+        InteractionSpec? interaction = null,
+        InteractionTemplateSpec? template = null)
+    {
+        var request = new StepRequestEvent
+        {
+            StepId = "notify-1",
+            StepType = "notify",
+            RunId = "run-1",
+            ExecutionId = "exec-1",
+            StepParameters = new WorkflowStepParameters(),
+        };
+        request.Parameters["delivery_target_id"] = "agent-delivery-1";
+        if (interaction is not null)
+            request.StepParameters.InteractionSpec = interaction;
+        if (template is not null)
+            request.StepParameters.InteractionTemplateSpec = template;
+        return request;
+    }
+
+    private static InteractionSpec BuildInteractionSpec() => new()
+    {
+        Title = "Status",
+        Body = "Run accepted.",
+        Actions =
+        {
+            new InteractionAction
+            {
+                Kind = InteractionActionKind.Button,
+                ActionId = "open",
+                Label = "Open",
+            },
+        },
+    };
+
+    private static InteractionTemplateSpec BuildTemplateSpec()
+    {
+        var spec = new InteractionTemplateSpec { TemplateId = "tpl-1" };
+        spec.TemplateVariable["run"] = "run-1";
+        return spec;
+    }
+
+    private static EventEnvelope Envelope(IMessage message) =>
+        new()
+        {
+            Payload = Any.Pack(message),
+        };
+
+    private sealed class RecordingWorkflowContext : IWorkflowExecutionContext
+    {
+        public EventEnvelope InboundEnvelope { get; } = new();
+
+        public string AgentId => "agent-1";
+
+        public string RunId => "run-1";
+
+        public IServiceProvider Services => EmptyServiceProvider.Instance;
+
+        public ILogger Logger { get; } = NullLogger.Instance;
+
+        public List<(IMessage Event, TopologyAudience Direction)> Published { get; } = [];
+
+        public TState LoadState<TState>(string scopeKey)
+            where TState : class, IMessage<TState>, new() =>
+            new();
+
+        public IReadOnlyList<KeyValuePair<string, TState>> LoadStates<TState>(string scopeKeyPrefix = "")
+            where TState : class, IMessage<TState>, new() =>
+            [];
+
+        public Task SaveStateAsync<TState>(string scopeKey, TState state, CancellationToken ct = default)
+            where TState : class, IMessage<TState> =>
+            Task.CompletedTask;
+
+        public Task ClearStateAsync(string scopeKey, CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task PublishAsync<TEvent>(
+            TEvent evt,
+            TopologyAudience audience = TopologyAudience.Children,
+            CancellationToken ct = default,
+            EventEnvelopePublishOptions? options = null)
+            where TEvent : IMessage
+        {
+            Published.Add((evt, audience));
+            return Task.CompletedTask;
+        }
+
+        public Task<RuntimeCallbackLease> ScheduleSelfDurableTimeoutAsync(
+            string callbackId,
+            TimeSpan dueTime,
+            IMessage evt,
+            EventEnvelopePublishOptions? options = null,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task CancelDurableCallbackAsync(RuntimeCallbackLease lease, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class EmptyServiceProvider : IServiceProvider
+    {
+        public static EmptyServiceProvider Instance { get; } = new();
+
+        public object? GetService(System.Type serviceType) => null;
+    }
+}

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowLoopModuleExpressionEvaluationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowLoopModuleExpressionEvaluationTests.cs
@@ -1,9 +1,12 @@
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.EventModules;
+using Aevatar.Foundation.Abstractions.Interactions;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Workflow.Abstractions;
-using Aevatar.Workflow.Core.Execution;
+using Aevatar.Workflow.Abstractions.Execution;
 using Aevatar.Workflow.Core;
+using Aevatar.Workflow.Core.Execution;
+using Aevatar.Workflow.Core.Modules;
 using Aevatar.Workflow.Core.Primitives;
 using FluentAssertions;
 using Google.Protobuf;
@@ -110,6 +113,67 @@ public class WorkflowLoopModuleExpressionEvaluationTests
         request.TargetRole.Should().Be("assistant");
     }
 
+    [Fact]
+    public async Task DispatchStep_WhenNotifyTemplateUsesExpressions_ShouldEvaluateBeforeNotifyModulePublishesNotification()
+    {
+        var workflow = new WorkflowDefinition
+        {
+            Name = "wf",
+            Roles = [],
+            Steps =
+            [
+                new StepDefinition
+                {
+                    Id = "notify",
+                    Type = "notify",
+                    Presentation = new StepPresentation
+                    {
+                        DeliveryTargetId = "agent-${input}",
+                        InteractionTemplateSpec = new InteractionTemplateSpec
+                        {
+                            TemplateId = "tpl-${input}",
+                            TemplateVariable =
+                            {
+                                ["title"] = "Deploy ${input}",
+                                ["run"] = "${run}",
+                            },
+                        },
+                    },
+                },
+            ],
+        };
+        var ctx = new CapturingContext();
+        var module = new WorkflowExecutionKernel(workflow, (IWorkflowExecutionStateHost)ctx.Agent);
+        var start = new StartWorkflowEvent
+        {
+            WorkflowName = "wf",
+            RunId = "run-template",
+            Input = "prod",
+        };
+        start.Parameters["run"] = "run-template";
+
+        await module.HandleAsync(Wrap(start), ctx, CancellationToken.None);
+
+        var request = ctx.Published.Single(x => x.Event is StepRequestEvent).Event
+            .Should().BeOfType<StepRequestEvent>().Subject;
+        request.Parameters.Should().NotContainKey("delivery_target_id");
+        request.StepParameters.DeliveryTargetId.Should().Be("agent-prod");
+        request.StepParameters.InteractionTemplateSpec.TemplateId.Should().Be("tpl-prod");
+        request.StepParameters.InteractionTemplateSpec.TemplateVariable["title"].Should().Be("Deploy prod");
+        request.StepParameters.InteractionTemplateSpec.TemplateVariable["run"].Should().Be("run-template");
+
+        var notifyCtx = new RecordingWorkflowContext();
+        await new NotifyModule().HandleAsync(Wrap(request), notifyCtx, CancellationToken.None);
+
+        var notification = notifyCtx.Published.Select(x => x.Event)
+            .OfType<WorkflowInteractionNotificationEvent>()
+            .Should().ContainSingle().Subject;
+        notification.DeliveryTargetId.Should().Be("agent-prod");
+        notification.InteractionTemplate.TemplateId.Should().Be("tpl-prod");
+        notification.InteractionTemplate.TemplateVariable["title"].Should().Be("Deploy prod");
+        notification.InteractionTemplate.TemplateVariable["run"].Should().Be("run-template");
+    }
+
     private static EventEnvelope Wrap(IMessage evt) => new()
     {
         Id = Guid.NewGuid().ToString("N"),
@@ -176,6 +240,58 @@ public class WorkflowLoopModuleExpressionEvaluationTests
             _ = ct;
             throw new NotSupportedException("This test context does not support scheduling.");
         }
+    }
+
+    private sealed class RecordingWorkflowContext : IWorkflowExecutionContext
+    {
+        public EventEnvelope InboundEnvelope { get; } = new();
+
+        public string AgentId => "agent-1";
+
+        public string RunId => "run-template";
+
+        public IServiceProvider Services { get; } = new NullServiceProvider();
+
+        public ILogger Logger { get; } = NullLogger.Instance;
+
+        public List<(IMessage Event, TopologyAudience Direction)> Published { get; } = [];
+
+        public TState LoadState<TState>(string scopeKey)
+            where TState : class, IMessage<TState>, new() =>
+            new();
+
+        public IReadOnlyList<KeyValuePair<string, TState>> LoadStates<TState>(string scopeKeyPrefix = "")
+            where TState : class, IMessage<TState>, new() =>
+            [];
+
+        public Task SaveStateAsync<TState>(string scopeKey, TState state, CancellationToken ct = default)
+            where TState : class, IMessage<TState> =>
+            Task.CompletedTask;
+
+        public Task ClearStateAsync(string scopeKey, CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task PublishAsync<TEvent>(
+            TEvent evt,
+            TopologyAudience direction = TopologyAudience.Children,
+            CancellationToken ct = default,
+            EventEnvelopePublishOptions? options = null)
+            where TEvent : IMessage
+        {
+            Published.Add((evt, direction));
+            return Task.CompletedTask;
+        }
+
+        public Task<RuntimeCallbackLease> ScheduleSelfDurableTimeoutAsync(
+            string callbackId,
+            TimeSpan dueTime,
+            IMessage evt,
+            EventEnvelopePublishOptions? options = null,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException("This test context does not support scheduling.");
+
+        public Task CancelDurableCallbackAsync(RuntimeCallbackLease lease, CancellationToken ct = default) =>
+            throw new NotSupportedException("This test context does not support scheduling.");
     }
 
     private sealed class StubWorkflowRunAgent(string id, string runId) : IAgent, IWorkflowExecutionStateHost

--- a/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowParserCoverageTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowParserCoverageTests.cs
@@ -263,8 +263,32 @@ public sealed class WorkflowParserCoverageTests
         spec!.TemplateId.Should().Be("tpl-${input}");
         spec.TemplateVariable["title"].Should().Be("Deploy");
         spec.TemplateVariable["run"].Should().Be("run-1");
-        step.Parameters.Should().ContainKey("delivery_target_id");
+        step.Presentation!.DeliveryTargetId.Should().Be("agent-1");
+        step.Parameters.Should().NotContainKey("delivery_target_id");
         step.Parameters.Should().NotContainKey("interaction_template_spec");
+    }
+
+    [Fact]
+    public void Parse_WhenNotifyUsesCamelCaseDeliveryTargetAlias_ShouldLeaveItAsOrdinaryParameter()
+    {
+        var workflow = new WorkflowParser().Parse(
+            """
+            name: notify_template
+            roles: []
+            steps:
+              - id: notify
+                type: notify
+                parameters:
+                  deliveryTargetId: agent-1
+                  interaction_template_spec:
+                    template_id: tpl-1
+            """);
+
+        var step = workflow.Steps[0];
+
+        step.Presentation?.DeliveryTargetId.Should().BeNull();
+        step.Parameters.Should().ContainKey("deliveryTargetId");
+        step.Parameters.Should().NotContainKey("delivery_target_id");
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowParserCoverageTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowParserCoverageTests.cs
@@ -238,6 +238,36 @@ public sealed class WorkflowParserCoverageTests
     }
 
     [Fact]
+    public void Parse_WhenInteractionTemplateSpecIsPresent_ShouldLiftTypedPresentation()
+    {
+        var workflow = new WorkflowParser().Parse(
+            """
+            name: notify_template
+            roles: []
+            steps:
+              - id: notify
+                type: notify
+                parameters:
+                  delivery_target_id: agent-1
+                  interaction_template_spec:
+                    template_id: tpl-${input}
+                    template_variable:
+                      title: "Deploy"
+                      run: run-1
+            """);
+
+        var step = workflow.Steps[0];
+        var spec = step.Presentation?.InteractionTemplateSpec;
+
+        spec.Should().NotBeNull();
+        spec!.TemplateId.Should().Be("tpl-${input}");
+        spec.TemplateVariable["title"].Should().Be("Deploy");
+        spec.TemplateVariable["run"].Should().Be("run-1");
+        step.Parameters.Should().ContainKey("delivery_target_id");
+        step.Parameters.Should().NotContainKey("interaction_template_spec");
+    }
+
+    [Fact]
     public void Parse_WhenPresentationContainsInlineSpec_ShouldLiftTypedPresentation()
     {
         var workflow = new WorkflowParser().Parse(

--- a/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowPrimitiveCatalogTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowPrimitiveCatalogTests.cs
@@ -17,4 +17,13 @@ public sealed class WorkflowPrimitiveCatalogTests
     {
         WorkflowPrimitiveCatalog.ToCanonicalType("schedule_workflow").Should().Be("self_reschedule");
     }
+
+    [Fact]
+    public void BuiltInCanonicalTypes_ShouldIncludeNotifyWithoutEmitOrPublishAlias()
+    {
+        WorkflowPrimitiveCatalog.ToCanonicalType("notify").Should().Be("notify");
+        WorkflowPrimitiveCatalog.ToCanonicalType("emit").Should().Be("emit");
+        WorkflowPrimitiveCatalog.ToCanonicalType("publish").Should().Be("emit");
+        WorkflowPrimitiveCatalog.BuiltInCanonicalTypes.Should().Contain("notify");
+    }
 }

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowAbstractionsProtoCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowAbstractionsProtoCoverageTests.cs
@@ -110,6 +110,7 @@ public class WorkflowAbstractionsProtoCoverageTests
             TemplateId = "tpl-review",
         };
         request.StepParameters.InteractionTemplateSpec.TemplateVariable["run"] = "run-1";
+        request.StepParameters.DeliveryTargetId = "agent-1";
 
         var completed = new StepCompletedEvent
         {
@@ -129,6 +130,7 @@ public class WorkflowAbstractionsProtoCoverageTests
         parsedRequest.StepParameters.InteractionSpec.Actions[0].Style.Should().Be(InteractionActionStyle.Primary);
         parsedRequest.StepParameters.InteractionTemplateSpec.TemplateId.Should().Be("tpl-review");
         parsedRequest.StepParameters.InteractionTemplateSpec.TemplateVariable["run"].Should().Be("run-1");
+        parsedRequest.StepParameters.DeliveryTargetId.Should().Be("agent-1");
 
         var parsedCompleted = StepCompletedEvent.Parser.ParseFrom(completed.ToByteArray());
         parsedCompleted.WorkerId.Should().Be("worker-1");
@@ -142,6 +144,8 @@ public class WorkflowAbstractionsProtoCoverageTests
     {
         StepRequestEvent.Descriptor.Fields.InDeclarationOrder()
             .Should().Contain(field => field.FieldNumber == 8 && field.Name == "step_parameters");
+        WorkflowStepParameters.Descriptor.Fields.InDeclarationOrder()
+            .Should().Contain(field => field.FieldNumber == 6 && field.Name == "delivery_target_id");
         StepRequestEvent.Descriptor.Fields.InDeclarationOrder()
             .Should().NotContain(field => field.FieldNumber == 5);
 
@@ -152,12 +156,14 @@ public class WorkflowAbstractionsProtoCoverageTests
             StepParameters = new WorkflowStepParameters(),
         };
         request.StepParameters.Parameters["op"] = "trim";
+        request.StepParameters.DeliveryTargetId = "agent-typed";
         request.Parameters["target"] = "result";
         request.StepParameters.InteractionSpec = new InteractionSpec { Body = "Continue?" };
 
         var parsed = StepRequestEvent.Parser.ParseFrom(request.ToByteArray());
         parsed.StepParameters.Parameters.Should().Contain(new KeyValuePair<string, string>("op", "trim"));
         parsed.Parameters.Should().Contain(new KeyValuePair<string, string>("target", "result"));
+        parsed.StepParameters.DeliveryTargetId.Should().Be("agent-typed");
         parsed.StepParameters.InteractionSpec.Body.Should().Be("Continue?");
         parsed.ToString().Should().Contain("stepParameters");
         ((IMessage)parsed.StepParameters).Descriptor.Name.Should().Be(nameof(WorkflowStepParameters));

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowAbstractionsProtoCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowAbstractionsProtoCoverageTests.cs
@@ -105,6 +105,11 @@ public class WorkflowAbstractionsProtoCoverageTests
             Label = "Approve",
             Style = InteractionActionStyle.Primary,
         });
+        request.StepParameters.InteractionTemplateSpec = new InteractionTemplateSpec
+        {
+            TemplateId = "tpl-review",
+        };
+        request.StepParameters.InteractionTemplateSpec.TemplateVariable["run"] = "run-1";
 
         var completed = new StepCompletedEvent
         {
@@ -122,6 +127,8 @@ public class WorkflowAbstractionsProtoCoverageTests
         parsedRequest.StepParameters.Parameters["temperature"].Should().Be("0.1");
         parsedRequest.StepParameters.InteractionSpec.Title.Should().Be("Review");
         parsedRequest.StepParameters.InteractionSpec.Actions[0].Style.Should().Be(InteractionActionStyle.Primary);
+        parsedRequest.StepParameters.InteractionTemplateSpec.TemplateId.Should().Be("tpl-review");
+        parsedRequest.StepParameters.InteractionTemplateSpec.TemplateVariable["run"].Should().Be("run-1");
 
         var parsedCompleted = StepCompletedEvent.Parser.ParseFrom(completed.ToByteArray());
         parsedCompleted.WorkerId.Should().Be("worker-1");
@@ -154,6 +161,44 @@ public class WorkflowAbstractionsProtoCoverageTests
         parsed.StepParameters.InteractionSpec.Body.Should().Be("Continue?");
         parsed.ToString().Should().Contain("stepParameters");
         ((IMessage)parsed.StepParameters).Descriptor.Name.Should().Be(nameof(WorkflowStepParameters));
+    }
+
+    [Fact]
+    public void WorkflowInteractionNotificationEvent_ShouldRoundtripTypedPayloads()
+    {
+        var interactionEvent = new WorkflowInteractionNotificationEvent
+        {
+            RunId = "run-1",
+            StepId = "notify-1",
+            DeliveryTargetId = "agent-1",
+            Interaction = new InteractionSpec
+            {
+                Title = "Status",
+                Body = "Accepted",
+            },
+        };
+        var templateEvent = new WorkflowInteractionNotificationEvent
+        {
+            RunId = "run-2",
+            StepId = "notify-2",
+            DeliveryTargetId = "agent-2",
+            InteractionTemplate = new InteractionTemplateSpec
+            {
+                TemplateId = "tpl-1",
+            },
+        };
+        templateEvent.InteractionTemplate.TemplateVariable["title"] = "Deploy";
+
+        var parsedInteraction = WorkflowInteractionNotificationEvent.Parser.ParseFrom(interactionEvent.ToByteArray());
+        var parsedTemplate = WorkflowInteractionNotificationEvent.Parser.ParseFrom(templateEvent.ToByteArray());
+
+        parsedInteraction.PayloadCase.Should().Be(WorkflowInteractionNotificationEvent.PayloadOneofCase.Interaction);
+        parsedInteraction.Interaction.Title.Should().Be("Status");
+        parsedTemplate.PayloadCase.Should().Be(WorkflowInteractionNotificationEvent.PayloadOneofCase.InteractionTemplate);
+        parsedTemplate.InteractionTemplate.TemplateId.Should().Be("tpl-1");
+        parsedTemplate.InteractionTemplate.TemplateVariable["title"].Should().Be("Deploy");
+        WorkflowExecutionMessagesReflection.Descriptor.MessageTypes.Select(x => x.Name)
+            .Should().Contain(nameof(WorkflowInteractionNotificationEvent));
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowInfrastructureCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowInfrastructureCoverageTests.cs
@@ -6,6 +6,7 @@ using Aevatar.Configuration;
 using Aevatar.Hosting;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.EventModules;
+using Aevatar.Foundation.Abstractions.HumanInteraction;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Schedules;
 using Aevatar.GAgentService.Hosting.DependencyInjection;
@@ -27,6 +28,8 @@ using Aevatar.Workflow.Infrastructure.DependencyInjection;
 using Aevatar.Workflow.Infrastructure.Reporting;
 using Aevatar.Workflow.Infrastructure.Runs;
 using Aevatar.Workflow.Infrastructure.Workflows;
+using Aevatar.Workflow.Presentation.AGUIAdapter;
+using Aevatar.Workflow.Projection;
 using Aevatar.Workflow.Projection.ReadModels;
 using Aevatar.Workflow.Projection.Workflows;
 using Google.Protobuf;
@@ -231,6 +234,12 @@ public sealed class WorkflowInfrastructureCoverageTests
         services.AddWorkflowCapability(configuration);
 
         services.Should().Contain(x => x.ServiceType == typeof(IWorkflowChatRunInteractionPort));
+        services.Should().Contain(x =>
+            x.ServiceType == typeof(IChannelInteractionNotificationPort) &&
+            x.ImplementationType == typeof(NullChannelInteractionNotificationPort));
+        services.Should().Contain(x =>
+            x.ServiceType == typeof(IProjectionProjector<WorkflowExecutionProjectionContext>) &&
+            x.ImplementationType == typeof(WorkflowInteractionNotificationProjector));
         services.Should().NotContain(x => x.ServiceType == typeof(ICommandInteractionService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowRunEventEnvelope, WorkflowProjectionCompletionStatus>));
         services.Should().Contain(x => x.ServiceType == typeof(ICommandDispatchService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>));
         services.Should().Contain(x => x.ServiceType == typeof(IWorkflowExecutionQueryApplicationService));

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowInteractionNotificationProjectorTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowInteractionNotificationProjectorTests.cs
@@ -1,0 +1,148 @@
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.HumanInteraction;
+using Aevatar.Foundation.Abstractions.Interactions;
+using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Presentation.AGUIAdapter;
+using Aevatar.Workflow.Projection;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Workflow.Host.Api.Tests;
+
+public sealed class WorkflowInteractionNotificationProjectorTests
+{
+    [Fact]
+    public async Task ProjectAsync_ShouldDeliverInteractionNotification_WhenRouteIsDispatchable()
+    {
+        var port = new RecordingNotificationPort();
+        var projector = new WorkflowInteractionNotificationProjector(port);
+
+        await projector.ProjectAsync(
+            BuildContext(),
+            new EventEnvelope
+            {
+                Id = "evt-notify-1",
+                Route = EnvelopeRouteSemantics.CreateObserverPublication("workflow-notify-test"),
+                Payload = Any.Pack(new WorkflowInteractionNotificationEvent
+                {
+                    RunId = "run-1",
+                    StepId = "notify-1",
+                    DeliveryTargetId = "agent-delivery-1",
+                    Interaction = new InteractionSpec
+                    {
+                        Title = "Status",
+                        Body = "Accepted",
+                    },
+                }),
+            },
+            CancellationToken.None);
+
+        port.Calls.Should().ContainSingle();
+        var call = port.Calls[0];
+        call.ActorId.Should().Be("workflow-actor-1");
+        call.RunId.Should().Be("run-1");
+        call.StepId.Should().Be("notify-1");
+        call.DeliveryTargetId.Should().Be("agent-delivery-1");
+        call.InteractionSpec.Should().NotBeNull();
+        call.InteractionSpec!.Title.Should().Be("Status");
+        call.InteractionTemplateSpec.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ProjectAsync_ShouldDeliverTemplateNotification_WhenTemplatePayloadIsPresent()
+    {
+        var port = new RecordingNotificationPort();
+        var projector = new WorkflowInteractionNotificationProjector(port);
+        var template = new InteractionTemplateSpec { TemplateId = "tpl-1" };
+        template.TemplateVariable["run"] = "run-1";
+
+        await projector.ProjectAsync(
+            BuildContext(),
+            new EventEnvelope
+            {
+                Id = "evt-notify-template",
+                Route = EnvelopeRouteSemantics.CreateObserverPublication("workflow-notify-test"),
+                Payload = Any.Pack(new WorkflowInteractionNotificationEvent
+                {
+                    RunId = "run-1",
+                    StepId = "notify-template",
+                    DeliveryTargetId = "agent-delivery-1",
+                    InteractionTemplate = template,
+                }),
+            },
+            CancellationToken.None);
+
+        port.Calls.Should().ContainSingle();
+        port.Calls[0].InteractionSpec.Should().BeNull();
+        port.Calls[0].InteractionTemplateSpec.Should().NotBeNull();
+        port.Calls[0].InteractionTemplateSpec!.TemplateVariable["run"].Should().Be("run-1");
+    }
+
+    [Fact]
+    public async Task ProjectAsync_ShouldIgnoreNonDispatchRouteNonNotificationAndMissingTarget()
+    {
+        var port = new RecordingNotificationPort();
+        var projector = new WorkflowInteractionNotificationProjector(port);
+
+        await projector.ProjectAsync(
+            BuildContext(),
+            new EventEnvelope
+            {
+                Id = "evt-direct",
+                Route = EnvelopeRouteSemantics.CreateDirect("workflow-actor-1", "projection-test"),
+                Payload = Any.Pack(new WorkflowInteractionNotificationEvent
+                {
+                    RunId = "run-1",
+                    StepId = "notify-direct",
+                    DeliveryTargetId = "agent-delivery-1",
+                    Interaction = new InteractionSpec { Title = "Ignored" },
+                }),
+            },
+            CancellationToken.None);
+        await projector.ProjectAsync(
+            BuildContext(),
+            new EventEnvelope
+            {
+                Id = "evt-other",
+                Route = EnvelopeRouteSemantics.CreateObserverPublication("workflow-notify-test"),
+                Payload = Any.Pack(new WorkflowCompletedEvent { RunId = "run-1" }),
+            },
+            CancellationToken.None);
+        await projector.ProjectAsync(
+            BuildContext(),
+            new EventEnvelope
+            {
+                Id = "evt-missing-target",
+                Route = EnvelopeRouteSemantics.CreateObserverPublication("workflow-notify-test"),
+                Payload = Any.Pack(new WorkflowInteractionNotificationEvent
+                {
+                    RunId = "run-1",
+                    StepId = "notify-missing",
+                    Interaction = new InteractionSpec { Title = "Ignored" },
+                }),
+            },
+            CancellationToken.None);
+
+        port.Calls.Should().BeEmpty();
+    }
+
+    private static WorkflowExecutionProjectionContext BuildContext() => new()
+    {
+        SessionId = "cmd-1",
+        RootActorId = "workflow-actor-1",
+        ProjectionKind = "workflow-execution-session",
+    };
+
+    private sealed class RecordingNotificationPort : IChannelInteractionNotificationPort
+    {
+        public List<ChannelInteractionNotificationRequest> Calls { get; } = [];
+
+        public Task DeliverAsync(
+            ChannelInteractionNotificationRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            Calls.Add(request);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -127,7 +127,7 @@ check_workflow_core_interaction_boundary() {
 
   set +e
   report="$(
-    rg -n "MessageContent|LarkMessageComposer|interactive_card|card JSON|raw Lark" "${workflow_core_dir}" \
+    rg -n "Aevatar\.GAgents\.Channel\.Abstractions|MessageContent|LarkMessageComposer|open-apis/im/v1/messages|interactive_card|raw Lark|raw card JSON|\"type\"[[:space:]]*:[[:space:]]*\"template\"" "${workflow_core_dir}" \
       -g '!**/bin/**' \
       -g '!**/obj/**' \
       -g '!*.g.cs' \
@@ -144,6 +144,32 @@ check_workflow_core_interaction_boundary() {
   if [ -n "${report}" ]; then
     echo "${report}"
     echo "Workflow Core must carry typed InteractionSpec only; channel content and raw card payloads belong at the channel boundary."
+    exit 1
+  fi
+
+  set +e
+  report="$(
+    rg -n "Metadata[[:space:]]*\[[[:space:]]*\"interaction\"|metadata[[:space:]]*\[[[:space:]]*\"interaction\"" \
+      src/workflow agents \
+      -g '*Human*Interaction*.cs' \
+      -g '*Notify*.cs' \
+      -g '*Notification*.cs' \
+      -g '!**/bin/**' \
+      -g '!**/obj/**' \
+      -g '!*.g.cs' \
+      -g '!*.Designer.cs'
+  )"
+  status=$?
+  set -e
+
+  if [[ ${status} -ne 0 && ${status} -ne 1 ]]; then
+    echo "HITL/notify metadata interaction guard execution failed."
+    exit "${status}"
+  fi
+
+  if [ -n "${report}" ]; then
+    echo "${report}"
+    echo "HITL/notify control must consume typed interaction contracts, not Metadata[\"interaction\"] bags."
     exit 1
   fi
 }


### PR DESCRIPTION
## Summary / 摘要

实现 #1863（aevatar–Lark 交互协议 · workflow 层 · 出站 notify，属于 #1853 umbrella，依赖已合并的 #1861/#1846）：新 `notify` primitive 让 workflow 主动向 Lark 出站结构化交互消息，**不挂起**、对称新链，不滥用 HITL suspension。

- **`NotifyModule`**（不挂起）：校验 `delivery_target_id` + `interaction`/`interaction_template` 恰一 → 发 `WorkflowInteractionNotificationEvent`，再发 `StepCompletedEvent(accepted)`；**绝不**发 `WorkflowSuspendedEvent`。
- **proto** `WorkflowInteractionNotificationEvent`（`oneof { InteractionSpec interaction; InteractionTemplateSpec interaction_template }`）+ Foundation 新增 `InteractionTemplateSpec`（template escape-hatch，仅 notify）。
- **`WorkflowInteractionNotificationProjector`** → 新 **`IChannelInteractionNotificationPort`**（+ `NullChannelInteractionNotificationPort`）+ `ChannelInteractionNotificationRequest`（extras 命名 `Annotations`，非 `Metadata`）。
- **`FeishuCardNotificationPort`**：复用 `InteractionSpecMapper`/`LarkMessageComposer`/`LarkOutboundDispatcher`；抽出 `FeishuCardOutboundMessageSender` 与 HITL port 共享发送件。
- **`architecture_guards.sh` FI-006**：Workflow Core 禁引用 channel 渲染 / raw Lark JSON。
- **ACK 诚实**：`accepted` 只代表 notification event 已 published，不暗示 Lark delivered。

## Scope / 范围
28 files (+1517/-170)，含 NotifyModuleTests / FeishuCardNotificationPortTests / WorkflowInteractionNotificationProjectorTests / proto round-trip / guard 测试。base = `crnd/integrate-1854`。

## 评审历史
设计 design-consensus r? 达成 `consensus:structural:independent-notify-typed-event-chain-accepted-only-ack`。本 PR 为对应 fresh 实现（旧占位/污染分支已弃，force-update 到当前 tip）。

🤖 controller (consensus-rnd loop)

⟦AI:AUTO-LOOP⟧
