### PR TITLE
feat(#1859): run-level on_failure auto fork-from-failed-step + coordinator

### DIFF
--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -52,6 +52,7 @@ message WorkflowRunResumeSeed
   string source_run_id = 1;
   string start_at_step_id = 2;
   map<string, string> variables = 3;
+  int32 attempt = 4;
 }
 
 message WorkflowRunForkRequestedEvent
@@ -95,6 +96,7 @@ message WorkflowRunExecutionStartedEvent
   string definition_actor_id = 4;
   string scope_id = 5;
   WorkflowRunExecutionContextDelta execution_context_delta = 6;
+  int32 attempt = 7;
 }
 message WorkflowRunExecutionContextDelta
 {

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/RunForks/WorkflowForkRunModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/RunForks/WorkflowForkRunModels.cs
@@ -8,7 +8,8 @@ public sealed record WorkflowForkRunCommand(
     IReadOnlyDictionary<string, string>? VariableOverrides = null,
     string? Input = null,
     string? CommandId = null,
-    string? CorrelationId = null);
+    string? CorrelationId = null,
+    int Attempt = 0);
 
 public enum WorkflowForkRunStartErrorCode
 {

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunModels.cs
@@ -33,7 +33,8 @@ public sealed record WorkflowCallerCredential(string? BearerToken = null);
 public sealed record WorkflowChatRunResumeSeed(
     string SourceRunId,
     string StartAtStepId,
-    IReadOnlyDictionary<string, string> Variables);
+    IReadOnlyDictionary<string, string> Variables,
+    int Attempt = 0);
 
 public enum WorkflowChatSourceKind
 {

--- a/src/workflow/Aevatar.Workflow.Application/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/workflow/Aevatar.Workflow.Application/DependencyInjection/ServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ using Aevatar.Workflow.Application.RunForks;
 using Aevatar.Workflow.Application.Runs;
 using Aevatar.Workflow.Application.Schedules;
 using Aevatar.Workflow.Application.Workflows;
+using Aevatar.Foundation.Abstractions.EventSourcing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -61,6 +62,9 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<ICommandTargetResolver<WorkflowChatRunRequest, WorkflowRunAcceptedCommandTarget, WorkflowChatRunStartError>, WorkflowRunAcceptedCommandTargetResolver>();
         services.AddSingleton<ICommandEnvelopeFactory<WorkflowChatRunRequest>, WorkflowChatRequestEnvelopeFactory>();
         services.TryAddSingleton<IWorkflowForkRunService, WorkflowForkRunService>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            ICommittedStatePublicationHook,
+            WorkflowRunForkCoordinator>());
         services.AddSingleton<ICommandTargetDispatcher<WorkflowRunCommandTarget>, ActorCommandTargetDispatcher<WorkflowRunCommandTarget>>();
         services.AddSingleton<ICommandTargetDispatcher<WorkflowRunAcceptedCommandTarget>, ActorCommandTargetDispatcher<WorkflowRunAcceptedCommandTarget>>();
         services.AddSingleton<ICommandReceiptFactory<WorkflowRunCommandTarget, WorkflowChatRunAcceptedReceipt>, WorkflowRunAcceptedReceiptFactory>();

--- a/src/workflow/Aevatar.Workflow.Application/RunForks/WorkflowForkRunService.cs
+++ b/src/workflow/Aevatar.Workflow.Application/RunForks/WorkflowForkRunService.cs
@@ -93,7 +93,8 @@ public sealed class WorkflowForkRunService : IWorkflowForkRunService
             ResumeSeed: new WorkflowChatRunResumeSeed(
                 sourceRunId,
                 startAtStepId,
-                variables),
+                variables,
+                Math.Max(0, command.Attempt)),
             TargetSeed: new WorkflowRunTargetSeed(
                 creationReceipt.ActorId,
                 validation.WorkflowName,

--- a/src/workflow/Aevatar.Workflow.Application/RunForks/WorkflowRunForkCoordinator.cs
+++ b/src/workflow/Aevatar.Workflow.Application/RunForks/WorkflowRunForkCoordinator.cs
@@ -1,0 +1,72 @@
+using Aevatar.Foundation.Abstractions.EventSourcing;
+using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Application.Abstractions.RunForks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.Workflow.Application.RunForks;
+
+internal sealed class WorkflowRunForkCoordinator : ICommittedStatePublicationHook
+{
+    private readonly IWorkflowForkRunService _forkRunService;
+    private readonly ILogger<WorkflowRunForkCoordinator> _logger;
+
+    public WorkflowRunForkCoordinator(
+        IWorkflowForkRunService forkRunService,
+        ILogger<WorkflowRunForkCoordinator>? logger = null)
+    {
+        _forkRunService = forkRunService ?? throw new ArgumentNullException(nameof(forkRunService));
+        _logger = logger ?? NullLogger<WorkflowRunForkCoordinator>.Instance;
+    }
+
+    public async Task BeforePublishAsync(CommittedStatePublicationContext context, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ct.ThrowIfCancellationRequested();
+
+        if (context.Published.StateEvent?.EventData?.Is(WorkflowRunForkRequestedEvent.Descriptor) != true)
+            return;
+
+        var requested = context.Published.StateEvent.EventData.Unpack<WorkflowRunForkRequestedEvent>();
+        if (string.IsNullOrWhiteSpace(requested.SourceRunId) ||
+            string.IsNullOrWhiteSpace(requested.StartAtStepId))
+        {
+            _logger.LogWarning(
+                "Ignoring workflow fork request with missing source or step. source={SourceRunId} step={StartAtStepId}",
+                requested.SourceRunId,
+                requested.StartAtStepId);
+            return;
+        }
+
+        try
+        {
+            var result = await _forkRunService.ForkAsync(
+                new WorkflowForkRunCommand(
+                    SourceRunId: requested.SourceRunId,
+                    StartAtStepId: requested.StartAtStepId,
+                    InlineYaml: null,
+                    Attempt: Math.Max(0, requested.Attempt)),
+                ct).ConfigureAwait(false);
+
+            if (!result.Succeeded)
+            {
+                _logger.LogWarning(
+                    "Workflow fork request failed. source={SourceRunId} step={StartAtStepId} attempt={Attempt} code={ErrorCode} reason={Reason}",
+                    requested.SourceRunId,
+                    requested.StartAtStepId,
+                    requested.Attempt,
+                    result.Error?.Code,
+                    result.Error?.Reason);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Workflow fork coordinator failed. source={SourceRunId} step={StartAtStepId} attempt={Attempt}",
+                requested.SourceRunId,
+                requested.StartAtStepId,
+                requested.Attempt);
+        }
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs
@@ -107,6 +107,7 @@ internal sealed class WorkflowChatRequestEnvelopeFactory : ICommandEnvelopeFacto
         {
             SourceRunId = source.SourceRunId ?? string.Empty,
             StartAtStepId = source.StartAtStepId ?? string.Empty,
+            Attempt = source.Attempt,
         };
         AppendVariables(payload.Variables, source.Variables);
         return payload;

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
@@ -343,7 +343,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                     runId,
                     evt.StepId,
                     evt.Error);
-                await CleanupRunAsync(state, ctx, ct);
+                await CleanupRunAsync(state, ctx, ct, preserveTerminalFacts: true, preserveCurrentStepInputVariable: true);
                 await PublishWorkflowCompletedAsync(
                     ctx,
                     new WorkflowCompletedEvent
@@ -367,7 +367,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                 runId,
                 evt.StepId,
                 evt.Error);
-            await CleanupRunAsync(state, ctx, ct);
+            await CleanupRunAsync(state, ctx, ct, preserveTerminalFacts: true, preserveCurrentStepInputVariable: true);
             await PublishWorkflowCompletedAsync(
                 ctx,
                 new WorkflowCompletedEvent
@@ -397,7 +397,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                     runId,
                     current.Id,
                     directNextStepId);
-                await CleanupRunAsync(state, ctx, ct);
+                await CleanupRunAsync(state, ctx, ct, preserveTerminalFacts: true, preserveCurrentStepInputVariable: true);
                 await PublishWorkflowCompletedAsync(
                     ctx,
                     new WorkflowCompletedEvent
@@ -418,7 +418,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
 
         if (next == null)
         {
-            await CleanupRunAsync(state, ctx, ct);
+            await CleanupRunAsync(state, ctx, ct, preserveTerminalFacts: true);
             await PublishWorkflowCompletedAsync(
                 ctx,
                 new WorkflowCompletedEvent
@@ -692,7 +692,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                 var next = _workflow.GetNextStep(step.Id);
                 if (next == null)
                 {
-                    await CleanupRunAsync(state, ctx, ct);
+                    await CleanupRunAsync(state, ctx, ct, preserveTerminalFacts: true);
                     await PublishWorkflowCompletedAsync(
                         ctx,
                         new WorkflowCompletedEvent
@@ -884,23 +884,41 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
     private async Task CleanupRunAsync(
         WorkflowExecutionKernelState state,
         IWorkflowExecutionContext ctx,
-        CancellationToken ct)
+        CancellationToken ct,
+        bool preserveTerminalFacts = false,
+        bool preserveCurrentStepInputVariable = false)
     {
         var timeoutLeases = state.TimeoutsByStepId.Values.ToList();
         var retryLeases = state.RetryBackoffsByStepId.Values.Select(x => x.Lease).ToList();
+        var terminalStepId = preserveTerminalFacts
+            ? state.CurrentStepId
+            : string.Empty;
+        var terminalStepInput = preserveTerminalFacts
+            ? state.CurrentStepInput
+            : string.Empty;
+        var terminalVariables = preserveTerminalFacts
+            ? state.Variables.ToDictionary(x => x.Key, x => x.Value, StringComparer.Ordinal)
+            : [];
+        var terminalUsage = preserveTerminalFacts
+            ? state.Usage?.Clone() ?? new WorkflowUsageMetricsState()
+            : new WorkflowUsageMetricsState();
 
         state.Active = false;
         state.RunId = string.Empty;
-        state.CurrentStepId = string.Empty;
-        state.CurrentStepInput = string.Empty;
+        state.CurrentStepId = terminalStepId;
+        state.CurrentStepInput = terminalStepInput;
         state.CurrentStepDispatchPending = false;
         state.CurrentStepTimeoutCallbackId = string.Empty;
         state.Variables.Clear();
+        foreach (var (key, value) in terminalVariables)
+            state.Variables[key] = value ?? string.Empty;
+        if (preserveCurrentStepInputVariable && !string.IsNullOrWhiteSpace(terminalStepInput))
+            state.Variables["input"] = terminalStepInput;
         state.RetryAttemptsByStepId.Clear();
         state.TimeoutsByStepId.Clear();
         state.RetryBackoffsByStepId.Clear();
         state.ExecutionIdsByStepId.Clear();
-        state.Usage = new WorkflowUsageMetricsState();
+        state.Usage = terminalUsage;
         await SaveStateAsync(state, ctx, ct);
 
         foreach (var lease in timeoutLeases)

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowDefinition.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowDefinition.cs
@@ -41,6 +41,11 @@ public sealed class WorkflowDefinition
     public WorkflowRuntimeConfiguration Configuration { get; init; } = new();
 
     /// <summary>
+    /// Run-level failure policy. Null means terminal failure is not auto-driven.
+    /// </summary>
+    public WorkflowRunFailurePolicy? OnFailure { get; init; }
+
+    /// <summary>
     /// 入口步骤 ID，即第一个步骤的 ID；若无步骤则为 null。
     /// </summary>
     public string? EntryStepId => Steps.Count > 0 ? Steps[0].Id : null;
@@ -93,6 +98,18 @@ public sealed class WorkflowRuntimeConfiguration
     /// Compatibility flag preserved in workflow YAML.
     /// </summary>
     public bool ClosedWorldMode { get; init; }
+}
+
+public sealed class WorkflowRunFailurePolicy
+{
+    public string Action { get; init; } = string.Empty;
+
+    public int MaxAttempts { get; init; }
+}
+
+public static class WorkflowRunFailureActions
+{
+    public const string ForkFromFailedStep = "fork_from_failed_step";
 }
 
 /// <summary>

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowParser.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowParser.cs
@@ -93,6 +93,7 @@ public sealed class WorkflowParser
             {
                 ClosedWorldMode = raw.Configuration?.ClosedWorldMode ?? false,
             },
+            OnFailure = MapOnFailure(raw.OnFailure),
         };
     }
 
@@ -401,7 +402,23 @@ public sealed class WorkflowParser
             DefaultOutput = e.DefaultOutput,
         };
 
-    private sealed class Raw { public string? Name { get; set; } public string? Description { get; set; } public string? WhenToUse { get; set; } public List<RawRole>? Roles { get; set; } public List<RawStep>? Steps { get; set; } public RawConfiguration? Configuration { get; set; } }
+    private static WorkflowRunFailurePolicy? MapOnFailure(RawOnFailure? policy)
+    {
+        if (policy == null)
+            return null;
+
+        var action = NormalizeText(policy.Action);
+        if (action == null)
+            return null;
+
+        return new WorkflowRunFailurePolicy
+        {
+            Action = action,
+            MaxAttempts = policy.MaxAttempts ?? 0,
+        };
+    }
+
+    private sealed class Raw { public string? Name { get; set; } public string? Description { get; set; } public string? WhenToUse { get; set; } public List<RawRole>? Roles { get; set; } public List<RawStep>? Steps { get; set; } public RawConfiguration? Configuration { get; set; } public RawOnFailure? OnFailure { get; set; } }
     private sealed class RawRole
     {
         // Refactor (iter30/cluster-030-workflow-step-raw-actor-lifecycle):
@@ -496,5 +513,6 @@ public sealed class WorkflowParser
         public string? DefaultOutput { get; set; }
     }
     private sealed class RawConfiguration { public bool? ClosedWorldMode { get; set; } }
+    private sealed class RawOnFailure { public string? Action { get; set; } public int? MaxAttempts { get; set; } }
     private sealed class RawRoleExtensions { public string? EventModules { get; set; } public string? EventRoutes { get; set; } }
 }

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
@@ -282,6 +282,7 @@ public sealed class WorkflowRunGAgent
             DefinitionActorId = State.DefinitionActorId ?? string.Empty,
             ScopeId = ResolveScopeId(request.ScopeId, State.ScopeId),
             ExecutionContextDelta = executionContextDelta,
+            Attempt = Math.Max(0, request.ResumeSeed?.Attempt ?? 0),
         });
 
         await PublishAsync(new StartWorkflowEvent
@@ -339,6 +340,7 @@ public sealed class WorkflowRunGAgent
             Input = request.Input ?? string.Empty,
             DefinitionActorId = State.DefinitionActorId ?? string.Empty,
             ScopeId = State.ScopeId ?? string.Empty,
+            Attempt = State.ForkAttempt,
         });
 
         await PublishAsync(new StartWorkflowEvent
@@ -479,6 +481,7 @@ public sealed class WorkflowRunGAgent
     {
         var stateBeforeCompletion = State.Clone();
         await PersistDomainEventAsync(evt);
+        await PersistForkRequestOnTerminalFailureAsync(evt, stateBeforeCompletion, CancellationToken.None);
         await _subWorkflowOrchestrator.CancelPendingDefinitionResolutionTimeoutsAsync(stateBeforeCompletion, CancellationToken.None);
         await _subWorkflowOrchestrator.CleanupPendingInvocationsForRunAsync(evt.RunId, stateBeforeCompletion, CancellationToken.None);
         await CleanupRoleAgentTreeAsync(CancellationToken.None);
@@ -510,6 +513,50 @@ public sealed class WorkflowRunGAgent
             Content = evt.Success ? evt.Output : $"Workflow execution failed: {evt.Error}",
             Error = evt.Success ? string.Empty : evt.Error,
         }, TopologyAudience.Parent);
+    }
+
+    private async Task PersistForkRequestOnTerminalFailureAsync(
+        WorkflowCompletedEvent evt,
+        WorkflowRunState stateBeforeCompletion,
+        CancellationToken ct)
+    {
+        if (evt.Success || _compiledWorkflow?.OnFailure == null)
+            return;
+
+        var policy = _compiledWorkflow.OnFailure;
+        if (!string.Equals(
+                policy.Action,
+                WorkflowRunFailureActions.ForkFromFailedStep,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var maxAttempts = Math.Max(0, policy.MaxAttempts);
+        var currentAttempt = Math.Max(0, State.ForkAttempt);
+        if (currentAttempt >= maxAttempts)
+            return;
+
+        var failedStepId = ResolveLastFailedStepId(State);
+        if (string.IsNullOrWhiteSpace(failedStepId))
+            failedStepId = ResolveLastFailedStepId(stateBeforeCompletion);
+        if (string.IsNullOrWhiteSpace(failedStepId))
+        {
+            Logger.LogWarning(
+                "Workflow run {RunId} failed with on_failure fork policy but no failed step id was available.",
+                evt.RunId);
+            return;
+        }
+
+        await PersistDomainEventAsync(
+            new WorkflowRunForkRequestedEvent
+            {
+                SourceRunId = string.IsNullOrWhiteSpace(evt.RunId) ? RunId : WorkflowRunIdNormalizer.Normalize(evt.RunId),
+                StartAtStepId = failedStepId,
+                Attempt = currentAttempt + 1,
+                ScopeId = State.ScopeId ?? string.Empty,
+            },
+            ct);
     }
 
     [EventHandler]
@@ -767,6 +814,7 @@ public sealed class WorkflowRunGAgent
         next.Input = string.Empty;
         next.FinalOutput = string.Empty;
         next.FinalError = string.Empty;
+        next.ForkAttempt = 0;
         next.ExecutionStates.Clear();
         next.ExecutionContext = new WorkflowRunExecutionContextState();
         next.SubWorkflowBindings.Clear();
@@ -804,6 +852,7 @@ public sealed class WorkflowRunGAgent
         next.Status = RunningStatus;
         next.FinalOutput = string.Empty;
         next.FinalError = string.Empty;
+        next.ForkAttempt = Math.Max(0, evt.Attempt);
         next.ExecutionContext ??= new WorkflowRunExecutionContextState();
         ApplyExecutionContextDelta(next.ExecutionContext, evt.ExecutionContextDelta);
         if (string.IsNullOrWhiteSpace(next.DefinitionActorId) && !string.IsNullOrWhiteSpace(evt.DefinitionActorId))
@@ -970,6 +1019,17 @@ public sealed class WorkflowRunGAgent
         string.Equals(status, CompletedStatus, StringComparison.OrdinalIgnoreCase) ||
         string.Equals(status, FailedStatus, StringComparison.OrdinalIgnoreCase) ||
         string.Equals(status, StoppedStatus, StringComparison.OrdinalIgnoreCase);
+
+    private static string ResolveLastFailedStepId(WorkflowRunState state)
+    {
+        foreach (var packedState in state.ExecutionStates.Values)
+        {
+            if (packedState?.Is(WorkflowExecutionKernelState.Descriptor) == true)
+                return packedState.Unpack<WorkflowExecutionKernelState>().CurrentStepId?.Trim() ?? string.Empty;
+        }
+
+        return string.Empty;
+    }
 
     private static string BuildStoppedMessage(string? reason) =>
         string.IsNullOrWhiteSpace(reason)

--- a/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
+++ b/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
@@ -142,6 +142,7 @@ message WorkflowRunState
   repeated PendingSubWorkflowDefinitionResolution pending_sub_workflow_definition_resolutions = 19;
   map<string, int32> pending_sub_workflow_definition_resolution_index_by_invocation_id = 20;
   WorkflowRunExecutionContextState execution_context = 21;
+  int32 fork_attempt = 22;
 }
 
 message WorkflowRunExecutionContextState

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunForkCoordinatorTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunForkCoordinatorTests.cs
@@ -1,0 +1,76 @@
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.EventSourcing;
+using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Application.Abstractions.RunForks;
+using Aevatar.Workflow.Application.RunForks;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Workflow.Application.Tests;
+
+public sealed class WorkflowRunForkCoordinatorTests
+{
+    [Fact]
+    public async Task BeforePublishAsync_WhenCommittedForkRequestedEvent_ShouldCallForkService()
+    {
+        var forkService = new RecordingForkRunService();
+        var coordinator = new WorkflowRunForkCoordinator(forkService);
+        var requested = new WorkflowRunForkRequestedEvent
+        {
+            SourceRunId = "run-source",
+            StartAtStepId = "failed-step",
+            Attempt = 2,
+            ScopeId = "scope-1",
+        };
+
+        await coordinator.BeforePublishAsync(CreateContext(requested), CancellationToken.None);
+
+        forkService.Commands.Should().ContainSingle();
+        var command = forkService.Commands.Single();
+        command.SourceRunId.Should().Be("run-source");
+        command.StartAtStepId.Should().Be("failed-step");
+        command.InlineYaml.Should().BeNull();
+        command.Attempt.Should().Be(2);
+    }
+
+    private static CommittedStatePublicationContext CreateContext(IMessage evt) =>
+        new()
+        {
+            ActorId = "run-source",
+            ActorType = typeof(object),
+            Published = new CommittedStateEventPublished
+            {
+                StateEvent = new StateEvent
+                {
+                    AgentId = "run-source",
+                    EventId = Guid.NewGuid().ToString("N"),
+                    Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+                    Version = 1,
+                    EventType = evt.Descriptor.FullName,
+                    EventData = Any.Pack(evt),
+                },
+            },
+        };
+
+    private sealed class RecordingForkRunService : IWorkflowForkRunService
+    {
+        public List<WorkflowForkRunCommand> Commands { get; } = [];
+
+        public Task<WorkflowForkRunResult> ForkAsync(
+            WorkflowForkRunCommand command,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Commands.Add(command);
+            return Task.FromResult(WorkflowForkRunResult.Accepted(new WorkflowForkRunAcceptedReceipt(
+                command.SourceRunId,
+                "new-run",
+                "wf",
+                true,
+                "cmd",
+                "corr",
+                DateTimeOffset.UtcNow)));
+        }
+    }
+}

--- a/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowParserCoverageTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowParserCoverageTests.cs
@@ -200,6 +200,43 @@ public sealed class WorkflowParserCoverageTests
     }
 
     [Fact]
+    public void Parse_WhenRunOnFailureIsPresent_ShouldMapRunLevelPolicy()
+    {
+        var workflow = new WorkflowParser().Parse(
+            """
+            name: run_on_failure
+            on_failure:
+              action: fork_from_failed_step
+              max_attempts: 3
+            roles: []
+            steps:
+              - id: step_1
+                type: transform
+            """);
+
+        workflow.OnFailure.Should().NotBeNull();
+        workflow.OnFailure!.Action.Should().Be(WorkflowRunFailureActions.ForkFromFailedStep);
+        workflow.OnFailure.MaxAttempts.Should().Be(3);
+        workflow.Steps[0].Retry.Should().BeNull();
+        workflow.Steps[0].OnError.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_WhenRunOnFailureIsAbsent_ShouldLeavePolicyNull()
+    {
+        var workflow = new WorkflowParser().Parse(
+            """
+            name: no_run_on_failure
+            roles: []
+            steps:
+              - id: step_1
+                type: transform
+            """);
+
+        workflow.OnFailure.Should().BeNull();
+    }
+
+    [Fact]
     public void Parse_WhenStepIdIsMissing_ShouldThrow()
     {
         Action act = () => new WorkflowParser().Parse(

--- a/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentForkOnFailureTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentForkOnFailureTests.cs
@@ -1,0 +1,400 @@
+using System.Reflection;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.EventModules;
+using Aevatar.Foundation.Abstractions.EventSourcing;
+using Aevatar.Foundation.Abstractions.Hooks;
+using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Foundation.Core;
+using Aevatar.Foundation.Core.EventSourcing;
+using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Core.Composition;
+using Aevatar.Workflow.Core.Execution;
+using Aevatar.Workflow.Core.Modules;
+using Aevatar.Workflow.Abstractions.Execution;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.Workflow.Core.Tests;
+
+public sealed class WorkflowRunGAgentForkOnFailureTests
+{
+    [Fact]
+    public async Task TerminalFailedRun_WithForkPolicy_ShouldCommitForkRequestedEvent()
+    {
+        var harness = await CreateStartedRunAsync(WorkflowYaml(onFailure: true), attempt: 1);
+
+        await harness.Agent.HandleEventAsync(SelfEnvelope(harness.RunId, new StepCompletedEvent
+        {
+            RunId = harness.RunId,
+            StepId = "failed-step",
+            Success = false,
+            Error = "boom",
+            ExecutionId = harness.StepExecutionId,
+        }));
+
+        var requested = harness.CommittedPublisher.Events
+            .Select(TryUnpackForkRequest)
+            .OfType<WorkflowRunForkRequestedEvent>()
+            .Should()
+            .ContainSingle()
+            .Subject;
+        requested.SourceRunId.Should().Be(harness.RunId);
+        requested.StartAtStepId.Should().Be("failed-step");
+        requested.Attempt.Should().Be(2);
+        requested.ScopeId.Should().Be("scope-1");
+    }
+
+    [Fact]
+    public async Task TerminalFailedRun_WithoutForkPolicy_ShouldNotCommitForkRequestedEvent()
+    {
+        var harness = await CreateStartedRunAsync(WorkflowYaml(onFailure: false), attempt: 0);
+
+        await harness.Agent.HandleEventAsync(SelfEnvelope(harness.RunId, new StepCompletedEvent
+        {
+            RunId = harness.RunId,
+            StepId = "failed-step",
+            Success = false,
+            Error = "boom",
+            ExecutionId = harness.StepExecutionId,
+        }));
+
+        harness.CommittedPublisher.Events
+            .Select(TryUnpackForkRequest)
+            .OfType<WorkflowRunForkRequestedEvent>()
+            .Should()
+            .BeEmpty();
+    }
+
+    [Fact]
+    public async Task TerminalFailedRun_WhenAttemptReachedMax_ShouldNotCommitForkRequestedEvent()
+    {
+        var harness = await CreateStartedRunAsync(WorkflowYaml(onFailure: true, maxAttempts: 2), attempt: 2);
+
+        await harness.Agent.HandleEventAsync(SelfEnvelope(harness.RunId, new StepCompletedEvent
+        {
+            RunId = harness.RunId,
+            StepId = "failed-step",
+            Success = false,
+            Error = "boom",
+            ExecutionId = harness.StepExecutionId,
+        }));
+
+        harness.CommittedPublisher.Events
+            .Select(TryUnpackForkRequest)
+            .OfType<WorkflowRunForkRequestedEvent>()
+            .Should()
+            .BeEmpty();
+    }
+
+    private static async Task<RunHarness> CreateStartedRunAsync(string workflowYaml, int attempt)
+    {
+        var runId = "run-1859-" + Guid.NewGuid().ToString("N");
+        var eventStore = new RecordingEventStore();
+        var committedHook = new RecordingCommittedStatePublicationHook();
+        var topologyPublisher = new RecordingEventPublisher(runId);
+        var agent = new WorkflowRunGAgent(
+            new UnsupportedActorRuntime(),
+            new UnsupportedActorRuntime(),
+            new EmptyEventModuleFactory(),
+            [new EmptyWorkflowModulePack()])
+        {
+            EventSourcingBehaviorFactory = new DefaultEventSourcingBehaviorFactory<WorkflowRunState>(eventStore),
+            EventPublisher = topologyPublisher,
+            Services = new TestServiceProvider(new NoopRuntimeCallbackScheduler(), committedHook),
+            Logger = NullLogger.Instance,
+        };
+        SetAgentId(agent, runId);
+        topologyPublisher.Agent = agent;
+        await agent.ActivateAsync();
+
+        await agent.HandleEventAsync(EnvelopeFrom("workflow-run-actor-port", new BindWorkflowRunDefinitionEvent
+        {
+            DefinitionActorId = "definition-1859",
+            WorkflowName = "wf_1859",
+            WorkflowYaml = workflowYaml,
+            RunId = runId,
+            ScopeId = "scope-1",
+        }));
+        await agent.HandleEventAsync(EnvelopeFrom("api", new WorkflowChatRequestEvent
+        {
+            Prompt = "hello",
+            ScopeId = "scope-1",
+            ResumeSeed = new WorkflowRunResumeSeed
+            {
+                Attempt = attempt,
+            },
+        }));
+
+        var stepRequest = topologyPublisher.Published
+            .Where(x => x.Event is StepRequestEvent)
+            .Select(x => (StepRequestEvent)x.Event)
+            .Should()
+            .ContainSingle()
+            .Subject;
+
+        return new RunHarness(agent, runId, stepRequest.ExecutionId, committedHook);
+    }
+
+    private static WorkflowRunForkRequestedEvent? TryUnpackForkRequest(CommittedStateEventPublished published)
+    {
+        if (published.StateEvent?.EventData?.Is(WorkflowRunForkRequestedEvent.Descriptor) != true)
+            return null;
+
+        return published.StateEvent.EventData.Unpack<WorkflowRunForkRequestedEvent>();
+    }
+
+    private static EventEnvelope SelfEnvelope(string runId, IMessage payload) =>
+        EnvelopeFrom(runId, payload);
+
+    private static EventEnvelope EnvelopeFrom(string publisherActorId, IMessage payload) =>
+        new()
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(payload),
+            Route = EnvelopeRouteSemantics.CreateTopologyPublication(publisherActorId, TopologyAudience.Self),
+            Propagation = new EnvelopePropagation
+            {
+                CorrelationId = Guid.NewGuid().ToString("N"),
+            },
+        };
+
+    private static string WorkflowYaml(bool onFailure, int maxAttempts = 3) =>
+        onFailure
+            ? $$"""
+                name: wf_1859
+                on_failure:
+                  action: fork_from_failed_step
+                  max_attempts: {{maxAttempts}}
+                roles: []
+                steps:
+                  - id: failed-step
+                    type: transform
+                """
+            : """
+                name: wf_1859
+                roles: []
+                steps:
+                  - id: failed-step
+                    type: transform
+                """;
+
+    private static void SetAgentId(GAgentBase agent, string agentId)
+    {
+        var setIdMethod = typeof(GAgentBase).GetMethod(
+            "SetId",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        setIdMethod.Should().NotBeNull();
+        setIdMethod!.Invoke(agent, [agentId]);
+    }
+
+    private sealed record RunHarness(
+        WorkflowRunGAgent Agent,
+        string RunId,
+        string StepExecutionId,
+        RecordingCommittedStatePublicationHook CommittedPublisher);
+
+    private sealed class EmptyWorkflowModulePack : IWorkflowModulePack
+    {
+        public string Name => "test.empty";
+
+        public IReadOnlyList<WorkflowModuleRegistration> Modules { get; } =
+        [
+            WorkflowModuleRegistration.Create<TransformModule>("transform"),
+        ];
+
+        public IReadOnlyList<IWorkflowModuleDependencyExpander> DependencyExpanders { get; } = [];
+
+        public IReadOnlyList<IWorkflowModuleConfigurator> Configurators { get; } = [];
+    }
+
+    private sealed class EmptyEventModuleFactory : IEventModuleFactory<IWorkflowExecutionContext>
+    {
+        public bool TryCreate(string name, out IEventModule<IWorkflowExecutionContext>? module)
+        {
+            _ = name;
+            module = null;
+            return false;
+        }
+    }
+
+    private sealed class RecordingEventPublisher(string runId) : IEventPublisher
+    {
+        public List<(IMessage Event, TopologyAudience Audience)> Published { get; } = [];
+
+        public async Task PublishAsync<T>(
+            T evt,
+            TopologyAudience audience,
+            CancellationToken ct,
+            EventEnvelope? sourceEnvelope,
+            EventEnvelopePublishOptions? options)
+            where T : IMessage
+        {
+            ct.ThrowIfCancellationRequested();
+            Published.Add((evt, audience));
+
+            if (audience == TopologyAudience.Self)
+                await Agent.HandleEventAsync(SelfEnvelope(runId, evt), ct);
+        }
+
+        public WorkflowRunGAgent Agent { get; set; } = null!;
+
+        public Task SendToAsync<T>(
+            string targetActorId,
+            T evt,
+            CancellationToken ct,
+            EventEnvelope? sourceEnvelope,
+            EventEnvelopePublishOptions? options)
+            where T : IMessage =>
+            Task.CompletedTask;
+    }
+
+    private sealed class RecordingCommittedStatePublicationHook : ICommittedStatePublicationHook
+    {
+        public List<CommittedStateEventPublished> Events { get; } = [];
+
+        public Task BeforePublishAsync(CommittedStatePublicationContext context, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            Events.Add(context.Published.Clone());
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingEventStore : IEventStore
+    {
+        private readonly Dictionary<string, List<StateEvent>> _streams = new(StringComparer.Ordinal);
+
+        public Task<EventStoreCommitResult> AppendAsync(
+            string agentId,
+            IEnumerable<StateEvent> events,
+            long expectedVersion,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            var stream = _streams.GetValueOrDefault(agentId) ?? [];
+            var currentVersion = stream.Count == 0 ? 0 : stream[^1].Version;
+            currentVersion.Should().Be(expectedVersion);
+
+            var committed = events.Select(x => x.Clone()).ToList();
+            stream.AddRange(committed);
+            _streams[agentId] = stream;
+
+            return Task.FromResult(new EventStoreCommitResult
+            {
+                AgentId = agentId,
+                LatestVersion = stream.Count == 0 ? 0 : stream[^1].Version,
+                CommittedEvents = { committed },
+            });
+        }
+
+        public Task<IReadOnlyList<StateEvent>> GetEventsAsync(
+            string agentId,
+            long? fromVersion = null,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            var events = _streams.GetValueOrDefault(agentId) ?? [];
+            return Task.FromResult<IReadOnlyList<StateEvent>>(
+                events
+                    .Where(x => !fromVersion.HasValue || x.Version >= fromVersion.Value)
+                    .Select(x => x.Clone())
+                    .ToArray());
+        }
+
+        public Task<long> GetVersionAsync(string agentId, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            var events = _streams.GetValueOrDefault(agentId) ?? [];
+            return Task.FromResult(events.Count == 0 ? 0 : events[^1].Version);
+        }
+
+        public Task<long> DeleteEventsUpToAsync(
+            string agentId,
+            long toVersion,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!_streams.TryGetValue(agentId, out var stream))
+                return Task.FromResult(0L);
+
+            var removed = stream.RemoveAll(x => x.Version <= toVersion);
+            return Task.FromResult((long)removed);
+        }
+    }
+
+    private sealed class TestServiceProvider(
+        NoopRuntimeCallbackScheduler scheduler,
+        RecordingCommittedStatePublicationHook committedHook) : IServiceProvider
+    {
+        public object? GetService(System.Type serviceType)
+        {
+            if (serviceType == typeof(IEnumerable<IGAgentExecutionHook>))
+                return Array.Empty<IGAgentExecutionHook>();
+            if (serviceType == typeof(IActorRuntimeCallbackScheduler))
+                return scheduler;
+            if (serviceType == typeof(IEnumerable<ICommittedStatePublicationHook>))
+                return new ICommittedStatePublicationHook[] { committedHook };
+
+            return null;
+        }
+    }
+
+    private sealed class NoopRuntimeCallbackScheduler : IActorRuntimeCallbackScheduler
+    {
+        public Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
+            RuntimeCallbackTimeoutRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                1,
+                RuntimeCallbackBackend.InMemory));
+
+        public Task<RuntimeCallbackLease> ScheduleTimerAsync(
+            RuntimeCallbackTimerRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                1,
+                RuntimeCallbackBackend.InMemory));
+
+        public Task CancelAsync(RuntimeCallbackLease lease, CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task PurgeActorAsync(string actorId, CancellationToken ct = default) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class UnsupportedActorRuntime : IActorRuntime, IActorDispatchPort
+    {
+        public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
+            where TAgent : IAgent =>
+            throw new NotSupportedException();
+
+        public Task<IActor> CreateAsync(System.Type agentType, string? id = null, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task DestroyAsync(string id, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<IActor?> GetAsync(string id) =>
+            throw new NotSupportedException();
+
+        public Task<bool> ExistsAsync(string id) =>
+            throw new NotSupportedException();
+
+        public Task LinkAsync(string parentId, string childId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task UnlinkAsync(string childId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<DispatchAdmission> DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
+}

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowAbstractionsProtoCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowAbstractionsProtoCoverageTests.cs
@@ -17,6 +17,7 @@ public class WorkflowAbstractionsProtoCoverageTests
             {
                 SourceRunId = "run-source",
                 StartAtStepId = "step-b",
+                Attempt = 1,
             },
         };
         evt.Parameters["k"] = "v";
@@ -31,6 +32,7 @@ public class WorkflowAbstractionsProtoCoverageTests
         parsed.Parameters["k"].Should().Be("v");
         parsed.ResumeSeed.SourceRunId.Should().Be("run-source");
         parsed.ResumeSeed.StartAtStepId.Should().Be("step-b");
+        parsed.ResumeSeed.Attempt.Should().Be(1);
         parsed.ResumeSeed.Variables["step-a"].Should().Be("alpha");
     }
 
@@ -41,6 +43,7 @@ public class WorkflowAbstractionsProtoCoverageTests
         {
             SourceRunId = "run-source",
             StartAtStepId = "step-b",
+            Attempt = 2,
         };
         seed.Variables["step-a"] = "alpha";
 


### PR DESCRIPTION
S5 of epic #1854（自动 driver，最后一单元）。承接 #1859。spec §10。

## 内容
- **run 级 `on_failure`**：`WorkflowParser`/`WorkflowDefinition` 解析顶层 `on_failure:{action:fork_from_failed_step, max_attempts:N}`（区别 step 级 retry/on_error）。
- **失败发事件**：`WorkflowRunGAgent` 终态失败时（在 actor 事件处理流程内）按策略 + `fork_attempt < max_attempts` 发 committed `WorkflowRunForkRequestedEvent{attempt+1}`。
- **attempt 跨 fork 链传播**（真正兜底 max_attempts）：event.attempt → command → seed → proto → `WorkflowRunExecutionStartedEvent.attempt` → `WorkflowRunState.fork_attempt`。
- **`WorkflowRunForkCoordinator`**（`ICommittedStatePublicationHook`）消费 committed 事件 → `IWorkflowForkRunService.ForkAsync(InlineYaml:null=复用源 YAML)`；不依赖持久定义 GAgent（覆盖 inline run）。

## ⚠️ 行为变更（repo-wide，需知悉）
kernel `CleanupRunAsync` 现在**终态保留执行事实**（CurrentStepId/Variables），而非清空——这是"fork 任意终态 run"必需的（否则失败 run 的 seed 读不到，整个特性失效；前面 S1-S4 漏了这点）。影响：终态 run 的 kernel 变量会保留（轻微存储增加），换取可 fork 性。

## 验证
build 0 err；Core.Tests 436 ✓、Application.Tests 263 ✓；architecture_guards + test_stability_guards 通过。额外跑 `Aevatar.Integration.Tests`：workflow 相关全绿（WorkflowGAgentCoverageTests 52/52 含 ExecutionStates 断言）；仅 2 个**无关的 flaky scripting E2E**（ScriptingServiceRevisionRepublish/ScriptAutonomousEvolution，已确认 S4 baseline 同样失败/flaky，非本 PR 引入）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)