### PR TITLE
将 scheduled_agent_creator 调整为无需远程审批

### DIFF
--- a/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentCreatorTool.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentCreatorTool.cs
@@ -127,7 +127,7 @@ public sealed class ScheduledAgentCreatorTool : IAgentTool
         }
         """;
 
-    public ToolApprovalMode ApprovalMode => ToolApprovalMode.AlwaysRequire;
+    public ToolApprovalMode ApprovalMode => ToolApprovalMode.NeverRequire;
     public bool IsReadOnly => false;
     public bool IsDestructive => false;
 

--- a/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
+++ b/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
@@ -134,7 +134,7 @@ Bind `agent_id` to the real outbound route:
 
 ### scheduled_agent_creator (scheduled Ornn skill agents)
 
-Use `scheduled_agent_creator` to create a new caller-owned scheduled automation agent from an Ornn skill reference. Required fields are `skill_ref`, `schedule_cron`, and `schedule_timezone`; optional LLM tuning fields are allowed. Do not provide owner, scope, Lark target, Nyx provider slug, API key, service IDs, inline skill content, or outbound credential fields. The tool derives those from the current authenticated/channel context, mints a scoped NyxID key, and returns only an accepted receipt.
+Use `scheduled_agent_creator` to create a new caller-owned scheduled automation agent from an Ornn skill reference. Required fields are `skill_ref`, `schedule_cron`, and `schedule_timezone`; optional LLM tuning fields are allowed. Do not provide owner, scope, Lark target, Nyx provider slug, API key, service IDs, inline skill content, or outbound credential fields. This write command does not request remote approval; the tool derives context from the current authenticated/channel turn, mints a scoped NyxID key, and returns only an accepted receipt or a typed tool error.
 
 `skill_ref` must be unversioned for now. A `name@version` reference returns `versioned_skill_ref_not_supported_yet`.
 
@@ -164,7 +164,7 @@ Use this playbook when the user asks for a recurring, scheduled, monitored, or o
 4. Publish the skill, then schedule it.
    - Call `ornn_publish_skill` with the assembled typed package.
    - If publish fails, inspect the diagnostics, fix the package, and retry.
-   - Ornn private skill publishing executes directly. Do not say it is waiting for NyxID approval unless a typed remote approval result explicitly says so.
+   - Ornn private skill publishing executes directly. Do not say it is waiting for remote approval unless a typed remote approval result explicitly says so.
    - Do not tell the user a skill was submitted, uploaded, or published unless the `ornn_publish_skill` call actually returned a success receipt for that skill.
    - Once the skill is published successfully, call `scheduled_agent_creator` with the published `skill_ref`, the agreed `schedule_cron`, and the agreed `schedule_timezone`.
    - Carry the negotiated delivery/output choice into the runner's `execution_prompt` and outbound delivery setup; if the chosen delivery target differs from the current conversation, rebind it with `agent_delivery_targets` using the returned `agent_id`.

--- a/test/Aevatar.AI.Tests/NyxIdChatSystemPromptTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatSystemPromptTests.cs
@@ -24,4 +24,14 @@ public class NyxIdChatSystemPromptTests
         prompt.Should().Contain("api-github");
         prompt.Should().NotContain("deadline-monitor");
     }
+
+    [Fact]
+    public void Value_ShouldStateScheduledAgentCreationDoesNotRequestRemoteApproval()
+    {
+        var prompt = NyxIdChatSystemPrompt.Value;
+
+        prompt.Should().Contain("This write command does not request remote approval");
+        prompt.Should().Contain("Do not say it is waiting for remote approval");
+        prompt.Should().NotContain("waiting for NyxID approval");
+    }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -910,7 +910,7 @@ public sealed class AgentBuilderToolTests
         tools.Select(tool => tool.Name).Should().BeEquivalentTo("agent_builder", "scheduled_agent_creator");
         var managementTool = tools.Single(tool => tool.Name == "agent_builder");
         var creatorTool = tools.Single(tool => tool.Name == "scheduled_agent_creator");
-        creatorTool.ApprovalMode.Should().Be(ToolApprovalMode.AlwaysRequire);
+        creatorTool.ApprovalMode.Should().Be(ToolApprovalMode.NeverRequire);
         creatorTool.IsReadOnly.Should().BeFalse();
         creatorTool.IsDestructive.Should().BeFalse();
 
@@ -972,7 +972,7 @@ public sealed class AgentBuilderToolTests
 
         tools.Select(tool => tool.Name).Should().BeEquivalentTo("agent_builder", "scheduled_agent_creator");
         tools.Single(tool => tool.Name == "scheduled_agent_creator").ApprovalMode
-            .Should().Be(ToolApprovalMode.AlwaysRequire);
+            .Should().Be(ToolApprovalMode.NeverRequire);
     }
 
     private static AgentBuilderTool CreateTool(IServiceCollection services)

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentCreatorToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentCreatorToolTests.cs
@@ -18,12 +18,12 @@ namespace Aevatar.GAgents.ChannelRuntime.Tests;
 public sealed class ScheduledAgentCreatorToolTests
 {
     [Fact]
-    public void ToolContract_ShouldRequireApproval_AndExposeClosedSchema()
+    public void ToolContract_ShouldNeverRequireApproval_AndExposeClosedSchema()
     {
         var tool = CreateHarness().Tool;
 
         tool.Name.Should().Be("scheduled_agent_creator");
-        tool.ApprovalMode.Should().Be(ToolApprovalMode.AlwaysRequire);
+        tool.ApprovalMode.Should().Be(ToolApprovalMode.NeverRequire);
         tool.IsReadOnly.Should().BeFalse();
         tool.IsDestructive.Should().BeFalse();
 


### PR DESCRIPTION
## Changed files

- `agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentCreatorTool.cs`：将 `scheduled_agent_creator` 的审批模式从 `ToolApprovalMode.AlwaysRequire` 改为显式 `ToolApprovalMode.NeverRequire`，避免被 `ToolApprovalMiddleware` 提前拦成远程审批等待。
- `test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentCreatorToolTests.cs`：更新工具合同测试，直接断言具体工具暴露 `NeverRequire`。
- `test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs`：补齐工具源发现与 DI 注册两条路径的断言，确认注册后的 `IAgentTool` 表面同样是 `NeverRequire`。
- `agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md`：同步提示词语义，说明定时 Agent 创建只返回 accepted-for-dispatch receipt 或 typed tool error，不再描述为 NyxID 远程审批流程。

## Test results

- 通过：`dotnet build aevatar.slnx --nologo`。结果为已有 warning，无 error。
- 通过：`dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo --filter "ScheduledAgentCreatorToolTests|AgentBuilderToolTests"`。结果为 42 passed，0 failed，0 skipped。
- 通过：`bash tools/ci/test_stability_guards.sh`。
- 通过：`rg -n "scheduled_agent_creator|ToolApprovalMode\\.(AlwaysRequire|NeverRequire)|approval_required|NyxID approval" agents/Aevatar.GAgents.Authoring.Lark test/Aevatar.GAgents.ChannelRuntime.Tests agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md`。结果确认 `scheduled_agent_creator` 合同已是 `NeverRequire`，剩余 `approval_required` 命中属于通用 NyxID 诊断或 safety-net 测试。
- 通过：`bash tools/ci/architecture_guards.sh`。

## Deviations

- 无 scope extension。
- `test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj` 在授权范围内，但现有引用已覆盖更新后的测试，因此未改动。
- 已只读检查 `/Users/zhaoyiqi/Code/NyxID` 与 `/Users/zhaoyiqi/Code/chrono-ornn` 的相关上下文；未修改外部仓库，也不依赖外部仓库新增能力。
- `HOST_REFACTOR_COMMENT_POLICY` 在可用 worktree 环境中缺失或为空，按规则归一为 `none`；refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)。
- 未修改 schema/protocol 文件，无需重新生成。

Closes #1885

⟦AI:AUTO-LOOP⟧
