### PR TITLE
强化 direct Responses 本地工具失败处理

### DIFF
--- a/docs/canon/nyxid-responses-direct.md
+++ b/docs/canon/nyxid-responses-direct.md
@@ -143,6 +143,8 @@ llm-anthropic/claude-haiku-4-5
 
 chat-route policy 指定 `tool_set_ref` 或 `tool_choice_hint` 时，三条直连入口都会使用同一个 direct tool plan：同一个 tool set 会被注入，同一个 trusted prefilled arguments 合并规则会生效。不要为 `/v1/messages` 或 `/v1/chat/completions` 另建工具白名单。
 
+直连工具的失败语义按边界分层处理。客户端声明但未被 Aevatar substitute 的 forwarded tools 仍然由客户端执行；这类工具不会在 Aevatar 内被降级。Aevatar 本地 direct tools 执行失败时，actor 会把失败转成合法 JSON tool output，并继续把结果送回模型，避免一个可选本地工具异常终止整次 response。该 JSON 只暴露稳定错误码、工具名和异常类型，不透出 token、请求头或内部路径。调用方取消仍然取消整次 run，不会被转成 tool output。chat-route `tool_set_ref` 解析错误仍然 fail closed 返回配置错误；但已经解析出的 tool source、全局 provider、skills/Ornn discovery 如果单个 source 失败，会记录 warning 并跳过该 source，其他可用工具继续进入本次计划。
+
 ## 6. 显式 Skill 触发
 
 直连入口支持同一套显式 skill 触发语法：

--- a/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesUserSkillsToolProvider.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesUserSkillsToolProvider.cs
@@ -3,20 +3,36 @@ using Aevatar.AI.ToolProviders.Ornn;
 using Aevatar.AI.ToolProviders.Skills;
 using Aevatar.GAgentService.Abstractions.Responses;
 using Aevatar.GAgentService.Application.Responses;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aevatar.Mainnet.Host.Api.Responses;
 
 internal sealed class ResponsesUserSkillsToolProvider : IResponsesToolProvider
 {
-    private readonly SkillsAgentToolSource _skillsSource;
-    private readonly OrnnAgentToolSource _ornnSource;
+    private readonly IAgentToolSource _skillsSource;
+    private readonly IAgentToolSource _ornnSource;
+    private readonly ILogger _logger;
 
     public ResponsesUserSkillsToolProvider(
         SkillsAgentToolSource skillsSource,
-        OrnnAgentToolSource ornnSource)
+        OrnnAgentToolSource ornnSource,
+        ILogger<ResponsesUserSkillsToolProvider>? logger = null)
+        : this(
+            (IAgentToolSource)(skillsSource ?? throw new ArgumentNullException(nameof(skillsSource))),
+            (IAgentToolSource)(ornnSource ?? throw new ArgumentNullException(nameof(ornnSource))),
+            logger)
+    {
+    }
+
+    internal ResponsesUserSkillsToolProvider(
+        IAgentToolSource skillsSource,
+        IAgentToolSource ornnSource,
+        ILogger<ResponsesUserSkillsToolProvider>? logger = null)
     {
         _skillsSource = skillsSource ?? throw new ArgumentNullException(nameof(skillsSource));
         _ornnSource = ornnSource ?? throw new ArgumentNullException(nameof(ornnSource));
+        _logger = logger ?? NullLogger<ResponsesUserSkillsToolProvider>.Instance;
     }
 
     public async ValueTask<IReadOnlyList<IAgentTool>> GetAdditiveToolsAsync(
@@ -26,8 +42,30 @@ internal sealed class ResponsesUserSkillsToolProvider : IResponsesToolProvider
         ArgumentNullException.ThrowIfNull(context);
 
         var tools = new List<IAgentTool>();
-        tools.AddRange(await _skillsSource.DiscoverToolsAsync(ct).ConfigureAwait(false));
-        tools.AddRange(await _ornnSource.DiscoverToolsAsync(ct).ConfigureAwait(false));
+        await AddDiscoveredToolsAsync(_skillsSource, tools, ct).ConfigureAwait(false);
+        await AddDiscoveredToolsAsync(_ornnSource, tools, ct).ConfigureAwait(false);
         return tools;
+    }
+
+    private async ValueTask AddDiscoveredToolsAsync(
+        IAgentToolSource source,
+        List<IAgentTool> tools,
+        CancellationToken ct)
+    {
+        try
+        {
+            tools.AddRange(await source.DiscoverToolsAsync(ct).ConfigureAwait(false));
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Responses user skill tool discovery failed for source {SourceType}; continuing without that source.",
+                source.GetType().Name);
+        }
     }
 }

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesDirectToolPlanService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesDirectToolPlanService.cs
@@ -2,6 +2,8 @@ using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.ToolProviders.ToolSetRegistry;
 using Aevatar.ChatRouting.Abstractions;
 using Aevatar.GAgentService.Abstractions.Responses;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aevatar.GAgentService.Application.Responses;
 
@@ -30,8 +32,11 @@ public sealed record ResponsesDirectToolPlan(
 }
 
 public sealed class ResponsesDirectToolPlanService(
-    IToolSetRegistry toolSetRegistry) : IResponsesDirectToolPlanService
+    IToolSetRegistry toolSetRegistry,
+    ILogger<ResponsesDirectToolPlanService>? logger = null) : IResponsesDirectToolPlanService
 {
+    private readonly ILogger _logger = logger ?? NullLogger<ResponsesDirectToolPlanService>.Instance;
+
     public ResponsesDirectToolPlan Build(ChatRouteAction? routeAction)
     {
         var forwardToModel = routeAction?.ForwardToModel;
@@ -52,7 +57,7 @@ public sealed class ResponsesDirectToolPlanService(
                     error.Message));
             }
 
-            additionalProviders.Add(new ToolSetResponsesToolProvider(toolSet.Sources));
+            additionalProviders.Add(new ToolSetResponsesToolProvider(toolSet.Sources, _logger));
         }
 
         return ResponsesDirectToolPlan.Success(
@@ -65,10 +70,14 @@ public sealed class ResponsesDirectToolPlanService(
     private sealed class ToolSetResponsesToolProvider : IResponsesToolProvider
     {
         private readonly IReadOnlyList<IAgentToolSource> _sources;
+        private readonly ILogger _logger;
 
-        public ToolSetResponsesToolProvider(IReadOnlyList<IAgentToolSource> sources)
+        public ToolSetResponsesToolProvider(
+            IReadOnlyList<IAgentToolSource> sources,
+            ILogger logger)
         {
             _sources = sources ?? throw new ArgumentNullException(nameof(sources));
+            _logger = logger ?? NullLogger.Instance;
         }
 
         public async ValueTask<IReadOnlyList<IAgentTool>> GetAdditiveToolsAsync(
@@ -83,7 +92,23 @@ public sealed class ResponsesDirectToolPlanService(
 
             var tools = new List<IAgentTool>();
             foreach (var source in _sources)
-                tools.AddRange(await source.DiscoverToolsAsync(ct));
+            {
+                try
+                {
+                    tools.AddRange(await source.DiscoverToolsAsync(ct).ConfigureAwait(false));
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Responses route tool source discovery failed for source {SourceType}; continuing without that source.",
+                        source.GetType().Name);
+                }
+            }
 
             return tools;
         }

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesToolClassificationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesToolClassificationService.cs
@@ -73,8 +73,22 @@ public static class ResponsesToolClassifier
         foreach (var provider in providerList)
         {
             ct.ThrowIfCancellationRequested();
-            discoveredSubstituteTools.AddRange(
-                await provider.GetSubstituteToolsAsync(context, ct).ConfigureAwait(false));
+            try
+            {
+                discoveredSubstituteTools.AddRange(
+                    await provider.GetSubstituteToolsAsync(context, ct).ConfigureAwait(false));
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(
+                    ex,
+                    "Responses substitute tool discovery failed for provider {ProviderType}; continuing without that provider.",
+                    provider.GetType().Name);
+            }
         }
 
         var substituteTools = discoveredSubstituteTools
@@ -86,8 +100,22 @@ public static class ResponsesToolClassifier
         foreach (var provider in providerList)
         {
             ct.ThrowIfCancellationRequested();
-            discoveredAdditiveTools.AddRange(
-                await provider.GetAdditiveToolsAsync(context, ct).ConfigureAwait(false));
+            try
+            {
+                discoveredAdditiveTools.AddRange(
+                    await provider.GetAdditiveToolsAsync(context, ct).ConfigureAwait(false));
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(
+                    ex,
+                    "Responses additive tool discovery failed for provider {ProviderType}; continuing without that provider.",
+                    provider.GetType().Name);
+            }
         }
 
         var additiveTools = discoveredAdditiveTools

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
@@ -9,6 +9,7 @@ using Aevatar.GAgentService.Abstractions.Responses;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -729,8 +730,37 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
         foreach (var provider in providers)
         {
             ct.ThrowIfCancellationRequested();
-            substituteTools.AddRange(await provider.GetSubstituteToolsAsync(context, ct).ConfigureAwait(false));
-            additiveTools.AddRange(await provider.GetAdditiveToolsAsync(context, ct).ConfigureAwait(false));
+            try
+            {
+                substituteTools.AddRange(await provider.GetSubstituteToolsAsync(context, ct).ConfigureAwait(false));
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(
+                    ex,
+                    "Responses substitute tool discovery failed for provider {ProviderType}; continuing without that provider.",
+                    provider.GetType().Name);
+            }
+
+            try
+            {
+                additiveTools.AddRange(await provider.GetAdditiveToolsAsync(context, ct).ConfigureAwait(false));
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(
+                    ex,
+                    "Responses additive tool discovery failed for provider {ProviderType}; continuing without that provider.",
+                    provider.GetType().Name);
+            }
         }
 
         var substitutedNames = (command.ToolSelection?.SubstitutedToolNames ?? [])
@@ -795,7 +825,8 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
                     ? "{}"
                     : toolCall.ArgumentsJson;
                 var result = toolsByName.TryGetValue(toolCall.Name, out var tool)
-                    ? await tool.ExecuteAsync(
+                    ? await ResponsesSafeToolExecutor.ExecuteAsync(
+                        tool,
                         argumentsJson,
                         ct)
                     : System.Text.Json.JsonSerializer.Serialize(new

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/ResponsesSafeToolExecutor.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/ResponsesSafeToolExecutor.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using Aevatar.AI.Abstractions.ToolProviders;
+
+namespace Aevatar.GAgentService.Core.GAgents;
+
+internal static class ResponsesSafeToolExecutor
+{
+    public static async Task<string> ExecuteAsync(
+        IAgentTool tool,
+        string argumentsJson,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(tool);
+
+        try
+        {
+            return await tool.ExecuteAsync(argumentsJson, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return BuildFailureJson(tool.Name, ex);
+        }
+    }
+
+    private static string BuildFailureJson(string toolName, Exception ex) =>
+        JsonSerializer.Serialize(new
+        {
+            error = new
+            {
+                code = "aevatar_local_tool_execution_failed",
+                message = "Aevatar local tool execution failed.",
+                tool_name = toolName,
+                exception_type = ex.GetType().Name,
+            },
+        });
+}

--- a/src/platform/Aevatar.GAgentService.Core/Properties/InternalsVisibleTo.cs
+++ b/src/platform/Aevatar.GAgentService.Core/Properties/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Aevatar.GAgentService.Tests")]

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesDirectToolPlanServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesDirectToolPlanServiceTests.cs
@@ -1,0 +1,96 @@
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.ToolProviders.ToolSetRegistry;
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.GAgentService.Abstractions.Responses;
+using Aevatar.GAgentService.Application.Responses;
+using FluentAssertions;
+
+namespace Aevatar.GAgentService.Tests.Application;
+
+public sealed class ResponsesDirectToolPlanServiceTests
+{
+    [Fact]
+    public async Task ToolSetProvider_WhenSourceDiscoveryFails_ShouldContinueWithOtherSources()
+    {
+        var service = new ResponsesDirectToolPlanService(new StaticToolSetRegistry(
+            [
+                new FaultingToolSource(),
+                new StaticToolSource([new StaticTool("use_skill")]),
+            ]));
+
+        var plan = service.Build(new ChatRouteAction
+        {
+            ForwardToModel = new ForwardToModel
+            {
+                ToolSetRef = new ChatRouteToolSetRef { Name = "workspace.default" },
+            },
+        });
+
+        plan.Error.Should().BeNull();
+        var provider = plan.AdditionalToolProviders.Should().ContainSingle().Subject;
+        var tools = await provider.GetAdditiveToolsAsync(
+            new ResponsesToolProviderContext(AgentToolExecutionContext.Empty));
+
+        tools.Select(static tool => tool.Name).Should().ContainSingle("use_skill");
+    }
+
+    [Fact]
+    public async Task ToolSetProvider_WhenCallerCancels_ShouldPropagateCancellation()
+    {
+        var service = new ResponsesDirectToolPlanService(new StaticToolSetRegistry(
+            [new FaultingToolSource()]));
+        var plan = service.Build(new ChatRouteAction
+        {
+            ForwardToModel = new ForwardToModel
+            {
+                ToolSetRef = new ChatRouteToolSetRef { Name = "workspace.default" },
+            },
+        });
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var act = () => plan.AdditionalToolProviders.Single()
+            .GetAdditiveToolsAsync(
+                new ResponsesToolProviderContext(AgentToolExecutionContext.Empty),
+                cts.Token)
+            .AsTask();
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    private sealed class StaticToolSetRegistry(IReadOnlyList<IAgentToolSource> sources) : IToolSetRegistry
+    {
+        public IReadOnlyList<string> GetRegisteredNames() => ["workspace.default"];
+
+        public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef) =>
+            ToolSetResolveResult.Success("workspace.default", sources);
+    }
+
+    private sealed class FaultingToolSource : IAgentToolSource
+    {
+        public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromException<IReadOnlyList<IAgentTool>>(
+                new InvalidOperationException("source discovery failed"));
+        }
+    }
+
+    private sealed class StaticToolSource(IReadOnlyList<IAgentTool> tools) : IAgentToolSource
+    {
+        public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default) =>
+            Task.FromResult(tools);
+    }
+
+    private sealed class StaticTool(string name) : IAgentTool
+    {
+        public string Name { get; } = name;
+
+        public string Description => "Static test tool";
+
+        public string ParametersSchema => """{"type":"object"}""";
+
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
+            Task.FromResult("{}");
+    }
+}

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesToolClassificationTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesToolClassificationTests.cs
@@ -81,6 +81,52 @@ public sealed class ResponsesToolClassificationTests
     }
 
     [Fact]
+    public async Task ClassifyAsync_WhenProviderDiscoveryFails_ShouldContinueWithOtherProviders()
+    {
+        var logger = new RecordingLogger();
+
+        var result = await ResponsesToolClassifier.ClassifyAsync(
+            [
+                new ResponsesApplicationToolDeclaration("client_tool", "client tool", """{"type":"object"}""", "client-hash"),
+            ],
+            [
+                new FaultingResponsesToolProvider(),
+                new RecordingResponsesToolProvider(
+                    [new RecordingTool("client_tool", """{"type":"object"}""", "{}")],
+                    [new RecordingTool("use_skill", """{"type":"object"}""", "{}")]),
+            ],
+            ToolProviderContext,
+            logger);
+
+        result.ForwardedTools.Should().BeEmpty();
+        result.SubstitutedToolNames.Should().ContainSingle("client_tool");
+        result.AdditiveToolNames.Should().ContainSingle("use_skill");
+        result.EffectiveTools.Select(static tool => tool.Name)
+            .Should().Equal("client_tool", "use_skill");
+        logger.Messages.Should().Contain(message =>
+            message.Contains("substitute tool discovery failed", StringComparison.Ordinal));
+        logger.Messages.Should().Contain(message =>
+            message.Contains("additive tool discovery failed", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ClassifyAsync_WhenCallerCancels_ShouldPropagateCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var act = () => ResponsesToolClassifier.ClassifyAsync(
+                [],
+                [new RecordingResponsesToolProvider([], [])],
+                ToolProviderContext,
+                new RecordingLogger(),
+                cts.Token)
+            .AsTask();
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
     public void ResponsesForwardedTool_ShouldExposeDeclarationAndRejectNull()
     {
         ((Action)(() => new ResponsesForwardedTool(null!)))
@@ -153,6 +199,21 @@ public sealed class ResponsesToolClassificationTests
             ResponsesToolProviderContext context,
             CancellationToken ct = default) =>
             ValueTask.FromResult(additiveTools);
+    }
+
+    private sealed class FaultingResponsesToolProvider : IResponsesToolProvider
+    {
+        public ValueTask<IReadOnlyList<IAgentTool>> GetSubstituteToolsAsync(
+            ResponsesToolProviderContext context,
+            CancellationToken ct = default) =>
+            ValueTask.FromException<IReadOnlyList<IAgentTool>>(
+                new InvalidOperationException("substitute discovery failed"));
+
+        public ValueTask<IReadOnlyList<IAgentTool>> GetAdditiveToolsAsync(
+            ResponsesToolProviderContext context,
+            CancellationToken ct = default) =>
+            ValueTask.FromException<IReadOnlyList<IAgentTool>>(
+                new InvalidOperationException("additive discovery failed"));
     }
 
     private sealed class EmptyResponsesToolProvider : IResponsesToolProvider;

--- a/test/Aevatar.GAgentService.Tests/Core/LlmSessionGAgentTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/LlmSessionGAgentTests.cs
@@ -1111,6 +1111,74 @@ public sealed class LlmSessionGAgentTests
     }
 
     [Fact]
+    public async Task HandleLlmRunRequestedAsync_WhenLocalToolThrows_ShouldRecordSafeToolOutputAndContinueNextRound()
+    {
+        var eventStore = new InMemoryEventStore();
+        var tool = new ThrowingAgentTool(
+            "get_weather",
+            new InvalidOperationException("secret token /Users/me/path"));
+        var toolProvider = new StaticResponsesToolProvider(substituteTools: [tool]);
+        var provider = new ScriptedLlmProviderFactory([
+            [
+                new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "call_1",
+                        Name = "get_weather",
+                        ArgumentsJson = """{"city":"Singapore"}""",
+                    },
+                    IsLast = true,
+                },
+            ],
+            [
+                new LLMStreamChunk
+                {
+                    DeltaContent = "safe output accepted",
+                    IsLast = true,
+                },
+            ],
+        ]);
+        var actor = CreateActorWithStore(
+            "resp_safe_tool_failure",
+            eventStore,
+            services =>
+            {
+                services.AddSingleton<ILLMProviderFactory>(provider);
+                services.AddSingleton<IResponsesToolProvider>(toolProvider);
+            });
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_safe_tool_failure"),
+        });
+        var selection = BuildForwardedSelection();
+        selection.SubstitutedToolNames.Add("get_weather");
+
+        await actor.HandleLlmRunRequestedAsync(BuildRunRequest("resp_safe_tool_failure", selection));
+
+        actor.State.Record!.Status.Should().Be(LlmSessionStatus.Completed);
+        actor.State.Completion!.OutputText.Should().Be("safe output accepted");
+        provider.Requests.Should().HaveCount(2);
+        var toolMessage = provider.Requests[1].Messages.Single(message =>
+            string.Equals(message.Role, "tool", StringComparison.Ordinal));
+        toolMessage.Content.Should().Contain("aevatar_local_tool_execution_failed");
+        toolMessage.Content.Should().Contain("get_weather");
+        toolMessage.Content.Should().NotContain("secret token");
+        toolMessage.Content.Should().NotContain("/Users/me/path");
+
+        var localObserved = (await eventStore.GetEventsAsync(actor.Id))
+            .Select(static evt => evt.EventData)
+            .Where(static payload => payload.Is(LlmToolCallObserved.Descriptor))
+            .Select(static payload => payload.Unpack<LlmToolCallObserved>())
+            .Should()
+            .ContainSingle(observed => !observed.Forwarded)
+            .Subject;
+        localObserved.LocalResultJson.Should().Be(toolMessage.Content);
+        localObserved.LocalResult.StructValue.Fields["error"]
+            .StructValue.Fields["code"].StringValue.Should().Be("aevatar_local_tool_execution_failed");
+    }
+
+    [Fact]
     public async Task HandleLlmRunRequestedAsync_ShouldPropagateTypedToolContextAcrossProviderAndToolScopes()
     {
         var tool = new RecordingAgentTool("get_weather", """{"temperature":28}""");
@@ -1193,6 +1261,53 @@ public sealed class LlmSessionGAgentTests
             options => options.Excluding(context => context.Request.CallId));
         tool.ExecutionContexts[0]!.Request.CallId.Should().Be("call_1");
         AgentToolRequestContext.Current.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandleLlmRunRequestedAsync_WhenToolProviderDiscoveryFails_ShouldContinueWithOtherProviders()
+    {
+        var tool = new RecordingAgentTool("get_weather", """{"temperature":28}""");
+        var provider = new ScriptedLlmProviderFactory([
+            [
+                new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "call_1",
+                        Name = "get_weather",
+                        ArgumentsJson = """{"city":"Singapore"}""",
+                    },
+                    IsLast = true,
+                },
+            ],
+            [
+                new LLMStreamChunk
+                {
+                    DeltaContent = "done",
+                    IsLast = true,
+                },
+            ],
+        ]);
+        var actor = CreateActor(
+            "resp_provider_discovery_failure",
+            services =>
+            {
+                services.AddSingleton<ILLMProviderFactory>(provider);
+                services.AddSingleton<IResponsesToolProvider>(new FaultingResponsesToolProvider());
+                services.AddSingleton<IResponsesToolProvider>(new StaticResponsesToolProvider(substituteTools: [tool]));
+            });
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_provider_discovery_failure"),
+        });
+        var selection = BuildForwardedSelection();
+        selection.SubstitutedToolNames.Add("get_weather");
+
+        await actor.HandleLlmRunRequestedAsync(BuildRunRequest("resp_provider_discovery_failure", selection));
+
+        actor.State.Record!.Status.Should().Be(LlmSessionStatus.Completed);
+        tool.Executions.Should().ContainSingle();
+        actor.State.Completion!.OutputText.Should().Be("done");
     }
 
     [Fact]
@@ -1560,6 +1675,21 @@ public sealed class LlmSessionGAgentTests
         }
     }
 
+    private sealed class FaultingResponsesToolProvider : IResponsesToolProvider
+    {
+        public ValueTask<IReadOnlyList<IAgentTool>> GetSubstituteToolsAsync(
+            ResponsesToolProviderContext context,
+            CancellationToken ct = default) =>
+            ValueTask.FromException<IReadOnlyList<IAgentTool>>(
+                new InvalidOperationException("substitute discovery failed"));
+
+        public ValueTask<IReadOnlyList<IAgentTool>> GetAdditiveToolsAsync(
+            ResponsesToolProviderContext context,
+            CancellationToken ct = default) =>
+            ValueTask.FromException<IReadOnlyList<IAgentTool>>(
+                new InvalidOperationException("additive discovery failed"));
+    }
+
     private sealed class RecordingAgentTool(string name, string resultJson) : IAgentTool
     {
         public List<string> Executions { get; } = [];
@@ -1577,5 +1707,17 @@ public sealed class LlmSessionGAgentTests
             ExecutionContexts.Add(AgentToolRequestContext.Current);
             return Task.FromResult(resultJson);
         }
+    }
+
+    private sealed class ThrowingAgentTool(string name, Exception exception) : IAgentTool
+    {
+        public string Name { get; } = name;
+
+        public string Description => "throwing test tool";
+
+        public string ParametersSchema => """{"type":"object"}""";
+
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
+            Task.FromException<string>(exception);
     }
 }

--- a/test/Aevatar.GAgentService.Tests/Core/ResponsesSafeToolExecutorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ResponsesSafeToolExecutorTests.cs
@@ -1,0 +1,50 @@
+using System.Text.Json;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.GAgentService.Core.GAgents;
+using FluentAssertions;
+
+namespace Aevatar.GAgentService.Tests.Core;
+
+public sealed class ResponsesSafeToolExecutorTests
+{
+    [Fact]
+    public async Task ExecuteAsync_WhenToolThrows_ShouldReturnRedactedJsonError()
+    {
+        var tool = new ThrowingTool("local_tool", new InvalidOperationException("secret token /Users/me/path"));
+
+        var result = await ResponsesSafeToolExecutor.ExecuteAsync(tool, """{"x":1}""");
+
+        using var document = JsonDocument.Parse(result);
+        var error = document.RootElement.GetProperty("error");
+        error.GetProperty("code").GetString().Should().Be("aevatar_local_tool_execution_failed");
+        error.GetProperty("message").GetString().Should().Be("Aevatar local tool execution failed.");
+        error.GetProperty("tool_name").GetString().Should().Be("local_tool");
+        error.GetProperty("exception_type").GetString().Should().Be(nameof(InvalidOperationException));
+        result.Should().NotContain("secret");
+        result.Should().NotContain("/Users/me/path");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenCallerCancels_ShouldPropagateCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        var tool = new ThrowingTool("local_tool", new OperationCanceledException(cts.Token));
+
+        var act = () => ResponsesSafeToolExecutor.ExecuteAsync(tool, "{}", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    private sealed class ThrowingTool(string name, Exception exception) : IAgentTool
+    {
+        public string Name { get; } = name;
+
+        public string Description => "Throwing test tool";
+
+        public string ParametersSchema => """{"type":"object"}""";
+
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
+            Task.FromException<string>(exception);
+    }
+}

--- a/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
@@ -528,6 +528,28 @@ public sealed class MainnetResponsesEndpointsTests
     }
 
     [Fact]
+    public async Task ResponsesUserSkillsToolProvider_WhenRequestIsCanceled_ShouldPropagateCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        var toolProvider = new ResponsesUserSkillsToolProvider(
+            new StubAgentToolSource(
+            [
+                new StubAgentTool("use_skill", "Run a registered skill body"),
+            ]),
+            new CanceledAgentToolSource());
+
+        Func<Task> act = async () => await toolProvider.GetAdditiveToolsAsync(
+            BuildToolProviderContext(
+                new ResponsesCallerScope("scope-1", "owner-1", LlmSessionOriginKind.ApiKey),
+                "resp_1",
+                "token"),
+            cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
     public async Task PostResponses_WhenSkillBridgeProviderRegistered_ShouldForwardSkillToolsToLlmRequest()
     {
         var provider = new RecordingLLMProvider
@@ -3132,6 +3154,12 @@ public sealed class MainnetResponsesEndpointsTests
         public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default) =>
             Task.FromException<IReadOnlyList<IAgentTool>>(
                 new InvalidOperationException("source discovery failed"));
+    }
+
+    private sealed class CanceledAgentToolSource : IAgentToolSource
+    {
+        public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default) =>
+            Task.FromException<IReadOnlyList<IAgentTool>>(new OperationCanceledException(ct));
     }
 
     private sealed class NotFoundHttpMessageHandler : HttpMessageHandler

--- a/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
@@ -507,6 +507,27 @@ public sealed class MainnetResponsesEndpointsTests
     }
 
     [Fact]
+    public async Task ResponsesUserSkillsToolProvider_WhenOneSourceDiscoveryFails_ShouldReturnOtherSourceTools()
+    {
+        var toolProvider = new ResponsesUserSkillsToolProvider(
+            new ThrowingAgentToolSource(),
+            new StubAgentToolSource(
+            [
+                new StubAgentTool("ornn_search_skills", "Search Ornn skill catalog"),
+            ]));
+
+        var tools = await toolProvider.GetAdditiveToolsAsync(
+            BuildToolProviderContext(
+                new ResponsesCallerScope("scope-1", "owner-1", LlmSessionOriginKind.ApiKey),
+                "resp_1",
+                "token"));
+
+        tools.Select(static tool => tool.Name)
+            .Should()
+            .ContainSingle("ornn_search_skills");
+    }
+
+    [Fact]
     public async Task PostResponses_WhenSkillBridgeProviderRegistered_ShouldForwardSkillToolsToLlmRequest()
     {
         var provider = new RecordingLLMProvider
@@ -3104,6 +3125,13 @@ public sealed class MainnetResponsesEndpointsTests
     {
         public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default) =>
             Task.FromResult(tools);
+    }
+
+    private sealed class ThrowingAgentToolSource : IAgentToolSource
+    {
+        public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default) =>
+            Task.FromException<IReadOnlyList<IAgentTool>>(
+                new InvalidOperationException("source discovery failed"));
     }
 
     private sealed class NotFoundHttpMessageHandler : HttpMessageHandler


### PR DESCRIPTION
## 问题与方案

Closes #1886

本次修复 direct Responses 链路里本地工具和可选 discovery 的失败传播问题：Aevatar/NyxID local tool 的非取消异常会转换成合法、脱敏的 JSON tool output，并回到 actor 主链继续下一轮；caller/request cancellation、forwarded client tools 和显式 route tool-set 配置错误仍保持原有更强语义。

## Changed files

- `docs/canon/nyxid-responses-direct.md`：记录 direct tool failure JSON 输出契约，以及 provider/source discovery fail-closed 契约。
- `src/Aevatar.Mainnet.Host.Api/Responses/ResponsesUserSkillsToolProvider.cs`：Mainnet user skills sources 按 source fail-closed，并保留请求取消向上冒泡。
- `src/platform/Aevatar.GAgentService.Application/Responses/ResponsesDirectToolPlanService.cs`：route tool-set source discovery 按 source fail-closed，显式 tool-set resolve error 保持原 Error。
- `src/platform/Aevatar.GAgentService.Application/Responses/ResponsesToolClassificationService.cs`：substitute/additive provider discovery 按 provider fail-closed。
- `src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs`：actor run rebuild discovery fail-closed，local tool execution 改走 safe executor。
- `src/platform/Aevatar.GAgentService.Core/GAgents/ResponsesSafeToolExecutor.cs`：新增 direct-only safe executor，将 local tool 非取消异常转成脱敏 JSON tool output。
- `src/platform/Aevatar.GAgentService.Core/Properties/InternalsVisibleTo.cs`：开放 Core internal helper 给 `Aevatar.GAgentService.Tests` 行为测试。
- `test/Aevatar.GAgentService.Tests/Application/ResponsesDirectToolPlanServiceTests.cs`：覆盖 route tool-set source discovery 单点失败跳过与 cancellation 传播。
- `test/Aevatar.GAgentService.Tests/Application/ResponsesToolClassificationTests.cs`：覆盖 provider discovery fail-closed 与 cancellation 传播。
- `test/Aevatar.GAgentService.Tests/Core/LlmSessionGAgentTests.cs`：覆盖 local tool 失败继续下一轮、actor rebuild discovery fail-closed。
- `test/Aevatar.GAgentService.Tests/Core/ResponsesSafeToolExecutorTests.cs`：覆盖脱敏 JSON error 与请求取消传播。
- `test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs`：覆盖 Mainnet user skills source discovery fail-closed。

## Test results

- `bash -lc "dotnet build aevatar.slnx --nologo"`：通过。
- `bash -lc "dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo"`：通过，826 passed，0 failed，0 skipped。
- `bash -lc "dotnet test test/Aevatar.Hosting.Tests/Aevatar.Hosting.Tests.csproj --nologo"`：通过，265 passed，0 failed，0 skipped。
- `bash tools/ci/test_stability_guards.sh`：通过。
- `bash tools/ci/architecture_guards.sh`：通过。
- `git diff --check`：通过。

## Deviations

- 当前环境缺少 `/Users/zhaoyiqi/Code/aevatar/.refactor-loop/host.env`，`HOST_REFACTOR_COMMENT_POLICY` 按规则归一化为 `none`；因此没有新增 refactor self-documentation 源码注释。
- 授权路径 `test/Aevatar.AI.ToolProviders.Channel.Tests/` 在该 worktree 中不存在，因此未在该路径创建文件。
- 构建和测试输出包含既有 NuGet/analyzer warnings，与本 work unit 无关；最终没有遗留失败的 guard。
- 本次不需要扩展 scope。

⟦AI:AUTO-LOOP⟧
