### PR TITLE
Remove workflow studio Team entry action

### DIFF
--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -388,7 +388,6 @@ const enUSMessages = {
   'teamMemberWorkflowStudio.header.executeWorkflow': 'Execute workflow',
   'teamMemberWorkflowStudio.header.identityAria': 'Workflow identity',
   'teamMemberWorkflowStudio.header.inputSet': 'input set',
-  'teamMemberWorkflowStudio.header.moreActionsAria': 'More workflow actions',
   'teamMemberWorkflowStudio.header.nodeActionsAria':
     'Workflow draft and node actions',
   'teamMemberWorkflowStudio.header.optionalTestPayload': 'Optional test payload',
@@ -401,7 +400,6 @@ const enUSMessages = {
   'teamMemberWorkflowStudio.header.runActiveMember': 'Run active member',
   'teamMemberWorkflowStudio.header.save': 'Save',
   'teamMemberWorkflowStudio.header.saveDraft': 'Save draft',
-  'teamMemberWorkflowStudio.header.setAsTeamEntry': 'Set as Team entry',
   'teamMemberWorkflowStudio.header.tabs.editor': 'Editor',
   'teamMemberWorkflowStudio.header.tabs.executions': 'Executions',
   'teamMemberWorkflowStudio.header.tabs.runs': 'Runs',

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -371,7 +371,6 @@ const zhCNMessages = {
   'teamMemberWorkflowStudio.header.executeWorkflow': '执行 Workflow',
   'teamMemberWorkflowStudio.header.identityAria': 'Workflow 身份信息',
   'teamMemberWorkflowStudio.header.inputSet': '已设置输入',
-  'teamMemberWorkflowStudio.header.moreActionsAria': '更多 Workflow 操作',
   'teamMemberWorkflowStudio.header.nodeActionsAria':
     'Workflow 草稿和节点操作',
   'teamMemberWorkflowStudio.header.optionalTestPayload': '可选测试载荷',
@@ -384,7 +383,6 @@ const zhCNMessages = {
   'teamMemberWorkflowStudio.header.runActiveMember': '运行活跃成员',
   'teamMemberWorkflowStudio.header.save': '保存',
   'teamMemberWorkflowStudio.header.saveDraft': '保存草稿',
-  'teamMemberWorkflowStudio.header.setAsTeamEntry': '设为团队入口',
   'teamMemberWorkflowStudio.header.tabs.editor': '编辑器',
   'teamMemberWorkflowStudio.header.tabs.executions': '执行记录',
   'teamMemberWorkflowStudio.header.tabs.runs': '运行记录',

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioHeader.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioHeader.tsx
@@ -1,9 +1,7 @@
 import {
   CloudUploadOutlined,
   DeleteOutlined,
-  DownOutlined,
   EditOutlined,
-  MoreOutlined,
   PlayCircleOutlined,
   PlusOutlined,
   SaveOutlined,
@@ -12,7 +10,6 @@ import {
 import {
   Breadcrumb,
   Button,
-  Dropdown,
   Input,
   Segmented,
   Space,
@@ -32,7 +29,6 @@ type WorkflowStudioHeaderProps = {
   readonly publishTone: "default" | "processing" | "success" | "warning" | "error";
   readonly canRunActiveMember: boolean;
   readonly canSave: boolean;
-  readonly canSetTeamEntry: boolean;
   readonly dirty: boolean;
   readonly activeMemberRunPending: boolean;
   readonly activeMemberRunPlaceholderReason?: string;
@@ -43,15 +39,12 @@ type WorkflowStudioHeaderProps = {
   readonly onRunActiveMember: () => void;
   readonly onNavigateBack: () => void;
   readonly onSave: () => void;
-  readonly onSetTeamEntry: () => void;
   readonly onTitleChange: (title: string) => void;
   readonly savePending: boolean;
   readonly savePlaceholderReason?: string;
   readonly selectedNodeId: string;
   readonly selectedTab: "editor" | "runs";
   readonly onTabChange: (tab: "editor" | "runs") => void;
-  readonly teamEntryNotice: string;
-  readonly teamEntryPending: boolean;
   readonly teamName: string;
   readonly workflowTitle: string;
 };
@@ -380,28 +373,20 @@ const HeaderTabs: React.FC<HeaderTabsProps> = ({
 
 type HeaderNodeActionsProps = {
   readonly canSave: boolean;
-  readonly canSetTeamEntry: boolean;
   readonly onDeleteNode: () => void;
   readonly onSave: () => void;
-  readonly onSetTeamEntry: () => void;
   readonly savePending: boolean;
   readonly savePlaceholderReason?: string;
   readonly selectedNodeId: string;
-  readonly teamEntryNotice: string;
-  readonly teamEntryPending: boolean;
 };
 
 const HeaderNodeActions: React.FC<HeaderNodeActionsProps> = ({
   canSave,
-  canSetTeamEntry,
   onDeleteNode,
   onSave,
-  onSetTeamEntry,
   savePending,
   savePlaceholderReason,
   selectedNodeId,
-  teamEntryNotice,
-  teamEntryPending,
 }) => (
   <section
     aria-label={t(
@@ -441,39 +426,6 @@ const HeaderNodeActions: React.FC<HeaderNodeActionsProps> = ({
     >
       {t("teamMemberWorkflowStudio.header.save", "Save")}
     </Button>
-    <Dropdown
-      menu={{
-        items: [
-          {
-            disabled: !canSetTeamEntry,
-            key: "set-team-entry",
-            label: t(
-              "teamMemberWorkflowStudio.header.setAsTeamEntry",
-              "Set as Team entry",
-            ),
-          },
-        ],
-        onClick: ({ key }) => {
-          if (key === "set-team-entry" && canSetTeamEntry) {
-            onSetTeamEntry();
-          }
-        },
-      }}
-      trigger={["click"]}
-    >
-      <Button
-        aria-label={t(
-          "teamMemberWorkflowStudio.header.moreActionsAria",
-          "More workflow actions",
-        )}
-        icon={<MoreOutlined />}
-        loading={teamEntryPending}
-        size="small"
-        title={teamEntryNotice}
-      >
-        <DownOutlined />
-      </Button>
-    </Dropdown>
   </section>
 );
 
@@ -486,7 +438,6 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
   publishTone,
   canRunActiveMember,
   canSave,
-  canSetTeamEntry,
   dirty,
   activeMemberRunPending,
   activeMemberRunPlaceholderReason,
@@ -497,15 +448,12 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
   onRunActiveMember,
   onNavigateBack,
   onSave,
-  onSetTeamEntry,
   onTitleChange,
   savePending,
   savePlaceholderReason,
   selectedNodeId,
   selectedTab,
   onTabChange,
-  teamEntryNotice,
-  teamEntryPending,
   teamName,
   workflowTitle,
 }) => {
@@ -586,15 +534,11 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
         <HeaderTabs onTabChange={onTabChange} selectedTab={selectedTab} />
         <HeaderNodeActions
           canSave={canSave}
-          canSetTeamEntry={canSetTeamEntry}
           onDeleteNode={onDeleteNode}
           onSave={onSave}
-          onSetTeamEntry={onSetTeamEntry}
           savePending={savePending}
           savePlaceholderReason={savePlaceholderReason}
           selectedNodeId={selectedNodeId}
-          teamEntryNotice={teamEntryNotice}
-          teamEntryPending={teamEntryPending}
         />
       </div>
     </header>

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -85,7 +85,6 @@ type TeamMemberWorkflowStudioState = {
   readonly backHref: string;
   readonly canRunActiveMember: boolean;
   readonly canSave: boolean;
-  readonly canSetTeamEntry: boolean;
   readonly closeNodeLibrary: () => void;
   readonly connectNodes: (sourceNodeId: string, targetNodeId: string) => void;
   readonly deleteSelectedNode: () => void;
@@ -126,10 +125,7 @@ type TeamMemberWorkflowStudioState = {
   readonly selectCanvas: () => void;
   readonly selectNode: (nodeId: string) => void;
   readonly setExecutionRunInput: (input: string) => void;
-  readonly setTeamEntry: () => void;
   readonly setWorkflowTitle: (title: string) => void;
-  readonly teamEntryNotice: string;
-  readonly teamEntryPending: boolean;
   readonly teamName: string;
   readonly workflowTitle: string;
 };
@@ -501,7 +497,6 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
   const [publishBindingRun, setPublishBindingRun] =
     React.useState<StudioMemberBindingRunStatusResponse | null>(null);
   const [publishError, setPublishError] = React.useState("");
-  const [teamEntryNotice, setTeamEntryNotice] = React.useState("");
   const [nodeLibraryOpen, setNodeLibraryOpen] = React.useState(false);
   const [runOptionsOpen, setRunOptionsOpen] = React.useState(false);
   const [selectedNodeId, setSelectedNodeId] = React.useState("");
@@ -880,34 +875,6 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       }
     },
   });
-  const setTeamEntryMutation = useMutation({
-    mutationFn: async () => {
-      if (!route.scopeId || !route.teamId || !route.memberId) {
-        throw new Error("Resolve an existing Team member before setting Team entry.");
-      }
-
-      return studioApi.setTeamEntryMember(
-        route.scopeId,
-        route.teamId,
-        route.memberId,
-      );
-    },
-    onError: (error) => {
-      const errorMessage =
-        error instanceof Error ? error.message : "Failed to set Team entry member.";
-      setTeamEntryNotice(errorMessage);
-      void message.error(errorMessage);
-    },
-    onMutate: () => {
-      setTeamEntryNotice("");
-    },
-    onSuccess: () => {
-      void teamQuery.refetch();
-      setTeamEntryNotice("Team entry change submitted.");
-      void message.success("Team entry change submitted.");
-    },
-  });
-
   const workflowLoading =
     route.mode === "existing" &&
     (memberQuery.isLoading ||
@@ -974,25 +941,6 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       : memberIsPublished
         ? "Published member workflow is serviceable."
         : "Draft member workflow is not published to the active member yet.");
-  const isTeamEntryMember =
-    Boolean(route.memberId) &&
-    trimOptional(teamQuery.data?.entryMemberId) === route.memberId;
-  const canSetTeamEntry = Boolean(
-    route.mode === "existing" &&
-      route.scopeId &&
-      route.teamId &&
-      route.memberId &&
-      memberIsPublished &&
-      !isTeamEntryMember &&
-      !setTeamEntryMutation.isPending,
-  );
-  const resolvedTeamEntryNotice =
-    teamEntryNotice ||
-    (isTeamEntryMember
-      ? "Team entry"
-      : memberIsPublished
-        ? "Team entry available"
-        : "Team entry needs a published member");
   const scopedMemberRuns = React.useMemo(() => {
     const executions = executionsQuery.data ?? [];
     if (!executions.length) {
@@ -1266,7 +1214,6 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     backHref,
     canRunActiveMember,
     canSave,
-    canSetTeamEntry,
     closeNodeLibrary: () => setNodeLibraryOpen(false),
     connectNodes,
     deleteSelectedNode,
@@ -1365,14 +1312,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     },
     setExecutionRunInput,
     setSelectedTab,
-    setTeamEntry: () => {
-      if (canSetTeamEntry) {
-        setTeamEntryMutation.mutate();
-      }
-    },
     setWorkflowTitle,
-    teamEntryNotice: resolvedTeamEntryNotice,
-    teamEntryPending: setTeamEntryMutation.isPending,
     teamName,
     updateSelectedStepParameters,
     workflowTitle,

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -831,10 +831,11 @@ describe("TeamMemberWorkflowStudioPage", () => {
       within(headerNodeActions).getByRole("button", { name: "Save" }),
     ).toBeTruthy();
     expect(
-      within(headerNodeActions).getByRole("button", {
+      within(headerNodeActions).queryByRole("button", {
         name: "More workflow actions",
       }),
-    ).toBeTruthy();
+    ).toBeNull();
+    expect(screen.queryByText("Set as Team entry")).toBeNull();
     expect(screen.queryByTestId("member-run-summary")).toBeNull();
     expect(screen.queryByText("Workflow member")).toBeNull();
     expect(screen.queryByText("Draft workflow member")).toBeNull();
@@ -1453,7 +1454,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(studioApi.setTeamEntryMember).not.toHaveBeenCalled();
   });
 
-  it("sets Team entry only from the explicit More menu action", async () => {
+  it("does not expose Team entry actions in workflow studio", async () => {
     window.history.replaceState(
       {},
       "",
@@ -1510,16 +1511,10 @@ describe("TeamMemberWorkflowStudioPage", () => {
       expect(screen.getByText("nodes:1")).toBeTruthy();
     });
     expect(studioApi.setTeamEntryMember).not.toHaveBeenCalled();
-    fireEvent.click(screen.getByRole("button", { name: "More workflow actions" }));
-    fireEvent.click(await screen.findByText("Set as Team entry"));
-
-    await waitFor(() => {
-      expect(studioApi.setTeamEntryMember).toHaveBeenCalledWith(
-        "scope-1",
-        "t-alpha",
-        "member-alpha",
-      );
-    });
+    expect(
+      screen.queryByRole("button", { name: "More workflow actions" }),
+    ).toBeNull();
+    expect(screen.queryByText("Set as Team entry")).toBeNull();
     expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
   });
 

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
@@ -34,7 +34,6 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
         publishTone={studio.publishTone}
         canRunActiveMember={studio.canRunActiveMember}
         canSave={studio.canSave}
-        canSetTeamEntry={studio.canSetTeamEntry}
         dirty={studio.dirty}
         activeMemberRunPending={studio.activeMemberRunPending}
         activeMemberRunPlaceholderReason={studio.activeMemberRunPlaceholderReason}
@@ -45,15 +44,12 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
         onRunActiveMember={studio.runActiveMember}
         onNavigateBack={studio.navigateBack}
         onSave={studio.save}
-        onSetTeamEntry={studio.setTeamEntry}
         onTitleChange={studio.setWorkflowTitle}
         savePending={studio.savePending}
         savePlaceholderReason={studio.savePlaceholderReason}
         selectedNodeId={studio.selectedNodeId}
         selectedTab={studio.selectedTab}
         onTabChange={studio.setSelectedTab}
-        teamEntryNotice={studio.teamEntryNotice}
-        teamEntryPending={studio.teamEntryPending}
         teamName={studio.teamName}
         workflowTitle={studio.workflowTitle}
       />


### PR DESCRIPTION
## Summary
- Remove the workflow studio More menu entry for setting a Team entry
- Drop workflow-studio-only Team entry state/mutation wiring and unused locale keys
- Update workflow studio tests to assert the Team entry action is absent

## Verification
- npm --prefix apps/aevatar-console-web test -- --runInBand src/pages/team-member-workflow-studio/index.test.tsx src/locales/hardcodedCopyAudit.test.ts src/locales/catalog.test.ts
- npm --prefix apps/aevatar-console-web run tsc -- --pretty false
- npm --prefix apps/aevatar-console-web run build
- git diff --check