### PR TITLE
收紧 Aevatar 运行观察工具契约

### DIFF
--- a/docs/adr/0026-tool-first-chat-ingress.md
+++ b/docs/adr/0026-tool-first-chat-ingress.md
@@ -18,7 +18,7 @@ Tool prefilled arguments must not be interpreted as actor addressing.
 D5/D6 describe the later session-owned execution topology. `ChatRunActor` is
 not implemented in the current v1 slice; `/v1/responses` `wait=complete`
 therefore returns the accepted/streaming invocation receipt and clients observe
-terminal completion through `aevatar_observe_run` or `aevatar_query_readmodel`.
+terminal completion through typed `aevatar_observe_run` targets.
 `VoiceSessionActor` is also not implemented by this ADR slice. Until that topology
 exists, ordinary `/ws/voice` supports only typed
 `tool_choice_hint.voice_attach_target` attachment; pure model forwarding
@@ -111,8 +111,7 @@ repository (no external repo changes — CLAUDE.md §"外部仓库无改动权")
 | `aevatar_invoke_gagent` | `actor_id`/`actor_name`, typed `payload` | `{run_id, status, stream_topic?, result?}` | `stream` |
 | `aevatar_invoke_team` | `team_id`, `endpoint_id`, typed `payload` | same | `stream` |
 | `aevatar_start_workflow` | `workflow_id`, typed `inputs` | same | `stream` |
-| `aevatar_observe_run` | `run_id` | `{status, recent_events, partial_output}` | — |
-| `aevatar_query_readmodel` | `readmodel_name`, typed `query` | typed result | — |
+| `aevatar_observe_run` | typed oneof target: `service_run`, `gagent_terminal_correlation`, `gagent_terminal_session`, or `workflow_current_state` | `{status, recent_events, partial_output}` | — |
 
 Payloads are typed proto, not free-form JSON. The dispatcher validates the
 proto schema before executing; a malformed call returns a structured error
@@ -234,7 +233,9 @@ deferred:
 - `/ws/voice/{actorId}` dev bypass is preserved.
 - This ADR does not redesign the read-path for sub-run state observation;
   `aevatar_observe_run` reads through the existing readmodel projection
-  surfaces. No new readmodel is introduced.
+  surfaces, one typed target per call. Ordinary workflow queries stay on
+  the workflow-owned `workflow_actor_current_state`, `workflow_status`, and
+  `event_query` tools. No new readmodel is introduced.
 
 ## Verification
 
@@ -290,7 +291,7 @@ Stage 1's tool sources are merged.
 
 | Stage | Scope | Breaking? |
 |---|---|---|
-| **1** | Implement `aevatar_invoke_gagent` / `_team` / `_workflow` / `_observe_run` / `_query_readmodel` as `IAgentToolSource`. Wire into existing ToolCallLoop. Verify Lark outbound user-scoped path (D7 prerequisite). | No |
+| **1** | Implement `aevatar_invoke_gagent` / `_team` / `_workflow` / `_observe_run` as `IAgentToolSource`. Wire into existing ToolCallLoop. Verify Lark outbound user-scoped path (D7 prerequisite). | No |
 | **2** | Extend `ForwardToModel` proto with `tool_set_ref` + `tool_choice_hint`. Policy authors express GAgent, team, and workflow targets directly as tool-first `ForwardToModel` actions. ChatRun-owned SSE session continuation remains deferred. | No |
 | **3** | Delete legacy wire actions and migration path. Reserve old proto tags/names for `ForwardToGAgent`, `ForwardToTeam`, `ForwardToWorkflow`, and `Bypass`; no new policy writer may emit them. | Yes (clients still using legacy actions) |
 | **4** | Remove code paths: `ResponsesEndpoints.cs:779-927`, `AgentRunGAgent.cs:1108-1141`, resolver branches for legacy actions. `/v1/messages` 501 fallback for these actions deleted. | Yes (clients still using legacy actions) |

--- a/docs/canon/status-dashboard.md
+++ b/docs/canon/status-dashboard.md
@@ -112,9 +112,9 @@ tick 通过 `ScheduleSelfDurableTimeoutAsync` 调度，回到同一个 actor inb
 Mainnet Host 额外注册 `aevatar_core_loop` executor。它不调用 LLM、不创建 run、不调用固定 actor/team，只验证 host 组合层是否仍具备 core-loop 所需能力：
 
 1. `workspace.default` tool set 可解析。
-2. 五个 Aevatar invocation tools 可发现，且具备 description、parameters schema 与 `IAevatarInvocationTool` 契约。
+2. 四个 Aevatar invocation tools 可发现，且具备 description、parameters schema 与 `IAevatarInvocationTool` 契约。
 3. route policy 使用 `ForwardToModel + tool_choice_hint` 表达 `aevatar_invoke_gagent`、`aevatar_invoke_team`、`aevatar_start_workflow` 目标；旧 GAgent/team wire action 已删除。
-4. `wait=complete` 在 `aevatar_invoke_gagent`、`aevatar_invoke_team`、`aevatar_start_workflow` 上只保留公开参数与 accepted/streaming receipt 语义；完成态由 `aevatar_observe_run` 或 `aevatar_query_readmodel` 读取 readmodel 获取，不再进入 ChatRun completion 协调。
+4. `wait=complete` 在 `aevatar_invoke_gagent`、`aevatar_invoke_team`、`aevatar_start_workflow` 上只保留公开参数与 accepted/streaming receipt 语义；完成态由 typed `aevatar_observe_run` target 读取单一 readmodel 获取，不再进入 ChatRun completion 协调。普通 workflow 查询走 workflow-owned `workflow_actor_current_state`、`workflow_status`、`event_query`。
 
 `http_status` 支持的常用参数：
 

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
@@ -14,7 +13,6 @@ using Aevatar.AGUI.Contracts;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Google.Protobuf;
-using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -42,15 +40,6 @@ public sealed class AevatarInvocationDispatcher
         LLMRequestMetadataKeys.ConnectedServicesContext,
         "scope_id",
     ];
-
-    private static readonly JsonFormatter ProtoJsonFormatter = new(
-        JsonFormatter.Settings.Default
-            .WithFormatDefaultValues(false)
-            .WithTypeRegistry(TypeRegistry.FromFiles(
-                AGUIEvent.Descriptor.File,
-                AnyReflection.Descriptor,
-                StructReflection.Descriptor,
-                WrappersReflection.Descriptor)));
 
     private readonly IActorDispatchPort _actorDispatchPort;
     private readonly IGAgentActorRegistryQueryPort _actorRegistryQueryPort;
@@ -288,80 +277,20 @@ public sealed class AevatarInvocationDispatcher
             return AevatarInvocationJson.Error(parsed.Error);
 
         var request = parsed.Value!;
-        var error = ProtoToolArguments.Require(request.RunId, "run_id", "run_id is required.");
-        if (error != null)
-            return AevatarInvocationJson.Error(error);
-
-        var runId = request.RunId.Trim();
-        var scope = ResolveCallerScope(requireOwner: false);
-        if (scope.Error != null)
-            return AevatarInvocationJson.Error(scope.Error);
-
-        ServiceRunSnapshot? serviceRun = null;
-        if (!string.IsNullOrWhiteSpace(request.ServiceId))
+        return request.TargetCase switch
         {
-            serviceRun = await _serviceRunQueryPort.GetByRunIdAsync(
-                scope.Value!.ScopeId,
-                request.ServiceId.Trim(),
-                runId,
-                ct);
-        }
-
-        var actorId = FirstNonEmpty(request.ActorId, serviceRun?.TargetActorId, serviceRun?.ActorId);
-        if (!string.IsNullOrWhiteSpace(actorId))
-        {
-            var terminal = await _terminalQueryPort.GetByCorrelationIdAsync(actorId!, runId, ct)
-                           ?? await _terminalQueryPort.GetBySessionIdAsync(actorId!, runId, ct);
-            if (terminal != null)
-                return AevatarInvocationJson.Serialize(MapTerminal(terminal, runId));
-
-            var workflow = await _workflowQueryService.GetWorkflowActorCurrentStateAsync(actorId!, ct);
-            if (workflow != null &&
-                (string.IsNullOrWhiteSpace(workflow.LastCommandId) ||
-                 string.Equals(workflow.LastCommandId, runId, StringComparison.Ordinal)))
-            {
-                return AevatarInvocationJson.Serialize(MapWorkflowSnapshot(workflow, runId, request.Take));
-            }
-        }
-
-        if (serviceRun != null)
-            return AevatarInvocationJson.Serialize(MapServiceRun(serviceRun));
-
-        return AevatarInvocationJson.Serialize(new ObserveRunResult
-        {
-            RunId = runId,
-            Error = Error(
-                "run_not_found",
-                "No registered service run, terminal GAgent snapshot, or workflow snapshot matched the requested run_id."),
-        });
-    }
-
-    public async Task<string> QueryReadModelAsync(string argumentsJson, CancellationToken ct = default)
-    {
-        var parsed = ProtoToolArguments.Parse<QueryReadModelToolRequest>(argumentsJson);
-        if (parsed.Error != null)
-            return AevatarInvocationJson.Error(parsed.Error);
-
-        var request = parsed.Value!;
-        var error = ProtoToolArguments.Require(request.ReadmodelName, "readmodel_name", "readmodel_name is required.") ??
-                    ProtoToolArguments.RequireMessage(request.Query, "query");
-        if (error != null)
-            return AevatarInvocationJson.Error(error);
-
-        return request.ReadmodelName.Trim() switch
-        {
-            AevatarInvocationReadModels.ServiceRunCurrentState => await QueryServiceRunAsync(request.Query, ct),
-            AevatarInvocationReadModels.GAgentRunTerminal => await QueryGAgentRunTerminalAsync(request.Query, ct),
-            AevatarInvocationReadModels.WorkflowActorCurrentState => await QueryWorkflowActorSnapshotAsync(request.Query, ct),
-            AevatarInvocationReadModels.WorkflowActorTimeline => await QueryWorkflowActorTimelineAsync(request.Query, ct),
-            _ => AevatarInvocationJson.Serialize(new QueryReadModelResult
-            {
-                ReadmodelName = request.ReadmodelName,
-                Error = Error(
-                    "readmodel_not_registered",
-                    $"readmodel_name must be one of: {string.Join(", ", AevatarInvocationToolSchemas.ReadModelNames)}",
-                    "readmodel_name"),
-            }),
+            ObserveRunToolRequest.TargetOneofCase.ServiceRun =>
+                await ObserveServiceRunAsync(request.ServiceRun, ct),
+            ObserveRunToolRequest.TargetOneofCase.GagentTerminalCorrelation =>
+                await ObserveGAgentTerminalCorrelationAsync(request.GagentTerminalCorrelation, ct),
+            ObserveRunToolRequest.TargetOneofCase.GagentTerminalSession =>
+                await ObserveGAgentTerminalSessionAsync(request.GagentTerminalSession, ct),
+            ObserveRunToolRequest.TargetOneofCase.WorkflowCurrentState =>
+                await ObserveWorkflowCurrentStateAsync(request.WorkflowCurrentState, ct),
+            _ => AevatarInvocationJson.Error(Error(
+                "invalid_arguments",
+                "one of service_run, gagent_terminal_correlation, gagent_terminal_session, or workflow_current_state is required.",
+                "target")),
         };
     }
 
@@ -623,144 +552,125 @@ public sealed class AevatarInvocationDispatcher
         return ActorTargetResolution.Success(group.ActorIds[0]);
     }
 
-    private async Task<string> QueryServiceRunAsync(ReadModelQuery query, CancellationToken ct)
+    private async Task<string> ObserveServiceRunAsync(
+        ServiceRunObservationTarget target,
+        CancellationToken ct)
     {
         var scope = ResolveCallerScope(requireOwner: false);
         if (scope.Error != null)
             return AevatarInvocationJson.Error(scope.Error);
 
-        if (string.IsNullOrWhiteSpace(query.ServiceId))
-        {
-            return AevatarInvocationJson.Serialize(new QueryReadModelResult
-            {
-                ReadmodelName = AevatarInvocationReadModels.ServiceRunCurrentState,
-                Error = Error("invalid_arguments", "query.service_id is required.", "query.service_id"),
-            });
-        }
+        var error = ProtoToolArguments.Require(
+                        target.ServiceId,
+                        "service_run.service_id",
+                        "service_run.service_id is required.") ??
+                    ProtoToolArguments.Require(
+                        target.RunId,
+                        "service_run.run_id",
+                        "service_run.run_id is required.");
+        if (error != null)
+            return AevatarInvocationJson.Error(error);
 
-        ServiceRunSnapshot? one = null;
-        if (!string.IsNullOrWhiteSpace(query.RunId))
-        {
-            one = await _serviceRunQueryPort.GetByRunIdAsync(
-                scope.Value!.ScopeId,
-                query.ServiceId.Trim(),
-                query.RunId.Trim(),
-                ct);
-        }
-        else if (!string.IsNullOrWhiteSpace(query.CommandId))
-        {
-            one = await _serviceRunQueryPort.GetByCommandIdAsync(
-                scope.Value!.ScopeId,
-                query.ServiceId.Trim(),
-                query.CommandId.Trim(),
-                ct);
-        }
-
-        if (one != null)
-        {
-            return AevatarInvocationJson.Serialize(new QueryReadModelResult
-            {
-                ReadmodelName = AevatarInvocationReadModels.ServiceRunCurrentState,
-                ResultJson = AevatarInvocationJson.ToJson(one),
-                Count = 1,
-            });
-        }
-
-        var items = await _serviceRunQueryPort.ListAsync(
-            new ServiceRunQuery(
-                scope.Value!.ScopeId,
-                query.ServiceId.Trim(),
-                BoundTake(query.Take)),
+        var serviceRun = await _serviceRunQueryPort.GetByRunIdAsync(
+            scope.Value!.ScopeId,
+            target.ServiceId.Trim(),
+            target.RunId.Trim(),
             ct);
-        return AevatarInvocationJson.Serialize(new QueryReadModelResult
-        {
-            ReadmodelName = AevatarInvocationReadModels.ServiceRunCurrentState,
-            ResultJson = AevatarInvocationJson.ToJson(items),
-            Count = items.Count,
-        });
+        return serviceRun == null
+            ? AevatarInvocationJson.Serialize(NotFound(
+                target.RunId.Trim(),
+                "service_run_not_found",
+                "No service run current-state readmodel matched service_run.service_id and service_run.run_id."))
+            : AevatarInvocationJson.Serialize(MapServiceRun(serviceRun));
     }
 
-    private async Task<string> QueryGAgentRunTerminalAsync(ReadModelQuery query, CancellationToken ct)
+    private async Task<string> ObserveGAgentTerminalCorrelationAsync(
+        GAgentTerminalCorrelationObservationTarget target,
+        CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(query.ActorId))
-        {
-            return AevatarInvocationJson.Serialize(new QueryReadModelResult
-            {
-                ReadmodelName = AevatarInvocationReadModels.GAgentRunTerminal,
-                Error = Error("invalid_arguments", "query.actor_id is required.", "query.actor_id"),
-            });
-        }
-
-        var correlationId = FirstNonEmpty(query.CommandId, query.RunId, query.Id);
-        if (string.IsNullOrWhiteSpace(correlationId))
-        {
-            return AevatarInvocationJson.Serialize(new QueryReadModelResult
-            {
-                ReadmodelName = AevatarInvocationReadModels.GAgentRunTerminal,
-                Error = Error("invalid_arguments", "query.command_id, query.run_id, or query.id is required.", "query.run_id"),
-            });
-        }
+        var error = ProtoToolArguments.Require(
+                        target.ActorId,
+                        "gagent_terminal_correlation.actor_id",
+                        "gagent_terminal_correlation.actor_id is required.") ??
+                    ProtoToolArguments.Require(
+                        target.CorrelationId,
+                        "gagent_terminal_correlation.correlation_id",
+                        "gagent_terminal_correlation.correlation_id is required.");
+        if (error != null)
+            return AevatarInvocationJson.Error(error);
 
         var snapshot = await _terminalQueryPort.GetByCorrelationIdAsync(
-            query.ActorId.Trim(),
-            correlationId!,
+            target.ActorId.Trim(),
+            target.CorrelationId.Trim(),
             ct);
-        return AevatarInvocationJson.Serialize(new QueryReadModelResult
-        {
-            ReadmodelName = AevatarInvocationReadModels.GAgentRunTerminal,
-            ResultJson = snapshot == null ? "null" : AevatarInvocationJson.ToJson(snapshot),
-            Count = snapshot == null ? 0 : 1,
-        });
+        return snapshot == null
+            ? AevatarInvocationJson.Serialize(NotFound(
+                target.CorrelationId.Trim(),
+                "gagent_terminal_not_found",
+                "No GAgent terminal readmodel matched gagent_terminal_correlation.actor_id and gagent_terminal_correlation.correlation_id."))
+            : AevatarInvocationJson.Serialize(MapTerminal(snapshot, target.CorrelationId.Trim()));
     }
 
-    private async Task<string> QueryWorkflowActorSnapshotAsync(ReadModelQuery query, CancellationToken ct)
+    private async Task<string> ObserveGAgentTerminalSessionAsync(
+        GAgentTerminalSessionObservationTarget target,
+        CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(query.ActorId))
-        {
-            return AevatarInvocationJson.Serialize(new QueryReadModelResult
-            {
-                ReadmodelName = AevatarInvocationReadModels.WorkflowActorCurrentState,
-                Error = Error("invalid_arguments", "query.actor_id is required.", "query.actor_id"),
-            });
-        }
+        var error = ProtoToolArguments.Require(
+                        target.ActorId,
+                        "gagent_terminal_session.actor_id",
+                        "gagent_terminal_session.actor_id is required.") ??
+                    ProtoToolArguments.Require(
+                        target.SessionId,
+                        "gagent_terminal_session.session_id",
+                        "gagent_terminal_session.session_id is required.");
+        if (error != null)
+            return AevatarInvocationJson.Error(error);
 
-        var snapshot = await _workflowQueryService.GetWorkflowActorCurrentStateAsync(query.ActorId.Trim(), ct);
-        return AevatarInvocationJson.Serialize(new QueryReadModelResult
-        {
-            ReadmodelName = AevatarInvocationReadModels.WorkflowActorCurrentState,
-            ResultJson = snapshot == null ? "null" : ProtoJsonFormatter.Format(snapshot),
-            Count = snapshot == null ? 0 : 1,
-        });
+        var snapshot = await _terminalQueryPort.GetBySessionIdAsync(
+            target.ActorId.Trim(),
+            target.SessionId.Trim(),
+            ct);
+        return snapshot == null
+            ? AevatarInvocationJson.Serialize(NotFound(
+                target.SessionId.Trim(),
+                "gagent_terminal_not_found",
+                "No GAgent terminal readmodel matched gagent_terminal_session.actor_id and gagent_terminal_session.session_id."))
+            : AevatarInvocationJson.Serialize(MapTerminal(snapshot, target.SessionId.Trim()));
     }
 
-    private async Task<string> QueryWorkflowActorTimelineAsync(ReadModelQuery query, CancellationToken ct)
+    private async Task<string> ObserveWorkflowCurrentStateAsync(
+        WorkflowCurrentStateObservationTarget target,
+        CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(query.ActorId))
+        var error = ProtoToolArguments.Require(
+            target.ActorId,
+            "workflow_current_state.actor_id",
+            "workflow_current_state.actor_id is required.");
+        if (error != null)
+            return AevatarInvocationJson.Error(error);
+
+        var snapshot = await _workflowQueryService.GetWorkflowActorCurrentStateAsync(target.ActorId.Trim(), ct);
+        if (snapshot == null)
         {
-            return AevatarInvocationJson.Serialize(new QueryReadModelResult
-            {
-                ReadmodelName = AevatarInvocationReadModels.WorkflowActorTimeline,
-                Error = Error("invalid_arguments", "query.actor_id is required.", "query.actor_id"),
-            });
+            return AevatarInvocationJson.Serialize(NotFound(
+                target.CommandId.Trim(),
+                "workflow_current_state_not_found",
+                "No workflow current-state readmodel matched workflow_current_state.actor_id."));
         }
 
-        var items = await _workflowQueryService.ListWorkflowRunTimelineExportAsync(
-            query.ActorId.Trim(),
-            BoundTake(query.Take),
-            ct);
-        return AevatarInvocationJson.Serialize(new QueryReadModelResult
+        if (!string.IsNullOrWhiteSpace(target.CommandId) &&
+            !string.Equals(snapshot.LastCommandId, target.CommandId.Trim(), StringComparison.Ordinal))
         {
-            ReadmodelName = AevatarInvocationReadModels.WorkflowActorTimeline,
-            ResultJson = ProtoJsonFormatter.Format(new ListValue
-            {
-                Values =
-                {
-                    items.Select(item => Value.ForStruct(JsonParser.Default.Parse<Struct>(
-                        ProtoJsonFormatter.Format(item)))),
-                },
-            }),
-            Count = items.Count,
-        });
+            return AevatarInvocationJson.Serialize(NotFound(
+                target.CommandId.Trim(),
+                "workflow_current_state_not_found",
+                "Workflow current-state readmodel actor matched, but last_command_id did not match workflow_current_state.command_id."));
+        }
+
+        var observedRunId = string.IsNullOrWhiteSpace(target.CommandId)
+            ? snapshot.LastCommandId
+            : target.CommandId.Trim();
+        return AevatarInvocationJson.Serialize(MapWorkflowSnapshot(snapshot, observedRunId));
     }
 
     private static ObserveRunResult MapTerminal(GAgentRunTerminalSnapshot terminal, string runId) =>
@@ -784,13 +694,12 @@ public sealed class AevatarInvocationDispatcher
 
     private static ObserveRunResult MapWorkflowSnapshot(
         WorkflowActorSnapshot snapshot,
-        string runId,
-        int take)
+        string runId)
     {
         var result = new ObserveRunResult
         {
             RunId = runId,
-            Status = snapshot.CompletionStatusValue.ToString(),
+            Status = snapshot.CompletionStatus.ToString(),
             PartialOutput = snapshot.LastOutput,
             ActorId = snapshot.ActorId,
             CommandId = snapshot.LastCommandId,
@@ -804,6 +713,16 @@ public sealed class AevatarInvocationDispatcher
         });
         return result;
     }
+
+    private static ObserveRunResult NotFound(
+        string runId,
+        string code,
+        string message) =>
+        new()
+        {
+            RunId = runId,
+            Error = Error(code, message),
+        };
 
     private static ObserveRunResult MapServiceRun(ServiceRunSnapshot snapshot) =>
         new()
@@ -1055,8 +974,6 @@ public sealed class AevatarInvocationDispatcher
         wait == InvocationWaitMode.Unspecified
             ? InvocationWaitMode.Stream
             : wait;
-
-    private static int BoundTake(int take) => take <= 0 ? 50 : Math.Clamp(take, 1, 200);
 
     private static string ResolveCommandId() =>
         Normalize(AgentToolRequestContext.CallId)

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationJson.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationJson.cs
@@ -60,16 +60,6 @@ internal static class AevatarInvocationJson
             }, Options)
             : Error(result.Error);
 
-    public static string Serialize(QueryReadModelResult result) =>
-        result.Error == null
-            ? JsonSerializer.Serialize(new
-            {
-                readmodel_name = result.ReadmodelName,
-                result = TryParseJson(result.ResultJson),
-                count = result.Count,
-            }, Options)
-            : Error(result.Error);
-
     public static Dictionary<string, string> ToDictionary(MapField<string, string> source)
     {
         var result = new Dictionary<string, string>(StringComparer.Ordinal);

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationReadModels.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationReadModels.cs
@@ -1,9 +1,0 @@
-namespace Aevatar.AI.ToolProviders.AevatarInvocation;
-
-internal static class AevatarInvocationReadModels
-{
-    public const string ServiceRunCurrentState = "service_run_current_state";
-    public const string GAgentRunTerminal = "gagent_run_terminal";
-    public const string WorkflowActorCurrentState = "workflow_actor_current_state";
-    public const string WorkflowActorTimeline = "workflow_actor_timeline";
-}

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSchemas.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSchemas.cs
@@ -9,18 +9,6 @@ internal static class AevatarInvocationToolSchemas
             ["kind"] = ["text", "image", "audio", "video"],
         };
 
-    private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> ReadModelValues =
-        new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
-        {
-            ["readmodel_name"] =
-            [
-                AevatarInvocationReadModels.ServiceRunCurrentState,
-                AevatarInvocationReadModels.GAgentRunTerminal,
-                AevatarInvocationReadModels.WorkflowActorCurrentState,
-                AevatarInvocationReadModels.WorkflowActorTimeline,
-            ],
-        };
-
     public static readonly string InvokeGAgent = ProtoToolSchema.Build(
         InvokeGAgentToolRequest.Descriptor,
         requiredFields: new HashSet<string>(StringComparer.Ordinal) { "payload" },
@@ -53,16 +41,11 @@ internal static class AevatarInvocationToolSchemas
 
     public static readonly string ObserveRun = ProtoToolSchema.Build(
         ObserveRunToolRequest.Descriptor,
-        requiredFields: new HashSet<string>(StringComparer.Ordinal) { "run_id" });
-
-    public static readonly string QueryReadModel = ProtoToolSchema.Build(
-        QueryReadModelToolRequest.Descriptor,
-        requiredFields: new HashSet<string>(StringComparer.Ordinal)
-        {
-            "readmodel_name",
-            "query",
-        },
-        stringEnums: ReadModelValues);
-
-    public static IReadOnlyList<string> ReadModelNames => ReadModelValues["readmodel_name"];
+        oneOfRequiredGroups:
+        [
+            ["service_run"],
+            ["gagent_terminal_correlation"],
+            ["gagent_terminal_session"],
+            ["workflow_current_state"],
+        ]);
 }

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSources.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSources.cs
@@ -54,19 +54,6 @@ public sealed class ObserveRunToolSource : IAgentToolSource
         Task.FromResult<IReadOnlyList<IAgentTool>>([new ObserveRunTool(_dispatcher)]);
 }
 
-public sealed class QueryReadModelToolSource : IAgentToolSource
-{
-    private readonly AevatarInvocationDispatcher _dispatcher;
-
-    public QueryReadModelToolSource(AevatarInvocationDispatcher dispatcher)
-    {
-        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
-    }
-
-    public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default) =>
-        Task.FromResult<IReadOnlyList<IAgentTool>>([new QueryReadModelTool(_dispatcher)]);
-}
-
 internal sealed class InvokeGAgentTool : IAevatarInvocationTool
 {
     private readonly AevatarInvocationDispatcher _dispatcher;
@@ -140,7 +127,7 @@ internal sealed class ObserveRunTool : IAevatarInvocationTool
     public string Name => "aevatar_observe_run";
 
     public string Description =>
-        "Observe a previously accepted Aevatar run by run_id through existing run and projection read models.";
+        "Observe a previously accepted Aevatar run through one explicitly selected readmodel target.";
 
     public string ParametersSchema => AevatarInvocationToolSchemas.ObserveRun;
 
@@ -148,26 +135,4 @@ internal sealed class ObserveRunTool : IAevatarInvocationTool
 
     public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
         _dispatcher.ObserveRunAsync(argumentsJson, ct);
-}
-
-internal sealed class QueryReadModelTool : IAevatarInvocationTool
-{
-    private readonly AevatarInvocationDispatcher _dispatcher;
-
-    public QueryReadModelTool(AevatarInvocationDispatcher dispatcher)
-    {
-        _dispatcher = dispatcher;
-    }
-
-    public string Name => "aevatar_query_readmodel";
-
-    public string Description =>
-        "Read one of the closed-set Aevatar current-state read models by name and typed query.";
-
-    public string ParametersSchema => AevatarInvocationToolSchemas.QueryReadModel;
-
-    public bool IsReadOnly => true;
-
-    public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
-        _dispatcher.QueryReadModelAsync(argumentsJson, ct);
 }

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/ServiceCollectionExtensions.cs
@@ -15,7 +15,6 @@ public static class ServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IAgentToolSource, InvokeTeamToolSource>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IAgentToolSource, StartWorkflowToolSource>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IAgentToolSource, ObserveRunToolSource>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IAgentToolSource, QueryReadModelToolSource>());
         return services;
     }
 }

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/aevatar_invocation_tools.proto
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/aevatar_invocation_tools.proto
@@ -59,25 +59,33 @@ message StartWorkflowToolRequest {
   repeated string workflow_yamls = 5;
 }
 
+message ServiceRunObservationTarget {
+  string service_id = 1;
+  string run_id = 2;
+}
+
+message GAgentTerminalCorrelationObservationTarget {
+  string actor_id = 1;
+  string correlation_id = 2;
+}
+
+message GAgentTerminalSessionObservationTarget {
+  string actor_id = 1;
+  string session_id = 2;
+}
+
+message WorkflowCurrentStateObservationTarget {
+  string actor_id = 1;
+  string command_id = 2;
+}
+
 message ObserveRunToolRequest {
-  string run_id = 1;
-  string actor_id = 2;
-  string service_id = 3;
-  int32 take = 4;
-}
-
-message ReadModelQuery {
-  string id = 1;
-  string actor_id = 2;
-  string run_id = 3;
-  string service_id = 4;
-  string command_id = 5;
-  int32 take = 6;
-}
-
-message QueryReadModelToolRequest {
-  string readmodel_name = 1;
-  ReadModelQuery query = 2;
+  oneof target {
+    ServiceRunObservationTarget service_run = 1;
+    GAgentTerminalCorrelationObservationTarget gagent_terminal_correlation = 2;
+    GAgentTerminalSessionObservationTarget gagent_terminal_session = 3;
+    WorkflowCurrentStateObservationTarget workflow_current_state = 4;
+  }
 }
 
 message InvocationToolError {
@@ -116,11 +124,4 @@ message ObserveRunResult {
   string actor_id = 6;
   string command_id = 7;
   int64 state_version = 8;
-}
-
-message QueryReadModelResult {
-  string readmodel_name = 1;
-  string result_json = 2;
-  InvocationToolError error = 3;
-  int32 count = 4;
 }

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -273,7 +273,6 @@ public static class MainnetHostBuilderExtensions
                     CreateToolSource<InvokeTeamToolSource>,
                     CreateToolSource<StartWorkflowToolSource>,
                     CreateToolSource<ObserveRunToolSource>,
-                    CreateToolSource<QueryReadModelToolSource>,
                     CreateToolSource<ResponsesAevatarToolProvider>,
                     CreateToolSource<ChannelInteractiveReplyToolSource>,
                     CreateToolSource<ChannelRegistrationToolSource>,

--- a/src/Aevatar.Mainnet.Host.Api/Status/AevatarCoreLoopStatusProbeExecutor.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Status/AevatarCoreLoopStatusProbeExecutor.cs
@@ -18,7 +18,6 @@ internal sealed class AevatarCoreLoopStatusProbeExecutor : IHealthProbeExecutor
         "aevatar_invoke_team",
         "aevatar_start_workflow",
         "aevatar_observe_run",
-        "aevatar_query_readmodel",
     ];
 
     private readonly IToolSetRegistry _toolSetRegistry;
@@ -145,7 +144,6 @@ internal sealed class AevatarCoreLoopStatusProbeExecutor : IHealthProbeExecutor
             typeof(InvokeTeamToolSource),
             typeof(StartWorkflowToolSource),
             typeof(ObserveRunToolSource),
-            typeof(QueryReadModelToolSource),
         };
 
         foreach (var source in sources)
@@ -293,8 +291,7 @@ internal sealed class AevatarCoreLoopStatusProbeExecutor : IHealthProbeExecutor
         source is InvokeGAgentToolSource or
             InvokeTeamToolSource or
             StartWorkflowToolSource or
-            ObserveRunToolSource or
-            QueryReadModelToolSource;
+            ObserveRunToolSource;
 
     private static HealthProbeOutcome? VerifyCompletionObservationTools(
         IReadOnlyDictionary<string, IAgentTool> discovered)
@@ -311,11 +308,6 @@ internal sealed class AevatarCoreLoopStatusProbeExecutor : IHealthProbeExecutor
             return Failure(
                 "completion_observe_tool_not_read_only",
                 "aevatar_observe_run must remain a read-only readmodel observation tool.");
-
-        if (discovered["aevatar_query_readmodel"] is not IAevatarInvocationTool queryReadmodel || !queryReadmodel.IsReadOnly)
-            return Failure(
-                "completion_query_tool_not_read_only",
-                "aevatar_query_readmodel must remain a read-only readmodel query tool.");
 
         return null;
     }

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -990,6 +990,80 @@ public sealed class AevatarInvocationToolSourceTests
     }
 
     [Fact]
+    public async Task ObserveRun_ServiceRun_WhenReadModelIsMissing_ShouldReturnNotFoundWithoutFallback()
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync("aevatar_observe_run");
+
+        using var _ = PushContext(callId: "call-observe-service-run-missing");
+        var output = await tool.ExecuteAsync("""
+            {
+              "service_run": {
+                "service_id": "service-1",
+                "run_id": "missing-run"
+              }
+            }
+            """);
+
+        ErrorCode(output).Should().Be("service_run_not_found");
+        harness.ServiceRunQuery.LastScopeId.Should().Be("scope-1");
+        harness.ServiceRunQuery.LastServiceId.Should().Be("service-1");
+        harness.ServiceRunQuery.LastRunId.Should().Be("missing-run");
+        harness.ServiceRunQuery.LastCommandId.Should().BeNull();
+        harness.ServiceRunQuery.LastQuery.Should().BeNull();
+        harness.TerminalQuery.LastActorId.Should().BeNull();
+        harness.WorkflowQuery.LastCurrentStateActorId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ObserveRun_GAgentTerminalCorrelation_WhenReadModelIsMissing_ShouldReturnNotFoundWithoutFallback()
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync("aevatar_observe_run");
+
+        using var _ = PushContext(callId: "call-observe-terminal-correlation-missing");
+        var output = await tool.ExecuteAsync("""
+            {
+              "gagent_terminal_correlation": {
+                "actor_id": "actor-1",
+                "correlation_id": "missing-correlation"
+              }
+            }
+            """);
+
+        ErrorCode(output).Should().Be("gagent_terminal_not_found");
+        harness.TerminalQuery.LastActorId.Should().Be("actor-1");
+        harness.TerminalQuery.LastCorrelationId.Should().Be("missing-correlation");
+        harness.TerminalQuery.LastSessionId.Should().BeNull();
+        harness.ServiceRunQuery.LastRunId.Should().BeNull();
+        harness.WorkflowQuery.LastCurrentStateActorId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ObserveRun_GAgentTerminalSession_WhenReadModelIsMissing_ShouldReturnNotFoundWithoutFallback()
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync("aevatar_observe_run");
+
+        using var _ = PushContext(callId: "call-observe-terminal-session-missing");
+        var output = await tool.ExecuteAsync("""
+            {
+              "gagent_terminal_session": {
+                "actor_id": "actor-1",
+                "session_id": "missing-session"
+              }
+            }
+            """);
+
+        ErrorCode(output).Should().Be("gagent_terminal_not_found");
+        harness.TerminalQuery.LastActorId.Should().Be("actor-1");
+        harness.TerminalQuery.LastCorrelationId.Should().BeNull();
+        harness.TerminalQuery.LastSessionId.Should().Be("missing-session");
+        harness.ServiceRunQuery.LastRunId.Should().BeNull();
+        harness.WorkflowQuery.LastCurrentStateActorId.Should().BeNull();
+    }
+
+    [Fact]
     public async Task ObserveRun_ShouldReadServiceRunTargetWithCallerScopeOnly()
     {
         var harness = new Harness();
@@ -1142,6 +1216,54 @@ public sealed class AevatarInvocationToolSourceTests
         var output = await tool.ExecuteAsync("{}");
 
         ErrorCode(output).Should().Be("invalid_arguments");
+    }
+
+    [Theory]
+    [InlineData(
+        """
+        {
+          "service_run": {
+            "run_id": "run-1"
+          }
+        }
+        """)]
+    [InlineData(
+        """
+        {
+          "gagent_terminal_correlation": {
+            "correlation_id": "correlation-1"
+          }
+        }
+        """)]
+    [InlineData(
+        """
+        {
+          "gagent_terminal_session": {
+            "actor_id": "actor-1"
+          }
+        }
+        """)]
+    [InlineData(
+        """
+        {
+          "workflow_current_state": {
+            "command_id": "command-1"
+          }
+        }
+        """)]
+    public async Task ObserveRun_WhenNestedRequiredFieldIsMissing_ShouldReturnStructuredErrorWithoutFallback(
+        string argumentsJson)
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync("aevatar_observe_run");
+
+        using var _ = PushContext(callId: "call-observe-nested-missing");
+        var output = await tool.ExecuteAsync(argumentsJson);
+
+        ErrorCode(output).Should().Be("invalid_arguments");
+        harness.ServiceRunQuery.LastRunId.Should().BeNull();
+        harness.TerminalQuery.LastActorId.Should().BeNull();
+        harness.WorkflowQuery.LastCurrentStateActorId.Should().BeNull();
     }
 
     private static bool HasStrictObjectSchema(string schema)

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -23,7 +23,7 @@ namespace Aevatar.AI.ToolProviders.AevatarInvocation.Tests;
 public sealed class AevatarInvocationToolSourceTests
 {
     [Fact]
-    public async Task AddAevatarInvocationTools_ShouldRegisterFiveTaggedToolSources()
+    public async Task AddAevatarInvocationTools_ShouldRegisterFourTaggedToolSources()
     {
         var services = new ServiceCollection();
         var harness = new Harness();
@@ -39,7 +39,6 @@ public sealed class AevatarInvocationToolSourceTests
         sources.OfType<InvokeTeamToolSource>().Should().ContainSingle();
         sources.OfType<StartWorkflowToolSource>().Should().ContainSingle();
         sources.OfType<ObserveRunToolSource>().Should().ContainSingle();
-        sources.OfType<QueryReadModelToolSource>().Should().ContainSingle();
 
         var tools = new List<IAgentTool>();
         foreach (var source in sources)
@@ -49,8 +48,7 @@ public sealed class AevatarInvocationToolSourceTests
             "aevatar_invoke_gagent",
             "aevatar_invoke_team",
             "aevatar_start_workflow",
-            "aevatar_observe_run",
-            "aevatar_query_readmodel");
+            "aevatar_observe_run");
         tools.All(static tool => tool is IAevatarInvocationTool invocationTool &&
                                  invocationTool.ToolSetTag == AevatarInvocationToolTags.ToolSet)
             .Should()
@@ -84,24 +82,28 @@ public sealed class AevatarInvocationToolSourceTests
     }
 
     [Fact]
-    public async Task QueryReadModelSchema_ShouldExposeClosedReadModelSet()
+    public async Task ObserveRunSchema_ShouldRequireTypedTarget()
     {
-        var tool = await DiscoverSingleAsync(new QueryReadModelToolSource(new Harness().CreateDispatcher()));
+        var tool = await DiscoverSingleAsync(new ObserveRunToolSource(new Harness().CreateDispatcher()));
         using var doc = JsonDocument.Parse(tool.ParametersSchema);
 
-        var values = doc.RootElement
+        var properties = doc.RootElement
             .GetProperty("properties")
-            .GetProperty("readmodel_name")
-            .GetProperty("enum")
+            .EnumerateObject()
+            .Select(static item => item.Name)
+            .ToArray();
+        var oneOfRequired = doc.RootElement
+            .GetProperty("oneOf")
             .EnumerateArray()
-            .Select(static item => item.GetString())
+            .Select(static item => item.GetProperty("required")[0].GetString())
             .ToArray();
 
-        values.Should().BeEquivalentTo(
-            "service_run_current_state",
-            "gagent_run_terminal",
-            "workflow_actor_current_state",
-            "workflow_actor_timeline");
+        properties.Should().BeEquivalentTo(
+            "service_run",
+            "gagent_terminal_correlation",
+            "gagent_terminal_session",
+            "workflow_current_state");
+        oneOfRequired.Should().BeEquivalentTo(properties);
     }
 
     [Theory]
@@ -109,7 +111,6 @@ public sealed class AevatarInvocationToolSourceTests
     [InlineData("aevatar_invoke_team", """{"team_id":"team"}""")]
     [InlineData("aevatar_start_workflow", """{"workflow_id":"wf"}""")]
     [InlineData("aevatar_observe_run", "{}")]
-    [InlineData("aevatar_query_readmodel", """{"readmodel_name":"service_run_current_state"}""")]
     public async Task Tools_ShouldReturnStructuredValidationError(string toolName, string argumentsJson)
     {
         var harness = new Harness();
@@ -912,7 +913,7 @@ public sealed class AevatarInvocationToolSourceTests
     }
 
     [Fact]
-    public async Task ObserveRun_ShouldReadExistingTerminalSnapshot()
+    public async Task ObserveRun_ShouldReadTerminalCorrelationTargetOnly()
     {
         var harness = new Harness();
         harness.TerminalQuery.ByCorrelationId = new GAgentRunTerminalSnapshot(
@@ -931,14 +932,19 @@ public sealed class AevatarInvocationToolSourceTests
         using var _ = PushContext(callId: "call-observe");
         var output = await tool.ExecuteAsync("""
             {
-              "run_id": "run-1",
-              "actor_id": "actor-1"
+              "gagent_terminal_correlation": {
+                "actor_id": "actor-1",
+                "correlation_id": "run-1"
+              }
             }
             """);
 
         ErrorCodeOrNull(output).Should().BeNull(output);
         harness.TerminalQuery.LastActorId.Should().Be("actor-1");
         harness.TerminalQuery.LastCorrelationId.Should().Be("run-1");
+        harness.TerminalQuery.LastSessionId.Should().BeNull();
+        harness.ServiceRunQuery.LastRunId.Should().BeNull();
+        harness.WorkflowQuery.LastCurrentStateActorId.Should().BeNull();
         var result = Read(output);
         result.GetProperty("run_id").GetString().Should().Be("run-1");
         result.GetProperty("status").GetString().Should().Be(nameof(GAgentRunTerminalStatus.RunFinished));
@@ -946,10 +952,10 @@ public sealed class AevatarInvocationToolSourceTests
     }
 
     [Fact]
-    public async Task ObserveRun_WhenCallerScopeIsUnavailable_ShouldFastFail()
+    public async Task ObserveRun_ShouldReadTerminalSessionTargetOnly()
     {
         var harness = new Harness();
-        harness.TerminalQuery.ByCorrelationId = new GAgentRunTerminalSnapshot(
+        harness.TerminalQuery.BySessionId = new GAgentRunTerminalSnapshot(
             "actor-1",
             "session-1",
             "run-1",
@@ -962,73 +968,180 @@ public sealed class AevatarInvocationToolSourceTests
             DateTimeOffset.UtcNow);
         var tool = await harness.DiscoverToolAsync("aevatar_observe_run");
 
-        using var _ = PushContext(callId: "call-observe-no-scope", scopeId: null);
+        using var _ = PushContext(callId: "call-observe-session");
         var output = await tool.ExecuteAsync("""
             {
-              "run_id": "run-1",
-              "actor_id": "actor-1"
-            }
-            """);
-
-        ErrorCode(output).Should().Be("caller_scope_unavailable");
-        harness.TerminalQuery.LastActorId.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task ObserveRun_WhenNoReadModelMatches_ShouldReturnStructuredError()
-    {
-        var harness = new Harness();
-        var tool = await harness.DiscoverToolAsync("aevatar_observe_run");
-
-        using var _ = PushContext(callId: "call-observe-missing");
-        var output = await tool.ExecuteAsync("""{"run_id":"missing","actor_id":"actor-1"}""");
-
-        ErrorCode(output).Should().Be("run_not_found");
-    }
-
-    [Fact]
-    public async Task QueryReadModel_ShouldUseClosedServiceRunReaderWithCallerScope()
-    {
-        var harness = new Harness();
-        harness.ServiceRunQuery.ListResult =
-        [
-            BuildServiceRun("scope-1", "service-1", "run-1", "command-1"),
-        ];
-        var tool = await harness.DiscoverToolAsync("aevatar_query_readmodel");
-
-        using var _ = PushContext(callId: "call-query");
-        var output = await tool.ExecuteAsync("""
-            {
-              "readmodel_name": "service_run_current_state",
-              "query": {
-                "service_id": "service-1",
-                "take": 10
+              "gagent_terminal_session": {
+                "actor_id": "actor-1",
+                "session_id": "session-1"
               }
             }
             """);
 
         ErrorCodeOrNull(output).Should().BeNull(output);
-        harness.ServiceRunQuery.LastQuery.Should().Be(new ServiceRunQuery("scope-1", "service-1", 10));
+        harness.TerminalQuery.LastActorId.Should().Be("actor-1");
+        harness.TerminalQuery.LastCorrelationId.Should().BeNull();
+        harness.TerminalQuery.LastSessionId.Should().Be("session-1");
+        harness.ServiceRunQuery.LastRunId.Should().BeNull();
+        harness.WorkflowQuery.LastCurrentStateActorId.Should().BeNull();
         var result = Read(output);
-        result.GetProperty("readmodel_name").GetString().Should().Be("service_run_current_state");
-        result.GetProperty("count").GetInt32().Should().Be(1);
+        result.GetProperty("run_id").GetString().Should().Be("session-1");
+        result.GetProperty("status").GetString().Should().Be(nameof(GAgentRunTerminalStatus.RunFinished));
     }
 
     [Fact]
-    public async Task QueryReadModel_WhenNameIsNotRegistered_ShouldReturnStructuredError()
+    public async Task ObserveRun_ShouldReadServiceRunTargetWithCallerScopeOnly()
     {
         var harness = new Harness();
-        var tool = await harness.DiscoverToolAsync("aevatar_query_readmodel");
+        harness.ServiceRunQuery.ByRunId = BuildServiceRun("scope-1", "service-1", "run-1", "command-1");
+        var tool = await harness.DiscoverToolAsync("aevatar_observe_run");
 
-        using var _ = PushContext(callId: "call-query-missing");
+        using var _ = PushContext(callId: "call-observe-service-run");
         var output = await tool.ExecuteAsync("""
             {
-              "readmodel_name": "arbitrary_collection",
-              "query": { "id": "1" }
+              "service_run": {
+                "service_id": "service-1",
+                "run_id": "run-1"
+              }
             }
             """);
 
-        ErrorCode(output).Should().Be("readmodel_not_registered");
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        harness.ServiceRunQuery.LastScopeId.Should().Be("scope-1");
+        harness.ServiceRunQuery.LastServiceId.Should().Be("service-1");
+        harness.ServiceRunQuery.LastRunId.Should().Be("run-1");
+        harness.ServiceRunQuery.LastCommandId.Should().BeNull();
+        harness.TerminalQuery.LastActorId.Should().BeNull();
+        harness.WorkflowQuery.LastCurrentStateActorId.Should().BeNull();
+        var result = Read(output);
+        result.GetProperty("run_id").GetString().Should().Be("run-1");
+        result.GetProperty("command_id").GetString().Should().Be("command-1");
+    }
+
+    [Fact]
+    public async Task ObserveRun_ServiceRun_WhenCallerScopeIsUnavailable_ShouldFastFail()
+    {
+        var harness = new Harness();
+        harness.ServiceRunQuery.ByRunId = BuildServiceRun("scope-1", "service-1", "run-1", "command-1");
+        var tool = await harness.DiscoverToolAsync("aevatar_observe_run");
+
+        using var _ = PushContext(callId: "call-observe-no-scope", scopeId: null);
+        var output = await tool.ExecuteAsync("""
+            {
+              "service_run": {
+                "service_id": "service-1",
+                "run_id": "run-1"
+              }
+            }
+            """);
+
+        ErrorCode(output).Should().Be("caller_scope_unavailable");
+        harness.ServiceRunQuery.LastScopeId.Should().BeNull();
+        harness.TerminalQuery.LastActorId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ObserveRun_ShouldReadWorkflowCurrentStateTargetOnly()
+    {
+        var harness = new Harness();
+        harness.WorkflowQuery.Snapshot = new WorkflowActorSnapshot
+        {
+            ActorId = "workflow-actor",
+            WorkflowName = "wf-main",
+            LastCommandId = "workflow-command",
+            CompletionStatus = WorkflowRunCompletionStatus.Completed,
+            StateVersion = 9,
+            LastOutput = "done",
+            LastUpdatedAt = DateTimeOffset.UtcNow,
+        };
+        var tool = await harness.DiscoverToolAsync("aevatar_observe_run");
+
+        using var _ = PushContext(callId: "call-observe-workflow");
+        var output = await tool.ExecuteAsync("""
+            {
+              "workflow_current_state": {
+                "actor_id": "workflow-actor",
+                "command_id": "workflow-command"
+              }
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        harness.WorkflowQuery.LastCurrentStateActorId.Should().Be("workflow-actor");
+        harness.TerminalQuery.LastActorId.Should().BeNull();
+        harness.ServiceRunQuery.LastRunId.Should().BeNull();
+        var result = Read(output);
+        result.GetProperty("run_id").GetString().Should().Be("workflow-command");
+        result.GetProperty("actor_id").GetString().Should().Be("workflow-actor");
+        result.GetProperty("status").GetString().Should().Be(nameof(WorkflowRunCompletionStatus.Completed));
+    }
+
+    [Fact]
+    public async Task ObserveRun_WorkflowCurrentState_WhenCommandIdIsOmitted_ShouldReturnSnapshotCommandId()
+    {
+        var harness = new Harness();
+        harness.WorkflowQuery.Snapshot = new WorkflowActorSnapshot
+        {
+            ActorId = "workflow-actor",
+            LastCommandId = "snapshot-command",
+            CompletionStatus = WorkflowRunCompletionStatus.Completed,
+        };
+        var tool = await harness.DiscoverToolAsync("aevatar_observe_run");
+
+        using var _ = PushContext(callId: "call-observe-workflow-current");
+        var output = await tool.ExecuteAsync("""
+            {
+              "workflow_current_state": {
+                "actor_id": "workflow-actor"
+              }
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        harness.WorkflowQuery.LastCurrentStateActorId.Should().Be("workflow-actor");
+        harness.TerminalQuery.LastActorId.Should().BeNull();
+        harness.ServiceRunQuery.LastRunId.Should().BeNull();
+        Read(output).GetProperty("run_id").GetString().Should().Be("snapshot-command");
+    }
+
+    [Fact]
+    public async Task ObserveRun_WorkflowCurrentState_WhenCommandIdDiffers_ShouldNotFallback()
+    {
+        var harness = new Harness();
+        harness.WorkflowQuery.Snapshot = new WorkflowActorSnapshot
+        {
+            ActorId = "workflow-actor",
+            LastCommandId = "newer-command",
+            CompletionStatus = WorkflowRunCompletionStatus.Completed,
+        };
+        var tool = await harness.DiscoverToolAsync("aevatar_observe_run");
+
+        using var _ = PushContext(callId: "call-observe-workflow-stale");
+        var output = await tool.ExecuteAsync("""
+            {
+              "workflow_current_state": {
+                "actor_id": "workflow-actor",
+                "command_id": "expected-command"
+              }
+            }
+            """);
+
+        ErrorCode(output).Should().Be("workflow_current_state_not_found");
+        harness.WorkflowQuery.LastCurrentStateActorId.Should().Be("workflow-actor");
+        harness.TerminalQuery.LastActorId.Should().BeNull();
+        harness.ServiceRunQuery.LastRunId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ObserveRun_WhenTargetIsMissing_ShouldReturnStructuredError()
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync("aevatar_observe_run");
+
+        using var _ = PushContext(callId: "call-observe-missing-target");
+        var output = await tool.ExecuteAsync("{}");
+
+        ErrorCode(output).Should().Be("invalid_arguments");
     }
 
     private static bool HasStrictObjectSchema(string schema)
@@ -1224,7 +1337,6 @@ public sealed class AevatarInvocationToolSourceTests
                 "aevatar_invoke_team" => new InvokeTeamToolSource(CreateDispatcher()),
                 "aevatar_start_workflow" => new StartWorkflowToolSource(CreateDispatcher()),
                 "aevatar_observe_run" => new ObserveRunToolSource(CreateDispatcher()),
-                "aevatar_query_readmodel" => new QueryReadModelToolSource(CreateDispatcher()),
                 _ => throw new ArgumentOutOfRangeException(nameof(toolName), toolName, null),
             };
             var tools = await source.DiscoverToolsAsync();
@@ -1359,6 +1471,7 @@ public sealed class AevatarInvocationToolSourceTests
         public string? LastScopeId { get; private set; }
         public string? LastServiceId { get; private set; }
         public string? LastRunId { get; private set; }
+        public string? LastCommandId { get; private set; }
         public IReadOnlyList<ServiceRunSnapshot> ListResult { get; set; } = [];
         public ServiceRunSnapshot? ByRunId { get; set; }
         public ServiceRunSnapshot? ByCommandId { get; set; }
@@ -1387,8 +1500,13 @@ public sealed class AevatarInvocationToolSourceTests
             string scopeId,
             string serviceId,
             string commandId,
-            CancellationToken ct = default) =>
-            Task.FromResult(ByCommandId);
+            CancellationToken ct = default)
+        {
+            LastScopeId = scopeId;
+            LastServiceId = serviceId;
+            LastCommandId = commandId;
+            return Task.FromResult(ByCommandId);
+        }
     }
 
     private sealed class RecordingTerminalQueryPort : IGAgentRunTerminalQueryPort
@@ -1425,6 +1543,7 @@ public sealed class AevatarInvocationToolSourceTests
         public bool WorkflowActorCurrentStateQueryEnabled => true;
         public WorkflowActorSnapshot? Snapshot { get; set; }
         public IReadOnlyList<WorkflowRunTimelineExportItem> Timeline { get; set; } = [];
+        public string? LastCurrentStateActorId { get; private set; }
 
         public Task<IReadOnlyList<WorkflowAgentSummary>> ListAgentsAsync(CancellationToken ct = default) =>
             Task.FromResult<IReadOnlyList<WorkflowAgentSummary>>([]);
@@ -1440,8 +1559,11 @@ public sealed class AevatarInvocationToolSourceTests
         public Task<WorkflowCapabilitiesDocument> GetCapabilitiesAsync(CancellationToken ct = default) =>
             Task.FromResult(new WorkflowCapabilitiesDocument());
 
-        public Task<WorkflowActorSnapshot?> GetWorkflowActorCurrentStateAsync(string actorId, CancellationToken ct = default) =>
-            Task.FromResult(Snapshot);
+        public Task<WorkflowActorSnapshot?> GetWorkflowActorCurrentStateAsync(string actorId, CancellationToken ct = default)
+        {
+            LastCurrentStateActorId = actorId;
+            return Task.FromResult(Snapshot);
+        }
 
         public Task<WorkflowRunReport?> GetWorkflowRunReportArtifactAsync(string actorId, CancellationToken ct = default) =>
             Task.FromResult<WorkflowRunReport?>(null);

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
@@ -445,7 +445,6 @@ public sealed class ConversationReplyGeneratorTests
                 new SingleToolSource(new FixedResultTool("aevatar_invoke_team", """{"ok":true}""")),
                 new SingleToolSource(new FixedResultTool("aevatar_start_workflow", """{"run_id":"run-1"}""")),
                 new SingleToolSource(new FixedResultTool("aevatar_observe_run", """{"status":"running"}""")),
-                new SingleToolSource(new FixedResultTool("aevatar_query_readmodel", """{"items":[]}""")),
             ]);
 
         var reply = await generator.GenerateReplyAsync(
@@ -477,7 +476,6 @@ public sealed class ConversationReplyGeneratorTests
             "aevatar_invoke_team",
             "aevatar_start_workflow",
             "aevatar_observe_run",
-            "aevatar_query_readmodel",
         ]);
         request.Tools!.Select(static tool => tool.Name).Should().NotContain("aevatar_invoke_workflow");
     }

--- a/test/Aevatar.Hosting.Tests/AevatarCoreLoopStatusProbeExecutorTests.cs
+++ b/test/Aevatar.Hosting.Tests/AevatarCoreLoopStatusProbeExecutorTests.cs
@@ -28,7 +28,7 @@ public sealed class AevatarCoreLoopStatusProbeExecutorTests
         var outcome = await executor.ProbeAsync(CoreLoopDescriptor(), CancellationToken.None);
 
         outcome.Status.Should().Be(HealthOutcomeStatus.Ok);
-        outcome.Detail.Should().Be("core_loop_tools_5");
+        outcome.Detail.Should().Be("core_loop_tools_4");
     }
 
     [Fact]
@@ -76,28 +76,10 @@ public sealed class AevatarCoreLoopStatusProbeExecutorTests
         outcome.ErrorMessage.Should().Contain("aevatar_observe_run");
     }
 
-    [Fact]
-    public async Task ProbeAsync_ShouldReportDown_WhenQueryReadModelToolIsNotReadOnly()
-    {
-        using var provider = BuildProvider(
-            includeInvokeTeamSource: true,
-            queryReadModelReadOnly: false);
-        var executor = provider.GetRequiredService<AevatarCoreLoopStatusProbeExecutor>();
-
-        var outcome = await executor.ProbeAsync(
-            CoreLoopDescriptor(requireWorkspaceSources: false),
-            CancellationToken.None);
-
-        outcome.Status.Should().Be(HealthOutcomeStatus.Down);
-        outcome.Detail.Should().Be("completion_query_tool_not_read_only");
-        outcome.ErrorMessage.Should().Contain("aevatar_query_readmodel");
-    }
-
     private static ServiceProvider BuildProvider(
         bool includeInvokeTeamSource,
         bool breakInvokeTeamDiscovery = false,
-        bool observeRunReadOnly = true,
-        bool queryReadModelReadOnly = true)
+        bool observeRunReadOnly = true)
     {
         var services = new ServiceCollection();
         services.AddLogging();
@@ -121,7 +103,6 @@ public sealed class AevatarCoreLoopStatusProbeExecutorTests
 
         services.AddSingleton<StartWorkflowToolSource>();
         services.AddSingleton<ObserveRunToolSource>();
-        services.AddSingleton<QueryReadModelToolSource>();
         services.AddToolSetRegistry(options =>
         {
             var sources = new List<Func<IServiceProvider, IAgentToolSource>>
@@ -136,9 +117,6 @@ public sealed class AevatarCoreLoopStatusProbeExecutorTests
             if (!observeRunReadOnly)
                 sources.Add(_ => new FixedToolSource(new FixedInvocationTool("aevatar_observe_run", false)));
             sources.Add(sp => sp.GetRequiredService<ObserveRunToolSource>());
-            if (!queryReadModelReadOnly)
-                sources.Add(_ => new FixedToolSource(new FixedInvocationTool("aevatar_query_readmodel", false)));
-            sources.Add(sp => sp.GetRequiredService<QueryReadModelToolSource>());
             options.AddToolSet(ToolSetNames.WorkspaceDefault, sources);
         });
 

--- a/test/Aevatar.Hosting.Tests/MainnetHostCompositionTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetHostCompositionTests.cs
@@ -169,7 +169,6 @@ public sealed class MainnetHostCompositionTests
         workspace.Sources.Should().Contain(source => source is InvokeTeamToolSource);
         workspace.Sources.Should().Contain(source => source is StartWorkflowToolSource);
         workspace.Sources.Should().Contain(source => source is ObserveRunToolSource);
-        workspace.Sources.Should().Contain(source => source is QueryReadModelToolSource);
         workspace.Sources.Should().Contain(source => source.GetType().Name == "ResponsesAevatarToolProvider");
         workspace.Sources.Should().Contain(source => source is ChannelInteractiveReplyToolSource);
         workspace.Sources.Should().Contain(source => source is ChannelRegistrationToolSource);
@@ -188,7 +187,6 @@ public sealed class MainnetHostCompositionTests
             .Equal(workspace.Sources.Select(static source => source.GetType()));
         larkSelfNotify.Sources.Should().Contain(source => source is LarkAgentToolSource);
         larkSelfNotify.Sources.Should().Contain(source => source is NyxIdAgentToolSource);
-        larkSelfNotify.Sources.Should().Contain(source => source is QueryReadModelToolSource);
 
         var nyxIdConnectedServices = registry.Resolve(new ChatRouteToolSetRef { Name = ToolSetNames.NyxIdConnectedServices });
         nyxIdConnectedServices.IsSuccess.Should().BeTrue(nyxIdConnectedServices.Error?.Message);


### PR DESCRIPTION
## Changed files
Closes #1894

将 `aevatar_observe_run` 收敛为 typed `oneof target` 合同，每次只读取一个明确读侧权威；删除 generic `aevatar_query_readmodel` 工具和 `readmodel_name + ReadModelQuery` 字符串路由。

同步更新 mainnet host toolset、core loop status probe、channel runtime fixture、Aevatar invocation 单元测试，以及工具入口 ADR / status dashboard 文档。

## Test results
- `dotnet build aevatar.slnx --nologo` 通过。
- `dotnet test test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/Aevatar.AI.ToolProviders.AevatarInvocation.Tests.csproj --nologo` 通过，42 passed。
- `dotnet test test/Aevatar.Hosting.Tests/Aevatar.Hosting.Tests.csproj --nologo` 通过，265 passed。
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo` 通过，1100 passed。
- `bash tools/ci/test_stability_guards.sh` 通过。
- `bash tools/ci/query_projection_priming_guard.sh` 通过。
- `bash tools/ci/architecture_guards.sh` 通过。

## Deviations
无 scope 扩展；未 commit、未 push、未调用 GitHub lifecycle 操作。

`HOST_REFACTOR_COMMENT_POLICY` 为空，按 `none` 处理；未新增 refactor-history 源码注释。

⟦AI:AUTO-LOOP⟧
