### PR TITLE
Fix Lark card finalize delivery truth

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.LarkCardStreaming.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.LarkCardStreaming.cs
@@ -574,34 +574,28 @@ public sealed partial class ConversationGAgent
         bool finalDiffers,
         IReadOnlyList<ConversationHistoryEntry> appendedHistory,
         long sequence,
-        long generation)
+        long generation,
+        ConversationTurnRuntimeContext runtimeContext)
     {
         var cardId = state.CardId ?? string.Empty;
         var cardMessageId = state.CardMessageId ?? string.Empty;
         var streamingElementId = state.StreamingElementId;
         var lastFlushedText = state.LastFlushedText;
-        var workItemId = BuildLarkCardOperationId(correlationId, LarkCardOperationPhase.Finalize, sequence, generation);
-        return PublishReplyOperationStepAsync(
-            workItemId,
-            "lark-card-finalize",
+        return ExecuteLarkCardFinalizeOperationAsync(
+            ResolveCardRunner(),
+            activityForToken.Clone(),
             correlationId,
+            commandId,
+            cardId,
+            cardMessageId,
+            streamingElementId,
+            finalText,
+            lastFlushedText,
+            finalDiffers,
+            appendedHistory.Select(entry => entry.Clone()).ToArray(),
+            sequence,
             generation,
-            ReplyOperationStepEvent.PayloadOneofCase.LarkCard,
-            new LarkCardOperationStepPayload
-            {
-                Operation = LarkCardOperationPhase.Finalize,
-                Sequence = sequence,
-                OperationGeneration = generation,
-                Activity = activityForToken.Clone(),
-                CommandId = commandId,
-                FinalText = finalText,
-                LastFlushedText = lastFlushedText,
-                CardId = cardId,
-                CardMessageId = cardMessageId,
-                StreamingElementId = streamingElementId,
-                FinalDiffers = finalDiffers,
-                AppendedHistory = { appendedHistory.Select(entry => entry.Clone()) },
-            },
+            runtimeContext,
             CancellationToken.None);
     }
 
@@ -649,7 +643,7 @@ public sealed partial class ConversationGAgent
                 CardId = cardId,
                 CardMessageId = cardMessageId,
                 CommandId = commandId,
-                Activity = activityForToken,
+                Activity = CloneForDurableState(activityForToken) ?? new ChatActivity(),
                 FinalText = finalText,
                 LastFlushedText = lastFlushedText,
             };
@@ -670,7 +664,7 @@ public sealed partial class ConversationGAgent
                 CardId = cardId,
                 CardMessageId = cardMessageId,
                 CommandId = commandId,
-                Activity = activityForToken,
+                Activity = CloneForDurableState(activityForToken) ?? new ChatActivity(),
                 FinalText = finalText,
                 LastFlushedText = lastFlushedText,
             };
@@ -735,6 +729,7 @@ public sealed partial class ConversationGAgent
                     CancellationToken.None);
                 return;
             case LarkCardOperationPhase.Finalize:
+                RestoreRuntimeTransportCredentials(step.Activity, runtimeContext);
                 await ExecuteLarkCardFinalizeOperationAsync(
                     ResolveCardRunner(),
                     step.Activity?.Clone() ?? new ChatActivity(),
@@ -933,7 +928,8 @@ public sealed partial class ConversationGAgent
         LlmReplyReadyEvent evt,
         string correlationId,
         string commandId,
-        ChatActivity? referenceActivity)
+        ChatActivity? referenceActivity,
+        ConversationTurnRuntimeContext runtimeContext)
     {
         var state = GetOrInitLarkCardStreamingState(correlationId);
         // Idle: card path was never started for this turn (or already cleaned up); let the
@@ -977,7 +973,8 @@ public sealed partial class ConversationGAgent
             && !string.Equals(finalText, state.LastFlushedText, StringComparison.Ordinal);
 
         var nextSequence = state.Sequence + 1;
-        var activityForToken = referenceActivity ?? evt.Activity ?? new ChatActivity();
+        var activityForToken = (referenceActivity ?? evt.Activity)?.Clone() ?? new ChatActivity();
+        RestoreRuntimeTransportCredentials(activityForToken, runtimeContext);
 
         var generation = NextLarkCardOperationGeneration(state);
         await TransitionLarkCardStreamingPhaseAsync(
@@ -1013,7 +1010,8 @@ public sealed partial class ConversationGAgent
             finalDiffers,
             evt.AppendedHistory.ToArray(),
             nextSequence,
-            generation);
+            generation,
+            runtimeContext);
         return true;
     }
 
@@ -1075,7 +1073,7 @@ public sealed partial class ConversationGAgent
                         OriginalCardId = NormalizeOptional(result.CardId),
                         InFlight = null,
                     });
-                await PersistCardStreamedCompletionAsync(
+                await PersistCardStreamedDeliveredCompletionAsync(
                     correlationId,
                     BuildLlmReplyCommandId(evt.Chunk?.CorrelationId ?? correlationId),
                     evt.Chunk?.Activity,
@@ -1170,7 +1168,7 @@ public sealed partial class ConversationGAgent
                     LarkCardStreamingPhase.Terminated,
                     terminalReason: $"stream_failed:{result.ErrorCode}",
                     fieldUpdate: s => s with { InFlight = null });
-                await PersistCardStreamedCompletionAsync(
+                await PersistCardStreamedDeliveredCompletionAsync(
                     correlationId,
                     BuildLlmReplyCommandId(evt.Chunk?.CorrelationId ?? correlationId),
                     evt.Chunk?.Activity,
@@ -1234,6 +1232,7 @@ public sealed partial class ConversationGAgent
         var finalText = state.PendingFinalizeText ?? evt.FinalText ?? string.Empty;
         var commandId = state.PendingFinalizeCommandId ?? evt.CommandId ?? BuildLlmReplyCommandId(correlationId);
         var visibleText = result.FinalTextWritten ? finalText : state.LastFlushedText;
+        var cardMessageId = state.CardMessageId ?? evt.CardMessageId ?? string.Empty;
         if (result.Success)
         {
             await TransitionLarkCardStreamingPhaseAsync(
@@ -1242,27 +1241,34 @@ public sealed partial class ConversationGAgent
                 LarkCardStreamingPhase.Completed,
                 terminalReason: "completed",
                 fieldUpdate: s => s with { InFlight = null });
-        }
-        else
-        {
-            Logger.LogWarning(
-                "Card finalize failed; persisting partial. correlation={CorrelationId}, code={ErrorCode}",
-                evt.CorrelationId,
-                result.ErrorCode);
-            await TransitionLarkCardStreamingPhaseAsync(
+            await PersistCardStreamedDeliveredCompletionAsync(
                 correlationId,
-                state,
-                LarkCardStreamingPhase.Terminated,
-                terminalReason: $"finalize_failed:{result.ErrorCode}",
-                fieldUpdate: s => s with { InFlight = null });
+                commandId,
+                evt.Activity,
+                cardMessageId,
+                visibleText,
+                evt.AppendedHistory.ToArray());
+            return;
         }
 
-        await PersistCardStreamedCompletionAsync(
+        Logger.LogWarning(
+            "Card finalize failed; persisting partial. correlation={CorrelationId}, code={ErrorCode}",
+            evt.CorrelationId,
+            result.ErrorCode);
+        await TransitionLarkCardStreamingPhaseAsync(
+            correlationId,
+            state,
+            LarkCardStreamingPhase.Terminated,
+            terminalReason: $"finalize_failed:{result.ErrorCode}",
+            fieldUpdate: s => s with { InFlight = null });
+        await PersistCardStreamedFailedCompletionAsync(
             correlationId,
             commandId,
             evt.Activity,
-            state.CardMessageId ?? evt.CardMessageId ?? string.Empty,
+            cardMessageId,
             visibleText,
+            result.ErrorCode,
+            result.ErrorSummary,
             evt.AppendedHistory.ToArray());
     }
 
@@ -1389,12 +1395,14 @@ public sealed partial class ConversationGAgent
                     LarkCardStreamingPhase.Terminated,
                     terminalReason: "finalize_timeout",
                     fieldUpdate: s => s with { InFlight = null });
-                await PersistCardStreamedCompletionAsync(
+                await PersistCardStreamedFailedCompletionAsync(
                     correlationId,
                     NormalizeOptional(evt.CommandId) ?? state.PendingFinalizeCommandId ?? BuildLlmReplyCommandId(correlationId),
                     evt.Activity,
                     state.CardMessageId ?? evt.CardMessageId ?? string.Empty,
                     state.LastFlushedText,
+                    "finalize_timeout",
+                    "Card finalize operation timed out.",
                     appendedHistory: []);
                 return;
         }
@@ -1424,7 +1432,13 @@ public sealed partial class ConversationGAgent
         {
             var finalText = state.PendingFinalizeText;
             var commandId = state.PendingFinalizeCommandId ?? BuildLlmReplyCommandId(correlationId);
-            var activity = sourceChunk?.Activity ?? new ChatActivity();
+            var activity = sourceChunk?.Activity?.Clone() ?? new ChatActivity();
+            var runtimeContext = BuildNyxRelayRuntimeContext(
+                correlationId,
+                activity,
+                sourceChunk?.ReplyToken,
+                sourceChunk?.ReplyTokenExpiresAtUnixMs ?? 0);
+            RestoreRuntimeTransportCredentials(activity, runtimeContext);
             var nextSequence = state.Sequence + 1;
             var generation = NextLarkCardOperationGeneration(state);
             var finalDiffers = !string.IsNullOrWhiteSpace(finalText)
@@ -1460,7 +1474,8 @@ public sealed partial class ConversationGAgent
                 finalDiffers,
                 state.PendingAppendedHistory,
                 nextSequence,
-                generation);
+                generation,
+                runtimeContext);
             return;
         }
 
@@ -1505,12 +1520,54 @@ public sealed partial class ConversationGAgent
     // Refactor (iter20/cluster-004):
     //   Old pattern: Card completion removed process-local token/card registries after writing only completion.
     //   New principle: Persist delivered + completion facts and clear the actor-owned lifecycle state explicitly.
+    private Task PersistCardStreamedDeliveredCompletionAsync(
+        string correlationId,
+        string commandId,
+        ChatActivity? eventActivity,
+        string cardMessageId,
+        string outboundText,
+        IReadOnlyList<ConversationHistoryEntry> appendedHistory) =>
+        PersistCardStreamedCompletionAsync(
+            correlationId,
+            commandId,
+            eventActivity,
+            cardMessageId,
+            outboundText,
+            deliveryFailure: null,
+            appendedHistory);
+
+    private Task PersistCardStreamedFailedCompletionAsync(
+        string correlationId,
+        string commandId,
+        ChatActivity? eventActivity,
+        string cardMessageId,
+        string outboundText,
+        string errorCode,
+        string errorSummary,
+        IReadOnlyList<ConversationHistoryEntry> appendedHistory) =>
+        PersistCardStreamedCompletionAsync(
+            correlationId,
+            commandId,
+            eventActivity,
+            cardMessageId,
+            outboundText,
+            new LlmReplyDeliveryFailedEvent
+            {
+                CorrelationId = correlationId,
+                RunId = ResolvePendingLlmReplyRunId(correlationId) ?? string.Empty,
+                FailedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                ErrorCode = errorCode ?? string.Empty,
+                ErrorMessage = errorSummary ?? string.Empty,
+            },
+            appendedHistory);
+
     private async Task PersistCardStreamedCompletionAsync(
         string correlationId,
         string commandId,
         ChatActivity? eventActivity,
         string cardMessageId,
         string outboundText,
+        LlmReplyDeliveryFailedEvent? deliveryFailure,
         IReadOnlyList<ConversationHistoryEntry> appendedHistory)
     {
         var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
@@ -1528,15 +1585,26 @@ public sealed partial class ConversationGAgent
             OutboundDelivery = ToOutboundDeliveryReceipt(eventActivity?.OutboundDelivery),
         };
         completed.AppendedHistory.AddRange(appendedHistory.Select(entry => entry.Clone()));
-        var delivered = new LlmReplyDeliveredEvent
+        if (deliveryFailure is null)
         {
-            CorrelationId = correlationId,
-            RunId = NormalizeOptional(State.PendingLlmReplyRequests.FirstOrDefault(request =>
-                string.Equals(request.CorrelationId, correlationId, StringComparison.Ordinal))?.RunId) ?? string.Empty,
-            AckedAtUnixMs = nowMs,
-            ChannelMessageId = $"lark-card-stream:{cardMessageId}",
-        };
-        await PersistDomainEventAsync(delivered);
+            var delivered = new LlmReplyDeliveredEvent
+            {
+                CorrelationId = correlationId,
+                RunId = ResolvePendingLlmReplyRunId(correlationId) ?? string.Empty,
+                AckedAtUnixMs = nowMs,
+                ChannelMessageId = $"lark-card-stream:{cardMessageId}",
+            };
+            await PersistDomainEventAsync(delivered);
+            if (eventActivity is not null)
+                _ = ResolveRunner().OnReplyDeliveredAsync(eventActivity, CancellationToken.None);
+        }
+        else
+        {
+            if (deliveryFailure.FailedAtUnixMs <= 0)
+                deliveryFailure.FailedAtUnixMs = nowMs;
+            await PersistDomainEventAsync(deliveryFailure);
+        }
+
         await ClearReplyLifecycleAsync(correlationId, ConversationReplyLifecycleMode.LarkCard, "card_fallback_or_terminal");
         await PersistDomainEventAsync(completed);
         Logger.LogInformation(

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.LarkCardStreaming.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.LarkCardStreaming.cs
@@ -574,28 +574,34 @@ public sealed partial class ConversationGAgent
         bool finalDiffers,
         IReadOnlyList<ConversationHistoryEntry> appendedHistory,
         long sequence,
-        long generation,
-        ConversationTurnRuntimeContext runtimeContext)
+        long generation)
     {
         var cardId = state.CardId ?? string.Empty;
         var cardMessageId = state.CardMessageId ?? string.Empty;
         var streamingElementId = state.StreamingElementId;
         var lastFlushedText = state.LastFlushedText;
-        return ExecuteLarkCardFinalizeOperationAsync(
-            ResolveCardRunner(),
-            activityForToken.Clone(),
+        var workItemId = BuildLarkCardOperationId(correlationId, LarkCardOperationPhase.Finalize, sequence, generation);
+        return PublishReplyOperationStepAsync(
+            workItemId,
+            "lark-card-finalize",
             correlationId,
-            commandId,
-            cardId,
-            cardMessageId,
-            streamingElementId,
-            finalText,
-            lastFlushedText,
-            finalDiffers,
-            appendedHistory.Select(entry => entry.Clone()).ToArray(),
-            sequence,
             generation,
-            runtimeContext,
+            ReplyOperationStepEvent.PayloadOneofCase.LarkCard,
+            new LarkCardOperationStepPayload
+            {
+                Operation = LarkCardOperationPhase.Finalize,
+                Sequence = sequence,
+                OperationGeneration = generation,
+                Activity = activityForToken.Clone(),
+                CommandId = commandId,
+                FinalText = finalText,
+                LastFlushedText = lastFlushedText,
+                CardId = cardId,
+                CardMessageId = cardMessageId,
+                StreamingElementId = streamingElementId,
+                FinalDiffers = finalDiffers,
+                AppendedHistory = { appendedHistory.Select(entry => entry.Clone()) },
+            },
             CancellationToken.None);
     }
 
@@ -1010,8 +1016,7 @@ public sealed partial class ConversationGAgent
             finalDiffers,
             evt.AppendedHistory.ToArray(),
             nextSequence,
-            generation,
-            runtimeContext);
+            generation);
         return true;
     }
 
@@ -1474,8 +1479,7 @@ public sealed partial class ConversationGAgent
                 finalDiffers,
                 state.PendingAppendedHistory,
                 nextSequence,
-                generation,
-                runtimeContext);
+                generation);
             return;
         }
 

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -730,16 +730,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             DescribeReplyTokenSource(evt, runtimeContext));
 
         if (await TryCompleteStreamedReplyAsync(evt, commandId, referenceActivity, runtimeContext))
-        {
-            // Streaming path bypasses RunLlmReplyAsync entirely (the reply was already finalized via
-            // RunStreamChunkAsync edits), so the runner's post-reply housekeeping never fires from
-            // there. Trigger the hook explicitly so platform-specific cleanup (e.g. Lark
-            // "Typing"→"DONE" reaction swap) still runs on the most common production reply path.
-            var streamingActivity = referenceActivity ?? evt.Activity;
-            if (streamingActivity is not null)
-                _ = ResolveRunner().OnReplyDeliveredAsync(streamingActivity, CancellationToken.None);
             return;
-        }
 
         var runner = ResolveRunner();
         var result = await runner.RunLlmReplyAsync(
@@ -996,7 +987,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         // finished as a terminal phase. Plain `await` so the continuation stays on the
         // actor's single-threaded scheduler (no ConfigureAwait(false) — it would let the
         // post-await active lifecycle reads run off the actor turn).
-        if (await TryCompleteCardStreamedReplyAsync(evt, correlationId, commandId, referenceActivity))
+        if (await TryCompleteCardStreamedReplyAsync(evt, correlationId, commandId, referenceActivity, runtimeContext))
             return true;
 
         var state = GetOrInitNyxRelayStreamingState(correlationId);
@@ -1881,6 +1872,8 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             ChannelMessageId = $"nyx-relay-stream:{platformMessageId}",
         };
         await PersistDomainEventAsync(delivered);
+        if (referenceActivity is not null)
+            _ = ResolveRunner().OnReplyDeliveredAsync(referenceActivity, CancellationToken.None);
         await ClearReplyLifecyclesAsync(evt.CorrelationId, referenceActivity, "streamed_completion");
         await PersistDomainEventAsync(completed);
         Logger.LogInformation(
@@ -2210,7 +2203,8 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             evt.CorrelationId,
             activity,
             evt.ReplyToken,
-            evt.ReplyTokenExpiresAtUnixMs);
+            evt.ReplyTokenExpiresAtUnixMs,
+            evt.Activity?.TransportExtras?.NyxUserAccessToken);
     }
 
     // Refactor (iter17/cluster-038): Old pattern: transient relay credentials could ride inside persisted ChatActivity clones. New principle: durable admission/retry/LLM state stores only non-secret relay facts; same-activation credentials stay in runtime context.

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -2998,7 +2998,7 @@ public sealed class ConversationGAgentDedupTests
             return Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
         }
 
-        public async Task<T> WaitForPayloadAsync<T>()
+        public async Task<T> WaitForPayloadAsync<T>(Func<T, bool>? predicate = null)
             where T : IMessage<T>, new()
         {
             var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
@@ -3014,8 +3014,12 @@ public sealed class ConversationGAgentDedupTests
                     envelope = _pending.Dequeue();
                 }
 
-                if (envelope.Payload.Is(new T().Descriptor))
-                    return envelope.Payload.Unpack<T>();
+                if (!envelope.Payload.Is(new T().Descriptor))
+                    continue;
+
+                var payload = envelope.Payload.Unpack<T>();
+                if (predicate is null || predicate(payload))
+                    return payload;
             }
 
             throw new TimeoutException($"Timed out waiting for dispatched {typeof(T).Name}.");
@@ -3472,7 +3476,8 @@ public sealed class ConversationGAgentDedupTests
     [Fact]
     public async Task HandleLlmReplyReadyAsync_CardModeStreamingCompleted_PersistsLarkCardStreamPrefix()
     {
-        var (agent, store) = CreateAgent(new RecordingTurnRunner(), "conv-card-finalize");
+        var card = new RecordingCardTurnRunner();
+        var (agent, store) = CreateAgent(new RecordingTurnRunner(), "conv-card-finalize", cardRunner: card);
 
         await agent.HandleLlmReplyCardStreamChunkAsync(
             CreateCardStreamChunk("act-card-finalize", "relay-msg-1", "complete answer"));
@@ -3495,9 +3500,18 @@ public sealed class ConversationGAgentDedupTests
             Activity = CreateRelayActivity("act-card-finalize", "relay-msg-1"),
             Outbound = new MessageContent { Text = "complete answer" },
             TerminalState = LlmReplyTerminalState.Completed,
+            ReplyToken = "runtime-ready-token",
+            ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeMilliseconds(),
             ReadyAtUnixMs = 100,
         };
+        ready.Activity.TransportExtras = new TransportExtras
+        {
+            NyxUserAccessToken = "ready-user-access-token",
+        };
         await agent.HandleLlmReplyReadyAsync(ready);
+        card.CardFinalizeCount.ShouldBe(1);
+        card.LastCardFinalizeActivityUserAccessToken.ShouldBe("ready-user-access-token");
+        card.LastCardFinalizeRuntimeUserAccessToken.ShouldBe("ready-user-access-token");
         var finalize = agent.State.ActiveReplyLifecycles.Single();
         await agent.HandleLarkCardOperationCompletedAsync(CreateCardFinalizeCompletion(
             "act-card-finalize",
@@ -3517,6 +3531,129 @@ public sealed class ConversationGAgentDedupTests
         var completed = ConversationTurnCompletedEvent.Parser.ParseFrom(events.Last().EventData.Value);
         completed.SentActivityId.ShouldStartWith("lark-card-stream:");
         completed.Outbound.Text.ShouldBe("complete answer");
+    }
+
+    [Fact]
+    public async Task HandleLlmReplyReadyAsync_CardFinalizeFailed_PersistsDeliveryFailedBeforeTurnCompleted()
+    {
+        var card = new RecordingCardTurnRunner
+        {
+            CardFinalizeResultFactory = (_, _, _, _) =>
+                ConversationCardFinalizeResult.Failed("card_close_streaming_failed", "close rejected"),
+        };
+        var dispatch = new RecordingActorDispatchPort();
+        var (agent, store) = CreateAgent(
+            new RecordingTurnRunner(),
+            "conv-card-finalize-failed",
+            cardRunner: card,
+            dispatchPort: dispatch);
+
+        await agent.HandleLlmReplyCardStreamChunkAsync(
+            CreateCardStreamChunk("act-card-finalize-failed", "relay-msg-1", "partial answer"));
+        var create = agent.State.ActiveReplyLifecycles.Single();
+        await agent.HandleLarkCardOperationCompletedAsync(CreateCardCreateCompletion(
+            "act-card-finalize-failed",
+            create.LarkCardInFlightSequence,
+            create.LarkCardOperationGeneration,
+            CreateCardStreamChunk("act-card-finalize-failed", "relay-msg-1", "partial answer"),
+            success: true,
+            cardId: "card_failed",
+            cardMessageId: "om_card_failed"));
+
+        await agent.HandleLlmReplyReadyAsync(new LlmReplyReadyEvent
+        {
+            CorrelationId = "act-card-finalize-failed",
+            RegistrationId = "reg-1",
+            RunId = "run-card-finalize-failed",
+            SourceActorId = "agent-run",
+            Activity = CreateRelayActivity("act-card-finalize-failed", "relay-msg-1"),
+            Outbound = new MessageContent { Text = "final answer" },
+            TerminalState = LlmReplyTerminalState.Completed,
+            ReadyAtUnixMs = 100,
+            ReplyToken = "runtime-ready-token",
+            ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeMilliseconds(),
+        });
+        var signal = await dispatch.WaitForPayloadAsync<LarkCardOperationCompletedEvent>(payload =>
+            payload.Operation == LarkCardOperationPhase.Finalize);
+        await agent.HandleLarkCardOperationCompletedAsync(signal);
+
+        agent.State.ActiveReplyLifecycles.ShouldBeEmpty();
+        agent.State.LastReplyDelivery.OutcomeCase.ShouldBe(ReplyDeliveryStatus.OutcomeOneofCase.Failed);
+        agent.State.LastReplyDelivery.Failed.ErrorCode.ShouldBe("card_close_streaming_failed");
+
+        var events = await store.GetEventsAsync(agent.Id);
+        var eventTypes = events.Select(e => e.EventType).ToList();
+        eventTypes.ShouldNotContain(type => type.Contains(nameof(LlmReplyDeliveredEvent), StringComparison.Ordinal));
+        var failedIndex = eventTypes.FindIndex(type =>
+            type.Contains(nameof(LlmReplyDeliveryFailedEvent), StringComparison.Ordinal));
+        var completedIndex = eventTypes.FindIndex(type =>
+            type.Contains(nameof(ConversationTurnCompletedEvent), StringComparison.Ordinal));
+        failedIndex.ShouldBeGreaterThanOrEqualTo(0);
+        completedIndex.ShouldBeGreaterThan(failedIndex);
+        var completed = ConversationTurnCompletedEvent.Parser.ParseFrom(events[completedIndex].EventData.Value);
+        completed.SentActivityId.ShouldBe("lark-card-stream:om_card_failed");
+        completed.Outbound.Text.ShouldBe("partial answer");
+    }
+
+    [Fact]
+    public async Task HandleLarkCardOperationTimeoutFiredAsync_CardFinalizeTimeout_PersistsDeliveryFailedBeforeTurnCompleted()
+    {
+        var (agent, store) = CreateAgent(new RecordingTurnRunner(), "conv-card-finalize-timeout");
+
+        await agent.HandleLlmReplyCardStreamChunkAsync(
+            CreateCardStreamChunk("act-card-finalize-timeout", "relay-msg-1", "partial answer"));
+        var create = agent.State.ActiveReplyLifecycles.Single();
+        await agent.HandleLarkCardOperationCompletedAsync(CreateCardCreateCompletion(
+            "act-card-finalize-timeout",
+            create.LarkCardInFlightSequence,
+            create.LarkCardOperationGeneration,
+            CreateCardStreamChunk("act-card-finalize-timeout", "relay-msg-1", "partial answer"),
+            success: true,
+            cardId: "card_timeout",
+            cardMessageId: "om_card_timeout"));
+
+        await agent.HandleLlmReplyReadyAsync(new LlmReplyReadyEvent
+        {
+            CorrelationId = "act-card-finalize-timeout",
+            RegistrationId = "reg-1",
+            RunId = "run-card-finalize-timeout",
+            SourceActorId = "agent-run",
+            Activity = CreateRelayActivity("act-card-finalize-timeout", "relay-msg-1"),
+            Outbound = new MessageContent { Text = "final answer" },
+            TerminalState = LlmReplyTerminalState.Completed,
+            ReadyAtUnixMs = 100,
+            ReplyToken = "runtime-ready-token",
+            ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeMilliseconds(),
+        });
+        var finalize = agent.State.ActiveReplyLifecycles.Single();
+
+        await agent.HandleLarkCardOperationTimeoutFiredAsync(new LarkCardOperationTimeoutFiredEvent
+        {
+            CorrelationId = "act-card-finalize-timeout",
+            Operation = LarkCardOperationPhase.Finalize,
+            Sequence = finalize.LarkCardInFlightSequence,
+            OperationGeneration = finalize.LarkCardOperationGeneration,
+            CardId = "card_timeout",
+            CardMessageId = "om_card_timeout",
+            CommandId = "llm:act-card-finalize-timeout",
+            Activity = CreateRelayActivity("act-card-finalize-timeout", "relay-msg-1"),
+            LastFlushedText = "partial answer",
+            FiredAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        });
+
+        agent.State.ActiveReplyLifecycles.ShouldBeEmpty();
+        agent.State.LastReplyDelivery.OutcomeCase.ShouldBe(ReplyDeliveryStatus.OutcomeOneofCase.Failed);
+        agent.State.LastReplyDelivery.Failed.ErrorCode.ShouldBe("finalize_timeout");
+
+        var events = await store.GetEventsAsync(agent.Id);
+        var eventTypes = events.Select(e => e.EventType).ToList();
+        eventTypes.ShouldNotContain(type => type.Contains(nameof(LlmReplyDeliveredEvent), StringComparison.Ordinal));
+        var failedIndex = eventTypes.FindIndex(type =>
+            type.Contains(nameof(LlmReplyDeliveryFailedEvent), StringComparison.Ordinal));
+        var completedIndex = eventTypes.FindIndex(type =>
+            type.Contains(nameof(ConversationTurnCompletedEvent), StringComparison.Ordinal));
+        failedIndex.ShouldBeGreaterThanOrEqualTo(0);
+        completedIndex.ShouldBeGreaterThan(failedIndex);
     }
 
     [Fact]
@@ -3771,6 +3908,8 @@ public sealed class ConversationGAgentDedupTests
         public int CardFinalizeCount;
         public long LastCardStreamSequence;
         public long LastCardFinalizeSequence;
+        public string? LastCardFinalizeActivityUserAccessToken;
+        public string? LastCardFinalizeRuntimeUserAccessToken;
 
         public Func<LlmReplyCardStreamChunkEvent, ConversationCardCreateResult>? CardCreateResultFactory { get; set; }
         public Func<LlmReplyCardStreamChunkEvent, string, string, long, ConversationCardStreamResult>? CardStreamResultFactory { get; set; }
@@ -3815,6 +3954,8 @@ public sealed class ConversationGAgentDedupTests
         {
             Interlocked.Increment(ref CardFinalizeCount);
             LastCardFinalizeSequence = sequence;
+            LastCardFinalizeActivityUserAccessToken = referenceActivity.TransportExtras?.NyxUserAccessToken;
+            LastCardFinalizeRuntimeUserAccessToken = runtimeContext.NyxUserAccessToken;
             var result = CardFinalizeResultFactory?.Invoke(referenceActivity, cardId, elementId, sequence)
                 ?? ConversationCardFinalizeResult.Succeeded();
             return Task.FromResult(result);

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkCardOperationSignalTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkCardOperationSignalTests.cs
@@ -329,12 +329,15 @@ public sealed class LarkCardOperationSignalTests
         var scheduler = new RecordingCallbackScheduler();
         var runner = new RecordingCardRunner();
         var store = new InMemoryEventStore();
+        var eventPublisher = new SelfHandlingEventPublisher(autoHandleSelfEvents: false);
         var agent = CreateAgent(
             "conv-lark-card-finalize-ready-token",
             runner,
             new RecordingActorDispatchPort(),
             store,
-            scheduler);
+            scheduler,
+            eventPublisher);
+        eventPublisher.SelfTarget = agent;
         var chunk = CreateCardStreamChunk("corr-card-finalize-ready-token", "relay-msg-1", "hello");
 
         await agent.HandleEventAsync(Envelope(agent.Id, chunk));
@@ -373,6 +376,16 @@ public sealed class LarkCardOperationSignalTests
             ReadyAtUnixMs = 100,
         });
 
+        runner.FinalizeCalls.Should().BeEmpty();
+        var finalizeStep = eventPublisher.Sent
+            .OfType<ReplyOperationStepEvent>()
+            .Single(step => step.LarkCard.Operation == LarkCardOperationPhase.Finalize);
+        finalizeStep.OperationName.Should().Be("lark-card-finalize");
+        finalizeStep.LarkCard.Activity.TransportExtras.NyxUserAccessToken.Should()
+            .Be("runtime-ready-user-access-token");
+
+        await agent.HandleReplyOperationStepAsync(finalizeStep);
+
         var finalizeCall = await runner.WaitForFinalizeCallAsync();
         finalizeCall.ActivityUserAccessToken.Should().Be("runtime-ready-user-access-token");
         finalizeCall.RuntimeUserAccessToken.Should().Be("runtime-ready-user-access-token");
@@ -392,7 +405,8 @@ public sealed class LarkCardOperationSignalTests
         IConversationCardTurnRunner cardRunner,
         IActorDispatchPort dispatch,
         IEventStore store,
-        IActorRuntimeCallbackScheduler? callbackScheduler = null)
+        IActorRuntimeCallbackScheduler? callbackScheduler = null,
+        SelfHandlingEventPublisher? eventPublisher = null)
     {
         var services = new ServiceCollection()
             .AddSingleton(store)
@@ -410,7 +424,9 @@ public sealed class LarkCardOperationSignalTests
                 services.GetRequiredService<IEventSourcingBehaviorFactory<ConversationGAgentState>>(),
         };
         SetId(agent, id);
-        agent.EventPublisher = new SelfHandlingEventPublisher(agent);
+        eventPublisher ??= new SelfHandlingEventPublisher();
+        eventPublisher.SelfTarget = agent;
+        agent.EventPublisher = eventPublisher;
         agent.ActivateAsync().GetAwaiter().GetResult();
         return agent;
     }
@@ -717,8 +733,12 @@ public sealed class LarkCardOperationSignalTests
         public Task PurgeActorAsync(string actorId, CancellationToken ct = default) => Task.CompletedTask;
     }
 
-    private sealed class SelfHandlingEventPublisher(ConversationGAgent agent) : IEventPublisher
+    private sealed class SelfHandlingEventPublisher(bool autoHandleSelfEvents = true) : IEventPublisher
     {
+        public ConversationGAgent? SelfTarget { get; set; }
+
+        public List<IMessage> Sent { get; } = [];
+
         public Task PublishAsync<TEvent>(
             TEvent evt,
             TopologyAudience audience = TopologyAudience.Children,
@@ -735,8 +755,17 @@ public sealed class LarkCardOperationSignalTests
             EventEnvelope? sourceEnvelope = null,
             EventEnvelopePublishOptions? options = null)
             where TEvent : IMessage =>
-            string.Equals(targetActorId, agent.Id, StringComparison.Ordinal)
-                ? agent.HandleEventAsync(Envelope(targetActorId, evt))
+            SendToSelfIfConfiguredAsync(targetActorId, evt);
+
+        private Task SendToSelfIfConfiguredAsync<TEvent>(string targetActorId, TEvent evt)
+            where TEvent : IMessage
+        {
+            Sent.Add(evt);
+            return autoHandleSelfEvents &&
+                   SelfTarget is not null &&
+                   string.Equals(targetActorId, SelfTarget.Id, StringComparison.Ordinal)
+                ? SelfTarget.HandleEventAsync(Envelope(targetActorId, evt))
                 : Task.CompletedTask;
+        }
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkCardOperationSignalTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkCardOperationSignalTests.cs
@@ -323,6 +323,70 @@ public sealed class LarkCardOperationSignalTests
         agent.State.ProcessedCommandIds.Should().Contain("llm:corr-card-create-inflight-failure");
     }
 
+    [Fact]
+    public async Task HandleLlmReplyReadyAsync_CardFinalize_UsesReadyRuntimeUserAccessTokenWithoutPersistingIt()
+    {
+        var scheduler = new RecordingCallbackScheduler();
+        var runner = new RecordingCardRunner();
+        var store = new InMemoryEventStore();
+        var agent = CreateAgent(
+            "conv-lark-card-finalize-ready-token",
+            runner,
+            new RecordingActorDispatchPort(),
+            store,
+            scheduler);
+        var chunk = CreateCardStreamChunk("corr-card-finalize-ready-token", "relay-msg-1", "hello");
+
+        await agent.HandleEventAsync(Envelope(agent.Id, chunk));
+        var lifecycle = agent.State.ActiveReplyLifecycles.Single();
+        await agent.HandleEventAsync(Envelope(agent.Id,
+            new LarkCardOperationCompletedEvent
+            {
+                OperationId = "corr-card-finalize-ready-token:create:1:1",
+                CorrelationId = "corr-card-finalize-ready-token",
+                Operation = LarkCardOperationPhase.Create,
+                Sequence = lifecycle.LarkCardInFlightSequence,
+                OperationGeneration = lifecycle.LarkCardOperationGeneration,
+                State = LarkCardOperationResultState.Succeeded,
+                Chunk = chunk.Clone(),
+                RawResult = new LarkCardOperationRawResult
+                {
+                    CardId = "card_ok",
+                    CardMessageId = "om_card_msg",
+                },
+            }));
+        scheduler.Timeouts.Clear();
+
+        var readyActivity = chunk.Activity.Clone();
+        readyActivity.TransportExtras.NyxUserAccessToken = "runtime-ready-user-access-token";
+        await agent.HandleLlmReplyReadyAsync(new LlmReplyReadyEvent
+        {
+            CorrelationId = "corr-card-finalize-ready-token",
+            RegistrationId = "reg-1",
+            SourceActorId = "agent-run",
+            RunId = "run-card-finalize-ready-token",
+            Activity = readyActivity,
+            Outbound = new MessageContent { Text = "final text" },
+            TerminalState = LlmReplyTerminalState.Completed,
+            ReplyToken = "runtime-ready-token-corr-card-finalize-ready-token",
+            ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeMilliseconds(),
+            ReadyAtUnixMs = 100,
+        });
+
+        var finalizeCall = await runner.WaitForFinalizeCallAsync();
+        finalizeCall.ActivityUserAccessToken.Should().Be("runtime-ready-user-access-token");
+        finalizeCall.RuntimeUserAccessToken.Should().Be("runtime-ready-user-access-token");
+
+        var scheduled = scheduler.Timeouts.Should().ContainSingle().Subject;
+        var timeout = scheduled.TriggerEnvelope.Payload.Unpack<LarkCardOperationTimeoutFiredEvent>();
+        timeout.Activity.TransportExtras.NyxUserAccessToken.Should().BeEmpty();
+
+        var persistedBytes = (await store.GetEventsAsync(agent.Id))
+            .SelectMany(evt => evt.EventData.Value.ToByteArray())
+            .ToArray();
+        Encoding.UTF8.GetString(persistedBytes).Should().NotContain("runtime-ready-user-access-token");
+    }
+
     private static ConversationGAgent CreateAgent(
         string id,
         IConversationCardTurnRunner cardRunner,
@@ -437,15 +501,15 @@ public sealed class LarkCardOperationSignalTests
 
     private sealed class RecordingCardRunner : IConversationCardTurnRunner
     {
-        private readonly TaskCompletionSource<(string FinalText, bool FinalTextDiffersFromLastFlushed, long Sequence)> _finalizeCall =
+        private readonly TaskCompletionSource<FinalizeCall> _finalizeCall =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public ConversationCardCreateResult CreateResult { get; init; } =
             ConversationCardCreateResult.Succeeded("card_ok", "om_card_msg");
 
-        public List<(string FinalText, bool FinalTextDiffersFromLastFlushed, long Sequence)> FinalizeCalls { get; } = [];
+        public List<FinalizeCall> FinalizeCalls { get; } = [];
 
-        public async Task<(string FinalText, bool FinalTextDiffersFromLastFlushed, long Sequence)> WaitForFinalizeCallAsync() =>
+        public async Task<FinalizeCall> WaitForFinalizeCallAsync() =>
             await _finalizeCall.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         public Task<ConversationCardCreateResult> RunCardCreateAsync(
@@ -474,12 +538,24 @@ public sealed class LarkCardOperationSignalTests
             ConversationTurnRuntimeContext runtimeContext,
             CancellationToken ct)
         {
-            var call = (finalText, finalTextDiffersFromLastFlushed, sequence);
+            var call = new FinalizeCall(
+                finalText,
+                finalTextDiffersFromLastFlushed,
+                sequence,
+                referenceActivity.TransportExtras?.NyxUserAccessToken ?? string.Empty,
+                runtimeContext.NyxUserAccessToken ?? string.Empty);
             FinalizeCalls.Add(call);
             _finalizeCall.TrySetResult(call);
             return Task.FromResult(ConversationCardFinalizeResult.Succeeded());
         }
     }
+
+    private sealed record FinalizeCall(
+        string FinalText,
+        bool FinalTextDiffersFromLastFlushed,
+        long Sequence,
+        string ActivityUserAccessToken,
+        string RuntimeUserAccessToken);
 
     private sealed class RecordingActorDispatchPort : IActorDispatchPort
     {


### PR DESCRIPTION
## Changed files

- `ConversationGAgent.cs`：把 ready event 的 user access token 纳入 same-turn runtime context，并把 streaming delivered hook 移到真实 delivered 持久化点。
- `ConversationGAgent.LarkCardStreaming.cs`：CardKit finalize 只用 transient runtime credentials；completion signal / timeout payload 继续使用清理后的 durable activity。Finalize failed / timeout 写入 `LlmReplyDeliveryFailedEvent`，`ConversationTurnCompletedEvent` 仅负责 turn 收口。
- `LarkCardOperationSignalTests.cs`：覆盖 ready token 到 finalize runner，但不进入 timeout payload 或 event store。
- `ConversationGAgentDedupTests.cs`：覆盖 CardKit finalize failed / timeout 的 delivery failed 事件顺序，并确认不再写 delivered。

Closes #1884

## Test results

- `bash -lc "dotnet build aevatar.slnx --nologo"`：通过。
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo --filter LarkCardOperationSignalTests`：通过，7/7。
- `dotnet test test/Aevatar.GAgents.Channel.Protocol.Tests/Aevatar.GAgents.Channel.Protocol.Tests.csproj --nologo --filter ConversationGAgentDedupTests`：通过，81/81。
- `bash tools/ci/test_stability_guards.sh`：通过。
- `bash tools/ci/architecture_guards.sh`：通过。

## Deviations

- 未新增 proto/schema 字段；未扩展授权范围；未 commit / push。
- `HOST_REFACTOR_COMMENT_POLICY` 为空，按 `none` 处理，未新增 refactor self-documentation 源码注释。

⟦AI:AUTO-LOOP⟧
