### PR TITLE
Refactor workflow tool child starts to parent-run managed context

### DIFF
--- a/docs/adr/0026-tool-first-chat-ingress.md
+++ b/docs/adr/0026-tool-first-chat-ingress.md
@@ -113,6 +113,14 @@ repository (no external repo changes — CLAUDE.md §"外部仓库无改动权")
 | `aevatar_start_workflow` | `workflow_id`, typed `inputs` | same | `stream` |
 | `aevatar_observe_run` | typed oneof target: `service_run`, `gagent_terminal_correlation`, `gagent_terminal_session`, or `workflow_current_state` | `{status, recent_events, partial_output}` | — |
 
+`aevatar_start_workflow` is still a top-level accepted-only ingress when
+called without workflow runtime context. When a workflow run calls it through
+`llm_call` or `tool_call`, the host stamps typed workflow runtime context on
+`AgentToolExecutionContext`; the dispatcher converts the call to a
+`SubWorkflowInvokeRequestedEvent` addressed to the parent run actor. Parent,
+root, depth, and fanout are not tool arguments and are rejected if supplied by
+the user or LLM.
+
 Payloads are typed proto, not free-form JSON. The dispatcher validates the
 proto schema before executing; a malformed call returns a structured error
 back to the LLM so it can self-correct rather than fail the turn.

--- a/docs/canon/workflow-primitives.md
+++ b/docs/canon/workflow-primitives.md
@@ -453,6 +453,10 @@ steps:
   - `workflow_call` 调用会生成统一格式的 invocation id：`<parent_run_id>:workflow_call:<parent_step_id|step>:<guidN>`；
   - 该规则由共享工厂统一生成，模块层与 actor 编排层保持一致；
   - 子流程 `child_run_id` 复用 invocation id，便于跨事件链路关联与回放定位。
+- Actor-owned admission：
+  - root run id、depth 与 active fanout 是父 run actor 持久态事实，不由工具调用参数提供；
+  - `SubWorkflowOrchestrator` 在注册或创建子 actor 前先执行 depth/fanout admission，拒绝结果以当前步骤失败事件返回；
+  - workflow 内的 `llm_call` / `tool_call` 若触发 `aevatar_start_workflow`，只能通过 host stamped typed runtime context 转成父 run actor 的 managed child start。
 
 ```yaml
 steps:

--- a/docs/canon/workflow-runtime.md
+++ b/docs/canon/workflow-runtime.md
@@ -216,6 +216,8 @@ roles:
 - `parent_step_id` 必须非空；缺失时直接失败，不再生成兜底 step token；
 - `WorkflowCallModule` 与 `WorkflowGAgent` 共用同一规则，避免双点实现漂移；
 - 子流程 run id 复用 invocation id，便于父子流程关联追踪。
+- 父子 run 的 root/depth/fanout 由父 `WorkflowRunGAgent` 持久态与 `SubWorkflowOrchestrator` 判定；`llm_call` / `tool_call` 只能透传 host stamped typed runtime context。
+- workflow 内调用 `aevatar_start_workflow` 时，如果工具上下文带有可信 workflow runtime context，dispatcher 必须发布 `SubWorkflowInvokeRequestedEvent` 给父 run actor，由父 actor 完成 admission、registration、start、completion 与 cleanup；公开 tool 参数不得暴露 parent/root/depth 字段。
 
 ### 从 Foundation Orchestration 迁移
 

--- a/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContext.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContext.cs
@@ -13,9 +13,34 @@ public sealed record AgentToolExecutionContext(
     AgentToolSenderBindingContext SenderBinding,
     LLMRequestRoutingContext Routing,
     AgentToolConnectedServicesContext ConnectedServices,
+    AgentWorkflowRuntimeContext WorkflowRuntime,
     AgentSkillRecoveryContext SkillRecovery,
     IReadOnlyDictionary<string, string> ExternalMetadata)
 {
+    public AgentToolExecutionContext(
+        AgentToolRequestIdentity Request,
+        AgentToolCredentials Credentials,
+        AgentToolCallerContext Caller,
+        AgentToolChannelContext Channel,
+        AgentToolSenderBindingContext SenderBinding,
+        LLMRequestRoutingContext Routing,
+        AgentToolConnectedServicesContext ConnectedServices,
+        AgentSkillRecoveryContext SkillRecovery,
+        IReadOnlyDictionary<string, string> ExternalMetadata)
+        : this(
+            Request,
+            Credentials,
+            Caller,
+            Channel,
+            SenderBinding,
+            Routing,
+            ConnectedServices,
+            AgentWorkflowRuntimeContext.Empty,
+            SkillRecovery,
+            ExternalMetadata)
+    {
+    }
+
     public static AgentToolExecutionContext Empty { get; } = new(
         AgentToolRequestIdentity.Empty,
         AgentToolCredentials.Empty,
@@ -24,6 +49,7 @@ public sealed record AgentToolExecutionContext(
         AgentToolSenderBindingContext.Empty,
         LLMRequestRoutingContext.Empty,
         AgentToolConnectedServicesContext.Empty,
+        AgentWorkflowRuntimeContext.Empty,
         AgentSkillRecoveryContext.Empty,
         new Dictionary<string, string>(StringComparer.Ordinal));
 
@@ -70,6 +96,21 @@ public sealed record AgentToolSenderBindingContext(string? BindingId)
 public sealed record AgentToolConnectedServicesContext(string? ContextJson)
 {
     public static AgentToolConnectedServicesContext Empty { get; } = new((string?)null);
+}
+
+public sealed record AgentWorkflowRuntimeContext(
+    string? ParentActorId,
+    string? ParentRunId,
+    string? ParentStepId,
+    string? RootRunId,
+    int Depth)
+{
+    public static AgentWorkflowRuntimeContext Empty { get; } = new(null, null, null, null, 0);
+
+    public bool HasManagedParent =>
+        !string.IsNullOrWhiteSpace(ParentActorId) &&
+        !string.IsNullOrWhiteSpace(ParentRunId) &&
+        !string.IsNullOrWhiteSpace(ParentStepId);
 }
 
 public sealed record AgentSkillRecoveryContext(

--- a/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContextMapper.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContextMapper.cs
@@ -24,6 +24,21 @@ public static class AgentToolExecutionContextMapper
         LLMRequestMetadataKeys.ConnectedServicesContext,
         LLMRequestMetadataKeys.SenderBindingId,
         LLMRequestMetadataKeys.SenderNyxIdAccessToken,
+        "workflow.parent_actor_id",
+        "workflow.parent_run_id",
+        "workflow.parent_step_id",
+        "workflow.root_run_id",
+        "workflow.depth",
+        "workflow_call.parent_actor_id",
+        "workflow_call.parent_run_id",
+        "workflow_call.parent_step_id",
+        "workflow_call.root_run_id",
+        "workflow_call.depth",
+        "aevatar.workflow.parent_actor_id",
+        "aevatar.workflow.parent_run_id",
+        "aevatar.workflow.parent_step_id",
+        "aevatar.workflow.root_run_id",
+        "aevatar.workflow.depth",
         "platform",
         "channel.platform",
         "sender_id",
@@ -134,6 +149,7 @@ public static class AgentToolExecutionContextMapper
                 payload.Routing?.HasMaxToolRoundsOverride == true ? payload.Routing.MaxToolRoundsOverride : null,
                 AgentToolExecutionContext.Normalize(payload.Routing?.UserMemoryPrompt)),
             new AgentToolConnectedServicesContext(AgentToolExecutionContext.Normalize(payload.ConnectedServices?.ContextJson)),
+            FromWorkflowRuntimePayload(payload.WorkflowRuntime),
             FromSkillRecoveryPayload(payload.SkillRecovery),
             StripOwnedControlKeys(payload.ExternalMetadata));
     }
@@ -183,6 +199,7 @@ public static class AgentToolExecutionContextMapper
             {
                 ContextJson = context.ConnectedServices.ContextJson ?? string.Empty,
             },
+            WorkflowRuntime = ToWorkflowRuntimePayload(context.WorkflowRuntime),
             SkillRecovery = ToSkillRecoveryPayload(context.SkillRecovery),
         };
 
@@ -221,6 +238,29 @@ public static class AgentToolExecutionContextMapper
             AgentToolExecutionContext.Normalize(payload.CommandArguments),
             payload.DiscoveryRequested);
     }
+
+    private static AgentWorkflowRuntimeContext FromWorkflowRuntimePayload(AgentWorkflowRuntimeContextPayload? payload)
+    {
+        if (payload == null)
+            return AgentWorkflowRuntimeContext.Empty;
+
+        return new AgentWorkflowRuntimeContext(
+            AgentToolExecutionContext.Normalize(payload.ParentActorId),
+            AgentToolExecutionContext.Normalize(payload.ParentRunId),
+            AgentToolExecutionContext.Normalize(payload.ParentStepId),
+            AgentToolExecutionContext.Normalize(payload.RootRunId),
+            Math.Max(0, payload.Depth));
+    }
+
+    private static AgentWorkflowRuntimeContextPayload ToWorkflowRuntimePayload(AgentWorkflowRuntimeContext context) =>
+        new()
+        {
+            ParentActorId = context.ParentActorId ?? string.Empty,
+            ParentRunId = context.ParentRunId ?? string.Empty,
+            ParentStepId = context.ParentStepId ?? string.Empty,
+            RootRunId = context.RootRunId ?? string.Empty,
+            Depth = Math.Max(0, context.Depth),
+        };
 
     private static AgentSkillRecoveryContextPayload ToSkillRecoveryPayload(AgentSkillRecoveryContext context) =>
         new()

--- a/src/Aevatar.AI.Abstractions/ai_messages.proto
+++ b/src/Aevatar.AI.Abstractions/ai_messages.proto
@@ -199,6 +199,16 @@ message AgentToolReceipt {
   string error_code = 12;
   string error_message = 13;
   string result_json = 14;
+  ManagedWorkflowHandoffReceipt managed_workflow_handoff = 15;
+}
+
+message ManagedWorkflowHandoffReceipt {
+  string parent_actor_id = 1;
+  string parent_run_id = 2;
+  string parent_step_id = 3;
+  string invocation_id = 4;
+  string child_run_id = 5;
+  string stream_topic = 6;
 }
 
 message ToolResultEvent {

--- a/src/Aevatar.AI.Abstractions/ai_messages.proto
+++ b/src/Aevatar.AI.Abstractions/ai_messages.proto
@@ -99,6 +99,7 @@ message AgentToolExecutionContextPayload {
   AgentToolConnectedServicesContextPayload connected_services = 7;
   map<string, string> external_metadata = 8;
   AgentSkillRecoveryContextPayload skill_recovery = 9;
+  AgentWorkflowRuntimeContextPayload workflow_runtime = 10;
 }
 
 message AgentSkillRecoveryContextPayload {
@@ -150,6 +151,14 @@ message LLMRequestRoutingContextPayload {
 
 message AgentToolConnectedServicesContextPayload {
   string context_json = 1;
+}
+
+message AgentWorkflowRuntimeContextPayload {
+  string parent_actor_id = 1;
+  string parent_run_id = 2;
+  string parent_step_id = 3;
+  string root_run_id = 4;
+  int32 depth = 5;
 }
 
 message TextMessageStartEvent   { string session_id = 1; string agent_id = 2; }

--- a/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
@@ -1038,7 +1038,8 @@ public sealed class ChatRuntime
             chunk.DeltaContentPart == null &&
             normalizedToolCall == null &&
             !chunk.IsLast &&
-            chunk.Usage == null)
+            chunk.Usage == null &&
+            chunk.ToolReceipt == null)
         {
             return null;
         }
@@ -1051,6 +1052,7 @@ public sealed class ChatRuntime
             DeltaToolCall = normalizedToolCall,
             Usage = chunk.Usage,
             IsLast = chunk.IsLast,
+            ToolReceipt = chunk.ToolReceipt?.Clone(),
             // Field-level patch (ADR-0021 §6 / canon §8): forward FinishReason so
             // the actor-edge closeout in ConversationReplyGenerator can observe
             // it. ChatRuntime itself remains transitional per aevatar#596 Phase A;

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/Aevatar.AI.ToolProviders.AevatarInvocation.csproj
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/Aevatar.AI.ToolProviders.AevatarInvocation.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\Aevatar.CQRS.Core.Abstractions\Aevatar.CQRS.Core.Abstractions.csproj" />
     <ProjectReference Include="..\Aevatar.AGUI.Contracts\Aevatar.AGUI.Contracts.csproj" />
     <ProjectReference Include="..\platform\Aevatar.GAgentService.Abstractions\Aevatar.GAgentService.Abstractions.csproj" />
+    <ProjectReference Include="..\workflow\Aevatar.Workflow.Abstractions\Aevatar.Workflow.Abstractions.csproj" />
     <ProjectReference Include="..\workflow\Aevatar.Workflow.Application.Abstractions\Aevatar.Workflow.Application.Abstractions.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -887,7 +887,8 @@ public sealed class AevatarInvocationDispatcher
             Prompt = payload.Prompt,
             SessionId = commandId,
             ScopeId = scope.ScopeId,
-            ToolContext = ToPayload(AgentToolRequestContext.Current),
+            ToolContext = AgentToolExecutionContextMapper.ToPayload(
+                AgentToolRequestContext.Current ?? AgentToolExecutionContext.Empty),
             LlmControl = ToLlmControlPayload(AgentToolRequestContext.Current),
         };
         AppendMetadata(request.Headers, headers);
@@ -928,60 +929,6 @@ public sealed class AevatarInvocationDispatcher
             if (!string.IsNullOrWhiteSpace(key) && !string.IsNullOrWhiteSpace(value))
                 destination[key.Trim()] = value.Trim();
         }
-    }
-
-    private static AgentToolExecutionContextPayload ToPayload(AgentToolExecutionContext? context)
-    {
-        // Refactor (iter1353/cluster-001): Old pattern: stamp trusted caller/control to Headers/Metadata.
-        // New principle: typed ScopeId/ToolContext/LlmControl are authority.
-        context ??= AgentToolExecutionContext.Empty;
-        var payload = new AgentToolExecutionContextPayload
-        {
-            Request = new AgentToolRequestIdentityPayload
-            {
-                RequestId = context.Request.RequestId ?? string.Empty,
-                CallId = context.Request.CallId ?? string.Empty,
-            },
-            Credentials = new AgentToolCredentialsPayload
-            {
-                NyxIdAccessToken = context.Credentials.NyxIdAccessToken ?? string.Empty,
-                NyxIdOrgToken = context.Credentials.NyxIdOrgToken ?? string.Empty,
-                SenderNyxIdAccessToken = context.Credentials.SenderNyxIdAccessToken ?? string.Empty,
-            },
-            Caller = new AgentToolCallerContextPayload
-            {
-                ScopeId = context.Caller.ScopeId ?? string.Empty,
-                OwnerSubject = context.Caller.OwnerSubject ?? string.Empty,
-                ResponseId = context.Caller.ResponseId ?? string.Empty,
-            },
-            Channel = new AgentToolChannelContextPayload
-            {
-                Platform = context.Channel.Platform ?? string.Empty,
-                SenderId = context.Channel.SenderId ?? string.Empty,
-                RegistrationScopeId = context.Channel.RegistrationScopeId ?? string.Empty,
-                MessageId = context.Channel.MessageId ?? string.Empty,
-                PlatformMessageId = context.Channel.PlatformMessageId ?? string.Empty,
-            },
-            SenderBinding = new AgentToolSenderBindingContextPayload
-            {
-                BindingId = context.SenderBinding.BindingId ?? string.Empty,
-            },
-            Routing = new LLMRequestRoutingContextPayload
-            {
-                ModelOverride = context.Routing.ModelOverride ?? string.Empty,
-                NyxIdRoutePreference = context.Routing.NyxIdRoutePreference ?? string.Empty,
-                UserMemoryPrompt = context.Routing.UserMemoryPrompt ?? string.Empty,
-            },
-            ConnectedServices = new AgentToolConnectedServicesContextPayload
-            {
-                ContextJson = context.ConnectedServices.ContextJson ?? string.Empty,
-            },
-        };
-        if (context.Routing.MaxToolRoundsOverride.HasValue)
-            payload.Routing.MaxToolRoundsOverride = context.Routing.MaxToolRoundsOverride.Value;
-        foreach (var (key, value) in context.ExternalMetadata)
-            payload.ExternalMetadata[key] = value;
-        return payload;
     }
 
     private static LLMControlContextPayload ToLlmControlPayload(AgentToolExecutionContext? context)

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -12,7 +12,9 @@ using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.AGUI.Contracts;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.Workflow.Abstractions;
 using Google.Protobuf;
+using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -40,6 +42,27 @@ public sealed class AevatarInvocationDispatcher
         LLMRequestMetadataKeys.ConnectedServicesContext,
         "scope_id",
     ];
+
+    private static readonly string[] ForbiddenStartWorkflowRootFields =
+    [
+        "parent_actor_id",
+        "parent_run_id",
+        "parent_step_id",
+        "root_run_id",
+        "depth",
+        "requested_depth",
+        "workflow_runtime_context",
+        "workflow_call_context",
+    ];
+
+    private static readonly JsonFormatter ProtoJsonFormatter = new(
+        JsonFormatter.Settings.Default
+            .WithFormatDefaultValues(false)
+            .WithTypeRegistry(TypeRegistry.FromFiles(
+                AGUIEvent.Descriptor.File,
+                AnyReflection.Descriptor,
+                StructReflection.Descriptor,
+                WrappersReflection.Descriptor)));
 
     private readonly IActorDispatchPort _actorDispatchPort;
     private readonly IGAgentActorRegistryQueryPort _actorRegistryQueryPort;
@@ -206,6 +229,13 @@ public sealed class AevatarInvocationDispatcher
         string argumentsJson,
         CancellationToken ct = default)
     {
+        var forbiddenField = ProtoToolArguments.RejectForbiddenRootFields(
+            argumentsJson,
+            ForbiddenStartWorkflowRootFields,
+            "trusted workflow runtime context");
+        if (forbiddenField != null)
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(forbiddenField), forbiddenField);
+
         var parsed = ProtoToolArguments.Parse<StartWorkflowToolRequest>(argumentsJson);
         if (parsed.Error != null)
             return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(parsed.Error), parsed.Error);
@@ -217,13 +247,6 @@ public sealed class AevatarInvocationDispatcher
         if (error != null)
             return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(error), error);
 
-        var scope = ResolveCallerScope();
-        if (scope.Error != null)
-            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(scope.Error), scope.Error);
-
-        // Refactor (iter1353/cluster-001): Old pattern: workflow dispatch stamped trusted caller/control facts into Metadata.
-        // New principle: Metadata carries only filtered payload headers; ScopeId, ToolContext, and LlmControl carry trusted facts.
-        var metadata = BuildPayloadHeaders(request.Inputs.Headers);
         var workflowYamls = request.WorkflowYamls.Count == 0
             ? null
             : request.WorkflowYamls
@@ -232,6 +255,28 @@ public sealed class AevatarInvocationDispatcher
                 .ToArray();
         var workflowName = request.WorkflowId.Trim();
         var actorId = string.IsNullOrWhiteSpace(request.ActorId) ? null : request.ActorId.Trim();
+        if (TryGetManagedWorkflowRuntimeContext(AgentToolRequestContext.Current, out var workflowRuntimeContext))
+        {
+            var managedScope = ResolveCallerScope(requireOwner: false);
+            if (managedScope.Error != null)
+                return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(managedScope.Error), managedScope.Error);
+
+            return await StartManagedSubWorkflowForChatRunAsync(
+                chatRunRequest,
+                request,
+                wait,
+                managedScope.Value!,
+                workflowRuntimeContext,
+                workflowName,
+                workflowYamls,
+                ct);
+        }
+
+        var scope = ResolveCallerScope();
+        if (scope.Error != null)
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(scope.Error), scope.Error);
+
+        var metadata = BuildPayloadHeaders(request.Inputs.Headers);
         var source = workflowYamls is { Length: > 0 }
             ? WorkflowChatSource.InlineYamlBundle(workflowYamls, workflowName, actorId)
             : string.IsNullOrWhiteSpace(actorId)
@@ -268,6 +313,92 @@ public sealed class AevatarInvocationDispatcher
             CorrelationId = receipt.CorrelationId,
             Wait = wait,
         }, scope.Value!.ScopeId);
+    }
+
+    private async Task<ChatRunToolCompletionRequest> StartManagedSubWorkflowForChatRunAsync(
+        ChatRunToolCompletionRequest? chatRunRequest,
+        StartWorkflowToolRequest request,
+        InvocationWaitMode wait,
+        InvocationCallerScope scope,
+        AgentWorkflowRuntimeContext workflowRuntimeContext,
+        string workflowName,
+        IReadOnlyList<string>? workflowYamls,
+        CancellationToken ct)
+    {
+        if (!string.IsNullOrWhiteSpace(request.ActorId))
+        {
+            var actorIdError = Error(
+                "invalid_arguments",
+                "actor_id is not accepted when a workflow runtime context manages child workflow start.",
+                "actor_id");
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(actorIdError), actorIdError);
+        }
+
+        var parentActorId = workflowRuntimeContext.ParentActorId!.Trim();
+        var parentRunId = workflowRuntimeContext.ParentRunId!.Trim();
+        var parentStepId = workflowRuntimeContext.ParentStepId!.Trim();
+        var commandId = ResolveCommandId();
+        var invocationId = $"{parentRunId}:workflow_tool:{parentStepId}:{commandId}";
+        var managedStart = new SubWorkflowInvokeRequestedEvent
+        {
+            InvocationId = invocationId,
+            ParentRunId = parentRunId,
+            ParentStepId = parentStepId,
+            WorkflowName = workflowName,
+            Input = request.Inputs.Prompt ?? string.Empty,
+            Lifecycle = "transient",
+            RequestedByActorId = parentActorId,
+            RootRunId = string.IsNullOrWhiteSpace(workflowRuntimeContext.RootRunId)
+                ? parentRunId
+                : workflowRuntimeContext.RootRunId.Trim(),
+            RequestedDepth = Math.Max(0, workflowRuntimeContext.Depth) + 1,
+        };
+
+        if (workflowYamls is { Count: > 0 })
+        {
+            var yamlError = Error(
+                "invalid_arguments",
+                "workflow_yamls are not accepted inside a managed workflow runtime context; mount reusable workflows before starting a child run.",
+                "workflow_yamls");
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(yamlError), yamlError);
+        }
+
+        var envelope = new EventEnvelope
+        {
+            Id = commandId,
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(managedStart),
+            Route = EnvelopeRouteSemantics.CreateTopologyPublication(parentActorId, TopologyAudience.Self),
+            Propagation = new EnvelopePropagation
+            {
+                CorrelationId = commandId,
+            },
+        };
+
+        try
+        {
+            await _actorDispatchPort.DispatchAsync(parentActorId, envelope, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            var dispatchError = Error(
+                "dispatch_failed",
+                $"Workflow child start failed: {ex.Message}");
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(dispatchError), dispatchError);
+        }
+
+        return ToChatRunRequest(chatRunRequest, new InvocationToolResult
+        {
+            RunId = invocationId,
+            Status = "accepted",
+            StreamTopic = wait == InvocationWaitMode.Stream
+                ? AevatarInvocationStreamTopics.ForActorRun(parentActorId, invocationId)
+                : string.Empty,
+            ActorId = parentActorId,
+            CommandId = commandId,
+            CorrelationId = commandId,
+            Wait = wait,
+        }, scope.ScopeId);
     }
 
     public async Task<string> ObserveRunAsync(string argumentsJson, CancellationToken ct = default)
@@ -881,7 +1012,16 @@ public sealed class AevatarInvocationDispatcher
         return new WorkflowLlmControl(
             context.Routing.ModelOverride,
             context.Routing.MaxToolRoundsOverride,
-            context.Routing.UserMemoryPrompt);
+            context.Routing.UserMemoryPrompt,
+            context.Routing.NyxIdRoutePreference);
+    }
+
+    private static bool TryGetManagedWorkflowRuntimeContext(
+        AgentToolExecutionContext? context,
+        out AgentWorkflowRuntimeContext workflowRuntimeContext)
+    {
+        workflowRuntimeContext = context?.WorkflowRuntime ?? AgentWorkflowRuntimeContext.Empty;
+        return workflowRuntimeContext.HasManagedParent;
     }
 
     private CallerScopeResolution ResolveCallerScope(bool requireOwner = true)
@@ -956,11 +1096,11 @@ public sealed class AevatarInvocationDispatcher
         {
             Kind = part.Kind switch
             {
-                InvocationContentPartKind.Text => WorkflowChatInputPartKind.Text,
-                InvocationContentPartKind.Image => WorkflowChatInputPartKind.Image,
-                InvocationContentPartKind.Audio => WorkflowChatInputPartKind.Audio,
-                InvocationContentPartKind.Video => WorkflowChatInputPartKind.Video,
-                _ => WorkflowChatInputPartKind.Unspecified,
+                InvocationContentPartKind.Text => Aevatar.Workflow.Application.Abstractions.Runs.WorkflowChatInputPartKind.Text,
+                InvocationContentPartKind.Image => Aevatar.Workflow.Application.Abstractions.Runs.WorkflowChatInputPartKind.Image,
+                InvocationContentPartKind.Audio => Aevatar.Workflow.Application.Abstractions.Runs.WorkflowChatInputPartKind.Audio,
+                InvocationContentPartKind.Video => Aevatar.Workflow.Application.Abstractions.Runs.WorkflowChatInputPartKind.Video,
+                _ => Aevatar.Workflow.Application.Abstractions.Runs.WorkflowChatInputPartKind.Unspecified,
             },
             Text = EmptyToNull(part.Text),
             DataBase64 = EmptyToNull(part.DataBase64),

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSources.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSources.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.ToolProviders;
 
 namespace Aevatar.AI.ToolProviders.AevatarInvocation;
@@ -113,6 +115,75 @@ internal sealed class StartWorkflowTool : IAevatarInvocationTool
 
     public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
         _dispatcher.StartWorkflowAsync(argumentsJson, ct);
+
+    public string SideEffectKind => "workflow.managed-child-start";
+
+    public AgentToolReceipt? CreateSuccessReceipt(string callId, string toolName, string resultJson)
+    {
+        var workflowRuntime = AgentToolRequestContext.Current?.WorkflowRuntime ?? AgentWorkflowRuntimeContext.Empty;
+        if (!workflowRuntime.HasManagedParent)
+            return null;
+
+        var invocation = ParseInvocationToolResult(resultJson);
+        if (invocation == null || !IsAcceptedManagedWorkflowStart(invocation))
+            return null;
+
+        return new AgentToolReceipt
+        {
+            CallId = callId ?? string.Empty,
+            ToolName = string.IsNullOrWhiteSpace(toolName) ? Name : toolName,
+            Status = AgentToolReceiptStatus.Success,
+            ApprovalMode = AgentToolReceiptApprovalMode.NeverRequire,
+            SideEffectKind = SideEffectKind,
+            ResultJson = resultJson ?? string.Empty,
+            ManagedWorkflowHandoff = new ManagedWorkflowHandoffReceipt
+            {
+                ParentActorId = workflowRuntime.ParentActorId?.Trim() ?? string.Empty,
+                ParentRunId = workflowRuntime.ParentRunId?.Trim() ?? string.Empty,
+                ParentStepId = workflowRuntime.ParentStepId?.Trim() ?? string.Empty,
+                InvocationId = invocation.RunId,
+                ChildRunId = invocation.RunId,
+                StreamTopic = invocation.StreamTopic,
+            },
+        };
+    }
+
+    private static ManagedWorkflowStartResult? ParseInvocationToolResult(string resultJson)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(resultJson);
+            var root = document.RootElement;
+            if (root.TryGetProperty("error", out _))
+                return null;
+
+            return new ManagedWorkflowStartResult(
+                ReadString(root, "run_id"),
+                ReadString(root, "status"),
+                ReadString(root, "actor_id"),
+                ReadString(root, "stream_topic"));
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string ReadString(JsonElement root, string propertyName) =>
+        root.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString() ?? string.Empty
+            : string.Empty;
+
+    private static bool IsAcceptedManagedWorkflowStart(ManagedWorkflowStartResult invocation) =>
+        !string.IsNullOrWhiteSpace(invocation.RunId) &&
+        !string.IsNullOrWhiteSpace(invocation.ActorId) &&
+        string.Equals(invocation.Status, "accepted", StringComparison.Ordinal);
+
+    private sealed record ManagedWorkflowStartResult(
+        string RunId,
+        string Status,
+        string ActorId,
+        string StreamTopic);
 }
 
 internal sealed class ObserveRunTool : IAevatarInvocationTool

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/ProtoToolArguments.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/ProtoToolArguments.cs
@@ -38,6 +38,38 @@ internal static class ProtoToolArguments
         }
     }
 
+    public static InvocationToolError? RejectForbiddenRootFields(
+        string argumentsJson,
+        IReadOnlyCollection<string> fields,
+        string replacement)
+    {
+        var normalized = string.IsNullOrWhiteSpace(argumentsJson) ? "{}" : argumentsJson;
+        try
+        {
+            if (JsonNode.Parse(normalized) is not JsonObject obj)
+                return null;
+
+            foreach (var field in fields)
+            {
+                if (!obj.ContainsKey(field))
+                    continue;
+
+                return new InvocationToolError
+                {
+                    Code = "invalid_arguments",
+                    Message = $"{field} is not accepted. Use {replacement}.",
+                    Field = field,
+                };
+            }
+
+            return null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
     public static ToolArgumentParseResult<T> Parse<T>(string argumentsJson)
         where T : class, IMessage<T>, new()
     {

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -72,6 +72,7 @@ message StartWorkflowEvent
   map<string, string> parameters = 3;
   string run_id = 4;
   WorkflowRunForkSeed fork_seed = 5;
+  WorkflowToolRuntimeContextPayload workflow_runtime = 6;
 }
 message BindWorkflowRunDefinitionEvent
 {
@@ -108,6 +109,8 @@ message WorkflowRunExecutionContextDelta
   bool clear_llm = 3;
   WorkflowCallerCredential caller_credential = 5;
   bool clear_caller_credential = 6;
+  WorkflowToolRuntimeContextPayload workflow_runtime = 7;
+  bool clear_workflow_runtime = 8;
 }
 message WorkflowRunLlmExecutionContextDelta
 {
@@ -280,6 +283,8 @@ message SubWorkflowInvokeRequestedEvent
   string input = 5;
   string lifecycle = 6;
   string requested_by_actor_id = 7;
+  string root_run_id = 8;
+  int32 requested_depth = 9;
 }
 message WorkflowDefinitionSnapshot
 {
@@ -336,6 +341,8 @@ message SubWorkflowDefinitionResolutionRegisteredEvent
   int32 timeout_callback_backend = 11;
   int32 timeout_ms = 12;
   int32 timeout_callback_slot_epoch = 13;
+  string root_run_id = 14;
+  int32 requested_depth = 15;
 }
 message SubWorkflowDefinitionResolutionClearedEvent
 {
@@ -365,6 +372,8 @@ message SubWorkflowInvocationRegisteredEvent
   string definition_yaml = 12;
   string scope_id = 13;
   map<string, string> inline_workflow_yamls = 14;
+  string root_run_id = 15;
+  int32 depth = 16;
 }
 message SubWorkflowInvocationHandoffAdvancedEvent
 {
@@ -482,6 +491,16 @@ message WorkflowLlmExecutionIntent
   WorkflowCallerCredential caller_credential = 12;
   string route_preference = 13;
   string sender_nyx_id_access_token = 14;
+  WorkflowToolRuntimeContextPayload workflow_runtime_context = 15;
+}
+
+message WorkflowToolRuntimeContextPayload
+{
+  string parent_actor_id = 1;
+  string parent_run_id = 2;
+  string parent_step_id = 3;
+  string root_run_id = 4;
+  int32 depth = 5;
 }
 
 message WorkflowLlmInvocationStartedEvent

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -532,6 +532,17 @@ message WorkflowLlmInvocationCompletedEvent
   string reasoning_content = 7;
   string error = 8;
   WorkflowUsageMetrics usage = 9;
+  WorkflowManagedHandoffOutcome managed_handoff = 10;
+}
+
+message WorkflowManagedHandoffOutcome
+{
+  string parent_actor_id = 1;
+  string parent_run_id = 2;
+  string parent_step_id = 3;
+  string invocation_id = 4;
+  string child_run_id = 5;
+  string stream_topic = 6;
 }
 
 message WorkflowToolCallStartedEvent
@@ -551,6 +562,7 @@ message WorkflowToolCallCompletedEvent
   bool success = 4;
   string result_json = 5;
   string error = 6;
+  WorkflowManagedHandoffOutcome managed_handoff = 7;
 }
 
 enum WorkflowLeaseConflictPolicy {

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
@@ -122,6 +122,13 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
         state.Usage = new WorkflowUsageMetricsState();
         state.CurrentStepDispatchPending = false;
         state.CurrentStepTimeoutCallbackId = string.Empty;
+        if (evt.WorkflowRuntime != null)
+        {
+            await _stateHost.UpdateExecutionContextAsync(
+                WorkflowRunExecutionContextStateAccess.BuildWorkflowRuntimeDelta(evt.WorkflowRuntime),
+                ct);
+        }
+
         var forkSeed = evt.ForkSeed;
         var hasForkSeedStart = forkSeed != null && !string.IsNullOrWhiteSpace(forkSeed.StartAtStepId);
         if (hasForkSeedStart)

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunExecutionContextStateAccess.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunExecutionContextStateAccess.cs
@@ -1,4 +1,5 @@
 using Aevatar.Workflow.Core.Primitives;
+using Aevatar.Workflow.Core.Modules;
 
 namespace Aevatar.Workflow.Core.Execution;
 
@@ -120,6 +121,71 @@ internal static class WorkflowRunExecutionContextStateAccess
                !string.IsNullOrWhiteSpace(llm.UserMemoryPrompt) ||
                !string.IsNullOrWhiteSpace(llm.RoutePreference) ||
                llm.HasMaxToolRoundsOverride;
+    }
+
+    public static WorkflowRunExecutionContextDelta ClearWorkflowRuntimeDelta() =>
+        new()
+        {
+            ClearWorkflowRuntime = true,
+        };
+
+    public static WorkflowRunExecutionContextDelta BuildWorkflowRuntimeDelta(WorkflowToolRuntimeContextPayload? runtimeContext)
+    {
+        var delta = ClearWorkflowRuntimeDelta();
+        if (runtimeContext == null)
+            return delta;
+
+        var parentActorId = Normalize(runtimeContext.ParentActorId);
+        var parentRunId = Normalize(runtimeContext.ParentRunId);
+        var parentStepId = Normalize(runtimeContext.ParentStepId);
+        if (string.IsNullOrWhiteSpace(parentActorId) ||
+            string.IsNullOrWhiteSpace(parentRunId) ||
+            string.IsNullOrWhiteSpace(parentStepId))
+        {
+            return delta;
+        }
+
+        var normalizedParentRunId = WorkflowRunIdNormalizer.Normalize(parentRunId);
+        delta.WorkflowRuntime = new WorkflowToolRuntimeContextPayload
+        {
+            ParentActorId = parentActorId,
+            ParentRunId = normalizedParentRunId,
+            ParentStepId = parentStepId,
+            RootRunId = string.IsNullOrWhiteSpace(runtimeContext.RootRunId)
+                ? normalizedParentRunId
+                : WorkflowRunIdNormalizer.Normalize(runtimeContext.RootRunId),
+            Depth = Math.Max(0, runtimeContext.Depth),
+        };
+        return delta;
+    }
+
+    public static WorkflowToolRuntimeContext GetWorkflowRuntimeContext(
+        IWorkflowExecutionContext ctx,
+        string parentActorId,
+        string runId,
+        string stepId)
+    {
+        var runtime = Get(ctx).WorkflowRuntime;
+        if (runtime == null ||
+            string.IsNullOrWhiteSpace(runtime.ParentActorId) ||
+            string.IsNullOrWhiteSpace(runtime.ParentRunId) ||
+            string.IsNullOrWhiteSpace(runtime.ParentStepId))
+        {
+            var normalizedRunId = WorkflowRunIdNormalizer.Normalize(runId);
+            return new WorkflowToolRuntimeContext(
+                parentActorId?.Trim() ?? string.Empty,
+                normalizedRunId,
+                stepId?.Trim() ?? string.Empty,
+                normalizedRunId,
+                0);
+        }
+
+        return new WorkflowToolRuntimeContext(
+            parentActorId?.Trim() ?? string.Empty,
+            WorkflowRunIdNormalizer.Normalize(runId),
+            stepId?.Trim() ?? string.Empty,
+            WorkflowRunIdNormalizer.Normalize(runtime.RootRunId),
+            Math.Max(0, runtime.Depth));
     }
 
     public static WorkflowRunExecutionContextState RedactedClone(WorkflowRunExecutionContextState? source)

--- a/src/workflow/Aevatar.Workflow.Core/Modules/IWorkflowToolSource.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/IWorkflowToolSource.cs
@@ -6,7 +6,15 @@ public interface IWorkflowTool
 {
     string Name { get; }
 
-    Task<string> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default);
+    Task<WorkflowToolExecutionResult> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default);
+}
+
+public sealed record WorkflowToolExecutionResult(
+    string ResultJson,
+    WorkflowManagedHandoffOutcome? ManagedHandoff = null)
+{
+    public static WorkflowToolExecutionResult Success(string resultJson) =>
+        new(resultJson ?? string.Empty);
 }
 
 public sealed record WorkflowToolExecutionRequest(

--- a/src/workflow/Aevatar.Workflow.Core/Modules/IWorkflowToolSource.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/IWorkflowToolSource.cs
@@ -16,7 +16,44 @@ public sealed record WorkflowToolExecutionRequest(
     string ExecutionId,
     string CallId,
     string ScopeId,
-    WorkflowCallerCredential CallerCredential);
+    WorkflowCallerCredential CallerCredential,
+    WorkflowToolRuntimeContext RuntimeContext)
+{
+    public WorkflowToolExecutionRequest(
+        string ArgumentsJson,
+        string RunId,
+        string StepId,
+        string ExecutionId,
+        string CallId,
+        string ScopeId,
+        WorkflowCallerCredential CallerCredential)
+        : this(
+            ArgumentsJson,
+            RunId,
+            StepId,
+            ExecutionId,
+            CallId,
+            ScopeId,
+            CallerCredential,
+            WorkflowToolRuntimeContext.Empty)
+    {
+    }
+}
+
+public sealed record WorkflowToolRuntimeContext(
+    string ParentActorId,
+    string ParentRunId,
+    string ParentStepId,
+    string RootRunId,
+    int Depth)
+{
+    public static WorkflowToolRuntimeContext Empty { get; } = new(
+        string.Empty,
+        string.Empty,
+        string.Empty,
+        string.Empty,
+        0);
+}
 
 public interface IWorkflowToolSource
 {

--- a/src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs
@@ -381,6 +381,19 @@ public sealed class LLMCallModule : IEventModule<IWorkflowExecutionContext>
             RunId = WorkflowRunIdNormalizer.Normalize(request.RunId),
             StepId = stepId,
         };
+        var runtimeContext = WorkflowRunExecutionContextStateAccess.GetWorkflowRuntimeContext(
+            ctx,
+            ctx.AgentId ?? string.Empty,
+            request.RunId ?? string.Empty,
+            stepId);
+        intent.WorkflowRuntimeContext = new WorkflowToolRuntimeContextPayload
+        {
+            ParentActorId = runtimeContext.ParentActorId,
+            ParentRunId = runtimeContext.ParentRunId,
+            ParentStepId = runtimeContext.ParentStepId,
+            RootRunId = runtimeContext.RootRunId,
+            Depth = runtimeContext.Depth,
+        };
         if (WorkflowRunExecutionContextStateAccess.TryGetLlm(ctx, out var llm))
         {
             intent.Model = Normalize(llm.ModelOverride) ?? string.Empty;

--- a/src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs
@@ -172,6 +172,12 @@ public sealed class LLMCallModule : IEventModule<IWorkflowExecutionContext>
             return;
         }
 
+        if (evt.ManagedHandoff != null && !string.IsNullOrWhiteSpace(evt.ManagedHandoff.InvocationId))
+        {
+            await RemovePendingAsync(sessionId, pending, ctx, ct);
+            return;
+        }
+
         ctx.Logger.LogInformation(
             "LLMCallModule: run={RunId} step={StepId} session={SessionId} status=completed output_len={OutputLen} output_redacted=true",
             pending.RunId,

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
@@ -79,16 +79,23 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
 
         try
         {
-            var resultJson = await ExecuteToolAsync(tool, argumentsJson, request, callId, ctx, ct);
+            var result = await ExecuteToolAsync(tool, argumentsJson, request, callId, ctx, ct);
 
-            await ctx.PublishAsync(new WorkflowToolCallCompletedEvent
+            var completed = new WorkflowToolCallCompletedEvent
             {
                 CallId = callId,
                 Success = true,
-                ResultJson = resultJson,
+                ResultJson = result.ResultJson,
                 RunId = request.RunId,
                 StepId = request.StepId,
-            }, TopologyAudience.Self, ct);
+            };
+            if (result.ManagedHandoff != null)
+                completed.ManagedHandoff = result.ManagedHandoff.Clone();
+
+            await ctx.PublishAsync(completed, TopologyAudience.Self, ct);
+
+            if (result.ManagedHandoff != null)
+                return;
 
             await ctx.PublishAsync(new StepCompletedEvent
             {
@@ -96,7 +103,7 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
                 RunId = request.RunId,
                 ExecutionId = request.ExecutionId,
                 Success = true,
-                Output = resultJson,
+                Output = result.ResultJson,
             }, TopologyAudience.Self, ct);
         }
         catch (Exception ex)
@@ -106,7 +113,7 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
         }
     }
 
-    private static Task<string> ExecuteToolAsync(
+    private static Task<WorkflowToolExecutionResult> ExecuteToolAsync(
         IWorkflowTool tool,
         string argumentsJson,
         StepRequestEvent request,

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
@@ -117,6 +117,11 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
         var callerCredential = WorkflowRunExecutionContextStateAccess.TryGetCallerCredential(ctx, out var credential)
             ? credential
             : new WorkflowCallerCredential();
+        var runtimeContext = WorkflowRunExecutionContextStateAccess.GetWorkflowRuntimeContext(
+            ctx,
+            ctx.AgentId ?? string.Empty,
+            request.RunId ?? string.Empty,
+            request.StepId ?? string.Empty);
         return tool.ExecuteAsync(
             new WorkflowToolExecutionRequest(
                 ArgumentsJson: argumentsJson,
@@ -125,7 +130,8 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
                 ExecutionId: request.ExecutionId ?? string.Empty,
                 CallId: callId,
                 ScopeId: ctx.ScopeId ?? string.Empty,
-                CallerCredential: callerCredential),
+                CallerCredential: callerCredential,
+                RuntimeContext: runtimeContext),
             ct);
     }
 

--- a/src/workflow/Aevatar.Workflow.Core/Modules/WorkflowCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/WorkflowCallModule.cs
@@ -6,6 +6,7 @@
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Abstractions.EventModules;
+using Aevatar.Workflow.Core.Execution;
 using Aevatar.Workflow.Core.Primitives;
 
 namespace Aevatar.Workflow.Core.Modules;
@@ -74,6 +75,11 @@ public sealed class WorkflowCallModule : IEventModule<IWorkflowExecutionContext>
             return;
         }
 
+        var runtimeContext = WorkflowRunExecutionContextStateAccess.GetWorkflowRuntimeContext(
+            ctx,
+            ctx.AgentId ?? string.Empty,
+            parentRunId,
+            parentStepId);
         var invocation = new SubWorkflowInvokeRequestedEvent
         {
             InvocationId = WorkflowCallInvocationIdFactory.Build(parentRunId, parentStepId),
@@ -83,6 +89,8 @@ public sealed class WorkflowCallModule : IEventModule<IWorkflowExecutionContext>
             Input = request.Input ?? string.Empty,
             Lifecycle = WorkflowCallLifecycle.Normalize(lifecycleRaw),
             RequestedByActorId = ctx.AgentId,
+            RootRunId = runtimeContext.RootRunId,
+            RequestedDepth = Math.Max(0, runtimeContext.Depth) + 1,
         };
 
         await ctx.PublishAsync(invocation, TopologyAudience.Self, ct);

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/SubWorkflowOrchestrator.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/SubWorkflowOrchestrator.cs
@@ -105,6 +105,21 @@ internal sealed class SubWorkflowOrchestrator
         var invocationId = string.IsNullOrWhiteSpace(request.InvocationId)
             ? WorkflowCallInvocationIdFactory.Build(parentRunId, parentStepId)
             : request.InvocationId.Trim();
+        var rootRunId = ResolveRootRunId(request.RootRunId, state, parentRunId);
+        var parentDepth = ResolveParentDepth(state, parentRunId);
+        var requestedDepth = WorkflowCallLimitPolicy.ResolveChildDepth(request.RequestedDepth, parentDepth);
+        var admission = WorkflowCallLimitPolicy.Admit(
+            requestedDepth,
+            parentDepth,
+            state.MaxSubWorkflowDepth,
+            state.PendingSubWorkflowInvocations.Count + state.PendingSubWorkflowDefinitionResolutions.Count,
+            state.MaxActiveSubWorkflows);
+        if (!admission.Accepted)
+        {
+            await PublishWorkflowCallFailureAsync(parentStepId, parentRunId, admission.Error, ct);
+            return;
+        }
+
         RuntimeCallbackLease? timeoutLease = null;
 
         try
@@ -119,6 +134,8 @@ internal sealed class SubWorkflowOrchestrator
                     request.Input ?? string.Empty,
                     lifecycle,
                     inlineSnapshot,
+                    rootRunId,
+                    requestedDepth,
                     state,
                     ct);
                 return;
@@ -160,6 +177,8 @@ internal sealed class SubWorkflowOrchestrator
                 },
                 TimeoutCallbackSlotEpoch = timeoutLease.SlotEpoch,
                 TimeoutMs = timeoutMs,
+                RootRunId = rootRunId,
+                RequestedDepth = requestedDepth,
             }, ct);
 
             await _sendToAsync(
@@ -293,6 +312,8 @@ internal sealed class SubWorkflowOrchestrator
                 pending.Input ?? string.Empty,
                 pending.Lifecycle,
                 definition,
+                ResolveRootRunId(pending.RootRunId, state, pending.ParentRunId),
+                WorkflowCallLimitPolicy.ResolveChildDepth(pending.RequestedDepth, ResolveParentDepth(state, pending.ParentRunId)),
                 state,
                 ct);
             await TryCancelDefinitionResolutionTimeoutAsync(pending, CancellationToken.None);
@@ -358,6 +379,8 @@ internal sealed class SubWorkflowOrchestrator
         string input,
         string lifecycle,
         WorkflowDefinitionSnapshot definition,
+        string rootRunId,
+        int depth,
         WorkflowRunState state,
         CancellationToken ct)
     {
@@ -368,7 +391,16 @@ internal sealed class SubWorkflowOrchestrator
         ArgumentNullException.ThrowIfNull(state);
         ValidateDefinitionSnapshotOrThrow(definition);
 
-        var registered = BuildPendingSubWorkflowInvocation(invocationId, parentRunId, parentStepId, input, lifecycle, definition, state);
+        var registered = BuildPendingSubWorkflowInvocation(
+            invocationId,
+            parentRunId,
+            parentStepId,
+            input,
+            lifecycle,
+            definition,
+            rootRunId,
+            depth,
+            state);
 
         await _persistDomainEventAsync(new SubWorkflowInvocationRegisteredEvent
         {
@@ -385,6 +417,8 @@ internal sealed class SubWorkflowOrchestrator
             HandoffPhase = (int)SubWorkflowInvocationHandoffPhase.Registered,
             DefinitionYaml = registered.DefinitionYaml,
             ScopeId = registered.ScopeId,
+            RootRunId = registered.RootRunId,
+            Depth = registered.Depth,
             InlineWorkflowYamls = { registered.InlineWorkflowYamls },
         }, ct);
 
@@ -594,9 +628,11 @@ internal sealed class SubWorkflowOrchestrator
                     Backend = evt.TimeoutCallbackBackend == (int)WorkflowRuntimeCallbackBackendState.Dedicated
                         ? WorkflowRuntimeCallbackBackendState.Dedicated
                         : WorkflowRuntimeCallbackBackendState.InMemory,
-                },
+            },
             TimeoutCallbackId = evt.TimeoutCallbackId?.Trim() ?? string.Empty,
             TimeoutMs = evt.TimeoutMs,
+            RootRunId = ResolveRootRunId(evt.RootRunId, current, evt.ParentRunId),
+            RequestedDepth = Math.Max(0, evt.RequestedDepth),
         };
 
         RemovePendingDefinitionResolution(next, invocationId);
@@ -636,6 +672,8 @@ internal sealed class SubWorkflowOrchestrator
             Input = evt.Input ?? string.Empty,
             DefinitionYaml = evt.DefinitionYaml ?? string.Empty,
             ScopeId = evt.ScopeId ?? string.Empty,
+            RootRunId = ResolveRootRunId(evt.RootRunId, current, evt.ParentRunId),
+            Depth = Math.Max(0, evt.Depth),
             InlineWorkflowYamls = { evt.InlineWorkflowYamls },
         };
         RemovePendingDefinitionResolution(next, invocationId);
@@ -694,6 +732,8 @@ internal sealed class SubWorkflowOrchestrator
         string input,
         string lifecycle,
         WorkflowDefinitionSnapshot definition,
+        string rootRunId,
+        int depth,
         WorkflowRunState state)
     {
         var normalizedLifecycle = WorkflowCallLifecycle.Normalize(lifecycle);
@@ -716,6 +756,8 @@ internal sealed class SubWorkflowOrchestrator
             ScopeId = string.IsNullOrWhiteSpace(definition.ScopeId)
                 ? state.ScopeId ?? string.Empty
                 : definition.ScopeId,
+            RootRunId = ResolveRootRunId(rootRunId, state, parentRunId),
+            Depth = Math.Max(0, depth),
         };
 
         foreach (var (inlineWorkflowName, inlineWorkflowYaml) in definition.InlineWorkflowYamls.Count > 0
@@ -902,6 +944,14 @@ internal sealed class SubWorkflowOrchestrator
             WorkflowName = definition.WorkflowName ?? string.Empty,
             Input = pending.Input ?? string.Empty,
             RunId = pending.ChildRunId,
+            WorkflowRuntime = new WorkflowToolRuntimeContextPayload
+            {
+                ParentActorId = _ownerActorIdAccessor(),
+                ParentRunId = pending.ParentRunId,
+                ParentStepId = pending.ParentStepId,
+                RootRunId = NormalizeRootRunId(pending.RootRunId, pending.ParentRunId),
+                Depth = Math.Max(0, pending.Depth),
+            },
         };
         start.Parameters[WorkflowCallInvocationIdMetadataKey] = pending.InvocationId;
         start.Parameters[WorkflowCallParentRunIdMetadataKey] = pending.ParentRunId;
@@ -1438,6 +1488,35 @@ internal sealed class SubWorkflowOrchestrator
     {
         return pendingInvocations.Any(x =>
             string.Equals(x.ChildActorId, childActorId, StringComparison.Ordinal));
+    }
+
+    private static string ResolveRootRunId(string? requestedRootRunId, WorkflowRunState state, string fallbackRunId)
+    {
+        var requested = WorkflowRunIdNormalizer.Normalize(requestedRootRunId);
+        if (!string.IsNullOrWhiteSpace(requested))
+            return requested;
+
+        return NormalizeRootRunId(state.RunId, fallbackRunId);
+    }
+
+    private static string NormalizeRootRunId(string? rootRunId, string fallbackRunId)
+    {
+        var normalizedRoot = WorkflowRunIdNormalizer.Normalize(rootRunId);
+        if (!string.IsNullOrWhiteSpace(normalizedRoot))
+            return normalizedRoot;
+
+        return WorkflowRunIdNormalizer.Normalize(fallbackRunId);
+    }
+
+    private static int ResolveParentDepth(WorkflowRunState state, string parentRunId)
+    {
+        foreach (var pending in state.PendingSubWorkflowInvocations)
+        {
+            if (string.Equals(pending.ChildRunId, parentRunId, StringComparison.Ordinal))
+                return Math.Max(0, pending.Depth);
+        }
+
+        return Math.Max(0, state.ExecutionContext?.WorkflowRuntime?.Depth ?? 0);
     }
 
     private static ISet<string> CollectReferencedSingletonWorkflowNames(IEnumerable<StepDefinition> steps)

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowCallLimitPolicy.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowCallLimitPolicy.cs
@@ -1,0 +1,42 @@
+namespace Aevatar.Workflow.Core.Primitives;
+
+internal sealed record WorkflowCallLimitAdmission(bool Accepted, string Error)
+{
+    public static WorkflowCallLimitAdmission Accept() => new(true, string.Empty);
+
+    public static WorkflowCallLimitAdmission Reject(string error) => new(false, error);
+}
+
+internal static class WorkflowCallLimitPolicy
+{
+    public const int DefaultMaxDepth = 8;
+    public const int DefaultMaxActiveSubWorkflows = 64;
+
+    public static int NormalizeMaxDepth(int configured) =>
+        configured <= 0 ? DefaultMaxDepth : configured;
+
+    public static int NormalizeMaxActiveSubWorkflows(int configured) =>
+        configured <= 0 ? DefaultMaxActiveSubWorkflows : configured;
+
+    public static int ResolveChildDepth(int requestedDepth, int parentDepth) =>
+        requestedDepth > 0 ? requestedDepth : Math.Max(0, parentDepth) + 1;
+
+    public static WorkflowCallLimitAdmission Admit(
+        int requestedDepth,
+        int parentDepth,
+        int maxDepth,
+        int activeSubWorkflowCount,
+        int maxActiveSubWorkflows)
+    {
+        var childDepth = ResolveChildDepth(requestedDepth, parentDepth);
+        var depthLimit = NormalizeMaxDepth(maxDepth);
+        if (childDepth > depthLimit)
+            return WorkflowCallLimitAdmission.Reject($"workflow_call depth limit exceeded: depth {childDepth} > {depthLimit}");
+
+        var activeLimit = NormalizeMaxActiveSubWorkflows(maxActiveSubWorkflows);
+        if (activeSubWorkflowCount >= activeLimit)
+            return WorkflowCallLimitAdmission.Reject($"workflow_call fanout limit exceeded: active {activeSubWorkflowCount} >= {activeLimit}");
+
+        return WorkflowCallLimitAdmission.Accept();
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
@@ -273,7 +273,10 @@ public sealed class WorkflowRunGAgent
         var runId = string.IsNullOrWhiteSpace(State.RunId)
             ? WorkflowRunIdNormalizer.Normalize(Id)
             : WorkflowRunIdNormalizer.Normalize(State.RunId);
-        var executionContextDelta = MergeExecutionContextDeltas(callerCredentialDelta, llmControlDelta);
+        var executionContextDelta = MergeExecutionContextDeltas(
+            callerCredentialDelta,
+            llmControlDelta,
+            WorkflowRunExecutionContextStateAccess.ClearWorkflowRuntimeDelta());
         var executionInput = ResolveExecutionInput(request);
         await PersistDomainEventAsync(new WorkflowRunExecutionStartedEvent
         {
@@ -341,6 +344,7 @@ public sealed class WorkflowRunGAgent
             Input = request.Input ?? string.Empty,
             DefinitionActorId = State.DefinitionActorId ?? string.Empty,
             ScopeId = State.ScopeId ?? string.Empty,
+            ExecutionContextDelta = WorkflowRunExecutionContextStateAccess.ClearWorkflowRuntimeDelta(),
             Attempt = State.ForkAttempt,
         });
 
@@ -896,6 +900,10 @@ public sealed class WorkflowRunGAgent
                 merged.Llm = delta.Llm.Clone();
             if (delta.CallerCredential != null)
                 merged.CallerCredential = delta.CallerCredential.Clone();
+            if (delta.ClearWorkflowRuntime)
+                merged.ClearWorkflowRuntime = true;
+            if (delta.WorkflowRuntime != null)
+                merged.WorkflowRuntime = delta.WorkflowRuntime.Clone();
         }
 
         return merged;
@@ -912,6 +920,8 @@ public sealed class WorkflowRunGAgent
             state.Llm = null;
         if (delta.ClearCallerCredential)
             state.CallerCredential = null;
+        if (delta.ClearWorkflowRuntime)
+            state.WorkflowRuntime = null;
 
         if (delta.Llm != null)
         {
@@ -931,6 +941,18 @@ public sealed class WorkflowRunGAgent
             state.CallerCredential = new WorkflowCallerCredentialState
             {
                 BearerToken = parsed.IsValid ? parsed.NormalizedBearerToken ?? string.Empty : string.Empty,
+            };
+        }
+
+        if (delta.WorkflowRuntime != null)
+        {
+            state.WorkflowRuntime = new WorkflowToolRuntimeContextState
+            {
+                ParentActorId = delta.WorkflowRuntime.ParentActorId?.Trim() ?? string.Empty,
+                ParentRunId = WorkflowRunIdNormalizer.Normalize(delta.WorkflowRuntime.ParentRunId),
+                ParentStepId = delta.WorkflowRuntime.ParentStepId?.Trim() ?? string.Empty,
+                RootRunId = WorkflowRunIdNormalizer.Normalize(delta.WorkflowRuntime.RootRunId),
+                Depth = Math.Max(0, delta.WorkflowRuntime.Depth),
             };
         }
     }

--- a/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
+++ b/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
@@ -33,6 +33,8 @@ message WorkflowState
     string definition_yaml = 12;
     string scope_id = 13;
     map<string, string> inline_workflow_yamls = 14;
+    string root_run_id = 15;
+    int32 depth = 16;
   }
 
   message PendingSubWorkflowDefinitionResolution
@@ -47,6 +49,8 @@ message WorkflowState
     WorkflowRuntimeCallbackLeaseState timeout_lease = 8;
     string timeout_callback_id = 9;
     int32 timeout_ms = 10;
+    string root_run_id = 11;
+    int32 requested_depth = 12;
   }
 
   message ChildRunIdSet
@@ -70,6 +74,8 @@ message WorkflowState
   map<string, ChildRunIdSet> pending_child_run_ids_by_parent_run_id = 13;
   string scope_id = 14;
   string source_kind = 15;
+  int32 max_sub_workflow_depth = 16;
+  int32 max_active_sub_workflows = 17;
 }
 
 message WorkflowRunState
@@ -99,6 +105,8 @@ message WorkflowRunState
     string definition_yaml = 12;
     string scope_id = 13;
     map<string, string> inline_workflow_yamls = 14;
+    string root_run_id = 15;
+    int32 depth = 16;
   }
 
   message PendingSubWorkflowDefinitionResolution
@@ -113,6 +121,8 @@ message WorkflowRunState
     WorkflowRuntimeCallbackLeaseState timeout_lease = 8;
     string timeout_callback_id = 9;
     int32 timeout_ms = 10;
+    string root_run_id = 11;
+    int32 requested_depth = 12;
   }
 
   message ChildRunIdSet
@@ -143,6 +153,8 @@ message WorkflowRunState
   map<string, int32> pending_sub_workflow_definition_resolution_index_by_invocation_id = 20;
   WorkflowRunExecutionContextState execution_context = 21;
   int32 fork_attempt = 22;
+  int32 max_sub_workflow_depth = 23;
+  int32 max_active_sub_workflows = 24;
 }
 
 message WorkflowRunExecutionContextState
@@ -151,6 +163,7 @@ message WorkflowRunExecutionContextState
   reserved 2;
   reserved "connector";
   WorkflowCallerCredentialState caller_credential = 3;
+  WorkflowToolRuntimeContextState workflow_runtime = 4;
 }
 
 message WorkflowLlmExecutionContextState
@@ -166,6 +179,15 @@ message WorkflowLlmExecutionContextState
 message WorkflowCallerCredentialState
 {
   string bearer_token = 1;
+}
+
+message WorkflowToolRuntimeContextState
+{
+  string parent_actor_id = 1;
+  string parent_run_id = 2;
+  string parent_step_id = 3;
+  string root_run_id = 4;
+  int32 depth = 5;
 }
 
 enum WorkflowRuntimeCallbackBackendState

--- a/src/workflow/Aevatar.Workflow.Integration.AI/AgentWorkflowToolSourceAdapter.cs
+++ b/src/workflow/Aevatar.Workflow.Integration.AI/AgentWorkflowToolSourceAdapter.cs
@@ -1,4 +1,6 @@
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Core.Modules;
 
 namespace Aevatar.Workflow.Integration.AI;
@@ -27,7 +29,7 @@ public sealed class AgentWorkflowToolSourceAdapter(IEnumerable<IAgentToolSource>
 
         public string Name => _tool.Name;
 
-        public async Task<string> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
+        public async Task<WorkflowToolExecutionResult> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
         {
             ArgumentNullException.ThrowIfNull(request);
 
@@ -52,10 +54,31 @@ public sealed class AgentWorkflowToolSourceAdapter(IEnumerable<IAgentToolSource>
                 },
             };
             using var scope = AgentToolContextScope.Push(toolContext);
-            return await _tool.ExecuteAsync(request.ArgumentsJson, ct).ConfigureAwait(false);
+            var resultJson = await _tool.ExecuteAsync(request.ArgumentsJson, ct).ConfigureAwait(false);
+            var receipt = _tool.CreateSuccessReceipt(request.CallId, _tool.Name, resultJson);
+            return new WorkflowToolExecutionResult(
+                resultJson,
+                ToWorkflowManagedHandoffOutcome(receipt?.ManagedWorkflowHandoff));
         }
 
         private static string? Normalize(string? value) =>
             string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+        private static WorkflowManagedHandoffOutcome? ToWorkflowManagedHandoffOutcome(
+            ManagedWorkflowHandoffReceipt? receipt)
+        {
+            if (receipt == null || string.IsNullOrWhiteSpace(receipt.InvocationId))
+                return null;
+
+            return new WorkflowManagedHandoffOutcome
+            {
+                ParentActorId = receipt.ParentActorId ?? string.Empty,
+                ParentRunId = receipt.ParentRunId ?? string.Empty,
+                ParentStepId = receipt.ParentStepId ?? string.Empty,
+                InvocationId = receipt.InvocationId ?? string.Empty,
+                ChildRunId = receipt.ChildRunId ?? string.Empty,
+                StreamTopic = receipt.StreamTopic ?? string.Empty,
+            };
+        }
     }
 }

--- a/src/workflow/Aevatar.Workflow.Integration.AI/AgentWorkflowToolSourceAdapter.cs
+++ b/src/workflow/Aevatar.Workflow.Integration.AI/AgentWorkflowToolSourceAdapter.cs
@@ -31,7 +31,15 @@ public sealed class AgentWorkflowToolSourceAdapter(IEnumerable<IAgentToolSource>
         {
             ArgumentNullException.ThrowIfNull(request);
 
-            var credentialContext = WorkflowCallerCredentialToolContextMapper.FromCredential(request.CallerCredential);
+            var workflowRuntimeContext = new AgentWorkflowRuntimeContext(
+                Normalize(request.RuntimeContext.ParentActorId),
+                Normalize(request.RuntimeContext.ParentRunId),
+                Normalize(request.RuntimeContext.ParentStepId),
+                Normalize(request.RuntimeContext.RootRunId),
+                Math.Max(0, request.RuntimeContext.Depth));
+            var credentialContext = WorkflowCallerCredentialToolContextMapper.FromCredential(
+                request.CallerCredential,
+                workflowRuntimeContext);
             var toolContext = credentialContext with
             {
                 Request = credentialContext.Request with

--- a/src/workflow/Aevatar.Workflow.Integration.AI/WorkflowCallerCredentialToolContextMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Integration.AI/WorkflowCallerCredentialToolContextMapper.cs
@@ -7,15 +7,28 @@ internal static class WorkflowCallerCredentialToolContextMapper
 {
     public static AgentToolExecutionContext FromCredential(WorkflowCallerCredential? credential)
     {
+        return FromCredential(credential, AgentWorkflowRuntimeContext.Empty);
+    }
+
+    public static AgentToolExecutionContext FromCredential(
+        WorkflowCallerCredential? credential,
+        AgentWorkflowRuntimeContext workflowRuntimeContext)
+    {
         var token = WorkflowCallerCredentialTokens.ParseOptional(credential?.BearerToken);
-        if (token.IsMissing)
-            return AgentToolExecutionContext.Empty;
         if (token.IsInvalid)
             throw new ArgumentException("Workflow caller credential bearer token is invalid.", nameof(credential));
 
-        return AgentToolExecutionContext.Empty with
+        var context = AgentToolExecutionContext.Empty with
         {
-            Credentials = AgentToolCredentials.Empty with
+            WorkflowRuntime = workflowRuntimeContext,
+        };
+
+        if (token.IsMissing)
+            return context;
+
+        return context with
+        {
+            Credentials = context.Credentials with
             {
                 NyxIdAccessToken = token.NormalizedBearerToken,
                 NyxIdOrgToken = token.NormalizedBearerToken,

--- a/src/workflow/Aevatar.Workflow.Integration.AI/WorkflowRoleGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Integration.AI/WorkflowRoleGAgent.cs
@@ -131,7 +131,15 @@ public class WorkflowRoleGAgent(
 
     private static ChatRequestEvent BuildChatRequestFromWorkflowIntent(WorkflowLlmExecutionIntent intent)
     {
-        var toolContext = WorkflowCallerCredentialToolContextMapper.FromCredential(intent.CallerCredential);
+        var workflowRuntimeContext = new AgentWorkflowRuntimeContext(
+            Normalize(intent.WorkflowRuntimeContext?.ParentActorId),
+            Normalize(intent.WorkflowRuntimeContext?.ParentRunId),
+            Normalize(intent.WorkflowRuntimeContext?.ParentStepId),
+            Normalize(intent.WorkflowRuntimeContext?.RootRunId),
+            Math.Max(0, intent.WorkflowRuntimeContext?.Depth ?? 0));
+        var toolContext = WorkflowCallerCredentialToolContextMapper.FromCredential(
+            intent.CallerCredential,
+            workflowRuntimeContext);
         if (!string.IsNullOrWhiteSpace(intent.RoutePreference))
         {
             toolContext = toolContext with
@@ -261,6 +269,9 @@ public class WorkflowRoleGAgent(
 
     private static string SanitizeWorkflowFailureMessage(string? message) =>
         string.IsNullOrWhiteSpace(message) ? "LLM request failed." : message.Trim();
+
+    private static string? Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
     private sealed record WorkflowIntentReplayRecord(
         string Content,

--- a/src/workflow/Aevatar.Workflow.Integration.AI/WorkflowRoleGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Integration.AI/WorkflowRoleGAgent.cs
@@ -78,7 +78,7 @@ public class WorkflowRoleGAgent(
         try
         {
             var replayRecord = await ExecuteWorkflowIntentStreamingChatAsync(intent, chatRequest, streamCt);
-            await PublishAsync(new WorkflowLlmInvocationCompletedEvent
+            var completed = new WorkflowLlmInvocationCompletedEvent
             {
                 RunId = intent.RunId ?? string.Empty,
                 StepId = intent.StepId ?? string.Empty,
@@ -88,7 +88,11 @@ public class WorkflowRoleGAgent(
                 Content = replayRecord.Content,
                 ReasoningContent = replayRecord.ReasoningContent,
                 Usage = ToWorkflowUsageMetrics(replayRecord.Usage, replayRecord.Model),
-            }, TopologyAudience.Parent);
+            };
+            var managedHandoff = ToWorkflowManagedHandoffOutcome(replayRecord.ToolReceipts);
+            if (managedHandoff != null)
+                completed.ManagedHandoff = managedHandoff;
+            await PublishAsync(completed, TopologyAudience.Parent);
             await PersistRoleChatSessionCompletionAsync(
                 chatRequest,
                 replayRecord.Content,
@@ -202,6 +206,7 @@ public class WorkflowRoleGAgent(
         var fullContent = new StringBuilder();
         var fullReasoning = new StringBuilder();
         var toolCalls = new WorkflowToolCallAccumulator();
+        var toolReceipts = new List<AgentToolReceipt>();
         var contentParts = new List<ContentPart>();
         TokenUsage? usage = null;
 
@@ -241,12 +246,16 @@ public class WorkflowRoleGAgent(
 
             if (chunk.DeltaToolCall != null)
                 toolCalls.TrackDelta(chunk.DeltaToolCall);
+
+            if (chunk.ToolReceipt != null)
+                toolReceipts.Add(chunk.ToolReceipt.Clone());
         }
 
         return new WorkflowIntentReplayRecord(
             fullContent.ToString(),
             fullReasoning.ToString(),
             toolCalls.BuildToolCalls(),
+            toolReceipts,
             contentParts,
             Usage: usage,
             Model: EffectiveConfig.Model ?? string.Empty,
@@ -277,10 +286,31 @@ public class WorkflowRoleGAgent(
         string Content,
         string ReasoningContent,
         IReadOnlyList<ToolCall> ToolCalls,
+        IReadOnlyList<AgentToolReceipt> ToolReceipts,
         IReadOnlyList<ContentPart> ContentParts,
         TokenUsage? Usage,
         string? Model,
         bool ContentEmitted);
+
+    private static WorkflowManagedHandoffOutcome? ToWorkflowManagedHandoffOutcome(
+        IReadOnlyList<AgentToolReceipt> toolReceipts)
+    {
+        var handoff = toolReceipts
+            .Select(static receipt => receipt.ManagedWorkflowHandoff)
+            .LastOrDefault(static receipt => receipt != null && !string.IsNullOrWhiteSpace(receipt.InvocationId));
+        if (handoff == null)
+            return null;
+
+        return new WorkflowManagedHandoffOutcome
+        {
+            ParentActorId = handoff.ParentActorId ?? string.Empty,
+            ParentRunId = handoff.ParentRunId ?? string.Empty,
+            ParentStepId = handoff.ParentStepId ?? string.Empty,
+            InvocationId = handoff.InvocationId ?? string.Empty,
+            ChildRunId = handoff.ChildRunId ?? string.Empty,
+            StreamTopic = handoff.StreamTopic ?? string.Empty,
+        };
+    }
 
     private static WorkflowUsageMetrics? ToWorkflowUsageMetrics(TokenUsage? usage, string? model) =>
         usage == null

--- a/test/Aevatar.AI.Tests/AIAbstractionsProtoCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/AIAbstractionsProtoCoverageTests.cs
@@ -103,10 +103,19 @@ public sealed class AIAbstractionsProtoCoverageTests
             ErrorCode = "",
             ErrorMessage = "",
             ResultJson = """{"guid":"skill-1","version":"1.0","skillHash":"hash-1"}""",
+            ManagedWorkflowHandoff = new ManagedWorkflowHandoffReceipt
+            {
+                ParentActorId = "parent-actor",
+                ParentRunId = "parent-run",
+                ParentStepId = "parent-step",
+                InvocationId = "invoke-1",
+                ChildRunId = "child-run-1",
+            },
         };
         var receiptRoundTrip = RoundTrip(receipt, AgentToolReceipt.Parser);
         receiptRoundTrip.SubjectId.Should().Be("skill-1");
         receiptRoundTrip.SubjectHash.Should().Be("hash-1");
+        receiptRoundTrip.ManagedWorkflowHandoff.InvocationId.Should().Be("invoke-1");
 
         var request = RoundTrip(new ChatRequestEvent
         {
@@ -458,7 +467,8 @@ public sealed class AIAbstractionsProtoCoverageTests
                 (11, "approval_request_id"),
                 (12, "error_code"),
                 (13, "error_message"),
-                (14, "result_json"));
+                (14, "result_json"),
+                (15, "managed_workflow_handoff"));
 
         AgentToolReceipt.Descriptor.Fields.InFieldNumberOrder()
             .Select(field => field.Name)

--- a/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
+++ b/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
@@ -39,6 +39,8 @@ public sealed class AgentToolExecutionContextMapperTests
                 [LLMRequestMetadataKeys.NyxIdRoutePreference] = "legacy-route",
                 [LLMRequestMetadataKeys.MaxToolRoundsOverride] = "4",
                 [LLMRequestMetadataKeys.UserMemoryPrompt] = "legacy-memory",
+                ["workflow.parent_actor_id"] = "forged-parent",
+                ["workflow.root_run_id"] = "forged-root",
                 ["external-trace"] = "trace-1",
             },
         };
@@ -56,6 +58,7 @@ public sealed class AgentToolExecutionContextMapperTests
         context.Routing.NyxIdRoutePreference.Should().Be("typed-route");
         context.Routing.MaxToolRoundsOverride.Should().Be(9);
         context.Routing.UserMemoryPrompt.Should().Be("typed-memory");
+        context.WorkflowRuntime.Should().Be(AgentWorkflowRuntimeContext.Empty);
         context.ExternalMetadata.Should().ContainSingle();
         context.ExternalMetadata["external-trace"].Should().Be("trace-1");
     }
@@ -199,6 +202,13 @@ public sealed class AgentToolExecutionContextMapperTests
             ["lark.open_id"] = "ou-lark",
             ["lark.message_id"] = "msg-lark",
             ["telegram.chat_id"] = "10001",
+            ["workflow.parent_actor_id"] = "forged-parent",
+            ["workflow.parent_run_id"] = "forged-run",
+            ["workflow.parent_step_id"] = "forged-step",
+            ["workflow.root_run_id"] = "forged-root",
+            ["workflow.depth"] = "99",
+            ["workflow_call.parent_actor_id"] = "forged-parent-2",
+            ["aevatar.workflow.root_run_id"] = "forged-root-2",
             ["trace-id"] = "trace-1",
         });
 
@@ -221,6 +231,7 @@ public sealed class AgentToolExecutionContextMapperTests
         context.Routing.MaxToolRoundsOverride.Should().BeNull();
         context.Routing.UserMemoryPrompt.Should().BeNull();
         context.ConnectedServices.ContextJson.Should().BeNull();
+        context.WorkflowRuntime.Should().Be(AgentWorkflowRuntimeContext.Empty);
         context.ExternalMetadata.Should().ContainSingle();
         context.ExternalMetadata["trace-id"].Should().Be("trace-1");
     }
@@ -255,6 +266,7 @@ public sealed class AgentToolExecutionContextMapperTests
             new AgentToolSenderBindingContext(" binding-1 "),
             new LLMRequestRoutingContext(" model-1 ", " route-1 ", 7, " memory-1 "),
             new AgentToolConnectedServicesContext("""{"service":"telegram"}"""),
+            new AgentWorkflowRuntimeContext(" parent-actor ", " parent-run ", " parent-step ", " root-run ", 3),
             new AgentSkillRecoveryContext(
                 RequireInitialOrnnSearch: true,
                 RequireOrnnSearchOnBlocker: true,
@@ -294,6 +306,12 @@ public sealed class AgentToolExecutionContextMapperTests
         copy.Routing.MaxToolRoundsOverride.Should().Be(7);
         copy.Routing.UserMemoryPrompt.Should().Be("memory-1");
         copy.ConnectedServices.ContextJson.Should().Be("""{"service":"telegram"}""");
+        copy.WorkflowRuntime.ParentActorId.Should().Be("parent-actor");
+        copy.WorkflowRuntime.ParentRunId.Should().Be("parent-run");
+        copy.WorkflowRuntime.ParentStepId.Should().Be("parent-step");
+        copy.WorkflowRuntime.RootRunId.Should().Be("root-run");
+        copy.WorkflowRuntime.Depth.Should().Be(3);
+        copy.WorkflowRuntime.HasManagedParent.Should().BeTrue();
         copy.SkillRecovery.RequireInitialOrnnSearch.Should().BeTrue();
         copy.SkillRecovery.RequireOrnnSearchOnBlocker.Should().BeTrue();
         copy.SkillRecovery.CommandName.Should().Be("goal");

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -755,6 +755,77 @@ public sealed class AevatarInvocationToolSourceTests
     }
 
     [Fact]
+    public async Task InvokeGAgentForChatRun_ShouldPreserveWorkflowRuntimeInCanonicalToolContextPayload()
+    {
+        var harness = new Harness();
+        var dispatcher = harness.CreateDispatcher();
+
+        using var _ = PushContext(
+            callId: "call-gagent-runtime",
+            workflowRuntime: new AgentWorkflowRuntimeContext(
+                "parent-actor",
+                "parent-run",
+                "parent-step",
+                "root-run",
+                2));
+        var request = BuildChatRunRequest(
+            "response-gagent",
+            "call-gagent-runtime-tool",
+            "aevatar_invoke_gagent",
+            """
+            {
+              "actor_id": "actor-1",
+              "payload": { "prompt": "run gagent" }
+            }
+            """);
+
+        var result = await dispatcher.InvokeGAgentForChatRunAsync(request, request.ArgumentsJson);
+
+        result.ErrorCode.Should().BeEmpty();
+        harness.ActorDispatch.Calls.Should().ContainSingle();
+        var chatRequest = harness.ActorDispatch.Calls.Single().Envelope.Payload.Unpack<ChatRequestEvent>();
+        chatRequest.ToolContext.WorkflowRuntime.ParentActorId.Should().Be("parent-actor");
+        chatRequest.ToolContext.WorkflowRuntime.ParentRunId.Should().Be("parent-run");
+        chatRequest.ToolContext.WorkflowRuntime.ParentStepId.Should().Be("parent-step");
+        chatRequest.ToolContext.WorkflowRuntime.RootRunId.Should().Be("root-run");
+        chatRequest.ToolContext.WorkflowRuntime.Depth.Should().Be(2);
+        chatRequest.ToolContext.SkillRecovery.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task StartWorkflow_WhenTrustedWorkflowRuntimeExists_ShouldCreateManagedHandoffReceipt()
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync("aevatar_start_workflow");
+
+        using var _ = PushContext(
+            callId: "call-managed-workflow",
+            workflowRuntime: new AgentWorkflowRuntimeContext(
+                "parent-actor",
+                "parent-run",
+                "parent-step",
+                "root-run",
+                2));
+
+        var output = await tool.ExecuteAsync("""
+            {
+              "workflow_id": "child-flow",
+              "inputs": { "prompt": "run child" },
+              "wait": "stream"
+            }
+            """);
+        var receipt = tool.CreateSuccessReceipt("call-managed-workflow", tool.Name, output);
+
+        receipt.Should().NotBeNull();
+        receipt!.ManagedWorkflowHandoff.Should().NotBeNull();
+        receipt.ManagedWorkflowHandoff.ParentActorId.Should().Be("parent-actor");
+        receipt.ManagedWorkflowHandoff.ParentRunId.Should().Be("parent-run");
+        receipt.ManagedWorkflowHandoff.ParentStepId.Should().Be("parent-step");
+        receipt.ManagedWorkflowHandoff.InvocationId.Should().Be("parent-run:workflow_tool:parent-step:call-managed-workflow");
+        receipt.ManagedWorkflowHandoff.ChildRunId.Should().Be("parent-run:workflow_tool:parent-step:call-managed-workflow");
+    }
+
+    [Fact]
     public async Task aevatar_start_workflow_with_actor_id_dispatches_definition_actor_source()
     {
         var harness = new Harness();

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -11,6 +11,7 @@ using Aevatar.GAgentService.Abstractions.Responses;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.AGUI.Contracts;
+using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using FluentAssertions;
@@ -909,6 +910,127 @@ public sealed class AevatarInvocationToolSourceTests
         ErrorCode(output).Should().Be("workflownotfound");
     }
 
+    [Theory]
+    [InlineData("parent_actor_id")]
+    [InlineData("parent_run_id")]
+    [InlineData("parent_step_id")]
+    [InlineData("root_run_id")]
+    [InlineData("depth")]
+    [InlineData("requested_depth")]
+    [InlineData("workflow_runtime_context")]
+    [InlineData("workflow_call_context")]
+    public async Task StartWorkflow_ShouldRejectPublicWorkflowRuntimeFields(string forbiddenField)
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync("aevatar_start_workflow");
+
+        using var _ = PushContext(callId: "call-workflow-forged");
+        var output = await tool.ExecuteAsync($$"""
+            {
+              "workflow_id": "wf-main",
+              "inputs": { "prompt": "run workflow" },
+              "{{forbiddenField}}": "forged"
+            }
+            """);
+
+        ErrorCode(output).Should().Be("invalid_arguments");
+        output.Should().Contain(forbiddenField);
+        harness.WorkflowDispatch.Command.Should().BeNull();
+        harness.ActorDispatch.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task StartWorkflow_WhenTrustedWorkflowRuntimeExists_ShouldDispatchManagedChildStartToParentActor()
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync("aevatar_start_workflow");
+
+        using var _ = PushContext(
+            callId: "call-managed-workflow",
+            workflowRuntime: new AgentWorkflowRuntimeContext(
+                "parent-actor",
+                "parent-run",
+                "parent-step",
+                "root-run",
+                2));
+        var output = await tool.ExecuteAsync("""
+            {
+              "workflow_id": "child-flow",
+              "inputs": { "prompt": "run child" },
+              "wait": "stream"
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        harness.WorkflowDispatch.Command.Should().BeNull();
+        harness.ActorDispatch.Calls.Should().ContainSingle();
+        var call = harness.ActorDispatch.Calls.Single();
+        call.ActorId.Should().Be("parent-actor");
+        call.Envelope.Route.PublisherActorId.Should().Be("parent-actor");
+        call.Envelope.Route.GetTopologyAudience().Should().Be(TopologyAudience.Self);
+        call.Envelope.Propagation.CorrelationId.Should().Be("call-managed-workflow");
+
+        var requested = call.Envelope.Payload.Unpack<SubWorkflowInvokeRequestedEvent>();
+        requested.InvocationId.Should().Be("parent-run:workflow_tool:parent-step:call-managed-workflow");
+        requested.ParentRunId.Should().Be("parent-run");
+        requested.ParentStepId.Should().Be("parent-step");
+        requested.WorkflowName.Should().Be("child-flow");
+        requested.Input.Should().Be("run child");
+        requested.RequestedByActorId.Should().Be("parent-actor");
+        requested.RootRunId.Should().Be("root-run");
+        requested.RequestedDepth.Should().Be(3);
+
+        var result = Read(output);
+        result.GetProperty("run_id").GetString().Should().Be(requested.InvocationId);
+        result.GetProperty("actor_id").GetString().Should().Be("parent-actor");
+        result.GetProperty("status").GetString().Should().Be("accepted");
+        result.GetProperty("stream_topic").GetString()
+            .Should()
+            .Be("aevatar://actors/parent-actor/runs/parent-run%3Aworkflow_tool%3Aparent-step%3Acall-managed-workflow");
+    }
+
+    [Theory]
+    [InlineData(
+        """
+        {
+          "workflow_id": "child-flow",
+          "actor_id": "definition-actor",
+          "inputs": { "prompt": "run child" }
+        }
+        """,
+        "actor_id")]
+    [InlineData(
+        """
+        {
+          "workflow_id": "child-flow",
+          "workflow_yamls": ["name: child_flow\nsteps: []"],
+          "inputs": { "prompt": "run child" }
+        }
+        """,
+        "workflow_yamls")]
+    public async Task StartWorkflow_WhenTrustedWorkflowRuntimeExists_ShouldRejectTopLevelStartOptions(
+        string argumentsJson,
+        string field)
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync("aevatar_start_workflow");
+
+        using var _ = PushContext(
+            callId: "call-managed-workflow-invalid",
+            workflowRuntime: new AgentWorkflowRuntimeContext(
+                "parent-actor",
+                "parent-run",
+                "parent-step",
+                "root-run",
+                1));
+        var output = await tool.ExecuteAsync(argumentsJson);
+
+        ErrorCode(output).Should().Be("invalid_arguments");
+        output.Should().Contain(field);
+        harness.WorkflowDispatch.Command.Should().BeNull();
+        harness.ActorDispatch.Calls.Should().BeEmpty();
+    }
+
     [Fact]
     public async Task ObserveRun_ShouldReadTerminalCorrelationTargetOnly()
     {
@@ -1346,9 +1468,13 @@ public sealed class AevatarInvocationToolSourceTests
         llmControl!.ModelOverride.Should().Be("model-1");
         llmControl.MaxToolRoundsOverride.Should().Be(4);
         llmControl.UserMemoryPrompt.Should().Be("memory");
+        llmControl.RoutePreference.Should().Be("route-1");
     }
 
-    private static AgentToolContextScope PushContext(string callId, string? scopeId = "scope-1") =>
+    private static AgentToolContextScope PushContext(
+        string callId,
+        string? scopeId = "scope-1",
+        AgentWorkflowRuntimeContext? workflowRuntime = null) =>
         AgentToolContextScope.Push(new AgentToolExecutionContext(
             new AgentToolRequestIdentity("request-1", callId),
             new AgentToolCredentials("access-token", "org-token", "sender-token"),
@@ -1357,6 +1483,7 @@ public sealed class AevatarInvocationToolSourceTests
             new AgentToolSenderBindingContext("binding-1"),
             new LLMRequestRoutingContext("model-1", "route-1", 4, "memory"),
             new AgentToolConnectedServicesContext("""{"service":"ctx"}"""),
+            workflowRuntime ?? AgentWorkflowRuntimeContext.Empty,
             AgentSkillRecoveryContext.Empty,
             new Dictionary<string, string>(StringComparer.Ordinal)
             {

--- a/test/Aevatar.Integration.Tests/WorkflowCoreModulesCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowCoreModulesCoverageTests.cs
@@ -1447,10 +1447,10 @@ public sealed class WorkflowCoreModulesCoverageTests
     {
         public string Name { get; } = name;
 
-        public Task<string> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
+        public Task<WorkflowToolExecutionResult> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
-            return Task.FromResult(execute(request.ArgumentsJson));
+            return Task.FromResult(WorkflowToolExecutionResult.Success(execute(request.ArgumentsJson)));
         }
     }
 
@@ -1459,11 +1459,11 @@ public sealed class WorkflowCoreModulesCoverageTests
         public string Name { get; } = name;
         public int ExecuteCalls { get; private set; }
 
-        public Task<string> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
+        public Task<WorkflowToolExecutionResult> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
             ExecuteCalls++;
-            return Task.FromResult(execute(request.ArgumentsJson));
+            return Task.FromResult(WorkflowToolExecutionResult.Success(execute(request.ArgumentsJson)));
         }
     }
 

--- a/test/Aevatar.Workflow.Core.Tests/Modules/AgentWorkflowToolSourceAdapterTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/AgentWorkflowToolSourceAdapterTests.cs
@@ -36,6 +36,39 @@ public sealed class AgentWorkflowToolSourceAdapterTests
         AgentToolRequestContext.Current.Should().BeNull();
     }
 
+    [Fact]
+    public async Task WorkflowTool_ShouldMapRuntimeContextToAgentToolExecutionContext()
+    {
+        var agentTool = new CapturingAgentTool();
+        var adapter = new AgentWorkflowToolSourceAdapter([new SingleAgentToolSource(agentTool)]);
+        var tool = (await adapter.GetToolsAsync(CancellationToken.None)).Single();
+
+        await tool.ExecuteAsync(
+            new WorkflowToolExecutionRequest(
+                ArgumentsJson: "{}",
+                RunId: "run-1",
+                StepId: "step-1",
+                ExecutionId: "exec-1",
+                CallId: "call-1",
+                ScopeId: "scope-1",
+                CallerCredential: new WorkflowCallerCredential { BearerToken = "token-123" },
+                RuntimeContext: new WorkflowToolRuntimeContext(
+                    " parent-actor ",
+                    " parent-run ",
+                    " parent-step ",
+                    " root-run ",
+                    2)),
+            CancellationToken.None);
+
+        agentTool.ObservedWorkflowRuntime.ParentActorId.Should().Be("parent-actor");
+        agentTool.ObservedWorkflowRuntime.ParentRunId.Should().Be("parent-run");
+        agentTool.ObservedWorkflowRuntime.ParentStepId.Should().Be("parent-step");
+        agentTool.ObservedWorkflowRuntime.RootRunId.Should().Be("root-run");
+        agentTool.ObservedWorkflowRuntime.Depth.Should().Be(2);
+        agentTool.ObservedWorkflowRuntime.HasManagedParent.Should().BeTrue();
+        AgentToolRequestContext.Current.Should().BeNull();
+    }
+
     [Theory]
     [InlineData(null, null, null, null)]
     [InlineData("", "", null, null)]
@@ -70,7 +103,7 @@ public sealed class AgentWorkflowToolSourceAdapterTests
     [Theory]
     [InlineData("")]
     [InlineData("  ")]
-    public async Task WorkflowTool_ShouldUseEmptyAgentToolContextWhenWorkflowCredentialIsMissing(string authorization)
+    public async Task WorkflowTool_ShouldPreserveRuntimeContextWhenWorkflowCredentialIsMissing(string authorization)
     {
         var agentTool = new CapturingAgentTool();
         var adapter = new AgentWorkflowToolSourceAdapter([new SingleAgentToolSource(agentTool)]);
@@ -84,11 +117,23 @@ public sealed class AgentWorkflowToolSourceAdapterTests
                 ExecutionId: "exec-1",
                 CallId: "call-1",
                 ScopeId: "scope-1",
-                CallerCredential: new WorkflowCallerCredential { BearerToken = authorization }),
+                CallerCredential: new WorkflowCallerCredential { BearerToken = authorization },
+                RuntimeContext: new WorkflowToolRuntimeContext(
+                    " parent-actor ",
+                    " parent-run ",
+                    " parent-step ",
+                    " root-run ",
+                    -1)),
             CancellationToken.None);
 
         agentTool.ObservedAccessToken.Should().BeNull();
         agentTool.ObservedOrgToken.Should().BeNull();
+        agentTool.ObservedWorkflowRuntime.ParentActorId.Should().Be("parent-actor");
+        agentTool.ObservedWorkflowRuntime.ParentRunId.Should().Be("parent-run");
+        agentTool.ObservedWorkflowRuntime.ParentStepId.Should().Be("parent-step");
+        agentTool.ObservedWorkflowRuntime.RootRunId.Should().Be("root-run");
+        agentTool.ObservedWorkflowRuntime.Depth.Should().Be(0);
+        agentTool.ObservedWorkflowRuntime.HasManagedParent.Should().BeTrue();
         AgentToolRequestContext.Current.Should().BeNull();
     }
 
@@ -141,6 +186,9 @@ public sealed class AgentWorkflowToolSourceAdapterTests
         public IReadOnlyDictionary<string, string> ObservedExternalMetadata { get; private set; } =
             new Dictionary<string, string>(StringComparer.Ordinal);
 
+        public AgentWorkflowRuntimeContext ObservedWorkflowRuntime { get; private set; } =
+            AgentWorkflowRuntimeContext.Empty;
+
         public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
@@ -165,6 +213,8 @@ public sealed class AgentWorkflowToolSourceAdapterTests
             ObservedCallId = AgentToolRequestContext.CallId;
             ObservedExternalMetadata = AgentToolRequestContext.Current?.ExternalMetadata
                 ?? new Dictionary<string, string>(StringComparer.Ordinal);
+            ObservedWorkflowRuntime = AgentToolRequestContext.Current?.WorkflowRuntime
+                ?? AgentWorkflowRuntimeContext.Empty;
         }
     }
 

--- a/test/Aevatar.Workflow.Core.Tests/Modules/AgentWorkflowToolSourceAdapterTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/AgentWorkflowToolSourceAdapterTests.cs
@@ -26,7 +26,8 @@ public sealed class AgentWorkflowToolSourceAdapterTests
                 CallerCredential: new WorkflowCallerCredential { BearerToken = "token-123" }),
             CancellationToken.None);
 
-        result.Should().Be("""{"observed":true}""");
+        result.ResultJson.Should().Be("""{"observed":true}""");
+        result.ManagedHandoff.Should().BeNull();
         agentTool.ObservedArgumentsJson.Should().Be("""{"ok":true}""");
         agentTool.ObservedAccessToken.Should().Be("token-123");
         agentTool.ObservedOrgToken.Should().Be("token-123");

--- a/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
@@ -103,6 +103,14 @@ public sealed class ToolCallModuleContextTests
         {
             BearerToken = " typed-token ",
         };
+        ctx.ExecutionContextState.WorkflowRuntime = new WorkflowToolRuntimeContextState
+        {
+            ParentActorId = "parent-actor",
+            ParentRunId = "parent-run",
+            ParentStepId = "parent-step",
+            RootRunId = "root-run",
+            Depth = 2,
+        };
         ctx.RuntimeContext.ApplyRequestMetadata(new Dictionary<string, string>(StringComparer.Ordinal)
         {
             ["connector.http.authorization"] = "Bearer metadata-token",
@@ -123,6 +131,11 @@ public sealed class ToolCallModuleContextTests
         tool.LastRequest.CallId.Should().Be("workflow:run-1:call_proxy:exec-1");
         tool.LastRequest.ScopeId.Should().Be("scope-1");
         tool.LastRequest.CallerCredential.BearerToken.Should().Be("typed-token");
+        tool.LastRequest.RuntimeContext.ParentActorId.Should().Be("agent-1");
+        tool.LastRequest.RuntimeContext.ParentRunId.Should().Be("run-1");
+        tool.LastRequest.RuntimeContext.ParentStepId.Should().Be("call_proxy");
+        tool.LastRequest.RuntimeContext.RootRunId.Should().Be("root-run");
+        tool.LastRequest.RuntimeContext.Depth.Should().Be(2);
         LastCompleted(ctx).Success.Should().BeTrue();
     }
 

--- a/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
@@ -140,6 +140,30 @@ public sealed class ToolCallModuleContextTests
     }
 
     [Fact]
+    public async Task ToolCallModule_WhenToolReturnsManagedHandoff_ShouldLeaveParentStepPending()
+    {
+        var handoff = new WorkflowManagedHandoffOutcome
+        {
+            ParentActorId = "parent-actor",
+            ParentRunId = "run-1",
+            ParentStepId = "call_proxy",
+            InvocationId = "run-1:workflow_tool:call_proxy:call-1",
+            ChildRunId = "run-1:workflow_tool:call_proxy:call-1",
+        };
+        var tool = new ManagedHandoffWorkflowTool("aevatar_start_workflow", handoff);
+        var module = CreateModule(tool);
+        var ctx = new RecordingWorkflowContext();
+
+        await ExecuteToolCallAsync(module, ctx, tool.Name, executionId: "exec-1");
+
+        var completed = ctx.Published.Select(x => x.Event).OfType<WorkflowToolCallCompletedEvent>().Single();
+        completed.Success.Should().BeTrue();
+        completed.ManagedHandoff.Should().NotBeNull();
+        completed.ManagedHandoff.InvocationId.Should().Be(handoff.InvocationId);
+        ctx.Published.Select(x => x.Event).OfType<StepCompletedEvent>().Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task ToolCallModule_ShouldFallbackToEmptyScopeIdWhenContextScopeIdIsNull()
     {
         var tool = new CapturingWorkflowTool("nyxid_tool");
@@ -229,10 +253,10 @@ public sealed class ToolCallModuleContextTests
     {
         public string Name { get; } = name;
 
-        public Task<string> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
+        public Task<WorkflowToolExecutionResult> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
-            return Task.FromResult(execute(request.ArgumentsJson));
+            return Task.FromResult(WorkflowToolExecutionResult.Success(execute(request.ArgumentsJson)));
         }
     }
 
@@ -242,11 +266,11 @@ public sealed class ToolCallModuleContextTests
 
         public int ExecuteCalls { get; private set; }
 
-        public Task<string> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
+        public Task<WorkflowToolExecutionResult> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
             ExecuteCalls++;
-            return Task.FromResult(execute(request.ArgumentsJson));
+            return Task.FromResult(WorkflowToolExecutionResult.Success(execute(request.ArgumentsJson)));
         }
     }
 
@@ -256,11 +280,22 @@ public sealed class ToolCallModuleContextTests
 
         public WorkflowToolExecutionRequest? LastRequest { get; private set; }
 
-        public Task<string> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
+        public Task<WorkflowToolExecutionResult> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
             LastRequest = request;
-            return Task.FromResult("""{"typed":true}""");
+            return Task.FromResult(WorkflowToolExecutionResult.Success("""{"typed":true}"""));
+        }
+    }
+
+    private sealed class ManagedHandoffWorkflowTool(string name, WorkflowManagedHandoffOutcome handoff) : IWorkflowTool
+    {
+        public string Name { get; } = name;
+
+        public Task<WorkflowToolExecutionResult> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(new WorkflowToolExecutionResult("""{"status":"accepted"}""", handoff));
         }
     }
 

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowLoopModuleExpressionEvaluationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowLoopModuleExpressionEvaluationTests.cs
@@ -114,6 +114,52 @@ public class WorkflowLoopModuleExpressionEvaluationTests
     }
 
     [Fact]
+    public async Task StartWorkflow_ShouldHydrateTypedWorkflowRuntimeBeforeFirstStepDispatch()
+    {
+        var workflow = new WorkflowDefinition
+        {
+            Name = "wf",
+            Roles = [],
+            Steps =
+            [
+                new StepDefinition
+                {
+                    Id = "tool",
+                    Type = "tool_call",
+                },
+            ],
+        };
+
+        var ctx = new CapturingContext();
+        var stateHost = (IWorkflowExecutionStateHost)ctx.Agent;
+        var module = new WorkflowExecutionKernel(workflow, stateHost);
+
+        await module.HandleAsync(Wrap(new StartWorkflowEvent
+        {
+            WorkflowName = "wf",
+            RunId = "child-run",
+            Input = "hello",
+            WorkflowRuntime = new WorkflowToolRuntimeContextPayload
+            {
+                ParentActorId = " parent-actor ",
+                ParentRunId = " parent-run ",
+                ParentStepId = " parent-step ",
+                RootRunId = " root-run ",
+                Depth = 3,
+            },
+        }), ctx, CancellationToken.None);
+
+        stateHost.ExecutionContextSnapshot.WorkflowRuntime.Should().NotBeNull();
+        stateHost.ExecutionContextSnapshot.WorkflowRuntime!.ParentActorId.Should().Be("parent-actor");
+        stateHost.ExecutionContextSnapshot.WorkflowRuntime.ParentRunId.Should().Be("parent-run");
+        stateHost.ExecutionContextSnapshot.WorkflowRuntime.ParentStepId.Should().Be("parent-step");
+        stateHost.ExecutionContextSnapshot.WorkflowRuntime.RootRunId.Should().Be("root-run");
+        stateHost.ExecutionContextSnapshot.WorkflowRuntime.Depth.Should().Be(3);
+        ctx.Published.Single(x => x.Event is StepRequestEvent).Event
+            .Should().BeOfType<StepRequestEvent>().Which.StepId.Should().Be("tool");
+    }
+
+    [Fact]
     public async Task DispatchStep_WhenNotifyTemplateUsesExpressions_ShouldEvaluateBeforeNotifyModulePublishesNotification()
     {
         var workflow = new WorkflowDefinition
@@ -318,6 +364,7 @@ public class WorkflowLoopModuleExpressionEvaluationTests
         {
             ExecutionContextState.Llm = null;
             ExecutionContextState.CallerCredential = null;
+            ExecutionContextState.WorkflowRuntime = null;
             return Task.CompletedTask;
         }
 
@@ -366,6 +413,8 @@ public class WorkflowLoopModuleExpressionEvaluationTests
             state.Llm = null;
         if (delta.ClearCallerCredential)
             state.CallerCredential = null;
+        if (delta.ClearWorkflowRuntime)
+            state.WorkflowRuntime = null;
         if (delta.Llm != null)
         {
             state.Llm = new WorkflowLlmExecutionContextState
@@ -383,6 +432,18 @@ public class WorkflowLoopModuleExpressionEvaluationTests
             state.CallerCredential = new WorkflowCallerCredentialState
             {
                 BearerToken = delta.CallerCredential.BearerToken,
+            };
+        }
+
+        if (delta.WorkflowRuntime != null)
+        {
+            state.WorkflowRuntime = new WorkflowToolRuntimeContextState
+            {
+                ParentActorId = delta.WorkflowRuntime.ParentActorId,
+                ParentRunId = delta.WorkflowRuntime.ParentRunId,
+                ParentStepId = delta.WorkflowRuntime.ParentStepId,
+                RootRunId = delta.WorkflowRuntime.RootRunId,
+                Depth = delta.WorkflowRuntime.Depth,
             };
         }
     }

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRoleGAgentMappingTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRoleGAgentMappingTests.cs
@@ -66,9 +66,54 @@ public sealed class WorkflowRoleGAgentMappingTests
             .ContainSingle(x => x.Success);
     }
 
+    [Fact]
+    public async Task WorkflowRoleGAgent_WhenToolReceiptCarriesManagedHandoff_ShouldPublishHandoffCompletion()
+    {
+        var provider = new RecordingLlmProvider
+        {
+            ToolReceipt = new AgentToolReceipt
+            {
+                CallId = "tool-call-1",
+                ToolName = "aevatar_start_workflow",
+                Status = AgentToolReceiptStatus.Success,
+                ManagedWorkflowHandoff = new ManagedWorkflowHandoffReceipt
+                {
+                    ParentActorId = "parent-actor",
+                    ParentRunId = "parent-run",
+                    ParentStepId = "reply",
+                    InvocationId = "parent-run:workflow_tool:reply:tool-call-1",
+                    ChildRunId = "parent-run:workflow_tool:reply:tool-call-1",
+                },
+            },
+        };
+        var publisher = new RecordingEventPublisher();
+        var agent = new WorkflowRoleGAgent(provider)
+        {
+            EventPublisher = publisher,
+        };
+
+        await agent.HandleWorkflowLlmExecutionIntent(new WorkflowLlmExecutionIntent
+        {
+            RunId = "parent-run",
+            StepId = "reply",
+            SessionId = "session-1",
+            Prompt = "start child",
+        });
+
+        var completed = publisher.Published
+            .OfType<WorkflowLlmInvocationCompletedEvent>()
+            .Single(x => x.ManagedHandoff != null && !string.IsNullOrWhiteSpace(x.ManagedHandoff.InvocationId));
+        completed.Success.Should().BeTrue();
+        completed.ManagedHandoff.Should().NotBeNull();
+        completed.ManagedHandoff.InvocationId.Should().Be("parent-run:workflow_tool:reply:tool-call-1");
+        completed.ManagedHandoff.ParentStepId.Should().Be("reply");
+    }
+
     private sealed class RecordingLlmProvider : ILLMProviderFactory, ILLMProvider
     {
         public LLMRequest? LastRequest { get; private set; }
+
+        public AgentToolReceipt? ToolReceipt { get; init; }
 
         public string Name => "recording";
 
@@ -93,6 +138,14 @@ public sealed class WorkflowRoleGAgentMappingTests
             {
                 DeltaContent = "ok",
             };
+            if (ToolReceipt != null)
+            {
+                yield return new LLMStreamChunk
+                {
+                    ToolReceipt = ToolReceipt,
+                };
+            }
+
             yield return new LLMStreamChunk
             {
                 IsLast = true,

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRoleGAgentMappingTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRoleGAgentMappingTests.cs
@@ -34,6 +34,14 @@ public sealed class WorkflowRoleGAgentMappingTests
             {
                 BearerToken = " raw-token ",
             },
+            WorkflowRuntimeContext = new WorkflowToolRuntimeContextPayload
+            {
+                ParentActorId = "parent-actor",
+                ParentRunId = "parent-run",
+                ParentStepId = "reply",
+                RootRunId = "root-run",
+                Depth = 2,
+            },
         });
 
         provider.LastRequest.Should().NotBeNull();
@@ -44,6 +52,12 @@ public sealed class WorkflowRoleGAgentMappingTests
         provider.LastRequest.ToolContext!.Credentials.NyxIdAccessToken.Should().Be("raw-token");
         provider.LastRequest.ToolContext.Credentials.NyxIdOrgToken.Should().Be("raw-token");
         provider.LastRequest.ToolContext.Routing.NyxIdRoutePreference.Should().Be("route-a");
+        provider.LastRequest.ToolContext.WorkflowRuntime.ParentActorId.Should().Be("parent-actor");
+        provider.LastRequest.ToolContext.WorkflowRuntime.ParentRunId.Should().Be("parent-run");
+        provider.LastRequest.ToolContext.WorkflowRuntime.ParentStepId.Should().Be("reply");
+        provider.LastRequest.ToolContext.WorkflowRuntime.RootRunId.Should().Be("root-run");
+        provider.LastRequest.ToolContext.WorkflowRuntime.Depth.Should().Be(2);
+        provider.LastRequest.ToolContext.WorkflowRuntime.HasManagedParent.Should().BeTrue();
         (provider.LastRequest.Metadata ?? new Dictionary<string, string>(StringComparer.Ordinal))
             .Should()
             .BeEmpty();

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRuntimeModuleBranchTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRuntimeModuleBranchTests.cs
@@ -276,6 +276,85 @@ public sealed class WorkflowRuntimeModuleBranchTests
     }
 
     [Fact]
+    public async Task LlmCallModule_ShouldPopulateWorkflowRuntimeContextFromActorOwnedExecutionState()
+    {
+        var module = new LLMCallModule();
+        var ctx = new RecordingWorkflowContext
+        {
+            ExecutionContextState =
+            {
+                WorkflowRuntime = new WorkflowToolRuntimeContextState
+                {
+                    ParentActorId = " upstream-parent ",
+                    ParentRunId = " upstream-run ",
+                    ParentStepId = " upstream-step ",
+                    RootRunId = " root-run ",
+                    Depth = 2,
+                },
+            },
+        };
+
+        await module.HandleAsync(
+            Wrap(new StepRequestEvent
+            {
+                StepId = "reply",
+                StepType = "llm_call",
+                RunId = "run-llm-runtime",
+                Input = "prompt",
+            }),
+            ctx,
+            CancellationToken.None);
+
+        var intent = DispatchedLlmIntent(ctx);
+        intent.WorkflowRuntimeContext.Should().NotBeNull();
+        intent.WorkflowRuntimeContext.ParentActorId.Should().Be("agent-1");
+        intent.WorkflowRuntimeContext.ParentRunId.Should().Be("run-llm-runtime");
+        intent.WorkflowRuntimeContext.ParentStepId.Should().Be("reply");
+        intent.WorkflowRuntimeContext.RootRunId.Should().Be("root-run");
+        intent.WorkflowRuntimeContext.Depth.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task LlmCallModule_WhenCompletionReportsManagedHandoff_ShouldLeaveParentStepPending()
+    {
+        var module = new LLMCallModule();
+        var ctx = new RecordingWorkflowContext();
+
+        await module.HandleAsync(
+            Wrap(new StepRequestEvent
+            {
+                StepId = "reply",
+                StepType = "llm_call",
+                RunId = "run-llm-handoff",
+                Input = "prompt",
+            }),
+            ctx,
+            CancellationToken.None);
+        var intent = DispatchedLlmIntent(ctx);
+        var watchdog = ctx.Scheduled.Single();
+
+        await module.HandleAsync(
+            Wrap(new WorkflowLlmInvocationCompletedEvent
+            {
+                SessionId = intent.SessionId,
+                Success = true,
+                ManagedHandoff = new WorkflowManagedHandoffOutcome
+                {
+                    ParentActorId = "agent-1",
+                    ParentRunId = "run-llm-handoff",
+                    ParentStepId = "reply",
+                    InvocationId = "run-llm-handoff:workflow_tool:reply:call-1",
+                    ChildRunId = "run-llm-handoff:workflow_tool:reply:call-1",
+                },
+            }),
+            ctx,
+            CancellationToken.None);
+
+        ctx.Canceled.Should().ContainSingle(x => x.CallbackId == watchdog.CallbackId);
+        ctx.Published.Select(x => x.Event).OfType<StepCompletedEvent>().Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task LlmCallModule_ShouldIgnoreMetadataOnlyCallerCredential()
     {
         var module = new LLMCallModule();
@@ -1059,6 +1138,8 @@ public sealed class WorkflowRuntimeModuleBranchTests
                 ExecutionContextState.Llm = null;
             if (delta.ClearCallerCredential)
                 ExecutionContextState.CallerCredential = null;
+            if (delta.ClearWorkflowRuntime)
+                ExecutionContextState.WorkflowRuntime = null;
             if (delta.Llm != null)
             {
                 ExecutionContextState.Llm = new WorkflowLlmExecutionContextState
@@ -1079,6 +1160,18 @@ public sealed class WorkflowRuntimeModuleBranchTests
                 };
             }
 
+            if (delta.WorkflowRuntime != null)
+            {
+                ExecutionContextState.WorkflowRuntime = new WorkflowToolRuntimeContextState
+                {
+                    ParentActorId = delta.WorkflowRuntime.ParentActorId,
+                    ParentRunId = delta.WorkflowRuntime.ParentRunId,
+                    ParentStepId = delta.WorkflowRuntime.ParentStepId,
+                    RootRunId = delta.WorkflowRuntime.RootRunId,
+                    Depth = delta.WorkflowRuntime.Depth,
+                };
+            }
+
             return Task.CompletedTask;
         }
 
@@ -1087,6 +1180,7 @@ public sealed class WorkflowRuntimeModuleBranchTests
             ct.ThrowIfCancellationRequested();
             ExecutionContextState.Llm = null;
             ExecutionContextState.CallerCredential = null;
+            ExecutionContextState.WorkflowRuntime = null;
             return Task.CompletedTask;
         }
 

--- a/test/Aevatar.Workflow.Core.Tests/Primitives/SubWorkflowOrchestratorTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Primitives/SubWorkflowOrchestratorTests.cs
@@ -115,6 +115,8 @@ public sealed class SubWorkflowOrchestratorTests
                 ParentRunId = "parent-run",
                 ParentStepId = "step-a",
                 WorkflowName = "sub_flow",
+                RootRunId = "root-run",
+                RequestedDepth = 2,
             },
             new WorkflowRunState(),
             CancellationToken.None);
@@ -127,6 +129,8 @@ public sealed class SubWorkflowOrchestratorTests
         registered.DefinitionActorId.Should().Be("workflow-definition:sub_flow");
         registered.TimeoutCallbackId.Should().NotBeNullOrWhiteSpace();
         registered.TimeoutMs.Should().Be(30_000);
+        registered.RootRunId.Should().Be("root-run");
+        registered.RequestedDepth.Should().Be(2);
         harness.ScheduledTimeouts.Should().ContainSingle(x =>
             x.CallbackId == registered.TimeoutCallbackId &&
             x.DueTime == TimeSpan.FromMilliseconds(30_000));
@@ -187,6 +191,8 @@ public sealed class SubWorkflowOrchestratorTests
                 WorkflowName = "sub_flow",
                 Input = "payload-a",
                 Lifecycle = WorkflowCallLifecycle.Singleton,
+                RootRunId = "root-run",
+                RequestedDepth = 2,
             },
             state,
             CancellationToken.None);
@@ -220,7 +226,9 @@ public sealed class SubWorkflowOrchestratorTests
             x.ParentId == "owner-1" &&
             x.ChildId == childActorId);
         harness.Persisted.OfType<SubWorkflowDefinitionResolvedEvent>().Should().ContainSingle(x => x.InvocationId == "invoke-1");
-        harness.Persisted.OfType<SubWorkflowInvocationRegisteredEvent>().Should().ContainSingle(x => x.InvocationId == "invoke-1");
+        var registeredInvocation = harness.Persisted.OfType<SubWorkflowInvocationRegisteredEvent>().Should().ContainSingle(x => x.InvocationId == "invoke-1").Subject;
+        registeredInvocation.RootRunId.Should().Be("root-run");
+        registeredInvocation.Depth.Should().Be(2);
         harness.Persisted.Should().NotContain(x => x is SubWorkflowBindingUpsertedEvent);
         harness.CancelledLeases.Should().ContainSingle(x => x.CallbackId == resolutionState.PendingSubWorkflowDefinitionResolutions[0].TimeoutCallbackId);
         harness.Sent.Should().ContainSingle(x => x.TargetActorId == childActorId);
@@ -228,6 +236,85 @@ public sealed class SubWorkflowOrchestratorTests
         start.RunId.Should().Be("invoke-1");
         start.Parameters["workflow_call.parent_run_id"].Should().Be("parent-run");
         start.Parameters["workflow_call.parent_step_id"].Should().Be("step-a");
+        start.WorkflowRuntime.ParentActorId.Should().Be("owner-1");
+        start.WorkflowRuntime.ParentRunId.Should().Be("parent-run");
+        start.WorkflowRuntime.ParentStepId.Should().Be("step-a");
+        start.WorkflowRuntime.RootRunId.Should().Be("root-run");
+        start.WorkflowRuntime.Depth.Should().Be(2);
+        start.Parameters.Keys.Should().NotContain(key => key.StartsWith("workflow_runtime.", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task HandleInvokeRequestedAsync_WhenRequestedDepthExceedsLimit_ShouldPublishFailureBeforeSideEffects()
+    {
+        var harness = CreateHarness();
+        var state = new WorkflowRunState
+        {
+            RunId = "parent-run",
+            MaxSubWorkflowDepth = 2,
+        };
+        state.InlineWorkflowYamls["sub_flow"] = ValidSubFlowYaml;
+
+        await harness.Orchestrator.HandleInvokeRequestedAsync(
+            new SubWorkflowInvokeRequestedEvent
+            {
+                InvocationId = "invoke-too-deep",
+                ParentRunId = "parent-run",
+                ParentStepId = "step-depth",
+                WorkflowName = "sub_flow",
+                RequestedDepth = 3,
+            },
+            state,
+            CancellationToken.None);
+
+        var failure = harness.Published.Should().ContainSingle().Subject.Message.Should().BeOfType<StepCompletedEvent>().Subject;
+        failure.StepId.Should().Be("step-depth");
+        failure.RunId.Should().Be("parent-run");
+        failure.Success.Should().BeFalse();
+        failure.Error.Should().Contain("depth");
+        harness.Persisted.Should().BeEmpty();
+        harness.Runtime.CreateRequests.Should().BeEmpty();
+        harness.Sent.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleInvokeRequestedAsync_WhenActiveFanoutLimitIsReached_ShouldPublishFailureBeforeSideEffects()
+    {
+        var harness = CreateHarness();
+        var state = new WorkflowRunState
+        {
+            RunId = "parent-run",
+            MaxActiveSubWorkflows = 1,
+        };
+        state.InlineWorkflowYamls["sub_flow"] = ValidSubFlowYaml;
+        state.PendingSubWorkflowInvocations.Add(new WorkflowRunState.Types.PendingSubWorkflowInvocation
+        {
+            InvocationId = "existing",
+            ParentRunId = "parent-run",
+            ParentStepId = "step-existing",
+            WorkflowName = "sub_flow",
+            ChildRunId = "existing-child",
+        });
+
+        await harness.Orchestrator.HandleInvokeRequestedAsync(
+            new SubWorkflowInvokeRequestedEvent
+            {
+                InvocationId = "invoke-fanout",
+                ParentRunId = "parent-run",
+                ParentStepId = "step-fanout",
+                WorkflowName = "sub_flow",
+            },
+            state,
+            CancellationToken.None);
+
+        var failure = harness.Published.Should().ContainSingle().Subject.Message.Should().BeOfType<StepCompletedEvent>().Subject;
+        failure.StepId.Should().Be("step-fanout");
+        failure.RunId.Should().Be("parent-run");
+        failure.Success.Should().BeFalse();
+        failure.Error.Should().Contain("active");
+        harness.Persisted.Should().BeEmpty();
+        harness.Runtime.CreateRequests.Should().BeEmpty();
+        harness.Sent.Should().BeEmpty();
     }
 
     [Fact]

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -894,6 +894,7 @@ END {
 fi
 
 bash "${SCRIPT_DIR}/query_projection_priming_guard.sh"
+bash "${SCRIPT_DIR}/workflow_call_context_guard.sh"
 bash "${SCRIPT_DIR}/command_observation_attach_only_guard.sh"
 bash "${SCRIPT_DIR}/projection_attach_existing_side_read_guard.sh"
 bash "${SCRIPT_DIR}/public_projection_ensure_ports_guard.sh"

--- a/tools/ci/workflow_call_context_guard.sh
+++ b/tools/ci/workflow_call_context_guard.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+tool_proto="src/Aevatar.AI.ToolProviders.AevatarInvocation/aevatar_invocation_tools.proto"
+dispatcher="src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs"
+ai_proto="src/Aevatar.AI.Abstractions/ai_messages.proto"
+workflow_messages="src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto"
+
+start_workflow_message="$(
+  awk '
+    /^message StartWorkflowToolRequest[[:space:]]*\{/ { in_message = 1 }
+    in_message { print }
+    in_message && /^\}/ { exit }
+  ' "${tool_proto}"
+)"
+
+if grep -Eq "(parent_actor_id|parent_run_id|parent_step_id|root_run_id|requested_depth|workflow_runtime_context|workflow_call_context)" <<<"${start_workflow_message}"; then
+  echo "${tool_proto}"
+  echo "StartWorkflowToolRequest must not expose workflow ancestry/depth fields; trusted workflow runtime context is host-stamped."
+  exit 1
+fi
+
+if ! rg -n "AgentWorkflowRuntimeContextPayload workflow_runtime" "${ai_proto}" >/dev/null; then
+  echo "${ai_proto}"
+  echo "Agent tool execution context must carry workflow runtime as typed Protobuf context."
+  exit 1
+fi
+
+if ! rg -n "string root_run_id = .*|int32 requested_depth = " "${workflow_messages}" >/dev/null; then
+  echo "${workflow_messages}"
+  echo "Sub-workflow invocation contract must carry typed root/depth fields."
+  exit 1
+fi
+
+if ! rg -n "WorkflowToolRuntimeContextPayload workflow_runtime" "${workflow_messages}" >/dev/null; then
+  echo "${workflow_messages}"
+  echo "StartWorkflowEvent must hydrate child workflow runtime from a typed Protobuf field, not string parameters."
+  exit 1
+fi
+
+if ! rg -n "RejectForbiddenRootFields" "${dispatcher}" >/dev/null; then
+  echo "${dispatcher}"
+  echo "aevatar_start_workflow must reject forged public workflow ancestry/depth fields before parsing."
+  exit 1
+fi
+
+if ! rg -n "TryGetManagedWorkflowRuntimeContext|StartManagedSubWorkflowForChatRunAsync|SubWorkflowInvokeRequestedEvent" "${dispatcher}" >/dev/null; then
+  echo "${dispatcher}"
+  echo "Trusted workflow runtime context must route aevatar_start_workflow through parent actor managed child start."
+  exit 1
+fi
+
+echo "Workflow call context guard passed."


### PR DESCRIPTION
## Changed files
实现了 workflow runtime typed context，并让 workflow 内 `aevatar_start_workflow` 在可信上下文存在时转为父 run actor managed child start。更新了 AI tool context、workflow execution context、SubWorkflowOrchestrator admission/persistence/start 链路、AI integration 映射、相关 canon/ADR 文档，以及 `workflow_call_context_guard`。

Closes #1902

## Test results
通过 `dotnet build aevatar.slnx --nologo`、四个指定测试项目、`test_stability_guards`、`workflow_binding_boundary_guard`、`workflow_call_context_guard`、`architecture_guards`、`tools/docs/lint.sh` 和 `git diff --check`。

## Deviations
`HOST_REFACTOR_COMMENT_POLICY` 为空，按规则归一化为 `none`，未新增 refactor-history source comments。judge artifact 为空且本地未找到 `gh-issue-1902` artifact，实施依据为 work-unit prompt 中的 issue facts。`tools/ci/workflow_call_context_guard.sh` 在提示与 scope 中列出但不存在，因此在授权路径内补齐。

⟦AI:AUTO-LOOP⟧
