### PR TITLE
fix(nyxid-chat): relay registration 按 canonical scope 选择，修复 /agents 在 DM 为空 (#1914)

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -1292,33 +1292,71 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         ArgumentNullException.ThrowIfNull(activity);
 
         var nyxAgentApiKeyId = NormalizeOptional(activity.TransportExtras?.NyxAgentApiKeyId);
-        if (!string.IsNullOrWhiteSpace(nyxAgentApiKeyId) &&
-            _registrationQueryByNyxIdentityPort is not null)
+        var canonicalScopeId = NormalizeOptional(activity.TransportExtras?.NyxRegistrationScopeId);
+        if (!string.IsNullOrWhiteSpace(nyxAgentApiKeyId))
         {
-            var byNyxIdentity = await _registrationQueryByNyxIdentityPort.GetByNyxAgentApiKeyIdAsync(
+            if (_registrationQueryByNyxIdentityPort is null)
+                return null;
+
+            var registrations = await _registrationQueryByNyxIdentityPort.ListByNyxAgentApiKeyIdAsync(
                 nyxAgentApiKeyId,
                 ct);
+            var byNyxIdentity = ResolveRegistrationByNyxIdentityCandidates(registrations, canonicalScopeId);
+
             if (byNyxIdentity is not null)
                 return byNyxIdentity;
 
-            if (IsNyxRelayActivity(activity, nyxAgentApiKeyId))
-            {
-                var byBoundedScan = await ResolveRegistrationByNyxIdentityScanAsync(nyxAgentApiKeyId, ct);
-                if (byBoundedScan is not null)
-                    return byBoundedScan;
-            }
+            if (registrations.Count > 0)
+                return null;
         }
 
-        return await ResolveRegistrationAsync(activity.Bot?.Value, ct);
+        var byBotId = await ResolveRegistrationAsync(activity.Bot?.Value, ct);
+        return byBotId is not null && IsBotIdFallbackRegistrationAllowed(byBotId, canonicalScopeId, nyxAgentApiKeyId)
+            ? byBotId
+            : null;
     }
 
-    private async Task<ChannelBotRegistrationEntry?> ResolveRegistrationByNyxIdentityScanAsync(
-        string nyxAgentApiKeyId,
-        CancellationToken ct)
+    private static ChannelBotRegistrationEntry? ResolveRegistrationByNyxIdentityCandidates(
+        IReadOnlyList<ChannelBotRegistrationEntry> registrations,
+        string? canonicalScopeId)
     {
-        var registrations = await _registrationQueryPort.QueryAllAsync(ct);
+        if (registrations.Count == 0)
+            return null;
+
+        if (!string.IsNullOrWhiteSpace(canonicalScopeId))
+        {
+            return registrations.FirstOrDefault(entry =>
+                string.Equals(NormalizeOptional(entry.ScopeId), canonicalScopeId, StringComparison.Ordinal));
+        }
+
+        var distinctScopeIds = registrations
+            .Select(entry => NormalizeOptional(entry.ScopeId))
+            .Where(static scopeId => scopeId is not null)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        if (distinctScopeIds.Length != 1)
+            return null;
+
+        var resolvedScopeId = distinctScopeIds[0];
         return registrations.FirstOrDefault(entry =>
-            string.Equals(NormalizeOptional(entry.NyxAgentApiKeyId), nyxAgentApiKeyId, StringComparison.Ordinal));
+            string.Equals(NormalizeOptional(entry.ScopeId), resolvedScopeId, StringComparison.Ordinal));
+    }
+
+    private static bool IsBotIdFallbackRegistrationAllowed(
+        ChannelBotRegistrationEntry registration,
+        string? canonicalScopeId,
+        string? nyxAgentApiKeyId)
+    {
+        if (string.IsNullOrWhiteSpace(canonicalScopeId))
+            return true;
+
+        if (!string.Equals(NormalizeOptional(registration.ScopeId), canonicalScopeId, StringComparison.Ordinal))
+            return false;
+
+        var registrationApiKeyId = NormalizeOptional(registration.NyxAgentApiKeyId);
+        return registrationApiKeyId is null ||
+               string.Equals(registrationApiKeyId, nyxAgentApiKeyId, StringComparison.Ordinal);
     }
 
     private async Task<ChannelBotRegistrationEntry?> ResolveRegistrationForReplyAsync(
@@ -1974,14 +2012,6 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
             ? "lark"
             : platform;
     }
-
-    private static bool IsNyxRelayActivity(ChatActivity activity, string nyxAgentApiKeyId) =>
-        activity.OutboundDelivery is
-        {
-            ReplyMessageId.Length: > 0,
-            CorrelationId.Length: > 0,
-        } &&
-        string.Equals(NormalizeOptional(activity.Bot?.Value), nyxAgentApiKeyId, StringComparison.Ordinal);
 
     // Lark reaction emoji_type for "hands typing on keyboard" — added immediately on inbound
     // so the user sees the bot is working before the LLM reply lands. After a reply succeeds,

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
@@ -593,6 +593,35 @@ public sealed class ChannelConversationTurnRunnerTests
             .GetAsync("reg-fallback", Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task RunInboundAsync_ShouldFailClosed_WhenNyxApiKeyPresentAndIdentityQueryPortMissing()
+    {
+        var fallback = BuildRegistrationEntry("reg-fallback");
+        fallback.NyxAgentApiKeyId = "nyx-key-1";
+        var registrationQueryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        registrationQueryPort.GetAsync("reg-fallback", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(fallback));
+        var adapter = new RecordingPlatformAdapter();
+        var runner = CreateRunner(registrationQueryPort, adapter);
+
+        var result = await runner.RunInboundAsync(
+            BuildInboundActivity(
+                "hello from relay",
+                "msg-missing-identity-query-port-1",
+                botId: "reg-fallback",
+                transportExtras: new TransportExtras
+                {
+                    NyxAgentApiKeyId = "nyx-key-1",
+                    NyxPlatform = "lark",
+                }),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be("registration_not_found");
+        await registrationQueryPort.DidNotReceive()
+            .GetAsync("reg-fallback", Arg.Any<CancellationToken>());
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData("nyx-key-1")]
@@ -629,6 +658,45 @@ public sealed class ChannelConversationTurnRunnerTests
         result.Success.Should().BeTrue();
         result.LlmReplyRequest.Should().NotBeNull();
         result.LlmReplyRequest!.RegistrationId.Should().Be("reg-fallback");
+    }
+
+    [Fact]
+    public async Task RunInboundAsync_ShouldRejectBotIdFallbackWithCanonicalScope_WhenFallbackScopeDiffers()
+    {
+        var fallback = BuildRegistrationEntry("reg-fallback");
+        fallback.ScopeId = "scope-other";
+        fallback.NyxAgentApiKeyId = "nyx-key-1";
+        var registrationQueryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        registrationQueryPort.GetAsync("reg-fallback", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(fallback));
+        var registrationByNyxIdentityPort = Substitute.For<IChannelBotRegistrationQueryByNyxIdentityPort>();
+        registrationByNyxIdentityPort.ListByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>(Array.Empty<ChannelBotRegistrationEntry>()));
+        var adapter = new RecordingPlatformAdapter();
+        var runner = CreateRunner(
+            registrationQueryPort,
+            adapter,
+            registrationQueryByNyxIdentityPort: registrationByNyxIdentityPort);
+
+        var result = await runner.RunInboundAsync(
+            BuildInboundActivity(
+                "hello from relay",
+                "msg-canonical-fallback-scope-reject-1",
+                botId: "reg-fallback",
+                transportExtras: new TransportExtras
+                {
+                    NyxAgentApiKeyId = "nyx-key-1",
+                    NyxRegistrationScopeId = "scope-canonical",
+                    NyxPlatform = "lark",
+                }),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be("registration_not_found");
+        await registrationByNyxIdentityPort.Received(1)
+            .ListByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>());
+        await registrationQueryPort.Received(1)
+            .GetAsync("reg-fallback", Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
@@ -329,14 +329,18 @@ public sealed class ChannelConversationTurnRunnerTests
     }
 
     [Fact]
-    public async Task RunInboundAsync_ShouldResolveRegistrationByNyxAgentApiKeyId_WhenBotIdDoesNotMatch()
+    public async Task RunInboundAsync_ShouldResolveRegistrationByNyxAgentApiKeyId_WhenCandidatesCollapseToOneScope()
     {
+        var first = BuildRegistrationEntry("reg-1a");
+        first.NyxAgentApiKeyId = "nyx-key-1";
+        var second = BuildRegistrationEntry("reg-1b");
+        second.NyxAgentApiKeyId = "nyx-key-1";
         var registrationQueryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
         registrationQueryPort.GetAsync("missing-reg", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(null));
         var registrationByNyxIdentityPort = Substitute.For<IChannelBotRegistrationQueryByNyxIdentityPort>();
-        registrationByNyxIdentityPort.GetByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(BuildRegistrationEntry()));
+        registrationByNyxIdentityPort.ListByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>([first, second]));
         var adapter = new RecordingPlatformAdapter();
         var runner = CreateRunner(
             registrationQueryPort,
@@ -359,25 +363,29 @@ public sealed class ChannelConversationTurnRunnerTests
 
         result.Success.Should().BeTrue();
         result.LlmReplyRequest.Should().NotBeNull();
-        result.LlmReplyRequest!.RegistrationId.Should().Be("reg-1");
+        result.LlmReplyRequest!.RegistrationId.Should().Be("reg-1a");
         result.LlmReplyRequest.Activity.TransportExtras?.NyxAgentApiKeyId.Should().Be("nyx-key-1");
         await registrationByNyxIdentityPort.Received(1)
-            .GetByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>());
+            .ListByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>());
         await registrationQueryPort.DidNotReceive()
             .GetAsync("missing-reg", Arg.Any<CancellationToken>());
+        await registrationQueryPort.DidNotReceive()
+            .QueryAllAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task RunInboundAsync_ShouldFallbackToBoundedRegistrationScan_ForRelayTurnWhenIdentityQueryMisses()
+    public async Task RunInboundAsync_ShouldResolveCanonicalScopeCandidate_ByNyxAgentApiKeyId()
     {
-        var registration = BuildRegistrationEntry();
+        var wrongScope = BuildRegistrationEntry("reg-wrong-scope");
+        wrongScope.NyxAgentApiKeyId = "nyx-key-1";
+        wrongScope.ScopeId = "scope-other";
+        var registration = BuildRegistrationEntry("reg-canonical");
         registration.NyxAgentApiKeyId = "nyx-key-1";
+        registration.ScopeId = "scope-canonical";
         var registrationQueryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
-        registrationQueryPort.QueryAllAsync(Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>([registration]));
         var registrationByNyxIdentityPort = Substitute.For<IChannelBotRegistrationQueryByNyxIdentityPort>();
-        registrationByNyxIdentityPort.GetByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(null));
+        registrationByNyxIdentityPort.ListByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>([wrongScope, registration]));
         var adapter = new RecordingPlatformAdapter();
         var runner = CreateRunner(
             registrationQueryPort,
@@ -398,6 +406,7 @@ public sealed class ChannelConversationTurnRunnerTests
                 {
                     NyxAgentApiKeyId = "nyx-key-1",
                     NyxMessageId = "nyx-msg-1",
+                    NyxRegistrationScopeId = "scope-canonical",
                     NyxPlatform = "lark",
                     NyxConversationId = "nyx-conv-1",
                 }),
@@ -405,29 +414,28 @@ public sealed class ChannelConversationTurnRunnerTests
 
         result.Success.Should().BeTrue();
         result.LlmReplyRequest.Should().NotBeNull();
-        result.LlmReplyRequest!.RegistrationId.Should().Be("reg-1");
+        result.LlmReplyRequest!.RegistrationId.Should().Be("reg-canonical");
         await registrationByNyxIdentityPort.Received(1)
-            .GetByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>());
-        await registrationQueryPort.Received(1)
-            .QueryAllAsync(Arg.Any<CancellationToken>());
+            .ListByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>());
         await registrationQueryPort.DidNotReceive()
             .GetAsync("nyx-key-1", Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task RunInboundAsync_BoundedRegistrationScan_ReturnsFirstMatchWhenMultipleShareNyxKey()
+    public async Task RunInboundAsync_ShouldFailClosed_WhenCanonicalScopeDoesNotMatchApiKeyCandidates()
     {
-        var stale = BuildRegistrationEntry("reg-old");
-        stale.NyxAgentApiKeyId = "nyx-key-1";
-        var fresh = BuildRegistrationEntry("reg-new");
-        fresh.NyxAgentApiKeyId = "nyx-key-1";
-
+        var wrongScope = BuildRegistrationEntry("reg-wrong-scope");
+        wrongScope.NyxAgentApiKeyId = "nyx-key-1";
+        wrongScope.ScopeId = "scope-other";
+        var fallback = BuildRegistrationEntry("reg-canonical");
+        fallback.ScopeId = "scope-canonical";
+        fallback.NyxAgentApiKeyId = "nyx-key-1";
         var registrationQueryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
-        registrationQueryPort.QueryAllAsync(Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>([stale, fresh]));
+        registrationQueryPort.GetAsync("reg-canonical", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(fallback));
         var registrationByNyxIdentityPort = Substitute.For<IChannelBotRegistrationQueryByNyxIdentityPort>();
-        registrationByNyxIdentityPort.GetByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(null));
+        registrationByNyxIdentityPort.ListByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>([wrongScope]));
         var adapter = new RecordingPlatformAdapter();
         var runner = CreateRunner(
             registrationQueryPort,
@@ -438,7 +446,7 @@ public sealed class ChannelConversationTurnRunnerTests
             BuildInboundActivity(
                 "hello from relay",
                 "msg-nyx-dup-1",
-                botId: "nyx-key-1",
+                botId: "reg-canonical",
                 outboundDelivery: new OutboundDeliveryContext
                 {
                     ReplyMessageId = "relay-msg-1",
@@ -447,34 +455,34 @@ public sealed class ChannelConversationTurnRunnerTests
                 transportExtras: new TransportExtras
                 {
                     NyxAgentApiKeyId = "nyx-key-1",
+                    NyxRegistrationScopeId = "scope-canonical",
                     NyxPlatform = "lark",
                 }),
             CancellationToken.None);
 
-        // Bounded scan has no ordering guarantee across duplicates sharing NyxAgentApiKeyId
-        // and returns the first hit from the projection. The stale entry can shadow the live one.
-        result.Success.Should().BeTrue();
-        result.LlmReplyRequest!.RegistrationId.Should().Be("reg-old");
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be("registration_not_found");
+        await registrationQueryPort.DidNotReceive()
+            .GetAsync("reg-canonical", Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task RunInboundAsync_BoundedRegistrationScan_FallsThroughToBotIdLookup_WhenScanMisses()
+    public async Task RunInboundAsync_ShouldFailClosed_WhenApiKeyCandidatesHaveMultipleScopesWithoutCanonicalScope()
     {
+        var first = BuildRegistrationEntry("reg-scope-1");
+        first.NyxAgentApiKeyId = "nyx-key-1";
+        first.ScopeId = "scope-1";
+        var second = BuildRegistrationEntry("reg-scope-2");
+        second.NyxAgentApiKeyId = "nyx-key-1";
+        second.ScopeId = "scope-2";
+        var fallback = BuildRegistrationEntry("reg-fallback");
+        fallback.ScopeId = "scope-fallback";
         var registrationQueryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
-        registrationQueryPort.QueryAllAsync(Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>(
-            [
-                new ChannelBotRegistrationEntry
-                {
-                    Id = "reg-other",
-                    NyxAgentApiKeyId = "different-key",
-                },
-            ]));
-        registrationQueryPort.GetAsync("nyx-key-1", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(null));
+        registrationQueryPort.GetAsync("reg-fallback", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(fallback));
         var registrationByNyxIdentityPort = Substitute.For<IChannelBotRegistrationQueryByNyxIdentityPort>();
-        registrationByNyxIdentityPort.GetByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(null));
+        registrationByNyxIdentityPort.ListByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>([first, second]));
         var adapter = new RecordingPlatformAdapter();
         var runner = CreateRunner(
             registrationQueryPort,
@@ -485,7 +493,7 @@ public sealed class ChannelConversationTurnRunnerTests
             BuildInboundActivity(
                 "hello from relay",
                 "msg-nyx-miss-scan-1",
-                botId: "nyx-key-1",
+                botId: "reg-fallback",
                 outboundDelivery: new OutboundDeliveryContext
                 {
                     ReplyMessageId = "relay-msg-1",
@@ -500,19 +508,27 @@ public sealed class ChannelConversationTurnRunnerTests
 
         result.Success.Should().BeFalse();
         result.ErrorCode.Should().Be("registration_not_found");
-        await registrationQueryPort.Received(1).QueryAllAsync(Arg.Any<CancellationToken>());
-        await registrationQueryPort.Received(1).GetAsync("nyx-key-1", Arg.Any<CancellationToken>());
+        await registrationQueryPort.DidNotReceive()
+            .GetAsync("reg-fallback", Arg.Any<CancellationToken>());
+        await registrationQueryPort.DidNotReceive()
+            .QueryAllAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task RunInboundAsync_ShouldSkipBoundedRegistrationScan_WhenOutboundDeliveryMissing()
+    public async Task RunInboundAsync_ShouldFailClosed_WhenApiKeyCandidatesHaveOnlyEmptyScopes()
     {
+        var empty = BuildRegistrationEntry("reg-empty");
+        empty.NyxAgentApiKeyId = "nyx-key-1";
+        empty.ScopeId = string.Empty;
+        var whitespace = BuildRegistrationEntry("reg-whitespace");
+        whitespace.NyxAgentApiKeyId = "nyx-key-1";
+        whitespace.ScopeId = "   ";
         var registrationQueryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
-        registrationQueryPort.GetAsync("nyx-key-1", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(null));
+        registrationQueryPort.GetAsync("reg-fallback", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(BuildRegistrationEntry("reg-fallback")));
         var registrationByNyxIdentityPort = Substitute.For<IChannelBotRegistrationQueryByNyxIdentityPort>();
-        registrationByNyxIdentityPort.GetByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(null));
+        registrationByNyxIdentityPort.ListByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>([empty, whitespace]));
         var adapter = new RecordingPlatformAdapter();
         var runner = CreateRunner(
             registrationQueryPort,
@@ -521,9 +537,9 @@ public sealed class ChannelConversationTurnRunnerTests
 
         var result = await runner.RunInboundAsync(
             BuildInboundActivity(
-                "hello without relay",
-                "msg-no-delivery-1",
-                botId: "nyx-key-1",
+                "hello from relay",
+                "msg-empty-scopes-1",
+                botId: "reg-fallback",
                 transportExtras: new TransportExtras
                 {
                     NyxAgentApiKeyId = "nyx-key-1",
@@ -533,18 +549,21 @@ public sealed class ChannelConversationTurnRunnerTests
 
         result.Success.Should().BeFalse();
         result.ErrorCode.Should().Be("registration_not_found");
-        await registrationQueryPort.DidNotReceive().QueryAllAsync(Arg.Any<CancellationToken>());
+        await registrationQueryPort.DidNotReceive()
+            .GetAsync("reg-fallback", Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task RunInboundAsync_ShouldSkipBoundedRegistrationScan_ForNonRelayIdentityMiss()
+    public async Task RunInboundAsync_ShouldUseBotIdFallback_WhenApiKeyListHasNoCandidates()
     {
+        var fallback = BuildRegistrationEntry("reg-fallback");
+        fallback.NyxAgentApiKeyId = "nyx-key-1";
         var registrationQueryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
-        registrationQueryPort.GetAsync("missing-reg", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(null));
+        registrationQueryPort.GetAsync("reg-fallback", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(fallback));
         var registrationByNyxIdentityPort = Substitute.For<IChannelBotRegistrationQueryByNyxIdentityPort>();
-        registrationByNyxIdentityPort.GetByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(null));
+        registrationByNyxIdentityPort.ListByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>(Array.Empty<ChannelBotRegistrationEntry>()));
         var adapter = new RecordingPlatformAdapter();
         var runner = CreateRunner(
             registrationQueryPort,
@@ -555,7 +574,7 @@ public sealed class ChannelConversationTurnRunnerTests
             BuildInboundActivity(
                 "hello from relay",
                 "msg-nyx-miss-1",
-                botId: "missing-reg",
+                botId: "reg-fallback",
                 transportExtras: new TransportExtras
                 {
                     NyxAgentApiKeyId = "nyx-key-1",
@@ -565,12 +584,86 @@ public sealed class ChannelConversationTurnRunnerTests
                 }),
             CancellationToken.None);
 
+        result.Success.Should().BeTrue();
+        result.LlmReplyRequest.Should().NotBeNull();
+        result.LlmReplyRequest!.RegistrationId.Should().Be("reg-fallback");
+        await registrationByNyxIdentityPort.Received(1)
+            .ListByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>());
+        await registrationQueryPort.Received(1)
+            .GetAsync("reg-fallback", Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("nyx-key-1")]
+    public async Task RunInboundAsync_ShouldUseBotIdFallbackWithCanonicalScope_WhenFallbackApiKeyIsEmptyOrMatches(string fallbackApiKeyId)
+    {
+        var fallback = BuildRegistrationEntry("reg-fallback");
+        fallback.ScopeId = "scope-canonical";
+        fallback.NyxAgentApiKeyId = fallbackApiKeyId;
+        var registrationQueryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        registrationQueryPort.GetAsync("reg-fallback", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(fallback));
+        var registrationByNyxIdentityPort = Substitute.For<IChannelBotRegistrationQueryByNyxIdentityPort>();
+        registrationByNyxIdentityPort.ListByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>(Array.Empty<ChannelBotRegistrationEntry>()));
+        var adapter = new RecordingPlatformAdapter();
+        var runner = CreateRunner(
+            registrationQueryPort,
+            adapter,
+            registrationQueryByNyxIdentityPort: registrationByNyxIdentityPort);
+
+        var result = await runner.RunInboundAsync(
+            BuildInboundActivity(
+                "hello from relay",
+                "msg-canonical-fallback-1",
+                botId: "reg-fallback",
+                transportExtras: new TransportExtras
+                {
+                    NyxAgentApiKeyId = "nyx-key-1",
+                    NyxRegistrationScopeId = "scope-canonical",
+                    NyxPlatform = "lark",
+                }),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.LlmReplyRequest.Should().NotBeNull();
+        result.LlmReplyRequest!.RegistrationId.Should().Be("reg-fallback");
+    }
+
+    [Fact]
+    public async Task RunInboundAsync_ShouldRejectBotIdFallbackWithCanonicalScope_WhenFallbackApiKeyDiffers()
+    {
+        var fallback = BuildRegistrationEntry("reg-fallback");
+        fallback.ScopeId = "scope-canonical";
+        fallback.NyxAgentApiKeyId = "different-key";
+        var registrationQueryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        registrationQueryPort.GetAsync("reg-fallback", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(fallback));
+        var registrationByNyxIdentityPort = Substitute.For<IChannelBotRegistrationQueryByNyxIdentityPort>();
+        registrationByNyxIdentityPort.ListByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>(Array.Empty<ChannelBotRegistrationEntry>()));
+        var adapter = new RecordingPlatformAdapter();
+        var runner = CreateRunner(
+            registrationQueryPort,
+            adapter,
+            registrationQueryByNyxIdentityPort: registrationByNyxIdentityPort);
+
+        var result = await runner.RunInboundAsync(
+            BuildInboundActivity(
+                "hello from relay",
+                "msg-canonical-fallback-reject-1",
+                botId: "reg-fallback",
+                transportExtras: new TransportExtras
+                {
+                    NyxAgentApiKeyId = "nyx-key-1",
+                    NyxRegistrationScopeId = "scope-canonical",
+                    NyxPlatform = "lark",
+                }),
+            CancellationToken.None);
+
         result.Success.Should().BeFalse();
         result.ErrorCode.Should().Be("registration_not_found");
-        await registrationQueryPort.DidNotReceive()
-            .QueryAllAsync(Arg.Any<CancellationToken>());
-        await registrationQueryPort.Received(1)
-            .GetAsync("missing-reg", Arg.Any<CancellationToken>());
     }
 
     [Fact]


### PR DESCRIPTION
## Changed files

- `agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs`：relay turn 带 `NyxAgentApiKeyId` 时改用 `ListByNyxAgentApiKeyIdAsync`，按 canonical scope 精确匹配或 same-scope collapse 选择 registration；候选不匹配、全空 scope、多 scope 时 fail closed。bot-id fallback 仅在 API-key list 无候选时执行，并校验 canonical scope 与 API key。
- `test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs`：删除旧 first-hit/bounded-scan 预期，补齐 canonical scope、same-scope collapse、ambiguous scope、empty scope、bot-id fallback 约束覆盖。

Closes #1914

## Test results

- `bash -lc "$BUILD_CMD"`：通过（`dotnet build aevatar.slnx --nologo`）。
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo --filter FullyQualifiedName~ChannelConversationTurnRunnerTests`：通过，85 passed。
- `bash tools/ci/test_stability_guards.sh`：通过。
- `bash -lc "$TEST_CMD"`：通过（`dotnet test aevatar.slnx --nologo`）。

## Deviations

- 无 scope 扩展；未改外部仓库；未新增依赖；未 commit / push。
- `$CI_GUARDS` 为空，未运行额外 host guard。
- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)

⟦AI:AUTO-LOOP⟧
