### PR TITLE
fix(nyxid-chat): 接通第一方直连 :stream/:approve 的 observation-scope 预激活(修复 #1913 ProjectionUnavailable)

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatObservationScopeLeasePreparation.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatObservationScopeLeasePreparation.cs
@@ -1,0 +1,72 @@
+using Aevatar.CQRS.Core.Abstractions.Commands;
+using Aevatar.CQRS.Core.Abstractions.Interactions;
+using Aevatar.CQRS.Projection.Core.Abstractions;
+
+namespace Aevatar.GAgents.NyxidChat;
+
+internal sealed class NyxIdChatObservationScopeLeasePreparation<TCommand>
+    : ICommandObservationScopeLeasePreparation<TCommand, NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt, NyxIdChatStartError>
+{
+    private readonly IProjectionScopeActivationService<NyxIdChatSessionRuntimeLease> _activationService;
+    private readonly IProjectionScopeReleaseService<NyxIdChatSessionRuntimeLease> _releaseService;
+    private readonly Func<TCommand, string> _sessionIdResolver;
+
+    public NyxIdChatObservationScopeLeasePreparation(
+        IProjectionScopeActivationService<NyxIdChatSessionRuntimeLease> activationService,
+        IProjectionScopeReleaseService<NyxIdChatSessionRuntimeLease> releaseService,
+        Func<TCommand, string> sessionIdResolver)
+    {
+        _activationService = activationService ?? throw new ArgumentNullException(nameof(activationService));
+        _releaseService = releaseService ?? throw new ArgumentNullException(nameof(releaseService));
+        _sessionIdResolver = sessionIdResolver ?? throw new ArgumentNullException(nameof(sessionIdResolver));
+    }
+
+    public async Task<CommandObservationScopeLeasePreparationResult<NyxIdChatStartError>> PrepareAsync(
+        TCommand command,
+        CommandDispatchExecution<NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt> execution,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(execution);
+
+        var actorId = execution.Target.ActorId;
+        var sessionId = _sessionIdResolver(command);
+        if (string.IsNullOrWhiteSpace(actorId) || string.IsNullOrWhiteSpace(sessionId))
+        {
+            return CommandObservationScopeLeasePreparationResult<NyxIdChatStartError>.Failure(
+                NyxIdChatStartError.ProjectionUnavailable);
+        }
+
+        try
+        {
+            var normalizedActorId = actorId.Trim();
+            var normalizedSessionId = sessionId.Trim();
+            var lease = await _activationService.EnsureAsync(
+                new ProjectionScopeStartRequest
+                {
+                    RootActorId = normalizedActorId,
+                    ProjectionKind = NyxIdChatProjectionKinds.ChatSession,
+                    Mode = ProjectionRuntimeMode.SessionObservation,
+                    SessionId = normalizedSessionId,
+                },
+                ct).ConfigureAwait(false);
+
+            return CommandObservationScopeLeasePreparationResult<NyxIdChatStartError>.Success(
+                new PreparedObservationScopeHandle(_releaseService, lease));
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            return CommandObservationScopeLeasePreparationResult<NyxIdChatStartError>.Failure(
+                NyxIdChatStartError.ProjectionUnavailable);
+        }
+    }
+
+    private sealed class PreparedObservationScopeHandle(
+        IProjectionScopeReleaseService<NyxIdChatSessionRuntimeLease> releaseService,
+        NyxIdChatSessionRuntimeLease lease)
+        : ICommandObservationScopeLeasePreparationHandle
+    {
+        public Task ReleaseAsync(CancellationToken ct = default) =>
+            releaseService.ReleaseIfIdleAsync(lease, ct);
+    }
+}

--- a/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
@@ -161,6 +161,18 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton(NyxIdChatInteractionFactories.CreateApprovalResolver);
         services.TryAddSingleton(NyxIdChatInteractionFactories.CreateChatObservationLifecycle);
         services.TryAddSingleton(NyxIdChatInteractionFactories.CreateApprovalObservationLifecycle);
+        services.TryAddSingleton<
+            ICommandObservationScopeLeasePreparation<NyxIdChatCommand, NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt, NyxIdChatStartError>>(
+            sp => new NyxIdChatObservationScopeLeasePreparation<NyxIdChatCommand>(
+                sp.GetRequiredService<IProjectionScopeActivationService<NyxIdChatSessionRuntimeLease>>(),
+                sp.GetRequiredService<IProjectionScopeReleaseService<NyxIdChatSessionRuntimeLease>>(),
+                static command => command.SessionId));
+        services.TryAddSingleton<
+            ICommandObservationScopeLeasePreparation<NyxIdApprovalCommand, NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt, NyxIdChatStartError>>(
+            sp => new NyxIdChatObservationScopeLeasePreparation<NyxIdApprovalCommand>(
+                sp.GetRequiredService<IProjectionScopeActivationService<NyxIdChatSessionRuntimeLease>>(),
+                sp.GetRequiredService<IProjectionScopeReleaseService<NyxIdChatSessionRuntimeLease>>(),
+                static command => command.SessionId));
         services.TryAddSingleton<ICommandEnvelopeFactory<NyxIdChatCommand>, NyxIdChatCommandEnvelopeFactory>();
         services.TryAddSingleton<ICommandEnvelopeFactory<NyxIdApprovalCommand>, NyxIdApprovalCommandEnvelopeFactory>();
         services.TryAddSingleton<ICommandTargetDispatcher<NyxIdChatCommandTarget>, ActorCommandTargetDispatcher<NyxIdChatCommandTarget>>();
@@ -181,7 +193,8 @@ public static class ServiceCollectionExtensions
                 sp.GetRequiredService<ICommandDurableCompletionResolver<NyxIdChatAcceptedReceipt, NyxIdChatCompletionStatus>>(),
                 sp.GetService<ILogger<DefaultCommandInteractionService<NyxIdChatCommand, NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, AGUIEvent, NyxIdChatCompletionStatus>>>(),
                 sp.GetRequiredService<ICommandObservationLifecycle<NyxIdChatCommand, NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt, NyxIdChatStartError>>(),
-                sp.GetRequiredService<ICommandReceiptFactory<NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt>>()));
+                sp.GetRequiredService<ICommandReceiptFactory<NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt>>(),
+                sp.GetRequiredService<ICommandObservationScopeLeasePreparation<NyxIdChatCommand, NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt, NyxIdChatStartError>>()));
         services.TryAddSingleton<IRealtimeSession<NyxIdChatCommand, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, NyxIdChatCompletionStatus>>(sp =>
             sp.GetRequiredService<ICommandInteractionService<NyxIdChatCommand, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, NyxIdChatCompletionStatus>>());
         services.TryAddSingleton<ICommandInteractionService<NyxIdApprovalCommand, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, NyxIdChatCompletionStatus>>(sp =>
@@ -193,7 +206,8 @@ public static class ServiceCollectionExtensions
                 sp.GetRequiredService<ICommandDurableCompletionResolver<NyxIdChatAcceptedReceipt, NyxIdChatCompletionStatus>>(),
                 sp.GetService<ILogger<DefaultCommandInteractionService<NyxIdApprovalCommand, NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, AGUIEvent, NyxIdChatCompletionStatus>>>(),
                 sp.GetRequiredService<ICommandObservationLifecycle<NyxIdApprovalCommand, NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt, NyxIdChatStartError>>(),
-                sp.GetRequiredService<ICommandReceiptFactory<NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt>>()));
+                sp.GetRequiredService<ICommandReceiptFactory<NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt>>(),
+                sp.GetRequiredService<ICommandObservationScopeLeasePreparation<NyxIdApprovalCommand, NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt, NyxIdChatStartError>>()));
         services.TryAddSingleton<IRealtimeSession<NyxIdApprovalCommand, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, NyxIdChatCompletionStatus>>(sp =>
             sp.GetRequiredService<ICommandInteractionService<NyxIdApprovalCommand, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, NyxIdChatCompletionStatus>>());
     }

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -18,6 +18,7 @@ using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Core.Commands;
 using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
@@ -1316,8 +1317,7 @@ public class NyxIdChatEndpointsCoverageTests
         projectionPort.AttachCount.Should().Be(1);
         projectionPort.DetachCount.Should().Be(1);
         projectionPort.ReleaseCount.Should().Be(1);
-        dispatchPort.Dispatches.Should().ContainSingle();
-        var envelope = dispatchPort.Dispatches.Single().Envelope;
+        var envelope = RequireDispatchedPayload<ChatRequestEvent>(dispatchPort);
         envelope.Route?.Direct?.TargetActorId.Should().Be(actor.Id);
         envelope.Propagation?.CorrelationId.Should().Be(result.Receipt.CorrelationId);
         var request = envelope.Payload.Unpack<ChatRequestEvent>();
@@ -1370,8 +1370,7 @@ public class NyxIdChatEndpointsCoverageTests
             (_, _) => ValueTask.CompletedTask);
 
         result.Succeeded.Should().BeTrue();
-        dispatchPort.Dispatches.Should().ContainSingle();
-        var request = dispatchPort.Dispatches.Single().Envelope.Payload.Unpack<ChatRequestEvent>();
+        var request = RequireDispatchedPayload<ChatRequestEvent>(dispatchPort).Payload.Unpack<ChatRequestEvent>();
         request.Prompt.Should().Be("::Goal ship today");
         var recovery = AgentToolExecutionContextMapper.FromPayload(request.ToolContext).SkillRecovery;
         recovery.RequireInitialOrnnSearch.Should().BeTrue();
@@ -1419,8 +1418,7 @@ public class NyxIdChatEndpointsCoverageTests
             (_, _) => ValueTask.CompletedTask);
 
         result.Succeeded.Should().BeTrue();
-        dispatchPort.Dispatches.Should().ContainSingle();
-        var request = dispatchPort.Dispatches.Single().Envelope.Payload.Unpack<ChatRequestEvent>();
+        var request = RequireDispatchedPayload<ChatRequestEvent>(dispatchPort).Payload.Unpack<ChatRequestEvent>();
         request.Prompt.Should().Be("::");
         var recovery = AgentToolExecutionContextMapper.FromPayload(request.ToolContext).SkillRecovery;
         recovery.RequireInitialOrnnSearch.Should().BeTrue();
@@ -1478,8 +1476,7 @@ public class NyxIdChatEndpointsCoverageTests
         projectionPort.AttachExistingCalls.Should().ContainSingle(x =>
             x.ActorId == actor.Id &&
             x.SessionId == "session-1");
-        dispatchPort.Dispatches.Should().ContainSingle();
-        var envelope = dispatchPort.Dispatches.Single().Envelope;
+        var envelope = RequireDispatchedPayload<ChatRequestEvent>(dispatchPort);
         envelope.Propagation?.CorrelationId.Should().Be("correlation-explicit");
         var request = envelope.Payload.Unpack<ChatRequestEvent>();
         request.SessionId.Should().Be("session-1");
@@ -1604,8 +1601,7 @@ public class NyxIdChatEndpointsCoverageTests
         projectionPort.AttachExistingCalls.Should().ContainSingle(x =>
             x.ActorId == actor.Id &&
             x.SessionId == "session-1");
-        dispatchPort.Dispatches.Should().ContainSingle();
-        var envelope = dispatchPort.Dispatches.Single().Envelope;
+        var envelope = RequireDispatchedPayload<ToolApprovalDecisionEvent>(dispatchPort);
         envelope.Propagation?.CorrelationId.Should().Be("approval-correlation-explicit");
         var decision = envelope.Payload.Unpack<ToolApprovalDecisionEvent>();
         decision.RequestId.Should().Be("request-1");
@@ -3270,6 +3266,18 @@ public class NyxIdChatEndpointsCoverageTests
     private static string ComputeBodySha256Hex(byte[] bodyBytes) =>
         Convert.ToHexString(SHA256.HashData(bodyBytes)).ToLowerInvariant();
 
+    private static EventEnvelope RequireDispatchedPayload<TPayload>(StubActorDispatchPort dispatchPort)
+        where TPayload : IMessage, new()
+    {
+        var descriptor = new TPayload().Descriptor;
+        var matches = dispatchPort.Dispatches
+            .Where(dispatch => dispatch.Envelope.Payload?.Is(descriptor) == true)
+            .Select(dispatch => dispatch.Envelope)
+            .ToList();
+        matches.Should().ContainSingle();
+        return matches[0];
+    }
+
     private sealed record RelayInvocationDependencies(
         NyxIdRelayTransport Transport,
         NyxIdRelayAuthValidator Validator,
@@ -3362,6 +3370,17 @@ public class NyxIdChatEndpointsCoverageTests
             return Task.FromResult(actor);
         }
 
+        public Task<IActor> CreateByKindAsync(string agentKind, string? id = null, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            var actorId = id ?? Guid.NewGuid().ToString("N");
+            IActor actor = agentKind.StartsWith("projection.session-scope.", StringComparison.Ordinal)
+                ? new StubProjectionScopeActor(actorId)
+                : new StubActor(actorId);
+            Actors[actorId] = actor;
+            return Task.FromResult(actor);
+        }
+
         public Task DestroyAsync(string id, CancellationToken ct = default)
         {
             DestroyCalls.Add(id);
@@ -3430,6 +3449,26 @@ public class NyxIdChatEndpointsCoverageTests
         public Task<IReadOnlyList<string>> GetChildrenIdsAsync() => Task.FromResult<IReadOnlyList<string>>([]);
     }
 
+    private sealed class StubProjectionScopeActor(string id) : IActor
+    {
+        public string Id { get; } = id;
+        public IAgent Agent { get; } = new StubAgent();
+        public List<EventEnvelope> HandledEnvelopes { get; } = [];
+        public bool Released { get; private set; }
+        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            HandledEnvelopes.Add(envelope);
+            if (envelope.Payload?.Is(ReleaseProjectionScopeCommand.Descriptor) == true)
+                Released = true;
+            return Task.CompletedTask;
+        }
+        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
+        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() => Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
     private sealed class StubActorDispatchPort(IActorRuntime runtime) : IActorDispatchPort
     {
         public List<(string ActorId, EventEnvelope Envelope)> Dispatches { get; } = [];
@@ -3446,12 +3485,19 @@ public class NyxIdChatEndpointsCoverageTests
 
     private sealed class ThrowingActorDispatchPort(Exception exception) : IActorDispatchPort
     {
+        public List<(string ActorId, EventEnvelope Envelope)> Dispatches { get; } = [];
+
         public Task<DispatchAdmission> DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
         {
-            _ = actorId;
-            _ = envelope;
-            _ = ct;
-            return Task.FromException<DispatchAdmission>(exception);
+            ct.ThrowIfCancellationRequested();
+            Dispatches.Add((actorId, envelope));
+            if (envelope.Payload?.Is(ChatRequestEvent.Descriptor) == true ||
+                envelope.Payload?.Is(ToolApprovalDecisionEvent.Descriptor) == true)
+            {
+                return Task.FromException<DispatchAdmission>(exception);
+            }
+
+            return Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
         }
     }
 

--- a/test/Aevatar.AI.Tests/NyxIdChatObservationScopeLeasePreparationTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatObservationScopeLeasePreparationTests.cs
@@ -1,0 +1,227 @@
+using Aevatar.CQRS.Core.Abstractions.Commands;
+using Aevatar.CQRS.Core.Abstractions.Interactions;
+using Aevatar.CQRS.Core.Abstractions.Streaming;
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.NyxidChat;
+using Aevatar.AGUI.Contracts;
+using FluentAssertions;
+
+namespace Aevatar.AI.Tests;
+
+public sealed class NyxIdChatObservationScopeLeasePreparationTests
+{
+    [Fact]
+    public async Task PrepareAsync_ShouldActivateSessionObservationScopeForChatCommand()
+    {
+        var activation = new RecordingActivationService();
+        var release = new RecordingReleaseService();
+        var preparation = new NyxIdChatObservationScopeLeasePreparation<NyxIdChatCommand>(
+            activation,
+            release,
+            static command => command.SessionId);
+        var execution = CreateExecution(" actor-1 ", "cmd-1", " session-1 ");
+
+        var result = await preparation.PrepareAsync(
+            new NyxIdChatCommand("actor-1", "scope-1", "hello", " session-1 ", "token", null, null),
+            execution,
+            CancellationToken.None);
+
+        result.Succeeded.Should().BeTrue();
+        result.Handle.Should().NotBeNull();
+        activation.Requests.Should().ContainSingle();
+        activation.Requests[0].RootActorId.Should().Be("actor-1");
+        activation.Requests[0].ProjectionKind.Should().Be("nyxid-chat-session");
+        activation.Requests[0].Mode.Should().Be(ProjectionRuntimeMode.SessionObservation);
+        activation.Requests[0].SessionId.Should().Be("session-1");
+
+        await result.Handle!.ReleaseAsync(CancellationToken.None);
+
+        release.Leases.Should().ContainSingle().Which.Should().BeSameAs(activation.Leases[0]);
+    }
+
+    [Fact]
+    public async Task PrepareAsync_ShouldActivateSessionObservationScopeForApprovalCommand()
+    {
+        var activation = new RecordingActivationService();
+        var preparation = new NyxIdChatObservationScopeLeasePreparation<NyxIdApprovalCommand>(
+            activation,
+            new RecordingReleaseService(),
+            static command => command.SessionId);
+        var execution = CreateExecution("actor-2", "cmd-2", "session-2");
+
+        var result = await preparation.PrepareAsync(
+            new NyxIdApprovalCommand("actor-2", "request-1", true, "approved", "session-2"),
+            execution,
+            CancellationToken.None);
+
+        result.Succeeded.Should().BeTrue();
+        activation.Requests.Should().ContainSingle();
+        activation.Requests[0].RootActorId.Should().Be("actor-2");
+        activation.Requests[0].SessionId.Should().Be("session-2");
+    }
+
+    [Theory]
+    [InlineData("", "session-1")]
+    [InlineData("   ", "session-1")]
+    [InlineData("actor-1", "")]
+    [InlineData("actor-1", "   ")]
+    public async Task PrepareAsync_ShouldReturnProjectionUnavailableForBlankIdentifiers(
+        string actorId,
+        string sessionId)
+    {
+        var activation = new RecordingActivationService();
+        var preparation = new NyxIdChatObservationScopeLeasePreparation<NyxIdChatCommand>(
+            activation,
+            new RecordingReleaseService(),
+            static command => command.SessionId);
+
+        var result = await preparation.PrepareAsync(
+            new NyxIdChatCommand(actorId, "scope-1", "hello", sessionId, "token", null, null),
+            CreateExecution(actorId, "cmd-1", sessionId),
+            CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(NyxIdChatStartError.ProjectionUnavailable);
+        result.Handle.Should().BeNull();
+        activation.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task PrepareAsync_ShouldReturnProjectionUnavailable_WhenActivationFails()
+    {
+        var activation = new RecordingActivationService { ThrowOnEnsure = true };
+        var release = new RecordingReleaseService();
+        var preparation = new NyxIdChatObservationScopeLeasePreparation<NyxIdChatCommand>(
+            activation,
+            release,
+            static command => command.SessionId);
+
+        var result = await preparation.PrepareAsync(
+            new NyxIdChatCommand("actor-1", "scope-1", "hello", "session-1", "token", null, null),
+            CreateExecution("actor-1", "cmd-1", "session-1"),
+            CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(NyxIdChatStartError.ProjectionUnavailable);
+        result.Handle.Should().BeNull();
+        release.Leases.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task PrepareAsync_ShouldHonorCancellation()
+    {
+        var preparation = new NyxIdChatObservationScopeLeasePreparation<NyxIdChatCommand>(
+            new RecordingActivationService(),
+            new RecordingReleaseService(),
+            static command => command.SessionId);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = async () => await preparation.PrepareAsync(
+            new NyxIdChatCommand("actor-1", "scope-1", "hello", "session-1", "token", null, null),
+            CreateExecution("actor-1", "cmd-1", "session-1"),
+            cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    private static CommandDispatchExecution<NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt> CreateExecution(
+        string actorId,
+        string commandId,
+        string sessionId)
+    {
+        var target = new NyxIdChatCommandTarget(
+            new TestActor(actorId),
+            new NoopProjectionPort());
+
+        return new CommandDispatchExecution<NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt>
+        {
+            Target = target,
+            Context = new CommandContext(actorId, commandId, "corr-1", new Dictionary<string, string>()),
+            Envelope = new EventEnvelope { Id = $"env-{commandId}" },
+            Receipt = new NyxIdChatAcceptedReceipt(actorId, commandId, "corr-1", sessionId),
+        };
+    }
+
+    private sealed class RecordingActivationService : IProjectionScopeActivationService<NyxIdChatSessionRuntimeLease>
+    {
+        public bool ThrowOnEnsure { get; init; }
+        public List<ProjectionScopeStartRequest> Requests { get; } = [];
+        public List<NyxIdChatSessionRuntimeLease> Leases { get; } = [];
+
+        public Task<NyxIdChatSessionRuntimeLease> EnsureAsync(
+            ProjectionScopeStartRequest request,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Requests.Add(request);
+            if (ThrowOnEnsure)
+                throw new InvalidOperationException("activation failed");
+
+            var lease = new NyxIdChatSessionRuntimeLease(new NyxIdChatSessionProjectionContext
+            {
+                RootActorId = request.RootActorId,
+                ProjectionKind = request.ProjectionKind,
+                SessionId = request.SessionId,
+            });
+            Leases.Add(lease);
+            return Task.FromResult(lease);
+        }
+    }
+
+    private sealed class RecordingReleaseService : IProjectionScopeReleaseService<NyxIdChatSessionRuntimeLease>
+    {
+        public List<NyxIdChatSessionRuntimeLease> Leases { get; } = [];
+
+        public Task ReleaseIfIdleAsync(NyxIdChatSessionRuntimeLease lease, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Leases.Add(lease);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class NoopProjectionPort : INyxIdChatSessionProjectionPort
+    {
+        public bool ProjectionEnabled => true;
+
+        public Task<EventSinkProjectionAttachment<INyxIdChatSessionProjectionLease>?> AttachExistingChatProjectionAsync(
+            string actorId,
+            string sessionId,
+            IEventSink<AGUIEvent> sink,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<IAsyncDisposable?> AttachLiveSinkAsync(
+            INyxIdChatSessionProjectionLease lease,
+            IEventSink<AGUIEvent> sink,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task DetachLiveSinkAsync(IAsyncDisposable? liveSinkLease, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task ReleaseActorProjectionAsync(
+            INyxIdChatSessionProjectionLease lease,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class TestActor(string id) : IActor
+    {
+        public string Id { get; } = id;
+        public IAgent Agent => throw new NotSupportedException();
+
+        public Task ActivateAsync(CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task DeactivateAsync(CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<string?> GetParentIdAsync() => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() => throw new NotSupportedException();
+    }
+}

--- a/test/Aevatar.AI.Tests/NyxIdChatServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatServiceCollectionExtensionsTests.cs
@@ -1,3 +1,4 @@
+using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.GAgents.Channel.NyxIdRelay;
 using Aevatar.GAgents.NyxidChat;
 using FluentAssertions;
@@ -31,5 +32,17 @@ public sealed class NyxIdChatServiceCollectionExtensionsTests
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(IAgentToolReceiptRenderer) &&
             descriptor.ImplementationType == typeof(AgentToolReceiptRenderer));
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(ICommandObservationScopeLeasePreparation<
+                NyxIdChatCommand,
+                NyxIdChatCommandTarget,
+                NyxIdChatAcceptedReceipt,
+                NyxIdChatStartError>));
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(ICommandObservationScopeLeasePreparation<
+                NyxIdApprovalCommand,
+                NyxIdChatCommandTarget,
+                NyxIdChatAcceptedReceipt,
+                NyxIdChatStartError>));
     }
 }


### PR DESCRIPTION
本 PR 解决 #1913:nyxid-chat 第一方直连 `:stream`/`:approve` 的 cold session 首请求永久 `ProjectionUnavailable`。

## 根因
13 个可观察子系统均在 dispatch 前为命令交互预激活 session projection lease,唯独 nyxid-chat 没有任何 observation-scope preparation。`DefaultCommandInteractionService` 已接受 `ICommandObservationScopeLeasePreparation` 参数(seam 已落地),但 nyxid-chat 从未注册/传入 → cold session `AttachExistingChatProjectionAsync` 命中 null → 必 `ProjectionUnavailable`(`NyxIdChatInteraction.cs:257`)。

## 方案(design-consensus framing=minimal,r3 共识)
新增 `NyxIdChatObservationScopeLeasePreparation<TCommand>`,复用既有 CQRS `ICommandObservationScopeLeasePreparation` seam:`PrepareAsync` 按 `RootActorId + SessionId` 调 `IProjectionScopeActivationService.EnsureAsync`(`ProjectionKind=ChatSession`,`Mode=SessionObservation`),失败 fail-closed 返回 `ProjectionUnavailable`,handle 经 `ReleaseIfIdleAsync` 释放;为 `NyxIdChatCommand` / `NyxIdApprovalCommand` 注册并注入两个 `DefaultCommandInteractionService` factory。observation binder 继续 attach-only,cold session 首请求即可命中 attach-existing。

- 不新增 committed-state activation provider(cold session 首请求等不到 committed event,必须在 dispatch 前的 interaction seam 预激活)
- 不删除/迁移 direct route;`NyxIdChatSessionProjection` 保留为统一 Projection Pipeline 的 SSE observation adapter
- endpoint/query/read path 不直接调 activation、不补 readmodel freshness(遵循读写分离;尊重 #1879/#1893 不在请求路径 priming)
- 不改 `docs/canon`,不依赖外部 NyxID 仓库;与 #1687 同方向(projection-owned observation lease preparation)

## Changed files
- `agents/Aevatar.GAgents.NyxidChat/NyxIdChatObservationScopeLeasePreparation.cs`(新,72)
- `agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs`(DI 注册 + 注入两个 factory,+18)
- `test/Aevatar.AI.Tests/NyxIdChatObservationScopeLeasePreparationTests.cs`(新,227:activation / release / cancellation / missing-id fail-closed 分支)
- `test/Aevatar.AI.Tests/NyxIdChatServiceCollectionExtensionsTests.cs`(+13:证明 `AddNyxIdChat` 为两类命令 wire preparation)
- `test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs`(+74,SCOPE_EXTEND:既有 `AddNyxIdChat` 真实交互图覆盖测试需建模 preparation dispatch)

## Test results
- `dotnet build aevatar.slnx --nologo`:全绿
- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --filter NyxIdChat`:**117 passed / 0 failed / 0 skipped**
- `bash tools/ci/test_stability_guards.sh`:passed
- `bash tools/ci/query_projection_priming_guard.sh`:passed

## Deviations
- 1 处 `SCOPE_EXTEND`(`NyxIdChatEndpointsCoverageTests.cs`,理由如上,实施时已声明)。
- implement worker 在写 PR artifacts 前被中断;controller 接管 publish gate(复跑 build/test/guards 全绿)后提交,故无 worker 自写 implement summary。

Closes #1913

🤖 controller (codex-refactor-loop)

⟦AI:AUTO-LOOP⟧
