### PR TITLE
Restore workflow studio frontend configurator

### DIFF
--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -317,6 +317,148 @@ const enUSMessages = {
   'teams.detail.update.fromTeam': 'From team update time',
   'teams.detail.update.fromVisibleRun': 'From the latest visible run',
   'teams.detail.update.fromWorkflow': 'From workflow update time',
+  'shared.studio.nodeConfiguration.assign.target.label': 'Target variable',
+  'shared.studio.nodeConfiguration.assign.target.placeholder': 'result',
+  'shared.studio.nodeConfiguration.assign.value.label': 'Value',
+  'shared.studio.nodeConfiguration.assign.value.placeholder': '$input',
+  'shared.studio.nodeConfiguration.cache.childStep.label': 'Cached node',
+  'shared.studio.nodeConfiguration.cache.key.label': 'Cache key',
+  'shared.studio.nodeConfiguration.cache.key.placeholder': '$input',
+  'shared.studio.nodeConfiguration.cache.ttl.label': 'TTL seconds',
+  'shared.studio.nodeConfiguration.cache.ttl.placeholder': '600',
+  'shared.studio.nodeConfiguration.connectorCall.connector.label': 'Connector',
+  'shared.studio.nodeConfiguration.connectorCall.connector.placeholder':
+    'Configured connector name',
+  'shared.studio.nodeConfiguration.connectorCall.method.label': 'Method',
+  'shared.studio.nodeConfiguration.connectorCall.method.option.delete': 'DELETE',
+  'shared.studio.nodeConfiguration.connectorCall.method.option.get': 'GET',
+  'shared.studio.nodeConfiguration.connectorCall.method.option.patch': 'PATCH',
+  'shared.studio.nodeConfiguration.connectorCall.method.option.post': 'POST',
+  'shared.studio.nodeConfiguration.connectorCall.method.option.put': 'PUT',
+  'shared.studio.nodeConfiguration.connectorCall.onError.label': 'On error',
+  'shared.studio.nodeConfiguration.connectorCall.operation.label': 'Operation',
+  'shared.studio.nodeConfiguration.connectorCall.operation.placeholder':
+    'Operation or endpoint name',
+  'shared.studio.nodeConfiguration.connectorCall.path.label': 'Path',
+  'shared.studio.nodeConfiguration.connectorCall.path.placeholder': '/v1/items',
+  'shared.studio.nodeConfiguration.connectorCall.retry.label': 'Retries',
+  'shared.studio.nodeConfiguration.connectorCall.retry.placeholder': '0',
+  'shared.studio.nodeConfiguration.connectorCall.timeout.label': 'Timeout ms',
+  'shared.studio.nodeConfiguration.connectorCall.timeout.placeholder': '10000',
+  'shared.studio.nodeConfiguration.delay.duration.label': 'Duration ms',
+  'shared.studio.nodeConfiguration.delay.duration.placeholder': '1000',
+  'shared.studio.nodeConfiguration.emit.eventType.label': 'Event type',
+  'shared.studio.nodeConfiguration.emit.eventType.placeholder':
+    'workflow.completed',
+  'shared.studio.nodeConfiguration.emit.payload.label': 'Payload',
+  'shared.studio.nodeConfiguration.emit.payload.placeholder': '$input',
+  'shared.studio.nodeConfiguration.guard.check.label': 'Check',
+  'shared.studio.nodeConfiguration.guard.check.option.contains':
+    'Contains keyword',
+  'shared.studio.nodeConfiguration.guard.check.option.jsonValid':
+    'Input is valid JSON',
+  'shared.studio.nodeConfiguration.guard.check.option.maxLength':
+    'Within max length',
+  'shared.studio.nodeConfiguration.guard.check.option.notEmpty':
+    'Input is not empty',
+  'shared.studio.nodeConfiguration.guard.check.option.regex': 'Matches regex',
+  'shared.studio.nodeConfiguration.guard.onFailure.label': 'On failure',
+  'shared.studio.nodeConfiguration.humanApproval.onReject.label': 'On rejection',
+  'shared.studio.nodeConfiguration.humanApproval.onReject.option.fail':
+    'Fail the run',
+  'shared.studio.nodeConfiguration.humanApproval.onReject.option.skip':
+    'Skip this step',
+  'shared.studio.nodeConfiguration.humanApproval.prompt.label':
+    'Approval prompt',
+  'shared.studio.nodeConfiguration.humanApproval.prompt.placeholder':
+    'Approve this step?',
+  'shared.studio.nodeConfiguration.humanInput.prompt.label': 'Input prompt',
+  'shared.studio.nodeConfiguration.humanInput.prompt.placeholder':
+    'Please provide the missing input.',
+  'shared.studio.nodeConfiguration.humanInput.variable.label':
+    'Response variable',
+  'shared.studio.nodeConfiguration.humanInput.variable.placeholder':
+    'human_response',
+  'shared.studio.nodeConfiguration.llmCall.instruction.description':
+    'Prepended to the run message before the role is called.',
+  'shared.studio.nodeConfiguration.llmCall.instruction.label': 'Instruction',
+  'shared.studio.nodeConfiguration.llmCall.instruction.placeholder':
+    'Tell the role what this step should do.',
+  'shared.studio.nodeConfiguration.option.onFailure.branch': 'Go to a branch',
+  'shared.studio.nodeConfiguration.option.onFailure.fail': 'Fail the run',
+  'shared.studio.nodeConfiguration.option.onFailure.skip': 'Skip this step',
+  'shared.studio.nodeConfiguration.retrieveFacts.query.label': 'Query',
+  'shared.studio.nodeConfiguration.retrieveFacts.query.placeholder':
+    'What facts should this step retrieve?',
+  'shared.studio.nodeConfiguration.retrieveFacts.topK.label': 'Top K',
+  'shared.studio.nodeConfiguration.retrieveFacts.topK.placeholder': '3',
+  'shared.studio.nodeConfiguration.stepType.option.assign': 'Assign',
+  'shared.studio.nodeConfiguration.stepType.option.cache': 'Cache',
+  'shared.studio.nodeConfiguration.stepType.option.checkpoint': 'Checkpoint',
+  'shared.studio.nodeConfiguration.stepType.option.conditional': 'Conditional',
+  'shared.studio.nodeConfiguration.stepType.option.connectorCall':
+    'Connector call',
+  'shared.studio.nodeConfiguration.stepType.option.delay': 'Delay',
+  'shared.studio.nodeConfiguration.stepType.option.dynamicWorkflow':
+    'Dynamic workflow',
+  'shared.studio.nodeConfiguration.stepType.option.emit': 'Emit',
+  'shared.studio.nodeConfiguration.stepType.option.evaluate': 'Evaluate',
+  'shared.studio.nodeConfiguration.stepType.option.foreach': 'For each',
+  'shared.studio.nodeConfiguration.stepType.option.guard': 'Guard',
+  'shared.studio.nodeConfiguration.stepType.option.humanApproval':
+    'Human approval',
+  'shared.studio.nodeConfiguration.stepType.option.humanInput': 'Human input',
+  'shared.studio.nodeConfiguration.stepType.option.llmCall': 'LLM call',
+  'shared.studio.nodeConfiguration.stepType.option.mapReduce': 'Map reduce',
+  'shared.studio.nodeConfiguration.stepType.option.parallel': 'Parallel',
+  'shared.studio.nodeConfiguration.stepType.option.race': 'Race',
+  'shared.studio.nodeConfiguration.stepType.option.reflect': 'Reflect',
+  'shared.studio.nodeConfiguration.stepType.option.retrieveFacts':
+    'Retrieve facts',
+  'shared.studio.nodeConfiguration.stepType.option.switch': 'Switch',
+  'shared.studio.nodeConfiguration.stepType.option.toolCall': 'Tool call',
+  'shared.studio.nodeConfiguration.stepType.option.transform': 'Transform',
+  'shared.studio.nodeConfiguration.stepType.option.vote': 'Vote',
+  'shared.studio.nodeConfiguration.stepType.option.waitSignal':
+    'Wait for signal',
+  'shared.studio.nodeConfiguration.stepType.option.while': 'While',
+  'shared.studio.nodeConfiguration.stepType.option.workflowCall':
+    'Workflow call',
+  'shared.studio.nodeConfiguration.stepType.option.workflowYamlValidate':
+    'Workflow YAML validation',
+  'shared.studio.nodeConfiguration.transform.operation.label': 'Operation',
+  'shared.studio.nodeConfiguration.transform.operation.option.count':
+    'Count lines',
+  'shared.studio.nodeConfiguration.transform.operation.option.identity':
+    'Pass through',
+  'shared.studio.nodeConfiguration.transform.operation.option.join':
+    'Join sections',
+  'shared.studio.nodeConfiguration.transform.operation.option.jsonExtract':
+    'Extract JSON',
+  'shared.studio.nodeConfiguration.transform.operation.option.lowercase':
+    'Lowercase',
+  'shared.studio.nodeConfiguration.transform.operation.option.split':
+    'Split into sections',
+  'shared.studio.nodeConfiguration.transform.operation.option.take':
+    'Take first lines',
+  'shared.studio.nodeConfiguration.transform.operation.option.takeLast':
+    'Take last lines',
+  'shared.studio.nodeConfiguration.transform.operation.option.trim':
+    'Trim whitespace',
+  'shared.studio.nodeConfiguration.transform.operation.option.uppercase':
+    'Uppercase',
+  'shared.studio.nodeConfiguration.waitSignal.signalName.label': 'Signal name',
+  'shared.studio.nodeConfiguration.waitSignal.signalName.placeholder': 'continue',
+  'shared.studio.nodeConfiguration.waitSignal.timeout.label': 'Timeout ms',
+  'shared.studio.nodeConfiguration.waitSignal.timeout.placeholder': '60000',
+  'shared.studio.nodeConfiguration.workflowCall.lifecycle.label': 'Lifecycle',
+  'shared.studio.nodeConfiguration.workflowCall.lifecycle.option.inline':
+    'Inline call',
+  'shared.studio.nodeConfiguration.workflowCall.lifecycle.option.scope':
+    'Use scope workflow',
+  'shared.studio.nodeConfiguration.workflowCall.workflow.label': 'Workflow',
+  'shared.studio.nodeConfiguration.workflowCall.workflow.placeholder':
+    'child_workflow',
   'teams.members.actions.build': 'Build',
   'teams.members.actions.clearEntry': 'Clear entry member',
   'teams.members.actions.create': 'Create member',
@@ -383,19 +525,16 @@ const enUSMessages = {
   'teamMemberWorkflowStudio.header.activation.ready': 'Ready',
   'teamMemberWorkflowStudio.header.addNode': 'Add node',
   'teamMemberWorkflowStudio.header.currentTeam': 'Current team',
+  'teamMemberWorkflowStudio.header.deleteConnection': 'Delete connection',
   'teamMemberWorkflowStudio.header.deleteNode': 'Delete node',
   'teamMemberWorkflowStudio.header.editWorkflowName': 'Edit workflow name',
-  'teamMemberWorkflowStudio.header.executeWorkflow': 'Execute workflow',
   'teamMemberWorkflowStudio.header.identityAria': 'Workflow identity',
   'teamMemberWorkflowStudio.header.inputSet': 'input set',
   'teamMemberWorkflowStudio.header.nodeActionsAria':
     'Workflow draft and node actions',
-  'teamMemberWorkflowStudio.header.optionalTestPayload': 'Optional test payload',
   'teamMemberWorkflowStudio.header.primaryActionsAria':
     'Workflow primary actions',
-  'teamMemberWorkflowStudio.header.runInput': 'Run input',
-  'teamMemberWorkflowStudio.header.runInputPlaceholder':
-    'Optional input for this workflow run',
+  'teamMemberWorkflowStudio.header.runMessage': 'Run message',
   'teamMemberWorkflowStudio.header.runOptionsAria': 'Run options',
   'teamMemberWorkflowStudio.header.runActiveMember': 'Run active member',
   'teamMemberWorkflowStudio.header.save': 'Save',
@@ -413,18 +552,22 @@ const enUSMessages = {
   'teamMemberWorkflowStudio.header.teamBreadcrumb': 'Team',
   'teamMemberWorkflowStudio.header.unsavedChanges': 'Unsaved changes',
   'teamMemberWorkflowStudio.header.viewsAria': 'Workflow views',
-  'teamMemberWorkflowStudio.header.workflowRun': 'Workflow run',
   'teamMemberWorkflowStudio.header.workflowTitleAria': 'Workflow title',
-  'teamMemberWorkflowStudio.nodeDetail.apply': 'Apply',
-  'teamMemberWorkflowStudio.nodeDetail.input': 'Input',
-  'teamMemberWorkflowStudio.nodeDetail.inputEmpty':
-    'Input preview will appear here when workflow execution is wired.',
-  'teamMemberWorkflowStudio.nodeDetail.output': 'Output',
-  'teamMemberWorkflowStudio.nodeDetail.outputEmpty':
-    'Output remains empty until a real workflow execution result is available.',
-  'teamMemberWorkflowStudio.nodeDetail.parameters': 'Parameters',
-  'teamMemberWorkflowStudio.nodeDetail.parametersAria': 'Node parameters',
+  'teamMemberWorkflowStudio.nodeDetail.advancedRawConfiguration':
+    'Advanced raw configuration',
+  'teamMemberWorkflowStudio.nodeDetail.advancedRawConfigurationDescription':
+    'Use this only when a node option is not available as a guided field.',
+  'teamMemberWorkflowStudio.nodeDetail.applyRawConfiguration': 'Apply raw JSON',
+  'teamMemberWorkflowStudio.nodeDetail.configuration': 'Configuration',
+  'teamMemberWorkflowStudio.nodeDetail.configurationDescription':
+    'Edit the fields this node uses when the draft runs.',
+  'teamMemberWorkflowStudio.nodeDetail.noSemanticFields':
+    'This node type does not have guided fields yet. Use advanced raw configuration when needed.',
+  'teamMemberWorkflowStudio.nodeDetail.rawConfigurationAria':
+    'Raw node configuration',
   'teamMemberWorkflowStudio.nodeDetail.sectionAria': 'Node detail',
+  'teamMemberWorkflowStudio.nodeDetail.stepId': 'Step ID: {stepId}',
+  'teamMemberWorkflowStudio.nodeDetail.updateNode': 'Update node',
   'teamMemberWorkflowStudio.nodeLibrary.closeAria': 'Close node library',
   'teamMemberWorkflowStudio.nodeLibrary.emptySearch':
     'No nodes match this search.',
@@ -433,8 +576,12 @@ const enUSMessages = {
   'teamMemberWorkflowStudio.nodeLibrary.searchPlaceholder': 'Search nodes',
   'teamMemberWorkflowStudio.nodeLibrary.sectionAria': 'Node library',
   'teamMemberWorkflowStudio.nodeLibrary.title': 'Node library',
-  'teamMemberWorkflowStudio.runOptionsPanel.inputPlaceholder':
-    'Optional input for this active member run',
+  'teamMemberWorkflowStudio.resize.executionPanel': 'Resize run console',
+  'teamMemberWorkflowStudio.resize.sidePanel': 'Resize side panel',
+  'teamMemberWorkflowStudio.runOptionsPanel.messageLabel':
+    'Message to active member',
+  'teamMemberWorkflowStudio.runOptionsPanel.messagePlaceholder':
+    'Optional message sent with this active member run',
   'teamMemberWorkflowStudio.runOptionsPanel.sectionAria': 'Run options panel',
   'teamMemberWorkflowStudio.runOptionsPanel.title': 'Run options',
   'teamMemberWorkflowStudio.runsPanel.description':

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -302,6 +302,139 @@ const zhCNMessages = {
   'teams.detail.update.fromTeam': '来自团队更新时间',
   'teams.detail.update.fromVisibleRun': '来自最近可见运行',
   'teams.detail.update.fromWorkflow': '来自 Workflow 更新时间',
+  'shared.studio.nodeConfiguration.assign.target.label': '目标变量',
+  'shared.studio.nodeConfiguration.assign.target.placeholder': 'result',
+  'shared.studio.nodeConfiguration.assign.value.label': '值',
+  'shared.studio.nodeConfiguration.assign.value.placeholder': '$input',
+  'shared.studio.nodeConfiguration.cache.childStep.label': '缓存节点',
+  'shared.studio.nodeConfiguration.cache.key.label': '缓存键',
+  'shared.studio.nodeConfiguration.cache.key.placeholder': '$input',
+  'shared.studio.nodeConfiguration.cache.ttl.label': 'TTL 秒数',
+  'shared.studio.nodeConfiguration.cache.ttl.placeholder': '600',
+  'shared.studio.nodeConfiguration.connectorCall.connector.label': 'Connector',
+  'shared.studio.nodeConfiguration.connectorCall.connector.placeholder':
+    '已配置的 Connector 名称',
+  'shared.studio.nodeConfiguration.connectorCall.method.label': '方法',
+  'shared.studio.nodeConfiguration.connectorCall.method.option.delete': 'DELETE',
+  'shared.studio.nodeConfiguration.connectorCall.method.option.get': 'GET',
+  'shared.studio.nodeConfiguration.connectorCall.method.option.patch': 'PATCH',
+  'shared.studio.nodeConfiguration.connectorCall.method.option.post': 'POST',
+  'shared.studio.nodeConfiguration.connectorCall.method.option.put': 'PUT',
+  'shared.studio.nodeConfiguration.connectorCall.onError.label': '出错时',
+  'shared.studio.nodeConfiguration.connectorCall.operation.label': '操作',
+  'shared.studio.nodeConfiguration.connectorCall.operation.placeholder':
+    '操作或 endpoint 名称',
+  'shared.studio.nodeConfiguration.connectorCall.path.label': '路径',
+  'shared.studio.nodeConfiguration.connectorCall.path.placeholder': '/v1/items',
+  'shared.studio.nodeConfiguration.connectorCall.retry.label': '重试次数',
+  'shared.studio.nodeConfiguration.connectorCall.retry.placeholder': '0',
+  'shared.studio.nodeConfiguration.connectorCall.timeout.label': '超时毫秒',
+  'shared.studio.nodeConfiguration.connectorCall.timeout.placeholder': '10000',
+  'shared.studio.nodeConfiguration.delay.duration.label': '持续毫秒',
+  'shared.studio.nodeConfiguration.delay.duration.placeholder': '1000',
+  'shared.studio.nodeConfiguration.emit.eventType.label': '事件类型',
+  'shared.studio.nodeConfiguration.emit.eventType.placeholder':
+    'workflow.completed',
+  'shared.studio.nodeConfiguration.emit.payload.label': 'Payload',
+  'shared.studio.nodeConfiguration.emit.payload.placeholder': '$input',
+  'shared.studio.nodeConfiguration.guard.check.label': '检查',
+  'shared.studio.nodeConfiguration.guard.check.option.contains': '包含关键词',
+  'shared.studio.nodeConfiguration.guard.check.option.jsonValid':
+    '输入是有效 JSON',
+  'shared.studio.nodeConfiguration.guard.check.option.maxLength':
+    '不超过最大长度',
+  'shared.studio.nodeConfiguration.guard.check.option.notEmpty': '输入非空',
+  'shared.studio.nodeConfiguration.guard.check.option.regex': '匹配正则',
+  'shared.studio.nodeConfiguration.guard.onFailure.label': '失败时',
+  'shared.studio.nodeConfiguration.humanApproval.onReject.label': '拒绝时',
+  'shared.studio.nodeConfiguration.humanApproval.onReject.option.fail':
+    '让运行失败',
+  'shared.studio.nodeConfiguration.humanApproval.onReject.option.skip':
+    '跳过这个步骤',
+  'shared.studio.nodeConfiguration.humanApproval.prompt.label': '审批提示',
+  'shared.studio.nodeConfiguration.humanApproval.prompt.placeholder':
+    'Approve this step?',
+  'shared.studio.nodeConfiguration.humanInput.prompt.label': '输入提示',
+  'shared.studio.nodeConfiguration.humanInput.prompt.placeholder':
+    'Please provide the missing input.',
+  'shared.studio.nodeConfiguration.humanInput.variable.label': '响应变量',
+  'shared.studio.nodeConfiguration.humanInput.variable.placeholder':
+    'human_response',
+  'shared.studio.nodeConfiguration.llmCall.instruction.description':
+    '在调用角色前，追加到本次运行消息之前。',
+  'shared.studio.nodeConfiguration.llmCall.instruction.label': '指令',
+  'shared.studio.nodeConfiguration.llmCall.instruction.placeholder':
+    '告诉这个角色该步骤要做什么。',
+  'shared.studio.nodeConfiguration.option.onFailure.branch': '进入分支',
+  'shared.studio.nodeConfiguration.option.onFailure.fail': '让运行失败',
+  'shared.studio.nodeConfiguration.option.onFailure.skip': '跳过这个步骤',
+  'shared.studio.nodeConfiguration.retrieveFacts.query.label': '查询',
+  'shared.studio.nodeConfiguration.retrieveFacts.query.placeholder':
+    '这个步骤要检索哪些事实？',
+  'shared.studio.nodeConfiguration.retrieveFacts.topK.label': 'Top K',
+  'shared.studio.nodeConfiguration.retrieveFacts.topK.placeholder': '3',
+  'shared.studio.nodeConfiguration.stepType.option.assign': '赋值',
+  'shared.studio.nodeConfiguration.stepType.option.cache': '缓存',
+  'shared.studio.nodeConfiguration.stepType.option.checkpoint': '检查点',
+  'shared.studio.nodeConfiguration.stepType.option.conditional': '条件判断',
+  'shared.studio.nodeConfiguration.stepType.option.connectorCall':
+    'Connector 调用',
+  'shared.studio.nodeConfiguration.stepType.option.delay': '延迟',
+  'shared.studio.nodeConfiguration.stepType.option.dynamicWorkflow':
+    '动态 Workflow',
+  'shared.studio.nodeConfiguration.stepType.option.emit': '发出事件',
+  'shared.studio.nodeConfiguration.stepType.option.evaluate': '评估',
+  'shared.studio.nodeConfiguration.stepType.option.foreach': '逐项处理',
+  'shared.studio.nodeConfiguration.stepType.option.guard': '检查守卫',
+  'shared.studio.nodeConfiguration.stepType.option.humanApproval': '人工审批',
+  'shared.studio.nodeConfiguration.stepType.option.humanInput': '人工输入',
+  'shared.studio.nodeConfiguration.stepType.option.llmCall': 'LLM 调用',
+  'shared.studio.nodeConfiguration.stepType.option.mapReduce': 'Map reduce',
+  'shared.studio.nodeConfiguration.stepType.option.parallel': '并行',
+  'shared.studio.nodeConfiguration.stepType.option.race': '抢先完成',
+  'shared.studio.nodeConfiguration.stepType.option.reflect': '反思',
+  'shared.studio.nodeConfiguration.stepType.option.retrieveFacts': '检索事实',
+  'shared.studio.nodeConfiguration.stepType.option.switch': '分支选择',
+  'shared.studio.nodeConfiguration.stepType.option.toolCall': '工具调用',
+  'shared.studio.nodeConfiguration.stepType.option.transform': '转换',
+  'shared.studio.nodeConfiguration.stepType.option.vote': '投票',
+  'shared.studio.nodeConfiguration.stepType.option.waitSignal': '等待信号',
+  'shared.studio.nodeConfiguration.stepType.option.while': '循环',
+  'shared.studio.nodeConfiguration.stepType.option.workflowCall':
+    'Workflow 调用',
+  'shared.studio.nodeConfiguration.stepType.option.workflowYamlValidate':
+    'Workflow YAML 校验',
+  'shared.studio.nodeConfiguration.transform.operation.label': '操作',
+  'shared.studio.nodeConfiguration.transform.operation.option.count': '统计行数',
+  'shared.studio.nodeConfiguration.transform.operation.option.identity': '原样传递',
+  'shared.studio.nodeConfiguration.transform.operation.option.join':
+    '合并分段',
+  'shared.studio.nodeConfiguration.transform.operation.option.jsonExtract':
+    '提取 JSON',
+  'shared.studio.nodeConfiguration.transform.operation.option.lowercase':
+    '转小写',
+  'shared.studio.nodeConfiguration.transform.operation.option.split':
+    '拆分分段',
+  'shared.studio.nodeConfiguration.transform.operation.option.take':
+    '取开头几行',
+  'shared.studio.nodeConfiguration.transform.operation.option.takeLast':
+    '取末尾几行',
+  'shared.studio.nodeConfiguration.transform.operation.option.trim':
+    '去除首尾空白',
+  'shared.studio.nodeConfiguration.transform.operation.option.uppercase':
+    '转大写',
+  'shared.studio.nodeConfiguration.waitSignal.signalName.label': '信号名',
+  'shared.studio.nodeConfiguration.waitSignal.signalName.placeholder': 'continue',
+  'shared.studio.nodeConfiguration.waitSignal.timeout.label': '超时毫秒',
+  'shared.studio.nodeConfiguration.waitSignal.timeout.placeholder': '60000',
+  'shared.studio.nodeConfiguration.workflowCall.lifecycle.label': '生命周期',
+  'shared.studio.nodeConfiguration.workflowCall.lifecycle.option.inline':
+    '内联调用',
+  'shared.studio.nodeConfiguration.workflowCall.lifecycle.option.scope':
+    '使用 scope Workflow',
+  'shared.studio.nodeConfiguration.workflowCall.workflow.label': 'Workflow',
+  'shared.studio.nodeConfiguration.workflowCall.workflow.placeholder':
+    'child_workflow',
   'teams.members.actions.build': '构建',
   'teams.members.actions.clearEntry': '清除入口成员',
   'teams.members.actions.create': '创建成员',
@@ -366,19 +499,16 @@ const zhCNMessages = {
   'teamMemberWorkflowStudio.header.activation.ready': '就绪',
   'teamMemberWorkflowStudio.header.addNode': '添加节点',
   'teamMemberWorkflowStudio.header.currentTeam': '当前团队',
+  'teamMemberWorkflowStudio.header.deleteConnection': '删除连接',
   'teamMemberWorkflowStudio.header.deleteNode': '删除节点',
   'teamMemberWorkflowStudio.header.editWorkflowName': '编辑 Workflow 名称',
-  'teamMemberWorkflowStudio.header.executeWorkflow': '执行 Workflow',
   'teamMemberWorkflowStudio.header.identityAria': 'Workflow 身份信息',
   'teamMemberWorkflowStudio.header.inputSet': '已设置输入',
   'teamMemberWorkflowStudio.header.nodeActionsAria':
     'Workflow 草稿和节点操作',
-  'teamMemberWorkflowStudio.header.optionalTestPayload': '可选测试载荷',
   'teamMemberWorkflowStudio.header.primaryActionsAria':
     'Workflow 主操作',
-  'teamMemberWorkflowStudio.header.runInput': '运行输入',
-  'teamMemberWorkflowStudio.header.runInputPlaceholder':
-    '本次 Workflow 运行的可选输入',
+  'teamMemberWorkflowStudio.header.runMessage': '运行消息',
   'teamMemberWorkflowStudio.header.runOptionsAria': '运行选项',
   'teamMemberWorkflowStudio.header.runActiveMember': '运行活跃成员',
   'teamMemberWorkflowStudio.header.save': '保存',
@@ -396,18 +526,23 @@ const zhCNMessages = {
   'teamMemberWorkflowStudio.header.teamBreadcrumb': '团队',
   'teamMemberWorkflowStudio.header.unsavedChanges': '有未保存更改',
   'teamMemberWorkflowStudio.header.viewsAria': 'Workflow 视图',
-  'teamMemberWorkflowStudio.header.workflowRun': 'Workflow 运行',
   'teamMemberWorkflowStudio.header.workflowTitleAria': 'Workflow 标题',
-  'teamMemberWorkflowStudio.nodeDetail.apply': '应用',
-  'teamMemberWorkflowStudio.nodeDetail.input': '输入',
-  'teamMemberWorkflowStudio.nodeDetail.inputEmpty':
-    '接入 Workflow 执行后，这里会展示输入预览。',
-  'teamMemberWorkflowStudio.nodeDetail.output': '输出',
-  'teamMemberWorkflowStudio.nodeDetail.outputEmpty':
-    '真实 Workflow 执行结果返回前，这里暂时没有输出。',
-  'teamMemberWorkflowStudio.nodeDetail.parameters': '参数',
-  'teamMemberWorkflowStudio.nodeDetail.parametersAria': '节点参数',
+  'teamMemberWorkflowStudio.nodeDetail.advancedRawConfiguration':
+    '高级原始配置',
+  'teamMemberWorkflowStudio.nodeDetail.advancedRawConfigurationDescription':
+    '只有当节点选项还没有引导字段时才使用这里。',
+  'teamMemberWorkflowStudio.nodeDetail.applyRawConfiguration':
+    '应用原始 JSON',
+  'teamMemberWorkflowStudio.nodeDetail.configuration': '配置',
+  'teamMemberWorkflowStudio.nodeDetail.configurationDescription':
+    '编辑这个节点在草稿运行时会使用的字段。',
+  'teamMemberWorkflowStudio.nodeDetail.noSemanticFields':
+    '这个节点类型暂时没有引导字段。需要时可以使用高级原始配置。',
+  'teamMemberWorkflowStudio.nodeDetail.rawConfigurationAria':
+    '原始节点配置',
   'teamMemberWorkflowStudio.nodeDetail.sectionAria': '节点详情',
+  'teamMemberWorkflowStudio.nodeDetail.stepId': '步骤 ID：{stepId}',
+  'teamMemberWorkflowStudio.nodeDetail.updateNode': '更新节点',
   'teamMemberWorkflowStudio.nodeLibrary.closeAria': '关闭节点库',
   'teamMemberWorkflowStudio.nodeLibrary.emptySearch':
     '没有匹配当前搜索的节点。',
@@ -416,8 +551,12 @@ const zhCNMessages = {
   'teamMemberWorkflowStudio.nodeLibrary.searchPlaceholder': '搜索节点',
   'teamMemberWorkflowStudio.nodeLibrary.sectionAria': '节点库',
   'teamMemberWorkflowStudio.nodeLibrary.title': '节点库',
-  'teamMemberWorkflowStudio.runOptionsPanel.inputPlaceholder':
-    '本次活跃成员运行的可选输入',
+  'teamMemberWorkflowStudio.resize.executionPanel': '调整运行控制台大小',
+  'teamMemberWorkflowStudio.resize.sidePanel': '调整侧边面板大小',
+  'teamMemberWorkflowStudio.runOptionsPanel.messageLabel':
+    '发送给活跃成员的消息',
+  'teamMemberWorkflowStudio.runOptionsPanel.messagePlaceholder':
+    '本次运行可选发送给活跃成员的消息',
   'teamMemberWorkflowStudio.runOptionsPanel.sectionAria': '运行选项面板',
   'teamMemberWorkflowStudio.runOptionsPanel.title': '运行选项',
   'teamMemberWorkflowStudio.runsPanel.description':

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioCanvas.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioCanvas.tsx
@@ -14,9 +14,12 @@ type WorkflowStudioCanvasProps = {
   readonly onAddFirstStep?: () => void;
   readonly onCanvasSelect?: () => void;
   readonly onConnectNodes?: (sourceNodeId: string, targetNodeId: string) => void;
+  readonly onDeleteEdges?: (edgeIds: string[]) => Promise<void> | void;
   readonly onDeleteNodes?: (nodeIds: string[]) => Promise<void> | void;
+  readonly onEdgeSelect?: (edgeId: string) => void;
   readonly onNodeLayoutChange?: (nodes: Node<StudioGraphNodeData>[]) => void;
   readonly onNodeSelect?: (nodeId: string) => void;
+  readonly selectedEdgeId?: string;
   readonly selectedNodeId?: string;
 };
 
@@ -27,9 +30,12 @@ const WorkflowStudioCanvas: React.FC<WorkflowStudioCanvasProps> = ({
   onAddFirstStep,
   onCanvasSelect,
   onConnectNodes,
+  onDeleteEdges,
   onDeleteNodes,
+  onEdgeSelect,
   onNodeLayoutChange,
   onNodeSelect,
+  selectedEdgeId,
   selectedNodeId,
 }) => (
   <div
@@ -60,9 +66,12 @@ const WorkflowStudioCanvas: React.FC<WorkflowStudioCanvasProps> = ({
       }
       onCanvasSelect={onCanvasSelect}
       onConnectNodes={onConnectNodes}
+      onDeleteEdges={onDeleteEdges}
       onDeleteNodes={onDeleteNodes}
+      onEdgeSelect={onEdgeSelect}
       onNodeLayoutChange={onNodeLayoutChange as (nodes: Node[]) => void}
       onNodeSelect={onNodeSelect}
+      selectedEdgeId={selectedEdgeId}
       selectedNodeId={selectedNodeId}
       variant="studio"
     />

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioExecutionPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioExecutionPanel.tsx
@@ -7,11 +7,13 @@ import type { StudioExecutionDetail } from "@/shared/studio/models";
 type WorkflowStudioExecutionPanelProps = {
   readonly detail: StudioExecutionDetail | null;
   readonly error?: string;
+  readonly height?: number;
 };
 
 const WorkflowStudioExecutionPanel: React.FC<WorkflowStudioExecutionPanelProps> = ({
   detail,
   error,
+  height = 210,
 }) => {
   const trace = React.useMemo(() => buildExecutionTrace(detail), [detail]);
   const rawFrames = detail?.frames ?? [];
@@ -31,7 +33,7 @@ const WorkflowStudioExecutionPanel: React.FC<WorkflowStudioExecutionPanelProps> 
         background: "#ffffff",
         borderTop: "1px solid #e5e7eb",
         display: "grid",
-        flex: "0 0 210px",
+        flex: `0 0 ${height}px`,
         gap: 10,
         gridTemplateRows: "minmax(0, 1fr)",
         minHeight: 0,
@@ -41,9 +43,9 @@ const WorkflowStudioExecutionPanel: React.FC<WorkflowStudioExecutionPanelProps> 
       <section
         data-testid="member-run-result-panel"
         style={{
-          display: "grid",
+          display: "flex",
+          flexDirection: "column",
           gap: 8,
-          gridTemplateRows: "auto minmax(0, 1fr)",
           minHeight: 0,
           minWidth: 0,
         }}
@@ -75,8 +77,9 @@ const WorkflowStudioExecutionPanel: React.FC<WorkflowStudioExecutionPanelProps> 
             <div
               style={{
                 display: "grid",
+                flex: 1,
                 gap: 6,
-                maxHeight: 130,
+                minHeight: 0,
                 overflow: "auto",
               }}
             >

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioHeader.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioHeader.tsx
@@ -34,6 +34,7 @@ type WorkflowStudioHeaderProps = {
   readonly activeMemberRunPlaceholderReason?: string;
   readonly onPublishMember: () => void;
   readonly onAddNode: () => void;
+  readonly onDeleteConnection: () => void;
   readonly onDeleteNode: () => void;
   readonly onOpenRunOptions: () => void;
   readonly onRunActiveMember: () => void;
@@ -42,6 +43,7 @@ type WorkflowStudioHeaderProps = {
   readonly onTitleChange: (title: string) => void;
   readonly savePending: boolean;
   readonly savePlaceholderReason?: string;
+  readonly selectedEdgeId: string;
   readonly selectedNodeId: string;
   readonly selectedTab: "editor" | "runs";
   readonly onTabChange: (tab: "editor" | "runs") => void;
@@ -373,61 +375,73 @@ const HeaderTabs: React.FC<HeaderTabsProps> = ({
 
 type HeaderNodeActionsProps = {
   readonly canSave: boolean;
+  readonly onDeleteConnection: () => void;
   readonly onDeleteNode: () => void;
   readonly onSave: () => void;
   readonly savePending: boolean;
   readonly savePlaceholderReason?: string;
+  readonly selectedEdgeId: string;
   readonly selectedNodeId: string;
 };
 
 const HeaderNodeActions: React.FC<HeaderNodeActionsProps> = ({
   canSave,
+  onDeleteConnection,
   onDeleteNode,
   onSave,
   savePending,
   savePlaceholderReason,
+  selectedEdgeId,
   selectedNodeId,
-}) => (
-  <section
-    aria-label={t(
-      "teamMemberWorkflowStudio.header.nodeActionsAria",
-      "Workflow draft and node actions",
-    )}
-    data-testid="workflow-header-node-actions"
-    style={{
-      alignItems: "center",
-      display: "flex",
-      flexWrap: "wrap",
-      gap: 8,
-      justifyContent: "flex-end",
-      minWidth: 0,
-    }}
-  >
-    <Button
-      disabled={!selectedNodeId}
-      icon={<DeleteOutlined />}
-      onClick={onDeleteNode}
-      size="small"
+}) => {
+  const hasSelectedConnection = Boolean(selectedEdgeId);
+  const hasSelectedNode = Boolean(selectedNodeId);
+  const deleteLabel = hasSelectedConnection
+    ? t("teamMemberWorkflowStudio.header.deleteConnection", "Delete connection")
+    : t("teamMemberWorkflowStudio.header.deleteNode", "Delete node");
+
+  return (
+    <section
+      aria-label={t(
+        "teamMemberWorkflowStudio.header.nodeActionsAria",
+        "Workflow draft and node actions",
+      )}
+      data-testid="workflow-header-node-actions"
+      style={{
+        alignItems: "center",
+        display: "flex",
+        flexWrap: "wrap",
+        gap: 8,
+        justifyContent: "flex-end",
+        minWidth: 0,
+      }}
     >
-      {t("teamMemberWorkflowStudio.header.deleteNode", "Delete node")}
-    </Button>
-    <Button
-      disabled={!canSave}
-      icon={<SaveOutlined />}
-      loading={savePending}
-      onClick={onSave}
-      size="small"
-      title={
-        canSave
-          ? t("teamMemberWorkflowStudio.header.saveDraft", "Save draft")
-          : savePlaceholderReason
-      }
-      type="primary"
-    >
-      {t("teamMemberWorkflowStudio.header.save", "Save")}
-    </Button>
-  </section>
-);
+      <Button
+        disabled={!hasSelectedConnection && !hasSelectedNode}
+        icon={<DeleteOutlined />}
+        onClick={hasSelectedConnection ? onDeleteConnection : onDeleteNode}
+        size="small"
+      >
+        {deleteLabel}
+      </Button>
+      <Button
+        disabled={!canSave}
+        icon={<SaveOutlined />}
+        loading={savePending}
+        onClick={onSave}
+        size="small"
+        title={
+          canSave
+            ? t("teamMemberWorkflowStudio.header.saveDraft", "Save draft")
+            : savePlaceholderReason
+        }
+        type="primary"
+      >
+        {t("teamMemberWorkflowStudio.header.save", "Save")}
+      </Button>
+    </section>
+  );
+};
 
 const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
   memberPublished,
@@ -443,6 +457,7 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
   activeMemberRunPlaceholderReason,
   onPublishMember,
   onAddNode,
+  onDeleteConnection,
   onDeleteNode,
   onOpenRunOptions,
   onRunActiveMember,
@@ -451,6 +466,7 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
   onTitleChange,
   savePending,
   savePlaceholderReason,
+  selectedEdgeId,
   selectedNodeId,
   selectedTab,
   onTabChange,
@@ -534,10 +550,12 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
         <HeaderTabs onTabChange={onTabChange} selectedTab={selectedTab} />
         <HeaderNodeActions
           canSave={canSave}
+          onDeleteConnection={onDeleteConnection}
           onDeleteNode={onDeleteNode}
           onSave={onSave}
           savePending={savePending}
           savePlaceholderReason={savePlaceholderReason}
+          selectedEdgeId={selectedEdgeId}
           selectedNodeId={selectedNodeId}
         />
       </div>

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioNodeDetailPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioNodeDetailPanel.tsx
@@ -1,33 +1,149 @@
-import { Alert, Button, Input, Space, Typography } from "antd";
+import { Alert, Button, Collapse, Input, Select, Space, Typography } from "antd";
 import React from "react";
-import { t } from "@/shared/i18n/messages";
+import {
+  applyStudioNodeConfigurationValues,
+  formatRawStudioNodeConfiguration,
+  getStudioNodeConfigurationSchema,
+  readStudioNodeConfigurationValues,
+  type StudioNodeConfigurationField,
+} from "@/shared/studio/nodeConfiguration";
+import { formatConsoleMessage, t } from "@/shared/i18n/messages";
 import type { StudioStepInspectorDraft } from "@/shared/studio/document";
+import { parseInspectorParameters } from "@/shared/studio/document";
 import { formatStudioStepTypeLabel } from "@/shared/studio/graph";
 
 type WorkflowStudioNodeDetailPanelProps = {
   readonly error?: string;
   readonly onClose: () => void;
-  readonly onParametersChange: (parametersText: string) => void;
+  readonly onConfigurationChange: (parametersText: string) => void;
   readonly stepDraft: StudioStepInspectorDraft | null;
+  readonly width?: number;
 };
+
+const fieldStackStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 6,
+};
+
+function readDraftParameters(stepDraft: StudioStepInspectorDraft): Record<string, unknown> {
+  try {
+    return parseInspectorParameters(stepDraft.parametersText);
+  } catch {
+    return {};
+  }
+}
+
+function useConfigurationState(stepDraft: StudioStepInspectorDraft | null) {
+  const [configurationValues, setConfigurationValues] = React.useState<
+    Record<string, string>
+  >({});
+  const [rawConfigurationText, setRawConfigurationText] = React.useState("");
+
+  React.useEffect(() => {
+    if (!stepDraft) {
+      setConfigurationValues({});
+      setRawConfigurationText("");
+      return;
+    }
+
+    const parameters = readDraftParameters(stepDraft);
+    setConfigurationValues(
+      readStudioNodeConfigurationValues(stepDraft.type, parameters),
+    );
+    setRawConfigurationText(formatRawStudioNodeConfiguration(parameters));
+  }, [stepDraft?.id, stepDraft?.parametersText, stepDraft?.type]);
+
+  return {
+    configurationValues,
+    rawConfigurationText,
+    setConfigurationValues,
+    setRawConfigurationText,
+  };
+}
 
 const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps> = ({
   error,
   onClose,
-  onParametersChange,
+  onConfigurationChange,
   stepDraft,
+  width = 420,
 }) => {
-  const [parametersText, setParametersText] = React.useState(
-    stepDraft?.parametersText ?? "",
-  );
-
-  React.useEffect(() => {
-    setParametersText(stepDraft?.parametersText ?? "");
-  }, [stepDraft?.id, stepDraft?.parametersText]);
+  const {
+    configurationValues,
+    rawConfigurationText,
+    setConfigurationValues,
+    setRawConfigurationText,
+  } = useConfigurationState(stepDraft);
 
   if (!stepDraft) {
     return null;
   }
+
+  const schema = getStudioNodeConfigurationSchema(stepDraft.type);
+  const hasSemanticFields = schema.fields.length > 0;
+  const nodeTypeLabel = formatStudioStepTypeLabel(stepDraft.type);
+
+  const updateFieldValue = (fieldName: string, value: string) => {
+    setConfigurationValues((current) => ({
+      ...current,
+      [fieldName]: value,
+    }));
+  };
+
+  const applyConfigurationToDraft = () => {
+    const nextParameters = applyStudioNodeConfigurationValues(
+      stepDraft.type,
+      readDraftParameters(stepDraft),
+      configurationValues,
+    );
+    onConfigurationChange(formatRawStudioNodeConfiguration(nextParameters));
+  };
+
+  const applyRawConfigurationToDraft = () => {
+    onConfigurationChange(rawConfigurationText);
+  };
+
+  const renderFieldControl = (field: StudioNodeConfigurationField) => {
+    const value = configurationValues[field.name] ?? "";
+    if (field.kind === "select") {
+      return (
+        <Select
+          aria-label={formatConsoleMessage(field.label)}
+          onChange={(nextValue) => updateFieldValue(field.name, nextValue)}
+          options={(field.options ?? []).map((option) => ({
+            label: formatConsoleMessage(option.label),
+            value: option.value,
+          }))}
+          value={value || undefined}
+        />
+      );
+    }
+
+    if (field.kind === "multi-line") {
+      return (
+        <Input.TextArea
+          aria-label={formatConsoleMessage(field.label)}
+          autoSize={{ minRows: 4, maxRows: 10 }}
+          onChange={(event) => updateFieldValue(field.name, event.target.value)}
+          placeholder={
+            field.placeholder ? formatConsoleMessage(field.placeholder) : undefined
+          }
+          value={value}
+        />
+      );
+    }
+
+    return (
+      <Input
+        aria-label={formatConsoleMessage(field.label)}
+        onChange={(event) => updateFieldValue(field.name, event.target.value)}
+        placeholder={
+          field.placeholder ? formatConsoleMessage(field.placeholder) : undefined
+        }
+        value={value}
+      />
+    );
+  };
 
   return (
     <aside
@@ -42,7 +158,7 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
         flexDirection: "column",
         flexShrink: 0,
         minHeight: 0,
-        width: 420,
+        width,
       }}
     >
       <header
@@ -54,12 +170,14 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
         <Space align="start" style={{ justifyContent: "space-between", width: "100%" }}>
           <div style={{ minWidth: 0 }}>
             <Typography.Text strong style={{ color: "#111827", fontSize: 16 }}>
-              {stepDraft.id}
+              {nodeTypeLabel}
             </Typography.Text>
             <Typography.Paragraph
               style={{ color: "#6b7280", margin: "2px 0 0" }}
             >
-              {formatStudioStepTypeLabel(stepDraft.type)}
+              {t("teamMemberWorkflowStudio.nodeDetail.stepId", "Step ID: {stepId}", {
+                stepId: stepDraft.id,
+              })}
             </Typography.Paragraph>
           </div>
           <Button onClick={onClose} size="small">
@@ -70,51 +188,125 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
       <div
         style={{
           display: "grid",
-          gap: 14,
+          gap: 16,
           overflow: "auto",
           padding: 18,
         }}
       >
-        <section>
+        <section style={{ display: "grid", gap: 14 }}>
           <Space
-            align="center"
+            align="start"
             style={{ justifyContent: "space-between", width: "100%" }}
           >
-            <Typography.Text strong>
-              {t("teamMemberWorkflowStudio.nodeDetail.parameters", "Parameters")}
-            </Typography.Text>
+            <div style={{ minWidth: 0 }}>
+              <Typography.Text strong>
+                {t(
+                  "teamMemberWorkflowStudio.nodeDetail.configuration",
+                  "Configuration",
+                )}
+              </Typography.Text>
+              <Typography.Paragraph
+                style={{ color: "#6b7280", margin: "2px 0 0" }}
+              >
+                {t(
+                  "teamMemberWorkflowStudio.nodeDetail.configurationDescription",
+                  "Edit the fields this node uses when the draft runs.",
+                )}
+              </Typography.Paragraph>
+            </div>
             <Button
-              onClick={() => onParametersChange(parametersText)}
+              onClick={applyConfigurationToDraft}
               size="small"
               type="primary"
             >
-              {t("teamMemberWorkflowStudio.nodeDetail.apply", "Apply")}
+              {t(
+                "teamMemberWorkflowStudio.nodeDetail.updateNode",
+                "Update node",
+              )}
             </Button>
           </Space>
-          <Input.TextArea
-            aria-label={t(
-              "teamMemberWorkflowStudio.nodeDetail.parametersAria",
-              "Node parameters",
-            )}
-            autoSize={{ minRows: 9, maxRows: 18 }}
-            onChange={(event) => setParametersText(event.target.value)}
-            spellCheck={false}
-            style={{
-              fontFamily:
-                "SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace",
-              marginTop: 8,
-            }}
-            value={parametersText}
-          />
+
+          {hasSemanticFields ? (
+            schema.fields.map((field) => (
+              <div key={field.name} style={fieldStackStyle}>
+                <Typography.Text strong style={{ color: "#374151", fontSize: 13 }}>
+                  {formatConsoleMessage(field.label)}
+                </Typography.Text>
+                {renderFieldControl(field)}
+                {field.description ? (
+                  <Typography.Text style={{ color: "#6b7280", fontSize: 12 }}>
+                    {formatConsoleMessage(field.description)}
+                  </Typography.Text>
+                ) : null}
+              </div>
+            ))
+          ) : (
+            <Alert
+              message={t(
+                "teamMemberWorkflowStudio.nodeDetail.noSemanticFields",
+                "This node type does not have guided fields yet. Use advanced raw configuration when needed.",
+              )}
+              showIcon
+              type="info"
+            />
+          )}
+
           {error ? (
             <Alert
               message={error}
               showIcon
-              style={{ marginTop: 10 }}
               type="error"
             />
           ) : null}
         </section>
+
+        <Collapse
+          bordered={false}
+          items={[
+            {
+              key: "raw-configuration",
+              label: t(
+                "teamMemberWorkflowStudio.nodeDetail.advancedRawConfiguration",
+                "Advanced raw configuration",
+              ),
+              children: (
+                <div style={{ display: "grid", gap: 10 }}>
+                  <Typography.Paragraph style={{ color: "#6b7280", margin: 0 }}>
+                    {t(
+                      "teamMemberWorkflowStudio.nodeDetail.advancedRawConfigurationDescription",
+                      "Use this only when a node option is not available as a guided field.",
+                    )}
+                  </Typography.Paragraph>
+                  <Input.TextArea
+                    aria-label={t(
+                      "teamMemberWorkflowStudio.nodeDetail.rawConfigurationAria",
+                      "Raw node configuration",
+                    )}
+                    autoSize={{ minRows: 8, maxRows: 16 }}
+                    onChange={(event) => setRawConfigurationText(event.target.value)}
+                    spellCheck={false}
+                    style={{
+                      fontFamily:
+                        "SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace",
+                    }}
+                    value={rawConfigurationText}
+                  />
+                  <Button onClick={applyRawConfigurationToDraft} size="small">
+                    {t(
+                      "teamMemberWorkflowStudio.nodeDetail.applyRawConfiguration",
+                      "Apply raw JSON",
+                    )}
+                  </Button>
+                </div>
+              ),
+            },
+          ]}
+          style={{
+            background: "#f9fafb",
+            border: "1px solid #e5e7eb",
+            borderRadius: 8,
+          }}
+        />
       </div>
     </aside>
   );

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioRunOptionsPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioRunOptionsPanel.tsx
@@ -4,16 +4,18 @@ import { t } from "@/shared/i18n/messages";
 
 type WorkflowStudioRunOptionsPanelProps = {
   readonly onClose: () => void;
-  readonly onRunInputChange: (input: string) => void;
+  readonly onRunMessageChange: (message: string) => void;
   readonly open: boolean;
-  readonly runInput: string;
+  readonly runMessage: string;
+  readonly width?: number;
 };
 
 const WorkflowStudioRunOptionsPanel: React.FC<WorkflowStudioRunOptionsPanelProps> = ({
   onClose,
-  onRunInputChange,
+  onRunMessageChange,
   open,
-  runInput,
+  runMessage,
+  width = 420,
 }) => {
   if (!open) {
     return null;
@@ -32,7 +34,7 @@ const WorkflowStudioRunOptionsPanel: React.FC<WorkflowStudioRunOptionsPanelProps
         flexDirection: "column",
         flexShrink: 0,
         minHeight: 0,
-        width: 420,
+        width,
       }}
     >
       <header
@@ -62,20 +64,26 @@ const WorkflowStudioRunOptionsPanel: React.FC<WorkflowStudioRunOptionsPanelProps
       >
         <section>
           <Typography.Text strong>
-            {t("teamMemberWorkflowStudio.header.runInput", "Run input")}
+            {t(
+              "teamMemberWorkflowStudio.runOptionsPanel.messageLabel",
+              "Message to active member",
+            )}
           </Typography.Text>
           <Input.TextArea
-            aria-label={t("teamMemberWorkflowStudio.header.runInput", "Run input")}
+            aria-label={t(
+              "teamMemberWorkflowStudio.runOptionsPanel.messageLabel",
+              "Message to active member",
+            )}
             autoSize={{ minRows: 8, maxRows: 16 }}
-            onChange={(event) => onRunInputChange(event.target.value)}
+            onChange={(event) => onRunMessageChange(event.target.value)}
             placeholder={t(
-              "teamMemberWorkflowStudio.runOptionsPanel.inputPlaceholder",
-              "Optional input for this active member run",
+              "teamMemberWorkflowStudio.runOptionsPanel.messagePlaceholder",
+              "Optional message sent with this active member run",
             )}
             style={{
               marginTop: 8,
             }}
-            value={runInput}
+            value={runMessage}
           />
         </section>
       </div>

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -17,6 +17,7 @@ import {
   connectStepToTarget,
   createStepInspectorDraft,
   insertStepByType,
+  removeStepConnection,
   removeStep,
   type StudioStepInspectorDraft,
 } from "@/shared/studio/document";
@@ -56,7 +57,7 @@ type SavedWorkflowDraft = {
 
 type RunActiveMemberVariables = {
   readonly memberId: string;
-  readonly runInput: string;
+  readonly runMessage: string;
   readonly publishedServiceId: string;
   readonly title: string;
   readonly workflowId?: string;
@@ -87,6 +88,7 @@ type TeamMemberWorkflowStudioState = {
   readonly canSave: boolean;
   readonly closeNodeLibrary: () => void;
   readonly connectNodes: (sourceNodeId: string, targetNodeId: string) => void;
+  readonly deleteSelectedConnection: () => void;
   readonly deleteSelectedNode: () => void;
   readonly dirty: boolean;
   readonly emptyDescription: string;
@@ -95,7 +97,7 @@ type TeamMemberWorkflowStudioState = {
   readonly activeMemberRunPlaceholderReason: string;
   readonly executionDetail: StudioExecutionDetail | null;
   readonly executionError: string;
-  readonly executionRunInput: string;
+  readonly executionRunMessage: string;
   readonly executionStatus: WorkflowExecutionStatus;
   readonly memberRuns: readonly StudioExecutionSummary[];
   readonly memberRunsEmptyReason: string;
@@ -116,15 +118,17 @@ type TeamMemberWorkflowStudioState = {
   readonly savePending: boolean;
   readonly savePlaceholderReason: string;
   readonly runOptionsOpen: boolean;
+  readonly selectedEdgeId: string;
   readonly selectedNodeId: string;
   readonly selectedStepDraft: StudioStepInspectorDraft | null;
-  readonly selectedStepParameterError: string;
+  readonly selectedStepConfigurationError: string;
   readonly selectedTab: "editor" | "runs";
   readonly setSelectedTab: (tab: "editor" | "runs") => void;
-  readonly updateSelectedStepParameters: (parametersText: string) => void;
+  readonly updateSelectedStepConfiguration: (parametersText: string) => void;
   readonly selectCanvas: () => void;
+  readonly selectEdge: (edgeId: string) => void;
   readonly selectNode: (nodeId: string) => void;
-  readonly setExecutionRunInput: (input: string) => void;
+  readonly setExecutionRunMessage: (message: string) => void;
   readonly setWorkflowTitle: (title: string) => void;
   readonly teamName: string;
   readonly workflowTitle: string;
@@ -204,6 +208,54 @@ function readStepIdFromGraphNodeId(nodeId: string): string {
   return normalized.startsWith("step:")
     ? normalized.slice("step:".length).trim()
     : normalized;
+}
+
+function readConnectionFromGraphEdgeId(edgeId: string): {
+  readonly branchLabel: string | null;
+  readonly sourceStepId: string;
+  readonly targetStepId: string;
+} | null {
+  const normalized = trimOptional(edgeId);
+  if (!normalized.startsWith("edge:")) {
+    return null;
+  }
+
+  const [, sourceStepId, targetStepId, edgeKind, ...labelParts] =
+    normalized.split(":");
+  if (!sourceStepId || !targetStepId) {
+    return null;
+  }
+
+  if (edgeKind === "linear") {
+    return {
+      branchLabel: null,
+      sourceStepId,
+      targetStepId,
+    };
+  }
+
+  if (edgeKind === "branch") {
+    const branchLabel = labelParts.join(":");
+    if (!branchLabel) {
+      return null;
+    }
+
+    return {
+      branchLabel,
+      sourceStepId,
+      targetStepId,
+    };
+  }
+
+  const legacyEdgeLabel = [edgeKind, ...labelParts]
+    .filter(Boolean)
+    .join(":");
+  return {
+    branchLabel:
+      legacyEdgeLabel && legacyEdgeLabel !== "next" ? legacyEdgeLabel : null,
+    sourceStepId,
+    targetStepId,
+  };
 }
 
 function waitForBindingRunPollTick(): Promise<void> {
@@ -493,16 +545,17 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
   const [executionDetail, setExecutionDetail] =
     React.useState<StudioExecutionDetail | null>(null);
   const [executionError, setExecutionError] = React.useState("");
-  const [executionRunInput, setExecutionRunInput] = React.useState("");
+  const [executionRunMessage, setExecutionRunMessage] = React.useState("");
   const [publishBindingRun, setPublishBindingRun] =
     React.useState<StudioMemberBindingRunStatusResponse | null>(null);
   const [publishError, setPublishError] = React.useState("");
   const [nodeLibraryOpen, setNodeLibraryOpen] = React.useState(false);
   const [runOptionsOpen, setRunOptionsOpen] = React.useState(false);
+  const [selectedEdgeId, setSelectedEdgeId] = React.useState("");
   const [selectedNodeId, setSelectedNodeId] = React.useState("");
   const [selectedTab, setSelectedTab] =
     React.useState<"editor" | "runs">("editor");
-  const [selectedStepParameterError, setSelectedStepParameterError] =
+  const [selectedStepConfigurationError, setSelectedStepConfigurationError] =
     React.useState("");
   const [workflowTitle, setWorkflowTitleState] =
     React.useState("Untitled member");
@@ -643,6 +696,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     });
     setEditableLayout(workflowQuery.data?.layout ?? null);
     setWorkflowTitleState(nextTitle);
+    setSelectedEdgeId("");
     setSelectedNodeId("");
     setRunOptionsOpen(false);
     setDirty(false);
@@ -685,7 +739,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     mutationFn: async ({
       memberId,
       publishedServiceId,
-      runInput,
+      runMessage,
       title,
       workflowId,
     }: RunActiveMemberVariables): Promise<StudioExecutionDetail> => {
@@ -694,7 +748,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       }
 
       const normalizedTitle = trimOptional(title) || "Member run";
-      const runMessage = trimOptional(runInput) || `Run ${normalizedTitle}`;
+      const resolvedRunMessage = trimOptional(runMessage) || `Run ${normalizedTitle}`;
       const startedAtUtc = new Date().toISOString();
       const executionId = `invoke:${memberId}:${Date.now().toString(36)}`;
       const frames: StudioExecutionFrame[] = [];
@@ -711,7 +765,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
           error,
           executionId,
           frames,
-          runMessage,
+          runMessage: resolvedRunMessage,
           serviceId: publishedServiceId,
           startedAtUtc,
           status,
@@ -729,7 +783,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
                   workflowId,
                 }
               : undefined,
-            prompt: runMessage,
+            prompt: resolvedRunMessage,
           },
           controller.signal,
           {
@@ -1099,6 +1153,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
 
       setEditableDocument(nextDocument);
       setEditableLayout(nextLayout);
+      setSelectedEdgeId("");
       setSelectedNodeId(result.nodeId);
       setNodeLibraryOpen(false);
       setDirty(true);
@@ -1130,6 +1185,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
         targetStepId,
       );
       setEditableDocument(result.document);
+      setSelectedEdgeId("");
       setSelectedNodeId(result.nodeId);
       setDirty(true);
     },
@@ -1159,10 +1215,32 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
 
     const result = removeStep(editableDocument, selectedStepId);
     setEditableDocument(result.document);
+    setSelectedEdgeId("");
     setSelectedNodeId(result.nodeId);
     setDirty(true);
   }, [editableDocument, selectedNodeId]);
-  const updateSelectedStepParameters = React.useCallback(
+  const deleteSelectedConnection = React.useCallback(() => {
+    if (!editableDocument || !selectedEdgeId) {
+      return;
+    }
+
+    const connection = readConnectionFromGraphEdgeId(selectedEdgeId);
+    if (!connection) {
+      return;
+    }
+
+    const result = removeStepConnection(
+      editableDocument,
+      connection.sourceStepId,
+      connection.targetStepId,
+      connection.branchLabel,
+    );
+    setEditableDocument(result.document);
+    setSelectedEdgeId("");
+    setSelectedNodeId(result.nodeId);
+    setDirty(true);
+  }, [editableDocument, selectedEdgeId]);
+  const updateSelectedStepConfiguration = React.useCallback(
     (parametersText: string) => {
       if (!editableDocument || !selectedStepDraft) {
         return;
@@ -1178,14 +1256,15 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
           },
         );
         setEditableDocument(result.document);
+        setSelectedEdgeId("");
         setSelectedNodeId(result.nodeId);
-        setSelectedStepParameterError("");
+        setSelectedStepConfigurationError("");
         setDirty(true);
       } catch (error) {
-        setSelectedStepParameterError(
+        setSelectedStepConfigurationError(
           error instanceof Error
             ? error.message
-            : "Step parameters must be a JSON object.",
+            : "Raw node configuration must be a JSON object.",
         );
       }
     },
@@ -1216,6 +1295,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     canSave,
     closeNodeLibrary: () => setNodeLibraryOpen(false),
     connectNodes,
+    deleteSelectedConnection,
     deleteSelectedNode,
     dirty,
     emptyDescription:
@@ -1229,7 +1309,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
         activeMemberRunMutation.mutate({
           memberId: route.memberId,
           publishedServiceId: memberPublishedServiceId,
-          runInput: trimOptional(executionRunInput),
+          runMessage: trimOptional(executionRunMessage),
           title: workflowTitle,
           workflowId: stableWorkflowId || undefined,
         });
@@ -1239,7 +1319,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     activeMemberRunPlaceholderReason,
     executionDetail,
     executionError,
-    executionRunInput,
+    executionRunMessage,
     executionStatus,
     memberRuns: scopedMemberRuns,
     memberRunsEmptyReason,
@@ -1280,6 +1360,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     openNodeLibrary: () => setNodeLibraryOpen(true),
     openRunOptions: () => {
       setSelectedTab("editor");
+      setSelectedEdgeId("");
       setSelectedNodeId("");
       setRunOptionsOpen(true);
     },
@@ -1298,23 +1379,31 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     savePending: saveMutation.isPending,
     savePlaceholderReason,
     runOptionsOpen,
+    selectedEdgeId,
     selectedNodeId,
     selectedStepDraft,
-    selectedStepParameterError,
+    selectedStepConfigurationError,
     selectedTab,
     selectCanvas: () => {
+      setSelectedEdgeId("");
+      setSelectedNodeId("");
+      setRunOptionsOpen(false);
+    },
+    selectEdge: (edgeId: string) => {
+      setSelectedEdgeId(edgeId);
       setSelectedNodeId("");
       setRunOptionsOpen(false);
     },
     selectNode: (nodeId: string) => {
+      setSelectedEdgeId("");
       setSelectedNodeId(nodeId);
       setRunOptionsOpen(false);
     },
-    setExecutionRunInput,
+    setExecutionRunMessage,
     setSelectedTab,
     setWorkflowTitle,
     teamName,
-    updateSelectedStepParameters,
+    updateSelectedStepConfiguration,
     workflowTitle,
   };
 }

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -14,8 +14,10 @@ jest.mock("@/shared/graphs/GraphCanvas", () => ({
   __esModule: true,
   default: (props: {
     nodes?: Array<{ id?: string; position?: { x: number; y: number } }>;
+    edges?: Array<{ id?: string }>;
     onCanvasSelect?: () => void;
     onConnectNodes?: (sourceNodeId: string, targetNodeId: string) => void;
+    onEdgeSelect?: (edgeId: string) => void;
     onNodeLayoutChange?: (
       nodes: Array<{ id?: string; position?: { x: number; y: number } }>,
     ) => void;
@@ -40,6 +42,17 @@ jest.mock("@/shared/graphs/GraphCanvas", () => ({
             type: "button",
           },
           `node:${node.id}`,
+        ),
+      ),
+      props.edges?.map((edge) =>
+        React.createElement(
+          "button",
+          {
+            key: edge.id,
+            onClick: () => props.onEdgeSelect?.(String(edge.id ?? "")),
+            type: "button",
+          },
+          `edge:${edge.id}`,
         ),
       ),
       React.createElement(
@@ -601,7 +614,203 @@ describe("TeamMemberWorkflowStudioPage", () => {
     });
   });
 
-  it("opens node detail and applies parameter edits into the workflow document", async () => {
+  it("deletes a selected connection without deleting either node", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1/t-alpha/members/member-alpha/workflow",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "workflow-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: null,
+        lifecycleStage: "created",
+        memberId: "member-alpha",
+        publishedServiceId: "",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "workflow-alpha.yaml",
+      filePath: "scope://scope-1/workflow-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "workflow-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: {
+        ...mockWorkflowDocument,
+        steps: [
+          {
+            id: "triage",
+            type: "llm_call",
+            targetRole: "assistant",
+            parameters: {},
+            next: "publish",
+            branches: {},
+          },
+          {
+            id: "publish",
+            type: "emit",
+            targetRole: null,
+            parameters: {},
+            next: null,
+            branches: {},
+          },
+        ],
+      },
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+    (studioApi.saveWorkflow as jest.Mock).mockResolvedValue({
+      workflowId: "workflow-alpha",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByText("nodes:2")).toBeTruthy();
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "edge:edge:triage:publish:linear" }),
+    );
+    expect(
+      screen.getByRole("button", { name: "Delete connection" }),
+    ).toBeEnabled();
+    fireEvent.click(screen.getByRole("button", { name: "Delete connection" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(studioApi.serializeYaml).toHaveBeenCalledWith(
+        expect.objectContaining({
+          document: expect.objectContaining({
+            steps: expect.arrayContaining([
+              expect.objectContaining({
+                id: "triage",
+                next: null,
+              }),
+              expect.objectContaining({
+                id: "publish",
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
+  });
+
+  it("deletes a branch labeled next without touching the linear next connection", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1/t-alpha/members/member-alpha/workflow",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "workflow-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: null,
+        lifecycleStage: "created",
+        memberId: "member-alpha",
+        publishedServiceId: "",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "workflow-alpha.yaml",
+      filePath: "scope://scope-1/workflow-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "workflow-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: {
+        ...mockWorkflowDocument,
+        steps: [
+          {
+            id: "guard",
+            type: "conditional",
+            targetRole: null,
+            parameters: {},
+            next: "linear_target",
+            branches: {
+              next: "branch_target",
+            },
+          },
+          {
+            id: "linear_target",
+            type: "emit",
+            targetRole: null,
+            parameters: {},
+            next: null,
+            branches: {},
+          },
+          {
+            id: "branch_target",
+            type: "emit",
+            targetRole: null,
+            parameters: {},
+            next: null,
+            branches: {},
+          },
+        ],
+      },
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByText("nodes:3")).toBeTruthy();
+    });
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "edge:edge:guard:branch_target:branch:next",
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Delete connection" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(studioApi.serializeYaml).toHaveBeenCalledWith(
+        expect.objectContaining({
+          document: expect.objectContaining({
+            steps: expect.arrayContaining([
+              expect.objectContaining({
+                branches: {},
+                id: "guard",
+                next: "linear_target",
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
+  });
+
+  it("opens node detail and applies guided configuration edits into the workflow document", async () => {
     window.history.replaceState(
       {},
       "",
@@ -652,17 +861,20 @@ describe("TeamMemberWorkflowStudioPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "node:step:triage" }));
     expect(screen.getByLabelText("Node detail")).toBeTruthy();
     expect(screen.getByText("LLM call")).toBeTruthy();
+    expect(screen.getByText("Step ID: triage")).toBeTruthy();
     expect(screen.queryByText("llm_call")).toBeNull();
     expect(screen.queryByText("Input")).toBeNull();
-    expect(screen.getByText("Parameters")).toBeTruthy();
+    expect(screen.getByText("Configuration")).toBeTruthy();
+    expect(screen.getByLabelText("Instruction")).toHaveValue("Triage the request");
+    expect(screen.queryByText("Parameters")).toBeNull();
+    expect(screen.queryByLabelText("Raw node configuration")).toBeNull();
+    expect(screen.queryByText(/prompt_prefix/)).toBeNull();
     expect(screen.queryByText("Output")).toBeNull();
 
-    fireEvent.change(screen.getByLabelText("Node parameters"), {
-      target: {
-        value: '{\n  "prompt_prefix": "Updated instruction"\n}',
-      },
+    fireEvent.change(screen.getByLabelText("Instruction"), {
+      target: { value: "Updated instruction" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    fireEvent.click(screen.getByRole("button", { name: "Update node" }));
     expect(screen.getByText("Unsaved changes")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
@@ -681,6 +893,80 @@ describe("TeamMemberWorkflowStudioPage", () => {
           }),
         }),
       );
+    });
+  });
+
+  it("resizes the node detail panel from the canvas divider", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1/t-alpha/members/member-alpha/workflow",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "workflow-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: null,
+        lifecycleStage: "created",
+        memberId: "member-alpha",
+        publishedServiceId: "",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "workflow-alpha.yaml",
+      filePath: "scope://scope-1/workflow-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "workflow-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: mockWorkflowDocument,
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByText("nodes:1")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "node:step:triage" }));
+
+    const detailPanel = screen.getByLabelText("Node detail");
+    const resizeHandle = screen.getByRole("separator", {
+      name: "Resize side panel",
+    });
+    expect(resizeHandle).toHaveAttribute("aria-orientation", "vertical");
+    expect(detailPanel).toHaveStyle({ width: "420px" });
+
+    fireEvent.mouseDown(resizeHandle, { clientX: 600 });
+    fireEvent.mouseMove(window, { clientX: 500 });
+    fireEvent.mouseUp(window);
+
+    await waitFor(() => {
+      expect(detailPanel).toHaveStyle({ width: "520px" });
+      expect(resizeHandle).toHaveAttribute("aria-valuenow", "520");
+    });
+
+    fireEvent.keyDown(resizeHandle, { key: "ArrowRight" });
+    await waitFor(() => {
+      expect(detailPanel).toHaveStyle({ width: "496px" });
+    });
+
+    fireEvent.keyDown(resizeHandle, { key: "Home" });
+    await waitFor(() => {
+      expect(detailPanel).toHaveStyle({ width: "320px" });
     });
   });
 
@@ -730,13 +1016,205 @@ describe("TeamMemberWorkflowStudioPage", () => {
       expect(screen.getByText("nodes:1")).toBeTruthy();
     });
     fireEvent.click(screen.getByRole("button", { name: "node:step:triage" }));
-    fireEvent.change(screen.getByLabelText("Node parameters"), {
+    expect(screen.queryByLabelText("Raw node configuration")).toBeNull();
+    fireEvent.click(screen.getByText("Advanced raw configuration"));
+    fireEvent.change(screen.getByLabelText("Raw node configuration"), {
       target: { value: "not-json" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    fireEvent.click(screen.getByRole("button", { name: "Apply raw JSON" }));
 
     expect(await screen.findByText(/Unexpected token/)).toBeTruthy();
     expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("applies non-LLM guided node configuration without changing parameter value shapes", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1/t-alpha/members/member-alpha/workflow",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "workflow-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: null,
+        lifecycleStage: "created",
+        memberId: "member-alpha",
+        publishedServiceId: "",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "workflow-alpha.yaml",
+      filePath: "scope://scope-1/workflow-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "workflow-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: {
+        ...mockWorkflowDocument,
+        steps: [
+          {
+            id: "wait_for_signal",
+            type: "wait_signal",
+            targetRole: null,
+            parameters: { signal_name: "continue", timeout_ms: "60000" },
+            next: null,
+            branches: {},
+          },
+        ],
+      },
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByText("nodes:1")).toBeTruthy();
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "node:step:wait_for_signal" }),
+    );
+    expect(screen.getByText("Wait for signal")).toBeTruthy();
+    fireEvent.change(screen.getByLabelText("Signal name"), {
+      target: { value: "approval-ready" },
+    });
+    fireEvent.change(screen.getByLabelText("Timeout ms"), {
+      target: { value: "90000" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Update node" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(studioApi.serializeYaml).toHaveBeenCalledWith(
+        expect.objectContaining({
+          document: expect.objectContaining({
+            steps: expect.arrayContaining([
+              expect.objectContaining({
+                id: "wait_for_signal",
+                parameters: expect.objectContaining({
+                  signal_name: "approval-ready",
+                  timeout_ms: "90000",
+                }),
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
+  });
+
+  it("shows backend child step ids as product labels in guided cache node configuration", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1/t-alpha/members/member-alpha/workflow",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "workflow-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: null,
+        lifecycleStage: "created",
+        memberId: "member-alpha",
+        publishedServiceId: "",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "workflow-alpha.yaml",
+      filePath: "scope://scope-1/workflow-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "workflow-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: {
+        ...mockWorkflowDocument,
+        steps: [
+          {
+            id: "cache_response",
+            type: "cache",
+            targetRole: null,
+            parameters: {
+              cache_key: "$input",
+              child_step_type: "llm_call",
+              ttl_seconds: "600",
+            },
+            next: null,
+            branches: {},
+          },
+        ],
+      },
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByText("nodes:1")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "node:step:cache_response" }));
+
+    expect(screen.getByText("Cache")).toBeTruthy();
+    expect(screen.getByText("Cached node")).toBeTruthy();
+    expect(screen.getByText("LLM call")).toBeTruthy();
+    expect(screen.queryByText("llm_call")).toBeNull();
+    expect(screen.queryByLabelText("Raw node configuration")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("TTL seconds"), {
+      target: { value: "900" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Update node" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(studioApi.serializeYaml).toHaveBeenCalledWith(
+        expect.objectContaining({
+          document: expect.objectContaining({
+            steps: expect.arrayContaining([
+              expect.objectContaining({
+                id: "cache_response",
+                parameters: expect.objectContaining({
+                  child_step_type: "llm_call",
+                  ttl_seconds: "900",
+                }),
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
+
+    expect(screen.queryByText("llm_call")).toBeNull();
+    fireEvent.click(screen.getByText("Advanced raw configuration"));
+    expect(
+      (screen.getByLabelText("Raw node configuration") as HTMLTextAreaElement)
+        .value,
+    ).toContain('"child_step_type": "llm_call"');
   });
 
   it("runs the active workflow member through invoke and shows returned logs", async () => {
@@ -844,7 +1322,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(
       screen.queryByLabelText("Member run console"),
     ).toBeNull();
-    expect(screen.queryByLabelText("Run input")).toBeNull();
+    expect(screen.queryByLabelText("Message to active member")).toBeNull();
     expect(
       screen.queryByLabelText("Run options panel"),
     ).toBeNull();
@@ -858,13 +1336,34 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(await screen.findByLabelText("Run options panel")).toHaveStyle({
       borderLeft: "1px solid #e5e7eb",
     });
-    fireEvent.change(screen.getByLabelText("Run input"), {
+    fireEvent.change(screen.getByLabelText("Message to active member"), {
       target: { value: "Run the workflow" },
     });
-    expect(screen.getByLabelText("Run input")).toHaveValue("Run the workflow");
+    expect(screen.getByLabelText("Message to active member")).toHaveValue(
+      "Run the workflow",
+    );
     expect(screen.queryByTestId("member-run-summary")).toBeNull();
     fireEvent.click(runActiveMemberButton);
     const resultPanel = await screen.findByTestId("member-run-result-panel");
+    const consolePanel = screen.getByLabelText("Member run console");
+    const consoleResizeHandle = screen.getByRole("separator", {
+      name: "Resize run console",
+    });
+    expect(consoleResizeHandle).toHaveAttribute("aria-orientation", "horizontal");
+    expect(consolePanel).toHaveStyle({ flex: "0 0 210px" });
+
+    fireEvent.mouseDown(consoleResizeHandle, { clientY: 700 });
+    fireEvent.mouseMove(window, { clientY: 600 });
+    fireEvent.mouseUp(window);
+    await waitFor(() => {
+      expect(consolePanel).toHaveStyle({ flex: "0 0 310px" });
+      expect(consoleResizeHandle).toHaveAttribute("aria-valuenow", "310");
+    });
+
+    fireEvent.keyDown(consoleResizeHandle, { key: "ArrowDown" });
+    await waitFor(() => {
+      expect(consolePanel).toHaveStyle({ flex: "0 0 286px" });
+    });
 
     await waitFor(() => {
       expect(runtimeRunsApi.streamChat).toHaveBeenCalledWith(
@@ -896,7 +1395,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
   });
 
-  it("keeps failed member run errors in the result panel while run input stays collapsed", async () => {
+  it("keeps failed member run errors in the result panel while run message stays collapsed", async () => {
     window.history.replaceState(
       {},
       "",
@@ -961,7 +1460,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(resultPanel).toHaveTextContent("failed");
     expect(screen.queryByTestId("member-run-summary")).toBeNull();
     expect(resultPanel).not.toHaveTextContent("Member run");
-    expect(screen.queryByLabelText("Run input")).toBeNull();
+    expect(screen.queryByLabelText("Message to active member")).toBeNull();
     expect(
       screen.queryByLabelText("Run options panel"),
     ).toBeNull();

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
@@ -10,12 +10,212 @@ import WorkflowStudioRunOptionsPanel from "./components/WorkflowStudioRunOptions
 import { useTeamMemberWorkflowStudio } from "./hooks/useTeamMemberWorkflowStudio";
 import { t } from "@/shared/i18n/messages";
 
+const SIDE_PANEL_DEFAULT_WIDTH = 420;
+const SIDE_PANEL_MIN_WIDTH = 320;
+const SIDE_PANEL_MAX_WIDTH = 640;
+const WORKFLOW_CANVAS_MIN_WIDTH = 360;
+const EXECUTION_PANEL_DEFAULT_HEIGHT = 210;
+const EXECUTION_PANEL_MIN_HEIGHT = 160;
+const EXECUTION_PANEL_MAX_HEIGHT = 520;
+const RESIZE_KEYBOARD_STEP = 24;
+
+function clampDimension(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function resolveSidePanelMaxWidth(container: HTMLElement | null) {
+  if (!container?.clientWidth) {
+    return SIDE_PANEL_MAX_WIDTH;
+  }
+
+  return Math.max(
+    SIDE_PANEL_MIN_WIDTH,
+    Math.min(SIDE_PANEL_MAX_WIDTH, container.clientWidth - WORKFLOW_CANVAS_MIN_WIDTH),
+  );
+}
+
+function resolveExecutionPanelMaxHeight(container: HTMLElement | null) {
+  if (!container?.clientHeight) {
+    return EXECUTION_PANEL_MAX_HEIGHT;
+  }
+
+  return Math.max(
+    EXECUTION_PANEL_MIN_HEIGHT,
+    Math.min(EXECUTION_PANEL_MAX_HEIGHT, Math.floor(container.clientHeight * 0.6)),
+  );
+}
+
 const TeamMemberWorkflowStudioPage: React.FC = () => {
   const studio = useTeamMemberWorkflowStudio();
+  const mainRef = React.useRef<HTMLElement | null>(null);
+  const editorRegionRef = React.useRef<HTMLElement | null>(null);
+  const resizeCleanupRef = React.useRef<(() => void) | null>(null);
+  const [sidePanelWidth, setSidePanelWidth] = React.useState(
+    SIDE_PANEL_DEFAULT_WIDTH,
+  );
+  const [executionPanelHeight, setExecutionPanelHeight] = React.useState(
+    EXECUTION_PANEL_DEFAULT_HEIGHT,
+  );
+  const sidePanelOpen = studio.runOptionsOpen || Boolean(studio.selectedStepDraft);
+  const executionPanelOpen = Boolean(studio.executionDetail || studio.executionError);
+
+  React.useEffect(
+    () => () => {
+      resizeCleanupRef.current?.();
+    },
+    [],
+  );
+
+  const attachResizeListeners = React.useCallback(
+    (cursor: "col-resize" | "row-resize", onMouseMove: (event: MouseEvent) => void) => {
+      resizeCleanupRef.current?.();
+
+      const previousCursor = document.body.style.cursor;
+      const previousUserSelect = document.body.style.userSelect;
+      document.body.style.cursor = cursor;
+      document.body.style.userSelect = "none";
+
+      const cleanup = () => {
+        window.removeEventListener("mousemove", onMouseMove);
+        window.removeEventListener("mouseup", cleanup);
+        document.body.style.cursor = previousCursor;
+        document.body.style.userSelect = previousUserSelect;
+        if (resizeCleanupRef.current === cleanup) {
+          resizeCleanupRef.current = null;
+        }
+      };
+
+      resizeCleanupRef.current = cleanup;
+      window.addEventListener("mousemove", onMouseMove);
+      window.addEventListener("mouseup", cleanup);
+    },
+    [],
+  );
+
+  const updateSidePanelWidth = React.useCallback((nextWidth: number) => {
+    setSidePanelWidth(
+      clampDimension(
+        nextWidth,
+        SIDE_PANEL_MIN_WIDTH,
+        resolveSidePanelMaxWidth(editorRegionRef.current),
+      ),
+    );
+  }, []);
+
+  const updateExecutionPanelHeight = React.useCallback((nextHeight: number) => {
+    setExecutionPanelHeight(
+      clampDimension(
+        nextHeight,
+        EXECUTION_PANEL_MIN_HEIGHT,
+        resolveExecutionPanelMaxHeight(mainRef.current),
+      ),
+    );
+  }, []);
+
+  const startSidePanelResize = React.useCallback(
+    (event: React.MouseEvent<HTMLHRElement>) => {
+      event.preventDefault();
+      event.currentTarget.focus();
+
+      const startX = event.clientX;
+      const startWidth = sidePanelWidth;
+      const maxWidth = resolveSidePanelMaxWidth(editorRegionRef.current);
+
+      attachResizeListeners("col-resize", (moveEvent) => {
+        setSidePanelWidth(
+          clampDimension(
+            startWidth + (startX - moveEvent.clientX),
+            SIDE_PANEL_MIN_WIDTH,
+            maxWidth,
+          ),
+        );
+      });
+    },
+    [attachResizeListeners, sidePanelWidth],
+  );
+
+  const startExecutionPanelResize = React.useCallback(
+    (event: React.MouseEvent<HTMLHRElement>) => {
+      event.preventDefault();
+      event.currentTarget.focus();
+
+      const startY = event.clientY;
+      const startHeight = executionPanelHeight;
+      const maxHeight = resolveExecutionPanelMaxHeight(mainRef.current);
+
+      attachResizeListeners("row-resize", (moveEvent) => {
+        setExecutionPanelHeight(
+          clampDimension(
+            startHeight + (startY - moveEvent.clientY),
+            EXECUTION_PANEL_MIN_HEIGHT,
+            maxHeight,
+          ),
+        );
+      });
+    },
+    [attachResizeListeners, executionPanelHeight],
+  );
+
+  const handleSidePanelResizeKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLHRElement>) => {
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        updateSidePanelWidth(sidePanelWidth + RESIZE_KEYBOARD_STEP);
+        return;
+      }
+
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        updateSidePanelWidth(sidePanelWidth - RESIZE_KEYBOARD_STEP);
+        return;
+      }
+
+      if (event.key === "Home") {
+        event.preventDefault();
+        updateSidePanelWidth(SIDE_PANEL_MIN_WIDTH);
+        return;
+      }
+
+      if (event.key === "End") {
+        event.preventDefault();
+        updateSidePanelWidth(resolveSidePanelMaxWidth(editorRegionRef.current));
+      }
+    },
+    [sidePanelWidth, updateSidePanelWidth],
+  );
+
+  const handleExecutionPanelResizeKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLHRElement>) => {
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        updateExecutionPanelHeight(executionPanelHeight + RESIZE_KEYBOARD_STEP);
+        return;
+      }
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        updateExecutionPanelHeight(executionPanelHeight - RESIZE_KEYBOARD_STEP);
+        return;
+      }
+
+      if (event.key === "Home") {
+        event.preventDefault();
+        updateExecutionPanelHeight(EXECUTION_PANEL_MIN_HEIGHT);
+        return;
+      }
+
+      if (event.key === "End") {
+        event.preventDefault();
+        updateExecutionPanelHeight(resolveExecutionPanelMaxHeight(mainRef.current));
+      }
+    },
+    [executionPanelHeight, updateExecutionPanelHeight],
+  );
 
   return (
     <main
       data-testid="team-member-workflow-studio"
+      ref={mainRef}
       style={{
         background: "#f3f4f6",
         display: "flex",
@@ -39,6 +239,7 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
         activeMemberRunPlaceholderReason={studio.activeMemberRunPlaceholderReason}
         onPublishMember={studio.publishMember}
         onAddNode={studio.openNodeLibrary}
+        onDeleteConnection={studio.deleteSelectedConnection}
         onDeleteNode={studio.deleteSelectedNode}
         onOpenRunOptions={studio.openRunOptions}
         onRunActiveMember={studio.runActiveMember}
@@ -47,6 +248,7 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
         onTitleChange={studio.setWorkflowTitle}
         savePending={studio.savePending}
         savePlaceholderReason={studio.savePlaceholderReason}
+        selectedEdgeId={studio.selectedEdgeId}
         selectedNodeId={studio.selectedNodeId}
         selectedTab={studio.selectedTab}
         onTabChange={studio.setSelectedTab}
@@ -69,6 +271,7 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
       ) : null}
       {studio.selectedTab === "editor" ? (
         <section
+          ref={editorRegionRef}
           style={{
             display: "flex",
             flex: 1,
@@ -96,13 +299,20 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
               onAddFirstStep={studio.openNodeLibrary}
               onCanvasSelect={studio.selectCanvas}
               onConnectNodes={studio.connectNodes}
+              onDeleteEdges={(edgeIds) => {
+                if (edgeIds.includes(studio.selectedEdgeId)) {
+                  studio.deleteSelectedConnection();
+                }
+              }}
               onDeleteNodes={(nodeIds) => {
                 if (nodeIds.includes(studio.selectedNodeId)) {
                   studio.deleteSelectedNode();
                 }
               }}
+              onEdgeSelect={studio.selectEdge}
               onNodeLayoutChange={studio.moveNodes}
               onNodeSelect={studio.selectNode}
+              selectedEdgeId={studio.selectedEdgeId}
               selectedNodeId={studio.selectedNodeId}
             />
           )}
@@ -111,18 +321,53 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
             onInsertNode={studio.insertNode}
             open={studio.nodeLibraryOpen}
           />
+          {sidePanelOpen ? (
+            <hr
+              aria-label={t(
+                "teamMemberWorkflowStudio.resize.sidePanel",
+                "Resize side panel",
+              )}
+              aria-orientation="vertical"
+              aria-valuemax={resolveSidePanelMaxWidth(editorRegionRef.current)}
+              aria-valuemin={SIDE_PANEL_MIN_WIDTH}
+              aria-valuenow={sidePanelWidth}
+              onKeyDown={handleSidePanelResizeKeyDown}
+              onMouseDown={startSidePanelResize}
+              style={{
+                alignItems: "center",
+                background: "#cbd5e1",
+                borderBottom: 0,
+                borderLeft: "3px solid #ffffff",
+                borderRight: "3px solid #ffffff",
+                borderTop: 0,
+                boxSizing: "border-box",
+                cursor: "col-resize",
+                display: "flex",
+                flex: "0 0 10px",
+                height: "100%",
+                justifyContent: "center",
+                margin: 0,
+                minHeight: 0,
+                position: "relative",
+                zIndex: 2,
+              }}
+              tabIndex={0}
+            />
+          ) : null}
           <WorkflowStudioRunOptionsPanel
             onClose={studio.selectCanvas}
-            onRunInputChange={studio.setExecutionRunInput}
+            onRunMessageChange={studio.setExecutionRunMessage}
             open={studio.runOptionsOpen}
-            runInput={studio.executionRunInput}
+            runMessage={studio.executionRunMessage}
+            width={sidePanelWidth}
           />
           {studio.runOptionsOpen ? null : (
             <WorkflowStudioNodeDetailPanel
-              error={studio.selectedStepParameterError}
+              error={studio.selectedStepConfigurationError}
               onClose={studio.selectCanvas}
-              onParametersChange={studio.updateSelectedStepParameters}
+              onConfigurationChange={studio.updateSelectedStepConfiguration}
               stepDraft={studio.selectedStepDraft}
+              width={sidePanelWidth}
             />
           )}
         </section>
@@ -135,9 +380,42 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
           onOpenExecution={studio.openExecution}
         />
       )}
+      {executionPanelOpen ? (
+        <hr
+          aria-label={t(
+            "teamMemberWorkflowStudio.resize.executionPanel",
+            "Resize run console",
+          )}
+          aria-orientation="horizontal"
+          aria-valuemax={resolveExecutionPanelMaxHeight(mainRef.current)}
+          aria-valuemin={EXECUTION_PANEL_MIN_HEIGHT}
+          aria-valuenow={executionPanelHeight}
+          onKeyDown={handleExecutionPanelResizeKeyDown}
+          onMouseDown={startExecutionPanelResize}
+          style={{
+            alignItems: "flex-start",
+            background: "#cbd5e1",
+            borderBottom: "4px solid #ffffff",
+            borderLeft: 0,
+            borderRight: 0,
+            borderTop: "4px solid #ffffff",
+            boxSizing: "border-box",
+            cursor: "row-resize",
+            display: "flex",
+            flex: "0 0 12px",
+            height: 12,
+            justifyContent: "center",
+            margin: 0,
+            position: "relative",
+            zIndex: 3,
+          }}
+          tabIndex={0}
+        />
+      ) : null}
       <WorkflowStudioExecutionPanel
         detail={studio.executionDetail}
         error={studio.executionError}
+        height={executionPanelHeight}
       />
     </main>
   );

--- a/apps/aevatar-console-web/src/shared/graphs/GraphCanvas.test.tsx
+++ b/apps/aevatar-console-web/src/shared/graphs/GraphCanvas.test.tsx
@@ -50,7 +50,16 @@ describe('GraphCanvas', () => {
       type: 'studioWorkflowNode',
     },
   ];
-  const edges: any[] = [];
+  const edges: any[] = [
+    {
+      id: 'edge:assert:publish:linear',
+      source: 'step:assert',
+      target: 'step:publish',
+      data: {
+        kind: 'next',
+      },
+    },
+  ];
 
   beforeEach(() => {
     mockReactFlowRender.mockClear();
@@ -89,6 +98,32 @@ describe('GraphCanvas', () => {
 
     expect(reactFlowProps.deleteKeyCode).toBeNull();
     expect(reactFlowProps.onBeforeDelete).toBeUndefined();
+  });
+
+  it('routes studio edge deletion through the parent callback before mutating the graph', async () => {
+    const onDeleteEdges = jest.fn(async () => undefined);
+
+    render(
+      <GraphCanvas
+        edges={edges}
+        nodes={nodes}
+        onDeleteEdges={onDeleteEdges}
+        variant="studio"
+      />,
+    );
+
+    const reactFlowProps = mockReactFlowRender.mock.calls.at(-1)?.[0] as any;
+
+    expect(reactFlowProps.deleteKeyCode).toBeUndefined();
+    await act(async () => {
+      await expect(
+        reactFlowProps.onBeforeDelete?.({
+          edges,
+          nodes: [],
+        }),
+      ).resolves.toBe(false);
+    });
+    expect(onDeleteEdges).toHaveBeenCalledWith(['edge:assert:publish:linear']);
   });
 
   it('renders studio nodes with their product label instead of the backend step type id', () => {

--- a/apps/aevatar-console-web/src/shared/graphs/GraphCanvas.tsx
+++ b/apps/aevatar-console-web/src/shared/graphs/GraphCanvas.tsx
@@ -54,6 +54,7 @@ type GraphCanvasProps = {
   }) => void;
   onConnectNodes?: (sourceId: string, targetId: string) => void;
   onNodeLayoutChange?: (nodes: Node[]) => void;
+  onDeleteEdges?: (edgeIds: string[]) => Promise<void> | void;
   onDeleteNodes?: (nodeIds: string[]) => Promise<void> | void;
 };
 
@@ -271,6 +272,7 @@ const GraphCanvas: React.FC<GraphCanvasProps> = ({
   onCanvasContextMenu,
   onConnectNodes,
   onNodeLayoutChange,
+  onDeleteEdges,
   onDeleteNodes,
 }) => {
   const [localNodes, setLocalNodes] = useNodesState(nodes);
@@ -433,20 +435,30 @@ const GraphCanvas: React.FC<GraphCanvasProps> = ({
         nodesDraggable={isStudioVariant}
         nodesConnectable={Boolean(isStudioVariant && onConnectNodes)}
         elementsSelectable
-        deleteKeyCode={isStudioVariant && !onDeleteNodes ? null : undefined}
+        deleteKeyCode={
+          isStudioVariant && !onDeleteNodes && !onDeleteEdges ? null : undefined
+        }
         onNodesChange={isStudioVariant ? handleNodesChange : undefined}
         onBeforeDelete={
-          isStudioVariant && onDeleteNodes
-            ? async ({ nodes: nodesToDelete }) => {
+          isStudioVariant && (onDeleteNodes || onDeleteEdges)
+            ? async ({ edges: edgesToDelete, nodes: nodesToDelete }) => {
                 const nodeIds = nodesToDelete
                   .map((node) => String(node.id ?? '').trim())
                   .filter(Boolean);
-                if (nodeIds.length === 0) {
+                const edgeIds = edgesToDelete
+                  .map((edge) => String(edge.id ?? '').trim())
+                  .filter(Boolean);
+                if (nodeIds.length === 0 && edgeIds.length === 0) {
                   return false;
                 }
 
                 try {
-                  await onDeleteNodes(nodeIds);
+                  if (nodeIds.length > 0) {
+                    await onDeleteNodes?.(nodeIds);
+                  }
+                  if (edgeIds.length > 0) {
+                    await onDeleteEdges?.(edgeIds);
+                  }
                 } catch {
                   // Keep the local graph unchanged until the parent document confirms deletion.
                 }

--- a/apps/aevatar-console-web/src/shared/studio/document.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/document.test.ts
@@ -7,6 +7,7 @@ import {
   parseInspectorBranches,
   parseInspectorParameters,
   removeStep,
+  removeStepConnection,
   removeSteps,
   suggestBranchLabelForStep,
 } from './document';
@@ -227,9 +228,9 @@ describe('studio document helpers', () => {
     });
   });
 
-  it('rejects non-object step parameters', () => {
+  it('rejects non-object raw node configuration', () => {
     expect(() => parseInspectorParameters('["nope"]')).toThrow(
-      'Step parameters must be a JSON object.',
+      'Raw node configuration must be a JSON object.',
     );
   });
 
@@ -277,7 +278,7 @@ describe('studio document helpers', () => {
     ]);
   });
 
-  it('removes a selected step and rewrites inbound edges to the next step', () => {
+  it('removes a selected step and clears incident connections without rewiring flow', () => {
     const document: StudioWorkflowDocument = {
       name: 'workspace-demo',
       roles: [],
@@ -317,18 +318,16 @@ describe('studio document helpers', () => {
     expect(result.document.steps).toEqual([
       expect.objectContaining({
         id: 'draft_step',
-        next: 'approve_step',
+        next: null,
       }),
       expect.objectContaining({
         id: 'approve_step',
-        branches: {
-          retry: 'approve_step',
-        },
+        branches: {},
       }),
     ]);
   });
 
-  it('removes multiple selected steps in document order and preserves rewired flow', () => {
+  it('removes multiple selected steps without inventing replacement connections', () => {
     const document: StudioWorkflowDocument = {
       name: 'workspace-demo',
       roles: [],
@@ -376,15 +375,107 @@ describe('studio document helpers', () => {
     expect(result.document.steps).toEqual([
       expect.objectContaining({
         id: 'draft_step',
-        next: 'publish_step',
+        next: null,
       }),
       expect.objectContaining({
         id: 'publish_step',
-        branches: {
-          retry: 'publish_step',
-        },
+        branches: {},
       }),
     ]);
+  });
+
+  it('removes an explicit next connection while keeping both steps', () => {
+    const document: StudioWorkflowDocument = {
+      name: 'workspace-demo',
+      roles: [],
+      steps: [
+        {
+          id: 'draft_step',
+          type: 'llm_call',
+          targetRole: 'assistant',
+          parameters: {},
+          next: 'approve_step',
+          branches: {},
+        },
+        {
+          id: 'approve_step',
+          type: 'human_approval',
+          targetRole: null,
+          parameters: {},
+          next: null,
+          branches: {},
+        },
+      ],
+    };
+
+    const result = removeStepConnection(
+      document,
+      'draft_step',
+      'approve_step',
+    );
+
+    expect(result.nodeId).toBe('step:draft_step');
+    expect(result.document.steps).toEqual([
+      expect.objectContaining({
+        id: 'draft_step',
+        next: null,
+      }),
+      expect.objectContaining({
+        id: 'approve_step',
+      }),
+    ]);
+  });
+
+  it('removes a branch connection while preserving sibling branches', () => {
+    const document: StudioWorkflowDocument = {
+      name: 'workspace-demo',
+      roles: [],
+      steps: [
+        {
+          id: 'guard_step',
+          type: 'conditional',
+          targetRole: null,
+          parameters: {},
+          next: null,
+          branches: {
+            true: 'approve_step',
+            false: 'retry_step',
+          },
+        },
+        {
+          id: 'approve_step',
+          type: 'human_approval',
+          targetRole: null,
+          parameters: {},
+          next: null,
+          branches: {},
+        },
+        {
+          id: 'retry_step',
+          type: 'llm_call',
+          targetRole: 'assistant',
+          parameters: {},
+          next: null,
+          branches: {},
+        },
+      ],
+    };
+
+    const result = removeStepConnection(
+      document,
+      'guard_step',
+      'retry_step',
+      'false',
+    );
+
+    expect(result.nodeId).toBe('step:guard_step');
+    expect(result.document.steps?.[0]).toEqual(
+      expect.objectContaining({
+        branches: {
+          true: 'approve_step',
+        },
+      }),
+    );
   });
 
   it('connects a step to a new linear next target', () => {

--- a/apps/aevatar-console-web/src/shared/studio/document.ts
+++ b/apps/aevatar-console-web/src/shared/studio/document.ts
@@ -208,7 +208,7 @@ export function parseInspectorParameters(
 
   const parsed = JSON.parse(trimmed) as unknown;
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    throw new Error('Step parameters must be a JSON object.');
+    throw new Error('Raw node configuration must be a JSON object.');
   }
 
   return Object.fromEntries(Object.entries(parsed));
@@ -566,8 +566,6 @@ export function removeStep(
     };
   }
 
-  const removedStep = steps[currentIndex] as StudioWorkflowStepDocument;
-  const replacementStepId = normalizeString(removedStep.next);
   const nextSteps = steps
     .filter((entry) => normalizeString(entry.id) !== currentStepId)
     .map((entry) => {
@@ -575,25 +573,18 @@ export function removeStep(
       const next = normalizeString(step.next);
       const branches = Object.fromEntries(
         Object.entries(step.branches ?? {})
-          .map(([label, target]) => [
-            label,
-            target === currentStepId ? replacementStepId : target,
-          ])
+          .filter(([, target]) => target !== currentStepId)
           .filter(([, target]) => Boolean(normalizeString(target))),
       );
 
       return {
         ...step,
-        next: next === currentStepId ? replacementStepId || null : step.next ?? null,
+        next: next === currentStepId ? null : step.next ?? null,
         branches,
       } satisfies StudioWorkflowStepDocument;
     });
 
-  const preferredStep =
-    nextSteps.find((entry) => normalizeString(entry.id) === replacementStepId) ??
-    nextSteps[currentIndex] ??
-    nextSteps[currentIndex - 1] ??
-    nextSteps[0];
+  const preferredStep = nextSteps[currentIndex] ?? nextSteps[currentIndex - 1] ?? nextSteps[0];
   const fallbackRoleId = normalizeString(roles[0]?.id);
 
   return {

--- a/apps/aevatar-console-web/src/shared/studio/graph.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/graph.test.ts
@@ -62,4 +62,89 @@ describe('studio graph helpers', () => {
       'No parameters configured',
     );
   });
+
+  it('does not invent edges from adjacent disconnected steps', () => {
+    const graph = buildStudioGraphElements({
+      name: 'workflow-demo',
+      steps: [
+        {
+          id: 'draft',
+          type: 'transform',
+          parameters: {},
+        },
+        {
+          id: 'review',
+          type: 'assign',
+          parameters: {},
+        },
+      ],
+    });
+
+    expect(graph.nodes).toHaveLength(2);
+    expect(graph.edges).toHaveLength(0);
+  });
+
+  it('renders explicit next and branch connections', () => {
+    const graph = buildStudioGraphElements({
+      name: 'workflow-demo',
+      steps: [
+        {
+          id: 'draft',
+          type: 'transform',
+          next: 'review',
+          parameters: {},
+        },
+        {
+          id: 'review',
+          type: 'conditional',
+          branches: {
+            true: 'publish',
+          },
+          parameters: {},
+        },
+        {
+          id: 'publish',
+          type: 'emit',
+          parameters: {},
+        },
+      ],
+    });
+
+    expect(graph.edges.map((edge) => edge.id)).toEqual([
+      'edge:draft:review:linear',
+      'edge:review:publish:branch:true',
+    ]);
+  });
+
+  it('keeps a branch labeled next distinct from a linear next connection', () => {
+    const graph = buildStudioGraphElements({
+      name: 'workflow-demo',
+      steps: [
+        {
+          id: 'guard',
+          type: 'conditional',
+          next: 'linear_target',
+          branches: {
+            next: 'branch_target',
+          },
+          parameters: {},
+        },
+        {
+          id: 'linear_target',
+          type: 'emit',
+          parameters: {},
+        },
+        {
+          id: 'branch_target',
+          type: 'emit',
+          parameters: {},
+        },
+      ],
+    });
+
+    expect(graph.edges.map((edge) => edge.id)).toEqual([
+      'edge:guard:linear_target:linear',
+      'edge:guard:branch_target:branch:next',
+    ]);
+  });
 });

--- a/apps/aevatar-console-web/src/shared/studio/graph.ts
+++ b/apps/aevatar-console-web/src/shared/studio/graph.ts
@@ -75,6 +75,21 @@ export type StudioWorkflowLayoutDocument = {
   readonly entryWorkflow?: string;
 };
 
+function buildStudioGraphNextEdgeId(
+  sourceStepId: string,
+  targetStepId: string,
+): string {
+  return `edge:${sourceStepId}:${targetStepId}:linear`;
+}
+
+function buildStudioGraphBranchEdgeId(
+  sourceStepId: string,
+  targetStepId: string,
+  branchLabel: string,
+): string {
+  return `edge:${sourceStepId}:${targetStepId}:branch:${branchLabel}`;
+}
+
 type WorkflowDocumentLike = {
   readonly name?: string;
   readonly description?: string;
@@ -393,19 +408,10 @@ function buildAutoLayoutPositions(
     incomingCount.set(stepId, 0);
   }
 
-  steps.forEach((step, index) => {
+  steps.forEach((step) => {
     const nextTargets: string[] = [];
     if (step.next && validStepIds.has(step.next)) {
       nextTargets.push(step.next);
-    } else if (
-      !step.next &&
-      Object.keys(step.branches).length === 0 &&
-      index < steps.length - 1
-    ) {
-      const fallbackNext = steps[index + 1]?.id;
-      if (fallbackNext && validStepIds.has(fallbackNext)) {
-        nextTargets.push(fallbackNext);
-      }
     }
 
     const branchTargets = Object.entries(step.branches)
@@ -644,7 +650,7 @@ export function buildStudioGraphElements(
     nodes.map((node) => [node.data.stepId, node] as const),
   );
   const edges: Edge<StudioGraphEdgeData>[] = [];
-  steps.forEach((step, index) => {
+  steps.forEach((step) => {
     const sourceNode = stepNodeById.get(step.id);
     if (!sourceNode) {
       return;
@@ -654,7 +660,7 @@ export function buildStudioGraphElements(
       const targetNode = stepNodeById.get(step.next);
       if (targetNode) {
         edges.push({
-          id: `edge:${step.id}:${step.next}:next`,
+          id: buildStudioGraphNextEdgeId(step.id, step.next),
           source: sourceNode.id,
           target: targetNode.id,
           type: 'smoothstep',
@@ -663,32 +669,6 @@ export function buildStudioGraphElements(
           data: {
             kind: 'next',
             implicit: false,
-          },
-          style: {
-            stroke: '#2F6FEC',
-            strokeWidth: 2.5,
-          },
-          markerEnd: {
-            type: MarkerType.ArrowClosed,
-            width: 11,
-            height: 11,
-            color: '#2F6FEC',
-          },
-          zIndex: 4,
-        });
-      }
-    } else if (Object.keys(step.branches).length === 0 && index < steps.length - 1) {
-      const fallbackTarget = steps[index + 1]?.id;
-      const targetNode = fallbackTarget ? stepNodeById.get(fallbackTarget) : null;
-      if (targetNode) {
-        edges.push({
-          id: `edge:${step.id}:${fallbackTarget}:next`,
-          source: sourceNode.id,
-          target: targetNode.id,
-          type: 'smoothstep',
-          data: {
-            kind: 'next',
-            implicit: true,
           },
           style: {
             stroke: '#2F6FEC',
@@ -714,7 +694,11 @@ export function buildStudioGraphElements(
         }
 
         edges.push({
-          id: `edge:${step.id}:${targetStepId}:${branchLabel}`,
+          id: buildStudioGraphBranchEdgeId(
+            step.id,
+            targetStepId,
+            branchLabel,
+          ),
           source: sourceNode.id,
           target: targetNode.id,
           type: 'smoothstep',

--- a/apps/aevatar-console-web/src/shared/studio/nodeConfiguration.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/nodeConfiguration.test.ts
@@ -1,0 +1,154 @@
+import {
+  applyRawStudioNodeConfiguration,
+  applyStudioNodeConfigurationValues,
+  formatRawStudioNodeConfiguration,
+  getStudioNodeConfigurationSchema,
+  readStudioNodeConfigurationValues,
+} from './nodeConfiguration';
+
+describe('studio node configuration semantics', () => {
+  it('presents llm_call prompt_prefix as an Instruction field while preserving runtime parameters', () => {
+    const schema = getStudioNodeConfigurationSchema('llm_call');
+    const values = readStudioNodeConfigurationValues('llm_call', {
+      prompt_prefix: 'Classify the request.',
+    });
+
+    expect(schema.fields).toEqual([
+      expect.objectContaining({
+        label: expect.objectContaining({ defaultMessage: 'Instruction' }),
+        name: 'instruction',
+        parameterName: 'prompt',
+      }),
+    ]);
+    expect(values).toEqual({
+      instruction: 'Classify the request.',
+    });
+
+    const nextParameters = applyStudioNodeConfigurationValues(
+      'llm_call',
+      { prompt_prefix: 'Old instruction' },
+      { instruction: 'Updated instruction' },
+    );
+
+    expect(nextParameters).toEqual({
+      prompt_prefix: 'Updated instruction',
+    });
+    expect(nextParameters).not.toHaveProperty('prompt');
+  });
+
+  it('reads legacy llm_call prompt but writes the canonical prompt_prefix parameter', () => {
+    const values = readStudioNodeConfigurationValues('llm_call', {
+      prompt: 'Legacy instruction',
+    });
+
+    expect(values).toEqual({
+      instruction: 'Legacy instruction',
+    });
+    expect(
+      applyStudioNodeConfigurationValues(
+        'llm_call',
+        { prompt: 'Legacy instruction' },
+        { instruction: 'Canonical instruction' },
+      ),
+    ).toEqual({
+      prompt_prefix: 'Canonical instruction',
+    });
+  });
+
+  it('maps transform operation without exposing raw backend op as the user field name', () => {
+    const schema = getStudioNodeConfigurationSchema('transform');
+    const values = readStudioNodeConfigurationValues('transform', { op: 'trim' });
+
+    expect(schema.fields[0]).toEqual(
+      expect.objectContaining({
+        label: expect.objectContaining({ defaultMessage: 'Operation' }),
+        name: 'operation',
+        parameterName: 'op',
+      }),
+    );
+    expect(values).toEqual({ operation: 'trim' });
+    expect(
+      applyStudioNodeConfigurationValues(
+        'transform',
+        { op: 'trim' },
+        { operation: 'uppercase' },
+      ),
+    ).toEqual({ op: 'uppercase' });
+  });
+
+  it('presents child step type values as product node labels while preserving runtime ids', () => {
+    const schema = getStudioNodeConfigurationSchema('cache');
+    const values = readStudioNodeConfigurationValues('cache', {
+      cache_key: '$input',
+      child_step_type: 'llm_call',
+      ttl_seconds: '600',
+    });
+    const childStepTypeField = schema.fields.find(
+      (field) => field.name === 'childStepType',
+    );
+
+    expect(childStepTypeField).toEqual(
+      expect.objectContaining({
+        kind: 'select',
+        label: expect.objectContaining({ defaultMessage: 'Cached node' }),
+        parameterName: 'child_step_type',
+      }),
+    );
+    expect(childStepTypeField?.placeholder).toBeUndefined();
+    expect(childStepTypeField?.options).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: expect.objectContaining({ defaultMessage: 'LLM call' }),
+          value: 'llm_call',
+        }),
+      ]),
+    );
+    expect(values).toEqual({
+      cacheKey: '$input',
+      childStepType: 'llm_call',
+      ttlSeconds: '600',
+    });
+    expect(
+      applyStudioNodeConfigurationValues(
+        'cache',
+        { cache_key: '$input', child_step_type: 'llm_call', ttl_seconds: '600' },
+        { cacheKey: '$input', childStepType: 'llm_call', ttlSeconds: '900' },
+      ),
+    ).toEqual({
+      cache_key: '$input',
+      child_step_type: 'llm_call',
+      ttl_seconds: '900',
+    });
+  });
+
+  it('keeps string-shaped numeric parameters as strings for the existing runtime contract', () => {
+    const values = readStudioNodeConfigurationValues('wait_signal', {
+      signal_name: 'continue',
+      timeout_ms: '60000',
+    });
+
+    expect(values).toEqual({
+      signalName: 'continue',
+      timeoutMs: '60000',
+    });
+    expect(
+      applyStudioNodeConfigurationValues(
+        'wait_signal',
+        { signal_name: 'continue', timeout_ms: '60000' },
+        { signalName: 'approval-ready', timeoutMs: '90000' },
+      ),
+    ).toEqual({
+      signal_name: 'approval-ready',
+      timeout_ms: '90000',
+    });
+  });
+
+  it('keeps raw configuration as an explicit advanced JSON path', () => {
+    expect(formatRawStudioNodeConfiguration({ op: 'trim' })).toBe(
+      '{\n  "op": "trim"\n}',
+    );
+    expect(
+      applyRawStudioNodeConfiguration('transform', '{ "op": "lowercase" }'),
+    ).toEqual({ op: 'lowercase' });
+  });
+});

--- a/apps/aevatar-console-web/src/shared/studio/nodeConfiguration.ts
+++ b/apps/aevatar-console-web/src/shared/studio/nodeConfiguration.ts
@@ -1,0 +1,959 @@
+import {
+  formatInspectorParameters,
+  normalizeStepParametersForType,
+  parseInspectorParameters,
+  readStepParameterValue,
+  resolveStepParameterName,
+} from './document';
+import type { ConsoleMessageDescriptor } from '@/shared/i18n/messages';
+
+export type StudioNodeConfigurationFieldKind =
+  | 'single-line'
+  | 'multi-line'
+  | 'select';
+
+export type StudioNodeConfigurationOption = {
+  readonly label: ConsoleMessageDescriptor;
+  readonly value: string;
+};
+
+export type StudioNodeConfigurationField = {
+  readonly description?: ConsoleMessageDescriptor;
+  readonly kind: StudioNodeConfigurationFieldKind;
+  readonly label: ConsoleMessageDescriptor;
+  readonly name: string;
+  readonly options?: readonly StudioNodeConfigurationOption[];
+  readonly parameterName: string;
+  readonly placeholder?: ConsoleMessageDescriptor;
+  readonly required?: boolean;
+};
+
+export type StudioNodeConfigurationSchema = {
+  readonly fields: readonly StudioNodeConfigurationField[];
+  readonly stepType: string;
+};
+
+function message(
+  id: string,
+  defaultMessage: string,
+): ConsoleMessageDescriptor {
+  return { defaultMessage, id };
+}
+
+const SHARED_OPTIONS = {
+  onFailure: [
+    {
+      label: message(
+        'shared.studio.nodeConfiguration.option.onFailure.fail',
+        'Fail the run',
+      ),
+      value: 'fail',
+    },
+    {
+      label: message(
+        'shared.studio.nodeConfiguration.option.onFailure.skip',
+        'Skip this step',
+      ),
+      value: 'skip',
+    },
+    {
+      label: message(
+        'shared.studio.nodeConfiguration.option.onFailure.branch',
+        'Go to a branch',
+      ),
+      value: 'branch',
+    },
+  ],
+} satisfies Record<string, readonly StudioNodeConfigurationOption[]>;
+
+const STEP_TYPE_OPTIONS = [
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.transform',
+      'Transform',
+    ),
+    value: 'transform',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.assign',
+      'Assign',
+    ),
+    value: 'assign',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.retrieveFacts',
+      'Retrieve facts',
+    ),
+    value: 'retrieve_facts',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.cache',
+      'Cache',
+    ),
+    value: 'cache',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.guard',
+      'Guard',
+    ),
+    value: 'guard',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.conditional',
+      'Conditional',
+    ),
+    value: 'conditional',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.switch',
+      'Switch',
+    ),
+    value: 'switch',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.while',
+      'While',
+    ),
+    value: 'while',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.delay',
+      'Delay',
+    ),
+    value: 'delay',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.waitSignal',
+      'Wait for signal',
+    ),
+    value: 'wait_signal',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.checkpoint',
+      'Checkpoint',
+    ),
+    value: 'checkpoint',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.llmCall',
+      'LLM call',
+    ),
+    value: 'llm_call',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.toolCall',
+      'Tool call',
+    ),
+    value: 'tool_call',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.evaluate',
+      'Evaluate',
+    ),
+    value: 'evaluate',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.reflect',
+      'Reflect',
+    ),
+    value: 'reflect',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.foreach',
+      'For each',
+    ),
+    value: 'foreach',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.parallel',
+      'Parallel',
+    ),
+    value: 'parallel',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.race',
+      'Race',
+    ),
+    value: 'race',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.mapReduce',
+      'Map reduce',
+    ),
+    value: 'map_reduce',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.workflowCall',
+      'Workflow call',
+    ),
+    value: 'workflow_call',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.dynamicWorkflow',
+      'Dynamic workflow',
+    ),
+    value: 'dynamic_workflow',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.vote',
+      'Vote',
+    ),
+    value: 'vote',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.connectorCall',
+      'Connector call',
+    ),
+    value: 'connector_call',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.emit',
+      'Emit',
+    ),
+    value: 'emit',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.humanInput',
+      'Human input',
+    ),
+    value: 'human_input',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.humanApproval',
+      'Human approval',
+    ),
+    value: 'human_approval',
+  },
+  {
+    label: message(
+      'shared.studio.nodeConfiguration.stepType.option.workflowYamlValidate',
+      'Workflow YAML validation',
+    ),
+    value: 'workflow_yaml_validate',
+  },
+] satisfies readonly StudioNodeConfigurationOption[];
+
+const SCHEMAS_BY_STEP_TYPE: Record<string, StudioNodeConfigurationSchema> = {
+  assign: {
+    stepType: 'assign',
+    fields: [
+      {
+        kind: 'single-line',
+        label: message(
+          'shared.studio.nodeConfiguration.assign.target.label',
+          'Target variable',
+        ),
+        name: 'target',
+        parameterName: 'target',
+        placeholder: message(
+          'shared.studio.nodeConfiguration.assign.target.placeholder',
+          'result',
+        ),
+        required: true,
+      },
+      {
+        kind: 'single-line',
+        label: message(
+          'shared.studio.nodeConfiguration.assign.value.label',
+          'Value',
+        ),
+        name: 'value',
+        parameterName: 'value',
+        placeholder: message(
+          'shared.studio.nodeConfiguration.assign.value.placeholder',
+          '$input',
+        ),
+      },
+    ],
+  },
+  cache: {
+    stepType: 'cache',
+    fields: [
+      {
+        kind: 'single-line',
+        label: message(
+          'shared.studio.nodeConfiguration.cache.key.label',
+          'Cache key',
+        ),
+        name: 'cacheKey',
+        parameterName: 'cache_key',
+        placeholder: message(
+          'shared.studio.nodeConfiguration.cache.key.placeholder',
+          '$input',
+        ),
+        required: true,
+      },
+      {
+        kind: 'single-line',
+        label: message(
+          'shared.studio.nodeConfiguration.cache.ttl.label',
+          'TTL seconds',
+        ),
+        name: 'ttlSeconds',
+        parameterName: 'ttl_seconds',
+        placeholder: message(
+          'shared.studio.nodeConfiguration.cache.ttl.placeholder',
+          '600',
+        ),
+      },
+      {
+        kind: 'select',
+        label: message(
+          'shared.studio.nodeConfiguration.cache.childStep.label',
+          'Cached node',
+        ),
+        name: 'childStepType',
+        options: STEP_TYPE_OPTIONS,
+        parameterName: 'child_step_type',
+      },
+    ],
+  },
+  connector_call: {
+    stepType: 'connector_call',
+    fields: [
+      {
+        kind: 'single-line',
+        label: message(
+          'shared.studio.nodeConfiguration.connectorCall.connector.label',
+          'Connector',
+        ),
+        name: 'connector',
+        parameterName: 'connector',
+        placeholder: message(
+          'shared.studio.nodeConfiguration.connectorCall.connector.placeholder',
+          'Configured connector name',
+        ),
+        required: true,
+      },
+      {
+        kind: 'single-line',
+        label: message(
+          'shared.studio.nodeConfiguration.connectorCall.operation.label',
+          'Operation',
+        ),
+        name: 'operation',
+        parameterName: 'operation',
+        placeholder: message(
+          'shared.studio.nodeConfiguration.connectorCall.operation.placeholder',
+          'Operation or endpoint name',
+        ),
+      },
+      {
+        kind: 'single-line',
+        label: message(
+          'shared.studio.nodeConfiguration.connectorCall.path.label',
+          'Path',
+        ),
+        name: 'path',
+        parameterName: 'path',
+        placeholder: message(
+          'shared.studio.nodeConfiguration.connectorCall.path.placeholder',
+          '/v1/items',
+        ),
+      },
+      {
+        kind: 'select',
+        label: message(
+          'shared.studio.nodeConfiguration.connectorCall.method.label',
+          'Method',
+        ),
+        name: 'method',
+        parameterName: 'method',
+        options: [
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.connectorCall.method.option.get',
+              'GET',
+            ),
+            value: 'GET',
+          },
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.connectorCall.method.option.post',
+              'POST',
+            ),
+            value: 'POST',
+          },
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.connectorCall.method.option.put',
+              'PUT',
+            ),
+            value: 'PUT',
+          },
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.connectorCall.method.option.patch',
+              'PATCH',
+            ),
+            value: 'PATCH',
+          },
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.connectorCall.method.option.delete',
+              'DELETE',
+            ),
+            value: 'DELETE',
+          },
+        ],
+      },
+      {
+        kind: 'single-line',
+        label: message(
+          'shared.studio.nodeConfiguration.connectorCall.timeout.label',
+          'Timeout ms',
+        ),
+        name: 'timeoutMs',
+        parameterName: 'timeout_ms',
+        placeholder: message(
+          'shared.studio.nodeConfiguration.connectorCall.timeout.placeholder',
+          '10000',
+        ),
+      },
+      {
+        kind: 'single-line',
+        label: message(
+          'shared.studio.nodeConfiguration.connectorCall.retry.label',
+          'Retries',
+        ),
+        name: 'retry',
+        parameterName: 'retry',
+        placeholder: message(
+          'shared.studio.nodeConfiguration.connectorCall.retry.placeholder',
+          '0',
+        ),
+      },
+      {
+        kind: 'select',
+        label: message(
+          'shared.studio.nodeConfiguration.connectorCall.onError.label',
+          'On error',
+        ),
+        name: 'onError',
+        options: SHARED_OPTIONS.onFailure,
+        parameterName: 'on_error',
+      },
+    ],
+  },
+  delay: {
+    stepType: 'delay',
+    fields: [
+      {
+        kind: 'single-line',
+        label: message(
+          'shared.studio.nodeConfiguration.delay.duration.label',
+          'Duration ms',
+        ),
+        name: 'durationMs',
+        parameterName: 'duration_ms',
+        placeholder: message(
+          'shared.studio.nodeConfiguration.delay.duration.placeholder',
+          '1000',
+        ),
+        required: true,
+      },
+    ],
+  },
+  emit: {
+    stepType: 'emit',
+    fields: [
+      {
+        kind: 'single-line',
+        label: message(
+          'shared.studio.nodeConfiguration.emit.eventType.label',
+          'Event type',
+        ),
+        name: 'eventType',
+        parameterName: 'event_type',
+        placeholder: message(
+          'shared.studio.nodeConfiguration.emit.eventType.placeholder',
+          'workflow.completed',
+        ),
+        required: true,
+      },
+      {
+        kind: 'multi-line',
+        label: message(
+          'shared.studio.nodeConfiguration.emit.payload.label',
+          'Payload',
+        ),
+        name: 'payload',
+        parameterName: 'payload',
+        placeholder: message(
+          'shared.studio.nodeConfiguration.emit.payload.placeholder',
+          '$input',
+        ),
+      },
+    ],
+  },
+  guard: {
+    stepType: 'guard',
+    fields: [
+      {
+        kind: 'select',
+        label: message(
+          'shared.studio.nodeConfiguration.guard.check.label',
+          'Check',
+        ),
+        name: 'check',
+        options: [
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.guard.check.option.notEmpty',
+              'Input is not empty',
+            ),
+            value: 'not_empty',
+          },
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.guard.check.option.jsonValid',
+              'Input is valid JSON',
+            ),
+            value: 'json_valid',
+          },
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.guard.check.option.regex',
+              'Matches regex',
+            ),
+            value: 'regex',
+          },
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.guard.check.option.maxLength',
+              'Within max length',
+            ),
+            value: 'max_length',
+          },
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.guard.check.option.contains',
+              'Contains keyword',
+            ),
+            value: 'contains',
+          },
+        ],
+        parameterName: 'check',
+        required: true,
+      },
+      {
+        kind: 'select',
+        label: message(
+          'shared.studio.nodeConfiguration.guard.onFailure.label',
+          'On failure',
+        ),
+        name: 'onFail',
+        options: SHARED_OPTIONS.onFailure,
+        parameterName: 'on_fail',
+      },
+    ],
+  },
+  human_approval: {
+    stepType: 'human_approval',
+    fields: [
+      {
+        kind: 'multi-line',
+        label: message(
+          'shared.studio.nodeConfiguration.humanApproval.prompt.label',
+          'Approval prompt',
+        ),
+        name: 'prompt',
+        parameterName: 'prompt',
+        placeholder: message(
+          'shared.studio.nodeConfiguration.humanApproval.prompt.placeholder',
+          'Approve this step?',
+        ),
+        required: true,
+      },
+      {
+        kind: 'select',
+        label: message(
+          'shared.studio.nodeConfiguration.humanApproval.onReject.label',
+          'On rejection',
+        ),
+        name: 'onReject',
+        options: [
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.humanApproval.onReject.option.fail',
+              'Fail the run',
+            ),
+            value: 'fail',
+          },
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.humanApproval.onReject.option.skip',
+              'Skip this step',
+            ),
+            value: 'skip',
+          },
+        ],
+        parameterName: 'on_reject',
+      },
+    ],
+  },
+  human_input: {
+    stepType: 'human_input',
+    fields: [
+      {
+        kind: 'multi-line',
+        label: message(
+          'shared.studio.nodeConfiguration.humanInput.prompt.label',
+          'Input prompt',
+        ),
+        name: 'prompt',
+        parameterName: 'prompt',
+        placeholder: message(
+          'shared.studio.nodeConfiguration.humanInput.prompt.placeholder',
+          'Please provide the missing input.',
+        ),
+        required: true,
+      },
+      {
+        kind: 'single-line',
+        label: message(
+          'shared.studio.nodeConfiguration.humanInput.variable.label',
+          'Response variable',
+        ),
+        name: 'variable',
+        parameterName: 'variable',
+        placeholder: message(
+          'shared.studio.nodeConfiguration.humanInput.variable.placeholder',
+          'human_response',
+        ),
+      },
+    ],
+  },
+  llm_call: {
+    stepType: 'llm_call',
+    fields: [
+      {
+        description: message(
+          'shared.studio.nodeConfiguration.llmCall.instruction.description',
+          'Prepended to the run input before the role is called.',
+        ),
+        kind: 'multi-line',
+        label: message(
+          'shared.studio.nodeConfiguration.llmCall.instruction.label',
+          'Instruction',
+        ),
+        name: 'instruction',
+        parameterName: 'prompt',
+        placeholder: message(
+          'shared.studio.nodeConfiguration.llmCall.instruction.placeholder',
+          'Tell the role what this step should do.',
+        ),
+        required: true,
+      },
+    ],
+  },
+  retrieve_facts: {
+    stepType: 'retrieve_facts',
+    fields: [
+      {
+        kind: 'multi-line',
+        label: message(
+          'shared.studio.nodeConfiguration.retrieveFacts.query.label',
+          'Query',
+        ),
+        name: 'query',
+        parameterName: 'query',
+        placeholder: message(
+          'shared.studio.nodeConfiguration.retrieveFacts.query.placeholder',
+          'What facts should this step retrieve?',
+        ),
+        required: true,
+      },
+      {
+        kind: 'single-line',
+        label: message(
+          'shared.studio.nodeConfiguration.retrieveFacts.topK.label',
+          'Top K',
+        ),
+        name: 'topK',
+        parameterName: 'top_k',
+        placeholder: message(
+          'shared.studio.nodeConfiguration.retrieveFacts.topK.placeholder',
+          '3',
+        ),
+      },
+    ],
+  },
+  transform: {
+    stepType: 'transform',
+    fields: [
+      {
+        kind: 'select',
+        label: message(
+          'shared.studio.nodeConfiguration.transform.operation.label',
+          'Operation',
+        ),
+        name: 'operation',
+        options: [
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.transform.operation.option.trim',
+              'Trim whitespace',
+            ),
+            value: 'trim',
+          },
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.transform.operation.option.identity',
+              'Pass through',
+            ),
+            value: 'identity',
+          },
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.transform.operation.option.uppercase',
+              'Uppercase',
+            ),
+            value: 'uppercase',
+          },
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.transform.operation.option.lowercase',
+              'Lowercase',
+            ),
+            value: 'lowercase',
+          },
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.transform.operation.option.count',
+              'Count lines',
+            ),
+            value: 'count',
+          },
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.transform.operation.option.take',
+              'Take first lines',
+            ),
+            value: 'take',
+          },
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.transform.operation.option.takeLast',
+              'Take last lines',
+            ),
+            value: 'take_last',
+          },
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.transform.operation.option.split',
+              'Split into sections',
+            ),
+            value: 'split',
+          },
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.transform.operation.option.join',
+              'Join sections',
+            ),
+            value: 'join',
+          },
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.transform.operation.option.jsonExtract',
+              'Extract JSON',
+            ),
+            value: 'json_extract',
+          },
+        ],
+        parameterName: 'op',
+        required: true,
+      },
+    ],
+  },
+  wait_signal: {
+    stepType: 'wait_signal',
+    fields: [
+      {
+        kind: 'single-line',
+        label: message(
+          'shared.studio.nodeConfiguration.waitSignal.signalName.label',
+          'Signal name',
+        ),
+        name: 'signalName',
+        parameterName: 'signal_name',
+        placeholder: message(
+          'shared.studio.nodeConfiguration.waitSignal.signalName.placeholder',
+          'continue',
+        ),
+        required: true,
+      },
+      {
+        kind: 'single-line',
+        label: message(
+          'shared.studio.nodeConfiguration.waitSignal.timeout.label',
+          'Timeout ms',
+        ),
+        name: 'timeoutMs',
+        parameterName: 'timeout_ms',
+        placeholder: message(
+          'shared.studio.nodeConfiguration.waitSignal.timeout.placeholder',
+          '60000',
+        ),
+      },
+    ],
+  },
+  workflow_call: {
+    stepType: 'workflow_call',
+    fields: [
+      {
+        kind: 'single-line',
+        label: message(
+          'shared.studio.nodeConfiguration.workflowCall.workflow.label',
+          'Workflow',
+        ),
+        name: 'workflow',
+        parameterName: 'workflow',
+        placeholder: message(
+          'shared.studio.nodeConfiguration.workflowCall.workflow.placeholder',
+          'child_workflow',
+        ),
+        required: true,
+      },
+      {
+        kind: 'select',
+        label: message(
+          'shared.studio.nodeConfiguration.workflowCall.lifecycle.label',
+          'Lifecycle',
+        ),
+        name: 'lifecycle',
+        options: [
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.workflowCall.lifecycle.option.scope',
+              'Use scope workflow',
+            ),
+            value: 'scope',
+          },
+          {
+            label: message(
+              'shared.studio.nodeConfiguration.workflowCall.lifecycle.option.inline',
+              'Inline call',
+            ),
+            value: 'inline',
+          },
+        ],
+        parameterName: 'lifecycle',
+      },
+    ],
+  },
+};
+
+function normalizeStepType(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function stringifyConfigurationValue(value: unknown): string {
+  if (value === undefined || value === null) {
+    return '';
+  }
+
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return String(value);
+  }
+
+  return JSON.stringify(value, null, 2);
+}
+
+export function getStudioNodeConfigurationSchema(
+  stepType: string,
+): StudioNodeConfigurationSchema {
+  const normalizedType = normalizeStepType(stepType);
+  return (
+    SCHEMAS_BY_STEP_TYPE[normalizedType] ?? {
+      stepType: normalizedType || 'step',
+      fields: [],
+    }
+  );
+}
+
+export function readStudioNodeConfigurationValues(
+  stepType: string,
+  parameters: Record<string, unknown> | null | undefined,
+): Record<string, string> {
+  const schema = getStudioNodeConfigurationSchema(stepType);
+  return Object.fromEntries(
+    schema.fields.map((field) => [
+      field.name,
+      stringifyConfigurationValue(
+        readStepParameterValue(parameters, stepType, field.parameterName),
+      ),
+    ]),
+  );
+}
+
+export function applyStudioNodeConfigurationValues(
+  stepType: string,
+  parameters: Record<string, unknown> | null | undefined,
+  values: Record<string, string>,
+): Record<string, unknown> {
+  const schema = getStudioNodeConfigurationSchema(stepType);
+  const nextParameters = {
+    ...(parameters && typeof parameters === 'object' ? parameters : {}),
+  };
+
+  for (const field of schema.fields) {
+    const value = values[field.name] ?? '';
+    const resolvedParameterName = resolveStepParameterName(
+      stepType,
+      field.parameterName,
+    );
+    if (field.required || value.trim()) {
+      nextParameters[resolvedParameterName] = value;
+    } else {
+      delete nextParameters[resolvedParameterName];
+    }
+  }
+
+  return normalizeStepParametersForType(stepType, nextParameters);
+}
+
+export function applyRawStudioNodeConfiguration(
+  stepType: string,
+  rawConfigurationText: string,
+): Record<string, unknown> {
+  return normalizeStepParametersForType(
+    stepType,
+    parseInspectorParameters(rawConfigurationText),
+  );
+}
+
+export function formatRawStudioNodeConfiguration(
+  parameters: Record<string, unknown> | null | undefined,
+): string {
+  return formatInspectorParameters(parameters);
+}


### PR DESCRIPTION
## Summary
- Restore the Workflow Studio frontend configurator changes from #1912 after #1921 reverted the mixed frontend/backend PR
- Keep this PR scoped to `apps/aevatar-console-web` only
- Preserve the backend workflow transition semantics for a separate PR

## Verification
- `npm --prefix apps/aevatar-console-web test -- --runInBand src/shared/studio/nodeConfiguration.test.ts src/pages/team-member-workflow-studio/index.test.tsx src/shared/studio/document.test.ts src/shared/studio/graph.test.ts src/shared/graphs/GraphCanvas.test.tsx src/locales/catalog.test.ts src/locales/hardcodedCopyAudit.test.ts`
- `npm --prefix apps/aevatar-console-web run tsc -- --pretty false`
- `git diff --check`

## Scope check
- `git diff --cached --name-only -- ':!apps/aevatar-console-web'` was empty before commit.