### PR TITLE
Make workflow transitions explicit

### DIFF
--- a/src/Aevatar.Studio.Domain/Studio/Services/WorkflowValidator.cs
+++ b/src/Aevatar.Studio.Domain/Studio/Services/WorkflowValidator.cs
@@ -189,14 +189,6 @@ public sealed class WorkflowValidator
 
         ValidateStepTypeParameters(step, stepPath, availableStepTypes, findings);
         ValidateTypeSpecificRules(step, stepPath, stepIds, availableWorkflowNames, findings);
-
-        if (visit.Index < visit.SiblingCount - 1 && string.IsNullOrWhiteSpace(step.Next) && step.Branches.Count == 0)
-        {
-            findings.Add(ValidationFinding.Warning(
-                stepPath,
-                $"Step '{step.Id}' relies on implicit sequential ordering because `next` is not set.",
-                code: "implicit_next"));
-        }
     }
 
     private void ValidateStepTypeParameters(

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowDefinition.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowDefinition.cs
@@ -31,7 +31,7 @@ public sealed class WorkflowDefinition
     public required List<RoleDefinition> Roles { get; init; }
 
     /// <summary>
-    /// 步骤定义列表，按执行顺序排列。
+    /// 步骤定义列表，按文档顺序排列；执行流由显式 Next 或 Branches 定义。
     /// </summary>
     public required List<StepDefinition> Steps { get; init; }
 
@@ -53,8 +53,7 @@ public sealed class WorkflowDefinition
     public StepDefinition? GetStep(string id) => Steps.Find(s => s.Id == id);
 
     /// <summary>
-    /// 获取当前步骤的后继步骤。
-    /// 优先使用步骤的 Next 字段，否则按顺序取下一项。
+    /// 获取当前步骤的显式后继步骤。
     /// </summary>
     /// <param name="currentId">当前步骤 ID。</param>
     /// <returns>后继步骤定义，若无则返回 null。</returns>
@@ -63,7 +62,7 @@ public sealed class WorkflowDefinition
     /// <summary>
     /// 获取后继步骤，支持 switch/conditional 分支。
     /// 当 <paramref name="branchKey"/> 非空时，优先从 <c>Branches[branchKey]</c> 查找目标步骤，
-    /// 找不到则尝试 <c>Branches["_default"]</c>，最后回退到 <see cref="GetNextStep(string)"/>。
+    /// 找不到则尝试 <c>Branches["_default"]</c>，最后回退到显式 <c>Next</c>。
     /// </summary>
     public StepDefinition? GetNextStep(string currentId, string? branchKey)
     {
@@ -78,9 +77,7 @@ public sealed class WorkflowDefinition
                 return defFound;
         }
 
-        if (s.Next != null) return GetStep(s.Next);
-        var idx = Steps.FindIndex(x => x.Id == currentId);
-        return idx >= 0 && idx + 1 < Steps.Count ? Steps[idx + 1] : null;
+        return string.IsNullOrWhiteSpace(s.Next) ? null : GetStep(s.Next);
     }
 }
 

--- a/src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowCatalogCurrentStateProjector.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowCatalogCurrentStateProjector.cs
@@ -221,14 +221,6 @@ public sealed class WorkflowCatalogCurrentStateProjector
                     });
                 }
             }
-            else if (i + 1 < definition.Steps.Count)
-            {
-                edges.Add(new WorkflowCatalogEdgeReadModel
-                {
-                    From = step.Id,
-                    To = definition.Steps[i + 1].Id,
-                });
-            }
 
             if (step.Children is { Count: > 0 })
             {

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeDraftRunWorkflowRunCurrentStateIntegrationTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeDraftRunWorkflowRunCurrentStateIntegrationTests.cs
@@ -319,6 +319,7 @@ public sealed class ScopeDraftRunWorkflowActorCurrentStateIntegrationTests
         steps:
           - id: call_level1
             type: workflow_call
+            next: format_final_output
             parameters:
               workflow: "subworkflow_level1"
 
@@ -335,6 +336,7 @@ public sealed class ScopeDraftRunWorkflowActorCurrentStateIntegrationTests
         steps:
           - id: call_level2
             type: workflow_call
+            next: reverse_lines_level1
             parameters:
               workflow: "subworkflow_level2"
 
@@ -350,6 +352,7 @@ public sealed class ScopeDraftRunWorkflowActorCurrentStateIntegrationTests
         steps:
           - id: call_level3
             type: workflow_call
+            next: distinct_level2
             parameters:
               workflow: "subworkflow_level3"
 

--- a/test/Aevatar.Integration.Tests/WorkflowIntegrationTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowIntegrationTests.cs
@@ -56,9 +56,11 @@ public class WorkflowIntegrationTests
           - id: research
             type: llm_call
             target_role: researcher
+            next: review
           - id: review
             type: llm_call
             target_role: reviewer
+            next: write
           - id: write
             type: llm_call
             target_role: writer

--- a/test/Aevatar.Integration.Tests/WorkflowLoopModuleCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowLoopModuleCoverageTests.cs
@@ -65,6 +65,7 @@ public sealed class WorkflowLoopModuleCoverageTests
             {
                 Id = "s1",
                 Type = "connector_call",
+                Next = "s2",
                 TargetRole = "coordinator",
                 Parameters = new Dictionary<string, string> { ["connector"] = "conn-a" },
             },
@@ -87,7 +88,7 @@ public sealed class WorkflowLoopModuleCoverageTests
             Envelope(new StepCompletedEvent { StepId = "s1", RunId = runId, Success = true, Output = "next-input" }),
             ctx,
             CancellationToken.None);
-        var secondRequest = ctx.Published.Should().ContainSingle().Subject.evt.Should().BeOfType<StepRequestEvent>().Subject;
+        var secondRequest = SingleStepRequest(ctx);
         secondRequest.StepId.Should().Be("s2");
         secondRequest.Input.Should().Be("next-input");
         ctx.Published.Clear();
@@ -458,6 +459,7 @@ public sealed class WorkflowLoopModuleCoverageTests
             {
                 Id = "s1",
                 Type = "llm_call",
+                Next = "s2",
                 OnError = new StepErrorPolicy
                 {
                     Strategy = "skip",
@@ -483,7 +485,7 @@ public sealed class WorkflowLoopModuleCoverageTests
             ctx,
             CancellationToken.None);
 
-        var nextRequest = ctx.Published.Should().ContainSingle().Subject.evt.Should().BeOfType<StepRequestEvent>().Subject;
+        var nextRequest = SingleStepRequest(ctx);
         nextRequest.StepId.Should().Be("s2");
         nextRequest.Input.Should().Be("skip-next-input");
     }
@@ -823,6 +825,7 @@ public sealed class WorkflowLoopModuleCoverageTests
             {
                 Id = "s1",
                 Type = "llm_call",
+                Next = "s2",
                 TimeoutMs = 2000,
             },
             new StepDefinition
@@ -843,7 +846,7 @@ public sealed class WorkflowLoopModuleCoverageTests
             ctx,
             CancellationToken.None);
 
-        var next = ctx.Published.Should().ContainSingle().Subject.evt.Should().BeOfType<StepRequestEvent>().Subject;
+        var next = SingleStepRequest(ctx);
         next.StepId.Should().Be("s2");
         ctx.Canceled.Should().ContainSingle(x =>
             x.CallbackId.StartsWith("workflow-step-timeout:run-cancel-timeout:s1:", StringComparison.Ordinal));
@@ -945,6 +948,7 @@ public sealed class WorkflowLoopModuleCoverageTests
             {
                 Id = "s1",
                 Type = "assign",
+                Next = "s2",
             },
             new StepDefinition
             {
@@ -984,7 +988,7 @@ public sealed class WorkflowLoopModuleCoverageTests
             ctx,
             CancellationToken.None);
 
-        var conditionalRequest = ctx.Published.Should().ContainSingle().Subject.evt.Should().BeOfType<StepRequestEvent>().Subject;
+        var conditionalRequest = SingleStepRequest(ctx);
         conditionalRequest.StepId.Should().Be("s2");
         conditionalRequest.Parameters["condition"].Should().Be("true");
     }
@@ -1053,6 +1057,12 @@ public sealed class WorkflowLoopModuleCoverageTests
             .Where(x => x.direction == direction)
             .Select(x => x.evt)
             .OfType<WorkflowCompletedEvent>()
+            .Single();
+
+    private static StepRequestEvent SingleStepRequest(TestEventHandlerContext ctx) =>
+        ctx.Published
+            .Select(x => x.evt)
+            .OfType<StepRequestEvent>()
             .Single();
 
     private static EventEnvelope Envelope(IMessage evt)

--- a/test/Aevatar.Integration.Tests/WorkflowTuringCompletenessTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowTuringCompletenessTests.cs
@@ -67,6 +67,7 @@ public sealed class WorkflowTuringCompletenessTests
                 {
                     Id = "init_c1",
                     Type = "assign",
+                    Next = "init_c2",
                     Parameters = new Dictionary<string, string>
                     {
                         ["target"] = "c1",
@@ -77,6 +78,7 @@ public sealed class WorkflowTuringCompletenessTests
                 {
                     Id = "init_c2",
                     Type = "assign",
+                    Next = "check_c1",
                     Parameters = new Dictionary<string, string>
                     {
                         ["target"] = "c2",
@@ -147,6 +149,7 @@ public sealed class WorkflowTuringCompletenessTests
                 {
                     Id = "init_a",
                     Type = "assign",
+                    Next = "init_b",
                     Parameters = new Dictionary<string, string>
                     {
                         ["target"] = "a",
@@ -157,6 +160,7 @@ public sealed class WorkflowTuringCompletenessTests
                 {
                     Id = "init_b",
                     Type = "assign",
+                    Next = "check_b",
                     Parameters = new Dictionary<string, string>
                     {
                         ["target"] = "b",

--- a/test/Aevatar.Studio.Tests/WorkflowValidatorTests.cs
+++ b/test/Aevatar.Studio.Tests/WorkflowValidatorTests.cs
@@ -219,7 +219,7 @@ public sealed class WorkflowValidatorTests
     }
 
     [Fact]
-    public void Validate_ShouldReportWarning_WhenImplicitSequentialOrdering()
+    public void Validate_ShouldAllowAdjacentDisconnectedSteps()
     {
         var doc = new WorkflowDocument
         {
@@ -232,7 +232,8 @@ public sealed class WorkflowValidatorTests
             ],
         };
         var findings = _validator.Validate(doc);
-        findings.Should().Contain(f => f.Code == "implicit_next");
+        findings.Should().NotContain(f => f.Code == "implicit_next");
+        findings.Where(f => f.Level == ValidationLevel.Error).Should().BeEmpty();
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Core.Tests/Modules/RuntimeCallbackEventizationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/RuntimeCallbackEventizationTests.cs
@@ -988,6 +988,66 @@ public class RuntimeCallbackEventizationTests
     }
 
     [Fact]
+    public async Task WorkflowLoop_ShouldNotDispatchAdjacentDisconnectedStepWhenOnErrorSkipHasNoNextStep()
+    {
+        var ctx = new SchedulingContext();
+        var module = CreateKernel(new WorkflowDefinition
+        {
+            Name = "wf-skip-disconnected",
+            Roles = [],
+            Steps =
+            [
+                new StepDefinition
+                {
+                    Id = "step-1",
+                    Type = "transform",
+                    OnError = new StepErrorPolicy
+                    {
+                        Strategy = "skip",
+                        DefaultOutput = "skipped-output",
+                    },
+                },
+                new StepDefinition
+                {
+                    Id = "disconnected",
+                    Type = "transform",
+                },
+            ],
+        }, ctx);
+
+        await module.HandleAsync(
+            Wrap(new StartWorkflowEvent
+            {
+                WorkflowName = "wf-skip-disconnected",
+                RunId = "run-skip-disconnected",
+                Input = "input",
+            }),
+            ctx,
+            CancellationToken.None);
+        ctx.Published.Clear();
+
+        await module.HandleAsync(
+            Wrap(new StepCompletedEvent
+            {
+                StepId = "step-1",
+                RunId = "run-skip-disconnected",
+                Success = false,
+                Error = "boom",
+            }),
+            ctx,
+            CancellationToken.None);
+
+        ctx.Published
+            .Select(x => x.Event)
+            .OfType<StepRequestEvent>()
+            .Should()
+            .NotContain(request => request.StepId == "disconnected");
+        var completion = SingleWorkflowCompletion(ctx);
+        completion.Success.Should().BeTrue();
+        completion.Output.Should().Be("skipped-output");
+    }
+
+    [Fact]
     public async Task WorkflowLoop_ShouldDispatchFallbackStepWhenOnErrorFallbackConfigured()
     {
         var ctx = new SchedulingContext();

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowLoopModuleExpressionEvaluationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowLoopModuleExpressionEvaluationTests.cs
@@ -28,6 +28,7 @@ public class WorkflowLoopModuleExpressionEvaluationTests
                 {
                     Id = "first",
                     Type = "transform",
+                    Next = "second",
                     Parameters = new Dictionary<string, string>
                     {
                         ["value"] = "${concat('v=', input)}",
@@ -77,6 +78,59 @@ public class WorkflowLoopModuleExpressionEvaluationTests
         secondReq!.StepId.Should().Be("second");
         secondReq.Input.Should().Be("out1");
         secondReq.Parameters["value"].Should().Be("prev=out1, input=out1");
+    }
+
+    [Fact]
+    public async Task WorkflowLoop_WhenAdjacentStepIsNotExplicitlyConnected_ShouldCompleteWithoutDispatchingIt()
+    {
+        var workflow = new WorkflowDefinition
+        {
+            Name = "wf",
+            Roles = [],
+            Steps =
+            [
+                new StepDefinition
+                {
+                    Id = "first",
+                    Type = "transform",
+                },
+                new StepDefinition
+                {
+                    Id = "disconnected",
+                    Type = "transform",
+                },
+            ],
+        };
+
+        var ctx = new CapturingContext();
+        var module = new WorkflowExecutionKernel(workflow, (IWorkflowExecutionStateHost)ctx.Agent);
+        const string runId = "run-disconnected";
+
+        await module.HandleAsync(Wrap(new StartWorkflowEvent
+        {
+            WorkflowName = "wf",
+            RunId = runId,
+            Input = "hello",
+        }), ctx, CancellationToken.None);
+
+        ctx.Published.Clear();
+
+        await module.HandleAsync(Wrap(new StepCompletedEvent
+        {
+            StepId = "first",
+            RunId = runId,
+            Success = true,
+            Output = "done",
+        }), ctx, CancellationToken.None);
+
+        ctx.Published
+            .Select(x => x.Event)
+            .OfType<StepRequestEvent>()
+            .Should()
+            .NotContain(request => request.StepId == "disconnected");
+        ctx.Published.Should().ContainSingle(x =>
+            x.Direction == TopologyAudience.Parent &&
+            x.Event is WorkflowCompletedEvent);
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowDefinitionTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowDefinitionTests.cs
@@ -94,14 +94,24 @@ public class WorkflowDefinitionTests
     }
 
     [Fact]
-    public void GetNextStep_WhenNoNextPointer_ShouldUseSequentialOrder()
+    public void GetNextStep_WhenNoNextPointer_ShouldReturnNull()
     {
         var workflow = BuildWorkflow(
             new StepDefinition { Id = "s1", Type = "llm_call" },
             new StepDefinition { Id = "s2", Type = "transform" });
 
-        workflow.GetNextStep("s1")!.Id.Should().Be("s2");
+        workflow.GetNextStep("s1").Should().BeNull();
         workflow.GetNextStep("s2").Should().BeNull();
+    }
+
+    [Fact]
+    public void GetNextStep_WhenNextPointerSet_ShouldUseExplicitTarget()
+    {
+        var workflow = BuildWorkflow(
+            new StepDefinition { Id = "s1", Type = "llm_call", Next = "s2" },
+            new StepDefinition { Id = "s2", Type = "transform" });
+
+        workflow.GetNextStep("s1")!.Id.Should().Be("s2");
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowProjectionMaterializationTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowProjectionMaterializationTests.cs
@@ -213,6 +213,41 @@ public sealed class WorkflowProjectionMaterializationTests
     }
 
     [Fact]
+    public async Task WorkflowCatalogCurrentStateProjector_ShouldNotInferEdgesFromAdjacentSteps()
+    {
+        var store = new RecordingDocumentStore<WorkflowCatalogCurrentStateDocument>(x => x.Id);
+        var projector = new WorkflowCatalogCurrentStateProjector(
+            store,
+            new FixedClock(DateTimeOffset.Parse("2026-03-17T10:00:00+00:00")));
+        var context = new WorkflowBindingProjectionContext
+        {
+            RootActorId = "workflow-definition:draft_disconnected",
+            ProjectionKind = "workflow-binding",
+        };
+
+        await projector.ProjectAsync(
+            context,
+            BuildDefinitionCommittedEnvelope(
+                11,
+                new BindWorkflowDefinitionEvent
+                {
+                    WorkflowName = "draft_disconnected",
+                    WorkflowYaml = BuildDisconnectedDefinitionYaml("draft_disconnected"),
+                },
+                new WorkflowState
+                {
+                    WorkflowName = "draft_disconnected",
+                    WorkflowYaml = BuildDisconnectedDefinitionYaml("draft_disconnected"),
+                    Compiled = true,
+                }));
+
+        var document = store.Stored["draft_disconnected"];
+        document.Steps.Select(step => step.Id).Should().Equal("draft", "review", "publish");
+        document.Edges.Should().ContainSingle(edge => edge.From == "review" && edge.To == "publish");
+        document.Edges.Should().NotContain(edge => edge.From == "draft" && edge.To == "review");
+    }
+
+    [Fact]
     public async Task WorkflowRunInsightReportArtifactProjector_ShouldTrackLifecycleReplyAndCompletionBranches()
     {
         var store = new RecordingDocumentStore<WorkflowRunInsightReportDocument>(x => x.Id);
@@ -685,6 +720,33 @@ public sealed class WorkflowProjectionMaterializationTests
                 type: llm_call
                 target_role: operator
                 prompt: "Summarize."
+        """;
+
+    private static string BuildDisconnectedDefinitionYaml(string name) =>
+        $"""
+        name: {name}
+        description: Draft with a disconnected node.
+        roles:
+          - id: operator
+            name: Operator
+            system_prompt: ""
+        steps:
+          - id: draft
+            type: assign
+            parameters:
+              target: draft
+              value: "ok"
+          - id: review
+            type: assign
+            next: publish
+            parameters:
+              target: review
+              value: "ok"
+          - id: publish
+            type: assign
+            parameters:
+              target: publish
+              value: "ok"
         """;
 
     private static WorkflowRunState BuildState(


### PR DESCRIPTION
## Summary
- Split the backend workflow transition semantics out of the mixed #1912 frontend PR
- Stop treating adjacent workflow steps as implicit execution/projection edges
- Require explicit `next` / `branches` links in runtime, validator expectations, catalog projection, and tests

## Impact paths
- `src/Aevatar.Studio.Domain/Studio/Services/WorkflowValidator.cs`
- `src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowDefinition.cs`
- `src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowCatalogCurrentStateProjector.cs`
- related workflow runtime/projection tests

## Verification
- `bash tools/ci/test_stability_guards.sh`
- `git diff --check`

## Not run
- Targeted `dotnet test` commands: local environment does not have `dotnet` on PATH or in common install locations (`/usr/local/share/dotnet`, `/opt/homebrew/bin`, `$HOME/.dotnet`).

## Split context
- Frontend-only restore PR: #1922
- This PR intentionally excludes `apps/aevatar-console-web`.