### PR TITLE
实现 workflow inline 文件大小校验

### DIFF
--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunModels.cs
@@ -168,6 +168,7 @@ public enum WorkflowChatRunStartError
     PromptRequired = 9,
     ProjectionUnavailable = 10,
     InvalidCallerCredential = 11,
+    InvalidFileInput = 12,
 }
 
 public enum WorkflowProjectionCompletionStatus

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatCapabilityModels.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatCapabilityModels.cs
@@ -121,6 +121,7 @@ public sealed record WorkflowChatInlineYamlDocumentInput
     public string? Yaml { get; init; }
 }
 
+[JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
 public sealed record ChatInputContentPart
 {
     public required string Type { get; init; }
@@ -128,6 +129,25 @@ public sealed record ChatInputContentPart
     public string? DataBase64 { get; init; }
     public string? MediaType { get; init; }
     public string? Uri { get; init; }
+    public string? Name { get; init; }
+    public ChatInputInlineFile? InlineFile { get; init; }
+    public ChatInputFileRef? FileRef { get; init; }
+}
+
+[JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
+public sealed record ChatInputInlineFile
+{
+    public string? DataBase64 { get; init; }
+    public string? MediaType { get; init; }
+    public string? Name { get; init; }
+    public long? SizeBytes { get; init; }
+}
+
+[JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
+public sealed record ChatInputFileRef
+{
+    public string? Uri { get; init; }
+    public string? MediaType { get; init; }
     public string? Name { get; init; }
 }
 

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunRequestNormalizer.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunRequestNormalizer.cs
@@ -41,7 +41,11 @@ internal static class ChatRunRequestNormalizer
         //   New principle: chat sources execute unchanged; hidden prompt mutation removed; explicit authoring surface (if needed) deferred to later-slice design
         ArgumentNullException.ThrowIfNull(input);
 
-        var normalizedInputParts = NormalizeInputParts(input.InputParts);
+        var normalizedInputPartsResult = NormalizeInputParts(input.InputParts);
+        if (normalizedInputPartsResult.Error != WorkflowChatRunStartError.None)
+            return ChatRunRequestNormalizationResult.Failed(normalizedInputPartsResult.Error);
+
+        var normalizedInputParts = normalizedInputPartsResult.InputParts;
         if (HasOnlyUnsupportedInputParts(input, normalizedInputParts))
             return ChatRunRequestNormalizationResult.Failed(WorkflowChatRunStartError.PromptRequired);
 
@@ -263,15 +267,26 @@ internal static class ChatRunRequestNormalizer
     private static string NormalizeWorkflowName(string? workflowName) =>
         string.IsNullOrWhiteSpace(workflowName) ? string.Empty : workflowName.Trim();
 
-    private static IReadOnlyList<WorkflowChatInputPart>? NormalizeInputParts(IReadOnlyList<ChatInputContentPart>? inputParts)
+    private readonly record struct InputPartsNormalizationResult(
+        IReadOnlyList<WorkflowChatInputPart>? InputParts,
+        WorkflowChatRunStartError Error);
+
+    private static InputPartsNormalizationResult NormalizeInputParts(IReadOnlyList<ChatInputContentPart>? inputParts)
     {
         if (inputParts == null || inputParts.Count == 0)
-            return null;
+            return new InputPartsNormalizationResult(null, WorkflowChatRunStartError.None);
 
         var normalized = new List<WorkflowChatInputPart>(inputParts.Count);
         foreach (var part in inputParts)
         {
-            if (part == null || string.IsNullOrWhiteSpace(part.Type))
+            if (part == null)
+                continue;
+
+            var fileInputResult = NormalizeFileInput(part);
+            if (fileInputResult.Error != WorkflowChatRunStartError.None)
+                return new InputPartsNormalizationResult(null, fileInputResult.Error);
+
+            if (string.IsNullOrWhiteSpace(part.Type))
                 continue;
 
             if (!TryParseContentPartKind(part.Type, out var kind))
@@ -281,15 +296,125 @@ internal static class ChatRunRequestNormalizer
             {
                 Kind = kind,
                 Text = string.IsNullOrWhiteSpace(part.Text) ? null : part.Text,
-                DataBase64 = string.IsNullOrWhiteSpace(part.DataBase64) ? null : part.DataBase64,
-                MediaType = string.IsNullOrWhiteSpace(part.MediaType) ? null : part.MediaType,
-                Uri = string.IsNullOrWhiteSpace(part.Uri) ? null : part.Uri,
-                Name = string.IsNullOrWhiteSpace(part.Name) ? null : part.Name,
+                DataBase64 = fileInputResult.DataBase64 ?? NormalizeContentPartValue(part.DataBase64),
+                MediaType = fileInputResult.MediaType ?? NormalizeContentPartValue(part.MediaType),
+                Uri = fileInputResult.Uri ?? NormalizeContentPartValue(part.Uri),
+                Name = fileInputResult.Name ?? NormalizeContentPartValue(part.Name),
             });
         }
 
-        return normalized.Count == 0 ? null : normalized;
+        return new InputPartsNormalizationResult(
+            normalized.Count == 0 ? null : normalized,
+            WorkflowChatRunStartError.None);
     }
+
+    private readonly record struct FileInputNormalizationResult(
+        string? DataBase64,
+        string? MediaType,
+        string? Uri,
+        string? Name,
+        WorkflowChatRunStartError Error);
+
+    private static FileInputNormalizationResult NormalizeFileInput(ChatInputContentPart part)
+    {
+        if (part.InlineFile != null && part.FileRef != null)
+            return InvalidFileInput();
+
+        if (part.InlineFile != null)
+            return NormalizeInlineFile(part.InlineFile);
+
+        if (part.FileRef != null)
+            return new FileInputNormalizationResult(
+                null,
+                NormalizeContentPartValue(part.FileRef.MediaType),
+                NormalizeContentPartValue(part.FileRef.Uri),
+                NormalizeContentPartValue(part.FileRef.Name),
+                WorkflowChatRunStartError.None);
+
+        return new FileInputNormalizationResult(null, null, null, null, WorkflowChatRunStartError.None);
+    }
+
+    private static FileInputNormalizationResult NormalizeInlineFile(ChatInputInlineFile inlineFile)
+    {
+        var dataBase64 = NormalizeOptional(inlineFile.DataBase64);
+        if (dataBase64 == null)
+            return InvalidFileInput();
+
+        if (!TryGetDecodedByteLength(dataBase64, out var decodedByteLength))
+            return InvalidFileInput();
+
+        if (inlineFile.SizeBytes.HasValue)
+        {
+            if (inlineFile.SizeBytes.Value < 0)
+                return InvalidFileInput();
+
+            if (inlineFile.SizeBytes.Value != decodedByteLength)
+                return InvalidFileInput();
+        }
+
+        return new FileInputNormalizationResult(
+            dataBase64,
+            NormalizeContentPartValue(inlineFile.MediaType),
+            null,
+            NormalizeContentPartValue(inlineFile.Name),
+            WorkflowChatRunStartError.None);
+    }
+
+    private static FileInputNormalizationResult InvalidFileInput() =>
+        new(null, null, null, null, WorkflowChatRunStartError.InvalidFileInput);
+
+    private static bool TryGetDecodedByteLength(string dataBase64, out long decodedByteLength)
+    {
+        long base64Length = 0;
+        var padding = 0;
+        var hasPadding = false;
+
+        foreach (var ch in dataBase64)
+        {
+            if (char.IsWhiteSpace(ch))
+                continue;
+
+            if (ch == '=')
+            {
+                hasPadding = true;
+                padding++;
+                base64Length++;
+                if (padding > 2)
+                {
+                    decodedByteLength = 0;
+                    return false;
+                }
+
+                continue;
+            }
+
+            if (hasPadding || !IsBase64Character(ch))
+            {
+                decodedByteLength = 0;
+                return false;
+            }
+
+            base64Length++;
+        }
+
+        if (base64Length == 0 || base64Length % 4 != 0)
+        {
+            decodedByteLength = 0;
+            return false;
+        }
+
+        decodedByteLength = (base64Length / 4 * 3) - padding;
+        return true;
+    }
+
+    private static bool IsBase64Character(char ch) =>
+        ch is >= 'A' and <= 'Z' ||
+        ch is >= 'a' and <= 'z' ||
+        ch is >= '0' and <= '9' ||
+        ch is '+' or '/';
+
+    private static string? NormalizeContentPartValue(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
 
     private static bool HasOnlyUnsupportedInputParts(
         ChatInput input,

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunStartErrorMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunStartErrorMapper.cs
@@ -20,6 +20,7 @@ internal static class ChatRunStartErrorMapper
             WorkflowChatRunStartError.WorkflowNameMismatch => StatusCodes.Status400BadRequest,
             WorkflowChatRunStartError.PromptRequired => StatusCodes.Status400BadRequest,
             WorkflowChatRunStartError.InvalidCallerCredential => StatusCodes.Status400BadRequest,
+            WorkflowChatRunStartError.InvalidFileInput => StatusCodes.Status400BadRequest,
             _ => StatusCodes.Status400BadRequest,
         };
     }
@@ -39,6 +40,7 @@ internal static class ChatRunStartErrorMapper
             WorkflowChatRunStartError.WorkflowNameMismatch => ("WORKFLOW_NAME_MISMATCH", "Workflow name does not match workflow YAML."),
             WorkflowChatRunStartError.PromptRequired => ("PROMPT_REQUIRED", "Prompt is required."),
             WorkflowChatRunStartError.InvalidCallerCredential => ("INVALID_CALLER_CREDENTIAL", "Caller credential is invalid."),
+            WorkflowChatRunStartError.InvalidFileInput => ("INVALID_FILE_INPUT", "File input is invalid."),
             _ => ("RUN_START_FAILED", "Failed to resolve actor."),
         };
     }

--- a/src/workflow/Aevatar.Workflow.Sdk/Contracts/WorkflowContracts.cs
+++ b/src/workflow/Aevatar.Workflow.Sdk/Contracts/WorkflowContracts.cs
@@ -21,6 +21,23 @@ public sealed record ChatRunContentPart
     public string? MediaType { get; init; }
     public string? Uri { get; init; }
     public string? Name { get; init; }
+    public ChatRunInlineFilePart? InlineFile { get; init; }
+    public ChatRunFileRefPart? FileRef { get; init; }
+}
+
+public sealed record ChatRunInlineFilePart
+{
+    public string? DataBase64 { get; init; }
+    public string? MediaType { get; init; }
+    public string? Name { get; init; }
+    public long? SizeBytes { get; init; }
+}
+
+public sealed record ChatRunFileRefPart
+{
+    public string? Uri { get; init; }
+    public string? MediaType { get; init; }
+    public string? Name { get; init; }
 }
 
 public sealed record WorkflowResumeRequest

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
@@ -1,5 +1,6 @@
 using System.Net.WebSockets;
 using System.Text;
+using System.Text.Json;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.Workflow.Abstractions;
@@ -173,6 +174,123 @@ public sealed class ChatEndpointsInternalTests
         service.LastCommand.InputParts.Should().ContainSingle();
         service.LastCommand.InputParts![0].Kind.Should()
             .Be(Aevatar.Workflow.Application.Abstractions.Runs.WorkflowChatInputPartKind.Image);
+    }
+
+    [Fact]
+    public async Task PostChat_ShouldReturnInvalidFileInput_WhenInlineFileSizeBytesMismatchesDecodedBytes()
+    {
+        var service = new FakeCommandDispatchService();
+        var input = JsonSerializer.Deserialize<ChatInput>(
+            """
+            {
+              "inputParts": [
+                {
+                  "type": "image",
+                  "inlineFile": {
+                    "dataBase64": "aGVsbG8=",
+                    "mediaType": "image/png",
+                    "sizeBytes": 6
+                  }
+                }
+              ]
+            }
+            """,
+            ChatWebSocketProtocol.JsonOptions)!;
+
+        var result = await WorkflowCapabilityEndpoints.HandleCommand(
+            input,
+            service,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+
+        var http = CreateHttpContext();
+        await result.ExecuteAsync(http);
+        var body = await ReadBodyAsync(http.Response);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        body.Should().Contain("INVALID_FILE_INPUT");
+        service.DispatchCalls.Should().Be(0);
+        service.LastCommand.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PostChat_ShouldReturnInvalidFileInput_WhenUnsupportedInputPartHasInvalidInlineFileSizeBytes()
+    {
+        var service = new FakeCommandDispatchService();
+        var input = JsonSerializer.Deserialize<ChatInput>(
+            """
+            {
+              "prompt": "describe this",
+              "inputParts": [
+                {
+                  "type": "unsupported",
+                  "inlineFile": {
+                    "dataBase64": "aGVsbG8=",
+                    "mediaType": "image/png",
+                    "sizeBytes": -1
+                  }
+                }
+              ]
+            }
+            """,
+            ChatWebSocketProtocol.JsonOptions)!;
+
+        var result = await WorkflowCapabilityEndpoints.HandleCommand(
+            input,
+            service,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+
+        var http = CreateHttpContext();
+        await result.ExecuteAsync(http);
+        var body = await ReadBodyAsync(http.Response);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        body.Should().Contain("INVALID_FILE_INPUT");
+        service.DispatchCalls.Should().Be(0);
+        service.LastCommand.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PostChat_ShouldDispatch_WhenInlineFileSizeBytesMatchesDecodedBytes()
+    {
+        var service = new FakeCommandDispatchService
+        {
+            Result = CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>.Success(
+                new WorkflowChatRunAcceptedReceipt("actor-1", "direct", "cmd-1", "corr-1")),
+        };
+        var input = JsonSerializer.Deserialize<ChatInput>(
+            """
+            {
+              "inputParts": [
+                {
+                  "type": "image",
+                  "inlineFile": {
+                    "dataBase64": "aGVsbG8=",
+                    "mediaType": "image/png",
+                    "name": "hello.png",
+                    "sizeBytes": 5
+                  }
+                }
+              ]
+            }
+            """,
+            ChatWebSocketProtocol.JsonOptions)!;
+
+        var result = await WorkflowCapabilityEndpoints.HandleCommand(
+            input,
+            service,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+
+        var http = CreateHttpContext();
+        await result.ExecuteAsync(http);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        service.DispatchCalls.Should().Be(1);
+        service.LastCommand.Should().NotBeNull();
+        service.LastCommand!.InputParts.Should().ContainSingle()
+            .Which.DataBase64.Should().Be("aGVsbG8=");
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatWebSocketCoordinatorAndProtocolTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatWebSocketCoordinatorAndProtocolTests.cs
@@ -164,6 +164,94 @@ public sealed class ChatWebSocketCoordinatorAndProtocolTests
     }
 
     [Fact]
+    public async Task ChatCommand_ShouldEmitInvalidFileInput_WhenInlineFileSizeBytesMismatchesDecodedBytes()
+    {
+        var socket = new FakeWebSocket(WebSocketState.Open);
+        var service = new FakeCommandInteractionService();
+        var input = JsonSerializer.Deserialize<ChatInput>(
+            """
+            {
+              "inputParts": [
+                {
+                  "type": "image",
+                  "inlineFile": {
+                    "dataBase64": "aGVsbG8=",
+                    "mediaType": "image/png",
+                    "sizeBytes": 6
+                  }
+                }
+              ]
+            }
+            """,
+            ChatWebSocketProtocol.JsonOptions)!;
+
+        await ChatWebSocketRunCoordinator.ExecuteAsync(
+            socket,
+            new ChatWebSocketCommandEnvelope(
+                "req-file",
+                input,
+                WebSocketMessageType.Text),
+            service,
+            ApiRequestScope.BeginHttp(),
+            CancellationToken.None);
+
+        socket.SentTexts.Should().ContainSingle();
+        socket.SentTexts[0].Should().Contain("\"type\":\"command.error\"");
+        socket.SentTexts[0].Should().Contain("INVALID_FILE_INPUT");
+        service.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ChatCommand_ShouldDispatch_WhenInlineFileSizeBytesMatchesDecodedBytes()
+    {
+        var socket = new FakeWebSocket(WebSocketState.Open);
+        var service = new FakeCommandInteractionService
+        {
+            Handler = async (_, _, onAcceptedAsync, ct) =>
+            {
+                var receipt = new WorkflowChatRunAcceptedReceipt("actor-1", "direct", "cmd-1", "corr-1");
+                if (onAcceptedAsync != null)
+                    await onAcceptedAsync(receipt, ct);
+                return CommandInteractionResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
+            },
+        };
+        var input = JsonSerializer.Deserialize<ChatInput>(
+            """
+            {
+              "inputParts": [
+                {
+                  "type": "image",
+                  "inlineFile": {
+                    "dataBase64": "aGVsbG8=",
+                    "mediaType": "image/png",
+                    "name": "hello.png",
+                    "sizeBytes": 5
+                  }
+                }
+              ]
+            }
+            """,
+            ChatWebSocketProtocol.JsonOptions)!;
+
+        await ChatWebSocketRunCoordinator.ExecuteAsync(
+            socket,
+            new ChatWebSocketCommandEnvelope(
+                "req-file",
+                input,
+                WebSocketMessageType.Text),
+            service,
+            ApiRequestScope.BeginHttp(),
+            CancellationToken.None);
+
+        socket.SentTexts.Should().ContainSingle();
+        socket.SentTexts[0].Should().Contain("\"type\":\"command.ack\"");
+        service.LastRequest.Should().NotBeNull();
+        service.LastRequest!.InputParts.Should().ContainSingle()
+            .Which.DataBase64.Should().Be("aGVsbG8=");
+    }
+
+    [Fact]
     public async Task ReceiveAsync_ShouldAssembleTextChunks()
     {
         var socket = new FakeWebSocket(WebSocketState.Open);

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowCapabilityEndpointsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowCapabilityEndpointsCoverageTests.cs
@@ -656,6 +656,192 @@ public sealed class WorkflowCapabilityEndpointsCoverageTests
     }
 
     [Fact]
+    public void ChatRunRequestNormalizer_ShouldAcceptFileInlineFileWithMatchingSizeBytes()
+    {
+        var input = JsonSerializer.Deserialize<ChatInput>(
+            """
+            {
+              "inputParts": [
+                {
+                  "type": "image",
+                  "inlineFile": {
+                    "dataBase64": "aGVsbG8=",
+                    "mediaType": "image/png",
+                    "name": "hello.png",
+                    "sizeBytes": 5
+                  }
+                }
+              ]
+            }
+            """,
+            ChatWebSocketProtocol.JsonOptions)!;
+
+        var result = ChatRunRequestNormalizer.Normalize(input);
+
+        result.Succeeded.Should().BeTrue();
+        result.Request!.Prompt.Should().Be("[image]");
+        result.Request.InputParts.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new WorkflowChatInputPart
+            {
+                Kind = Aevatar.Workflow.Application.Abstractions.Runs.WorkflowChatInputPartKind.Image,
+                DataBase64 = "aGVsbG8=",
+                MediaType = "image/png",
+                Name = "hello.png",
+            });
+    }
+
+    [Fact]
+    public void ChatRunRequestNormalizer_ShouldAcceptFileInlineFileWithoutSizeBytes()
+    {
+        var input = JsonSerializer.Deserialize<ChatInput>(
+            """
+            {
+              "inputParts": [
+                {
+                  "type": "image",
+                  "inlineFile": {
+                    "dataBase64": "aGVsbG8=",
+                    "mediaType": "image/png",
+                    "name": "hello.png"
+                  }
+                }
+              ]
+            }
+            """,
+            ChatWebSocketProtocol.JsonOptions)!;
+
+        var result = ChatRunRequestNormalizer.Normalize(input);
+
+        result.Succeeded.Should().BeTrue();
+        result.Request!.InputParts.Should().ContainSingle()
+            .Which.DataBase64.Should().Be("aGVsbG8=");
+    }
+
+    [Fact]
+    public void ChatRunRequestNormalizer_ShouldRejectFileInlineFileWithMismatchedSizeBytes()
+    {
+        var input = JsonSerializer.Deserialize<ChatInput>(
+            """
+            {
+              "inputParts": [
+                {
+                  "type": "image",
+                  "inlineFile": {
+                    "dataBase64": "aGVsbG8=",
+                    "mediaType": "image/png",
+                    "sizeBytes": 6
+                  }
+                }
+              ]
+            }
+            """,
+            ChatWebSocketProtocol.JsonOptions)!;
+
+        var result = ChatRunRequestNormalizer.Normalize(input);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(WorkflowChatRunStartError.InvalidFileInput);
+    }
+
+    [Fact]
+    public void ChatRunRequestNormalizer_ShouldRejectFileInlineFileWithNegativeSizeBytes()
+    {
+        var input = JsonSerializer.Deserialize<ChatInput>(
+            """
+            {
+              "inputParts": [
+                {
+                  "type": "image",
+                  "inlineFile": {
+                    "dataBase64": "aGVsbG8=",
+                    "mediaType": "image/png",
+                    "sizeBytes": -1
+                  }
+                }
+              ]
+            }
+            """,
+            ChatWebSocketProtocol.JsonOptions)!;
+
+        var result = ChatRunRequestNormalizer.Normalize(input);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(WorkflowChatRunStartError.InvalidFileInput);
+    }
+
+    [Fact]
+    public void ChatRunRequestNormalizer_ShouldRejectUnsupportedInputPartWithInvalidInlineFileSizeBytes()
+    {
+        var input = JsonSerializer.Deserialize<ChatInput>(
+            """
+            {
+              "prompt": "describe this",
+              "inputParts": [
+                {
+                  "type": "unsupported",
+                  "inlineFile": {
+                    "dataBase64": "aGVsbG8=",
+                    "mediaType": "image/png",
+                    "sizeBytes": -1
+                  }
+                }
+              ]
+            }
+            """,
+            ChatWebSocketProtocol.JsonOptions)!;
+
+        var result = ChatRunRequestNormalizer.Normalize(input);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(WorkflowChatRunStartError.InvalidFileInput);
+    }
+
+    [Fact]
+    public void ChatRunRequestNormalizer_ShouldRejectFileRefSizeBytes()
+    {
+        const string json = """
+            {
+              "inputParts": [
+                {
+                  "type": "image",
+                  "fileRef": {
+                    "uri": "artifact://file-1",
+                    "mediaType": "image/png",
+                    "name": "hello.png",
+                    "sizeBytes": 5
+                  }
+                }
+              ]
+            }
+            """;
+
+        var act = () => JsonSerializer.Deserialize<ChatInput>(json, ChatWebSocketProtocol.JsonOptions);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void ChatRunRequestNormalizer_ShouldRejectTopLevelFileSizeBytes()
+    {
+        const string json = """
+            {
+              "inputParts": [
+                {
+                  "type": "image",
+                  "dataBase64": "aGVsbG8=",
+                  "mediaType": "image/png",
+                  "sizeBytes": 5
+                }
+              ]
+            }
+            """;
+
+        var act = () => JsonSerializer.Deserialize<ChatInput>(json, ChatWebSocketProtocol.JsonOptions);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact]
     public void ChatRunRequestNormalizer_ShouldDerivePlaceholderPrompt_FromMediaOnlyInput()
     {
         var input = new ChatInput

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowCapabilityEndpointsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowCapabilityEndpointsCoverageTests.cs
@@ -718,6 +718,152 @@ public sealed class WorkflowCapabilityEndpointsCoverageTests
     }
 
     [Fact]
+    public void ChatRunRequestNormalizer_ShouldNormalizeFileRefInputPart()
+    {
+        var input = JsonSerializer.Deserialize<ChatInput>(
+            """
+            {
+              "inputParts": [
+                {
+                  "type": "image",
+                  "fileRef": {
+                    "uri": "artifact://file-1",
+                    "mediaType": "image/png",
+                    "name": "hello.png"
+                  }
+                }
+              ]
+            }
+            """,
+            ChatWebSocketProtocol.JsonOptions)!;
+
+        var result = ChatRunRequestNormalizer.Normalize(input);
+
+        result.Succeeded.Should().BeTrue();
+        result.Request!.Prompt.Should().Be("[image]");
+        result.Request.InputParts.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new WorkflowChatInputPart
+            {
+                Kind = Aevatar.Workflow.Application.Abstractions.Runs.WorkflowChatInputPartKind.Image,
+                Uri = "artifact://file-1",
+                MediaType = "image/png",
+                Name = "hello.png",
+            });
+    }
+
+    [Fact]
+    public void ChatRunRequestNormalizer_ShouldAcceptInlineFileBase64WithWhitespace()
+    {
+        var input = JsonSerializer.Deserialize<ChatInput>(
+            """
+            {
+              "inputParts": [
+                {
+                  "type": "image",
+                  "inlineFile": {
+                    "dataBase64": "aG Vs\nbG8=",
+                    "mediaType": "image/png",
+                    "sizeBytes": 5
+                  }
+                }
+              ]
+            }
+            """,
+            ChatWebSocketProtocol.JsonOptions)!;
+
+        var result = ChatRunRequestNormalizer.Normalize(input);
+
+        result.Succeeded.Should().BeTrue();
+        result.Request!.InputParts.Should().ContainSingle()
+            .Which.DataBase64.Should().Be("aG Vs\nbG8=");
+    }
+
+    [Fact]
+    public void ChatRunRequestNormalizer_ShouldRejectFilePartWithBothInlineFileAndFileRef()
+    {
+        var input = JsonSerializer.Deserialize<ChatInput>(
+            """
+            {
+              "prompt": "describe this",
+              "inputParts": [
+                {
+                  "type": "image",
+                  "inlineFile": {
+                    "dataBase64": "aGVsbG8=",
+                    "mediaType": "image/png"
+                  },
+                  "fileRef": {
+                    "uri": "artifact://file-1",
+                    "mediaType": "image/png"
+                  }
+                }
+              ]
+            }
+            """,
+            ChatWebSocketProtocol.JsonOptions)!;
+
+        var result = ChatRunRequestNormalizer.Normalize(input);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(WorkflowChatRunStartError.InvalidFileInput);
+    }
+
+    [Fact]
+    public void ChatRunRequestNormalizer_ShouldRejectInlineFileWithoutDataBase64()
+    {
+        var input = JsonSerializer.Deserialize<ChatInput>(
+            """
+            {
+              "prompt": "describe this",
+              "inputParts": [
+                {
+                  "type": "image",
+                  "inlineFile": {
+                    "mediaType": "image/png"
+                  }
+                }
+              ]
+            }
+            """,
+            ChatWebSocketProtocol.JsonOptions)!;
+
+        var result = ChatRunRequestNormalizer.Normalize(input);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(WorkflowChatRunStartError.InvalidFileInput);
+    }
+
+    [Theory]
+    [InlineData("aGVsbG8=AAAA")]
+    [InlineData("aGVsbG8!")]
+    [InlineData("====")]
+    [InlineData("abc")]
+    public void ChatRunRequestNormalizer_ShouldRejectInlineFileWithInvalidBase64(string dataBase64)
+    {
+        var input = new ChatInput
+        {
+            Prompt = "describe this",
+            InputParts =
+            [
+                new ChatInputContentPart
+                {
+                    Type = "image",
+                    InlineFile = new ChatInputInlineFile
+                    {
+                        DataBase64 = dataBase64,
+                        MediaType = "image/png",
+                    },
+                },
+            ],
+        };
+
+        var result = ChatRunRequestNormalizer.Normalize(input);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(WorkflowChatRunStartError.InvalidFileInput);
+    }
+
+    [Fact]
     public void ChatRunRequestNormalizer_ShouldRejectFileInlineFileWithMismatchedSizeBytes()
     {
         var input = JsonSerializer.Deserialize<ChatInput>(
@@ -809,6 +955,29 @@ public sealed class WorkflowCapabilityEndpointsCoverageTests
                     "mediaType": "image/png",
                     "name": "hello.png",
                     "sizeBytes": 5
+                  }
+                }
+              ]
+            }
+            """;
+
+        var act = () => JsonSerializer.Deserialize<ChatInput>(json, ChatWebSocketProtocol.JsonOptions);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void ChatRunRequestNormalizer_ShouldRejectInlineFileUnmappedJsonMembers()
+    {
+        const string json = """
+            {
+              "inputParts": [
+                {
+                  "type": "image",
+                  "inlineFile": {
+                    "dataBase64": "aGVsbG8=",
+                    "mediaType": "image/png",
+                    "checksum": "sha256:abc"
                   }
                 }
               ]

--- a/test/Aevatar.Workflow.Sdk.Tests/WorkflowFileInputJsonTests.cs
+++ b/test/Aevatar.Workflow.Sdk.Tests/WorkflowFileInputJsonTests.cs
@@ -80,6 +80,41 @@ public sealed class WorkflowFileInputJsonTests
     }
 
     [Fact]
+    public void ShouldDeserializeInlineFileSizeBytesWhenProvided()
+    {
+        var request = JsonSerializer.Deserialize<ChatRunRequest>(
+            """
+            {
+              "prompt": "hello",
+              "workflow": "direct",
+              "scopeId": "scope-1",
+              "inputParts": [
+                {
+                  "type": "image",
+                  "inlineFile": {
+                    "dataBase64": "aGVsbG8=",
+                    "mediaType": "image/png",
+                    "name": "hello.png",
+                    "sizeBytes": 5
+                  }
+                }
+              ]
+            }
+            """,
+            JsonOptions);
+
+        request.Should().NotBeNull();
+        request!.InputParts.Should().ContainSingle()
+            .Which.InlineFile.Should().BeEquivalentTo(new ChatRunInlineFilePart
+            {
+                DataBase64 = "aGVsbG8=",
+                MediaType = "image/png",
+                Name = "hello.png",
+                SizeBytes = 5,
+            });
+    }
+
+    [Fact]
     public void ShouldNotExposeSizeBytesOnFileRef()
     {
         typeof(ChatRunFileRefPart)
@@ -116,5 +151,38 @@ public sealed class WorkflowFileInputJsonTests
             .TryGetProperty("sizeBytes", out _)
             .Should()
             .BeFalse();
+    }
+
+    [Fact]
+    public void ShouldDeserializeFileRefPart()
+    {
+        var request = JsonSerializer.Deserialize<ChatRunRequest>(
+            """
+            {
+              "prompt": "hello",
+              "workflow": "direct",
+              "scopeId": "scope-1",
+              "inputParts": [
+                {
+                  "type": "image",
+                  "fileRef": {
+                    "uri": "artifact://file-1",
+                    "mediaType": "image/png",
+                    "name": "hello.png"
+                  }
+                }
+              ]
+            }
+            """,
+            JsonOptions);
+
+        request.Should().NotBeNull();
+        request!.InputParts.Should().ContainSingle()
+            .Which.FileRef.Should().BeEquivalentTo(new ChatRunFileRefPart
+            {
+                Uri = "artifact://file-1",
+                MediaType = "image/png",
+                Name = "hello.png",
+            });
     }
 }

--- a/test/Aevatar.Workflow.Sdk.Tests/WorkflowFileInputJsonTests.cs
+++ b/test/Aevatar.Workflow.Sdk.Tests/WorkflowFileInputJsonTests.cs
@@ -1,0 +1,120 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Aevatar.Workflow.Sdk.Contracts;
+using FluentAssertions;
+
+namespace Aevatar.Workflow.Sdk.Tests;
+
+public sealed class WorkflowFileInputJsonTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    [Fact]
+    public void ShouldSerializeInlineFileSizeBytesWhenProvided()
+    {
+        var request = new ChatRunRequest
+        {
+            Prompt = "hello",
+            Workflow = "direct",
+            ScopeId = "scope-1",
+            InputParts =
+            [
+                new ChatRunContentPart
+                {
+                    Type = "image",
+                    InlineFile = new ChatRunInlineFilePart
+                    {
+                        DataBase64 = "aGVsbG8=",
+                        MediaType = "image/png",
+                        Name = "hello.png",
+                        SizeBytes = 5,
+                    },
+                },
+            ],
+        };
+
+        var json = JsonSerializer.Serialize(request, JsonOptions);
+        using var doc = JsonDocument.Parse(json);
+
+        var inlineFile = doc.RootElement
+            .GetProperty("inputParts")[0]
+            .GetProperty("inlineFile");
+        inlineFile.GetProperty("sizeBytes").GetInt64().Should().Be(5);
+        inlineFile.GetProperty("dataBase64").GetString().Should().Be("aGVsbG8=");
+    }
+
+    [Fact]
+    public void ShouldOmitInlineFileSizeBytesWhenUnset()
+    {
+        var request = new ChatRunRequest
+        {
+            Prompt = "hello",
+            Workflow = "direct",
+            ScopeId = "scope-1",
+            InputParts =
+            [
+                new ChatRunContentPart
+                {
+                    Type = "image",
+                    InlineFile = new ChatRunInlineFilePart
+                    {
+                        DataBase64 = "aGVsbG8=",
+                        MediaType = "image/png",
+                    },
+                },
+            ],
+        };
+
+        var json = JsonSerializer.Serialize(request, JsonOptions);
+        using var doc = JsonDocument.Parse(json);
+
+        doc.RootElement
+            .GetProperty("inputParts")[0]
+            .GetProperty("inlineFile")
+            .TryGetProperty("sizeBytes", out _)
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact]
+    public void ShouldNotExposeSizeBytesOnFileRef()
+    {
+        typeof(ChatRunFileRefPart)
+            .GetProperty("SizeBytes")
+            .Should()
+            .BeNull();
+
+        var request = new ChatRunRequest
+        {
+            Prompt = "hello",
+            Workflow = "direct",
+            ScopeId = "scope-1",
+            InputParts =
+            [
+                new ChatRunContentPart
+                {
+                    Type = "image",
+                    FileRef = new ChatRunFileRefPart
+                    {
+                        Uri = "artifact://file-1",
+                        MediaType = "image/png",
+                        Name = "hello.png",
+                    },
+                },
+            ],
+        };
+
+        var json = JsonSerializer.Serialize(request, JsonOptions);
+        using var doc = JsonDocument.Parse(json);
+
+        doc.RootElement
+            .GetProperty("inputParts")[0]
+            .GetProperty("fileRef")
+            .TryGetProperty("sizeBytes", out _)
+            .Should()
+            .BeFalse();
+    }
+}


### PR DESCRIPTION
## 摘要

- 为 workflow chat/API inline 文件输入增加 `inlineFile.sizeBytes` 可选校验字段。
- 在 normalizer 中于 command dispatch 前 fail closed 负数、mismatch、无效 base64、`fileRef.sizeBytes` 与顶层 `sizeBytes`。
- 保持大小事实不进入 command、descriptor、readmodel、proto 或 projection authority；descriptor/readmodel size 仍来自实际 bytes。

Refs #1917

说明：本 PR 仅覆盖 #1917 中 chat/API inline 文件的 `inlineFile.sizeBytes` 校验子项；完整文件引用、artifact store、外部资源获取/提交、`document_extract`、projection readmodel 等验收项仍需后续 PR 继续实现。

## 验证

- `dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo --no-restore --filter "FullyQualifiedName~ChatRunRequestNormalizer_ShouldAcceptFileInlineFileWithMatchingSizeBytes|FullyQualifiedName~ChatRunRequestNormalizer_ShouldAcceptFileInlineFileWithoutSizeBytes|FullyQualifiedName~ChatRunRequestNormalizer_ShouldRejectFileInlineFileWithMismatchedSizeBytes|FullyQualifiedName~ChatRunRequestNormalizer_ShouldRejectFileInlineFileWithNegativeSizeBytes|FullyQualifiedName~ChatRunRequestNormalizer_ShouldRejectUnsupportedInputPartWithInvalidInlineFileSizeBytes|FullyQualifiedName~ChatRunRequestNormalizer_ShouldRejectFileRefSizeBytes|FullyQualifiedName~ChatRunRequestNormalizer_ShouldRejectTopLevelFileSizeBytes|FullyQualifiedName~PostChat_ShouldReturnInvalidFileInput_WhenInlineFileSizeBytesMismatchesDecodedBytes|FullyQualifiedName~PostChat_ShouldReturnInvalidFileInput_WhenUnsupportedInputPartHasInvalidInlineFileSizeBytes|FullyQualifiedName~PostChat_ShouldDispatch_WhenInlineFileSizeBytesMatchesDecodedBytes|FullyQualifiedName~ChatCommand_ShouldEmitInvalidFileInput_WhenInlineFileSizeBytesMismatchesDecodedBytes|FullyQualifiedName~ChatCommand_ShouldDispatch_WhenInlineFileSizeBytesMatchesDecodedBytes"`
- `dotnet test test/Aevatar.Workflow.Sdk.Tests/Aevatar.Workflow.Sdk.Tests.csproj --nologo --no-restore --filter "FullyQualifiedName~ShouldSerializeInlineFileSizeBytesWhenProvided|FullyQualifiedName~ShouldOmitInlineFileSizeBytesWhenUnset|FullyQualifiedName~ShouldNotExposeSizeBytesOnFileRef"`
- `bash tools/ci/test_stability_guards.sh`
- `source .config/consensus-rnd/host.env && bash -lc "$BUILD_CMD"`
- `bash tools/ci/architecture_guards.sh`
- `git diff HEAD --check`

🤖 controller status banner

⟦AI:AUTO-LOOP⟧