### PR TITLE
Fix workflow draft id resolution

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -3600,6 +3600,68 @@ describe("StudioPage", () => {
     expect(studioApi.getMember).toHaveBeenCalledWith("scope-1", "workspace-demo");
   });
 
+  it("resolves workflow member display names to stable draft ids before loading drafts", async () => {
+    mockStudioMembers = [
+      {
+        ...mockStudioMembers[0],
+        memberId: "untitled-member",
+        displayName: "Untitled member",
+        publishedServiceId: "",
+        lastBoundRevisionId: null,
+      },
+    ];
+    mockWorkflowSummaries = [
+      {
+        ...mockWorkflowSummaries[0],
+        workflowId: "untitled-member",
+        name: "Untitled member",
+        fileName: "untitled-member.yaml",
+        filePath: "scope://scope-1/untitled-member.yaml",
+      },
+    ];
+    mockWorkflowFile = {
+      ...mockWorkflowFile,
+      workflowId: "untitled-member",
+      name: "Untitled member",
+      fileName: "untitled-member.yaml",
+      filePath: "scope://scope-1/untitled-member.yaml",
+      yaml: "name: Untitled member\nsteps: []\n",
+      document: {
+        ...mockParsedDocument,
+        name: "Untitled member",
+      },
+    };
+    (studioApi.listWorkflows as jest.Mock).mockResolvedValue(mockWorkflowSummaries);
+    (studioApi.getWorkflow as jest.Mock).mockImplementation(
+      async (workflowId: string) => {
+        if (workflowId !== "untitled-member") {
+          throw new Error(`Unexpected workflow id: ${workflowId}`);
+        }
+
+        return mockWorkflowFile;
+      }
+    );
+
+    renderStudioPage(
+      "/studio?scopeId=scope-1&member=member%3Auntitled-member&step=bind&tab=bindings"
+    );
+
+    expect(await screen.findByTestId("studio-bind-surface")).toBeTruthy();
+    await waitFor(() => {
+      expect(studioApi.getWorkflow).toHaveBeenCalledWith(
+        "untitled-member",
+        "scope-1"
+      );
+      expect(studioApi.getWorkflow).not.toHaveBeenCalledWith(
+        "Untitled member",
+        "scope-1"
+      );
+      const searchParams = new URLSearchParams(window.location.search);
+      expect(searchParams.get("member")).toBe("member:untitled-member");
+      expect(searchParams.get("focus")).toBe("workflow:untitled-member");
+    });
+  });
+
   it("canonicalizes a legacy service member link to the real backend member identity", async () => {
     renderStudioPage(
       "/studio?scopeId=scope-1&memberId=default&step=invoke&tab=invoke"

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -3662,6 +3662,62 @@ describe("StudioPage", () => {
     });
   });
 
+  it("matches workflow member display names before falling back to direct member ids", async () => {
+    mockStudioMembers = [
+      {
+        ...mockStudioMembers[0],
+        memberId: "m-1",
+        displayName: "Workflow One",
+        publishedServiceId: "",
+        lastBoundRevisionId: null,
+      },
+    ];
+    mockWorkflowSummaries = [
+      {
+        ...mockWorkflowSummaries[0],
+        workflowId: "wf-1",
+        name: "Workflow One",
+        fileName: "workflow-one.yaml",
+        filePath: "scope://scope-1/workflow-one.yaml",
+      },
+    ];
+    mockWorkflowFile = {
+      ...mockWorkflowFile,
+      workflowId: "wf-1",
+      name: "Workflow One",
+      fileName: "workflow-one.yaml",
+      filePath: "scope://scope-1/workflow-one.yaml",
+      yaml: "name: Workflow One\nsteps: []\n",
+      document: {
+        ...mockParsedDocument,
+        name: "Workflow One",
+      },
+    };
+    (studioApi.listWorkflows as jest.Mock).mockResolvedValue(mockWorkflowSummaries);
+    (studioApi.getWorkflow as jest.Mock).mockImplementation(
+      async (workflowId: string) => {
+        if (workflowId !== "wf-1") {
+          throw new Error(`Unexpected workflow id: ${workflowId}`);
+        }
+
+        return mockWorkflowFile;
+      }
+    );
+
+    renderStudioPage(
+      "/studio?scopeId=scope-1&member=member%3Am-1&step=bind&tab=bindings"
+    );
+
+    expect(await screen.findByTestId("studio-bind-surface")).toBeTruthy();
+    await waitFor(() => {
+      expect(studioApi.getWorkflow).toHaveBeenCalledWith("wf-1", "scope-1");
+      expect(studioApi.getWorkflow).not.toHaveBeenCalledWith("m-1", "scope-1");
+      const searchParams = new URLSearchParams(window.location.search);
+      expect(searchParams.get("member")).toBe("member:m-1");
+      expect(searchParams.get("focus")).toBe("workflow:wf-1");
+    });
+  });
+
   it("canonicalizes a legacy service member link to the real backend member identity", async () => {
     renderStudioPage(
       "/studio?scopeId=scope-1&memberId=default&step=invoke&tab=invoke"

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -795,16 +795,29 @@ function resolveWorkflowIdFromMemberWorkflowReference(
   }
 
   if (memberId) {
-    return resolveWorkflowIdFromRouteValue(memberId, workflows, {
-      allowDirectIdFallback: true,
+    const resolvedByMemberId = resolveWorkflowIdFromRouteValue(memberId, workflows, {
+      allowDirectIdFallback: false,
       workflowFile,
     });
+    if (resolvedByMemberId) {
+      return resolvedByMemberId;
+    }
   }
 
   const displayName = trimOptional(input.displayName);
-  return displayName
-    ? resolveWorkflowIdFromRouteValue(displayName, workflows, {
-        allowDirectIdFallback: false,
+  if (displayName) {
+    const resolvedByDisplayName = resolveWorkflowIdFromRouteValue(displayName, workflows, {
+      allowDirectIdFallback: false,
+      workflowFile,
+    });
+    if (resolvedByDisplayName) {
+      return resolvedByDisplayName;
+    }
+  }
+
+  return memberId
+    ? resolveWorkflowIdFromRouteValue(memberId, workflows, {
+        allowDirectIdFallback: true,
         workflowFile,
       })
     : '';

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -760,6 +760,56 @@ function resolveWorkflowIdFromRouteValue(
   return options?.allowDirectIdFallback ? normalizedRouteValue : '';
 }
 
+function resolveWorkflowIdFromMemberWorkflowReference(
+  input: {
+    readonly workflowId?: string | null;
+    readonly memberId?: string | null;
+    readonly displayName?: string | null;
+  },
+  workflows: ReadonlyArray<{
+    readonly workflowId: string;
+    readonly name: string;
+    readonly fileName: string;
+    readonly description?: string;
+  }>,
+  workflowFile?: Pick<StudioWorkflowFile, 'workflowId' | 'name' | 'fileName'> | null,
+): string {
+  const typedWorkflowId = trimOptional(input.workflowId);
+  const memberId = trimOptional(input.memberId);
+  if (typedWorkflowId) {
+    const resolvedWorkflowId = resolveWorkflowIdFromRouteValue(typedWorkflowId, workflows, {
+      allowDirectIdFallback: false,
+      workflowFile,
+    });
+    if (resolvedWorkflowId) {
+      return resolvedWorkflowId;
+    }
+
+    return !memberId ||
+      normalizeComparableText(typedWorkflowId) === normalizeComparableText(memberId)
+      ? resolveWorkflowIdFromRouteValue(typedWorkflowId, workflows, {
+          allowDirectIdFallback: true,
+          workflowFile,
+        })
+      : '';
+  }
+
+  if (memberId) {
+    return resolveWorkflowIdFromRouteValue(memberId, workflows, {
+      allowDirectIdFallback: true,
+      workflowFile,
+    });
+  }
+
+  const displayName = trimOptional(input.displayName);
+  return displayName
+    ? resolveWorkflowIdFromRouteValue(displayName, workflows, {
+        allowDirectIdFallback: false,
+        workflowFile,
+      })
+    : '';
+}
+
 function describeSavedWorkflowLocation(
   workflow: Pick<StudioWorkflowFile, 'directoryLabel' | 'fileName' | 'filePath'>,
 ): string {
@@ -1549,40 +1599,6 @@ function resolveLifecycleScriptId(
   return '';
 }
 
-function resolveLifecycleWorkflowId(
-  memberKey: string,
-  publishedMembers: readonly PublishedStudioMemberRecord[],
-  studioScopeMembers: readonly StudioMemberSummary[],
-): string {
-  const workflowRouteValue = readWorkflowMemberRouteValueFromMemberKey(memberKey);
-  if (workflowRouteValue) {
-    return workflowRouteValue;
-  }
-
-  const publishedWorkflowId = trimOptional(
-    findPublishedStudioMemberByMemberKey(memberKey, publishedMembers)?.matchedWorkflow
-      ?.workflowId,
-  );
-  if (publishedWorkflowId) {
-    return publishedWorkflowId;
-  }
-
-  const memberSummary = resolveStudioMemberSummaryFromMemberKey(
-    memberKey,
-    publishedMembers,
-    studioScopeMembers,
-  );
-  if (
-    normalizeStudioMemberBindingImplementationKind(
-      memberSummary?.implementationKind,
-    ) === 'workflow'
-  ) {
-    return trimOptional(memberSummary?.displayName);
-  }
-
-  return '';
-}
-
 function resolveWorkflowIdForMemberSummary(
   memberSummary: StudioMemberSummary | null | undefined,
   workflows: ReadonlyArray<{
@@ -1601,15 +1617,30 @@ function resolveWorkflowIdForMemberSummary(
     return '';
   }
 
-  const implementationRef = trimOptional(memberSummary?.displayName);
-  if (!implementationRef) {
-    return '';
-  }
+  return resolveWorkflowIdFromMemberWorkflowReference({
+    memberId: memberSummary?.memberId,
+    displayName: memberSummary?.displayName,
+  }, workflows, workflowFile);
+}
 
-  return resolveWorkflowIdFromRouteValue(implementationRef, workflows, {
-    allowDirectIdFallback: true,
-    workflowFile,
-  });
+function resolveWorkflowIdForMemberDetail(
+  input: {
+    readonly implementationRefWorkflowId?: string | null;
+    readonly memberSummary?: StudioMemberSummary | null;
+  },
+  workflows: ReadonlyArray<{
+    readonly workflowId: string;
+    readonly name: string;
+    readonly fileName: string;
+    readonly description?: string;
+  }>,
+  workflowFile?: Pick<StudioWorkflowFile, 'workflowId' | 'name' | 'fileName'> | null,
+): string {
+  return resolveWorkflowIdFromMemberWorkflowReference({
+    workflowId: input.implementationRefWorkflowId,
+    memberId: input.memberSummary?.memberId,
+    displayName: input.memberSummary?.displayName,
+  }, workflows, workflowFile);
 }
 
 function resolveLifecycleBuildSurface(input: {
@@ -7670,17 +7701,13 @@ const StudioPage: React.FC = () => {
       return;
     }
 
-    const workflowLookupValue =
-      trimOptional(memberImplementationRef?.workflowId) ||
-      trimOptional(memberSummary?.displayName) ||
-      trimOptional(memberSummary?.memberId);
-    const workflowId = resolveWorkflowIdFromRouteValue(
-      workflowLookupValue,
-      visibleWorkflowSummaries,
+    const workflowId = resolveWorkflowIdForMemberDetail(
       {
-        allowDirectIdFallback: true,
-        workflowFile: activeWorkflowFile,
+        implementationRefWorkflowId: memberImplementationRef?.workflowId,
+        memberSummary,
       },
+      visibleWorkflowSummaries,
+      activeWorkflowFile,
     );
     if (!workflowId) {
       return;
@@ -8092,19 +8119,28 @@ const StudioPage: React.FC = () => {
           setSelectedScriptId('');
           setTemplateWorkflow('');
         } else {
-          const lifecycleWorkflowId = resolveLifecycleWorkflowId(
+          const lifecycleMemberSummary = resolveStudioMemberSummaryFromMemberKey(
             lifecycleMemberKey,
             publishedScopeMembers,
             studioScopeMembers,
           );
-          const resolvedLifecycleWorkflowId = resolveWorkflowIdFromRouteValue(
-            lifecycleWorkflowId,
-            visibleWorkflowSummaries,
-            {
-              allowDirectIdFallback: true,
-              workflowFile: activeWorkflowFile,
-            },
+          const lifecycleWorkflowRouteValue = readWorkflowMemberRouteValueFromMemberKey(
+            lifecycleMemberKey,
           );
+          const resolvedLifecycleWorkflowId = lifecycleWorkflowRouteValue
+            ? resolveWorkflowIdFromRouteValue(
+                lifecycleWorkflowRouteValue,
+                visibleWorkflowSummaries,
+                {
+                  allowDirectIdFallback: true,
+                  workflowFile: activeWorkflowFile,
+                },
+              )
+            : resolveWorkflowIdForMemberSummary(
+                lifecycleMemberSummary,
+                visibleWorkflowSummaries,
+                activeWorkflowFile,
+              );
           if (resolvedLifecycleWorkflowId) {
             setSelectedWorkflowId(resolvedLifecycleWorkflowId);
             setSelectedScriptId('');
@@ -9197,13 +9233,10 @@ const StudioPage: React.FC = () => {
             trimOptional(selectedMemberSummary?.memberId);
 
           if (memberImplementationKind === 'workflow') {
-            const workflowId = resolveWorkflowIdFromRouteValue(
-              memberImplementationName,
+            const workflowId = resolveWorkflowIdForMemberSummary(
+              selectedMemberSummary,
               visibleWorkflowSummaries,
-              {
-                allowDirectIdFallback: true,
-                workflowFile: activeWorkflowFile,
-              },
+              activeWorkflowFile,
             );
             if (workflowId) {
               const selectedWorkflowSummary = visibleWorkflowSummaries.find(


### PR DESCRIPTION
## Summary

- Fix Studio workflow-member routing so display names are resolved to stable workflow draft ids before loading drafts.
- Stop treating member display names such as `Untitled member` as direct `/api/workspace/workflow-drafts/{workflowId}` path ids.
- Add a regression test for scoped workflow members whose display name differs from the normalized draft id.

## Root Cause

The Studio member-first flow could fall back from a workflow member display name directly to a workflow draft id. That made the frontend request paths like `/api/workspace/workflow-drafts/Untitled%20member`, while the backend stores the stable draft id as a normalized value such as `untitled-member`.

## Validation

- `pnpm --dir apps/aevatar-console-web test src/pages/studio/index.test.tsx --runInBand`
- `pnpm --dir apps/aevatar-console-web tsc`
- `bash tools/ci/test_stability_guards.sh`
- `pnpm --dir apps/aevatar-console-web build`
- `git diff --check`
