### PR TITLE
Productize workflow node Inspector fields

### DIFF
--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -574,6 +574,8 @@ const enUSMessages = {
     'This node type does not have guided fields yet. Use advanced raw configuration when needed.',
   'teamMemberWorkflowStudio.nodeDetail.rawConfigurationAria':
     'Raw node configuration',
+  'teamMemberWorkflowStudio.nodeDetail.rawConfigurationError':
+    'Raw node configuration must be a JSON object.',
   'teamMemberWorkflowStudio.nodeDetail.sectionAria': 'Node detail',
   'teamMemberWorkflowStudio.nodeDetail.stepId': 'Step ID: {stepId}',
   'teamMemberWorkflowStudio.nodeDetail.updateNode': 'Update node',

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -548,6 +548,8 @@ const zhCNMessages = {
     '这个节点类型暂时没有引导字段。需要时可以使用高级原始配置。',
   'teamMemberWorkflowStudio.nodeDetail.rawConfigurationAria':
     '原始节点配置',
+  'teamMemberWorkflowStudio.nodeDetail.rawConfigurationError':
+    '原始节点配置必须是 JSON 对象。',
   'teamMemberWorkflowStudio.nodeDetail.sectionAria': '节点详情',
   'teamMemberWorkflowStudio.nodeDetail.stepId': '步骤 ID：{stepId}',
   'teamMemberWorkflowStudio.nodeDetail.updateNode': '更新节点',

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioHeader.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioHeader.tsx
@@ -485,6 +485,7 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
     publishPending ||
     publishTone === "processing" ||
     publishTone === "error" ||
+    dirty ||
     !memberPublished ||
     !publishDisabled;
 

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioNodeDetailPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioNodeDetailPanel.tsx
@@ -6,16 +6,18 @@ import {
   Input,
   Select,
   Space,
+  Switch,
   Typography,
   theme,
 } from "antd";
 import React from "react";
 import {
-  applyStudioNodeConfigurationValues,
+  applyRawStudioNodeConfiguration,
+  applyStudioNodeConfigurationValuesWithValidation,
   formatRawStudioNodeConfiguration,
   getStudioNodeConfigurationSchema,
   readStudioNodeConfigurationValues,
-  type StudioNodeConfigurationField,
+  type NodeConfigField,
 } from "@/shared/studio/nodeConfiguration";
 import { formatConsoleMessage, t } from "@/shared/i18n/messages";
 import type { StudioStepInspectorDraft } from "@/shared/studio/document";
@@ -26,6 +28,7 @@ type WorkflowStudioNodeDetailPanelProps = {
   readonly error?: string;
   readonly onClose: () => void;
   readonly onConfigurationChange: (parametersText: string) => void;
+  readonly onConfigurationErrorChange: (error: string) => void;
   readonly stepDraft: StudioStepInspectorDraft | null;
 };
 
@@ -186,16 +189,31 @@ function readDraftParameters(stepDraft: StudioStepInspectorDraft): Record<string
   }
 }
 
+function readCurrentParameters(
+  stepDraft: StudioStepInspectorDraft,
+  rawConfigurationText: string,
+): Record<string, unknown> {
+  try {
+    return parseInspectorParameters(rawConfigurationText);
+  } catch {
+    return readDraftParameters(stepDraft);
+  }
+}
+
 function useConfigurationState(stepDraft: StudioStepInspectorDraft | null) {
   const [configurationValues, setConfigurationValues] = React.useState<
     Record<string, string>
   >({});
   const [rawConfigurationText, setRawConfigurationText] = React.useState("");
+  const [structuredError, setStructuredError] = React.useState("");
+  const [rawError, setRawError] = React.useState("");
 
   React.useEffect(() => {
     if (!stepDraft) {
       setConfigurationValues({});
       setRawConfigurationText("");
+      setRawError("");
+      setStructuredError("");
       return;
     }
 
@@ -204,13 +222,19 @@ function useConfigurationState(stepDraft: StudioStepInspectorDraft | null) {
       readStudioNodeConfigurationValues(stepDraft.type, parameters),
     );
     setRawConfigurationText(formatRawStudioNodeConfiguration(parameters));
+    setRawError("");
+    setStructuredError("");
   }, [stepDraft?.id, stepDraft?.parametersText, stepDraft?.type]);
 
   return {
     configurationValues,
     rawConfigurationText,
+    rawError,
     setConfigurationValues,
     setRawConfigurationText,
+    setRawError,
+    setStructuredError,
+    structuredError,
   };
 }
 
@@ -218,6 +242,7 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
   error,
   onClose,
   onConfigurationChange,
+  onConfigurationErrorChange,
   stepDraft,
 }) => {
   const { token } = theme.useToken();
@@ -230,8 +255,12 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
   const {
     configurationValues,
     rawConfigurationText,
+    rawError,
     setConfigurationValues,
     setRawConfigurationText,
+    setRawError,
+    setStructuredError,
+    structuredError,
   } = useConfigurationState(stepDraft);
 
   React.useEffect(() => {
@@ -249,6 +278,10 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
       document.body.style.userSelect = previousUserSelect;
     };
   }, [resizing]);
+
+  React.useEffect(() => {
+    onConfigurationErrorChange(structuredError || rawError);
+  }, [onConfigurationErrorChange, rawError, structuredError]);
 
   if (!stepDraft) {
     return null;
@@ -287,10 +320,12 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
     "--workflow-node-inspector-text": token.colorText,
     "--workflow-node-inspector-text-strong": token.colorTextHeading,
   };
-  const schema = getStudioNodeConfigurationSchema(stepDraft.type);
+  const parameters = readCurrentParameters(stepDraft, rawConfigurationText);
+  const schema = getStudioNodeConfigurationSchema(stepDraft.type, parameters);
   const hasSemanticFields = schema.fields.length > 0;
   const nodeTypeLabel = formatStudioStepTypeLabel(stepDraft.type);
   const branchesSummary = summarizeBranches(stepDraft.branchesText);
+  const activeError = structuredError || rawError || error || "";
 
   const startResize = (event: React.PointerEvent<HTMLDivElement>) => {
     event.preventDefault();
@@ -334,28 +369,93 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
   };
 
   const updateFieldValue = (fieldName: string, value: string) => {
-    setConfigurationValues((current) => ({
-      ...current,
+    const nextValues = {
+      ...configurationValues,
       [fieldName]: value,
-    }));
+    };
+    const result = applyStudioNodeConfigurationValuesWithValidation(
+      stepDraft.type,
+      parameters,
+      nextValues,
+    );
+
+    setConfigurationValues(nextValues);
+    setStructuredError(result.errors[0] ?? "");
+    setRawError("");
+    if (result.valid) {
+      setRawConfigurationText(formatRawStudioNodeConfiguration(result.parameters));
+    }
   };
 
   const applyConfigurationToDraft = () => {
-    const nextParameters = applyStudioNodeConfigurationValues(
+    const result = applyStudioNodeConfigurationValuesWithValidation(
       stepDraft.type,
-      readDraftParameters(stepDraft),
+      parameters,
       configurationValues,
     );
-    onConfigurationChange(formatRawStudioNodeConfiguration(nextParameters));
+    const nextError = result.errors[0] ?? "";
+    setStructuredError(nextError);
+    setRawError("");
+    if (!result.valid) {
+      return;
+    }
+
+    const nextRawText = formatRawStudioNodeConfiguration(result.parameters);
+    setRawConfigurationText(nextRawText);
+    onConfigurationChange(nextRawText);
   };
 
   const applyRawConfigurationToDraft = () => {
-    onConfigurationChange(rawConfigurationText);
+    try {
+      const nextParameters = applyRawStudioNodeConfiguration(
+        stepDraft.type,
+        rawConfigurationText,
+      );
+      const nextRawText = formatRawStudioNodeConfiguration(nextParameters);
+      setRawError("");
+      setStructuredError("");
+      setRawConfigurationText(nextRawText);
+      setConfigurationValues(
+        readStudioNodeConfigurationValues(stepDraft.type, nextParameters),
+      );
+      onConfigurationChange(nextRawText);
+    } catch (error) {
+      setRawError(
+        error instanceof Error
+          ? error.message
+          : t(
+              "teamMemberWorkflowStudio.nodeDetail.rawConfigurationError",
+              "Raw node configuration must be a JSON object.",
+            ),
+      );
+    }
   };
 
-  const renderFieldControl = (field: StudioNodeConfigurationField) => {
+  const updateRawConfigurationText = (value: string) => {
+    setRawConfigurationText(value);
+    try {
+      const nextParameters = applyRawStudioNodeConfiguration(stepDraft.type, value);
+      setRawError("");
+      setStructuredError("");
+      setConfigurationValues(
+        readStudioNodeConfigurationValues(stepDraft.type, nextParameters),
+      );
+    } catch (error) {
+      setRawError(
+        error instanceof Error
+          ? error.message
+          : t(
+              "teamMemberWorkflowStudio.nodeDetail.rawConfigurationError",
+              "Raw node configuration must be a JSON object.",
+            ),
+      );
+    }
+  };
+
+  const renderFieldControl = (field: NodeConfigField) => {
     const value = configurationValues[field.name] ?? "";
-    if (field.kind === "select") {
+    const control = field.control ?? field.kind;
+    if (control === "select") {
       return (
         <Select
           aria-label={formatConsoleMessage(field.label)}
@@ -369,7 +469,38 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
       );
     }
 
-    if (field.kind === "multi-line") {
+    if (control === "boolean") {
+      return (
+        <Switch
+          aria-label={formatConsoleMessage(field.label)}
+          checked={value === "true"}
+          onChange={(checked) => updateFieldValue(field.name, String(checked))}
+        />
+      );
+    }
+
+    if (control === "number") {
+      return (
+        <Input
+          aria-label={formatConsoleMessage(field.label)}
+          inputMode="decimal"
+          onChange={(event) => updateFieldValue(field.name, event.target.value)}
+          placeholder={
+            field.placeholder ? formatConsoleMessage(field.placeholder) : undefined
+          }
+          status={structuredError ? "error" : undefined}
+          value={value}
+        />
+      );
+    }
+
+    if (
+      control === "array" ||
+      control === "json" ||
+      control === "object" ||
+      control === "multi-line" ||
+      control === "textarea"
+    ) {
       return (
         <Input.TextArea
           aria-label={formatConsoleMessage(field.label)}
@@ -378,6 +509,7 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
           placeholder={
             field.placeholder ? formatConsoleMessage(field.placeholder) : undefined
           }
+          status={structuredError ? "error" : undefined}
           value={value}
         />
       );
@@ -390,6 +522,7 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
         placeholder={
           field.placeholder ? formatConsoleMessage(field.placeholder) : undefined
         }
+        status={structuredError ? "error" : undefined}
         value={value}
       />
     );
@@ -563,6 +696,7 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
               </Typography.Paragraph>
             </div>
             <Button
+              disabled={Boolean(structuredError)}
               onClick={applyConfigurationToDraft}
               size="small"
               type="primary"
@@ -599,9 +733,9 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
             />
           )}
 
-          {error ? (
+          {activeError ? (
             <Alert
-              message={error}
+              message={activeError}
               showIcon
               type="error"
             />
@@ -631,15 +765,22 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
                       "Raw node configuration",
                     )}
                     autoSize={{ minRows: 8, maxRows: 16 }}
-                    onChange={(event) => setRawConfigurationText(event.target.value)}
+                    onChange={(event) =>
+                      updateRawConfigurationText(event.target.value)
+                    }
                     spellCheck={false}
+                    status={rawError ? "error" : undefined}
                     style={{
                       fontFamily:
                         "SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace",
                     }}
                     value={rawConfigurationText}
                   />
-                  <Button onClick={applyRawConfigurationToDraft} size="small">
+                  <Button
+                    disabled={Boolean(rawError)}
+                    onClick={applyRawConfigurationToDraft}
+                    size="small"
+                  >
                     {t(
                       "teamMemberWorkflowStudio.nodeDetail.applyRawConfiguration",
                       "Apply raw JSON",

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioNodeDetailPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioNodeDetailPanel.tsx
@@ -200,28 +200,71 @@ function readCurrentParameters(
   }
 }
 
+function mergeSchemaParameters(
+  current: Record<string, unknown>,
+  next: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    ...current,
+    ...next,
+  };
+}
+
 function useConfigurationState(stepDraft: StudioStepInspectorDraft | null) {
   const [configurationValues, setConfigurationValues] = React.useState<
     Record<string, string>
   >({});
   const [rawConfigurationText, setRawConfigurationText] = React.useState("");
+  const [schemaParameters, setSchemaParameters] = React.useState<
+    Record<string, unknown>
+  >({});
   const [structuredError, setStructuredError] = React.useState("");
   const [rawError, setRawError] = React.useState("");
+  const schemaParametersRef = React.useRef<Record<string, unknown>>({});
+  const stepKeyRef = React.useRef("");
+
+  const rememberSchemaParameters = React.useCallback(
+    (parameters: Record<string, unknown>): Record<string, unknown> => {
+      const nextSchemaParameters = mergeSchemaParameters(
+        schemaParametersRef.current,
+        parameters,
+      );
+      schemaParametersRef.current = nextSchemaParameters;
+      setSchemaParameters(nextSchemaParameters);
+      return nextSchemaParameters;
+    },
+    [],
+  );
 
   React.useEffect(() => {
     if (!stepDraft) {
       setConfigurationValues({});
       setRawConfigurationText("");
+      schemaParametersRef.current = {};
+      stepKeyRef.current = "";
+      setSchemaParameters({});
       setRawError("");
       setStructuredError("");
       return;
     }
 
     const parameters = readDraftParameters(stepDraft);
+    const stepKey = `${stepDraft.id}\u0000${stepDraft.type}`;
+    const nextSchemaParameters =
+      stepKeyRef.current === stepKey
+        ? mergeSchemaParameters(schemaParametersRef.current, parameters)
+        : parameters;
+    schemaParametersRef.current = nextSchemaParameters;
+    stepKeyRef.current = stepKey;
     setConfigurationValues(
-      readStudioNodeConfigurationValues(stepDraft.type, parameters),
+      readStudioNodeConfigurationValues(
+        stepDraft.type,
+        parameters,
+        nextSchemaParameters,
+      ),
     );
     setRawConfigurationText(formatRawStudioNodeConfiguration(parameters));
+    setSchemaParameters(nextSchemaParameters);
     setRawError("");
     setStructuredError("");
   }, [stepDraft?.id, stepDraft?.parametersText, stepDraft?.type]);
@@ -230,9 +273,11 @@ function useConfigurationState(stepDraft: StudioStepInspectorDraft | null) {
     configurationValues,
     rawConfigurationText,
     rawError,
+    schemaParameters,
     setConfigurationValues,
     setRawConfigurationText,
     setRawError,
+    rememberSchemaParameters,
     setStructuredError,
     structuredError,
   };
@@ -256,9 +301,11 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
     configurationValues,
     rawConfigurationText,
     rawError,
+    schemaParameters,
     setConfigurationValues,
     setRawConfigurationText,
     setRawError,
+    rememberSchemaParameters,
     setStructuredError,
     structuredError,
   } = useConfigurationState(stepDraft);
@@ -321,7 +368,7 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
     "--workflow-node-inspector-text-strong": token.colorTextHeading,
   };
   const parameters = readCurrentParameters(stepDraft, rawConfigurationText);
-  const schema = getStudioNodeConfigurationSchema(stepDraft.type, parameters);
+  const schema = getStudioNodeConfigurationSchema(stepDraft.type, schemaParameters);
   const hasSemanticFields = schema.fields.length > 0;
   const nodeTypeLabel = formatStudioStepTypeLabel(stepDraft.type);
   const branchesSummary = summarizeBranches(stepDraft.branchesText);
@@ -377,6 +424,7 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
       stepDraft.type,
       parameters,
       nextValues,
+      schemaParameters,
     );
 
     setConfigurationValues(nextValues);
@@ -384,6 +432,7 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
     setRawError("");
     if (result.valid) {
       setRawConfigurationText(formatRawStudioNodeConfiguration(result.parameters));
+      rememberSchemaParameters(result.parameters);
     }
   };
 
@@ -392,6 +441,7 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
       stepDraft.type,
       parameters,
       configurationValues,
+      schemaParameters,
     );
     const nextError = result.errors[0] ?? "";
     setStructuredError(nextError);
@@ -402,6 +452,7 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
 
     const nextRawText = formatRawStudioNodeConfiguration(result.parameters);
     setRawConfigurationText(nextRawText);
+    rememberSchemaParameters(result.parameters);
     onConfigurationChange(nextRawText);
   };
 
@@ -415,8 +466,13 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
       setRawError("");
       setStructuredError("");
       setRawConfigurationText(nextRawText);
+      const nextSchemaParameters = rememberSchemaParameters(nextParameters);
       setConfigurationValues(
-        readStudioNodeConfigurationValues(stepDraft.type, nextParameters),
+        readStudioNodeConfigurationValues(
+          stepDraft.type,
+          nextParameters,
+          nextSchemaParameters,
+        ),
       );
       onConfigurationChange(nextRawText);
     } catch (error) {
@@ -435,10 +491,15 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
     setRawConfigurationText(value);
     try {
       const nextParameters = applyRawStudioNodeConfiguration(stepDraft.type, value);
+      const nextSchemaParameters = rememberSchemaParameters(nextParameters);
       setRawError("");
       setStructuredError("");
       setConfigurationValues(
-        readStudioNodeConfigurationValues(stepDraft.type, nextParameters),
+        readStudioNodeConfigurationValues(
+          stepDraft.type,
+          nextParameters,
+          nextSchemaParameters,
+        ),
       );
     } catch (error) {
       setRawError(

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -143,6 +143,7 @@ type TeamMemberWorkflowStudioState = {
   readonly selectedStepConfigurationError: string;
   readonly selectedTab: "editor" | "runs";
   readonly setSelectedTab: (tab: "editor" | "runs") => void;
+  readonly setSelectedStepConfigurationError: (error: string) => void;
   readonly updateSelectedStepConfiguration: (parametersText: string) => void;
   readonly selectCanvas: () => void;
   readonly selectEdge: (edgeId: string) => void;
@@ -1098,12 +1099,14 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
             route.teamId &&
             editableDocument &&
             dirty &&
+            !selectedStepConfigurationError &&
             !createWorkflowMemberMutation.isPending,
         )
       : Boolean(
           workflowQuery.data &&
             editableDocument &&
             dirty &&
+            !selectedStepConfigurationError &&
             !linkedWorkflowMissing &&
             !saveMutation.isPending,
         );
@@ -1536,6 +1539,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       setSelectedTab("editor");
       setSelectedEdgeId("");
       setSelectedNodeId("");
+      setSelectedStepConfigurationError("");
       setRunOptionsOpen(true);
     },
     save: () => {
@@ -1572,20 +1576,24 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     selectCanvas: () => {
       setSelectedEdgeId("");
       setSelectedNodeId("");
+      setSelectedStepConfigurationError("");
       setRunOptionsOpen(false);
     },
     selectEdge: (edgeId: string) => {
       setSelectedEdgeId(edgeId);
       setSelectedNodeId("");
+      setSelectedStepConfigurationError("");
       setRunOptionsOpen(false);
     },
     selectNode: (nodeId: string) => {
       setSelectedEdgeId("");
       setSelectedNodeId(nodeId);
+      setSelectedStepConfigurationError("");
       setRunOptionsOpen(false);
     },
     setExecutionRunMessage,
     setSelectedTab,
+    setSelectedStepConfigurationError,
     setWorkflowTitle,
     teamName,
     updateSelectedStepConfiguration,

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -1132,6 +1132,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       !workflowQuery.data ||
       !editableDocument ||
       !workflowHasSteps ||
+      Boolean(selectedStepConfigurationError) ||
       publishMutation.isPending ||
       publishBindingStillInProgress ||
       (memberIsPublished && !publishHasDraftChanges),
@@ -1141,6 +1142,8 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       ? "Create and link a workflow member before publishing."
       : linkedWorkflowMissing
         ? "No stable workflow draft is linked to this member yet."
+        : selectedStepConfigurationError
+          ? selectedStepConfigurationError
         : publishBindingStillInProgress
           ? "Publish was accepted and binding is still in progress. Refresh later before publishing again."
         : memberIsPublished && !publishHasDraftChanges
@@ -1450,7 +1453,11 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
 
   return {
     publishMember: () => {
-      if (workflowQuery.data && editableDocument) {
+      if (
+        workflowQuery.data &&
+        editableDocument &&
+        !selectedStepConfigurationError
+      ) {
         publishMutation.mutate({
           document: editableDocument,
           layout:

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -1191,10 +1191,19 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(screen.queryByLabelText("Raw node configuration")).toBeNull();
     expect(screen.queryByText(/prompt_prefix/)).toBeNull();
     expect(screen.queryByText("Output")).toBeNull();
+    fireEvent.click(screen.getByText("Advanced raw configuration"));
+    expect(
+      (screen.getByLabelText("Raw node configuration") as HTMLTextAreaElement)
+        .value,
+    ).toContain('"prompt_prefix": "Triage the request"');
 
     fireEvent.change(screen.getByLabelText("Instruction"), {
       target: { value: "Updated instruction" },
     });
+    expect(
+      (screen.getByLabelText("Raw node configuration") as HTMLTextAreaElement)
+        .value,
+    ).toContain('"prompt_prefix": "Updated instruction"');
     fireEvent.click(screen.getByRole("button", { name: "Update node" }));
     expect(screen.getByText("Unsaved changes")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
@@ -1472,9 +1481,9 @@ describe("TeamMemberWorkflowStudioPage", () => {
     fireEvent.change(screen.getByLabelText("Raw node configuration"), {
       target: { value: "not-json" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Apply raw JSON" }));
 
     expect(await screen.findByText(/Unexpected token/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Apply raw JSON" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
   });
 
@@ -1666,6 +1675,194 @@ describe("TeamMemberWorkflowStudioPage", () => {
       (screen.getByLabelText("Raw node configuration") as HTMLTextAreaElement)
         .value,
     ).toContain('"child_step_type": "llm_call"');
+  });
+
+  it("infers typed configuration fields for unknown node parameters and writes them through raw JSON", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1/t-alpha/members/member-alpha/workflow",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "workflow-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: null,
+        lifecycleStage: "created",
+        memberId: "member-alpha",
+        publishedServiceId: "",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "workflow-alpha.yaml",
+      filePath: "scope://scope-1/workflow-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "workflow-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: {
+        ...mockWorkflowDocument,
+        steps: [
+          {
+            id: "custom_step",
+            type: "custom_node",
+            targetRole: null,
+            parameters: {
+              enabled: true,
+              limit: 3,
+              payload: { source: "input" },
+              title: "Draft",
+            },
+            next: null,
+            branches: {},
+          },
+        ],
+      },
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByText("nodes:1")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "node:step:custom_step" }));
+
+    expect(screen.getByLabelText("Title")).toHaveValue("Draft");
+    expect(screen.getByLabelText("Limit")).toHaveValue("3");
+    expect(screen.getByRole("switch", { name: "Enabled" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect((screen.getByLabelText("Payload") as HTMLTextAreaElement).value).toContain(
+      '"source": "input"',
+    );
+
+    fireEvent.click(screen.getByText("Advanced raw configuration"));
+    fireEvent.click(screen.getByRole("switch", { name: "Enabled" }));
+    fireEvent.change(screen.getByLabelText("Limit"), {
+      target: { value: "5" },
+    });
+    fireEvent.change(screen.getByLabelText("Payload"), {
+      target: { value: '{ "source": "updated" }' },
+    });
+    expect(
+      (screen.getByLabelText("Raw node configuration") as HTMLTextAreaElement)
+        .value,
+    ).toContain('"enabled": false');
+    fireEvent.click(screen.getByRole("button", { name: "Update node" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(studioApi.serializeYaml).toHaveBeenCalledWith(
+        expect.objectContaining({
+          document: expect.objectContaining({
+            steps: expect.arrayContaining([
+              expect.objectContaining({
+                id: "custom_step",
+                parameters: expect.objectContaining({
+                  enabled: false,
+                  limit: 5,
+                  payload: { source: "updated" },
+                }),
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
+  });
+
+  it("blocks invalid inferred object edits before they can be applied", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1/t-alpha/members/member-alpha/workflow",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "workflow-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: null,
+        lifecycleStage: "created",
+        memberId: "member-alpha",
+        publishedServiceId: "",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "workflow-alpha.yaml",
+      filePath: "scope://scope-1/workflow-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "workflow-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: {
+        ...mockWorkflowDocument,
+        steps: [
+          {
+            id: "custom_step",
+            type: "custom_node",
+            targetRole: null,
+            parameters: { payload: { source: "input" } },
+            next: null,
+            branches: {},
+          },
+        ],
+      },
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByText("nodes:1")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "node:step:custom_step" }));
+    fireEvent.change(screen.getByLabelText("Payload"), {
+      target: { value: "not-json" },
+    });
+
+    expect(await screen.findByText(/Payload.*Unexpected token/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Update node" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    expect(studioApi.serializeYaml).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        document: expect.objectContaining({
+          steps: expect.arrayContaining([
+            expect.objectContaining({
+              id: "custom_step",
+              parameters: expect.objectContaining({ payload: "not-json" }),
+            }),
+          ]),
+        }),
+      }),
+    );
   });
 
   it("runs the active workflow member through invoke and shows returned logs", async () => {

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -1786,6 +1786,101 @@ describe("TeamMemberWorkflowStudioPage", () => {
     });
   });
 
+  it("keeps inferred fields visible after optional unknown node values are cleared", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1/t-alpha/members/member-alpha/workflow",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "workflow-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: null,
+        lifecycleStage: "created",
+        memberId: "member-alpha",
+        publishedServiceId: "",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "workflow-alpha.yaml",
+      filePath: "scope://scope-1/workflow-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "workflow-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: {
+        ...mockWorkflowDocument,
+        steps: [
+          {
+            id: "custom_step",
+            type: "custom_node",
+            targetRole: null,
+            parameters: {
+              enabled: true,
+              title: "Draft",
+            },
+            next: null,
+            branches: {},
+          },
+        ],
+      },
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByText("nodes:1")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "node:step:custom_step" }));
+    fireEvent.click(screen.getByText("Advanced raw configuration"));
+
+    fireEvent.change(screen.getByLabelText("Title"), {
+      target: { value: "" },
+    });
+
+    expect(screen.getByLabelText("Title")).toBeTruthy();
+    expect(screen.getByLabelText("Title")).toHaveValue("");
+    expect(
+      (screen.getByLabelText("Raw node configuration") as HTMLTextAreaElement)
+        .value,
+    ).not.toContain('"title"');
+
+    fireEvent.click(screen.getByRole("button", { name: "Update node" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(studioApi.serializeYaml).toHaveBeenCalledWith(
+        expect.objectContaining({
+          document: expect.objectContaining({
+            steps: expect.arrayContaining([
+              expect.objectContaining({
+                id: "custom_step",
+                parameters: expect.not.objectContaining({
+                  title: expect.anything(),
+                }),
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
+  });
+
   it("blocks invalid inferred object edits before they can be applied", async () => {
     window.history.replaceState(
       {},
@@ -2330,6 +2425,68 @@ describe("TeamMemberWorkflowStudioPage", () => {
       expect(screen.getByTitle(/Published member workflow is serviceable/)).toBeTruthy();
     });
     expect(studioApi.setTeamEntryMember).not.toHaveBeenCalled();
+  });
+
+  it("blocks publish when selected node configuration is invalid", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1/t-alpha/members/member-alpha/workflow",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "workflow-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: null,
+        lifecycleStage: "build_ready",
+        memberId: "member-alpha",
+        publishedServiceId: "",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "workflow-alpha.yaml",
+      filePath: "scope://scope-1/workflow-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "workflow-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: mockWorkflowDocument,
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByText("nodes:1")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByLabelText("Workflow title"), {
+      target: { value: "Workflow Alpha Published" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "node:step:triage" }));
+    fireEvent.change(screen.getByLabelText("Instruction"), {
+      target: { value: "" },
+    });
+
+    expect(await screen.findByText("Instruction is required.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Publish member" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Publish member" }));
+
+    await flushAsyncWork();
+    expect(studioApi.saveWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
   });
 
   it("reports rejected publish binding without introducing activation language", async () => {

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
@@ -366,6 +366,7 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
               error={studio.selectedStepConfigurationError}
               onClose={studio.selectCanvas}
               onConfigurationChange={studio.updateSelectedStepConfiguration}
+              onConfigurationErrorChange={studio.setSelectedStepConfigurationError}
               stepDraft={studio.selectedStepDraft}
             />
           )}

--- a/apps/aevatar-console-web/src/shared/studio/nodeConfiguration.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/nodeConfiguration.test.ts
@@ -241,6 +241,45 @@ describe('studio node configuration semantics', () => {
     });
   });
 
+  it('keeps inferred fields available from a stable schema source when values are cleared', () => {
+    const result = applyStudioNodeConfigurationValuesWithValidation(
+      'custom_step',
+      {
+        enabled: true,
+        title: 'Draft',
+      },
+      {
+        enabled: 'true',
+        title: '',
+      },
+      {
+        enabled: true,
+        title: 'Draft',
+      },
+    );
+
+    expect(result).toEqual({
+      errors: [],
+      parameters: {
+        enabled: true,
+      },
+      valid: true,
+    });
+    expect(
+      readStudioNodeConfigurationValues(
+        'custom_step',
+        result.parameters,
+        {
+          enabled: true,
+          title: 'Draft',
+        },
+      ),
+    ).toEqual({
+      enabled: 'true',
+      title: '',
+    });
+  });
+
   it('rejects invalid inferred structured JSON fields', () => {
     const result = applyStudioNodeConfigurationValuesWithValidation(
       'custom_step',

--- a/apps/aevatar-console-web/src/shared/studio/nodeConfiguration.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/nodeConfiguration.test.ts
@@ -1,6 +1,7 @@
 import {
   applyRawStudioNodeConfiguration,
   applyStudioNodeConfigurationValues,
+  applyStudioNodeConfigurationValuesWithValidation,
   formatRawStudioNodeConfiguration,
   getStudioNodeConfigurationSchema,
   readStudioNodeConfigurationValues,
@@ -18,6 +19,7 @@ describe('studio node configuration semantics', () => {
         label: expect.objectContaining({ defaultMessage: 'Instruction' }),
         name: 'instruction',
         parameterName: 'prompt',
+        path: 'prompt',
       }),
     ]);
     expect(values).toEqual({
@@ -64,6 +66,7 @@ describe('studio node configuration semantics', () => {
         label: expect.objectContaining({ defaultMessage: 'Operation' }),
         name: 'operation',
         parameterName: 'op',
+        path: 'op',
       }),
     );
     expect(values).toEqual({ operation: 'trim' });
@@ -92,6 +95,7 @@ describe('studio node configuration semantics', () => {
         kind: 'select',
         label: expect.objectContaining({ defaultMessage: 'Cached node' }),
         parameterName: 'child_step_type',
+        path: 'child_step_type',
       }),
     );
     expect(childStepTypeField?.placeholder).toBeUndefined();
@@ -150,5 +154,103 @@ describe('studio node configuration semantics', () => {
     expect(
       applyRawStudioNodeConfiguration('transform', '{ "op": "lowercase" }'),
     ).toEqual({ op: 'lowercase' });
+  });
+
+  it('infers typed fields for unknown node parameters from the workflow document', () => {
+    const parameters = {
+      enabled: true,
+      limit: 3,
+      notes: 'line one\nline two',
+      payload: { source: 'input' },
+      tags: ['alpha', 'beta'],
+      title: 'Draft',
+    };
+    const schema = getStudioNodeConfigurationSchema('custom_step', parameters);
+
+    expect(schema.fields).toEqual([
+      expect.objectContaining({
+        control: 'boolean',
+        label: expect.objectContaining({ defaultMessage: 'Enabled' }),
+        name: 'enabled',
+        path: 'enabled',
+      }),
+      expect.objectContaining({
+        control: 'number',
+        label: expect.objectContaining({ defaultMessage: 'Limit' }),
+        name: 'limit',
+        path: 'limit',
+      }),
+      expect.objectContaining({
+        control: 'textarea',
+        label: expect.objectContaining({ defaultMessage: 'Notes' }),
+        name: 'notes',
+        path: 'notes',
+      }),
+      expect.objectContaining({
+        control: 'object',
+        label: expect.objectContaining({ defaultMessage: 'Payload' }),
+        name: 'payload',
+        path: 'payload',
+      }),
+      expect.objectContaining({
+        control: 'array',
+        label: expect.objectContaining({ defaultMessage: 'Tags' }),
+        name: 'tags',
+        path: 'tags',
+      }),
+      expect.objectContaining({
+        control: 'text',
+        label: expect.objectContaining({ defaultMessage: 'Title' }),
+        name: 'title',
+        path: 'title',
+      }),
+    ]);
+    expect(readStudioNodeConfigurationValues('custom_step', parameters)).toEqual({
+      enabled: 'true',
+      limit: '3',
+      notes: 'line one\nline two',
+      payload: '{\n  "source": "input"\n}',
+      tags: '[\n  "alpha",\n  "beta"\n]',
+      title: 'Draft',
+    });
+  });
+
+  it('applies inferred typed values without diverging from raw parameters', () => {
+    const result = applyStudioNodeConfigurationValuesWithValidation(
+      'custom_step',
+      {
+        enabled: true,
+        limit: 3,
+        payload: { source: 'input' },
+      },
+      {
+        enabled: 'false',
+        limit: '5',
+        payload: '{ "source": "updated" }',
+      },
+    );
+
+    expect(result).toEqual({
+      errors: [],
+      parameters: {
+        enabled: false,
+        limit: 5,
+        payload: { source: 'updated' },
+      },
+      valid: true,
+    });
+  });
+
+  it('rejects invalid inferred structured JSON fields', () => {
+    const result = applyStudioNodeConfigurationValuesWithValidation(
+      'custom_step',
+      { payload: { source: 'input' } },
+      { payload: 'not-json' },
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('Payload');
+    expect(result.errors[0]).toContain('Unexpected token');
+    expect(result.parameters).toEqual({ payload: { source: 'input' } });
   });
 });

--- a/apps/aevatar-console-web/src/shared/studio/nodeConfiguration.ts
+++ b/apps/aevatar-console-web/src/shared/studio/nodeConfiguration.ts
@@ -8,9 +8,16 @@ import {
 import type { ConsoleMessageDescriptor } from '@/shared/i18n/messages';
 
 export type StudioNodeConfigurationFieldKind =
+  | 'array'
+  | 'boolean'
+  | 'json'
+  | 'number'
+  | 'object'
+  | 'select'
   | 'single-line'
   | 'multi-line'
-  | 'select';
+  | 'text'
+  | 'textarea';
 
 export type StudioNodeConfigurationOption = {
   readonly label: ConsoleMessageDescriptor;
@@ -18,17 +25,34 @@ export type StudioNodeConfigurationOption = {
 };
 
 export type StudioNodeConfigurationField = {
+  readonly control?: StudioNodeConfigurationFieldKind;
+  readonly defaultValue?: unknown;
   readonly description?: ConsoleMessageDescriptor;
   readonly kind: StudioNodeConfigurationFieldKind;
   readonly label: ConsoleMessageDescriptor;
   readonly name: string;
   readonly options?: readonly StudioNodeConfigurationOption[];
+  readonly path?: string;
   readonly parameterName: string;
   readonly placeholder?: ConsoleMessageDescriptor;
   readonly required?: boolean;
+  readonly validation?: {
+    readonly integer?: boolean;
+    readonly max?: number;
+    readonly min?: number;
+  };
+};
+
+export type NodeConfigField = StudioNodeConfigurationField & {
+  readonly path: string;
 };
 
 export type StudioNodeConfigurationSchema = {
+  readonly fields: readonly NodeConfigField[];
+  readonly stepType: string;
+};
+
+type StudioNodeConfigurationSchemaDefinition = {
   readonly fields: readonly StudioNodeConfigurationField[];
   readonly stepType: string;
 };
@@ -258,7 +282,7 @@ const STEP_TYPE_OPTIONS = [
   },
 ] satisfies readonly StudioNodeConfigurationOption[];
 
-const SCHEMAS_BY_STEP_TYPE: Record<string, StudioNodeConfigurationSchema> = {
+const SCHEMAS_BY_STEP_TYPE: Record<string, StudioNodeConfigurationSchemaDefinition> = {
   assign: {
     stepType: 'assign',
     fields: [
@@ -873,6 +897,102 @@ function normalizeStepType(value: string): string {
   return value.trim().toLowerCase();
 }
 
+function normalizeParameterName(value: string): string {
+  return value.trim();
+}
+
+function labelFromParameterName(parameterName: string): ConsoleMessageDescriptor {
+  const normalized = normalizeParameterName(parameterName);
+  const label = normalized
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .trim()
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+
+  return message(
+    `shared.studio.nodeConfiguration.inferred.${normalized || 'parameter'}.label`,
+    label || 'Parameter',
+  );
+}
+
+function normalizeField(
+  field: StudioNodeConfigurationField,
+): NodeConfigField {
+  const parameterName = normalizeParameterName(field.parameterName || field.path || '');
+  return {
+    ...field,
+    control: field.control ?? field.kind,
+    parameterName,
+    path: normalizeParameterName(field.path || parameterName),
+  };
+}
+
+function inferControlFromValue(value: unknown): StudioNodeConfigurationFieldKind {
+  if (typeof value === 'boolean') {
+    return 'boolean';
+  }
+
+  if (typeof value === 'number') {
+    return 'number';
+  }
+
+  if (Array.isArray(value)) {
+    return 'array';
+  }
+
+  if (value && typeof value === 'object') {
+    return 'object';
+  }
+
+  if (typeof value === 'string' && value.includes('\n')) {
+    return 'textarea';
+  }
+
+  return 'text';
+}
+
+function inferConfigurationFields(
+  parameters: Record<string, unknown> | null | undefined,
+): readonly NodeConfigField[] {
+  const normalizedParameters =
+    parameters && typeof parameters === 'object' && !Array.isArray(parameters)
+      ? parameters
+      : {};
+
+  return Object.entries(normalizedParameters).map(([parameterName, value]) => {
+    const control = inferControlFromValue(value);
+    return normalizeField({
+      control,
+      defaultValue: value,
+      kind: control,
+      label: labelFromParameterName(parameterName),
+      name: parameterName,
+      parameterName,
+      path: parameterName,
+    });
+  });
+}
+
+function buildConfigurationSchema(
+  stepType: string,
+  parameters?: Record<string, unknown> | null,
+): StudioNodeConfigurationSchema {
+  const normalizedType = normalizeStepType(stepType);
+  const schema = SCHEMAS_BY_STEP_TYPE[normalizedType];
+
+  if (schema) {
+    return {
+      ...schema,
+      fields: schema.fields.map(normalizeField),
+    };
+  }
+
+  return {
+    fields: inferConfigurationFields(parameters),
+    stepType: normalizedType || 'step',
+  };
+}
+
 function stringifyConfigurationValue(value: unknown): string {
   if (value === undefined || value === null) {
     return '';
@@ -891,21 +1011,16 @@ function stringifyConfigurationValue(value: unknown): string {
 
 export function getStudioNodeConfigurationSchema(
   stepType: string,
+  parameters?: Record<string, unknown> | null,
 ): StudioNodeConfigurationSchema {
-  const normalizedType = normalizeStepType(stepType);
-  return (
-    SCHEMAS_BY_STEP_TYPE[normalizedType] ?? {
-      stepType: normalizedType || 'step',
-      fields: [],
-    }
-  );
+  return buildConfigurationSchema(stepType, parameters);
 }
 
 export function readStudioNodeConfigurationValues(
   stepType: string,
   parameters: Record<string, unknown> | null | undefined,
 ): Record<string, string> {
-  const schema = getStudioNodeConfigurationSchema(stepType);
+  const schema = getStudioNodeConfigurationSchema(stepType, parameters);
   return Object.fromEntries(
     schema.fields.map((field) => [
       field.name,
@@ -921,25 +1036,143 @@ export function applyStudioNodeConfigurationValues(
   parameters: Record<string, unknown> | null | undefined,
   values: Record<string, string>,
 ): Record<string, unknown> {
-  const schema = getStudioNodeConfigurationSchema(stepType);
+  const result = applyStudioNodeConfigurationValuesWithValidation(
+    stepType,
+    parameters,
+    values,
+  );
+
+  if (!result.valid) {
+    throw new Error(result.errors[0] ?? 'Node configuration is invalid.');
+  }
+
+  return result.parameters;
+}
+
+function readFieldValueFromInput(
+  field: StudioNodeConfigurationField,
+  value: string,
+): { error?: string; include: boolean; value?: unknown } {
+  const trimmed = value.trim();
+  const control = field.control ?? field.kind;
+
+  if (!trimmed && !field.required) {
+    return { include: false };
+  }
+
+  if (!trimmed && field.required) {
+    return {
+      error: `${field.label.defaultMessage} is required.`,
+      include: false,
+    };
+  }
+
+  switch (control) {
+    case 'array':
+    case 'json':
+    case 'object': {
+      try {
+        const parsed = JSON.parse(value) as unknown;
+        if (control === 'array' && !Array.isArray(parsed)) {
+          return {
+            error: `${field.label.defaultMessage} must be a JSON array.`,
+            include: false,
+          };
+        }
+        if (
+          control === 'object' &&
+          (!parsed || typeof parsed !== 'object' || Array.isArray(parsed))
+        ) {
+          return {
+            error: `${field.label.defaultMessage} must be a JSON object.`,
+            include: false,
+          };
+        }
+        return { include: true, value: parsed };
+      } catch (error) {
+        return {
+          error:
+            error instanceof Error
+              ? `${field.label.defaultMessage}: ${error.message}`
+              : `${field.label.defaultMessage} must be valid JSON.`,
+          include: false,
+        };
+      }
+    }
+    case 'boolean':
+      return { include: true, value: trimmed === 'true' };
+    case 'number': {
+      const parsed = Number(trimmed);
+      if (!Number.isFinite(parsed)) {
+        return {
+          error: `${field.label.defaultMessage} must be a number.`,
+          include: false,
+        };
+      }
+      if (field.validation?.integer && !Number.isInteger(parsed)) {
+        return {
+          error: `${field.label.defaultMessage} must be a whole number.`,
+          include: false,
+        };
+      }
+      if (field.validation?.min !== undefined && parsed < field.validation.min) {
+        return {
+          error: `${field.label.defaultMessage} must be at least ${field.validation.min}.`,
+          include: false,
+        };
+      }
+      if (field.validation?.max !== undefined && parsed > field.validation.max) {
+        return {
+          error: `${field.label.defaultMessage} must be at most ${field.validation.max}.`,
+          include: false,
+        };
+      }
+      return { include: true, value: parsed };
+    }
+    default:
+      return { include: true, value };
+  }
+}
+
+export function applyStudioNodeConfigurationValuesWithValidation(
+  stepType: string,
+  parameters: Record<string, unknown> | null | undefined,
+  values: Record<string, string>,
+): {
+  readonly errors: readonly string[];
+  readonly parameters: Record<string, unknown>;
+  readonly valid: boolean;
+} {
+  const schema = getStudioNodeConfigurationSchema(stepType, parameters);
   const nextParameters = {
     ...(parameters && typeof parameters === 'object' ? parameters : {}),
   };
+  const errors: string[] = [];
 
   for (const field of schema.fields) {
     const value = values[field.name] ?? '';
+    const fieldValue = readFieldValueFromInput(field, value);
+    if (fieldValue.error) {
+      errors.push(fieldValue.error);
+      continue;
+    }
+
     const resolvedParameterName = resolveStepParameterName(
       stepType,
       field.parameterName,
     );
-    if (field.required || value.trim()) {
-      nextParameters[resolvedParameterName] = value;
+    if (fieldValue.include) {
+      nextParameters[resolvedParameterName] = fieldValue.value;
     } else {
       delete nextParameters[resolvedParameterName];
     }
   }
 
-  return normalizeStepParametersForType(stepType, nextParameters);
+  return {
+    errors,
+    parameters: normalizeStepParametersForType(stepType, nextParameters),
+    valid: errors.length === 0,
+  };
 }
 
 export function applyRawStudioNodeConfiguration(

--- a/apps/aevatar-console-web/src/shared/studio/nodeConfiguration.ts
+++ b/apps/aevatar-console-web/src/shared/studio/nodeConfiguration.ts
@@ -52,6 +52,8 @@ export type StudioNodeConfigurationSchema = {
   readonly stepType: string;
 };
 
+type StudioNodeConfigurationSchemaSource = Record<string, unknown> | null | undefined;
+
 type StudioNodeConfigurationSchemaDefinition = {
   readonly fields: readonly StudioNodeConfigurationField[];
   readonly stepType: string;
@@ -1019,8 +1021,9 @@ export function getStudioNodeConfigurationSchema(
 export function readStudioNodeConfigurationValues(
   stepType: string,
   parameters: Record<string, unknown> | null | undefined,
+  schemaParameters: StudioNodeConfigurationSchemaSource = parameters,
 ): Record<string, string> {
-  const schema = getStudioNodeConfigurationSchema(stepType, parameters);
+  const schema = getStudioNodeConfigurationSchema(stepType, schemaParameters);
   return Object.fromEntries(
     schema.fields.map((field) => [
       field.name,
@@ -1035,11 +1038,13 @@ export function applyStudioNodeConfigurationValues(
   stepType: string,
   parameters: Record<string, unknown> | null | undefined,
   values: Record<string, string>,
+  schemaParameters?: StudioNodeConfigurationSchemaSource,
 ): Record<string, unknown> {
   const result = applyStudioNodeConfigurationValuesWithValidation(
     stepType,
     parameters,
     values,
+    schemaParameters,
   );
 
   if (!result.valid) {
@@ -1138,12 +1143,13 @@ export function applyStudioNodeConfigurationValuesWithValidation(
   stepType: string,
   parameters: Record<string, unknown> | null | undefined,
   values: Record<string, string>,
+  schemaParameters: StudioNodeConfigurationSchemaSource = parameters,
 ): {
   readonly errors: readonly string[];
   readonly parameters: Record<string, unknown>;
   readonly valid: boolean;
 } {
-  const schema = getStudioNodeConfigurationSchema(stepType, parameters);
+  const schema = getStudioNodeConfigurationSchema(stepType, schemaParameters);
   const nextParameters = {
     ...(parameters && typeof parameters === 'object' ? parameters : {}),
   };


### PR DESCRIPTION
## Summary
- Added a generic frontend NodeConfigField descriptor foundation for Workflow Studio Inspector configuration fields.
- Added adapter-backed known node fields plus inference from existing workflow document parameters for unknown node types.
- Kept Advanced raw JSON in the same Inspector and synchronized structured edits and raw JSON against the same parameters object.
- Added inline validation for invalid structured and raw JSON edits, with frontend save gating while invalid configuration is present.

## Scope
Frontend-only under `apps/aevatar-console-web`. No backend, proto, API, actor, projection, workflow runtime, database, backend test, backend config, architecture doc, or non-frontend source changes.

## Validation
- `pnpm --dir apps/aevatar-console-web tsc` passed.
- `pnpm --dir apps/aevatar-console-web test src/pages/team-member-workflow-studio/index.test.tsx --runInBand` passed.
- `bash tools/ci/test_stability_guards.sh` passed.
- `git diff --check` passed.

## Boundary
PR #1909 and other non-owner PRs were treated as read-only evidence only; this branch does not mutate them.

Closes #1933
