### PR TITLE
Fix Workflow Studio draft persistence

### DIFF
--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -94,6 +94,24 @@ function getTeamMemberWorkflowStudioTeamQueryKey(
   return ["team-member-workflow-studio", "team", scopeId, teamId] as const;
 }
 
+function getTeamMemberWorkflowStudioWorkflowQueryKey(
+  scopeId: string,
+  workflowIds: readonly string[],
+) {
+  return [
+    "team-member-workflow-studio",
+    "workflow",
+    scopeId,
+    [...workflowIds],
+  ] as const;
+}
+
+type WorkflowSourceSignature = {
+  readonly updatedAtUtc: string;
+  readonly workflowId: string;
+  readonly yaml: string;
+};
+
 type TeamMemberWorkflowStudioState = {
   readonly publishMember: () => void;
   readonly memberPublished: boolean;
@@ -226,7 +244,9 @@ function resolveNewWorkflowDirectoryId(input: {
   );
 }
 
-function resolveWorkflowId(memberDetail: StudioMemberDetail | null | undefined): string {
+function resolveExplicitWorkflowId(
+  memberDetail: StudioMemberDetail | null | undefined,
+): string {
   const implementationRef = memberDetail?.implementationRef;
   if (
     trimOptional(implementationRef?.implementationKind).toLowerCase() !== "workflow"
@@ -235,6 +255,58 @@ function resolveWorkflowId(memberDetail: StudioMemberDetail | null | undefined):
   }
 
   return trimOptional(implementationRef?.workflowId);
+}
+
+function resolveWorkflowDraftReloadIds(
+  memberDetail: StudioMemberDetail | null | undefined,
+): readonly string[] {
+  const explicitWorkflowId = resolveExplicitWorkflowId(memberDetail);
+  const memberWorkflowId =
+    trimOptional(memberDetail?.summary.implementationKind).toLowerCase() ===
+    "workflow"
+      ? trimOptional(memberDetail?.summary.memberId)
+      : "";
+  const ids = [explicitWorkflowId, memberWorkflowId].filter(Boolean);
+
+  return Array.from(new Set(ids));
+}
+
+function readWorkflowSourceSignature(
+  workflow: StudioWorkflowFile | null | undefined,
+): WorkflowSourceSignature | null {
+  if (!workflow) {
+    return null;
+  }
+
+  return {
+    updatedAtUtc: trimOptional(workflow.updatedAtUtc),
+    workflowId: trimOptional(workflow.workflowId),
+    yaml: workflow.yaml ?? "",
+  };
+}
+
+function workflowSourceSignaturesMatch(
+  left: WorkflowSourceSignature,
+  right: WorkflowSourceSignature,
+): boolean {
+  return (
+    left.workflowId === right.workflowId &&
+    left.updatedAtUtc === right.updatedAtUtc &&
+    left.yaml === right.yaml
+  );
+}
+
+function buildSavedWorkflowCacheValue(
+  saved: SavedWorkflowDraft,
+): StudioWorkflowFile {
+  return {
+    ...saved.workflow,
+    document: cloneWorkflowDocument(saved.document),
+    draftExists: true,
+    findings: saved.workflow.findings ?? [],
+    layout: saved.layout,
+    name: saved.title,
+  };
 }
 
 function readStepIdFromGraphNodeId(nodeId: string): string {
@@ -600,6 +672,8 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
   const [workflowTitle, setWorkflowTitleState] =
     React.useState("Untitled member");
   const sourceKeyRef = React.useRef("");
+  const suppressedSourceSignatureRef =
+    React.useRef<WorkflowSourceSignature | null>(null);
   const backHref = buildTeamDetailHref({
     memberId: route.memberId || undefined,
     scopeId: route.scopeId,
@@ -655,32 +729,50 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     ],
     queryFn: () => studioApi.getMember(route.scopeId, route.memberId),
   });
-  const stableWorkflowId =
-    route.mode === "existing" ? resolveWorkflowId(memberQuery.data) : "";
+  const explicitWorkflowId =
+    route.mode === "existing" ? resolveExplicitWorkflowId(memberQuery.data) : "";
+  const workflowDraftReloadIds =
+    route.mode === "existing"
+      ? resolveWorkflowDraftReloadIds(memberQuery.data)
+      : [];
   const memberPublishedServiceId = trimOptional(
     memberQuery.data?.summary.publishedServiceId,
   );
+  const workflowQueryKey = getTeamMemberWorkflowStudioWorkflowQueryKey(
+    route.scopeId,
+    workflowDraftReloadIds,
+  );
   const workflowQuery = useQuery({
-    enabled: Boolean(route.scopeId && stableWorkflowId),
-    queryKey: [
-      "team-member-workflow-studio",
-      "workflow",
-      route.scopeId,
-      stableWorkflowId,
-    ],
-    queryFn: () => studioApi.getWorkflow(stableWorkflowId, route.scopeId),
+    enabled: Boolean(route.scopeId && workflowDraftReloadIds.length),
+    queryKey: workflowQueryKey,
+    queryFn: async () => {
+      let lastError: unknown = null;
+      for (const workflowId of workflowDraftReloadIds) {
+        try {
+          return await studioApi.getWorkflow(workflowId, route.scopeId);
+        } catch (error) {
+          lastError = error;
+        }
+      }
+
+      throw lastError instanceof Error
+        ? lastError
+        : new Error("Workflow draft was not found.");
+    },
+    retry: explicitWorkflowId ? undefined : false,
   });
+  const editableWorkflowId = trimOptional(workflowQuery.data?.workflowId);
   const executionsQuery = useQuery({
     enabled: Boolean(
       selectedTab === "runs" &&
-        route.scopeId &&
-        (stableWorkflowId || memberPublishedServiceId),
+      route.scopeId &&
+      (editableWorkflowId || memberPublishedServiceId),
     ),
     queryKey: [
       "team-member-workflow-studio",
       "executions",
       route.scopeId,
-      stableWorkflowId,
+      editableWorkflowId,
       memberPublishedServiceId,
       route.memberId,
     ],
@@ -696,7 +788,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       "team-member-workflow-studio",
       "parse-yaml",
       route.scopeId,
-      stableWorkflowId,
+      workflowQuery.data?.workflowId ?? workflowDraftReloadIds.join("|"),
       workflowQuery.data?.yaml,
     ],
     queryFn: () =>
@@ -713,12 +805,16 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       : trimOptional(memberQuery.data?.summary.displayName) ||
         route.memberId ||
         "Workflow member";
+  const activeMemberTitle =
+    trimOptional(memberQuery.data?.summary.displayName) ||
+    trimOptional(workflowTitle) ||
+    routeFallbackTitle;
   const teamName =
     trimOptional(teamQuery.data?.displayName) || route.teamId || "Current team";
   const linkedWorkflowMissing =
     route.mode === "existing" &&
     !memberQuery.isLoading &&
-    !stableWorkflowId &&
+    (!workflowDraftReloadIds.length || workflowQuery.isError) &&
     Boolean(memberQuery.data);
   const sourceDocument =
     route.mode === "new"
@@ -730,10 +826,10 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
   const sourceKey =
     route.mode === "new"
       ? `new:${route.scopeId}:${route.teamId}`
-      : stableWorkflowId && workflowQuery.data
+      : workflowQuery.data
         ? [
             "workflow",
-            stableWorkflowId,
+            workflowQuery.data.workflowId,
             workflowQuery.data.updatedAtUtc,
             workflowQuery.data.yaml,
             parseQuery.data ? "parsed" : "document",
@@ -744,6 +840,18 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
 
   React.useEffect(() => {
     if (!sourceDocument || !sourceKey || sourceKeyRef.current === sourceKey) {
+      return;
+    }
+
+    const sourceSignature = readWorkflowSourceSignature(workflowQuery.data);
+    const suppressedSourceSignature = suppressedSourceSignatureRef.current;
+    if (
+      sourceSignature &&
+      suppressedSourceSignature &&
+      workflowSourceSignaturesMatch(sourceSignature, suppressedSourceSignature)
+    ) {
+      suppressedSourceSignatureRef.current = null;
+      sourceKeyRef.current = sourceKey;
       return;
     }
 
@@ -782,6 +890,35 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     setWorkflowTitleState(saved.title);
     setDirty(false);
   }, []);
+  const markSavedDraft = React.useCallback(
+    (saved: SavedWorkflowDraft) => {
+      const savedWorkflow = buildSavedWorkflowCacheValue(saved);
+      const savedSignature = readWorkflowSourceSignature(savedWorkflow);
+      if (savedSignature && route.scopeId && workflowDraftReloadIds.length > 0) {
+        suppressedSourceSignatureRef.current = savedSignature;
+        queryClient.setQueryData(workflowQueryKey, savedWorkflow);
+      }
+
+      setEditableDocument((currentDocument) =>
+        currentDocument
+          ? trimOptional(currentDocument.name) === saved.title
+            ? currentDocument
+            : {
+                ...currentDocument,
+                name: saved.title,
+              }
+          : cloneWorkflowDocument(saved.document),
+      );
+      setWorkflowTitleState(saved.title);
+      setDirty(false);
+    },
+    [
+      queryClient,
+      route.scopeId,
+      workflowDraftReloadIds.length,
+      workflowQueryKey,
+    ],
+  );
 
   const saveMutation = useMutation({
     mutationFn: (variables: SaveWorkflowDraftVariables) =>
@@ -795,8 +932,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       );
     },
     onSuccess: (saved) => {
-      applySavedDraft(saved);
-      void workflowQuery.refetch();
+      markSavedDraft(saved);
       void message.success("Workflow draft saved.");
     },
   });
@@ -1089,7 +1225,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
   const workflowLoading =
     route.mode === "existing" &&
     (memberQuery.isLoading ||
-      (Boolean(stableWorkflowId) &&
+      (workflowDraftReloadIds.length > 0 &&
         (workflowQuery.isLoading || parseQuery.isLoading)));
   const canSave =
     route.mode === "new"
@@ -1173,8 +1309,8 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
 
     return executions.filter((execution) => {
       const executionWorkflowId = readExecutionWorkflowId(execution);
-      if (stableWorkflowId && executionWorkflowId) {
-        return executionWorkflowId === stableWorkflowId;
+      if (editableWorkflowId && executionWorkflowId) {
+        return executionWorkflowId === editableWorkflowId;
       }
 
       const executionServiceId = trimOptional(execution.serviceId);
@@ -1184,11 +1320,11 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
 
       return false;
     });
-  }, [executionsQuery.data, memberPublishedServiceId, stableWorkflowId]);
+  }, [editableWorkflowId, executionsQuery.data, memberPublishedServiceId]);
   const memberRunsEmptyReason =
     route.mode === "new"
       ? "Run history is unavailable until this draft is saved as a linked Team member."
-      : !stableWorkflowId && !memberPublishedServiceId
+      : !editableWorkflowId && !memberPublishedServiceId
         ? "Run history is available after this member has a saved workflow link or active published version."
         : executionsQuery.isLoading
           ? "Loading runs."
@@ -1484,8 +1620,8 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
           memberId: route.memberId,
           publishedServiceId: memberPublishedServiceId,
           runMessage: trimOptional(executionRunMessage),
-          title: workflowTitle,
-          workflowId: stableWorkflowId || undefined,
+          title: activeMemberTitle,
+          workflowId: editableWorkflowId || undefined,
         });
       }
     },

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -719,7 +719,152 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(studioApi.getWorkflow).toHaveBeenCalledWith("workflow-alpha", "scope-1");
   });
 
-  it("shows a recoverable state when no stable workflow ref exists", async () => {
+  it("reloads a scoped workflow member from the member id when the read model omits the draft ref", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1/t-alpha/members/untitled-member/workflow",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: null,
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Untitled member",
+        implementationKind: "workflow",
+        lastBoundRevisionId: null,
+        lifecycleStage: "created",
+        memberId: "untitled-member",
+        publishedServiceId: "",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:01Z",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "untitled-member.yaml",
+      filePath: "scope://scope-1/untitled-member.yaml",
+      findings: [],
+      layout: null,
+      name: "Untitled member",
+      workflowId: "untitled-member",
+      yaml: "name: Untitled member\nsteps: []\n",
+      document: {
+        name: "Untitled member",
+        roles: [],
+        steps: [
+          {
+            id: "llm_call",
+            type: "llm_call",
+            targetRole: null,
+            parameters: {},
+            next: null,
+            branches: {},
+          },
+        ],
+      },
+      updatedAtUtc: "2026-06-08T00:00:01Z",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    expect(await screen.findByDisplayValue("Untitled member")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText("nodes:1")).toBeTruthy();
+    });
+    expect(studioApi.getWorkflow).toHaveBeenCalledWith(
+      "untitled-member",
+      "scope-1",
+    );
+    expect(
+      screen.queryByText("No workflow draft is linked to this member yet."),
+    ).toBeNull();
+  });
+
+  it("falls back to the scoped member draft when the workflow ref points at the runtime name", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1/t-alpha/members/untitled-member/workflow",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "Untitled member",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Untitled member",
+        implementationKind: "workflow",
+        lastBoundRevisionId: null,
+        lifecycleStage: "created",
+        memberId: "untitled-member",
+        publishedServiceId: "",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:01Z",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockImplementation(
+      async (workflowId: string) => {
+        if (workflowId === "Untitled member") {
+          throw Object.assign(new Error("Not found"), { status: 404 });
+        }
+
+        return {
+          directoryId: "scope:scope-1",
+          directoryLabel: "scope-1",
+          draftExists: true,
+          fileName: "untitled-member.yaml",
+          filePath: "scope://scope-1/untitled-member.yaml",
+          findings: [],
+          layout: null,
+          name: "Untitled member",
+          workflowId: "untitled-member",
+          yaml: "name: Untitled member\nsteps: []\n",
+          document: {
+            name: "Untitled member",
+            roles: [],
+            steps: [
+              {
+                id: "llm_call",
+                type: "llm_call",
+                targetRole: null,
+                parameters: {},
+                next: null,
+                branches: {},
+              },
+            ],
+          },
+          updatedAtUtc: "2026-06-08T00:00:01Z",
+        };
+      },
+    );
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    expect(await screen.findByDisplayValue("Untitled member")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText("nodes:1")).toBeTruthy();
+    });
+    expect(studioApi.getWorkflow).toHaveBeenCalledWith(
+      "Untitled member",
+      "scope-1",
+    );
+    expect(studioApi.getWorkflow).toHaveBeenCalledWith(
+      "untitled-member",
+      "scope-1",
+    );
+    expect(
+      screen.queryByText("No workflow draft is linked to this member yet."),
+    ).toBeNull();
+  });
+
+  it("shows a recoverable state when neither stable workflow ref nor scoped draft fallback exists", async () => {
     window.history.replaceState(
       {},
       "",
@@ -744,6 +889,9 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
+    (studioApi.getWorkflow as jest.Mock).mockRejectedValue(
+      Object.assign(new Error("Not found"), { status: 404 }),
+    );
 
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
@@ -752,10 +900,10 @@ describe("TeamMemberWorkflowStudioPage", () => {
         "No workflow draft is linked to this member yet.",
       ),
     ).not.toHaveLength(0);
-    expect(studioApi.getWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.getWorkflow).toHaveBeenCalledWith("member-alpha", "scope-1");
   });
 
-  it("saves existing workflow drafts without publishing or execution calls", async () => {
+  it("saves existing workflow drafts without publishing, execution calls, or canvas reload", async () => {
     window.history.replaceState(
       {},
       "",
@@ -780,7 +928,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    const loadedWorkflow = {
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -793,8 +941,18 @@ describe("TeamMemberWorkflowStudioPage", () => {
       yaml: "name: Workflow Alpha\nsteps: []\n",
       document: mockWorkflowDocument,
       updatedAtUtc: "2026-06-08T00:00:00Z",
-    });
+    };
+    (studioApi.getWorkflow as jest.Mock)
+      .mockResolvedValueOnce(loadedWorkflow)
+      .mockResolvedValueOnce({
+        ...loadedWorkflow,
+        updatedAtUtc: "2026-06-08T00:00:02Z",
+      });
     (studioApi.saveWorkflow as jest.Mock).mockResolvedValue({
+      ...loadedWorkflow,
+      document: null,
+      updatedAtUtc: "2026-06-08T00:00:01Z",
+      yaml: "name: Workflow Alpha\nsteps:\n  - id: triage\n    type: llm_call\n  - id: guard_step\n    type: guard\n",
       workflowId: "workflow-alpha",
     });
 
@@ -835,6 +993,12 @@ describe("TeamMemberWorkflowStudioPage", () => {
     });
     expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
     expect(studioApi.startExecution).not.toHaveBeenCalled();
+    await flushAsyncWork();
+    expect(studioApi.getWorkflow).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("nodes:2")).toBeTruthy();
+    await waitFor(() => {
+      expect(saveButton).toBeDisabled();
+    });
   });
 
   it("supports selecting, deleting, connecting, and moving nodes before save", async () => {
@@ -2026,7 +2190,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         },
       );
     });
-    expect(studioApi.getWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.getWorkflow).toHaveBeenCalledWith("member-alpha", "scope-1");
   });
 
   it("publishes an existing workflow member through save, bind, and binding-run observation only", async () => {


### PR DESCRIPTION
## Summary
- Load Workflow Studio drafts through explicit workflow refs with member-id fallback for scoped workflow members
- Keep Save from refetching and rebuilding the canvas after a successful draft save
- Add regression coverage for missing refs, runtime-name refs, save persistence, and active-member run metadata

## Verification
- npm run test -- --runInBand src/pages/team-member-workflow-studio/index.test.tsx
- npm run tsc
- git diff --check