### PR TITLE
Fix Workflow Studio connection deletion selection

### DIFF
--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -1547,7 +1547,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     );
     setEditableDocument(result.document);
     setSelectedEdgeId("");
-    setSelectedNodeId(result.nodeId);
+    setSelectedNodeId("");
     setDirty(true);
   }, [editableDocument, selectedEdgeId]);
   const updateSelectedStepConfiguration = React.useCallback(

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -1164,6 +1164,12 @@ describe("TeamMemberWorkflowStudioPage", () => {
       screen.getByRole("button", { name: "Delete connection" }),
     ).toBeEnabled();
     fireEvent.click(screen.getByRole("button", { name: "Delete connection" }));
+    expect(screen.queryByRole("button", {
+      name: "edge:edge:triage:publish:linear",
+    })).toBeNull();
+    expect(screen.getByText("nodes:2")).toBeTruthy();
+    expect(screen.queryByTestId("workflow-node-inspector")).toBeNull();
+    expect(screen.getByRole("button", { name: "Delete node" })).toBeDisabled();
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- Clear the canvas selection after deleting a selected workflow connection
- Prevent the node inspector from opening automatically for the source node after a connection delete
- Add regression coverage that the connection disappears, both nodes remain, and node actions reset

## Verification
- npm run test -- --runInBand src/pages/team-member-workflow-studio/index.test.tsx
- npm run tsc
- git diff --check