### PR TITLE
Limit Teams Home run signal queries

### DIFF
--- a/apps/aevatar-console-web/src/pages/teams/home.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.test.tsx
@@ -309,6 +309,73 @@ describe("TeamsHomePage", () => {
     expect(screen.queryByText(/帮助你快速判断是否需要处理/)).toBeNull();
   });
 
+  it("keeps the team runtime signal scoped to the entry member when other bound members are not sampled", async () => {
+    (studioApi.listTeams as jest.Mock).mockResolvedValueOnce({
+      scopeId: "scope-a",
+      teams: [
+        {
+          ...defaultTeams[0],
+          entryMemberId: "member-entry",
+          memberCount: 2,
+        },
+      ],
+      nextPageToken: null,
+    });
+    (studioApi.listMembers as jest.Mock).mockResolvedValueOnce({
+      scopeId: "scope-a",
+      members: [
+        {
+          ...defaultMembers[0],
+          memberId: "member-entry",
+          displayName: "入口成员",
+          publishedServiceId: "service-entry",
+        },
+        {
+          ...defaultMembers[0],
+          memberId: "member-secondary",
+          displayName: "普通成员",
+          publishedServiceId: "service-secondary",
+        },
+      ],
+      nextPageToken: null,
+    });
+    (scopeRuntimeApi.listMemberRuns as jest.Mock).mockResolvedValueOnce({
+      scopeId: "scope-a",
+      serviceId: "service-entry",
+      serviceKey: "scope-a:entry",
+      displayName: "入口运行时",
+      runs: [
+        {
+          ...buildMemberRunCatalog("member-alpha").runs[0],
+          serviceId: "service-entry",
+          runId: "run-entry-latest",
+          completionStatus: "completed",
+          lastSuccess: true,
+        },
+      ],
+    });
+
+    renderWithQueryClient(React.createElement(TeamsHomePage));
+
+    expect(await screen.findByText("已完成")).toBeTruthy();
+    expect(screen.getByText("运行中")).toBeTruthy();
+    expect(
+      screen.getByText("最近一次成员运行正常，可继续进入详情查看。"),
+    ).toBeTruthy();
+    expect(screen.queryByText("待运行")).toBeNull();
+    expect(
+      screen.queryByText("成员已绑定服务。下一步：进入团队详情后测试团队，生成第一条可见运行。"),
+    ).toBeNull();
+    await waitFor(() => {
+      expect(scopeRuntimeApi.listMemberRuns).toHaveBeenCalledTimes(1);
+    });
+    expect(scopeRuntimeApi.listMemberRuns).toHaveBeenCalledWith(
+      "scope-a",
+      "member-entry",
+      { take: 1 },
+    );
+  });
+
   it("keeps long member and service summaries compact while preserving full text in titles", async () => {
     (studioApi.listTeams as jest.Mock).mockResolvedValueOnce({
       scopeId: "scope-a",

--- a/apps/aevatar-console-web/src/pages/teams/home.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.test.tsx
@@ -33,6 +33,7 @@ const defaultTeams = [
     displayName: "客服团队",
     description: "负责处理用户问题",
     lifecycleStage: "active",
+    entryMemberId: "member-alpha",
     memberCount: 1,
     createdAt: "2026-05-01T09:00:00Z",
     updatedAt: "2026-05-01T10:02:00Z",
@@ -159,7 +160,7 @@ describe("TeamsHomePage", () => {
   it("renders the team homepage around real Team roster with member runtime hints", async () => {
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
-    expect(await screen.findByRole("button", { name: "调试工作流" })).toBeTruthy();
+    expect(await screen.findByRole("button", { name: "调试入口工作流" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "查看团队" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "查看成员" })).toBeTruthy();
     expect(screen.getByText("阿凡达/团队")).toBeTruthy();
@@ -188,7 +189,7 @@ describe("TeamsHomePage", () => {
 
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
-    expect(await screen.findByRole("button", { name: "Debug workflow" })).toBeTruthy();
+    expect(await screen.findByRole("button", { name: "Debug entry workflow" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "View team" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "View members" })).toBeTruthy();
     expect(screen.getByText("My AI teams")).toBeTruthy();
@@ -203,7 +204,7 @@ describe("TeamsHomePage", () => {
   it("keeps team card actions focused on member work and team detail", async () => {
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
-    await screen.findByRole("button", { name: "调试工作流" });
+    await screen.findByRole("button", { name: "调试入口工作流" });
     expect(screen.getByRole("button", { name: "查看团队" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "查看成员" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "更多" })).toBeNull();
@@ -260,7 +261,7 @@ describe("TeamsHomePage", () => {
     ).toBeNull();
   });
 
-  it("loads every bound member run summary without showing a synthetic sync warning", async () => {
+  it("loads only the configured entry member run summary for the homepage signal", async () => {
     const members = Array.from({ length: 13 }, (_, index) => ({
       ...defaultMembers[0],
       memberId: `member-${index + 1}`,
@@ -268,6 +269,18 @@ describe("TeamsHomePage", () => {
       publishedServiceId: `service-${index + 1}`,
       teamId: "t-support",
     }));
+    const entryMemberId = "member-7";
+    (studioApi.listTeams as jest.Mock).mockResolvedValueOnce({
+      scopeId: "scope-a",
+      teams: [
+        {
+          ...defaultTeams[0],
+          entryMemberId,
+          memberCount: members.length,
+        },
+      ],
+      nextPageToken: null,
+    });
     (studioApi.listMembers as jest.Mock).mockResolvedValueOnce({
       scopeId: "scope-a",
       members,
@@ -280,8 +293,13 @@ describe("TeamsHomePage", () => {
       await screen.findByText("成员已绑定服务。下一步：进入团队详情后测试团队，生成第一条可见运行。"),
     ).toBeTruthy();
     await waitFor(() => {
-      expect(scopeRuntimeApi.listMemberRuns).toHaveBeenCalledTimes(13);
+      expect(scopeRuntimeApi.listMemberRuns).toHaveBeenCalledTimes(1);
     });
+    expect(scopeRuntimeApi.listMemberRuns).toHaveBeenCalledWith(
+      "scope-a",
+      entryMemberId,
+      { take: 1 },
+    );
     expect(screen.queryByText("部分 Team 的运行状态仍在同步")).toBeNull();
     expect(screen.queryByText("状态同步中")).toBeNull();
     expect(
@@ -370,6 +388,24 @@ describe("TeamsHomePage", () => {
       "title",
       "t-long",
     );
+  });
+
+  it("does not query member runs for a Team without an entry member", async () => {
+    (studioApi.listTeams as jest.Mock).mockResolvedValueOnce({
+      scopeId: "scope-a",
+      teams: [
+        {
+          ...defaultTeams[0],
+          entryMemberId: null,
+        },
+      ],
+      nextPageToken: null,
+    });
+
+    renderWithQueryClient(React.createElement(TeamsHomePage));
+
+    expect(await screen.findByRole("heading", { level: 3, name: "客服团队" })).toBeTruthy();
+    expect(scopeRuntimeApi.listMemberRuns).not.toHaveBeenCalled();
   });
 
   it("keeps long Team titles compact while preserving the full title in a tooltip", async () => {
@@ -470,7 +506,7 @@ describe("TeamsHomePage", () => {
   it("opens the workflow member debugger from the primary action", async () => {
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
-    fireEvent.click(await screen.findByRole("button", { name: "调试工作流" }));
+    fireEvent.click(await screen.findByRole("button", { name: "调试入口工作流" }));
 
     await waitFor(() => {
       expect(window.location.pathname).toBe(
@@ -698,7 +734,8 @@ describe("TeamsHomePage", () => {
     expect(await screen.findByRole("heading", { level: 3, name: "客服团队" })).toBeTruthy();
     expect(screen.getByRole("heading", { level: 3, name: "joker" })).toBeTruthy();
     expect(screen.getByText("ID：t-joker")).toBeTruthy();
-    expect(screen.getAllByRole("button", { name: "调试工作流" })).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: "调试入口工作流" })).toHaveLength(1);
+    expect(screen.getAllByRole("button", { name: "调试工作流" })).toHaveLength(1);
     expect(screen.getAllByRole("button", { name: "查看团队" })).toHaveLength(2);
     expect(screen.getAllByRole("button", { name: "查看成员" })).toHaveLength(2);
   });

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -1148,22 +1148,43 @@ const TeamsHomePage: React.FC = () => {
     () => groupMembersByTeamId(studioMembers),
     [studioMembers],
   );
-  const runtimeTrackableMembers = React.useMemo(
-    () =>
-      studioMembers.filter(
-        (member) =>
-          Boolean(trimOptional(member.publishedServiceId)) ||
-          Boolean(trimOptional(member.lastBoundRevisionId)),
-      ),
-    [studioMembers],
-  );
+  const runtimeTrackableEntryMembers = React.useMemo(() => {
+    const membersById = new Map(
+      studioMembers
+        .map((member) => [trimOptional(member.memberId), member] as const)
+        .filter(([memberId]) => memberId.length > 0),
+    );
+    const seenMemberIds = new Set<string>();
+    const result: StudioMemberSummary[] = [];
+
+    studioTeams.forEach((team) => {
+      const entryMemberId = trimOptional(team.entryMemberId);
+      if (!entryMemberId || seenMemberIds.has(entryMemberId)) {
+        return;
+      }
+
+      const member = membersById.get(entryMemberId);
+      if (
+        !member ||
+        (!trimOptional(member.publishedServiceId) &&
+          !trimOptional(member.lastBoundRevisionId))
+      ) {
+        return;
+      }
+
+      seenMemberIds.add(entryMemberId);
+      result.push(member);
+    });
+
+    return result;
+  }, [studioMembers, studioTeams]);
   const memberRunQueries = useQueries({
-    queries: runtimeTrackableMembers.map((member) => ({
+    queries: runtimeTrackableEntryMembers.map((member) => ({
       enabled: canLoadRoster && membersQuery.isSuccess,
       queryKey: ["teams", "member-runs", queryScopeId, member.memberId],
       queryFn: () =>
         scopeRuntimeApi.listMemberRuns(queryScopeId, member.memberId, {
-          take: 12,
+          take: 1,
         }),
       retry: false,
     })),
@@ -1171,12 +1192,12 @@ const TeamsHomePage: React.FC = () => {
   const runsByMemberId = React.useMemo(
     () =>
       Object.fromEntries(
-        runtimeTrackableMembers.map((member, index) => [
+        runtimeTrackableEntryMembers.map((member, index) => [
           trimOptional(member.memberId),
           memberRunQueries[index]?.data?.runs ?? [],
         ]),
       ) as Record<string, readonly ScopeServiceRunSummary[]>,
-    [memberRunQueries, runtimeTrackableMembers],
+    [memberRunQueries, runtimeTrackableEntryMembers],
   );
   const teamPreviews = React.useMemo(
     () =>

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -564,11 +564,12 @@ function buildTeamRosterPreview(input: {
     }),
   );
   const sortedMembers = [...input.members].sort(compareMembers);
-  const latestRun =
-    memberPreviews
-      .map((preview) => preview.latestRun)
-      .filter((run): run is ScopeServiceRunSummary => Boolean(run))
-      .sort(compareRuns)[0] ?? null;
+  const memberCount =
+    input.team.memberCount > 0 ? input.team.memberCount : input.members.length;
+  const entryMemberId = trimOptional(input.team.entryMemberId);
+  const entryMemberPreview = entryMemberId
+    ? memberPreviews.find((preview) => preview.memberId === entryMemberId)
+    : undefined;
   const statusRank: Record<TeamOperationalAttention, number> = {
     failed: 0,
     waiting: 1,
@@ -585,12 +586,11 @@ function buildTeamRosterPreview(input: {
         parseTimestamp(right.updatedAt) - parseTimestamp(left.updatedAt) ||
         right.memberId.localeCompare(left.memberId),
     )[0];
-  const memberCount =
-    input.team.memberCount > 0 ? input.team.memberCount : input.members.length;
-  const entryMemberId = trimOptional(input.team.entryMemberId);
   const entryMember = entryMemberId
     ? input.members.find((member) => trimOptional(member.memberId) === entryMemberId)
     : undefined;
+  const runtimeSignalPreview = entryMemberPreview ?? mostImportantMemberPreview;
+  const latestRun = runtimeSignalPreview?.latestRun ?? null;
   // Deferred P2: keep the current workflow-member fallback when the entry is non-workflow.
   // A later pass should surface an explicit entry-unsupported/manage-members state.
   const preferredWorkflowMember =
@@ -660,7 +660,10 @@ function buildTeamRosterPreview(input: {
   const serviceTooltip =
     uniqueServiceLabels.length > 0 ? uniqueServiceLabels.join(" / ") : undefined;
   const primaryMemberPreview =
-    memberPreviews.find((preview) => preview.serviceId) ?? memberPreviews[0] ?? null;
+    entryMemberPreview ??
+    memberPreviews.find((preview) => preview.serviceId) ??
+    memberPreviews[0] ??
+    null;
   const detailHref = buildTeamDetailHref({
     memberId: primaryMemberPreview?.memberId || undefined,
     runId: latestRun?.runId || undefined,
@@ -675,13 +678,13 @@ function buildTeamRosterPreview(input: {
   });
 
   let attention: TeamOperationalAttention =
-    mostImportantMemberPreview?.attention ?? "draft";
+    runtimeSignalPreview?.attention ?? "draft";
   let attentionDetail = t("pages.teams.home.team", "This team has no members yet. Next: add an entry member, then test the team.");
   if (input.team.lifecycleStage === "archived") {
     attention = "draft";
     attentionDetail = t("pages.teams.home.team.roster", "This team has been archived; the list keeps only its backend roster fact.");
-  } else if (mostImportantMemberPreview) {
-    attentionDetail = mostImportantMemberPreview.attentionDetail;
+  } else if (runtimeSignalPreview) {
+    attentionDetail = runtimeSignalPreview.attentionDetail;
   }
 
   return {
@@ -703,7 +706,7 @@ function buildTeamRosterPreview(input: {
     title: pickMeaningfulLabel(input.team.displayName, input.team.teamId) || t("pages.teams.home.team.2", "Unnamed team"),
     updatedAt:
       latestRun?.lastUpdatedAt ||
-      mostImportantMemberPreview?.updatedAt ||
+      runtimeSignalPreview?.updatedAt ||
       input.team.updatedAt ||
       null,
   };


### PR DESCRIPTION
## Problem

Teams Home was using member run history as its homepage runtime signal. That made the page fan out to `/api/scopes/{scopeId}/members/{memberId}/runs` for every bound/runtime-trackable member, even though the homepage only needs a lightweight team-level signal.

This created an N+1 request pattern and blurred the product boundary between Teams Home triage and deeper member/run diagnostics.

## Solution

- Scope Teams Home runtime signal queries to configured Team entry members only.
- Request only the latest entry-member run with `take=1`.
- Skip member run queries entirely when a Team has no `entryMemberId`.
- Keep full run history behavior in deeper Team Detail / Member Runtime surfaces.

## Impacted paths

- `apps/aevatar-console-web/src/pages/teams/home.tsx`
- `apps/aevatar-console-web/src/pages/teams/home.test.tsx`

## Follow-up

Tracks the longer-term API/product contract follow-up in #1946: a Team/homepage-shaped runtime summary endpoint would be cleaner than using member run history from the homepage.

## Verification

- `pnpm --dir apps/aevatar-console-web test --runInBand src/pages/teams/home.test.tsx`
- `pnpm --dir apps/aevatar-console-web tsc`
- `bash tools/ci/test_stability_guards.sh`
