### PR TITLE
让 workflow tool_call 复用 canonical tool middleware chain

### DIFF
--- a/src/Aevatar.AI.Core/Middleware/ToolCallMiddlewareChainFactory.cs
+++ b/src/Aevatar.AI.Core/Middleware/ToolCallMiddlewareChainFactory.cs
@@ -25,7 +25,8 @@ public static class ToolCallMiddlewareChainFactory
         effectiveToolMiddlewares.Add(new ToolApprovalMiddleware(
             approvalHandler ?? MissingApprovalHandler.Instance,
             hooks));
-        effectiveToolMiddlewares.AddRange(toolMiddlewares);
+        effectiveToolMiddlewares.AddRange(toolMiddlewares.Where(static middleware =>
+            middleware is not ToolApprovalMiddleware));
         return effectiveToolMiddlewares;
     }
 }

--- a/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
+using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Core;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.Middleware;
 using Aevatar.AI.Core.Voice;
 using Aevatar.AI.Core.LLMProviders;
 using Aevatar.AI.LLMProviders.MEAI;
@@ -102,6 +104,8 @@ public static class ServiceCollectionExtensions
             .ScanAssemblies(typeof(RoleGAgent).Assembly)
             .Register<WorkflowRoleGAgent>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IWorkflowToolSource, AgentWorkflowToolSourceAdapter>());
+        services.TryAddSingleton<IToolApprovalHandler, YieldApprovalHandler>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IToolCallMiddleware, ToolApprovalMiddleware>());
         services.TryAddSingleton<IVoiceToolInvoker, AgentToolVoiceInvoker>();
         services.TryAddSingleton<IVoiceToolCatalog, AgentToolVoiceCatalog>();
         services.TryAddSingleton<IWorkflowYamlValidator, WorkflowYamlValidatorImpl>();

--- a/src/workflow/Aevatar.Workflow.Integration.AI/AgentWorkflowToolSourceAdapter.cs
+++ b/src/workflow/Aevatar.Workflow.Integration.AI/AgentWorkflowToolSourceAdapter.cs
@@ -1,14 +1,26 @@
+using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.Hooks;
+using Aevatar.AI.Core.Middleware;
 using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Core.Modules;
 
 namespace Aevatar.Workflow.Integration.AI;
 
-public sealed class AgentWorkflowToolSourceAdapter(IEnumerable<IAgentToolSource> agentToolSources) : IWorkflowToolSource
+public sealed class AgentWorkflowToolSourceAdapter(
+    IEnumerable<IAgentToolSource> agentToolSources,
+    IEnumerable<IToolCallMiddleware>? toolMiddlewares = null,
+    IToolApprovalHandler? approvalHandler = null,
+    IEnumerable<IAIGAgentExecutionHook>? hooks = null) : IWorkflowToolSource
 {
     private readonly IEnumerable<IAgentToolSource> _agentToolSources =
         agentToolSources ?? throw new ArgumentNullException(nameof(agentToolSources));
+    private readonly IReadOnlyList<IToolCallMiddleware> _toolMiddlewares =
+        ToolCallMiddlewareChainFactory.ForAgentRuntime(
+            toolMiddlewares ?? [],
+            approvalHandler,
+            hooks == null ? null : new AgentHookPipeline(hooks));
 
     public async Task<IReadOnlyList<IWorkflowTool>> GetToolsAsync(CancellationToken ct = default)
     {
@@ -17,15 +29,19 @@ public sealed class AgentWorkflowToolSourceAdapter(IEnumerable<IAgentToolSource>
         {
             var tools = await source.DiscoverToolsAsync(ct).ConfigureAwait(false);
             foreach (var tool in tools)
-                workflowTools.Add(new AgentWorkflowToolAdapter(tool));
+                workflowTools.Add(new AgentWorkflowToolAdapter(tool, _toolMiddlewares));
         }
 
         return workflowTools;
     }
 
-    private sealed class AgentWorkflowToolAdapter(IAgentTool tool) : IWorkflowTool
+    private sealed class AgentWorkflowToolAdapter(
+        IAgentTool tool,
+        IReadOnlyList<IToolCallMiddleware> toolMiddlewares) : IWorkflowTool
     {
         private readonly IAgentTool _tool = tool ?? throw new ArgumentNullException(nameof(tool));
+        private readonly IReadOnlyList<IToolCallMiddleware> _toolMiddlewares =
+            toolMiddlewares ?? throw new ArgumentNullException(nameof(toolMiddlewares));
 
         public string Name => _tool.Name;
 
@@ -54,8 +70,30 @@ public sealed class AgentWorkflowToolSourceAdapter(IEnumerable<IAgentToolSource>
                 },
             };
             using var scope = AgentToolContextScope.Push(toolContext);
-            var resultJson = await _tool.ExecuteAsync(request.ArgumentsJson, ct).ConfigureAwait(false);
-            var receipt = _tool.CreateSuccessReceipt(request.CallId, _tool.Name, resultJson);
+            var toolCallContext = new ToolCallContext
+            {
+                Tool = _tool,
+                ToolName = _tool.Name,
+                ToolCallId = Normalize(request.CallId) ?? string.Empty,
+                ArgumentsJson = request.ArgumentsJson,
+                CancellationToken = ct,
+            };
+
+            await MiddlewarePipeline.RunToolCallAsync(_toolMiddlewares, toolCallContext, async () =>
+            {
+                if (toolCallContext.Terminate)
+                    return;
+
+                toolCallContext.Result = await _tool.ExecuteAsync(toolCallContext.ArgumentsJson, ct).ConfigureAwait(false);
+            }).ConfigureAwait(false);
+
+            if (toolCallContext.Terminate)
+                throw new InvalidOperationException(FormatMiddlewareTermination(toolCallContext));
+
+            var resultJson = toolCallContext.Result
+                             ?? throw new InvalidOperationException(
+                                 $"Tool '{_tool.Name}' returned no result.");
+            var receipt = _tool.CreateSuccessReceipt(toolCallContext.ToolCallId, _tool.Name, resultJson);
             return new WorkflowToolExecutionResult(
                 resultJson,
                 ToWorkflowManagedHandoffOutcome(receipt?.ManagedWorkflowHandoff));
@@ -63,6 +101,17 @@ public sealed class AgentWorkflowToolSourceAdapter(IEnumerable<IAgentToolSource>
 
         private static string? Normalize(string? value) =>
             string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+        private static string FormatMiddlewareTermination(ToolCallContext context)
+        {
+            var reason = string.IsNullOrWhiteSpace(context.TerminationReason)
+                ? context.Result
+                : context.TerminationReason;
+            var suffix = string.IsNullOrWhiteSpace(reason)
+                ? string.Empty
+                : $": {reason}";
+            return $"Tool '{context.ToolName}' execution terminated by middleware ({context.TerminationKind}){suffix}";
+        }
 
         private static WorkflowManagedHandoffOutcome? ToWorkflowManagedHandoffOutcome(
             ManagedWorkflowHandoffReceipt? receipt)

--- a/test/Aevatar.AI.Core.Tests/Middleware/ToolApprovalMiddlewareTests.cs
+++ b/test/Aevatar.AI.Core.Tests/Middleware/ToolApprovalMiddlewareTests.cs
@@ -33,7 +33,11 @@ public class ToolApprovalMiddlewareTests
     [Fact]
     public async Task ForAgentRuntime_NullApprovalHandler_AllowsNeverRequireTool()
     {
-        var middlewares = ToolCallMiddlewareChainFactory.ForAgentRuntime([], null, null);
+        var duplicateHandler = new ScriptedApprovalHandler(ToolApprovalResult.Denied("duplicate"));
+        var middlewares = ToolCallMiddlewareChainFactory.ForAgentRuntime(
+            [new ToolApprovalMiddleware(duplicateHandler)],
+            null,
+            null);
         var ctx = new ToolCallContext
         {
             Tool = new FakeAgentTool("search", ToolApprovalMode.NeverRequire),
@@ -51,6 +55,7 @@ public class ToolApprovalMiddlewareTests
 
         nextExecuted.Should().BeTrue();
         ctx.Terminate.Should().BeFalse();
+        duplicateHandler.Requests.Should().BeEmpty();
     }
 
     [Theory]

--- a/test/Aevatar.AI.Core.Tests/Middleware/ToolCallMiddlewareChainFactoryTests.cs
+++ b/test/Aevatar.AI.Core.Tests/Middleware/ToolCallMiddlewareChainFactoryTests.cs
@@ -1,0 +1,105 @@
+using Aevatar.AI.Abstractions.Middleware;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.Middleware;
+using FluentAssertions;
+
+namespace Aevatar.AI.Core.Tests.Middleware;
+
+public sealed class ToolCallMiddlewareChainFactoryTests
+{
+    [Fact]
+    public async Task ForAgentRuntime_ShouldPrependCanonicalApprovalMiddleware()
+    {
+        var custom = new RecordingMiddleware();
+
+        var chain = ToolCallMiddlewareChainFactory.ForAgentRuntime(
+            [custom],
+            new ScriptedApprovalHandler(ToolApprovalResult.Approved()),
+            null);
+
+        chain.Should().HaveCount(2);
+        chain[0].Should().BeOfType<ToolApprovalMiddleware>();
+        chain[1].Should().BeSameAs(custom);
+
+        var context = NewContext();
+        await RunChainAsync(chain, context);
+
+        custom.Executions.Should().Be(1);
+        context.Result.Should().Be("""{"ok":true}""");
+    }
+
+    [Fact]
+    public async Task ForAgentRuntime_ShouldRemoveExternallyRegisteredApprovalMiddleware()
+    {
+        var custom = new RecordingMiddleware();
+        var duplicateHandler = new ScriptedApprovalHandler(ToolApprovalResult.Denied("duplicate"));
+
+        var chain = ToolCallMiddlewareChainFactory.ForAgentRuntime(
+            [new ToolApprovalMiddleware(duplicateHandler), custom],
+            new ScriptedApprovalHandler(ToolApprovalResult.Approved()),
+            null);
+
+        chain.Should().HaveCount(2);
+        chain.Should().ContainSingle(middleware => middleware is ToolApprovalMiddleware);
+        chain[1].Should().BeSameAs(custom);
+
+        var context = NewContext();
+        await RunChainAsync(chain, context);
+
+        duplicateHandler.Requests.Should().BeEmpty();
+        custom.Executions.Should().Be(1);
+        context.Terminate.Should().BeFalse();
+        context.Result.Should().Be("""{"ok":true}""");
+    }
+
+    private static ToolCallContext NewContext() => new()
+    {
+        Tool = new FakeAgentTool(),
+        ToolName = "danger",
+        ToolCallId = "call-1",
+        ArgumentsJson = "{}",
+    };
+
+    private static Task RunChainAsync(IReadOnlyList<IToolCallMiddleware> chain, ToolCallContext context) =>
+        MiddlewarePipeline.RunToolCallAsync(chain, context, () =>
+        {
+            context.Result = """{"ok":true}""";
+            return Task.CompletedTask;
+        });
+
+    private sealed class RecordingMiddleware : IToolCallMiddleware
+    {
+        public int Executions { get; private set; }
+
+        public async Task InvokeAsync(ToolCallContext context, Func<Task> next)
+        {
+            Executions++;
+            await next();
+        }
+    }
+
+    private sealed class ScriptedApprovalHandler(params ToolApprovalResult[] results) : IToolApprovalHandler
+    {
+        private readonly Queue<ToolApprovalResult> _results = new(results);
+
+        public List<ToolApprovalRequest> Requests { get; } = [];
+
+        public Task<ToolApprovalResult> RequestApprovalAsync(ToolApprovalRequest request, CancellationToken ct)
+        {
+            Requests.Add(request);
+            return Task.FromResult(_results.TryDequeue(out var result)
+                ? result
+                : ToolApprovalResult.Denied("missing scripted result"));
+        }
+    }
+
+    private sealed class FakeAgentTool : IAgentTool
+    {
+        public string Name => "danger";
+        public string Description => "fake";
+        public string ParametersSchema => "{}";
+        public ToolApprovalMode ApprovalMode => ToolApprovalMode.AlwaysRequire;
+        public bool IsDestructive => true;
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) => Task.FromResult("{}");
+    }
+}

--- a/test/Aevatar.Bootstrap.Tests/AIFeatureBootstrapCoverageTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/AIFeatureBootstrapCoverageTests.cs
@@ -2,9 +2,11 @@ using System.Collections;
 using System.Net.Http;
 using System.Reflection;
 using System.Text.Json;
+using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.AI.Abstractions.Agents;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Core.Middleware;
 using Aevatar.AI.Core.Voice;
 using Aevatar.AI.Core.LLMProviders;
 using Aevatar.AI.LLMProviders.MEAI;
@@ -579,6 +581,9 @@ public class AIFeatureBootstrapCoverageTests
         services.AddAevatarAIFeatures(config, options => options.EnableMEAIProviders = false);
 
         await using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IToolApprovalHandler>().Should().BeOfType<YieldApprovalHandler>();
+        provider.GetServices<IToolCallMiddleware>().Should().ContainSingle(x => x is ToolApprovalMiddleware);
+
         var workflowSource = provider.GetServices<IWorkflowToolSource>()
             .Should()
             .ContainSingle()
@@ -589,7 +594,7 @@ public class AIFeatureBootstrapCoverageTests
             .Subject;
 
         tool.Name.Should().Be("demo_tool");
-        (await tool.ExecuteAsync(
+        var result = await tool.ExecuteAsync(
             new WorkflowToolExecutionRequest(
                 ArgumentsJson: "{}",
                 RunId: "run-1",
@@ -597,7 +602,8 @@ public class AIFeatureBootstrapCoverageTests
                 ExecutionId: "exec-1",
                 CallId: "call-1",
                 ScopeId: "scope-1",
-                CallerCredential: new WorkflowCallerCredential()))).Should().Be("""{"ok":true}""");
+                CallerCredential: new WorkflowCallerCredential()));
+        result.ResultJson.Should().Be("""{"ok":true}""");
     }
 
     [Fact]

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/LocalActorDispatchAdmissionTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/LocalActorDispatchAdmissionTests.cs
@@ -58,7 +58,10 @@ public sealed class LocalActorDispatchAdmissionTests
             new InMemoryStreamOptions(),
             NullLoggerFactory.Instance,
             new InMemoryStreamForwardingRegistry());
-        var runtime = new LocalActorRuntime(streams, new ServiceCollection().BuildServiceProvider(), streams);
+        var services = new ServiceCollection()
+            .AddAevatarAgentKindRegistry(builder => builder.Register<OrderedAgent>())
+            .BuildServiceProvider();
+        var runtime = new LocalActorRuntime(streams, services, streams);
         await runtime.CreateAsync<OrderedAgent>("ordered-actor");
         var dispatchPort = new LocalActorDispatchPort(runtime);
 
@@ -105,6 +108,7 @@ public sealed class LocalActorDispatchAdmissionTests
             Propagation = new EnvelopePropagation { CorrelationId = $"corr-{id}" },
         };
 
+    [GAgent("tests.ordered-agent")]
     private sealed class OrderedAgent : IAgent
     {
         public static Channel<string> Handled { get; private set; } = Channel.CreateUnbounded<string>();

--- a/test/Aevatar.Workflow.Core.Tests/Modules/AgentWorkflowToolSourceAdapterTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/AgentWorkflowToolSourceAdapterTests.cs
@@ -1,4 +1,6 @@
+using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.Middleware;
 using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Core.Modules;
 using Aevatar.Workflow.Integration.AI;
@@ -34,6 +36,121 @@ public sealed class AgentWorkflowToolSourceAdapterTests
         agentTool.ObservedScopeId.Should().Be("scope-1");
         agentTool.ObservedCallId.Should().Be("call-1");
         agentTool.ObservedExternalMetadata.Should().NotContainKey("ExecutionId");
+        AgentToolRequestContext.Current.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task WorkflowTool_ShouldExecuteAgentToolThroughToolMiddlewareChain()
+    {
+        var agentTool = new CapturingAgentTool();
+        var middleware = new RewritingToolCallMiddleware();
+        var adapter = new AgentWorkflowToolSourceAdapter(
+            [new SingleAgentToolSource(agentTool)],
+            [middleware]);
+        var tool = (await adapter.GetToolsAsync(CancellationToken.None)).Single();
+
+        var result = await tool.ExecuteAsync(
+            new WorkflowToolExecutionRequest(
+                ArgumentsJson: """{"original":true}""",
+                RunId: "run-1",
+                StepId: "step-1",
+                ExecutionId: "exec-1",
+                CallId: "call-1",
+                ScopeId: "scope-1",
+                CallerCredential: new WorkflowCallerCredential()),
+            CancellationToken.None);
+
+        agentTool.ObservedArgumentsJson.Should().Be("""{"rewritten":true}""");
+        result.ResultJson.Should().Be("""{"middleware":true}""");
+        middleware.NextExecuted.Should().BeTrue();
+        AgentToolRequestContext.Current.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task WorkflowTool_WhenApprovalDenied_ShouldFailClosedWithoutExecutingAgentTool()
+    {
+        var agentTool = new CapturingAgentTool(ToolApprovalMode.AlwaysRequire);
+        var approvalHandler = new ScriptedApprovalHandler(ToolApprovalResult.Denied("blocked"));
+        var adapter = new AgentWorkflowToolSourceAdapter(
+            [new SingleAgentToolSource(agentTool)],
+            approvalHandler: approvalHandler);
+        var tool = (await adapter.GetToolsAsync(CancellationToken.None)).Single();
+
+        await FluentActions.Awaiting(() => tool.ExecuteAsync(
+                new WorkflowToolExecutionRequest(
+                    ArgumentsJson: "{}",
+                    RunId: "run-1",
+                    StepId: "step-1",
+                    ExecutionId: "exec-1",
+                    CallId: "call-1",
+                    ScopeId: "scope-1",
+                    CallerCredential: new WorkflowCallerCredential()),
+                CancellationToken.None))
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*ApprovalDenied*blocked*");
+
+        agentTool.ExecuteCount.Should().Be(0);
+        approvalHandler.Requests.Should().ContainSingle();
+        AgentToolRequestContext.Current.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task WorkflowTool_WhenApprovalPending_ShouldFailClosedWithoutReturningPendingPayload()
+    {
+        var agentTool = new CapturingAgentTool(ToolApprovalMode.AlwaysRequire);
+        var approvalHandler = new ScriptedApprovalHandler(ToolApprovalResult.Yielded("approval-1"));
+        var adapter = new AgentWorkflowToolSourceAdapter(
+            [new SingleAgentToolSource(agentTool)],
+            approvalHandler: approvalHandler);
+        var tool = (await adapter.GetToolsAsync(CancellationToken.None)).Single();
+
+        await FluentActions.Awaiting(() => tool.ExecuteAsync(
+                new WorkflowToolExecutionRequest(
+                    ArgumentsJson: "{}",
+                    RunId: "run-1",
+                    StepId: "step-1",
+                    ExecutionId: "exec-1",
+                    CallId: "call-1",
+                    ScopeId: "scope-1",
+                    CallerCredential: new WorkflowCallerCredential()),
+                CancellationToken.None))
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*ApprovalPending*approval-1*");
+
+        agentTool.ExecuteCount.Should().Be(0);
+        approvalHandler.Requests.Should().ContainSingle();
+        AgentToolRequestContext.Current.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task WorkflowTool_ShouldUseSingleCanonicalApprovalMiddlewareWhenHostRegistersDuplicate()
+    {
+        var agentTool = new CapturingAgentTool(ToolApprovalMode.AlwaysRequire);
+        var canonicalHandler = new ScriptedApprovalHandler(ToolApprovalResult.Approved());
+        var duplicateHandler = new ScriptedApprovalHandler(ToolApprovalResult.Denied("duplicate"));
+        var adapter = new AgentWorkflowToolSourceAdapter(
+            [new SingleAgentToolSource(agentTool)],
+            [new ToolApprovalMiddleware(duplicateHandler)],
+            canonicalHandler);
+        var tool = (await adapter.GetToolsAsync(CancellationToken.None)).Single();
+
+        var result = await tool.ExecuteAsync(
+            new WorkflowToolExecutionRequest(
+                ArgumentsJson: "{}",
+                RunId: "run-1",
+                StepId: "step-1",
+                ExecutionId: "exec-1",
+                CallId: "call-1",
+                ScopeId: "scope-1",
+                CallerCredential: new WorkflowCallerCredential()),
+            CancellationToken.None);
+
+        result.ResultJson.Should().Be("""{"observed":true}""");
+        agentTool.ExecuteCount.Should().Be(1);
+        canonicalHandler.Requests.Should().ContainSingle();
+        duplicateHandler.Requests.Should().BeEmpty();
         AgentToolRequestContext.Current.Should().BeNull();
     }
 
@@ -166,13 +283,17 @@ public sealed class AgentWorkflowToolSourceAdapterTests
         AgentToolRequestContext.Current.Should().BeNull();
     }
 
-    private sealed class CapturingAgentTool : IAgentTool
+    private sealed class CapturingAgentTool(ToolApprovalMode approvalMode = ToolApprovalMode.NeverRequire) : IAgentTool
     {
         public string Name => "capture_context";
 
         public string Description => "Capture tool context";
 
         public string ParametersSchema => "{}";
+
+        public ToolApprovalMode ApprovalMode { get; } = approvalMode;
+
+        public int ExecuteCount { get; private set; }
 
         public string? ObservedArgumentsJson { get; private set; }
 
@@ -193,6 +314,7 @@ public sealed class AgentWorkflowToolSourceAdapterTests
         public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
+            ExecuteCount++;
             ObservedArgumentsJson = argumentsJson;
             CaptureContext();
             return ExecuteAsyncCore(ct);
@@ -216,6 +338,35 @@ public sealed class AgentWorkflowToolSourceAdapterTests
                 ?? new Dictionary<string, string>(StringComparer.Ordinal);
             ObservedWorkflowRuntime = AgentToolRequestContext.Current?.WorkflowRuntime
                 ?? AgentWorkflowRuntimeContext.Empty;
+        }
+    }
+
+    private sealed class RewritingToolCallMiddleware : IToolCallMiddleware
+    {
+        public bool NextExecuted { get; private set; }
+
+        public async Task InvokeAsync(ToolCallContext context, Func<Task> next)
+        {
+            context.ArgumentsJson = """{"rewritten":true}""";
+            await next();
+            NextExecuted = true;
+            context.Result = """{"middleware":true}""";
+        }
+    }
+
+    private sealed class ScriptedApprovalHandler(params ToolApprovalResult[] results) : IToolApprovalHandler
+    {
+        private readonly Queue<ToolApprovalResult> _results = new(results);
+
+        public List<ToolApprovalRequest> Requests { get; } = [];
+
+        public Task<ToolApprovalResult> RequestApprovalAsync(ToolApprovalRequest request, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            Requests.Add(request);
+            return Task.FromResult(_results.TryDequeue(out var result)
+                ? result
+                : ToolApprovalResult.Denied("missing scripted result"));
         }
     }
 


### PR DESCRIPTION
## Changed files

- `ToolCallMiddlewareChainFactory` 现在唯一前置 canonical `ToolApprovalMiddleware`，并去重外部重复注册的同类型 middleware。
- `AgentWorkflowToolSourceAdapter` 现在通过 canonical tool middleware chain 执行 agent tool；approval denied/pending/timed-out 或其它 middleware termination 会进入 workflow 失败路径，不再把 pending/denied JSON 当成功输出。
- Bootstrap 注册默认 yielding approval handler 与 tool approval middleware surface；测试覆盖 workflow adapter、factory 去重、bootstrap DI 与一个 host `$TEST_CMD` 暴露的本地 runtime 测试注册缺口。

## Test results

- `bash -lc "$BUILD_CMD"`: passed。
- Targeted tests passed: Workflow Core, AI Core, Bootstrap。
- `bash -lc "$TEST_CMD"`: passed。
- `bash tools/ci/test_stability_guards.sh`: passed。

## Deviations

- Closes #1904
- 使用一次 scope extension 修复 `LocalActorDispatchAdmissionTests` 中缺失的 `IAgentKindRegistry` 测试注册，使 host `$TEST_CMD` 可通过。
- `CI_GUARDS` 为空，架构守卫按 host 配置跳过。
- `HOST_REFACTOR_COMMENT_POLICY=none`，未新增 refactor-history source comments。

⟦AI:AUTO-LOOP⟧
