### PR TITLE
Port backend Studio invocation readiness to dev

### DIFF
--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -180,6 +180,7 @@ public sealed class AevatarInvocationDispatcher
             var resolution = await _teamEntryMemberResolver.ResolveAsync(
                 scope.Value!.ScopeId,
                 request.TeamId.Trim(),
+                request.EndpointId.Trim(),
                 ct);
             var invocation = BuildStaticInvocationRequest(resolution, request);
             // Refactor (v1/issue1470-first): InvokeTeam wait=complete must return the dispatch receipt only;

--- a/src/Aevatar.Studio.Application/Studio/Contracts/MemberContracts.cs
+++ b/src/Aevatar.Studio.Application/Studio/Contracts/MemberContracts.cs
@@ -38,6 +38,27 @@ public static class StudioMemberBindingRunStatusNames
     public const string Unknown = "unknown";
 }
 
+public static class StudioMemberInvocationReadinessStatusNames
+{
+    public const string Ready = "ready";
+    public const string ServiceCatalogMissing = "service_catalog_missing";
+    public const string ServingSetMissing = "serving_set_missing";
+    public const string EligibleServingTargetMissing = "eligible_serving_target_missing";
+    public const string ServiceCatalogTargetMissing = "service_catalog_target_missing";
+    public const string TrafficViewTargetMissing = "traffic_view_target_missing";
+    public const string PreparedArtifactMissing = "prepared_artifact_missing";
+    public const string Unknown = "unknown";
+}
+
+public sealed record StudioMemberInvocationReadinessResponse(
+    bool CanInvoke,
+    string Status,
+    string ReasonCode,
+    string Message,
+    string? RevisionId = null,
+    string? DeploymentId = null,
+    DateTimeOffset? ObservedAtUtc = null);
+
 /// <summary>
 /// Wire-format status values returned in
 /// <see cref="StudioMemberBindingRevisionActionResponse.Status"/>. Centralizing
@@ -247,6 +268,7 @@ public sealed record StudioMemberEndpointContractResponse(
     string? SampleRequestJson,
     string DeploymentStatus,
     string RevisionId,
+    StudioMemberInvocationReadinessResponse InvocationReadiness,
     string? CurlExample = null,
     string? FetchExample = null);
 

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioMemberService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioMemberService.cs
@@ -23,6 +23,7 @@ public sealed class StudioMemberService : IStudioMemberService
     private readonly IStudioMemberBindingRunQueryPort _bindingRunQueryPort;
     private readonly IStudioTeamQueryPort _teamQueryPort;
     private readonly IServiceLifecycleQueryPort _serviceLifecycleQueryPort;
+    private readonly IScopeBindingReadinessQueryPort _readinessQueryPort;
     private readonly IServiceCommandPort _serviceCommandPort;
 
     public StudioMemberService(
@@ -31,6 +32,7 @@ public sealed class StudioMemberService : IStudioMemberService
         IStudioMemberBindingRunQueryPort bindingRunQueryPort,
         IStudioTeamQueryPort teamQueryPort,
         IServiceLifecycleQueryPort serviceLifecycleQueryPort,
+        IScopeBindingReadinessQueryPort readinessQueryPort,
         IServiceCommandPort serviceCommandPort)
     {
         _memberCommandPort = memberCommandPort ?? throw new ArgumentNullException(nameof(memberCommandPort));
@@ -39,6 +41,7 @@ public sealed class StudioMemberService : IStudioMemberService
         _teamQueryPort = teamQueryPort ?? throw new ArgumentNullException(nameof(teamQueryPort));
         _serviceLifecycleQueryPort = serviceLifecycleQueryPort
             ?? throw new ArgumentNullException(nameof(serviceLifecycleQueryPort));
+        _readinessQueryPort = readinessQueryPort ?? throw new ArgumentNullException(nameof(readinessQueryPort));
         _serviceCommandPort = serviceCommandPort
             ?? throw new ArgumentNullException(nameof(serviceCommandPort));
     }
@@ -177,13 +180,28 @@ public sealed class StudioMemberService : IStudioMemberService
     {
         var normalizedEndpointId = NormalizeRequired(endpointId, nameof(endpointId));
         var context = await ResolveBoundServiceContextAsync(scopeId, memberId, ct);
-        return BuildMemberEndpointContractResponse(
+        var contract = BuildMemberEndpointContractResponse(
             context.ScopeId,
             context.MemberId,
             context.PublishedServiceId,
             normalizedEndpointId,
             context.Service,
-            context.Revisions);
+            context.Revisions,
+            StudioMemberInvocationReadinessUnknown(
+                revisionId: ServiceEndpointContractMath.ResolveCurrentContractRevision(
+                    context.Service,
+                    context.Revisions,
+                    normalizedEndpointId)?.RevisionId));
+        if (contract == null)
+            return null;
+
+        var readiness = await ResolveInvocationReadinessAsync(
+            context.ScopeId,
+            context.PublishedServiceId,
+            contract.RevisionId,
+            endpointId: normalizedEndpointId,
+            ct);
+        return contract with { InvocationReadiness = readiness };
     }
 
     public async Task<StudioMemberBindingActivationResponse> ActivateBindingRevisionAsync(
@@ -303,6 +321,88 @@ public sealed class StudioMemberService : IStudioMemberService
         return await GetAsync(scopeId, memberId, ct);
     }
 
+    private async Task<StudioMemberInvocationReadinessResponse> ResolveInvocationReadinessAsync(
+        string scopeId,
+        string? publishedServiceId,
+        string? expectedRevisionId,
+        string? endpointId,
+        CancellationToken ct)
+    {
+        var normalizedServiceId = publishedServiceId?.Trim() ?? string.Empty;
+        if (normalizedServiceId.Length == 0)
+        {
+            return StudioMemberInvocationReadinessUnknown(
+                expectedRevisionId,
+                "Member has no published service yet; bind the member before invoking it.");
+        }
+
+        var request = new ScopeBindingReadinessRequest(
+            ScopeId: scopeId,
+            ServiceId: normalizedServiceId,
+            ExpectedRevisionId: NormalizeOptional(expectedRevisionId),
+            ExpectedEndpointIds: string.IsNullOrWhiteSpace(endpointId) ? null : [endpointId.Trim()]);
+        var snapshot = await _readinessQueryPort.GetReadinessAsync(request, ct);
+        return MapInvocationReadiness(snapshot);
+    }
+
+    private static StudioMemberInvocationReadinessResponse MapInvocationReadiness(
+        ScopeBindingReadinessSnapshot snapshot)
+    {
+        var status = MapInvocationReadinessStatus(snapshot.Status);
+        var canInvoke = snapshot.Status == ScopeBindingReadinessStatus.Ready && snapshot.InvokeReady;
+        return new StudioMemberInvocationReadinessResponse(
+            CanInvoke: canInvoke,
+            Status: status,
+            ReasonCode: canInvoke ? StudioMemberInvocationReadinessStatusNames.Ready : status,
+            Message: BuildInvocationReadinessMessage(status, canInvoke),
+            RevisionId: snapshot.RevisionId,
+            DeploymentId: snapshot.DeploymentId,
+            ObservedAtUtc: snapshot.ObservedAtUtc);
+    }
+
+    private static StudioMemberInvocationReadinessResponse StudioMemberInvocationReadinessUnknown(
+        string? revisionId,
+        string message = "Invocation readiness is not available yet.") =>
+        new(
+            CanInvoke: false,
+            Status: StudioMemberInvocationReadinessStatusNames.Unknown,
+            ReasonCode: StudioMemberInvocationReadinessStatusNames.Unknown,
+            Message: message,
+            RevisionId: NormalizeOptional(revisionId));
+
+    private static string MapInvocationReadinessStatus(ScopeBindingReadinessStatus status) =>
+        status switch
+        {
+            ScopeBindingReadinessStatus.Ready => StudioMemberInvocationReadinessStatusNames.Ready,
+            ScopeBindingReadinessStatus.ServiceCatalogMissing => StudioMemberInvocationReadinessStatusNames.ServiceCatalogMissing,
+            ScopeBindingReadinessStatus.ServingSetMissing => StudioMemberInvocationReadinessStatusNames.ServingSetMissing,
+            ScopeBindingReadinessStatus.EligibleServingTargetMissing => StudioMemberInvocationReadinessStatusNames.EligibleServingTargetMissing,
+            ScopeBindingReadinessStatus.ServiceCatalogTargetMissing => StudioMemberInvocationReadinessStatusNames.ServiceCatalogTargetMissing,
+            ScopeBindingReadinessStatus.TrafficViewTargetMissing => StudioMemberInvocationReadinessStatusNames.TrafficViewTargetMissing,
+            ScopeBindingReadinessStatus.PreparedArtifactMissing => StudioMemberInvocationReadinessStatusNames.PreparedArtifactMissing,
+            _ => StudioMemberInvocationReadinessStatusNames.Unknown,
+        };
+
+    private static string BuildInvocationReadinessMessage(string status, bool canInvoke) =>
+        canInvoke
+            ? "Member endpoint is ready for invocation."
+            : status switch
+            {
+                StudioMemberInvocationReadinessStatusNames.PreparedArtifactMissing =>
+                    "Binding is complete, but the runtime artifact is not prepared for invocation yet.",
+                StudioMemberInvocationReadinessStatusNames.ServiceCatalogMissing =>
+                    "Published service is not visible in the service catalog yet.",
+                StudioMemberInvocationReadinessStatusNames.ServingSetMissing =>
+                    "Serving target is not visible yet.",
+                StudioMemberInvocationReadinessStatusNames.EligibleServingTargetMissing =>
+                    "No active serving target is eligible for invocation yet.",
+                StudioMemberInvocationReadinessStatusNames.ServiceCatalogTargetMissing =>
+                    "The selected endpoint is not visible in the service catalog yet.",
+                StudioMemberInvocationReadinessStatusNames.TrafficViewTargetMissing =>
+                    "Runtime traffic view has not observed the serving target yet.",
+                _ => "Invocation readiness is not available yet.",
+            };
+
     /// <summary>
     /// Resolves the published service the member is currently bound to in
     /// one round-trip: member authority → service catalog → revisions.
@@ -379,6 +479,12 @@ public sealed class StudioMemberService : IStudioMemberService
         return normalized;
     }
 
+    private static string? NormalizeOptional(string? value)
+    {
+        var normalized = value?.Trim() ?? string.Empty;
+        return normalized.Length == 0 ? null : normalized;
+    }
+
     private static string GenerateBindingRunId() =>
         $"bind-{Guid.NewGuid():N}";
 
@@ -449,7 +555,8 @@ public sealed class StudioMemberService : IStudioMemberService
         string publishedServiceId,
         string normalizedEndpointId,
         ServiceCatalogSnapshot service,
-        ServiceRevisionCatalogSnapshot? revisions)
+        ServiceRevisionCatalogSnapshot? revisions,
+        StudioMemberInvocationReadinessResponse invocationReadiness)
     {
         var currentRevision = ServiceEndpointContractMath.ResolveCurrentContractRevision(
             service, revisions, normalizedEndpointId);
@@ -504,6 +611,7 @@ public sealed class StudioMemberService : IStudioMemberService
                 ?? ServiceEndpointContractMath.NullIfEmpty(service.DefaultServingRevisionId)
                 ?? ServiceEndpointContractMath.NullIfEmpty(service.ActiveServingRevisionId)
                 ?? string.Empty,
+            InvocationReadiness: invocationReadiness,
             CurlExample: smokeTestSupported
                 ? BuildCurlExample(invokePath, supportsSse, endpoint.RequestTypeUrl)
                 : null,

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioTeamEntryMemberResolver.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioTeamEntryMemberResolver.cs
@@ -1,3 +1,4 @@
+using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
@@ -17,13 +18,16 @@ public sealed class StudioTeamEntryMemberResolver : ITeamEntryMemberResolver
 {
     private readonly IStudioTeamQueryPort _teamQueryPort;
     private readonly IStudioMemberQueryPort _memberQueryPort;
+    private readonly IScopeBindingReadinessQueryPort _readinessQueryPort;
 
     public StudioTeamEntryMemberResolver(
         IStudioTeamQueryPort teamQueryPort,
-        IStudioMemberQueryPort memberQueryPort)
+        IStudioMemberQueryPort memberQueryPort,
+        IScopeBindingReadinessQueryPort readinessQueryPort)
     {
         _teamQueryPort = teamQueryPort ?? throw new ArgumentNullException(nameof(teamQueryPort));
         _memberQueryPort = memberQueryPort ?? throw new ArgumentNullException(nameof(memberQueryPort));
+        _readinessQueryPort = readinessQueryPort ?? throw new ArgumentNullException(nameof(readinessQueryPort));
     }
 
     public async Task<TeamEntryMemberResolution> ResolveAsync(
@@ -89,12 +93,39 @@ public sealed class StudioTeamEntryMemberResolver : ITeamEntryMemberResolver
                 $"entry member '{entryMemberId}' is not bind-ready.");
         }
 
+        var readiness = await _readinessQueryPort.GetReadinessAsync(
+            new ScopeBindingReadinessRequest(
+                ScopeId: team.ScopeId,
+                ServiceId: member.Summary.PublishedServiceId),
+            ct);
+        if (readiness.Status != ScopeBindingReadinessStatus.Ready || !readiness.InvokeReady)
+        {
+            throw Failure(
+                TeamEntryMemberErrorCodes.EntryMemberNotReady,
+                team.ScopeId,
+                team.TeamId,
+                $"entry member '{entryMemberId}' is not invocation-ready: {MapReadinessReason(readiness.Status)}.");
+        }
+
         return new TeamEntryMemberResolution(
             ScopeId: team.ScopeId,
             TeamId: team.TeamId,
             EntryMemberId: entryMemberId,
             PublishedServiceId: member.Summary.PublishedServiceId);
     }
+
+    private static string MapReadinessReason(ScopeBindingReadinessStatus status) =>
+        status switch
+        {
+            ScopeBindingReadinessStatus.PreparedArtifactMissing => "prepared_artifact_missing",
+            ScopeBindingReadinessStatus.ServiceCatalogMissing => "service_catalog_missing",
+            ScopeBindingReadinessStatus.ServingSetMissing => "serving_set_missing",
+            ScopeBindingReadinessStatus.EligibleServingTargetMissing => "eligible_serving_target_missing",
+            ScopeBindingReadinessStatus.ServiceCatalogTargetMissing => "service_catalog_target_missing",
+            ScopeBindingReadinessStatus.TrafficViewTargetMissing => "traffic_view_target_missing",
+            ScopeBindingReadinessStatus.Ready => "ready",
+            _ => "unknown",
+        };
 
     private static TeamEntryMemberResolutionException Failure(
         string code,

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioTeamEntryMemberResolver.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioTeamEntryMemberResolver.cs
@@ -33,8 +33,10 @@ public sealed class StudioTeamEntryMemberResolver : ITeamEntryMemberResolver
     public async Task<TeamEntryMemberResolution> ResolveAsync(
         string scopeId,
         string teamId,
+        string endpointId,
         CancellationToken ct = default)
     {
+        var normalizedEndpointId = NormalizeRequired(endpointId, nameof(endpointId));
         var team = await _teamQueryPort.GetAsync(scopeId, teamId, ct);
         if (team == null)
         {
@@ -96,7 +98,8 @@ public sealed class StudioTeamEntryMemberResolver : ITeamEntryMemberResolver
         var readiness = await _readinessQueryPort.GetReadinessAsync(
             new ScopeBindingReadinessRequest(
                 ScopeId: team.ScopeId,
-                ServiceId: member.Summary.PublishedServiceId),
+                ServiceId: member.Summary.PublishedServiceId,
+                ExpectedEndpointIds: [normalizedEndpointId]),
             ct);
         if (readiness.Status != ScopeBindingReadinessStatus.Ready || !readiness.InvokeReady)
         {
@@ -112,6 +115,15 @@ public sealed class StudioTeamEntryMemberResolver : ITeamEntryMemberResolver
             TeamId: team.TeamId,
             EntryMemberId: entryMemberId,
             PublishedServiceId: member.Summary.PublishedServiceId);
+    }
+
+    private static string NormalizeRequired(string? value, string fieldName)
+    {
+        var normalized = value?.Trim() ?? string.Empty;
+        if (normalized.Length == 0)
+            throw new InvalidOperationException($"{fieldName} is required.");
+
+        return normalized;
     }
 
     private static string MapReadinessReason(ScopeBindingReadinessStatus status) =>

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioTeamGAgentStreamInvocationService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioTeamGAgentStreamInvocationService.cs
@@ -36,7 +36,7 @@ public sealed class StudioTeamGAgentStreamInvocationService : IStudioTeamGAgentS
         var endpointId = NormalizeRequired(request.EndpointId, nameof(request.EndpointId));
         var input = request.Input ?? throw new InvalidOperationException("input is required.");
 
-        var resolution = await _teamEntryMemberResolver.ResolveAsync(scopeId, teamId, ct);
+        var resolution = await _teamEntryMemberResolver.ResolveAsync(scopeId, teamId, endpointId, ct);
         var identity = new ServiceIdentity
         {
             TenantId = NormalizeRequired(resolution.ScopeId, nameof(resolution.ScopeId)),

--- a/src/platform/Aevatar.GAgentService.Abstractions/Ports/ITeamEntryMemberResolver.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Ports/ITeamEntryMemberResolver.cs
@@ -14,6 +14,7 @@ public interface ITeamEntryMemberResolver
     Task<TeamEntryMemberResolution> ResolveAsync(
         string scopeId,
         string teamId,
+        string endpointId,
         CancellationToken ct = default);
 }
 

--- a/src/platform/Aevatar.GAgentService.Abstractions/ScopeBindings/ScopeBindingReadinessModels.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/ScopeBindings/ScopeBindingReadinessModels.cs
@@ -9,6 +9,7 @@ public enum ScopeBindingReadinessStatus
     ServiceCatalogTargetMissing = 4,
     Ready = 5,
     TrafficViewTargetMissing = 6,
+    PreparedArtifactMissing = 7,
 }
 
 public sealed record ScopeBindingReadinessRequest(

--- a/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingReadinessQueryService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingReadinessQueryService.cs
@@ -1,6 +1,7 @@
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.GAgentService.Application.Workflows;
 using Microsoft.Extensions.Options;
 
@@ -10,15 +11,18 @@ public sealed class ScopeBindingReadinessQueryService : IScopeBindingReadinessQu
 {
     private readonly IServiceLifecycleQueryPort _serviceLifecycleQueryPort;
     private readonly IServiceServingQueryPort _serviceServingQueryPort;
+    private readonly IServiceRevisionCatalogQueryReader _revisionCatalogQueryReader;
     private readonly ScopeWorkflowCapabilityOptions _options;
 
     public ScopeBindingReadinessQueryService(
         IServiceLifecycleQueryPort serviceLifecycleQueryPort,
         IServiceServingQueryPort serviceServingQueryPort,
+        IServiceRevisionCatalogQueryReader revisionCatalogQueryReader,
         IOptions<ScopeWorkflowCapabilityOptions> options)
     {
         _serviceLifecycleQueryPort = serviceLifecycleQueryPort ?? throw new ArgumentNullException(nameof(serviceLifecycleQueryPort));
         _serviceServingQueryPort = serviceServingQueryPort ?? throw new ArgumentNullException(nameof(serviceServingQueryPort));
+        _revisionCatalogQueryReader = revisionCatalogQueryReader ?? throw new ArgumentNullException(nameof(revisionCatalogQueryReader));
         ArgumentNullException.ThrowIfNull(options);
         _options = options.Value ?? throw new InvalidOperationException("Scope workflow capability options are required.");
     }
@@ -117,6 +121,23 @@ public sealed class ScopeBindingReadinessQueryService : IScopeBindingReadinessQu
                 ObservedAtUtc: observedAtUtc);
         }
 
+        var revisionCatalog = await _revisionCatalogQueryReader.GetAsync(identity, ct).ConfigureAwait(false);
+        var artifact = FindPreparedArtifact(revisionCatalog, eligibleTarget.RevisionId);
+        if (!DoesArtifactExposeEndpoints(artifact, serviceEndpointIds))
+        {
+            return new ScopeBindingReadinessSnapshot(
+                normalizedScopeId,
+                normalizedServiceId,
+                ScopeBindingReadinessStatus.PreparedArtifactMissing,
+                ServiceCatalogVisible: true,
+                ServingSetVisible: true,
+                EligibleServingTargetVisible: true,
+                InvokeReady: false,
+                RevisionId: eligibleTarget.RevisionId,
+                DeploymentId: eligibleTarget.DeploymentId,
+                ObservedAtUtc: observedAtUtc);
+        }
+
         return new ScopeBindingReadinessSnapshot(
             normalizedScopeId,
             normalizedServiceId,
@@ -191,6 +212,23 @@ public sealed class ScopeBindingReadinessQueryService : IScopeBindingReadinessQu
             .ToList();
         return observedEndpointViews.Count == 0 || observedEndpointViews.All(endpoint => endpoint.Targets.Any(target =>
             IsEligibleTrafficTarget(target, expectedRevisionId, expectedDeploymentId)));
+    }
+
+    private static PreparedServiceRevisionArtifact? FindPreparedArtifact(
+        ServiceRevisionCatalogSnapshot? catalog,
+        string revisionId) =>
+        catalog?.Revisions.FirstOrDefault(revision =>
+            string.Equals(revision.RevisionId, revisionId, StringComparison.Ordinal))?.PreparedArtifact;
+
+    private static bool DoesArtifactExposeEndpoints(
+        PreparedServiceRevisionArtifact? artifact,
+        IReadOnlyList<string> serviceEndpointIds)
+    {
+        if (artifact == null)
+            return false;
+
+        return serviceEndpointIds.Count == 0 || serviceEndpointIds.All(endpointId =>
+            artifact.Endpoints.Any(endpoint => string.Equals(endpoint.EndpointId, endpointId, StringComparison.Ordinal)));
     }
 
     private static bool IsEligibleServingTarget(

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -749,7 +749,7 @@ public static class ScopeServiceEndpoints
             if (await AevatarScopeAccessGuard.TryWriteScopeAccessDeniedAsync(http, scopeId, ct))
                 return;
 
-            var teamResolution = await teamEntryMemberResolver.ResolveAsync(scopeId, teamId, ct);
+            var teamResolution = await teamEntryMemberResolver.ResolveAsync(scopeId, teamId, endpointId, ct);
             await HandleInvokeStreamAsync(
                 http,
                 teamResolution.ScopeId,
@@ -804,7 +804,7 @@ public static class ScopeServiceEndpoints
             if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
                 return denied;
 
-            var teamResolution = await teamEntryMemberResolver.ResolveAsync(scopeId, teamId, ct);
+            var teamResolution = await teamEntryMemberResolver.ResolveAsync(scopeId, teamId, endpointId, ct);
             return await HandleInvokeAsyncCore(
                 http,
                 teamResolution.ScopeId,

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -351,6 +351,7 @@ public sealed class AevatarInvocationToolSourceTests
         ErrorCodeOrNull(output).Should().BeNull(output);
         harness.TeamResolver.LastScopeId.Should().Be("scope-1");
         harness.TeamResolver.LastTeamId.Should().Be("team-1");
+        harness.TeamResolver.LastEndpointId.Should().Be("entry");
         harness.TeamInvocation.Request.Should().NotBeNull();
         harness.TeamInvocation.Request!.Identity.TenantId.Should().Be("scope-1");
         harness.TeamInvocation.Request.Identity.ServiceId.Should().Be("service-1");
@@ -1197,16 +1198,19 @@ public sealed class AevatarInvocationToolSourceTests
     {
         public string? LastScopeId { get; private set; }
         public string? LastTeamId { get; private set; }
+        public string? LastEndpointId { get; private set; }
         public TeamEntryMemberResolution Resolution { get; set; } = new("scope-1", "team-1", "member-1", "service-1");
         public TeamEntryMemberResolutionException? Failure { get; set; }
 
         public Task<TeamEntryMemberResolution> ResolveAsync(
             string scopeId,
             string teamId,
+            string endpointId,
             CancellationToken ct = default)
         {
             LastScopeId = scopeId;
             LastTeamId = teamId;
+            LastEndpointId = endpointId;
             if (Failure != null)
                 throw Failure;
 

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeDraftRunWorkflowRunCurrentStateIntegrationTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeDraftRunWorkflowRunCurrentStateIntegrationTests.cs
@@ -241,6 +241,7 @@ public sealed class ScopeDraftRunWorkflowActorCurrentStateIntegrationTests
         public Task<TeamEntryMemberResolution> ResolveAsync(
             string scopeId,
             string teamId,
+            string endpointId,
             CancellationToken ct = default) =>
             throw new TeamEntryMemberResolutionException(
                 TeamEntryMemberErrorCodes.TeamNotFound,

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -2365,7 +2365,7 @@ public sealed class ScopeServiceEndpointsTests
 
         response.StatusCode.Should().Be(HttpStatusCode.OK, "stream body: {0}", body);
         body.Should().Contain("aevatar.run.context");
-        host.TeamEntryMemberResolver.Calls.Should().ContainSingle().Which.Should().Be(("scope-a", "team-a"));
+        host.TeamEntryMemberResolver.Calls.Should().ContainSingle().Which.Should().Be(("scope-a", "team-a", "chat"));
         host.InteractionService.LastRequest.Should().NotBeNull();
         host.InteractionService.LastRequest!.Source.ActorId.Should().Be("definition-actor-member-a");
         host.InteractionService.LastRequest.ScopeId.Should().Be("scope-a");
@@ -2847,7 +2847,7 @@ public sealed class ScopeServiceEndpointsTests
         var receipt = await response.Content.ReadFromJsonAsync<ServiceInvocationAcceptedReceipt>();
         receipt.Should().NotBeNull();
         receipt!.StatusUrl.Should().Be("/api/scopes/scope-a/members/member-a/runs/run-1");
-        host.TeamEntryMemberResolver.Calls.Should().ContainSingle().Which.Should().Be(("scope-a", "team-a"));
+        host.TeamEntryMemberResolver.Calls.Should().ContainSingle().Which.Should().Be(("scope-a", "team-a", "chat"));
         host.InvocationPort.LastRequest.Should().NotBeNull();
         host.InvocationPort.LastRequest!.Identity.Should().BeEquivalentTo(new ServiceIdentity
         {
@@ -5240,7 +5240,7 @@ public sealed class ScopeServiceEndpointsTests
 
     private sealed class FakeTeamEntryMemberResolver : ITeamEntryMemberResolver
     {
-        public List<(string ScopeId, string TeamId)> Calls { get; } = [];
+        public List<(string ScopeId, string TeamId, string EndpointId)> Calls { get; } = [];
 
         public TeamEntryMemberResolution Result { get; set; } =
             new("scope-a", "team-a", "member-a", "member-a");
@@ -5250,9 +5250,10 @@ public sealed class ScopeServiceEndpointsTests
         public Task<TeamEntryMemberResolution> ResolveAsync(
             string scopeId,
             string teamId,
+            string endpointId,
             CancellationToken ct = default)
         {
-            Calls.Add((scopeId, teamId));
+            Calls.Add((scopeId, teamId, endpointId));
             if (Exception != null)
                 throw Exception;
 

--- a/test/Aevatar.GAgentService.Tests/Application/ApplicationServiceGuardTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ApplicationServiceGuardTests.cs
@@ -107,12 +107,26 @@ public sealed class ApplicationServiceGuardTests
                 new NoOpRolloutQueryReader(),
                 new NoOpRolloutCommandObservationQueryReader(),
                 new NoOpTrafficViewQueryReader()),
+            new NoOpRevisionCatalogQueryReader(),
             Options.Create(new ScopeWorkflowCapabilityOptions()));
         Action nullServingPort = () => new ScopeBindingReadinessQueryService(
             new ServiceLifecycleQueryApplicationService(
                 new NoOpCatalogQueryReader(),
                 new NoOpRevisionCatalogQueryReader(),
                 new NoOpDeploymentCatalogQueryReader()),
+            null!,
+            new NoOpRevisionCatalogQueryReader(),
+            Options.Create(new ScopeWorkflowCapabilityOptions()));
+        Action nullRevisionCatalogReader = () => new ScopeBindingReadinessQueryService(
+            new ServiceLifecycleQueryApplicationService(
+                new NoOpCatalogQueryReader(),
+                new NoOpRevisionCatalogQueryReader(),
+                new NoOpDeploymentCatalogQueryReader()),
+            new ServiceServingQueryApplicationService(
+                new NoOpServingSetQueryReader(),
+                new NoOpRolloutQueryReader(),
+                new NoOpRolloutCommandObservationQueryReader(),
+                new NoOpTrafficViewQueryReader()),
             null!,
             Options.Create(new ScopeWorkflowCapabilityOptions()));
         Action nullOptions = () => new ScopeBindingReadinessQueryService(
@@ -125,10 +139,12 @@ public sealed class ApplicationServiceGuardTests
                 new NoOpRolloutQueryReader(),
                 new NoOpRolloutCommandObservationQueryReader(),
                 new NoOpTrafficViewQueryReader()),
+            new NoOpRevisionCatalogQueryReader(),
             null!);
 
         nullLifecyclePort.Should().Throw<ArgumentNullException>();
         nullServingPort.Should().Throw<ArgumentNullException>();
+        nullRevisionCatalogReader.Should().Throw<ArgumentNullException>();
         nullOptions.Should().Throw<ArgumentNullException>();
     }
 

--- a/test/Aevatar.GAgentService.Tests/Application/ScopeBindingReadinessQueryServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScopeBindingReadinessQueryServiceTests.cs
@@ -217,6 +217,92 @@ public sealed class ScopeBindingReadinessQueryServiceTests
     }
 
     [Fact]
+    public async Task GetReadinessAsync_WhenPreparedArtifactMissing_ShouldReturnPreparedArtifactMissing()
+    {
+        var lifecyclePort = new FakeServiceLifecycleQueryPort
+        {
+            Service = CreateServiceSnapshot("service-a", activeRevisionId: "rev-ready"),
+        };
+        var servingPort = new FakeServiceServingQueryPort
+        {
+            ServingSet = CreateServingSet([
+                CreateTarget("rev-ready", ServiceServingState.Active, allocationWeight: 100),
+            ]),
+        };
+        var service = CreateService(lifecyclePort, servingPort, CreateRevisionCatalogReader(preparedArtifactRevisionIds: []));
+
+        var snapshot = await service.GetReadinessAsync(new ScopeBindingReadinessRequest(
+            "scope-a",
+            "service-a",
+            ExpectedRevisionId: "rev-ready"));
+
+        snapshot.Status.Should().Be(ScopeBindingReadinessStatus.PreparedArtifactMissing);
+        snapshot.ServiceCatalogVisible.Should().BeTrue();
+        snapshot.ServingSetVisible.Should().BeTrue();
+        snapshot.EligibleServingTargetVisible.Should().BeTrue();
+        snapshot.InvokeReady.Should().BeFalse();
+        snapshot.RevisionId.Should().Be("rev-ready");
+        snapshot.DeploymentId.Should().Be("deployment-rev-ready");
+    }
+
+    [Fact]
+    public async Task GetReadinessAsync_WhenRevisionCatalogMissing_ShouldReturnPreparedArtifactMissing()
+    {
+        var lifecyclePort = new FakeServiceLifecycleQueryPort
+        {
+            Service = CreateServiceSnapshot("service-a", activeRevisionId: "rev-ready"),
+        };
+        var servingPort = new FakeServiceServingQueryPort
+        {
+            ServingSet = CreateServingSet([
+                CreateTarget("rev-ready", ServiceServingState.Active, allocationWeight: 100),
+            ]),
+        };
+        var service = CreateService(lifecyclePort, servingPort, new FakeServiceRevisionCatalogQueryReader(null));
+
+        var snapshot = await service.GetReadinessAsync(new ScopeBindingReadinessRequest(
+            "scope-a",
+            "service-a",
+            ExpectedRevisionId: "rev-ready"));
+
+        snapshot.Status.Should().Be(ScopeBindingReadinessStatus.PreparedArtifactMissing);
+        snapshot.InvokeReady.Should().BeFalse();
+        snapshot.RevisionId.Should().Be("rev-ready");
+        snapshot.DeploymentId.Should().Be("deployment-rev-ready");
+    }
+
+    [Fact]
+    public async Task GetReadinessAsync_WhenPreparedArtifactDoesNotExposeExpectedEndpoint_ShouldReturnPreparedArtifactMissing()
+    {
+        var lifecyclePort = new FakeServiceLifecycleQueryPort
+        {
+            Service = CreateServiceSnapshot("service-a", activeRevisionId: "rev-ready", endpoints: [CreateServiceEndpoint("chat")]),
+        };
+        var servingPort = new FakeServiceServingQueryPort
+        {
+            ServingSet = CreateServingSet([
+                CreateTarget("rev-ready", ServiceServingState.Active, allocationWeight: 100, enabledEndpointIds: ["chat"]),
+            ]),
+        };
+        var revisionCatalogReader = CreateRevisionCatalogReader(preparedArtifacts: new Dictionary<string, PreparedServiceRevisionArtifact>(StringComparer.Ordinal)
+        {
+            ["rev-ready"] = CreateArtifact("rev-ready", ["command"]),
+        });
+        var service = CreateService(lifecyclePort, servingPort, revisionCatalogReader);
+
+        var snapshot = await service.GetReadinessAsync(new ScopeBindingReadinessRequest(
+            "scope-a",
+            "service-a",
+            ExpectedRevisionId: "rev-ready",
+            ExpectedEndpointIds: ["chat"]));
+
+        snapshot.Status.Should().Be(ScopeBindingReadinessStatus.PreparedArtifactMissing);
+        snapshot.InvokeReady.Should().BeFalse();
+        snapshot.RevisionId.Should().Be("rev-ready");
+        snapshot.DeploymentId.Should().Be("deployment-rev-ready");
+    }
+
+    [Fact]
     public async Task GetReadinessAsync_WhenTrafficViewHasStaleTargets_ShouldReturnTrafficViewTargetMissing()
     {
         var lifecyclePort = new FakeServiceLifecycleQueryPort
@@ -350,8 +436,63 @@ public sealed class ScopeBindingReadinessQueryServiceTests
 
     private static ScopeBindingReadinessQueryService CreateService(
         FakeServiceLifecycleQueryPort lifecyclePort,
-        FakeServiceServingQueryPort servingPort) =>
-        new(lifecyclePort, servingPort, Options.Create(DefaultOptions));
+        FakeServiceServingQueryPort servingPort,
+        FakeServiceRevisionCatalogQueryReader? revisionCatalogReader = null) =>
+        new(lifecyclePort, servingPort, revisionCatalogReader ?? CreateRevisionCatalogReader(), Options.Create(DefaultOptions));
+
+    private static FakeServiceRevisionCatalogQueryReader CreateRevisionCatalogReader(
+        IReadOnlyDictionary<string, PreparedServiceRevisionArtifact>? preparedArtifacts = null,
+        IReadOnlyList<string>? preparedArtifactRevisionIds = null)
+    {
+        preparedArtifacts ??= (preparedArtifactRevisionIds ?? ["rev-1", "rev-new", "rev-ready", "rev-zero"])
+            .ToDictionary(
+                revisionId => revisionId,
+                revisionId => CreateArtifact(revisionId, revisionId == "rev-ready" ? ["chat", "command"] : ["chat"]),
+                StringComparer.Ordinal);
+
+        return new FakeServiceRevisionCatalogQueryReader(new ServiceRevisionCatalogSnapshot(
+            ServiceKey: "scope-a:default:default:service-a",
+            Revisions: preparedArtifacts.Select(entry => new ServiceRevisionSnapshot(
+                RevisionId: entry.Key,
+                ImplementationKind: ServiceImplementationKind.Static.ToString(),
+                Status: "Prepared",
+                ArtifactHash: $"hash-{entry.Key}",
+                FailureReason: string.Empty,
+                Endpoints: [],
+                CreatedAt: DateTimeOffset.UtcNow,
+                PreparedAt: DateTimeOffset.UtcNow,
+                PublishedAt: null,
+                RetiredAt: null,
+                PreparedArtifact: entry.Value)).ToArray(),
+            UpdatedAt: DateTimeOffset.UtcNow));
+    }
+
+    private static PreparedServiceRevisionArtifact CreateArtifact(
+        string revisionId,
+        IReadOnlyList<string> endpointIds)
+    {
+        var artifact = new PreparedServiceRevisionArtifact
+        {
+            Identity = new ServiceIdentity
+            {
+                TenantId = "scope-a",
+                AppId = DefaultOptions.ServiceAppId,
+                Namespace = DefaultOptions.ServiceNamespace,
+                ServiceId = "service-a",
+            },
+            RevisionId = revisionId,
+            ImplementationKind = ServiceImplementationKind.Static,
+        };
+        artifact.Endpoints.Add(endpointIds.Select(endpointId => new ServiceEndpointDescriptor
+        {
+            EndpointId = endpointId,
+            DisplayName = endpointId,
+            Kind = ServiceEndpointKind.Chat,
+            RequestTypeUrl = "type.googleapis.com/a.Request",
+            ResponseTypeUrl = "type.googleapis.com/a.Response",
+        }));
+        return artifact;
+    }
 
     private static ServiceCatalogSnapshot CreateServiceSnapshot(
         string serviceId,
@@ -491,5 +632,20 @@ public sealed class ScopeBindingReadinessQueryServiceTests
             ServiceIdentity identity,
             CancellationToken ct = default) =>
             Task.FromResult(TrafficView);
+    }
+
+    private sealed class FakeServiceRevisionCatalogQueryReader : IServiceRevisionCatalogQueryReader
+    {
+        private readonly ServiceRevisionCatalogSnapshot? _catalog;
+
+        public FakeServiceRevisionCatalogQueryReader(ServiceRevisionCatalogSnapshot? catalog)
+        {
+            _catalog = catalog;
+        }
+
+        public Task<ServiceRevisionCatalogSnapshot?> GetAsync(
+            ServiceIdentity identity,
+            CancellationToken ct = default) =>
+            Task.FromResult(_catalog);
     }
 }

--- a/test/Aevatar.Studio.Tests/StudioMemberBindingHostedConsistencyTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberBindingHostedConsistencyTests.cs
@@ -73,7 +73,26 @@ public sealed class StudioMemberBindingHostedConsistencyTests
         host.BindingRunQueryPort.Requests.Should().ContainSingle()
             .Which.Should().Be((ScopeId, MemberId, accepted.BindingRunId));
 
+        var rosterWhilePending = await host.Client.GetFromJsonAsync<StudioMemberRosterResponse>(
+            $"/api/scopes/{ScopeId}/members");
+        rosterWhilePending.Should().NotBeNull();
+        var pendingMember = rosterWhilePending!.Members.Should().ContainSingle().Which;
+        pendingMember.PublishedServiceId.Should().BeEmpty();
+
         host.Scenario.CompleteBinding();
+
+        var completedRoster = await host.Client.GetFromJsonAsync<StudioMemberRosterResponse>(
+            $"/api/scopes/{ScopeId}/members");
+        completedRoster.Should().NotBeNull();
+        var completedMember = completedRoster!.Members.Should().ContainSingle().Which;
+        completedMember.PublishedServiceId.Should().Be("member-member-1");
+        completedMember.LastBoundRevisionId.Should().Be("rev-1");
+
+        var completedDetail = await host.Client.GetFromJsonAsync<StudioMemberDetailResponse>(
+            $"/api/scopes/{ScopeId}/members/{MemberId}");
+        completedDetail.Should().NotBeNull();
+        completedDetail!.Summary.PublishedServiceId.Should().Be("member-member-1");
+        completedDetail.Summary.LastBoundRevisionId.Should().Be("rev-1");
 
         var completedRun = await host.Client.GetFromJsonAsync<StudioMemberBindingRunStatusResponse>(
             $"/api/scopes/{ScopeId}/members/{MemberId}/binding-runs/{accepted.BindingRunId}");
@@ -130,6 +149,7 @@ public sealed class StudioMemberBindingHostedConsistencyTests
             builder.Services.AddSingleton<IStudioMemberBindingRunQueryPort>(bindingRunQueryPort);
             builder.Services.AddSingleton<IStudioTeamQueryPort>(new InertTeamQueryPort());
             builder.Services.AddSingleton<IServiceLifecycleQueryPort>(new ThrowingServiceLifecycleQueryPort());
+            builder.Services.AddSingleton<IScopeBindingReadinessQueryPort>(new ThrowingScopeBindingReadinessQueryPort());
             builder.Services.AddSingleton<IServiceCommandPort>(new ThrowingServiceCommandPort());
             builder.Services.AddSingleton<IStudioMemberService, StudioMemberService>();
             builder.Services.AddAuthorization();
@@ -347,6 +367,14 @@ public sealed class StudioMemberBindingHostedConsistencyTests
             string teamId,
             CancellationToken ct = default) =>
             Task.FromResult<StudioTeamSummaryResponse?>(null);
+    }
+
+    private sealed class ThrowingScopeBindingReadinessQueryPort : IScopeBindingReadinessQueryPort
+    {
+        public Task<ScopeBindingReadinessSnapshot> GetReadinessAsync(
+            ScopeBindingReadinessRequest request,
+            CancellationToken ct = default) =>
+            throw new InvalidOperationException("Member list and binding views must not query invocation readiness.");
     }
 
     private sealed class ThrowingServiceLifecycleQueryPort : IServiceLifecycleQueryPort

--- a/test/Aevatar.Studio.Tests/StudioMemberEndpointsTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberEndpointsTests.cs
@@ -621,7 +621,13 @@ public sealed class StudioMemberEndpointsTests
         DefaultSmokePrompt: "Hello from Studio Bind.",
         SampleRequestJson: null,
         DeploymentStatus: "Active",
-        RevisionId: "rev-1");
+        RevisionId: "rev-1",
+        InvocationReadiness: new StudioMemberInvocationReadinessResponse(
+            CanInvoke: true,
+            Status: StudioMemberInvocationReadinessStatusNames.Ready,
+            ReasonCode: StudioMemberInvocationReadinessStatusNames.Ready,
+            Message: "Member endpoint is ready for invocation.",
+            RevisionId: "rev-1"));
 
     private static StudioMemberSummaryResponse NewSummary() => new(
         MemberId: "m-1",

--- a/test/Aevatar.Studio.Tests/StudioMemberServiceBindingTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberServiceBindingTests.cs
@@ -271,6 +271,7 @@ public sealed class StudioMemberServiceBindingTests
             bindingRunQueryPort ?? new InMemoryBindingRunQueryPort(null),
             new InertTeamQueryPort(),
             new ThrowingServiceLifecycleQueryPort(),
+            new ReadyScopeBindingReadinessQueryPort(),
             new ThrowingServiceCommandPort());
 
     private sealed class InertTeamQueryPort : IStudioTeamQueryPort
@@ -410,6 +411,24 @@ public sealed class StudioMemberServiceBindingTests
             OperationsInOrder.Add("PatchTeamAssignment");
             return Task.CompletedTask;
         }
+    }
+
+    private sealed class ReadyScopeBindingReadinessQueryPort : IScopeBindingReadinessQueryPort
+    {
+        public Task<ScopeBindingReadinessSnapshot> GetReadinessAsync(
+            ScopeBindingReadinessRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(new ScopeBindingReadinessSnapshot(
+                request.ScopeId,
+                request.ServiceId,
+                ScopeBindingReadinessStatus.Ready,
+                ServiceCatalogVisible: true,
+                ServingSetVisible: true,
+                EligibleServingTargetVisible: true,
+                InvokeReady: true,
+                RevisionId: request.ExpectedRevisionId,
+                DeploymentId: "dep-1",
+                ObservedAtUtc: DateTimeOffset.UtcNow));
     }
 
     private sealed class ThrowingServiceLifecycleQueryPort : IServiceLifecycleQueryPort

--- a/test/Aevatar.Studio.Tests/StudioMemberServiceContractAndRevisionTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberServiceContractAndRevisionTests.cs
@@ -72,6 +72,7 @@ public sealed class StudioMemberServiceContractAndRevisionTests
             new InertBindingRunQueryPort(),
             new InertTeamQueryPort(),
             lifecycle,
+            new ReadyScopeBindingReadinessQueryPort(),
             commandPort);
 
         var contract = await service.GetEndpointContractAsync(ScopeId, MemberId, "chat", CancellationToken.None);
@@ -91,6 +92,57 @@ public sealed class StudioMemberServiceContractAndRevisionTests
         contract.InvokePath.Should().Be($"/api/scopes/{ScopeId}/members/{MemberId}/invoke/chat:stream");
         contract.SupportsSse.Should().BeTrue();
         contract.StreamFrameFormat.Should().Be("workflow-run-event");
+        contract.InvocationReadiness.CanInvoke.Should().BeTrue();
+        contract.InvocationReadiness.Status.Should().Be(StudioMemberInvocationReadinessStatusNames.Ready);
+    }
+
+    [Fact]
+    public async Task GetEndpointContractAsync_ShouldExposePreparedArtifactMissingReadiness()
+    {
+        var detail = NewDetail();
+        var queryPort = new InMemoryMemberQueryPort(detail);
+        var lifecycle = new InMemoryServiceLifecycleQueryPort
+        {
+            Service = NewService(
+                endpoints:
+                [
+                    new ServiceEndpointSnapshot(
+                        EndpointId: "chat",
+                        DisplayName: "Chat",
+                        Kind: "chat",
+                        RequestTypeUrl: "type.googleapis.com/x.Request",
+                        ResponseTypeUrl: "type.googleapis.com/x.Response",
+                        Description: string.Empty),
+                ]),
+            Revisions = NewRevisions(
+                implementationKind: ServiceImplementationKind.Workflow,
+                endpoints:
+                [
+                    new ServiceEndpointSnapshot(
+                        EndpointId: "chat",
+                        DisplayName: "Chat",
+                        Kind: "chat",
+                        RequestTypeUrl: "type.googleapis.com/x.Request",
+                        ResponseTypeUrl: "type.googleapis.com/x.Response",
+                        Description: string.Empty),
+                ]),
+        };
+
+        var service = new StudioMemberService(
+            new InertMemberCommandPort(),
+            queryPort,
+            new InertBindingRunQueryPort(),
+            new InertTeamQueryPort(),
+            lifecycle,
+            new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.PreparedArtifactMissing, invokeReady: false),
+            new RecordingServiceCommandPort());
+
+        var contract = await service.GetEndpointContractAsync(ScopeId, MemberId, "chat", CancellationToken.None);
+
+        contract.Should().NotBeNull();
+        contract!.InvocationReadiness.CanInvoke.Should().BeFalse();
+        contract.InvocationReadiness.Status.Should().Be(StudioMemberInvocationReadinessStatusNames.PreparedArtifactMissing);
+        contract.InvocationReadiness.ReasonCode.Should().Be(StudioMemberInvocationReadinessStatusNames.PreparedArtifactMissing);
     }
 
     [Fact]
@@ -110,6 +162,7 @@ public sealed class StudioMemberServiceContractAndRevisionTests
             new InertBindingRunQueryPort(),
             new InertTeamQueryPort(),
             lifecycle,
+            new ReadyScopeBindingReadinessQueryPort(),
             new RecordingServiceCommandPort());
 
         var contract = await service.GetEndpointContractAsync(ScopeId, MemberId, "ghost", CancellationToken.None);
@@ -127,6 +180,7 @@ public sealed class StudioMemberServiceContractAndRevisionTests
             new InertBindingRunQueryPort(),
             new InertTeamQueryPort(),
             new InMemoryServiceLifecycleQueryPort(),
+            new ReadyScopeBindingReadinessQueryPort(),
             new RecordingServiceCommandPort());
 
         var act = () => service.GetEndpointContractAsync(ScopeId, "m-missing", "chat");
@@ -149,6 +203,7 @@ public sealed class StudioMemberServiceContractAndRevisionTests
             new InertBindingRunQueryPort(),
             new InertTeamQueryPort(),
             lifecycle,
+            new ReadyScopeBindingReadinessQueryPort(),
             new RecordingServiceCommandPort());
 
         var act = () => service.GetEndpointContractAsync(ScopeId, MemberId, "chat");
@@ -179,6 +234,7 @@ public sealed class StudioMemberServiceContractAndRevisionTests
             new InertBindingRunQueryPort(),
             new InertTeamQueryPort(),
             lifecycle,
+            new ReadyScopeBindingReadinessQueryPort(),
             commandPort);
 
         var response = await service.ActivateBindingRevisionAsync(
@@ -224,6 +280,7 @@ public sealed class StudioMemberServiceContractAndRevisionTests
             new InertBindingRunQueryPort(),
             new InertTeamQueryPort(),
             lifecycle,
+            new ReadyScopeBindingReadinessQueryPort(),
             commandPort);
 
         var act = () => service.ActivateBindingRevisionAsync(ScopeId, MemberId, "rev-r");
@@ -256,6 +313,7 @@ public sealed class StudioMemberServiceContractAndRevisionTests
             new InertBindingRunQueryPort(),
             new InertTeamQueryPort(),
             lifecycle,
+            new ReadyScopeBindingReadinessQueryPort(),
             commandPort);
 
         var act = () => service.ActivateBindingRevisionAsync(ScopeId, MemberId, "rev-missing");
@@ -286,6 +344,7 @@ public sealed class StudioMemberServiceContractAndRevisionTests
             new InertBindingRunQueryPort(),
             new InertTeamQueryPort(),
             lifecycle,
+            new ReadyScopeBindingReadinessQueryPort(),
             commandPort);
 
         var response = await service.RetireBindingRevisionAsync(
@@ -323,6 +382,7 @@ public sealed class StudioMemberServiceContractAndRevisionTests
             new InertBindingRunQueryPort(),
             new InertTeamQueryPort(),
             lifecycle,
+            new ReadyScopeBindingReadinessQueryPort(),
             commandPort);
 
         var act = () => service.RetireBindingRevisionAsync(ScopeId, MemberId, "rev-missing");
@@ -462,6 +522,41 @@ public sealed class StudioMemberServiceContractAndRevisionTests
         public Task<ScopeBindingUpsertResult> UpsertAsync(
             ScopeBindingUpsertRequest request, CancellationToken ct = default) =>
             throw new InvalidOperationException("contract/activate/retire flows must not invoke the scope binding port.");
+    }
+
+    private sealed class ReadyScopeBindingReadinessQueryPort : FixedScopeBindingReadinessQueryPort
+    {
+        public ReadyScopeBindingReadinessQueryPort()
+            : base(ScopeBindingReadinessStatus.Ready, invokeReady: true)
+        {
+        }
+    }
+
+    private class FixedScopeBindingReadinessQueryPort : IScopeBindingReadinessQueryPort
+    {
+        private readonly ScopeBindingReadinessStatus _status;
+        private readonly bool _invokeReady;
+
+        public FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus status, bool invokeReady)
+        {
+            _status = status;
+            _invokeReady = invokeReady;
+        }
+
+        public Task<ScopeBindingReadinessSnapshot> GetReadinessAsync(
+            ScopeBindingReadinessRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(new ScopeBindingReadinessSnapshot(
+                request.ScopeId,
+                request.ServiceId,
+                _status,
+                ServiceCatalogVisible: true,
+                ServingSetVisible: true,
+                EligibleServingTargetVisible: true,
+                InvokeReady: _invokeReady,
+                RevisionId: request.ExpectedRevisionId ?? "rev-1",
+                DeploymentId: "dep-1",
+                ObservedAtUtc: DateTimeOffset.UtcNow));
     }
 
     private sealed class InMemoryServiceLifecycleQueryPort : IServiceLifecycleQueryPort

--- a/test/Aevatar.Studio.Tests/StudioMemberServiceTeamTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberServiceTeamTests.cs
@@ -157,6 +157,7 @@ public sealed class StudioMemberServiceTeamTests
             new InertBindingRunQueryPort(),
             teamQueryPort ?? new InMemoryTeamQueryPort(NewTeamSummary()),
             new ThrowingServiceLifecycleQueryPort(),
+            new ReadyScopeBindingReadinessQueryPort(),
             new ThrowingServiceCommandPort());
 
     private static StudioMemberDetailResponse NewDetail(string? currentTeamId = null)
@@ -290,6 +291,24 @@ public sealed class StudioMemberServiceTeamTests
         public Task<ScopeBindingUpsertResult> UpsertAsync(
             ScopeBindingUpsertRequest request, CancellationToken ct = default) =>
             throw new InvalidOperationException("scope binding should not be called in team tests.");
+    }
+
+    private sealed class ReadyScopeBindingReadinessQueryPort : IScopeBindingReadinessQueryPort
+    {
+        public Task<ScopeBindingReadinessSnapshot> GetReadinessAsync(
+            ScopeBindingReadinessRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(new ScopeBindingReadinessSnapshot(
+                request.ScopeId,
+                request.ServiceId,
+                ScopeBindingReadinessStatus.Ready,
+                ServiceCatalogVisible: true,
+                ServingSetVisible: true,
+                EligibleServingTargetVisible: true,
+                InvokeReady: true,
+                RevisionId: request.ExpectedRevisionId,
+                DeploymentId: "dep-1",
+                ObservedAtUtc: DateTimeOffset.UtcNow));
     }
 
     private sealed class ThrowingServiceLifecycleQueryPort : IServiceLifecycleQueryPort

--- a/test/Aevatar.Studio.Tests/StudioTeamEntryMemberResolverTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamEntryMemberResolverTests.cs
@@ -22,7 +22,7 @@ public sealed class StudioTeamEntryMemberResolverTests
             new MemberQueryPort(NewMember()),
             new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.Ready, invokeReady: true));
 
-        var result = await resolver.ResolveAsync(ScopeId, TeamId);
+        var result = await resolver.ResolveAsync(ScopeId, TeamId, "chat");
 
         result.ScopeId.Should().Be(ScopeId);
         result.TeamId.Should().Be(TeamId);
@@ -40,7 +40,7 @@ public sealed class StudioTeamEntryMemberResolverTests
             memberPort,
             new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.Ready, invokeReady: true));
 
-        var result = await resolver.ResolveAsync(ScopeId, TeamId);
+        var result = await resolver.ResolveAsync(ScopeId, TeamId, "chat");
 
         result.Should().Be(new TeamEntryMemberResolution(
             ScopeId,
@@ -91,7 +91,7 @@ public sealed class StudioTeamEntryMemberResolverTests
             new MemberQueryPort(NewMember()),
             new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.Ready, invokeReady: true));
 
-        var act = () => resolver.ResolveAsync(ScopeId, TeamId);
+        var act = () => resolver.ResolveAsync(ScopeId, TeamId, "chat");
 
         await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
             .Where(ex => ex.Code == TeamEntryMemberErrorCodes.TeamNotFound);
@@ -105,7 +105,7 @@ public sealed class StudioTeamEntryMemberResolverTests
             new MemberQueryPort(NewMember()),
             new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.Ready, invokeReady: true));
 
-        var act = () => resolver.ResolveAsync(ScopeId, TeamId);
+        var act = () => resolver.ResolveAsync(ScopeId, TeamId, "chat");
 
         await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
             .Where(ex => ex.Code == TeamEntryMemberErrorCodes.TeamArchived);
@@ -119,7 +119,7 @@ public sealed class StudioTeamEntryMemberResolverTests
             new MemberQueryPort(NewMember()),
             new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.Ready, invokeReady: true));
 
-        var act = () => resolver.ResolveAsync(ScopeId, TeamId);
+        var act = () => resolver.ResolveAsync(ScopeId, TeamId, "chat");
 
         await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
             .Where(ex => ex.Code == TeamEntryMemberErrorCodes.EntryMemberNotConfigured);
@@ -133,7 +133,7 @@ public sealed class StudioTeamEntryMemberResolverTests
             new MemberQueryPort(null),
             new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.Ready, invokeReady: true));
 
-        var act = () => resolver.ResolveAsync(ScopeId, TeamId);
+        var act = () => resolver.ResolveAsync(ScopeId, TeamId, "chat");
 
         await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
             .Where(ex => ex.Code == TeamEntryMemberErrorCodes.EntryMemberNotFound);
@@ -147,7 +147,7 @@ public sealed class StudioTeamEntryMemberResolverTests
             new MemberQueryPort(NewMember(teamId: "other-team")),
             new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.Ready, invokeReady: true));
 
-        var act = () => resolver.ResolveAsync(ScopeId, TeamId);
+        var act = () => resolver.ResolveAsync(ScopeId, TeamId, "chat");
 
         await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
             .Where(ex => ex.Code == TeamEntryMemberErrorCodes.EntryMemberMismatch);
@@ -161,7 +161,7 @@ public sealed class StudioTeamEntryMemberResolverTests
             new MemberQueryPort(NewMember(lifecycleStage: MemberLifecycleStageNames.BuildReady)),
             new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.Ready, invokeReady: true));
 
-        var act = () => resolver.ResolveAsync(ScopeId, TeamId);
+        var act = () => resolver.ResolveAsync(ScopeId, TeamId, "chat");
 
         await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
             .Where(ex => ex.Code == TeamEntryMemberErrorCodes.EntryMemberNotReady);
@@ -175,7 +175,7 @@ public sealed class StudioTeamEntryMemberResolverTests
             new MemberQueryPort(NewMember(publishedServiceId: "")),
             new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.Ready, invokeReady: true));
 
-        var act = () => resolver.ResolveAsync(ScopeId, TeamId);
+        var act = () => resolver.ResolveAsync(ScopeId, TeamId, "chat");
 
         await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
             .Where(ex => ex.Code == TeamEntryMemberErrorCodes.EntryMemberNotReady);
@@ -190,10 +190,27 @@ public sealed class StudioTeamEntryMemberResolverTests
             new MemberQueryPort(NewMember()),
             readinessPort);
 
-        await resolver.ResolveAsync(ScopeId, TeamId);
+        await resolver.ResolveAsync(ScopeId, TeamId, "chat");
 
         readinessPort.LastRequest.Should().NotBeNull();
         readinessPort.LastRequest!.ExpectedRevisionId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldCheckReadinessForRequestedEndpointOnly()
+    {
+        var readinessPort = new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.Ready, invokeReady: true);
+        var resolver = new StudioTeamEntryMemberResolver(
+            new TeamQueryPort(NewTeam()),
+            new MemberQueryPort(NewMember()),
+            readinessPort);
+
+        await resolver.ResolveAsync(ScopeId, TeamId, " chat ");
+
+        readinessPort.LastRequest.Should().NotBeNull();
+        readinessPort.LastRequest!.ExpectedEndpointIds.Should().BeEquivalentTo(
+            ["chat"],
+            options => options.WithStrictOrdering());
     }
 
     [Fact]
@@ -204,7 +221,7 @@ public sealed class StudioTeamEntryMemberResolverTests
             new MemberQueryPort(NewMember()),
             new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.PreparedArtifactMissing, invokeReady: false));
 
-        var act = () => resolver.ResolveAsync(ScopeId, TeamId);
+        var act = () => resolver.ResolveAsync(ScopeId, TeamId, "chat");
 
         await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
             .Where(ex => ex.Code == TeamEntryMemberErrorCodes.EntryMemberNotReady

--- a/test/Aevatar.Studio.Tests/StudioTeamEntryMemberResolverTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamEntryMemberResolverTests.cs
@@ -1,3 +1,4 @@
+using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
@@ -18,7 +19,8 @@ public sealed class StudioTeamEntryMemberResolverTests
     {
         var resolver = new StudioTeamEntryMemberResolver(
             new TeamQueryPort(NewTeam()),
-            new MemberQueryPort(NewMember()));
+            new MemberQueryPort(NewMember()),
+            new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.Ready, invokeReady: true));
 
         var result = await resolver.ResolveAsync(ScopeId, TeamId);
 
@@ -33,7 +35,10 @@ public sealed class StudioTeamEntryMemberResolverTests
     {
         var teamPort = new TeamQueryPort(NewTeam());
         var memberPort = new MemberQueryPort(NewMember());
-        var resolver = new StudioTeamEntryMemberResolver(teamPort, memberPort);
+        var resolver = new StudioTeamEntryMemberResolver(
+            teamPort,
+            memberPort,
+            new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.Ready, invokeReady: true));
 
         var result = await resolver.ResolveAsync(ScopeId, TeamId);
 
@@ -83,7 +88,8 @@ public sealed class StudioTeamEntryMemberResolverTests
     {
         var resolver = new StudioTeamEntryMemberResolver(
             new TeamQueryPort(null),
-            new MemberQueryPort(NewMember()));
+            new MemberQueryPort(NewMember()),
+            new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.Ready, invokeReady: true));
 
         var act = () => resolver.ResolveAsync(ScopeId, TeamId);
 
@@ -96,7 +102,8 @@ public sealed class StudioTeamEntryMemberResolverTests
     {
         var resolver = new StudioTeamEntryMemberResolver(
             new TeamQueryPort(NewTeam(lifecycleStage: TeamLifecycleStageNames.Archived)),
-            new MemberQueryPort(NewMember()));
+            new MemberQueryPort(NewMember()),
+            new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.Ready, invokeReady: true));
 
         var act = () => resolver.ResolveAsync(ScopeId, TeamId);
 
@@ -109,7 +116,8 @@ public sealed class StudioTeamEntryMemberResolverTests
     {
         var resolver = new StudioTeamEntryMemberResolver(
             new TeamQueryPort(NewTeam(entryMemberId: null)),
-            new MemberQueryPort(NewMember()));
+            new MemberQueryPort(NewMember()),
+            new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.Ready, invokeReady: true));
 
         var act = () => resolver.ResolveAsync(ScopeId, TeamId);
 
@@ -122,7 +130,8 @@ public sealed class StudioTeamEntryMemberResolverTests
     {
         var resolver = new StudioTeamEntryMemberResolver(
             new TeamQueryPort(NewTeam()),
-            new MemberQueryPort(null));
+            new MemberQueryPort(null),
+            new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.Ready, invokeReady: true));
 
         var act = () => resolver.ResolveAsync(ScopeId, TeamId);
 
@@ -135,7 +144,8 @@ public sealed class StudioTeamEntryMemberResolverTests
     {
         var resolver = new StudioTeamEntryMemberResolver(
             new TeamQueryPort(NewTeam()),
-            new MemberQueryPort(NewMember(teamId: "other-team")));
+            new MemberQueryPort(NewMember(teamId: "other-team")),
+            new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.Ready, invokeReady: true));
 
         var act = () => resolver.ResolveAsync(ScopeId, TeamId);
 
@@ -148,7 +158,8 @@ public sealed class StudioTeamEntryMemberResolverTests
     {
         var resolver = new StudioTeamEntryMemberResolver(
             new TeamQueryPort(NewTeam()),
-            new MemberQueryPort(NewMember(lifecycleStage: MemberLifecycleStageNames.BuildReady)));
+            new MemberQueryPort(NewMember(lifecycleStage: MemberLifecycleStageNames.BuildReady)),
+            new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.Ready, invokeReady: true));
 
         var act = () => resolver.ResolveAsync(ScopeId, TeamId);
 
@@ -161,12 +172,43 @@ public sealed class StudioTeamEntryMemberResolverTests
     {
         var resolver = new StudioTeamEntryMemberResolver(
             new TeamQueryPort(NewTeam()),
-            new MemberQueryPort(NewMember(publishedServiceId: "")));
+            new MemberQueryPort(NewMember(publishedServiceId: "")),
+            new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.Ready, invokeReady: true));
 
         var act = () => resolver.ResolveAsync(ScopeId, TeamId);
 
         await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
             .Where(ex => ex.Code == TeamEntryMemberErrorCodes.EntryMemberNotReady);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldNotPinReadinessToLastBoundRevision()
+    {
+        var readinessPort = new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.Ready, invokeReady: true);
+        var resolver = new StudioTeamEntryMemberResolver(
+            new TeamQueryPort(NewTeam()),
+            new MemberQueryPort(NewMember()),
+            readinessPort);
+
+        await resolver.ResolveAsync(ScopeId, TeamId);
+
+        readinessPort.LastRequest.Should().NotBeNull();
+        readinessPort.LastRequest!.ExpectedRevisionId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldThrowNotReady_WhenPreparedArtifactMissing()
+    {
+        var resolver = new StudioTeamEntryMemberResolver(
+            new TeamQueryPort(NewTeam()),
+            new MemberQueryPort(NewMember()),
+            new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.PreparedArtifactMissing, invokeReady: false));
+
+        var act = () => resolver.ResolveAsync(ScopeId, TeamId);
+
+        await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
+            .Where(ex => ex.Code == TeamEntryMemberErrorCodes.EntryMemberNotReady
+                && ex.Message.Contains("prepared_artifact_missing", StringComparison.Ordinal));
     }
 
     private static StudioTeamSummaryResponse NewTeam(
@@ -206,6 +248,38 @@ public sealed class StudioTeamEntryMemberResolverTests
         };
 
         return new StudioMemberDetailResponse(summary, null, null);
+    }
+
+    private sealed class FixedScopeBindingReadinessQueryPort : IScopeBindingReadinessQueryPort
+    {
+        private readonly ScopeBindingReadinessStatus _status;
+        private readonly bool _invokeReady;
+
+        public FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus status, bool invokeReady)
+        {
+            _status = status;
+            _invokeReady = invokeReady;
+        }
+
+        public ScopeBindingReadinessRequest? LastRequest { get; private set; }
+
+        public Task<ScopeBindingReadinessSnapshot> GetReadinessAsync(
+            ScopeBindingReadinessRequest request,
+            CancellationToken ct = default)
+        {
+            LastRequest = request;
+            return Task.FromResult(new ScopeBindingReadinessSnapshot(
+                request.ScopeId,
+                request.ServiceId,
+                _status,
+                ServiceCatalogVisible: true,
+                ServingSetVisible: true,
+                EligibleServingTargetVisible: true,
+                InvokeReady: _invokeReady,
+                RevisionId: request.ExpectedRevisionId ?? "rev-1",
+                DeploymentId: "dep-1",
+                ObservedAtUtc: DateTimeOffset.UtcNow));
+        }
     }
 
     private sealed class TeamQueryPort(StudioTeamSummaryResponse? team) : IStudioTeamQueryPort

--- a/test/Aevatar.Studio.Tests/StudioTeamGAgentStreamInvocationServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamGAgentStreamInvocationServiceTests.cs
@@ -21,7 +21,8 @@ public sealed class StudioTeamGAgentStreamInvocationServiceTests
     public async Task InvokeAsync_ShouldResolveEntryMemberAndDelegateToPublishedServiceIdentity()
     {
         var staticPort = new RecordingStaticGAgentStreamInvocationPort();
-        var service = CreateService(staticPort);
+        var readinessPort = new ReadyScopeBindingReadinessQueryPort();
+        var service = CreateService(staticPort, readinessPort: readinessPort);
         var emitted = new List<AGUIEvent>();
         StudioTeamStreamInvocationAcceptedReceipt? accepted = null;
 
@@ -78,6 +79,10 @@ public sealed class StudioTeamGAgentStreamInvocationServiceTests
         delegated.Identity.Namespace.Should().Be(ScopeServiceIdentityDefaults.ServiceNamespace);
         delegated.Identity.ServiceId.Should().Be(PublishedServiceId);
         delegated.EndpointId.Should().Be("chat");
+        readinessPort.LastRequest.Should().NotBeNull();
+        readinessPort.LastRequest!.ExpectedEndpointIds.Should().BeEquivalentTo(
+            ["chat"],
+            options => options.WithStrictOrdering());
         delegated.Input.Prompt.Should().Be("hello team");
         delegated.Input.PreferredActorId.Should().Be("actor-preferred");
         delegated.Input.SessionId.Should().Be("session-1");
@@ -157,12 +162,13 @@ public sealed class StudioTeamGAgentStreamInvocationServiceTests
     private static StudioTeamGAgentStreamInvocationService CreateService(
         RecordingStaticGAgentStreamInvocationPort staticPort,
         StudioTeamSummaryResponse? team = null,
-        StudioMemberDetailResponse? member = null)
+        StudioMemberDetailResponse? member = null,
+        ReadyScopeBindingReadinessQueryPort? readinessPort = null)
     {
         var resolver = new StudioTeamEntryMemberResolver(
             new TeamQueryPort(team ?? NewTeam()),
             new MemberQueryPort(member ?? NewMember()),
-            new ReadyScopeBindingReadinessQueryPort());
+            readinessPort ?? new ReadyScopeBindingReadinessQueryPort());
         return new StudioTeamGAgentStreamInvocationService(
             resolver,
             staticPort);
@@ -170,10 +176,14 @@ public sealed class StudioTeamGAgentStreamInvocationServiceTests
 
     private sealed class ReadyScopeBindingReadinessQueryPort : IScopeBindingReadinessQueryPort
     {
+        public ScopeBindingReadinessRequest? LastRequest { get; private set; }
+
         public Task<ScopeBindingReadinessSnapshot> GetReadinessAsync(
             ScopeBindingReadinessRequest request,
-            CancellationToken ct = default) =>
-            Task.FromResult(new ScopeBindingReadinessSnapshot(
+            CancellationToken ct = default)
+        {
+            LastRequest = request;
+            return Task.FromResult(new ScopeBindingReadinessSnapshot(
                 request.ScopeId,
                 request.ServiceId,
                 ScopeBindingReadinessStatus.Ready,
@@ -184,6 +194,7 @@ public sealed class StudioTeamGAgentStreamInvocationServiceTests
                 RevisionId: request.ExpectedRevisionId ?? "rev-1",
                 DeploymentId: "dep-1",
                 ObservedAtUtc: DateTimeOffset.UtcNow));
+        }
     }
 
     private static StudioTeamStreamInvocationRequest NewRequest() =>

--- a/test/Aevatar.Studio.Tests/StudioTeamGAgentStreamInvocationServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamGAgentStreamInvocationServiceTests.cs
@@ -161,10 +161,29 @@ public sealed class StudioTeamGAgentStreamInvocationServiceTests
     {
         var resolver = new StudioTeamEntryMemberResolver(
             new TeamQueryPort(team ?? NewTeam()),
-            new MemberQueryPort(member ?? NewMember()));
+            new MemberQueryPort(member ?? NewMember()),
+            new ReadyScopeBindingReadinessQueryPort());
         return new StudioTeamGAgentStreamInvocationService(
             resolver,
             staticPort);
+    }
+
+    private sealed class ReadyScopeBindingReadinessQueryPort : IScopeBindingReadinessQueryPort
+    {
+        public Task<ScopeBindingReadinessSnapshot> GetReadinessAsync(
+            ScopeBindingReadinessRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(new ScopeBindingReadinessSnapshot(
+                request.ScopeId,
+                request.ServiceId,
+                ScopeBindingReadinessStatus.Ready,
+                ServiceCatalogVisible: true,
+                ServingSetVisible: true,
+                EligibleServingTargetVisible: true,
+                InvokeReady: true,
+                RevisionId: request.ExpectedRevisionId ?? "rev-1",
+                DeploymentId: "dep-1",
+                ObservedAtUtc: DateTimeOffset.UtcNow));
     }
 
     private static StudioTeamStreamInvocationRequest NewRequest() =>


### PR DESCRIPTION
## Summary
- Port only the backend Studio invocation readiness changes onto a fresh `dev`-based branch.
- Add prepared-artifact readiness detection for scope bindings and expose endpoint contract readiness from Studio member backend APIs.
- Keep Team Test backend admission guarded by authoritative readiness while excluding all frontend changes.

## Test plan
- [x] `bash tools/ci/test_stability_guards.sh`
- [x] `dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --filter "ApplicationServiceGuardTests|ScopeBindingReadinessQueryServiceTests" --nologo`
- [x] `dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --filter "StudioMemberBindingHostedConsistencyTests|StudioMemberEndpointsTests|StudioMemberServiceBindingTests|StudioMemberServiceContractAndRevisionTests|StudioMemberServiceTeamTests|StudioTeamEntryMemberResolverTests|StudioTeamGAgentStreamInvocationServiceTests" --nologo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)