### PR TITLE
限制 workflow llm_call 的工具可见范围

### DIFF
--- a/docs/canon/connector.md
+++ b/docs/canon/connector.md
@@ -134,6 +134,8 @@ roles:
 
 这一步只负责“传授权信息”，不直接执行 connector。
 
+注意：`roles[].connectors` 只约束 `connector_call` 对中心化 connector 的访问；它不控制 LLM agent tool。`llm_call` 的 agent tool 可见范围使用 role/step 根部的 `allowed_tools`，并通过 typed `agent_tool_scope` 传到 AI 工具执行上下文。
+
 ## 3.2 connector_call 执行主链路
 
 `ConnectorCallModule` 处理 `StepRequestEvent`（`step_type == connector_call`）：

--- a/docs/canon/workflow-primitives.md
+++ b/docs/canon/workflow-primitives.md
@@ -55,6 +55,7 @@ roles:
     event_routes: |
       event.type == ChatRequestEvent -> llm_handler
     connectors: [my_api, my_mcp]
+    allowed_tools: [web_search, calendar_lookup]
     extensions:
       event_modules: "fallback_module"
       event_routes: "event.type == X -> fallback_module"
@@ -62,6 +63,7 @@ roles:
 
 - `agent_kind` 是可选的稳定 kind token；配置后由 `WorkflowRunGAgent` 通过 Foundation runtime 创建该 role actor；省略时默认 `workflow.role-agent`。
 - `roles` 配置会透传到 `InitializeRoleAgentEvent`，并在 role actor 运行时生效。
+- `allowed_tools` 是 role 级 agent tool 可见范围上限；省略表示不限制，显式 `[]` 表示该 role 默认不暴露 agent tool。
 - `event_modules/event_routes` 合并优先级：平铺字段 > `extensions.*`。
 - `workflow yaml roles` 与独立 `role yaml` 共享同一归一化语义，避免双套解析规则。
 - step 只能通过 `target_role` / `role` 指向角色；`parameters.agent_type` 与 `parameters.agent_id` 不是 workflow DSL。
@@ -310,9 +312,13 @@ steps:
   - id: analyze
     type: llm_call
     target_role: analyst
+    allowed_tools: [web_search]
     parameters:
       prompt_prefix: "Analyze this input:"
 ```
+
+- `allowed_tools` 可写在 `llm_call` step 根部，用于收窄目标 role 的工具范围；省略继承 role 上限，显式 `[]` 表示本次 LLM call 不暴露 agent tool。
+- role 与 step 均配置时取交集；同一结果会同时限制 provider 可见的 `LLMRequest.Tools` 与执行期 tool lookup。
 
 ### `tool_call`
 

--- a/docs/canon/workflow-runtime.md
+++ b/docs/canon/workflow-runtime.md
@@ -169,6 +169,7 @@ roles:
     event_routes: |
       event.type == ChatRequestEvent -> llm_handler
     connectors: [incident_api, search_mcp]
+    allowed_tools: [web_search, issue_lookup]
     extensions:
       event_modules: "fallback_module"
       event_routes: "event.type == X -> fallback_module"
@@ -178,6 +179,9 @@ roles:
 
 - `workflow roles` 与 `role yaml` 共用同一份解析归一化逻辑（`RoleConfigurationNormalizer`）。
 - `agent_kind` 是 role-level actor lifecycle 入口，可指向任意已注册 primary `[GAgent]` kind；step 只使用 `target_role` / `role`，不得通过参数选择 CLR 类型或 actor id。
+- `allowed_tools` 是 role actor 上 agent tool 可见范围的上限；未配置表示兼容旧行为的全量工具，配置为空数组表示默认不暴露工具。
+- `llm_call` step 可在根部配置 `allowed_tools` 继续收窄本次调用；role scope 与 step scope 取交集后写入 `WorkflowStepParameters.agent_tool_scope`，再由 `WorkflowLlmExecutionIntent.agent_tool_scope` 传给 AI `AgentToolExecutionContext.ToolVisibility`。
+- 工具可见范围同时作用于 provider 看到的 `LLMRequest.Tools` 和 streaming tool executor 的实际 lookup；未授权工具调用会得到 not-available tool result，不会执行工具。
 - `event_modules` / `event_routes` 支持平铺写法和 `extensions.*` 写法，且**平铺字段优先级更高**。
 - 未配置 `event_modules` 时，`RoleGAgent` 不会额外装配 event modules（保持旧行为）。
 - Refactor (iter31/cluster-032-chatruntime-taskrun-business-loop):

--- a/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContext.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContext.cs
@@ -16,6 +16,8 @@ public sealed record AgentToolExecutionContext(
     AgentSkillRecoveryContext SkillRecovery,
     IReadOnlyDictionary<string, string> ExternalMetadata)
 {
+    public AgentToolVisibilityScope ToolVisibility { get; init; } = AgentToolVisibilityScope.Unrestricted;
+
     public static AgentToolExecutionContext Empty { get; } = new(
         AgentToolRequestIdentity.Empty,
         AgentToolCredentials.Empty,
@@ -32,6 +34,42 @@ public sealed record AgentToolExecutionContext(
 
     internal static string? Normalize(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}
+
+public sealed record AgentToolVisibilityScope(IReadOnlySet<string>? AllowedToolNames)
+{
+    public static AgentToolVisibilityScope Unrestricted { get; } = new((IReadOnlySet<string>?)null);
+
+    public static AgentToolVisibilityScope Empty { get; } = new(new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+
+    public bool IsRestricted => AllowedToolNames is not null;
+
+    public bool Allows(string? toolName)
+    {
+        if (AllowedToolNames is null)
+            return true;
+
+        if (string.IsNullOrWhiteSpace(toolName))
+            return false;
+
+        return AllowedToolNames.Contains(toolName.Trim());
+    }
+
+    public static AgentToolVisibilityScope FromAllowedToolNames(IEnumerable<string>? toolNames)
+    {
+        if (toolNames is null)
+            return Unrestricted;
+
+        var allowed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var toolName in toolNames)
+        {
+            var normalized = AgentToolExecutionContext.Normalize(toolName);
+            if (normalized is not null)
+                allowed.Add(normalized);
+        }
+
+        return new AgentToolVisibilityScope(allowed);
+    }
 }
 
 public sealed record AgentToolRequestIdentity(string? RequestId, string? CallId)

--- a/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContextMapper.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContextMapper.cs
@@ -109,7 +109,7 @@ public static class AgentToolExecutionContextMapper
         if (payload == null)
             return AgentToolExecutionContext.Empty;
 
-        return new AgentToolExecutionContext(
+        var context = new AgentToolExecutionContext(
             new AgentToolRequestIdentity(
                 AgentToolExecutionContext.Normalize(payload.Request?.RequestId),
                 AgentToolExecutionContext.Normalize(payload.Request?.CallId)),
@@ -136,6 +136,7 @@ public static class AgentToolExecutionContextMapper
             new AgentToolConnectedServicesContext(AgentToolExecutionContext.Normalize(payload.ConnectedServices?.ContextJson)),
             FromSkillRecoveryPayload(payload.SkillRecovery),
             StripOwnedControlKeys(payload.ExternalMetadata));
+        return context with { ToolVisibility = FromToolVisibilityPayload(payload.ToolVisibility) };
     }
 
     public static AgentToolExecutionContextPayload ToPayload(this AgentToolExecutionContext context)
@@ -189,6 +190,9 @@ public static class AgentToolExecutionContextMapper
         if (context.Routing.MaxToolRoundsOverride.HasValue)
             payload.Routing.MaxToolRoundsOverride = context.Routing.MaxToolRoundsOverride.Value;
 
+        if (context.ToolVisibility.IsRestricted)
+            payload.ToolVisibility = ToToolVisibilityPayload(context.ToolVisibility);
+
         foreach (var pair in StripOwnedControlKeys(context.ExternalMetadata))
             payload.ExternalMetadata[pair.Key] = pair.Value;
 
@@ -234,6 +238,26 @@ public static class AgentToolExecutionContextMapper
             CommandArguments = context.CommandArguments ?? string.Empty,
             DiscoveryRequested = context.DiscoveryRequested,
         };
+
+    private static AgentToolVisibilityScope FromToolVisibilityPayload(AgentToolVisibilityScopePayload? payload)
+    {
+        if (payload == null)
+            return AgentToolVisibilityScope.Unrestricted;
+
+        return AgentToolVisibilityScope.FromAllowedToolNames(payload.AllowedToolNames);
+    }
+
+    private static AgentToolVisibilityScopePayload ToToolVisibilityPayload(AgentToolVisibilityScope scope)
+    {
+        var payload = new AgentToolVisibilityScopePayload();
+        if (scope.AllowedToolNames is null)
+            return payload;
+
+        foreach (var toolName in scope.AllowedToolNames.OrderBy(static name => name, StringComparer.OrdinalIgnoreCase))
+            payload.AllowedToolNames.Add(toolName);
+
+        return payload;
+    }
 
     public static IReadOnlyDictionary<string, string> StripOwnedControlKeys(IReadOnlyDictionary<string, string>? metadata)
     {

--- a/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolRequestContext.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolRequestContext.cs
@@ -35,6 +35,8 @@ public static class AgentToolRequestContext
     public static string? ChannelRegistrationScopeId => s_context.Value?.Channel.RegistrationScopeId;
     public static string? ChannelMessageId => s_context.Value?.Channel.MessageId;
     public static string? ChannelPlatformMessageId => s_context.Value?.Channel.PlatformMessageId;
+    public static AgentToolVisibilityScope ToolVisibility =>
+        s_context.Value?.ToolVisibility ?? AgentToolVisibilityScope.Unrestricted;
 
     public static string? TryGetExternalMetadata(string key)
     {

--- a/src/Aevatar.AI.Abstractions/ai_messages.proto
+++ b/src/Aevatar.AI.Abstractions/ai_messages.proto
@@ -99,6 +99,7 @@ message AgentToolExecutionContextPayload {
   AgentToolConnectedServicesContextPayload connected_services = 7;
   map<string, string> external_metadata = 8;
   AgentSkillRecoveryContextPayload skill_recovery = 9;
+  AgentToolVisibilityScopePayload tool_visibility = 10;
 }
 
 message AgentSkillRecoveryContextPayload {
@@ -110,6 +111,10 @@ message AgentSkillRecoveryContextPayload {
   int32 max_ornn_search_attempts = 6;
   string command_arguments = 7;
   bool discovery_requested = 8;
+}
+
+message AgentToolVisibilityScopePayload {
+  repeated string allowed_tool_names = 1;
 }
 
 message AgentToolRequestIdentityPayload {

--- a/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
@@ -963,12 +963,26 @@ public sealed class ChatRuntime
             ToolContext = effectiveToolContext,
             RoutingContext = effectiveLlmControl?.ToRoutingContext(baseRequest.RoutingContext) ?? baseRequest.RoutingContext,
             LlmControl = effectiveLlmControl,
-            Tools = baseRequest.Tools,
+            Tools = FilterVisibleTools(baseRequest.Tools, effectiveToolContext.ToolVisibility),
             Model = baseRequest.Model,
             Temperature = baseRequest.Temperature,
             MaxTokens = baseRequest.MaxTokens,
             ResponseFormat = baseRequest.ResponseFormat,
         };
+    }
+
+    private static IReadOnlyList<IAgentTool>? FilterVisibleTools(
+        IReadOnlyList<IAgentTool>? tools,
+        AgentToolVisibilityScope visibility)
+    {
+        if (tools is not { Count: > 0 })
+            return null;
+
+        if (!visibility.IsRestricted)
+            return tools;
+
+        var visibleTools = tools.Where(tool => visibility.Allows(tool.Name)).ToList();
+        return visibleTools.Count > 0 ? visibleTools : null;
     }
 
     private static IReadOnlyDictionary<string, string>? MergeMetadata(

--- a/src/Aevatar.AI.Core/Tools/StreamingToolExecutor.cs
+++ b/src/Aevatar.AI.Core/Tools/StreamingToolExecutor.cs
@@ -72,6 +72,25 @@ public sealed class StreamingToolExecutor
         ArgumentNullException.ThrowIfNull(state);
         ArgumentNullException.ThrowIfNull(toolCall);
 
+        if (!IsToolVisible(toolCall.Name))
+        {
+            var unauthorized = new ToolExecutionEntry(
+                Call: toolCall,
+                Tool: null,
+                IsConcurrencySafe: true)
+            {
+                Status = ToolStatus.Completed,
+                Result = new ToolExecutionResult(
+                    toolCall.Id,
+                    toolCall.Name,
+                    ToolManager.BuildErrorJson($"Tool '{toolCall.Name}' is not available in this context."),
+                    IsError: true),
+            };
+            state.Tools.Add(unauthorized);
+            Advance(state);
+            return;
+        }
+
         var tool = _tools.Get(toolCall.Name);
         var tracked = new ToolExecutionEntry(
             Call: toolCall,
@@ -301,6 +320,17 @@ public sealed class StreamingToolExecutor
 
             // Re-resolve tool after hooks — hooks may have rewritten the tool name.
             var effectiveToolName = string.IsNullOrWhiteSpace(toolCtx.ToolName) ? call.Name : toolCtx.ToolName!;
+            if (!IsToolVisible(effectiveToolName))
+            {
+                return new ToolExecutionCompletion(
+                    new ToolExecutionResult(
+                        call.Id,
+                        call.Name,
+                        ToolManager.BuildErrorJson($"Tool '{effectiveToolName}' is not available in this context."),
+                        IsError: true),
+                    SchedulerFault: true);
+            }
+
             var effectiveTool = _tools.Get(effectiveToolName) ?? tracked.Tool ?? new NullAgentTool(call.Name);
 
             // If the hook changed the tool name to a different tool, re-evaluate concurrency
@@ -404,6 +434,9 @@ public sealed class StreamingToolExecutor
                 SchedulerFault: false);
         }
     }
+
+    private bool IsToolVisible(string? toolName) =>
+        (_toolContext ?? AgentToolRequestContext.Current)?.ToolVisibility.Allows(toolName) ?? true;
 
     private sealed class NullAgentTool(string name) : IAgentTool
     {

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -235,6 +235,7 @@ message WorkflowStepParameters
   aevatar.foundation.interactions.InteractionSpec interaction_spec = 4;
   aevatar.foundation.interactions.InteractionTemplateSpec interaction_template_spec = 5;
   string delivery_target_id = 6;
+  WorkflowAgentToolScope agent_tool_scope = 7;
 }
 message StepRequestEvent
 {
@@ -482,6 +483,12 @@ message WorkflowLlmExecutionIntent
   WorkflowCallerCredential caller_credential = 12;
   string route_preference = 13;
   string sender_nyx_id_access_token = 14;
+  WorkflowAgentToolScope agent_tool_scope = 15;
+}
+
+message WorkflowAgentToolScope
+{
+  repeated string allowed_tool_names = 1;
 }
 
 message WorkflowLlmInvocationStartedEvent

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
@@ -1160,12 +1160,59 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                 x => string.Equals(x.Id, effectiveTargetRole, StringComparison.OrdinalIgnoreCase));
             if (role is { Connectors.Count: > 0 })
                 request.Parameters["allowed_connectors"] = string.Join(",", role.Connectors);
+            ApplyAgentToolScope(request, role?.AgentToolScope, step.AgentToolScope);
+        }
+        else
+        {
+            ApplyAgentToolScope(request, roleScope: null, step.AgentToolScope);
         }
 
         ApplyInteractionPresentation(request, step.Presentation, state);
 
         return request;
     }
+
+    private static void ApplyAgentToolScope(
+        StepRequestEvent request,
+        WorkflowAgentToolScopeDefinition? roleScope,
+        WorkflowAgentToolScopeDefinition? stepScope)
+    {
+        var effectiveScope = IntersectAgentToolScope(roleScope, stepScope);
+        if (effectiveScope == null)
+            return;
+
+        var payload = (request.StepParameters ??= new WorkflowStepParameters()).AgentToolScope = new WorkflowAgentToolScope();
+        foreach (var toolName in effectiveScope.AllowedToolNames)
+            payload.AllowedToolNames.Add(toolName);
+    }
+
+    private static WorkflowAgentToolScopeDefinition? IntersectAgentToolScope(
+        WorkflowAgentToolScopeDefinition? roleScope,
+        WorkflowAgentToolScopeDefinition? stepScope)
+    {
+        if (roleScope == null)
+            return stepScope == null ? null : CloneAgentToolScope(stepScope);
+
+        if (stepScope == null)
+            return CloneAgentToolScope(roleScope);
+
+        var stepAllowed = new HashSet<string>(stepScope.AllowedToolNames, StringComparer.OrdinalIgnoreCase);
+        return new WorkflowAgentToolScopeDefinition
+        {
+            AllowedToolNames = roleScope.AllowedToolNames
+                .Where(stepAllowed.Contains)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+        };
+    }
+
+    private static WorkflowAgentToolScopeDefinition CloneAgentToolScope(WorkflowAgentToolScopeDefinition scope) =>
+        new()
+        {
+            AllowedToolNames = scope.AllowedToolNames
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+        };
 
     private void ApplyInteractionPresentation(
         StepRequestEvent request,

--- a/src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs
@@ -393,6 +393,7 @@ public sealed class LLMCallModule : IEventModule<IWorkflowExecutionContext>
             ? callerCredential
             : new WorkflowCallerCredential();
         WorkflowLlmExecutionIntentRuntimeContextAccess.ApplySenderNyxIdAccessToken(ctx, intent);
+        CopyAgentToolScope(request.StepParameters?.AgentToolScope, intent);
         CopyParametersToChatRequest(request, intent, timeoutMs);
         WorkflowRequestMetadataRuntimeContextAccess.CopyRequestMetadata(ctx, intent.Headers);
         var dispatchOptions = BuildDispatchOptions(dispatchDedupId);
@@ -480,6 +481,22 @@ public sealed class LLMCallModule : IEventModule<IWorkflowExecutionContext>
 
     private static string? Normalize(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static void CopyAgentToolScope(
+        WorkflowAgentToolScope? source,
+        WorkflowLlmExecutionIntent intent)
+    {
+        if (source == null)
+            return;
+
+        intent.AgentToolScope = new WorkflowAgentToolScope();
+        foreach (var toolName in source.AllowedToolNames)
+        {
+            var normalized = Normalize(toolName);
+            if (normalized is not null)
+                intent.AgentToolScope.AllowedToolNames.Add(normalized);
+        }
+    }
 
     private static bool TryResolvePending(
         LLMCallModuleState state,

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/StepDefinition.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/StepDefinition.cs
@@ -30,6 +30,8 @@ public sealed class StepDefinition
     /// </summary>
     public StepPresentation? Presentation { get; init; }
 
+    public WorkflowAgentToolScopeDefinition? AgentToolScope { get; init; }
+
     /// <summary>
     /// 下一步骤 ID，用于线性流程控制。
     /// </summary>

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowAgentToolScopeDefinition.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowAgentToolScopeDefinition.cs
@@ -1,0 +1,6 @@
+namespace Aevatar.Workflow.Core.Primitives;
+
+public sealed class WorkflowAgentToolScopeDefinition
+{
+    public List<string> AllowedToolNames { get; init; } = [];
+}

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowDefinition.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowDefinition.cs
@@ -177,6 +177,8 @@ public sealed class RoleDefinition
     /// </summary>
     public string? EventRoutes { get; init; }
 
+    public WorkflowAgentToolScopeDefinition? AgentToolScope { get; init; }
+
     /// <summary>
     /// 该角色允许使用的 Connector 名称列表（中心化配置在 ~/.aevatar/connectors.json）。
     /// 当 connector_call 步骤指定本角色时，仅允许调用此列表中的 connector。

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowParser.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowParser.cs
@@ -122,6 +122,7 @@ public sealed class WorkflowParser
             MaxHistoryMessages = role.MaxHistoryMessages,
             EventModules = eventModules,
             EventRoutes = eventRoutes,
+            AgentToolScope = MapAgentToolScope(role.AllowedTools),
             Connectors = role.Connectors?.Where(x => !string.IsNullOrWhiteSpace(x)).Select(x => x.Trim()).Distinct(StringComparer.Ordinal).ToList() ?? [],
         };
     }
@@ -147,6 +148,7 @@ public sealed class WorkflowParser
         var rawParameters = s.Parameters is null
             ? null
             : new Dictionary<string, object?>(s.Parameters, StringComparer.Ordinal);
+        var agentToolScope = MapAgentToolScope(ResolveStepAllowedTools(s, rawParameters));
         var presentation = MapPresentation(canonicalType, s, rawParameters);
         var parameters = NormalizeParameters(rawParameters);
 
@@ -160,6 +162,7 @@ public sealed class WorkflowParser
             TargetRole = s.TargetRole ?? s.Role,
             Parameters = WorkflowPrimitiveCatalog.CanonicalizeStepTypeParameters(parameters),
             Presentation = presentation,
+            AgentToolScope = agentToolScope,
             Next = s.Next,
             Children = s.Children?.Select(MapStep).ToList(),
             Branches = NormalizeBranches(s.Branches),
@@ -219,6 +222,101 @@ public sealed class WorkflowParser
         }
 
         return null;
+    }
+
+    private static object? ResolveStepAllowedTools(
+        RawStep step,
+        IDictionary<string, object?>? rawParameters)
+    {
+        object? parameterSource = null;
+        if (rawParameters is not null)
+        {
+            foreach (var key in new[] { "allowed_tools", "allowedTools" })
+            {
+                if (!rawParameters.TryGetValue(key, out var source))
+                    continue;
+
+                rawParameters.Remove(key);
+                parameterSource ??= source;
+            }
+        }
+
+        if (step.AllowedTools is not null)
+            return step.AllowedTools;
+
+        return parameterSource;
+    }
+
+    private static WorkflowAgentToolScopeDefinition? MapAgentToolScope(object? source)
+    {
+        if (source is null)
+            return null;
+
+        return new WorkflowAgentToolScopeDefinition
+        {
+            AllowedToolNames = NormalizeToolNames(source).ToList(),
+        };
+    }
+
+    private static IEnumerable<string> NormalizeToolNames(object? source)
+    {
+        switch (source)
+        {
+            case null:
+                yield break;
+            case string text:
+            {
+                if (string.IsNullOrWhiteSpace(text))
+                    yield break;
+
+                var trimmed = text.Trim();
+                if (trimmed.StartsWith("[", StringComparison.Ordinal) ||
+                    trimmed.StartsWith("{", StringComparison.Ordinal))
+                {
+                    using var document = JsonDocument.Parse(trimmed);
+                    foreach (var item in NormalizeToolNames(document.RootElement.Clone()))
+                        yield return item;
+                    yield break;
+                }
+
+                foreach (var item in trimmed.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+                    yield return item;
+                yield break;
+            }
+            case JsonElement element:
+            {
+                if (element.ValueKind != JsonValueKind.Array)
+                    yield break;
+
+                foreach (var item in element.EnumerateArray())
+                {
+                    var toolName = ConvertValueToString(item).Trim();
+                    if (!string.IsNullOrWhiteSpace(toolName))
+                        yield return toolName;
+                }
+
+                yield break;
+            }
+            case IEnumerable sequence:
+            {
+                var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var item in sequence)
+                {
+                    var toolName = ConvertValueToString(item).Trim();
+                    if (!string.IsNullOrWhiteSpace(toolName) && seen.Add(toolName))
+                        yield return toolName;
+                }
+
+                yield break;
+            }
+            default:
+            {
+                var toolName = ConvertValueToString(source).Trim();
+                if (!string.IsNullOrWhiteSpace(toolName))
+                    yield return toolName;
+                yield break;
+            }
+        }
     }
 
     private static object? ResolveInteractionTemplateSpecSource(
@@ -1003,6 +1101,7 @@ public sealed class WorkflowParser
         public int? MaxHistoryMessages { get; set; }
         public string? EventModules { get; set; }
         public string? EventRoutes { get; set; }
+        public object? AllowedTools { get; set; }
         public RawRoleExtensions? Extensions { get; set; }
         public List<string>? Connectors { get; set; }
     }
@@ -1062,6 +1161,7 @@ public sealed class WorkflowParser
         public string? HolderToken { get; set; }
         public object? Generation { get; set; }
         public string? HolderTokenVariable { get; set; }
+        public object? AllowedTools { get; set; }
         public object? InteractionSpec { get; set; }
         public object? InteractionTemplateSpec { get; set; }
         public string? DeliveryTargetId { get; set; }

--- a/src/workflow/Aevatar.Workflow.Integration.AI/WorkflowRoleGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Integration.AI/WorkflowRoleGAgent.cs
@@ -142,6 +142,7 @@ public class WorkflowRoleGAgent(
                 },
             };
         }
+        toolContext = ApplyToolVisibility(intent.AgentToolScope, toolContext);
 
         var request = new ChatRequestEvent
         {
@@ -163,6 +164,19 @@ public class WorkflowRoleGAgent(
         CopyWorkflowIntentMetadata(intent.Headers, request.Metadata);
         CopyWorkflowIntentMetadata(intent.Annotations, request.Metadata);
         return request;
+    }
+
+    private static AgentToolExecutionContext ApplyToolVisibility(
+        WorkflowAgentToolScope? scope,
+        AgentToolExecutionContext toolContext)
+    {
+        if (scope == null)
+            return toolContext;
+
+        return toolContext with
+        {
+            ToolVisibility = AgentToolVisibilityScope.FromAllowedToolNames(scope.AllowedToolNames),
+        };
     }
 
     private static void CopyWorkflowIntentMetadata(

--- a/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
+++ b/test/Aevatar.AI.Tests/AgentToolExecutionContextMapperTests.cs
@@ -168,6 +168,33 @@ public sealed class AgentToolExecutionContextMapperTests
     }
 
     [Fact]
+    public void ToPayloadAndFromPayload_ShouldPreserveRestrictedToolVisibility()
+    {
+        var context = AgentToolExecutionContext.Empty with
+        {
+            ToolVisibility = AgentToolVisibilityScope.FromAllowedToolNames(["search"]),
+        };
+
+        var payload = AgentToolExecutionContextMapper.ToPayload(context);
+        var mapped = AgentToolExecutionContextMapper.FromPayload(payload);
+
+        payload.ToolVisibility.Should().NotBeNull();
+        payload.ToolVisibility.AllowedToolNames.Should().Equal("search");
+        mapped.ToolVisibility.IsRestricted.Should().BeTrue();
+        mapped.ToolVisibility.Allows("search").Should().BeTrue();
+        mapped.ToolVisibility.Allows("calendar").Should().BeFalse();
+    }
+
+    [Fact]
+    public void ToPayload_WhenToolVisibilityUnrestricted_ShouldOmitVisibilityPayload()
+    {
+        var payload = AgentToolExecutionContextMapper.ToPayload(AgentToolExecutionContext.Empty);
+
+        payload.ToolVisibility.Should().BeNull();
+        AgentToolExecutionContextMapper.FromPayload(payload).ToolVisibility.IsRestricted.Should().BeFalse();
+    }
+
+    [Fact]
     public void FromMetadata_ShouldIgnoreOwnedControlKeysAndKeepExternalMetadata()
     {
         var context = AgentToolExecutionContextMapper.FromMetadata(new Dictionary<string, string>(StringComparer.Ordinal)

--- a/test/Aevatar.AI.Tests/MultimodalPipelineTests.cs
+++ b/test/Aevatar.AI.Tests/MultimodalPipelineTests.cs
@@ -1,5 +1,6 @@
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.Core.Chat;
 using Aevatar.AI.Core.Tools;
 using FluentAssertions;
@@ -156,6 +157,52 @@ public class MultimodalPipelineTests
         chunks.Should().Contain(c => c.DeltaContent == "Hello world");
     }
 
+    [Fact]
+    public async Task ChatRuntime_WhenToolVisibilityRestricted_ShouldOnlyExposeAllowedToolsToProvider()
+    {
+        var provider = new RecordingProvider();
+        var toolManager = new ToolManager();
+        toolManager.Register(new NamedTool("search"));
+        toolManager.Register(new NamedTool("calendar"));
+        var runtime = CreateRuntime(
+            provider,
+            toolManager,
+            AgentToolExecutionContext.Empty with
+            {
+                ToolVisibility = AgentToolVisibilityScope.FromAllowedToolNames(["search"]),
+            });
+
+        await foreach (var _ in runtime.ChatStreamAsync("hello"))
+        {
+        }
+
+        provider.Requests.Should().ContainSingle();
+        provider.Requests[0].Tools.Should().NotBeNull();
+        provider.Requests[0].Tools!.Select(static tool => tool.Name).Should().Equal("search");
+    }
+
+    [Fact]
+    public async Task ChatRuntime_WhenToolVisibilityPresentEmpty_ShouldExposeNoToolsToProvider()
+    {
+        var provider = new RecordingProvider();
+        var toolManager = new ToolManager();
+        toolManager.Register(new NamedTool("search"));
+        var runtime = CreateRuntime(
+            provider,
+            toolManager,
+            AgentToolExecutionContext.Empty with
+            {
+                ToolVisibility = AgentToolVisibilityScope.Empty,
+            });
+
+        await foreach (var _ in runtime.ChatStreamAsync("hello"))
+        {
+        }
+
+        provider.Requests.Should().ContainSingle();
+        provider.Requests[0].Tools.Should().BeNull();
+    }
+
     // ─── Helpers ───
 
     private static ChatRuntime CreateRuntime(ILLMProvider provider)
@@ -174,6 +221,26 @@ public class MultimodalPipelineTests
             });
     }
 
+    private static ChatRuntime CreateRuntime(
+        ILLMProvider provider,
+        ToolManager toolManager,
+        AgentToolExecutionContext toolContext)
+    {
+        var history = new ChatHistory();
+        var toolLoop = new ToolCallLoop(toolManager);
+        return new ChatRuntime(
+            providerFactory: () => provider,
+            history: history,
+            toolLoop: toolLoop,
+            hooks: null,
+            requestBuilder: () => new LLMRequest
+            {
+                Messages = history.BuildMessages("You are a helpful assistant."),
+                Tools = toolManager.GetAll(),
+                ToolContext = toolContext,
+            });
+    }
+
     private sealed class StreamingProvider : ILLMProvider
     {
         private readonly IReadOnlyList<LLMStreamChunk> _chunks;
@@ -189,5 +256,32 @@ public class MultimodalPipelineTests
                 yield return chunk;
             }
         }
+    }
+
+    private sealed class RecordingProvider : ILLMProvider
+    {
+        public string Name => "recording-test";
+
+        public List<LLMRequest> Requests { get; } = [];
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Requests.Add(request);
+            await Task.Yield();
+            yield return new LLMStreamChunk { DeltaContent = "ok" };
+            yield return new LLMStreamChunk { IsLast = true };
+        }
+    }
+
+    private sealed class NamedTool(string name) : IAgentTool
+    {
+        public string Name => name;
+        public string Description => name;
+        public string ParametersSchema => "{}";
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
+            Task.FromResult("{}");
     }
 }

--- a/test/Aevatar.AI.Tests/StreamingToolExecutorTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingToolExecutorTests.cs
@@ -613,6 +613,65 @@ public class StreamingToolExecutorTests
     }
 
     [Fact]
+    public async Task UnauthorizedTool_ShouldReturnNotAvailableWithoutExecutingTool()
+    {
+        var executed = false;
+        var tools = new ToolManager();
+        tools.Register(new DelegateAgentTool("blocked", _ =>
+        {
+            executed = true;
+            return "{}";
+        }));
+        var executor = new StreamingToolExecutor(
+            tools,
+            toolContext: AgentToolExecutionContext.Empty with
+            {
+                ToolVisibility = AgentToolVisibilityScope.FromAllowedToolNames(["allowed"]),
+            });
+        using var executionState = executor.CreateExecutionState();
+
+        executor.AddTool(executionState, new ToolCall { Id = "tc-blocked", Name = "blocked", ArgumentsJson = "{}" });
+
+        var results = new List<ToolExecutionResult>();
+        await foreach (var result in executor.GetRemainingResultsAsync(executionState, CancellationToken.None))
+            results.Add(result);
+
+        results.Should().ContainSingle();
+        results[0].CallId.Should().Be("tc-blocked");
+        results[0].IsError.Should().BeTrue();
+        results[0].Result.Should().Contain("not available");
+        executed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HookRewrite_ToUnauthorizedTool_ShouldReturnNotAvailable()
+    {
+        var tools = new ToolManager();
+        tools.Register(new DelegateAgentTool("allowed", _ => "{}"));
+        tools.Register(new DelegateAgentTool("blocked", _ => """{"blocked":true}"""));
+        var hooks = new AgentHookPipeline([new RewriteToolNameHook("allowed", "blocked")]);
+        var executor = new StreamingToolExecutor(
+            tools,
+            hooks,
+            toolContext: AgentToolExecutionContext.Empty with
+            {
+                ToolVisibility = AgentToolVisibilityScope.FromAllowedToolNames(["allowed"]),
+            });
+        using var executionState = executor.CreateExecutionState();
+
+        executor.AddTool(executionState, new ToolCall { Id = "tc-rewrite", Name = "allowed", ArgumentsJson = "{}" });
+
+        var results = new List<ToolExecutionResult>();
+        await foreach (var result in executor.GetRemainingResultsAsync(executionState, CancellationToken.None))
+            results.Add(result);
+
+        results.Should().ContainSingle();
+        results[0].CallId.Should().Be("tc-rewrite");
+        results[0].IsError.Should().BeTrue();
+        results[0].Result.Should().Contain("not available");
+    }
+
+    [Fact]
     public async Task ReceiptWorthyFormula_ShouldIgnoreNonReadOnlyAlone_AndEmitForApprovalDestructiveOrSideEffect()
     {
         var tools = new ToolManager();

--- a/test/Aevatar.Workflow.Core.Tests/Execution/IdempotentStepExecutionTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/IdempotentStepExecutionTests.cs
@@ -632,6 +632,89 @@ public sealed class IdempotentStepExecutionTests
         request.StepParameters.InteractionSpec.Actions[0].Style.Should().Be(InteractionActionStyle.Primary);
     }
 
+    [Fact]
+    public async Task StartWorkflow_WithRoleAndStepToolScopes_ShouldDispatchIntersection()
+    {
+        var ctx = new RecordingEventHandlerContext();
+        var host = new RecordingStateHost();
+        var workflow = new WorkflowDefinition
+        {
+            Name = "tool-scope-workflow",
+            Roles =
+            [
+                new RoleDefinition
+                {
+                    Id = "worker",
+                    Name = "Worker",
+                    AgentToolScope = new WorkflowAgentToolScopeDefinition
+                    {
+                        AllowedToolNames = ["search", "calendar"],
+                    },
+                },
+            ],
+            Steps =
+            [
+                new StepDefinition
+                {
+                    Id = "scoped",
+                    Type = "llm_call",
+                    TargetRole = "worker",
+                    AgentToolScope = new WorkflowAgentToolScopeDefinition
+                    {
+                        AllowedToolNames = ["calendar", "forbidden"],
+                    },
+                },
+            ],
+        };
+        var kernel = new WorkflowExecutionKernel(workflow, host);
+
+        await kernel.HandleAsync(Wrap(new StartWorkflowEvent { RunId = "run-tools", Input = "hello" }), ctx, CancellationToken.None);
+
+        var request = StepRequests(ctx).Single();
+        request.StepParameters.AgentToolScope.Should().NotBeNull();
+        request.StepParameters.AgentToolScope.AllowedToolNames.Should().Equal("calendar");
+    }
+
+    [Fact]
+    public async Task StartWorkflow_WithPresentEmptyStepToolScope_ShouldDispatchNoToolsScope()
+    {
+        var ctx = new RecordingEventHandlerContext();
+        var host = new RecordingStateHost();
+        var workflow = new WorkflowDefinition
+        {
+            Name = "no-tools-workflow",
+            Roles =
+            [
+                new RoleDefinition
+                {
+                    Id = "worker",
+                    Name = "Worker",
+                    AgentToolScope = new WorkflowAgentToolScopeDefinition
+                    {
+                        AllowedToolNames = ["search"],
+                    },
+                },
+            ],
+            Steps =
+            [
+                new StepDefinition
+                {
+                    Id = "scoped",
+                    Type = "llm_call",
+                    TargetRole = "worker",
+                    AgentToolScope = new WorkflowAgentToolScopeDefinition(),
+                },
+            ],
+        };
+        var kernel = new WorkflowExecutionKernel(workflow, host);
+
+        await kernel.HandleAsync(Wrap(new StartWorkflowEvent { RunId = "run-no-tools", Input = "hello" }), ctx, CancellationToken.None);
+
+        var request = StepRequests(ctx).Single();
+        request.StepParameters.AgentToolScope.Should().NotBeNull();
+        request.StepParameters.AgentToolScope.AllowedToolNames.Should().BeEmpty();
+    }
+
     // ──── Test infrastructure ────
 
     private static readonly string[] DefaultStartVariableKeys =

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRoleGAgentMappingTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRoleGAgentMappingTests.cs
@@ -52,6 +52,35 @@ public sealed class WorkflowRoleGAgentMappingTests
             .ContainSingle(x => x.Success);
     }
 
+    [Fact]
+    public async Task WorkflowRoleGAgent_ShouldMapWorkflowToolScopeToAiVisibility()
+    {
+        var provider = new RecordingLlmProvider();
+        var publisher = new RecordingEventPublisher();
+        var agent = new WorkflowRoleGAgent(provider)
+        {
+            EventPublisher = publisher,
+        };
+
+        await agent.HandleWorkflowLlmExecutionIntent(new WorkflowLlmExecutionIntent
+        {
+            RunId = "run-1",
+            StepId = "reply",
+            SessionId = "session-1",
+            Prompt = "hello",
+            AgentToolScope = new WorkflowAgentToolScope
+            {
+                AllowedToolNames = { "search" },
+            },
+        });
+
+        provider.LastRequest.Should().NotBeNull();
+        provider.LastRequest!.ToolContext.Should().NotBeNull();
+        provider.LastRequest.ToolContext!.ToolVisibility.IsRestricted.Should().BeTrue();
+        provider.LastRequest.ToolContext.ToolVisibility.Allows("search").Should().BeTrue();
+        provider.LastRequest.ToolContext.ToolVisibility.Allows("calendar").Should().BeFalse();
+    }
+
     private sealed class RecordingLlmProvider : ILLMProviderFactory, ILLMProvider
     {
         public LLMRequest? LastRequest { get; private set; }

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRuntimeModuleBranchTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRuntimeModuleBranchTests.cs
@@ -516,6 +516,56 @@ public sealed class WorkflowRuntimeModuleBranchTests
     }
 
     [Fact]
+    public async Task LlmCallModule_ShouldCopyTypedAgentToolScopeToIntent()
+    {
+        var module = new LLMCallModule();
+        var ctx = new RecordingWorkflowContext();
+
+        await module.HandleAsync(
+            Wrap(new StepRequestEvent
+            {
+                StepId = "llm-tool-scope",
+                StepType = "llm_call",
+                RunId = "run-llm-tool-scope",
+                Input = "draft",
+                StepParameters = new WorkflowStepParameters
+                {
+                    AgentToolScope = new WorkflowAgentToolScope
+                    {
+                        AllowedToolNames = { "search" },
+                    },
+                },
+            }),
+            ctx,
+            CancellationToken.None);
+
+        var intent = DispatchedLlmIntent(ctx);
+        intent.AgentToolScope.Should().NotBeNull();
+        intent.AgentToolScope.AllowedToolNames.Should().Equal("search");
+        intent.Annotations.Should().NotContainKey("allowed_tools");
+    }
+
+    [Fact]
+    public async Task LlmCallModule_WithNoAgentToolScope_ShouldLeaveIntentUnrestricted()
+    {
+        var module = new LLMCallModule();
+        var ctx = new RecordingWorkflowContext();
+
+        await module.HandleAsync(
+            Wrap(new StepRequestEvent
+            {
+                StepId = "llm-unrestricted",
+                StepType = "llm_call",
+                RunId = "run-llm-unrestricted",
+                Input = "draft",
+            }),
+            ctx,
+            CancellationToken.None);
+
+        DispatchedLlmIntent(ctx).AgentToolScope.Should().BeNull();
+    }
+
+    [Fact]
     public async Task EvaluateModule_ShouldPublishZeroScorePass_WhenContentHasNoNumberAndThresholdIsZero()
     {
         var module = new EvaluateModule();

--- a/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowParserConfigurationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowParserConfigurationTests.cs
@@ -90,6 +90,39 @@ public class WorkflowParserConfigurationTests
     }
 
     [Fact]
+    public void Parse_WhenRoleAndStepDeclareAllowedTools_ShouldBindTypedAgentToolScopes()
+    {
+        var yaml = """
+            name: tool_scope
+            roles:
+              - id: planner
+                allowed_tools: [search, calendar]
+            steps:
+              - id: scoped
+                type: llm_call
+                target_role: planner
+                allowed_tools: [calendar]
+                parameters:
+                  allowed_tools: [search]
+                  prompt_prefix: "Use scoped tool"
+              - id: no_tools
+                type: llm_call
+                target_role: planner
+                allowed_tools: []
+            """;
+
+        var workflow = new WorkflowParser().Parse(yaml);
+
+        workflow.Roles.Should().ContainSingle().Subject.AgentToolScope.Should().NotBeNull();
+        workflow.Roles[0].AgentToolScope!.AllowedToolNames.Should().Equal("search", "calendar");
+        workflow.Steps[0].AgentToolScope.Should().NotBeNull();
+        workflow.Steps[0].AgentToolScope!.AllowedToolNames.Should().Equal("calendar");
+        workflow.Steps[0].Parameters.Should().NotContainKey("allowed_tools");
+        workflow.Steps[1].AgentToolScope.Should().NotBeNull();
+        workflow.Steps[1].AgentToolScope!.AllowedToolNames.Should().BeEmpty();
+    }
+
+    [Fact]
     public void Parse_WhenRoleDefinesTopLevelAndExtensionsEventFields_ShouldPreferTopLevel()
     {
         var yaml = """


### PR DESCRIPTION
## Changed files
- 新增 workflow `agent_tool_scope` 与 AI `ToolVisibility` typed contract, 保留 absent scope 全量兼容, 支持 present-empty no-tools。
- 更新 workflow parser/kernel/LLM module/role agent 映射, role `allowed_tools` 作为上限, step `allowed_tools` 取交集收窄。
- 更新 ChatRuntime provider 工具可见列表过滤与 StreamingToolExecutor 执行前授权检查, 并补充 parser/kernel/module/AI mapper/runtime/executor 行为测试和 canon 文档。

## Test results
- PASS: `dotnet build aevatar.slnx --nologo` in sourced host shell。
- PASS: workflow focused tests - 64 passed。
- PASS: AI focused tests - 48 passed。
- PASS: AI.Core tests - 77 passed。
- PASS: `bash tools/ci/test_stability_guards.sh`。
- PASS: `bash tools/ci/architecture_guards.sh`。
- SKIP: host guard hook - `guards skipped: CI_GUARDS unset`。
- NOTE: controller publish gate 的 full `dotnet test aevatar.slnx --nologo` 命中既有基线失败 `LocalActorDispatchAdmissionTests.DispatchAsync_ShouldProcessRapidDispatchesInAdmissionOrder`，同一测试在 `feat/2026-06-10_milestone-23-base` 上也以相同 `IAgentKindRegistry` DI 错误失败；#1903 focused tests 与 guards 已通过。

## Deviations
- 无 scope 扩展。
- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)
- Closes #1903

⟦AI:AUTO-LOOP⟧
