### PR TITLE
Refactor Studio node parameter fields

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
@@ -1498,6 +1498,100 @@ describe('StudioWorkflowBuildPanel', () => {
     });
   });
 
+  it('infers unknown step parameters and keeps structured edits on parametersText', async () => {
+    const handleApplyStepDraft = jest.fn<Promise<void>, [AppliedStepDraft]>(
+      async () => undefined,
+    );
+
+    render(
+      <WorkflowBuildHarness
+        initialDocumentOverride={{
+          ...initialDocument,
+          steps: [
+            {
+              ...initialDocument.steps[0],
+              parameters: {
+                config: {
+                  mode: 'strict',
+                },
+                note: 'legacy',
+              },
+              type: 'custom_step',
+            },
+            initialDocument.steps[1],
+          ],
+        }}
+        onApplyStepDraftOverride={handleApplyStepDraft}
+        onContinueToBind={jest.fn()}
+        onSaveDraft={jest.fn()}
+        runtimePrimitivesOverride={[]}
+      />,
+    );
+
+    const configInput = await screen.findByLabelText('Parameter Config');
+    expect(configInput).toHaveValue('{\n  "mode": "strict"\n}');
+
+    fireEvent.change(configInput, {
+      target: {
+        value: '{\n  "mode": "relaxed"\n}',
+      },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply changes' }));
+
+    await waitFor(() => {
+      expect(handleApplyStepDraft).toHaveBeenCalledTimes(1);
+    });
+    const appliedDraft = handleApplyStepDraft.mock.calls.at(0)?.[0];
+    if (!appliedDraft) {
+      throw new Error('Expected an applied step draft.');
+    }
+    expect(JSON.parse(appliedDraft.parametersText)).toEqual({
+      config: {
+        mode: 'relaxed',
+      },
+      note: 'legacy',
+    });
+  });
+
+  it('blocks apply, save, and run when parameter JSON is invalid', async () => {
+    const handleApplyStepDraft = jest.fn<Promise<void>, [AppliedStepDraft]>(
+      async () => undefined,
+    );
+    const handleSaveDraft = jest.fn();
+    const buildWorkflowYamls = jest.fn<
+      Promise<string[]>,
+      Parameters<BuildWorkflowYamlsForTest>
+    >(async () => ['name: workflow-demo']);
+
+    render(
+      <WorkflowBuildHarness
+        buildWorkflowYamlsOverride={buildWorkflowYamls}
+        onApplyStepDraftOverride={handleApplyStepDraft}
+        onContinueToBind={jest.fn()}
+        onSaveDraft={handleSaveDraft}
+      />,
+    );
+
+    fireEvent.change(await screen.findByLabelText('Step parameters'), {
+      target: {
+        value: '{ "prompt_prefix": ',
+      },
+    });
+
+    expect(screen.getByText('Unexpected end of JSON input')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Apply changes' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Save draft' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Run' })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply changes' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save draft' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    expect(handleApplyStepDraft).not.toHaveBeenCalled();
+    expect(handleSaveDraft).not.toHaveBeenCalled();
+    expect(buildWorkflowYamls).not.toHaveBeenCalled();
+  });
+
   it('keeps runtime metadata out of output and only exposes it in debug details', async () => {
     mockedParseBackendSSEStream.mockImplementationOnce(async function* () {
       yield {

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
@@ -51,12 +51,15 @@ import {
 } from '@/shared/studio/scriptPackage';
 import {
   createStepInspectorDraft,
-  readStepParameterValue,
-  resolveStepParameterName,
-  normalizeStepParametersForType,
-  parseInspectorParameters,
   type StudioStepInspectorDraft,
 } from '@/shared/studio/document';
+import {
+  buildNodeConfigFields,
+  findNodeConfigPrimitiveDescriptor,
+  updateNodeConfigFieldParametersText,
+  validateNodeConfigParametersText,
+  type NodeConfigField,
+} from '@/shared/studio/nodeConfigFields';
 import { scriptsApi } from '@/shared/studio/scriptsApi';
 import type {
   DraftRunResult,
@@ -591,214 +594,6 @@ function extractRunFinishedOutput(result: unknown): string {
   return typeof candidate === 'string' ? candidate : '';
 }
 
-function tryParseStepParameters(
-  value: string,
-): Record<string, unknown> | null {
-  try {
-    return parseInspectorParameters(value);
-  } catch {
-    return null;
-  }
-}
-
-function normalizePrimitiveParameterDescriptor(
-  stepType: string,
-  parameter: WorkflowPrimitiveDescriptor['parameters'][number],
-): WorkflowPrimitiveDescriptor['parameters'][number] {
-  const resolvedName = resolveStepParameterName(stepType, parameter.name);
-  if (resolvedName === parameter.name) {
-    return parameter;
-  }
-
-  return {
-    ...parameter,
-    name: resolvedName,
-  };
-}
-
-function isLLMPromptInstructionParameter(
-  stepType: string,
-  parameterName: string,
-): boolean {
-  return (
-    stepType.trim().toLowerCase() === 'llm_call' &&
-    resolveStepParameterName(stepType, parameterName) === 'prompt_prefix'
-  );
-}
-
-function getParameterDisplayLabel(
-  stepType: string,
-  parameter: WorkflowPrimitiveDescriptor['parameters'][number],
-): string {
-  return isLLMPromptInstructionParameter(stepType, parameter.name)
-    ? t("pages.studio.studiobuildpanels.prompt.instruction", "Prompt instruction")
-    : parameter.name;
-}
-
-function getParameterDisplayDescription(
-  stepType: string,
-  parameter: WorkflowPrimitiveDescriptor['parameters'][number],
-): string {
-  if (isLLMPromptInstructionParameter(stepType, parameter.name)) {
-    return t("pages.studio.studiobuildpanels.prompt.instruction.description", "Instruction added before each workflow run input reaches the LLM.");
-  }
-
-  return parameter.description || t("pages.studio.studiobuildpanels.type.parameter", "Type: {type}", { type: parameter.type });
-}
-
-function getParameterPlaceholder(
-  stepType: string,
-  parameter: WorkflowPrimitiveDescriptor['parameters'][number],
-): string {
-  if (isLLMPromptInstructionParameter(stepType, parameter.name)) {
-    return t("pages.studio.studiobuildpanels.prompt.instruction.placeholder", "e.g. Translate the user input to Japanese");
-  }
-
-  return parameter.default || parameter.type || t("pages.studio.studiobuildpanels.value.placeholder", "Value");
-}
-
-function shouldUseParameterDefault(
-  stepType: string,
-  parameter: WorkflowPrimitiveDescriptor['parameters'][number],
-): boolean {
-  return !isLLMPromptInstructionParameter(stepType, parameter.name);
-}
-
-function normalizeParameterEditorSourceValue(
-  stepType: string,
-  parameterName: string,
-  value: unknown,
-): unknown {
-  if (
-    isLLMPromptInstructionParameter(stepType, parameterName) &&
-    value !== null &&
-    typeof value === 'object'
-  ) {
-    return '';
-  }
-
-  return value;
-}
-
-function normalizePrimitiveParameterDescriptors(
-  stepType: string,
-  parameters: readonly WorkflowPrimitiveDescriptor['parameters'][number][],
-): WorkflowPrimitiveDescriptor['parameters'][number][] {
-  const nextParameters: WorkflowPrimitiveDescriptor['parameters'][number][] = [];
-  const seenParameterNames = new Set<string>();
-
-  for (const parameter of parameters) {
-    const normalizedParameter = normalizePrimitiveParameterDescriptor(
-      stepType,
-      parameter,
-    );
-    const normalizedName = normalizedParameter.name.trim().toLowerCase();
-    if (!normalizedName || seenParameterNames.has(normalizedName)) {
-      continue;
-    }
-
-    seenParameterNames.add(normalizedName);
-    nextParameters.push(normalizedParameter);
-  }
-
-  return nextParameters;
-}
-
-function formatParameterEditorValue(value: unknown): string {
-  if (value === null || value === undefined) {
-    return '';
-  }
-
-  if (typeof value === 'string') {
-    return value;
-  }
-
-  if (
-    typeof value === 'number' ||
-    typeof value === 'boolean'
-  ) {
-    return String(value);
-  }
-
-  return JSON.stringify(value, null, 2);
-}
-
-function coerceParameterEditorValue(
-  rawValue: string,
-  parameterType: string,
-): unknown {
-  const trimmed = rawValue.trim();
-  const normalizedType = parameterType.trim().toLowerCase();
-
-  if (!trimmed) {
-    return '';
-  }
-
-  if (
-    normalizedType === 'bool' ||
-    normalizedType === 'boolean'
-  ) {
-    return trimmed.toLowerCase() === 'true';
-  }
-
-  if (
-    normalizedType === 'number' ||
-    normalizedType === 'int' ||
-    normalizedType === 'int32' ||
-    normalizedType === 'int64' ||
-    normalizedType === 'float' ||
-    normalizedType === 'double'
-  ) {
-    const parsed = Number(trimmed);
-    return Number.isFinite(parsed) ? parsed : trimmed;
-  }
-
-  if (
-    (normalizedType === 'json' ||
-      normalizedType === 'object' ||
-      normalizedType === 'array' ||
-      normalizedType === 'map') &&
-    ((trimmed.startsWith('{') && trimmed.endsWith('}')) ||
-      (trimmed.startsWith('[') && trimmed.endsWith(']')))
-  ) {
-    try {
-      return JSON.parse(trimmed);
-    } catch {
-      return trimmed;
-    }
-  }
-
-  return trimmed;
-}
-
-function updateStepDraftParameterValue(
-  draft: StudioStepInspectorDraft,
-  parameterName: string,
-  parameterType: string,
-  rawValue: string,
-): StudioStepInspectorDraft {
-  const resolvedParameterName = resolveStepParameterName(draft.type, parameterName);
-  const nextParameters = normalizeStepParametersForType(
-    draft.type,
-    tryParseStepParameters(draft.parametersText) ?? {},
-  );
-  const trimmed = rawValue.trim();
-
-  if (!trimmed) {
-    delete nextParameters[resolvedParameterName];
-  } else {
-    nextParameters[resolvedParameterName] = coerceParameterEditorValue(
-      rawValue,
-      parameterType,
-    );
-  }
-
-  return {
-    ...draft,
-    parametersText: JSON.stringify(nextParameters, null, 2),
-  };
-}
-
 function areStepInspectorDraftsEqual(
   left: StudioStepInspectorDraft | null,
   right: StudioStepInspectorDraft | null,
@@ -1196,31 +991,28 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
   );
   const selectedPrimitiveDescriptor = React.useMemo(
     () =>
-      runtimePrimitives.find((primitive) => {
-        const selectedKindDescriptor = stepDraft?.type || selectedStep?.type || '';
-        if (primitive.name.trim().toLowerCase() === selectedKindDescriptor.trim().toLowerCase()) {
-          return true;
-        }
-
-        return primitive.aliases.some(
-          (alias) => alias.trim().toLowerCase() === selectedKindDescriptor.trim().toLowerCase(),
-        );
-      }) ?? null,
+      findNodeConfigPrimitiveDescriptor(
+        runtimePrimitives,
+        stepDraft?.type || selectedStep?.type || '',
+      ),
     [runtimePrimitives, selectedStep?.type, stepDraft?.type],
   );
-  const selectedPrimitiveParameters = React.useMemo(
-    () =>
-      normalizePrimitiveParameterDescriptors(
-        stepDraft?.type || selectedStep?.type || '',
-        selectedPrimitiveDescriptor?.parameters ?? [],
-      ),
-    [selectedPrimitiveDescriptor, selectedStep?.type, stepDraft?.type],
-  );
-  const parsedStepParameters = React.useMemo(
+  const stepParameterConfig = React.useMemo(
     () =>
       stepDraft
-        ? tryParseStepParameters(stepDraft.parametersText)
+        ? buildNodeConfigFields({
+            nodeType: stepDraft.type,
+            parametersText: stepDraft.parametersText,
+            primitiveDescriptor: selectedPrimitiveDescriptor,
+          })
         : null,
+    [selectedPrimitiveDescriptor, stepDraft],
+  );
+  const stepParameterDraftError = React.useMemo(
+    () =>
+      stepDraft
+        ? validateNodeConfigParametersText(stepDraft.parametersText)
+        : '',
     [stepDraft],
   );
 
@@ -1258,6 +1050,14 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
     }
 
     const currentStepDraft = stepDraftRef.current;
+    const currentParameterError = currentStepDraft
+      ? validateNodeConfigParametersText(currentStepDraft.parametersText)
+      : '';
+    if (currentParameterError) {
+      setStepMutationError(currentParameterError);
+      void message.error(currentParameterError);
+      return;
+    }
 
     if (!scopeId) {
       const visibleMessage = 'Resolve the current workspace before running the workflow draft.';
@@ -1382,6 +1182,15 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
       return;
     }
 
+    const currentParameterError = validateNodeConfigParametersText(
+      currentStepDraft.parametersText,
+    );
+    if (currentParameterError) {
+      setStepMutationError(currentParameterError);
+      void message.error(currentParameterError);
+      return;
+    }
+
     stepMutationPendingRef.current = true;
     setStepMutationPending('apply');
     setStepMutationError('');
@@ -1399,6 +1208,15 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
 
   const handleSaveDraft = React.useCallback(() => {
     const currentStepDraft = stepDraftRef.current;
+    const currentParameterError = currentStepDraft
+      ? validateNodeConfigParametersText(currentStepDraft.parametersText)
+      : '';
+    if (currentParameterError) {
+      setStepMutationError(currentParameterError);
+      void message.error(currentParameterError);
+      return;
+    }
+
     onSaveDraft(
       currentStepDraft &&
         selectedStepDraftSeed &&
@@ -1508,7 +1326,7 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
           <Space wrap size={[8, 8]}>
             <Button
               className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
-              disabled={!canSaveWorkflow}
+              disabled={!canSaveWorkflow || Boolean(stepParameterDraftError)}
               loading={savePending}
               onClick={handleSaveDraft}
             >
@@ -1775,70 +1593,78 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
                 </div>
                 <div style={{ ...workflowFieldStyle, gridColumn: '1 / -1' }}>
                   <div style={workflowSectionHeadingStyle}>{t("pages.studio.studiobuildpanels.parameters.2", "Parameters")}</div>
-                  {selectedPrimitiveParameters.length ? (
+                  {stepParameterConfig?.parseError ? (
+                    <Alert
+                      message={stepParameterConfig.parseError}
+                      showIcon
+                      type="error"
+                    />
+                  ) : null}
+                  {stepParameterConfig?.fields.length ? (
                     <div style={{ display: 'grid', gap: 10 }}>
-                      {selectedPrimitiveParameters.map((parameter) => {
-                        const parameterDisplayLabel = getParameterDisplayLabel(
-                          stepDraft.type,
-                          parameter,
-                        );
-                        const parameterAriaLabel = `Parameter ${parameterDisplayLabel}`;
-                        const parameterPlaceholder = getParameterPlaceholder(
-                          stepDraft.type,
-                          parameter,
-                        );
-                        const parameterDescription = getParameterDisplayDescription(
-                          stepDraft.type,
-                          parameter,
-                        );
-                        const parameterValue = normalizeParameterEditorSourceValue(
-                          stepDraft.type,
-                          parameter.name,
-                          readStepParameterValue(
-                            parsedStepParameters,
-                            stepDraft.type,
-                            parameter.name,
-                          ),
-                        );
-                        const currentValue = formatParameterEditorValue(
-                          parameterValue ??
-                            (shouldUseParameterDefault(stepDraft.type, parameter)
-                              ? parameter.default
-                              : ''),
-                        );
-
+                      {stepParameterConfig.fields.map((field) => {
+                        const parameterAriaLabel = `Parameter ${field.label}`;
+                        const inputId = `workflow-step-parameter-${field.name}`;
                         return (
                           <div
-                            key={parameter.name}
+                            key={field.name}
                             style={workflowFieldStyle}
                           >
                             <label
-                              htmlFor={`workflow-step-parameter-${parameter.name}`}
+                              htmlFor={inputId}
                               style={workflowFieldLabelStyle}
                             >
-                              {parameterDisplayLabel}
-                              {parameter.required ? ' *' : ''}
+                              {field.label}
+                              {field.required ? ' *' : ''}
                             </label>
-                            {parameter.enumValues.length > 0 ? (
+                            {field.kind === 'select' ? (
                               <Select
-                                allowClear={!parameter.required}
+                                allowClear={!field.required}
                                 aria-label={parameterAriaLabel}
-                                id={`workflow-step-parameter-${parameter.name}`}
-                                options={parameter.enumValues.map((value) => ({
-                                  label: value,
-                                  value,
+                                id={inputId}
+                                options={field.options.map((option) => ({
+                                  label: option.label,
+                                  value: option.value,
                                 }))}
-                                placeholder={parameterPlaceholder}
-                                value={currentValue || undefined}
+                                placeholder={field.placeholder}
+                                value={field.value || undefined}
                                 onChange={(value) =>
                                   updateStepDraft((current) =>
                                     current
-                                      ? updateStepDraftParameterValue(
-                                          current,
-                                          parameter.name,
-                                          parameter.type,
-                                          String(value || ''),
-                                        )
+                                      ? {
+                                          ...current,
+                                          parametersText:
+                                            updateNodeConfigFieldParametersText({
+                                              field,
+                                              nodeType: current.type,
+                                              parametersText: current.parametersText,
+                                              rawValue: String(value || ''),
+                                            }),
+                                        }
+                                      : current,
+                                  )
+                                }
+                              />
+                            ) : field.kind === 'json' ? (
+                              <Input.TextArea
+                                aria-label={parameterAriaLabel}
+                                autoSize={{ minRows: 3, maxRows: 8 }}
+                                id={inputId}
+                                placeholder={field.placeholder}
+                                value={field.value}
+                                onChange={(event) =>
+                                  updateStepDraft((current) =>
+                                    current
+                                      ? {
+                                          ...current,
+                                          parametersText:
+                                            updateNodeConfigFieldParametersText({
+                                              field,
+                                              nodeType: current.type,
+                                              parametersText: current.parametersText,
+                                              rawValue: event.target.value,
+                                            }),
+                                        }
                                       : current,
                                   )
                                 }
@@ -1846,25 +1672,29 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
                             ) : (
                               <Input
                                 aria-label={parameterAriaLabel}
-                                id={`workflow-step-parameter-${parameter.name}`}
-                                placeholder={parameterPlaceholder}
-                                value={currentValue}
+                                id={inputId}
+                                placeholder={field.placeholder}
+                                value={field.value}
                                 onChange={(event) =>
                                   updateStepDraft((current) =>
                                     current
-                                      ? updateStepDraftParameterValue(
-                                          current,
-                                          parameter.name,
-                                          parameter.type,
-                                          event.target.value,
-                                        )
+                                      ? {
+                                          ...current,
+                                          parametersText:
+                                            updateNodeConfigFieldParametersText({
+                                              field,
+                                              nodeType: current.type,
+                                              parametersText: current.parametersText,
+                                              rawValue: event.target.value,
+                                            }),
+                                        }
                                       : current,
                                   )
                                 }
                               />
                             )}
                             <div style={workflowInlineMetaStyle}>
-                              {parameterDescription}
+                              {field.description}
                             </div>
                           </div>
                         );
@@ -1937,7 +1767,12 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
                   {t("pages.studio.studiobuildpanels.delete.step.2", "Delete step")}</Button>
                 <Button
                   className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
-                  disabled={!selectedStepId || !stepDraft || Boolean(stepMutationPending)}
+                  disabled={
+                    !selectedStepId ||
+                    !stepDraft ||
+                    Boolean(stepMutationPending) ||
+                    Boolean(stepParameterDraftError)
+                  }
                   loading={stepMutationPending === 'apply'}
                   type="primary"
                   onClick={() => void handleApplyStepChanges()}
@@ -2000,7 +1835,11 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
             icon={<PlayCircleOutlined />}
             loading={runState.status === 'running'}
             type="primary"
-            disabled={Boolean(dryRunBlockedReason?.trim()) || runState.status === 'running'}
+            disabled={
+              Boolean(dryRunBlockedReason?.trim()) ||
+              runState.status === 'running' ||
+              Boolean(stepParameterDraftError)
+            }
             onClick={() => void handleRun()}
           >
             {t("pages.studio.studiobuildpanels.run.4", "Run")}</Button>

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioInspectorPane.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioInspectorPane.test.tsx
@@ -134,6 +134,7 @@ describe('StudioInspectorPane', () => {
 
   it('renders step summary cards and keeps node actions wired', () => {
     const onApplyNodeChanges = jest.fn();
+    const onChangeNodeInspectorDraft = jest.fn();
 
     render(
       <StudioInspectorPane
@@ -149,6 +150,7 @@ describe('StudioInspectorPane', () => {
             branchesText: '{\n  "retry": "retry_step"\n}',
             parametersText: '{\n  "connector": "search"\n}',
           },
+          onChangeNodeInspectorDraft,
           onApplyNodeChanges,
         })}
       />,
@@ -162,5 +164,44 @@ describe('StudioInspectorPane', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Apply node changes' }));
 
     expect(onApplyNodeChanges).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(screen.getByLabelText('Parameter Operation'), {
+      target: { value: 'query' },
+    });
+    expect(onChangeNodeInspectorDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parametersText: expect.stringContaining('"operation": "query"'),
+      }),
+    );
+  });
+
+  it('blocks node apply when raw parameter JSON is invalid', () => {
+    const onApplyNodeChanges = jest.fn();
+
+    render(
+      <StudioInspectorPane
+        {...createBaseProps({
+          inspectorTab: 'node',
+          selectedGraphStep: workflowStep,
+          nodeInspectorDraft: {
+            kind: 'step',
+            id: 'review_step',
+            type: 'connector_call',
+            targetRole: 'assistant',
+            next: 'publish_step',
+            branchesText: '{\n  "retry": "retry_step"\n}',
+            parametersText: '{ "connector": ',
+          },
+          onApplyNodeChanges,
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Unexpected end of JSON input')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Apply node changes' })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply node changes' }));
+
+    expect(onApplyNodeChanges).not.toHaveBeenCalled();
   });
 });

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioInspectorPane.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioInspectorPane.tsx
@@ -1,4 +1,4 @@
-import { Button, Empty, Input, Select, Space, Tag, Typography } from 'antd';
+import { Alert, Button, Empty, Input, Select, Space, Tag, Typography } from 'antd';
 import React from 'react';
 import type { StudioNodeInspectorDraft } from '@/shared/studio/document';
 import {
@@ -11,6 +11,12 @@ import type {
   StudioRoleDefinition,
   StudioValidationFinding,
 } from '@/shared/studio/models';
+import {
+  buildNodeConfigFields,
+  updateNodeConfigFieldParametersText,
+  validateNodeConfigParametersText,
+  type NodeConfigField,
+} from '@/shared/studio/nodeConfigFields';
 import {
   cardListActionStyle,
   cardListHeaderStyle,
@@ -121,6 +127,11 @@ type NoticePanelProps = {
   type?: 'default' | 'info' | 'success' | 'warning' | 'error';
 };
 
+type NodeConfigFieldsEditorProps = {
+  readonly fields: readonly NodeConfigField[];
+  readonly onChangeFieldValue: (field: NodeConfigField, value: string) => void;
+};
+
 const summaryMetricToneMap: Record<
   NonNullable<SummaryMetricProps['tone']>,
   { color: string }
@@ -161,6 +172,12 @@ const yamlEditorStyle: React.CSSProperties = {
     "'SFMono-Regular', 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace",
   fontSize: 13,
   lineHeight: 1.5,
+};
+
+const fieldDescriptionStyle: React.CSSProperties = {
+  color: 'var(--ant-color-text-secondary)',
+  fontSize: 12,
+  lineHeight: '18px',
 };
 
 function hasValidationError(findings: StudioValidationFinding[]): boolean {
@@ -329,6 +346,75 @@ const NoticePanel: React.FC<NoticePanelProps> = ({
         {action}
       </div>
       {children}
+    </div>
+  );
+};
+
+const NodeConfigFieldsEditor: React.FC<NodeConfigFieldsEditorProps> = ({
+  fields,
+  onChangeFieldValue,
+}) => {
+  if (fields.length === 0) {
+    return (
+      <Typography.Text type="secondary">
+        {t("pages.studio.studioinspectorpane.no.structured.parameters", "No structured parameters inferred. Edit the raw JSON below.")}
+      </Typography.Text>
+    );
+  }
+
+  return (
+    <div style={formGridStyle}>
+      {fields.map((field) => {
+        const inputId = `studio-node-config-field-${field.name}`;
+        const ariaLabel = `Parameter ${field.label}`;
+
+        return (
+          <div key={field.name} style={cardStackStyle}>
+            <Typography.Text strong>
+              {field.label}
+              {field.required ? ' *' : ''}
+            </Typography.Text>
+            {field.kind === 'select' ? (
+              <Select
+                allowClear={!field.required}
+                aria-label={ariaLabel}
+                id={inputId}
+                options={field.options.map((option) => ({
+                  label: option.label,
+                  value: option.value,
+                }))}
+                placeholder={field.placeholder}
+                value={field.value || undefined}
+                onChange={(value) => onChangeFieldValue(field, String(value || ''))}
+              />
+            ) : field.kind === 'json' ? (
+              <Input.TextArea
+                aria-label={ariaLabel}
+                autoSize={{ minRows: 3, maxRows: 8 }}
+                id={inputId}
+                placeholder={field.placeholder}
+                value={field.value}
+                onChange={(event) =>
+                  onChangeFieldValue(field, event.target.value)
+                }
+              />
+            ) : (
+              <Input
+                aria-label={ariaLabel}
+                id={inputId}
+                placeholder={field.placeholder}
+                value={field.value}
+                onChange={(event) =>
+                  onChangeFieldValue(field, event.target.value)
+                }
+              />
+            )}
+            <Typography.Text style={fieldDescriptionStyle}>
+              {field.description}
+            </Typography.Text>
+          </div>
+        );
+      })}
     </div>
   );
 };
@@ -541,19 +627,56 @@ const StudioInspectorPane: React.FC<StudioInspectorPaneProps> = ({
     return items;
   }, [selectedGraphStep]);
 
+  const nodeConfigFieldSet = React.useMemo(
+    () =>
+      nodeInspectorDraft?.kind === 'step'
+        ? buildNodeConfigFields({
+            connectors,
+            nodeType: nodeInspectorDraft.type,
+            parametersText: nodeInspectorDraft.parametersText,
+          })
+        : null,
+    [connectors, nodeInspectorDraft],
+  );
+  const parameterDraftError = React.useMemo(
+    () =>
+      nodeInspectorDraft?.kind === 'step'
+        ? validateNodeConfigParametersText(nodeInspectorDraft.parametersText)
+        : '',
+    [nodeInspectorDraft],
+  );
   const selectedConnectorName = React.useMemo(() => {
-    if (nodeInspectorDraft?.kind !== 'step' || nodeInspectorDraft.type !== 'connector_call') {
+    if (!nodeConfigFieldSet?.parameters) {
       return '';
     }
 
-    try {
-      return String(
-        JSON.parse(nodeInspectorDraft.parametersText || '{}').connector || '',
-      );
-    } catch {
-      return '';
+    return String(nodeConfigFieldSet.parameters.connector || '');
+  }, [nodeConfigFieldSet]);
+  const handleApplyNodeChanges = React.useCallback(() => {
+    if (parameterDraftError) {
+      return;
     }
-  }, [nodeInspectorDraft]);
+
+    onApplyNodeChanges();
+  }, [onApplyNodeChanges, parameterDraftError]);
+  const handleChangeNodeConfigFieldValue = React.useCallback(
+    (field: NodeConfigField, value: string) => {
+      if (nodeInspectorDraft?.kind !== 'step') {
+        return;
+      }
+
+      onChangeNodeInspectorDraft({
+        ...nodeInspectorDraft,
+        parametersText: updateNodeConfigFieldParametersText({
+          field,
+          nodeType: nodeInspectorDraft.type,
+          parametersText: nodeInspectorDraft.parametersText,
+          rawValue: value,
+        }),
+      });
+    },
+    [nodeInspectorDraft, onChangeNodeInspectorDraft],
+  );
 
   const filteredSavedRoles = React.useMemo(() => {
     const keyword = roleSearch.trim().toLowerCase();
@@ -601,11 +724,9 @@ const StudioInspectorPane: React.FC<StudioInspectorPaneProps> = ({
             />
             <SummaryMetric
               label={t("pages.studio.studioinspectorpane.connector.mode", "Connector mode")}
-              tone={nodeInspectorDraft.type === 'connector_call' ? 'warning' : 'default'}
+              tone={selectedConnectorName ? 'warning' : 'default'}
               value={
-                nodeInspectorDraft.type === 'connector_call'
-                  ? selectedConnectorName || 'Pending'
-                  : 'Direct'
+                selectedConnectorName || 'Direct'
               }
             />
           </div>
@@ -726,45 +847,16 @@ const StudioInspectorPane: React.FC<StudioInspectorPaneProps> = ({
             title="Parameters"
             help="Keep runtime inputs readable and wire connector calls explicitly."
           />
-          {nodeInspectorDraft.type === 'connector_call' ? (
-            <div style={cardStackStyle}>
-              <Typography.Text strong>{t("pages.studio.studioinspectorpane.connector.3", "Connector")}</Typography.Text>
-              <Select
-                aria-label={t("pages.studio.studioinspectorpane.studio.connector.call.connector", "Studio connector call connector")}
-                allowClear
-                placeholder={t("pages.studio.studioinspectorpane.select.connector", "Select connector")}
-                value={selectedConnectorName || undefined}
-                options={connectors.map((connector) => ({
-                  label: t("pages.studio.studioinspectorpane.copy.2", "{value1} · {value2}", { value1: connector.name, value2: connector.type }),
-                  value: connector.name,
-                }))}
-                onChange={(value) => {
-                  try {
-                    const parsed = JSON.parse(nodeInspectorDraft.parametersText || '{}');
-                    onChangeNodeInspectorDraft({
-                      ...nodeInspectorDraft,
-                      parametersText: JSON.stringify(
-                        {
-                          ...(parsed && typeof parsed === 'object' ? parsed : {}),
-                          connector: value || '',
-                        },
-                        null,
-                        2,
-                      ),
-                    });
-                  } catch {
-                    onChangeNodeInspectorDraft({
-                      ...nodeInspectorDraft,
-                      parametersText: JSON.stringify(
-                        { connector: value || '' },
-                        null,
-                        2,
-                      ),
-                    });
-                  }
-                }}
-              />
-            </div>
+          <NodeConfigFieldsEditor
+            fields={nodeConfigFieldSet?.fields ?? []}
+            onChangeFieldValue={handleChangeNodeConfigFieldValue}
+          />
+          {nodeConfigFieldSet?.parseError ? (
+            <Alert
+              message={nodeConfigFieldSet.parseError}
+              showIcon
+              type="error"
+            />
           ) : null}
           <div style={cardStackStyle}>
             <Typography.Text strong>{t("pages.studio.studioinspectorpane.parameters", "Parameters")}</Typography.Text>
@@ -835,8 +927,9 @@ const StudioInspectorPane: React.FC<StudioInspectorPaneProps> = ({
           <div style={cardListActionStyle}>
             <Button
               type="primary"
+              disabled={Boolean(parameterDraftError)}
               loading={inspectorPending}
-              onClick={onApplyNodeChanges}
+              onClick={handleApplyNodeChanges}
             >
               {t("pages.studio.studioinspectorpane.apply.node.changes", "Apply node changes")}</Button>
             <Button loading={inspectorPending} onClick={onInsertStep}>

--- a/apps/aevatar-console-web/src/shared/studio/nodeConfigFields.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/nodeConfigFields.test.ts
@@ -1,0 +1,136 @@
+import {
+  buildNodeConfigFields,
+  updateNodeConfigFieldParametersText,
+  validateNodeConfigParametersText,
+} from './nodeConfigFields';
+
+describe('nodeConfigFields', () => {
+  it('adapts connector fields without requiring the renderer to know the node type', () => {
+    const fieldSet = buildNodeConfigFields({
+      connectors: [
+        {
+          enabled: true,
+          name: 'web-search',
+          retry: 0,
+          timeoutMs: 10000,
+          type: 'http',
+        },
+      ],
+      nodeType: 'connector_call',
+      parametersText: JSON.stringify({ connector: 'web-search', limit: 3 }),
+    });
+
+    expect(fieldSet.parseError).toBe('');
+    expect(fieldSet.fields.map((field) => field.name)).toEqual(
+      expect.arrayContaining(['connector', 'operation', 'limit']),
+    );
+    expect(fieldSet.fields.find((field) => field.name === 'connector')).toMatchObject({
+      kind: 'select',
+      options: [{ label: 'web-search - http', value: 'web-search' }],
+      value: 'web-search',
+    });
+    expect(fieldSet.fields.find((field) => field.name === 'limit')).toMatchObject({
+      kind: 'text',
+      value: '3',
+      valueType: 'number',
+    });
+  });
+
+  it('maps runtime prompt descriptors to prompt_prefix for llm_call', () => {
+    const fieldSet = buildNodeConfigFields({
+      nodeType: 'llm_call',
+      parametersText: JSON.stringify({ prompt: 'Legacy prompt' }),
+      primitiveDescriptor: {
+        aliases: [],
+        category: 'ai',
+        description: 'Call an LLM.',
+        exampleWorkflows: [],
+        name: 'llm_call',
+        parameters: [
+          {
+            default: '',
+            description: 'Prompt override',
+            enumValues: [],
+            name: 'prompt',
+            required: false,
+            type: 'string',
+          },
+        ],
+      },
+    });
+
+    expect(fieldSet.fields).toHaveLength(1);
+    expect(fieldSet.fields[0]).toMatchObject({
+      label: 'Prompt instruction',
+      name: 'prompt_prefix',
+      value: 'Legacy prompt',
+    });
+
+    const nextText = updateNodeConfigFieldParametersText({
+      field: fieldSet.fields[0],
+      nodeType: 'llm_call',
+      parametersText: JSON.stringify({ prompt: 'Legacy prompt' }),
+      rawValue: 'Translate the input.',
+    });
+
+    expect(JSON.parse(nextText)).toEqual({
+      prompt_prefix: 'Translate the input.',
+    });
+  });
+
+  it('infers unknown-node fields and edits object or array values through JSON fallback', () => {
+    const fieldSet = buildNodeConfigFields({
+      nodeType: 'custom_step',
+      parametersText: JSON.stringify({
+        config: { mode: 'strict' },
+        tags: ['risk'],
+      }),
+    });
+
+    expect(fieldSet.fields.find((field) => field.name === 'config')).toMatchObject({
+      kind: 'json',
+      value: '{\n  "mode": "strict"\n}',
+      valueType: 'object',
+    });
+    expect(fieldSet.fields.find((field) => field.name === 'tags')).toMatchObject({
+      kind: 'json',
+      value: '[\n  "risk"\n]',
+      valueType: 'array',
+    });
+
+    const nextText = updateNodeConfigFieldParametersText({
+      field: fieldSet.fields.find((field) => field.name === 'config')!,
+      nodeType: 'custom_step',
+      parametersText: JSON.stringify({
+        config: { mode: 'strict' },
+        tags: ['risk'],
+      }),
+      rawValue: '{\n  "mode": "relaxed"\n}',
+    });
+
+    expect(JSON.parse(nextText)).toEqual({
+      config: { mode: 'relaxed' },
+      tags: ['risk'],
+    });
+  });
+
+  it('keeps invalid object edits in parametersText so the existing apply path blocks them', () => {
+    const fieldSet = buildNodeConfigFields({
+      nodeType: 'custom_step',
+      parametersText: JSON.stringify({ config: { mode: 'strict' } }),
+    });
+    const configField = fieldSet.fields.find((field) => field.name === 'config');
+    if (!configField) {
+      throw new Error('Expected config field.');
+    }
+
+    const nextText = updateNodeConfigFieldParametersText({
+      field: configField,
+      nodeType: 'custom_step',
+      parametersText: JSON.stringify({ config: { mode: 'strict' } }),
+      rawValue: '{ "mode": ',
+    });
+
+    expect(validateNodeConfigParametersText(nextText)).toBeTruthy();
+  });
+});

--- a/apps/aevatar-console-web/src/shared/studio/nodeConfigFields.ts
+++ b/apps/aevatar-console-web/src/shared/studio/nodeConfigFields.ts
@@ -1,0 +1,595 @@
+import type { WorkflowPrimitiveDescriptor } from '@/shared/models/runtime/query';
+import {
+  normalizeStepParametersForType,
+  parseInspectorParameters,
+  readStepParameterValue,
+  resolveStepParameterName,
+} from './document';
+import type { StudioConnectorDefinition } from './models';
+
+export type NodeConfigFieldKind = 'json' | 'select' | 'text';
+
+export type NodeConfigFieldOption = {
+  readonly label: string;
+  readonly value: string;
+};
+
+export type NodeConfigField = {
+  readonly name: string;
+  readonly label: string;
+  readonly description: string;
+  readonly kind: NodeConfigFieldKind;
+  readonly placeholder: string;
+  readonly required: boolean;
+  readonly value: string;
+  readonly valueType: string;
+  readonly options: readonly NodeConfigFieldOption[];
+};
+
+export type NodeConfigFieldSet = {
+  readonly fields: readonly NodeConfigField[];
+  readonly parameters: Record<string, unknown> | null;
+  readonly parseError: string;
+};
+
+type NodeConfigFieldSource = {
+  readonly name: string;
+  readonly label?: string;
+  readonly description?: string;
+  readonly default?: string;
+  readonly enumValues?: readonly string[];
+  readonly kind?: NodeConfigFieldKind;
+  readonly placeholder?: string;
+  readonly required?: boolean;
+  readonly type?: string;
+};
+
+const LLM_CALL_STEP_TYPE = 'llm_call';
+const PROMPT_PREFIX_PARAMETER = 'prompt_prefix';
+
+const CONNECTOR_CALL_FIELDS: readonly NodeConfigFieldSource[] = [
+  {
+    name: 'connector',
+    label: 'Connector',
+    description: 'Connector name passed to the runtime.',
+    kind: 'select',
+    placeholder: 'Select connector',
+    type: 'string',
+  },
+  {
+    name: 'operation',
+    label: 'Operation',
+    description: 'Optional operation name for connector implementations that expose multiple operations.',
+    type: 'string',
+  },
+  {
+    name: 'path',
+    label: 'Path',
+    description: 'Optional request path or connector-specific target.',
+    type: 'string',
+  },
+  {
+    name: 'method',
+    label: 'Method',
+    description: 'HTTP method or connector-specific verb.',
+    enumValues: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
+    type: 'string',
+    default: 'POST',
+  },
+  {
+    name: 'timeout_ms',
+    label: 'Timeout ms',
+    description: 'Connector timeout in milliseconds.',
+    type: 'number',
+    default: '10000',
+  },
+  {
+    name: 'retry',
+    label: 'Retry',
+    description: 'Retry count for transient connector failures.',
+    type: 'number',
+    default: '0',
+  },
+  {
+    name: 'on_error',
+    label: 'On error',
+    description: 'Failure behavior when the connector call cannot complete.',
+    enumValues: ['fail', 'continue'],
+    type: 'string',
+    default: 'fail',
+  },
+];
+
+const LLM_CALL_FIELDS: readonly NodeConfigFieldSource[] = [
+  {
+    name: PROMPT_PREFIX_PARAMETER,
+    label: 'Prompt instruction',
+    description: 'Instruction added before each workflow run input reaches the LLM.',
+    placeholder: 'e.g. Translate the user input to Japanese',
+    type: 'string',
+  },
+];
+
+function normalizeString(value: unknown): string {
+  return String(value ?? '').trim();
+}
+
+function normalizeStepType(value: unknown): string {
+  return normalizeString(value).toLowerCase();
+}
+
+function formatFieldValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  return JSON.stringify(value, null, 2);
+}
+
+function normalizeValueType(value: string | null | undefined): string {
+  return normalizeString(value || 'string').toLowerCase();
+}
+
+function inferFieldKind(
+  value: unknown,
+  source: NodeConfigFieldSource,
+): NodeConfigFieldKind {
+  if (source.kind) {
+    return source.kind;
+  }
+
+  if ((source.enumValues ?? []).length > 0) {
+    return 'select';
+  }
+
+  if (Array.isArray(value) || (value !== null && typeof value === 'object')) {
+    return 'json';
+  }
+
+  const valueType = normalizeValueType(source.type);
+  return valueType === 'json' ||
+    valueType === 'object' ||
+    valueType === 'array' ||
+    valueType === 'map'
+    ? 'json'
+    : 'text';
+}
+
+function formatLabel(name: string): string {
+  return name
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join(' ');
+}
+
+function isLLMPromptInstructionParameter(
+  stepType: string,
+  parameterName: string,
+): boolean {
+  return (
+    normalizeStepType(stepType) === LLM_CALL_STEP_TYPE &&
+    resolveStepParameterName(stepType, parameterName) === PROMPT_PREFIX_PARAMETER
+  );
+}
+
+function shouldUseParameterDefault(
+  stepType: string,
+  parameterName: string,
+): boolean {
+  return !isLLMPromptInstructionParameter(stepType, parameterName);
+}
+
+function normalizeFieldSourceName(
+  stepType: string,
+  source: NodeConfigFieldSource,
+): NodeConfigFieldSource {
+  const resolvedName = resolveStepParameterName(stepType, source.name);
+  if (resolvedName === source.name) {
+    return source;
+  }
+
+  return {
+    ...source,
+    name: resolvedName,
+  };
+}
+
+function createField(
+  stepType: string,
+  parameters: Record<string, unknown>,
+  source: NodeConfigFieldSource,
+): NodeConfigField | null {
+  const normalizedSource = normalizeFieldSourceName(stepType, source);
+  const name = normalizeString(normalizedSource.name);
+  if (!name) {
+    return null;
+  }
+
+  const rawValue = readStepParameterValue(parameters, stepType, name);
+  const fallbackDefault = shouldUseParameterDefault(stepType, name)
+    ? normalizedSource.default
+    : '';
+  const value = rawValue ?? fallbackDefault ?? '';
+  const options = (normalizedSource.enumValues ?? [])
+    .map((entry) => normalizeString(entry))
+    .filter(Boolean)
+    .map((entry) => ({
+      label: entry,
+      value: entry,
+    }));
+
+  return {
+    name,
+    label:
+      isLLMPromptInstructionParameter(stepType, name)
+        ? 'Prompt instruction'
+        : normalizeString(normalizedSource.label) || formatLabel(name),
+    description:
+      isLLMPromptInstructionParameter(stepType, name)
+        ? 'Instruction added before each workflow run input reaches the LLM.'
+        : normalizeString(normalizedSource.description) ||
+          `Type: ${normalizeValueType(normalizedSource.type)}`,
+    kind: inferFieldKind(value, {
+      ...normalizedSource,
+      enumValues: options.map((option) => option.value),
+    }),
+    placeholder:
+      isLLMPromptInstructionParameter(stepType, name)
+        ? 'e.g. Translate the user input to Japanese'
+        : normalizeString(normalizedSource.placeholder) ||
+          normalizeString(normalizedSource.default) ||
+          normalizeValueType(normalizedSource.type) ||
+          'Value',
+    required: Boolean(normalizedSource.required),
+    value: formatFieldValue(value),
+    valueType: normalizeValueType(normalizedSource.type),
+    options,
+  };
+}
+
+function createInferredFieldSource(
+  name: string,
+  value: unknown,
+): NodeConfigFieldSource {
+  if (Array.isArray(value)) {
+    return {
+      name,
+      label: formatLabel(name),
+      description: 'Array value edited as JSON.',
+      kind: 'json',
+      type: 'array',
+    };
+  }
+
+  if (value !== null && typeof value === 'object') {
+    return {
+      name,
+      label: formatLabel(name),
+      description: 'Object value edited as JSON.',
+      kind: 'json',
+      type: 'object',
+    };
+  }
+
+  if (typeof value === 'boolean') {
+    return {
+      name,
+      label: formatLabel(name),
+      description: 'Boolean value.',
+      enumValues: ['true', 'false'],
+      type: 'boolean',
+    };
+  }
+
+  if (typeof value === 'number') {
+    return {
+      name,
+      label: formatLabel(name),
+      description: 'Numeric value.',
+      type: 'number',
+    };
+  }
+
+  return {
+    name,
+    label: formatLabel(name),
+    description: 'String value.',
+    type: 'string',
+  };
+}
+
+function createPrimitiveFieldSources(
+  stepType: string,
+  primitiveDescriptor: WorkflowPrimitiveDescriptor,
+): NodeConfigFieldSource[] {
+  return primitiveDescriptor.parameters.map((parameter) =>
+    normalizeFieldSourceName(stepType, {
+      name: parameter.name,
+      label: parameter.name,
+      description: parameter.description,
+      default: parameter.default,
+      enumValues: parameter.enumValues,
+      required: parameter.required,
+      type: parameter.type,
+    }),
+  );
+}
+
+function createKnownFieldSources(
+  stepType: string,
+  primitiveDescriptor?: WorkflowPrimitiveDescriptor | null,
+): NodeConfigFieldSource[] {
+  if (primitiveDescriptor) {
+    return createPrimitiveFieldSources(stepType, primitiveDescriptor);
+  }
+
+  switch (normalizeStepType(stepType)) {
+    case 'connector_call':
+      return [...CONNECTOR_CALL_FIELDS];
+    case LLM_CALL_STEP_TYPE:
+      return [...LLM_CALL_FIELDS];
+    default:
+      return [];
+  }
+}
+
+function createConnectorOptions(
+  connectors: readonly StudioConnectorDefinition[],
+): NodeConfigFieldOption[] {
+  return connectors
+    .map((connector) => {
+      const name = normalizeString(connector.name);
+      if (!name) {
+        return null;
+      }
+
+      const type = normalizeString(connector.type);
+      return {
+        label: type ? `${name} - ${type}` : name,
+        value: name,
+      };
+    })
+    .filter((entry): entry is NodeConfigFieldOption => Boolean(entry));
+}
+
+function withConnectorOptions(
+  fields: readonly NodeConfigField[],
+  connectors: readonly StudioConnectorDefinition[],
+): NodeConfigField[] {
+  const connectorOptions = createConnectorOptions(connectors);
+  if (connectorOptions.length === 0) {
+    return [...fields];
+  }
+
+  return fields.map((field) =>
+    field.name === 'connector'
+      ? {
+          ...field,
+          kind: 'select',
+          options: connectorOptions,
+          placeholder: field.placeholder || 'Select connector',
+        }
+      : field,
+  );
+}
+
+export function findNodeConfigPrimitiveDescriptor(
+  primitives: readonly WorkflowPrimitiveDescriptor[],
+  stepType: string,
+): WorkflowPrimitiveDescriptor | null {
+  const normalizedStepType = normalizeStepType(stepType);
+  return (
+    primitives.find((primitive) => {
+      if (normalizeStepType(primitive.name) === normalizedStepType) {
+        return true;
+      }
+
+      return primitive.aliases.some(
+        (alias) => normalizeStepType(alias) === normalizedStepType,
+      );
+    }) ?? null
+  );
+}
+
+export function validateNodeConfigParametersText(value: string): string {
+  try {
+    parseInspectorParameters(value);
+    return '';
+  } catch (error) {
+    return error instanceof Error
+      ? error.message
+      : 'Step parameters must be a JSON object.';
+  }
+}
+
+export function buildNodeConfigFields(options: {
+  readonly connectors?: readonly StudioConnectorDefinition[];
+  readonly nodeType: string;
+  readonly parametersText: string;
+  readonly primitiveDescriptor?: WorkflowPrimitiveDescriptor | null;
+}): NodeConfigFieldSet {
+  let parameters: Record<string, unknown>;
+  try {
+    parameters = normalizeStepParametersForType(
+      options.nodeType,
+      parseInspectorParameters(options.parametersText),
+    );
+  } catch (error) {
+    return {
+      fields: [],
+      parameters: null,
+      parseError:
+        error instanceof Error
+          ? error.message
+          : 'Step parameters must be a JSON object.',
+    };
+  }
+
+  const fieldSources = createKnownFieldSources(
+    options.nodeType,
+    options.primitiveDescriptor,
+  );
+  const seenNames = new Set<string>();
+  const fields: NodeConfigField[] = [];
+
+  for (const source of fieldSources) {
+    const field = createField(options.nodeType, parameters, source);
+    if (!field) {
+      continue;
+    }
+
+    const normalizedName = normalizeStepType(field.name);
+    if (seenNames.has(normalizedName)) {
+      continue;
+    }
+
+    seenNames.add(normalizedName);
+    fields.push(field);
+  }
+
+  for (const [name, value] of Object.entries(parameters)) {
+    const resolvedName = resolveStepParameterName(options.nodeType, name);
+    const normalizedName = normalizeStepType(resolvedName);
+    if (!normalizedName || seenNames.has(normalizedName)) {
+      continue;
+    }
+
+    const field = createField(
+      options.nodeType,
+      parameters,
+      createInferredFieldSource(resolvedName, value),
+    );
+    if (!field) {
+      continue;
+    }
+
+    seenNames.add(normalizedName);
+    fields.push(field);
+  }
+
+  return {
+    fields: withConnectorOptions(fields, options.connectors ?? []),
+    parameters,
+    parseError: '',
+  };
+}
+
+function coerceFieldValue(field: NodeConfigField, rawValue: string): unknown {
+  const trimmed = rawValue.trim();
+  const valueType = normalizeValueType(field.valueType);
+
+  if (!trimmed) {
+    return '';
+  }
+
+  if (field.kind === 'json') {
+    return JSON.parse(trimmed) as unknown;
+  }
+
+  if (valueType === 'bool' || valueType === 'boolean') {
+    return trimmed.toLowerCase() === 'true';
+  }
+
+  if (
+    valueType === 'number' ||
+    valueType === 'int' ||
+    valueType === 'int32' ||
+    valueType === 'int64' ||
+    valueType === 'float' ||
+    valueType === 'double'
+  ) {
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : trimmed;
+  }
+
+  if (
+    (valueType === 'json' ||
+      valueType === 'object' ||
+      valueType === 'array' ||
+      valueType === 'map') &&
+    ((trimmed.startsWith('{') && trimmed.endsWith('}')) ||
+      (trimmed.startsWith('[') && trimmed.endsWith(']')))
+  ) {
+    try {
+      return JSON.parse(trimmed) as unknown;
+    } catch {
+      return trimmed;
+    }
+  }
+
+  return trimmed;
+}
+
+function indentMultiline(value: string): string {
+  return value.replace(/\n/g, '\n  ');
+}
+
+function formatParametersWithRawJsonField(
+  parameters: Record<string, unknown>,
+  fieldName: string,
+  rawValue: string,
+): string {
+  const entries = Object.entries(parameters)
+    .filter(([name]) => name !== fieldName)
+    .map(([name, value]) =>
+      `${JSON.stringify(name)}: ${indentMultiline(JSON.stringify(value, null, 2))}`,
+    );
+  const normalizedRawValue = rawValue.trim() || 'null';
+  entries.push(`${JSON.stringify(fieldName)}: ${indentMultiline(normalizedRawValue)}`);
+
+  if (entries.length === 0) {
+    return '{}';
+  }
+
+  return `{\n  ${entries.join(',\n  ')}\n}`;
+}
+
+export function updateNodeConfigFieldParametersText(options: {
+  readonly field: NodeConfigField;
+  readonly nodeType: string;
+  readonly parametersText: string;
+  readonly rawValue: string;
+}): string {
+  const parameters = normalizeStepParametersForType(
+    options.nodeType,
+    parseInspectorParameters(options.parametersText),
+  );
+  const nextParameters = { ...parameters };
+  const trimmed = options.rawValue.trim();
+
+  if (!trimmed) {
+    delete nextParameters[options.field.name];
+    return JSON.stringify(nextParameters, null, 2);
+  }
+
+  if (options.field.kind === 'json') {
+    try {
+      nextParameters[options.field.name] = coerceFieldValue(
+        options.field,
+        options.rawValue,
+      );
+    } catch {
+      return formatParametersWithRawJsonField(
+        nextParameters,
+        options.field.name,
+        options.rawValue,
+      );
+    }
+  } else {
+    nextParameters[options.field.name] = coerceFieldValue(
+      options.field,
+      options.rawValue,
+    );
+  }
+
+  return JSON.stringify(nextParameters, null, 2);
+}


### PR DESCRIPTION
## Changed files
- `apps/aevatar-console-web/src/shared/studio/nodeConfigFields.ts` / `.test.ts`: 新增前端本地 `NodeConfigField` 字段主线，统一 known adapter、unknown 参数推断、对象/数组 JSON fallback 与 `parametersText` 写回。
- `StudioInspectorPane.tsx` / `.test.tsx`: Inspector 参数区改为只消费字段描述；不再按 `connector_call` 写专用 JSON parse / Select 分支，非法参数 JSON 阻断 Apply。
- `StudioBuildPanels.tsx` / `.test.tsx`: Build 面板复用同一字段主线，删除旧 guided parameter helper；Apply、Save draft、Run 共用参数错误态。

## Test results
- `npx --yes pnpm@10.2.1 --dir apps/aevatar-console-web tsc`: passed。
- `npx --yes pnpm@10.2.1 --dir apps/aevatar-console-web test --runInBand -- StudioInspectorPane StudioBuildPanels NodeConfigField nodeConfigFields`: passed，3 suites / 31 tests。
- `bash tools/ci/test_stability_guards.sh`: passed。
- `bash -lc "dotnet build aevatar.slnx --nologo"`: passed，0 errors。
- `bash tools/ci/architecture_guards.sh`: passed。

## Deviations
- `HOST_REFACTOR_COMMENT_POLICY` 为空，按规则归一化为 `none`，未新增源码 Refactor 历史注释。
- 当前 worktree 没有 `apps/aevatar-console-web/src/pages/team-member-workflow-studio/`，未创建该目录。
- 为了匹配项目 `packageManager`，前端验证使用 `npx --yes pnpm@10.2.1` 调用项目脚本；验证后已删除临时 `node_modules`。

Closes #1933

⟦AI:AUTO-LOOP⟧
