### PR TITLE
Fix Teams runtime run sampling

### DIFF
--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -1289,6 +1289,71 @@ describe("TeamDetailPage", () => {
     expect(scopeRuntimeApi.listMemberRuns).not.toHaveBeenCalled();
   });
 
+  it("does not sample runtime runs while browsing members with member-owned service ids", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1/t-alpha?tab=members",
+    );
+    (studioApi.getTeam as jest.Mock).mockResolvedValueOnce({
+      ...mockCreateTeamSummary(),
+      displayName: "test09",
+      entryMemberId: "member-untitled-member1",
+      memberCount: 5,
+    });
+    (studioApi.listTeamMembers as jest.Mock).mockResolvedValueOnce({
+      scopeId: "scope-1",
+      members: [
+        {
+          memberId: "member-untitled-member1",
+          scopeId: "scope-1",
+          teamId: "t-alpha",
+          displayName: "Untitled member1",
+          description: "Member page should only render roster facts",
+          implementationKind: "workflow",
+          lifecycleStage: "bind_ready",
+          publishedServiceId: "member-untitled-member1",
+          lastBoundRevisionId: "rev-member-1",
+          createdAt: "2026-04-09T08:00:00Z",
+          updatedAt: "2026-04-09T09:00:00Z",
+        },
+      ],
+      nextPageToken: null,
+    });
+    (scopeRuntimeApi.listServices as jest.Mock).mockResolvedValueOnce([
+      {
+        serviceKey: "scope-1:member-untitled-member1",
+        tenantId: "scope-1",
+        appId: "default",
+        namespace: "default",
+        serviceId: "member-untitled-member1",
+        displayName: "Untitled member1 runtime",
+        defaultServingRevisionId: "rev-member-1",
+        activeServingRevisionId: "rev-member-1",
+        deploymentId: "dep-member-1",
+        primaryActorId: "actor-member-1",
+        deploymentStatus: "Active",
+        endpoints: [],
+        policyIds: [],
+        updatedAt: "2026-04-09T09:00:00Z",
+      },
+    ]);
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    expect(await screen.findByText("Untitled member1")).toBeTruthy();
+    expect(screen.getByText("member-untitled-member1")).toBeTruthy();
+    expect(screen.getByText("memb...ber1")).toBeTruthy();
+
+    await waitFor(() => {
+      expect(studioApi.listTeamMembers).toHaveBeenCalledWith("scope-1", "t-alpha");
+    });
+    expect(scopeRuntimeApi.listServices).not.toHaveBeenCalled();
+    expect(scopeRuntimeApi.getServiceRevisions).not.toHaveBeenCalled();
+    expect(scopeRuntimeApi.listServiceRuns).not.toHaveBeenCalled();
+    expect(scopeRuntimeApi.listMemberRuns).not.toHaveBeenCalled();
+  });
+
   it("shows the configured Team entry member without treating it as the service target", async () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -170,6 +170,43 @@ function mockCreateServiceRevisionCatalog(overrides?: Record<string, any>) {
   };
 }
 
+function mockCreateServiceCatalog() {
+  return [
+    {
+      serviceKey: "scope-1:default",
+      tenantId: "scope-1",
+      appId: "default",
+      namespace: "default",
+      serviceId: "default",
+      displayName: "Support Runtime",
+      defaultServingRevisionId: "rev-2",
+      activeServingRevisionId: "rev-2",
+      deploymentId: "dep-2",
+      primaryActorId: "actor-intake",
+      deploymentStatus: "Active",
+      endpoints: [],
+      policyIds: [],
+      updatedAt: "2026-04-09T09:00:00Z",
+    },
+    {
+      serviceKey: "scope-1:alpha-service",
+      tenantId: "scope-1",
+      appId: "default",
+      namespace: "default",
+      serviceId: "alpha-service",
+      displayName: "Team Alpha Runtime",
+      defaultServingRevisionId: "rev-2",
+      activeServingRevisionId: "rev-2",
+      deploymentId: "dep-2",
+      primaryActorId: "actor-intake",
+      deploymentStatus: "Active",
+      endpoints: [],
+      policyIds: [],
+      updatedAt: "2026-04-09T09:00:00Z",
+    },
+  ];
+}
+
 function mockCreateMembersCatalog() {
   return {
     scopeId: "scope-1",
@@ -501,24 +538,7 @@ jest.mock("@/shared/api/runtimeActorsApi", () => ({
 
 jest.mock("@/shared/api/scopeRuntimeApi", () => ({
   scopeRuntimeApi: {
-    listServices: jest.fn(async () => [
-      {
-        serviceKey: "scope-1:default",
-        tenantId: "scope-1",
-        appId: "default",
-        namespace: "default",
-        serviceId: "default",
-        displayName: "Support Runtime",
-        defaultServingRevisionId: "rev-2",
-        activeServingRevisionId: "rev-2",
-        deploymentId: "dep-2",
-        primaryActorId: "actor-intake",
-        deploymentStatus: "Active",
-        endpoints: [],
-        policyIds: [],
-        updatedAt: "2026-04-09T09:00:00Z",
-      },
-    ]),
+    listServices: jest.fn(async () => mockCreateServiceCatalog()),
     getServiceRevisions: jest.fn(async () => mockCreateServiceRevisionCatalog()),
     listMemberRuns: jest.fn(async () => mockCreateRunsCatalog()),
     listServiceRuns: jest.fn(async () => mockCreateRunsCatalog()),
@@ -774,6 +794,10 @@ describe("TeamDetailPage", () => {
     (scopesApi.listScripts as jest.Mock).mockClear();
     (runtimeGAgentApi.listActors as jest.Mock).mockClear();
     (runtimeActorsApi.getActorGraphEnriched as jest.Mock).mockClear();
+    (scopeRuntimeApi.listServices as jest.Mock).mockReset();
+    (scopeRuntimeApi.listServices as jest.Mock).mockImplementation(
+      async () => mockCreateServiceCatalog(),
+    );
     (scopeRuntimeApi.getServiceRevisions as jest.Mock).mockReset();
     (scopeRuntimeApi.getServiceRevisions as jest.Mock).mockImplementation(
       async () => mockCreateServiceRevisionCatalog(),
@@ -1122,12 +1146,13 @@ describe("TeamDetailPage", () => {
     });
 
     await waitFor(() => {
-      expect(scopeRuntimeApi.listMemberRuns).toHaveBeenCalledWith(
+      expect(scopeRuntimeApi.listServiceRuns).toHaveBeenCalledWith(
         "scope-1",
-        "member-support",
+        "default",
         expect.objectContaining({ take: 12 }),
       );
     });
+    expect(scopeRuntimeApi.listMemberRuns).not.toHaveBeenCalled();
   });
 
   it("shows configuration details in the overview", async () => {
@@ -1194,7 +1219,7 @@ describe("TeamDetailPage", () => {
   });
 
   it("guides the user to test the Team when no run is visible yet", async () => {
-    (scopeRuntimeApi.listMemberRuns as jest.Mock).mockResolvedValueOnce({
+    (scopeRuntimeApi.listServiceRuns as jest.Mock).mockResolvedValueOnce({
       ...mockCreateRunsCatalog(),
       runs: [],
     });
@@ -1215,6 +1240,53 @@ describe("TeamDetailPage", () => {
     expect(screen.getByText("测试团队后会在这里显示最新运行。")).toBeTruthy();
     expect(screen.queryByText("暂无可见运行")).toBeNull();
     expect(screen.queryByText("暂无近期可见运行")).toBeNull();
+    expect(scopeRuntimeApi.listMemberRuns).not.toHaveBeenCalled();
+  });
+
+  it("does not query runs for member-like service ids that are missing from the service catalog", async () => {
+    (studioApi.getTeam as jest.Mock).mockResolvedValueOnce({
+      ...mockCreateTeamSummary(),
+      entryMemberId: "member-untitled-member1",
+    });
+    (studioApi.listTeamMembers as jest.Mock).mockResolvedValueOnce({
+      scopeId: "scope-1",
+      members: [
+        {
+          memberId: "member-untitled-member1",
+          scopeId: "scope-1",
+          teamId: "t-alpha",
+          displayName: "Untitled Member",
+          description: "Service id points at a missing member-derived service",
+          implementationKind: "workflow",
+          lifecycleStage: "bind_ready",
+          publishedServiceId: "member-untitled-member1",
+          lastBoundRevisionId: "rev-missing",
+          createdAt: "2026-04-09T08:00:00Z",
+          updatedAt: "2026-04-09T09:00:00Z",
+        },
+      ],
+      nextPageToken: null,
+    });
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    expect((await screen.findAllByText("Untitled Member")).length).toBeGreaterThan(0);
+
+    await waitFor(() => {
+      expect(scopeRuntimeApi.listServices).toHaveBeenCalledWith("scope-1", {
+        appId: "default",
+      });
+    });
+    expect(scopeRuntimeApi.getServiceRevisions).not.toHaveBeenCalledWith(
+      "scope-1",
+      "member-untitled-member1",
+    );
+    expect(scopeRuntimeApi.listServiceRuns).not.toHaveBeenCalledWith(
+      "scope-1",
+      "member-untitled-member1",
+      expect.anything(),
+    );
+    expect(scopeRuntimeApi.listMemberRuns).not.toHaveBeenCalled();
   });
 
   it("shows the configured Team entry member without treating it as the service target", async () => {

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -502,16 +502,38 @@ const TeamDetailPage: React.FC = () => {
     ((teamMembersQuery.failureCount > 0 &&
       isProjectionSyncing404(teamMembersQuery.failureReason)) ||
       (teamMembersQuery.isError && isProjectionSyncing404(teamMembersQuery.error)));
-  const teamMemberServiceIds = React.useMemo(
-    () =>
-      (teamMembersQuery.data?.members ?? [])
+  const teamRuntimeServiceIds = React.useMemo(() => {
+    if (activeTab !== "overview") {
+      return [];
+    }
+
+    const members = teamMembersQuery.data?.members ?? [];
+    const entryMemberId = trimText(teamSummaryQuery.data?.entryMemberId);
+    if (entryMemberId) {
+      const entryMember = members.find(
+        (member) => trimText(member.memberId) === entryMemberId,
+      );
+      const entryServiceId = trimText(entryMember?.publishedServiceId);
+      return entryServiceId ? [entryServiceId] : [];
+    }
+
+    if (teamSummaryQuery.isError) {
+      return members
         .map((member) => trimText(member.publishedServiceId))
-        .filter(Boolean),
-    [teamMembersQuery.data?.members],
-  );
+        .filter(Boolean);
+    }
+
+    return [];
+  }, [
+    activeTab,
+    teamMembersQuery.data?.members,
+    teamSummaryQuery.data?.entryMemberId,
+    teamSummaryQuery.isError,
+  ]);
   const hasExplicitRuntimeFocus = Boolean(
     trimText(preferredMemberId) || trimText(preferredServiceId) || trimText(preferredRunId),
   );
+  const shouldLoadTeamRuntimeLens = hasTeamIdentity && activeTab === "overview";
   const {
     lens,
     runsQuery,
@@ -521,11 +543,11 @@ const TeamDetailPage: React.FC = () => {
     workflowsQuery,
   } = useTeamRuntimeLens(scopeId, {
     allowScopeServiceFallback: false,
-    enabled: hasTeamIdentity,
+    enabled: shouldLoadTeamRuntimeLens,
     preferredMemberId,
     preferredRunId,
     preferredServiceId,
-    teamMemberServiceIds,
+    teamMemberServiceIds: teamRuntimeServiceIds,
   });
 
   React.useEffect(() => {
@@ -1030,18 +1052,21 @@ const TeamDetailPage: React.FC = () => {
 
   const pushTeamTab = React.useCallback(
     (tab: TeamDetailTab) => {
+      const includeRuntimeContext = tab === "overview";
       setActiveTab(tab);
       history.push(
         buildTeamDetailHref({
           memberId: currentMemberId || undefined,
           scopeId,
           teamId: selectedTeamId || undefined,
-          workflowId: activeWorkflowId || undefined,
-          serviceId: runtimeServiceId,
+          workflowId: includeRuntimeContext ? activeWorkflowId || undefined : undefined,
+          serviceId: includeRuntimeContext ? runtimeServiceId : undefined,
           runId:
-            preferredRunId ||
-            lens.currentRun?.runId ||
-            undefined,
+            includeRuntimeContext
+              ? preferredRunId ||
+                lens.currentRun?.runId ||
+                undefined
+              : undefined,
           tab,
         }),
       );

--- a/apps/aevatar-console-web/src/pages/teams/home.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.test.tsx
@@ -14,7 +14,7 @@ import { rememberPendingTeamRosterSummary } from "./pendingTeamRoster";
 jest.mock("@/shared/api/scopeRuntimeApi", () => ({
   scopeRuntimeApi: {
     listServices: jest.fn(),
-    listMemberRuns: jest.fn(),
+    listServiceRuns: jest.fn(),
   },
 }));
 
@@ -75,8 +75,8 @@ const defaultServices = [
   },
 ];
 
-function buildMemberRunCatalog(memberId: string) {
-  if (memberId === "member-alpha") {
+function buildServiceRunCatalog(serviceId: string) {
+  if (serviceId === "service-alpha") {
     return {
       scopeId: "scope-a",
       serviceId: "service-alpha",
@@ -109,7 +109,7 @@ function buildMemberRunCatalog(memberId: string) {
     };
   }
 
-  if (memberId === "member-joker") {
+  if (serviceId === "service-joker") {
     return {
       scopeId: "scope-a",
       serviceId: "service-joker",
@@ -123,7 +123,7 @@ function buildMemberRunCatalog(memberId: string) {
     scopeId: "scope-a",
     serviceId: "",
     serviceKey: "",
-    displayName: memberId,
+    displayName: serviceId,
     runs: [],
   };
 }
@@ -152,8 +152,8 @@ describe("TeamsHomePage", () => {
       nextPageToken: null,
     });
     (scopeRuntimeApi.listServices as jest.Mock).mockResolvedValue(defaultServices);
-    (scopeRuntimeApi.listMemberRuns as jest.Mock).mockImplementation(
-      async (_scopeId: string, memberId: string) => buildMemberRunCatalog(memberId),
+    (scopeRuntimeApi.listServiceRuns as jest.Mock).mockImplementation(
+      async (_scopeId: string, serviceId: string) => buildServiceRunCatalog(serviceId),
     );
   });
 
@@ -214,11 +214,11 @@ describe("TeamsHomePage", () => {
   });
 
   it("shows completed run status as completion, not stability", async () => {
-    (scopeRuntimeApi.listMemberRuns as jest.Mock).mockResolvedValueOnce({
-      ...buildMemberRunCatalog("member-alpha"),
+    (scopeRuntimeApi.listServiceRuns as jest.Mock).mockResolvedValueOnce({
+      ...buildServiceRunCatalog("service-alpha"),
       runs: [
         {
-          ...buildMemberRunCatalog("member-alpha").runs[0],
+          ...buildServiceRunCatalog("service-alpha").runs[0],
           completionStatus: "completed",
           lastSuccess: true,
         },
@@ -248,8 +248,8 @@ describe("TeamsHomePage", () => {
   });
 
   it("keeps the homepage visible without warning on sampled runtime failures", async () => {
-    (scopeRuntimeApi.listMemberRuns as jest.Mock).mockRejectedValueOnce(
-      new Error("No stub for /api/scopes/scope-a/members/member-alpha/runs"),
+    (scopeRuntimeApi.listServiceRuns as jest.Mock).mockRejectedValueOnce(
+      new Error("No stub for /api/scopes/scope-a/services/service-alpha/runs"),
     );
 
     renderWithQueryClient(React.createElement(TeamsHomePage));
@@ -257,11 +257,11 @@ describe("TeamsHomePage", () => {
     expect(await screen.findByRole("heading", { level: 3, name: "客服团队" })).toBeTruthy();
     expect(screen.queryByText("部分团队信号暂时不可见")).toBeNull();
     expect(
-      screen.queryByText("No stub for /api/scopes/scope-a/members/member-alpha/runs"),
+      screen.queryByText("No stub for /api/scopes/scope-a/services/service-alpha/runs"),
     ).toBeNull();
   });
 
-  it("loads only the configured entry member run summary for the homepage signal", async () => {
+  it("loads only the configured entry member service run summary for the homepage signal", async () => {
     const members = Array.from({ length: 13 }, (_, index) => ({
       ...defaultMembers[0],
       memberId: `member-${index + 1}`,
@@ -293,11 +293,11 @@ describe("TeamsHomePage", () => {
       await screen.findByText("成员已绑定服务。下一步：进入团队详情后测试团队，生成第一条可见运行。"),
     ).toBeTruthy();
     await waitFor(() => {
-      expect(scopeRuntimeApi.listMemberRuns).toHaveBeenCalledTimes(1);
+      expect(scopeRuntimeApi.listServiceRuns).toHaveBeenCalledTimes(1);
     });
-    expect(scopeRuntimeApi.listMemberRuns).toHaveBeenCalledWith(
+    expect(scopeRuntimeApi.listServiceRuns).toHaveBeenCalledWith(
       "scope-a",
-      entryMemberId,
+      "service-7",
       { take: 1 },
     );
     expect(screen.queryByText("部分 Team 的运行状态仍在同步")).toBeNull();
@@ -339,14 +339,14 @@ describe("TeamsHomePage", () => {
       ],
       nextPageToken: null,
     });
-    (scopeRuntimeApi.listMemberRuns as jest.Mock).mockResolvedValueOnce({
+    (scopeRuntimeApi.listServiceRuns as jest.Mock).mockResolvedValueOnce({
       scopeId: "scope-a",
       serviceId: "service-entry",
       serviceKey: "scope-a:entry",
       displayName: "入口运行时",
       runs: [
         {
-          ...buildMemberRunCatalog("member-alpha").runs[0],
+          ...buildServiceRunCatalog("service-alpha").runs[0],
           serviceId: "service-entry",
           runId: "run-entry-latest",
           completionStatus: "completed",
@@ -367,11 +367,11 @@ describe("TeamsHomePage", () => {
       screen.queryByText("成员已绑定服务。下一步：进入团队详情后测试团队，生成第一条可见运行。"),
     ).toBeNull();
     await waitFor(() => {
-      expect(scopeRuntimeApi.listMemberRuns).toHaveBeenCalledTimes(1);
+      expect(scopeRuntimeApi.listServiceRuns).toHaveBeenCalledTimes(1);
     });
-    expect(scopeRuntimeApi.listMemberRuns).toHaveBeenCalledWith(
+    expect(scopeRuntimeApi.listServiceRuns).toHaveBeenCalledWith(
       "scope-a",
-      "member-entry",
+      "service-entry",
       { take: 1 },
     );
   });
@@ -457,7 +457,7 @@ describe("TeamsHomePage", () => {
     );
   });
 
-  it("does not query member runs for a Team without an entry member", async () => {
+  it("does not query service runs for a Team without an entry member", async () => {
     (studioApi.listTeams as jest.Mock).mockResolvedValueOnce({
       scopeId: "scope-a",
       teams: [
@@ -472,7 +472,7 @@ describe("TeamsHomePage", () => {
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
     expect(await screen.findByRole("heading", { level: 3, name: "客服团队" })).toBeTruthy();
-    expect(scopeRuntimeApi.listMemberRuns).not.toHaveBeenCalled();
+    expect(scopeRuntimeApi.listServiceRuns).not.toHaveBeenCalled();
   });
 
   it("keeps long Team titles compact while preserving the full title in a tooltip", async () => {
@@ -836,7 +836,7 @@ describe("TeamsHomePage", () => {
     expect(screen.queryByRole("heading", { level: 3, name: "未归队成员" })).toBeNull();
   });
 
-  it("shows an empty Team roster state without querying member runs", async () => {
+  it("shows an empty Team roster state without querying service runs", async () => {
     (studioApi.listTeams as jest.Mock).mockResolvedValueOnce({
       scopeId: "scope-a",
       teams: [],
@@ -855,7 +855,7 @@ describe("TeamsHomePage", () => {
         "当前账号还没有创建任何团队。创建后，这里会展示你的 AI 团队列表。",
       ),
     ).toBeTruthy();
-    expect(scopeRuntimeApi.listMemberRuns).not.toHaveBeenCalled();
+    expect(scopeRuntimeApi.listServiceRuns).not.toHaveBeenCalled();
   });
 
   it("keeps a just-created Team visible while the roster projection catches up", async () => {

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -1151,56 +1151,78 @@ const TeamsHomePage: React.FC = () => {
     () => groupMembersByTeamId(studioMembers),
     [studioMembers],
   );
-  const runtimeTrackableEntryMembers = React.useMemo(() => {
+  const runtimeTrackableEntryMemberServices = React.useMemo(() => {
     const membersById = new Map(
       studioMembers
         .map((member) => [trimOptional(member.memberId), member] as const)
         .filter(([memberId]) => memberId.length > 0),
     );
-    const seenMemberIds = new Set<string>();
-    const result: StudioMemberSummary[] = [];
+    const result: Array<{
+      readonly memberId: string;
+      readonly serviceId: string;
+    }> = [];
 
     studioTeams.forEach((team) => {
       const entryMemberId = trimOptional(team.entryMemberId);
-      if (!entryMemberId || seenMemberIds.has(entryMemberId)) {
+      if (!entryMemberId) {
         return;
       }
 
       const member = membersById.get(entryMemberId);
-      if (
-        !member ||
-        (!trimOptional(member.publishedServiceId) &&
-          !trimOptional(member.lastBoundRevisionId))
-      ) {
+      const serviceId = trimOptional(member?.publishedServiceId);
+      if (!member || !serviceId) {
         return;
       }
 
-      seenMemberIds.add(entryMemberId);
-      result.push(member);
+      result.push({
+        memberId: entryMemberId,
+        serviceId,
+      });
     });
 
     return result;
   }, [studioMembers, studioTeams]);
+  const runtimeTrackableServiceIds = React.useMemo(
+    () =>
+      Array.from(
+        new Set(
+          runtimeTrackableEntryMemberServices.map((entry) => entry.serviceId),
+        ),
+      ),
+    [runtimeTrackableEntryMemberServices],
+  );
   const memberRunQueries = useQueries({
-    queries: runtimeTrackableEntryMembers.map((member) => ({
+    queries: runtimeTrackableServiceIds.map((serviceId) => ({
       enabled: canLoadRoster && membersQuery.isSuccess,
-      queryKey: ["teams", "member-runs", queryScopeId, member.memberId],
+      queryKey: ["teams", "service-runs", queryScopeId, serviceId],
       queryFn: () =>
-        scopeRuntimeApi.listMemberRuns(queryScopeId, member.memberId, {
+        scopeRuntimeApi.listServiceRuns(queryScopeId, serviceId, {
           take: 1,
         }),
       retry: false,
     })),
   });
   const runsByMemberId = React.useMemo(
-    () =>
-      Object.fromEntries(
-        runtimeTrackableEntryMembers.map((member, index) => [
-          trimOptional(member.memberId),
+    () => {
+      const runsByServiceId = Object.fromEntries(
+        runtimeTrackableServiceIds.map((serviceId, index) => [
+          serviceId,
           memberRunQueries[index]?.data?.runs ?? [],
         ]),
-      ) as Record<string, readonly ScopeServiceRunSummary[]>,
-    [memberRunQueries, runtimeTrackableEntryMembers],
+      ) as Record<string, readonly ScopeServiceRunSummary[]>;
+
+      return Object.fromEntries(
+        runtimeTrackableEntryMemberServices.map((entry) => [
+          entry.memberId,
+          runsByServiceId[entry.serviceId] ?? [],
+        ]),
+      ) as Record<string, readonly ScopeServiceRunSummary[]>;
+    },
+    [
+      memberRunQueries,
+      runtimeTrackableEntryMemberServices,
+      runtimeTrackableServiceIds,
+    ],
   );
   const teamPreviews = React.useMemo(
     () =>

--- a/apps/aevatar-console-web/src/pages/teams/runtime/useTeamRuntimeLens.ts
+++ b/apps/aevatar-console-web/src/pages/teams/runtime/useTeamRuntimeLens.ts
@@ -124,14 +124,15 @@ export function useTeamRuntimeLens(
     trimOptional(preferredMemberSummary?.publishedServiceId) ||
     teamMemberServiceIds[0] ||
     "";
-  const serviceId = preferredServiceHint
+  const matchedPreferredServiceId = preferredServiceHint
     ? services.find((service) => service.serviceId === preferredServiceHint)?.serviceId ||
-      preferredServiceHint
-    : preferredMemberId.length > 0
-      ? ""
-      : allowScopeServiceFallback
-        ? services[0]?.serviceId || ""
-        : "";
+      ""
+    : "";
+  const serviceId =
+    matchedPreferredServiceId ||
+    (!preferredServiceHint && preferredMemberId.length === 0 && allowScopeServiceFallback
+      ? services[0]?.serviceId || ""
+      : "");
   const serviceRevisionsQuery = useQuery({
     enabled: enabled && normalizedScopeId.length > 0 && serviceId.length > 0,
     queryKey: ["teams", "service-revisions", normalizedScopeId, serviceId],
@@ -142,7 +143,7 @@ export function useTeamRuntimeLens(
     enabled:
       enabled &&
       normalizedScopeId.length > 0 &&
-      (serviceId.length > 0 || preferredMemberId.length > 0),
+      serviceId.length > 0,
     queryKey: [
       "teams",
       "runs",
@@ -151,13 +152,9 @@ export function useTeamRuntimeLens(
       serviceId || null,
     ],
     queryFn: () =>
-      preferredMemberId.length > 0
-        ? scopeRuntimeApi.listMemberRuns(normalizedScopeId, preferredMemberId, {
-            take: 12,
-          })
-        : scopeRuntimeApi.listServiceRuns(normalizedScopeId, serviceId, {
-            take: 12,
-          }),
+      scopeRuntimeApi.listServiceRuns(normalizedScopeId, serviceId, {
+        take: 12,
+      }),
     retry: false,
   });
 


### PR DESCRIPTION
## 问题

Teams Home 和 Team Detail 会把 Team member id / roster 上的 member-like `publishedServiceId` 用来请求 runtime runs。部分场景会打到 member 私有接口或不存在的 service runtime，例如：

- `/api/scopes/{scopeId}/members/{memberId}/runs?take=1` 返回 `MEMBER_ACCESS_DENIED`
- `/api/scopes/{scopeId}/services/member-untitled-member1/runs?take=12` 因为 service id 不存在而 500

## 方案

- Teams Home 改为按成员的 `publishedServiceId` 聚合 service-scoped runs，不再批量请求 member-scoped runs。
- Team Detail 的 runtime lens 只在 service catalog 中确认 service id 存在后，才请求 service revisions / service runs。
- 移除 Team Detail 对 `listMemberRuns` 的 fallback，避免页面用 member 私有运行接口作为团队运行态来源。
- 增加回归测试覆盖 member-like service id 缺失时不请求 runs/revisions 的场景。

## 影响路径

- `apps/aevatar-console-web/src/pages/teams/home.tsx`
- `apps/aevatar-console-web/src/pages/teams/runtime/useTeamRuntimeLens.ts`
- `apps/aevatar-console-web/src/pages/teams/home.test.tsx`
- `apps/aevatar-console-web/src/pages/teams/detail.test.tsx`

## 验证

- `npm test -- src/pages/teams/home.test.tsx src/pages/teams/detail.test.tsx --runInBand`：71 passed
- `npm run tsc`：passed
- `bash tools/ci/test_stability_guards.sh`：passed
- `git diff --check`：passed

## 备注

之前误提到 `dev` 的 PR #1962 已关闭；这个 PR 的 base 是 `feat/2026-06-08_workflow-studio`。
