### PR TITLE
通过单规则命令更新聊天路由策略

### DIFF
--- a/agents/Aevatar.GAgents.ChatRouting/ChatRoutePolicyCommandPort.cs
+++ b/agents/Aevatar.GAgents.ChatRouting/ChatRoutePolicyCommandPort.cs
@@ -38,6 +38,15 @@ internal sealed class ChatRoutePolicyCommandPort : IChatRoutePolicyCommandPort
         return DispatchAsync(scopeId, command, ct);
     }
 
+    public Task<ChatRoutePolicyCommandAcceptedReceipt> UpsertRuleAsync(
+        string scopeId,
+        UpsertChatRouteRuleRequested command,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        return DispatchAsync(scopeId, command, ct);
+    }
+
     public Task<ChatRoutePolicyCommandAcceptedReceipt> RemoveRuleAsync(
         string scopeId,
         RemoveChatRouteRuleRequested command,

--- a/src/Aevatar.ChatRouting.Core/IChatRoutePolicyCommandPort.cs
+++ b/src/Aevatar.ChatRouting.Core/IChatRoutePolicyCommandPort.cs
@@ -16,6 +16,11 @@ public interface IChatRoutePolicyCommandPort
         UpsertChatRoutePolicyRequested command,
         CancellationToken ct = default);
 
+    Task<ChatRoutePolicyCommandAcceptedReceipt> UpsertRuleAsync(
+        string scopeId,
+        UpsertChatRouteRuleRequested command,
+        CancellationToken ct = default);
+
     Task<ChatRoutePolicyCommandAcceptedReceipt> RemoveRuleAsync(
         string scopeId,
         RemoveChatRouteRuleRequested command,

--- a/src/Aevatar.Mainnet.Host.Api/ChatRouting/ChatRoutePolicyAdminEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/ChatRouting/ChatRoutePolicyAdminEndpoints.cs
@@ -92,6 +92,11 @@ internal static class ChatRoutePolicyAdminEndpoints
             return JsonError(StatusCodes.Status400BadRequest, "invalid_body",
                 $"Could not parse request body as UpsertChatRoutePolicyRequested: {ex.Message}");
         }
+        catch (InvalidJsonException ex)
+        {
+            return JsonError(StatusCodes.Status400BadRequest, "invalid_body",
+                $"Could not parse request body as UpsertChatRoutePolicyRequested: {ex.Message}");
+        }
 
         if (command.DefaultTarget is null ||
             command.DefaultTarget.ActionCase == ChatRouteAction.ActionOneofCase.None)
@@ -149,6 +154,11 @@ internal static class ChatRoutePolicyAdminEndpoints
             command = BodyParser.Parse<UpsertChatRouteRuleRequested>(bodyJson);
         }
         catch (InvalidProtocolBufferException ex)
+        {
+            return JsonError(StatusCodes.Status400BadRequest, "invalid_body",
+                $"Could not parse request body as UpsertChatRouteRuleRequested: {ex.Message}");
+        }
+        catch (InvalidJsonException ex)
         {
             return JsonError(StatusCodes.Status400BadRequest, "invalid_body",
                 $"Could not parse request body as UpsertChatRouteRuleRequested: {ex.Message}");

--- a/src/Aevatar.Mainnet.Host.Api/ChatRouting/ChatRoutePolicyAdminEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/ChatRouting/ChatRoutePolicyAdminEndpoints.cs
@@ -19,6 +19,7 @@ namespace Aevatar.Mainnet.Host.Api.ChatRouting;
 /// service), so the generic <c>/api/scopes/{scopeId}/invoke/{endpointId}</c>
 /// surface can't address it. This endpoint dispatches
 /// <see cref="UpsertChatRoutePolicyRequested"/> /
+/// <see cref="UpsertChatRouteRuleRequested"/> /
 /// <see cref="RemoveChatRouteRuleRequested"/> through the chat route policy
 /// application command port.
 ///
@@ -48,6 +49,7 @@ internal static class ChatRoutePolicyAdminEndpoints
             .WithTags("ChatRoutePolicy");
 
         group.MapPut("", HandleUpsertAsync);
+        group.MapPut("/rules/{ruleId}", HandleUpsertRuleAsync);
         group.MapDelete("/rules/{ruleId}", HandleRemoveRuleAsync);
         group.MapGet("", HandleGetAsync);
 
@@ -116,6 +118,61 @@ internal static class ChatRoutePolicyAdminEndpoints
             actor_id = receipt.ActorId,
             command_id = receipt.CommandId,
             note = "Upsert dispatched. Re-query GET to observe materialized state.",
+        });
+    }
+
+    /// <summary>
+    /// PUT /api/scopes/{scopeId}/chat-route-policy/rules/{ruleId}
+    /// </summary>
+    private static async Task<IResult> HandleUpsertRuleAsync(
+        HttpContext http,
+        string scopeId,
+        string ruleId,
+        [FromServices] IChatRoutePolicyCommandPort commandPort,
+        CancellationToken ct)
+    {
+        if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+            return denied;
+
+        if (string.IsNullOrWhiteSpace(ruleId))
+            return JsonError(StatusCodes.Status400BadRequest, "rule_id_required", "rule_id path segment is required.");
+
+        UpsertChatRouteRuleRequested command;
+        try
+        {
+            using var reader = new StreamReader(http.Request.Body);
+            var bodyJson = await reader.ReadToEndAsync(ct);
+            if (string.IsNullOrWhiteSpace(bodyJson))
+                return JsonError(StatusCodes.Status400BadRequest, "empty_body",
+                    "Request body is required: protobuf-JSON of UpsertChatRouteRuleRequested.");
+
+            command = BodyParser.Parse<UpsertChatRouteRuleRequested>(bodyJson);
+        }
+        catch (InvalidProtocolBufferException ex)
+        {
+            return JsonError(StatusCodes.Status400BadRequest, "invalid_body",
+                $"Could not parse request body as UpsertChatRouteRuleRequested: {ex.Message}");
+        }
+
+        if (command.Rule is null)
+            return JsonError(StatusCodes.Status400BadRequest, "rule_required",
+                "rule is required: a rule upsert must include the ChatRouteRule payload.");
+
+        command.OwnerScope = new OwnerScope
+        {
+            NyxUserId = scopeId,
+            Platform = OwnerScope.NyxIdPlatform,
+            RegistrationScopeId = string.Empty,
+            SenderId = string.Empty,
+        };
+        command.Rule.RuleId = ruleId.Trim();
+
+        var receipt = await commandPort.UpsertRuleAsync(scopeId, command, ct);
+        return Results.Accepted(value: new
+        {
+            actor_id = receipt.ActorId,
+            command_id = receipt.CommandId,
+            note = "Rule upsert dispatched. Re-query GET to observe materialized state.",
         });
     }
 

--- a/src/Aevatar.Mainnet.Host.Api/Voice/VoiceDemoBootstrapEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Voice/VoiceDemoBootstrapEndpoints.cs
@@ -33,7 +33,7 @@ internal static class VoiceDemoBootstrapEndpoints
         [FromServices] IVoiceDemoAgentCommandPort voiceDemoAgentCommandPort,
         [FromServices] IUserAgentCatalogCommandPort catalogCommandPort,
         [FromServices] IChatRoutePolicyCommandPort routePolicyCommandPort,
-        [FromServices] IChatRoutePolicyQueryPort routePolicyQueryPort,
+        [FromServices] IChatRouteFallbackProvider fallbackProvider,
         CancellationToken ct)
     {
         // Refactor (iter34/cluster-004-voice-bootstrap-application-port):
@@ -64,7 +64,7 @@ internal static class VoiceDemoBootstrapEndpoints
             ownerScope,
             actorId,
             routePolicyCommandPort,
-            routePolicyQueryPort,
+            fallbackProvider,
             ct);
 
         return Results.Accepted(value: new
@@ -87,41 +87,26 @@ internal static class VoiceDemoBootstrapEndpoints
         OwnerScope ownerScope,
         string actorId,
         IChatRoutePolicyCommandPort routePolicyCommandPort,
-        IChatRoutePolicyQueryPort routePolicyQueryPort,
+        IChatRouteFallbackProvider fallbackProvider,
         CancellationToken ct)
     {
-        var existing = await routePolicyQueryPort.LookupForCallerAsync(ownerScope, ct);
-        if (existing is null)
-            return null;
-
-        var keptRules = existing.Rules
-            .Where(static rule => !string.Equals(rule.RuleId, RouteRuleId, StringComparison.Ordinal))
-            .Select(static rule => rule.Clone())
-            .ToArray();
-
-        var command = new UpsertChatRoutePolicyRequested
+        var command = new UpsertChatRouteRuleRequested
         {
-            OwnerScope = new OwnerScope
+            OwnerScope = ownerScope.Clone(),
+            DefaultTargetIfUninitialized = fallbackProvider.GetFallbackDecision().Action?.Clone(),
+            Rule = new ChatRouteRule
             {
-                NyxUserId = scopeId,
-                Platform = OwnerScope.NyxIdPlatform,
+                RuleId = RouteRuleId,
+                Priority = 900,
+                Match = new ChatRouteMatch { SourceKind = ChatSourceKind.Voice },
+                Action = ChatRouteActionTargets.ForwardToVoiceAttachTarget(
+                    actorId,
+                    VoiceModuleName),
+                Description = "Voice demo typed attach target.",
             },
-            DefaultTarget = existing.DefaultTarget.Clone(),
         };
 
-        command.Rules.AddRange(keptRules);
-        command.Rules.Add(new ChatRouteRule
-        {
-            RuleId = RouteRuleId,
-            Priority = 900,
-            Match = new ChatRouteMatch { SourceKind = ChatSourceKind.Voice },
-            Action = ChatRouteActionTargets.ForwardToVoiceAttachTarget(
-                actorId,
-                VoiceModuleName),
-            Description = "Voice demo typed attach target.",
-        });
-
-        return await routePolicyCommandPort.UpsertAsync(scopeId, command, ct);
+        return await routePolicyCommandPort.UpsertRuleAsync(scopeId, command, ct);
     }
 
     private static bool TryResolveScopeId(ClaimsPrincipal user, out string scopeId)

--- a/test/Aevatar.GAgents.ChatRouting.Tests/ChatRoutePolicyCommandPortTests.cs
+++ b/test/Aevatar.GAgents.ChatRouting.Tests/ChatRoutePolicyCommandPortTests.cs
@@ -68,6 +68,36 @@ public sealed class ChatRoutePolicyCommandPortTests
         envelope.Route.Direct.TargetActorId.Should().Be("chat-route-policy:scope-1");
     }
 
+    [Fact]
+    public async Task UpsertRuleAsync_DispatchesSingleRulePayloadToScopeActor()
+    {
+        var actorRuntime = new RecordingActorRuntime();
+        var dispatchPort = new RecordingActorDispatchPort();
+        using var provider = CreateProvider(actorRuntime, dispatchPort);
+        var commandPort = provider.GetRequiredService<IChatRoutePolicyCommandPort>();
+        var command = new UpsertChatRouteRuleRequested
+        {
+            Rule = new ChatRouteRule
+            {
+                RuleId = "voice-demo",
+                Action = new ChatRouteAction
+                {
+                    ForwardToModel = new ForwardToModel { ModelName = "voice-model" },
+                },
+            },
+        };
+
+        await commandPort.UpsertRuleAsync("scope-1", command);
+
+        dispatchPort.Dispatches.Should().ContainSingle();
+        var (actorId, envelope) = dispatchPort.Dispatches[0];
+        actorId.Should().Be("chat-route-policy:scope-1");
+        envelope.Payload.Unpack<UpsertChatRouteRuleRequested>()
+            .Rule.RuleId.Should().Be("voice-demo");
+        envelope.Route.PublisherActorId.Should().Be("chat-route-policy-admin");
+        envelope.Route.Direct.TargetActorId.Should().Be("chat-route-policy:scope-1");
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]
@@ -109,6 +139,22 @@ public sealed class ChatRoutePolicyCommandPortTests
         var commandPort = provider.GetRequiredService<IChatRoutePolicyCommandPort>();
 
         var act = () => commandPort.RemoveRuleAsync("scope-1", null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>()
+            .WithParameterName("command");
+        actorRuntime.CreatedActors.Should().BeEmpty();
+        dispatchPort.Dispatches.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task UpsertRuleAsync_RejectsNullCommand()
+    {
+        var actorRuntime = new RecordingActorRuntime();
+        var dispatchPort = new RecordingActorDispatchPort();
+        using var provider = CreateProvider(actorRuntime, dispatchPort);
+        var commandPort = provider.GetRequiredService<IChatRoutePolicyCommandPort>();
+
+        var act = () => commandPort.UpsertRuleAsync("scope-1", null!);
 
         await act.Should().ThrowAsync<ArgumentNullException>()
             .WithParameterName("command");

--- a/test/Aevatar.Hosting.Tests/MainnetChatRoutePolicyAdminEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetChatRoutePolicyAdminEndpointsTests.cs
@@ -102,6 +102,60 @@ public sealed class MainnetChatRoutePolicyAdminEndpointsTests
     }
 
     [Fact]
+    public async Task PutRule_StampsOwnerScopeAndDispatchesRuleCommandToScopeActor()
+    {
+        var commandPort = new RecordingChatRoutePolicyCommandPort();
+        await using var app = await CreateAppAsync(commandPort);
+        var client = app.GetTestClient();
+
+        var body = """
+        {
+          "owner_scope": { "nyx_user_id": "attacker" },
+          "default_target_if_uninitialized": {
+            "forward_to_model": { "model_name": "deepseek/deepseek-chat" }
+          },
+          "rule": {
+            "rule_id": "body-rule",
+            "priority": 100,
+            "match": { "source_kind": "CHAT_SOURCE_KIND_VOICE" },
+            "action": {
+              "forward_to_model": {
+                "tool_choice_hint": {
+                  "voice_attach_target": {
+                    "actor_id": "voice-agent",
+                    "voice_module_name": "voice_presence_openai"
+                  }
+                }
+              }
+            },
+            "description": "voice route"
+          }
+        }
+        """;
+        using var request = new HttpRequestMessage(
+            HttpMethod.Put,
+            $"/api/scopes/{Scope}/chat-route-policy/rules/voice-demo")
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+
+        var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted, await response.Content.ReadAsStringAsync());
+        commandPort.Upserts.Should().BeEmpty();
+        commandPort.RuleUpserts.Should().ContainSingle();
+        var (acceptedScope, command) = commandPort.RuleUpserts[0];
+        acceptedScope.Should().Be(Scope);
+        command.OwnerScope.NyxUserId.Should().Be(Scope);
+        command.OwnerScope.Platform.Should().Be(OwnerScope.NyxIdPlatform);
+        command.DefaultTargetIfUninitialized.ForwardToModel.ModelName.Should().Be("deepseek/deepseek-chat");
+        command.Rule.RuleId.Should().Be("voice-demo",
+            "the path rule id is the command identity; body rule_id must not target a different rule");
+        command.Rule.Match.SourceKind.Should().Be(ChatSourceKind.Voice);
+        command.Rule.Action.ForwardToModel.ToolChoiceHint.VoiceAttachTarget.ActorId.Should().Be("voice-agent");
+    }
+
+    [Fact]
     public async Task DeleteRule_DispatchesRemoveCommandWithTrimmedRuleId()
     {
         var commandPort = new RecordingChatRoutePolicyCommandPort();
@@ -273,6 +327,7 @@ public sealed class MainnetChatRoutePolicyAdminEndpointsTests
     private sealed class RecordingChatRoutePolicyCommandPort : IChatRoutePolicyCommandPort
     {
         public List<(string ScopeId, UpsertChatRoutePolicyRequested Command)> Upserts { get; } = [];
+        public List<(string ScopeId, UpsertChatRouteRuleRequested Command)> RuleUpserts { get; } = [];
         public List<(string ScopeId, RemoveChatRouteRuleRequested Command)> Removals { get; } = [];
 
         public Task<ChatRoutePolicyCommandAcceptedReceipt> UpsertAsync(
@@ -285,6 +340,18 @@ public sealed class MainnetChatRoutePolicyAdminEndpointsTests
                 $"chat-route-policy:{scopeId}",
                 "accepted-upsert",
                 "accepted-upsert"));
+        }
+
+        public Task<ChatRoutePolicyCommandAcceptedReceipt> UpsertRuleAsync(
+            string scopeId,
+            UpsertChatRouteRuleRequested command,
+            CancellationToken ct = default)
+        {
+            RuleUpserts.Add((scopeId, command.Clone()));
+            return Task.FromResult(new ChatRoutePolicyCommandAcceptedReceipt(
+                $"chat-route-policy:{scopeId}",
+                "accepted-rule-upsert",
+                "accepted-rule-upsert"));
         }
 
         public Task<ChatRoutePolicyCommandAcceptedReceipt> RemoveRuleAsync(

--- a/test/Aevatar.Hosting.Tests/MainnetChatRoutePolicyAdminEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetChatRoutePolicyAdminEndpointsTests.cs
@@ -155,6 +155,38 @@ public sealed class MainnetChatRoutePolicyAdminEndpointsTests
         command.Rule.Action.ForwardToModel.ToolChoiceHint.VoiceAttachTarget.ActorId.Should().Be("voice-agent");
     }
 
+    [Theory]
+    [InlineData("%20%20", "{\"rule\": {\"action\": {\"forward_to_model\": {\"model_name\": \"model\"}}}}", "rule_id_required")]
+    [InlineData("voice-demo", "", "empty_body")]
+    [InlineData("voice-demo", "{", "invalid_body")]
+    [InlineData("voice-demo", "{}", "rule_required")]
+    public async Task PutRule_RejectsInvalidRequestWithoutDispatch(
+        string routeRuleId,
+        string bodyJson,
+        string expectedError)
+    {
+        var commandPort = new RecordingChatRoutePolicyCommandPort();
+        await using var app = await CreateAppAsync(commandPort);
+        var client = app.GetTestClient();
+
+        using var request = new HttpRequestMessage(
+            HttpMethod.Put,
+            $"/api/scopes/{Scope}/chat-route-policy/rules/{routeRuleId}")
+        {
+            Content = new StringContent(bodyJson, Encoding.UTF8, "application/json"),
+        };
+
+        var response = await client.SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, body);
+        body.Should().Contain(expectedError);
+        commandPort.RuleUpserts.Should().BeEmpty(
+            "REST validation must reject malformed rule upserts before admitting an actor command");
+        commandPort.Upserts.Should().BeEmpty();
+        commandPort.Removals.Should().BeEmpty();
+    }
+
     [Fact]
     public async Task DeleteRule_DispatchesRemoveCommandWithTrimmedRuleId()
     {

--- a/test/Aevatar.Hosting.Tests/VoiceDemoBootstrapEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/VoiceDemoBootstrapEndpointsTests.cs
@@ -32,33 +32,13 @@ public sealed class VoiceDemoBootstrapEndpointsTests
     {
         var voiceDemoCommandPort = new RecordingVoiceDemoAgentCommandPort();
         var catalogCommandPort = new RecordingCatalogCommandPort();
-        var existing = new ChatRoutePolicySnapshot(
-            new ChatRouteAction { ForwardToModel = new ForwardToModel { ModelName = "existing-default" } },
-            [
-                new ChatRouteRule
-                {
-                    RuleId = "keep-chat",
-                    Priority = 10,
-                    Match = new ChatRouteMatch { SourceKind = ChatSourceKind.NyxResponses },
-                    Action = new ChatRouteAction { ForwardToModel = new ForwardToModel { ModelName = "kept-model" } },
-                    Description = "preserve non-voice-demo rule",
-                },
-                new ChatRouteRule
-                {
-                    RuleId = "voice-demo",
-                    Priority = 900,
-                    Match = new ChatRouteMatch { SourceKind = ChatSourceKind.Voice },
-                    Action = TypedVoiceAttachTarget("old-agent", "voice_presence_openai"),
-                    Description = "remove stale voice demo rule",
-                },
-            ]);
-        var routePolicyQueryPort = new StaticRoutePolicyQueryPort(existing);
         var routePolicyCommandPort = new RecordingChatRoutePolicyCommandPort();
+        var fallbackProvider = new StaticChatRouteFallbackProvider("fallback-model");
         await using var app = await CreateAppAsync(
             voiceDemoCommandPort,
             catalogCommandPort,
             routePolicyCommandPort,
-            routePolicyQueryPort);
+            fallbackProvider);
         var client = app.GetTestClient();
 
         var response = await client.PostAsync("/api/demo/voice/bootstrap", content: null);
@@ -78,39 +58,41 @@ public sealed class VoiceDemoBootstrapEndpointsTests
         demoActorId.Should().Be(RecordingVoiceDemoAgentCommandPort.DemoActorId);
         body["route_policy_actor_id"].ToString().Should().Be($"chat-route-policy:{Scope}");
         body["agent_command_id"].ToString().Should().Be("voice-demo-command");
-        body["route_policy_command_id"].ToString().Should().Be("route-policy-command");
+        body["route_policy_command_id"].ToString().Should().Be("route-policy-rule-command");
 
         voiceDemoCommandPort.Commands.Should().ContainSingle()
             .Which.Should().Be((Scope, "voice_presence_openai"));
         catalogCommandPort.Commands.Should().ContainSingle()
             .Which.AgentId.Should().Be(demoActorId);
 
-        routePolicyCommandPort.Upserts.Should().ContainSingle();
-        var (policyScope, command) = routePolicyCommandPort.Upserts[0];
+        routePolicyCommandPort.Upserts.Should().BeEmpty();
+        routePolicyCommandPort.RuleUpserts.Should().ContainSingle();
+        var (policyScope, command) = routePolicyCommandPort.RuleUpserts[0];
         policyScope.Should().Be(Scope);
         command.OwnerScope.NyxUserId.Should().Be(Scope);
         command.OwnerScope.Platform.Should().Be(RoutingOwnerScope.NyxIdPlatform);
-        command.DefaultTarget.ForwardToModel.ModelName.Should().Be("existing-default");
-        command.Rules.Should().ContainSingle(rule => rule.RuleId == "keep-chat")
-            .Which.Action.ForwardToModel.ModelName.Should().Be("kept-model");
-        var voiceRule = command.Rules.Should().ContainSingle(rule => rule.RuleId == "voice-demo").Subject;
+        command.DefaultTargetIfUninitialized.ForwardToModel.ModelName.Should().Be("fallback-model");
+        var voiceRule = command.Rule;
+        voiceRule.RuleId.Should().Be("voice-demo");
+        voiceRule.Priority.Should().Be(900);
+        voiceRule.Match.SourceKind.Should().Be(ChatSourceKind.Voice);
         voiceRule.Action.ForwardToModel.ToolChoiceHint.VoiceAttachTarget.ActorId.Should().Be(demoActorId);
         voiceRule.Action.ForwardToModel.ToolChoiceHint.VoiceAttachTarget.VoiceModuleName.Should().Be("voice_presence_openai");
         voiceRule.Action.ForwardToModel.ToolChoiceHint.PrefilledArguments.Should().BeNull();
     }
 
     [Fact]
-    public async Task Bootstrap_DoesNotCreateRoutePolicy_WhenNoExistingPolicyExists()
+    public async Task Bootstrap_UpsertsVoiceRuleWithoutReadingRoutePolicySnapshot()
     {
         var voiceDemoCommandPort = new RecordingVoiceDemoAgentCommandPort();
         var catalogCommandPort = new RecordingCatalogCommandPort();
-        var routePolicyQueryPort = new StaticRoutePolicyQueryPort(null);
         var routePolicyCommandPort = new RecordingChatRoutePolicyCommandPort();
+        var fallbackProvider = new StaticChatRouteFallbackProvider("cold-start-model");
         await using var app = await CreateAppAsync(
             voiceDemoCommandPort,
             catalogCommandPort,
             routePolicyCommandPort,
-            routePolicyQueryPort);
+            fallbackProvider);
         var client = app.GetTestClient();
 
         var response = await client.PostAsync("/api/demo/voice/bootstrap", content: null);
@@ -122,18 +104,20 @@ public sealed class VoiceDemoBootstrapEndpointsTests
         catalogCommandPort.Commands.Should().ContainSingle()
             .Which.AgentId.Should().Be(RecordingVoiceDemoAgentCommandPort.DemoActorId);
         routePolicyCommandPort.Upserts.Should().BeEmpty();
-        body.Should().ContainKey("route_policy_actor_id").WhoseValue.Should().BeNull();
-        body.Should().ContainKey("route_policy_command_id").WhoseValue.Should().BeNull();
+        routePolicyCommandPort.RuleUpserts.Should().ContainSingle();
+        routePolicyCommandPort.RuleUpserts[0].Command
+            .DefaultTargetIfUninitialized.ForwardToModel.ModelName.Should().Be("cold-start-model");
+        body.Should().ContainKey("route_policy_actor_id")
+            .WhoseValue!.ToString().Should().Be($"chat-route-policy:{Scope}");
+        body.Should().ContainKey("route_policy_command_id")
+            .WhoseValue!.ToString().Should().Be("route-policy-rule-command");
     }
-
-    private static ChatRouteAction TypedVoiceAttachTarget(string actorId, string voiceModuleName) =>
-        ChatRouteActionTargets.ForwardToVoiceAttachTarget(actorId, voiceModuleName);
 
     private static async Task<WebApplication> CreateAppAsync(
         RecordingVoiceDemoAgentCommandPort voiceDemoCommandPort,
         RecordingCatalogCommandPort catalogCommandPort,
         RecordingChatRoutePolicyCommandPort routePolicyCommandPort,
-        StaticRoutePolicyQueryPort routePolicyQueryPort)
+        IChatRouteFallbackProvider fallbackProvider)
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
         {
@@ -143,7 +127,7 @@ public sealed class VoiceDemoBootstrapEndpointsTests
         builder.Services.AddSingleton<IVoiceDemoAgentCommandPort>(voiceDemoCommandPort);
         builder.Services.AddSingleton<IUserAgentCatalogCommandPort>(catalogCommandPort);
         builder.Services.AddSingleton<IChatRoutePolicyCommandPort>(routePolicyCommandPort);
-        builder.Services.AddSingleton<IChatRoutePolicyQueryPort>(routePolicyQueryPort);
+        builder.Services.AddSingleton(fallbackProvider);
 
         var app = builder.Build();
         app.Use(async (context, next) =>
@@ -180,6 +164,7 @@ public sealed class VoiceDemoBootstrapEndpointsTests
     private sealed class RecordingChatRoutePolicyCommandPort : IChatRoutePolicyCommandPort
     {
         public List<(string ScopeId, UpsertChatRoutePolicyRequested Command)> Upserts { get; } = [];
+        public List<(string ScopeId, UpsertChatRouteRuleRequested Command)> RuleUpserts { get; } = [];
 
         public Task<ChatRoutePolicyCommandAcceptedReceipt> UpsertAsync(
             string scopeId,
@@ -191,6 +176,18 @@ public sealed class VoiceDemoBootstrapEndpointsTests
                 $"chat-route-policy:{scopeId}",
                 "route-policy-command",
                 "route-policy-command"));
+        }
+
+        public Task<ChatRoutePolicyCommandAcceptedReceipt> UpsertRuleAsync(
+            string scopeId,
+            UpsertChatRouteRuleRequested command,
+            CancellationToken ct = default)
+        {
+            RuleUpserts.Add((scopeId, command.Clone()));
+            return Task.FromResult(new ChatRoutePolicyCommandAcceptedReceipt(
+                $"chat-route-policy:{scopeId}",
+                "route-policy-rule-command",
+                "route-policy-rule-command"));
         }
 
         public Task<ChatRoutePolicyCommandAcceptedReceipt> RemoveRuleAsync(
@@ -216,11 +213,15 @@ public sealed class VoiceDemoBootstrapEndpointsTests
         public Task TombstoneAsync(string agentId, CancellationToken ct = default) => Task.CompletedTask;
     }
 
-    private sealed class StaticRoutePolicyQueryPort(ChatRoutePolicySnapshot? snapshot) : IChatRoutePolicyQueryPort
+    private sealed class StaticChatRouteFallbackProvider(string modelName) : IChatRouteFallbackProvider
     {
-        public Task<ChatRoutePolicySnapshot?> LookupForCallerAsync(
-            RoutingOwnerScope callerScope,
-            CancellationToken ct = default) =>
-            Task.FromResult(snapshot);
+        public ChatRouteDecision GetFallbackDecision() => new()
+        {
+            Action = new ChatRouteAction
+            {
+                ForwardToModel = new ForwardToModel { ModelName = modelName },
+            },
+            UsedFallback = true,
+        };
     }
 }


### PR DESCRIPTION
## Changed files

- Added `UpsertRuleAsync` to the chat route policy command port and runtime-backed implementation.
- Added an admin rule-upsert endpoint that sends `UpsertChatRouteRuleRequested` directly to the policy actor.
- Changed voice bootstrap to submit a typed single-rule command instead of reading and rebuilding the policy readmodel.
- Updated command-port, admin endpoint, and voice bootstrap tests for the single-rule mutation path.

## Test results

- `dotnet build aevatar.slnx --nologo`: passed.
- `dotnet test test/Aevatar.GAgents.ChatRouting.Tests/Aevatar.GAgents.ChatRouting.Tests.csproj --nologo --filter ChatRoutePolicyCommandPort`: passed.
- `dotnet test test/Aevatar.Hosting.Tests/Aevatar.Hosting.Tests.csproj --nologo --filter "MainnetChatRoutePolicyAdminEndpointsTests|VoiceDemoBootstrapEndpointsTests"`: passed.
- `dotnet test test/Aevatar.ChatRouting.Voice.Integration.Tests/Aevatar.ChatRouting.Voice.Integration.Tests.csproj --nologo --filter PolicyAwareVoiceEndpoints`: passed.
- `bash tools/ci/test_stability_guards.sh`: passed.
- `bash tools/ci/architecture_guards.sh`: passed.

## Deviations

- Host command variables were not present in `host.env`; verification used repository defaults plus the work-unit hints.
- Refactor self-documentation was not added because the host refactor comment policy normalized to `none`.
- No scope expansion was used.
- Closes #1940

⟦AI:AUTO-LOOP⟧
