### PR TITLE
Fix NyxID direct chat delivery from committed completions

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatCompletionAguiFrameBuilder.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatCompletionAguiFrameBuilder.cs
@@ -1,0 +1,116 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.AGUI.Contracts;
+using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Google.Protobuf.WellKnownTypes;
+using AguiTextContent = Aevatar.AGUI.Contracts.TextMessageContentEvent;
+using AguiTextEnd = Aevatar.AGUI.Contracts.TextMessageEndEvent;
+using AguiTextStart = Aevatar.AGUI.Contracts.TextMessageStartEvent;
+
+namespace Aevatar.GAgents.NyxidChat;
+
+internal static class NyxIdChatCompletionAguiFrameBuilder
+{
+    public static IReadOnlyList<AGUIEvent> Build(
+        NyxIdChatSessionProjectionContext context,
+        RoleChatSessionCompletedEvent completed)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(completed);
+
+        var messageId = string.IsNullOrWhiteSpace(completed.SessionId)
+            ? context.SessionId
+            : completed.SessionId.Trim();
+        var content = completed.Content ?? string.Empty;
+
+        if (TryBuildFailureFrame(content, context.SessionId, out var failureFrame))
+            return [failureFrame];
+
+        var frames = new List<AGUIEvent>();
+        if (!string.IsNullOrEmpty(content))
+        {
+            frames.Add(new AGUIEvent
+            {
+                TextMessageStart = new AguiTextStart
+                {
+                    MessageId = messageId,
+                    Role = "assistant",
+                },
+            });
+            frames.Add(new AGUIEvent
+            {
+                TextMessageContent = new AguiTextContent
+                {
+                    MessageId = messageId,
+                    Delta = content,
+                },
+            });
+        }
+
+        if (completed.Usage != null)
+            frames.Add(BuildUsageFrame(completed.Usage, completed.Model));
+
+        frames.Add(new AGUIEvent
+        {
+            TextMessageEnd = new AguiTextEnd
+            {
+                MessageId = messageId,
+            },
+        });
+        frames.Add(new AGUIEvent
+        {
+            RunFinished = new RunFinishedEvent
+            {
+                ThreadId = context.RootActorId,
+                RunId = context.SessionId,
+                Result = Any.Pack(new StringValue { Value = content }),
+            },
+        });
+        return frames;
+    }
+
+    private static bool TryBuildFailureFrame(string content, string runId, out AGUIEvent failureFrame)
+    {
+        failureFrame = null!;
+        if (string.IsNullOrEmpty(content))
+            return false;
+
+        const string llmErrorPrefix = "[[AEVATAR_LLM_ERROR]]";
+        const string llmFailedPrefix = "LLM request failed";
+        if (content.StartsWith(llmErrorPrefix, StringComparison.Ordinal))
+        {
+            failureFrame = BuildRunError(content[llmErrorPrefix.Length..].Trim(), runId);
+            return true;
+        }
+
+        if (content.StartsWith(llmFailedPrefix, StringComparison.Ordinal))
+        {
+            failureFrame = BuildRunError(ScopeGAgentAguiEventMapper.NormalizeLlmFailureMessage(content), runId);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static AGUIEvent BuildRunError(string message, string runId) =>
+        new()
+        {
+            RunError = new RunErrorEvent
+            {
+                Message = string.IsNullOrWhiteSpace(message) ? "LLM request failed." : message,
+                RunId = runId,
+            },
+        };
+
+    private static AGUIEvent BuildUsageFrame(TokenUsagePayload usage, string? model) =>
+        new()
+        {
+            Usage = new UsageEvent
+            {
+                Available = true,
+                PromptTokens = usage.PromptTokens,
+                CompletionTokens = usage.CompletionTokens,
+                TotalTokens = usage.TotalTokens,
+                Model = string.IsNullOrWhiteSpace(model) ? null : model,
+            },
+        };
+}

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatGAgent.cs
@@ -36,6 +36,7 @@ public sealed class NyxIdChatGAgent : RoleGAgent
 {
     private readonly LocalSkillCatalog? _localSkillCatalog;
     private readonly NyxIdRelayOptions? _relayOptions;
+    private readonly TimeProvider _timeProvider;
 
     public NyxIdChatGAgent(
         ILLMProviderFactory? llmProviderFactory = null,
@@ -46,13 +47,15 @@ public sealed class NyxIdChatGAgent : RoleGAgent
         IEnumerable<IAgentToolSource>? toolSources = null,
         LocalSkillCatalog? localSkillCatalog = null,
         IRemoteToolApprovalPort? remoteToolApprovalPort = null,
-        NyxIdRelayOptions? relayOptions = null)
+        NyxIdRelayOptions? relayOptions = null,
+        TimeProvider? timeProvider = null)
         : base(llmProviderFactory, additionalHooks, agentMiddlewares, toolMiddlewares, llmMiddlewares, toolSources,
                approvalHandler: new YieldApprovalHandler(),
                remoteToolApprovalPort: remoteToolApprovalPort)
     {
         _localSkillCatalog = localSkillCatalog;
         _relayOptions = relayOptions;
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     // Refactor (iter47/issue-877-chat-endpoints-own-lifecycle-and-compensation):
@@ -289,6 +292,14 @@ public sealed class NyxIdChatGAgent : RoleGAgent
         return prompt;
     }
 
+    public override async Task HandleChatRequest(ChatRequestEvent request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        await base.HandleChatRequest(request);
+        await SaveDirectChatCompletionAsync(request, CancellationToken.None);
+    }
+
     private bool RequiresNyxIdProviderMigration()
     {
         var overrides = State.ConfigOverrides;
@@ -356,5 +367,66 @@ public sealed class NyxIdChatGAgent : RoleGAgent
             DestroyActor = destroyActor,
             Reason = reason,
         });
+    }
+
+    private async Task SaveDirectChatCompletionAsync(ChatRequestEvent request, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(request.ScopeId) ||
+            string.IsNullOrWhiteSpace(request.SessionId) ||
+            !State.Sessions.TryGetValue(request.SessionId, out var completedSession) ||
+            !completedSession.Completed)
+        {
+            return;
+        }
+
+        var prompt = request.Prompt ?? completedSession.Prompt ?? string.Empty;
+        var completion = completedSession.FinalContent ?? string.Empty;
+        var completedAt = _timeProvider.GetUtcNow();
+        var timestamp = completedAt.ToUnixTimeMilliseconds();
+        var messages = new[]
+        {
+            new StoredChatMessage(
+                Id: $"{request.SessionId}-user",
+                Role: "user",
+                Content: prompt,
+                Timestamp: timestamp,
+                Status: "completed"),
+            new StoredChatMessage(
+                Id: $"{request.SessionId}-assistant",
+                Role: "assistant",
+                Content: completion,
+                Timestamp: timestamp,
+                Status: "completed",
+                Thinking: string.IsNullOrWhiteSpace(completedSession.FinalReasoningContent)
+                    ? null
+                    : completedSession.FinalReasoningContent),
+        };
+        var meta = new ConversationMeta(
+            Id: Id,
+            Title: BuildConversationTitle(prompt, completion, Id),
+            ServiceId: Id,
+            ServiceKind: NyxIdChatServiceDefaults.GAgentKind,
+            CreatedAt: completedAt,
+            UpdatedAt: completedAt,
+            MessageCount: messages.Length,
+            LlmRoute: NyxIdChatServiceDefaults.ProviderName,
+            LlmModel: string.IsNullOrWhiteSpace(completedSession.Model) ? null : completedSession.Model);
+
+        await Services.GetRequiredService<IChatHistoryCommandPort>()
+            .SaveMessagesAsync(request.ScopeId, Id, meta, messages, ct)
+            .ConfigureAwait(false);
+    }
+
+    private static string BuildConversationTitle(string prompt, string completion, string fallback)
+    {
+        var source = string.IsNullOrWhiteSpace(prompt) ? completion : prompt;
+        source = source.Trim();
+        if (string.IsNullOrWhiteSpace(source))
+            return fallback;
+
+        const int maxTitleLength = 80;
+        return source.Length <= maxTitleLength
+            ? source
+            : source[..maxTitleLength].TrimEnd();
     }
 }

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatProjectionSession.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatProjectionSession.cs
@@ -1,8 +1,9 @@
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.Abstractions.Orchestration;
 using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.Foundation.Abstractions;
-using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.AI.Abstractions;
 using Aevatar.AGUI.Contracts;
 using Google.Protobuf;
 
@@ -187,48 +188,25 @@ public sealed class NyxIdChatSessionEventProjector
         NyxIdChatSessionProjectionContext context,
         EventEnvelope envelope)
     {
-        // Refactor (iter1/cluster-004):
-        //   Old pattern: NyxID SSE endpoints subscribed to raw EventEnvelope and inferred terminal state.
-        //   New principle: Projection consumes EventEnvelope once and publishes typed AGUIEvent session frames.
         if (string.IsNullOrWhiteSpace(context.RootActorId) || string.IsNullOrWhiteSpace(context.SessionId))
             return EmptyEntries;
 
-        var mapped = ScopeGAgentAguiEventMapper.TryMap(envelope);
-        if (mapped == null)
+        if (!CommittedStateEventEnvelope.TryGetObservedPayload(envelope, out var payload, out _, out _) ||
+            payload?.Is(RoleChatSessionCompletedEvent.Descriptor) != true)
+        {
             return EmptyEntries;
+        }
 
-        FillSessionDefaults(context, mapped);
-        if (mapped.EventCase != AGUIEvent.EventOneofCase.TextMessageEnd)
-            return [Entry(context, mapped)];
-
-        return
-        [
-            Entry(context, mapped),
-            Entry(context, new AGUIEvent
-            {
-                RunFinished = new RunFinishedEvent
-                {
-                    ThreadId = context.RootActorId,
-                    RunId = context.SessionId,
-                },
-            }),
-        ];
+        var completed = payload.Unpack<RoleChatSessionCompletedEvent>();
+        return NyxIdChatCompletionAguiFrameBuilder.Build(context, completed)
+            .Select(frame => Entry(context, frame))
+            .ToArray();
     }
 
     private static ProjectionSessionEventEntry<AGUIEvent> Entry(
         NyxIdChatSessionProjectionContext context,
         AGUIEvent evt) =>
         new(context.RootActorId, context.SessionId, evt);
-
-    private static void FillSessionDefaults(NyxIdChatSessionProjectionContext context, AGUIEvent evt)
-    {
-        if (evt.TextMessageStart != null && string.IsNullOrWhiteSpace(evt.TextMessageStart.MessageId))
-            evt.TextMessageStart.MessageId = context.SessionId;
-        if (evt.TextMessageContent != null && string.IsNullOrWhiteSpace(evt.TextMessageContent.MessageId))
-            evt.TextMessageContent.MessageId = context.SessionId;
-        if (evt.TextMessageEnd != null && string.IsNullOrWhiteSpace(evt.TextMessageEnd.MessageId))
-            evt.TextMessageEnd.MessageId = context.SessionId;
-    }
 }
 
 internal static class NyxIdChatProjectionKinds

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -2665,15 +2665,13 @@ public class NyxIdChatEndpointsCoverageTests
 
         await projector.ProjectAsync(
             context,
-            new EventEnvelope { Payload = Any.Pack(new AiTextMessageContentEvent { Delta = "delta-1" }) },
-            CancellationToken.None);
-        await projector.ProjectAsync(
-            context,
-            new EventEnvelope
-            {
-                Payload = Any.Pack(new ChatTokenUsageEvent
+            CommittedNyxIdCompletionEnvelope(
+                context.RootActorId,
+                new RoleChatSessionCompletedEvent
                 {
                     SessionId = "session-1",
+                    Content = "done",
+                    ContentEmitted = false,
                     Usage = new TokenUsagePayload
                     {
                         PromptTokens = 2,
@@ -2682,22 +2680,36 @@ public class NyxIdChatEndpointsCoverageTests
                     },
                     Model = "nyxid-model",
                 }),
-            },
-            CancellationToken.None);
-        await projector.ProjectAsync(
-            context,
-            new EventEnvelope { Payload = Any.Pack(new AiTextMessageEndEvent { Content = "done" }) },
             CancellationToken.None);
 
-        sessionHub.Published.Should().HaveCount(4);
-        sessionHub.Published[0].Event.TextMessageContent.Delta.Should().Be("delta-1");
-        sessionHub.Published[1].Event.EventCase.Should().Be(AGUIEvent.EventOneofCase.Usage);
-        sessionHub.Published[1].Event.Usage.Available.Should().BeTrue();
-        sessionHub.Published[1].Event.Usage.TotalTokens.Should().Be(6);
-        sessionHub.Published[2].Event.EventCase.Should().Be(AGUIEvent.EventOneofCase.TextMessageEnd);
-        sessionHub.Published[3].Event.EventCase.Should().Be(AGUIEvent.EventOneofCase.RunFinished);
+        sessionHub.Published.Should().HaveCount(5);
+        sessionHub.Published[0].Event.EventCase.Should().Be(AGUIEvent.EventOneofCase.TextMessageStart);
+        sessionHub.Published[1].Event.TextMessageContent.Delta.Should().Be("done");
+        sessionHub.Published[2].Event.EventCase.Should().Be(AGUIEvent.EventOneofCase.Usage);
+        sessionHub.Published[2].Event.Usage.Available.Should().BeTrue();
+        sessionHub.Published[2].Event.Usage.TotalTokens.Should().Be(6);
+        sessionHub.Published[3].Event.EventCase.Should().Be(AGUIEvent.EventOneofCase.TextMessageEnd);
+        sessionHub.Published[4].Event.EventCase.Should().Be(AGUIEvent.EventOneofCase.RunFinished);
         sessionHub.Published.Should().OnlyContain(x => x.RootActorId == "actor-1" && x.SessionId == "session-1");
     }
+
+    private static EventEnvelope CommittedNyxIdCompletionEnvelope(string actorId, RoleChatSessionCompletedEvent evt) => new()
+    {
+        Id = Guid.NewGuid().ToString("N"),
+        Payload = Any.Pack(new CommittedStateEventPublished
+        {
+            StateEvent = new StateEvent
+            {
+                EventId = Guid.NewGuid().ToString("N"),
+                Version = 1,
+                EventData = Any.Pack(evt),
+                Timestamp = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            },
+            StateRoot = Any.Pack(new RoleGAgentState()),
+        }),
+        Route = EnvelopeRouteSemantics.CreateObserverPublication(actorId),
+        Timestamp = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+    };
 
     private static async Task<IResult> InvokeResultAsync(string methodName, params object[] args)
     {

--- a/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
@@ -22,7 +22,7 @@ public class NyxIdChatGAgentTests
     [Fact]
     public async Task ActivateAsync_ShouldPinNyxIdProviderOnFirstInitialization()
     {
-        using var provider = BuildServiceProvider();
+        using var provider = BuildServiceProvider(historyCommandPort: new RecordingChatHistoryCommandPort());
         var agent = CreateAgent(provider, "nyxid-chat-init");
 
         await agent.ActivateAsync();
@@ -36,7 +36,7 @@ public class NyxIdChatGAgentTests
     [Fact]
     public async Task ActivateAsync_ShouldMigrateLegacyBlankProviderToNyxId()
     {
-        using var provider = BuildServiceProvider();
+        using var provider = BuildServiceProvider(historyCommandPort: new RecordingChatHistoryCommandPort());
         var actorId = "nyxid-chat-migration";
 
         var legacyAgent = CreateAgent(provider, actorId);
@@ -76,7 +76,7 @@ public class NyxIdChatGAgentTests
         const string toolArgs = """{"action":"show","slug":"telegram-bot"}""";
         const string toolResult = """{"slug":"telegram-bot","provider_type":"api_key"}""";
 
-        using var provider = BuildServiceProvider();
+        using var provider = BuildServiceProvider(historyCommandPort: new RecordingChatHistoryCommandPort());
         var llmProviderFactory = new StreamingToolLoopProviderFactory(
             [
                 [
@@ -168,7 +168,7 @@ public class NyxIdChatGAgentTests
     [Fact]
     public async Task ActivateAsync_ShouldUseConfiguredRelayCallbackUrlInSystemPrompt()
     {
-        using var provider = BuildServiceProvider();
+        using var provider = BuildServiceProvider(historyCommandPort: new RecordingChatHistoryCommandPort());
         var llmProviderFactory = new StreamingToolLoopProviderFactory(
             [
                 [
@@ -198,6 +198,96 @@ public class NyxIdChatGAgentTests
         systemPrompt.Should().Contain("do not call `lark_messages_reply` or `lark_messages_react` to deliver the answer");
         systemPrompt.Should().Contain("the channel runtime will send it through the Nyx relay reply token");
         systemPrompt.Should().NotContain("call `lark_messages_react` first");
+    }
+
+    [Fact]
+    public async Task HandleChatRequest_ShouldSaveDirectChatTurnToHistory()
+    {
+        var history = new RecordingChatHistoryCommandPort();
+        var now = DateTimeOffset.Parse("2026-06-11T01:02:03Z", null, System.Globalization.DateTimeStyles.AssumeUniversal);
+        using var provider = BuildServiceProvider(historyCommandPort: history);
+        var llmProviderFactory = new StreamingToolLoopProviderFactory(
+            [
+                [
+                    new LLMStreamChunk
+                    {
+                        DeltaContent = "direct answer",
+                        Usage = new TokenUsage(3, 5, 8),
+                    },
+                ],
+            ]);
+        var agent = CreateAgent(
+            provider,
+            "nyxid-chat-history",
+            llmProviderFactory,
+            timeProvider: new FixedTimeProvider(now));
+
+        await agent.ActivateAsync();
+        await agent.HandleChatRequest(new ChatRequestEvent
+        {
+            ScopeId = "scope-a",
+            Prompt = "How do I connect a bot?",
+            SessionId = "session-history",
+        });
+
+        history.Saved.Should().ContainSingle();
+        var saved = history.Saved.Single();
+        saved.ScopeId.Should().Be("scope-a");
+        saved.ConversationId.Should().Be("nyxid-chat-history");
+        saved.Meta.Should().BeEquivalentTo(new ConversationMeta(
+            "nyxid-chat-history",
+            "How do I connect a bot?",
+            "nyxid-chat-history",
+            NyxIdChatServiceDefaults.GAgentKind,
+            now,
+            now,
+            2,
+            NyxIdChatServiceDefaults.ProviderName,
+            null));
+        saved.Messages.Should().HaveCount(2);
+        saved.Messages[0].Should().BeEquivalentTo(new StoredChatMessage(
+            "session-history-user",
+            "user",
+            "How do I connect a bot?",
+            now.ToUnixTimeMilliseconds(),
+            "completed",
+            null,
+            null,
+            null,
+            null));
+        saved.Messages[1].Should().BeEquivalentTo(new StoredChatMessage(
+            "session-history-assistant",
+            "assistant",
+            "direct answer",
+            now.ToUnixTimeMilliseconds(),
+            "completed",
+            null,
+            null,
+            null,
+            null));
+    }
+
+    [Fact]
+    public async Task HandleChatRequest_ShouldNotSaveHistoryWithoutScopeId()
+    {
+        var history = new RecordingChatHistoryCommandPort();
+        using var provider = BuildServiceProvider(historyCommandPort: history);
+        var llmProviderFactory = new StreamingToolLoopProviderFactory(
+            [
+                [
+                    new LLMStreamChunk { DeltaContent = "direct answer" },
+                ],
+            ]);
+        var agent = CreateAgent(provider, "nyxid-chat-no-scope", llmProviderFactory);
+
+        await agent.ActivateAsync();
+        await agent.HandleChatRequest(new ChatRequestEvent
+        {
+            Prompt = "hello",
+            SessionId = "session-no-scope",
+        });
+
+        history.Saved.Should().BeEmpty();
     }
 
     [Fact]
@@ -274,7 +364,8 @@ public class NyxIdChatGAgentTests
 
     private static ServiceProvider BuildServiceProvider(
         IGAgentActorRegistryCommandPort? registryCommandPort = null,
-        IActorRuntime? actorRuntime = null)
+        IActorRuntime? actorRuntime = null,
+        IChatHistoryCommandPort? historyCommandPort = null)
     {
         var services = new ServiceCollection()
             .AddSingleton<IEventStore, InMemoryEventStoreForTests>()
@@ -288,6 +379,9 @@ public class NyxIdChatGAgentTests
         if (actorRuntime is not null)
             services.AddSingleton(actorRuntime);
 
+        if (historyCommandPort is not null)
+            services.AddSingleton(historyCommandPort);
+
         return services.BuildServiceProvider();
     }
 
@@ -296,9 +390,14 @@ public class NyxIdChatGAgentTests
         string actorId,
         ILLMProviderFactory? llmProviderFactory = null,
         IEnumerable<IAgentToolSource>? toolSources = null,
-        NyxIdRelayOptions? relayOptions = null)
+        NyxIdRelayOptions? relayOptions = null,
+        TimeProvider? timeProvider = null)
     {
-        var agent = new NyxIdChatGAgent(llmProviderFactory, toolSources: toolSources, relayOptions: relayOptions)
+        var agent = new NyxIdChatGAgent(
+            llmProviderFactory,
+            toolSources: toolSources,
+            relayOptions: relayOptions,
+            timeProvider: timeProvider)
         {
             Services = provider,
             EventSourcingBehaviorFactory = provider.GetRequiredService<IEventSourcingBehaviorFactory<RoleGAgentState>>(),
@@ -344,6 +443,40 @@ public class NyxIdChatGAgentTests
                 registration,
                 GAgentActorRegistryCommandStage.AdmissionRemoved));
         }
+    }
+
+    private sealed class RecordingChatHistoryCommandPort : IChatHistoryCommandPort
+    {
+        public List<SavedChatHistory> Saved { get; } = [];
+        public List<(string ScopeId, string ConversationId)> Deleted { get; } = [];
+
+        public Task SaveMessagesAsync(
+            string scopeId,
+            string conversationId,
+            ConversationMeta meta,
+            IReadOnlyList<StoredChatMessage> messages,
+            CancellationToken ct = default)
+        {
+            Saved.Add(new SavedChatHistory(scopeId, conversationId, meta, messages.ToArray()));
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteConversationAsync(string scopeId, string conversationId, CancellationToken ct = default)
+        {
+            Deleted.Add((scopeId, conversationId));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record SavedChatHistory(
+        string ScopeId,
+        string ConversationId,
+        ConversationMeta Meta,
+        IReadOnlyList<StoredChatMessage> Messages);
+
+    private sealed class FixedTimeProvider(DateTimeOffset value) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => value;
     }
 
     private sealed class NoopRuntimeCallbackScheduler : IActorRuntimeCallbackScheduler

--- a/test/Aevatar.AI.Tests/NyxIdChatProjectionSessionTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatProjectionSessionTests.cs
@@ -141,7 +141,7 @@ public sealed class NyxIdChatProjectionSessionTests
     }
 
     [Fact]
-    public async Task Projector_ShouldFillMessageDefaultsAndEmitTerminalFrame()
+    public async Task Projector_ShouldIgnoreBareTransientTextEvents()
     {
         var hub = new RecordingSessionEventHub();
         var projector = new NyxIdChatSessionEventProjector(hub);
@@ -191,11 +191,46 @@ public sealed class NyxIdChatProjectionSessionTests
             },
             CancellationToken.None);
 
+        hub.Published.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Projector_ShouldEmitTerminalFramesFromCommittedCompletion()
+    {
+        var hub = new RecordingSessionEventHub();
+        var projector = new NyxIdChatSessionEventProjector(hub);
+        var context = new NyxIdChatSessionProjectionContext
+        {
+            RootActorId = "chat-actor-1",
+            SessionId = "session-1",
+            ProjectionKind = "nyxid-chat-session",
+        };
+
+        await projector.ProjectAsync(
+            context,
+            CommittedEnvelope(
+                context.RootActorId,
+                new RoleChatSessionCompletedEvent
+                {
+                    SessionId = "session-1",
+                    Content = "done",
+                    ContentEmitted = false,
+                    Usage = new TokenUsagePayload
+                    {
+                        PromptTokens = 2,
+                        CompletionTokens = 4,
+                        TotalTokens = 6,
+                    },
+                    Model = "nyxid-model",
+                }),
+            CancellationToken.None);
+
         hub.Published.Should().HaveCount(5);
         hub.Published.Should().OnlyContain(p => p.RootActorId == "chat-actor-1" && p.SessionId == "session-1");
         hub.Published[0].Event.TextMessageStart.MessageId.Should().Be("session-1");
+        hub.Published[0].Event.TextMessageStart.Role.Should().Be("assistant");
         hub.Published[1].Event.TextMessageContent.MessageId.Should().Be("session-1");
-        hub.Published[1].Event.TextMessageContent.Delta.Should().Be("delta");
+        hub.Published[1].Event.TextMessageContent.Delta.Should().Be("done");
         hub.Published[2].Event.Usage.Should().NotBeNull();
         hub.Published[2].Event.Usage.Available.Should().BeTrue();
         hub.Published[2].Event.Usage.TotalTokens.Should().Be(6);
@@ -203,6 +238,67 @@ public sealed class NyxIdChatProjectionSessionTests
         hub.Published[3].Event.TextMessageEnd.MessageId.Should().Be("session-1");
         hub.Published[4].Event.RunFinished.ThreadId.Should().Be("chat-actor-1");
         hub.Published[4].Event.RunFinished.RunId.Should().Be("session-1");
+        hub.Published[4].Event.RunFinished.Result.Unpack<StringValue>().Value.Should().Be("done");
+    }
+
+    [Fact]
+    public async Task Projector_ShouldSynthesizeContent_WhenActorAlreadyEmittedTransientFrames()
+    {
+        var hub = new RecordingSessionEventHub();
+        var projector = new NyxIdChatSessionEventProjector(hub);
+        var context = new NyxIdChatSessionProjectionContext
+        {
+            RootActorId = "chat-actor-1",
+            SessionId = "session-1",
+            ProjectionKind = "nyxid-chat-session",
+        };
+
+        await projector.ProjectAsync(
+            context,
+            CommittedEnvelope(
+                context.RootActorId,
+                new RoleChatSessionCompletedEvent
+                {
+                    SessionId = "session-1",
+                    Content = "done",
+                    ContentEmitted = true,
+                }),
+            CancellationToken.None);
+
+        hub.Published.Select(p => p.Event.EventCase).Should().Equal(
+            AGUIEvent.EventOneofCase.TextMessageStart,
+            AGUIEvent.EventOneofCase.TextMessageContent,
+            AGUIEvent.EventOneofCase.TextMessageEnd,
+            AGUIEvent.EventOneofCase.RunFinished);
+        hub.Published[1].Event.TextMessageContent.Delta.Should().Be("done");
+    }
+
+    [Fact]
+    public async Task Projector_ShouldEmitRunErrorFromCommittedFailure()
+    {
+        var hub = new RecordingSessionEventHub();
+        var projector = new NyxIdChatSessionEventProjector(hub);
+        var context = new NyxIdChatSessionProjectionContext
+        {
+            RootActorId = "chat-actor-1",
+            SessionId = "session-1",
+            ProjectionKind = "nyxid-chat-session",
+        };
+
+        await projector.ProjectAsync(
+            context,
+            CommittedEnvelope(
+                context.RootActorId,
+                new RoleChatSessionCompletedEvent
+                {
+                    SessionId = "session-1",
+                    Content = "LLM request failed [tools=none]: upstream unavailable",
+                }),
+            CancellationToken.None);
+
+        hub.Published.Should().ContainSingle();
+        hub.Published[0].Event.RunError.Message.Should().Be("upstream unavailable");
+        hub.Published[0].Event.RunError.RunId.Should().Be("session-1");
     }
 
     [Fact]
@@ -238,6 +334,23 @@ public sealed class NyxIdChatProjectionSessionTests
 
         hub.Published.Should().BeEmpty();
     }
+
+    private static EventEnvelope CommittedEnvelope(string actorId, IMessage evt) => new()
+    {
+        Payload = Any.Pack(new CommittedStateEventPublished
+        {
+            StateEvent = new StateEvent
+            {
+                EventId = Guid.NewGuid().ToString("N"),
+                Version = 1,
+                EventData = Any.Pack(evt),
+                Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            },
+            StateRoot = Any.Pack(new RoleGAgentState()),
+        }),
+        Route = EnvelopeRouteSemantics.CreateObserverPublication(actorId),
+        Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+    };
 
     private sealed class RecordingReleaseService : IProjectionScopeReleaseService<NyxIdChatSessionRuntimeLease>
     {


### PR DESCRIPTION
## 摘要

修复 #1970：nyxid-chat 第一方直连 `:stream` 的回复「凭空消失」——LLM 已生成、actor 已 commit，但 SSE 只有 RUN_STARTED、chat-history 为空。

根因（issue 内有完整 file:line 取证）：observation relay 只转发 `CommittedStateEventPublished`，而 `NyxIdChatSessionEventProjector` 只映射生产链路送不到的裸 `TextMessage*` 瞬态帧 → 对任何可能收到的 envelope 都产出零帧；direct path 的 server 侧 chat-history 写入从未存在。

方案（design-consensus r3 共识，3/3 solver 选 A，framing=structural）：
- **SSE**：删除不可达的裸帧 mapper 分支；projector 解包 committed `RoleChatSessionCompletedEvent`，经新增 `NyxIdChatCompletionAguiFrameBuilder` 合成 terminal AGUI 帧（content→TextMessageStart/Content，failure→RunError，Usage、TextMessageEnd、RunFinished）。
- **History**：`NyxIdChatGAgent.HandleChatRequest` override 在 `base` turn 完成、completion state 已应用后，同一 actor turn 内用现有 `IChatHistoryCommandPort.SaveMessagesAsync` 写入本轮 user/assistant 对（归属事实 = `ChatRequestEvent.ScopeId` + actor 已提交 state）。
- 不改 proto、不放宽 relay、不新增 materializer、无 query-time replay、无外部仓库改动。

共识 artifact：`.refactor-loop/runs/phase9-issue1970-r3-judge.md`（issue 评论含全部 solver/judge 自发记录）。

## Changed files
- Added a NyxID chat completion AGUI frame builder and changed the projection session to consume committed RoleChatSessionCompletedEvent observer publications instead of bare transient text/usage envelopes.
- Updated NyxIdChatGAgent direct chat handling to persist the current user/assistant turn to chat history after the base actor turn has applied completion state.
- Updated NyxID chat tests for committed-only SSE projection, terminal frame synthesis, direct history persistence, and the existing endpoint coverage contract.

## Test results
- dotnet build aevatar.slnx --nologo: passed with existing NU1510 warnings.
- dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --filter "FullyQualifiedName~NyxIdChat" --nologo: passed, 134 passed.
- bash tools/ci/test_stability_guards.sh: passed.
- bash tools/ci/query_projection_priming_guard.sh: passed.

## Deviations
- Closes #1970
- Scope extension: test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs was updated because an existing NyxIdChat filtered test conflicted with the authorized committed-only projection behavior.
- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)

⟦AI:AUTO-LOOP⟧
