### PR TITLE
允许 DeviceInbound 直达语音注入

### DIFF
--- a/agents/Aevatar.GAgents.Device/DeviceEventEndpoints.cs
+++ b/agents/Aevatar.GAgents.Device/DeviceEventEndpoints.cs
@@ -256,9 +256,69 @@ public static class DeviceEventEndpoints
                     Text = GetOptionalString(inner, "text"),
                 };
                 break;
+            case "doorbell_pressed":
+            case "smoke_detected":
+            case "water_leak_detected":
+            case "carbon_monoxide_detected":
+            case "glass_break_detected":
+            case "lock_tampered":
+            case "alarm_triggered":
+                inbound.HomeAlert = new HomeAlertDeviceInboundPayload
+                {
+                    Severity = ResolveHomeAlertSeverity(inbound.EventType, inner),
+                    Area = GetOptionalString(inner, "area"),
+                    EntityId = GetOptionalString(inner, "entity_id"),
+                    CorrelationKey = FirstNonEmpty(
+                        GetOptionalString(inner, "correlation_key"),
+                        GetOptionalString(inner, "event_id"),
+                        inbound.EventId),
+                    Summary = FirstNonEmpty(
+                        GetOptionalString(inner, "summary"),
+                        GetOptionalString(inner, "description"),
+                        inbound.EventType),
+                };
+                break;
             default:
                 throw new JsonException($"Unsupported device event_type '{inbound.EventType}'");
         }
+    }
+
+    private static DeviceEventSeverity ResolveHomeAlertSeverity(string eventType, JsonElement inner)
+    {
+        var configuredSeverity = GetOptionalString(inner, "severity");
+        if (!string.IsNullOrWhiteSpace(configuredSeverity))
+        {
+            return configuredSeverity.Trim().ToLowerInvariant() switch
+            {
+                "critical" or "emergency" or "alarm" => DeviceEventSeverity.Critical,
+                "warning" or "warn" => DeviceEventSeverity.Warning,
+                "info" or "information" => DeviceEventSeverity.Info,
+                _ => DeviceEventSeverity.Unspecified,
+            };
+        }
+
+        return eventType switch
+        {
+            "smoke_detected" or
+            "water_leak_detected" or
+            "carbon_monoxide_detected" or
+            "glass_break_detected" or
+            "lock_tampered" or
+            "alarm_triggered" => DeviceEventSeverity.Critical,
+            "doorbell_pressed" => DeviceEventSeverity.Info,
+            _ => DeviceEventSeverity.Unspecified,
+        };
+    }
+
+    private static string FirstNonEmpty(params string[] values)
+    {
+        foreach (var value in values)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+                return value.Trim();
+        }
+
+        return string.Empty;
     }
 
     private static string GetOptionalString(JsonElement root, string propertyName)

--- a/agents/Aevatar.GAgents.Household/household_messages.proto
+++ b/agents/Aevatar.GAgents.Household/household_messages.proto
@@ -149,6 +149,21 @@ message SpeechDeviceInboundPayload {
   string text = 1;
 }
 
+enum DeviceEventSeverity {
+  DEVICE_EVENT_SEVERITY_UNSPECIFIED = 0;
+  DEVICE_EVENT_SEVERITY_INFO = 1;
+  DEVICE_EVENT_SEVERITY_WARNING = 2;
+  DEVICE_EVENT_SEVERITY_CRITICAL = 3;
+}
+
+message HomeAlertDeviceInboundPayload {
+  DeviceEventSeverity severity = 1;
+  string area = 2;
+  string entity_id = 3;
+  string correlation_key = 4;
+  string summary = 5;
+}
+
 // V1 normalized device event from NyxID relay's CallbackPayload.
 // Defined in Household domain because it's the inbound contract for
 // HouseholdEntity; DeviceEventEndpoints (boundary layer) references
@@ -172,5 +187,6 @@ message DeviceInbound {
     CameraDeviceInboundPayload camera = 8;
     MotionDeviceInboundPayload motion = 9;
     SpeechDeviceInboundPayload speech = 10;
+    HomeAlertDeviceInboundPayload home_alert = 11;
   }
 }

--- a/docs/adr/0025-voice-router-integration.md
+++ b/docs/adr/0025-voice-router-integration.md
@@ -43,6 +43,13 @@ and provider state machines.
 - Explicit actorId bypass stays at `GET /ws/voice/{actorId}`, but Mainnet Host
   gates it with the `voice-dev` authorization policy (`voice:bypass` scope or
   admin/owner role).
+- Device-originated push events reuse the existing NyxID HTTP Event Gateway to
+  Aevatar `/api/device-events/{registrationId}` path. The device callback
+  facade dispatches a typed `DeviceInbound` protobuf directly to the target
+  actor. `VoicePresenceModule` may admit that direct envelope only when the
+  host explicitly configures the exact protobuf `Any.TypeUrl`, the publisher is
+  `device-events.callback`, the direct target is the current actor, and the
+  actor already has an active voice session or lease.
 
 ## Boundaries
 
@@ -63,6 +70,12 @@ and provider state machines.
 - Rejections that can be known before upgrade use HTTP status codes
   (`403`, `404`, `501`, `503`). WebSocket close `1008` is reserved for failures
   discovered after upgrade.
+- Voice direct external-event admission is not a second webhook, active-session
+  router, readmodel session lookup, or module signal bridge. It reuses the
+  target actor's existing event turn, voice external-event policy, actor-owned
+  dedupe fence, pending injection buffer, and provider injection path. No active
+  voice session means drop and log in v1; it must not create a provider session,
+  create a voice lease, or fall back to text notification.
 - This ADR does not solve #560 stream-session robustness concerns such as
   cross-host reconnect, seq/ack, or replay.
 
@@ -77,3 +90,7 @@ and provider state machines.
 - `/ws/voice/{actorId}` rejects callers without `voice:bypass` or admin/owner.
 - Static checks show no ChatRouting dependency inside
   `Aevatar.Foundation.VoicePresence`.
+- A direct `DeviceInbound` envelope from `device-events.callback` is injected
+  only when its exact TypeUrl is configured and the target actor has an active
+  voice session; untrusted publishers, target mismatch, unknown TypeUrls, and
+  no-session cases are rejected before provider injection.

--- a/docs/adr/0025-voice-router-integration.md
+++ b/docs/adr/0025-voice-router-integration.md
@@ -43,13 +43,6 @@ and provider state machines.
 - Explicit actorId bypass stays at `GET /ws/voice/{actorId}`, but Mainnet Host
   gates it with the `voice-dev` authorization policy (`voice:bypass` scope or
   admin/owner role).
-- Device-originated push events reuse the existing NyxID HTTP Event Gateway to
-  Aevatar `/api/device-events/{registrationId}` path. The device callback
-  facade dispatches a typed `DeviceInbound` protobuf directly to the target
-  actor. `VoicePresenceModule` may admit that direct envelope only when the
-  host explicitly configures the exact protobuf `Any.TypeUrl`, the publisher is
-  `device-events.callback`, the direct target is the current actor, and the
-  actor already has an active voice session or lease.
 
 ## Boundaries
 
@@ -70,12 +63,6 @@ and provider state machines.
 - Rejections that can be known before upgrade use HTTP status codes
   (`403`, `404`, `501`, `503`). WebSocket close `1008` is reserved for failures
   discovered after upgrade.
-- Voice direct external-event admission is not a second webhook, active-session
-  router, readmodel session lookup, or module signal bridge. It reuses the
-  target actor's existing event turn, voice external-event policy, actor-owned
-  dedupe fence, pending injection buffer, and provider injection path. No active
-  voice session means drop and log in v1; it must not create a provider session,
-  create a voice lease, or fall back to text notification.
 - This ADR does not solve #560 stream-session robustness concerns such as
   cross-host reconnect, seq/ack, or replay.
 
@@ -90,7 +77,3 @@ and provider state machines.
 - `/ws/voice/{actorId}` rejects callers without `voice:bypass` or admin/owner.
 - Static checks show no ChatRouting dependency inside
   `Aevatar.Foundation.VoicePresence`.
-- A direct `DeviceInbound` envelope from `device-events.callback` is injected
-  only when its exact TypeUrl is configured and the target actor has an active
-  voice session; untrusted publishers, target mismatch, unknown TypeUrls, and
-  no-session cases are rejected before provider injection.

--- a/docs/canon/aevatar-channel-architecture.md
+++ b/docs/canon/aevatar-channel-architecture.md
@@ -2172,7 +2172,7 @@ v1 cutover step 2 细化为：
 | **Voice Presence** | `VoicePresence` EventModule capability on a target actor; `/ws/voice` policy-aware Host entry; `/ws/voice/{actorId}` dev/admin bypass | 语音是独立 modality：wake word / AEC / VAD / ASR / LLM / TTS 链路完全不同于 IM webhook 模型。VoicePresence 不是独立 router/session GAgent，Voice ↔ Chat 互通接口见 §15.5 open question |
 | **Aevatar Console Web chat 框** | `apps/aevatar-console-web/` | Console 是 aevatar 自有前端 UI，直接调 HTTP API，不走外部 IM channel 链路 |
 | **Direct HTTP API** | `/api/scopes/{scopeId}/...` | 同上 |
-| **DeviceRegistration / HouseholdEntity 设备事件** | `Aevatar.GAgents.Device` + `Aevatar.GAgents.Household` | 设备事件是 sensor push，业务语义和对话无关。transport 虽然也是 webhook，但强行套 channel adapter 抽象会让 `IChannelTransport` / `IChannelOutboundPort` 失焦 |
+| **DeviceRegistration / HouseholdEntity 设备事件** | `Aevatar.GAgents.Device` + `Aevatar.GAgents.Household` | 设备事件是 sensor push，业务语义和对话无关。transport 虽然也是 webhook，但强行套 channel adapter 抽象会让 `IChannelTransport` / `IChannelOutboundPort` 失焦。voice 主动播报复用此路径：NyxID HTTP Event Gateway -> `/api/device-events/{registrationId}` -> typed `DeviceInbound` -> target actor direct envelope；`VoicePresenceModule` 只在 Host 明确配置 exact `Any.TypeUrl`、publisher 为 `device-events.callback`、direct target 等于当前 actor 且存在 active voice session/lease 时注入，v1 无会话 drop+log，不新建 webhook、session router、readmodel lookup 或进程内 active-session registry |
 | **WeChat 个人 bot** | — | transport + capability gap 差异过大，单独 RFC 承接，继承本 RFC 的 `IChannelTransport` + `IChannelOutboundPort` 契约 |
 
 这是**显式的 scope 收缩**，避免抽象被"所有 aevatar 入口都要统一"的诱惑牵引而退化成 LCD（最小公约数）。

--- a/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
@@ -473,6 +473,8 @@ public static class ServiceCollectionExtensions
             ToolExecutionTimeout = options.ToolExecutionTimeout,
             PendingInjectionCapacity = options.PendingInjectionCapacity,
             TimeProvider = options.TimeProvider,
+            DirectExternalEventTypeUrls = options.DirectExternalEventTypeUrls,
+            DirectExternalEventNoActiveSessionPolicy = options.DirectExternalEventNoActiveSessionPolicy,
         };
 
     private static bool IsOpenAIVoiceConfigured(VoiceProviderConfig config) =>

--- a/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
@@ -23,6 +23,7 @@ namespace Aevatar.Foundation.VoicePresence.Modules;
 public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypassModule
 {
     private static readonly JsonFormatter PayloadJsonFormatter = new(JsonFormatter.Settings.Default);
+    private const string TrustedDirectExternalEventPublisherActorId = "device-events.callback";
     private const int DefaultLastDrainAckResponseId = -1;
     private const long DefaultLastDrainAckPlayoutSequence = -1;
 
@@ -30,6 +31,7 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
     private readonly VoiceProviderConfig _providerConfig;
     private readonly VoiceSessionConfig? _sessionConfig;
     private readonly VoicePresenceModuleOptions _options;
+    private readonly IReadOnlySet<string> _directExternalEventTypeUrls;
     private readonly IVoiceToolInvoker? _toolInvoker;
     private readonly IVoiceToolCatalog? _toolCatalog;
     private readonly ILogger _logger;
@@ -47,6 +49,9 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         _providerConfig = providerConfig?.Clone() ?? throw new ArgumentNullException(nameof(providerConfig));
         _sessionConfig = sessionConfig?.Clone();
         _options = options ?? new VoicePresenceModuleOptions();
+        _directExternalEventTypeUrls = new HashSet<string>(
+            _options.DirectExternalEventTypeUrls,
+            StringComparer.Ordinal);
         _toolInvoker = toolInvoker;
         _toolCatalog = toolCatalog;
         _logger = logger ?? NullLogger.Instance;
@@ -80,7 +85,8 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         return envelope.Payload.Is(VoiceModuleSignal.Descriptor) ||
                envelope.Payload.Is(VoiceProviderEvent.Descriptor) ||
                envelope.Payload.Is(VoiceControlFrame.Descriptor) ||
-               envelope.Route?.IsPublication() == true;
+               envelope.Route?.IsPublication() == true ||
+               IsConfiguredDirectExternalEvent(envelope, null);
     }
 
     public async Task HandleAsync(EventEnvelope envelope, IEventHandlerContext ctx, CancellationToken ct)
@@ -1117,7 +1123,7 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
     {
         var state = HydrateRuntimeStateFromActor(ctx);
 
-        if (!ShouldInjectExternalEvent(envelope, ctx.AgentId))
+        if (!ShouldInjectExternalEvent(envelope, ctx.AgentId, state))
             return;
 
         var now = _options.TimeProvider.GetUtcNow();
@@ -1141,7 +1147,10 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         await PersistRuntimeStateAsync(ctx, state, ct);
     }
 
-    private bool ShouldInjectExternalEvent(EventEnvelope envelope, string agentId)
+    private bool ShouldInjectExternalEvent(
+        EventEnvelope envelope,
+        string agentId,
+        VoicePresenceRuntimeState state)
     {
         if (envelope.Payload == null)
             return false;
@@ -1154,11 +1163,50 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
             return false;
         }
 
-        if (envelope.Route?.IsPublication() != true)
+        if (envelope.Route?.IsPublication() == true)
+            return !string.Equals(envelope.Route.PublisherActorId, agentId, StringComparison.Ordinal);
+
+        if (!IsConfiguredDirectExternalEvent(envelope, agentId))
             return false;
 
-        return !string.Equals(envelope.Route.PublisherActorId, agentId, StringComparison.Ordinal);
+        if (HasActiveSession(state))
+            return true;
+
+        if (_options.DirectExternalEventNoActiveSessionPolicy ==
+            VoiceDirectExternalEventNoActiveSessionPolicy.DropAndLog)
+        {
+            _logger.LogInformation(
+                "Dropping direct external voice event: reason=no_active_session envelope_id={EnvelopeId} publisher_actor_id={PublisherActorId} event_type={EventType} target_actor_id={TargetActorId}.",
+                envelope.Id ?? string.Empty,
+                envelope.Route?.PublisherActorId ?? string.Empty,
+                envelope.Payload.TypeUrl ?? string.Empty,
+                envelope.Route?.GetTargetActorId() ?? string.Empty);
+        }
+
+        return false;
     }
+
+    private bool IsConfiguredDirectExternalEvent(EventEnvelope envelope, string? agentId)
+    {
+        if (_directExternalEventTypeUrls.Count == 0 ||
+            envelope.Payload == null ||
+            envelope.Route?.IsDirect() != true ||
+            !string.Equals(
+                envelope.Route.PublisherActorId,
+                TrustedDirectExternalEventPublisherActorId,
+                StringComparison.Ordinal) ||
+            !_directExternalEventTypeUrls.Contains(envelope.Payload.TypeUrl ?? string.Empty))
+        {
+            return false;
+        }
+
+        return agentId == null ||
+               string.Equals(envelope.Route.GetTargetActorId(), agentId, StringComparison.Ordinal);
+    }
+
+    private bool HasActiveSession(VoicePresenceRuntimeState state) =>
+        !string.IsNullOrWhiteSpace(state.ActiveSessionId) &&
+        !IsLeaseExpired(state.LeaseExpiresAt);
 
     private VoicePendingEventInjection BuildPendingInjection(EventEnvelope envelope, DateTimeOffset now)
     {

--- a/src/Aevatar.Foundation.VoicePresence/VoicePresenceModuleOptions.cs
+++ b/src/Aevatar.Foundation.VoicePresence/VoicePresenceModuleOptions.cs
@@ -5,6 +5,8 @@ namespace Aevatar.Foundation.VoicePresence;
 /// </summary>
 public sealed class VoicePresenceModuleOptions
 {
+    private IReadOnlyList<string> _directExternalEventTypeUrls = [];
+
     public string Name { get; init; } = "voice_presence";
 
     public int Priority { get; init; }
@@ -20,4 +22,30 @@ public sealed class VoicePresenceModuleOptions
     public int PendingInjectionCapacity { get; init; } = 16;
 
     public TimeProvider TimeProvider { get; init; } = TimeProvider.System;
+
+    public IReadOnlyList<string> DirectExternalEventTypeUrls
+    {
+        get => _directExternalEventTypeUrls;
+        init => _directExternalEventTypeUrls = NormalizeTypeUrls(value);
+    }
+
+    public VoiceDirectExternalEventNoActiveSessionPolicy DirectExternalEventNoActiveSessionPolicy { get; init; } =
+        VoiceDirectExternalEventNoActiveSessionPolicy.DropAndLog;
+
+    private static IReadOnlyList<string> NormalizeTypeUrls(IEnumerable<string>? typeUrls)
+    {
+        if (typeUrls == null)
+            return [];
+
+        return typeUrls
+            .Select(static typeUrl => typeUrl.Trim())
+            .Where(static typeUrl => !string.IsNullOrWhiteSpace(typeUrl))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+}
+
+public enum VoiceDirectExternalEventNoActiveSessionPolicy
+{
+    DropAndLog = 0,
 }

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -16,6 +16,7 @@ using Aevatar.AI.ToolProviders.ToolSetRegistry;
 using Aevatar.AI.ToolProviders.Web;
 using Aevatar.Authentication.Hosting;
 using Aevatar.Authentication.Providers.NyxId;
+using Aevatar.Bootstrap.Extensions.AI;
 using Aevatar.Bootstrap.Hosting;
 using Aevatar.ChatRouting.Core;
 using Aevatar.GAgentService.Abstractions.Responses;
@@ -38,6 +39,7 @@ using Aevatar.GAgents.StatusDashboard.DependencyInjection;
 using Aevatar.GAgents.StatusDashboard.Executors;
 using Aevatar.GAgents.StreamingProxy;
 using Aevatar.Foundation.Runtime.Hosting.Maintenance;
+using Aevatar.Foundation.VoicePresence;
 using Aevatar.Foundation.VoicePresence.Hosting;
 using Aevatar.Mainnet.Host.Api.ChatCompletions;
 using Aevatar.Mainnet.Host.Api.ChatRouting;
@@ -64,6 +66,8 @@ public static class MainnetHostBuilderExtensions
     internal const int ContainerHttpPort = 8080;
     internal const string ContainerListenUrl = "http://+:8080";
     internal const string LocalDevelopmentListenUrl = "http://127.0.0.1:5080";
+    private const string DeviceInboundDirectExternalEventTypeUrl =
+        "type.googleapis.com/aevatar.gagents.household.DeviceInbound";
 
     public static WebApplicationBuilder AddAevatarMainnetHost(
         this WebApplicationBuilder builder,
@@ -111,6 +115,7 @@ public static class MainnetHostBuilderExtensions
         builder.AddAevatarPlatform(options =>
         {
             options.EnableMakerExtensions = true;
+            options.ConfigureAIFeatures = ConfigureMainnetAIFeatures;
         });
         builder.AddGAgentServiceCapabilityBundle();
         builder.AddStudioCapability();
@@ -387,5 +392,41 @@ public static class MainnetHostBuilderExtensions
         var value = Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER");
         return string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) ||
                string.Equals(value, "1", StringComparison.Ordinal);
+    }
+
+    private static void ConfigureMainnetAIFeatures(AevatarAIFeatureOptions options)
+    {
+        if (!options.VoicePresence.Module.DirectExternalEventTypeUrls.Contains(
+                DeviceInboundDirectExternalEventTypeUrl,
+                StringComparer.Ordinal))
+        {
+            options.VoicePresence.Module = CloneVoicePresenceModuleOptionsWithDirectEventType(
+                options.VoicePresence.Module,
+                DeviceInboundDirectExternalEventTypeUrl);
+        }
+    }
+
+    private static VoicePresenceModuleOptions CloneVoicePresenceModuleOptionsWithDirectEventType(
+        VoicePresenceModuleOptions options,
+        string typeUrl)
+    {
+        var directEventTypeUrls = options.DirectExternalEventTypeUrls
+            .Append(typeUrl)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        return new VoicePresenceModuleOptions
+        {
+            Name = options.Name,
+            Priority = options.Priority,
+            LinkId = options.LinkId,
+            StaleAfter = options.StaleAfter,
+            DedupeWindow = options.DedupeWindow,
+            ToolExecutionTimeout = options.ToolExecutionTimeout,
+            PendingInjectionCapacity = options.PendingInjectionCapacity,
+            TimeProvider = options.TimeProvider,
+            DirectExternalEventTypeUrls = directEventTypeUrls,
+            DirectExternalEventNoActiveSessionPolicy = options.DirectExternalEventNoActiveSessionPolicy,
+        };
     }
 }

--- a/test/Aevatar.Bootstrap.Tests/AIFeatureBootstrapCoverageTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/AIFeatureBootstrapCoverageTests.cs
@@ -21,7 +21,6 @@ using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.Foundation.Abstractions.EventModules;
-using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.Foundation.VoicePresence;
 using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.Foundation.VoicePresence.Abstractions;
@@ -208,12 +207,79 @@ public class AIFeatureBootstrapCoverageTests
 
         factory.TryCreate("voice_presence", out var defaultModule).Should().BeTrue();
         defaultModule.Should().BeOfType<VoicePresenceModule>();
+        defaultModule.As<VoicePresenceModule>()
+            .CanHandle(new EventEnvelope
+            {
+                Payload = Google.Protobuf.WellKnownTypes.Any.Pack(new Google.Protobuf.WellKnownTypes.StringValue
+                {
+                    Value = "doorbell",
+                }),
+                Route = EnvelopeRouteSemantics.CreateDirect("device-events.callback", "voice-agent"),
+            })
+            .Should()
+            .BeFalse();
 
         factory.TryCreate("voice_presence_openai", out var openAIModule).Should().BeTrue();
         openAIModule.Should().BeOfType<VoicePresenceModule>();
 
         factory.TryCreate("voice_presence_minicpm", out var miniCpmModule).Should().BeFalse();
         miniCpmModule.Should().BeNull();
+    }
+
+    [Fact]
+    public void AddAevatarAIFeatures_ShouldPreserveConfiguredVoiceDirectExternalEventTypeUrls()
+    {
+        var services = new ServiceCollection();
+        var config = new ConfigurationBuilder().Build();
+        services.AddLogging();
+        services.AddSingleton<IActorDispatchPort, NoOpActorDispatchPort>();
+        services.AddSingleton<IProjectionDocumentReader<VoicePresenceCapabilityReadModel, string>>(
+            new EmptyVoicePresenceCapabilityReader());
+
+        services.AddAevatarAIFeatures(config, options =>
+        {
+            options.EnableMEAIProviders = false;
+            options.VoicePresence.Module = new VoicePresenceModuleOptions
+            {
+                DirectExternalEventTypeUrls =
+                [
+                    " type.googleapis.com/example.External ",
+                    "type.googleapis.com/example.External",
+                ],
+            };
+            options.VoicePresence.OpenAIProvider = new VoiceProviderConfig
+            {
+                ProviderName = "openai",
+                ApiKey = "voice-openai-key",
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var factory = provider.GetServices<IEventModuleFactory<IEventHandlerContext>>()
+            .OfType<VoicePresenceModuleFactory>()
+            .Single();
+
+        factory.TryCreate("voice_presence", out var module).Should().BeTrue();
+        var voiceModule = module.Should().BeOfType<VoicePresenceModule>().Subject;
+
+        voiceModule.CanHandle(new EventEnvelope
+        {
+            Payload = new Google.Protobuf.WellKnownTypes.Any
+            {
+                TypeUrl = "type.googleapis.com/example.External",
+                Value = Google.Protobuf.ByteString.CopyFromUtf8("payload"),
+            },
+            Route = EnvelopeRouteSemantics.CreateDirect("device-events.callback", "voice-agent"),
+        }).Should().BeTrue();
+        voiceModule.CanHandle(new EventEnvelope
+        {
+            Payload = new Google.Protobuf.WellKnownTypes.Any
+            {
+                TypeUrl = "type.googleapis.com/example.Other",
+                Value = Google.Protobuf.ByteString.CopyFromUtf8("payload"),
+            },
+            Route = EnvelopeRouteSemantics.CreateDirect("device-events.callback", "voice-agent"),
+        }).Should().BeFalse();
     }
 
     [Fact]

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceEventInjectionTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceEventInjectionTests.cs
@@ -208,11 +208,74 @@ public class VoicePresenceEventInjectionTests
         provider.InjectedEvents.ShouldBeEmpty();
     }
 
+    [Fact]
+    public async Task Configured_direct_external_event_with_active_session_should_inject()
+    {
+        var timeProvider = new ManualTimeProvider(new DateTimeOffset(2026, 4, 14, 9, 0, 0, TimeSpan.Zero));
+        var provider = new RecordingVoiceProvider();
+        var module = CreateModule(
+            provider,
+            timeProvider: timeProvider,
+            directExternalEventTypeUrls: ["type.googleapis.com/google.protobuf.StringValue"]);
+        var roleAgent = new RecordingRoleAgent("voice-agent");
+        roleAgent.VoicePresence["voice_presence"] = CreateActiveSessionState();
+        var ctx = new StubEventHandlerContext(roleAgent);
+        var envelope = CreateDirectExternalEnvelope(
+            "device-events.callback",
+            "voice-agent",
+            "doorbell",
+            timeProvider.GetUtcNow());
+
+        await module.InitializeAsync(CancellationToken.None);
+
+        module.CanHandle(envelope).ShouldBeTrue();
+        await module.HandleAsync(envelope, ctx, CancellationToken.None);
+
+        provider.InjectedEvents.ShouldHaveSingleItem();
+        provider.InjectedEvents[0].PublisherActorId.ShouldBe("device-events.callback");
+        provider.InjectedEvents[0].EventType.ShouldBe("type.googleapis.com/google.protobuf.StringValue");
+        provider.InjectedEvents[0].PayloadJson.ShouldBe("\"doorbell\"");
+    }
+
+    [Fact]
+    public async Task Direct_external_event_should_require_configured_type_publisher_target_and_active_session()
+    {
+        var timeProvider = new ManualTimeProvider(new DateTimeOffset(2026, 4, 14, 9, 0, 0, TimeSpan.Zero));
+        var provider = new RecordingVoiceProvider();
+        var module = CreateModule(
+            provider,
+            timeProvider: timeProvider,
+            directExternalEventTypeUrls: ["type.googleapis.com/google.protobuf.StringValue"]);
+        var roleAgent = new RecordingRoleAgent("voice-agent");
+        roleAgent.VoicePresence["voice_presence"] = CreateActiveSessionState();
+        var ctx = new StubEventHandlerContext(roleAgent);
+
+        await module.InitializeAsync(CancellationToken.None);
+
+        await module.HandleAsync(
+            CreateDirectExternalEnvelope("untrusted", "voice-agent", "ignored", timeProvider.GetUtcNow()),
+            ctx,
+            CancellationToken.None);
+        await module.HandleAsync(
+            CreateDirectExternalEnvelope("device-events.callback", "other-agent", "ignored", timeProvider.GetUtcNow()),
+            ctx,
+            CancellationToken.None);
+
+        roleAgent.VoicePresence["voice_presence"] = new VoicePresenceRuntimeState();
+        await module.HandleAsync(
+            CreateDirectExternalEnvelope("device-events.callback", "voice-agent", "ignored", timeProvider.GetUtcNow()),
+            ctx,
+            CancellationToken.None);
+
+        provider.InjectedEvents.ShouldBeEmpty();
+    }
+
     private static VoicePresenceModule CreateModule(
         RecordingVoiceProvider provider,
         TimeProvider? timeProvider = null,
         TimeSpan? staleAfter = null,
-        int pendingInjectionCapacity = 16) =>
+        int pendingInjectionCapacity = 16,
+        IReadOnlyList<string>? directExternalEventTypeUrls = null) =>
         new(
             provider,
             new VoiceProviderConfig
@@ -234,6 +297,7 @@ public class VoicePresenceEventInjectionTests
                 DedupeWindow = TimeSpan.FromSeconds(2),
                 PendingInjectionCapacity = pendingInjectionCapacity,
                 TimeProvider = timeProvider ?? TimeProvider.System,
+                DirectExternalEventTypeUrls = directExternalEventTypeUrls ?? [],
             });
 
     private static EventEnvelope CreateExternalEnvelope(
@@ -246,6 +310,29 @@ public class VoicePresenceEventInjectionTests
             Timestamp = Timestamp.FromDateTimeOffset(observedAt),
             Payload = Any.Pack(new StringValue { Value = value }),
             Route = EnvelopeRouteSemantics.CreateTopologyPublication(publisherActorId, TopologyAudience.Children),
+        };
+
+    private static EventEnvelope CreateDirectExternalEnvelope(
+        string publisherActorId,
+        string targetActorId,
+        string value,
+        DateTimeOffset observedAt) =>
+        new()
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTimeOffset(observedAt),
+            Payload = Any.Pack(new StringValue { Value = value }),
+            Route = EnvelopeRouteSemantics.CreateDirect(publisherActorId, targetActorId),
+        };
+
+    private static VoicePresenceRuntimeState CreateActiveSessionState() =>
+        new()
+        {
+            ActiveSessionId = "lease-1",
+            Status = VoicePresenceRuntimeStatus.Idle,
+            LastDrainAckResponseId = -1,
+            LastDrainAckPlayoutSequence = -1,
+            NextResponseId = 1,
         };
 
     private static EventEnvelope CreateVoiceEnvelope(IMessage payload) =>

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceEventEndpointsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceEventEndpointsTests.cs
@@ -75,6 +75,9 @@ public class DeviceEventEndpointsTests
     [InlineData("scene_summary", Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.Camera)]
     [InlineData("motion_detected", Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.Motion)]
     [InlineData("speech_detected", Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.Speech)]
+    [InlineData("doorbell_pressed", Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.HomeAlert)]
+    [InlineData("smoke_detected", Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.HomeAlert)]
+    [InlineData("water_leak_detected", Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.HomeAlert)]
     public void ParseCallbackPayload_known_v1_event_types_map_to_typed_payload_cases(
         string eventType,
         Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase expectedPayloadCase)
@@ -366,6 +369,38 @@ public class DeviceEventEndpointsTests
 
         inbound.PayloadCase.Should().Be(Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.Motion);
         inbound.Motion.Detected.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("doorbell_pressed", "info", Aevatar.GAgents.Household.DeviceEventSeverity.Info)]
+    [InlineData("smoke_detected", "", Aevatar.GAgents.Household.DeviceEventSeverity.Critical)]
+    [InlineData("water_leak_detected", "warning", Aevatar.GAgents.Household.DeviceEventSeverity.Warning)]
+    public void ParseCallbackPayload_home_alert_events_map_to_typed_alert_payload(
+        string eventType,
+        string severity,
+        Aevatar.GAgents.Household.DeviceEventSeverity expectedSeverity)
+    {
+        var innerEvent = JsonSerializer.Serialize(new
+        {
+            event_id = $"evt-{eventType}",
+            source = "home-assistant",
+            event_type = eventType,
+            severity,
+            area = "kitchen",
+            entity_id = "binary_sensor.kitchen",
+            correlation_key = "ha-alert-1",
+            summary = "Kitchen alert",
+        });
+
+        var payload = EncodeCallbackPayload(innerEvent, senderPlatformId: "ha-bridge");
+        var inbound = DeviceEventEndpoints.ParseCallbackPayload(Encoding.UTF8.GetBytes(payload));
+
+        inbound.PayloadCase.Should().Be(Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.HomeAlert);
+        inbound.HomeAlert.Severity.Should().Be(expectedSeverity);
+        inbound.HomeAlert.Area.Should().Be("kitchen");
+        inbound.HomeAlert.EntityId.Should().Be("binary_sensor.kitchen");
+        inbound.HomeAlert.CorrelationKey.Should().Be("ha-alert-1");
+        inbound.HomeAlert.Summary.Should().Be("Kitchen alert");
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceEventEndpointsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceEventEndpointsTests.cs
@@ -78,6 +78,10 @@ public class DeviceEventEndpointsTests
     [InlineData("doorbell_pressed", Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.HomeAlert)]
     [InlineData("smoke_detected", Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.HomeAlert)]
     [InlineData("water_leak_detected", Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.HomeAlert)]
+    [InlineData("carbon_monoxide_detected", Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.HomeAlert)]
+    [InlineData("glass_break_detected", Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.HomeAlert)]
+    [InlineData("lock_tampered", Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.HomeAlert)]
+    [InlineData("alarm_triggered", Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.HomeAlert)]
     public void ParseCallbackPayload_known_v1_event_types_map_to_typed_payload_cases(
         string eventType,
         Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase expectedPayloadCase)
@@ -372,9 +376,13 @@ public class DeviceEventEndpointsTests
     }
 
     [Theory]
-    [InlineData("doorbell_pressed", "info", Aevatar.GAgents.Household.DeviceEventSeverity.Info)]
+    [InlineData("doorbell_pressed", "", Aevatar.GAgents.Household.DeviceEventSeverity.Info)]
     [InlineData("smoke_detected", "", Aevatar.GAgents.Household.DeviceEventSeverity.Critical)]
     [InlineData("water_leak_detected", "warning", Aevatar.GAgents.Household.DeviceEventSeverity.Warning)]
+    [InlineData("carbon_monoxide_detected", "", Aevatar.GAgents.Household.DeviceEventSeverity.Critical)]
+    [InlineData("glass_break_detected", "", Aevatar.GAgents.Household.DeviceEventSeverity.Critical)]
+    [InlineData("lock_tampered", "", Aevatar.GAgents.Household.DeviceEventSeverity.Critical)]
+    [InlineData("alarm_triggered", "", Aevatar.GAgents.Household.DeviceEventSeverity.Critical)]
     public void ParseCallbackPayload_home_alert_events_map_to_typed_alert_payload(
         string eventType,
         string severity,
@@ -401,6 +409,28 @@ public class DeviceEventEndpointsTests
         inbound.HomeAlert.EntityId.Should().Be("binary_sensor.kitchen");
         inbound.HomeAlert.CorrelationKey.Should().Be("ha-alert-1");
         inbound.HomeAlert.Summary.Should().Be("Kitchen alert");
+    }
+
+    [Fact]
+    public void ParseCallbackPayload_home_alert_events_use_typed_fallback_fields()
+    {
+        var innerEvent = JsonSerializer.Serialize(new
+        {
+            event_id = "evt-fallback",
+            source = "home-assistant",
+            event_type = "alarm_triggered",
+            area = "garage",
+            entity_id = "alarm.garage",
+            description = "Garage alarm",
+        });
+
+        var payload = EncodeCallbackPayload(innerEvent, senderPlatformId: "ha-bridge");
+        var inbound = DeviceEventEndpoints.ParseCallbackPayload(Encoding.UTF8.GetBytes(payload));
+
+        inbound.PayloadCase.Should().Be(Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.HomeAlert);
+        inbound.HomeAlert.Severity.Should().Be(Aevatar.GAgents.Household.DeviceEventSeverity.Critical);
+        inbound.HomeAlert.CorrelationKey.Should().Be("evt-fallback");
+        inbound.HomeAlert.Summary.Should().Be("Garage alarm");
     }
 
     [Fact]

--- a/test/Aevatar.Hosting.Tests/MainnetHostCompositionTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetHostCompositionTests.cs
@@ -16,7 +16,11 @@ using Aevatar.ChatRouting.Core;
 using Aevatar.Configuration;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.EventModules;
 using Aevatar.Foundation.Runtime.Hosting.Maintenance;
+using Aevatar.Foundation.VoicePresence;
+using Aevatar.Foundation.VoicePresence.Modules;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgents.Channel.Identity;
 using Aevatar.GAgents.Channel.Identity.Abstractions;
@@ -28,6 +32,8 @@ using Aevatar.Mainnet.Host.Api.Hosting;
 using Aevatar.Scripting.Projection.ReadModels;
 using Aevatar.Workflow.Projection.ReadModels;
 using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
@@ -300,6 +306,61 @@ public sealed class MainnetHostCompositionTests
 
         // Refactor (issue1290-first): Old: strict cleanup-before-module-startup invariant.  New: cleanup is best-effort restart-idempotent, not a cross-pod completion barrier.
         HostedServiceDescriptors<RetiredActorCleanupHostedService>(builder.Services).Should().ContainSingle();
+    }
+
+    [Fact]
+    public void AddAevatarMainnetHost_ShouldEnableDeviceInboundDirectVoiceAdmissionOnce()
+    {
+        using var home = new TemporaryAevatarHomeScope();
+        using var runtimeProvider = new EnvironmentVariableScope(
+            "AEVATAR_ActorRuntime__Provider", "InMemory");
+        using var documentProvider = new EnvironmentVariableScope(
+            "AEVATAR_Projection__Document__Providers__InMemory__Enabled", "true");
+        using var documentElasticsearch = new EnvironmentVariableScope(
+            "AEVATAR_Projection__Document__Providers__Elasticsearch__Enabled", "false");
+        using var graphProvider = new EnvironmentVariableScope(
+            "AEVATAR_Projection__Graph__Providers__InMemory__Enabled", "true");
+        using var graphNeo4j = new EnvironmentVariableScope(
+            "AEVATAR_Projection__Graph__Providers__Neo4j__Enabled", "false");
+        using var projectionEnvironment = new EnvironmentVariableScope(
+            "Projection__Policies__Environment", "Development");
+        using var denyInMemoryDocument = new EnvironmentVariableScope(
+            "Projection__Policies__DenyInMemoryDocumentReadStore", "false");
+        using var denyInMemoryGraph = new EnvironmentVariableScope(
+            "Projection__Policies__DenyInMemoryGraphFactStore", "false");
+        var builder = CreateBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Aevatar:VoicePresence:OpenAI:ApiKey"] = "voice-openai-key",
+        });
+
+        builder.AddAevatarMainnetHost(options =>
+        {
+            options.EnableConnectorBootstrap = false;
+            options.EnableCors = false;
+        });
+
+        using var app = builder.Build();
+        var factory = app.Services.GetServices<IEventModuleFactory<IEventHandlerContext>>()
+            .OfType<VoicePresenceModuleFactory>()
+            .Single();
+        factory.TryCreate("voice_presence", out var module).Should().BeTrue();
+        var voiceModule = module.Should().BeOfType<VoicePresenceModule>().Subject;
+        var deviceInboundEnvelope = new EventEnvelope
+        {
+            Payload = new Any
+            {
+                TypeUrl = "type.googleapis.com/aevatar.gagents.household.DeviceInbound",
+                Value = ByteString.CopyFromUtf8("device-inbound"),
+            },
+            Route = EnvelopeRouteSemantics.CreateDirect("device-events.callback", "voice-agent"),
+        };
+
+        voiceModule.CanHandle(deviceInboundEnvelope).Should().BeTrue();
+        app.Services.GetServices<VoicePresenceModuleRegistration>()
+            .SelectMany(static registration => registration.Names)
+            .Should()
+            .ContainSingle(static name => string.Equals(name, "voice_presence", StringComparison.OrdinalIgnoreCase));
     }
 
     private static WebApplicationBuilder CreateBuilder()


### PR DESCRIPTION
## Changed files
本次实现将 `VoicePresenceModule` 的直接外部事件入口改为默认关闭、Host 显式配置的 exact `Any.TypeUrl` allowlist，并要求 publisher 为 `device-events.callback`、direct target 等于当前 actor、actor 已有 active voice session/lease 后才进入既有 voice external-event policy、dedupe、pending injection 和 provider injection 路径。Mainnet Host 通过现有 AI feature 配置 hook 允许 `DeviceInbound` TypeUrl。

同时补齐 Household/Device 的 HA alert typed payload：新增 `HomeAlertDeviceInboundPayload` 与 severity enum，并让 doorbell/smoke/water leak/carbon monoxide/glass break/lock tampered/alarm 事件映射到强类型 payload。相关 ADR 和 canon 文档已同步。

## Test results
已通过 `dotnet build aevatar.slnx --nologo`、`test_stability_guards.sh`、`Aevatar.Foundation.VoicePresence.Tests`、`Aevatar.GAgents.ChannelRuntime.Tests`、`Aevatar.Bootstrap.Tests` 和 `architecture_guards.sh`。Bootstrap suite 保留 1 个既有环境依赖 skip。

## Deviations
未扩展 scope。`AevatarPlatformHostBuilderExtensions.cs` 已有 `ConfigureAIFeatures` hook，因此无需修改。refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)

Closes #1944

⟦AI:AUTO-LOOP⟧
