### PR TITLE
test(nyxid-chat): 补 committed LLM-error → RunError 帧覆盖（#1971 遗留）

### DIFF
--- a/test/Aevatar.AI.Tests/NyxIdChatProjectionSessionTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatProjectionSessionTests.cs
@@ -302,6 +302,35 @@ public sealed class NyxIdChatProjectionSessionTests
     }
 
     [Fact]
+    public async Task Projector_ShouldEmitRunErrorFromCommittedLlmErrorPrefix()
+    {
+        var hub = new RecordingSessionEventHub();
+        var projector = new NyxIdChatSessionEventProjector(hub);
+        var context = new NyxIdChatSessionProjectionContext
+        {
+            RootActorId = "chat-actor-1",
+            SessionId = "session-1",
+            ProjectionKind = "nyxid-chat-session",
+        };
+
+        await projector.ProjectAsync(
+            context,
+            CommittedEnvelope(
+                context.RootActorId,
+                new RoleChatSessionCompletedEvent
+                {
+                    SessionId = "session-1",
+                    Content = "[[AEVATAR_LLM_ERROR]] provider exploded",
+                }),
+            CancellationToken.None);
+
+        var published = hub.Published.Should().ContainSingle().Which;
+        published.Event.EventCase.Should().Be(AGUIEvent.EventOneofCase.RunError);
+        published.Event.RunError.Message.Should().Be("provider exploded");
+        published.Event.RunError.RunId.Should().Be("session-1");
+    }
+
+    [Fact]
     public async Task Projector_ShouldIgnoreInvalidContextAndUnmappedEnvelope()
     {
         var hub = new RecordingSessionEventHub();


### PR DESCRIPTION
## 摘要

补 PR #1971 review-gate r1 tests reviewer 留下的窄缺口（PR 在 fix round 完成前被自治 runner 按 r2 3/3 approve 合并，fix 产物随 worktree 清理丢失）：

`NyxIdChatCompletionAguiFrameBuilder.cs:77` 的 `[[AEVATAR_LLM_ERROR]]` committed-failure 分支此前无测试。本 PR 按 reviewer 原始验收新增 `Projector_ShouldEmitRunErrorFromCommittedLlmErrorPrefix`：committed `RoleChatSessionCompletedEvent.Content = "[[AEVATAR_LLM_ERROR]] provider exploded"` → 恰好一条 `RunError` 帧、marker 剥离（`Message == "provider exploded"`）、`RunId == session id`。

test-only，单文件 +29 行。关联 #1970 / #1971。

## 验证

- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --filter "FullyQualifiedName~NyxIdChatProjectionSession" --nologo`：11/11 通过（controller 独立复验同绿）
- `bash tools/ci/test_stability_guards.sh`：通过

⟦AI:AUTO-LOOP⟧
