### PR TITLE
为 VoicePresence 增加输入图片直传支持

### DIFF
--- a/src/Aevatar.Foundation.VoicePresence.Abstractions/IRealtimeVoiceProvider.cs
+++ b/src/Aevatar.Foundation.VoicePresence.Abstractions/IRealtimeVoiceProvider.cs
@@ -21,6 +21,8 @@ public abstract class RealtimeVoiceProviderSession : IAsyncDisposable
 {
     public abstract Task SendAudioAsync(ReadOnlyMemory<byte> pcm16, CancellationToken ct);
 
+    public abstract Task SendInputImageAsync(VoiceInputImage inputImage, CancellationToken ct);
+
     public abstract Task SendToolResultAsync(string callId, string resultJson, CancellationToken ct);
 
     public abstract Task InjectEventAsync(VoiceConversationEventInjection injection, CancellationToken ct);

--- a/src/Aevatar.Foundation.VoicePresence.Abstractions/Protos/voice_presence.proto
+++ b/src/Aevatar.Foundation.VoicePresence.Abstractions/Protos/voice_presence.proto
@@ -217,6 +217,20 @@ message VoiceRemoteControlInputReceived {
   VoiceControlFrame control_frame = 2;
 }
 
+message VoiceInputImage {
+  string media_type = 1;
+  bytes data = 2;
+}
+
+message VoiceInputImageReceived {
+  string session_id = 1;
+  string transport_lease_id = 2;
+  VoiceInputImage input_image = 3;
+  string owner_id = 4;
+  google.protobuf.Timestamp lease_expires_at = 5;
+  int64 lease_epoch = 6;
+}
+
 message VoiceTransportAttachRequested {
   string session_id = 1;
   string owner_id = 2;
@@ -308,6 +322,7 @@ message VoiceModuleSignal {
     VoiceTransportRelayStopped transport_relay_stopped = 13;
     VoiceProviderEventReceived provider_event_received = 14;
     VoiceTransportLifetimeCompleted transport_lifetime_completed = 16;
+    VoiceInputImageReceived input_image_received = 17;
   }
 }
 

--- a/src/Aevatar.Foundation.VoicePresence.MiniCPM/MiniCPMRealtimeProvider.cs
+++ b/src/Aevatar.Foundation.VoicePresence.MiniCPM/MiniCPMRealtimeProvider.cs
@@ -175,6 +175,14 @@ public sealed class MiniCPMRealtimeProvider : IRealtimeVoiceProvider
                 throw new InvalidOperationException(await BuildHttpFailureMessageAsync("stream", response, ct));
         }
 
+        public override Task SendInputImageAsync(VoiceInputImage inputImage, CancellationToken ct)
+        {
+            _ = inputImage;
+            _ = ct;
+            throw new NotSupportedException(
+                "MiniCPM-o demo protocol does not support provider-side image input.");
+        }
+
         public override Task SendToolResultAsync(string callId, string resultJson, CancellationToken ct)
         {
             _ = callId;

--- a/src/Aevatar.Foundation.VoicePresence.OpenAI/Internal/IOpenAIRealtimeSession.cs
+++ b/src/Aevatar.Foundation.VoicePresence.OpenAI/Internal/IOpenAIRealtimeSession.cs
@@ -8,6 +8,8 @@ internal interface IOpenAIRealtimeSession : IAsyncDisposable
 
     Task SendInputAudioAsync(BinaryData audio, CancellationToken ct);
 
+    Task SendInputImageAsync(BinaryData inputImageEvent, CancellationToken ct);
+
     Task AddItemAsync(RealtimeItem item, CancellationToken ct);
 
     Task StartResponseAsync(CancellationToken ct);

--- a/src/Aevatar.Foundation.VoicePresence.OpenAI/Internal/OpenAIRealtimeSession.cs
+++ b/src/Aevatar.Foundation.VoicePresence.OpenAI/Internal/OpenAIRealtimeSession.cs
@@ -86,6 +86,16 @@ internal sealed class OpenAIRealtimeSession : IOpenAIRealtimeSession
     public Task SendInputAudioAsync(BinaryData audio, CancellationToken ct) =>
         _session.SendInputAudioAsync(audio, ct);
 
+    public async Task SendInputImageAsync(BinaryData inputImageEvent, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(inputImageEvent);
+        await _session.WebSocket.SendAsync(
+            inputImageEvent.ToMemory(),
+            WebSocketMessageType.Text,
+            endOfMessage: true,
+            cancellationToken: ct);
+    }
+
     public Task AddItemAsync(RealtimeItem item, CancellationToken ct) =>
         _session.AddItemAsync(item, ct);
 

--- a/src/Aevatar.Foundation.VoicePresence.OpenAI/OpenAIRealtimeProvider.cs
+++ b/src/Aevatar.Foundation.VoicePresence.OpenAI/OpenAIRealtimeProvider.cs
@@ -335,6 +335,22 @@ public sealed class OpenAIRealtimeProvider : IRealtimeVoiceProvider
             return _physicalSession.SendInputAudioAsync(BinaryData.FromBytes(pcm16.ToArray()), ct);
         }
 
+        public override async Task SendInputImageAsync(VoiceInputImage inputImage, CancellationToken ct)
+        {
+            ArgumentNullException.ThrowIfNull(inputImage);
+            if (inputImage.Data.IsEmpty)
+                return;
+
+            var mediaType = string.IsNullOrWhiteSpace(inputImage.MediaType)
+                ? "image/png"
+                : inputImage.MediaType.Trim();
+            if (!mediaType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+                throw new ArgumentException("Image media_type must start with 'image/'.", nameof(inputImage));
+
+            await _physicalSession.SendInputImageAsync(BuildInputImageEvent(inputImage, mediaType), ct);
+            await _physicalSession.StartResponseAsync(ct);
+        }
+
         public override async Task SendToolResultAsync(string callId, string resultJson, CancellationToken ct)
         {
             if (string.IsNullOrWhiteSpace(callId))
@@ -374,6 +390,29 @@ public sealed class OpenAIRealtimeProvider : IRealtimeVoiceProvider
 
             await _physicalSession.AddItemAsync(item, ct);
             await _physicalSession.StartResponseAsync(ct);
+        }
+
+        private static BinaryData BuildInputImageEvent(VoiceInputImage inputImage, string mediaType)
+        {
+            var eventObject = new JsonObject
+            {
+                ["type"] = "conversation.item.create",
+                ["item"] = new JsonObject
+                {
+                    ["type"] = "message",
+                    ["role"] = "user",
+                    ["content"] = new JsonArray
+                    {
+                        new JsonObject
+                        {
+                            ["type"] = "input_image",
+                            ["image_url"] = $"data:{mediaType};base64,{Convert.ToBase64String(inputImage.Data.ToByteArray())}",
+                        },
+                    },
+                },
+            };
+
+            return BinaryData.FromString(eventObject.ToJsonString());
         }
 
         public override async ValueTask DisposeAsync()

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceSessionDispatch.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceSessionDispatch.cs
@@ -90,6 +90,9 @@ internal static class VoicePresenceSessionDispatch
             case VoiceProviderEventReceived providerReceived:
                 signal.ProviderEventReceived = providerReceived.Clone();
                 break;
+            case VoiceInputImageReceived inputImageReceived:
+                signal.InputImageReceived = inputImageReceived.Clone();
+                break;
             default:
                 throw new InvalidOperationException(
                     $"Unsupported voice module signal payload '{message.GetType().Name}'.");

--- a/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
@@ -158,6 +158,9 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
             case VoiceModuleSignal.SignalOneofCase.ProviderEventReceived:
                 await HandleProviderEventReceivedAsync(signal.ProviderEventReceived, ctx, ct);
                 break;
+            case VoiceModuleSignal.SignalOneofCase.InputImageReceived:
+                await HandleInputImageReceivedAsync(signal.InputImageReceived, ctx, ct);
+                break;
             case VoiceModuleSignal.SignalOneofCase.None:
             default:
                 break;
@@ -442,6 +445,22 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         await HandleProviderEventAsync(request.ProviderEvent, ctx, ct);
     }
 
+    private async Task HandleInputImageReceivedAsync(
+        VoiceInputImageReceived request,
+        IEventHandlerContext ctx,
+        CancellationToken ct)
+    {
+        var state = HydrateRuntimeStateFromActor(ctx);
+        if (!IsAcceptedInputImageSignal(state, request) ||
+            request.InputImage == null)
+        {
+            return;
+        }
+
+        await using var providerSession = await ConnectProviderSessionAsync(state, ct);
+        await providerSession.SendInputImageAsync(request.InputImage, ct);
+    }
+
     private async Task HandleTransportAttachRequestedAsync(
         VoiceTransportAttachRequested request,
         IEventHandlerContext ctx,
@@ -607,6 +626,36 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         return string.Equals(state.RemoteSessionId, sessionId, StringComparison.Ordinal) &&
                string.Equals(state.ActiveSessionId, sessionId, StringComparison.Ordinal) &&
                MatchesLeaseEpoch(state, leaseEpoch);
+    }
+
+    private bool IsAcceptedInputImageSignal(
+        VoicePresenceRuntimeState state,
+        VoiceInputImageReceived request)
+    {
+        if (request == null ||
+            string.IsNullOrWhiteSpace(request.SessionId) ||
+            IsLeaseExpired(state.LeaseExpiresAt))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.TransportLeaseId))
+        {
+            return IsAcceptedTransportSignal(
+                state,
+                request.SessionId,
+                request.TransportLeaseId,
+                request.OwnerId,
+                request.LeaseExpiresAt,
+                request.LeaseEpoch);
+        }
+
+        if (string.IsNullOrWhiteSpace(state.RemoteSessionId))
+            return false;
+
+        return string.Equals(state.RemoteSessionId, request.SessionId, StringComparison.Ordinal) &&
+               string.Equals(state.ActiveSessionId, request.SessionId, StringComparison.Ordinal) &&
+               MatchesLeaseEpoch(state, request.LeaseEpoch);
     }
 
     private static bool MatchesLeaseEpoch(VoicePresenceRuntimeState state, long leaseEpoch) =>

--- a/test/Aevatar.Foundation.VoicePresence.MiniCPM.Tests/MiniCPMRealtimeProviderTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.MiniCPM.Tests/MiniCPMRealtimeProviderTests.cs
@@ -421,6 +421,26 @@ public class MiniCPMRealtimeProviderTests
     }
 
     [Fact]
+    public async Task SendInputImage_should_throw_not_supported()
+    {
+        await using var provider = CreateProvider(new StubHttpMessageHandler((request, ct) =>
+        {
+            _ = request;
+            _ = ct;
+            return Task.FromResult(CreateSseResponse(blockAfterPayload: true));
+        }));
+
+        var providerSession = await ConnectAsync(provider);
+
+        await Should.ThrowAsync<NotSupportedException>(() =>
+            providerSession.SendInputImageAsync(new VoiceInputImage
+            {
+                MediaType = "image/png",
+                Data = Google.Protobuf.ByteString.CopyFrom([1]),
+            }, CancellationToken.None));
+    }
+
+    [Fact]
     public async Task InjectEvent_should_throw_not_supported()
     {
         await using var provider = CreateProvider(new StubHttpMessageHandler((request, ct) =>

--- a/test/Aevatar.Foundation.VoicePresence.OpenAI.Tests/OpenAIRealtimeProviderTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.OpenAI.Tests/OpenAIRealtimeProviderTests.cs
@@ -296,6 +296,64 @@ public class OpenAIRealtimeProviderTests
     }
 
     [Fact]
+    public async Task SendInputImage_should_emit_openai_conversation_item_and_start_response()
+    {
+        var session = new FakeSession();
+        var provider = CreateProvider(session);
+
+        var providerSession = await ConnectAsync(provider);
+        await providerSession.SendInputImageAsync(new VoiceInputImage
+        {
+            MediaType = "image/png",
+            Data = Google.Protobuf.ByteString.CopyFrom([1, 2, 3]),
+        }, CancellationToken.None);
+
+        session.InputImageEvents.Count.ShouldBe(1);
+        using var document = JsonDocument.Parse(session.InputImageEvents.Single());
+        var root = document.RootElement;
+        root.GetProperty("type").GetString().ShouldBe("conversation.item.create");
+        var item = root.GetProperty("item");
+        item.GetProperty("type").GetString().ShouldBe("message");
+        item.GetProperty("role").GetString().ShouldBe("user");
+        var content = item.GetProperty("content")[0];
+        content.GetProperty("type").GetString().ShouldBe("input_image");
+        content.GetProperty("image_url").GetString()
+            .ShouldBe($"data:image/png;base64,{Convert.ToBase64String([1, 2, 3])}");
+        session.StartResponseCalls.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task SendInputImage_empty_should_be_noop()
+    {
+        var session = new FakeSession();
+        var provider = CreateProvider(session);
+
+        var providerSession = await ConnectAsync(provider);
+        await providerSession.SendInputImageAsync(new VoiceInputImage
+        {
+            MediaType = "image/png",
+        }, CancellationToken.None);
+
+        session.InputImageEvents.ShouldBeEmpty();
+        session.StartResponseCalls.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task SendInputImage_should_reject_non_image_media_type()
+    {
+        var session = new FakeSession();
+        var provider = CreateProvider(session);
+        var providerSession = await ConnectAsync(provider);
+
+        await Should.ThrowAsync<ArgumentException>(() =>
+            providerSession.SendInputImageAsync(new VoiceInputImage
+            {
+                MediaType = "application/octet-stream",
+                Data = Google.Protobuf.ByteString.CopyFrom([1]),
+            }, CancellationToken.None));
+    }
+
+    [Fact]
     public async Task Unsupported_sample_rate_should_be_rejected()
     {
         var session = new FakeSession();
@@ -559,6 +617,8 @@ public class OpenAIRealtimeProviderTests
 
         public List<BinaryData> SentAudio { get; } = [];
 
+        public List<string> InputImageEvents { get; } = [];
+
         public List<RealtimeItem> AddedItems { get; } = [];
 
         public int StartResponseCalls { get; private set; }
@@ -579,6 +639,13 @@ public class OpenAIRealtimeProviderTests
         {
             _ = ct;
             SentAudio.Add(audio);
+            return Task.CompletedTask;
+        }
+
+        public Task SendInputImageAsync(BinaryData inputImageEvent, CancellationToken ct)
+        {
+            _ = ct;
+            InputImageEvents.Add(inputImageEvent.ToString());
             return Task.CompletedTask;
         }
 
@@ -626,6 +693,7 @@ public class OpenAIRealtimeProviderTests
     {
         public Task SendSessionUpdateAsync(BinaryData sessionUpdateEvent, CancellationToken ct) => Task.CompletedTask;
         public Task SendInputAudioAsync(BinaryData audio, CancellationToken ct) => Task.CompletedTask;
+        public Task SendInputImageAsync(BinaryData inputImageEvent, CancellationToken ct) => Task.CompletedTask;
         public Task AddItemAsync(RealtimeItem item, CancellationToken ct) => Task.CompletedTask;
         public Task StartResponseAsync(CancellationToken ct) => Task.CompletedTask;
         public Task CancelResponseAsync(CancellationToken ct) => Task.CompletedTask;

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceEventInjectionTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceEventInjectionTests.cs
@@ -281,6 +281,7 @@ public class VoicePresenceEventInjectionTests
         private sealed class RecordingProviderSession(RecordingVoiceProvider provider) : RealtimeVoiceProviderSession
         {
             public override Task SendAudioAsync(ReadOnlyMemory<byte> pcm16, CancellationToken ct) => Task.CompletedTask;
+            public override Task SendInputImageAsync(VoiceInputImage inputImage, CancellationToken ct) => Task.CompletedTask;
             public override Task SendToolResultAsync(string callId, string resultJson, CancellationToken ct) => Task.CompletedTask;
             public override Task InjectEventAsync(VoiceConversationEventInjection injection, CancellationToken ct)
             {

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleFactoryTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleFactoryTests.cs
@@ -95,6 +95,7 @@ public class VoicePresenceModuleFactoryTests
         private sealed class NoopProviderSession : RealtimeVoiceProviderSession
         {
             public override Task SendAudioAsync(ReadOnlyMemory<byte> pcm16, CancellationToken ct) => Task.CompletedTask;
+            public override Task SendInputImageAsync(VoiceInputImage inputImage, CancellationToken ct) => Task.CompletedTask;
             public override Task SendToolResultAsync(string callId, string resultJson, CancellationToken ct) => Task.CompletedTask;
             public override Task InjectEventAsync(VoiceConversationEventInjection injection, CancellationToken ct) => Task.CompletedTask;
             public override Task CancelResponseAsync(CancellationToken ct) => Task.CompletedTask;

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
@@ -92,6 +92,72 @@ public class VoicePresenceModuleTests
     }
 
     [Fact]
+    public async Task Accepted_input_image_signal_should_forward_to_provider_without_state_or_realtime_publication()
+    {
+        var provider = new RecordingVoiceProvider();
+        var module = CreateModule(provider);
+        var hub = new RecordingProjectionSessionEventHub();
+        var services = new ServiceCollection()
+            .AddSingleton<IProjectionSessionEventHub<VoiceRealtimeFrame>>(hub)
+            .BuildServiceProvider();
+        var ctx = new StubEventHandlerContext(services, CreateRoleAgentWithActiveSession());
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = DefaultModuleName,
+            InputImageReceived = new VoiceInputImageReceived
+            {
+                SessionId = "session-1",
+                InputImage = new VoiceInputImage
+                {
+                    MediaType = "image/png",
+                    Data = ByteString.CopyFrom([1, 2, 3]),
+                },
+            },
+        }), ctx, CancellationToken.None);
+
+        provider.InputImages.ShouldHaveSingleItem().Data.ToByteArray().ShouldBe([1, 2, 3]);
+        ctx.Agent.ShouldBeOfType<RecordingRoleAgent>().PersistedStates.ShouldBeEmpty();
+        hub.Events.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Stale_input_image_signal_should_be_ignored()
+    {
+        var provider = new RecordingVoiceProvider();
+        var module = CreateModule(provider);
+        var roleAgent = CreateRoleAgentWithActiveSession();
+        roleAgent.State.VoicePresence[DefaultModuleName].TransportAttached = true;
+        roleAgent.State.VoicePresence[DefaultModuleName].ActiveTransportLeaseId = "transport-1";
+        roleAgent.State.VoicePresence[DefaultModuleName].ActiveLeaseOwnerId = "host-1";
+        roleAgent.State.VoicePresence[DefaultModuleName].LeaseExpiresAt =
+            Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddMinutes(5));
+        roleAgent.State.VoicePresence[DefaultModuleName].LeaseEpoch = 3;
+        var ctx = new StubEventHandlerContext(agent: roleAgent);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = DefaultModuleName,
+            InputImageReceived = new VoiceInputImageReceived
+            {
+                SessionId = "session-1",
+                OwnerId = "host-1",
+                TransportLeaseId = "stale-transport",
+                LeaseExpiresAt = roleAgent.State.VoicePresence[DefaultModuleName].LeaseExpiresAt.Clone(),
+                LeaseEpoch = 3,
+                InputImage = new VoiceInputImage
+                {
+                    MediaType = "image/png",
+                    Data = ByteString.CopyFrom([1]),
+                },
+            },
+        }), ctx, CancellationToken.None);
+
+        provider.InputImages.ShouldBeEmpty();
+        roleAgent.PersistedStates.ShouldBeEmpty();
+    }
+
+    [Fact]
     public void CanHandle_should_accept_voice_frames_and_external_publications()
     {
         var module = CreateModule(new RecordingVoiceProvider());
@@ -1940,6 +2006,7 @@ public class VoicePresenceModuleTests
         public int InjectEventCalls { get; private set; }
 
         public List<byte[]> AudioFrames { get; } = [];
+        public List<VoiceInputImage> InputImages { get; } = [];
         public List<(string CallId, string ResultJson)> ToolResults { get; } = [];
         public List<VoiceConversationEventInjection> InjectedEvents { get; } = [];
 
@@ -1973,6 +2040,12 @@ public class VoicePresenceModuleTests
             public override Task SendAudioAsync(ReadOnlyMemory<byte> pcm16, CancellationToken ct)
             {
                 provider.AudioFrames.Add(pcm16.ToArray());
+                return Task.CompletedTask;
+            }
+
+            public override Task SendInputImageAsync(VoiceInputImage inputImage, CancellationToken ct)
+            {
+                provider.InputImages.Add(inputImage.Clone());
                 return Task.CompletedTask;
             }
 

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
@@ -122,6 +122,47 @@ public class VoicePresenceModuleTests
     }
 
     [Fact]
+    public async Task Accepted_keyed_input_image_signal_should_forward_to_provider_without_state_or_realtime_publication()
+    {
+        var provider = new RecordingVoiceProvider();
+        var module = CreateModule(provider);
+        var hub = new RecordingProjectionSessionEventHub();
+        var services = new ServiceCollection()
+            .AddSingleton<IProjectionSessionEventHub<VoiceRealtimeFrame>>(hub)
+            .BuildServiceProvider();
+        var roleAgent = CreateRoleAgentWithActiveSession();
+        roleAgent.State.VoicePresence[DefaultModuleName].TransportAttached = true;
+        roleAgent.State.VoicePresence[DefaultModuleName].ActiveTransportLeaseId = "transport-1";
+        roleAgent.State.VoicePresence[DefaultModuleName].ActiveLeaseOwnerId = "host-1";
+        roleAgent.State.VoicePresence[DefaultModuleName].LeaseExpiresAt =
+            Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddMinutes(5));
+        roleAgent.State.VoicePresence[DefaultModuleName].LeaseEpoch = 3;
+        var ctx = new StubEventHandlerContext(services, roleAgent);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = DefaultModuleName,
+            InputImageReceived = new VoiceInputImageReceived
+            {
+                SessionId = "session-1",
+                OwnerId = "host-1",
+                TransportLeaseId = "transport-1",
+                LeaseExpiresAt = roleAgent.State.VoicePresence[DefaultModuleName].LeaseExpiresAt.Clone(),
+                LeaseEpoch = 3,
+                InputImage = new VoiceInputImage
+                {
+                    MediaType = "image/png",
+                    Data = ByteString.CopyFrom([4, 5, 6]),
+                },
+            },
+        }), ctx, CancellationToken.None);
+
+        provider.InputImages.ShouldHaveSingleItem().Data.ToByteArray().ShouldBe([4, 5, 6]);
+        roleAgent.PersistedStates.ShouldBeEmpty();
+        hub.Events.ShouldBeEmpty();
+    }
+
+    [Fact]
     public async Task Stale_input_image_signal_should_be_ignored()
     {
         var provider = new RecordingVoiceProvider();

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceProtoTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceProtoTests.cs
@@ -165,6 +165,40 @@ public class VoicePresenceProtoTests
     }
 
     [Fact]
+    public void VoiceModuleSignal_should_roundtrip_input_image_received()
+    {
+        var expiresAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddMinutes(5));
+        var image = new VoiceInputImageReceived
+        {
+            SessionId = "lease-1",
+            OwnerId = "host-1",
+            TransportLeaseId = "transport-1",
+            LeaseExpiresAt = expiresAt,
+            LeaseEpoch = 10,
+            InputImage = new VoiceInputImage
+            {
+                MediaType = "image/png",
+                Data = ByteString.CopyFrom([1, 2, 3]),
+            },
+        };
+        var signal = new VoiceModuleSignal
+        {
+            ModuleName = "voice_presence",
+            InputImageReceived = image,
+        };
+
+        var parsed = VoiceModuleSignal.Parser.ParseFrom(signal.ToByteArray());
+
+        parsed.ShouldBe(signal);
+        parsed.SignalCase.ShouldBe(VoiceModuleSignal.SignalOneofCase.InputImageReceived);
+        parsed.InputImageReceived.InputImage.Data.ToByteArray().ShouldBe([1, 2, 3]);
+        VoicePresenceReflection.Descriptor.MessageTypes.Select(static x => x.Name)
+            .ShouldContain(nameof(VoiceInputImage));
+        VoicePresenceReflection.Descriptor.MessageTypes.Select(static x => x.Name)
+            .ShouldContain(nameof(VoiceInputImageReceived));
+    }
+
+    [Fact]
     public void VoicePresenceSessionDispatch_should_wrap_transport_control_self_signal()
     {
         var control = new VoiceTransportControlFrameReceived
@@ -193,5 +227,32 @@ public class VoicePresenceProtoTests
         signal.TransportControlFrameReceived.LeaseEpoch.ShouldBe(9);
         signal.TransportControlFrameReceived.ShouldBe(control);
         signal.TransportControlFrameReceived.ShouldNotBeSameAs(control);
+    }
+
+    [Fact]
+    public void VoicePresenceSessionDispatch_should_wrap_input_image_direct_signal()
+    {
+        var image = new VoiceInputImageReceived
+        {
+            SessionId = "lease-1",
+            OwnerId = "host-1",
+            TransportLeaseId = "transport-1",
+            LeaseExpiresAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddMinutes(5)),
+            LeaseEpoch = 11,
+            InputImage = new VoiceInputImage
+            {
+                MediaType = "image/jpeg",
+                Data = ByteString.CopyFrom([4, 5, 6]),
+            },
+        };
+
+        var envelope = VoicePresenceSessionDispatch.BuildDirectEnvelope("voice-agent", "voice_presence", image);
+        var signal = envelope.Payload.Unpack<VoiceModuleSignal>();
+
+        envelope.Route.ShouldBe(EnvelopeRouteSemantics.CreateDirect(VoicePresenceSessionDispatch.HostPublisherId, "voice-agent"));
+        signal.ModuleName.ShouldBe("voice_presence");
+        signal.SignalCase.ShouldBe(VoiceModuleSignal.SignalOneofCase.InputImageReceived);
+        signal.InputImageReceived.ShouldBe(image);
+        signal.InputImageReceived.ShouldNotBeSameAs(image);
     }
 }

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoiceRealtimeSessionTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoiceRealtimeSessionTests.cs
@@ -987,6 +987,9 @@ public class VoiceRealtimeSessionTests
             return Task.CompletedTask;
         }
 
+        public override Task SendInputImageAsync(VoiceInputImage inputImage, CancellationToken ct) =>
+            Task.CompletedTask;
+
         public Task EmitAudioAsync(byte[] pcm16, CancellationToken ct) =>
             _audioSink?.Invoke(
                 _sessionKey,


### PR DESCRIPTION
## Changed files
- `src/Aevatar.Foundation.VoicePresence.Abstractions/Protos/voice_presence.proto` 新增强类型 `VoiceInputImage` / `VoiceInputImageReceived`，并通过既有 `VoiceModuleSignal` 承载图片输入信号。
- `src/Aevatar.Foundation.VoicePresence.Abstractions/IRealtimeVoiceProvider.cs` 为实时 provider session 合同新增 `SendInputImageAsync`。
- `src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceSessionDispatch.cs` 支持把图片输入包装成 direct module-signal envelope。
- `src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs` 只接受当前 session / lease 的图片信号，直接转发到 provider，不写入 actor state、event store、projection、readmodel 或 `VoiceRealtimeFrame`。
- `src/Aevatar.Foundation.VoicePresence.OpenAI/Internal/IOpenAIRealtimeSession.cs`、`src/Aevatar.Foundation.VoicePresence.OpenAI/Internal/OpenAIRealtimeSession.cs`、`src/Aevatar.Foundation.VoicePresence.OpenAI/OpenAIRealtimeProvider.cs` 在 OpenAI adapter 内部把 typed image bytes 转为 data URL，并发送 `conversation.item.create` / `input_image` realtime JSON。
- `src/Aevatar.Foundation.VoicePresence.MiniCPM/MiniCPMRealtimeProvider.cs` 对 MiniCPM demo protocol 图片输入保持 fail-closed unsupported。
- 相关 VoicePresence、OpenAI、MiniCPM 测试覆盖 proto roundtrip、dispatch 包装、accepted / stale 图片信号、OpenAI JSON 发送、空图片 no-op、非图片 media type 拒绝、MiniCPM unsupported，以及新增 provider-session 合同的 fake 实现。

Closes #1943

## Test results
- `dotnet build src/Aevatar.Foundation.VoicePresence.Abstractions/Aevatar.Foundation.VoicePresence.Abstractions.csproj --nologo`：通过。
- `dotnet build src/Aevatar.Foundation.VoicePresence.OpenAI/Aevatar.Foundation.VoicePresence.OpenAI.csproj --nologo`：通过。
- `dotnet test test/Aevatar.Foundation.VoicePresence.Tests/Aevatar.Foundation.VoicePresence.Tests.csproj --nologo`：通过，166 passed。
- `dotnet test test/Aevatar.Foundation.VoicePresence.OpenAI.Tests/Aevatar.Foundation.VoicePresence.OpenAI.Tests.csproj --nologo`：通过，25 passed，1 个既有 integration fact skipped。
- `dotnet test test/Aevatar.Foundation.VoicePresence.MiniCPM.Tests/Aevatar.Foundation.VoicePresence.MiniCPM.Tests.csproj --nologo`：通过，14 passed。
- `dotnet build aevatar.slnx --nologo`：通过，158 warnings，0 errors。
- `bash tools/ci/test_stability_guards.sh`：通过。
- `bash tools/ci/architecture_guards.sh`：通过。
- `git diff --check`：通过。
- Host `$CI_GUARDS` 未设置，按实现记录为 skipped。

## Deviations
- 实现 summary 在主工作区指定路径不存在，但 implementation worktree 内存在同名 summary，且 implementation log 尾部包含一致的完成记录；本 PR artifact 基于该 summary、log 与 worktree staged diff 生成。
- Prompt 中列出的非 `Internal` OpenAI realtime session 路径在该 checkout 中不存在；实际实现位于 `src/Aevatar.Foundation.VoicePresence.OpenAI/Internal/OpenAIRealtimeSession.cs`。
- 新增 abstract provider-session 方法后，三个既有测试 helper 需要补 no-op fake 实现以保持编译覆盖。
- `refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)`。

⟦AI:AUTO-LOOP⟧
