### PR TITLE
Preserve workflow id in Studio member binding

### DIFF
--- a/agents/Aevatar.GAgents.StudioMember/studio_member_messages.proto
+++ b/agents/Aevatar.GAgents.StudioMember/studio_member_messages.proto
@@ -100,6 +100,7 @@ message StudioMemberBindingAuthorityState {
 
 message StudioMemberWorkflowBindingRequest {
   repeated string workflow_yamls = 1;
+  string workflow_id = 2;
 }
 
 message StudioMemberScriptBindingRequest {

--- a/docs/2026-04-27-member-first-studio-apis.md
+++ b/docs/2026-04-27-member-first-studio-apis.md
@@ -36,6 +36,7 @@ The resolver is exposed through `IMemberPublishedServiceResolver`, so a later ac
 
 - Member routes for Bind / Invoke / Observe-read / run lifecycle control do not require frontend callers to know or pass `serviceId`.
 - Binding writes are asynchronous. The `PUT /binding` response only means the command was accepted for dispatch and returns a stable `bindingRunId`; completion is observed through `GET /binding-runs/{bindingRunId}` or `GET /binding`.
+- Workflow binding requests must carry `workflow.workflowId` as the stable workflow identity. The first YAML document's `name` remains the runtime/display `workflowName` and may differ from `workflowId`; successful member binding returns the stable id in `implementationRef.workflow.workflowId`.
 - The binding-run `Location` is read-model backed and can be briefly unavailable immediately after `202 Accepted`. Clients should treat a short-lived `404` for the accepted run id as pending/read-model lag, not as terminal failure. Only explicit `failed` or `rejected` run status should surface as a binding error.
 - Binding execution still publishes through the existing service command/runtime path after the member actor has admitted the request and resolved its `publishedServiceId`.
 - Runs and run detail still read workflow run read models; they do not query actor state or replay events.

--- a/src/Aevatar.Studio.Application/Studio/Contracts/MemberContracts.cs
+++ b/src/Aevatar.Studio.Application/Studio/Contracts/MemberContracts.cs
@@ -1,5 +1,7 @@
 namespace Aevatar.Studio.Application.Studio.Contracts;
 
+using System.Text.Json.Serialization;
+
 /// <summary>
 /// Wire-format implementation kind for HTTP/JSON. Uses lowercase strings so
 /// Studio's HTTP surface stays member-centric and frontend-friendly. Mapped
@@ -207,8 +209,26 @@ public sealed record UpdateStudioMemberBindingRequest(
     StudioMemberScriptBindingSpec? Script = null,
     StudioMemberGAgentBindingSpec? GAgent = null);
 
-public sealed record StudioMemberWorkflowBindingSpec(
-    IReadOnlyList<string> WorkflowYamls);
+public sealed record StudioMemberWorkflowBindingSpec
+{
+    [JsonConstructor]
+    public StudioMemberWorkflowBindingSpec(
+        string WorkflowId,
+        IReadOnlyList<string> WorkflowYamls)
+    {
+        this.WorkflowId = WorkflowId;
+        this.WorkflowYamls = WorkflowYamls;
+    }
+
+    public StudioMemberWorkflowBindingSpec(IReadOnlyList<string> WorkflowYamls)
+        : this(string.Empty, WorkflowYamls)
+    {
+    }
+
+    public string WorkflowId { get; init; }
+
+    public IReadOnlyList<string> WorkflowYamls { get; init; }
+}
 
 public sealed record StudioMemberScriptBindingSpec(
     string ScriptId,

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioMemberService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioMemberService.cs
@@ -499,6 +499,12 @@ public sealed class StudioMemberService : IStudioMemberService
         {
             count++;
             implementationKind = MemberImplementationKindNames.Workflow;
+            if (string.IsNullOrWhiteSpace(request.Workflow.WorkflowId))
+            {
+                throw new InvalidOperationException(
+                    $"member '{memberId}' bind: workflowId is required for workflow members.");
+            }
+
             if (request.Workflow.WorkflowYamls.Count == 0)
             {
                 throw new InvalidOperationException(

--- a/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchStudioMemberCommandService.cs
+++ b/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchStudioMemberCommandService.cs
@@ -273,7 +273,10 @@ internal sealed class ActorDispatchStudioMemberCommandService : IStudioMemberCom
         switch (implementationKindName)
         {
             case MemberImplementationKindNames.Workflow:
-                request.Workflow = new StudioMemberWorkflowBindingRequest();
+                request.Workflow = new StudioMemberWorkflowBindingRequest
+                {
+                    WorkflowId = binding.Workflow?.WorkflowId ?? string.Empty,
+                };
                 request.Workflow.WorkflowYamls.Add(binding.Workflow?.WorkflowYamls ?? []);
                 break;
             case MemberImplementationKindNames.Script:

--- a/src/Aevatar.Studio.Projection/CommandServices/ScopeBindingStudioMemberPlatformBindingCommandService.cs
+++ b/src/Aevatar.Studio.Projection/CommandServices/ScopeBindingStudioMemberPlatformBindingCommandService.cs
@@ -320,7 +320,9 @@ internal sealed class ScopeBindingStudioMemberPlatformBindingCommandService : IS
             StudioMemberBindingRequest.ImplementationOneofCase.Workflow => new ScopeBindingUpsertRequest(
                 ScopeId: bindingRequest.ScopeId,
                 ImplementationKind: ScopeBindingImplementationKind.Workflow,
-                Workflow: new ScopeBindingWorkflowSpec(bindingRequest.Workflow.WorkflowYamls.ToArray()),
+                Workflow: new ScopeBindingWorkflowSpec(
+                    bindingRequest.Workflow.WorkflowId,
+                    bindingRequest.Workflow.WorkflowYamls.ToArray()),
                 DisplayName: request.Admitted.DisplayName,
                 RevisionId: revisionId,
                 ServiceId: request.Admitted.PublishedServiceId,
@@ -437,7 +439,7 @@ internal sealed class ScopeBindingStudioMemberPlatformBindingCommandService : IS
             {
                 Workflow = new StudioMemberWorkflowRef
                 {
-                    WorkflowId = result.Workflow?.WorkflowName ?? result.WorkflowName,
+                    WorkflowId = ResolveWorkflowId(result),
                     WorkflowRevision = result.RevisionId,
                 },
             },
@@ -458,4 +460,13 @@ internal sealed class ScopeBindingStudioMemberPlatformBindingCommandService : IS
             },
             _ => new StudioMemberImplementationRef(),
         };
+
+    private static string ResolveWorkflowId(ScopeBindingUpsertResult result)
+    {
+        var workflowId = result.Workflow?.WorkflowId?.Trim();
+        if (!string.IsNullOrWhiteSpace(workflowId))
+            return workflowId;
+
+        return result.ServiceId?.Trim() ?? string.Empty;
+    }
 }

--- a/src/Aevatar.Studio.Projection/CommandServices/ScopeBindingStudioMemberPlatformBindingCommandService.cs
+++ b/src/Aevatar.Studio.Projection/CommandServices/ScopeBindingStudioMemberPlatformBindingCommandService.cs
@@ -191,6 +191,26 @@ internal sealed class ScopeBindingStudioMemberPlatformBindingCommandService : IS
             return null;
         }
 
+        StudioMemberImplementationRef implementationRef;
+        try
+        {
+            implementationRef = BuildImplementationRef(result);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "StudioMember platform binding result mapping failed. bindingRunId={BindingRunId} platformBindingCommandId={CommandId}",
+                request.BindingRunId,
+                commandId);
+
+            return BuildFailedContinuation(
+                request.BindingRunId,
+                commandId,
+                PlatformBindingFailedFailureCode,
+                ex.Message);
+        }
+
         return new StudioMemberPlatformBindingSucceeded
         {
             BindingRunId = request.BindingRunId,
@@ -202,7 +222,7 @@ internal sealed class ScopeBindingStudioMemberPlatformBindingCommandService : IS
                 RevisionId = result.RevisionId,
                 ImplementationKind = ToStudioKind(result.ImplementationKind),
                 ExpectedActorId = result.ExpectedActorId,
-                ImplementationRef = BuildImplementationRef(result),
+                ImplementationRef = implementationRef,
             },
         };
     }
@@ -467,6 +487,6 @@ internal sealed class ScopeBindingStudioMemberPlatformBindingCommandService : IS
         if (!string.IsNullOrWhiteSpace(workflowId))
             return workflowId;
 
-        return result.Workflow?.WorkflowName?.Trim() ?? result.WorkflowName?.Trim() ?? string.Empty;
+        throw new InvalidOperationException("scope binding workflow result workflow id is required for workflow member binding.");
     }
 }

--- a/src/Aevatar.Studio.Projection/CommandServices/ScopeBindingStudioMemberPlatformBindingCommandService.cs
+++ b/src/Aevatar.Studio.Projection/CommandServices/ScopeBindingStudioMemberPlatformBindingCommandService.cs
@@ -467,6 +467,6 @@ internal sealed class ScopeBindingStudioMemberPlatformBindingCommandService : IS
         if (!string.IsNullOrWhiteSpace(workflowId))
             return workflowId;
 
-        return result.ServiceId?.Trim() ?? string.Empty;
+        return result.Workflow?.WorkflowName?.Trim() ?? result.WorkflowName?.Trim() ?? string.Empty;
     }
 }

--- a/src/platform/Aevatar.GAgentService.Abstractions/ScopeBindings/ScopeBindingModels.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/ScopeBindings/ScopeBindingModels.cs
@@ -1,5 +1,7 @@
 namespace Aevatar.GAgentService.Abstractions;
 
+using System.Text.Json.Serialization;
+
 public enum ScopeBindingImplementationKind
 {
     Unspecified = 0,
@@ -8,8 +10,26 @@ public enum ScopeBindingImplementationKind
     GAgent = 3,
 }
 
-public sealed record ScopeBindingWorkflowSpec(
-    IReadOnlyList<string> WorkflowYamls);
+public sealed record ScopeBindingWorkflowSpec
+{
+    [JsonConstructor]
+    public ScopeBindingWorkflowSpec(
+        string WorkflowId,
+        IReadOnlyList<string> WorkflowYamls)
+    {
+        this.WorkflowId = WorkflowId;
+        this.WorkflowYamls = WorkflowYamls;
+    }
+
+    public ScopeBindingWorkflowSpec(IReadOnlyList<string> WorkflowYamls)
+        : this(string.Empty, WorkflowYamls)
+    {
+    }
+
+    public string WorkflowId { get; init; }
+
+    public IReadOnlyList<string> WorkflowYamls { get; init; }
+}
 
 public sealed record ScopeBindingScriptSpec(
     string ScriptId,
@@ -49,9 +69,32 @@ public sealed record ScopeBindingUpsertRequest(
     bool AllowExistingRevisionReplay = false,
     string? ReplayRevisionId = null);
 
-public sealed record ScopeBindingWorkflowResult(
-    string WorkflowName,
-    string DefinitionActorIdPrefix);
+public sealed record ScopeBindingWorkflowResult
+{
+    [JsonConstructor]
+    public ScopeBindingWorkflowResult(
+        string WorkflowId,
+        string WorkflowName,
+        string DefinitionActorIdPrefix)
+    {
+        this.WorkflowId = WorkflowId;
+        this.WorkflowName = WorkflowName;
+        this.DefinitionActorIdPrefix = DefinitionActorIdPrefix;
+    }
+
+    public ScopeBindingWorkflowResult(
+        string WorkflowName,
+        string DefinitionActorIdPrefix)
+        : this(string.Empty, WorkflowName, DefinitionActorIdPrefix)
+    {
+    }
+
+    public string WorkflowId { get; init; }
+
+    public string WorkflowName { get; init; }
+
+    public string DefinitionActorIdPrefix { get; init; }
+}
 
 public sealed record ScopeBindingScriptResult(
     string ScriptId,

--- a/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingCommandApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingCommandApplicationService.cs
@@ -330,6 +330,8 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
         CancellationToken ct)
     {
         var workflowBundle = await ParseWorkflowBundleAsync(request.Workflow?.WorkflowYamls, ct);
+        var workflowId = ScopeWorkflowCapabilityConventions.NormalizeOptional(request.Workflow?.WorkflowId) ??
+                         ScopeWorkflowCapabilityOptions.NormalizeRequired(identity.ServiceId, nameof(identity.ServiceId));
         var definitionActorIdPrefix = ScopeWorkflowCapabilityConventions.BuildDefaultDefinitionActorIdPrefix(_options, normalizedScopeId);
         var displayName = ScopeWorkflowCapabilityConventions.ResolveDisplayName(
             request.DisplayName,
@@ -373,6 +375,7 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
                     WorkflowName: workflowBundle.EntryWorkflowName,
                     DefinitionActorIdPrefix: definitionActorIdPrefix,
                     Workflow: new ScopeBindingWorkflowResult(
+                        workflowId,
                         workflowBundle.EntryWorkflowName,
                         definitionActorIdPrefix),
                     ExpectedDeploymentId: expectedDeploymentId));

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -3239,7 +3239,9 @@ const response = await fetch("{{invokePath}}", {
     private static ScopeBindingWorkflowSpec? ToWorkflowSpec(UpsertScopeBindingHttpRequest request)
     {
         var workflowYamls = request.Workflow?.WorkflowYamls;
-        return workflowYamls == null ? null : new ScopeBindingWorkflowSpec(workflowYamls);
+        return workflowYamls == null
+            ? null
+            : new ScopeBindingWorkflowSpec(request.Workflow?.WorkflowId ?? string.Empty, workflowYamls);
     }
 
     private static string? NormalizeOptional(string? value)
@@ -3296,6 +3298,7 @@ const response = await fetch("{{invokePath}}", {
         string? ServiceId = null);
 
     public sealed record ScopeBindingWorkflowHttpRequest(
+        string? WorkflowId,
         IReadOnlyList<string>? WorkflowYamls);
 
     public sealed record ScopeBindingScriptHttpRequest(

--- a/test/Aevatar.GAgentService.Tests/Application/ScopeBindingCommandApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScopeBindingCommandApplicationServiceTests.cs
@@ -44,10 +44,12 @@ public sealed class ScopeBindingCommandApplicationServiceTests
         var result = await service.UpsertAsync(new ScopeBindingUpsertRequest(
             ScopeId,
             ScopeBindingImplementationKind.Workflow,
-            Workflow: new ScopeBindingWorkflowSpec([
-                "name: main\nsteps:\n  - run: echo hello",
-                "name: child\nsteps:\n  - run: echo child",
-            ])));
+            Workflow: new ScopeBindingWorkflowSpec(
+                "workflow-stable-id",
+                [
+                    "name: main_runtime\nsteps:\n  - run: echo hello",
+                    "name: child\nsteps:\n  - run: echo child",
+                ])));
 
         commandPort.Calls.Should().HaveCount(6);
         commandPort.Calls[0].Method.Should().Be("CreateServiceAsync");
@@ -62,8 +64,9 @@ public sealed class ScopeBindingCommandApplicationServiceTests
         result.AcceptanceStage.Should().Be("accepted");
         result.PropagationStage.Should().Be("readmodel_propagating");
         result.Workflow.Should().NotBeNull();
-        result.Workflow!.WorkflowName.Should().Be("main");
-        result.DisplayName.Should().Be("main");
+        result.Workflow!.WorkflowId.Should().Be("workflow-stable-id");
+        result.Workflow!.WorkflowName.Should().Be("main_runtime");
+        result.DisplayName.Should().Be("main_runtime");
 
         var createCommand = commandPort.Calls[0].Command.Should().BeOfType<CreateServiceDefinitionCommand>().Subject;
         createCommand.Spec.Identity.Should().BeEquivalentTo(new ServiceIdentity

--- a/test/Aevatar.Studio.Tests/ActorDispatchStudioMemberCommandServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/ActorDispatchStudioMemberCommandServiceTests.cs
@@ -202,17 +202,20 @@ public sealed class ActorDispatchStudioMemberCommandServiceTests
                 ImplementationKind: MemberImplementationKindNames.Workflow,
                 Binding: new UpdateStudioMemberBindingRequest(
                     RevisionId: "rev-explicit",
-                    Workflow: new StudioMemberWorkflowBindingSpec([
-                        "workflow:\n  name: alpha",
-                        "workflow:\n  name: beta",
-                    ]))),
+                    Workflow: new StudioMemberWorkflowBindingSpec(
+                        "workflow-stable-id",
+                        [
+                            "workflow:\n  name: alpha_runtime",
+                            "workflow:\n  name: beta",
+                        ]))),
             CancellationToken.None);
 
         var evt = dispatch.Dispatches.Should().ContainSingle().Which
             .Envelope.Payload.Unpack<StudioMemberBindingRunRequested>();
         evt.Request.RevisionId.Should().Be("rev-explicit");
+        evt.Request.Workflow.WorkflowId.Should().Be("workflow-stable-id");
         evt.Request.Workflow.WorkflowYamls.Should().Equal(
-            "workflow:\n  name: alpha",
+            "workflow:\n  name: alpha_runtime",
             "workflow:\n  name: beta");
     }
 

--- a/test/Aevatar.Studio.Tests/ScopeBindingStudioMemberPlatformBindingCommandServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/ScopeBindingStudioMemberPlatformBindingCommandServiceTests.cs
@@ -118,7 +118,7 @@ public sealed class ScopeBindingStudioMemberPlatformBindingCommandServiceTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_WhenWorkflowResultHasNoWorkflowId_ShouldUseWorkflowNameFallback()
+    public async Task ExecuteAsync_WhenWorkflowResultHasNoWorkflowId_ShouldDispatchFailedContinuation()
     {
         var scopeBindingPort = new RecordingScopeBindingCommandPort
         {
@@ -132,9 +132,9 @@ public sealed class ScopeBindingStudioMemberPlatformBindingCommandServiceTests
             "platform-bind-1",
             NewWorkflowStartRequest());
 
-        var succeeded = await dispatchPort.WaitForPayloadAsync<StudioMemberPlatformBindingSucceeded>();
-        succeeded.Result.PublishedServiceId.Should().Be("member-m-1");
-        succeeded.Result.ImplementationRef.Workflow.WorkflowId.Should().Be("workflow-main");
+        var failed = await dispatchPort.WaitForPayloadAsync<StudioMemberPlatformBindingFailed>();
+        failed.Failure.Code.Should().Be("STUDIO_MEMBER_PLATFORM_BINDING_FAILED");
+        failed.Failure.Message.Should().Be("scope binding workflow result workflow id is required for workflow member binding.");
     }
 
     [Fact]

--- a/test/Aevatar.Studio.Tests/ScopeBindingStudioMemberPlatformBindingCommandServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/ScopeBindingStudioMemberPlatformBindingCommandServiceTests.cs
@@ -106,11 +106,12 @@ public sealed class ScopeBindingStudioMemberPlatformBindingCommandServiceTests
         var dispatch = await dispatchPort.NextDispatch.Task.WaitAsync(TimeSpan.FromSeconds(5));
         var succeeded = dispatch.Envelope.Payload.Unpack<StudioMemberPlatformBindingSucceeded>();
         succeeded.Result.ImplementationKind.Should().Be(StudioMemberImplementationKind.Workflow);
-        succeeded.Result.ImplementationRef.Workflow.WorkflowId.Should().Be("workflow-main");
+        succeeded.Result.ImplementationRef.Workflow.WorkflowId.Should().Be("workflow-stable-id");
         succeeded.Result.ImplementationRef.Workflow.WorkflowRevision.Should().Be("rev-platform-bind-1");
 
         var request = scopeBindingPort.Requests.Should().ContainSingle().Subject;
         request.ImplementationKind.Should().Be(ScopeBindingImplementationKind.Workflow);
+        request.Workflow!.WorkflowId.Should().Be("workflow-stable-id");
         request.Workflow!.WorkflowYamls.Should().ContainSingle().Which.Should().Contain("name: workflow-main");
         request.AllowExistingRevisionReplay.Should().BeTrue();
         request.ReplayRevisionId.Should().Be("rev-platform-bind-1");
@@ -568,6 +569,7 @@ public sealed class ScopeBindingStudioMemberPlatformBindingCommandServiceTests
         request.Request.Script = null;
         request.Request.Workflow = new StudioMemberWorkflowBindingRequest
         {
+            WorkflowId = "workflow-stable-id",
             WorkflowYamls = { "name: workflow-main\nsteps: []\n" },
         };
         return request;
@@ -679,6 +681,7 @@ public sealed class ScopeBindingStudioMemberPlatformBindingCommandServiceTests
                 WorkflowName: "workflow-main",
                 DefinitionActorIdPrefix: "scope-workflow:scope-1:workflow-main",
                 Workflow: new ScopeBindingWorkflowResult(
+                    request.Workflow?.WorkflowId ?? string.Empty,
                     "workflow-main",
                     "scope-workflow:scope-1:workflow-main"),
                 ExpectedDeploymentId: "deployment-1");

--- a/test/Aevatar.Studio.Tests/ScopeBindingStudioMemberPlatformBindingCommandServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/ScopeBindingStudioMemberPlatformBindingCommandServiceTests.cs
@@ -118,6 +118,26 @@ public sealed class ScopeBindingStudioMemberPlatformBindingCommandServiceTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_WhenWorkflowResultHasNoWorkflowId_ShouldUseWorkflowNameFallback()
+    {
+        var scopeBindingPort = new RecordingScopeBindingCommandPort
+        {
+            OmitWorkflowId = true,
+        };
+        var dispatchPort = new RecordingDispatchPort();
+        var service = CreateService(scopeBindingPort, dispatchPort);
+
+        await service.ExecuteAsync(
+            "studio-member-binding-run:bind-1",
+            "platform-bind-1",
+            NewWorkflowStartRequest());
+
+        var succeeded = await dispatchPort.WaitForPayloadAsync<StudioMemberPlatformBindingSucceeded>();
+        succeeded.Result.PublishedServiceId.Should().Be("member-m-1");
+        succeeded.Result.ImplementationRef.Workflow.WorkflowId.Should().Be("workflow-main");
+    }
+
+    [Fact]
     public async Task ExecuteAsync_ShouldBuildGAgentBindingRequestAndDispatchGAgentResult()
     {
         var scopeBindingPort = new RecordingScopeBindingCommandPort();
@@ -643,6 +663,7 @@ public sealed class ScopeBindingStudioMemberPlatformBindingCommandServiceTests
         public List<ScopeBindingUpsertRequest> Requests { get; } = [];
         public Exception? Failure { get; init; }
         public bool OmitExpectedDeploymentId { get; init; }
+        public bool OmitWorkflowId { get; init; }
         public TaskCompletionSource<ScopeBindingUpsertRequest> UpsertStarted { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
         public TaskCompletionSource<object?>? ReleaseUpsert { get; init; }
@@ -660,7 +681,7 @@ public sealed class ScopeBindingStudioMemberPlatformBindingCommandServiceTests
 
             var result = request.ImplementationKind switch
             {
-                ScopeBindingImplementationKind.Workflow => BuildWorkflowResult(request),
+                ScopeBindingImplementationKind.Workflow => BuildWorkflowResult(request, OmitWorkflowId),
                 ScopeBindingImplementationKind.GAgent => BuildGAgentResult(request),
                 _ => BuildScriptResult(request),
             };
@@ -668,7 +689,9 @@ public sealed class ScopeBindingStudioMemberPlatformBindingCommandServiceTests
             return OmitExpectedDeploymentId ? result with { ExpectedDeploymentId = "" } : result;
         }
 
-        private static ScopeBindingUpsertResult BuildWorkflowResult(ScopeBindingUpsertRequest request)
+        private static ScopeBindingUpsertResult BuildWorkflowResult(
+            ScopeBindingUpsertRequest request,
+            bool omitWorkflowId)
         {
             var revisionId = request.RevisionId ?? "rev-1";
             return new ScopeBindingUpsertResult(
@@ -681,7 +704,7 @@ public sealed class ScopeBindingStudioMemberPlatformBindingCommandServiceTests
                 WorkflowName: "workflow-main",
                 DefinitionActorIdPrefix: "scope-workflow:scope-1:workflow-main",
                 Workflow: new ScopeBindingWorkflowResult(
-                    request.Workflow?.WorkflowId ?? string.Empty,
+                    omitWorkflowId ? string.Empty : request.Workflow?.WorkflowId ?? string.Empty,
                     "workflow-main",
                     "scope-workflow:scope-1:workflow-main"),
                 ExpectedDeploymentId: "deployment-1");

--- a/test/Aevatar.Studio.Tests/StudioMemberBindingHostedConsistencyTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberBindingHostedConsistencyTests.cs
@@ -33,7 +33,9 @@ public sealed class StudioMemberBindingHostedConsistencyTests
         var bindResponse = await host.Client.PutAsJsonAsync(
             $"/api/scopes/{ScopeId}/members/{MemberId}/binding",
             new UpdateStudioMemberBindingRequest(
-                Workflow: new StudioMemberWorkflowBindingSpec(["name: main\nsteps:\n  - run: echo hello"])));
+                Workflow: new StudioMemberWorkflowBindingSpec(
+                    "workflow-stable-id",
+                    ["name: main\nsteps:\n  - run: echo hello"])));
 
         bindResponse.StatusCode.Should().Be(HttpStatusCode.Accepted);
 
@@ -51,7 +53,8 @@ public sealed class StudioMemberBindingHostedConsistencyTests
         startedRun.ScopeId.Should().Be(ScopeId);
         startedRun.MemberId.Should().Be(MemberId);
         startedRun.ImplementationKind.Should().Be(MemberImplementationKindNames.Workflow);
-        startedRun.Binding.Workflow!.WorkflowYamls.Should().ContainSingle()
+        startedRun.Binding.Workflow!.WorkflowId.Should().Be("workflow-stable-id");
+        startedRun.Binding.Workflow.WorkflowYamls.Should().ContainSingle()
             .Which.Should().Contain("echo hello");
 
         var runWhilePending = await host.Client.GetFromJsonAsync<StudioMemberBindingRunStatusResponse>(
@@ -93,6 +96,9 @@ public sealed class StudioMemberBindingHostedConsistencyTests
         completedDetail.Should().NotBeNull();
         completedDetail!.Summary.PublishedServiceId.Should().Be("member-member-1");
         completedDetail.Summary.LastBoundRevisionId.Should().Be("rev-1");
+        completedDetail.ImplementationRef.Should().NotBeNull();
+        completedDetail.ImplementationRef!.WorkflowId.Should().Be("workflow-stable-id");
+        completedDetail.ImplementationRef.WorkflowRevision.Should().Be("rev-1");
 
         var completedRun = await host.Client.GetFromJsonAsync<StudioMemberBindingRunStatusResponse>(
             $"/api/scopes/{ScopeId}/members/{MemberId}/binding-runs/{accepted.BindingRunId}");
@@ -285,7 +291,7 @@ public sealed class StudioMemberBindingHostedConsistencyTests
                     UpdatedAt: now),
                 ImplementationRef: new StudioMemberImplementationRefResponse(
                     ImplementationKind: MemberImplementationKindNames.Workflow,
-                    WorkflowId: "main",
+                    WorkflowId: "workflow-stable-id",
                     WorkflowRevision: completed ? "rev-1" : null),
                 LastBinding: completed
                     ? new StudioMemberBindingContractResponse(

--- a/test/Aevatar.Studio.Tests/StudioMemberEndpointsTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberEndpointsTests.cs
@@ -176,7 +176,7 @@ public sealed class StudioMemberEndpointsTests
             ScopeId,
             "m-1",
             new UpdateStudioMemberBindingRequest(
-                Workflow: new StudioMemberWorkflowBindingSpec(["w:"])),
+                Workflow: new StudioMemberWorkflowBindingSpec("workflow-stable-id", ["w:"])),
             service,
             CancellationToken.None);
 

--- a/test/Aevatar.Studio.Tests/StudioMemberServiceBindingTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberServiceBindingTests.cs
@@ -34,7 +34,9 @@ public sealed class StudioMemberServiceBindingTests
             ScopeId,
             MemberId,
             new UpdateStudioMemberBindingRequest(
-                Workflow: new StudioMemberWorkflowBindingSpec(["workflow:\n  name: x"])),
+                Workflow: new StudioMemberWorkflowBindingSpec(
+                    "workflow-stable-id",
+                    ["workflow:\n  name: x"])),
             CancellationToken.None);
 
         response.Status.Should().Be(StudioMemberBindingRunStatusNames.Accepted);
@@ -47,6 +49,7 @@ public sealed class StudioMemberServiceBindingTests
         started.ScopeId.Should().Be(ScopeId);
         started.MemberId.Should().Be(MemberId);
         started.ImplementationKind.Should().Be(MemberImplementationKindNames.Workflow);
+        started.Binding.Workflow!.WorkflowId.Should().Be("workflow-stable-id");
         started.Binding.Workflow!.WorkflowYamls.Should().ContainSingle();
     }
 
@@ -112,11 +115,33 @@ public sealed class StudioMemberServiceBindingTests
             ScopeId,
             MemberId,
             new UpdateStudioMemberBindingRequest(
-                Workflow: new StudioMemberWorkflowBindingSpec(["workflow:"])),
+                Workflow: new StudioMemberWorkflowBindingSpec(
+                    "workflow-stable-id",
+                    ["workflow:"])),
             CancellationToken.None);
 
         response.Status.Should().Be(StudioMemberBindingRunStatusNames.Accepted);
         commandPort.StartedRuns.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task BindAsync_Workflow_ShouldRequireWorkflowId()
+    {
+        var service = NewService(
+            new RecordingCommandPort(),
+            new ThrowingBindQueryPort());
+
+        var act = () => service.BindAsync(
+            ScopeId,
+            MemberId,
+            new UpdateStudioMemberBindingRequest(
+                Workflow: new StudioMemberWorkflowBindingSpec(
+                    string.Empty,
+                    ["workflow:\n  name: x"])),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*workflowId is required for workflow members*");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add typed workflowId to Studio member workflow binding requests and internal proto payloads.
- Preserve workflowId separately from YAML workflowName through scope binding results and member implementation refs.
- Add regression coverage for workflowId != workflowName and member re-entry/detail reads.

## Test plan
- [x] dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --filter "FullyQualifiedName~ActorDispatchStudioMemberCommandServiceTests|FullyQualifiedName~ScopeBindingStudioMemberPlatformBindingCommandServiceTests|FullyQualifiedName~StudioMemberServiceBindingTests|FullyQualifiedName~StudioMemberEndpointsTests|FullyQualifiedName~StudioMemberBindingHostedConsistencyTests" --nologo
- [x] dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --filter "FullyQualifiedName~ScopeBindingCommandApplicationServiceTests" --nologo
- [x] bash tools/ci/test_stability_guards.sh
- [x] bash tools/ci/workflow_binding_boundary_guard.sh

Fixes #1976

🤖 Generated with [Claude Code](https://claude.com/claude-code)