### PR TITLE
feat(workflow/lark): 新增 Bitable 单记录创建工具

### DIFF
--- a/src/Aevatar.AI.ToolProviders.Lark/ILarkNyxClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/ILarkNyxClient.cs
@@ -11,6 +11,7 @@ public interface ILarkNyxClient
     Task<string> BatchGetMessagesAsync(string token, LarkMessagesBatchGetRequest request, CancellationToken ct);
     Task<string> SearchChatsAsync(string token, LarkChatSearchRequest request, CancellationToken ct);
     Task<string> AppendSheetRowsAsync(string token, LarkSheetAppendRowsRequest request, CancellationToken ct);
+    Task<string> CreateBitableRecordAsync(string token, LarkBitableRecordCreateRequest request, CancellationToken ct);
     Task<string> ListApprovalTasksAsync(string token, LarkApprovalTaskQueryRequest request, CancellationToken ct);
     Task<string> ActOnApprovalTaskAsync(string token, LarkApprovalTaskActionRequest request, CancellationToken ct);
 }
@@ -74,6 +75,12 @@ public sealed record LarkSheetAppendRowsRequest(
     string SpreadsheetToken,
     string Range,
     IReadOnlyList<IReadOnlyList<string?>> Rows);
+
+public sealed record LarkBitableRecordCreateRequest(
+    string AppToken,
+    string TableId,
+    string FieldsJson,
+    string? ClientToken);
 
 public sealed record LarkApprovalTaskQueryRequest(
     string Topic,

--- a/src/Aevatar.AI.ToolProviders.Lark/LarkAgentToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/LarkAgentToolSource.cs
@@ -58,6 +58,8 @@ public sealed class LarkAgentToolSource : IAgentToolSource
             tools.Add(new LarkChatsLookupTool(_client));
         if (_options.EnableSheetsAppendRows)
             tools.Add(new LarkSheetsAppendRowsTool(_client));
+        if (_options.EnableBitableRecordsCreate)
+            tools.Add(new LarkBitableRecordsCreateTool(_client));
         if (_options.EnableApprovalsList)
             tools.Add(new LarkApprovalsListTool(_client));
         if (_options.EnableApprovalsAct)

--- a/src/Aevatar.AI.ToolProviders.Lark/LarkNyxClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/LarkNyxClient.cs
@@ -243,6 +243,31 @@ public sealed class LarkNyxClient : ILarkNyxClient
             ct);
     }
 
+    public Task<string> CreateBitableRecordAsync(string token, LarkBitableRecordCreateRequest request, CancellationToken ct)
+    {
+        using var fieldsDocument = JsonDocument.Parse(request.FieldsJson);
+        var body = new Dictionary<string, object?>
+        {
+            ["fields"] = fieldsDocument.RootElement.Clone(),
+        };
+
+        var path = $"open-apis/bitable/v1/apps/{Uri.EscapeDataString(request.AppToken)}/tables/{Uri.EscapeDataString(request.TableId)}/records";
+        var queryParts = new List<string>();
+        if (!string.IsNullOrWhiteSpace(request.ClientToken))
+            queryParts.Add($"client_token={Uri.EscapeDataString(request.ClientToken.Trim())}");
+        if (queryParts.Count > 0)
+            path += $"?{string.Join("&", queryParts)}";
+
+        return _nyxClient.ProxyRequestAsync(
+            token,
+            _options.ProviderSlug,
+            path,
+            "POST",
+            JsonSerializer.Serialize(body, JsonOptions),
+            extraHeaders: null,
+            ct);
+    }
+
     public Task<string> ListApprovalTasksAsync(string token, LarkApprovalTaskQueryRequest request, CancellationToken ct)
     {
         var queryParts = new List<string>

--- a/src/Aevatar.AI.ToolProviders.Lark/LarkProxyResponseParser.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/LarkProxyResponseParser.cs
@@ -243,6 +243,24 @@ internal static class LarkProxyResponseParser
             UpdatedCells: TryReadInt(updates, "updatedCells") ?? TryReadInt(updates, "updated_cells"));
     }
 
+    public static LarkBitableRecordCreateResult ParseBitableRecordCreateSuccess(string response)
+    {
+        using var document = JsonDocument.Parse(response);
+        var data = ResolveDataRoot(document.RootElement);
+        var record = data.TryGetProperty("record", out var recordProp) && recordProp.ValueKind == JsonValueKind.Object
+            ? recordProp
+            : data;
+
+        var fieldsJson = record.TryGetProperty("fields", out var fieldsProp) && fieldsProp.ValueKind == JsonValueKind.Object
+            ? fieldsProp.GetRawText()
+            : null;
+
+        return new LarkBitableRecordCreateResult(
+            RecordId: TryReadString(record, "record_id"),
+            Revision: TryReadInt(record, "revision"),
+            FieldsJson: fieldsJson);
+    }
+
     public static LarkApprovalTaskQueryResult ParseApprovalTaskQuerySuccess(string response)
     {
         using var document = JsonDocument.Parse(response);
@@ -443,6 +461,11 @@ internal sealed record LarkSheetAppendResult(
     int? UpdatedRows,
     int? UpdatedColumns,
     int? UpdatedCells);
+
+internal sealed record LarkBitableRecordCreateResult(
+    string? RecordId,
+    int? Revision,
+    string? FieldsJson);
 
 internal sealed record LarkApprovalTaskField(
     string? Key,

--- a/src/Aevatar.AI.ToolProviders.Lark/LarkToolOptions.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/LarkToolOptions.cs
@@ -12,6 +12,7 @@ public sealed class LarkToolOptions
     public bool EnableMessageBatchGet { get; set; } = true;
     public bool EnableChatLookup { get; set; } = true;
     public bool EnableSheetsAppendRows { get; set; } = true;
+    public bool EnableBitableRecordsCreate { get; set; } = true;
     public bool EnableApprovalsList { get; set; } = true;
     public bool EnableApprovalsAct { get; set; } = true;
 }

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkBitableRecordsCreateTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkBitableRecordsCreateTool.cs
@@ -1,0 +1,102 @@
+using System.Text.Json;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+
+namespace Aevatar.AI.ToolProviders.Lark.Tools;
+
+public sealed class LarkBitableRecordsCreateTool : AgentToolBase<LarkBitableRecordsCreateTool.Parameters>
+{
+    private readonly ILarkNyxClient _client;
+
+    public LarkBitableRecordsCreateTool(ILarkNyxClient client)
+    {
+        _client = client;
+    }
+
+    public override string Name => "lark_bitable_records_create";
+
+    public override string Description =>
+        "Create one Lark Bitable record through Nyx-backed transport. " +
+        "Use this when the target app_token, table_id, and record fields object are already known.";
+
+    public override ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;
+
+    protected override async Task<string> ExecuteAsync(Parameters parameters, CancellationToken ct)
+    {
+        var token = AgentToolRequestContext.NyxIdAccessToken;
+        if (string.IsNullOrWhiteSpace(token))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "No NyxID access token available. User must be authenticated." });
+
+        var appToken = parameters.AppToken?.Trim();
+        if (string.IsNullOrWhiteSpace(appToken))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "app_token is required." });
+
+        var tableId = parameters.TableId?.Trim();
+        if (string.IsNullOrWhiteSpace(tableId))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "table_id is required." });
+
+        var fieldsValidation = ValidateFieldsJson(parameters.FieldsJson);
+        if (!fieldsValidation.Success)
+            return LarkProxyResponseParser.Serialize(new { success = false, error = fieldsValidation.Error });
+
+        var response = await _client.CreateBitableRecordAsync(
+            token,
+            new LarkBitableRecordCreateRequest(
+                AppToken: appToken,
+                TableId: tableId,
+                FieldsJson: fieldsValidation.FieldsJson!,
+                ClientToken: parameters.ClientToken?.Trim()),
+            ct);
+
+        if (LarkProxyResponseParser.TryParseError(response, out var error))
+        {
+            return LarkProxyResponseParser.Serialize(new
+            {
+                success = false,
+                error,
+                app_token = appToken,
+                table_id = tableId,
+            });
+        }
+
+        var result = LarkProxyResponseParser.ParseBitableRecordCreateSuccess(response);
+        if (string.IsNullOrWhiteSpace(result.RecordId))
+        {
+            return LarkProxyResponseParser.Serialize(new
+            {
+                success = false,
+                error = "missing_record_id",
+                app_token = appToken,
+                table_id = tableId,
+            });
+        }
+
+        return LarkProxyResponseParser.Serialize(new
+        {
+            success = true,
+            app_token = appToken,
+            table_id = tableId,
+            record_id = result.RecordId,
+            revision = result.Revision,
+            fields_json = result.FieldsJson,
+        });
+    }
+
+    private static (bool Success, string? FieldsJson, string? Error) ValidateFieldsJson(JsonElement? fieldsJson)
+    {
+        if (fieldsJson is null || fieldsJson.Value.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
+            return (false, null, "fields_json is required.");
+        if (fieldsJson.Value.ValueKind != JsonValueKind.Object)
+            return (false, null, "fields_json must be a JSON object.");
+
+        return (true, fieldsJson.Value.GetRawText(), null);
+    }
+
+    public sealed class Parameters
+    {
+        public string? AppToken { get; set; }
+        public string? TableId { get; set; }
+        public JsonElement? FieldsJson { get; set; }
+        public string? ClientToken { get; set; }
+    }
+}

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkCoverageTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkCoverageTests.cs
@@ -76,6 +76,12 @@ public sealed class LarkCoverageTests
         sheetsTool.Name.Should().Be("lark_sheets_append_rows");
         sheetsTool.Description.Should().Contain("Append rows to a known Lark spreadsheet");
         sheetsTool.ApprovalMode.Should().Be(ToolApprovalMode.Auto);
+
+        var bitableTool = new LarkBitableRecordsCreateTool(client);
+        bitableTool.Name.Should().Be("lark_bitable_records_create");
+        bitableTool.Description.Should().Contain("Create one Lark Bitable record");
+        bitableTool.ApprovalMode.Should().Be(ToolApprovalMode.Auto);
+        bitableTool.ParametersSchema.Should().Contain("fields_json");
     }
 
     [Fact]
@@ -333,6 +339,14 @@ public sealed class LarkCoverageTests
             _ = request;
             _ = ct;
             return Task.FromResult("""{"code":0,"data":{"updates":{}}}""");
+        }
+
+        public Task<string> CreateBitableRecordAsync(string token, LarkBitableRecordCreateRequest request, CancellationToken ct)
+        {
+            _ = token;
+            _ = request;
+            _ = ct;
+            return Task.FromResult("""{"code":0,"data":{"record":{}}}""");
         }
 
         public Task<string> ListApprovalTasksAsync(string token, LarkApprovalTaskQueryRequest request, CancellationToken ct)

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
@@ -859,6 +859,175 @@ public class LarkToolsTests
     }
 
     [Fact]
+    public async Task LarkBitableRecordsCreateTool_CreatesRecordAndNormalizesResponse()
+    {
+        var client = new StubLarkNyxClient
+        {
+            BitableRecordCreateResponse =
+                """
+                {
+                  "code": 0,
+                  "data": {
+                    "record": {
+                      "record_id": "rec_123",
+                      "fields": {
+                        "Task": "Call customer",
+                        "Done": false
+                      }
+                    }
+                  }
+                }
+                """,
+        };
+        var tool = new LarkBitableRecordsCreateTool(client);
+
+        using var _ = new AgentToolRequestMetadataScope("token-123");
+        var result = await tool.ExecuteAsync(
+            """
+            {
+              "app_token": "base_123",
+              "table_id": "tbl_456",
+              "fields_json": {
+                "Task": "Call customer",
+                "Done": false
+              },
+              "client_token": "fe599b60-450f-46ff-b2ef-9f6675625b97"
+            }
+            """);
+
+        using var document = JsonDocument.Parse(result);
+        document.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+        document.RootElement.GetProperty("app_token").GetString().Should().Be("base_123");
+        document.RootElement.GetProperty("table_id").GetString().Should().Be("tbl_456");
+        document.RootElement.GetProperty("record_id").GetString().Should().Be("rec_123");
+
+        using var fieldsDocument = JsonDocument.Parse(document.RootElement.GetProperty("fields_json").GetString()!);
+        fieldsDocument.RootElement.GetProperty("Task").GetString().Should().Be("Call customer");
+        fieldsDocument.RootElement.GetProperty("Done").GetBoolean().Should().BeFalse();
+
+        client.LastBitableRecordCreateToken.Should().Be("token-123");
+        client.LastBitableRecordCreateRequest.Should().NotBeNull();
+        client.LastBitableRecordCreateRequest!.AppToken.Should().Be("base_123");
+        client.LastBitableRecordCreateRequest.TableId.Should().Be("tbl_456");
+        client.LastBitableRecordCreateRequest.FieldsJson.Should().Contain("\"Task\"");
+        client.LastBitableRecordCreateRequest.ClientToken.Should().Be("fe599b60-450f-46ff-b2ef-9f6675625b97");
+    }
+
+    [Fact]
+    public async Task LarkBitableRecordsCreateTool_ShouldValidateInputs_AndSurfaceProxyErrors()
+    {
+        var validationClient = new StubLarkNyxClient();
+        var tool = new LarkBitableRecordsCreateTool(validationClient);
+
+        using (new AgentToolRequestMetadataScope())
+        {
+            (await tool.ExecuteAsync("""{"app_token":"base_123","table_id":"tbl_456","fields_json":{"Task":"Call"}}"""))
+                .Should().Contain("No NyxID access token available");
+        }
+
+        using (new AgentToolRequestMetadataScope("token-123"))
+        {
+            (await tool.ExecuteAsync("""{"table_id":"tbl_456","fields_json":{"Task":"Call"}}"""))
+                .Should().Contain("app_token is required");
+            (await tool.ExecuteAsync("""{"app_token":"base_123","fields_json":{"Task":"Call"}}"""))
+                .Should().Contain("table_id is required");
+            (await tool.ExecuteAsync("""{"app_token":"base_123","table_id":"tbl_456"}"""))
+                .Should().Contain("fields_json is required");
+            (await tool.ExecuteAsync("""{"app_token":"base_123","table_id":"tbl_456","fields_json":[]}"""))
+                .Should().Contain("fields_json must be a JSON object");
+            (await tool.ExecuteAsync("""{"app_token":"base_123","table_id":"tbl_456","fields_json":"not-object"}"""))
+                .Should().Contain("fields_json must be a JSON object");
+            (await tool.ExecuteAsync("""{"app_token":"base_123","table_id":"tbl_456","fields_json":{"Task":"Call"}"""))
+                .Should().Contain("Invalid parameters");
+        }
+
+        validationClient.LastBitableRecordCreateRequest.Should().BeNull();
+
+        var errorTool = new LarkBitableRecordsCreateTool(new StubLarkNyxClient
+        {
+            BitableRecordCreateResponse = """{"error":true,"status":403,"message":"forbidden"}""",
+        });
+        using (new AgentToolRequestMetadataScope("token-123"))
+        {
+            var result = await errorTool.ExecuteAsync(
+                """{"app_token":"base_123","table_id":"tbl_456","fields_json":{"Task":"Call"}}""");
+
+            result.Should().Contain("nyx_proxy_error status=403");
+            result.Should().Contain("\"app_token\":\"base_123\"");
+            result.Should().Contain("\"table_id\":\"tbl_456\"");
+        }
+    }
+
+    [Theory]
+    [InlineData("""{"code":0,"data":{"record":{"fields":{"Task":"Call"}}}}""", "missing_record_id")]
+    [InlineData("""{"code":99991672,"msg":"invalid app token"}""", "lark_code=99991672")]
+    [InlineData("""{not-json""", "invalid_lark_response_json")]
+    public async Task LarkBitableRecordsCreateTool_ShouldReturnFailure_WithAppAndTableContext_WhenResponseCannotCreateRecord(
+        string response,
+        string expectedError)
+    {
+        var tool = new LarkBitableRecordsCreateTool(new StubLarkNyxClient
+        {
+            BitableRecordCreateResponse = response,
+        });
+
+        using var _ = new AgentToolRequestMetadataScope("token-123");
+        var result = await tool.ExecuteAsync(
+            """{"app_token":"base_123","table_id":"tbl_456","fields_json":{"Task":"Call"}}""");
+
+        using var document = JsonDocument.Parse(result);
+        document.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+        document.RootElement.GetProperty("error").GetString().Should().Contain(expectedError);
+        document.RootElement.GetProperty("app_token").GetString().Should().Be("base_123");
+        document.RootElement.GetProperty("table_id").GetString().Should().Be("tbl_456");
+    }
+
+    [Fact]
+    public async Task LarkBitableRecordsCreateTool_DoesNotLetPayloadOrExternalMetadataOverrideCallerScope()
+    {
+        var client = new StubLarkNyxClient
+        {
+            BitableRecordCreateResponse = """{"code":0,"data":{"record":{"record_id":"rec_123"}}}""",
+        };
+        var tool = new LarkBitableRecordsCreateTool(client);
+        using var _ = new AgentToolRequestContextScope(new AgentToolExecutionContext(
+            AgentToolRequestIdentity.Empty,
+            new AgentToolCredentials("trusted-caller-token", null, null),
+            AgentToolCallerContext.Empty,
+            AgentToolChannelContext.Empty,
+            AgentToolSenderBindingContext.Empty,
+            LLMRequestRoutingContext.Empty,
+            AgentToolConnectedServicesContext.Empty,
+            AgentSkillRecoveryContext.Empty,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [LLMRequestMetadataKeys.NyxIdAccessToken] = "external-metadata-token",
+            }));
+
+        var result = await tool.ExecuteAsync(
+            """
+            {
+              "app_token": "base_123",
+              "table_id": "tbl_456",
+              "fields_json": {
+                "Task": "Call customer"
+              },
+              "nyx_id_access_token": "payload-token",
+              "headers": {
+                "x-nyxid-access-token": "payload-header-token"
+              },
+              "metadata": {
+                "nyx_id_access_token": "payload-metadata-token"
+              }
+            }
+            """);
+
+        using var document = JsonDocument.Parse(result);
+        document.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+        client.LastBitableRecordCreateToken.Should().Be("trusted-caller-token");
+    }
+
+    [Fact]
     public async Task LarkApprovalsListTool_NormalizesTopicAndResponse()
     {
         var client = new StubLarkNyxClient
@@ -1169,7 +1338,7 @@ public class LarkToolsTests
 
         var tools = await source.DiscoverToolsAsync();
 
-        tools.Should().HaveCount(11);
+        tools.Should().HaveCount(12);
         tools.Should().Contain(tool => tool is LarkMessagesSendTool);
         tools.Should().Contain(tool => tool is LarkMessagesReplyTool);
         tools.Should().Contain(tool => tool is LarkMessagesReactTool);
@@ -1179,7 +1348,29 @@ public class LarkToolsTests
         tools.Should().Contain(tool => tool is LarkMessagesBatchGetTool);
         tools.Should().Contain(tool => tool is LarkChatsLookupTool);
         tools.Should().Contain(tool => tool is LarkSheetsAppendRowsTool);
+        tools.Should().Contain(tool => tool is LarkBitableRecordsCreateTool);
         tools.Should().Contain(tool => tool is LarkApprovalsListTool);
+        tools.Should().Contain(tool => tool is LarkApprovalsActTool);
+    }
+
+    [Fact]
+    public async Task LarkAgentToolSource_SkipsBitableRecordCreate_WhenDisabled()
+    {
+        var options = new LarkToolOptions();
+        var property = typeof(LarkToolOptions).GetProperty("EnableBitableRecordsCreate");
+        property.Should().NotBeNull();
+        property!.SetValue(options, false);
+
+        var source = new LarkAgentToolSource(
+            options,
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new StubLarkNyxClient());
+
+        var tools = await source.DiscoverToolsAsync();
+
+        tools.Should().HaveCount(11);
+        tools.Should().NotContain(tool => tool is LarkBitableRecordsCreateTool);
+        tools.Should().Contain(tool => tool is LarkMessagesSendTool);
         tools.Should().Contain(tool => tool is LarkApprovalsActTool);
     }
 
@@ -1421,6 +1612,40 @@ public class LarkToolsTests
     }
 
     [Fact]
+    public async Task LarkNyxClient_CreateBitableRecord_ShapesProxyRequest()
+    {
+        var handler = new RecordingHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"code":0,"data":{"record":{"record_id":"rec_123"}}}""", Encoding.UTF8, "application/json"),
+            });
+        var client = new LarkNyxClient(
+            new LarkToolOptions { ProviderSlug = "api-lark-bot" },
+            new NyxIdApiClient(
+                new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+                new HttpClient(handler)));
+
+        await client.CreateBitableRecordAsync(
+            "token-123",
+            new LarkBitableRecordCreateRequest(
+                "base_123",
+                "tbl_456",
+                """{"Task":"Call customer","Done":false}""",
+                "fe599b60-450f-46ff-b2ef-9f6675625b97"),
+            CancellationToken.None);
+
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.RequestUri!.ToString()
+            .Should().Be("https://nyx.example.com/api/v1/proxy/s/api-lark-bot/open-apis/bitable/v1/apps/base_123/tables/tbl_456/records?client_token=fe599b60-450f-46ff-b2ef-9f6675625b97");
+        handler.LastRequest.Headers.Authorization!.Parameter.Should().Be("token-123");
+
+        using var body = JsonDocument.Parse(handler.LastBody!);
+        var fields = body.RootElement.GetProperty("fields");
+        fields.GetProperty("Task").GetString().Should().Be("Call customer");
+        fields.GetProperty("Done").GetBoolean().Should().BeFalse();
+    }
+
+    [Fact]
     public async Task LarkNyxClient_ListApprovalTasks_ShapesProxyRequest()
     {
         var handler = new RecordingHandler(_ =>
@@ -1493,10 +1718,12 @@ public class LarkToolsTests
         public string MessagesBatchGetResponse { get; set; } = """{"code":0,"data":{"items":[]}}""";
         public string SearchResponse { get; set; } = """{"code":0,"data":{"items":[],"total":0}}""";
         public string AppendSheetResponse { get; set; } = """{"code":0,"data":{"updates":{}}}""";
+        public string BitableRecordCreateResponse { get; set; } = """{"code":0,"data":{"record":{}}}""";
         public string ApprovalListResponse { get; set; } = """{"code":0,"data":{"tasks":[],"count":0}}""";
         public string ApprovalActionResponse { get; set; } = """{"code":0,"data":{}}""";
 
         public string? LastSendToken { get; private set; }
+        public string? LastBitableRecordCreateToken { get; private set; }
         public LarkSendMessageRequest? LastSendRequest { get; private set; }
         public LarkReplyMessageRequest? LastReplyRequest { get; private set; }
         public LarkMessageReactionRequest? LastReactionRequest { get; private set; }
@@ -1506,6 +1733,7 @@ public class LarkToolsTests
         public LarkMessagesBatchGetRequest? LastBatchGetRequest { get; private set; }
         public LarkChatSearchRequest? LastSearchRequest { get; private set; }
         public LarkSheetAppendRowsRequest? LastSheetAppendRequest { get; private set; }
+        public LarkBitableRecordCreateRequest? LastBitableRecordCreateRequest { get; private set; }
         public LarkApprovalTaskQueryRequest? LastApprovalQueryRequest { get; private set; }
         public LarkApprovalTaskActionRequest? LastApprovalActionRequest { get; private set; }
 
@@ -1562,6 +1790,13 @@ public class LarkToolsTests
         {
             LastSheetAppendRequest = request;
             return Task.FromResult(AppendSheetResponse);
+        }
+
+        public Task<string> CreateBitableRecordAsync(string token, LarkBitableRecordCreateRequest request, CancellationToken ct)
+        {
+            LastBitableRecordCreateToken = token;
+            LastBitableRecordCreateRequest = request;
+            return Task.FromResult(BitableRecordCreateResponse);
         }
 
         public Task<string> ListApprovalTasksAsync(string token, LarkApprovalTaskQueryRequest request, CancellationToken ct)

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCardConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCardConversationTurnRunnerTests.cs
@@ -214,6 +214,9 @@ public sealed class ChannelCardConversationTurnRunnerTests
         public Task<string> AppendSheetRowsAsync(string token, LarkSheetAppendRowsRequest request, CancellationToken ct) =>
             throw new NotSupportedException();
 
+        public Task<string> CreateBitableRecordAsync(string token, LarkBitableRecordCreateRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+
         public Task<string> ListApprovalTasksAsync(string token, LarkApprovalTaskQueryRequest request, CancellationToken ct) =>
             throw new NotSupportedException();
 


### PR DESCRIPTION
## Summary / 摘要

实现 #1980：新增受控的 `lark_bitable_records_create` typed Lark side-effect tool。

- 通过现有 `LarkAgentToolSource` / `ILarkNyxClient` / `LarkNyxClient` 主链调用 NyxID-backed Lark API。
- 显式校验 typed caller credential、`app_token`、`table_id`、JSON object 形式 `fields_json`，并支持可选 `client_token`。
- 成功返回稳定 `success/app_token/table_id/record_id`，并覆盖 missing `record_id`、Lark error、invalid JSON、credential override、disable switch 和 transport shape 测试。

## Scope / 范围

- `src/Aevatar.AI.ToolProviders.Lark/*`
- `test/Aevatar.AI.ToolProviders.Lark.Tests/*`
- `test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCardConversationTurnRunnerTests.cs`（同步 `ILarkNyxClient` test double）

## Verification / 验证

- `dotnet test test/Aevatar.AI.ToolProviders.Lark.Tests/Aevatar.AI.ToolProviders.Lark.Tests.csproj --nologo`：通过，71 passed。
- `dotnet build aevatar.slnx --nologo`：通过，0 errors。
- `dotnet test aevatar.slnx --nologo`：通过，exit 0。
- `bash tools/ci/test_stability_guards.sh`：通过。
- `bash tools/ci/architecture_guards.sh`：通过。
- `git diff --check && git diff --cached --check`：通过。

Closes #1980

🤖 Generated with Claude Code

⟦AI:AUTO-LOOP⟧