### PR TITLE
Use themed create team buttons

### DIFF
--- a/apps/aevatar-console-web/src/pages/teams/new.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/new.tsx
@@ -17,10 +17,7 @@ import {
 import { t } from "@/shared/i18n/messages";
 
 const primaryActionButtonStyle: React.CSSProperties = {
-  background: '#6c5ce7',
-  borderColor: '#6c5ce7',
   borderRadius: 10,
-  color: '#ffffff',
   fontSize: 14,
   fontWeight: 600,
   height: 44,
@@ -167,6 +164,7 @@ const TeamCreatePage: React.FC = () => {
             loading={isCreatingTeam}
             onClick={() => void handleCreateTeam()}
             style={primaryActionButtonStyle}
+            type="primary"
           >
             {t("pages.teams.new.create.team", "Create Team")}</Button>
         </Space>
@@ -238,6 +236,7 @@ const TeamCreatePage: React.FC = () => {
               loading={isCreatingTeam}
               onClick={() => void handleCreateTeam()}
               style={primaryActionButtonStyle}
+              type="primary"
             >
               {t("pages.teams.new.create.team.3", "Create Team")}</Button>
             <Button onClick={() => history.push(buildTeamsHref())}>


### PR DESCRIPTION
## What changed

- Removed the one-off hard-coded purple background, border, and text color from the Create Team page action style.
- Switched both Create Team actions to Ant Design `type="primary"` so they follow the console theme tokens and built-in button states.

## Why

The Create Team buttons were visually inconsistent with other console pages because the page owned its own `#6c5ce7` color instead of using the shared primary button styling.

## Impact

- Affects `apps/aevatar-console-web/src/pages/teams/new.tsx` only.
- Keeps the existing size, spacing, radius, and font weight while aligning color, hover, loading, and disabled states with the rest of the app.

## Validation

- `pnpm --dir apps/aevatar-console-web tsc`
