### PR TITLE
Fix workflow studio back route

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -1273,6 +1273,7 @@ jest.mock("@/shared/studio/api", () => ({
       scopeId: string;
       memberId: string;
       displayName?: string;
+      workflowId: string;
       workflowYamls: string[];
     }) => {
       mockStudioMembers = mockStudioMembers.map((member) =>
@@ -5537,6 +5538,7 @@ describe("StudioPage", () => {
           scopeId: "scope-1",
           memberId: "workspace-demo",
           displayName: "workspace-demo",
+          workflowId: "workflow-1",
           workflowYamls: expect.arrayContaining([expect.stringContaining("name: workspace-demo")]),
         }),
       );
@@ -5961,6 +5963,7 @@ describe("StudioPage", () => {
           scopeId: "scope-1",
           memberId: "draft1",
           displayName: "draft1",
+          workflowId: "workflow-1",
         })
       );
     });

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -4953,10 +4953,18 @@ const StudioPage: React.FC = () => {
     let memberBindingRunOutcome: StudioBindingRunOutcome | null = null;
     if (buildPendingBindCandidate.kind === 'workflow') {
       if (resolvedBuildMemberId) {
+        const workflowIdForBinding = trimOptional(
+          selectedWorkflowId || activeWorkflowFile?.workflowId,
+        );
+        if (!workflowIdForBinding) {
+          throw new Error('Resolve a stable workflow draft id before binding this member.');
+        }
+
         const receipt = await studioApi.bindMemberWorkflow({
           scopeId: resolvedStudioScopeId,
           memberId: resolvedBuildMemberId,
           displayName: buildPendingBindCandidate.displayName,
+          workflowId: workflowIdForBinding,
           workflowYamls: await buildWorkflowYamlBundle(),
         });
         await queryClient.invalidateQueries({

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -1294,9 +1294,8 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
         throw new Error("Workflow draft save did not return a stable workflow id.");
       }
 
-      const createdMember = await studioApi.createMemberWithId({
+      const createdMember = await studioApi.createMember({
         scopeId: route.scopeId,
-        memberId: savedWorkflowId,
         displayName: normalizedTitle,
         implementationKind: "workflow",
         teamId: route.teamId,

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -1316,6 +1316,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
         scopeId: route.scopeId,
         memberId: createdMemberId,
         displayName: savedDraft.title,
+        workflowId: savedWorkflowId,
         workflowYamls: [serialized.yaml],
       });
 
@@ -1517,6 +1518,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       let savedDraft: SavedWorkflowDraft | null = null;
       let documentForPublish = document;
       let titleForPublish = trimOptional(title) || trimOptional(document.name);
+      let workflowIdForPublish = trimOptional(workflow.workflowId);
       if (dirty) {
         savedDraft = await saveWorkflowDraft({
           document,
@@ -1527,6 +1529,12 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
         });
         documentForPublish = savedDraft.document;
         titleForPublish = savedDraft.title;
+        workflowIdForPublish =
+          trimOptional(savedDraft.workflow.workflowId) || workflowIdForPublish;
+      }
+
+      if (!workflowIdForPublish) {
+        throw new Error("Resolve a stable workflow draft id before publishing.");
       }
 
       const serialized = await studioApi.serializeYaml({
@@ -1540,6 +1548,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
         scopeId: route.scopeId,
         memberId: route.memberId,
         displayName: titleForPublish,
+        workflowId: workflowIdForPublish,
         workflowYamls: [serialized.yaml],
       });
 

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -919,7 +919,6 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
   const suppressedSourceSignatureRef =
     React.useRef<WorkflowSourceSignature | null>(null);
   const backHref = buildTeamDetailHref({
-    memberId: route.memberId || undefined,
     scopeId: route.scopeId,
     tab: "members",
     teamId: route.teamId,

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -420,12 +420,12 @@ describe("TeamMemberWorkflowStudioPage", () => {
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
-      fileName: "untitled-member.yaml",
-      filePath: "scope://scope-1/untitled-member.yaml",
+      fileName: "wf-untitled-member.yaml",
+      filePath: "scope://scope-1/wf-untitled-member.yaml",
       findings: [],
       layout: null,
       name: "Untitled member",
-      workflowId: "untitled-member",
+      workflowId: "wf-untitled-member",
       yaml: "name: Untitled member\nsteps: []\n",
       document: {
         name: "Untitled member",
@@ -443,29 +443,29 @@ describe("TeamMemberWorkflowStudioPage", () => {
       },
       updatedAtUtc: "2026-06-08T00:00:01Z",
     });
-    (studioApi.createMemberWithId as jest.Mock).mockResolvedValue({
+    (studioApi.createMember as jest.Mock).mockResolvedValue({
       createdAt: "2026-06-08T00:00:00Z",
       description: "",
       displayName: "Untitled member",
       implementationKind: "workflow",
       lastBoundRevisionId: null,
       lifecycleStage: "created",
-      memberId: "untitled-member",
-      publishedServiceId: "member-untitled-member",
+      memberId: "m-untitled-member",
+      publishedServiceId: "member-m-untitled-member",
       scopeId: "scope-1",
       teamId: "t-alpha",
       updatedAt: "2026-06-08T00:00:01Z",
     });
     (studioApi.bindMemberWorkflow as jest.Mock).mockResolvedValue({
       bindingRunId: "binding-run-new",
-      memberId: "untitled-member",
+      memberId: "m-untitled-member",
       scopeId: "scope-1",
       status: "accepted",
     });
     (studioApi.getMember as jest.Mock).mockResolvedValue({
       implementationRef: {
         implementationKind: "workflow",
-        workflowId: "untitled-member",
+        workflowId: "wf-untitled-member",
       },
       summary: {
         createdAt: "2026-06-08T00:00:00Z",
@@ -474,7 +474,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         implementationKind: "workflow",
         lastBoundRevisionId: null,
         lifecycleStage: "created",
-        memberId: "untitled-member",
+        memberId: "m-untitled-member",
         publishedServiceId: "",
         scopeId: "scope-1",
         teamId: "t-alpha",
@@ -485,12 +485,12 @@ describe("TeamMemberWorkflowStudioPage", () => {
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
-      fileName: "untitled-member.yaml",
-      filePath: "scope://scope-1/untitled-member.yaml",
+      fileName: "wf-untitled-member.yaml",
+      filePath: "scope://scope-1/wf-untitled-member.yaml",
       findings: [],
       layout: null,
       name: "Untitled member",
-      workflowId: "untitled-member",
+      workflowId: "wf-untitled-member",
       yaml: "name: Untitled member\nsteps: []\n",
       document: {
         name: "Untitled member",
@@ -552,28 +552,27 @@ describe("TeamMemberWorkflowStudioPage", () => {
           workflowId: "",
         }),
       );
-      expect(studioApi.createMemberWithId).toHaveBeenCalledWith({
+      expect(studioApi.createMember).toHaveBeenCalledWith({
         displayName: "Untitled member",
         implementationKind: "workflow",
-        memberId: "untitled-member",
         scopeId: "scope-1",
         teamId: "t-alpha",
       });
-      expect(studioApi.createMember).not.toHaveBeenCalled();
+      expect(studioApi.createMemberWithId).not.toHaveBeenCalled();
       expect(studioApi.updateMemberTeamAssignment).not.toHaveBeenCalled();
       expect(studioApi.bindMemberWorkflow).toHaveBeenCalledWith({
         displayName: "Untitled member",
-        memberId: "untitled-member",
+        memberId: "m-untitled-member",
         scopeId: "scope-1",
-        workflowId: "untitled-member",
+        workflowId: "wf-untitled-member",
         workflowYamls: [expect.stringContaining("name: Untitled member")],
       });
     });
     expect(window.location.pathname).toBe(
-      "/scopes/scope-1/teams/t-alpha/members/untitled-member/workflow",
+      "/scopes/scope-1/teams/t-alpha/members/m-untitled-member/workflow",
     );
     expect(new URLSearchParams(window.location.search).get("workflowId")).toBe(
-      "untitled-member",
+      "wf-untitled-member",
     );
     expect(invalidateQueriesSpy).toHaveBeenCalledWith({
       queryKey: ["team-member-workflow-studio", "team", "scope-1", "t-alpha"],
@@ -602,12 +601,12 @@ describe("TeamMemberWorkflowStudioPage", () => {
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
-      fileName: "untitled-member.yaml",
-      filePath: "scope://scope-1/untitled-member.yaml",
+      fileName: "wf-untitled-member.yaml",
+      filePath: "scope://scope-1/wf-untitled-member.yaml",
       findings: [],
       layout: null,
       name: "Untitled member",
-      workflowId: "untitled-member",
+      workflowId: "wf-untitled-member",
       yaml: "name: Untitled member\nsteps: []\n",
       document: {
         name: "Untitled member",
@@ -628,7 +627,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     const createdMemberDetail = {
       implementationRef: {
         implementationKind: "workflow",
-        workflowId: "untitled-member",
+        workflowId: "wf-untitled-member",
       },
       summary: {
         createdAt: "2026-06-08T00:00:00Z",
@@ -637,19 +636,19 @@ describe("TeamMemberWorkflowStudioPage", () => {
         implementationKind: "workflow",
         lastBoundRevisionId: null,
         lifecycleStage: "created",
-        memberId: "untitled-member",
-        publishedServiceId: "member-untitled-member",
+        memberId: "m-untitled-member",
+        publishedServiceId: "member-m-untitled-member",
         scopeId: "scope-1",
         teamId: "t-alpha",
         updatedAt: "2026-06-08T00:00:01Z",
       },
     };
-    (studioApi.createMemberWithId as jest.Mock).mockResolvedValue(
+    (studioApi.createMember as jest.Mock).mockResolvedValue(
       createdMemberDetail.summary,
     );
     (studioApi.bindMemberWorkflow as jest.Mock).mockResolvedValue({
       bindingRunId: "binding-run-new",
-      memberId: "untitled-member",
+      memberId: "m-untitled-member",
       scopeId: "scope-1",
       status: "accepted",
     });
@@ -657,12 +656,12 @@ describe("TeamMemberWorkflowStudioPage", () => {
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
-      fileName: "untitled-member.yaml",
-      filePath: "scope://scope-1/untitled-member.yaml",
+      fileName: "wf-untitled-member.yaml",
+      filePath: "scope://scope-1/wf-untitled-member.yaml",
       findings: [],
       layout: null,
       name: "Untitled member",
-      workflowId: "untitled-member",
+      workflowId: "wf-untitled-member",
       yaml: "name: Untitled member\nsteps: []\n",
       document: {
         name: "Untitled member",
@@ -682,11 +681,11 @@ describe("TeamMemberWorkflowStudioPage", () => {
     };
     (studioApi.getMember as jest.Mock).mockImplementation(
       async (_scopeId: string, memberId: string) =>
-        memberId === "untitled-member" ? createdMemberDetail : undefined,
+        memberId === "m-untitled-member" ? createdMemberDetail : undefined,
     );
     (studioApi.getWorkflow as jest.Mock).mockImplementation(
       async (workflowId: string) =>
-        workflowId === "untitled-member" ? createdWorkflow : undefined,
+        workflowId === "wf-untitled-member" ? createdWorkflow : undefined,
     );
 
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
@@ -699,17 +698,17 @@ describe("TeamMemberWorkflowStudioPage", () => {
 
     await waitFor(() => {
       expect(window.location.pathname).toBe(
-        "/scopes/scope-1/teams/t-alpha/members/untitled-member/workflow",
+        "/scopes/scope-1/teams/t-alpha/members/m-untitled-member/workflow",
       );
       expect(new URLSearchParams(window.location.search).get("workflowId")).toBe(
-        "untitled-member",
+        "wf-untitled-member",
       );
       expect(studioApi.getMember).toHaveBeenCalledWith(
         "scope-1",
-        "untitled-member",
+        "m-untitled-member",
       );
       expect(studioApi.getWorkflow).toHaveBeenCalledWith(
-        "untitled-member",
+        "wf-untitled-member",
         "scope-1",
       );
     });

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -565,6 +565,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         displayName: "Untitled member",
         memberId: "untitled-member",
         scopeId: "scope-1",
+        workflowId: "untitled-member",
         workflowYamls: [expect.stringContaining("name: Untitled member")],
       });
     });
@@ -3638,6 +3639,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         displayName: "Workflow Alpha Published",
         memberId: "member-alpha",
         scopeId: "scope-1",
+        workflowId: "workflow-alpha",
         workflowYamls: [expect.stringContaining("name: Workflow Alpha Published")],
       });
       expect(studioApi.getMemberBindingRun).toHaveBeenCalledWith(
@@ -3978,6 +3980,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         displayName: "Workflow Alpha v2",
         memberId: "member-alpha",
         scopeId: "scope-1",
+        workflowId: "workflow-alpha",
         workflowYamls: [expect.stringContaining("name: Workflow Alpha v2")],
       });
     });

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -805,7 +805,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: "Back" }));
     expect(`${window.location.pathname}${window.location.search}`).toBe(
-      "/scopes/scope-1/teams/t-alpha?memberId=member-alpha&tab=members",
+      "/scopes/scope-1/teams/t-alpha?tab=members",
     );
   });
 
@@ -914,7 +914,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
 
     expect(window.location.pathname).toBe("/scopes/scope-1/teams/t-alpha");
     const params = new URLSearchParams(window.location.search);
-    expect(params.get("memberId")).toBe("member-alpha");
+    expect(params.get("memberId")).toBeNull();
     expect(params.get("tab")).toBe("members");
     expect(params.get("workflowId")).toBeNull();
   });

--- a/apps/aevatar-console-web/src/shared/studio/api.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.test.ts
@@ -872,11 +872,13 @@ describe('studioApi host-session requests', () => {
     } as Response);
     global.fetch = fetchMock as typeof global.fetch;
 
+    const runtimeWorkflowYaml = 'name: joker-runtime\nsteps: []\n';
     const result = await studioApi.bindMemberWorkflow({
       scopeId: 'scope-1',
       memberId: 'joker',
       displayName: 'joker',
-      workflowYamls: ['name: joker\nsteps: []\n'],
+      workflowId: 'workflow-stable-1',
+      workflowYamls: [runtimeWorkflowYaml],
       revisionId: 'rev-1',
     });
 
@@ -897,10 +899,23 @@ describe('studioApi host-session requests', () => {
       implementationKind: 'workflow',
       displayName: 'joker',
       workflow: {
-        workflowYamls: ['name: joker\nsteps: []\n'],
+        workflowId: 'workflow-stable-1',
+        workflowYamls: [runtimeWorkflowYaml],
       },
       revisionId: 'rev-1',
     });
+  });
+
+  it('rejects member workflow binding without a stable workflow id', async () => {
+    expect(() =>
+      studioApi.bindMemberWorkflow({
+        scopeId: 'scope-1',
+        memberId: 'joker',
+        displayName: 'joker',
+        workflowId: ' ',
+        workflowYamls: ['name: joker\nsteps: []\n'],
+      }),
+    ).toThrow('Workflow member binding requires a stable workflow id.');
   });
 
   it('binds a GAgent to the default service using the scope binding endpoint', async () => {

--- a/apps/aevatar-console-web/src/shared/studio/api.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.ts
@@ -25,6 +25,7 @@ import type {
   StudioMemberLifecycleStage,
   StudioMemberRoster,
   StudioMemberSummary,
+  StudioMemberWorkflowBindingInput,
   StudioParseYamlResult,
   StudioRoleCatalogImportResult,
   StudioRoleCatalog,
@@ -1997,13 +1998,14 @@ export const studioApi = {
     );
   },
 
-  bindMemberWorkflow(input: {
-    scopeId: string;
-    memberId: string;
-    displayName?: string | null;
-    workflowYamls: readonly string[];
-    revisionId?: string | null;
-  }): Promise<StudioMemberBindingAcceptedResponse> {
+  bindMemberWorkflow(
+    input: StudioMemberWorkflowBindingInput
+  ): Promise<StudioMemberBindingAcceptedResponse> {
+    const workflowId = trimOptional(input.workflowId);
+    if (!workflowId) {
+      throw new Error("Workflow member binding requires a stable workflow id.");
+    }
+
     return requestDecodedJson(
       `/api/scopes/${encodeURIComponent(input.scopeId.trim())}/members/${encodeURIComponent(input.memberId.trim())}/binding`,
       decodeStudioMemberBindingAcceptedResponse,
@@ -2015,6 +2017,7 @@ export const studioApi = {
             implementationKind: "workflow",
             displayName: trimOptional(input.displayName),
             workflow: {
+              workflowId,
               workflowYamls: input.workflowYamls,
             },
             revisionId: trimOptional(input.revisionId),

--- a/apps/aevatar-console-web/src/shared/studio/models.ts
+++ b/apps/aevatar-console-web/src/shared/studio/models.ts
@@ -214,6 +214,15 @@ export interface StudioStartExecutionInput {
   readonly eventFormat?: string | null;
 }
 
+export interface StudioMemberWorkflowBindingInput {
+  readonly scopeId: string;
+  readonly memberId: string;
+  readonly displayName?: string | null;
+  readonly workflowId: string;
+  readonly workflowYamls: readonly string[];
+  readonly revisionId?: string | null;
+}
+
 export type StudioScopeBindingImplementationKind =
   | 'workflow'
   | 'script'


### PR DESCRIPTION
## Summary
- Route the workflow studio Back button to the owning Team members tab without carrying the current member identity query.
- Update workflow studio navigation tests to assert the canonical Team members URL and no editor identity leakage.

## Verification
- npm test -- --runInBand src/pages/team-member-workflow-studio/index.test.tsx
- npm run tsc
- bash tools/ci/test_stability_guards.sh