### PR TITLE
Implement NyxID workflow service integration

### DIFF
--- a/docs/audit-scorecard/2026-06-11-nyxid-workflow-scope-service-runbook.md
+++ b/docs/audit-scorecard/2026-06-11-nyxid-workflow-scope-service-runbook.md
@@ -1,0 +1,223 @@
+---
+title: NyxID workflow scope service integration runbook
+status: active
+owner: codex
+issue: 1981
+---
+
+# NyxID Workflow Scope Service Integration Runbook
+
+## Scope
+
+This issue is zero production code. The validation path must use existing Aevatar scope service endpoints and the existing NyxID downstream/proxy surfaces. Do not add a workflow tool, NyxID client, availability fallback, automatic registration, or any NyxID repository change for this runbook.
+
+This worker has no live secrets or external environment. All response samples below are placeholders or evidence checklist items. Replace placeholders with redacted live evidence only when running in an authorized environment.
+
+## Inputs
+
+| Name | Placeholder |
+|---|---|
+| Aevatar host | `<AEVATAR_BASE_URL>` |
+| NyxID host | `<NYXID_BASE_URL>` |
+| Caller token | `<NYXID_OR_AEVATAR_BEARER>` |
+| Scope id | `<SCOPE_ID>` |
+| Service id | `<SERVICE_ID>` |
+| Revision id | `<REVISION_ID>` |
+| Endpoint id | `<ENDPOINT_ID>` |
+| NyxID slug | `<NYXID_SLUG>` |
+| Run id | `<RUN_ID>` |
+
+## Publish Scope Service
+
+Use the existing scope binding surface to publish a workflow-backed service in a scope:
+
+```bash
+curl -sS -X PUT "$AEVATAR_BASE_URL/api/scopes/$SCOPE_ID/binding" \
+  -H "Authorization: Bearer $NYXID_OR_AEVATAR_BEARER" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "implementationKind": "workflow",
+    "displayName": "<DISPLAY_NAME>",
+    "serviceId": "<SERVICE_ID>",
+    "revisionId": "<REVISION_ID>",
+    "workflow": {
+      "workflowId": "<WORKFLOW_ID>",
+      "workflowYamls": ["<WORKFLOW_YAML>"]
+    }
+  }'
+```
+
+Evidence checklist:
+
+| Check | Evidence |
+|---|---|
+| Command accepted | `<HTTP_STATUS_AND_REDACTED_BODY>` |
+| Service id returned | `<SERVICE_ID>` |
+| Revision id returned | `<REVISION_ID>` |
+| No synchronous completion claimed | `<ACK_ONLY_CONFIRMATION>` |
+
+Confirm the scope service catalog readmodel exposes the published service before registering it in NyxID:
+
+```bash
+curl -sS "$AEVATAR_BASE_URL/api/scopes/$SCOPE_ID/services?take=20" \
+  -H "Authorization: Bearer $NYXID_OR_AEVATAR_BEARER"
+```
+
+Evidence checklist:
+
+| Check | Evidence |
+|---|---|
+| Service appears in catalog | `<SERVICE_ID_AND_STATE_VERSION_OR_UPDATED_AT>` |
+| Invoke readiness is visible | `<INVOKE_READINESS_STATUS>` |
+
+## Register / Connect In NyxID
+
+Use NyxID's existing service add/update surface to create or update a downstream service that points at the Aevatar scope service endpoint. The exact CLI/API form depends on the authorized NyxID environment and credential type.
+
+```bash
+nyxid service add --custom \
+  --label "<DISPLAY_NAME>" \
+  --endpoint-url "$AEVATAR_BASE_URL" \
+  --auth-method bearer \
+  --credential-env AEVATAR_SCOPE_SERVICE_TOKEN
+```
+
+Alternative API placeholder:
+
+```bash
+curl -sS -X POST "$NYXID_BASE_URL/api/v1/keys" \
+  -H "Authorization: Bearer <NYXID_USER_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "label": "<DISPLAY_NAME>",
+    "endpoint_url": "<AEVATAR_BASE_URL>",
+    "auth_method": "bearer",
+    "credential": "<REDACTED>"
+  }'
+```
+
+Evidence checklist:
+
+| Check | Evidence |
+|---|---|
+| NyxID connected service created or updated | `<HTTP_STATUS_OR_CLI_OUTPUT>` |
+| Slug captured | `<NYXID_SLUG>` |
+| Credential not logged | `<CONFIRMATION>` |
+
+## Discover With `nyxid_proxy`
+
+In chat, call `nyxid_proxy` without slug/path first. This uses the existing discovery behavior and should list proxyable services for the current caller context.
+
+```json
+{
+  "tool": "nyxid_proxy",
+  "arguments": {}
+}
+```
+
+Evidence checklist:
+
+| Check | Evidence |
+|---|---|
+| Discovery succeeds | `<REDACTED_DISCOVERY_STATUS>` |
+| Aevatar service slug present | `<NYXID_SLUG>` |
+| Endpoint hints visible if configured | `<REDACTED_ENDPOINT_HINTS>` |
+
+## Invoke Through NyxID Proxy
+
+Call the discovered slug/path. Use the endpoint path that maps to the Aevatar scope service invoke route.
+
+```json
+{
+  "tool": "nyxid_proxy",
+  "arguments": {
+    "slug": "<NYXID_SLUG>",
+    "method": "POST",
+    "path": "/api/scopes/<SCOPE_ID>/services/<SERVICE_ID>/invoke/<ENDPOINT_ID>",
+    "body": {
+      "prompt": "Hello from NyxID proxy validation."
+    }
+  }
+}
+```
+
+Evidence checklist:
+
+| Check | Evidence |
+|---|---|
+| Proxy call reaches Aevatar | `<HTTP_STATUS>` |
+| Accepted receipt has stable run id | `<RUN_ID>` |
+| No fabricated completion state in ACK | `<ACK_FIELDS>` |
+
+## Stream Validation
+
+Use the existing streaming invoke endpoint when the service endpoint supports SSE.
+
+```bash
+curl -N -X POST "$NYXID_BASE_URL/api/v1/proxy/s/$NYXID_SLUG/api/scopes/$SCOPE_ID/services/$SERVICE_ID/invoke/$ENDPOINT_ID:stream" \
+  -H "Authorization: Bearer <NYXID_AGENT_KEY>" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d '{"prompt":"Hello from stream validation."}'
+```
+
+Evidence checklist:
+
+| Check | Evidence |
+|---|---|
+| SSE opens | `<FIRST_EVENT>` |
+| Progress events arrive | `<REDACTED_EVENT_SEQUENCE>` |
+| Terminal event arrives or expected suspension is observed | `<TERMINAL_OR_SUSPENDED_EVENT>` |
+
+## Run Query Validation
+
+Read the run through Aevatar's read-model-backed run query. Do not use event replay or query-time projection priming.
+
+```bash
+curl -sS "$AEVATAR_BASE_URL/api/scopes/$SCOPE_ID/services/$SERVICE_ID/runs/$RUN_ID" \
+  -H "Authorization: Bearer $NYXID_OR_AEVATAR_BEARER"
+```
+
+Evidence checklist:
+
+| Check | Evidence |
+|---|---|
+| Run readmodel exists | `<HTTP_STATUS_AND_REDACTED_BODY>` |
+| State version or update timestamp exposed | `<VERSION_OR_TIMESTAMP>` |
+| Status matches stream/accepted observations | `<STATUS>` |
+
+## Approval Validation
+
+If NyxID approval is enabled for the connected service, the first proxy call can return an approval-required response. Capture the redacted response and approve or deny through NyxID's existing approval surface.
+
+```bash
+curl -sS "$NYXID_BASE_URL/api/v1/approvals/requests?status=pending" \
+  -H "Authorization: Bearer <NYXID_USER_TOKEN>"
+```
+
+```bash
+curl -sS -X POST "$NYXID_BASE_URL/api/v1/approvals/requests/<REQUEST_ID>/decide" \
+  -H "Authorization: Bearer <NYXID_USER_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{"decision":"approved"}'
+```
+
+Evidence checklist:
+
+| Check | Evidence |
+|---|---|
+| Approval challenge is returned or not required | `<APPROVAL_STATUS>` |
+| Approve/deny decision recorded | `<REQUEST_ID_AND_DECISION>` |
+| Retry behavior matches NyxID policy | `<RETRY_RESULT>` |
+
+## Follow-up Gap Templates
+
+Create follow-up issues only for observed future failures. Do not create them from this worker.
+
+| Observed failure | Follow-up template |
+|---|---|
+| NyxID discovery omits the Aevatar service after registration | "NyxID discovery gap: registered Aevatar service `<slug>` is not returned by no-slug `nyxid_proxy` discovery. Evidence: `<redacted commands/results>`." |
+| NyxID proxy cannot invoke the discovered Aevatar path | "NyxID proxy invocation gap: discovered slug `<slug>` cannot reach Aevatar path `<path>`. Evidence: `<redacted status/body>`." |
+| Aevatar accepted run is not visible in run query after expected projection lag | "Aevatar run readmodel gap: accepted run `<runId>` for service `<serviceId>` is not query-visible. Evidence: `<accepted receipt>`, `<query response>`, `<timestamps>`." |
+| SSE stream misses terminal or suspension observation | "Scope service stream gap: stream for run `<runId>` did not emit expected terminal/suspended event. Evidence: `<event sequence>`." |
+| Approval-required response is ambiguous or not actionable | "NyxID approval gap: proxy approval response lacks actionable request id/status. Evidence: `<redacted response>`." |

--- a/docs/canon/nyxid-responses-direct.md
+++ b/docs/canon/nyxid-responses-direct.md
@@ -220,11 +220,20 @@ NyxID slug proxy 路由是 REST proxy plane：
 /api/v1/proxy/s/{slug}/{path}
 ```
 
+## 10. Aevatar Service 外部暴露记录
+
+Aevatar service catalog 的 `externalExposure` 是 service definition 拥有的 typed fact，用来记录该 service 已经作为外部 NyxID downstream service 暴露时的稳定信息：
+
+- `nyxidSlug`：NyxID 侧用于 `/api/v1/proxy/s/{slug}/...` 的 slug。
+- `registeredAt`：该外部暴露记录写入 Aevatar service definition 的时间。
+
+这个事实不属于 service binding。Binding 只表达本 service 依赖的下游资源；`externalExposure` 表达本 service 自身对外暴露后的可发现信息。Aevatar 不会因为该字段自动向 NyxID 注册服务，也不会把该字段接入 dispatcher 路由。写入仍走 service definition 的窄 external exposure 更新入口，读取走 service catalog readmodel 与现有 service/scope service API 响应。
+
 因此 API key 至少需要 `proxy` scope，或更宽的 proxy scope。生产上可以用 `--allowed-services` 收紧到 Aevatar 与目标 LLM 服务；调试时可以先用 `--allow-all-services` 验证链路。
 
 `--allowed-services` 必须填 `nyxid service list --output json` 里的 UserService id，不是 catalog id。填错时常见错误是 `api_key_scope_forbidden_legacy`。
 
-## 10. 代码锚点
+## 11. 代码锚点
 
 主机端入口：
 

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -301,9 +301,12 @@ public sealed class AevatarInvocationDispatcher
         var result = await _workflowDispatchService.DispatchAsync(command, ct);
         if (!result.Succeeded || result.Receipt == null)
         {
+            var message = result.Error == WorkflowChatRunStartError.WorkflowNotFound
+                ? WorkflowChatRunStartErrorGuidance.WorkflowNotFound
+                : $"Workflow start failed: {result.Error}";
             var startError = Error(
                 result.Error.ToString(),
-                $"Workflow start failed: {result.Error}");
+                message);
             return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(startError), startError);
         }
 

--- a/src/platform/Aevatar.GAgentService.Abstractions/Ports/IServiceCommandPort.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Ports/IServiceCommandPort.cs
@@ -12,6 +12,11 @@ public interface IServiceCommandPort
         UpdateServiceDefinitionCommand command,
         CancellationToken ct = default);
 
+    Task<ServiceCommandAcceptedReceipt> UpdateServiceExternalExposureAsync(
+        UpdateServiceExternalExposureCommand command,
+        CancellationToken ct = default) =>
+        throw new NotSupportedException();
+
     Task<ServiceCommandAcceptedReceipt> CreateRevisionAsync(
         CreateServiceRevisionCommand command,
         CancellationToken ct = default);

--- a/src/platform/Aevatar.GAgentService.Abstractions/Protos/service_definition.proto
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Protos/service_definition.proto
@@ -4,13 +4,20 @@ package aevatar.gagentservice;
 
 option csharp_namespace = "Aevatar.GAgentService.Abstractions";
 
+import "google/protobuf/timestamp.proto";
 import "service_endpoint.proto";
+
+message ExternalExposure {
+  string nyxid_slug = 1;
+  google.protobuf.Timestamp registered_at = 2;
+}
 
 message ServiceDefinitionSpec {
   ServiceIdentity identity = 1;
   string display_name = 2;
   repeated ServiceEndpointSpec endpoints = 3;
   repeated string policy_ids = 4;
+  ExternalExposure external_exposure = 5;
 }
 
 message ServiceDefinitionState {
@@ -28,6 +35,11 @@ message UpdateServiceDefinitionCommand {
   ServiceDefinitionSpec spec = 1;
 }
 
+message UpdateServiceExternalExposureCommand {
+  ServiceIdentity identity = 1;
+  ExternalExposure external_exposure = 2;
+}
+
 message SetDefaultServingRevisionCommand {
   ServiceIdentity identity = 1;
   string revision_id = 2;
@@ -39,6 +51,11 @@ message ServiceDefinitionCreatedEvent {
 
 message ServiceDefinitionUpdatedEvent {
   ServiceDefinitionSpec spec = 1;
+}
+
+message ServiceExternalExposureUpdatedEvent {
+  ServiceIdentity identity = 1;
+  ExternalExposure external_exposure = 2;
 }
 
 message DefaultServingRevisionChangedEvent {

--- a/src/platform/Aevatar.GAgentService.Abstractions/Queries/ServiceCatalogSnapshot.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Queries/ServiceCatalogSnapshot.cs
@@ -14,7 +14,8 @@ public sealed record ServiceCatalogSnapshot(
     string DeploymentStatus,
     IReadOnlyList<ServiceEndpointSnapshot> Endpoints,
     IReadOnlyList<string> PolicyIds,
-    DateTimeOffset UpdatedAt);
+    DateTimeOffset UpdatedAt,
+    ServiceExternalExposureSnapshot? ExternalExposure = null);
 
 public sealed record ServiceEndpointSnapshot(
     string EndpointId,
@@ -23,3 +24,7 @@ public sealed record ServiceEndpointSnapshot(
     string RequestTypeUrl,
     string ResponseTypeUrl,
     string Description);
+
+public sealed record ServiceExternalExposureSnapshot(
+    string NyxidSlug,
+    DateTimeOffset? RegisteredAt);

--- a/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingCommandApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingCommandApplicationService.cs
@@ -80,6 +80,7 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
         {
             var updateSpec = CloneServiceDefinition(desiredBinding.ServiceDefinition);
             updateSpec.PolicyIds.Add(existingService.PolicyIds);
+            ApplyExistingExternalExposure(updateSpec, existingService.ExternalExposure);
             await _serviceCommandPort.UpdateServiceAsync(new UpdateServiceDefinitionCommand
             {
                 Spec = updateSpec,
@@ -613,7 +614,25 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
         };
         clone.Endpoints.Add(source.Endpoints.Select(CloneEndpointSpec));
         clone.PolicyIds.Add(source.PolicyIds);
+        if (source.ExternalExposure != null)
+            clone.ExternalExposure = source.ExternalExposure.Clone();
         return clone;
+    }
+
+    private static void ApplyExistingExternalExposure(
+        ServiceDefinitionSpec spec,
+        ServiceExternalExposureSnapshot? existingExternalExposure)
+    {
+        if (existingExternalExposure == null)
+            return;
+
+        spec.ExternalExposure = new ExternalExposure
+        {
+            NyxidSlug = existingExternalExposure.NyxidSlug ?? string.Empty,
+            RegisteredAt = existingExternalExposure.RegisteredAt.HasValue
+                ? Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset(existingExternalExposure.RegisteredAt.Value)
+                : null,
+        };
     }
 
     private static ServiceEndpointSpec CloneEndpointSpec(ServiceEndpointSpec spec) =>

--- a/src/platform/Aevatar.GAgentService.Application/Services/ServiceCommandApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Services/ServiceCommandApplicationService.cs
@@ -39,6 +39,15 @@ public sealed class ServiceCommandApplicationService : IServiceCommandPort
         return await DispatchAsync(actorId, command, CorrelationForService(command.Spec.Identity), ct);
     }
 
+    public async Task<ServiceCommandAcceptedReceipt> UpdateServiceExternalExposureAsync(
+        UpdateServiceExternalExposureCommand command,
+        CancellationToken ct = default)
+    {
+        var actorId = await _targetProvisioner.EnsureDefinitionTargetAsync(command.Identity, ct);
+        await _targetProvisioner.EnsureInvocationCatalogTargetAsync(command.Identity, ct);
+        return await DispatchAsync(actorId, command, CorrelationForService(command.Identity), ct);
+    }
+
     public async Task<ServiceCommandAcceptedReceipt> CreateRevisionAsync(
         CreateServiceRevisionCommand command,
         CancellationToken ct = default)

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/ServiceDefinitionGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/ServiceDefinitionGAgent.cs
@@ -51,6 +51,19 @@ public sealed class ServiceDefinitionGAgent : GAgentBase<ServiceDefinitionState>
     }
 
     [EventHandler]
+    public async Task HandleUpdateExternalExposureAsync(UpdateServiceExternalExposureCommand command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        EnsureExistingIdentity(command.Identity);
+        await PersistDomainEventAsync(new ServiceExternalExposureUpdatedEvent
+        {
+            Identity = command.Identity.Clone(),
+            ExternalExposure = command.ExternalExposure?.Clone() ?? new ExternalExposure(),
+        });
+        await DispatchInvocationCatalogObservationAsync(CancellationToken.None);
+    }
+
+    [EventHandler]
     public async Task HandleSetDefaultServingRevisionAsync(SetDefaultServingRevisionCommand command)
     {
         ArgumentNullException.ThrowIfNull(command);
@@ -71,6 +84,7 @@ public sealed class ServiceDefinitionGAgent : GAgentBase<ServiceDefinitionState>
             .Match(current, evt)
             .On<ServiceDefinitionCreatedEvent>(ApplyCreated)
             .On<ServiceDefinitionUpdatedEvent>(ApplyUpdated)
+            .On<ServiceExternalExposureUpdatedEvent>(ApplyExternalExposureUpdated)
             .On<DefaultServingRevisionChangedEvent>(ApplyDefaultServingRevisionChanged)
             .OrCurrent();
 
@@ -86,9 +100,23 @@ public sealed class ServiceDefinitionGAgent : GAgentBase<ServiceDefinitionState>
     private static ServiceDefinitionState ApplyUpdated(ServiceDefinitionState state, ServiceDefinitionUpdatedEvent evt)
     {
         var next = state.Clone();
-        next.Spec = evt.Spec?.Clone() ?? new ServiceDefinitionSpec();
+        var spec = evt.Spec?.Clone() ?? new ServiceDefinitionSpec();
+        if (spec.ExternalExposure == null && state.Spec?.ExternalExposure != null)
+            spec.ExternalExposure = state.Spec.ExternalExposure.Clone();
+        next.Spec = spec;
         next.LastAppliedEventVersion = state.LastAppliedEventVersion + 1;
         next.LastEventId = BuildEventId(evt.Spec?.Identity, "updated");
+        return next;
+    }
+
+    private static ServiceDefinitionState ApplyExternalExposureUpdated(
+        ServiceDefinitionState state,
+        ServiceExternalExposureUpdatedEvent evt)
+    {
+        var next = state.Clone();
+        next.Spec.ExternalExposure = evt.ExternalExposure?.Clone() ?? new ExternalExposure();
+        next.LastAppliedEventVersion = state.LastAppliedEventVersion + 1;
+        next.LastEventId = BuildEventId(evt.Identity, "external-exposure-updated");
         return next;
     }
 
@@ -133,7 +161,8 @@ public sealed class ServiceDefinitionGAgent : GAgentBase<ServiceDefinitionState>
 
     private Task DispatchInvocationCatalogObservationAsync(CancellationToken ct)
     {
-        var identity = State.Spec?.Identity;
+        var spec = State.Spec;
+        var identity = spec?.Identity;
         if (identity == null || string.IsNullOrWhiteSpace(identity.ServiceId))
             return Task.CompletedTask;
 
@@ -145,7 +174,7 @@ public sealed class ServiceDefinitionGAgent : GAgentBase<ServiceDefinitionState>
                 new ObserveServiceInvocationCatalogCommand
                 {
                     Identity = identity.Clone(),
-                    ServiceEndpoints = { State.Spec.Endpoints.Select(ToDescriptor) },
+                    ServiceEndpoints = { spec!.Endpoints.Select(ToDescriptor) },
                     SourceCatalogVersion = State.LastAppliedEventVersion,
                     ObservedAt = Timestamp.FromDateTime(DateTime.UtcNow),
                 }),

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -2404,7 +2404,8 @@ public static class ScopeServiceEndpoints
             service.UpdatedAt,
             revisionSnapshots,
             revisions?.StateVersion ?? 0,
-            revisions?.LastEventId ?? string.Empty);
+            revisions?.LastEventId ?? string.Empty,
+            ExternalExposure: MapExternalExposure(service.ExternalExposure));
     }
 
     private static async Task<IReadOnlyList<ScopeServiceHttpResponse>> JoinScopeInvokeReadinessAsync(
@@ -2451,7 +2452,8 @@ public static class ScopeServiceEndpoints
                 service.UpdatedAt,
                 ready,
                 status.ToString(),
-                reason));
+                reason,
+                MapExternalExposure(service.ExternalExposure)));
         }
 
         return responses;
@@ -2487,7 +2489,8 @@ public static class ScopeServiceEndpoints
             revisions?.StateVersion ?? 0,
             revisions?.LastEventId ?? string.Empty,
             revisions?.UpdatedAt ?? service.UpdatedAt,
-            BuildScopeRevisionResponses(service, revisions, servingSet));
+            BuildScopeRevisionResponses(service, revisions, servingSet),
+            ExternalExposure: MapExternalExposure(service.ExternalExposure));
     }
 
     private static ScopeServiceEndpointContractHttpResponse? BuildScopeServiceEndpointContractResponse(
@@ -2945,6 +2948,23 @@ const response = await fetch("{{invokePath}}", {
         }
 
         return spec;
+    }
+
+    private static ExternalExposureHttpResponse? MapExternalExposure(
+        ServiceExternalExposureSnapshot? externalExposure)
+    {
+        if (externalExposure == null)
+            return null;
+
+        if (string.IsNullOrWhiteSpace(externalExposure.NyxidSlug) &&
+            externalExposure.RegisteredAt == null)
+        {
+            return null;
+        }
+
+        return new ExternalExposureHttpResponse(
+            externalExposure.NyxidSlug ?? string.Empty,
+            externalExposure.RegisteredAt);
     }
 
     private static ServiceBindingKind ParseBindingKind(string? rawValue)
@@ -3530,7 +3550,8 @@ const response = await fetch("{{invokePath}}", {
         DateTimeOffset? UpdatedAt,
         IReadOnlyList<ScopeBindingRevisionHttpResponse> Revisions,
         long CatalogStateVersion = 0,
-        string CatalogLastEventId = "");
+        string CatalogLastEventId = "",
+        ExternalExposureHttpResponse? ExternalExposure = null);
 
     public sealed record MemberPublishedServiceHttpResponse(
         string ScopeId,
@@ -3588,7 +3609,8 @@ const response = await fetch("{{invokePath}}", {
         DateTimeOffset UpdatedAt,
         bool InvokeReady,
         string InvokeReadinessStatus,
-        string? InvokeUnavailableReason);
+        string? InvokeUnavailableReason,
+        ExternalExposureHttpResponse? ExternalExposure = null);
 
     public sealed record ScopeServiceRevisionCatalogHttpResponse(
         string ScopeId,
@@ -3603,7 +3625,12 @@ const response = await fetch("{{invokePath}}", {
         long CatalogStateVersion,
         string CatalogLastEventId,
         DateTimeOffset UpdatedAt,
-        IReadOnlyList<ScopeBindingRevisionHttpResponse> Revisions);
+        IReadOnlyList<ScopeBindingRevisionHttpResponse> Revisions,
+        ExternalExposureHttpResponse? ExternalExposure = null);
+
+    public sealed record ExternalExposureHttpResponse(
+        string NyxidSlug,
+        DateTimeOffset? RegisteredAt);
 
     public sealed record ScopeServiceRevisionActionHttpResponse(
         string ScopeId,

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ServiceEndpoints.cs
@@ -21,6 +21,7 @@ public static partial class ServiceEndpoints
     {
         var group = app.MapGroup("/api/services");
         group.MapPost(string.Empty, HandleCreateServiceAsync);
+        group.MapPut("/{serviceId}/external-exposure", HandleUpdateServiceExternalExposureAsync);
         group.MapPost("/{serviceId}/revisions", HandleCreateRevisionAsync);
         group.MapPost("/{serviceId}/revisions/{revisionId}:prepare", HandlePrepareRevisionAsync);
         group.MapPost("/{serviceId}/revisions/{revisionId}:publish", HandlePublishRevisionAsync);
@@ -60,15 +61,46 @@ public static partial class ServiceEndpoints
             return denied;
         }
 
+        var spec = new ServiceDefinitionSpec
+        {
+            Identity = identity,
+            DisplayName = request.DisplayName ?? string.Empty,
+            Endpoints = { request.Endpoints.Select(ToEndpointSpec) },
+            PolicyIds = { request.PolicyIds ?? [] },
+        };
+        ApplyExternalExposure(spec, request.ExternalExposure);
+
         var receipt = await commandPort.CreateServiceAsync(new CreateServiceDefinitionCommand
         {
-            Spec = new ServiceDefinitionSpec
-            {
-                Identity = identity,
-                DisplayName = request.DisplayName ?? string.Empty,
-                Endpoints = { request.Endpoints.Select(ToEndpointSpec) },
-                PolicyIds = { request.PolicyIds ?? [] },
-            },
+            Spec = spec,
+        }, ct);
+        return Results.Accepted($"/api/services/{identity.ServiceId}", receipt);
+    }
+
+    private static async Task<IResult> HandleUpdateServiceExternalExposureAsync(
+        HttpContext http,
+        string serviceId,
+        UpdateServiceExternalExposureHttpRequest request,
+        [FromServices] IServiceIdentityContextResolver identityResolver,
+        [FromServices] IServiceCommandPort commandPort,
+        CancellationToken ct)
+    {
+        if (!ServiceIdentityEndpointAccess.TryResolveIdentity(
+                identityResolver,
+                request.TenantId,
+                request.AppId,
+                request.Namespace,
+                serviceId,
+                out var identity,
+                out var denied))
+        {
+            return denied;
+        }
+
+        var receipt = await commandPort.UpdateServiceExternalExposureAsync(new UpdateServiceExternalExposureCommand
+        {
+            Identity = identity,
+            ExternalExposure = ToExternalExposure(request),
         }, ct);
         return Results.Accepted($"/api/services/{identity.ServiceId}", receipt);
     }
@@ -557,7 +589,8 @@ public static partial class ServiceEndpoints
             service.UpdatedAt,
             ready,
             status.ToString(),
-            reason);
+            reason,
+            MapExternalExposure(service.ExternalExposure));
     }
 
     private static bool HasCompleteInvocationIdentity(ServiceCatalogSnapshot service) =>
@@ -598,6 +631,54 @@ public static partial class ServiceEndpoints
             ResponseTypeUrl = request.ResponseTypeUrl ?? string.Empty,
             Description = request.Description ?? string.Empty,
         };
+
+    private static void ApplyExternalExposure(
+        ServiceDefinitionSpec spec,
+        ExternalExposureHttpRequest? externalExposure)
+    {
+        var mapped = ToExternalExposure(externalExposure);
+        if (mapped != null)
+            spec.ExternalExposure = mapped;
+    }
+
+    private static ExternalExposure? ToExternalExposure(ExternalExposureHttpRequest? request)
+    {
+        if (request == null)
+            return null;
+
+        var slug = request.NyxidSlug?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(slug) && request.RegisteredAt == null)
+            return null;
+
+        return new ExternalExposure
+        {
+            NyxidSlug = slug,
+            RegisteredAt = request.RegisteredAt.HasValue
+                ? Timestamp.FromDateTimeOffset(request.RegisteredAt.Value)
+                : null,
+        };
+    }
+
+    private static ExternalExposure ToExternalExposure(UpdateServiceExternalExposureHttpRequest request) =>
+        ToExternalExposure(new ExternalExposureHttpRequest(request.NyxidSlug, request.RegisteredAt))
+        ?? new ExternalExposure();
+
+    private static ExternalExposureHttpResponse? MapExternalExposure(
+        ServiceExternalExposureSnapshot? externalExposure)
+    {
+        if (externalExposure == null)
+            return null;
+
+        if (string.IsNullOrWhiteSpace(externalExposure.NyxidSlug) &&
+            externalExposure.RegisteredAt == null)
+        {
+            return null;
+        }
+
+        return new ExternalExposureHttpResponse(
+            externalExposure.NyxidSlug ?? string.Empty,
+            externalExposure.RegisteredAt);
+    }
 
     private static ServiceImplementationKind ParseImplementationKind(string? rawValue)
     {
@@ -643,7 +724,8 @@ public static partial class ServiceEndpoints
         DateTimeOffset UpdatedAt,
         bool InvokeReady,
         string InvokeReadinessStatus,
-        string? InvokeUnavailableReason);
+        string? InvokeUnavailableReason,
+        ExternalExposureHttpResponse? ExternalExposure = null);
 
     public sealed record ServiceIdentityHttpRequest(
         string TenantId,
@@ -658,6 +740,14 @@ public static partial class ServiceEndpoints
         string ResponseTypeUrl,
         string Description);
 
+    public sealed record ExternalExposureHttpRequest(
+        string? NyxidSlug,
+        DateTimeOffset? RegisteredAt = null);
+
+    public sealed record ExternalExposureHttpResponse(
+        string NyxidSlug,
+        DateTimeOffset? RegisteredAt);
+
     public sealed record CreateServiceHttpRequest(
         string TenantId,
         string AppId,
@@ -665,7 +755,15 @@ public static partial class ServiceEndpoints
         string ServiceId,
         string DisplayName,
         IReadOnlyList<ServiceEndpointHttpRequest> Endpoints,
-        IReadOnlyList<string>? PolicyIds = null);
+        IReadOnlyList<string>? PolicyIds = null,
+        ExternalExposureHttpRequest? ExternalExposure = null);
+
+    public sealed record UpdateServiceExternalExposureHttpRequest(
+        string TenantId,
+        string AppId,
+        string Namespace,
+        string? NyxidSlug,
+        DateTimeOffset? RegisteredAt = null);
 
     public sealed record StaticRevisionHttpRequest(
         string ActorTypeName,

--- a/src/platform/Aevatar.GAgentService.Projection/Orchestration/ServiceCommittedStateProjectionActivationPlanProvider.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Orchestration/ServiceCommittedStateProjectionActivationPlanProvider.cs
@@ -48,6 +48,7 @@ public sealed class ServiceCommittedStateProjectionActivationPlanProvider : IPro
     {
         if (!payload.Is(ServiceDefinitionCreatedEvent.Descriptor) &&
             !payload.Is(ServiceDefinitionUpdatedEvent.Descriptor) &&
+            !payload.Is(ServiceExternalExposureUpdatedEvent.Descriptor) &&
             !payload.Is(DefaultServingRevisionChangedEvent.Descriptor))
         {
             return [];

--- a/src/platform/Aevatar.GAgentService.Projection/Projectors/ServiceCatalogProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Projectors/ServiceCatalogProjector.cs
@@ -49,6 +49,7 @@ public sealed class ServiceCatalogProjector
             DefaultServingRevisionId = state.DefaultServingRevisionId ?? string.Empty,
             Endpoints = state.Spec.Endpoints.Select(MapEndpoint).ToList(),
             PolicyIds = [.. state.Spec.PolicyIds],
+            ExternalExposure = MapExternalExposure(state.Spec.ExternalExposure),
         };
         ApplyIdentity(readModel, state.Spec.Identity);
         ApplyProjectionStamp(readModel, context.RootActorId, eventId, stateVersion, observedAt);
@@ -87,4 +88,20 @@ public sealed class ServiceCatalogProjector
             ResponseTypeUrl = endpoint.ResponseTypeUrl ?? string.Empty,
             Description = endpoint.Description ?? string.Empty,
         };
+
+    private static ServiceCatalogExternalExposureReadModel? MapExternalExposure(ExternalExposure? externalExposure)
+    {
+        if (externalExposure == null ||
+            string.IsNullOrWhiteSpace(externalExposure.NyxidSlug) &&
+            externalExposure.RegisteredAt == null)
+        {
+            return null;
+        }
+
+        return new ServiceCatalogExternalExposureReadModel
+        {
+            NyxidSlug = externalExposure.NyxidSlug ?? string.Empty,
+            RegisteredAtUtcValue = externalExposure.RegisteredAt?.Clone(),
+        };
+    }
 }

--- a/src/platform/Aevatar.GAgentService.Projection/Queries/ServiceCatalogQueryReader.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Queries/ServiceCatalogQueryReader.cs
@@ -120,6 +120,21 @@ public sealed class ServiceCatalogQueryReader : IServiceCatalogQueryReader
                     x.Description))
                 .ToList(),
             [.. readModel.PolicyIds],
-            readModel.UpdatedAt);
+            readModel.UpdatedAt,
+            MapExternalExposure(readModel.ExternalExposure));
+    }
+
+    private static ServiceExternalExposureSnapshot? MapExternalExposure(
+        ServiceCatalogExternalExposureReadModel? externalExposure)
+    {
+        if (externalExposure == null)
+            return null;
+
+        var nyxidSlug = externalExposure.NyxidSlug ?? string.Empty;
+        var registeredAt = externalExposure.RegisteredAt;
+        if (string.IsNullOrWhiteSpace(nyxidSlug) && registeredAt == null)
+            return null;
+
+        return new ServiceExternalExposureSnapshot(nyxidSlug, registeredAt);
     }
 }

--- a/src/platform/Aevatar.GAgentService.Projection/ReadModels/ServiceProjectionReadModels.Partial.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/ReadModels/ServiceProjectionReadModels.Partial.cs
@@ -25,6 +25,15 @@ public sealed partial class ServiceCatalogReadModel : IProjectionReadModel<Servi
     }
 }
 
+public sealed partial class ServiceCatalogExternalExposureReadModel
+{
+    public DateTimeOffset? RegisteredAt
+    {
+        get => ServiceProjectionReadModelSupport.ToNullableDateTimeOffset(RegisteredAtUtcValue);
+        set => RegisteredAtUtcValue = ServiceProjectionReadModelSupport.ToNullableTimestamp(value);
+    }
+}
+
 public sealed partial class ServiceDeploymentCatalogReadModel : IProjectionReadModel<ServiceDeploymentCatalogReadModel>
 {
     public DateTimeOffset UpdatedAt

--- a/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
+++ b/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
@@ -27,6 +27,7 @@ message ServiceCatalogReadModel {
   google.protobuf.Timestamp updated_at_utc_value = 15;
   repeated ServiceCatalogEndpointReadModel endpoint_entries = 16;
   repeated string policy_id_entries = 17;
+  ServiceCatalogExternalExposureReadModel external_exposure = 18;
 }
 
 message ServiceCatalogEndpointReadModel {
@@ -36,6 +37,11 @@ message ServiceCatalogEndpointReadModel {
   string request_type_url = 4;
   string response_type_url = 5;
   string description = 6;
+}
+
+message ServiceCatalogExternalExposureReadModel {
+  string nyxid_slug = 1;
+  google.protobuf.Timestamp registered_at_utc_value = 2;
 }
 
 // --- ServiceDeploymentCatalogReadModel ---

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunStartErrorGuidance.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunStartErrorGuidance.cs
@@ -1,0 +1,7 @@
+namespace Aevatar.Workflow.Application.Abstractions.Runs;
+
+public static class WorkflowChatRunStartErrorGuidance
+{
+    public const string WorkflowNotFound =
+        "Workflow is not in the current scope catalog. If it is published as a NyxID downstream service, call nyxid_proxy without a slug or path first to discover available services, then call the discovered slug/path. If it is a skill-provided workflow, call use_skill first, then retry with workflow_id.";
+}

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunStartErrorMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunStartErrorMapper.cs
@@ -30,7 +30,7 @@ internal static class ChatRunStartErrorMapper
         return error switch
         {
             WorkflowChatRunStartError.AgentNotFound => ("AGENT_NOT_FOUND", "Agent not found."),
-            WorkflowChatRunStartError.WorkflowNotFound => ("WORKFLOW_NOT_FOUND", "Workflow not found."),
+            WorkflowChatRunStartError.WorkflowNotFound => ("WORKFLOW_NOT_FOUND", WorkflowChatRunStartErrorGuidance.WorkflowNotFound),
             WorkflowChatRunStartError.AgentTypeNotSupported => ("AGENT_TYPE_NOT_SUPPORTED", "Actor is not workflow-capable."),
             WorkflowChatRunStartError.ProjectionDisabled => ("PROJECTION_DISABLED", "Projection pipeline is disabled."),
             WorkflowChatRunStartError.ProjectionUnavailable => ("WORKFLOW_PROJECTION_UNAVAILABLE", "Workflow projection is unavailable."),

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -1001,6 +1001,7 @@ public sealed class AevatarInvocationToolSourceTests
             """);
 
         ErrorCode(output).Should().Be("workflownotfound");
+        ErrorMessage(output).Should().Be(WorkflowChatRunStartErrorGuidance.WorkflowNotFound);
     }
 
     [Theory]
@@ -1499,6 +1500,15 @@ public sealed class AevatarInvocationToolSourceTests
 
     private static string ErrorCode(string json) =>
         ErrorCodeOrNull(json) ?? throw new InvalidOperationException($"Expected an error result: {json}");
+
+    private static string ErrorMessage(string json)
+    {
+        var root = Read(json);
+        return root.TryGetProperty("error", out var error) &&
+               error.TryGetProperty("message", out var message)
+            ? message.GetString() ?? string.Empty
+            : throw new InvalidOperationException($"Expected an error message: {json}");
+    }
 
     private static string? ErrorCodeOrNull(string json)
     {

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -312,7 +312,10 @@ public sealed class ScopeServiceEndpointsTests
                         "Run command"),
                 ],
                 [],
-                DateTimeOffset.UtcNow),
+                DateTimeOffset.UtcNow,
+                new ServiceExternalExposureSnapshot(
+                    "aevatar-orders",
+                    DateTimeOffset.Parse("2026-06-11T01:02:03+00:00"))),
             new ServiceCatalogSnapshot(
                 "scope-a:default:default:billing",
                 "scope-a",
@@ -418,6 +421,10 @@ public sealed class ScopeServiceEndpointsTests
         body.Should().NotBeNull();
         body!.Should().HaveCount(4);
         body.Single(x => x.ServiceId == "orders").Endpoints.Should().ContainSingle(x => x.EndpointId == "run");
+        body.Single(x => x.ServiceId == "orders").ExternalExposure.Should().NotBeNull();
+        body.Single(x => x.ServiceId == "orders").ExternalExposure!.NyxidSlug.Should().Be("aevatar-orders");
+        body.Single(x => x.ServiceId == "orders").ExternalExposure!.RegisteredAt.Should()
+            .Be(DateTimeOffset.Parse("2026-06-11T01:02:03+00:00"));
         body.Single(x => x.ServiceId == "orders").InvokeReady.Should().BeTrue();
         body.Single(x => x.ServiceId == "orders").InvokeReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Ready.ToString());
         body.Single(x => x.ServiceId == "orders").InvokeUnavailableReason.Should().BeNull();

--- a/test/Aevatar.GAgentService.Integration.Tests/ServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ServiceEndpointsTests.cs
@@ -44,7 +44,10 @@ public sealed class ServiceEndpointsTests
                     "type.googleapis.com/demo.Submit",
                     string.Empty,
                     "submit command"),
-            ]));
+            ],
+            ExternalExposure: new ServiceEndpoints.ExternalExposureHttpRequest(
+                " aevatar-orders ",
+                DateTimeOffset.Parse("2026-06-11T01:02:03+00:00"))));
 
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
         host.CommandPort.CreateServiceCommand.Should().NotBeNull();
@@ -57,6 +60,53 @@ public sealed class ServiceEndpointsTests
         });
         host.CommandPort.CreateServiceCommand.Spec.Endpoints.Should().ContainSingle();
         host.CommandPort.CreateServiceCommand.Spec.Endpoints[0].Kind.Should().Be(ServiceEndpointKind.Command);
+        host.CommandPort.CreateServiceCommand.Spec.ExternalExposure.Should().NotBeNull();
+        host.CommandPort.CreateServiceCommand.Spec.ExternalExposure.NyxidSlug.Should().Be("aevatar-orders");
+        host.CommandPort.CreateServiceCommand.Spec.ExternalExposure.RegisteredAt.ToDateTimeOffset()
+            .Should().Be(DateTimeOffset.Parse("2026-06-11T01:02:03+00:00"));
+    }
+
+    [Fact]
+    public async Task UpdateServiceAsync_ShouldDispatchTypedExternalExposure()
+    {
+        await using var host = await EndpointTestHost.StartAsync();
+
+        var response = await host.Client.PutAsJsonAsync("/api/services/orders/external-exposure", new ServiceEndpoints.UpdateServiceExternalExposureHttpRequest(
+            "tenant",
+            "app",
+            "ns",
+            "aevatar-orders",
+            DateTimeOffset.Parse("2026-06-11T01:02:03+00:00")));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        host.CommandPort.UpdateExternalExposureCommand.Should().NotBeNull();
+        host.CommandPort.UpdateExternalExposureCommand!.Identity.Should().BeEquivalentTo(new ServiceIdentity
+        {
+            TenantId = "tenant",
+            AppId = "app",
+            Namespace = "ns",
+            ServiceId = "orders",
+        });
+        host.CommandPort.UpdateExternalExposureCommand.ExternalExposure.Should().NotBeNull();
+        host.CommandPort.UpdateExternalExposureCommand.ExternalExposure.NyxidSlug.Should().Be("aevatar-orders");
+        host.CommandPort.UpdateExternalExposureCommand.ExternalExposure.RegisteredAt.ToDateTimeOffset()
+            .Should().Be(DateTimeOffset.Parse("2026-06-11T01:02:03+00:00"));
+    }
+
+    [Fact]
+    public async Task UpdateServiceAsync_WhenReadModelMissing_ShouldStillDispatchAuthoritativeCommand()
+    {
+        await using var host = await EndpointTestHost.StartAsync();
+
+        var response = await host.Client.PutAsJsonAsync("/api/services/orders/external-exposure", new ServiceEndpoints.UpdateServiceExternalExposureHttpRequest(
+            "tenant",
+            "app",
+            "ns",
+            "aevatar-orders",
+            DateTimeOffset.Parse("2026-06-11T01:02:03+00:00")));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        host.CommandPort.UpdateExternalExposureCommand.Should().NotBeNull();
     }
 
     [Fact]
@@ -492,7 +542,10 @@ public sealed class ServiceEndpointsTests
                     new ServiceEndpointSnapshot("submit", "Submit", "command", "req", string.Empty, "desc"),
                 ],
                 [],
-                DateTimeOffset.Parse("2026-03-14T00:00:00+00:00")),
+                DateTimeOffset.Parse("2026-03-14T00:00:00+00:00"),
+                new ServiceExternalExposureSnapshot(
+                    "aevatar-orders",
+                    DateTimeOffset.Parse("2026-06-11T01:02:03+00:00"))),
             new ServiceCatalogSnapshot(
                 "tenant/app/ns/billing",
                 "tenant",
@@ -584,6 +637,9 @@ public sealed class ServiceEndpointsTests
         getResponse.InvokeReady.Should().BeTrue();
         getResponse.InvokeReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Ready.ToString());
         getResponse.InvokeUnavailableReason.Should().BeNull();
+        getResponse.ExternalExposure.Should().NotBeNull();
+        getResponse.ExternalExposure!.NyxidSlug.Should().Be("aevatar-orders");
+        getResponse.ExternalExposure.RegisteredAt.Should().Be(DateTimeOffset.Parse("2026-06-11T01:02:03+00:00"));
         revisionResponse!.Revisions.Should().ContainSingle();
         host.QueryPort.LastListServicesTake.Should().Be(10);
         host.QueryPort.LastGetServiceIdentity!.ServiceId.Should().Be("orders");
@@ -1453,6 +1509,10 @@ public sealed class ServiceEndpointsTests
     {
         public CreateServiceDefinitionCommand? CreateServiceCommand { get; private set; }
 
+        public UpdateServiceDefinitionCommand? UpdateServiceCommand { get; private set; }
+
+        public UpdateServiceExternalExposureCommand? UpdateExternalExposureCommand { get; private set; }
+
         public CreateServiceRevisionCommand? CreateRevisionCommand { get; private set; }
 
         public PrepareServiceRevisionCommand? PrepareRevisionCommand { get; private set; }
@@ -1485,8 +1545,17 @@ public sealed class ServiceEndpointsTests
             return Task.FromResult(new ServiceCommandAcceptedReceipt("definition-actor", "cmd-create-service", "corr-create-service"));
         }
 
-        public Task<ServiceCommandAcceptedReceipt> UpdateServiceAsync(UpdateServiceDefinitionCommand command, CancellationToken ct = default) =>
-            Task.FromResult(new ServiceCommandAcceptedReceipt("definition-actor", "cmd-update-service", "corr-update-service"));
+        public Task<ServiceCommandAcceptedReceipt> UpdateServiceAsync(UpdateServiceDefinitionCommand command, CancellationToken ct = default)
+        {
+            UpdateServiceCommand = command;
+            return Task.FromResult(new ServiceCommandAcceptedReceipt("definition-actor", "cmd-update-service", "corr-update-service"));
+        }
+
+        public Task<ServiceCommandAcceptedReceipt> UpdateServiceExternalExposureAsync(UpdateServiceExternalExposureCommand command, CancellationToken ct = default)
+        {
+            UpdateExternalExposureCommand = command;
+            return Task.FromResult(new ServiceCommandAcceptedReceipt("definition-actor", "cmd-update-external-exposure", "corr-update-external-exposure"));
+        }
 
         public Task<ServiceCommandAcceptedReceipt> CreateRevisionAsync(CreateServiceRevisionCommand command, CancellationToken ct = default)
         {

--- a/test/Aevatar.GAgentService.Tests/Application/ServiceCommandApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ServiceCommandApplicationServiceTests.cs
@@ -62,6 +62,11 @@ public sealed class ServiceCommandApplicationServiceTests
         {
             Spec = GAgentServiceTestKit.CreateDefinitionSpec(identity),
         });
+        var externalExposureReceipt = await service.UpdateServiceExternalExposureAsync(new UpdateServiceExternalExposureCommand
+        {
+            Identity = identity.Clone(),
+            ExternalExposure = new ExternalExposure { NyxidSlug = "aevatar-orders" },
+        });
         var defaultReceipt = await service.SetDefaultServingRevisionAsync(new SetDefaultServingRevisionCommand
         {
             Identity = identity.Clone(),
@@ -70,15 +75,17 @@ public sealed class ServiceCommandApplicationServiceTests
 
         createReceipt.TargetActorId.Should().Be(ServiceActorIds.Definition(identity));
         updateReceipt.TargetActorId.Should().Be(ServiceActorIds.Definition(identity));
+        externalExposureReceipt.TargetActorId.Should().Be(ServiceActorIds.Definition(identity));
         defaultReceipt.TargetActorId.Should().Be(ServiceActorIds.Definition(identity));
         defaultReceipt.CorrelationId.Should().Be($"{ServiceKeys.Build(identity)}:rev-1");
-        provisioner.DefinitionRequests.Should().HaveCount(3);
-        provisioner.InvocationCatalogRequests.Should().HaveCount(3);
+        provisioner.DefinitionRequests.Should().HaveCount(4);
+        provisioner.InvocationCatalogRequests.Should().HaveCount(4);
         provisioner.InvocationCatalogRequests.Should().OnlyContain(x =>
             ServiceKeys.Build(x) == ServiceKeys.Build(identity));
         dispatchPort.Calls.Select(x => x.envelope.Payload.TypeUrl).Should().Contain([
             AnyTypeUrl<CreateServiceDefinitionCommand>(),
             AnyTypeUrl<UpdateServiceDefinitionCommand>(),
+            AnyTypeUrl<UpdateServiceExternalExposureCommand>(),
             AnyTypeUrl<SetDefaultServingRevisionCommand>(),
         ]);
     }

--- a/test/Aevatar.GAgentService.Tests/Core/ServiceDefinitionGAgentTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ServiceDefinitionGAgentTests.cs
@@ -43,6 +43,42 @@ public sealed class ServiceDefinitionGAgentTests
     }
 
     [Fact]
+    public async Task HandleCreateAsync_ShouldPersistTypedExternalExposure()
+    {
+        var eventStore = new InMemoryEventStore();
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var actorId = ServiceActorIds.Definition(identity);
+        var agent = GAgentServiceTestKit.CreateStatefulAgent<ServiceDefinitionGAgent, ServiceDefinitionState>(
+            eventStore,
+            actorId,
+            static () => new ServiceDefinitionGAgent(GAgentServiceTestKit.NoOpDispatchPort));
+        var spec = GAgentServiceTestKit.CreateDefinitionSpec(identity);
+        spec.ExternalExposure = new ExternalExposure
+        {
+            NyxidSlug = "aevatar-orders",
+            RegisteredAt = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset(
+                DateTimeOffset.Parse("2026-06-11T01:02:03+00:00")),
+        };
+
+        await agent.HandleCreateAsync(new CreateServiceDefinitionCommand
+        {
+            Spec = spec,
+        });
+        await agent.DeactivateAsync();
+
+        var replayed = GAgentServiceTestKit.CreateStatefulAgent<ServiceDefinitionGAgent, ServiceDefinitionState>(
+            eventStore,
+            actorId,
+            static () => new ServiceDefinitionGAgent(GAgentServiceTestKit.NoOpDispatchPort));
+        await replayed.ActivateAsync();
+
+        replayed.State.Spec.ExternalExposure.Should().NotBeNull();
+        replayed.State.Spec.ExternalExposure.NyxidSlug.Should().Be("aevatar-orders");
+        replayed.State.Spec.ExternalExposure.RegisteredAt.ToDateTimeOffset()
+            .Should().Be(DateTimeOffset.Parse("2026-06-11T01:02:03+00:00"));
+    }
+
+    [Fact]
     public async Task HandleCreateAsync_ShouldRejectDuplicateCreate_AndKeepOriginalState()
     {
         var identity = GAgentServiceTestKit.CreateIdentity();
@@ -112,6 +148,130 @@ public sealed class ServiceDefinitionGAgentTests
         updateObservation.ServiceEndpoints[0].RequestTypeUrl.Should().Be("type.googleapis.com/test.chat");
         var defaultObservation = dispatchPort.Calls[2].Envelope.Payload.Unpack<ObserveServiceInvocationCatalogCommand>();
         defaultObservation.SourceCatalogVersion.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task HandleUpdateExternalExposureAsync_ShouldMergeIntoExistingDefinition()
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var dispatchPort = new RecordingActorDispatchPort();
+        var agent = GAgentServiceTestKit.CreateStatefulAgent<ServiceDefinitionGAgent, ServiceDefinitionState>(
+            new InMemoryEventStore(),
+            ServiceActorIds.Definition(identity),
+            () => new ServiceDefinitionGAgent(dispatchPort));
+
+        await agent.HandleCreateAsync(new CreateServiceDefinitionCommand
+        {
+            Spec = GAgentServiceTestKit.CreateDefinitionSpec(identity),
+        });
+
+        await agent.HandleUpdateExternalExposureAsync(new UpdateServiceExternalExposureCommand
+        {
+            Identity = identity.Clone(),
+            ExternalExposure = new ExternalExposure
+            {
+                NyxidSlug = "aevatar-orders",
+                RegisteredAt = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset(
+                    DateTimeOffset.Parse("2026-06-11T01:02:03+00:00")),
+            },
+        });
+
+        agent.State.Spec.DisplayName.Should().Be("Service");
+        agent.State.Spec.Endpoints.Should().ContainSingle(x => x.EndpointId == "run");
+        agent.State.Spec.ExternalExposure.Should().NotBeNull();
+        agent.State.Spec.ExternalExposure.NyxidSlug.Should().Be("aevatar-orders");
+        agent.State.Spec.ExternalExposure.RegisteredAt.ToDateTimeOffset()
+            .Should().Be(DateTimeOffset.Parse("2026-06-11T01:02:03+00:00"));
+        agent.State.LastAppliedEventVersion.Should().Be(2);
+        agent.State.LastEventId.Should().EndWith(":external-exposure-updated");
+        dispatchPort.Calls.Should().HaveCount(2);
+        var observation = dispatchPort.Calls[1].Envelope.Payload.Unpack<ObserveServiceInvocationCatalogCommand>();
+        observation.SourceCatalogVersion.Should().Be(2);
+        observation.ServiceEndpoints.Should().ContainSingle(x => x.EndpointId == "run");
+    }
+
+    [Fact]
+    public async Task HandleUpdateAsync_ShouldPreserveExistingExternalExposure_WhenUpdateSpecOmitsIt()
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var agent = GAgentServiceTestKit.CreateStatefulAgent<ServiceDefinitionGAgent, ServiceDefinitionState>(
+            new InMemoryEventStore(),
+            ServiceActorIds.Definition(identity),
+            static () => new ServiceDefinitionGAgent(GAgentServiceTestKit.NoOpDispatchPort));
+        var originalSpec = GAgentServiceTestKit.CreateDefinitionSpec(identity);
+        originalSpec.ExternalExposure = new ExternalExposure
+        {
+            NyxidSlug = "aevatar-orders",
+            RegisteredAt = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset(
+                DateTimeOffset.Parse("2026-06-11T01:02:03+00:00")),
+        };
+        await agent.HandleCreateAsync(new CreateServiceDefinitionCommand
+        {
+            Spec = originalSpec,
+        });
+
+        var updatedSpec = GAgentServiceTestKit.CreateDefinitionSpec(identity);
+        updatedSpec.DisplayName = "Updated";
+        await agent.HandleUpdateAsync(new UpdateServiceDefinitionCommand
+        {
+            Spec = updatedSpec,
+        });
+
+        agent.State.Spec.DisplayName.Should().Be("Updated");
+        agent.State.Spec.ExternalExposure.Should().NotBeNull();
+        agent.State.Spec.ExternalExposure.NyxidSlug.Should().Be("aevatar-orders");
+        agent.State.Spec.ExternalExposure.RegisteredAt.ToDateTimeOffset()
+            .Should().Be(DateTimeOffset.Parse("2026-06-11T01:02:03+00:00"));
+    }
+
+    [Fact]
+    public async Task HandleUpdateExternalExposureAsync_ShouldClearExistingExternalExposure_WhenCommandCarriesEmptyExposure()
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var agent = GAgentServiceTestKit.CreateStatefulAgent<ServiceDefinitionGAgent, ServiceDefinitionState>(
+            new InMemoryEventStore(),
+            ServiceActorIds.Definition(identity),
+            static () => new ServiceDefinitionGAgent(GAgentServiceTestKit.NoOpDispatchPort));
+        var originalSpec = GAgentServiceTestKit.CreateDefinitionSpec(identity);
+        originalSpec.ExternalExposure = new ExternalExposure
+        {
+            NyxidSlug = "aevatar-orders",
+            RegisteredAt = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset(
+                DateTimeOffset.Parse("2026-06-11T01:02:03+00:00")),
+        };
+        await agent.HandleCreateAsync(new CreateServiceDefinitionCommand
+        {
+            Spec = originalSpec,
+        });
+
+        await agent.HandleUpdateExternalExposureAsync(new UpdateServiceExternalExposureCommand
+        {
+            Identity = identity.Clone(),
+            ExternalExposure = new ExternalExposure(),
+        });
+
+        agent.State.Spec.ExternalExposure.Should().NotBeNull();
+        agent.State.Spec.ExternalExposure.NyxidSlug.Should().BeEmpty();
+        agent.State.Spec.ExternalExposure.RegisteredAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandleUpdateExternalExposureAsync_ShouldRejectMissingDefinition()
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var agent = GAgentServiceTestKit.CreateStatefulAgent<ServiceDefinitionGAgent, ServiceDefinitionState>(
+            new InMemoryEventStore(),
+            ServiceActorIds.Definition(identity),
+            static () => new ServiceDefinitionGAgent(GAgentServiceTestKit.NoOpDispatchPort));
+
+        var act = () => agent.HandleUpdateExternalExposureAsync(new UpdateServiceExternalExposureCommand
+        {
+            Identity = identity.Clone(),
+            ExternalExposure = new ExternalExposure { NyxidSlug = "aevatar-orders" },
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*does not exist*");
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceCatalogProjectorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceCatalogProjectorTests.cs
@@ -24,6 +24,11 @@ public sealed class ServiceCatalogProjectorTests
             Spec = GAgentServiceTestKit.CreateDefinitionSpec(identity),
             DefaultServingRevisionId = "r-default",
         };
+        state.Spec.ExternalExposure = new ExternalExposure
+        {
+            NyxidSlug = "aevatar-orders",
+            RegisteredAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-06-11T01:02:03+00:00")),
+        };
         var context = new ServiceCatalogProjectionContext
         {
             RootActorId = "tenant:app:default:svc",
@@ -44,6 +49,9 @@ public sealed class ServiceCatalogProjectorTests
         readModel!.DisplayName.Should().Be("Service");
         readModel.DefaultServingRevisionId.Should().Be("r-default");
         readModel.Endpoints.Should().ContainSingle(x => x.EndpointId == "run");
+        readModel.ExternalExposure.Should().NotBeNull();
+        readModel.ExternalExposure.NyxidSlug.Should().Be("aevatar-orders");
+        readModel.ExternalExposure.RegisteredAt.Should().Be(DateTimeOffset.Parse("2026-06-11T01:02:03+00:00"));
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceCatalogQueryReaderTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceCatalogQueryReaderTests.cs
@@ -32,6 +32,11 @@ public sealed class ServiceCatalogQueryReaderTests
                     RequestTypeUrl = "type.googleapis.com/test.command",
                 },
             },
+            ExternalExposure = new ServiceCatalogExternalExposureReadModel
+            {
+                NyxidSlug = "aevatar-orders",
+                RegisteredAt = DateTimeOffset.Parse("2026-06-11T01:02:03+00:00"),
+            },
             UpdatedAt = DateTimeOffset.UtcNow,
         });
         var reader = new ServiceCatalogQueryReader(store);
@@ -41,6 +46,9 @@ public sealed class ServiceCatalogQueryReaderTests
         snapshot.Should().NotBeNull();
         snapshot!.ServiceKey.Should().Be("tenant:app:default:svc");
         snapshot.Endpoints.Should().ContainSingle(x => x.EndpointId == "run");
+        snapshot.ExternalExposure.Should().NotBeNull();
+        snapshot.ExternalExposure.NyxidSlug.Should().Be("aevatar-orders");
+        snapshot.ExternalExposure.RegisteredAt.Should().Be(DateTimeOffset.Parse("2026-06-11T01:02:03+00:00"));
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceCommittedStateProjectionActivationPlanProviderTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceCommittedStateProjectionActivationPlanProviderTests.cs
@@ -15,20 +15,29 @@ namespace Aevatar.GAgentService.Tests.Projection;
 
 public sealed class ServiceCommittedStateProjectionActivationPlanProviderTests
 {
-    [Fact]
-    public void GetPlans_ShouldMapServiceDefinitionEventsToCatalogScope()
+    [Theory]
+    [MemberData(nameof(ServiceDefinitionCatalogEvents))]
+    public void GetPlans_ShouldMapServiceDefinitionEventsToCatalogScope(IMessage serviceDefinitionEvent)
     {
         var provider = new ServiceCommittedStateProjectionActivationPlanProvider();
 
         var plans = provider.GetPlans(BuildContext(
             typeof(ServiceDefinitionGAgent),
-            new ServiceDefinitionCreatedEvent { Spec = new ServiceDefinitionSpec { Identity = Identity() } })).ToArray();
+            serviceDefinitionEvent)).ToArray();
 
         plans.Should().ContainSingle();
         plans[0].LeaseType.Should().Be(typeof(ServiceProjectionRuntimeLease<ServiceCatalogProjectionContext>));
         plans[0].StartRequest.RootActorId.Should().Be("service-actor");
         plans[0].StartRequest.ProjectionKind.Should().Be("service-catalog");
         plans[0].StartRequest.Mode.Should().Be(ProjectionRuntimeMode.DurableMaterialization);
+    }
+
+    public static IEnumerable<object[]> ServiceDefinitionCatalogEvents()
+    {
+        yield return [new ServiceDefinitionCreatedEvent { Spec = new ServiceDefinitionSpec { Identity = Identity() } }];
+        yield return [new ServiceDefinitionUpdatedEvent { Spec = new ServiceDefinitionSpec { Identity = Identity() } }];
+        yield return [new ServiceExternalExposureUpdatedEvent { Identity = Identity(), ExternalExposure = new ExternalExposure { NyxidSlug = "aevatar-orders" } }];
+        yield return [new DefaultServingRevisionChangedEvent { Identity = Identity(), RevisionId = "r1" }];
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatRunStartErrorMapperTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatRunStartErrorMapperTests.cs
@@ -32,7 +32,12 @@ public class ChatRunStartErrorMapperTests
         var mapped = ChatRunStartErrorMapper.ToCommandError(WorkflowChatRunStartError.WorkflowNotFound);
 
         mapped.Code.Should().Be("WORKFLOW_NOT_FOUND");
-        mapped.Message.Should().Be("Workflow not found.");
+        mapped.Message.Should().Be(WorkflowChatRunStartErrorGuidance.WorkflowNotFound);
+        mapped.Message.Should().Contain("current scope catalog");
+        mapped.Message.Should().Contain("nyxid_proxy");
+        mapped.Message.Should().Contain("slug/path");
+        mapped.Message.Should().Contain("use_skill");
+        mapped.Message.Should().Contain("workflow_id");
     }
 
     [Fact]


### PR DESCRIPTION
## Changed files
- Added a reproducible NyxID workflow scope-service runbook.
- Added shared actionable WorkflowNotFound guidance for HTTP/WebSocket chat and aevatar_start_workflow.
- Added typed ServiceDefinition externalExposure, narrow update command/API, owner-actor state handling, service catalog projection/query/API exposure, and docs.

## Test results
- dotnet build src/platform/Aevatar.GAgentService.Hosting/Aevatar.GAgentService.Hosting.csproj --nologo
- dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo --filter "ServiceDefinitionGAgentTests|ServiceCommandApplicationServiceTests|ServiceCatalogProjectorTests|ServiceCatalogQueryReaderTests|ServiceCommittedStateProjectionActivationPlanProviderTests"
- dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --filter "UpdateServiceAsync_ShouldDispatchTypedExternalExposure|UpdateServiceAsync_WhenReadModelMissing_ShouldStillDispatchAuthoritativeCommand|CreateServiceAsync_ShouldDispatchTypedCommand|QueryEndpoints_ShouldJoinInvokeReadiness"
- dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo --filter ChatRunStartErrorMapperTests
- dotnet test test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/Aevatar.AI.ToolProviders.AevatarInvocation.Tests.csproj --nologo --filter StartWorkflow_WhenDispatchRejects_ShouldReturnStructuredError
- bash tools/ci/test_stability_guards.sh
- bash tools/ci/query_projection_priming_guard.sh
- bash tools/ci/projection_state_version_guard.sh
- bash tools/ci/projection_state_mirror_current_state_guard.sh
- bash tools/ci/architecture_guards.sh

## Deviations
- `query_projection_priming_guard.sh` and `architecture_guards.sh` print existing missing-file `rg` warnings, but both guards exited 0.

Closes #1981
Closes #1982
Closes #1983

⟦AI:AUTO-LOOP⟧