### PR TITLE
Expose Studio member roster implementation refs

### DIFF
--- a/src/Aevatar.Studio.Application/Studio/Contracts/MemberContracts.cs
+++ b/src/Aevatar.Studio.Application/Studio/Contracts/MemberContracts.cs
@@ -106,6 +106,13 @@ public sealed record StudioMemberSummaryResponse(
     /// the create/patch flows pass it through unchanged.
     /// </summary>
     public string? TeamId { get; init; }
+
+    /// <summary>
+    /// Typed implementation identity shared by scope and team roster
+    /// summaries. Null means the member read model has not yet observed an
+    /// implementation reference.
+    /// </summary>
+    public StudioMemberImplementationRefResponse? ImplementationRef { get; init; }
 }
 
 public sealed record StudioMemberDetailResponse(

--- a/src/Aevatar.Studio.Projection/QueryPorts/ProjectionStudioMemberQueryPort.cs
+++ b/src/Aevatar.Studio.Projection/QueryPorts/ProjectionStudioMemberQueryPort.cs
@@ -125,15 +125,17 @@ public sealed class ProjectionStudioMemberQueryPort : IStudioMemberQueryPort
             // proto3 optional `team_id` semantics — absence on the wire means
             // "unassigned" on the application contract.
             TeamId = document.HasTeamId ? document.TeamId : null,
+            ImplementationRef = ToImplementationRefResponse(
+                document,
+                NormalizeImplementationKindWire(document.ImplementationKind)),
         };
     }
 
     private static StudioMemberDetailResponse ToDetail(StudioMemberCurrentStateDocument document)
     {
         var summary = ToSummary(document);
-        var implementationRef = ToImplementationRefResponse(document, summary.ImplementationKind);
         var lastBinding = ToLastBindingResponse(document);
-        return new StudioMemberDetailResponse(summary, implementationRef, lastBinding)
+        return new StudioMemberDetailResponse(summary, summary.ImplementationRef, lastBinding)
         {
             CurrentBindingRun = ToBindingRunStatusResponse(document),
         };

--- a/test/Aevatar.Studio.Tests/StudioMemberQueryPortTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberQueryPortTests.cs
@@ -51,6 +51,7 @@ public sealed class ProjectionStudioMemberQueryPortTests
         detail.ImplementationRef.Should().NotBeNull();
         detail.ImplementationRef!.WorkflowId.Should().Be("wf-1");
         detail.ImplementationRef.WorkflowRevision.Should().Be("v2");
+        detail.Summary.ImplementationRef.Should().BeEquivalentTo(detail.ImplementationRef);
         detail.LastBinding.Should().NotBeNull();
         detail.LastBinding!.RevisionId.Should().Be("rev-bind");
         detail.CurrentBindingRun.Should().NotBeNull();
@@ -90,7 +91,7 @@ public sealed class ProjectionStudioMemberQueryPortTests
     [Fact]
     public async Task ListAsync_ShouldReturnOnlyMembersInScope()
     {
-        var inScopeA = NewDocument(scopeId: ScopeId, memberId: "m-1");
+        var inScopeA = NewDocument(scopeId: ScopeId, memberId: "m-1", includeImplementationRef: true);
         var inScopeB = NewDocument(scopeId: ScopeId, memberId: "m-2");
         var inOtherScope = NewDocument(scopeId: "scope-other", memberId: "m-3");
 
@@ -101,6 +102,13 @@ public sealed class ProjectionStudioMemberQueryPortTests
 
         roster.ScopeId.Should().Be(ScopeId);
         roster.Members.Select(m => m.MemberId).Should().BeEquivalentTo("m-1", "m-2");
+        var workflowMember = roster.Members.Single(m => m.MemberId == "m-1");
+        workflowMember.ImplementationRef.Should().NotBeNull();
+        workflowMember.ImplementationRef!.ImplementationKind.Should().Be(MemberImplementationKindNames.Workflow);
+        workflowMember.ImplementationRef.WorkflowId.Should().Be("wf-1");
+        workflowMember.ImplementationRef.WorkflowRevision.Should().Be("v2");
+        reader.QueryCallCount.Should().Be(1);
+        reader.GetCallCount.Should().Be(0);
     }
 
     [Fact]
@@ -129,7 +137,11 @@ public sealed class ProjectionStudioMemberQueryPortTests
     public async Task ListAsync_ShouldApplyTeamFilterBeforePagination()
     {
         var inOtherTeamA = NewDocument(scopeId: ScopeId, memberId: "m-other-1", teamId: "other-team");
-        var inTeamA = NewDocument(scopeId: ScopeId, memberId: "m-team-1", teamId: "team-1");
+        var inTeamA = NewDocument(
+            scopeId: ScopeId,
+            memberId: "m-team-1",
+            includeImplementationRef: true,
+            teamId: "team-1");
         var inOtherScope = NewDocument(scopeId: "scope-other", memberId: "m-foreign", teamId: "team-1");
         var inOtherTeamB = NewDocument(scopeId: ScopeId, memberId: "m-other-2", teamId: "other-team");
         var inTeamB = NewDocument(scopeId: ScopeId, memberId: "m-team-2", teamId: "team-1");
@@ -157,7 +169,13 @@ public sealed class ProjectionStudioMemberQueryPortTests
             string.Equals(team, "team-1", StringComparison.Ordinal))
             .Should().BeTrue();
         roster.Members.Select(m => m.MemberId).Should().ContainInOrder("m-team-1", "m-team-2");
+        var workflowMember = roster.Members.Single(m => m.MemberId == "m-team-1");
+        workflowMember.ImplementationRef.Should().NotBeNull();
+        workflowMember.ImplementationRef!.WorkflowId.Should().Be("wf-1");
+        workflowMember.ImplementationRef.WorkflowRevision.Should().Be("v2");
         roster.NextPageToken.Should().Be("team-cursor-2");
+        reader.QueryCallCount.Should().Be(1);
+        reader.GetCallCount.Should().Be(0);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Expose typed `implementationRef` on shared Studio member roster summaries.
- Populate roster implementation refs from `StudioMemberCurrentStateDocument` in the projection query port, so scope and team member lists share the same shape.
- Add query-port tests covering scope/team rosters and asserting no per-row document lookups are introduced.

Fixes #2011

## Test plan
- [x] `dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --filter "ProjectionStudioMemberQueryPortTests"`
- [x] `bash tools/ci/test_stability_guards.sh`
- [x] `bash tools/ci/query_projection_priming_guard.sh`

Notes: focused test output included existing analyzer/package-source warnings unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)