### PR TITLE
Fix console SPA static export

### DIFF
--- a/apps/aevatar-console-web/.env.production.example
+++ b/apps/aevatar-console-web/.env.production.example
@@ -13,5 +13,14 @@ NYXID_SCOPE="openid profile email roles groups"
 # Ornn skills platform for the browser client
 ORNN_BASE_URL=https://ornn.example.com
 
-# Planned but not wired in the current frontend build:
+# Public URL mount path for the built console assets and HTML5 history routes.
+# Keep "/" when the browser-visible console URL is rooted at the domain.
+AEVATAR_CONSOLE_PUBLIC_PATH=/
+#
+# If the console is intentionally served from a browser-visible subpath, use
+# that same subpath here:
 # AEVATAR_CONSOLE_PUBLIC_PATH=/console/
+#
+# Do not use an internal object-store prefix here unless that prefix is also
+# part of the public browser URL. For internal prefixes such as
+# aevatar-console/, configure the CDN origin path or rewrite target instead.

--- a/apps/aevatar-console-web/README.md
+++ b/apps/aevatar-console-web/README.md
@@ -59,6 +59,27 @@ AEVATAR_CONSOLE_PUBLIC_PATH=/
 `ORNN_BASE_URL` controls the Ornn skills endpoint used by Studio Settings. If you omit it, the frontend falls back to the public Ornn instance.
 If you change `.env.local`, restart `pnpm dev` so Umi reloads the injected env values.
 
+## Static Hosting
+
+The console uses HTML5 history routes with runtime-owned IDs, for example
+`/scopes/:scopeId/teams/:teamId/members/:memberId/workflow`. Do not enable Umi
+static route export for this app, because build-time route templates such as
+`/scopes/:scopeId/teams/index.html` cannot match real scope and team IDs.
+
+Production static hosting must serve the built `index.html` as the SPA fallback
+for every frontend deep link, while keeping `/api/*` routed to the backend. When
+the public URL is rooted at `https://aevatar-console.aevatar.ai/`, keep:
+
+```bash
+AEVATAR_CONSOLE_PUBLIC_PATH=/
+```
+
+If the object store keeps files under an internal prefix such as
+`aevatar-console/`, configure the CDN origin path or rewrite target to that
+prefix. Do not expose the internal object-store prefix through
+`AEVATAR_CONSOLE_PUBLIC_PATH` unless the browser-visible URL also includes that
+same prefix.
+
 ## Available scripts
 
 ```bash

--- a/apps/aevatar-console-web/config/config.ts
+++ b/apps/aevatar-console-web/config/config.ts
@@ -152,7 +152,6 @@ const config: ReturnType<typeof defineConfig> = defineConfig({
   headScripts: [],
   //================ pro 插件配置 =================
   presets: ['umi-presets-pro'],
-  exportStatic: {},
   esbuildMinifyIIFE: true,
   define: {
     'process.env.CI': JSON.stringify(process.env.CI),

--- a/apps/aevatar-console-web/src/consoleBuildConfig.test.ts
+++ b/apps/aevatar-console-web/src/consoleBuildConfig.test.ts
@@ -1,0 +1,30 @@
+describe("console build config", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...originalEnv,
+      AEVATAR_CONSOLE_PUBLIC_PATH: "/",
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("keeps dynamic Team routes on the SPA fallback instead of static route exports", () => {
+    let config!: Record<string, unknown>;
+
+    jest.isolateModules(() => {
+      jest.doMock("@umijs/max", () => ({
+        defineConfig: (value: Record<string, unknown>) => value,
+      }));
+      config = require("../config/config").default as Record<string, unknown>;
+    });
+
+    expect(config.base).toBe("/");
+    expect(config.publicPath).toBe("/");
+    expect(config).not.toHaveProperty("exportStatic");
+  });
+});


### PR DESCRIPTION
## Problem

The console currently enables Umi `exportStatic`, which emits build-time route-template HTML such as `scopes/:scopeId/teams/index.html`. Those files cannot match real runtime IDs like `/scopes/{scopeId}/teams`, and they make static object hosting look for per-route HTML documents instead of serving the SPA entry.

## Solution

- Remove `exportStatic` from the console build config so production builds emit the SPA entry only.
- Add a config test that keeps dynamic Team routes on the SPA fallback contract.
- Document static hosting requirements: frontend deep links must rewrite to `index.html`, while `/api/*` stays routed to the backend.

## Validation

- `./node_modules/.bin/jest --runTestsByPath src/consoleBuildConfig.test.ts src/routesConfig.test.ts --runInBand`
- `./node_modules/.bin/tsc --noEmit`
- `bash tools/ci/test_stability_guards.sh`
- `AEVATAR_CONSOLE_PUBLIC_PATH=/ ./node_modules/.bin/max build`

After removing `exportStatic`, the production build emits only `dist/index.html` as an HTML entry instead of dynamic route-template HTML files.

## Deployment Note

The CDN/object-store layer still needs SPA fallback: all non-API frontend deep links should rewrite to the deployed `index.html`. If files live under an internal object-store prefix such as `aevatar-console/`, configure the origin path or rewrite target accordingly; do not expose that internal prefix through `AEVATAR_CONSOLE_PUBLIC_PATH` unless it is also part of the browser-visible URL.