### PR TITLE
实现工作流工具审批 typed continuation

### DIFF
--- a/docs/canon/workflow-primitives.md
+++ b/docs/canon/workflow-primitives.md
@@ -709,11 +709,13 @@ steps:
 事件对照：
 
 - `human_input` / `human_approval`：`WorkflowSuspendedEvent` -> `WorkflowResumedEvent`
+- `tool_call` 工具审批：`WorkflowSuspendedEvent(suspension_type="tool_approval", tool_approval=...)` -> `WorkflowResumedEvent(execution_id, approval_request_id, approved)`
 - `wait_signal`：`WaitingForSignalEvent(run_id, step_id, signal_name, ...)` -> `SignalReceivedEvent`
 
 约束补充：
 
 - `WorkflowResumedEvent` 与 `SignalReceivedEvent` 都必须显式携带 `run_id`；运行时不再对缺失 `run_id` 做 best-effort 猜测。
+- `tool_call` 工具审批恢复必须同时携带 `run_id + step_id + execution_id + approval_request_id`，运行时只按这些 typed 字段命中挂起审批，不从 `metadata` 或工具结果 JSON 中恢复审批状态。
 - `SignalReceivedEvent.step_id` 在“同一 run + 同一 signal_name”存在多个 waiter 时必填，用于精确命中 waiter。
 
 建议的请求契约（以 Web API 为例）：
@@ -724,6 +726,8 @@ POST /api/workflows/resume
   "actorId": "wf-2f3f...",
   "runId": "c7e0...",
   "stepId": "approval_gate",
+  "executionId": "exec-optional-for-tool-approval",
+  "approvalRequestId": "approval-optional-for-tool-approval",
   "approved": true,
   "userInput": "approved by oncall",
   "metadata": { "operator": "alice" }

--- a/src/Aevatar.AI.Abstractions/Middleware/IToolCallMiddleware.cs
+++ b/src/Aevatar.AI.Abstractions/Middleware/IToolCallMiddleware.cs
@@ -31,6 +31,10 @@ public sealed record ToolApprovalPendingContext(
     bool IsReadOnly,
     bool IsDestructive);
 
+public sealed record ToolApprovalGrantContext(
+    string ApprovalRequestId,
+    bool Approved);
+
 /// <summary>Context for tool call middleware.</summary>
 public sealed class ToolCallContext
 {
@@ -57,6 +61,9 @@ public sealed class ToolCallContext
 
     /// <summary>Typed business keys for a tool approval yield.</summary>
     public ToolApprovalPendingContext? PendingApproval { get; set; }
+
+    /// <summary>Typed approval decision previously matched by the owning workflow actor.</summary>
+    public ToolApprovalGrantContext? ApprovalGrant { get; init; }
 
     /// <summary>When true, tool execution is skipped and Result is returned as-is.</summary>
     public bool Terminate { get; set; }

--- a/src/Aevatar.AI.Core/Middleware/ToolApprovalMiddleware.cs
+++ b/src/Aevatar.AI.Core/Middleware/ToolApprovalMiddleware.cs
@@ -82,6 +82,30 @@ public sealed class ToolApprovalMiddleware : IToolCallMiddleware
             return;
         }
 
+        if (context.ApprovalGrant is { } grant)
+        {
+            if (grant.Approved)
+            {
+                context.Items[DenialCountItemKey] = 0;
+                await next();
+                return;
+            }
+
+            context.Items[DenialCountItemKey] = denialCount + 1;
+            context.Terminate = true;
+            context.TerminationKind = ToolCallTerminationKind.ApprovalDenied;
+            context.TerminationReason = "Tool approval rejected.";
+            context.Result = $"Tool '{context.ToolName}' execution denied by approval decision.";
+            context.Receipt = AgentToolReceiptFactory.CreateDenied(
+                context.Tool,
+                context.ToolCallId,
+                context.ToolName,
+                context.Result,
+                grant.ApprovalRequestId,
+                context.TerminationReason);
+            return;
+        }
+
         // 请求审批
         var request = new ToolApprovalRequest
         {

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -503,6 +503,8 @@ message WorkflowResumedEvent
   map<string, string> metadata = 5;
   string edited_content = 6;
   string feedback = 7;
+  string execution_id = 8;
+  string approval_request_id = 9;
 }
 message WorkflowHumanApprovalResolvedEvent
 {

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowRunControlModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowRunControlModels.cs
@@ -85,7 +85,9 @@ public sealed record WorkflowResumeCommand(
     IReadOnlyDictionary<string, string>? Metadata = null,
     string? EditedContent = null,
     string? Feedback = null,
-    string? CorrelationId = null) : WorkflowRunControlCommandBase(ActorId, RunId, CommandId, CorrelationId);
+    string? CorrelationId = null,
+    string? ExecutionId = null,
+    string? ApprovalRequestId = null) : WorkflowRunControlCommandBase(ActorId, RunId, CommandId, CorrelationId);
 
 public sealed record WorkflowSignalCommand(
     string ActorId,

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowResumeCommandEnvelopeFactory.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowResumeCommandEnvelopeFactory.cs
@@ -22,6 +22,8 @@ internal sealed class WorkflowResumeCommandEnvelopeFactory : ICommandEnvelopeFac
             UserInput = command.UserInput ?? string.Empty,
             EditedContent = command.EditedContent ?? string.Empty,
             Feedback = command.Feedback ?? string.Empty,
+            ExecutionId = NormalizeOptional(command.ExecutionId),
+            ApprovalRequestId = NormalizeOptional(command.ApprovalRequestId),
         };
         AppendMetadata(resumed.Metadata, command.Metadata);
 
@@ -67,4 +69,7 @@ internal sealed class WorkflowResumeCommandEnvelopeFactory : ICommandEnvelopeFac
             ? throw new ArgumentException("Value is required.", paramName)
             : normalized;
     }
+
+    private static string NormalizeOptional(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
 }

--- a/src/workflow/Aevatar.Workflow.Core/Modules/IWorkflowToolSource.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/IWorkflowToolSource.cs
@@ -9,13 +9,34 @@ public interface IWorkflowTool
     Task<WorkflowToolExecutionResult> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default);
 }
 
+public enum WorkflowToolExecutionOutcome
+{
+    Success = 0,
+    ApprovalPending = 1,
+}
+
 public sealed record WorkflowToolExecutionResult(
     string ResultJson,
-    WorkflowManagedHandoffOutcome? ManagedHandoff = null)
+    WorkflowManagedHandoffOutcome? ManagedHandoff = null,
+    WorkflowToolApprovalPendingOutcome? ApprovalPending = null,
+    WorkflowToolExecutionOutcome Outcome = WorkflowToolExecutionOutcome.Success)
 {
     public static WorkflowToolExecutionResult Success(string resultJson) =>
         new(resultJson ?? string.Empty);
+
+    public static WorkflowToolExecutionResult PendingApproval(WorkflowToolApprovalPendingOutcome approvalPending) =>
+        new(string.Empty, ApprovalPending: approvalPending, Outcome: WorkflowToolExecutionOutcome.ApprovalPending);
 }
+
+public sealed record WorkflowToolApprovalPendingOutcome(
+    string ApprovalRequestId,
+    string ToolName,
+    string ToolCallId,
+    string ArgumentsJson);
+
+public sealed record WorkflowToolApprovalGrant(
+    string ApprovalRequestId,
+    bool Approved);
 
 public sealed record WorkflowToolExecutionRequest(
     string ArgumentsJson,
@@ -25,7 +46,8 @@ public sealed record WorkflowToolExecutionRequest(
     string CallId,
     string ScopeId,
     WorkflowCallerCredential CallerCredential,
-    WorkflowToolRuntimeContext RuntimeContext)
+    WorkflowToolRuntimeContext RuntimeContext,
+    WorkflowToolApprovalGrant? ApprovalGrant = null)
 {
     public WorkflowToolExecutionRequest(
         string ArgumentsJson,
@@ -43,7 +65,30 @@ public sealed record WorkflowToolExecutionRequest(
             CallId,
             ScopeId,
             CallerCredential,
-            WorkflowToolRuntimeContext.Empty)
+            WorkflowToolRuntimeContext.Empty,
+            null)
+    {
+    }
+
+    public WorkflowToolExecutionRequest(
+        string ArgumentsJson,
+        string RunId,
+        string StepId,
+        string ExecutionId,
+        string CallId,
+        string ScopeId,
+        WorkflowCallerCredential CallerCredential,
+        WorkflowToolApprovalGrant? ApprovalGrant)
+        : this(
+            ArgumentsJson,
+            RunId,
+            StepId,
+            ExecutionId,
+            CallId,
+            ScopeId,
+            CallerCredential,
+            WorkflowToolRuntimeContext.Empty,
+            ApprovalGrant)
     {
     }
 }

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
@@ -7,6 +7,7 @@ using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Abstractions.EventModules;
 using Aevatar.Workflow.Core.Execution;
+using Aevatar.Workflow.Core.Primitives;
 using Microsoft.Extensions.Logging;
 
 namespace Aevatar.Workflow.Core.Modules;
@@ -14,6 +15,8 @@ namespace Aevatar.Workflow.Core.Modules;
 /// <summary>工具调用模块。处理 type=tool_call 的步骤。</summary>
 public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
 {
+    private const string ModuleStateKey = "tool_call";
+
     private readonly IEnumerable<IWorkflowToolSource> _toolSources;
     private readonly ILogger<ToolCallModule> _logger;
     private volatile Lazy<Task<IReadOnlyDictionary<string, IWorkflowTool>>>? _toolIndex;
@@ -31,13 +34,20 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
 
     /// <inheritdoc />
     public bool CanHandle(EventEnvelope envelope) =>
-        envelope.Payload?.Is(StepRequestEvent.Descriptor) == true;
+        envelope.Payload?.Is(StepRequestEvent.Descriptor) == true ||
+        envelope.Payload?.Is(WorkflowResumedEvent.Descriptor) == true;
 
     /// <inheritdoc />
     public async Task HandleAsync(EventEnvelope envelope, IWorkflowExecutionContext ctx, CancellationToken ct)
     {
         var payload = envelope.Payload;
         if (payload == null) return;
+
+        if (payload.Is(WorkflowResumedEvent.Descriptor))
+        {
+            await HandleResumedAsync(payload.Unpack<WorkflowResumedEvent>(), ctx, ct);
+            return;
+        }
 
         var request = payload.Unpack<StepRequestEvent>();
         if (request.StepType != "tool_call") return;
@@ -80,31 +90,13 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
         try
         {
             var result = await ExecuteToolAsync(tool, argumentsJson, request, callId, ctx, ct);
-
-            var completed = new WorkflowToolCallCompletedEvent
+            if (result.Outcome == WorkflowToolExecutionOutcome.ApprovalPending)
             {
-                CallId = callId,
-                Success = true,
-                ResultJson = result.ResultJson,
-                RunId = request.RunId,
-                StepId = request.StepId,
-            };
-            if (result.ManagedHandoff != null)
-                completed.ManagedHandoff = result.ManagedHandoff.Clone();
-
-            await ctx.PublishAsync(completed, TopologyAudience.Self, ct);
-
-            if (result.ManagedHandoff != null)
+                await SuspendForApprovalAsync(ctx, request, toolName, callId, argumentsJson, result, ct);
                 return;
+            }
 
-            await ctx.PublishAsync(new StepCompletedEvent
-            {
-                StepId = request.StepId,
-                RunId = request.RunId,
-                ExecutionId = request.ExecutionId,
-                Success = true,
-                Output = result.ResultJson,
-            }, TopologyAudience.Self, ct);
+            await PublishToolSuccessAsync(ctx, request, callId, result, ct);
         }
         catch (Exception ex)
         {
@@ -141,6 +133,256 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
                 RuntimeContext: runtimeContext),
             ct);
     }
+
+    private static Task<WorkflowToolExecutionResult> ExecuteToolWithGrantAsync(
+        IWorkflowTool tool,
+        PendingToolCallApprovalState pending,
+        bool approved,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var callerCredential = WorkflowRunExecutionContextStateAccess.TryGetCallerCredential(ctx, out var credential)
+            ? credential
+            : new WorkflowCallerCredential();
+        var runtimeContext = WorkflowRunExecutionContextStateAccess.GetWorkflowRuntimeContext(
+            ctx,
+            ctx.AgentId ?? string.Empty,
+            pending.RunId ?? string.Empty,
+            pending.StepId ?? string.Empty);
+        return tool.ExecuteAsync(
+            new WorkflowToolExecutionRequest(
+                ArgumentsJson: pending.ArgumentsJson ?? string.Empty,
+                RunId: pending.RunId ?? string.Empty,
+                StepId: pending.StepId ?? string.Empty,
+                ExecutionId: pending.ExecutionId ?? string.Empty,
+                CallId: pending.ToolCallId ?? string.Empty,
+                ScopeId: ctx.ScopeId ?? string.Empty,
+                CallerCredential: callerCredential,
+                RuntimeContext: runtimeContext,
+                ApprovalGrant: new WorkflowToolApprovalGrant(
+                    pending.ApprovalRequestId ?? string.Empty,
+                    approved)),
+            ct);
+    }
+
+    private async Task HandleResumedAsync(
+        WorkflowResumedEvent resumed,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var state = WorkflowExecutionStateAccess.Load<ToolCallModuleState>(ctx, ModuleStateKey);
+        if (!TryResolvePendingApproval(state, resumed, out var pendingKey, out var pending))
+            return;
+
+        state.PendingApprovals.Remove(pendingKey);
+        await SaveStateAsync(state, ctx, ct);
+
+        if (!resumed.Approved)
+        {
+            await PublishRejectedApprovalAsync(ctx, pending, ct);
+            return;
+        }
+
+        var toolIndex = await GetOrDiscoverAsync(ct);
+        if (!toolIndex.TryGetValue(pending.ToolName, out var tool))
+        {
+            const string notFound = "tool not found or no tool sources configured";
+            await PublishToolFailureAsync(ctx, pending, notFound, ct);
+            return;
+        }
+
+        try
+        {
+            var result = await ExecuteToolWithGrantAsync(tool, pending, approved: true, ctx, ct);
+            if (result.Outcome == WorkflowToolExecutionOutcome.ApprovalPending)
+            {
+                await PublishToolFailureAsync(ctx, pending, "approved tool call returned approval pending again", ct);
+                return;
+            }
+
+            await PublishToolSuccessAsync(ctx, pending, result, ct);
+        }
+        catch (Exception ex)
+        {
+            await PublishToolFailureAsync(ctx, pending, ex.Message, ct);
+            ctx.Logger.LogWarning(
+                ex,
+                "ToolCall: run={RunId} step={StepId} tool={Tool} approved execution failed",
+                pending.RunId,
+                pending.StepId,
+                pending.ToolName);
+        }
+    }
+
+    private static async Task SuspendForApprovalAsync(
+        IWorkflowExecutionContext ctx,
+        StepRequestEvent request,
+        string toolName,
+        string callId,
+        string argumentsJson,
+        WorkflowToolExecutionResult result,
+        CancellationToken ct)
+    {
+        var approval = result.ApprovalPending
+                       ?? throw new InvalidOperationException("Tool approval pending outcome is missing approval details.");
+        var pending = new PendingToolCallApprovalState
+        {
+            RunId = WorkflowRunIdNormalizer.Normalize(request.RunId),
+            StepId = request.StepId ?? string.Empty,
+            ExecutionId = request.ExecutionId ?? string.Empty,
+            ToolName = string.IsNullOrWhiteSpace(approval.ToolName) ? toolName : approval.ToolName,
+            ToolCallId = string.IsNullOrWhiteSpace(approval.ToolCallId) ? callId : approval.ToolCallId,
+            ApprovalRequestId = approval.ApprovalRequestId ?? string.Empty,
+            ArgumentsJson = string.IsNullOrWhiteSpace(approval.ArgumentsJson) ? argumentsJson : approval.ArgumentsJson,
+            Input = request.Input ?? string.Empty,
+        };
+        var state = WorkflowExecutionStateAccess.Load<ToolCallModuleState>(ctx, ModuleStateKey);
+        state.PendingApprovals[BuildPendingApprovalKey(pending)] = pending;
+        await SaveStateAsync(state, ctx, ct);
+
+        await ctx.PublishAsync(new WorkflowSuspendedEvent
+        {
+            RunId = pending.RunId,
+            StepId = pending.StepId,
+            SuspensionType = "tool_approval",
+            ToolApproval = new WorkflowToolApprovalSuspension
+            {
+                ExecutionId = pending.ExecutionId,
+                ToolName = pending.ToolName,
+                ToolCallId = pending.ToolCallId,
+                ApprovalRequestId = pending.ApprovalRequestId,
+                ArgumentsJson = pending.ArgumentsJson,
+            },
+        }, TopologyAudience.ParentAndChildren, ct);
+    }
+
+    private static bool TryResolvePendingApproval(
+        ToolCallModuleState state,
+        WorkflowResumedEvent resumed,
+        out string pendingKey,
+        out PendingToolCallApprovalState pending)
+    {
+        pendingKey = string.Empty;
+        pending = new PendingToolCallApprovalState();
+
+        if (string.IsNullOrWhiteSpace(resumed.RunId) ||
+            string.IsNullOrWhiteSpace(resumed.StepId) ||
+            string.IsNullOrWhiteSpace(resumed.ExecutionId) ||
+            string.IsNullOrWhiteSpace(resumed.ApprovalRequestId))
+        {
+            return false;
+        }
+
+        pendingKey = BuildPendingApprovalKey(
+            WorkflowRunIdNormalizer.Normalize(resumed.RunId),
+            resumed.StepId,
+            resumed.ExecutionId,
+            resumed.ApprovalRequestId);
+        if (!state.PendingApprovals.TryGetValue(pendingKey, out var resolvedPending))
+            return false;
+
+        pending = resolvedPending;
+        return string.Equals(pending.RunId, WorkflowRunIdNormalizer.Normalize(resumed.RunId), StringComparison.Ordinal) &&
+               string.Equals(pending.StepId, resumed.StepId, StringComparison.Ordinal) &&
+               string.Equals(pending.ExecutionId, resumed.ExecutionId, StringComparison.Ordinal) &&
+               string.Equals(pending.ApprovalRequestId, resumed.ApprovalRequestId, StringComparison.Ordinal);
+    }
+
+    private static string BuildPendingApprovalKey(PendingToolCallApprovalState pending) =>
+        BuildPendingApprovalKey(
+            pending.RunId,
+            pending.StepId,
+            pending.ExecutionId,
+            pending.ApprovalRequestId);
+
+    private static string BuildPendingApprovalKey(
+        string runId,
+        string stepId,
+        string executionId,
+        string approvalRequestId) =>
+        $"{WorkflowRunIdNormalizer.Normalize(runId)}::{stepId}::{executionId}::{approvalRequestId}";
+
+    private static Task SaveStateAsync(
+        ToolCallModuleState state,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        if (state.PendingApprovals.Count == 0)
+            return WorkflowExecutionStateAccess.ClearAsync(ctx, ModuleStateKey, ct);
+
+        return WorkflowExecutionStateAccess.SaveAsync(ctx, ModuleStateKey, state, ct);
+    }
+
+    private static async Task PublishToolSuccessAsync(
+        IWorkflowExecutionContext ctx,
+        StepRequestEvent request,
+        string callId,
+        WorkflowToolExecutionResult result,
+        CancellationToken ct)
+    {
+        var completed = new WorkflowToolCallCompletedEvent
+        {
+            CallId = callId,
+            Success = true,
+            ResultJson = result.ResultJson,
+            RunId = request.RunId,
+            StepId = request.StepId,
+        };
+        if (result.ManagedHandoff != null)
+            completed.ManagedHandoff = result.ManagedHandoff.Clone();
+
+        await ctx.PublishAsync(completed, TopologyAudience.Self, ct);
+
+        if (result.ManagedHandoff != null)
+            return;
+
+        await ctx.PublishAsync(new StepCompletedEvent
+        {
+            StepId = request.StepId,
+            RunId = request.RunId,
+            ExecutionId = request.ExecutionId,
+            Success = true,
+            Output = result.ResultJson,
+        }, TopologyAudience.Self, ct);
+    }
+
+    private static async Task PublishToolSuccessAsync(
+        IWorkflowExecutionContext ctx,
+        PendingToolCallApprovalState pending,
+        WorkflowToolExecutionResult result,
+        CancellationToken ct)
+    {
+        var completed = new WorkflowToolCallCompletedEvent
+        {
+            CallId = pending.ToolCallId,
+            Success = true,
+            ResultJson = result.ResultJson,
+            RunId = pending.RunId,
+            StepId = pending.StepId,
+        };
+        if (result.ManagedHandoff != null)
+            completed.ManagedHandoff = result.ManagedHandoff.Clone();
+
+        await ctx.PublishAsync(completed, TopologyAudience.Self, ct);
+
+        if (result.ManagedHandoff != null)
+            return;
+
+        await ctx.PublishAsync(new StepCompletedEvent
+        {
+            StepId = pending.StepId,
+            RunId = pending.RunId,
+            ExecutionId = pending.ExecutionId,
+            Success = true,
+            Output = result.ResultJson,
+        }, TopologyAudience.Self, ct);
+    }
+
+    private static Task PublishRejectedApprovalAsync(
+        IWorkflowExecutionContext ctx,
+        PendingToolCallApprovalState pending,
+        CancellationToken ct) =>
+        PublishToolFailureAsync(ctx, pending, "tool approval rejected", ct);
 
     private static string ResolveArgumentsJson(StepRequestEvent request)
     {
@@ -267,6 +509,33 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
             StepId = request.StepId,
             RunId = request.RunId,
             ExecutionId = request.ExecutionId,
+            Success = false,
+            Error = errorMessage,
+        }, TopologyAudience.Self, ct);
+    }
+
+    private static async Task PublishToolFailureAsync(
+        IWorkflowExecutionContext ctx,
+        PendingToolCallApprovalState pending,
+        string error,
+        CancellationToken ct)
+    {
+        var errorMessage = $"tool '{pending.ToolName}' execution failed: {error}";
+
+        await ctx.PublishAsync(new WorkflowToolCallCompletedEvent
+        {
+            CallId = pending.ToolCallId,
+            Success = false,
+            Error = errorMessage,
+            RunId = pending.RunId,
+            StepId = pending.StepId,
+        }, TopologyAudience.Self, ct);
+
+        await ctx.PublishAsync(new StepCompletedEvent
+        {
+            StepId = pending.StepId,
+            RunId = pending.RunId,
+            ExecutionId = pending.ExecutionId,
             Success = false,
             Error = errorMessage,
         }, TopologyAudience.Self, ct);

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatCapabilityModels.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatCapabilityModels.cs
@@ -168,6 +168,8 @@ public sealed record WorkflowResumeInput
     public required string ActorId { get; init; }
     public required string RunId { get; init; }
     public required string StepId { get; init; }
+    public string? ExecutionId { get; init; }
+    public string? ApprovalRequestId { get; init; }
     public string? CommandId { get; init; }
     public bool Approved { get; init; }
     public string? UserInput { get; init; }

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
@@ -207,6 +207,8 @@ public static class WorkflowCapabilityEndpoints
             var actorId = (input.ActorId ?? string.Empty).Trim();
             var runId = (input.RunId ?? string.Empty).Trim();
             var stepId = (input.StepId ?? string.Empty).Trim();
+            var executionId = NormalizeOptional(input.ExecutionId);
+            var approvalRequestId = NormalizeOptional(input.ApprovalRequestId);
             var commandId = NormalizeOptional(input.CommandId);
             if (string.IsNullOrWhiteSpace(actorId) ||
                 string.IsNullOrWhiteSpace(runId) ||
@@ -226,7 +228,9 @@ public static class WorkflowCapabilityEndpoints
                     input.UserInput,
                     NormalizeMetadata(input.Metadata),
                     input.EditedContent,
-                    input.Feedback),
+                    input.Feedback,
+                    ExecutionId: executionId,
+                    ApprovalRequestId: approvalRequestId),
                 ct);
             if (!dispatch.Succeeded || dispatch.Receipt == null)
             {
@@ -243,6 +247,8 @@ public static class WorkflowCapabilityEndpoints
                 actorId = dispatch.Receipt.ActorId,
                 runId = dispatch.Receipt.RunId,
                 stepId,
+                executionId,
+                approvalRequestId,
                 acceptedCommandId = dispatch.Receipt.CommandId,
                 correlationId = dispatch.Receipt.CorrelationId,
                 statusUrl,

--- a/src/workflow/Aevatar.Workflow.Integration.AI/AgentWorkflowToolSourceAdapter.cs
+++ b/src/workflow/Aevatar.Workflow.Integration.AI/AgentWorkflowToolSourceAdapter.cs
@@ -77,6 +77,11 @@ public sealed class AgentWorkflowToolSourceAdapter(
                 ToolCallId = Normalize(request.CallId) ?? string.Empty,
                 ArgumentsJson = request.ArgumentsJson,
                 CancellationToken = ct,
+                ApprovalGrant = request.ApprovalGrant == null
+                    ? null
+                    : new ToolApprovalGrantContext(
+                        Normalize(request.ApprovalGrant.ApprovalRequestId) ?? string.Empty,
+                        request.ApprovalGrant.Approved),
             };
 
             await MiddlewarePipeline.RunToolCallAsync(_toolMiddlewares, toolCallContext, async () =>
@@ -86,6 +91,18 @@ public sealed class AgentWorkflowToolSourceAdapter(
 
                 toolCallContext.Result = await _tool.ExecuteAsync(toolCallContext.ArgumentsJson, ct).ConfigureAwait(false);
             }).ConfigureAwait(false);
+
+            if (toolCallContext.Terminate &&
+                toolCallContext.TerminationKind == ToolCallTerminationKind.ApprovalPending &&
+                toolCallContext.PendingApproval != null)
+            {
+                var pending = toolCallContext.PendingApproval;
+                return WorkflowToolExecutionResult.PendingApproval(new WorkflowToolApprovalPendingOutcome(
+                    pending.ApprovalRequestId,
+                    pending.ToolName,
+                    pending.ToolCallId,
+                    pending.ArgumentsJson));
+            }
 
             if (toolCallContext.Terminate)
                 throw new InvalidOperationException(FormatMiddlewareTermination(toolCallContext));

--- a/src/workflow/Aevatar.Workflow.Sdk/AevatarWorkflowClient.cs
+++ b/src/workflow/Aevatar.Workflow.Sdk/AevatarWorkflowClient.cs
@@ -101,6 +101,8 @@ public sealed class AevatarWorkflowClient : IAevatarWorkflowClient
             {
                 actorId = NormalizeOptional(request.ActorId),
                 stepId = request.StepId,
+                executionId = NormalizeOptional(request.ExecutionId),
+                approvalRequestId = NormalizeOptional(request.ApprovalRequestId),
                 commandId = NormalizeOptional(request.CommandId),
                 approved = request.Approved,
                 userInput = NormalizeOptional(request.UserInput),

--- a/src/workflow/Aevatar.Workflow.Sdk/Contracts/WorkflowContracts.cs
+++ b/src/workflow/Aevatar.Workflow.Sdk/Contracts/WorkflowContracts.cs
@@ -55,6 +55,8 @@ public sealed record WorkflowResumeRequest
     public required string ServiceId { get; init; }
     public required string RunId { get; init; }
     public required string StepId { get; init; }
+    public string? ExecutionId { get; init; }
+    public string? ApprovalRequestId { get; init; }
     public string? ActorId { get; init; }
     public string? CommandId { get; init; }
     public bool Approved { get; init; }
@@ -82,6 +84,8 @@ public sealed record WorkflowResumeResponse
     public string? ActorId { get; init; }
     public string? RunId { get; init; }
     public string? StepId { get; init; }
+    public string? ExecutionId { get; init; }
+    public string? ApprovalRequestId { get; init; }
     public string? CommandId { get; init; }
 }
 

--- a/src/workflow/Aevatar.Workflow.Sdk/Contracts/WorkflowCustomEvents.cs
+++ b/src/workflow/Aevatar.Workflow.Sdk/Contracts/WorkflowCustomEvents.cs
@@ -10,6 +10,7 @@ public static class WorkflowCustomEventNames
     public const string StepRequest = "aevatar.step.request";
     public const string StepCompleted = "aevatar.step.completed";
     public const string HumanInputRequest = "aevatar.human_input.request";
+    public const string ToolApprovalPending = "aevatar.tool_approval.pending";
     public const string WaitingSignal = "aevatar.workflow.waiting_signal";
     public const string SignalBuffered = "aevatar.workflow.signal.buffered";
     public const string LlmReasoning = "aevatar.llm.reasoning";
@@ -58,6 +59,17 @@ public sealed record WorkflowHumanInputRequestEventData
     public bool? Secure { get; init; }
     public string? RedactedOutput { get; init; }
     public IDictionary<string, string>? Metadata { get; init; }
+}
+
+public sealed record WorkflowToolApprovalPendingEventData
+{
+    public string? RunId { get; init; }
+    public string? StepId { get; init; }
+    public string? ExecutionId { get; init; }
+    public string? ToolName { get; init; }
+    public string? ToolCallId { get; init; }
+    public string? ApprovalRequestId { get; init; }
+    public string? ArgumentsJson { get; init; }
 }
 
 public sealed record WorkflowWaitingSignalEventData
@@ -163,6 +175,32 @@ public static class WorkflowCustomEventParser
                 Secure = payload.Secure,
                 RedactedOutput = payload.RedactedOutput,
                 Metadata = FilterReservedHumanInputMetadata(payload.Metadata),
+            };
+            return true;
+        }
+
+        data = default!;
+        return false;
+    }
+
+    public static bool TryParseToolApprovalPending(
+        WorkflowRunEventEnvelope frame,
+        out WorkflowToolApprovalPendingEventData data)
+    {
+        if (TryUnpackCustomPayload<WorkflowToolApprovalSuspensionCustomPayload>(
+                frame,
+                WorkflowCustomEventNames.ToolApprovalPending,
+                out var payload))
+        {
+            data = new WorkflowToolApprovalPendingEventData
+            {
+                RunId = payload.RunId,
+                StepId = payload.StepId,
+                ExecutionId = payload.ExecutionId,
+                ToolName = payload.ToolName,
+                ToolCallId = payload.ToolCallId,
+                ApprovalRequestId = payload.ApprovalRequestId,
+                ArgumentsJson = payload.ArgumentsJson,
             };
             return true;
         }

--- a/src/workflow/Aevatar.Workflow.Sdk/Session/RunSessionTracker.cs
+++ b/src/workflow/Aevatar.Workflow.Sdk/Session/RunSessionTracker.cs
@@ -11,6 +11,8 @@ public sealed record RunSessionSnapshot
     public string? CommandId { get; init; }
     public string? RunId { get; init; }
     public string? StepId { get; init; }
+    public string? ExecutionId { get; init; }
+    public string? ApprovalRequestId { get; init; }
     public string? SuspensionType { get; init; }
     public string? LastSignalName { get; init; }
 
@@ -30,6 +32,8 @@ public sealed class RunSessionTracker
     private string? _commandId;
     private string? _runId;
     private string? _stepId;
+    private string? _executionId;
+    private string? _approvalRequestId;
     private string? _suspensionType;
     private string? _lastSignalName;
 
@@ -40,6 +44,8 @@ public sealed class RunSessionTracker
         CommandId = _commandId,
         RunId = _runId,
         StepId = _stepId,
+        ExecutionId = _executionId,
+        ApprovalRequestId = _approvalRequestId,
         SuspensionType = _suspensionType,
         LastSignalName = _lastSignalName,
     };
@@ -90,6 +96,8 @@ public sealed class RunSessionTracker
             ActorId = _actorId,
             RunId = _runId!,
             StepId = _stepId!,
+            ExecutionId = _executionId,
+            ApprovalRequestId = _approvalRequestId,
             Approved = approved,
             UserInput = userInput,
             EditedContent = editedContent,
@@ -163,6 +171,16 @@ public sealed class RunSessionTracker
             _runId = humanInput.RunId ?? _runId;
             _stepId = humanInput.StepId ?? _stepId;
             _suspensionType = humanInput.SuspensionType ?? _suspensionType;
+            return;
+        }
+
+        if (WorkflowCustomEventParser.TryParseToolApprovalPending(frame, out var toolApproval))
+        {
+            _runId = toolApproval.RunId ?? _runId;
+            _stepId = toolApproval.StepId ?? _stepId;
+            _executionId = toolApproval.ExecutionId ?? _executionId;
+            _approvalRequestId = toolApproval.ApprovalRequestId ?? _approvalRequestId;
+            _suspensionType = "tool_approval";
             return;
         }
 

--- a/test/Aevatar.AI.Core.Tests/Middleware/ToolApprovalMiddlewareTests.cs
+++ b/test/Aevatar.AI.Core.Tests/Middleware/ToolApprovalMiddlewareTests.cs
@@ -342,6 +342,47 @@ public class ToolApprovalMiddlewareTests
     }
 
     [Fact]
+    public async Task ApprovedGrant_ExecutesNextWithoutRequestingApprovalAgain()
+    {
+        var handler = new ScriptedApprovalHandler(ToolApprovalResult.Denied("would-loop"));
+        var middleware = new ToolApprovalMiddleware(handler);
+        var ctx = NewContext("danger", "tc-grant-1", new ToolApprovalGrantContext("approval-1", true));
+
+        var nextExecuted = false;
+        await middleware.InvokeAsync(ctx, () =>
+        {
+            nextExecuted = true;
+            return Task.CompletedTask;
+        });
+
+        nextExecuted.Should().BeTrue();
+        ctx.Terminate.Should().BeFalse();
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RejectedGrant_FailsClosedWithoutRequestingApprovalAgain()
+    {
+        var handler = new ScriptedApprovalHandler(ToolApprovalResult.Approved());
+        var middleware = new ToolApprovalMiddleware(handler);
+        var ctx = NewContext("danger", "tc-grant-2", new ToolApprovalGrantContext("approval-2", false));
+
+        var nextExecuted = false;
+        await middleware.InvokeAsync(ctx, () =>
+        {
+            nextExecuted = true;
+            return Task.CompletedTask;
+        });
+
+        nextExecuted.Should().BeFalse();
+        ctx.Terminate.Should().BeTrue();
+        ctx.TerminationKind.Should().Be(ToolCallTerminationKind.ApprovalDenied);
+        ctx.Receipt.Should().NotBeNull();
+        ctx.Receipt!.ApprovalRequestId.Should().Be("approval-2");
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task RequestScopedDenialCountBlocksExecutionWithoutCallingHandler()
     {
         var handler = new ScriptedApprovalHandler(ToolApprovalResult.Approved());
@@ -393,12 +434,16 @@ public class ToolApprovalMiddlewareTests
         handler.Requests.Should().HaveCount(3);
     }
 
-    private static ToolCallContext NewContext(string toolName, string callId) => new()
+    private static ToolCallContext NewContext(
+        string toolName,
+        string callId,
+        ToolApprovalGrantContext? approvalGrant = null) => new()
     {
         Tool = new FakeAgentTool(toolName, ToolApprovalMode.AlwaysRequire) { IsDestructive = true },
         ToolName = toolName,
         ToolCallId = callId,
         ArgumentsJson = "{}",
+        ApprovalGrant = approvalGrant,
     };
 
     private static Task InvokeChainAsync(

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
@@ -265,6 +265,8 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
         resumed.UserInput.Should().BeEmpty();
         resumed.EditedContent.Should().BeEmpty();
         resumed.Feedback.Should().BeEmpty();
+        resumed.ExecutionId.Should().BeEmpty();
+        resumed.ApprovalRequestId.Should().BeEmpty();
 
         var actOnCommand = () => factory.CreateEnvelope(null!, context);
         var actOnContext = () => factory.CreateEnvelope(

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlCommandTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlCommandTests.cs
@@ -127,7 +127,9 @@ public sealed class WorkflowRunControlCommandTests
                     ["source"] = "tests",
                 },
                 "edited draft",
-                "minor note"),
+                "minor note",
+                ExecutionId: "exec-1",
+                ApprovalRequestId: "approval-1"),
             new CommandContext("actor-1", "cmd-1", "corr-1", new Dictionary<string, string>()));
 
         var resumed = envelope.Payload.Unpack<WorkflowResumedEvent>();
@@ -142,6 +144,8 @@ public sealed class WorkflowRunControlCommandTests
         resumed.UserInput.Should().Be("approved");
         resumed.EditedContent.Should().Be("edited draft");
         resumed.Feedback.Should().Be("minor note");
+        resumed.ExecutionId.Should().Be("exec-1");
+        resumed.ApprovalRequestId.Should().Be("approval-1");
         resumed.Metadata.Should().ContainKey("source").WhoseValue.Should().Be("tests");
     }
 

--- a/test/Aevatar.Workflow.Core.Tests/Modules/AgentWorkflowToolSourceAdapterTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/AgentWorkflowToolSourceAdapterTests.cs
@@ -96,7 +96,7 @@ public sealed class AgentWorkflowToolSourceAdapterTests
     }
 
     [Fact]
-    public async Task WorkflowTool_WhenApprovalPending_ShouldFailClosedWithoutReturningPendingPayload()
+    public async Task WorkflowTool_WhenApprovalPending_ShouldReturnTypedPendingOutcome()
     {
         var agentTool = new CapturingAgentTool(ToolApprovalMode.AlwaysRequire);
         var approvalHandler = new ScriptedApprovalHandler(ToolApprovalResult.Yielded("approval-1"));
@@ -105,22 +105,55 @@ public sealed class AgentWorkflowToolSourceAdapterTests
             approvalHandler: approvalHandler);
         var tool = (await adapter.GetToolsAsync(CancellationToken.None)).Single();
 
-        await FluentActions.Awaiting(() => tool.ExecuteAsync(
-                new WorkflowToolExecutionRequest(
-                    ArgumentsJson: "{}",
-                    RunId: "run-1",
-                    StepId: "step-1",
-                    ExecutionId: "exec-1",
-                    CallId: "call-1",
-                    ScopeId: "scope-1",
-                    CallerCredential: new WorkflowCallerCredential()),
-                CancellationToken.None))
-            .Should()
-            .ThrowAsync<InvalidOperationException>()
-            .WithMessage("*ApprovalPending*approval-1*");
+        var result = await tool.ExecuteAsync(
+            new WorkflowToolExecutionRequest(
+                ArgumentsJson: "{}",
+                RunId: "run-1",
+                StepId: "step-1",
+                ExecutionId: "exec-1",
+                CallId: "call-1",
+                ScopeId: "scope-1",
+                CallerCredential: new WorkflowCallerCredential()),
+            CancellationToken.None);
 
+        result.Outcome.Should().Be(WorkflowToolExecutionOutcome.ApprovalPending);
+        result.ApprovalPending.Should().NotBeNull();
+        result.ApprovalPending!.ApprovalRequestId.Should().NotBeNullOrWhiteSpace();
+        result.ApprovalPending.ToolCallId.Should().Be("call-1");
+        result.ApprovalPending.ToolName.Should().Be(agentTool.Name);
+        result.ApprovalPending.ArgumentsJson.Should().Be("{}");
+        result.ResultJson.Should().BeEmpty();
         agentTool.ExecuteCount.Should().Be(0);
         approvalHandler.Requests.Should().ContainSingle();
+        AgentToolRequestContext.Current.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task WorkflowTool_WhenApprovalGrantApproved_ShouldExecuteAgentToolWithoutRequestingApprovalAgain()
+    {
+        var agentTool = new CapturingAgentTool(ToolApprovalMode.AlwaysRequire);
+        var approvalHandler = new ScriptedApprovalHandler(ToolApprovalResult.Denied("would-loop"));
+        var adapter = new AgentWorkflowToolSourceAdapter(
+            [new SingleAgentToolSource(agentTool)],
+            approvalHandler: approvalHandler);
+        var tool = (await adapter.GetToolsAsync(CancellationToken.None)).Single();
+
+        var result = await tool.ExecuteAsync(
+            new WorkflowToolExecutionRequest(
+                ArgumentsJson: "{}",
+                RunId: "run-1",
+                StepId: "step-1",
+                ExecutionId: "exec-1",
+                CallId: "call-1",
+                ScopeId: "scope-1",
+                CallerCredential: new WorkflowCallerCredential(),
+                ApprovalGrant: new WorkflowToolApprovalGrant("approval-1", true)),
+            CancellationToken.None);
+
+        result.ResultJson.Should().Be("""{"observed":true}""");
+        result.Outcome.Should().Be(WorkflowToolExecutionOutcome.Success);
+        agentTool.ExecuteCount.Should().Be(1);
+        approvalHandler.Requests.Should().BeEmpty();
         AgentToolRequestContext.Current.Should().BeNull();
     }
 

--- a/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
@@ -224,6 +224,130 @@ public sealed class ToolCallModuleContextTests
     }
 
     [Fact]
+    public async Task ToolCallModule_WhenToolApprovalPending_ShouldPersistPendingApprovalAndSuspendWithoutCompletingStep()
+    {
+        var tool = new ApprovalPendingWorkflowTool("dangerous_tool");
+        var module = CreateModule(tool);
+        var ctx = new RecordingWorkflowContext();
+
+        await ExecuteToolCallAsync(module, ctx, tool.Name, input: """{"danger":true}""", executionId: "exec-1");
+
+        ctx.Published.Select(x => x.Event).OfType<WorkflowToolCallStartedEvent>().Should().ContainSingle();
+        ctx.Published.Select(x => x.Event).OfType<WorkflowToolCallCompletedEvent>().Should().BeEmpty();
+        ctx.Published.Select(x => x.Event).OfType<StepCompletedEvent>().Should().BeEmpty();
+        var suspended = ctx.Published.Single(x => x.Event is WorkflowSuspendedEvent).Event
+            .Should().BeOfType<WorkflowSuspendedEvent>().Subject;
+        suspended.RunId.Should().Be("run-1");
+        suspended.StepId.Should().Be("call_proxy");
+        suspended.SuspensionType.Should().Be("tool_approval");
+        suspended.ToolApproval.Should().NotBeNull();
+        suspended.ToolApproval.ExecutionId.Should().Be("exec-1");
+        suspended.ToolApproval.ToolName.Should().Be(tool.Name);
+        suspended.ToolApproval.ToolCallId.Should().Be("workflow:run-1:call_proxy:exec-1");
+        suspended.ToolApproval.ApprovalRequestId.Should().Be("approval-1");
+        suspended.ToolApproval.ArgumentsJson.Should().Be("""{"danger":true}""");
+        ctx.Published.Single(x => x.Event is WorkflowSuspendedEvent).Direction
+            .Should().Be(TopologyAudience.ParentAndChildren);
+        var state = ctx.LoadState<ToolCallModuleState>("tool_call");
+        state.PendingApprovals.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task ToolCallModule_WhenApprovalResumeApproved_ShouldReplayOriginalToolWithGrantAndCompleteStep()
+    {
+        var tool = new ApprovalPendingWorkflowTool("dangerous_tool");
+        var module = CreateModule(tool);
+        var ctx = new RecordingWorkflowContext();
+
+        await ExecuteToolCallAsync(module, ctx, tool.Name, input: """{"danger":true}""", executionId: "exec-1");
+        ctx.Published.Clear();
+
+        await module.HandleAsync(
+            Envelope(new WorkflowResumedEvent
+            {
+                RunId = "run-1",
+                StepId = "call_proxy",
+                ExecutionId = "exec-1",
+                ApprovalRequestId = "approval-1",
+                Approved = true,
+            }),
+            ctx,
+            CancellationToken.None);
+
+        tool.ExecuteCalls.Should().Be(2);
+        tool.LastRequest.Should().NotBeNull();
+        tool.LastRequest!.ApprovalGrant.Should().NotBeNull();
+        tool.LastRequest.ApprovalGrant!.ApprovalRequestId.Should().Be("approval-1");
+        tool.LastRequest.ApprovalGrant.Approved.Should().BeTrue();
+        tool.LastRequest.ArgumentsJson.Should().Be("""{"danger":true}""");
+        var completed = ctx.Published.Select(x => x.Event).OfType<WorkflowToolCallCompletedEvent>().Single();
+        completed.Success.Should().BeTrue();
+        completed.ResultJson.Should().Be("""{"approved":true}""");
+        LastCompleted(ctx).Success.Should().BeTrue();
+        LastCompleted(ctx).ExecutionId.Should().Be("exec-1");
+        LastCompleted(ctx).Output.Should().Be("""{"approved":true}""");
+        ctx.LoadState<ToolCallModuleState>("tool_call").PendingApprovals.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ToolCallModule_WhenApprovalResumeRejected_ShouldClearStateAndPublishFailedCompletion()
+    {
+        var tool = new ApprovalPendingWorkflowTool("dangerous_tool");
+        var module = CreateModule(tool);
+        var ctx = new RecordingWorkflowContext();
+
+        await ExecuteToolCallAsync(module, ctx, tool.Name, executionId: "exec-1");
+        ctx.Published.Clear();
+
+        await module.HandleAsync(
+            Envelope(new WorkflowResumedEvent
+            {
+                RunId = "run-1",
+                StepId = "call_proxy",
+                ExecutionId = "exec-1",
+                ApprovalRequestId = "approval-1",
+                Approved = false,
+            }),
+            ctx,
+            CancellationToken.None);
+
+        tool.ExecuteCalls.Should().Be(1);
+        var toolCompleted = ctx.Published.Select(x => x.Event).OfType<WorkflowToolCallCompletedEvent>().Single();
+        toolCompleted.Success.Should().BeFalse();
+        toolCompleted.Error.Should().Contain("tool approval rejected");
+        var completed = LastCompleted(ctx);
+        completed.Success.Should().BeFalse();
+        completed.ExecutionId.Should().Be("exec-1");
+        completed.Error.Should().Contain("tool approval rejected");
+        ctx.LoadState<ToolCallModuleState>("tool_call").PendingApprovals.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ToolCallModule_WhenApprovalResumeMissingTypedKeys_ShouldIgnoreResumeAndKeepPendingState()
+    {
+        var tool = new ApprovalPendingWorkflowTool("dangerous_tool");
+        var module = CreateModule(tool);
+        var ctx = new RecordingWorkflowContext();
+
+        await ExecuteToolCallAsync(module, ctx, tool.Name, executionId: "exec-1");
+        ctx.Published.Clear();
+
+        await module.HandleAsync(
+            Envelope(new WorkflowResumedEvent
+            {
+                RunId = "run-1",
+                StepId = "call_proxy",
+                Approved = true,
+            }),
+            ctx,
+            CancellationToken.None);
+
+        ctx.Published.Should().BeEmpty();
+        ctx.LoadState<ToolCallModuleState>("tool_call").PendingApprovals.Should().ContainSingle();
+        tool.ExecuteCalls.Should().Be(1);
+    }
+
+    [Fact]
     public void IWorkflowTool_ShouldExposeOnlyTypedWorkflowExecutionMethod()
     {
         var executeMethods = typeof(IWorkflowTool)
@@ -313,6 +437,30 @@ public sealed class ToolCallModuleContextTests
             ct.ThrowIfCancellationRequested();
             LastRequest = request;
             return Task.FromResult(WorkflowToolExecutionResult.Success("""{"typed":true}"""));
+        }
+    }
+
+    private sealed class ApprovalPendingWorkflowTool(string name) : IWorkflowTool
+    {
+        public string Name { get; } = name;
+
+        public int ExecuteCalls { get; private set; }
+
+        public WorkflowToolExecutionRequest? LastRequest { get; private set; }
+
+        public Task<WorkflowToolExecutionResult> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            ExecuteCalls++;
+            LastRequest = request;
+            if (request.ApprovalGrant?.Approved == true)
+                return Task.FromResult(WorkflowToolExecutionResult.Success("""{"approved":true}"""));
+
+            return Task.FromResult(WorkflowToolExecutionResult.PendingApproval(new WorkflowToolApprovalPendingOutcome(
+                "approval-1",
+                Name,
+                request.CallId,
+                request.ArgumentsJson)));
         }
     }
 

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
@@ -909,6 +909,8 @@ public sealed class ChatEndpointsInternalTests
                 ActorId = "actor-1",
                 RunId = "run-1",
                 StepId = "step-1",
+                ExecutionId = "exec-1",
+                ApprovalRequestId = "approval-1",
                 CommandId = "cmd-1",
                 Approved = true,
                 UserInput = "approved",
@@ -929,11 +931,15 @@ public sealed class ChatEndpointsInternalTests
         http.Response.Headers.Location.ToString().Should().Be("/api/workflow-actors/actor-1/current-state");
         var body = await ReadBodyAsync(http.Response);
         body.Should().Contain("\"acceptedCommandId\":\"cmd-1\"");
+        body.Should().Contain("\"executionId\":\"exec-1\"");
+        body.Should().Contain("\"approvalRequestId\":\"approval-1\"");
         body.Should().Contain("\"statusUrl\":\"/api/workflow-actors/actor-1/current-state\"");
         service.Commands.Should().ContainSingle();
         service.Commands.Single().ActorId.Should().Be("actor-1");
         service.Commands.Single().RunId.Should().Be("run-1");
         service.Commands.Single().StepId.Should().Be("step-1");
+        service.Commands.Single().ExecutionId.Should().Be("exec-1");
+        service.Commands.Single().ApprovalRequestId.Should().Be("approval-1");
         service.Commands.Single().CommandId.Should().Be("cmd-1");
         service.Commands.Single().Approved.Should().BeTrue();
         service.Commands.Single().UserInput.Should().Be("approved");

--- a/test/Aevatar.Workflow.Sdk.Tests/AevatarWorkflowClientTests.cs
+++ b/test/Aevatar.Workflow.Sdk.Tests/AevatarWorkflowClientTests.cs
@@ -55,6 +55,8 @@ data: {"stateSnapshot":{"snapshot":{"@type":"type.googleapis.com/aevatar.workflo
             using var doc = JsonDocument.Parse(body);
             doc.RootElement.GetProperty("actorId").GetString().Should().Be("actor-1");
             doc.RootElement.GetProperty("stepId").GetString().Should().Be("approval-1");
+            doc.RootElement.GetProperty("executionId").GetString().Should().Be("exec-1");
+            doc.RootElement.GetProperty("approvalRequestId").GetString().Should().Be("approval-1");
             doc.RootElement.GetProperty("editedContent").GetString().Should().Be("Final draft");
             doc.RootElement.GetProperty("feedback").GetString().Should().Be("Looks good");
             doc.RootElement.GetProperty("metadata").GetProperty("source").GetString().Should().Be("sdk");
@@ -62,7 +64,7 @@ data: {"stateSnapshot":{"snapshot":{"@type":"type.googleapis.com/aevatar.workflo
             return new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent(
-                    """{"accepted":true,"actorId":"actor-1","runId":"run-1","stepId":"approval-1","commandId":"cmd-1"}""",
+                    """{"accepted":true,"actorId":"actor-1","runId":"run-1","stepId":"approval-1","executionId":"exec-1","approvalRequestId":"approval-1","commandId":"cmd-1"}""",
                     Encoding.UTF8,
                     "application/json"),
             };
@@ -75,6 +77,8 @@ data: {"stateSnapshot":{"snapshot":{"@type":"type.googleapis.com/aevatar.workflo
             ActorId = "actor-1",
             RunId = "run-1",
             StepId = "approval-1",
+            ExecutionId = "exec-1",
+            ApprovalRequestId = "approval-1",
             Approved = true,
             CommandId = "cmd-1",
             EditedContent = "Final draft",
@@ -87,6 +91,8 @@ data: {"stateSnapshot":{"snapshot":{"@type":"type.googleapis.com/aevatar.workflo
 
         result.Accepted.Should().BeTrue();
         result.ActorId.Should().Be("actor-1");
+        result.ExecutionId.Should().Be("exec-1");
+        result.ApprovalRequestId.Should().Be("approval-1");
         result.CommandId.Should().Be("cmd-1");
     }
 

--- a/test/Aevatar.Workflow.Sdk.Tests/Session/RunSessionTrackerTests.cs
+++ b/test/Aevatar.Workflow.Sdk.Tests/Session/RunSessionTrackerTests.cs
@@ -107,6 +107,42 @@ public sealed class RunSessionTrackerTests
     }
 
     [Fact]
+    public void Track_ShouldCaptureToolApprovalPendingContextForResumeRequest()
+    {
+        var tracker = new RunSessionTracker();
+
+        tracker.Track(CustomFrame("aevatar.run.context", new WorkflowRunContextPayload
+        {
+            ActorId = "actor-1",
+            WorkflowName = "auto",
+        }));
+        tracker.Track(CustomFrame(WorkflowCustomEventNames.ToolApprovalPending, new WorkflowToolApprovalSuspensionCustomPayload
+        {
+            RunId = "run-1",
+            StepId = "tool-step",
+            ExecutionId = "exec-1",
+            ToolName = "dangerous_tool",
+            ToolCallId = "call-1",
+            ApprovalRequestId = "approval-1",
+            ArgumentsJson = "{}",
+        }));
+
+        var snapshot = tracker.Snapshot;
+        snapshot.RunId.Should().Be("run-1");
+        snapshot.StepId.Should().Be("tool-step");
+        snapshot.ExecutionId.Should().Be("exec-1");
+        snapshot.ApprovalRequestId.Should().Be("approval-1");
+        snapshot.SuspensionType.Should().Be("tool_approval");
+
+        var resume = tracker.CreateResumeRequest("scope-a", approved: true, serviceId: "orders");
+        resume.ActorId.Should().Be("actor-1");
+        resume.RunId.Should().Be("run-1");
+        resume.StepId.Should().Be("tool-step");
+        resume.ExecutionId.Should().Be("exec-1");
+        resume.ApprovalRequestId.Should().Be("approval-1");
+    }
+
+    [Fact]
     public void CreateSignalRequest_ShouldAllowExplicitStepOverride()
     {
         var tracker = new RunSessionTracker();

--- a/test/Aevatar.Workflow.Sdk.Tests/Session/WorkflowCustomEventParserTests.cs
+++ b/test/Aevatar.Workflow.Sdk.Tests/Session/WorkflowCustomEventParserTests.cs
@@ -194,6 +194,32 @@ public sealed class WorkflowCustomEventParserTests
     }
 
     [Fact]
+    public void TryParseToolApprovalPending_ShouldReturnTypedContinuationFields()
+    {
+        var frame = CustomFrame(WorkflowCustomEventNames.ToolApprovalPending, new WorkflowToolApprovalSuspensionCustomPayload
+        {
+            RunId = "run-tool",
+            StepId = "step-tool",
+            ExecutionId = "exec-tool",
+            ToolName = "dangerous_tool",
+            ToolCallId = "call-tool",
+            ApprovalRequestId = "approval-tool",
+            ArgumentsJson = """{"danger":true}""",
+        });
+
+        var ok = WorkflowCustomEventParser.TryParseToolApprovalPending(frame, out var data);
+
+        ok.Should().BeTrue();
+        data.RunId.Should().Be("run-tool");
+        data.StepId.Should().Be("step-tool");
+        data.ExecutionId.Should().Be("exec-tool");
+        data.ToolName.Should().Be("dangerous_tool");
+        data.ToolCallId.Should().Be("call-tool");
+        data.ApprovalRequestId.Should().Be("approval-tool");
+        data.ArgumentsJson.Should().Be("""{"danger":true}""");
+    }
+
+    [Fact]
     public void TryParseSignalBuffered_ShouldReturnTypedPayload()
     {
         var frame = CustomFrame(WorkflowCustomEventNames.SignalBuffered, new WorkflowSignalBufferedCustomPayload


### PR DESCRIPTION
## Changed files

- 将 workflow tool execution 扩展为 typed outcome，`ApprovalPending` 不再作为 middleware termination 异常向 `ToolCallModule` 冒泡。
- `ToolCallModule` 在 actor state 中保存 pending approval，并发布 `tool_approval` suspension；pending 时不发布 tool/step completed。
- resume command、API、SDK 与 AGUI custom event 全链路承载 `execution_id` 和 `approval_request_id`，approved resume 通过窄 typed grant 重跑原工具。
- 补齐 middleware、adapter、module、application、SDK、Host API 的行为测试，并更新 workflow primitives 文档。

## Test results

- `dotnet build aevatar.slnx --nologo` passed。
- 指定测试项目全部 passed：Workflow.Core、AI.Core、Workflow.Application、Workflow.Sdk、Workflow.Host.Api。
- `test_stability_guards.sh`、`workflow_binding_boundary_guard.sh`、`architecture_guards.sh` passed。

## Deviations

- Closes #2015
- `HOST_REFACTOR_COMMENT_POLICY` 归一化为 `none`，未新增本 issue 的 refactor-history 源码注释。
- 记录了必要的 scope 扩展：API input model、SDK client、SDK custom event parser、Application coverage test、Host API endpoint test、SDK parser test。

⟦AI:AUTO-LOOP⟧
