### PR TITLE
Implement typed workflow tool approval suspension

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
@@ -198,6 +198,18 @@ message WorkflowResumeActionPayload {
   string edited_content = 6;
   // The feedback submitted with an approval or rejection action.
   string feedback = 7;
+  // The typed tool approval continuation keys for direct workflow tool calls.
+  WorkflowToolApprovalResumeActionPayload tool_approval = 8;
+}
+
+// Carries direct workflow tool approval resume keys.
+message WorkflowToolApprovalResumeActionPayload {
+  // The workflow tool execution identifier.
+  string execution_id = 1;
+  // The original workflow tool call identifier.
+  string tool_call_id = 2;
+  // The approval request identifier emitted by the workflow actor.
+  string approval_request_id = 3;
 }
 
 // Refactor (iter93/cluster-093):

--- a/agents/Aevatar.GAgents.NyxidChat/ChannelCardActionRouting.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelCardActionRouting.cs
@@ -67,7 +67,8 @@ public static class ChannelCardActionRouting
             ResolveUserInput(values, approved),
             metadata,
             editedContent,
-            feedback);
+            feedback,
+            ToolApproval: ToToolApprovalResumeCommand(payload.ToolApproval));
         return true;
     }
 
@@ -94,6 +95,21 @@ public static class ChannelCardActionRouting
             values["edited_content"] = payload.EditedContent;
         if (!string.IsNullOrWhiteSpace(payload.Feedback))
             values["feedback"] = payload.Feedback;
+    }
+
+    private static WorkflowToolApprovalResumeCommand? ToToolApprovalResumeCommand(
+        WorkflowToolApprovalResumeActionPayload? payload)
+    {
+        if (payload == null)
+            return null;
+
+        var executionId = NormalizeOptional(payload.ExecutionId);
+        var toolCallId = NormalizeOptional(payload.ToolCallId);
+        var approvalRequestId = NormalizeOptional(payload.ApprovalRequestId);
+        if (executionId == null || toolCallId == null || approvalRequestId == null)
+            return null;
+
+        return new WorkflowToolApprovalResumeCommand(executionId, toolCallId, approvalRequestId);
     }
 
     private static bool TryGetRequiredValue(

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
@@ -463,7 +463,10 @@ public sealed class NyxIdRelayTransport
                 "actor_id",
                 "run_id",
                 "step_id",
-                "approved");
+                "approved",
+                "execution_id",
+                "tool_call_id",
+                "approval_request_id");
         }
 
         if (TryBuildLlmSelectionPayload(submission, out var llmSelection))
@@ -570,6 +573,27 @@ public sealed class NyxIdRelayTransport
         if (submission.FormFields.TryGetValue("feedback", out var feedback))
             payload.Feedback = feedback ?? string.Empty;
 
+        if (TryBuildWorkflowToolApprovalResumePayload(submission, out var toolApproval))
+            payload.ToolApproval = toolApproval;
+
+        return true;
+    }
+
+    private static bool TryBuildWorkflowToolApprovalResumePayload(
+        CardActionSubmission submission,
+        out WorkflowToolApprovalResumeActionPayload payload)
+    {
+        payload = new WorkflowToolApprovalResumeActionPayload();
+        if (!TryGetRequiredValue(submission.Arguments, "execution_id", out var executionId) ||
+            !TryGetRequiredValue(submission.Arguments, "tool_call_id", out var toolCallId) ||
+            !TryGetRequiredValue(submission.Arguments, "approval_request_id", out var approvalRequestId))
+        {
+            return false;
+        }
+
+        payload.ExecutionId = executionId;
+        payload.ToolCallId = toolCallId;
+        payload.ApprovalRequestId = approvalRequestId;
         return true;
     }
 

--- a/docs/canon/workflow-primitives.md
+++ b/docs/canon/workflow-primitives.md
@@ -350,6 +350,9 @@ steps:
 - 作用：调用已注册工具（函数/工具链/MCP 工具）。
 - 常用参数：`tool`。
 - 工具输出若是 JSON object 且步骤成功，运行时会把顶层字段镜像为 `steps.<step_id>.json.<field>` 变量，供后续 `switch` / `conditional` / `while` 分支使用。
+- 需要人工审批的 direct `tool_call` 不把 `ApprovalPending` 当作失败完成。`ToolCallModule` 将原始 tool name、arguments、`execution_id`、`tool_call_id`、`approval_request_id` 持久化到 workflow actor state，并发布 `WorkflowSuspendedEvent.tool_approval`。该 suspension 只暴露审批对账键，不暴露工具参数。
+- tool approval resume 使用 `WorkflowResumedEvent.tool_approval` nested payload，仅携带 `execution_id`、`tool_call_id`、`approval_request_id`。客户端不得在 resume payload 中提交 tool name 或 arguments；approved replay 必须从 actor pending state 读取原始工具和参数，并向 tool middleware 传递 typed `ToolApprovalGrant`。
+- resume 对账按 `run_id + step_id + execution_id + tool_call_id + approval_request_id` 精确匹配。approved 后重放原工具；rejected / timed out / non-pending termination fail closed 并清理 pending state；stale 或 mismatched resume event 直接忽略。
 
 ```yaml
 steps:

--- a/src/Aevatar.AI.Abstractions/Middleware/IToolCallMiddleware.cs
+++ b/src/Aevatar.AI.Abstractions/Middleware/IToolCallMiddleware.cs
@@ -31,6 +31,11 @@ public sealed record ToolApprovalPendingContext(
     bool IsReadOnly,
     bool IsDestructive);
 
+public sealed record ToolApprovalGrant(
+    string ApprovalRequestId,
+    string ToolName,
+    string ToolCallId);
+
 /// <summary>Context for tool call middleware.</summary>
 public sealed class ToolCallContext
 {
@@ -57,6 +62,9 @@ public sealed class ToolCallContext
 
     /// <summary>Typed business keys for a tool approval yield.</summary>
     public ToolApprovalPendingContext? PendingApproval { get; set; }
+
+    /// <summary>Typed approval replay grant supplied by the workflow actor.</summary>
+    public ToolApprovalGrant? ApprovalGrant { get; set; }
 
     /// <summary>When true, tool execution is skipped and Result is returned as-is.</summary>
     public bool Terminate { get; set; }

--- a/src/Aevatar.AI.Core/Middleware/ToolApprovalMiddleware.cs
+++ b/src/Aevatar.AI.Core/Middleware/ToolApprovalMiddleware.cs
@@ -34,6 +34,20 @@ public sealed class ToolApprovalMiddleware : IToolCallMiddleware
     public async Task InvokeAsync(ToolCallContext context, Func<Task> next)
     {
         var mode = context.Tool.ApprovalMode;
+        if (TryConsumeMatchingGrant(context))
+        {
+            await next();
+            return;
+        }
+
+        if (context.ApprovalGrant != null)
+        {
+            context.Terminate = true;
+            context.TerminationKind = ToolCallTerminationKind.ApprovalDenied;
+            context.TerminationReason = "Tool approval grant does not match the requested tool call.";
+            context.Result = $"Tool '{context.ToolName}' approval grant does not match the requested tool call.";
+            return;
+        }
 
         // NeverRequire → 直接执行
         if (mode == ToolApprovalMode.NeverRequire)
@@ -183,6 +197,22 @@ public sealed class ToolApprovalMiddleware : IToolCallMiddleware
     /// <summary>Request-scoped consecutive denial count carried by the caller.</summary>
     public const string DenialCountItemKey = "approval_denial_count";
 
+    private static bool TryConsumeMatchingGrant(ToolCallContext context)
+    {
+        var grant = context.ApprovalGrant;
+        if (grant == null)
+            return false;
+
+        var approvalRequestId = Normalize(grant.ApprovalRequestId);
+        var toolName = Normalize(grant.ToolName);
+        var toolCallId = Normalize(grant.ToolCallId);
+        if (approvalRequestId.Length == 0 || toolName.Length == 0 || toolCallId.Length == 0)
+            return false;
+
+        return string.Equals(toolName, Normalize(context.ToolName), StringComparison.Ordinal) &&
+               string.Equals(toolCallId, Normalize(context.ToolCallId), StringComparison.Ordinal);
+    }
+
     private static int GetRequestScopedDenialCount(ToolCallContext context)
     {
         if (!context.Items.TryGetValue(DenialCountItemKey, out var value))
@@ -197,6 +227,9 @@ public sealed class ToolApprovalMiddleware : IToolCallMiddleware
         };
     }
 
+    private static string Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
+
     private static string BuildApprovalPendingResult(ToolApprovalRequest request) =>
         System.Text.Json.JsonSerializer.Serialize(new
         {
@@ -204,7 +237,6 @@ public sealed class ToolApprovalMiddleware : IToolCallMiddleware
             request_id = request.RequestId,
             tool_name = request.ToolName,
             tool_call_id = request.ToolCallId,
-            arguments = request.ArgumentsJson,
             message = "This tool requires user approval before execution. Execution is paused; " +
                       "the approval request will be submitted for review and the run resumes only " +
                       "after it is approved. Do not claim the tool has executed.",

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -2085,6 +2085,14 @@ public static class ScopeServiceEndpoints
                 Approved = request.Approved,
                 UserInput = request.UserInput,
                 Metadata = request.Metadata,
+                ToolApproval = request.ToolApproval == null
+                    ? null
+                    : new WorkflowToolApprovalResumeInput
+                    {
+                        ExecutionId = request.ToolApproval.ExecutionId ?? string.Empty,
+                        ToolCallId = request.ToolApproval.ToolCallId ?? string.Empty,
+                        ApprovalRequestId = request.ToolApproval.ApprovalRequestId ?? string.Empty,
+                    },
             },
             resumeService,
             ct);
@@ -3489,7 +3497,13 @@ const response = await fetch("{{invokePath}}", {
         bool Approved,
         string? UserInput = null,
         Dictionary<string, string>? Metadata = null,
-        string? ActorId = null);
+        string? ActorId = null,
+        WorkflowToolApprovalResumeHttpRequest? ToolApproval = null);
+
+    public sealed record WorkflowToolApprovalResumeHttpRequest(
+        string? ExecutionId,
+        string? ToolCallId,
+        string? ApprovalRequestId);
 
     public sealed record SignalScopeServiceRunHttpRequest(
         string? SignalName,

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -491,7 +491,14 @@ message WorkflowToolApprovalSuspension
   string tool_name = 2;
   string tool_call_id = 3;
   string approval_request_id = 4;
-  string arguments_json = 5;
+  reserved 5;
+  reserved "arguments_json";
+}
+message WorkflowToolApprovalResume
+{
+  string execution_id = 1;
+  string tool_call_id = 2;
+  string approval_request_id = 3;
 }
 message WorkflowResumedEvent
 {
@@ -502,6 +509,7 @@ message WorkflowResumedEvent
   map<string, string> metadata = 5;
   string edited_content = 6;
   string feedback = 7;
+  WorkflowToolApprovalResume tool_approval = 8;
 }
 message WorkflowHumanApprovalResolvedEvent
 {

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowRunControlModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowRunControlModels.cs
@@ -85,7 +85,13 @@ public sealed record WorkflowResumeCommand(
     IReadOnlyDictionary<string, string>? Metadata = null,
     string? EditedContent = null,
     string? Feedback = null,
-    string? CorrelationId = null) : WorkflowRunControlCommandBase(ActorId, RunId, CommandId, CorrelationId);
+    string? CorrelationId = null,
+    WorkflowToolApprovalResumeCommand? ToolApproval = null) : WorkflowRunControlCommandBase(ActorId, RunId, CommandId, CorrelationId);
+
+public sealed record WorkflowToolApprovalResumeCommand(
+    string ExecutionId,
+    string ToolCallId,
+    string ApprovalRequestId);
 
 public sealed record WorkflowSignalCommand(
     string ActorId,

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowResumeCommandEnvelopeFactory.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowResumeCommandEnvelopeFactory.cs
@@ -24,6 +24,15 @@ internal sealed class WorkflowResumeCommandEnvelopeFactory : ICommandEnvelopeFac
             Feedback = command.Feedback ?? string.Empty,
         };
         AppendMetadata(resumed.Metadata, command.Metadata);
+        if (command.ToolApproval != null)
+        {
+            resumed.ToolApproval = new WorkflowToolApprovalResume
+            {
+                ExecutionId = NormalizeRequired(command.ToolApproval.ExecutionId, nameof(command.ToolApproval.ExecutionId)),
+                ToolCallId = NormalizeRequired(command.ToolApproval.ToolCallId, nameof(command.ToolApproval.ToolCallId)),
+                ApprovalRequestId = NormalizeRequired(command.ToolApproval.ApprovalRequestId, nameof(command.ToolApproval.ApprovalRequestId)),
+            };
+        }
 
         return new EventEnvelope
         {

--- a/src/workflow/Aevatar.Workflow.Core/Modules/IWorkflowToolSource.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/IWorkflowToolSource.cs
@@ -11,11 +11,21 @@ public interface IWorkflowTool
 
 public sealed record WorkflowToolExecutionResult(
     string ResultJson,
-    WorkflowManagedHandoffOutcome? ManagedHandoff = null)
+    WorkflowManagedHandoffOutcome? ManagedHandoff = null,
+    WorkflowToolApprovalPendingOutcome? PendingApproval = null)
 {
     public static WorkflowToolExecutionResult Success(string resultJson) =>
         new(resultJson ?? string.Empty);
 }
+
+public sealed record WorkflowToolApprovalPendingOutcome(
+    string ApprovalRequestId,
+    string ToolName,
+    string ToolCallId,
+    string ArgumentsJson,
+    string ApprovalMode,
+    bool IsReadOnly,
+    bool IsDestructive);
 
 public sealed record WorkflowToolExecutionRequest(
     string ArgumentsJson,
@@ -25,7 +35,8 @@ public sealed record WorkflowToolExecutionRequest(
     string CallId,
     string ScopeId,
     WorkflowCallerCredential CallerCredential,
-    WorkflowToolRuntimeContext RuntimeContext)
+    WorkflowToolRuntimeContext RuntimeContext,
+    ToolApprovalGrant? ApprovalGrant = null)
 {
     public WorkflowToolExecutionRequest(
         string ArgumentsJson,
@@ -43,10 +54,16 @@ public sealed record WorkflowToolExecutionRequest(
             CallId,
             ScopeId,
             CallerCredential,
-            WorkflowToolRuntimeContext.Empty)
+            WorkflowToolRuntimeContext.Empty,
+            null)
     {
     }
 }
+
+public sealed record ToolApprovalGrant(
+    string ApprovalRequestId,
+    string ToolName,
+    string ToolCallId);
 
 public sealed record WorkflowToolRuntimeContext(
     string ParentActorId,

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
@@ -14,6 +14,8 @@ namespace Aevatar.Workflow.Core.Modules;
 /// <summary>工具调用模块。处理 type=tool_call 的步骤。</summary>
 public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
 {
+    private const string ModuleStateKey = "tool_call";
+
     private readonly IEnumerable<IWorkflowToolSource> _toolSources;
     private readonly ILogger<ToolCallModule> _logger;
     private volatile Lazy<Task<IReadOnlyDictionary<string, IWorkflowTool>>>? _toolIndex;
@@ -31,13 +33,20 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
 
     /// <inheritdoc />
     public bool CanHandle(EventEnvelope envelope) =>
-        envelope.Payload?.Is(StepRequestEvent.Descriptor) == true;
+        envelope.Payload?.Is(StepRequestEvent.Descriptor) == true ||
+        envelope.Payload?.Is(WorkflowResumedEvent.Descriptor) == true;
 
     /// <inheritdoc />
     public async Task HandleAsync(EventEnvelope envelope, IWorkflowExecutionContext ctx, CancellationToken ct)
     {
         var payload = envelope.Payload;
         if (payload == null) return;
+
+        if (payload.Is(WorkflowResumedEvent.Descriptor))
+        {
+            await HandleResumeAsync(payload.Unpack<WorkflowResumedEvent>(), ctx, ct);
+            return;
+        }
 
         var request = payload.Unpack<StepRequestEvent>();
         if (request.StepType != "tool_call") return;
@@ -80,6 +89,11 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
         try
         {
             var result = await ExecuteToolAsync(tool, argumentsJson, request, callId, ctx, ct);
+            if (result.PendingApproval != null)
+            {
+                await SuspendForApprovalAsync(ctx, request, toolName, callId, result.PendingApproval, ct);
+                return;
+            }
 
             var completed = new WorkflowToolCallCompletedEvent
             {
@@ -119,7 +133,8 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
         StepRequestEvent request,
         string callId,
         IWorkflowExecutionContext ctx,
-        CancellationToken ct)
+        CancellationToken ct,
+        ToolApprovalGrant? approvalGrant = null)
     {
         var callerCredential = WorkflowRunExecutionContextStateAccess.TryGetCallerCredential(ctx, out var credential)
             ? credential
@@ -138,8 +153,235 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
                 CallId: callId,
                 ScopeId: ctx.ScopeId ?? string.Empty,
                 CallerCredential: callerCredential,
-                RuntimeContext: runtimeContext),
+                RuntimeContext: runtimeContext,
+                ApprovalGrant: approvalGrant),
             ct);
+    }
+
+    private async Task HandleResumeAsync(
+        WorkflowResumedEvent resumed,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        if (resumed.ToolApproval == null)
+            return;
+
+        var state = WorkflowExecutionStateAccess.Load<ToolCallModuleState>(ctx, ModuleStateKey);
+        if (!TryResolvePending(state, resumed, out var pendingKey, out var pending))
+            return;
+
+        if (!resumed.Approved)
+        {
+            state.PendingApprovals.Remove(pendingKey);
+            await SaveStateAsync(state, ctx, ct);
+            await PublishToolFailureAsync(
+                ctx,
+                pending,
+                BuildRejectedApprovalError(resumed),
+                ct);
+            return;
+        }
+
+        var toolIndex = await GetOrDiscoverAsync(ct);
+        if (!toolIndex.TryGetValue(pending.ToolName, out var tool))
+        {
+            state.PendingApprovals.Remove(pendingKey);
+            await SaveStateAsync(state, ctx, ct);
+            await PublishToolFailureAsync(
+                ctx,
+                pending,
+                "tool not found or no tool sources configured",
+                ct);
+            return;
+        }
+
+        try
+        {
+            state.PendingApprovals.Remove(pendingKey);
+            await SaveStateAsync(state, ctx, ct);
+
+            var result = await ExecuteToolAsync(
+                tool,
+                pending.ArgumentsJson,
+                ToStepRequest(pending),
+                pending.ToolCallId,
+                ctx,
+                ct,
+                new ToolApprovalGrant(
+                    pending.ApprovalRequestId,
+                    pending.ToolName,
+                    pending.ToolCallId));
+
+            if (result.PendingApproval != null)
+            {
+                await SuspendForApprovalAsync(
+                    ctx,
+                    ToStepRequest(pending),
+                    pending.ToolName,
+                    pending.ToolCallId,
+                    result.PendingApproval,
+                    ct);
+                return;
+            }
+
+            await PublishToolSuccessAsync(ctx, pending, result, ct);
+        }
+        catch (Exception ex)
+        {
+            await PublishToolFailureAsync(ctx, pending, ex.Message, ct);
+            ctx.Logger.LogWarning(
+                ex,
+                "ToolCall: step={StepId} tool={Tool} approved replay failed",
+                pending.StepId,
+                pending.ToolName);
+        }
+    }
+
+    private static bool TryResolvePending(
+        ToolCallModuleState state,
+        WorkflowResumedEvent resumed,
+        out string pendingKey,
+        out PendingToolCallApprovalState pending)
+    {
+        pendingKey = BuildPendingKey(
+            resumed.RunId,
+            resumed.StepId,
+            resumed.ToolApproval?.ExecutionId,
+            resumed.ToolApproval?.ToolCallId,
+            resumed.ToolApproval?.ApprovalRequestId);
+        pending = new PendingToolCallApprovalState();
+        if (string.IsNullOrWhiteSpace(resumed.RunId) ||
+            string.IsNullOrWhiteSpace(resumed.StepId) ||
+            resumed.ToolApproval == null ||
+            string.IsNullOrWhiteSpace(resumed.ToolApproval.ExecutionId) ||
+            string.IsNullOrWhiteSpace(resumed.ToolApproval.ToolCallId) ||
+            string.IsNullOrWhiteSpace(resumed.ToolApproval.ApprovalRequestId))
+        {
+            return false;
+        }
+
+        if (!state.PendingApprovals.TryGetValue(pendingKey, out var resolvedPending))
+            return false;
+
+        pending = resolvedPending;
+        return string.Equals(pending.RunId, NormalizeRequired(resumed.RunId), StringComparison.Ordinal) &&
+               string.Equals(pending.StepId, NormalizeRequired(resumed.StepId), StringComparison.Ordinal) &&
+               string.Equals(pending.ExecutionId, NormalizeRequired(resumed.ToolApproval.ExecutionId), StringComparison.Ordinal) &&
+               string.Equals(pending.ToolCallId, NormalizeRequired(resumed.ToolApproval.ToolCallId), StringComparison.Ordinal) &&
+               string.Equals(pending.ApprovalRequestId, NormalizeRequired(resumed.ToolApproval.ApprovalRequestId), StringComparison.Ordinal);
+    }
+
+    private static async Task SuspendForApprovalAsync(
+        IWorkflowExecutionContext ctx,
+        StepRequestEvent request,
+        string toolName,
+        string callId,
+        WorkflowToolApprovalPendingOutcome pending,
+        CancellationToken ct)
+    {
+        var state = WorkflowExecutionStateAccess.Load<ToolCallModuleState>(ctx, ModuleStateKey);
+        var pendingState = new PendingToolCallApprovalState
+        {
+            RunId = NormalizeRequired(request.RunId),
+            StepId = NormalizeRequired(request.StepId),
+            ExecutionId = NormalizeRequired(request.ExecutionId),
+            ToolName = NormalizeRequired(toolName),
+            ToolCallId = NormalizeRequired(callId),
+            ApprovalRequestId = NormalizeRequired(pending.ApprovalRequestId),
+            ArgumentsJson = pending.ArgumentsJson ?? string.Empty,
+        };
+        state.PendingApprovals[BuildPendingKey(pendingState)] = pendingState;
+        await SaveStateAsync(state, ctx, ct);
+
+        await ctx.PublishAsync(new WorkflowSuspendedEvent
+        {
+            RunId = pendingState.RunId,
+            StepId = pendingState.StepId,
+            SuspensionType = "tool_approval",
+            Prompt = $"Approve tool '{pendingState.ToolName}' execution?",
+            ToolApproval = new WorkflowToolApprovalSuspension
+            {
+                ExecutionId = pendingState.ExecutionId,
+                ToolName = pendingState.ToolName,
+                ToolCallId = pendingState.ToolCallId,
+                ApprovalRequestId = pendingState.ApprovalRequestId,
+            },
+        }, TopologyAudience.ParentAndChildren, ct);
+    }
+
+    private static Task PublishToolSuccessAsync(
+        IWorkflowExecutionContext ctx,
+        PendingToolCallApprovalState pending,
+        WorkflowToolExecutionResult result,
+        CancellationToken ct)
+    {
+        var completed = new WorkflowToolCallCompletedEvent
+        {
+            CallId = pending.ToolCallId,
+            Success = true,
+            ResultJson = result.ResultJson,
+            RunId = pending.RunId,
+            StepId = pending.StepId,
+        };
+        if (result.ManagedHandoff != null)
+            completed.ManagedHandoff = result.ManagedHandoff.Clone();
+
+        return PublishToolSuccessAsync(ctx, pending, completed, result, ct);
+    }
+
+    private static async Task PublishToolSuccessAsync(
+        IWorkflowExecutionContext ctx,
+        PendingToolCallApprovalState pending,
+        WorkflowToolCallCompletedEvent completed,
+        WorkflowToolExecutionResult result,
+        CancellationToken ct)
+    {
+        await ctx.PublishAsync(completed, TopologyAudience.Self, ct);
+
+        if (result.ManagedHandoff != null)
+            return;
+
+        await ctx.PublishAsync(new StepCompletedEvent
+        {
+            StepId = pending.StepId,
+            RunId = pending.RunId,
+            ExecutionId = pending.ExecutionId,
+            Success = true,
+            Output = result.ResultJson,
+        }, TopologyAudience.Self, ct);
+    }
+
+    private static Task PublishToolFailureAsync(
+        IWorkflowExecutionContext ctx,
+        PendingToolCallApprovalState pending,
+        string error,
+        CancellationToken ct) =>
+        PublishToolFailureAsync(
+            ctx,
+            ToStepRequest(pending),
+            pending.ToolName,
+            error,
+            ct);
+
+    private static StepRequestEvent ToStepRequest(PendingToolCallApprovalState pending) =>
+        new()
+        {
+            StepId = pending.StepId,
+            StepType = "tool_call",
+            RunId = pending.RunId,
+            ExecutionId = pending.ExecutionId,
+            Input = pending.ArgumentsJson,
+            Parameters = { ["tool"] = pending.ToolName },
+        };
+
+    private static string BuildRejectedApprovalError(WorkflowResumedEvent resumed)
+    {
+        var feedback = Normalize(resumed.Feedback)
+                       ?? Normalize(resumed.UserInput)
+                       ?? Normalize(resumed.EditedContent);
+        return feedback == null
+            ? "approval rejected"
+            : $"approval rejected: {feedback}";
     }
 
     private static string ResolveArgumentsJson(StepRequestEvent request)
@@ -171,6 +413,36 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
 
     private static string? Normalize(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string NormalizeRequired(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
+
+    private static string BuildPendingKey(PendingToolCallApprovalState pending) =>
+        BuildPendingKey(
+            pending.RunId,
+            pending.StepId,
+            pending.ExecutionId,
+            pending.ToolCallId,
+            pending.ApprovalRequestId);
+
+    private static string BuildPendingKey(
+        string? runId,
+        string? stepId,
+        string? executionId,
+        string? toolCallId,
+        string? approvalRequestId) =>
+        $"{NormalizeRequired(runId)}:{NormalizeRequired(stepId)}:{NormalizeRequired(executionId)}:{NormalizeRequired(toolCallId)}:{NormalizeRequired(approvalRequestId)}";
+
+    private static Task SaveStateAsync(
+        ToolCallModuleState state,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        if (state.PendingApprovals.Count == 0)
+            return WorkflowExecutionStateAccess.ClearAsync(ctx, ModuleStateKey, ct);
+
+        return WorkflowExecutionStateAccess.SaveAsync(ctx, ModuleStateKey, state, ct);
+    }
 
     private Task<IReadOnlyDictionary<string, IWorkflowTool>> GetOrDiscoverAsync(CancellationToken ct)
     {

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatCapabilityModels.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatCapabilityModels.cs
@@ -163,6 +163,7 @@ public sealed record ChatInputFileRef
     public string? OwnerScopeId { get; init; }
 }
 
+[JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
 public sealed record WorkflowResumeInput
 {
     public required string ActorId { get; init; }
@@ -174,6 +175,15 @@ public sealed record WorkflowResumeInput
     public string? EditedContent { get; init; }
     public string? Feedback { get; init; }
     public IDictionary<string, string>? Metadata { get; init; }
+    public WorkflowToolApprovalResumeInput? ToolApproval { get; init; }
+}
+
+[JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
+public sealed record WorkflowToolApprovalResumeInput
+{
+    public required string ExecutionId { get; init; }
+    public required string ToolCallId { get; init; }
+    public required string ApprovalRequestId { get; init; }
 }
 
 public sealed record WorkflowSignalInput

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
@@ -226,7 +226,8 @@ public static class WorkflowCapabilityEndpoints
                     input.UserInput,
                     NormalizeMetadata(input.Metadata),
                     input.EditedContent,
-                    input.Feedback),
+                    input.Feedback,
+                    ToolApproval: ToToolApprovalResumeCommand(input.ToolApproval)),
                 ct);
             if (!dispatch.Succeeded || dispatch.Receipt == null)
             {
@@ -478,6 +479,27 @@ public static class WorkflowCapabilityEndpoints
                 }),
             },
         };
+
+    private static WorkflowToolApprovalResumeCommand? ToToolApprovalResumeCommand(
+        WorkflowToolApprovalResumeInput? input)
+    {
+        if (input == null)
+            return null;
+
+        return new WorkflowToolApprovalResumeCommand(
+            NormalizeRequired(input.ExecutionId, nameof(input.ExecutionId)),
+            NormalizeRequired(input.ToolCallId, nameof(input.ToolCallId)),
+            NormalizeRequired(input.ApprovalRequestId, nameof(input.ApprovalRequestId)));
+    }
+
+    private static string NormalizeRequired(string? value, string name)
+    {
+        var normalized = NormalizeOptional(value);
+        if (normalized == null)
+            throw new ArgumentException("Value is required.", name);
+
+        return normalized;
+    }
 
     private static IResult MapRunControlDispatchFailure(
         WorkflowRunControlStartError error,

--- a/src/workflow/Aevatar.Workflow.Integration.AI/AgentWorkflowToolSourceAdapter.cs
+++ b/src/workflow/Aevatar.Workflow.Integration.AI/AgentWorkflowToolSourceAdapter.cs
@@ -77,6 +77,12 @@ public sealed class AgentWorkflowToolSourceAdapter(
                 ToolCallId = Normalize(request.CallId) ?? string.Empty,
                 ArgumentsJson = request.ArgumentsJson,
                 CancellationToken = ct,
+                ApprovalGrant = request.ApprovalGrant == null
+                    ? null
+                    : new Aevatar.AI.Abstractions.Middleware.ToolApprovalGrant(
+                        request.ApprovalGrant.ApprovalRequestId,
+                        request.ApprovalGrant.ToolName,
+                        request.ApprovalGrant.ToolCallId),
             };
 
             await MiddlewarePipeline.RunToolCallAsync(_toolMiddlewares, toolCallContext, async () =>
@@ -86,6 +92,15 @@ public sealed class AgentWorkflowToolSourceAdapter(
 
                 toolCallContext.Result = await _tool.ExecuteAsync(toolCallContext.ArgumentsJson, ct).ConfigureAwait(false);
             }).ConfigureAwait(false);
+
+            if (toolCallContext.Terminate &&
+                toolCallContext.TerminationKind == ToolCallTerminationKind.ApprovalPending &&
+                toolCallContext.PendingApproval != null)
+            {
+                return new WorkflowToolExecutionResult(
+                    string.Empty,
+                    PendingApproval: ToWorkflowToolApprovalPendingOutcome(toolCallContext.PendingApproval));
+            }
 
             if (toolCallContext.Terminate)
                 throw new InvalidOperationException(FormatMiddlewareTermination(toolCallContext));
@@ -98,6 +113,17 @@ public sealed class AgentWorkflowToolSourceAdapter(
                 resultJson,
                 ToWorkflowManagedHandoffOutcome(receipt?.ManagedWorkflowHandoff));
         }
+
+        private static WorkflowToolApprovalPendingOutcome ToWorkflowToolApprovalPendingOutcome(
+            ToolApprovalPendingContext pending) =>
+            new(
+                pending.ApprovalRequestId,
+                pending.ToolName,
+                pending.ToolCallId,
+                pending.ArgumentsJson,
+                pending.ApprovalMode.ToString(),
+                pending.IsReadOnly,
+                pending.IsDestructive);
 
         private static string? Normalize(string? value) =>
             string.IsNullOrWhiteSpace(value) ? null : value.Trim();

--- a/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/EventEnvelopeToWorkflowRunEventMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/EventEnvelopeToWorkflowRunEventMapper.cs
@@ -657,7 +657,6 @@ public sealed class WorkflowSuspendedRunEventEnvelopeMappingHandler : IWorkflowR
                             ToolName = evt.ToolApproval?.ToolName ?? string.Empty,
                             ToolCallId = evt.ToolApproval?.ToolCallId ?? string.Empty,
                             ApprovalRequestId = evt.ToolApproval?.ApprovalRequestId ?? string.Empty,
-                            ArgumentsJson = evt.ToolApproval?.ArgumentsJson ?? string.Empty,
                         }),
                     },
                 },

--- a/src/workflow/Aevatar.Workflow.Sdk/AevatarWorkflowClient.cs
+++ b/src/workflow/Aevatar.Workflow.Sdk/AevatarWorkflowClient.cs
@@ -107,6 +107,7 @@ public sealed class AevatarWorkflowClient : IAevatarWorkflowClient
                 editedContent = NormalizeOptional(request.EditedContent),
                 feedback = NormalizeOptional(request.Feedback),
                 metadata = request.Metadata,
+                toolApproval = ToToolApprovalPayload(request.ToolApproval),
             },
             cancellationToken).ConfigureAwait(false);
     }
@@ -413,5 +414,27 @@ public sealed class AevatarWorkflowClient : IAevatarWorkflowClient
     {
         var normalized = value?.Trim();
         return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
+    private static object? ToToolApprovalPayload(WorkflowToolApprovalResumeRequest? request)
+    {
+        if (request == null)
+            return null;
+
+        return new
+        {
+            executionId = NormalizeRequired(request.ExecutionId, nameof(request.ExecutionId)),
+            toolCallId = NormalizeRequired(request.ToolCallId, nameof(request.ToolCallId)),
+            approvalRequestId = NormalizeRequired(request.ApprovalRequestId, nameof(request.ApprovalRequestId)),
+        };
+    }
+
+    private static string NormalizeRequired(string? value, string fieldName)
+    {
+        var normalized = NormalizeOptional(value);
+        if (normalized == null)
+            throw AevatarWorkflowException.InvalidRequest($"Parameter '{fieldName}' is required.");
+
+        return normalized;
     }
 }

--- a/src/workflow/Aevatar.Workflow.Sdk/Contracts/WorkflowContracts.cs
+++ b/src/workflow/Aevatar.Workflow.Sdk/Contracts/WorkflowContracts.cs
@@ -62,6 +62,14 @@ public sealed record WorkflowResumeRequest
     public string? EditedContent { get; init; }
     public string? Feedback { get; init; }
     public IDictionary<string, string>? Metadata { get; init; }
+    public WorkflowToolApprovalResumeRequest? ToolApproval { get; init; }
+}
+
+public sealed record WorkflowToolApprovalResumeRequest
+{
+    public required string ExecutionId { get; init; }
+    public required string ToolCallId { get; init; }
+    public required string ApprovalRequestId { get; init; }
 }
 
 public sealed record WorkflowSignalRequest

--- a/src/workflow/Aevatar.Workflow.Sdk/Session/RunSessionTracker.cs
+++ b/src/workflow/Aevatar.Workflow.Sdk/Session/RunSessionTracker.cs
@@ -12,6 +12,7 @@ public sealed record RunSessionSnapshot
     public string? RunId { get; init; }
     public string? StepId { get; init; }
     public string? SuspensionType { get; init; }
+    public WorkflowToolApprovalResumeRequest? ToolApproval { get; init; }
     public string? LastSignalName { get; init; }
 
     public bool CanResume =>
@@ -25,12 +26,15 @@ public sealed record RunSessionSnapshot
 
 public sealed class RunSessionTracker
 {
+    private const string ToolApprovalPendingEventName = "aevatar.tool_approval.pending";
+
     private string? _actorId;
     private string? _workflowName;
     private string? _commandId;
     private string? _runId;
     private string? _stepId;
     private string? _suspensionType;
+    private WorkflowToolApprovalResumeRequest? _toolApproval;
     private string? _lastSignalName;
 
     public RunSessionSnapshot Snapshot => new()
@@ -41,6 +45,7 @@ public sealed class RunSessionTracker
         RunId = _runId,
         StepId = _stepId,
         SuspensionType = _suspensionType,
+        ToolApproval = _toolApproval,
         LastSignalName = _lastSignalName,
     };
 
@@ -97,6 +102,7 @@ public sealed class RunSessionTracker
             // Refactor (issue1326): Old pattern: Resume requests inherited the tracked start-run command id from the session. New principle: Resume control commands use a fresh server id unless the caller supplies an explicit id.
             CommandId = commandId,
             Metadata = metadata,
+            ToolApproval = _toolApproval,
         };
     }
 
@@ -163,15 +169,56 @@ public sealed class RunSessionTracker
             _runId = humanInput.RunId ?? _runId;
             _stepId = humanInput.StepId ?? _stepId;
             _suspensionType = humanInput.SuspensionType ?? _suspensionType;
+            _toolApproval = null;
             return;
         }
 
+        if (TryParseToolApprovalRequest(frame, out var toolApproval))
+        {
+            _runId = toolApproval.Payload.RunId ?? _runId;
+            _stepId = toolApproval.Payload.StepId ?? _stepId;
+            _suspensionType = "tool_approval";
+            _toolApproval = toolApproval.Resume;
+            return;
+        }
+
+        TrackSignalFrame(frame);
+    }
+
+    private static bool TryParseToolApprovalRequest(
+        WorkflowRunEventEnvelope frame,
+        out TrackedToolApprovalRequest toolApproval)
+    {
+        var custom = frame.Custom;
+        if (frame.EventCase != WorkflowRunEventEnvelope.EventOneofCase.Custom ||
+            custom == null ||
+            !string.Equals(custom.Name, ToolApprovalPendingEventName, StringComparison.Ordinal) ||
+            custom.Payload?.Is(WorkflowToolApprovalSuspensionCustomPayload.Descriptor) != true)
+        {
+            toolApproval = default!;
+            return false;
+        }
+
+        var payload = custom.Payload.Unpack<WorkflowToolApprovalSuspensionCustomPayload>();
+        toolApproval = new TrackedToolApprovalRequest(
+            payload,
+            new WorkflowToolApprovalResumeRequest
+            {
+                ExecutionId = payload.ExecutionId,
+                ToolCallId = payload.ToolCallId,
+                ApprovalRequestId = payload.ApprovalRequestId,
+            });
+        return true;
+    }
+
+    private bool TrackSignalFrame(WorkflowRunEventEnvelope frame)
+    {
         if (WorkflowCustomEventParser.TryParseWaitingSignal(frame, out var waitingSignal))
         {
             _runId = waitingSignal.RunId ?? _runId;
             _stepId = waitingSignal.StepId ?? _stepId;
             _lastSignalName = waitingSignal.SignalName ?? _lastSignalName;
-            return;
+            return true;
         }
 
         if (WorkflowCustomEventParser.TryParseSignalBuffered(frame, out var bufferedSignal))
@@ -179,8 +226,10 @@ public sealed class RunSessionTracker
             _runId = bufferedSignal.RunId ?? _runId;
             _stepId = bufferedSignal.StepId ?? _stepId;
             _lastSignalName = bufferedSignal.SignalName ?? _lastSignalName;
-            return;
+            return true;
         }
+
+        return false;
     }
 
     private void EnsureResumeContext()
@@ -203,4 +252,8 @@ public sealed class RunSessionTracker
         if (string.IsNullOrWhiteSpace(value))
             throw AevatarWorkflowException.InvalidRequest($"Run session is missing '{field}'.");
     }
+
+    private sealed record TrackedToolApprovalRequest(
+        WorkflowToolApprovalSuspensionCustomPayload Payload,
+        WorkflowToolApprovalResumeRequest Resume);
 }

--- a/test/Aevatar.AI.Core.Tests/Middleware/ToolApprovalMiddlewareTests.cs
+++ b/test/Aevatar.AI.Core.Tests/Middleware/ToolApprovalMiddlewareTests.cs
@@ -342,6 +342,79 @@ public class ToolApprovalMiddlewareTests
     }
 
     [Fact]
+    public async Task MatchingToolApprovalGrant_ShouldBypassApprovalAndExecuteNext()
+    {
+        var handler = new ScriptedApprovalHandler(ToolApprovalResult.Denied("should-not-run"));
+        var middleware = new ToolApprovalMiddleware(handler);
+        var ctx = NewContext("danger", "tc-grant-1");
+        ctx.ApprovalGrant = new ToolApprovalGrant(
+            ApprovalRequestId: "approval-1",
+            ToolName: "danger",
+            ToolCallId: "tc-grant-1");
+
+        var nextExecuted = false;
+        await middleware.InvokeAsync(ctx, () =>
+        {
+            nextExecuted = true;
+            return Task.CompletedTask;
+        });
+
+        nextExecuted.Should().BeTrue();
+        handler.Requests.Should().BeEmpty();
+        ctx.Terminate.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task MismatchedToolApprovalGrant_ShouldFailClosedWithoutCallingHandlerOrTool()
+    {
+        var handler = new ScriptedApprovalHandler(ToolApprovalResult.Approved());
+        var middleware = new ToolApprovalMiddleware(handler);
+        var ctx = NewContext("danger", "tc-grant-2");
+        ctx.ApprovalGrant = new ToolApprovalGrant(
+            ApprovalRequestId: "approval-1",
+            ToolName: "other_tool",
+            ToolCallId: "tc-grant-2");
+
+        var nextExecuted = false;
+        await middleware.InvokeAsync(ctx, () =>
+        {
+            nextExecuted = true;
+            return Task.CompletedTask;
+        });
+
+        nextExecuted.Should().BeFalse();
+        handler.Requests.Should().BeEmpty();
+        ctx.Terminate.Should().BeTrue();
+        ctx.TerminationKind.Should().Be(ToolCallTerminationKind.ApprovalDenied);
+        ctx.Result.Should().Contain("approval grant does not match");
+    }
+
+    [Fact]
+    public async Task IncompleteToolApprovalGrant_ShouldFailClosedWithoutCallingHandlerOrTool()
+    {
+        var handler = new ScriptedApprovalHandler(ToolApprovalResult.Approved());
+        var middleware = new ToolApprovalMiddleware(handler);
+        var ctx = NewContext("danger", "tc-grant-3");
+        ctx.ApprovalGrant = new ToolApprovalGrant(
+            ApprovalRequestId: " ",
+            ToolName: "danger",
+            ToolCallId: "tc-grant-3");
+
+        var nextExecuted = false;
+        await middleware.InvokeAsync(ctx, () =>
+        {
+            nextExecuted = true;
+            return Task.CompletedTask;
+        });
+
+        nextExecuted.Should().BeFalse();
+        handler.Requests.Should().BeEmpty();
+        ctx.Terminate.Should().BeTrue();
+        ctx.TerminationKind.Should().Be(ToolCallTerminationKind.ApprovalDenied);
+        ctx.Result.Should().Contain("approval grant does not match");
+    }
+
+    [Fact]
     public async Task RequestScopedDenialCountBlocksExecutionWithoutCallingHandler()
     {
         var handler = new ScriptedApprovalHandler(ToolApprovalResult.Approved());

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -2753,6 +2753,12 @@ public sealed class ScopeServiceEndpointsTests
             stepId = "approval-1",
             approved = true,
             userInput = "approved",
+            toolApproval = new
+            {
+                executionId = "exec-default-1",
+                toolCallId = "tool-call-default-1",
+                approvalRequestId = "approval-default-1",
+            },
         });
 
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
@@ -2761,6 +2767,10 @@ public sealed class ScopeServiceEndpointsTests
         host.ResumeDispatchService.LastCommand!.ActorId.Should().Be("run-actor-default-1");
         host.ResumeDispatchService.LastCommand.RunId.Should().Be("run-default-1");
         host.ResumeDispatchService.LastCommand.StepId.Should().Be("approval-1");
+        host.ResumeDispatchService.LastCommand.ToolApproval.Should().NotBeNull();
+        host.ResumeDispatchService.LastCommand.ToolApproval!.ExecutionId.Should().Be("exec-default-1");
+        host.ResumeDispatchService.LastCommand.ToolApproval.ToolCallId.Should().Be("tool-call-default-1");
+        host.ResumeDispatchService.LastCommand.ToolApproval.ApprovalRequestId.Should().Be("approval-default-1");
     }
 
     [Fact]
@@ -3400,6 +3410,12 @@ public sealed class ScopeServiceEndpointsTests
             approved = true,
             userInput = "approved",
             metadata = new Dictionary<string, string> { ["source"] = "test" },
+            toolApproval = new
+            {
+                executionId = "exec-1",
+                toolCallId = "tool-call-1",
+                approvalRequestId = "approval-1",
+            },
         });
 
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
@@ -3409,6 +3425,10 @@ public sealed class ScopeServiceEndpointsTests
         host.ResumeDispatchService.LastCommand.RunId.Should().Be("run-1");
         host.ResumeDispatchService.LastCommand.StepId.Should().Be("approval-1");
         host.ResumeDispatchService.LastCommand.Approved.Should().BeTrue();
+        host.ResumeDispatchService.LastCommand.ToolApproval.Should().NotBeNull();
+        host.ResumeDispatchService.LastCommand.ToolApproval!.ExecutionId.Should().Be("exec-1");
+        host.ResumeDispatchService.LastCommand.ToolApproval.ToolCallId.Should().Be("tool-call-1");
+        host.ResumeDispatchService.LastCommand.ToolApproval.ApprovalRequestId.Should().Be("approval-1");
     }
 
     [Fact]
@@ -3819,6 +3839,12 @@ public sealed class ScopeServiceEndpointsTests
         {
             stepId = "approval-1",
             approved = true,
+            toolApproval = new
+            {
+                executionId = "exec-member-1",
+                toolCallId = "tool-call-member-1",
+                approvalRequestId = "approval-member-1",
+            },
         });
 
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
@@ -3827,6 +3853,10 @@ public sealed class ScopeServiceEndpointsTests
         host.ResumeDispatchService.LastCommand!.ActorId.Should().Be("run-actor-member-resume-1");
         host.ResumeDispatchService.LastCommand.RunId.Should().Be("run-member-resume-1");
         host.ResumeDispatchService.LastCommand.StepId.Should().Be("approval-1");
+        host.ResumeDispatchService.LastCommand.ToolApproval.Should().NotBeNull();
+        host.ResumeDispatchService.LastCommand.ToolApproval!.ExecutionId.Should().Be("exec-member-1");
+        host.ResumeDispatchService.LastCommand.ToolApproval.ToolCallId.Should().Be("tool-call-member-1");
+        host.ResumeDispatchService.LastCommand.ToolApproval.ApprovalRequestId.Should().Be("approval-member-1");
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelAbstractionsProtoTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelAbstractionsProtoTests.cs
@@ -65,6 +65,18 @@ public sealed class ChannelAbstractionsProtoTests
                     SubmittedValue = "true",
                     SourceMessageId = "om_123",
                     ActionKind = ActionElementKind.FormSubmit,
+                    WorkflowResume = new WorkflowResumeActionPayload
+                    {
+                        ActorId = "workflow-actor-1",
+                        RunId = "run-1",
+                        StepId = "tool-step",
+                        ToolApproval = new WorkflowToolApprovalResumeActionPayload
+                        {
+                            ExecutionId = "exec-1",
+                            ToolCallId = "tool-call-1",
+                            ApprovalRequestId = "approval-1",
+                        },
+                    },
                     NyxIdApproval = new NyxIdApprovalActionPayload
                     {
                         RequestId = "nyx-approval-1",
@@ -129,6 +141,9 @@ public sealed class ChannelAbstractionsProtoTests
         parsed.ShouldBe(activity);
         parsed.Content.CardAction.ActionId.ShouldBe("approve");
         parsed.Content.CardAction.ActionKind.ShouldBe(ActionElementKind.FormSubmit);
+        parsed.Content.CardAction.WorkflowResume.ToolApproval.ExecutionId.ShouldBe("exec-1");
+        parsed.Content.CardAction.WorkflowResume.ToolApproval.ToolCallId.ShouldBe("tool-call-1");
+        parsed.Content.CardAction.WorkflowResume.ToolApproval.ApprovalRequestId.ShouldBe("approval-1");
         parsed.Content.CardAction.NyxIdApproval.RequestId.ShouldBe("nyx-approval-1");
         parsed.Content.CardAction.NyxIdApproval.Approved.ShouldBeTrue();
         parsed.Content.Actions[0].Kind.ShouldBe(ActionElementKind.Button);
@@ -145,6 +160,9 @@ public sealed class ChannelAbstractionsProtoTests
             .ShouldContain(nameof(CardActionSubmission));
         ChatActivityReflection.Descriptor.MessageTypes.Select(x => x.Name)
             .ShouldContain(nameof(NyxIdApprovalActionPayload));
+        ChatActivityReflection.Descriptor.MessageTypes.Select(x => x.Name)
+            .ShouldContain(nameof(WorkflowToolApprovalResumeActionPayload));
+        WorkflowResumeActionPayload.Descriptor.FindFieldByName("tool_approval")!.FieldNumber.ShouldBe(8);
         ActionElement.Descriptor.FindFieldByName("nyx_id_approval")!.FieldNumber.ShouldBe(13);
         CardActionSubmission.Descriptor.FindFieldByName("nyx_id_approval")!.FieldNumber.ShouldBe(9);
         ChatActivityReflection.Descriptor.MessageTypes.Select(x => x.Name)

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCardActionRoutingTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCardActionRoutingTests.cs
@@ -53,6 +53,49 @@ public sealed class ChannelCardActionRoutingTests
     }
 
     [Fact]
+    public void TryBuildWorkflowResumeCommand_should_preserve_nested_tool_approval_payload()
+    {
+        var inbound = new InboundMessage
+        {
+            Platform = "lark",
+            ConversationId = "oc_chat_1",
+            SenderId = "ou_user_1",
+            SenderName = string.Empty,
+            Text = "{}",
+            MessageId = "evt_card_tool_approval_1",
+            ChatType = "card_action",
+            CardAction = new CardActionSubmission
+            {
+                ActionKind = ActionElementKind.FormSubmit,
+                WorkflowResume = new WorkflowResumeActionPayload
+                {
+                    ActorId = "run-actor-1",
+                    RunId = "run-1",
+                    StepId = "tool-step",
+                    Approved = true,
+                    ToolApproval = new WorkflowToolApprovalResumeActionPayload
+                    {
+                        ExecutionId = "exec-1",
+                        ToolCallId = "tool-call-1",
+                        ApprovalRequestId = "approval-1",
+                    },
+                },
+            },
+        };
+
+        var matched = ChannelCardActionRouting.TryBuildWorkflowResumeCommand(inbound, out var command);
+
+        matched.Should().BeTrue();
+        command.Should().NotBeNull();
+        command!.ToolApproval.Should().NotBeNull();
+        command.ToolApproval!.ExecutionId.Should().Be("exec-1");
+        command.ToolApproval.ToolCallId.Should().Be("tool-call-1");
+        command.ToolApproval.ApprovalRequestId.Should().Be("approval-1");
+        command.Metadata.Should().NotContainKey("execution_id");
+        command.Metadata.Should().NotContainKey("approval_request_id");
+    }
+
+    [Fact]
     public void TryBuildWorkflowResumeCommand_should_reject_deprecated_literal_key_fallback()
     {
         var inbound = new InboundMessage

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlCommandTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlCommandTests.cs
@@ -146,6 +146,33 @@ public sealed class WorkflowRunControlCommandTests
     }
 
     [Fact]
+    public void ResumeEnvelopeFactory_ShouldPackNestedToolApprovalResume()
+    {
+        var factory = new WorkflowResumeCommandEnvelopeFactory();
+        var envelope = factory.CreateEnvelope(
+            new WorkflowResumeCommand(
+                "actor-1",
+                "run-1",
+                "tool-step",
+                "cmd-1",
+                true,
+                null,
+                ToolApproval: new WorkflowToolApprovalResumeCommand(
+                    ExecutionId: "exec-1",
+                    ToolCallId: "tool-call-1",
+                    ApprovalRequestId: "approval-1")),
+            new CommandContext("actor-1", "cmd-1", "corr-1", new Dictionary<string, string>()));
+
+        var resumed = envelope.Payload.Unpack<WorkflowResumedEvent>();
+
+        resumed.ToolApproval.Should().NotBeNull();
+        resumed.ToolApproval.ExecutionId.Should().Be("exec-1");
+        resumed.ToolApproval.ToolCallId.Should().Be("tool-call-1");
+        resumed.ToolApproval.ApprovalRequestId.Should().Be("approval-1");
+        resumed.Metadata.Should().BeEmpty();
+    }
+
+    [Fact]
     public void ResumeEnvelopeFactory_ShouldRejectBlankStepId()
     {
         var factory = new WorkflowResumeCommandEnvelopeFactory();

--- a/test/Aevatar.Workflow.Core.Tests/Modules/AgentWorkflowToolSourceAdapterTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/AgentWorkflowToolSourceAdapterTests.cs
@@ -96,7 +96,7 @@ public sealed class AgentWorkflowToolSourceAdapterTests
     }
 
     [Fact]
-    public async Task WorkflowTool_WhenApprovalPending_ShouldFailClosedWithoutReturningPendingPayload()
+    public async Task WorkflowTool_WhenApprovalPending_ShouldReturnTypedPendingOutcomeWithoutExecutingAgentTool()
     {
         var agentTool = new CapturingAgentTool(ToolApprovalMode.AlwaysRequire);
         var approvalHandler = new ScriptedApprovalHandler(ToolApprovalResult.Yielded("approval-1"));
@@ -105,22 +105,26 @@ public sealed class AgentWorkflowToolSourceAdapterTests
             approvalHandler: approvalHandler);
         var tool = (await adapter.GetToolsAsync(CancellationToken.None)).Single();
 
-        await FluentActions.Awaiting(() => tool.ExecuteAsync(
-                new WorkflowToolExecutionRequest(
-                    ArgumentsJson: "{}",
-                    RunId: "run-1",
-                    StepId: "step-1",
-                    ExecutionId: "exec-1",
-                    CallId: "call-1",
-                    ScopeId: "scope-1",
-                    CallerCredential: new WorkflowCallerCredential()),
-                CancellationToken.None))
-            .Should()
-            .ThrowAsync<InvalidOperationException>()
-            .WithMessage("*ApprovalPending*approval-1*");
+        var result = await tool.ExecuteAsync(
+            new WorkflowToolExecutionRequest(
+                ArgumentsJson: """{"danger":true}""",
+                RunId: "run-1",
+                StepId: "step-1",
+                ExecutionId: "exec-1",
+                CallId: "call-1",
+                ScopeId: "scope-1",
+                CallerCredential: new WorkflowCallerCredential()),
+            CancellationToken.None);
 
         agentTool.ExecuteCount.Should().Be(0);
         approvalHandler.Requests.Should().ContainSingle();
+        result.PendingApproval.Should().NotBeNull();
+        result.PendingApproval!.ApprovalRequestId.Should().Be(approvalHandler.Requests.Single().RequestId);
+        result.PendingApproval.ApprovalRequestId.Should().NotBeNullOrWhiteSpace();
+        result.PendingApproval.ToolName.Should().Be("capture_context");
+        result.PendingApproval.ToolCallId.Should().Be("call-1");
+        result.PendingApproval.ArgumentsJson.Should().Be("""{"danger":true}""");
+        result.ResultJson.Should().BeEmpty();
         AgentToolRequestContext.Current.Should().BeNull();
     }
 

--- a/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleApprovalTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleApprovalTests.cs
@@ -1,0 +1,380 @@
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Abstractions.Execution;
+using Aevatar.Workflow.Core.Execution;
+using Aevatar.Workflow.Core.Modules;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.Workflow.Core.Tests.Modules;
+
+public sealed class ToolCallModuleApprovalTests
+{
+    [Fact]
+    public async Task PendingApproval_ShouldPersistStateAndPublishSuspensionWithoutCompletion()
+    {
+        var pending = new WorkflowToolApprovalPendingOutcome(
+            ApprovalRequestId: "approval-1",
+            ToolName: "danger",
+            ToolCallId: "workflow:run-1:danger_step:exec-1",
+            ArgumentsJson: """{"danger":true}""",
+            ApprovalMode: "AlwaysRequire",
+            IsReadOnly: false,
+            IsDestructive: true);
+        var tool = new ScriptedWorkflowTool("danger", _ => new WorkflowToolExecutionResult(string.Empty, PendingApproval: pending));
+        var module = CreateModule(tool);
+        var ctx = new RecordingWorkflowContext();
+
+        await ExecuteToolCallAsync(module, ctx, tool.Name, "danger_step", """{"danger":true}""", "exec-1");
+
+        ctx.Published.Select(x => x.Event).OfType<WorkflowToolCallStartedEvent>().Should().ContainSingle();
+        ctx.Published.Select(x => x.Event).OfType<WorkflowToolCallCompletedEvent>().Should().BeEmpty();
+        ctx.Published.Select(x => x.Event).OfType<StepCompletedEvent>().Should().BeEmpty();
+        var suspended = ctx.Published.Select(x => x.Event).OfType<WorkflowSuspendedEvent>().Should().ContainSingle().Subject;
+        suspended.RunId.Should().Be("run-1");
+        suspended.StepId.Should().Be("danger_step");
+        suspended.SuspensionType.Should().Be("tool_approval");
+        suspended.ToolApproval.Should().NotBeNull();
+        suspended.ToolApproval.ExecutionId.Should().Be("exec-1");
+        suspended.ToolApproval.ToolName.Should().Be("danger");
+        suspended.ToolApproval.ToolCallId.Should().Be("workflow:run-1:danger_step:exec-1");
+        suspended.ToolApproval.ApprovalRequestId.Should().Be("approval-1");
+        var state = ctx.LoadState<ToolCallModuleState>("tool_call");
+        state.PendingApprovals.Should().ContainKey("run-1:danger_step:exec-1:workflow:run-1:danger_step:exec-1:approval-1");
+    }
+
+    [Fact]
+    public async Task ApprovedResume_ShouldReplayOriginalToolArgumentsWithTypedGrantAndClearPendingState()
+    {
+        var pending = new WorkflowToolApprovalPendingOutcome(
+            ApprovalRequestId: "approval-1",
+            ToolName: "danger",
+            ToolCallId: "workflow:run-1:danger_step:exec-1",
+            ArgumentsJson: """{"danger":true}""",
+            ApprovalMode: "AlwaysRequire",
+            IsReadOnly: false,
+            IsDestructive: true);
+        var tool = new ScriptedWorkflowTool(
+            "danger",
+            request => request.ApprovalGrant is null
+                ? new WorkflowToolExecutionResult(string.Empty, PendingApproval: pending)
+                : WorkflowToolExecutionResult.Success("""{"executed":true}"""));
+        var module = CreateModule(tool);
+        var ctx = new RecordingWorkflowContext();
+
+        await ExecuteToolCallAsync(module, ctx, tool.Name, "danger_step", """{"danger":true}""", "exec-1");
+        ctx.Published.Clear();
+
+        await module.HandleAsync(
+            Envelope(new WorkflowResumedEvent
+            {
+                RunId = "run-1",
+                StepId = "danger_step",
+                Approved = true,
+                ToolApproval = new WorkflowToolApprovalResume
+                {
+                    ExecutionId = "exec-1",
+                    ToolCallId = "workflow:run-1:danger_step:exec-1",
+                    ApprovalRequestId = "approval-1",
+                },
+            }),
+            ctx,
+            CancellationToken.None);
+
+        tool.Requests.Should().HaveCount(2);
+        tool.Requests[1].ArgumentsJson.Should().Be("""{"danger":true}""");
+        tool.Requests[1].ApprovalGrant.Should().NotBeNull();
+        var grant = tool.Requests[1].ApprovalGrant!;
+        grant.ApprovalRequestId.Should().Be("approval-1");
+        grant.ToolName.Should().Be("danger");
+        grant.ToolCallId.Should().Be("workflow:run-1:danger_step:exec-1");
+        ctx.Published.Select(x => x.Event).OfType<WorkflowToolCallCompletedEvent>().Single().Success.Should().BeTrue();
+        var completed = ctx.Published.Select(x => x.Event).OfType<StepCompletedEvent>().Single();
+        completed.Success.Should().BeTrue();
+        completed.Output.Should().Be("""{"executed":true}""");
+        ctx.LoadState<ToolCallModuleState>("tool_call").PendingApprovals.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RejectedResume_ShouldFailClosedAndClearPendingState()
+    {
+        var pending = new WorkflowToolApprovalPendingOutcome(
+            ApprovalRequestId: "approval-1",
+            ToolName: "danger",
+            ToolCallId: "workflow:run-1:danger_step:exec-1",
+            ArgumentsJson: """{"danger":true}""",
+            ApprovalMode: "AlwaysRequire",
+            IsReadOnly: false,
+            IsDestructive: true);
+        var tool = new ScriptedWorkflowTool("danger", _ => new WorkflowToolExecutionResult(string.Empty, PendingApproval: pending));
+        var module = CreateModule(tool);
+        var ctx = new RecordingWorkflowContext();
+
+        await ExecuteToolCallAsync(module, ctx, tool.Name, "danger_step", """{"danger":true}""", "exec-1");
+        ctx.Published.Clear();
+
+        await module.HandleAsync(
+            Envelope(new WorkflowResumedEvent
+            {
+                RunId = "run-1",
+                StepId = "danger_step",
+                Approved = false,
+                Feedback = "blocked",
+                ToolApproval = new WorkflowToolApprovalResume
+                {
+                    ExecutionId = "exec-1",
+                    ToolCallId = "workflow:run-1:danger_step:exec-1",
+                    ApprovalRequestId = "approval-1",
+                },
+            }),
+            ctx,
+            CancellationToken.None);
+
+        tool.Requests.Should().ContainSingle();
+        ctx.Published.Select(x => x.Event).OfType<WorkflowToolCallCompletedEvent>().Single().Success.Should().BeFalse();
+        var completed = ctx.Published.Select(x => x.Event).OfType<StepCompletedEvent>().Single();
+        completed.Success.Should().BeFalse();
+        completed.Error.Should().Contain("approval rejected");
+        completed.Error.Should().Contain("blocked");
+        ctx.LoadState<ToolCallModuleState>("tool_call").PendingApprovals.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task MismatchedResume_ShouldIgnoreWithoutClearingPendingState()
+    {
+        var pending = new WorkflowToolApprovalPendingOutcome(
+            ApprovalRequestId: "approval-1",
+            ToolName: "danger",
+            ToolCallId: "workflow:run-1:danger_step:exec-1",
+            ArgumentsJson: """{"danger":true}""",
+            ApprovalMode: "AlwaysRequire",
+            IsReadOnly: false,
+            IsDestructive: true);
+        var tool = new ScriptedWorkflowTool("danger", _ => new WorkflowToolExecutionResult(string.Empty, PendingApproval: pending));
+        var module = CreateModule(tool);
+        var ctx = new RecordingWorkflowContext();
+
+        await ExecuteToolCallAsync(module, ctx, tool.Name, "danger_step", """{"danger":true}""", "exec-1");
+        ctx.Published.Clear();
+
+        await module.HandleAsync(
+            Envelope(new WorkflowResumedEvent
+            {
+                RunId = "run-1",
+                StepId = "danger_step",
+                Approved = true,
+                ToolApproval = new WorkflowToolApprovalResume
+                {
+                    ExecutionId = "exec-1",
+                    ToolCallId = "workflow:run-1:danger_step:exec-1",
+                    ApprovalRequestId = "other-approval",
+                },
+            }),
+            ctx,
+            CancellationToken.None);
+
+        tool.Requests.Should().ContainSingle();
+        ctx.Published.Should().BeEmpty();
+        ctx.LoadState<ToolCallModuleState>("tool_call").PendingApprovals.Should().ContainSingle();
+    }
+
+    private static ToolCallModule CreateModule(IWorkflowTool tool) =>
+        new([new SingleToolSource(tool)], NullLogger<ToolCallModule>.Instance);
+
+    private static async Task ExecuteToolCallAsync(
+        ToolCallModule module,
+        RecordingWorkflowContext ctx,
+        string toolName,
+        string stepId,
+        string input,
+        string executionId)
+    {
+        await module.HandleAsync(
+            Envelope(new StepRequestEvent
+            {
+                StepId = stepId,
+                StepType = "tool_call",
+                RunId = ctx.RunId,
+                ExecutionId = executionId,
+                Input = input,
+                Parameters = { ["tool"] = toolName },
+            }),
+            ctx,
+            CancellationToken.None);
+    }
+
+    private static EventEnvelope Envelope(IMessage evt) =>
+        new()
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(evt),
+            Route = EnvelopeRouteSemantics.CreateTopologyPublication("test", TopologyAudience.Self),
+        };
+
+    private sealed class ScriptedWorkflowTool(
+        string name,
+        Func<WorkflowToolExecutionRequest, WorkflowToolExecutionResult> execute) : IWorkflowTool
+    {
+        public string Name { get; } = name;
+
+        public List<WorkflowToolExecutionRequest> Requests { get; } = [];
+
+        public Task<WorkflowToolExecutionResult> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Requests.Add(request);
+            return Task.FromResult(execute(request));
+        }
+    }
+
+    private sealed class SingleToolSource(IWorkflowTool tool) : IWorkflowToolSource
+    {
+        public Task<IReadOnlyList<IWorkflowTool>> GetToolsAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult<IReadOnlyList<IWorkflowTool>>([tool]);
+        }
+    }
+
+    private sealed class RecordingWorkflowContext
+        : IWorkflowExecutionContext, IWorkflowExecutionRuntimeContextAccessor, IWorkflowExecutionStateHost
+    {
+        private readonly Dictionary<string, Any> _states = new(StringComparer.Ordinal);
+
+        public EventEnvelope InboundEnvelope { get; } = new()
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+        };
+
+        public string AgentId => "agent-1";
+        public string RunId => "run-1";
+        public string ScopeId => "scope-1";
+        public IServiceProvider Services { get; } = new EmptyServiceProvider();
+        public ILogger Logger { get; } = NullLogger.Instance;
+        public WorkflowExecutionRuntimeContext RuntimeContext { get; } = new();
+        public WorkflowRunExecutionContextState ExecutionContextState { get; } = new();
+        public WorkflowRunExecutionContextState ExecutionContextSnapshot => ExecutionContextState.Clone();
+        public List<(IMessage Event, TopologyAudience Direction)> Published { get; } = [];
+
+        public TState LoadState<TState>(string scopeKey)
+            where TState : class, IMessage<TState>, new()
+        {
+            if (!_states.TryGetValue(scopeKey, out var packed) || !packed.Is(new TState().Descriptor))
+                return new TState();
+
+            return packed.Unpack<TState>() ?? new TState();
+        }
+
+        public IReadOnlyList<KeyValuePair<string, TState>> LoadStates<TState>(string scopeKeyPrefix = "")
+            where TState : class, IMessage<TState>, new() =>
+            _states
+                .Where(x => string.IsNullOrEmpty(scopeKeyPrefix) || x.Key.StartsWith(scopeKeyPrefix, StringComparison.Ordinal))
+                .Where(x => x.Value.Is(new TState().Descriptor))
+                .Select(x => new KeyValuePair<string, TState>(x.Key, x.Value.Unpack<TState>() ?? new TState()))
+                .ToList();
+
+        public Task SaveStateAsync<TState>(string scopeKey, TState state, CancellationToken ct = default)
+            where TState : class, IMessage<TState>
+        {
+            ct.ThrowIfCancellationRequested();
+            _states[scopeKey] = Any.Pack(state);
+            return Task.CompletedTask;
+        }
+
+        public Task ClearStateAsync(string scopeKey, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            _states.Remove(scopeKey);
+            return Task.CompletedTask;
+        }
+
+        public Any? GetExecutionState(string scopeKey) => _states.GetValueOrDefault(scopeKey);
+
+        public IReadOnlyList<KeyValuePair<string, Any>> GetExecutionStates() => _states.ToList();
+
+        public Task UpsertExecutionStateAsync(string scopeKey, Any state, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            _states[scopeKey] = state;
+            return Task.CompletedTask;
+        }
+
+        public Task ClearExecutionStateAsync(string scopeKey, CancellationToken ct = default) =>
+            ClearStateAsync(scopeKey, ct);
+
+        public Task UpdateExecutionContextAsync(
+            WorkflowRunExecutionContextDelta delta,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            _ = delta;
+            return Task.CompletedTask;
+        }
+
+        public Task ClearExecutionContextAsync(CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public Task PublishAsync<TEvent>(
+            TEvent evt,
+            TopologyAudience direction = TopologyAudience.Children,
+            CancellationToken ct = default,
+            EventEnvelopePublishOptions? options = null)
+            where TEvent : IMessage
+        {
+            ct.ThrowIfCancellationRequested();
+            _ = options;
+            Published.Add((evt, direction));
+            return Task.CompletedTask;
+        }
+
+        public Task SendToAsync<TEvent>(
+            string targetActorId,
+            TEvent evt,
+            CancellationToken ct = default,
+            EventEnvelopePublishOptions? options = null)
+            where TEvent : IMessage
+        {
+            ct.ThrowIfCancellationRequested();
+            _ = targetActorId;
+            _ = evt;
+            _ = options;
+            return Task.CompletedTask;
+        }
+
+        public Task<RuntimeCallbackLease> ScheduleSelfDurableTimeoutAsync(
+            string callbackId,
+            TimeSpan dueTime,
+            IMessage evt,
+            EventEnvelopePublishOptions? options = null,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            _ = callbackId;
+            _ = dueTime;
+            _ = evt;
+            _ = options;
+            return Task.FromResult(new RuntimeCallbackLease(AgentId, "callback-1", 1, RuntimeCallbackBackend.InMemory));
+        }
+
+        public Task CancelDurableCallbackAsync(RuntimeCallbackLease lease, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            _ = lease;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class EmptyServiceProvider : IServiceProvider
+    {
+        public object? GetService(System.Type serviceType) => null;
+    }
+}

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
@@ -943,6 +943,44 @@ public sealed class ChatEndpointsInternalTests
     }
 
     [Fact]
+    public async Task HandleResume_ShouldDispatchNestedToolApproval()
+    {
+        var service = new RecordingDispatchService<WorkflowResumeCommand, WorkflowRunControlAcceptedReceipt, WorkflowRunControlStartError>
+        {
+            Result = CommandDispatchResult<WorkflowRunControlAcceptedReceipt, WorkflowRunControlStartError>.Success(
+                new WorkflowRunControlAcceptedReceipt("actor-1", "run-1", "cmd-1", "cmd-1")),
+        };
+
+        var result = await WorkflowCapabilityEndpoints.HandleResume(
+            new WorkflowResumeInput
+            {
+                ActorId = "actor-1",
+                RunId = "run-1",
+                StepId = "tool-step",
+                Approved = true,
+                ToolApproval = new WorkflowToolApprovalResumeInput
+                {
+                    ExecutionId = "exec-1",
+                    ToolCallId = "tool-call-1",
+                    ApprovalRequestId = "approval-1",
+                },
+            },
+            service,
+            ct: CancellationToken.None);
+
+        var http = CreateHttpContext();
+        await result.ExecuteAsync(http);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        service.Commands.Should().ContainSingle();
+        var command = service.Commands.Single();
+        command.ToolApproval.Should().NotBeNull();
+        command.ToolApproval!.ExecutionId.Should().Be("exec-1");
+        command.ToolApproval.ToolCallId.Should().Be("tool-call-1");
+        command.ToolApproval.ApprovalRequestId.Should().Be("approval-1");
+    }
+
+    [Fact]
     public async Task HandleResume_ShouldTreatActorIdAsOpaqueAndForwardItUnchanged()
     {
         const string opaqueActorId = "static-gagent:script-runtime:mixed-shape";

--- a/test/Aevatar.Workflow.Host.Api.Tests/EventEnvelopeToAGUIEventMapperTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/EventEnvelopeToAGUIEventMapperTests.cs
@@ -411,7 +411,6 @@ public sealed class EventEnvelopeToAGUIEventMapperTests
                 ToolName = "dangerous_tool",
                 ToolCallId = "call-tool",
                 ApprovalRequestId = "approval-tool",
-                ArgumentsJson = """{"danger":true}""",
             },
         }));
 
@@ -424,7 +423,7 @@ public sealed class EventEnvelopeToAGUIEventMapperTests
         payload.ToolName.Should().Be("dangerous_tool");
         payload.ToolCallId.Should().Be("call-tool");
         payload.ApprovalRequestId.Should().Be("approval-tool");
-        payload.ArgumentsJson.Should().Be("""{"danger":true}""");
+        payload.ArgumentsJson.Should().BeEmpty();
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowHumanInteractionProjectorTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowHumanInteractionProjectorTests.cs
@@ -212,7 +212,6 @@ public sealed class WorkflowHumanInteractionProjectorTests
                         ToolName = "dangerous_tool",
                         ToolCallId = "call-tool",
                         ApprovalRequestId = "approval-tool",
-                        ArgumentsJson = "{}",
                     },
                 }),
             },

--- a/test/Aevatar.Workflow.Sdk.Tests/AevatarWorkflowClientTests.cs
+++ b/test/Aevatar.Workflow.Sdk.Tests/AevatarWorkflowClientTests.cs
@@ -91,6 +91,52 @@ data: {"stateSnapshot":{"snapshot":{"@type":"type.googleapis.com/aevatar.workflo
     }
 
     [Fact]
+    public async Task ResumeAsync_ShouldSerializeNestedToolApprovalPayload()
+    {
+        var client = CreateClient(async (request, ct) =>
+        {
+            request.Method.Should().Be(HttpMethod.Post);
+            request.RequestUri?.AbsolutePath.Should().Be("/api/scopes/scope-a/services/approval/runs/run-1:resume");
+
+            var body = await request.Content!.ReadAsStringAsync(ct);
+            using var doc = JsonDocument.Parse(body);
+            doc.RootElement.TryGetProperty("executionId", out _).Should().BeFalse();
+            doc.RootElement.TryGetProperty("approvalRequestId", out _).Should().BeFalse();
+            var toolApproval = doc.RootElement.GetProperty("toolApproval");
+            toolApproval.GetProperty("executionId").GetString().Should().Be("exec-1");
+            toolApproval.GetProperty("toolCallId").GetString().Should().Be("tool-call-1");
+            toolApproval.GetProperty("approvalRequestId").GetString().Should().Be("approval-1");
+
+            return new HttpResponseMessage(HttpStatusCode.Accepted)
+            {
+                Content = new StringContent(
+                    """{"accepted":true,"actorId":"actor-1","runId":"run-1","stepId":"tool-step","commandId":"cmd-1"}""",
+                    Encoding.UTF8,
+                    "application/json"),
+            };
+        });
+
+        var result = await client.ResumeAsync(new WorkflowResumeRequest
+        {
+            ScopeId = "scope-a",
+            ServiceId = "approval",
+            ActorId = "actor-1",
+            RunId = "run-1",
+            StepId = "tool-step",
+            Approved = true,
+            ToolApproval = new WorkflowToolApprovalResumeRequest
+            {
+                ExecutionId = "exec-1",
+                ToolCallId = "tool-call-1",
+                ApprovalRequestId = "approval-1",
+            },
+        });
+
+        result.Accepted.Should().BeTrue();
+        result.StepId.Should().Be("tool-step");
+    }
+
+    [Fact]
     public async Task SignalAsync_ShouldSerializeOptionalStepId()
     {
         var client = CreateClient(async (request, ct) =>

--- a/test/Aevatar.Workflow.Sdk.Tests/Session/RunSessionTrackerTests.cs
+++ b/test/Aevatar.Workflow.Sdk.Tests/Session/RunSessionTrackerTests.cs
@@ -69,6 +69,44 @@ public sealed class RunSessionTrackerTests
     }
 
     [Fact]
+    public void Track_ShouldCaptureToolApprovalAndBuildNestedResumeRequest()
+    {
+        var tracker = new RunSessionTracker();
+
+        tracker.Track(CustomFrame("aevatar.run.context", new WorkflowRunContextPayload
+        {
+            ActorId = "actor-1",
+            WorkflowName = "auto",
+            CommandId = "cmd-1",
+        }));
+        tracker.Track(CustomFrame("aevatar.tool_approval.pending", new WorkflowToolApprovalSuspensionCustomPayload
+        {
+            RunId = "run-1",
+            StepId = "tool-step",
+            ExecutionId = "exec-1",
+            ToolName = "danger",
+            ToolCallId = "tool-call-1",
+            ApprovalRequestId = "approval-1",
+        }));
+
+        var snapshot = tracker.Snapshot;
+        snapshot.RunId.Should().Be("run-1");
+        snapshot.StepId.Should().Be("tool-step");
+        snapshot.SuspensionType.Should().Be("tool_approval");
+        snapshot.ToolApproval.Should().NotBeNull();
+        snapshot.ToolApproval!.ExecutionId.Should().Be("exec-1");
+        snapshot.ToolApproval.ToolCallId.Should().Be("tool-call-1");
+        snapshot.ToolApproval.ApprovalRequestId.Should().Be("approval-1");
+
+        var resume = tracker.CreateResumeRequest("scope-a", approved: true, serviceId: "auto");
+
+        resume.ToolApproval.Should().NotBeNull();
+        resume.ToolApproval!.ExecutionId.Should().Be("exec-1");
+        resume.ToolApproval.ToolCallId.Should().Be("tool-call-1");
+        resume.ToolApproval.ApprovalRequestId.Should().Be("approval-1");
+    }
+
+    [Fact]
     public void CreateResumeAndSignalRequest_ShouldUseExplicitCommandIdOnly()
     {
         var tracker = new RunSessionTracker();


### PR DESCRIPTION
Closes #2015

## Changed files

- Added typed tool approval pending and grant contracts across workflow tool execution and AI tool middleware.
- Persisted pending approval in workflow module actor state, emitted `tool_approval` suspension events, and replayed approved tools from actor-owned pending state only.
- Added nested `WorkflowResumedEvent.tool_approval` and carried it through Application, HTTP, ScopeService, SDK, AGUI, NyxID channel action, and relay paths.
- Updated workflow canon documentation and coverage for pending, approved, rejected, mismatched, and stale approval resume behavior.

## Test results

- `dotnet build aevatar.slnx --nologo` — passed on `.worktrees/iter2015-issue-2015` after fast-forwarding to `origin/feature/integrate`.
- `dotnet test aevatar.slnx --nologo` — passed on `.worktrees/iter2015-issue-2015`.
- `bash tools/ci/test_stability_guards.sh` — passed.
- `bash tools/ci/architecture_guards.sh` — blocked by current `origin/feature/integrate` baseline Studio guard evidence in `src/Aevatar.Studio.Application/Studio/Services/StudioMemberService.cs`; #2015 does not modify `Aevatar.Studio.*` files.

## Deviations

- Scope was extended to update `test/Aevatar.Workflow.Host.Api.Tests/EventEnvelopeToAGUIEventMapperTests.cs` and `test/Aevatar.Workflow.Host.Api.Tests/WorkflowHumanInteractionProjectorTests.cs` because their host API fixtures still referenced the removed unsafe `arguments_json` tool approval suspension field.
- The consensus artifact was read from the main repository path because the worktree-local `.refactor-loop/runs` directory did not contain a copy.
- The repository's actual channel protocol test project is `test/Aevatar.GAgents.Channel.Protocol.Tests`.

⟦AI:AUTO-LOOP⟧
