### PR TITLE
fix(frontend): use drawer for member invoke inspector

### DIFF
--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -783,8 +783,6 @@ const enUSMessages = {
   'pages.studio.studiomemberinvokeinspector.current.run': 'Current run',
   'pages.studio.studiomemberinvokeinspector.close':
     'Close details',
-  'pages.studio.studiomemberinvokeinspector.drag.handle':
-    'Drag details panel',
   'pages.studio.studiomemberinvokeinspector.endpoint': 'Endpoint',
   'pages.studio.studiomemberinvokeinspector.endpoint.2': 'Endpoint',
   'pages.studio.studiomemberinvokeinspector.history': 'History',
@@ -799,8 +797,6 @@ const enUSMessages = {
   'pages.studio.studiomemberinvokeinspector.paste.encoded.protobuf.payload.when':
     'Paste encoded protobuf payload when this type cannot be built from text.',
   'pages.studio.studiomemberinvokeinspector.revision': 'Revision',
-  'pages.studio.studiomemberinvokeinspector.resize.handle':
-    'Resize details panel',
   'pages.studio.studiomemberinvokeinspector.run': 'Run',
   'pages.studio.studiomemberinvokeinspector.service.target': 'Service target',
   'pages.studio.studiomemberinvokeinspector.title': 'Details',

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -740,7 +740,6 @@ const zhCNMessages = {
     '端点详情、类型化载荷和最近运行记录会在这里按需打开，不改变主控制台布局。',
   'pages.studio.studiomemberinvokeinspector.current.run': '当前运行',
   'pages.studio.studiomemberinvokeinspector.close': '关闭详情',
-  'pages.studio.studiomemberinvokeinspector.drag.handle': '拖拽详情面板',
   'pages.studio.studiomemberinvokeinspector.endpoint': '端点',
   'pages.studio.studiomemberinvokeinspector.endpoint.2': '端点',
   'pages.studio.studiomemberinvokeinspector.history': '历史',
@@ -755,8 +754,6 @@ const zhCNMessages = {
   'pages.studio.studiomemberinvokeinspector.paste.encoded.protobuf.payload.when':
     '当文本无法构造该类型时，粘贴编码后的 protobuf 载荷。',
   'pages.studio.studiomemberinvokeinspector.revision': '版本',
-  'pages.studio.studiomemberinvokeinspector.resize.handle':
-    '调整调用检查器宽度',
   'pages.studio.studiomemberinvokeinspector.run': '运行',
   'pages.studio.studiomemberinvokeinspector.service.target': '服务目标',
   'pages.studio.studiomemberinvokeinspector.title': '详情',

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokeInspector.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokeInspector.tsx
@@ -1,12 +1,15 @@
 import {
   ApartmentOutlined,
-  CloseOutlined,
   HistoryOutlined,
   InfoCircleOutlined,
 } from '@ant-design/icons';
-import { Button, Drawer, Grid, Input, Segmented, Typography } from 'antd';
+import { Drawer, Grid, Input, Segmented, Typography } from 'antd';
 import React from 'react';
-import { aevatarDrawerBodyStyle } from '@/shared/ui/aevatarWorkbench';
+import {
+  AEVATAR_GLOBAL_UI_SPEC,
+  aevatarDrawerBodyStyle,
+  aevatarDrawerScrollStyle,
+} from '@/shared/ui/aevatarWorkbench';
 import type {
   CurrentRunRequest,
   InvokeHistoryEntry,
@@ -32,19 +35,6 @@ type StudioMemberInvokeInspectorTab =
 type InspectorField = {
   readonly label: string;
   readonly value: React.ReactNode;
-};
-
-type DesktopFrame = {
-  readonly width: number;
-  readonly x: number;
-  readonly y: number;
-};
-
-type DesktopInteraction = {
-  readonly mode: 'move' | 'resize';
-  readonly startClientX: number;
-  readonly startClientY: number;
-  readonly startFrame: DesktopFrame;
 };
 
 type StudioMemberInvokeInspectorProps = {
@@ -91,78 +81,6 @@ function renderInspectorField(field: InspectorField): React.ReactNode {
       <div style={contractValueStyle}>{field.value}</div>
     </div>
   );
-}
-
-const DESKTOP_INSPECTOR_MIN_WIDTH = 360;
-const DESKTOP_INSPECTOR_MAX_WIDTH = 500;
-const DESKTOP_INSPECTOR_DEFAULT_WIDTH = 420;
-const DESKTOP_INSPECTOR_MARGIN = 16;
-const DESKTOP_INSPECTOR_DEFAULT_TOP = 96;
-const DESKTOP_INSPECTOR_MIN_HEIGHT = 220;
-
-function getViewportSize(): { readonly height: number; readonly width: number } {
-  if (typeof window === 'undefined') {
-    return { height: 900, width: 1280 };
-  }
-
-  return {
-    height: window.innerHeight || 900,
-    width: window.innerWidth || 1280,
-  };
-}
-
-function clampValue(value: number, min: number, max: number): number {
-  if (max < min) {
-    return min;
-  }
-
-  return Math.min(Math.max(value, min), max);
-}
-
-function clampInspectorWidth(width: number): number {
-  const viewport = getViewportSize();
-  const viewportMaxWidth = Math.max(
-    DESKTOP_INSPECTOR_MIN_WIDTH,
-    viewport.width - DESKTOP_INSPECTOR_MARGIN * 2,
-  );
-  return clampValue(
-    width,
-    DESKTOP_INSPECTOR_MIN_WIDTH,
-    Math.min(DESKTOP_INSPECTOR_MAX_WIDTH, viewportMaxWidth),
-  );
-}
-
-function readPointerCoordinate(value: number, fallback: number): number {
-  return Number.isFinite(value) ? value : fallback;
-}
-
-function clampDesktopFrame(frame: DesktopFrame): DesktopFrame {
-  const viewport = getViewportSize();
-  const width = clampInspectorWidth(frame.width);
-  const maxX = Math.max(
-    DESKTOP_INSPECTOR_MARGIN,
-    viewport.width - width - DESKTOP_INSPECTOR_MARGIN,
-  );
-  const maxY = Math.max(
-    DESKTOP_INSPECTOR_MARGIN,
-    viewport.height - DESKTOP_INSPECTOR_MIN_HEIGHT - DESKTOP_INSPECTOR_MARGIN,
-  );
-
-  return {
-    width,
-    x: clampValue(frame.x, DESKTOP_INSPECTOR_MARGIN, maxX),
-    y: clampValue(frame.y, DESKTOP_INSPECTOR_MARGIN, maxY),
-  };
-}
-
-function createDefaultDesktopFrame(): DesktopFrame {
-  const viewport = getViewportSize();
-  const width = clampInspectorWidth(DESKTOP_INSPECTOR_DEFAULT_WIDTH);
-  return clampDesktopFrame({
-    width,
-    x: viewport.width - width - 32,
-    y: DESKTOP_INSPECTOR_DEFAULT_TOP,
-  });
 }
 
 const inspectorBodyStyle: React.CSSProperties = {
@@ -219,72 +137,11 @@ const historyInspectorStyle: React.CSSProperties = {
 
 const drawerBodyStyle: React.CSSProperties = {
   ...aevatarDrawerBodyStyle,
-  overflow: 'auto',
 };
 
-const desktopInspectorShellBaseStyle: React.CSSProperties = {
-  background: studioInvokeColors.panel,
-  border: `1px solid ${studioInvokeColors.border}`,
-  borderRadius: 8,
-  boxShadow: '0 24px 64px rgba(15, 23, 42, 0.22)',
-  boxSizing: 'border-box',
-  color: studioInvokeColors.text,
-  display: 'flex',
-  flexDirection: 'column',
-  minHeight: DESKTOP_INSPECTOR_MIN_HEIGHT,
-  overflow: 'hidden',
-  position: 'fixed',
-  zIndex: 1050,
-};
-
-const desktopInspectorDragHandleBaseStyle: React.CSSProperties = {
-  alignItems: 'center',
-  borderBottom: `1px solid ${studioInvokeColors.border}`,
-  cursor: 'grab',
-  display: 'flex',
-  flex: '0 0 auto',
-  gap: 12,
-  justifyContent: 'space-between',
-  minWidth: 0,
-  padding: '12px 14px',
-  touchAction: 'none',
-};
-
-const desktopInspectorTitleStyle: React.CSSProperties = {
-  fontSize: 14,
-  fontWeight: 700,
-  lineHeight: '20px',
-  minWidth: 0,
-};
-
-const desktopInspectorContentStyle: React.CSSProperties = {
-  flex: '1 1 auto',
-  minHeight: 0,
-  overflow: 'auto',
-  padding: 16,
-};
-
-const desktopResizeHandleStyle: React.CSSProperties = {
-  bottom: 0,
-  cursor: 'ew-resize',
-  left: -5,
-  outline: 'none',
-  position: 'absolute',
-  top: 0,
-  touchAction: 'none',
-  width: 10,
-  zIndex: 2,
-};
-
-const desktopResizeRailStyle: React.CSSProperties = {
-  background: studioInvokeColors.activeBorder,
-  borderRadius: 999,
-  bottom: 16,
-  left: 4,
-  opacity: 0.72,
-  position: 'absolute',
-  top: 16,
-  width: 2,
+const drawerScrollStyle: React.CSSProperties = {
+  ...aevatarDrawerScrollStyle,
+  gap: 0,
 };
 
 const StudioMemberInvokeInspector: React.FC<
@@ -325,14 +182,6 @@ const StudioMemberInvokeInspector: React.FC<
   const isDesktop = Boolean(screens.md);
   const [activeTab, setActiveTab] =
     React.useState<StudioMemberInvokeInspectorTab>('endpoint');
-  const [desktopFrame, setDesktopFrame] = React.useState<DesktopFrame>(
-    createDefaultDesktopFrame,
-  );
-  const [desktopInteractionMode, setDesktopInteractionMode] = React.useState<
-    DesktopInteraction['mode'] | null
-  >(null);
-  const desktopFrameRef = React.useRef(desktopFrame);
-  const desktopInteractionRef = React.useRef<DesktopInteraction | null>(null);
   const placement = isDesktop ? 'right' : 'bottom';
   const canEditPayload = !isChatEndpoint;
   const tabOptions = React.useMemo(
@@ -379,169 +228,6 @@ const StudioMemberInvokeInspector: React.FC<
       setActiveTab('endpoint');
     }
   }, [activeTab, canEditPayload]);
-
-  React.useEffect(() => {
-    desktopFrameRef.current = desktopFrame;
-  }, [desktopFrame]);
-
-  React.useEffect(() => {
-    if (!open || !isDesktop) {
-      desktopInteractionRef.current = null;
-      setDesktopInteractionMode(null);
-      return;
-    }
-
-    setDesktopFrame((currentFrame) => clampDesktopFrame(currentFrame));
-  }, [isDesktop, open]);
-
-  React.useEffect(() => {
-    if (!open || !isDesktop || typeof window === 'undefined') {
-      return undefined;
-    }
-
-    const handleResize = () => {
-      setDesktopFrame((currentFrame) => clampDesktopFrame(currentFrame));
-    };
-
-    window.addEventListener('resize', handleResize);
-    return () => {
-      window.removeEventListener('resize', handleResize);
-    };
-  }, [isDesktop, open]);
-
-  React.useEffect(() => {
-    if (
-      !desktopInteractionMode ||
-      !open ||
-      !isDesktop ||
-      typeof window === 'undefined'
-    ) {
-      return undefined;
-    }
-
-    const previousCursor = document.body.style.cursor;
-    const previousUserSelect = document.body.style.userSelect;
-    document.body.style.cursor =
-      desktopInteractionMode === 'move' ? 'grabbing' : 'ew-resize';
-    document.body.style.userSelect = 'none';
-
-    const stopInteraction = () => {
-      desktopInteractionRef.current = null;
-      setDesktopInteractionMode(null);
-    };
-
-    const handlePointerMove = (event: PointerEvent) => {
-      const interaction = desktopInteractionRef.current;
-      if (!interaction) {
-        return;
-      }
-
-      event.preventDefault();
-      const clientX = readPointerCoordinate(
-        event.clientX,
-        interaction.startClientX,
-      );
-      const clientY = readPointerCoordinate(
-        event.clientY,
-        interaction.startClientY,
-      );
-      if (interaction.mode === 'move') {
-        setDesktopFrame(
-          clampDesktopFrame({
-            ...interaction.startFrame,
-            x:
-              interaction.startFrame.x +
-              clientX -
-              interaction.startClientX,
-            y:
-              interaction.startFrame.y +
-              clientY -
-              interaction.startClientY,
-          }),
-        );
-        return;
-      }
-
-      const rightEdge = interaction.startFrame.x + interaction.startFrame.width;
-      const width = clampInspectorWidth(
-        interaction.startFrame.width +
-          interaction.startClientX -
-          clientX,
-      );
-      setDesktopFrame(
-        clampDesktopFrame({
-          ...interaction.startFrame,
-          width,
-          x: rightEdge - width,
-        }),
-      );
-    };
-
-    window.addEventListener('pointermove', handlePointerMove);
-    window.addEventListener('pointerup', stopInteraction);
-    window.addEventListener('pointercancel', stopInteraction);
-
-    return () => {
-      window.removeEventListener('pointermove', handlePointerMove);
-      window.removeEventListener('pointerup', stopInteraction);
-      window.removeEventListener('pointercancel', stopInteraction);
-      document.body.style.cursor = previousCursor;
-      document.body.style.userSelect = previousUserSelect;
-    };
-  }, [desktopInteractionMode, isDesktop, open]);
-
-  React.useEffect(() => {
-    if (!open || !isDesktop || typeof window === 'undefined') {
-      return undefined;
-    }
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        onClose();
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [isDesktop, onClose, open]);
-
-  const startDesktopInteraction = React.useCallback(
-    (mode: DesktopInteraction['mode'], event: React.PointerEvent) => {
-      event.preventDefault();
-      const currentFrame = desktopFrameRef.current;
-      desktopInteractionRef.current = {
-        mode,
-        startClientX: readPointerCoordinate(event.clientX, currentFrame.x),
-        startClientY: readPointerCoordinate(event.clientY, currentFrame.y),
-        startFrame: currentFrame,
-      };
-      setDesktopInteractionMode(mode);
-    },
-    [],
-  );
-
-  const resizeDesktopInspectorWithKeyboard = React.useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
-        return;
-      }
-
-      event.preventDefault();
-      setDesktopFrame((currentFrame) => {
-        const rightEdge = currentFrame.x + currentFrame.width;
-        const delta = event.key === 'ArrowLeft' ? 16 : -16;
-        const width = clampInspectorWidth(currentFrame.width + delta);
-        return clampDesktopFrame({
-          ...currentFrame,
-          width,
-          x: rightEdge - width,
-        });
-      });
-    },
-    [],
-  );
 
   const fields: InspectorField[] = [
     {
@@ -675,72 +361,6 @@ const StudioMemberInvokeInspector: React.FC<
     </div>
   );
 
-  if (isDesktop) {
-    if (!open) {
-      return null;
-    }
-
-    return (
-      <div
-        aria-label={inspectorTitle}
-        data-testid="studio-invoke-inspector"
-        role="dialog"
-        style={{
-          ...desktopInspectorShellBaseStyle,
-          height: `min(720px, calc(100vh - ${Math.round(
-            desktopFrame.y + DESKTOP_INSPECTOR_MARGIN,
-          )}px))`,
-          left: desktopFrame.x,
-          top: desktopFrame.y,
-          width: desktopFrame.width,
-        }}
-      >
-        <div
-          aria-label={t(
-            "pages.studio.studiomemberinvokeinspector.drag.handle",
-            "Drag details panel",
-          )}
-          data-testid="studio-invoke-inspector-drag-handle"
-          onPointerDown={(event) => startDesktopInteraction('move', event)}
-          style={{
-            ...desktopInspectorDragHandleBaseStyle,
-            cursor:
-              desktopInteractionMode === 'move' ? 'grabbing' : 'grab',
-          }}
-        >
-          <Typography.Text style={desktopInspectorTitleStyle}>
-            {inspectorTitle}
-          </Typography.Text>
-          <Button
-            aria-label={t(
-              "pages.studio.studiomemberinvokeinspector.close",
-              "Close details",
-            )}
-            icon={<CloseOutlined />}
-            type="text"
-            onClick={onClose}
-            onPointerDown={(event) => event.stopPropagation()}
-          />
-        </div>
-        <div
-          aria-label={t(
-            "pages.studio.studiomemberinvokeinspector.resize.handle",
-            "Resize details panel",
-          )}
-          data-testid="studio-invoke-inspector-resize-handle"
-          role="separator"
-          tabIndex={0}
-          onKeyDown={resizeDesktopInspectorWithKeyboard}
-          onPointerDown={(event) => startDesktopInteraction('resize', event)}
-          style={desktopResizeHandleStyle}
-        >
-          <span aria-hidden style={desktopResizeRailStyle} />
-        </div>
-        <div style={desktopInspectorContentStyle}>{inspectorContent}</div>
-      </div>
-    );
-  }
-
   return (
     <Drawer
       destroyOnHidden
@@ -748,15 +368,13 @@ const StudioMemberInvokeInspector: React.FC<
       onClose={onClose}
       open={open}
       placement={placement}
-      styles={{
-        body: drawerBodyStyle,
-        wrapper: {
-          height: '72vh',
-        },
-      }}
+      size={
+        isDesktop ? AEVATAR_GLOBAL_UI_SPEC.tokens.inspectorWidth : '72vh'
+      }
+      styles={{ body: drawerBodyStyle }}
       title={inspectorTitle}
     >
-      {inspectorContent}
+      <div style={drawerScrollStyle}>{inspectorContent}</div>
     </Drawer>
   );
 };

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.test.tsx
@@ -123,19 +123,6 @@ describe('StudioMemberInvokePanel', () => {
     );
   });
 
-  function dispatchWindowPointerEvent(
-    type: 'pointercancel' | 'pointermove' | 'pointerup',
-    init: MouseEventInit = {},
-  ): void {
-    window.dispatchEvent(
-      new MouseEvent(type, {
-        bubbles: true,
-        cancelable: true,
-        ...init,
-      }),
-    );
-  }
-
   it('renders the workflow run surface with a compact summary and closed details', async () => {
     render(
       React.createElement(StudioMemberInvokePanel, {
@@ -258,56 +245,15 @@ describe('StudioMemberInvokePanel', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Details' }));
     const inspector = await screen.findByTestId('studio-invoke-inspector');
     expect(inspector).toBeTruthy();
-    expect(inspector.style.position).toBe('fixed');
-    expect(inspector.style.width).toBe('420px');
-    expect(inspector.style.left).toBe('572px');
-    expect(inspector.style.top).toBe('96px');
     expect(screen.getAllByText('Details').length).toBeGreaterThanOrEqual(1);
-    const dragHandle = screen.getByTestId('studio-invoke-inspector-drag-handle');
-    const initialDetailsLeft = inspector.style.left;
-    const initialDetailsTop = inspector.style.top;
-    fireEvent.pointerDown(dragHandle, { clientX: 800, clientY: 120 });
-    await waitFor(() => {
-      expect(document.body.style.cursor).toBe('grabbing');
-    });
-    dispatchWindowPointerEvent('pointermove', { clientX: 780, clientY: 150 });
-    await waitFor(() => {
-      expect(inspector.style.left).not.toBe(initialDetailsLeft);
-      expect(inspector.style.top).not.toBe(initialDetailsTop);
-    });
-    expect(Number.parseFloat(inspector.style.left)).toBeGreaterThanOrEqual(16);
-    expect(Number.parseFloat(inspector.style.left)).toBeLessThanOrEqual(
-      1024 - 420 - 16,
-    );
-    expect(Number.parseFloat(inspector.style.top)).toBeGreaterThanOrEqual(16);
-    expect(Number.parseFloat(inspector.style.top)).toBeLessThanOrEqual(
-      768 - 220 - 16,
-    );
-    dispatchWindowPointerEvent('pointerup');
-    await waitFor(() => {
-      expect(document.body.style.cursor).toBe('');
-    });
-    const resizeHandle = screen.getByTestId(
-      'studio-invoke-inspector-resize-handle',
-    );
-    fireEvent.pointerDown(resizeHandle, { clientX: 552, clientY: 180 });
-    await waitFor(() => {
-      expect(document.body.style.cursor).toBe('ew-resize');
-    });
-    dispatchWindowPointerEvent('pointermove', {
-      clientX: -1000,
-      clientY: 180,
-    });
-    await waitFor(() => {
-      expect(inspector.style.width).toBe('500px');
-    });
-    dispatchWindowPointerEvent('pointerup');
-    fireEvent.pointerDown(resizeHandle, { clientX: 472, clientY: 180 });
-    dispatchWindowPointerEvent('pointermove', { clientX: 700, clientY: 180 });
-    await waitFor(() => {
-      expect(inspector.style.width).toBe('360px');
-    });
-    dispatchWindowPointerEvent('pointerup');
+    expect(screen.getByText('Service target')).toBeTruthy();
+    expect(screen.getByText('Revision')).toBeTruthy();
+    expect(
+      screen.queryByTestId('studio-invoke-inspector-drag-handle'),
+    ).toBeNull();
+    expect(
+      screen.queryByTestId('studio-invoke-inspector-resize-handle'),
+    ).toBeNull();
     fireEvent.click(screen.getByText('Payload'));
     expect(screen.getByLabelText('Payload type URL')).toHaveValue(
       'type.googleapis.com/google.protobuf.StringValue',


### PR DESCRIPTION
## Summary

- Replaces the desktop member invoke Details floating overlay with the standard Ant Design Drawer pattern.
- Removes the custom drag, resize, fixed-position frame, pointer listeners, and obsolete drag/resize locale copy.
- Updates the focused invoke panel test so it verifies inspector behavior and tabs instead of locking in window coordinates.

## Why

The Details inspector is a persistent context surface for endpoint, payload, run, and history information. A right-side drawer matches the existing Aevatar console context-panel pattern better than a draggable floating window, and it avoids custom focus/layering/resize code.

## Validation

- `pnpm --dir apps/aevatar-console-web test --runInBand src/pages/studio/components/StudioMemberInvokePanel.test.tsx`
- `pnpm --dir apps/aevatar-console-web test --runInBand src/pages/team-member-invoke/index.test.tsx`
- `pnpm --dir apps/aevatar-console-web test --runInBand src/locales/hardcodedCopyAudit.test.ts`
- `pnpm --dir apps/aevatar-console-web tsc`
- `bash tools/ci/test_stability_guards.sh`
- `git diff --check`

Note: Jest emitted existing watchman recrawl/open-handle warnings during local runs, but all commands exited successfully.
