### PR TITLE
非流式 /v1/responses 等待 terminal completion 后返回 completed JSON

### DIFF
--- a/docs/canon/nyxid-responses-direct.md
+++ b/docs/canon/nyxid-responses-direct.md
@@ -103,6 +103,10 @@ llm-anthropic/claude-haiku-4-5
 - `max_output_tokens`、`temperature`
 - response session 注册、查询可见性校验、24 小时 TTL
 
+默认非 streaming create 是 completed-only：Aevatar 会先把 run command dispatch 到 response session actor，再通过 observation/projection 链等待 terminal event。成功时 HTTP 200 只返回 `status:"completed"` 的 response JSON，`output` 包含 completed message 和已完成的 function-call output item，`usage` 来自 terminal observation。
+
+非 streaming create 不返回 `status:"in_progress"` accepted 空壳。观察超时返回 HTTP 504 error envelope，`code:"response_timeout"`；terminal failure 返回非 2xx error envelope，默认 HTTP 500 或 terminal failure 指定状态；terminal cancellation 返回 HTTP 409，`code:"run_cancelled"`；请求取消或客户端中断沿用 HTTP 408，`code:"request_timeout"`。这些失败不会返回 failed response JSON。真正的 `background:true` 和 `GET /v1/responses/{id}` retrieve 属于后续独立协议与 readmodel，不属于当前入口。
+
 `previous_response_id` 的约束是诚实的：只能继续同一 caller scope 可见、未过期、未失败、未取消的 session。带 `function_call_output` 且显式带 `previous_response_id` 时，Aevatar 会按上一轮记录的 forwarded tool call 对账。
 
 为了兼容 Anthropic 到 OpenAI 的转换器，如果请求里有 `function_call_output`，但没有 `previous_response_id`，Aevatar 不会直接报错，而是把这些 tool result 折进 prompt，形如：

--- a/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesEndpoints.cs
@@ -86,15 +86,6 @@ internal static partial class ResponsesApiEndpoints
             return Results.Empty;
         }
 
-        if (result.Accepted is not null)
-        {
-            return Results.Json(
-                BuildAcceptedResponse(
-                    result.Accepted.Normalized,
-                    result.Accepted.CreatedAt),
-                statusCode: StatusCodes.Status200OK);
-        }
-
         if (result.Completed is not null)
         {
             return Results.Json(
@@ -316,32 +307,6 @@ internal static partial class ResponsesApiEndpoints
             MaxOutputTokens = normalized.MaxOutputTokens,
             Model = normalized.Model,
             Output = [],
-            PreviousResponseId = normalized.PreviousResponseId,
-            ParallelToolCalls = true,
-            Reasoning = new ResponsesReasoningSettings(),
-            Store = false,
-            Temperature = normalized.Temperature,
-            ToolChoice = "auto",
-            Tools = [],
-            Truncation = "disabled",
-            Usage = null,
-            Metadata = new Dictionary<string, string>(StringComparer.Ordinal),
-        };
-    }
-
-    private static ResponsesResponseSnapshot BuildAcceptedResponse(
-        NormalizedResponsesRequest normalized,
-        long createdAt)
-    {
-        return new ResponsesResponseSnapshot
-        {
-            Id = normalized.ResponseId,
-            CreatedAt = createdAt,
-            Status = "in_progress",
-            Input = [BuildInputMessage(normalized.Prompt)],
-            MaxOutputTokens = normalized.MaxOutputTokens,
-            Model = normalized.Model,
-            Output = [BuildOutputMessage(normalized.MessageItemId, "in_progress", text: null)],
             PreviousResponseId = normalized.PreviousResponseId,
             ParallelToolCalls = true,
             Reasoning = new ResponsesReasoningSettings(),

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandContracts.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandContracts.cs
@@ -186,20 +186,16 @@ public sealed record ResponsesCreateCommandPlan(
 public sealed record ResponsesCreateCommandResult(
     ResponsesCommandError? Error,
     ResponsesCreateCommandPlan? StreamPlan,
-    ResponsesCreateCompletedCommandResult? Completed,
-    ResponsesCreateAcceptedCommandResult? Accepted)
+    ResponsesCreateCompletedCommandResult? Completed)
 {
     public static ResponsesCreateCommandResult FromError(int statusCode, string code, string message) =>
-        new(new ResponsesCommandError(statusCode, code, message), null, null, null);
+        new(new ResponsesCommandError(statusCode, code, message), null, null);
 
     public static ResponsesCreateCommandResult FromStreamPlan(ResponsesCreateCommandPlan plan) =>
-        new(null, plan, null, null);
+        new(null, plan, null);
 
     public static ResponsesCreateCommandResult FromCompleted(ResponsesCreateCompletedCommandResult completed) =>
-        new(null, null, completed, null);
-
-    public static ResponsesCreateCommandResult FromAccepted(ResponsesCreateAcceptedCommandResult accepted) =>
-        new(null, null, null, accepted);
+        new(null, null, completed);
 }
 
 public sealed record ResponsesCreateCompletedCommandResult(
@@ -213,12 +209,6 @@ public enum ResponsesCompletionStage
     Committed = 0,
     ReadModelObserved = 1,
 }
-
-public sealed record ResponsesCreateAcceptedCommandResult(
-    NormalizedResponsesRequest Normalized,
-    long CreatedAt,
-    LlmSessionRegistrationResult Session,
-    DispatchAdmission Admission);
 
 public sealed record ResponsesStreamCommandResult(
     ResponsesCommandError? Error,

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandFacade.cs
@@ -461,13 +461,45 @@ public sealed class ResponsesCommandFacade(
     {
         try
         {
-            var admission = await DispatchRunAsync(plan, ct);
-            await TryResolveIncomingToolResultsAsync(plan.PreviousSnapshot, plan.Normalized, ct);
-            return ResponsesCreateCommandResult.FromAccepted(new ResponsesCreateAcceptedCommandResult(
-                plan.Normalized,
-                plan.CreatedAt.ToUnixTimeSeconds(),
-                plan.Session,
-                admission));
+            var observed = await observationService.ObserveAsync(
+                new LlmSessionRunObservationRequest(
+                    plan.Session.ActorId,
+                    plan.Session.ResponseId,
+                    $"{plan.Session.ResponseId}:llm-run",
+                    async token =>
+                    {
+                        var admission = await DispatchRunAsync(plan, token).ConfigureAwait(false);
+                        await TryResolveIncomingToolResultsAsync(plan.PreviousSnapshot, plan.Normalized, token)
+                            .ConfigureAwait(false);
+                        return admission;
+                    },
+                    DefaultObservationTimeout),
+                null,
+                ct).ConfigureAwait(false);
+            if (observed.Error is not null)
+            {
+                await TryUpdateSessionStatusAsync(
+                    plan.Session,
+                    observed.Error.Kind == LlmSessionRunObservedTerminalKind.Cancelled
+                        ? LlmSessionStatus.Cancelled
+                        : LlmSessionStatus.Failed,
+                    CancellationToken.None);
+                return ResponsesCreateCommandResult.FromError(
+                    observed.Error.StatusCode,
+                    observed.Error.Code,
+                    observed.Error.Message);
+            }
+
+            return observed.Completion is not null
+                ? ResponsesCreateCommandResult.FromCompleted(new ResponsesCreateCompletedCommandResult(
+                    plan.Normalized,
+                    plan.CreatedAt.ToUnixTimeSeconds(),
+                    ResponsesCompletionStage.ReadModelObserved,
+                    observed.Completion))
+                : ResponsesCreateCommandResult.FromError(
+                    503,
+                    "observation_unavailable",
+                    "LLM run observation ended without a terminal event.");
         }
         catch (NyxIdAuthenticationRequiredException ex)
         {

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
@@ -38,18 +38,16 @@ public sealed class ResponsesCommandFacadeTests
             []), CallerScopeContext("token"));
 
         result.Error.Should().BeNull();
-        result.Accepted.Should().NotBeNull();
-        result.Completed.Should().BeNull();
-        result.Accepted!.Admission.Accepted.Should().BeTrue();
+        result.Completed.Should().NotBeNull();
+        result.Completed!.CompletionStage.Should().Be(ResponsesCompletionStage.ReadModelObserved);
+        result.Completed.Completion.OutputText.Should().Be("ok");
         sessions.Registered.Should().ContainSingle().Which.ResponseId.Should().StartWith("resp_");
-        sessions.RecordedCompletions.Should().BeEmpty();
         sessions.UpdatedStatuses.Should().BeEmpty();
         var command = dispatch.Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
         command.Model.Should().Be("gpt-5");
         command.RoutePreference.Should().Be("route-value");
         command.ScopeId.Should().Be("scope-1");
         command.BearerToken.Should().Be("token");
-        result.Accepted.Admission.CommandId.Should().NotBeNullOrWhiteSpace();
         var toolContext = AgentToolExecutionContextMapper.FromPayload(command.ToolContext);
         toolContext.Request.RequestId.Should().Be(command.ResponseId);
         toolContext.Caller.ScopeId.Should().Be("scope-1");
@@ -81,7 +79,7 @@ public sealed class ResponsesCommandFacadeTests
             []), CallerScopeContext("token"));
 
         result.Error.Should().BeNull();
-        result.Accepted.Should().NotBeNull();
+        result.Completed.Should().NotBeNull();
         var command = dispatch.Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
         command.Model.Should().Be("gpt-5.4-mini");
         command.RoutePreference.Should().Be("/api/v1/proxy/s/chrono-llm");
@@ -108,7 +106,7 @@ public sealed class ResponsesCommandFacadeTests
             []), CallerScopeContext("token"));
 
         result.Error.Should().BeNull();
-        result.Accepted.Should().NotBeNull();
+        result.Completed.Should().NotBeNull();
         var command = dispatch.Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
         command.Model.Should().Be("gpt-5.4-mini");
         command.RoutePreference.Should().Be("/api/v1/proxy/s/chrono-llm");
@@ -139,8 +137,7 @@ public sealed class ResponsesCommandFacadeTests
 
         result.Error.Should().BeNull();
         sessions.Registered.Should().ContainSingle();
-        result.Accepted.Should().NotBeNull();
-        sessions.RecordedCompletions.Should().BeEmpty();
+        result.Completed.Should().NotBeNull();
         sessions.UpdatedStatuses.Should().BeEmpty();
         var command = dispatch.Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
         command.ToolSelection.AdditiveToolNames.Should().Contain("aevatar_invoke_gagent");
@@ -189,7 +186,7 @@ public sealed class ResponsesCommandFacadeTests
             []), CallerScopeContext("token"));
 
         result.Error.Should().BeNull();
-        result.Accepted.Should().NotBeNull();
+        result.Completed.Should().NotBeNull();
         var command = dispatch.Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
         command.ToolSelection.AdditiveToolNames.Should().Contain("aevatar_invoke_gagent");
         command.ToolSelection.ToolChoiceHintArguments.Fields["actor_id"].StringValue.Should().Be("member-1");
@@ -301,14 +298,12 @@ public sealed class ResponsesCommandFacadeTests
             403,
             "response_scope_mismatch",
             "response id is not visible to the current caller scope."));
-        result.Accepted.Should().BeNull();
         result.Completed.Should().BeNull();
         result.StreamPlan.Should().BeNull();
         sessions.Registered.Should().BeEmpty();
         sessions.ToolResults.Should().BeEmpty();
         sessions.ResolvedToolResults.Should().BeEmpty();
         sessions.RecordedToolCalls.Should().BeEmpty();
-        sessions.RecordedCompletions.Should().BeEmpty();
         sessions.UpdatedStatuses.Should().BeEmpty();
         dispatch.Calls.Should().BeEmpty();
     }
@@ -361,7 +356,6 @@ public sealed class ResponsesCommandFacadeTests
             []), CallerScopeContext("token"));
 
         result.Error.Should().BeNull();
-        result.Accepted.Should().BeNull();
         result.Completed.Should().NotBeNull();
         result.Completed!.CompletionStage.Should().Be(ResponsesCompletionStage.Committed);
         result.Completed.Completion.OutputText.Should().Be("""{"temperature":"31C"}""");
@@ -577,6 +571,121 @@ public sealed class ResponsesCommandFacadeTests
         recovery.CommandName.Should().BeNull();
         recovery.PrimarySkillName.Should().BeNull();
         recovery.OriginalCommand.Should().Be("::");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenObservedRunFails_ShouldReturnFailure_AndMarkSessionFailed()
+    {
+        var sessions = new RecordingSessionPort();
+        var facade = CreateFacade(
+            sessionPort: sessions,
+            observationService: StaticLlmSessionRunObservationService.Error(
+                LlmSessionRunObservedTerminalKind.Failed,
+                500,
+                "provider_failed",
+                "provider crashed"));
+
+        var result = await facade.CreateAsync(new ResponsesCommandRequest(
+            "model",
+            "hello",
+            [],
+            false,
+            null,
+            null,
+            null,
+            []), CallerScopeContext("token"));
+
+        result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
+            500,
+            "provider_failed",
+            "provider crashed"));
+        result.Completed.Should().BeNull();
+        sessions.UpdatedStatuses.Should().ContainSingle().Which.Status.Should().Be(LlmSessionStatus.Failed);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenObservedRunIsCancelled_ShouldReturnCancel_AndMarkSessionCancelled()
+    {
+        var sessions = new RecordingSessionPort();
+        var facade = CreateFacade(
+            sessionPort: sessions,
+            observationService: StaticLlmSessionRunObservationService.Error(
+                LlmSessionRunObservedTerminalKind.Cancelled,
+                409,
+                "run_cancelled",
+                "LLM run was cancelled."));
+
+        var result = await facade.CreateAsync(new ResponsesCommandRequest(
+            "model",
+            "hello",
+            [],
+            false,
+            null,
+            null,
+            null,
+            []), CallerScopeContext("token"));
+
+        result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
+            409,
+            "run_cancelled",
+            "LLM run was cancelled."));
+        result.Completed.Should().BeNull();
+        sessions.UpdatedStatuses.Should().ContainSingle().Which.Status.Should().Be(LlmSessionStatus.Cancelled);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenObservationTimesOut_ShouldReturnTimeout_AndMarkSessionFailed()
+    {
+        var sessions = new RecordingSessionPort();
+        var facade = CreateFacade(
+            sessionPort: sessions,
+            observationService: StaticLlmSessionRunObservationService.Error(
+                LlmSessionRunObservedTerminalKind.TimedOut,
+                504,
+                "response_timeout",
+                "Timed out waiting 30 seconds for the LLM run to emit a terminal event."));
+
+        var result = await facade.CreateAsync(new ResponsesCommandRequest(
+            "model",
+            "hello",
+            [],
+            false,
+            null,
+            null,
+            null,
+            []), CallerScopeContext("token"));
+
+        result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
+            504,
+            "response_timeout",
+            "Timed out waiting 30 seconds for the LLM run to emit a terminal event."));
+        result.Completed.Should().BeNull();
+        sessions.UpdatedStatuses.Should().ContainSingle().Which.Status.Should().Be(LlmSessionStatus.Failed);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenRequestIsCancelled_ShouldReturnTimeout_AndMarkSessionCancelled()
+    {
+        var sessions = new RecordingSessionPort();
+        var dispatch = new RecordingActorDispatchPort(ct => new OperationCanceledException(ct));
+        var facade = CreateFacade(sessionPort: sessions, dispatchPort: dispatch);
+
+        var result = await facade.CreateAsync(new ResponsesCommandRequest(
+            "model",
+            "hello",
+            [],
+            false,
+            null,
+            null,
+            null,
+            []), CallerScopeContext("token"));
+
+        result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
+            408,
+            "request_timeout",
+            "Request timed out."));
+        result.Completed.Should().BeNull();
+        sessions.UpdatedStatuses.Should().ContainSingle().Which.Status.Should().Be(LlmSessionStatus.Cancelled);
     }
 
     [Fact]

--- a/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
@@ -80,17 +80,18 @@ public sealed class MainnetResponsesEndpointsTests
         root.GetProperty("id").GetString().Should().StartWith("resp_");
         var responseId = root.GetProperty("id").GetString()!;
         root.GetProperty("object").GetString().Should().Be("response");
-        root.GetProperty("status").GetString().Should().Be("in_progress");
+        root.GetProperty("status").GetString().Should().Be("completed");
         root.GetProperty("model").GetString().Should().Be("gpt-5.4");
         root.GetProperty("max_output_tokens").GetInt32().Should().Be(128);
         root.GetProperty("temperature").GetDouble().Should().Be(0.2);
         root.GetProperty("parallel_tool_calls").GetBoolean().Should().BeTrue();
         root.GetProperty("reasoning").GetProperty("effort").ValueKind.Should().Be(JsonValueKind.Null);
-        root.GetProperty("output").GetArrayLength().Should().Be(1);
-        root.GetProperty("output")[0].GetProperty("status").GetString().Should().Be("in_progress");
-        root.GetProperty("usage").ValueKind.Should().Be(JsonValueKind.Null);
+        AssertCompletedMessage(root, "pong");
+        root.GetProperty("usage").GetProperty("input_tokens").GetInt32().Should().Be(3);
+        root.GetProperty("usage").GetProperty("output_tokens").GetInt32().Should().Be(2);
+        root.GetProperty("usage").GetProperty("total_tokens").GetInt32().Should().Be(5);
 
-        provider.StreamCallCount.Should().Be(0);
+        provider.StreamCallCount.Should().Be(1);
         provider.LastRequest.Should().NotBeNull();
         provider.LastRequest!.Model.Should().Be("gpt-5.4");
         provider.LastRequest.MaxTokens.Should().Be(128);
@@ -126,7 +127,6 @@ public sealed class MainnetResponsesEndpointsTests
         sessions.Registered[0].OriginKind.Should().Be(LlmSessionOriginKind.ApiKey);
         var snapshot = await sessions.GetByResponseIdAsync(responseId);
         snapshot!.ActorId.Should().NotContain(responseId);
-        sessions.RecordedCompletions.Should().BeEmpty();
     }
 
     [Fact]
@@ -161,9 +161,8 @@ public sealed class MainnetResponsesEndpointsTests
 
         response.StatusCode.Should().Be(HttpStatusCode.OK, body);
         using var doc = JsonDocument.Parse(body);
-        doc.RootElement.GetProperty("status").GetString().Should().Be("in_progress");
-        doc.RootElement.GetProperty("output").GetArrayLength().Should().Be(1);
-        doc.RootElement.GetProperty("output")[0].GetProperty("status").GetString().Should().Be("in_progress");
+        doc.RootElement.GetProperty("status").GetString().Should().Be("completed");
+        AssertCompletedMessage(doc.RootElement, "eventually visible");
     }
 
     [Fact]
@@ -216,6 +215,37 @@ public sealed class MainnetResponsesEndpointsTests
     }
 
     [Fact]
+    public async Task PostResponses_WhenNonStreamObservationTimesOut_ShouldReturnTimeoutEnvelope()
+    {
+        var provider = new RecordingLLMProvider();
+        var sessions = new RecordingResponseSessionStore();
+        await using var app = await CreateAppAsync(
+            provider,
+            sessions,
+            observationService: StaticLlmSessionRunObservationService.Error(
+                LlmSessionRunObservedTerminalKind.TimedOut,
+                StatusCodes.Status504GatewayTimeout,
+                "response_timeout",
+                "Timed out waiting 30 seconds for the LLM run to emit a terminal event."));
+        var client = app.GetTestClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/v1/responses")
+        {
+            Content = JsonContent("""{"model":"gpt-5.4","input":"ping","stream":false}"""),
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "secret-token");
+
+        var response = await client.SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.GatewayTimeout, body);
+        GetErrorCode(body).Should().Be("response_timeout");
+        body.Should().NotContain("\"status\":\"in_progress\"");
+        body.Should().NotContain("\"object\":\"response\"");
+        sessions.StatusUpdates.Should().ContainSingle().Which.Status.Should().Be(LlmSessionStatus.Failed);
+    }
+
+    [Fact]
     public async Task PostResponses_WithDeclaredToolCall_ShouldPersistForwardedToolCallAndReturnFunctionCallItem()
     {
         const string parametersJson = """{"type":"object","properties":{"city":{"type":"string"}}}""";
@@ -263,9 +293,11 @@ public sealed class MainnetResponsesEndpointsTests
 
         response.StatusCode.Should().Be(HttpStatusCode.OK, body);
         using var doc = JsonDocument.Parse(body);
-        doc.RootElement.GetProperty("status").GetString().Should().Be("in_progress");
-        doc.RootElement.GetProperty("output").GetArrayLength().Should().Be(1);
-        doc.RootElement.GetProperty("output")[0].GetProperty("status").GetString().Should().Be("in_progress");
+        doc.RootElement.GetProperty("status").GetString().Should().Be("completed");
+        AssertCompletedMessage(doc.RootElement, string.Empty);
+        doc.RootElement.GetProperty("output").GetArrayLength().Should().Be(2);
+        doc.RootElement.GetProperty("output")[1].GetProperty("type").GetString().Should().Be("function_call");
+        doc.RootElement.GetProperty("output")[1].GetProperty("call_id").GetString().Should().Be("call_weather_1");
 
         provider.LastRequest.Should().NotBeNull();
         provider.LastRequest!.Tools.Should().NotBeNull();
@@ -338,7 +370,7 @@ public sealed class MainnetResponsesEndpointsTests
         var body = await response.Content.ReadAsStringAsync();
 
         response.StatusCode.Should().Be(HttpStatusCode.OK, body);
-        provider.StreamCallCount.Should().Be(0);
+        provider.StreamCallCount.Should().Be(1);
         provider.LastRequest.Should().NotBeNull();
         provider.LastRequest!.Tools.Should().NotBeNull();
         provider.LastRequest.Tools!.Select(static tool => tool.Name)
@@ -351,9 +383,9 @@ public sealed class MainnetResponsesEndpointsTests
             .Which.Content.Should().Be("delegate work");
         sessions.ForwardedToolCalls.Should().BeEmpty();
         using var doc = JsonDocument.Parse(body);
-        doc.RootElement.GetProperty("status").GetString().Should().Be("in_progress");
-        doc.RootElement.GetProperty("output").GetArrayLength().Should().Be(1);
-        doc.RootElement.GetProperty("output")[0].GetProperty("status").GetString().Should().Be("in_progress");
+        doc.RootElement.GetProperty("status").GetString().Should().Be("completed");
+        AssertCompletedMessage(doc.RootElement, string.Empty);
+        doc.RootElement.GetProperty("output")[1].GetProperty("call_id").GetString().Should().Be("call_task_1");
     }
 
     [Fact]
@@ -1589,13 +1621,12 @@ public sealed class MainnetResponsesEndpointsTests
         var body = await response.Content.ReadAsStringAsync();
 
         response.StatusCode.Should().Be(HttpStatusCode.OK, body);
-        provider.StreamCallCount.Should().Be(0);
+        provider.StreamCallCount.Should().Be(1);
         var command = app.Services.GetRequiredService<ResponsesRecordingActorDispatchPort>()
             .Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
         var argumentsJson = ToolChoiceHintArgumentsJson(command, "aevatar_invoke_gagent");
         AssertToolArgument(argumentsJson, "actor_id", "auth-pipeline-member");
-        sessions.RecordedCompletions.Should().BeEmpty();
-        body.Should().Contain("\"status\":\"in_progress\"");
+        body.Should().Contain("\"status\":\"completed\"");
 
         await app.StopAsync();
     }
@@ -2081,8 +2112,7 @@ public sealed class MainnetResponsesEndpointsTests
 
         response.StatusCode.Should().Be(HttpStatusCode.OK, body);
         responseSessions.Registered.Should().ContainSingle();
-        responseSessions.RecordedCompletions.Should().BeEmpty();
-        provider.StreamCallCount.Should().Be(0);
+        provider.StreamCallCount.Should().Be(1);
         provider.LastRequest.Should().NotBeNull();
         provider.LastRequest!.Tools.Should().NotBeNull();
         provider.LastRequest.Tools!.Select(static tool => tool.Name)
@@ -2094,9 +2124,9 @@ public sealed class MainnetResponsesEndpointsTests
 
         using var doc = JsonDocument.Parse(body);
         var root = doc.RootElement;
-        root.GetProperty("status").GetString().Should().Be("in_progress");
-        root.GetProperty("output").GetArrayLength().Should().Be(1);
-        root.GetProperty("output")[0].GetProperty("status").GetString().Should().Be("in_progress");
+        root.GetProperty("status").GetString().Should().Be("completed");
+        AssertCompletedMessage(root, string.Empty);
+        root.GetProperty("output")[1].GetProperty("call_id").GetString().Should().Be("call_gagent_1");
     }
 
     [Fact]
@@ -2221,7 +2251,7 @@ public sealed class MainnetResponsesEndpointsTests
         var body = await response.Content.ReadAsStringAsync();
 
         response.StatusCode.Should().Be(HttpStatusCode.OK, body);
-        body.Should().Contain("\"status\":\"in_progress\"");
+        body.Should().Contain("\"status\":\"completed\"");
         responseSessions.ForwardedToolCalls.Should().BeEmpty();
         var command = app.Services.GetRequiredService<ResponsesRecordingActorDispatchPort>()
             .Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
@@ -2300,7 +2330,6 @@ public sealed class MainnetResponsesEndpointsTests
             .Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
         ToolChoiceHintArgumentsJson(command, "aevatar_invoke_gagent")
             .Should().Contain("\"actor_id\":\"ghost-member\"");
-        responseSessions.RecordedCompletions.Should().BeEmpty();
     }
 
     [Fact]
@@ -2377,7 +2406,6 @@ public sealed class MainnetResponsesEndpointsTests
             .Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
         ToolChoiceHintArgumentsJson(command, "aevatar_invoke_gagent")
             .Should().Contain("\"actor_id\":\"bad/member\"");
-        responseSessions.RecordedCompletions.Should().BeEmpty();
     }
 
     [Fact]
@@ -2411,8 +2439,7 @@ public sealed class MainnetResponsesEndpointsTests
 
         response.StatusCode.Should().Be(HttpStatusCode.OK, body);
         responseSessions.Registered.Should().ContainSingle();
-        responseSessions.RecordedCompletions.Should().BeEmpty();
-        provider.StreamCallCount.Should().Be(0);
+        provider.StreamCallCount.Should().Be(1);
         var command = app.Services.GetRequiredService<ResponsesRecordingActorDispatchPort>()
             .Calls.Should().ContainSingle().Subject.Envelope.Payload.Unpack<LlmRunRequested>();
         var argumentsJson = ToolChoiceHintArgumentsJson(command, "aevatar_invoke_team");
@@ -2421,9 +2448,9 @@ public sealed class MainnetResponsesEndpointsTests
 
         using var doc = JsonDocument.Parse(body);
         var root = doc.RootElement;
-        root.GetProperty("status").GetString().Should().Be("in_progress");
-        root.GetProperty("output").GetArrayLength().Should().Be(1);
-        root.GetProperty("output")[0].GetProperty("status").GetString().Should().Be("in_progress");
+        root.GetProperty("status").GetString().Should().Be("completed");
+        AssertCompletedMessage(root, string.Empty);
+        root.GetProperty("output")[1].GetProperty("call_id").GetString().Should().Be("call_team_1");
     }
 
     [Fact]
@@ -2507,7 +2534,6 @@ public sealed class MainnetResponsesEndpointsTests
         var argumentsJson = ToolChoiceHintArgumentsJson(command, "aevatar_invoke_team");
         AssertToolArgument(argumentsJson, "team_id", "missing-team");
         AssertToolArgument(argumentsJson, "endpoint_id", "chat");
-        responseSessions.RecordedCompletions.Should().BeEmpty();
     }
 
     [Fact]
@@ -2544,7 +2570,8 @@ public sealed class MainnetResponsesEndpointsTests
         IResponsesToolProvider? responsesToolProvider = null,
         IResponsesModelsAggregator? modelsAggregator = null,
         IResponsesRouteResolver? routeResolver = null,
-        IChatRoutePolicyQueryPort? chatRoutePolicyQueryPort = null)
+        IChatRoutePolicyQueryPort? chatRoutePolicyQueryPort = null,
+        ILlmSessionRunObservationService? observationService = null)
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
         {
@@ -2562,7 +2589,10 @@ public sealed class MainnetResponsesEndpointsTests
         builder.Services.AddSingleton<IActorDispatchPort>(static sp => sp.GetRequiredService<ResponsesRecordingActorDispatchPort>());
         builder.Services.AddSingleton<ILlmSessionObservationScopeLeasePreparationPort>(static sp => sp.GetRequiredService<ResponsesObservationRuntime>().ScopePreparationPort);
         builder.Services.AddSingleton<ILlmSessionObservationProjectionPort>(static sp => sp.GetRequiredService<ResponsesObservationRuntime>().ProjectionPort);
-        builder.Services.AddSingleton<ILlmSessionRunObservationService, LlmSessionRunObservationService>();
+        if (observationService is null)
+            builder.Services.AddSingleton<ILlmSessionRunObservationService, LlmSessionRunObservationService>();
+        else
+            builder.Services.AddSingleton(observationService);
         builder.Services.AddSingleton<IResponsesCommandFacade, ResponsesCommandFacade>();
         builder.Services.AddSingleton<IResponsesToolClassificationService, ResponsesToolClassificationService>();
         builder.Services.AddSingleton<IResponsesDirectToolPlanService, ResponsesDirectToolPlanService>();
@@ -2630,6 +2660,29 @@ public sealed class MainnetResponsesEndpointsTests
             }
 
             return DispatchAdmissionFactory.Create(actorId, envelope);
+        }
+    }
+
+    private sealed class StaticLlmSessionRunObservationService(LlmSessionRunObservedResult result)
+        : ILlmSessionRunObservationService
+    {
+        public static StaticLlmSessionRunObservationService Error(
+            LlmSessionRunObservedTerminalKind kind,
+            int statusCode,
+            string code,
+            string message) =>
+            new(new LlmSessionRunObservedResult(
+                null,
+                null,
+                new LlmSessionRunObservedError(kind, statusCode, code, message)));
+
+        public async Task<LlmSessionRunObservedResult> ObserveAsync(
+            LlmSessionRunObservationRequest request,
+            Func<LlmSessionRunObservedDelta, CancellationToken, ValueTask>? onDelta,
+            CancellationToken ct = default)
+        {
+            var admission = await request.DispatchAsync(ct);
+            return result with { Admission = admission };
         }
     }
 
@@ -2809,6 +2862,20 @@ public sealed class MainnetResponsesEndpointsTests
     {
         using var doc = JsonDocument.Parse(json);
         return doc.RootElement.GetProperty("error").GetProperty("code").GetString();
+    }
+
+    private static void AssertCompletedMessage(JsonElement response, string expectedText)
+    {
+        var output = response.GetProperty("output");
+        output.GetArrayLength().Should().BeGreaterThan(0);
+        output[0].GetProperty("status").GetString().Should().Be("completed");
+        if (string.IsNullOrWhiteSpace(expectedText))
+        {
+            output[0].GetProperty("content").GetArrayLength().Should().Be(0);
+            return;
+        }
+
+        output[0].GetProperty("content")[0].GetProperty("text").GetString().Should().Be(expectedText);
     }
 
     private static IReadOnlyList<IReadOnlyList<LLMStreamChunk>> ToolThenTextBatches(


### PR DESCRIPTION
## Summary / 摘要

issue #2025：mainnet 实测发现默认非流式 `POST /v1/responses` 返回不可取回的 `in_progress`（Host 无 `GET /v1/responses/{id}`），任何标准 OpenAI Responses 客户端拿到受理回执后无路可走。

按 design-consensus r2 共识（**minimal** framing，3 solver + meta-judge，artifact 见 issue 共识卡片）：

- **Old**：默认非流式 create 在 dispatch ACK 后返回 `status:"in_progress"` / 空 `output`，response id 永不可取回。
- **New**：默认非流式 create 走 `Dispatch -> Observe -> terminal`（复用 `ILlmSessionRunObservationService`）；成功只返回 completed JSON；observation timeout=504 `response_timeout`、terminal failure=error envelope、terminal cancellation=409 `run_cancelled`、请求取消沿用 408 `request_timeout`；**符号级删除** `ResponsesCreateAcceptedCommandResult` 与 Host accepted 渲染分支，禁止 fallback accepted。

`background:true`、`GET /v1/responses/{id}`、typed request/readmodel 检索契约按共识划入后续独立 issue。

## Scope / 范围

6 files changed (+271/−104)：ResponsesCommandFacade / ResponsesCommandContracts / ResponsesEndpoints / 两个测试工程 / docs/canon/nyxid-responses-direct.md。

## 验证

- `dotnet test test/Aevatar.GAgentService.Tests` 865/865
- `dotnet test test/Aevatar.Hosting.Tests` 272/272
- `bash tools/ci/test_stability_guards.sh` 通过

Closes #2025

🤖 Auto-loop / consensus-rnd scoped run issue-2025

⟦AI:AUTO-LOOP⟧
