### PR TITLE
Add Team roster loading skeletons

### DIFF
--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -1226,6 +1226,33 @@ describe("TeamDetailPage", () => {
     expect(screen.queryByRole("button", { name: "打开 Services" })).toBeNull();
   });
 
+  it("shows the members table skeleton while the Team member roster loads", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha?tab=members",
+    );
+    let resolveTeamMembers: (value: unknown) => void = () => undefined;
+    (studioApi.listTeamMembers as jest.Mock).mockImplementationOnce(
+      () =>
+        new Promise<unknown>((resolve) => {
+          resolveTeamMembers = resolve;
+        }),
+    );
+
+    const { unmount } = renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    expect(await screen.findByTestId("team-members-skeleton")).toBeTruthy();
+    expect(screen.getAllByTestId("team-members-skeleton-row")).toHaveLength(3);
+    expect(screen.queryByText("这支团队还没有成员")).toBeNull();
+    expect(screen.queryByText("Team Alpha Operator")).toBeNull();
+
+    unmount();
+    await act(async () => {
+      resolveTeamMembers(mockCreateTeamMembersCatalog());
+    });
+  });
+
   it("marks the route-selected member in the members tab", async () => {
     window.history.replaceState(
       {},

--- a/apps/aevatar-console-web/src/pages/teams/home.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import { setLocale } from "@umijs/max";
 import React from "react";
 import { scopeRuntimeApi } from "@/shared/api/scopeRuntimeApi";
@@ -189,7 +189,13 @@ describe("TeamsHomePage", () => {
 
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
-    expect(await screen.findByRole("button", { name: "Debug entry workflow" })).toBeTruthy();
+    expect(
+      await screen.findByRole(
+        "button",
+        { name: "Debug entry workflow" },
+        { timeout: 3000 },
+      ),
+    ).toBeTruthy();
     expect(screen.getByRole("button", { name: "View team" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "View members" })).toBeTruthy();
     expect(screen.getByText("My AI teams")).toBeTruthy();
@@ -914,5 +920,61 @@ describe("TeamsHomePage", () => {
     fireEvent.click(await screen.findByRole("button", { name: "组建新团队" }));
 
     expect(window.location.pathname).toBe("/scopes/scope-a/teams/new");
+  });
+
+  it("shows the home skeleton while the route scope waits for server auth confirmation", async () => {
+    let resolveAuthSession: (value: unknown) => void = () => undefined;
+    (studioApi.getAuthSession as jest.Mock).mockImplementationOnce(
+      () =>
+        new Promise<unknown>((resolve) => {
+          resolveAuthSession = resolve;
+        }),
+    );
+
+    const { unmount } = renderWithQueryClient(React.createElement(TeamsHomePage));
+
+    expect(await screen.findByTestId("teams-home-skeleton")).toBeTruthy();
+    expect(screen.getAllByTestId("teams-home-summary-skeleton")).toHaveLength(3);
+    expect(screen.getAllByTestId("teams-home-card-skeleton")).toHaveLength(3);
+    expect(screen.queryByText("AI 团队总数")).toBeNull();
+    expect(studioApi.listTeams).not.toHaveBeenCalled();
+    expect(studioApi.listMembers).not.toHaveBeenCalled();
+    expect(scopeRuntimeApi.listServices).not.toHaveBeenCalled();
+
+    unmount();
+    await act(async () => {
+      resolveAuthSession({
+        enabled: false,
+        scopeId: "scope-a",
+        scopeSource: "nyxid",
+      });
+    });
+  });
+
+  it("shows the home skeleton while the Team roster loads", async () => {
+    let resolveTeams: (value: unknown) => void = () => undefined;
+    (studioApi.listTeams as jest.Mock).mockImplementationOnce(
+      () =>
+        new Promise<unknown>((resolve) => {
+          resolveTeams = resolve;
+        }),
+    );
+
+    const { unmount } = renderWithQueryClient(React.createElement(TeamsHomePage));
+
+    expect(await screen.findByTestId("teams-home-skeleton")).toBeTruthy();
+    expect(screen.getAllByTestId("teams-home-summary-skeleton")).toHaveLength(3);
+    expect(screen.getAllByTestId("teams-home-card-skeleton")).toHaveLength(3);
+    expect(screen.queryByText("AI 团队总数")).toBeNull();
+    expect(screen.queryByText("当前账号还没有创建团队")).toBeNull();
+
+    unmount();
+    await act(async () => {
+      resolveTeams({
+        scopeId: "scope-a",
+        teams: defaultTeams,
+        nextPageToken: null,
+      });
+    });
   });
 });

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -10,6 +10,7 @@ import {
   Alert,
   Button,
   Empty,
+  Skeleton,
   Space,
   Tooltip,
   Typography,
@@ -32,10 +33,7 @@ import {
   type StudioMemberSummary,
   type StudioTeamSummary,
 } from "@/shared/studio/models";
-import {
-  AevatarInspectorEmpty,
-  AevatarPageShell,
-} from "@/shared/ui/aevatarPageShells";
+import { AevatarPageShell } from "@/shared/ui/aevatarPageShells";
 import { describeError } from "@/shared/ui/errorText";
 import { resolveStudioScopeContext } from "../scopes/components/resolvedScope";
 import {
@@ -345,6 +343,46 @@ const SummaryStatCard: React.FC<{
   );
 };
 
+const SkeletonLine: React.FC<{
+  readonly height?: number;
+  readonly width: number | string;
+}> = ({ height = 16, width }) => (
+  <Skeleton.Input
+    active
+    size="small"
+    style={{
+      borderRadius: 999,
+      height,
+      maxWidth: "100%",
+      width,
+    }}
+  />
+);
+
+const SummaryStatSkeletonCard: React.FC = () => {
+  const { token } = theme.useToken();
+
+  return (
+    <div
+      data-testid="teams-home-summary-skeleton"
+      style={{
+        background: token.colorBgContainer,
+        border: `1px solid ${token.colorBorderSecondary}`,
+        borderRadius: 22,
+        boxShadow: token.boxShadowTertiary,
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        minHeight: 104,
+        padding: 18,
+      }}
+    >
+      <SkeletonLine height={30} width={68} />
+      <SkeletonLine width="72%" />
+    </div>
+  );
+};
+
 const TeamTitle: React.FC<{
   readonly level: 3 | 4;
   readonly title: string;
@@ -414,6 +452,150 @@ const TeamFact: React.FC<{
     </div>
   );
 };
+
+const TeamRosterCardSkeleton: React.FC = () => {
+  const { token } = theme.useToken();
+
+  return (
+    <article
+      data-testid="teams-home-card-skeleton"
+      style={{
+        background: token.colorBgContainer,
+        border: `1px solid ${token.colorBorderSecondary}`,
+        borderRadius: 24,
+        boxShadow: token.boxShadowTertiary,
+        display: "flex",
+        flexDirection: "column",
+        gap: 16,
+        minWidth: 0,
+        padding: 18,
+      }}
+    >
+      <div
+        style={{
+          alignItems: "flex-start",
+          display: "flex",
+          gap: 16,
+          justifyContent: "space-between",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            flex: "1 1 auto",
+            flexDirection: "column",
+            gap: 10,
+            minWidth: 0,
+          }}
+        >
+          <SkeletonLine height={26} width="62%" />
+          <SkeletonLine width="88%" />
+        </div>
+        <Skeleton.Button active shape="round" size="small" style={{ width: 92 }} />
+      </div>
+      <SkeletonLine width="38%" />
+      <div
+        style={{
+          borderTop: `1px solid ${token.colorBorderSecondary}`,
+          display: "grid",
+          gap: 14,
+          gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+          paddingTop: 14,
+        }}
+      >
+        <SkeletonLine width="78%" />
+        <SkeletonLine width="68%" />
+        <SkeletonLine width="74%" />
+      </div>
+      <div
+        style={{
+          borderTop: `1px solid ${token.colorBorderSecondary}`,
+          display: "grid",
+          gap: 14,
+          gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+          paddingTop: 14,
+        }}
+      >
+        <SkeletonLine width="80%" />
+        <SkeletonLine width="72%" />
+      </div>
+      <Space size={8} wrap>
+        <Skeleton.Button active shape="round" style={{ width: 132 }} />
+        <Skeleton.Button active shape="round" style={{ width: 108 }} />
+        <Skeleton.Button active shape="round" style={{ width: 126 }} />
+      </Space>
+    </article>
+  );
+};
+
+const summaryStatSkeletonKeys = ["total", "actionable", "healthy"] as const;
+const rosterCardSkeletonKeys = ["primary", "secondary", "tertiary"] as const;
+
+const TeamsHomeLoadingSkeleton: React.FC = () => (
+  <section
+    aria-busy="true"
+    aria-label={t("pages.teams.home.copy.53", "Reading the team list.")}
+    data-testid="teams-home-skeleton"
+    role="status"
+    style={{ display: "flex", flexDirection: "column", gap: 20 }}
+  >
+    <div
+      style={{
+        display: "grid",
+        gap: 16,
+        gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+      }}
+    >
+      {summaryStatSkeletonKeys.map((key) => (
+        <SummaryStatSkeletonCard key={key} />
+      ))}
+    </div>
+
+    <div
+      style={{
+        alignItems: "center",
+        display: "flex",
+        flexWrap: "wrap",
+        gap: 12,
+        justifyContent: "space-between",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 8,
+          minWidth: 240,
+        }}
+      >
+        <SkeletonLine height={22} width={128} />
+        <SkeletonLine width={360} />
+      </div>
+      <Space.Compact>
+        <Skeleton.Button active style={{ height: 44, width: 44 }} />
+        <Skeleton.Button active style={{ height: 44, width: 44 }} />
+      </Space.Compact>
+    </div>
+
+    <ul
+      aria-hidden="true"
+      style={{
+        display: "grid",
+        gap: 16,
+        gridTemplateColumns: "repeat(auto-fit, minmax(340px, 1fr))",
+        listStyle: "none",
+        margin: 0,
+        padding: 0,
+      }}
+    >
+      {rosterCardSkeletonKeys.map((key) => (
+        <li key={key}>
+          <TeamRosterCardSkeleton />
+        </li>
+      ))}
+    </ul>
+  </section>
+);
 
 function compareMembers(
   left: StudioMemberSummary,
@@ -723,7 +905,6 @@ function renderMemberQuickActionIcon(
       return <BarsOutlined />;
     case "edit-entry-member":
     case "edit-member":
-    default:
       return <EditOutlined />;
   }
 }
@@ -1064,6 +1245,8 @@ const TeamsHomePage: React.FC = () => {
   const queryScopeId =
     serverResolvedScope?.scopeId?.trim() === scopeId ? scopeId : "";
   const canLoadRoster = queryScopeId.length > 0;
+  const scopeAuthResolving =
+    scopeId.length > 0 && !canLoadRoster && authSessionQuery.isLoading;
 
   React.useEffect(() => {
     if (!scopeId) {
@@ -1232,6 +1415,8 @@ const TeamsHomePage: React.FC = () => {
     manualRosterView ??
     (visibleTeamCount >= compactTeamRosterThreshold ? "list" : "cards");
   const useCompactRoster = resolvedRosterView === "list";
+  const rosterBootstrapLoading =
+    scopeAuthResolving || (!teamsQuery.isError && teamsQuery.isLoading);
   const emptyRosterHint =
     canLoadRoster
       ? t("pages.teams.home.team.ai", "This account has not created any teams yet. Your AI team list will appear here after you create one.")
@@ -1319,8 +1504,17 @@ const TeamsHomePage: React.FC = () => {
           />
         ) : null}
 
-        {canLoadRoster ? (
-          <>
+        {canLoadRoster || scopeAuthResolving ? (
+          rosterBootstrapLoading ? (
+            <TeamsHomeLoadingSkeleton />
+          ) : teamsQuery.isError ? (
+            <Alert
+              showIcon
+              title={t("pages.teams.home.copy.54", "The team list cannot be loaded right now.")}
+              type="error"
+            />
+          ) : (
+            <>
             <div
               style={{
                 display: "grid",
@@ -1333,15 +1527,7 @@ const TeamsHomePage: React.FC = () => {
               <SummaryStatCard label={t("pages.teams.home.copy.52", "Stable runs exist")} value={healthyTeamCount} />
             </div>
 
-            {teamsQuery.isLoading ? (
-              <AevatarInspectorEmpty description={t("pages.teams.home.copy.53", "Reading the team list.")} />
-            ) : teamsQuery.isError ? (
-              <Alert
-                showIcon
-                title={t("pages.teams.home.copy.54", "The team list cannot be loaded right now.")}
-                type="error"
-              />
-            ) : teamPreviews.length > 0 ? (
+            {teamPreviews.length > 0 ? (
               <>
                 <div
                   style={{
@@ -1444,8 +1630,8 @@ const TeamsHomePage: React.FC = () => {
                   {t("pages.teams.home.copy.62", "Create team")}</Button>
               </Empty>
             )}
-
-          </>
+            </>
+          )
         ) : null}
       </div>
     </AevatarPageShell>

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
@@ -4,7 +4,7 @@ import {
   PlusOutlined,
   ToolOutlined,
 } from "@ant-design/icons";
-import { Button, Tooltip, Typography, theme } from "antd";
+import { Button, Skeleton, Tooltip, Typography, theme } from "antd";
 import { useIntl } from "@umijs/max";
 import React from "react";
 import {
@@ -210,6 +210,24 @@ const entryActionStyle: React.CSSProperties = {
   paddingInline: 12,
 };
 
+const memberRosterSkeletonRowKeys = ["primary", "secondary", "tertiary"] as const;
+
+const SkeletonLine: React.FC<{
+  readonly height?: number;
+  readonly width: number | string;
+}> = ({ height = 16, width }) => (
+  <Skeleton.Input
+    active
+    size="small"
+    style={{
+      borderRadius: 999,
+      height,
+      maxWidth: "100%",
+      width,
+    }}
+  />
+);
+
 const panelHeaderStyle: React.CSSProperties = {
   alignItems: "center",
   display: "flex",
@@ -284,6 +302,110 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
     borderBottom: `1px solid ${token.colorBorderSecondary}`,
     color: token.colorTextSecondary,
   };
+  const renderTableHeader = () => (
+    <div className="team-members-table-header" style={tableHeadStyle}>
+      <span>{intl.formatMessage({ id: "teams.members.columns.member" })}</span>
+      <span>
+        {intl.formatMessage({ id: "teams.members.columns.implementation" })}
+      </span>
+      <span>{intl.formatMessage({ id: "teams.members.columns.service" })}</span>
+      <span style={tableHeaderActionStyle}>
+        {intl.formatMessage({ id: "teams.members.columns.actions" })}
+      </span>
+    </div>
+  );
+  const renderTableSkeleton = (status: "loading" | "syncing") => {
+    const statusTitle = intl.formatMessage({
+      id:
+        status === "syncing"
+          ? "teams.members.syncing.title"
+          : "teams.members.loading.title",
+    });
+    const statusDescription = intl.formatMessage({
+      id:
+        status === "syncing"
+          ? "teams.members.syncing.description"
+          : "teams.members.loading.description",
+    });
+
+    return (
+      <div
+        aria-busy="true"
+        aria-label={statusTitle}
+        data-testid="team-members-skeleton"
+        role="status"
+        style={{ display: "flex", flexDirection: "column", gap: 12 }}
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          <Typography.Text strong>{statusTitle}</Typography.Text>
+          <Typography.Text style={{ fontSize: 13 }} type="secondary">
+            {statusDescription}
+          </Typography.Text>
+        </div>
+        <div style={tableFrameStyle}>
+          <div style={tableScrollStyle}>
+            <div style={tableInnerStyle}>
+              <style>{responsiveTableStyle}</style>
+              {renderTableHeader()}
+              {memberRosterSkeletonRowKeys.map((key, index) => (
+                <div
+                  className="team-members-table-row"
+                  data-testid="team-members-skeleton-row"
+                  key={key}
+                  style={{
+                    ...rosterRowBaseStyle,
+                    background: token.colorBgContainer,
+                    borderTop:
+                      index === 0
+                        ? "none"
+                        : `1px solid ${token.colorBorderSecondary}`,
+                  }}
+                >
+                  <div style={memberCellStyle}>
+                    <SkeletonLine height={22} width="64%" />
+                    <SkeletonLine width="88%" />
+                  </div>
+                  <div style={implementationCellStyle}>
+                    <SkeletonLine width="58%" />
+                    <SkeletonLine height={24} width={92} />
+                  </div>
+                  <div style={serviceCellStyle}>
+                    <SkeletonLine width="72%" />
+                    <SkeletonLine width="86%" />
+                  </div>
+                  <div className="team-members-table-actions" style={actionCellStyle}>
+                    <div
+                      className="team-members-table-primary-actions"
+                      style={primaryActionsStyle}
+                    >
+                      <Skeleton.Button
+                        active
+                        className="team-members-table-invoke-action"
+                        size="small"
+                        style={invokeActionStyle}
+                      />
+                      <Skeleton.Button
+                        active
+                        className="team-members-table-studio-action"
+                        size="small"
+                        style={studioActionStyle}
+                      />
+                    </div>
+                    <Skeleton.Button
+                      active
+                      className="team-members-table-entry-action"
+                      size="small"
+                      style={entryActionStyle}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
   const handleNavigate = React.useCallback(
     (href: string) => (event: React.MouseEvent<HTMLElement>) => {
       if (!href || !onNavigate) {
@@ -338,21 +460,9 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
           {intl.formatMessage({ id: "teams.members.description" })}
         </Typography.Text>
         {rosterSyncing ? (
-          <AevatarInspectorEmpty
-            compact
-            title={intl.formatMessage({ id: "teams.members.syncing.title" })}
-            description={intl.formatMessage({
-              id: "teams.members.syncing.description",
-            })}
-          />
+          renderTableSkeleton("syncing")
         ) : rosterLoading ? (
-          <AevatarInspectorEmpty
-            compact
-            title={intl.formatMessage({ id: "teams.members.loading.title" })}
-            description={intl.formatMessage({
-              id: "teams.members.loading.description",
-            })}
-          />
+          renderTableSkeleton("loading")
         ) : rosterError ? (
           <AevatarInspectorEmpty
             compact
@@ -366,16 +476,7 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
             <div style={tableScrollStyle}>
               <div style={tableInnerStyle}>
                 <style>{responsiveTableStyle}</style>
-                <div className="team-members-table-header" style={tableHeadStyle}>
-                  <span>{intl.formatMessage({ id: "teams.members.columns.member" })}</span>
-                  <span>
-                    {intl.formatMessage({ id: "teams.members.columns.implementation" })}
-                  </span>
-                  <span>{intl.formatMessage({ id: "teams.members.columns.service" })}</span>
-                  <span style={tableHeaderActionStyle}>
-                    {intl.formatMessage({ id: "teams.members.columns.actions" })}
-                  </span>
-                </div>
+                {renderTableHeader()}
                 {rosterRows.map((row, index) => {
                   const invokeDisabledReason = row.workflowSupported
                     ? intl.formatMessage({


### PR DESCRIPTION
## Problem
Closes #2028.

Team home and Team member list could briefly render an empty or low-structure loading surface while scope authorization, Team roster, or Team member roster queries were still in flight. That produced a visible white/blank interval and layout jump before the real roster appeared.

## Solution
- Add a structured Team home skeleton for route-scope auth confirmation and Team roster bootstrap loading.
- Replace the Team members tab compact loading/empty placeholder with a table-shaped skeleton for both roster loading and projection-sync retry windows.
- Keep existing loading/syncing copy so the state remains explicit while the layout stays stable.
- Add tests that pin both the Team home and member roster loading windows.

## Impact Paths
- `apps/aevatar-console-web/src/pages/teams/home.tsx`
- `apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx`
- `apps/aevatar-console-web/src/pages/teams/home.test.tsx`
- `apps/aevatar-console-web/src/pages/teams/detail.test.tsx`

## Verification
- `pnpm --dir apps/aevatar-console-web exec biome lint src/pages/teams/home.tsx src/pages/teams/home.test.tsx src/pages/teams/tabs/TeamMembersTab.tsx src/pages/teams/detail.test.tsx`
- `pnpm --dir apps/aevatar-console-web jest src/pages/teams/detail.test.tsx src/pages/teams/home.test.tsx --runInBand` — passed, 80 tests. Jest emitted the existing Watchman recrawl warning and a post-run async-handle hint while exiting with code 0.
- `pnpm --dir apps/aevatar-console-web tsc`
- `bash tools/ci/test_stability_guards.sh`
- `pnpm --dir apps/aevatar-console-web build`
- `git diff --check`
