### PR TITLE
Fix Studio GAgent build contract

### DIFF
--- a/apps/aevatar-console-web/src/shared/api/runtimeGAgentApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/runtimeGAgentApi.test.ts
@@ -54,7 +54,7 @@ describe("runtimeGAgentApi", () => {
       string,
       RequestInit | undefined,
     ];
-    expect(input).toBe("/api/scopes/gagent-kinds");
+    expect(input).toBe("/api/scopes/gagent-types");
     expect(new Headers(init?.headers).get("Authorization")).toBe(
       "Bearer access-token"
     );
@@ -169,6 +169,7 @@ describe("runtimeGAgentApi", () => {
       preferredActorId: "orders-1",
       timeoutMs: undefined,
     });
+    expect(JSON.parse(String(init?.body))).not.toHaveProperty("actorTypeName");
     expect(init?.signal).toBe(controller.signal);
   });
 

--- a/apps/aevatar-console-web/src/shared/api/runtimeGAgentApi.ts
+++ b/apps/aevatar-console-web/src/shared/api/runtimeGAgentApi.ts
@@ -325,7 +325,7 @@ function decodeBindingRetirementResult(
 export const runtimeGAgentApi = {
   listKinds(): Promise<RuntimeGAgentKindDescriptor[]> {
     return requestJson(
-      "/api/scopes/gagent-kinds",
+      "/api/scopes/gagent-types",
       (value) =>
         expectArray(value, "RuntimeGAgentKindDescriptor[]", decodeGAgentKindDescriptor)
     );

--- a/docs/adr/0030-gagent-registry-agent-kind-key.md
+++ b/docs/adr/0030-gagent-registry-agent-kind-key.md
@@ -26,7 +26,7 @@ Registry state, registry commands/events, admission checks, draft-run targets, H
 
 Legacy registry rows keyed by CLR type names are migrated by the registry authority only. `GAgentRegistryGAgent` probes the actor-owned kind contract, commits one `ActorRegistrationKeyCanonicalizedEvent` per actor when the canonical kind is known, and quarantines unmappable rows. No application, read model, or adapter may use CLR-name mapping fallback for admission.
 
-The scope GAgent catalog route is `/api/scopes/gagent-kinds`. The old `/api/scopes/gagent-types` route is not mapped and returns ordinary `404 Not Found`.
+The Studio-facing scope GAgent catalog route is `/api/scopes/gagent-types`, but the route returns a strongly typed `AgentKind` catalog. The route name is a UI capability surface, not permission to use CLR type names as registry identity.
 
 ## Consequences
 

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeGAgentEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeGAgentEndpoints.cs
@@ -27,7 +27,7 @@ public static class ScopeGAgentEndpoints
     public static IEndpointRouteBuilder MapScopeGAgentCapabilityEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/scopes").WithTags("ScopeGAgent");
-        group.MapGet("/gagent-kinds", HandleListGAgentKindsAsync);
+        group.MapGet("/gagent-types", HandleListGAgentKindsAsync);
         group.MapPost("/{scopeId}/gagent/draft-run", HandleDraftRunAsync);
         group.MapGet("/{scopeId}/gagent-actors", HandleListActorsAsync);
         group.MapPost("/{scopeId}/gagent-actors", HandleAddActorAsync);

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeGAgentEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeGAgentEndpointsTests.cs
@@ -54,8 +54,8 @@ public sealed class ScopeGAgentEndpointsTests
             .Where(r => r != null)
             .ToHashSet(StringComparer.Ordinal);
 
-        routes.Should().Contain(route => route.Contains("gagent-kinds"));
-        routes.Should().NotContain(route => route.Contains("gagent-types"));
+        routes.Should().Contain(route => route.Contains("gagent-types"));
+        routes.Should().NotContain(route => route.Contains("gagent-kinds"));
         routes.Should().Contain(route => route.Contains("gagent/draft-run"));
         routes.Should().Contain(route => route.Contains("gagent-actors"));
         routes.Should().Contain("/api/scopes/{scopeId}/execution-events");
@@ -120,12 +120,32 @@ public sealed class ScopeGAgentEndpointsTests
     }
 
     [Fact]
-    public async Task OldGAgentTypesRoute_ShouldReturnNotFoundOverHttp()
+    public async Task GAgentTypesRoute_ShouldReturnAgentKindCatalogOverHttp()
     {
-        await using var host = await ScopeGAgentEndpointHostedTestHost.StartAsync(new FakeGAgentDraftRunInteractionPort());
+        var catalogReader = new FakeServiceCatalogQueryReader
+        {
+            Services = [CreateServiceCatalogSnapshot("orders")],
+        };
+        var revisionReader = new FakeServiceRevisionCatalogQueryReader();
+        revisionReader.Revisions[ServiceKeys.Build(CreateServiceIdentity("orders"))] = new ServiceRevisionCatalogSnapshot(
+            ServiceKeys.Build(CreateServiceIdentity("orders")),
+            [CreateStaticRevisionSnapshot(
+                "rev-1",
+                "Tests.OrdersGAgent, Tests",
+                "tests.orders",
+                "run")],
+            DateTimeOffset.UtcNow);
+        await using var host = await ScopeGAgentEndpointHostedTestHost.StartAsync(
+            new FakeGAgentDraftRunInteractionPort(),
+            catalogReader,
+            revisionReader);
         using var response = await host.Client.GetAsync("/api/scopes/gagent-types");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("\"agentKind\":\"tests.orders\"");
+        body.Should().Contain("\"diagnosticClrTypeName\":\"Tests.OrdersGAgent, Tests\"");
+        body.Should().NotContain("actorTypeName");
     }
 
     [Fact]
@@ -1641,7 +1661,9 @@ public sealed class ScopeGAgentEndpointsTests
         public InMemoryStreamProvider StreamProvider { get; }
 
         public static async Task<ScopeGAgentEndpointHostedTestHost> StartAsync(
-            FakeGAgentDraftRunInteractionPort interactionPort)
+            FakeGAgentDraftRunInteractionPort interactionPort,
+            IServiceCatalogQueryReader? catalogReader = null,
+            IServiceRevisionCatalogQueryReader? revisionCatalogReader = null)
         {
             var builder = WebApplication.CreateBuilder(new WebApplicationOptions
             {
@@ -1657,6 +1679,8 @@ public sealed class ScopeGAgentEndpointsTests
             builder.Services.AddSingleton<IGAgentActorRegistryCommandPort>(actorStore);
             builder.Services.AddSingleton<IGAgentActorRegistryQueryPort>(actorStore);
             builder.Services.AddSingleton<IScopeResourceAdmissionPort>(actorStore);
+            builder.Services.AddSingleton(catalogReader ?? new FakeServiceCatalogQueryReader());
+            builder.Services.AddSingleton(revisionCatalogReader ?? new FakeServiceRevisionCatalogQueryReader());
 
             var app = builder.Build();
             app.Use(async (http, next) =>

--- a/tools/ci/gagent_registry_kind_guard.sh
+++ b/tools/ci/gagent_registry_kind_guard.sh
@@ -88,13 +88,13 @@ report_filtered_matches \
   "${registry_identity_paths[@]}"
 
 report_matches \
-  "Scope GAgent route production code must not expose gagent-types" \
-  "gagent-types|/gagent-types|HandleListGAgentTypesAsync|GAgentTypeCatalogHttpResponse" \
+  "Scope GAgent catalog production code must not reintroduce type-keyed catalog models" \
+  "HandleListGAgentTypesAsync|GAgentTypeCatalogHttpResponse" \
   "src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeGAgentEndpoints.cs"
 
 report_matches \
   "Frontend runtime identity code must not keep type-keyed catalog aliases" \
-  "RuntimeGAgentTypeDescriptor|selectedGAgentTypeName|gAgentTypes|listTypes\\(|gagent-types|/gagent-types|normalizeRuntimeGAgentTypeName" \
+  "RuntimeGAgentTypeDescriptor|selectedGAgentTypeName|gAgentTypes|listTypes\\(|normalizeRuntimeGAgentTypeName" \
   "${frontend_runtime_identity_paths[@]}"
 
 report_filtered_matches \
@@ -153,9 +153,9 @@ report_filtered_matches \
   "test/Aevatar.AI.ToolProviders.Binding.Tests"
 
 report_filtered_matches \
-  "Positive tests must not use the old gagent-types route" \
-  "gagent-types|/gagent-types" \
-  "NotContain|Should\\(\\)\\.Be\\(StatusCodes\\.Status404NotFound\\)|Should\\(\\)\\.Be\\(HttpStatusCode\\.NotFound\\)|GetAsync\\(\"/api/scopes/gagent-types\"\\)|returns 404|old route" \
+  "Tests must not treat gagent-types as a legacy type-keyed route" \
+  "GAgentTypeCatalog|gagent type|old gagent-types|old /api/scopes/gagent-types" \
+  "NotContain" \
   "test" \
   "apps/aevatar-console-web/src"
 


### PR DESCRIPTION
## Summary
- Expose the Studio-facing GAgent catalog at `/api/scopes/gagent-types` while keeping `agentKind` as the semantic catalog/dry-run key.
- Update frontend runtime API calls and tests to use the aligned catalog route and verify dry-run payloads do not send `actorTypeName`.
- Update endpoint integration tests, ADR wording, and the registry guard so route naming does not reintroduce CLR type identity semantics.

## Test plan
- [x] `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --filter FullyQualifiedName~ScopeGAgentEndpointsTests`
- [x] `pnpm --dir apps/aevatar-console-web jest src/shared/api/runtimeGAgentApi.test.ts --runInBand`
- [x] `bash tools/ci/gagent_registry_kind_guard.sh`
- [x] `bash tools/ci/test_stability_guards.sh`

Fixes #1831

🤖 Generated with [Claude Code](https://claude.com/claude-code)