### PR TITLE
Reduce Team card action button size

### DIFF
--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -913,14 +913,17 @@ const TeamRosterActionGroup: React.FC<{
   readonly large?: boolean;
   readonly preview: TeamRosterPreview;
 }> = ({ large = false, preview }) => {
-  const buttonSize = large ? "large" : "middle";
+  const buttonSize = "middle";
   const { token } = theme.useToken();
   const showViewMembersAction =
     preview.memberQuickAction.href !== preview.membersHref;
   const buttonStyle: React.CSSProperties = {
     borderRadius: 999,
+    fontSize: large ? 13 : 12,
     fontWeight: 600,
-    paddingInline: large ? 12 : 10,
+    height: large ? 34 : 30,
+    lineHeight: "20px",
+    paddingInline: large ? 10 : 8,
   };
   const renderSeparator = () => (
     <span
@@ -929,7 +932,7 @@ const TeamRosterActionGroup: React.FC<{
         alignSelf: "center",
         background: token.colorBorderSecondary,
         display: "inline-block",
-        height: large ? 18 : 16,
+        height: large ? 15 : 14,
         width: 1,
       }}
     />
@@ -943,7 +946,7 @@ const TeamRosterActionGroup: React.FC<{
         background: token.colorFillQuaternary,
         border: `1px solid ${token.colorBorderSecondary}`,
         borderRadius: 999,
-        padding: large ? 4 : 3,
+        padding: large ? 3 : 2,
         width: "fit-content",
       }}
       wrap


### PR DESCRIPTION
## Problem

The Team home card action rail used the large Ant Design button sizing. In dense card layouts, actions such as "Debug workflow", "View team", and "View members" visually competed with the team title and roster facts.

## Solution

- Keep the existing Team card action model and actions.
- Reduce the action group button size, font size, height, padding, and separator height.
- Preserve the pill-shaped action rail and click targets while making it read as a secondary control area.

## Impact Paths

- `apps/aevatar-console-web/src/pages/teams/home.tsx`

## Verification

- `pnpm --dir apps/aevatar-console-web exec biome lint src/pages/teams/home.tsx src/pages/teams/home.test.tsx`
- `pnpm --dir apps/aevatar-console-web jest src/pages/teams/home.test.tsx --runInBand` — passed, 26 tests. Jest emitted the existing Watchman recrawl warning.
