### PR TITLE
将当前步骤文件引用传给 document_extract

### DIFF
--- a/docs/canon/chat-api.md
+++ b/docs/canon/chat-api.md
@@ -103,7 +103,7 @@ owner: eanzhao
 - 时间戳必须为非负 Unix milliseconds；同时存在 `createdAtUnixMs` 与 `expiresAtUnixMs` 时，过期时间不得早于创建时间。
 - public `fileRef` 不接受 `sizeBytes`。文件大小事实只能由 ingress/artifact descriptor 或 decoded bytes 产生，不能由客户端在 reusable file ref 上声明。
 - 当前文件链路支持 chat/API inline bytes 暂存、Lark resource 下载、command-level `fileRef` 替换、descriptor-only projection readmodel 物化、`document_extract` 文档抽取，以及 workflow-only Lark 文件提交。
-- `document_extract` 只能读取 workflow artifact store 中的文件引用，返回 descriptor + bounded extracted text；支持 UTF-8 text/json/markdown/csv、PDF text、DOCX text，不返回 bytes/base64。
+- `document_extract` 只能读取 workflow artifact store 中的文件引用，返回 descriptor + bounded extracted text；支持 UTF-8 text/json/markdown/csv、PDF text、DOCX text，不返回 bytes/base64。显式 arguments `fileRef` 优先；未传 `fileRef` 时，只允许从当前 step 的 typed input file refs 中选择唯一一项，0 个或多个输入文件都 fail closed。
 - `workflow_file_submit` 是 workflow-only tool source，当前只支持两个固定 Lark 目标：`lark_drive_media` 返回 `file_token`，`lark_approval_file` 返回审批附件 `file_code`。文件内容只在 adapter 边界从 artifact store 流式读出，不进入 actor state/readmodel/prompt/result JSON。
 
 ## 3. 自动编排能力（按 prompt 决策）

--- a/docs/canon/workflow-primitives.md
+++ b/docs/canon/workflow-primitives.md
@@ -350,6 +350,7 @@ steps:
 - 作用：调用已注册工具（函数/工具链/MCP 工具）。
 - 常用参数：`tool`。
 - 工具输出若是 JSON object 且步骤成功，运行时会把顶层字段镜像为 `steps.<step_id>.json.<field>` 变量，供后续 `switch` / `conditional` / `while` 分支使用。
+- 当前 step 的 typed input file refs 会随 `WorkflowToolExecutionRequest` 传给 workflow tool。工具若同时支持 arguments `fileRef` 与当前输入文件上下文，显式 `fileRef` 优先；未显式选择时，只能在恰好 1 个当前输入文件时 fallback，多文件必须 fail closed 并要求调用方显式选择。
 - 需要人工审批的 direct `tool_call` 不把 `ApprovalPending` 当作失败完成。`ToolCallModule` 将原始 tool name、arguments、`execution_id`、`tool_call_id`、`approval_request_id` 持久化到 workflow actor state，并发布 `WorkflowSuspendedEvent.tool_approval`。该 suspension 只暴露审批对账键，不暴露工具参数。
 - tool approval resume 使用 `WorkflowResumedEvent.tool_approval` nested payload，仅携带 `execution_id`、`tool_call_id`、`approval_request_id`。客户端不得在 resume payload 中提交 tool name 或 arguments；approved replay 必须从 actor pending state 读取原始工具和参数，并向 tool middleware 传递 typed `ToolApprovalGrant`。
 - resume 对账按 `run_id + step_id + execution_id + tool_call_id + approval_request_id` 精确匹配。approved 后重放原工具；rejected / timed out / non-pending termination fail closed 并清理 pending state；stale 或 mismatched resume event 直接忽略。

--- a/src/workflow/Aevatar.Workflow.Core/Modules/IWorkflowToolSource.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/IWorkflowToolSource.cs
@@ -27,16 +27,7 @@ public sealed record WorkflowToolApprovalPendingOutcome(
     bool IsReadOnly,
     bool IsDestructive);
 
-public sealed record WorkflowToolExecutionRequest(
-    string ArgumentsJson,
-    string RunId,
-    string StepId,
-    string ExecutionId,
-    string CallId,
-    string ScopeId,
-    WorkflowCallerCredential CallerCredential,
-    WorkflowToolRuntimeContext RuntimeContext,
-    ToolApprovalGrant? ApprovalGrant = null)
+public sealed record WorkflowToolExecutionRequest
 {
     public WorkflowToolExecutionRequest(
         string ArgumentsJson,
@@ -55,9 +46,83 @@ public sealed record WorkflowToolExecutionRequest(
             ScopeId,
             CallerCredential,
             WorkflowToolRuntimeContext.Empty,
+            null,
             null)
     {
     }
+
+    public WorkflowToolExecutionRequest(
+        string ArgumentsJson,
+        string RunId,
+        string StepId,
+        string ExecutionId,
+        string CallId,
+        string ScopeId,
+        WorkflowCallerCredential CallerCredential,
+        IReadOnlyList<WorkflowFileRef>? InputFileRefs)
+        : this(
+            ArgumentsJson,
+            RunId,
+            StepId,
+            ExecutionId,
+            CallId,
+            ScopeId,
+            CallerCredential,
+            WorkflowToolRuntimeContext.Empty,
+            null,
+            InputFileRefs)
+    {
+    }
+
+    public WorkflowToolExecutionRequest(
+        string ArgumentsJson,
+        string RunId,
+        string StepId,
+        string ExecutionId,
+        string CallId,
+        string ScopeId,
+        WorkflowCallerCredential CallerCredential,
+        WorkflowToolRuntimeContext RuntimeContext,
+        ToolApprovalGrant? ApprovalGrant = null,
+        IReadOnlyList<WorkflowFileRef>? InputFileRefs = null)
+    {
+        this.ArgumentsJson = ArgumentsJson;
+        this.RunId = RunId;
+        this.StepId = StepId;
+        this.ExecutionId = ExecutionId;
+        this.CallId = CallId;
+        this.ScopeId = ScopeId;
+        this.CallerCredential = CallerCredential;
+        this.RuntimeContext = RuntimeContext;
+        this.ApprovalGrant = ApprovalGrant;
+        this.InputFileRefs = CopyInputFileRefs(InputFileRefs);
+    }
+
+    public string ArgumentsJson { get; init; }
+
+    public string RunId { get; init; }
+
+    public string StepId { get; init; }
+
+    public string ExecutionId { get; init; }
+
+    public string CallId { get; init; }
+
+    public string ScopeId { get; init; }
+
+    public WorkflowCallerCredential CallerCredential { get; init; }
+
+    public WorkflowToolRuntimeContext RuntimeContext { get; init; }
+
+    public ToolApprovalGrant? ApprovalGrant { get; init; }
+
+    public IReadOnlyList<WorkflowFileRef> InputFileRefs { get; private init; }
+
+    private static IReadOnlyList<WorkflowFileRef> CopyInputFileRefs(
+        IReadOnlyList<WorkflowFileRef>? inputFileRefs) =>
+        inputFileRefs == null || inputFileRefs.Count == 0
+            ? []
+            : inputFileRefs.Select(static fileRef => fileRef.Clone()).ToArray();
 }
 
 public sealed record ToolApprovalGrant(

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
@@ -154,7 +154,8 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
                 ScopeId: ctx.ScopeId ?? string.Empty,
                 CallerCredential: callerCredential,
                 RuntimeContext: runtimeContext,
-                ApprovalGrant: approvalGrant),
+                ApprovalGrant: approvalGrant,
+                InputFileRefs: request.InputFileRefs),
             ct);
     }
 
@@ -290,6 +291,7 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
             ApprovalRequestId = NormalizeRequired(pending.ApprovalRequestId),
             ArgumentsJson = pending.ArgumentsJson ?? string.Empty,
         };
+        pendingState.InputFileRefs.Add(request.InputFileRefs.Select(static fileRef => fileRef.Clone()));
         state.PendingApprovals[BuildPendingKey(pendingState)] = pendingState;
         await SaveStateAsync(state, ctx, ct);
 
@@ -372,6 +374,7 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
             ExecutionId = pending.ExecutionId,
             Input = pending.ArgumentsJson,
             Parameters = { ["tool"] = pending.ToolName },
+            InputFileRefs = { pending.InputFileRefs.Select(static fileRef => fileRef.Clone()) },
         };
 
     private static string BuildRejectedApprovalError(WorkflowResumedEvent resumed)

--- a/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
+++ b/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
@@ -390,6 +390,7 @@ message PendingToolCallApprovalState
   string approval_request_id = 6;
   string arguments_json = 7;
   string input = 8;
+  repeated WorkflowFileRef input_file_refs = 9;
 }
 
 message ToolCallModuleState

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Runs/WorkflowDocumentExtractToolSource.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Runs/WorkflowDocumentExtractToolSource.cs
@@ -7,6 +7,8 @@ using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Core.Modules;
 using System.IO.Compression;
 using UglyToad.PdfPig;
+using ProtoWorkflowFileRef = Aevatar.Workflow.Abstractions.WorkflowFileRef;
+using ProtoWorkflowFileSourceKind = Aevatar.Workflow.Abstractions.WorkflowFileSourceKind;
 
 namespace Aevatar.Workflow.Infrastructure.Runs;
 
@@ -40,7 +42,7 @@ public sealed class WorkflowDocumentExtractToolSource(IWorkflowFileArtifactReadP
         {
             try
             {
-                var arguments = ParseArguments(request.ArgumentsJson);
+                var arguments = ParseArguments(request);
                 var artifact = await _fileArtifacts.OpenReadAsync(arguments.FileRef, ct)
                     .ConfigureAwait(false);
                 await using (artifact.Content.ConfigureAwait(false))
@@ -93,20 +95,19 @@ public sealed class WorkflowDocumentExtractToolSource(IWorkflowFileArtifactReadP
             }
         }
 
-        private static DocumentExtractArguments ParseArguments(string argumentsJson)
+        private static DocumentExtractArguments ParseArguments(WorkflowToolExecutionRequest request)
         {
-            if (string.IsNullOrWhiteSpace(argumentsJson))
-                throw new ArgumentException("document_extract arguments are required.");
-
+            var argumentsJson = string.IsNullOrWhiteSpace(request.ArgumentsJson)
+                ? "{}"
+                : request.ArgumentsJson;
             using var document = JsonDocument.Parse(argumentsJson);
             var root = document.RootElement;
             if (root.ValueKind != JsonValueKind.Object)
                 throw new ArgumentException("document_extract arguments must be a JSON object.");
-            if (!TryGetProperty(root, "fileRef", "file_ref", out var fileRefElement) ||
-                fileRefElement.ValueKind != JsonValueKind.Object)
-                throw new ArgumentException("document_extract requires a fileRef object.");
 
-            var fileRef = ParseFileRef(fileRefElement);
+            var fileRef = TryResolveExplicitFileRef(root, out var explicitFileRef)
+                ? explicitFileRef
+                : ResolveSingleInputFileRef(request.InputFileRefs);
             if (string.IsNullOrWhiteSpace(fileRef.FileId) &&
                 string.IsNullOrWhiteSpace(fileRef.ArtifactId))
                 throw new ArgumentException("document_extract fileRef requires fileId or artifactId.");
@@ -119,6 +120,58 @@ public sealed class WorkflowDocumentExtractToolSource(IWorkflowFileArtifactReadP
                     : throw new ArgumentException("document_extract maxChars must be an integer.");
             return new DocumentExtractArguments(fileRef, maxChars);
         }
+
+        private static bool TryResolveExplicitFileRef(
+            JsonElement root,
+            out WorkflowFileRef fileRef)
+        {
+            fileRef = new WorkflowFileRef();
+            if (!TryGetProperty(root, "fileRef", "file_ref", out var fileRefElement))
+                return false;
+            if (fileRefElement.ValueKind != JsonValueKind.Object)
+                throw new ArgumentException("document_extract fileRef must be an object.");
+
+            fileRef = ParseFileRef(fileRefElement);
+            return true;
+        }
+
+        private static WorkflowFileRef ResolveSingleInputFileRef(
+            IReadOnlyList<ProtoWorkflowFileRef> inputFileRefs)
+        {
+            if (inputFileRefs.Count == 1)
+                return ToApplicationFileRef(inputFileRefs[0]);
+
+            throw new ArgumentException(inputFileRefs.Count == 0
+                ? "document_extract requires a fileRef object or exactly one input file ref."
+                : "document_extract received multiple input file refs; provide fileRef explicitly.");
+        }
+
+        private static WorkflowFileRef ToApplicationFileRef(ProtoWorkflowFileRef source) =>
+            new()
+            {
+                FileId = Normalize(source.FileId),
+                ArtifactId = Normalize(source.ArtifactId),
+                SourceKind = source.SourceKind switch
+                {
+                    ProtoWorkflowFileSourceKind.ChatInput => WorkflowFileSourceKind.ChatInput,
+                    ProtoWorkflowFileSourceKind.FormUpload => WorkflowFileSourceKind.FormUpload,
+                    ProtoWorkflowFileSourceKind.ConnectedServiceResource =>
+                        WorkflowFileSourceKind.ConnectedServiceResource,
+                    ProtoWorkflowFileSourceKind.ExternalResource => WorkflowFileSourceKind.ExternalResource,
+                    ProtoWorkflowFileSourceKind.Generated => WorkflowFileSourceKind.Generated,
+                    _ => WorkflowFileSourceKind.Unspecified,
+                },
+                SourceMessageId = Normalize(source.SourceMessageId),
+                SourceResourceKey = Normalize(source.SourceResourceKey),
+                FileName = Normalize(source.FileName),
+                MediaType = Normalize(source.MediaType),
+                SizeBytes = source.SizeBytes,
+                Sha256 = Normalize(source.Sha256),
+                CreatedAtUnixMs = source.CreatedAtUnixMs,
+                ExpiresAtUnixMs = source.ExpiresAtUnixMs,
+                OwnerRunId = Normalize(source.OwnerRunId),
+                OwnerScopeId = Normalize(source.OwnerScopeId),
+            };
 
         private static WorkflowFileRef ParseFileRef(JsonElement fileRefElement)
         {

--- a/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleApprovalTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleApprovalTests.cs
@@ -28,8 +28,16 @@ public sealed class ToolCallModuleApprovalTests
         var tool = new ScriptedWorkflowTool("danger", _ => new WorkflowToolExecutionResult(string.Empty, PendingApproval: pending));
         var module = CreateModule(tool);
         var ctx = new RecordingWorkflowContext();
+        var fileRef = BuildWorkflowFileRef("file-approval");
 
-        await ExecuteToolCallAsync(module, ctx, tool.Name, "danger_step", """{"danger":true}""", "exec-1");
+        await ExecuteToolCallAsync(
+            module,
+            ctx,
+            tool.Name,
+            "danger_step",
+            """{"danger":true}""",
+            "exec-1",
+            [fileRef]);
 
         ctx.Published.Select(x => x.Event).OfType<WorkflowToolCallStartedEvent>().Should().ContainSingle();
         ctx.Published.Select(x => x.Event).OfType<WorkflowToolCallCompletedEvent>().Should().BeEmpty();
@@ -45,6 +53,8 @@ public sealed class ToolCallModuleApprovalTests
         suspended.ToolApproval.ApprovalRequestId.Should().Be("approval-1");
         var state = ctx.LoadState<ToolCallModuleState>("tool_call");
         state.PendingApprovals.Should().ContainKey("run-1:danger_step:exec-1:workflow:run-1:danger_step:exec-1:approval-1");
+        var pendingState = state.PendingApprovals.Values.Should().ContainSingle().Subject;
+        pendingState.InputFileRefs.Should().ContainSingle().Which.FileId.Should().Be("file-approval");
     }
 
     [Fact]
@@ -65,8 +75,16 @@ public sealed class ToolCallModuleApprovalTests
                 : WorkflowToolExecutionResult.Success("""{"executed":true}"""));
         var module = CreateModule(tool);
         var ctx = new RecordingWorkflowContext();
+        var fileRef = BuildWorkflowFileRef("file-replay");
 
-        await ExecuteToolCallAsync(module, ctx, tool.Name, "danger_step", """{"danger":true}""", "exec-1");
+        await ExecuteToolCallAsync(
+            module,
+            ctx,
+            tool.Name,
+            "danger_step",
+            """{"danger":true}""",
+            "exec-1",
+            [fileRef]);
         ctx.Published.Clear();
 
         await module.HandleAsync(
@@ -87,6 +105,7 @@ public sealed class ToolCallModuleApprovalTests
 
         tool.Requests.Should().HaveCount(2);
         tool.Requests[1].ArgumentsJson.Should().Be("""{"danger":true}""");
+        tool.Requests[1].InputFileRefs.Should().ContainSingle().Which.FileId.Should().Be("file-replay");
         tool.Requests[1].ApprovalGrant.Should().NotBeNull();
         var grant = tool.Requests[1].ApprovalGrant!;
         grant.ApprovalRequestId.Should().Be("approval-1");
@@ -191,21 +210,35 @@ public sealed class ToolCallModuleApprovalTests
         string toolName,
         string stepId,
         string input,
-        string executionId)
+        string executionId,
+        IReadOnlyList<WorkflowFileRef>? inputFileRefs = null)
     {
+        var request = new StepRequestEvent
+        {
+            StepId = stepId,
+            StepType = "tool_call",
+            RunId = ctx.RunId,
+            ExecutionId = executionId,
+            Input = input,
+            Parameters = { ["tool"] = toolName },
+        };
+        request.InputFileRefs.Add(inputFileRefs?.Select(static fileRef => fileRef.Clone()) ?? []);
+
         await module.HandleAsync(
-            Envelope(new StepRequestEvent
-            {
-                StepId = stepId,
-                StepType = "tool_call",
-                RunId = ctx.RunId,
-                ExecutionId = executionId,
-                Input = input,
-                Parameters = { ["tool"] = toolName },
-            }),
+            Envelope(request),
             ctx,
             CancellationToken.None);
     }
+
+    private static WorkflowFileRef BuildWorkflowFileRef(string fileId) =>
+        new()
+        {
+            FileId = fileId,
+            ArtifactId = $"artifact-{fileId}",
+            SourceKind = WorkflowFileSourceKind.ChatInput,
+            FileName = $"{fileId}.txt",
+            MediaType = "text/plain",
+        };
 
     private static EventEnvelope Envelope(IMessage evt) =>
         new()

--- a/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
@@ -168,6 +168,27 @@ public sealed class ToolCallModuleContextTests
     }
 
     [Fact]
+    public async Task ToolCallModule_ShouldPassCurrentStepInputFileRefsToDirectTool()
+    {
+        var tool = new CapturingWorkflowTool("document_extract");
+        var module = CreateModule(tool);
+        var ctx = new RecordingWorkflowContext();
+        var fileRef = BuildWorkflowFileRef("file-step");
+
+        await ExecuteToolCallAsync(
+            module,
+            ctx,
+            tool.Name,
+            inputFileRefs: [fileRef]);
+
+        tool.LastRequest.Should().NotBeNull();
+        var requestFileRef = tool.LastRequest!.InputFileRefs.Should().ContainSingle().Subject;
+        requestFileRef.FileId.Should().Be("file-step");
+        requestFileRef.Should().NotBeSameAs(fileRef);
+        LastCompleted(ctx).Success.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task ToolCallModule_WhenToolReturnsManagedHandoff_ShouldLeaveParentStepPending()
     {
         var handoff = new WorkflowManagedHandoffOutcome
@@ -247,21 +268,35 @@ public sealed class ToolCallModuleContextTests
         string toolName,
         string stepId = "call_proxy",
         string input = "{}",
-        string executionId = "")
+        string executionId = "",
+        IReadOnlyList<WorkflowFileRef>? inputFileRefs = null)
     {
+        var request = new StepRequestEvent
+        {
+            StepId = stepId,
+            StepType = "tool_call",
+            RunId = ctx.RunId,
+            ExecutionId = executionId,
+            Input = input,
+            Parameters = { ["tool"] = toolName },
+        };
+        request.InputFileRefs.Add(inputFileRefs?.Select(static fileRef => fileRef.Clone()) ?? []);
+
         await module.HandleAsync(
-            Envelope(new StepRequestEvent
-            {
-                StepId = stepId,
-                StepType = "tool_call",
-                RunId = ctx.RunId,
-                ExecutionId = executionId,
-                Input = input,
-                Parameters = { ["tool"] = toolName },
-            }),
+            Envelope(request),
             ctx,
             CancellationToken.None);
     }
+
+    private static WorkflowFileRef BuildWorkflowFileRef(string fileId) =>
+        new()
+        {
+            FileId = fileId,
+            ArtifactId = $"artifact-{fileId}",
+            SourceKind = WorkflowFileSourceKind.ChatInput,
+            FileName = $"{fileId}.txt",
+            MediaType = "text/plain",
+        };
 
     private static StepCompletedEvent LastCompleted(RecordingWorkflowContext ctx) =>
         ctx.Published.Select(x => x.Event).OfType<StepCompletedEvent>().Last();

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowInfrastructureCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowInfrastructureCoverageTests.cs
@@ -677,6 +677,35 @@ public sealed class WorkflowInfrastructureCoverageTests
     }
 
     [Fact]
+    public async Task WorkflowDocumentExtractTool_ShouldFailClosedWhenNoInputFileRefsAreAvailable()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "aevatar-workflow-document-extract-zero-ref-tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var tool = await GetDocumentExtractToolAsync(CreateFileArtifactPort(root));
+
+            var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+                "{}",
+                "run-1",
+                "extract",
+                "exec-1",
+                "call-1",
+                "scope-1",
+                new ProtoWorkflowCallerCredential()));
+
+            using var document = JsonDocument.Parse(output.ResultJson);
+            document.RootElement.GetProperty("error").GetString().Should().Be("invalid_arguments");
+            document.RootElement.GetProperty("detail").GetString()
+                .Should().Contain("fileRef object or exactly one input file ref");
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task WorkflowDocumentExtractTool_ShouldFailClosedWhenInputFileRefsAreAmbiguous()
     {
         var root = Path.Combine(Path.GetTempPath(), "aevatar-workflow-document-extract-ambiguous-ref-tests", Guid.NewGuid().ToString("N"));

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowInfrastructureCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowInfrastructureCoverageTests.cs
@@ -55,6 +55,8 @@ using UglyToad.PdfPig.Writer;
 using ApplicationWorkflowFileRef = Aevatar.Workflow.Application.Abstractions.Runs.WorkflowFileRef;
 using ApplicationWorkflowFileSourceKind = Aevatar.Workflow.Application.Abstractions.Runs.WorkflowFileSourceKind;
 using ProtoWorkflowCallerCredential = Aevatar.Workflow.Abstractions.WorkflowCallerCredential;
+using ProtoWorkflowFileRef = Aevatar.Workflow.Abstractions.WorkflowFileRef;
+using ProtoWorkflowFileSourceKind = Aevatar.Workflow.Abstractions.WorkflowFileSourceKind;
 
 namespace Aevatar.Workflow.Host.Api.Tests;
 
@@ -591,6 +593,121 @@ public sealed class WorkflowInfrastructureCoverageTests
             rootElement.GetProperty("file").GetProperty("sha256").GetString().Should().Be(result.FileRef.Sha256);
             output.ResultJson.Contains("base64", StringComparison.OrdinalIgnoreCase).Should().BeFalse();
             output.ResultJson.Contains("data_base64", StringComparison.OrdinalIgnoreCase).Should().BeFalse();
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task WorkflowDocumentExtractTool_ShouldFallbackToSingleInputFileRef()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "aevatar-workflow-document-extract-input-ref-tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var port = CreateFileArtifactPort(root);
+            var result = await port.IngestAsync(new WorkflowFileIngressRequest(
+                Encoding.UTF8.GetBytes("single input file"),
+                ApplicationWorkflowFileSourceKind.ChatInput,
+                FileName: "single.txt",
+                MediaType: "text/plain"));
+            var tool = await GetDocumentExtractToolAsync(port);
+
+            var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+                "{}",
+                "run-1",
+                "extract",
+                "exec-1",
+                "call-1",
+                "scope-1",
+                new ProtoWorkflowCallerCredential(),
+                InputFileRefs: [ToProtoWorkflowFileRef(result.FileRef)]));
+
+            using var document = JsonDocument.Parse(output.ResultJson);
+            document.RootElement.GetProperty("text").GetString().Should().Be("single input file");
+            document.RootElement.GetProperty("file").GetProperty("file_id").GetString().Should().Be(result.FileRef.FileId);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task WorkflowDocumentExtractTool_ShouldPreferExplicitFileRefOverInputFileRefs()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "aevatar-workflow-document-extract-explicit-ref-tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var port = CreateFileArtifactPort(root);
+            var explicitFile = await port.IngestAsync(new WorkflowFileIngressRequest(
+                Encoding.UTF8.GetBytes("explicit file"),
+                ApplicationWorkflowFileSourceKind.ChatInput,
+                FileName: "explicit.txt",
+                MediaType: "text/plain"));
+            var inputFile = await port.IngestAsync(new WorkflowFileIngressRequest(
+                Encoding.UTF8.GetBytes("input file"),
+                ApplicationWorkflowFileSourceKind.ChatInput,
+                FileName: "input.txt",
+                MediaType: "text/plain"));
+            var tool = await GetDocumentExtractToolAsync(port);
+
+            var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+                BuildDocumentExtractArguments(explicitFile.FileRef),
+                "run-1",
+                "extract",
+                "exec-1",
+                "call-1",
+                "scope-1",
+                new ProtoWorkflowCallerCredential(),
+                InputFileRefs: [ToProtoWorkflowFileRef(inputFile.FileRef)]));
+
+            using var document = JsonDocument.Parse(output.ResultJson);
+            document.RootElement.GetProperty("text").GetString().Should().Be("explicit file");
+            document.RootElement.GetProperty("file").GetProperty("file_id").GetString().Should().Be(explicitFile.FileRef.FileId);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task WorkflowDocumentExtractTool_ShouldFailClosedWhenInputFileRefsAreAmbiguous()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "aevatar-workflow-document-extract-ambiguous-ref-tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var port = CreateFileArtifactPort(root);
+            var first = await port.IngestAsync(new WorkflowFileIngressRequest(
+                Encoding.UTF8.GetBytes("first"),
+                ApplicationWorkflowFileSourceKind.ChatInput,
+                FileName: "first.txt",
+                MediaType: "text/plain"));
+            var second = await port.IngestAsync(new WorkflowFileIngressRequest(
+                Encoding.UTF8.GetBytes("second"),
+                ApplicationWorkflowFileSourceKind.ChatInput,
+                FileName: "second.txt",
+                MediaType: "text/plain"));
+            var tool = await GetDocumentExtractToolAsync(port);
+
+            var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+                "{}",
+                "run-1",
+                "extract",
+                "exec-1",
+                "call-1",
+                "scope-1",
+                new ProtoWorkflowCallerCredential(),
+                InputFileRefs: [ToProtoWorkflowFileRef(first.FileRef), ToProtoWorkflowFileRef(second.FileRef)]));
+
+            using var document = JsonDocument.Parse(output.ResultJson);
+            document.RootElement.GetProperty("error").GetString().Should().Be("invalid_arguments");
+            document.RootElement.GetProperty("detail").GetString().Should().Contain("multiple input file refs");
         }
         finally
         {
@@ -1192,6 +1309,32 @@ public sealed class WorkflowInfrastructureCoverageTests
 
         return JsonSerializer.Serialize(payload);
     }
+
+    private static ProtoWorkflowFileRef ToProtoWorkflowFileRef(ApplicationWorkflowFileRef source) =>
+        new()
+        {
+            FileId = source.FileId ?? string.Empty,
+            ArtifactId = source.ArtifactId ?? string.Empty,
+            SourceKind = source.SourceKind switch
+            {
+                ApplicationWorkflowFileSourceKind.ChatInput => ProtoWorkflowFileSourceKind.ChatInput,
+                ApplicationWorkflowFileSourceKind.FormUpload => ProtoWorkflowFileSourceKind.FormUpload,
+                ApplicationWorkflowFileSourceKind.ConnectedServiceResource => ProtoWorkflowFileSourceKind.ConnectedServiceResource,
+                ApplicationWorkflowFileSourceKind.ExternalResource => ProtoWorkflowFileSourceKind.ExternalResource,
+                ApplicationWorkflowFileSourceKind.Generated => ProtoWorkflowFileSourceKind.Generated,
+                _ => ProtoWorkflowFileSourceKind.Unspecified,
+            },
+            SourceMessageId = source.SourceMessageId ?? string.Empty,
+            SourceResourceKey = source.SourceResourceKey ?? string.Empty,
+            FileName = source.FileName ?? string.Empty,
+            MediaType = source.MediaType ?? string.Empty,
+            SizeBytes = source.SizeBytes,
+            Sha256 = source.Sha256 ?? string.Empty,
+            CreatedAtUnixMs = source.CreatedAtUnixMs,
+            ExpiresAtUnixMs = source.ExpiresAtUnixMs,
+            OwnerRunId = source.OwnerRunId ?? string.Empty,
+            OwnerScopeId = source.OwnerScopeId ?? string.Empty,
+        };
 
     private static byte[] BuildSimplePdf(string text)
     {


### PR DESCRIPTION
## Changed files

- `WorkflowToolExecutionRequest` 新增 typed `InputFileRefs` 快照，`ToolCallModule` 将当前 step 的 `InputFileRefs` 传给工具，并在 pending approval state 中持久化以支持 approved replay。
- `document_extract` 保持显式 arguments `fileRef` 优先；未传 `fileRef` 时仅在当前 step 恰好 1 个输入文件时 fallback，多文件或无文件 fail closed。
- 更新 core/host API 测试与 canon 文档，覆盖 typed context 传递、审批 replay、显式优先和多文件歧义。

## Test results

- `dotnet build aevatar.slnx --nologo` 通过。
- `dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --nologo --filter ToolCallModule` 通过。
- `dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo --filter WorkflowDocumentExtract` 通过。
- `bash tools/ci/test_stability_guards.sh` 通过。
- `dotnet test aevatar.slnx --nologo` 通过。

## Deviations

- `SCOPE_EXTEND`: none.
- `CI_GUARDS`: unset，按 host contract 记录为 skipped。
- `refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)`.
- Closes #2037

⟦AI:AUTO-LOOP⟧
