### PR TITLE
Scope the bot owner's LLM route into scheduled-agent keys

### DIFF
--- a/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentApiKeyIssuer.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentApiKeyIssuer.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.ToolProviders.NyxId;
 using Microsoft.Extensions.Logging;
 
@@ -11,15 +12,18 @@ internal sealed class ScheduledAgentApiKeyIssuer
 
     private readonly INyxIdApiClientFactory _nyxClientFactory;
     private readonly ScheduledAgentCreatorOptions _options;
+    private readonly IOwnerLlmConfigSource? _ownerLlmConfigSource;
     private readonly ILogger<ScheduledAgentApiKeyIssuer>? _logger;
 
     public ScheduledAgentApiKeyIssuer(
         INyxIdApiClientFactory nyxClientFactory,
         ScheduledAgentCreatorOptions options,
+        IOwnerLlmConfigSource? ownerLlmConfigSource = null,
         ILogger<ScheduledAgentApiKeyIssuer>? logger = null)
     {
         _nyxClientFactory = nyxClientFactory ?? throw new ArgumentNullException(nameof(nyxClientFactory));
         _options = options ?? throw new ArgumentNullException(nameof(options));
+        _ownerLlmConfigSource = ownerLlmConfigSource;
         _logger = logger;
     }
 
@@ -28,13 +32,15 @@ internal sealed class ScheduledAgentApiKeyIssuer
         ScheduledAgentServiceSlugs serviceSlugs,
         string agentId,
         string skillName,
+        string? scopeId,
         CancellationToken ct)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(token);
         ArgumentException.ThrowIfNullOrWhiteSpace(agentId);
         ArgumentNullException.ThrowIfNull(serviceSlugs);
 
-        var slugs = RequiredSlugs(serviceSlugs).Distinct(StringComparer.Ordinal).ToArray();
+        var ownerLlmRouteSlug = await ResolveOwnerLlmRouteServiceSlugAsync(scopeId, ct);
+        var slugs = RequiredSlugs(serviceSlugs, ownerLlmRouteSlug).Distinct(StringComparer.Ordinal).ToArray();
         if (slugs.Length == 0)
             return ScheduledAgentApiKeyIssueResult.Failed("missing_required_service_slugs");
 
@@ -101,7 +107,7 @@ internal sealed class ScheduledAgentApiKeyIssuer
         }
     }
 
-    private IEnumerable<string> RequiredSlugs(ScheduledAgentServiceSlugs serviceSlugs)
+    private IEnumerable<string> RequiredSlugs(ScheduledAgentServiceSlugs serviceSlugs, string? ownerLlmRouteSlug)
     {
         var ornnSlug = GetOrnnServiceSlug();
         if (serviceSlugs.RequiresOrnnService)
@@ -119,6 +125,94 @@ internal sealed class ScheduledAgentApiKeyIssuer
             if (!string.IsNullOrWhiteSpace(slug))
                 yield return slug;
         }
+
+        // The scheduled run pins the bot owner's pre-configured NyxID LLM route
+        // (OwnerLlmConfigApplier, mirrored by SkillRunnerGAgent/WorkflowAgentGAgent). When that
+        // route is a custom proxy service (e.g. `/api/v1/proxy/s/chrono-llm`) rather than the
+        // shared gateway, the scoped key must be authorized for that UserService — otherwise
+        // NyxID's proxy scope check rejects every run with HTTP 403 api_key_scope_forbidden
+        // (error_code 9000) even though the schedule itself fired correctly.
+        if (!string.IsNullOrWhiteSpace(ownerLlmRouteSlug))
+            yield return ownerLlmRouteSlug;
+    }
+
+    private async Task<string?> ResolveOwnerLlmRouteServiceSlugAsync(string? scopeId, CancellationToken ct)
+    {
+        if (_ownerLlmConfigSource is null || string.IsNullOrWhiteSpace(scopeId))
+            return null;
+
+        OwnerLlmConfig config;
+        try
+        {
+            config = await _ownerLlmConfigSource.GetForScopeAsync(scopeId.Trim(), ct) ?? OwnerLlmConfig.Empty;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Mirror OwnerLlmConfigApplier's swallow-and-log policy: a flaky user-config
+            // projection must not fail agent creation. The key is minted without the LLM-route
+            // grant (identical to pre-fix behavior) so the misconfiguration, if any, surfaces at
+            // run time rather than blocking creation on a transient lookup error.
+            _logger?.LogWarning(
+                ex,
+                "Scheduled agent key issuance could not load owner LLM config for scope {ScopeId}; minting key without an LLM-route grant",
+                scopeId);
+            return null;
+        }
+
+        return ExtractProxyServiceSlug(config.PreferredLlmRoute);
+    }
+
+    /// <summary>
+    /// Maps a saved owner LLM route preference to the NyxID proxy <c>service</c> slug that the
+    /// scoped key must be authorized for, or <c>null</c> when no per-service grant is needed.
+    /// Returns a slug only for proxy-service routes (<c>/api/v1/proxy/s/{slug}</c>) or a bare
+    /// slug; the shared gateway route and absolute non-proxy paths use the bearer token directly
+    /// and resolve to <c>null</c>. Mirrors <c>NyxIdLlmServiceCatalogParser.NormalizeProxyRouteValue</c>.
+    /// </summary>
+    internal static string? ExtractProxyServiceSlug(string? preferredLlmRoute)
+    {
+        var normalized = preferredLlmRoute?.Trim();
+        if (string.IsNullOrWhiteSpace(normalized))
+            return null;
+
+        // A full URL / scheme-relative value cannot be mapped to a UserService id here; the
+        // provider treats such values as "use the gateway" anyway, which needs no per-service grant.
+        if (normalized.Contains("://", StringComparison.Ordinal) ||
+            normalized.StartsWith("//", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        const string proxyPrefix = "/api/v1/proxy/s/";
+        var prefixIndex = normalized.IndexOf(proxyPrefix, StringComparison.OrdinalIgnoreCase);
+        if (prefixIndex >= 0)
+            return FirstPathSegment(normalized[(prefixIndex + proxyPrefix.Length)..]);
+
+        // Any other absolute path (e.g. the `/api/v1/llm/gateway/v1` gateway route) is not a
+        // per-service proxy route, so there is nothing to authorize.
+        if (normalized.StartsWith("/", StringComparison.Ordinal))
+            return null;
+
+        // Bare slug form.
+        return FirstPathSegment(normalized);
+    }
+
+    private static string? FirstPathSegment(string value)
+    {
+        var segment = value.Trim().Trim('/');
+        if (string.IsNullOrWhiteSpace(segment))
+            return null;
+
+        var end = segment.IndexOfAny(['/', '?', '#']);
+        if (end >= 0)
+            segment = segment[..end];
+
+        segment = segment.Trim();
+        return string.IsNullOrWhiteSpace(segment) ? null : Uri.UnescapeDataString(segment);
     }
 
     private async Task<ScheduledAgentSkillPreflightResult> PreflightSkillFetchAsync(

--- a/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentCreatorTool.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentCreatorTool.cs
@@ -182,7 +182,7 @@ public sealed class ScheduledAgentCreatorTool : IAgentTool
         if (!plan.Success)
             return plan.ErrorJson ?? """{"error":"validation_error"}""";
 
-        var key = await _apiKeyIssuer.IssueAsync(token, plan.ServiceSlugs!, agentId, plan.Request!.Reference.Name, ct);
+        var key = await _apiKeyIssuer.IssueAsync(token, plan.ServiceSlugs!, agentId, plan.Request!.Reference.Name, plan.Request!.ScopeId, ct);
         if (!key.Success)
             return key.ToErrorJson();
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentCreatorToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentCreatorToolTests.cs
@@ -426,6 +426,90 @@ public sealed class ScheduledAgentCreatorToolTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_WhenOwnerPinsCustomLlmProxyRoute_ShouldGrantScopedKeyAccessToThatService()
+    {
+        // Regression for the scheduled-run 403 incident: the bot owner pre-configured a custom
+        // NyxID LLM route (`/api/v1/proxy/s/chrono-llm`, model gpt-5.5). The scoped key was minted
+        // with allow_all_services=false but its allowlist omitted chrono-llm, so the schedule fired
+        // yet every run failed NyxID's proxy scope check with HTTP 403 api_key_scope_forbidden.
+        // The issued key must be authorized for the owner's pinned LLM route.
+        var handler = CreateSuccessHandler();
+        handler.Add(HttpMethod.Get, "/api/v1/keys", """
+            {
+              "keys": [
+                {"id":"svc-ornn","slug":"ornn-api"},
+                {"id":"svc-lark","slug":"api-lark-bot"},
+                {"id":"svc-lark-failure","slug":"api-lark-bot-inbound"},
+                {"id":"svc-chrono","slug":"chrono-llm"}
+              ]
+            }
+            """);
+
+        var ownerLlmConfigSource = Substitute.For<IOwnerLlmConfigSource>();
+        ownerLlmConfigSource.GetForScopeAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new OwnerLlmConfig("gpt-5.5", "/api/v1/proxy/s/chrono-llm", 0)));
+
+        var harness = CreateHarness(handler: handler, ownerLlmConfigSource: ownerLlmConfigSource);
+
+        await WithToolContext(async () =>
+        {
+            var result = await harness.Tool.ExecuteAsync(BaseArgs);
+
+            using var document = JsonDocument.Parse(result);
+            document.RootElement.GetProperty("status").GetString().Should().Be("accepted");
+
+            await ownerLlmConfigSource.Received().GetForScopeAsync("scope-bot-1", Arg.Any<CancellationToken>());
+
+            var createRequest = handler.Requests.Single(request => request.Method == HttpMethod.Post);
+            using var createBody = JsonDocument.Parse(createRequest.Body!);
+            createBody.RootElement.GetProperty("allow_all_services").GetBoolean().Should().BeFalse();
+            createBody.RootElement.GetProperty("allowed_service_ids").EnumerateArray().Select(static x => x.GetString())
+                .Should().BeEquivalentTo("svc-ornn", "svc-lark", "svc-lark-failure", "svc-chrono");
+        });
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenOwnerUsesGatewayRoute_ShouldNotWidenScopedKeyAllowlist()
+    {
+        // The shared gateway route uses the bearer token directly and needs no per-service grant,
+        // so a gateway/empty PreferredLlmRoute must leave the scoped allowlist unchanged.
+        var handler = CreateSuccessHandler();
+        var ownerLlmConfigSource = Substitute.For<IOwnerLlmConfigSource>();
+        ownerLlmConfigSource.GetForScopeAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new OwnerLlmConfig("gpt-5.5", null, 0)));
+
+        var harness = CreateHarness(handler: handler, ownerLlmConfigSource: ownerLlmConfigSource);
+
+        await WithToolContext(async () =>
+        {
+            var result = await harness.Tool.ExecuteAsync(BaseArgs);
+
+            using var document = JsonDocument.Parse(result);
+            document.RootElement.GetProperty("status").GetString().Should().Be("accepted");
+
+            var createRequest = handler.Requests.Single(request => request.Method == HttpMethod.Post);
+            using var createBody = JsonDocument.Parse(createRequest.Body!);
+            createBody.RootElement.GetProperty("allowed_service_ids").EnumerateArray().Select(static x => x.GetString())
+                .Should().BeEquivalentTo("svc-ornn", "svc-lark", "svc-lark-failure");
+        });
+    }
+
+    [Theory]
+    [InlineData("/api/v1/proxy/s/chrono-llm", "chrono-llm")]
+    [InlineData("/api/v1/proxy/s/chrono-llm/v1", "chrono-llm")]
+    [InlineData("  /api/v1/proxy/s/Custom-LLM  ", "Custom-LLM")]
+    [InlineData("chrono-llm", "chrono-llm")]
+    [InlineData(null, null)]
+    [InlineData("", null)]
+    [InlineData("   ", null)]
+    [InlineData("/api/v1/llm/gateway/v1", null)]
+    [InlineData("https://nyx.example.com/api/v1/proxy/s/chrono-llm", null)]
+    public void ExtractProxyServiceSlug_ShouldReturnSlugOnlyForProxyServiceRoutes(string? route, string? expected)
+    {
+        ScheduledAgentApiKeyIssuer.ExtractProxyServiceSlug(route).Should().Be(expected);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_WhenDeclaredRuntimeServiceMissing_ShouldFailBeforeKeyCreation()
     {
         var handler = CreateSuccessHandler();
@@ -839,7 +923,8 @@ public sealed class ScheduledAgentCreatorToolTests
     private static CreatorHarness CreateHarness(
         RoutingJsonHandler? handler = null,
         OwnerScope? scope = null,
-        bool callerScopeUnavailable = false)
+        bool callerScopeUnavailable = false,
+        IOwnerLlmConfigSource? ownerLlmConfigSource = null)
     {
         handler ??= CreateSuccessHandler();
 
@@ -871,6 +956,8 @@ public sealed class ScheduledAgentCreatorToolTests
         services.AddSingleton(queryPort);
         services.AddSingleton(new ScheduledAgentCreatorOptions());
         services.AddSingleton<ScheduledAgentCreateRequestMapper>();
+        if (ownerLlmConfigSource is not null)
+            services.AddSingleton(ownerLlmConfigSource);
         services.AddSingleton<ScheduledAgentApiKeyIssuer>();
 
         var provider = services.BuildServiceProvider();


### PR DESCRIPTION
## Problem

A scheduled agent's cron fired correctly, but the skill run failed with:

```
Skill runner failed: Upstream LLM route '/api/v1/proxy/s/chrono-llm' rejected the request
with HTTP 403 for model 'gpt-5.5'. Your session may have expired — try signing in again.
Upstream said: {"error":"api_key_scope_forbidden","error_code":9000,
"message":"API key scope forbidden: API key does not have access to this service"}
```

`error_code 9000` / `api_key_scope_forbidden` is emitted by **NyxID's own proxy auth layer**
(`backend/src/handlers/proxy.rs`), not the upstream LLM gateway. NyxID returns it when the
calling key has `allow_all_services=false` **and** the target service id is not in its
`allowed_service_ids`. (The "session may have expired" hint in `NyxIdLLMProvider` is therefore
misleading for this case — see follow-up below.)

## Root cause

`ScheduledAgentApiKeyIssuer.IssueAsync` mints each scheduled agent a scoped NyxID key
(`allow_all_services=false`) whose allowlist is built by `RequiredSlugs`: the Ornn service, the
Lark outbound slug, the failure-notification slug, and any caller-supplied
`required_service_slugs`. It **never included the bot owner's pre-configured LLM route**.

But at run time `SkillRunnerGAgent` pins that route onto outbound LLM control via
`OwnerLlmConfigApplier` (`OwnerLlmConfig.PreferredLlmRoute`). When the owner uses a **custom
proxy service** — e.g. `/api/v1/proxy/s/chrono-llm` with model `gpt-5.5` — instead of the shared
gateway, the scoped key has no grant for that `UserService`, so every run is rejected by NyxID's
proxy scope check.

Creation still succeeded because the only preflight is the Ornn skill fetch, which exercises a
different grant — so the failure only surfaces on the first scheduled run.

## Fix

At issuance, resolve the owner's `PreferredLlmRoute` via `IOwnerLlmConfigSource` (the same source
the runner reads at execution, keyed by the same `scopeId`), extract the proxy service slug, and
include it in the key's `allowed_service_ids`.

- Gateway/`auto`/empty routes use the bearer token directly and add **no** slug, preserving
  least privilege.
- The config source is an **optional, swallow-and-log** dependency (mirroring
  `OwnerLlmConfigApplier`): a flaky user-config projection cannot fail agent creation — the key
  is simply minted without the LLM grant (pre-fix behavior) and the misconfiguration surfaces at
  run time instead.
- Slug extraction handles `/api/v1/proxy/s/{slug}`, `/api/v1/proxy/s/{slug}/...`, and bare-slug
  forms; full URLs and other absolute paths (the gateway route) resolve to `null`.

## Testing

`dotnet test Aevatar.GAgents.ChannelRuntime.Tests` — **1259 passed, 0 failed**. New coverage in
`ScheduledAgentCreatorToolTests`:

- owner pins `/api/v1/proxy/s/chrono-llm` → key allowlist now includes that service id;
- owner on gateway route → allowlist unchanged (no widening);
- 8-case theory for `ExtractProxyServiceSlug` (proxy routes, bare slug, gateway path, full URL,
  null/blank).

Existing allowlist assertions (no owner-config source wired) are unchanged, confirming no
regression.

## Note: existing agents

This fixes **newly created** scheduled agents. An agent created before this change still holds a
key minted without the LLM-route grant, so it must be **recreated** (or its key's
`allowed_service_ids` updated in NyxID) to recover.

## Follow-up (not in this PR)

`NyxIdLLMProvider.ClassifyUpstreamFailure` maps every 401/403 to "Your session may have expired".
For `api_key_scope_forbidden` (a key-scope problem, not an expired session) a scope-specific hint
("the agent key isn't authorized for this LLM route — recreate the scheduled agent") would be
clearer. Left out here to keep this PR focused on the root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
