### PR TITLE
Fix entry member configuration gating

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -4360,7 +4360,10 @@ describe("StudioPage", () => {
     );
   });
 
-  it("does not offer Team entry actions for an unbound workflow member", async () => {
+  it("allows unbound workflow members to be configured as Team entry members", async () => {
+    (studioApi.getTeam as jest.Mock).mockResolvedValueOnce(
+      mockCreateDefaultTeamSummary({ entryMemberId: null })
+    );
     mockStudioMembers = [
       {
         ...mockStudioMembers[0],
@@ -4376,12 +4379,19 @@ describe("StudioPage", () => {
 
     const rail = await screen.findByLabelText("Team members");
     expect(await within(rail).findByRole("button", { name: "workspace-demo" })).toBeTruthy();
-    expect(
-      within(rail).queryByRole("button", {
+    fireEvent.click(
+      await within(rail).findByRole("button", {
         name: "Set workspace-demo as Team entry member",
       })
-    ).toBeNull();
-    expect(studioApi.setTeamEntryMember).not.toHaveBeenCalled();
+    );
+
+    await waitFor(() => {
+      expect(studioApi.setTeamEntryMember).toHaveBeenCalledWith(
+        "scope-1",
+        "t-alpha",
+        "workspace-demo"
+      );
+    });
   });
 
   it("marks the selected Studio member when it is already the Team entry", async () => {

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -4394,6 +4394,44 @@ describe("StudioPage", () => {
     });
   });
 
+  it("does not offer the Studio inventory entry action for members outside the current Team roster", async () => {
+    (studioApi.getTeam as jest.Mock).mockResolvedValueOnce(
+      mockCreateDefaultTeamSummary({ entryMemberId: null })
+    );
+    mockStudioMembers = [
+      {
+        ...mockStudioMembers[0],
+        memberId: "alpha-member",
+        displayName: "Alpha member",
+        teamId: "t-alpha",
+      },
+      {
+        ...mockStudioMembers[0],
+        memberId: "other-team-member",
+        displayName: "Other team member",
+        teamId: "t-beta",
+      },
+    ];
+
+    renderStudioPage(
+      "/studio?scopeId=scope-1&teamId=t-alpha&member=member%3Aother-team-member&tab=studio"
+    );
+
+    const rail = await screen.findByLabelText("Team members");
+    expect(await within(rail).findByRole("button", { name: "Alpha member" })).toBeTruthy();
+    expect(
+      within(rail).queryByRole("button", {
+        name: "Set Other team member as Team entry member",
+      })
+    ).toBeNull();
+    expect(
+      within(rail).queryByRole("button", {
+        name: "Set other-team-member as Team entry member",
+      })
+    ).toBeNull();
+    expect(studioApi.setTeamEntryMember).not.toHaveBeenCalled();
+  });
+
   it("marks the selected Studio member when it is already the Team entry", async () => {
     (studioApi.getTeam as jest.Mock).mockResolvedValueOnce(
       mockCreateDefaultTeamSummary({ entryMemberId: "workspace-demo" })

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -8959,22 +8959,10 @@ const StudioPage: React.FC = () => {
   const selectedInventoryIsEntryMember =
     Boolean(selectedInventoryEntryMemberId) &&
     selectedInventoryEntryMemberId === studioTeamEntryMemberId;
-  const selectedInventoryEntryMemberSummary =
-    workbenchStudioMember?.memberId === selectedInventoryEntryMemberId
-      ? workbenchStudioMember
-      : workbenchStudioMemberSummary?.memberId === selectedInventoryEntryMemberId
-        ? workbenchStudioMemberSummary
-        : null;
-  const selectedInventoryEntryMemberReady =
-    normalizeStudioMemberLifecycleStage(
-      selectedInventoryEntryMemberSummary?.lifecycleStage,
-    ) === 'bind_ready' &&
-    Boolean(trimOptional(selectedInventoryEntryMemberSummary?.publishedServiceId));
   const canSetSelectedInventoryEntryMember = Boolean(
     resolvedStudioScopeId &&
       resolvedStudioTeamId &&
-      selectedInventoryEntryMemberId &&
-      selectedInventoryEntryMemberReady,
+      selectedInventoryEntryMemberId,
   );
   const handleSetSelectedInventoryEntryMember = useCallback(async () => {
     if (
@@ -9022,7 +9010,6 @@ const StudioPage: React.FC = () => {
     resolvedStudioScopeId,
     resolvedStudioTeamId,
     selectedInventoryEntryMemberId,
-    selectedInventoryEntryMemberReady,
     selectedInventoryIsEntryMember,
     studioTeamSummaryQueryKey,
   ]);

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -8959,10 +8959,15 @@ const StudioPage: React.FC = () => {
   const selectedInventoryIsEntryMember =
     Boolean(selectedInventoryEntryMemberId) &&
     selectedInventoryEntryMemberId === studioTeamEntryMemberId;
+  const selectedInventoryEntryMemberResolved =
+    Boolean(selectedInventoryEntryMemberId) &&
+    trimOptional(workbenchStudioMemberSummary?.memberId) ===
+      selectedInventoryEntryMemberId;
   const canSetSelectedInventoryEntryMember = Boolean(
     resolvedStudioScopeId &&
       resolvedStudioTeamId &&
-      selectedInventoryEntryMemberId,
+      selectedInventoryEntryMemberId &&
+      selectedInventoryEntryMemberResolved,
   );
   const handleSetSelectedInventoryEntryMember = useCallback(async () => {
     if (

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -1558,7 +1558,7 @@ describe("TeamDetailPage", () => {
     expect(screen.getByLabelText("测试 Prompt")).toBeTruthy();
   });
 
-  it("does not treat bind-ready members without a published service as Team entry candidates", async () => {
+  it("does not treat bind-ready members without a published service as Team Test candidates", async () => {
     (studioApi.getTeam as jest.Mock).mockImplementation(async () => ({
       ...mockCreateTeamSummary(),
       entryMemberId: null,
@@ -1582,6 +1582,35 @@ describe("TeamDetailPage", () => {
     ).toBeNull();
     expect(within(dialog).getByRole("link", { name: "先 Build / Bind" }))
       .toHaveAttribute("href", expect.stringContaining("member-unpublished"));
+  });
+
+  it("allows members without a published service to be configured as Team entry members", async () => {
+    (studioApi.getTeam as jest.Mock).mockImplementation(async () => ({
+      ...mockCreateTeamSummary(),
+      entryMemberId: null,
+    }));
+    (studioApi.listTeamMembers as jest.Mock).mockImplementation(
+      async () => mockCreateTeamMembersCatalogWithUnpublishedReadyMember(),
+    );
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    await screen.findByRole("button", { name: "编辑团队" });
+    fireEvent.click(screen.getByRole("button", { name: "团队成员" }));
+    expect(await screen.findByText("Unpublished Ready Member")).toBeTruthy();
+
+    const setEntryButtons = await screen.findAllByRole("button", {
+      name: "设为入口成员",
+    });
+    fireEvent.click(setEntryButtons[1]);
+
+    await waitFor(() => {
+      expect(studioApi.setTeamEntryMember).toHaveBeenCalledWith(
+        "scope-1",
+        "t-alpha",
+        "member-unpublished",
+      );
+    });
   });
 
   it("sets a ready member as entry before testing when the Team has no entry", async () => {

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -761,6 +761,7 @@ const TeamDetailPage: React.FC = () => {
           description: trimText(member.description),
           canInvokeAsEntry: isBoundMember,
           canInvokeMember: isWorkflowMember && isBoundMember,
+          canSetAsEntry: Boolean(trimText(member.memberId)),
           editStudioHref: isWorkflowMember ? workflowStudioHref : "",
           implementationKind: formatCompositionKind(member.implementationKind),
           invokeHref: isWorkflowMember ? memberInvokeHref : "",

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
@@ -19,6 +19,7 @@ import {
 type TeamRosterMemberRow = {
   readonly canInvokeAsEntry: boolean;
   readonly canInvokeMember: boolean;
+  readonly canSetAsEntry: boolean;
   readonly description: string;
   readonly implementationKind: string;
   readonly isServiceBound: boolean;
@@ -647,7 +648,7 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                           >
                             {intl.formatMessage({ id: "teams.members.actions.clearEntry" })}
                           </Button>
-                        ) : row.canInvokeAsEntry && onSetEntry ? (
+                        ) : row.canSetAsEntry && onSetEntry ? (
                           <Button
                             className="team-members-table-entry-action"
                             disabled={


### PR DESCRIPTION
## Problem

Team member entry configuration was gated by the same readiness condition used for immediate Team Test invocation. As a result, unbound members could not be selected as the Team entry member even though the backend entry-member command only requires a valid member in the team roster.

## Solution

- Split Team Members table semantics so `Set as entry member` uses `canSetAsEntry` instead of `canInvokeAsEntry`.
- Keep Team Test readiness behavior unchanged: only bind-ready members with a published service can be used for immediate test/invoke.
- Remove bind-ready/published-service gating from Studio inventory `Set as entry`.
- Update frontend tests to lock the distinction between configurable entry and invokable/testable entry.

## Impact Paths

- `apps/aevatar-console-web/src/pages/teams/detail.tsx`
- `apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx`
- `apps/aevatar-console-web/src/pages/studio/index.tsx`
- Team Detail and Studio page tests

## Verification

- `pnpm --dir apps/aevatar-console-web test --runInBand src/pages/teams/detail.test.tsx src/pages/studio/index.test.tsx`
- `pnpm --dir apps/aevatar-console-web tsc`
- `bash tools/ci/test_stability_guards.sh`
- `git diff --check`