### PR TITLE
Fix member binding completion semantics

### DIFF
--- a/.agents/skills/address-own-pr-comments/SKILL.md
+++ b/.agents/skills/address-own-pr-comments/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: address-own-pr-comments
+description: Use when Codex needs to handle GitHub PR review comments, failing PR checks, or unit-test/Jest/xUnit failures on a PR that may be authored by the current user or agent. Trigger for requests like "判断是不是自己的 PR 并按下面评论修改和回复", "address my PR comments", "fix reviewer comments on the current PR", "处理 PR review comments", "修一下 PR 单测问题", "fix the failing tests on my PR", or when the user pastes reviewer comments, CI logs, or failed test output and wants code/test changes plus replies. The skill verifies PR ownership, gathers pasted/GitHub comments and test failures, implements scoped fixes only for own PRs, runs relevant validation, and drafts or posts review replies.
+---
+
+# Address Own PR Comments
+
+## Overview
+
+Act as the PR author handling reviewer feedback and PR validation failures. First determine whether the target PR is safe to treat as "ours"; then classify comments and test failures, make the smallest correct code/doc/test changes, validate them, and reply with evidence.
+
+## Ownership Gate
+
+Before editing, pushing, resolving, or replying, establish the target PR and ownership.
+
+1. Identify the PR:
+   - Prefer an explicit PR URL or number from the user.
+   - Otherwise use the current branch:
+
+```bash
+gh pr view --json number,url,title,author,headRefName,headRepositoryOwner,baseRefName,isDraft
+gh api user --jq .login
+git branch --show-current
+git status --short
+```
+
+2. Treat the PR as own only when at least one is true:
+   - The PR author matches `gh api user --jq .login`.
+   - The user explicitly says this is their PR or asks to handle "my/current PR", and the local branch/head matches the PR.
+   - The current task is running inside an agent-owned branch/worktree created for this PR.
+
+3. If ownership is unclear:
+   - Do not post replies, resolve threads, push, or make broad edits.
+   - Summarize what can be inferred and ask for confirmation or a PR URL.
+   - If the user only pasted comments and asked for help, produce a local fix plan and draft replies without claiming to have acted on GitHub.
+
+4. If the PR is not own:
+   - Switch to review/triage mode.
+   - Do not modify the branch unless the user explicitly asks to prepare a patch for someone else's PR.
+   - Do not post author-style replies such as "fixed" or "pushed".
+
+## Comment Intake
+
+Use both pasted comments and GitHub comments when available. Preserve reviewer intent and exact locations.
+
+Useful commands:
+
+```bash
+gh pr view <pr> --json number,url,title,author,headRefName,baseRefName,body,reviews,comments
+gh pr diff <pr> --name-only
+gh api repos/:owner/:repo/pulls/<number>/comments --paginate
+gh api repos/:owner/:repo/issues/<number>/comments --paginate
+gh pr checks <pr>
+```
+
+For each comment, record:
+
+- `source`: pasted, review thread, issue comment, CI/bot output, or maintainer note.
+- `location`: file/line or general PR.
+- `ask`: requested change, bug report, question, nit, false positive, or out of scope.
+- `decision`: fix, explain, defer, split follow-up, or ask clarification.
+- `evidence`: code reference, test result, guard result, or reason.
+
+Ignore automated noise only after checking whether it points to a real failing check. Do not dismiss human comments as nits when they indicate correctness, architecture, security, data loss, or test reliability risk.
+
+## Test Failure Intake
+
+Handle pasted test output, CI failures, and reviewer comments about unit tests as first-class PR feedback.
+
+When the user mentions failing tests, CI, checks, unit tests, Jest, xUnit, snapshots, coverage, flaky tests, or "单测", gather the failure before editing:
+
+```bash
+gh pr checks <pr>
+gh run list --branch <head-branch> --limit 10
+gh run view <run-id> --log-failed
+```
+
+Use local commands when the failing scope is discoverable:
+
+```bash
+pnpm --dir <frontend-dir> test --runInBand <test-file-or-pattern>
+pnpm --dir <frontend-dir> tsc
+dotnet test <test-project-or-sln> --filter <name>
+```
+
+For each failure, record:
+
+- `failing target`: check name, test suite, test case, file, or command.
+- `symptom`: assertion diff, stack trace, timeout, type error, snapshot diff, or guard output.
+- `owner area`: product code, test fixture, mock, snapshot, test harness, CI environment, or flaky timing.
+- `contract`: expected behavior or repository rule that the test is supposed to protect.
+- `decision`: fix product code, fix test code, update fixture/snapshot, quarantine/deflake, or ask clarification.
+
+Prefer reproducing the failure locally. If local reproduction is not possible, use CI logs plus code/test evidence and say what could not be reproduced.
+
+## Fix Workflow
+
+1. Read the relevant files and tests before editing.
+2. Group comments by root cause so one fix can close multiple threads.
+3. Make the smallest durable change that satisfies the reviewer and the repository rules.
+4. Update or add tests for behavior changes.
+5. Run targeted validation first, then required guards for touched areas.
+6. Inspect the diff for unrelated churn.
+7. Commit/push only when the user requested that workflow or the repository task clearly expects it.
+8. Reply only after the fix is present and validation evidence is known.
+
+Follow repository instructions above all reviewer suggestions when they conflict. For this repository, especially preserve architecture boundaries, actor/readmodel semantics, identity separation (`memberId`, `workflowId`, `publishedServiceId`), protobuf serialization rules, and required CI guards.
+
+## Unit Test Fix Rules
+
+It is allowed to modify unit tests when the test itself is the problem. Preserve the test's signal.
+
+Change production code when:
+
+- The test exposes a real regression, missing validation, broken API contract, data loss, security risk, or architecture violation.
+- The expected behavior in the test matches the current product/domain contract.
+- Multiple tests fail from the same product bug.
+
+Change test code when:
+
+- The test asserts stale behavior after an intentional product/contract change.
+- The fixture uses invalid identities, impossible state, wrong route shape, wrong API payload, or a mock that no longer matches the contract.
+- The assertion is over-specific about implementation details while the externally visible behavior remains correct.
+- The test is flaky because it relies on timing, polling, ordering, local timezone, random data, or shared state.
+- The snapshot or golden file changed only because the reviewed UI/API contract intentionally changed.
+
+Do not weaken tests merely to make CI green:
+
+- Do not delete failing assertions without replacing them with contract-focused assertions.
+- Do not mark tests skipped, todo, flaky, or allowlisted unless the repository policy allows it and the reason is explicit.
+- Do not broaden matchers so far that the bug would no longer be caught.
+- Do not update snapshots blindly; inspect the diff and tie it to a real intended change.
+- Do not hide async races with arbitrary sleeps. Prefer deterministic synchronization such as resolved promises, fake timers, channels, or explicit event hooks.
+- In this repository, if tests add or change polling/waiting behavior, run `bash tools/ci/test_stability_guards.sh` and update the allowlist only for justified cross-process or cross-node eventual consistency probes.
+
+When modifying tests, keep IDs semantically distinct in fixtures, especially `memberId`, `workflowId`, and `publishedServiceId`. A test that reuses one string for multiple identities may mask the exact class of bug this repository is trying to prevent.
+
+## Test Fix Workflow
+
+1. Reproduce the failing test or isolate the smallest failing command.
+2. Read the test and the production path it covers.
+3. Identify whether the contract is wrong, the product code is wrong, or the test harness is wrong.
+4. Make the narrow fix:
+   - product bug: fix production code and keep or strengthen the test.
+   - stale test: update the expected behavior and add a comment only when the contract is non-obvious.
+   - fixture/mock bug: fix the fixture to match the real API/route/state contract.
+   - flaky test: remove timing dependence and add deterministic synchronization.
+5. Run the smallest failing test command again.
+6. Run adjacent validation that proves the fix did not only satisfy one brittle assertion.
+7. If touching tests in this repository, run `bash tools/ci/test_stability_guards.sh`.
+8. Include the exact failing command and passing command in the PR reply or final summary.
+
+## Reply Policy
+
+Prefer concise, concrete replies. Each reply should say what changed, where, and how it was verified.
+
+Use this shape:
+
+```markdown
+Fixed in <file/function>. <One sentence explaining the change>.
+
+Verified with:
+- `<command>`
+```
+
+For questions or rejected suggestions:
+
+```markdown
+I checked this path. I kept <current behavior> because <specific contract/reason>.
+The relevant evidence is <file/test/guard>. Happy to split a follow-up if you want <alternative>.
+```
+
+Do not overclaim. If tests were not run, say so. If a change is deferred, name the follow-up boundary and why it is separate.
+
+For test-failure replies:
+
+```markdown
+Fixed in <test/code path>. The failure was <product bug/test fixture/stale assertion/flaky timing>, so I changed <specific thing> while preserving <contract>.
+
+Verified with:
+- `<previously failing command>`
+- `<required guard>`
+```
+
+## Posting Replies
+
+When the user wants actual GitHub replies, prefer `gh` commands and keep replies tied to the original thread when possible.
+
+Before posting:
+
+```bash
+git diff --check
+git status --short
+```
+
+For general PR comments:
+
+```bash
+gh pr comment <pr> --body-file <reply-file>
+```
+
+For review-thread replies, use the GitHub API only after confirming the thread/comment id from `gh api`. If the correct endpoint or id is unclear, draft the reply in the final answer instead of guessing.
+
+After posting or drafting, provide a compact table:
+
+| Comment | Decision | Evidence | Reply |
+| --- | --- | --- | --- |
+| `<reviewer/file>` | fixed/explained/deferred | `<test or file>` | posted/drafted |
+
+## Guardrails
+
+- Do not modify someone else's PR as if it is own.
+- Do not push, resolve threads, or post comments without a clear target PR and user authorization.
+- Do not treat a review comment as resolved until code/docs/tests actually address it.
+- Do not make broad refactors while addressing review comments unless the reviewer request requires it.
+- Do not hide validation failures; report them and either fix or explain the remaining blocker.
+- Do not use identity guesses, branch prefixes, or string equality as business facts in aevatar code changes.
+- Do not introduce compatibility shims or stale routes just to satisfy a review comment; prefer the repository's "delete over compatibility" rule unless the user explicitly asks otherwise.

--- a/.agents/skills/address-own-pr-comments/agents/openai.yaml
+++ b/.agents/skills/address-own-pr-comments/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Address Own PR Comments"
+  short_description: "Fix PR comments and failing tests"
+  default_prompt: "Use $address-own-pr-comments to handle review comments and failing tests on my current PR."

--- a/apps/aevatar-console-web/src/pages/team-member-invoke/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-invoke/index.test.tsx
@@ -330,4 +330,29 @@ describe("TeamMemberInvokePage", () => {
       "/scopes/scope-1/teams/team-1/members/member-alpha/workflow",
     );
   });
+
+  it("does not treat a member service identity as a completed binding", async () => {
+    (studioApi.getMember as jest.Mock).mockResolvedValueOnce(
+      createWorkflowMember({
+        lastBoundRevisionId: null,
+        lifecycleStage: "bind_ready",
+        publishedServiceId: "svc-alpha",
+      }),
+    );
+    (studioApi.getMemberBinding as jest.Mock).mockResolvedValueOnce({
+      currentBindingRun: null,
+      lastBinding: null,
+    });
+    (scopeRuntimeApi.listServices as jest.Mock).mockResolvedValueOnce([
+      createService(),
+    ]);
+
+    renderWithQueryClient(React.createElement(TeamMemberInvokePage));
+
+    expect(
+      await screen.findByText("This workflow member is not bound yet."),
+    ).toBeTruthy();
+    expect(screen.queryByTestId("member-invoke-panel")).toBeNull();
+    expect(scopeRuntimeApi.getServiceRevisions).not.toHaveBeenCalled();
+  });
 });

--- a/apps/aevatar-console-web/src/pages/team-member-invoke/index.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-invoke/index.tsx
@@ -20,6 +20,8 @@ import {
 import { studioApi } from "@/shared/studio/api";
 import {
   normalizeStudioMemberBindingImplementationKind,
+  normalizeStudioMemberLifecycleStage,
+  type StudioMemberBindingContract,
 } from "@/shared/studio/models";
 import {
   AevatarInspectorEmpty,
@@ -38,6 +40,13 @@ type TeamMemberInvokeRouteState = {
 
 function trimOptional(value: string | null | undefined): string {
   return value?.trim() ?? "";
+}
+
+function getCompletedBindingRevisionId(
+  lastBinding: StudioMemberBindingContract | null | undefined,
+  lastBoundRevisionId: string | null | undefined,
+): string {
+  return trimOptional(lastBinding?.revisionId) || trimOptional(lastBoundRevisionId);
 }
 
 function decodePathSegment(value: string): string {
@@ -122,18 +131,28 @@ const TeamMemberInvokePage: React.FC = () => {
   const memberKind = normalizeStudioMemberBindingImplementationKind(
     memberSummary?.implementationKind,
   );
+  const memberLifecycleStage = normalizeStudioMemberLifecycleStage(
+    memberSummary?.lifecycleStage,
+  );
   const lastBinding = bindingQuery.data?.lastBinding ?? memberQuery.data?.lastBinding ?? null;
-  const publishedServiceId =
-    trimOptional(lastBinding?.publishedServiceId) ||
-    trimOptional(memberSummary?.publishedServiceId);
+  const completedBindingRevisionId = getCompletedBindingRevisionId(
+    lastBinding,
+    memberSummary?.lastBoundRevisionId,
+  );
+  const memberBindingCompleted =
+    memberLifecycleStage === "bind_ready" && Boolean(completedBindingRevisionId);
+  const boundPublishedServiceId = memberBindingCompleted
+    ? trimOptional(lastBinding?.publishedServiceId) ||
+      trimOptional(memberSummary?.publishedServiceId)
+    : "";
   const selectedService = React.useMemo(
     () =>
-      publishedServiceId
+      boundPublishedServiceId
         ? (servicesQuery.data ?? []).find(
-            (service) => trimOptional(service.serviceId) === publishedServiceId,
+            (service) => trimOptional(service.serviceId) === boundPublishedServiceId,
           ) ?? null
         : null,
-    [publishedServiceId, servicesQuery.data],
+    [boundPublishedServiceId, servicesQuery.data],
   );
   const invokeServices = React.useMemo(
     () =>
@@ -149,10 +168,10 @@ const TeamMemberInvokePage: React.FC = () => {
       "team-member-invoke",
       "service-revisions",
       route.scopeId,
-      publishedServiceId,
+      boundPublishedServiceId,
     ],
-    enabled: Boolean(route.scopeId && publishedServiceId),
-    queryFn: () => scopeRuntimeApi.getServiceRevisions(route.scopeId, publishedServiceId),
+    enabled: Boolean(route.scopeId && boundPublishedServiceId),
+    queryFn: () => scopeRuntimeApi.getServiceRevisions(route.scopeId, boundPublishedServiceId),
   });
   const memberRevision =
     getScopeServiceCurrentRevision(serviceRevisionQuery.data) ??
@@ -222,7 +241,7 @@ const TeamMemberInvokePage: React.FC = () => {
       };
     }
 
-    if (memberSummary && !publishedServiceId) {
+    if (memberSummary && !memberBindingCompleted) {
       return {
         description: t(
           "pages.teammemberinvoke.unbound.description",
@@ -233,7 +252,7 @@ const TeamMemberInvokePage: React.FC = () => {
       };
     }
 
-    if (memberSummary && publishedServiceId && !selectedService && !servicesQuery.isLoading) {
+    if (memberSummary && memberBindingCompleted && !selectedService && !servicesQuery.isLoading) {
       return {
         description: t(
           "pages.teammemberinvoke.service.pending.description",
@@ -259,9 +278,9 @@ const TeamMemberInvokePage: React.FC = () => {
   }, [
     invokeServices.length,
     loadError,
+    memberBindingCompleted,
     memberKind,
     memberSummary,
-    publishedServiceId,
     route.memberId,
     route.scopeId,
     route.teamId,
@@ -315,7 +334,7 @@ const TeamMemberInvokePage: React.FC = () => {
           </AevatarPanel>
         ) : (
           <StudioMemberInvokePanel
-            initialServiceId={publishedServiceId}
+            initialServiceId={boundPublishedServiceId}
             memberId={route.memberId}
             memberRevision={memberRevision}
             runtimeTarget="service"

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioHeader.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioHeader.tsx
@@ -7,6 +7,7 @@ import {
   FileTextOutlined,
   PlayCircleOutlined,
   PlusOutlined,
+  ReloadOutlined,
   SaveOutlined,
 } from "@ant-design/icons";
 import {
@@ -28,12 +29,15 @@ type WorkflowStudioHeaderProps = {
   readonly publishPending: boolean;
   readonly publishPlaceholderReason?: string;
   readonly publishTone: "default" | "processing" | "success" | "warning" | "error";
+  readonly refreshPublishStatusPending: boolean;
+  readonly showRefreshPublishStatus: boolean;
   readonly canOpenDraftRunPanel: boolean;
   readonly canSave: boolean;
   readonly canViewYaml: boolean;
   readonly dirty: boolean;
   readonly activeMemberRunPlaceholderReason?: string;
   readonly onPublishMember: () => void;
+  readonly onRefreshPublishStatus: () => void;
   readonly onAddNode: () => void;
   readonly onDeleteConnection: () => void;
   readonly onDeleteNode: () => void;
@@ -70,7 +74,7 @@ function formatPublishStatusLabel(input: {
   }
 
   if (input.tone === "processing") {
-    return t("teamMemberWorkflowStudio.header.publish.binding", "Binding");
+    return t("teamMemberWorkflowStudio.header.publish.publishingStatus", "Publishing");
   }
 
   return input.checked
@@ -286,12 +290,15 @@ type HeaderPrimaryActionsProps = {
   readonly onOpenDraftRunPanel: () => void;
   readonly onPasteYamlClick: () => void;
   readonly onPublishMember: () => void;
+  readonly onRefreshPublishStatus: () => void;
   readonly onViewYaml: () => void;
   readonly pasteYamlPending: boolean;
   readonly publishDisabled: boolean;
   readonly publishPending: boolean;
   readonly publishPlaceholderReason?: string;
+  readonly refreshPublishStatusPending: boolean;
   readonly showPublishButton: boolean;
+  readonly showRefreshPublishStatus: boolean;
 };
 
 const HeaderPrimaryActions: React.FC<HeaderPrimaryActionsProps> = ({
@@ -302,12 +309,15 @@ const HeaderPrimaryActions: React.FC<HeaderPrimaryActionsProps> = ({
   onOpenDraftRunPanel,
   onPasteYamlClick,
   onPublishMember,
+  onRefreshPublishStatus,
   onViewYaml,
   pasteYamlPending,
   publishDisabled,
   publishPending,
   publishPlaceholderReason,
+  refreshPublishStatusPending,
   showPublishButton,
+  showRefreshPublishStatus,
 }) => (
   <section
     aria-label={t(
@@ -341,6 +351,23 @@ const HeaderPrimaryActions: React.FC<HeaderPrimaryActionsProps> = ({
         }
       >
         {t("teamMemberWorkflowStudio.header.publishMemberShort", "Publish member")}
+      </Button>
+    ) : null}
+    {showRefreshPublishStatus ? (
+      <Button
+        icon={<ReloadOutlined />}
+        loading={refreshPublishStatusPending}
+        onClick={onRefreshPublishStatus}
+        size="small"
+        title={t(
+          "teamMemberWorkflowStudio.header.refreshPublishStatusTitle",
+          "Refresh published member status",
+        )}
+      >
+        {t(
+          "teamMemberWorkflowStudio.header.refreshPublishStatus",
+          "Refresh status",
+        )}
       </Button>
     ) : null}
     <Button
@@ -469,6 +496,8 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
   publishPending,
   publishPlaceholderReason,
   publishTone,
+  refreshPublishStatusPending,
+  showRefreshPublishStatus,
   canOpenDraftRunPanel,
   canSave,
   canViewYaml,
@@ -480,6 +509,7 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
   onDeleteNode,
   onOpenDraftRunPanel,
   onOpenPasteYaml,
+  onRefreshPublishStatus,
   onViewYaml,
   onNavigateBack,
   onNavigateToTeam,
@@ -506,10 +536,8 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
     .join(" · ");
   const showPublishButton =
     publishPending ||
-    publishTone === "processing" ||
     publishTone === "error" ||
-    dirty ||
-    !memberPublished ||
+    (!memberPublished && publishTone !== "processing") ||
     !publishDisabled;
   return (
     <header
@@ -555,12 +583,15 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
           onOpenDraftRunPanel={onOpenDraftRunPanel}
           onPasteYamlClick={onOpenPasteYaml}
           onPublishMember={onPublishMember}
+          onRefreshPublishStatus={onRefreshPublishStatus}
           onViewYaml={onViewYaml}
           pasteYamlPending={pasteYamlPending}
           publishDisabled={publishDisabled}
           publishPending={publishPending}
           publishPlaceholderReason={publishPlaceholderReason}
+          refreshPublishStatusPending={refreshPublishStatusPending}
           showPublishButton={showPublishButton}
+          showRefreshPublishStatus={showRefreshPublishStatus}
         />
       </div>
       <div

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -35,6 +35,7 @@ import {
   STUDIO_GRAPH_CATEGORIES,
 } from "@/shared/studio/graph";
 import { isStudioApiStatus, studioApi } from "@/shared/studio/api";
+import { normalizeStudioMemberLifecycleStage } from "@/shared/studio/models";
 import type {
   StudioExecutionDetail,
   StudioExecutionFrame,
@@ -134,6 +135,9 @@ type TeamMemberWorkflowStudioState = {
   readonly publishPending: boolean;
   readonly publishPlaceholderReason: string;
   readonly publishTone: WorkflowPublishTone;
+  readonly refreshPublishStatus: () => void;
+  readonly refreshPublishStatusPending: boolean;
+  readonly showRefreshPublishStatus: boolean;
   readonly backHref: string;
   readonly navigateToTeam: () => void;
   readonly navigateToTeams: () => void;
@@ -208,6 +212,31 @@ const CREATED_MEMBER_MATERIALIZATION_DELAY_MS = 450;
 
 function trimOptional(value: string | null | undefined): string {
   return value?.trim() ?? "";
+}
+
+function hasCurrentCompletedMemberBinding(
+  detail: StudioMemberDetail | null | undefined,
+): boolean {
+  if (
+    normalizeStudioMemberLifecycleStage(detail?.summary.lifecycleStage) !==
+    "bind_ready"
+  ) {
+    return false;
+  }
+
+  return Boolean(
+    trimOptional(detail?.summary.lastBoundRevisionId) ||
+      trimOptional(detail?.lastBinding?.revisionId),
+  );
+}
+
+function hasActiveMemberBindingRun(
+  detail: StudioMemberDetail | null | undefined,
+): boolean {
+  return Boolean(
+    detail?.currentBindingRun &&
+      !isTerminalBindingRun(detail.currentBindingRun),
+  );
 }
 
 function readPathSegments(): {
@@ -513,7 +542,7 @@ function readBindingRunFailureMessage(
   run: StudioMemberBindingRunStatusResponse | null,
 ): string {
   if (!run) {
-    return "Publish binding status is still pending.";
+    return "Publish status is still pending.";
   }
 
   if (run.failure?.message) {
@@ -1443,6 +1472,23 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
         throw new Error("Resolve an existing workflow member before publishing.");
       }
 
+      const currentMember = await studioApi.getMember(route.scopeId, route.memberId);
+      queryClient.setQueryData(
+        getTeamMemberWorkflowStudioMemberQueryKey(route.scopeId, route.memberId),
+        currentMember,
+      );
+      if (hasCurrentCompletedMemberBinding(currentMember)) {
+        throw new Error(
+          "This member already has a published service. Save draft changes instead of publishing again.",
+        );
+      }
+
+      if (hasActiveMemberBindingRun(currentMember)) {
+        throw new Error(
+          "Publish is already in progress for this member. Refresh status before publishing again.",
+        );
+      }
+
       let savedDraft: SavedWorkflowDraft | null = null;
       let documentForPublish = document;
       let titleForPublish = trimOptional(title) || trimOptional(document.name);
@@ -1497,7 +1543,9 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
             throw error;
           }
         }
-        await waitForBindingRunPollTick();
+        if (attempt < MEMBER_BINDING_RUN_POLL_ATTEMPTS - 1) {
+          await waitForBindingRunPollTick();
+        }
       }
 
       if (lastRun?.status === "failed" || lastRun?.status === "rejected") {
@@ -1528,7 +1576,9 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       if (run?.status === "succeeded") {
         void message.success("Workflow member published.");
       } else {
-        void message.info("Publish was accepted and is still binding.");
+        void message.info(
+          "Publish was accepted. Studio is still waiting for published status.",
+        );
       }
     },
   });
@@ -1571,22 +1621,27 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
             ((workflowQuery.data && !linkedWorkflowMissing) ||
               canCreateUnlinkedMemberDraft),
         );
-  const memberPublishedByQuery =
-    memberQuery.data?.summary.lifecycleStage === "bind_ready" &&
-    !linkedWorkflowMissing &&
-    Boolean(workflowQuery.data);
+  const authoritativeMemberPublished = hasCurrentCompletedMemberBinding(
+    memberQuery.data,
+  );
+  const authoritativeBindingRunInProgress = hasActiveMemberBindingRun(
+    memberQuery.data,
+  );
+  const memberPublishedByQuery = authoritativeMemberPublished;
   const memberIsPublished =
     memberPublishedByQuery ||
     publishBindingRun?.status === "succeeded";
-  const publishBindingStillInProgress = Boolean(
-    !memberPublishedByQuery &&
-      publishBindingRun &&
-      publishBindingRun.status !== "succeeded" &&
-      !isTerminalBindingRun(publishBindingRun),
+  const publishStatusStillInProgress = Boolean(
+    authoritativeBindingRunInProgress ||
+      (publishBindingRun &&
+        publishBindingRun.status !== "succeeded" &&
+        !isTerminalBindingRun(publishBindingRun)),
   );
   const publishHasDraftChanges = Boolean(dirty && workflowHasSteps);
   const publishPending = publishMutation.isPending;
   const memberPublished = memberIsPublished;
+  const publishVisibleError =
+    memberIsPublished || publishStatusStillInProgress ? "" : publishError;
   const publishDisabled = Boolean(
     route.mode === "new" ||
       linkedWorkflowMissing ||
@@ -1595,8 +1650,8 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       !workflowHasSteps ||
       Boolean(selectedStepConfigurationError) ||
       publishMutation.isPending ||
-      publishBindingStillInProgress ||
-      (memberIsPublished && !publishHasDraftChanges),
+      publishStatusStillInProgress ||
+      memberIsPublished,
   );
   const publishPlaceholderReason =
     route.mode === "new"
@@ -1605,10 +1660,12 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
         ? "No stable workflow draft is linked to this member yet."
         : selectedStepConfigurationError
           ? selectedStepConfigurationError
-        : publishBindingStillInProgress
-          ? "Publish was accepted and binding is still in progress. Refresh later before publishing again."
-        : memberIsPublished && !publishHasDraftChanges
-          ? "This member workflow is already published. Edit the draft before publishing a new version."
+        : publishStatusStillInProgress
+          ? "Publish is still in progress. Use Refresh status before publishing again."
+        : memberIsPublished
+          ? publishHasDraftChanges
+            ? "This member already has a published service. Save draft changes instead of publishing again."
+            : "This member workflow is already published. Use Refresh status to check readiness."
         : !workflowQuery.data || !editableDocument
             ? "Load the workflow draft before publishing."
             : !workflowHasSteps
@@ -1617,21 +1674,70 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
                 ? "Publish saves draft changes, binds the member workflow, and observes readiness."
                 : "Publish binds the saved workflow draft to this member and observes readiness.";
   const publishTone: WorkflowPublishTone = publishError
-    ? "error"
-    : publishPending || publishBindingStillInProgress
+    ? publishVisibleError
+      ? "error"
+      : publishStatusStillInProgress
+        ? "processing"
+        : memberIsPublished
+          ? "success"
+          : "default"
+    : publishPending || publishStatusStillInProgress
       ? "processing"
       : memberIsPublished
         ? "success"
         : "default";
   const publishNotice =
-    publishError ||
+    publishVisibleError ||
     (publishPending
-      ? `Publish binding status: ${publishBindingRun?.status ?? "accepted"}.`
-      : publishBindingStillInProgress
-        ? `Publish was accepted and binding is still in progress (${publishBindingRun?.status ?? "accepted"}). Refresh later to check readiness.`
+      ? `Publish status: ${publishBindingRun?.status ?? "accepted"}.`
+      : publishStatusStillInProgress
+        ? `Publish is still in progress (${memberQuery.data?.currentBindingRun?.status ?? publishBindingRun?.status ?? "accepted"}). Use Refresh status to check readiness.`
       : memberIsPublished
         ? "Published member workflow is serviceable."
         : "Draft member workflow is not published to the active member yet.");
+  const showRefreshPublishStatus = Boolean(
+    route.mode === "existing" &&
+      route.scopeId &&
+      route.memberId &&
+      (publishStatusStillInProgress ||
+        memberIsPublished ||
+        publishError ||
+        publishBindingRun),
+  );
+  const refreshPublishStatusPending = Boolean(
+    memberQuery.isFetching || workflowQuery.isFetching,
+  );
+  const refreshPublishStatus = React.useCallback(async () => {
+    if (route.mode !== "existing" || !route.scopeId || !route.memberId) {
+      return;
+    }
+
+    const memberResult = await memberQuery.refetch();
+    if (routeDraftWorkflowId) {
+      await workflowQuery.refetch();
+    }
+
+    const refreshedMember = memberResult.data;
+    if (hasActiveMemberBindingRun(refreshedMember)) {
+      void message.info("Publish is still in progress.");
+      return;
+    }
+
+    if (hasCurrentCompletedMemberBinding(refreshedMember)) {
+      setPublishBindingRun((currentRun) =>
+        currentRun && !isTerminalBindingRun(currentRun)
+          ? {
+              ...currentRun,
+              status: "succeeded",
+            }
+          : currentRun,
+      );
+      void message.success("Published member status refreshed.");
+      return;
+    }
+
+    void message.info("No published member status is visible yet.");
+  }, [memberQuery, route.memberId, route.mode, route.scopeId, routeDraftWorkflowId, workflowQuery]);
   const executionStatus = activeMemberRunMutation.isPending
     ? "running"
     : resolveWorkflowExecutionStatus(executionDetail);
@@ -2008,6 +2114,9 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     publishPending,
     publishPlaceholderReason,
     publishTone,
+    refreshPublishStatus,
+    refreshPublishStatusPending,
+    showRefreshPublishStatus,
     backHref,
     navigateToTeam: () => {
       if (!dirty || confirmDiscardUnsavedChanges()) {

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -475,7 +475,7 @@ function mockNewWorkflowMemberCreateFixtures() {
 
 describe("TeamMemberWorkflowStudioPage", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
     window.history.replaceState({}, "", "/");
     mockTeam();
     mockSerializeYaml();
@@ -604,6 +604,12 @@ describe("TeamMemberWorkflowStudioPage", () => {
         scopeId: "scope-1",
         teamId: "t-alpha",
         updatedAt: "2026-06-08T00:00:01Z",
+      },
+      lastBinding: {
+        boundAt: "2026-06-08T00:00:00Z",
+        implementationKind: "workflow",
+        publishedServiceId: "svc-alpha",
+        revisionId: "",
       },
     });
     (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
@@ -1818,7 +1824,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(studioApi.saveWorkflow).toHaveBeenCalledTimes(1);
   });
 
-  it("does not show published when a refreshed saved member has no linked workflow draft", async () => {
+  it("keeps draft status when only the published service identity exists", async () => {
     window.history.replaceState(
       {},
       "",
@@ -1835,7 +1841,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         displayName: "Untitled member 8",
         implementationKind: "workflow",
         lastBoundRevisionId: null,
-        lifecycleStage: "bind_ready",
+        lifecycleStage: "created",
         memberId: "m-alpha",
         publishedServiceId: "svc-alpha",
         scopeId: "scope-1",
@@ -1857,8 +1863,118 @@ describe("TeamMemberWorkflowStudioPage", () => {
     ).not.toHaveLength(0);
     expect(screen.getByText("Draft")).toBeTruthy();
     expect(screen.queryByText("Published")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Refresh status" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Publish member" })).toBeDisabled();
     expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
     expect(studioApi.getWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("shows published member status from completed binding facts even when no workflow draft is linked", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Untitled member 8",
+        implementationKind: "workflow",
+        lastBoundRevisionId: "rev-alpha",
+        lifecycleStage: "bind_ready",
+        memberId: "m-alpha",
+        publishedServiceId: "svc-alpha",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+      lastBinding: {
+        boundAt: "2026-06-08T00:00:00Z",
+        implementationKind: "workflow",
+        publishedServiceId: "svc-alpha",
+        revisionId: "rev-alpha",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockRejectedValue(
+      Object.assign(new Error("Not found"), { status: 404 }),
+    );
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    expect(await screen.findByDisplayValue("Untitled member 8")).toBeTruthy();
+    expect(
+      await screen.findAllByText(
+        "No workflow draft is linked to this member yet.",
+      ),
+    ).not.toHaveLength(0);
+    expect(screen.getByText("Published")).toBeTruthy();
+    expect(screen.queryByText("Draft")).toBeNull();
+    expect(screen.getByRole("button", { name: "Refresh status" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Publish member" })).toBeNull();
+    expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.getWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("keeps draft status when the previous binding is stale for the current implementation", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow?workflowId=wf-alpha",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "wf-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: "rev-old",
+        lifecycleStage: "build_ready",
+        memberId: "m-alpha",
+        publishedServiceId: "svc-alpha",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+      lastBinding: {
+        boundAt: "2026-06-08T00:00:00Z",
+        implementationKind: "workflow",
+        publishedServiceId: "svc-alpha",
+        revisionId: "rev-old",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "wf-alpha.yaml",
+      filePath: "scope://scope-1/wf-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "wf-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: mockWorkflowDocument,
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByText("nodes:1")).toBeTruthy();
+    });
+    expect(screen.getByText("Draft")).toBeTruthy();
+    expect(screen.queryByText("Published")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Refresh status" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Publish member" })).toBeEnabled();
   });
 
   it("saves existing workflow drafts without publishing, execution calls, or canvas reload", async () => {
@@ -3330,13 +3446,18 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(
       within(headerIdentity).getByRole("button", { name: "Back" }),
     ).toBeTruthy();
-    expect(within(headerIdentity).getByText("Published")).toBeTruthy();
+    expect(within(headerIdentity).getByText("Draft")).toBeTruthy();
     expect(
       within(headerIdentity).getByRole("button", { name: "Edit workflow name" }),
     ).toBeTruthy();
     expect(
-      within(headerPrimaryActions).queryByRole("button", {
+      within(headerPrimaryActions).getByRole("button", {
         name: "Publish member",
+      }),
+    ).toBeTruthy();
+    expect(
+      within(headerPrimaryActions).queryByRole("button", {
+        name: "Refresh status",
       }),
     ).toBeNull();
     expect(
@@ -4508,12 +4629,12 @@ describe("TeamMemberWorkflowStudioPage", () => {
       }
 
       await waitFor(() => {
-        expect(screen.queryByText("Publishing")).toBeNull();
-        expect(screen.getByText("Binding")).toBeTruthy();
+        expect(screen.getByText("Publishing")).toBeTruthy();
       });
-      expect(screen.getByRole("button", { name: "Publish member" })).toBeDisabled();
+      expect(screen.queryByRole("button", { name: "Publish member" })).toBeNull();
+      expect(screen.getByRole("button", { name: "Refresh status" })).toBeTruthy();
       expect(
-        screen.getAllByTitle(/Publish was accepted and binding is still in progress/).length,
+        screen.getAllByTitle(/Publish is still in progress/).length,
       ).toBeGreaterThan(0);
       expect(studioApi.getMemberBindingRun).toHaveBeenCalledTimes(8);
     } finally {
@@ -4521,16 +4642,16 @@ describe("TeamMemberWorkflowStudioPage", () => {
     }
   });
 
-  it("allows publishing a new draft version for an already published workflow member", async () => {
+  it("blocks duplicate publish for an already published workflow member and refreshes status through reads", async () => {
     window.history.replaceState(
       {},
       "",
-      "/scopes/scope-1/teams/t-alpha/members/member-alpha/workflow?workflowId=workflow-alpha",
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow?workflowId=wf-alpha",
     );
     (studioApi.getMember as jest.Mock).mockResolvedValue({
       implementationRef: {
         implementationKind: "workflow",
-        workflowId: "workflow-alpha",
+        workflowId: "wf-alpha",
       },
       summary: {
         createdAt: "2026-06-08T00:00:00Z",
@@ -4539,23 +4660,29 @@ describe("TeamMemberWorkflowStudioPage", () => {
         implementationKind: "workflow",
         lastBoundRevisionId: "rev-1",
         lifecycleStage: "bind_ready",
-        memberId: "member-alpha",
-        publishedServiceId: "service-alpha",
+        memberId: "m-alpha",
+        publishedServiceId: "svc-alpha",
         scopeId: "scope-1",
         teamId: "t-alpha",
         updatedAt: "2026-06-08T00:00:00Z",
+      },
+      lastBinding: {
+        boundAt: "2026-06-08T00:00:00Z",
+        implementationKind: "workflow",
+        publishedServiceId: "svc-alpha",
+        revisionId: "rev-1",
       },
     });
     (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
-      fileName: "workflow-alpha.yaml",
-      filePath: "scope://scope-1/workflow-alpha.yaml",
+      fileName: "wf-alpha.yaml",
+      filePath: "scope://scope-1/wf-alpha.yaml",
       findings: [],
       layout: null,
       name: "Workflow Alpha",
-      workflowId: "workflow-alpha",
+      workflowId: "wf-alpha",
       yaml: "name: Workflow Alpha\nsteps: []\n",
       document: mockWorkflowDocument,
       updatedAtUtc: "2026-06-08T00:00:00Z",
@@ -4564,12 +4691,12 @@ describe("TeamMemberWorkflowStudioPage", () => {
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
-      fileName: "workflow-alpha.yaml",
-      filePath: "scope://scope-1/workflow-alpha.yaml",
+      fileName: "wf-alpha.yaml",
+      filePath: "scope://scope-1/wf-alpha.yaml",
       findings: [],
       layout: null,
       name: "Workflow Alpha v2",
-      workflowId: "workflow-alpha",
+      workflowId: "wf-alpha",
       yaml: "name: Workflow Alpha v2\nsteps: []\n",
       document: {
         ...mockWorkflowDocument,
@@ -4577,21 +4704,6 @@ describe("TeamMemberWorkflowStudioPage", () => {
       },
       updatedAtUtc: "2026-06-08T00:00:01Z",
     });
-    (studioApi.bindMemberWorkflow as jest.Mock).mockResolvedValue({
-      bindingRunId: "binding-run-2",
-      memberId: "member-alpha",
-      scopeId: "scope-1",
-      status: "accepted",
-    });
-    (studioApi.getMemberBindingRun as jest.Mock).mockResolvedValue({
-      bindingRunId: "binding-run-2",
-      memberId: "member-alpha",
-      scopeId: "scope-1",
-      status: "succeeded",
-      stateVersion: 3,
-      updatedAt: "2026-06-08T00:00:02Z",
-    });
-
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     await waitFor(() => {
@@ -4606,29 +4718,195 @@ describe("TeamMemberWorkflowStudioPage", () => {
       target: { value: "Workflow Alpha v2" },
     });
 
-    const publishButton = await screen.findByRole("button", {
-      name: "Publish member",
+    await waitFor(() => {
+      expect(screen.getByText("Unsaved changes")).toBeTruthy();
     });
+    expect(screen.queryByRole("button", { name: "Publish member" })).toBeNull();
+
+    const getMemberCallCount = (studioApi.getMember as jest.Mock).mock.calls.length;
+    fireEvent.click(screen.getByRole("button", { name: "Refresh status" }));
+    await waitFor(() => {
+      expect(studioApi.getMember).toHaveBeenCalledTimes(getMemberCallCount + 1);
+    });
+    expect(studioApi.getMember).toHaveBeenLastCalledWith("scope-1", "m-alpha");
+    expect(studioApi.getWorkflow).toHaveBeenCalledWith("wf-alpha", "scope-1");
+    expect(studioApi.saveWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.getMemberBindingRun).not.toHaveBeenCalled();
+    expect(studioApi.setTeamEntryMember).not.toHaveBeenCalled();
+  });
+
+  it("updates stale publish eligibility from the preflight member read before side effects", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow?workflowId=wf-alpha",
+    );
+    const initialUnpublishedMember = {
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "wf-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: null,
+        lifecycleStage: "build_ready",
+        memberId: "m-alpha",
+        publishedServiceId: "",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+    };
+    const refreshedPublishedMember = {
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "wf-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: "rev-1",
+        lifecycleStage: "bind_ready",
+        memberId: "m-alpha",
+        publishedServiceId: "svc-alpha",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:01Z",
+      },
+      lastBinding: {
+        boundAt: "2026-06-08T00:00:01Z",
+        implementationKind: "workflow",
+        publishedServiceId: "svc-alpha",
+        revisionId: "rev-1",
+      },
+    };
+    (studioApi.getMember as jest.Mock)
+      .mockResolvedValueOnce(initialUnpublishedMember)
+      .mockResolvedValueOnce(refreshedPublishedMember);
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "wf-alpha.yaml",
+      filePath: "scope://scope-1/wf-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "wf-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: mockWorkflowDocument,
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByText("nodes:1")).toBeTruthy();
+    });
+    const publishButton = screen.getByRole("button", { name: "Publish member" });
     await waitFor(() => {
       expect(publishButton).toBeEnabled();
     });
     fireEvent.click(publishButton);
 
     await waitFor(() => {
-      expect(studioApi.saveWorkflow).toHaveBeenCalledWith(
-        expect.objectContaining({
-          workflowName: "Workflow Alpha v2",
-        }),
-      );
-      expect(studioApi.bindMemberWorkflow).toHaveBeenCalledWith({
-        displayName: "Workflow Alpha v2",
-        memberId: "member-alpha",
-        scopeId: "scope-1",
-        workflowId: "workflow-alpha",
-        workflowYamls: [expect.stringContaining("name: Workflow Alpha v2")],
-      });
+      expect(studioApi.getMember).toHaveBeenCalledTimes(2);
+      expect(screen.getByText("Published")).toBeTruthy();
     });
-    expect(studioApi.setTeamEntryMember).not.toHaveBeenCalled();
+    expect(studioApi.getMember).toHaveBeenLastCalledWith("scope-1", "m-alpha");
+    expect(screen.queryByText("Error")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Publish member" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Refresh status" })).toBeTruthy();
+    expect(studioApi.saveWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.getMemberBindingRun).not.toHaveBeenCalled();
+  });
+
+  it("allows publishing when the member has a service identity but no completed binding fact", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow?workflowId=wf-alpha",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "wf-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: null,
+        lifecycleStage: "created",
+        memberId: "m-alpha",
+        publishedServiceId: "member-m-alpha",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+      lastBinding: null,
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "wf-alpha.yaml",
+      filePath: "scope://scope-1/wf-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "wf-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: mockWorkflowDocument,
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+    (studioApi.bindMemberWorkflow as jest.Mock).mockResolvedValue({
+      bindingRunId: "binding-run-identity-only",
+      memberId: "m-alpha",
+      scopeId: "scope-1",
+      status: "accepted",
+    });
+    (studioApi.getMemberBindingRun as jest.Mock).mockResolvedValue({
+      bindingRunId: "binding-run-identity-only",
+      memberId: "m-alpha",
+      scopeId: "scope-1",
+      status: "succeeded",
+      stateVersion: 2,
+      updatedAt: "2026-06-08T00:00:02Z",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByText("nodes:1")).toBeTruthy();
+    });
+    expect(screen.getByText("Draft")).toBeTruthy();
+    const publishButton = screen.getByRole("button", { name: "Publish member" });
+    await waitFor(() => {
+      expect(publishButton).toBeEnabled();
+    });
+
+    fireEvent.click(publishButton);
+
+    await waitFor(() => {
+      expect(studioApi.bindMemberWorkflow).toHaveBeenCalledWith({
+        displayName: "Workflow Alpha",
+        memberId: "m-alpha",
+        scopeId: "scope-1",
+        workflowId: "wf-alpha",
+        workflowYamls: [expect.stringContaining("name: Workflow Alpha")],
+      });
+      expect(screen.getByText("Published")).toBeTruthy();
+    });
+    expect(studioApi.saveWorkflow).not.toHaveBeenCalled();
   });
 
   it("does not expose Team entry actions in workflow studio", async () => {
@@ -4771,10 +5049,28 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "workflow-alpha.yaml",
+      filePath: "scope://scope-1/workflow-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "workflow-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: mockWorkflowDocument,
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
 
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     expect(await screen.findByTestId("workflow-studio-canvas")).toBeTruthy();
+    expect(studioApi.getWorkflow).toHaveBeenCalledWith(
+      "workflow-alpha",
+      "scope-1",
+    );
     expect(screen.queryByText("Runs")).toBeNull();
     expect(studioApi.listExecutions).not.toHaveBeenCalled();
   });

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
@@ -234,12 +234,15 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
         publishPending={studio.publishPending}
         publishPlaceholderReason={studio.publishPlaceholderReason}
         publishTone={studio.publishTone}
+        refreshPublishStatusPending={studio.refreshPublishStatusPending}
+        showRefreshPublishStatus={studio.showRefreshPublishStatus}
         canOpenDraftRunPanel={studio.canOpenDraftRunPanel}
         canSave={studio.canSave}
         canViewYaml={studio.canViewYaml}
         dirty={studio.dirty}
         activeMemberRunPlaceholderReason={studio.activeMemberRunPlaceholderReason}
         onPublishMember={studio.publishMember}
+        onRefreshPublishStatus={studio.refreshPublishStatus}
         onAddNode={studio.openNodeLibrary}
         onDeleteConnection={studio.deleteSelectedConnection}
         onDeleteNode={studio.deleteSelectedNode}

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioMemberService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioMemberService.cs
@@ -442,6 +442,9 @@ public sealed class StudioMemberService : IStudioMemberService
         var detail = await _memberQueryPort.GetAsync(normalizedScopeId, memberId, ct)
             ?? throw new StudioMemberNotFoundException(normalizedScopeId, memberId);
 
+        if (!HasCurrentCompletedBinding(detail))
+            throw BuildMemberNotBoundException(memberId);
+
         var publishedServiceId = detail.Summary.PublishedServiceId;
         if (string.IsNullOrWhiteSpace(publishedServiceId))
         {
@@ -472,6 +475,11 @@ public sealed class StudioMemberService : IStudioMemberService
             service,
             revisions);
     }
+
+    private static bool HasCurrentCompletedBinding(StudioMemberDetailResponse detail) =>
+        string.Equals(detail.Summary.LifecycleStage, MemberLifecycleStageNames.BindReady, StringComparison.Ordinal)
+        && (!string.IsNullOrWhiteSpace(detail.Summary.LastBoundRevisionId)
+            || !string.IsNullOrWhiteSpace(detail.LastBinding?.RevisionId));
 
     private static ServiceRevisionSnapshot ResolveRevisionOrThrow(
         ServiceRevisionCatalogSnapshot? revisions,

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioTeamEntryMemberResolver.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioTeamEntryMemberResolver.cs
@@ -86,13 +86,22 @@ public sealed class StudioTeamEntryMemberResolver : ITeamEntryMemberResolver
         }
 
         if (!string.Equals(member.Summary.LifecycleStage, MemberLifecycleStageNames.BindReady, StringComparison.Ordinal)
-            || string.IsNullOrWhiteSpace(member.Summary.PublishedServiceId))
+            || !HasCompletedBinding(member))
         {
             throw Failure(
                 TeamEntryMemberErrorCodes.EntryMemberNotReady,
                 team.ScopeId,
                 team.TeamId,
                 $"entry member '{entryMemberId}' is not bind-ready.");
+        }
+
+        if (string.IsNullOrWhiteSpace(member.Summary.PublishedServiceId))
+        {
+            throw Failure(
+                TeamEntryMemberErrorCodes.EntryMemberNotReady,
+                team.ScopeId,
+                team.TeamId,
+                $"entry member '{entryMemberId}' has no published service identity.");
         }
 
         var readiness = await _readinessQueryPort.GetReadinessAsync(
@@ -116,6 +125,10 @@ public sealed class StudioTeamEntryMemberResolver : ITeamEntryMemberResolver
             EntryMemberId: entryMemberId,
             PublishedServiceId: member.Summary.PublishedServiceId);
     }
+
+    private static bool HasCompletedBinding(StudioMemberDetailResponse member) =>
+        !string.IsNullOrWhiteSpace(member.Summary.LastBoundRevisionId)
+        || !string.IsNullOrWhiteSpace(member.LastBinding?.RevisionId);
 
     private static string NormalizeRequired(string? value, string fieldName)
     {

--- a/test/Aevatar.Studio.Tests/StudioMemberServiceContractAndRevisionTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberServiceContractAndRevisionTests.cs
@@ -191,12 +191,38 @@ public sealed class StudioMemberServiceContractAndRevisionTests
     [Fact]
     public async Task GetEndpointContractAsync_ShouldThrowInvalidOperation_WhenMemberNotYetBound()
     {
-        // Member exists but has not been bound, so the platform lifecycle
-        // port has no service catalog entry. Surface as InvalidOperation,
-        // which endpoints map to 400, distinct from 404 missing-member.
-        var detail = NewDetail();
+        // The member-owned publishedServiceId is stable identity, not a
+        // completed binding fact. Even if a platform service catalog entry
+        // exists for that identity, member-first contract reads must wait for
+        // the member read model to expose a current completed binding.
+        var detail = NewDetail(lastBoundRevisionId: null);
         var queryPort = new InMemoryMemberQueryPort(detail);
-        var lifecycle = new InMemoryServiceLifecycleQueryPort { Service = null };
+        var lifecycle = new InMemoryServiceLifecycleQueryPort
+        {
+            Service = NewService(
+                endpoints:
+                [
+                    new ServiceEndpointSnapshot(
+                        EndpointId: "chat",
+                        DisplayName: "Chat",
+                        Kind: "chat",
+                        RequestTypeUrl: "type.googleapis.com/x.Request",
+                        ResponseTypeUrl: "type.googleapis.com/x.Response",
+                        Description: string.Empty),
+                ]),
+            Revisions = NewRevisions(
+                implementationKind: ServiceImplementationKind.Workflow,
+                endpoints:
+                [
+                    new ServiceEndpointSnapshot(
+                        EndpointId: "chat",
+                        DisplayName: "Chat",
+                        Kind: "chat",
+                        RequestTypeUrl: "type.googleapis.com/x.Request",
+                        ResponseTypeUrl: "type.googleapis.com/x.Response",
+                        Description: string.Empty),
+                ]),
+        };
         var service = new StudioMemberService(
             new InertMemberCommandPort(),
             queryPort,
@@ -210,6 +236,7 @@ public sealed class StudioMemberServiceContractAndRevisionTests
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*has no published service yet*");
+        lifecycle.LastIdentity.Should().BeNull();
     }
 
     [Fact]
@@ -391,7 +418,9 @@ public sealed class StudioMemberServiceContractAndRevisionTests
         commandPort.OperationsInOrder.Should().BeEmpty();
     }
 
-    private static StudioMemberDetailResponse NewDetail()
+    private static StudioMemberDetailResponse NewDetail(
+        string lifecycleStage = MemberLifecycleStageNames.BindReady,
+        string? lastBoundRevisionId = "rev-1")
     {
         var summary = new StudioMemberSummaryResponse(
             MemberId: MemberId,
@@ -399,9 +428,9 @@ public sealed class StudioMemberServiceContractAndRevisionTests
             DisplayName: "Test Member",
             Description: string.Empty,
             ImplementationKind: MemberImplementationKindNames.Workflow,
-            LifecycleStage: MemberLifecycleStageNames.BindReady,
+            LifecycleStage: lifecycleStage,
             PublishedServiceId: PublishedServiceId,
-            LastBoundRevisionId: "rev-1",
+            LastBoundRevisionId: lastBoundRevisionId,
             CreatedAt: DateTimeOffset.UtcNow.AddDays(-1),
             UpdatedAt: DateTimeOffset.UtcNow.AddHours(-1));
 

--- a/test/Aevatar.Studio.Tests/StudioTeamEntryMemberResolverTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamEntryMemberResolverTests.cs
@@ -168,7 +168,21 @@ public sealed class StudioTeamEntryMemberResolverTests
     }
 
     [Fact]
-    public async Task ResolveAsync_ShouldThrowNotReady_WhenPublishedServiceMissing()
+    public async Task ResolveAsync_ShouldThrowNotReady_WhenCompletedBindingMissing()
+    {
+        var resolver = new StudioTeamEntryMemberResolver(
+            new TeamQueryPort(NewTeam()),
+            new MemberQueryPort(NewMember(lastBoundRevisionId: null)),
+            new FixedScopeBindingReadinessQueryPort(ScopeBindingReadinessStatus.Ready, invokeReady: true));
+
+        var act = () => resolver.ResolveAsync(ScopeId, TeamId, "chat");
+
+        await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
+            .Where(ex => ex.Code == TeamEntryMemberErrorCodes.EntryMemberNotReady);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldThrowNotReady_WhenCompletedBindingHasNoServiceIdentity()
     {
         var resolver = new StudioTeamEntryMemberResolver(
             new TeamQueryPort(NewTeam()),
@@ -247,7 +261,8 @@ public sealed class StudioTeamEntryMemberResolverTests
     private static StudioMemberDetailResponse NewMember(
         string? teamId = TeamId,
         string lifecycleStage = MemberLifecycleStageNames.BindReady,
-        string publishedServiceId = PublishedServiceId)
+        string publishedServiceId = PublishedServiceId,
+        string? lastBoundRevisionId = "rev-1")
     {
         var summary = new StudioMemberSummaryResponse(
             MemberId: EntryMemberId,
@@ -257,7 +272,7 @@ public sealed class StudioTeamEntryMemberResolverTests
             ImplementationKind: MemberImplementationKindNames.Workflow,
             LifecycleStage: lifecycleStage,
             PublishedServiceId: publishedServiceId,
-            LastBoundRevisionId: "rev-1",
+            LastBoundRevisionId: lastBoundRevisionId,
             CreatedAt: DateTimeOffset.UtcNow.AddDays(-1),
             UpdatedAt: DateTimeOffset.UtcNow)
         {


### PR DESCRIPTION
## Summary
- Treat `publishedServiceId` as member-owned service identity, not a completed binding fact.
- Gate Workflow Studio published state, Team member invoke, Team entry resolution, and member contract/revision reads on current completed binding facts (`bind_ready` plus revision fact).
- Add regressions for identity-only members, stale previous bindings, invoke blocking, and backend contract admission.

## Verification
- `pnpm --dir apps/aevatar-console-web test --runInBand src/pages/team-member-invoke/index.test.tsx src/pages/team-member-workflow-studio/index.test.tsx`
- `pnpm --dir apps/aevatar-console-web tsc`
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/workflow_binding_boundary_guard.sh`
- `git diff --check`

## Not run
- `dotnet test ...` because `dotnet` is not available in the local PATH (`zsh:1: command not found: dotnet`).