### PR TITLE
Fix workflow studio header actions

### DIFF
--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -694,18 +694,30 @@ const enUSMessages = {
   'teamMemberWorkflowStudio.header.addNode': 'Add node',
   'teamMemberWorkflowStudio.header.back': 'Back',
   'teamMemberWorkflowStudio.header.currentTeam': 'Current team',
+  'teamMemberWorkflowStudio.header.confirmDeleteConnection':
+    'Delete the selected connection? This cannot be undone.',
+  'teamMemberWorkflowStudio.header.confirmDeleteNode':
+    'Delete the selected node? This cannot be undone.',
   'teamMemberWorkflowStudio.header.deleteConnection': 'Delete connection',
   'teamMemberWorkflowStudio.header.deleteNode': 'Delete node',
+  'teamMemberWorkflowStudio.header.deleteSelectedConnection':
+    'Delete selected connection',
+  'teamMemberWorkflowStudio.header.deleteSelectedNode': 'Delete selected node',
   'teamMemberWorkflowStudio.header.editWorkflowName': 'Edit workflow name',
   'teamMemberWorkflowStudio.header.identityAria': 'Workflow identity',
   'teamMemberWorkflowStudio.header.inputSet': 'input set',
+  'teamMemberWorkflowStudio.header.more': 'More',
+  'teamMemberWorkflowStudio.header.moreActions': 'More workflow actions',
   'teamMemberWorkflowStudio.header.nodeActionsAria':
     'Workflow draft and node actions',
   'teamMemberWorkflowStudio.header.pasteYaml': 'Paste YAML',
   'teamMemberWorkflowStudio.header.primaryActionsAria':
     'Workflow primary actions',
   'teamMemberWorkflowStudio.header.prepareDraftRun': 'Prepare draft run',
+  'teamMemberWorkflowStudio.header.publish': 'Publish',
   'teamMemberWorkflowStudio.header.runMessage': 'Run message',
+  'teamMemberWorkflowStudio.header.refreshPublishStatus': 'Refresh status',
+  'teamMemberWorkflowStudio.header.run': 'Run',
   'teamMemberWorkflowStudio.header.runActiveMember': 'Run draft',
   'teamMemberWorkflowStudio.header.runDraft': 'Run draft',
   'teamMemberWorkflowStudio.header.save': 'Save',
@@ -718,6 +730,7 @@ const enUSMessages = {
   'teamMemberWorkflowStudio.header.publish.error': 'Error',
   'teamMemberWorkflowStudio.header.publish.published': 'Published',
   'teamMemberWorkflowStudio.header.publish.publishing': 'Publishing',
+  'teamMemberWorkflowStudio.header.publish.publishingStatus': 'Publishing',
   'teamMemberWorkflowStudio.header.publishMember': 'Publish member workflow',
   'teamMemberWorkflowStudio.header.publishMemberShort': 'Publish member',
   'teamMemberWorkflowStudio.header.teamBreadcrumb': 'Team',
@@ -727,6 +740,10 @@ const enUSMessages = {
     'Load the workflow draft before viewing YAML.',
   'teamMemberWorkflowStudio.header.viewsAria': 'Workflow views',
   'teamMemberWorkflowStudio.header.workflowTitleAria': 'Workflow title',
+  'teamMemberWorkflowStudio.header.yaml': 'YAML',
+  'teamMemberWorkflowStudio.header.yamlActions': 'YAML',
+  'teamMemberWorkflowStudio.header.yamlActionsTitle':
+    'View or import workflow YAML',
   'teamMemberWorkflowStudio.nodeDetail.advancedRawConfiguration':
     'Advanced raw configuration',
   'teamMemberWorkflowStudio.nodeDetail.advancedRawConfigurationDescription':

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -653,18 +653,30 @@ const zhCNMessages = {
   'teamMemberWorkflowStudio.header.addNode': '添加节点',
   'teamMemberWorkflowStudio.header.back': '返回',
   'teamMemberWorkflowStudio.header.currentTeam': '当前团队',
+  'teamMemberWorkflowStudio.header.confirmDeleteConnection':
+    '确定删除当前选中的连接吗？此操作不可撤销。',
+  'teamMemberWorkflowStudio.header.confirmDeleteNode':
+    '确定删除当前选中的节点吗？此操作不可撤销。',
   'teamMemberWorkflowStudio.header.deleteConnection': '删除连接',
   'teamMemberWorkflowStudio.header.deleteNode': '删除节点',
+  'teamMemberWorkflowStudio.header.deleteSelectedConnection':
+    '删除选中的连接',
+  'teamMemberWorkflowStudio.header.deleteSelectedNode': '删除选中的节点',
   'teamMemberWorkflowStudio.header.editWorkflowName': '编辑 Workflow 名称',
   'teamMemberWorkflowStudio.header.identityAria': 'Workflow 身份信息',
   'teamMemberWorkflowStudio.header.inputSet': '已设置输入',
+  'teamMemberWorkflowStudio.header.more': '更多',
+  'teamMemberWorkflowStudio.header.moreActions': '更多 Workflow 操作',
   'teamMemberWorkflowStudio.header.nodeActionsAria':
     'Workflow 草稿和节点操作',
   'teamMemberWorkflowStudio.header.pasteYaml': '粘贴 YAML',
   'teamMemberWorkflowStudio.header.primaryActionsAria':
     'Workflow 主操作',
   'teamMemberWorkflowStudio.header.prepareDraftRun': '准备草稿运行',
+  'teamMemberWorkflowStudio.header.publish': '发布',
   'teamMemberWorkflowStudio.header.runMessage': '运行消息',
+  'teamMemberWorkflowStudio.header.refreshPublishStatus': '刷新状态',
+  'teamMemberWorkflowStudio.header.run': '运行',
   'teamMemberWorkflowStudio.header.runActiveMember': '运行草稿',
   'teamMemberWorkflowStudio.header.runDraft': '运行草稿',
   'teamMemberWorkflowStudio.header.save': '保存',
@@ -677,6 +689,7 @@ const zhCNMessages = {
   'teamMemberWorkflowStudio.header.publish.error': '错误',
   'teamMemberWorkflowStudio.header.publish.published': '已发布',
   'teamMemberWorkflowStudio.header.publish.publishing': '发布中',
+  'teamMemberWorkflowStudio.header.publish.publishingStatus': '发布中',
   'teamMemberWorkflowStudio.header.publishMember': '发布成员 Workflow',
   'teamMemberWorkflowStudio.header.publishMemberShort': '发布成员',
   'teamMemberWorkflowStudio.header.teamBreadcrumb': '团队',
@@ -686,6 +699,10 @@ const zhCNMessages = {
     '加载 Workflow 草稿后才能查看 YAML。',
   'teamMemberWorkflowStudio.header.viewsAria': 'Workflow 视图',
   'teamMemberWorkflowStudio.header.workflowTitleAria': 'Workflow 标题',
+  'teamMemberWorkflowStudio.header.yaml': 'YAML',
+  'teamMemberWorkflowStudio.header.yamlActions': 'YAML',
+  'teamMemberWorkflowStudio.header.yamlActionsTitle':
+    '查看或导入 Workflow YAML',
   'teamMemberWorkflowStudio.nodeDetail.advancedRawConfiguration':
     '高级原始配置',
   'teamMemberWorkflowStudio.nodeDetail.advancedRawConfigurationDescription':

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioHeader.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioHeader.tsx
@@ -3,23 +3,21 @@ import {
   CloudUploadOutlined,
   CodeOutlined,
   DeleteOutlined,
+  DownOutlined,
   EditOutlined,
   FileTextOutlined,
+  MoreOutlined,
   PlayCircleOutlined,
   PlusOutlined,
+  ReloadOutlined,
   SaveOutlined,
 } from "@ant-design/icons";
-import {
-  Breadcrumb,
-  Button,
-  Input,
-  Space,
-  Tag,
-  Tooltip,
-} from "antd";
-import type { InputRef } from "antd";
+import { Breadcrumb, Button, Dropdown, Input, Tag, Tooltip } from "antd";
+import type { InputRef, MenuProps } from "antd";
 import React from "react";
 import { t } from "@/shared/i18n/messages";
+
+type WorkflowHeaderMenuItem = NonNullable<MenuProps["items"]>[number];
 
 type WorkflowStudioHeaderProps = {
   readonly memberPublished: boolean;
@@ -28,12 +26,15 @@ type WorkflowStudioHeaderProps = {
   readonly publishPending: boolean;
   readonly publishPlaceholderReason?: string;
   readonly publishTone: "default" | "processing" | "success" | "warning" | "error";
+  readonly refreshPublishStatusPending: boolean;
+  readonly showRefreshPublishStatus: boolean;
   readonly canOpenDraftRunPanel: boolean;
   readonly canSave: boolean;
   readonly canViewYaml: boolean;
   readonly dirty: boolean;
   readonly activeMemberRunPlaceholderReason?: string;
   readonly onPublishMember: () => void;
+  readonly onRefreshPublishStatus: () => void;
   readonly onAddNode: () => void;
   readonly onDeleteConnection: () => void;
   readonly onDeleteNode: () => void;
@@ -56,6 +57,188 @@ type WorkflowStudioHeaderProps = {
   readonly workflowTitle: string;
 };
 
+const workflowStudioHeaderCss = `
+.workflow-studio-header {
+  background: #ffffff;
+  border-bottom: 1px solid #e5e7eb;
+  display: block;
+  flex: 0 0 auto;
+  padding: 10px 20px;
+}
+
+.workflow-studio-header__row {
+  align-items: center;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  min-width: 0;
+}
+
+.workflow-studio-header__identity {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.workflow-studio-header__breadcrumb {
+  flex: 0 1 auto;
+  max-width: clamp(120px, 22vw, 280px);
+  min-width: 72px;
+  overflow: hidden;
+}
+
+.workflow-studio-header__breadcrumb .ant-breadcrumb {
+  min-width: 0;
+  white-space: nowrap;
+}
+
+.workflow-studio-header__breadcrumb .ant-breadcrumb ol {
+  flex-wrap: nowrap;
+  min-width: 0;
+}
+
+.workflow-studio-header__breadcrumb .ant-breadcrumb li {
+  min-width: 0;
+}
+
+.workflow-studio-header__breadcrumb-link {
+  color: #4b5563;
+  cursor: pointer;
+  display: inline-block;
+  max-width: 140px;
+  overflow: hidden;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  vertical-align: bottom;
+  white-space: nowrap;
+}
+
+.workflow-studio-header__breadcrumb-link--muted {
+  color: #6b7280;
+}
+
+.workflow-studio-header__title-shell {
+  align-items: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  display: inline-flex;
+  flex: 1 1 220px;
+  gap: 2px;
+  max-width: 460px;
+  min-width: 96px;
+  padding: 0 2px;
+}
+
+.workflow-studio-header__title-shell--focused {
+  background: #f9fafb;
+  border-color: #93c5fd;
+}
+
+.workflow-studio-header__title-input {
+  min-width: 0;
+}
+
+.workflow-studio-header__title-input input {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workflow-studio-header__status {
+  align-items: center;
+  display: inline-flex;
+  flex: 0 0 auto;
+  margin-inline-end: 0;
+}
+
+.workflow-studio-header__actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 6px;
+  justify-content: flex-end;
+  min-width: max-content;
+  white-space: nowrap;
+}
+
+.workflow-studio-header__actions .ant-btn {
+  flex: 0 0 auto;
+}
+
+.workflow-studio-header__primary-button {
+  min-width: 72px;
+}
+
+.workflow-studio-header__status-button {
+  min-width: 88px;
+}
+
+.workflow-studio-header__compact-button {
+  min-width: 68px;
+}
+
+.workflow-studio-header__icon-button {
+  align-items: center;
+  display: inline-flex;
+  flex: 0 0 auto;
+  height: 30px;
+  justify-content: center;
+  width: 30px;
+}
+
+@media (max-width: 1080px) {
+  .workflow-studio-header__breadcrumb {
+    max-width: 180px;
+  }
+
+  .workflow-studio-header__title-shell {
+    max-width: 360px;
+  }
+
+  .workflow-studio-header__action-label--secondary {
+    display: none;
+  }
+
+  .workflow-studio-header__compact-button {
+    min-width: 34px;
+    padding-inline: 8px;
+  }
+}
+
+@media (max-width: 760px) {
+  .workflow-studio-header {
+    padding-inline: 12px;
+  }
+
+  .workflow-studio-header__row {
+    gap: 10px;
+  }
+
+  .workflow-studio-header__breadcrumb {
+    display: none;
+  }
+
+  .workflow-studio-header__title-shell {
+    max-width: none;
+  }
+
+  .workflow-studio-header__action-label {
+    display: none;
+  }
+
+  .workflow-studio-header__primary-button,
+  .workflow-studio-header__status-button,
+  .workflow-studio-header__compact-button {
+    min-width: 34px;
+    padding-inline: 8px;
+  }
+}
+`;
+
 function formatPublishStatusLabel(input: {
   readonly checked: boolean;
   readonly pending: boolean;
@@ -70,7 +253,7 @@ function formatPublishStatusLabel(input: {
   }
 
   if (input.tone === "processing") {
-    return t("teamMemberWorkflowStudio.header.publish.binding", "Binding");
+    return t("teamMemberWorkflowStudio.header.publish.publishingStatus", "Publishing");
   }
 
   return input.checked
@@ -109,10 +292,6 @@ const HeaderIdentity: React.FC<HeaderIdentityProps> = ({
 }) => {
   const titleInputRef = React.useRef<InputRef>(null);
   const [titleFocused, setTitleFocused] = React.useState(false);
-  const workflowTitleInputWidth = Math.min(
-    300,
-    Math.max(80, workflowTitle.trim().length * 15 + 12),
-  );
 
   return (
     <section
@@ -120,60 +299,105 @@ const HeaderIdentity: React.FC<HeaderIdentityProps> = ({
         "teamMemberWorkflowStudio.header.identityAria",
         "Workflow identity",
       )}
+      className="workflow-studio-header__identity"
       data-testid="workflow-header-identity"
-      style={{
-        display: "grid",
-        gap: 8,
-        minWidth: 0,
-      }}
     >
-      <Breadcrumb
-        items={[
-          {
-            title: (
-              <a
-                href={teamsHref}
-                onClick={(event) => {
-                  event.preventDefault();
-                  onNavigateToTeams();
-                }}
-                style={{
-                  color: "#6b7280",
-                  cursor: "pointer",
-                  textDecoration: "none",
-                }}
-              >
-                {t("teamMemberWorkflowStudio.header.teamBreadcrumb", "Team")}
-              </a>
-            ),
-          },
-          {
-            title: (
-              <a
-                href={teamHref}
-                onClick={(event) => {
-                  event.preventDefault();
-                  onNavigateToTeam();
-                }}
-                style={{
-                  color: "#374151",
-                  cursor: "pointer",
-                  textDecoration: "none",
-                }}
-              >
-                {teamName ||
-                  t("teamMemberWorkflowStudio.header.currentTeam", "Current team")}
-              </a>
-            ),
-          },
-        ]}
-      />
-      <Space size={10} style={{ minWidth: 0 }} wrap>
-        <Tooltip title={t("teamMemberWorkflowStudio.header.back", "Back")}>
+      <Tooltip title={t("teamMemberWorkflowStudio.header.back", "Back")}>
+        <Button
+          aria-label={t("teamMemberWorkflowStudio.header.back", "Back")}
+          className="workflow-studio-header__icon-button"
+          icon={<ArrowLeftOutlined />}
+          onClick={onNavigateBack}
+          size="small"
+          style={{
+            borderColor: "#d1d5db",
+            color: "#4b5563",
+          }}
+        />
+      </Tooltip>
+      <div className="workflow-studio-header__breadcrumb">
+        <Breadcrumb
+          items={[
+            {
+              title: (
+                <a
+                  className="workflow-studio-header__breadcrumb-link workflow-studio-header__breadcrumb-link--muted"
+                  href={teamsHref}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    onNavigateToTeams();
+                  }}
+                >
+                  {t("teamMemberWorkflowStudio.header.teamBreadcrumb", "Team")}
+                </a>
+              ),
+            },
+            {
+              title: (
+                <a
+                  className="workflow-studio-header__breadcrumb-link"
+                  href={teamHref}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    onNavigateToTeam();
+                  }}
+                >
+                  {teamName ||
+                    t("teamMemberWorkflowStudio.header.currentTeam", "Current team")}
+                </a>
+              ),
+            },
+          ]}
+        />
+      </div>
+      <div
+        className={[
+          "workflow-studio-header__title-shell",
+          titleFocused ? "workflow-studio-header__title-shell--focused" : "",
+        ]
+          .filter(Boolean)
+          .join(" ")}
+      >
+        <Input
+          aria-label={t(
+            "teamMemberWorkflowStudio.header.workflowTitleAria",
+            "Workflow title",
+          )}
+          className="workflow-studio-header__title-input"
+          onBlur={() => setTitleFocused(false)}
+          onChange={(event) => onTitleChange(event.target.value)}
+          onFocus={() => setTitleFocused(true)}
+          ref={titleInputRef}
+          style={{
+            background: "transparent",
+            color: "#111827",
+            fontSize: 20,
+            fontWeight: 700,
+            height: 34,
+            lineHeight: "28px",
+            padding: 0,
+            width: "100%",
+          }}
+          title={t(
+            "teamMemberWorkflowStudio.header.editWorkflowName",
+            "Edit workflow name",
+          )}
+          value={workflowTitle}
+          variant="borderless"
+        />
+        <Tooltip
+          title={t(
+            "teamMemberWorkflowStudio.header.editWorkflowName",
+            "Edit workflow name",
+          )}
+        >
           <Button
-            aria-label={t("teamMemberWorkflowStudio.header.back", "Back")}
-            icon={<ArrowLeftOutlined />}
-            onClick={onNavigateBack}
+            aria-label={t(
+              "teamMemberWorkflowStudio.header.editWorkflowName",
+              "Edit workflow name",
+            )}
+            icon={<EditOutlined />}
+            onClick={() => titleInputRef.current?.focus()}
             size="small"
             style={{
               alignItems: "center",
@@ -181,269 +405,173 @@ const HeaderIdentity: React.FC<HeaderIdentityProps> = ({
               color: "#4b5563",
               display: "inline-flex",
               flex: "0 0 auto",
-              height: 30,
+              height: 28,
               justifyContent: "center",
-              width: 30,
+              width: 28,
             }}
           />
         </Tooltip>
-        <div
-          style={{
-            alignItems: "center",
-            background: titleFocused ? "#f9fafb" : "transparent",
-            border: titleFocused
-              ? "1px solid #93c5fd"
-              : "1px solid transparent",
-            borderRadius: 6,
-            display: "inline-flex",
-            gap: 2,
-            maxWidth: "100%",
-            padding: "0 2px",
-          }}
-        >
-          <Input
-            aria-label={t(
-              "teamMemberWorkflowStudio.header.workflowTitleAria",
-              "Workflow title",
-            )}
-            onBlur={() => setTitleFocused(false)}
-            onChange={(event) => onTitleChange(event.target.value)}
-            onFocus={() => setTitleFocused(true)}
-            ref={titleInputRef}
-            style={{
-              background: "transparent",
-              color: "#111827",
-              fontSize: 22,
-              fontWeight: 700,
-              height: 38,
-              lineHeight: "30px",
-              padding: 0,
-              width: workflowTitleInputWidth,
-            }}
-            title={t(
-              "teamMemberWorkflowStudio.header.editWorkflowName",
-              "Edit workflow name",
-            )}
-            value={workflowTitle}
-            variant="borderless"
-          />
-          <Tooltip
-            title={t(
-              "teamMemberWorkflowStudio.header.editWorkflowName",
-              "Edit workflow name",
-            )}
-          >
-            <Button
-              aria-label={t(
-                "teamMemberWorkflowStudio.header.editWorkflowName",
-                "Edit workflow name",
-              )}
-              icon={<EditOutlined />}
-              onClick={() => titleInputRef.current?.focus()}
-              size="small"
-              style={{
-                alignItems: "center",
-                borderColor: "#d1d5db",
-                color: "#4b5563",
-                display: "inline-flex",
-                flex: "0 0 auto",
-                height: 28,
-                justifyContent: "center",
-                width: 28,
-              }}
-            />
-          </Tooltip>
-        </div>
-        <Tag
-          color={publishStatusColor === "default" ? "default" : publishStatusColor}
-          style={{
-            alignItems: "center",
-            display: "inline-flex",
-            marginInlineEnd: 0,
-          }}
-          title={publishStatusTitle}
-        >
-          {publishStatusLabel}
+      </div>
+      <Tag
+        className="workflow-studio-header__status"
+        color={publishStatusColor === "default" ? "default" : publishStatusColor}
+        title={publishStatusTitle}
+      >
+        {publishStatusLabel}
+      </Tag>
+      {dirty ? (
+        <Tag className="workflow-studio-header__status" color="gold">
+          {t(
+            "teamMemberWorkflowStudio.header.unsavedChanges",
+            "Unsaved changes",
+          )}
         </Tag>
-        {dirty ? (
-          <Tag color="gold">
-            {t(
-              "teamMemberWorkflowStudio.header.unsavedChanges",
-              "Unsaved changes",
-            )}
-          </Tag>
-        ) : null}
-      </Space>
+      ) : null}
     </section>
   );
 };
 
-type HeaderPrimaryActionsProps = {
+type HeaderActionsProps = {
   readonly activeMemberRunPlaceholderReason?: string;
   readonly canOpenDraftRunPanel: boolean;
+  readonly canSave: boolean;
   readonly canViewYaml: boolean;
   readonly onAddNode: () => void;
+  readonly onDeleteConnection: () => void;
+  readonly onDeleteNode: () => void;
   readonly onOpenDraftRunPanel: () => void;
   readonly onPasteYamlClick: () => void;
   readonly onPublishMember: () => void;
+  readonly onRefreshPublishStatus: () => void;
+  readonly onSave: () => void;
   readonly onViewYaml: () => void;
   readonly pasteYamlPending: boolean;
   readonly publishDisabled: boolean;
   readonly publishPending: boolean;
   readonly publishPlaceholderReason?: string;
-  readonly showPublishButton: boolean;
+  readonly refreshPublishStatusPending: boolean;
+  readonly savePending: boolean;
+  readonly savePlaceholderReason?: string;
+  readonly selectedEdgeId: string;
+  readonly selectedNodeId: string;
+  readonly showPublishAction: boolean;
+  readonly showRefreshPublishStatus: boolean;
 };
 
-const HeaderPrimaryActions: React.FC<HeaderPrimaryActionsProps> = ({
+const HeaderActions: React.FC<HeaderActionsProps> = ({
   activeMemberRunPlaceholderReason,
   canOpenDraftRunPanel,
+  canSave,
   canViewYaml,
   onAddNode,
+  onDeleteConnection,
+  onDeleteNode,
   onOpenDraftRunPanel,
   onPasteYamlClick,
   onPublishMember,
+  onRefreshPublishStatus,
+  onSave,
   onViewYaml,
   pasteYamlPending,
   publishDisabled,
   publishPending,
   publishPlaceholderReason,
-  showPublishButton,
-}) => (
-  <section
-    aria-label={t(
-      "teamMemberWorkflowStudio.header.primaryActionsAria",
-      "Workflow primary actions",
-    )}
-    data-testid="workflow-header-primary-actions"
-    style={{
-      alignItems: "center",
-      display: "flex",
-      flexWrap: "wrap",
-      gap: 8,
-      justifyContent: "flex-end",
-      minWidth: 0,
-    }}
-  >
-    {showPublishButton ? (
-      <Button
-        disabled={publishDisabled}
-        icon={<CloudUploadOutlined />}
-        loading={publishPending}
-        onClick={onPublishMember}
-        size="small"
-        title={
-          publishDisabled
-            ? publishPlaceholderReason
-            : t(
-                "teamMemberWorkflowStudio.header.publishMember",
-                "Publish member workflow",
-              )
-        }
-      >
-        {t("teamMemberWorkflowStudio.header.publishMemberShort", "Publish member")}
-      </Button>
-    ) : null}
-    <Button
-      disabled={!canOpenDraftRunPanel}
-      icon={<PlayCircleOutlined />}
-      onClick={onOpenDraftRunPanel}
-      size="small"
-      title={
-        canOpenDraftRunPanel
-          ? t(
-              "teamMemberWorkflowStudio.header.prepareDraftRun",
-              "Prepare draft run",
-            )
-          : activeMemberRunPlaceholderReason
-      }
-    >
-      {t(
-        "teamMemberWorkflowStudio.header.runDraft",
-        "Run draft",
-      )}
-    </Button>
-    <Button
-      icon={<FileTextOutlined />}
-      loading={pasteYamlPending}
-      onClick={onPasteYamlClick}
-      size="small"
-    >
-      {t("teamMemberWorkflowStudio.header.pasteYaml", "Paste YAML")}
-    </Button>
-    <Button
-      disabled={!canViewYaml}
-      icon={<CodeOutlined />}
-      onClick={onViewYaml}
-      size="small"
-      title={
-        canViewYaml
-          ? t("teamMemberWorkflowStudio.header.viewYaml", "View YAML")
-          : t(
-              "teamMemberWorkflowStudio.header.viewYamlUnavailable",
-              "Load the workflow draft before viewing YAML.",
-            )
-      }
-    >
-      {t("teamMemberWorkflowStudio.header.viewYaml", "View YAML")}
-    </Button>
-    <Button icon={<PlusOutlined />} onClick={onAddNode} size="small">
-      {t("teamMemberWorkflowStudio.header.addNode", "Add node")}
-    </Button>
-  </section>
-);
-
-type HeaderNodeActionsProps = {
-  readonly canSave: boolean;
-  readonly onDeleteConnection: () => void;
-  readonly onDeleteNode: () => void;
-  readonly onSave: () => void;
-  readonly savePending: boolean;
-  readonly savePlaceholderReason?: string;
-  readonly selectedEdgeId: string;
-  readonly selectedNodeId: string;
-};
-
-const HeaderNodeActions: React.FC<HeaderNodeActionsProps> = ({
-  canSave,
-  onDeleteConnection,
-  onDeleteNode,
-  onSave,
+  refreshPublishStatusPending,
   savePending,
   savePlaceholderReason,
   selectedEdgeId,
   selectedNodeId,
+  showPublishAction,
+  showRefreshPublishStatus,
 }) => {
   const hasSelectedConnection = Boolean(selectedEdgeId);
   const hasSelectedNode = Boolean(selectedNodeId);
-  const deleteLabel = hasSelectedConnection
-    ? t("teamMemberWorkflowStudio.header.deleteConnection", "Delete connection")
-    : t("teamMemberWorkflowStudio.header.deleteNode", "Delete node");
+  const showStatusAction = showPublishAction || showRefreshPublishStatus;
+  const deleteSelectionLabel = hasSelectedConnection
+    ? t(
+        "teamMemberWorkflowStudio.header.deleteSelectedConnection",
+        "Delete selected connection",
+      )
+    : t(
+        "teamMemberWorkflowStudio.header.deleteSelectedNode",
+        "Delete selected node",
+      );
+  const yamlMenuItems: WorkflowHeaderMenuItem[] = [
+    {
+      disabled: !canViewYaml,
+      icon: <CodeOutlined />,
+      key: "view-yaml",
+      label: t("teamMemberWorkflowStudio.header.viewYaml", "View YAML"),
+      title: canViewYaml
+        ? undefined
+        : t(
+            "teamMemberWorkflowStudio.header.viewYamlUnavailable",
+            "Load the workflow draft before viewing YAML.",
+          ),
+    },
+    {
+      disabled: pasteYamlPending,
+      icon: <FileTextOutlined />,
+      key: "paste-yaml",
+      label: t("teamMemberWorkflowStudio.header.pasteYaml", "Paste YAML"),
+    },
+  ];
+  const moreMenuItems: WorkflowHeaderMenuItem[] = [
+    hasSelectedConnection || hasSelectedNode
+      ? {
+          danger: true,
+          icon: <DeleteOutlined />,
+          key: hasSelectedConnection ? "delete-connection" : "delete-node",
+          label: deleteSelectionLabel,
+        }
+      : null,
+  ].filter(Boolean) as WorkflowHeaderMenuItem[];
+  const moreMenuHasActions = Boolean(moreMenuItems.length);
 
   return (
     <section
       aria-label={t(
-        "teamMemberWorkflowStudio.header.nodeActionsAria",
-        "Workflow draft and node actions",
+        "teamMemberWorkflowStudio.header.primaryActionsAria",
+        "Workflow primary actions",
       )}
-      data-testid="workflow-header-node-actions"
-      style={{
-        alignItems: "center",
-        display: "flex",
-        flexWrap: "wrap",
-        gap: 8,
-        justifyContent: "flex-end",
-        minWidth: 0,
-      }}
+      className="workflow-studio-header__actions"
+      data-nowrap="true"
+      data-testid="workflow-header-primary-actions"
     >
       <Button
-        disabled={!hasSelectedConnection && !hasSelectedNode}
-        icon={<DeleteOutlined />}
-        onClick={hasSelectedConnection ? onDeleteConnection : onDeleteNode}
+        aria-label={t("teamMemberWorkflowStudio.header.run", "Run")}
+        className="workflow-studio-header__compact-button"
+        disabled={!canOpenDraftRunPanel}
+        icon={<PlayCircleOutlined />}
+        onClick={onOpenDraftRunPanel}
         size="small"
+        title={
+          canOpenDraftRunPanel
+            ? t(
+                "teamMemberWorkflowStudio.header.prepareDraftRun",
+                "Prepare draft run",
+              )
+            : activeMemberRunPlaceholderReason
+        }
       >
-        {deleteLabel}
+        <span className="workflow-studio-header__action-label">
+          {t("teamMemberWorkflowStudio.header.run", "Run")}
+        </span>
       </Button>
       <Button
+        aria-label={t("teamMemberWorkflowStudio.header.addNode", "Add node")}
+        className="workflow-studio-header__compact-button"
+        icon={<PlusOutlined />}
+        onClick={onAddNode}
+        size="small"
+      >
+        <span className="workflow-studio-header__action-label workflow-studio-header__action-label--secondary">
+          {t("teamMemberWorkflowStudio.header.addNode", "Add node")}
+        </span>
+      </Button>
+      <Button
+        aria-label={t("teamMemberWorkflowStudio.header.save", "Save")}
+        className="workflow-studio-header__primary-button"
         disabled={!canSave}
         icon={<SaveOutlined />}
         loading={savePending}
@@ -451,13 +579,151 @@ const HeaderNodeActions: React.FC<HeaderNodeActionsProps> = ({
         size="small"
         title={
           canSave
-            ? t("teamMemberWorkflowStudio.header.saveDraft", "Save draft")
+            ? t(
+                "teamMemberWorkflowStudio.header.saveDraft",
+                "Save draft",
+              )
             : savePlaceholderReason
         }
-        type="primary"
+        type={canSave ? "primary" : "default"}
       >
-        {t("teamMemberWorkflowStudio.header.save", "Save")}
+        <span className="workflow-studio-header__action-label">
+          {t("teamMemberWorkflowStudio.header.save", "Save")}
+        </span>
       </Button>
+      {showStatusAction ? (
+        showPublishAction ? (
+          <Button
+            aria-label={t("teamMemberWorkflowStudio.header.publish", "Publish")}
+            className="workflow-studio-header__status-button"
+            disabled={publishDisabled}
+            icon={<CloudUploadOutlined />}
+            loading={publishPending}
+            onClick={onPublishMember}
+            size="small"
+            title={
+              publishDisabled
+                ? publishPlaceholderReason
+                : t(
+                    "teamMemberWorkflowStudio.header.publishMember",
+                    "Publish member workflow",
+                  )
+            }
+          >
+            <span className="workflow-studio-header__action-label">
+              {t("teamMemberWorkflowStudio.header.publish", "Publish")}
+            </span>
+          </Button>
+        ) : (
+          <Button
+            aria-label={t(
+              "teamMemberWorkflowStudio.header.refreshPublishStatus",
+              "Refresh status",
+            )}
+            className="workflow-studio-header__status-button"
+            disabled={refreshPublishStatusPending}
+            icon={<ReloadOutlined />}
+            loading={refreshPublishStatusPending}
+            onClick={onRefreshPublishStatus}
+            size="small"
+            title={t(
+              "teamMemberWorkflowStudio.header.refreshPublishStatus",
+              "Refresh status",
+            )}
+          >
+            <span className="workflow-studio-header__action-label">
+              {t(
+                "teamMemberWorkflowStudio.header.refreshPublishStatus",
+                "Refresh status",
+              )}
+            </span>
+          </Button>
+        )
+      ) : null}
+      <Dropdown
+        menu={{
+          items: yamlMenuItems,
+          onClick: ({ key }) => {
+            if (key === "view-yaml" && canViewYaml) {
+              onViewYaml();
+              return;
+            }
+
+            if (key === "paste-yaml" && !pasteYamlPending) {
+              onPasteYamlClick();
+            }
+          },
+        }}
+        placement="bottomRight"
+        trigger={["click"]}
+      >
+        <Button
+          aria-label={t("teamMemberWorkflowStudio.header.yamlActions", "YAML")}
+          className="workflow-studio-header__compact-button"
+          icon={<FileTextOutlined />}
+          loading={pasteYamlPending}
+          size="small"
+          title={t(
+            "teamMemberWorkflowStudio.header.yamlActionsTitle",
+            "View or import workflow YAML",
+          )}
+        >
+          <span className="workflow-studio-header__action-label workflow-studio-header__action-label--secondary">
+            {t("teamMemberWorkflowStudio.header.yaml", "YAML")}
+          </span>
+          <DownOutlined style={{ fontSize: 10 }} />
+        </Button>
+      </Dropdown>
+      {moreMenuHasActions ? (
+        <Dropdown
+          menu={{
+            items: moreMenuItems,
+            onClick: ({ key }) => {
+              if (key === "delete-node") {
+                const confirmed =
+                  typeof window === "undefined" ||
+                  window.confirm(
+                    t(
+                      "teamMemberWorkflowStudio.header.confirmDeleteNode",
+                      "Delete the selected node? This cannot be undone.",
+                    ),
+                  );
+                if (confirmed) {
+                  onDeleteNode();
+                }
+                return;
+              }
+
+              if (key === "delete-connection") {
+                const confirmed =
+                  typeof window === "undefined" ||
+                  window.confirm(
+                    t(
+                      "teamMemberWorkflowStudio.header.confirmDeleteConnection",
+                      "Delete the selected connection? This cannot be undone.",
+                    ),
+                  );
+                if (confirmed) {
+                  onDeleteConnection();
+                }
+              }
+            },
+          }}
+          placement="bottomRight"
+          trigger={["click"]}
+        >
+          <Button
+            aria-label={t(
+              "teamMemberWorkflowStudio.header.moreActions",
+              "More workflow actions",
+            )}
+            className="workflow-studio-header__icon-button"
+            icon={<MoreOutlined />}
+            size="small"
+            title={t("teamMemberWorkflowStudio.header.more", "More")}
+          />
+        </Dropdown>
+      ) : null}
     </section>
   );
 };
@@ -469,12 +735,15 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
   publishPending,
   publishPlaceholderReason,
   publishTone,
+  refreshPublishStatusPending,
+  showRefreshPublishStatus,
   canOpenDraftRunPanel,
   canSave,
   canViewYaml,
   dirty,
   activeMemberRunPlaceholderReason,
   onPublishMember,
+  onRefreshPublishStatus,
   onAddNode,
   onDeleteConnection,
   onDeleteNode,
@@ -504,34 +773,21 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
   const publishStatusTitle = [publishNotice, publishPlaceholderReason]
     .filter(Boolean)
     .join(" · ");
-  const showPublishButton =
-    publishPending ||
-    publishTone === "processing" ||
-    publishTone === "error" ||
-    dirty ||
-    !memberPublished ||
-    !publishDisabled;
+  const showPublishAction =
+    !showRefreshPublishStatus &&
+    (publishPending ||
+      publishTone === "processing" ||
+      publishTone === "error" ||
+      dirty ||
+      !memberPublished ||
+      !publishDisabled);
+
   return (
-    <header
-      style={{
-        background: "#ffffff",
-        borderBottom: "1px solid #e5e7eb",
-        display: "grid",
-        flex: "0 0 auto",
-        gap: 12,
-        padding: "14px 22px 12px",
-      }}
-    >
+    <header className="workflow-studio-header">
+      <style>{workflowStudioHeaderCss}</style>
       <div
+        className="workflow-studio-header__row"
         data-testid="workflow-header-main-row"
-        style={{
-          alignItems: "center",
-          display: "flex",
-          flexWrap: "wrap",
-          gap: "12px 24px",
-          justifyContent: "space-between",
-          minWidth: 0,
-        }}
       >
         <HeaderIdentity
           dirty={dirty}
@@ -547,44 +803,31 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
           teamsHref={teamsHref}
           workflowTitle={workflowTitle}
         />
-        <HeaderPrimaryActions
+        <HeaderActions
           activeMemberRunPlaceholderReason={activeMemberRunPlaceholderReason}
           canOpenDraftRunPanel={canOpenDraftRunPanel}
+          canSave={canSave}
           canViewYaml={canViewYaml}
           onAddNode={onAddNode}
+          onDeleteConnection={onDeleteConnection}
+          onDeleteNode={onDeleteNode}
           onOpenDraftRunPanel={onOpenDraftRunPanel}
           onPasteYamlClick={onOpenPasteYaml}
           onPublishMember={onPublishMember}
+          onRefreshPublishStatus={onRefreshPublishStatus}
+          onSave={onSave}
           onViewYaml={onViewYaml}
           pasteYamlPending={pasteYamlPending}
           publishDisabled={publishDisabled}
           publishPending={publishPending}
           publishPlaceholderReason={publishPlaceholderReason}
-          showPublishButton={showPublishButton}
-        />
-      </div>
-      <div
-        data-testid="workflow-header-context-row"
-        style={{
-          alignItems: "center",
-          borderTop: "1px solid #f3f4f6",
-          display: "flex",
-          flexWrap: "wrap",
-          gap: "10px 16px",
-          justifyContent: "flex-end",
-          minWidth: 0,
-          paddingTop: 10,
-        }}
-      >
-        <HeaderNodeActions
-          canSave={canSave}
-          onDeleteConnection={onDeleteConnection}
-          onDeleteNode={onDeleteNode}
-          onSave={onSave}
+          refreshPublishStatusPending={refreshPublishStatusPending}
           savePending={savePending}
           savePlaceholderReason={savePlaceholderReason}
           selectedEdgeId={selectedEdgeId}
           selectedNodeId={selectedNodeId}
+          showPublishAction={showPublishAction}
+          showRefreshPublishStatus={showRefreshPublishStatus}
         />
       </div>
     </header>

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -134,6 +134,9 @@ type TeamMemberWorkflowStudioState = {
   readonly publishPending: boolean;
   readonly publishPlaceholderReason: string;
   readonly publishTone: WorkflowPublishTone;
+  readonly refreshPublishStatus: () => void;
+  readonly refreshPublishStatusPending: boolean;
+  readonly showRefreshPublishStatus: boolean;
   readonly backHref: string;
   readonly navigateToTeam: () => void;
   readonly navigateToTeams: () => void;
@@ -1632,6 +1635,26 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       : memberIsPublished
         ? "Published member workflow is serviceable."
         : "Draft member workflow is not published to the active member yet.");
+  const showRefreshPublishStatus = Boolean(
+    route.mode === "existing" &&
+      route.scopeId &&
+      route.memberId &&
+      publishBindingStillInProgress &&
+      !publishPending,
+  );
+  const refreshPublishStatusPending = Boolean(
+    memberQuery.isFetching || workflowQuery.isFetching,
+  );
+  const refreshPublishStatus = React.useCallback(() => {
+    if (route.mode !== "existing" || !route.scopeId || !route.memberId) {
+      return;
+    }
+
+    void memberQuery.refetch();
+    if (routeDraftWorkflowId) {
+      void workflowQuery.refetch();
+    }
+  }, [memberQuery, route.memberId, route.mode, route.scopeId, routeDraftWorkflowId, workflowQuery]);
   const executionStatus = activeMemberRunMutation.isPending
     ? "running"
     : resolveWorkflowExecutionStatus(executionDetail);
@@ -2008,6 +2031,9 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     publishPending,
     publishPlaceholderReason,
     publishTone,
+    refreshPublishStatus,
+    refreshPublishStatusPending,
+    showRefreshPublishStatus,
     backHref,
     navigateToTeam: () => {
       if (!dirty || confirmDiscardUnsavedChanges()) {
@@ -2067,7 +2093,6 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
         runMessage: trimOptional(executionRunMessage),
         title: activeMemberTitle,
       });
-      setDraftRunPanelOpen(false);
     },
     activeMemberRunPending: activeMemberRunMutation.isPending,
     activeMemberRunPlaceholderReason,

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -400,6 +400,37 @@ async function flushAsyncWork() {
   }
 }
 
+function openYamlActionsMenu() {
+  fireEvent.click(screen.getByRole("button", { name: "YAML" }));
+}
+
+function clickYamlAction(name: "Paste YAML" | "View YAML") {
+  openYamlActionsMenu();
+  fireEvent.click(screen.getByRole("menuitem", { name }));
+}
+
+function openMoreActionsMenu() {
+  fireEvent.click(screen.getByRole("button", { name: "More workflow actions" }));
+}
+
+function closeOpenMenu() {
+  fireEvent.keyDown(document, { key: "Escape" });
+  fireEvent.click(document.body);
+}
+
+function clickMoreAction(
+  name:
+    | "Delete selected connection"
+    | "Delete selected node",
+) {
+  openMoreActionsMenu();
+  fireEvent.click(screen.getByRole("menuitem", { name }));
+}
+
+function clickPublishAction() {
+  fireEvent.click(screen.getByRole("button", { name: "Publish" }));
+}
+
 function createPointerDragEvent(
   type: "pointerdown" | "pointermove" | "pointerup",
   clientX: number,
@@ -475,7 +506,7 @@ function mockNewWorkflowMemberCreateFixtures() {
 
 describe("TeamMemberWorkflowStudioPage", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
     window.history.replaceState({}, "", "/");
     mockTeam();
     mockSerializeYaml();
@@ -660,7 +691,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
     expect(screen.getByRole("button", { name: "node:step:llm_step" })).toBeTruthy();
     expect(screen.getByText("Unsaved changes")).toBeTruthy();
@@ -1086,7 +1117,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
 
     expect(await screen.findByDisplayValue("Workflow Alpha")).toBeTruthy();
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
     expect(screen.getByRole("button", { name: "node:step:triage" })).toBeTruthy();
     expect(studioApi.getMember).toHaveBeenCalledWith("scope-1", "member-alpha");
@@ -1149,9 +1180,9 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
-    fireEvent.click(screen.getByRole("button", { name: "View YAML" }));
+    clickYamlAction("View YAML");
 
     const yamlView = await screen.findByLabelText("Current workflow YAML");
     await waitFor(() => {
@@ -1184,7 +1215,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     await waitFor(() => {
       expect(screen.queryByLabelText("Workflow YAML panel")).toBeNull();
     });
-    fireEvent.click(screen.getByRole("button", { name: "View YAML" }));
+    clickYamlAction("View YAML");
     await screen.findByLabelText("Current workflow YAML");
     expect(studioApi.serializeYaml).toHaveBeenCalledTimes(1);
   });
@@ -1239,9 +1270,9 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
-    fireEvent.click(screen.getByRole("button", { name: "View YAML" }));
+    clickYamlAction("View YAML");
 
     expect(await screen.findByText("Serialization failed")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
@@ -1354,7 +1385,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
     fireEvent.click(screen.getByRole("button", { name: "Back" }));
 
@@ -1412,7 +1443,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
 
     expect(await screen.findByDisplayValue("Untitled member")).toBeTruthy();
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
     expect(studioApi.getMember).toHaveBeenCalledWith(
       "scope-1",
@@ -1531,7 +1562,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
 
     expect(await screen.findByDisplayValue("Untitled member")).toBeTruthy();
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
     expect(screen.getByRole("button", { name: "node:step:llm_step" })).toBeTruthy();
     expect(
@@ -1702,7 +1733,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
       expect(saveButton).toBeDisabled();
       expect(screen.getByDisplayValue("Untitled member 9")).toBeTruthy();
     });
-    fireEvent.click(screen.getByRole("button", { name: "Paste YAML" }));
+    clickYamlAction("Paste YAML");
     fireEvent.change(await screen.findByLabelText("Workflow YAML"), {
       target: {
         value: "name: Untitled member 9\nsteps:\n  - id: triage\n    type: llm_call\n",
@@ -1711,7 +1742,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Import" }));
 
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
       expect(saveButton).toBeEnabled();
     });
     fireEvent.click(saveButton);
@@ -1795,7 +1826,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         "untitled-member-9",
         "scope-1",
       );
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
       expect(saveButton).toBeDisabled();
     });
     fireEvent.click(screen.getByRole("button", { name: "Add node" }));
@@ -2091,7 +2122,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
     fireEvent.click(screen.getByRole("button", { name: "Add node" }));
     fireEvent.click(await screen.findByRole("button", { name: "Insert Guard node" }));
@@ -2099,7 +2130,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
       expect(screen.getByText("nodes:2")).toBeTruthy();
       expect(screen.getByText("Unsaved changes")).toBeTruthy();
     });
-    fireEvent.click(screen.getByRole("button", { name: "View YAML" }));
+    clickYamlAction("View YAML");
 
     const yamlView = await screen.findByLabelText("Current workflow YAML");
     await waitFor(() => {
@@ -2167,14 +2198,25 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
     fireEvent.click(screen.getByRole("button", { name: "node:step:triage" }));
-    expect(screen.getByRole("button", { name: "Delete node" })).toBeEnabled();
-    fireEvent.click(screen.getByRole("button", { name: "Delete node" }));
+    openMoreActionsMenu();
+    expect(
+      screen.getByRole("menuitem", { name: "Delete selected node" }),
+    ).toBeTruthy();
+    closeOpenMenu();
+    const confirmSpy = jest
+      .spyOn(window, "confirm")
+      .mockImplementation(() => true);
+    clickMoreAction("Delete selected node");
     await waitFor(() => {
       expect(screen.getByText("nodes:0")).toBeTruthy();
     });
+    expect(confirmSpy).toHaveBeenCalledWith(
+      "Delete the selected node? This cannot be undone.",
+    );
+    confirmSpy.mockRestore();
 
     fireEvent.click(screen.getByRole("button", { name: "Add node" }));
     fireEvent.click(await screen.findByRole("button", { name: "Insert LLM call node" }));
@@ -2280,16 +2322,27 @@ describe("TeamMemberWorkflowStudioPage", () => {
     fireEvent.click(
       screen.getByRole("button", { name: "edge:edge:triage:publish:linear" }),
     );
+    openMoreActionsMenu();
     expect(
-      screen.getByRole("button", { name: "Delete connection" }),
-    ).toBeEnabled();
-    fireEvent.click(screen.getByRole("button", { name: "Delete connection" }));
+      screen.getByRole("menuitem", { name: "Delete selected connection" }),
+    ).toBeTruthy();
+    closeOpenMenu();
+    const confirmSpy = jest
+      .spyOn(window, "confirm")
+      .mockImplementation(() => true);
+    clickMoreAction("Delete selected connection");
     expect(screen.queryByRole("button", {
       name: "edge:edge:triage:publish:linear",
     })).toBeNull();
     expect(screen.getByText("nodes:2")).toBeTruthy();
     expect(screen.queryByTestId("workflow-node-inspector")).toBeNull();
-    expect(screen.getByRole("button", { name: "Delete node" })).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: "More workflow actions" }),
+    ).toBeNull();
+    expect(confirmSpy).toHaveBeenCalledWith(
+      "Delete the selected connection? This cannot be undone.",
+    );
+    confirmSpy.mockRestore();
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
@@ -2391,7 +2444,11 @@ describe("TeamMemberWorkflowStudioPage", () => {
         name: "edge:edge:guard:branch_target:branch:next",
       }),
     );
-    fireEvent.click(screen.getByRole("button", { name: "Delete connection" }));
+    const confirmSpy = jest
+      .spyOn(window, "confirm")
+      .mockImplementation(() => true);
+    clickMoreAction("Delete selected connection");
+    confirmSpy.mockRestore();
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
@@ -2457,7 +2514,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
     fireEvent.click(screen.getByRole("button", { name: "node:step:triage" }));
     const inspector = screen.getByLabelText("Node inspector");
@@ -2763,7 +2820,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
     fireEvent.click(screen.getByRole("button", { name: "node:step:triage" }));
     expect(screen.queryByLabelText("Raw node configuration")).toBeNull();
@@ -2832,7 +2889,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
     fireEvent.click(
       screen.getByRole("button", { name: "node:step:wait_for_signal" }),
@@ -2925,7 +2982,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
     fireEvent.click(screen.getByRole("button", { name: "node:step:cache_response" }));
 
@@ -3027,7 +3084,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
     fireEvent.click(screen.getByRole("button", { name: "node:step:custom_step" }));
 
@@ -3134,7 +3191,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
     fireEvent.click(screen.getByRole("button", { name: "node:step:custom_step" }));
     fireEvent.click(screen.getByText("Advanced raw configuration"));
@@ -3226,7 +3283,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
     fireEvent.click(screen.getByRole("button", { name: "node:step:custom_step" }));
     fireEvent.change(screen.getByLabelText("Payload"), {
@@ -3297,10 +3354,10 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     const runDraftButton = await screen.findByRole("button", {
-      name: "Run draft",
+      name: "Run",
     });
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
     expect(screen.getByLabelText("Workflow title")).toHaveAttribute(
       "title",
@@ -3310,13 +3367,17 @@ describe("TeamMemberWorkflowStudioPage", () => {
       screen.getByRole("button", { name: "Edit workflow name" }),
     );
     expect(screen.getByLabelText("Workflow title")).toHaveFocus();
+    fireEvent.blur(screen.getByLabelText("Workflow title"));
     const headerIdentity = screen.getByTestId("workflow-header-identity");
     const headerPrimaryActions = screen.getByTestId(
       "workflow-header-primary-actions",
     );
-    const headerNodeActions = screen.getByTestId(
-      "workflow-header-node-actions",
-    );
+    const headerMainRow = screen.getByTestId("workflow-header-main-row");
+    expect(headerMainRow).toHaveClass("workflow-studio-header__row");
+    expect(headerPrimaryActions).toHaveClass("workflow-studio-header__actions");
+    expect(headerPrimaryActions).toHaveAttribute("data-nowrap", "true");
+    expect(screen.queryByTestId("workflow-header-context-row")).toBeNull();
+    expect(screen.queryByTestId("workflow-header-node-actions")).toBeNull();
     expect(within(headerIdentity).getByRole("link", { name: "Team" })).toHaveAttribute(
       "href",
       "/scopes",
@@ -3335,33 +3396,49 @@ describe("TeamMemberWorkflowStudioPage", () => {
       within(headerIdentity).getByRole("button", { name: "Edit workflow name" }),
     ).toBeTruthy();
     expect(
-      within(headerPrimaryActions).queryByRole("button", {
-        name: "Publish member",
-      }),
-    ).toBeNull();
-    expect(
       within(headerPrimaryActions).getByRole("button", {
-        name: "Run draft",
+        name: "Run",
       }),
     ).toBeTruthy();
     expect(
       within(headerPrimaryActions).getByRole("button", { name: "Add node" }),
     ).toBeTruthy();
     expect(
-      within(headerPrimaryActions).getByRole("button", { name: "Paste YAML" }),
-    ).toBeTruthy();
-    expect(screen.queryByText("Runs")).toBeNull();
-    expect(
-      within(headerNodeActions).getByRole("button", { name: "Delete node" }),
+      within(headerPrimaryActions).getByRole("button", { name: "Save" }),
     ).toBeTruthy();
     expect(
-      within(headerNodeActions).getByRole("button", { name: "Save" }),
+      within(headerPrimaryActions).queryByRole("button", { name: "Publish" }),
+    ).toBeNull();
+    expect(
+      within(headerPrimaryActions).queryByRole("button", {
+        name: "Refresh status",
+      }),
+    ).toBeNull();
+    expect(
+      within(headerPrimaryActions).getByRole("button", { name: "YAML" }),
     ).toBeTruthy();
     expect(
-      within(headerNodeActions).queryByRole("button", {
+      within(headerPrimaryActions).queryByRole("button", {
         name: "More workflow actions",
       }),
     ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Paste YAML" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "View YAML" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Delete node" })).toBeNull();
+    openYamlActionsMenu();
+    expect(
+      screen.getByRole("menuitem", { name: "View YAML" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("menuitem", { name: "Paste YAML" }),
+    ).toBeTruthy();
+    closeOpenMenu();
+    expect(screen.queryByRole("menuitem", { name: "Publish member" })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: "Refresh status" })).toBeNull();
+    expect(
+      screen.queryByRole("menuitem", { name: "Delete selected node" }),
+    ).toBeNull();
+    expect(screen.queryByText("Runs")).toBeNull();
     expect(screen.queryByText("Set as Team entry")).toBeNull();
     expect(screen.queryByTestId("member-run-summary")).toBeNull();
     expect(screen.queryByText("Workflow member")).toBeNull();
@@ -3399,7 +3476,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     );
     const resultPanel = await screen.findByTestId("member-run-result-panel");
     const consolePanel = screen.getByLabelText("Draft run console");
-    expect(screen.queryByLabelText("Draft run panel")).toBeNull();
+    expect(screen.getByLabelText("Draft run panel")).toBeTruthy();
     const consoleResizeHandle = screen.getByRole("separator", {
       name: "Resize run console",
     });
@@ -3481,6 +3558,109 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
   });
 
+  it("keeps the header action bar stable while save, YAML, and contextual delete states change", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/member-alpha/workflow?workflowId=workflow-alpha",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "workflow-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: "rev-1",
+        lifecycleStage: "bind_ready",
+        memberId: "member-alpha",
+        publishedServiceId: "service-alpha",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "workflow-alpha.yaml",
+      filePath: "scope://scope-1/workflow-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "workflow-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: mockWorkflowDocument,
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
+    });
+
+    const headerMainRow = screen.getByTestId("workflow-header-main-row");
+    const headerPrimaryActions = screen.getByTestId(
+      "workflow-header-primary-actions",
+    );
+    const readActionButtonNames = () =>
+      within(headerPrimaryActions)
+        .getAllByRole("button")
+        .map((button) => button.getAttribute("aria-label") || button.textContent);
+
+    expect(headerMainRow).toHaveClass("workflow-studio-header__row");
+    expect(headerPrimaryActions).toHaveAttribute("data-nowrap", "true");
+    expect(screen.queryByTestId("workflow-header-context-row")).toBeNull();
+    expect(screen.queryByTestId("workflow-header-node-actions")).toBeNull();
+    expect(readActionButtonNames()).toEqual([
+      "Run",
+      "Add node",
+      "Save",
+      "YAML",
+    ]);
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+
+    expect(
+      within(headerPrimaryActions).queryByRole("button", {
+        name: "More workflow actions",
+      }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("menuitem", { name: "Delete selected node" }),
+    ).toBeNull();
+
+    openYamlActionsMenu();
+    expect(screen.getByRole("menuitem", { name: "View YAML" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Paste YAML" })).toBeTruthy();
+    closeOpenMenu();
+
+    fireEvent.change(screen.getByLabelText("Workflow title"), {
+      target: {
+        value:
+          "A very long workflow title that should truncate instead of pushing actions down",
+      },
+    });
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+    expect(readActionButtonNames()).toEqual([
+      "Run",
+      "Add node",
+      "Save",
+      "Publish",
+      "YAML",
+    ]);
+
+    fireEvent.click(screen.getByRole("button", { name: "node:step:triage" }));
+    openMoreActionsMenu();
+    expect(
+      screen.getByRole("menuitem", { name: "Delete selected node" }),
+    ).toBeTruthy();
+  });
+
   it("renders draft run log cards as SSE frames arrive", async () => {
     window.history.replaceState(
       {},
@@ -3529,7 +3709,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     const runDraftButton = await screen.findByRole("button", {
-      name: "Run draft",
+      name: "Run",
     });
     await waitFor(() => {
       expect(runDraftButton).toBeEnabled();
@@ -3666,7 +3846,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     const runDraftButton = await screen.findByRole("button", {
-      name: "Run draft",
+      name: "Run",
     });
     await waitFor(() => {
       expect(runDraftButton).toBeEnabled();
@@ -3689,7 +3869,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(screen.queryByTestId("member-run-summary")).toBeNull();
     expect(resultPanel).not.toHaveTextContent("Member run");
     expect(runtimeRunsApi.streamChat).not.toHaveBeenCalled();
-    expect(screen.queryByLabelText("Draft run panel")).toBeNull();
+    expect(screen.getByLabelText("Draft run panel")).toBeTruthy();
   });
 
   it("runs draft workflow members before they are published", async () => {
@@ -3741,10 +3921,10 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     const runDraftButton = await screen.findByRole("button", {
-      name: "Run draft",
+      name: "Run",
     });
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
     await waitFor(() => {
       expect(runDraftButton).toBeEnabled();
@@ -3754,7 +3934,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     fireEvent.click(
       within(draftRunPanel).getByRole("button", { name: "Start draft run" }),
     );
-    expect(screen.queryByLabelText("Draft run panel")).toBeNull();
+    expect(screen.getByLabelText("Draft run panel")).toBeTruthy();
 
     await waitFor(() => {
       expect(runtimeRunsApi.streamDraftRun).toHaveBeenCalledWith(
@@ -3846,7 +4026,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     await waitFor(() => {
       expect(screen.getByText("nodes:0")).toBeTruthy();
     });
-    fireEvent.click(screen.getByRole("button", { name: "Paste YAML" }));
+    clickYamlAction("Paste YAML");
     expect(screen.getByLabelText("Paste workflow YAML panel")).toBeTruthy();
     fireEvent.change(await screen.findByLabelText("Workflow YAML"), {
       target: {
@@ -3942,7 +4122,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     await waitFor(() => {
       expect(screen.getByText("nodes:0")).toBeTruthy();
     });
-    fireEvent.click(screen.getByRole("button", { name: "Paste YAML" }));
+    clickYamlAction("Paste YAML");
     expect(screen.getByLabelText("Paste workflow YAML panel")).toBeTruthy();
     fireEvent.change(await screen.findByLabelText("Workflow YAML"), {
       target: {
@@ -3956,7 +4136,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
       expect(screen.getByText("nodes:2")).toBeTruthy();
     });
     expect(screen.getByText("Unsaved changes")).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "View YAML" }));
+    clickYamlAction("View YAML");
 
     const yamlView = await screen.findByLabelText("Current workflow YAML");
     await waitFor(() => {
@@ -4027,9 +4207,9 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
-    fireEvent.click(screen.getByRole("button", { name: "Paste YAML" }));
+    clickYamlAction("Paste YAML");
     expect(screen.getByLabelText("Paste workflow YAML panel")).toBeTruthy();
     fireEvent.change(await screen.findByLabelText("Workflow YAML"), {
       target: { value: "not: valid" },
@@ -4045,7 +4225,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(screen.getByLabelText("Paste workflow YAML panel")).toBeTruthy();
     expect(screen.getByText("Invalid workflow YAML")).toBeTruthy();
     expect(await screen.findByLabelText("Workflow YAML")).toHaveValue("not: valid");
-    expect(screen.getByText("nodes:1")).toBeTruthy();
+    expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     expect(screen.getByRole("button", { name: "node:step:triage" })).toBeTruthy();
     expect(screen.queryByText("Unsaved changes")).toBeNull();
     expect(studioApi.serializeYaml).not.toHaveBeenCalled();
@@ -4106,10 +4286,10 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     const runDraftButton = await screen.findByRole("button", {
-      name: "Run draft",
+      name: "Run",
     });
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
     expect(studioApi.getWorkflow).toHaveBeenCalledWith(
       "workflow-alpha",
@@ -4263,13 +4443,13 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
     fireEvent.change(screen.getByLabelText("Workflow title"), {
       target: { value: "Workflow Alpha Published" },
     });
     expect(screen.queryByRole("switch")).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Publish member" }));
+    clickPublishAction();
 
     await waitFor(() => {
       expect(studioApi.saveWorkflow).toHaveBeenCalledWith(
@@ -4342,7 +4522,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
     fireEvent.change(screen.getByLabelText("Workflow title"), {
       target: { value: "Workflow Alpha Published" },
@@ -4353,8 +4533,8 @@ describe("TeamMemberWorkflowStudioPage", () => {
     });
 
     expect(await screen.findByText("Instruction is required.")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Publish member" })).toBeDisabled();
-    fireEvent.click(screen.getByRole("button", { name: "Publish member" }));
+    expect(screen.getByRole("button", { name: "Publish" })).toBeDisabled();
+    clickPublishAction();
 
     await flushAsyncWork();
     expect(studioApi.saveWorkflow).not.toHaveBeenCalled();
@@ -4418,9 +4598,9 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
-    fireEvent.click(screen.getByRole("button", { name: "Publish member" }));
+    clickPublishAction();
 
     await waitFor(() => {
       expect(screen.getByText("Error")).toBeTruthy();
@@ -4493,9 +4673,9 @@ describe("TeamMemberWorkflowStudioPage", () => {
       renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
       await waitFor(() => {
-        expect(screen.getByText("nodes:1")).toBeTruthy();
+        expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
       });
-      fireEvent.click(screen.getByRole("button", { name: "Publish member" }));
+      clickPublishAction();
 
       await waitFor(() => {
         expect(screen.getByText("Publishing")).toBeTruthy();
@@ -4508,15 +4688,19 @@ describe("TeamMemberWorkflowStudioPage", () => {
       }
 
       await waitFor(() => {
-        expect(screen.queryByText("Publishing")).toBeNull();
-        expect(screen.getByText("Binding")).toBeTruthy();
+        expect(screen.getByText("Publishing")).toBeTruthy();
       });
-      expect(screen.getByRole("button", { name: "Publish member" })).toBeDisabled();
       expect(
         screen.getAllByTitle(/Publish was accepted and binding is still in progress/).length,
       ).toBeGreaterThan(0);
+      expect(screen.getByRole("button", { name: "Refresh status" })).toBeEnabled();
+      expect(screen.queryByRole("button", { name: "Publish" })).toBeNull();
       expect(studioApi.getMemberBindingRun).toHaveBeenCalledTimes(8);
     } finally {
+      await act(async () => {
+        jest.runOnlyPendingTimers();
+        await flushAsyncWork();
+      });
       jest.useRealTimers();
     }
   });
@@ -4595,19 +4779,20 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
       expect(screen.getByText("Published")).toBeTruthy();
       expect(
-        screen.queryByRole("button", { name: "Publish member" }),
+        screen.queryByRole("button", { name: "Publish" }),
       ).toBeNull();
+      expect(screen.queryByRole("button", { name: "Refresh status" })).toBeNull();
     });
     expect(screen.getByDisplayValue("Workflow Alpha")).toBeTruthy();
     fireEvent.change(screen.getByLabelText("Workflow title"), {
       target: { value: "Workflow Alpha v2" },
     });
 
-    const publishButton = await screen.findByRole("button", {
-      name: "Publish member",
+    const publishButton = screen.getByRole("button", {
+      name: "Publish",
     });
     await waitFor(() => {
       expect(publishButton).toBeEnabled();
@@ -4685,12 +4870,9 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
     expect(studioApi.setTeamEntryMember).not.toHaveBeenCalled();
-    expect(
-      screen.queryByRole("button", { name: "More workflow actions" }),
-    ).toBeNull();
     expect(screen.queryByText("Set as Team entry")).toBeNull();
     expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
   });
@@ -4737,7 +4919,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     await waitFor(() => {
-      expect(screen.getByText("nodes:1")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
     expect(screen.queryByText("Runs")).toBeNull();
     expect(screen.queryByLabelText("Member runs")).toBeNull();
@@ -4770,6 +4952,20 @@ describe("TeamMemberWorkflowStudioPage", () => {
         teamId: "t-alpha",
         updatedAt: "2026-06-08T00:00:00Z",
       },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "workflow-alpha.yaml",
+      filePath: "scope://scope-1/workflow-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "workflow-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: mockWorkflowDocument,
+      updatedAtUtc: "2026-06-08T00:00:00Z",
     });
 
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
@@ -234,12 +234,15 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
         publishPending={studio.publishPending}
         publishPlaceholderReason={studio.publishPlaceholderReason}
         publishTone={studio.publishTone}
+        refreshPublishStatusPending={studio.refreshPublishStatusPending}
+        showRefreshPublishStatus={studio.showRefreshPublishStatus}
         canOpenDraftRunPanel={studio.canOpenDraftRunPanel}
         canSave={studio.canSave}
         canViewYaml={studio.canViewYaml}
         dirty={studio.dirty}
         activeMemberRunPlaceholderReason={studio.activeMemberRunPlaceholderReason}
         onPublishMember={studio.publishMember}
+        onRefreshPublishStatus={studio.refreshPublishStatus}
         onAddNode={studio.openNodeLibrary}
         onDeleteConnection={studio.deleteSelectedConnection}
         onDeleteNode={studio.deleteSelectedNode}


### PR DESCRIPTION
## Problem

The workflow studio detail/editor header had two separate action rows and wrapping action containers. Primary actions, YAML actions, save, refresh, and delete competed for space, which made buttons jump between the title row and a second row as state, title length, or viewport width changed.

## Solution

- Consolidate the header into a single stable row with a left identity area and right action cluster.
- Keep primary actions visible as `Run | Add node | Save`, with Save disabled until there are unsaved changes.
- Merge YAML actions into one dropdown containing `View YAML` and `Paste YAML`.
- Move refresh and publish into the More menu.
- Show delete only as a contextual More-menu action when a node or connection is selected, with confirmation preserved.
- Add nowrap/ellipsis behavior so the title compresses instead of forcing actions onto another row.

## Impacted Paths

- `apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioHeader.tsx`
- `apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts`
- `apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx`
- `apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx`

## Verification

- `pnpm --dir apps/aevatar-console-web jest src/pages/team-member-workflow-studio/index.test.tsx --runInBand`
- `pnpm --dir apps/aevatar-console-web tsc --noEmit --pretty false`
- `bash tools/ci/test_stability_guards.sh`
- `git diff --check`
