### PR TITLE
Fix member binding completion semantics

### DIFF
--- a/apps/aevatar-console-web/src/pages/team-member-invoke/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-invoke/index.test.tsx
@@ -330,4 +330,29 @@ describe("TeamMemberInvokePage", () => {
       "/scopes/scope-1/teams/team-1/members/member-alpha/workflow",
     );
   });
+
+  it("does not treat a member service identity as a completed binding", async () => {
+    (studioApi.getMember as jest.Mock).mockResolvedValueOnce(
+      createWorkflowMember({
+        lastBoundRevisionId: null,
+        lifecycleStage: "bind_ready",
+        publishedServiceId: "svc-alpha",
+      }),
+    );
+    (studioApi.getMemberBinding as jest.Mock).mockResolvedValueOnce({
+      currentBindingRun: null,
+      lastBinding: null,
+    });
+    (scopeRuntimeApi.listServices as jest.Mock).mockResolvedValueOnce([
+      createService(),
+    ]);
+
+    renderWithQueryClient(React.createElement(TeamMemberInvokePage));
+
+    expect(
+      await screen.findByText("This workflow member is not bound yet."),
+    ).toBeTruthy();
+    expect(screen.queryByTestId("member-invoke-panel")).toBeNull();
+    expect(scopeRuntimeApi.getServiceRevisions).not.toHaveBeenCalled();
+  });
 });

--- a/apps/aevatar-console-web/src/pages/team-member-invoke/index.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-invoke/index.tsx
@@ -20,6 +20,8 @@ import {
 import { studioApi } from "@/shared/studio/api";
 import {
   normalizeStudioMemberBindingImplementationKind,
+  normalizeStudioMemberLifecycleStage,
+  type StudioMemberBindingContract,
 } from "@/shared/studio/models";
 import {
   AevatarInspectorEmpty,
@@ -38,6 +40,13 @@ type TeamMemberInvokeRouteState = {
 
 function trimOptional(value: string | null | undefined): string {
   return value?.trim() ?? "";
+}
+
+function getCompletedBindingRevisionId(
+  lastBinding: StudioMemberBindingContract | null | undefined,
+  lastBoundRevisionId: string | null | undefined,
+): string {
+  return trimOptional(lastBinding?.revisionId) || trimOptional(lastBoundRevisionId);
 }
 
 function decodePathSegment(value: string): string {
@@ -122,18 +131,28 @@ const TeamMemberInvokePage: React.FC = () => {
   const memberKind = normalizeStudioMemberBindingImplementationKind(
     memberSummary?.implementationKind,
   );
+  const memberLifecycleStage = normalizeStudioMemberLifecycleStage(
+    memberSummary?.lifecycleStage,
+  );
   const lastBinding = bindingQuery.data?.lastBinding ?? memberQuery.data?.lastBinding ?? null;
-  const publishedServiceId =
-    trimOptional(lastBinding?.publishedServiceId) ||
-    trimOptional(memberSummary?.publishedServiceId);
+  const completedBindingRevisionId = getCompletedBindingRevisionId(
+    lastBinding,
+    memberSummary?.lastBoundRevisionId,
+  );
+  const memberBindingCompleted =
+    memberLifecycleStage === "bind_ready" && Boolean(completedBindingRevisionId);
+  const boundPublishedServiceId = memberBindingCompleted
+    ? trimOptional(lastBinding?.publishedServiceId) ||
+      trimOptional(memberSummary?.publishedServiceId)
+    : "";
   const selectedService = React.useMemo(
     () =>
-      publishedServiceId
+      boundPublishedServiceId
         ? (servicesQuery.data ?? []).find(
-            (service) => trimOptional(service.serviceId) === publishedServiceId,
+            (service) => trimOptional(service.serviceId) === boundPublishedServiceId,
           ) ?? null
         : null,
-    [publishedServiceId, servicesQuery.data],
+    [boundPublishedServiceId, servicesQuery.data],
   );
   const invokeServices = React.useMemo(
     () =>
@@ -149,10 +168,10 @@ const TeamMemberInvokePage: React.FC = () => {
       "team-member-invoke",
       "service-revisions",
       route.scopeId,
-      publishedServiceId,
+      boundPublishedServiceId,
     ],
-    enabled: Boolean(route.scopeId && publishedServiceId),
-    queryFn: () => scopeRuntimeApi.getServiceRevisions(route.scopeId, publishedServiceId),
+    enabled: Boolean(route.scopeId && boundPublishedServiceId),
+    queryFn: () => scopeRuntimeApi.getServiceRevisions(route.scopeId, boundPublishedServiceId),
   });
   const memberRevision =
     getScopeServiceCurrentRevision(serviceRevisionQuery.data) ??
@@ -222,7 +241,7 @@ const TeamMemberInvokePage: React.FC = () => {
       };
     }
 
-    if (memberSummary && !publishedServiceId) {
+    if (memberSummary && !memberBindingCompleted) {
       return {
         description: t(
           "pages.teammemberinvoke.unbound.description",
@@ -233,7 +252,7 @@ const TeamMemberInvokePage: React.FC = () => {
       };
     }
 
-    if (memberSummary && publishedServiceId && !selectedService && !servicesQuery.isLoading) {
+    if (memberSummary && memberBindingCompleted && !selectedService && !servicesQuery.isLoading) {
       return {
         description: t(
           "pages.teammemberinvoke.service.pending.description",
@@ -259,9 +278,9 @@ const TeamMemberInvokePage: React.FC = () => {
   }, [
     invokeServices.length,
     loadError,
+    memberBindingCompleted,
     memberKind,
     memberSummary,
-    publishedServiceId,
     route.memberId,
     route.scopeId,
     route.teamId,
@@ -315,7 +334,7 @@ const TeamMemberInvokePage: React.FC = () => {
           </AevatarPanel>
         ) : (
           <StudioMemberInvokePanel
-            initialServiceId={publishedServiceId}
+            initialServiceId={boundPublishedServiceId}
             memberId={route.memberId}
             memberRevision={memberRevision}
             runtimeTarget="service"

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -35,6 +35,7 @@ import {
   STUDIO_GRAPH_CATEGORIES,
 } from "@/shared/studio/graph";
 import { isStudioApiStatus, studioApi } from "@/shared/studio/api";
+import { normalizeStudioMemberLifecycleStage } from "@/shared/studio/models";
 import type {
   StudioExecutionDetail,
   StudioExecutionFrame,
@@ -211,6 +212,41 @@ const CREATED_MEMBER_MATERIALIZATION_DELAY_MS = 450;
 
 function trimOptional(value: string | null | undefined): string {
   return value?.trim() ?? "";
+}
+
+function hasCurrentCompletedMemberBinding(
+  detail: StudioMemberDetail | null | undefined,
+): boolean {
+  if (
+    normalizeStudioMemberLifecycleStage(detail?.summary.lifecycleStage) !==
+    "bind_ready"
+  ) {
+    return false;
+  }
+
+  return Boolean(
+    trimOptional(detail?.summary.lastBoundRevisionId) ||
+      trimOptional(detail?.lastBinding?.revisionId),
+  );
+}
+
+function hasActiveMemberBindingRun(
+  detail: StudioMemberDetail | null | undefined,
+): boolean {
+  return Boolean(
+    detail?.currentBindingRun &&
+      !isTerminalBindingRun(detail.currentBindingRun),
+  );
+}
+
+function readActiveMemberBindingRunId(
+  detail: StudioMemberDetail | null | undefined,
+): string {
+  if (!hasActiveMemberBindingRun(detail)) {
+    return "";
+  }
+
+  return trimOptional(detail?.currentBindingRun?.bindingRunId);
 }
 
 function readPathSegments(): {
@@ -512,11 +548,18 @@ function isTerminalBindingRun(
   return run?.status === "succeeded" || run?.status === "failed" || run?.status === "rejected";
 }
 
+function isSameBindingRun(
+  run: StudioMemberBindingRunStatusResponse | null,
+  bindingRunId: string,
+): boolean {
+  return Boolean(run && trimOptional(run.bindingRunId) === bindingRunId);
+}
+
 function readBindingRunFailureMessage(
   run: StudioMemberBindingRunStatusResponse | null,
 ): string {
   if (!run) {
-    return "Publish binding status is still pending.";
+    return "Publish status is still pending.";
   }
 
   if (run.failure?.message) {
@@ -1446,6 +1489,23 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
         throw new Error("Resolve an existing workflow member before publishing.");
       }
 
+      const currentMember = await studioApi.getMember(route.scopeId, route.memberId);
+      queryClient.setQueryData(
+        getTeamMemberWorkflowStudioMemberQueryKey(route.scopeId, route.memberId),
+        currentMember,
+      );
+      if (hasCurrentCompletedMemberBinding(currentMember)) {
+        throw new Error(
+          "This member already has a published service. Save draft changes instead of publishing again.",
+        );
+      }
+
+      if (hasActiveMemberBindingRun(currentMember)) {
+        throw new Error(
+          "Publish is already in progress for this member. Refresh status before publishing again.",
+        );
+      }
+
       let savedDraft: SavedWorkflowDraft | null = null;
       let documentForPublish = document;
       let titleForPublish = trimOptional(title) || trimOptional(document.name);
@@ -1500,7 +1560,9 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
             throw error;
           }
         }
-        await waitForBindingRunPollTick();
+        if (attempt < MEMBER_BINDING_RUN_POLL_ATTEMPTS - 1) {
+          await waitForBindingRunPollTick();
+        }
       }
 
       if (lastRun?.status === "failed" || lastRun?.status === "rejected") {
@@ -1531,7 +1593,9 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       if (run?.status === "succeeded") {
         void message.success("Workflow member published.");
       } else {
-        void message.info("Publish was accepted and is still binding.");
+        void message.info(
+          "Publish was accepted. Studio is still waiting for published status.",
+        );
       }
     },
   });
@@ -1574,22 +1638,33 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
             ((workflowQuery.data && !linkedWorkflowMissing) ||
               canCreateUnlinkedMemberDraft),
         );
-  const memberPublishedByQuery =
-    memberQuery.data?.summary.lifecycleStage === "bind_ready" &&
-    !linkedWorkflowMissing &&
-    Boolean(workflowQuery.data);
+  const authoritativeMemberPublished = hasCurrentCompletedMemberBinding(
+    memberQuery.data,
+  );
+  const authoritativeBindingRunId = readActiveMemberBindingRunId(
+    memberQuery.data,
+  );
+  const publishBindingRunTerminal = isTerminalBindingRun(publishBindingRun);
+  const authoritativeBindingRunInProgress = Boolean(
+    authoritativeBindingRunId &&
+      (!publishBindingRunTerminal ||
+        !isSameBindingRun(publishBindingRun, authoritativeBindingRunId)),
+  );
+  const memberPublishedByQuery = authoritativeMemberPublished;
   const memberIsPublished =
     memberPublishedByQuery ||
     publishBindingRun?.status === "succeeded";
-  const publishBindingStillInProgress = Boolean(
-    !memberPublishedByQuery &&
-      publishBindingRun &&
-      publishBindingRun.status !== "succeeded" &&
-      !isTerminalBindingRun(publishBindingRun),
+  const publishStatusStillInProgress = Boolean(
+    authoritativeBindingRunInProgress ||
+      (publishBindingRun &&
+        publishBindingRun.status !== "succeeded" &&
+        !publishBindingRunTerminal),
   );
   const publishHasDraftChanges = Boolean(dirty && workflowHasSteps);
   const publishPending = publishMutation.isPending;
   const memberPublished = memberIsPublished;
+  const publishVisibleError =
+    memberIsPublished || publishStatusStillInProgress ? "" : publishError;
   const publishDisabled = Boolean(
     route.mode === "new" ||
       linkedWorkflowMissing ||
@@ -1598,8 +1673,8 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       !workflowHasSteps ||
       Boolean(selectedStepConfigurationError) ||
       publishMutation.isPending ||
-      publishBindingStillInProgress ||
-      (memberIsPublished && !publishHasDraftChanges),
+      publishStatusStillInProgress ||
+      memberIsPublished,
   );
   const publishPlaceholderReason =
     route.mode === "new"
@@ -1608,10 +1683,12 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
         ? "No stable workflow draft is linked to this member yet."
         : selectedStepConfigurationError
           ? selectedStepConfigurationError
-        : publishBindingStillInProgress
-          ? "Publish was accepted and binding is still in progress. Refresh later before publishing again."
-        : memberIsPublished && !publishHasDraftChanges
-          ? "This member workflow is already published. Edit the draft before publishing a new version."
+        : publishStatusStillInProgress
+          ? "Publish is still in progress. Use Refresh status before publishing again."
+        : memberIsPublished
+          ? publishHasDraftChanges
+            ? "This member already has a published service. Save draft changes instead of publishing again."
+            : "This member workflow is already published. Use Refresh status to check readiness."
         : !workflowQuery.data || !editableDocument
             ? "Load the workflow draft before publishing."
             : !workflowHasSteps
@@ -1620,18 +1697,24 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
                 ? "Publish saves draft changes, binds the member workflow, and observes readiness."
                 : "Publish binds the saved workflow draft to this member and observes readiness.";
   const publishTone: WorkflowPublishTone = publishError
-    ? "error"
-    : publishPending || publishBindingStillInProgress
+    ? publishVisibleError
+      ? "error"
+      : publishStatusStillInProgress
+        ? "processing"
+        : memberIsPublished
+          ? "success"
+          : "default"
+    : publishPending || publishStatusStillInProgress
       ? "processing"
       : memberIsPublished
         ? "success"
         : "default";
   const publishNotice =
-    publishError ||
+    publishVisibleError ||
     (publishPending
-      ? `Publish binding status: ${publishBindingRun?.status ?? "accepted"}.`
-      : publishBindingStillInProgress
-        ? `Publish was accepted and binding is still in progress (${publishBindingRun?.status ?? "accepted"}). Refresh later to check readiness.`
+      ? `Publish status: ${publishBindingRun?.status ?? "accepted"}.`
+      : publishStatusStillInProgress
+        ? `Publish is still in progress (${memberQuery.data?.currentBindingRun?.status ?? publishBindingRun?.status ?? "accepted"}). Use Refresh status to check readiness.`
       : memberIsPublished
         ? "Published member workflow is serviceable."
         : "Draft member workflow is not published to the active member yet.");
@@ -1639,21 +1722,62 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     route.mode === "existing" &&
       route.scopeId &&
       route.memberId &&
-      publishBindingStillInProgress &&
-      !publishPending,
+      (publishStatusStillInProgress ||
+        memberIsPublished ||
+        publishError ||
+        publishBindingRun),
   );
   const refreshPublishStatusPending = Boolean(
     memberQuery.isFetching || workflowQuery.isFetching,
   );
-  const refreshPublishStatus = React.useCallback(() => {
+  const refreshPublishStatus = React.useCallback(async () => {
     if (route.mode !== "existing" || !route.scopeId || !route.memberId) {
       return;
     }
 
-    void memberQuery.refetch();
+    const memberResult = await memberQuery.refetch();
     if (routeDraftWorkflowId) {
-      void workflowQuery.refetch();
+      await workflowQuery.refetch();
     }
+
+    const refreshedMember = memberResult.data;
+    const activeRunId = readActiveMemberBindingRunId(refreshedMember);
+    if (activeRunId) {
+      const refreshedRun = await studioApi.getMemberBindingRun(
+        route.scopeId,
+        route.memberId,
+        activeRunId,
+      );
+      setPublishBindingRun(refreshedRun);
+      if (refreshedRun.status === "failed" || refreshedRun.status === "rejected") {
+        setPublishError(readBindingRunFailureMessage(refreshedRun));
+        void message.error(readBindingRunFailureMessage(refreshedRun));
+        return;
+      }
+
+      if (refreshedRun.status === "succeeded") {
+        void message.success("Published member status refreshed.");
+        return;
+      }
+
+      void message.info("Publish is still in progress.");
+      return;
+    }
+
+    if (hasCurrentCompletedMemberBinding(refreshedMember)) {
+      setPublishBindingRun((currentRun) =>
+        currentRun && !isTerminalBindingRun(currentRun)
+          ? {
+              ...currentRun,
+              status: "succeeded",
+            }
+          : currentRun,
+      );
+      void message.success("Published member status refreshed.");
+      return;
+    }
+
+    void message.info("No published member status is visible yet.");
   }, [memberQuery, route.memberId, route.mode, route.scopeId, routeDraftWorkflowId, workflowQuery]);
   const executionStatus = activeMemberRunMutation.isPending
     ? "running"

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -249,6 +249,18 @@ function readActiveMemberBindingRunId(
   return trimOptional(detail?.currentBindingRun?.bindingRunId);
 }
 
+function readFallbackBindingRun(
+  detail: StudioMemberDetail | null | undefined,
+  bindingRunId: string,
+): StudioMemberBindingRunStatusResponse | null {
+  const currentRun = detail?.currentBindingRun ?? null;
+  if (!isSameBindingRun(currentRun, bindingRunId)) {
+    return null;
+  }
+
+  return currentRun;
+}
+
 function readPathSegments(): {
   canonicalHref: string;
   memberId: string;
@@ -1744,6 +1756,10 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     memberQuery.data,
   );
   const publishBindingRunTerminal = isTerminalBindingRun(publishBindingRun);
+  const publishBindingRunFailed = Boolean(
+    publishBindingRun?.status === "failed" ||
+      publishBindingRun?.status === "rejected",
+  );
   const authoritativeBindingRunInProgress = Boolean(
     authoritativeBindingRunId &&
       (!publishBindingRunTerminal ||
@@ -1763,7 +1779,11 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
   const publishPending = publishMutation.isPending;
   const memberPublished = memberIsPublished;
   const publishVisibleError =
-    memberIsPublished || publishStatusStillInProgress ? "" : publishError;
+    publishError &&
+    (publishBindingRunFailed ||
+      (!memberIsPublished && !publishStatusStillInProgress))
+      ? publishError
+      : "";
   const publishDisabled = Boolean(
     route.mode === "new" ||
       linkedWorkflowMissing ||
@@ -1842,11 +1862,26 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     const refreshedMember = memberResult.data;
     const activeRunId = readActiveMemberBindingRunId(refreshedMember);
     if (activeRunId) {
-      const refreshedRun = await studioApi.getMemberBindingRun(
-        route.scopeId,
-        route.memberId,
-        activeRunId,
-      );
+      let refreshedRun: StudioMemberBindingRunStatusResponse | null = null;
+      try {
+        refreshedRun = await studioApi.getMemberBindingRun(
+          route.scopeId,
+          route.memberId,
+          activeRunId,
+        );
+      } catch (error) {
+        if (!isStudioApiStatus(error, 404)) {
+          throw error;
+        }
+
+        refreshedRun = readFallbackBindingRun(refreshedMember, activeRunId);
+      }
+
+      if (!refreshedRun) {
+        void message.info("Publish status is not materialized yet. Try refreshing again.");
+        return;
+      }
+
       setPublishBindingRun(refreshedRun);
       if (refreshedRun.status === "failed" || refreshedRun.status === "rejected") {
         setPublishError(readBindingRunFailureMessage(refreshedRun));

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -1849,7 +1849,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(studioApi.saveWorkflow).toHaveBeenCalledTimes(1);
   });
 
-  it("does not show published when a refreshed saved member has no linked workflow draft", async () => {
+  it("keeps draft status when only the published service identity exists", async () => {
     window.history.replaceState(
       {},
       "",
@@ -1866,7 +1866,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         displayName: "Untitled member 8",
         implementationKind: "workflow",
         lastBoundRevisionId: null,
-        lifecycleStage: "bind_ready",
+        lifecycleStage: "created",
         memberId: "m-alpha",
         publishedServiceId: "svc-alpha",
         scopeId: "scope-1",
@@ -1888,8 +1888,118 @@ describe("TeamMemberWorkflowStudioPage", () => {
     ).not.toHaveLength(0);
     expect(screen.getByText("Draft")).toBeTruthy();
     expect(screen.queryByText("Published")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Refresh status" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Publish" })).toBeDisabled();
     expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
     expect(studioApi.getWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("shows published member status from completed binding facts even when no workflow draft is linked", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Untitled member 8",
+        implementationKind: "workflow",
+        lastBoundRevisionId: "rev-alpha",
+        lifecycleStage: "bind_ready",
+        memberId: "m-alpha",
+        publishedServiceId: "svc-alpha",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+      lastBinding: {
+        boundAt: "2026-06-08T00:00:00Z",
+        implementationKind: "workflow",
+        publishedServiceId: "svc-alpha",
+        revisionId: "rev-alpha",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockRejectedValue(
+      Object.assign(new Error("Not found"), { status: 404 }),
+    );
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    expect(await screen.findByDisplayValue("Untitled member 8")).toBeTruthy();
+    expect(
+      await screen.findAllByText(
+        "No workflow draft is linked to this member yet.",
+      ),
+    ).not.toHaveLength(0);
+    expect(screen.getByText("Published")).toBeTruthy();
+    expect(screen.queryByText("Draft")).toBeNull();
+    expect(screen.getByRole("button", { name: "Refresh status" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Publish" })).toBeNull();
+    expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.getWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("keeps draft status when the previous binding is stale for the current implementation", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow?workflowId=wf-alpha",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "wf-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: "rev-old",
+        lifecycleStage: "build_ready",
+        memberId: "m-alpha",
+        publishedServiceId: "svc-alpha",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+      lastBinding: {
+        boundAt: "2026-06-08T00:00:00Z",
+        implementationKind: "workflow",
+        publishedServiceId: "svc-alpha",
+        revisionId: "rev-old",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "wf-alpha.yaml",
+      filePath: "scope://scope-1/wf-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "wf-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: mockWorkflowDocument,
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByText("nodes:1")).toBeTruthy();
+    });
+    expect(screen.getByText("Draft")).toBeTruthy();
+    expect(screen.queryByText("Published")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Refresh status" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Publish" })).toBeEnabled();
   });
 
   it("saves existing workflow drafts without publishing, execution calls, or canvas reload", async () => {
@@ -3391,7 +3501,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(
       within(headerIdentity).getByRole("button", { name: "Back" }),
     ).toBeTruthy();
-    expect(within(headerIdentity).getByText("Published")).toBeTruthy();
+    expect(within(headerIdentity).getByText("Draft")).toBeTruthy();
     expect(
       within(headerIdentity).getByRole("button", { name: "Edit workflow name" }),
     ).toBeTruthy();
@@ -3407,11 +3517,16 @@ describe("TeamMemberWorkflowStudioPage", () => {
       within(headerPrimaryActions).getByRole("button", { name: "Save" }),
     ).toBeTruthy();
     expect(
-      within(headerPrimaryActions).queryByRole("button", { name: "Publish" }),
-    ).toBeNull();
+      within(headerPrimaryActions).getByRole("button", { name: "Publish" }),
+    ).toBeTruthy();
     expect(
       within(headerPrimaryActions).queryByRole("button", {
         name: "Refresh status",
+      }),
+    ).toBeNull();
+    expect(
+      within(headerPrimaryActions).queryByRole("button", {
+        name: "Publish member",
       }),
     ).toBeNull();
     expect(
@@ -3621,6 +3736,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
       "Run",
       "Add node",
       "Save",
+      "Refresh status",
       "YAML",
     ]);
     expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
@@ -3650,7 +3766,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
       "Run",
       "Add node",
       "Save",
-      "Publish",
+      "Refresh status",
       "YAML",
     ]);
 
@@ -4691,7 +4807,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         expect(screen.getByText("Publishing")).toBeTruthy();
       });
       expect(
-        screen.getAllByTitle(/Publish was accepted and binding is still in progress/).length,
+        screen.getAllByTitle(/Publish is still in progress/).length,
       ).toBeGreaterThan(0);
       expect(screen.getByRole("button", { name: "Refresh status" })).toBeEnabled();
       expect(screen.queryByRole("button", { name: "Publish" })).toBeNull();
@@ -4705,16 +4821,16 @@ describe("TeamMemberWorkflowStudioPage", () => {
     }
   });
 
-  it("allows publishing a new draft version for an already published workflow member", async () => {
+  it("blocks duplicate publish for an already published workflow member and refreshes status through reads", async () => {
     window.history.replaceState(
       {},
       "",
-      "/scopes/scope-1/teams/t-alpha/members/member-alpha/workflow?workflowId=workflow-alpha",
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow?workflowId=wf-alpha",
     );
     (studioApi.getMember as jest.Mock).mockResolvedValue({
       implementationRef: {
         implementationKind: "workflow",
-        workflowId: "workflow-alpha",
+        workflowId: "wf-alpha",
       },
       summary: {
         createdAt: "2026-06-08T00:00:00Z",
@@ -4723,23 +4839,29 @@ describe("TeamMemberWorkflowStudioPage", () => {
         implementationKind: "workflow",
         lastBoundRevisionId: "rev-1",
         lifecycleStage: "bind_ready",
-        memberId: "member-alpha",
-        publishedServiceId: "service-alpha",
+        memberId: "m-alpha",
+        publishedServiceId: "svc-alpha",
         scopeId: "scope-1",
         teamId: "t-alpha",
         updatedAt: "2026-06-08T00:00:00Z",
+      },
+      lastBinding: {
+        boundAt: "2026-06-08T00:00:00Z",
+        implementationKind: "workflow",
+        publishedServiceId: "svc-alpha",
+        revisionId: "rev-1",
       },
     });
     (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
-      fileName: "workflow-alpha.yaml",
-      filePath: "scope://scope-1/workflow-alpha.yaml",
+      fileName: "wf-alpha.yaml",
+      filePath: "scope://scope-1/wf-alpha.yaml",
       findings: [],
       layout: null,
       name: "Workflow Alpha",
-      workflowId: "workflow-alpha",
+      workflowId: "wf-alpha",
       yaml: "name: Workflow Alpha\nsteps: []\n",
       document: mockWorkflowDocument,
       updatedAtUtc: "2026-06-08T00:00:00Z",
@@ -4748,32 +4870,18 @@ describe("TeamMemberWorkflowStudioPage", () => {
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
-      fileName: "workflow-alpha.yaml",
-      filePath: "scope://scope-1/workflow-alpha.yaml",
+      fileName: "wf-alpha.yaml",
+      filePath: "scope://scope-1/wf-alpha.yaml",
       findings: [],
       layout: null,
       name: "Workflow Alpha v2",
-      workflowId: "workflow-alpha",
+      workflowId: "wf-alpha",
       yaml: "name: Workflow Alpha v2\nsteps: []\n",
       document: {
         ...mockWorkflowDocument,
         name: "Workflow Alpha v2",
       },
       updatedAtUtc: "2026-06-08T00:00:01Z",
-    });
-    (studioApi.bindMemberWorkflow as jest.Mock).mockResolvedValue({
-      bindingRunId: "binding-run-2",
-      memberId: "member-alpha",
-      scopeId: "scope-1",
-      status: "accepted",
-    });
-    (studioApi.getMemberBindingRun as jest.Mock).mockResolvedValue({
-      bindingRunId: "binding-run-2",
-      memberId: "member-alpha",
-      scopeId: "scope-1",
-      status: "succeeded",
-      stateVersion: 3,
-      updatedAt: "2026-06-08T00:00:02Z",
     });
 
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
@@ -4784,36 +4892,282 @@ describe("TeamMemberWorkflowStudioPage", () => {
       expect(
         screen.queryByRole("button", { name: "Publish" }),
       ).toBeNull();
-      expect(screen.queryByRole("button", { name: "Refresh status" })).toBeNull();
+      expect(screen.getByRole("button", { name: "Refresh status" })).toBeTruthy();
     });
     expect(screen.getByDisplayValue("Workflow Alpha")).toBeTruthy();
     fireEvent.change(screen.getByLabelText("Workflow title"), {
       target: { value: "Workflow Alpha v2" },
     });
 
-    const publishButton = screen.getByRole("button", {
-      name: "Publish",
+    await waitFor(() => {
+      expect(screen.getByText("Unsaved changes")).toBeTruthy();
     });
+
+    expect(screen.queryByRole("button", { name: "Publish" })).toBeNull();
+    const getMemberCallCount = (studioApi.getMember as jest.Mock).mock.calls.length;
+    fireEvent.click(screen.getByRole("button", { name: /Refresh status/ }));
+    await waitFor(() => {
+      expect(studioApi.getMember).toHaveBeenCalledTimes(getMemberCallCount + 1);
+    });
+    expect(studioApi.getMember).toHaveBeenLastCalledWith("scope-1", "m-alpha");
+    expect(studioApi.getWorkflow).toHaveBeenCalledWith("wf-alpha", "scope-1");
+    expect(studioApi.saveWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.getMemberBindingRun).not.toHaveBeenCalled();
+    expect(studioApi.setTeamEntryMember).not.toHaveBeenCalled();
+  });
+
+  it("refreshes a stale member current binding run from the binding-run read model", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow?workflowId=wf-alpha",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "wf-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: null,
+        lifecycleStage: "build_ready",
+        memberId: "m-alpha",
+        publishedServiceId: "svc-alpha",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+      currentBindingRun: {
+        bindingRunId: "binding-run-stale-member",
+        memberId: "m-alpha",
+        scopeId: "scope-1",
+        stateVersion: 1,
+        status: "accepted",
+        updatedAt: "2026-06-08T00:00:01Z",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "wf-alpha.yaml",
+      filePath: "scope://scope-1/wf-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "wf-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: mockWorkflowDocument,
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+    (studioApi.getMemberBindingRun as jest.Mock).mockResolvedValue({
+      bindingRunId: "binding-run-stale-member",
+      memberId: "m-alpha",
+      scopeId: "scope-1",
+      stateVersion: 2,
+      status: "succeeded",
+      updatedAt: "2026-06-08T00:00:10Z",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByText("Publishing")).toBeTruthy();
+    });
+
+    const refreshButton = screen.getByRole("button", { name: "Refresh status" });
+    await waitFor(() => {
+      expect(refreshButton).not.toBeDisabled();
+    });
+    fireEvent.click(refreshButton);
+
+    await waitFor(() => {
+      expect(studioApi.getMemberBindingRun).toHaveBeenCalledWith(
+        "scope-1",
+        "m-alpha",
+        "binding-run-stale-member",
+      );
+      expect(screen.getByText("Published")).toBeTruthy();
+    });
+    expect(screen.queryByText("Publishing")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Publish" })).toBeNull();
+  });
+
+  it("updates stale publish eligibility from the preflight member read before side effects", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow?workflowId=wf-alpha",
+    );
+    const initialUnpublishedMember = {
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "wf-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: null,
+        lifecycleStage: "build_ready",
+        memberId: "m-alpha",
+        publishedServiceId: "",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+    };
+    const refreshedPublishedMember = {
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "wf-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: "rev-1",
+        lifecycleStage: "bind_ready",
+        memberId: "m-alpha",
+        publishedServiceId: "svc-alpha",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:01Z",
+      },
+      lastBinding: {
+        boundAt: "2026-06-08T00:00:01Z",
+        implementationKind: "workflow",
+        publishedServiceId: "svc-alpha",
+        revisionId: "rev-1",
+      },
+    };
+    (studioApi.getMember as jest.Mock)
+      .mockResolvedValueOnce(initialUnpublishedMember)
+      .mockResolvedValueOnce(refreshedPublishedMember);
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "wf-alpha.yaml",
+      filePath: "scope://scope-1/wf-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "wf-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: mockWorkflowDocument,
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByText("nodes:1")).toBeTruthy();
+    });
+    const publishButton = screen.getByRole("button", { name: "Publish" });
     await waitFor(() => {
       expect(publishButton).toBeEnabled();
     });
     fireEvent.click(publishButton);
 
     await waitFor(() => {
-      expect(studioApi.saveWorkflow).toHaveBeenCalledWith(
-        expect.objectContaining({
-          workflowName: "Workflow Alpha v2",
-        }),
-      );
-      expect(studioApi.bindMemberWorkflow).toHaveBeenCalledWith({
-        displayName: "Workflow Alpha v2",
-        memberId: "member-alpha",
-        scopeId: "scope-1",
-        workflowId: "workflow-alpha",
-        workflowYamls: [expect.stringContaining("name: Workflow Alpha v2")],
-      });
+      expect(studioApi.getMember).toHaveBeenCalledTimes(2);
+      expect(screen.getByText("Published")).toBeTruthy();
     });
-    expect(studioApi.setTeamEntryMember).not.toHaveBeenCalled();
+    expect(studioApi.getMember).toHaveBeenLastCalledWith("scope-1", "m-alpha");
+    expect(screen.queryByText("Error")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Publish" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Refresh status" })).toBeTruthy();
+    expect(studioApi.saveWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.getMemberBindingRun).not.toHaveBeenCalled();
+  });
+
+  it("allows publishing when the member has a service identity but no completed binding fact", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow?workflowId=wf-alpha",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "wf-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: null,
+        lifecycleStage: "created",
+        memberId: "m-alpha",
+        publishedServiceId: "member-m-alpha",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+      lastBinding: null,
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "wf-alpha.yaml",
+      filePath: "scope://scope-1/wf-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "wf-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: mockWorkflowDocument,
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+    (studioApi.bindMemberWorkflow as jest.Mock).mockResolvedValue({
+      bindingRunId: "binding-run-identity-only",
+      memberId: "m-alpha",
+      scopeId: "scope-1",
+      status: "accepted",
+    });
+    (studioApi.getMemberBindingRun as jest.Mock).mockResolvedValue({
+      bindingRunId: "binding-run-identity-only",
+      memberId: "m-alpha",
+      scopeId: "scope-1",
+      status: "succeeded",
+      stateVersion: 2,
+      updatedAt: "2026-06-08T00:00:02Z",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByText("nodes:1")).toBeTruthy();
+    });
+    expect(screen.getByText("Draft")).toBeTruthy();
+    const publishButton = screen.getByRole("button", { name: "Publish" });
+    await waitFor(() => {
+      expect(publishButton).toBeEnabled();
+    });
+
+    fireEvent.click(publishButton);
+
+    await waitFor(() => {
+      expect(studioApi.bindMemberWorkflow).toHaveBeenCalledWith({
+        displayName: "Workflow Alpha",
+        memberId: "m-alpha",
+        scopeId: "scope-1",
+        workflowId: "wf-alpha",
+        workflowYamls: [expect.stringContaining("name: Workflow Alpha")],
+      });
+      expect(screen.getByText("Published")).toBeTruthy();
+    });
+    expect(studioApi.saveWorkflow).not.toHaveBeenCalled();
   });
 
   it("does not expose Team entry actions in workflow studio", async () => {

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -5043,6 +5043,107 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(studioApi.setTeamEntryMember).not.toHaveBeenCalled();
   });
 
+  it("surfaces failed republish even when an older member binding remains serviceable", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow?workflowId=wf-alpha",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "wf-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: "rev-1",
+        lifecycleStage: "bind_ready",
+        memberId: "m-alpha",
+        publishedServiceId: "svc-alpha",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+      lastBinding: {
+        boundAt: "2026-06-08T00:00:00Z",
+        implementationKind: "workflow",
+        publishedServiceId: "svc-alpha",
+        revisionId: "rev-1",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "wf-alpha.yaml",
+      filePath: "scope://scope-1/wf-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "wf-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: mockWorkflowDocument,
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+    (studioApi.saveWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "wf-alpha.yaml",
+      filePath: "scope://scope-1/wf-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha v2",
+      workflowId: "wf-alpha",
+      yaml: "name: Workflow Alpha v2\nsteps: []\n",
+      document: {
+        ...mockWorkflowDocument,
+        name: "Workflow Alpha v2",
+      },
+      updatedAtUtc: "2026-06-08T00:00:01Z",
+    });
+    (studioApi.bindMemberWorkflow as jest.Mock).mockResolvedValue({
+      bindingRunId: "binding-run-v2",
+      memberId: "m-alpha",
+      scopeId: "scope-1",
+      status: "accepted",
+    });
+    (studioApi.getMemberBindingRun as jest.Mock).mockResolvedValue({
+      bindingRunId: "binding-run-v2",
+      failure: {
+        code: "BINDING_FAILED",
+        message: "Latest workflow draft failed to bind.",
+      },
+      memberId: "m-alpha",
+      scopeId: "scope-1",
+      status: "failed",
+      stateVersion: 3,
+      updatedAt: "2026-06-08T00:00:02Z",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
+      expect(screen.getByText("Published")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByLabelText("Workflow title"), {
+      target: { value: "Workflow Alpha v2" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Publish" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Error")).toBeTruthy();
+      expect(
+        screen.getByTitle(/Latest workflow draft failed to bind/),
+      ).toBeTruthy();
+    });
+    expect(screen.queryByTitle(/Published member workflow is serviceable/)).toBeNull();
+  });
+
   it("refreshes a stale member current binding run from the binding-run read model", async () => {
     window.history.replaceState(
       {},
@@ -5121,6 +5222,86 @@ describe("TeamMemberWorkflowStudioPage", () => {
     });
     expect(screen.queryByText("Publishing")).toBeNull();
     expect(screen.queryByRole("button", { name: "Publish" })).toBeNull();
+  });
+
+  it("falls back to member current binding run when refresh read model is not materialized", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow?workflowId=wf-alpha",
+    );
+    const memberWithFallbackBindingRun = {
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "wf-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: null,
+        lifecycleStage: "build_ready",
+        memberId: "m-alpha",
+        publishedServiceId: "svc-alpha",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+      currentBindingRun: {
+        bindingRunId: "binding-run-fallback",
+        memberId: "m-alpha",
+        scopeId: "scope-1",
+        stateVersion: 1,
+        status: "accepted",
+        updatedAt: "2026-06-08T00:00:01Z",
+      },
+    };
+    (studioApi.getMember as jest.Mock).mockResolvedValue(memberWithFallbackBindingRun);
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "wf-alpha.yaml",
+      filePath: "scope://scope-1/wf-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "wf-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: mockWorkflowDocument,
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+    (studioApi.getMemberBindingRun as jest.Mock).mockRejectedValue(
+      new StudioApiError("Binding run is not materialized.", 404),
+    );
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByText("Publishing")).toBeTruthy();
+    });
+    (studioApi.getMemberBindingRun as jest.Mock).mockClear();
+
+    const refreshButton = screen.getByRole("button", { name: "Refresh status" });
+    await waitFor(() => {
+      expect(refreshButton).not.toBeDisabled();
+    });
+    fireEvent.click(refreshButton);
+
+    await waitFor(() => {
+      expect(studioApi.getMemberBindingRun).toHaveBeenCalledWith(
+        "scope-1",
+        "m-alpha",
+        "binding-run-fallback",
+      );
+      expect(screen.getByText("Publishing")).toBeTruthy();
+      expect(
+        screen.getAllByTitle(/Publish is still in progress/).length,
+      ).toBeGreaterThan(0);
+    });
+    expect(screen.getByRole("button", { name: "Refresh status" })).toBeEnabled();
+    expect(screen.queryByText("Error")).toBeNull();
   });
 
   it("updates stale publish eligibility from the preflight member read before side effects", async () => {


### PR DESCRIPTION
## Summary
- Treat `publishedServiceId` as member-owned service identity, not a completed binding fact.
- Gate Workflow Studio published state, Team member invoke, Team entry resolution, and member contract/revision reads on current completed binding facts (`bind_ready` plus revision fact).
- Add regressions for identity-only members, stale previous bindings, invoke blocking, and backend contract admission.

## Verification
- `pnpm --dir apps/aevatar-console-web test --runInBand src/pages/team-member-invoke/index.test.tsx src/pages/team-member-workflow-studio/index.test.tsx`
- `pnpm --dir apps/aevatar-console-web tsc`
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/workflow_binding_boundary_guard.sh`
- `git diff --check`

## Not run
- `dotnet test ...` because `dotnet` is not available in the local PATH (`zsh:1: command not found: dotnet`).