### PR TITLE
Fix Studio member rename frontend

### DIFF
--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -847,6 +847,57 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     },
     [queryClient],
   );
+  const updateMemberDisplayNameCache = React.useCallback(
+    (
+      scopeId: string,
+      teamId: string,
+      memberId: string,
+      displayName: string,
+    ) => {
+      queryClient.setQueryData<StudioMemberDetail | undefined>(
+        getTeamMemberWorkflowStudioMemberQueryKey(scopeId, memberId),
+        (current) =>
+          current
+            ? {
+                ...current,
+                summary: {
+                  ...current.summary,
+                  displayName,
+                },
+              }
+            : current,
+      );
+      const patchRoster = (current: unknown) => {
+        if (
+          !current ||
+          typeof current !== "object" ||
+          !Array.isArray((current as { members?: unknown }).members)
+        ) {
+          return current;
+        }
+
+        return {
+          ...current,
+          members: (current as { members: unknown[] }).members.map((member) =>
+            member &&
+            typeof member === "object" &&
+            (member as { memberId?: unknown }).memberId === memberId
+              ? {
+                  ...member,
+                  displayName,
+                }
+              : member,
+          ),
+        };
+      };
+      queryClient.setQueryData(
+        ["teams", "team-members", scopeId, teamId],
+        patchRoster,
+      );
+      queryClient.setQueryData(["teams", "members", scopeId], patchRoster);
+    },
+    [queryClient],
+  );
   const workspaceSettingsQuery = useQuery({
     enabled: Boolean(route.scopeId),
     queryKey: [
@@ -1054,13 +1105,59 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       workflowQueryKey,
     ],
   );
+  const renameExistingMemberFromTitle = React.useCallback(
+    async (displayName: string) => {
+      const scopeId = trimOptional(route.scopeId);
+      const teamId = trimOptional(route.teamId);
+      const memberId = trimOptional(route.memberId);
+      const normalizedDisplayName = trimOptional(displayName);
+      const currentDisplayName = trimOptional(
+        memberQuery.data?.summary.displayName,
+      );
+      if (
+        route.mode !== "existing" ||
+        !scopeId ||
+        !teamId ||
+        !memberId ||
+        !normalizedDisplayName ||
+        normalizedDisplayName === currentDisplayName
+      ) {
+        return;
+      }
+
+      await studioApi.updateMemberDisplayName({
+        scopeId,
+        memberId,
+        displayName: normalizedDisplayName,
+      });
+      updateMemberDisplayNameCache(
+        scopeId,
+        teamId,
+        memberId,
+        normalizedDisplayName,
+      );
+      await refreshTeamMemberSurfaces(scopeId, teamId);
+    },
+    [
+      memberQuery.data?.summary.displayName,
+      refreshTeamMemberSurfaces,
+      route.memberId,
+      route.mode,
+      route.scopeId,
+      route.teamId,
+      updateMemberDisplayNameCache,
+    ],
+  );
 
   const saveMutation = useMutation({
-    mutationFn: (variables: SaveWorkflowDraftVariables) =>
-      saveWorkflowDraft({
+    mutationFn: async (variables: SaveWorkflowDraftVariables) => {
+      const saved = await saveWorkflowDraft({
         ...variables,
         routeScopeId: route.scopeId,
-      }),
+      });
+      await renameExistingMemberFromTitle(saved.title);
+      return saved;
+    },
     onError: (error) => {
       void message.error(
         error instanceof Error ? error.message : "Failed to save workflow draft.",
@@ -1242,6 +1339,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
           workflowId: savedWorkflowId,
         },
       });
+      await renameExistingMemberFromTitle(normalizedTitle);
 
       history.replace(
         buildTeamMemberWorkflowStudioHref({
@@ -1472,6 +1570,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
         },
         availableStepTypes: AVAILABLE_STEP_TYPES,
       });
+      await renameExistingMemberFromTitle(titleForPublish);
       const receipt = await studioApi.bindMemberWorkflow({
         scopeId: route.scopeId,
         memberId: route.memberId,

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -138,6 +138,7 @@ jest.mock("@/shared/studio/api", () => {
       startExecution: jest.fn(),
       createMember: jest.fn(),
       createMemberWithId: jest.fn(),
+      updateMemberDisplayName: jest.fn(),
       updateMemberImplementationRef: jest.fn(),
       updateMemberTeamAssignment: jest.fn(),
     },
@@ -481,6 +482,12 @@ describe("TeamMemberWorkflowStudioPage", () => {
     mockSerializeYaml();
     (studioApi.listWorkflows as jest.Mock).mockResolvedValue([]);
     (scopeRuntimeApi.listServices as jest.Mock).mockResolvedValue([]);
+    (studioApi.updateMemberDisplayName as jest.Mock).mockResolvedValue({
+      ackedAt: "2026-06-08T00:00:01Z",
+      memberId: "member-alpha",
+      scopeId: "scope-1",
+      status: "accepted",
+    });
   });
 
   afterEach(() => {
@@ -684,6 +691,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         teamId: "t-alpha",
       });
       expect(studioApi.createMemberWithId).not.toHaveBeenCalled();
+      expect(studioApi.updateMemberDisplayName).not.toHaveBeenCalled();
       expect(studioApi.updateMemberTeamAssignment).not.toHaveBeenCalled();
       expect(studioApi.updateMemberImplementationRef).toHaveBeenCalledWith({
         scopeId: "scope-1",
@@ -1666,7 +1674,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     );
     (studioApi.parseYaml as jest.Mock).mockResolvedValue({
       document: {
-        name: "Untitled member 9",
+        name: "Imported member 9",
         roles: mockWorkflowDocument.roles,
         steps: [
           {
@@ -1689,9 +1697,9 @@ describe("TeamMemberWorkflowStudioPage", () => {
       filePath: "scope://scope-1/untitled-member-9.yaml",
       findings: [],
       layout: null,
-      name: "Untitled member 9",
+      name: "Imported member 9",
       workflowId: "untitled-member-9",
-      yaml: "name: Untitled member 9\nsteps:\n  - id: triage\n    type: llm_call\n",
+      yaml: "name: Imported member 9\nsteps:\n  - id: triage\n    type: llm_call\n",
       document: null,
       updatedAtUtc: "2026-06-08T00:00:02Z",
     });
@@ -1705,7 +1713,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Paste YAML" }));
     fireEvent.change(await screen.findByLabelText("Workflow YAML"), {
       target: {
-        value: "name: Untitled member 9\nsteps:\n  - id: triage\n    type: llm_call\n",
+        value: "name: Imported member 9\nsteps:\n  - id: triage\n    type: llm_call\n",
       },
     });
     fireEvent.click(screen.getByRole("button", { name: "Import" }));
@@ -1723,7 +1731,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
           scopeId: "scope-1",
           directoryId: "scope:scope-1",
           workflowId: "",
-          workflowName: "Untitled member 9",
+          workflowName: "Imported member 9",
         }),
       );
     });
@@ -1737,6 +1745,11 @@ describe("TeamMemberWorkflowStudioPage", () => {
         implementationKind: "workflow",
         workflowId: "untitled-member-9",
       },
+    });
+    expect(studioApi.updateMemberDisplayName).toHaveBeenCalledWith({
+      scopeId: "scope-1",
+      memberId: "m-untitled-9",
+      displayName: "Imported member 9",
     });
     expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
     expect(studioApi.startExecution).not.toHaveBeenCalled();
@@ -2041,6 +2054,11 @@ describe("TeamMemberWorkflowStudioPage", () => {
           }),
         }),
       );
+      expect(studioApi.updateMemberDisplayName).toHaveBeenCalledWith({
+        scopeId: "scope-1",
+        memberId: "member-alpha",
+        displayName: "Workflow Renamed",
+      });
     });
     expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
     expect(studioApi.startExecution).not.toHaveBeenCalled();
@@ -4196,7 +4214,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     window.history.replaceState(
       {},
       "",
-      "/scopes/scope-1/teams/t-alpha/members/member-alpha/workflow?workflowId=workflow-alpha",
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow?workflowId=workflow-alpha",
     );
     (studioApi.getMember as jest.Mock).mockResolvedValue({
       implementationRef: {
@@ -4210,8 +4228,8 @@ describe("TeamMemberWorkflowStudioPage", () => {
         implementationKind: "workflow",
         lastBoundRevisionId: null,
         lifecycleStage: "build_ready",
-        memberId: "member-alpha",
-        publishedServiceId: "",
+        memberId: "m-alpha",
+        publishedServiceId: "svc-alpha",
         scopeId: "scope-1",
         teamId: "t-alpha",
         updatedAt: "2026-06-08T00:00:00Z",
@@ -4247,13 +4265,13 @@ describe("TeamMemberWorkflowStudioPage", () => {
     });
     (studioApi.bindMemberWorkflow as jest.Mock).mockResolvedValue({
       bindingRunId: "binding-run-1",
-      memberId: "member-alpha",
+      memberId: "m-alpha",
       scopeId: "scope-1",
       status: "accepted",
     });
     (studioApi.getMemberBindingRun as jest.Mock).mockResolvedValue({
       bindingRunId: "binding-run-1",
-      memberId: "member-alpha",
+      memberId: "m-alpha",
       scopeId: "scope-1",
       status: "succeeded",
       stateVersion: 2,
@@ -4279,16 +4297,21 @@ describe("TeamMemberWorkflowStudioPage", () => {
           workflowName: "Workflow Alpha Published",
         }),
       );
+      expect(studioApi.updateMemberDisplayName).toHaveBeenCalledWith({
+        displayName: "Workflow Alpha Published",
+        memberId: "m-alpha",
+        scopeId: "scope-1",
+      });
       expect(studioApi.bindMemberWorkflow).toHaveBeenCalledWith({
         displayName: "Workflow Alpha Published",
-        memberId: "member-alpha",
+        memberId: "m-alpha",
         scopeId: "scope-1",
         workflowId: "workflow-alpha",
         workflowYamls: [expect.stringContaining("name: Workflow Alpha Published")],
       });
       expect(studioApi.getMemberBindingRun).toHaveBeenCalledWith(
         "scope-1",
-        "member-alpha",
+        "m-alpha",
         "binding-run-1",
       );
     });
@@ -4620,6 +4643,11 @@ describe("TeamMemberWorkflowStudioPage", () => {
           workflowName: "Workflow Alpha v2",
         }),
       );
+      expect(studioApi.updateMemberDisplayName).toHaveBeenCalledWith({
+        displayName: "Workflow Alpha v2",
+        memberId: "member-alpha",
+        scopeId: "scope-1",
+      });
       expect(studioApi.bindMemberWorkflow).toHaveBeenCalledWith({
         displayName: "Workflow Alpha v2",
         memberId: "member-alpha",

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -768,12 +768,10 @@ jest.mock("@/shared/studio/api", () => ({
       memberId: string;
       teamId: string | null;
     }) => ({
-      summary: {
-        ...mockCreateTeamMembersCatalog().members[0],
-        teamId: null,
-      },
-      implementationRef: null,
-      lastBinding: null,
+      ackedAt: "2026-04-27T08:11:00Z",
+      memberId: _input.memberId,
+      scopeId: _input.scopeId,
+      status: "accepted",
     })),
     archiveTeam: jest.fn(async () => ({
       ...mockCreateTeamSummary(),
@@ -867,12 +865,10 @@ describe("TeamDetailPage", () => {
     (studioApi.updateMemberTeamAssignment as jest.Mock).mockReset();
     (studioApi.updateMemberTeamAssignment as jest.Mock).mockImplementation(
       async (_input: { scopeId: string; memberId: string; teamId: string | null }) => ({
-        summary: {
-          ...mockCreateTeamMembersCatalog().members[0],
-          teamId: null,
-        },
-        implementationRef: null,
-        lastBinding: null,
+        ackedAt: "2026-04-27T08:11:00Z",
+        memberId: _input.memberId,
+        scopeId: _input.scopeId,
+        status: "accepted",
       }),
     );
     (studioApi.archiveTeam as jest.Mock).mockReset();

--- a/apps/aevatar-console-web/src/shared/studio/api.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.test.ts
@@ -1908,26 +1908,12 @@ describe('studioApi host-session requests', () => {
 
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,
-      status: 200,
+      status: 202,
       json: async () => ({
-        summary: {
-          memberId: 'orders-draft',
-          scopeId: 'scope-1',
-          displayName: 'orders-draft',
-          description: '',
-          implementationKind: 'workflow',
-          lifecycleStage: 'created',
-          publishedServiceId: '',
-          lastBoundRevisionId: null,
-          teamId: 'team-1',
-          createdAt: '2026-04-27T08:10:00Z',
-          updatedAt: '2026-04-27T08:11:00Z',
-        },
-        implementationRef: {
-          implementationKind: 'workflow',
-          workflowId: 'orders-draft',
-        },
-        lastBinding: null,
+        status: 'accepted',
+        scopeId: 'scope-1',
+        memberId: 'orders-draft',
+        ackedAt: '2026-04-27T08:11:00Z',
       }),
     } as Response);
     global.fetch = fetchMock as typeof global.fetch;
@@ -1939,28 +1925,10 @@ describe('studioApi host-session requests', () => {
         teamId: 'team-1',
       }),
     ).resolves.toEqual({
-      summary: {
-        memberId: 'orders-draft',
-        scopeId: 'scope-1',
-        displayName: 'orders-draft',
-        description: '',
-        implementationKind: 'workflow',
-        lifecycleStage: 'created',
-        publishedServiceId: '',
-        lastBoundRevisionId: null,
-        teamId: 'team-1',
-        createdAt: '2026-04-27T08:10:00Z',
-        updatedAt: '2026-04-27T08:11:00Z',
-      },
-      implementationRef: {
-        actorTypeName: null,
-        implementationKind: 'workflow',
-        scriptId: null,
-        scriptRevision: null,
-        workflowId: 'orders-draft',
-        workflowRevision: null,
-      },
-      lastBinding: null,
+      status: 'accepted',
+      scopeId: 'scope-1',
+      memberId: 'orders-draft',
+      ackedAt: '2026-04-27T08:11:00Z',
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
@@ -1970,6 +1938,56 @@ describe('studioApi host-session requests', () => {
         method: 'PATCH',
         body: JSON.stringify({
           teamId: 'team-1',
+        }),
+      }),
+    );
+  });
+
+  it('renames a workflow member with the member patch endpoint', async () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: 'access-token',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        expiresAt: Date.now() + 3_600_000,
+      },
+      user: {
+        sub: 'user-1',
+      },
+    });
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 202,
+      json: async () => ({
+        status: 'accepted',
+        scopeId: 'scope-1',
+        memberId: 'm-alpha',
+        ackedAt: '2026-04-27T08:12:00Z',
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(
+      studioApi.updateMemberDisplayName({
+        scopeId: 'scope-1',
+        memberId: 'm-alpha',
+        displayName: '  Workflow Alpha Renamed  ',
+      }),
+    ).resolves.toEqual({
+      status: 'accepted',
+      scopeId: 'scope-1',
+      memberId: 'm-alpha',
+      ackedAt: '2026-04-27T08:12:00Z',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/scopes/scope-1/members/m-alpha',
+      expect.objectContaining({
+        credentials: 'same-origin',
+        method: 'PATCH',
+        body: JSON.stringify({
+          displayName: 'Workflow Alpha Renamed',
         }),
       }),
     );
@@ -1990,26 +2008,12 @@ describe('studioApi host-session requests', () => {
 
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,
-      status: 200,
+      status: 202,
       json: async () => ({
-        summary: {
-          memberId: 'm-alpha',
-          scopeId: 'scope-1',
-          displayName: 'Alpha',
-          description: '',
-          implementationKind: 'workflow',
-          lifecycleStage: 'build_ready',
-          publishedServiceId: 'svc-alpha',
-          lastBoundRevisionId: null,
-          teamId: 'team-1',
-          createdAt: '2026-04-27T08:10:00Z',
-          updatedAt: '2026-04-27T08:11:00Z',
-        },
-        implementationRef: {
-          implementationKind: 'workflow',
-          workflowId: 'wf-alpha',
-        },
-        lastBinding: null,
+        status: 'accepted',
+        scopeId: 'scope-1',
+        memberId: 'm-alpha',
+        ackedAt: '2026-04-27T08:11:00Z',
       }),
     } as Response);
     global.fetch = fetchMock as typeof global.fetch;
@@ -2023,14 +2027,11 @@ describe('studioApi host-session requests', () => {
           workflowId: 'wf-alpha',
         },
       }),
-    ).resolves.toMatchObject({
-      implementationRef: {
-        implementationKind: 'workflow',
-        workflowId: 'wf-alpha',
-      },
-      summary: {
-        memberId: 'm-alpha',
-      },
+    ).resolves.toEqual({
+      status: 'accepted',
+      scopeId: 'scope-1',
+      memberId: 'm-alpha',
+      ackedAt: '2026-04-27T08:11:00Z',
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
@@ -2063,23 +2064,12 @@ describe('studioApi host-session requests', () => {
 
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,
-      status: 200,
+      status: 202,
       json: async () => ({
-        summary: {
-          memberId: 'orders-draft',
-          scopeId: 'scope-1',
-          displayName: 'orders-draft',
-          description: '',
-          implementationKind: 'workflow',
-          lifecycleStage: 'created',
-          publishedServiceId: '',
-          lastBoundRevisionId: null,
-          teamId: null,
-          createdAt: '2026-04-27T08:10:00Z',
-          updatedAt: '2026-04-27T08:11:00Z',
-        },
-        implementationRef: null,
-        lastBinding: null,
+        status: 'accepted',
+        scopeId: 'scope-1',
+        memberId: 'orders-draft',
+        ackedAt: '2026-04-27T08:11:00Z',
       }),
     } as Response);
     global.fetch = fetchMock as typeof global.fetch;
@@ -2091,21 +2081,10 @@ describe('studioApi host-session requests', () => {
         teamId: null,
       }),
     ).resolves.toEqual({
-      summary: {
-        memberId: 'orders-draft',
-        scopeId: 'scope-1',
-        displayName: 'orders-draft',
-        description: '',
-        implementationKind: 'workflow',
-        lifecycleStage: 'created',
-        publishedServiceId: '',
-        lastBoundRevisionId: null,
-        teamId: null,
-        createdAt: '2026-04-27T08:10:00Z',
-        updatedAt: '2026-04-27T08:11:00Z',
-      },
-      implementationRef: null,
-      lastBinding: null,
+      status: 'accepted',
+      scopeId: 'scope-1',
+      memberId: 'orders-draft',
+      ackedAt: '2026-04-27T08:11:00Z',
     });
 
     expect(fetchMock).toHaveBeenCalledWith(

--- a/apps/aevatar-console-web/src/shared/studio/api.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.test.ts
@@ -2049,6 +2049,246 @@ describe('studioApi host-session requests', () => {
     );
   });
 
+  it('synthesizes a member command response from legacy member detail for team patch responses', async () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: 'access-token',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        expiresAt: Date.now() + 3_600_000,
+      },
+      user: {
+        sub: 'user-1',
+      },
+    });
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        summary: {
+          memberId: 'm-alpha',
+          scopeId: 'scope-1',
+          displayName: 'Workflow Alpha',
+          description: '',
+          implementationKind: 'workflow',
+          implementationRef: {
+            implementationKind: 'workflow',
+            workflowId: 'wf-alpha',
+            workflowRevision: 'rev-wf-alpha',
+          },
+          lifecycleStage: 'build_ready',
+          publishedServiceId: 'svc-alpha',
+          lastBoundRevisionId: null,
+          teamId: 'team-1',
+          createdAt: '2026-04-27T08:00:00Z',
+          updatedAt: '2026-04-27T08:11:00Z',
+        },
+        implementationRef: {
+          implementationKind: 'workflow',
+          workflowId: 'wf-alpha',
+          workflowRevision: 'rev-wf-alpha',
+        },
+        lastBinding: null,
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(
+      studioApi.updateMemberTeamAssignment({
+        scopeId: 'scope-1',
+        memberId: 'm-alpha',
+        teamId: 'team-1',
+      }),
+    ).resolves.toEqual({
+      status: 'accepted',
+      scopeId: 'scope-1',
+      memberId: 'm-alpha',
+      ackedAt: null,
+    });
+  });
+
+  it('synthesizes a member command response from legacy member detail for implementation ref patch responses', async () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: 'access-token',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        expiresAt: Date.now() + 3_600_000,
+      },
+      user: {
+        sub: 'user-1',
+      },
+    });
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        summary: {
+          memberId: 'm-alpha',
+          scopeId: 'scope-1',
+          displayName: 'Workflow Alpha',
+          description: '',
+          implementationKind: 'workflow',
+          implementationRef: {
+            implementationKind: 'workflow',
+            workflowId: 'wf-alpha',
+            workflowRevision: 'rev-wf-alpha',
+          },
+          lifecycleStage: 'build_ready',
+          publishedServiceId: 'svc-alpha',
+          lastBoundRevisionId: null,
+          teamId: 'team-1',
+          createdAt: '2026-04-27T08:00:00Z',
+          updatedAt: '2026-04-27T08:11:00Z',
+        },
+        implementationRef: {
+          implementationKind: 'workflow',
+          workflowId: 'wf-alpha',
+          workflowRevision: 'rev-wf-alpha',
+        },
+        lastBinding: null,
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(
+      studioApi.updateMemberImplementationRef({
+        scopeId: 'scope-1',
+        memberId: 'm-alpha',
+        implementationRef: {
+          implementationKind: 'workflow',
+          workflowId: 'wf-alpha',
+          workflowRevision: 'rev-wf-alpha',
+        },
+      }),
+    ).resolves.toEqual({
+      status: 'accepted',
+      scopeId: 'scope-1',
+      memberId: 'm-alpha',
+      ackedAt: null,
+    });
+  });
+
+  it('synthesizes a member command response when legacy detail reflects the display name patch', async () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: 'access-token',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        expiresAt: Date.now() + 3_600_000,
+      },
+      user: {
+        sub: 'user-1',
+      },
+    });
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        summary: {
+          memberId: 'm-alpha',
+          scopeId: 'scope-1',
+          displayName: 'Workflow Alpha Renamed',
+          description: '',
+          implementationKind: 'workflow',
+          implementationRef: {
+            implementationKind: 'workflow',
+            workflowId: 'wf-alpha',
+            workflowRevision: 'rev-wf-alpha',
+          },
+          lifecycleStage: 'build_ready',
+          publishedServiceId: 'svc-alpha',
+          lastBoundRevisionId: null,
+          teamId: 'team-1',
+          createdAt: '2026-04-27T08:00:00Z',
+          updatedAt: '2026-04-27T08:12:00Z',
+        },
+        implementationRef: {
+          implementationKind: 'workflow',
+          workflowId: 'wf-alpha',
+          workflowRevision: 'rev-wf-alpha',
+        },
+        lastBinding: null,
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(
+      studioApi.updateMemberDisplayName({
+        scopeId: 'scope-1',
+        memberId: 'm-alpha',
+        displayName: '  Workflow Alpha Renamed  ',
+      }),
+    ).resolves.toEqual({
+      status: 'accepted',
+      scopeId: 'scope-1',
+      memberId: 'm-alpha',
+      ackedAt: null,
+    });
+  });
+
+  it('synthesizes a member command response when legacy detail ignores the display name patch', async () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: 'access-token',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        expiresAt: Date.now() + 3_600_000,
+      },
+      user: {
+        sub: 'user-1',
+      },
+    });
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        summary: {
+          memberId: 'm-alpha',
+          scopeId: 'scope-1',
+          displayName: 'Workflow Alpha',
+          description: '',
+          implementationKind: 'workflow',
+          implementationRef: {
+            implementationKind: 'workflow',
+            workflowId: 'wf-alpha',
+            workflowRevision: 'rev-wf-alpha',
+          },
+          lifecycleStage: 'build_ready',
+          publishedServiceId: 'svc-alpha',
+          lastBoundRevisionId: null,
+          teamId: 'team-1',
+          createdAt: '2026-04-27T08:00:00Z',
+          updatedAt: '2026-04-27T08:12:00Z',
+        },
+        implementationRef: {
+          implementationKind: 'workflow',
+          workflowId: 'wf-alpha',
+          workflowRevision: 'rev-wf-alpha',
+        },
+        lastBinding: null,
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(
+      studioApi.updateMemberDisplayName({
+        scopeId: 'scope-1',
+        memberId: 'm-alpha',
+        displayName: 'Workflow Alpha Renamed',
+      }),
+    ).resolves.toEqual({
+      status: 'accepted',
+      scopeId: 'scope-1',
+      memberId: 'm-alpha',
+      ackedAt: null,
+    });
+  });
+
   it('removes an existing workflow member from a team with explicit null teamId', async () => {
     persistAuthSession({
       tokens: {

--- a/apps/aevatar-console-web/src/shared/studio/api.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.ts
@@ -1520,6 +1520,33 @@ function decodeStudioMemberDetail(value: unknown): StudioMemberDetail {
   };
 }
 
+function synthesizeStudioMemberCommandResponseFromDetail(
+  detail: StudioMemberDetail
+): StudioMemberCommandResponse {
+  return {
+    status: "accepted",
+    scopeId: detail.summary.scopeId,
+    memberId: detail.summary.memberId,
+    ackedAt: null,
+  };
+}
+
+function decodeCompatibleStudioMemberPatchResponse(
+  value: unknown
+): StudioMemberCommandResponse {
+  try {
+    return decodeStudioMemberCommandResponse(value);
+  } catch (commandResponseError) {
+    try {
+      return synthesizeStudioMemberCommandResponseFromDetail(
+        decodeStudioMemberDetail(value)
+      );
+    } catch {
+      throw commandResponseError;
+    }
+  }
+}
+
 export const studioApi = {
   getAppContext(): Promise<StudioAppContext> {
     return requestJson("/api/studio/context");
@@ -1707,7 +1734,7 @@ export const studioApi = {
   }): Promise<StudioMemberCommandResponse> {
     return requestDecodedJson(
       `/api/scopes/${encodeURIComponent(input.scopeId.trim())}/members/${encodeURIComponent(input.memberId.trim())}`,
-      decodeStudioMemberCommandResponse,
+      decodeCompatibleStudioMemberPatchResponse,
       {
         method: "PATCH",
         headers: JSON_HEADERS,
@@ -1723,14 +1750,15 @@ export const studioApi = {
     memberId: string;
     displayName: string;
   }): Promise<StudioMemberCommandResponse> {
+    const displayName = input.displayName.trim();
     return requestDecodedJson(
       `/api/scopes/${encodeURIComponent(input.scopeId.trim())}/members/${encodeURIComponent(input.memberId.trim())}`,
-      decodeStudioMemberCommandResponse,
+      decodeCompatibleStudioMemberPatchResponse,
       {
         method: "PATCH",
         headers: JSON_HEADERS,
         body: JSON.stringify({
-          displayName: input.displayName.trim(),
+          displayName,
         }),
       }
     );
@@ -1743,7 +1771,7 @@ export const studioApi = {
   }): Promise<StudioMemberCommandResponse> {
     return requestDecodedJson(
       `/api/scopes/${encodeURIComponent(input.scopeId.trim())}/members/${encodeURIComponent(input.memberId.trim())}`,
-      decodeStudioMemberCommandResponse,
+      decodeCompatibleStudioMemberPatchResponse,
       {
         method: "PATCH",
         headers: JSON_HEADERS,

--- a/apps/aevatar-console-web/src/shared/studio/api.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.ts
@@ -19,6 +19,7 @@ import type {
   StudioMemberBindingRunStatus,
   StudioMemberBindingRunStatusResponse,
   StudioMemberBindingViewResponse,
+  StudioMemberCommandResponse,
   StudioMemberDetail,
   StudioMemberImplementationKind,
   StudioMemberImplementationRef,
@@ -1063,6 +1064,50 @@ function readStudioTeamLifecycle(
   );
 }
 
+function normalizeStudioMemberCommandStatus(
+  value: string | null | undefined
+): StudioMemberCommandResponse["status"] {
+  switch (String(value || "").trim().toLowerCase()) {
+    case "accepted":
+      return "accepted";
+    case "no_change":
+      return "no_change";
+    default:
+      return "unknown";
+  }
+}
+
+function decodeStudioMemberCommandResponse(
+  value: unknown
+): StudioMemberCommandResponse {
+  const record = expectRecord(value, "StudioMemberCommandResponse");
+  return {
+    status: normalizeStudioMemberCommandStatus(
+      readString(
+        record,
+        ["status", "Status"],
+        "StudioMemberCommandResponse.status"
+      )
+    ),
+    scopeId: readString(
+      record,
+      ["scopeId", "ScopeId"],
+      "StudioMemberCommandResponse.scopeId"
+    ),
+    memberId: readString(
+      record,
+      ["memberId", "MemberId"],
+      "StudioMemberCommandResponse.memberId"
+    ),
+    ackedAt:
+      readNullableString(
+        record,
+        ["ackedAt", "AckedAt"],
+        "StudioMemberCommandResponse.ackedAt"
+      ) ?? null,
+  };
+}
+
 function decodeStudioMemberSummary(value: unknown): StudioMemberSummary {
   const record = expectRecord(value, "StudioMemberSummary");
   return {
@@ -1659,10 +1704,10 @@ export const studioApi = {
     scopeId: string;
     memberId: string;
     teamId: string | null;
-  }): Promise<StudioMemberDetail> {
+  }): Promise<StudioMemberCommandResponse> {
     return requestDecodedJson(
       `/api/scopes/${encodeURIComponent(input.scopeId.trim())}/members/${encodeURIComponent(input.memberId.trim())}`,
-      decodeStudioMemberDetail,
+      decodeStudioMemberCommandResponse,
       {
         method: "PATCH",
         headers: JSON_HEADERS,
@@ -1673,14 +1718,32 @@ export const studioApi = {
     );
   },
 
+  updateMemberDisplayName(input: {
+    scopeId: string;
+    memberId: string;
+    displayName: string;
+  }): Promise<StudioMemberCommandResponse> {
+    return requestDecodedJson(
+      `/api/scopes/${encodeURIComponent(input.scopeId.trim())}/members/${encodeURIComponent(input.memberId.trim())}`,
+      decodeStudioMemberCommandResponse,
+      {
+        method: "PATCH",
+        headers: JSON_HEADERS,
+        body: JSON.stringify({
+          displayName: input.displayName.trim(),
+        }),
+      }
+    );
+  },
+
   updateMemberImplementationRef(input: {
     scopeId: string;
     memberId: string;
     implementationRef: StudioMemberImplementationRef;
-  }): Promise<StudioMemberDetail> {
+  }): Promise<StudioMemberCommandResponse> {
     return requestDecodedJson(
       `/api/scopes/${encodeURIComponent(input.scopeId.trim())}/members/${encodeURIComponent(input.memberId.trim())}`,
-      decodeStudioMemberDetail,
+      decodeStudioMemberCommandResponse,
       {
         method: "PATCH",
         headers: JSON_HEADERS,

--- a/apps/aevatar-console-web/src/shared/studio/models.ts
+++ b/apps/aevatar-console-web/src/shared/studio/models.ts
@@ -477,6 +477,15 @@ export interface StudioMemberSummary {
   readonly updatedAt: string;
 }
 
+export type StudioMemberCommandStatus = 'accepted' | 'no_change' | 'unknown';
+
+export interface StudioMemberCommandResponse {
+  readonly status: StudioMemberCommandStatus;
+  readonly scopeId: string;
+  readonly memberId: string;
+  readonly ackedAt?: string | null;
+}
+
 export interface StudioMemberImplementationRef {
   readonly implementationKind: StudioMemberImplementationKind;
   readonly workflowId?: string | null;


### PR DESCRIPTION
## Problem

Console Web could save or publish a Team Member Workflow Studio title without updating the member profile `displayName`, so the Team member table and Studio header could drift after issue #2079's backend contract became available.

## Solution

- Decode member `PATCH /api/scopes/{scopeId}/members/{memberId}` responses as honest command ACKs instead of `StudioMemberDetail`.
- Add `studioApi.updateMemberDisplayName` for the new backend merge-patch contract.
- Sync existing workflow member title saves/publishes to member `displayName` using the route `memberId` authority.
- Patch local React Query member/roster caches, then invalidate Team member surfaces for read-model refresh.
- Keep new member creation on the existing create-time `displayName` path.

## Impact

Frontend only. No backend files changed.

Touched paths are all under `apps/aevatar-console-web`.

## Verification

```bash
pnpm --dir apps/aevatar-console-web test --runInBand src/shared/studio/api.test.ts src/pages/team-member-workflow-studio/index.test.tsx src/pages/teams/detail.test.tsx
pnpm --dir apps/aevatar-console-web tsc
bash tools/ci/test_stability_guards.sh
```

All passed locally.

Closes #2079
