### PR TITLE
Fix studio member patch receipt decoding

### DIFF
--- a/apps/aevatar-console-web/src/shared/studio/api.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.test.ts
@@ -1908,26 +1908,12 @@ describe('studioApi host-session requests', () => {
 
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,
-      status: 200,
+      status: 202,
       json: async () => ({
-        summary: {
-          memberId: 'orders-draft',
-          scopeId: 'scope-1',
-          displayName: 'orders-draft',
-          description: '',
-          implementationKind: 'workflow',
-          lifecycleStage: 'created',
-          publishedServiceId: '',
-          lastBoundRevisionId: null,
-          teamId: 'team-1',
-          createdAt: '2026-04-27T08:10:00Z',
-          updatedAt: '2026-04-27T08:11:00Z',
-        },
-        implementationRef: {
-          implementationKind: 'workflow',
-          workflowId: 'orders-draft',
-        },
-        lastBinding: null,
+        status: 'accepted',
+        scopeId: 'scope-1',
+        memberId: 'orders-draft',
+        ackedAt: '2026-04-27T08:11:00Z',
       }),
     } as Response);
     global.fetch = fetchMock as typeof global.fetch;
@@ -1939,28 +1925,10 @@ describe('studioApi host-session requests', () => {
         teamId: 'team-1',
       }),
     ).resolves.toEqual({
-      summary: {
-        memberId: 'orders-draft',
-        scopeId: 'scope-1',
-        displayName: 'orders-draft',
-        description: '',
-        implementationKind: 'workflow',
-        lifecycleStage: 'created',
-        publishedServiceId: '',
-        lastBoundRevisionId: null,
-        teamId: 'team-1',
-        createdAt: '2026-04-27T08:10:00Z',
-        updatedAt: '2026-04-27T08:11:00Z',
-      },
-      implementationRef: {
-        actorTypeName: null,
-        implementationKind: 'workflow',
-        scriptId: null,
-        scriptRevision: null,
-        workflowId: 'orders-draft',
-        workflowRevision: null,
-      },
-      lastBinding: null,
+      status: 'accepted',
+      scopeId: 'scope-1',
+      memberId: 'orders-draft',
+      ackedAt: '2026-04-27T08:11:00Z',
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
@@ -1990,26 +1958,12 @@ describe('studioApi host-session requests', () => {
 
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,
-      status: 200,
+      status: 202,
       json: async () => ({
-        summary: {
-          memberId: 'm-alpha',
-          scopeId: 'scope-1',
-          displayName: 'Alpha',
-          description: '',
-          implementationKind: 'workflow',
-          lifecycleStage: 'build_ready',
-          publishedServiceId: 'svc-alpha',
-          lastBoundRevisionId: null,
-          teamId: 'team-1',
-          createdAt: '2026-04-27T08:10:00Z',
-          updatedAt: '2026-04-27T08:11:00Z',
-        },
-        implementationRef: {
-          implementationKind: 'workflow',
-          workflowId: 'wf-alpha',
-        },
-        lastBinding: null,
+        status: 'accepted',
+        scopeId: 'scope-1',
+        memberId: 'm-alpha',
+        ackedAt: '2026-04-27T08:11:00Z',
       }),
     } as Response);
     global.fetch = fetchMock as typeof global.fetch;
@@ -2023,14 +1977,11 @@ describe('studioApi host-session requests', () => {
           workflowId: 'wf-alpha',
         },
       }),
-    ).resolves.toMatchObject({
-      implementationRef: {
-        implementationKind: 'workflow',
-        workflowId: 'wf-alpha',
-      },
-      summary: {
-        memberId: 'm-alpha',
-      },
+    ).resolves.toEqual({
+      status: 'accepted',
+      scopeId: 'scope-1',
+      memberId: 'm-alpha',
+      ackedAt: '2026-04-27T08:11:00Z',
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
@@ -2063,23 +2014,12 @@ describe('studioApi host-session requests', () => {
 
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,
-      status: 200,
+      status: 202,
       json: async () => ({
-        summary: {
-          memberId: 'orders-draft',
-          scopeId: 'scope-1',
-          displayName: 'orders-draft',
-          description: '',
-          implementationKind: 'workflow',
-          lifecycleStage: 'created',
-          publishedServiceId: '',
-          lastBoundRevisionId: null,
-          teamId: null,
-          createdAt: '2026-04-27T08:10:00Z',
-          updatedAt: '2026-04-27T08:11:00Z',
-        },
-        implementationRef: null,
-        lastBinding: null,
+        status: 'accepted',
+        scopeId: 'scope-1',
+        memberId: 'orders-draft',
+        ackedAt: '2026-04-27T08:11:00Z',
       }),
     } as Response);
     global.fetch = fetchMock as typeof global.fetch;
@@ -2091,21 +2031,10 @@ describe('studioApi host-session requests', () => {
         teamId: null,
       }),
     ).resolves.toEqual({
-      summary: {
-        memberId: 'orders-draft',
-        scopeId: 'scope-1',
-        displayName: 'orders-draft',
-        description: '',
-        implementationKind: 'workflow',
-        lifecycleStage: 'created',
-        publishedServiceId: '',
-        lastBoundRevisionId: null,
-        teamId: null,
-        createdAt: '2026-04-27T08:10:00Z',
-        updatedAt: '2026-04-27T08:11:00Z',
-      },
-      implementationRef: null,
-      lastBinding: null,
+      status: 'accepted',
+      scopeId: 'scope-1',
+      memberId: 'orders-draft',
+      ackedAt: '2026-04-27T08:11:00Z',
     });
 
     expect(fetchMock).toHaveBeenCalledWith(

--- a/apps/aevatar-console-web/src/shared/studio/api.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.ts
@@ -19,6 +19,8 @@ import type {
   StudioMemberBindingRunStatus,
   StudioMemberBindingRunStatusResponse,
   StudioMemberBindingViewResponse,
+  StudioMemberCommandResponse,
+  StudioMemberCommandStatus,
   StudioMemberDetail,
   StudioMemberImplementationKind,
   StudioMemberImplementationRef,
@@ -1335,6 +1337,29 @@ function normalizeStudioMemberBindingRunStatus(
   }) as StudioMemberBindingRunStatus;
 }
 
+function normalizeStudioMemberCommandStatus(
+  value: string | number | null | undefined
+): StudioMemberCommandStatus {
+  if (value == null) {
+    return "unknown";
+  }
+
+  const normalized = normalizeEnumValue(value, "status", {
+    "0": "unknown",
+    "1": "accepted",
+    "2": "no_change",
+    accepted: "accepted",
+    no_change: "no_change",
+    nochange: "no_change",
+    unchanged: "no_change",
+    unknown: "unknown",
+  });
+
+  return normalized === "accepted" || normalized === "no_change"
+    ? normalized
+    : "unknown";
+}
+
 function decodeStudioMemberBindingFailure(
   value: unknown
 ): StudioMemberBindingFailure {
@@ -1423,6 +1448,33 @@ function decodeStudioMemberBindingAcceptedResponse(
       ["memberId", "MemberId"],
       "StudioMemberBindingAcceptedResponse.memberId"
     ),
+  };
+}
+
+function decodeStudioMemberCommandResponse(
+  value: unknown
+): StudioMemberCommandResponse {
+  const record = expectRecord(value, "StudioMemberCommandResponse");
+  return {
+    status: normalizeStudioMemberCommandStatus(
+      readOptionalScalar(record, ["status", "Status"])
+    ),
+    scopeId: readString(
+      record,
+      ["scopeId", "ScopeId"],
+      "StudioMemberCommandResponse.scopeId"
+    ),
+    memberId: readString(
+      record,
+      ["memberId", "MemberId"],
+      "StudioMemberCommandResponse.memberId"
+    ),
+    ackedAt:
+      readNullableString(
+        record,
+        ["ackedAt", "AckedAt"],
+        "StudioMemberCommandResponse.ackedAt"
+      ) ?? null,
   };
 }
 
@@ -1659,10 +1711,10 @@ export const studioApi = {
     scopeId: string;
     memberId: string;
     teamId: string | null;
-  }): Promise<StudioMemberDetail> {
+  }): Promise<StudioMemberCommandResponse> {
     return requestDecodedJson(
       `/api/scopes/${encodeURIComponent(input.scopeId.trim())}/members/${encodeURIComponent(input.memberId.trim())}`,
-      decodeStudioMemberDetail,
+      decodeStudioMemberCommandResponse,
       {
         method: "PATCH",
         headers: JSON_HEADERS,
@@ -1677,10 +1729,10 @@ export const studioApi = {
     scopeId: string;
     memberId: string;
     implementationRef: StudioMemberImplementationRef;
-  }): Promise<StudioMemberDetail> {
+  }): Promise<StudioMemberCommandResponse> {
     return requestDecodedJson(
       `/api/scopes/${encodeURIComponent(input.scopeId.trim())}/members/${encodeURIComponent(input.memberId.trim())}`,
-      decodeStudioMemberDetail,
+      decodeStudioMemberCommandResponse,
       {
         method: "PATCH",
         headers: JSON_HEADERS,

--- a/apps/aevatar-console-web/src/shared/studio/models.ts
+++ b/apps/aevatar-console-web/src/shared/studio/models.ts
@@ -528,6 +528,18 @@ export interface StudioMemberBindingAcceptedResponse {
   readonly memberId: string;
 }
 
+export type StudioMemberCommandStatus =
+  | 'accepted'
+  | 'no_change'
+  | 'unknown';
+
+export interface StudioMemberCommandResponse {
+  readonly status: StudioMemberCommandStatus;
+  readonly scopeId: string;
+  readonly memberId: string;
+  readonly ackedAt?: string | null;
+}
+
 export interface StudioMemberDetail {
   readonly summary: StudioMemberSummary;
   readonly implementationRef?: StudioMemberImplementationRef | null;


### PR DESCRIPTION
## Problem

Saving a new Team member workflow could show `StudioMemberDetail.summary must be an object.` The frontend decoded `PATCH /api/scopes/{scopeId}/members/{memberId}` as `StudioMemberDetail`, but the backend contract on `feature/integrate` returns `202 Accepted` with `StudioMemberCommandResponse`.

## Solution

- Add typed `StudioMemberCommandResponse` / status models.
- Decode member PATCH responses as command receipts for implementation-ref and team-assignment updates.
- Update API tests to use the `202` receipt shape from the backend contract.

## Verification

- `pnpm --dir apps/aevatar-console-web tsc`
- `pnpm --dir apps/aevatar-console-web test --runInBand src/shared/studio/api.test.ts src/pages/team-member-workflow-studio/index.test.tsx`
- `bash tools/ci/test_stability_guards.sh`

## Manual Check

Started the fixed frontend on `http://127.0.0.1:5174` with both API targets set to `https://aevatar-console-backend-api.aevatar.ai`, and verified `/api/studio/context` proxies to the hosted backend.