### PR TITLE
feat(voice): broker OpenAI Realtime credential through NyxID ephemeral

### DIFF
--- a/docs/adr/0033-voice-provider-nyxid-ephemeral-broker.md
+++ b/docs/adr/0033-voice-provider-nyxid-ephemeral-broker.md
@@ -1,0 +1,123 @@
+---
+title: "Voice Provider Credential via NyxID Ephemeral Broker"
+status: proposed
+owner: eanzhao
+---
+
+# ADR-0033: 语音 Provider 凭证经 NyxID 临时密钥经纪
+
+## Context
+
+`VoicePresence` 的 OpenAI Realtime provider 之前从宿主静态配置/环境变量读取
+`OPENAI_API_KEY`（`Aevatar.Bootstrap.Extensions.AI.ServiceCollectionExtensions.BuildOpenAIVoiceProviderConfig`
+读 `Aevatar:VoicePresence:OpenAI:ApiKey` / `OPENAI_API_KEY`），并以
+`IsOpenAIVoiceConfigured = !empty(ApiKey)` 作为 host 启动期注册门槛。这与仓库两条
+不变量冲突：
+
+- **零长期 secret material（#375 / ADR-0018）**：aevatar 不应持有长期 provider 密钥。
+- **NyxID 是唯一凭证经纪**：aevatar 的 tool / LLM 调用已经只走 per-request 的
+  caller NyxID token（`AgentToolRequestContext.NyxIdAccessToken` + `NyxIdApiClient`，
+  "token comes exclusively from per-request metadata, no local secrets fallback"）；
+  唯独 voice provider 这条路径仍读裸 key。
+
+后果：生产部署没有配置静态 key 时，voice 模块在启动期不注册，`/ws/voice` 落到
+fail-closed 兜底返回 `503 voice_not_configured`（见 `PolicyAwareVoiceEndpoints` /
+`MainnetHostBuilderExtensions`）。
+
+约束（来自 CLAUDE.md「外部仓库无改动权」+ ADR-013）：
+
+- **不得改 NyxID 代码**：只能用 NyxID 现有 proxy surface（加 service 属配置，非代码）。
+- **NyxID 不进音频热路径（ADR-013）**：实时音频 WS 必须 aevatar 直连 provider，
+  不能整条 WS 走 NyxID 代理。
+
+## Decision
+
+为 voice provider 引入 **per-session 凭证经纪**，取代启动期静态 key：
+
+1. provider 凭证在 **connect 时** 由 `IRealtimeProviderCredentialResolver` 解析，而非
+   启动期写死。无 resolver 时回退到静态 `VoiceProviderConfig.ApiKey`（本地/直连开发不变）。
+2. 生产实现 `NyxIdRealtimeProviderCredentialResolver`：用 **caller 的 NyxID token**
+   经 NyxID proxy `POST /api/v1/proxy/s/<slug>/v1/realtime/client_secrets` 让 NyxID
+   注入真实 `sk-...` 并向 OpenAI 申请一个 **短期 ephemeral client secret（`ek_...`）**，
+   aevatar 随后用该 ephemeral **直连** `wss://api.openai.com/v1/realtime`。
+3. caller 的 NyxID token 由 host 在 `/ws/voice` 连接时从已验证的 bearer 取出，经
+   `AgentToolContextScope` 注入 `AgentToolRequestContext`；因为 provider connect 在
+   `VoiceVolatileMediaStreamPort.AttachAsync` 内 **同步 in-process** 发生，AsyncLocal
+   随调用链流到 resolver，**token 不落 grain/proto state**。
+
+```
+/ws/voice handler  (已验证的 caller NyxID bearer, scope 含 proxy)
+   │  AgentToolContextScope.Push(Credentials.NyxIdAccessToken = bearer)
+   ▼
+VoiceVolatileMediaStreamPort.AttachAsync  ──(同一 async 上下文, in-process)──┐
+   ▼                                                                        │ AsyncLocal 流动
+OpenAIRealtimeProvider.ConnectAsync                                          │
+   │  resolver.ResolveApiKeyAsync(sessionKey, config)                       │
+   │     callerToken = AgentToolRequestContext.NyxIdAccessToken  ◄──────────┘
+   │     ephemeral  = NyxID proxy POST /v1/realtime/client_secrets  (NyxID 注入真实 sk-)
+   │     config.ApiKey = ephemeral.value   (ek_…, ~60s TTL, 只在内存)
+   ▼  RealtimeClient(ApiKeyCredential(ek_…)) → 直连 OpenAI
+OpenAI Realtime WS  ◄──── 音频热路径不经 NyxID（ADR-013 ✓）
+```
+
+注册门槛改为 `IsOpenAIVoiceConfigured(config) || nyxIdRealtimeBrokerEnabled`，其中
+`nyxIdRealtimeBrokerEnabled = !empty(Aevatar:VoicePresence:OpenAI:Nyxid:ServiceSlug)`，
+使纯经纪部署（无静态 key）也能注册 voice 模块、不再 503。
+
+## 不变量对齐
+
+- **零 secret material**：aevatar 不持有 `sk-...`；ephemeral `ek_...` 仅在 connect
+  内存中短暂存在，不入 actor/projection/log；caller bearer 只走 AsyncLocal，不持久化。
+- **ADR-013**：NyxID 只在「申请 ephemeral」这一次 HTTP 调用里出现，音频 WS aevatar 直连。
+- **per-caller-token 模型**：复用 `AgentToolRequestContext.NyxIdAccessToken` +
+  `NyxIdApiClient.ProxyRequestAsync(token, …)`，不新增任何 service-level NyxID secret。
+- **不改 NyxID**：仅用现有 proxy；OpenAI service 在 NyxID 侧属配置（`nyxid service add`）。
+
+## 实现
+
+| 层 | 改动 |
+|---|---|
+| `Foundation.VoicePresence.Abstractions` | 新增 `IRealtimeProviderCredentialResolver` + `RealtimeProviderCredentialException` |
+| `Foundation.VoicePresence.OpenAI` | `OpenAIRealtimeProvider` 可选注入 resolver；connect 时 resolve-then-validate，未配置时用静态 key |
+| `Bootstrap.Extensions.AI` | `NyxIdRealtimeProviderCredentialResolver` + `NyxIdRealtimeProviderCredentialOptions`；门槛 `\|\| brokerEnabled`；注册 resolver；两处 provider 构造注入 resolver |
+| `Mainnet.Host.Api/Voice` | `PolicyAwareVoiceEndpoints` 在 attach 前 `AgentToolContextScope.Push(caller bearer)` |
+
+依赖：经纪模式要求宿主已配置 NyxID tools（`INyxIdApiClientFactory`）。
+
+OpenAI ephemeral 响应解析兼容 GA（`{ "value": "ek_…" }`）与旧 beta
+（`{ "client_secret": { "value": "ek_…" } }`）两种形状。
+
+## Configuration
+
+```
+Aevatar:VoicePresence:OpenAI:Nyxid:ServiceSlug = openai-realtime   # 启用经纪
+Aevatar:VoicePresence:OpenAI:Nyxid:MintPath    = v1/realtime/client_secrets  # 默认
+Aevatar:VoicePresence:OpenAI:Nyxid:Model       = gpt-realtime               # 默认/回退
+```
+
+NyxID 侧（运维一次性，凭证只存 NyxID）：
+
+```
+nyxid service add --custom --slug openai-realtime --label "OpenAI Realtime" \
+  --endpoint-url https://api.openai.com --auth-method bearer
+# 凭证填真实 sk-...；service 归属/共享给连接 /ws/voice 的 caller 身份，
+# 使其 proxy-scoped token 可访问该 service。
+```
+
+`endpoint-url` 必须是裸 host `https://api.openai.com`，使 proxy 路径解析为
+`…/v1/realtime/client_secrets`。
+
+## Consequences
+
+- 生产无需也不应配置静态 `OPENAI_API_KEY`；密钥只在 NyxID。
+- NyxID 成为 voice provider 凭证的单一 control point（限流/审计/吊销）。
+- ephemeral TTL 极短（~60s），仅用于开连接；泄漏窗口最小。
+- 静态 key 路径保留，本地/直连开发与单测不受影响。
+- 后续（单独 PR）：voice **工具** 调用在 actor turn 上执行，AsyncLocal 不跨 actor 边界，
+  仍未拿到 caller NyxID 凭证；需用 volatile per-lease 旁路（仿 `IVoiceVolatileMediaStreamPort`）
+  补齐，超出本 ADR 范围。
+
+## Related
+
+- ADR-013 — NyxID pure passthrough（不进音频热路径）
+- ADR-0018 — Per-User NyxID Binding via OAuth Broker（零 secret material / 经纪范式）

--- a/src/Aevatar.Bootstrap.Extensions.AI/Aevatar.Bootstrap.Extensions.AI.csproj
+++ b/src/Aevatar.Bootstrap.Extensions.AI/Aevatar.Bootstrap.Extensions.AI.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\Aevatar.AI.LLMProviders.NyxId\Aevatar.AI.LLMProviders.NyxId.csproj" />
     <ProjectReference Include="..\Aevatar.AI.LLMProviders.Tornado\Aevatar.AI.LLMProviders.Tornado.csproj" />
     <ProjectReference Include="..\Aevatar.AI.ToolProviders.MCP\Aevatar.AI.ToolProviders.MCP.csproj" />
+    <ProjectReference Include="..\Aevatar.AI.ToolProviders.NyxId\Aevatar.AI.ToolProviders.NyxId.csproj" />
     <ProjectReference Include="..\Aevatar.AI.ToolProviders.Ornn\Aevatar.AI.ToolProviders.Ornn.csproj" />
     <ProjectReference Include="..\Aevatar.AI.ToolProviders.Scripting\Aevatar.AI.ToolProviders.Scripting.csproj" />
     <ProjectReference Include="..\Aevatar.AI.ToolProviders.ServiceInvoke\Aevatar.AI.ToolProviders.ServiceInvoke.csproj" />

--- a/src/Aevatar.Bootstrap.Extensions.AI/NyxIdRealtimeProviderCredentialOptions.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/NyxIdRealtimeProviderCredentialOptions.cs
@@ -1,0 +1,31 @@
+using Aevatar.Foundation.VoicePresence.OpenAI;
+
+namespace Aevatar.Bootstrap.Extensions.AI;
+
+/// <summary>
+/// Options for brokering the OpenAI Realtime provider credential through NyxID.
+/// Bound from <c>Aevatar:VoicePresence:OpenAI:Nyxid:*</c>. When
+/// <see cref="ServiceSlug" /> is set, broker mode is enabled: the long-lived
+/// OpenAI key lives only in the NyxID service and aevatar mints a short-lived
+/// ephemeral per session, so no static <c>OPENAI_API_KEY</c> is required. See ADR-0033.
+/// </summary>
+public sealed class NyxIdRealtimeProviderCredentialOptions
+{
+    /// <summary>
+    /// NyxID service slug that holds the real OpenAI key (e.g. <c>openai-realtime</c>).
+    /// Empty disables broker mode (static-key / local-dev path stays in effect).
+    /// </summary>
+    public string ServiceSlug { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Proxied OpenAI path that mints the realtime ephemeral client secret. The
+    /// NyxID service endpoint must be the bare host (<c>https://api.openai.com</c>)
+    /// so this resolves to <c>…/v1/realtime/client_secrets</c>.
+    /// </summary>
+    public string MintPath { get; set; } = "v1/realtime/client_secrets";
+
+    /// <summary>Model used when minting the ephemeral session; falls back to the provider config model.</summary>
+    public string Model { get; set; } = OpenAIRealtimeProviderOptions.DefaultModelName;
+
+    public bool Enabled => !string.IsNullOrWhiteSpace(ServiceSlug);
+}

--- a/src/Aevatar.Bootstrap.Extensions.AI/NyxIdRealtimeProviderCredentialResolver.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/NyxIdRealtimeProviderCredentialResolver.cs
@@ -1,0 +1,131 @@
+using System.Text.Json;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.Foundation.VoicePresence.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.Bootstrap.Extensions.AI;
+
+/// <summary>
+/// Brokers the OpenAI Realtime provider credential through NyxID: mints a
+/// short-lived ephemeral client secret via the NyxID proxy using the caller's
+/// per-request NyxID access token (from <see cref="AgentToolRequestContext" />,
+/// set by the voice host before connect). The long-lived OpenAI key lives only
+/// in the NyxID service; aevatar connects directly to OpenAI with the ephemeral,
+/// so NyxID is never in the audio hot path (ADR-013) and aevatar holds no
+/// long-lived provider secret (zero-secret-material, ADR-0018). See ADR-0033.
+/// </summary>
+// Refactor (cluster-voice-nyxid-ephemeral-broker):
+//   Old pattern: VoiceProviderConfig.ApiKey carried a static OPENAI_API_KEY; aevatar held the provider key.
+//   New principle: the provider key is brokered per session from NyxID into a short-lived ephemeral, on
+//     the caller's NyxID identity — consistent with aevatar's per-caller-token NyxID model (no service secret).
+public sealed class NyxIdRealtimeProviderCredentialResolver : IRealtimeProviderCredentialResolver
+{
+    private readonly INyxIdApiClientFactory _clientFactory;
+    private readonly NyxIdRealtimeProviderCredentialOptions _options;
+    private readonly ILogger<NyxIdRealtimeProviderCredentialResolver> _logger;
+
+    public NyxIdRealtimeProviderCredentialResolver(
+        INyxIdApiClientFactory clientFactory,
+        NyxIdRealtimeProviderCredentialOptions options,
+        ILogger<NyxIdRealtimeProviderCredentialResolver> logger)
+    {
+        _clientFactory = clientFactory ?? throw new ArgumentNullException(nameof(clientFactory));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<string?> ResolveApiKeyAsync(
+        VoiceProviderSessionKey sessionKey,
+        VoiceProviderConfig config,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(sessionKey);
+        ArgumentNullException.ThrowIfNull(config);
+
+        var callerToken = AgentToolRequestContext.NyxIdAccessToken;
+        if (string.IsNullOrWhiteSpace(callerToken))
+        {
+            // No per-request NyxID credential in context (e.g. a connect path that
+            // is not driven by an authenticated caller). Fall back to the static
+            // config key instead of failing here; pure broker deployments (no
+            // static key) surface the missing key at provider validation.
+            _logger.LogWarning(
+                "Realtime provider credential brokering skipped for session {SessionId}: no caller NyxID token in tool-request context.",
+                sessionKey.SessionId);
+            return null;
+        }
+
+        var model = string.IsNullOrWhiteSpace(config.Model) ? _options.Model : config.Model;
+        var requestBody = JsonSerializer.Serialize(new
+        {
+            session = new { type = "realtime", model },
+        });
+
+        string responseJson;
+        try
+        {
+            var client = _clientFactory.CreateClient();
+            responseJson = await client.ProxyRequestAsync(
+                callerToken,
+                _options.ServiceSlug,
+                _options.MintPath,
+                "POST",
+                requestBody,
+                extraHeaders: null,
+                ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new RealtimeProviderCredentialException(
+                $"Failed to mint an OpenAI realtime ephemeral credential via NyxID service '{_options.ServiceSlug}'.",
+                ex);
+        }
+
+        var ephemeral = ExtractEphemeralSecret(responseJson);
+        if (string.IsNullOrWhiteSpace(ephemeral))
+        {
+            throw new RealtimeProviderCredentialException(
+                $"NyxID service '{_options.ServiceSlug}' returned no ephemeral client secret for the realtime session.");
+        }
+
+        _logger.LogDebug(
+            "Brokered realtime provider ephemeral credential for session {SessionId} via NyxID service {ServiceSlug}.",
+            sessionKey.SessionId,
+            _options.ServiceSlug);
+        return ephemeral;
+    }
+
+    // OpenAI GA POST /v1/realtime/client_secrets returns { "value": "ek_...", "expires_at": ... };
+    // the older beta POST /v1/realtime/sessions nests it under { "client_secret": { "value": ... } }.
+    private static string? ExtractEphemeralSecret(string responseJson)
+    {
+        if (string.IsNullOrWhiteSpace(responseJson))
+            return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(responseJson);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+                return null;
+
+            if (root.TryGetProperty("value", out var value) && value.ValueKind == JsonValueKind.String)
+                return value.GetString();
+
+            if (root.TryGetProperty("client_secret", out var clientSecret) &&
+                clientSecret.ValueKind == JsonValueKind.Object &&
+                clientSecret.TryGetProperty("value", out var nestedValue) &&
+                nestedValue.ValueKind == JsonValueKind.String)
+            {
+                return nestedValue.GetString();
+            }
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        return null;
+    }
+}

--- a/src/Aevatar.Bootstrap.Extensions.AI/NyxIdRealtimeProviderCredentialResolver.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/NyxIdRealtimeProviderCredentialResolver.cs
@@ -121,9 +121,10 @@ public sealed class NyxIdRealtimeProviderCredentialResolver : IRealtimeProviderC
                 return nestedValue.GetString();
             }
         }
-        catch (JsonException)
+        catch (JsonException ex)
         {
-            return null;
+            throw new RealtimeProviderCredentialException(
+                "NyxID realtime credential mint returned a non-JSON response.", ex);
         }
 
         return null;

--- a/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
@@ -165,6 +165,16 @@ public static class ServiceCollectionExtensions
         if (registrations.Count == 0)
             return;
 
+        // Refactor (cluster-voice-nyxid-ephemeral-broker): when the OpenAI realtime credential is
+        // brokered through NyxID, register the resolver so the provider mints a per-session ephemeral
+        // instead of reading a static OPENAI_API_KEY. Requires NyxID tools (INyxIdApiClientFactory) wired.
+        var nyxIdRealtimeCredentialOptions = BuildNyxIdRealtimeCredentialOptions(configuration);
+        if (nyxIdRealtimeCredentialOptions.Enabled)
+        {
+            services.TryAddSingleton(nyxIdRealtimeCredentialOptions);
+            services.TryAddSingleton<IRealtimeProviderCredentialResolver, NyxIdRealtimeProviderCredentialResolver>();
+        }
+
         services.TryAddSingleton<IVoicePresenceCapabilityQueryPort, VoicePresenceCapabilityQueryPort>();
         services.TryAddSingleton<IVoicePresenceSessionLeasePort, VoicePresenceSessionLeasePort>();
         services.TryAddSingleton<IVoicePresenceTransportAttachmentPort, VoicePresenceTransportAttachmentPort>();
@@ -220,12 +230,13 @@ public static class ServiceCollectionExtensions
         var voiceOptions = options.VoicePresence;
         var openAIProviderConfig = BuildOpenAIVoiceProviderConfig(configuration, options);
         var miniCpmProviderConfig = BuildMiniCpmVoiceProviderConfig(configuration, options);
+        var nyxIdRealtimeBrokerEnabled = IsNyxIdRealtimeBrokerEnabled(configuration);
         var resolvedDefaultProvider = ResolveVoicePresenceDefaultProvider(
             voiceOptions.DefaultProvider,
             openAIProviderConfig,
             miniCpmProviderConfig);
 
-        if (IsOpenAIVoiceConfigured(openAIProviderConfig))
+        if (IsOpenAIVoiceConfigured(openAIProviderConfig) || nyxIdRealtimeBrokerEnabled)
         {
             registrations.Add(new VoicePresenceModuleRegistration(
                 BuildVoicePresenceModuleNames(
@@ -235,7 +246,8 @@ public static class ServiceCollectionExtensions
                 (serviceProvider, resolvedModuleName) => new VoicePresenceModule(
                     new OpenAIRealtimeProvider(
                         voiceOptions.OpenAIProviderOptions,
-                        serviceProvider.GetService<ILogger<OpenAIRealtimeProvider>>()),
+                        serviceProvider.GetService<ILogger<OpenAIRealtimeProvider>>(),
+                        serviceProvider.GetService<IRealtimeProviderCredentialResolver>()),
                     openAIProviderConfig.Clone(),
                     BuildOpenAIVoiceSessionConfig(configuration, options),
                     CloneVoicePresenceModuleOptions(voiceOptions.Module, resolvedModuleName),
@@ -246,7 +258,8 @@ public static class ServiceCollectionExtensions
                     handle,
                     new OpenAIRealtimeProvider(
                         voiceOptions.OpenAIProviderOptions,
-                        serviceProvider.GetService<ILogger<OpenAIRealtimeProvider>>()),
+                        serviceProvider.GetService<ILogger<OpenAIRealtimeProvider>>(),
+                        serviceProvider.GetService<IRealtimeProviderCredentialResolver>()),
                     openAIProviderConfig.Clone(),
                     BuildOpenAIVoiceSessionConfig(configuration, options),
                     serviceProvider.GetService<IVoiceToolCatalog>(),
@@ -394,6 +407,28 @@ public static class ServiceCollectionExtensions
             names.Add(providerName == "openai" ? "voice_presence_openai" : "voice_presence_minicpm");
 
         return names.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+    }
+
+    private static bool IsNyxIdRealtimeBrokerEnabled(IConfiguration configuration) =>
+        !string.IsNullOrWhiteSpace(configuration["Aevatar:VoicePresence:OpenAI:Nyxid:ServiceSlug"]);
+
+    private static NyxIdRealtimeProviderCredentialOptions BuildNyxIdRealtimeCredentialOptions(
+        IConfiguration configuration)
+    {
+        var options = new NyxIdRealtimeProviderCredentialOptions
+        {
+            ServiceSlug = configuration["Aevatar:VoicePresence:OpenAI:Nyxid:ServiceSlug"]?.Trim() ?? string.Empty,
+        };
+
+        var mintPath = configuration["Aevatar:VoicePresence:OpenAI:Nyxid:MintPath"];
+        if (!string.IsNullOrWhiteSpace(mintPath))
+            options.MintPath = mintPath.Trim();
+
+        var model = configuration["Aevatar:VoicePresence:OpenAI:Nyxid:Model"];
+        if (!string.IsNullOrWhiteSpace(model))
+            options.Model = model.Trim();
+
+        return options;
     }
 
     private static VoiceProviderConfig BuildOpenAIVoiceProviderConfig(

--- a/src/Aevatar.Foundation.VoicePresence.Abstractions/IRealtimeProviderCredentialResolver.cs
+++ b/src/Aevatar.Foundation.VoicePresence.Abstractions/IRealtimeProviderCredentialResolver.cs
@@ -1,0 +1,43 @@
+namespace Aevatar.Foundation.VoicePresence.Abstractions;
+
+/// <summary>
+/// Resolves the realtime provider API credential at connect time instead of
+/// reading a static key from configuration. Lets a deployment broker a
+/// short-lived provider secret (e.g. an OpenAI Realtime ephemeral client
+/// secret minted through NyxID) per session, so no long-lived provider key is
+/// held by aevatar grain/config state (zero-secret-material; see ADR-0018 and
+/// ADR-0033).
+/// </summary>
+// Refactor (cluster-voice-nyxid-ephemeral-broker):
+//   Old pattern: VoiceProviderConfig.ApiKey carried a static OPENAI_API_KEY loaded from host config/env;
+//     IsOpenAIVoiceConfigured gated registration on that static key being present.
+//   New principle: the long-lived provider key lives only in the credential broker (NyxID); the realtime
+//     provider credential is resolved per connect into a short-lived ephemeral, and aevatar connects
+//     directly to the provider with it. NyxID is never in the audio hot path (ADR-013).
+public interface IRealtimeProviderCredentialResolver
+{
+    /// <summary>
+    /// Returns the effective provider API key for this session, or <c>null</c>
+    /// to fall back to <see cref="VoiceProviderConfig.ApiKey" /> (static-key /
+    /// local-dev path). The returned key is short-lived and used only to open
+    /// the provider connection; it is never persisted.
+    /// </summary>
+    /// <exception cref="RealtimeProviderCredentialException">
+    /// Thrown when brokering was attempted (a caller credential was present)
+    /// but minting failed. Broker mode does not silently fall back to a
+    /// missing static key.
+    /// </exception>
+    Task<string?> ResolveApiKeyAsync(
+        VoiceProviderSessionKey sessionKey,
+        VoiceProviderConfig config,
+        CancellationToken ct);
+}
+
+/// <summary>Raised when realtime provider credential brokering was attempted and failed.</summary>
+public sealed class RealtimeProviderCredentialException : Exception
+{
+    public RealtimeProviderCredentialException(string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Aevatar.Foundation.VoicePresence.OpenAI/OpenAIRealtimeProvider.cs
+++ b/src/Aevatar.Foundation.VoicePresence.OpenAI/OpenAIRealtimeProvider.cs
@@ -27,28 +27,33 @@ public sealed class OpenAIRealtimeProvider : IRealtimeVoiceProvider
 
     private readonly IOpenAIRealtimeSessionFactory _sessionFactory;
     private readonly OpenAIRealtimeProviderOptions _options;
+    private readonly IRealtimeProviderCredentialResolver? _credentialResolver;
     private readonly ILogger _logger;
 
     private bool _disposed;
 
     public OpenAIRealtimeProvider(
         OpenAIRealtimeProviderOptions? options = null,
-        ILogger<OpenAIRealtimeProvider>? logger = null)
+        ILogger<OpenAIRealtimeProvider>? logger = null,
+        IRealtimeProviderCredentialResolver? credentialResolver = null)
         : this(
             new OpenAIRealtimeSessionFactory(),
             options ?? new OpenAIRealtimeProviderOptions(),
-            logger ?? NullLogger<OpenAIRealtimeProvider>.Instance)
+            logger ?? NullLogger<OpenAIRealtimeProvider>.Instance,
+            credentialResolver)
     {
     }
 
     internal OpenAIRealtimeProvider(
         IOpenAIRealtimeSessionFactory sessionFactory,
         OpenAIRealtimeProviderOptions options,
-        ILogger logger)
+        ILogger logger,
+        IRealtimeProviderCredentialResolver? credentialResolver = null)
     {
         _sessionFactory = sessionFactory ?? throw new ArgumentNullException(nameof(sessionFactory));
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _credentialResolver = credentialResolver;
     }
 
     public async Task<RealtimeVoiceProviderSession> ConnectAsync(
@@ -62,9 +67,11 @@ public sealed class OpenAIRealtimeProvider : IRealtimeVoiceProvider
         ArgumentNullException.ThrowIfNull(config);
         ArgumentNullException.ThrowIfNull(eventSink);
         ArgumentNullException.ThrowIfNull(audioSink);
-        ValidateProviderConfig(config);
 
-        var session = await _sessionFactory.StartConversationSessionAsync(config, _options.DefaultModel, ct);
+        var effectiveConfig = await ResolveEffectiveConfigAsync(sessionKey, config, ct);
+        ValidateProviderConfig(effectiveConfig);
+
+        var session = await _sessionFactory.StartConversationSessionAsync(effectiveConfig, _options.DefaultModel, ct);
         var providerSession = new OpenAIRealtimeProviderSession(sessionKey, session, this, _logger, eventSink, audioSink);
         providerSession.Start();
         return providerSession;
@@ -289,6 +296,28 @@ public sealed class OpenAIRealtimeProvider : IRealtimeVoiceProvider
         }
 
         return requested;
+    }
+
+    // Refactor (cluster-voice-nyxid-ephemeral-broker):
+    //   Old pattern: config.ApiKey was a static OPENAI_API_KEY loaded from host config/env and used as-is.
+    //   New principle: when a credential resolver is wired (NyxID broker mode), resolve a short-lived
+    //     ephemeral key per connect; otherwise fall back to the static config key (local/direct dev).
+    //   The resolved key only opens the provider connection and is never persisted.
+    private async Task<VoiceProviderConfig> ResolveEffectiveConfigAsync(
+        VoiceProviderSessionKey sessionKey,
+        VoiceProviderConfig config,
+        CancellationToken ct)
+    {
+        if (_credentialResolver is null)
+            return config;
+
+        var resolvedApiKey = await _credentialResolver.ResolveApiKeyAsync(sessionKey, config, ct);
+        if (string.IsNullOrWhiteSpace(resolvedApiKey))
+            return config;
+
+        var effective = config.Clone();
+        effective.ApiKey = resolvedApiKey;
+        return effective;
     }
 
     private static void ValidateProviderConfig(VoiceProviderConfig config)

--- a/src/Aevatar.Mainnet.Host.Api/Voice/PolicyAwareVoiceEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Voice/PolicyAwareVoiceEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Authentication.Abstractions;
 using Aevatar.ChatRouting.Abstractions;
 using Aevatar.ChatRouting.Core;
@@ -165,7 +166,15 @@ public static class PolicyAwareVoiceEndpoints
                 throw;
             }
 
-            await mediaStreamPort.AttachAsync(accepted.LeaseHandle, transport, http.RequestAborted);
+            // Refactor (cluster-voice-nyxid-ephemeral-broker): the realtime provider connect runs
+            // in-process inside AttachAsync, so the caller's NyxID bearer (already validated by the
+            // JWT handler) flows via AsyncLocal to the NyxID credential resolver, which mints the
+            // provider ephemeral on the caller's identity. The token is never persisted.
+            using (AgentToolContextScope.Push(BuildVoiceCallerToolContext(http)))
+            {
+                await mediaStreamPort.AttachAsync(accepted.LeaseHandle, transport, http.RequestAborted);
+            }
+
             attached = true;
             await WaitUntilClosedAsync(transport, http.RequestAborted);
         }
@@ -185,6 +194,35 @@ public static class PolicyAwareVoiceEndpoints
             if (attached)
                 await mediaStreamPort.DetachAsync(accepted.LeaseHandle, transport, http.RequestAborted);
         }
+    }
+
+    // Caller credential for realtime provider brokering: the NyxID resolver reads
+    // AgentToolRequestContext.NyxIdAccessToken to mint the provider ephemeral on the caller's
+    // identity. Sourced from the same places the JWT bearer handler accepts for /ws/voice.
+    private static AgentToolExecutionContext BuildVoiceCallerToolContext(HttpContext http)
+    {
+        var bearer = ExtractCallerBearer(http);
+        return string.IsNullOrWhiteSpace(bearer)
+            ? AgentToolExecutionContext.Empty
+            : AgentToolExecutionContext.Empty with
+            {
+                Credentials = new AgentToolCredentials(bearer, null, null),
+            };
+    }
+
+    private static string? ExtractCallerBearer(HttpContext http)
+    {
+        var header = http.Request.Headers.Authorization.ToString();
+        const string bearerPrefix = "Bearer ";
+        if (header.StartsWith(bearerPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            var token = header[bearerPrefix.Length..].Trim();
+            if (!string.IsNullOrWhiteSpace(token))
+                return token;
+        }
+
+        var queryToken = http.Request.Query["access_token"].ToString();
+        return string.IsNullOrWhiteSpace(queryToken) ? null : queryToken.Trim();
     }
 
     private static async Task<VoiceRealtimeSessionAccepted?> WriteNonAcceptedResolutionAsync(

--- a/test/Aevatar.Bootstrap.Tests/Aevatar.Bootstrap.Tests.csproj
+++ b/test/Aevatar.Bootstrap.Tests/Aevatar.Bootstrap.Tests.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\..\src\Aevatar.Authentication.Providers.NyxId\Aevatar.Authentication.Providers.NyxId.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.AI.Abstractions\Aevatar.AI.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.AI.ToolProviders.MCP\Aevatar.AI.ToolProviders.MCP.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.AI.ToolProviders.NyxId\Aevatar.AI.ToolProviders.NyxId.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.AI.ToolProviders.Skills\Aevatar.AI.ToolProviders.Skills.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.AI.LLMProviders.NyxId\Aevatar.AI.LLMProviders.NyxId.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.Configuration\Aevatar.Configuration.csproj" />

--- a/test/Aevatar.Bootstrap.Tests/NyxIdRealtimeProviderCredentialResolverTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/NyxIdRealtimeProviderCredentialResolverTests.cs
@@ -1,0 +1,161 @@
+using System.Net;
+using System.Reflection;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.Bootstrap.Extensions.AI;
+using Aevatar.Foundation.VoicePresence.Abstractions;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.Bootstrap.Tests;
+
+public sealed class NyxIdRealtimeProviderCredentialResolverTests
+{
+    private static readonly VoiceProviderSessionKey SessionKey =
+        new("session-1", "owner-1", "transport-1", 1);
+
+    private static VoiceProviderConfig Config() =>
+        new() { ProviderName = "openai", Model = "gpt-realtime" };
+
+    [Fact]
+    public async Task ResolveApiKey_with_caller_token_mints_ga_shape_ephemeral_on_caller_identity()
+    {
+        var resolver = CreateResolver("""{"value":"ek_ga_123","expires_at":1781534157}""", out var handler);
+
+        string? result;
+        using (AgentToolContextScope.Push(ContextWithToken("caller-jwt")))
+        {
+            result = await resolver.ResolveApiKeyAsync(SessionKey, Config(), CancellationToken.None);
+        }
+
+        result.Should().Be("ek_ga_123");
+        handler.RequestCount.Should().Be(1);
+        handler.LastRequestPath.Should().EndWith("/api/v1/proxy/s/openai-realtime/v1/realtime/client_secrets");
+        handler.LastAuthorization.Should().Be("Bearer caller-jwt");
+    }
+
+    [Fact]
+    public async Task ResolveApiKey_supports_legacy_client_secret_shape()
+    {
+        var resolver = CreateResolver("""{"client_secret":{"value":"ek_beta_456","expires_at":1}}""", out _);
+
+        using var scope = AgentToolContextScope.Push(ContextWithToken("caller-jwt"));
+        var result = await resolver.ResolveApiKeyAsync(SessionKey, Config(), CancellationToken.None);
+
+        result.Should().Be("ek_beta_456");
+    }
+
+    [Fact]
+    public async Task ResolveApiKey_without_caller_token_returns_null_and_does_not_call_nyxid()
+    {
+        var resolver = CreateResolver("""{"value":"ek_unused"}""", out var handler);
+
+        // No AgentToolContextScope pushed → no caller NyxID token in context.
+        var result = await resolver.ResolveApiKeyAsync(SessionKey, Config(), CancellationToken.None);
+
+        result.Should().BeNull();
+        handler.RequestCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ResolveApiKey_when_response_has_no_ephemeral_throws()
+    {
+        var resolver = CreateResolver("""{"unexpected":true}""", out _);
+
+        using var scope = AgentToolContextScope.Push(ContextWithToken("caller-jwt"));
+        var act = () => resolver.ResolveApiKeyAsync(SessionKey, Config(), CancellationToken.None);
+
+        await act.Should().ThrowAsync<RealtimeProviderCredentialException>();
+    }
+
+    [Fact]
+    public void Broker_is_enabled_only_when_service_slug_configured()
+    {
+        IsBrokerEnabled(BuildConfig(slug: null)).Should().BeFalse();
+        IsBrokerEnabled(BuildConfig(slug: "")).Should().BeFalse();
+        IsBrokerEnabled(BuildConfig(slug: "openai-realtime")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Broker_options_bind_slug_and_defaults_from_configuration()
+    {
+        var options = BuildBrokerOptions(BuildConfig(slug: "openai-realtime"));
+
+        options.ServiceSlug.Should().Be("openai-realtime");
+        options.MintPath.Should().Be("v1/realtime/client_secrets");
+        options.Enabled.Should().BeTrue();
+    }
+
+    private static AgentToolExecutionContext ContextWithToken(string token) =>
+        AgentToolExecutionContext.Empty with
+        {
+            Credentials = new AgentToolCredentials(token, null, null),
+        };
+
+    private static NyxIdRealtimeProviderCredentialResolver CreateResolver(
+        string responseJson,
+        out StubHttpMessageHandler handler)
+    {
+        var capturedHandler = new StubHttpMessageHandler(responseJson);
+        handler = capturedHandler;
+        var factory = new StubClientFactory(() => new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example" },
+            new HttpClient(capturedHandler),
+            logger: null));
+        var options = new NyxIdRealtimeProviderCredentialOptions { ServiceSlug = "openai-realtime" };
+        return new NyxIdRealtimeProviderCredentialResolver(
+            factory,
+            options,
+            NullLogger<NyxIdRealtimeProviderCredentialResolver>.Instance);
+    }
+
+    private static IConfiguration BuildConfig(string? slug)
+    {
+        var values = new Dictionary<string, string?>();
+        if (slug != null)
+            values["Aevatar:VoicePresence:OpenAI:Nyxid:ServiceSlug"] = slug;
+        return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+    }
+
+    private static bool IsBrokerEnabled(IConfiguration configuration)
+    {
+        var method = typeof(Aevatar.Bootstrap.Extensions.AI.ServiceCollectionExtensions).GetMethod(
+            "IsNyxIdRealtimeBrokerEnabled",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (bool)method.Invoke(null, [configuration])!;
+    }
+
+    private static NyxIdRealtimeProviderCredentialOptions BuildBrokerOptions(IConfiguration configuration)
+    {
+        var method = typeof(Aevatar.Bootstrap.Extensions.AI.ServiceCollectionExtensions).GetMethod(
+            "BuildNyxIdRealtimeCredentialOptions",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (NyxIdRealtimeProviderCredentialOptions)method.Invoke(null, [configuration])!;
+    }
+
+    private sealed class StubClientFactory(Func<NyxIdApiClient> create) : INyxIdApiClientFactory
+    {
+        public NyxIdApiClient CreateClient() => create();
+    }
+
+    private sealed class StubHttpMessageHandler(string responseJson) : HttpMessageHandler
+    {
+        public int RequestCount { get; private set; }
+        public string? LastRequestPath { get; private set; }
+        public string? LastAuthorization { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            LastRequestPath = request.RequestUri?.AbsolutePath;
+            LastAuthorization = request.Headers.Authorization?.ToString();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseJson),
+            });
+        }
+    }
+}

--- a/test/Aevatar.Foundation.VoicePresence.OpenAI.Tests/OpenAIRealtimeProviderTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.OpenAI.Tests/OpenAIRealtimeProviderTests.cs
@@ -571,6 +571,69 @@ public class OpenAIRealtimeProviderTests
         callCount.ShouldBeGreaterThanOrEqualTo(3);
     }
 
+    [Fact]
+    public async Task Connect_uses_resolver_provided_ephemeral_key_over_static_config()
+    {
+        var session = new FakeSession();
+        var factory = new FakeSessionFactory(session);
+        var provider = new OpenAIRealtimeProvider(
+            factory,
+            new OpenAIRealtimeProviderOptions(),
+            NullLogger<OpenAIRealtimeProvider>.Instance,
+            new StubCredentialResolver("ek_session_123"));
+
+        await using var providerSession = await provider.ConnectAsync(
+            new VoiceProviderSessionKey("session-1", "owner-1", "transport-1", 1),
+            new VoiceProviderConfig { ProviderName = "openai", ApiKey = string.Empty, Model = "gpt-realtime" },
+            static (_, _, _) => Task.CompletedTask,
+            static (_, _, _) => Task.CompletedTask,
+            CancellationToken.None);
+
+        factory.LastConfig.ShouldNotBeNull();
+        factory.LastConfig!.ApiKey.ShouldBe("ek_session_123");
+    }
+
+    [Fact]
+    public async Task Connect_without_resolver_uses_static_config_key()
+    {
+        var session = new FakeSession();
+        var factory = new FakeSessionFactory(session);
+        var provider = new OpenAIRealtimeProvider(
+            factory,
+            new OpenAIRealtimeProviderOptions(),
+            NullLogger<OpenAIRealtimeProvider>.Instance);
+
+        await using var providerSession = await provider.ConnectAsync(
+            new VoiceProviderSessionKey("session-1", "owner-1", "transport-1", 1),
+            CreateConfig(),
+            static (_, _, _) => Task.CompletedTask,
+            static (_, _, _) => Task.CompletedTask,
+            CancellationToken.None);
+
+        factory.LastConfig!.ApiKey.ShouldBe("sk-test");
+    }
+
+    [Fact]
+    public async Task Connect_when_resolver_returns_null_falls_back_to_static_config_key()
+    {
+        var session = new FakeSession();
+        var factory = new FakeSessionFactory(session);
+        var provider = new OpenAIRealtimeProvider(
+            factory,
+            new OpenAIRealtimeProviderOptions(),
+            NullLogger<OpenAIRealtimeProvider>.Instance,
+            new StubCredentialResolver(null));
+
+        await using var providerSession = await provider.ConnectAsync(
+            new VoiceProviderSessionKey("session-1", "owner-1", "transport-1", 1),
+            CreateConfig(),
+            static (_, _, _) => Task.CompletedTask,
+            static (_, _, _) => Task.CompletedTask,
+            CancellationToken.None);
+
+        factory.LastConfig!.ApiKey.ShouldBe("sk-test");
+    }
+
     private static OpenAIRealtimeProvider CreateProvider(
         IOpenAIRealtimeSession session,
         OpenAIRealtimeProviderOptions? options = null)
@@ -622,6 +685,15 @@ public class OpenAIRealtimeProviderTests
             },
             ct);
 
+    private sealed class StubCredentialResolver(string? apiKey) : IRealtimeProviderCredentialResolver
+    {
+        public Task<string?> ResolveApiKeyAsync(
+            VoiceProviderSessionKey sessionKey,
+            VoiceProviderConfig config,
+            CancellationToken ct) =>
+            Task.FromResult(apiKey);
+    }
+
     private sealed class FakeSessionFactory : IOpenAIRealtimeSessionFactory
     {
         private readonly IOpenAIRealtimeSession _session;
@@ -631,12 +703,14 @@ public class OpenAIRealtimeProviderTests
             _session = session;
         }
 
+        public VoiceProviderConfig? LastConfig { get; private set; }
+
         public Task<IOpenAIRealtimeSession> StartConversationSessionAsync(
             VoiceProviderConfig config,
             string defaultModel,
             CancellationToken ct)
         {
-            _ = config;
+            LastConfig = config;
             _ = defaultModel;
             _ = ct;
             return Task.FromResult(_session);

--- a/tools/ci/guards/catch_exception_observability_baseline.tsv
+++ b/tools/ci/guards/catch_exception_observability_baseline.tsv
@@ -54,8 +54,8 @@ src/Aevatar.Foundation.VoicePresence/Transport/WebRtcVoiceTransport.cs	111	empty
 src/Aevatar.Foundation.VoicePresence/Transport/WebRtcVoiceTransport.cs	127	empty broad catch block
 src/Aevatar.Foundation.VoicePresence/Transport/WebSocketVoiceTransport.cs	161	empty broad catch block
 src/Aevatar.Foundation.VoicePresence/Transport/WebSocketVoiceTransport.cs	265	empty broad catch block
-src/Aevatar.Mainnet.Host.Api/Voice/PolicyAwareVoiceEndpoints.cs	250	empty broad catch block
-src/Aevatar.Mainnet.Host.Api/Voice/PolicyAwareVoiceEndpoints.cs	276	empty broad catch block
+src/Aevatar.Mainnet.Host.Api/Voice/PolicyAwareVoiceEndpoints.cs	288	empty broad catch block
+src/Aevatar.Mainnet.Host.Api/Voice/PolicyAwareVoiceEndpoints.cs	314	empty broad catch block
 src/Aevatar.Scripting.Core/ScriptEvolutionSessionGAgent.cs	423	empty broad catch block
 src/Aevatar.Scripting.Infrastructure/Compilation/CachedScriptBehaviorArtifactResolver.cs	295	empty broad catch block
 src/Aevatar.Scripting.Infrastructure/Compilation/GrpcToolsScriptProtoCompiler.cs	131	empty broad catch block


### PR DESCRIPTION
## What

Broker the OpenAI Realtime **provider credential** through NyxID as a short-lived
ephemeral, instead of a static `OPENAI_API_KEY` held by aevatar.

## Why

- The voice realtime provider was the **only** path still reading a raw provider
  key — `tool`/LLM calls already broker the per-caller NyxID token. This violated
  the zero-secret-material invariant (#375 / ADR-0018) and the NyxID-broker thesis.
- A prod deployment with no static key registers no voice module at startup, so
  `/ws/voice` falls to the fail-closed stand-in and returns `503 voice_not_configured`.

## How

- `IRealtimeProviderCredentialResolver` resolves the provider API key **per connect**;
  `OpenAIRealtimeProvider` uses it before validation and falls back to the static
  `VoiceProviderConfig.ApiKey` when absent (local/direct dev unchanged).
- `NyxIdRealtimeProviderCredentialResolver` mints an ephemeral (`ek_…`) via the NyxID
  proxy `POST /api/v1/proxy/s/<slug>/v1/realtime/client_secrets` on the **caller's**
  NyxID identity (`AgentToolRequestContext.NyxIdAccessToken`); aevatar then connects
  **directly** to OpenAI with the ephemeral — NyxID never enters the audio hot path (ADR-013).
- The `/ws/voice` handler pushes the validated caller bearer into `AgentToolContextScope`
  around `AttachAsync`. The provider connect runs in-process inside `AttachAsync`, so the
  token flows via AsyncLocal to the resolver and is **never persisted** (no grain/proto state).
- Registration gate: `IsOpenAIVoiceConfigured || Aevatar:VoicePresence:OpenAI:Nyxid:ServiceSlug set`.

Full design + invariant rationale in **ADR-0033**.

## Config

```
Aevatar:VoicePresence:OpenAI:Nyxid:ServiceSlug = openai-realtime
```

NyxID side (operator, real `sk-…` lives only in NyxID — no NyxID code change):

```
nyxid service add --custom --slug openai-realtime --label "OpenAI Realtime" \
  --endpoint-url https://api.openai.com --auth-method bearer
```

## Tests

- `OpenAIRealtimeProviderTests` (+3): resolver-provided key overrides static / no resolver
  uses static / resolver-null falls back to static — **29/29 pass**.
- `NyxIdRealtimeProviderCredentialResolverTests` (new): GA + legacy ephemeral shapes,
  no-caller-token fallback (no NyxID call), mint-with-no-secret throws, broker gate +
  config binding — **6/6 pass**.
- `Bootstrap.Extensions.AI` + `Mainnet.Host.Api` build with 0 errors.

## Not in scope

Voice **tool** calls still don't thread the caller's NyxID credential — they execute on
actor turns where AsyncLocal doesn't flow, so they need a volatile per-lease side-channel
(mirroring `IVoiceVolatileMediaStreamPort`). Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
