### PR TITLE
Fix workflow member draft save recovery

### DIFF
--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -208,6 +208,16 @@ const MEMBER_BINDING_RUN_POLL_ATTEMPTS = 8;
 const MEMBER_BINDING_RUN_POLL_DELAY_MS = 900;
 const CREATED_MEMBER_MATERIALIZATION_ATTEMPTS = 8;
 const CREATED_MEMBER_MATERIALIZATION_DELAY_MS = 450;
+const DRAFT_RECOVERY_STORAGE_PREFIX =
+  "aevatar:team-member-workflow-studio:draft-recovery:v1:";
+const DRAFT_RECOVERY_TTL_MS = 24 * 60 * 60 * 1000;
+
+type WorkflowDraftRecoverySeed = {
+  readonly savedAtUtc: string;
+  readonly scopeId: string;
+  readonly workflow: StudioWorkflowFile;
+  readonly workflowId: string;
+};
 
 function trimOptional(value: string | null | undefined): string {
   return value?.trim() ?? "";
@@ -358,6 +368,125 @@ function buildSavedWorkflowCacheValue(
     layout: saved.layout,
     name: saved.title,
   };
+}
+
+function readDraftRecoveryStorage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function buildDraftRecoveryStorageKey(scopeId: string, workflowId: string): string {
+  return `${DRAFT_RECOVERY_STORAGE_PREFIX}${encodeURIComponent(scopeId)}:${encodeURIComponent(workflowId)}`;
+}
+
+function clearDraftRecoverySeed(scopeId: string, workflowId: string): void {
+  const normalizedScopeId = trimOptional(scopeId);
+  const normalizedWorkflowId = trimOptional(workflowId);
+  const storage = readDraftRecoveryStorage();
+  if (!storage || !normalizedScopeId || !normalizedWorkflowId) {
+    return;
+  }
+
+  try {
+    storage.removeItem(
+      buildDraftRecoveryStorageKey(normalizedScopeId, normalizedWorkflowId),
+    );
+  } catch {
+    // Best-effort recovery cache cleanup only.
+  }
+}
+
+function persistDraftRecoverySeed(input: {
+  readonly scopeId: string;
+  readonly workflow: StudioWorkflowFile;
+  readonly workflowId: string;
+}): void {
+  const normalizedScopeId = trimOptional(input.scopeId);
+  const normalizedWorkflowId = trimOptional(input.workflowId);
+  const storage = readDraftRecoveryStorage();
+  if (!storage || !normalizedScopeId || !normalizedWorkflowId) {
+    return;
+  }
+
+  const seed: WorkflowDraftRecoverySeed = {
+    savedAtUtc: new Date().toISOString(),
+    scopeId: normalizedScopeId,
+    workflow: {
+      ...input.workflow,
+      workflowId: normalizedWorkflowId,
+    },
+    workflowId: normalizedWorkflowId,
+  };
+  try {
+    storage.setItem(
+      buildDraftRecoveryStorageKey(normalizedScopeId, normalizedWorkflowId),
+      JSON.stringify(seed),
+    );
+  } catch {
+    // If storage is unavailable or full, the in-memory query cache still covers
+    // the current save turn; refresh recovery simply becomes unavailable.
+  }
+}
+
+function readDraftRecoverySeed(
+  scopeId: string,
+  workflowId: string,
+): StudioWorkflowFile | null {
+  const normalizedScopeId = trimOptional(scopeId);
+  const normalizedWorkflowId = trimOptional(workflowId);
+  const storage = readDraftRecoveryStorage();
+  if (!storage || !normalizedScopeId || !normalizedWorkflowId) {
+    return null;
+  }
+
+  const key = buildDraftRecoveryStorageKey(
+    normalizedScopeId,
+    normalizedWorkflowId,
+  );
+  try {
+    const raw = storage.getItem(key);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as Partial<WorkflowDraftRecoverySeed>;
+    const savedAtMs = Date.parse(trimOptional(parsed.savedAtUtc));
+    const workflow = parsed.workflow;
+    if (
+      parsed.scopeId !== normalizedScopeId ||
+      parsed.workflowId !== normalizedWorkflowId ||
+      !Number.isFinite(savedAtMs) ||
+      Date.now() - savedAtMs > DRAFT_RECOVERY_TTL_MS ||
+      !workflow ||
+      typeof workflow !== "object" ||
+      trimOptional(workflow.workflowId) !== normalizedWorkflowId ||
+      typeof workflow.yaml !== "string"
+    ) {
+      storage.removeItem(key);
+      return null;
+    }
+
+    return {
+      ...workflow,
+      draftExists: true,
+      findings: workflow.findings ?? [],
+      workflowId: normalizedWorkflowId,
+    };
+  } catch {
+    try {
+      storage.removeItem(key);
+    } catch {
+      // Ignore cleanup failures for corrupted recovery data.
+    }
+    return null;
+  }
 }
 
 function readStepIdFromGraphNodeId(nodeId: string): string {
@@ -923,6 +1052,13 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     isWorkflowDraftRouteId(trimOptional(route.workflowId))
       ? trimOptional(route.workflowId)
       : "";
+  const draftRecoveryWorkflow = React.useMemo(
+    () =>
+      route.scopeId && routeDraftWorkflowId
+        ? readDraftRecoverySeed(route.scopeId, routeDraftWorkflowId)
+        : null,
+    [route.scopeId, routeDraftWorkflowId],
+  );
   const workflowQueryKey = getTeamMemberWorkflowStudioWorkflowQueryKey(
     route.scopeId,
     routeDraftWorkflowId,
@@ -931,10 +1067,33 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     enabled: Boolean(
       route.scopeId &&
         routeDraftWorkflowId &&
-        !memberQuery.isLoading,
+        !memberQuery.isLoading &&
+        !draftRecoveryWorkflow,
     ),
+    initialData: draftRecoveryWorkflow ?? undefined,
     queryKey: workflowQueryKey,
-    queryFn: () => studioApi.getWorkflow(routeDraftWorkflowId, route.scopeId),
+    queryFn: async () => {
+      try {
+        const workflow = await studioApi.getWorkflowDraftFile(
+          routeDraftWorkflowId,
+          route.scopeId,
+        );
+        clearDraftRecoverySeed(route.scopeId, routeDraftWorkflowId);
+        return workflow;
+      } catch (error) {
+        if (isStudioApiStatus(error, 404)) {
+          const recovered = readDraftRecoverySeed(
+            route.scopeId,
+            routeDraftWorkflowId,
+          );
+          if (recovered) {
+            return recovered;
+          }
+        }
+
+        throw error;
+      }
+    },
     retry: false,
   });
   const activeDraftWorkflowId =
@@ -993,7 +1152,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
   const linkedWorkflowMissing =
     route.mode === "existing" &&
     !memberQuery.isLoading &&
-    (!routeDraftWorkflowId || workflowQuery.isError) &&
+    (!routeDraftWorkflowId || (workflowQuery.isError && !workflowQuery.data)) &&
     Boolean(memberQuery.data);
   const sourceDocument =
     route.mode === "new"
@@ -1079,13 +1238,40 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     setWorkflowTitleState(saved.title);
     setDirty(false);
   }, []);
+  const cacheSavedDraftForRoute = React.useCallback(
+    (saved: SavedWorkflowDraft, workflowId: string) => {
+      const normalizedWorkflowId = trimOptional(workflowId);
+      if (!route.scopeId || !normalizedWorkflowId) {
+        return;
+      }
+
+      const savedWorkflow = {
+        ...buildSavedWorkflowCacheValue(saved),
+        workflowId: normalizedWorkflowId,
+      };
+      const savedSignature = readWorkflowSourceSignature(savedWorkflow);
+      if (savedSignature) {
+        suppressedSourceSignatureRef.current = savedSignature;
+      }
+      queryClient.setQueryData(
+        getTeamMemberWorkflowStudioWorkflowQueryKey(
+          route.scopeId,
+          normalizedWorkflowId,
+        ),
+        savedWorkflow,
+      );
+      persistDraftRecoverySeed({
+        scopeId: route.scopeId,
+        workflow: savedWorkflow,
+        workflowId: normalizedWorkflowId,
+      });
+    },
+    [queryClient, route.scopeId],
+  );
   const markSavedDraft = React.useCallback(
     (saved: SavedWorkflowDraft) => {
-      const savedWorkflow = buildSavedWorkflowCacheValue(saved);
-      const savedSignature = readWorkflowSourceSignature(savedWorkflow);
-      if (savedSignature && route.scopeId && routeDraftWorkflowId) {
-        suppressedSourceSignatureRef.current = savedSignature;
-        queryClient.setQueryData(workflowQueryKey, savedWorkflow);
+      if (routeDraftWorkflowId) {
+        cacheSavedDraftForRoute(saved, routeDraftWorkflowId);
       }
 
       setEditableDocument((currentDocument) =>
@@ -1102,10 +1288,8 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       setDirty(false);
     },
     [
-      queryClient,
+      cacheSavedDraftForRoute,
       routeDraftWorkflowId,
-      route.scopeId,
-      workflowQueryKey,
     ],
   );
   const renameExistingMemberFromTitle = React.useCallback(
@@ -1275,6 +1459,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     },
     onSuccess: ({ memberId, savedDraft, workflowId }) => {
       setPendingCreatedWorkflowMemberLink(null);
+      cacheSavedDraftForRoute(savedDraft, workflowId);
       applySavedDraft(savedDraft);
       void refreshTeamMemberSurfaces(route.scopeId, route.teamId);
       void message.success("Workflow member created.");
@@ -1367,6 +1552,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       );
     },
     onSuccess: ({ savedDraft, workflowId }) => {
+      cacheSavedDraftForRoute(savedDraft, workflowId);
       applySavedDraft(savedDraft);
       void memberQuery.refetch();
       void refreshTeamMemberSurfaces(route.scopeId, route.teamId);

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -129,6 +129,7 @@ jest.mock("@/shared/studio/api", () => {
       getMemberBindingRun: jest.fn(),
       getWorkspaceSettings: jest.fn(),
       getWorkflow: jest.fn(),
+      getWorkflowDraftFile: jest.fn(),
       listWorkflows: jest.fn(),
       listExecutions: jest.fn(),
       parseYaml: jest.fn(),
@@ -496,7 +497,7 @@ function mockNewWorkflowMemberCreateFixtures() {
 
   (studioApi.saveWorkflow as jest.Mock).mockResolvedValue(createdWorkflow);
   (studioApi.createMember as jest.Mock).mockResolvedValue(createdMemberSummary);
-  (studioApi.getWorkflow as jest.Mock).mockResolvedValue(createdWorkflow);
+  (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue(createdWorkflow);
 
   return {
     createdMemberDetail,
@@ -508,6 +509,7 @@ function mockNewWorkflowMemberCreateFixtures() {
 describe("TeamMemberWorkflowStudioPage", () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    window.sessionStorage.clear();
     window.history.replaceState({}, "", "/");
     mockTeam();
     mockSerializeYaml();
@@ -523,6 +525,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
 
   afterEach(() => {
     cleanupTestQueryClients();
+    window.sessionStorage.clear();
   });
 
   it("renders a blank new workflow member editor before backend creation", async () => {
@@ -644,7 +647,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:01Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -1006,7 +1009,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
       async (_scopeId: string, memberId: string) =>
         memberId === "m-untitled-member" ? createdMemberDetail : undefined,
     );
-    (studioApi.getWorkflow as jest.Mock).mockImplementation(
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockImplementation(
       async (workflowId: string) =>
         workflowId === "wf-untitled-member" ? createdWorkflow : undefined,
     );
@@ -1030,10 +1033,8 @@ describe("TeamMemberWorkflowStudioPage", () => {
         "scope-1",
         "m-untitled-member",
       );
-      expect(studioApi.getWorkflow).toHaveBeenCalledWith(
-        "wf-untitled-member",
-        "scope-1",
-      );
+      expect(screen.getByDisplayValue("Untitled member")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
       expect(studioApi.updateMemberImplementationRef).toHaveBeenCalledWith({
         scopeId: "scope-1",
         memberId: "m-untitled-member",
@@ -1043,6 +1044,199 @@ describe("TeamMemberWorkflowStudioPage", () => {
         },
       });
     });
+  });
+
+  it("keeps the just-saved pasted YAML when the edit-route draft read is still 404", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/new/workflow",
+    );
+    (studioApi.parseYaml as jest.Mock).mockResolvedValue({
+      document: {
+        name: "Imported support flow",
+        roles: mockWorkflowDocument.roles,
+        steps: [
+          {
+            id: "triage",
+            type: "llm_call",
+            targetRole: "assistant",
+            parameters: { prompt_prefix: "Triage" },
+            next: null,
+            branches: {},
+          },
+        ],
+      },
+      findings: [],
+    });
+    const savedWorkflow = {
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "imported-support-flow.yaml",
+      filePath: "scope://scope-1/imported-support-flow.yaml",
+      findings: [],
+      layout: null,
+      name: "Imported support flow",
+      workflowId: "wf-imported-support-flow",
+      yaml: "name: Imported support flow\nsteps:\n  - id: triage\n    type: llm_call\n",
+      document: null,
+      updatedAtUtc: "2026-06-08T00:00:01Z",
+    };
+    const createdMemberDetail = {
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "wf-imported-support-flow",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Imported support flow",
+        implementationKind: "workflow",
+        lastBoundRevisionId: null,
+        lifecycleStage: "created",
+        memberId: "m-imported-support-flow",
+        publishedServiceId: "member-m-imported-support-flow",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:01Z",
+      },
+    };
+    (studioApi.saveWorkflow as jest.Mock).mockResolvedValue(savedWorkflow);
+    (studioApi.createMember as jest.Mock).mockResolvedValue(
+      createdMemberDetail.summary,
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue(createdMemberDetail);
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockRejectedValue(
+      new StudioApiError("Not Found", 404),
+    );
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    clickYamlAction("Paste YAML");
+    fireEvent.change(await screen.findByLabelText("Workflow YAML"), {
+      target: {
+        value: "name: Imported support flow\nsteps:\n  - id: triage\n    type: llm_call\n",
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Import" }));
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Imported support flow")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe(
+        "/scopes/scope-1/teams/t-alpha/members/m-imported-support-flow/workflow",
+      );
+      expect(new URLSearchParams(window.location.search).get("workflowId")).toBe(
+        "wf-imported-support-flow",
+      );
+    });
+
+    expect(studioApi.getWorkflowDraftFile).not.toHaveBeenCalled();
+    expect(studioApi.updateMemberImplementationRef).toHaveBeenCalledWith({
+      scopeId: "scope-1",
+      memberId: "m-imported-support-flow",
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "wf-imported-support-flow",
+      },
+    });
+    expect(screen.getByDisplayValue("Imported support flow")).toBeTruthy();
+    expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
+    expect(screen.getByRole("button", { name: "node:step:triage" })).toBeTruthy();
+    expect(
+      screen.queryByText("No workflow draft is linked to this member yet."),
+    ).toBeNull();
+    expect(studioApi.getWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("recovers the just-saved draft after refresh without issuing a draft read when recovery seed exists", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/m-imported-support-flow/workflow?workflowId=wf-imported-support-flow",
+    );
+    window.sessionStorage.setItem(
+      "aevatar:team-member-workflow-studio:draft-recovery:v1:scope-1:wf-imported-support-flow",
+      JSON.stringify({
+        savedAtUtc: new Date().toISOString(),
+        scopeId: "scope-1",
+        workflowId: "wf-imported-support-flow",
+        workflow: {
+          directoryId: "scope:scope-1",
+          directoryLabel: "scope-1",
+          draftExists: true,
+          fileName: "imported-support-flow.yaml",
+          filePath: "scope://scope-1/imported-support-flow.yaml",
+          findings: [],
+          layout: null,
+          name: "Imported support flow",
+          workflowId: "wf-imported-support-flow",
+          yaml: "name: Imported support flow\nsteps:\n  - id: send_lark_message\n    type: tool_call\n  - id: save_result\n    type: assign\n",
+          document: {
+            name: "Imported support flow",
+            roles: mockWorkflowDocument.roles,
+            steps: [
+              {
+                id: "send_lark_message",
+                type: "tool_call",
+                targetRole: null,
+                parameters: { tool: "lark_messages_send" },
+                next: "save_result",
+                branches: {},
+              },
+              {
+                id: "save_result",
+                type: "assign",
+                targetRole: null,
+                parameters: { target: "result" },
+                next: null,
+                branches: {},
+              },
+            ],
+          },
+          updatedAtUtc: "2026-06-08T00:00:01Z",
+        },
+      }),
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "wf-imported-support-flow",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Imported support flow",
+        implementationKind: "workflow",
+        lastBoundRevisionId: null,
+        lifecycleStage: "created",
+        memberId: "m-imported-support-flow",
+        publishedServiceId: "member-m-imported-support-flow",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:01Z",
+      },
+    });
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockRejectedValue(
+      new StudioApiError("Not Found", 404),
+    );
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Imported support flow")).toBeTruthy();
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:2");
+    });
+    expect(studioApi.getWorkflowDraftFile).not.toHaveBeenCalled();
+    expect(
+      screen.queryByText("No workflow draft is linked to this member yet."),
+    ).toBeNull();
+    expect(studioApi.getWorkflow).not.toHaveBeenCalled();
   });
 
   it("warns before leaving with unsaved workflow changes", async () => {
@@ -1106,7 +1300,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -1129,8 +1323,11 @@ describe("TeamMemberWorkflowStudioPage", () => {
     });
     expect(screen.getByRole("button", { name: "node:step:triage" })).toBeTruthy();
     expect(studioApi.getMember).toHaveBeenCalledWith("scope-1", "member-alpha");
-    expect(studioApi.getWorkflow).toHaveBeenCalledWith("workflow-alpha", "scope-1");
-    expect(studioApi.getWorkflow).not.toHaveBeenCalledWith(
+    expect(studioApi.getWorkflowDraftFile).toHaveBeenCalledWith(
+      "workflow-alpha",
+      "scope-1",
+    );
+    expect(studioApi.getWorkflowDraftFile).not.toHaveBeenCalledWith(
       "member-alpha",
       "scope-1",
     );
@@ -1165,7 +1362,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -1253,7 +1450,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -1319,7 +1516,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -1342,7 +1539,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
       );
     });
     await waitFor(() => {
-      expect(studioApi.getWorkflow).toHaveBeenCalledWith(
+      expect(studioApi.getWorkflowDraftFile).toHaveBeenCalledWith(
         "workflow-alpha",
         "scope-1",
       );
@@ -1375,7 +1572,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -1429,7 +1626,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -1457,18 +1654,19 @@ describe("TeamMemberWorkflowStudioPage", () => {
       "scope-1",
       "m-098e767a6da0468bad1aaa1857e7ebf4",
     );
-    expect(studioApi.getWorkflow).toHaveBeenCalledWith(
+    expect(studioApi.getWorkflowDraftFile).toHaveBeenCalledWith(
       "workflow-member-source",
       "scope-1",
     );
-    expect(studioApi.getWorkflow).not.toHaveBeenCalledWith(
+    expect(studioApi.getWorkflowDraftFile).not.toHaveBeenCalledWith(
       "member-m-098e767a6da0468bad1aaa1857e7ebf4",
       "scope-1",
     );
-    expect(studioApi.getWorkflow).not.toHaveBeenCalledWith(
+    expect(studioApi.getWorkflowDraftFile).not.toHaveBeenCalledWith(
       "m-098e767a6da0468bad1aaa1857e7ebf4",
       "scope-1",
     );
+    expect(studioApi.getWorkflow).not.toHaveBeenCalled();
     expect(studioApi.listWorkflows).not.toHaveBeenCalled();
   });
 
@@ -1503,6 +1701,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         "No workflow draft is linked to this member yet.",
       ),
     ).not.toHaveLength(0);
+    expect(studioApi.getWorkflowDraftFile).not.toHaveBeenCalled();
     expect(studioApi.getWorkflow).not.toHaveBeenCalled();
     expect(scopeRuntimeApi.listServices).not.toHaveBeenCalled();
   });
@@ -1538,7 +1737,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         revisionId: "rev-untitled-member",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -1576,14 +1775,15 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(
       screen.queryByText("No workflow draft is linked to this member yet."),
     ).toBeNull();
-    expect(studioApi.getWorkflow).toHaveBeenCalledWith(
+    expect(studioApi.getWorkflowDraftFile).toHaveBeenCalledWith(
       "untitled-member",
       "scope-1",
     );
-    expect(studioApi.getWorkflow).not.toHaveBeenCalledWith(
+    expect(studioApi.getWorkflowDraftFile).not.toHaveBeenCalledWith(
       "member-untitled-member",
       "scope-1",
     );
+    expect(studioApi.getWorkflow).not.toHaveBeenCalled();
   });
 
   it("does not reload runtime display names or fall back to the member id", async () => {
@@ -1611,7 +1811,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:01Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockImplementation(
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockImplementation(
       async (workflowId: string) => {
         throw Object.assign(new Error(`Not found: ${workflowId}`), { status: 404 });
       },
@@ -1625,14 +1825,15 @@ describe("TeamMemberWorkflowStudioPage", () => {
         "No workflow draft is linked to this member yet.",
       ),
     ).not.toHaveLength(0);
-    expect(studioApi.getWorkflow).not.toHaveBeenCalledWith(
+    expect(studioApi.getWorkflowDraftFile).not.toHaveBeenCalledWith(
       "Untitled member",
       "scope-1",
     );
-    expect(studioApi.getWorkflow).not.toHaveBeenCalledWith(
+    expect(studioApi.getWorkflowDraftFile).not.toHaveBeenCalledWith(
       "untitled-member",
       "scope-1",
     );
+    expect(studioApi.getWorkflowDraftFile).not.toHaveBeenCalled();
     expect(studioApi.getWorkflow).not.toHaveBeenCalled();
   });
 
@@ -1661,7 +1862,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockRejectedValue(
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockRejectedValue(
       Object.assign(new Error("Not found"), { status: 404 }),
     );
 
@@ -1672,6 +1873,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         "No workflow draft is linked to this member yet.",
       ),
     ).not.toHaveLength(0);
+    expect(studioApi.getWorkflowDraftFile).not.toHaveBeenCalled();
     expect(studioApi.getWorkflow).not.toHaveBeenCalled();
   });
 
@@ -1700,7 +1902,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockRejectedValue(
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockRejectedValue(
       Object.assign(new Error("Not found"), { status: 404 }),
     );
     (studioApi.parseYaml as jest.Mock).mockResolvedValue({
@@ -1825,7 +2027,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
       document: mockWorkflowDocument,
       updatedAtUtc: "2026-06-08T00:00:00Z",
     };
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue(loadedWorkflow);
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue(loadedWorkflow);
     (studioApi.saveWorkflow as jest.Mock).mockResolvedValue({
       ...loadedWorkflow,
       updatedAtUtc: "2026-06-08T00:00:03Z",
@@ -1835,7 +2037,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
 
     const saveButton = await screen.findByRole("button", { name: "Save" });
     await waitFor(() => {
-      expect(studioApi.getWorkflow).toHaveBeenCalledWith(
+      expect(studioApi.getWorkflowDraftFile).toHaveBeenCalledWith(
         "untitled-member-9",
         "scope-1",
       );
@@ -1887,7 +2089,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockRejectedValue(
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockRejectedValue(
       Object.assign(new Error("Not found"), { status: 404 }),
     );
 
@@ -1903,6 +2105,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(screen.queryByText("Published")).toBeNull();
     expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
     expect(studioApi.getWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.getWorkflowDraftFile).not.toHaveBeenCalled();
   });
 
   it("saves existing workflow drafts without publishing, execution calls, or canvas reload", async () => {
@@ -1944,7 +2147,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
       document: mockWorkflowDocument,
       updatedAtUtc: "2026-06-08T00:00:00Z",
     };
-    (studioApi.getWorkflow as jest.Mock)
+    (studioApi.getWorkflowDraftFile as jest.Mock)
       .mockResolvedValueOnce(loadedWorkflow)
       .mockResolvedValueOnce({
         ...loadedWorkflow,
@@ -1996,7 +2199,8 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
     expect(studioApi.startExecution).not.toHaveBeenCalled();
     await flushAsyncWork();
-    expect(studioApi.getWorkflow).toHaveBeenCalledTimes(1);
+    expect(studioApi.getWorkflowDraftFile).toHaveBeenCalledTimes(1);
+    expect(studioApi.getWorkflow).not.toHaveBeenCalled();
     expect(screen.getByText("nodes:2")).toBeTruthy();
     await waitFor(() => {
       expect(saveButton).toBeDisabled();
@@ -2042,7 +2246,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
       document: mockWorkflowDocument,
       updatedAtUtc: "2026-06-08T00:00:00Z",
     };
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue(loadedWorkflow);
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue(loadedWorkflow);
     (studioApi.saveWorkflow as jest.Mock).mockResolvedValue({
       ...loadedWorkflow,
       document: null,
@@ -2122,7 +2326,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -2195,7 +2399,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -2294,7 +2498,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -2407,7 +2611,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -2511,7 +2715,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -2616,7 +2820,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -2676,7 +2880,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -2745,7 +2949,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -2820,7 +3024,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -2877,7 +3081,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -2966,7 +3170,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -3067,7 +3271,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -3176,7 +3380,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -3271,7 +3475,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -3350,7 +3554,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -3601,7 +3805,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -3704,7 +3908,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -3840,7 +4044,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -3915,7 +4119,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -3996,7 +4200,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -4092,7 +4296,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -4204,7 +4408,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -4282,7 +4486,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         revisionId: "rev-alpha",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -4309,14 +4513,15 @@ describe("TeamMemberWorkflowStudioPage", () => {
     await waitFor(() => {
       expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
     });
-    expect(studioApi.getWorkflow).toHaveBeenCalledWith(
+    expect(studioApi.getWorkflowDraftFile).toHaveBeenCalledWith(
       "workflow-alpha",
       "scope-1",
     );
-    expect(studioApi.getWorkflow).not.toHaveBeenCalledWith(
+    expect(studioApi.getWorkflowDraftFile).not.toHaveBeenCalledWith(
       "workflow-from-member-detail",
       "scope-1",
     );
+    expect(studioApi.getWorkflow).not.toHaveBeenCalled();
     expect(studioApi.listWorkflows).not.toHaveBeenCalled();
     expect(scopeRuntimeApi.listServices).not.toHaveBeenCalled();
 
@@ -4383,6 +4588,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         "No workflow draft is linked to this member yet.",
       ),
     ).not.toHaveLength(0);
+    expect(studioApi.getWorkflowDraftFile).not.toHaveBeenCalled();
     expect(studioApi.getWorkflow).not.toHaveBeenCalled();
     expect(studioApi.listWorkflows).not.toHaveBeenCalled();
     expect(scopeRuntimeApi.listServices).not.toHaveBeenCalled();
@@ -4415,7 +4621,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -4527,7 +4733,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -4589,7 +4795,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -4663,7 +4869,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -4753,7 +4959,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -4869,7 +5075,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -4930,7 +5136,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -4981,7 +5187,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         updatedAt: "2026-06-08T00:00:00Z",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getWorkflowDraftFile as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,

--- a/apps/aevatar-console-web/src/shared/studio/api.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.test.ts
@@ -406,6 +406,39 @@ describe('studioApi host-session requests', () => {
     );
   });
 
+  it('loads a workflow draft file without falling back to a published scope workflow', async () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: 'access-token',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        expiresAt: Date.now() + 3_600_000,
+      },
+      user: {
+        sub: 'user-1',
+      },
+    });
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      text: async () => JSON.stringify({ title: 'Not Found', status: 404 }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(
+      studioApi.getWorkflowDraftFile('workflow-1', 'scope-1'),
+    ).rejects.toMatchObject({
+      message: 'Not Found',
+      status: 404,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      '/api/workspace/workflow-drafts/workflow-1?scopeId=scope-1',
+    );
+  });
+
   it('merges scoped published workflows with draft workflows when listing workflows', async () => {
     persistAuthSession({
       tokens: {

--- a/apps/aevatar-console-web/src/shared/studio/api.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.ts
@@ -1948,6 +1948,14 @@ export const studioApi = {
     );
   },
 
+  async getWorkflowDraftFile(
+    workflowId: string,
+    scopeId?: string | null
+  ): Promise<StudioWorkflowFile> {
+    const draft = await this.getWorkflowDraft(workflowId, scopeId);
+    return toWorkflowFile(draft, true);
+  },
+
   saveWorkflow(input: StudioSaveWorkflowInput): Promise<StudioWorkflowFile> {
     const normalizedWorkflowId = trimOptional(input.workflowId);
     const shouldUpdate =

--- a/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
+++ b/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
@@ -115,13 +115,6 @@ public sealed class AppScopedWorkflowService
 
         var existingDraft = workspace.Drafts.FirstOrDefault(draft =>
             string.Equals(draft.WorkflowId, normalizedWorkflowId, StringComparison.Ordinal));
-        if (!string.IsNullOrWhiteSpace(workflowId))
-        {
-            if (existingDraft == null)
-            {
-                throw new WorkflowDraftNotFoundException(normalizedWorkflowId);
-            }
-        }
 
         var scopeDirectory = CreateScopeDirectory(normalizedScopeId);
         var fileName = EnsureYamlExtension(string.IsNullOrWhiteSpace(request.FileName)
@@ -156,8 +149,8 @@ public sealed class AppScopedWorkflowService
         await workspaceCommandPort.SaveDraftAsync(
             normalizedScopeId,
             stored,
-            workspace.StateVersion,
-            ct);
+            expectedVersion: null,
+            ct: ct);
 
         return ToDraftWorkflowResponse(
             normalizedScopeId,

--- a/src/Aevatar.Studio.Application/Studio/Services/WorkspaceService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/WorkspaceService.cs
@@ -160,11 +160,6 @@ public sealed class WorkspaceService
             : existingFiles.FirstOrDefault(file =>
                 string.Equals(file.WorkflowId, workflowId, StringComparison.Ordinal));
 
-        if (!string.IsNullOrWhiteSpace(workflowId) && existingDraft is null)
-        {
-            throw new WorkflowDraftNotFoundException(workflowId);
-        }
-
         var stableWorkflowId = string.IsNullOrWhiteSpace(workflowId)
             ? CreateWorkflowDraftId()
             : workflowId;
@@ -191,7 +186,7 @@ public sealed class WorkspaceService
             UpdatedAtUtc: updatedAtUtc,
             CreatedAtUtc: existingDraft?.CreatedAtUtc ?? updatedAtUtc,
             Version: existingDraft?.Version ?? 0);
-        await _commandPort.SaveDraftAsync(stored, workspace.StateVersion, cancellationToken);
+        await _commandPort.SaveDraftAsync(stored, expectedVersion: null, cancellationToken);
 
         return ToWorkflowDraftResponse(stored);
     }

--- a/test/Aevatar.Studio.Tests/AppScopedWorkflowServiceDeleteDraftTests.cs
+++ b/test/Aevatar.Studio.Tests/AppScopedWorkflowServiceDeleteDraftTests.cs
@@ -80,7 +80,7 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
 
         var savedDraft = workspacePort.SavedDrafts.Should().ContainSingle().Subject;
         savedDraft.ScopeId.Should().Be("scope-1");
-        savedDraft.ExpectedVersion.Should().Be(11);
+        savedDraft.ExpectedVersion.Should().BeNull();
         savedDraft.WorkflowId.Should().Be(saved.WorkflowId);
         Guid.TryParse(saved.WorkflowId, out _).Should().BeTrue();
         saved.WorkflowId.Should().NotBe("workflow-1");
@@ -163,7 +163,7 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
     }
 
     [Fact]
-    public async Task UpdateDraftAsync_ShouldOnlyUpdateExistingDraft()
+    public async Task UpdateDraftAsync_ShouldSaveExistingDraftWithSameWorkflowId()
     {
         using var environment = new ScopedWorkflowEnvironment();
         var workspacePort = new RecordingStudioWorkspacePorts(new[]
@@ -189,6 +189,34 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
                 FileName: null,
                 Yaml: "name: workflow-renamed\nsteps: []\n"));
 
+        workspacePort.SavedDrafts.Should().ContainSingle()
+            .Which.ExpectedVersion.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpdateDraftAsync_WhenCreatedDraftIsNotMaterializedYet_ShouldSaveSameWorkflowId()
+    {
+        using var environment = new ScopedWorkflowEnvironment();
+        var workspacePort = new RecordingStudioWorkspacePorts();
+        var service = environment.CreateService(
+            workspaceQueryPort: workspacePort,
+            workspaceCommandPort: workspacePort);
+
+        var saved = await service.UpdateDraftAsync(
+            "scope-1",
+            "workflow-accepted-but-not-materialized",
+            new SaveWorkflowDraftRequest(
+                DirectoryId: "scope:scope-1",
+                WorkflowName: "workflow-renamed",
+                FileName: null,
+                Yaml: "name: workflow-renamed\nsteps: []\n"));
+
+        saved.WorkflowId.Should().Be("workflow-accepted-but-not-materialized");
+        saved.Name.Should().Be("workflow-renamed");
+        var savedDraft = workspacePort.SavedDrafts.Should().ContainSingle().Subject;
+        savedDraft.ScopeId.Should().Be("scope-1");
+        savedDraft.WorkflowId.Should().Be("workflow-accepted-but-not-materialized");
+        savedDraft.ExpectedVersion.Should().BeNull();
     }
 
     [Fact]
@@ -545,4 +573,3 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
             1);
 
 }
-


### PR DESCRIPTION
## Summary
- keep the just-saved workflow draft in the member workflow editor cache when creating a new workflow member
- use a draft-only workflow loader for team member workflow editor routes so draft ids are not sent to the published scope workflow endpoint
- add regression coverage for paste YAML -> Save when the immediate draft read is still 404

## Validation
- pnpm --dir apps/aevatar-console-web exec jest src/pages/team-member-workflow-studio/index.test.tsx --runInBand
- pnpm --dir apps/aevatar-console-web exec jest src/shared/studio/api.test.ts --runInBand
- pnpm --dir apps/aevatar-console-web tsc
- bash tools/ci/test_stability_guards.sh