### PR TITLE
feat(workflow): saga reverse-compensation orchestration (ADR-0034 step 3) · #2097

### DIFF
--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -851,6 +851,7 @@ message CompensationRequestEvent
   string compensation_step_id = 3;
   string idempotency_key = 4;
   string captured_output = 5;
+  string execution_id = 6;
 }
 
 message CompensationStepCompletedEvent
@@ -859,6 +860,7 @@ message CompensationStepCompletedEvent
   string compensation_step_id = 2;
   bool success = 3;
   string error = 4;
+  string execution_id = 5;
 }
 
 message WorkflowCompensationCompletedEvent

--- a/src/workflow/Aevatar.Workflow.Core/Execution/IWorkflowExecutionStateHost.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/IWorkflowExecutionStateHost.cs
@@ -2,6 +2,25 @@ using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.Workflow.Core.Execution;
 
+internal enum WorkflowCompensationTransitionStatus
+{
+    Started,
+    AlreadyCompensating,
+    NoCompensableLedger,
+    AdvancedAndRequestedNext,
+    CompletedAll,
+    RejectedStaleOrDuplicate,
+    FailedSeam,
+}
+
+internal readonly record struct WorkflowCompensationTransitionResult(
+    WorkflowCompensationTransitionStatus Status,
+    string NextCompensationStepId,   // empty when no next request should be sent
+    string IdempotencyKey,
+    string CapturedOutput,
+    int CompensationCursor,
+    string ExecutionId);
+
 // Refactor (iter115/cluster-3):
 //   Old pattern: WorkflowRunGAgent exposed only a process-local runtime context,
 //                so durable control/security facts could not survive replay.
@@ -35,6 +54,26 @@ internal interface IWorkflowExecutionStateHost
     Task ClearExecutionStateAsync(
         string scopeKey,
         CancellationToken ct = default);
+
+    Task<WorkflowCompensationTransitionResult> TryStartCompensationAsync(
+        WorkflowCompletedEvent terminalFailure, CancellationToken ct = default) =>
+        Task.FromResult(new WorkflowCompensationTransitionResult(
+            WorkflowCompensationTransitionStatus.NoCompensableLedger,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            0,
+            string.Empty));
+
+    Task<WorkflowCompensationTransitionResult> RecordCompensationStepCompletionAsync(
+        CompensationStepCompletedEvent completion, CancellationToken ct = default) =>
+        Task.FromResult(new WorkflowCompensationTransitionResult(
+            WorkflowCompensationTransitionStatus.NoCompensableLedger,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            0,
+            string.Empty));
 }
 
 internal interface IWorkflowExecutionStateHostAccessor

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
@@ -42,6 +42,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
         return payload != null &&
                (payload.Is(StartWorkflowEvent.Descriptor) ||
                 payload.Is(CompensationRequestEvent.Descriptor) ||
+                payload.Is(CompensationStepCompletedEvent.Descriptor) ||
                 payload.Is(StepCompletedEvent.Descriptor) ||
                 payload.Is(WorkflowStoppedEvent.Descriptor) ||
                 payload.Is(WorkflowStepTimeoutFiredEvent.Descriptor) ||
@@ -82,6 +83,12 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
         if (payload.Is(WorkflowStoppedEvent.Descriptor))
         {
             await HandleWorkflowStoppedAsync(payload.Unpack<WorkflowStoppedEvent>(), workflowContext, ct);
+            return;
+        }
+
+        if (payload.Is(CompensationStepCompletedEvent.Descriptor))
+        {
+            await HandleCompensationStepCompletedAsync(payload.Unpack<CompensationStepCompletedEvent>(), workflowContext, ct);
             return;
         }
 
@@ -132,6 +139,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
         state.RetryBackoffsByStepId.Clear();
         state.ExecutionIdsByStepId.Clear();
         state.IdempotencyByStepId.Clear();
+        state.CompensationExecutionIdsByStepId.Clear();
         state.Usage = new WorkflowUsageMetricsState();
         state.CurrentStepDispatchPending = false;
         state.CurrentStepTimeoutCallbackId = string.Empty;
@@ -301,8 +309,12 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
         }
 
         state.ExecutionIdsByStepId.Remove(evt.StepId);
+        var compensationExecutionId = state.CompensationExecutionIdsByStepId.TryGetValue(evt.StepId, out var carriedCompensationExecutionId)
+            ? carriedCompensationExecutionId
+            : string.Empty;
 
         await CancelTimeoutAsync(state, evt.StepId, ctx, ct);
+
         if (!evt.Success && state.RetryBackoffsByStepId.ContainsKey(evt.StepId))
         {
             ctx.Logger.LogDebug(
@@ -314,7 +326,6 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
 
         if (evt.Success)
         {
-            state.IdempotencyByStepId.Remove(evt.StepId);
             await CancelRetryBackoffAsync(state, evt.StepId, ctx, CancellationToken.None);
         }
 
@@ -357,6 +368,15 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
 
         if (!evt.Success)
         {
+            if (!string.IsNullOrWhiteSpace(compensationExecutionId))
+            {
+                if (await TryRetryAsync(current, evt, state, ctx, ct))
+                    return;
+
+                await TryRecordFailedCompensationSeamAsync(evt, compensationExecutionId, state, ctx, ct);
+                return;
+            }
+
             if (IsTimeoutError(evt.Error))
             {
                 ctx.Logger.LogError(
@@ -364,8 +384,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                     runId,
                     evt.StepId,
                     evt.Error);
-                await CleanupRunAsync(state, ctx, ct, preserveTerminalFacts: true, preserveCurrentStepInputVariable: true);
-                await PublishWorkflowCompletedAsync(
+                await TryStartCompensationOrPublishTerminalFailureAsync(
                     ctx,
                     new WorkflowCompletedEvent
                     {
@@ -374,6 +393,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                         Success = false,
                         Error = evt.Error,
                     },
+                    state,
                     ct);
                 return;
             }
@@ -388,8 +408,10 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                 runId,
                 evt.StepId,
                 evt.Error);
-            await CleanupRunAsync(state, ctx, ct, preserveTerminalFacts: true, preserveCurrentStepInputVariable: true);
-            await PublishWorkflowCompletedAsync(
+            if (await TryRecordFailedCompensationSeamAsync(evt, compensationExecutionId, state, ctx, ct))
+                return;
+
+            await TryStartCompensationOrPublishTerminalFailureAsync(
                 ctx,
                 new WorkflowCompletedEvent
                 {
@@ -398,6 +420,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                     Success = false,
                     Error = evt.Error,
                 },
+                state,
                 ct);
             return;
         }
@@ -405,6 +428,9 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
         state.RetryAttemptsByStepId.Remove(evt.StepId);
         state.RetryBackoffsByStepId.Remove(evt.StepId);
         await SaveStateAsync(state, ctx, ct);
+
+        if (await TryRecordSuccessfulCompensationAsync(evt, compensationExecutionId, state, ctx, ct))
+            return;
 
         StepDefinition? next;
         if (!string.IsNullOrWhiteSpace(evt.NextStepId))
@@ -418,8 +444,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                     runId,
                     current.Id,
                     directNextStepId);
-                await CleanupRunAsync(state, ctx, ct, preserveTerminalFacts: true, preserveCurrentStepInputVariable: true);
-                await PublishWorkflowCompletedAsync(
+                await TryStartCompensationOrPublishTerminalFailureAsync(
                     ctx,
                     new WorkflowCompletedEvent
                     {
@@ -428,6 +453,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                         Success = false,
                         Error = $"invalid next_step '{directNextStepId}' from step '{current.Id}'",
                     },
+                    state,
                     ct);
                 return;
             }
@@ -479,6 +505,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                 CompensationStepId = compensationStepId,
                 Success = false,
                 Error = $"compensation step '{compensationStepId}' was not found",
+                ExecutionId = evt.ExecutionId ?? string.Empty,
             }, TopologyAudience.Self, ct);
             return;
         }
@@ -493,13 +520,198 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                 LogicalAttempt = Math.Max(1, state.RetryAttemptsByStepId.GetValueOrDefault(compensationStepId, 0) + 1),
                 IdempotencyKey = evt.IdempotencyKey ?? string.Empty,
             };
-            await SaveStateAsync(state, ctx, ct);
         }
+
+        if (!string.IsNullOrWhiteSpace(evt.ExecutionId))
+            state.CompensationExecutionIdsByStepId[compensationStepId] = evt.ExecutionId.Trim();
+
+        await SaveStateAsync(state, ctx, ct);
 
         var input = string.IsNullOrWhiteSpace(evt.CapturedOutput)
             ? state.CurrentStepInput
             : evt.CapturedOutput;
         await DispatchStepAsync(step, input, state.CurrentStepInputFileRefs, state, ctx, ct);
+    }
+
+    private async Task HandleCompensationStepCompletedAsync(
+        CompensationStepCompletedEvent completion,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var result = await _stateHost.RecordCompensationStepCompletionAsync(completion, ct);
+        await HandleCompensationTransitionAsync(
+            result,
+            completion.RunId,
+            completion.CompensationStepId,
+            completion.Error,
+            ctx,
+            ct);
+    }
+
+    private async Task<bool> TryRecordSuccessfulCompensationAsync(
+        StepCompletedEvent evt,
+        string compensationExecutionId,
+        WorkflowExecutionKernelState state,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var result = await _stateHost.RecordCompensationStepCompletionAsync(new CompensationStepCompletedEvent
+        {
+            RunId = evt.RunId,
+            CompensationStepId = evt.StepId,
+            Success = true,
+            ExecutionId = compensationExecutionId ?? string.Empty,
+        }, ct);
+        if (result.Status != WorkflowCompensationTransitionStatus.NoCompensableLedger &&
+            state.CompensationExecutionIdsByStepId.Remove(evt.StepId))
+        {
+            await SaveStateAsync(state, ctx, ct);
+        }
+
+        return await HandleCompensationTransitionAsync(
+            result,
+            evt.RunId,
+            evt.StepId,
+            evt.Error,
+            ctx,
+            ct);
+    }
+
+    private async Task<bool> TryRecordFailedCompensationSeamAsync(
+        StepCompletedEvent evt,
+        string compensationExecutionId,
+        WorkflowExecutionKernelState state,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var result = await _stateHost.RecordCompensationStepCompletionAsync(new CompensationStepCompletedEvent
+        {
+            RunId = evt.RunId,
+            CompensationStepId = evt.StepId,
+            Success = false,
+            Error = evt.Error ?? string.Empty,
+            ExecutionId = compensationExecutionId ?? string.Empty,
+        }, ct);
+        if (result.Status != WorkflowCompensationTransitionStatus.NoCompensableLedger &&
+            state.CompensationExecutionIdsByStepId.Remove(evt.StepId))
+        {
+            await SaveStateAsync(state, ctx, ct);
+        }
+
+        return await HandleCompensationTransitionAsync(
+            result,
+            evt.RunId,
+            evt.StepId,
+            evt.Error,
+            ctx,
+            ct);
+    }
+
+    private async Task<bool> HandleCompensationTransitionAsync(
+        WorkflowCompensationTransitionResult result,
+        string runId,
+        string currentCompensationStepId,
+        string? error,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        switch (result.Status)
+        {
+            case WorkflowCompensationTransitionStatus.AdvancedAndRequestedNext:
+            case WorkflowCompensationTransitionStatus.Started:
+            case WorkflowCompensationTransitionStatus.AlreadyCompensating:
+                await PublishCompensationRequestAsync(
+                    ctx,
+                    runId,
+                    currentCompensationStepId,
+                    result,
+                    ct);
+                return true;
+            case WorkflowCompensationTransitionStatus.CompletedAll:
+                await CleanupRunAsync(
+                    LoadState(ctx),
+                    ctx,
+                    ct,
+                    preserveTerminalFacts: true,
+                    preserveCurrentStepInputVariable: true);
+                await PublishWorkflowCompletedAsync(
+                    ctx,
+                    new WorkflowCompletedEvent
+                    {
+                        WorkflowName = _workflow.Name,
+                        RunId = NormalizeRunId(runId),
+                        Success = false,
+                        Error = error ?? string.Empty,
+                    },
+                    ct);
+                return true;
+            case WorkflowCompensationTransitionStatus.RejectedStaleOrDuplicate:
+            case WorkflowCompensationTransitionStatus.FailedSeam:
+                return true;
+            case WorkflowCompensationTransitionStatus.NoCompensableLedger:
+                return false;
+            default:
+                return false;
+        }
+    }
+
+    private async Task TryStartCompensationOrPublishTerminalFailureAsync(
+        IWorkflowExecutionContext ctx,
+        WorkflowCompletedEvent terminalFailure,
+        WorkflowExecutionKernelState state,
+        CancellationToken ct)
+    {
+        var result = await _stateHost.TryStartCompensationAsync(terminalFailure, ct);
+        switch (result.Status)
+        {
+            case WorkflowCompensationTransitionStatus.Started:
+            case WorkflowCompensationTransitionStatus.AlreadyCompensating:
+            case WorkflowCompensationTransitionStatus.AdvancedAndRequestedNext:
+                await PublishCompensationRequestAsync(
+                    ctx,
+                    terminalFailure.RunId,
+                    state.CurrentStepId,
+                    result,
+                    ct);
+                return;
+            case WorkflowCompensationTransitionStatus.NoCompensableLedger:
+                await CleanupRunAsync(
+                    state,
+                    ctx,
+                    ct,
+                    preserveTerminalFacts: true,
+                    preserveCurrentStepInputVariable: true);
+                await PublishWorkflowCompletedAsync(ctx, terminalFailure, ct);
+                return;
+            case WorkflowCompensationTransitionStatus.CompletedAll:
+                await PublishWorkflowCompletedAsync(ctx, terminalFailure, ct);
+                return;
+            case WorkflowCompensationTransitionStatus.RejectedStaleOrDuplicate:
+            case WorkflowCompensationTransitionStatus.FailedSeam:
+            default:
+                return;
+        }
+    }
+
+    private static Task PublishCompensationRequestAsync(
+        IWorkflowExecutionContext ctx,
+        string runId,
+        string failedStepId,
+        WorkflowCompensationTransitionResult result,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(result.NextCompensationStepId))
+            return Task.CompletedTask;
+
+        return ctx.PublishAsync(new CompensationRequestEvent
+        {
+            RunId = NormalizeRunId(runId),
+            FailedStepId = failedStepId ?? string.Empty,
+            CompensationStepId = result.NextCompensationStepId,
+            IdempotencyKey = result.IdempotencyKey ?? string.Empty,
+            CapturedOutput = result.CapturedOutput ?? string.Empty,
+            ExecutionId = result.ExecutionId ?? string.Empty,
+        }, TopologyAudience.Self, ct);
     }
 
     private async Task HandleWorkflowStoppedAsync(
@@ -1002,6 +1214,12 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                 x => x.Value.Clone(),
                 StringComparer.Ordinal)
             : [];
+        var terminalCompensationExecutionIds = preserveTerminalFacts
+            ? state.CompensationExecutionIdsByStepId.ToDictionary(
+                x => x.Key,
+                x => x.Value,
+                StringComparer.Ordinal)
+            : [];
 
         state.Active = false;
         state.RunId = string.Empty;
@@ -1022,8 +1240,11 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
         state.RetryBackoffsByStepId.Clear();
         state.ExecutionIdsByStepId.Clear();
         state.IdempotencyByStepId.Clear();
+        state.CompensationExecutionIdsByStepId.Clear();
         foreach (var (key, value) in terminalIdempotency)
             state.IdempotencyByStepId[key] = value;
+        foreach (var (key, value) in terminalCompensationExecutionIds)
+            state.CompensationExecutionIdsByStepId[key] = value ?? string.Empty;
         state.Usage = terminalUsage;
         await SaveStateAsync(state, ctx, ct);
 
@@ -1061,6 +1282,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
             state.RetryBackoffsByStepId.Count == 0 &&
             state.ExecutionIdsByStepId.Count == 0 &&
             state.IdempotencyByStepId.Count == 0 &&
+            state.CompensationExecutionIdsByStepId.Count == 0 &&
             state.InputFileRefs.Count == 0 &&
             state.CurrentStepInputFileRefs.Count == 0 &&
             IsEmptyUsage(state.Usage))

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
@@ -41,6 +41,8 @@ public sealed class WorkflowRunGAgent
     private const string CompletedStatus = "completed";
     private const string FailedStatus = "failed";
     private const string StoppedStatus = "stopped";
+    private const string CompensatingSagaStatus = "compensating";
+    private const string CompensatedFailedSagaStatus = "compensated_failed";
     private WorkflowDefinition? _compiledWorkflow;
     private readonly WorkflowParser _parser = new();
     private readonly List<string> _childAgentIds = [];
@@ -180,12 +182,110 @@ public sealed class WorkflowRunGAgent
             ct);
     }
 
+    async Task<WorkflowCompensationTransitionResult> IWorkflowExecutionStateHost.TryStartCompensationAsync(
+        WorkflowCompletedEvent terminalFailure,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(terminalFailure);
+
+        if (IsCompensating(State))
+            return BuildCurrentCompensationResult(WorkflowCompensationTransitionStatus.AlreadyCompensating);
+
+        if (State.CompensableLedger.Count == 0)
+            return EmptyCompensationResult(WorkflowCompensationTransitionStatus.NoCompensableLedger);
+
+        var cursor = State.CompensableLedger.Count - 1;
+        var entry = State.CompensableLedger[cursor];
+        var executionId = Guid.NewGuid().ToString("N");
+        await PersistDomainEventAsync(new CompensationRequestEvent
+        {
+            RunId = string.IsNullOrWhiteSpace(terminalFailure.RunId) ? RunId : WorkflowRunIdNormalizer.Normalize(terminalFailure.RunId),
+            FailedStepId = ResolveLastFailedStepId(State),
+            CompensationStepId = entry.CompensationStepId,
+            IdempotencyKey = entry.IdempotencyKey,
+            CapturedOutput = entry.CapturedOutput,
+            ExecutionId = executionId,
+        }, ct);
+
+        return BuildCompensationResult(
+            WorkflowCompensationTransitionStatus.Started,
+            entry,
+            cursor,
+            executionId);
+    }
+
+    async Task<WorkflowCompensationTransitionResult> IWorkflowExecutionStateHost.RecordCompensationStepCompletionAsync(
+        CompensationStepCompletedEvent completion,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(completion);
+
+        if (!IsCompensating(State))
+            return EmptyCompensationResult(WorkflowCompensationTransitionStatus.NoCompensableLedger);
+
+        var cursor = State.CompensationCursor;
+        if (!TryGetLedgerEntry(cursor, out var currentEntry) ||
+            !MatchesCurrentCompensation(completion, currentEntry))
+        {
+            await PersistDomainEventAsync(new StaleStepCompletionRejectedEvent
+            {
+                StepId = completion.CompensationStepId ?? string.Empty,
+                RunId = completion.RunId ?? string.Empty,
+                ExpectedExecutionId = State.CompensationExecutionId ?? string.Empty,
+                ReceivedExecutionId = completion.ExecutionId ?? string.Empty,
+            }, ct);
+            return EmptyCompensationResult(WorkflowCompensationTransitionStatus.RejectedStaleOrDuplicate);
+        }
+
+        await PersistDomainEventAsync(new CompensationStepCompletedEvent
+        {
+            RunId = WorkflowRunIdNormalizer.Normalize(completion.RunId),
+            CompensationStepId = currentEntry.CompensationStepId,
+            Success = completion.Success,
+            Error = completion.Error ?? string.Empty,
+            ExecutionId = completion.ExecutionId ?? string.Empty,
+        }, ct);
+
+        if (!completion.Success)
+            return EmptyCompensationResult(WorkflowCompensationTransitionStatus.FailedSeam);
+
+        var nextCursor = cursor - 1;
+        if (nextCursor < 0)
+        {
+            await PersistDomainEventAsync(new WorkflowCompensationCompletedEvent
+            {
+                RunId = State.RunId ?? string.Empty,
+                CompensatedSteps = State.CompensableLedger.Count,
+            }, ct);
+            return EmptyCompensationResult(WorkflowCompensationTransitionStatus.CompletedAll);
+        }
+
+        var nextEntry = State.CompensableLedger[nextCursor];
+        var nextExecutionId = Guid.NewGuid().ToString("N");
+        await PersistDomainEventAsync(new CompensationRequestEvent
+        {
+            RunId = State.RunId ?? string.Empty,
+            FailedStepId = ResolveLastFailedStepId(State),
+            CompensationStepId = nextEntry.CompensationStepId,
+            IdempotencyKey = nextEntry.IdempotencyKey,
+            CapturedOutput = nextEntry.CapturedOutput,
+            ExecutionId = nextExecutionId,
+        }, ct);
+
+        return BuildCompensationResult(
+            WorkflowCompensationTransitionStatus.AdvancedAndRequestedNext,
+            nextEntry,
+            nextCursor,
+            nextExecutionId);
+    }
+
     protected override async Task OnActivateAsync(CancellationToken ct)
     {
         RebuildCompiledWorkflowCache();
-        InstallCognitiveModules();
         await base.OnActivateAsync(ct);
+        InstallCognitiveModules();
         await _subWorkflowOrchestrator.RecoverPendingSubWorkflowInvocationsAsync(State, ct);
+        await ResumeCompensationAsync(ct);
     }
 
     public async Task BindWorkflowRunDefinitionAsync(
@@ -822,7 +922,7 @@ public sealed class WorkflowRunGAgent
             return;
         }
 
-        if (IsTerminalStatus(State.Status))
+        if (IsTerminalStatus(State.Status) && !IsCompensating(State))
         {
             Logger.LogDebug(
                 "Workflow run is terminal; skipping module installation for actor {ActorId} status={Status}.",
@@ -894,6 +994,10 @@ public sealed class WorkflowRunGAgent
             .On<WorkflowRunExecutionContextClearedEvent>(ApplyWorkflowRunExecutionContextCleared)
             .On<WorkflowExecutionStateUpsertedEvent>(ApplyWorkflowExecutionStateUpserted)
             .On<WorkflowExecutionStateClearedEvent>(ApplyWorkflowExecutionStateCleared)
+            .On<StepCompletedEvent>(ApplyStepCompleted)
+            .On<CompensationRequestEvent>(ApplyCompensationRequest)
+            .On<CompensationStepCompletedEvent>(ApplyCompensationStepCompleted)
+            .On<WorkflowCompensationCompletedEvent>(ApplyWorkflowCompensationCompleted)
             .On<WorkflowStoppedEvent>(ApplyWorkflowStopped)
             .On<WorkflowCompletedEvent>(ApplyWorkflowCompleted)
             .On<WorkflowRunStoppedEvent>(ApplyWorkflowRunStopped)
@@ -927,6 +1031,10 @@ public sealed class WorkflowRunGAgent
         next.FinalOutput = string.Empty;
         next.FinalError = string.Empty;
         next.ForkAttempt = 0;
+        next.CompensableLedger.Clear();
+        next.CompensationCursor = 0;
+        next.SagaStatus = string.Empty;
+        next.CompensationExecutionId = string.Empty;
         next.ExecutionStates.Clear();
         next.ExecutionContext = new WorkflowRunExecutionContextState();
         next.SubWorkflowBindings.Clear();
@@ -965,6 +1073,10 @@ public sealed class WorkflowRunGAgent
         next.FinalOutput = string.Empty;
         next.FinalError = string.Empty;
         next.ForkAttempt = Math.Max(0, evt.Attempt);
+        next.CompensableLedger.Clear();
+        next.CompensationCursor = 0;
+        next.SagaStatus = string.Empty;
+        next.CompensationExecutionId = string.Empty;
         next.ExecutionContext ??= new WorkflowRunExecutionContextState();
         ApplyExecutionContextDelta(next.ExecutionContext, evt.ExecutionContextDelta);
         if (string.IsNullOrWhiteSpace(next.DefinitionActorId) && !string.IsNullOrWhiteSpace(evt.DefinitionActorId))
@@ -1093,6 +1205,93 @@ public sealed class WorkflowRunGAgent
         return next;
     }
 
+    private WorkflowRunState ApplyStepCompleted(WorkflowRunState current, StepCompletedEvent evt)
+    {
+        var next = current.Clone();
+        if (!evt.Success)
+            return next;
+
+        var stepId = evt.StepId?.Trim() ?? string.Empty;
+        var workflow = ResolveWorkflowForTransition(current);
+        var step = string.IsNullOrWhiteSpace(stepId) ? null : workflow?.GetStep(stepId);
+        var compensationStepId = step?.Compensation?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(compensationStepId))
+            return next;
+
+        var idempotencyKey = ResolveStepCompletionIdempotency(evt, current, stepId);
+        if (next.CompensableLedger.Any(entry =>
+                string.Equals(entry.StepId, stepId, StringComparison.Ordinal) &&
+                string.Equals(entry.CompensationStepId, compensationStepId, StringComparison.Ordinal) &&
+                string.Equals(entry.IdempotencyKey, idempotencyKey, StringComparison.Ordinal)))
+        {
+            return next;
+        }
+
+        next.CompensableLedger.Add(new CompletedStepLedgerEntry
+        {
+            StepId = stepId,
+            CompensationStepId = compensationStepId,
+            IdempotencyKey = idempotencyKey,
+            CapturedOutput = evt.Output ?? string.Empty,
+            CommittedAtUnixMs = 0,
+        });
+        return next;
+    }
+
+    private static WorkflowRunState ApplyCompensationRequest(WorkflowRunState current, CompensationRequestEvent evt)
+    {
+        var next = current.Clone();
+        var compensationStepId = evt.CompensationStepId?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(compensationStepId))
+            return next;
+
+        next.SagaStatus = CompensatingSagaStatus;
+        next.CompensationExecutionId = evt.ExecutionId?.Trim() ?? string.Empty;
+        for (var i = next.CompensableLedger.Count - 1; i >= 0; i--)
+        {
+            var ledgerEntry = next.CompensableLedger[i];
+            if (string.Equals(ledgerEntry.CompensationStepId, compensationStepId, StringComparison.Ordinal) &&
+                string.Equals(ledgerEntry.IdempotencyKey ?? string.Empty, evt.IdempotencyKey ?? string.Empty, StringComparison.Ordinal) &&
+                string.Equals(ledgerEntry.CapturedOutput ?? string.Empty, evt.CapturedOutput ?? string.Empty, StringComparison.Ordinal))
+            {
+                next.CompensationCursor = i;
+                break;
+            }
+        }
+
+        return next;
+    }
+
+    private static WorkflowRunState ApplyCompensationStepCompleted(
+        WorkflowRunState current,
+        CompensationStepCompletedEvent evt)
+    {
+        var next = current.Clone();
+        if (!IsCompensating(next))
+            return next;
+
+        if (!evt.Success)
+        {
+            next.CompensationExecutionId = string.Empty;
+            return next;
+        }
+
+        next.CompensationCursor -= 1;
+        next.CompensationExecutionId = string.Empty;
+        return next;
+    }
+
+    private static WorkflowRunState ApplyWorkflowCompensationCompleted(
+        WorkflowRunState current,
+        WorkflowCompensationCompletedEvent evt)
+    {
+        var next = current.Clone();
+        next.SagaStatus = CompensatedFailedSagaStatus;
+        next.CompensationCursor = -1;
+        next.CompensationExecutionId = string.Empty;
+        return next;
+    }
+
     private static WorkflowRunState ApplyWorkflowStopped(WorkflowRunState current, WorkflowStoppedEvent evt)
     {
         var next = current.Clone();
@@ -1149,6 +1348,104 @@ public sealed class WorkflowRunGAgent
         string.Equals(status, CompletedStatus, StringComparison.OrdinalIgnoreCase) ||
         string.Equals(status, FailedStatus, StringComparison.OrdinalIgnoreCase) ||
         string.Equals(status, StoppedStatus, StringComparison.OrdinalIgnoreCase);
+
+    private async Task ResumeCompensationAsync(CancellationToken ct)
+    {
+        if (!IsCompensating(State) ||
+            string.IsNullOrWhiteSpace(State.CompensationExecutionId) ||
+            !TryGetLedgerEntry(State.CompensationCursor, out var entry))
+        {
+            return;
+        }
+
+        await PublishAsync(new CompensationRequestEvent
+        {
+            RunId = State.RunId ?? string.Empty,
+            FailedStepId = ResolveLastFailedStepId(State),
+            CompensationStepId = entry.CompensationStepId,
+            IdempotencyKey = entry.IdempotencyKey,
+            CapturedOutput = entry.CapturedOutput,
+            ExecutionId = State.CompensationExecutionId ?? string.Empty,
+        }, TopologyAudience.Self, ct);
+    }
+
+    private WorkflowCompensationTransitionResult BuildCurrentCompensationResult(
+        WorkflowCompensationTransitionStatus status)
+    {
+        if (!TryGetLedgerEntry(State.CompensationCursor, out var entry))
+            return EmptyCompensationResult(status);
+
+        return BuildCompensationResult(
+            status,
+            entry,
+            State.CompensationCursor,
+            State.CompensationExecutionId ?? string.Empty);
+    }
+
+    private static WorkflowCompensationTransitionResult BuildCompensationResult(
+        WorkflowCompensationTransitionStatus status,
+        CompletedStepLedgerEntry entry,
+        int cursor,
+        string executionId) =>
+        new(
+            status,
+            entry.CompensationStepId ?? string.Empty,
+            entry.IdempotencyKey ?? string.Empty,
+            entry.CapturedOutput ?? string.Empty,
+            cursor,
+            executionId ?? string.Empty);
+
+    private static WorkflowCompensationTransitionResult EmptyCompensationResult(
+        WorkflowCompensationTransitionStatus status) =>
+        new(status, string.Empty, string.Empty, string.Empty, 0, string.Empty);
+
+    private bool TryGetLedgerEntry(int cursor, [NotNullWhen(true)] out CompletedStepLedgerEntry? entry)
+    {
+        if (cursor >= 0 && cursor < State.CompensableLedger.Count)
+        {
+            entry = State.CompensableLedger[cursor];
+            return true;
+        }
+
+        entry = null;
+        return false;
+    }
+
+    private bool MatchesCurrentCompensation(
+        CompensationStepCompletedEvent completion,
+        CompletedStepLedgerEntry currentEntry)
+    {
+        var runId = WorkflowRunIdNormalizer.Normalize(completion.RunId);
+        return string.Equals(State.RunId, runId, StringComparison.Ordinal) &&
+               string.Equals(currentEntry.CompensationStepId, completion.CompensationStepId?.Trim(), StringComparison.Ordinal) &&
+               string.Equals(State.CompensationExecutionId ?? string.Empty, completion.ExecutionId ?? string.Empty, StringComparison.Ordinal);
+    }
+
+    private static bool IsCompensating(WorkflowRunState state) =>
+        string.Equals(state.SagaStatus, CompensatingSagaStatus, StringComparison.Ordinal);
+
+    private static string ResolveStepCompletionIdempotency(
+        StepCompletedEvent evt,
+        WorkflowRunState state,
+        string stepId) =>
+        evt.Annotations.TryGetValue("idempotency_key", out var annotatedKey)
+            ? annotatedKey ?? string.Empty
+            : ResolveCompletedStepIdempotency(state, stepId);
+
+    private static string ResolveCompletedStepIdempotency(WorkflowRunState state, string stepId)
+    {
+        foreach (var packedState in state.ExecutionStates.Values)
+        {
+            if (packedState?.Is(WorkflowExecutionKernelState.Descriptor) != true)
+                continue;
+
+            var kernelState = packedState.Unpack<WorkflowExecutionKernelState>();
+            if (kernelState.IdempotencyByStepId.TryGetValue(stepId, out var idempotency))
+                return idempotency.IdempotencyKey ?? string.Empty;
+        }
+
+        return string.Empty;
+    }
 
     private static string ResolveLastFailedStepId(WorkflowRunState state)
     {
@@ -1276,6 +1573,25 @@ public sealed class WorkflowRunGAgent
         {
             Logger.LogWarning(ex, "RebuildCompiledWorkflowCache: parse failed.");
             _compiledWorkflow = null;
+        }
+    }
+
+    private WorkflowDefinition? ResolveWorkflowForTransition(WorkflowRunState state)
+    {
+        if (_compiledWorkflow != null)
+            return _compiledWorkflow;
+
+        if (string.IsNullOrWhiteSpace(state.WorkflowYaml))
+            return null;
+
+        try
+        {
+            return _parser.Parse(state.WorkflowYaml);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Failed to parse workflow while rebuilding run transition state.");
+            return null;
         }
     }
 

--- a/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
+++ b/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
@@ -158,6 +158,7 @@ message WorkflowRunState
   repeated CompletedStepLedgerEntry compensable_ledger = 25;
   int32 compensation_cursor = 26;
   string saga_status = 27;
+  string compensation_execution_id = 28;
 }
 
 message WorkflowRunExecutionContextState
@@ -300,6 +301,7 @@ message WorkflowExecutionKernelState
   repeated WorkflowFileRef input_file_refs = 13;
   repeated WorkflowFileRef current_step_input_file_refs = 14;
   map<string, WorkflowStepIdempotencyState> idempotency_by_step_id = 15;
+  map<string, string> compensation_execution_ids_by_step_id = 16;
 }
 
 message WorkflowUsageMetricsState

--- a/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentSagaCompensationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentSagaCompensationTests.cs
@@ -1,0 +1,702 @@
+using System.Reflection;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.EventModules;
+using Aevatar.Foundation.Abstractions.EventSourcing;
+using Aevatar.Foundation.Abstractions.Hooks;
+using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Foundation.Core;
+using Aevatar.Foundation.Core.EventSourcing;
+using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Abstractions.Execution;
+using Aevatar.Workflow.Core.Composition;
+using Aevatar.Workflow.Core.Modules;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.Workflow.Core.Tests;
+
+public sealed class WorkflowRunGAgentSagaCompensationTests
+{
+    [Fact]
+    public async Task TerminalFailure_WithCompensableLedger_ShouldDispatchCompensationsInReverseOrder()
+    {
+        var harness = await CreateStartedRunAsync(SagaWorkflowYaml());
+
+        await CompleteStepAsync(harness, "create_order", "order-output");
+        await CompleteStepAsync(harness, "charge_payment", "charge-output");
+        harness.Agent.State.CompensableLedger.Should().HaveCount(2);
+
+        await FailStepAsync(harness, "ship_order", "ship failed");
+
+        var firstRequest = CompensationRequests(harness.Publisher).Should().ContainSingle().Subject;
+        firstRequest.CompensationStepId.Should().Be("refund_payment");
+        firstRequest.CapturedOutput.Should().Be("charge-output");
+        firstRequest.IdempotencyKey.Should().Be($"{harness.RunId}:charge_payment:1");
+
+        await CompleteCompensationAsync(harness, firstRequest);
+        var secondRequest = CompensationRequests(harness.Publisher).Last();
+        secondRequest.CompensationStepId.Should().Be("cancel_order");
+        secondRequest.CapturedOutput.Should().Be("order-output");
+        secondRequest.IdempotencyKey.Should().Be($"{harness.RunId}:create_order:1");
+
+        await CompleteCompensationAsync(harness, secondRequest);
+
+        CommittedEvents<WorkflowCompensationCompletedEvent>(harness.CommittedPublisher)
+            .Should()
+            .ContainSingle()
+            .Which.CompensatedSteps.Should().Be(2);
+        CommittedEvents<WorkflowCompletedEvent>(harness.CommittedPublisher)
+            .Where(x => !x.Success)
+            .Should()
+            .ContainSingle()
+            .Which.RunId.Should().Be(harness.RunId);
+        harness.Agent.State.SagaStatus.Should().Be("compensated_failed");
+    }
+
+    [Fact]
+    public async Task Reactivation_MidCompensation_ShouldReplayCurrentRequestWithoutDuplicateCommit()
+    {
+        var harness = await CreateStartedRunAsync(SagaWorkflowYaml());
+        await CompleteStepAsync(harness, "create_order", "order-output");
+        await CompleteStepAsync(harness, "charge_payment", "charge-output");
+        await FailStepAsync(harness, "ship_order", "ship failed");
+
+        var originalRequests = CommittedEvents<CompensationRequestEvent>(harness.CommittedPublisher).ToList();
+        originalRequests.Should().ContainSingle();
+
+        var reactivated = await CreateRunAsync(
+            harness.RunId,
+            SagaWorkflowYaml(),
+            harness.EventStore,
+            autoReplaySelfPublished: false);
+
+        reactivated.Agent.State.SagaStatus.Should().Be("compensating");
+        reactivated.Agent.State.CompensationCursor.Should().Be(1);
+        reactivated.Agent.State.CompensationExecutionId.Should().Be(originalRequests[0].ExecutionId);
+        var replayed = CompensationRequests(reactivated.Publisher).Should().ContainSingle().Subject;
+        replayed.CompensationStepId.Should().Be(originalRequests[0].CompensationStepId);
+        replayed.ExecutionId.Should().Be(originalRequests[0].ExecutionId);
+        CommittedEvents<CompensationRequestEvent>(reactivated.CommittedPublisher).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Reactivation_WithRepeatedCompensationStepId_ShouldReplayExactCursor()
+    {
+        var harness = await CreateStartedRunAsync(RepeatedCompensationTargetWorkflowYaml());
+        await CompleteStepAsync(harness, "reserve_stock", "stock-output");
+        await CompleteStepAsync(harness, "reserve_credit", "credit-output");
+        await FailStepAsync(harness, "finalize", "finalize failed");
+
+        var firstRequest = CompensationRequests(harness.Publisher).Single();
+        firstRequest.CompensationStepId.Should().Be("release");
+        firstRequest.CapturedOutput.Should().Be("credit-output");
+        firstRequest.IdempotencyKey.Should().Be($"{harness.RunId}:reserve_credit:1");
+
+        var reactivated = await CreateRunAsync(
+            harness.RunId,
+            RepeatedCompensationTargetWorkflowYaml(),
+            harness.EventStore,
+            autoReplaySelfPublished: false);
+
+        reactivated.Agent.State.CompensationCursor.Should().Be(1);
+        var replayed = CompensationRequests(reactivated.Publisher).Should().ContainSingle().Subject;
+        replayed.CompensationStepId.Should().Be("release");
+        replayed.CapturedOutput.Should().Be("credit-output");
+        replayed.IdempotencyKey.Should().Be($"{harness.RunId}:reserve_credit:1");
+        replayed.ExecutionId.Should().Be(firstRequest.ExecutionId);
+    }
+
+    [Fact]
+    public async Task StaleOrDuplicateCompensationCompletion_ShouldBeRejectedAndNotAdvanceCursor()
+    {
+        var harness = await CreateStartedRunAsync(SagaWorkflowYaml());
+        await CompleteStepAsync(harness, "create_order", "order-output");
+        await CompleteStepAsync(harness, "charge_payment", "charge-output");
+        await FailStepAsync(harness, "ship_order", "ship failed");
+
+        var request = CompensationRequests(harness.Publisher).Single();
+        await harness.Agent.HandleEventAsync(SelfEnvelope(harness.RunId, new CompensationStepCompletedEvent
+        {
+            RunId = harness.RunId,
+            CompensationStepId = request.CompensationStepId,
+            Success = true,
+            ExecutionId = "stale-execution",
+        }));
+
+        CommittedEvents<CompensationStepCompletedEvent>(harness.CommittedPublisher).Should().BeEmpty();
+        CommittedEvents<StaleStepCompletionRejectedEvent>(harness.CommittedPublisher)
+            .Should()
+            .ContainSingle()
+            .Which.ReceivedExecutionId.Should().Be("stale-execution");
+        harness.Agent.State.CompensationCursor.Should().Be(1);
+
+        await CompleteCompensationAsync(harness, request);
+        await harness.Agent.HandleEventAsync(SelfEnvelope(harness.RunId, new CompensationStepCompletedEvent
+        {
+            RunId = harness.RunId,
+            CompensationStepId = request.CompensationStepId,
+            Success = true,
+            ExecutionId = request.ExecutionId,
+        }));
+
+        CommittedEvents<CompensationStepCompletedEvent>(harness.CommittedPublisher)
+            .Should()
+            .ContainSingle(x => x.CompensationStepId == "refund_payment");
+        CommittedEvents<StaleStepCompletionRejectedEvent>(harness.CommittedPublisher)
+            .Should()
+            .HaveCount(2);
+    }
+
+    [Fact]
+    public async Task NoCompensationWorkflow_TerminalFailure_ShouldKeepOriginalCompletionShape()
+    {
+        var harness = await CreateStartedRunAsync(NoCompensationWorkflowYaml());
+
+        await FailStepAsync(harness, "failed_step", "boom");
+
+        CommittedEvents<CompensationRequestEvent>(harness.CommittedPublisher).Should().BeEmpty();
+        var completed = CommittedEvents<WorkflowCompletedEvent>(harness.CommittedPublisher)
+            .Where(x => !x.Success)
+            .Should()
+            .ContainSingle()
+            .Subject;
+        completed.Should().BeEquivalentTo(new WorkflowCompletedEvent
+        {
+            WorkflowName = "wf_2097",
+            RunId = harness.RunId,
+            Success = false,
+            Error = "boom",
+        });
+        completed.ToByteArray().Should().Equal(new WorkflowCompletedEvent
+        {
+            WorkflowName = "wf_2097",
+            RunId = harness.RunId,
+            Success = false,
+            Error = "boom",
+        }.ToByteArray());
+    }
+
+    [Fact]
+    public async Task CompensationDispatch_ShouldUseSelfContinuation()
+    {
+        var harness = await CreateStartedRunAsync(SagaWorkflowYaml());
+        await CompleteStepAsync(harness, "create_order", "order-output");
+        await CompleteStepAsync(harness, "charge_payment", "charge-output");
+
+        await FailStepAsync(harness, "ship_order", "ship failed");
+
+        harness.Publisher.Published
+            .Where(x => x.Event is CompensationRequestEvent)
+            .Should()
+            .ContainSingle()
+            .Which.Audience.Should().Be(TopologyAudience.Self);
+        harness.Publisher.Published
+            .Where(x => x.Event is StepRequestEvent { StepId: "refund_payment" })
+            .Should()
+            .ContainSingle()
+            .Which.Audience.Should().Be(TopologyAudience.Self);
+    }
+
+    [Fact]
+    public async Task FailedCompensation_ShouldPersistFailureAndStopAtFailedSeam()
+    {
+        var harness = await CreateStartedRunAsync(SagaWorkflowYaml());
+        await CompleteStepAsync(harness, "create_order", "order-output");
+        await CompleteStepAsync(harness, "charge_payment", "charge-output");
+        await FailStepAsync(harness, "ship_order", "ship failed");
+
+        var request = CompensationRequests(harness.Publisher).Single();
+        await FailCompensationAsync(harness, request, "refund failed");
+
+        CommittedEvents<CompensationStepCompletedEvent>(harness.CommittedPublisher)
+            .Should()
+            .ContainSingle()
+            .Which.Should().BeEquivalentTo(new CompensationStepCompletedEvent
+            {
+                RunId = harness.RunId,
+                CompensationStepId = "refund_payment",
+                Success = false,
+                Error = "refund failed",
+                ExecutionId = request.ExecutionId,
+            });
+        CommittedEvents<WorkflowCompensationCompletedEvent>(harness.CommittedPublisher).Should().BeEmpty();
+        CommittedEvents<WorkflowCompensationFailedEvent>(harness.CommittedPublisher).Should().BeEmpty();
+        CommittedEvents<WorkflowCompletedEvent>(harness.CommittedPublisher)
+            .Where(x => !x.Success)
+            .Should()
+            .BeEmpty();
+        var reactivated = await CreateRunAsync(
+            harness.RunId,
+            SagaWorkflowYaml(),
+            harness.EventStore,
+            autoReplaySelfPublished: false);
+        CompensationRequests(reactivated.Publisher).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task FailedCompensation_WithOnErrorFallback_ShouldStillStopAtFailedSeam()
+    {
+        var harness = await CreateStartedRunAsync(CompensationOnErrorWorkflowYaml());
+        await CompleteStepAsync(harness, "create_order", "order-output");
+        await FailStepAsync(harness, "ship_order", "ship failed");
+
+        var request = CompensationRequests(harness.Publisher).Single();
+        await FailCompensationAsync(harness, request, "cancel failed");
+
+        CommittedEvents<CompensationStepCompletedEvent>(harness.CommittedPublisher)
+            .Should()
+            .ContainSingle()
+            .Which.Success.Should().BeFalse();
+        harness.Publisher.Published
+            .Where(x => x.Event is StepRequestEvent { StepId: "fallback_cancel" })
+            .Should()
+            .BeEmpty();
+        CommittedEvents<WorkflowCompletedEvent>(harness.CommittedPublisher)
+            .Where(x => !x.Success)
+            .Should()
+            .BeEmpty();
+    }
+
+    private static async Task CompleteStepAsync(RunHarness harness, string stepId, string output)
+    {
+        var request = harness.Publisher.Published
+            .Where(x => x.Event is StepRequestEvent requestEvent && requestEvent.StepId == stepId)
+            .Select(x => (StepRequestEvent)x.Event)
+            .Last();
+        harness.Publisher.Published.Clear();
+
+        await harness.Agent.HandleEventAsync(SelfEnvelope(harness.RunId, new StepCompletedEvent
+        {
+            RunId = harness.RunId,
+            StepId = stepId,
+            Success = true,
+            Output = output,
+            ExecutionId = request.ExecutionId,
+        }));
+    }
+
+    private static async Task FailStepAsync(RunHarness harness, string stepId, string error)
+    {
+        var request = harness.Publisher.Published
+            .Where(x => x.Event is StepRequestEvent requestEvent && requestEvent.StepId == stepId)
+            .Select(x => (StepRequestEvent)x.Event)
+            .Last();
+
+        await harness.Agent.HandleEventAsync(SelfEnvelope(harness.RunId, new StepCompletedEvent
+        {
+            RunId = harness.RunId,
+            StepId = stepId,
+            Success = false,
+            Error = error,
+            ExecutionId = request.ExecutionId,
+        }));
+    }
+
+    private static async Task CompleteCompensationAsync(RunHarness harness, CompensationRequestEvent request)
+    {
+        var stepRequest = harness.Publisher.Published
+            .Where(x => x.Event is StepRequestEvent stepRequestEvent && stepRequestEvent.StepId == request.CompensationStepId)
+            .Select(x => (StepRequestEvent)x.Event)
+            .Last();
+        harness.Publisher.Published.Clear();
+
+        await harness.Agent.HandleEventAsync(SelfEnvelope(harness.RunId, new StepCompletedEvent
+        {
+            RunId = harness.RunId,
+            StepId = request.CompensationStepId,
+            Success = true,
+            Output = $"done:{request.CompensationStepId}",
+            ExecutionId = stepRequest.ExecutionId,
+        }));
+    }
+
+    private static async Task FailCompensationAsync(RunHarness harness, CompensationRequestEvent request, string error)
+    {
+        var stepRequest = harness.Publisher.Published
+            .Where(x => x.Event is StepRequestEvent stepRequestEvent && stepRequestEvent.StepId == request.CompensationStepId)
+            .Select(x => (StepRequestEvent)x.Event)
+            .Last();
+
+        await harness.Agent.HandleEventAsync(SelfEnvelope(harness.RunId, new StepCompletedEvent
+        {
+            RunId = harness.RunId,
+            StepId = request.CompensationStepId,
+            Success = false,
+            Error = error,
+            ExecutionId = stepRequest.ExecutionId,
+        }));
+    }
+
+    private static async Task<RunHarness> CreateStartedRunAsync(string workflowYaml)
+    {
+        var runId = "run-2097-" + Guid.NewGuid().ToString("N");
+        var harness = await CreateRunAsync(runId, workflowYaml);
+
+        await harness.Agent.HandleEventAsync(EnvelopeFrom("api", new WorkflowChatRequestEvent
+        {
+            Prompt = "hello",
+            ScopeId = "scope-1",
+        }));
+
+        return harness;
+    }
+
+    private static async Task<RunHarness> CreateRunAsync(
+        string runId,
+        string workflowYaml,
+        RecordingEventStore? eventStore = null,
+        bool autoReplaySelfPublished = true)
+    {
+        eventStore ??= new RecordingEventStore();
+        var committedHook = new RecordingCommittedStatePublicationHook();
+        var topologyPublisher = new RecordingEventPublisher(runId)
+        {
+            AutoReplaySelfPublished = autoReplaySelfPublished,
+        };
+        var agent = new WorkflowRunGAgent(
+            new UnsupportedActorRuntime(),
+            new UnsupportedActorRuntime(),
+            new EmptyEventModuleFactory(),
+            [new EmptyWorkflowModulePack()])
+        {
+            EventSourcingBehaviorFactory = new DefaultEventSourcingBehaviorFactory<WorkflowRunState>(eventStore),
+            EventPublisher = topologyPublisher,
+            Services = new TestServiceProvider(new NoopRuntimeCallbackScheduler(), committedHook),
+            Logger = NullLogger.Instance,
+        };
+        SetAgentId(agent, runId);
+        topologyPublisher.Agent = agent;
+        await agent.ActivateAsync();
+
+        if (string.IsNullOrWhiteSpace(agent.State.WorkflowYaml))
+        {
+            await agent.HandleEventAsync(EnvelopeFrom("workflow-run-actor-port", new BindWorkflowRunDefinitionEvent
+            {
+                DefinitionActorId = "definition-2097",
+                WorkflowName = "wf_2097",
+                WorkflowYaml = workflowYaml,
+                RunId = runId,
+                ScopeId = "scope-1",
+            }));
+        }
+
+        return new RunHarness(agent, runId, eventStore, committedHook, topologyPublisher);
+    }
+
+    private static IReadOnlyList<CompensationRequestEvent> CompensationRequests(RecordingEventPublisher publisher) =>
+        publisher.Published
+            .Where(x => x.Event is CompensationRequestEvent)
+            .Select(x => (CompensationRequestEvent)x.Event)
+            .ToArray();
+
+    private static IReadOnlyList<TEvent> CommittedEvents<TEvent>(RecordingCommittedStatePublicationHook committedPublisher)
+        where TEvent : class, IMessage<TEvent>, new() =>
+        committedPublisher.Events
+            .Where(x => x.StateEvent?.EventData?.Is(new TEvent().Descriptor) == true)
+            .Select(x => x.StateEvent.EventData.Unpack<TEvent>())
+            .ToArray();
+
+    private static EventEnvelope SelfEnvelope(string runId, IMessage payload) =>
+        EnvelopeFrom(runId, payload);
+
+    private static EventEnvelope EnvelopeFrom(string publisherActorId, IMessage payload) =>
+        new()
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(payload),
+            Route = EnvelopeRouteSemantics.CreateTopologyPublication(publisherActorId, TopologyAudience.Self),
+            Propagation = new EnvelopePropagation
+            {
+                CorrelationId = Guid.NewGuid().ToString("N"),
+            },
+        };
+
+    private static string SagaWorkflowYaml() =>
+        """
+        name: wf_2097
+        roles: []
+        steps:
+          - id: create_order
+            type: transform
+            next: charge_payment
+            compensation: cancel_order
+          - id: charge_payment
+            type: transform
+            next: ship_order
+            compensation: refund_payment
+          - id: ship_order
+            type: transform
+          - id: refund_payment
+            type: transform
+          - id: cancel_order
+            type: transform
+        """;
+
+    private static string NoCompensationWorkflowYaml() =>
+        """
+        name: wf_2097
+        roles: []
+        steps:
+          - id: failed_step
+            type: transform
+        """;
+
+    private static string RepeatedCompensationTargetWorkflowYaml() =>
+        """
+        name: wf_2097
+        roles: []
+        steps:
+          - id: reserve_stock
+            type: transform
+            next: reserve_credit
+            compensation: release
+          - id: reserve_credit
+            type: transform
+            next: finalize
+            compensation: release
+          - id: finalize
+            type: transform
+          - id: release
+            type: transform
+        """;
+
+    private static string CompensationOnErrorWorkflowYaml() =>
+        """
+        name: wf_2097
+        roles: []
+        steps:
+          - id: create_order
+            type: transform
+            next: ship_order
+            compensation: cancel_order
+          - id: ship_order
+            type: transform
+          - id: cancel_order
+            type: transform
+            on_error:
+              strategy: fallback
+              fallback_step: fallback_cancel
+          - id: fallback_cancel
+            type: transform
+        """;
+
+    private static void SetAgentId(GAgentBase agent, string agentId)
+    {
+        var setIdMethod = typeof(GAgentBase).GetMethod(
+            "SetId",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        setIdMethod.Should().NotBeNull();
+        setIdMethod!.Invoke(agent, [agentId]);
+    }
+
+    private sealed record RunHarness(
+        WorkflowRunGAgent Agent,
+        string RunId,
+        RecordingEventStore EventStore,
+        RecordingCommittedStatePublicationHook CommittedPublisher,
+        RecordingEventPublisher Publisher);
+
+    private sealed class EmptyWorkflowModulePack : IWorkflowModulePack
+    {
+        public string Name => "test.empty";
+
+        public IReadOnlyList<WorkflowModuleRegistration> Modules { get; } = [];
+
+        public IReadOnlyList<IWorkflowModuleDependencyExpander> DependencyExpanders { get; } = [];
+
+        public IReadOnlyList<IWorkflowModuleConfigurator> Configurators { get; } = [];
+    }
+
+    private sealed class EmptyEventModuleFactory : IEventModuleFactory<IWorkflowExecutionContext>
+    {
+        public bool TryCreate(string name, out IEventModule<IWorkflowExecutionContext>? module)
+        {
+            _ = name;
+            module = null;
+            return false;
+        }
+    }
+
+    private sealed class RecordingEventPublisher(string runId) : IEventPublisher
+    {
+        public List<(IMessage Event, TopologyAudience Audience)> Published { get; } = [];
+
+        public bool AutoReplaySelfPublished { get; init; } = true;
+
+        public WorkflowRunGAgent Agent { get; set; } = null!;
+
+        public async Task PublishAsync<T>(
+            T evt,
+            TopologyAudience audience,
+            CancellationToken ct,
+            EventEnvelope? sourceEnvelope,
+            EventEnvelopePublishOptions? options)
+            where T : IMessage
+        {
+            ct.ThrowIfCancellationRequested();
+            Published.Add((evt.Descriptor.Parser.ParseFrom(evt.ToByteArray()), audience));
+
+            if (AutoReplaySelfPublished && audience == TopologyAudience.Self)
+                await Agent.HandleEventAsync(SelfEnvelope(runId, evt), ct);
+        }
+
+        public Task SendToAsync<T>(
+            string targetActorId,
+            T evt,
+            CancellationToken ct,
+            EventEnvelope? sourceEnvelope,
+            EventEnvelopePublishOptions? options)
+            where T : IMessage =>
+            Task.CompletedTask;
+    }
+
+    private sealed class RecordingCommittedStatePublicationHook : ICommittedStatePublicationHook
+    {
+        public List<CommittedStateEventPublished> Events { get; } = [];
+
+        public Task BeforePublishAsync(CommittedStatePublicationContext context, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            Events.Add(context.Published.Clone());
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingEventStore : IEventStore
+    {
+        private readonly Dictionary<string, List<StateEvent>> _streams = new(StringComparer.Ordinal);
+
+        public Task<EventStoreCommitResult> AppendAsync(
+            string agentId,
+            IEnumerable<StateEvent> events,
+            long expectedVersion,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            var stream = _streams.GetValueOrDefault(agentId) ?? [];
+            var currentVersion = stream.Count == 0 ? 0 : stream[^1].Version;
+            currentVersion.Should().Be(expectedVersion);
+
+            var committed = events.Select(x => x.Clone()).ToList();
+            stream.AddRange(committed);
+            _streams[agentId] = stream;
+
+            return Task.FromResult(new EventStoreCommitResult
+            {
+                AgentId = agentId,
+                LatestVersion = stream.Count == 0 ? 0 : stream[^1].Version,
+                CommittedEvents = { committed },
+            });
+        }
+
+        public Task<IReadOnlyList<StateEvent>> GetEventsAsync(
+            string agentId,
+            long? fromVersion = null,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            var events = _streams.GetValueOrDefault(agentId) ?? [];
+            return Task.FromResult<IReadOnlyList<StateEvent>>(
+                events
+                    .Where(x => !fromVersion.HasValue || x.Version >= fromVersion.Value)
+                    .Select(x => x.Clone())
+                    .ToArray());
+        }
+
+        public Task<long> GetVersionAsync(string agentId, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            var events = _streams.GetValueOrDefault(agentId) ?? [];
+            return Task.FromResult(events.Count == 0 ? 0 : events[^1].Version);
+        }
+
+        public Task<long> DeleteEventsUpToAsync(
+            string agentId,
+            long toVersion,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!_streams.TryGetValue(agentId, out var stream))
+                return Task.FromResult(0L);
+
+            var removed = stream.RemoveAll(x => x.Version <= toVersion);
+            return Task.FromResult((long)removed);
+        }
+    }
+
+    private sealed class TestServiceProvider(
+        NoopRuntimeCallbackScheduler scheduler,
+        RecordingCommittedStatePublicationHook committedHook) : IServiceProvider
+    {
+        public object? GetService(System.Type serviceType)
+        {
+            if (serviceType == typeof(IEnumerable<IGAgentExecutionHook>))
+                return Array.Empty<IGAgentExecutionHook>();
+            if (serviceType == typeof(IActorRuntimeCallbackScheduler))
+                return scheduler;
+            if (serviceType == typeof(IEnumerable<ICommittedStatePublicationHook>))
+                return new ICommittedStatePublicationHook[] { committedHook };
+
+            return null;
+        }
+    }
+
+    private sealed class NoopRuntimeCallbackScheduler : IActorRuntimeCallbackScheduler
+    {
+        public Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
+            RuntimeCallbackTimeoutRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                1,
+                RuntimeCallbackBackend.InMemory));
+
+        public Task<RuntimeCallbackLease> ScheduleTimerAsync(
+            RuntimeCallbackTimerRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                1,
+                RuntimeCallbackBackend.InMemory));
+
+        public Task CancelAsync(RuntimeCallbackLease lease, CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task PurgeActorAsync(string actorId, CancellationToken ct = default) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class UnsupportedActorRuntime : IActorRuntime, IActorDispatchPort
+    {
+        public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
+            where TAgent : IAgent =>
+            throw new NotSupportedException();
+
+        public Task<IActor> CreateAsync(System.Type agentType, string? id = null, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task DestroyAsync(string id, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<IActor?> GetAsync(string id) =>
+            throw new NotSupportedException();
+
+        public Task<bool> ExistsAsync(string id) =>
+            throw new NotSupportedException();
+
+        public Task LinkAsync(string parentId, string childId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task UnlinkAsync(string childId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<DispatchAdmission> DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
## 摘要

实现 **ADR-0034 cutover step 3（orchestration）**：把反向补偿相位作为 run 生命周期终止子态，由 `WorkflowRunGAgent` 单一拥有、event-sourced、self-continuation 驱动。Milestone 25 · ADR-0034 step 3，依赖已合并的 #2096（契约）+ #2098（幂等键）。

- **Old**：引擎 forward-only —— 终止失败发 `WorkflowCompletedEvent{success=false}` 即停，已提交 side-effect 永不撤销。
- **New**：reducer 从 unchanged `StepCompletedEvent` 派生 `compensable_ledger`；终止失败（retry/on_error/fork 耗尽）且账本非空 → `saga_status=compensating`；按 cursor 反向逐个 self-continuation 派发；对账 `compensation_cursor + execution_id`，stale/duplicate 拒绝；全撤销 → `WorkflowCompensationCompletedEvent` + 终止 `compensated_failed`。

## 范围（6 文件，+1293/-10）

- `Execution/IWorkflowExecutionStateHost.cs`：2 方法 `TryStartCompensationAsync`/`RecordCompensationStepCompletionAsync` + 单一 `WorkflowCompensationTransitionResult`（7 成员 enum）。kernel 只 branch on `Status`，**不 side-read run state**。
- `Execution/WorkflowExecutionKernel.cs`：终止失败拦截 + 补偿 self-continuation 派发 + exhausted seam。
- `WorkflowRunGAgent.cs`：2 host 方法实现 + reducer 账本派生 + actor-owned cursor/status 对账 + `OnActivateAsync` saga-resume（重放不重复 persist `CompensationRequestEvent`）。
- proto（append-only）：`CompensationRequestEvent.execution_id=6`、`CompensationStepCompletedEvent.execution_id=5`；durable saga execution-id 字段（`WorkflowRunState.compensation_execution_id=28`、`WorkflowExecutionKernelState.compensation_execution_ids_by_step_id=16`，用于 crash-replay 对账，落在共识允许的 conditional state 范围内）。
- `WorkflowRunGAgentSagaCompensationTests.cs`（+702，8 测试）。

## 设计（design-consensus，r1→r6 收敛）

reducer-derived 账本（不新增 ledger event）；`CompensationRequestEvent` = committed transition + self-continuation；stale key = `run_id + compensation_step_id + execution_id`；**failed compensation 只落 `CompensationStepCompletedEvent{success=false}` 并停（`FailedSeam`），durable dead-letter terminal 归 #2099**。

## 验证

- `dotnet build aevatar.slnx --nologo` — 0 error
- `dotnet test test/Aevatar.Workflow.Core.Tests` — **520 passed**（含 8 个 `WorkflowRunGAgentSagaCompensationTests`）
- `bash tools/ci/test_stability_guards.sh` + `architecture_guards.sh` — pass

## 验收对照（#2097）

- [x] 补偿按反向顺序执行
- [x] 补偿相位 event-sourced，actor 重激活 mid-walk 后可恢复（replay 测试）
- [x] stale/duplicate `CompensationStepCompletedEvent` 被拒绝、不重复计数
- [x] 无 compensation 声明的 workflow 终止逐字节不变
- [x] 补偿 dispatch 走 inbox/self-continuation

Closes #2097 · ADR-0034 cutover step 3 · base `feature/integrate`

🤖 consensus-loop · design-consensus r6 consensus → implement

⟦AI:AUTO-LOOP⟧
