### PR TITLE
test(workflow): lock saga invariants — guards, e2e tests & docs (ADR-0034 step 6) · #2100

### DIFF
--- a/docs/adr/0006-multi-agent-evolution.md
+++ b/docs/adr/0006-multi-agent-evolution.md
@@ -296,6 +296,8 @@ WorkflowRunGAgent (编排者)
      → 父 workflow 执行定义中的 fallback 步骤
 ```
 
+**SUPERSEDING NOTE:** The optional compensation sketch above is superseded by ADR-0034 for workflow saga compensation. Current workflow compensation semantics are actor-owned and ledger-based: terminal failure with a non-empty `compensable_ledger` enters `compensating`, dispatches compensation by self continuation in reverse order, and terminates as `compensated_failed` or `compensation_dead_letter`. ADR-0006's original decision is not rewritten.
+
 ---
 
 ### Phase 3：协议完善 [P1]

--- a/docs/canon/workflow-primitives.md
+++ b/docs/canon/workflow-primitives.md
@@ -71,6 +71,36 @@ roles:
   Old pattern: ChatRuntime.ChatStreamAsync 用 Task.Run + Channel<LLMStreamChunk>/ChannelWriter 在 actor turn 外跑 LLM/tool/hook/history 业务循环,违反 actor execution integrity
   New principle: ChatStreamAsync owns the stream flow directly; the Task.Run + Channel owned-stream loop and stream_buffer_capacity config were removed; middleware wrapping stays inside private bridge adapters.
 
+### Saga compensation
+
+Every step may declare `compensation: <step_id>` when its successful side effect can be undone by another step in the same workflow. The compensation target must resolve to an existing step id during validation; it is not a late-bound name or inline body.
+
+```yaml
+steps:
+  - id: create_order
+    type: connector_call
+    next: charge_payment
+    compensation: cancel_order
+  - id: charge_payment
+    type: connector_call
+    next: ship_order
+    compensation: refund_payment
+  - id: ship_order
+    type: connector_call
+  - id: refund_payment
+    type: connector_call
+  - id: cancel_order
+    type: connector_call
+```
+
+Runtime semantics:
+
+- A successful step with a valid `compensation` declaration is added to the run actor's `compensable_ledger`.
+- If a later terminal failure occurs while the ledger is non-empty, compensation runs in reverse ledger order.
+- The saga status moves `running -> compensating -> compensated_failed` when every compensation step succeeds.
+- If a compensation step fails, the run moves to `compensation_dead_letter` and emits `WorkflowCompensationFailedEvent` with the failed compensation step, remaining uncompensated count, and error.
+- Compensation dispatch uses self continuation. Stale or duplicate compensation completions are rejected by execution id and do not advance the cursor.
+
 ## 2. Data 原语
 
 ### `transform`

--- a/docs/canon/workflow-runtime.md
+++ b/docs/canon/workflow-runtime.md
@@ -294,6 +294,7 @@ POST /api/chat { prompt, workflow?, workflowYaml?, source? }
   │
   ├── WorkflowExecutionKernel 收到 StepCompletedEvent
   │     ├── 有下一步 → 再发 StepRequestEvent（循环）
+  │     ├── 有补偿 ledger 的终止失败 → 发布 CompensationRequestEvent 并进入补偿相位
   │     └── 无下一步 → 发布 WorkflowCompletedEvent
   │
   ├── run actor envelope 流进入统一 Projection Pipeline（一对多分发）
@@ -305,6 +306,26 @@ POST /api/chat { prompt, workflow?, workflowYaml?, source? }
 ```
 
 关键点：**流程控制由模块完成，不写死在单个 Agent 的方法里。**
+
+### Saga 补偿生命周期
+
+Workflow step 可以通过 `compensation` 声明一个已存在的 step id。静态校验阶段会解析该目标，引用不存在的补偿步骤会被拒绝。运行时中，成功完成且声明了补偿的业务 step 会进入 `compensable_ledger`，ledger 归 `WorkflowRunGAgent` 持有，是 run actor 的权威状态。
+
+当后续 step 发生终止失败且 ledger 非空时，run 不直接提交 `WorkflowCompletedEvent(success=false)`。`WorkflowExecutionKernel` 先请求 run actor 开启补偿相位，run actor 按 ledger 反向顺序提交 `CompensationRequestEvent`，再通过 self continuation 派发对应补偿 step。补偿 step 完成后以 `CompensationStepCompletedEvent` 回到 run actor，由 actor 校验 `run_id + compensation_step_id + execution_id`，拒绝陈旧或重复完成事件。
+
+Saga 状态生命周期为：
+
+```text
+running -> compensating -> compensated_failed
+running -> compensating -> compensation_dead_letter
+```
+
+- `running`：正常执行阶段，成功的 compensable step 按完成顺序写入 ledger。
+- `compensating`：终止失败已转入补偿相位，`compensation_cursor` 指向当前待补偿 ledger 项。
+- `compensated_failed`：所有补偿按反向顺序成功，随后发布失败的 `WorkflowCompletedEvent`，表示原业务 run 失败但补偿已完成。
+- `compensation_dead_letter`：某个补偿 step 失败或补偿耗尽，run actor 提交 `WorkflowCompensationFailedEvent`，记录失败补偿 step、剩余未补偿数量和错误；此状态不再走 on_error fallback，也不会静默丢弃。
+
+补偿相位继续遵守 actor 化执行约束：补偿推进只通过 self message 进入 actor inbox，不在 callback 线程或 helper 内 inline 推进；crash/reactivation 时，actor 根据已提交 `CompensationRequestEvent` 和当前 cursor 重发当前 self continuation，不重复提交领域事件。
 
 ## Host Boundary For GitHub / Router / Closure
 
@@ -642,7 +663,7 @@ steps:
 
 ### Q3：模块失败会怎样？
 
-取决于模块实现和步骤配置。`WorkflowLoopModule` 收到 `Success=false` 的 `StepCompletedEvent` 后会直接发布 `WorkflowCompletedEvent(Success=false)`，终止整个 workflow。`ConnectorCallModule` 支持 `on_error: continue` 降级策略。
+取决于模块实现、步骤配置和 saga ledger。`WorkflowExecutionKernel` 收到 `Success=false` 的 `StepCompletedEvent` 后，若当前 run 有非空 `compensable_ledger`，先进入补偿相位；补偿全部成功后才以 `WorkflowCompletedEvent(Success=false)` 结束。没有 compensable ledger 时，失败直接发布 `WorkflowCompletedEvent(Success=false)`。支持 retry/on_error 的 step 会先按对应策略处理，未被策略接管的终止失败才触发上述逻辑。
 
 ### Q4：怎么新增一种步骤类型？
 

--- a/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentSagaCompensationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentSagaCompensationTests.cs
@@ -35,6 +35,10 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
         firstRequest.CompensationStepId.Should().Be("refund_payment");
         firstRequest.CapturedOutput.Should().Be("charge-output");
         firstRequest.IdempotencyKey.Should().Be($"{harness.RunId}:charge_payment:1");
+        CommittedEvents<WorkflowCompletedEvent>(harness.CommittedPublisher)
+            .Where(x => !x.Success)
+            .Should()
+            .BeEmpty();
 
         await CompleteCompensationAsync(harness, firstRequest);
         var secondRequest = CompensationRequests(harness.Publisher).Last();
@@ -44,6 +48,10 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
 
         await CompleteCompensationAsync(harness, secondRequest);
 
+        CommittedEvents<CompensationStepCompletedEvent>(harness.CommittedPublisher)
+            .Select(x => x.CompensationStepId)
+            .Should()
+            .Equal("refund_payment", "cancel_order");
         CommittedEvents<WorkflowCompensationCompletedEvent>(harness.CommittedPublisher)
             .Should()
             .ContainSingle()
@@ -78,7 +86,37 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
         reactivated.Agent.State.CompensationExecutionId.Should().Be(originalRequests[0].ExecutionId);
         var replayed = CompensationRequests(reactivated.Publisher).Should().ContainSingle().Subject;
         replayed.CompensationStepId.Should().Be(originalRequests[0].CompensationStepId);
+        replayed.IdempotencyKey.Should().Be(originalRequests[0].IdempotencyKey);
+        replayed.CapturedOutput.Should().Be(originalRequests[0].CapturedOutput);
         replayed.ExecutionId.Should().Be(originalRequests[0].ExecutionId);
+        CommittedEvents<CompensationRequestEvent>(reactivated.CommittedPublisher).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Reactivation_AfterPartialCompensation_ShouldReplayRemainingCurrentRequest()
+    {
+        var harness = await CreateStartedRunAsync(SagaWorkflowYaml());
+        await CompleteStepAsync(harness, "create_order", "order-output");
+        await CompleteStepAsync(harness, "charge_payment", "charge-output");
+        await FailStepAsync(harness, "ship_order", "ship failed");
+
+        var firstRequest = CompensationRequests(harness.Publisher).Single();
+        await CompleteCompensationAsync(harness, firstRequest);
+        var secondRequest = CompensationRequests(harness.Publisher).Last();
+
+        var reactivated = await CreateRunAsync(
+            harness.RunId,
+            SagaWorkflowYaml(),
+            harness.EventStore,
+            autoReplaySelfPublished: false);
+
+        reactivated.Agent.State.SagaStatus.Should().Be("compensating");
+        reactivated.Agent.State.CompensationCursor.Should().Be(0);
+        var replayed = CompensationRequests(reactivated.Publisher).Should().ContainSingle().Subject;
+        replayed.CompensationStepId.Should().Be("cancel_order");
+        replayed.IdempotencyKey.Should().Be(secondRequest.IdempotencyKey);
+        replayed.CapturedOutput.Should().Be("order-output");
+        replayed.ExecutionId.Should().Be(secondRequest.ExecutionId);
         CommittedEvents<CompensationRequestEvent>(reactivated.CommittedPublisher).Should().BeEmpty();
     }
 
@@ -131,6 +169,8 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
             .Should()
             .ContainSingle()
             .Which.ReceivedExecutionId.Should().Be("stale-execution");
+        CommittedEvents<WorkflowCompensationFailedEvent>(harness.CommittedPublisher).Should().BeEmpty();
+        CommittedEvents<WorkflowCompensationCompletedEvent>(harness.CommittedPublisher).Should().BeEmpty();
         harness.Agent.State.CompensationCursor.Should().Be(1);
 
         await CompleteCompensationAsync(harness, request);
@@ -238,6 +278,7 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
             .Where(x => !x.Success)
             .Should()
             .BeEmpty();
+        CommittedEvents<WorkflowCompensationCompletedEvent>(harness.CommittedPublisher).Should().BeEmpty();
         harness.Agent.State.Status.Should().Be("failed");
         harness.Agent.State.SagaStatus.Should().Be("compensation_dead_letter");
         harness.Agent.State.DeadLetterFailedCompensationStepId.Should().Be("refund_payment");

--- a/test/Aevatar.Workflow.Core.Tests/WorkflowSagaContractTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/WorkflowSagaContractTests.cs
@@ -1,6 +1,8 @@
 using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Core;
 using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.Reflection;
 
 namespace Aevatar.Workflow.Core.Tests;
 
@@ -53,35 +55,71 @@ public sealed class WorkflowSagaContractTests
     [Fact]
     public void WorkflowExecutionMessages_ShouldExposeCompensationEventContracts()
     {
-        new CompensationRequestEvent
+        AssertField<CompensationRequestEvent>("run_id", 1);
+        AssertField<CompensationRequestEvent>("failed_step_id", 2);
+        AssertField<CompensationRequestEvent>("compensation_step_id", 3);
+        AssertField<CompensationRequestEvent>("idempotency_key", 4);
+        AssertField<CompensationRequestEvent>("captured_output", 5);
+        AssertField<CompensationRequestEvent>("execution_id", 6);
+        AssertRoundTrip(new CompensationRequestEvent
         {
             RunId = "run-1",
             FailedStepId = "charge_payment",
             CompensationStepId = "cancel_order",
             IdempotencyKey = "run-1:create_order",
             CapturedOutput = """{"orderId":"order-1"}""",
-        }.Should().NotBeNull();
+            ExecutionId = "compensate-1",
+        });
 
-        new CompensationStepCompletedEvent
+        AssertField<CompensationStepCompletedEvent>("run_id", 1);
+        AssertField<CompensationStepCompletedEvent>("compensation_step_id", 2);
+        AssertField<CompensationStepCompletedEvent>("success", 3);
+        AssertField<CompensationStepCompletedEvent>("error", 4);
+        AssertField<CompensationStepCompletedEvent>("execution_id", 5);
+        AssertRoundTrip(new CompensationStepCompletedEvent
         {
             RunId = "run-1",
             CompensationStepId = "cancel_order",
             Success = true,
             Error = "",
-        }.Should().NotBeNull();
+            ExecutionId = "compensate-1",
+        });
 
-        new WorkflowCompensationCompletedEvent
+        AssertField<WorkflowCompensationCompletedEvent>("run_id", 1);
+        AssertField<WorkflowCompensationCompletedEvent>("compensated_steps", 2);
+        AssertRoundTrip(new WorkflowCompensationCompletedEvent
         {
             RunId = "run-1",
             CompensatedSteps = 1,
-        }.Should().NotBeNull();
+        });
 
-        new WorkflowCompensationFailedEvent
+        AssertField<WorkflowCompensationFailedEvent>("run_id", 1);
+        AssertField<WorkflowCompensationFailedEvent>("failed_compensation_step_id", 2);
+        AssertField<WorkflowCompensationFailedEvent>("remaining_uncompensated", 3);
+        AssertField<WorkflowCompensationFailedEvent>("error", 4);
+        AssertRoundTrip(new WorkflowCompensationFailedEvent
         {
             RunId = "run-1",
             FailedCompensationStepId = "cancel_order",
             RemainingUncompensated = 1,
             Error = "failed",
-        }.Should().NotBeNull();
+        });
+    }
+
+    private static void AssertField<TMessage>(string name, int number)
+        where TMessage : IMessage<TMessage>, new()
+    {
+        var field = new TMessage().Descriptor.FindFieldByName(name);
+
+        field.Should().NotBeNull();
+        field!.FieldNumber.Should().Be(number);
+    }
+
+    private static void AssertRoundTrip<TMessage>(TMessage message)
+        where TMessage : IMessage<TMessage>, new()
+    {
+        var clone = new TMessage().Descriptor.Parser.ParseFrom(message.ToByteArray());
+
+        clone.Should().BeEquivalentTo(message);
     }
 }

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -1424,6 +1424,9 @@ bash tools/ci/projection_route_mapping_guard.sh
 echo "Running closed-world workflow guards..."
 bash tools/ci/workflow_closed_world_guards.sh
 
+echo "Running workflow saga compensation guard..."
+bash tools/ci/workflow_saga_compensation_guard.sh
+
 echo "Running workflow run-id guard..."
 bash tools/ci/workflow_runid_guard.sh
 

--- a/tools/ci/tests/test_workflow_saga_compensation_guard.sh
+++ b/tools/ci/tests/test_workflow_saga_compensation_guard.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." && pwd)"
+GUARD="${REPO_ROOT}/tools/ci/workflow_saga_compensation_guard.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+assert_fails_with() {
+  local expected="$1"
+  shift
+  local output="${TMP_DIR}/failure.out"
+
+  set +e
+  "$@" > "${output}" 2>&1
+  local status=$?
+  set -e
+
+  if [[ ${status} -eq 0 ]]; then
+    echo "Expected command to fail: $*"
+    cat "${output}"
+    exit 1
+  fi
+
+  if ! rg -q "${expected}" "${output}"; then
+    echo "Expected failure output to contain: ${expected}"
+    cat "${output}"
+    exit 1
+  fi
+}
+
+copy_fixture() {
+  local name="$1"
+  local root="${TMP_DIR}/${name}"
+
+  mkdir -p \
+    "${root}/tools/ci" \
+    "${root}/src/workflow/Aevatar.Workflow.Core/Execution" \
+    "${root}/src/workflow/Aevatar.Workflow.Core/Validation" \
+    "${root}/src/workflow/Aevatar.Workflow.Core"
+
+  cp "${GUARD}" "${root}/tools/ci/workflow_saga_compensation_guard.sh"
+  cp "${REPO_ROOT}/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs" \
+    "${root}/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs"
+  cp "${REPO_ROOT}/src/workflow/Aevatar.Workflow.Core/Validation/WorkflowValidator.cs" \
+    "${root}/src/workflow/Aevatar.Workflow.Core/Validation/WorkflowValidator.cs"
+  cp "${REPO_ROOT}/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs" \
+    "${root}/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs"
+
+  printf '%s\n' "${root}"
+}
+
+python_replace() {
+  local file="$1"
+  local old="$2"
+  local new="$3"
+
+  python3 - "$file" "$old" "$new" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+old = sys.argv[2]
+new = sys.argv[3]
+text = path.read_text()
+if old not in text:
+    raise SystemExit(f"fixture text not found in {path}: {old}")
+path.write_text(text.replace(old, new, 1))
+PY
+}
+
+python_replace_all() {
+  local file="$1"
+  local old="$2"
+  local new="$3"
+
+  python3 - "$file" "$old" "$new" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+old = sys.argv[2]
+new = sys.argv[3]
+text = path.read_text()
+if old not in text:
+    raise SystemExit(f"fixture text not found in {path}: {old}")
+path.write_text(text.replace(old, new))
+PY
+}
+
+bash "${GUARD}"
+
+direct_failure_root="$(copy_fixture direct-failed-completion)"
+python_replace_all \
+  "${direct_failure_root}/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs" \
+  "await TryStartCompensationOrPublishTerminalFailureAsync(" \
+  "await PublishWorkflowCompletedAsync("
+assert_fails_with \
+  "Terminal workflow failure must enter the compensation decision path" \
+  bash "${direct_failure_root}/tools/ci/workflow_saga_compensation_guard.sh"
+
+inline_dispatch_root="$(copy_fixture inline-dispatch)"
+python_replace \
+  "${inline_dispatch_root}/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs" \
+  "return ctx.PublishAsync(new CompensationRequestEvent" \
+  "return DispatchStepAsync(new StepDefinition(), string.Empty, [], new WorkflowExecutionKernelState(), ctx, ct); // return ctx.PublishAsync(new CompensationRequestEvent"
+assert_fails_with \
+  "Compensation request dispatch must not inline-advance" \
+  bash "${inline_dispatch_root}/tools/ci/workflow_saga_compensation_guard.sh"
+
+missing_validator_root="$(copy_fixture missing-validator)"
+python_replace \
+  "${missing_validator_root}/src/workflow/Aevatar.Workflow.Core/Validation/WorkflowValidator.cs" \
+  "            if (!string.IsNullOrWhiteSpace(step.Compensation) && !stepIds.Contains(step.Compensation))" \
+  "            if (!string.IsNullOrWhiteSpace(step.Compensation) && stepIds.Count < 0)"
+assert_fails_with \
+  "WorkflowValidator must reject compensation declarations" \
+  bash "${missing_validator_root}/tools/ci/workflow_saga_compensation_guard.sh"
+
+log_drop_root="$(copy_fixture log-drop)"
+python_replace \
+  "${log_drop_root}/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs" \
+  "await PersistDomainEventAsync(new WorkflowCompensationFailedEvent" \
+  "await PersistDomainEventAsync(new CompensationStepCompletedEvent"
+assert_fails_with \
+  "Failed compensation completion must persist WorkflowCompensationFailedEvent" \
+  bash "${log_drop_root}/tools/ci/workflow_saga_compensation_guard.sh"
+
+echo "workflow saga compensation guard tests passed"

--- a/tools/ci/workflow_saga_compensation_guard.sh
+++ b/tools/ci/workflow_saga_compensation_guard.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+ci_rg_bin="${AEVATAR_CI_RG_BIN:-rg}"
+
+ci_file() {
+  local path="$1"
+
+  if [ ! -f "${path}" ]; then
+    echo "Missing required saga compensation contract file: ${path}"
+    exit 1
+  fi
+}
+
+ci_extract_method() {
+  local file="$1"
+  local signature="$2"
+
+  awk -v signature="${signature}" '
+    index($0, signature) > 0 { capture = 1 }
+    capture { print }
+    capture && /^[[:space:]]{4}\}/ { exit }
+  ' "${file}"
+}
+
+ci_require_pattern() {
+  local text="$1"
+  local pattern="$2"
+  local failure="$3"
+
+  if ! printf '%s\n' "${text}" | "${ci_rg_bin}" -q --multiline "${pattern}"; then
+    echo "${failure}"
+    exit 1
+  fi
+}
+
+ci_forbid_pattern() {
+  local text="$1"
+  local pattern="$2"
+  local failure="$3"
+
+  if printf '%s\n' "${text}" | "${ci_rg_bin}" -q --multiline "${pattern}"; then
+    echo "${failure}"
+    exit 1
+  fi
+}
+
+ci_require_file_pattern() {
+  local file="$1"
+  local pattern="$2"
+  local failure="$3"
+
+  if ! "${ci_rg_bin}" -q --multiline "${pattern}" "${file}"; then
+    echo "${failure}"
+    exit 1
+  fi
+}
+
+if ! command -v "${ci_rg_bin}" >/dev/null 2>&1; then
+  echo "workflow saga compensation guard requires rg-compatible search binary."
+  exit 1
+fi
+
+kernel_file="src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs"
+run_agent_file="src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs"
+validator_file="src/workflow/Aevatar.Workflow.Core/Validation/WorkflowValidator.cs"
+
+ci_file "${kernel_file}"
+ci_file "${run_agent_file}"
+ci_file "${validator_file}"
+
+step_completed_method="$(ci_extract_method "${kernel_file}" "private async Task HandleStepCompletedAsync(")"
+try_start_method="$(ci_extract_method "${kernel_file}" "private async Task TryStartCompensationOrPublishTerminalFailureAsync(")"
+publish_compensation_method="$(ci_extract_method "${kernel_file}" "private static Task PublishCompensationRequestAsync(")"
+record_completion_method="$(ci_extract_method "${run_agent_file}" "async Task<WorkflowCompensationTransitionResult> IWorkflowExecutionStateHost.RecordCompensationStepCompletionAsync(")"
+
+if [ -z "${step_completed_method}" ] || [ -z "${try_start_method}" ] || [ -z "${publish_compensation_method}" ] || [ -z "${record_completion_method}" ]; then
+  echo "Unable to locate saga compensation methods; guard fails closed."
+  exit 1
+fi
+
+ci_require_pattern \
+  "${step_completed_method}" \
+  "TryStartCompensationOrPublishTerminalFailureAsync[[:space:]]*\\(" \
+  "Terminal workflow failure must enter the compensation decision path before publishing failed WorkflowCompletedEvent."
+
+ci_require_pattern \
+  "${try_start_method}" \
+  "TryStartCompensationAsync[[:space:]]*\\(" \
+  "Terminal workflow failure must ask the state host to start compensation."
+
+ci_require_pattern \
+  "${try_start_method}" \
+  "(?s)WorkflowCompensationTransitionStatus\\.(Started|AlreadyCompensating|AdvancedAndRequestedNext)[[:space:]]*:.*PublishCompensationRequestAsync[[:space:]]*\\(" \
+  "Compensable terminal failure must publish a compensation request instead of completing failed directly."
+
+ci_require_pattern \
+  "${try_start_method}" \
+  "(?s)WorkflowCompensationTransitionStatus\\.NoCompensableLedger[[:space:]]*:.*PublishWorkflowCompletedAsync[[:space:]]*\\([[:space:]]*ctx,[[:space:]]*terminalFailure" \
+  "Failed WorkflowCompletedEvent may only be published directly when no compensable ledger exists."
+
+ci_require_pattern \
+  "${publish_compensation_method}" \
+  "(?s)ctx\\.PublishAsync[[:space:]]*\\([[:space:]]*new CompensationRequestEvent.*TopologyAudience\\.Self" \
+  "Compensation request dispatch must use self-continuation."
+
+ci_forbid_pattern \
+  "${publish_compensation_method}" \
+  "DispatchStepAsync|HandleCompensationRequestAsync|HandleStepCompletedAsync|Task\\.Run" \
+  "Compensation request dispatch must not inline-advance or use callback-thread execution."
+
+ci_require_file_pattern \
+  "${validator_file}" \
+  "step\\.Compensation.*!stepIds\\.Contains\\(step\\.Compensation\\)" \
+  "WorkflowValidator must reject compensation declarations that do not resolve to an existing step id."
+
+ci_require_pattern \
+  "${record_completion_method}" \
+  "(?s)!completion\\.Success.*PersistDomainEventAsync[[:space:]]*\\([[:space:]]*new WorkflowCompensationFailedEvent" \
+  "Failed compensation completion must persist WorkflowCompensationFailedEvent."
+
+ci_require_pattern \
+  "${record_completion_method}" \
+  "WorkflowCompensationTransitionStatus\\.CompensationDeadLettered" \
+  "Failed compensation completion must return the dead-letter transition instead of logging and dropping."
+
+echo "Workflow saga compensation guards passed."


### PR DESCRIPTION
## 摘要

实现 **ADR-0034 cutover step 6（guards, integration tests & canon docs）—— Milestone 25 最后一个 issue**。把 saga/compensation 协议当可执行规范 LOCK + 文档化，**不改任何 saga 运行时行为**（`git diff -- src/workflow/*.cs` 非测试为空）。依赖已合并的 #2096+#2097+#2098+#2099。

## 范围（8 文件，+407/-9）

- **CI guard**：新增 `tools/ci/workflow_saga_compensation_guard.sh`（单脚本 4 个 fail-closed check）+ wire 进 `tools/ci/architecture_guards.sh` + `tools/ci/tests/test_workflow_saga_compensation_guard.sh`（broken-fixture 自测）：
  1. 终止失败且 `compensable_ledger` 非空必走补偿相位，不直发 `WorkflowCompletedEvent{success=false}`；
  2. 补偿 dispatch 必走 self-continuation（拒 inline/callback-thread）；
  3. `compensation` 声明编译期必解析到已存在 step id；
  4. 补偿耗尽必发 `WorkflowCompensationFailedEvent`（无 log-and-drop）。
- **集成测试**：扩展 `WorkflowRunGAgentSagaCompensationTests`（已承载完整 run actor 生命周期）覆盖端到端 saga —— 反向补偿、crash/reactivation 幂等再补偿、partial→dead-letter、stale-event 拒绝（确定性，无 sleep）。
- **contract 测试**：`WorkflowSagaContractTests` 4 个 compensation 事件从 `NotBeNull` 强化为 field/descriptor 断言，pin proto 字段号（fold #2096 tests-reviewer advisory）。
- **docs**：`docs/canon/workflow-{primitives,runtime}.md` 描述补偿相位 + saga 生命周期 `running → compensating → compensated_failed | compensation_dead_letter`；`docs/adr/0006-multi-agent-evolution.md` §2-B superseding note 指向 ADR-0034。

## 验证

- `bash tools/ci/workflow_saga_compensation_guard.sh` — pass（真树）
- `bash tools/ci/tests/test_workflow_saga_compensation_guard.sh` — pass（broken fixture 各 check 如期 fail）
- `bash tools/ci/architecture_guards.sh` — pass（含新 guard，已 wire 于 :1428）
- `dotnet test Core.Tests` — **522 passed**
- `bash tools/ci/test_stability_guards.sh` — pass · `bash tools/docs/lint.sh` — pass（58 docs）
- `dotnet build aevatar.slnx --nologo` — 0 error

## 验收对照（#2100）

- [x] 4 个 guard check 存在、对 broken fixture fail、wire 进 workflow guard set
- [x] `test_stability_guards.sh` 对新测试 pass
- [x] canon workflow docs 描述 saga 生命周期；`tools/docs/lint.sh` pass
- [x] ADR-0006 带 superseding note 指向 ADR-0034

Closes #2100 · ADR-0034 cutover step 6（final）· base `feature/integrate`

🤖 consensus-loop · design-consensus r1 consensus → implement · **Milestone 25 完结**

⟦AI:AUTO-LOOP⟧
