### PR TITLE
fix(workflow): saga dead-letter terminal notifies caller/parent (ADR-0034) for issue 2124

### DIFF
--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
@@ -648,13 +648,27 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
             case WorkflowCompensationTransitionStatus.RejectedStaleOrDuplicate:
                 return true;
             case WorkflowCompensationTransitionStatus.CompensationDeadLettered:
+            {
+                var state = LoadState(ctx);
                 await CleanupRunAsync(
-                    LoadState(ctx),
+                    state,
                     ctx,
                     ct,
                     preserveTerminalFacts: true,
                     preserveCurrentStepInputVariable: true);
+                var deadLetterError = error ?? string.Empty;
+                await PublishWorkflowCompletedAsync(
+                    ctx,
+                    new WorkflowCompletedEvent
+                    {
+                        WorkflowName = _workflow.Name,
+                        RunId = NormalizeRunId(runId),
+                        Success = false,
+                        Error = deadLetterError,
+                    },
+                    ct);
                 return true;
+            }
             case WorkflowCompensationTransitionStatus.NoCompensableLedger:
                 return false;
             default:
@@ -693,8 +707,16 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
             case WorkflowCompensationTransitionStatus.CompletedAll:
                 await PublishWorkflowCompletedAsync(ctx, terminalFailure, ct);
                 return;
-            case WorkflowCompensationTransitionStatus.RejectedStaleOrDuplicate:
             case WorkflowCompensationTransitionStatus.CompensationDeadLettered:
+                await CleanupRunAsync(
+                    state,
+                    ctx,
+                    ct,
+                    preserveTerminalFacts: true,
+                    preserveCurrentStepInputVariable: true);
+                await PublishWorkflowCompletedAsync(ctx, terminalFailure, ct);
+                return;
+            case WorkflowCompensationTransitionStatus.RejectedStaleOrDuplicate:
             default:
                 return;
         }

--- a/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentSagaCompensationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentSagaCompensationTests.cs
@@ -241,7 +241,7 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
     }
 
     [Fact]
-    public async Task FailedCompensation_ShouldPersistDeadLetterTerminal()
+    public async Task FailedCompensation_ShouldPersistDeadLetterTerminalAndNotifyCaller()
     {
         var harness = await CreateStartedRunAsync(SagaWorkflowYaml());
         await CompleteStepAsync(harness, "create_order", "order-output");
@@ -274,10 +274,14 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
             RemainingUncompensated = 2,
             Error = "refund failed",
         });
-        CommittedEvents<WorkflowCompletedEvent>(harness.CommittedPublisher)
+        var completed = CommittedEvents<WorkflowCompletedEvent>(harness.CommittedPublisher)
             .Where(x => !x.Success)
             .Should()
-            .BeEmpty();
+            .ContainSingle()
+            .Subject;
+        completed.RunId.Should().Be(harness.RunId);
+        completed.Error.Should().Be("refund failed");
+        AssertDeadLetterCompletionPublished(harness, "refund failed");
         CommittedEvents<WorkflowCompensationCompletedEvent>(harness.CommittedPublisher).Should().BeEmpty();
         harness.Agent.State.Status.Should().Be("failed");
         harness.Agent.State.SagaStatus.Should().Be(WorkflowSagaStatus.CompensationDeadLetter);
@@ -314,7 +318,9 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
         CommittedEvents<WorkflowCompletedEvent>(harness.CommittedPublisher)
             .Where(x => !x.Success)
             .Should()
-            .BeEmpty();
+            .ContainSingle()
+            .Which.Error.Should().Be("cancel failed");
+        AssertDeadLetterCompletionPublished(harness, "cancel failed");
         var failed = CommittedEvents<WorkflowCompensationFailedEvent>(harness.CommittedPublisher)
             .Should()
             .ContainSingle()
@@ -395,6 +401,28 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
         }));
     }
 
+    private static void AssertDeadLetterCompletionPublished(RunHarness harness, string error)
+    {
+        var parentCompletion = PublishedEvents<WorkflowCompletedEvent>(harness.Publisher)
+            .Where(x => x.Audience == TopologyAudience.Parent && !x.Event.Success)
+            .Should()
+            .ContainSingle()
+            .Subject
+            .Event;
+        parentCompletion.RunId.Should().Be(harness.RunId);
+        parentCompletion.Error.Should().Be(error);
+
+        var llmCompletion = PublishedEvents<WorkflowLlmInvocationCompletedEvent>(harness.Publisher)
+            .Where(x => x.Audience == TopologyAudience.Parent)
+            .Should()
+            .ContainSingle()
+            .Subject
+            .Event;
+        llmCompletion.RunId.Should().Be(harness.RunId);
+        llmCompletion.Success.Should().BeFalse();
+        llmCompletion.Error.Should().Be(error);
+    }
+
     private static async Task<RunHarness> CreateStartedRunAsync(string workflowYaml)
     {
         var runId = "run-2097-" + Guid.NewGuid().ToString("N");
@@ -455,6 +483,14 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
         publisher.Published
             .Where(x => x.Event is CompensationRequestEvent)
             .Select(x => (CompensationRequestEvent)x.Event)
+            .ToArray();
+
+    private static IReadOnlyList<(TEvent Event, TopologyAudience Audience)> PublishedEvents<TEvent>(
+        RecordingEventPublisher publisher)
+        where TEvent : class, IMessage<TEvent>, new() =>
+        publisher.Published
+            .Where(x => x.Event is TEvent)
+            .Select(x => ((TEvent)x.Event, x.Audience))
             .ToArray();
 
     private static IReadOnlyList<TEvent> CommittedEvents<TEvent>(RecordingCommittedStatePublicationHook committedPublisher)

--- a/tools/ci/workflow_saga_compensation_guard.sh
+++ b/tools/ci/workflow_saga_compensation_guard.sh
@@ -28,6 +28,19 @@ ci_extract_method() {
   ' "${file}"
 }
 
+ci_extract_case() {
+  local text="$1"
+  local case_label="$2"
+
+  printf '%s\n' "${text}" | awk -v case_label="${case_label}" '
+    index($0, case_label) > 0 { capture = 1 }
+    capture { print }
+    capture && capture_count > 0 && /^[[:space:]]*case / { exit }
+    capture && /^[[:space:]]*default:/ { exit }
+    capture { capture_count++ }
+  '
+}
+
 ci_require_pattern() {
   local text="$1"
   local pattern="$2"
@@ -75,12 +88,21 @@ ci_file "${run_agent_file}"
 ci_file "${validator_file}"
 
 step_completed_method="$(ci_extract_method "${kernel_file}" "private async Task HandleStepCompletedAsync(")"
+compensation_transition_method="$(ci_extract_method "${kernel_file}" "private async Task<bool> HandleCompensationTransitionAsync(")"
 try_start_method="$(ci_extract_method "${kernel_file}" "private async Task TryStartCompensationOrPublishTerminalFailureAsync(")"
 publish_compensation_method="$(ci_extract_method "${kernel_file}" "private static Task PublishCompensationRequestAsync(")"
 record_completion_method="$(ci_extract_method "${run_agent_file}" "async Task<WorkflowCompensationTransitionResult> IWorkflowExecutionStateHost.RecordCompensationStepCompletionAsync(")"
 
-if [ -z "${step_completed_method}" ] || [ -z "${try_start_method}" ] || [ -z "${publish_compensation_method}" ] || [ -z "${record_completion_method}" ]; then
+if [ -z "${step_completed_method}" ] || [ -z "${compensation_transition_method}" ] || [ -z "${try_start_method}" ] || [ -z "${publish_compensation_method}" ] || [ -z "${record_completion_method}" ]; then
   echo "Unable to locate saga compensation methods; guard fails closed."
+  exit 1
+fi
+
+transition_dead_letter_case="$(ci_extract_case "${compensation_transition_method}" "WorkflowCompensationTransitionStatus.CompensationDeadLettered")"
+try_start_dead_letter_case="$(ci_extract_case "${try_start_method}" "WorkflowCompensationTransitionStatus.CompensationDeadLettered")"
+
+if [ -z "${transition_dead_letter_case}" ] || [ -z "${try_start_dead_letter_case}" ]; then
+  echo "Unable to locate saga compensation dead-letter cases; guard fails closed."
   exit 1
 fi
 
@@ -103,6 +125,16 @@ ci_require_pattern \
   "${try_start_method}" \
   "(?s)WorkflowCompensationTransitionStatus\\.NoCompensableLedger[[:space:]]*:.*PublishWorkflowCompletedAsync[[:space:]]*\\([[:space:]]*ctx,[[:space:]]*terminalFailure" \
   "Failed WorkflowCompletedEvent may only be published directly when no compensable ledger exists."
+
+ci_require_pattern \
+  "${transition_dead_letter_case}" \
+  "PublishWorkflowCompletedAsync[[:space:]]*\\(" \
+  "Dead-lettered compensation transition must publish failed WorkflowCompletedEvent to notify callers."
+
+ci_require_pattern \
+  "${try_start_dead_letter_case}" \
+  "PublishWorkflowCompletedAsync[[:space:]]*\\(" \
+  "Dead-lettered compensation start result must publish failed WorkflowCompletedEvent to notify callers."
 
 ci_require_pattern \
   "${publish_compensation_method}" \


### PR DESCRIPTION
⟦AI:AUTO-LOOP⟧
## 问题
saga `compensation_dead_letter` 终态在 `WorkflowExecutionKernel` 的两个分支只 cleanup 后 return，从不向 caller/parent publish 终态 `WorkflowCompletedEvent` —— chat/`/responses` 调用方与 `workflow_call` parent 永久挂起。与会通知的 `CompletedAll`/`NoCompensableLedger` 兄弟分支不对称。

## 方案（publish-only，仅改 kernel 终态）
- `HandleCompensationTransitionAsync`：load state 一次 → cleanup → publish `WorkflowCompletedEvent{Success=false, Error=error ?? string.Empty}`。dead-letter error 即 `WorkflowCompensationFailedEvent` 提交的同一 `completion.Error`；`WorkflowExecutionKernelState` 无 `DeadLetterError` 字段（在 `WorkflowRunState`），故 `error` 是可编译且语义正确的来源。
- `TryStartCompensationOrPublishTerminalFailureAsync`：把 `CompensationDeadLettered` 从 no-op 组拆出，镜像 `NoCompensableLedger` 发布 `terminalFailure`。
- 不改 committed event / read-model / WorkflowRunGAgent / proto。child 契约（`WorkflowLlmInvocationCompletedEvent`、`SubWorkflowInvocationCompletedEvent`）一旦 completion publish 即自动触发。

## 影响路径
- `src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs`（2 个 dead-letter case 补 publish）
- `test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentSagaCompensationTests.cs`（断言 parent publish：单次 `WorkflowCompletedEvent{Success=false}` + `WorkflowLlmInvocationCompletedEvent`）
- `tools/ci/workflow_saga_compensation_guard.sh`（要求两个 dead-letter case 含 `PublishWorkflowCompletedAsync`，method-/case-aware，fail-closed）

## 验证
`dotnet build aevatar.slnx --nologo`；`dotnet test test/Aevatar.Workflow.Core.Tests --nologo`；`workflow_saga_compensation_guard.sh`；`test_stability_guards.sh`；`architecture_guards.sh` —— 全绿。

广义 guard 收紧延后 #2131；`compensated` flag / doc reconciliation 延后 #2132。

Closes #2124

🤖 Generated with [Claude Code](https://claude.com/claude-code)