### PR TITLE
feat(workflow): strengthen compensation authoring validation (ADR-0034) for issue 2129

### DIFF
--- a/src/workflow/Aevatar.Workflow.Core/Validation/WorkflowValidator.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Validation/WorkflowValidator.cs
@@ -75,6 +75,9 @@ public static class WorkflowValidator
             if (!string.IsNullOrWhiteSpace(step.Next) && !stepIds.Contains(step.Next))
                 errors.Add($"步骤 '{step.Id}' 的 next 引用不存在的步骤 '{step.Next}'");
 
+            if (!string.IsNullOrWhiteSpace(step.Compensation) && step.Compensation == step.Id)
+                errors.Add($"步骤 '{step.Id}' 的 compensation 不能指向自身");
+
             if (!string.IsNullOrWhiteSpace(step.Compensation) && !stepIds.Contains(step.Compensation))
                 errors.Add($"步骤 '{step.Id}' 的 compensation '{step.Compensation}' 引用不存在的步骤 '{step.Compensation}'");
 
@@ -83,7 +86,134 @@ public static class WorkflowValidator
 
         }
 
+        DetectCompensationCycles(allSteps, stepIds, errors);
+        ValidateCompensationTargetsExcludedFromForwardPath(allSteps, errors);
+        ValidateNestedCompensationTargets(allSteps, errors);
+
         return errors;
+    }
+
+    private static void DetectCompensationCycles(
+        IReadOnlyList<StepDefinition> allSteps,
+        ISet<string> stepIds,
+        List<string> errors)
+    {
+        var stepsById = BuildFirstStepById(allSteps);
+        var inspectedStarts = new HashSet<string>(StringComparer.Ordinal);
+        var reportedCycles = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var step in allSteps)
+        {
+            if (string.IsNullOrWhiteSpace(step.Id) || !inspectedStarts.Add(step.Id))
+                continue;
+
+            var path = new List<string>();
+            var pathIndexes = new Dictionary<string, int>(StringComparer.Ordinal);
+            var currentId = step.Id;
+
+            while (stepsById.TryGetValue(currentId, out var currentStep))
+            {
+                pathIndexes[currentId] = path.Count;
+                path.Add(currentId);
+
+                var nextId = currentStep.Compensation;
+                if (string.IsNullOrWhiteSpace(nextId) ||
+                    !stepIds.Contains(nextId) ||
+                    nextId == currentId)
+                {
+                    break;
+                }
+
+                if (pathIndexes.TryGetValue(nextId, out var cycleStartIndex))
+                {
+                    var cyclePath = path
+                        .Skip(cycleStartIndex)
+                        .Append(nextId)
+                        .ToList();
+                    var cycleKey = string.Join(
+                        "\u001F",
+                        cyclePath
+                            .Take(cyclePath.Count - 1)
+                            .OrderBy(id => id, StringComparer.Ordinal));
+
+                    if (reportedCycles.Add(cycleKey))
+                    {
+                        errors.Add(
+                            $"步骤 '{step.Id}' 的 compensation 链构成环：{string.Join(" -> ", cyclePath)}");
+                    }
+                    break;
+                }
+
+                currentId = nextId;
+            }
+        }
+    }
+
+    private static void ValidateCompensationTargetsExcludedFromForwardPath(
+        IReadOnlyList<StepDefinition> allSteps,
+        List<string> errors)
+    {
+        var forwardReferenced = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var step in allSteps)
+        {
+            if (!string.IsNullOrWhiteSpace(step.Next))
+                forwardReferenced.Add(step.Next);
+
+            if (step.Branches == null)
+                continue;
+
+            foreach (var target in step.Branches.Values)
+            {
+                if (!string.IsNullOrWhiteSpace(target))
+                    forwardReferenced.Add(target);
+            }
+        }
+
+        var reportedTargets = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var step in allSteps)
+        {
+            if (string.IsNullOrWhiteSpace(step.Compensation) ||
+                !forwardReferenced.Contains(step.Compensation) ||
+                !reportedTargets.Add(step.Compensation))
+            {
+                continue;
+            }
+
+            errors.Add($"步骤 '{step.Compensation}' 既是 compensation 目标又出现在正向路径（next/branches），会被双重执行");
+        }
+    }
+
+    private static void ValidateNestedCompensationTargets(
+        IReadOnlyList<StepDefinition> allSteps,
+        List<string> errors)
+    {
+        var stepsById = BuildFirstStepById(allSteps);
+        var reportedTargets = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var step in allSteps)
+        {
+            if (string.IsNullOrWhiteSpace(step.Compensation) ||
+                !reportedTargets.Add(step.Compensation) ||
+                !stepsById.TryGetValue(step.Compensation, out var compensationStep) ||
+                string.IsNullOrWhiteSpace(compensationStep.Compensation))
+            {
+                continue;
+            }
+
+            errors.Add($"步骤 '{step.Compensation}' 是 compensation 步骤，不允许再声明 compensation（不会在反向 walk 生效）");
+        }
+    }
+
+    private static Dictionary<string, StepDefinition> BuildFirstStepById(IEnumerable<StepDefinition> allSteps)
+    {
+        var stepsById = new Dictionary<string, StepDefinition>(StringComparer.Ordinal);
+        foreach (var step in allSteps)
+        {
+            if (!string.IsNullOrWhiteSpace(step.Id))
+                stepsById.TryAdd(step.Id, step);
+        }
+
+        return stepsById;
     }
 
     private static void ValidateBranchTargets(

--- a/test/Aevatar.Workflow.Core.Tests/Validation/WorkflowValidatorTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Validation/WorkflowValidatorTests.cs
@@ -149,22 +149,123 @@ public sealed class WorkflowValidatorTests
             error.Contains("cancel_order", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void Validate_WhenCompensationPointsToSameStep_ShouldReject()
+    {
+        var errors = WorkflowValidator.Validate(WorkflowWith(
+            Step("create_order", "tool_call", new(), compensation: "create_order")));
+
+        errors.Should().Contain("步骤 'create_order' 的 compensation 不能指向自身");
+    }
+
+    [Fact]
+    public void Validate_WhenCompensationChainHasTwoStepCycle_ShouldReject()
+    {
+        var errors = WorkflowValidator.Validate(WorkflowWith(
+            Step("create_order", "tool_call", new(), compensation: "cancel_order"),
+            Step("cancel_order", "tool_call", new(), compensation: "create_order")));
+
+        errors.Should().Contain(
+            "步骤 'create_order' 的 compensation 链构成环：create_order -> cancel_order -> create_order");
+    }
+
+    [Fact]
+    public void Validate_WhenCompensationChainHasThreeStepCycle_ShouldReject()
+    {
+        var errors = WorkflowValidator.Validate(WorkflowWith(
+            Step("reserve_inventory", "tool_call", new(), compensation: "release_inventory"),
+            Step("release_inventory", "tool_call", new(), compensation: "audit_release"),
+            Step("audit_release", "tool_call", new(), compensation: "reserve_inventory")));
+
+        errors.Should().Contain(
+            "步骤 'reserve_inventory' 的 compensation 链构成环：reserve_inventory -> release_inventory -> audit_release -> reserve_inventory");
+    }
+
+    [Fact]
+    public void Validate_WhenCompensationTargetAppearsInNextPath_ShouldReject()
+    {
+        var errors = WorkflowValidator.Validate(WorkflowWith(
+            Step("create_order", "tool_call", new(), next: "cancel_order", compensation: "cancel_order"),
+            Step("cancel_order", "tool_call", new())));
+
+        errors.Should().Contain(
+            "步骤 'cancel_order' 既是 compensation 目标又出现在正向路径（next/branches），会被双重执行");
+    }
+
+    [Fact]
+    public void Validate_WhenCompensationTargetAppearsInBranchPath_ShouldReject()
+    {
+        var errors = WorkflowValidator.Validate(WorkflowWith(
+            Step("create_order", "tool_call", new(), compensation: "cancel_order"),
+            Step(
+                "check_payment",
+                "conditional",
+                new(),
+                branches: new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["true"] = "ship_order",
+                    ["false"] = "cancel_order",
+                }),
+            Step("ship_order", "tool_call", new()),
+            Step("cancel_order", "tool_call", new())));
+
+        errors.Should().Contain(
+            "步骤 'cancel_order' 既是 compensation 目标又出现在正向路径（next/branches），会被双重执行");
+    }
+
+    [Fact]
+    public void Validate_WhenCompensationTargetDeclaresCompensation_ShouldReject()
+    {
+        var errors = WorkflowValidator.Validate(WorkflowWith(
+            Step("create_order", "tool_call", new(), compensation: "cancel_order"),
+            Step("cancel_order", "tool_call", new(), compensation: "audit_cancel"),
+            Step("audit_cancel", "tool_call", new())));
+
+        errors.Should().Contain(
+            "步骤 'cancel_order' 是 compensation 步骤，不允许再声明 compensation（不会在反向 walk 生效）");
+    }
+
+    [Fact]
+    public void Validate_WhenSagaCompensationGraphIsValid_ShouldNotReportCompensationGraphErrors()
+    {
+        var errors = WorkflowValidator.Validate(WorkflowWith(
+            Step("create_order", "tool_call", new(), next: "charge_payment", compensation: "cancel_order"),
+            Step("charge_payment", "tool_call", new(), next: "ship_order", compensation: "refund_payment"),
+            Step("ship_order", "tool_call", new()),
+            Step("refund_payment", "tool_call", new()),
+            Step("cancel_order", "tool_call", new())));
+
+        errors.Should().NotContain("步骤 'create_order' 的 compensation 不能指向自身");
+        errors.Should().NotContain(error => error.Contains("compensation 链构成环", StringComparison.Ordinal));
+        errors.Should().NotContain(error => error.Contains("既是 compensation 目标又出现在正向路径", StringComparison.Ordinal));
+        errors.Should().NotContain(error => error.Contains("是 compensation 步骤，不允许再声明 compensation", StringComparison.Ordinal));
+    }
+
     private static WorkflowDefinition WorkflowWith(StepDefinition step) =>
+        WorkflowWith([step]);
+
+    private static WorkflowDefinition WorkflowWith(params StepDefinition[] steps) =>
         new()
         {
             Name = "lease_validation",
             Roles = [],
-            Steps = [step],
+            Steps = [.. steps],
         };
 
     private static StepDefinition Step(
         string id,
         string type,
-        Dictionary<string, string> parameters) =>
+        Dictionary<string, string> parameters,
+        string? next = null,
+        string? compensation = null,
+        Dictionary<string, string>? branches = null) =>
         new()
         {
             Id = id,
             Type = type,
             Parameters = parameters,
+            Next = next,
+            Compensation = compensation,
+            Branches = branches,
         };
 }


### PR DESCRIPTION
⟦AI:AUTO-LOOP⟧
## 问题
`WorkflowValidator` 对 compensation 只校验 target existence，以下 authoring 错误被静默接受、只能在运行时反向 walk 时（甚至完全不）暴露：self-compensation、compensation 环、compensation target 被 `next`/`branches` 放回正向路径（正向+反向双重执行）、nested/inert compensation。

## 方案（编译期静态图不变量，仅 WorkflowValidator）
复用既有 `allSteps`/`stepIds`/`EnumerateSteps`，新增 4 类 hard error：
- self-compensation：`step.compensation == step.id`
- compensation 环：`DetectCompensationCycles`（A→B→A 及更长；环去重；self-cycle 不重复报）
- forward-path exclusion：compensation target ∩ (next ∪ branches values)
- nested/inert：compensation target 自身又声明 compensation

**刻意不做**：issue item (d) 的「必须 authored idempotency_key」。引擎已通过 `WorkflowSideEffectIdempotencyKeyResolver.BuildDefaultKey`（`{run_id}:{step_id}:{attempt}`）为任何 side-effecting step 派生稳定 replay-safe key，compensation step 走同一 dispatch 链，强制 authored key 会错误拒绝合法 authoring。(d) 的真实子点（nested/inert）已覆盖。

## 影响路径
- `src/workflow/Aevatar.Workflow.Core/Validation/WorkflowValidator.cs`
- `test/Aevatar.Workflow.Core.Tests/Validation/WorkflowValidatorTests.cs`（self / 2-cycle / 3-cycle / forward-next / forward-branch / nested / 合法 saga happy path）

## 范围纪律
不改 runtime 补偿行为；这些检查的 compile-time guard 收紧延后 **#2131**；无 ADR/canon 改动（doc reconciliation 归 **#2132**）。full reachable-from-root / children 分析显式 deferred。

## 验证
`dotnet build aevatar.slnx --nologo`；`dotnet test test/Aevatar.Workflow.Core.Tests --nologo`；`test_stability_guards.sh`；`architecture_guards.sh` —— 全绿。

Closes #2129

🤖 Generated with [Claude Code](https://claude.com/claude-code)