### PR TITLE
fix(voice): thread actor-owned lease_epoch through provider/transport fencing (#2150)

### DIFF
--- a/docs/canon/voice-presence-integration.md
+++ b/docs/canon/voice-presence-integration.md
@@ -108,7 +108,9 @@ The edge consumes a JSON projection of it (camelCase), hand-parsed by
   drops any local `function_call_output` (tools execute actor-side).
 - **Lease** — the host attaches a transport lease (`transport_lease_id`,
   `owner_id`, `lease_epoch`, `lease_expires_at`) the actor owns; the volatile
-  media relay is bound to that lease.
+  media relay is bound to that lease. Host/provider connect paths must carry
+  the readmodel-observed positive `lease_epoch`; transport attach reuses that
+  lease generation and does not create the next epoch.
 
 ## Connect + turn sequence
 

--- a/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
@@ -176,6 +176,7 @@ public static class ServiceCollectionExtensions
         }
 
         services.TryAddSingleton<IVoicePresenceCapabilityQueryPort, VoicePresenceCapabilityQueryPort>();
+        services.TryAddSingleton<IVoicePresenceLeaseObservationPort, VoicePresenceLeaseObservationPort>();
         services.TryAddSingleton<IVoicePresenceSessionLeasePort, VoicePresenceSessionLeasePort>();
         services.TryAddSingleton<IVoicePresenceTransportAttachmentPort, VoicePresenceTransportAttachmentPort>();
         services.TryAddSingleton<IVoiceVolatileMediaStreamPort, VoiceVolatileMediaStreamPort>();
@@ -319,7 +320,7 @@ public static class ServiceCollectionExtensions
                 handle.SessionId,
                 handle.OwnerId,
                 handle.ActiveTransportLeaseId ?? string.Empty,
-                0,
+                handle.LeaseEpoch,
                 Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset(handle.ExpiresAtUtc.ToUniversalTime()),
                 handle.ActorId,
                 handle.ModuleName),

--- a/src/Aevatar.Foundation.VoicePresence.Abstractions/Protos/voice_presence.proto
+++ b/src/Aevatar.Foundation.VoicePresence.Abstractions/Protos/voice_presence.proto
@@ -384,4 +384,6 @@ message VoicePresenceCapabilityReadModel {
   google.protobuf.Timestamp lease_expires_at = 11;
   VoiceRemoteAudioSupport remote_audio_support = 12;
   string active_transport_lease_id = 13;
+  int64 lease_epoch = 14;
+  string active_lease_owner_id = 15;
 }

--- a/src/Aevatar.Foundation.VoicePresence.Abstractions/Sessions/IVoicePresenceLeaseObservationPort.cs
+++ b/src/Aevatar.Foundation.VoicePresence.Abstractions/Sessions/IVoicePresenceLeaseObservationPort.cs
@@ -1,0 +1,13 @@
+namespace Aevatar.Foundation.VoicePresence.Abstractions.Sessions;
+
+public interface IVoicePresenceLeaseObservationPort
+{
+    Task<VoicePresenceCapabilitySnapshot> ObserveSessionLeaseAsync(
+        VoicePresenceSessionLeaseRequest request,
+        CancellationToken ct = default);
+
+    Task<VoicePresenceCapabilitySnapshot> ObserveTransportAttachAsync(
+        VoicePresenceSessionLeaseHandle handle,
+        string transportLeaseId,
+        CancellationToken ct = default);
+}

--- a/src/Aevatar.Foundation.VoicePresence.Abstractions/Sessions/VoicePresenceCapabilitySnapshot.cs
+++ b/src/Aevatar.Foundation.VoicePresence.Abstractions/Sessions/VoicePresenceCapabilitySnapshot.cs
@@ -15,4 +15,6 @@ public sealed record VoicePresenceCapabilitySnapshot(
     string? ActiveSessionId,
     DateTimeOffset? LeaseExpiresAt,
     VoiceRemoteAudioSupport RemoteAudioSupport,
-    string? ActiveTransportLeaseId = null);
+    string? ActiveTransportLeaseId = null,
+    long LeaseEpoch = 0,
+    string? ActiveLeaseOwnerId = null);

--- a/src/Aevatar.Foundation.VoicePresence.Abstractions/Sessions/VoicePresenceSessionLeaseHandle.cs
+++ b/src/Aevatar.Foundation.VoicePresence.Abstractions/Sessions/VoicePresenceSessionLeaseHandle.cs
@@ -11,4 +11,5 @@ public sealed record VoicePresenceSessionLeaseHandle(
     long ObservedStateVersion,
     DateTimeOffset ExpiresAtUtc,
     VoiceRemoteAudioSupport RemoteAudioSupport,
-    string? ActiveTransportLeaseId = null);
+    string? ActiveTransportLeaseId = null,
+    long LeaseEpoch = 0);

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/ActorOwnedVoiceRealtimeSession.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/ActorOwnedVoiceRealtimeSession.cs
@@ -59,7 +59,8 @@ public sealed class ActorOwnedVoiceRealtimeSession
                     capability.StateVersion,
                     capability.LeaseExpiresAt ?? _timeProvider.GetUtcNow(),
                     capability.RemoteAudioSupport,
-                    capability.ActiveTransportLeaseId));
+                    capability.ActiveTransportLeaseId,
+                    capability.LeaseEpoch));
             if (onAcceptedAsync != null)
                 await onAcceptedAsync(acceptedDetach, ct);
 

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceLeaseObservationPort.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceLeaseObservationPort.cs
@@ -1,0 +1,127 @@
+using Aevatar.Foundation.VoicePresence.Abstractions.Sessions;
+
+namespace Aevatar.Foundation.VoicePresence.Hosting;
+
+public sealed class VoicePresenceLeaseObservationPort : IVoicePresenceLeaseObservationPort
+{
+    private static readonly TimeSpan DefaultObservationTimeout = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan ObservationInterval = TimeSpan.FromMilliseconds(100);
+
+    private readonly IVoicePresenceCapabilityQueryPort _queryPort;
+    private readonly TimeProvider _timeProvider;
+    private readonly TimeSpan _observationTimeout;
+    private readonly TimeSpan _observationInterval;
+
+    public VoicePresenceLeaseObservationPort(IVoicePresenceCapabilityQueryPort queryPort)
+        : this(queryPort, null, DefaultObservationTimeout, ObservationInterval)
+    {
+    }
+
+    internal VoicePresenceLeaseObservationPort(
+        IVoicePresenceCapabilityQueryPort queryPort,
+        TimeProvider? timeProvider,
+        TimeSpan observationTimeout,
+        TimeSpan observationInterval)
+    {
+        _queryPort = queryPort ?? throw new ArgumentNullException(nameof(queryPort));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _observationTimeout = observationTimeout;
+        _observationInterval = observationInterval;
+    }
+
+    public Task<VoicePresenceCapabilitySnapshot> ObserveSessionLeaseAsync(
+        VoicePresenceSessionLeaseRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return ObserveAsync(
+            request.ActorId,
+            request.ModuleName,
+            snapshot => MatchesSessionLease(request, snapshot, _timeProvider.GetUtcNow()),
+            "Voice presence session lease was not observed.",
+            ct);
+    }
+
+    public Task<VoicePresenceCapabilitySnapshot> ObserveTransportAttachAsync(
+        VoicePresenceSessionLeaseHandle handle,
+        string transportLeaseId,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(handle);
+        ArgumentException.ThrowIfNullOrWhiteSpace(transportLeaseId);
+        return ObserveAsync(
+            handle.ActorId,
+            handle.ModuleName,
+            snapshot => MatchesTransportAttach(handle, transportLeaseId, snapshot, _timeProvider.GetUtcNow()),
+            "Voice presence transport attach was not observed.",
+            ct);
+    }
+
+    private async Task<VoicePresenceCapabilitySnapshot> ObserveAsync(
+        string actorId,
+        string moduleName,
+        Func<VoicePresenceCapabilitySnapshot, bool> matches,
+        string failureMessage,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(actorId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(moduleName);
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(_observationTimeout);
+
+        try
+        {
+            while (true)
+            {
+                timeoutCts.Token.ThrowIfCancellationRequested();
+
+                var snapshot = await _queryPort.GetAsync(actorId, moduleName, timeoutCts.Token);
+                if (snapshot != null && matches(snapshot))
+                    return snapshot;
+
+                await Task.Delay(_observationInterval, _timeProvider, timeoutCts.Token);
+            }
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            throw new TimeoutException(failureMessage);
+        }
+    }
+
+    private static bool MatchesSessionLease(
+        VoicePresenceSessionLeaseRequest request,
+        VoicePresenceCapabilitySnapshot snapshot,
+        DateTimeOffset utcNow) =>
+        MatchesActorModule(request.ActorId, request.ModuleName, snapshot) &&
+        string.Equals(snapshot.ActiveSessionId, request.SessionId, StringComparison.Ordinal) &&
+        string.Equals(snapshot.ActiveLeaseOwnerId, request.OwnerId, StringComparison.Ordinal) &&
+        snapshot.StateVersion > request.ObservedStateVersion &&
+        snapshot.LeaseEpoch > 0 &&
+        HasActiveLeaseExpiry(snapshot.LeaseExpiresAt, utcNow);
+
+    private static bool MatchesTransportAttach(
+        VoicePresenceSessionLeaseHandle handle,
+        string transportLeaseId,
+        VoicePresenceCapabilitySnapshot snapshot,
+        DateTimeOffset utcNow) =>
+        MatchesActorModule(handle.ActorId, handle.ModuleName, snapshot) &&
+        string.Equals(snapshot.ActiveSessionId, handle.SessionId, StringComparison.Ordinal) &&
+        string.Equals(snapshot.ActiveLeaseOwnerId, handle.OwnerId, StringComparison.Ordinal) &&
+        snapshot.TransportAttached &&
+        string.Equals(snapshot.ActiveTransportLeaseId, transportLeaseId, StringComparison.Ordinal) &&
+        snapshot.LeaseEpoch == handle.LeaseEpoch &&
+        snapshot.LeaseEpoch > 0 &&
+        HasActiveLeaseExpiry(snapshot.LeaseExpiresAt, utcNow);
+
+    private static bool MatchesActorModule(
+        string actorId,
+        string moduleName,
+        VoicePresenceCapabilitySnapshot snapshot) =>
+        string.Equals(snapshot.ActorId, actorId, StringComparison.Ordinal) &&
+        string.Equals(snapshot.ModuleName, moduleName, StringComparison.OrdinalIgnoreCase);
+
+    private static bool HasActiveLeaseExpiry(DateTimeOffset? leaseExpiresAt, DateTimeOffset utcNow) =>
+        leaseExpiresAt.HasValue &&
+        leaseExpiresAt.Value.ToUniversalTime() > utcNow;
+}

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceSessionLeasePort.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceSessionLeasePort.cs
@@ -8,10 +8,14 @@ namespace Aevatar.Foundation.VoicePresence.Hosting;
 public sealed class VoicePresenceSessionLeasePort : IVoicePresenceSessionLeasePort
 {
     private readonly IActorDispatchPort _dispatchPort;
+    private readonly IVoicePresenceLeaseObservationPort _observationPort;
 
-    public VoicePresenceSessionLeasePort(IActorDispatchPort dispatchPort)
+    public VoicePresenceSessionLeasePort(
+        IActorDispatchPort dispatchPort,
+        IVoicePresenceLeaseObservationPort observationPort)
     {
         _dispatchPort = dispatchPort ?? throw new ArgumentNullException(nameof(dispatchPort));
+        _observationPort = observationPort ?? throw new ArgumentNullException(nameof(observationPort));
     }
 
     public async Task<VoicePresenceSessionLeaseHandle> AcquireAsync(
@@ -39,14 +43,18 @@ public sealed class VoicePresenceSessionLeasePort : IVoicePresenceSessionLeasePo
                 }),
             ct);
 
+        var observed = await _observationPort.ObserveSessionLeaseAsync(request, ct);
+
         return new VoicePresenceSessionLeaseHandle(
             request.ActorId,
             request.ModuleName,
             request.SessionId,
             request.OwnerId,
-            request.ObservedStateVersion,
-            expiresAtUtc,
-            request.ObservedRemoteAudioSupport);
+            observed.StateVersion,
+            observed.LeaseExpiresAt?.ToUniversalTime() ?? expiresAtUtc,
+            observed.RemoteAudioSupport,
+            observed.ActiveTransportLeaseId,
+            observed.LeaseEpoch);
     }
 
     public Task ReleaseAsync(
@@ -91,6 +99,7 @@ public sealed class VoicePresenceSessionLeasePort : IVoicePresenceSessionLeasePo
                     OwnerId = handle.OwnerId,
                     TransportLeaseId = transportLeaseId,
                     LeaseExpiresAt = Timestamp.FromDateTimeOffset(handle.ExpiresAtUtc.ToUniversalTime()),
+                    LeaseEpoch = handle.LeaseEpoch,
                     Reason = reason,
                 }),
             ct);

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceTransportAttachmentPort.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceTransportAttachmentPort.cs
@@ -5,11 +5,15 @@ using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.Foundation.VoicePresence.Hosting;
 
-public sealed class VoicePresenceTransportAttachmentPort(IActorDispatchPort dispatchPort)
+public sealed class VoicePresenceTransportAttachmentPort(
+    IActorDispatchPort dispatchPort,
+    IVoicePresenceLeaseObservationPort observationPort)
     : IVoicePresenceTransportAttachmentPort
 {
     private readonly IActorDispatchPort _dispatchPort =
         dispatchPort ?? throw new ArgumentNullException(nameof(dispatchPort));
+    private readonly IVoicePresenceLeaseObservationPort _observationPort =
+        observationPort ?? throw new ArgumentNullException(nameof(observationPort));
 
     public async Task<VoicePresenceSessionLeaseHandle> AttachAsync(
         VoicePresenceSessionLeaseHandle handle,
@@ -20,11 +24,6 @@ public sealed class VoicePresenceTransportAttachmentPort(IActorDispatchPort disp
         ArgumentNullException.ThrowIfNull(transport);
 
         var transportLeaseId = Guid.NewGuid().ToString("N");
-        var attachedHandle = handle with
-        {
-            ActiveTransportLeaseId = transportLeaseId,
-        };
-
         await _dispatchPort.DispatchAsync(
             handle.ActorId,
             VoicePresenceSessionDispatch.BuildDirectEnvelope(
@@ -36,10 +35,17 @@ public sealed class VoicePresenceTransportAttachmentPort(IActorDispatchPort disp
                     OwnerId = handle.OwnerId,
                     TransportLeaseId = transportLeaseId,
                     LeaseExpiresAt = Timestamp.FromDateTimeOffset(handle.ExpiresAtUtc.ToUniversalTime()),
+                    LeaseEpoch = handle.LeaseEpoch,
                 }),
             ct);
 
-        return attachedHandle;
+        var observed = await _observationPort.ObserveTransportAttachAsync(handle, transportLeaseId, ct);
+        return handle with
+        {
+            ObservedStateVersion = observed.StateVersion,
+            ActiveTransportLeaseId = transportLeaseId,
+            LeaseEpoch = observed.LeaseEpoch,
+        };
     }
 
     public Task DetachAsync(
@@ -65,6 +71,7 @@ public sealed class VoicePresenceTransportAttachmentPort(IActorDispatchPort disp
                     OwnerId = handle.OwnerId,
                     TransportLeaseId = transportLeaseId,
                     LeaseExpiresAt = Timestamp.FromDateTimeOffset(handle.ExpiresAtUtc.ToUniversalTime()),
+                    LeaseEpoch = handle.LeaseEpoch,
                     Reason = "host_transport_detached",
                 }),
             ct);

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/VoiceVolatileMediaStreamPort.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/VoiceVolatileMediaStreamPort.cs
@@ -161,6 +161,7 @@ public sealed class VoiceVolatileMediaStreamPort(
                     OwnerId = sessionKey.OwnerId,
                     TransportLeaseId = sessionKey.TransportLeaseId,
                     LeaseExpiresAt = sessionKey.LeaseExpiresAt?.Clone(),
+                    LeaseEpoch = sessionKey.LeaseEpoch,
                     ProviderEvent = providerEvent.Clone(),
                 }),
             ct);
@@ -181,6 +182,7 @@ public sealed class VoiceVolatileMediaStreamPort(
                     OwnerId = handle.OwnerId,
                     TransportLeaseId = handle.ActiveTransportLeaseId ?? string.Empty,
                     LeaseExpiresAt = Timestamp.FromDateTimeOffset(handle.ExpiresAtUtc.ToUniversalTime()),
+                    LeaseEpoch = handle.LeaseEpoch,
                     ControlFrame = controlFrame.Clone(),
                 }),
             ct);
@@ -200,6 +202,7 @@ public sealed class VoiceVolatileMediaStreamPort(
                     OwnerId = handle.OwnerId,
                     TransportLeaseId = handle.ActiveTransportLeaseId ?? string.Empty,
                     LeaseExpiresAt = Timestamp.FromDateTimeOffset(handle.ExpiresAtUtc.ToUniversalTime()),
+                    LeaseEpoch = handle.LeaseEpoch,
                     InputImage = inputImage.Clone(),
                 }),
             ct);
@@ -213,6 +216,7 @@ public sealed class VoiceVolatileMediaStreamPort(
             OwnerId = handle.OwnerId,
             TransportLeaseId = handle.ActiveTransportLeaseId ?? string.Empty,
             LeaseExpiresAt = Timestamp.FromDateTimeOffset(handle.ExpiresAtUtc.ToUniversalTime()),
+            LeaseEpoch = handle.LeaseEpoch,
             Reason = reason,
         };
 

--- a/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
@@ -480,6 +480,7 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
 
         if (!MatchesLeaseOwner(state, request.OwnerId) ||
             !MatchesLeaseExpiry(state, request.LeaseExpiresAt) ||
+            !MatchesLeaseEpoch(state, request.LeaseEpoch) ||
             IsLeaseExpired(state.LeaseExpiresAt))
         {
             return;
@@ -494,7 +495,6 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         state.TransportAttached = true;
         state.ActiveLeaseOwnerId = request.OwnerId;
         state.ActiveTransportLeaseId = request.TransportLeaseId;
-        state.LeaseEpoch = request.LeaseEpoch > 0 ? request.LeaseEpoch : NextLeaseEpoch(state);
         RefreshCapabilityFacts(state, ctx);
 
         await PersistRuntimeStateAsync(ctx, state, ct);
@@ -659,7 +659,7 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
     }
 
     private static bool MatchesLeaseEpoch(VoicePresenceRuntimeState state, long leaseEpoch) =>
-        leaseEpoch <= 0 || state.LeaseEpoch == leaseEpoch;
+        leaseEpoch > 0 && state.LeaseEpoch == leaseEpoch;
 
     private static long NextLeaseEpoch(VoicePresenceRuntimeState state) =>
         state.LeaseEpoch <= 0 ? 1 : state.LeaseEpoch + 1;

--- a/src/Aevatar.Foundation.VoicePresence/Projection/VoicePresenceCapabilityReadModelMapper.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Projection/VoicePresenceCapabilityReadModelMapper.cs
@@ -45,6 +45,8 @@ internal static class VoicePresenceCapabilityReadModelMapper
                 ? VoiceRemoteAudioSupport.LocalOnly
                 : state.RemoteAudioSupport,
             ActiveTransportLeaseId = state.ActiveTransportLeaseId ?? string.Empty,
+            LeaseEpoch = state.LeaseEpoch,
+            ActiveLeaseOwnerId = state.ActiveLeaseOwnerId ?? string.Empty,
         };
     }
 
@@ -68,7 +70,9 @@ internal static class VoicePresenceCapabilityReadModelMapper
             readModel.RemoteAudioSupport == VoiceRemoteAudioSupport.Unspecified
                 ? VoiceRemoteAudioSupport.LocalOnly
                 : readModel.RemoteAudioSupport,
-            string.IsNullOrWhiteSpace(readModel.ActiveTransportLeaseId) ? null : readModel.ActiveTransportLeaseId);
+            string.IsNullOrWhiteSpace(readModel.ActiveTransportLeaseId) ? null : readModel.ActiveTransportLeaseId,
+            readModel.LeaseEpoch,
+            string.IsNullOrWhiteSpace(readModel.ActiveLeaseOwnerId) ? null : readModel.ActiveLeaseOwnerId);
     }
 
     public static string NormalizeModuleName(string? moduleName) =>

--- a/test/Aevatar.Bootstrap.Tests/AIFeatureBootstrapCoverageTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/AIFeatureBootstrapCoverageTests.cs
@@ -176,6 +176,7 @@ public class AIFeatureBootstrapCoverageTests
         services.AddSingleton<IActorDispatchPort, NoOpActorDispatchPort>();
         services.AddSingleton<IProjectionDocumentReader<VoicePresenceCapabilityReadModel, string>>(
             new EmptyVoicePresenceCapabilityReader());
+        AddVoicePresenceTestCredentialResolver(services);
 
         services.AddAevatarAIFeatures(config, options =>
         {
@@ -239,6 +240,7 @@ public class AIFeatureBootstrapCoverageTests
         services.AddSingleton<IActorDispatchPort, NoOpActorDispatchPort>();
         services.AddSingleton<IProjectionDocumentReader<VoicePresenceCapabilityReadModel, string>>(
             new EmptyVoicePresenceCapabilityReader());
+        AddVoicePresenceTestCredentialResolver(services);
 
         services.AddAevatarAIFeatures(config, options =>
         {
@@ -284,100 +286,6 @@ public class AIFeatureBootstrapCoverageTests
             },
             Route = EnvelopeRouteSemantics.CreateDirect("device-events.callback", "voice-agent"),
         }).Should().BeFalse();
-    }
-
-    [Fact]
-    public void AddAevatarAIFeatures_WhenVoicePresenceOpenAIEndpointOnlyConfigured_ShouldNotRegisterOpenAI()
-    {
-        using var envScope = new EnvironmentVariablesScope(new Dictionary<string, string?>
-        {
-            ["OPENAI_API_KEY"] = null,
-        });
-
-        var services = new ServiceCollection();
-        var config = new ConfigurationBuilder().Build();
-        services.AddLogging();
-        services.AddSingleton<IActorDispatchPort, NoOpActorDispatchPort>();
-        services.AddSingleton<IProjectionDocumentReader<VoicePresenceCapabilityReadModel, string>>(
-            new EmptyVoicePresenceCapabilityReader());
-
-        services.AddAevatarAIFeatures(config, options =>
-        {
-            options.EnableMEAIProviders = false;
-            options.VoicePresence.DefaultProvider = "minicpm";
-            options.VoicePresence.OpenAIProvider = new VoiceProviderConfig
-            {
-                ProviderName = "openai",
-                Endpoint = "https://nyx.example.com/api/v1/proxy/s/llm-openai",
-            };
-            options.VoicePresence.OpenAISession = new VoiceSessionConfig
-            {
-                Voice = "alloy",
-                SampleRateHz = 24000,
-            };
-            options.VoicePresence.MiniCPMProvider = new VoiceProviderConfig
-            {
-                ProviderName = "minicpm",
-                Endpoint = "https://minicpm.example.com",
-            };
-            options.VoicePresence.MiniCPMSession = new VoiceSessionConfig
-            {
-                SampleRateHz = 16000,
-            };
-        });
-
-        using var provider = services.BuildServiceProvider();
-        var factory = provider.GetServices<IEventModuleFactory<IEventHandlerContext>>()
-            .OfType<VoicePresenceModuleFactory>()
-            .Single();
-
-        factory.TryCreate("voice_presence", out var defaultModule).Should().BeTrue();
-        defaultModule.Should().BeOfType<VoicePresenceModule>();
-
-        factory.TryCreate("voice_presence_openai", out var openAIModule).Should().BeFalse();
-        openAIModule.Should().BeNull();
-    }
-
-    [Fact]
-    public void AddAevatarAIFeatures_WhenVoicePresenceMiniCpmConfiguredAsDefault_ShouldCreateDefaultAlias()
-    {
-        using var envScope = new EnvironmentVariablesScope(new Dictionary<string, string?>
-        {
-            ["OPENAI_API_KEY"] = null,
-        });
-
-        var services = new ServiceCollection();
-        var config = new ConfigurationBuilder().Build();
-        services.AddLogging();
-
-        services.AddAevatarAIFeatures(config, options =>
-        {
-            options.EnableMEAIProviders = false;
-            options.VoicePresence.DefaultProvider = "minicpm-o";
-            options.VoicePresence.MiniCPMProvider = new VoiceProviderConfig
-            {
-                ProviderName = "minicpm-o",
-                Endpoint = "https://minicpm.example.com",
-            };
-            options.VoicePresence.MiniCPMSession = new VoiceSessionConfig
-            {
-                SampleRateHz = 16000,
-            };
-        });
-
-        using var provider = services.BuildServiceProvider();
-        var factory = provider.GetServices<IEventModuleFactory<IEventHandlerContext>>()
-            .OfType<VoicePresenceModuleFactory>()
-            .Single();
-
-        factory.TryCreate("voice_presence", out var defaultModule).Should().BeTrue();
-        defaultModule.Should().BeOfType<VoicePresenceModule>();
-
-        factory.TryCreate("voice_presence_minicpm_o", out var miniCpmModule).Should().BeTrue();
-        miniCpmModule.Should().BeOfType<VoicePresenceModule>();
-
-        factory.TryCreate("voice_presence_openai", out var openAIModule).Should().BeFalse();
-        openAIModule.Should().BeNull();
     }
 
     [Fact]
@@ -773,6 +681,9 @@ public class AIFeatureBootstrapCoverageTests
         return property!.GetValue(configuredProvider) as string;
     }
 
+    private static void AddVoicePresenceTestCredentialResolver(IServiceCollection services) =>
+        services.AddSingleton<IRealtimeProviderCredentialResolver, NoOpRealtimeProviderCredentialResolver>();
+
     private sealed class EnvironmentVariablesScope : IDisposable
     {
         private readonly Dictionary<string, string?> _previousValues = new(StringComparer.Ordinal);
@@ -908,4 +819,14 @@ public class AIFeatureBootstrapCoverageTests
             CancellationToken ct = default) =>
             Task.FromResult(ProjectionDocumentQueryResult<VoicePresenceCapabilityReadModel>.Empty);
     }
+
+    private sealed class NoOpRealtimeProviderCredentialResolver : IRealtimeProviderCredentialResolver
+    {
+        public Task<string?> ResolveApiKeyAsync(
+            VoiceProviderSessionKey sessionKey,
+            VoiceProviderConfig config,
+            CancellationToken ct) =>
+            Task.FromResult<string?>(null);
+    }
+
 }

--- a/test/Aevatar.Bootstrap.Tests/VoicePresenceBootstrapTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/VoicePresenceBootstrapTests.cs
@@ -1,0 +1,255 @@
+using System.Reflection;
+using Aevatar.AI.Abstractions.Voice;
+using Aevatar.Bootstrap.Extensions.AI;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.EventModules;
+using Aevatar.Foundation.VoicePresence;
+using Aevatar.Foundation.VoicePresence.Abstractions;
+using Aevatar.Foundation.VoicePresence.Abstractions.Sessions;
+using Aevatar.Foundation.VoicePresence.Hosting;
+using Aevatar.Foundation.VoicePresence.Modules;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.Bootstrap.Tests;
+
+[Collection(ProcessEnvSerialCollection.Name)]
+public sealed class VoicePresenceBootstrapTests
+{
+    [Fact]
+    public void AddAevatarAIFeatures_ShouldRegisterLeaseObservationPort()
+    {
+        var services = new ServiceCollection();
+        var config = new ConfigurationBuilder().Build();
+
+        services.AddAevatarAIFeatures(config, options => options.EnableMEAIProviders = false);
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IVoicePresenceLeaseObservationPort>()
+            .Should().BeOfType<VoicePresenceLeaseObservationPort>();
+    }
+
+    [Fact]
+    public void AddAevatarAIFeatures_WhenVoicePresenceOpenAIEndpointOnlyConfigured_ShouldRegisterOpenAIThroughBroker()
+    {
+        using var envScope = new EnvironmentVariablesScope(new Dictionary<string, string?>
+        {
+            ["OPENAI_API_KEY"] = null,
+        });
+
+        var services = new ServiceCollection();
+        var config = new ConfigurationBuilder().Build();
+        services.AddLogging();
+        AddVoicePresenceTestCredentialResolver(services);
+
+        services.AddAevatarAIFeatures(config, options =>
+        {
+            options.EnableMEAIProviders = false;
+            options.VoicePresence.DefaultProvider = "minicpm";
+            options.VoicePresence.OpenAIProvider = new VoiceProviderConfig
+            {
+                ProviderName = "openai",
+                Endpoint = "https://nyx.example.com/api/v1/proxy/s/llm-openai",
+            };
+            options.VoicePresence.OpenAISession = new VoiceSessionConfig
+            {
+                Voice = "alloy",
+                SampleRateHz = 24000,
+            };
+            options.VoicePresence.MiniCPMProvider = new VoiceProviderConfig
+            {
+                ProviderName = "minicpm",
+                Endpoint = "https://minicpm.example.com",
+            };
+            options.VoicePresence.MiniCPMSession = new VoiceSessionConfig
+            {
+                SampleRateHz = 16000,
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var factory = provider.GetServices<IEventModuleFactory<IEventHandlerContext>>()
+            .OfType<VoicePresenceModuleFactory>()
+            .Single();
+
+        factory.TryCreate("voice_presence", out var defaultModule).Should().BeTrue();
+        defaultModule.Should().BeOfType<VoicePresenceModule>();
+
+        factory.TryCreate("voice_presence_openai", out var openAIModule).Should().BeTrue();
+        openAIModule.Should().BeOfType<VoicePresenceModule>();
+    }
+
+    [Fact]
+    public void AddAevatarAIFeatures_WhenVoicePresenceMiniCpmConfiguredAsDefault_ShouldCreateDefaultAlias()
+    {
+        using var envScope = new EnvironmentVariablesScope(new Dictionary<string, string?>
+        {
+            ["OPENAI_API_KEY"] = null,
+        });
+
+        var services = new ServiceCollection();
+        var config = new ConfigurationBuilder().Build();
+        services.AddLogging();
+        AddVoicePresenceTestCredentialResolver(services);
+
+        services.AddAevatarAIFeatures(config, options =>
+        {
+            options.EnableMEAIProviders = false;
+            options.VoicePresence.DefaultProvider = "minicpm-o";
+            options.VoicePresence.MiniCPMProvider = new VoiceProviderConfig
+            {
+                ProviderName = "minicpm-o",
+                Endpoint = "https://minicpm.example.com",
+            };
+            options.VoicePresence.MiniCPMSession = new VoiceSessionConfig
+            {
+                SampleRateHz = 16000,
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var factory = provider.GetServices<IEventModuleFactory<IEventHandlerContext>>()
+            .OfType<VoicePresenceModuleFactory>()
+            .Single();
+
+        factory.TryCreate("voice_presence", out var defaultModule).Should().BeTrue();
+        defaultModule.Should().BeOfType<VoicePresenceModule>();
+
+        factory.TryCreate("voice_presence_minicpm_o", out var miniCpmModule).Should().BeTrue();
+        miniCpmModule.Should().BeOfType<VoicePresenceModule>();
+
+        factory.TryCreate("voice_presence_openai", out var openAIModule).Should().BeTrue();
+        openAIModule.Should().BeOfType<VoicePresenceModule>();
+    }
+
+    [Fact]
+    public async Task ConnectVoiceProviderSessionAsync_ShouldUseHandleLeaseEpochInProviderSessionKey()
+    {
+        var provider = new RecordingRealtimeVoiceProvider();
+        var handle = new VoicePresenceSessionLeaseHandle(
+            "agent-1",
+            "voice_presence",
+            "lease-1",
+            "host-1",
+            8,
+            DateTimeOffset.UtcNow.AddMinutes(5),
+            VoiceRemoteAudioSupport.Supported,
+            "transport-1",
+            17);
+
+        await using var session = await InvokeConnectVoiceProviderSessionAsync(
+            handle,
+            provider,
+            new VoiceProviderConfig { ProviderName = "test" },
+            new VoiceSessionConfig { SampleRateHz = 24000 },
+            toolCatalog: null);
+
+        provider.SessionKey.Should().NotBeNull();
+        provider.SessionKey!.LeaseEpoch.Should().Be(17);
+        provider.SessionKey.TransportLeaseId.Should().Be("transport-1");
+    }
+
+    private static async Task<RealtimeVoiceProviderSession> InvokeConnectVoiceProviderSessionAsync(
+        VoicePresenceSessionLeaseHandle handle,
+        IRealtimeVoiceProvider provider,
+        VoiceProviderConfig providerConfig,
+        VoiceSessionConfig sessionConfig,
+        IVoiceToolCatalog? toolCatalog)
+    {
+        var method = typeof(global::Aevatar.Bootstrap.Extensions.AI.ServiceCollectionExtensions).GetMethod(
+            "ConnectVoiceProviderSessionAsync",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        method.Should().NotBeNull();
+
+        var task = method!.Invoke(null,
+        [
+            handle,
+            provider,
+            providerConfig,
+            sessionConfig,
+            toolCatalog,
+            new Func<VoiceProviderSessionKey, VoiceProviderEvent, CancellationToken, Task>(
+                static (_, _, _) => Task.CompletedTask),
+            new Func<VoiceProviderSessionKey, VoiceProviderAudioFrame, CancellationToken, Task>(
+                static (_, _, _) => Task.CompletedTask),
+            CancellationToken.None,
+        ]).Should().BeAssignableTo<Task<RealtimeVoiceProviderSession>>().Subject;
+
+        return await task;
+    }
+
+    private static void AddVoicePresenceTestCredentialResolver(IServiceCollection services) =>
+        services.AddSingleton<IRealtimeProviderCredentialResolver, NoOpRealtimeProviderCredentialResolver>();
+
+    private sealed class EnvironmentVariablesScope : IDisposable
+    {
+        private readonly Dictionary<string, string?> _previousValues = new(StringComparer.Ordinal);
+
+        public EnvironmentVariablesScope(IReadOnlyDictionary<string, string?> overrides)
+        {
+            foreach (var pair in overrides)
+            {
+                _previousValues[pair.Key] = Environment.GetEnvironmentVariable(pair.Key);
+                Environment.SetEnvironmentVariable(pair.Key, pair.Value);
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (var pair in _previousValues)
+                Environment.SetEnvironmentVariable(pair.Key, pair.Value);
+        }
+    }
+
+    private sealed class NoOpRealtimeProviderCredentialResolver : IRealtimeProviderCredentialResolver
+    {
+        public Task<string?> ResolveApiKeyAsync(
+            VoiceProviderSessionKey sessionKey,
+            VoiceProviderConfig config,
+            CancellationToken ct) =>
+            Task.FromResult<string?>(null);
+    }
+
+    private sealed class RecordingRealtimeVoiceProvider : IRealtimeVoiceProvider
+    {
+        public VoiceProviderSessionKey? SessionKey { get; private set; }
+
+        public Task<RealtimeVoiceProviderSession> ConnectAsync(
+            VoiceProviderSessionKey sessionKey,
+            VoiceProviderConfig config,
+            Func<VoiceProviderSessionKey, VoiceProviderEvent, CancellationToken, Task> eventSink,
+            Func<VoiceProviderSessionKey, VoiceProviderAudioFrame, CancellationToken, Task> audioSink,
+            CancellationToken ct)
+        {
+            _ = config;
+            _ = eventSink;
+            _ = audioSink;
+            _ = ct;
+            SessionKey = sessionKey;
+            return Task.FromResult<RealtimeVoiceProviderSession>(new RecordingRealtimeVoiceProviderSession());
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class RecordingRealtimeVoiceProviderSession : RealtimeVoiceProviderSession
+    {
+        public override Task SendAudioAsync(ReadOnlyMemory<byte> pcm16, CancellationToken ct) => Task.CompletedTask;
+
+        public override Task SendInputImageAsync(VoiceInputImage inputImage, CancellationToken ct) => Task.CompletedTask;
+
+        public override Task SendToolResultAsync(string callId, string resultJson, CancellationToken ct) =>
+            Task.CompletedTask;
+
+        public override Task InjectEventAsync(VoiceConversationEventInjection injection, CancellationToken ct) =>
+            Task.CompletedTask;
+
+        public override Task CancelResponseAsync(CancellationToken ct) => Task.CompletedTask;
+
+        public override Task UpdateSessionAsync(VoiceSessionConfig session, CancellationToken ct) => Task.CompletedTask;
+
+        public override ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
@@ -108,6 +108,7 @@ public class VoicePresenceModuleTests
             InputImageReceived = new VoiceInputImageReceived
             {
                 SessionId = "session-1",
+                LeaseEpoch = 7,
                 InputImage = new VoiceInputImage
                 {
                     MediaType = "image/png",
@@ -744,6 +745,7 @@ public class VoicePresenceModuleTests
             ActiveLeaseOwnerId = "host-1",
             LeaseExpiresAt = expiresAt.Clone(),
             Initialized = true,
+            LeaseEpoch = 7,
         };
         var ctx = new StubEventHandlerContext(agent: roleAgent);
 
@@ -756,6 +758,7 @@ public class VoicePresenceModuleTests
                 OwnerId = "host-1",
                 TransportLeaseId = "transport-1",
                 LeaseExpiresAt = expiresAt.Clone(),
+                LeaseEpoch = 7,
             },
         }), ctx, CancellationToken.None);
 
@@ -786,6 +789,7 @@ public class VoicePresenceModuleTests
             ActiveLeaseOwnerId = "host-1",
             LeaseExpiresAt = activeExpiry.Clone(),
             Initialized = true,
+            LeaseEpoch = 7,
         };
         var ctx = new StubEventHandlerContext(agent: roleAgent);
 
@@ -798,6 +802,7 @@ public class VoicePresenceModuleTests
                 OwnerId = "host-2",
                 TransportLeaseId = "transport-1",
                 LeaseExpiresAt = activeExpiry.Clone(),
+                LeaseEpoch = 7,
             },
         }), ctx, CancellationToken.None);
 
@@ -816,6 +821,42 @@ public class VoicePresenceModuleTests
                 OwnerId = "host-1",
                 TransportLeaseId = "transport-1",
                 LeaseExpiresAt = Timestamp.FromDateTimeOffset(now.AddSeconds(-1)),
+                LeaseEpoch = 7,
+            },
+        }), ctx, CancellationToken.None);
+
+        roleAgent.PersistedStates.ShouldBeEmpty();
+        roleAgent.State.VoicePresence["voice_presence"].TransportAttached.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(6)]
+    public async Task Transport_attach_signal_should_reject_zero_or_stale_lease_epoch(long leaseEpoch)
+    {
+        var module = CreateModule(new RecordingVoiceProvider());
+        var roleAgent = new RecordingRoleAgent("voice-agent");
+        var expiresAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddMinutes(5));
+        roleAgent.State.VoicePresence["voice_presence"] = new VoicePresenceRuntimeState
+        {
+            ActiveSessionId = "lease-1",
+            ActiveLeaseOwnerId = "host-1",
+            LeaseExpiresAt = expiresAt.Clone(),
+            Initialized = true,
+            LeaseEpoch = 7,
+        };
+        var ctx = new StubEventHandlerContext(agent: roleAgent);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = "voice_presence",
+            TransportAttachRequested = new VoiceTransportAttachRequested
+            {
+                SessionId = "lease-1",
+                OwnerId = "host-1",
+                TransportLeaseId = "transport-1",
+                LeaseExpiresAt = expiresAt.Clone(),
+                LeaseEpoch = leaseEpoch,
             },
         }), ctx, CancellationToken.None);
 
@@ -834,6 +875,7 @@ public class VoicePresenceModuleTests
             ActiveLeaseOwnerId = "host-current",
             LeaseExpiresAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddMinutes(5)),
             TransportAttached = true,
+            LeaseEpoch = 7,
             ActiveTransportLeaseId = "transport-current",
             Status = VoicePresenceRuntimeStatus.AudioDraining,
             CurrentResponseId = 4,
@@ -852,6 +894,7 @@ public class VoicePresenceModuleTests
                 OwnerId = "host-current",
                 TransportLeaseId = "transport-old",
                 LeaseExpiresAt = roleAgent.State.VoicePresence["voice_presence"].LeaseExpiresAt.Clone(),
+                LeaseEpoch = 7,
                 ControlFrame = new VoiceControlFrame
                 {
                     DrainAcknowledged = new VoiceDrainAcknowledged
@@ -902,6 +945,7 @@ public class VoicePresenceModuleTests
                 OwnerId = "host-current",
                 TransportLeaseId = "transport-current",
                 LeaseExpiresAt = roleAgent.State.VoicePresence["voice_presence"].LeaseExpiresAt.Clone(),
+                LeaseEpoch = 7,
                 ControlFrame = new VoiceControlFrame
                 {
                     DrainAcknowledged = new VoiceDrainAcknowledged
@@ -929,6 +973,7 @@ public class VoicePresenceModuleTests
             ActiveLeaseOwnerId = "host-current",
             LeaseExpiresAt = expiresAt.Clone(),
             TransportAttached = true,
+            LeaseEpoch = 7,
             ActiveTransportLeaseId = "transport-current",
             Status = VoicePresenceRuntimeStatus.Idle,
             CurrentResponseId = 0,
@@ -947,6 +992,7 @@ public class VoicePresenceModuleTests
                 OwnerId = "host-current",
                 TransportLeaseId = "transport-old",
                 LeaseExpiresAt = expiresAt.Clone(),
+                LeaseEpoch = 7,
                 ProviderEvent = new VoiceProviderEvent
                 {
                     ResponseStarted = new VoiceResponseStarted { ProviderResponseId = "provider-r1" },
@@ -969,6 +1015,7 @@ public class VoicePresenceModuleTests
         {
             ActiveSessionId = "remote-current",
             RemoteSessionId = "remote-current",
+            LeaseEpoch = 7,
             Status = VoicePresenceRuntimeStatus.Idle,
             CurrentResponseId = 0,
             NextResponseId = 1,
@@ -1005,6 +1052,7 @@ public class VoicePresenceModuleTests
             ActiveLeaseOwnerId = "host-current",
             LeaseExpiresAt = expiresAt.Clone(),
             TransportAttached = true,
+            LeaseEpoch = 7,
             ActiveTransportLeaseId = "transport-current",
             Status = VoicePresenceRuntimeStatus.Idle,
             CurrentResponseId = 0,
@@ -1023,6 +1071,7 @@ public class VoicePresenceModuleTests
                 OwnerId = "host-current",
                 TransportLeaseId = "transport-current",
                 LeaseExpiresAt = expiresAt.Clone(),
+                LeaseEpoch = 7,
                 ProviderEvent = new VoiceProviderEvent
                 {
                     ResponseStarted = new VoiceResponseStarted { ProviderResponseId = "provider-r1" },
@@ -1044,6 +1093,7 @@ public class VoicePresenceModuleTests
         {
             ActiveSessionId = "remote-current",
             RemoteSessionId = "remote-current",
+            LeaseEpoch = 7,
             Status = VoicePresenceRuntimeStatus.Idle,
             CurrentResponseId = 0,
             NextResponseId = 1,
@@ -1058,6 +1108,7 @@ public class VoicePresenceModuleTests
             ProviderEventReceived = new VoiceProviderEventReceived
             {
                 SessionId = "remote-current",
+                LeaseEpoch = 7,
                 ProviderEvent = new VoiceProviderEvent
                 {
                     ResponseStarted = new VoiceResponseStarted { ProviderResponseId = "provider-r1" },
@@ -1082,6 +1133,7 @@ public class VoicePresenceModuleTests
             ActiveLeaseOwnerId = "host-current",
             LeaseExpiresAt = expiresAt.Clone(),
             TransportAttached = true,
+            LeaseEpoch = 7,
             ActiveTransportLeaseId = "transport-current",
             Status = VoicePresenceRuntimeStatus.Idle,
             CurrentResponseId = 0,
@@ -1100,6 +1152,7 @@ public class VoicePresenceModuleTests
                 OwnerId = "host-current",
                 TransportLeaseId = "transport-current",
                 LeaseExpiresAt = expiresAt.Clone(),
+                LeaseEpoch = 7,
                 Reason = "test-detach",
             },
         }), ctx, CancellationToken.None);
@@ -1121,6 +1174,7 @@ public class VoicePresenceModuleTests
             ActiveLeaseOwnerId = "host-current",
             LeaseExpiresAt = expiresAt.Clone(),
             TransportAttached = true,
+            LeaseEpoch = 7,
             ActiveTransportLeaseId = "transport-current",
             Status = VoicePresenceRuntimeStatus.Idle,
             CurrentResponseId = 0,
@@ -1139,6 +1193,7 @@ public class VoicePresenceModuleTests
                 OwnerId = "host-current",
                 TransportLeaseId = "transport-current",
                 LeaseExpiresAt = expiresAt.Clone(),
+                LeaseEpoch = 7,
                 Reason = "test-stop",
             },
         }), ctx, CancellationToken.None);
@@ -1160,6 +1215,7 @@ public class VoicePresenceModuleTests
             ActiveLeaseOwnerId = "host-current",
             LeaseExpiresAt = expiresAt.Clone(),
             TransportAttached = true,
+            LeaseEpoch = 7,
             ActiveTransportLeaseId = "transport-current",
             Status = VoicePresenceRuntimeStatus.Idle,
             CurrentResponseId = 0,
@@ -1178,6 +1234,7 @@ public class VoicePresenceModuleTests
                 OwnerId = "host-current",
                 TransportLeaseId = "transport-current",
                 LeaseExpiresAt = expiresAt.Clone(),
+                LeaseEpoch = 7,
                 Reason = "host_transport_completed",
             },
         }), ctx, CancellationToken.None);
@@ -1202,6 +1259,7 @@ public class VoicePresenceModuleTests
             ActiveLeaseOwnerId = "host-current",
             LeaseExpiresAt = expiresAt.Clone(),
             TransportAttached = true,
+            LeaseEpoch = 7,
             ActiveTransportLeaseId = "transport-current",
             Status = VoicePresenceRuntimeStatus.Idle,
             CurrentResponseId = 0,
@@ -1220,6 +1278,7 @@ public class VoicePresenceModuleTests
                 OwnerId = "host-current",
                 TransportLeaseId = "transport-stale",
                 LeaseExpiresAt = expiresAt.Clone(),
+                LeaseEpoch = 7,
                 Reason = "host_transport_completed",
             },
         }), ctx, CancellationToken.None);
@@ -1272,6 +1331,114 @@ public class VoicePresenceModuleTests
 
         roleAgent.State.VoicePresence["voice_presence"].CurrentResponseId.ShouldBe(0);
         provider.ConnectCalls.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Provider_function_call_callback_with_zero_lease_epoch_should_not_execute_tool()
+    {
+        var provider = new RecordingVoiceProvider();
+        var invoker = new RecordingVoiceToolInvoker("""{"ok":true}""");
+        var module = CreateModule(provider, toolInvoker: invoker);
+        var roleAgent = CreateRoleAgentWithAttachedTransport();
+        var ctx = new StubEventHandlerContext(agent: roleAgent);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = "voice_presence",
+            ProviderEventReceived = new VoiceProviderEventReceived
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseExpiresAt = roleAgent.State.VoicePresence["voice_presence"].LeaseExpiresAt.Clone(),
+                LeaseEpoch = 0,
+                ProviderEvent = new VoiceProviderEvent
+                {
+                    FunctionCall = new VoiceFunctionCallRequested
+                    {
+                        CallId = "call-zero",
+                        ToolName = "doorbell.open",
+                        ArgumentsJson = "{}",
+                        ResponseId = 1,
+                    },
+                },
+            },
+        }), ctx, CancellationToken.None);
+
+        invoker.Calls.ShouldBe(0);
+        provider.ToolResults.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Provider_function_call_callback_with_active_lease_epoch_should_execute_tool()
+    {
+        var provider = new RecordingVoiceProvider();
+        var invoker = new RecordingVoiceToolInvoker("""{"ok":true}""");
+        var module = CreateModule(provider, toolInvoker: invoker);
+        var roleAgent = CreateRoleAgentWithAttachedTransport();
+        var ctx = new StubEventHandlerContext(agent: roleAgent);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = "voice_presence",
+            ProviderEventReceived = new VoiceProviderEventReceived
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseExpiresAt = roleAgent.State.VoicePresence["voice_presence"].LeaseExpiresAt.Clone(),
+                LeaseEpoch = 7,
+                ProviderEvent = new VoiceProviderEvent
+                {
+                    FunctionCall = new VoiceFunctionCallRequested
+                    {
+                        CallId = "call-active",
+                        ToolName = "doorbell.open",
+                        ArgumentsJson = "{}",
+                        ResponseId = 1,
+                    },
+                },
+            },
+        }), ctx, CancellationToken.None);
+
+        invoker.Calls.ShouldBe(1);
+        provider.ToolResults.ShouldHaveSingleItem().CallId.ShouldBe("call-active");
+    }
+
+    [Fact]
+    public async Task Provider_function_call_callback_with_stale_lease_epoch_should_not_execute_tool()
+    {
+        var provider = new RecordingVoiceProvider();
+        var invoker = new RecordingVoiceToolInvoker("""{"ok":true}""");
+        var module = CreateModule(provider, toolInvoker: invoker);
+        var roleAgent = CreateRoleAgentWithAttachedTransport();
+        var ctx = new StubEventHandlerContext(agent: roleAgent);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = "voice_presence",
+            ProviderEventReceived = new VoiceProviderEventReceived
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseExpiresAt = roleAgent.State.VoicePresence["voice_presence"].LeaseExpiresAt.Clone(),
+                LeaseEpoch = 6,
+                ProviderEvent = new VoiceProviderEvent
+                {
+                    FunctionCall = new VoiceFunctionCallRequested
+                    {
+                        CallId = "call-stale",
+                        ToolName = "doorbell.open",
+                        ArgumentsJson = "{}",
+                        ResponseId = 1,
+                    },
+                },
+            },
+        }), ctx, CancellationToken.None);
+
+        invoker.Calls.ShouldBe(0);
+        provider.ToolResults.ShouldBeEmpty();
     }
 
     [Fact]
@@ -2029,6 +2196,27 @@ public class VoicePresenceModuleTests
             Initialized = true,
             RemoteSessionId = "session-1",
             ActiveSessionId = "session-1",
+            LeaseEpoch = 7,
+            Status = VoicePresenceRuntimeStatus.Idle,
+            NextResponseId = 1,
+            LastDrainAckResponseId = -1,
+            LastDrainAckPlayoutSequence = -1,
+        };
+        return roleAgent;
+    }
+
+    private static RecordingRoleAgent CreateRoleAgentWithAttachedTransport()
+    {
+        var roleAgent = new RecordingRoleAgent("voice-agent");
+        roleAgent.State.VoicePresence[DefaultModuleName] = new VoicePresenceRuntimeState
+        {
+            Initialized = true,
+            ActiveSessionId = "lease-current",
+            ActiveLeaseOwnerId = "host-current",
+            LeaseExpiresAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddMinutes(5)),
+            TransportAttached = true,
+            ActiveTransportLeaseId = "transport-current",
+            LeaseEpoch = 7,
             Status = VoicePresenceRuntimeStatus.Idle,
             NextResponseId = 1,
             LastDrainAckResponseId = -1,

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoiceRealtimeSessionTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoiceRealtimeSessionTests.cs
@@ -61,6 +61,7 @@ public class VoiceRealtimeSessionTests
         result.Receipt.ModuleName.ShouldBe("voice_presence_openai");
         result.Receipt.PcmSampleRateHz.ShouldBe(16000);
         result.Receipt.ObservedStateVersion.ShouldBe(5);
+        result.Receipt.LeaseHandle.LeaseEpoch.ShouldBe(7);
         acceptedCallbacks.ShouldHaveSingleItem().SessionId.ShouldBe(result.Receipt.SessionId);
         leasePort.AcquireRequests.ShouldHaveSingleItem().ModuleName.ShouldBe("voice_presence_openai");
     }
@@ -177,6 +178,7 @@ public class VoiceRealtimeSessionTests
         result.Receipt.ShouldNotBeNull();
         result.Receipt.SessionId.ShouldBe("session-1");
         result.Receipt.LeaseHandle.ActiveTransportLeaseId.ShouldBe("transport-1");
+        result.Receipt.LeaseHandle.LeaseEpoch.ShouldBe(7);
         leasePort.AcquireRequests.ShouldBeEmpty();
     }
 
@@ -210,6 +212,7 @@ public class VoiceRealtimeSessionTests
         detachResult.Receipt.ShouldNotBeNull();
         detachResult.Receipt.SessionId.ShouldBe("session-1");
         detachResult.Receipt.LeaseHandle.ActiveTransportLeaseId.ShouldBe("transport-1");
+        detachResult.Receipt.LeaseHandle.LeaseEpoch.ShouldBe(7);
         leasePort.AcquireRequests.ShouldBeEmpty();
     }
 
@@ -351,27 +354,34 @@ public class VoiceRealtimeSessionTests
             .ToList();
         signals.Count.ShouldBe(3);
         signals.ShouldContain(static signal =>
-            signal.SignalCase == VoiceModuleSignal.SignalOneofCase.TransportControlFrameReceived);
+            signal.SignalCase == VoiceModuleSignal.SignalOneofCase.TransportControlFrameReceived &&
+            signal.TransportControlFrameReceived.LeaseEpoch == 7);
         signals.ShouldContain(signal =>
             signal.SignalCase == VoiceModuleSignal.SignalOneofCase.InputImageReceived &&
             signal.InputImageReceived.TransportLeaseId == "transport-1" &&
+            signal.InputImageReceived.LeaseEpoch == 7 &&
             signal.InputImageReceived.InputImage.MediaType == "image/png" &&
             signal.InputImageReceived.InputImage.Data.ToByteArray().SequenceEqual(new byte[] { 5, 6, 7 }));
         signals.ShouldContain(static signal =>
-            signal.SignalCase == VoiceModuleSignal.SignalOneofCase.ProviderEventReceived);
+            signal.SignalCase == VoiceModuleSignal.SignalOneofCase.ProviderEventReceived &&
+            signal.ProviderEventReceived.LeaseEpoch == 7);
     }
 
     [Fact]
     public async Task VoicePresenceTransportAttachmentPort_should_dispatch_attach_signal_and_return_active_transport_lease_handle()
     {
         var dispatchPort = new RecordingDispatchPort();
-        var port = new VoicePresenceTransportAttachmentPort(dispatchPort);
+        var observationPort = new RecordingLeaseObservationPort();
+        var port = new VoicePresenceTransportAttachmentPort(dispatchPort, observationPort);
         var expiresAt = DateTimeOffset.UtcNow.AddMinutes(5);
         var handle = CreateLeaseHandle(expiresAt);
 
         var attached = await port.AttachAsync(handle, new PassiveVoiceTransport(), CancellationToken.None);
 
         attached.ActiveTransportLeaseId.ShouldNotBeNullOrWhiteSpace();
+        attached.LeaseEpoch.ShouldBe(7);
+        attached.ObservedStateVersion.ShouldBe(11);
+        observationPort.AttachRequests.ShouldHaveSingleItem().TransportLeaseId.ShouldBe(attached.ActiveTransportLeaseId);
         dispatchPort.Dispatches.ShouldHaveSingleItem().ActorId.ShouldBe("agent-1");
         var signal = dispatchPort.Dispatches[0].Envelope.Payload.Unpack<VoiceModuleSignal>();
         signal.ModuleName.ShouldBe("voice_presence");
@@ -380,13 +390,14 @@ public class VoiceRealtimeSessionTests
         signal.TransportAttachRequested.OwnerId.ShouldBe("host-1");
         signal.TransportAttachRequested.TransportLeaseId.ShouldBe(attached.ActiveTransportLeaseId);
         signal.TransportAttachRequested.LeaseExpiresAt.ToDateTimeOffset().ShouldBe(expiresAt.ToUniversalTime());
+        signal.TransportAttachRequested.LeaseEpoch.ShouldBe(7);
     }
 
     [Fact]
     public async Task VoicePresenceTransportAttachmentPort_should_dispatch_detach_signal_for_active_transport_lease()
     {
         var dispatchPort = new RecordingDispatchPort();
-        var port = new VoicePresenceTransportAttachmentPort(dispatchPort);
+        var port = new VoicePresenceTransportAttachmentPort(dispatchPort, new RecordingLeaseObservationPort());
         var expiresAt = DateTimeOffset.UtcNow.AddMinutes(5);
         var handle = CreateLeaseHandle(expiresAt, activeTransportLeaseId: "transport-1");
 
@@ -401,13 +412,14 @@ public class VoiceRealtimeSessionTests
         signal.TransportDetachRequested.TransportLeaseId.ShouldBe("transport-1");
         signal.TransportDetachRequested.Reason.ShouldBe("host_transport_detached");
         signal.TransportDetachRequested.LeaseExpiresAt.ToDateTimeOffset().ShouldBe(expiresAt.ToUniversalTime());
+        signal.TransportDetachRequested.LeaseEpoch.ShouldBe(7);
     }
 
     [Fact]
     public async Task VoicePresenceTransportAttachmentPort_should_not_dispatch_detach_without_active_transport_lease()
     {
         var dispatchPort = new RecordingDispatchPort();
-        var port = new VoicePresenceTransportAttachmentPort(dispatchPort);
+        var port = new VoicePresenceTransportAttachmentPort(dispatchPort, new RecordingLeaseObservationPort());
 
         await port.DetachAsync(CreateLeaseHandle(), null, CancellationToken.None);
 
@@ -418,7 +430,8 @@ public class VoiceRealtimeSessionTests
     public async Task VoicePresenceSessionLeasePort_should_dispatch_typed_lease_signal_and_return_accepted_handle()
     {
         var dispatchPort = new RecordingDispatchPort();
-        var leasePort = new VoicePresenceSessionLeasePort(dispatchPort);
+        var observationPort = new RecordingLeaseObservationPort();
+        var leasePort = new VoicePresenceSessionLeasePort(dispatchPort, observationPort);
         var expiresAt = DateTimeOffset.UtcNow.AddMinutes(5);
 
         var handle = await leasePort.AcquireAsync(new VoicePresenceSessionLeaseRequest(
@@ -431,8 +444,10 @@ public class VoiceRealtimeSessionTests
             VoiceRemoteAudioSupport.LocalOnly));
 
         handle.SessionId.ShouldBe("lease-1");
-        handle.ObservedStateVersion.ShouldBe(7);
+        handle.ObservedStateVersion.ShouldBe(8);
         handle.ExpiresAtUtc.ShouldBe(expiresAt.ToUniversalTime());
+        handle.LeaseEpoch.ShouldBe(7);
+        observationPort.SessionLeaseRequests.ShouldHaveSingleItem().ObservedStateVersion.ShouldBe(7);
         dispatchPort.Dispatches.ShouldHaveSingleItem().ActorId.ShouldBe("agent-1");
         var signal = dispatchPort.Dispatches[0].Envelope.Payload.Unpack<VoiceModuleSignal>();
         signal.ModuleName.ShouldBe("voice_presence");
@@ -444,7 +459,7 @@ public class VoiceRealtimeSessionTests
     public async Task VoicePresenceSessionLeasePort_should_dispatch_typed_release_signal()
     {
         var dispatchPort = new RecordingDispatchPort();
-        var leasePort = new VoicePresenceSessionLeasePort(dispatchPort);
+        var leasePort = new VoicePresenceSessionLeasePort(dispatchPort, new RecordingLeaseObservationPort());
         var handle = CreateLeaseHandle();
 
         await leasePort.ReleaseAsync(handle, "test-release");
@@ -459,7 +474,7 @@ public class VoiceRealtimeSessionTests
     public async Task VoicePresenceSessionLeasePort_should_dispatch_typed_lifetime_completed_signal()
     {
         var dispatchPort = new RecordingDispatchPort();
-        var leasePort = new VoicePresenceSessionLeasePort(dispatchPort);
+        var leasePort = new VoicePresenceSessionLeasePort(dispatchPort, new RecordingLeaseObservationPort());
         var expiresAt = DateTimeOffset.UtcNow.AddMinutes(5);
         var handle = CreateLeaseHandle(expiresAt, activeTransportLeaseId: "transport-1");
 
@@ -471,6 +486,127 @@ public class VoiceRealtimeSessionTests
         signal.TransportLifetimeCompleted.TransportLeaseId.ShouldBe("transport-1");
         signal.TransportLifetimeCompleted.Reason.ShouldBe("test-complete");
         signal.TransportLifetimeCompleted.LeaseExpiresAt.ToDateTimeOffset().ShouldBe(expiresAt.ToUniversalTime());
+        signal.TransportLifetimeCompleted.LeaseEpoch.ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task VoicePresenceLeaseObservationPort_should_observe_positive_session_epoch()
+    {
+        var expiresAt = DateTimeOffset.UtcNow.AddMinutes(5);
+        var snapshot = CreateCapability(
+            "agent-1",
+            "voice_presence",
+            initialized: true,
+            activeSessionId: "lease-1",
+            remoteAudioSupport: VoiceRemoteAudioSupport.Supported) with
+        {
+            StateVersion = 8,
+            LeaseExpiresAt = expiresAt,
+            LeaseEpoch = 7,
+            ActiveLeaseOwnerId = "host-1",
+        };
+        var port = new VoicePresenceLeaseObservationPort(new FakeCapabilityQueryPort(snapshot));
+
+        var observed = await port.ObserveSessionLeaseAsync(new VoicePresenceSessionLeaseRequest(
+            "agent-1",
+            "voice_presence",
+            "lease-1",
+            "host-1",
+            expiresAt,
+            7,
+            VoiceRemoteAudioSupport.LocalOnly));
+
+        observed.LeaseEpoch.ShouldBe(7);
+        observed.StateVersion.ShouldBe(8);
+    }
+
+    [Fact]
+    public async Task VoicePresenceLeaseObservationPort_should_fail_closed_when_session_epoch_is_not_positive()
+    {
+        var expiresAt = DateTimeOffset.UtcNow.AddMinutes(5);
+        var snapshot = CreateCapability(
+            "agent-1",
+            "voice_presence",
+            initialized: true,
+            activeSessionId: "lease-1",
+            remoteAudioSupport: VoiceRemoteAudioSupport.Supported) with
+        {
+            StateVersion = 8,
+            LeaseExpiresAt = expiresAt,
+            LeaseEpoch = 0,
+            ActiveLeaseOwnerId = "host-1",
+        };
+        var port = new VoicePresenceLeaseObservationPort(
+            new FakeCapabilityQueryPort(snapshot),
+            TimeProvider.System,
+            TimeSpan.Zero,
+            TimeSpan.Zero);
+
+        await Should.ThrowAsync<TimeoutException>(() => port.ObserveSessionLeaseAsync(new VoicePresenceSessionLeaseRequest(
+            "agent-1",
+            "voice_presence",
+            "lease-1",
+            "host-1",
+            expiresAt,
+            7,
+            VoiceRemoteAudioSupport.LocalOnly)));
+    }
+
+    [Fact]
+    public async Task VoicePresenceLeaseObservationPort_should_observe_attach_with_exact_epoch()
+    {
+        var expiresAt = DateTimeOffset.UtcNow.AddMinutes(5);
+        var snapshot = CreateCapability(
+            "agent-1",
+            "voice_presence",
+            initialized: true,
+            activeSessionId: "lease-1",
+            activeTransportLeaseId: "transport-1",
+            transportAttached: true,
+            remoteAudioSupport: VoiceRemoteAudioSupport.Supported) with
+        {
+            StateVersion = 11,
+            LeaseExpiresAt = expiresAt,
+            LeaseEpoch = 7,
+            ActiveLeaseOwnerId = "host-1",
+        };
+        var port = new VoicePresenceLeaseObservationPort(new FakeCapabilityQueryPort(snapshot));
+
+        var observed = await port.ObserveTransportAttachAsync(
+            CreateLeaseHandle(expiresAt),
+            "transport-1");
+
+        observed.LeaseEpoch.ShouldBe(7);
+        observed.ActiveTransportLeaseId.ShouldBe("transport-1");
+    }
+
+    [Fact]
+    public async Task VoicePresenceLeaseObservationPort_should_fail_closed_when_attach_epoch_is_stale()
+    {
+        var expiresAt = DateTimeOffset.UtcNow.AddMinutes(5);
+        var snapshot = CreateCapability(
+            "agent-1",
+            "voice_presence",
+            initialized: true,
+            activeSessionId: "lease-1",
+            activeTransportLeaseId: "transport-1",
+            transportAttached: true,
+            remoteAudioSupport: VoiceRemoteAudioSupport.Supported) with
+        {
+            StateVersion = 11,
+            LeaseExpiresAt = expiresAt,
+            LeaseEpoch = 8,
+            ActiveLeaseOwnerId = "host-1",
+        };
+        var port = new VoicePresenceLeaseObservationPort(
+            new FakeCapabilityQueryPort(snapshot),
+            TimeProvider.System,
+            TimeSpan.Zero,
+            TimeSpan.Zero);
+
+        await Should.ThrowAsync<TimeoutException>(() => port.ObserveTransportAttachAsync(
+            CreateLeaseHandle(expiresAt),
+            "transport-1"));
     }
 
     [Fact]
@@ -487,6 +623,8 @@ public class VoiceRealtimeSessionTests
             Initialized = true,
             PcmSampleRateHz = 24000,
             RemoteAudioSupport = VoiceRemoteAudioSupport.LocalOnly,
+            LeaseEpoch = 7,
+            ActiveLeaseOwnerId = "host-1",
         };
         var queryPort = new VoicePresenceCapabilityQueryPort(new FakeCapabilityReader(readModel));
 
@@ -498,6 +636,8 @@ public class VoiceRealtimeSessionTests
         snapshot.StateVersion.ShouldBe(7);
         snapshot.Initialized.ShouldBeTrue();
         snapshot.PcmSampleRateHz.ShouldBe(24000);
+        snapshot.LeaseEpoch.ShouldBe(7);
+        snapshot.ActiveLeaseOwnerId.ShouldBe("host-1");
     }
 
     [Fact]
@@ -512,6 +652,8 @@ public class VoiceRealtimeSessionTests
                 Initialized = true,
                 LeaseExpiresAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddMinutes(3)),
                 ActiveTransportLeaseId = "transport-1",
+                ActiveLeaseOwnerId = "host-1",
+                LeaseEpoch = 7,
             },
             8,
             null!,
@@ -526,6 +668,8 @@ public class VoiceRealtimeSessionTests
         readModel.PcmSampleRateHz.ShouldBe(24000);
         readModel.ActiveSessionId.ShouldBeEmpty();
         readModel.ActiveTransportLeaseId.ShouldBe("transport-1");
+        readModel.ActiveLeaseOwnerId.ShouldBe("host-1");
+        readModel.LeaseEpoch.ShouldBe(7);
         readModel.RemoteAudioSupport.ShouldBe(VoiceRemoteAudioSupport.LocalOnly);
     }
 
@@ -540,12 +684,16 @@ public class VoiceRealtimeSessionTests
             LastEventId = "event-3",
             ActiveSessionId = " ",
             ActiveTransportLeaseId = "transport-1",
+            ActiveLeaseOwnerId = "host-1",
+            LeaseEpoch = 7,
         });
 
         snapshot.UpdatedAt.ShouldBe(DateTimeOffset.MinValue);
         snapshot.PcmSampleRateHz.ShouldBe(24000);
         snapshot.ActiveSessionId.ShouldBeNull();
         snapshot.ActiveTransportLeaseId.ShouldBe("transport-1");
+        snapshot.ActiveLeaseOwnerId.ShouldBe("host-1");
+        snapshot.LeaseEpoch.ShouldBe(7);
         snapshot.LeaseExpiresAt.ShouldBeNull();
         snapshot.RemoteAudioSupport.ShouldBe(VoiceRemoteAudioSupport.LocalOnly);
     }
@@ -568,6 +716,8 @@ public class VoiceRealtimeSessionTests
                     PcmSampleRateHz = 16000,
                     ActiveSessionId = "lease-1",
                     ActiveTransportLeaseId = "transport-1",
+                    ActiveLeaseOwnerId = "host-1",
+                    LeaseEpoch = 7,
                     RemoteAudioSupport = VoiceRemoteAudioSupport.Supported,
                 },
             },
@@ -593,6 +743,8 @@ public class VoiceRealtimeSessionTests
         document.PcmSampleRateHz.ShouldBe(16000);
         document.ActiveSessionId.ShouldBe("lease-1");
         document.ActiveTransportLeaseId.ShouldBe("transport-1");
+        document.ActiveLeaseOwnerId.ShouldBe("host-1");
+        document.LeaseEpoch.ShouldBe(7);
         document.RemoteAudioSupport.ShouldBe(VoiceRemoteAudioSupport.Supported);
     }
 
@@ -679,7 +831,8 @@ public class VoiceRealtimeSessionTests
             10,
             expiresAt ?? DateTimeOffset.UtcNow.AddMinutes(5),
             VoiceRemoteAudioSupport.LocalOnly,
-            activeTransportLeaseId);
+            activeTransportLeaseId,
+            7);
 
     private static VoicePresenceModuleRegistration CreateRelayRegistration(
         RecordingRelayProviderSession providerSession) =>
@@ -693,7 +846,7 @@ public class VoiceRealtimeSessionTests
                         handle.SessionId,
                         handle.OwnerId,
                         handle.ActiveTransportLeaseId ?? string.Empty,
-                        0,
+                        handle.LeaseEpoch,
                         Timestamp.FromDateTimeOffset(handle.ExpiresAtUtc.ToUniversalTime()),
                         handle.ActorId,
                         handle.ModuleName),
@@ -722,7 +875,9 @@ public class VoiceRealtimeSessionTests
             activeSessionId,
             DateTimeOffset.UtcNow.AddMinutes(5),
             remoteAudioSupport,
-            activeTransportLeaseId);
+            activeTransportLeaseId,
+            7,
+            "host-1");
 
     private static string FindRepoRoot()
     {
@@ -755,6 +910,60 @@ public class VoiceRealtimeSessionTests
         }
     }
 
+    private sealed class RecordingLeaseObservationPort : IVoicePresenceLeaseObservationPort
+    {
+        public List<VoicePresenceSessionLeaseRequest> SessionLeaseRequests { get; } = [];
+
+        public List<(VoicePresenceSessionLeaseHandle Handle, string TransportLeaseId)> AttachRequests { get; } = [];
+
+        public Task<VoicePresenceCapabilitySnapshot> ObserveSessionLeaseAsync(
+            VoicePresenceSessionLeaseRequest request,
+            CancellationToken ct = default)
+        {
+            _ = ct;
+            SessionLeaseRequests.Add(request);
+            return Task.FromResult(new VoicePresenceCapabilitySnapshot(
+                request.ActorId,
+                request.ModuleName,
+                request.ObservedStateVersion + 1,
+                "event-observed",
+                DateTimeOffset.UtcNow,
+                true,
+                false,
+                24000,
+                request.SessionId,
+                request.ExpiresAtUtc,
+                VoiceRemoteAudioSupport.Supported,
+                null,
+                7,
+                request.OwnerId));
+        }
+
+        public Task<VoicePresenceCapabilitySnapshot> ObserveTransportAttachAsync(
+            VoicePresenceSessionLeaseHandle handle,
+            string transportLeaseId,
+            CancellationToken ct = default)
+        {
+            _ = ct;
+            AttachRequests.Add((handle, transportLeaseId));
+            return Task.FromResult(new VoicePresenceCapabilitySnapshot(
+                handle.ActorId,
+                handle.ModuleName,
+                handle.ObservedStateVersion + 1,
+                "event-attached",
+                DateTimeOffset.UtcNow,
+                true,
+                true,
+                24000,
+                handle.SessionId,
+                handle.ExpiresAtUtc,
+                handle.RemoteAudioSupport,
+                transportLeaseId,
+                handle.LeaseEpoch,
+                handle.OwnerId));
+        }
+    }
+
     private sealed class RecordingLeasePort : IVoicePresenceSessionLeasePort
     {
         public List<VoicePresenceSessionLeaseRequest> AcquireRequests { get; } = [];
@@ -775,7 +984,9 @@ public class VoiceRealtimeSessionTests
                 request.OwnerId,
                 request.ObservedStateVersion,
                 request.ExpiresAtUtc,
-                request.ObservedRemoteAudioSupport));
+                request.ObservedRemoteAudioSupport,
+                null,
+                7));
         }
 
         public Task ReleaseAsync(


### PR DESCRIPTION
## Summary / 摘要

修复 #2150：voice provider/transport fencing 的 `lease_epoch` 形同虚设（已 firsthand 证实 `ServiceCollectionExtensions.cs:321` 硬编码 `0`、`VoiceVolatileMediaStreamPort.cs` 的 `VoiceProviderEventReceived` 不设 `LeaseEpoch`、`MatchesLeaseEpoch` 的 `<= 0` 逃生口）。

- **Old**：provider/transport hot path 用 `0` 或 host-controlled epoch 绕过 actor-owned lease fencing；`MatchesLeaseEpoch` 对 zero epoch 放行；dispatch ACK 被误当 committed epoch 来源。
- **New**：`LeaseEpoch` 为 actor-owned 正数 fencing token；新增窄 `IVoicePresenceLeaseObservationPort` 从 `VoicePresenceCapabilityReadModel` 观察；attach exact-match `handle.LeaseEpoch`（不递增/不 `+1`/不降级 `0`，attach 属同一 lease generation — Option A）；provider/control/image/lifetime/detach callback 全携带正数 observed epoch；`MatchesLeaseEpoch` 收紧为 `leaseEpoch > 0 && match`，关闭 provider `function_call` hot-path 的 zero escape hatch。

design-consensus r3（`consensus:structural:adopt-strawman-option-A`）。

## Scope / 范围

14 files changed（含 proto `lease_epoch=14` + `active_lease_owner_id=15` 用于 owner-validated observation；新增 `IVoicePresenceLeaseObservationPort` + 实现）。
- 测试：`Aevatar.Foundation.VoicePresence.Tests` 192 passed；`AIFeatureBootstrapCoverageTests` 18 passed；新 `VoicePresenceBootstrapTests` 4 passed。
- Guards：test_stability / projection_priming / projection_state_version / projection_state_mirror / architecture 全绿；`tools/docs/lint.sh` 绿；`git diff --check` 绿。
- 声明的 SCOPE_EXTEND：readmodel 增 `active_lease_owner_id`（observation 需校验 owner）；bootstrap 测试拆分（CoverageTests 行预算 guard）。

Closes #2150

🤖 consensus-loop (milestone 23) · design r3 consensus → implement → review-gate

⟦AI:AUTO-LOOP⟧
