### PR TITLE
收敛 connected-service resource fetch 到 workflow canonical tool

### DIFF
--- a/docs/canon/workflow-runtime.md
+++ b/docs/canon/workflow-runtime.md
@@ -122,6 +122,18 @@ BindWorkflowDefinition(yaml)
 - timezone 为空时默认为 `UTC`，非空时必须能被 runtime `TimeZoneInfo` 解析。
 - `Headers` 是 command dispatch headers，不用于承载 schedule 核心语义。
 
+### Connected-Service Resource Fetch
+
+Workflow runtime owns the canonical connected-service resource fetch use case. The only workflow-callable tool name is `workflow_connected_service_resource_fetch`; connected-service provider packages do not publish a same-name workflow tool.
+
+运行边界：
+
+- Tool arguments identify a narrow route with typed fields: `provider`、`operation`、`resource_kind`、`message_id`、`resource_key`。
+- Workflow infrastructure resolves the route through registered `IWorkflowConnectedServiceResourceFetchAdapter` instances. Unsupported routes fail before any provider call.
+- Provider packages only register binary adapters for their own public surface. The first Lark adapter exposes `lark/message_resource_download/image` and `lark/message_resource_download/file`.
+- Downloaded bytes must enter workflow storage only through `IWorkflowFileIngressPort` with `WorkflowFileSourceKind.ConnectedServiceResource`; workflow commands, actor state, readmodels, logs, and tool results must not carry raw bytes or base64.
+- The tool result is a sanitized `WorkflowFileRef` plus route facts. It does not expose provider response bodies, base64, or downloaded content.
+
 ### Webhook Ingress API
 
 `POST /api/workflow-webhooks/{routeKey}` 是 workflow 的第四个 start-run 入口。它和 `/api/chat` 复用同一条 `WorkflowChatRunRequest` accepted-only command dispatch 主干；它不是 workflow YAML 顶级 trigger，也不复用 channel inbound 或 `WorkflowSignalCommand`。

--- a/src/Aevatar.AI.ToolProviders.Lark/LarkMessageResourceFetchAdapter.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/LarkMessageResourceFetchAdapter.cs
@@ -1,0 +1,69 @@
+using Aevatar.Workflow.Application.Abstractions.Runs;
+
+namespace Aevatar.AI.ToolProviders.Lark;
+
+public sealed class LarkMessageResourceFetchAdapter(ILarkNyxClient client)
+    : IWorkflowConnectedServiceResourceFetchAdapter
+{
+    private static readonly WorkflowConnectedServiceResourceFetchRoute ImageRoute =
+        new("lark", "message_resource_download", "image");
+    private static readonly WorkflowConnectedServiceResourceFetchRoute FileRoute =
+        new("lark", "message_resource_download", "file");
+
+    private readonly ILarkNyxClient _client = client ?? throw new ArgumentNullException(nameof(client));
+
+    public IReadOnlyList<WorkflowConnectedServiceResourceFetchRoute> Routes { get; } =
+    [
+        ImageRoute,
+        FileRoute,
+    ];
+
+    public async ValueTask<WorkflowConnectedServiceResourceFetchResult> FetchAsync(
+        WorkflowConnectedServiceResourceFetchRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var kind = ResolveResourceKind(request.Route);
+        var token = Normalize(request.CallerCredential.BearerToken)
+                    ?? throw new ArgumentException("Lark message resource download requires a caller bearer token.", nameof(request));
+
+        var result = await _client.DownloadMessageResourceAsync(
+            token,
+            new LarkMessageResourceDownloadRequest(
+                request.SourceMessageId,
+                request.SourceResourceKey,
+                kind),
+            cancellationToken).ConfigureAwait(false);
+
+        return new WorkflowConnectedServiceResourceFetchResult(
+            result.Succeeded,
+            result.Content,
+            result.ContentType,
+            result.FileName,
+            result.Detail,
+            result.HttpStatus);
+    }
+
+    private static LarkMessageResourceKind ResolveResourceKind(
+        WorkflowConnectedServiceResourceFetchRoute route)
+    {
+        if (RouteEquals(route, ImageRoute))
+            return LarkMessageResourceKind.Image;
+        if (RouteEquals(route, FileRoute))
+            return LarkMessageResourceKind.File;
+
+        throw new ArgumentException(
+            "Lark message resource fetch only supports lark/message_resource_download/image and lark/message_resource_download/file.",
+            nameof(route));
+    }
+
+    private static bool RouteEquals(
+        WorkflowConnectedServiceResourceFetchRoute left,
+        WorkflowConnectedServiceResourceFetchRoute right) =>
+        string.Equals(left.Provider, right.Provider, StringComparison.Ordinal) &&
+        string.Equals(left.Operation, right.Operation, StringComparison.Ordinal) &&
+        string.Equals(left.ResourceKind, right.ResourceKind, StringComparison.Ordinal);
+
+    private static string? Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/Aevatar.AI.ToolProviders.Lark/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Core.Modules;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -22,6 +23,9 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<ILarkCardKitClient, LarkCardKitClient>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IAgentToolSource, LarkAgentToolSource>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IWorkflowToolSource, LarkWorkflowFileSubmitToolSource>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            IWorkflowConnectedServiceResourceFetchAdapter,
+            LarkMessageResourceFetchAdapter>());
 
         return services;
     }

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowConnectedServiceResourceFetchPort.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowConnectedServiceResourceFetchPort.cs
@@ -1,0 +1,29 @@
+namespace Aevatar.Workflow.Application.Abstractions.Runs;
+
+public sealed record WorkflowConnectedServiceResourceFetchRoute(
+    string Provider,
+    string Operation,
+    string ResourceKind);
+
+public sealed record WorkflowConnectedServiceResourceFetchRequest(
+    WorkflowConnectedServiceResourceFetchRoute Route,
+    string SourceMessageId,
+    string SourceResourceKey,
+    WorkflowCallerCredential CallerCredential);
+
+public sealed record WorkflowConnectedServiceResourceFetchResult(
+    bool Succeeded,
+    ReadOnlyMemory<byte> Content,
+    string? MediaType = null,
+    string? FileName = null,
+    string? Detail = null,
+    int StatusCode = 0);
+
+public interface IWorkflowConnectedServiceResourceFetchAdapter
+{
+    IReadOnlyList<WorkflowConnectedServiceResourceFetchRoute> Routes { get; }
+
+    ValueTask<WorkflowConnectedServiceResourceFetchResult> FetchAsync(
+        WorkflowConnectedServiceResourceFetchRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/workflow/Aevatar.Workflow.Host.Api/README.md
+++ b/src/workflow/Aevatar.Workflow.Host.Api/README.md
@@ -64,7 +64,8 @@
 - Workflow Host 只消费这条 CQRS 骨架，不自定义通用 command lifecycle；workflow 领域只负责目标解析、payload 映射与读侧观察映射。
 - `resume/signal` 也复用同一条骨架，Host 只依赖对应的 `ICommandDispatchService<...>`，不再直接注入 `IActorRuntime/IActorDispatchPort`。
 - Webhook ingress 只在 Host/Adapter 处理 raw JSON、HMAC 与 binding mapping；应用层接收 typed `WorkflowExternalIngressContext`，防重放依赖 `IWorkflowWebhookReplayStore`，生产启用但缺少 durable store 时 fail closed。
-- Workflow file tools 只通过 workflow tool source 暴露：`document_extract` 读取 artifact store 中的 typed file ref 并返回 bounded text；`workflow_file_submit` 只提交到固定 Lark Drive media 或 Lark approval file upload 目标，结果只包含 `file_token`/`file_code` 等 typed facts，不回显 bytes/base64。
+- Workflow file tools 只通过 workflow-owned tool source 暴露：`workflow_connected_service_resource_fetch` 按 provider/operation/resource_kind allowlist 读取 connected-service 二进制资源，并且只通过 `IWorkflowFileIngressPort` 以 `SourceKind=ConnectedServiceResource` 写入 artifact store；结果只返回 sanitized `WorkflowFileRef`，不回显 bytes/base64。Connected-service 包只注册窄 adapter，例如 Lark 的 `lark/message_resource_download/image|file`。
+- `document_extract` 读取 artifact store 中的 typed file ref 并返回 bounded text；`workflow_file_submit` 只提交到固定 Lark Drive media 或 Lark approval file upload 目标，结果只包含 `file_token`/`file_code` 等 typed facts，不回显 bytes/base64。
 - `multipart/form-data` 文件上传只在 Host/API 边界读取文件 bytes；Host 先校验 caller credential、表单 shape、文件大小与媒体类型，再通过 `IWorkflowFileIngressPort` 写入 artifact store。后续 `WorkflowChatRunRequest` 只携带 typed `WorkflowFileRef` input part，`SourceKind=FormUpload`，不把 bytes/base64 带入 actor-facing command、state、readmodel 或日志。
 - 命令最终会被包装成 `EventEnvelope`；目标 Actor 的获取/创建由 `IActorRuntime` 负责，envelope 投递由 `IActorDispatchPort` 完成，CQRS 侧由 `ActorCommandTargetDispatcher` 承接 target dispatch。
 - 这里的 `EventEnvelope` 是 runtime message envelope，不等于 Event Sourcing 的领域事件记录。

--- a/src/workflow/Aevatar.Workflow.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IWorkflowFileArtifactOwnershipPort>(sp =>
             sp.GetRequiredService<FileSystemWorkflowFileIngressPort>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IWorkflowToolSource, WorkflowDocumentExtractToolSource>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IWorkflowToolSource, WorkflowConnectedServiceResourceFetchToolSource>());
         services.TryAddSingleton<WorkflowRunActorPort>();
         services.TryAddSingleton<IWorkflowDefinitionProvisioningPort>(sp =>
             sp.GetRequiredService<WorkflowRunActorPort>());

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Runs/WorkflowConnectedServiceResourceFetchToolSource.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Runs/WorkflowConnectedServiceResourceFetchToolSource.cs
@@ -1,0 +1,237 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.Workflow.Core.Modules;
+
+namespace Aevatar.Workflow.Infrastructure.Runs;
+
+public sealed class WorkflowConnectedServiceResourceFetchToolSource(
+    IEnumerable<IWorkflowConnectedServiceResourceFetchAdapter> adapters,
+    IWorkflowFileIngressPort fileIngress) : IWorkflowToolSource
+{
+    private readonly IReadOnlyList<IWorkflowConnectedServiceResourceFetchAdapter> _adapters =
+        adapters?.ToArray() ?? throw new ArgumentNullException(nameof(adapters));
+    private readonly IWorkflowFileIngressPort _fileIngress =
+        fileIngress ?? throw new ArgumentNullException(nameof(fileIngress));
+
+    public Task<IReadOnlyList<IWorkflowTool>> GetToolsAsync(CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyList<IWorkflowTool>>([new ConnectedServiceResourceFetchTool(_adapters, _fileIngress)]);
+
+    private sealed class ConnectedServiceResourceFetchTool(
+        IReadOnlyList<IWorkflowConnectedServiceResourceFetchAdapter> adapters,
+        IWorkflowFileIngressPort fileIngress) : IWorkflowTool
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            PropertyNameCaseInsensitive = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        };
+
+        private readonly IReadOnlyList<IWorkflowConnectedServiceResourceFetchAdapter> _adapters = adapters;
+        private readonly IWorkflowFileIngressPort _fileIngress = fileIngress;
+
+        public string Name => "workflow_connected_service_resource_fetch";
+
+        public async Task<WorkflowToolExecutionResult> ExecuteAsync(
+            WorkflowToolExecutionRequest request,
+            CancellationToken ct = default)
+        {
+            WorkflowConnectedServiceResourceFetchArguments arguments;
+            try
+            {
+                arguments = ParseArguments(request.ArgumentsJson);
+            }
+            catch (JsonException ex)
+            {
+                return Error("invalid_arguments", ex.Message);
+            }
+            catch (ArgumentException ex)
+            {
+                return Error("invalid_arguments", ex.Message);
+            }
+
+            var route = new WorkflowConnectedServiceResourceFetchRoute(
+                arguments.Provider,
+                arguments.Operation,
+                arguments.ResourceKind);
+            var adapter = ResolveAdapter(route);
+            if (adapter == null)
+                return Error(
+                    "unsupported_resource_route",
+                    "workflow_connected_service_resource_fetch only supports registered connected-service resource routes.");
+
+            var token = Normalize(request.CallerCredential.BearerToken);
+            if (token == null)
+                return Error("missing_bearer", "workflow_connected_service_resource_fetch requires a workflow caller bearer token.");
+
+            WorkflowConnectedServiceResourceFetchResult fetchResult;
+            try
+            {
+                fetchResult = await adapter.FetchAsync(
+                    new WorkflowConnectedServiceResourceFetchRequest(
+                        route,
+                        arguments.MessageId,
+                        arguments.ResourceKey,
+                        new WorkflowCallerCredential(token)),
+                    ct).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                return Error("provider_call_failed", "Connected-service resource fetch failed.");
+            }
+
+            if (!fetchResult.Succeeded)
+                return Error(
+                    "provider_resource_unavailable",
+                    "Connected-service resource fetch did not return content.");
+            if (fetchResult.Content.IsEmpty)
+                return Error("empty_resource", "Connected-service resource fetch returned empty content.");
+
+            WorkflowFileIngressResult ingressResult;
+            try
+            {
+                ingressResult = await _fileIngress.IngestAsync(new WorkflowFileIngressRequest(
+                    fetchResult.Content,
+                    WorkflowFileSourceKind.ConnectedServiceResource,
+                    SourceMessageId: arguments.MessageId,
+                    SourceResourceKey: arguments.ResourceKey,
+                    FileName: fetchResult.FileName,
+                    MediaType: fetchResult.MediaType,
+                    OwnerRunId: Normalize(request.RunId),
+                    OwnerScopeId: Normalize(request.ScopeId)), ct).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                return Error("artifact_ingress_failed", "Connected-service resource could not be stored.");
+            }
+
+            return WorkflowToolExecutionResult.Success(JsonSerializer.Serialize(
+                new WorkflowConnectedServiceResourceFetchOutput(
+                    Success: true,
+                    Provider: route.Provider,
+                    Operation: route.Operation,
+                    ResourceKind: route.ResourceKind,
+                    FileRef: ToOutputFileRef(ingressResult.FileRef)),
+                JsonOptions));
+        }
+
+        private IWorkflowConnectedServiceResourceFetchAdapter? ResolveAdapter(
+            WorkflowConnectedServiceResourceFetchRoute route)
+        {
+            foreach (var adapter in _adapters)
+            {
+                if (adapter.Routes.Any(adapterRoute => RoutesEqual(adapterRoute, route)))
+                    return adapter;
+            }
+
+            return null;
+        }
+
+        private static WorkflowConnectedServiceResourceFetchArguments ParseArguments(string? argumentsJson)
+        {
+            using var document = JsonDocument.Parse(string.IsNullOrWhiteSpace(argumentsJson)
+                ? "{}"
+                : argumentsJson);
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+                throw new ArgumentException("workflow_connected_service_resource_fetch arguments must be a JSON object.");
+
+            var provider = RequiredString(root, "provider");
+            var operation = RequiredString(root, "operation");
+            var resourceKind = RequiredString(root, "resource_kind", "resourceKind");
+            var messageId = RequiredString(root, "message_id", "messageId");
+            var resourceKey = RequiredString(root, "resource_key", "resourceKey");
+
+            return new WorkflowConnectedServiceResourceFetchArguments(
+                provider,
+                operation,
+                resourceKind,
+                messageId,
+                resourceKey);
+        }
+
+        private static string RequiredString(JsonElement root, params string[] propertyNames)
+        {
+            foreach (var propertyName in propertyNames)
+            {
+                if (!root.TryGetProperty(propertyName, out var property))
+                    continue;
+                if (property.ValueKind != JsonValueKind.String)
+                    throw new ArgumentException(
+                        $"workflow_connected_service_resource_fetch {propertyName} must be a string.");
+                var value = Normalize(property.GetString());
+                if (value != null)
+                    return value;
+            }
+
+            throw new ArgumentException(
+                $"workflow_connected_service_resource_fetch {propertyNames[0]} is required.");
+        }
+
+        private static bool RoutesEqual(
+            WorkflowConnectedServiceResourceFetchRoute left,
+            WorkflowConnectedServiceResourceFetchRoute right) =>
+            string.Equals(left.Provider, right.Provider, StringComparison.Ordinal) &&
+            string.Equals(left.Operation, right.Operation, StringComparison.Ordinal) &&
+            string.Equals(left.ResourceKind, right.ResourceKind, StringComparison.Ordinal);
+
+        private static WorkflowConnectedServiceResourceFetchFileRef ToOutputFileRef(WorkflowFileRef fileRef) =>
+            new(
+                fileRef.FileId,
+                fileRef.ArtifactId,
+                fileRef.SourceKind.ToString(),
+                fileRef.SourceMessageId,
+                fileRef.SourceResourceKey,
+                fileRef.FileName,
+                fileRef.MediaType,
+                fileRef.SizeBytes,
+                fileRef.Sha256,
+                fileRef.CreatedAtUnixMs,
+                fileRef.ExpiresAtUnixMs,
+                fileRef.OwnerRunId,
+                fileRef.OwnerScopeId);
+
+        private static WorkflowToolExecutionResult Error(string error, string detail) =>
+            WorkflowToolExecutionResult.Success(JsonSerializer.Serialize(
+                new WorkflowConnectedServiceResourceFetchError(false, error, detail),
+                JsonOptions));
+
+        private static string? Normalize(string? value) =>
+            string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    private sealed record WorkflowConnectedServiceResourceFetchArguments(
+        string Provider,
+        string Operation,
+        string ResourceKind,
+        string MessageId,
+        string ResourceKey);
+
+    private sealed record WorkflowConnectedServiceResourceFetchOutput(
+        bool Success,
+        string Provider,
+        string Operation,
+        string ResourceKind,
+        WorkflowConnectedServiceResourceFetchFileRef FileRef);
+
+    private sealed record WorkflowConnectedServiceResourceFetchFileRef(
+        string? FileId,
+        string? ArtifactId,
+        string SourceKind,
+        string? SourceMessageId,
+        string? SourceResourceKey,
+        string? FileName,
+        string? MediaType,
+        long SizeBytes,
+        string? Sha256,
+        long CreatedAtUnixMs,
+        long ExpiresAtUnixMs,
+        string? OwnerRunId,
+        string? OwnerScopeId);
+
+    private sealed record WorkflowConnectedServiceResourceFetchError(
+        bool Success,
+        string Error,
+        string Detail);
+}

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkConnectedServiceResourceFetchAdapterRegistrationTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkConnectedServiceResourceFetchAdapterRegistrationTests.cs
@@ -1,0 +1,21 @@
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Aevatar.AI.ToolProviders.Lark.Tests;
+
+public sealed class LarkConnectedServiceResourceFetchAdapterRegistrationTests
+{
+    [Fact]
+    public void AddLarkTools_ShouldRegisterMessageResourceFetchAdapter()
+    {
+        var services = new ServiceCollection();
+
+        services.AddLarkTools();
+
+        services.Should().ContainSingle(descriptor =>
+            descriptor.ServiceType == typeof(IWorkflowConnectedServiceResourceFetchAdapter) &&
+            descriptor.ImplementationType == typeof(LarkMessageResourceFetchAdapter));
+    }
+}

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkConnectedServiceResourceFetchAdapterRegistrationTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkConnectedServiceResourceFetchAdapterRegistrationTests.cs
@@ -18,4 +18,74 @@ public sealed class LarkConnectedServiceResourceFetchAdapterRegistrationTests
             descriptor.ServiceType == typeof(IWorkflowConnectedServiceResourceFetchAdapter) &&
             descriptor.ImplementationType == typeof(LarkMessageResourceFetchAdapter));
     }
+
+    [Fact]
+    public void LarkMessageResourceFetchAdapter_ShouldAdvertiseCanonicalMessageResourceRoutes()
+    {
+        var adapter = new LarkMessageResourceFetchAdapter(new ThrowingLarkNyxClient());
+
+        adapter.Routes.Should().BeEquivalentTo(
+            [
+                new WorkflowConnectedServiceResourceFetchRoute("lark", "message_resource_download", "image"),
+                new WorkflowConnectedServiceResourceFetchRoute("lark", "message_resource_download", "file"),
+            ],
+            options => options.WithStrictOrdering());
+    }
+
+    private sealed class ThrowingLarkNyxClient : ILarkNyxClient
+    {
+        public Task<string> SendMessageAsync(string token, LarkSendMessageRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<string> ReplyToMessageAsync(string token, LarkReplyMessageRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<string> CreateMessageReactionAsync(string token, LarkMessageReactionRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<string> ListMessageReactionsAsync(string token, LarkMessageReactionListRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<string> DeleteMessageReactionAsync(string token, LarkMessageReactionDeleteRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<string> BatchGetMessagesAsync(string token, LarkMessagesBatchGetRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<LarkMessageResourceDownloadResult> DownloadMessageResourceAsync(
+            string token,
+            LarkMessageResourceDownloadRequest request,
+            CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<string> SearchChatsAsync(string token, LarkChatSearchRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<string> AppendSheetRowsAsync(string token, LarkSheetAppendRowsRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<string> ListApprovalTasksAsync(string token, LarkApprovalTaskQueryRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<string> GetApprovalInstanceAsync(string token, LarkApprovalInstanceGetRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<string> ActOnApprovalTaskAsync(string token, LarkApprovalTaskActionRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<string> CreateDocxDocumentAsync(string token, LarkDocxCreateRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<string> AppendDocxTextBlocksAsync(string token, LarkDocxAppendBlocksRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<string> SetDrivePermissionAsync(string token, LarkDrivePermissionRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<string> UploadDriveMediaAsync(string token, LarkDriveMediaUploadRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<string> UploadApprovalFileAsync(string token, LarkApprovalFileUploadRequest request, CancellationToken ct) =>
+            throw new NotSupportedException();
+    }
 }

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkCoverageTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkCoverageTests.cs
@@ -143,6 +143,7 @@ public sealed class LarkCoverageTests
         services.Should().ContainSingle(descriptor =>
             descriptor.ServiceType == typeof(IWorkflowToolSource) &&
             descriptor.ImplementationType == typeof(LarkWorkflowFileSubmitToolSource));
+
         services.Single(descriptor => descriptor.ServiceType == typeof(LarkToolOptions))
             .ImplementationInstance.Should().BeOfType<LarkToolOptions>()
             .Which.ProviderSlug.Should().Be("custom-provider");

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkCoverageTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkCoverageTests.cs
@@ -143,7 +143,6 @@ public sealed class LarkCoverageTests
         services.Should().ContainSingle(descriptor =>
             descriptor.ServiceType == typeof(IWorkflowToolSource) &&
             descriptor.ImplementationType == typeof(LarkWorkflowFileSubmitToolSource));
-
         services.Single(descriptor => descriptor.ServiceType == typeof(LarkToolOptions))
             .ImplementationInstance.Should().BeOfType<LarkToolOptions>()
             .Which.ProviderSlug.Should().Be("custom-provider");

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
@@ -411,6 +411,53 @@ public class LarkToolsTests
     }
 
     [Fact]
+    public async Task LarkMessageResourceFetchAdapter_ShouldMapWorkflowRouteToBinaryDownload()
+    {
+        var client = new StubLarkNyxClient
+        {
+            MessageResourceResponse = new LarkMessageResourceDownloadResult(
+                Succeeded: true,
+                Content: Encoding.UTF8.GetBytes("downloaded"),
+                ContentType: "image/png",
+                FileName: "picture.png"),
+        };
+        var adapter = new LarkMessageResourceFetchAdapter(client);
+
+        var result = await adapter.FetchAsync(new WorkflowConnectedServiceResourceFetchRequest(
+            Route: new WorkflowConnectedServiceResourceFetchRoute("lark", "message_resource_download", "image"),
+            SourceMessageId: "om_123",
+            SourceResourceKey: "img_v3_456",
+            CallerCredential: new WorkflowCallerCredential("token-123")));
+
+        result.Succeeded.Should().BeTrue();
+        result.Content.ToArray().Should().Equal(Encoding.UTF8.GetBytes("downloaded"));
+        result.MediaType.Should().Be("image/png");
+        result.FileName.Should().Be("picture.png");
+        client.LastMessageResourceToken.Should().Be("token-123");
+        client.LastMessageResourceRequest.Should().Be(new LarkMessageResourceDownloadRequest(
+            "om_123",
+            "img_v3_456",
+            LarkMessageResourceKind.Image));
+    }
+
+    [Fact]
+    public async Task LarkMessageResourceFetchAdapter_ShouldFailClosedForWrongRoute()
+    {
+        var client = new StubLarkNyxClient();
+        var adapter = new LarkMessageResourceFetchAdapter(client);
+
+        Func<Task> act = () => adapter.FetchAsync(new WorkflowConnectedServiceResourceFetchRequest(
+            Route: new WorkflowConnectedServiceResourceFetchRoute("nyxid", "message_resource_download", "image"),
+            SourceMessageId: "om_123",
+            SourceResourceKey: "img_v3_456",
+            CallerCredential: new WorkflowCallerCredential("token-123"))).AsTask();
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*lark/message_resource_download/image*");
+        client.LastMessageResourceRequest.Should().BeNull();
+    }
+
+    [Fact]
     // Refactor (issue1378/first-slice):
     //   Old pattern: ResolveOrCurrent hid missing message_id by reacting to the current message.
     //   New principle: reaction tests require structured error and explicit external message_id.
@@ -2512,6 +2559,7 @@ public class LarkToolsTests
         public string? LastDocxCreateToken { get; private set; }
         public string? LastDriveMediaUploadToken { get; private set; }
         public string? LastApprovalFileUploadToken { get; private set; }
+        public string? LastMessageResourceToken { get; private set; }
         public LarkSendMessageRequest? LastSendRequest { get; private set; }
         public LarkReplyMessageRequest? LastReplyRequest { get; private set; }
         public LarkMessageReactionRequest? LastReactionRequest { get; private set; }
@@ -2572,6 +2620,7 @@ public class LarkToolsTests
             LarkMessageResourceDownloadRequest request,
             CancellationToken ct)
         {
+            LastMessageResourceToken = token;
             LastMessageResourceRequest = request;
             return Task.FromResult(MessageResourceResponse);
         }

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
@@ -441,6 +441,36 @@ public class LarkToolsTests
     }
 
     [Fact]
+    public async Task LarkMessageResourceFetchAdapter_ShouldMapFileRouteToBinaryDownload()
+    {
+        var client = new StubLarkNyxClient
+        {
+            MessageResourceResponse = new LarkMessageResourceDownloadResult(
+                Succeeded: true,
+                Content: Encoding.UTF8.GetBytes("downloaded-file"),
+                ContentType: "application/pdf",
+                FileName: "receipt.pdf"),
+        };
+        var adapter = new LarkMessageResourceFetchAdapter(client);
+
+        var result = await adapter.FetchAsync(new WorkflowConnectedServiceResourceFetchRequest(
+            Route: new WorkflowConnectedServiceResourceFetchRoute("lark", "message_resource_download", "file"),
+            SourceMessageId: "om_123",
+            SourceResourceKey: "file_v3_456",
+            CallerCredential: new WorkflowCallerCredential("token-123")));
+
+        result.Succeeded.Should().BeTrue();
+        result.Content.ToArray().Should().Equal(Encoding.UTF8.GetBytes("downloaded-file"));
+        result.MediaType.Should().Be("application/pdf");
+        result.FileName.Should().Be("receipt.pdf");
+        client.LastMessageResourceToken.Should().Be("token-123");
+        client.LastMessageResourceRequest.Should().Be(new LarkMessageResourceDownloadRequest(
+            "om_123",
+            "file_v3_456",
+            LarkMessageResourceKind.File));
+    }
+
+    [Fact]
     public async Task LarkMessageResourceFetchAdapter_ShouldFailClosedForWrongRoute()
     {
         var client = new StubLarkNyxClient();

--- a/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
+++ b/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
@@ -199,6 +199,16 @@ public sealed class MainnetHostCompositionTests
         workspace.Sources.Should().Contain(source => source is OrnnAgentToolSource);
         app.Services.GetRequiredService<LarkToolOptions>()
             .EnableWorkflowFileSubmit.Should().BeFalse();
+        app.Services.GetServices<Aevatar.Workflow.Application.Abstractions.Runs.IWorkflowConnectedServiceResourceFetchAdapter>()
+            .Should()
+            .ContainSingle(adapter => adapter.GetType().Name == "LarkMessageResourceFetchAdapter");
+        var workflowToolNames = new List<string>();
+        foreach (var source in app.Services.GetServices<Aevatar.Workflow.Core.Modules.IWorkflowToolSource>())
+        {
+            var tools = await source.GetToolsAsync();
+            workflowToolNames.AddRange(tools.Select(static tool => tool.Name));
+        }
+        workflowToolNames.Should().ContainSingle(name => name == "workflow_connected_service_resource_fetch");
 
         var larkSelfNotify = registry.Resolve(new ChatRouteToolSetRef { Name = ToolSetNames.LarkSelfNotify });
         larkSelfNotify.IsSuccess.Should().BeTrue(larkSelfNotify.Error?.Message);

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowConnectedServiceResourceFetchToolTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowConnectedServiceResourceFetchToolTests.cs
@@ -136,15 +136,183 @@ public sealed class WorkflowConnectedServiceResourceFetchToolTests
         output.ResultJson.Should().Contain("unsupported_resource_route");
     }
 
+    [Theory]
+    [InlineData("{bad json")]
+    [InlineData("[]")]
+    public async Task ExecuteAsync_ShouldRejectInvalidArgumentsBeforeProviderCall(string argumentsJson)
+    {
+        var ingressPort = new RecordingWorkflowFileIngressPort();
+        var adapter = new RecordingConnectedServiceResourceFetchAdapter(
+            new WorkflowConnectedServiceResourceFetchRoute("lark", "message_resource_download", "image"));
+        var tool = await GetFetchToolAsync(adapter, ingressPort);
+
+        var output = await tool.ExecuteAsync(NewFetchRequest(argumentsJson));
+
+        AssertError(output, "invalid_arguments");
+        adapter.Requests.Should().BeEmpty();
+        ingressPort.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldRejectMissingBearerBeforeProviderCall()
+    {
+        var ingressPort = new RecordingWorkflowFileIngressPort();
+        var adapter = new RecordingConnectedServiceResourceFetchAdapter(
+            new WorkflowConnectedServiceResourceFetchRoute("lark", "message_resource_download", "image"));
+        var tool = await GetFetchToolAsync(adapter, ingressPort);
+
+        var output = await tool.ExecuteAsync(NewFetchRequest(ValidImageArguments, bearerToken: " "));
+
+        AssertError(output, "missing_bearer");
+        adapter.Requests.Should().BeEmpty();
+        ingressPort.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldFailClosedWhenProviderThrowsBeforeIngress()
+    {
+        var ingressPort = new RecordingWorkflowFileIngressPort();
+        var adapter = new RecordingConnectedServiceResourceFetchAdapter(
+            new WorkflowConnectedServiceResourceFetchRoute("lark", "message_resource_download", "image"))
+        {
+            FetchException = new InvalidOperationException("""{"body":"bad upstream","data_base64":"AAAA"}"""),
+        };
+        var tool = await GetFetchToolAsync(adapter, ingressPort);
+
+        var output = await tool.ExecuteAsync(NewFetchRequest(ValidImageArguments));
+
+        AssertError(output, "provider_call_failed");
+        output.ResultJson.Should().NotContain("bad upstream");
+        output.ResultJson.Contains("base64", StringComparison.OrdinalIgnoreCase).Should().BeFalse();
+        adapter.Requests.Should().ContainSingle();
+        ingressPort.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldFailClosedWhenProviderDoesNotSucceedBeforeIngress()
+    {
+        var ingressPort = new RecordingWorkflowFileIngressPort();
+        var adapter = new RecordingConnectedServiceResourceFetchAdapter(
+            new WorkflowConnectedServiceResourceFetchRoute("lark", "message_resource_download", "image"))
+        {
+            Result = new WorkflowConnectedServiceResourceFetchResult(
+                Succeeded: false,
+                Content: Encoding.UTF8.GetBytes("provider-bytes"),
+                Detail: "provider detail"),
+        };
+        var tool = await GetFetchToolAsync(adapter, ingressPort);
+
+        var output = await tool.ExecuteAsync(NewFetchRequest(ValidImageArguments));
+
+        AssertError(output, "provider_resource_unavailable");
+        output.ResultJson.Should().NotContain("provider detail");
+        output.ResultJson.Should().NotContain("provider-bytes");
+        adapter.Requests.Should().ContainSingle();
+        ingressPort.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldRejectEmptyProviderContentBeforeIngress()
+    {
+        var ingressPort = new RecordingWorkflowFileIngressPort();
+        var adapter = new RecordingConnectedServiceResourceFetchAdapter(
+            new WorkflowConnectedServiceResourceFetchRoute("lark", "message_resource_download", "image"))
+        {
+            Result = new WorkflowConnectedServiceResourceFetchResult(
+                Succeeded: true,
+                Content: ReadOnlyMemory<byte>.Empty),
+        };
+        var tool = await GetFetchToolAsync(adapter, ingressPort);
+
+        var output = await tool.ExecuteAsync(NewFetchRequest(ValidImageArguments));
+
+        AssertError(output, "empty_resource");
+        adapter.Requests.Should().ContainSingle();
+        ingressPort.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldFailClosedWhenArtifactIngressThrows()
+    {
+        var ingressPort = new RecordingWorkflowFileIngressPort
+        {
+            IngestException = new InvalidOperationException("""{"path":"secret","data_base64":"AAAA"}"""),
+        };
+        var adapter = new RecordingConnectedServiceResourceFetchAdapter(
+            new WorkflowConnectedServiceResourceFetchRoute("lark", "message_resource_download", "image"))
+        {
+            Result = new WorkflowConnectedServiceResourceFetchResult(
+                Succeeded: true,
+                Content: Encoding.UTF8.GetBytes("image-bytes"),
+                MediaType: "image/png",
+                FileName: "photo.png"),
+        };
+        var tool = await GetFetchToolAsync(adapter, ingressPort);
+
+        var output = await tool.ExecuteAsync(NewFetchRequest(ValidImageArguments));
+
+        AssertError(output, "artifact_ingress_failed");
+        output.ResultJson.Should().NotContain("secret");
+        output.ResultJson.Contains("base64", StringComparison.OrdinalIgnoreCase).Should().BeFalse();
+        adapter.Requests.Should().ContainSingle();
+        ingressPort.Requests.Should().ContainSingle();
+    }
+
+    private const string ValidImageArguments =
+        """
+        {
+          "provider": "lark",
+          "operation": "message_resource_download",
+          "resource_kind": "image",
+          "message_id": "om_123",
+          "resource_key": "img_v3_456"
+        }
+        """;
+
+    private static async Task<IWorkflowTool> GetFetchToolAsync(
+        IWorkflowConnectedServiceResourceFetchAdapter adapter,
+        IWorkflowFileIngressPort ingressPort)
+    {
+        var source = new WorkflowConnectedServiceResourceFetchToolSource([adapter], ingressPort);
+        return (await source.GetToolsAsync()).Single();
+    }
+
+    private static WorkflowToolExecutionRequest NewFetchRequest(
+        string argumentsJson,
+        string? bearerToken = "token-123") =>
+        new(
+            ArgumentsJson: argumentsJson,
+            RunId: "run-1",
+            StepId: "step-1",
+            ExecutionId: "exec-1",
+            CallId: "call-1",
+            ScopeId: "scope-1",
+            CallerCredential: new ProtoWorkflowCallerCredential { BearerToken = bearerToken });
+
+    private static void AssertError(WorkflowToolExecutionResult output, string expectedError)
+    {
+        using var document = JsonDocument.Parse(output.ResultJson);
+        var root = document.RootElement;
+        root.GetProperty("success").GetBoolean().Should().BeFalse();
+        root.GetProperty("error").GetString().Should().Be(expectedError);
+        root.GetProperty("detail").GetString().Should().NotBeNullOrWhiteSpace();
+        root.TryGetProperty("file_ref", out _).Should().BeFalse();
+    }
+
     private sealed class RecordingWorkflowFileIngressPort : IWorkflowFileIngressPort
     {
         public List<WorkflowFileIngressRequest> Requests { get; } = [];
+
+        public Exception? IngestException { get; init; }
 
         public ValueTask<WorkflowFileIngressResult> IngestAsync(
             WorkflowFileIngressRequest request,
             CancellationToken cancellationToken = default)
         {
             Requests.Add(request);
+            if (IngestException != null)
+                throw IngestException;
+
             return ValueTask.FromResult(new WorkflowFileIngressResult(new AppWorkflowFileRef
             {
                 FileId = "wf-file-1",
@@ -174,11 +342,16 @@ public sealed class WorkflowConnectedServiceResourceFetchToolTests
         public WorkflowConnectedServiceResourceFetchResult Result { get; init; } =
             new(true, Encoding.UTF8.GetBytes("resource"));
 
+        public Exception? FetchException { get; init; }
+
         public ValueTask<WorkflowConnectedServiceResourceFetchResult> FetchAsync(
             WorkflowConnectedServiceResourceFetchRequest request,
             CancellationToken cancellationToken = default)
         {
             Requests.Add(request);
+            if (FetchException != null)
+                throw FetchException;
+
             return ValueTask.FromResult(Result);
         }
     }

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowConnectedServiceResourceFetchToolTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowConnectedServiceResourceFetchToolTests.cs
@@ -1,0 +1,185 @@
+using System.Text;
+using System.Text.Json;
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.Workflow.Core.Modules;
+using Aevatar.Workflow.Infrastructure.DependencyInjection;
+using Aevatar.Workflow.Infrastructure.Runs;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using AppWorkflowCallerCredential = Aevatar.Workflow.Application.Abstractions.Runs.WorkflowCallerCredential;
+using AppWorkflowFileRef = Aevatar.Workflow.Application.Abstractions.Runs.WorkflowFileRef;
+using AppWorkflowFileSourceKind = Aevatar.Workflow.Application.Abstractions.Runs.WorkflowFileSourceKind;
+using ProtoWorkflowCallerCredential = Aevatar.Workflow.Abstractions.WorkflowCallerCredential;
+
+namespace Aevatar.Workflow.Host.Api.Tests;
+
+public sealed class WorkflowConnectedServiceResourceFetchToolTests
+{
+    [Fact]
+    public async Task AddWorkflowInfrastructure_ShouldRegisterCanonicalFetchToolSource()
+    {
+        var services = new ServiceCollection();
+
+        services.AddWorkflowInfrastructure();
+
+        services.Should().ContainSingle(x =>
+            x.ServiceType == typeof(IWorkflowToolSource) &&
+            x.ImplementationType == typeof(WorkflowConnectedServiceResourceFetchToolSource));
+        using var provider = services.BuildServiceProvider();
+        var toolNames = new List<string>();
+        foreach (var toolSource in provider.GetServices<IWorkflowToolSource>())
+        {
+            var tools = await toolSource.GetToolsAsync();
+            toolNames.AddRange(tools.Select(x => x.Name));
+        }
+
+        toolNames.Should().ContainSingle(name => name == "workflow_connected_service_resource_fetch");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldIngestProviderBytesAndReturnSanitizedFileRef()
+    {
+        var ingressPort = new RecordingWorkflowFileIngressPort();
+        var adapter = new RecordingConnectedServiceResourceFetchAdapter(
+            new WorkflowConnectedServiceResourceFetchRoute("lark", "message_resource_download", "image"))
+        {
+            Result = new WorkflowConnectedServiceResourceFetchResult(
+                Succeeded: true,
+                Content: Encoding.UTF8.GetBytes("image-bytes"),
+                MediaType: "image/png",
+                FileName: "photo.png"),
+        };
+        var source = new WorkflowConnectedServiceResourceFetchToolSource([adapter], ingressPort);
+
+        var tool = (await source.GetToolsAsync()).Should()
+            .ContainSingle(x => x.Name == "workflow_connected_service_resource_fetch")
+            .Subject;
+
+        var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+            ArgumentsJson: """
+            {
+              "provider": "lark",
+              "operation": "message_resource_download",
+              "resource_kind": "image",
+              "message_id": "om_123",
+              "resource_key": "img_v3_456"
+            }
+            """,
+            RunId: "run-1",
+            StepId: "step-1",
+            ExecutionId: "exec-1",
+            CallId: "call-1",
+            ScopeId: "scope-1",
+            CallerCredential: new ProtoWorkflowCallerCredential { BearerToken = "token-123" }));
+
+        adapter.Requests.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new WorkflowConnectedServiceResourceFetchRequest(
+                Route: new WorkflowConnectedServiceResourceFetchRoute("lark", "message_resource_download", "image"),
+                SourceMessageId: "om_123",
+                SourceResourceKey: "img_v3_456",
+                CallerCredential: new AppWorkflowCallerCredential("token-123")));
+        ingressPort.Requests.Should().ContainSingle();
+        var ingressRequest = ingressPort.Requests[0];
+        ingressRequest.Content.ToArray().Should().Equal(Encoding.UTF8.GetBytes("image-bytes"));
+        ingressRequest.SourceKind.Should().Be(AppWorkflowFileSourceKind.ConnectedServiceResource);
+        ingressRequest.SourceMessageId.Should().Be("om_123");
+        ingressRequest.SourceResourceKey.Should().Be("img_v3_456");
+        ingressRequest.FileName.Should().Be("photo.png");
+        ingressRequest.MediaType.Should().Be("image/png");
+        ingressRequest.OwnerRunId.Should().Be("run-1");
+        ingressRequest.OwnerScopeId.Should().Be("scope-1");
+
+        using var document = JsonDocument.Parse(output.ResultJson);
+        var root = document.RootElement;
+        root.GetProperty("success").GetBoolean().Should().BeTrue();
+        root.GetProperty("provider").GetString().Should().Be("lark");
+        root.GetProperty("operation").GetString().Should().Be("message_resource_download");
+        root.GetProperty("resource_kind").GetString().Should().Be("image");
+        var fileRef = root.GetProperty("file_ref");
+        fileRef.GetProperty("file_id").GetString().Should().Be("wf-file-1");
+        fileRef.GetProperty("artifact_id").GetString().Should().Be("workflow-file://wf-file-1");
+        fileRef.GetProperty("source_kind").GetString().Should().Be("ConnectedServiceResource");
+        fileRef.GetProperty("source_message_id").GetString().Should().Be("om_123");
+        fileRef.GetProperty("source_resource_key").GetString().Should().Be("img_v3_456");
+        root.ToString().Should().NotContain("image-bytes");
+        root.ToString().Contains("base64", StringComparison.OrdinalIgnoreCase).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldRejectUnsupportedRoutesBeforeProviderCall()
+    {
+        var ingressPort = new RecordingWorkflowFileIngressPort();
+        var adapter = new RecordingConnectedServiceResourceFetchAdapter(
+            new WorkflowConnectedServiceResourceFetchRoute("lark", "message_resource_download", "image"));
+        var source = new WorkflowConnectedServiceResourceFetchToolSource([adapter], ingressPort);
+        var tool = (await source.GetToolsAsync()).Single();
+
+        var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+            ArgumentsJson: """
+            {
+              "provider": "lark",
+              "operation": "message_resource_download",
+              "resource_kind": "video",
+              "message_id": "om_123",
+              "resource_key": "video_456"
+            }
+            """,
+            RunId: "run-1",
+            StepId: "step-1",
+            ExecutionId: "exec-1",
+            CallId: "call-1",
+            ScopeId: "scope-1",
+            CallerCredential: new ProtoWorkflowCallerCredential { BearerToken = "token-123" }));
+
+        adapter.Requests.Should().BeEmpty();
+        ingressPort.Requests.Should().BeEmpty();
+        output.ResultJson.Should().Contain("unsupported_resource_route");
+    }
+
+    private sealed class RecordingWorkflowFileIngressPort : IWorkflowFileIngressPort
+    {
+        public List<WorkflowFileIngressRequest> Requests { get; } = [];
+
+        public ValueTask<WorkflowFileIngressResult> IngestAsync(
+            WorkflowFileIngressRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            Requests.Add(request);
+            return ValueTask.FromResult(new WorkflowFileIngressResult(new AppWorkflowFileRef
+            {
+                FileId = "wf-file-1",
+                ArtifactId = "workflow-file://wf-file-1",
+                SourceKind = request.SourceKind,
+                SourceMessageId = request.SourceMessageId,
+                SourceResourceKey = request.SourceResourceKey,
+                FileName = request.FileName,
+                MediaType = request.MediaType,
+                SizeBytes = request.Content.Length,
+                Sha256 = "sha256",
+                CreatedAtUnixMs = 1,
+                ExpiresAtUnixMs = 2,
+                OwnerRunId = request.OwnerRunId,
+                OwnerScopeId = request.OwnerScopeId,
+            }));
+        }
+    }
+
+    private sealed class RecordingConnectedServiceResourceFetchAdapter(
+        WorkflowConnectedServiceResourceFetchRoute route) : IWorkflowConnectedServiceResourceFetchAdapter
+    {
+        public IReadOnlyList<WorkflowConnectedServiceResourceFetchRoute> Routes { get; } = [route];
+
+        public List<WorkflowConnectedServiceResourceFetchRequest> Requests { get; } = [];
+
+        public WorkflowConnectedServiceResourceFetchResult Result { get; init; } =
+            new(true, Encoding.UTF8.GetBytes("resource"));
+
+        public ValueTask<WorkflowConnectedServiceResourceFetchResult> FetchAsync(
+            WorkflowConnectedServiceResourceFetchRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            Requests.Add(request);
+            return ValueTask.FromResult(Result);
+        }
+    }
+}


### PR DESCRIPTION
## Changed files

实现 workflow-owned `workflow_connected_service_resource_fetch` canonical tool，并新增 `IWorkflowConnectedServiceResourceFetchAdapter` 抽象。Workflow 侧负责 route allowlist、caller bearer token、文件 ingress 和 sanitized `WorkflowFileRef` 输出；Lark 侧只注册 narrow binary adapter，映射 `lark/message_resource_download/image|file` 到现有 Lark message resource download client。

同步更新 workflow runtime 文档和 Host API README，补充 mainnet composition、workflow tool、Lark adapter 注册与行为测试。Closes #2139

## Test results

- `bash -lc "dotnet build aevatar.slnx --nologo"`：通过，52 warnings，0 errors。
- `bash -lc "dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo"`：通过，551 passed，0 failed。
- `bash -lc "dotnet test test/Aevatar.AI.ToolProviders.Lark.Tests/Aevatar.AI.ToolProviders.Lark.Tests.csproj --nologo"`：通过，114 passed，0 failed。
- `bash -lc "dotnet test test/Aevatar.Capabilities.Tests/Aevatar.Capabilities.Tests.csproj --nologo"`：通过，289 passed，0 failed。
- `bash tools/ci/test_stability_guards.sh`：通过。
- `bash tools/ci/architecture_guards.sh`：通过。
- `bash -lc "... dotnet test aevatar.slnx --nologo"`：通过，exit code 0；各项目 summary 均为 0 failed。

## Deviations

- 未扩展 scope。
- `.refactor-loop/host.env` 在本机不存在；未创建或修改该 host artifact，最终 build/test 使用 guarded source 检查后在当前 shell 环境执行。
- `HOST_REFACTOR_COMMENT_POLICY=none`，未添加 refactor-history source comments。

⟦AI:AUTO-LOOP⟧
