### PR TITLE
fix(voice): add replay protection to the device-event HMAC ingress (#2157)

### DIFF
--- a/agents/Aevatar.GAgents.Device/DeviceCallbackAdmission.cs
+++ b/agents/Aevatar.GAgents.Device/DeviceCallbackAdmission.cs
@@ -1,0 +1,41 @@
+using System.Globalization;
+
+namespace Aevatar.GAgents.Device;
+
+public sealed record DeviceCallbackAdmission(
+    string RegistrationId,
+    string MessageId,
+    string DeliveryId,
+    string SignedBodyTimestampValue,
+    DateTimeOffset SignedBodyTimestamp,
+    DateTimeOffset OccurredAt)
+{
+    public const string OperationPrefix = "device-event";
+
+    public string OperationId => $"{OperationPrefix}:{RegistrationId.Trim()}:{DeliveryId.Trim()}";
+
+    public bool IsFreshAt(DateTimeOffset now, TimeSpan freshnessWindow)
+    {
+        var skew = now >= SignedBodyTimestamp
+            ? now - SignedBodyTimestamp
+            : SignedBodyTimestamp - now;
+
+        return skew <= freshnessWindow;
+    }
+
+    public static bool TryParseSignedBodyTimestamp(string value, out DateTimeOffset timestamp)
+    {
+        if (DateTimeOffset.TryParse(
+                value,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out timestamp))
+        {
+            timestamp = timestamp.ToUniversalTime();
+            return true;
+        }
+
+        timestamp = default;
+        return false;
+    }
+}

--- a/agents/Aevatar.GAgents.Device/DeviceCommandFacades.cs
+++ b/agents/Aevatar.GAgents.Device/DeviceCommandFacades.cs
@@ -36,9 +36,28 @@ public interface IDeviceCallbackCommandService
 public sealed record DeviceCallbackDispatchCommand(
     string RegistrationId,
     DeviceInbound Inbound,
+    DeviceCallbackAdmission? Admission = null,
     string? CommandId = null,
     string? CorrelationId = null,
-    IReadOnlyDictionary<string, string>? Headers = null) : ICommandContextSeed;
+    IReadOnlyDictionary<string, string>? Headers = null) : ICommandContextSeed
+{
+    string? ICommandContextSeed.CommandId => FirstNonEmpty(CommandId, Admission?.MessageId, Inbound?.EventId);
+
+    string? ICommandContextSeed.CorrelationId => FirstNonEmpty(CorrelationId, CommandId, Admission?.MessageId, Inbound?.EventId);
+
+    IReadOnlyDictionary<string, string>? ICommandContextSeed.Headers => Headers;
+
+    private static string? FirstNonEmpty(params string?[] values)
+    {
+        foreach (var value in values)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+                return value.Trim();
+        }
+
+        return null;
+    }
+}
 
 // Refactor (iter47/issue-873-device-endpoint-direct-runtime-dispatch):
 //   Old pattern: Device HTTP endpoint resolves/creates actors, builds EventEnvelope directly, and dispatches through runtime/dispatch ports.
@@ -260,10 +279,25 @@ internal sealed class DeviceCallbackCommandEnvelopeFactory
         return new EventEnvelope
         {
             Id = context.CommandId,
-            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            Timestamp = Timestamp.FromDateTimeOffset(command.Admission?.OccurredAt ?? DateTimeOffset.UtcNow),
             Payload = Any.Pack(command.Inbound),
             Route = EnvelopeRouteSemantics.CreateDirect(PublisherActorId, context.TargetId),
+            Runtime = new EnvelopeRuntime
+            {
+                Deduplication = new DeliveryDeduplication
+                {
+                    OperationId = ResolveOperationId(command, context),
+                },
+            },
         };
+    }
+
+    private static string ResolveOperationId(DeviceCallbackDispatchCommand command, CommandContext context)
+    {
+        if (!string.IsNullOrWhiteSpace(command.Admission?.OperationId))
+            return command.Admission.OperationId;
+
+        return context.CommandId;
     }
 }
 

--- a/agents/Aevatar.GAgents.Device/DeviceEventEndpoints.cs
+++ b/agents/Aevatar.GAgents.Device/DeviceEventEndpoints.cs
@@ -15,6 +15,8 @@ namespace Aevatar.GAgents.Device;
 public sealed class DeviceEventOptions
 {
     public bool SkipHmacVerification { get; set; }
+
+    public TimeSpan CallbackFreshnessWindow { get; set; } = TimeSpan.FromSeconds(10);
 }
 
 public static class DeviceEventEndpoints
@@ -75,12 +77,21 @@ public static class DeviceEventEndpoints
             bodyBytes = ms.ToArray();
         }
 
-        // HMAC verification
-        if (!VerifyHmacSignature(http, bodyBytes, registration, options.Value))
+        var now = DateTimeOffset.UtcNow;
+        var admissionResult = AdmitCallback(http, bodyBytes, registration, options.Value, now);
+        if (!admissionResult.Succeeded)
         {
-            logger.LogWarning("Device event HMAC verification failed: registration={RegistrationId}", registrationId);
-            return Results.Unauthorized();
+            logger.LogWarning(
+                "Device event callback admission failed: registration={RegistrationId}, reason={Reason}",
+                registrationId,
+                admissionResult.Error);
+            return admissionResult.Error == DeviceCallbackAdmissionError.SignatureRejected
+                ? Results.Unauthorized()
+                : Results.BadRequest(new { error = admissionResult.Error });
         }
+
+        var admission = admissionResult.Admission!;
+        LogHeaderTimestampDiagnostic(logger, http, admission);
 
         // Parse callback payload into the v1 typed DeviceInbound allowlist.
         // Unknown event_type values are rejected here, before actor/read-model/projection dispatch.
@@ -103,7 +114,7 @@ public static class DeviceEventEndpoints
         try
         {
             var dispatch = await callbackCommandService.DispatchCallbackAsync(
-                new DeviceCallbackDispatchCommand(registrationId, inbound),
+                new DeviceCallbackDispatchCommand(registrationId, inbound, admission),
                 ct);
             if (!dispatch.Succeeded)
             {
@@ -136,11 +147,50 @@ public static class DeviceEventEndpoints
         }
     }
 
+    internal static DeviceCallbackAdmissionResult AdmitCallback(
+        HttpContext http,
+        byte[] bodyBytes,
+        DeviceRegistrationEntry registration,
+        DeviceEventOptions options,
+        DateTimeOffset now)
+    {
+        ArgumentNullException.ThrowIfNull(http);
+        ArgumentNullException.ThrowIfNull(bodyBytes);
+        ArgumentNullException.ThrowIfNull(registration);
+        ArgumentNullException.ThrowIfNull(options);
+
+        try
+        {
+            if (!TryReadCallbackAdmissionFacts(
+                    bodyBytes,
+                    registration.Id ?? string.Empty,
+                    out var admission,
+                    out var parseError))
+            {
+                return DeviceCallbackAdmissionResult.Failure(parseError);
+            }
+
+            var admitted = admission!;
+            if (!VerifyHmacSignature(http, bodyBytes, registration, options, admitted))
+                return DeviceCallbackAdmissionResult.Failure(DeviceCallbackAdmissionError.SignatureRejected);
+
+            if (!admitted.IsFreshAt(now, options.CallbackFreshnessWindow))
+                return DeviceCallbackAdmissionResult.Failure(DeviceCallbackAdmissionError.StaleSignedBodyTimestamp);
+
+            return DeviceCallbackAdmissionResult.Success(admitted);
+        }
+        catch (JsonException)
+        {
+            return DeviceCallbackAdmissionResult.Failure(DeviceCallbackAdmissionError.InvalidDeliveryId);
+        }
+    }
+
     internal static bool VerifyHmacSignature(
         HttpContext http,
         byte[] bodyBytes,
         DeviceRegistrationEntry registration,
-        DeviceEventOptions options)
+        DeviceEventOptions options,
+        DeviceCallbackAdmission? admission = null)
     {
         if (options.SkipHmacVerification)
             return true;
@@ -152,14 +202,131 @@ public static class DeviceEventEndpoints
         if (string.IsNullOrEmpty(registration.HmacKey))
             return false;
 
+        if (admission is null)
+        {
+            try
+            {
+                if (!TryReadCallbackAdmissionFacts(
+                        bodyBytes,
+                        registration.Id ?? string.Empty,
+                        out admission,
+                        out _))
+                {
+                    return false;
+                }
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+        }
+
         var keyBytes = Encoding.UTF8.GetBytes(registration.HmacKey);
         using var hmac = new HMACSHA256(keyBytes);
-        var computedHash = hmac.ComputeHash(bodyBytes);
+        var computedHash = hmac.ComputeHash(BuildSignaturePayload(bodyBytes));
         var computedSignature = Convert.ToHexStringLower(computedHash);
 
         return CryptographicOperations.FixedTimeEquals(
             Encoding.UTF8.GetBytes(computedSignature),
-            Encoding.UTF8.GetBytes(signatureHeader.ToString()));
+            Encoding.UTF8.GetBytes(signatureHeader.ToString().Trim()));
+    }
+
+    internal static byte[] BuildSignaturePayload(byte[] bodyBytes) => bodyBytes;
+
+    private static void LogHeaderTimestampDiagnostic(
+        ILogger logger,
+        HttpContext http,
+        DeviceCallbackAdmission admission)
+    {
+        if (!http.Request.Headers.TryGetValue("X-NyxID-Timestamp", out var headerValue) ||
+            string.IsNullOrWhiteSpace(headerValue))
+        {
+            return;
+        }
+
+        var headerTimestampValue = headerValue.ToString();
+        if (!DeviceCallbackAdmission.TryParseSignedBodyTimestamp(headerTimestampValue, out var headerTimestamp))
+        {
+            logger.LogWarning("Device callback X-NyxID-Timestamp header is not parseable.");
+            return;
+        }
+
+        if (headerTimestamp != admission.SignedBodyTimestamp)
+        {
+            logger.LogWarning(
+                "Device callback X-NyxID-Timestamp differs from signed body timestamp: header={HeaderTimestamp}, body={BodyTimestamp}",
+                headerTimestamp,
+                admission.SignedBodyTimestamp);
+        }
+    }
+
+    private static bool TryReadCallbackAdmissionFacts(
+        byte[] bodyBytes,
+        string registrationId,
+        out DeviceCallbackAdmission? admission,
+        out DeviceCallbackAdmissionError error)
+    {
+        using var doc = JsonDocument.Parse(bodyBytes);
+        var root = doc.RootElement;
+
+        var messageId = root.TryGetProperty("message_id", out var messageIdElement)
+            ? messageIdElement.GetString() ?? string.Empty
+            : string.Empty;
+
+        var contentText = root.TryGetProperty("content", out var content) &&
+                          content.TryGetProperty("text", out var contentTextElement)
+            ? contentTextElement.GetString() ?? string.Empty
+            : string.Empty;
+        if (string.IsNullOrWhiteSpace(contentText))
+        {
+            admission = null;
+            error = DeviceCallbackAdmissionError.InvalidDeliveryId;
+            return false;
+        }
+
+        using var innerDoc = JsonDocument.Parse(contentText);
+        var inner = innerDoc.RootElement;
+        if (inner.ValueKind != JsonValueKind.Object)
+        {
+            admission = null;
+            error = DeviceCallbackAdmissionError.InvalidDeliveryId;
+            return false;
+        }
+
+        var timestampValue = root.TryGetProperty("timestamp", out var timestampElement)
+            ? timestampElement.GetString() ?? string.Empty
+            : string.Empty;
+        timestampValue = FirstNonEmpty(timestampValue, GetOptionalString(inner, "timestamp"));
+        if (string.IsNullOrWhiteSpace(timestampValue) ||
+            !DeviceCallbackAdmission.TryParseSignedBodyTimestamp(timestampValue, out var signedBodyTimestamp))
+        {
+            admission = null;
+            error = DeviceCallbackAdmissionError.InvalidSignedBodyTimestamp;
+            return false;
+        }
+
+        var eventId = GetOptionalString(inner, "event_id");
+        var correlationKey = inner.TryGetProperty("correlation_key", out var correlationKeyElement)
+            ? correlationKeyElement.GetString() ?? string.Empty
+            : string.Empty;
+        var deliveryId = FirstNonEmpty(eventId, correlationKey);
+        if (string.IsNullOrWhiteSpace(deliveryId))
+        {
+            admission = null;
+            error = DeviceCallbackAdmissionError.InvalidDeliveryId;
+            return false;
+        }
+
+        var commandId = FirstNonEmpty(messageId, deliveryId);
+        admission = new DeviceCallbackAdmission(
+            registrationId,
+            commandId,
+            deliveryId,
+            timestampValue,
+            signedBodyTimestamp,
+            signedBodyTimestamp);
+        error = DeviceCallbackAdmissionError.None;
+        return true;
     }
 
     /// <summary>
@@ -444,4 +611,25 @@ public static class DeviceEventEndpoints
         string? NyxConversationId,
         string? Description,
         string? DeviceEventTargetActorId);
+}
+
+internal sealed record DeviceCallbackAdmissionResult(
+    bool Succeeded,
+    DeviceCallbackAdmission? Admission,
+    DeviceCallbackAdmissionError Error)
+{
+    public static DeviceCallbackAdmissionResult Success(DeviceCallbackAdmission admission) =>
+        new(true, admission, DeviceCallbackAdmissionError.None);
+
+    public static DeviceCallbackAdmissionResult Failure(DeviceCallbackAdmissionError error) =>
+        new(false, null, error);
+}
+
+internal enum DeviceCallbackAdmissionError
+{
+    None = 0,
+    SignatureRejected = 1,
+    InvalidSignedBodyTimestamp = 2,
+    StaleSignedBodyTimestamp = 3,
+    InvalidDeliveryId = 4,
 }

--- a/docs/canon/voice-presence-integration.md
+++ b/docs/canon/voice-presence-integration.md
@@ -82,7 +82,17 @@ touch the audio socket.
 | **Audio + control** | edge ⇄ aevatar ⇄ OpenAI | binary PCM16 (audio) + JSON `VoiceControlFrame` (control) over `/ws/voice`; relay WS to OpenAI | Hot path. Raw PCM never enters the actor inbox / `EventEnvelope` / projection / committed store (ADR-013 media red line). |
 | **Credential** | aevatar → NyxID → OpenAI | HTTPS mint, caller bearer flowed via AsyncLocal | Connect-time only. NyxID injects the real `sk-`; aevatar receives a short-lived `ek_` (~60s TTL) and dials OpenAI directly (ADR-0033). |
 | **Edge tools** | actor → NyxID proxy → node WS → edge HTTP → LAN | NyxID connected-service `x-aevatar-tool` operations | The LAN tool bridge. Edge publishes `/edge-tools/openapi.json`; only `EDGE_TOOLS_ALLOWLIST` operations are exposed (ADR-0031 short-term bridge). |
-| **Device events** | edge → aevatar `/api/device-events/{regId}` | HMAC-SHA256 signed body | Off-socket household-event ingress; the actor owns dedupe / fencing / turn creation. |
+| **Device events** | edge → aevatar `/api/device-events/{regId}` | HMAC-SHA256 signed callback body | Off-socket household-event ingress. The endpoint admits only fresh signed body timestamps and maps a stable delivery id into the envelope dedupe operation; the actor owns fencing / turn creation. |
+
+Device-event replay protection is enforced before dispatch. The endpoint trusts
+only the timestamp carried in the HMAC-covered callback body, with a default
+10-second freshness window aligned to voice event staleness. `X-NyxID-Timestamp`
+is diagnostic only and cannot refresh a captured body. The delivery id is
+`content.text.event_id` when present, otherwise a home-alert `correlation_key`;
+it becomes `Runtime.Deduplication.OperationId =
+device-event:{registrationId}:{deliveryId}`. If no active voice session exists,
+the event is still drop-and-log at the voice boundary; this integration does not
+add a durable spool.
 
 ## Wire contract
 

--- a/src/Aevatar.Foundation.VoicePresence/Events/VoicePresenceEventPolicy.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Events/VoicePresenceEventPolicy.cs
@@ -11,7 +11,7 @@ public sealed class VoicePresenceEventPolicy
 {
     public TimeSpan StaleAfter { get; init; } = TimeSpan.FromSeconds(10);
 
-    public TimeSpan DedupeWindow { get; init; } = TimeSpan.FromSeconds(2);
+    public TimeSpan DedupeWindow { get; init; } = TimeSpan.FromSeconds(10);
 
     // Refactor (iter104/cluster-3): Old pattern: VoicePresenceEventPolicy kept module-local in-memory recent-event dedupe set. New principle: dedupe fence in VoicePresenceRuntimeState (actor-owned); policy is pure evaluator over passed-in actor state.
     public VoicePresenceEventPolicyVerdict Evaluate(
@@ -74,6 +74,13 @@ public sealed class VoicePresenceEventPolicy
     public static string BuildKey(EventEnvelope envelope)
     {
         ArgumentNullException.ThrowIfNull(envelope);
+
+        var operationId = envelope.Runtime?.Deduplication?.OperationId;
+        if (!string.IsNullOrWhiteSpace(operationId))
+            return $"operation:{operationId.Trim()}";
+
+        if (!string.IsNullOrWhiteSpace(envelope.Id))
+            return $"envelope:{envelope.Id.Trim()}";
 
         if (envelope.Payload == null)
             return "payload:null";

--- a/src/Aevatar.Foundation.VoicePresence/VoicePresenceModuleOptions.cs
+++ b/src/Aevatar.Foundation.VoicePresence/VoicePresenceModuleOptions.cs
@@ -15,7 +15,7 @@ public sealed class VoicePresenceModuleOptions
 
     public TimeSpan StaleAfter { get; init; } = TimeSpan.FromSeconds(10);
 
-    public TimeSpan DedupeWindow { get; init; } = TimeSpan.FromSeconds(2);
+    public TimeSpan DedupeWindow { get; init; } = TimeSpan.FromSeconds(10);
 
     public TimeSpan ToolExecutionTimeout { get; init; } = TimeSpan.FromSeconds(10);
 

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceEventPolicyTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceEventPolicyTests.cs
@@ -35,8 +35,8 @@ public class VoicePresenceEventPolicyTests
     {
         var policy = new VoicePresenceEventPolicy { DedupeWindow = TimeSpan.FromSeconds(2) };
         var now = DateTimeOffset.UtcNow;
-        var first = MakeEnvelope("Alice", now);
-        var second = MakeEnvelope("Alice", now.AddMilliseconds(500));
+        var first = MakeEnvelope("Alice", now, envelopeId: "event-1");
+        var second = MakeEnvelope("Alice", now.AddMilliseconds(500), envelopeId: "event-1");
         var fence = new List<VoicePresenceEventDedupeFenceEntry>();
 
         var verdict = policy.Evaluate(first, now, fence);
@@ -87,10 +87,10 @@ public class VoicePresenceEventPolicyTests
         var now = DateTimeOffset.UtcNow;
         var fence = new List<VoicePresenceEventDedupeFenceEntry>();
 
-        var verdict = policy.Evaluate(MakeEnvelope("Alice", now), now, fence);
+        var verdict = policy.Evaluate(MakeEnvelope("Alice", now, envelopeId: "event-a"), now, fence);
         verdict.Decision.ShouldBe(VoicePresenceEventPolicyDecision.Admit);
         fence = policy.BuildFence(fence, verdict, now).ToList();
-        policy.Evaluate(MakeEnvelope("Bob", now), now.AddMilliseconds(10), fence)
+        policy.Evaluate(MakeEnvelope("Bob", now, envelopeId: "event-b"), now.AddMilliseconds(10), fence)
             .Decision
             .ShouldBe(VoicePresenceEventPolicyDecision.Admit);
     }
@@ -100,8 +100,8 @@ public class VoicePresenceEventPolicyTests
     {
         var policy = new VoicePresenceEventPolicy { DedupeWindow = TimeSpan.FromSeconds(2) };
         var now = DateTimeOffset.UtcNow;
-        var first = MakeEnvelope("Alice", now);
-        var later = MakeEnvelope("Alice", now.AddSeconds(5));
+        var first = MakeEnvelope("Alice", now, envelopeId: "event-1");
+        var later = MakeEnvelope("Alice", now.AddSeconds(5), envelopeId: "event-1");
         var fence = new List<VoicePresenceEventDedupeFenceEntry>();
 
         var verdict = policy.Evaluate(first, now, fence);
@@ -131,15 +131,65 @@ public class VoicePresenceEventPolicyTests
             .ShouldBe(VoicePresenceEventPolicyDecision.DropDuplicate);
     }
 
-    private static EventEnvelope MakeEnvelope(string person, DateTimeOffset observedAt)
+    [Fact]
+    public void BuildKey_prefers_operation_id_then_envelope_id_then_payload()
     {
-        return new EventEnvelope
+        var operationEnvelope = MakeEnvelope("Alice", DateTimeOffset.UtcNow, operationId: "device-event:reg-1:evt-1");
+        var idEnvelope = MakeEnvelope("Alice", DateTimeOffset.UtcNow, envelopeId: "event-1");
+        var payloadEnvelope = MakeEnvelope("Alice", DateTimeOffset.UtcNow, envelopeId: string.Empty);
+
+        VoicePresenceEventPolicy.BuildKey(operationEnvelope)
+            .ShouldBe("operation:device-event:reg-1:evt-1");
+        VoicePresenceEventPolicy.BuildKey(idEnvelope)
+            .ShouldBe("envelope:event-1");
+        VoicePresenceEventPolicy.BuildKey(payloadEnvelope)
+            .ShouldStartWith("type.googleapis.com/google.protobuf.StringValue|");
+    }
+
+    [Fact]
+    public void Same_delivery_operation_id_is_dropped_for_entire_dedupe_window()
+    {
+        var policy = new VoicePresenceEventPolicy();
+        var now = DateTimeOffset.UtcNow;
+        var first = MakeEnvelope("Alice", now, operationId: "device-event:reg-1:evt-1");
+        var replay = MakeEnvelope("Bob", now.AddSeconds(9), operationId: "device-event:reg-1:evt-1");
+        var fence = new List<VoicePresenceEventDedupeFenceEntry>();
+
+        var verdict = policy.Evaluate(first, now, fence);
+        verdict.Decision.ShouldBe(VoicePresenceEventPolicyDecision.Admit);
+        fence = policy.BuildFence(fence, verdict, now).ToList();
+
+        policy.Evaluate(replay, now.AddSeconds(9), fence)
+            .Decision
+            .ShouldBe(VoicePresenceEventPolicyDecision.DropDuplicate);
+    }
+
+    private static EventEnvelope MakeEnvelope(
+        string person,
+        DateTimeOffset observedAt,
+        string? envelopeId = null,
+        string? operationId = null)
+    {
+        var envelope = new EventEnvelope
         {
-            Id = Guid.NewGuid().ToString("N"),
+            Id = envelopeId ?? Guid.NewGuid().ToString("N"),
             Timestamp = Timestamp.FromDateTimeOffset(observedAt),
             Payload = Any.Pack(new StringValue { Value = person }),
             Route = EnvelopeRouteSemantics.CreateTopologyPublication("voice-agent", TopologyAudience.Self),
         };
+
+        if (!string.IsNullOrWhiteSpace(operationId))
+        {
+            envelope.Runtime = new EnvelopeRuntime
+            {
+                Deduplication = new DeliveryDeduplication
+                {
+                    OperationId = operationId,
+                },
+            };
+        }
+
+        return envelope;
     }
 
     private static string FindRepositoryFile(params string[] relativePath)

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceCommandFacadeTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceCommandFacadeTests.cs
@@ -1,7 +1,11 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.Device;
 using Aevatar.GAgents.Household;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using NSubstitute;
 
 namespace Aevatar.GAgents.ChannelRuntime.Tests;
@@ -50,6 +54,95 @@ public sealed class DeviceCommandFacadeTests
             DeviceRegistrationGAgent.WellKnownId,
             Arg.Any<EventEnvelope>(),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DispatchCallbackAsync_WhenAdmissionUsesEventId_ShouldMapEnvelopeIdentityTimestampAndOperationId()
+    {
+        EventEnvelope? capturedEnvelope = null;
+        var targetActor = Substitute.For<IActor>();
+        targetActor.Id.Returns("household-scope-a");
+        var queryPort = Substitute.For<IDeviceRegistrationQueryPort>();
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        var dispatchPort = Substitute.For<IActorDispatchPort>();
+        queryPort.GetAsync("reg-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<DeviceRegistrationEntry?>(new DeviceRegistrationEntry
+            {
+                Id = "reg-1",
+                ScopeId = "scope-a",
+                HmacKey = "key-a",
+                DeviceEventTargetActorId = "household-scope-a",
+            }));
+        actorRuntime.GetAsync("household-scope-a")
+            .Returns(Task.FromResult<IActor?>(targetActor));
+        dispatchPort.DispatchAsync(
+                "household-scope-a",
+                Arg.Do<EventEnvelope>(envelope => capturedEnvelope = envelope),
+                Arg.Any<CancellationToken>())
+            .Returns(ActorDispatchPortTestSupport.AcceptAsync);
+        var facade = DeviceCommandFacadeTestSupport.CreateCallbackFacade(queryPort, actorRuntime, dispatchPort);
+        var admission = CreateAdmission("reg-1", "nxmsg-1", eventId: "evt-3", correlationKey: "ha-corr-1");
+
+        var result = await facade.DispatchCallbackAsync(new DeviceCallbackDispatchCommand(
+            "reg-1",
+            new DeviceInbound
+            {
+                EventId = "evt-3",
+                EventType = "temperature_change",
+            },
+            admission));
+
+        result.Succeeded.Should().BeTrue();
+        result.Receipt!.CommandId.Should().Be("nxmsg-1");
+        capturedEnvelope.Should().NotBeNull();
+        capturedEnvelope!.Id.Should().Be("nxmsg-1");
+        capturedEnvelope.Timestamp.ToDateTimeOffset().Should().Be(admission.OccurredAt);
+        capturedEnvelope.Runtime.Deduplication.OperationId.Should().Be("device-event:reg-1:evt-3");
+    }
+
+    [Fact]
+    public async Task DispatchCallbackAsync_WhenEventIdMissing_ShouldUseHomeAlertCorrelationKeyForOperationId()
+    {
+        EventEnvelope? capturedEnvelope = null;
+        var targetActor = Substitute.For<IActor>();
+        targetActor.Id.Returns("household-scope-a");
+        var queryPort = Substitute.For<IDeviceRegistrationQueryPort>();
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        var dispatchPort = Substitute.For<IActorDispatchPort>();
+        queryPort.GetAsync("reg-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<DeviceRegistrationEntry?>(new DeviceRegistrationEntry
+            {
+                Id = "reg-1",
+                ScopeId = "scope-a",
+                HmacKey = "key-a",
+                DeviceEventTargetActorId = "household-scope-a",
+            }));
+        actorRuntime.GetAsync("household-scope-a")
+            .Returns(Task.FromResult<IActor?>(targetActor));
+        dispatchPort.DispatchAsync(
+                "household-scope-a",
+                Arg.Do<EventEnvelope>(envelope => capturedEnvelope = envelope),
+                Arg.Any<CancellationToken>())
+            .Returns(ActorDispatchPortTestSupport.AcceptAsync);
+        var facade = DeviceCommandFacadeTestSupport.CreateCallbackFacade(queryPort, actorRuntime, dispatchPort);
+        var admission = CreateAdmission("reg-1", "nxmsg-2", eventId: "", correlationKey: "ha-corr-2");
+
+        var result = await facade.DispatchCallbackAsync(new DeviceCallbackDispatchCommand(
+            "reg-1",
+            new DeviceInbound
+            {
+                EventType = "alarm_triggered",
+                HomeAlert = new HomeAlertDeviceInboundPayload
+                {
+                    CorrelationKey = "ha-corr-2",
+                },
+            },
+            admission));
+
+        result.Succeeded.Should().BeTrue();
+        admission.DeliveryId.Should().Be("ha-corr-2");
+        capturedEnvelope.Should().NotBeNull();
+        capturedEnvelope!.Runtime.Deduplication.OperationId.Should().Be("device-event:reg-1:ha-corr-2");
     }
 
     [Fact]
@@ -150,5 +243,48 @@ public sealed class DeviceCommandFacadeTests
             "household-scope-a",
             Arg.Any<EventEnvelope>(),
             Arg.Any<CancellationToken>());
+    }
+
+    private static DeviceCallbackAdmission CreateAdmission(
+        string registrationId,
+        string messageId,
+        string eventId,
+        string correlationKey)
+    {
+        const string hmacKey = "key-a";
+        const string timestampValue = "2026-04-09T10:00:00Z";
+        var body = JsonSerializer.Serialize(new
+        {
+            message_id = messageId,
+            content = new
+            {
+                text = JsonSerializer.Serialize(new
+                {
+                    event_id = eventId,
+                    event_type = "alarm_triggered",
+                    correlation_key = correlationKey,
+                }),
+            },
+            timestamp = timestampValue,
+        });
+        var bodyBytes = Encoding.UTF8.GetBytes(body);
+        var context = new DefaultHttpContext();
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(hmacKey));
+        context.Request.Headers["X-NyxID-Signature"] = Convert.ToHexStringLower(
+            hmac.ComputeHash(DeviceEventEndpoints.BuildSignaturePayload(bodyBytes)));
+
+        var result = DeviceEventEndpoints.AdmitCallback(
+            context,
+            bodyBytes,
+            new DeviceRegistrationEntry
+            {
+                Id = registrationId,
+                HmacKey = hmacKey,
+            },
+            new DeviceEventOptions { CallbackFreshnessWindow = TimeSpan.FromSeconds(10) },
+            DateTimeOffset.Parse(timestampValue).AddSeconds(1));
+
+        result.Succeeded.Should().BeTrue();
+        return result.Admission!;
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceEventEndpointsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceEventEndpointsTests.cs
@@ -255,7 +255,7 @@ public class DeviceEventEndpointsTests
         var queryPort = Substitute.For<IDeviceRegistrationQueryPort>();
         var callbackService = Substitute.For<IDeviceCallbackCommandService>();
         queryPort.GetAsync("reg-known", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<DeviceRegistrationEntry?>(MakeRegistration()));
+            .Returns(Task.FromResult<DeviceRegistrationEntry?>(MakeRegistration(registrationId: "reg-known")));
         callbackService.DispatchCallbackAsync(
                 Arg.Do<DeviceCallbackDispatchCommand>(command => capturedCommand = command),
                 Arg.Any<CancellationToken>())
@@ -276,7 +276,10 @@ public class DeviceEventEndpointsTests
             humidity = 44.0,
             light_level = 18.0,
         });
-        var context = CreateJsonHttpContext(EncodeCallbackPayload(innerEvent, senderPlatformId: "sensor-1"));
+        var context = CreateJsonHttpContext(EncodeCallbackPayload(
+            innerEvent,
+            senderPlatformId: "sensor-1",
+            callbackTimestamp: DateTimeOffset.UtcNow.ToString("O")));
 
         var result = await InvokeHandleDeviceCallbackAsync(
             context,
@@ -289,6 +292,10 @@ public class DeviceEventEndpointsTests
         body.Should().Contain("accepted");
         capturedCommand.Should().NotBeNull();
         capturedCommand!.RegistrationId.Should().Be("reg-known");
+        capturedCommand.Admission.Should().NotBeNull();
+        capturedCommand.Admission!.RegistrationId.Should().Be("reg-known");
+        capturedCommand.Admission.MessageId.Should().Be("nxmsg-55");
+        capturedCommand.Admission.DeliveryId.Should().Be("evt-known");
         capturedCommand.Inbound.DeviceId.Should().Be("sensor-1");
         capturedCommand.Inbound.PayloadCase.Should().Be(Aevatar.GAgents.Household.DeviceInbound.PayloadOneofCase.Sensor);
         capturedCommand.Inbound.Sensor.Temperature.Should().Be(23.5);
@@ -303,7 +310,7 @@ public class DeviceEventEndpointsTests
         var queryPort = Substitute.For<IDeviceRegistrationQueryPort>();
         var callbackService = Substitute.For<IDeviceCallbackCommandService>();
         queryPort.GetAsync("reg-unknown", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<DeviceRegistrationEntry?>(MakeRegistration()));
+            .Returns(Task.FromResult<DeviceRegistrationEntry?>(MakeRegistration(registrationId: "reg-unknown")));
 
         var innerEvent = JsonSerializer.Serialize(new
         {
@@ -311,7 +318,9 @@ public class DeviceEventEndpointsTests
             event_type = "unknown_type",
             payload = new { raw = "not admitted" },
         });
-        var context = CreateJsonHttpContext(EncodeCallbackPayload(innerEvent));
+        var context = CreateJsonHttpContext(EncodeCallbackPayload(
+            innerEvent,
+            callbackTimestamp: DateTimeOffset.UtcNow.ToString("O")));
 
         var result = await InvokeHandleDeviceCallbackAsync(
             context,
@@ -322,6 +331,36 @@ public class DeviceEventEndpointsTests
 
         statusCode.Should().Be(StatusCodes.Status400BadRequest);
         body.Should().Contain("Invalid callback payload");
+        await callbackService.DidNotReceiveWithAnyArgs()
+            .DispatchCallbackAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task HandleDeviceCallbackAsync_stale_signed_body_returns_reject_status_and_does_not_dispatch()
+    {
+        var queryPort = Substitute.For<IDeviceRegistrationQueryPort>();
+        var callbackService = Substitute.For<IDeviceCallbackCommandService>();
+        queryPort.GetAsync("reg-stale", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<DeviceRegistrationEntry?>(MakeRegistration(registrationId: "reg-stale")));
+        var innerEvent = JsonSerializer.Serialize(new
+        {
+            event_id = "evt-stale-dispatch",
+            event_type = "motion_detected",
+            detected = true,
+        });
+        var context = CreateJsonHttpContext(EncodeCallbackPayload(
+            innerEvent,
+            callbackTimestamp: "2026-04-09T10:00:00Z"));
+
+        var result = await InvokeHandleDeviceCallbackAsync(
+            context,
+            "reg-stale",
+            queryPort,
+            callbackService);
+        var (statusCode, body) = await ExecuteResultAsync(result);
+
+        statusCode.Should().Be(StatusCodes.Status400BadRequest);
+        body.Should().Contain(((int)DeviceCallbackAdmissionError.StaleSignedBodyTimestamp).ToString());
         await callbackService.DidNotReceiveWithAnyArgs()
             .DispatchCallbackAsync(default!, default);
     }
@@ -473,9 +512,11 @@ public class DeviceEventEndpointsTests
 
     // ─── HMAC Verification Tests ───
 
-    private static DeviceRegistrationEntry MakeRegistration(string hmacKey = "test-secret") => new()
+    private static DeviceRegistrationEntry MakeRegistration(
+        string hmacKey = "test-secret",
+        string registrationId = "reg-test-1") => new()
     {
-        Id = "reg-test-1",
+        Id = registrationId,
         ScopeId = "scope-test",
         HmacKey = hmacKey,
         CreatedAt = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
@@ -484,7 +525,9 @@ public class DeviceEventEndpointsTests
     private static string EncodeCallbackPayload(
         string innerEvent,
         string? senderPlatformId = null,
-        string? legacySenderId = null)
+        string? legacySenderId = null,
+        string? callbackTimestamp = null,
+        string messageId = "nxmsg-55")
     {
         object sender = legacySenderId is not null
             ? new { id = legacySenderId }
@@ -492,13 +535,13 @@ public class DeviceEventEndpointsTests
 
         return JsonSerializer.Serialize(new
         {
-            message_id = "nxmsg-55",
+            message_id = messageId,
             platform = "device",
             agent = new { api_key_id = "key-1", name = "home-agent" },
             conversation = new { id = "conv-99", platform_id = "conv-p-99", conversation_type = "direct" },
             sender,
             content = new { content_type = "text", text = innerEvent, attachments = Array.Empty<object>() },
-            timestamp = "2026-04-09T10:00:00Z",
+            timestamp = callbackTimestamp ?? "2026-04-09T10:00:00Z",
         });
     }
 
@@ -553,24 +596,33 @@ public class DeviceEventEndpointsTests
     }
 
     private static (HttpContext context, byte[] bodyBytes) CreateContextWithSignature(
-        string body, string hmacKey)
+        string body,
+        string hmacKey,
+        string? nyxTimestampHeader = null)
     {
         var bodyBytes = Encoding.UTF8.GetBytes(body);
         var keyBytes = Encoding.UTF8.GetBytes(hmacKey);
         using var hmac = new HMACSHA256(keyBytes);
-        var hash = hmac.ComputeHash(bodyBytes);
+        var hash = hmac.ComputeHash(DeviceEventEndpoints.BuildSignaturePayload(bodyBytes));
         var signature = Convert.ToHexStringLower(hash);
 
         var context = new DefaultHttpContext();
         context.Request.Headers["X-NyxID-Signature"] = signature;
+        if (nyxTimestampHeader is not null)
+            context.Request.Headers["X-NyxID-Timestamp"] = nyxTimestampHeader;
         return (context, bodyBytes);
     }
 
     [Fact]
     public void HmacVerification_valid_signature_returns_true()
     {
-        const string body = "{\"test\":\"data\"}";
         const string hmacKey = "my-secret-key";
+        var body = EncodeCallbackPayload(JsonSerializer.Serialize(new
+        {
+            event_id = "evt-signature",
+            event_type = "motion_detected",
+            detected = true,
+        }));
 
         var (context, bodyBytes) = CreateContextWithSignature(body, hmacKey);
         var registration = MakeRegistration(hmacKey);
@@ -579,6 +631,157 @@ public class DeviceEventEndpointsTests
         var result = DeviceEventEndpoints.VerifyHmacSignature(context, bodyBytes, registration, options);
 
         result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AdmitCallback_rejects_signed_body_outside_freshness_window()
+    {
+        const string hmacKey = "my-secret-key";
+        var now = DateTimeOffset.Parse("2026-04-09T10:00:20Z");
+        var body = EncodeCallbackPayload(
+            JsonSerializer.Serialize(new
+            {
+                event_id = "evt-stale",
+                event_type = "motion_detected",
+                detected = true,
+            }),
+            callbackTimestamp: "2026-04-09T10:00:00Z");
+        var (context, bodyBytes) = CreateContextWithSignature(body, hmacKey);
+
+        var result = DeviceEventEndpoints.AdmitCallback(
+            context,
+            bodyBytes,
+            MakeRegistration(hmacKey),
+            new DeviceEventOptions { CallbackFreshnessWindow = TimeSpan.FromSeconds(10) },
+            now);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(DeviceCallbackAdmissionError.StaleSignedBodyTimestamp);
+    }
+
+    [Fact]
+    public void AdmitCallback_rejects_captured_signed_body_replayed_after_window()
+    {
+        const string hmacKey = "my-secret-key";
+        var signedAt = DateTimeOffset.Parse("2026-04-09T10:00:00Z");
+        var body = EncodeCallbackPayload(
+            JsonSerializer.Serialize(new
+            {
+                event_id = "evt-replay",
+                event_type = "motion_detected",
+                detected = true,
+            }),
+            callbackTimestamp: "2026-04-09T10:00:00Z");
+        var (context, bodyBytes) = CreateContextWithSignature(body, hmacKey);
+        var options = new DeviceEventOptions { CallbackFreshnessWindow = TimeSpan.FromSeconds(10) };
+
+        var first = DeviceEventEndpoints.AdmitCallback(
+            context,
+            bodyBytes,
+            MakeRegistration(hmacKey),
+            options,
+            signedAt.AddSeconds(2));
+        var replay = DeviceEventEndpoints.AdmitCallback(
+            context,
+            bodyBytes,
+            MakeRegistration(hmacKey),
+            options,
+            signedAt.AddSeconds(11));
+
+        first.Succeeded.Should().BeTrue();
+        replay.Succeeded.Should().BeFalse();
+        replay.Error.Should().Be(DeviceCallbackAdmissionError.StaleSignedBodyTimestamp);
+    }
+
+    [Fact]
+    public void AdmitCallback_uses_body_timestamp_not_X_NyxID_Timestamp_as_freshness_authority()
+    {
+        const string hmacKey = "my-secret-key";
+        var body = EncodeCallbackPayload(
+            JsonSerializer.Serialize(new
+            {
+                event_id = "evt-header",
+                event_type = "motion_detected",
+                detected = true,
+            }),
+            callbackTimestamp: "2026-04-09T10:00:00Z");
+        var (context, bodyBytes) = CreateContextWithSignature(
+            body,
+            hmacKey,
+            nyxTimestampHeader: "2026-04-09T10:00:20Z");
+
+        var result = DeviceEventEndpoints.AdmitCallback(
+            context,
+            bodyBytes,
+            MakeRegistration(hmacKey),
+            new DeviceEventOptions { CallbackFreshnessWindow = TimeSpan.FromSeconds(10) },
+            DateTimeOffset.Parse("2026-04-09T10:00:20Z"));
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(DeviceCallbackAdmissionError.StaleSignedBodyTimestamp);
+    }
+
+    [Fact]
+    public void AdmitCallback_rejects_body_timestamp_tampering_without_resigning()
+    {
+        const string hmacKey = "my-secret-key";
+        var originalBody = EncodeCallbackPayload(
+            JsonSerializer.Serialize(new
+            {
+                event_id = "evt-tamper",
+                event_type = "motion_detected",
+                detected = true,
+            }),
+            callbackTimestamp: "2026-04-09T10:00:00Z");
+        var (context, _) = CreateContextWithSignature(originalBody, hmacKey);
+        var tamperedBody = originalBody.Replace(
+            "2026-04-09T10:00:00Z",
+            "2026-04-09T10:00:20Z",
+            StringComparison.Ordinal);
+
+        var result = DeviceEventEndpoints.AdmitCallback(
+            context,
+            Encoding.UTF8.GetBytes(tamperedBody),
+            MakeRegistration(hmacKey),
+            new DeviceEventOptions { CallbackFreshnessWindow = TimeSpan.FromSeconds(10) },
+            DateTimeOffset.Parse("2026-04-09T10:00:20Z"));
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(DeviceCallbackAdmissionError.SignatureRejected);
+    }
+
+    [Fact]
+    public void AdmitCallback_uses_inner_body_timestamp_when_outer_timestamp_is_absent()
+    {
+        const string hmacKey = "my-secret-key";
+        var body = JsonSerializer.Serialize(new
+        {
+            message_id = "nxmsg-inner-ts",
+            platform = "device",
+            content = new
+            {
+                content_type = "text",
+                text = JsonSerializer.Serialize(new
+                {
+                    event_id = "evt-inner-ts",
+                    event_type = "motion_detected",
+                    timestamp = "2026-04-09T10:00:00Z",
+                    detected = true,
+                }),
+            },
+        });
+        var (context, bodyBytes) = CreateContextWithSignature(body, hmacKey);
+
+        var result = DeviceEventEndpoints.AdmitCallback(
+            context,
+            bodyBytes,
+            MakeRegistration(hmacKey),
+            new DeviceEventOptions { CallbackFreshnessWindow = TimeSpan.FromSeconds(10) },
+            DateTimeOffset.Parse("2026-04-09T10:00:02Z"));
+
+        result.Succeeded.Should().BeTrue();
+        result.Admission!.SignedBodyTimestampValue.Should().Be("2026-04-09T10:00:00Z");
+        result.Admission.DeliveryId.Should().Be("evt-inner-ts");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary / 摘要

修复 #2157：device-event HMAC ingress 缺防重放——只做 body-only HMAC、facade 用 server `UtcNow` 重盖 `EventEnvelope.Timestamp`、voice policy 靠 payload bytes 短窗口 dedupe，导致 captured signed body 可跨窗口 replay 并刷新 staleness（涉及 alarm_triggered/lock_tampered/smoke 等安全相关告警）。

- **New**：typed `DeviceCallbackAdmission`；freshness 只信 HMAC 覆盖的 body timestamp（默认 10s，与 `VoicePresenceEventPolicy.StaleAfter` 对齐）；`EventEnvelope.Timestamp` 来自 admission occurred-time（不再 server UtcNow 重盖）；`EventEnvelope.Id` 由 body `message_id` seed；`Runtime.Deduplication.OperationId=device-event:{registrationId}:{deliveryId}`（deliveryId 优先 inner event_id，fallback home-alert correlation_key）；`VoicePresenceEventPolicy.BuildKey` 读 OperationId→Id→payload，Foundation 不引用 DeviceInbound。`X-NyxID-Timestamp` 仅诊断，不作 freshness authority；不要求 NyxID 改动。

design-consensus r2（`consensus:structural`）。

## Scope / 范围

9 files（新增 `DeviceCallbackAdmission.cs`；改 endpoints/facade/policy/options + 3 test 文件 + canon doc）。SCOPE_EXTEND：`VoicePresenceModuleOptions` 默认 dedupe 窗口对齐 10s。
- 测试：ChannelRuntime.Tests（DeviceEventEndpoints|DeviceCommandFacade）57 passed；VoicePresenceEventPolicyTests 10 passed；test_stability/architecture guards + docs lint 绿。

Closes #2157

🤖 consensus-loop (milestone 23)

⟦AI:AUTO-LOOP⟧
