### PR TITLE
fix(scheduled): SkillRunner cron fire 消费侧 occurrence 幂等 #2183

### DIFF
--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerDefaults.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerDefaults.cs
@@ -14,6 +14,7 @@ public static class SkillRunnerDefaults
     public const string StatusDisabled = "disabled";
     public const string StatusCompleted = "completed";
     public const string RejectionReasonRunnerDisabled = "runner_disabled";
+    public const string ScheduleTriggerReason = "schedule";
     public const string ExternalTriggerReason = "external_trigger";
     public const string OneShotTriggerReason = "one_shot";
     public const string OneShotSkillName = "one-shot-reminder";
@@ -30,8 +31,10 @@ public static class SkillRunnerDefaults
     public const int MaxRetryAttempts = 1;
     public const int ExternalTriggerMaxDispatchAttempts = 3;
     public const int ExternalTriggerTerminalDeliveryRetention = 1000;
+    public const int CronOccurrenceTerminalRetention = 1000;
     public static readonly TimeSpan RetryBackoff = TimeSpan.FromSeconds(30);
     public static readonly TimeSpan ExternalTriggerTerminalDeliveryRetentionAge = TimeSpan.FromDays(30);
+    public static readonly TimeSpan CronOccurrenceTerminalRetentionAge = TimeSpan.FromDays(30);
 
     /// <summary>
     /// Throttle for streaming-edit (Lark <c>PUT /open-apis/im/v1/messages/{id}</c>) deltas.

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
@@ -17,6 +17,7 @@ using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.GAgents.Platform.Lark;
+using Aevatar.GAgentService.Abstractions.Schedules;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
@@ -255,6 +256,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             .On<SkillRunnerExternalTriggerDispatchRequestedEvent>(ApplyExternalTriggerDispatchRequested)
             .On<SkillRunnerExternalTriggerRejectedEvent>(ApplyExternalTriggerRejected)
             .On<SkillRunnerExternalTriggerDuplicateIgnoredEvent>(ApplyExternalTriggerDuplicateIgnored)
+            .On<SkillRunnerCronOccurrenceDuplicateIgnoredEvent>(ApplyCronOccurrenceDuplicateIgnored)
             .On<SkillRunnerDisabledEvent>(ApplyDisabled)
             .On<SkillRunnerEnabledEvent>(ApplyEnabled)
             .OrCurrent();
@@ -393,6 +395,17 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
     [EventHandler(AllowSelfHandling = true)]
     public async Task HandleTriggerAsync(TriggerSkillRunnerExecutionCommand command)
     {
+        var cronOccurrenceKey = ResolveCronOccurrenceKey(command);
+        if (ShouldSkipCronOccurrence(command, cronOccurrenceKey))
+        {
+            await PersistDomainEventAsync(new SkillRunnerCronOccurrenceDuplicateIgnoredEvent
+            {
+                CronOccurrenceKey = cronOccurrenceKey,
+                IgnoredAt = Timestamp.FromDateTimeOffset(_clock.UtcNow),
+            });
+            return;
+        }
+
         var externalIdentity = NormalizeExternalTriggerIdentity(command.ExternalTriggerIdentity, _clock.UtcNow);
         var hasExternalTrigger = IsValidExternalTriggerIdentity(externalIdentity);
         if (hasExternalTrigger && State.IsExternalTriggerTerminal(externalIdentity))
@@ -414,6 +427,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
                 RejectedAt = Timestamp.FromDateTimeOffset(_clock.UtcNow),
                 Reason = SkillRunnerDefaults.RejectionReasonRunnerDisabled,
                 ExternalTriggerIdentity = hasExternalTrigger ? externalIdentity : null,
+                CronOccurrenceKey = cronOccurrenceKey,
             });
             if (State.ScheduleMode == SkillRunnerScheduleMode.OneShot && !hasExternalTrigger)
                 await RetireOneShotAsync(_clock.UtcNow, SkillRunnerDefaults.OneShotRetirementReasonRejected, CancellationToken.None);
@@ -443,6 +457,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
                 WorkflowCommandId = result.WorkflowReceipt?.CommandId ?? string.Empty,
                 WorkflowCorrelationId = result.WorkflowReceipt?.CorrelationId ?? string.Empty,
                 ExternalTriggerIdentity = hasExternalTrigger ? externalIdentity : null,
+                CronOccurrenceKey = cronOccurrenceKey,
             });
 
             await CancelRetryLeaseAsync(CancellationToken.None);
@@ -483,6 +498,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
                 WorkflowId = executionFailure?.WorkflowId ?? string.Empty,
                 ErrorCode = executionFailure?.ErrorCode ?? SkillRunnerExecutionErrorCode.Unspecified,
                 ExternalTriggerIdentity = hasExternalTrigger ? externalIdentity : null,
+                CronOccurrenceKey = cronOccurrenceKey,
             });
 
             await TrySendFailureAsync(ex.Message, CancellationToken.None);
@@ -512,14 +528,68 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         await CancelRetryLeaseAsync(ct);
         var retryCommand = command.Clone();
         retryCommand.RetryAttempt = retryAttempt;
+        var cronOccurrenceKey = ResolveCronOccurrenceKey(command);
+        var options = string.IsNullOrWhiteSpace(cronOccurrenceKey)
+            ? null
+            : CreateCronOccurrencePropagationOptions(cronOccurrenceKey);
         _retryLease = await ScheduleSelfDurableTimeoutAsync(
             SkillRunnerDefaults.RetryCallbackId,
             SkillRunnerDefaults.RetryBackoff,
             retryCommand,
+            options,
             ct: ct);
         Logger.LogInformation(
             "Skill runner {ActorId} scheduled retry attempt {Attempt} in {Backoff}",
             Id, retryAttempt, SkillRunnerDefaults.RetryBackoff);
+    }
+
+    private bool ShouldSkipCronOccurrence(
+        TriggerSkillRunnerExecutionCommand command,
+        string cronOccurrenceKey) =>
+        command.RetryAttempt == 0 &&
+        !string.IsNullOrWhiteSpace(cronOccurrenceKey) &&
+        State.IsCronOccurrenceTerminal(cronOccurrenceKey);
+
+    private string ResolveCronOccurrenceKey(TriggerSkillRunnerExecutionCommand command)
+    {
+        if (!IsCronScheduleTrigger(command))
+            return string.Empty;
+
+        if (TryReadCronOccurrenceKeyFromBaggage(out var baggageKey))
+            return baggageKey;
+
+        return ActiveInboundEnvelope?.Id?.Trim() ?? string.Empty;
+    }
+
+    private bool TryReadCronOccurrenceKeyFromBaggage(out string cronOccurrenceKey)
+    {
+        cronOccurrenceKey = string.Empty;
+        if (ActiveInboundEnvelope?.Propagation?.Baggage is null)
+            return false;
+
+        if (!ActiveInboundEnvelope.Propagation.Baggage.TryGetValue(
+                ScheduledDispatchMetadataKeys.IdempotencyKey,
+                out var value))
+        {
+            return false;
+        }
+
+        cronOccurrenceKey = value?.Trim() ?? string.Empty;
+        return !string.IsNullOrEmpty(cronOccurrenceKey);
+    }
+
+    private static bool IsCronScheduleTrigger(TriggerSkillRunnerExecutionCommand command) =>
+        string.Equals(command.Reason?.Trim(), SkillRunnerDefaults.ScheduleTriggerReason, StringComparison.Ordinal) &&
+        !IsValidExternalTriggerIdentity(command.ExternalTriggerIdentity);
+
+    private static EventEnvelopePublishOptions CreateCronOccurrencePropagationOptions(string cronOccurrenceKey)
+    {
+        var options = new EventEnvelopePublishOptions
+        {
+            Propagation = new EventEnvelopePropagationOverrides(),
+        };
+        options.Propagation.Baggage[ScheduledDispatchMetadataKeys.IdempotencyKey] = cronOccurrenceKey.Trim();
+        return options;
     }
 
     private async Task CancelRetryLeaseAsync(CancellationToken ct)
@@ -1966,6 +2036,10 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             next.TrimExternalTriggerDeliveries(ToDateTimeOffset(evt.CompletedAt));
         }
 
+        MarkCronOccurrenceTerminal(
+            next,
+            evt.CronOccurrenceKey,
+            evt.CompletedAt ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow));
         return next;
     }
 
@@ -1995,6 +2069,10 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             next.TrimExternalTriggerDeliveries(ToDateTimeOffset(evt.FailedAt));
         }
 
+        MarkCronOccurrenceTerminal(
+            next,
+            evt.CronOccurrenceKey,
+            evt.FailedAt ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow));
         return next;
     }
 
@@ -2014,6 +2092,10 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             next.TrimExternalTriggerDeliveries(ToDateTimeOffset(evt.RejectedAt));
         }
 
+        MarkCronOccurrenceTerminal(
+            next,
+            evt.CronOccurrenceKey,
+            evt.RejectedAt ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow));
         return next;
     }
 
@@ -2087,6 +2169,30 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         }
 
         return next;
+    }
+
+    private static SkillRunnerState ApplyCronOccurrenceDuplicateIgnored(
+        SkillRunnerState current,
+        SkillRunnerCronOccurrenceDuplicateIgnoredEvent evt)
+    {
+        var next = current.Clone();
+        MarkCronOccurrenceTerminal(
+            next,
+            evt.CronOccurrenceKey,
+            evt.IgnoredAt ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow));
+        return next;
+    }
+
+    private static void MarkCronOccurrenceTerminal(
+        SkillRunnerState state,
+        string? cronOccurrenceKey,
+        Timestamp terminalAt)
+    {
+        if (string.IsNullOrWhiteSpace(cronOccurrenceKey))
+            return;
+
+        state.UpsertCronOccurrenceTerminal(cronOccurrenceKey, terminalAt);
+        state.TrimCronOccurrenceTerminals(ToDateTimeOffset(terminalAt));
     }
 
     private static SkillRunnerState ApplyDisabled(SkillRunnerState current, SkillRunnerDisabledEvent _)

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerState.Partial.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerState.Partial.cs
@@ -33,6 +33,17 @@ public sealed partial class SkillRunnerState
         return record is not null && IsTerminalExternalTriggerStatus(record.Status);
     }
 
+    public bool IsCronOccurrenceTerminal(string? cronOccurrenceKey)
+    {
+        var normalized = NormalizeCronOccurrenceKey(cronOccurrenceKey);
+        return !string.IsNullOrEmpty(normalized) &&
+               RecentCronOccurrenceTerminals.Any(record =>
+                   string.Equals(
+                       NormalizeCronOccurrenceKey(record.CronOccurrenceKey),
+                       normalized,
+                       StringComparison.Ordinal));
+    }
+
     public IReadOnlyList<SkillRunnerExternalTriggerDeliveryRecord> RecoverableExternalTriggerDeliveries() =>
         RecentExternalTriggerDeliveries
             .Where(static record => record.Identity is not null)
@@ -98,6 +109,50 @@ public sealed partial class SkillRunnerState
         RecentExternalTriggerDeliveries.AddRange(kept);
     }
 
+    internal void UpsertCronOccurrenceTerminal(string? cronOccurrenceKey, Timestamp terminalAt)
+    {
+        ArgumentNullException.ThrowIfNull(terminalAt);
+
+        var normalized = NormalizeCronOccurrenceKey(cronOccurrenceKey);
+        if (string.IsNullOrEmpty(normalized))
+            return;
+
+        var existingIndex = FindCronOccurrenceTerminalIndex(normalized);
+        var next = new SkillRunnerCronOccurrenceTerminalRecord
+        {
+            CronOccurrenceKey = normalized,
+            TerminalAt = terminalAt,
+        };
+
+        if (existingIndex >= 0)
+            RecentCronOccurrenceTerminals[existingIndex] = next;
+        else
+            RecentCronOccurrenceTerminals.Add(next);
+    }
+
+    internal void TrimCronOccurrenceTerminals(DateTimeOffset now)
+    {
+        var cutoff = now - SkillRunnerDefaults.CronOccurrenceTerminalRetentionAge;
+        var keysToRemove = RecentCronOccurrenceTerminals
+            .OrderByDescending(static record => ToDateTimeOffset(record.TerminalAt))
+            .Skip(SkillRunnerDefaults.CronOccurrenceTerminalRetention)
+            .Concat(RecentCronOccurrenceTerminals
+                .Where(record => ToDateTimeOffset(record.TerminalAt) < cutoff))
+            .Select(static record => NormalizeCronOccurrenceKey(record.CronOccurrenceKey))
+            .Where(static key => !string.IsNullOrEmpty(key))
+            .ToHashSet(StringComparer.Ordinal);
+
+        if (keysToRemove.Count == 0)
+            return;
+
+        var kept = RecentCronOccurrenceTerminals
+            .Where(record => !keysToRemove.Contains(NormalizeCronOccurrenceKey(record.CronOccurrenceKey)))
+            .Select(static record => record.Clone())
+            .ToArray();
+        RecentCronOccurrenceTerminals.Clear();
+        RecentCronOccurrenceTerminals.AddRange(kept);
+    }
+
     private int FindExternalTriggerDeliveryIndex(SkillRunnerExternalTriggerIdentity identity)
     {
         for (var i = 0; i < RecentExternalTriggerDeliveries.Count; i++)
@@ -105,6 +160,23 @@ public sealed partial class SkillRunnerState
             var record = RecentExternalTriggerDeliveries[i];
             if (string.Equals(record.Identity?.SourceId?.Trim(), identity.SourceId?.Trim(), StringComparison.Ordinal) &&
                 string.Equals(record.Identity?.DeliveryId?.Trim(), identity.DeliveryId?.Trim(), StringComparison.Ordinal))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private int FindCronOccurrenceTerminalIndex(string normalizedCronOccurrenceKey)
+    {
+        for (var i = 0; i < RecentCronOccurrenceTerminals.Count; i++)
+        {
+            var record = RecentCronOccurrenceTerminals[i];
+            if (string.Equals(
+                    NormalizeCronOccurrenceKey(record.CronOccurrenceKey),
+                    normalizedCronOccurrenceKey,
+                    StringComparison.Ordinal))
             {
                 return i;
             }
@@ -128,4 +200,7 @@ public sealed partial class SkillRunnerState
 
     private static string BuildDeliveryKey(SkillRunnerExternalTriggerIdentity? identity) =>
         $"{identity?.SourceId?.Trim() ?? string.Empty}\n{identity?.DeliveryId?.Trim() ?? string.Empty}";
+
+    private static string NormalizeCronOccurrenceKey(string? cronOccurrenceKey) =>
+        cronOccurrenceKey?.Trim() ?? string.Empty;
 }

--- a/agents/Aevatar.GAgents.Scheduled/protos/skill_runner.proto
+++ b/agents/Aevatar.GAgents.Scheduled/protos/skill_runner.proto
@@ -99,6 +99,11 @@ message SkillRunnerExternalTriggerDeliveryRecord {
   int32 dispatch_attempt = 6;
 }
 
+message SkillRunnerCronOccurrenceTerminalRecord {
+  string cron_occurrence_key = 1;
+  google.protobuf.Timestamp terminal_at = 2;
+}
+
 message SkillRunnerOutboundConfig {
   string conversation_id = 1;
   string nyx_provider_slug = 2;
@@ -173,6 +178,7 @@ message SkillRunnerState {
   google.protobuf.Timestamp retired_at = 27;
   string retirement_reason = 28;
   string one_shot_message = 29;
+  repeated SkillRunnerCronOccurrenceTerminalRecord recent_cron_occurrence_terminals = 30;
 }
 
 message SkillRunnerExecutionDocument {
@@ -282,6 +288,7 @@ message SkillRunnerExecutionCompletedEvent {
   string workflow_command_id = 9;
   string workflow_correlation_id = 10;
   SkillRunnerExternalTriggerIdentity external_trigger_identity = 11;
+  string cron_occurrence_key = 12;
 }
 
 message SkillRunnerExecutionFailedEvent {
@@ -293,12 +300,14 @@ message SkillRunnerExecutionFailedEvent {
   string workflow_id = 6;
   SkillRunnerExecutionErrorCode error_code = 7;
   SkillRunnerExternalTriggerIdentity external_trigger_identity = 8;
+  string cron_occurrence_key = 9;
 }
 
 message SkillRunnerExecutionRejectedEvent {
   google.protobuf.Timestamp rejected_at = 1;
   string reason = 2;
   SkillRunnerExternalTriggerIdentity external_trigger_identity = 3;
+  string cron_occurrence_key = 4;
 }
 
 message SkillRunnerExternalTriggerAdmittedEvent {
@@ -322,6 +331,11 @@ message SkillRunnerExternalTriggerDuplicateIgnoredEvent {
   SkillRunnerExternalTriggerIdentity identity = 1;
   google.protobuf.Timestamp ignored_at = 2;
   string reason = 3;
+}
+
+message SkillRunnerCronOccurrenceDuplicateIgnoredEvent {
+  string cron_occurrence_key = 1;
+  google.protobuf.Timestamp ignored_at = 2;
 }
 
 message DisableSkillRunnerCommand {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -18,6 +18,7 @@ using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.GAgents.Platform.Lark;
 using Aevatar.GAgents.Scheduled;
+using Aevatar.GAgentService.Abstractions.Schedules;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using FluentAssertions;
 using Google.Protobuf;
@@ -433,6 +434,161 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         _agent.State.Enabled.Should().BeFalse();
         _agent.State.LastError.Should().Be(SkillRunnerDefaults.RejectionReasonRunnerDisabled);
         _agent.State.ErrorCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task HandleTriggerAsync_SameCronOccurrenceDeliveredTwice_ShouldExecuteAndSendOnlyOnce()
+    {
+        var provider = new StubStreamingProviderFactory("first output", "second output");
+        var agent = CreateAgent("skill-runner-cron-duplicate", providerFactory: provider);
+        await agent.ActivateAsync();
+        await agent.HandleInitializeAsync(CreateTextOutputInitializeCommand());
+        var handler = new RecordingHandler("""{"code":0,"msg":"success","data":{"message_id":"om_cron"}}""");
+        AttachNyxIdApiClient(agent, handler);
+        var occurrenceKey = "schedule:runner-1:fire:2026-06-16T01:00:00.0000000+00:00";
+
+        await DispatchCronFireAsync(agent, "schedule-envelope-1", occurrenceKey);
+        var outboundRequestsAfterFirstDelivery = handler.Requests.Count;
+
+        await DispatchCronFireAsync(agent, "schedule-envelope-redelivery", occurrenceKey);
+
+        provider.Requests.Should().ContainSingle();
+        handler.Requests.Should().HaveCount(outboundRequestsAfterFirstDelivery);
+        var persisted = await _store.GetEventsAsync("skill-runner-cron-duplicate");
+        persisted.Select(x => x.EventData)
+            .Count(x => x.Is(SkillRunnerExecutionCompletedEvent.Descriptor))
+            .Should()
+            .Be(1);
+        var duplicate = persisted.Select(x => x.EventData)
+            .Where(x => x.Is(SkillRunnerCronOccurrenceDuplicateIgnoredEvent.Descriptor))
+            .Select(x => x.Unpack<SkillRunnerCronOccurrenceDuplicateIgnoredEvent>())
+            .Should()
+            .ContainSingle()
+            .Subject;
+        duplicate.CronOccurrenceKey.Should().Be(occurrenceKey);
+        agent.State.IsCronOccurrenceTerminal(occurrenceKey).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HandleTriggerAsync_CronOccurrenceWithoutBaggage_ShouldUseEnvelopeIdForRedeliveryDedup()
+    {
+        var provider = new StubStreamingProviderFactory("first output", "second output");
+        var agent = CreateAgent("skill-runner-cron-envelope-id", providerFactory: provider);
+        await agent.ActivateAsync();
+        await agent.HandleInitializeAsync(CreateTextOutputInitializeCommand());
+        AttachNyxIdApiClient(agent, new RecordingHandler("""{"code":0,"msg":"success","data":{"message_id":"om_cron"}}"""));
+        var envelopeId = "schedule:runner-1:fire:2026-06-16T02:00:00.0000000+00:00";
+
+        await DispatchCronFireAsync(agent, envelopeId, cronOccurrenceKey: null);
+        await DispatchCronFireAsync(agent, envelopeId, cronOccurrenceKey: null);
+
+        provider.Requests.Should().ContainSingle();
+        var completed = await ReadSingleCompletedEventAsync(_store, "skill-runner-cron-envelope-id");
+        completed.CronOccurrenceKey.Should().Be(envelopeId);
+        agent.State.IsCronOccurrenceTerminal(envelopeId).Should().BeTrue();
+        var persisted = await _store.GetEventsAsync("skill-runner-cron-envelope-id");
+        persisted.Select(x => x.EventData)
+            .Count(x => x.Is(SkillRunnerCronOccurrenceDuplicateIgnoredEvent.Descriptor))
+            .Should()
+            .Be(1);
+    }
+
+    [Fact]
+    public async Task HandleTriggerAsync_CronRetryAttempt_ShouldBypassDuplicateSkipAndUseSameOccurrenceKey()
+    {
+        var scheduler = new RecordingCallbackScheduler();
+        var provider = new StubStreamingProviderFactory(
+            new StubStreamingTurn(new InvalidOperationException("transient")),
+            new StubStreamingTurn(["retry output"]));
+        using var serviceProvider = BuildServiceProvider(
+            new InMemoryEventStore(),
+            services => services.AddSingleton<IActorRuntimeCallbackScheduler>(scheduler));
+        var agent = CreateAgent(
+            "skill-runner-cron-retry",
+            serviceProvider,
+            providerFactory: provider);
+        await agent.ActivateAsync();
+        await agent.HandleInitializeAsync(CreateTextOutputInitializeCommand());
+        AttachNyxIdApiClient(agent, new RecordingHandler("""{"code":0,"msg":"success","data":{"message_id":"om_retry"}}"""));
+        var occurrenceKey = "schedule:runner-1:fire:2026-06-16T03:00:00.0000000+00:00";
+
+        await DispatchCronFireAsync(agent, "first-attempt-envelope", occurrenceKey);
+
+        scheduler.Timeouts.Should().ContainSingle();
+        var retryEnvelope = scheduler.Timeouts[0].TriggerEnvelope;
+        retryEnvelope.Propagation.Baggage[ScheduledDispatchMetadataKeys.IdempotencyKey].Should().Be(occurrenceKey);
+
+        await agent.HandleEventAsync(retryEnvelope);
+
+        provider.Requests.Should().HaveCount(2);
+        var store = serviceProvider.GetRequiredService<IEventStore>() as InMemoryEventStore
+            ?? throw new InvalidOperationException("test store missing");
+        var completed = await ReadSingleCompletedEventAsync(store, "skill-runner-cron-retry");
+        completed.CronOccurrenceKey.Should().Be(occurrenceKey);
+        agent.State.IsCronOccurrenceTerminal(occurrenceKey).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HandleTriggerAsync_ExternalTriggerWithScheduleReason_ShouldNotUseCronOccurrenceDedup()
+    {
+        var provider = new StubStreamingProviderFactory("external output");
+        var agent = CreateAgent("skill-runner-external-schedule-reason", providerFactory: provider);
+        await agent.ActivateAsync();
+        var initialize = CreateInitializeCommandWithExternalSource();
+        initialize.OutputFormat = SkillRunnerOutputFormat.Text;
+        initialize.OutboundConfig.OutputFormat = SkillRunnerOutputFormat.Text;
+        await agent.HandleInitializeAsync(initialize);
+        AttachNyxIdApiClient(agent, new RecordingHandler("""{"code":0,"msg":"success","data":{"message_id":"om_external"}}"""));
+        var identity = CreateExternalIdentity("delivery-schedule-reason");
+        await agent.HandleAdmitExternalTriggerAsync(new AdmitSkillRunnerExternalTriggerCommand { Identity = identity });
+
+        await DispatchCronFireAsync(
+            agent,
+            "schedule-envelope-external",
+            "schedule:runner-1:fire:2026-06-16T04:00:00.0000000+00:00",
+            new TriggerSkillRunnerExecutionCommand
+            {
+                Reason = SkillRunnerDefaults.ScheduleTriggerReason,
+                ExternalTriggerIdentity = identity.Clone(),
+            });
+
+        provider.Requests.Should().ContainSingle();
+        var completed = await ReadSingleCompletedEventAsync(_store, "skill-runner-external-schedule-reason");
+        completed.ExternalTriggerIdentity.DeliveryId.Should().Be(identity.DeliveryId);
+        completed.CronOccurrenceKey.Should().BeEmpty();
+        agent.State.RecentCronOccurrenceTerminals.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleTriggerAsync_OneShotReminder_ShouldNotUseCronOccurrenceDedup()
+    {
+        using var provider = BuildServiceProvider(
+            new InMemoryEventStore(),
+            services =>
+            {
+                services.AddSingleton<IActorRuntimeCallbackScheduler>(new RecordingCallbackScheduler());
+            });
+        var agent = CreateAgent("skill-runner-one-shot-not-cron", provider);
+        await agent.ActivateAsync();
+        AttachNyxIdApiClient(agent, new RecordingHandler("""{"code":0,"msg":"success","data":{"message_id":"om_one_shot"}}"""));
+        await agent.HandleInitializeAsync(CreateOneShotInitializeCommand(DateTimeOffset.UtcNow.AddMinutes(30)));
+
+        await DispatchCronFireAsync(
+            agent,
+            "one-shot-envelope",
+            "schedule:runner-1:fire:2026-06-16T05:00:00.0000000+00:00",
+            new TriggerSkillRunnerExecutionCommand
+            {
+                Reason = SkillRunnerDefaults.OneShotTriggerReason,
+            });
+
+        var completed = await ReadSingleCompletedEventAsync(
+            provider.GetRequiredService<IEventStore>() as InMemoryEventStore
+            ?? throw new InvalidOperationException("test store missing"),
+            "skill-runner-one-shot-not-cron");
+        completed.CronOccurrenceKey.Should().BeEmpty();
+        agent.State.RecentCronOccurrenceTerminals.Should().BeEmpty();
+        agent.State.RetiredAt.Should().NotBeNull();
     }
 
     [Fact]
@@ -870,6 +1026,83 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         var nonTerminal = state.FindExternalTriggerDelivery(oldNonTerminal);
         nonTerminal.Should().NotBeNull();
         nonTerminal!.Status.Should().Be(SkillRunnerExternalTriggerDeliveryStatus.DispatchRequested);
+    }
+
+    [Fact]
+    public void TrimCronOccurrenceTerminals_ShouldTrimByCountAndAge()
+    {
+        var state = new SkillRunnerState();
+        var now = new DateTimeOffset(2026, 6, 16, 8, 0, 0, TimeSpan.Zero);
+
+        for (var i = 0; i <= SkillRunnerDefaults.CronOccurrenceTerminalRetention; i++)
+        {
+            state.UpsertCronOccurrenceTerminal(
+                $"schedule:runner-1:fire:recent-{i:0000}",
+                Timestamp.FromDateTimeOffset(now - TimeSpan.FromMinutes(i)));
+        }
+
+        var oldKey = "schedule:runner-1:fire:old";
+        state.UpsertCronOccurrenceTerminal(
+            oldKey,
+            Timestamp.FromDateTimeOffset(now - SkillRunnerDefaults.CronOccurrenceTerminalRetentionAge - TimeSpan.FromDays(1)));
+
+        state.TrimCronOccurrenceTerminals(now);
+
+        state.RecentCronOccurrenceTerminals.Should().HaveCount(SkillRunnerDefaults.CronOccurrenceTerminalRetention);
+        state.IsCronOccurrenceTerminal(oldKey).Should().BeFalse();
+        state.IsCronOccurrenceTerminal("schedule:runner-1:fire:recent-1000").Should().BeFalse();
+        state.IsCronOccurrenceTerminal("schedule:runner-1:fire:recent-0000").Should().BeTrue();
+    }
+
+    [Fact]
+    public void SkillRunnerCronOccurrenceProtoContract_ShouldUseAppendOnlyFieldNumbersAndRoundTrip()
+    {
+        SkillRunnerState.Descriptor.FindFieldByName("recent_cron_occurrence_terminals")!.FieldNumber
+            .Should()
+            .Be(30);
+        SkillRunnerExecutionCompletedEvent.Descriptor.FindFieldByName("cron_occurrence_key")!.FieldNumber
+            .Should()
+            .Be(12);
+        SkillRunnerExecutionFailedEvent.Descriptor.FindFieldByName("cron_occurrence_key")!.FieldNumber
+            .Should()
+            .Be(9);
+        SkillRunnerExecutionRejectedEvent.Descriptor.FindFieldByName("cron_occurrence_key")!.FieldNumber
+            .Should()
+            .Be(4);
+        SkillRunnerCronOccurrenceDuplicateIgnoredEvent.Descriptor.FindFieldByName("cron_occurrence_key")!.FieldNumber
+            .Should()
+            .Be(1);
+        SkillRunnerCronOccurrenceDuplicateIgnoredEvent.Descriptor.FindFieldByName("ignored_at")!.FieldNumber
+            .Should()
+            .Be(2);
+
+        var state = new SkillRunnerState();
+        state.RecentCronOccurrenceTerminals.Add(new SkillRunnerCronOccurrenceTerminalRecord
+        {
+            CronOccurrenceKey = "schedule:runner-1:fire:2026-06-16T06:00:00.0000000+00:00",
+            TerminalAt = Timestamp.FromDateTimeOffset(new DateTimeOffset(2026, 6, 16, 6, 0, 0, TimeSpan.Zero)),
+        });
+
+        var parsedState = SkillRunnerState.Parser.ParseFrom(state.ToByteArray());
+        parsedState.RecentCronOccurrenceTerminals.Should().ContainSingle()
+            .Which.CronOccurrenceKey.Should().Be(state.RecentCronOccurrenceTerminals[0].CronOccurrenceKey);
+
+        var completed = new SkillRunnerExecutionCompletedEvent
+        {
+            CompletedAt = Timestamp.FromDateTimeOffset(new DateTimeOffset(2026, 6, 16, 6, 1, 0, TimeSpan.Zero)),
+            Output = "done",
+            CronOccurrenceKey = state.RecentCronOccurrenceTerminals[0].CronOccurrenceKey,
+        };
+        SkillRunnerExecutionCompletedEvent.Parser.ParseFrom(completed.ToByteArray())
+            .CronOccurrenceKey.Should().Be(completed.CronOccurrenceKey);
+
+        var duplicate = new SkillRunnerCronOccurrenceDuplicateIgnoredEvent
+        {
+            CronOccurrenceKey = completed.CronOccurrenceKey,
+            IgnoredAt = Timestamp.FromDateTimeOffset(new DateTimeOffset(2026, 6, 16, 6, 2, 0, TimeSpan.Zero)),
+        };
+        SkillRunnerCronOccurrenceDuplicateIgnoredEvent.Parser.ParseFrom(duplicate.ToByteArray())
+            .CronOccurrenceKey.Should().Be(duplicate.CronOccurrenceKey);
     }
 
     [Fact]
@@ -2493,6 +2726,30 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
                evt.Unpack<SkillRunnerExecutionRejectedEvent>().ExternalTriggerIdentity is not null;
     }
 
+    private static Task DispatchCronFireAsync(
+        SkillRunnerGAgent agent,
+        string envelopeId,
+        string? cronOccurrenceKey,
+        TriggerSkillRunnerExecutionCommand? command = null)
+    {
+        var envelope = new EventEnvelope
+        {
+            Id = envelopeId,
+            Timestamp = Timestamp.FromDateTimeOffset(new DateTimeOffset(2026, 6, 16, 0, 0, 0, TimeSpan.Zero)),
+            Payload = Any.Pack(command ?? new TriggerSkillRunnerExecutionCommand
+            {
+                Reason = SkillRunnerDefaults.ScheduleTriggerReason,
+            }),
+            Route = EnvelopeRouteSemantics.CreateDirect("scheduled-dispatch:test", agent.Id),
+            Propagation = new EnvelopePropagation(),
+        };
+
+        if (!string.IsNullOrWhiteSpace(cronOccurrenceKey))
+            envelope.Propagation.Baggage[ScheduledDispatchMetadataKeys.IdempotencyKey] = cronOccurrenceKey.Trim();
+
+        return agent.HandleEventAsync(envelope);
+    }
+
     private sealed record SkillRunnerExecutionResultSnapshot(
         string Output,
         SkillRunnerExecutionKind ExecutionKind,
@@ -2641,15 +2898,17 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
 
     private sealed class RecordingHandler(string responseBody) : HttpMessageHandler
     {
-        public HttpRequestMessage? LastRequest { get; private set; }
-        public string? LastBody { get; private set; }
+        public List<HttpRequestMessage> Requests { get; } = [];
+        public List<string?> Bodies { get; } = [];
+        public HttpRequestMessage? LastRequest => Requests.LastOrDefault();
+        public string? LastBody => Bodies.LastOrDefault();
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            LastRequest = request;
-            LastBody = request.Content == null
+            Requests.Add(request);
+            Bodies.Add(request.Content == null
                 ? null
-                : await request.Content.ReadAsStringAsync(cancellationToken);
+                : await request.Content.ReadAsStringAsync(cancellationToken));
             return new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
@@ -2797,6 +3056,7 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         var services = new ServiceCollection();
         services.AddSingleton(eventStore);
         services.AddSingleton<EventSourcingRuntimeOptions>();
+        services.AddSingleton<IActorRuntimeCallbackScheduler>(new RecordingCallbackScheduler());
         services.AddTransient(
             typeof(IEventSourcingBehaviorFactory<>),
             typeof(DefaultEventSourcingBehaviorFactory<>));
@@ -2822,6 +3082,14 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
             NyxApiKey = "nyx-api-key",
         },
     };
+
+    private static InitializeSkillRunnerCommand CreateTextOutputInitializeCommand()
+    {
+        var command = CreateInitializeCommand();
+        command.OutputFormat = SkillRunnerOutputFormat.Text;
+        command.OutboundConfig.OutputFormat = SkillRunnerOutputFormat.Text;
+        return command;
+    }
 
     private static InitializeSkillRunnerCommand CreateOneShotInitializeCommand(DateTimeOffset runAtUtc) => new()
     {


### PR DESCRIPTION
## Summary / 摘要

修复 #2183：cron 模式 SkillRunner 消费侧零幂等。生产实测 pod 重启后未 ack 的 cron-fire envelope 被至少一次重投到 `HandleTriggerAsync`，无条件重跑 ornn skill 并重复推 Lark 卡。

- **Old**：cron fire 到 `HandleTriggerAsync` 无条件执行，仅 external-trigger 有终态去重；`SkillRunnerState` 无 cron occurrence 记录。
- **New**：actor-owned 有界 occurrence terminal set 做消费侧幂等。occurrence key 优先读 `Propagation.Baggage[IdempotencyKey]` → fallback inbound envelope `Id`（= `schedule:{id}:fire:{ts}`）；命中已终态 → 仅持久化 `SkillRunnerCronOccurrenceDuplicateIgnoredEvent` 并 return；成功/终态失败/disabled-rejected 写 `cron_occurrence_key` 标记 terminal；`RetryAttempt>0` 自调度重试绕过去重；保留最近 1000 条 + 删 30 天前记录。

## Scope / 范围

5 files：`protos/skill_runner.proto`（新增 `SkillRunnerCronOccurrenceTerminalRecord` + `recent_cron_occurrence_terminals` + `SkillRunnerCronOccurrenceDuplicateIgnoredEvent` + 终态事件加 `cron_occurrence_key`）、`SkillRunnerDefaults.cs`（bounded-retention 常量）、`SkillRunnerState.Partial.cs`（occurrence lookup/upsert/trim 助手）、`SkillRunnerGAgent.cs`（cron dedup 分支 + reducer）、`SkillRunnerGAgentTests.cs`（重复/envelope-id fallback/retry 绕过/one-shot+external 不回归/bounded trim/proto round-trip）。

不改 `TriggerSkillRunnerExecutionCommand` 契约；不重建 dispatch-side cron lease/next-fire/fire-records（遵循 #2035 决策）。dispatch-side「FireDispatched 终态先于副作用」顺序问题为单独 issue，本 PR 不含。

## 验证

- `dotnet build aevatar.slnx --nologo`：0 error（controller publish gate 复核）。
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests`：1340 passed / 0 failed / 0 skipped。
- `tools/ci/test_stability_guards.sh` + `architecture_guards.sh`：pass。

## Consensus

design-consensus r1 → `consensus:structural`（Idempotent Consumer pattern）。consensus-loop scoped run（milestone 26 / eanzhao）。

Closes #2183

🤖 consensus-loop

⟦AI:AUTO-LOOP⟧
