### PR TITLE
feat(ornn): ornn 写工具以 sender NyxID 身份执行 + 诚实权限错误 #2174

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
@@ -755,11 +755,13 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
 
     private IReadOnlyList<IToolCallMiddleware> BuildToolMiddlewaresForTurn()
     {
-        var effective = new List<IToolCallMiddleware>(_toolMiddlewares.Count + 1)
+        var effective = new List<IToolCallMiddleware>(_toolMiddlewares.Count + 2)
         {
+            new ToolCallCredentialPolicyMiddleware(),
             new ToolApprovalMiddleware(_approvalHandler ?? MissingApprovalHandler.Instance),
         };
-        effective.AddRange(_toolMiddlewares.Where(static middleware => middleware is not ToolApprovalMiddleware));
+        effective.AddRange(_toolMiddlewares.Where(static middleware =>
+            middleware is not ToolApprovalMiddleware and not ToolCallCredentialPolicyMiddleware));
         return effective;
     }
 
@@ -839,6 +841,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
             ownerFallbackControl = effectiveControl with { SenderNyxIdAccessToken = null };
             ownerFallbackToolContext = ClearSenderBinding(effectiveToolContext);
             ownerFallback = ownerSnapshot;
+            var senderToken = llmControl?.SenderNyxIdAccessToken?.Trim();
 
             if (_preferencesStore is not null)
             {
@@ -855,27 +858,12 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
                     string.IsNullOrWhiteSpace(effectiveControl.ModelOverride) ? "<server-default>" : effectiveControl.ModelOverride,
                     string.IsNullOrWhiteSpace(effectiveControl.NyxIdRoutePreference) ? "<server-default>" : effectiveControl.NyxIdRoutePreference,
                     effectiveControl.MaxToolRoundsOverride);
-                if (applied.RouteApplied)
+                if (applied.RouteApplied && string.IsNullOrWhiteSpace(senderToken))
                 {
-                    if (!string.IsNullOrWhiteSpace(llmControl?.SenderNyxIdAccessToken))
+                    effectiveControl = effectiveControl with
                     {
-                        var trimmedToken = llmControl.SenderNyxIdAccessToken.Trim();
-                        effectiveControl = effectiveControl with
-                        {
-                            NyxIdAccessToken = trimmedToken,
-                            NyxIdOrgToken = trimmedToken,
-                            SenderNyxIdAccessToken = trimmedToken,
-                        };
-                    }
-                    else
-                    {
-                        effective = ownerSnapshot;
-                        effectiveControl = ownerFallbackControl;
-                        effectiveToolContext = ownerFallbackToolContext;
-                        ownerFallback = null;
-                        ownerFallbackControl = null;
-                        ownerFallbackToolContext = null;
-                    }
+                        NyxIdRoutePreference = ownerFallbackControl?.NyxIdRoutePreference,
+                    };
                 }
             }
             else
@@ -883,6 +871,16 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
                 _logger.LogWarning(
                     "Sender binding is present but LLM preferences store is unavailable; using bot owner/default LLM config: bindingId={BindingId}",
                     senderBindingId);
+            }
+
+            if (!string.IsNullOrWhiteSpace(senderToken))
+            {
+                effectiveControl = effectiveControl with
+                {
+                    NyxIdAccessToken = senderToken,
+                    NyxIdOrgToken = senderToken,
+                    SenderNyxIdAccessToken = senderToken,
+                };
             }
         }
 
@@ -905,9 +903,9 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
             {
                 throw;
             }
-            catch
+            catch (Exception ex)
             {
-                // User memory is best-effort context and must not break the main reply path.
+                _logger.LogWarning(ex, "User memory prompt context is unavailable; continuing reply generation without user memory.");
             }
         }
 

--- a/src/Aevatar.AI.Core/Middleware/ToolCallCredentialPolicyMiddleware.cs
+++ b/src/Aevatar.AI.Core/Middleware/ToolCallCredentialPolicyMiddleware.cs
@@ -1,0 +1,69 @@
+using System.Text.Json;
+using Aevatar.AI.Abstractions.Middleware;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.Tools;
+
+namespace Aevatar.AI.Core.Middleware;
+
+public sealed class ToolCallCredentialPolicyMiddleware : IToolCallMiddleware
+{
+    private const string ErrorCode = "credential_denied";
+
+    public async Task InvokeAsync(ToolCallContext context, Func<Task> next)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(next);
+
+        var current = AgentToolRequestContext.Current;
+        var senderBindingId = current?.SenderBinding.BindingId?.Trim();
+        if (string.IsNullOrWhiteSpace(senderBindingId))
+        {
+            await next();
+            return;
+        }
+
+        var senderToken = current?.Credentials.SenderNyxIdAccessToken?.Trim();
+        if (!string.IsNullOrWhiteSpace(senderToken))
+        {
+            var senderContext = current! with
+            {
+                Credentials = current.Credentials with
+                {
+                    NyxIdAccessToken = senderToken,
+                    NyxIdOrgToken = senderToken,
+                    SenderNyxIdAccessToken = senderToken,
+                },
+            };
+
+            using var _ = AgentToolContextScope.Push(senderContext);
+            await next();
+            return;
+        }
+
+        if (!AgentToolCredentialPolicy.IsMutation(context.Tool, context.ArgumentsJson))
+        {
+            await next();
+            return;
+        }
+
+        var message = $"Tool '{context.ToolName}' was not executed because sender binding '{senderBindingId}' has no sender NyxID token. Owner credentials were not used.";
+        context.Terminate = true;
+        context.TerminationKind = ToolCallTerminationKind.MiddlewareTerminated;
+        context.TerminationReason = message;
+        context.Result = JsonSerializer.Serialize(new
+        {
+            error = ErrorCode,
+            code = ErrorCode,
+            message,
+            tool_name = context.ToolName,
+            sender_binding_id = senderBindingId,
+        });
+        context.Receipt = AgentToolReceiptFactory.CreateError(
+            context.Tool,
+            context.ToolCallId,
+            context.ToolName,
+            context.Result,
+            ErrorCode,
+            message);
+    }
+}

--- a/src/Aevatar.AI.Core/Middleware/ToolCallMiddlewareChainFactory.cs
+++ b/src/Aevatar.AI.Core/Middleware/ToolCallMiddlewareChainFactory.cs
@@ -22,11 +22,12 @@ public static class ToolCallMiddlewareChainFactory
         AgentHookPipeline? hooks)
     {
         var effectiveToolMiddlewares = new List<IToolCallMiddleware>();
+        effectiveToolMiddlewares.Add(new ToolCallCredentialPolicyMiddleware());
         effectiveToolMiddlewares.Add(new ToolApprovalMiddleware(
             approvalHandler ?? MissingApprovalHandler.Instance,
             hooks));
         effectiveToolMiddlewares.AddRange(toolMiddlewares.Where(static middleware =>
-            middleware is not ToolApprovalMiddleware));
+            middleware is not ToolApprovalMiddleware and not ToolCallCredentialPolicyMiddleware));
         return effectiveToolMiddlewares;
     }
 }

--- a/src/Aevatar.AI.Core/Tools/AgentToolCredentialPolicy.cs
+++ b/src/Aevatar.AI.Core/Tools/AgentToolCredentialPolicy.cs
@@ -1,0 +1,16 @@
+using Aevatar.AI.Abstractions.ToolProviders;
+
+namespace Aevatar.AI.Core.Tools;
+
+internal static class AgentToolCredentialPolicy
+{
+    public static bool IsMutation(IAgentTool tool, string argumentsJson)
+    {
+        ArgumentNullException.ThrowIfNull(tool);
+
+        return !tool.IsReadOnly ||
+               tool.IsDestructive ||
+               !string.IsNullOrWhiteSpace(tool.SideEffectKind) ||
+               tool.RequiresApproval(argumentsJson) == true;
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
@@ -262,6 +262,7 @@ public sealed class OrnnSkillClient
                          statusProp.ValueKind == JsonValueKind.Number
                 ? statusProp.GetInt32()
                 : 0;
+            var upstreamDetail = TryExtractUpstreamOrnnReason(root);
 
             // 404 here means NyxID could not resolve `_options.NyxIdSlug` to an upstream: either
             // the user has not bound an Ornn service to this slug, or the deployment's NyxID
@@ -270,9 +271,8 @@ public sealed class OrnnSkillClient
             // of a bare "status=404".
             var detail = status switch
             {
-                403 => $"Ornn skill API access denied through NyxID proxy slug '{_options.NyxIdSlug}'. " +
-                       "The API key is missing proxy scope or service authorization for the Ornn UserService. " +
-                       "Reconnect the Ornn service in NyxID and recreate or rotate the scheduled agent key.",
+                403 when !string.IsNullOrWhiteSpace(upstreamDetail) => upstreamDetail,
+                403 => BuildProxyScopeAccessDeniedDetail(),
                 404 => $"Ornn skill API not reachable: NyxID has no service bound to slug '{_options.NyxIdSlug}'. " +
                        "The user may need to connect their Ornn account via NyxID (nyxid_services action=create), " +
                        "or the deployment may need to override Aevatar:Ornn:NyxIdSlug.",
@@ -286,6 +286,54 @@ public sealed class OrnnSkillClient
             return false;
         }
     }
+
+    private string BuildProxyScopeAccessDeniedDetail() =>
+        $"Ornn skill API access denied through NyxID proxy slug '{_options.NyxIdSlug}'. " +
+        "The API key is missing proxy scope or service authorization for the Ornn UserService. " +
+        "Reconnect the Ornn service in NyxID and recreate or rotate the scheduled agent key.";
+
+    private static string? TryExtractUpstreamOrnnReason(JsonElement root)
+    {
+        var body = root.TryGetProperty("body", out var bodyProp) && bodyProp.ValueKind == JsonValueKind.String
+            ? bodyProp.GetString()
+            : null;
+        if (string.IsNullOrWhiteSpace(body))
+            return null;
+
+        var trimmed = body.Trim();
+        if (!trimmed.StartsWith('{'))
+            return trimmed;
+
+        try
+        {
+            using var bodyDocument = JsonDocument.Parse(trimmed);
+            var bodyRoot = bodyDocument.RootElement;
+            if (bodyRoot.ValueKind != JsonValueKind.Object)
+                return trimmed;
+
+            if (bodyRoot.TryGetProperty("error", out var errorProp) &&
+                errorProp.ValueKind == JsonValueKind.Object)
+            {
+                var code = TryReadString(errorProp, "code");
+                var message = TryReadString(errorProp, "message");
+                if (!string.IsNullOrWhiteSpace(message))
+                    return string.IsNullOrWhiteSpace(code) ? message : $"{code}: {message}";
+            }
+
+            return TryReadString(bodyRoot, "message") ??
+                   TryReadString(bodyRoot, "detail");
+        }
+        catch (JsonException)
+        {
+            return trimmed;
+        }
+    }
+
+    private static string? TryReadString(JsonElement root, string propertyName) =>
+        root.TryGetProperty(propertyName, out var prop) && prop.ValueKind == JsonValueKind.String &&
+        !string.IsNullOrWhiteSpace(prop.GetString())
+            ? prop.GetString()
+            : null;
 
     private sealed record NyxIdProxyError(int Status, string Detail);
 }

--- a/test/Aevatar.AI.Core.Tests/Middleware/ToolCallMiddlewareChainFactoryTests.cs
+++ b/test/Aevatar.AI.Core.Tests/Middleware/ToolCallMiddlewareChainFactoryTests.cs
@@ -8,7 +8,7 @@ namespace Aevatar.AI.Core.Tests.Middleware;
 public sealed class ToolCallMiddlewareChainFactoryTests
 {
     [Fact]
-    public async Task ForAgentRuntime_ShouldPrependCanonicalApprovalMiddleware()
+    public async Task ForAgentRuntime_ShouldPrependCanonicalCredentialAndApprovalMiddlewares()
     {
         var custom = new RecordingMiddleware();
 
@@ -17,9 +17,10 @@ public sealed class ToolCallMiddlewareChainFactoryTests
             new ScriptedApprovalHandler(ToolApprovalResult.Approved()),
             null);
 
-        chain.Should().HaveCount(2);
-        chain[0].Should().BeOfType<ToolApprovalMiddleware>();
-        chain[1].Should().BeSameAs(custom);
+        chain.Should().HaveCount(3);
+        chain[0].Should().BeOfType<ToolCallCredentialPolicyMiddleware>();
+        chain[1].Should().BeOfType<ToolApprovalMiddleware>();
+        chain[2].Should().BeSameAs(custom);
 
         var context = NewContext();
         await RunChainAsync(chain, context);
@@ -39,9 +40,10 @@ public sealed class ToolCallMiddlewareChainFactoryTests
             new ScriptedApprovalHandler(ToolApprovalResult.Approved()),
             null);
 
-        chain.Should().HaveCount(2);
+        chain.Should().HaveCount(3);
+        chain[0].Should().BeOfType<ToolCallCredentialPolicyMiddleware>();
         chain.Should().ContainSingle(middleware => middleware is ToolApprovalMiddleware);
-        chain[1].Should().BeSameAs(custom);
+        chain[2].Should().BeSameAs(custom);
 
         var context = NewContext();
         await RunChainAsync(chain, context);
@@ -50,6 +52,22 @@ public sealed class ToolCallMiddlewareChainFactoryTests
         custom.Executions.Should().Be(1);
         context.Terminate.Should().BeFalse();
         context.Result.Should().Be("""{"ok":true}""");
+    }
+
+    [Fact]
+    public void ForAgentRuntime_ShouldRemoveExternallyRegisteredCredentialPolicyMiddleware()
+    {
+        var custom = new RecordingMiddleware();
+
+        var chain = ToolCallMiddlewareChainFactory.ForAgentRuntime(
+            [new ToolCallCredentialPolicyMiddleware(), custom],
+            new ScriptedApprovalHandler(ToolApprovalResult.Approved()),
+            null);
+
+        chain.Should().HaveCount(3);
+        chain.Should().ContainSingle(middleware => middleware is ToolCallCredentialPolicyMiddleware);
+        chain[0].Should().BeOfType<ToolCallCredentialPolicyMiddleware>();
+        chain[2].Should().BeSameAs(custom);
     }
 
     private static ToolCallContext NewContext() => new()

--- a/test/Aevatar.AI.Tests/ToolCallCredentialPolicyMiddlewareTests.cs
+++ b/test/Aevatar.AI.Tests/ToolCallCredentialPolicyMiddlewareTests.cs
@@ -1,0 +1,149 @@
+using System.Text.Json;
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.Middleware;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.Middleware;
+using FluentAssertions;
+
+namespace Aevatar.AI.Tests;
+
+public sealed class ToolCallCredentialPolicyMiddlewareTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task InvokeAsync_WhenSenderTokenExists_ShouldRunToolUnderSenderCredentials(bool isReadOnly)
+    {
+        var middleware = new ToolCallCredentialPolicyMiddleware();
+        var context = NewContext(new StubTool(isReadOnly: isReadOnly), "{}");
+        using var _ = AgentToolContextScope.Push(SenderBoundContext(
+            ownerToken: "owner-token",
+            senderToken: " sender-token "));
+        AgentToolExecutionContext? observed = null;
+
+        await middleware.InvokeAsync(context, () =>
+        {
+            observed = AgentToolRequestContext.Current;
+            return Task.CompletedTask;
+        });
+
+        observed.Should().NotBeNull();
+        observed!.Credentials.NyxIdAccessToken.Should().Be("sender-token");
+        observed.Credentials.NyxIdOrgToken.Should().Be("sender-token");
+        observed.Credentials.SenderNyxIdAccessToken.Should().Be("sender-token");
+        context.Terminate.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(false, false, "", null)]
+    [InlineData(true, true, "", null)]
+    [InlineData(true, false, "external_write", null)]
+    [InlineData(true, false, "", true)]
+    public async Task InvokeAsync_WhenSenderBoundMutationHasNoSenderToken_ShouldDenyAndTerminate(
+        bool isReadOnly,
+        bool isDestructive,
+        string sideEffectKind,
+        bool? requiresApproval)
+    {
+        var middleware = new ToolCallCredentialPolicyMiddleware();
+        var context = NewContext(new StubTool(
+            isReadOnly: isReadOnly,
+            isDestructive: isDestructive,
+            sideEffectKind: sideEffectKind,
+            requiresApproval: requiresApproval), "{}");
+        using var _ = AgentToolContextScope.Push(SenderBoundContext(
+            ownerToken: "owner-token",
+            senderToken: null));
+        var nextCalled = false;
+
+        await middleware.InvokeAsync(context, () =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        nextCalled.Should().BeFalse();
+        context.Terminate.Should().BeTrue();
+        context.TerminationKind.Should().Be(ToolCallTerminationKind.MiddlewareTerminated);
+        context.Result.Should().Contain("credential_denied");
+        context.Result.Should().Contain("Owner credentials were not used");
+        using var result = JsonDocument.Parse(context.Result!);
+        result.RootElement.GetProperty("error").GetString().Should().Be("credential_denied");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenSenderBoundReadOnlyHasNoSenderToken_ShouldNotBlock()
+    {
+        var middleware = new ToolCallCredentialPolicyMiddleware();
+        var context = NewContext(new StubTool(isReadOnly: true), "{}");
+        using var _ = AgentToolContextScope.Push(SenderBoundContext(
+            ownerToken: "owner-token",
+            senderToken: null));
+        var nextCalled = false;
+
+        await middleware.InvokeAsync(context, () =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        nextCalled.Should().BeTrue();
+        context.Terminate.Should().BeFalse();
+        AgentToolRequestContext.NyxIdAccessToken.Should().Be("owner-token");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenNoSenderBinding_ShouldLeaveOwnerCredentialsUnchanged()
+    {
+        var middleware = new ToolCallCredentialPolicyMiddleware();
+        var context = NewContext(new StubTool(isReadOnly: false), "{}");
+        using var _ = AgentToolContextScope.Push(AgentToolExecutionContext.Empty with
+        {
+            Credentials = new AgentToolCredentials("owner-token", "owner-org-token", null),
+        });
+        AgentToolExecutionContext? observed = null;
+
+        await middleware.InvokeAsync(context, () =>
+        {
+            observed = AgentToolRequestContext.Current;
+            return Task.CompletedTask;
+        });
+
+        observed.Should().NotBeNull();
+        observed!.Credentials.NyxIdAccessToken.Should().Be("owner-token");
+        observed.Credentials.NyxIdOrgToken.Should().Be("owner-org-token");
+        context.Terminate.Should().BeFalse();
+    }
+
+    private static ToolCallContext NewContext(IAgentTool tool, string argumentsJson) => new()
+    {
+        Tool = tool,
+        ToolName = tool.Name,
+        ToolCallId = "call-1",
+        ArgumentsJson = argumentsJson,
+    };
+
+    private static AgentToolExecutionContext SenderBoundContext(string ownerToken, string? senderToken) =>
+        AgentToolExecutionContext.Empty with
+        {
+            Credentials = new AgentToolCredentials(ownerToken, ownerToken, senderToken),
+            SenderBinding = new AgentToolSenderBindingContext("binding-1"),
+        };
+
+    private sealed class StubTool(
+        bool isReadOnly,
+        bool isDestructive = false,
+        string sideEffectKind = "",
+        bool? requiresApproval = null) : IAgentTool
+    {
+        public string Name => "test_tool";
+        public string Description => "test";
+        public string ParametersSchema => "{}";
+        public bool IsReadOnly => isReadOnly;
+        public bool IsDestructive => isDestructive;
+        public string SideEffectKind => sideEffectKind;
+        public bool? RequiresApproval(string argumentsJson) => requiresApproval;
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
+            Task.FromResult("""{"ok":true}""");
+    }
+}

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnPublishSkillToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnPublishSkillToolTests.cs
@@ -291,6 +291,24 @@ public sealed class OrnnPublishSkillToolTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_WhenPublishReturnsPermissionError_ShouldSurfaceUpstreamReason()
+    {
+        var handler = new CapturingHandler(
+            new CapturingResponse("""{ "data": { "valid": true, "violations": [] } }"""),
+            new CapturingResponse(
+                """{ "status": 403, "code": "permission_denied", "detail": "Missing ornn:skill:create permission" }""",
+                HttpStatusCode.Forbidden));
+        var tool = CreateTool(handler);
+
+        using var _ = BeginTokenScope();
+        var result = await tool.ExecuteAsync(ValidArguments());
+
+        result.Should().Contain("\"status\":\"error\"");
+        result.Should().Contain("Missing ornn:skill:create permission");
+        result.Should().NotContain("missing proxy scope");
+    }
+
+    [Fact]
     public async Task CreateSuccessReceipt_ShouldMapPublishedSkillSubjectFromToolResult()
     {
         var handler = new CapturingHandler(
@@ -376,11 +394,16 @@ public sealed class OrnnPublishSkillToolTests
 
     private sealed class CapturingHandler : HttpMessageHandler
     {
-        private readonly Queue<string> _responses;
+        private readonly Queue<CapturingResponse> _responses;
 
         public CapturingHandler(params string[] responses)
+            : this(responses.Select(body => new CapturingResponse(body)).ToArray())
         {
-            _responses = new Queue<string>(responses);
+        }
+
+        public CapturingHandler(params CapturingResponse[] responses)
+        {
+            _responses = new Queue<CapturingResponse>(responses);
         }
 
         public List<HttpRequestMessage> Requests { get; } = [];
@@ -390,11 +413,15 @@ public sealed class OrnnPublishSkillToolTests
             CancellationToken cancellationToken)
         {
             Requests.Add(request);
-            var body = _responses.Count == 0 ? """{ "error": true }""" : _responses.Dequeue();
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            var response = _responses.Count == 0
+                ? new CapturingResponse("""{ "error": true }""")
+                : _responses.Dequeue();
+            return Task.FromResult(new HttpResponseMessage(response.StatusCode)
             {
-                Content = new StringContent(body),
+                Content = new StringContent(response.Body),
             });
         }
     }
+
+    private sealed record CapturingResponse(string Body, HttpStatusCode StatusCode = HttpStatusCode.OK);
 }

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnSkillClientTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnSkillClientTests.cs
@@ -296,6 +296,38 @@ public sealed class OrnnSkillClientTests
     }
 
     [Fact]
+    public async Task GetSkillJsonAsync_WhenOrnnReturnsNestedPermissionError_ShouldSurfaceUpstreamReason()
+    {
+        var handler = OrnnTestHttpMessageHandler.ReturningJson(
+            """{ "error": { "code": "permission_denied", "message": "Missing ornn:skill:read permission" } }""",
+            HttpStatusCode.Forbidden);
+        var client = CreateClient(handler, slug: "ornn-api");
+
+        var act = async () => await client.GetSkillJsonAsync("sender-token", "private-skill");
+
+        var assertion = await act.Should().ThrowAsync<RemoteSkillFetchException>();
+        assertion.Which.HttpStatus.Should().Be(403);
+        assertion.Which.Message.Should().Contain("permission_denied: Missing ornn:skill:read permission");
+        assertion.Which.Message.Should().NotContain("missing proxy scope");
+    }
+
+    [Fact]
+    public async Task GetSkillJsonAsync_WhenOrnnReturnsProblemJsonPermissionError_ShouldSurfaceDetail()
+    {
+        var handler = OrnnTestHttpMessageHandler.ReturningJson(
+            """{ "status": 403, "code": "permission_denied", "detail": "You do not have permission to read this skill" }""",
+            HttpStatusCode.Forbidden);
+        var client = CreateClient(handler, slug: "ornn-api");
+
+        var act = async () => await client.GetSkillJsonAsync("sender-token", "private-skill");
+
+        var assertion = await act.Should().ThrowAsync<RemoteSkillFetchException>();
+        assertion.Which.HttpStatus.Should().Be(403);
+        assertion.Which.Message.Should().Contain("You do not have permission to read this skill");
+        assertion.Which.Message.Should().NotContain("missing proxy scope");
+    }
+
+    [Fact]
     public async Task GetSkillJsonAsync_ReturnsNullWhenPerCallTimeoutFiresOnSlowUpstream()
     {
         // Regression for the 2026-05-13 lark-bot incident: a NyxID-proxied call to

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
@@ -1486,7 +1486,14 @@ public sealed class AgentRunGAgentTests
             {
                 SenderBinding = new AgentToolSenderBindingContext("bnd-user-1"),
             }).ToPayload(),
-            LlmControl = ControlForAgentRun(rounds: 6).ToPayload(),
+            LlmControl = new LLMControlContext(
+                NyxIdAccessToken: null,
+                NyxIdOrgToken: null,
+                SenderNyxIdAccessToken: "sender-session-jwt",
+                ModelOverride: null,
+                NyxIdRoutePreference: null,
+                MaxToolRoundsOverride: 6,
+                UserMemoryPrompt: null).ToPayload(),
             Metadata =
             {
                 [ChannelMetadataKeys.Platform] = "lark",

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
@@ -1584,7 +1584,7 @@ public sealed class ConversationReplyGeneratorTests
     }
 
     [Fact]
-    public async Task GenerateReplyAsync_UsesOwnerPrefsImmediatelyWhenSenderRouteHasNoToken()
+    public async Task GenerateReplyAsync_WhenSenderRouteHasNoToken_ShouldKeepSenderBindingAndFallbackOnlyLlmRoute()
     {
         var providerFactory = new RecordingProviderFactory();
         var prefsStore = new ScopedStubPreferencesStore
@@ -1612,16 +1612,51 @@ public sealed class ConversationReplyGeneratorTests
             streamingSink: null,
             CancellationToken.None);
 
-        var ownerRequest = providerFactory.Requests.Should().ContainSingle().Subject;
-        ownerRequest.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.ModelOverride);
-        var ownerToolContext = ownerRequest.ToolContext!;
-        ownerToolContext.Routing.ModelOverride.Should().Be("owner-model");
-        ownerToolContext.Routing.NyxIdRoutePreference.Should().Be("/api/v1/proxy/s/owner");
-        ownerToolContext.Routing.MaxToolRoundsOverride.Should().Be(5);
-        ownerToolContext.Credentials.NyxIdAccessToken.Should().Be("owner-token");
-        ownerToolContext.Credentials.NyxIdOrgToken.Should().Be("owner-token");
-        ownerToolContext.SenderBinding.BindingId.Should().BeNull();
-        ownerToolContext.Credentials.SenderNyxIdAccessToken.Should().BeNull();
+        var request = providerFactory.Requests.Should().ContainSingle().Subject;
+        request.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.ModelOverride);
+        var requestToolContext = request.ToolContext!;
+        requestToolContext.Routing.ModelOverride.Should().Be("sender-model");
+        requestToolContext.Routing.NyxIdRoutePreference.Should().Be("/api/v1/proxy/s/owner");
+        requestToolContext.Routing.MaxToolRoundsOverride.Should().Be(7);
+        requestToolContext.Credentials.NyxIdAccessToken.Should().Be("owner-token");
+        requestToolContext.Credentials.NyxIdOrgToken.Should().Be("owner-token");
+        requestToolContext.SenderBinding.BindingId.Should().Be("bnd_sender");
+        requestToolContext.Credentials.SenderNyxIdAccessToken.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GenerateReplyAsync_WhenSenderHasNoRoutePreference_ShouldStillPromoteSenderTokenForTools()
+    {
+        var providerFactory = new RecordingProviderFactory();
+        var prefsStore = new ScopedStubPreferencesStore
+        {
+            ByBinding =
+            {
+                ["bnd_sender"] = new NyxIdUserLlmPreferences("sender-model", string.Empty, MaxToolRounds: 0),
+            },
+        };
+        var generator = new NyxIdConversationReplyGenerator(providerFactory, preferencesStore: prefsStore);
+
+        await generator.GenerateReplyAsync(
+            new ChatActivity
+            {
+                Id = "msg-sender-token-no-route-pref",
+                Conversation = new ConversationReference { CanonicalKey = "lark:dm:user-1" },
+                Content = new MessageContent { Text = "hello" },
+            },
+            new Dictionary<string, string>(),
+            Control("owner-model", "/api/v1/proxy/s/owner", 5, "owner-token", " sender-token "),
+            ToolContext("bnd_sender"),
+            streamingSink: null,
+            CancellationToken.None);
+
+        var toolContext = providerFactory.Requests.Should().ContainSingle().Subject.ToolContext!;
+        toolContext.Routing.ModelOverride.Should().Be("sender-model");
+        toolContext.Routing.NyxIdRoutePreference.Should().Be("/api/v1/proxy/s/owner");
+        toolContext.Credentials.NyxIdAccessToken.Should().Be("sender-token");
+        toolContext.Credentials.NyxIdOrgToken.Should().Be("sender-token");
+        toolContext.Credentials.SenderNyxIdAccessToken.Should().Be("sender-token");
+        toolContext.SenderBinding.BindingId.Should().Be("bnd_sender");
     }
 
     // ─── Issue #513 phase 3 — explicit 3 binding × 3 owner-prefs override matrix ───
@@ -1633,9 +1668,8 @@ public sealed class ConversationReplyGeneratorTests
     // crossed with the owner-prefs axis (none / partial=model-only / full).
     // Sender prefs in the bound-set row deliberately set ONLY DefaultModel so
     // we exercise the "sender supplies a subset, owner fills the rest" path
-    // without crossing the route-applied + no-sender-token branch (which
-    // silently swaps in the owner snapshot — orthogonal to the matrix and
-    // already covered by UsesOwnerPrefsImmediatelyWhenSenderRouteHasNoToken).
+    // without crossing the route-applied + no-sender-token branch, which
+    // now falls back only the LLM route while preserving sender binding.
     public const string MatrixUnbound = "unbound";
     public const string MatrixBoundEmpty = "bound_empty_prefs";
     public const string MatrixBoundModelOnly = "bound_model_only";

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
@@ -803,6 +803,44 @@ public sealed class ConversationReplyGeneratorTests
     }
 
     [Fact]
+    public async Task GenerateReplyAsync_WhenSenderBoundMutationHasNoSenderToken_ShouldDenyBeforeApprovalAndExecution()
+    {
+        var tool = new ApprovalRequiredTool();
+        var approvalHandler = new CountingApprovalHandler();
+        var providerFactory = new ToolResultEchoingProviderFactory();
+        var generator = new NyxIdConversationReplyGenerator(
+            providerFactory,
+            toolSources: [new SingleToolSource(tool)],
+            approvalHandler: approvalHandler);
+
+        var reply = await generator.GenerateReplyAsync(
+            new ChatActivity
+            {
+                Id = "msg-sender-bound-no-token-write",
+                Conversation = new ConversationReference { CanonicalKey = "lark:dm:user-sender-bound-no-token" },
+                Content = new MessageContent { Text = "run tool" },
+            },
+            new Dictionary<string, string>(),
+            Control(token: "owner-token"),
+            ToolContext("bnd_sender"),
+            streamingSink: null,
+            CancellationToken.None);
+
+        providerFactory.Requests.Should().HaveCount(2);
+        var toolResult = providerFactory.Requests[1].Messages
+            .Should()
+            .ContainSingle(message => message.Role == "tool")
+            .Subject
+            .Content;
+        toolResult.Should().Contain("credential_denied");
+        toolResult.Should().Contain("Owner credentials were not used");
+        reply.Text.Should().Contain("credential_denied");
+        reply.Text.Should().Contain("Owner credentials were not used");
+        approvalHandler.RequestCount.Should().Be(0);
+        tool.ExecuteCount.Should().Be(0);
+    }
+
+    [Fact]
     public async Task GenerateReplyAsync_WithLocalSkillCatalog_AddsLocalSkillsWithoutRemoteFetcherWarning()
     {
         var logger = new ListLogger<NyxIdConversationReplyGenerator>();
@@ -1986,6 +2024,8 @@ public sealed class ConversationReplyGeneratorTests
     {
         public string Name => "tool-result-echoing";
 
+        public List<LLMRequest> Requests { get; } = [];
+
         public ILLMProvider GetProvider(string name) => this;
 
         public ILLMProvider GetDefault() => this;
@@ -1996,6 +2036,7 @@ public sealed class ConversationReplyGeneratorTests
             LLMRequest request,
             [EnumeratorCancellation] CancellationToken ct = default)
         {
+            Requests.Add(request);
             var toolResult = request.Messages.LastOrDefault(static message => message.Role == "tool")?.Content;
             if (toolResult is not null)
             {

--- a/tools/ci/guards/catch_exception_observability_baseline.tsv
+++ b/tools/ci/guards/catch_exception_observability_baseline.tsv
@@ -1,6 +1,5 @@
 path	line	message
 agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs	155	empty broad catch block
-agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs	908	empty broad catch block
 agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.ConnectedServices.cs	109	empty broad catch block
 agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Streaming.cs	376	empty broad catch block
 agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs	333	broad catch returns null without visible failure signal


### PR DESCRIPTION
## Summary / 摘要

修复 #2174：ornn 写工具的执行身份意外耦合到 LLM route 偏好——sender 没设 route 偏好时 tool 调用回退 bot OWNER token（归属/权限错配），且 ornn 403 真实权限原因被 proxy 文案掩盖。

- **Old**：`ConversationReplyGenerator` 只在 `applied.RouteApplied` 分支内套 sender token，否则 tool 调用以 owner 身份跑；403 错误不透传 upstream 真实原因。
- **New**：metadata 驱动的 `ToolCallCredentialPolicyMiddleware`（注册于 `ToolApprovalMiddleware` 前，覆盖 chain factory + ConversationReplyGenerator 两条链）强制 tool 执行身份——sender 绑定 + sender token 时以 sender 身份跑；mutation 无 sender token → fail-closed（结构化拒绝 + Terminate，绝不以 owner 跑）；只读工具不拦。`RouteApplied` 只管 LLM routing，与 tool identity 解耦。`OrnnSkillClient` 本地 unwrap 透传 upstream Ornn 403 真实权限原因。

## Scope / 范围

- `ConversationReplyGenerator.cs`：解耦 + 注册中间件
- `ToolCallCredentialPolicyMiddleware.cs`（新）+ `AgentToolCredentialPolicy.cs`（新，mutation 判定 `!IsReadOnly || IsDestructive || SideEffectKind 非空 || RequiresApproval==true`，不硬编码 tool 名）
- `ToolCallMiddlewareChainFactory.cs`：共享链注册
- `OrnnSkillClient.cs`：403 honest unwrap
- 测试：`ToolCallCredentialPolicyMiddlewareTests`（新）+ ChainFactory/ConversationReplyGenerator/AgentRunGAgent/Ornn{SkillClient,PublishSkillTool} 覆盖
- `catch_exception_observability_baseline.tsv`：移除已可观察的 catch 基线项

## 验证

- `dotnet build aevatar.slnx --nologo`：0 error（controller gate 复核）。
- `dotnet test`：AI.Tests 900 / AI.Core.Tests 85 / Ornn.Tests 136 / ChannelRuntime.Tests 1334，全 0 fail。
- `test_stability_guards.sh` + `architecture_guards.sh`：pass。

## Consensus

design-consensus r3 → `consensus:structural`（least privilege + fail-closed + chain-of-responsibility middleware）。consensus-loop scoped run（milestone 26 / eanzhao）。后续 #2172（ornn_update_skill）将基于本 PR。

Closes #2174

🤖 consensus-loop

⟦AI:AUTO-LOOP⟧
