### PR TITLE
feat(ornn): ornn_update_skill 工具 + UpdateSkillAsync（PUT by id）#2172

### DIFF
--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnAgentToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnAgentToolSource.cs
@@ -5,25 +5,28 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Aevatar.AI.ToolProviders.Ornn;
 
 /// <summary>
-/// Ornn 技能工具来源。提供 ornn_search_skills 发现工具。
-/// 技能使用功能已合入统一的 use_skill 工具（通过 IRemoteSkillFetcher）。
+/// Ornn skill tool source. Skill execution stays in the shared use_skill tool
+/// through IRemoteSkillFetcher.
 /// </summary>
 public sealed class OrnnAgentToolSource : IAgentToolSource
 {
     private readonly OrnnOptions _options;
     private readonly OrnnSkillClient _client;
     private readonly OrnnPublishSkillTool _publishTool;
+    private readonly OrnnUpdateSkillTool _updateTool;
     private readonly ILogger _logger;
 
     public OrnnAgentToolSource(
         OrnnOptions options,
         OrnnSkillClient client,
         OrnnPublishSkillTool publishTool,
+        OrnnUpdateSkillTool updateTool,
         ILogger<OrnnAgentToolSource>? logger = null)
     {
         _options = options;
         _client = client;
         _publishTool = publishTool;
+        _updateTool = updateTool;
         _logger = logger ?? NullLogger<OrnnAgentToolSource>.Instance;
     }
 
@@ -34,7 +37,7 @@ public sealed class OrnnAgentToolSource : IAgentToolSource
         // point and resorts to nyxid_proxy path-guessing (issue #530). OrnnSkillClient
         // routes through NyxID's proxy, so the slug — not a hardcoded base URL — is what
         // determines reachability.
-        IReadOnlyList<IAgentTool> tools = [new OrnnSearchSkillsTool(_client), _publishTool];
+        IReadOnlyList<IAgentTool> tools = [new OrnnSearchSkillsTool(_client), _publishTool, _updateTool];
 
         _logger.LogInformation(
             "Ornn tools registered (NyxID slug: {Slug})", _options.NyxIdSlug);

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
@@ -236,6 +236,55 @@ public sealed class OrnnSkillClient
         }
     }
 
+    public async Task<OrnnSkillPublishResponse> UpdateSkillAsync(
+        string accessToken,
+        string skillId,
+        byte[] zipBytes,
+        CancellationToken ct = default)
+    {
+        var path = $"/api/v1/skills/{Uri.EscapeDataString(skillId)}";
+        using var timeoutCts = new CancellationTokenSource(_perCallTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+
+        try
+        {
+            var response = await _nyxApi.ProxyRequestBinaryAsync(
+                token: accessToken,
+                slug: _options.NyxIdSlug,
+                path: path,
+                method: "PUT",
+                body: zipBytes,
+                contentType: "application/zip",
+                extraHeaders: null,
+                ct: linkedCts.Token);
+
+            if (TryUnwrapNyxIdProxyError(response, out var proxyError))
+                return new OrnnSkillPublishResponse(false, response, proxyError.Detail);
+
+            return new OrnnSkillPublishResponse(true, response);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+        {
+            _logger.LogWarning(
+                "Ornn skill update exceeded {TimeoutSeconds}s per-call budget for '{SkillId}'",
+                (int)_perCallTimeout.TotalSeconds,
+                skillId);
+            return new OrnnSkillPublishResponse(
+                false,
+                string.Empty,
+                $"Ornn skill update exceeded {(int)_perCallTimeout.TotalSeconds}s budget.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Ornn skill update failed for '{SkillId}'", skillId);
+            return new OrnnSkillPublishResponse(false, string.Empty, ex.Message);
+        }
+    }
+
     /// <summary>
     /// Detect the wrapped error envelope NyxIdApiClient.SendAsync emits when the upstream
     /// returns non-2xx (<c>{"error": true, "status": N, "body": "..."}</c>) so callers see a

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnUpdateSkillTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnUpdateSkillTool.cs
@@ -1,0 +1,356 @@
+using System.Text;
+using System.Text.Json;
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.ToolProviders.Ornn.Publishing;
+
+namespace Aevatar.AI.ToolProviders.Ornn;
+
+public sealed class OrnnUpdateSkillTool : IAgentTool
+{
+    private readonly OrnnSkillPublishValidationPipeline _validationPipeline;
+    private readonly OrnnSkillPackageBuilder _packageBuilder;
+    private readonly OrnnSkillPackageFormatValidator _formatValidator;
+    private readonly OrnnSkillClient _client;
+
+    public OrnnUpdateSkillTool(
+        OrnnSkillPublishValidationPipeline validationPipeline,
+        OrnnSkillPackageBuilder packageBuilder,
+        OrnnSkillPackageFormatValidator formatValidator,
+        OrnnSkillClient client)
+    {
+        _validationPipeline = validationPipeline;
+        _packageBuilder = packageBuilder;
+        _formatValidator = formatValidator;
+        _client = client;
+    }
+
+    public string Name => "ornn_update_skill";
+
+    public string Description =>
+        "Update an existing Ornn skill package for the current NyxID caller by stable skill_id. " +
+        "Before calling, search or GET the current skill JSON, apply the requested full-package change, then submit the complete typed package with the same stable skill_id. " +
+        "This validates workflow YAML, scripts, package format, then uploads the ZIP with PUT by id. " +
+        "The tool never accepts credentials, service routing fields, raw file maps, metadata bags, public visibility, or skip-validation flags.";
+
+    public ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;
+
+    public bool IsReadOnly => false;
+
+    public bool IsDestructive => false;
+
+    public string SideEffectKind => "ornn.update.skill";
+
+    public AgentToolReceipt? CreateSuccessReceipt(string callId, string toolName, string resultJson)
+    {
+        var updated = ExtractUpdatedSkill(resultJson);
+        if (!updated.HasAny)
+            return null;
+
+        return new AgentToolReceipt
+        {
+            CallId = callId ?? string.Empty,
+            ToolName = string.IsNullOrWhiteSpace(toolName) ? Name : toolName,
+            Status = AgentToolReceiptStatus.Success,
+            ApprovalMode = AgentToolReceiptApprovalMode.Auto,
+            IsDestructive = false,
+            SideEffectKind = SideEffectKind,
+            SubjectKind = "ornn.skill",
+            SubjectId = updated.Guid ?? string.Empty,
+            SubjectVersion = updated.Version ?? string.Empty,
+            SubjectHash = updated.SkillHash ?? string.Empty,
+            ResultJson = resultJson ?? string.Empty,
+        };
+    }
+
+    public string ParametersSchema => """
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "skill_id": { "type": "string", "description": "Stable Ornn skill GUID to update." },
+            "name": { "type": "string", "description": "Kebab-case skill package name." },
+            "description": { "type": "string", "description": "Short skill description without XML angle brackets." },
+            "version": { "type": "string", "description": "Skill version in <major>.<minor> format, for example 1.0." },
+            "category": { "type": "string", "enum": ["plain", "tool-based", "runtime-based", "mixed"] },
+            "instructions_markdown": { "type": "string", "description": "SKILL.md body content only. Do not include frontmatter delimiters." },
+            "visibility": { "type": "string", "enum": ["private"], "description": "Optional. v1 only accepts private." },
+            "tags": { "type": "array", "items": { "type": "string" } },
+            "output_type": { "type": "string", "enum": ["text", "file"] },
+            "runtimes": { "type": "array", "items": { "type": "string" } },
+            "runtime_dependencies": { "type": "array", "items": { "type": "string" } },
+            "runtime_env_vars": { "type": "array", "items": { "type": "string" } },
+            "tool_list": { "type": "array", "items": { "type": "string" } },
+            "workflow_yamls": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "workflow_id": { "type": "string" },
+                  "content": { "type": "string" }
+                },
+                "required": ["workflow_id", "content"]
+              }
+            },
+            "scripts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "path": { "type": "string" },
+                  "content": { "type": "string" }
+                },
+                "required": ["path", "content"]
+              }
+            },
+            "references": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "path": { "type": "string" },
+                  "content": { "type": "string" }
+                },
+                "required": ["path", "content"]
+              }
+            },
+            "assets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "path": { "type": "string" },
+                  "content": { "type": "string" }
+                },
+                "required": ["path", "content"]
+              }
+            }
+          },
+          "required": ["skill_id", "name", "description", "version", "category", "instructions_markdown"]
+        }
+        """;
+
+    public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+    {
+        var token = AgentToolRequestContext.NyxIdAccessToken;
+        if (string.IsNullOrWhiteSpace(token))
+            return BuildResult("error", "No NyxID access token available. User must be authenticated.");
+
+        var (skillId, packageArgumentsJson, skillIdDiagnostics) = ExtractSkillIdAndPackageArguments(argumentsJson);
+        if (skillId == null || packageArgumentsJson == null)
+            return BuildDiagnosticsResult("validation_error", skillIdDiagnostics);
+
+        var (request, parseDiagnostics) = OrnnSkillPublishRequestParser.Parse(packageArgumentsJson);
+        if (request == null)
+            return BuildDiagnosticsResult("validation_error", parseDiagnostics);
+
+        var localValidation = await _validationPipeline.ValidateAsync(request, ct);
+        if (!localValidation.IsValid)
+            return BuildDiagnosticsResult("validation_error", localValidation.Diagnostics);
+
+        var (package, buildValidation) = _packageBuilder.Build(request);
+        if (package == null)
+            return BuildDiagnosticsResult("validation_error", buildValidation.Diagnostics);
+
+        var formatValidation = await _formatValidator.ValidateAsync(token, package.ZipBytes, ct);
+        if (!formatValidation.IsValid)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                result_type = "ornn_update_skill",
+                status = "format_validation_error",
+                error = formatValidation.Error,
+                violations = formatValidation.Violations,
+            });
+        }
+
+        var update = await _client.UpdateSkillAsync(token, skillId, package.ZipBytes, ct);
+        if (!update.Succeeded)
+            return BuildResult("error", update.Error ?? "Ornn update failed.");
+
+        var updated = ExtractUpdatedSkill(update.RawResponse);
+        return JsonSerializer.Serialize(new
+        {
+            result_type = "ornn_update_skill",
+            status = "success",
+            skill_id = skillId,
+            name = request.Name,
+            guid = updated.Guid ?? skillId,
+            version = updated.Version ?? request.Version,
+            skillHash = updated.SkillHash,
+            package_bytes = package.ZipBytes.Length,
+            response = update.RawResponse,
+        });
+    }
+
+    private static (string? SkillId, string? PackageArgumentsJson, IReadOnlyList<OrnnSkillPublishDiagnostic> Diagnostics)
+        ExtractSkillIdAndPackageArguments(string argumentsJson)
+    {
+        if (string.IsNullOrWhiteSpace(argumentsJson))
+            return (null, null, [new OrnnSkillPublishDiagnostic("invalid_json", "Arguments JSON is required.")]);
+
+        try
+        {
+            using var document = JsonDocument.Parse(argumentsJson);
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+                return (null, null, [new OrnnSkillPublishDiagnostic("invalid_json", "Arguments must be a JSON object.")]);
+
+            var diagnostics = new List<OrnnSkillPublishDiagnostic>();
+            var skillId = ReadRequiredSkillId(root, diagnostics);
+            if (diagnostics.Count > 0)
+                return (null, null, diagnostics);
+
+            return (skillId, StripSkillId(root), diagnostics);
+        }
+        catch (JsonException ex)
+        {
+            return (null, null, [new OrnnSkillPublishDiagnostic("invalid_json", ex.Message)]);
+        }
+    }
+
+    private static string? ReadRequiredSkillId(JsonElement root, List<OrnnSkillPublishDiagnostic> diagnostics)
+    {
+        if (!root.TryGetProperty("skill_id", out var property))
+        {
+            diagnostics.Add(new OrnnSkillPublishDiagnostic("missing_field", "skill_id is required.", "$.skill_id"));
+            return null;
+        }
+
+        if (property.ValueKind != JsonValueKind.String)
+        {
+            diagnostics.Add(new OrnnSkillPublishDiagnostic("invalid_field", "skill_id must be a string.", "$.skill_id"));
+            return null;
+        }
+
+        var value = property.GetString()?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            diagnostics.Add(new OrnnSkillPublishDiagnostic("missing_field", "skill_id must not be empty.", "$.skill_id"));
+            return null;
+        }
+
+        if (!Guid.TryParse(value, out _))
+        {
+            diagnostics.Add(new OrnnSkillPublishDiagnostic("invalid_skill_id", "skill_id must be a GUID.", "$.skill_id"));
+            return null;
+        }
+
+        return value;
+    }
+
+    private static string StripSkillId(JsonElement root)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            foreach (var property in root.EnumerateObject())
+            {
+                if (string.Equals(property.Name, "skill_id", StringComparison.Ordinal))
+                    continue;
+
+                property.WriteTo(writer);
+            }
+            writer.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static string BuildDiagnosticsResult(
+        string status,
+        IReadOnlyList<OrnnSkillPublishDiagnostic> diagnostics) =>
+        JsonSerializer.Serialize(new
+        {
+            result_type = "ornn_update_skill",
+            status,
+            diagnostics,
+        });
+
+    private static string BuildResult(string status, string error) =>
+        JsonSerializer.Serialize(new
+        {
+            result_type = "ornn_update_skill",
+            status,
+            error,
+        });
+
+    private static UpdatedSkillSubject ExtractUpdatedSkill(string? rawResponse)
+    {
+        if (string.IsNullOrWhiteSpace(rawResponse))
+            return new UpdatedSkillSubject(null, null, null);
+
+        try
+        {
+            using var doc = JsonDocument.Parse(rawResponse);
+            return ExtractUpdatedSkill(doc.RootElement);
+        }
+        catch (JsonException)
+        {
+            return new UpdatedSkillSubject(null, null, null);
+        }
+    }
+
+    private static UpdatedSkillSubject ExtractUpdatedSkill(JsonElement root)
+    {
+        var subject = ExtractUpdatedSkillFromObject(root);
+        if (subject.HasAny)
+            return subject;
+
+        if (root.ValueKind != JsonValueKind.Object)
+            return subject;
+
+        foreach (var propertyName in new[] { "data", "result", "skill" })
+        {
+            if (!root.TryGetProperty(propertyName, out var nested) || nested.ValueKind != JsonValueKind.Object)
+                continue;
+
+            subject = ExtractUpdatedSkillFromObject(nested);
+            if (subject.HasAny)
+                return subject;
+        }
+
+        return subject;
+    }
+
+    private static UpdatedSkillSubject ExtractUpdatedSkillFromObject(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+            return new UpdatedSkillSubject(null, null, null);
+
+        return new UpdatedSkillSubject(
+            TryGetString(element, "guid", "id", "skill_id", "skillId"),
+            TryGetString(element, "version", "subject_version", "subjectVersion"),
+            TryGetString(element, "skillHash", "skill_hash", "hash", "subject_hash"));
+    }
+
+    private static string? TryGetString(JsonElement element, params string[] keys)
+    {
+        foreach (var key in keys)
+        {
+            if (!element.TryGetProperty(key, out var value))
+                continue;
+
+            if (value.ValueKind == JsonValueKind.String)
+                return value.GetString();
+
+            if (value.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined)
+                return value.ToString();
+        }
+
+        return null;
+    }
+
+    private sealed record UpdatedSkillSubject(string? Guid, string? Version, string? SkillHash)
+    {
+        public bool HasAny =>
+            !string.IsNullOrWhiteSpace(Guid) ||
+            !string.IsNullOrWhiteSpace(Version) ||
+            !string.IsNullOrWhiteSpace(SkillHash);
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.Ornn/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/ServiceCollectionExtensions.cs
@@ -45,6 +45,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<OrnnSkillPackageBuilder>();
         services.TryAddSingleton<OrnnSkillPackageFormatValidator>();
         services.TryAddSingleton<OrnnPublishSkillTool>();
+        services.TryAddSingleton<OrnnUpdateSkillTool>();
         services.TryAddSingleton<IRemoteSkillFetcher, OrnnRemoteSkillFetcher>();
         services.TryAddSingleton<OrnnAgentToolSource>();
         services.TryAddAgentToolSourceAlias<OrnnAgentToolSource>(GetOrnnAgentToolSource);

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnSkillClientTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnSkillClientTests.cs
@@ -382,6 +382,23 @@ public sealed class OrnnSkillClientTests
         await act.Should().ThrowAsync<OperationCanceledException>();
     }
 
+    [Fact]
+    public async Task UpdateSkillAsync_RoutesPutThroughNyxIdProxyWithEscapedIdAndZipContentType()
+    {
+        var handler = OrnnTestHttpMessageHandler.ReturningJson("""{ "data": { "id": "skill-1" } }""");
+        var client = CreateClient(handler);
+
+        var result = await client.UpdateSkillAsync("access-token", "skill id/1", [1, 2, 3]);
+
+        result.Succeeded.Should().BeTrue();
+        var request = handler.Requests.Should().ContainSingle().Subject;
+        request.Method.Should().Be(HttpMethod.Put);
+        request.Authorization!.Parameter.Should().Be("access-token");
+        request.ContentType.Should().Be("application/zip");
+        request.RequestUri!.AbsoluteUri.Should().Be(
+            "https://nyx.example/api/v1/proxy/s/ornn/api/v1/skills/skill%20id%2F1");
+    }
+
     private static OrnnSkillClient CreateClient(
         OrnnTestHttpMessageHandler handler,
         string slug = "ornn",

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnTestHttpMessageHandler.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnTestHttpMessageHandler.cs
@@ -73,13 +73,15 @@ internal sealed class OrnnTestHttpMessageHandler : HttpMessageHandler
 internal sealed record CapturedHttpRequest(
     HttpMethod Method,
     Uri? RequestUri,
-    AuthenticationHeaderValue? Authorization)
+    AuthenticationHeaderValue? Authorization,
+    string? ContentType)
 {
     public static CapturedHttpRequest From(HttpRequestMessage request)
     {
         return new CapturedHttpRequest(
             request.Method,
             request.RequestUri,
-            request.Headers.Authorization);
+            request.Headers.Authorization,
+            request.Content?.Headers.ContentType?.MediaType);
     }
 }

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnUpdateSkillToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnUpdateSkillToolTests.cs
@@ -1,0 +1,325 @@
+using System.Net;
+using System.Text.Json;
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.AI.ToolProviders.Ornn.Publishing;
+using FluentAssertions;
+
+namespace Aevatar.AI.ToolProviders.Ornn.Tests;
+
+public sealed class OrnnUpdateSkillToolTests
+{
+    private const string SkillId = "11111111-2222-3333-4444-555555555555";
+
+    [Fact]
+    public void ToolMetadata_ShouldExposeUpdateToolWithNarrowMutationContract()
+    {
+        var tool = CreateTool(new CapturingHandler("""{ "data": { "valid": true } }"""));
+
+        tool.Name.Should().Be("ornn_update_skill");
+        tool.ApprovalMode.Should().Be(ToolApprovalMode.Auto);
+        tool.IsReadOnly.Should().BeFalse();
+        tool.IsDestructive.Should().BeFalse();
+        tool.SideEffectKind.Should().Be("ornn.update.skill");
+        tool.Description.Should().Contain("search or GET the current skill JSON");
+        tool.Description.Should().Contain("stable skill_id");
+
+        using var schema = JsonDocument.Parse(tool.ParametersSchema);
+        var root = schema.RootElement;
+        root.GetProperty("additionalProperties").GetBoolean().Should().BeFalse();
+        var properties = root.GetProperty("properties").EnumerateObject().Select(x => x.Name).ToArray();
+        properties.Should().Equal(
+            "skill_id",
+            "name",
+            "description",
+            "version",
+            "category",
+            "instructions_markdown",
+            "visibility",
+            "tags",
+            "output_type",
+            "runtimes",
+            "runtime_dependencies",
+            "runtime_env_vars",
+            "tool_list",
+            "workflow_yamls",
+            "scripts",
+            "references",
+            "assets");
+        root.GetProperty("required").EnumerateArray().Select(x => x.GetString()).Should().Equal(
+            "skill_id",
+            "name",
+            "description",
+            "version",
+            "category",
+            "instructions_markdown");
+        properties.Should().NotContain([
+            "skill_name",
+            "id_or_name",
+            "credential",
+            "token",
+            "owner",
+            "service_url",
+            "metadata",
+            "raw_file_map",
+            "skip_validation"
+        ]);
+    }
+
+    [Fact]
+    public void ToolDescription_ShouldNotHardcodeProductionSkillNames()
+    {
+        var tool = CreateTool(new CapturingHandler("""{ "data": { "valid": true } }"""));
+
+        var text = tool.Description + tool.ParametersSchema;
+
+        text.Should().NotContain("/daily");
+        text.Should().NotContain("chrono-ai-daily");
+        text.Should().NotContain("project-summary");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldRejectMissingCallerToken()
+    {
+        var tool = CreateTool(new CapturingHandler("""{ "data": { "valid": true } }"""));
+        AgentToolRequestContext.Current = null;
+
+        var result = await tool.ExecuteAsync(ValidArguments());
+
+        result.Should().Contain("No NyxID access token");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-guid")]
+    public async Task ExecuteAsync_ShouldRejectMissingOrInvalidSkillIdBeforeUpload(string skillId)
+    {
+        var handler = new CapturingHandler("""{ "data": { "valid": true } }""");
+        var tool = CreateTool(handler);
+
+        using var _ = BeginTokenScope();
+        var result = await tool.ExecuteAsync(ValidArguments(skillId: skillId));
+
+        result.Should().Contain("validation_error");
+        result.Should().Contain(string.IsNullOrEmpty(skillId) ? "missing_field" : "invalid_skill_id");
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("skill_name")]
+    [InlineData("id_or_name")]
+    [InlineData("credential")]
+    [InlineData("token")]
+    [InlineData("owner")]
+    [InlineData("service_url")]
+    [InlineData("metadata")]
+    [InlineData("raw_file_map")]
+    [InlineData("skip_validation")]
+    public async Task ExecuteAsync_ShouldRejectForbiddenRootFieldsBeforeUpload(string field)
+    {
+        var handler = new CapturingHandler("""{ "data": { "valid": true } }""");
+        var tool = CreateTool(handler);
+
+        using var _ = BeginTokenScope();
+        var result = await tool.ExecuteAsync(ValidArguments(extraFields: $$"""
+            "{{field}}": "bad"
+            """));
+
+        result.Should().Contain("validation_error");
+        result.Should().Contain("unknown_field");
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldSkipUploadWhenLocalValidationFailsAfterStrippingSkillId()
+    {
+        var handler = new CapturingHandler("""{ "data": { "valid": true } }""");
+        var tool = CreateTool(handler, validators:
+        [
+            new StubValidator(
+                OrnnSkillPublishValidationPipeline.ScriptAssetKind,
+                new OrnnSkillPublishDiagnostic("bad_script", "bad script"))
+        ]);
+
+        using var _ = BeginTokenScope();
+        var result = await tool.ExecuteAsync(ValidArguments(extraFields: """
+            "scripts": [{ "path": "main.cs", "content": "class C {}" }]
+            """));
+
+        result.Should().Contain("bad_script");
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldSkipUpdateWhenOrnnFormatValidationFails()
+    {
+        var handler = new CapturingHandler("""
+            { "data": { "valid": false, "violations": [{ "rule": "skill-md", "message": "bad" }] } }
+            """);
+        var tool = CreateTool(handler);
+
+        using var _ = BeginTokenScope();
+        var result = await tool.ExecuteAsync(ValidArguments());
+
+        result.Should().Contain("format_validation_error");
+        handler.Requests.Should().ContainSingle();
+        handler.Requests[0].RequestUri!.AbsolutePath.Should().Be(
+            "/api/v1/proxy/s/ornn/api/v1/skill-format/validate");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldValidateThenUpdateBySkillIdOnSuccess()
+    {
+        var handler = new CapturingHandler(
+            """{ "data": { "valid": true, "violations": [] } }""",
+            """{ "data": { "id": "11111111-2222-3333-4444-555555555555", "version": "1.2", "skillHash": "hash-1" } }""");
+        var tool = CreateTool(handler);
+
+        using var _ = BeginTokenScope();
+        var result = await tool.ExecuteAsync(ValidArguments());
+
+        using var document = JsonDocument.Parse(result);
+        var root = document.RootElement;
+        root.GetProperty("status").GetString().Should().Be("success");
+        root.GetProperty("skill_id").GetString().Should().Be(SkillId);
+        root.GetProperty("guid").GetString().Should().Be(SkillId);
+        root.GetProperty("version").GetString().Should().Be("1.2");
+        root.GetProperty("skillHash").GetString().Should().Be("hash-1");
+
+        handler.Requests.Select(x => x.RequestUri!.AbsolutePath).Should().Equal(
+            "/api/v1/proxy/s/ornn/api/v1/skill-format/validate",
+            $"/api/v1/proxy/s/ornn/api/v1/skills/{SkillId}");
+        handler.Requests.Select(x => x.Method).Should().Equal(HttpMethod.Post, HttpMethod.Put);
+        handler.Requests.Select(x => x.Content!.Headers.ContentType!.MediaType).Should().Equal(
+            "application/zip",
+            "application/zip");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenUpdateReturnsPermissionError_ShouldSurfaceUpstreamReason()
+    {
+        var handler = new CapturingHandler(
+            new CapturingResponse("""{ "data": { "valid": true, "violations": [] } }"""),
+            new CapturingResponse(
+                """{ "status": 403, "code": "permission_denied", "detail": "Missing ornn:skill:update permission" }""",
+                HttpStatusCode.Forbidden));
+        var tool = CreateTool(handler);
+
+        using var _ = BeginTokenScope();
+        var result = await tool.ExecuteAsync(ValidArguments());
+
+        result.Should().Contain("\"status\":\"error\"");
+        result.Should().Contain("Missing ornn:skill:update permission");
+        result.Should().NotContain("missing proxy scope");
+    }
+
+    [Fact]
+    public async Task CreateSuccessReceipt_ShouldMapUpdatedSkillSubjectFromToolResult()
+    {
+        var handler = new CapturingHandler(
+            """{ "data": { "valid": true, "violations": [] } }""",
+            """{ "data": { "id": "11111111-2222-3333-4444-555555555555", "hash": "hash-3" } }""");
+        var tool = CreateTool(handler);
+
+        using var _ = BeginTokenScope();
+        var result = await tool.ExecuteAsync(ValidArguments());
+        var receipt = tool.CreateSuccessReceipt("call-1", tool.Name, result);
+
+        receipt.Should().NotBeNull();
+        receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+        receipt.ApprovalMode.Should().Be(AgentToolReceiptApprovalMode.Auto);
+        receipt.IsDestructive.Should().BeFalse();
+        receipt.SideEffectKind.Should().Be("ornn.update.skill");
+        receipt.SubjectKind.Should().Be("ornn.skill");
+        receipt.SubjectId.Should().Be(SkillId);
+        receipt.SubjectVersion.Should().Be("1.0");
+        receipt.SubjectHash.Should().Be("hash-3");
+    }
+
+    private static string ValidArguments(string skillId = SkillId, string? extraFields = null)
+    {
+        var commaExtra = string.IsNullOrWhiteSpace(extraFields) ? string.Empty : "," + extraFields;
+        return $$"""
+            {
+              "skill_id": "{{skillId}}",
+              "name": "plain-skill",
+              "description": "Plain skill",
+              "version": "1.0",
+              "category": "plain",
+              "instructions_markdown": "Do the work."
+              {{commaExtra}}
+            }
+            """;
+    }
+
+    private static OrnnUpdateSkillTool CreateTool(
+        CapturingHandler handler,
+        IReadOnlyList<IOrnnSkillPublishAssetValidator>? validators = null)
+    {
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example" },
+            new HttpClient(handler));
+        var options = new OrnnOptions { NyxIdSlug = "ornn" };
+        var pipeline = new OrnnSkillPublishValidationPipeline(validators);
+        var formatValidator = new OrnnSkillPackageFormatValidator(options, nyxClient);
+        var client = new OrnnSkillClient(options, nyxClient);
+        return new OrnnUpdateSkillTool(
+            pipeline,
+            new OrnnSkillPackageBuilder(),
+            formatValidator,
+            client);
+    }
+
+    private static AgentToolContextScope BeginTokenScope() =>
+        AgentToolContextScope.Push(global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "caller-token",
+        }));
+
+    private sealed class StubValidator(
+        string assetKind,
+        params OrnnSkillPublishDiagnostic[] diagnostics) : IOrnnSkillPublishAssetValidator
+    {
+        public string AssetKind { get; } = assetKind;
+
+        public Task<IReadOnlyList<OrnnSkillPublishDiagnostic>> ValidateAsync(
+            OrnnSkillPublishRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<OrnnSkillPublishDiagnostic>>(diagnostics);
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        private readonly Queue<CapturingResponse> _responses;
+
+        public CapturingHandler(params string[] responses)
+            : this(responses.Select(body => new CapturingResponse(body)).ToArray())
+        {
+        }
+
+        public CapturingHandler(params CapturingResponse[] responses)
+        {
+            _responses = new Queue<CapturingResponse>(responses);
+        }
+
+        public List<HttpRequestMessage> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            var response = _responses.Count == 0
+                ? new CapturingResponse("""{ "error": true }""")
+                : _responses.Dequeue();
+            return Task.FromResult(new HttpResponseMessage(response.StatusCode)
+            {
+                Content = new StringContent(response.Body),
+            });
+        }
+    }
+
+    private sealed record CapturingResponse(string Body, HttpStatusCode StatusCode = HttpStatusCode.OK);
+}

--- a/test/Aevatar.Capabilities.Tests/MainnetResponsesEndpointsTests.cs
+++ b/test/Aevatar.Capabilities.Tests/MainnetResponsesEndpointsTests.cs
@@ -535,7 +535,7 @@ public sealed class MainnetResponsesEndpointsTests
 
         tools.Select(static tool => tool.Name)
             .Should()
-            .Equal("use_skill", "ornn_search_skills", "ornn_publish_skill");
+            .Equal("use_skill", "ornn_search_skills", "ornn_publish_skill", "ornn_update_skill");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary / 摘要

修复 #2172：Lark bot 能 discover/create ornn skill 但**不能 update** 已存在的 org-shared skill（同名 re-publish 走 `POST /api/v1/skills` 会 409），缺 by-id 写动词。

- **Old**：`OrnnSkillClient` 只有 search/get + `PublishSkillAsync`(POST=create)；无 PUT/PATCH；LLM 无更新工具。
- **New**：新增 `OrnnSkillClient.UpdateSkillAsync(token, skillId, zipBytes, ct)` → `ProxyRequestBinaryAsync(PUT /api/v1/skills/{id}, application/zip)`；新 `OrnnUpdateSkillTool`（`ornn_update_skill`），复用 publish 的 typed package parse/validate/build/format 流水线，`SideEffectKind="ornn.update.skill"`（mutation），`ApprovalMode.Auto`，required `skill_id` GUID（描述指导：先 search/GET 当前 JSON → 应用整包变更 → 按 id 更新）。

## Scope / 范围

- `OrnnSkillClient.cs`（UpdateSkillAsync，复用 #2174 已合并的 `TryUnwrapNyxIdProxyError` 诚实错误）
- `OrnnUpdateSkillTool.cs`（新）+ `OrnnAgentToolSource.cs`（注册）+ `ServiceCollectionExtensions.cs`（DI）
- 测试：`OrnnUpdateSkillToolTests`（新）+ `OrnnSkillClientTests`（PUT/403/校验）+ `OrnnTestHttpMessageHandler`；`MainnetResponsesEndpointsTests` 工具顺序断言更新（publish 后加 update）

凭证选择/owner fallback 完全交给已合并的 #2174 `ToolCallCredentialPolicyMiddleware`，本工具不做 credential 逻辑。无新增 `IOrnnSkillClient` 接口；无外部仓库改动；无硬编码 skill 名。

## 验证

- `dotnet build aevatar.slnx --nologo`：0 error（controller gate 复核）。
- `dotnet test Ornn.Tests`：156 passed；`Capabilities.Tests --filter MainnetResponsesEndpointsTests`：55 passed。
- `test_stability_guards.sh` + `architecture_guards.sh`：pass。

## Consensus

design-consensus r1 → `consensus:structural`（REST resource semantics + least-authority capability tools）。consensus-loop scoped run（milestone 26 / eanzhao）。基于已合并的 #2174。

Closes #2172

🤖 consensus-loop

⟦AI:AUTO-LOOP⟧
