### PR TITLE
feat(chat): honest-failure guardrail — bot 不得伪造 mutation 成功 #2173

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs
@@ -231,7 +231,8 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
             plan.ToolContext,
             plan.LlmControl,
             workItem.StepState.Round,
-            workItem.StepState.FinalNoToolsStep);
+            workItem.StepState.FinalNoToolsStep,
+            toolReceipts: workItem.StepState.ToolReceipts);
         if (workItem.StepState.FinalNoToolsStep && llmRequest.Tools is { Count: > 0 })
         {
             // Refactor (issue1318/first-slice): Old: unbound sender still saw tool dispatch + unknown

--- a/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
+++ b/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
@@ -183,9 +183,9 @@ Use this playbook when the user asks for a recurring, scheduled, monitored, or o
    - For plain text output, the skill should send a concise digest back to Lark. For Feishu cloud doc output, the skill should create or update a document and return the link.
 
 6. Recover cleanly.
-- Publish failure means the package is wrong; refine and republish.
-- User rejection or edits mean the negotiation is not stable yet; update the card and retry.
-- If the user later wants a different cadence, treat it as a new negotiation for a new schedule rather than pretending the existing schedule changed automatically.
+   - Publish failure means the package is wrong; refine and republish.
+   - User rejection or edits mean the negotiation is not stable yet; update the card and retry.
+   - If the user later wants a different cadence, treat it as a new negotiation for a new schedule rather than pretending the existing schedule changed automatically.
 
 ## Honest Success Rule
 

--- a/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
+++ b/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
@@ -183,9 +183,15 @@ Use this playbook when the user asks for a recurring, scheduled, monitored, or o
    - For plain text output, the skill should send a concise digest back to Lark. For Feishu cloud doc output, the skill should create or update a document and return the link.
 
 6. Recover cleanly.
-   - Publish failure means the package is wrong; refine and republish.
-   - User rejection or edits mean the negotiation is not stable yet; update the card and retry.
-   - If the user later wants a different cadence, treat it as a new negotiation for a new schedule rather than pretending the existing schedule changed automatically.
+- Publish failure means the package is wrong; refine and republish.
+- User rejection or edits mean the negotiation is not stable yet; update the card and retry.
+- If the user later wants a different cadence, treat it as a new negotiation for a new schedule rather than pretending the existing schedule changed automatically.
+
+## Honest Success Rule
+
+- Do not say a definition, format, configuration, schedule, registration, file, publication, or external service was changed unless this turn includes a successful mutating tool result or typed success receipt for that mutation.
+- Read-only checks, searches, observation, trigger/rerun requests, failed tool calls, denied approvals, and pending approvals are not successful mutations.
+- A genuine successful mutating tool receipt is enough evidence to report the completed change.
 
 ### agent_builder (Day One persistent automation lifecycle)
 

--- a/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
@@ -4,6 +4,7 @@
 using Aevatar.AI.Core.Hooks;
 using Aevatar.AI.Core.Middleware;
 using Aevatar.AI.Core.Tools;
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
@@ -316,6 +317,7 @@ public sealed class ChatRuntime
         var lengthRecoveryCount = 0;
         var hasStreamedTextContent = false;
         var skillRecovery = CreateSkillRecoveryOrchestrator(baseRequest);
+        var executedToolOutcomes = new List<ToolOutcomeReplyFact>();
 
         if (skillRecovery.RequiresInitialSearch)
         {
@@ -496,6 +498,7 @@ public sealed class ChatRuntime
                             textToolExecutor.AddTool(textToolState, tc);
                         await foreach (var result in textToolExecutor.GetRemainingResultsAsync(textToolState, runToken))
                         {
+                            executedToolOutcomes.Add(BuildToolOutcomeReplyFact(result, parsed.ToolCalls));
                             if (result.Receipt is not null)
                                 yield return new LLMStreamChunk { ToolReceipt = result.Receipt.Clone() };
                             var toolMsg = ToolCallLoop.BuildToolResultMessage(result.CallId, result.ToolName, result.Result);
@@ -575,6 +578,7 @@ public sealed class ChatRuntime
 
             await foreach (var result in streamingExecutor.GetRemainingResultsAsync(streamingToolState, runToken))
             {
+                executedToolOutcomes.Add(BuildToolOutcomeReplyFact(result, roundResult.ToolCalls));
                 if (result.Receipt is not null)
                     yield return new LLMStreamChunk { ToolReceipt = result.Receipt.Clone() };
                 var toolMsg = ToolCallLoop.BuildToolResultMessage(result.CallId, result.ToolName, result.Result);
@@ -593,7 +597,7 @@ public sealed class ChatRuntime
 
             var finalRequest = new LLMRequest
             {
-                Messages = [..messages],
+                Messages = BuildFinalNoToolsMessages(messages, executedToolOutcomes, toolReceipts: null),
                 RequestId = baseRequest.RequestId,
                 Metadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(baseRequest.Metadata),
                 CallerContext = baseRequest.CallerContext,
@@ -636,6 +640,7 @@ public sealed class ChatRuntime
                     finalToolExecutor.AddTool(finalToolState, tc);
                 await foreach (var result in finalToolExecutor.GetRemainingResultsAsync(finalToolState, runToken))
                 {
+                    executedToolOutcomes.Add(BuildToolOutcomeReplyFact(result, finalParsed.ToolCalls));
                     if (result.Receipt is not null)
                         yield return new LLMStreamChunk { ToolReceipt = result.Receipt.Clone() };
                     var toolMsg = ToolCallLoop.BuildToolResultMessage(result.CallId, result.ToolName, result.Result);
@@ -645,7 +650,7 @@ public sealed class ChatRuntime
 
                 var summaryRequest = new LLMRequest
                 {
-                    Messages = [..messages],
+                    Messages = BuildFinalNoToolsMessages(messages, executedToolOutcomes, toolReceipts: null),
                     RequestId = finalRequest.RequestId,
                     Metadata = finalRequest.Metadata,
                     CallerContext = finalRequest.CallerContext,
@@ -694,6 +699,34 @@ public sealed class ChatRuntime
                 _toolLoop.ToolMiddlewares,
                 requestMetadata: baseRequest.Metadata,
                 toolContext: toolContext ?? AgentToolExecutionContextMapper.FromRequest(baseRequest)));
+
+    private List<ChatMessage> BuildFinalNoToolsMessages(
+        IReadOnlyList<ChatMessage> messages,
+        IReadOnlyList<ToolOutcomeReplyFact> toolOutcomes,
+        IReadOnlyList<AgentToolReceipt>? toolReceipts)
+    {
+        var constraints = ToolOutcomeReplyConstraintBuilder.BuildFinalNoToolsConstraints(toolOutcomes, toolReceipts);
+        if (constraints.Count == 0)
+            return [.. messages];
+
+        return [.. messages, .. constraints];
+    }
+
+    private ToolOutcomeReplyFact BuildToolOutcomeReplyFact(
+        ToolExecutionResult result,
+        IReadOnlyList<ToolCall>? toolCalls)
+    {
+        var matchingCall = toolCalls?.FirstOrDefault(call =>
+            string.Equals(call.Id, result.CallId, StringComparison.Ordinal) ||
+            string.Equals(call.Name, result.ToolName, StringComparison.OrdinalIgnoreCase));
+        var tool = _toolLoop.Tools.Get(result.ToolName)
+                   ?? (matchingCall is null ? null : _toolLoop.Tools.Get(matchingCall.Name));
+        return new ToolOutcomeReplyFact(
+            tool,
+            matchingCall?.ArgumentsJson,
+            Succeeded: !result.IsError,
+            result.Receipt?.Clone());
+    }
 
     private async Task RunStopHookAsync(
         string? finalContent,

--- a/src/Aevatar.AI.Core/Chat/ChatRuntimeStepExecutor.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntimeStepExecutor.cs
@@ -1,3 +1,4 @@
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
@@ -45,12 +46,13 @@ public sealed class ChatRuntimeStepExecutor
         AgentToolExecutionContext? toolContext,
         LLMControlContext? llmControl,
         int round,
-        bool finalNoTools)
+        bool finalNoTools,
+        IReadOnlyList<AgentToolReceipt>? toolReceipts = null)
     {
         var baseRequest = BuildBaseRequest(requestId, metadata, toolContext, llmControl);
         return new LLMRequest
         {
-            Messages = [..messages],
+            Messages = BuildStepMessages(messages, finalNoTools, toolReceipts),
             RequestId = baseRequest.RequestId,
             Metadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(baseRequest.Metadata),
             CallerContext = baseRequest.CallerContext,
@@ -185,6 +187,21 @@ public sealed class ChatRuntimeStepExecutor
         }
 
         return merged;
+    }
+
+    private static List<ChatMessage> BuildStepMessages(
+        IReadOnlyList<ChatMessage> messages,
+        bool finalNoTools,
+        IReadOnlyList<AgentToolReceipt>? toolReceipts)
+    {
+        if (!finalNoTools)
+            return [..messages];
+
+        var constraints = ToolOutcomeReplyConstraintBuilder.BuildFinalNoToolsConstraints(toolOutcomes: null, toolReceipts);
+        if (constraints.Count == 0)
+            return [..messages];
+
+        return [..messages, ..constraints];
     }
 }
 

--- a/src/Aevatar.AI.Core/Tools/ToolOutcomeReplyConstraintBuilder.cs
+++ b/src/Aevatar.AI.Core/Tools/ToolOutcomeReplyConstraintBuilder.cs
@@ -1,0 +1,64 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+
+namespace Aevatar.AI.Core.Tools;
+
+internal static class ToolOutcomeReplyConstraintBuilder
+{
+    internal const string ConstraintText =
+        "System constraint: In this turn, no successful mutating tool execution has been observed. " +
+        "Do not claim that a definition, format, configuration, publication, schedule, registration, file, or external service was changed, updated, saved, applied, published, created, deleted, or otherwise mutated. " +
+        "Read-only operations, status checks, searches, observation, trigger/rerun requests, failed tool calls, denied approvals, and pending approvals are not successful mutations. " +
+        "If the user asked for a mutation, state only what was observed and that the mutation has not been confirmed by a successful mutating tool receipt.";
+
+    internal static IReadOnlyList<ChatMessage> BuildFinalNoToolsConstraints(
+        IReadOnlyList<ToolOutcomeReplyFact>? toolOutcomes,
+        IReadOnlyList<AgentToolReceipt>? toolReceipts)
+    {
+        if (HasSuccessfulMutatingToolOutcome(toolOutcomes) ||
+            HasSuccessfulMutatingReceipt(toolReceipts))
+        {
+            return [];
+        }
+
+        return [ChatMessage.System(ConstraintText)];
+    }
+
+    internal static bool IsMutatingTool(IAgentTool tool, string? argumentsJson)
+    {
+        ArgumentNullException.ThrowIfNull(tool);
+        return !tool.IsReadOnly ||
+               tool.IsDestructive ||
+               !string.IsNullOrWhiteSpace(tool.SideEffectKind) ||
+               tool.RequiresApproval(argumentsJson ?? string.Empty) == true;
+    }
+
+    private static bool HasSuccessfulMutatingToolOutcome(IReadOnlyList<ToolOutcomeReplyFact>? toolOutcomes)
+    {
+        if (toolOutcomes is not { Count: > 0 })
+            return false;
+
+        return toolOutcomes.Any(static outcome =>
+            outcome.Succeeded &&
+            (outcome.Receipt?.Status is null or AgentToolReceiptStatus.Success) &&
+            outcome.Tool is not null &&
+            IsMutatingTool(outcome.Tool, outcome.ArgumentsJson));
+    }
+
+    private static bool HasSuccessfulMutatingReceipt(IReadOnlyList<AgentToolReceipt>? toolReceipts)
+    {
+        if (toolReceipts is not { Count: > 0 })
+            return false;
+
+        return toolReceipts.Any(static receipt =>
+            receipt.Status == AgentToolReceiptStatus.Success &&
+            (receipt.IsDestructive || !string.IsNullOrWhiteSpace(receipt.SideEffectKind)));
+    }
+}
+
+internal readonly record struct ToolOutcomeReplyFact(
+    IAgentTool? Tool,
+    string? ArgumentsJson,
+    bool Succeeded,
+    AgentToolReceipt? Receipt = null);

--- a/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
+++ b/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
@@ -592,6 +592,101 @@ public sealed class ChatRuntimeStreamingBufferTests
     }
 
     [Fact]
+    public async Task ChatStreamAsync_WhenFinalTextToolHasNoMutatingSuccess_ShouldInjectSummaryConstraint()
+    {
+        var provider = new QueuedStreamingProvider(
+        [
+            [
+                new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "tc-initial-read",
+                        Name = "lookup",
+                        ArgumentsJson = "{\"q\":\"initial\"}",
+                    },
+                },
+            ],
+            [
+                new LLMStreamChunk
+                {
+                    DeltaContent = """
+                        <function_calls>
+                        <invoke name="lookup">
+                        <parameter name="q">final</parameter>
+                        </invoke>
+                        </function_calls>
+                        """,
+                },
+            ],
+            [
+                new LLMStreamChunk { DeltaContent = "summary-ready" },
+            ],
+        ]);
+        var tools = new ToolManager();
+        tools.Register(new DelegateTool("lookup", args => $"RESULT:{args}", isReadOnly: true));
+        var runtime = CreateRuntime(provider, tools: tools);
+
+        await foreach (var _ in runtime.ChatStreamAsync("hello", maxToolRounds: 1))
+        {
+        }
+
+        provider.StreamRequests.Should().HaveCount(3);
+        provider.StreamRequests[2].Messages
+            .Where(message => message.Role == "system" &&
+                              message.Content?.Contains("no successful mutating tool execution") == true)
+            .Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task ChatStreamAsync_WhenFinalTextToolHasMutatingSuccess_ShouldNotInjectSummaryConstraint()
+    {
+        var provider = new QueuedStreamingProvider(
+        [
+            [
+                new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "tc-initial-read",
+                        Name = "lookup",
+                        ArgumentsJson = "{\"q\":\"initial\"}",
+                    },
+                },
+            ],
+            [
+                new LLMStreamChunk
+                {
+                    DeltaContent = """
+                        <function_calls>
+                        <invoke name="write_config">
+                        <parameter name="value">new</parameter>
+                        </invoke>
+                        </function_calls>
+                        """,
+                },
+            ],
+            [
+                new LLMStreamChunk { DeltaContent = "summary-ready" },
+            ],
+        ]);
+        var tools = new ToolManager();
+        tools.Register(new DelegateTool("lookup", args => $"RESULT:{args}", isReadOnly: true));
+        tools.Register(new DelegateTool("write_config", args => $"RESULT:{args}"));
+        var runtime = CreateRuntime(provider, tools: tools);
+
+        await foreach (var _ in runtime.ChatStreamAsync("hello", maxToolRounds: 1))
+        {
+        }
+
+        provider.StreamRequests.Should().HaveCount(3);
+        provider.StreamRequests[2].Messages
+            .Where(message => message.Role == "system" &&
+                              message.Content?.Contains("no successful mutating tool execution") == true)
+            .Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task ChatStreamAsync_WhenFinalNoToolsHasNoMutatingSuccess_ShouldInjectEphemeralConstraint()
     {
         var provider = new QueuedStreamingProvider(

--- a/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
+++ b/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using System.Text;
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
@@ -232,7 +233,8 @@ public sealed class ChatRuntimeStreamingBufferTests
             toolContext: null,
             llmControl,
             round: 1,
-            finalNoTools: true);
+            finalNoTools: true,
+            toolReceipts: null);
 
         finalRequest.Tools.Should().BeNull();
         finalRequest.ToolContext!.Request.CallId.Should().Be("req-123:final");
@@ -275,6 +277,65 @@ public sealed class ChatRuntimeStreamingBufferTests
         tool.CapturedContext.ExternalMetadata["safe"].Should().Be("tool-context");
         tool.CapturedContext.ExternalMetadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
         tool.CapturedContext.ExternalMetadata.Should().NotContainKey(LLMRequestMetadataKeys.ModelOverride);
+    }
+
+    [Fact]
+    public void BuildLlmStepRequest_WhenFinalNoToolsWithoutMutatingReceipt_ShouldInjectConstraintWithoutMutatingCallerMessages()
+    {
+        var provider = new RecordingStepProvider();
+        var runtime = CreateRuntime(provider);
+        var executor = runtime.CreateStepExecutor();
+        var messages = new List<ChatMessage>
+        {
+            ChatMessage.System("system"),
+            ChatMessage.User("hello"),
+        };
+
+        var request = executor.BuildLlmStepRequest(
+            messages,
+            "req-final",
+            metadata: null,
+            toolContext: null,
+            llmControl: null,
+            round: 1,
+            finalNoTools: true);
+
+        request.Messages.Should().HaveCount(3);
+        request.Messages.Last().Role.Should().Be("system");
+        request.Messages.Last().Content.Should().Contain("no successful mutating tool execution");
+        messages.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void BuildLlmStepRequest_WhenFinalNoToolsHasMutatingSuccessReceipt_ShouldNotInjectConstraint()
+    {
+        var provider = new RecordingStepProvider();
+        var runtime = CreateRuntime(provider);
+        var executor = runtime.CreateStepExecutor();
+        var messages = new List<ChatMessage>
+        {
+            ChatMessage.System("system"),
+            ChatMessage.User("hello"),
+        };
+
+        var request = executor.BuildLlmStepRequest(
+            messages,
+            "req-final",
+            metadata: null,
+            toolContext: null,
+            llmControl: null,
+            round: 1,
+            finalNoTools: true,
+            toolReceipts:
+            [
+                new AgentToolReceipt
+                {
+                    Status = AgentToolReceiptStatus.Success,
+                    SideEffectKind = "definition.update",
+                },
+            ]);
+
+        request.Messages.Should().BeEquivalentTo(messages);
     }
 
     [Fact]
@@ -528,6 +589,89 @@ public sealed class ChatRuntimeStreamingBufferTests
             m.ToolCalls[0].Name == "lookup" &&
             m.ReasoningContent == "thinking-before-final-text-tool");
         assistantToolCallMessage.ReasoningContent.Should().Be("thinking-before-final-text-tool");
+    }
+
+    [Fact]
+    public async Task ChatStreamAsync_WhenFinalNoToolsHasNoMutatingSuccess_ShouldInjectEphemeralConstraint()
+    {
+        var provider = new QueuedStreamingProvider(
+        [
+            [
+                new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "tc-read",
+                        Name = "lookup",
+                        ArgumentsJson = "{\"q\":\"status\"}",
+                    },
+                },
+            ],
+            [
+                new LLMStreamChunk { DeltaContent = "final-without-mutation" },
+            ],
+            [
+                new LLMStreamChunk { DeltaContent = "second-turn" },
+            ],
+        ]);
+        var tools = new ToolManager();
+        tools.Register(new DelegateTool("lookup", args => $"RESULT:{args}", isReadOnly: true));
+        var runtime = CreateRuntime(provider, tools: tools);
+
+        await foreach (var _ in runtime.ChatStreamAsync("hello", maxToolRounds: 1))
+        {
+        }
+
+        provider.StreamRequests.Should().HaveCount(2);
+        provider.StreamRequests[1].Messages
+            .Where(message => message.Role == "system" &&
+                              message.Content?.Contains("no successful mutating tool execution") == true)
+            .Should().ContainSingle();
+
+        await foreach (var _ in runtime.ChatStreamAsync("next", maxToolRounds: 1))
+        {
+        }
+
+        provider.StreamRequests.Should().HaveCount(3);
+        provider.StreamRequests[2].Messages
+            .Where(message => message.Role == "system" &&
+                              message.Content?.Contains("no successful mutating tool execution") == true)
+            .Should().BeEmpty("the guard is request-local and must not be persisted to history");
+    }
+
+    [Fact]
+    public async Task ChatStreamAsync_WhenFinalNoToolsHasMutatingSuccess_ShouldNotInjectConstraint()
+    {
+        var provider = new QueuedStreamingProvider(
+        [
+            [
+                new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "tc-write",
+                        Name = "write_config",
+                        ArgumentsJson = "{\"value\":\"new\"}",
+                    },
+                },
+            ],
+            [
+                new LLMStreamChunk { DeltaContent = "final-after-mutation" },
+            ],
+        ]);
+        var tools = new ToolManager();
+        tools.Register(new DelegateTool("write_config", args => $"RESULT:{args}"));
+        var runtime = CreateRuntime(provider, tools: tools);
+
+        await foreach (var _ in runtime.ChatStreamAsync("hello", maxToolRounds: 1))
+        {
+        }
+
+        provider.StreamRequests.Should().HaveCount(2);
+        provider.StreamRequests[1].Messages
+            .Where(message => message.Role == "system" &&
+                              message.Content?.Contains("no successful mutating tool execution") == true)
+            .Should().BeEmpty();
     }
 
     [Fact]
@@ -1159,11 +1303,19 @@ public sealed class ChatRuntimeStreamingBufferTests
         public Task InvokeAsync(LLMCallContext context, Func<Task> next) => handler(context, next);
     }
 
-    private sealed class DelegateTool(string name, Func<string, string> execute) : IAgentTool
+    private sealed class DelegateTool(
+        string name,
+        Func<string, string> execute,
+        bool isReadOnly = false,
+        bool isDestructive = false,
+        string sideEffectKind = "") : IAgentTool
     {
         public string Name => name;
         public string Description => "delegate";
         public string ParametersSchema => "{}";
+        public bool IsReadOnly => isReadOnly;
+        public bool IsDestructive => isDestructive;
+        public string SideEffectKind => sideEffectKind;
 
         public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
         {

--- a/test/Aevatar.AI.Tests/NyxIdChatSystemPromptTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatSystemPromptTests.cs
@@ -35,4 +35,15 @@ public class NyxIdChatSystemPromptTests
         prompt.Should().Contain("Do not say it is waiting for remote approval");
         prompt.Should().NotContain("waiting for NyxID approval");
     }
+
+    [Fact]
+    public void Value_ShouldContainHonestSuccessRule()
+    {
+        var prompt = NyxIdChatSystemPrompt.Value;
+
+        prompt.Should().Contain("## Honest Success Rule");
+        prompt.Should().Contain("successful mutating tool result or typed success receipt");
+        prompt.Should().Contain("Read-only checks, searches, observation, trigger/rerun requests");
+        prompt.Should().Contain("genuine successful mutating tool receipt");
+    }
 }

--- a/test/Aevatar.AI.Tests/ToolOutcomeReplyConstraintBuilderTests.cs
+++ b/test/Aevatar.AI.Tests/ToolOutcomeReplyConstraintBuilderTests.cs
@@ -1,0 +1,139 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.Tools;
+using FluentAssertions;
+
+namespace Aevatar.AI.Tests;
+
+public sealed class ToolOutcomeReplyConstraintBuilderTests
+{
+    [Fact]
+    public void BuildFinalNoToolsConstraints_WhenOnlyReadOnlyToolSucceeded_ShouldReturnConstraint()
+    {
+        var constraints = ToolOutcomeReplyConstraintBuilder.BuildFinalNoToolsConstraints(
+            [Succeeded(new StubTool("read", isReadOnly: true))],
+            toolReceipts: null);
+
+        constraints.Should().ContainSingle();
+        constraints[0].Role.Should().Be("system");
+        constraints[0].Content.Should().Contain("no successful mutating tool execution");
+    }
+
+    [Fact]
+    public void BuildFinalNoToolsConstraints_WhenMutatingToolSucceeded_ShouldReturnNone()
+    {
+        var constraints = ToolOutcomeReplyConstraintBuilder.BuildFinalNoToolsConstraints(
+            [Succeeded(new StubTool("write"))],
+            toolReceipts: null);
+
+        constraints.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildFinalNoToolsConstraints_WhenReadOnlyAndMutatingSuccessAreMixed_ShouldReturnNone()
+    {
+        var constraints = ToolOutcomeReplyConstraintBuilder.BuildFinalNoToolsConstraints(
+            [
+                Succeeded(new StubTool("read", isReadOnly: true)),
+                Succeeded(new StubTool("write")),
+            ],
+            toolReceipts: null);
+
+        constraints.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(AgentToolReceiptStatus.Error)]
+    [InlineData(AgentToolReceiptStatus.Denied)]
+    [InlineData(AgentToolReceiptStatus.ApprovalRequired)]
+    public void BuildFinalNoToolsConstraints_WhenMutatingToolDidNotSucceed_ShouldReturnConstraint(
+        AgentToolReceiptStatus status)
+    {
+        var constraints = ToolOutcomeReplyConstraintBuilder.BuildFinalNoToolsConstraints(
+            [
+                new ToolOutcomeReplyFact(
+                    new StubTool("write"),
+                    "{}",
+                    Succeeded: false,
+                    Receipt(status, isDestructive: true)),
+            ],
+            toolReceipts: null);
+
+        constraints.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void BuildFinalNoToolsConstraints_WhenSuccessfulMutatingReceiptExists_ShouldReturnNone()
+    {
+        var constraints = ToolOutcomeReplyConstraintBuilder.BuildFinalNoToolsConstraints(
+            toolOutcomes: null,
+            toolReceipts:
+            [
+                Receipt(AgentToolReceiptStatus.Success, sideEffectKind: "definition.update"),
+            ]);
+
+        constraints.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildFinalNoToolsConstraints_WhenOnlyFailedMutatingReceiptsExist_ShouldReturnConstraint()
+    {
+        var constraints = ToolOutcomeReplyConstraintBuilder.BuildFinalNoToolsConstraints(
+            toolOutcomes: null,
+            toolReceipts:
+            [
+                Receipt(AgentToolReceiptStatus.Error, sideEffectKind: "definition.update"),
+                Receipt(AgentToolReceiptStatus.Denied, isDestructive: true),
+            ]);
+
+        constraints.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void IsMutatingTool_ShouldUseReadOnlyDestructiveSideEffectAndApprovalPredicate()
+    {
+        ToolOutcomeReplyConstraintBuilder.IsMutatingTool(new StubTool("read", isReadOnly: true), "{}")
+            .Should().BeFalse();
+        ToolOutcomeReplyConstraintBuilder.IsMutatingTool(new StubTool("default-write"), "{}")
+            .Should().BeTrue();
+        ToolOutcomeReplyConstraintBuilder.IsMutatingTool(new StubTool("destroy", isReadOnly: true, isDestructive: true), "{}")
+            .Should().BeTrue();
+        ToolOutcomeReplyConstraintBuilder.IsMutatingTool(new StubTool("side-effect", isReadOnly: true, sideEffectKind: "publish"), "{}")
+            .Should().BeTrue();
+        ToolOutcomeReplyConstraintBuilder.IsMutatingTool(new StubTool("approval", isReadOnly: true, requiresApproval: true), "{}")
+            .Should().BeTrue();
+    }
+
+    private static ToolOutcomeReplyFact Succeeded(IAgentTool tool) =>
+        new(tool, "{}", Succeeded: true);
+
+    private static AgentToolReceipt Receipt(
+        AgentToolReceiptStatus status,
+        bool isDestructive = false,
+        string sideEffectKind = "") =>
+        new()
+        {
+            ToolName = "tool",
+            Status = status,
+            IsDestructive = isDestructive,
+            SideEffectKind = sideEffectKind,
+        };
+
+    private sealed class StubTool(
+        string name,
+        bool isReadOnly = false,
+        bool isDestructive = false,
+        string sideEffectKind = "",
+        bool? requiresApproval = null) : IAgentTool
+    {
+        public string Name => name;
+        public string Description => name;
+        public string ParametersSchema => "{}";
+        public bool IsReadOnly => isReadOnly;
+        public bool IsDestructive => isDestructive;
+        public string SideEffectKind => sideEffectKind;
+        public bool? RequiresApproval(string argumentsJson) => requiresApproval;
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
+            Task.FromResult("{}");
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunReplyGenerationExecutorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunReplyGenerationExecutorTests.cs
@@ -1,0 +1,164 @@
+using System.Runtime.CompilerServices;
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.Chat;
+using Aevatar.AI.Core.Tools;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.Channel.Abstractions;
+using Aevatar.GAgents.Channel.Runtime;
+using Aevatar.GAgents.NyxidChat;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+public sealed class AgentRunReplyGenerationExecutorTests
+{
+    [Fact]
+    public async Task BuildLlmStepContinuation_WhenFinalNoToolsHasNoSuccessfulMutatingReceipt_ShouldPassReceiptsToCoreConstraint()
+    {
+        var provider = new RecordingProvider();
+        var executor = CreateExecutor(provider);
+        var workItem = BuildFinalNoToolsWorkItem();
+
+        await executor.BuildLlmStepContinuationAsync(workItem, CancellationToken.None);
+
+        var request = provider.Requests.Should().ContainSingle().Subject;
+        request.Tools.Should().BeNull();
+        request.Messages
+            .Where(message => message.Role == "system" &&
+                              message.Content?.Contains("no successful mutating tool execution") == true)
+            .Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task BuildLlmStepContinuation_WhenFinalNoToolsHasSuccessfulMutatingReceipt_ShouldSuppressCoreConstraint()
+    {
+        var provider = new RecordingProvider();
+        var executor = CreateExecutor(provider);
+        var workItem = BuildFinalNoToolsWorkItem(
+            new AgentToolReceipt
+            {
+                Status = AgentToolReceiptStatus.Success,
+                SideEffectKind = "definition.update",
+            });
+
+        await executor.BuildLlmStepContinuationAsync(workItem, CancellationToken.None);
+
+        var request = provider.Requests.Should().ContainSingle().Subject;
+        request.Tools.Should().BeNull();
+        request.Messages
+            .Where(message => message.Role == "system" &&
+                              message.Content?.Contains("no successful mutating tool execution") == true)
+            .Should().BeEmpty();
+    }
+
+    private static AgentRunReplyGenerationExecutor CreateExecutor(RecordingProvider provider)
+    {
+        var runtime = new ChatRuntime(
+            providerFactory: () => provider,
+            history: new ChatHistory(),
+            toolLoop: new ToolCallLoop(new ToolManager()),
+            hooks: null,
+            requestBuilder: static () => new LLMRequest { Messages = [] });
+        var plan = new AgentRunReplyStepPlan(
+            runtime.CreateStepExecutor(),
+            new Dictionary<string, string>(),
+            LLMControlContext.Empty,
+            AgentToolExecutionContext.Empty,
+            InitialMessages: [],
+            MaxToolRounds: 1,
+            DisableTools: true);
+
+        return new AgentRunReplyGenerationExecutor(
+            Substitute.For<IActorDispatchPort>(),
+            new StaticStepPlanReplyGenerator(plan),
+            interactiveReplyCollector: null,
+            relayOptions: null,
+            NullLogger<AgentRunReplyGenerationExecutor>.Instance);
+    }
+
+    private static AgentRunReplyStepExecutionRequest BuildFinalNoToolsWorkItem(params AgentToolReceipt[] receipts)
+    {
+        var request = new NeedsLlmReplyEvent
+        {
+            RunId = "run-1",
+            CorrelationId = "corr-1",
+            TargetActorId = "conversation-actor",
+            Activity = new ChatActivity
+            {
+                Id = "activity-1",
+                Content = new MessageContent { Text = "finish" },
+            },
+        };
+        var stepState = new AgentRunReplyStepState
+        {
+            RunId = "run-1",
+            CorrelationId = "corr-1",
+            TargetActorId = "conversation-actor",
+            Attempt = 1,
+            NextStepIndex = 2,
+            Round = 1,
+            MaxToolRounds = 1,
+            FinalNoToolsStep = true,
+        };
+        stepState.Messages.Add(AgentRunReplyStepMappers.ToProto(ChatMessage.User("hello")));
+        stepState.Messages.Add(AgentRunReplyStepMappers.ToProto(ChatMessage.Assistant("partial")));
+        stepState.ToolReceipts.AddRange(receipts.Select(receipt => receipt.Clone()));
+
+        return new AgentRunReplyStepExecutionRequest(
+            "run-1",
+            "channel-agent-run:run-1",
+            Attempt: 1,
+            StepIndex: 2,
+            request,
+            stepState);
+    }
+
+    private sealed class RecordingProvider : ILLMProvider
+    {
+        public string Name => "recording-provider";
+        public List<LLMRequest> Requests { get; } = [];
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            Requests.Add(request);
+            yield return new LLMStreamChunk { DeltaContent = "final" };
+            await Task.Yield();
+        }
+    }
+
+    private sealed class StaticStepPlanReplyGenerator(AgentRunReplyStepPlan plan) : IAgentRunStepConversationReplyGenerator
+    {
+        public Task<AgentRunReplyStepPlan> BuildStepPlanAsync(
+            ChatActivity activity,
+            IReadOnlyDictionary<string, string> metadata,
+            LLMControlContext? llmControl,
+            AgentToolExecutionContext? toolContext,
+            IReadOnlyList<ConversationHistoryEntry>? priorHistory,
+            ChatAttachmentInputContext? attachmentContext,
+            bool forceDisableTools,
+            CancellationToken ct) =>
+            Task.FromResult(plan);
+
+        public Task<ConversationReplyResult> GenerateReplyAsync(
+            ChatActivity activity,
+            IReadOnlyDictionary<string, string> metadata,
+            LLMControlContext? llmControl,
+            AgentToolExecutionContext? toolContext,
+            IStreamingReplySink? streamingSink,
+            CancellationToken ct) =>
+            throw new NotSupportedException("Per-step tests drive BuildLlmStepContinuationAsync only.");
+
+        public Task<ConversationReplyResult> GenerateReplyAsync(
+            ChatActivity activity,
+            IReadOnlyDictionary<string, string> metadata,
+            IStreamingReplySink? streamingSink,
+            CancellationToken ct) =>
+            throw new NotSupportedException("Per-step tests drive BuildLlmStepContinuationAsync only.");
+    }
+}


### PR DESCRIPTION
## Summary / 摘要

修复 #2173：bot 对未真正执行的 mutation 伪造成功语（"已应用"）——把 `run_agent` 重跑误当格式变更，最危险的失败模式（绿勾"已完成"但实际没变）。

- **Old**：final LLM reply 不受本轮成功 mutating tool 事实约束，可在仅 read/trigger/无成功 mutating 活动后声称变更成功。
- **New**：mutation 成功语必须基于本轮成功 mutating tool outcome/receipt。新增 Core internal `ToolOutcomeReplyConstraintBuilder`；本轮无成功 mutating tool 时，Core（`ChatRuntime` / `ChatRuntimeStepExecutor`）在 final no-tools request 注入一条**不持久化**的 system constraint（诚实说明未变更、re-trigger/read 不是变更、不得声称已改/已更新/已应用）；有成功 mutating tool 时允许 success copy。`AgentRunReplyGenerationExecutor` 仅**透传** `StepState.ToolReceipts` 进 Core（无分类、无措辞）。

## Scope / 范围

`ToolOutcomeReplyConstraintBuilder.cs`（新，Core internal）+ `ChatRuntime.cs` + `ChatRuntimeStepExecutor.cs`（注入）+ `AgentRunReplyGenerationExecutor.cs`（pass-through-only）+ `system-prompt.md`（规则强化）+ 4 个测试。mutation 判定复用 #2174 谓词；**无 free-text NLP、无硬编码 `run_agent`/`ornn_*`**；不改 ToolCallLoop/proto/外部仓库。

## 验证

- `dotnet build aevatar.slnx --nologo`：0 error（controller gate 复核）。
- `dotnet test`：AI.Tests 914 / ChannelRuntime.Tests 1329，全 0 fail。
- `test_stability_guards.sh` + `architecture_guards.sh`：pass。

## Consensus

design-consensus **r5** `consensus:minimal`（command/result provenance + honest ACK；5 轮逐层收敛到 Core typed gate + pass-through）。consensus-loop scoped run（milestone 26 / eanzhao）。配合 #2172（真实 update 能力）+ #2174（诚实权限错误）三件套闭环。

Closes #2173

🤖 consensus-loop

⟦AI:AUTO-LOOP⟧
