### PR TITLE
feat(workflow): compensate in-flight side-effecting steps on saga trigger (ADR-0034) for issue 2125

### DIFF
--- a/docs/adr/0034-workflow-saga-compensation-protocol.md
+++ b/docs/adr/0034-workflow-saga-compensation-protocol.md
@@ -378,3 +378,7 @@ string. A non-compensating run carries `UNSPECIFIED`; there is no distinct
 `running` saga state (the run-level status remains `running` while
 `saga_status = UNSPECIFIED`). The authoritative proto enum is the live contract;
 current operational vocabulary lives in `docs/canon/workflow-runtime.md`.
+
+## Update — 2026-06-16 (saga v1.1, #2125)
+
+Saga v1.1 adds provisional ledger accounting for in-flight side-effecting steps. `tool_call`, `connector_call`, and `secure_connector_call` steps that declare `compensation` now persist a run-owned `CompensableStepDispatchedEvent` before dispatch, creating a `PROVISIONAL` ledger entry. Success confirms it as `CONFIRMED` and fills captured output; `WorkflowStepFailureOutcome.CALLEE_CONFIRMED` drops the provisional entry; `OUTCOME_UNCERTAIN` keeps it and enters the existing reverse compensation walk. The #2126 phase deadline/budget must count provisional `OUTCOME_UNCERTAIN` entries the same as confirmed entries; dropped `CALLEE_CONFIRMED` entries do not count.

--- a/docs/canon/workflow-primitives.md
+++ b/docs/canon/workflow-primitives.md
@@ -95,8 +95,10 @@ steps:
 
 Runtime semantics:
 
-- A successful step with a valid `compensation` declaration is added to the run actor's `compensable_ledger`.
-- If a later terminal failure occurs while the ledger is non-empty, compensation runs in reverse ledger order.
+- `tool_call`, `connector_call`, and `secure_connector_call` are the v1.1 side-effecting primitive set. When one declares `compensation`, dispatch first records a `PROVISIONAL` ledger entry before the external side-effect boundary.
+- A successful completion confirms a matching provisional entry as `CONFIRMED` and fills captured output. If no dispatch event exists, legacy success still appends one `CONFIRMED` entry.
+- A callee-confirmed failure removes the matching provisional entry. Timeout, force-fail, or stop-to-failure paths set `failure_outcome = OUTCOME_UNCERTAIN`, keep the provisional entry, and let compensation treat undoing a not-applied side effect as a safe no-op.
+- If a later terminal failure occurs while the ledger is non-empty, compensation runs in reverse ledger order over both `PROVISIONAL` and `CONFIRMED` entries.
 - The typed `WorkflowSagaStatus` moves `WORKFLOW_SAGA_STATUS_UNSPECIFIED -> WORKFLOW_SAGA_STATUS_COMPENSATING -> WORKFLOW_SAGA_STATUS_COMPENSATED_FAILED` when every compensation step succeeds (a non-compensating run stays `UNSPECIFIED`; there is no distinct `running` saga status).
 - If a compensation step fails, the run moves to `WORKFLOW_SAGA_STATUS_COMPENSATION_DEAD_LETTER` and emits `WorkflowCompensationFailedEvent` with the failed compensation step, remaining uncompensated count, and error.
 - Compensation dispatch uses self continuation. Stale or duplicate compensation completions are rejected by execution id and do not advance the cursor.
@@ -381,7 +383,7 @@ steps:
 - 常用参数：`tool`。
 - 工具输出若是 JSON object 且步骤成功，运行时会把顶层字段镜像为 `steps.<step_id>.json.<field>` 变量，供后续 `switch` / `conditional` / `while` 分支使用。
 - 当前 step 的 typed input file refs 会随 `WorkflowToolExecutionRequest` 传给 workflow tool。工具若同时支持 arguments `fileRef` 与当前输入文件上下文，显式 `fileRef` 优先；未显式选择时，只能在恰好 1 个当前输入文件时 fallback，多文件必须 fail closed 并要求调用方显式选择。
-- `tool_call` side effect 是 at-least-once。workflow actor 在 dispatch seam 解析并持久化 typed `idempotency_key`，审批 replay / crash replay 会复用同一个 key 并传给 tool invocation envelope；该 key 只用于 callee-side 幂等建议，不表示 engine-side dedup 或 exactly-once。
+- `tool_call` side effect 是 at-least-once。workflow actor 在 dispatch seam 解析并持久化 typed `idempotency_key`；若 step 声明 `compensation`，同一 seam 先写入 `PROVISIONAL` compensation ledger，再发布 tool invocation envelope。审批 replay / crash replay 会复用同一个 key；该 key 只用于 callee-side 幂等建议，不表示 engine-side dedup 或 exactly-once。
 - 需要人工审批的 direct `tool_call` 不把 `ApprovalPending` 当作失败完成。`ToolCallModule` 将原始 tool name、arguments、`execution_id`、`tool_call_id`、`approval_request_id` 持久化到 workflow actor state，并发布 `WorkflowSuspendedEvent.tool_approval`。该 suspension 只暴露审批对账键，不暴露工具参数。
 - tool approval resume 使用 `WorkflowResumedEvent.tool_approval` nested payload，仅携带 `execution_id`、`tool_call_id`、`approval_request_id`。客户端不得在 resume payload 中提交 tool name 或 arguments；approved replay 必须从 actor pending state 读取原始工具和参数，并向 tool middleware 传递 typed `ToolApprovalGrant`。
 - resume 对账按 `run_id + step_id + execution_id + tool_call_id + approval_request_id` 精确匹配。approved 后重放原工具；rejected / timed out / non-pending termination fail closed 并清理 pending state；stale 或 mismatched resume event 直接忽略。
@@ -636,7 +638,7 @@ steps:
 
 - 作用：调用外部 connector（HTTP/CLI/MCP 等），支持重试和降级策略。
 - 常用参数：`connector`、`operation`、`retry`、`timeout_ms`、`optional`、`on_missing`、`on_error`。
-- `connector_call` side effect 是 at-least-once。workflow actor 按 logical run id + step id + logical attempt 解析并持久化 typed `idempotency_key`，connector physical retry / pending replay 复用同一个 key；HTTP connector 会在 key 非空时发送 `Idempotency-Key` header，其他 connector 可按自身边界使用或忽略。该 key 不提供 engine-side dedup 或 exactly-once。
+- `connector_call` / `secure_connector_call` side effect 是 at-least-once。workflow actor 按 logical run id + step id + logical attempt 解析并持久化 typed `idempotency_key`；若 step 声明 `compensation`，同一 seam 先写入 `PROVISIONAL` compensation ledger，再发布 connector request。connector physical retry / pending replay 复用同一个 key；HTTP connector 会在 key 非空时发送 `Idempotency-Key` header，其他 connector 可按自身边界使用或忽略。该 key 不提供 engine-side dedup 或 exactly-once。
 - Ergonomic 说明（统一归一化到 `connector_call`）：
   - `http_get`/`http_post`/`http_put`/`http_delete`：自动补 `method=GET/POST/PUT/DELETE`（若未显式提供）。
   - `mcp_call`：若只写 `tool` 且未写 `operation/action`，会自动补 `operation=<tool>`。

--- a/docs/canon/workflow-runtime.md
+++ b/docs/canon/workflow-runtime.md
@@ -309,9 +309,11 @@ POST /api/chat { prompt, workflow?, workflowYaml?, source? }
 
 ### Saga 补偿生命周期
 
-Workflow step 可以通过 `compensation` 声明一个已存在的 step id。静态校验阶段会解析该目标，引用不存在的补偿步骤会被拒绝。运行时中，成功完成且声明了补偿的业务 step 会进入 `compensable_ledger`，ledger 归 `WorkflowRunGAgent` 持有，是 run actor 的权威状态。
+Workflow step 可以通过 `compensation` 声明一个已存在的 step id。静态校验阶段会解析该目标，引用不存在的补偿步骤会被拒绝。运行时中，`tool_call`、`connector_call`、`secure_connector_call` 这三个 side-effecting primitive 在 dispatch 前会由 `WorkflowRunGAgent` 持久化 `CompensableStepDispatchedEvent`，先写入 `PROVISIONAL` ledger 项；其他 primitive 即使声明 compensation，也只在成功完成后按 legacy 路径写入 `CONFIRMED` ledger 项。`compensable_ledger` 归 `WorkflowRunGAgent` 持有，是 run actor 的权威状态。
 
-当后续 step 发生终止失败且 ledger 非空时，run 不直接提交 `WorkflowCompletedEvent(success=false)`。`WorkflowExecutionKernel` 先请求 run actor 开启补偿相位，run actor 按 ledger 反向顺序提交 `CompensationRequestEvent`，再通过 self continuation 派发对应补偿 step。补偿 step 完成后以 `CompensationStepCompletedEvent` 回到 run actor，由 actor 校验 `run_id + compensation_step_id + execution_id`，拒绝陈旧或重复完成事件。
+成功完成会把匹配的 `PROVISIONAL` ledger 项确认成 `CONFIRMED` 并补齐 captured output；没有 provisional 项的 legacy success 仍追加一条 `CONFIRMED` ledger。失败完成通过 typed `WorkflowStepFailureOutcome` 对账：`CALLEE_CONFIRMED`（含默认 `UNSPECIFIED`）删除匹配 provisional，表示 callee 已确认没有可补偿副作用；`OUTCOME_UNCERTAIN` 保留 provisional，timeout / force-fail / stop-to-failure 这类中断按“副作用可能已发生”处理。
+
+当后续 step 发生终止失败且 ledger 非空时，run 不直接提交 `WorkflowCompletedEvent(success=false)`。`WorkflowExecutionKernel` 先请求 run actor 开启补偿相位，run actor 按 ledger 反向顺序提交 `CompensationRequestEvent`，再通过 self continuation 派发对应补偿 step。`PROVISIONAL` 和 `CONFIRMED` 项使用同一条 LIFO compensation walk；provisional 的 captured output 可为空，补偿 idempotency key 保持稳定，撤销未生效副作用必须是安全 no-op。补偿 step 完成后以 `CompensationStepCompletedEvent` 回到 run actor，由 actor 校验 `run_id + compensation_step_id + execution_id`，拒绝陈旧或重复完成事件。
 
 Saga 状态由强类型枚举 `WorkflowSagaStatus`（`workflow_execution_messages.proto`）表达，生命周期为：
 
@@ -320,7 +322,7 @@ WORKFLOW_SAGA_STATUS_UNSPECIFIED -> WORKFLOW_SAGA_STATUS_COMPENSATING -> WORKFLO
 WORKFLOW_SAGA_STATUS_UNSPECIFIED -> WORKFLOW_SAGA_STATUS_COMPENSATING -> WORKFLOW_SAGA_STATUS_COMPENSATION_DEAD_LETTER
 ```
 
-- `UNSPECIFIED`：非补偿阶段（run 仍是普通 `running` 运行态），成功的 compensable step 按完成顺序写入 ledger；saga_status 没有独立的 `running` 取值。
+- `UNSPECIFIED`：非补偿阶段（run 仍是普通 `running` 运行态），provisional/confirmed compensable step 按 dispatch/完成顺序写入 ledger；saga_status 没有独立的 `running` 取值。
 - `COMPENSATING`：终止失败已转入补偿相位，`compensation_cursor` 指向当前待补偿 ledger 项。
 - `COMPENSATED_FAILED`：所有补偿按反向顺序成功，随后发布失败的 `WorkflowCompletedEvent`，表示原业务 run 失败但补偿已完成。
 - `COMPENSATION_DEAD_LETTER`：某个补偿 step 失败或补偿耗尽，run actor 提交 `WorkflowCompensationFailedEvent`，记录失败补偿 step、剩余未补偿数量和错误；此状态不再走 on_error fallback，也不会静默丢弃。
@@ -663,7 +665,7 @@ steps:
 
 ### Q3：模块失败会怎样？
 
-取决于模块实现、步骤配置和 saga ledger。`WorkflowExecutionKernel` 收到 `Success=false` 的 `StepCompletedEvent` 后，若当前 run 有非空 `compensable_ledger`，先进入补偿相位；补偿全部成功后才以 `WorkflowCompletedEvent(Success=false)` 结束。没有 compensable ledger 时，失败直接发布 `WorkflowCompletedEvent(Success=false)`。支持 retry/on_error 的 step 会先按对应策略处理，未被策略接管的终止失败才触发上述逻辑。
+取决于模块实现、步骤配置和 saga ledger。`WorkflowExecutionKernel` 收到 `Success=false` 的 `StepCompletedEvent` 后，先用 `failure_outcome` 对账 provisional ledger；若当前 run 仍有非空 `compensable_ledger`，再进入补偿相位；补偿全部成功后才以 `WorkflowCompletedEvent(Success=false)` 结束。没有 compensable ledger 时，失败直接发布 `WorkflowCompletedEvent(Success=false)`。支持 retry/on_error 的 step 会先按对应策略处理，未被策略接管的终止失败才触发上述逻辑。
 
 ### Q4：怎么新增一种步骤类型？
 

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -29,6 +29,12 @@ enum WorkflowSagaStatus {
   WORKFLOW_SAGA_STATUS_COMPENSATION_DEAD_LETTER = 3;
 }
 
+enum WorkflowStepFailureOutcome {
+  WORKFLOW_STEP_FAILURE_OUTCOME_UNSPECIFIED = 0;
+  WORKFLOW_STEP_FAILURE_OUTCOME_CALLEE_CONFIRMED = 1;
+  WORKFLOW_STEP_FAILURE_OUTCOME_OUTCOME_UNCERTAIN = 2;
+}
+
 message WorkflowFileRef {
   string file_id = 1;
   string artifact_id = 2;
@@ -370,6 +376,7 @@ message StepCompletedEvent {
   string execution_id = 12;
   WorkflowUsageMetrics usage = 13;
   VoteAgreementDecision vote_agreement_decision = 14;
+  WorkflowStepFailureOutcome failure_outcome = 15;
 }
 message SubWorkflowInvokeRequestedEvent
 {
@@ -849,6 +856,15 @@ message StaleStepCompletionRejectedEvent
   string run_id = 2;
   string expected_execution_id = 3;
   string received_execution_id = 4;
+}
+
+message CompensableStepDispatchedEvent
+{
+  string run_id = 1;
+  string step_id = 2;
+  string compensation_step_id = 3;
+  string idempotency_key = 4;
+  int64 dispatched_at_unix_ms = 5;
 }
 
 message CompensationRequestEvent

--- a/src/workflow/Aevatar.Workflow.Core/Execution/IWorkflowExecutionStateHost.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/IWorkflowExecutionStateHost.cs
@@ -56,18 +56,12 @@ internal interface IWorkflowExecutionStateHost
 
     Task<WorkflowCompensationTransitionResult> TryStartCompensationAsync(
         WorkflowCompletedEvent terminalFailure,
-        CancellationToken ct = default);
-
-    Task<WorkflowCompensationTransitionResult> TryStartCompensationAsync(
-        WorkflowCompletedEvent terminalFailure,
         StepCompletedEvent? terminalStep,
-        CancellationToken ct = default) =>
-        TryStartCompensationAsync(terminalFailure, ct);
+        CancellationToken ct = default);
 
     Task RecordCompensableStepDispatchAsync(
         CompensableStepDispatchedEvent evt,
-        CancellationToken ct = default) =>
-        Task.CompletedTask;
+        CancellationToken ct = default);
 
     Task<WorkflowCompensationTransitionResult> RecordCompensationStepCompletionAsync(
         CompensationStepCompletedEvent completion,

--- a/src/workflow/Aevatar.Workflow.Core/Execution/IWorkflowExecutionStateHost.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/IWorkflowExecutionStateHost.cs
@@ -58,6 +58,17 @@ internal interface IWorkflowExecutionStateHost
         WorkflowCompletedEvent terminalFailure,
         CancellationToken ct = default);
 
+    Task<WorkflowCompensationTransitionResult> TryStartCompensationAsync(
+        WorkflowCompletedEvent terminalFailure,
+        StepCompletedEvent? terminalStep,
+        CancellationToken ct = default) =>
+        TryStartCompensationAsync(terminalFailure, ct);
+
+    Task RecordCompensableStepDispatchAsync(
+        CompensableStepDispatchedEvent evt,
+        CancellationToken ct = default) =>
+        Task.CompletedTask;
+
     Task<WorkflowCompensationTransitionResult> RecordCompensationStepCompletionAsync(
         CompensationStepCompletedEvent completion,
         CancellationToken ct = default);

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
@@ -236,6 +236,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
             RunId = runId,
             Success = false,
             Error = $"TIMEOUT after {evt.TimeoutMs}ms",
+            FailureOutcome = WorkflowStepFailureOutcome.OutcomeUncertain,
         }, TopologyAudience.Self, ct);
 
         state.TimeoutsByStepId.Remove(stepId);
@@ -394,6 +395,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                         Error = evt.Error,
                     },
                     state,
+                    evt,
                     ct);
                 return;
             }
@@ -421,6 +423,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                     Error = evt.Error,
                 },
                 state,
+                evt,
                 ct);
             return;
         }
@@ -454,6 +457,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                         Error = $"invalid next_step '{directNextStepId}' from step '{current.Id}'",
                     },
                     state,
+                    null,
                     ct);
                 return;
             }
@@ -680,9 +684,10 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
         IWorkflowExecutionContext ctx,
         WorkflowCompletedEvent terminalFailure,
         WorkflowExecutionKernelState state,
+        StepCompletedEvent? terminalStep,
         CancellationToken ct)
     {
-        var result = await _stateHost.TryStartCompensationAsync(terminalFailure, ct);
+        var result = await _stateHost.TryStartCompensationAsync(terminalFailure, terminalStep, ct);
         switch (result.Status)
         {
             case WorkflowCompensationTransitionStatus.Started:
@@ -1096,6 +1101,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                 await SaveStateAsync(state, ctx, ct);
             }
 
+            await RecordCompensableStepDispatchAsync(step, idempotency, ctx, ct);
             await ctx.PublishAsync(request, TopologyAudience.Self, ct);
         }
         catch
@@ -1116,6 +1122,31 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
 
         state.CurrentStepDispatchPending = false;
         await SaveStateAsync(state, ctx, ct);
+    }
+
+    private async Task RecordCompensableStepDispatchAsync(
+        StepDefinition step,
+        WorkflowStepIdempotencyState idempotency,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var compensationStepId = step.Compensation?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(compensationStepId) ||
+            !WorkflowPrimitiveCatalog.IsSideEffectingPrimitive(step.Type))
+        {
+            return;
+        }
+
+        await _stateHost.RecordCompensableStepDispatchAsync(
+            new CompensableStepDispatchedEvent
+            {
+                RunId = NormalizeRunId(_stateHost.RunId),
+                StepId = step.Id,
+                CompensationStepId = compensationStepId,
+                IdempotencyKey = idempotency.IdempotencyKey ?? string.Empty,
+                DispatchedAtUnixMs = 0,
+            },
+            ct);
     }
 
     private WorkflowStepIdempotencyState ResolveAndPersistStepIdempotency(

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
@@ -1101,7 +1101,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                 await SaveStateAsync(state, ctx, ct);
             }
 
-            await RecordCompensableStepDispatchAsync(step, idempotency, ctx, ct);
+            await RecordCompensableStepDispatchAsync(step, idempotency, ct);
             await ctx.PublishAsync(request, TopologyAudience.Self, ct);
         }
         catch
@@ -1127,7 +1127,6 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
     private async Task RecordCompensableStepDispatchAsync(
         StepDefinition step,
         WorkflowStepIdempotencyState idempotency,
-        IWorkflowExecutionContext ctx,
         CancellationToken ct)
     {
         var compensationStepId = step.Compensation?.Trim() ?? string.Empty;

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowPrimitiveCatalog.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowPrimitiveCatalog.cs
@@ -109,6 +109,15 @@ public static class WorkflowPrimitiveCatalog
                knownCanonicalStepTypes.Contains(canonical);
     }
 
+    public static bool IsSideEffectingPrimitive(string stepType)
+    {
+        var canonical = ToCanonicalType(stepType);
+        // Saga v1.1 provisions only the current external-dispatch primitives; future primitives can opt in explicitly.
+        return string.Equals(canonical, "tool_call", StringComparison.Ordinal) ||
+               string.Equals(canonical, "connector_call", StringComparison.Ordinal) ||
+               string.Equals(canonical, "secure_connector_call", StringComparison.Ordinal);
+    }
+
     public static Dictionary<string, string> CanonicalizeStepTypeParameters(
         IReadOnlyDictionary<string, string>? parameters)
     {

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
@@ -180,8 +180,22 @@ public sealed class WorkflowRunGAgent
             ct);
     }
 
+    Task IWorkflowExecutionStateHost.RecordCompensableStepDispatchAsync(
+        CompensableStepDispatchedEvent evt,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+        return PersistDomainEventAsync(evt, ct);
+    }
+
     async Task<WorkflowCompensationTransitionResult> IWorkflowExecutionStateHost.TryStartCompensationAsync(
         WorkflowCompletedEvent terminalFailure,
+        CancellationToken ct) =>
+        await ((IWorkflowExecutionStateHost)this).TryStartCompensationAsync(terminalFailure, null, ct);
+
+    async Task<WorkflowCompensationTransitionResult> IWorkflowExecutionStateHost.TryStartCompensationAsync(
+        WorkflowCompletedEvent terminalFailure,
+        StepCompletedEvent? terminalStep,
         CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(terminalFailure);
@@ -189,16 +203,17 @@ public sealed class WorkflowRunGAgent
         if (IsCompensating(State))
             return BuildCurrentCompensationResult(WorkflowCompensationTransitionStatus.AlreadyCompensating);
 
-        if (State.CompensableLedger.Count == 0)
+        var compensationState = BuildCompensationStartState(State, terminalStep);
+        if (compensationState.CompensableLedger.Count == 0)
             return EmptyCompensationResult(WorkflowCompensationTransitionStatus.NoCompensableLedger);
 
-        var cursor = State.CompensableLedger.Count - 1;
-        var entry = State.CompensableLedger[cursor];
+        var cursor = compensationState.CompensableLedger.Count - 1;
+        var entry = compensationState.CompensableLedger[cursor];
         var executionId = Guid.NewGuid().ToString("N");
         await PersistDomainEventAsync(new CompensationRequestEvent
         {
             RunId = string.IsNullOrWhiteSpace(terminalFailure.RunId) ? RunId : WorkflowRunIdNormalizer.Normalize(terminalFailure.RunId),
-            FailedStepId = ResolveLastFailedStepId(State),
+            FailedStepId = ResolveLastFailedStepId(compensationState),
             CompensationStepId = entry.CompensationStepId,
             IdempotencyKey = entry.IdempotencyKey,
             CapturedOutput = entry.CapturedOutput,
@@ -1003,6 +1018,7 @@ public sealed class WorkflowRunGAgent
             .On<WorkflowRunExecutionContextClearedEvent>(ApplyWorkflowRunExecutionContextCleared)
             .On<WorkflowExecutionStateUpsertedEvent>(ApplyWorkflowExecutionStateUpserted)
             .On<WorkflowExecutionStateClearedEvent>(ApplyWorkflowExecutionStateCleared)
+            .On<CompensableStepDispatchedEvent>(ApplyCompensableStepDispatched)
             .On<StepCompletedEvent>(ApplyStepCompleted)
             .On<CompensationRequestEvent>(ApplyCompensationRequest)
             .On<CompensationStepCompletedEvent>(ApplyCompensationStepCompleted)
@@ -1224,10 +1240,10 @@ public sealed class WorkflowRunGAgent
     private WorkflowRunState ApplyStepCompleted(WorkflowRunState current, StepCompletedEvent evt)
     {
         var next = current.Clone();
-        if (!evt.Success)
+        var stepId = evt.StepId?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(stepId))
             return next;
 
-        var stepId = evt.StepId?.Trim() ?? string.Empty;
         var workflow = ResolveWorkflowForTransition(current);
         var step = string.IsNullOrWhiteSpace(stepId) ? null : workflow?.GetStep(stepId);
         var compensationStepId = step?.Compensation?.Trim() ?? string.Empty;
@@ -1235,6 +1251,27 @@ public sealed class WorkflowRunGAgent
             return next;
 
         var idempotencyKey = ResolveStepCompletionIdempotency(evt, current, stepId);
+        if (!evt.Success)
+        {
+            var failureOutcome = NormalizeFailureOutcome(evt.FailureOutcome);
+            if (failureOutcome == WorkflowStepFailureOutcome.CalleeConfirmed)
+                RemoveMatchingProvisionalLedgerEntries(next, stepId, compensationStepId, idempotencyKey);
+
+            return next;
+        }
+
+        var matchingProvisional = next.CompensableLedger.FirstOrDefault(entry =>
+            IsProvisional(entry) &&
+            string.Equals(entry.StepId, stepId, StringComparison.Ordinal) &&
+            string.Equals(entry.CompensationStepId, compensationStepId, StringComparison.Ordinal) &&
+            string.Equals(entry.IdempotencyKey, idempotencyKey, StringComparison.Ordinal));
+        if (matchingProvisional != null)
+        {
+            matchingProvisional.CapturedOutput = evt.Output ?? string.Empty;
+            matchingProvisional.LedgerStatus = CompensableLedgerEntryStatus.Confirmed;
+            return next;
+        }
+
         if (next.CompensableLedger.Any(entry =>
                 string.Equals(entry.StepId, stepId, StringComparison.Ordinal) &&
                 string.Equals(entry.CompensationStepId, compensationStepId, StringComparison.Ordinal) &&
@@ -1250,6 +1287,49 @@ public sealed class WorkflowRunGAgent
             IdempotencyKey = idempotencyKey,
             CapturedOutput = evt.Output ?? string.Empty,
             CommittedAtUnixMs = 0,
+            LedgerStatus = CompensableLedgerEntryStatus.Confirmed,
+        });
+        return next;
+    }
+
+    private WorkflowRunState BuildCompensationStartState(WorkflowRunState current, StepCompletedEvent? terminalStep)
+    {
+        if (terminalStep == null || terminalStep.Success)
+            return current;
+
+        if (NormalizeFailureOutcome(terminalStep.FailureOutcome) == WorkflowStepFailureOutcome.OutcomeUncertain)
+            return current;
+
+        return ApplyStepCompleted(current, terminalStep);
+    }
+
+    private static WorkflowRunState ApplyCompensableStepDispatched(
+        WorkflowRunState current,
+        CompensableStepDispatchedEvent evt)
+    {
+        var next = current.Clone();
+        var stepId = evt.StepId?.Trim() ?? string.Empty;
+        var compensationStepId = evt.CompensationStepId?.Trim() ?? string.Empty;
+        var idempotencyKey = evt.IdempotencyKey ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(stepId) || string.IsNullOrWhiteSpace(compensationStepId))
+            return next;
+
+        if (next.CompensableLedger.Any(entry =>
+                string.Equals(entry.StepId, stepId, StringComparison.Ordinal) &&
+                string.Equals(entry.CompensationStepId, compensationStepId, StringComparison.Ordinal) &&
+                string.Equals(entry.IdempotencyKey, idempotencyKey, StringComparison.Ordinal)))
+        {
+            return next;
+        }
+
+        next.CompensableLedger.Add(new CompletedStepLedgerEntry
+        {
+            StepId = stepId,
+            CompensationStepId = compensationStepId,
+            IdempotencyKey = idempotencyKey,
+            CapturedOutput = string.Empty,
+            CommittedAtUnixMs = Math.Max(0, evt.DispatchedAtUnixMs),
+            LedgerStatus = CompensableLedgerEntryStatus.Provisional,
         });
         return next;
     }
@@ -1434,6 +1514,35 @@ public sealed class WorkflowRunGAgent
             return 0;
 
         return Math.Clamp(cursor + 1, 0, ledgerCount);
+    }
+
+    private static WorkflowStepFailureOutcome NormalizeFailureOutcome(WorkflowStepFailureOutcome failureOutcome) =>
+        failureOutcome == WorkflowStepFailureOutcome.OutcomeUncertain
+            ? WorkflowStepFailureOutcome.OutcomeUncertain
+            : WorkflowStepFailureOutcome.CalleeConfirmed;
+
+    private static bool IsProvisional(CompletedStepLedgerEntry entry) =>
+        entry.LedgerStatus == CompensableLedgerEntryStatus.Provisional;
+
+    private static void RemoveMatchingProvisionalLedgerEntries(
+        WorkflowRunState state,
+        string stepId,
+        string compensationStepId,
+        string idempotencyKey)
+    {
+        for (var i = state.CompensableLedger.Count - 1; i >= 0; i--)
+        {
+            var entry = state.CompensableLedger[i];
+            if (!IsProvisional(entry))
+                continue;
+
+            if (string.Equals(entry.StepId, stepId, StringComparison.Ordinal) &&
+                string.Equals(entry.CompensationStepId, compensationStepId, StringComparison.Ordinal) &&
+                string.Equals(entry.IdempotencyKey, idempotencyKey, StringComparison.Ordinal))
+            {
+                state.CompensableLedger.RemoveAt(i);
+            }
+        }
     }
 
     private bool TryGetLedgerEntry(int cursor, [NotNullWhen(true)] out CompletedStepLedgerEntry? entry)

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
@@ -190,11 +190,6 @@ public sealed class WorkflowRunGAgent
 
     async Task<WorkflowCompensationTransitionResult> IWorkflowExecutionStateHost.TryStartCompensationAsync(
         WorkflowCompletedEvent terminalFailure,
-        CancellationToken ct) =>
-        await ((IWorkflowExecutionStateHost)this).TryStartCompensationAsync(terminalFailure, null, ct);
-
-    async Task<WorkflowCompensationTransitionResult> IWorkflowExecutionStateHost.TryStartCompensationAsync(
-        WorkflowCompletedEvent terminalFailure,
         StepCompletedEvent? terminalStep,
         CancellationToken ct)
     {

--- a/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
+++ b/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
@@ -220,6 +220,13 @@ enum SubWorkflowInvocationHandoffPhase
   SUB_WORKFLOW_INVOCATION_HANDOFF_PHASE_START_DISPATCHED = 6;
 }
 
+enum CompensableLedgerEntryStatus
+{
+  COMPENSABLE_LEDGER_ENTRY_STATUS_UNSPECIFIED = 0;
+  COMPENSABLE_LEDGER_ENTRY_STATUS_CONFIRMED = 1;
+  COMPENSABLE_LEDGER_ENTRY_STATUS_PROVISIONAL = 2;
+}
+
 message WorkflowRuntimeCallbackLeaseState
 {
   string actor_id = 1;
@@ -668,4 +675,5 @@ message CompletedStepLedgerEntry
   string idempotency_key = 3;
   string captured_output = 4;
   int64 committed_at_unix_ms = 5;
+  CompensableLedgerEntryStatus ledger_status = 6;
 }

--- a/test/Aevatar.Integration.Tests/TestDoubles/TestEventHandlerContext.cs
+++ b/test/Aevatar.Integration.Tests/TestDoubles/TestEventHandlerContext.cs
@@ -323,13 +323,24 @@ internal sealed class TestAgent(string id, string? runId = null) : IAgent, IWork
         return Task.CompletedTask;
     }
 
-    public Task<WorkflowCompensationTransitionResult> TryStartCompensationAsync(
+    Task<WorkflowCompensationTransitionResult> IWorkflowExecutionStateHost.TryStartCompensationAsync(
         WorkflowCompletedEvent terminalFailure,
-        CancellationToken ct = default)
+        StepCompletedEvent? terminalStep,
+        CancellationToken ct)
     {
         _ = terminalFailure;
+        _ = terminalStep;
         ct.ThrowIfCancellationRequested();
         return Task.FromResult(NoCompensableLedger());
+    }
+
+    Task IWorkflowExecutionStateHost.RecordCompensableStepDispatchAsync(
+        CompensableStepDispatchedEvent evt,
+        CancellationToken ct)
+    {
+        _ = evt;
+        ct.ThrowIfCancellationRequested();
+        return Task.CompletedTask;
     }
 
     public Task<WorkflowCompensationTransitionResult> RecordCompensationStepCompletionAsync(
@@ -413,13 +424,24 @@ internal sealed class TestWorkflowRunAgent(string id, string runId) : IAgent, IW
         return Task.CompletedTask;
     }
 
-    public Task<WorkflowCompensationTransitionResult> TryStartCompensationAsync(
+    Task<WorkflowCompensationTransitionResult> IWorkflowExecutionStateHost.TryStartCompensationAsync(
         WorkflowCompletedEvent terminalFailure,
-        CancellationToken ct = default)
+        StepCompletedEvent? terminalStep,
+        CancellationToken ct)
     {
         _ = terminalFailure;
+        _ = terminalStep;
         ct.ThrowIfCancellationRequested();
         return Task.FromResult(NoCompensableLedger());
+    }
+
+    Task IWorkflowExecutionStateHost.RecordCompensableStepDispatchAsync(
+        CompensableStepDispatchedEvent evt,
+        CancellationToken ct)
+    {
+        _ = evt;
+        ct.ThrowIfCancellationRequested();
+        return Task.CompletedTask;
     }
 
     public Task<WorkflowCompensationTransitionResult> RecordCompensationStepCompletionAsync(

--- a/test/Aevatar.Workflow.Core.Tests/Execution/IdempotentStepExecutionTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/IdempotentStepExecutionTests.cs
@@ -1149,13 +1149,24 @@ public sealed class IdempotentStepExecutionTests
             return Task.CompletedTask;
         }
 
-        public Task<WorkflowCompensationTransitionResult> TryStartCompensationAsync(
+        Task<WorkflowCompensationTransitionResult> IWorkflowExecutionStateHost.TryStartCompensationAsync(
             WorkflowCompletedEvent terminalFailure,
-            CancellationToken ct = default)
+            StepCompletedEvent? terminalStep,
+            CancellationToken ct)
         {
             _ = terminalFailure;
+            _ = terminalStep;
             ct.ThrowIfCancellationRequested();
             return Task.FromResult(NoCompensableLedger());
+        }
+
+        Task IWorkflowExecutionStateHost.RecordCompensableStepDispatchAsync(
+            CompensableStepDispatchedEvent evt,
+            CancellationToken ct)
+        {
+            _ = evt;
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
         }
 
         public Task<WorkflowCompensationTransitionResult> RecordCompensationStepCompletionAsync(

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionContextAdapterTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionContextAdapterTests.cs
@@ -360,13 +360,24 @@ public sealed class WorkflowExecutionContextAdapterTests
             return Task.CompletedTask;
         }
 
-        public Task<WorkflowCompensationTransitionResult> TryStartCompensationAsync(
+        Task<WorkflowCompensationTransitionResult> IWorkflowExecutionStateHost.TryStartCompensationAsync(
             WorkflowCompletedEvent terminalFailure,
-            CancellationToken ct = default)
+            StepCompletedEvent? terminalStep,
+            CancellationToken ct)
         {
             _ = terminalFailure;
+            _ = terminalStep;
             ct.ThrowIfCancellationRequested();
             return Task.FromResult(NoCompensableLedger());
+        }
+
+        Task IWorkflowExecutionStateHost.RecordCompensableStepDispatchAsync(
+            CompensableStepDispatchedEvent evt,
+            CancellationToken ct)
+        {
+            _ = evt;
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
         }
 
         public Task<WorkflowCompensationTransitionResult> RecordCompensationStepCompletionAsync(
@@ -431,13 +442,24 @@ public sealed class WorkflowExecutionContextAdapterTests
             return Task.CompletedTask;
         }
 
-        public Task<WorkflowCompensationTransitionResult> TryStartCompensationAsync(
+        Task<WorkflowCompensationTransitionResult> IWorkflowExecutionStateHost.TryStartCompensationAsync(
             WorkflowCompletedEvent terminalFailure,
-            CancellationToken ct = default)
+            StepCompletedEvent? terminalStep,
+            CancellationToken ct)
         {
             _ = terminalFailure;
+            _ = terminalStep;
             ct.ThrowIfCancellationRequested();
             return Task.FromResult(NoCompensableLedger());
+        }
+
+        Task IWorkflowExecutionStateHost.RecordCompensableStepDispatchAsync(
+            CompensableStepDispatchedEvent evt,
+            CancellationToken ct)
+        {
+            _ = evt;
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
         }
 
         public Task<WorkflowCompensationTransitionResult> RecordCompensationStepCompletionAsync(

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
@@ -384,13 +384,24 @@ public sealed class WorkflowExecutionRuntimeContextTests
             return Task.CompletedTask;
         }
 
-        public Task<WorkflowCompensationTransitionResult> TryStartCompensationAsync(
+        Task<WorkflowCompensationTransitionResult> IWorkflowExecutionStateHost.TryStartCompensationAsync(
             WorkflowCompletedEvent terminalFailure,
-            CancellationToken ct = default)
+            StepCompletedEvent? terminalStep,
+            CancellationToken ct)
         {
             _ = terminalFailure;
+            _ = terminalStep;
             ct.ThrowIfCancellationRequested();
             return Task.FromResult(NoCompensableLedger());
+        }
+
+        Task IWorkflowExecutionStateHost.RecordCompensableStepDispatchAsync(
+            CompensableStepDispatchedEvent evt,
+            CancellationToken ct)
+        {
+            _ = evt;
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
         }
 
         public Task<WorkflowCompensationTransitionResult> RecordCompensationStepCompletionAsync(
@@ -479,13 +490,24 @@ public sealed class WorkflowExecutionRuntimeContextTests
             return Task.CompletedTask;
         }
 
-        public Task<WorkflowCompensationTransitionResult> TryStartCompensationAsync(
+        Task<WorkflowCompensationTransitionResult> IWorkflowExecutionStateHost.TryStartCompensationAsync(
             WorkflowCompletedEvent terminalFailure,
-            CancellationToken ct = default)
+            StepCompletedEvent? terminalStep,
+            CancellationToken ct)
         {
             _ = terminalFailure;
+            _ = terminalStep;
             ct.ThrowIfCancellationRequested();
             return Task.FromResult(NoCompensableLedger());
+        }
+
+        Task IWorkflowExecutionStateHost.RecordCompensableStepDispatchAsync(
+            CompensableStepDispatchedEvent evt,
+            CancellationToken ct)
+        {
+            _ = evt;
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
         }
 
         public Task<WorkflowCompensationTransitionResult> RecordCompensationStepCompletionAsync(

--- a/test/Aevatar.Workflow.Core.Tests/Modules/RuntimeCallbackEventizationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/RuntimeCallbackEventizationTests.cs
@@ -1445,13 +1445,24 @@ public class RuntimeCallbackEventizationTests
             return Task.CompletedTask;
         }
 
-        public Task<WorkflowCompensationTransitionResult> TryStartCompensationAsync(
+        Task<WorkflowCompensationTransitionResult> IWorkflowExecutionStateHost.TryStartCompensationAsync(
             WorkflowCompletedEvent terminalFailure,
-            CancellationToken ct = default)
+            StepCompletedEvent? terminalStep,
+            CancellationToken ct)
         {
             _ = terminalFailure;
+            _ = terminalStep;
             ct.ThrowIfCancellationRequested();
             return Task.FromResult(NoCompensableLedger());
+        }
+
+        Task IWorkflowExecutionStateHost.RecordCompensableStepDispatchAsync(
+            CompensableStepDispatchedEvent evt,
+            CancellationToken ct)
+        {
+            _ = evt;
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
         }
 
         public Task<WorkflowCompensationTransitionResult> RecordCompensationStepCompletionAsync(

--- a/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleApprovalTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleApprovalTests.cs
@@ -347,13 +347,24 @@ public sealed class ToolCallModuleApprovalTests
         public Task ClearExecutionStateAsync(string scopeKey, CancellationToken ct = default) =>
             ClearStateAsync(scopeKey, ct);
 
-        public Task<WorkflowCompensationTransitionResult> TryStartCompensationAsync(
+        Task<WorkflowCompensationTransitionResult> IWorkflowExecutionStateHost.TryStartCompensationAsync(
             WorkflowCompletedEvent terminalFailure,
-            CancellationToken ct = default)
+            StepCompletedEvent? terminalStep,
+            CancellationToken ct)
         {
             _ = terminalFailure;
+            _ = terminalStep;
             ct.ThrowIfCancellationRequested();
             return Task.FromResult(NoCompensableLedger());
+        }
+
+        Task IWorkflowExecutionStateHost.RecordCompensableStepDispatchAsync(
+            CompensableStepDispatchedEvent evt,
+            CancellationToken ct)
+        {
+            _ = evt;
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
         }
 
         public Task<WorkflowCompensationTransitionResult> RecordCompensationStepCompletionAsync(

--- a/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
@@ -454,13 +454,24 @@ public sealed class ToolCallModuleContextTests
         public Task ClearExecutionStateAsync(string scopeKey, CancellationToken ct = default) =>
             ClearStateAsync(scopeKey, ct);
 
-        public Task<WorkflowCompensationTransitionResult> TryStartCompensationAsync(
+        Task<WorkflowCompensationTransitionResult> IWorkflowExecutionStateHost.TryStartCompensationAsync(
             WorkflowCompletedEvent terminalFailure,
-            CancellationToken ct = default)
+            StepCompletedEvent? terminalStep,
+            CancellationToken ct)
         {
             _ = terminalFailure;
+            _ = terminalStep;
             ct.ThrowIfCancellationRequested();
             return Task.FromResult(NoCompensableLedger());
+        }
+
+        Task IWorkflowExecutionStateHost.RecordCompensableStepDispatchAsync(
+            CompensableStepDispatchedEvent evt,
+            CancellationToken ct)
+        {
+            _ = evt;
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
         }
 
         public Task<WorkflowCompensationTransitionResult> RecordCompensationStepCompletionAsync(

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowLoopModuleExpressionEvaluationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowLoopModuleExpressionEvaluationTests.cs
@@ -479,13 +479,24 @@ public class WorkflowLoopModuleExpressionEvaluationTests
             return Task.CompletedTask;
         }
 
-        public Task<WorkflowCompensationTransitionResult> TryStartCompensationAsync(
+        Task<WorkflowCompensationTransitionResult> IWorkflowExecutionStateHost.TryStartCompensationAsync(
             WorkflowCompletedEvent terminalFailure,
-            CancellationToken ct = default)
+            StepCompletedEvent? terminalStep,
+            CancellationToken ct)
         {
             _ = terminalFailure;
+            _ = terminalStep;
             ct.ThrowIfCancellationRequested();
             return Task.FromResult(NoCompensableLedger());
+        }
+
+        Task IWorkflowExecutionStateHost.RecordCompensableStepDispatchAsync(
+            CompensableStepDispatchedEvent evt,
+            CancellationToken ct)
+        {
+            _ = evt;
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
         }
 
         public Task<WorkflowCompensationTransitionResult> RecordCompensationStepCompletionAsync(

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRuntimeModuleBranchTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRuntimeModuleBranchTests.cs
@@ -1216,13 +1216,24 @@ public sealed class WorkflowRuntimeModuleBranchTests
         public Task ClearExecutionStateAsync(string scopeKey, CancellationToken ct = default) =>
             ClearStateAsync(scopeKey, ct);
 
-        public Task<WorkflowCompensationTransitionResult> TryStartCompensationAsync(
+        Task<WorkflowCompensationTransitionResult> IWorkflowExecutionStateHost.TryStartCompensationAsync(
             WorkflowCompletedEvent terminalFailure,
-            CancellationToken ct = default)
+            StepCompletedEvent? terminalStep,
+            CancellationToken ct)
         {
             _ = terminalFailure;
+            _ = terminalStep;
             ct.ThrowIfCancellationRequested();
             return Task.FromResult(NoCompensableLedger());
+        }
+
+        Task IWorkflowExecutionStateHost.RecordCompensableStepDispatchAsync(
+            CompensableStepDispatchedEvent evt,
+            CancellationToken ct)
+        {
+            _ = evt;
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
         }
 
         public Task<WorkflowCompensationTransitionResult> RecordCompensationStepCompletionAsync(

--- a/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowPrimitiveCatalogTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowPrimitiveCatalogTests.cs
@@ -26,4 +26,21 @@ public sealed class WorkflowPrimitiveCatalogTests
         WorkflowPrimitiveCatalog.ToCanonicalType("publish").Should().Be("emit");
         WorkflowPrimitiveCatalog.BuiltInCanonicalTypes.Should().Contain("notify");
     }
+
+    [Fact]
+    public void IsSideEffectingPrimitive_ShouldOnlyIncludeSagaV11ExternalDispatchPrimitives()
+    {
+        new[] { "tool_call", "connector_call", "secure_connector_call", "bridge_call", "http_post" }
+            .Should()
+            .OnlyContain(stepType => WorkflowPrimitiveCatalog.IsSideEffectingPrimitive(stepType));
+
+        new[]
+            {
+                "llm_call", "evaluate", "reflect", "emit", "notify", "workflow_call",
+                "dynamic_workflow", "lease", "human_input", "human_approval", "wait_signal",
+                "transform", "assign", "retrieve_facts", "cache",
+            }
+            .Should()
+            .OnlyContain(stepType => !WorkflowPrimitiveCatalog.IsSideEffectingPrimitive(stepType));
+    }
 }

--- a/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentSagaCompensationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentSagaCompensationTests.cs
@@ -21,6 +21,116 @@ namespace Aevatar.Workflow.Core.Tests;
 public sealed class WorkflowRunGAgentSagaCompensationTests
 {
     [Fact]
+    public async Task InFlightSideEffectingCompensableTimeout_ShouldDispatchProvisionalCompensation()
+    {
+        var harness = await CreateStartedRunAsync(InFlightCompensationWorkflowYaml());
+        var request = StepRequests(harness.Publisher, "create_order").Single();
+        var timeout = ScheduledTimeouts(harness.Publisher)
+            .Should()
+            .ContainSingle(x => x.Event is WorkflowStepTimeoutFiredEvent)
+            .Subject;
+        harness.Publisher.Published.Clear();
+
+        await harness.Agent.HandleEventAsync(SelfEnvelope(
+            harness.RunId,
+            new WorkflowStepTimeoutFiredEvent
+            {
+                RunId = harness.RunId,
+                StepId = "create_order",
+                TimeoutMs = 500,
+            },
+            MetadataFor(timeout)));
+
+        harness.Agent.State.CompensableLedger
+            .Should()
+            .ContainSingle()
+            .Which.Should().BeEquivalentTo(new CompletedStepLedgerEntry
+            {
+                StepId = "create_order",
+                CompensationStepId = "cancel_order",
+                IdempotencyKey = request.IdempotencyKey,
+                CapturedOutput = string.Empty,
+                LedgerStatus = CompensableLedgerEntryStatus.Provisional,
+            }, options => options.Excluding(x => x.CommittedAtUnixMs));
+
+        var compensation = CompensationRequests(harness.Publisher).Should().ContainSingle().Subject;
+        compensation.CompensationStepId.Should().Be("cancel_order");
+        compensation.IdempotencyKey.Should().Be(request.IdempotencyKey);
+        compensation.CapturedOutput.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CalleeConfirmedFailureAfterProvisionalDispatch_ShouldDropLedgerAndNotCompensate()
+    {
+        var harness = await CreateStartedRunAsync(InFlightCompensationWorkflowYaml());
+        var request = StepRequests(harness.Publisher, "create_order").Single();
+        harness.Agent.State.CompensableLedger.Should().ContainSingle()
+            .Which.LedgerStatus.Should().Be(CompensableLedgerEntryStatus.Provisional);
+        harness.Publisher.Published.Clear();
+
+        await harness.Agent.HandleEventAsync(SelfEnvelope(harness.RunId, new StepCompletedEvent
+        {
+            RunId = harness.RunId,
+            StepId = "create_order",
+            Success = false,
+            Error = "callee rejected cleanly",
+            ExecutionId = request.ExecutionId,
+            FailureOutcome = WorkflowStepFailureOutcome.CalleeConfirmed,
+        }));
+
+        harness.Agent.State.CompensableLedger.Should().BeEmpty();
+        CompensationRequests(harness.Publisher).Should().BeEmpty();
+        CommittedEvents<WorkflowCompensationFailedEvent>(harness.CommittedPublisher).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SuccessfulCompletionAfterProvisionalDispatch_ShouldConfirmSingleLedgerEntry()
+    {
+        var harness = await CreateStartedRunAsync(InFlightCompensationWorkflowYaml());
+        var request = StepRequests(harness.Publisher, "create_order").Single();
+        harness.Agent.State.CompensableLedger.Should().ContainSingle()
+            .Which.LedgerStatus.Should().Be(CompensableLedgerEntryStatus.Provisional);
+        harness.Publisher.Published.Clear();
+
+        await harness.Agent.HandleEventAsync(SelfEnvelope(harness.RunId, new StepCompletedEvent
+        {
+            RunId = harness.RunId,
+            StepId = "create_order",
+            Success = true,
+            Output = """{"orderId":"order-1"}""",
+            ExecutionId = request.ExecutionId,
+        }));
+
+        harness.Agent.State.CompensableLedger.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new CompletedStepLedgerEntry
+            {
+                StepId = "create_order",
+                CompensationStepId = "cancel_order",
+                IdempotencyKey = request.IdempotencyKey,
+                CapturedOutput = """{"orderId":"order-1"}""",
+                LedgerStatus = CompensableLedgerEntryStatus.Confirmed,
+            }, options => options.Excluding(x => x.CommittedAtUnixMs));
+    }
+
+    [Fact]
+    public async Task LegacySuccessfulCompletionWithoutDispatchEvent_ShouldAppendConfirmedLedgerEntry()
+    {
+        var harness = await CreateStartedRunAsync(LegacyCompensationWorkflowYaml());
+
+        await CompleteStepAsync(harness, "create_order", "order-output");
+
+        harness.Agent.State.CompensableLedger.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new CompletedStepLedgerEntry
+            {
+                StepId = "create_order",
+                CompensationStepId = "cancel_order",
+                IdempotencyKey = $"{harness.RunId}:create_order:1",
+                CapturedOutput = "order-output",
+                LedgerStatus = CompensableLedgerEntryStatus.Confirmed,
+            }, options => options.Excluding(x => x.CommittedAtUnixMs));
+    }
+
+    [Fact]
     public async Task TerminalFailure_WithCompensableLedger_ShouldDispatchCompensationsInReverseOrder()
     {
         var harness = await CreateStartedRunAsync(SagaWorkflowYaml());
@@ -445,6 +555,7 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
     {
         eventStore ??= new RecordingEventStore();
         var committedHook = new RecordingCommittedStatePublicationHook();
+        var callbackScheduler = new RecordingRuntimeCallbackScheduler();
         var topologyPublisher = new RecordingEventPublisher(runId)
         {
             AutoReplaySelfPublished = autoReplaySelfPublished,
@@ -457,7 +568,7 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
         {
             EventSourcingBehaviorFactory = new DefaultEventSourcingBehaviorFactory<WorkflowRunState>(eventStore),
             EventPublisher = topologyPublisher,
-            Services = new TestServiceProvider(new NoopRuntimeCallbackScheduler(), committedHook),
+            Services = new TestServiceProvider(callbackScheduler, committedHook),
             Logger = NullLogger.Instance,
         };
         SetAgentId(agent, runId);
@@ -476,7 +587,7 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
             }));
         }
 
-        return new RunHarness(agent, runId, eventStore, committedHook, topologyPublisher);
+        return new RunHarness(agent, runId, eventStore, committedHook, topologyPublisher, callbackScheduler);
     }
 
     private static IReadOnlyList<CompensationRequestEvent> CompensationRequests(RecordingEventPublisher publisher) =>
@@ -484,6 +595,15 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
             .Where(x => x.Event is CompensationRequestEvent)
             .Select(x => (CompensationRequestEvent)x.Event)
             .ToArray();
+
+    private static IReadOnlyList<StepRequestEvent> StepRequests(RecordingEventPublisher publisher, string stepId) =>
+        publisher.Published
+            .Where(x => x.Event is StepRequestEvent requestEvent && requestEvent.StepId == stepId)
+            .Select(x => (StepRequestEvent)x.Event)
+            .ToArray();
+
+    private static IReadOnlyList<ScheduledCallback> ScheduledTimeouts(RecordingEventPublisher publisher) =>
+        publisher.CallbackScheduler.ScheduledCallbacks.ToArray();
 
     private static IReadOnlyList<(TEvent Event, TopologyAudience Audience)> PublishedEvents<TEvent>(
         RecordingEventPublisher publisher)
@@ -500,20 +620,41 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
             .Select(x => x.StateEvent.EventData.Unpack<TEvent>())
             .ToArray();
 
-    private static EventEnvelope SelfEnvelope(string runId, IMessage payload) =>
-        EnvelopeFrom(runId, payload);
+    private static EventEnvelope SelfEnvelope(
+        string runId,
+        IMessage payload,
+        EnvelopeCallbackContext? callback = null) =>
+        EnvelopeFrom(runId, payload, callback);
 
-    private static EventEnvelope EnvelopeFrom(string publisherActorId, IMessage payload) =>
+    private static EventEnvelope EnvelopeFrom(
+        string publisherActorId,
+        IMessage payload,
+        EnvelopeCallbackContext? callback = null) =>
         new()
         {
             Id = Guid.NewGuid().ToString("N"),
             Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
             Payload = Any.Pack(payload),
             Route = EnvelopeRouteSemantics.CreateTopologyPublication(publisherActorId, TopologyAudience.Self),
+            Runtime = callback == null
+                ? null
+                : new EnvelopeRuntime
+                {
+                    Callback = callback.Clone(),
+                },
             Propagation = new EnvelopePropagation
             {
                 CorrelationId = Guid.NewGuid().ToString("N"),
             },
+        };
+
+    private static EnvelopeCallbackContext MetadataFor(ScheduledCallback callback) =>
+        new()
+        {
+            CallbackId = callback.CallbackId,
+            Generation = callback.Generation,
+            SlotEpoch = callback.SlotEpoch,
+            FiredAtUnixTimeMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
         };
 
     private static string SagaWorkflowYaml() =>
@@ -533,6 +674,31 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
             type: transform
           - id: refund_payment
             type: transform
+          - id: cancel_order
+            type: transform
+        """;
+
+    private static string InFlightCompensationWorkflowYaml() =>
+        """
+        name: wf_2097
+        roles: []
+        steps:
+          - id: create_order
+            type: connector_call
+            timeout_ms: 500
+            compensation: cancel_order
+          - id: cancel_order
+            type: connector_call
+        """;
+
+    private static string LegacyCompensationWorkflowYaml() =>
+        """
+        name: wf_2097
+        roles: []
+        steps:
+          - id: create_order
+            type: transform
+            compensation: cancel_order
           - id: cancel_order
             type: transform
         """;
@@ -599,7 +765,8 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
         string RunId,
         RecordingEventStore EventStore,
         RecordingCommittedStatePublicationHook CommittedPublisher,
-        RecordingEventPublisher Publisher);
+        RecordingEventPublisher Publisher,
+        RecordingRuntimeCallbackScheduler CallbackScheduler);
 
     private sealed class EmptyWorkflowModulePack : IWorkflowModulePack
     {
@@ -630,6 +797,9 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
 
         public WorkflowRunGAgent Agent { get; set; } = null!;
 
+        public RecordingRuntimeCallbackScheduler CallbackScheduler =>
+            (RecordingRuntimeCallbackScheduler)((TestServiceProvider)Agent.Services).Scheduler;
+
         public async Task PublishAsync<T>(
             T evt,
             TopologyAudience audience,
@@ -654,6 +824,12 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
             where T : IMessage =>
             Task.CompletedTask;
     }
+
+    private sealed record ScheduledCallback(
+        string CallbackId,
+        long Generation,
+        int SlotEpoch,
+        IMessage Event);
 
     private sealed class RecordingCommittedStatePublicationHook : ICommittedStatePublicationHook
     {
@@ -730,15 +906,17 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
     }
 
     private sealed class TestServiceProvider(
-        NoopRuntimeCallbackScheduler scheduler,
+        IActorRuntimeCallbackScheduler scheduler,
         RecordingCommittedStatePublicationHook committedHook) : IServiceProvider
     {
+        public IActorRuntimeCallbackScheduler Scheduler { get; } = scheduler;
+
         public object? GetService(System.Type serviceType)
         {
             if (serviceType == typeof(IEnumerable<IGAgentExecutionHook>))
                 return Array.Empty<IGAgentExecutionHook>();
             if (serviceType == typeof(IActorRuntimeCallbackScheduler))
-                return scheduler;
+                return Scheduler;
             if (serviceType == typeof(IEnumerable<ICommittedStatePublicationHook>))
                 return new ICommittedStatePublicationHook[] { committedHook };
 
@@ -746,25 +924,35 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
         }
     }
 
-    private sealed class NoopRuntimeCallbackScheduler : IActorRuntimeCallbackScheduler
+    private sealed class RecordingRuntimeCallbackScheduler : IActorRuntimeCallbackScheduler
     {
+        public List<ScheduledCallback> ScheduledCallbacks { get; } = [];
+
         public Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
             RuntimeCallbackTimeoutRequest request,
-            CancellationToken ct = default) =>
-            Task.FromResult(new RuntimeCallbackLease(
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            var generation = ScheduledCallbacks.Count(x => x.CallbackId == request.CallbackId) + 1;
+            var slotEpoch = request.TriggerEnvelope.Runtime?.Callback?.SlotEpoch ?? 0;
+            var evt = request.TriggerEnvelope.Payload?.Unpack<WorkflowStepTimeoutFiredEvent>()
+                      ?? throw new InvalidOperationException("Expected scheduled timeout payload.");
+            ScheduledCallbacks.Add(new ScheduledCallback(request.CallbackId, generation, slotEpoch, evt));
+            var lease = new RuntimeCallbackLease(
                 request.ActorId,
                 request.CallbackId,
-                1,
-                RuntimeCallbackBackend.InMemory));
+                generation,
+                RuntimeCallbackBackend.InMemory)
+            {
+                SlotEpoch = slotEpoch,
+            };
+            return Task.FromResult(lease);
+        }
 
         public Task<RuntimeCallbackLease> ScheduleTimerAsync(
             RuntimeCallbackTimerRequest request,
             CancellationToken ct = default) =>
-            Task.FromResult(new RuntimeCallbackLease(
-                request.ActorId,
-                request.CallbackId,
-                1,
-                RuntimeCallbackBackend.InMemory));
+            throw new NotSupportedException("Saga compensation tests do not use durable timers.");
 
         public Task CancelAsync(RuntimeCallbackLease lease, CancellationToken ct = default) =>
             Task.CompletedTask;

--- a/test/Aevatar.Workflow.Core.Tests/WorkflowSagaContractTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/WorkflowSagaContractTests.cs
@@ -23,6 +23,7 @@ public sealed class WorkflowSagaContractTests
             IdempotencyKey = "run-1:create_order",
             CapturedOutput = """{"orderId":"order-1"}""",
             CommittedAtUnixMs = 123456789,
+            LedgerStatus = CompensableLedgerEntryStatus.Confirmed,
         });
 
         state.CompensableLedger.Should().ContainSingle();
@@ -31,6 +32,7 @@ public sealed class WorkflowSagaContractTests
         state.CompensableLedger[0].IdempotencyKey.Should().Be("run-1:create_order");
         state.CompensableLedger[0].CapturedOutput.Should().Be("""{"orderId":"order-1"}""");
         state.CompensableLedger[0].CommittedAtUnixMs.Should().Be(123456789);
+        state.CompensableLedger[0].LedgerStatus.Should().Be(CompensableLedgerEntryStatus.Confirmed);
         state.CompensationCursor.Should().Be(1);
         state.SagaStatus.Should().Be(WorkflowSagaStatus.Compensating);
     }
@@ -55,6 +57,30 @@ public sealed class WorkflowSagaContractTests
     [Fact]
     public void WorkflowExecutionMessages_ShouldExposeCompensationEventContracts()
     {
+        AssertField<StepCompletedEvent>("failure_outcome", 15);
+        AssertRoundTrip(new StepCompletedEvent
+        {
+            RunId = "run-1",
+            StepId = "create_order",
+            Success = false,
+            Error = "timeout",
+            FailureOutcome = WorkflowStepFailureOutcome.OutcomeUncertain,
+        });
+
+        AssertField<CompensableStepDispatchedEvent>("run_id", 1);
+        AssertField<CompensableStepDispatchedEvent>("step_id", 2);
+        AssertField<CompensableStepDispatchedEvent>("compensation_step_id", 3);
+        AssertField<CompensableStepDispatchedEvent>("idempotency_key", 4);
+        AssertField<CompensableStepDispatchedEvent>("dispatched_at_unix_ms", 5);
+        AssertRoundTrip(new CompensableStepDispatchedEvent
+        {
+            RunId = "run-1",
+            StepId = "create_order",
+            CompensationStepId = "cancel_order",
+            IdempotencyKey = "run-1:create_order:1",
+            DispatchedAtUnixMs = 123456789,
+        });
+
         AssertField<CompensationRequestEvent>("run_id", 1);
         AssertField<CompensationRequestEvent>("failed_step_id", 2);
         AssertField<CompensationRequestEvent>("compensation_step_id", 3);
@@ -103,6 +129,36 @@ public sealed class WorkflowSagaContractTests
             FailedCompensationStepId = "cancel_order",
             RemainingUncompensated = 1,
             Error = "failed",
+        });
+    }
+
+    [Fact]
+    public void WorkflowSagaEnums_ShouldPreserveFieldNumbersAndRoundTrip()
+    {
+        ((int)WorkflowStepFailureOutcome.Unspecified).Should().Be(0);
+        ((int)WorkflowStepFailureOutcome.CalleeConfirmed).Should().Be(1);
+        ((int)WorkflowStepFailureOutcome.OutcomeUncertain).Should().Be(2);
+        ((int)CompensableLedgerEntryStatus.Unspecified).Should().Be(0);
+        ((int)CompensableLedgerEntryStatus.Confirmed).Should().Be(1);
+        ((int)CompensableLedgerEntryStatus.Provisional).Should().Be(2);
+
+        AssertField<CompletedStepLedgerEntry>("step_id", 1);
+        AssertField<CompletedStepLedgerEntry>("compensation_step_id", 2);
+        AssertField<CompletedStepLedgerEntry>("idempotency_key", 3);
+        AssertField<CompletedStepLedgerEntry>("captured_output", 4);
+        AssertField<CompletedStepLedgerEntry>("committed_at_unix_ms", 5);
+        AssertField<CompletedStepLedgerEntry>("ledger_status", 6);
+        AssertField<WorkflowRunState>("compensable_ledger", 25);
+        AssertField<WorkflowRunState>("compensation_cursor", 26);
+        AssertField<WorkflowRunState>("saga_status", 27);
+        AssertRoundTrip(new CompletedStepLedgerEntry
+        {
+            StepId = "create_order",
+            CompensationStepId = "cancel_order",
+            IdempotencyKey = "run-1:create_order:1",
+            CapturedOutput = "{}",
+            CommittedAtUnixMs = 123456789,
+            LedgerStatus = CompensableLedgerEntryStatus.Provisional,
         });
     }
 

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionCatalogTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionCatalogTests.cs
@@ -396,13 +396,24 @@ public class WorkflowDefinitionCatalogTests
             return Task.CompletedTask;
         }
 
-        public Task<WorkflowCompensationTransitionResult> TryStartCompensationAsync(
+        Task<WorkflowCompensationTransitionResult> IWorkflowExecutionStateHost.TryStartCompensationAsync(
             WorkflowCompletedEvent terminalFailure,
-            CancellationToken ct = default)
+            StepCompletedEvent? terminalStep,
+            CancellationToken ct)
         {
             _ = terminalFailure;
+            _ = terminalStep;
             ct.ThrowIfCancellationRequested();
             return Task.FromResult(NoCompensableLedger());
+        }
+
+        Task IWorkflowExecutionStateHost.RecordCompensableStepDispatchAsync(
+            CompensableStepDispatchedEvent evt,
+            CancellationToken ct)
+        {
+            _ = evt;
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
         }
 
         public Task<WorkflowCompensationTransitionResult> RecordCompensationStepCompletionAsync(


### PR DESCRIPTION
⟦AI:AUTO-LOOP⟧
## 问题
compensable ledger 只在 success completion 时写入，因此一个已 dispatch 但 success 未对账的 side-effecting step（如 timeout/force-fail 打断 in-flight 的 tool_call/connector_call）永不入账、永不补偿，即使副作用可能已在 callee 生效。ADR-0034 §Q8 只 carve out exactly-once，未 carve out in-flight effects。

## 方案（Option A：事件溯源 provisional ledger，产品确认）
- **Proto**：`WorkflowStepFailureOutcome` 枚举（UNSPECIFIED/CALLEE_CONFIRMED/OUTCOME_UNCERTAIN）+ `StepCompletedEvent.failure_outcome=15`；新 committed event `CompensableStepDispatchedEvent`；`CompensableLedgerEntryStatus` 枚举（UNSPECIFIED/CONFIRMED/PROVISIONAL）+ `CompletedStepLedgerEntry.ledger_status=6`（旧 entry 缺省=CONFIRMED）。
- **窄集合**：`IsSideEffectingPrimitive` 仅 tool_call/connector_call/secure_connector_call（含别名）入账。
- **Dispatch seam**：side-effecting 且声明 compensation 的 step 在发 StepRequest 前提交 `CompensableStepDispatchedEvent`（经新 `IWorkflowExecutionStateHost.RecordCompensableStepDispatchAsync`），reducer 写 PROVISIONAL；RunGAgent 仍是 ledger 唯一写者。
- **Reducer 对账**：success 确认 provisional（补 output、flip CONFIRMED、不重复）；CALLEE_CONFIRMED failure 删除 provisional（不补偿、不 spurious dead-letter）；OUTCOME_UNCERTAIN（timeout/force-fail）保留进入 LIFO 补偿。terminal `StepCompletedEvent` 被 thread 进 `TryStartCompensationAsync`（向后兼容的 default-method overload），使失败步骤的 provisional 在 eligibility 评估前被对账。
- 补偿 walk 不变；idempotency-keyed 补偿使撤销未生效副作用为安全 no-op。强类型 outcome（无字符串 error 推断）；dispatched_at/committed_at 保持 0（无引擎 wall-clock 依赖）。

## 影响路径
2 protos、kernel、WorkflowRunGAgent reducer、WorkflowPrimitiveCatalog、IWorkflowExecutionStateHost、3 个测试文件、ADR-0034（append-only dated note）、canon workflow-runtime.md + workflow-primitives.md。

## #2126 hand-off
provisional OUTCOME_UNCERTAIN entries 与 confirmed 同样计入 #2126 的 compensation phase deadline/budget；dropped CALLEE_CONFIRMED 不计入。

## 验证
`dotnet build aevatar.slnx --nologo`（0 error）；`Core.Tests 535/535`（timeout→补偿 / callee-confirmed→drop / success→confirm / legacy→confirm / contract 字段号）；`workflow_saga_compensation_guard.sh`；`proto_lint_guard.sh`；`test_stability_guards.sh`；`architecture_guards.sh`；`docs/lint.sh` —— 全绿。

Closes #2125

🤖 Generated with [Claude Code](https://claude.com/claude-code)