### PR TITLE
fix(voice): renew /ws/voice session lease while the transport relay is attached (#2151)

### DIFF
--- a/docs/canon/voice-presence-integration.md
+++ b/docs/canon/voice-presence-integration.md
@@ -120,7 +120,11 @@ The edge consumes a JSON projection of it (camelCase), hand-parsed by
   `owner_id`, `lease_epoch`, `lease_expires_at`) the actor owns; the volatile
   media relay is bound to that lease. Host/provider connect paths must carry
   the readmodel-observed positive `lease_epoch`; transport attach reuses that
-  lease generation and does not create the next epoch.
+  lease generation and does not create the next epoch. While the relay remains
+  live it sends typed actor renewal signals that extend the actor-owned lease
+  deadline. `owner_id`, `transport_lease_id`, and `lease_epoch` form the identity
+  fence; `lease_expires_at` / `renew_expires_at` are freshness deadlines and do
+  not independently identify a lease generation.
 - **Credential ref lifetime** — `/ws/voice` admission mints at most one
   `voice-tool:` ref for an attach attempt and hands a non-protobuf transport
   binding to the host attach path. The raw caller bearer becomes resolvable

--- a/src/Aevatar.Foundation.VoicePresence.Abstractions/Protos/voice_presence.proto
+++ b/src/Aevatar.Foundation.VoicePresence.Abstractions/Protos/voice_presence.proto
@@ -304,6 +304,14 @@ message VoiceTransportAttachRequested {
   int64 lease_epoch = 6;
 }
 
+message VoiceTransportLeaseRenewRequested {
+  string session_id = 1;
+  string owner_id = 2;
+  string transport_lease_id = 3;
+  int64 lease_epoch = 4;
+  google.protobuf.Timestamp renew_expires_at = 5;
+}
+
 message VoiceTransportDetachRequested {
   string session_id = 1;
   string transport_lease_id = 2;
@@ -388,6 +396,7 @@ message VoiceModuleSignal {
     VoiceProviderEventReceived provider_event_received = 14;
     VoiceTransportLifetimeCompleted transport_lifetime_completed = 16;
     VoiceInputImageReceived input_image_received = 17;
+    VoiceTransportLeaseRenewRequested transport_lease_renew_requested = 18;
   }
 }
 

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/ActorOwnedVoiceRealtimeSession.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/ActorOwnedVoiceRealtimeSession.cs
@@ -7,7 +7,7 @@ namespace Aevatar.Foundation.VoicePresence.Hosting;
 public sealed class ActorOwnedVoiceRealtimeSession
     : IRealtimeSession<VoiceRealtimeSessionRequest, VoiceRealtimeSessionAccepted, VoiceRealtimeSessionStartError, VoiceRealtimeFrame, VoiceRealtimeSessionCompletion>
 {
-    private static readonly TimeSpan DefaultLeaseTtl = TimeSpan.FromMinutes(5);
+    internal static readonly TimeSpan DefaultLeaseTtl = TimeSpan.FromMinutes(5);
     private const string HostOwnerId = "voice-presence.host";
 
     private readonly IVoicePresenceCapabilityQueryPort _capabilityQueryPort;

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceSessionDispatch.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceSessionDispatch.cs
@@ -75,6 +75,9 @@ internal static class VoicePresenceSessionDispatch
             case VoiceTransportAttachRequested attachRequested:
                 signal.TransportAttachRequested = attachRequested.Clone();
                 break;
+            case VoiceTransportLeaseRenewRequested renewRequested:
+                signal.TransportLeaseRenewRequested = renewRequested.Clone();
+                break;
             case VoiceTransportDetachRequested detachRequested:
                 signal.TransportDetachRequested = detachRequested.Clone();
                 break;

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/VoiceVolatileMediaStreamPort.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/VoiceVolatileMediaStreamPort.cs
@@ -12,7 +12,8 @@ public sealed class VoiceVolatileMediaStreamPort(
     IEnumerable<VoicePresenceModuleRegistration> moduleRegistrations,
     IServiceProvider serviceProvider,
     IActorDispatchPort dispatchPort,
-    IVoiceVolatileToolCredentialPort? toolCredentialPort = null)
+    IVoiceVolatileToolCredentialPort? toolCredentialPort = null,
+    TimeProvider? timeProvider = null)
     : IVoiceVolatileMediaStreamPort
 {
     private const string DetachedReason = "host_transport_detached";
@@ -24,6 +25,7 @@ public sealed class VoiceVolatileMediaStreamPort(
     private readonly IActorDispatchPort _dispatchPort =
         dispatchPort ?? throw new ArgumentNullException(nameof(dispatchPort));
     private readonly IVoiceVolatileToolCredentialPort? _toolCredentialPort = toolCredentialPort;
+    private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
     private readonly IServiceProvider _serviceProvider =
         serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
     private readonly IReadOnlyDictionary<string, VoicePresenceModuleRegistration> _registrationsByName =
@@ -86,7 +88,7 @@ public sealed class VoiceVolatileMediaStreamPort(
                 throw new InvalidOperationException("Voice transport already attached.");
             }
 
-            relay.Start();
+            relay.Start(ct => RunLeaseRenewalAsync(attachedHandle, relay, ct));
             return BuildLifetimeCompleted(attachedHandle, "transport_relay_completed");
         }
         catch
@@ -187,6 +189,44 @@ public sealed class VoiceVolatileMediaStreamPort(
         if (_activeRelays.TryRemove(transportLeaseId, out var relay))
             await relay.DisposeAsync();
     }
+
+    private async Task RunLeaseRenewalAsync(
+        VoicePresenceSessionLeaseHandle handle,
+        VoiceVolatileMediaRelay relay,
+        CancellationToken ct)
+    {
+        var renewalInterval = ActorOwnedVoiceRealtimeSession.DefaultLeaseTtl / 2;
+        while (!ct.IsCancellationRequested)
+        {
+            await Task.Delay(renewalInterval, _timeProvider, ct);
+            if (!IsActiveRelay(handle.ActiveTransportLeaseId, relay))
+                return;
+
+            await DispatchLeaseRenewalAsync(handle, ct);
+        }
+    }
+
+    private bool IsActiveRelay(string? transportLeaseId, VoiceVolatileMediaRelay relay) =>
+        !string.IsNullOrWhiteSpace(transportLeaseId) &&
+        _activeRelays.TryGetValue(transportLeaseId, out var activeRelay) &&
+        ReferenceEquals(activeRelay, relay);
+
+    private Task DispatchLeaseRenewalAsync(VoicePresenceSessionLeaseHandle handle, CancellationToken ct) =>
+        _dispatchPort.DispatchAsync(
+            handle.ActorId,
+            VoicePresenceSessionDispatch.BuildDirectEnvelope(
+                handle.ActorId,
+                handle.ModuleName,
+                new VoiceTransportLeaseRenewRequested
+                {
+                    SessionId = handle.SessionId,
+                    OwnerId = handle.OwnerId,
+                    TransportLeaseId = handle.ActiveTransportLeaseId ?? string.Empty,
+                    LeaseEpoch = handle.LeaseEpoch,
+                    RenewExpiresAt = Timestamp.FromDateTimeOffset(
+                        _timeProvider.GetUtcNow().Add(ActorOwnedVoiceRealtimeSession.DefaultLeaseTtl)),
+                }),
+            ct);
 
     private async Task BindToolCredentialAsync(
         VoicePresenceSessionLeaseHandle handle,
@@ -337,9 +377,13 @@ public sealed class VoiceVolatileMediaStreamPort(
         private Task? _relayTask;
         private bool _disposed;
 
-        public void Start()
+        private Task? _renewalTask;
+
+        public void Start(Func<CancellationToken, Task> renewalLoop)
         {
-            _relayTask = RunAsync(_relayCancellation.Token);
+            var ct = _relayCancellation.Token;
+            _relayTask = RunAsync(ct);
+            _renewalTask = renewalLoop(ct);
         }
 
         public Task SendProviderAudioAsync(VoiceProviderAudioFrame audioFrame, CancellationToken ct)
@@ -364,6 +408,7 @@ public sealed class VoiceVolatileMediaStreamPort(
             _disposed = true;
             _relayCancellation.Cancel();
             await AwaitRelayAsync(_relayTask);
+            await AwaitRelayAsync(_renewalTask);
             _relayCancellation.Dispose();
         }
 

--- a/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
@@ -147,6 +147,9 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
             case VoiceModuleSignal.SignalOneofCase.TransportAttachRequested:
                 await HandleTransportAttachRequestedAsync(signal.TransportAttachRequested, ctx, ct);
                 break;
+            case VoiceModuleSignal.SignalOneofCase.TransportLeaseRenewRequested:
+                await HandleTransportLeaseRenewRequestedAsync(signal.TransportLeaseRenewRequested, ctx, ct);
+                break;
             case VoiceModuleSignal.SignalOneofCase.TransportDetachRequested:
                 await HandleTransportDetachRequestedAsync(signal.TransportDetachRequested, ctx, ct);
                 break;
@@ -438,7 +441,6 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
                 request.SessionId,
                 request.TransportLeaseId,
                 request.OwnerId,
-                request.LeaseExpiresAt,
                 request.LeaseEpoch))
         {
             return;
@@ -507,6 +509,33 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         await PersistRuntimeStateAsync(ctx, state, ct);
     }
 
+    private async Task HandleTransportLeaseRenewRequestedAsync(
+        VoiceTransportLeaseRenewRequested request,
+        IEventHandlerContext ctx,
+        CancellationToken ct)
+    {
+        var state = HydrateRuntimeStateFromActor(ctx);
+        if (!IsAcceptedTransportSignal(
+                state,
+                request.SessionId,
+                request.TransportLeaseId,
+                request.OwnerId,
+                request.LeaseEpoch) ||
+            request.RenewExpiresAt == null)
+        {
+            return;
+        }
+
+        if (state.LeaseExpiresAt == null ||
+            request.RenewExpiresAt.ToDateTimeOffset() <= state.LeaseExpiresAt.ToDateTimeOffset())
+        {
+            return;
+        }
+
+        state.LeaseExpiresAt = request.RenewExpiresAt.Clone();
+        await PersistRuntimeStateAsync(ctx, state, ct);
+    }
+
     private async Task HandleTransportDetachRequestedAsync(
         VoiceTransportDetachRequested request,
         IEventHandlerContext ctx,
@@ -518,7 +547,6 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
                 request.SessionId,
                 request.TransportLeaseId,
                 request.OwnerId,
-                request.LeaseExpiresAt,
                 request.LeaseEpoch))
             return;
 
@@ -537,7 +565,6 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
                 request.SessionId,
                 request.TransportLeaseId,
                 request.OwnerId,
-                request.LeaseExpiresAt,
                 request.LeaseEpoch) ||
             request.ControlFrame == null)
         {
@@ -558,7 +585,6 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
                 request.SessionId,
                 request.TransportLeaseId,
                 request.OwnerId,
-                request.LeaseExpiresAt,
                 request.LeaseEpoch))
             return;
 
@@ -577,7 +603,6 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
                 request.SessionId,
                 request.TransportLeaseId,
                 request.OwnerId,
-                request.LeaseExpiresAt,
                 request.LeaseEpoch))
             return;
 
@@ -594,7 +619,6 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         string sessionId,
         string transportLeaseId,
         string? ownerId = null,
-        Timestamp? leaseExpiresAt = null,
         long leaseEpoch = 0)
     {
         if (string.IsNullOrWhiteSpace(sessionId) ||
@@ -608,7 +632,6 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         return string.Equals(state.ActiveSessionId, sessionId, StringComparison.Ordinal) &&
                string.Equals(state.ActiveTransportLeaseId, transportLeaseId, StringComparison.Ordinal) &&
                MatchesLeaseOwner(state, ownerId) &&
-               MatchesLeaseExpiry(state, leaseExpiresAt) &&
                MatchesLeaseEpoch(state, leaseEpoch);
     }
 
@@ -617,12 +640,11 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         string sessionId,
         string transportLeaseId,
         string? ownerId,
-        Timestamp? leaseExpiresAt,
         long leaseEpoch)
     {
         if (!string.IsNullOrWhiteSpace(transportLeaseId))
         {
-            return IsAcceptedTransportSignal(state, sessionId, transportLeaseId, ownerId, leaseExpiresAt, leaseEpoch);
+            return IsAcceptedTransportSignal(state, sessionId, transportLeaseId, ownerId, leaseEpoch);
         }
 
         if (string.IsNullOrWhiteSpace(sessionId) ||
@@ -654,7 +676,6 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
                 request.SessionId,
                 request.TransportLeaseId,
                 request.OwnerId,
-                request.LeaseExpiresAt,
                 request.LeaseEpoch);
         }
 

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
@@ -720,7 +720,9 @@ public class VoicePresenceModuleTests
         moduleSource.ShouldNotContain("TransportAttached = _userTransport", Case.Sensitive);
         moduleSource.ShouldNotContain("IsActorAccepted", Case.Sensitive);
         moduleSource.ShouldNotContain("DispatchFireAndForget", Case.Sensitive);
-        moduleSource.ShouldNotContain("VoiceTransportLease", Case.Sensitive);
+        moduleSource.ShouldNotContain("VoiceTransportLease _", Case.Sensitive);
+        moduleSource.ShouldNotContain("VoiceTransportLease(", Case.Sensitive);
+        moduleSource.ShouldNotContain("VoiceTransportLease =", Case.Sensitive);
         moduleSource.ShouldNotContain("_transportPump", Case.Sensitive);
         moduleSource.ShouldNotContain("_providerSession", Case.Sensitive);
         moduleSource.ShouldNotContain("_providerSessionKey", Case.Sensitive);
@@ -983,6 +985,212 @@ public class VoicePresenceModuleTests
 
         roleAgent.PersistedStates.ShouldBeEmpty();
         roleAgent.State.VoicePresence["voice_presence"].TransportAttached.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Transport_lease_renew_signal_should_extend_actor_owned_expiry_without_bumping_epoch()
+    {
+        var now = new DateTimeOffset(2026, 6, 17, 8, 0, 0, TimeSpan.Zero);
+        var module = CreateModule(
+            new RecordingVoiceProvider(),
+            options: new VoicePresenceModuleOptions
+            {
+                TimeProvider = new ManualTimeProvider(now),
+            });
+        var roleAgent = CreateRoleAgentWithAttachedTransport(now.AddMinutes(5));
+        var ctx = new StubEventHandlerContext(agent: roleAgent);
+        var renewExpiresAt = Timestamp.FromDateTimeOffset(now.AddMinutes(10));
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = "voice_presence",
+            TransportLeaseRenewRequested = new VoiceTransportLeaseRenewRequested
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseEpoch = 7,
+                RenewExpiresAt = renewExpiresAt.Clone(),
+            },
+        }), ctx, CancellationToken.None);
+
+        var renewed = roleAgent.PersistedStates.ShouldHaveSingleItem().State;
+        renewed.LeaseExpiresAt.ShouldBe(renewExpiresAt);
+        renewed.LeaseEpoch.ShouldBe(7);
+        renewed.ActiveTransportLeaseId.ShouldBe("transport-current");
+        renewed.TransportAttached.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Transport_lease_renew_signal_should_not_shorten_actor_owned_expiry()
+    {
+        var now = new DateTimeOffset(2026, 6, 17, 8, 0, 0, TimeSpan.Zero);
+        var module = CreateModule(
+            new RecordingVoiceProvider(),
+            options: new VoicePresenceModuleOptions
+            {
+                TimeProvider = new ManualTimeProvider(now),
+            });
+        var roleAgent = CreateRoleAgentWithAttachedTransport(now.AddMinutes(10));
+        var ctx = new StubEventHandlerContext(agent: roleAgent);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = "voice_presence",
+            TransportLeaseRenewRequested = new VoiceTransportLeaseRenewRequested
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseEpoch = 7,
+                RenewExpiresAt = Timestamp.FromDateTimeOffset(now.AddMinutes(5)),
+            },
+        }), ctx, CancellationToken.None);
+
+        roleAgent.PersistedStates.ShouldBeEmpty();
+        roleAgent.State.VoicePresence["voice_presence"].LeaseExpiresAt.ToDateTimeOffset()
+            .ShouldBe(now.AddMinutes(10));
+    }
+
+    [Theory]
+    [InlineData("owner")]
+    [InlineData("transport")]
+    [InlineData("epoch")]
+    [InlineData("expired")]
+    public async Task Transport_lease_renew_signal_should_ignore_identity_mismatch_or_expired_lease(
+        string mismatch)
+    {
+        var now = new DateTimeOffset(2026, 6, 17, 8, 0, 0, TimeSpan.Zero);
+        var module = CreateModule(
+            new RecordingVoiceProvider(),
+            options: new VoicePresenceModuleOptions
+            {
+                TimeProvider = new ManualTimeProvider(now),
+            });
+        var activeExpiry = mismatch == "expired" ? now.AddSeconds(-1) : now.AddMinutes(5);
+        var roleAgent = CreateRoleAgentWithAttachedTransport(activeExpiry);
+        var ctx = new StubEventHandlerContext(agent: roleAgent);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = "voice_presence",
+            TransportLeaseRenewRequested = new VoiceTransportLeaseRenewRequested
+            {
+                SessionId = "lease-current",
+                OwnerId = mismatch == "owner" ? "host-stale" : "host-current",
+                TransportLeaseId = mismatch == "transport" ? "transport-stale" : "transport-current",
+                LeaseEpoch = mismatch == "epoch" ? 6 : 7,
+                RenewExpiresAt = Timestamp.FromDateTimeOffset(now.AddMinutes(10)),
+            },
+        }), ctx, CancellationToken.None);
+
+        roleAgent.PersistedStates.ShouldBeEmpty();
+        roleAgent.State.VoicePresence["voice_presence"].LeaseExpiresAt.ToDateTimeOffset()
+            .ShouldBe(activeExpiry);
+    }
+
+    [Fact]
+    public async Task Transport_control_signal_should_accept_old_lease_expiry_after_renewal()
+    {
+        var now = new DateTimeOffset(2026, 6, 17, 8, 0, 0, TimeSpan.Zero);
+        var oldExpiry = Timestamp.FromDateTimeOffset(now.AddMinutes(5));
+        var roleAgent = CreateRoleAgentWithAttachedTransport(now.AddMinutes(10));
+        var state = roleAgent.State.VoicePresence["voice_presence"];
+        state.Status = VoicePresenceRuntimeStatus.AudioDraining;
+        state.CurrentResponseId = 4;
+        state.NextResponseId = 5;
+        var module = CreateModule(new RecordingVoiceProvider());
+        var ctx = new StubEventHandlerContext(agent: roleAgent);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = "voice_presence",
+            TransportControlFrameReceived = new VoiceTransportControlFrameReceived
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseExpiresAt = oldExpiry.Clone(),
+                LeaseEpoch = 7,
+                ControlFrame = new VoiceControlFrame
+                {
+                    DrainAcknowledged = new VoiceDrainAcknowledged
+                    {
+                        ResponseId = 4,
+                        PlayoutSequence = 9,
+                    },
+                },
+            },
+        }), ctx, CancellationToken.None);
+
+        var persisted = roleAgent.PersistedStates.ShouldHaveSingleItem().State;
+        persisted.LastDrainAckResponseId.ShouldBe(4);
+        persisted.LastDrainAckPlayoutSequence.ShouldBe(9);
+        persisted.LeaseExpiresAt.ToDateTimeOffset().ShouldBe(now.AddMinutes(10));
+    }
+
+    [Fact]
+    public async Task Provider_callback_signal_should_accept_old_lease_expiry_after_renewal()
+    {
+        var now = new DateTimeOffset(2026, 6, 17, 8, 0, 0, TimeSpan.Zero);
+        var oldExpiry = Timestamp.FromDateTimeOffset(now.AddMinutes(5));
+        var roleAgent = CreateRoleAgentWithAttachedTransport(now.AddMinutes(10));
+        var module = CreateModule(new RecordingVoiceProvider());
+        var ctx = new StubEventHandlerContext(agent: roleAgent);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = "voice_presence",
+            ProviderEventReceived = new VoiceProviderEventReceived
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseExpiresAt = oldExpiry.Clone(),
+                LeaseEpoch = 7,
+                ProviderEvent = new VoiceProviderEvent
+                {
+                    ResponseStarted = new VoiceResponseStarted { ProviderResponseId = "provider-r1" },
+                },
+            },
+        }), ctx, CancellationToken.None);
+
+        var persisted = roleAgent.PersistedStates.ShouldHaveSingleItem().State;
+        persisted.Status.ShouldBe(VoicePresenceRuntimeStatus.ResponseInProgress);
+        persisted.ProviderResponseBindings.ShouldHaveSingleItem().ProviderResponseId.ShouldBe("provider-r1");
+        persisted.LeaseExpiresAt.ToDateTimeOffset().ShouldBe(now.AddMinutes(10));
+    }
+
+    [Fact]
+    public async Task Input_image_signal_should_accept_old_lease_expiry_after_renewal()
+    {
+        var now = new DateTimeOffset(2026, 6, 17, 8, 0, 0, TimeSpan.Zero);
+        var oldExpiry = Timestamp.FromDateTimeOffset(now.AddMinutes(5));
+        var provider = new RecordingVoiceProvider();
+        var roleAgent = CreateRoleAgentWithAttachedTransport(now.AddMinutes(10));
+        var module = CreateModule(provider);
+        var ctx = new StubEventHandlerContext(agent: roleAgent);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = "voice_presence",
+            InputImageReceived = new VoiceInputImageReceived
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseExpiresAt = oldExpiry.Clone(),
+                LeaseEpoch = 7,
+                InputImage = new VoiceInputImage
+                {
+                    MediaType = "image/png",
+                    Data = ByteString.CopyFrom([7, 8, 9]),
+                },
+            },
+        }), ctx, CancellationToken.None);
+
+        provider.InputImages.ShouldHaveSingleItem().Data.ToByteArray().ShouldBe([7, 8, 9]);
+        roleAgent.PersistedStates.ShouldBeEmpty();
     }
 
     [Fact]
@@ -2328,13 +2536,18 @@ public class VoicePresenceModuleTests
 
     private static RecordingRoleAgent CreateRoleAgentWithAttachedTransport()
     {
+        return CreateRoleAgentWithAttachedTransport(DateTimeOffset.UtcNow.AddMinutes(5));
+    }
+
+    private static RecordingRoleAgent CreateRoleAgentWithAttachedTransport(DateTimeOffset leaseExpiresAt)
+    {
         var roleAgent = new RecordingRoleAgent("voice-agent");
         roleAgent.State.VoicePresence[DefaultModuleName] = new VoicePresenceRuntimeState
         {
             Initialized = true,
             ActiveSessionId = "lease-current",
             ActiveLeaseOwnerId = "host-current",
-            LeaseExpiresAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddMinutes(5)),
+            LeaseExpiresAt = Timestamp.FromDateTimeOffset(leaseExpiresAt.ToUniversalTime()),
             TransportAttached = true,
             ActiveTransportLeaseId = "transport-current",
             LeaseEpoch = 7,

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceProtoTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceProtoTests.cs
@@ -227,6 +227,40 @@ public class VoicePresenceProtoTests
     }
 
     [Fact]
+    public void VoiceModuleSignal_should_roundtrip_transport_lease_renew_requested()
+    {
+        var renewExpiresAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddMinutes(5));
+        var renew = new VoiceTransportLeaseRenewRequested
+        {
+            SessionId = "lease-1",
+            OwnerId = "host-1",
+            TransportLeaseId = "transport-1",
+            LeaseEpoch = 12,
+            RenewExpiresAt = renewExpiresAt,
+        };
+        var signal = new VoiceModuleSignal
+        {
+            ModuleName = "voice_presence",
+            TransportLeaseRenewRequested = renew,
+        };
+
+        var parsed = VoiceModuleSignal.Parser.ParseFrom(signal.ToByteArray());
+        var signalOneof = VoiceModuleSignal.Descriptor.Oneofs
+            .Single(static oneof => oneof.Name == "signal");
+        var renewField = signalOneof.Fields
+            .Single(static field => field.Name == "transport_lease_renew_requested");
+
+        parsed.ShouldBe(signal);
+        parsed.SignalCase.ShouldBe(VoiceModuleSignal.SignalOneofCase.TransportLeaseRenewRequested);
+        parsed.TransportLeaseRenewRequested.ShouldBe(renew);
+        renewField.FieldNumber.ShouldBe(18);
+        renewField.MessageType.Name.ShouldBe(nameof(VoiceTransportLeaseRenewRequested));
+        VoiceTransportLeaseRenewRequested.Descriptor.Fields.InDeclarationOrder()
+            .Select(static field => field.Name)
+            .ShouldNotContain("previous_lease_expires_at");
+    }
+
+    [Fact]
     public void VoicePresenceSessionDispatch_should_wrap_transport_control_self_signal()
     {
         var control = new VoiceTransportControlFrameReceived
@@ -282,5 +316,27 @@ public class VoicePresenceProtoTests
         signal.SignalCase.ShouldBe(VoiceModuleSignal.SignalOneofCase.InputImageReceived);
         signal.InputImageReceived.ShouldBe(image);
         signal.InputImageReceived.ShouldNotBeSameAs(image);
+    }
+
+    [Fact]
+    public void VoicePresenceSessionDispatch_should_wrap_transport_lease_renew_direct_signal()
+    {
+        var renew = new VoiceTransportLeaseRenewRequested
+        {
+            SessionId = "lease-1",
+            OwnerId = "host-1",
+            TransportLeaseId = "transport-1",
+            LeaseEpoch = 13,
+            RenewExpiresAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddMinutes(5)),
+        };
+
+        var envelope = VoicePresenceSessionDispatch.BuildDirectEnvelope("voice-agent", "voice_presence", renew);
+        var signal = envelope.Payload.Unpack<VoiceModuleSignal>();
+
+        envelope.Route.ShouldBe(EnvelopeRouteSemantics.CreateDirect(VoicePresenceSessionDispatch.HostPublisherId, "voice-agent"));
+        signal.ModuleName.ShouldBe("voice_presence");
+        signal.SignalCase.ShouldBe(VoiceModuleSignal.SignalOneofCase.TransportLeaseRenewRequested);
+        signal.TransportLeaseRenewRequested.ShouldBe(renew);
+        signal.TransportLeaseRenewRequested.ShouldNotBeSameAs(renew);
     }
 }

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoiceRealtimeSessionTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoiceRealtimeSessionTests.cs
@@ -378,6 +378,79 @@ public class VoiceRealtimeSessionTests
     }
 
     [Fact]
+    public async Task VoiceVolatileMediaStreamPort_should_dispatch_lease_renewal_while_relay_is_attached()
+    {
+        var now = new DateTimeOffset(2026, 6, 17, 8, 0, 0, TimeSpan.Zero);
+        var timeProvider = new ControllableTimeProvider(now);
+        var leasePort = new RecordingLeasePort();
+        var attachmentPort = new RecordingAttachmentPort();
+        var dispatchPort = new RecordingDispatchPort();
+        var providerSession = new RecordingRelayProviderSession();
+        var port = new VoiceVolatileMediaStreamPort(
+            attachmentPort,
+            leasePort,
+            [CreateRelayRegistration(providerSession)],
+            new ServiceCollection().BuildServiceProvider(),
+            dispatchPort,
+            timeProvider: timeProvider);
+        var handle = CreateLeaseHandle(now.AddMinutes(5), activeTransportLeaseId: "transport-1");
+        var transport = new PassiveVoiceTransport();
+
+        await port.AttachAsync(handle, transport, CancellationToken.None);
+        timeProvider.Advance(ActorOwnedVoiceRealtimeSession.DefaultLeaseTtl / 2);
+
+        var signal = await dispatchPort.TakeSignalAsync<VoiceTransportLeaseRenewRequested>();
+
+        signal.SessionId.ShouldBe("lease-1");
+        signal.OwnerId.ShouldBe("host-1");
+        signal.TransportLeaseId.ShouldBe("transport-1");
+        signal.LeaseEpoch.ShouldBe(7);
+        signal.RenewExpiresAt.ToDateTimeOffset().ShouldBe(now.AddMinutes(7.5));
+
+        await port.DetachAsync(handle, transport, CancellationToken.None);
+    }
+
+    [Theory]
+    [InlineData("detached")]
+    [InlineData("completed")]
+    public async Task VoiceVolatileMediaStreamPort_should_stop_lease_renewal_after_relay_is_removed(
+        string removalPath)
+    {
+        var now = new DateTimeOffset(2026, 6, 17, 8, 0, 0, TimeSpan.Zero);
+        var timeProvider = new ControllableTimeProvider(now);
+        var leasePort = new RecordingLeasePort();
+        var attachmentPort = new RecordingAttachmentPort();
+        var dispatchPort = new RecordingDispatchPort();
+        var providerSession = new RecordingRelayProviderSession();
+        var port = new VoiceVolatileMediaStreamPort(
+            attachmentPort,
+            leasePort,
+            [CreateRelayRegistration(providerSession)],
+            new ServiceCollection().BuildServiceProvider(),
+            dispatchPort,
+            timeProvider: timeProvider);
+        var handle = CreateLeaseHandle(now.AddMinutes(5), activeTransportLeaseId: "transport-1");
+        var transport = new PassiveVoiceTransport();
+
+        await port.AttachAsync(handle, transport, CancellationToken.None);
+        if (removalPath == "detached")
+        {
+            await port.DetachAsync(handle, transport, CancellationToken.None);
+        }
+        else
+        {
+            await port.CompleteTransportLifetimeAsync(handle, null, "host_transport_completed");
+        }
+
+        timeProvider.Advance(ActorOwnedVoiceRealtimeSession.DefaultLeaseTtl / 2);
+
+        dispatchPort.Dispatches
+            .Select(static dispatch => dispatch.Envelope.Payload.Unpack<VoiceModuleSignal>())
+            .ShouldNotContain(static signal =>
+                signal.SignalCase == VoiceModuleSignal.SignalOneofCase.TransportLeaseRenewRequested);
+    }
+
+    [Fact]
     public async Task VoiceVolatileMediaStreamPort_should_bind_tool_credential_to_transport_lease_and_evict_on_detach()
     {
         var leasePort = new RecordingLeasePort();
@@ -1233,12 +1306,75 @@ public class VoiceRealtimeSessionTests
 
     private sealed class RecordingDispatchPort : IActorDispatchPort
     {
+        private readonly object _gate = new();
+        private readonly List<ISignalWaiter> _waiters = [];
+
         public List<(string ActorId, EventEnvelope Envelope)> Dispatches { get; } = [];
 
         public Task<DispatchAdmission> DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
         {
-            Dispatches.Add((actorId, envelope));
+            lock (_gate)
+            {
+                Dispatches.Add((actorId, envelope));
+                var signal = envelope.Payload.Unpack<VoiceModuleSignal>();
+                for (var i = _waiters.Count - 1; i >= 0; i--)
+                {
+                    if (_waiters[i].TrySet(signal))
+                        _waiters.RemoveAt(i);
+                }
+            }
+
             return Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
+        }
+
+        public Task<T> TakeSignalAsync<T>()
+            where T : IMessage
+        {
+            lock (_gate)
+            {
+                foreach (var dispatch in Dispatches)
+                {
+                    var signal = dispatch.Envelope.Payload.Unpack<VoiceModuleSignal>();
+                    if (TryGetSignal(signal, out T? payload))
+                        return Task.FromResult(payload!);
+                }
+
+                var completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+                _waiters.Add(new SignalWaiter<T>(completion));
+                return completion.Task;
+            }
+        }
+
+        private static bool TryGetSignal<T>(VoiceModuleSignal signal, out T? payload)
+            where T : IMessage
+        {
+            if (typeof(T) == typeof(VoiceTransportLeaseRenewRequested) &&
+                signal.SignalCase == VoiceModuleSignal.SignalOneofCase.TransportLeaseRenewRequested)
+            {
+                payload = (T)(object)signal.TransportLeaseRenewRequested;
+                return true;
+            }
+
+            payload = default;
+            return false;
+        }
+
+        private interface ISignalWaiter
+        {
+            bool TrySet(VoiceModuleSignal signal);
+        }
+
+        private sealed class SignalWaiter<T>(TaskCompletionSource<T> completion) : ISignalWaiter
+            where T : IMessage
+        {
+            public bool TrySet(VoiceModuleSignal signal)
+            {
+                if (!TryGetSignal(signal, out T? payload))
+                    return false;
+
+                completion.TrySetResult(payload!);
+                return true;
+            }
         }
     }
 
@@ -1261,6 +1397,130 @@ public class VoiceRealtimeSessionTests
     private sealed class FixedProjectionClock(DateTimeOffset utcNow) : IProjectionClock
     {
         public DateTimeOffset UtcNow { get; } = utcNow;
+    }
+
+    private sealed class ControllableTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        private readonly object _gate = new();
+        private readonly List<ManualTimer> _timers = [];
+        private DateTimeOffset _utcNow = utcNow;
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            lock (_gate)
+            {
+                return _utcNow;
+            }
+        }
+
+        public void Advance(TimeSpan delta)
+        {
+            ManualTimer[] timers;
+            lock (_gate)
+            {
+                _utcNow = _utcNow.Add(delta);
+                timers = _timers.ToArray();
+            }
+
+            foreach (var timer in timers)
+                timer.FireIfDue();
+        }
+
+        public override ITimer CreateTimer(
+            TimerCallback callback,
+            object? state,
+            TimeSpan dueTime,
+            TimeSpan period)
+        {
+            var timer = new ManualTimer(this, callback, state, dueTime, period);
+            lock (_gate)
+            {
+                _timers.Add(timer);
+            }
+
+            timer.FireIfDue();
+            return timer;
+        }
+
+        private void Remove(ManualTimer timer)
+        {
+            lock (_gate)
+            {
+                _timers.Remove(timer);
+            }
+        }
+
+        private sealed class ManualTimer(
+            ControllableTimeProvider owner,
+            TimerCallback callback,
+            object? state,
+            TimeSpan dueTime,
+            TimeSpan period) : ITimer
+        {
+            private readonly object _gate = new();
+            private TimeSpan _period = period;
+            private DateTimeOffset? _dueAt = ResolveDueAt(owner.GetUtcNow(), dueTime);
+            private bool _disposed;
+
+            public bool Change(TimeSpan dueTime, TimeSpan period)
+            {
+                lock (_gate)
+                {
+                    if (_disposed)
+                        return false;
+
+                    _period = period;
+                    _dueAt = ResolveDueAt(owner.GetUtcNow(), dueTime);
+                }
+
+                FireIfDue();
+                return true;
+            }
+
+            public void FireIfDue()
+            {
+                while (true)
+                {
+                    lock (_gate)
+                    {
+                        if (_disposed ||
+                            !_dueAt.HasValue ||
+                            _dueAt.Value > owner.GetUtcNow())
+                        {
+                            return;
+                        }
+
+                        _dueAt = _period == Timeout.InfiniteTimeSpan
+                            ? null
+                            : ResolveDueAt(owner.GetUtcNow(), _period);
+                    }
+
+                    callback(state);
+                }
+            }
+
+            public void Dispose()
+            {
+                lock (_gate)
+                {
+                    if (_disposed)
+                        return;
+
+                    _disposed = true;
+                }
+
+                owner.Remove(this);
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                Dispose();
+                return ValueTask.CompletedTask;
+            }
+
+            private static DateTimeOffset? ResolveDueAt(DateTimeOffset now, TimeSpan dueTime) =>
+                dueTime == Timeout.InfiniteTimeSpan ? null : now.Add(dueTime);
+        }
     }
 
     private static EventEnvelope WrapCommitted(


### PR DESCRIPTION
## Summary / 摘要

修复 #2151：`/ws/voice` transport lease 只在 attach 写 5min TTL，live relay 期间不续租 → 长会话 actor lease 过期后控制面（transcript/tool/barge-in/device-event injection）静默失效，raw PCM relay 绕过 actor 仍在播。

- **New**：relay 在 TTL/2 发布 typed `VoiceTransportLeaseRenewRequested`（self-message，oneof field 18）；actor turn 内对账 `owner_id`/`transport_lease_id`/`lease_epoch`(`>0 && match`)/`TransportAttached`/未过期后，把 `LeaseExpiresAt` 单调推进到 `max(current, renew_expires_at)`，**不改 `LeaseEpoch`**；移除下游 fence 对 `lease_expires_at` 的精确相等要求（保留 identity + freshness）。**不**新增 RenewAsync port / options；NyxID expires_at observability 留后续 issue。

design-consensus r3（`adopt-strawman-renew-proto`）。

## Scope / 范围

9 files（proto + dispatch + VoiceVolatileMediaStreamPort renew loop + ActorOwnedVoiceRealtimeSession + VoicePresenceModule handler + 3 test 文件 + canon doc）。0 SCOPE_EXTEND。
- 测试：VoicePresence.Tests 210 passed；全量 `dotnet test aevatar.slnx` 绿；test_stability + architecture + projection guards + docs lint 全过（renew loop 测试用手动时间源，无 Task.Delay/polling）。

Closes #2151

🤖 consensus-loop (milestone 23)

⟦AI:AUTO-LOOP⟧
