### PR TITLE
fix(voice): bound AudioDraining with a server-side drain-timeout self-signal (#2152)

### DIFF
--- a/docs/canon/voice-presence-integration.md
+++ b/docs/canon/voice-presence-integration.md
@@ -142,6 +142,11 @@ The edge consumes a JSON projection of it (camelCase), hand-parsed by
   turn running in another silo cannot resolve this volatile ref today; that is
   the same known boundary as the live media relay and is a follow-up topology
   problem, not a durable credential fact source.
+- **Drain-ack timeout** — when a response enters `AudioDraining`, the actor
+  schedules a durable `VoiceDrainTimeoutExpired` self-signal and releases the
+  drain fence only after matching the active `response_id` and positive
+  `lease_epoch`; this preserves the existing ACK watermark without treating the
+  timeout as edge playout confirmation.
 
 ## Connect + turn sequence
 

--- a/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
@@ -554,6 +554,7 @@ public static class ServiceCollectionExtensions
             StaleAfter = options.StaleAfter,
             DedupeWindow = options.DedupeWindow,
             ToolExecutionTimeout = options.ToolExecutionTimeout,
+            DrainTimeout = options.DrainTimeout,
             PendingInjectionCapacity = options.PendingInjectionCapacity,
             TimeProvider = options.TimeProvider,
             DirectExternalEventTypeUrls = options.DirectExternalEventTypeUrls,

--- a/src/Aevatar.Foundation.VoicePresence.Abstractions/Protos/voice_presence.proto
+++ b/src/Aevatar.Foundation.VoicePresence.Abstractions/Protos/voice_presence.proto
@@ -348,6 +348,14 @@ message VoiceTransportLifetimeCompleted {
   int64 lease_epoch = 6;
 }
 
+message VoiceDrainTimeoutExpired {
+  string session_id = 1;
+  string owner_id = 2;
+  string transport_lease_id = 3;
+  int64 lease_epoch = 4;
+  int32 response_id = 5;
+}
+
 message VoiceProviderEventReceived {
   string session_id = 1;
   string transport_lease_id = 2;
@@ -397,6 +405,7 @@ message VoiceModuleSignal {
     VoiceTransportLifetimeCompleted transport_lifetime_completed = 16;
     VoiceInputImageReceived input_image_received = 17;
     VoiceTransportLeaseRenewRequested transport_lease_renew_requested = 18;
+    VoiceDrainTimeoutExpired drain_timeout_expired = 19;
   }
 }
 

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceSessionDispatch.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceSessionDispatch.cs
@@ -78,6 +78,9 @@ internal static class VoicePresenceSessionDispatch
             case VoiceTransportLeaseRenewRequested renewRequested:
                 signal.TransportLeaseRenewRequested = renewRequested.Clone();
                 break;
+            case VoiceDrainTimeoutExpired drainTimeoutExpired:
+                signal.DrainTimeoutExpired = drainTimeoutExpired.Clone();
+                break;
             case VoiceTransportDetachRequested detachRequested:
                 signal.TransportDetachRequested = detachRequested.Clone();
                 break;

--- a/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
@@ -150,6 +150,9 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
             case VoiceModuleSignal.SignalOneofCase.TransportLeaseRenewRequested:
                 await HandleTransportLeaseRenewRequestedAsync(signal.TransportLeaseRenewRequested, ctx, ct);
                 break;
+            case VoiceModuleSignal.SignalOneofCase.DrainTimeoutExpired:
+                await HandleDrainTimeoutExpiredAsync(signal.DrainTimeoutExpired, ctx, ct);
+                break;
             case VoiceModuleSignal.SignalOneofCase.TransportDetachRequested:
                 await HandleTransportDetachRequestedAsync(signal.TransportDetachRequested, ctx, ct);
                 break;
@@ -214,10 +217,19 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
                 stateChanged = true;
                 break;
             case VoiceProviderEvent.EventOneofCase.ResponseDone:
+            {
+                var previousStatus = state.Status;
                 ApplyResponseDone(state, normalizedEvent.ResponseDone.ResponseId);
+                if (previousStatus != VoicePresenceRuntimeStatus.AudioDraining &&
+                    state.Status == VoicePresenceRuntimeStatus.AudioDraining)
+                {
+                    await ScheduleDrainTimeoutAsync(state, normalizedEvent.ResponseDone.ResponseId, ctx, ct);
+                }
+
                 RetireProviderResponse(state, normalizedEvent.ResponseDone.ProviderResponseId);
                 stateChanged = true;
                 break;
+            }
             case VoiceProviderEvent.EventOneofCase.ResponseCancelled:
                 state.AwaitingInjectedResponseStart = false;
                 ApplyResponseCancelled(state, normalizedEvent.ResponseCancelled.ResponseId);
@@ -509,6 +521,36 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         await PersistRuntimeStateAsync(ctx, state, ct);
     }
 
+    private async Task ScheduleDrainTimeoutAsync(
+        VoicePresenceRuntimeState state,
+        int responseId,
+        IEventHandlerContext ctx,
+        CancellationToken ct)
+    {
+        if (_options.DrainTimeout <= TimeSpan.Zero)
+            return;
+
+        if (responseId <= 0 || state.LeaseEpoch <= 0)
+            return;
+
+        await ctx.ScheduleSelfDurableTimeoutAsync(
+            BuildDrainTimeoutCallbackId(state.LeaseEpoch, responseId),
+            _options.DrainTimeout,
+            new VoiceModuleSignal
+            {
+                ModuleName = Name,
+                DrainTimeoutExpired = new VoiceDrainTimeoutExpired
+                {
+                    SessionId = state.ActiveSessionId ?? string.Empty,
+                    OwnerId = state.ActiveLeaseOwnerId ?? string.Empty,
+                    TransportLeaseId = state.ActiveTransportLeaseId ?? string.Empty,
+                    LeaseEpoch = state.LeaseEpoch,
+                    ResponseId = responseId,
+                },
+            },
+            ct: ct);
+    }
+
     private async Task HandleTransportLeaseRenewRequestedAsync(
         VoiceTransportLeaseRenewRequested request,
         IEventHandlerContext ctx,
@@ -533,6 +575,33 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         }
 
         state.LeaseExpiresAt = request.RenewExpiresAt.Clone();
+        await PersistRuntimeStateAsync(ctx, state, ct);
+    }
+
+    private async Task HandleDrainTimeoutExpiredAsync(
+        VoiceDrainTimeoutExpired request,
+        IEventHandlerContext ctx,
+        CancellationToken ct)
+    {
+        var state = HydrateRuntimeStateFromActor(ctx);
+        if (request == null ||
+            state.Status != VoicePresenceRuntimeStatus.AudioDraining ||
+            request.ResponseId != state.CurrentResponseId ||
+            request.LeaseEpoch <= 0 ||
+            state.LeaseEpoch != request.LeaseEpoch ||
+            !string.Equals(state.ActiveSessionId, request.SessionId, StringComparison.Ordinal) ||
+            !string.Equals(state.ActiveLeaseOwnerId ?? string.Empty, request.OwnerId, StringComparison.Ordinal) ||
+            !string.Equals(
+                state.ActiveTransportLeaseId ?? string.Empty,
+                request.TransportLeaseId,
+                StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        state.LastDrainAckResponseId = request.ResponseId;
+        state.Status = VoicePresenceRuntimeStatus.Idle;
+        await FlushPendingEventInjectionsAsync(state, ct);
         await PersistRuntimeStateAsync(ctx, state, ct);
     }
 
@@ -714,6 +783,9 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
     private bool IsLeaseExpired(Timestamp? leaseExpiresAt) =>
         leaseExpiresAt != null &&
         leaseExpiresAt.ToDateTimeOffset() <= _options.TimeProvider.GetUtcNow();
+
+    private string BuildDrainTimeoutCallbackId(long leaseEpoch, int responseId) =>
+        $"{Name}:voice-drain-timeout:{leaseEpoch}:{responseId}";
 
     private static void ClearTransportLeaseState(VoicePresenceRuntimeState state)
     {
@@ -1732,6 +1804,8 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         long playoutSequence)
     {
         if (responseId != state.CurrentResponseId)
+            return;
+        if (state.LastDrainAckResponseId >= responseId)
             return;
 
         state.LastDrainAckResponseId = responseId;

--- a/src/Aevatar.Foundation.VoicePresence/VoicePresenceModuleOptions.cs
+++ b/src/Aevatar.Foundation.VoicePresence/VoicePresenceModuleOptions.cs
@@ -19,6 +19,8 @@ public sealed class VoicePresenceModuleOptions
 
     public TimeSpan ToolExecutionTimeout { get; init; } = TimeSpan.FromSeconds(10);
 
+    public TimeSpan DrainTimeout { get; init; } = TimeSpan.FromSeconds(5);
+
     public int PendingInjectionCapacity { get; init; } = 16;
 
     public TimeProvider TimeProvider { get; init; } = TimeProvider.System;

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -430,6 +430,7 @@ public static class MainnetHostBuilderExtensions
             StaleAfter = options.StaleAfter,
             DedupeWindow = options.DedupeWindow,
             ToolExecutionTimeout = options.ToolExecutionTimeout,
+            DrainTimeout = options.DrainTimeout,
             PendingInjectionCapacity = options.PendingInjectionCapacity,
             TimeProvider = options.TimeProvider,
             DirectExternalEventTypeUrls = directEventTypeUrls,

--- a/test/Aevatar.Bootstrap.Tests/VoicePresenceModuleOptionsCloneTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/VoicePresenceModuleOptionsCloneTests.cs
@@ -1,0 +1,45 @@
+using System.Reflection;
+using Aevatar.Bootstrap.Extensions.AI;
+using Aevatar.Foundation.VoicePresence;
+using FluentAssertions;
+
+namespace Aevatar.Bootstrap.Tests;
+
+public sealed class VoicePresenceModuleOptionsCloneTests
+{
+    [Fact]
+    public void CloneVoicePresenceModuleOptions_ShouldPreserveConfiguredDrainTimeout()
+    {
+        var options = new VoicePresenceModuleOptions
+        {
+            Name = "voice_presence",
+            DrainTimeout = TimeSpan.FromSeconds(13),
+            DirectExternalEventTypeUrls =
+            [
+                "type.googleapis.com/example.External",
+            ],
+        };
+
+        var clone = InvokeCloneVoicePresenceModuleOptions(options, "voice_presence_openai");
+
+        clone.Name.Should().Be("voice_presence_openai");
+        clone.DrainTimeout.Should().Be(TimeSpan.FromSeconds(13));
+        clone.DirectExternalEventTypeUrls
+            .Should()
+            .ContainSingle("type.googleapis.com/example.External");
+    }
+
+    private static VoicePresenceModuleOptions InvokeCloneVoicePresenceModuleOptions(
+        VoicePresenceModuleOptions options,
+        string resolvedName)
+    {
+        var method = typeof(global::Aevatar.Bootstrap.Extensions.AI.ServiceCollectionExtensions).GetMethod(
+            "CloneVoicePresenceModuleOptions",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        method.Should().NotBeNull();
+
+        var result = method!.Invoke(null, [options, resolvedName]);
+        result.Should().NotBeNull();
+        return result.Should().BeOfType<VoicePresenceModuleOptions>().Subject;
+    }
+}

--- a/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
+++ b/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
@@ -13,6 +13,7 @@ using Aevatar.AI.ToolProviders.Skills;
 using Aevatar.AI.ToolProviders.Telegram;
 using Aevatar.AI.ToolProviders.ToolSetRegistry;
 using Aevatar.AI.ToolProviders.Web;
+using Aevatar.Bootstrap.Extensions.AI;
 using Aevatar.ChatRouting.Abstractions;
 using Aevatar.ChatRouting.Core;
 using Aevatar.Configuration;
@@ -39,6 +40,7 @@ using Aevatar.Workflow.Projection.ReadModels;
 using FluentAssertions;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
+using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
@@ -406,6 +408,23 @@ public sealed class MainnetHostCompositionTests
             .ContainSingle(static name => string.Equals(name, "voice_presence", StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public void ConfigureMainnetAIFeatures_ShouldPreserveConfiguredVoiceDrainTimeout()
+    {
+        var options = new AevatarAIFeatureOptions();
+        options.VoicePresence.Module = new VoicePresenceModuleOptions
+        {
+            DrainTimeout = TimeSpan.FromSeconds(17),
+        };
+
+        InvokeConfigureMainnetAIFeatures(options);
+
+        options.VoicePresence.Module.DrainTimeout.Should().Be(TimeSpan.FromSeconds(17));
+        options.VoicePresence.Module.DirectExternalEventTypeUrls
+            .Should()
+            .ContainSingle("type.googleapis.com/aevatar.gagents.household.DeviceInbound");
+    }
+
     private static WebApplicationBuilder CreateBuilder(IReadOnlyDictionary<string, string?>? overrides = null)
     {
         var options = new WebApplicationOptions
@@ -432,6 +451,16 @@ public sealed class MainnetHostCompositionTests
 
         builder.Configuration.AddInMemoryCollection(values);
         return builder;
+    }
+
+    private static void InvokeConfigureMainnetAIFeatures(AevatarAIFeatureOptions options)
+    {
+        var method = typeof(MainnetHostBuilderExtensions).GetMethod(
+            "ConfigureMainnetAIFeatures",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        method.Should().NotBeNull();
+
+        method!.Invoke(null, [options]);
     }
 
     private static IEnumerable<ServiceDescriptor> HostedServiceDescriptors<THostedService>(IServiceCollection services)

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
@@ -296,6 +296,226 @@ public class VoicePresenceModuleTests
     }
 
     [Fact]
+    public async Task Response_done_on_active_lease_should_schedule_epoch_fenced_drain_timeout()
+    {
+        var module = CreateModule(
+            new RecordingVoiceProvider(),
+            options: new VoicePresenceModuleOptions
+            {
+                DrainTimeout = TimeSpan.FromSeconds(7),
+            });
+        var roleAgent = CreateRoleAgentWithAttachedTransport();
+        var ctx = new StubEventHandlerContext(agent: roleAgent);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = DefaultModuleName,
+            ProviderEventReceived = new VoiceProviderEventReceived
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseEpoch = 7,
+                ProviderEvent = new VoiceProviderEvent
+                {
+                    ResponseStarted = new VoiceResponseStarted
+                    {
+                        ProviderResponseId = "provider-r1",
+                    },
+                },
+            },
+        }), ctx, CancellationToken.None);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = DefaultModuleName,
+            ProviderEventReceived = new VoiceProviderEventReceived
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseEpoch = 7,
+                ProviderEvent = new VoiceProviderEvent
+                {
+                    ResponseDone = new VoiceResponseDone
+                    {
+                        ProviderResponseId = "provider-r1",
+                    },
+                },
+            },
+        }), ctx, CancellationToken.None);
+
+        var scheduled = ctx.ScheduledTimeouts.ShouldHaveSingleItem();
+        scheduled.CallbackId.ShouldBe("voice_presence:voice-drain-timeout:7:1");
+        scheduled.DueTime.ShouldBe(TimeSpan.FromSeconds(7));
+        var signal = scheduled.Event.ShouldBeOfType<VoiceModuleSignal>();
+        signal.SignalCase.ShouldBe(VoiceModuleSignal.SignalOneofCase.DrainTimeoutExpired);
+        signal.DrainTimeoutExpired.SessionId.ShouldBe("lease-current");
+        signal.DrainTimeoutExpired.OwnerId.ShouldBe("host-current");
+        signal.DrainTimeoutExpired.TransportLeaseId.ShouldBe("transport-current");
+        signal.DrainTimeoutExpired.LeaseEpoch.ShouldBe(7);
+        signal.DrainTimeoutExpired.ResponseId.ShouldBe(1);
+        RoleVoiceState(ctx).Status.ShouldBe(VoicePresenceRuntimeStatus.AudioDraining);
+    }
+
+    [Fact]
+    public async Task Drain_timeout_should_release_audio_draining_and_flush_pending_injection()
+    {
+        var provider = new RecordingVoiceProvider();
+        var module = CreateModule(provider);
+        var roleAgent = CreateRoleAgentWithAttachedTransport();
+        roleAgent.State.VoicePresence[DefaultModuleName].Status = VoicePresenceRuntimeStatus.AudioDraining;
+        roleAgent.State.VoicePresence[DefaultModuleName].CurrentResponseId = 4;
+        roleAgent.State.VoicePresence[DefaultModuleName].NextResponseId = 5;
+        roleAgent.State.VoicePresence[DefaultModuleName].PendingInjections.Add(new VoicePendingEventInjection
+        {
+            EnvelopeId = "external-timeout",
+            PublisherActorId = "external-agent",
+            EventType = StringValue.Descriptor.FullName,
+            Payload = Any.Pack(new StringValue { Value = "safety event" }),
+            ObservedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        });
+        var ctx = new StubEventHandlerContext(agent: roleAgent);
+
+        await module.InitializeAsync(CancellationToken.None);
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = DefaultModuleName,
+            DrainTimeoutExpired = new VoiceDrainTimeoutExpired
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseEpoch = 7,
+                ResponseId = 4,
+            },
+        }), ctx, CancellationToken.None);
+
+        provider.InjectedEvents.ShouldHaveSingleItem().EnvelopeId.ShouldBe("external-timeout");
+        var persisted = roleAgent.PersistedStates.ShouldHaveSingleItem().State;
+        persisted.Status.ShouldBe(VoicePresenceRuntimeStatus.Idle);
+        persisted.LastDrainAckResponseId.ShouldBe(4);
+        persisted.LastDrainAckPlayoutSequence.ShouldBe(-1);
+        persisted.PendingInjections.ShouldBeEmpty();
+        persisted.AwaitingInjectedResponseStart.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("response")]
+    [InlineData("epoch")]
+    [InlineData("zero-epoch")]
+    [InlineData("transport")]
+    public async Task Drain_timeout_should_ignore_stale_or_unfenced_signals(string mismatch)
+    {
+        var module = CreateModule(new RecordingVoiceProvider());
+        var roleAgent = CreateRoleAgentWithAttachedTransport();
+        roleAgent.State.VoicePresence[DefaultModuleName].Status = VoicePresenceRuntimeStatus.AudioDraining;
+        roleAgent.State.VoicePresence[DefaultModuleName].CurrentResponseId = 4;
+        roleAgent.State.VoicePresence[DefaultModuleName].NextResponseId = 5;
+        var ctx = new StubEventHandlerContext(agent: roleAgent);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = DefaultModuleName,
+            DrainTimeoutExpired = new VoiceDrainTimeoutExpired
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = mismatch == "transport" ? "transport-stale" : "transport-current",
+                LeaseEpoch = mismatch switch
+                {
+                    "epoch" => 6,
+                    "zero-epoch" => 0,
+                    _ => 7,
+                },
+                ResponseId = mismatch == "response" ? 3 : 4,
+            },
+        }), ctx, CancellationToken.None);
+
+        roleAgent.PersistedStates.ShouldBeEmpty();
+        var state = roleAgent.State.VoicePresence[DefaultModuleName];
+        state.Status.ShouldBe(VoicePresenceRuntimeStatus.AudioDraining);
+        state.LastDrainAckResponseId.ShouldBe(-1);
+    }
+
+    [Fact]
+    public async Task Drain_ack_after_timeout_should_be_idempotent_and_not_set_playout_sentinel()
+    {
+        var module = CreateModule(new RecordingVoiceProvider());
+        var roleAgent = CreateRoleAgentWithAttachedTransport();
+        roleAgent.State.VoicePresence[DefaultModuleName].Status = VoicePresenceRuntimeStatus.AudioDraining;
+        roleAgent.State.VoicePresence[DefaultModuleName].CurrentResponseId = 4;
+        roleAgent.State.VoicePresence[DefaultModuleName].NextResponseId = 5;
+        var ctx = new StubEventHandlerContext(agent: roleAgent);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = DefaultModuleName,
+            DrainTimeoutExpired = new VoiceDrainTimeoutExpired
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseEpoch = 7,
+                ResponseId = 4,
+            },
+        }), ctx, CancellationToken.None);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceControlFrame
+        {
+            DrainAcknowledged = new VoiceDrainAcknowledged
+            {
+                ResponseId = 4,
+                PlayoutSequence = 99,
+            },
+        }), ctx, CancellationToken.None);
+
+        var state = roleAgent.PersistedStates.Last().State;
+        state.Status.ShouldBe(VoicePresenceRuntimeStatus.Idle);
+        state.LastDrainAckResponseId.ShouldBe(4);
+        state.LastDrainAckPlayoutSequence.ShouldBe(-1);
+    }
+
+    [Fact]
+    public async Task Drain_timeout_after_ack_should_be_idempotent_noop()
+    {
+        var module = CreateModule(new RecordingVoiceProvider());
+        var roleAgent = CreateRoleAgentWithAttachedTransport();
+        roleAgent.State.VoicePresence[DefaultModuleName].Status = VoicePresenceRuntimeStatus.AudioDraining;
+        roleAgent.State.VoicePresence[DefaultModuleName].CurrentResponseId = 4;
+        roleAgent.State.VoicePresence[DefaultModuleName].NextResponseId = 5;
+        var ctx = new StubEventHandlerContext(agent: roleAgent);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceControlFrame
+        {
+            DrainAcknowledged = new VoiceDrainAcknowledged
+            {
+                ResponseId = 4,
+                PlayoutSequence = 88,
+            },
+        }), ctx, CancellationToken.None);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = DefaultModuleName,
+            DrainTimeoutExpired = new VoiceDrainTimeoutExpired
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseEpoch = 7,
+                ResponseId = 4,
+            },
+        }), ctx, CancellationToken.None);
+
+        roleAgent.PersistedStates.Count.ShouldBe(1);
+        var state = roleAgent.PersistedStates.Single().State;
+        state.Status.ShouldBe(VoicePresenceRuntimeStatus.Idle);
+        state.LastDrainAckResponseId.ShouldBe(4);
+        state.LastDrainAckPlayoutSequence.ShouldBe(88);
+    }
+
+    [Fact]
     public async Task Response_cancelled_should_return_to_idle()
     {
         var module = CreateModule(new RecordingVoiceProvider());
@@ -2802,6 +3022,8 @@ public class VoicePresenceModuleTests
 
         public List<IMessage> PublishedEvents { get; } = [];
 
+        public List<ScheduledSelfTimeout> ScheduledTimeouts { get; } = [];
+
         public Task PublishAsync<TEvent>(
             TEvent evt,
             TopologyAudience audience = TopologyAudience.Children,
@@ -2835,8 +3057,16 @@ public class VoicePresenceModuleTests
             TimeSpan dueTime,
             IMessage evt,
             EventEnvelopePublishOptions? options = null,
-            CancellationToken ct = default) =>
-            throw new NotSupportedException();
+            CancellationToken ct = default)
+        {
+            _ = options;
+            ct.ThrowIfCancellationRequested();
+            ScheduledTimeouts.Add(new ScheduledSelfTimeout(
+                callbackId,
+                dueTime,
+                evt.Descriptor.Parser.ParseFrom(evt.ToByteArray())));
+            return Task.FromResult(new RuntimeCallbackLease(AgentId, callbackId, ScheduledTimeouts.Count, RuntimeCallbackBackend.InMemory));
+        }
 
         public Task<RuntimeCallbackLease> ScheduleSelfDurableTimerAsync(
             string callbackId,
@@ -2850,6 +3080,8 @@ public class VoicePresenceModuleTests
         public Task CancelDurableCallbackAsync(RuntimeCallbackLease lease, CancellationToken ct = default) =>
             throw new NotSupportedException();
     }
+
+    private sealed record ScheduledSelfTimeout(string CallbackId, TimeSpan DueTime, IMessage Event);
 
     private sealed class StubAgent : IAgent
     {

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
@@ -359,6 +359,136 @@ public class VoicePresenceModuleTests
     }
 
     [Fact]
+    public async Task Duplicate_response_done_while_audio_draining_should_not_schedule_another_timeout()
+    {
+        var module = CreateModule(
+            new RecordingVoiceProvider(),
+            options: new VoicePresenceModuleOptions
+            {
+                DrainTimeout = TimeSpan.FromSeconds(7),
+            });
+        var roleAgent = CreateRoleAgentWithAttachedTransport();
+        var ctx = new StubEventHandlerContext(agent: roleAgent);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = DefaultModuleName,
+            ProviderEventReceived = new VoiceProviderEventReceived
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseEpoch = 7,
+                ProviderEvent = new VoiceProviderEvent
+                {
+                    ResponseStarted = new VoiceResponseStarted
+                    {
+                        ResponseId = 1,
+                    },
+                },
+            },
+        }), ctx, CancellationToken.None);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = DefaultModuleName,
+            ProviderEventReceived = new VoiceProviderEventReceived
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseEpoch = 7,
+                ProviderEvent = new VoiceProviderEvent
+                {
+                    ResponseDone = new VoiceResponseDone
+                    {
+                        ResponseId = 1,
+                    },
+                },
+            },
+        }), ctx, CancellationToken.None);
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = DefaultModuleName,
+            ProviderEventReceived = new VoiceProviderEventReceived
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseEpoch = 7,
+                ProviderEvent = new VoiceProviderEvent
+                {
+                    ResponseDone = new VoiceResponseDone
+                    {
+                        ResponseId = 1,
+                    },
+                },
+            },
+        }), ctx, CancellationToken.None);
+
+        var scheduled = ctx.ScheduledTimeouts.ShouldHaveSingleItem();
+        scheduled.CallbackId.ShouldBe("voice_presence:voice-drain-timeout:7:1");
+        RoleVoiceState(ctx).Status.ShouldBe(VoicePresenceRuntimeStatus.AudioDraining);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task Response_done_with_disabled_drain_timeout_should_remain_audio_draining_without_scheduling(
+        int drainTimeoutSeconds)
+    {
+        var module = CreateModule(
+            new RecordingVoiceProvider(),
+            options: new VoicePresenceModuleOptions
+            {
+                DrainTimeout = TimeSpan.FromSeconds(drainTimeoutSeconds),
+            });
+        var roleAgent = CreateRoleAgentWithAttachedTransport();
+        var ctx = new StubEventHandlerContext(agent: roleAgent);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = DefaultModuleName,
+            ProviderEventReceived = new VoiceProviderEventReceived
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseEpoch = 7,
+                ProviderEvent = new VoiceProviderEvent
+                {
+                    ResponseStarted = new VoiceResponseStarted
+                    {
+                        ResponseId = 1,
+                    },
+                },
+            },
+        }), ctx, CancellationToken.None);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = DefaultModuleName,
+            ProviderEventReceived = new VoiceProviderEventReceived
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseEpoch = 7,
+                ProviderEvent = new VoiceProviderEvent
+                {
+                    ResponseDone = new VoiceResponseDone
+                    {
+                        ResponseId = 1,
+                    },
+                },
+            },
+        }), ctx, CancellationToken.None);
+
+        ctx.ScheduledTimeouts.ShouldBeEmpty();
+        RoleVoiceState(ctx).Status.ShouldBe(VoicePresenceRuntimeStatus.AudioDraining);
+    }
+
+    [Fact]
     public async Task Drain_timeout_should_release_audio_draining_and_flush_pending_injection()
     {
         var provider = new RecordingVoiceProvider();
@@ -1319,7 +1449,12 @@ public class VoicePresenceModuleTests
         state.Status = VoicePresenceRuntimeStatus.AudioDraining;
         state.CurrentResponseId = 4;
         state.NextResponseId = 5;
-        var module = CreateModule(new RecordingVoiceProvider());
+        var module = CreateModule(
+            new RecordingVoiceProvider(),
+            options: new VoicePresenceModuleOptions
+            {
+                TimeProvider = new ManualTimeProvider(now),
+            });
         var ctx = new StubEventHandlerContext(agent: roleAgent);
 
         await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
@@ -1355,7 +1490,12 @@ public class VoicePresenceModuleTests
         var now = new DateTimeOffset(2026, 6, 17, 8, 0, 0, TimeSpan.Zero);
         var oldExpiry = Timestamp.FromDateTimeOffset(now.AddMinutes(5));
         var roleAgent = CreateRoleAgentWithAttachedTransport(now.AddMinutes(10));
-        var module = CreateModule(new RecordingVoiceProvider());
+        var module = CreateModule(
+            new RecordingVoiceProvider(),
+            options: new VoicePresenceModuleOptions
+            {
+                TimeProvider = new ManualTimeProvider(now),
+            });
         var ctx = new StubEventHandlerContext(agent: roleAgent);
 
         await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
@@ -1388,7 +1528,12 @@ public class VoicePresenceModuleTests
         var oldExpiry = Timestamp.FromDateTimeOffset(now.AddMinutes(5));
         var provider = new RecordingVoiceProvider();
         var roleAgent = CreateRoleAgentWithAttachedTransport(now.AddMinutes(10));
-        var module = CreateModule(provider);
+        var module = CreateModule(
+            provider,
+            options: new VoicePresenceModuleOptions
+            {
+                TimeProvider = new ManualTimeProvider(now),
+            });
         var ctx = new StubEventHandlerContext(agent: roleAgent);
 
         await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceProtoTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceProtoTests.cs
@@ -261,6 +261,45 @@ public class VoicePresenceProtoTests
     }
 
     [Fact]
+    public void VoiceModuleSignal_should_roundtrip_drain_timeout_expired_with_tag_19()
+    {
+        var timeout = new VoiceDrainTimeoutExpired
+        {
+            SessionId = "lease-1",
+            OwnerId = "host-1",
+            TransportLeaseId = "transport-1",
+            LeaseEpoch = 14,
+            ResponseId = 5,
+        };
+        var signal = new VoiceModuleSignal
+        {
+            ModuleName = "voice_presence",
+            DrainTimeoutExpired = timeout,
+        };
+
+        var parsed = VoiceModuleSignal.Parser.ParseFrom(signal.ToByteArray());
+        var signalOneof = VoiceModuleSignal.Descriptor.Oneofs
+            .Single(static oneof => oneof.Name == "signal");
+        var timeoutField = signalOneof.Fields
+            .Single(static field => field.Name == "drain_timeout_expired");
+
+        parsed.ShouldBe(signal);
+        parsed.SignalCase.ShouldBe(VoiceModuleSignal.SignalOneofCase.DrainTimeoutExpired);
+        parsed.DrainTimeoutExpired.ShouldBe(timeout);
+        timeoutField.FieldNumber.ShouldBe(19);
+        timeoutField.MessageType.Name.ShouldBe(nameof(VoiceDrainTimeoutExpired));
+        VoiceDrainTimeoutExpired.Descriptor.Fields.InDeclarationOrder()
+            .Select(static field => field.Name)
+            .ShouldBe([
+                "session_id",
+                "owner_id",
+                "transport_lease_id",
+                "lease_epoch",
+                "response_id",
+            ]);
+    }
+
+    [Fact]
     public void VoicePresenceSessionDispatch_should_wrap_transport_control_self_signal()
     {
         var control = new VoiceTransportControlFrameReceived
@@ -338,5 +377,27 @@ public class VoicePresenceProtoTests
         signal.SignalCase.ShouldBe(VoiceModuleSignal.SignalOneofCase.TransportLeaseRenewRequested);
         signal.TransportLeaseRenewRequested.ShouldBe(renew);
         signal.TransportLeaseRenewRequested.ShouldNotBeSameAs(renew);
+    }
+
+    [Fact]
+    public void VoicePresenceSessionDispatch_should_wrap_drain_timeout_direct_signal()
+    {
+        var timeout = new VoiceDrainTimeoutExpired
+        {
+            SessionId = "lease-1",
+            OwnerId = "host-1",
+            TransportLeaseId = "transport-1",
+            LeaseEpoch = 14,
+            ResponseId = 5,
+        };
+
+        var envelope = VoicePresenceSessionDispatch.BuildDirectEnvelope("voice-agent", "voice_presence", timeout);
+        var signal = envelope.Payload.Unpack<VoiceModuleSignal>();
+
+        envelope.Route.ShouldBe(EnvelopeRouteSemantics.CreateDirect(VoicePresenceSessionDispatch.HostPublisherId, "voice-agent"));
+        signal.ModuleName.ShouldBe("voice_presence");
+        signal.SignalCase.ShouldBe(VoiceModuleSignal.SignalOneofCase.DrainTimeoutExpired);
+        signal.DrainTimeoutExpired.ShouldBe(timeout);
+        signal.DrainTimeoutExpired.ShouldNotBeSameAs(timeout);
     }
 }


### PR DESCRIPTION
## Summary / 摘要

修复 #2152：`AudioDraining` 只能由 edge `drainAcknowledged`/cancel/disconnect 解除，无 server-side 超时；edge 不 ack（WS drop / crash / `RequiresDrainAck=false` sink / 丢帧）时 fence 钉死、`IsSafeToInject` 永 false，安全相关 household event 排队到 StaleAfter 被静默丢弃。

- **New**：typed `VoiceDrainTimeoutExpired` self-signal（oneof 19；18 已被 #2151 占用），在可配 `VoicePresenceModuleOptions.DrainTimeout`（默认 5s）后回 actor inbox；按 `response_id` + positive `lease_epoch` 对账后 force-resolve `AudioDraining→Idle` + flush pending injections，**复用** `LastDrainAckResponseId` watermark（幂等，迟到 ack/timeout 互为 no-op）；不新增第二套 release authority、不伪造 edge playout ACK。

design-consensus r5（`adopt-final-strawman`，controller strawman 锁定全部命名）。

## Scope / 范围

9 files（proto + options + dispatch + module handler + 调度 wiring + 2 test + canon）。
- 验证（controller publish-gate）：build 0 err；`Aevatar.Foundation.VoicePresence.Tests` 220 passed；test_stability + architecture_guards + docs_lint 全过。
- 注：implement codex 在最终验证阶段被 gpt-5.5 并发限制中断（worktree 成果完整），controller 直接复验绿后提交。

Closes #2152

🤖 consensus-loop (milestone 23)

⟦AI:AUTO-LOOP⟧
