### PR TITLE
Handle scoped workflow draft accepted polling

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
@@ -809,7 +809,10 @@ export type StudioWorkflowBuildPanelProps = {
   ) => void;
   readonly savePending: boolean;
   readonly canSaveWorkflow: boolean;
-  readonly saveNotice?: { readonly type: 'success' | 'error'; readonly message: string } | null;
+  readonly saveNotice?: {
+    readonly type: 'success' | 'info' | 'error';
+    readonly message: string;
+  } | null;
   readonly workflowGraph: {
     readonly steps: readonly StudioGraphStep[];
     readonly nodes: Node[];
@@ -1344,7 +1347,13 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
           <Alert
             message={saveNotice.message}
             showIcon
-            type={saveNotice.type === 'success' ? 'success' : 'error'}
+            type={
+              saveNotice.type === 'success'
+                ? 'success'
+                : saveNotice.type === 'info'
+                  ? 'info'
+                  : 'error'
+            }
           />
         ) : null}
       </div>

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -116,9 +116,11 @@ import type {
   StudioMemberSummary,
   StudioTeamSummary,
   StudioValidationFinding,
+  StudioWorkflowDraftCreateAcceptedReceipt,
   StudioWorkflowDocument,
   StudioWorkflowFile,
   StudioWorkflowDirectory,
+  StudioWorkflowSaveResult,
 } from '@/shared/studio/models';
 import {
   formatStudioMemberLifecycleStage,
@@ -198,7 +200,7 @@ type BuildSurface = 'editor' | 'scripts' | 'gagent';
 type StudioSurface = 'build' | 'bind' | 'invoke' | 'observe';
 
 type DraftSaveNotice = {
-  readonly type: 'success' | 'error';
+  readonly type: 'success' | 'info' | 'error';
   readonly message: string;
 };
 
@@ -236,6 +238,9 @@ type StudioBindingRunOutcome =
     };
 
 const MEMBER_BINDING_RUN_POLL_ATTEMPTS = 8;
+const WORKFLOW_DRAFT_MATERIALIZATION_ATTEMPTS = 10;
+const WORKFLOW_DRAFT_MATERIALIZATION_DELAY_MS = 900;
+const SAVED_WORKFLOW_QUERY_STALE_MS = 30_000;
 
 // Refactor (iter160/cluster-1200): member binding run waiting uses shared
 //   probeAsyncOperation normalized states instead of duplicated page-local
@@ -659,10 +664,76 @@ function trimOptional(value: string | null | undefined): string {
   return value?.trim() ?? '';
 }
 
+function normalizeWorkflowSaveResult(
+  result: StudioWorkflowSaveResult | StudioWorkflowFile,
+): StudioWorkflowSaveResult {
+  if ('kind' in result) {
+    return result;
+  }
+
+  return {
+    kind: 'materialized',
+    workflow: result,
+  };
+}
+
+function describeWorkflowDraftAcceptedReceipt(
+  receipt: StudioWorkflowDraftCreateAcceptedReceipt,
+): string {
+  return (
+    trimOptional(receipt.readiness.message) ||
+    `Workflow draft ${receipt.workflowId} was accepted. Studio is waiting for the scoped workspace projection.`
+  );
+}
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => {
     globalThis.setTimeout(resolve, ms);
   });
+}
+
+function waitForWorkflowDraftMaterializationTick(): Promise<void> {
+  const testEnvironment =
+    typeof process !== 'undefined' && process.env.NODE_ENV === 'test';
+  return delay(testEnvironment ? 0 : WORKFLOW_DRAFT_MATERIALIZATION_DELAY_MS);
+}
+
+async function waitForWorkflowDraftMaterialized(input: {
+  readonly receipt: StudioWorkflowDraftCreateAcceptedReceipt;
+  readonly scopeId: string;
+}): Promise<StudioWorkflowFile> {
+  let lastNotFound: unknown = null;
+
+  for (
+    let attempt = 0;
+    attempt < WORKFLOW_DRAFT_MATERIALIZATION_ATTEMPTS;
+    attempt += 1
+  ) {
+    try {
+      return await studioApi.getWorkflowDraftFile(
+        input.receipt.workflowId,
+        input.scopeId,
+      );
+    } catch (error) {
+      if (!isStudioApiStatus(error, 404)) {
+        throw error;
+      }
+
+      lastNotFound = error;
+      if (attempt < WORKFLOW_DRAFT_MATERIALIZATION_ATTEMPTS - 1) {
+        await waitForWorkflowDraftMaterializationTick();
+      }
+    }
+  }
+
+  throw lastNotFound instanceof Error
+    ? new Error(
+        `Workflow draft ${input.receipt.workflowId} was accepted but is not readable yet. Retry saving in a moment.`,
+        { cause: lastNotFound },
+      )
+    : new Error(
+        `Workflow draft ${input.receipt.workflowId} was accepted but is not readable yet. Retry saving in a moment.`,
+      );
 }
 
 function normalizeComparableText(value: string | null | undefined): string {
@@ -3217,6 +3288,7 @@ const StudioPage: React.FC = () => {
     queryKey: ['studio-workflow', workflowWorkspaceContextKey, selectedWorkflowId],
     enabled: studioHostReady && Boolean(selectedWorkflowId),
     queryFn: () => studioApi.getWorkflow(selectedWorkflowId, resolvedStudioScopeId),
+    staleTime: SAVED_WORKFLOW_QUERY_STALE_MS,
   });
   const gAgentKindsQuery = useQuery({
     queryKey: ['studio-runtime-gagent-kinds'],
@@ -5451,6 +5523,40 @@ const StudioPage: React.FC = () => {
       workflowWorkspaceContextKey,
     ],
   );
+
+  const waitForAcceptedWorkflowDraft = useCallback(
+    async (
+      receipt: StudioWorkflowDraftCreateAcceptedReceipt,
+    ): Promise<StudioWorkflowFile> => {
+      if (!resolvedStudioScopeId) {
+        throw new Error(
+          `Workflow draft ${receipt.workflowId} was accepted without a workspace scope.`,
+        );
+      }
+
+      const noticeMessage = describeWorkflowDraftAcceptedReceipt(receipt);
+      setSaveNotice({
+        type: 'info',
+        message: noticeMessage,
+      });
+      void message.info(noticeMessage);
+
+      const materializedWorkflow = await waitForWorkflowDraftMaterialized({
+        receipt,
+        scopeId: resolvedStudioScopeId,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ['studio-workspace-workflows', workflowWorkspaceContextKey],
+      });
+      return materializedWorkflow;
+    },
+    [
+      queryClient,
+      resolvedStudioScopeId,
+      workflowWorkspaceContextKey,
+    ],
+  );
+
   const confirmScriptsStudioLeave = useCallback(async () => {
     if (!isBuildScriptsSurface) {
       return true;
@@ -5567,16 +5673,22 @@ const StudioPage: React.FC = () => {
         return;
       }
 
-      const savedWorkflow = await studioApi.saveWorkflow({
-        workflowId: activeWorkflowFile?.workflowId || undefined,
-        draftExists: activeWorkflowFile?.draftExists,
-        scopeId: resolvedStudioScopeId || undefined,
-        directoryId,
-        workflowName,
-        fileName: draftFileName,
-        yaml: savePayload.yaml,
-        layout: savePayload.layout,
-      });
+      const saveResult = normalizeWorkflowSaveResult(
+        await studioApi.saveWorkflow({
+          workflowId: activeWorkflowFile?.workflowId || undefined,
+          draftExists: activeWorkflowFile?.draftExists,
+          scopeId: resolvedStudioScopeId || undefined,
+          directoryId,
+          workflowName,
+          fileName: draftFileName,
+          yaml: savePayload.yaml,
+          layout: savePayload.layout,
+        }),
+      );
+      const savedWorkflow =
+        saveResult.kind === 'accepted'
+          ? await waitForAcceptedWorkflowDraft(saveResult.receipt)
+          : saveResult.workflow;
 
       await applySavedWorkflowSelection(savedWorkflow, {
         document: savePayload.document,
@@ -5968,14 +6080,20 @@ const StudioPage: React.FC = () => {
     setInventoryBusyAction('create');
 
     try {
-      const savedWorkflow = await studioApi.saveWorkflow({
-        scopeId: resolvedStudioScopeId || undefined,
-        directoryId,
-        workflowName,
-        fileName: buildWorkflowFileName(workflowName),
-        yaml: buildBlankDraftYaml(workflowName),
-        layout: buildStudioWorkflowLayout(workflowName, []),
-      });
+      const saveResult = normalizeWorkflowSaveResult(
+        await studioApi.saveWorkflow({
+          scopeId: resolvedStudioScopeId || undefined,
+          directoryId,
+          workflowName,
+          fileName: buildWorkflowFileName(workflowName),
+          yaml: buildBlankDraftYaml(workflowName),
+          layout: buildStudioWorkflowLayout(workflowName, []),
+        }),
+      );
+      const savedWorkflow =
+        saveResult.kind === 'accepted'
+          ? await waitForAcceptedWorkflowDraft(saveResult.receipt)
+          : saveResult.workflow;
 
       await applySavedWorkflowSelection(savedWorkflow);
       setCreateMemberModalOpen(false);
@@ -6156,21 +6274,27 @@ const StudioPage: React.FC = () => {
           ),
           availableStepTypes,
         });
-        const savedWorkflow = await studioApi.saveWorkflow({
-          workflowId,
-          scopeId: resolvedStudioScopeId || undefined,
-          directoryId:
-            (isSelectedWorkflow ? draftDirectoryId : '') ||
-            fallbackWorkflowFile.directoryId ||
-            currentWorkflowSummary?.directoryId ||
-            inventoryDirectoryId,
-          workflowName: nextWorkflowName,
-          fileName: buildWorkflowFileName(nextWorkflowName),
-          yaml: serialized.yaml,
-          layout:
-            (isSelectedWorkflow ? draftWorkflowLayout : null) ||
-            fallbackWorkflowFile.layout,
-        });
+        const saveResult = normalizeWorkflowSaveResult(
+          await studioApi.saveWorkflow({
+            workflowId,
+            scopeId: resolvedStudioScopeId || undefined,
+            directoryId:
+              (isSelectedWorkflow ? draftDirectoryId : '') ||
+              fallbackWorkflowFile.directoryId ||
+              currentWorkflowSummary?.directoryId ||
+              inventoryDirectoryId,
+            workflowName: nextWorkflowName,
+            fileName: buildWorkflowFileName(nextWorkflowName),
+            yaml: serialized.yaml,
+            layout:
+              (isSelectedWorkflow ? draftWorkflowLayout : null) ||
+              fallbackWorkflowFile.layout,
+          }),
+        );
+        const savedWorkflow =
+          saveResult.kind === 'accepted'
+            ? await waitForAcceptedWorkflowDraft(saveResult.receipt)
+            : saveResult.workflow;
 
         if (isSelectedWorkflow) {
           setEditableWorkflowDocument(

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -1243,6 +1243,22 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     },
     [queryClient, route.scopeId],
   );
+  const invalidateSavedWorkflowDraft = React.useCallback(
+    (saved: SavedWorkflowDraft) => {
+      const savedWorkflowId = trimOptional(saved.workflow.workflowId);
+      if (!route.scopeId || !savedWorkflowId) {
+        return;
+      }
+
+      void queryClient.invalidateQueries({
+        queryKey: getTeamMemberWorkflowStudioWorkflowQueryKey(
+          route.scopeId,
+          savedWorkflowId,
+        ),
+      });
+    },
+    [queryClient, route.scopeId],
+  );
   const markSavedDraft = React.useCallback(
     (saved: SavedWorkflowDraft) => {
       cacheSavedWorkflowDraft(saved);
@@ -1432,6 +1448,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     onSuccess: ({ memberId, savedDraft, workflowId }) => {
       setPendingCreatedWorkflowMemberLink(null);
       cacheSavedWorkflowDraft(savedDraft);
+      invalidateSavedWorkflowDraft(savedDraft);
       applySavedDraft(savedDraft);
       void refreshTeamMemberSurfaces(route.scopeId, route.teamId);
       void message.success("Workflow member created.");

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -41,8 +41,10 @@ import type {
   StudioExecutionFrame,
   StudioMemberBindingRunStatusResponse,
   StudioMemberDetail,
+  StudioWorkflowDraftCreateAcceptedReceipt,
   StudioWorkflowDocument,
   StudioWorkflowFile,
+  StudioWorkflowSaveResult,
 } from "@/shared/studio/models";
 
 type TeamMemberWorkflowStudioMode = "new" | "existing";
@@ -209,9 +211,34 @@ const MEMBER_BINDING_RUN_POLL_ATTEMPTS = 8;
 const MEMBER_BINDING_RUN_POLL_DELAY_MS = 900;
 const CREATED_MEMBER_MATERIALIZATION_ATTEMPTS = 8;
 const CREATED_MEMBER_MATERIALIZATION_DELAY_MS = 450;
+const WORKFLOW_DRAFT_MATERIALIZATION_ATTEMPTS = 10;
+const WORKFLOW_DRAFT_MATERIALIZATION_DELAY_MS = 900;
+const SAVED_WORKFLOW_QUERY_STALE_MS = 30_000;
 
 function trimOptional(value: string | null | undefined): string {
   return value?.trim() ?? "";
+}
+
+function normalizeWorkflowSaveResult(
+  result: StudioWorkflowSaveResult | StudioWorkflowFile,
+): StudioWorkflowSaveResult {
+  if ("kind" in result) {
+    return result;
+  }
+
+  return {
+    kind: "materialized",
+    workflow: result,
+  };
+}
+
+function describeWorkflowDraftAcceptedReceipt(
+  receipt: StudioWorkflowDraftCreateAcceptedReceipt,
+): string {
+  return (
+    trimOptional(receipt.readiness.message) ||
+    `Workflow draft ${receipt.workflowId} was accepted. Studio is waiting for the scoped workspace projection.`
+  );
 }
 
 function hasCurrentCompletedMemberBinding(
@@ -480,6 +507,17 @@ function waitForCreatedMemberMaterializationTick(): Promise<void> {
   });
 }
 
+function waitForWorkflowDraftMaterializationTick(): Promise<void> {
+  return new Promise((resolve) => {
+    const testEnvironment =
+      typeof process !== "undefined" && process.env.NODE_ENV === "test";
+    window.setTimeout(
+      resolve,
+      testEnvironment ? 0 : WORKFLOW_DRAFT_MATERIALIZATION_DELAY_MS,
+    );
+  });
+}
+
 async function waitForCreatedMemberVisible(input: {
   readonly memberId: string;
   readonly scopeId: string;
@@ -512,6 +550,44 @@ async function waitForCreatedMemberVisible(input: {
       )
     : new Error(
         `Workflow member ${input.memberId} was created but is not visible yet. Retry saving in a moment.`,
+      );
+}
+
+async function waitForWorkflowDraftMaterialized(input: {
+  readonly receipt: StudioWorkflowDraftCreateAcceptedReceipt;
+  readonly scopeId: string;
+}): Promise<StudioWorkflowFile> {
+  let lastNotFound: unknown = null;
+
+  for (
+    let attempt = 0;
+    attempt < WORKFLOW_DRAFT_MATERIALIZATION_ATTEMPTS;
+    attempt += 1
+  ) {
+    try {
+      return await studioApi.getWorkflowDraftFile(
+        input.receipt.workflowId,
+        input.scopeId,
+      );
+    } catch (error) {
+      if (!isStudioApiStatus(error, 404)) {
+        throw error;
+      }
+
+      lastNotFound = error;
+      if (attempt < WORKFLOW_DRAFT_MATERIALIZATION_ATTEMPTS - 1) {
+        await waitForWorkflowDraftMaterializationTick();
+      }
+    }
+  }
+
+  throw lastNotFound instanceof Error
+    ? new Error(
+        `Workflow draft ${input.receipt.workflowId} was accepted but is not readable yet. Retry saving in a moment.`,
+        { cause: lastNotFound },
+      )
+    : new Error(
+        `Workflow draft ${input.receipt.workflowId} was accepted but is not readable yet. Retry saving in a moment.`,
       );
 }
 
@@ -808,16 +884,28 @@ async function saveWorkflowDraft(input: {
     graphForLayout.nodes,
     layout ?? workflow.layout,
   );
-  const savedWorkflow = await studioApi.saveWorkflow({
-    workflowId: workflow.workflowId,
-    draftExists: workflow.draftExists,
-    scopeId: routeScopeId,
-    directoryId: workflow.directoryId,
-    workflowName: normalizedTitle,
-    fileName: workflow.fileName,
-    yaml: serialized.yaml,
-    layout: nextLayout,
-  });
+  const saveResult = normalizeWorkflowSaveResult(
+    await studioApi.saveWorkflow({
+      workflowId: workflow.workflowId,
+      draftExists: workflow.draftExists,
+      scopeId: routeScopeId,
+      directoryId: workflow.directoryId,
+      workflowName: normalizedTitle,
+      fileName: workflow.fileName,
+      yaml: serialized.yaml,
+      layout: nextLayout,
+    }),
+  );
+  if (saveResult.kind === "accepted") {
+    void message.info(describeWorkflowDraftAcceptedReceipt(saveResult.receipt));
+  }
+  const savedWorkflow =
+    saveResult.kind === "accepted"
+      ? await waitForWorkflowDraftMaterialized({
+          receipt: saveResult.receipt,
+          scopeId: routeScopeId,
+        })
+      : saveResult.workflow;
 
   return {
     document: savedDocument,
@@ -990,6 +1078,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     ),
     queryKey: workflowQueryKey,
     queryFn: () => studioApi.getWorkflow(routeDraftWorkflowId, route.scopeId),
+    staleTime: SAVED_WORKFLOW_QUERY_STALE_MS,
     retry: false,
   });
   const activeDraftWorkflowId =
@@ -1134,14 +1223,29 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     setWorkflowTitleState(saved.title);
     setDirty(false);
   }, []);
-  const markSavedDraft = React.useCallback(
+  const cacheSavedWorkflowDraft = React.useCallback(
     (saved: SavedWorkflowDraft) => {
       const savedWorkflow = buildSavedWorkflowCacheValue(saved);
       const savedSignature = readWorkflowSourceSignature(savedWorkflow);
-      if (savedSignature && route.scopeId && routeDraftWorkflowId) {
-        suppressedSourceSignatureRef.current = savedSignature;
-        queryClient.setQueryData(workflowQueryKey, savedWorkflow);
+      const savedWorkflowId = trimOptional(savedWorkflow.workflowId);
+      if (!savedSignature || !route.scopeId || !savedWorkflowId) {
+        return;
       }
+
+      suppressedSourceSignatureRef.current = savedSignature;
+      queryClient.setQueryData(
+        getTeamMemberWorkflowStudioWorkflowQueryKey(
+          route.scopeId,
+          savedWorkflowId,
+        ),
+        savedWorkflow,
+      );
+    },
+    [queryClient, route.scopeId],
+  );
+  const markSavedDraft = React.useCallback(
+    (saved: SavedWorkflowDraft) => {
+      cacheSavedWorkflowDraft(saved);
 
       setEditableDocument((currentDocument) =>
         currentDocument
@@ -1157,10 +1261,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       setDirty(false);
     },
     [
-      queryClient,
-      routeDraftWorkflowId,
-      route.scopeId,
-      workflowQueryKey,
+      cacheSavedWorkflowDraft,
     ],
   );
   const renameExistingMemberFromTitle = React.useCallback(
@@ -1330,6 +1431,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     },
     onSuccess: ({ memberId, savedDraft, workflowId }) => {
       setPendingCreatedWorkflowMemberLink(null);
+      cacheSavedWorkflowDraft(savedDraft);
       applySavedDraft(savedDraft);
       void refreshTeamMemberSurfaces(route.scopeId, route.teamId);
       void message.success("Workflow member created.");
@@ -1399,16 +1501,6 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       });
       await renameExistingMemberFromTitle(normalizedTitle);
 
-      history.replace(
-        buildTeamMemberWorkflowStudioHref({
-          memberId: route.memberId,
-          mode: "edit-member",
-          scopeId: route.scopeId,
-          teamId: route.teamId,
-          workflowId: savedWorkflowId,
-        }),
-      );
-
       return {
         savedDraft,
         workflowId: savedWorkflowId,
@@ -1422,7 +1514,17 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       );
     },
     onSuccess: ({ savedDraft, workflowId }) => {
+      cacheSavedWorkflowDraft(savedDraft);
       applySavedDraft(savedDraft);
+      history.replace(
+        buildTeamMemberWorkflowStudioHref({
+          memberId: route.memberId,
+          mode: "edit-member",
+          scopeId: route.scopeId,
+          teamId: route.teamId,
+          workflowId,
+        }),
+      );
       void memberQuery.refetch();
       void refreshTeamMemberSurfaces(route.scopeId, route.teamId);
       void message.success("Workflow draft saved.");

--- a/apps/aevatar-console-web/src/shared/studio/api.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.ts
@@ -56,9 +56,11 @@ import type {
   StudioUserConfigRuntime,
   StudioUserLlmSettings,
   StudioWorkflowDraft,
+  StudioWorkflowDraftCreateAcceptedReceipt,
   StudioWorkflowDraftSummary,
   StudioWorkflowDocument,
   StudioWorkflowFile,
+  StudioWorkflowSaveResult,
   StudioWorkflowSummary,
   StudioWorkspaceSettings,
 } from "./models";
@@ -222,6 +224,59 @@ function toWorkflowFile(
     document: null,
     draftExists,
     findings: [],
+  };
+}
+
+function decodeStudioWorkflowDraft(
+  value: unknown,
+  label = "StudioWorkflowDraft"
+): StudioWorkflowDraft {
+  const record = expectRecord(value, label);
+  return {
+    workflowId: readString(record, "workflowId", `${label}.workflowId`),
+    name: readString(record, "name", `${label}.name`),
+    fileName: readString(record, "fileName", `${label}.fileName`),
+    filePath: readString(record, "filePath", `${label}.filePath`),
+    directoryId: readString(record, "directoryId", `${label}.directoryId`),
+    directoryLabel: readString(
+      record,
+      "directoryLabel",
+      `${label}.directoryLabel`
+    ),
+    yaml: readString(record, "yaml", `${label}.yaml`),
+    layout: record.layout,
+    updatedAtUtc: readString(record, "updatedAtUtc", `${label}.updatedAtUtc`),
+  };
+}
+
+function decodeStudioWorkflowDraftCreateAcceptedReceipt(
+  value: unknown,
+  label = "StudioWorkflowDraftCreateAcceptedReceipt"
+): StudioWorkflowDraftCreateAcceptedReceipt {
+  const record = expectRecord(value, label);
+  const readiness = expectRecord(record.readiness, `${label}.readiness`);
+  const accepted = readBoolean(record, "accepted", `${label}.accepted`);
+  if (!accepted) {
+    throw new Error(`${label}.accepted must be true.`);
+  }
+
+  return {
+    accepted,
+    workflowId: readString(record, "workflowId", `${label}.workflowId`),
+    commandId: readString(record, "commandId", `${label}.commandId`),
+    ackStage: readString(record, "ackStage", `${label}.ackStage`),
+    actorId: readString(record, "actorId", `${label}.actorId`),
+    workspaceId: readString(record, "workspaceId", `${label}.workspaceId`),
+    expectedVersion:
+      record.expectedVersion === null || record.expectedVersion === undefined
+        ? null
+        : readNumber(record, "expectedVersion", `${label}.expectedVersion`),
+    ackedAtUtc: readString(record, "ackedAtUtc", `${label}.ackedAtUtc`),
+    readiness: {
+      readable: readBoolean(readiness, "readable", `${label}.readiness.readable`),
+      stage: readString(readiness, "stage", `${label}.readiness.stage`),
+      message: readString(readiness, "message", `${label}.readiness.message`),
+    },
   };
 }
 
@@ -1832,10 +1887,18 @@ export const studioApi = {
     );
   },
 
+  async getWorkflowDraftFile(
+    workflowId: string,
+    scopeId?: string | null
+  ): Promise<StudioWorkflowFile> {
+    const draft = await this.getWorkflowDraft(workflowId, scopeId);
+    return toWorkflowFile(draft, true);
+  },
+
   createWorkflowDraft(
     input: Omit<StudioSaveWorkflowInput, "workflowId">
-  ): Promise<StudioWorkflowDraft> {
-    return requestJson(withOptionalScopeId("/api/workspace/workflow-drafts", input.scopeId), {
+  ): Promise<StudioWorkflowSaveResult> {
+    return studioHostFetch(withOptionalScopeId("/api/workspace/workflow-drafts", input.scopeId), {
       method: "POST",
       headers: JSON_HEADERS,
       body: JSON.stringify(
@@ -1847,6 +1910,23 @@ export const studioApi = {
           layout: input.layout,
         })
       ),
+    }).then(async (response) => {
+      if (!response.ok) {
+        throw await createStudioApiError(response);
+      }
+
+      const payload = await response.json();
+      if (response.status === 202) {
+        return {
+          kind: "accepted",
+          receipt: decodeStudioWorkflowDraftCreateAcceptedReceipt(payload),
+        };
+      }
+
+      return {
+        kind: "materialized",
+        workflow: toWorkflowFile(decodeStudioWorkflowDraft(payload), true),
+      };
     });
   },
 
@@ -1959,25 +2039,30 @@ export const studioApi = {
     );
   },
 
-  saveWorkflow(input: StudioSaveWorkflowInput): Promise<StudioWorkflowFile> {
+  async saveWorkflow(input: StudioSaveWorkflowInput): Promise<StudioWorkflowSaveResult> {
     const normalizedWorkflowId = trimOptional(input.workflowId);
     const shouldUpdate =
       Boolean(normalizedWorkflowId) &&
       (input.draftExists ?? Boolean(normalizedWorkflowId));
-    const request = shouldUpdate && normalizedWorkflowId
-      ? this.updateWorkflowDraft({
-          ...input,
-          workflowId: normalizedWorkflowId,
-        })
-      : this.createWorkflowDraft({
-          scopeId: input.scopeId,
-          directoryId: input.directoryId,
-          workflowName: input.workflowName,
-          fileName: input.fileName,
-          yaml: input.yaml,
-          layout: input.layout,
-        });
-    return request.then((draft) => toWorkflowFile(draft, true));
+    if (shouldUpdate && normalizedWorkflowId) {
+      const draft = await this.updateWorkflowDraft({
+        ...input,
+        workflowId: normalizedWorkflowId,
+      });
+      return {
+        kind: "materialized",
+        workflow: toWorkflowFile(draft, true),
+      };
+    }
+
+    return this.createWorkflowDraft({
+      scopeId: input.scopeId,
+      directoryId: input.directoryId,
+      workflowName: input.workflowName,
+      fileName: input.fileName,
+      yaml: input.yaml,
+      layout: input.layout,
+    });
   },
 
   deleteWorkflow(

--- a/apps/aevatar-console-web/src/shared/studio/models.ts
+++ b/apps/aevatar-console-web/src/shared/studio/models.ts
@@ -152,6 +152,24 @@ export interface StudioSaveWorkflowInput {
   readonly layout?: unknown;
 }
 
+export interface StudioWorkflowDraftCreateReadiness {
+  readonly readable: boolean;
+  readonly stage: string;
+  readonly message: string;
+}
+
+export interface StudioWorkflowDraftCreateAcceptedReceipt {
+  readonly accepted: true;
+  readonly workflowId: string;
+  readonly commandId: string;
+  readonly ackStage: string;
+  readonly actorId: string;
+  readonly workspaceId: string;
+  readonly expectedVersion?: number | null;
+  readonly ackedAtUtc: string;
+  readonly readiness: StudioWorkflowDraftCreateReadiness;
+}
+
 export interface StudioParseYamlResult {
   readonly document?: StudioWorkflowDocument | null;
   readonly graph?: unknown;
@@ -165,6 +183,16 @@ export type StudioWorkflowFile = StudioWorkflowDraft & {
   readonly draftExists?: boolean;
   readonly findings: StudioValidationFinding[];
 };
+
+export type StudioWorkflowSaveResult =
+  | {
+      readonly kind: "materialized";
+      readonly workflow: StudioWorkflowFile;
+    }
+  | {
+      readonly kind: "accepted";
+      readonly receipt: StudioWorkflowDraftCreateAcceptedReceipt;
+    };
 
 export interface StudioSerializeYamlResult {
   readonly yaml: string;


### PR DESCRIPTION
## Summary
- Decode scoped workflow draft create `202 Accepted` responses as accepted/readiness receipts.
- Poll the single draft detail endpoint by returned `workflowId`, treating interim `404` as projection pending.
- Apply saved workflow selection and Team member workflow linking only after the draft detail read model returns a real `WorkflowDraftResponse`.

## Validation
- `pnpm --dir apps/aevatar-console-web tsc --pretty false`
- `git diff --check`

## Notes
- Frontend-only change.
- Unit tests intentionally deferred until manual validation passes.