### PR TITLE
Canonize approval quota ledger external boundary

### DIFF
--- a/docs/canon/approval-quota-ledger.md
+++ b/docs/canon/approval-quota-ledger.md
@@ -1,0 +1,103 @@
+---
+title: "Approval Quota Ledger"
+status: active
+owner: architecture
+---
+
+# Approval Quota Ledger
+
+Approval workflows sometimes need to check and consume an allowance before or after a human decision. The allowance itself is not an Aevatar fact. It belongs to an external quota backend or to the native account system of the channel that already owns the allowance.
+
+This document defines the Aevatar-side canon for that boundary. The machine-readable profile is [approval-quota-ledger.openapi.yaml](../contracts/approval-quota-ledger.openapi.yaml). Aevatar may call a registered service through NyxID proxy or expose its marked operations as connected-service tools, but Aevatar must not create a parallel quota ledger.
+
+## 1. Ownership
+
+The authoritative source for each quota fact is one of two surfaces:
+
+| Route | Authority | When to use |
+|---|---|---|
+| A. External `QuotaLedger` backend | A dedicated downstream service registered in NyxID | The target workflow needs a reusable approval allowance ledger and no channel-native system already owns the quota. |
+| B. Channel-native ledger | The channel or SaaS platform that already stores and consumes the allowance | The platform exposes read/write APIs with sufficient scopes and a real subject probe proves the target subject can be resolved. |
+
+NyxID is the credential, proxy, approval, audit, and service-discovery channel. It is not the quota authority. Aevatar is the workflow and orchestration caller. It is not the quota authority.
+
+## 2. Route A: `QuotaLedger` connected-service profile
+
+Route A uses a downstream service that implements the OpenAPI profile in `docs/contracts/approval-quota-ledger.openapi.yaml` and is registered as a NyxID connected service.
+
+Required operations:
+
+| Operation | Purpose | Mutation |
+|---|---|---|
+| `GET /balances` | Read current available quota for a subject. | No |
+| `POST /balances/reserve` | Hold quota before a side effect or approval branch completes. | Yes |
+| `POST /balances/deduct` | Finalize a reservation after approval succeeds. | Yes |
+| `POST /balances/release` | Release a reservation after rejection, cancellation, expiry, or pre-deduct failure. | Yes |
+
+Required semantic fields are explicit: `subject_id`, `quota_type`, `unit`, `available`, `amount`, `idempotency_key`, `reservation_id`, `ledger_transaction_id`, `effective_at`, and `expires_at`. Do not replace these with a generic bag.
+
+A route A service is not considered usable until all of these facts are recorded in the issue or PR that wires the workflow:
+
+1. NyxID service slug or user-service id, with secrets redacted.
+2. OpenAPI spec URL or checked-in equivalent.
+3. Subject mapping rule, such as channel user id to employee id.
+4. Successful read probe against a real non-production subject.
+5. Successful reserve probe and repeated idempotency probe.
+6. Successful deduct or release probe in a non-production allowance bucket.
+
+## 3. Route B: Channel-Native Ledger
+
+Route B is preferred when the downstream channel already owns the allowance and exposes enough API surface to support the workflow without duplicating facts.
+
+Before choosing route B, record:
+
+1. The channel API endpoints used for read and mutation.
+2. Required OAuth scopes, service permissions, or app grants.
+3. The subject mapping from Aevatar caller or channel sender to the channel's quota subject.
+4. A read probe for a real non-production subject.
+5. A side-effect probe or documented sandbox constraint that proves how the channel consumes or releases quota.
+
+If the channel API automatically consumes quota as part of the approved business action, Aevatar must not also call route A `deduct`. That would create a double-spend path. If the channel only reads quota but does not reserve or consume it, route B is insufficient for workflows that require a hold before approval.
+
+## 4. Workflow Orchestration
+
+No workflow should be changed to call quota endpoints until the selected route has real service registration and probe evidence. Once evidence exists, the expected route A workflow shape is:
+
+1. Read `GET /balances` for the target `subject_id`, `quota_type`, and `unit`.
+2. Reserve the requested `amount` with a stable `idempotency_key`.
+3. Run the human approval step.
+4. On approval success, call `deduct` with a new stable `idempotency_key`.
+5. On rejection, cancellation, expiry, or pre-deduct failure, call `release` with a new stable `idempotency_key`.
+
+Idempotency keys are part of the external ledger contract. Aevatar can derive them from stable run, step, and action identifiers, then pass them through the existing NyxID proxy call. Repeated reserve, deduct, or release calls for the same logical action must return the same external result or an explicit conflict.
+
+## 5. Aevatar Boundaries
+
+The following are not allowed:
+
+1. An Aevatar-owned quota balance actor, readmodel, or database table for these allowance facts.
+2. A process-local service catalog keyed by service slug, subject id, workflow run id, or session id.
+3. Query-time replay, projection priming, or a workflow-side balance reconstruction path.
+4. Direct calls to a downstream quota backend that bypass NyxID proxy when NyxID is the configured credential channel.
+5. A dependency on new NyxID endpoints, schema fields, or repository changes.
+
+If a future product requirement needs Aevatar to own cross-channel quota aggregation, that is a different capability. It needs an actor-owned domain model and a separate design decision before implementation.
+
+## 6. Probe Evidence Template
+
+Use this template in the implementation issue or PR. Do not paste tokens, raw secrets, or personally sensitive balance values.
+
+| Field | Value |
+|---|---|
+| Selected route | `A: QuotaLedger` or `B: channel-native` |
+| NyxID service slug / channel service | `<redacted slug or service id>` |
+| Subject mapping | `<source identifier> -> <external subject id shape>` |
+| Quota type and unit | `<quota_type>` / `<unit>` |
+| Read probe command | `<redacted command or HTTP request>` |
+| Read probe assertion | `subject resolved`, `available present`, `effective_at present` |
+| Reserve or channel mutation probe | `<redacted command or HTTP request>` |
+| Idempotency assertion | `repeat returned same reservation or transaction` |
+| Deduct/release assertion | `deduct finalized` or `release restored hold` |
+| Approval policy | `NyxID approval config or channel-native approval note` |
+
+Keep the evidence with the change that wires the real workflow. This canon file remains the stable contract and decision guide; it is not a ledger of individual probe runs.

--- a/docs/canon/nyxid-connected-service-tools.md
+++ b/docs/canon/nyxid-connected-service-tools.md
@@ -92,7 +92,15 @@ token 可见性与 `NyxIdProxyTool` 一致：user token 优先，org-only 的 se
 - 不绕过 NyxID proxy 直接打下游 base URL。
 - 不引入新的投影主链或 read model。
 
-## 6. 相关代码
+## 6. `QuotaLedger` profile
+
+审批额度账本使用同一条 connected-service 边界。`QuotaLedger` 不是 Aevatar 内部账本，也不是 NyxID 新能力；它只是一个外部 REST service profile，契约见 [approval-quota-ledger.openapi.yaml](../contracts/approval-quota-ledger.openapi.yaml)，权威口径见 [approval-quota-ledger.md](approval-quota-ledger.md)。
+
+注册时把该 OpenAPI spec 挂到现有 NyxID service 上，Aevatar 仍通过 NyxID live discovery 读取 spec，并通过 `proxy/s/{slug}/...` 调用 `GET /balances`、`POST /balances/reserve`、`POST /balances/deduct` 和 `POST /balances/release`。余额、reservation、deduction transaction 都归外部 ledger 或渠道原生账本拥有；Aevatar 只传递强类型字段和稳定 idempotency key。
+
+如果目标渠道已经原生维护额度，优先记录渠道 API、scope 和真实 subject probe，再直接使用渠道原生账本。渠道自动扣减时不得再调用 `QuotaLedger` deduct。
+
+## 7. 相关代码
 
 - `src/Aevatar.AI.ToolProviders.NyxId/NyxIdConnectedServiceToolSource.cs`
 - `src/Aevatar.AI.ToolProviders.NyxId/ConnectedServices/`（marker / 解析 / schema 内联 / 命名 / proxy tool）

--- a/docs/canon/overview.md
+++ b/docs/canon/overview.md
@@ -17,6 +17,8 @@ owner: eanzhao
 
 新增功能的落点先读 [module-placement-map.md](module-placement-map.md)。该入口按 feature family 给出 tier、actor/domain owner、Application command/query、Projection/readmodel、Infrastructure/provider、Host/bootstrap 与 cross-actor protocol 的默认位置，避免从项目引用图反推架构职责。
 
+审批额度账本边界见 [approval-quota-ledger.md](approval-quota-ledger.md)：额度事实源属于外部 connected service 或渠道原生账本，不属于 Aevatar runtime、readmodel 或 projection 主链。
+
 ## 2. 解决方案结构
 
 ```mermaid

--- a/docs/contracts/approval-quota-ledger.openapi.yaml
+++ b/docs/contracts/approval-quota-ledger.openapi.yaml
@@ -1,0 +1,428 @@
+openapi: 3.1.0
+info:
+  title: Approval Quota Ledger Connected-Service Profile
+  version: 0.1.0
+  description: >
+    External quota ledger profile for approval workflows. The ledger authority is
+    an external backend or a channel-native account system; Aevatar consumes this
+    contract through NyxID proxy or connected-service tools and does not own the
+    balance facts.
+servers:
+  - url: https://quota-ledger.example.com
+    description: Placeholder external ledger origin registered behind NyxID.
+tags:
+  - name: balances
+    description: Quota balance lookup and reservation operations.
+paths:
+  /balances:
+    get:
+      tags:
+        - balances
+      operationId: listQuotaBalances
+      summary: List quota balances for a subject.
+      description: >
+        Returns the external ledger's current balance facts for one subject.
+        This operation is read-only and must not reserve, deduct, or release
+        quota.
+      x-aevatar-tool:
+        enabled: true
+        name: quota_list_balances
+        readOnly: true
+        destructive: false
+        approval: auto
+      parameters:
+        - $ref: '#/components/parameters/SubjectId'
+        - $ref: '#/components/parameters/QuotaType'
+        - $ref: '#/components/parameters/Unit'
+      responses:
+        '200':
+          description: Current balances for the requested subject.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BalanceListResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /balances/reserve:
+    post:
+      tags:
+        - balances
+      operationId: reserveQuota
+      summary: Reserve quota before an approval side effect.
+      description: >
+        Places a temporary hold against available quota. The same
+        idempotency_key must return the same reservation result.
+      x-aevatar-tool:
+        enabled: true
+        name: quota_reserve
+        readOnly: false
+        destructive: false
+        approval: always
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReserveQuotaRequest'
+      responses:
+        '200':
+          description: Existing reservation returned for a repeated idempotency key.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReserveQuotaResponse'
+        '201':
+          description: New reservation created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReserveQuotaResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          $ref: '#/components/responses/Conflict'
+  /balances/deduct:
+    post:
+      tags:
+        - balances
+      operationId: deductReservedQuota
+      summary: Convert a reservation into a final quota deduction.
+      description: >
+        Finalizes a previously reserved amount after the business approval has
+        completed. The same idempotency_key must return the same transaction
+        result.
+      x-aevatar-tool:
+        enabled: true
+        name: quota_deduct
+        readOnly: false
+        destructive: true
+        approval: always
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeductQuotaRequest'
+      responses:
+        '200':
+          description: Existing or newly finalized deduction.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeductQuotaResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+  /balances/release:
+    post:
+      tags:
+        - balances
+      operationId: releaseReservedQuota
+      summary: Release a reservation that will not be deducted.
+      description: >
+        Releases a previously reserved amount when approval is rejected,
+        cancelled, expired, or fails before the final deduction.
+      x-aevatar-tool:
+        enabled: true
+        name: quota_release
+        readOnly: false
+        destructive: false
+        approval: always
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReleaseQuotaRequest'
+      responses:
+        '200':
+          description: Existing or newly released reservation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReleaseQuotaResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+components:
+  parameters:
+    SubjectId:
+      name: subject_id
+      in: query
+      required: true
+      description: External ledger subject, such as an employee, account, or channel user id.
+      schema:
+        $ref: '#/components/schemas/SubjectId'
+    QuotaType:
+      name: quota_type
+      in: query
+      required: false
+      description: Optional quota bucket filter.
+      schema:
+        $ref: '#/components/schemas/QuotaType'
+    Unit:
+      name: unit
+      in: query
+      required: false
+      description: Optional unit filter.
+      schema:
+        $ref: '#/components/schemas/QuotaUnit'
+  responses:
+    BadRequest:
+      description: The request is malformed or violates the ledger contract.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Unauthorized:
+      description: The external ledger rejected the credential supplied by NyxID.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    NotFound:
+      description: The requested subject or reservation was not found.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Conflict:
+      description: The operation conflicts with current ledger state.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+  schemas:
+    SubjectId:
+      type: string
+      minLength: 1
+      maxLength: 256
+      description: Stable subject identifier in the external ledger.
+      examples:
+        - employee:12345
+    QuotaType:
+      type: string
+      minLength: 1
+      maxLength: 128
+      pattern: '^[A-Za-z0-9._:-]+$'
+      description: Ledger-owned quota bucket name.
+      examples:
+        - annual_leave
+    QuotaUnit:
+      type: string
+      minLength: 1
+      maxLength: 64
+      pattern: '^[A-Za-z0-9._:-]+$'
+      description: Unit used by the ledger for this quota bucket.
+      examples:
+        - day
+        - hour
+    Amount:
+      type: number
+      format: double
+      minimum: 0
+      description: Non-negative quota amount in the declared unit.
+      examples:
+        - 1
+        - 0.5
+    IdempotencyKey:
+      type: string
+      minLength: 8
+      maxLength: 256
+      description: Caller-supplied stable key for one logical reserve, deduct, or release action.
+      examples:
+        - approval-run-123-step-reserve
+    ReservationId:
+      type: string
+      minLength: 1
+      maxLength: 256
+      description: Ledger-issued reservation identifier.
+      examples:
+        - rsv_12345
+    LedgerTransactionId:
+      type: string
+      minLength: 1
+      maxLength: 256
+      description: Ledger-issued transaction identifier for a finalized mutation.
+      examples:
+        - txn_12345
+    Timestamp:
+      type: string
+      format: date-time
+      description: RFC 3339 timestamp from the external ledger.
+    Balance:
+      type: object
+      additionalProperties: false
+      required:
+        - subject_id
+        - quota_type
+        - unit
+        - available
+        - effective_at
+      properties:
+        subject_id:
+          $ref: '#/components/schemas/SubjectId'
+        quota_type:
+          $ref: '#/components/schemas/QuotaType'
+        unit:
+          $ref: '#/components/schemas/QuotaUnit'
+        available:
+          $ref: '#/components/schemas/Amount'
+        effective_at:
+          $ref: '#/components/schemas/Timestamp'
+    BalanceListResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - balances
+        - effective_at
+      properties:
+        balances:
+          type: array
+          minItems: 0
+          items:
+            $ref: '#/components/schemas/Balance'
+        effective_at:
+          $ref: '#/components/schemas/Timestamp'
+    ReserveQuotaRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - subject_id
+        - quota_type
+        - unit
+        - amount
+        - idempotency_key
+        - expires_at
+      properties:
+        subject_id:
+          $ref: '#/components/schemas/SubjectId'
+        quota_type:
+          $ref: '#/components/schemas/QuotaType'
+        unit:
+          $ref: '#/components/schemas/QuotaUnit'
+        amount:
+          $ref: '#/components/schemas/Amount'
+        idempotency_key:
+          $ref: '#/components/schemas/IdempotencyKey'
+        expires_at:
+          $ref: '#/components/schemas/Timestamp'
+    ReserveQuotaResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - subject_id
+        - quota_type
+        - unit
+        - amount
+        - reservation_id
+        - available
+        - effective_at
+        - expires_at
+      properties:
+        subject_id:
+          $ref: '#/components/schemas/SubjectId'
+        quota_type:
+          $ref: '#/components/schemas/QuotaType'
+        unit:
+          $ref: '#/components/schemas/QuotaUnit'
+        amount:
+          $ref: '#/components/schemas/Amount'
+        reservation_id:
+          $ref: '#/components/schemas/ReservationId'
+        available:
+          $ref: '#/components/schemas/Amount'
+        effective_at:
+          $ref: '#/components/schemas/Timestamp'
+        expires_at:
+          $ref: '#/components/schemas/Timestamp'
+    DeductQuotaRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - reservation_id
+        - amount
+        - idempotency_key
+      properties:
+        reservation_id:
+          $ref: '#/components/schemas/ReservationId'
+        amount:
+          $ref: '#/components/schemas/Amount'
+        idempotency_key:
+          $ref: '#/components/schemas/IdempotencyKey'
+    DeductQuotaResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - reservation_id
+        - amount
+        - ledger_transaction_id
+        - effective_at
+      properties:
+        reservation_id:
+          $ref: '#/components/schemas/ReservationId'
+        amount:
+          $ref: '#/components/schemas/Amount'
+        ledger_transaction_id:
+          $ref: '#/components/schemas/LedgerTransactionId'
+        effective_at:
+          $ref: '#/components/schemas/Timestamp'
+    ReleaseQuotaRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - reservation_id
+        - idempotency_key
+      properties:
+        reservation_id:
+          $ref: '#/components/schemas/ReservationId'
+        idempotency_key:
+          $ref: '#/components/schemas/IdempotencyKey'
+    ReleaseQuotaResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - reservation_id
+        - amount
+        - ledger_transaction_id
+        - effective_at
+      properties:
+        reservation_id:
+          $ref: '#/components/schemas/ReservationId'
+        amount:
+          $ref: '#/components/schemas/Amount'
+        ledger_transaction_id:
+          $ref: '#/components/schemas/LedgerTransactionId'
+        effective_at:
+          $ref: '#/components/schemas/Timestamp'
+    ErrorResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          minLength: 1
+          maxLength: 128
+        message:
+          type: string
+          minLength: 1
+          maxLength: 1024


### PR DESCRIPTION
## Changed files

新增 `docs/contracts/approval-quota-ledger.openapi.yaml`，把审批额度账本定义为外部 `QuotaLedger` connected-service profile，覆盖余额读取、预留、扣减、释放和幂等字段。

新增 `docs/canon/approval-quota-ledger.md`，明确额度事实源只能属于外部后台或渠道原生账本，Aevatar 只保留编排边界、A/B 决策规则和 probe 证据模板。

更新 `docs/canon/nyxid-connected-service-tools.md` 与 `docs/canon/overview.md`，把 `QuotaLedger` 接入现有 NyxID connected-service/proxy 文档入口。

## Test results

- `dotnet build aevatar.slnx --nologo`：通过，0 errors，保留既有 warnings。
- `bash tools/docs/lint.sh`：通过，60 files checked，0 errors。
- OpenAPI YAML parse：通过。
- Host guard：`CI_GUARDS` 未设置，按 host 契约跳过。

## Deviations

未修改 workflow、C#、proto 或测试项目；本轮为 docs/contract scope。Closes #2177

`refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)`

⟦AI:AUTO-LOOP⟧
