### PR TITLE
Relax projection read-model version gap handling

### DIFF
--- a/src/Aevatar.CQRS.Projection.Stores.Abstractions/Abstractions/ReadModels/ProjectionWriteResultEvaluator.cs
+++ b/src/Aevatar.CQRS.Projection.Stores.Abstractions/Abstractions/ReadModels/ProjectionWriteResultEvaluator.cs
@@ -28,9 +28,6 @@ public static class ProjectionWriteResultEvaluator
                 : ProjectionWriteResult.Conflict();
         }
 
-        if (incoming.StateVersion > existing.StateVersion + 1)
-            return ProjectionWriteResult.Gap();
-
         return ProjectionWriteResult.Applied();
     }
 }

--- a/test/Aevatar.CQRS.Projection.Core.Tests/ElasticsearchProjectionDocumentStoreBehaviorTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/ElasticsearchProjectionDocumentStoreBehaviorTests.cs
@@ -636,6 +636,43 @@ public sealed class ElasticsearchProjectionDocumentStoreBehaviorTests
     }
 
     [Fact]
+    public async Task UpsertAsync_WhenIncomingAuthoritativeVersionSkipsAhead_ShouldApply()
+    {
+        var handler = new ScriptedHttpMessageHandler();
+        handler.EnqueueResponse(_ => CreateJsonResponse(
+            HttpStatusCode.OK,
+            """{"_seq_no":7,"_primary_term":3,"_source":{"id":"actor-gap","actor_id":"actor-gap","state_version":"1","last_event_id":"evt-1","updated_at_utc_value":"2026-06-17T00:00:00Z","value":"v1"}}"""));
+        handler.EnqueueResponse(_ => CreateJsonResponse(
+            HttpStatusCode.OK,
+            """{"result":"updated"}"""));
+
+        using var store = CreateStore(
+            new ElasticsearchProjectionDocumentStoreOptions
+            {
+                AutoCreateIndex = false,
+            },
+            handler);
+
+        var result = await store.UpsertAsync(new TestStoreReadModel
+        {
+            Id = "actor-gap",
+            ActorId = "actor-gap",
+            StateVersion = 4,
+            LastEventId = "evt-4",
+            UpdatedAt = DateTimeOffset.Parse("2026-06-17T00:00:04Z"),
+            Value = "v4",
+        });
+
+        result.Disposition.Should().Be(ProjectionWriteDisposition.Applied);
+        handler.CapturedRequests.Should().HaveCount(2);
+        handler.CapturedRequests[1].PathAndQuery.Should().Contain("if_seq_no=7");
+        handler.CapturedRequests[1].PathAndQuery.Should().Contain("if_primary_term=3");
+        handler.CapturedRequests[1].Body.Should().Contain("\"state_version\":\"4\"");
+        handler.CapturedRequests[1].Body.Should().Contain("\"last_event_id\":\"evt-4\"");
+        handler.CapturedRequests[1].Body.Should().Contain("\"value\":\"v4\"");
+    }
+
+    [Fact]
     public async Task UpsertAsync_WhenReadModelUsesDynamicIndexScope_ShouldTargetScopeSpecificIndices()
     {
         var handler = new ScriptedHttpMessageHandler();

--- a/test/Aevatar.CQRS.Projection.Core.Tests/InMemoryProjectionDocumentStoreBehaviorTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/InMemoryProjectionDocumentStoreBehaviorTests.cs
@@ -102,4 +102,37 @@ public sealed class InMemoryProjectionDocumentStoreBehaviorTests
         first.Disposition.Should().Be(ProjectionWriteDisposition.Applied);
         second.Disposition.Should().Be(ProjectionWriteDisposition.Duplicate);
     }
+
+    [Fact]
+    public async Task UpsertAsync_WhenIncomingAuthoritativeVersionSkipsAhead_ShouldApply()
+    {
+        var store = new InMemoryProjectionDocumentStore<TestStoreReadModel, string>(
+            keySelector: model => model.Id);
+        await store.UpsertAsync(new TestStoreReadModel
+        {
+            Id = "actor-gap",
+            ActorId = "actor-gap",
+            StateVersion = 1,
+            LastEventId = "evt-1",
+            UpdatedAt = DateTimeOffset.Parse("2026-06-17T00:00:00Z"),
+            Value = "v1",
+        });
+
+        var result = await store.UpsertAsync(new TestStoreReadModel
+        {
+            Id = "actor-gap",
+            ActorId = "actor-gap",
+            StateVersion = 4,
+            LastEventId = "evt-4",
+            UpdatedAt = DateTimeOffset.Parse("2026-06-17T00:00:04Z"),
+            Value = "v4",
+        });
+
+        result.Disposition.Should().Be(ProjectionWriteDisposition.Applied);
+        var stored = await store.GetAsync("actor-gap");
+        stored.Should().NotBeNull();
+        stored!.StateVersion.Should().Be(4);
+        stored.LastEventId.Should().Be("evt-4");
+        stored.Value.Should().Be("v4");
+    }
 }

--- a/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionHotspotCoverageTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionHotspotCoverageTests.cs
@@ -216,7 +216,7 @@ public sealed class ProjectionHotspotCoverageTests
         ProjectionWriteResultEvaluator.Evaluate(existing, new TestReadModel("actor-1", 4, "evt-4b"))
             .Disposition.Should().Be(ProjectionWriteDisposition.Conflict);
         ProjectionWriteResultEvaluator.Evaluate(existing, new TestReadModel("actor-1", 6, "evt-6"))
-            .Disposition.Should().Be(ProjectionWriteDisposition.Gap);
+            .Disposition.Should().Be(ProjectionWriteDisposition.Applied);
         ProjectionWriteResultEvaluator.Evaluate(existing, new TestReadModel("actor-1", 5, "evt-5"))
             .Disposition.Should().Be(ProjectionWriteDisposition.Applied);
 

--- a/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionStoreValueAndResultCoverageTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionStoreValueAndResultCoverageTests.cs
@@ -93,7 +93,7 @@ public sealed class ProjectionStoreValueAndResultCoverageTests
                 CreateReadModel("actor-1", "evt-3", 4))
             .Disposition
             .Should()
-            .Be(ProjectionWriteDisposition.Gap);
+            .Be(ProjectionWriteDisposition.Applied);
     }
 
     [Fact]


### PR DESCRIPTION
Allow authoritative projection read-model versions to skip ahead while keeping stale and conflicting writes blocked, so committed state can materialize after version gaps.