### PR TITLE
Fix workflow studio guard parameter validation

### DIFF
--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -43,6 +43,7 @@ import type {
   StudioExecutionFrame,
   StudioMemberBindingRunStatusResponse,
   StudioMemberDetail,
+  StudioValidationFinding,
   StudioWorkflowDraftCreateAcceptedReceipt,
   StudioWorkflowDocument,
   StudioWorkflowFile,
@@ -220,9 +221,306 @@ const CREATED_MEMBER_MATERIALIZATION_DELAY_MS = 450;
 const WORKFLOW_DRAFT_MATERIALIZATION_ATTEMPTS = 10;
 const WORKFLOW_DRAFT_MATERIALIZATION_DELAY_MS = 900;
 const SAVED_WORKFLOW_QUERY_STALE_MS = 30_000;
+const SUPPORTED_GUARD_CHECK_TYPES = [
+  "not_empty",
+  "json_valid",
+  "regex",
+  "max_length",
+  "contains",
+] as const;
+const SUPPORTED_GUARD_CHECK_TYPES_TEXT = SUPPORTED_GUARD_CHECK_TYPES.join("|");
 
 function trimOptional(value: string | null | undefined): string {
   return value?.trim() ?? "";
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function buildBlockingValidationFinding(input: {
+  readonly code: string;
+  readonly message: string;
+  readonly path: string;
+}): StudioValidationFinding {
+  return {
+    code: input.code,
+    level: 2,
+    message: input.message,
+    path: input.path,
+  };
+}
+
+function isSupportedGuardCheckType(
+  value: string,
+): value is (typeof SUPPORTED_GUARD_CHECK_TYPES)[number] {
+  return SUPPORTED_GUARD_CHECK_TYPES.includes(
+    value.toLowerCase() as (typeof SUPPORTED_GUARD_CHECK_TYPES)[number],
+  );
+}
+
+function readGuardParameter(
+  parameters: Record<string, unknown>,
+  parameterName: string,
+): unknown {
+  if (Object.prototype.hasOwnProperty.call(parameters, parameterName)) {
+    return parameters[parameterName];
+  }
+
+  const matchingKey = Object.keys(parameters).find(
+    (key) => key.toLowerCase() === parameterName.toLowerCase(),
+  );
+
+  return matchingKey ? parameters[matchingKey] : undefined;
+}
+
+function hasNonBlankGuardStringParameter(
+  parameters: Record<string, unknown>,
+  parameterName: string,
+): boolean {
+  const value = readGuardParameter(parameters, parameterName);
+
+  return typeof value === "string" && trimOptional(value).length > 0;
+}
+
+function hasPositiveIntegerGuardParameter(
+  parameters: Record<string, unknown>,
+  parameterName: string,
+): boolean {
+  const value = readGuardParameter(parameters, parameterName);
+  if (typeof value === "number") {
+    return Number.isInteger(value) && value > 0;
+  }
+
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  const normalized = trimOptional(value);
+
+  return /^[1-9]\d*$/.test(normalized);
+}
+
+function formatValidationFieldName(value: string): string {
+  const normalized = trimOptional(value);
+  if (!normalized) {
+    return "Configuration";
+  }
+
+  const labels: Record<string, string> = {
+    check: "Check",
+    keyword: "Keyword",
+    max: "Max length",
+    on_fail: "On failure",
+    pattern: "Pattern",
+  };
+
+  return (
+    labels[normalized] ||
+    normalized
+      .split(/[_\-\s]+/)
+      .filter(Boolean)
+      .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+      .join(" ") ||
+    "Configuration"
+  );
+}
+
+function formatStudioStepType(value: string | null | undefined): string {
+  const normalized = trimOptional(value);
+  if (!normalized) {
+    return "step";
+  }
+
+  return normalized
+    .split(/[_\-\s]+/)
+    .filter(Boolean)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+function collectLocalWorkflowGuardFindings(
+  document: StudioWorkflowDocument,
+): StudioValidationFinding[] {
+  const findings: StudioValidationFinding[] = [];
+  const steps = Array.isArray(document.steps) ? document.steps : [];
+
+  steps.forEach((step, stepIndex) => {
+    if (trimOptional(step.type).toLowerCase() !== "guard") {
+      return;
+    }
+
+    const parameters = isPlainRecord(step.parameters) ? step.parameters : {};
+    const checkRaw = readGuardParameter(parameters, "check");
+    const checkPath = `/steps/${stepIndex}/parameters/check`;
+    if (checkRaw == null) {
+      return;
+    }
+
+    if (typeof checkRaw !== "string") {
+      findings.push(
+        buildBlockingValidationFinding({
+          code: "invalid_guard_check",
+          message: `Guard check must be one of ${SUPPORTED_GUARD_CHECK_TYPES_TEXT}.`,
+          path: checkPath,
+        }),
+      );
+      return;
+    }
+
+    const trimmedCheck = trimOptional(checkRaw);
+    const check = trimmedCheck.toLowerCase();
+    if (!check) {
+      findings.push(
+        buildBlockingValidationFinding({
+          code: "invalid_guard_check",
+          message: `Guard check cannot be blank; supported checks are ${SUPPORTED_GUARD_CHECK_TYPES_TEXT}.`,
+          path: checkPath,
+        }),
+      );
+      return;
+    }
+
+    if (checkRaw !== trimmedCheck) {
+      findings.push(
+        buildBlockingValidationFinding({
+          code: "invalid_guard_check",
+          message: `Guard check cannot include leading or trailing whitespace; supported checks are ${SUPPORTED_GUARD_CHECK_TYPES_TEXT}.`,
+          path: checkPath,
+        }),
+      );
+      return;
+    }
+
+    if (!isSupportedGuardCheckType(check)) {
+      findings.push(
+        buildBlockingValidationFinding({
+          code: "unknown_guard_check",
+          message: `Unknown guard check type: ${check}. Supported checks are ${SUPPORTED_GUARD_CHECK_TYPES_TEXT}.`,
+          path: checkPath,
+        }),
+      );
+      return;
+    }
+
+    if (
+      check === "regex" &&
+      !hasNonBlankGuardStringParameter(parameters, "pattern")
+    ) {
+      findings.push(
+        buildBlockingValidationFinding({
+          code: "missing_guard_regex_pattern",
+          message: "Guard regex check requires a non-empty pattern parameter.",
+          path: `/steps/${stepIndex}/parameters/pattern`,
+        }),
+      );
+    }
+
+    if (
+      check === "max_length" &&
+      !hasPositiveIntegerGuardParameter(parameters, "max")
+    ) {
+      findings.push(
+        buildBlockingValidationFinding({
+          code: "invalid_guard_max_length",
+          message: "Guard max_length check requires a positive integer max parameter.",
+          path: `/steps/${stepIndex}/parameters/max`,
+        }),
+      );
+    }
+
+    if (
+      check === "contains" &&
+      !hasNonBlankGuardStringParameter(parameters, "keyword")
+    ) {
+      findings.push(
+        buildBlockingValidationFinding({
+          code: "missing_guard_contains_keyword",
+          message: "Guard contains check requires a non-empty keyword parameter.",
+          path: `/steps/${stepIndex}/parameters/keyword`,
+        }),
+      );
+    }
+  });
+
+  return findings;
+}
+
+function readValidationFindingStepIndex(path: string | null | undefined): number | null {
+  const match = trimOptional(path).match(/^\/steps\/(\d+)(?:\/|$)/);
+
+  return match ? Number(match[1]) : null;
+}
+
+function readValidationFindingFieldName(path: string | null | undefined): string {
+  const segments = trimOptional(path).split("/").filter(Boolean);
+  const parametersIndex = segments.indexOf("parameters");
+  if (parametersIndex >= 0 && segments[parametersIndex + 1]) {
+    return formatValidationFieldName(segments[parametersIndex + 1]);
+  }
+
+  return formatValidationFieldName(segments.at(-1) ?? "");
+}
+
+function formatValidationFindingLocation(
+  finding: StudioValidationFinding,
+  document: StudioWorkflowDocument,
+): string {
+  const stepIndex = readValidationFindingStepIndex(finding.path);
+  if (stepIndex == null) {
+    return readValidationFindingFieldName(finding.path);
+  }
+
+  const step = Array.isArray(document.steps) ? document.steps[stepIndex] : null;
+  const stepId = trimOptional(step?.id) || `step ${stepIndex + 1}`;
+  const stepType = formatStudioStepType(step?.type || step?.originalType);
+  const fieldName = readValidationFindingFieldName(finding.path);
+
+  return `Node "${stepId}" (${stepType}, #${stepIndex + 1}) -> ${fieldName}`;
+}
+
+function simplifyValidationFindingMessage(
+  finding: StudioValidationFinding,
+): string {
+  const message = trimOptional(finding.message);
+  if (!message) {
+    return "Invalid configuration.";
+  }
+
+  if (
+    finding.code === "invalid_guard_check" ||
+    finding.code === "unknown_guard_check"
+  ) {
+    return `Choose a supported guard check: ${SUPPORTED_GUARD_CHECK_TYPES.join(", ")}.`;
+  }
+
+  return message;
+}
+
+function isBlockingValidationFinding(finding: StudioValidationFinding): boolean {
+  const level = finding.level;
+
+  return level === 2 || String(level).toLowerCase() === "error";
+}
+
+function buildValidationFindingsError(
+  findings: readonly StudioValidationFinding[],
+  document: StudioWorkflowDocument,
+): string {
+  const messages = findings
+    .filter(isBlockingValidationFinding)
+    .map((finding) => {
+      const location = formatValidationFindingLocation(finding, document);
+      const detail = simplifyValidationFindingMessage(finding);
+
+      return `- ${location}: ${detail}`;
+    })
+    .filter(Boolean);
+
+  return [
+    "Fix the workflow configuration before starting a draft run:",
+    ...messages,
+  ].join("\n");
 }
 
 function normalizeWorkflowSaveResult(
@@ -1629,6 +1927,11 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
 
       const normalizedTitle = trimOptional(title) || "Workflow draft";
       const userRunMessage = trimOptional(runMessage);
+      const localValidationFindings = collectLocalWorkflowGuardFindings(document);
+      if (localValidationFindings.some(isBlockingValidationFinding)) {
+        throw new Error(buildValidationFindingsError(localValidationFindings, document));
+      }
+
       const serialized = await studioApi.serializeYaml({
         document: {
           ...document,
@@ -1636,6 +1939,10 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
         },
         availableStepTypes: AVAILABLE_STEP_TYPES,
       });
+      if (serialized.findings.some(isBlockingValidationFinding)) {
+        throw new Error(buildValidationFindingsError(serialized.findings, document));
+      }
+
       const startedAtUtc = new Date().toISOString();
       const executionId = `draft-run:${memberId}:${Date.now().toString(36)}`;
       const frames: StudioExecutionFrame[] = [];

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -3750,6 +3750,84 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
   });
 
+  it("blocks draft run locally when guard check is structured", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/member-alpha/workflow?workflowId=workflow-alpha",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "workflow-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: null,
+        lifecycleStage: "bind_ready",
+        memberId: "member-alpha",
+        publishedServiceId: "service-alpha",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "workflow-alpha.yaml",
+      filePath: "scope://scope-1/workflow-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "workflow-alpha",
+      yaml: "name: Workflow Alpha\nsteps:\n  - id: guard\n    type: guard\n    parameters:\n      check: {}\n",
+      document: {
+        ...mockWorkflowDocument,
+        steps: [
+          {
+            id: "guard",
+            type: "guard",
+            targetRole: "",
+            parameters: { check: {}, on_fail: "fail" },
+            next: null,
+            branches: {},
+          },
+        ],
+      },
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    const runDraftButton = await screen.findByRole("button", {
+      name: "Run",
+    });
+    await waitFor(() => {
+      expect(runDraftButton).toBeEnabled();
+    });
+    fireEvent.click(runDraftButton);
+    const draftRunPanel = await screen.findByLabelText("Draft run panel");
+    fireEvent.click(
+      within(draftRunPanel).getByRole("button", { name: "Start draft run" }),
+    );
+
+    await waitFor(() => {
+      expect(studioApi.serializeYaml).not.toHaveBeenCalled();
+      expect(runtimeRunsApi.streamDraftRun).not.toHaveBeenCalled();
+      expect(screen.getByText(/Fix the workflow configuration/)).toBeTruthy();
+    });
+    expect(screen.getByText(/Node "guard" \(Guard, #1\) -> Check/)).toBeTruthy();
+    expect(screen.getByText(/Choose a supported guard check/)).toBeTruthy();
+    expect(screen.getByTestId("member-run-result-panel")).toHaveTextContent(
+      "Node \"guard\"",
+    );
+  });
+
   it("keeps the header action bar stable while save, YAML, and contextual delete states change", async () => {
     window.history.replaceState(
       {},

--- a/apps/aevatar-console-web/src/shared/studio/nodeConfigFieldSchemas.ts
+++ b/apps/aevatar-console-web/src/shared/studio/nodeConfigFieldSchemas.ts
@@ -1569,6 +1569,22 @@ function readFieldValueFromInput(
       }
       return { include: true, value: parsed };
     }
+    case 'select': {
+      const options = field.options ?? [];
+      if (
+        options.length > 0 &&
+        !options.some((option) => option.value === trimmed)
+      ) {
+        return {
+          error: `${field.label.defaultMessage} must be one of: ${options
+            .map((option) => option.value)
+            .join(', ')}.`,
+          include: false,
+        };
+      }
+
+      return { include: true, value: trimmed };
+    }
     default:
       return { include: true, value };
   }

--- a/apps/aevatar-console-web/src/shared/studio/nodeConfigFields.structured.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/nodeConfigFields.structured.test.ts
@@ -263,6 +263,40 @@ describe('studio node configuration semantics', () => {
     });
   });
 
+  it('rejects invalid guard check enum values instead of treating objects as select choices', () => {
+    const objectValueResult = applyStudioNodeConfigurationValuesWithValidation(
+      'guard',
+      { check: {}, on_fail: 'fail' },
+      {
+        check: '{}',
+        onFail: 'fail',
+      },
+    );
+
+    expect(objectValueResult.valid).toBe(false);
+    expect(objectValueResult.errors[0]).toContain('Check must be one of');
+    expect(objectValueResult.parameters).toEqual({
+      check: {},
+      on_fail: 'fail',
+    });
+
+    const unknownValueResult = applyStudioNodeConfigurationValuesWithValidation(
+      'guard',
+      { check: 'not_empty', on_fail: 'fail' },
+      {
+        check: 'unknown_check',
+        onFail: 'fail',
+      },
+    );
+
+    expect(unknownValueResult.valid).toBe(false);
+    expect(unknownValueResult.errors[0]).toContain('not_empty');
+    expect(unknownValueResult.parameters).toEqual({
+      check: 'not_empty',
+      on_fail: 'fail',
+    });
+  });
+
   it('keeps raw configuration as an explicit advanced JSON path', () => {
     expect(formatRawStudioNodeConfiguration({ op: 'trim' })).toBe(
       '{\n  "op": "trim"\n}',


### PR DESCRIPTION
## Summary

- block Workflow Studio draft runs locally when a guard `check` parameter has already been corrupted into a structured value like `{}`
- validate select-backed node configuration fields against their declared options before writing parameters
- add frontend regression coverage for invalid guard checks and draft-run blocking

## Context

The user-facing YAML is valid, but a backend response serialization issue can turn scalar step parameters such as `check: not_empty` into `{}` during the Studio YAML/document round trip. The backend root cause is tracked separately in #2225 and assigned to Louis. This PR intentionally avoids backend changes and only adds frontend protection so the corrupted config is not sent to runtime as `guard check '{}'`.

## Validation

- `pnpm --dir apps/aevatar-console-web tsc`
- `pnpm --dir apps/aevatar-console-web jest src/shared/studio/nodeConfigFields.structured.test.ts --runInBand`
- `pnpm --dir apps/aevatar-console-web jest src/pages/team-member-workflow-studio/index.test.tsx --runInBand`
- `bash tools/ci/test_stability_guards.sh`
- `git diff --check`
