### PR TITLE
添加 workflow spreadsheet_extract 有界预览

### DIFF
--- a/docs/discussions/2026-06-16-workflow-file-handling-issue-1917-gap-dependencies.md
+++ b/docs/discussions/2026-06-16-workflow-file-handling-issue-1917-gap-dependencies.md
@@ -23,6 +23,10 @@ No new public `WorkflowFileBatch*` execution proto was introduced. Durable execu
 
 Ingress remains a Host/Infrastructure concern. Once file descriptors enter the run, partial success and failure are represented by actor/module-owned execution state and completion events, not by request-time fallback queries or process-local registries.
 
+Issue 2223 added a separate workflow-owned `spreadsheet_extract` tool source for workbook previews. It reuses the existing workflow file artifact read port and only accepts `.xlsx` descriptors with media type `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`. Legacy `.xls`, macro/binary workbooks, ODS, octet-stream uploads, encrypted packages, macro packages, external-link packages, malformed workbooks, and configured limit overruns fail closed with safe error JSON.
+
+The spreadsheet result is a bounded preview contract: descriptor-only file ref, explicit limits, workbook sheet count/truncation, and per-sheet row/cell preview. Workbook bytes, base64, provider payloads, package part names, raw XML, and unbounded table dumps are not emitted to step output. `document_extract` remains limited to text/document/image extraction and rejects spreadsheet media types. No spreadsheet readmodel, proto result, actor state shape, or package dependency was added for this phase.
+
 ## Context
 
 Issue 1917 left one dependency gap in the workflow file submit path: `WorkflowConnectedServiceFileSubmitOptions.Targets` already existed as the typed policy shape, but Workflow/Mainnet composition did not bind a stable configuration section or fail fast when a generic connected-service endpoint policy was malformed.

--- a/src/workflow/Aevatar.Workflow.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -36,6 +36,13 @@ public static class ServiceCollectionExtensions
         }
 
         submitOptions.ValidateOnStart();
+        var spreadsheetOptions = services.AddOptions<WorkflowSpreadsheetExtractOptions>();
+        if (configuration != null)
+        {
+            spreadsheetOptions.Bind(
+                configuration.GetSection(WorkflowSpreadsheetExtractOptions.SectionName));
+        }
+
         services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IValidateOptions<WorkflowConnectedServiceFileSubmitOptions>,
             WorkflowConnectedServiceFileSubmitOptionsValidator>());
@@ -50,6 +57,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IWorkflowFileArtifactOwnershipPort>(sp =>
             sp.GetRequiredService<FileSystemWorkflowFileIngressPort>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IWorkflowToolSource, WorkflowDocumentExtractToolSource>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IWorkflowToolSource, WorkflowSpreadsheetExtractToolSource>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IWorkflowToolSource, WorkflowConnectedServiceResourceFetchToolSource>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IWorkflowToolSource, WorkflowFileSubmitToolSource>());
         services.TryAddSingleton<WorkflowRunActorPort>();

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Runs/SpreadsheetPreviewExtractor.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Runs/SpreadsheetPreviewExtractor.cs
@@ -1,0 +1,400 @@
+using System.Globalization;
+using System.IO.Compression;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace Aevatar.Workflow.Infrastructure.Runs;
+
+internal sealed class SpreadsheetPreviewExtractor(WorkflowSpreadsheetExtractOptions options)
+{
+    private static readonly XNamespace PackageRelationshipsNamespace =
+        "http://schemas.openxmlformats.org/package/2006/relationships";
+    private static readonly XNamespace SpreadsheetNamespace =
+        "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+    private static readonly XNamespace OfficeRelationshipsNamespace =
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+    private readonly WorkflowSpreadsheetExtractOptions _options = NormalizeOptions(options);
+
+    public WorkflowSpreadsheetPreview Extract(byte[] workbookBytes)
+    {
+        if (workbookBytes.Length > _options.MaxWorkbookBytes)
+            throw new SpreadsheetPreviewException(
+                SpreadsheetPreviewErrorCode.WorkbookTooLarge,
+                $"Spreadsheet workbook exceeds {_options.MaxWorkbookBytes} bytes.");
+
+        using var stream = new MemoryStream(workbookBytes, writable: false);
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: false);
+        ValidatePackage(archive);
+
+        var workbookRelationships = LoadRelationships(archive, "xl/_rels/workbook.xml.rels");
+        if (workbookRelationships.Values.Any(static relationship => relationship.IsExternalLink))
+            throw new SpreadsheetPreviewException(
+                SpreadsheetPreviewErrorCode.UnsafeWorkbook,
+                "Spreadsheet workbook contains external links.");
+
+        var workbookDocument = LoadXmlDocument(archive, "xl/workbook.xml");
+        var sheetDefinitions = ReadSheetDefinitions(workbookDocument, workbookRelationships);
+        var sharedStrings = ReadSharedStrings(archive);
+        var sheets = new List<SpreadsheetSheetPreview>();
+        var workbookTruncated = sheetDefinitions.Count > _options.MaxSheets;
+
+        foreach (var sheetDefinition in sheetDefinitions.Take(_options.MaxSheets))
+        {
+            var sheet = ReadSheet(archive, sheetDefinition, sharedStrings);
+            if (sheet.Truncated)
+                workbookTruncated = true;
+            sheets.Add(sheet);
+        }
+
+        return new WorkflowSpreadsheetPreview(
+            new WorkflowSpreadsheetPreviewLimits(
+                _options.MaxWorkbookBytes,
+                _options.MaxSheets,
+                _options.MaxRowsPerSheet,
+                _options.MaxColumnsPerRow,
+                _options.MaxCellChars),
+            new WorkflowSpreadsheetWorkbookPreview(sheetDefinitions.Count, workbookTruncated),
+            sheets,
+            workbookTruncated);
+    }
+
+    private void ValidatePackage(ZipArchive archive)
+    {
+        if (archive.Entries.Count > _options.MaxPackageEntries)
+            throw new SpreadsheetPreviewException(
+                SpreadsheetPreviewErrorCode.WorkbookTooLarge,
+                $"Spreadsheet workbook package exceeds {_options.MaxPackageEntries} entries.");
+
+        var hasEncryptedPackage = false;
+        var hasEncryptionInfo = false;
+        foreach (var entry in archive.Entries)
+        {
+            var name = NormalizePartName(entry.FullName);
+            if (entry.Length > _options.MaxPackageEntryBytes)
+                throw new SpreadsheetPreviewException(
+                    SpreadsheetPreviewErrorCode.WorkbookTooLarge,
+                    $"Spreadsheet workbook package part exceeds {_options.MaxPackageEntryBytes} bytes.");
+
+            if (string.Equals(name, "encryptedpackage", StringComparison.Ordinal))
+                hasEncryptedPackage = true;
+            if (string.Equals(name, "encryptioninfo", StringComparison.Ordinal))
+                hasEncryptionInfo = true;
+            if (name.EndsWith("vbaproject.bin", StringComparison.Ordinal) ||
+                name.Contains("vbaprojectsignature", StringComparison.Ordinal))
+            {
+                throw new SpreadsheetPreviewException(
+                    SpreadsheetPreviewErrorCode.UnsafeWorkbook,
+                    "Spreadsheet workbook contains macros.");
+            }
+        }
+
+        if (hasEncryptedPackage || hasEncryptionInfo)
+            throw new SpreadsheetPreviewException(
+                SpreadsheetPreviewErrorCode.EncryptedWorkbook,
+                "Spreadsheet workbook is encrypted.");
+
+        if (archive.GetEntry("xl/workbook.xml") == null ||
+            archive.GetEntry("xl/_rels/workbook.xml.rels") == null)
+            throw new SpreadsheetPreviewException(
+                SpreadsheetPreviewErrorCode.InvalidWorkbook,
+                "Spreadsheet workbook package is incomplete.");
+    }
+
+    private IReadOnlyList<SheetDefinition> ReadSheetDefinitions(
+        XDocument workbookDocument,
+        IReadOnlyDictionary<string, WorkbookRelationship> relationships)
+    {
+        var sheets = workbookDocument.Root?
+            .Element(SpreadsheetNamespace + "sheets")?
+            .Elements(SpreadsheetNamespace + "sheet") ?? [];
+        var definitions = new List<SheetDefinition>();
+        foreach (var sheet in sheets)
+        {
+            var relationshipId = (string?)sheet.Attribute(OfficeRelationshipsNamespace + "id");
+            if (string.IsNullOrWhiteSpace(relationshipId) ||
+                !relationships.TryGetValue(relationshipId, out var relationship) ||
+                relationship.IsExternalLink)
+            {
+                throw new SpreadsheetPreviewException(
+                    SpreadsheetPreviewErrorCode.InvalidWorkbook,
+                    "Spreadsheet workbook sheet relationship is invalid.");
+            }
+
+            definitions.Add(new SheetDefinition(
+                SanitizeSheetName((string?)sheet.Attribute("name")),
+                relationship.TargetPart));
+        }
+
+        if (definitions.Count == 0)
+            throw new SpreadsheetPreviewException(
+                SpreadsheetPreviewErrorCode.InvalidWorkbook,
+                "Spreadsheet workbook does not contain worksheets.");
+
+        return definitions;
+    }
+
+    private IReadOnlyList<string> ReadSharedStrings(ZipArchive archive)
+    {
+        if (archive.GetEntry("xl/sharedStrings.xml") == null)
+            return [];
+
+        var document = LoadXmlDocument(archive, "xl/sharedStrings.xml");
+        var values = new List<string>();
+        foreach (var item in document.Descendants(SpreadsheetNamespace + "si"))
+        {
+            if (values.Count >= _options.MaxSharedStrings)
+                throw new SpreadsheetPreviewException(
+                    SpreadsheetPreviewErrorCode.WorkbookTooLarge,
+                    $"Spreadsheet workbook shared strings exceed {_options.MaxSharedStrings} entries.");
+
+            values.Add(string.Concat(item.Descendants(SpreadsheetNamespace + "t").Select(static text => text.Value)));
+        }
+
+        return values;
+    }
+
+    private SpreadsheetSheetPreview ReadSheet(
+        ZipArchive archive,
+        SheetDefinition sheetDefinition,
+        IReadOnlyList<string> sharedStrings)
+    {
+        var document = LoadXmlDocument(archive, sheetDefinition.TargetPart);
+        var rows = new List<SpreadsheetRowPreview>();
+        var sheetTruncated = false;
+        var rowElements = document.Descendants(SpreadsheetNamespace + "row");
+        foreach (var rowElement in rowElements)
+        {
+            if (rows.Count >= _options.MaxRowsPerSheet)
+            {
+                sheetTruncated = true;
+                break;
+            }
+
+            var cells = ReadCells(rowElement, sharedStrings, ref sheetTruncated);
+            rows.Add(new SpreadsheetRowPreview(
+                ParsePositiveInt((string?)rowElement.Attribute("r"), rows.Count + 1),
+                cells));
+        }
+
+        return new SpreadsheetSheetPreview(sheetDefinition.Name, rows, sheetTruncated);
+    }
+
+    private IReadOnlyList<SpreadsheetCellPreview> ReadCells(
+        XElement rowElement,
+        IReadOnlyList<string> sharedStrings,
+        ref bool sheetTruncated)
+    {
+        var cells = new List<SpreadsheetCellPreview>();
+        foreach (var cellElement in rowElement.Elements(SpreadsheetNamespace + "c"))
+        {
+            if (cells.Count >= _options.MaxColumnsPerRow)
+            {
+                sheetTruncated = true;
+                break;
+            }
+
+            var value = ResolveCellValue(cellElement, sharedStrings);
+            var truncated = value.Length > _options.MaxCellChars;
+            if (truncated)
+                value = value[.._options.MaxCellChars];
+
+            cells.Add(new SpreadsheetCellPreview(
+                NormalizeCellReference((string?)cellElement.Attribute("r")),
+                value,
+                ResolveCellValueKind((string?)cellElement.Attribute("t")),
+                truncated));
+        }
+
+        return cells;
+    }
+
+    private string ResolveCellValue(XElement cellElement, IReadOnlyList<string> sharedStrings)
+    {
+        var cellType = (string?)cellElement.Attribute("t");
+        if (string.Equals(cellType, "s", StringComparison.Ordinal))
+        {
+            var indexText = cellElement.Element(SpreadsheetNamespace + "v")?.Value;
+            if (!int.TryParse(indexText, NumberStyles.None, CultureInfo.InvariantCulture, out var sharedStringIndex) ||
+                sharedStringIndex < 0 ||
+                sharedStringIndex >= sharedStrings.Count)
+            {
+                throw new SpreadsheetPreviewException(
+                    SpreadsheetPreviewErrorCode.InvalidWorkbook,
+                    "Spreadsheet workbook shared string reference is invalid.");
+            }
+
+            return sharedStrings[sharedStringIndex];
+        }
+
+        if (string.Equals(cellType, "inlineStr", StringComparison.Ordinal))
+        {
+            return string.Concat(cellElement
+                .Descendants(SpreadsheetNamespace + "t")
+                .Select(static text => text.Value));
+        }
+
+        return cellElement.Element(SpreadsheetNamespace + "v")?.Value ?? string.Empty;
+    }
+
+    private static IReadOnlyDictionary<string, WorkbookRelationship> LoadRelationships(
+        ZipArchive archive,
+        string partName)
+    {
+        var document = LoadXmlDocument(archive, partName);
+        var relationships = new Dictionary<string, WorkbookRelationship>(StringComparer.Ordinal);
+        foreach (var element in document.Root?.Elements(PackageRelationshipsNamespace + "Relationship") ?? [])
+        {
+            var id = (string?)element.Attribute("Id");
+            var target = (string?)element.Attribute("Target");
+            if (string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(target))
+                continue;
+
+            var targetMode = (string?)element.Attribute("TargetMode");
+            var type = (string?)element.Attribute("Type") ?? string.Empty;
+            var isExternal = string.Equals(targetMode, "External", StringComparison.OrdinalIgnoreCase) ||
+                type.Contains("externalLink", StringComparison.OrdinalIgnoreCase);
+            relationships[id] = new WorkbookRelationship(
+                ResolveWorkbookRelationshipTarget(target),
+                isExternal);
+        }
+
+        return relationships;
+    }
+
+    private static XDocument LoadXmlDocument(ZipArchive archive, string partName)
+    {
+        var entry = archive.GetEntry(partName)
+            ?? throw new SpreadsheetPreviewException(
+                SpreadsheetPreviewErrorCode.InvalidWorkbook,
+                "Spreadsheet workbook package is incomplete.");
+        using var stream = entry.Open();
+        using var xmlReader = XmlReader.Create(stream, new XmlReaderSettings
+        {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
+        });
+        return XDocument.Load(xmlReader, LoadOptions.None);
+    }
+
+    private static string ResolveWorkbookRelationshipTarget(string target)
+    {
+        var normalized = target.Replace('\\', '/').TrimStart('/');
+        if (!normalized.StartsWith("xl/", StringComparison.Ordinal))
+            normalized = $"xl/{normalized}";
+
+        var fullPath = Path.GetFullPath(
+            normalized,
+            Path.GetFullPath("package-root", AppContext.BaseDirectory));
+        var rootPath = Path.GetFullPath("package-root", AppContext.BaseDirectory);
+        if (!fullPath.StartsWith(rootPath, StringComparison.Ordinal))
+            throw new SpreadsheetPreviewException(
+                SpreadsheetPreviewErrorCode.InvalidWorkbook,
+                "Spreadsheet workbook sheet relationship is invalid.");
+
+        return normalized;
+    }
+
+    private static string NormalizeCellReference(string? reference) =>
+        string.IsNullOrWhiteSpace(reference) ? string.Empty : reference.Trim();
+
+    private static int ParsePositiveInt(string? value, int fallback) =>
+        int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var parsed) && parsed > 0
+            ? parsed
+            : fallback;
+
+    private static string ResolveCellValueKind(string? cellType) =>
+        cellType switch
+        {
+            "s" => "shared_string",
+            "inlineStr" => "inline_string",
+            "b" => "boolean",
+            "str" => "formula_string",
+            "e" => "error",
+            _ => "value",
+        };
+
+    private static string SanitizeSheetName(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return "Sheet";
+        var normalized = new StringBuilder();
+        foreach (var c in name.Trim())
+        {
+            if (!char.IsControl(c))
+                normalized.Append(c);
+        }
+
+        return normalized.Length == 0 ? "Sheet" : normalized.ToString();
+    }
+
+    private static string NormalizePartName(string value) =>
+        value.Replace('\\', '/').TrimStart('/').ToLowerInvariant();
+
+    private static WorkflowSpreadsheetExtractOptions NormalizeOptions(WorkflowSpreadsheetExtractOptions options) =>
+        new()
+        {
+            MaxWorkbookBytes = PositiveOrDefault(options.MaxWorkbookBytes, 5 * 1024 * 1024),
+            MaxPackageEntries = PositiveOrDefault(options.MaxPackageEntries, 256),
+            MaxPackageEntryBytes = PositiveOrDefault(options.MaxPackageEntryBytes, 1024 * 1024),
+            MaxSheets = PositiveOrDefault(options.MaxSheets, 5),
+            MaxRowsPerSheet = PositiveOrDefault(options.MaxRowsPerSheet, 50),
+            MaxColumnsPerRow = PositiveOrDefault(options.MaxColumnsPerRow, 20),
+            MaxCellChars = PositiveOrDefault(options.MaxCellChars, 200),
+            MaxSharedStrings = PositiveOrDefault(options.MaxSharedStrings, 10_000),
+        };
+
+    private static int PositiveOrDefault(int value, int defaultValue) =>
+        value > 0 ? value : defaultValue;
+
+    private sealed record SheetDefinition(string Name, string TargetPart);
+
+    private sealed record WorkbookRelationship(string TargetPart, bool IsExternalLink);
+}
+
+internal sealed record WorkflowSpreadsheetPreview(
+    WorkflowSpreadsheetPreviewLimits Limits,
+    WorkflowSpreadsheetWorkbookPreview Workbook,
+    IReadOnlyList<SpreadsheetSheetPreview> Sheets,
+    bool Truncated);
+
+internal sealed record WorkflowSpreadsheetPreviewLimits(
+    int MaxWorkbookBytes,
+    int MaxSheets,
+    int MaxRowsPerSheet,
+    int MaxColumnsPerRow,
+    int MaxCellChars);
+
+internal sealed record WorkflowSpreadsheetWorkbookPreview(int SheetCount, bool Truncated);
+
+internal sealed record SpreadsheetSheetPreview(
+    string Name,
+    IReadOnlyList<SpreadsheetRowPreview> Rows,
+    bool Truncated);
+
+internal sealed record SpreadsheetRowPreview(
+    int Index,
+    IReadOnlyList<SpreadsheetCellPreview> Cells);
+
+internal sealed record SpreadsheetCellPreview(
+    string Reference,
+    string Value,
+    string Kind,
+    bool Truncated);
+
+internal sealed class SpreadsheetPreviewException(
+    SpreadsheetPreviewErrorCode errorCode,
+    string message) : Exception(message)
+{
+    public SpreadsheetPreviewErrorCode ErrorCode { get; } = errorCode;
+}
+
+internal enum SpreadsheetPreviewErrorCode
+{
+    InvalidWorkbook,
+    UnsupportedWorkbook,
+    UnsafeWorkbook,
+    EncryptedWorkbook,
+    WorkbookTooLarge,
+}

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Runs/WorkflowSpreadsheetExtractOptions.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Runs/WorkflowSpreadsheetExtractOptions.cs
@@ -1,0 +1,22 @@
+namespace Aevatar.Workflow.Infrastructure.Runs;
+
+public sealed class WorkflowSpreadsheetExtractOptions
+{
+    public const string SectionName = "WorkflowSpreadsheetExtract";
+
+    public int MaxWorkbookBytes { get; set; } = 5 * 1024 * 1024;
+
+    public int MaxPackageEntries { get; set; } = 256;
+
+    public int MaxPackageEntryBytes { get; set; } = 1024 * 1024;
+
+    public int MaxSheets { get; set; } = 5;
+
+    public int MaxRowsPerSheet { get; set; } = 50;
+
+    public int MaxColumnsPerRow { get; set; } = 20;
+
+    public int MaxCellChars { get; set; } = 200;
+
+    public int MaxSharedStrings { get; set; } = 10_000;
+}

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Runs/WorkflowSpreadsheetExtractToolSource.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Runs/WorkflowSpreadsheetExtractToolSource.cs
@@ -1,0 +1,427 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Xml;
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.Workflow.Core.Modules;
+using Microsoft.Extensions.Options;
+using ProtoWorkflowFileRef = Aevatar.Workflow.Abstractions.WorkflowFileRef;
+using ProtoWorkflowFileSourceKind = Aevatar.Workflow.Abstractions.WorkflowFileSourceKind;
+
+namespace Aevatar.Workflow.Infrastructure.Runs;
+
+public sealed class WorkflowSpreadsheetExtractToolSource(
+    IWorkflowFileArtifactReadPort fileArtifacts,
+    IOptions<WorkflowSpreadsheetExtractOptions> options) : IWorkflowToolSource
+{
+    private readonly IWorkflowFileArtifactReadPort _fileArtifacts =
+        fileArtifacts ?? throw new ArgumentNullException(nameof(fileArtifacts));
+    private readonly IOptions<WorkflowSpreadsheetExtractOptions> _options =
+        options ?? throw new ArgumentNullException(nameof(options));
+
+    public Task<IReadOnlyList<IWorkflowTool>> GetToolsAsync(CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyList<IWorkflowTool>>([
+            new SpreadsheetExtractTool(_fileArtifacts, _options),
+        ]);
+
+    private sealed class SpreadsheetExtractTool(
+        IWorkflowFileArtifactReadPort fileArtifacts,
+        IOptions<WorkflowSpreadsheetExtractOptions> options) : IWorkflowTool
+    {
+        private const string XlsxMediaType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            PropertyNameCaseInsensitive = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        };
+
+        private readonly IWorkflowFileArtifactReadPort _fileArtifacts = fileArtifacts;
+        private readonly IOptions<WorkflowSpreadsheetExtractOptions> _options = options;
+
+        public string Name => "spreadsheet_extract";
+
+        public async Task<WorkflowToolExecutionResult> ExecuteAsync(
+            WorkflowToolExecutionRequest request,
+            CancellationToken ct = default)
+        {
+            try
+            {
+                var arguments = ParseArguments(request);
+                var artifact = await _fileArtifacts.OpenReadAsync(arguments.FileRef, ct)
+                    .ConfigureAwait(false);
+                await using (artifact.Content.ConfigureAwait(false))
+                {
+                    var descriptor = artifact.FileRef;
+                    var mediaType = NormalizeMediaType(descriptor.MediaType);
+                    if (mediaType == null)
+                        return Error("unsupported_media_type", "Workflow file media type is required.");
+
+                    if (!string.Equals(mediaType, XlsxMediaType, StringComparison.Ordinal))
+                    {
+                        return Error(
+                            "unsupported_media_type",
+                            $"spreadsheet_extract does not support media type '{mediaType}'.");
+                    }
+
+                    if (!HasSupportedXlsxFileName(descriptor.FileName))
+                    {
+                        return Error(
+                            "unsupported_file_type",
+                            "spreadsheet_extract only supports .xlsx workbook files.");
+                    }
+
+                    var normalizedOptions = NormalizeOptions(_options.Value);
+                    if (descriptor.SizeBytes > normalizedOptions.MaxWorkbookBytes)
+                    {
+                        return Error(
+                            "workbook_too_large",
+                            $"Spreadsheet workbook exceeds {normalizedOptions.MaxWorkbookBytes} bytes.");
+                    }
+
+                    var workbookBytes = await ReadCappedWorkbookBytesAsync(
+                        artifact.Content,
+                        normalizedOptions.MaxWorkbookBytes,
+                        ct).ConfigureAwait(false);
+                    var preview = new SpreadsheetPreviewExtractor(normalizedOptions).Extract(workbookBytes);
+                    return WorkflowToolExecutionResult.Success(JsonSerializer.Serialize(
+                        new SpreadsheetExtractResult(
+                            Kind: "spreadsheet_preview",
+                            MediaType: mediaType,
+                            File: ToResultFileRef(descriptor),
+                            Limits: preview.Limits,
+                            Workbook: preview.Workbook,
+                            Sheets: preview.Sheets,
+                            Truncated: preview.Truncated),
+                        JsonOptions));
+                }
+            }
+            catch (JsonException ex)
+            {
+                return Error("invalid_arguments", ex.Message);
+            }
+            catch (ArgumentException ex)
+            {
+                return Error("invalid_arguments", ex.Message);
+            }
+            catch (SpreadsheetTooLargeException ex)
+            {
+                return Error("workbook_too_large", ex.Message);
+            }
+            catch (SpreadsheetPreviewException ex)
+            {
+                return Error(ToErrorName(ex.ErrorCode), ex.Message);
+            }
+            catch (InvalidDataException)
+            {
+                return Error("invalid_workbook", "Spreadsheet workbook package is invalid.");
+            }
+            catch (XmlException)
+            {
+                return Error("invalid_workbook", "Spreadsheet workbook XML is invalid.");
+            }
+            catch (Exception ex) when (IsSafeArtifactFailure(ex))
+            {
+                return Error("artifact_unavailable", SafeArtifactDetail(ex));
+            }
+        }
+
+        private static SpreadsheetExtractArguments ParseArguments(WorkflowToolExecutionRequest request)
+        {
+            var argumentsJson = string.IsNullOrWhiteSpace(request.ArgumentsJson)
+                ? "{}"
+                : request.ArgumentsJson;
+            using var document = JsonDocument.Parse(argumentsJson);
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+                throw new ArgumentException("spreadsheet_extract arguments must be a JSON object.");
+
+            var fileRef = TryResolveExplicitFileRef(root, out var explicitFileRef)
+                ? explicitFileRef
+                : ResolveSingleInputFileRef(request.InputFileRefs);
+            if (string.IsNullOrWhiteSpace(fileRef.FileId) &&
+                string.IsNullOrWhiteSpace(fileRef.ArtifactId))
+                throw new ArgumentException("spreadsheet_extract fileRef requires fileId or artifactId.");
+
+            return new SpreadsheetExtractArguments(fileRef);
+        }
+
+        private static bool TryResolveExplicitFileRef(
+            JsonElement root,
+            out WorkflowFileRef fileRef)
+        {
+            fileRef = new WorkflowFileRef();
+            if (!TryGetProperty(root, "fileRef", "file_ref", out var fileRefElement))
+                return false;
+            if (fileRefElement.ValueKind != JsonValueKind.Object)
+                throw new ArgumentException("spreadsheet_extract fileRef must be an object.");
+
+            fileRef = ParseFileRef(fileRefElement);
+            return true;
+        }
+
+        private static WorkflowFileRef ResolveSingleInputFileRef(
+            IReadOnlyList<ProtoWorkflowFileRef> inputFileRefs)
+        {
+            if (inputFileRefs.Count == 1)
+                return ToApplicationFileRef(inputFileRefs[0]);
+
+            throw new ArgumentException(inputFileRefs.Count == 0
+                ? "spreadsheet_extract requires a fileRef object or exactly one input file ref."
+                : "spreadsheet_extract received multiple input file refs; provide fileRef explicitly.");
+        }
+
+        private static WorkflowFileRef ToApplicationFileRef(ProtoWorkflowFileRef source) =>
+            new()
+            {
+                FileId = Normalize(source.FileId),
+                ArtifactId = Normalize(source.ArtifactId),
+                SourceKind = source.SourceKind switch
+                {
+                    ProtoWorkflowFileSourceKind.ChatInput => WorkflowFileSourceKind.ChatInput,
+                    ProtoWorkflowFileSourceKind.FormUpload => WorkflowFileSourceKind.FormUpload,
+                    ProtoWorkflowFileSourceKind.ConnectedServiceResource =>
+                        WorkflowFileSourceKind.ConnectedServiceResource,
+                    ProtoWorkflowFileSourceKind.ExternalResource => WorkflowFileSourceKind.ExternalResource,
+                    ProtoWorkflowFileSourceKind.Generated => WorkflowFileSourceKind.Generated,
+                    _ => WorkflowFileSourceKind.Unspecified,
+                },
+                SourceMessageId = Normalize(source.SourceMessageId),
+                SourceResourceKey = Normalize(source.SourceResourceKey),
+                FileName = Normalize(source.FileName),
+                MediaType = Normalize(source.MediaType),
+                SizeBytes = source.SizeBytes,
+                Sha256 = Normalize(source.Sha256),
+                CreatedAtUnixMs = source.CreatedAtUnixMs,
+                ExpiresAtUnixMs = source.ExpiresAtUnixMs,
+                OwnerRunId = Normalize(source.OwnerRunId),
+                OwnerScopeId = Normalize(source.OwnerScopeId),
+            };
+
+        private static WorkflowFileRef ParseFileRef(JsonElement fileRefElement)
+        {
+            var sourceKind = WorkflowFileSourceKind.Unspecified;
+            if (TryGetProperty(fileRefElement, "sourceKind", "source_kind", out var sourceKindElement))
+                sourceKind = ParseSourceKind(sourceKindElement);
+
+            return new WorkflowFileRef
+            {
+                FileId = GetString(fileRefElement, "fileId", "file_id"),
+                ArtifactId = GetString(fileRefElement, "artifactId", "artifact_id"),
+                SourceKind = sourceKind,
+                SourceMessageId = GetString(fileRefElement, "sourceMessageId", "source_message_id"),
+                SourceResourceKey = GetString(fileRefElement, "sourceResourceKey", "source_resource_key"),
+                FileName = GetString(fileRefElement, "fileName", "file_name"),
+                MediaType = GetString(fileRefElement, "mediaType", "media_type"),
+                SizeBytes = GetInt64(fileRefElement, "sizeBytes", "size_bytes") ?? 0,
+                Sha256 = GetString(fileRefElement, "sha256", "sha256"),
+                CreatedAtUnixMs = GetInt64(fileRefElement, "createdAtUnixMs", "created_at_unix_ms") ?? 0,
+                ExpiresAtUnixMs = GetInt64(fileRefElement, "expiresAtUnixMs", "expires_at_unix_ms") ?? 0,
+            };
+        }
+
+        private static WorkflowFileSourceKind ParseSourceKind(JsonElement element)
+        {
+            if (element.ValueKind == JsonValueKind.Number && element.TryGetInt32(out var numeric))
+                return Enum.IsDefined(typeof(WorkflowFileSourceKind), numeric)
+                    ? (WorkflowFileSourceKind)numeric
+                    : WorkflowFileSourceKind.Unspecified;
+
+            if (element.ValueKind != JsonValueKind.String)
+                return WorkflowFileSourceKind.Unspecified;
+
+            return NormalizeKey(element.GetString()) switch
+            {
+                "chatinput" => WorkflowFileSourceKind.ChatInput,
+                "formupload" => WorkflowFileSourceKind.FormUpload,
+                "connectedserviceresource" => WorkflowFileSourceKind.ConnectedServiceResource,
+                "externalresource" => WorkflowFileSourceKind.ExternalResource,
+                "generated" => WorkflowFileSourceKind.Generated,
+                _ => WorkflowFileSourceKind.Unspecified,
+            };
+        }
+
+        private static string? GetString(JsonElement source, string camelCaseName, string snakeCaseName)
+        {
+            if (!TryGetProperty(source, camelCaseName, snakeCaseName, out var value) ||
+                value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+                return null;
+            return value.ValueKind == JsonValueKind.String
+                ? Normalize(value.GetString())
+                : throw new ArgumentException($"spreadsheet_extract fileRef.{camelCaseName} must be a string.");
+        }
+
+        private static long? GetInt64(JsonElement source, string camelCaseName, string snakeCaseName)
+        {
+            if (!TryGetProperty(source, camelCaseName, snakeCaseName, out var value) ||
+                value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+                return null;
+            return value.ValueKind == JsonValueKind.Number && value.TryGetInt64(out var parsed)
+                ? parsed
+                : throw new ArgumentException($"spreadsheet_extract fileRef.{camelCaseName} must be an integer.");
+        }
+
+        private static bool TryGetProperty(
+            JsonElement source,
+            string camelCaseName,
+            string snakeCaseName,
+            out JsonElement value)
+        {
+            if (source.TryGetProperty(camelCaseName, out value))
+                return true;
+            return source.TryGetProperty(snakeCaseName, out value);
+        }
+
+        private static async Task<byte[]> ReadCappedWorkbookBytesAsync(
+            Stream content,
+            int maxBytes,
+            CancellationToken ct)
+        {
+            using var buffer = new MemoryStream(capacity: Math.Min(maxBytes, 81920));
+            var chunk = new byte[81920];
+            while (true)
+            {
+                var read = await content.ReadAsync(chunk.AsMemory(0, chunk.Length), ct)
+                    .ConfigureAwait(false);
+                if (read == 0)
+                    break;
+
+                if (buffer.Length + read > maxBytes)
+                    throw new SpreadsheetTooLargeException($"Spreadsheet workbook exceeds {maxBytes} bytes.");
+
+                buffer.Write(chunk, 0, read);
+            }
+
+            return buffer.ToArray();
+        }
+
+        private static WorkflowSpreadsheetExtractOptions NormalizeOptions(WorkflowSpreadsheetExtractOptions options) =>
+            new()
+            {
+                MaxWorkbookBytes = PositiveOrDefault(options.MaxWorkbookBytes, 5 * 1024 * 1024),
+                MaxPackageEntries = PositiveOrDefault(options.MaxPackageEntries, 256),
+                MaxPackageEntryBytes = PositiveOrDefault(options.MaxPackageEntryBytes, 1024 * 1024),
+                MaxSheets = PositiveOrDefault(options.MaxSheets, 5),
+                MaxRowsPerSheet = PositiveOrDefault(options.MaxRowsPerSheet, 50),
+                MaxColumnsPerRow = PositiveOrDefault(options.MaxColumnsPerRow, 20),
+                MaxCellChars = PositiveOrDefault(options.MaxCellChars, 200),
+                MaxSharedStrings = PositiveOrDefault(options.MaxSharedStrings, 10_000),
+            };
+
+        private static int PositiveOrDefault(int value, int defaultValue) =>
+            value > 0 ? value : defaultValue;
+
+        private static string? Normalize(string? value) =>
+            string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+        private static string NormalizeKey(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return string.Empty;
+            var builder = new StringBuilder(value.Length);
+            foreach (var c in value)
+            {
+                if (c is '_' or '-' or ' ')
+                    continue;
+                builder.Append(char.ToLowerInvariant(c));
+            }
+
+            return builder.ToString();
+        }
+
+        private static string? NormalizeMediaType(string? mediaType)
+        {
+            if (string.IsNullOrWhiteSpace(mediaType))
+                return null;
+            var normalized = mediaType.Trim();
+            var separatorIndex = normalized.IndexOf(';', StringComparison.Ordinal);
+            if (separatorIndex >= 0)
+                normalized = normalized[..separatorIndex].Trim();
+            return normalized.ToLowerInvariant();
+        }
+
+        private static bool HasSupportedXlsxFileName(string? fileName)
+        {
+            var normalized = Normalize(fileName);
+            return normalized == null ||
+                string.Equals(Path.GetExtension(normalized), ".xlsx", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static WorkflowSpreadsheetExtractFileRef ToResultFileRef(WorkflowFileRef descriptor) =>
+            new(
+                descriptor.FileId,
+                descriptor.ArtifactId,
+                descriptor.SourceKind.ToString(),
+                descriptor.SourceMessageId,
+                descriptor.SourceResourceKey,
+                descriptor.FileName,
+                descriptor.MediaType,
+                descriptor.SizeBytes,
+                descriptor.Sha256,
+                descriptor.CreatedAtUnixMs,
+                descriptor.ExpiresAtUnixMs,
+                descriptor.OwnerRunId,
+                descriptor.OwnerScopeId);
+
+        private static WorkflowToolExecutionResult Error(string error, string detail) =>
+            WorkflowToolExecutionResult.Success(JsonSerializer.Serialize(
+                new SpreadsheetExtractError(error, detail),
+                JsonOptions));
+
+        private static string ToErrorName(SpreadsheetPreviewErrorCode errorCode) =>
+            errorCode switch
+            {
+                SpreadsheetPreviewErrorCode.EncryptedWorkbook => "encrypted_workbook",
+                SpreadsheetPreviewErrorCode.UnsafeWorkbook => "unsafe_workbook",
+                SpreadsheetPreviewErrorCode.WorkbookTooLarge => "workbook_too_large",
+                SpreadsheetPreviewErrorCode.UnsupportedWorkbook => "unsupported_workbook",
+                _ => "invalid_workbook",
+            };
+
+        private static bool IsSafeArtifactFailure(Exception ex) =>
+            ex is FileNotFoundException ||
+            ex is InvalidOperationException ||
+            ex is UnauthorizedAccessException ||
+            ex is IOException;
+
+        private static string SafeArtifactDetail(Exception ex) =>
+            ex switch
+            {
+                FileNotFoundException => "Workflow file artifact content was not found.",
+                UnauthorizedAccessException => "Workflow file artifact content could not be accessed.",
+                IOException => "Workflow file artifact content could not be read.",
+                _ => ex.Message,
+            };
+    }
+
+    private sealed class SpreadsheetTooLargeException(string message) : Exception(message);
+
+    private sealed record SpreadsheetExtractArguments(WorkflowFileRef FileRef);
+
+    private sealed record SpreadsheetExtractResult(
+        string Kind,
+        string MediaType,
+        WorkflowSpreadsheetExtractFileRef File,
+        WorkflowSpreadsheetPreviewLimits Limits,
+        WorkflowSpreadsheetWorkbookPreview Workbook,
+        IReadOnlyList<SpreadsheetSheetPreview> Sheets,
+        bool Truncated);
+
+    private sealed record WorkflowSpreadsheetExtractFileRef(
+        string? FileId,
+        string? ArtifactId,
+        string SourceKind,
+        string? SourceMessageId,
+        string? SourceResourceKey,
+        string? FileName,
+        string? MediaType,
+        long SizeBytes,
+        string? Sha256,
+        long CreatedAtUnixMs,
+        long ExpiresAtUnixMs,
+        string? OwnerRunId,
+        string? OwnerScopeId);
+
+    private sealed record SpreadsheetExtractError(string Error, string Detail);
+}

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDocumentExtractToolTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDocumentExtractToolTests.cs
@@ -194,6 +194,41 @@ public sealed class WorkflowDocumentExtractToolTests
     }
 
     [Fact]
+    public async Task WorkflowDocumentExtractTool_ShouldRejectSpreadsheetMediaType()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "aevatar-workflow-document-extract-spreadsheet-tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var port = CreateFileArtifactPort(root);
+            var result = await port.IngestAsync(new WorkflowFileIngressRequest(
+                new byte[] { 80, 75, 3, 4 },
+                ApplicationWorkflowFileSourceKind.ChatInput,
+                FileName: "budget.xlsx",
+                MediaType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
+            var tool = await GetDocumentExtractToolAsync(port);
+
+            var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+                BuildDocumentExtractArguments(result.FileRef),
+                "run-1",
+                "extract",
+                "exec-1",
+                "call-1",
+                "scope-1",
+                new ProtoWorkflowCallerCredential()));
+
+            using var document = JsonDocument.Parse(output.ResultJson);
+            document.RootElement.GetProperty("error").GetString().Should().Be("unsupported_media_type");
+            document.RootElement.GetProperty("detail").GetString().Should().Contain("spreadsheetml.sheet");
+            output.ResultJson.Contains("base64", StringComparison.OrdinalIgnoreCase).Should().BeFalse();
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task WorkflowDocumentExtractTool_ShouldReturnUnavailableWhenProviderDoesNotSupportImageInput()
     {
         var root = Path.Combine(Path.GetTempPath(), "aevatar-workflow-document-extract-image-text-provider-tests", Guid.NewGuid().ToString("N"));

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowInfrastructureCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowInfrastructureCoverageTests.cs
@@ -95,6 +95,9 @@ public sealed class WorkflowInfrastructureCoverageTests
         }
 
         toolNames.Should().Contain("document_extract");
+        toolNames.Should().Contain("spreadsheet_extract");
+        provider.GetRequiredService<IOptions<WorkflowSpreadsheetExtractOptions>>()
+            .Value.MaxRowsPerSheet.Should().Be(50);
         services.Should().Contain(x =>
             x.ServiceType == typeof(WorkflowRunActorPort) &&
             x.ImplementationType == typeof(WorkflowRunActorPort));

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowSpreadsheetExtractToolTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowSpreadsheetExtractToolTests.cs
@@ -116,6 +116,119 @@ public sealed class WorkflowSpreadsheetExtractToolTests
         }
     }
 
+    [Fact]
+    public async Task WorkflowSpreadsheetExtractTool_ShouldFailClosedWhenNoInputFileRefsAreAvailable()
+    {
+        var tool = await GetSpreadsheetExtractToolAsync(new StaticWorkflowFileArtifactReadPort(
+            new ApplicationWorkflowFileRef
+            {
+                FileId = "unread-workbook",
+                SourceKind = ApplicationWorkflowFileSourceKind.ChatInput,
+                FileName = "unread.xlsx",
+                MediaType = XlsxMediaType,
+                SizeBytes = 13,
+            },
+            new MemoryStream(Encoding.UTF8.GetBytes("hidden workbook"))));
+
+        var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+            "{}",
+            "run-1",
+            "extract",
+            "exec-1",
+            "call-1",
+            "scope-1",
+            new ProtoWorkflowCallerCredential()));
+
+        using var document = JsonDocument.Parse(output.ResultJson);
+        document.RootElement.GetProperty("error").GetString().Should().Be("invalid_arguments");
+        document.RootElement.GetProperty("detail").GetString()
+            .Should().Contain("requires a fileRef object or exactly one input file ref");
+        output.ResultJson.Should().NotContain("hidden workbook");
+        output.ResultJson.Should().NotContain("xl/");
+    }
+
+    [Fact]
+    public async Task WorkflowSpreadsheetExtractTool_ShouldFailClosedWhenInputFileRefsAreAmbiguous()
+    {
+        var tool = await GetSpreadsheetExtractToolAsync(new StaticWorkflowFileArtifactReadPort(
+            new ApplicationWorkflowFileRef
+            {
+                FileId = "unread-workbook",
+                SourceKind = ApplicationWorkflowFileSourceKind.ChatInput,
+                FileName = "unread.xlsx",
+                MediaType = XlsxMediaType,
+                SizeBytes = 13,
+            },
+            new MemoryStream(Encoding.UTF8.GetBytes("hidden workbook"))));
+        var firstFileRef = new ApplicationWorkflowFileRef
+        {
+            FileId = "first-workbook",
+            SourceKind = ApplicationWorkflowFileSourceKind.ChatInput,
+            FileName = "first.xlsx",
+            MediaType = XlsxMediaType,
+            SizeBytes = 1,
+        };
+        var secondFileRef = new ApplicationWorkflowFileRef
+        {
+            FileId = "second-workbook",
+            SourceKind = ApplicationWorkflowFileSourceKind.ChatInput,
+            FileName = "second.xlsx",
+            MediaType = XlsxMediaType,
+            SizeBytes = 1,
+        };
+
+        var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+            "{}",
+            "run-1",
+            "extract",
+            "exec-1",
+            "call-1",
+            "scope-1",
+            new ProtoWorkflowCallerCredential(),
+            InputFileRefs: [
+                ToProtoWorkflowFileRef(firstFileRef),
+                ToProtoWorkflowFileRef(secondFileRef),
+            ]));
+
+        using var document = JsonDocument.Parse(output.ResultJson);
+        document.RootElement.GetProperty("error").GetString().Should().Be("invalid_arguments");
+        document.RootElement.GetProperty("detail").GetString()
+            .Should().Contain("received multiple input file refs; provide fileRef explicitly");
+        output.ResultJson.Should().NotContain("hidden workbook");
+        output.ResultJson.Should().NotContain("xl/");
+    }
+
+    [Fact]
+    public async Task WorkflowSpreadsheetExtractTool_ShouldRejectEmptyExplicitFileRef()
+    {
+        var tool = await GetSpreadsheetExtractToolAsync(new StaticWorkflowFileArtifactReadPort(
+            new ApplicationWorkflowFileRef
+            {
+                FileId = "unread-workbook",
+                SourceKind = ApplicationWorkflowFileSourceKind.ChatInput,
+                FileName = "unread.xlsx",
+                MediaType = XlsxMediaType,
+                SizeBytes = 13,
+            },
+            new MemoryStream(Encoding.UTF8.GetBytes("hidden workbook"))));
+
+        var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+            """{"file_ref":{}}""",
+            "run-1",
+            "extract",
+            "exec-1",
+            "call-1",
+            "scope-1",
+            new ProtoWorkflowCallerCredential()));
+
+        using var document = JsonDocument.Parse(output.ResultJson);
+        document.RootElement.GetProperty("error").GetString().Should().Be("invalid_arguments");
+        document.RootElement.GetProperty("detail").GetString()
+            .Should().Contain("fileRef requires fileId or artifactId");
+        output.ResultJson.Should().NotContain("hidden workbook");
+        output.ResultJson.Should().NotContain("xl/");
+    }
+
     [Theory]
     [InlineData("application/vnd.ms-excel", "legacy.xls", "unsupported_media_type")]
     [InlineData("application/vnd.ms-excel.sheet.macroEnabled.12", "macro.xlsm", "unsupported_media_type")]

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowSpreadsheetExtractToolTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowSpreadsheetExtractToolTests.cs
@@ -1,0 +1,635 @@
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.Workflow.Core.Modules;
+using Aevatar.Workflow.Infrastructure.Runs;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using ApplicationWorkflowFileRef = Aevatar.Workflow.Application.Abstractions.Runs.WorkflowFileRef;
+using ApplicationWorkflowFileSourceKind = Aevatar.Workflow.Application.Abstractions.Runs.WorkflowFileSourceKind;
+using ProtoWorkflowCallerCredential = Aevatar.Workflow.Abstractions.WorkflowCallerCredential;
+using ProtoWorkflowFileRef = Aevatar.Workflow.Abstractions.WorkflowFileRef;
+using ProtoWorkflowFileSourceKind = Aevatar.Workflow.Abstractions.WorkflowFileSourceKind;
+
+namespace Aevatar.Workflow.Host.Api.Tests;
+
+public sealed class WorkflowSpreadsheetExtractToolTests
+{
+    private const string XlsxMediaType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+    [Fact]
+    public async Task WorkflowSpreadsheetExtractTool_ShouldReturnBoundedPreviewForStoredXlsx()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "aevatar-workflow-spreadsheet-extract-preview-tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var port = CreateFileArtifactPort(root);
+            var workbookBytes = BuildWorkbook(("Summary", new[]
+            {
+                new[] { "Name", "Amount" },
+                new[] { "Alice", "42" },
+            }));
+            var result = await port.IngestAsync(new WorkflowFileIngressRequest(
+                workbookBytes,
+                ApplicationWorkflowFileSourceKind.ChatInput,
+                FileName: "invoice.xlsx",
+                MediaType: $"{XlsxMediaType}; charset=binary"));
+            var tool = await GetSpreadsheetExtractToolAsync(port);
+
+            var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+                BuildSpreadsheetExtractArguments(result.FileRef),
+                "run-1",
+                "extract",
+                "exec-1",
+                "call-1",
+                "scope-1",
+                new ProtoWorkflowCallerCredential()));
+
+            using var document = JsonDocument.Parse(output.ResultJson);
+            var rootElement = document.RootElement;
+            rootElement.GetProperty("kind").GetString().Should().Be("spreadsheet_preview");
+            rootElement.GetProperty("media_type").GetString().Should().Be(XlsxMediaType);
+            rootElement.GetProperty("file").GetProperty("file_id").GetString().Should().Be(result.FileRef.FileId);
+            rootElement.GetProperty("file").GetProperty("sha256").GetString().Should().Be(result.FileRef.Sha256);
+            rootElement.GetProperty("limits").GetProperty("max_rows_per_sheet").GetInt32().Should().Be(50);
+            rootElement.GetProperty("workbook").GetProperty("sheet_count").GetInt32().Should().Be(1);
+            rootElement.GetProperty("truncated").GetBoolean().Should().BeFalse();
+
+            var sheet = rootElement.GetProperty("sheets").EnumerateArray().Should().ContainSingle().Subject;
+            sheet.GetProperty("name").GetString().Should().Be("Summary");
+            sheet.GetProperty("rows").EnumerateArray().Should().HaveCount(2);
+            var firstRow = sheet.GetProperty("rows")[0];
+            firstRow.GetProperty("index").GetInt32().Should().Be(1);
+            firstRow.GetProperty("cells")[0].GetProperty("reference").GetString().Should().Be("A1");
+            firstRow.GetProperty("cells")[0].GetProperty("value").GetString().Should().Be("Name");
+            firstRow.GetProperty("cells")[1].GetProperty("value").GetString().Should().Be("Amount");
+            var secondRow = sheet.GetProperty("rows")[1];
+            secondRow.GetProperty("cells")[0].GetProperty("value").GetString().Should().Be("Alice");
+            secondRow.GetProperty("cells")[1].GetProperty("value").GetString().Should().Be("42");
+
+            output.ResultJson.Contains(Convert.ToBase64String(workbookBytes), StringComparison.Ordinal).Should().BeFalse();
+            output.ResultJson.Contains("[Content_Types].xml", StringComparison.OrdinalIgnoreCase).Should().BeFalse();
+            output.ResultJson.Contains("xl/worksheets", StringComparison.OrdinalIgnoreCase).Should().BeFalse();
+            output.ResultJson.Contains("base64", StringComparison.OrdinalIgnoreCase).Should().BeFalse();
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task WorkflowSpreadsheetExtractTool_ShouldFallbackToSingleInputFileRef()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "aevatar-workflow-spreadsheet-extract-input-ref-tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var port = CreateFileArtifactPort(root);
+            var result = await port.IngestAsync(new WorkflowFileIngressRequest(
+                BuildWorkbook(("Sheet1", new[] { new[] { "single input" } })),
+                ApplicationWorkflowFileSourceKind.ChatInput,
+                FileName: "single.xlsx",
+                MediaType: XlsxMediaType));
+            var tool = await GetSpreadsheetExtractToolAsync(port);
+
+            var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+                "{}",
+                "run-1",
+                "extract",
+                "exec-1",
+                "call-1",
+                "scope-1",
+                new ProtoWorkflowCallerCredential(),
+                InputFileRefs: [ToProtoWorkflowFileRef(result.FileRef)]));
+
+            using var document = JsonDocument.Parse(output.ResultJson);
+            document.RootElement.GetProperty("file").GetProperty("file_id").GetString().Should().Be(result.FileRef.FileId);
+            document.RootElement.GetProperty("sheets")[0].GetProperty("rows")[0]
+                .GetProperty("cells")[0].GetProperty("value").GetString().Should().Be("single input");
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData("application/vnd.ms-excel", "legacy.xls", "unsupported_media_type")]
+    [InlineData("application/vnd.ms-excel.sheet.macroEnabled.12", "macro.xlsm", "unsupported_media_type")]
+    [InlineData("application/vnd.ms-excel.sheet.binary.macroEnabled.12", "binary.xlsb", "unsupported_media_type")]
+    [InlineData("application/vnd.oasis.opendocument.spreadsheet", "open.ods", "unsupported_media_type")]
+    [InlineData("application/octet-stream", "unknown.xlsx", "unsupported_media_type")]
+    public async Task WorkflowSpreadsheetExtractTool_ShouldFailClosedForUnsupportedMediaTypes(
+        string mediaType,
+        string fileName,
+        string expectedError)
+    {
+        var fileRef = new ApplicationWorkflowFileRef
+        {
+            FileId = "unsupported-workbook",
+            SourceKind = ApplicationWorkflowFileSourceKind.ChatInput,
+            FileName = fileName,
+            MediaType = mediaType,
+            SizeBytes = 3,
+        };
+        var tool = await GetSpreadsheetExtractToolAsync(new StaticWorkflowFileArtifactReadPort(
+            fileRef,
+            new MemoryStream(new byte[] { 1, 2, 3 })));
+
+        var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+            BuildSpreadsheetExtractArguments(fileRef),
+            "run-1",
+            "extract",
+            "exec-1",
+            "call-1",
+            "scope-1",
+            new ProtoWorkflowCallerCredential()));
+
+        using var document = JsonDocument.Parse(output.ResultJson);
+        document.RootElement.GetProperty("error").GetString().Should().Be(expectedError);
+        output.ResultJson.Should().NotContain("base64");
+        output.ResultJson.Should().NotContain("xl/");
+    }
+
+    [Fact]
+    public async Task WorkflowSpreadsheetExtractTool_ShouldRejectWorkbookOverConfiguredByteLimit()
+    {
+        var workbookBytes = BuildWorkbook(("Sheet1", new[] { new[] { "too large" } }));
+        var fileRef = new ApplicationWorkflowFileRef
+        {
+            FileId = "large-workbook",
+            SourceKind = ApplicationWorkflowFileSourceKind.ChatInput,
+            FileName = "large.xlsx",
+            MediaType = XlsxMediaType,
+            SizeBytes = workbookBytes.Length,
+        };
+        var tool = await GetSpreadsheetExtractToolAsync(
+            new StaticWorkflowFileArtifactReadPort(fileRef, new MemoryStream(workbookBytes)),
+            new WorkflowSpreadsheetExtractOptions
+            {
+                MaxWorkbookBytes = workbookBytes.Length - 1,
+            });
+
+        var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+            BuildSpreadsheetExtractArguments(fileRef),
+            "run-1",
+            "extract",
+            "exec-1",
+            "call-1",
+            "scope-1",
+            new ProtoWorkflowCallerCredential()));
+
+        using var document = JsonDocument.Parse(output.ResultJson);
+        document.RootElement.GetProperty("error").GetString().Should().Be("workbook_too_large");
+        document.RootElement.GetProperty("detail").GetString().Should().Contain((workbookBytes.Length - 1).ToString());
+    }
+
+    [Theory]
+    [InlineData("legacy.xls")]
+    [InlineData("macro.xlsm")]
+    [InlineData("binary.xlsb")]
+    [InlineData("open.ods")]
+    public async Task WorkflowSpreadsheetExtractTool_ShouldRejectNonXlsxFileNamesEvenWhenMediaTypeIsXlsx(
+        string fileName)
+    {
+        var workbookBytes = BuildWorkbook(("Sheet1", new[] { new[] { "mislabeled" } }));
+        var fileRef = new ApplicationWorkflowFileRef
+        {
+            FileId = "mislabeled-workbook",
+            SourceKind = ApplicationWorkflowFileSourceKind.ChatInput,
+            FileName = fileName,
+            MediaType = XlsxMediaType,
+            SizeBytes = workbookBytes.Length,
+        };
+        var tool = await GetSpreadsheetExtractToolAsync(
+            new StaticWorkflowFileArtifactReadPort(fileRef, new MemoryStream(workbookBytes)));
+
+        var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+            BuildSpreadsheetExtractArguments(fileRef),
+            "run-1",
+            "extract",
+            "exec-1",
+            "call-1",
+            "scope-1",
+            new ProtoWorkflowCallerCredential()));
+
+        using var document = JsonDocument.Parse(output.ResultJson);
+        document.RootElement.GetProperty("error").GetString().Should().Be("unsupported_file_type");
+        output.ResultJson.Should().NotContain("mislabeled");
+    }
+
+    [Fact]
+    public async Task WorkflowSpreadsheetExtractTool_ShouldRejectMacroWorkbookPackage()
+    {
+        var workbookBytes = BuildWorkbook(("Sheet1", new[] { new[] { "macro" } }), includeMacroProject: true);
+        var fileRef = new ApplicationWorkflowFileRef
+        {
+            FileId = "macro-workbook",
+            SourceKind = ApplicationWorkflowFileSourceKind.ChatInput,
+            FileName = "macro.xlsx",
+            MediaType = XlsxMediaType,
+            SizeBytes = workbookBytes.Length,
+        };
+        var tool = await GetSpreadsheetExtractToolAsync(
+            new StaticWorkflowFileArtifactReadPort(fileRef, new MemoryStream(workbookBytes)));
+
+        var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+            BuildSpreadsheetExtractArguments(fileRef),
+            "run-1",
+            "extract",
+            "exec-1",
+            "call-1",
+            "scope-1",
+            new ProtoWorkflowCallerCredential()));
+
+        using var document = JsonDocument.Parse(output.ResultJson);
+        document.RootElement.GetProperty("error").GetString().Should().Be("unsafe_workbook");
+        document.RootElement.GetProperty("detail").GetString().Should().Contain("macros");
+        output.ResultJson.Should().NotContain("vbaProject.bin");
+    }
+
+    [Fact]
+    public async Task WorkflowSpreadsheetExtractTool_ShouldRejectExternalLinkWorkbookPackage()
+    {
+        var workbookBytes = BuildWorkbook(("Sheet1", new[] { new[] { "external" } }), includeExternalRelationship: true);
+        var fileRef = new ApplicationWorkflowFileRef
+        {
+            FileId = "external-workbook",
+            SourceKind = ApplicationWorkflowFileSourceKind.ChatInput,
+            FileName = "external.xlsx",
+            MediaType = XlsxMediaType,
+            SizeBytes = workbookBytes.Length,
+        };
+        var tool = await GetSpreadsheetExtractToolAsync(
+            new StaticWorkflowFileArtifactReadPort(fileRef, new MemoryStream(workbookBytes)));
+
+        var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+            BuildSpreadsheetExtractArguments(fileRef),
+            "run-1",
+            "extract",
+            "exec-1",
+            "call-1",
+            "scope-1",
+            new ProtoWorkflowCallerCredential()));
+
+        using var document = JsonDocument.Parse(output.ResultJson);
+        document.RootElement.GetProperty("error").GetString().Should().Be("unsafe_workbook");
+        document.RootElement.GetProperty("detail").GetString().Should().Contain("external links");
+        output.ResultJson.Should().NotContain("https://example.com");
+    }
+
+    [Fact]
+    public async Task WorkflowSpreadsheetExtractTool_ShouldRejectEncryptedWorkbookPackage()
+    {
+        var workbookBytes = BuildEncryptedWorkbookPackage();
+        var fileRef = new ApplicationWorkflowFileRef
+        {
+            FileId = "encrypted-workbook",
+            SourceKind = ApplicationWorkflowFileSourceKind.ChatInput,
+            FileName = "encrypted.xlsx",
+            MediaType = XlsxMediaType,
+            SizeBytes = workbookBytes.Length,
+        };
+        var tool = await GetSpreadsheetExtractToolAsync(
+            new StaticWorkflowFileArtifactReadPort(fileRef, new MemoryStream(workbookBytes)));
+
+        var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+            BuildSpreadsheetExtractArguments(fileRef),
+            "run-1",
+            "extract",
+            "exec-1",
+            "call-1",
+            "scope-1",
+            new ProtoWorkflowCallerCredential()));
+
+        using var document = JsonDocument.Parse(output.ResultJson);
+        document.RootElement.GetProperty("error").GetString().Should().Be("encrypted_workbook");
+        output.ResultJson.Should().NotContain("EncryptedPackage");
+        output.ResultJson.Should().NotContain("EncryptionInfo");
+    }
+
+    [Fact]
+    public async Task WorkflowSpreadsheetExtractTool_ShouldTruncateRowsCellsAndCellTextWithinPreviewLimits()
+    {
+        var workbookBytes = BuildWorkbook(("Sheet1", new[]
+        {
+            new[] { "very-long-cell-value", "hidden-column" },
+            new[] { "hidden-row", "hidden-value" },
+        }));
+        var fileRef = new ApplicationWorkflowFileRef
+        {
+            FileId = "bounded-workbook",
+            SourceKind = ApplicationWorkflowFileSourceKind.ChatInput,
+            FileName = "bounded.xlsx",
+            MediaType = XlsxMediaType,
+            SizeBytes = workbookBytes.Length,
+        };
+        var tool = await GetSpreadsheetExtractToolAsync(
+            new StaticWorkflowFileArtifactReadPort(fileRef, new MemoryStream(workbookBytes)),
+            new WorkflowSpreadsheetExtractOptions
+            {
+                MaxRowsPerSheet = 1,
+                MaxColumnsPerRow = 1,
+                MaxCellChars = 4,
+            });
+
+        var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+            BuildSpreadsheetExtractArguments(fileRef),
+            "run-1",
+            "extract",
+            "exec-1",
+            "call-1",
+            "scope-1",
+            new ProtoWorkflowCallerCredential()));
+
+        using var document = JsonDocument.Parse(output.ResultJson);
+        var rootElement = document.RootElement;
+        rootElement.GetProperty("truncated").GetBoolean().Should().BeTrue();
+        var sheet = rootElement.GetProperty("sheets")[0];
+        sheet.GetProperty("truncated").GetBoolean().Should().BeTrue();
+        sheet.GetProperty("rows").EnumerateArray().Should().ContainSingle();
+        var cell = sheet.GetProperty("rows")[0].GetProperty("cells").EnumerateArray().Should().ContainSingle().Subject;
+        cell.GetProperty("value").GetString().Should().Be("very");
+        cell.GetProperty("truncated").GetBoolean().Should().BeTrue();
+        output.ResultJson.Should().NotContain("hidden-column");
+        output.ResultJson.Should().NotContain("hidden-row");
+    }
+
+    private static FileSystemWorkflowFileIngressPort CreateFileArtifactPort(string root) =>
+        new(Options.Create(new FileSystemWorkflowFileIngressOptions
+        {
+            RootDirectory = root,
+            TimeToLive = TimeSpan.FromMinutes(30),
+        }));
+
+    private static async Task<IWorkflowTool> GetSpreadsheetExtractToolAsync(
+        IWorkflowFileArtifactReadPort readPort,
+        WorkflowSpreadsheetExtractOptions? options = null)
+    {
+        var source = new WorkflowSpreadsheetExtractToolSource(
+            readPort,
+            Options.Create(options ?? new WorkflowSpreadsheetExtractOptions()));
+        var tools = await source.GetToolsAsync();
+        return tools.Should().ContainSingle(x => x.Name == "spreadsheet_extract").Subject;
+    }
+
+    private static string BuildSpreadsheetExtractArguments(ApplicationWorkflowFileRef fileRef)
+    {
+        var payload = new Dictionary<string, object?>
+        {
+            ["file_ref"] = new Dictionary<string, object?>
+            {
+                ["file_id"] = fileRef.FileId,
+                ["artifact_id"] = fileRef.ArtifactId,
+                ["source_kind"] = fileRef.SourceKind.ToString(),
+                ["file_name"] = fileRef.FileName,
+                ["media_type"] = fileRef.MediaType,
+                ["size_bytes"] = fileRef.SizeBytes,
+                ["sha256"] = fileRef.Sha256,
+                ["created_at_unix_ms"] = fileRef.CreatedAtUnixMs,
+                ["expires_at_unix_ms"] = fileRef.ExpiresAtUnixMs,
+            },
+        };
+
+        return JsonSerializer.Serialize(payload);
+    }
+
+    private static ProtoWorkflowFileRef ToProtoWorkflowFileRef(ApplicationWorkflowFileRef source) =>
+        new()
+        {
+            FileId = source.FileId ?? string.Empty,
+            ArtifactId = source.ArtifactId ?? string.Empty,
+            SourceKind = source.SourceKind switch
+            {
+                ApplicationWorkflowFileSourceKind.ChatInput => ProtoWorkflowFileSourceKind.ChatInput,
+                ApplicationWorkflowFileSourceKind.FormUpload => ProtoWorkflowFileSourceKind.FormUpload,
+                ApplicationWorkflowFileSourceKind.ConnectedServiceResource => ProtoWorkflowFileSourceKind.ConnectedServiceResource,
+                ApplicationWorkflowFileSourceKind.ExternalResource => ProtoWorkflowFileSourceKind.ExternalResource,
+                ApplicationWorkflowFileSourceKind.Generated => ProtoWorkflowFileSourceKind.Generated,
+                _ => ProtoWorkflowFileSourceKind.Unspecified,
+            },
+            SourceMessageId = source.SourceMessageId ?? string.Empty,
+            SourceResourceKey = source.SourceResourceKey ?? string.Empty,
+            FileName = source.FileName ?? string.Empty,
+            MediaType = source.MediaType ?? string.Empty,
+            SizeBytes = source.SizeBytes,
+            Sha256 = source.Sha256 ?? string.Empty,
+            CreatedAtUnixMs = source.CreatedAtUnixMs,
+            ExpiresAtUnixMs = source.ExpiresAtUnixMs,
+            OwnerRunId = source.OwnerRunId ?? string.Empty,
+            OwnerScopeId = source.OwnerScopeId ?? string.Empty,
+        };
+
+    private static byte[] BuildWorkbook(params (string Name, IReadOnlyList<string[]> Rows)[] sheets) =>
+        BuildWorkbook(sheets, includeMacroProject: false, includeExternalRelationship: false);
+
+    private static byte[] BuildWorkbook(
+        (string Name, IReadOnlyList<string[]> Rows) sheet,
+        bool includeMacroProject = false,
+        bool includeExternalRelationship = false) =>
+        BuildWorkbook([sheet], includeMacroProject, includeExternalRelationship);
+
+    private static byte[] BuildWorkbook(
+        IReadOnlyList<(string Name, IReadOnlyList<string[]> Rows)> sheets,
+        bool includeMacroProject,
+        bool includeExternalRelationship)
+    {
+        using var stream = new MemoryStream();
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            AddEntry(archive, "[Content_Types].xml", BuildContentTypes(sheets.Count, includeMacroProject));
+            AddEntry(archive, "_rels/.rels", """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+                  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+                </Relationships>
+                """);
+            AddEntry(archive, "xl/workbook.xml", BuildWorkbookXml(sheets));
+            AddEntry(archive, "xl/_rels/workbook.xml.rels", BuildWorkbookRelationships(sheets.Count, includeExternalRelationship));
+            AddEntry(archive, "xl/sharedStrings.xml", BuildSharedStringsXml(sheets));
+            for (var i = 0; i < sheets.Count; i++)
+            {
+                AddEntry(archive, $"xl/worksheets/sheet{i + 1}.xml", BuildWorksheetXml(sheets[i].Rows));
+            }
+
+            if (includeMacroProject)
+                AddEntry(archive, "xl/vbaProject.bin", "macro");
+        }
+
+        return stream.ToArray();
+    }
+
+    private static byte[] BuildEncryptedWorkbookPackage()
+    {
+        using var stream = new MemoryStream();
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            AddEntry(archive, "EncryptionInfo", "encrypted metadata");
+            AddEntry(archive, "EncryptedPackage", "encrypted bytes");
+        }
+
+        return stream.ToArray();
+    }
+
+    private static string BuildContentTypes(int sheetCount, bool includeMacroProject)
+    {
+        var builder = new StringBuilder();
+        builder.Append("""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+              <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+              <Default Extension="xml" ContentType="application/xml"/>
+              <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+              <Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>
+            """);
+        for (var i = 1; i <= sheetCount; i++)
+        {
+            builder.Append(CultureInvariant($"""
+                <Override PartName="/xl/worksheets/sheet{i}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+            """));
+        }
+
+        if (includeMacroProject)
+            builder.Append("""<Default Extension="bin" ContentType="application/vnd.ms-office.vbaProject"/>""");
+
+        builder.Append("</Types>");
+        return builder.ToString();
+    }
+
+    private static string BuildWorkbookXml(IReadOnlyList<(string Name, IReadOnlyList<string[]> Rows)> sheets)
+    {
+        var builder = new StringBuilder();
+        builder.Append("""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+              <sheets>
+            """);
+        for (var i = 0; i < sheets.Count; i++)
+        {
+            builder.Append(CultureInvariant($"""<sheet name="{EscapeXml(sheets[i].Name)}" sheetId="{i + 1}" r:id="rId{i + 1}"/>"""));
+        }
+
+        builder.Append("""
+              </sheets>
+            </workbook>
+            """);
+        return builder.ToString();
+    }
+
+    private static string BuildWorkbookRelationships(int sheetCount, bool includeExternalRelationship)
+    {
+        var builder = new StringBuilder();
+        builder.Append("""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+            """);
+        for (var i = 1; i <= sheetCount; i++)
+        {
+            builder.Append(CultureInvariant($"""<Relationship Id="rId{i}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet{i}.xml"/>"""));
+        }
+
+        if (includeExternalRelationship)
+        {
+            builder.Append("""
+                  <Relationship Id="rIdExternal" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLinkPath" Target="https://example.com/source.xlsx" TargetMode="External"/>
+                """);
+        }
+
+        builder.Append("</Relationships>");
+        return builder.ToString();
+    }
+
+    private static string BuildSharedStringsXml(IReadOnlyList<(string Name, IReadOnlyList<string[]> Rows)> sheets)
+    {
+        var values = sheets.SelectMany(sheet => sheet.Rows).SelectMany(row => row).ToArray();
+        var builder = new StringBuilder();
+        builder.Append(CultureInvariant($"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="{values.Length}" uniqueCount="{values.Length}">
+            """));
+        foreach (var value in values)
+        {
+            builder.Append(CultureInvariant($"""<si><t>{EscapeXml(value)}</t></si>"""));
+        }
+
+        builder.Append("</sst>");
+        return builder.ToString();
+    }
+
+    private static string BuildWorksheetXml(IReadOnlyList<string[]> rows)
+    {
+        var sharedStringIndex = 0;
+        var builder = new StringBuilder();
+        builder.Append("""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+              <sheetData>
+            """);
+        for (var rowIndex = 0; rowIndex < rows.Count; rowIndex++)
+        {
+            builder.Append(CultureInvariant($"""<row r="{rowIndex + 1}">"""));
+            for (var columnIndex = 0; columnIndex < rows[rowIndex].Length; columnIndex++)
+            {
+                var reference = $"{ColumnName(columnIndex + 1)}{rowIndex + 1}";
+                builder.Append(CultureInvariant($"""<c r="{reference}" t="s"><v>{sharedStringIndex}</v></c>"""));
+                sharedStringIndex++;
+            }
+
+            builder.Append("</row>");
+        }
+
+        builder.Append("""
+              </sheetData>
+            </worksheet>
+            """);
+        return builder.ToString();
+    }
+
+    private static void AddEntry(ZipArchive archive, string name, string content)
+    {
+        var entry = archive.CreateEntry(name, CompressionLevel.NoCompression);
+        using var writer = new StreamWriter(entry.Open(), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        writer.Write(content);
+    }
+
+    private static string ColumnName(int columnNumber)
+    {
+        var builder = new StringBuilder();
+        while (columnNumber > 0)
+        {
+            columnNumber--;
+            builder.Insert(0, (char)('A' + (columnNumber % 26)));
+            columnNumber /= 26;
+        }
+
+        return builder.ToString();
+    }
+
+    private static string EscapeXml(string value) =>
+        value
+            .Replace("&", "&amp;", StringComparison.Ordinal)
+            .Replace("\"", "&quot;", StringComparison.Ordinal)
+            .Replace("<", "&lt;", StringComparison.Ordinal)
+            .Replace(">", "&gt;", StringComparison.Ordinal);
+
+    private static string CultureInvariant(FormattableString value) =>
+        FormattableString.Invariant(value);
+
+    private sealed class StaticWorkflowFileArtifactReadPort(
+        ApplicationWorkflowFileRef fileRef,
+        Stream content) : IWorkflowFileArtifactReadPort
+    {
+        public ValueTask<ApplicationWorkflowFileRef> DescribeAsync(
+            ApplicationWorkflowFileRef requestedFileRef,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(fileRef);
+
+        public ValueTask<WorkflowFileArtifactContent> OpenReadAsync(
+            ApplicationWorkflowFileRef requestedFileRef,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(new WorkflowFileArtifactContent(fileRef, content));
+    }
+}

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowSpreadsheetExtractToolTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowSpreadsheetExtractToolTests.cs
@@ -334,6 +334,79 @@ public sealed class WorkflowSpreadsheetExtractToolTests
         output.ResultJson.Should().NotContain("stream too large");
     }
 
+    [Fact]
+    public async Task WorkflowSpreadsheetExtractTool_ShouldRejectPackageEntryCountOverConfiguredLimit()
+    {
+        var workbookBytes = BuildWorkbookWithExtraEntries(3);
+        var maxPackageEntries = CountPackageEntries(workbookBytes) - 1;
+        var fileRef = BuildXlsxFileRef("entry-count-workbook", "entry-count.xlsx", workbookBytes);
+
+        var output = await ExecuteSpreadsheetExtractAsync(
+            fileRef,
+            workbookBytes,
+            new WorkflowSpreadsheetExtractOptions
+            {
+                MaxPackageEntries = maxPackageEntries,
+            });
+
+        using var document = JsonDocument.Parse(output.ResultJson);
+        document.RootElement.GetProperty("error").GetString().Should().Be("workbook_too_large");
+        document.RootElement.GetProperty("detail").GetString()
+            .Should().Contain($"exceeds {maxPackageEntries} entries");
+        output.ResultJson.Should().NotContain("entry-count-secret");
+        output.ResultJson.Should().NotContain("xl/extra");
+    }
+
+    [Fact]
+    public async Task WorkflowSpreadsheetExtractTool_ShouldRejectPackagePartOverConfiguredByteLimit()
+    {
+        const int maxPackageEntryBytes = 1024;
+        var workbookBytes = BuildWorkbookWithExtraEntry(
+            "xl/extra/oversized-part.xml",
+            "package-part-secret-" + new string('x', maxPackageEntryBytes + 1));
+        var fileRef = BuildXlsxFileRef("large-part-workbook", "large-part.xlsx", workbookBytes);
+
+        var output = await ExecuteSpreadsheetExtractAsync(
+            fileRef,
+            workbookBytes,
+            new WorkflowSpreadsheetExtractOptions
+            {
+                MaxPackageEntryBytes = maxPackageEntryBytes,
+            });
+
+        using var document = JsonDocument.Parse(output.ResultJson);
+        document.RootElement.GetProperty("error").GetString().Should().Be("workbook_too_large");
+        document.RootElement.GetProperty("detail").GetString()
+            .Should().Contain($"package part exceeds {maxPackageEntryBytes} bytes");
+        output.ResultJson.Should().NotContain("package-part-secret");
+        output.ResultJson.Should().NotContain("oversized-part.xml");
+    }
+
+    [Fact]
+    public async Task WorkflowSpreadsheetExtractTool_ShouldRejectSharedStringCountOverConfiguredLimit()
+    {
+        var workbookBytes = BuildWorkbook(("Sheet1", new[]
+        {
+            new[] { "first-shared-string", "shared-string-secret" },
+        }));
+        var fileRef = BuildXlsxFileRef("shared-string-limit-workbook", "shared-string-limit.xlsx", workbookBytes);
+
+        var output = await ExecuteSpreadsheetExtractAsync(
+            fileRef,
+            workbookBytes,
+            new WorkflowSpreadsheetExtractOptions
+            {
+                MaxSharedStrings = 1,
+            });
+
+        using var document = JsonDocument.Parse(output.ResultJson);
+        document.RootElement.GetProperty("error").GetString().Should().Be("workbook_too_large");
+        document.RootElement.GetProperty("detail").GetString()
+            .Should().Contain("shared strings exceed 1 entries");
+        output.ResultJson.Should().NotContain("first-shared-string");
+        output.ResultJson.Should().NotContain("shared-string-secret");
+    }
+
     [Theory]
     [InlineData("legacy.xls")]
     [InlineData("macro.xlsm")]
@@ -568,6 +641,38 @@ public sealed class WorkflowSpreadsheetExtractToolTests
         return tools.Should().ContainSingle(x => x.Name == "spreadsheet_extract").Subject;
     }
 
+    private static async Task<WorkflowToolExecutionResult> ExecuteSpreadsheetExtractAsync(
+        ApplicationWorkflowFileRef fileRef,
+        byte[] workbookBytes,
+        WorkflowSpreadsheetExtractOptions options)
+    {
+        var tool = await GetSpreadsheetExtractToolAsync(
+            new StaticWorkflowFileArtifactReadPort(fileRef, new MemoryStream(workbookBytes)),
+            options);
+
+        return await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+            BuildSpreadsheetExtractArguments(fileRef),
+            "run-1",
+            "extract",
+            "exec-1",
+            "call-1",
+            "scope-1",
+            new ProtoWorkflowCallerCredential()));
+    }
+
+    private static ApplicationWorkflowFileRef BuildXlsxFileRef(
+        string fileId,
+        string fileName,
+        byte[] workbookBytes) =>
+        new()
+        {
+            FileId = fileId,
+            SourceKind = ApplicationWorkflowFileSourceKind.ChatInput,
+            FileName = fileName,
+            MediaType = XlsxMediaType,
+            SizeBytes = workbookBytes.Length,
+        };
+
     private static string BuildSpreadsheetExtractArguments(ApplicationWorkflowFileRef fileRef)
     {
         var payload = new Dictionary<string, object?>
@@ -627,7 +732,14 @@ public sealed class WorkflowSpreadsheetExtractToolTests
     private static byte[] BuildWorkbook(
         IReadOnlyList<(string Name, IReadOnlyList<string[]> Rows)> sheets,
         bool includeMacroProject,
-        bool includeExternalRelationship)
+        bool includeExternalRelationship) =>
+        BuildWorkbook(sheets, includeMacroProject, includeExternalRelationship, []);
+
+    private static byte[] BuildWorkbook(
+        IReadOnlyList<(string Name, IReadOnlyList<string[]> Rows)> sheets,
+        bool includeMacroProject,
+        bool includeExternalRelationship,
+        IReadOnlyList<(string Name, string Content)> extraEntries)
     {
         using var stream = new MemoryStream();
         using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
@@ -649,9 +761,39 @@ public sealed class WorkflowSpreadsheetExtractToolTests
 
             if (includeMacroProject)
                 AddEntry(archive, "xl/vbaProject.bin", "macro");
+
+            foreach (var extraEntry in extraEntries)
+            {
+                AddEntry(archive, extraEntry.Name, extraEntry.Content);
+            }
         }
 
         return stream.ToArray();
+    }
+
+    private static byte[] BuildWorkbookWithExtraEntries(int extraEntryCount) =>
+        BuildWorkbook(
+            [("Sheet1", new[] { new[] { "entry-count-visible" } })],
+            includeMacroProject: false,
+            includeExternalRelationship: false,
+            Enumerable.Range(0, extraEntryCount)
+                .Select(static index => (
+                    Name: $"xl/extra/entry{index + 1}.xml",
+                    Content: $"entry-count-secret-{index + 1}"))
+                .ToArray());
+
+    private static byte[] BuildWorkbookWithExtraEntry(string entryName, string content) =>
+        BuildWorkbook(
+            [("Sheet1", new[] { new[] { "part-size-visible" } })],
+            includeMacroProject: false,
+            includeExternalRelationship: false,
+            [(entryName, content)]);
+
+    private static int CountPackageEntries(byte[] workbookBytes)
+    {
+        using var stream = new MemoryStream(workbookBytes, writable: false);
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: false);
+        return archive.Entries.Count;
     }
 
     private static byte[] BuildEncryptedWorkbookPackage()

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowSpreadsheetExtractToolTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowSpreadsheetExtractToolTests.cs
@@ -187,6 +187,40 @@ public sealed class WorkflowSpreadsheetExtractToolTests
         document.RootElement.GetProperty("detail").GetString().Should().Contain((workbookBytes.Length - 1).ToString());
     }
 
+    [Fact]
+    public async Task WorkflowSpreadsheetExtractTool_ShouldRejectUnderreportedStreamOverConfiguredByteLimit()
+    {
+        var workbookBytes = BuildWorkbook(("Sheet1", new[] { new[] { "stream too large" } }));
+        var fileRef = new ApplicationWorkflowFileRef
+        {
+            FileId = "underreported-workbook",
+            SourceKind = ApplicationWorkflowFileSourceKind.ChatInput,
+            FileName = "underreported.xlsx",
+            MediaType = XlsxMediaType,
+            SizeBytes = 0,
+        };
+        var tool = await GetSpreadsheetExtractToolAsync(
+            new StaticWorkflowFileArtifactReadPort(fileRef, new MemoryStream(workbookBytes)),
+            new WorkflowSpreadsheetExtractOptions
+            {
+                MaxWorkbookBytes = workbookBytes.Length - 1,
+            });
+
+        var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+            BuildSpreadsheetExtractArguments(fileRef),
+            "run-1",
+            "extract",
+            "exec-1",
+            "call-1",
+            "scope-1",
+            new ProtoWorkflowCallerCredential()));
+
+        using var document = JsonDocument.Parse(output.ResultJson);
+        document.RootElement.GetProperty("error").GetString().Should().Be("workbook_too_large");
+        document.RootElement.GetProperty("detail").GetString().Should().Contain((workbookBytes.Length - 1).ToString());
+        output.ResultJson.Should().NotContain("stream too large");
+    }
+
     [Theory]
     [InlineData("legacy.xls")]
     [InlineData("macro.xlsm")]
@@ -356,6 +390,51 @@ public sealed class WorkflowSpreadsheetExtractToolTests
         cell.GetProperty("truncated").GetBoolean().Should().BeTrue();
         output.ResultJson.Should().NotContain("hidden-column");
         output.ResultJson.Should().NotContain("hidden-row");
+    }
+
+    [Fact]
+    public async Task WorkflowSpreadsheetExtractTool_ShouldTruncateWorkbookSheetsWithinPreviewLimits()
+    {
+        var workbookBytes = BuildWorkbook([
+            ("Visible", new[] { new[] { "visible-sheet" } }),
+            ("Hidden", new[] { new[] { "hidden-sheet" } }),
+        ]);
+        var fileRef = new ApplicationWorkflowFileRef
+        {
+            FileId = "sheet-limited-workbook",
+            SourceKind = ApplicationWorkflowFileSourceKind.ChatInput,
+            FileName = "sheet-limited.xlsx",
+            MediaType = XlsxMediaType,
+            SizeBytes = workbookBytes.Length,
+        };
+        var tool = await GetSpreadsheetExtractToolAsync(
+            new StaticWorkflowFileArtifactReadPort(fileRef, new MemoryStream(workbookBytes)),
+            new WorkflowSpreadsheetExtractOptions
+            {
+                MaxSheets = 1,
+            });
+
+        var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+            BuildSpreadsheetExtractArguments(fileRef),
+            "run-1",
+            "extract",
+            "exec-1",
+            "call-1",
+            "scope-1",
+            new ProtoWorkflowCallerCredential()));
+
+        using var document = JsonDocument.Parse(output.ResultJson);
+        var rootElement = document.RootElement;
+        rootElement.GetProperty("truncated").GetBoolean().Should().BeTrue();
+        rootElement.GetProperty("workbook").GetProperty("sheet_count").GetInt32().Should().Be(2);
+        rootElement.GetProperty("workbook").GetProperty("truncated").GetBoolean().Should().BeTrue();
+        rootElement.GetProperty("sheets").EnumerateArray().Should().ContainSingle();
+        var sheet = rootElement.GetProperty("sheets")[0];
+        sheet.GetProperty("name").GetString().Should().Be("Visible");
+        sheet.GetProperty("rows")[0].GetProperty("cells")[0].GetProperty("value").GetString()
+            .Should().Be("visible-sheet");
+        output.ResultJson.Should().NotContain("Hidden");
+        output.ResultJson.Should().NotContain("hidden-sheet");
     }
 
     private static FileSystemWorkflowFileIngressPort CreateFileArtifactPort(string root) =>


### PR DESCRIPTION
## Changed files

实现独立的 workflow-owned `spreadsheet_extract` tool source，复用现有 workflow file artifact read port 读取 descriptor 指向的文件。新增 bounded XLSX preview extractor 和 options，输出仅包含 file descriptor、limits、workbook/sheet/row/cell preview 与 safe error。

保持 `document_extract` 不接管 spreadsheet：新增 regression test 确认 spreadsheet media type 会 fail closed。补充 DI coverage 和 discussion doc，明确本阶段不新增 spreadsheet readmodel、proto result、actor state shape 或 package dependency。

Closes #2223

## Test results

- `dotnet build aevatar.slnx --nologo` 通过，只有既有 warning。
- `dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo` 通过，622 passed。
- `dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --nologo` 通过，512 passed。
- `bash tools/ci/test_stability_guards.sh` 通过。
- `bash tools/ci/architecture_guards.sh` 通过。
- `dotnet test aevatar.slnx --nologo` 通过，exit 0，只有既有 skipped tests。

## Deviations

未扩展 scope。未修改 `Directory.Packages.props` / infrastructure csproj，因为不需要新增依赖；未修改 core backpressure tests，因为 core foreach/backpressure 行为未变。`HOST_REFACTOR_COMMENT_POLICY=none`，因此未添加 refactor self-documentation source comments。

⟦AI:AUTO-LOOP⟧
