### PR TITLE
Add explicit delivery target creation

### DIFF
--- a/agents/Aevatar.GAgents.Authoring.Lark/DependencyInjection/AuthoringServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/DependencyInjection/AuthoringServiceCollectionExtensions.cs
@@ -34,6 +34,7 @@ public static class AuthoringServiceCollectionExtensions
         services.TryAddSingleton<ScheduledAgentCreatorOptions>();
         services.TryAddSingleton<ScheduledAgentCreateRequestMapper>();
         services.TryAddSingleton<ScheduledAgentApiKeyIssuer>();
+        services.TryAddSingleton<IScheduledAgentApiKeyIssuer>(sp => sp.GetRequiredService<ScheduledAgentApiKeyIssuer>());
         if (!services.Any(IsAgentBuilderToolSourceRegistration))
             services.Add(ServiceDescriptor.Singleton(typeof(IAgentToolSource), AgentToolSourceFactory));
 

--- a/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentApiKeyIssuer.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/ScheduledAgentApiKeyIssuer.cs
@@ -2,11 +2,12 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.GAgents.Scheduled;
 using Microsoft.Extensions.Logging;
 
 namespace Aevatar.GAgents.Authoring.Lark;
 
-internal sealed class ScheduledAgentApiKeyIssuer
+internal sealed class ScheduledAgentApiKeyIssuer : IScheduledAgentApiKeyIssuer
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
@@ -585,50 +586,4 @@ internal sealed record ScheduledAgentSkillPreflightResult(
         string hint,
         int? httpStatus) =>
         new(false, error, detail, hint, httpStatus);
-}
-
-internal sealed record ScheduledAgentServiceSlugs(
-    string PrimaryOutboundSlug,
-    string? FailureNotificationSlug,
-    IReadOnlyList<string> RequiredServiceSlugs,
-    bool RequiresOrnnService = true);
-
-internal sealed record ScheduledAgentApiKeyIssueResult(
-    bool Success,
-    string? ApiKeyId,
-    string? FullKey,
-    string? Error,
-    string? Detail = null,
-    string? Hint = null,
-    int? HttpStatus = null,
-    string? ServiceSlug = null,
-    string? SkillRef = null)
-{
-    private static readonly JsonSerializerOptions ErrorJsonOptions = new(JsonSerializerDefaults.Web)
-    {
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    };
-
-    public static ScheduledAgentApiKeyIssueResult Succeeded(string apiKeyId, string fullKey) =>
-        new(true, apiKeyId, fullKey, null);
-
-    public static ScheduledAgentApiKeyIssueResult Failed(
-        string error,
-        string? detail = null,
-        string? hint = null,
-        int? httpStatus = null,
-        string? serviceSlug = null,
-        string? skillRef = null) =>
-        new(false, null, null, error, detail, hint, httpStatus, serviceSlug, skillRef);
-
-    public string ToErrorJson() =>
-        JsonSerializer.Serialize(new
-        {
-            error = Error ?? "api_key_issue_failed",
-            detail = Detail,
-            hint = Hint,
-            http_status = HttpStatus,
-            service_slug = ServiceSlug,
-            skill_ref = SkillRef,
-        }, ErrorJsonOptions);
 }

--- a/agents/Aevatar.GAgents.Scheduled/IScheduledAgentApiKeyIssuer.cs
+++ b/agents/Aevatar.GAgents.Scheduled/IScheduledAgentApiKeyIssuer.cs
@@ -1,0 +1,20 @@
+namespace Aevatar.GAgents.Scheduled;
+
+public interface IScheduledAgentApiKeyIssuer
+{
+    Task<ScheduledAgentApiKeyIssueResult> IssueAsync(
+        string token,
+        ScheduledAgentServiceSlugs serviceSlugs,
+        string agentId,
+        string skillName,
+        string? scopeId,
+        CancellationToken ct);
+
+    Task TryRevokeAsync(string token, string apiKeyId, CancellationToken ct);
+}
+
+public sealed record ScheduledAgentServiceSlugs(
+    string PrimaryOutboundSlug,
+    string? FailureNotificationSlug,
+    IReadOnlyList<string> RequiredServiceSlugs,
+    bool RequiresOrnnService = true);

--- a/agents/Aevatar.GAgents.Scheduled/IUserAgentCatalogQueryPort.cs
+++ b/agents/Aevatar.GAgents.Scheduled/IUserAgentCatalogQueryPort.cs
@@ -19,6 +19,13 @@ public interface IUserAgentCatalogQueryPort
 {
     Task<UserAgentCatalogReadModelEntry?> GetForCallerAsync(string agentId, OwnerScope caller, CancellationToken ct = default);
 
+    /// <summary>
+    /// Returns whether the catalog id is occupied by any non-tombstoned row. This is a
+    /// narrow create-admission check: callers get only availability, never another
+    /// owner's catalog data.
+    /// </summary>
+    Task<bool> ExistsActiveAsync(string agentId, CancellationToken ct = default);
+
     Task<IReadOnlyList<UserAgentCatalogReadModelEntry>> QueryByCallerAsync(OwnerScope caller, CancellationToken ct = default);
 
     /// <summary>

--- a/agents/Aevatar.GAgents.Scheduled/ScheduledAgentApiKeyIssueResult.cs
+++ b/agents/Aevatar.GAgents.Scheduled/ScheduledAgentApiKeyIssueResult.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Aevatar.GAgents.Scheduled;
+
+public sealed record ScheduledAgentApiKeyIssueResult(
+    bool Success,
+    string? ApiKeyId,
+    string? FullKey,
+    string? Error,
+    string? Detail = null,
+    string? Hint = null,
+    int? HttpStatus = null,
+    string? ServiceSlug = null,
+    string? SkillRef = null)
+{
+    private static readonly JsonSerializerOptions ErrorJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public static ScheduledAgentApiKeyIssueResult Succeeded(string apiKeyId, string fullKey) =>
+        new(true, apiKeyId, fullKey, null);
+
+    public static ScheduledAgentApiKeyIssueResult Failed(
+        string error,
+        string? detail = null,
+        string? hint = null,
+        int? httpStatus = null,
+        string? serviceSlug = null,
+        string? skillRef = null) =>
+        new(false, null, null, error, detail, hint, httpStatus, serviceSlug, skillRef);
+
+    public string ToErrorJson() =>
+        JsonSerializer.Serialize(new
+        {
+            error = Error ?? "api_key_issue_failed",
+            detail = Detail,
+            hint = Hint,
+            http_status = HttpStatus,
+            service_slug = ServiceSlug,
+            skill_ref = SkillRef,
+        }, ErrorJsonOptions);
+}

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogGAgent.cs
@@ -56,6 +56,7 @@ public sealed class UserAgentCatalogGAgent : GAgentBase<UserAgentCatalogState>
             LarkReceiveIdType = MergeNonEmpty(command.LarkReceiveIdType, existing?.LarkReceiveIdType),
             LarkReceiveIdFallback = MergeNonEmpty(command.LarkReceiveIdFallback, existing?.LarkReceiveIdFallback),
             LarkReceiveIdTypeFallback = MergeNonEmpty(command.LarkReceiveIdTypeFallback, existing?.LarkReceiveIdTypeFallback),
+            TargetPlatform = MergeNonEmpty(command.TargetPlatform, existing?.TargetPlatform),
             OutputFormat = command.OutputFormat == SkillRunnerOutputFormat.Auto
                 ? existing?.OutputFormat ?? SkillRunnerOutputFormat.Auto
                 : command.OutputFormat,

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogGAgent.cs
@@ -1,3 +1,4 @@
+using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Attributes;
 using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.Foundation.Core;
@@ -34,6 +35,14 @@ public sealed class UserAgentCatalogGAgent : GAgentBase<UserAgentCatalogState>
         }
 
         var existing = State.Entries.FirstOrDefault(x => string.Equals(x.AgentId, command.AgentId, StringComparison.Ordinal));
+        if (existing is { Tombstoned: false } && !SameOwner(existing, command))
+        {
+            Logger.LogWarning(
+                "Cannot upsert user agent catalog entry owned by another caller: {AgentId}",
+                command.AgentId.Trim());
+            return;
+        }
+
         var now = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
         var entry = new UserAgentCatalogEntry
         {
@@ -88,6 +97,23 @@ public sealed class UserAgentCatalogGAgent : GAgentBase<UserAgentCatalogState>
         {
             Entry = entry,
         });
+    }
+
+    private static bool SameOwner(UserAgentCatalogEntry existing, UserAgentCatalogUpsertCommand command)
+    {
+        var existingScope = existing.OwnerScope ?? OwnerScope.FromLegacyFields(
+#pragma warning disable CS0612 // legacy field read for cross-owner overwrite guard
+            existing.OwnerNyxUserId,
+            existing.Platform);
+#pragma warning restore CS0612
+
+        var commandScope = command.OwnerScope ?? OwnerScope.FromLegacyFields(
+#pragma warning disable CS0612 // legacy command shape remains supported
+            command.OwnerNyxUserId,
+            command.Platform);
+#pragma warning restore CS0612
+
+        return existingScope is null || commandScope is null || existingScope.MatchesStrictly(commandScope);
     }
 
     [EventHandler]

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogProjector.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogProjector.cs
@@ -101,6 +101,7 @@ public sealed class UserAgentCatalogProjector
         document.LarkReceiveIdFallback = entry.LarkReceiveIdFallback ?? string.Empty;
         document.LarkReceiveIdTypeFallback = entry.LarkReceiveIdTypeFallback ?? string.Empty;
         document.OutputFormat = entry.OutputFormat;
+        document.TargetPlatform = entry.TargetPlatform ?? string.Empty;
 
         // Project owner_scope verbatim from the upserted entry. Per issue #466 the entry
         // is the authoritative source for ownership; the projector materializes it for

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogQueryPort.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogQueryPort.cs
@@ -72,6 +72,14 @@ public sealed class UserAgentCatalogQueryPort : IUserAgentCatalogQueryPort
         return ToEntry(document);
     }
 
+    public async Task<bool> ExistsActiveAsync(string agentId, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(agentId)) return false;
+
+        var document = await _documentReader.GetAsync(agentId.Trim(), ct);
+        return document is { Tombstoned: false };
+    }
+
     /// <summary>
     /// Hard cap on the cumulative count returned to a single caller. Bounds the
     /// in-memory accumulation so a misbehaving / pathological tenant cannot drag

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogQueryPort.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogQueryPort.cs
@@ -248,6 +248,7 @@ public sealed class UserAgentCatalogQueryPort : IUserAgentCatalogQueryPort
             LarkReceiveIdTypeFallback = document.LarkReceiveIdTypeFallback ?? string.Empty,
             OutputFormat = document.OutputFormat,
             OwnerScope = documentScope,
+            TargetPlatform = document.TargetPlatform ?? string.Empty,
             CatalogAuthorityStateVersion = document.StateVersion,
             CatalogLastEventId = document.LastEventId ?? string.Empty,
         };

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogReadModelEntry.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogReadModelEntry.cs
@@ -36,6 +36,7 @@ public sealed class UserAgentCatalogReadModelEntry
     public string LarkReceiveIdTypeFallback { get; init; } = string.Empty;
     public SkillRunnerOutputFormat OutputFormat { get; init; } = SkillRunnerOutputFormat.Auto;
     public OwnerScope? OwnerScope { get; init; }
+    public string TargetPlatform { get; init; } = string.Empty;
     public long CatalogAuthorityStateVersion { get; init; }
     public string CatalogLastEventId { get; init; } = string.Empty;
     public long? RunnerAuthorityStateVersion { get; init; }

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentDeliveryTargetReader.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentDeliveryTargetReader.cs
@@ -77,13 +77,6 @@ public sealed class UserAgentDeliveryTargetReader : IUserAgentDeliveryTargetRead
             return document.Platform;
 #pragma warning restore CS0612
 
-        if (!string.IsNullOrWhiteSpace(document.LarkReceiveId) ||
-            !string.IsNullOrWhiteSpace(document.LarkReceiveIdType) ||
-            document.NyxProviderSlug?.Contains("lark", StringComparison.OrdinalIgnoreCase) == true)
-        {
-            return "lark";
-        }
-
-        return document.OwnerScope?.Platform ?? string.Empty;
+        return document.TargetPlatform ?? string.Empty;
     }
 }

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentDeliveryTargetReader.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentDeliveryTargetReader.cs
@@ -56,7 +56,7 @@ public sealed class UserAgentDeliveryTargetReader : IUserAgentDeliveryTargetRead
         return new UserAgentDeliveryTarget(
             AgentId: document.Id ?? string.Empty,
 #pragma warning disable CS0612 // legacy field read for delivery target compatibility
-            Platform: document.Platform ?? string.Empty,
+            Platform: ResolveDeliveryPlatform(document),
 #pragma warning restore CS0612
             ConversationId: document.ConversationId ?? string.Empty,
             NyxProviderSlug: document.NyxProviderSlug ?? string.Empty,
@@ -68,5 +68,22 @@ public sealed class UserAgentDeliveryTargetReader : IUserAgentDeliveryTargetRead
             OutputFormat: document.OutputFormat,
             TemplateName: document.TemplateName ?? string.Empty,
             AgentType: document.AgentType ?? string.Empty);
+    }
+
+    private static string ResolveDeliveryPlatform(UserAgentCatalogDocument document)
+    {
+#pragma warning disable CS0612 // legacy field read for delivery target compatibility
+        if (!string.IsNullOrWhiteSpace(document.Platform))
+            return document.Platform;
+#pragma warning restore CS0612
+
+        if (!string.IsNullOrWhiteSpace(document.LarkReceiveId) ||
+            !string.IsNullOrWhiteSpace(document.LarkReceiveIdType) ||
+            document.NyxProviderSlug?.Contains("lark", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return "lark";
+        }
+
+        return document.OwnerScope?.Platform ?? string.Empty;
     }
 }

--- a/agents/Aevatar.GAgents.Scheduled/protos/user_agent_catalog.proto
+++ b/agents/Aevatar.GAgents.Scheduled/protos/user_agent_catalog.proto
@@ -67,6 +67,9 @@ message UserAgentCatalogEntry {
   // legacy state (issue #466 migration plan).
   aevatar.OwnerScope owner_scope = 26;
   SkillRunnerOutputFormat output_format = 27;
+  // Delivery target platform selected by the creator.
+  // This is distinct from owner_scope.platform, which identifies the caller surface.
+  string target_platform = 28;
 }
 
 message UserAgentCatalogState {
@@ -100,6 +103,9 @@ message UserAgentCatalogUpsertCommand {
   // Caller scope captured at create time. Required for new writes.
   aevatar.OwnerScope owner_scope = 18;
   SkillRunnerOutputFormat output_format = 19;
+  // Delivery target platform selected by the creator.
+  // This is distinct from owner_scope.platform, which identifies the caller surface.
+  string target_platform = 20;
 }
 
 message UserAgentCatalogTombstoneCommand {
@@ -166,6 +172,9 @@ message UserAgentCatalogDocument {
   reserved 29, 30, 31, 32;
   reserved "catalog_source_version", "catalog_last_event_id", "runner_source_version", "runner_last_event_id";
   SkillRunnerOutputFormat output_format = 33;
+  // Delivery target platform selected by the creator.
+  // This is distinct from owner_scope.platform, which identifies the caller surface.
+  string target_platform = 34;
 }
 
 // Runtime-only Nyx credential read model for delivery-target execution paths.

--- a/src/Aevatar.AI.ToolProviders.AgentCatalog/AgentDeliveryTargetTool.cs
+++ b/src/Aevatar.AI.ToolProviders.AgentCatalog/AgentDeliveryTargetTool.cs
@@ -47,7 +47,7 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
         "Manage agent delivery targets for workflow human interaction cards and outbound channel delivery. " +
         "Actions: list, create, upsert (rebind existing only), delete. " +
         "Use create to mint server-side credentials for a stable delivery_target_id without creating a scheduled runner. " +
-        "Use upsert to rebind an existing agent_id/delivery_target_id to a different Lark conversation or Nyx provider slug. " +
+        "Use upsert to rebind an existing agent_id/delivery_target_id to a different platform conversation or outbound provider slug. " +
         "Operations are scoped to the caller's own delivery targets.";
 
     // Note (issue #466): no `owner_nyx_user_id` and no `nyx_api_key` parameters. Owner
@@ -72,15 +72,15 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
             },
             "platform": {
               "type": "string",
-              "description": "Target platform (default: lark)"
+              "description": "Delivery platform for the target"
             },
             "conversation_id": {
               "type": "string",
-              "description": "Conversation/chat ID on the target platform"
+              "description": "Platform conversation or recipient ID"
             },
             "nyx_provider_slug": {
               "type": "string",
-              "description": "Nyx proxy service slug, e.g. api-lark-bot"
+              "description": "Outbound provider service slug for this target"
             },
             "confirm": {
               "type": "boolean",
@@ -160,16 +160,11 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
         if (nyxProviderSlug.error != null)
             return nyxProviderSlug.error;
 
-        var platform = (GetStr(args, "platform") ?? "lark").Trim();
-        if (!string.Equals(platform, "lark", StringComparison.OrdinalIgnoreCase))
-        {
-            return JsonSerializer.Serialize(new
-            {
-                error = "unsupported_delivery_platform",
-                platform,
-                hint = "Only lark delivery targets can be created by this tool.",
-            });
-        }
+        var platform = GetRequired(args, "'platform' is required for create", "platform");
+        if (platform.error != null)
+            return platform.error;
+
+        var targetPlatform = platform.value!;
 
         var existingForCaller = await queryPort.GetForCallerAsync(deliveryTargetId.value!, caller, ct);
         if (existingForCaller is not null)
@@ -214,7 +209,6 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
 
         try
         {
-            var receiveIdType = ResolveLarkReceiveIdType(conversationId.value);
             await commandPort.UpsertAsync(
                 new UserAgentCatalogUpsertCommand
                 {
@@ -226,8 +220,7 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
                     AgentType = "delivery_target",
                     TemplateName = "explicit_delivery_target",
                     ScopeId = keyScopeId,
-                    LarkReceiveId = conversationId.value!,
-                    LarkReceiveIdType = receiveIdType,
+                    TargetPlatform = targetPlatform,
                     OwnerScope = caller.Clone(),
                 },
                 ct);
@@ -243,7 +236,7 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
             status = "accepted",
             agent_id = deliveryTargetId.value,
             delivery_target_id = deliveryTargetId.value,
-            platform = "lark",
+            platform = targetPlatform,
             conversation_id = conversationId.value,
             nyx_provider_slug = nyxProviderSlug.value,
             api_key_id = key.ApiKeyId,
@@ -438,27 +431,6 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
         return (null, JsonSerializer.Serialize(new { error = errorMessage }));
     }
 
-    private static string ResolveLarkReceiveIdType(string? conversationId)
-    {
-        var trimmed = conversationId?.Trim();
-        if (string.IsNullOrEmpty(trimmed))
-            return "chat_id";
-        if (trimmed.StartsWith("ou_", StringComparison.Ordinal))
-            return "open_id";
-        if (trimmed.StartsWith("on_", StringComparison.Ordinal))
-            return "union_id";
-        return "chat_id";
-    }
-
-    private static string ResolveDeliveryPlatform(UserAgentCatalogReadModelEntry entry)
-    {
-        if (!string.IsNullOrWhiteSpace(entry.LarkReceiveId) ||
-            !string.IsNullOrWhiteSpace(entry.LarkReceiveIdType) ||
-            entry.NyxProviderSlug?.Contains("lark", StringComparison.OrdinalIgnoreCase) == true)
-        {
-            return "lark";
-        }
-
-        return entry.OwnerScope?.Platform ?? string.Empty;
-    }
+    private static string ResolveDeliveryPlatform(UserAgentCatalogReadModelEntry entry) =>
+        entry.TargetPlatform ?? string.Empty;
 }

--- a/src/Aevatar.AI.ToolProviders.AgentCatalog/AgentDeliveryTargetTool.cs
+++ b/src/Aevatar.AI.ToolProviders.AgentCatalog/AgentDeliveryTargetTool.cs
@@ -68,7 +68,7 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
             },
             "delivery_target_id": {
               "type": "string",
-              "description": "Stable delivery target alias. Required for create; accepted as an alias for agent_id in upsert/delete."
+              "description": "Stable delivery target ID. Required for create; accepted as an alias for agent_id in upsert/delete."
             },
             "platform": {
               "type": "string",
@@ -166,14 +166,13 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
 
         var targetPlatform = platform.value!;
 
-        var existingForCaller = await queryPort.GetForCallerAsync(deliveryTargetId.value!, caller, ct);
-        if (existingForCaller is not null)
+        if (await queryPort.ExistsActiveAsync(deliveryTargetId.value!, ct))
         {
             return JsonSerializer.Serialize(new
             {
                 error = "delivery_target_already_exists",
-                delivery_target_id = existingForCaller.AgentId,
-                hint = "Use action=upsert to rebind an existing delivery target.",
+                delivery_target_id = deliveryTargetId.value,
+                hint = "Use a different delivery_target_id. Existing delivery target ids are globally reserved.",
             });
         }
 

--- a/src/Aevatar.AI.ToolProviders.AgentCatalog/AgentDeliveryTargetTool.cs
+++ b/src/Aevatar.AI.ToolProviders.AgentCatalog/AgentDeliveryTargetTool.cs
@@ -27,24 +27,27 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
     private readonly IUserAgentCatalogQueryPort _queryPort;
     private readonly IUserAgentCatalogCommandPort _commandPort;
     private readonly ICallerScopeResolver _callerScopeResolver;
+    private readonly IScheduledAgentApiKeyIssuer? _apiKeyIssuer;
 
     public AgentDeliveryTargetTool(
         IUserAgentCatalogQueryPort queryPort,
         IUserAgentCatalogCommandPort commandPort,
-        ICallerScopeResolver callerScopeResolver)
+        ICallerScopeResolver callerScopeResolver,
+        IScheduledAgentApiKeyIssuer? apiKeyIssuer = null)
     {
         _queryPort = queryPort ?? throw new ArgumentNullException(nameof(queryPort));
         _commandPort = commandPort ?? throw new ArgumentNullException(nameof(commandPort));
         _callerScopeResolver = callerScopeResolver ?? throw new ArgumentNullException(nameof(callerScopeResolver));
+        _apiKeyIssuer = apiKeyIssuer;
     }
 
     public string Name => "agent_delivery_targets";
 
     public string Description =>
         "Manage agent delivery targets for workflow human interaction cards and outbound channel delivery. " +
-        "Actions: list, upsert (rebind existing only), delete. " +
-        "Use this to rebind an agent_id/delivery_target_id to a different Lark conversation or Nyx provider slug; " +
-        "creating new delivery targets (which mints credentials) is the scheduled_agent_creator tool's job. " +
+        "Actions: list, create, upsert (rebind existing only), delete. " +
+        "Use create to mint server-side credentials for a stable delivery_target_id without creating a scheduled runner. " +
+        "Use upsert to rebind an existing agent_id/delivery_target_id to a different Lark conversation or Nyx provider slug. " +
         "Operations are scoped to the caller's own delivery targets.";
 
     // Note (issue #466): no `owner_nyx_user_id` and no `nyx_api_key` parameters. Owner
@@ -56,12 +59,16 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
           "properties": {
             "action": {
               "type": "string",
-              "enum": ["list", "upsert", "delete"],
+              "enum": ["list", "create", "upsert", "delete"],
               "description": "Action to perform (default: list)"
             },
             "agent_id": {
               "type": "string",
               "description": "Agent ID / delivery target ID to bind"
+            },
+            "delivery_target_id": {
+              "type": "string",
+              "description": "Stable delivery target alias. Required for create; accepted as an alias for agent_id in upsert/delete."
             },
             "platform": {
               "type": "string",
@@ -108,10 +115,11 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
         var root = doc.RootElement;
         var action = GetStr(root, "action") ?? "list";
 
-        if (action is "upsert" or "delete")
+        if (action is "create" or "upsert" or "delete")
         {
             return action switch
             {
+                "create" => await CreateAsync(_queryPort, _commandPort, _callerScopeResolver, _apiKeyIssuer, token, caller, root, ct),
                 "upsert" => await UpsertAsync(_queryPort, _commandPort, caller, root, ct),
                 "delete" => await DeleteAsync(_queryPort, _commandPort, caller, root, ct),
                 _ => await ListAsync(_queryPort, caller, ct),
@@ -119,6 +127,128 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
         }
 
         return await ListAsync(_queryPort, caller, ct);
+    }
+
+    private static async Task<string> CreateAsync(
+        IUserAgentCatalogQueryPort queryPort,
+        IUserAgentCatalogCommandPort commandPort,
+        ICallerScopeResolver callerScopeResolver,
+        IScheduledAgentApiKeyIssuer? apiKeyIssuer,
+        string token,
+        OwnerScope caller,
+        JsonElement args,
+        CancellationToken ct)
+    {
+        if (apiKeyIssuer is null)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                error = "delivery_target_creation_unavailable",
+                hint = "The host has not registered the delivery-target credential issuer.",
+            });
+        }
+
+        var deliveryTargetId = GetRequired(args, "'delivery_target_id' is required for create", "delivery_target_id", "agent_id", "deliveryTargetId", "agentId");
+        if (deliveryTargetId.error != null)
+            return deliveryTargetId.error;
+
+        var conversationId = GetRequired(args, "'conversation_id' is required for create", "conversation_id", "conversationId");
+        if (conversationId.error != null)
+            return conversationId.error;
+
+        var nyxProviderSlug = GetRequired(args, "'nyx_provider_slug' is required for create", "nyx_provider_slug", "nyxProviderSlug");
+        if (nyxProviderSlug.error != null)
+            return nyxProviderSlug.error;
+
+        var platform = (GetStr(args, "platform") ?? "lark").Trim();
+        if (!string.Equals(platform, "lark", StringComparison.OrdinalIgnoreCase))
+        {
+            return JsonSerializer.Serialize(new
+            {
+                error = "unsupported_delivery_platform",
+                platform,
+                hint = "Only lark delivery targets can be created by this tool.",
+            });
+        }
+
+        var existingForCaller = await queryPort.GetForCallerAsync(deliveryTargetId.value!, caller, ct);
+        if (existingForCaller is not null)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                error = "delivery_target_already_exists",
+                delivery_target_id = existingForCaller.AgentId,
+                hint = "Use action=upsert to rebind an existing delivery target.",
+            });
+        }
+
+        OwnerScope keyScope;
+        try
+        {
+            keyScope = await callerScopeResolver.RequireAsync(ct);
+        }
+        catch (CallerScopeUnavailableException ex)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                error = "caller_scope_unavailable",
+                detail = ex.Message,
+                hint = "Re-authenticate (cli/web) or ensure the channel relay propagates platform/sender_id metadata.",
+            });
+        }
+
+        var keyScopeId = keyScope.RegistrationScopeId;
+        var key = await apiKeyIssuer.IssueAsync(
+            token,
+            new ScheduledAgentServiceSlugs(
+                nyxProviderSlug.value!,
+                FailureNotificationSlug: null,
+                RequiredServiceSlugs: [],
+                RequiresOrnnService: false),
+            deliveryTargetId.value!,
+            skillName: string.Empty,
+            scopeId: keyScopeId,
+            ct);
+        if (!key.Success)
+            return key.ToErrorJson();
+
+        try
+        {
+            var receiveIdType = ResolveLarkReceiveIdType(conversationId.value);
+            await commandPort.UpsertAsync(
+                new UserAgentCatalogUpsertCommand
+                {
+                    AgentId = deliveryTargetId.value!,
+                    ConversationId = conversationId.value!,
+                    NyxProviderSlug = nyxProviderSlug.value!,
+                    NyxApiKey = key.FullKey ?? string.Empty,
+                    ApiKeyId = key.ApiKeyId ?? string.Empty,
+                    AgentType = "delivery_target",
+                    TemplateName = "explicit_delivery_target",
+                    ScopeId = keyScopeId,
+                    LarkReceiveId = conversationId.value!,
+                    LarkReceiveIdType = receiveIdType,
+                    OwnerScope = caller.Clone(),
+                },
+                ct);
+        }
+        catch
+        {
+            await apiKeyIssuer.TryRevokeAsync(token, key.ApiKeyId ?? string.Empty, CancellationToken.None);
+            throw;
+        }
+
+        return JsonSerializer.Serialize(new
+        {
+            status = "accepted",
+            agent_id = deliveryTargetId.value,
+            delivery_target_id = deliveryTargetId.value,
+            platform = "lark",
+            conversation_id = conversationId.value,
+            nyx_provider_slug = nyxProviderSlug.value,
+            api_key_id = key.ApiKeyId,
+            note = "Delivery target create accepted. Projection is propagating; try 'list' after a few seconds.",
+        });
     }
 
     private static string? GetStr(JsonElement el, params string[] properties)
@@ -164,7 +294,7 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
             {
                 agent_id = entry.AgentId,
                 delivery_target_id = entry.AgentId,
-                platform = entry.OwnerScope?.Platform ?? string.Empty,
+                platform = ResolveDeliveryPlatform(entry),
                 conversation_id = entry.ConversationId,
                 nyx_provider_slug = entry.NyxProviderSlug,
                 created_at = entry.CreatedAt,
@@ -182,15 +312,15 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
         JsonElement args,
         CancellationToken ct)
     {
-        var agentId = GetRequired(args, "agent_id", "delivery_target_id", "agentId", "deliveryTargetId");
+        var agentId = GetRequired(args, "'agent_id' is required for upsert", "agent_id", "delivery_target_id", "agentId", "deliveryTargetId");
         if (agentId.error != null)
             return agentId.error;
 
-        var conversationId = GetRequired(args, "conversation_id", "conversationId");
+        var conversationId = GetRequired(args, "'conversation_id' is required for upsert", "conversation_id", "conversationId");
         if (conversationId.error != null)
             return conversationId.error;
 
-        var nyxProviderSlug = GetRequired(args, "nyx_provider_slug", "nyxProviderSlug");
+        var nyxProviderSlug = GetRequired(args, "'nyx_provider_slug' is required for upsert", "nyx_provider_slug", "nyxProviderSlug");
         if (nyxProviderSlug.error != null)
             return nyxProviderSlug.error;
 
@@ -212,7 +342,7 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
             return JsonSerializer.Serialize(new
             {
                 error = "delivery_target_not_found_for_caller",
-                hint = "agent_delivery_targets.upsert is a rebind operation only — it preserves the existing API key. To create a new agent (which mints credentials), use the scheduled_agent_creator tool instead.",
+                hint = "agent_delivery_targets.upsert is a rebind operation only — it preserves the existing API key. Use action=create to create a new delivery target with server-side credentials.",
             });
         }
 
@@ -299,12 +429,36 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
         });
     }
 
-    private static (string? value, string? error) GetRequired(JsonElement args, params string[] keys)
+    private static (string? value, string? error) GetRequired(JsonElement args, string errorMessage, params string[] keys)
     {
         var value = GetStr(args, keys)?.Trim();
         if (!string.IsNullOrWhiteSpace(value))
             return (value, null);
 
-        return (null, JsonSerializer.Serialize(new { error = $"'{keys[0]}' is required for upsert" }));
+        return (null, JsonSerializer.Serialize(new { error = errorMessage }));
+    }
+
+    private static string ResolveLarkReceiveIdType(string? conversationId)
+    {
+        var trimmed = conversationId?.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+            return "chat_id";
+        if (trimmed.StartsWith("ou_", StringComparison.Ordinal))
+            return "open_id";
+        if (trimmed.StartsWith("on_", StringComparison.Ordinal))
+            return "union_id";
+        return "chat_id";
+    }
+
+    private static string ResolveDeliveryPlatform(UserAgentCatalogReadModelEntry entry)
+    {
+        if (!string.IsNullOrWhiteSpace(entry.LarkReceiveId) ||
+            !string.IsNullOrWhiteSpace(entry.LarkReceiveIdType) ||
+            entry.NyxProviderSlug?.Contains("lark", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return "lark";
+        }
+
+        return entry.OwnerScope?.Platform ?? string.Empty;
     }
 }

--- a/src/Aevatar.AI.ToolProviders.AgentCatalog/AgentDeliveryTargetToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.AgentCatalog/AgentDeliveryTargetToolSource.cs
@@ -11,21 +11,24 @@ public sealed class AgentDeliveryTargetToolSource : IAgentToolSource
     private readonly IUserAgentCatalogQueryPort _queryPort;
     private readonly IUserAgentCatalogCommandPort _commandPort;
     private readonly ICallerScopeResolver _callerScopeResolver;
+    private readonly IScheduledAgentApiKeyIssuer? _apiKeyIssuer;
 
     public AgentDeliveryTargetToolSource(
         IUserAgentCatalogQueryPort queryPort,
         IUserAgentCatalogCommandPort commandPort,
-        ICallerScopeResolver callerScopeResolver)
+        ICallerScopeResolver callerScopeResolver,
+        IScheduledAgentApiKeyIssuer? apiKeyIssuer = null)
     {
         _queryPort = queryPort ?? throw new ArgumentNullException(nameof(queryPort));
         _commandPort = commandPort ?? throw new ArgumentNullException(nameof(commandPort));
         _callerScopeResolver = callerScopeResolver ?? throw new ArgumentNullException(nameof(callerScopeResolver));
+        _apiKeyIssuer = apiKeyIssuer;
     }
 
     public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default)
     {
         ct.ThrowIfCancellationRequested();
-        IReadOnlyList<IAgentTool> tools = [new AgentDeliveryTargetTool(_queryPort, _commandPort, _callerScopeResolver)];
+        IReadOnlyList<IAgentTool> tools = [new AgentDeliveryTargetTool(_queryPort, _commandPort, _callerScopeResolver, _apiKeyIssuer)];
         return Task.FromResult(tools);
     }
 }

--- a/src/Aevatar.AI.ToolProviders.AgentCatalog/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.AgentCatalog/ServiceCollectionExtensions.cs
@@ -9,6 +9,8 @@ namespace Aevatar.AI.ToolProviders.AgentCatalog;
 /// </summary>
 public static class ServiceCollectionExtensions
 {
+    private static readonly Func<IServiceProvider, object> ToolSourceFactory = CreateToolSource;
+
     /// <summary>
     /// Registers the agent-delivery-target tool source so LLM turns can resolve the
     /// catalog of user-owned agents available as delivery targets.
@@ -17,8 +19,21 @@ public static class ServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IAgentToolSource, AgentDeliveryTargetToolSource>());
+        if (!services.Any(IsToolSourceRegistration))
+            services.Add(ServiceDescriptor.Singleton(typeof(IAgentToolSource), ToolSourceFactory));
 
         return services;
     }
+
+    private static bool IsToolSourceRegistration(ServiceDescriptor descriptor) =>
+        descriptor.ServiceType == typeof(IAgentToolSource) &&
+        (descriptor.ImplementationType == typeof(AgentDeliveryTargetToolSource) ||
+         descriptor.ImplementationFactory == ToolSourceFactory);
+
+    private static object CreateToolSource(IServiceProvider sp) =>
+        new AgentDeliveryTargetToolSource(
+            sp.GetRequiredService<Aevatar.GAgents.Scheduled.IUserAgentCatalogQueryPort>(),
+            sp.GetRequiredService<Aevatar.GAgents.Scheduled.IUserAgentCatalogCommandPort>(),
+            sp.GetRequiredService<Aevatar.GAgents.Scheduled.ICallerScopeResolver>(),
+            sp.GetService<Aevatar.GAgents.Scheduled.IScheduledAgentApiKeyIssuer>());
 }

--- a/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
+++ b/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
@@ -787,6 +787,12 @@ public sealed class PolicyAwareVoiceEndpointsTests
                 : null);
         }
 
+        public Task<bool> ExistsActiveAsync(string agentId, CancellationToken ct = default)
+        {
+            _ = ct;
+            return Task.FromResult(_allowedActorIds.Contains(agentId));
+        }
+
         public Task<IReadOnlyList<UserAgentCatalogReadModelEntry>> QueryByCallerAsync(
             ScheduledOwnerScope caller,
             CancellationToken ct = default) =>

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentDeliveryTargetToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentDeliveryTargetToolTests.cs
@@ -32,7 +32,14 @@ public sealed class AgentDeliveryTargetToolTests
         properties.TryGetProperty("nyx_api_key", out _).Should().BeFalse();
         properties.TryGetProperty("api_key_id", out _).Should().BeFalse();
         properties.TryGetProperty("allowed_service_ids", out _).Should().BeFalse();
-        tool.Description.Should().Contain("scheduled_agent_creator");
+        document.RootElement.GetProperty("properties")
+            .GetProperty("action")
+            .GetProperty("enum")
+            .EnumerateArray()
+            .Select(static value => value.GetString())
+            .Should()
+            .Contain("create");
+        tool.Description.Should().Contain("without creating a scheduled runner");
         tool.Description.Should().NotContain("agent_builder tool's job");
     }
 
@@ -135,6 +142,226 @@ public sealed class AgentDeliveryTargetToolTests
             var result = await tool.ExecuteAsync("""{"action":"upsert"}""");
             result.Should().Contain("agent_id");
             result.Should().Contain("required");
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = null;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Create_MintsCredential_And_UpsertsCatalogAlias()
+    {
+        var caller = OwnerScope.ForNyxIdNative("user-1");
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.GetForCallerAsync("aelf-twitter-approval", Arg.Any<OwnerScope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<UserAgentCatalogReadModelEntry?>(null));
+
+        UserAgentCatalogUpsertCommand? captured = null;
+        var commandPort = Substitute.For<IUserAgentCatalogCommandPort>();
+        commandPort.UpsertAsync(Arg.Do<UserAgentCatalogUpsertCommand>(command => captured = command), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var issuer = new RecordingApiKeyIssuer();
+        var resolver = Substitute.For<ICallerScopeResolver>();
+        resolver.TryResolveAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<OwnerScope?>(caller));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(queryPort);
+        services.AddSingleton(commandPort);
+        services.AddSingleton(resolver);
+        services.AddSingleton<IScheduledAgentApiKeyIssuer>(issuer);
+        var tool = CreateTool(services);
+
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+        });
+        try
+        {
+            var result = await tool.ExecuteAsync("""
+                {
+                  "action": "create",
+                  "delivery_target_id": "aelf-twitter-approval",
+                  "platform": "lark",
+                  "conversation_id": "oc_9f1b8d3835674963417954fad20f8a3c",
+                  "nyx_provider_slug": "api-lark-bot-2"
+                }
+                """);
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("status").GetString().Should().Be("accepted");
+            doc.RootElement.GetProperty("delivery_target_id").GetString().Should().Be("aelf-twitter-approval");
+            doc.RootElement.GetProperty("api_key_id").GetString().Should().Be("key-aelf-twitter-approval");
+
+            result.Should().NotContain("nyx_api_key");
+            result.Should().NotContain("full_key");
+            result.Should().NotContain("secret-created-key");
+
+            issuer.Issues.Should().ContainSingle();
+            issuer.Issues[0].AgentId.Should().Be("aelf-twitter-approval");
+            issuer.Issues[0].ServiceSlugs.PrimaryOutboundSlug.Should().Be("api-lark-bot-2");
+            issuer.Issues[0].ServiceSlugs.RequiresOrnnService.Should().BeFalse();
+            issuer.Issues[0].SkillName.Should().BeEmpty();
+
+            captured.Should().NotBeNull();
+            captured!.AgentId.Should().Be("aelf-twitter-approval");
+            captured.ConversationId.Should().Be("oc_9f1b8d3835674963417954fad20f8a3c");
+            captured.NyxProviderSlug.Should().Be("api-lark-bot-2");
+            captured.NyxApiKey.Should().Be("secret-created-key");
+            captured.ApiKeyId.Should().Be("key-aelf-twitter-approval");
+            captured.AgentType.Should().Be("delivery_target");
+            captured.TemplateName.Should().Be("explicit_delivery_target");
+            captured.LarkReceiveId.Should().Be("oc_9f1b8d3835674963417954fad20f8a3c");
+            captured.LarkReceiveIdType.Should().Be("chat_id");
+            captured.OwnerScope.Should().NotBeNull();
+            captured.OwnerScope!.MatchesStrictly(caller).Should().BeTrue();
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = null;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Create_DoesNotRequireScheduledRunnerPort()
+    {
+        var caller = OwnerScope.ForNyxIdNative("user-1");
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.GetForCallerAsync("aelf-twitter-approval", Arg.Any<OwnerScope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<UserAgentCatalogReadModelEntry?>(null));
+
+        var commandPort = Substitute.For<IUserAgentCatalogCommandPort>();
+        commandPort.UpsertAsync(Arg.Any<UserAgentCatalogUpsertCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var resolver = Substitute.For<ICallerScopeResolver>();
+        resolver.TryResolveAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<OwnerScope?>(caller));
+
+        var tool = new AgentDeliveryTargetTool(
+            queryPort,
+            commandPort,
+            resolver,
+            new RecordingApiKeyIssuer());
+
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+        });
+        try
+        {
+            var result = await tool.ExecuteAsync("""
+                {
+                  "action": "create",
+                  "delivery_target_id": "aelf-twitter-approval",
+                  "platform": "lark",
+                  "conversation_id": "oc_chat_1",
+                  "nyx_provider_slug": "api-lark-bot"
+                }
+                """);
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("status").GetString().Should().Be("accepted");
+            await commandPort.Received(1).UpsertAsync(Arg.Any<UserAgentCatalogUpsertCommand>(), Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = null;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Create_RollsBackCredential_WhenCatalogDispatchFails()
+    {
+        var caller = OwnerScope.ForNyxIdNative("user-1");
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.GetForCallerAsync("aelf-twitter-approval", Arg.Any<OwnerScope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<UserAgentCatalogReadModelEntry?>(null));
+
+        var commandPort = Substitute.For<IUserAgentCatalogCommandPort>();
+        commandPort.UpsertAsync(Arg.Any<UserAgentCatalogUpsertCommand>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("dispatch failed"));
+
+        var issuer = new RecordingApiKeyIssuer();
+        var resolver = Substitute.For<ICallerScopeResolver>();
+        resolver.TryResolveAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<OwnerScope?>(caller));
+
+        var tool = new AgentDeliveryTargetTool(queryPort, commandPort, resolver, issuer);
+
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+        });
+        try
+        {
+            var act = () => tool.ExecuteAsync("""
+                {
+                  "action": "create",
+                  "delivery_target_id": "aelf-twitter-approval",
+                  "platform": "lark",
+                  "conversation_id": "oc_chat_1",
+                  "nyx_provider_slug": "api-lark-bot"
+                }
+                """);
+
+            await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("dispatch failed");
+            issuer.RevokedApiKeyIds.Should().ContainSingle().Which.Should().Be("key-aelf-twitter-approval");
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = null;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_List_Shows_Created_DeliveryTarget_FromProjection()
+    {
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.QueryByCallerAsync(Arg.Any<OwnerScope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<UserAgentCatalogReadModelEntry>>(
+                [
+                new UserAgentCatalogReadModelEntry
+                {
+                    AgentId = "aelf-twitter-approval",
+                    ConversationId = "oc_9f1b8d3835674963417954fad20f8a3c",
+                    NyxProviderSlug = "api-lark-bot-2",
+                    LarkReceiveId = "oc_9f1b8d3835674963417954fad20f8a3c",
+                    LarkReceiveIdType = "chat_id",
+                    OwnerScope = OwnerScope.ForNyxIdNative("user-1"),
+                    AgentType = "delivery_target",
+                },
+            ]));
+
+        var resolver = Substitute.For<ICallerScopeResolver>();
+        resolver.TryResolveAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(queryPort);
+        services.AddSingleton(Substitute.For<IUserAgentCatalogCommandPort>());
+        services.AddSingleton(resolver);
+        var tool = CreateTool(services);
+
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+        });
+        try
+        {
+            var result = await tool.ExecuteAsync("""{"action":"list"}""");
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("total").GetInt32().Should().Be(1);
+            var target = doc.RootElement.GetProperty("delivery_targets")[0];
+            target.GetProperty("delivery_target_id").GetString().Should().Be("aelf-twitter-approval");
+            target.GetProperty("platform").GetString().Should().Be("lark");
+            target.GetProperty("conversation_id").GetString().Should().Be("oc_9f1b8d3835674963417954fad20f8a3c");
+            target.GetProperty("nyx_provider_slug").GetString().Should().Be("api-lark-bot-2");
+            result.Should().NotContain("secret");
+            result.Should().NotContain("nyx_api_key");
         }
         finally
         {
@@ -728,7 +955,8 @@ public sealed class AgentDeliveryTargetToolTests
         return new AgentDeliveryTargetTool(
             provider.GetRequiredService<IUserAgentCatalogQueryPort>(),
             provider.GetService<IUserAgentCatalogCommandPort>() ?? Substitute.For<IUserAgentCatalogCommandPort>(),
-            provider.GetRequiredService<ICallerScopeResolver>());
+            provider.GetRequiredService<ICallerScopeResolver>(),
+            provider.GetService<IScheduledAgentApiKeyIssuer>());
     }
 
     private static IServiceCollection CreateDefaultServices()
@@ -757,4 +985,35 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(resolver);
         return (CreateTool(services), queryPort, commandPort);
     }
+
+    private sealed class RecordingApiKeyIssuer : IScheduledAgentApiKeyIssuer
+    {
+        public List<IssueCall> Issues { get; } = [];
+        public List<string> RevokedApiKeyIds { get; } = [];
+
+        public Task<ScheduledAgentApiKeyIssueResult> IssueAsync(
+            string token,
+            ScheduledAgentServiceSlugs serviceSlugs,
+            string agentId,
+            string skillName,
+            string? scopeId,
+            CancellationToken ct)
+        {
+            Issues.Add(new IssueCall(token, serviceSlugs, agentId, skillName, scopeId));
+            return Task.FromResult(ScheduledAgentApiKeyIssueResult.Succeeded($"key-{agentId}", "secret-created-key"));
+        }
+
+        public Task TryRevokeAsync(string token, string apiKeyId, CancellationToken ct)
+        {
+            RevokedApiKeyIds.Add(apiKeyId);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record IssueCall(
+        string Token,
+        ScheduledAgentServiceSlugs ServiceSlugs,
+        string AgentId,
+        string SkillName,
+        string? ScopeId);
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentDeliveryTargetToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentDeliveryTargetToolTests.cs
@@ -152,7 +152,7 @@ public sealed class AgentDeliveryTargetToolTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_Create_MintsCredential_And_UpsertsCatalogAlias()
+    public async Task ExecuteAsync_Create_MintsCredential_And_UpsertsCatalog()
     {
         var caller = OwnerScope.ForNyxIdNative("user-1");
         var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
@@ -272,6 +272,50 @@ public sealed class AgentDeliveryTargetToolTests
             captured.NyxProviderSlug.Should().Be("api-email-outbound");
             captured.LarkReceiveId.Should().BeEmpty();
             captured.LarkReceiveIdType.Should().BeEmpty();
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = null;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Create_Rejects_Global_DeliveryTargetId_Collision_BeforeMintingCredential()
+    {
+        var caller = OwnerScope.ForNyxIdNative("user-2");
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.ExistsActiveAsync("approvals", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(true));
+
+        var commandPort = Substitute.For<IUserAgentCatalogCommandPort>();
+        var issuer = new RecordingApiKeyIssuer();
+        var resolver = Substitute.For<ICallerScopeResolver>();
+        resolver.TryResolveAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<OwnerScope?>(caller));
+
+        var tool = new AgentDeliveryTargetTool(queryPort, commandPort, resolver, issuer);
+
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+        });
+        try
+        {
+            var result = await tool.ExecuteAsync("""
+                {
+                  "action": "create",
+                  "delivery_target_id": "approvals",
+                  "platform": "email",
+                  "conversation_id": "approvals@example.com",
+                  "nyx_provider_slug": "api-email-outbound"
+                }
+                """);
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("error").GetString().Should().Be("delivery_target_already_exists");
+            doc.RootElement.GetProperty("delivery_target_id").GetString().Should().Be("approvals");
+            issuer.Issues.Should().BeEmpty();
+            await commandPort.DidNotReceive().UpsertAsync(Arg.Any<UserAgentCatalogUpsertCommand>(), Arg.Any<CancellationToken>());
         }
         finally
         {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentDeliveryTargetToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentDeliveryTargetToolTests.cs
@@ -40,6 +40,8 @@ public sealed class AgentDeliveryTargetToolTests
             .Should()
             .Contain("create");
         tool.Description.Should().Contain("without creating a scheduled runner");
+        tool.Description.Should().Contain("different platform conversation");
+        tool.Description.Should().NotContain("different Lark conversation");
         tool.Description.Should().NotContain("agent_builder tool's job");
     }
 
@@ -213,10 +215,63 @@ public sealed class AgentDeliveryTargetToolTests
             captured.ApiKeyId.Should().Be("key-aelf-twitter-approval");
             captured.AgentType.Should().Be("delivery_target");
             captured.TemplateName.Should().Be("explicit_delivery_target");
-            captured.LarkReceiveId.Should().Be("oc_9f1b8d3835674963417954fad20f8a3c");
-            captured.LarkReceiveIdType.Should().Be("chat_id");
+            captured.TargetPlatform.Should().Be("lark");
+            captured.LarkReceiveId.Should().BeEmpty();
+            captured.LarkReceiveIdType.Should().BeEmpty();
             captured.OwnerScope.Should().NotBeNull();
             captured.OwnerScope!.MatchesStrictly(caller).Should().BeTrue();
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = null;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Create_Accepts_NonLark_TargetPlatform_WithoutLarkFields()
+    {
+        var caller = OwnerScope.ForNyxIdNative("user-1");
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.GetForCallerAsync("email-approval", Arg.Any<OwnerScope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<UserAgentCatalogReadModelEntry?>(null));
+
+        UserAgentCatalogUpsertCommand? captured = null;
+        var commandPort = Substitute.For<IUserAgentCatalogCommandPort>();
+        commandPort.UpsertAsync(Arg.Do<UserAgentCatalogUpsertCommand>(command => captured = command), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var resolver = Substitute.For<ICallerScopeResolver>();
+        resolver.TryResolveAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<OwnerScope?>(caller));
+
+        var tool = new AgentDeliveryTargetTool(queryPort, commandPort, resolver, new RecordingApiKeyIssuer());
+
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+        });
+        try
+        {
+            var result = await tool.ExecuteAsync("""
+                {
+                  "action": "create",
+                  "delivery_target_id": "email-approval",
+                  "platform": "email",
+                  "conversation_id": "approvals@example.com",
+                  "nyx_provider_slug": "api-email-outbound"
+                }
+                """);
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("status").GetString().Should().Be("accepted");
+            doc.RootElement.GetProperty("platform").GetString().Should().Be("email");
+
+            captured.Should().NotBeNull();
+            captured!.TargetPlatform.Should().Be("email");
+            captured.ConversationId.Should().Be("approvals@example.com");
+            captured.NyxProviderSlug.Should().Be("api-email-outbound");
+            captured.LarkReceiveId.Should().BeEmpty();
+            captured.LarkReceiveIdType.Should().BeEmpty();
         }
         finally
         {
@@ -330,6 +385,7 @@ public sealed class AgentDeliveryTargetToolTests
                     NyxProviderSlug = "api-lark-bot-2",
                     LarkReceiveId = "oc_9f1b8d3835674963417954fad20f8a3c",
                     LarkReceiveIdType = "chat_id",
+                    TargetPlatform = "lark",
                     OwnerScope = OwnerScope.ForNyxIdNative("user-1"),
                     AgentType = "delivery_target",
                 },
@@ -362,6 +418,53 @@ public sealed class AgentDeliveryTargetToolTests
             target.GetProperty("nyx_provider_slug").GetString().Should().Be("api-lark-bot-2");
             result.Should().NotContain("secret");
             result.Should().NotContain("nyx_api_key");
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = null;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_List_Uses_TargetPlatform_As_DeliveryPlatform()
+    {
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.QueryByCallerAsync(Arg.Any<OwnerScope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<UserAgentCatalogReadModelEntry>>(
+                [
+                new UserAgentCatalogReadModelEntry
+                {
+                    AgentId = "email-approval",
+                    ConversationId = "approvals@example.com",
+                    NyxProviderSlug = "api-email-outbound",
+                    TargetPlatform = "email",
+                    OwnerScope = OwnerScope.ForNyxIdNative("user-1"),
+                    AgentType = "delivery_target",
+                },
+            ]));
+
+        var resolver = Substitute.For<ICallerScopeResolver>();
+        resolver.TryResolveAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(queryPort);
+        services.AddSingleton(Substitute.For<IUserAgentCatalogCommandPort>());
+        services.AddSingleton(resolver);
+        var tool = CreateTool(services);
+
+        AgentToolRequestContext.Current = global::TestAgentToolContexts.FromMetadata(new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+        });
+        try
+        {
+            var result = await tool.ExecuteAsync("""{"action":"list"}""");
+
+            using var doc = JsonDocument.Parse(result);
+            var target = doc.RootElement.GetProperty("delivery_targets")[0];
+            target.GetProperty("delivery_target_id").GetString().Should().Be("email-approval");
+            target.GetProperty("platform").GetString().Should().Be("email");
         }
         finally
         {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentCatalogGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentCatalogGAgentTests.cs
@@ -87,6 +87,31 @@ public sealed class UserAgentCatalogGAgentTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task HandleUpsertAsync_RejectsCrossOwnerOverwrite()
+    {
+        var firstOwner = OwnerScope.ForNyxIdNative("user-1");
+        var secondOwner = OwnerScope.ForNyxIdNative("user-2");
+        await _agent.HandleUpsertAsync(new UserAgentCatalogUpsertCommand
+        {
+            AgentId = "approvals",
+            ConversationId = "first-conversation",
+            OwnerScope = firstOwner,
+        });
+
+        await _agent.HandleUpsertAsync(new UserAgentCatalogUpsertCommand
+        {
+            AgentId = "approvals",
+            ConversationId = "second-conversation",
+            OwnerScope = secondOwner,
+        });
+
+        _agent.State.Entries.Should().ContainSingle();
+        var entry = _agent.State.Entries[0];
+        entry.ConversationId.Should().Be("first-conversation");
+        entry.OwnerScope!.MatchesStrictly(firstOwner).Should().BeTrue();
+    }
+
+    [Fact]
     public async Task HandleUpsertAsync_WithoutOwnerScope_PersistsLegacyOwnershipFields()
     {
         await _agent.HandleUpsertAsync(new UserAgentCatalogUpsertCommand

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentDeliveryTargetReaderTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentDeliveryTargetReaderTests.cs
@@ -1,4 +1,5 @@
 using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.Scheduled;
 using FluentAssertions;
 using NSubstitute;
@@ -37,6 +38,46 @@ public sealed class UserAgentDeliveryTargetReaderTests
         target!.NyxApiKey.Should().Be("live-key");
         target.ConversationId.Should().Be("oc_chat_1");
         target.OutputFormat.Should().Be(SkillRunnerOutputFormat.Text);
+    }
+
+    [Fact]
+    public async Task GetAsync_ResolvesExplicitDeliveryTargetAlias_ForWorkflowDelivery()
+    {
+        var documentReader = Substitute.For<IProjectionDocumentReader<UserAgentCatalogDocument, string>>();
+        var credentialReader = Substitute.For<IProjectionDocumentReader<UserAgentCatalogNyxCredentialDocument, string>>();
+
+        documentReader.GetAsync("aelf-twitter-approval", Arg.Any<CancellationToken>())
+            .Returns(new UserAgentCatalogDocument
+            {
+                Id = "aelf-twitter-approval",
+                ConversationId = "oc_9f1b8d3835674963417954fad20f8a3c",
+                NyxProviderSlug = "api-lark-bot-2",
+                LarkReceiveId = "oc_9f1b8d3835674963417954fad20f8a3c",
+                LarkReceiveIdType = "chat_id",
+                AgentType = "delivery_target",
+                TemplateName = "explicit_delivery_target",
+                OwnerScope = OwnerScope.ForNyxIdNative("user-1"),
+            });
+        credentialReader.GetAsync("aelf-twitter-approval", Arg.Any<CancellationToken>())
+            .Returns(new UserAgentCatalogNyxCredentialDocument
+            {
+                Id = "aelf-twitter-approval",
+                NyxApiKey = "secret-created-key",
+            });
+
+        var reader = new UserAgentDeliveryTargetReader(documentReader, credentialReader);
+
+        var target = await reader.GetAsync("aelf-twitter-approval", CancellationToken.None);
+
+        target.Should().NotBeNull();
+        target!.AgentId.Should().Be("aelf-twitter-approval");
+        target.Platform.Should().Be("lark");
+        target.ConversationId.Should().Be("oc_9f1b8d3835674963417954fad20f8a3c");
+        target.NyxProviderSlug.Should().Be("api-lark-bot-2");
+        target.NyxApiKey.Should().Be("secret-created-key");
+        target.LarkReceiveId.Should().Be("oc_9f1b8d3835674963417954fad20f8a3c");
+        target.LarkReceiveIdType.Should().Be("chat_id");
+        target.AgentType.Should().Be("delivery_target");
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentDeliveryTargetReaderTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentDeliveryTargetReaderTests.cs
@@ -54,6 +54,7 @@ public sealed class UserAgentDeliveryTargetReaderTests
                 NyxProviderSlug = "api-lark-bot-2",
                 LarkReceiveId = "oc_9f1b8d3835674963417954fad20f8a3c",
                 LarkReceiveIdType = "chat_id",
+                TargetPlatform = "lark",
                 AgentType = "delivery_target",
                 TemplateName = "explicit_delivery_target",
                 OwnerScope = OwnerScope.ForNyxIdNative("user-1"),
@@ -78,6 +79,41 @@ public sealed class UserAgentDeliveryTargetReaderTests
         target.LarkReceiveId.Should().Be("oc_9f1b8d3835674963417954fad20f8a3c");
         target.LarkReceiveIdType.Should().Be("chat_id");
         target.AgentType.Should().Be("delivery_target");
+    }
+
+    [Fact]
+    public async Task GetAsync_UsesTargetPlatform_When_NotLark()
+    {
+        var documentReader = Substitute.For<IProjectionDocumentReader<UserAgentCatalogDocument, string>>();
+        var credentialReader = Substitute.For<IProjectionDocumentReader<UserAgentCatalogNyxCredentialDocument, string>>();
+
+        documentReader.GetAsync("email-approval", Arg.Any<CancellationToken>())
+            .Returns(new UserAgentCatalogDocument
+            {
+                Id = "email-approval",
+                TargetPlatform = "email",
+                ConversationId = "approvals@example.com",
+                NyxProviderSlug = "api-email-outbound",
+                AgentType = "delivery_target",
+                TemplateName = "explicit_delivery_target",
+                OwnerScope = OwnerScope.ForNyxIdNative("user-1"),
+            });
+        credentialReader.GetAsync("email-approval", Arg.Any<CancellationToken>())
+            .Returns(new UserAgentCatalogNyxCredentialDocument
+            {
+                Id = "email-approval",
+                NyxApiKey = "secret-created-key",
+            });
+
+        var reader = new UserAgentDeliveryTargetReader(documentReader, credentialReader);
+
+        var target = await reader.GetAsync("email-approval", CancellationToken.None);
+
+        target.Should().NotBeNull();
+        target!.Platform.Should().Be("email");
+        target.ConversationId.Should().Be("approvals@example.com");
+        target.LarkReceiveId.Should().BeEmpty();
+        target.LarkReceiveIdType.Should().BeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add `agent_delivery_targets` `action: create` so workflows can create stable delivery target aliases without creating scheduled skill runners.
- Reuse the existing scheduled-agent NyxID credential issuer flow and persist targets through `UserAgentCatalog` while keeping full API keys server-side.
- Teach list/runtime delivery resolution to infer Lark delivery targets from typed Lark fields/provider slug when legacy platform is empty.

Closes aevatarAI/aevatar#2229

## Test plan
- [x] `dotnet restore test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo`
- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --no-restore --filter "FullyQualifiedName~AgentDeliveryTargetToolTests|FullyQualifiedName~UserAgentDeliveryTargetReaderTests" --nologo` — 30 passed, 0 failed, 0 skipped
- [x] `git diff --check`
- [x] `dotnet build src/Aevatar.AI.ToolProviders.AgentCatalog/Aevatar.AI.ToolProviders.AgentCatalog.csproj --no-restore --nologo` — succeeded with existing warnings
- [ ] `bash tools/ci/test_stability_guards.sh` — failed on pre-existing unrelated coverage-file budget: `test/Aevatar.AI.Tests/RoleGAgentStateCoverageTests.cs:1800` exceeds frozen budget `1769`; this PR does not touch that file

🤖 Generated with [Claude Code](https://claude.com/claude-code)