### PR TITLE
fix(studio): store workspace state as opaque JSON

### DIFF
--- a/src/Aevatar.Studio.Projection/Metadata/StudioWorkspaceCurrentStateDocumentMetadataProvider.cs
+++ b/src/Aevatar.Studio.Projection/Metadata/StudioWorkspaceCurrentStateDocumentMetadataProvider.cs
@@ -29,6 +29,22 @@ public sealed class StudioWorkspaceCurrentStateDocumentMetadataProvider
                     ["type"] = "text",
                     ["index"] = false,
                 },
+                ["draft_summaries"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["type"] = "nested",
+                    ["dynamic"] = false,
+                    ["properties"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                    {
+                        ["workflow_id"] = Keyword(),
+                        ["name"] = Keyword(),
+                        ["file_name"] = Keyword(),
+                        ["directory_id"] = Keyword(),
+                        ["version"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                        {
+                            ["type"] = "long",
+                        },
+                    },
+                },
             },
         },
         Settings: new Dictionary<string, object?>(StringComparer.Ordinal),

--- a/src/Aevatar.Studio.Projection/Metadata/StudioWorkspaceCurrentStateDocumentMetadataProvider.cs
+++ b/src/Aevatar.Studio.Projection/Metadata/StudioWorkspaceCurrentStateDocumentMetadataProvider.cs
@@ -10,8 +10,32 @@ public sealed class StudioWorkspaceCurrentStateDocumentMetadataProvider
         IndexName: "studio-workspaces",
         Mappings: new Dictionary<string, object?>(StringComparer.Ordinal)
         {
-            ["dynamic"] = true,
+            ["dynamic"] = false,
+            ["properties"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["id"] = Keyword(),
+                ["actor_id"] = Keyword(),
+                ["state_version"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["type"] = "long",
+                },
+                ["last_event_id"] = Keyword(),
+                ["updated_at"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["type"] = "date",
+                },
+                ["state_root_json"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["type"] = "text",
+                    ["index"] = false,
+                },
+            },
         },
         Settings: new Dictionary<string, object?>(StringComparer.Ordinal),
         Aliases: new Dictionary<string, object?>(StringComparer.Ordinal));
+
+    private static Dictionary<string, object?> Keyword() => new(StringComparer.Ordinal)
+    {
+        ["type"] = "keyword",
+    };
 }

--- a/src/Aevatar.Studio.Projection/Projectors/StudioWorkspaceCurrentStateProjector.cs
+++ b/src/Aevatar.Studio.Projection/Projectors/StudioWorkspaceCurrentStateProjector.cs
@@ -52,7 +52,7 @@ public sealed class StudioWorkspaceCurrentStateProjector
         }
 
         var updatedAt = CommittedStateEventEnvelope.ResolveTimestamp(envelope, _clock.UtcNow);
-        await _writeDispatcher.UpsertAsync(new StudioWorkspaceCurrentStateDocument
+        var document = new StudioWorkspaceCurrentStateDocument
         {
             Id = context.RootActorId,
             ActorId = context.RootActorId,
@@ -60,6 +60,18 @@ public sealed class StudioWorkspaceCurrentStateProjector
             LastEventId = stateEvent.EventId ?? string.Empty,
             UpdatedAt = Timestamp.FromDateTimeOffset(updatedAt),
             StateRootJson = StateRootFormatter.Format(state),
-        }, ct);
+        };
+        document.DraftSummaries.AddRange(state.Drafts.Values.Select(ToDraftSummary));
+
+        await _writeDispatcher.UpsertAsync(document, ct);
     }
+
+    private static StudioWorkspaceDraftSummary ToDraftSummary(StudioWorkflowDraft draft) => new()
+    {
+        WorkflowId = draft.WorkflowId,
+        Name = draft.Name,
+        FileName = draft.FileName,
+        DirectoryId = draft.DirectoryId,
+        Version = draft.Version,
+    };
 }

--- a/src/Aevatar.Studio.Projection/Projectors/StudioWorkspaceCurrentStateProjector.cs
+++ b/src/Aevatar.Studio.Projection/Projectors/StudioWorkspaceCurrentStateProjector.cs
@@ -5,6 +5,7 @@ using Aevatar.Foundation.Abstractions;
 using Aevatar.Studio.Workspace;
 using Aevatar.Studio.Projection.Orchestration;
 using Aevatar.Studio.Projection.ReadModels;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.Studio.Projection.Projectors;
@@ -15,6 +16,11 @@ namespace Aevatar.Studio.Projection.Projectors;
 public sealed class StudioWorkspaceCurrentStateProjector
     : ICurrentStateProjectionMaterializer<StudioMaterializationContext>
 {
+    private static readonly JsonFormatter StateRootFormatter = new(
+        JsonFormatter.Settings.Default
+            .WithPreserveProtoFieldNames(true)
+            .WithFormatDefaultValues(true));
+
     private readonly IProjectionWriteDispatcher<StudioWorkspaceCurrentStateDocument> _writeDispatcher;
     private readonly IProjectionClock _clock;
 
@@ -53,7 +59,7 @@ public sealed class StudioWorkspaceCurrentStateProjector
             StateVersion = stateEvent.Version,
             LastEventId = stateEvent.EventId ?? string.Empty,
             UpdatedAt = Timestamp.FromDateTimeOffset(updatedAt),
-            StateRoot = Any.Pack(state),
+            StateRootJson = StateRootFormatter.Format(state),
         }, ct);
     }
 }

--- a/src/Aevatar.Studio.Projection/QueryPorts/ProjectionStudioWorkspaceQueryPort.cs
+++ b/src/Aevatar.Studio.Projection/QueryPorts/ProjectionStudioWorkspaceQueryPort.cs
@@ -3,6 +3,7 @@ using Aevatar.Studio.Workspace;
 using Aevatar.Studio.Application.Studio;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Projection.ReadModels;
+using Google.Protobuf;
 
 namespace Aevatar.Studio.Projection.QueryPorts;
 
@@ -11,6 +12,9 @@ namespace Aevatar.Studio.Projection.QueryPorts;
 //   New principle: Studio executions are a bounded ServiceRunGAgent readmodel facade; UI/layout/draft index are deleted/downgraded to client cache or derived from existing actor-backed sources. No new history/draft index actor.
 public sealed class ProjectionStudioWorkspaceQueryPort : IStudioWorkspaceQueryPort
 {
+    private static readonly JsonParser StateRootParser = new(
+        JsonParser.Settings.Default.WithIgnoreUnknownFields(true));
+
     private readonly IProjectionDocumentReader<StudioWorkspaceCurrentStateDocument, string> _documentReader;
     private readonly IAppScopeResolver _scopeResolver;
 
@@ -36,9 +40,8 @@ public sealed class ProjectionStudioWorkspaceQueryPort : IStudioWorkspaceQueryPo
         var normalizedScopeId = StudioWorkspaceConventions.NormalizeScopeId(scopeId);
         var actorId = StudioWorkspaceConventions.BuildActorId(normalizedScopeId);
         var document = await _documentReader.GetAsync(actorId, ct);
-        var state = document?.StateRoot?.Is(StudioWorkspaceState.Descriptor) == true
-            ? document.StateRoot.Unpack<StudioWorkspaceState>()
-            : new StudioWorkspaceState
+        var state = TryParseStateRoot(document?.StateRootJson) ??
+                    new StudioWorkspaceState
             {
                 WorkspaceId = actorId,
                 ScopeId = normalizedScopeId,
@@ -106,5 +109,24 @@ public sealed class ProjectionStudioWorkspaceQueryPort : IStudioWorkspaceQueryPo
             draft.UpdatedAtUtc?.ToDateTimeOffset() ?? DateTimeOffset.MinValue,
             draft.CreatedAtUtc?.ToDateTimeOffset() ?? DateTimeOffset.MinValue,
             draft.Version);
+    }
+
+    private static StudioWorkspaceState? TryParseStateRoot(string? stateRootJson)
+    {
+        if (string.IsNullOrWhiteSpace(stateRootJson))
+            return null;
+
+        try
+        {
+            return StateRootParser.Parse<StudioWorkspaceState>(stateRootJson);
+        }
+        catch (InvalidProtocolBufferException)
+        {
+            return null;
+        }
+        catch (InvalidJsonException)
+        {
+            return null;
+        }
     }
 }

--- a/src/Aevatar.Studio.Projection/ReadModels/studio_projection_readmodels.proto
+++ b/src/Aevatar.Studio.Projection/ReadModels/studio_projection_readmodels.proto
@@ -225,6 +225,14 @@ message StudioTeamCurrentStateDocument {
 // connector/role catalogs, service-run execution state, workflow runtime state,
 // provider secrets, memory, and registry facts.
 
+message StudioWorkspaceDraftSummary {
+  string workflow_id = 1;
+  string name = 2;
+  string file_name = 3;
+  string directory_id = 4;
+  int64 version = 5;
+}
+
 message StudioWorkspaceCurrentStateDocument {
   string id = 1;
   string actor_id = 2;
@@ -237,4 +245,8 @@ message StudioWorkspaceCurrentStateDocument {
   // Opaque protobuf JSON for StudioWorkspaceState. Stored as a scalar readmodel
   // field so Elasticsearch never dynamically maps draft YAML/step/config trees.
   string state_root_json = 11;
+
+  // Stable draft query surface. Complex draft payloads such as YAML remain only
+  // in state_root_json and are not indexed as dynamic Elasticsearch fields.
+  repeated StudioWorkspaceDraftSummary draft_summaries = 12;
 }

--- a/src/Aevatar.Studio.Projection/ReadModels/studio_projection_readmodels.proto
+++ b/src/Aevatar.Studio.Projection/ReadModels/studio_projection_readmodels.proto
@@ -231,5 +231,10 @@ message StudioWorkspaceCurrentStateDocument {
   int64 state_version = 3;
   string last_event_id = 4;
   google.protobuf.Timestamp updated_at = 5;
-  google.protobuf.Any state_root = 10;
+  reserved 10;
+  reserved "state_root";
+
+  // Opaque protobuf JSON for StudioWorkspaceState. Stored as a scalar readmodel
+  // field so Elasticsearch never dynamically maps draft YAML/step/config trees.
+  string state_root_json = 11;
 }

--- a/test/Aevatar.Studio.Tests/ProjectionStudioWorkspaceQueryPortTests.cs
+++ b/test/Aevatar.Studio.Tests/ProjectionStudioWorkspaceQueryPortTests.cs
@@ -5,6 +5,7 @@ using Aevatar.Studio.Projection.QueryPorts;
 using Aevatar.Studio.Projection.ReadModels;
 using Aevatar.Studio.Workspace;
 using FluentAssertions;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Http;
 using ProtoWorkspaceDirectory = Aevatar.Studio.Workspace.StudioWorkspaceDirectory;
@@ -14,8 +15,13 @@ namespace Aevatar.Studio.Tests;
 
 public sealed class ProjectionStudioWorkspaceQueryPortTests
 {
+    private static readonly JsonFormatter StateRootFormatter = new(
+        JsonFormatter.Settings.Default
+            .WithPreserveProtoFieldNames(true)
+            .WithFormatDefaultValues(true));
+
     [Fact]
-    public async Task GetAsync_ShouldMapPackedWorkspaceState()
+    public async Task GetAsync_ShouldMapOpaqueWorkspaceStateJson()
     {
         var scopeResolver = new StubScopeResolver { ScopeId = "scope-1" };
         var actorId = StudioWorkspaceConventions.BuildActorId("scope-1");
@@ -57,7 +63,7 @@ public sealed class ProjectionStudioWorkspaceQueryPortTests
             StateVersion = 17,
             LastEventId = "evt-17",
             UpdatedAt = Timestamp.FromDateTimeOffset(updatedAt),
-            StateRoot = Any.Pack(state),
+            StateRootJson = StateRootFormatter.Format(state),
         });
         var port = new ProjectionStudioWorkspaceQueryPort(reader, scopeResolver);
 
@@ -116,7 +122,7 @@ public sealed class ProjectionStudioWorkspaceQueryPortTests
     }
 
     [Fact]
-    public async Task GetAsync_WhenStateRootIsUnexpectedType_ShouldUseScopedEmptyStateButKeepDocumentWatermark()
+    public async Task GetAsync_WhenStateRootJsonIsInvalid_ShouldUseScopedEmptyStateButKeepDocumentWatermark()
     {
         var scopeResolver = new StubScopeResolver { ScopeId = "scope-2" };
         var actorId = StudioWorkspaceConventions.BuildActorId("scope-2");
@@ -129,7 +135,7 @@ public sealed class ProjectionStudioWorkspaceQueryPortTests
             StateVersion = 23,
             LastEventId = "evt-23",
             UpdatedAt = Timestamp.FromDateTimeOffset(updatedAt),
-            StateRoot = Any.Pack(new StringValue { Value = "not-a-workspace-state" }),
+            StateRootJson = "{not-json",
         });
         var port = new ProjectionStudioWorkspaceQueryPort(reader, scopeResolver);
 

--- a/test/Aevatar.Studio.Tests/StudioWorkspaceCurrentStateProjectorTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioWorkspaceCurrentStateProjectorTests.cs
@@ -112,16 +112,33 @@ public sealed class StudioWorkspaceCurrentStateProjectorTests
 
         var written = dispatcher.Upserts.Should().ContainSingle().Subject;
         written.StateRootJson.Should().Contain("\"drafts\"");
+        written.StateRootJson.Should().Contain("nested");
+        written.DraftSummaries.Should().ContainSingle().Which.Should().BeEquivalentTo(new StudioWorkspaceDraftSummary
+        {
+            WorkflowId = "wf-alpha",
+            Name = "workflow alpha",
+            FileName = "workflow-alpha.yaml",
+            DirectoryId = "dir-1",
+            Version = 4,
+        });
         StudioWorkspaceCurrentStateDocument.Descriptor.Fields.InDeclarationOrder()
             .Select(field => field.Name)
             .Should().NotContain("state_root");
         StudioWorkspaceCurrentStateDocument.Descriptor.Fields.InDeclarationOrder()
             .Single(field => field.Name == "state_root_json")
             .FieldType.Should().Be(FieldType.String);
+        StudioWorkspaceCurrentStateDocument.Descriptor.Fields.InDeclarationOrder()
+            .Single(field => field.Name == "draft_summaries")
+            .MessageType.Should().Be(StudioWorkspaceDraftSummary.Descriptor);
 
         using var serialized = JsonDocument.Parse(ReadModelFormatter.Format(written));
         serialized.RootElement.TryGetProperty("state_root_json", out var stateRootJsonElement).Should().BeTrue();
         stateRootJsonElement.ValueKind.Should().Be(JsonValueKind.String);
+        serialized.RootElement.TryGetProperty("draft_summaries", out var draftSummariesElement).Should().BeTrue();
+        draftSummariesElement.ValueKind.Should().Be(JsonValueKind.Array);
+        draftSummariesElement[0].TryGetProperty("workflow_id", out _).Should().BeTrue();
+        draftSummariesElement[0].TryGetProperty("name", out _).Should().BeTrue();
+        draftSummariesElement[0].TryGetProperty("yaml", out _).Should().BeFalse();
         serialized.RootElement.TryGetProperty("state_root", out _).Should().BeFalse();
     }
 
@@ -146,6 +163,17 @@ public sealed class StudioWorkspaceCurrentStateProjectorTests
             .Subject;
         stateRootJsonMapping["type"].Should().Be("text");
         stateRootJsonMapping["index"].Should().Be(false);
+
+        var draftSummariesMapping = properties["draft_summaries"].Should()
+            .BeAssignableTo<IReadOnlyDictionary<string, object?>>()
+            .Subject;
+        draftSummariesMapping["type"].Should().Be("nested");
+        draftSummariesMapping["dynamic"].Should().Be(false);
+        var draftSummaryProperties = draftSummariesMapping["properties"].Should()
+            .BeAssignableTo<IReadOnlyDictionary<string, object?>>()
+            .Subject;
+        draftSummaryProperties.Should().ContainKeys("workflow_id", "name", "file_name", "directory_id", "version");
+        draftSummaryProperties.Should().NotContainKey("yaml");
     }
 
     [Fact]

--- a/test/Aevatar.Studio.Tests/StudioWorkspaceCurrentStateProjectorTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioWorkspaceCurrentStateProjectorTests.cs
@@ -2,19 +2,27 @@ using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.CQRS.Projection.Runtime.Abstractions;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Studio.Projection.Metadata;
 using Aevatar.Studio.Projection.Orchestration;
 using Aevatar.Studio.Projection.Projectors;
 using Aevatar.Studio.Projection.ReadModels;
 using Aevatar.Studio.Workspace;
 using FluentAssertions;
 using Google.Protobuf;
+using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
+using System.Text.Json;
 
 namespace Aevatar.Studio.Tests;
 
 public sealed class StudioWorkspaceCurrentStateProjectorTests
 {
     private const string RootActorId = "studio-workspace-scope-1";
+    private static readonly JsonFormatter ReadModelFormatter = new(
+        JsonFormatter.Settings.Default
+            .WithPreserveProtoFieldNames(true)
+            .WithFormatDefaultValues(true));
+    private static readonly JsonParser StateRootParser = new(JsonParser.Settings.Default.WithIgnoreUnknownFields(true));
 
     [Fact]
     public async Task ProjectAsync_ShouldUpsertDocument_WhenCommittedWorkspaceStateArrives()
@@ -53,8 +61,91 @@ public sealed class StudioWorkspaceCurrentStateProjectorTests
         written.StateVersion.Should().Be(7);
         written.LastEventId.Should().Be("evt-7");
         written.UpdatedAt.Should().NotBeNull();
-        written.StateRoot.Is(StudioWorkspaceState.Descriptor).Should().BeTrue();
-        written.StateRoot.Unpack<StudioWorkspaceState>().Settings.RuntimeBaseUrl.Should().Be("http://127.0.0.1:5100");
+        var parsedState = StateRootParser.Parse<StudioWorkspaceState>(written.StateRootJson);
+        parsedState.Settings.RuntimeBaseUrl.Should().Be("http://127.0.0.1:5100");
+    }
+
+    [Fact]
+    public async Task ProjectAsync_ShouldStoreWorkspaceStateAsOpaqueJsonString_ForElasticsearch()
+    {
+        var dispatcher = new RecordingWriteDispatcher();
+        var projector = new StudioWorkspaceCurrentStateProjector(
+            dispatcher,
+            new FixedProjectionClock(DateTimeOffset.Parse("2026-05-19T08:00:00Z")));
+        var state = new StudioWorkspaceState
+        {
+            WorkspaceId = RootActorId,
+            ScopeId = "scope-1",
+        };
+        state.Drafts.Add("wf-alpha", new StudioWorkflowDraft
+        {
+            WorkflowId = "wf-alpha",
+            Name = "workflow alpha",
+            FileName = "workflow-alpha.yaml",
+            DirectoryId = "dir-1",
+            DirectoryLabel = "Drafts",
+            Yaml = """
+                   name: workflow-alpha
+                   steps:
+                     - id: step-1
+                       config:
+                         model:
+                           provider:
+                             nested:
+                               arbitrary: value
+                   """,
+            Version = 4,
+        });
+
+        await projector.ProjectAsync(
+            NewContext(),
+            WrapCommitted(
+                new StudioWorkflowDraftSaved
+                {
+                    WorkspaceId = RootActorId,
+                    ScopeId = "scope-1",
+                    Draft = state.Drafts["wf-alpha"],
+                },
+                state,
+                version: 9,
+                eventId: "evt-9"));
+
+        var written = dispatcher.Upserts.Should().ContainSingle().Subject;
+        written.StateRootJson.Should().Contain("\"drafts\"");
+        StudioWorkspaceCurrentStateDocument.Descriptor.Fields.InDeclarationOrder()
+            .Select(field => field.Name)
+            .Should().NotContain("state_root");
+        StudioWorkspaceCurrentStateDocument.Descriptor.Fields.InDeclarationOrder()
+            .Single(field => field.Name == "state_root_json")
+            .FieldType.Should().Be(FieldType.String);
+
+        using var serialized = JsonDocument.Parse(ReadModelFormatter.Format(written));
+        serialized.RootElement.TryGetProperty("state_root_json", out var stateRootJsonElement).Should().BeTrue();
+        stateRootJsonElement.ValueKind.Should().Be(JsonValueKind.String);
+        serialized.RootElement.TryGetProperty("state_root", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Metadata_ShouldDisableDynamicMappingAndKeepStateRootJsonNonIndexed()
+    {
+        var metadata = new StudioWorkspaceCurrentStateDocumentMetadataProvider().Metadata;
+
+        metadata.Mappings["dynamic"].Should().Be(false);
+        var properties = metadata.Mappings["properties"].Should()
+            .BeAssignableTo<IReadOnlyDictionary<string, object?>>()
+            .Subject;
+        properties.Should().ContainKey("id");
+        properties.Should().ContainKey("actor_id");
+        properties.Should().ContainKey("state_version");
+        properties.Should().ContainKey("last_event_id");
+        properties.Should().ContainKey("updated_at");
+        properties.Should().NotContainKey("state_root");
+
+        var stateRootJsonMapping = properties["state_root_json"].Should()
+            .BeAssignableTo<IReadOnlyDictionary<string, object?>>()
+            .Subject;
+        stateRootJsonMapping["type"].Should().Be("text");
+        stateRootJsonMapping["index"].Should().Be(false);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Replace the Studio workspace current-state `Any` payload with an opaque `state_root_json` scalar so Elasticsearch does not dynamically map arbitrary workflow draft YAML/step/config fields.
- Keep the full workspace state payload intact in `state_root_json`; no draft data is dropped.
- Add explicit `draft_summaries` for the basic query surface (`workflow_id`, `name`, `file_name`, `directory_id`, `version`) and map it as non-dynamic nested fields.
- Disable dynamic mapping for `studio-workspaces` and explicitly map only stable query fields plus non-indexed `state_root_json`.
- Rehydrate `StudioWorkspaceState` from the opaque JSON in the query port and cover invalid/missing JSON fallback.

## Test plan
- [x] `dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --no-restore --filter "StudioWorkspaceCurrentStateProjectorTests|ProjectionStudioWorkspaceQueryPortTests" -v quiet`
- [ ] Full `bash tools/ci/test_stability_guards.sh` is blocked by unrelated existing coverage budget failure in `test/Aevatar.AI.Tests/RoleGAgentStateCoverageTests.cs`.

Fixes #2233

🤖 Generated with [Claude Code](https://claude.com/claude-code)