### PR TITLE
chore(workflow): polish saga v1 child compensation

### DIFF
--- a/docs/adr/0034-workflow-saga-compensation-protocol.md
+++ b/docs/adr/0034-workflow-saga-compensation-protocol.md
@@ -88,7 +88,9 @@ state already holds the execution context, variables, and sub-workflow bindings.
 Introducing a separate coordinator would violate "Actor 即业务实体" and create a
 cross-actor consistency problem (who is authoritative for run termination?) that
 does not exist today. Compensation is a terminal phase of the run's own state
-machine: `running → compensating → compensated_failed | compensation_dead_letter`.
+machine. Ordinary run execution is represented by run `status`; `saga_status`
+stays `UNSPECIFIED` until a terminal failure enters compensation, then moves
+`COMPENSATING → COMPENSATED_FAILED | COMPENSATION_DEAD_LETTER`.
 
 ### Q2. Choreography or orchestration?
 
@@ -243,6 +245,9 @@ steps:
   exist).
 - A compensation target step is not auto-inserted into the forward path; it runs
   only during the reverse walk.
+- `CompletedStepLedgerEntry.committed_at_unix_ms` was removed because ledger
+  order is the durable ordering fact; field number `5` and name
+  `committed_at_unix_ms` are reserved.
 
 ### Proto — state (`workflow_state.proto`)
 
@@ -250,18 +255,33 @@ steps:
 // One entry per successfully-committed step that declared a compensation,
 // in commit order. The reverse walk consumes this back-to-front.
 message CompletedStepLedgerEntry {
+  reserved 5;
+  reserved "committed_at_unix_ms";
   string step_id            = 1;
   string compensation_step_id = 2;
   string idempotency_key    = 3;
   string captured_output    = 4;   // the step output the compensation may need
-  int64  committed_at_unix_ms = 5;
+  CompensableLedgerEntryStatus ledger_status = 6;
 }
 
 // Added to WorkflowRunState (run-owned, durable):
-//   repeated CompletedStepLedgerEntry compensable_ledger = N;
-//   int32  compensation_cursor = N+1;   // index into ledger, walked downward
-//   string saga_status = N+2;           // running | compensating | compensated_failed | compensation_dead_letter
+//   repeated CompletedStepLedgerEntry compensable_ledger = 25;
+//   int32 compensation_cursor = 26;     // index into ledger, walked downward
+//   WorkflowSagaStatus saga_status = 27;
+//   string compensation_execution_id = 28;
+//   string dead_letter_failed_compensation_step_id = 29;
+//   int32 dead_letter_remaining_uncompensated = 30;
+//   string dead_letter_error = 31;
+//   string compensation_origin_failed_step_id = 32;
+//   bool terminal_workflow_completion_recorded = 33;
 ```
+
+`compensation_origin_failed_step_id` preserves the original terminal failure
+that triggered compensation. Later compensation requests must reuse it rather
+than deriving from the current compensation cursor. The terminal completion flag
+is the idempotency guard for redelivered `WorkflowCompletedEvent`; saga
+dead-letter state alone does not mean the final workflow completion fact has
+already been recorded.
 
 ### Proto — events (`workflow_execution_messages.proto`)
 
@@ -272,6 +292,16 @@ message CompensationRequestEvent {
   string compensation_step_id = 3;  // the compensation to run now (reverse cursor)
   string idempotency_key     = 4;
   string captured_output     = 5;
+  string execution_id         = 6;
+}
+
+message SubWorkflowInvocationCompletedEvent {
+  string invocation_id = 1;
+  string child_run_id = 2;
+  bool success = 3;
+  string output = 4;
+  string error = 5;
+  bool compensated = 6; // child run failed after completing its own compensation
 }
 
 message CompensationStepCompletedEvent {
@@ -279,6 +309,7 @@ message CompensationStepCompletedEvent {
   string compensation_step_id = 2;
   bool   success             = 3;
   string error               = 4;
+  string execution_id         = 5;
 }
 
 message WorkflowCompensationCompletedEvent {
@@ -293,6 +324,13 @@ message WorkflowCompensationFailedEvent {
   string error               = 4;
 }
 ```
+
+`SubWorkflowInvocationCompletedEvent.compensated` is child-outcome-only. It is
+`true` only when the child workflow terminally failed after reaching
+`WORKFLOW_SAGA_STATUS_COMPENSATED_FAILED` or an equivalent actor-owned fact.
+Ordinary child failure, stop, cleanup, dispatch failure, and historical
+completion remain `false`. Parent `StepCompletedEvent` remains unchanged in
+saga v1.
 
 ### Side-effect idempotency
 

--- a/docs/canon/workflow-primitives.md
+++ b/docs/canon/workflow-primitives.md
@@ -102,6 +102,7 @@ Runtime semantics:
 - The typed `WorkflowSagaStatus` moves `WORKFLOW_SAGA_STATUS_UNSPECIFIED -> WORKFLOW_SAGA_STATUS_COMPENSATING -> WORKFLOW_SAGA_STATUS_COMPENSATED_FAILED` when every compensation step succeeds (a non-compensating run stays `UNSPECIFIED`; there is no distinct `running` saga status).
 - If a compensation step fails, the run moves to `WORKFLOW_SAGA_STATUS_COMPENSATION_DEAD_LETTER` and emits `WorkflowCompensationFailedEvent` with the failed compensation step, remaining uncompensated count, and error.
 - Compensation dispatch uses self continuation. Stale or duplicate compensation completions are rejected by execution id and do not advance the cursor.
+- A child `workflow_call` reports its own compensated terminal failure with `SubWorkflowInvocationCompletedEvent.compensated = true`. The flag is child-outcome-only; parent workflow compensation remains driven by the parent run's own ledger.
 
 ## 2. Data 原语
 

--- a/docs/canon/workflow-runtime.md
+++ b/docs/canon/workflow-runtime.md
@@ -317,6 +317,10 @@ Workflow step 可以通过 `compensation` 声明一个已存在的 step id。静
 
 补偿相位本身也有 actor-owned durable deadline。第一次进入补偿相位或 crash/reactivation 后重发当前 `CompensationRequestEvent` 时，`WorkflowExecutionKernel` 通过 `ScheduleSelfDurableTimeoutAsync` 安排 `WorkflowCompensationPhaseDeadlineFiredEvent`，相对超时为 `CompensationPhaseDeadlineMs = 300000`。deadline fired 后若 run 仍处于当前补偿相位且 callback lease 匹配，kernel 只向 `WorkflowRunGAgent` 报告 deadline exceeded；仍由 run actor 依据权威 `compensation_cursor` 提交 `WorkflowCompensationFailedEvent`，进入 `COMPENSATION_DEAD_LETTER` 并复用失败 `WorkflowCompletedEvent` 通知 caller。补偿正常完成或 dead-letter 终态会清理并取消 phase deadline lease；终态后迟到的 deadline fired event 会被忽略。
 
+run actor 会把触发补偿的原始失败 step 持久化为 `compensation_origin_failed_step_id`，后续每个 `CompensationRequestEvent.failed_step_id` 都复用这个 actor-owned fact，不从当前 compensation cursor 反推。`terminal_workflow_completion_recorded` 是 `WorkflowCompletedEvent` redelivery 的幂等门禁；补偿 dead-letter 可以先把 run 标为 failed，但不会阻止第一次最终 completion fact 落账。
+
+`workflow_call` child run 失败时先由 child run 自己完成补偿，再向 parent actor 发送 `SubWorkflowInvocationCompletedEvent(success=false, compensated=true)`。`compensated` 只表达 child compensation outcome；parent 侧仍把该 child failure 转成普通 `StepCompletedEvent(success=false)` 推进本 run，是否补偿 parent 的 `workflow_call` step 由 parent 自己的 ledger 决定。
+
 Saga 状态由强类型枚举 `WorkflowSagaStatus`（`workflow_execution_messages.proto`）表达，生命周期为：
 
 ```text

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -509,6 +509,7 @@ message SubWorkflowInvocationCompletedEvent
   bool success = 3;
   string output = 4;
   string error = 5;
+  bool compensated = 6;
 }
 message WorkflowSuspendedEvent
 {

--- a/src/workflow/Aevatar.Workflow.Core/Execution/IWorkflowExecutionStateHost.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/IWorkflowExecutionStateHost.cs
@@ -16,6 +16,7 @@ internal enum WorkflowCompensationTransitionStatus
 internal readonly record struct WorkflowCompensationTransitionResult(
     WorkflowCompensationTransitionStatus Status,
     string NextCompensationStepId,   // empty when no next request should be sent
+    string FailedStepId,
     string IdempotencyKey,
     string CapturedOutput,
     string ExecutionId);

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
@@ -764,7 +764,9 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
         return ctx.PublishAsync(new CompensationRequestEvent
         {
             RunId = NormalizeRunId(runId),
-            FailedStepId = failedStepId ?? string.Empty,
+            FailedStepId = string.IsNullOrWhiteSpace(result.FailedStepId)
+                ? failedStepId ?? string.Empty
+                : result.FailedStepId,
             CompensationStepId = result.NextCompensationStepId,
             IdempotencyKey = result.IdempotencyKey ?? string.Empty,
             CapturedOutput = result.CapturedOutput ?? string.Empty,
@@ -1084,7 +1086,14 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
         ArgumentNullException.ThrowIfNull(ctx);
         ArgumentNullException.ThrowIfNull(completed);
 
+        var state = LoadState(ctx);
+        var hasManagedWorkflowCallParent =
+            WorkflowRunExecutionContextStateAccess.Get(ctx).WorkflowRuntime != null &&
+            state.Variables.ContainsKey(WorkflowCallInvocationIdParameterKey);
         await ctx.PublishAsync(completed, TopologyAudience.Self, ct);
+        if (hasManagedWorkflowCallParent)
+            return;
+
         await ctx.PublishAsync(completed.Clone(), TopologyAudience.Parent, ct);
     }
 

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/SubWorkflowOrchestrator.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/SubWorkflowOrchestrator.cs
@@ -462,30 +462,69 @@ internal sealed class SubWorkflowOrchestrator
                 completionPublisherId);
         }
 
-        await _persistDomainEventAsync(new SubWorkflowInvocationCompletedEvent
-        {
-            InvocationId = pending.InvocationId,
-            ChildRunId = childRunId,
-            Success = completed.Success,
-            Output = completed.Output ?? string.Empty,
-            Error = completed.Error ?? string.Empty,
-        }, ct);
+        await PersistInvocationCompletedAsync(
+            pending,
+            childRunId,
+            completed.Success,
+            completed.Output ?? string.Empty,
+            completed.Error ?? string.Empty,
+            compensated: false,
+            ct);
 
-        var parentCompleted = new StepCompletedEvent
-        {
-            StepId = pending.ParentStepId,
-            RunId = pending.ParentRunId,
-            Success = completed.Success,
-            Output = completed.Output,
-            Error = completed.Error,
-        };
-        parentCompleted.Annotations[WorkflowCallInvocationIdMetadataKey] = pending.InvocationId;
-        parentCompleted.Annotations[WorkflowCallWorkflowNameMetadataKey] = pending.WorkflowName;
-        parentCompleted.Annotations[WorkflowCallLifecycleMetadataKey] = WorkflowCallLifecycle.Normalize(pending.Lifecycle);
-        parentCompleted.Annotations[WorkflowCallChildActorIdMetadataKey] = pending.ChildActorId;
-        parentCompleted.Annotations[WorkflowCallChildRunIdMetadataKey] = childRunId;
+        await PublishParentStepCompletionAsync(
+            pending,
+            childRunId,
+            completed.Success,
+            completed.Output ?? string.Empty,
+            completed.Error ?? string.Empty,
+            ct);
+        await TryFinalizeNonSingletonChildAsync(pending, ct);
+        return true;
+    }
 
-        await _publishAsync(parentCompleted, TopologyAudience.Self, ct);
+    public async Task<bool> HandleInvocationCompletedAsync(
+        SubWorkflowInvocationCompletedEvent completed,
+        WorkflowRunState state,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(completed);
+        ArgumentNullException.ThrowIfNull(state);
+
+        var childRunId = completed.ChildRunId?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(childRunId))
+            return false;
+
+        if (!TryGetPendingInvocationByChildRunId(state, childRunId, out var pending))
+            return false;
+
+        var invocationId = completed.InvocationId?.Trim() ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(invocationId) &&
+            !string.Equals(invocationId, pending.InvocationId, StringComparison.Ordinal))
+        {
+            _loggerAccessor().LogWarning(
+                "Ignore workflow_call completion due to invocation mismatch. childRun={ChildRunId} expectedInvocation={ExpectedInvocationId} actualInvocation={ActualInvocationId}",
+                childRunId,
+                pending.InvocationId,
+                invocationId);
+            return true;
+        }
+
+        await PersistInvocationCompletedAsync(
+            pending,
+            childRunId,
+            completed.Success,
+            completed.Output ?? string.Empty,
+            completed.Error ?? string.Empty,
+            completed.Compensated,
+            ct);
+
+        await PublishParentStepCompletionAsync(
+            pending,
+            childRunId,
+            completed.Success,
+            completed.Output ?? string.Empty,
+            completed.Error ?? string.Empty,
+            ct);
         await TryFinalizeNonSingletonChildAsync(pending, ct);
         return true;
     }
@@ -1266,6 +1305,51 @@ internal sealed class SubWorkflowOrchestrator
                 "Ignore non-singleton child cleanup failure for actor {ChildActorId}.",
                 pending.ChildActorId);
         }
+    }
+
+    private async Task PersistInvocationCompletedAsync(
+        WorkflowRunState.Types.PendingSubWorkflowInvocation pending,
+        string childRunId,
+        bool success,
+        string output,
+        string error,
+        bool compensated,
+        CancellationToken ct)
+    {
+        await _persistDomainEventAsync(new SubWorkflowInvocationCompletedEvent
+        {
+            InvocationId = pending.InvocationId,
+            ChildRunId = childRunId,
+            Success = success,
+            Output = output ?? string.Empty,
+            Error = error ?? string.Empty,
+            Compensated = compensated,
+        }, ct);
+    }
+
+    private async Task PublishParentStepCompletionAsync(
+        WorkflowRunState.Types.PendingSubWorkflowInvocation pending,
+        string childRunId,
+        bool success,
+        string output,
+        string error,
+        CancellationToken ct)
+    {
+        var parentCompleted = new StepCompletedEvent
+        {
+            StepId = pending.ParentStepId,
+            RunId = pending.ParentRunId,
+            Success = success,
+            Output = output ?? string.Empty,
+            Error = error ?? string.Empty,
+        };
+        parentCompleted.Annotations[WorkflowCallInvocationIdMetadataKey] = pending.InvocationId;
+        parentCompleted.Annotations[WorkflowCallWorkflowNameMetadataKey] = pending.WorkflowName;
+        parentCompleted.Annotations[WorkflowCallLifecycleMetadataKey] = WorkflowCallLifecycle.Normalize(pending.Lifecycle);
+        parentCompleted.Annotations[WorkflowCallChildActorIdMetadataKey] = pending.ChildActorId;
+        parentCompleted.Annotations[WorkflowCallChildRunIdMetadataKey] = childRunId;
+
+        await _publishAsync(parentCompleted, TopologyAudience.Self, ct);
     }
 
     private async Task TryCancelDefinitionResolutionTimeoutAsync(

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
@@ -202,13 +202,14 @@ public sealed class WorkflowRunGAgent
         if (compensationState.CompensableLedger.Count == 0)
             return EmptyCompensationResult(WorkflowCompensationTransitionStatus.NoCompensableLedger);
 
+        var originFailedStepId = ResolveCompensationOriginFailedStepId(compensationState, terminalStep);
         var cursor = compensationState.CompensableLedger.Count - 1;
         var entry = compensationState.CompensableLedger[cursor];
         var executionId = Guid.NewGuid().ToString("N");
         await PersistDomainEventAsync(new CompensationRequestEvent
         {
             RunId = string.IsNullOrWhiteSpace(terminalFailure.RunId) ? RunId : WorkflowRunIdNormalizer.Normalize(terminalFailure.RunId),
-            FailedStepId = ResolveLastFailedStepId(compensationState),
+            FailedStepId = originFailedStepId,
             CompensationStepId = entry.CompensationStepId,
             IdempotencyKey = entry.IdempotencyKey,
             CapturedOutput = entry.CapturedOutput,
@@ -218,6 +219,7 @@ public sealed class WorkflowRunGAgent
         return BuildCompensationResult(
             WorkflowCompensationTransitionStatus.Started,
             entry,
+            originFailedStepId,
             executionId);
     }
 
@@ -282,10 +284,11 @@ public sealed class WorkflowRunGAgent
 
         var nextEntry = State.CompensableLedger[nextCursor];
         var nextExecutionId = Guid.NewGuid().ToString("N");
+        var originFailedStepId = ResolveLastFailedStepId(State);
         await PersistDomainEventAsync(new CompensationRequestEvent
         {
             RunId = State.RunId ?? string.Empty,
-            FailedStepId = ResolveLastFailedStepId(State),
+            FailedStepId = originFailedStepId,
             CompensationStepId = nextEntry.CompensationStepId,
             IdempotencyKey = nextEntry.IdempotencyKey,
             CapturedOutput = nextEntry.CapturedOutput,
@@ -295,6 +298,7 @@ public sealed class WorkflowRunGAgent
         return BuildCompensationResult(
             WorkflowCompensationTransitionStatus.AdvancedAndRequestedNext,
             nextEntry,
+            originFailedStepId,
             nextExecutionId);
     }
 
@@ -738,6 +742,15 @@ public sealed class WorkflowRunGAgent
 
     public async Task HandleWorkflowCompleted(WorkflowCompletedEvent evt)
     {
+        if (ShouldIgnoreWorkflowCompleted(State))
+        {
+            Logger.LogDebug(
+                "Ignore duplicate WorkflowCompletedEvent for terminal run={RunId} status={Status}.",
+                string.IsNullOrWhiteSpace(evt.RunId) ? RunId : evt.RunId,
+                State.Status);
+            return;
+        }
+
         var stateBeforeCompletion = State.Clone();
         await PersistDomainEventAsync(evt);
         await PersistForkRequestOnTerminalFailureAsync(evt, stateBeforeCompletion, CancellationToken.None);
@@ -772,6 +785,14 @@ public sealed class WorkflowRunGAgent
             Content = evt.Success ? evt.Output : $"Workflow execution failed: {evt.Error}",
             Error = evt.Success ? string.Empty : evt.Error,
         }, TopologyAudience.Parent);
+
+        await PublishManagedParentInvocationCompletionAsync(evt, stateBeforeCompletion, CancellationToken.None);
+    }
+
+    [EventHandler]
+    public async Task HandleSubWorkflowInvocationCompleted(SubWorkflowInvocationCompletedEvent completed)
+    {
+        await _subWorkflowOrchestrator.HandleInvocationCompletedAsync(completed, State, CancellationToken.None);
     }
 
     private async Task PersistForkRequestOnTerminalFailureAsync(
@@ -1087,6 +1108,8 @@ public sealed class WorkflowRunGAgent
         next.DeadLetterFailedCompensationStepId = string.Empty;
         next.DeadLetterRemainingUncompensated = 0;
         next.DeadLetterError = string.Empty;
+        next.CompensationOriginFailedStepId = string.Empty;
+        next.TerminalWorkflowCompletionRecorded = false;
         next.ExecutionStates.Clear();
         next.ExecutionContext = new WorkflowRunExecutionContextState();
         next.SubWorkflowBindings.Clear();
@@ -1132,6 +1155,8 @@ public sealed class WorkflowRunGAgent
         next.DeadLetterFailedCompensationStepId = string.Empty;
         next.DeadLetterRemainingUncompensated = 0;
         next.DeadLetterError = string.Empty;
+        next.CompensationOriginFailedStepId = string.Empty;
+        next.TerminalWorkflowCompletionRecorded = false;
         next.ExecutionContext ??= new WorkflowRunExecutionContextState();
         ApplyExecutionContextDelta(next.ExecutionContext, evt.ExecutionContextDelta);
         if (string.IsNullOrWhiteSpace(next.DefinitionActorId) && !string.IsNullOrWhiteSpace(evt.DefinitionActorId))
@@ -1309,7 +1334,6 @@ public sealed class WorkflowRunGAgent
             CompensationStepId = compensationStepId,
             IdempotencyKey = idempotencyKey,
             CapturedOutput = evt.Output ?? string.Empty,
-            CommittedAtUnixMs = 0,
             LedgerStatus = CompensableLedgerEntryStatus.Confirmed,
         });
         return next;
@@ -1351,7 +1375,6 @@ public sealed class WorkflowRunGAgent
             CompensationStepId = compensationStepId,
             IdempotencyKey = idempotencyKey,
             CapturedOutput = string.Empty,
-            CommittedAtUnixMs = Math.Max(0, evt.DispatchedAtUnixMs),
             LedgerStatus = CompensableLedgerEntryStatus.Provisional,
         });
         return next;
@@ -1366,6 +1389,8 @@ public sealed class WorkflowRunGAgent
 
         next.SagaStatus = WorkflowSagaStatus.Compensating;
         next.CompensationExecutionId = evt.ExecutionId?.Trim() ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(evt.FailedStepId))
+            next.CompensationOriginFailedStepId = evt.FailedStepId.Trim();
         for (var i = next.CompensableLedger.Count - 1; i >= 0; i--)
         {
             var ledgerEntry = next.CompensableLedger[i];
@@ -1450,6 +1475,7 @@ public sealed class WorkflowRunGAgent
         next.Status = evt.Success ? CompletedStatus : FailedStatus;
         next.FinalOutput = evt.Output ?? string.Empty;
         next.FinalError = evt.Error ?? string.Empty;
+        next.TerminalWorkflowCompletionRecorded = true;
         next.ExecutionContext = new WorkflowRunExecutionContextState();
         next.PendingSubWorkflowDefinitionResolutions.Clear();
         next.PendingSubWorkflowDefinitionResolutionIndexByInvocationId.Clear();
@@ -1484,6 +1510,11 @@ public sealed class WorkflowRunGAgent
         string.Equals(status, FailedStatus, StringComparison.OrdinalIgnoreCase) ||
         string.Equals(status, StoppedStatus, StringComparison.OrdinalIgnoreCase);
 
+    private static bool ShouldIgnoreWorkflowCompleted(WorkflowRunState state) =>
+        state.TerminalWorkflowCompletionRecorded ||
+        (IsTerminalStatus(state.Status) &&
+         state.SagaStatus != WorkflowSagaStatus.CompensationDeadLetter);
+
     private async Task ResumeCompensationAsync(CancellationToken ct)
     {
         if (!IsCompensating(State) ||
@@ -1513,23 +1544,26 @@ public sealed class WorkflowRunGAgent
         return BuildCompensationResult(
             status,
             entry,
+            ResolveLastFailedStepId(State),
             State.CompensationExecutionId ?? string.Empty);
     }
 
     private static WorkflowCompensationTransitionResult BuildCompensationResult(
         WorkflowCompensationTransitionStatus status,
         CompletedStepLedgerEntry entry,
+        string failedStepId,
         string executionId) =>
         new(
             status,
             entry.CompensationStepId ?? string.Empty,
+            failedStepId ?? string.Empty,
             entry.IdempotencyKey ?? string.Empty,
             entry.CapturedOutput ?? string.Empty,
             executionId ?? string.Empty);
 
     private static WorkflowCompensationTransitionResult EmptyCompensationResult(
         WorkflowCompensationTransitionStatus status) =>
-        new(status, string.Empty, string.Empty, string.Empty, string.Empty);
+        new(status, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty);
 
     private static int CalculateRemainingUncompensated(int ledgerCount, int cursor)
     {
@@ -1618,10 +1652,71 @@ public sealed class WorkflowRunGAgent
 
     private static string ResolveLastFailedStepId(WorkflowRunState state)
     {
+        if (!string.IsNullOrWhiteSpace(state.CompensationOriginFailedStepId))
+            return state.CompensationOriginFailedStepId.Trim();
+
         foreach (var packedState in state.ExecutionStates.Values)
         {
             if (packedState?.Is(WorkflowExecutionKernelState.Descriptor) == true)
                 return packedState.Unpack<WorkflowExecutionKernelState>().CurrentStepId?.Trim() ?? string.Empty;
+        }
+
+        return string.Empty;
+    }
+
+    private static string ResolveCompensationOriginFailedStepId(
+        WorkflowRunState state,
+        StepCompletedEvent? terminalStep)
+    {
+        if (terminalStep != null && !terminalStep.Success && !string.IsNullOrWhiteSpace(terminalStep.StepId))
+            return terminalStep.StepId.Trim();
+
+        return ResolveLastFailedStepId(state);
+    }
+
+    private async Task PublishManagedParentInvocationCompletionAsync(
+        WorkflowCompletedEvent evt,
+        WorkflowRunState stateBeforeCompletion,
+        CancellationToken ct)
+    {
+        var runtime = stateBeforeCompletion.ExecutionContext?.WorkflowRuntime;
+        if (runtime == null ||
+            string.IsNullOrWhiteSpace(runtime.ParentActorId) ||
+            string.IsNullOrWhiteSpace(runtime.ParentRunId) ||
+            string.IsNullOrWhiteSpace(runtime.ParentStepId))
+        {
+            return;
+        }
+
+        var invocationId = TryResolveWorkflowCallInvocationId(stateBeforeCompletion);
+        if (string.IsNullOrWhiteSpace(invocationId))
+            return;
+
+        await SendToAsync(
+            runtime.ParentActorId,
+            new SubWorkflowInvocationCompletedEvent
+            {
+                InvocationId = invocationId,
+                ChildRunId = string.IsNullOrWhiteSpace(evt.RunId) ? RunId : WorkflowRunIdNormalizer.Normalize(evt.RunId),
+                Success = evt.Success,
+                Output = evt.Output ?? string.Empty,
+                Error = evt.Error ?? string.Empty,
+                Compensated = !evt.Success && State.SagaStatus == WorkflowSagaStatus.CompensatedFailed,
+            },
+            ct);
+    }
+
+    private static string TryResolveWorkflowCallInvocationId(WorkflowRunState state)
+    {
+        foreach (var packedState in state.ExecutionStates.Values)
+        {
+            if (packedState?.Is(WorkflowExecutionKernelState.Descriptor) != true)
+                continue;
+
+            var kernelState = packedState.Unpack<WorkflowExecutionKernelState>();
+            return kernelState.Variables.TryGetValue("workflow_call.invocation_id", out var invocationId)
+                ? invocationId?.Trim() ?? string.Empty
+                : string.Empty;
         }
 
         return string.Empty;

--- a/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
+++ b/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
@@ -162,6 +162,8 @@ message WorkflowRunState
   string dead_letter_failed_compensation_step_id = 29;
   int32 dead_letter_remaining_uncompensated = 30;
   string dead_letter_error = 31;
+  string compensation_origin_failed_step_id = 32;
+  bool terminal_workflow_completion_recorded = 33;
 }
 
 message WorkflowRunExecutionContextState
@@ -676,10 +678,11 @@ message BackpressureQueueState
 
 message CompletedStepLedgerEntry
 {
+  reserved 5;
+  reserved "committed_at_unix_ms";
   string step_id = 1;
   string compensation_step_id = 2;
   string idempotency_key = 3;
   string captured_output = 4;
-  int64 committed_at_unix_ms = 5;
   CompensableLedgerEntryStatus ledger_status = 6;
 }

--- a/test/Aevatar.Integration.Tests/TestDoubles/TestEventHandlerContext.cs
+++ b/test/Aevatar.Integration.Tests/TestDoubles/TestEventHandlerContext.cs
@@ -369,6 +369,7 @@ internal sealed class TestAgent(string id, string? runId = null) : IAgent, IWork
             string.Empty,
             string.Empty,
             string.Empty,
+            string.Empty,
             string.Empty);
 
     public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) => Task.CompletedTask;
@@ -478,6 +479,7 @@ internal sealed class TestWorkflowRunAgent(string id, string runId) : IAgent, IW
     private static WorkflowCompensationTransitionResult NoCompensableLedger() =>
         new(
             WorkflowCompensationTransitionStatus.NoCompensableLedger,
+            string.Empty,
             string.Empty,
             string.Empty,
             string.Empty,

--- a/test/Aevatar.Workflow.Core.Tests/Execution/IdempotentStepExecutionTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/IdempotentStepExecutionTests.cs
@@ -1195,6 +1195,7 @@ public sealed class IdempotentStepExecutionTests
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 string.Empty);
     }
 

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionContextAdapterTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionContextAdapterTests.cs
@@ -406,6 +406,7 @@ public sealed class WorkflowExecutionContextAdapterTests
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 string.Empty);
     }
 
@@ -496,6 +497,7 @@ public sealed class WorkflowExecutionContextAdapterTests
         private static WorkflowCompensationTransitionResult NoCompensableLedger() =>
             new(
                 WorkflowCompensationTransitionStatus.NoCompensableLedger,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
@@ -430,6 +430,7 @@ public sealed class WorkflowExecutionRuntimeContextTests
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 string.Empty);
     }
 
@@ -544,6 +545,7 @@ public sealed class WorkflowExecutionRuntimeContextTests
         private static WorkflowCompensationTransitionResult NoCompensableLedger() =>
             new(
                 WorkflowCompensationTransitionStatus.NoCompensableLedger,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,

--- a/test/Aevatar.Workflow.Core.Tests/Modules/RuntimeCallbackEventizationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/RuntimeCallbackEventizationTests.cs
@@ -1491,6 +1491,7 @@ public class RuntimeCallbackEventizationTests
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 string.Empty);
 
         public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) => Task.CompletedTask;

--- a/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleApprovalTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleApprovalTests.cs
@@ -393,6 +393,7 @@ public sealed class ToolCallModuleApprovalTests
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 string.Empty);
 
         public Task UpdateExecutionContextAsync(

--- a/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
@@ -500,6 +500,7 @@ public sealed class ToolCallModuleContextTests
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 string.Empty);
 
         public Task UpdateExecutionContextAsync(

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowLoopModuleExpressionEvaluationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowLoopModuleExpressionEvaluationTests.cs
@@ -525,6 +525,7 @@ public class WorkflowLoopModuleExpressionEvaluationTests
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 string.Empty);
 
         public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) => Task.CompletedTask;

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRuntimeModuleBranchTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRuntimeModuleBranchTests.cs
@@ -1262,6 +1262,7 @@ public sealed class WorkflowRuntimeModuleBranchTests
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 string.Empty);
 
         public Task UpdateExecutionContextAsync(

--- a/test/Aevatar.Workflow.Core.Tests/Primitives/SubWorkflowOrchestratorTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Primitives/SubWorkflowOrchestratorTests.cs
@@ -942,6 +942,80 @@ public sealed class SubWorkflowOrchestratorTests
     }
 
     [Fact]
+    public async Task HandleInvocationCompletedAsync_WhenCompensatedChildFails_ShouldPersistCompensatedTerminalOutcome()
+    {
+        var harness = CreateHarness();
+        var state = BuildStateWithPending(new WorkflowRunState.Types.PendingSubWorkflowInvocation
+        {
+            InvocationId = "invoke-compensated",
+            ParentRunId = "parent-run",
+            ParentStepId = "step-compensated",
+            WorkflowName = "sub_flow",
+            ChildActorId = "child-compensated",
+            ChildRunId = "child-run-compensated",
+            Lifecycle = WorkflowCallLifecycle.Transient,
+        });
+
+        var handled = await harness.Orchestrator.HandleInvocationCompletedAsync(
+            new SubWorkflowInvocationCompletedEvent
+            {
+                InvocationId = "invoke-compensated",
+                ChildRunId = "child-run-compensated",
+                Success = false,
+                Error = "child failed after compensation",
+                Compensated = true,
+            },
+            state,
+            CancellationToken.None);
+
+        handled.Should().BeTrue();
+        var completion = harness.Persisted.OfType<SubWorkflowInvocationCompletedEvent>()
+            .Should()
+            .ContainSingle()
+            .Subject;
+        completion.Compensated.Should().BeTrue();
+        completion.Success.Should().BeFalse();
+        var parentCompletion = harness.Published.Should().ContainSingle().Subject.Message.Should().BeOfType<StepCompletedEvent>().Subject;
+        parentCompletion.Success.Should().BeFalse();
+        parentCompletion.Error.Should().Be("child failed after compensation");
+        harness.Runtime.Unlinked.Should().ContainSingle("child-compensated");
+        harness.Runtime.Destroyed.Should().ContainSingle("child-compensated");
+    }
+
+    [Fact]
+    public async Task TryHandleCompletionAsync_WhenOrdinaryChildCompletes_ShouldPersistCompensatedFalse()
+    {
+        var harness = CreateHarness();
+        var state = BuildStateWithPending(new WorkflowRunState.Types.PendingSubWorkflowInvocation
+        {
+            InvocationId = "invoke-ordinary",
+            ParentRunId = "parent-run",
+            ParentStepId = "step-ordinary",
+            WorkflowName = "sub_flow",
+            ChildActorId = "child-ordinary",
+            ChildRunId = "child-run-ordinary",
+            Lifecycle = WorkflowCallLifecycle.Singleton,
+        });
+
+        var handled = await harness.Orchestrator.TryHandleCompletionAsync(
+            new WorkflowCompletedEvent
+            {
+                RunId = "child-run-ordinary",
+                Success = false,
+                Error = "ordinary child failure",
+            },
+            "child-ordinary",
+            state,
+            CancellationToken.None);
+
+        handled.Should().BeTrue();
+        harness.Persisted.OfType<SubWorkflowInvocationCompletedEvent>()
+            .Should()
+            .ContainSingle()
+            .Which.Compensated.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task TryHandleStoppedAsync_WhenTransientChildStops_ShouldPublishParentFailureAndCleanup()
     {
         var harness = CreateHarness();
@@ -970,7 +1044,8 @@ public sealed class SubWorkflowOrchestratorTests
         harness.Persisted.OfType<SubWorkflowInvocationCompletedEvent>().Should().ContainSingle(x =>
             x.InvocationId == "invoke-stop-1" &&
             !x.Success &&
-            x.Error.Contains("manual", StringComparison.Ordinal));
+            x.Error.Contains("manual", StringComparison.Ordinal) &&
+            !x.Compensated);
         var parentCompletion = harness.Published.Single().Message.Should().BeOfType<StepCompletedEvent>().Subject;
         parentCompletion.StepId.Should().Be("step-stop-a");
         parentCompletion.RunId.Should().Be("parent-run");
@@ -1011,7 +1086,8 @@ public sealed class SubWorkflowOrchestratorTests
         harness.Persisted.OfType<SubWorkflowInvocationCompletedEvent>().Should().ContainSingle(x =>
             x.InvocationId == "invoke-stop-2" &&
             !x.Success &&
-            x.Error.Contains("manual", StringComparison.Ordinal));
+            x.Error.Contains("manual", StringComparison.Ordinal) &&
+            !x.Compensated);
         harness.Published.Should().ContainSingle();
         harness.Runtime.Unlinked.Should().BeEmpty();
         harness.Runtime.Destroyed.Should().BeEmpty();
@@ -1052,6 +1128,9 @@ public sealed class SubWorkflowOrchestratorTests
 
         harness.Persisted.Should().HaveCount(2);
         harness.Persisted.Should().OnlyContain(x => x is SubWorkflowInvocationCompletedEvent);
+        harness.Persisted.OfType<SubWorkflowInvocationCompletedEvent>()
+            .Should()
+            .OnlyContain(x => !x.Compensated);
         harness.Runtime.Unlinked.Should().ContainSingle("child-transient");
         harness.Runtime.Destroyed.Should().ContainSingle("child-transient");
         harness.Runtime.Unlinked.Should().NotContain("child-singleton");

--- a/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentSagaCompensationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentSagaCompensationTests.cs
@@ -52,7 +52,7 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
                 IdempotencyKey = request.IdempotencyKey,
                 CapturedOutput = string.Empty,
                 LedgerStatus = CompensableLedgerEntryStatus.Provisional,
-            }, options => options.Excluding(x => x.CommittedAtUnixMs));
+            });
 
         var compensation = CompensationRequests(harness.Publisher).Should().ContainSingle().Subject;
         compensation.CompensationStepId.Should().Be("cancel_order");
@@ -110,7 +110,7 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
                 IdempotencyKey = request.IdempotencyKey,
                 CapturedOutput = """{"orderId":"order-1"}""",
                 LedgerStatus = CompensableLedgerEntryStatus.Confirmed,
-            }, options => options.Excluding(x => x.CommittedAtUnixMs));
+            });
     }
 
     [Fact]
@@ -128,7 +128,7 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
                 IdempotencyKey = $"{harness.RunId}:create_order:1",
                 CapturedOutput = "order-output",
                 LedgerStatus = CompensableLedgerEntryStatus.Confirmed,
-            }, options => options.Excluding(x => x.CommittedAtUnixMs));
+            });
     }
 
     [Fact]
@@ -173,6 +173,50 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
             .ContainSingle()
             .Which.RunId.Should().Be(harness.RunId);
         harness.Agent.State.SagaStatus.Should().Be(WorkflowSagaStatus.CompensatedFailed);
+    }
+
+    [Fact]
+    public async Task TerminalFailure_WithMultipleCompensations_ShouldPreserveOriginalFailedStepId()
+    {
+        var harness = await CreateStartedRunAsync(SagaWorkflowYaml());
+
+        await CompleteStepAsync(harness, "create_order", "order-output");
+        await CompleteStepAsync(harness, "charge_payment", "charge-output");
+        await FailStepAsync(harness, "ship_order", "ship failed");
+
+        var firstRequest = CompensationRequests(harness.Publisher).Should().ContainSingle().Subject;
+        firstRequest.FailedStepId.Should().Be("ship_order");
+        harness.Agent.State.CompensationOriginFailedStepId.Should().Be("ship_order");
+
+        await CompleteCompensationAsync(harness, firstRequest);
+
+        var secondRequest = CompensationRequests(harness.Publisher).Last();
+        secondRequest.CompensationStepId.Should().Be("cancel_order");
+        secondRequest.FailedStepId.Should().Be("ship_order");
+        harness.Agent.State.CompensationOriginFailedStepId.Should().Be("ship_order");
+    }
+
+    [Fact]
+    public async Task WorkflowCompletionRedelivery_WhenRunIsTerminal_ShouldNotDuplicateTerminalFacts()
+    {
+        var harness = await CreateStartedRunAsync(NoCompensationWorkflowYaml());
+
+        await FailStepAsync(harness, "failed_step", "boom");
+        var terminal = CommittedEvents<WorkflowCompletedEvent>(harness.CommittedPublisher)
+            .Should()
+            .ContainSingle(x => !x.Success)
+            .Subject;
+        var committedEventCount = harness.CommittedPublisher.Events.Count;
+        var publishedEventCount = harness.Publisher.Published.Count;
+
+        await harness.Agent.HandleEventAsync(SelfEnvelope(harness.RunId, terminal.Clone()));
+
+        CommittedEvents<WorkflowCompletedEvent>(harness.CommittedPublisher)
+            .Where(x => !x.Success)
+            .Should()
+            .ContainSingle();
+        harness.CommittedPublisher.Events.Should().HaveCount(committedEventCount);
+        harness.Publisher.Published.Should().HaveCount(publishedEventCount);
     }
 
     [Fact]
@@ -767,6 +811,55 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
         harness.Agent.State.SagaStatus.Should().Be(WorkflowSagaStatus.CompensationDeadLetter);
     }
 
+    [Fact]
+    public async Task ManagedWorkflowCallChild_WhenCompensationCompletes_ShouldSendCompensatedChildCompletionToParent()
+    {
+        const string parentActorId = "parent-run-actor";
+        const string parentRunId = "parent-run";
+        const string parentStepId = "call_child";
+        const string invocationId = "invoke-child-1";
+        var childRunId = "child-run-" + Guid.NewGuid().ToString("N");
+        var harness = await CreateRunAsync(childRunId, SagaWorkflowYaml());
+
+        await harness.Agent.HandleEventAsync(EnvelopeFrom(parentActorId, new StartWorkflowEvent
+        {
+            WorkflowName = "wf_2097",
+            RunId = childRunId,
+            Input = "hello",
+            WorkflowRuntime = new WorkflowToolRuntimeContextPayload
+            {
+                ParentActorId = parentActorId,
+                ParentRunId = parentRunId,
+                ParentStepId = parentStepId,
+                RootRunId = parentRunId,
+                Depth = 1,
+            },
+            Parameters =
+            {
+                ["workflow_call.invocation_id"] = invocationId,
+            },
+        }));
+
+        await CompleteStepAsync(harness, "create_order", "order-output");
+        await CompleteStepAsync(harness, "charge_payment", "charge-output");
+        await FailStepAsync(harness, "ship_order", "ship failed");
+        var firstRequest = CompensationRequests(harness.Publisher).Single();
+        await CompleteCompensationAsync(harness, firstRequest);
+        var secondRequest = CompensationRequests(harness.Publisher).Last();
+        await CompleteCompensationAsync(harness, secondRequest);
+
+        PublishedEvents<WorkflowCompletedEvent>(harness.Publisher)
+            .Where(x => x.Audience == TopologyAudience.Parent)
+            .Should()
+            .BeEmpty();
+        var sent = harness.Publisher.Sent.Should().ContainSingle(x => x.TargetActorId == parentActorId).Subject;
+        var completed = sent.Event.Should().BeOfType<SubWorkflowInvocationCompletedEvent>().Subject;
+        completed.InvocationId.Should().Be(invocationId);
+        completed.ChildRunId.Should().Be(childRunId);
+        completed.Success.Should().BeFalse();
+        completed.Compensated.Should().BeTrue();
+    }
+
     private static async Task CompleteStepAsync(RunHarness harness, string stepId, string output)
     {
         var request = harness.Publisher.Published
@@ -1185,6 +1278,8 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
     {
         public List<(IMessage Event, TopologyAudience Audience)> Published { get; } = [];
 
+        public List<(string TargetActorId, IMessage Event)> Sent { get; } = [];
+
         public bool AutoReplaySelfPublished { get; init; } = true;
 
         public WorkflowRunGAgent Agent { get; set; } = null!;
@@ -1213,8 +1308,12 @@ public sealed class WorkflowRunGAgentSagaCompensationTests
             CancellationToken ct,
             EventEnvelope? sourceEnvelope,
             EventEnvelopePublishOptions? options)
-            where T : IMessage =>
-            Task.CompletedTask;
+            where T : IMessage
+        {
+            ct.ThrowIfCancellationRequested();
+            Sent.Add((targetActorId, evt.Descriptor.Parser.ParseFrom(evt.ToByteArray())));
+            return Task.CompletedTask;
+        }
     }
 
     private sealed record ScheduledCallback(

--- a/test/Aevatar.Workflow.Core.Tests/WorkflowSagaContractTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/WorkflowSagaContractTests.cs
@@ -22,7 +22,6 @@ public sealed class WorkflowSagaContractTests
             CompensationStepId = "cancel_order",
             IdempotencyKey = "run-1:create_order",
             CapturedOutput = """{"orderId":"order-1"}""",
-            CommittedAtUnixMs = 123456789,
             LedgerStatus = CompensableLedgerEntryStatus.Confirmed,
         });
 
@@ -31,7 +30,6 @@ public sealed class WorkflowSagaContractTests
         state.CompensableLedger[0].CompensationStepId.Should().Be("cancel_order");
         state.CompensableLedger[0].IdempotencyKey.Should().Be("run-1:create_order");
         state.CompensableLedger[0].CapturedOutput.Should().Be("""{"orderId":"order-1"}""");
-        state.CompensableLedger[0].CommittedAtUnixMs.Should().Be(123456789);
         state.CompensableLedger[0].LedgerStatus.Should().Be(CompensableLedgerEntryStatus.Confirmed);
         state.CompensationCursor.Should().Be(1);
         state.SagaStatus.Should().Be(WorkflowSagaStatus.Compensating);
@@ -136,6 +134,17 @@ public sealed class WorkflowSagaContractTests
         {
             RunId = "run-1",
         });
+
+        AssertField<SubWorkflowInvocationCompletedEvent>("compensated", 6);
+        AssertRoundTrip(new SubWorkflowInvocationCompletedEvent
+        {
+            InvocationId = "invoke-1",
+            ChildRunId = "child-run-1",
+            Success = false,
+            Output = string.Empty,
+            Error = "failed after compensation",
+            Compensated = true,
+        });
     }
 
     [Fact]
@@ -152,20 +161,22 @@ public sealed class WorkflowSagaContractTests
         AssertField<CompletedStepLedgerEntry>("compensation_step_id", 2);
         AssertField<CompletedStepLedgerEntry>("idempotency_key", 3);
         AssertField<CompletedStepLedgerEntry>("captured_output", 4);
-        AssertField<CompletedStepLedgerEntry>("committed_at_unix_ms", 5);
+        AssertFieldMissing<CompletedStepLedgerEntry>("committed_at_unix_ms");
+        AssertReserved<CompletedStepLedgerEntry>("committed_at_unix_ms", 5);
         AssertField<CompletedStepLedgerEntry>("ledger_status", 6);
         AssertField<WorkflowRunState>("compensable_ledger", 25);
         AssertField<WorkflowRunState>("compensation_cursor", 26);
         AssertField<WorkflowRunState>("saga_status", 27);
         AssertField<WorkflowExecutionKernelState>("compensation_phase_deadline_lease", 17);
         AssertField<WorkflowExecutionKernelState>("compensation_phase_deadline_callback_id", 18);
+        AssertField<WorkflowRunState>("compensation_origin_failed_step_id", 32);
+        AssertField<WorkflowRunState>("terminal_workflow_completion_recorded", 33);
         AssertRoundTrip(new CompletedStepLedgerEntry
         {
             StepId = "create_order",
             CompensationStepId = "cancel_order",
             IdempotencyKey = "run-1:create_order:1",
             CapturedOutput = "{}",
-            CommittedAtUnixMs = 123456789,
             LedgerStatus = CompensableLedgerEntryStatus.Provisional,
         });
     }
@@ -177,6 +188,25 @@ public sealed class WorkflowSagaContractTests
 
         field.Should().NotBeNull();
         field!.FieldNumber.Should().Be(number);
+    }
+
+    private static void AssertFieldMissing<TMessage>(string name)
+        where TMessage : IMessage<TMessage>, new()
+    {
+        new TMessage().Descriptor.FindFieldByName(name).Should().BeNull();
+    }
+
+    private static void AssertReserved<TMessage>(string name, int number)
+        where TMessage : IMessage<TMessage>, new()
+    {
+        var messageDescriptor = new TMessage().Descriptor;
+        var file = FileDescriptorProto.Parser.ParseFrom(messageDescriptor.File.SerializedData);
+        var descriptor = file.MessageType.Single(message => message.Name == messageDescriptor.Name);
+
+        descriptor.ReservedName.Should().Contain(name);
+        descriptor.ReservedRange.Should().Contain(range =>
+            range.Start <= number &&
+            number < range.End);
     }
 
     private static void AssertRoundTrip<TMessage>(TMessage message)

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionCatalogTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionCatalogTests.cs
@@ -442,6 +442,7 @@ public class WorkflowDefinitionCatalogTests
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 string.Empty);
 
         public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) => Task.CompletedTask;


### PR DESCRIPTION
## 问题

Milestone 25 issue #2132 要求对 workflow saga v1 合同做窄范围 polish：child workflow compensation outcome 只能落在 `SubWorkflowInvocationCompletedEvent.compensated`，不得扩展 parent `StepCompletedEvent.workflow_call`。

## 方案

- 新增 `SubWorkflowInvocationCompletedEvent.compensated = 6`，只表达 child run 自己完成补偿后的失败结果。
- 删除并 reserve `CompletedStepLedgerEntry.committed_at_unix_ms`，ledger 顺序继续作为权威顺序事实。
- 持久化 `compensation_origin_failed_step_id` 和 terminal completion idempotency fact，避免多步补偿后丢失原始失败 step，并避免 `WorkflowCompletedEvent` redelivery 重复落账。
- 更新 `SubWorkflowOrchestrator`、`WorkflowRunGAgent` 和核心测试，保持 parent `StepCompletedEvent` 不新增 `workflow_call` 载荷。
- 同步 ADR-0034 与 canon docs。

## 验证

- `dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --nologo --filter "FullyQualifiedName~WorkflowSagaContractTests|FullyQualifiedName~SubWorkflowOrchestratorTests|FullyQualifiedName~WorkflowRunGAgentSagaCompensationTests|FullyQualifiedName~IdempotentStepExecutionTests"`
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/docs/lint.sh`
- `git diff --check origin/feature/integrate...HEAD`
- Forbidden-surface grep: only expected `committed_at_unix_ms` reservation/docs/test assertions; no parent `StepCompletedEvent.workflow_call` field added.

Closes #2132

⟦AI:AUTO-LOOP⟧
