### PR TITLE
Resolve Lark subject IDs through channel metadata

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/ChannelMetadataKeys.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/ChannelMetadataKeys.cs
@@ -46,6 +46,16 @@ public static class ChannelMetadataKeys
     /// <summary>Lark <c>union_id</c> of the card-action operator when available.</summary>
     public const string LarkOperatorUnionId = "channel.lark.operator_union_id";
     /// <summary>
+    /// Lark <c>user_id</c> of the ordinary-message sender resolved from Lark contact lookup.
+    /// Distinct from <see cref="LarkOperatorUserId"/>, which is scoped to card actions.
+    /// </summary>
+    public const string LarkSubjectUserId = "channel.lark.subject_user_id";
+    /// <summary>
+    /// Lark <c>employee_id</c> of the ordinary-message sender resolved from Lark contact lookup.
+    /// Distinct from card-action operator identity.
+    /// </summary>
+    public const string LarkSubjectEmployeeId = "channel.lark.subject_employee_id";
+    /// <summary>
     /// Authoritative outbound Lark <c>receive_id</c> for the current workflow run, captured at
     /// agent-create time. Propagated via <c>WorkflowChatRunRequest.Metadata</c> so workflow
     /// modules can surface their result back into the same chat without having to look up the

--- a/agents/Aevatar.GAgents.NyxidChat/ChannelContextMiddleware.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelContextMiddleware.cs
@@ -99,6 +99,8 @@ internal sealed class ChannelContextMiddleware : ILLMCallMiddleware
                 $"operator_user_id: {Resolve(metadata, ChannelMetadataKeys.LarkOperatorUserId)}",
                 $"operator_open_id: {Resolve(metadata, ChannelMetadataKeys.LarkOperatorOpenId)}",
                 $"operator_union_id: {Resolve(metadata, ChannelMetadataKeys.LarkOperatorUnionId)}",
+                $"subject_user_id: {Resolve(metadata, ChannelMetadataKeys.LarkSubjectUserId)}",
+                $"subject_employee_id: {Resolve(metadata, ChannelMetadataKeys.LarkSubjectEmployeeId)}",
                 "</channel-context>",
             ]);
     }

--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -68,6 +68,8 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         ExternalSubjectRef? Subject,
         BindingId? BindingId);
 
+    private sealed record LarkSubjectContactIds(string? UserId, string? EmployeeId);
+
     private readonly IServiceProvider _toolServiceProvider;
     private readonly IChannelBotRegistrationQueryPort _registrationQueryPort;
     private readonly IChannelBotRegistrationQueryByNyxIdentityPort? _registrationQueryByNyxIdentityPort;
@@ -1309,6 +1311,7 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
             var metadata = await BuildAgentBuilderMetadataAsync(
                     activity,
                     inboundEvent,
+                    runtimeContext,
                     ct);
             using (AgentToolContextScope.Push(BuildAgentBuilderToolContext(
                        inboundEvent,
@@ -1768,6 +1771,7 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
     private async Task<IReadOnlyDictionary<string, string>> BuildReplyMetadataAsync(
         ChannelInboundEvent inboundEvent,
         ChatActivity? activity,
+        ConversationTurnRuntimeContext runtimeContext,
         CancellationToken ct)
     {
         var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
@@ -1823,7 +1827,132 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         if (!string.IsNullOrWhiteSpace(larkOperatorUnionId))
             metadata[ChannelMetadataKeys.LarkOperatorUnionId] = larkOperatorUnionId;
 
+        if (await TryResolveLarkSubjectContactIdsAsync(inboundEvent, activity, runtimeContext, larkUnionId, ct)
+                .ConfigureAwait(false) is { } subjectContactIds)
+        {
+            if (!string.IsNullOrWhiteSpace(subjectContactIds.UserId))
+                metadata[ChannelMetadataKeys.LarkSubjectUserId] = subjectContactIds.UserId;
+            if (!string.IsNullOrWhiteSpace(subjectContactIds.EmployeeId))
+                metadata[ChannelMetadataKeys.LarkSubjectEmployeeId] = subjectContactIds.EmployeeId;
+        }
+
         return metadata;
+    }
+
+    private async Task<LarkSubjectContactIds?> TryResolveLarkSubjectContactIdsAsync(
+        ChannelInboundEvent inboundEvent,
+        ChatActivity? activity,
+        ConversationTurnRuntimeContext runtimeContext,
+        string? larkUnionId,
+        CancellationToken ct)
+    {
+        if (activity?.Type != ActivityType.Message)
+            return null;
+
+        if (!IsLarkPlatform(inboundEvent.Platform))
+            return null;
+
+        var accessToken = activity is null
+            ? NormalizeOptional(runtimeContext.NyxUserAccessToken)
+            : ResolveUserAccessToken(activity, runtimeContext);
+        var providerSlug = NormalizeOptional(inboundEvent.NyxProviderSlug);
+        var scopeId = NormalizeOptional(inboundEvent.RegistrationScopeId);
+        if (string.IsNullOrWhiteSpace(accessToken) ||
+            string.IsNullOrWhiteSpace(providerSlug) ||
+            string.IsNullOrWhiteSpace(scopeId))
+        {
+            return null;
+        }
+
+        var lookupId = NormalizeOptional(larkUnionId);
+        var userIdType = "union_id";
+        if (string.IsNullOrWhiteSpace(lookupId))
+        {
+            lookupId = NormalizeOptional(inboundEvent.SenderId);
+            userIdType = "open_id";
+        }
+
+        if (string.IsNullOrWhiteSpace(lookupId))
+            return null;
+
+        try
+        {
+            var response = await _nyxClient.ProxyRequestAsync(
+                    accessToken!,
+                    providerSlug!,
+                    $"/open-apis/contact/v3/users/{Uri.EscapeDataString(lookupId!)}?user_id_type={userIdType}",
+                    "GET",
+                    body: null,
+                    extraHeaders: null,
+                    ct)
+                .ConfigureAwait(false);
+
+            if (LarkProxyResponse.TryGetError(response, out _, out _))
+                return null;
+
+            return TryParseLarkSubjectContactIds(response, out var contactIds) ? contactIds : null;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(
+                ex,
+                "Lark subject contact lookup failed open: provider={ProviderSlug}, userIdType={UserIdType}",
+                providerSlug,
+                userIdType);
+            return null;
+        }
+    }
+
+    private static bool TryParseLarkSubjectContactIds(string? response, out LarkSubjectContactIds contactIds)
+    {
+        contactIds = new LarkSubjectContactIds(null, null);
+        if (string.IsNullOrWhiteSpace(response))
+            return false;
+
+        try
+        {
+            using var document = JsonDocument.Parse(response);
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object ||
+                !root.TryGetProperty("data", out var data) ||
+                data.ValueKind != JsonValueKind.Object ||
+                !data.TryGetProperty("user", out var user) ||
+                user.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            var userId = TryReadString(user, "user_id");
+            var employeeId = TryReadString(user, "employee_id");
+            if (string.IsNullOrWhiteSpace(userId) && string.IsNullOrWhiteSpace(employeeId))
+                return false;
+
+            contactIds = new LarkSubjectContactIds(userId, employeeId);
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsLarkPlatform(string? platform) =>
+        string.Equals(platform, "lark", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(platform, "feishu", StringComparison.OrdinalIgnoreCase);
+
+    private static string? TryReadString(JsonElement container, string propertyName)
+    {
+        if (!container.TryGetProperty(propertyName, out var property) ||
+            property.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
+        return NormalizeOptional(property.GetString());
     }
 
     private static AgentToolExecutionContext BuildAgentBuilderToolContext(
@@ -1857,10 +1986,11 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
     private async Task<IReadOnlyDictionary<string, string>> BuildAgentBuilderMetadataAsync(
         ChatActivity activity,
         ChannelInboundEvent inboundEvent,
+        ConversationTurnRuntimeContext runtimeContext,
         CancellationToken ct)
     {
         var metadata = new Dictionary<string, string>(
-            await BuildReplyMetadataAsync(inboundEvent, activity, ct),
+            await BuildReplyMetadataAsync(inboundEvent, activity, runtimeContext, ct),
             StringComparer.Ordinal)
         {
             [ChannelMetadataKeys.ChatType] = ResolveConversationChatType(activity.Conversation),
@@ -2041,7 +2171,7 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
             request.ReplyTokenExpiresAtUnixMs = token.ExpiresAtUtc.ToUnixTimeMilliseconds();
         }
 
-        var replyMetadata = await BuildReplyMetadataAsync(inboundEvent, activity, ct);
+        var replyMetadata = await BuildReplyMetadataAsync(inboundEvent, activity, runtimeContext, ct);
         foreach (var pair in replyMetadata)
             request.Metadata[pair.Key] = pair.Value;
 

--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -1898,7 +1898,7 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(
+            _logger.LogWarning(
                 ex,
                 "Lark subject contact lookup failed open: provider={ProviderSlug}, userIdType={UserIdType}",
                 providerSlug,

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
@@ -375,7 +375,9 @@ public sealed class ChannelConversationTurnRunnerTests
     {
         var registrationQueryPort = BuildRegistrationQueryPort();
         var adapter = new RecordingPlatformAdapter();
-        var runner = CreateRunner(registrationQueryPort, adapter);
+        var nyxHandler = new RecordingJsonHandler(
+            """{"code":0,"data":{"user":{"user_id":"lark-user-1","employee_id":"emp-1"}}}""");
+        var runner = CreateRunner(registrationQueryPort, adapter, nyxHandler: nyxHandler);
 
         var result = await runner.RunInboundAsync(
             BuildInboundActivity(
@@ -384,7 +386,7 @@ public sealed class ChannelConversationTurnRunnerTests
                 transportExtras: new TransportExtras
                 {
                     NyxPlatform = "lark",
-                    NyxPlatformMessageId = "om_123",
+                    NyxUserAccessToken = "user-token-1",
                     NyxLarkUnionId = "on_union_1",
                     NyxLarkChatId = "oc_chat_1",
                 }),
@@ -392,9 +394,53 @@ public sealed class ChannelConversationTurnRunnerTests
 
         result.Success.Should().BeTrue();
         result.LlmReplyRequest.Should().NotBeNull();
-        result.LlmReplyRequest!.Metadata[ChannelMetadataKeys.PlatformMessageId].Should().Be("om_123");
-        result.LlmReplyRequest.Metadata[ChannelMetadataKeys.LarkUnionId].Should().Be("on_union_1");
+        result.LlmReplyRequest!.Metadata[ChannelMetadataKeys.LarkUnionId].Should().Be("on_union_1");
         result.LlmReplyRequest.Metadata[ChannelMetadataKeys.LarkChatId].Should().Be("oc_chat_1");
+        result.LlmReplyRequest.Metadata[ChannelMetadataKeys.LarkSubjectUserId].Should().Be("lark-user-1");
+        result.LlmReplyRequest.Metadata[ChannelMetadataKeys.LarkSubjectEmployeeId].Should().Be("emp-1");
+
+        var toolContext = AgentToolExecutionContextMapper.FromPayload(result.LlmReplyRequest.ToolContext);
+        toolContext.ExternalMetadata[ChannelMetadataKeys.LarkSubjectUserId].Should().Be("lark-user-1");
+        toolContext.ExternalMetadata[ChannelMetadataKeys.LarkSubjectEmployeeId].Should().Be("emp-1");
+        nyxHandler.Requests.Should().ContainSingle();
+        nyxHandler.Requests[0].Method.Should().Be("GET");
+        nyxHandler.Requests[0].Path.Should().Be(
+            "/api/v1/proxy/s/api-lark-bot/open-apis/contact/v3/users/on_union_1?user_id_type=union_id");
+        nyxHandler.Requests[0].Authorization.Should().Be("Bearer user-token-1");
+    }
+
+    [Fact]
+    public async Task RunInboundAsync_ShouldResolveLarkSubjectIdsByOpenId_WhenUnionIdIsUnavailable()
+    {
+        var registrationQueryPort = BuildRegistrationQueryPort();
+        var adapter = new RecordingPlatformAdapter();
+        var nyxHandler = new RecordingJsonHandler(
+            """{"code":0,"data":{"user":{"user_id":"lark-user-open","employee_id":"emp-open"}}}""");
+        var runner = CreateRunner(registrationQueryPort, adapter, nyxHandler: nyxHandler);
+
+        var result = await runner.RunInboundAsync(
+            BuildInboundActivity(
+                "hello",
+                "msg-lark-subject-open-id",
+                transportExtras: new TransportExtras
+                {
+                    NyxPlatform = "lark",
+                    NyxUserAccessToken = "user-token-1",
+                }),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.LlmReplyRequest.Should().NotBeNull();
+        result.LlmReplyRequest!.Metadata.Should().NotContainKey(ChannelMetadataKeys.LarkUnionId);
+        result.LlmReplyRequest.Metadata[ChannelMetadataKeys.LarkSubjectUserId].Should().Be("lark-user-open");
+        result.LlmReplyRequest.Metadata[ChannelMetadataKeys.LarkSubjectEmployeeId].Should().Be("emp-open");
+
+        var toolContext = AgentToolExecutionContextMapper.FromPayload(result.LlmReplyRequest.ToolContext);
+        toolContext.ExternalMetadata[ChannelMetadataKeys.LarkSubjectUserId].Should().Be("lark-user-open");
+        toolContext.ExternalMetadata[ChannelMetadataKeys.LarkSubjectEmployeeId].Should().Be("emp-open");
+        nyxHandler.Requests.Should().ContainSingle();
+        nyxHandler.Requests[0].Path.Should().Be(
+            "/api/v1/proxy/s/api-lark-bot/open-apis/contact/v3/users/ou_user_1?user_id_type=open_id");
     }
 
     [Fact]
@@ -424,6 +470,105 @@ public sealed class ChannelConversationTurnRunnerTests
         result.LlmReplyRequest.Metadata[ChannelMetadataKeys.LarkOperatorUserId].Should().NotBe("nyx-user-1");
         result.LlmReplyRequest.Metadata[ChannelMetadataKeys.LarkOperatorOpenId].Should().Be("ou_open_operator_1");
         result.LlmReplyRequest.Metadata[ChannelMetadataKeys.LarkOperatorUnionId].Should().Be("on_operator_1");
+        result.LlmReplyRequest.Metadata.Should().NotContainKey(ChannelMetadataKeys.LarkSubjectUserId);
+        result.LlmReplyRequest.Metadata.Should().NotContainKey(ChannelMetadataKeys.LarkSubjectEmployeeId);
+    }
+
+    [Theory]
+    [InlineData(null, "api-lark-bot", "scope-1", """{"code":0,"data":{"user":{"user_id":"lark-user-1","employee_id":"emp-1"}}}""")]
+    [InlineData("user-token-1", "", "scope-1", """{"code":0,"data":{"user":{"user_id":"lark-user-1","employee_id":"emp-1"}}}""")]
+    [InlineData("user-token-1", "api-lark-bot", "", """{"code":0,"data":{"user":{"user_id":"lark-user-1","employee_id":"emp-1"}}}""")]
+    [InlineData("user-token-1", "api-lark-bot", "scope-1", """{"error":true,"message":"proxy unavailable"}""")]
+    [InlineData("user-token-1", "api-lark-bot", "scope-1", """{"code":99991663,"msg":"permission denied"}""")]
+    [InlineData("user-token-1", "api-lark-bot", "scope-1", "not-json")]
+    [InlineData("user-token-1", "api-lark-bot", "scope-1", """{"code":0,"data":{"user":{}}}""")]
+    public async Task RunInboundAsync_ShouldFailOpen_WhenLarkSubjectLookupCannotResolve(
+        string? userAccessToken,
+        string providerSlug,
+        string scopeId,
+        string proxyBody)
+    {
+        var registration = BuildRegistrationEntry();
+        registration.NyxProviderSlug = providerSlug;
+        registration.ScopeId = scopeId;
+        var registrationQueryPort = BuildRegistrationQueryPort(registration);
+        var adapter = new RecordingPlatformAdapter();
+        var nyxHandler = new RecordingJsonHandler(proxyBody);
+        var runner = CreateRunner(registrationQueryPort, adapter, nyxHandler: nyxHandler);
+
+        var result = await runner.RunInboundAsync(
+            BuildInboundActivity(
+                "hello",
+                $"msg-lark-subject-fail-open-{Guid.NewGuid():N}",
+                transportExtras: new TransportExtras
+                {
+                    NyxPlatform = "lark",
+                    NyxUserAccessToken = userAccessToken ?? string.Empty,
+                    NyxLarkUnionId = "on_union_1",
+                }),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.LlmReplyRequest.Should().NotBeNull();
+        result.LlmReplyRequest!.Metadata.Should().NotContainKey(ChannelMetadataKeys.LarkSubjectUserId);
+        result.LlmReplyRequest.Metadata.Should().NotContainKey(ChannelMetadataKeys.LarkSubjectEmployeeId);
+        var toolContext = AgentToolExecutionContextMapper.FromPayload(result.LlmReplyRequest.ToolContext);
+        toolContext.ExternalMetadata.Should().NotContainKey(ChannelMetadataKeys.LarkSubjectUserId);
+        toolContext.ExternalMetadata.Should().NotContainKey(ChannelMetadataKeys.LarkSubjectEmployeeId);
+    }
+
+    [Fact]
+    public async Task RunInboundAsync_ShouldFailOpen_WhenLarkSubjectLookupThrows()
+    {
+        var registrationQueryPort = BuildRegistrationQueryPort();
+        var adapter = new RecordingPlatformAdapter();
+        var nyxHandler = new ThrowingJsonHandler(new HttpRequestException("proxy unavailable"));
+        var runner = CreateRunner(registrationQueryPort, adapter, nyxHandler: nyxHandler);
+
+        var result = await runner.RunInboundAsync(
+            BuildInboundActivity(
+                "hello",
+                "msg-lark-subject-proxy-throws",
+                transportExtras: new TransportExtras
+                {
+                    NyxPlatform = "lark",
+                    NyxUserAccessToken = "user-token-1",
+                    NyxLarkUnionId = "on_union_1",
+                }),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.LlmReplyRequest.Should().NotBeNull();
+        result.LlmReplyRequest!.Metadata.Should().NotContainKey(ChannelMetadataKeys.LarkSubjectUserId);
+        result.LlmReplyRequest.Metadata.Should().NotContainKey(ChannelMetadataKeys.LarkSubjectEmployeeId);
+        var toolContext = AgentToolExecutionContextMapper.FromPayload(result.LlmReplyRequest.ToolContext);
+        toolContext.ExternalMetadata.Should().NotContainKey(ChannelMetadataKeys.LarkSubjectUserId);
+        toolContext.ExternalMetadata.Should().NotContainKey(ChannelMetadataKeys.LarkSubjectEmployeeId);
+    }
+
+    [Fact]
+    public async Task RunInboundAsync_ShouldPropagateCancellation_WhenLarkSubjectLookupIsCanceled()
+    {
+        var registrationQueryPort = BuildRegistrationQueryPort();
+        var adapter = new RecordingPlatformAdapter();
+        var nyxHandler = new RecordingJsonHandler(
+            """{"code":0,"data":{"user":{"user_id":"lark-user-1","employee_id":"emp-1"}}}""");
+        var runner = CreateRunner(registrationQueryPort, adapter, nyxHandler: nyxHandler);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var activity = BuildInboundActivity(
+            "hello",
+            "msg-lark-subject-canceled",
+            transportExtras: new TransportExtras
+            {
+                NyxPlatform = "lark",
+                NyxUserAccessToken = "user-token-1",
+                NyxLarkUnionId = "on_union_1",
+            });
+
+        var exception = await Record.ExceptionAsync(() => runner.RunInboundAsync(activity, cts.Token));
+        exception.Should().BeAssignableTo<OperationCanceledException>();
     }
 
     [Fact]
@@ -541,10 +686,10 @@ public sealed class ChannelConversationTurnRunnerTests
             CancellationToken.None);
 
         result.Success.Should().BeTrue();
-        nyxHandler.Requests.Should().ContainSingle();
-        nyxHandler.Requests[0].Path.Should().Be("/api/v1/proxy/s/api-lark-bot/open-apis/im/v1/messages/om_123/reactions");
-        nyxHandler.Requests[0].Authorization.Should().Be("Bearer user-token-1");
-        nyxHandler.Requests[0].Body.Should().Contain("\"emoji_type\":\"Typing\"");
+        var reactionRequest = nyxHandler.Requests.Should().Contain(request =>
+            request.Path == "/api/v1/proxy/s/api-lark-bot/open-apis/im/v1/messages/om_123/reactions").Subject;
+        reactionRequest.Authorization.Should().Be("Bearer user-token-1");
+        reactionRequest.Body.Should().Contain("\"emoji_type\":\"Typing\"");
     }
 
     [Fact]
@@ -552,7 +697,10 @@ public sealed class ChannelConversationTurnRunnerTests
     {
         var registrationQueryPort = BuildRegistrationQueryPort();
         var adapter = new RecordingPlatformAdapter();
-        var nyxHandler = new BlockingJsonHandler("""{"code":0,"data":{}}""");
+        var nyxHandler = new TypingReactionGateHandler(
+            expectedTotalCallCount: 2,
+            """{"code":0,"data":{}}""",
+            """{"code":0,"data":{}}""");
         var runner = CreateRunner(registrationQueryPort, adapter, nyxHandler: nyxHandler);
 
         var runTask = runner.RunInboundAsync(
@@ -567,14 +715,15 @@ public sealed class ChannelConversationTurnRunnerTests
                 }),
             CancellationToken.None);
 
-        await nyxHandler.Started.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await nyxHandler.TypingPostStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
         runTask.IsCompleted.Should().BeTrue();
 
         var result = await runTask;
         result.Success.Should().BeTrue();
         result.LlmReplyRequest.Should().NotBeNull();
 
-        nyxHandler.Release.TrySetResult();
+        nyxHandler.ReleaseTypingPost.TrySetResult();
+        await nyxHandler.Completed.Task.WaitAsync(TimeSpan.FromSeconds(1));
     }
 
     [Fact]
@@ -597,7 +746,9 @@ public sealed class ChannelConversationTurnRunnerTests
             CancellationToken.None);
 
         result.Success.Should().BeTrue();
-        nyxHandler.Requests.Should().BeEmpty();
+        nyxHandler.Requests.Should().ContainSingle();
+        nyxHandler.Requests[0].Path.Should().Be(
+            "/api/v1/proxy/s/api-lark-bot/open-apis/contact/v3/users/ou_user_1?user_id_type=open_id");
     }
 
     [Fact]
@@ -2003,6 +2154,8 @@ public sealed class ChannelConversationTurnRunnerTests
         var registrationQueryPort = BuildRegistrationQueryPort();
         var adapter = new RecordingPlatformAdapter();
         var relayHandler = new RecordingJsonHandler("""{"message_id":"relay-agent-builder-reply"}""");
+        var nyxHandler = new RecordingJsonHandler(
+            """{"code":0,"data":{"user":{"user_id":"lark-user-direct","employee_id":"emp-direct"}}}""");
         var callerScopeResolver = new CapturingCallerScopeResolver();
         var services = new ServiceCollection()
             .AddSingleton(Substitute.For<IUserAgentCatalogQueryPort>())
@@ -2021,7 +2174,8 @@ public sealed class ChannelConversationTurnRunnerTests
             registrationQueryPort,
             adapter,
             services,
-            relayHandler: relayHandler);
+            relayHandler: relayHandler,
+            nyxHandler: nyxHandler);
 
         var result = await runner.RunInboundAsync(
             BuildInboundActivity(
@@ -2038,6 +2192,7 @@ public sealed class ChannelConversationTurnRunnerTests
                 {
                     NyxPlatform = "lark",
                     NyxUserAccessToken = string.Empty,
+                    NyxLarkUnionId = "on_union_direct",
                 }),
             RelayRuntimeContext(
                 "corr-runtime-token-1",
@@ -2060,6 +2215,14 @@ public sealed class ChannelConversationTurnRunnerTests
             .Should().Be("runtime-user-token-1");
         callerScopeResolver.CapturedMetadata[ChannelMetadataKeys.MessageId]
             .Should().Be("msg-runtime-token-agent-builder-1");
+        callerScopeResolver.CapturedMetadata[ChannelMetadataKeys.LarkSubjectUserId]
+            .Should().Be("lark-user-direct");
+        callerScopeResolver.CapturedMetadata[ChannelMetadataKeys.LarkSubjectEmployeeId]
+            .Should().Be("emp-direct");
+        nyxHandler.Requests.Should().ContainSingle();
+        nyxHandler.Requests[0].Path.Should().Be(
+            "/api/v1/proxy/s/api-lark-bot/open-apis/contact/v3/users/on_union_direct?user_id_type=union_id");
+        nyxHandler.Requests[0].Authorization.Should().Be("Bearer runtime-user-token-1");
         AgentToolRequestContext.Current.Should().BeNull();
     }
 
@@ -3909,7 +4072,11 @@ public sealed class ChannelConversationTurnRunnerTests
 
     private static IChannelBotRegistrationQueryPort BuildRegistrationQueryPort()
     {
-        var registration = BuildRegistrationEntry();
+        return BuildRegistrationQueryPort(BuildRegistrationEntry());
+    }
+
+    private static IChannelBotRegistrationQueryPort BuildRegistrationQueryPort(ChannelBotRegistrationEntry registration)
+    {
         var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
         queryPort.GetAsync(registration.Id, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(registration));
@@ -4039,17 +4206,23 @@ public sealed class ChannelConversationTurnRunnerTests
             var current = AgentToolRequestContext.Current;
             CapturedMetadata = current is null
                 ? null
-                : new Dictionary<string, string>(StringComparer.Ordinal)
-                {
-                    [LLMRequestMetadataKeys.NyxIdAccessToken] = current.Credentials.NyxIdAccessToken ?? string.Empty,
-                    [LLMRequestMetadataKeys.NyxIdOrgToken] = current.Credentials.NyxIdOrgToken ?? string.Empty,
-                    [ChannelMetadataKeys.MessageId] = current.Channel.MessageId ?? string.Empty,
-                };
+                : CaptureMetadata(current);
             return Task.FromResult<OwnerScope?>(OwnerScope.ForChannel(
                 "nyx-user-1",
                 "lark",
                 "scope-1",
                 "ou_user_1"));
+        }
+
+        private static IReadOnlyDictionary<string, string> CaptureMetadata(AgentToolExecutionContext current)
+        {
+            var captured = new Dictionary<string, string>(current.ExternalMetadata, StringComparer.Ordinal)
+            {
+                [LLMRequestMetadataKeys.NyxIdAccessToken] = current.Credentials.NyxIdAccessToken ?? string.Empty,
+                [LLMRequestMetadataKeys.NyxIdOrgToken] = current.Credentials.NyxIdOrgToken ?? string.Empty,
+                [ChannelMetadataKeys.MessageId] = current.Channel.MessageId ?? string.Empty,
+            };
+            return captured;
         }
     }
 
@@ -4176,6 +4349,14 @@ public sealed class ChannelConversationTurnRunnerTests
             await Release.Task.WaitAsync(cancellationToken);
             return await base.SendAsync(request, cancellationToken);
         }
+    }
+
+    private sealed class ThrowingJsonHandler(Exception exception) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromException<HttpResponseMessage>(exception);
     }
 
     // Parks the FIRST request (the typing POST that fires from RunInboundAsync) on a

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
@@ -631,6 +631,44 @@ public sealed class ConversationReplyGeneratorTests
     }
 
     [Fact]
+    public async Task GenerateReplyAsync_WithChannelContextMiddleware_IncludesLarkSubjectIdsSeparatelyFromOperatorIds()
+    {
+        var providerFactory = new RecordingProviderFactory();
+        var generator = new NyxIdConversationReplyGenerator(
+            providerFactory,
+            llmMiddlewares: [new ChannelContextMiddleware(NullLogger<ChannelContextMiddleware>.Instance)]);
+
+        var reply = await generator.GenerateReplyAsync(
+            new ChatActivity
+            {
+                Id = "msg-lark-subject-context",
+                ChannelId = ChannelId.From("lark"),
+                Conversation = new ConversationReference { CanonicalKey = "lark:group:oc_1" },
+                Content = new MessageContent { Text = "hello" },
+            },
+            new Dictionary<string, string>
+            {
+                [ChannelMetadataKeys.Platform] = "lark",
+                [ChannelMetadataKeys.ChatType] = "group",
+                [ChannelMetadataKeys.SenderId] = "ou_sender_1",
+                [ChannelMetadataKeys.ConversationId] = "oc_1",
+                [ChannelMetadataKeys.LarkSubjectUserId] = "lark-subject-user-1",
+                [ChannelMetadataKeys.LarkSubjectEmployeeId] = "employee-1",
+            },
+            streamingSink: null,
+            CancellationToken.None);
+
+        reply.Text.Should().Be("ok");
+        var systemPrompt = providerFactory.Requests.Should().ContainSingle().Subject
+            .Messages.First(message => message.Role == "system").Content;
+        systemPrompt.Should().Contain("subject_user_id: \"lark-subject-user-1\"");
+        systemPrompt.Should().Contain("subject_employee_id: \"employee-1\"");
+        systemPrompt.Should().Contain("operator_user_id: \"\"");
+        systemPrompt.Should().Contain("operator_open_id: \"\"");
+        systemPrompt.Should().NotContain("operator_user_id: \"lark-subject-user-1\"");
+    }
+
+    [Fact]
     public async Task GenerateReplyAsync_AggregatesUsageAndFinishReasonAtActorEdge()
     {
         // ADR-0021 §6 / canon §8: the actor-edge closeout returned by GenerateReplyAsync


### PR DESCRIPTION
## 摘要

解析并注入 Lark 普通消息请求方的稳定身份元数据，保持 metadata-only 边界：新增 `channel.lark.subject_user_id` / `channel.lark.subject_employee_id`，通过现有 NyxID proxy contact lookup 获取，不新增 typed subject identity、resolver port、缓存、actor state、projection 或外部仓库改动。

## 范围

- `ChannelMetadataKeys` 新增 subject user/employee metadata key。
- `ChannelConversationTurnRunner` 在 Lark/Feishu ordinary message 路径中通过 union_id 优先、open_id fallback 查询 Lark contact，并 fail-open 注入 metadata。
- deferred LLM reply 与 direct AgentBuilder tool context 都携带 subject metadata。
- channel context prompt 显示 subject_user_id / subject_employee_id，和 operator_* 字段保持分离。
- 增加 direct/deferred propagation、fail-open、cancellation、context rendering 相关测试。

## 验证

- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo`：rebase 后 1382 passed。
- `bash tools/ci/test_stability_guards.sh`：passed。
- `git diff --check origin/feature/integrate...HEAD`：passed。
- clean witness：`.refactor-loop/logs/witness-issue-2179-log-evidence-only.log` 以 `EXIT=0` 结束，并输出 `IMPLEMENT_DONE:issue-2179:ok`。

Closes #2179

⟦AI:AUTO-LOOP⟧
