### PR TITLE
Implement NyxID proxy file artifact downloads

### DIFF
--- a/docs/canon/workflow-runtime.md
+++ b/docs/canon/workflow-runtime.md
@@ -134,6 +134,18 @@ Workflow runtime owns the canonical connected-service resource fetch use case. T
 - Downloaded bytes must enter workflow storage only through `IWorkflowFileIngressPort` with `WorkflowFileSourceKind.ConnectedServiceResource`; workflow commands, actor state, readmodels, logs, and tool results must not carry raw bytes or base64.
 - The tool result is a sanitized `WorkflowFileRef` plus route facts. It does not expose provider response bodies, base64, or downloaded content.
 
+### NyxID Proxy File Artifacts
+
+`nyxid_proxy(response_mode=file_artifact)` is the only v1 public NyxID proxy binary download mode for workflow-managed runs. Missing `response_mode` and explicit `text` keep the existing string proxy behavior.
+
+运行边界：
+
+- `NyxIdProxyTool` owns response-mode parsing. Invalid modes fail closed; v1 does not expose `file_artifact_put`、`nyxid_binary_download`、provider-specific global download tools、`binary_base64` or `data_uri`.
+- `response_mode=file_artifact` requires `GET`, no request body, a managed workflow runtime parent from typed `AgentToolRequestContext.Current.WorkflowRuntime`, a caller scope, and a host-registered `INyxIdProxyFileArtifactIngress`.
+- The binary response is downloaded through `NyxIdApiClient.ProxyGetBinaryResponseAsync` with `ProxyFileArtifactMaxBytes` defaulting to 25 MiB and capped at 100 MiB. Content-length and streaming reads are bounded before workflow ingress.
+- Persistence only goes through `IWorkflowFileIngressPort` with `WorkflowFileSourceKind.ConnectedServiceResource`; `nyxid_proxy` does not stage process-local handles or persist raw bytes itself.
+- Success and failure results are structured JSON with `success`、`response_mode`、bounded source diagnostics, and a sanitized `WorkflowFileRef` projection on success. Results must not include raw bytes, base64, data URI, provider response bodies, or durable byte state.
+
 ### Workflow File Artifact Lifecycle
 
 Workflow file artifacts use narrow ports with separate responsibilities:

--- a/src/Aevatar.AI.ToolProviders.NyxId/INyxIdProxyFileArtifactIngress.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/INyxIdProxyFileArtifactIngress.cs
@@ -1,0 +1,10 @@
+using Aevatar.Workflow.Application.Abstractions.Runs;
+
+namespace Aevatar.AI.ToolProviders.NyxId;
+
+public interface INyxIdProxyFileArtifactIngress
+{
+    ValueTask<WorkflowFileIngressResult> IngestAsync(
+        WorkflowFileIngressRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdAgentToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdAgentToolSource.cs
@@ -15,16 +15,19 @@ public sealed class NyxIdAgentToolSource : IAgentToolSource
     private readonly NyxIdApiClient _client;
     private readonly ILogger _logger;
     private readonly bool _toolApprovalHandlerAvailable;
+    private readonly INyxIdProxyFileArtifactIngress? _fileArtifactIngress;
 
     public NyxIdAgentToolSource(
         NyxIdToolOptions options,
         NyxIdApiClient client,
         IToolApprovalHandler? approvalHandler = null,
+        INyxIdProxyFileArtifactIngress? fileArtifactIngress = null,
         ILogger<NyxIdAgentToolSource>? logger = null)
     {
         _options = options;
         _client = client;
         _toolApprovalHandlerAvailable = approvalHandler is not null;
+        _fileArtifactIngress = fileArtifactIngress;
         _logger = logger ?? NullLogger<NyxIdAgentToolSource>.Instance;
     }
 
@@ -48,7 +51,7 @@ public sealed class NyxIdAgentToolSource : IAgentToolSource
             new NyxIdSessionsTool(_client),
             new NyxIdCatalogTool(_client),
             new NyxIdServicesTool(_client),
-            new NyxIdProxyTool(_client, _logger),
+            new NyxIdProxyTool(_client, _logger, _fileArtifactIngress, _options.EffectiveProxyFileArtifactMaxBytes),
             new NyxIdCodeExecuteTool(_client, _logger),
             new NyxIdApiKeysTool(_client),
             new NyxIdNodesTool(_client),

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiClient.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiClient.cs
@@ -296,6 +296,21 @@ public sealed class NyxIdApiClient : IDisposable
         string slug,
         string path,
         Dictionary<string, string>? extraHeaders,
+        CancellationToken ct) =>
+        await ProxyGetBinaryResponseAsync(
+            token,
+            slug,
+            path,
+            extraHeaders,
+            NyxIdToolOptions.DefaultProxyFileArtifactMaxBytes,
+            ct);
+
+    public async Task<NyxIdProxyBinaryResponse> ProxyGetBinaryResponseAsync(
+        string token,
+        string slug,
+        string path,
+        Dictionary<string, string>? extraHeaders,
+        long maxBytes,
         CancellationToken ct)
     {
         var baseUrl = GetBaseUrl();
@@ -309,7 +324,7 @@ public sealed class NyxIdApiClient : IDisposable
         if (!callerSpecifiedUserAgent)
             request.Headers.TryAddWithoutValidation(UserAgentHeaderName, DefaultProxyUserAgent);
 
-        return await SendBinaryResponseAsync(request, ct);
+        return await SendBinaryResponseAsync(request, NormalizeProxyFileArtifactMaxBytes(maxBytes), ct);
     }
 
     // ─── SSH ───
@@ -950,7 +965,10 @@ public sealed class NyxIdApiClient : IDisposable
         }
     }
 
-    private async Task<NyxIdProxyBinaryResponse> SendBinaryResponseAsync(HttpRequestMessage request, CancellationToken ct)
+    private async Task<NyxIdProxyBinaryResponse> SendBinaryResponseAsync(
+        HttpRequestMessage request,
+        long maxBytes,
+        CancellationToken ct)
     {
         try
         {
@@ -958,12 +976,15 @@ public sealed class NyxIdApiClient : IDisposable
                 request,
                 HttpCompletionOption.ResponseHeadersRead,
                 ct);
-            var content = await response.Content.ReadAsByteArrayAsync(ct);
             var contentType = response.Content.Headers.ContentType?.ToString();
             var fileName = ResolveContentDispositionFileName(response);
 
             if (!response.IsSuccessStatusCode)
             {
+                var errorContent = await ReadBoundedContentAsync(
+                    response.Content,
+                    Math.Min(maxBytes, 64 * 1024),
+                    ct);
                 _logger.LogWarning(
                     "NyxID binary proxy request failed: {Method} {Url} -> {Status}",
                     request.Method, request.RequestUri, (int)response.StatusCode);
@@ -972,13 +993,43 @@ public sealed class NyxIdApiClient : IDisposable
                     [],
                     contentType,
                     fileName,
-                    Detail: Encoding.UTF8.GetString(content),
+                    Detail: Encoding.UTF8.GetString(errorContent.Content),
+                    HttpStatus: (int)response.StatusCode);
+            }
+
+            if (response.Content.Headers.ContentLength is { } contentLength &&
+                contentLength > maxBytes)
+            {
+                _logger.LogWarning(
+                    "NyxID binary proxy response content length exceeded max bytes: {Method} {Url} length={Length} max={MaxBytes}",
+                    request.Method, request.RequestUri, contentLength, maxBytes);
+                return new NyxIdProxyBinaryResponse(
+                    false,
+                    [],
+                    contentType,
+                    fileName,
+                    Detail: "content_length_exceeds_max_bytes",
+                    HttpStatus: (int)response.StatusCode);
+            }
+
+            var content = await ReadBoundedContentAsync(response.Content, maxBytes, ct);
+            if (content.Exceeded)
+            {
+                _logger.LogWarning(
+                    "NyxID binary proxy response exceeded max bytes while reading: {Method} {Url} max={MaxBytes}",
+                    request.Method, request.RequestUri, maxBytes);
+                return new NyxIdProxyBinaryResponse(
+                    false,
+                    [],
+                    contentType,
+                    fileName,
+                    Detail: "content_exceeds_max_bytes",
                     HttpStatus: (int)response.StatusCode);
             }
 
             return new NyxIdProxyBinaryResponse(
                 true,
-                content,
+                content.Content,
                 contentType,
                 fileName,
                 HttpStatus: (int)response.StatusCode);
@@ -1013,6 +1064,36 @@ public sealed class NyxIdApiClient : IDisposable
         return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
     }
 
+    private static long NormalizeProxyFileArtifactMaxBytes(long maxBytes) =>
+        maxBytes <= 0
+            ? NyxIdToolOptions.DefaultProxyFileArtifactMaxBytes
+            : Math.Min(maxBytes, NyxIdToolOptions.HardProxyFileArtifactMaxBytes);
+
+    private static async Task<BoundedBinaryContent> ReadBoundedContentAsync(
+        HttpContent content,
+        long maxBytes,
+        CancellationToken ct)
+    {
+        await using var stream = await content.ReadAsStreamAsync(ct);
+        using var memory = new MemoryStream();
+        var buffer = new byte[81920];
+        long total = 0;
+        while (true)
+        {
+            var read = await stream.ReadAsync(buffer, ct);
+            if (read == 0)
+                break;
+
+            total += read;
+            if (total > maxBytes)
+                return new BoundedBinaryContent([], Exceeded: true);
+
+            memory.Write(buffer, 0, read);
+        }
+
+        return new BoundedBinaryContent(memory.ToArray(), Exceeded: false);
+    }
+
     private static string EscapeJsonString(string value) =>
         System.Text.Json.JsonSerializer.Serialize(value);
 
@@ -1027,6 +1108,8 @@ public sealed class NyxIdApiClient : IDisposable
         detail = string.Empty;
         return false;
     }
+
+    private readonly record struct BoundedBinaryContent(byte[] Content, bool Exceeded);
 
     private static bool TryParseStructuredErrorEnvelope(string response, out NyxIdApiErrorEnvelope error)
     {

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdProxyWorkflowFileArtifactIngress.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdProxyWorkflowFileArtifactIngress.cs
@@ -1,0 +1,15 @@
+using Aevatar.Workflow.Application.Abstractions.Runs;
+
+namespace Aevatar.AI.ToolProviders.NyxId;
+
+public sealed class NyxIdProxyWorkflowFileArtifactIngress(IWorkflowFileIngressPort fileIngress)
+    : INyxIdProxyFileArtifactIngress
+{
+    private readonly IWorkflowFileIngressPort _fileIngress =
+        fileIngress ?? throw new ArgumentNullException(nameof(fileIngress));
+
+    public ValueTask<WorkflowFileIngressResult> IngestAsync(
+        WorkflowFileIngressRequest request,
+        CancellationToken cancellationToken = default) =>
+        _fileIngress.IngestAsync(request, cancellationToken);
+}

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdToolOptions.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdToolOptions.cs
@@ -3,6 +3,9 @@ namespace Aevatar.AI.ToolProviders.NyxId;
 /// <summary>NyxID tool provider configuration.</summary>
 public sealed class NyxIdToolOptions
 {
+    public const long DefaultProxyFileArtifactMaxBytes = 25L * 1024 * 1024;
+    public const long HardProxyFileArtifactMaxBytes = 100L * 1024 * 1024;
+
     /// <summary>NyxID API base URL (e.g. https://nyx-api.chrono-ai.fun).</summary>
     public string? BaseUrl { get; set; }
 
@@ -23,4 +26,14 @@ public sealed class NyxIdToolOptions
     /// identity policy already define the trust boundary.
     /// </summary>
     public bool BypassSshExecApproval { get; set; }
+
+    /// <summary>
+    /// Maximum bytes accepted by nyxid_proxy response_mode=file_artifact.
+    /// </summary>
+    public long ProxyFileArtifactMaxBytes { get; set; } = DefaultProxyFileArtifactMaxBytes;
+
+    public long EffectiveProxyFileArtifactMaxBytes =>
+        ProxyFileArtifactMaxBytes <= 0
+            ? DefaultProxyFileArtifactMaxBytes
+            : Math.Min(ProxyFileArtifactMaxBytes, HardProxyFileArtifactMaxBytes);
 }

--- a/src/Aevatar.AI.ToolProviders.NyxId/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/ServiceCollectionExtensions.cs
@@ -34,6 +34,13 @@ public static class ServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IWorkflowConnectedServiceFileSubmitAdapter,
             NyxIdWorkflowConnectedServiceFileSubmitAdapter>());
+        if (services.Any(static descriptor => descriptor.ServiceType == typeof(IWorkflowFileIngressPort)))
+        {
+            services.TryAddSingleton<INyxIdProxyFileArtifactIngress>(sp =>
+                new NyxIdProxyWorkflowFileArtifactIngress(
+                    sp.GetRequiredService<IWorkflowFileIngressPort>()));
+        }
+
         services.TryAddEnumerable(
             ServiceDescriptor.Transient<IAgentToolSource, NyxIdAgentToolSource>());
 

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdProxyTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdProxyTool.cs
@@ -186,7 +186,7 @@ public sealed class NyxIdProxyTool : IAgentTool
         if (!string.Equals(method.Trim(), "GET", StringComparison.OrdinalIgnoreCase))
             return FileArtifactError("file_artifact_requires_get", "response_mode=file_artifact only supports GET.");
 
-        if (HasRequestBody(args, body))
+        if (HasRequestBody(args))
             return FileArtifactError("file_artifact_disallows_body", "response_mode=file_artifact does not accept a request body.");
 
         if (_fileArtifactIngress == null)
@@ -496,7 +496,7 @@ public sealed class NyxIdProxyTool : IAgentTool
         return null;
     }
 
-    private static bool HasRequestBody(ToolArgs args, string? body) =>
+    private static bool HasRequestBody(ToolArgs args) =>
         args.Has("body");
 
     private static long NormalizeMaxBytes(long maxBytes) =>

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdProxyTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdProxyTool.cs
@@ -1,20 +1,40 @@
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.Workflow.Application.Abstractions.Runs;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Aevatar.AI.ToolProviders.NyxId.Tools;
 
 /// <summary>Tool to make proxied requests to downstream services through NyxID.</summary>
 public sealed class NyxIdProxyTool : IAgentTool
 {
+    private const string TextResponseMode = "text";
+    private const string FileArtifactResponseMode = "file_artifact";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
     private readonly NyxIdApiClient _client;
     private readonly ILogger _logger;
+    private readonly INyxIdProxyFileArtifactIngress? _fileArtifactIngress;
+    private readonly long _fileArtifactMaxBytes;
 
-    public NyxIdProxyTool(NyxIdApiClient client, ILogger? logger = null)
+    public NyxIdProxyTool(
+        NyxIdApiClient client,
+        ILogger? logger = null,
+        INyxIdProxyFileArtifactIngress? fileArtifactIngress = null,
+        long fileArtifactMaxBytes = NyxIdToolOptions.DefaultProxyFileArtifactMaxBytes)
     {
         _client = client;
         _logger = logger ?? NullLogger.Instance;
+        _fileArtifactIngress = fileArtifactIngress;
+        _fileArtifactMaxBytes = NormalizeMaxBytes(fileArtifactMaxBytes);
     }
 
     public string Name => "nyxid_proxy";
@@ -59,6 +79,11 @@ public sealed class NyxIdProxyTool : IAgentTool
               "type": "object",
               "additionalProperties": { "type": "string" },
               "description": "Additional HTTP headers"
+            },
+            "response_mode": {
+              "type": "string",
+              "enum": ["text", "file_artifact"],
+              "description": "Response handling mode. Omit or use text for the existing JSON/string response. Use file_artifact only for GET binary downloads in a managed workflow run."
             }
           }
         }
@@ -69,11 +94,6 @@ public sealed class NyxIdProxyTool : IAgentTool
         // Refactor (iter25/cluster-025-nyxid-tool-discovery-actor-cache):
         //   Old pattern: NyxIdSpecCatalog + SpecFetchToken + IServiceDiscoveryCache 在仓库内建第二 catalog(NyxID 真实源的影子)
         //   New principle: NyxID 是唯一真实源;删除 in-process catalog 假权威面; routing 和 spec hints 请求时读取 live NyxID surface;保留 typed tools + live nyxid_proxy
-        var token = AgentToolRequestContext.NyxIdAccessToken;
-        var orgToken = AgentToolRequestContext.NyxIdOrgToken;
-        if (string.IsNullOrWhiteSpace(token))
-            return """{"error":"No NyxID access token available. User must be authenticated."}""";
-
         _logger.LogDebug("[nyxid_proxy] Raw arguments: {Args}", argumentsJson);
 
         var args = ToolArgs.Parse(argumentsJson);
@@ -81,6 +101,19 @@ public sealed class NyxIdProxyTool : IAgentTool
         {
             _logger.LogWarning("[nyxid_proxy] Argument parse failed: {Error}, raw={Raw}", args.ParseError, args.Raw);
             return $"{{\"error\":\"Failed to parse tool arguments\",\"detail\":{System.Text.Json.JsonSerializer.Serialize(args.ParseError)},\"received\":{System.Text.Json.JsonSerializer.Serialize(args.Raw)}}}";
+        }
+
+        var responseMode = ResolveResponseMode(args.Str("response_mode"));
+        if (responseMode == null)
+            return FileArtifactError("invalid_response_mode", "response_mode must be omitted, text, or file_artifact.");
+
+        var token = AgentToolRequestContext.NyxIdAccessToken;
+        var orgToken = AgentToolRequestContext.NyxIdOrgToken;
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return responseMode == FileArtifactResponseMode
+                ? FileArtifactError("missing_nyxid_access_token", "No NyxID access token available. User must be authenticated.")
+                : """{"error":"No NyxID access token available. User must be authenticated."}""";
         }
 
         var slug = args.Str("slug") ?? args.Str("service");
@@ -92,6 +125,9 @@ public sealed class NyxIdProxyTool : IAgentTool
         // No slug → discover mode: merge services from both tokens
         if (string.IsNullOrWhiteSpace(slug))
         {
+            if (responseMode == FileArtifactResponseMode)
+                return FileArtifactError("file_artifact_requires_slug", "response_mode=file_artifact requires slug.");
+
             _logger.LogInformation("[nyxid_proxy] No slug provided, returning service discovery. raw={Raw}", args.Raw);
             return await DiscoverMergedServicesAsync(token, orgToken, ct);
         }
@@ -99,7 +135,24 @@ public sealed class NyxIdProxyTool : IAgentTool
         if (string.IsNullOrWhiteSpace(path))
         {
             _logger.LogWarning("[nyxid_proxy] Missing path. slug={Slug}, raw={Raw}", slug, args.Raw);
+            if (responseMode == FileArtifactResponseMode)
+                return FileArtifactError("file_artifact_requires_path", "response_mode=file_artifact requires path.");
+
             return $"{{\"error\":\"'path' is required when 'slug' is provided\",\"received\":{args.Raw}}}";
+        }
+
+        if (responseMode == FileArtifactResponseMode)
+        {
+            return await ExecuteFileArtifactAsync(
+                token,
+                orgToken,
+                slug,
+                path,
+                method,
+                args,
+                body,
+                headers,
+                ct);
         }
 
         // Resolve which token owns the target service: user token first, fallback to org token
@@ -117,6 +170,102 @@ public sealed class NyxIdProxyTool : IAgentTool
         }
 
         return result;
+    }
+
+    private async Task<string> ExecuteFileArtifactAsync(
+        string token,
+        string? orgToken,
+        string slug,
+        string path,
+        string method,
+        ToolArgs args,
+        string? body,
+        Dictionary<string, string>? headers,
+        CancellationToken ct)
+    {
+        if (!string.Equals(method.Trim(), "GET", StringComparison.OrdinalIgnoreCase))
+            return FileArtifactError("file_artifact_requires_get", "response_mode=file_artifact only supports GET.");
+
+        if (HasRequestBody(args, body))
+            return FileArtifactError("file_artifact_disallows_body", "response_mode=file_artifact does not accept a request body.");
+
+        if (_fileArtifactIngress == null)
+            return FileArtifactError("file_artifact_ingress_unavailable", "Host has not registered workflow file artifact ingress.");
+
+        var context = AgentToolRequestContext.Current;
+        var workflowRuntime = context?.WorkflowRuntime ?? AgentWorkflowRuntimeContext.Empty;
+        var callerScopeId = Normalize(context?.Caller.ScopeId);
+        var ownerRunId = Normalize(workflowRuntime.ParentRunId);
+        if (!workflowRuntime.HasManagedParent || callerScopeId == null || ownerRunId == null)
+            return FileArtifactError("managed_workflow_context_required", "response_mode=file_artifact requires a managed workflow runtime context and caller scope.");
+
+        var effectiveToken = await ResolveTokenForServiceAsync(token, orgToken, slug, ct);
+        _logger.LogInformation(
+            "[nyxid_proxy] GET file_artifact slug={Slug} path={Path} maxBytes={MaxBytes} tokenSource={Source}",
+            slug,
+            path,
+            _fileArtifactMaxBytes,
+            effectiveToken == token ? "user" : "org");
+
+        var response = await _client.ProxyGetBinaryResponseAsync(
+            effectiveToken,
+            slug,
+            path,
+            headers,
+            _fileArtifactMaxBytes,
+            ct);
+
+        if (!response.Succeeded)
+        {
+            var error = response.Detail switch
+            {
+                "content_length_exceeds_max_bytes" => "file_artifact_too_large",
+                "content_exceeds_max_bytes" => "file_artifact_too_large",
+                _ => "provider_binary_download_failed",
+            };
+            var detail = error == "file_artifact_too_large"
+                ? response.Detail ?? "content_exceeds_max_bytes"
+                : "NyxID binary proxy request failed.";
+            return FileArtifactError(
+                error,
+                detail,
+                response.HttpStatus,
+                response.ContentType);
+        }
+
+        if (response.Content.Length == 0)
+            return FileArtifactError("empty_file_artifact", "NyxID binary proxy response was empty.", response.HttpStatus, response.ContentType);
+
+        WorkflowFileIngressResult ingressResult;
+        try
+        {
+            ingressResult = await _fileArtifactIngress.IngestAsync(new WorkflowFileIngressRequest(
+                response.Content,
+                WorkflowFileSourceKind.ConnectedServiceResource,
+                SourceMessageId: $"nyxid_proxy:{slug}",
+                SourceResourceKey: path,
+                FileName: response.FileName,
+                MediaType: response.ContentType,
+                OwnerRunId: ownerRunId,
+                OwnerScopeId: callerScopeId), ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "[nyxid_proxy] File artifact ingress failed. slug={Slug} path={Path}", slug, path);
+            return FileArtifactError("artifact_ingress_failed", "Downloaded resource could not be stored.", response.HttpStatus, response.ContentType);
+        }
+
+        return JsonSerializer.Serialize(
+            new NyxIdProxyFileArtifactSuccess(
+                true,
+                FileArtifactResponseMode,
+                slug,
+                path,
+                response.HttpStatus,
+                response.ContentType,
+                response.FileName,
+                ToFileRefProjection(ingressResult.FileRef)),
+            JsonOptions);
     }
 
     // ─── Dual-token service discovery + routing ───
@@ -332,4 +481,93 @@ public sealed class NyxIdProxyTool : IAgentTool
         }
     }
 
+    private static string? ResolveResponseMode(string? raw)
+    {
+        var normalized = Normalize(raw);
+        if (normalized == null)
+            return TextResponseMode;
+
+        if (string.Equals(normalized, TextResponseMode, StringComparison.OrdinalIgnoreCase))
+            return TextResponseMode;
+
+        if (string.Equals(normalized, FileArtifactResponseMode, StringComparison.OrdinalIgnoreCase))
+            return FileArtifactResponseMode;
+
+        return null;
+    }
+
+    private static bool HasRequestBody(ToolArgs args, string? body) =>
+        args.Has("body");
+
+    private static long NormalizeMaxBytes(long maxBytes) =>
+        maxBytes <= 0
+            ? NyxIdToolOptions.DefaultProxyFileArtifactMaxBytes
+            : Math.Min(maxBytes, NyxIdToolOptions.HardProxyFileArtifactMaxBytes);
+
+    private static string FileArtifactError(
+        string error,
+        string detail,
+        int httpStatus = 0,
+        string? sourceContentType = null) =>
+        JsonSerializer.Serialize(
+            new NyxIdProxyFileArtifactError(
+                false,
+                FileArtifactResponseMode,
+                error,
+                detail,
+                httpStatus == 0 ? null : httpStatus,
+                sourceContentType),
+            JsonOptions);
+
+    private static NyxIdProxyWorkflowFileRefProjection ToFileRefProjection(WorkflowFileRef fileRef) =>
+        new(
+            fileRef.FileId,
+            fileRef.ArtifactId,
+            fileRef.SourceKind.ToString(),
+            fileRef.SourceMessageId,
+            fileRef.SourceResourceKey,
+            fileRef.FileName,
+            fileRef.MediaType,
+            fileRef.SizeBytes,
+            fileRef.Sha256,
+            fileRef.CreatedAtUnixMs,
+            fileRef.ExpiresAtUnixMs,
+            fileRef.OwnerRunId,
+            fileRef.OwnerScopeId);
+
+    private static string? Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private sealed record NyxIdProxyFileArtifactSuccess(
+        bool Success,
+        string ResponseMode,
+        string Slug,
+        string Path,
+        int HttpStatus,
+        string? SourceContentType,
+        string? SourceFileName,
+        NyxIdProxyWorkflowFileRefProjection FileRef);
+
+    private sealed record NyxIdProxyFileArtifactError(
+        bool Success,
+        string ResponseMode,
+        string Error,
+        string Detail,
+        int? HttpStatus,
+        string? SourceContentType);
+
+    private sealed record NyxIdProxyWorkflowFileRefProjection(
+        string? FileId,
+        string? ArtifactId,
+        string SourceKind,
+        string? SourceMessageId,
+        string? SourceResourceKey,
+        string? FileName,
+        string? MediaType,
+        long SizeBytes,
+        string? Sha256,
+        long CreatedAtUnixMs,
+        long ExpiresAtUnixMs,
+        string? OwnerRunId,
+        string? OwnerScopeId);
 }

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -232,6 +232,8 @@ public static class MainnetHostBuilderExtensions
             else
                 o.EnableSshExecTool = true; // mainnet default: enabled (Lark bot needs it)
             o.BypassSshExecApproval = true; // mainnet Lark bot internal-only
+            if (long.TryParse(builder.Configuration["Aevatar:NyxId:ProxyFileArtifactMaxBytes"], out var maxBytes))
+                o.ProxyFileArtifactMaxBytes = maxBytes;
         });
         builder.Services.AddLarkTools(o =>
         {

--- a/src/workflow/Aevatar.Workflow.Host.Api/Program.cs
+++ b/src/workflow/Aevatar.Workflow.Host.Api/Program.cs
@@ -11,6 +11,7 @@
 
 using Aevatar.Bootstrap.Hosting;
 using Aevatar.GAgentService.Hosting.DependencyInjection;
+using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.Workflow.Extensions.Hosting;
 using Aevatar.Workflow.Host.Api;
 
@@ -23,6 +24,14 @@ builder.AddAevatarDefaultHost(
         options.EnableWebSockets = true;
     });
 builder.AddAevatarPlatform();
+builder.Services.AddNyxIdTools(options =>
+{
+    options.BaseUrl = builder.Configuration["Aevatar:NyxId:Authority"]
+                      ?? builder.Configuration["Cli:App:NyxId:Authority"]
+                      ?? builder.Configuration["Aevatar:Authentication:Authority"];
+    if (long.TryParse(builder.Configuration["Aevatar:NyxId:ProxyFileArtifactMaxBytes"], out var maxBytes))
+        options.ProxyFileArtifactMaxBytes = maxBytes;
+});
 builder.Services.AddScheduledDispatchCapability(builder.Configuration);
 builder.AddAevatarWorkflowObservability();
 

--- a/test/Aevatar.AI.Tests/NyxIdApiClientProxyBinaryTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdApiClientProxyBinaryTests.cs
@@ -163,6 +163,55 @@ public sealed class NyxIdApiClientProxyBinaryTests
     }
 
     [Fact]
+    public async Task ProxyGetBinaryResponseAsync_ShouldFailBeforeBufferingWhenContentLengthExceedsMaxBytes()
+    {
+        var handler = new CapturingHandler(
+            responseBody: [1, 2, 3, 4],
+            contentType: "application/octet-stream",
+            contentLength: 4);
+        var client = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example" },
+            new HttpClient(handler));
+
+        var response = await client.ProxyGetBinaryResponseAsync(
+            token: "token",
+            slug: "storage",
+            path: "files/export",
+            extraHeaders: null,
+            maxBytes: 3,
+            ct: CancellationToken.None);
+
+        response.Succeeded.Should().BeFalse();
+        response.Content.Should().BeEmpty();
+        response.Detail.Should().Be("content_length_exceeds_max_bytes");
+        response.HttpStatus.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task ProxyGetBinaryResponseAsync_ShouldFailWhenDownloadedContentExceedsMaxBytes()
+    {
+        var handler = new CapturingHandler(
+            responseBody: [1, 2, 3, 4],
+            contentType: "application/octet-stream");
+        var client = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example" },
+            new HttpClient(handler));
+
+        var response = await client.ProxyGetBinaryResponseAsync(
+            token: "token",
+            slug: "storage",
+            path: "files/export",
+            extraHeaders: null,
+            maxBytes: 3,
+            ct: CancellationToken.None);
+
+        response.Succeeded.Should().BeFalse();
+        response.Content.Should().BeEmpty();
+        response.Detail.Should().Be("content_exceeds_max_bytes");
+        response.HttpStatus.Should().Be(200);
+    }
+
+    [Fact]
     public async Task ProxyGetBinaryResponseAsync_ShouldReturnFailureWithoutBytesOnNonSuccess()
     {
         var handler = new CapturingHandler(
@@ -219,6 +268,7 @@ public sealed class NyxIdApiClientProxyBinaryTests
         private readonly string? _contentType;
         private readonly string? _contentDisposition;
         private readonly HttpStatusCode _statusCode;
+        private readonly long? _contentLength;
 
         public CapturingHandler(
             string responseBody,
@@ -231,12 +281,14 @@ public sealed class NyxIdApiClientProxyBinaryTests
             byte[] responseBody,
             string? contentType = null,
             string? contentDisposition = null,
-            HttpStatusCode statusCode = HttpStatusCode.OK)
+            HttpStatusCode statusCode = HttpStatusCode.OK,
+            long? contentLength = null)
         {
             _responseBody = responseBody;
             _contentType = contentType;
             _contentDisposition = contentDisposition;
             _statusCode = statusCode;
+            _contentLength = contentLength;
         }
 
         public List<CapturedRequest> Requests { get; } = [];
@@ -261,12 +313,16 @@ public sealed class NyxIdApiClientProxyBinaryTests
 
             var response = new HttpResponseMessage(_statusCode)
             {
-                Content = new ByteArrayContent(_responseBody),
+                Content = _contentLength.HasValue
+                    ? new ByteArrayContent(_responseBody)
+                    : new UnknownLengthByteArrayContent(_responseBody),
             };
             if (!string.IsNullOrWhiteSpace(_contentType))
                 response.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(_contentType);
             if (!string.IsNullOrWhiteSpace(_contentDisposition))
                 response.Content.Headers.ContentDisposition = ContentDispositionHeaderValue.Parse(_contentDisposition);
+            if (_contentLength.HasValue)
+                response.Content.Headers.ContentLength = _contentLength.Value;
 
             return response;
         }
@@ -280,4 +336,18 @@ public sealed class NyxIdApiClientProxyBinaryTests
         string? ContentTypeHeader,
         byte[] Body,
         IReadOnlyDictionary<string, string[]> Headers);
+
+    private sealed class UnknownLengthByteArrayContent(byte[] content) : HttpContent
+    {
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+        {
+            return stream.WriteAsync(content).AsTask();
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
+    }
 }

--- a/test/Aevatar.AI.Tests/NyxIdProxyToolFileArtifactTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdProxyToolFileArtifactTests.cs
@@ -179,6 +179,105 @@ public sealed class NyxIdProxyToolFileArtifactTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_WithFileArtifactResponseMode_ShouldReturnStructuredErrorWhenAccessTokenIsMissing()
+    {
+        var handler = new ProxyRecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"ok":true}""", Encoding.UTF8, "application/json"),
+        });
+        var ingress = new RecordingNyxIdProxyFileArtifactIngress();
+        var tool = CreateTool(handler, ingress);
+        var previous = AgentToolRequestContext.Current;
+        try
+        {
+            AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
+            {
+                Caller = new AgentToolCallerContext("scope-a", null, null),
+                WorkflowRuntime = new AgentWorkflowRuntimeContext(
+                    "workflow-run-actor",
+                    "run-a",
+                    "step-a",
+                    "run-a",
+                    1),
+            };
+
+            var result = await tool.ExecuteAsync(
+                """{"slug":"storage","path":"/reports/1","response_mode":"file_artifact"}""");
+
+            AssertFileArtifactError(
+                result,
+                "missing_nyxid_access_token",
+                "No NyxID access token available. User must be authenticated.");
+            handler.Requests.Should().BeEmpty();
+            ingress.Requests.Should().BeEmpty();
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = previous;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithFileArtifactResponseMode_ShouldRequireSlugBeforeProxyCall()
+    {
+        var handler = new ProxyRecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"ok":true}""", Encoding.UTF8, "application/json"),
+        });
+        var ingress = new RecordingNyxIdProxyFileArtifactIngress();
+        var tool = CreateTool(handler, ingress);
+        var previous = AgentToolRequestContext.Current;
+        try
+        {
+            AgentToolRequestContext.Current = BuildContext();
+
+            var result = await tool.ExecuteAsync(
+                """{"path":"/reports/1","response_mode":"file_artifact"}""");
+
+            AssertFileArtifactError(
+                result,
+                "file_artifact_requires_slug",
+                "response_mode=file_artifact requires slug.");
+            handler.Requests.Should().BeEmpty();
+            ingress.Requests.Should().BeEmpty();
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = previous;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithFileArtifactResponseMode_ShouldRequirePathBeforeProxyCall()
+    {
+        var handler = new ProxyRecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"ok":true}""", Encoding.UTF8, "application/json"),
+        });
+        var ingress = new RecordingNyxIdProxyFileArtifactIngress();
+        var tool = CreateTool(handler, ingress);
+        var previous = AgentToolRequestContext.Current;
+        try
+        {
+            AgentToolRequestContext.Current = BuildContext();
+
+            var result = await tool.ExecuteAsync(
+                """{"slug":"storage","response_mode":"file_artifact"}""");
+
+            AssertFileArtifactError(
+                result,
+                "file_artifact_requires_path",
+                "response_mode=file_artifact requires path.");
+            handler.Requests.Should().BeEmpty();
+            ingress.Requests.Should().BeEmpty();
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = previous;
+        }
+    }
+
+    [Fact]
     public async Task ExecuteAsync_WithFileArtifactResponseMode_ShouldRequireManagedWorkflowContextAndIngress()
     {
         var toolWithoutIngress = CreateTool(new ProxyRecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
@@ -225,6 +324,150 @@ public sealed class NyxIdProxyToolFileArtifactTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_WithFileArtifactResponseMode_ShouldMapTooLargeDownloadToStructuredError()
+    {
+        var handler = new ProxyRecordingHandler(_ =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent([1, 2, 3, 4]),
+            };
+            response.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/octet-stream");
+            response.Content.Headers.ContentLength = 4;
+            return response;
+        });
+        var ingress = new RecordingNyxIdProxyFileArtifactIngress();
+        var tool = CreateTool(handler, ingress, fileArtifactMaxBytes: 3);
+        var previous = AgentToolRequestContext.Current;
+        try
+        {
+            AgentToolRequestContext.Current = BuildContext();
+
+            var result = await tool.ExecuteAsync(
+                """{"slug":"storage","path":"/reports/1","response_mode":"file_artifact"}""");
+
+            AssertFileArtifactError(
+                result,
+                "file_artifact_too_large",
+                "content_length_exceeds_max_bytes",
+                expectedHttpStatus: 200,
+                expectedSourceContentType: "application/octet-stream");
+            handler.Requests.Should().ContainSingle();
+            ingress.Requests.Should().BeEmpty();
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = previous;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithFileArtifactResponseMode_ShouldMapProviderFailureToStructuredError()
+    {
+        var handler = new ProxyRecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.Forbidden)
+        {
+            Content = new StringContent("""{"error":"missing scope"}""", Encoding.UTF8, "application/json"),
+        });
+        var ingress = new RecordingNyxIdProxyFileArtifactIngress();
+        var tool = CreateTool(handler, ingress);
+        var previous = AgentToolRequestContext.Current;
+        try
+        {
+            AgentToolRequestContext.Current = BuildContext();
+
+            var result = await tool.ExecuteAsync(
+                """{"slug":"storage","path":"/reports/1","response_mode":"file_artifact"}""");
+
+            AssertFileArtifactError(
+                result,
+                "provider_binary_download_failed",
+                "NyxID binary proxy request failed.",
+                expectedHttpStatus: 403,
+                expectedSourceContentType: "application/json; charset=utf-8");
+            handler.Requests.Should().ContainSingle();
+            ingress.Requests.Should().BeEmpty();
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = previous;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithFileArtifactResponseMode_ShouldRejectEmptySuccessfulBinaryResponse()
+    {
+        var handler = new ProxyRecordingHandler(_ =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent([]),
+            };
+            response.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/octet-stream");
+            return response;
+        });
+        var ingress = new RecordingNyxIdProxyFileArtifactIngress();
+        var tool = CreateTool(handler, ingress);
+        var previous = AgentToolRequestContext.Current;
+        try
+        {
+            AgentToolRequestContext.Current = BuildContext();
+
+            var result = await tool.ExecuteAsync(
+                """{"slug":"storage","path":"/reports/1","response_mode":"file_artifact"}""");
+
+            AssertFileArtifactError(
+                result,
+                "empty_file_artifact",
+                "NyxID binary proxy response was empty.",
+                expectedHttpStatus: 200,
+                expectedSourceContentType: "application/octet-stream");
+            handler.Requests.Should().ContainSingle();
+            ingress.Requests.Should().BeEmpty();
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = previous;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithFileArtifactResponseMode_ShouldReturnStructuredErrorWhenIngressThrows()
+    {
+        var handler = new ProxyRecordingHandler(_ =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(Encoding.UTF8.GetBytes("downloaded bytes")),
+            };
+            response.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("text/csv");
+            return response;
+        });
+        var ingress = new RecordingNyxIdProxyFileArtifactIngress(new InvalidOperationException("store failed"));
+        var tool = CreateTool(handler, ingress);
+        var previous = AgentToolRequestContext.Current;
+        try
+        {
+            AgentToolRequestContext.Current = BuildContext();
+
+            var result = await tool.ExecuteAsync(
+                """{"slug":"storage","path":"/reports/1","response_mode":"file_artifact"}""");
+
+            AssertFileArtifactError(
+                result,
+                "artifact_ingress_failed",
+                "Downloaded resource could not be stored.",
+                expectedHttpStatus: 200,
+                expectedSourceContentType: "text/csv");
+            handler.Requests.Should().ContainSingle();
+            ingress.Requests.Should().ContainSingle();
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = previous;
+        }
+    }
+
+    [Fact]
     public async Task ExecuteAsync_WithInvalidResponseMode_ShouldFailClosedWithoutProxyCall()
     {
         var handler = new ProxyRecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
@@ -253,12 +496,37 @@ public sealed class NyxIdProxyToolFileArtifactTests
 
     private static NyxIdProxyTool CreateTool(
         ProxyRecordingHandler handler,
-        INyxIdProxyFileArtifactIngress? ingress = null)
+        INyxIdProxyFileArtifactIngress? ingress = null,
+        long fileArtifactMaxBytes = NyxIdToolOptions.DefaultProxyFileArtifactMaxBytes)
     {
         var client = new NyxIdApiClient(
             new NyxIdToolOptions { BaseUrl = "https://nyx.example" },
             new HttpClient(handler));
-        return new NyxIdProxyTool(client, null, ingress);
+        return new NyxIdProxyTool(client, null, ingress, fileArtifactMaxBytes);
+    }
+
+    private static void AssertFileArtifactError(
+        string result,
+        string expectedError,
+        string expectedDetail,
+        int? expectedHttpStatus = null,
+        string? expectedSourceContentType = null)
+    {
+        using var document = JsonDocument.Parse(result);
+        var root = document.RootElement;
+        root.GetProperty("success").GetBoolean().Should().BeFalse();
+        root.GetProperty("response_mode").GetString().Should().Be("file_artifact");
+        root.GetProperty("error").GetString().Should().Be(expectedError);
+        root.GetProperty("detail").GetString().Should().Be(expectedDetail);
+        if (expectedHttpStatus.HasValue)
+            root.GetProperty("http_status").GetInt32().Should().Be(expectedHttpStatus.Value);
+        else
+            root.TryGetProperty("http_status", out _).Should().BeFalse();
+
+        if (expectedSourceContentType != null)
+            root.GetProperty("source_content_type").GetString().Should().Be(expectedSourceContentType);
+        else
+            root.TryGetProperty("source_content_type", out _).Should().BeFalse();
     }
 
     private static AgentToolExecutionContext BuildContext(
@@ -281,6 +549,13 @@ public sealed class NyxIdProxyToolFileArtifactTests
 
     private sealed class RecordingNyxIdProxyFileArtifactIngress : INyxIdProxyFileArtifactIngress
     {
+        private readonly Exception? _exception;
+
+        public RecordingNyxIdProxyFileArtifactIngress(Exception? exception = null)
+        {
+            _exception = exception;
+        }
+
         public List<WorkflowFileIngressRequest> Requests { get; } = [];
 
         public ValueTask<WorkflowFileIngressResult> IngestAsync(
@@ -288,6 +563,9 @@ public sealed class NyxIdProxyToolFileArtifactTests
             CancellationToken cancellationToken = default)
         {
             Requests.Add(request);
+            if (_exception != null)
+                throw _exception;
+
             return ValueTask.FromResult(new WorkflowFileIngressResult(new WorkflowFileRef
             {
                 FileId = "file-1",

--- a/test/Aevatar.AI.Tests/NyxIdProxyToolFileArtifactTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdProxyToolFileArtifactTests.cs
@@ -1,0 +1,323 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.AI.ToolProviders.NyxId.Tools;
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using FluentAssertions;
+
+namespace Aevatar.AI.Tests;
+
+public sealed class NyxIdProxyToolFileArtifactTests
+{
+    [Fact]
+    public async Task ExecuteAsync_WithMissingResponseMode_ShouldKeepTextProxyBehavior()
+    {
+        var handler = new ProxyRecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"ok":true}""", Encoding.UTF8, "application/json"),
+        });
+        var tool = CreateTool(handler);
+        var previous = AgentToolRequestContext.Current;
+        try
+        {
+            AgentToolRequestContext.Current = BuildContext();
+
+            var result = await tool.ExecuteAsync(
+                """{"slug":"storage","path":"/records","method":"GET"}""");
+
+            result.Should().Be("""{"ok":true}""");
+            handler.Requests.Should().ContainSingle();
+            handler.Requests.Last().RequestUri!.AbsolutePath.Should().Be("/api/v1/proxy/s/storage/records");
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = previous;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithTextResponseMode_ShouldKeepTextProxyBehavior()
+    {
+        var handler = new ProxyRecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"ok":true}""", Encoding.UTF8, "application/json"),
+        });
+        var ingress = new RecordingNyxIdProxyFileArtifactIngress();
+        var tool = CreateTool(handler, ingress);
+        var previous = AgentToolRequestContext.Current;
+        try
+        {
+            AgentToolRequestContext.Current = BuildContext();
+
+            var result = await tool.ExecuteAsync(
+                """{"slug":"storage","path":"/records","method":"GET","response_mode":"text"}""");
+
+            result.Should().Be("""{"ok":true}""");
+            ingress.Requests.Should().BeEmpty();
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = previous;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithFileArtifactResponseMode_ShouldStoreBinaryThroughIngressAndReturnSanitizedFileRef()
+    {
+        var body = Encoding.UTF8.GetBytes("downloaded bytes");
+        var handler = new ProxyRecordingHandler(request =>
+        {
+            if (request.RequestUri!.AbsolutePath == "/api/v1/proxy/services")
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("""[{"slug":"storage"}]""", Encoding.UTF8, "application/json"),
+                };
+            }
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(body),
+            };
+            response.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("text/csv");
+            response.Content.Headers.ContentDisposition =
+                ContentDispositionHeaderValue.Parse("attachment; filename=\"report.csv\"");
+            return response;
+        });
+        var ingress = new RecordingNyxIdProxyFileArtifactIngress();
+        var tool = CreateTool(handler, ingress);
+        var previous = AgentToolRequestContext.Current;
+        try
+        {
+            AgentToolRequestContext.Current = BuildContext(
+                scopeId: "scope-a",
+                parentRunId: "run-a",
+                parentStepId: "step-a",
+                rootRunId: "root-a");
+
+            var result = await tool.ExecuteAsync(
+                """{"slug":"storage","path":"/reports/1","method":"GET","response_mode":"file_artifact","headers":{"X-Trace":"trace-1"}}""");
+
+            using var document = JsonDocument.Parse(result);
+            var root = document.RootElement;
+            root.GetProperty("success").GetBoolean().Should().BeTrue();
+            root.GetProperty("response_mode").GetString().Should().Be("file_artifact");
+            root.GetProperty("slug").GetString().Should().Be("storage");
+            root.GetProperty("path").GetString().Should().Be("/reports/1");
+            root.GetProperty("http_status").GetInt32().Should().Be(200);
+            root.GetProperty("file_ref").GetProperty("file_id").GetString().Should().Be("file-1");
+            root.GetProperty("file_ref").GetProperty("artifact_id").GetString().Should().Be("artifact-1");
+            root.GetProperty("file_ref").GetProperty("source_kind").GetString().Should().Be("ConnectedServiceResource");
+            result.Should().NotContain("downloaded bytes");
+            result.Contains("base64", StringComparison.OrdinalIgnoreCase).Should().BeFalse();
+            result.Should().NotContain("data:");
+
+            ingress.Requests.Should().ContainSingle();
+            var ingressRequest = ingress.Requests[0];
+            ingressRequest.Content.ToArray().Should().Equal(body);
+            ingressRequest.SourceKind.Should().Be(WorkflowFileSourceKind.ConnectedServiceResource);
+            ingressRequest.SourceMessageId.Should().Be("nyxid_proxy:storage");
+            ingressRequest.SourceResourceKey.Should().Be("/reports/1");
+            ingressRequest.FileName.Should().Be("report.csv");
+            ingressRequest.MediaType.Should().Be("text/csv");
+            ingressRequest.OwnerRunId.Should().Be("run-a");
+            ingressRequest.OwnerScopeId.Should().Be("scope-a");
+
+            var binaryRequest = handler.Requests.Last();
+            binaryRequest.Method.Should().Be(HttpMethod.Get);
+            binaryRequest.Headers.GetValues("X-Trace").Should().ContainSingle().Which.Should().Be("trace-1");
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = previous;
+        }
+    }
+
+    [Theory]
+    [InlineData("POST", """{"name":"report"}""", "file_artifact_requires_get")]
+    [InlineData("GET", """{"name":"report"}""", "file_artifact_disallows_body")]
+    [InlineData("GET", "", "file_artifact_disallows_body")]
+    public async Task ExecuteAsync_WithFileArtifactResponseMode_ShouldRejectUnsafeRequestShapes(
+        string method,
+        string body,
+        string expectedError)
+    {
+        var ingress = new RecordingNyxIdProxyFileArtifactIngress();
+        var tool = CreateTool(new ProxyRecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""[{"slug":"storage"}]""", Encoding.UTF8, "application/json"),
+        }), ingress);
+        var previous = AgentToolRequestContext.Current;
+        try
+        {
+            AgentToolRequestContext.Current = BuildContext();
+
+            var result = await tool.ExecuteAsync(
+                JsonSerializer.Serialize(new
+                {
+                    slug = "storage",
+                    path = "/reports/1",
+                    method,
+                    body,
+                    response_mode = "file_artifact",
+                }));
+
+            using var document = JsonDocument.Parse(result);
+            document.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+            document.RootElement.GetProperty("response_mode").GetString().Should().Be("file_artifact");
+            document.RootElement.GetProperty("error").GetString().Should().Be(expectedError);
+            ingress.Requests.Should().BeEmpty();
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = previous;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithFileArtifactResponseMode_ShouldRequireManagedWorkflowContextAndIngress()
+    {
+        var toolWithoutIngress = CreateTool(new ProxyRecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""[{"slug":"storage"}]""", Encoding.UTF8, "application/json"),
+        }));
+        var previous = AgentToolRequestContext.Current;
+        try
+        {
+            AgentToolRequestContext.Current = BuildContext();
+
+            var missingIngress = await toolWithoutIngress.ExecuteAsync(
+                """{"slug":"storage","path":"/reports/1","response_mode":"file_artifact"}""");
+            using (var document = JsonDocument.Parse(missingIngress))
+            {
+                document.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+                document.RootElement.GetProperty("error").GetString().Should().Be("file_artifact_ingress_unavailable");
+            }
+
+            AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
+            {
+                Credentials = new AgentToolCredentials("access-token", null, null),
+                Caller = new AgentToolCallerContext("scope-a", null, null),
+            };
+            var toolWithIngress = CreateTool(
+                new ProxyRecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("""[{"slug":"storage"}]""", Encoding.UTF8, "application/json"),
+                }),
+                new RecordingNyxIdProxyFileArtifactIngress());
+
+            var missingWorkflowRuntime = await toolWithIngress.ExecuteAsync(
+                """{"slug":"storage","path":"/reports/1","response_mode":"file_artifact"}""");
+            using (var document = JsonDocument.Parse(missingWorkflowRuntime))
+            {
+                document.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+                document.RootElement.GetProperty("error").GetString().Should().Be("managed_workflow_context_required");
+            }
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = previous;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithInvalidResponseMode_ShouldFailClosedWithoutProxyCall()
+    {
+        var handler = new ProxyRecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"ok":true}""", Encoding.UTF8, "application/json"),
+        });
+        var tool = CreateTool(handler, new RecordingNyxIdProxyFileArtifactIngress());
+        var previous = AgentToolRequestContext.Current;
+        try
+        {
+            AgentToolRequestContext.Current = BuildContext();
+
+            var result = await tool.ExecuteAsync(
+                """{"slug":"storage","path":"/reports/1","response_mode":"binary_base64"}""");
+
+            using var document = JsonDocument.Parse(result);
+            document.RootElement.GetProperty("success").GetBoolean().Should().BeFalse();
+            document.RootElement.GetProperty("error").GetString().Should().Be("invalid_response_mode");
+            handler.Requests.Should().BeEmpty();
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = previous;
+        }
+    }
+
+    private static NyxIdProxyTool CreateTool(
+        ProxyRecordingHandler handler,
+        INyxIdProxyFileArtifactIngress? ingress = null)
+    {
+        var client = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example" },
+            new HttpClient(handler));
+        return new NyxIdProxyTool(client, null, ingress);
+    }
+
+    private static AgentToolExecutionContext BuildContext(
+        string scopeId = "scope-a",
+        string parentActorId = "workflow-run-actor",
+        string parentRunId = "run-a",
+        string parentStepId = "step-a",
+        string rootRunId = "run-a") =>
+        AgentToolExecutionContext.Empty with
+        {
+            Credentials = new AgentToolCredentials("access-token", null, null),
+            Caller = new AgentToolCallerContext(scopeId, null, null),
+            WorkflowRuntime = new AgentWorkflowRuntimeContext(
+                parentActorId,
+                parentRunId,
+                parentStepId,
+                rootRunId,
+                1),
+        };
+
+    private sealed class RecordingNyxIdProxyFileArtifactIngress : INyxIdProxyFileArtifactIngress
+    {
+        public List<WorkflowFileIngressRequest> Requests { get; } = [];
+
+        public ValueTask<WorkflowFileIngressResult> IngestAsync(
+            WorkflowFileIngressRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            Requests.Add(request);
+            return ValueTask.FromResult(new WorkflowFileIngressResult(new WorkflowFileRef
+            {
+                FileId = "file-1",
+                ArtifactId = "artifact-1",
+                SourceKind = request.SourceKind,
+                SourceMessageId = request.SourceMessageId,
+                SourceResourceKey = request.SourceResourceKey,
+                FileName = request.FileName,
+                MediaType = request.MediaType,
+                SizeBytes = request.Content.Length,
+                Sha256 = "sha",
+                CreatedAtUnixMs = 10,
+                ExpiresAtUnixMs = 20,
+                OwnerRunId = request.OwnerRunId,
+                OwnerScopeId = request.OwnerScopeId,
+            }));
+        }
+    }
+
+    private sealed class ProxyRecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+        : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            return Task.FromResult(responder(request));
+        }
+    }
+}

--- a/test/Aevatar.AI.Tests/ToolProviderHttpClientRegistrationTests.cs
+++ b/test/Aevatar.AI.Tests/ToolProviderHttpClientRegistrationTests.cs
@@ -3,6 +3,7 @@ using Aevatar.AI.ToolProviders.ChronoStorage;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.AI.ToolProviders.NyxId.Tools;
 using Aevatar.AI.ToolProviders.Web;
+using Aevatar.Workflow.Application.Abstractions.Runs;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http;
@@ -32,6 +33,28 @@ public sealed class ToolProviderHttpClientRegistrationTests
         provider.GetRequiredService<IRemoteToolApprovalPort>().Should()
             .BeOfType<NyxIdRemoteToolApprovalPort>();
         provider.GetServices<IToolApprovalHandler>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AddNyxIdTools_ShouldRegisterFileArtifactIngressOnlyWhenWorkflowIngressExists()
+    {
+        var withoutWorkflowIngress = new ServiceCollection();
+        withoutWorkflowIngress.AddNyxIdTools(options => options.BaseUrl = "https://nyx.test");
+
+        withoutWorkflowIngress.Should().NotContain(descriptor =>
+            descriptor.ServiceType == typeof(INyxIdProxyFileArtifactIngress));
+
+        var withWorkflowIngress = new ServiceCollection();
+        withWorkflowIngress.AddSingleton<IWorkflowFileIngressPort, StubWorkflowFileIngressPort>();
+        withWorkflowIngress.AddNyxIdTools(options => options.BaseUrl = "https://nyx.test");
+
+        withWorkflowIngress.Should().ContainSingle(descriptor =>
+            descriptor.ServiceType == typeof(INyxIdProxyFileArtifactIngress) &&
+            descriptor.ImplementationFactory != null);
+        using var provider = withWorkflowIngress.BuildServiceProvider();
+        provider.GetRequiredService<INyxIdProxyFileArtifactIngress>()
+            .Should()
+            .BeOfType<NyxIdProxyWorkflowFileArtifactIngress>();
     }
 
     [Fact]
@@ -150,4 +173,17 @@ file static class HttpClientRegistrationAssertions
             .Should()
             .BeTrue("AddHttpClient should register HttpClientFactoryOptions for '{0}'", name);
     }
+}
+
+file sealed class StubWorkflowFileIngressPort : IWorkflowFileIngressPort
+{
+    public ValueTask<WorkflowFileIngressResult> IngestAsync(
+        WorkflowFileIngressRequest request,
+        CancellationToken cancellationToken = default) =>
+        ValueTask.FromResult(new WorkflowFileIngressResult(new WorkflowFileRef
+        {
+            FileId = "file-1",
+            ArtifactId = "artifact-1",
+            SourceKind = request.SourceKind,
+        }));
 }

--- a/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
+++ b/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
@@ -281,6 +281,29 @@ public sealed class MainnetHostCompositionTests
     }
 
     [Fact]
+    public void AddAevatarMainnetHost_ShouldRegisterNyxIdProxyFileArtifactIngressWithWorkflowFileStorage()
+    {
+        using var home = new TemporaryAevatarHomeScope();
+        var builder = CreateBuilder(new Dictionary<string, string?>
+        {
+            ["Aevatar:NyxId:ProxyFileArtifactMaxBytes"] = "12345",
+        });
+
+        builder.AddAevatarMainnetHost(options =>
+        {
+            options.EnableConnectorBootstrap = false;
+            options.EnableCors = false;
+        });
+
+        using var app = builder.Build();
+        app.Services.GetRequiredService<INyxIdProxyFileArtifactIngress>()
+            .Should()
+            .BeOfType<NyxIdProxyWorkflowFileArtifactIngress>();
+        app.Services.GetRequiredService<NyxIdToolOptions>()
+            .ProxyFileArtifactMaxBytes.Should().Be(12345);
+    }
+
+    [Fact]
     public async Task AddAevatarMainnetHost_ShouldFailFastOnMalformedWorkflowFileSubmitEndpointPolicy()
     {
         using var home = new TemporaryAevatarHomeScope();


### PR DESCRIPTION
## Changed files
实现 `nyxid_proxy(response_mode=file_artifact)` 作为 v1 唯一公开二进制下载路径：`NyxIdProxyTool` 负责 response mode 解析、GET/no-body/managed workflow 校验、调用有界 NyxID binary proxy 下载，并只通过 workflow file ingress 写入 `WorkflowFileRef`。缺省和 `response_mode=text` 保持原有字符串 proxy 行为。

新增 provider 内部 `INyxIdProxyFileArtifactIngress` 及 workflow file ingress 适配；NyxID tool 选项新增 `ProxyFileArtifactMaxBytes`，默认 25 MiB、硬上限 100 MiB。mainnet/workflow host 组合绑定相关配置，文档同步记录该契约和禁止 raw bytes/base64/data URI/第二公开工具等 side path。

Closes #2246

## Test results
- `bash -lc "dotnet build aevatar.slnx --nologo"`: passed。
- `bash -lc "dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --nologo"`: 899 passed，0 failed，0 skipped。
- `bash -lc "dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --nologo"`: 512 passed，0 failed，0 skipped。
- `bash -lc "dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo"`: 658 passed，0 failed，0 skipped。
- `bash -lc "dotnet test test/Aevatar.Capabilities.Tests/Aevatar.Capabilities.Tests.csproj --nologo"`: 292 passed，0 failed，0 skipped。
- `bash -lc "bash tools/ci/test_stability_guards.sh"`: passed。
- `bash -lc "bash tools/ci/architecture_guards.sh"`: passed。
- `git diff --check`: passed。

## Deviations
没有扩展 scope，没有修改外部仓库，没有改动 proto/schema/protocol 文件，也没有创建 commit。`HOST_REFACTOR_COMMENT_POLICY=none`，因此没有新增 refactor-history source comments；refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)。

⟦AI:AUTO-LOOP⟧
