### PR TITLE
统一 scope service multipart 文件输入解析

### DIFF
--- a/docs/canon/chat-api.md
+++ b/docs/canon/chat-api.md
@@ -95,13 +95,13 @@ owner: eanzhao
 
 #### Multipart File Producer
 
-`multipart/form-data` 用于在 Host/API 边界上传一个文件并启动同一条 chat run 主链路。
+`multipart/form-data` 用于在 Host/API 边界上传文件并启动同一条 chat run 主链路。multipart shape、字段名、大小、媒体类型、raw `payload` JSON 与 pending file bytes 由 workflow infrastructure 的共享 `WorkflowMultipartFileInputParser` 处理；artifact ingress 与 typed `WorkflowFileRef` 注入只在确认目标语义后发生。
 
 必需字段：
 
 | Field | Requirement |
 |---|---|
-| `file` | 必须且只能出现一个文件 part；字段名必须是 `file`，可通过 `WorkflowFormFileIngress:FileFieldName` 调整。 |
+| `file` | 必须至少出现一个文件 part；字段名必须是 `file`，可通过 `WorkflowFormFileIngress:FileFieldName` 调整。同一字段可重复，按 form 顺序追加 input parts。 |
 
 可选字段：
 
@@ -125,9 +125,9 @@ owner: eanzhao
 成功路径：
 
 1. Host 先校验 caller credential；无效 bearer 不读取文件、不写 artifact store。
-2. Host 校验 multipart shape、文件数量、字段名、大小、media type。
-3. Host 调用 `IWorkflowFileIngressPort.IngestAsync(...)`，`SourceKind=FormUpload`。
-4. parser 把返回的 typed `WorkflowFileRef` 构造成既有 `ChatInputContentPart.fileRef`；`image/*`、`audio/*`、`video/*` 分别映射为 `type=image/audio/video`，其余已允许的 document/text/spreadsheet 类型统一映射为 `type=file`。
+2. Host 通过共享 parser 校验 multipart shape、字段名、大小、media type，并得到 raw payload JSON 与 pending files。
+3. `/api/chat` 兼容 facade 在 payload 校验通过后调用 `IWorkflowFileIngressPort.IngestAsync(...)`，`SourceKind=FormUpload`。
+4. 共享 parser 的 mapping helper 把返回的 typed `WorkflowFileRef` 构造成既有 `ChatInputContentPart.fileRef`；`image/*`、`audio/*`、`video/*` 分别映射为 `type=image/audio/video`，其余已允许的 document/text/spreadsheet 类型统一映射为 `type=file`。
 5. `ChatRunRequestNormalizer` 继续生成 `WorkflowChatRunRequest`，后续 CQRS command skeleton 不区分 JSON producer 与 form producer。
 
 actor-facing command、state、readmodel、stream frame 与日志都不得携带上传文件 bytes/base64；它们只携带 `WorkflowFileRef` 或由它派生出的 URI/metadata。
@@ -138,13 +138,15 @@ actor-facing command、state、readmodel、stream frame 与日志都不得携带
 |---|---:|---|
 | `INVALID_CALLER_CREDENTIAL` | 400 | Authorization bearer 格式无效。 |
 | `INVALID_CHAT_INPUT` | 400 | JSON body 或 multipart payload 不是合法 `ChatInput`。 |
-| `INVALID_FILE_INPUT` | 400 | 文件缺失、多个文件、字段名不匹配、media type 不允许、大小超限或 payload 试图携带 actor-facing file payload。 |
+| `INVALID_FILE_INPUT` | 400 | 文件缺失、字段名不匹配、media type 不允许、大小超限或 payload 试图携带 actor-facing file payload。 |
 | `UNSUPPORTED_MEDIA_TYPE` | 415 | 请求不是 JSON，也不是 `multipart/form-data`。 |
 | `PROMPT_REQUIRED` | 400 | normalizer 无法从 prompt 或 input parts 得到有效输入。 |
 | `WORKFLOW_NOT_FOUND` | 404 | workflow 名称未命中。 |
 | `WORKFLOW_BINDING_MISMATCH` | 409 | 目标 actor workflow binding 与请求不一致。 |
 
 WebSocket 不接收 `multipart/form-data`。文件输入应先经 HTTP artifact ingress producer 生成 typed file ref，或由客户端使用已有 `fileRef` descriptor。
+
+Scope service stream 入口（如 `/api/scopes/{scopeId}/invoke/chat:stream`、member/team stream）也可以接收 `multipart/form-data`，但 Host 只做 Content-Type 分派、path `scopeId` 权威性、DTO 反序列化、service kind gating 和错误映射。共享 parser 先返回 raw payload JSON、`HasFiles` 与 pending files；只有 service invocation 目标解析并确认是 workflow service 后，Host 才使用 path `scopeId` 调用 `IWorkflowFileIngressPort.IngestAsync(...)` 并追加 typed file refs。static / scripting 目标收到 multipart 文件时 fail closed，且不得通过公开 JSON `inputParts`、headers 或 metadata 承载上传文件语义。
 
 ### 多模态文件输入
 

--- a/docs/canon/workflow-runtime.md
+++ b/docs/canon/workflow-runtime.md
@@ -142,6 +142,7 @@ Workflow file artifacts use narrow ports with separate responsibilities:
 - `IWorkflowFileArtifactReadPort` describes or opens an existing descriptor-backed artifact.
 - `IWorkflowFileArtifactOwnershipPort` binds owner facts when a workflow run actor later claims an ownerless artifact.
 - `IWorkflowFileArtifactCleanupPort` is cleanup-only lifecycle surface. It is triggered by Host background service, while the provider owns physical cleanup decisions.
+- `WorkflowMultipartFileInputParser` is the shared Host/adapter boundary parser for multipart file input. It validates form shape and media constraints, returns raw payload JSON, `HasFiles`, and pending file bytes, but does not decide service kind and does not write artifacts by itself.
 
 Runtime boundary:
 
@@ -149,6 +150,7 @@ Runtime boundary:
 - Workflow run ownership remains actor fact. Descriptor owner fields are only file-reference facts used by the artifact provider and do not replace actor-owned run state.
 - Cleanup must be based on durable descriptor/index state. A provider must not depend on a process-local run/artifact registry, `actorId -> context` lookup, or query-time reconstruction to decide what to remove.
 - `WorkflowChatRunRequest`、actor state、readmodels、logs、prompts 与 tool results continue to carry only `WorkflowFileRef` descriptors or sanitized derived fields. They must not carry file bytes, base64, multipart payloads, or provider raw response bodies.
+- Scope service endpoints that accept multipart stream requests must resolve the service target first. Only workflow service targets may ingest pending files into artifact storage, and the owner scope must come from the path `scopeId`; static or scripting targets fail closed before artifact ingress.
 - Host composition must fail closed for production/external backends. `WorkflowFileArtifacts:Backend=External` requires explicit registrations for ingress/read/ownership/cleanup ports; production policy rejects the implicit filesystem backend.
 - The filesystem backend is the local/test concrete backend. Its cleanup removes expired descriptor-committed artifacts and stale staged directories without introducing a process-local artifact registry.
 

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -32,6 +32,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Text.Json;
 
@@ -47,6 +48,7 @@ public static class ScopeServiceEndpoints
     {
         WriteIndented = true,
     };
+    private static readonly JsonSerializerOptions ScopeRequestJsonOptions = new(JsonSerializerDefaults.Web);
 
     public static IEndpointRouteBuilder MapScopeServiceEndpoints(this IEndpointRouteBuilder app)
     {
@@ -593,12 +595,13 @@ public static class ScopeServiceEndpoints
     private static async Task HandleInvokeDefaultChatStreamAsync(
         HttpContext http,
         string scopeId,
-        StreamScopeServiceHttpRequest request,
         [FromServices] ServiceInvocationResolutionService resolutionService,
         [FromServices] ServiceInvokeReadinessErrorMapper readinessErrorMapper,
         [FromServices] IInvokeAdmissionAuthorizer admissionAuthorizer,
         [FromServices] IServiceRunRegistrationPort serviceRunRegistrationPort,
         [FromServices] IWorkflowChatRunInteractionPort chatRunService,
+        [FromServices] WorkflowMultipartFileInputParser multipartFileInputParser,
+        [FromServices] IWorkflowFileIngressPort workflowFileIngressPort,
         [FromServices] ICommandInteractionService<ScriptServiceRunCommand, ScriptServiceRunAcceptedReceipt, ScriptServiceRunStartError, AGUIEvent, ScriptServiceRunCompletionStatus> scriptServiceRunService,
         [FromServices] IStaticGAgentStreamInvocationPort<AGUIEvent> staticGAgentStreamInvocationPort,
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
@@ -613,13 +616,14 @@ public static class ScopeServiceEndpoints
             scopeId,
             serviceId,
             "chat",
-            request,
+            multipartFileInputParser,
             appId: null,
             resolutionService,
             readinessErrorMapper,
             admissionAuthorizer,
             serviceRunRegistrationPort,
             chatRunService,
+            workflowFileIngressPort,
             scriptServiceRunService,
             staticGAgentStreamInvocationPort,
             options,
@@ -656,13 +660,14 @@ public static class ScopeServiceEndpoints
         string scopeId,
         string memberId,
         string endpointId,
-        StreamScopeServiceHttpRequest request,
         [FromServices] IMemberPublishedServiceResolver memberPublishedServiceResolver,
         [FromServices] ServiceInvocationResolutionService resolutionService,
         [FromServices] ServiceInvokeReadinessErrorMapper readinessErrorMapper,
         [FromServices] IInvokeAdmissionAuthorizer admissionAuthorizer,
         [FromServices] IServiceRunRegistrationPort serviceRunRegistrationPort,
         [FromServices] IWorkflowChatRunInteractionPort chatRunService,
+        [FromServices] WorkflowMultipartFileInputParser multipartFileInputParser,
+        [FromServices] IWorkflowFileIngressPort workflowFileIngressPort,
         [FromServices] ICommandInteractionService<ScriptServiceRunCommand, ScriptServiceRunAcceptedReceipt, ScriptServiceRunStartError, AGUIEvent, ScriptServiceRunCompletionStatus> scriptServiceRunService,
         [FromServices] IStaticGAgentStreamInvocationPort<AGUIEvent> staticGAgentStreamInvocationPort,
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
@@ -681,13 +686,14 @@ public static class ScopeServiceEndpoints
                 memberResolution.ScopeId,
                 memberResolution.PublishedServiceId,
                 endpointId,
-                request,
+                multipartFileInputParser,
                 null,
                 resolutionService,
                 readinessErrorMapper,
                 admissionAuthorizer,
                 serviceRunRegistrationPort,
                 chatRunService,
+                workflowFileIngressPort,
                 scriptServiceRunService,
                 staticGAgentStreamInvocationPort,
                 options,
@@ -752,13 +758,14 @@ public static class ScopeServiceEndpoints
         string scopeId,
         string teamId,
         string endpointId,
-        StreamScopeServiceHttpRequest request,
         [FromServices] ITeamEntryMemberResolver teamEntryMemberResolver,
         [FromServices] ServiceInvocationResolutionService resolutionService,
         [FromServices] ServiceInvokeReadinessErrorMapper readinessErrorMapper,
         [FromServices] IInvokeAdmissionAuthorizer admissionAuthorizer,
         [FromServices] IServiceRunRegistrationPort serviceRunRegistrationPort,
         [FromServices] IWorkflowChatRunInteractionPort chatRunService,
+        [FromServices] WorkflowMultipartFileInputParser multipartFileInputParser,
+        [FromServices] IWorkflowFileIngressPort workflowFileIngressPort,
         [FromServices] ICommandInteractionService<ScriptServiceRunCommand, ScriptServiceRunAcceptedReceipt, ScriptServiceRunStartError, AGUIEvent, ScriptServiceRunCompletionStatus> scriptServiceRunService,
         [FromServices] IStaticGAgentStreamInvocationPort<AGUIEvent> staticGAgentStreamInvocationPort,
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
@@ -775,13 +782,14 @@ public static class ScopeServiceEndpoints
                 teamResolution.ScopeId,
                 teamResolution.PublishedServiceId,
                 endpointId,
-                request,
+                multipartFileInputParser,
                 null,
                 resolutionService,
                 readinessErrorMapper,
                 admissionAuthorizer,
                 serviceRunRegistrationPort,
                 chatRunService,
+                workflowFileIngressPort,
                 scriptServiceRunService,
                 staticGAgentStreamInvocationPort,
                 options,
@@ -1504,13 +1512,14 @@ public static class ScopeServiceEndpoints
         string scopeId,
         string serviceId,
         string endpointId,
-        StreamScopeServiceHttpRequest request,
+        WorkflowMultipartFileInputParser multipartFileInputParser,
         string? appId,
         [FromServices] ServiceInvocationResolutionService resolutionService,
         [FromServices] ServiceInvokeReadinessErrorMapper readinessErrorMapper,
         [FromServices] IInvokeAdmissionAuthorizer admissionAuthorizer,
         [FromServices] IServiceRunRegistrationPort serviceRunRegistrationPort,
         [FromServices] IWorkflowChatRunInteractionPort chatRunService,
+        [FromServices] IWorkflowFileIngressPort workflowFileIngressPort,
         [FromServices] ICommandInteractionService<ScriptServiceRunCommand, ScriptServiceRunAcceptedReceipt, ScriptServiceRunStartError, AGUIEvent, ScriptServiceRunCompletionStatus> scriptServiceRunService,
         [FromServices] IStaticGAgentStreamInvocationPort<AGUIEvent> staticGAgentStreamInvocationPort,
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
@@ -1521,6 +1530,19 @@ public static class ScopeServiceEndpoints
             if (await AevatarScopeAccessGuard.TryWriteScopeAccessDeniedAsync(http, scopeId, ct))
                 return;
 
+            var requestInput = await ParseScopeStreamRequestAsync(http, multipartFileInputParser, ct);
+            if (requestInput.Failure != null)
+            {
+                await WriteJsonErrorResponseAsync(
+                    http,
+                    requestInput.Failure.Value.StatusCode,
+                    requestInput.Failure.Value.Code,
+                    requestInput.Failure.Value.Message,
+                    ct);
+                return;
+            }
+
+            var request = requestInput.Request!;
             var normalizedPrompt = request.Prompt?.Trim() ?? string.Empty;
             var scopedHeaders = BuildScopedHeaders(request.Headers);
             var callerCredential = WorkflowCallerCredentialExtractor.Extract(http);
@@ -1553,12 +1575,23 @@ public static class ScopeServiceEndpoints
             {
                 case ServiceImplementationKind.Workflow:
                     EnsureWorkflowStreamTarget(target, invocationRequest);
+                    var inputParts = MapInputParts(request.InputParts);
+                    if (requestInput.MultipartForm is { HasFiles: true } multipartForm)
+                    {
+                        var uploadedParts = await IngestMultipartInputPartsAsync(
+                            multipartForm,
+                            workflowFileIngressPort,
+                            scopeId,
+                            ct);
+                        inputParts = AppendInputParts(inputParts, uploadedParts);
+                    }
+
                     await WorkflowCapabilityEndpoints.HandleChat(
                         http,
                         new ChatInput
                         {
                             Prompt = normalizedPrompt,
-                            InputParts = MapInputParts(request.InputParts),
+                            InputParts = inputParts,
                             Source = new WorkflowChatSourceInput
                             {
                                 Kind = "definition_actor",
@@ -1591,6 +1624,7 @@ public static class ScopeServiceEndpoints
                     break;
 
                 case ServiceImplementationKind.Static:
+                    EnsureNoMultipartFilesForNonWorkflowStream(requestInput);
                     await HandleStaticGAgentChatStreamAsync(
                         http,
                         normalizedPrompt,
@@ -1605,6 +1639,7 @@ public static class ScopeServiceEndpoints
                     break;
 
                 case ServiceImplementationKind.Scripting:
+                    EnsureNoMultipartFilesForNonWorkflowStream(requestInput);
                     await HandleScriptingServiceChatStreamAsync(
                         http,
                         target,
@@ -3148,9 +3183,11 @@ const response = await fetch("{{invokePath}}", {
                     NyxIdRoutePreference = route,
                 };
             }
-            catch
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                // Best-effort; fall back to provider defaults if config unavailable.
+                http.RequestServices.GetService<ILoggerFactory>()
+                    ?.CreateLogger("Aevatar.GAgentService.Hosting.Endpoints.ScopeServiceEndpoints")
+                    .LogWarning(ex, "Failed to read scoped user LLM configuration; provider defaults will be used.");
             }
         }
 
@@ -3170,6 +3207,67 @@ const response = await fetch("{{invokePath}}", {
         }
     }
 
+    private static async ValueTask<ScopeStreamRequestInput> ParseScopeStreamRequestAsync(
+        HttpContext http,
+        WorkflowMultipartFileInputParser multipartFileInputParser,
+        CancellationToken ct)
+    {
+        if (WorkflowMultipartFileInputParser.IsMultipartForm(http.Request.ContentType))
+        {
+            var multipartResult = await multipartFileInputParser.ParseAsync(http, ct);
+            if (!multipartResult.Succeeded)
+                return ScopeStreamRequestInput.Failed(ToScopeStreamRequestError(multipartResult.Error!.Value));
+
+            var request = ParseScopeStreamPayload(multipartResult.RawPayloadJson);
+            if (request == null)
+                return ScopeStreamRequestInput.Failed(ScopeStreamRequestParseError.InvalidRequest);
+
+            return ScopeStreamRequestInput.Success(request, multipartResult.Form);
+        }
+
+        if (!IsJsonContentType(http.Request.ContentType))
+            return ScopeStreamRequestInput.Failed(ScopeStreamRequestParseError.UnsupportedMediaType);
+
+        StreamScopeServiceHttpRequest? parsed;
+        try
+        {
+            parsed = await JsonSerializer.DeserializeAsync<StreamScopeServiceHttpRequest>(
+                http.Request.Body,
+                ScopeRequestJsonOptions,
+                ct);
+        }
+        catch (JsonException)
+        {
+            return ScopeStreamRequestInput.Failed(ScopeStreamRequestParseError.InvalidRequest);
+        }
+
+        return parsed == null
+            ? ScopeStreamRequestInput.Failed(ScopeStreamRequestParseError.InvalidRequest)
+            : ScopeStreamRequestInput.Success(parsed, null);
+    }
+
+    private static StreamScopeServiceHttpRequest? ParseScopeStreamPayload(string? payload)
+    {
+        if (string.IsNullOrWhiteSpace(payload))
+            return new StreamScopeServiceHttpRequest(null);
+
+        try
+        {
+            return JsonSerializer.Deserialize<StreamScopeServiceHttpRequest>(payload, ScopeRequestJsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static bool IsJsonContentType(string? contentType) =>
+        contentType?.StartsWith("application/json", StringComparison.OrdinalIgnoreCase) == true;
+
+    private static ScopeStreamRequestParseError ToScopeStreamRequestError(
+        WorkflowMultipartFileInputParseError error) =>
+        new(error.StatusCode, error.Code, error.Message);
+
     private static IReadOnlyList<ChatInputContentPart>? MapInputParts(
         IReadOnlyList<StreamContentPartHttpRequest>? parts)
     {
@@ -3187,6 +3285,63 @@ const response = await fetch("{{invokePath}}", {
                 Uri = p.Uri,
                 Name = p.Name,
             }).ToList();
+    }
+
+    private static IReadOnlyList<ChatInputContentPart>? AppendInputParts(
+        IReadOnlyList<ChatInputContentPart>? existing,
+        IReadOnlyList<ChatInputContentPart> appended)
+    {
+        if (appended.Count == 0)
+            return existing;
+
+        if (existing is not { Count: > 0 })
+            return appended;
+
+        var inputParts = new List<ChatInputContentPart>(existing.Count + appended.Count);
+        inputParts.AddRange(existing);
+        inputParts.AddRange(appended);
+        return inputParts;
+    }
+
+    private static async ValueTask<IReadOnlyList<ChatInputContentPart>> IngestMultipartInputPartsAsync(
+        WorkflowMultipartFileInputForm form,
+        IWorkflowFileIngressPort workflowFileIngressPort,
+        string scopeId,
+        CancellationToken ct)
+    {
+        var inputParts = new List<ChatInputContentPart>(form.PendingFiles.Count);
+        foreach (var file in form.PendingFiles)
+        {
+            WorkflowFileIngressResult ingressResult;
+            try
+            {
+                ingressResult = await workflowFileIngressPort.IngestAsync(
+                    WorkflowMultipartFileInputParser.BuildIngressRequest(file, scopeId),
+                    ct);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new InvalidOperationException("Multipart chat file input is invalid.", ex);
+            }
+            catch (InvalidOperationException ex)
+            {
+                throw new InvalidOperationException("Multipart chat file input is invalid.", ex);
+            }
+            catch (IOException ex)
+            {
+                throw new InvalidOperationException("Multipart chat file input is invalid.", ex);
+            }
+
+            inputParts.Add(WorkflowMultipartFileInputParser.BuildInputPart(file, ingressResult.FileRef));
+        }
+
+        return inputParts;
+    }
+
+    private static void EnsureNoMultipartFilesForNonWorkflowStream(ScopeStreamRequestInput requestInput)
+    {
+        if (requestInput.MultipartForm?.HasFiles == true)
+            throw new InvalidOperationException("Multipart file input is only supported for workflow services.");
     }
 
     private static IReadOnlyList<GAgentDraftRunInputPart>? MapGAgentDraftRunInputParts(
@@ -3549,6 +3704,36 @@ const response = await fetch("{{invokePath}}", {
         ServiceDeploymentCatalogSnapshot? Deployments,
         WorkflowActorBinding? Binding,
         IResult? Failure);
+
+    private sealed record ScopeStreamRequestInput(
+        StreamScopeServiceHttpRequest? Request,
+        WorkflowMultipartFileInputForm? MultipartForm,
+        ScopeStreamRequestParseError? Failure)
+    {
+        public static ScopeStreamRequestInput Success(
+            StreamScopeServiceHttpRequest request,
+            WorkflowMultipartFileInputForm? multipartForm) =>
+            new(request, multipartForm, null);
+
+        public static ScopeStreamRequestInput Failed(ScopeStreamRequestParseError error) =>
+            new(null, null, error);
+    }
+
+    private readonly record struct ScopeStreamRequestParseError(
+        int StatusCode,
+        string Code,
+        string Message)
+    {
+        public static readonly ScopeStreamRequestParseError UnsupportedMediaType = new(
+            StatusCodes.Status415UnsupportedMediaType,
+            "UNSUPPORTED_MEDIA_TYPE",
+            "Content-Type must be application/json or multipart/form-data.");
+
+        public static readonly ScopeStreamRequestParseError InvalidRequest = new(
+            StatusCodes.Status400BadRequest,
+            "INVALID_SERVICE_STREAM_REQUEST",
+            "Service stream request body is invalid.");
+    }
 
     public sealed record ScopeBindingStatusHttpResponse(
         bool Available,

--- a/src/workflow/Aevatar.Workflow.Host.Api/CHAT_API_CAPABILITIES.md
+++ b/src/workflow/Aevatar.Workflow.Host.Api/CHAT_API_CAPABILITIES.md
@@ -7,8 +7,9 @@
 ## 快速结论
 
 - `/api/chat`（SSE）与 `/api/ws/chat`（WebSocket）能力一致，仅传输协议不同。
-- `/api/chat` 支持 `application/json` 与 `multipart/form-data`；multipart producer 只负责把单个 `file` 表单文件写入 artifact store，并把返回的 typed `WorkflowFileRef` 注入既有 input part。
+- `/api/chat` 支持 `application/json` 与 `multipart/form-data`；multipart producer 复用 workflow infrastructure 的共享 parser 校验表单与 pending files，再把 `file` 表单文件写入 artifact store，并把返回的 typed `WorkflowFileRef` 注入既有 input part。
 - multipart 默认允许 image/audio/video 与 PDF、DOCX、CSV、plain text、markdown、XLSX；非 image/audio/video 的允许类型统一进入 `inputParts[].type = "file"`。
+- scope service stream 入口只在解析出 workflow service 目标后才会把 pending files 写入 artifact store；static / scripting 目标收到 multipart 文件会 fail closed，不通过公开 JSON `inputParts`、headers 或 metadata 偷渡文件语义。
 - 支持 typed `source`、`workflowYamls`、`workflow` 与 `default(auto)` 的运行选择；`default(auto)` 仅在未提供 source/workflow/workflowYamls 时触发。
 - `workflow` 用于已注册 workflow 名称查找（内建 + 文件加载）；`workflowYamls` 仅用于 inline YAML bundle（首项入口）。
 - 当 `workflow` 与 `workflowYamls` 同时出现时，固定使用 `workflowYamls`。

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowMultipartChatRequestParser.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowMultipartChatRequestParser.cs
@@ -17,7 +17,7 @@ internal sealed class WorkflowMultipartChatRequestParser
         _fileIngressPort = fileIngressPort;
     }
 
-    public WorkflowMultipartChatRequestParser(
+    internal WorkflowMultipartChatRequestParser(
         IWorkflowFileIngressPort fileIngressPort,
         Microsoft.Extensions.Options.IOptions<WorkflowMultipartFileIngressOptions> multipartOptions,
         Microsoft.Extensions.Options.IOptions<WorkflowFormFileIngressOptions>? formOptions = null)

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowMultipartChatRequestParser.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowMultipartChatRequestParser.cs
@@ -1,25 +1,28 @@
 using System.Text.Json;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Primitives;
 
 namespace Aevatar.Workflow.Infrastructure.CapabilityApi;
 
 internal sealed class WorkflowMultipartChatRequestParser
 {
+    private readonly WorkflowMultipartFileInputParser _fileInputParser;
     private readonly IWorkflowFileIngressPort _fileIngressPort;
-    private readonly IOptions<WorkflowMultipartFileIngressOptions> _multipartOptions;
-    private readonly IOptions<WorkflowFormFileIngressOptions> _formOptions;
+
+    public WorkflowMultipartChatRequestParser(
+        WorkflowMultipartFileInputParser fileInputParser,
+        IWorkflowFileIngressPort fileIngressPort)
+    {
+        _fileInputParser = fileInputParser;
+        _fileIngressPort = fileIngressPort;
+    }
 
     public WorkflowMultipartChatRequestParser(
         IWorkflowFileIngressPort fileIngressPort,
-        IOptions<WorkflowMultipartFileIngressOptions> multipartOptions,
-        IOptions<WorkflowFormFileIngressOptions>? formOptions = null)
+        Microsoft.Extensions.Options.IOptions<WorkflowMultipartFileIngressOptions> multipartOptions,
+        Microsoft.Extensions.Options.IOptions<WorkflowFormFileIngressOptions>? formOptions = null)
+        : this(new WorkflowMultipartFileInputParser(multipartOptions, formOptions), fileIngressPort)
     {
-        _fileIngressPort = fileIngressPort;
-        _multipartOptions = multipartOptions;
-        _formOptions = formOptions ?? Options.Create(new WorkflowFormFileIngressOptions());
     }
 
     public async ValueTask<WorkflowMultipartChatRequestParseResult> ParseAsync(
@@ -28,27 +31,16 @@ internal sealed class WorkflowMultipartChatRequestParser
     {
         ArgumentNullException.ThrowIfNull(http);
 
-        if (!IsMultipartForm(http.Request.ContentType))
+        var multipartResult = await _fileInputParser.ParseAsync(http, cancellationToken);
+        if (!multipartResult.Succeeded)
+            return WorkflowMultipartChatRequestParseResult.Failed(ToChatError(multipartResult.Error!.Value));
+
+        var form = multipartResult.Form!;
+        if (!form.HasFiles)
             return WorkflowMultipartChatRequestParseResult.Failed(
-                WorkflowMultipartChatRequestParseError.UnsupportedMediaType);
+                WorkflowMultipartChatRequestParseError.InvalidFileInput);
 
-        IFormCollection form;
-        try
-        {
-            form = await http.Request.ReadFormAsync(cancellationToken);
-        }
-        catch (InvalidDataException)
-        {
-            return WorkflowMultipartChatRequestParseResult.Failed(
-                WorkflowMultipartChatRequestParseError.InvalidRequest);
-        }
-
-        var formOptions = _formOptions.Value;
-        var filesResult = ResolveFiles(form, formOptions.FileFieldName);
-        if (!filesResult.Succeeded)
-            return WorkflowMultipartChatRequestParseResult.Failed(filesResult.Error!.Value);
-
-        var payloadResult = ParsePayload(form, formOptions.PayloadFieldName);
+        var payloadResult = ParsePayload(form.RawPayloadJson);
         if (!payloadResult.Succeeded)
             return WorkflowMultipartChatRequestParseResult.Failed(payloadResult.Error!.Value);
 
@@ -56,42 +48,15 @@ internal sealed class WorkflowMultipartChatRequestParser
         if (ContainsActorFacingFilePayload(source))
             return WorkflowMultipartChatRequestParseResult.Failed(WorkflowMultipartChatRequestParseError.InvalidFileInput);
 
-        var files = filesResult.Files!;
-        var inputPartTypes = new string[files.Count];
-        for (var i = 0; i < files.Count; i++)
-        {
-            var file = files[i];
-            if (!TryResolveInputPartType(file.ContentType, out var inputPartType))
-                return WorkflowMultipartChatRequestParseResult.Failed(
-                    WorkflowMultipartChatRequestParseError.InvalidFileInput);
-
-            var validationError = ValidateFile(file);
-            if (validationError != null)
-                return WorkflowMultipartChatRequestParseResult.Failed(validationError.Value);
-
-            inputPartTypes[i] = inputPartType;
-        }
-
-        var ownerScopeId = ResolveScalar(form, "scopeId");
+        var ownerScopeId = form.ResolveScalar("scopeId");
         var inputParts = new List<ChatInputContentPart>(source.InputParts ?? []);
-        for (var i = 0; i < files.Count; i++)
+        foreach (var file in form.PendingFiles)
         {
-            var file = files[i];
-            var content = await ReadFileContentAsync(file, cancellationToken);
-            if (content.Length == 0)
-                return WorkflowMultipartChatRequestParseResult.Failed(
-                    WorkflowMultipartChatRequestParseError.InvalidFileInput);
-
             WorkflowFileIngressResult ingressResult;
             try
             {
                 ingressResult = await _fileIngressPort.IngestAsync(
-                    new WorkflowFileIngressRequest(
-                        content,
-                        WorkflowFileSourceKind.FormUpload,
-                        FileName: Normalize(file.FileName),
-                        MediaType: Normalize(file.ContentType),
-                        OwnerScopeId: ownerScopeId),
+                    WorkflowMultipartFileInputParser.BuildIngressRequest(file, ownerScopeId),
                     cancellationToken);
             }
             catch (ArgumentException)
@@ -110,100 +75,23 @@ internal sealed class WorkflowMultipartChatRequestParser
                     WorkflowMultipartChatRequestParseError.InvalidFileInput);
             }
 
-            var uploadedFileRef = ToInputFileRef(ingressResult.FileRef);
-            inputParts.Add(new ChatInputContentPart
-            {
-                Type = inputPartTypes[i],
-                MediaType = uploadedFileRef.MediaType,
-                Uri = uploadedFileRef.ArtifactId ?? uploadedFileRef.Uri,
-                Name = uploadedFileRef.FileName ?? uploadedFileRef.Name,
-                FileRef = uploadedFileRef,
-            });
+            inputParts.Add(WorkflowMultipartFileInputParser.BuildInputPart(file, ingressResult.FileRef));
         }
 
         return WorkflowMultipartChatRequestParseResult.Success(source with
         {
-            Prompt = ResolveScalar(form, "prompt") ?? source.Prompt,
-            Workflow = ResolveScalar(form, "workflow") ?? source.Workflow,
-            SessionId = ResolveScalar(form, "sessionId") ?? source.SessionId,
+            Prompt = form.ResolveScalar("prompt") ?? source.Prompt,
+            Workflow = form.ResolveScalar("workflow") ?? source.Workflow,
+            SessionId = form.ResolveScalar("sessionId") ?? source.SessionId,
             ScopeId = ownerScopeId ?? source.ScopeId,
-            WorkflowYaml = ResolveScalar(form, "workflowYaml") ?? source.WorkflowYaml,
-            WorkflowYamls = ResolveWorkflowYamls(form) ?? source.WorkflowYamls,
+            WorkflowYaml = form.ResolveScalar("workflowYaml") ?? source.WorkflowYaml,
+            WorkflowYamls = form.ResolveRepeatedScalars("workflowYamls") ?? source.WorkflowYamls,
             InputParts = inputParts,
         });
     }
 
-    private WorkflowMultipartChatRequestParseError? ValidateFile(IFormFile file)
+    private static PayloadParseResult ParsePayload(string? payload)
     {
-        if (file.Length <= 0)
-            return WorkflowMultipartChatRequestParseError.InvalidFileInput;
-
-        var options = _multipartOptions.Value;
-        if (options.MaxFileBytes <= 0 || file.Length > options.MaxFileBytes)
-            return WorkflowMultipartChatRequestParseError.InvalidFileInput;
-
-        var mediaType = Normalize(file.ContentType);
-        if (mediaType == null || !IsAllowedMediaType(mediaType, options.AllowedMediaTypes))
-            return WorkflowMultipartChatRequestParseError.InvalidFileInput;
-
-        return null;
-    }
-
-    private static FileListResult ResolveFiles(IFormCollection form, string fileFieldName)
-    {
-        var expectedName = Normalize(fileFieldName) ?? "file";
-        if (form.Files.Count == 0)
-            return FileListResult.Failed(WorkflowMultipartChatRequestParseError.InvalidFileInput);
-
-        var files = new List<IFormFile>(form.Files.Count);
-        foreach (var file in form.Files)
-        {
-            if (!string.Equals(file.Name, expectedName, StringComparison.Ordinal))
-                return FileListResult.Failed(WorkflowMultipartChatRequestParseError.InvalidFileInput);
-
-            files.Add(file);
-        }
-
-        return FileListResult.Success(files);
-    }
-
-    private static async ValueTask<byte[]> ReadFileContentAsync(
-        IFormFile file,
-        CancellationToken cancellationToken)
-    {
-        await using var source = file.OpenReadStream();
-        using var target = new MemoryStream((int)Math.Min(file.Length, int.MaxValue));
-        await source.CopyToAsync(target, cancellationToken);
-        return target.ToArray();
-    }
-
-    private static bool IsMultipartForm(string? contentType) =>
-        contentType?.StartsWith("multipart/form-data", StringComparison.OrdinalIgnoreCase) == true;
-
-    private static bool TryResolveInputPartType(string? mediaType, out string type)
-    {
-        var normalized = Normalize(mediaType);
-        type = normalized switch
-        {
-            { } value when value.StartsWith("image/", StringComparison.OrdinalIgnoreCase) => "image",
-            { } value when value.StartsWith("audio/", StringComparison.OrdinalIgnoreCase) => "audio",
-            { } value when value.StartsWith("video/", StringComparison.OrdinalIgnoreCase) => "video",
-            { } => "file",
-            _ => string.Empty,
-        };
-
-        return type.Length > 0;
-    }
-
-    private static bool IsAllowedMediaType(string mediaType, IEnumerable<string> allowedMediaTypes) =>
-        allowedMediaTypes.Any(allowed =>
-            string.Equals(Normalize(allowed), mediaType, StringComparison.OrdinalIgnoreCase));
-
-    private static PayloadParseResult ParsePayload(
-        IFormCollection form,
-        string payloadFieldName)
-    {
-        var payload = ResolveScalar(form, payloadFieldName);
         if (payload == null)
             return PayloadParseResult.Success(null);
 
@@ -224,59 +112,8 @@ internal sealed class WorkflowMultipartChatRequestParser
             part.InlineFile != null ||
             part.FileRef != null) == true;
 
-    private static IReadOnlyList<string>? ResolveWorkflowYamls(IFormCollection form)
-    {
-        if (!form.TryGetValue("workflowYamls", out var values) || values.Count == 0)
-            return null;
-
-        var normalized = values
-            .Select(static value => string.IsNullOrWhiteSpace(value) ? null : value)
-            .Where(static value => value != null)
-            .Cast<string>()
-            .ToArray();
-
-        return normalized.Length == 0 ? null : normalized;
-    }
-
-    private static ChatInputFileRef ToInputFileRef(WorkflowFileRef fileRef) =>
-        new()
-        {
-            FileId = fileRef.FileId,
-            ArtifactId = fileRef.ArtifactId,
-            SourceKind = "form_upload",
-            SourceMessageId = fileRef.SourceMessageId,
-            SourceResourceKey = fileRef.SourceResourceKey,
-            FileName = fileRef.FileName,
-            MediaType = fileRef.MediaType,
-            CreatedAtUnixMs = fileRef.CreatedAtUnixMs,
-            ExpiresAtUnixMs = fileRef.ExpiresAtUnixMs,
-            Sha256 = fileRef.Sha256,
-            OwnerRunId = fileRef.OwnerRunId,
-            OwnerScopeId = fileRef.OwnerScopeId,
-        };
-
-    private static string? ResolveScalar(IFormCollection form, string key)
-    {
-        if (!form.TryGetValue(key, out StringValues values) || values.Count == 0)
-            return null;
-
-        var value = values[0];
-        return Normalize(value);
-    }
-
-    private static string? Normalize(string? value) =>
-        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
-
-    private readonly record struct FileListResult(
-        IReadOnlyList<IFormFile>? Files,
-        WorkflowMultipartChatRequestParseError? Error)
-    {
-        public bool Succeeded => Error == null && Files is { Count: > 0 };
-
-        public static FileListResult Success(IReadOnlyList<IFormFile> files) => new(files, null);
-
-        public static FileListResult Failed(WorkflowMultipartChatRequestParseError error) => new(null, error);
-    }
+    private static WorkflowMultipartChatRequestParseError ToChatError(WorkflowMultipartFileInputParseError error) =>
+        new(error.StatusCode, error.Code, error.Message);
 
     private readonly record struct PayloadParseResult(ChatInput? Input, WorkflowMultipartChatRequestParseError? Error)
     {

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowMultipartFileInputParser.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowMultipartFileInputParser.cs
@@ -1,0 +1,277 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Aevatar.Workflow.Application.Abstractions.Runs;
+
+namespace Aevatar.Workflow.Infrastructure.CapabilityApi;
+
+public sealed class WorkflowMultipartFileInputParser
+{
+    private readonly IOptions<WorkflowMultipartFileIngressOptions> _multipartOptions;
+    private readonly IOptions<WorkflowFormFileIngressOptions> _formOptions;
+
+    public WorkflowMultipartFileInputParser(
+        IOptions<WorkflowMultipartFileIngressOptions> multipartOptions,
+        IOptions<WorkflowFormFileIngressOptions>? formOptions = null)
+    {
+        _multipartOptions = multipartOptions;
+        _formOptions = formOptions ?? Options.Create(new WorkflowFormFileIngressOptions());
+    }
+
+    public async ValueTask<WorkflowMultipartFileInputParseResult> ParseAsync(
+        HttpContext http,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(http);
+
+        if (!IsMultipartForm(http.Request.ContentType))
+            return WorkflowMultipartFileInputParseResult.Failed(
+                WorkflowMultipartFileInputParseError.UnsupportedMediaType);
+
+        IFormCollection form;
+        try
+        {
+            form = await http.Request.ReadFormAsync(cancellationToken);
+        }
+        catch (InvalidDataException)
+        {
+            return WorkflowMultipartFileInputParseResult.Failed(
+                WorkflowMultipartFileInputParseError.InvalidRequest);
+        }
+
+        var filesResult = await ResolveFilesAsync(form, _formOptions.Value.FileFieldName, cancellationToken);
+        if (!filesResult.Succeeded)
+            return WorkflowMultipartFileInputParseResult.Failed(filesResult.Error!.Value);
+
+        var fields = ResolveFields(form);
+        return WorkflowMultipartFileInputParseResult.Success(new WorkflowMultipartFileInputForm(
+            fields,
+            filesResult.Files!,
+            ResolveScalar(fields, _formOptions.Value.PayloadFieldName)));
+    }
+
+    private async ValueTask<FileListResult> ResolveFilesAsync(
+        IFormCollection form,
+        string fileFieldName,
+        CancellationToken cancellationToken)
+    {
+        var expectedName = Normalize(fileFieldName) ?? "file";
+        var files = new List<WorkflowPendingMultipartFile>(form.Files.Count);
+        foreach (var file in form.Files)
+        {
+            if (!string.Equals(file.Name, expectedName, StringComparison.Ordinal))
+                return FileListResult.Failed(WorkflowMultipartFileInputParseError.InvalidFileInput);
+
+            var validationError = ValidateFile(file);
+            if (validationError != null)
+                return FileListResult.Failed(validationError.Value);
+
+            var content = await ReadFileContentAsync(file, cancellationToken);
+            if (content.Length == 0)
+                return FileListResult.Failed(WorkflowMultipartFileInputParseError.InvalidFileInput);
+
+            files.Add(new WorkflowPendingMultipartFile(
+                content,
+                Normalize(file.FileName),
+                Normalize(file.ContentType),
+                ResolveInputPartType(file.ContentType)));
+        }
+
+        return FileListResult.Success(files);
+    }
+
+    private WorkflowMultipartFileInputParseError? ValidateFile(IFormFile file)
+    {
+        if (file.Length <= 0)
+            return WorkflowMultipartFileInputParseError.InvalidFileInput;
+
+        var options = _multipartOptions.Value;
+        if (options.MaxFileBytes <= 0 || file.Length > options.MaxFileBytes)
+            return WorkflowMultipartFileInputParseError.InvalidFileInput;
+
+        var mediaType = Normalize(file.ContentType);
+        if (mediaType == null || !IsAllowedMediaType(mediaType, options.AllowedMediaTypes))
+            return WorkflowMultipartFileInputParseError.InvalidFileInput;
+
+        return null;
+    }
+
+    private static Dictionary<string, StringValues> ResolveFields(IFormCollection form)
+    {
+        var fields = new Dictionary<string, StringValues>(StringComparer.Ordinal);
+        foreach (var (key, value) in form)
+        {
+            fields[key] = value;
+        }
+
+        return fields;
+    }
+
+    private static async ValueTask<byte[]> ReadFileContentAsync(
+        IFormFile file,
+        CancellationToken cancellationToken)
+    {
+        await using var source = file.OpenReadStream();
+        using var target = new MemoryStream((int)Math.Min(file.Length, int.MaxValue));
+        await source.CopyToAsync(target, cancellationToken);
+        return target.ToArray();
+    }
+
+    private static string ResolveInputPartType(string? mediaType)
+    {
+        var normalized = Normalize(mediaType);
+        return normalized switch
+        {
+            { } value when value.StartsWith("image/", StringComparison.OrdinalIgnoreCase) => "image",
+            { } value when value.StartsWith("audio/", StringComparison.OrdinalIgnoreCase) => "audio",
+            { } value when value.StartsWith("video/", StringComparison.OrdinalIgnoreCase) => "video",
+            _ => "file",
+        };
+    }
+
+    private static bool IsAllowedMediaType(string mediaType, IEnumerable<string> allowedMediaTypes) =>
+        allowedMediaTypes.Any(allowed =>
+            string.Equals(Normalize(allowed), mediaType, StringComparison.OrdinalIgnoreCase));
+
+    public static string? ResolveScalar(IReadOnlyDictionary<string, StringValues> form, string key)
+    {
+        if (!form.TryGetValue(key, out var values) || values.Count == 0)
+            return null;
+
+        return Normalize(values[0]);
+    }
+
+    public static string? Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    public static bool IsMultipartForm(string? contentType) =>
+        contentType?.StartsWith("multipart/form-data", StringComparison.OrdinalIgnoreCase) == true;
+
+    public static WorkflowFileIngressRequest BuildIngressRequest(
+        WorkflowPendingMultipartFile file,
+        string? ownerScopeId) =>
+        new(
+            file.Content,
+            WorkflowFileSourceKind.FormUpload,
+            FileName: file.FileName,
+            MediaType: file.MediaType,
+            OwnerScopeId: Normalize(ownerScopeId));
+
+    public static ChatInputContentPart BuildInputPart(
+        WorkflowPendingMultipartFile file,
+        WorkflowFileRef fileRef)
+    {
+        var inputFileRef = ToInputFileRef(fileRef);
+        return new ChatInputContentPart
+        {
+            Type = file.InputPartType,
+            MediaType = inputFileRef.MediaType,
+            Uri = inputFileRef.ArtifactId ?? inputFileRef.Uri,
+            Name = inputFileRef.FileName ?? inputFileRef.Name,
+            FileRef = inputFileRef,
+        };
+    }
+
+    private static ChatInputFileRef ToInputFileRef(WorkflowFileRef fileRef) =>
+        new()
+        {
+            FileId = fileRef.FileId,
+            ArtifactId = fileRef.ArtifactId,
+            SourceKind = "form_upload",
+            SourceMessageId = fileRef.SourceMessageId,
+            SourceResourceKey = fileRef.SourceResourceKey,
+            FileName = fileRef.FileName,
+            MediaType = fileRef.MediaType,
+            CreatedAtUnixMs = fileRef.CreatedAtUnixMs,
+            ExpiresAtUnixMs = fileRef.ExpiresAtUnixMs,
+            Sha256 = fileRef.Sha256,
+            OwnerRunId = fileRef.OwnerRunId,
+            OwnerScopeId = fileRef.OwnerScopeId,
+        };
+
+    private readonly record struct FileListResult(
+        IReadOnlyList<WorkflowPendingMultipartFile>? Files,
+        WorkflowMultipartFileInputParseError? Error)
+    {
+        public bool Succeeded => Error == null && Files != null;
+
+        public static FileListResult Success(IReadOnlyList<WorkflowPendingMultipartFile> files) => new(files, null);
+
+        public static FileListResult Failed(WorkflowMultipartFileInputParseError error) => new(null, error);
+    }
+}
+
+public sealed record WorkflowMultipartFileInputForm(
+    IReadOnlyDictionary<string, StringValues> Fields,
+    IReadOnlyList<WorkflowPendingMultipartFile> PendingFiles,
+    string? RawPayloadJson)
+{
+    public bool HasFiles => PendingFiles.Count > 0;
+
+    public string? ResolveScalar(string key) =>
+        WorkflowMultipartFileInputParser.ResolveScalar(Fields, key);
+
+    public IReadOnlyList<string>? ResolveRepeatedScalars(string key)
+    {
+        if (!Fields.TryGetValue(key, out var values) || values.Count == 0)
+            return null;
+
+        var normalized = values
+            .Select(static value => string.IsNullOrWhiteSpace(value) ? null : value)
+            .Where(static value => value != null)
+            .Cast<string>()
+            .ToArray();
+
+        return normalized.Length == 0 ? null : normalized;
+    }
+}
+
+public sealed record WorkflowPendingMultipartFile(
+    ReadOnlyMemory<byte> Content,
+    string? FileName,
+    string? MediaType,
+    string InputPartType);
+
+public readonly record struct WorkflowMultipartFileInputParseResult(
+    WorkflowMultipartFileInputForm? Form,
+    WorkflowMultipartFileInputParseError? Error)
+{
+    public bool Succeeded => Error == null && Form != null;
+
+    public bool HasFiles => Form?.HasFiles == true;
+
+    public string? RawPayloadJson => Form?.RawPayloadJson;
+
+    public int StatusCode => Error?.StatusCode ?? StatusCodes.Status200OK;
+
+    public string Code => Error?.Code ?? string.Empty;
+
+    public string Message => Error?.Message ?? string.Empty;
+
+    public static WorkflowMultipartFileInputParseResult Success(WorkflowMultipartFileInputForm form) =>
+        new(form, null);
+
+    public static WorkflowMultipartFileInputParseResult Failed(WorkflowMultipartFileInputParseError error) =>
+        new(null, error);
+}
+
+public readonly record struct WorkflowMultipartFileInputParseError(
+    int StatusCode,
+    string Code,
+    string Message)
+{
+    public static readonly WorkflowMultipartFileInputParseError UnsupportedMediaType = new(
+        StatusCodes.Status415UnsupportedMediaType,
+        "UNSUPPORTED_MEDIA_TYPE",
+        "Content-Type must be multipart/form-data.");
+
+    public static readonly WorkflowMultipartFileInputParseError InvalidRequest = new(
+        StatusCodes.Status400BadRequest,
+        "INVALID_CHAT_INPUT",
+        "Multipart chat request is invalid.");
+
+    public static readonly WorkflowMultipartFileInputParseError InvalidFileInput = new(
+        StatusCodes.Status400BadRequest,
+        "INVALID_FILE_INPUT",
+        "Multipart chat file input is invalid.");
+}

--- a/src/workflow/Aevatar.Workflow.Infrastructure/DependencyInjection/WorkflowCapabilityServiceCollectionExtensions.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/DependencyInjection/WorkflowCapabilityServiceCollectionExtensions.cs
@@ -49,6 +49,7 @@ public static class WorkflowCapabilityServiceCollectionExtensions
             .Bind(configuration.GetSection(WorkflowMultipartFileIngressOptions.SectionName));
         services.AddOptions<WorkflowFormFileIngressOptions>()
             .Bind(configuration.GetSection(WorkflowFormFileIngressOptions.SectionName));
+        services.TryAddSingleton<WorkflowMultipartFileInputParser>();
         services.TryAddSingleton<WorkflowMultipartChatRequestParser>();
         services.TryAddSingleton<WorkflowWebhookIngressRequestBuilder>();
         var webhookReplayRedisConnectionString = configuration[$"{WorkflowWebhookIngressOptions.SectionName}:RedisConnectionString"];

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceDraftRunMultipartTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceDraftRunMultipartTests.cs
@@ -1,0 +1,36 @@
+using System.Net;
+using System.Text.Json;
+using Aevatar.CQRS.Core.Abstractions.Interactions;
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgentService.Integration.Tests;
+
+[Collection(ScopeServiceEndpointCollection.Name)]
+public sealed class ScopeServiceDraftRunMultipartTests : ScopeServiceEndpointTestKit
+{
+    [Fact]
+    public async Task ScopeDraftRunEndpoint_ShouldRejectMultipartWithoutWritingArtifacts()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/scopes/scope-a/workflow/draft-run")
+        {
+            Content = CreateMultipartScopeStreamContent(
+                """
+                {
+                  "prompt": "run the draft",
+                  "workflowYamls": ["name: main\nsteps:\n  - run: echo hello"]
+                }
+                """,
+                [("cat.png", "image/png", "hello")]),
+        };
+
+        var response = await host.Client.SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType, "body: {0}", body);
+        host.WorkflowFileIngressPort.Requests.Should().BeEmpty();
+        host.InteractionService.LastRequest.Should().BeNull();
+    }
+}

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceEndpointTestKit.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceEndpointTestKit.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Reflection;
 using System.Security.Claims;
+using System.Text;
 using System.Text.Json;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
@@ -257,7 +258,8 @@ public abstract class ScopeServiceEndpointTestKit
             RecordingSignalDispatchService signalDispatchService,
             RecordingStopDispatchService stopDispatchService,
             RecordingServiceRunRegistrationPort serviceRunRegistrationPort,
-            FakeServiceRunQueryPort serviceRunQueryPort)
+            FakeServiceRunQueryPort serviceRunQueryPort,
+            RecordingWorkflowFileIngressPort workflowFileIngressPort)
         {
             _app = app;
             Client = client;
@@ -282,6 +284,7 @@ public abstract class ScopeServiceEndpointTestKit
             StopDispatchService = stopDispatchService;
             ServiceRunRegistrationPort = serviceRunRegistrationPort;
             ServiceRunQueryPort = serviceRunQueryPort;
+            WorkflowFileIngressPort = workflowFileIngressPort;
         }
 
         public HttpClient Client { get; }
@@ -336,6 +339,8 @@ public abstract class ScopeServiceEndpointTestKit
 
         public FakeServiceRunQueryPort ServiceRunQueryPort { get; }
 
+        public RecordingWorkflowFileIngressPort WorkflowFileIngressPort { get; }
+
         public static async Task<ScopeServiceEndpointTestHost> StartAsync(
             bool authenticationEnabled = true,
             IUserConfigQueryPort? userConfigQueryPort = null)
@@ -385,6 +390,7 @@ public abstract class ScopeServiceEndpointTestKit
             {
                 LinkedQueryPort = serviceRunQueryPort,
             };
+            var workflowFileIngressPort = new RecordingWorkflowFileIngressPort();
             builder.Services.AddSingleton<IServiceGovernanceCommandPort>(commandPort);
             builder.Services.AddSingleton<IServiceGovernanceQueryPort>(queryPort);
             builder.Services.AddSingleton<IScopeBindingCommandPort>(scopeBindingPort);
@@ -414,6 +420,10 @@ public abstract class ScopeServiceEndpointTestKit
             builder.Services.AddSingleton<IActorEventSubscriptionProvider>(eventSubscriptionProvider);
             builder.Services.AddSingleton<IServiceRunRegistrationPort>(serviceRunRegistrationPort);
             builder.Services.AddSingleton<IServiceRunQueryPort>(serviceRunQueryPort);
+            builder.Services.AddSingleton<IWorkflowFileIngressPort>(workflowFileIngressPort);
+            builder.Services.AddSingleton<WorkflowMultipartFileInputParser>();
+            builder.Services.AddSingleton(Options.Create(new WorkflowMultipartFileIngressOptions()));
+            builder.Services.AddSingleton(Options.Create(new WorkflowFormFileIngressOptions()));
             if (userConfigQueryPort != null)
                 builder.Services.AddSingleton(userConfigQueryPort);
             builder.Services.AddSingleton<IOptions<ScopeWorkflowCapabilityOptions>>(
@@ -528,7 +538,8 @@ public abstract class ScopeServiceEndpointTestKit
                 signalDispatchService,
                 stopDispatchService,
                 serviceRunRegistrationPort,
-                serviceRunQueryPort);
+                serviceRunQueryPort,
+                workflowFileIngressPort);
         }
 
         private static bool TryGetRequestedScopeId(string? path, out string scopeId)
@@ -1664,5 +1675,49 @@ public abstract class ScopeServiceEndpointTestKit
             // This handler returns NoResult so it does not interfere.
             return Task.FromResult(Microsoft.AspNetCore.Authentication.AuthenticateResult.NoResult());
         }
+    }
+
+    protected sealed class RecordingWorkflowFileIngressPort : IWorkflowFileIngressPort
+    {
+        public List<WorkflowFileIngressRequest> Requests { get; } = [];
+
+        public ValueTask<WorkflowFileIngressResult> IngestAsync(
+            WorkflowFileIngressRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            Requests.Add(request);
+            var index = Requests.Count;
+            return ValueTask.FromResult(new WorkflowFileIngressResult(new WorkflowFileRef
+            {
+                FileId = $"file-{index}",
+                ArtifactId = $"workflow-file://file-{index}",
+                SourceKind = request.SourceKind,
+                FileName = request.FileName,
+                MediaType = request.MediaType,
+                SizeBytes = request.Content.Length,
+                Sha256 = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+                CreatedAtUnixMs = 1710000000000,
+                ExpiresAtUnixMs = 1710003600000,
+                OwnerScopeId = request.OwnerScopeId,
+            }));
+        }
+    }
+
+    protected static MultipartFormDataContent CreateMultipartScopeStreamContent(
+        string? payloadJson,
+        IReadOnlyList<(string FileName, string ContentType, string Content)> files)
+    {
+        var content = new MultipartFormDataContent();
+        if (payloadJson != null)
+            content.Add(new StringContent(payloadJson, Encoding.UTF8, "application/json"), "payload");
+
+        foreach (var file in files)
+        {
+            var fileContent = new ByteArrayContent(Encoding.UTF8.GetBytes(file.Content));
+            fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(file.ContentType);
+            content.Add(fileContent, "file", file.FileName);
+        }
+
+        return content;
     }
 }

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceTeamStreamMultipartTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceTeamStreamMultipartTests.cs
@@ -1,0 +1,211 @@
+using System.Net;
+using Aevatar.AGUI.Contracts;
+using Aevatar.CQRS.Core.Abstractions.Interactions;
+using Aevatar.AI.Abstractions;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.GAgentService.Abstractions.Services;
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgentService.Integration.Tests;
+
+[Collection(ScopeServiceEndpointCollection.Name)]
+public sealed class ScopeServiceTeamStreamMultipartTests : ScopeServiceEndpointTestKit
+{
+    [Fact]
+    public async Task TeamInvokeStreamEndpoint_ShouldIngestMultipartFileForWorkflowTargetAfterTeamResolution()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.TeamEntryMemberResolver.Result = new TeamEntryMemberResolution(
+            "scope-a",
+            "team-a",
+            "member-a",
+            "member-a");
+        var service = BuildService("scope-a", "member-a", "definition-actor-member-a");
+        host.ServiceCatalogReader.Service = service;
+        host.TrafficViewReader.View = new ServiceTrafficViewSnapshot(
+            service.ServiceKey,
+            1,
+            string.Empty,
+            [
+                new ServiceTrafficEndpointSnapshot(
+                    "chat",
+                    [
+                        new ServiceTrafficTargetSnapshot(
+                            "dep-team-member-a-1",
+                            "rev-team-member-a-1",
+                            "definition-actor-member-a",
+                            100,
+                            ServiceServingState.Active.ToString()),
+                    ]),
+            ],
+            DateTimeOffset.UtcNow);
+        await host.RevisionCatalog.UpsertRevisionAsync(
+            service.ServiceKey,
+            "rev-team-member-a-1",
+            new PreparedServiceRevisionArtifact
+            {
+                Identity = new ServiceIdentity
+                {
+                    TenantId = "scope-a",
+                    AppId = "default",
+                    Namespace = "default",
+                    ServiceId = "member-a",
+                },
+                RevisionId = "rev-team-member-a-1",
+                ImplementationKind = ServiceImplementationKind.Workflow,
+                Endpoints =
+                {
+                    new ServiceEndpointDescriptor
+                    {
+                        EndpointId = "chat",
+                        DisplayName = "chat",
+                        Kind = ServiceEndpointKind.Chat,
+                        RequestTypeUrl = Any.Pack(new ChatRequestEvent()).TypeUrl,
+                        ResponseTypeUrl = Any.Pack(new ChatResponseEvent()).TypeUrl,
+                    },
+                },
+                DeploymentPlan = new ServiceDeploymentPlan
+                {
+                    WorkflowPlan = new WorkflowServiceDeploymentPlan
+                    {
+                        WorkflowName = "member-a",
+                        WorkflowYaml = "name: member_a\nsteps:\n  - run: echo member",
+                        DefinitionActorId = "definition-actor-member-a",
+                    },
+                },
+            },
+            CancellationToken.None);
+        host.InteractionService.ResultFactory = async (request, emitAsync, onAcceptedAsync, ct) =>
+        {
+            var receipt = new WorkflowChatRunAcceptedReceipt("run-actor-team-a", "member-a", "cmd-team-a", "corr-team-a");
+            if (onAcceptedAsync != null)
+                await onAcceptedAsync(receipt, ct);
+            return CommandInteractionResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
+        };
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/scopes/scope-a/teams/team-a/invoke/chat:stream")
+        {
+            Content = CreateMultipartScopeStreamContent(
+                """
+                {
+                  "prompt": "hello team",
+                  "headers": { "channel": "team-tests" }
+                }
+                """,
+                [("cat.png", "image/png", "hello")]),
+        };
+
+        var response = await host.Client.SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, "stream body: {0}", body);
+        body.Should().Contain("aevatar.run.context");
+        host.TeamEntryMemberResolver.Calls.Should().ContainSingle().Which.Should().Be(("scope-a", "team-a", "chat"));
+        host.WorkflowFileIngressPort.Requests.Should().ContainSingle();
+        var ingressRequest = host.WorkflowFileIngressPort.Requests[0];
+        ingressRequest.SourceKind.Should().Be(WorkflowFileSourceKind.FormUpload);
+        ingressRequest.OwnerScopeId.Should().Be("scope-a");
+        ingressRequest.FileName.Should().Be("cat.png");
+        ingressRequest.MediaType.Should().Be("image/png");
+        host.InteractionService.LastRequest.Should().NotBeNull();
+        host.InteractionService.LastRequest!.ScopeId.Should().Be("scope-a");
+        host.InteractionService.LastRequest.Source.ActorId.Should().Be("definition-actor-member-a");
+        host.InteractionService.LastRequest.Headers.Should().ContainKey("channel").WhoseValue.Should().Be("team-tests");
+        var part = host.InteractionService.LastRequest.InputParts.Should().ContainSingle().Which;
+        part.Kind.Should().Be(WorkflowChatInputPartKind.Image);
+        part.DataBase64.Should().BeNull();
+        part.FileRef.Should().NotBeNull();
+        part.FileRef!.ArtifactId.Should().Be("workflow-file://file-1");
+        part.FileRef.OwnerScopeId.Should().Be("scope-a");
+    }
+
+    [Fact]
+    public async Task TeamInvokeStreamEndpoint_ShouldRejectMultipartForStaticTargetWithoutWritingArtifacts()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.TeamEntryMemberResolver.Result = new TeamEntryMemberResolution(
+            "scope-a",
+            "team-a",
+            "member-a",
+            "member-a");
+        var service = BuildService("scope-a", "member-a", "definition-actor-member-a");
+        host.ServiceCatalogReader.Service = service;
+        host.TrafficViewReader.View = new ServiceTrafficViewSnapshot(
+            service.ServiceKey,
+            1,
+            string.Empty,
+            [
+                new ServiceTrafficEndpointSnapshot(
+                    "chat",
+                    [
+                        new ServiceTrafficTargetSnapshot(
+                            "dep-team-member-a-1",
+                            "rev-team-member-a-1",
+                            "definition-actor-member-a",
+                            100,
+                            ServiceServingState.Active.ToString()),
+                    ]),
+            ],
+            DateTimeOffset.UtcNow);
+        await host.RevisionCatalog.UpsertRevisionAsync(
+            service.ServiceKey,
+            "rev-team-member-a-1",
+            new PreparedServiceRevisionArtifact
+            {
+                Identity = new ServiceIdentity
+                {
+                    TenantId = "scope-a",
+                    AppId = "default",
+                    Namespace = "default",
+                    ServiceId = "member-a",
+                },
+                RevisionId = "rev-team-member-a-1",
+                ImplementationKind = ServiceImplementationKind.Static,
+                Endpoints =
+                {
+                    new ServiceEndpointDescriptor
+                    {
+                        EndpointId = "chat",
+                        DisplayName = "chat",
+                        Kind = ServiceEndpointKind.Chat,
+                        RequestTypeUrl = Any.Pack(new ChatRequestEvent()).TypeUrl,
+                        ResponseTypeUrl = Any.Pack(new ChatResponseEvent()).TypeUrl,
+                    },
+                },
+                DeploymentPlan = new ServiceDeploymentPlan
+                {
+                    StaticPlan = new StaticServiceDeploymentPlan
+                    {
+                        ActorTypeName = "Test.StaticAgent, Tests",
+                    },
+                },
+            },
+            CancellationToken.None);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/scopes/scope-a/teams/team-a/invoke/chat:stream")
+        {
+            Content = CreateMultipartScopeStreamContent(
+                """
+                {
+                  "prompt": "hello team"
+                }
+                """,
+                [("cat.png", "image/png", "hello")]),
+        };
+
+        var response = await host.Client.SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, "stream body: {0}", body);
+        body.Should().Contain("INVALID_SERVICE_STREAM_REQUEST");
+        body.Should().Contain("Multipart file input is only supported for workflow services.");
+        host.TeamEntryMemberResolver.Calls.Should().ContainSingle().Which.Should().Be(("scope-a", "team-a", "chat"));
+        host.WorkflowFileIngressPort.Requests.Should().BeEmpty();
+        host.StaticGAgentStreamInvocationPort.Requests.Should().BeEmpty();
+        host.InteractionService.LastRequest.Should().BeNull();
+    }
+}

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatFormRunRequestParserTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatFormRunRequestParserTests.cs
@@ -4,6 +4,7 @@ using Aevatar.Workflow.Infrastructure.CapabilityApi;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using ApplicationWorkflowFileRef = Aevatar.Workflow.Application.Abstractions.Runs.WorkflowFileRef;
@@ -13,6 +14,26 @@ namespace Aevatar.Workflow.Host.Api.Tests;
 
 public sealed class ChatFormRunRequestParserTests
 {
+    [Fact]
+    public void ServiceProvider_ShouldResolveParserWithSharedMultipartFileParser()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.AddSingleton<IWorkflowFileIngressPort>(new RecordingWorkflowFileIngressPort());
+        services.AddSingleton<WorkflowMultipartFileInputParser>();
+        services.AddSingleton<WorkflowMultipartChatRequestParser>();
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true,
+        });
+
+        provider.GetRequiredService<WorkflowMultipartChatRequestParser>()
+            .Should()
+            .NotBeNull();
+    }
+
     [Fact]
     public async Task ParseAsync_ShouldIngestSingleFileAsFormUploadAndBuildFileRefInputPart()
     {

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowMultipartFileInputParserTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowMultipartFileInputParserTests.cs
@@ -1,0 +1,189 @@
+using System.Text;
+using Aevatar.Workflow.Infrastructure.CapabilityApi;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+
+namespace Aevatar.Workflow.Host.Api.Tests;
+
+public sealed class WorkflowMultipartFileInputParserTests
+{
+    [Fact]
+    public async Task ParseAsync_ShouldReturnRawPayloadAndPendingFilesWithoutIngress()
+    {
+        var parser = CreateParser();
+        var http = CreateMultipartHttpContext(
+            new Dictionary<string, string>
+            {
+                ["payload"] = """{"prompt":"payload prompt"}""",
+                ["prompt"] = "form prompt",
+            },
+            [CreateFormFile("file", "cat.png", "image/png", "hello")]);
+
+        var result = await parser.ParseAsync(http, CancellationToken.None);
+
+        result.Succeeded.Should().BeTrue();
+        result.HasFiles.Should().BeTrue();
+        result.RawPayloadJson.Should().Be("""{"prompt":"payload prompt"}""");
+        result.Form.Should().NotBeNull();
+        result.Form!.Fields["prompt"].ToString().Should().Be("form prompt");
+        result.Form.PendingFiles.Should().ContainSingle();
+        var file = result.Form.PendingFiles[0];
+        file.FileName.Should().Be("cat.png");
+        file.MediaType.Should().Be("image/png");
+        file.InputPartType.Should().Be("image");
+        Encoding.UTF8.GetString(file.Content.ToArray()).Should().Be("hello");
+    }
+
+    [Fact]
+    public async Task ParseAsync_ShouldAllowNoFileMultipartForHostDtoParsing()
+    {
+        var parser = CreateParser();
+        var http = CreateMultipartHttpContext(
+            new Dictionary<string, string>
+            {
+                ["payload"] = """{"prompt":"payload prompt"}""",
+            },
+            []);
+
+        var result = await parser.ParseAsync(http, CancellationToken.None);
+
+        result.Succeeded.Should().BeTrue();
+        result.HasFiles.Should().BeFalse();
+        result.RawPayloadJson.Should().Be("""{"prompt":"payload prompt"}""");
+        result.Form.Should().NotBeNull();
+        result.Form!.PendingFiles.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ParseAsync_ShouldRejectMismatchedFileFieldName()
+    {
+        var parser = CreateParser();
+        var http = CreateMultipartHttpContext(
+            new Dictionary<string, string>
+            {
+                ["prompt"] = "hello",
+            },
+            [CreateFormFile("upload", "cat.png", "image/png", "hello")]);
+
+        var result = await parser.ParseAsync(http, CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        result.Code.Should().Be("INVALID_FILE_INPUT");
+    }
+
+    [Fact]
+    public async Task ParseAsync_ShouldRejectWholeRequest_WhenAnyFileIsInvalid()
+    {
+        var parser = CreateParser(new WorkflowMultipartFileIngressOptions
+        {
+            MaxFileBytes = 8,
+        });
+        var http = CreateMultipartHttpContext(
+            new Dictionary<string, string>
+            {
+                ["prompt"] = "hello",
+            },
+            [
+                CreateFormFile("file", "cat.png", "image/png", "hello"),
+                CreateFormFile("file", "large.png", "image/png", "too-large"),
+            ]);
+
+        var result = await parser.ParseAsync(http, CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        result.Code.Should().Be("INVALID_FILE_INPUT");
+    }
+
+    [Fact]
+    public async Task ParseAsync_ShouldRejectUnsupportedMediaType()
+    {
+        var parser = CreateParser();
+        var http = CreateMultipartHttpContext(
+            new Dictionary<string, string>
+            {
+                ["prompt"] = "hello",
+            },
+            [CreateFormFile("file", "cat.gif", "image/gif", "hello")]);
+
+        var result = await parser.ParseAsync(http, CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        result.Code.Should().Be("INVALID_FILE_INPUT");
+    }
+
+    [Fact]
+    public async Task ParseAsync_ShouldAcceptConfiguredFileFieldName()
+    {
+        var parser = CreateParser(formOptions: new WorkflowFormFileIngressOptions
+        {
+            FileFieldName = "upload",
+        });
+        var http = CreateMultipartHttpContext(
+            new Dictionary<string, string>
+            {
+                ["prompt"] = "hello",
+            },
+            [CreateFormFile("upload", "cat.png", "image/png", "hello")]);
+
+        var result = await parser.ParseAsync(http, CancellationToken.None);
+
+        result.Succeeded.Should().BeTrue();
+        result.Form.Should().NotBeNull();
+        result.Form!.PendingFiles.Should().ContainSingle()
+            .Which.FileName.Should().Be("cat.png");
+    }
+
+    private static WorkflowMultipartFileInputParser CreateParser(
+        WorkflowMultipartFileIngressOptions? options = null,
+        WorkflowFormFileIngressOptions? formOptions = null) =>
+        new(
+            Options.Create(options ?? new WorkflowMultipartFileIngressOptions()),
+            Options.Create(formOptions ?? new WorkflowFormFileIngressOptions()));
+
+    private static DefaultHttpContext CreateMultipartHttpContext(
+        IDictionary<string, string> fields,
+        IReadOnlyList<IFormFile> files)
+    {
+        var stringValues = fields.ToDictionary(
+            static pair => pair.Key,
+            static pair => new StringValues(pair.Value),
+            StringComparer.Ordinal);
+
+        return CreateMultipartHttpContext(stringValues, files);
+    }
+
+    private static DefaultHttpContext CreateMultipartHttpContext(
+        IDictionary<string, StringValues> fields,
+        IReadOnlyList<IFormFile> files)
+    {
+        var http = new DefaultHttpContext();
+        http.Request.ContentType = "multipart/form-data; boundary=test";
+        var formFiles = new FormFileCollection();
+        foreach (var file in files)
+            formFiles.Add(file);
+        http.Features.Set<IFormFeature>(new FormFeature(new FormCollection(
+            new Dictionary<string, StringValues>(fields, StringComparer.Ordinal),
+            formFiles)));
+        return http;
+    }
+
+    private static IFormFile CreateFormFile(
+        string fieldName,
+        string fileName,
+        string contentType,
+        string content)
+    {
+        var bytes = Encoding.UTF8.GetBytes(content);
+        return new FormFile(new MemoryStream(bytes), 0, bytes.Length, fieldName, fileName)
+        {
+            Headers = new HeaderDictionary(),
+            ContentType = contentType,
+        };
+    }
+}

--- a/tools/ci/guards/catch_exception_observability_baseline.tsv
+++ b/tools/ci/guards/catch_exception_observability_baseline.tsv
@@ -76,7 +76,6 @@ src/Aevatar.Studio.Infrastructure/Storage/FileAevatarSettingsStore.cs	452	broad 
 src/platform/Aevatar.GAgentService.Application/ScopeGAgents/ScopeGAgentActorTypeResolver.cs	27	empty broad catch block
 src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeGAgentEndpoints.cs	186	empty broad catch block
 src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeGAgentEndpoints.cs	213	empty broad catch block
-src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs	3151	empty broad catch block
 src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs	649	empty broad catch block
 src/platform/Aevatar.GAgentService.Projection/Orchestration/GAgentDraftRunObservationScopeActivationPort.cs	71	broad catch returns null without visible failure signal
 src/platform/Aevatar.GAgentService.Projection/Orchestration/LlmSessionObservationScopeLeasePreparationPort.cs	47	broad catch returns null without visible failure signal


### PR DESCRIPTION
## Changed files

- 新增 `WorkflowMultipartFileInputParser`，把 multipart content-type、字段、媒体类型、大小、文件 bytes 读取和 pending file 表达收敛到 workflow infrastructure。
- `WorkflowMultipartChatRequestParser` 改为复用共享 parser，并继续只在 workflow chat 目标确认后执行 artifact ingress 与 typed file-ref 映射。
- scope service stream endpoint 改为在 path scope access guard 之后统一解析 JSON/multipart，请求目标确认是 workflow service 后才用 path `scopeId` 写入 artifact store；static/scripting stream 对 multipart 文件 fail-closed。
- 补充 workflow host parser 单测、scope service multipart 集成测试，以及 chat API / runtime canonical docs。
- 清理 `ScopeServiceEndpoints.cs` 已修复空 broad catch 后产生的 catch-observability stale baseline 行。

## Test results

- `bash -lc "dotnet build aevatar.slnx --nologo"`：通过，0 errors。
- `bash -lc "dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --filter \"WorkflowMultipartFileInputParserTests|ChatFormRunRequestParserTests\" --nologo"`：通过，26 passed。
- `bash -lc "dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --filter \"ScopeServiceDraftRunEndpointTests|ScopeServiceDraftRunMultipartTests|ScopeServiceStreamInvocationEndpointTests|ScopeServiceTeamStreamMultipartTests\" --nologo"`：通过，25 passed。
- `bash tools/ci/test_stability_guards.sh`：通过。
- `bash tools/docs/lint.sh`：通过。
- `bash tools/ci/architecture_guards.sh`：通过。

## Deviations

- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)
- 记录了一次 scope 扩展：`tools/ci/guards/catch_exception_observability_baseline.tsv`，用于删除因本次 observable catch 修复产生的 stale baseline 行。
- 未 commit、未 push、未执行任何 GitHub lifecycle 操作。
- Closes #2243

⟦AI:AUTO-LOOP⟧
