### PR TITLE
Polish team member action controls

### DIFF
--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioExecutionPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioExecutionPanel.tsx
@@ -115,6 +115,8 @@ const statusColors: Record<ExecutionLogStatus, string> = {
   waiting: "orange",
 };
 
+const nodeDetailBlockHeight = 230;
+
 function formatConsoleDateTime(value: string | null | undefined): string {
   if (!value) {
     return "";
@@ -167,7 +169,6 @@ function readStatusLabel(status: ExecutionLogStatus): string {
       return t("teamMemberWorkflowStudio.executionPanel.status.success", "Success");
     case "waiting":
       return t("teamMemberWorkflowStudio.executionPanel.status.waiting", "Waiting");
-    case "running":
     default:
       return t("teamMemberWorkflowStudio.executionPanel.status.running", "Running");
   }
@@ -183,7 +184,6 @@ function renderStatusIcon(status: ExecutionLogStatus): React.ReactNode {
       return <CheckCircleOutlined style={{ color: "#16a34a" }} />;
     case "waiting":
       return <PauseCircleOutlined style={{ color: "#d97706" }} />;
-    case "running":
     default:
       return <LoadingOutlined style={{ color: "#2563eb" }} />;
   }
@@ -448,9 +448,15 @@ function renderDataBlock(
   label: string,
   value: string,
   emptyText: string,
-  options: { readonly danger?: boolean; readonly maxHeight?: number } = {},
+  options: {
+    readonly danger?: boolean;
+    readonly height?: number;
+    readonly maxHeight?: number;
+    readonly testId?: string;
+  } = {},
 ): React.ReactNode {
   const text = value.trim();
+  const blockHeight = options.height;
 
   return (
     <div
@@ -473,6 +479,7 @@ function renderDataBlock(
         {label}
       </Typography.Text>
       <pre
+        data-testid={options.testId}
         style={{
           background: text ? "#f8fafc" : "#ffffff",
           border: `1px solid ${options.danger ? "#fecaca" : "#e5e7eb"}`,
@@ -481,9 +488,10 @@ function renderDataBlock(
           fontFamily:
             "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
           fontSize: 12,
+          height: blockHeight,
           lineHeight: "18px",
           margin: 0,
-          maxHeight: options.maxHeight ?? 180,
+          maxHeight: blockHeight ? undefined : options.maxHeight ?? 180,
           minHeight: 50,
           overflow: "auto",
           padding: "9px 10px",
@@ -631,7 +639,7 @@ function renderOverviewRow(
 
 function renderNodeInputPane(
   entry: ExecutionOverviewEntry,
-  maxHeight = 260,
+  blockHeight = nodeDetailBlockHeight,
 ): React.ReactNode {
   const interactionContext = entry.meta.trim();
 
@@ -653,14 +661,14 @@ function renderNodeInputPane(
           "teamMemberWorkflowStudio.executionPanel.emptyNodeInput",
           "No input captured for this node.",
         ),
-        { maxHeight },
+        { height: blockHeight, testId: "workflow-execution-node-input-block" },
       )}
       {entry.pendingText
         ? renderDataBlock(
             t("teamMemberWorkflowStudio.executionPanel.nodePrompt", "Prompt"),
             [interactionContext, entry.pendingText].filter(Boolean).join("\n\n"),
             "",
-            { maxHeight: Math.max(90, Math.floor(maxHeight / 2)) },
+            { maxHeight: Math.max(90, Math.floor(blockHeight / 2)) },
           )
         : null}
       {entry.interactionText
@@ -673,7 +681,7 @@ function renderNodeInputPane(
               .filter(Boolean)
               .join("\n\n"),
             "",
-            { maxHeight: Math.max(90, Math.floor(maxHeight / 2)) },
+            { maxHeight: Math.max(90, Math.floor(blockHeight / 2)) },
           )
         : null}
     </div>
@@ -682,7 +690,7 @@ function renderNodeInputPane(
 
 function renderNodeOutputPane(
   entry: ExecutionOverviewEntry,
-  maxHeight = 260,
+  blockHeight = nodeDetailBlockHeight,
 ): React.ReactNode {
   const outputIsError = entry.status === "error";
 
@@ -695,7 +703,11 @@ function renderNodeOutputPane(
       "teamMemberWorkflowStudio.executionPanel.emptyNodeOutput",
       "No output captured for this node.",
     ),
-    { danger: outputIsError, maxHeight },
+    {
+      danger: outputIsError,
+      height: blockHeight,
+      testId: "workflow-execution-node-output-block",
+    },
   );
 }
 
@@ -761,8 +773,8 @@ function renderSelectedDetails(
         minWidth: 0,
       }}
     >
-      {showInput ? renderNodeInputPane(entry, showOutput ? 170 : 260) : null}
-      {showOutput ? renderNodeOutputPane(entry, showInput ? 250 : 260) : null}
+      {showInput ? renderNodeInputPane(entry) : null}
+      {showOutput ? renderNodeOutputPane(entry) : null}
     </div>
   );
 }
@@ -1006,11 +1018,6 @@ const WorkflowStudioExecutionPanel: React.FC<WorkflowStudioExecutionPanelProps> 
               }}
             >
               <section
-                aria-label={t(
-                  "teamMemberWorkflowStudio.executionPanel.logsOverview",
-                  "Logs overview",
-                )}
-                onKeyDown={handleOverviewKeyDown}
                 style={{
                   borderRight: selectedEntry ? "1px solid #edf2f7" : 0,
                   display: "grid",
@@ -1019,7 +1026,6 @@ const WorkflowStudioExecutionPanel: React.FC<WorkflowStudioExecutionPanelProps> 
                   minWidth: 0,
                   padding: "10px 12px 12px",
                 }}
-                tabIndex={0}
               >
                 <div
                   style={{
@@ -1070,6 +1076,13 @@ const WorkflowStudioExecutionPanel: React.FC<WorkflowStudioExecutionPanelProps> 
                   />
                 </div>
                 <div
+                  aria-label={t(
+                    "teamMemberWorkflowStudio.executionPanel.logsOverview",
+                    "Logs overview",
+                  )}
+                  onKeyDown={handleOverviewKeyDown}
+                  role="listbox"
+                  tabIndex={0}
                   style={{
                     display: "grid",
                     gap: 8,

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -3850,6 +3850,12 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(logDetails).toHaveTextContent("Run the workflow");
     expect(logDetails).toHaveTextContent("Workflow complete");
     expect(
+      within(logDetails).getByTestId("workflow-execution-node-input-block"),
+    ).toHaveStyle({ height: "230px" });
+    expect(
+      within(logDetails).getByTestId("workflow-execution-node-output-block"),
+    ).toHaveStyle({ height: "230px" });
+    expect(
       within(consolePanel).queryByRole("button", { name: "Copy selected log" }),
     ).toBeNull();
     expect(screen.getByRole("button", { name: "node:step:triage" })).toHaveAttribute(

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
@@ -3,6 +3,7 @@ import {
   ClockCircleOutlined,
   PlayCircleOutlined,
   PlusOutlined,
+  StopOutlined,
   ToolOutlined,
 } from "@ant-design/icons";
 import { Button, Skeleton, Tooltip, Typography, theme } from "antd";
@@ -64,7 +65,7 @@ const ellipsisTextStyle: React.CSSProperties = {
 };
 
 const tableGridTemplateColumns =
-  "minmax(280px, 1.35fr) minmax(140px, 0.45fr) minmax(180px, 0.55fr) minmax(390px, 0.95fr)";
+  "minmax(260px, 1.4fr) minmax(140px, 0.45fr) minmax(180px, 0.7fr) 180px";
 
 const tableShellStyle: React.CSSProperties = {
   borderRadius: 8,
@@ -96,32 +97,37 @@ const responsiveTableStyle = `
   }
 
   .team-members-table-actions {
+    justify-content: flex-start !important;
     width: 100% !important;
   }
 
   .team-members-table-primary-actions {
-    grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+    justify-content: flex-start !important;
     width: 100% !important;
   }
 
   .team-members-table-invoke-action,
   .team-members-table-automate-action,
-  .team-members-table-studio-action {
-    min-width: 0 !important;
-    padding-inline: 8px !important;
-    width: 100% !important;
-  }
-
+  .team-members-table-studio-action,
   .team-members-table-entry-action {
     min-width: 0 !important;
-    width: 100% !important;
   }
 }
 
 @media (max-width: 420px) {
   .team-members-table-primary-actions {
-    grid-template-columns: minmax(0, 1fr) !important;
+    justify-content: flex-start !important;
   }
+}
+
+.team-members-table-action-button {
+  transition: background-color 160ms ease, color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+}
+
+.team-members-table-action-button:hover,
+.team-members-table-action-button:focus-visible {
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08) !important;
+  transform: translateY(-1px);
 }
 `;
 
@@ -136,7 +142,8 @@ const tableHeaderStyle: React.CSSProperties = {
 };
 
 const tableHeaderActionStyle: React.CSSProperties = {
-  justifySelf: "start",
+  justifySelf: "end",
+  textAlign: "right",
 };
 
 const rosterRowBaseStyle: React.CSSProperties = {
@@ -179,41 +186,35 @@ const serviceCellStyle: React.CSSProperties = {
 
 const actionCellStyle: React.CSSProperties = {
   alignItems: "flex-start",
-  display: "grid",
-  gap: 10,
-  justifyItems: "start",
+  display: "flex",
+  justifyContent: "flex-end",
+  justifyItems: "end",
+  justifySelf: "stretch",
   minWidth: 0,
+  width: "100%",
 };
 
 const primaryActionsStyle: React.CSSProperties = {
   alignItems: "center",
-  display: "grid",
-  gap: 8,
-  gridTemplateColumns: "minmax(104px, max-content) minmax(122px, max-content) minmax(148px, max-content)",
-  justifyContent: "start",
+  borderRadius: 12,
+  display: "flex",
+  flex: "0 0 auto",
+  gap: 4,
+  justifyContent: "flex-end",
   minWidth: 0,
+  padding: 4,
+  width: "max-content",
 };
 
-const invokeActionStyle: React.CSSProperties = {
-  fontWeight: 650,
+const memberActionButtonBaseStyle: React.CSSProperties = {
+  border: "none",
+  borderRadius: 8,
+  boxShadow: "none",
   height: 32,
-  justifyContent: "center",
-  minWidth: 104,
-  paddingInline: 12,
-};
-
-const studioActionStyle: React.CSSProperties = {
-  height: 32,
-  justifyContent: "center",
-  minWidth: 148,
-  paddingInline: 12,
-};
-
-const entryActionStyle: React.CSSProperties = {
-  height: 32,
-  justifyContent: "center",
-  minWidth: 260,
-  paddingInline: 12,
+  lineHeight: 1,
+  minWidth: 32,
+  paddingInline: 0,
+  width: 32,
 };
 
 const memberRosterSkeletonRowKeys = ["primary", "secondary", "tertiary"] as const;
@@ -388,21 +389,27 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                         active
                         className="team-members-table-invoke-action"
                         size="small"
-                        style={invokeActionStyle}
+                        style={memberActionButtonBaseStyle}
+                      />
+                      <Skeleton.Button
+                        active
+                        className="team-members-table-automate-action"
+                        size="small"
+                        style={memberActionButtonBaseStyle}
                       />
                       <Skeleton.Button
                         active
                         className="team-members-table-studio-action"
                         size="small"
-                        style={studioActionStyle}
+                        style={memberActionButtonBaseStyle}
+                      />
+                      <Skeleton.Button
+                        active
+                        className="team-members-table-entry-action"
+                        size="small"
+                        style={memberActionButtonBaseStyle}
                       />
                     </div>
-                    <Skeleton.Button
-                      active
-                      className="team-members-table-entry-action"
-                      size="small"
-                      style={entryActionStyle}
-                    />
                   </div>
                 </div>
               ))}
@@ -492,6 +499,49 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                         id: "teams.members.actions.workflowOnlyTitle",
                       });
                   const rowBusy = entryActionBusyMemberId === row.memberId;
+                  const invokeActionLabel = intl.formatMessage({
+                    id: "teams.members.actions.invokeWorkflow",
+                  });
+                  const automateActionLabel = intl.formatMessage({
+                    defaultMessage: "Automate",
+                    id: "teams.members.actions.automate",
+                  });
+                  const studioActionLabel = intl.formatMessage({
+                    id: "teams.members.actions.workflowStudio",
+                  });
+                  const entryActionLabel = row.isEntryMember
+                    ? intl.formatMessage({ id: "teams.members.actions.clearEntry" })
+                    : intl.formatMessage({ id: "teams.members.actions.setEntry" });
+                  const entryActionIcon = row.isEntryMember ? (
+                    <StopOutlined />
+                  ) : (
+                    <CheckCircleOutlined />
+                  );
+                  const buildMemberActionButtonStyle = (
+                    tone: "default" | "primary" | "success" = "default",
+                  ): React.CSSProperties => {
+                    if (tone === "success") {
+                      return {
+                        ...memberActionButtonBaseStyle,
+                        background: token.colorSuccessBg,
+                        color: token.colorSuccess,
+                      };
+                    }
+
+                    if (tone === "primary") {
+                      return {
+                        ...memberActionButtonBaseStyle,
+                        background: token.colorPrimaryBg,
+                        color: token.colorPrimary,
+                      };
+                    }
+
+                    return {
+                      ...memberActionButtonBaseStyle,
+                      background: token.colorBgContainer,
+                      color: token.colorTextSecondary,
+                    };
+                  };
 
                   return (
                     <div
@@ -582,124 +632,127 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                       <div className="team-members-table-actions" style={actionCellStyle}>
                         <div
                           className="team-members-table-primary-actions"
-                          style={primaryActionsStyle}
+                          style={{
+                            ...primaryActionsStyle,
+                            background: token.colorFillQuaternary,
+                            border: `1px solid ${token.colorBorderSecondary}`,
+                          }}
                         >
-                          <Button
-                            className="team-members-table-invoke-action"
-                            href={row.canInvokeMember ? row.invokeHref : undefined}
-                            disabled={!row.canInvokeMember}
-                            icon={<PlayCircleOutlined />}
-                            onClick={
+                          <Tooltip
+                            title={
                               row.canInvokeMember
-                                ? handleNavigate(row.invokeHref)
-                                : undefined
+                                ? invokeActionLabel
+                                : invokeDisabledReason
                             }
-                            size="small"
-                            style={{
-                              ...invokeActionStyle,
-                              ...(row.canInvokeMember
-                                ? {
-                                    background: token.colorSuccessBg,
-                                    borderColor: token.colorSuccessBorder,
-                                    color: token.colorSuccess,
-                                  }
-                                : null),
-                            }}
-                            title={row.canInvokeMember ? undefined : invokeDisabledReason}
-                            type="default"
                           >
-                            {intl.formatMessage({ id: "teams.members.actions.invokeWorkflow" })}
-                          </Button>
-                          <Button
-                            className="team-members-table-automate-action"
-                            href={row.canAutomateMember ? row.automationsHref : undefined}
-                            disabled={!row.canAutomateMember}
-                            icon={<ClockCircleOutlined />}
-                            onClick={
-                              row.canAutomateMember
-                                ? handleNavigate(row.automationsHref)
-                                : undefined
-                            }
-                            size="small"
-                            style={{
-                              ...invokeActionStyle,
-                              minWidth: 122,
-                            }}
+                            <Button
+                              aria-label={invokeActionLabel}
+                              className="team-members-table-action-button team-members-table-invoke-action"
+                              href={row.canInvokeMember ? row.invokeHref : undefined}
+                              disabled={!row.canInvokeMember}
+                              icon={<PlayCircleOutlined />}
+                              onClick={
+                                row.canInvokeMember
+                                  ? handleNavigate(row.invokeHref)
+                                  : undefined
+                              }
+                              size="small"
+                              style={buildMemberActionButtonStyle(
+                                row.canInvokeMember ? "success" : "default",
+                              )}
+                              type="default"
+                            />
+                          </Tooltip>
+                          <Tooltip
                             title={
                               row.canAutomateMember
-                                ? undefined
+                                ? automateActionLabel
                                 : row.automationDisabledReason
                             }
-                            type="default"
                           >
-                            {intl.formatMessage({
-                              defaultMessage: "Automate",
-                              id: "teams.members.actions.automate",
-                            })}
-                          </Button>
-                          <Button
-                            className="team-members-table-studio-action"
-                            href={row.workflowSupported ? row.studioHref : undefined}
-                            disabled={!row.workflowSupported}
-                            icon={<ToolOutlined />}
-                            onClick={
-                              row.workflowSupported
-                                ? handleNavigate(row.studioHref)
-                                : undefined
-                            }
-                            size="small"
-                            style={studioActionStyle}
+                            <Button
+                              aria-label={automateActionLabel}
+                              className="team-members-table-action-button team-members-table-automate-action"
+                              href={
+                                row.canAutomateMember
+                                  ? row.automationsHref
+                                  : undefined
+                              }
+                              disabled={!row.canAutomateMember}
+                              icon={<ClockCircleOutlined />}
+                              onClick={
+                                row.canAutomateMember
+                                  ? handleNavigate(row.automationsHref)
+                                  : undefined
+                              }
+                              size="small"
+                              style={buildMemberActionButtonStyle()}
+                              type="default"
+                            />
+                          </Tooltip>
+                          <Tooltip
                             title={
                               row.workflowSupported
-                                ? undefined
+                                ? studioActionLabel
                                 : intl.formatMessage({
                                     id: "teams.members.actions.workflowOnlyTitle",
                                   })
                             }
-                            type="default"
                           >
-                            {intl.formatMessage({ id: "teams.members.actions.workflowStudio" })}
-                          </Button>
+                            <Button
+                              aria-label={studioActionLabel}
+                              className="team-members-table-action-button team-members-table-studio-action"
+                              href={row.workflowSupported ? row.studioHref : undefined}
+                              disabled={!row.workflowSupported}
+                              icon={<ToolOutlined />}
+                              onClick={
+                                row.workflowSupported
+                                  ? handleNavigate(row.studioHref)
+                                  : undefined
+                              }
+                              size="small"
+                              style={buildMemberActionButtonStyle()}
+                              type="default"
+                            />
+                          </Tooltip>
+                          {row.isEntryMember ? (
+                            <Tooltip title={entryActionLabel}>
+                              <Button
+                                aria-label={entryActionLabel}
+                                icon={entryActionIcon}
+                                className="team-members-table-action-button team-members-table-entry-action"
+                                disabled={
+                                  rowBusy ||
+                                  (isEntryActionBusy &&
+                                    entryActionBusyMemberId !== row.memberId)
+                                }
+                                loading={entryActionBusyMemberId === row.memberId}
+                                onClick={onClearEntry}
+                                size="small"
+                                style={buildMemberActionButtonStyle("primary")}
+                                type="default"
+                              />
+                            </Tooltip>
+                          ) : row.canSetAsEntry && onSetEntry ? (
+                            <Tooltip title={entryActionLabel}>
+                              <Button
+                                aria-label={entryActionLabel}
+                                className="team-members-table-action-button team-members-table-entry-action"
+                                disabled={
+                                  rowBusy ||
+                                  (isEntryActionBusy &&
+                                    entryActionBusyMemberId !== row.memberId)
+                                }
+                                icon={entryActionIcon}
+                                loading={entryActionBusyMemberId === row.memberId}
+                                onClick={() => onSetEntry(row.memberId)}
+                                size="small"
+                                style={buildMemberActionButtonStyle()}
+                                type="default"
+                              />
+                            </Tooltip>
+                          ) : null}
                         </div>
-                        {row.isEntryMember ? (
-                          <Button
-                            icon={<CheckCircleOutlined />}
-                            className="team-members-table-entry-action"
-                            disabled={
-                              rowBusy ||
-                              (isEntryActionBusy && entryActionBusyMemberId !== row.memberId)
-                            }
-                            loading={entryActionBusyMemberId === row.memberId}
-                            onClick={onClearEntry}
-                            size="small"
-                            style={{
-                              ...entryActionStyle,
-                              color: token.colorTextSecondary,
-                            }}
-                            type="default"
-                          >
-                            {intl.formatMessage({ id: "teams.members.actions.clearEntry" })}
-                          </Button>
-                        ) : row.canSetAsEntry && onSetEntry ? (
-                          <Button
-                            className="team-members-table-entry-action"
-                            disabled={
-                              rowBusy ||
-                              (isEntryActionBusy &&
-                                entryActionBusyMemberId !== row.memberId)
-                            }
-                            loading={entryActionBusyMemberId === row.memberId}
-                            onClick={() => onSetEntry(row.memberId)}
-                            size="small"
-                            style={{
-                              ...entryActionStyle,
-                              color: token.colorTextSecondary,
-                            }}
-                            type="default"
-                          >
-                            {intl.formatMessage({ id: "teams.members.actions.setEntry" })}
-                          </Button>
-                        ) : null}
                       </div>
                     </div>
                   );


### PR DESCRIPTION
## Summary
- Align Team members row action controls with the compact Automations action-button style
- Keep the Team members Actions column right-aligned without clipping the icon group
- Normalize Workflow Studio draft-run Input and Output panels to the same fixed height with independent scrolling

## Validation
- pnpm --dir apps/aevatar-console-web exec biome lint src/pages/team-member-workflow-studio/components/WorkflowStudioExecutionPanel.tsx src/pages/team-member-workflow-studio/index.test.tsx src/pages/teams/tabs/TeamMembersTab.tsx
- pnpm --dir apps/aevatar-console-web tsc
- pnpm --dir apps/aevatar-console-web test src/pages/teams/detail.test.tsx --runInBand --testNamePattern="shows a readable team members view|sets a Team entry member from the members tab|routes workflow member build actions into the new workflow studio|routes workflow member invoke actions into the member invoke page|routes workflow member automation actions into the Team automations tab|keeps invoke disabled for workflow members that are not bound yet"
- pnpm --dir apps/aevatar-console-web test src/pages/team-member-workflow-studio/index.test.tsx --runInBand --testNamePattern="runs the current workflow draft and shows returned logs"
- pnpm --dir apps/aevatar-console-web build
- git diff --check