### PR TITLE
Keep workflow nodes draggable after run

### DIFF
--- a/apps/aevatar-console-web/src/shared/studio/execution.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/execution.test.ts
@@ -1,4 +1,10 @@
-import { buildExecutionTrace } from './execution';
+import type { Node } from '@xyflow/react';
+import {
+  buildExecutionTrace,
+  decorateNodesForExecution,
+  type ExecutionTrace,
+} from './execution';
+import type { StudioGraphNodeData } from './graph';
 import type { StudioExecutionDetail } from './models';
 
 function createExecutionDetail(
@@ -43,5 +49,57 @@ describe('buildExecutionTrace', () => {
     expect(outputLog?.clipboardText).toBe('Final answer');
     expect(outputLog?.previewText).toBe('Final answer');
     expect(outputLog?.payloadText).toContain('"stateVersion": 7');
+  });
+});
+
+describe('decorateNodesForExecution', () => {
+  it('keeps workflow editor nodes draggable while applying execution status', () => {
+    const nodes: Array<Node<StudioGraphNodeData>> = [
+      {
+        id: 'step:draft',
+        position: { x: 120, y: 80 },
+        data: {
+          branchCount: 0,
+          kind: 'step',
+          label: 'draft',
+          parametersSummary: 'instruction: Draft report',
+          stepId: 'draft',
+          stepType: 'llm_call',
+          subtitle: 'LLM call',
+          targetRole: 'analyst',
+          title: 'draft',
+        },
+        type: 'studioWorkflowNode',
+      },
+    ];
+    const trace: ExecutionTrace = {
+      defaultLogIndex: null,
+      latestStepId: 'draft',
+      logs: [],
+      stepStates: new Map([
+        [
+          'draft',
+          {
+            branchKey: '',
+            completedAt: null,
+            error: '',
+            nextStepId: '',
+            startedAt: '2026-06-08T00:00:01Z',
+            status: 'active',
+            stepId: 'draft',
+            stepType: 'llm_call',
+            success: null,
+            targetRole: 'analyst',
+          },
+        ],
+      ]),
+      traversedEdges: new Set(),
+    };
+
+    const decorated = decorateNodesForExecution(nodes, trace, null);
+
+    expect(decorated[0]?.draggable).toBeUndefined();
+    expect(decorated[0]?.selectable).toBe(true);
+    expect(decorated[0]?.data.executionStatus).toBe('active');
   });
 });

--- a/apps/aevatar-console-web/src/shared/studio/execution.ts
+++ b/apps/aevatar-console-web/src/shared/studio/execution.ts
@@ -893,7 +893,6 @@ export function decorateNodesForExecution(
     const stepState = trace?.stepStates.get(node.data.stepId);
     return {
       ...node,
-      draggable: false,
       selectable: true,
       data: {
         ...node.data,


### PR DESCRIPTION
## Problem
After saving and running a Team member workflow draft, React Flow nodes could no longer be dragged individually. The execution trace decoration was setting each node-level `draggable` flag to `false`, which overrides the canvas-level draggable setting.

## Solution
Remove the node-level drag lock from execution decoration while preserving node selection and execution status/focus styling. Add a regression test that verifies decorated workflow editor nodes remain draggable after execution status is applied.

## Impact Paths
- `apps/aevatar-console-web/src/shared/studio/execution.ts`
- `apps/aevatar-console-web/src/shared/studio/execution.test.ts`

## Verification
- `pnpm --dir apps/aevatar-console-web jest src/shared/studio/execution.test.ts --runInBand`
- `pnpm --dir apps/aevatar-console-web jest src/shared/graphs/GraphCanvas.test.tsx --runInBand`
- `pnpm --dir apps/aevatar-console-web tsc`
- `bash tools/ci/test_stability_guards.sh`
- `git diff --check`