### PR TITLE
解耦 voice attach media readiness 与 session update readiness

### DIFF
--- a/docs/canon/nyxid-connected-service-tools.md
+++ b/docs/canon/nyxid-connected-service-tools.md
@@ -85,6 +85,13 @@ token 可见性与 `NyxIdProxyTool` 一致：user token 优先，org-only 的 se
 
 发现发生在请求期的工具分类阶段：tool-set 边界（`ToolSetResponsesToolProvider`）会把请求的 `AgentToolExecutionContext` 通过 `AgentToolContextScope` 发布到 AsyncLocal，`NyxIdConnectedServiceToolSource.DiscoverToolsAsync` 据此拿到当前用户的 NyxID token 并 live 发现。未配置 NyxID base URL 或上下文里没有 token 时，不暴露任何动态工具。
 
+Voice realtime attach 也遵循同一边界。若 live transport lease 带有可用的
+`voice-tool:` credential ref，session-readiness discovery 会解析该 ref，并为
+该 lease 构建 caller-scoped snapshot；它不得读取或写入匿名的进程级 voice
+catalog cache。匿名 voice session 仍可复用 no-token catalog cache；带 caller
+token 的发现必须保持 request/lease scoped，因为 connected-service 可见性由
+bearer 决定。
+
 ## 5. 架构边界
 
 - 发现期可请求 NyxID live surface，但**不在中间层保存 service/endpoint 事实状态**；没有进程内 catalog。

--- a/docs/canon/voice-presence-integration.md
+++ b/docs/canon/voice-presence-integration.md
@@ -136,6 +136,14 @@ The edge consumes a JSON projection of it (camelCase), hand-parsed by
   cleanup path that removes the volatile media relay; expired refs are evicted
   on resolve/issue and never fall back to durable `IAevatarSecretsStore`
   writes.
+- **Media readiness vs. session-update readiness** — attach returns a provider
+  media session as soon as the provider socket is connected. Tool discovery and
+  the full `session.update` run as a lease-scoped readiness task behind that
+  session; audio frames and `response.cancel` pass through immediately, while
+  image input, event injection, tool results, and later session updates wait for
+  readiness. OpenAI connects with a no-auto-response baseline until the full
+  update lands, so first audio is not blocked by NyxID/OpenAPI discovery and the
+  model cannot create responses before the tool/persona session is ready.
 - **Credential/media co-location boundary** — voice tool credentials share the
   `IVoiceVolatileMediaStreamPort` lifetime boundary: resolve is valid only in
   the host process that owns the live transport lease and media relay. A tool
@@ -171,7 +179,10 @@ sequenceDiagram
   N->>O: POST /v1/realtime/client_secrets (NyxID injects sk-)
   O-->>N: ek_ (~60s TTL)
   N-->>H: ek_
-  H->>O: open realtime WS (ek_) — relay
+  H->>O: open realtime WS (ek_) — relay; no-auto-response baseline
+  H-->>VP: media relay starts; first PCM can flow
+  H->>N: discover caller-scoped tools if a live credential_ref exists
+  H->>O: session.update persona + tools; readiness opens response-producing calls
   loop conversation — hot path (no NyxID, no actor)
     VP->>H: PCM16 mic (binary)
     H->>O: PCM16 (relay)
@@ -221,7 +232,6 @@ Hardening and contract-completeness follow-ups are tracked under **milestone 23
 - #2151 — renew the session lease while the relay is attached
 - #2152 — bound `AudioDraining` with a server-side drain-ack timeout
 - #2153 — reuse the live relay provider session for upstream sends (barge-in latency)
-- #2154 — don't block first-audio on connect-time tool discovery
 - #2155 — route-scoped voice tool execution context (unblocks per-caller edge tools)
 - #2156 — typed `VoiceFunctionCallOutput` control frame
 - #2157 — replay protection for the device-event HMAC ingress

--- a/src/Aevatar.Bootstrap.Extensions.AI/ReadinessGatedRealtimeVoiceProviderSession.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/ReadinessGatedRealtimeVoiceProviderSession.cs
@@ -1,0 +1,84 @@
+using Aevatar.Foundation.VoicePresence.Abstractions;
+
+namespace Aevatar.Bootstrap.Extensions.AI;
+
+internal sealed class ReadinessGatedRealtimeVoiceProviderSession(
+    RealtimeVoiceProviderSession innerSession,
+    Task readiness,
+    CancellationTokenSource readinessCancellation)
+    : RealtimeVoiceProviderSession
+{
+    private readonly RealtimeVoiceProviderSession _innerSession =
+        innerSession ?? throw new ArgumentNullException(nameof(innerSession));
+    private readonly Task _readiness = readiness ?? throw new ArgumentNullException(nameof(readiness));
+    private readonly CancellationTokenSource _readinessCancellation =
+        readinessCancellation ?? throw new ArgumentNullException(nameof(readinessCancellation));
+    private bool _disposed;
+
+    public override Task SendAudioAsync(ReadOnlyMemory<byte> pcm16, CancellationToken ct) =>
+        _innerSession.SendAudioAsync(pcm16, ct);
+
+    public override async Task SendInputImageAsync(VoiceInputImage inputImage, CancellationToken ct)
+    {
+        await AwaitReadinessAsync(ct);
+        await _innerSession.SendInputImageAsync(inputImage, ct);
+    }
+
+    public override async Task SendToolResultAsync(string callId, string resultJson, CancellationToken ct)
+    {
+        await AwaitReadinessAsync(ct);
+        await _innerSession.SendToolResultAsync(callId, resultJson, ct);
+    }
+
+    public override async Task InjectEventAsync(VoiceConversationEventInjection injection, CancellationToken ct)
+    {
+        await AwaitReadinessAsync(ct);
+        await _innerSession.InjectEventAsync(injection, ct);
+    }
+
+    public override Task CancelResponseAsync(CancellationToken ct) =>
+        _innerSession.CancelResponseAsync(ct);
+
+    public override async Task UpdateSessionAsync(VoiceSessionConfig session, CancellationToken ct)
+    {
+        await AwaitReadinessAsync(ct);
+        await _innerSession.UpdateSessionAsync(session, ct);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        await _readinessCancellation.CancelAsync();
+        try
+        {
+            await AwaitReadinessForDisposeAsync();
+        }
+        finally
+        {
+            _readinessCancellation.Dispose();
+            await _innerSession.DisposeAsync();
+        }
+    }
+
+    private async Task AwaitReadinessAsync(CancellationToken ct)
+    {
+        await _readiness.WaitAsync(ct);
+    }
+
+    private async Task AwaitReadinessForDisposeAsync()
+    {
+        try
+        {
+            await _readiness;
+        }
+        catch (OperationCanceledException) when (_readinessCancellation.IsCancellationRequested)
+        {
+        }
+        catch
+        {
+        }
+    }
+}

--- a/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
@@ -345,58 +345,15 @@ public static class ServiceCollectionExtensions
         Func<VoiceProviderSessionKey, VoiceProviderAudioFrame, CancellationToken, Task> audioSink,
         CancellationToken ct)
     {
-        var providerSession = await provider.ConnectAsync(
-            new VoiceProviderSessionKey(
-                handle.SessionId,
-                handle.OwnerId,
-                handle.ActiveTransportLeaseId ?? string.Empty,
-                handle.LeaseEpoch,
-                Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset(handle.ExpiresAtUtc.ToUniversalTime()),
-                handle.ActorId,
-                handle.ModuleName,
-                handle.ToolContext?.Clone()),
+        return await VoiceRealtimeSessionReadinessBootstrapper.ConnectAsync(
+            handle,
+            provider,
             providerConfig,
+            sessionConfig,
+            toolCatalog,
             eventSink,
             audioSink,
             ct);
-
-        var effectiveSession = await BuildEffectiveVoiceSessionConfigAsync(sessionConfig, toolCatalog, ct);
-        await providerSession.UpdateSessionAsync(effectiveSession, ct);
-        return providerSession;
-    }
-
-    private static async Task<VoiceSessionConfig> BuildEffectiveVoiceSessionConfigAsync(
-        VoiceSessionConfig sessionConfig,
-        IVoiceToolCatalog? toolCatalog,
-        CancellationToken ct)
-    {
-        var effectiveSession = sessionConfig.Clone();
-        if (toolCatalog == null)
-            return effectiveSession;
-
-        var knownNames = new HashSet<string>(
-            effectiveSession.ToolDefinitions
-                .Select(static definition => definition.Name)
-                .Where(static name => !string.IsNullOrWhiteSpace(name)),
-            StringComparer.OrdinalIgnoreCase);
-
-        foreach (var discoveredTool in await toolCatalog.DiscoverAsync(toolContext: null, ct: ct))
-        {
-            var toolName = discoveredTool.Name?.Trim();
-            if (string.IsNullOrWhiteSpace(toolName) || !knownNames.Add(toolName))
-                continue;
-
-            effectiveSession.ToolDefinitions.Add(new VoiceToolDefinition
-            {
-                Name = toolName,
-                Description = discoveredTool.Description ?? string.Empty,
-                ParametersSchema = string.IsNullOrWhiteSpace(discoveredTool.ParametersSchema)
-                    ? "{}"
-                    : discoveredTool.ParametersSchema,
-            });
-        }
-
-        return effectiveSession;
     }
 
     private static string? ResolveVoicePresenceDefaultProvider(

--- a/src/Aevatar.Bootstrap.Extensions.AI/VoiceRealtimeSessionReadinessBootstrapper.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/VoiceRealtimeSessionReadinessBootstrapper.cs
@@ -1,0 +1,99 @@
+using Aevatar.Foundation.VoicePresence.Abstractions;
+using Aevatar.Foundation.VoicePresence.Abstractions.Sessions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Bootstrap.Extensions.AI;
+
+internal static class VoiceRealtimeSessionReadinessBootstrapper
+{
+    public static async Task<RealtimeVoiceProviderSession> ConnectAsync(
+        VoicePresenceSessionLeaseHandle handle,
+        IRealtimeVoiceProvider provider,
+        VoiceProviderConfig providerConfig,
+        VoiceSessionConfig sessionConfig,
+        IVoiceToolCatalog? toolCatalog,
+        Func<VoiceProviderSessionKey, VoiceProviderEvent, CancellationToken, Task> eventSink,
+        Func<VoiceProviderSessionKey, VoiceProviderAudioFrame, CancellationToken, Task> audioSink,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(handle);
+        ArgumentNullException.ThrowIfNull(provider);
+        ArgumentNullException.ThrowIfNull(providerConfig);
+        ArgumentNullException.ThrowIfNull(sessionConfig);
+        ArgumentNullException.ThrowIfNull(eventSink);
+        ArgumentNullException.ThrowIfNull(audioSink);
+
+        var providerSession = await provider.ConnectAsync(
+            BuildSessionKey(handle),
+            providerConfig,
+            eventSink,
+            audioSink,
+            ct);
+
+        var readinessCancellation = new CancellationTokenSource();
+        var readiness = CompleteReadinessAsync(
+            providerSession,
+            sessionConfig.Clone(),
+            toolCatalog,
+            handle.ToolContext?.Clone(),
+            readinessCancellation.Token);
+        return new ReadinessGatedRealtimeVoiceProviderSession(providerSession, readiness, readinessCancellation);
+    }
+
+    private static VoiceProviderSessionKey BuildSessionKey(VoicePresenceSessionLeaseHandle handle) =>
+        new(
+            handle.SessionId,
+            handle.OwnerId,
+            handle.ActiveTransportLeaseId ?? string.Empty,
+            handle.LeaseEpoch,
+            Timestamp.FromDateTimeOffset(handle.ExpiresAtUtc.ToUniversalTime()),
+            handle.ActorId,
+            handle.ModuleName,
+            handle.ToolContext?.Clone());
+
+    private static async Task CompleteReadinessAsync(
+        RealtimeVoiceProviderSession providerSession,
+        VoiceSessionConfig sessionConfig,
+        IVoiceToolCatalog? toolCatalog,
+        VoiceToolExecutionContext? toolContext,
+        CancellationToken ct)
+    {
+        var effectiveSession = await BuildEffectiveVoiceSessionConfigAsync(sessionConfig, toolCatalog, toolContext, ct);
+        await providerSession.UpdateSessionAsync(effectiveSession, ct);
+    }
+
+    internal static async Task<VoiceSessionConfig> BuildEffectiveVoiceSessionConfigAsync(
+        VoiceSessionConfig sessionConfig,
+        IVoiceToolCatalog? toolCatalog,
+        VoiceToolExecutionContext? toolContext,
+        CancellationToken ct)
+    {
+        var effectiveSession = sessionConfig.Clone();
+        if (toolCatalog == null)
+            return effectiveSession;
+
+        var knownNames = new HashSet<string>(
+            effectiveSession.ToolDefinitions
+                .Select(static definition => definition.Name)
+                .Where(static name => !string.IsNullOrWhiteSpace(name)),
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var discoveredTool in await toolCatalog.DiscoverAsync(toolContext, ct))
+        {
+            var toolName = discoveredTool.Name?.Trim();
+            if (string.IsNullOrWhiteSpace(toolName) || !knownNames.Add(toolName))
+                continue;
+
+            effectiveSession.ToolDefinitions.Add(new VoiceToolDefinition
+            {
+                Name = toolName,
+                Description = discoveredTool.Description ?? string.Empty,
+                ParametersSchema = string.IsNullOrWhiteSpace(discoveredTool.ParametersSchema)
+                    ? "{}"
+                    : discoveredTool.ParametersSchema,
+            });
+        }
+
+        return effectiveSession;
+    }
+}

--- a/src/Aevatar.Foundation.VoicePresence.OpenAI/OpenAIRealtimeProvider.cs
+++ b/src/Aevatar.Foundation.VoicePresence.OpenAI/OpenAIRealtimeProvider.cs
@@ -74,6 +74,7 @@ public sealed class OpenAIRealtimeProvider : IRealtimeVoiceProvider
         var session = await _sessionFactory.StartConversationSessionAsync(effectiveConfig, _options.DefaultModel, ct);
         var providerSession = new OpenAIRealtimeProviderSession(sessionKey, session, this, _logger, eventSink, audioSink);
         providerSession.Start();
+        await providerSession.UpdateSessionAsync(BuildNoAutoResponseSessionConfig(), createResponse: false, ct);
         return providerSession;
     }
 
@@ -149,7 +150,10 @@ public sealed class OpenAIRealtimeProvider : IRealtimeVoiceProvider
             _ => null,
         };
 
-    private BinaryData BuildSessionUpdateEvent(VoiceSessionConfig session, int sampleRateHz)
+    private BinaryData BuildSessionUpdateEvent(
+        VoiceSessionConfig session,
+        int sampleRateHz,
+        bool? createResponseOverride = null)
     {
         // Refactor (iter94/cluster-809):
         // Old:OpenAI SDK typed beta session options.
@@ -165,7 +169,7 @@ public sealed class OpenAIRealtimeProvider : IRealtimeVoiceProvider
                 ["input"] = new JsonObject
                 {
                     ["format"] = BuildPcmAudioFormat(sampleRateHz),
-                    ["turn_detection"] = BuildTurnDetection(session),
+                    ["turn_detection"] = BuildTurnDetection(session, createResponseOverride),
                 },
                 ["output"] = new JsonObject
                 {
@@ -203,6 +207,13 @@ public sealed class OpenAIRealtimeProvider : IRealtimeVoiceProvider
 
         return BinaryData.FromString(updateEvent.ToJsonString());
     }
+
+    private static VoiceSessionConfig BuildNoAutoResponseSessionConfig() =>
+        new()
+        {
+            SampleRateHz = OpenAIRealtimeProviderOptions.DefaultSampleRateHz,
+            TurnDetectionMode = VoiceTurnDetectionMode.ServerVad,
+        };
 
     private JsonArray BuildTools(VoiceSessionConfig session)
     {
@@ -267,18 +278,19 @@ public sealed class OpenAIRealtimeProvider : IRealtimeVoiceProvider
             ["rate"] = sampleRateHz,
         };
 
-    private JsonNode? BuildTurnDetection(VoiceSessionConfig session)
+    private JsonNode? BuildTurnDetection(VoiceSessionConfig session, bool? createResponseOverride = null)
     {
         return session.TurnDetectionMode switch
         {
             VoiceTurnDetectionMode.Disabled or VoiceTurnDetectionMode.ClientVad => null,
             VoiceTurnDetectionMode.Unspecified when !_options.EnableServerVad => null,
-            VoiceTurnDetectionMode.Unspecified or VoiceTurnDetectionMode.ServerVad => BuildServerVadTurnDetection(session),
+            VoiceTurnDetectionMode.Unspecified or VoiceTurnDetectionMode.ServerVad =>
+                BuildServerVadTurnDetection(session, createResponseOverride),
             _ => null,
         };
     }
 
-    private JsonObject BuildServerVadTurnDetection(VoiceSessionConfig session)
+    private JsonObject BuildServerVadTurnDetection(VoiceSessionConfig session, bool? createResponseOverride = null)
     {
         return new JsonObject
         {
@@ -293,7 +305,7 @@ public sealed class OpenAIRealtimeProvider : IRealtimeVoiceProvider
                 ? session.VadSilenceDurationMs
                 : (int)_options.SilenceDuration.TotalMilliseconds,
             ["interrupt_response"] = _options.InterruptResponseOnSpeech,
-            ["create_response"] = _options.AutoCreateResponse,
+            ["create_response"] = createResponseOverride ?? _options.AutoCreateResponse,
         };
     }
 
@@ -433,6 +445,19 @@ public sealed class OpenAIRealtimeProvider : IRealtimeVoiceProvider
 
             _outputSampleRateHz = _connector.ResolveSampleRateHz(session.SampleRateHz);
             await _physicalSession.SendSessionUpdateAsync(_connector.BuildSessionUpdateEvent(session, _outputSampleRateHz), ct);
+        }
+
+        internal async Task UpdateSessionAsync(
+            VoiceSessionConfig session,
+            bool createResponse,
+            CancellationToken ct)
+        {
+            ArgumentNullException.ThrowIfNull(session);
+
+            _outputSampleRateHz = _connector.ResolveSampleRateHz(session.SampleRateHz);
+            await _physicalSession.SendSessionUpdateAsync(
+                _connector.BuildSessionUpdateEvent(session, _outputSampleRateHz, createResponse),
+                ct);
         }
 
         internal async Task InjectUserTextAsync(string text, CancellationToken ct)

--- a/test/Aevatar.AI.Core.Tests/Voice/AgentToolVoiceCatalogTests.cs
+++ b/test/Aevatar.AI.Core.Tests/Voice/AgentToolVoiceCatalogTests.cs
@@ -93,6 +93,25 @@ public class AgentToolVoiceCatalogTests
     }
 
     [Fact]
+    public async Task DiscoverAsync_WithDifferentCredentialRefs_ShouldNotReuseCallerScopedSnapshot()
+    {
+        var source = new TokenNamedToolSource();
+        var credentials = new StubCredentialProvider(
+            ("voice-tool:ref-1", "caller-token-123"),
+            ("voice-tool:ref-2", "caller-token-456"));
+        var catalog = new AgentToolVoiceCatalog([source], credentials);
+
+        var firstDefinitions = await catalog.DiscoverAsync(CreateToolContext("voice-tool:ref-1"));
+        var secondDefinitions = await catalog.DiscoverAsync(CreateToolContext("voice-tool:ref-2"));
+
+        firstDefinitions.Should().ContainSingle(definition => definition.Name == "caller-token-123.only");
+        secondDefinitions.Should().ContainSingle(definition => definition.Name == "caller-token-456.only");
+        credentials.RequestedRefs.Should().Equal("voice-tool:ref-1", "voice-tool:ref-2");
+        source.CapturedNyxIdAccessTokens.Should().Equal("caller-token-123", "caller-token-456");
+        source.DiscoverCalls.Should().Be(2);
+    }
+
+    [Fact]
     public async Task DiscoverAsync_WithCredentialRef_ShouldMapVoiceBusinessContextAndRestrictVisibleTools()
     {
         var allowedTool = new FakeAgentTool("door.open", "allowed", "{}");
@@ -126,26 +145,29 @@ public class AgentToolVoiceCatalogTests
 
     private static VoiceToolExecutionContext CreateFullToolContext(string credentialRef)
     {
-        var toolContext = new VoiceToolExecutionContext
-        {
-            CredentialRef = credentialRef,
-            ExpiresAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddMinutes(5)),
-            CallerScopeId = " caller-scope-1 ",
-            OwnerSubject = " owner-subject-1 ",
-            ResponseId = " response-1 ",
-            ChannelPlatform = " lark ",
-            ChannelSenderId = " sender-1 ",
-            ChannelRegistrationScopeId = " registration-scope-1 ",
-            ChannelMessageId = " message-1 ",
-            ChannelPlatformMessageId = " platform-message-1 ",
-            ChannelDeliveryTargetId = " delivery-1 ",
-            SenderBindingId = " sender-binding-1 ",
-            NyxIdRoutePreference = " direct ",
-            ConnectedServicesContextJson = """ {"service":"ctx"} """,
-        };
+        var toolContext = CreateToolContext(credentialRef);
+        toolContext.CallerScopeId = " caller-scope-1 ";
+        toolContext.OwnerSubject = " owner-subject-1 ";
+        toolContext.ResponseId = " response-1 ";
+        toolContext.ChannelPlatform = " lark ";
+        toolContext.ChannelSenderId = " sender-1 ";
+        toolContext.ChannelRegistrationScopeId = " registration-scope-1 ";
+        toolContext.ChannelMessageId = " message-1 ";
+        toolContext.ChannelPlatformMessageId = " platform-message-1 ";
+        toolContext.ChannelDeliveryTargetId = " delivery-1 ";
+        toolContext.SenderBindingId = " sender-binding-1 ";
+        toolContext.NyxIdRoutePreference = " direct ";
+        toolContext.ConnectedServicesContextJson = """ {"service":"ctx"} """;
         toolContext.AllowedToolNames.Add(" door.open ");
         return toolContext;
     }
+
+    private static VoiceToolExecutionContext CreateToolContext(string credentialRef) =>
+        new()
+        {
+            CredentialRef = credentialRef,
+            ExpiresAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddMinutes(5)),
+        };
 
     private sealed class StubToolSource(params IAgentTool[] tools) : IAgentToolSource
     {
@@ -221,6 +243,24 @@ public class AgentToolVoiceCatalogTests
                 ? new FakeAgentTool("anonymous.only", "anonymous", "{}")
                 : new FakeAgentTool("caller.only", "caller", "{}");
             return Task.FromResult<IReadOnlyList<IAgentTool>>([tool]);
+        }
+    }
+
+    private sealed class TokenNamedToolSource : IAgentToolSource
+    {
+        public int DiscoverCalls { get; private set; }
+        public List<string?> CapturedNyxIdAccessTokens { get; } = [];
+
+        public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default)
+        {
+            _ = ct;
+            DiscoverCalls++;
+            var token = AgentToolRequestContext.NyxIdAccessToken;
+            CapturedNyxIdAccessTokens.Add(token);
+            return Task.FromResult<IReadOnlyList<IAgentTool>>(
+            [
+                new FakeAgentTool($"{token}.only", "caller", "{}"),
+            ]);
         }
     }
 

--- a/test/Aevatar.Bootstrap.Tests/VoicePresenceBootstrapTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/VoicePresenceBootstrapTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Aevatar.AI.Abstractions.Voice;
 using Aevatar.Bootstrap.Extensions.AI;
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Credentials;
 using Aevatar.Foundation.Abstractions.EventModules;
 using Aevatar.Foundation.VoicePresence;
 using Aevatar.Foundation.VoicePresence.Abstractions;
@@ -151,6 +152,119 @@ public sealed class VoicePresenceBootstrapTests
         provider.SessionKey.TransportLeaseId.Should().Be("transport-1");
     }
 
+    [Fact]
+    public async Task ConnectVoiceProviderSessionAsync_ShouldReturnBeforeToolDiscoveryAndSessionUpdateComplete()
+    {
+        using var toolCatalog = new BlockingVoiceToolCatalog();
+        var provider = new RecordingRealtimeVoiceProvider();
+        var handle = CreateLeaseHandle(toolContext: null);
+
+        await using var session = await InvokeConnectVoiceProviderSessionAsync(
+            handle,
+            provider,
+            new VoiceProviderConfig { ProviderName = "test" },
+            new VoiceSessionConfig { SampleRateHz = 24000 },
+            toolCatalog);
+
+        provider.Session.Should().NotBeNull();
+        provider.Session!.UpdateCalls.Should().Be(0);
+        await toolCatalog.WaitForDiscoveryAsync();
+
+        toolCatalog.Release([new VoiceToolDefinition
+        {
+            Name = "door.open",
+            Description = "open door",
+            ParametersSchema = """{"type":"object"}""",
+        }]);
+
+        await provider.Session.WaitForUpdateAsync();
+        provider.Session.UpdateCalls.Should().Be(1);
+        provider.Session.LastSession!.ToolDefinitions
+            .Should().ContainSingle(definition => definition.Name == "door.open");
+    }
+
+    [Fact]
+    public async Task ReadinessGatedSession_ShouldPassAudioAndCancelThroughBeforeReadiness()
+    {
+        using var toolCatalog = new BlockingVoiceToolCatalog();
+        var provider = new RecordingRealtimeVoiceProvider();
+        var handle = CreateLeaseHandle(toolContext: null);
+
+        await using var session = await InvokeConnectVoiceProviderSessionAsync(
+            handle,
+            provider,
+            new VoiceProviderConfig { ProviderName = "test" },
+            new VoiceSessionConfig { SampleRateHz = 24000 },
+            toolCatalog);
+
+        await toolCatalog.WaitForDiscoveryAsync();
+        await session.SendAudioAsync(new byte[] { 1, 2, 3 }, CancellationToken.None);
+        await session.CancelResponseAsync(CancellationToken.None);
+
+        provider.Session!.SentAudioFrames.Should().ContainSingle()
+            .Which.Should().Equal([1, 2, 3]);
+        provider.Session.CancelCalls.Should().Be(1);
+        provider.Session.UpdateCalls.Should().Be(0);
+
+        toolCatalog.Release([]);
+        await provider.Session.WaitForUpdateAsync();
+    }
+
+    [Fact]
+    public async Task ReadinessGatedSession_ShouldGateResponseProducingMethodsOnReadiness()
+    {
+        using var toolCatalog = new BlockingVoiceToolCatalog();
+        var provider = new RecordingRealtimeVoiceProvider();
+        var handle = CreateLeaseHandle(toolContext: null);
+
+        await using var session = await InvokeConnectVoiceProviderSessionAsync(
+            handle,
+            provider,
+            new VoiceProviderConfig { ProviderName = "test" },
+            new VoiceSessionConfig { SampleRateHz = 24000 },
+            toolCatalog);
+
+        await toolCatalog.WaitForDiscoveryAsync();
+        var sendToolResult = session.SendToolResultAsync("call-1", """{"ok":true}""", CancellationToken.None);
+
+        provider.Session!.ToolResultCalls.Should().Be(0);
+        sendToolResult.IsCompleted.Should().BeFalse();
+
+        toolCatalog.Release([]);
+        await provider.Session.WaitForUpdateAsync();
+        await sendToolResult.WaitAsync(TimeSpan.FromSeconds(5));
+
+        provider.Session.ToolResultCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ConnectVoiceProviderSessionAsync_ShouldPassLeaseToolContextToCatalog()
+    {
+        var toolCatalog = new CapturingVoiceToolCatalog();
+        var provider = new RecordingRealtimeVoiceProvider();
+        var toolContext = new VoiceToolExecutionContext
+        {
+            CredentialRef = "voice-tool:ref-1",
+            ExpiresAt = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset(
+                DateTimeOffset.UtcNow.AddMinutes(5)),
+        };
+        var handle = CreateLeaseHandle(toolContext);
+
+        await using var session = await InvokeConnectVoiceProviderSessionAsync(
+            handle,
+            provider,
+            new VoiceProviderConfig { ProviderName = "test" },
+            new VoiceSessionConfig { SampleRateHz = 24000 },
+            toolCatalog);
+
+        await provider.Session!.WaitForUpdateAsync();
+
+        toolCatalog.Contexts.Should().ContainSingle();
+        toolCatalog.Contexts[0]!.CredentialRef.Should().Be("voice-tool:ref-1");
+        provider.Session.LastSession!.ToolDefinitions
+            .Should().ContainSingle(definition => definition.Name == "caller.only");
+    }
+
     private static async Task<RealtimeVoiceProviderSession> InvokeConnectVoiceProviderSessionAsync(
         VoicePresenceSessionLeaseHandle handle,
         IRealtimeVoiceProvider provider,
@@ -179,6 +293,19 @@ public sealed class VoicePresenceBootstrapTests
 
         return await task;
     }
+
+    private static VoicePresenceSessionLeaseHandle CreateLeaseHandle(VoiceToolExecutionContext? toolContext) =>
+        new(
+            "agent-1",
+            "voice_presence",
+            "lease-1",
+            "host-1",
+            8,
+            DateTimeOffset.UtcNow.AddMinutes(5),
+            VoiceRemoteAudioSupport.Supported,
+            "transport-1",
+            17,
+            toolContext);
 
     private static void AddVoicePresenceTestCredentialResolver(IServiceCollection services) =>
         services.AddSingleton<IRealtimeProviderCredentialResolver, NoOpRealtimeProviderCredentialResolver>();
@@ -215,6 +342,7 @@ public sealed class VoicePresenceBootstrapTests
     private sealed class RecordingRealtimeVoiceProvider : IRealtimeVoiceProvider
     {
         public VoiceProviderSessionKey? SessionKey { get; private set; }
+        public RecordingRealtimeVoiceProviderSession? Session { get; private set; }
 
         public Task<RealtimeVoiceProviderSession> ConnectAsync(
             VoiceProviderSessionKey sessionKey,
@@ -228,7 +356,8 @@ public sealed class VoicePresenceBootstrapTests
             _ = audioSink;
             _ = ct;
             SessionKey = sessionKey;
-            return Task.FromResult<RealtimeVoiceProviderSession>(new RecordingRealtimeVoiceProviderSession());
+            Session = new RecordingRealtimeVoiceProviderSession();
+            return Task.FromResult<RealtimeVoiceProviderSession>(Session);
         }
 
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
@@ -236,20 +365,105 @@ public sealed class VoicePresenceBootstrapTests
 
     private sealed class RecordingRealtimeVoiceProviderSession : RealtimeVoiceProviderSession
     {
-        public override Task SendAudioAsync(ReadOnlyMemory<byte> pcm16, CancellationToken ct) => Task.CompletedTask;
+        private readonly TaskCompletionSource _sessionUpdated =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public List<byte[]> SentAudioFrames { get; } = [];
+        public int CancelCalls { get; private set; }
+        public int ToolResultCalls { get; private set; }
+        public int UpdateCalls { get; private set; }
+        public VoiceSessionConfig? LastSession { get; private set; }
+
+        public override Task SendAudioAsync(ReadOnlyMemory<byte> pcm16, CancellationToken ct)
+        {
+            _ = ct;
+            SentAudioFrames.Add(pcm16.ToArray());
+            return Task.CompletedTask;
+        }
 
         public override Task SendInputImageAsync(VoiceInputImage inputImage, CancellationToken ct) => Task.CompletedTask;
 
-        public override Task SendToolResultAsync(string callId, string resultJson, CancellationToken ct) =>
-            Task.CompletedTask;
+        public override Task SendToolResultAsync(string callId, string resultJson, CancellationToken ct)
+        {
+            _ = callId;
+            _ = resultJson;
+            _ = ct;
+            ToolResultCalls++;
+            return Task.CompletedTask;
+        }
 
         public override Task InjectEventAsync(VoiceConversationEventInjection injection, CancellationToken ct) =>
             Task.CompletedTask;
 
-        public override Task CancelResponseAsync(CancellationToken ct) => Task.CompletedTask;
+        public override Task CancelResponseAsync(CancellationToken ct)
+        {
+            _ = ct;
+            CancelCalls++;
+            return Task.CompletedTask;
+        }
 
-        public override Task UpdateSessionAsync(VoiceSessionConfig session, CancellationToken ct) => Task.CompletedTask;
+        public override Task UpdateSessionAsync(VoiceSessionConfig session, CancellationToken ct)
+        {
+            _ = ct;
+            UpdateCalls++;
+            LastSession = session.Clone();
+            _sessionUpdated.TrySetResult();
+            return Task.CompletedTask;
+        }
+
+        public Task WaitForUpdateAsync() =>
+            _sessionUpdated.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         public override ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class BlockingVoiceToolCatalog : IVoiceToolCatalog, IDisposable
+    {
+        private readonly TaskCompletionSource _entered =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<IReadOnlyList<VoiceToolDefinition>> _release =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<IReadOnlyList<VoiceToolDefinition>> DiscoverAsync(
+            VoiceToolExecutionContext? toolContext = null,
+            CancellationToken ct = default)
+        {
+            _ = toolContext;
+            _entered.TrySetResult();
+            return _release.Task.WaitAsync(ct);
+        }
+
+        public Task WaitForDiscoveryAsync() =>
+            _entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        public void Release(IReadOnlyList<VoiceToolDefinition> definitions) =>
+            _release.TrySetResult(definitions);
+
+        public void Dispose()
+        {
+            _release.TrySetResult([]);
+        }
+    }
+
+    private sealed class CapturingVoiceToolCatalog : IVoiceToolCatalog
+    {
+        public List<VoiceToolExecutionContext?> Contexts { get; } = [];
+
+        public Task<IReadOnlyList<VoiceToolDefinition>> DiscoverAsync(
+            VoiceToolExecutionContext? toolContext = null,
+            CancellationToken ct = default)
+        {
+            _ = ct;
+            Contexts.Add(toolContext?.Clone());
+            return Task.FromResult<IReadOnlyList<VoiceToolDefinition>>(
+            [
+                new VoiceToolDefinition
+                {
+                    Name = "caller.only",
+                    Description = "caller",
+                    ParametersSchema = "{}",
+                },
+            ]);
+        }
     }
 }

--- a/test/Aevatar.Foundation.VoicePresence.OpenAI.Tests/OpenAIRealtimeProviderTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.OpenAI.Tests/OpenAIRealtimeProviderTests.cs
@@ -25,8 +25,8 @@ public class OpenAIRealtimeProviderTests
             ToolNames = { "door.open" },
         }, CancellationToken.None);
 
-        session.SessionUpdateEvents.Count.ShouldBe(1);
-        using var document = JsonDocument.Parse(session.SessionUpdateEvents.Single());
+        session.SessionUpdateEvents.Count.ShouldBe(2);
+        using var document = JsonDocument.Parse(session.SessionUpdateEvents.Last());
         var root = document.RootElement;
         root.GetProperty("type").GetString().ShouldBe("session.update");
         root.TryGetProperty("input_audio_format", out _).ShouldBeFalse();
@@ -90,7 +90,7 @@ public class OpenAIRealtimeProviderTests
             ToolNames = { "door.open", "door.close" },
         }, CancellationToken.None);
 
-        using var document = JsonDocument.Parse(session.SessionUpdateEvents.Single());
+        using var document = JsonDocument.Parse(session.SessionUpdateEvents.Last());
         var tools = document.RootElement.GetProperty("session").GetProperty("tools").EnumerateArray().ToArray();
         tools.Length.ShouldBe(2);
 
@@ -128,7 +128,7 @@ public class OpenAIRealtimeProviderTests
             TurnDetectionMode = VoiceTurnDetectionMode.Disabled,
         }, CancellationToken.None);
 
-        using var serverVadDocument = JsonDocument.Parse(session.SessionUpdateEvents[0]);
+        using var serverVadDocument = JsonDocument.Parse(session.SessionUpdateEvents[1]);
         var turnDetection = serverVadDocument.RootElement
             .GetProperty("session")
             .GetProperty("audio")
@@ -139,7 +139,7 @@ public class OpenAIRealtimeProviderTests
         turnDetection.GetProperty("prefix_padding_ms").GetInt32().ShouldBe(125);
         turnDetection.GetProperty("silence_duration_ms").GetInt32().ShouldBe(375);
 
-        using var disabledDocument = JsonDocument.Parse(session.SessionUpdateEvents[1]);
+        using var disabledDocument = JsonDocument.Parse(session.SessionUpdateEvents[2]);
         disabledDocument.RootElement
             .GetProperty("session")
             .GetProperty("audio")
@@ -448,6 +448,25 @@ public class OpenAIRealtimeProviderTests
     }
 
     [Fact]
+    public async Task Connect_should_configure_no_auto_response_before_readiness_update()
+    {
+        var session = new FakeSession();
+        var provider = CreateProvider(session);
+
+        await using var providerSession = await ConnectAsync(provider);
+
+        session.SessionUpdateEvents.Count.ShouldBe(1);
+        using var document = JsonDocument.Parse(session.SessionUpdateEvents.Single());
+        var turnDetection = document.RootElement
+            .GetProperty("session")
+            .GetProperty("audio")
+            .GetProperty("input")
+            .GetProperty("turn_detection");
+        turnDetection.GetProperty("type").GetString().ShouldBe("server_vad");
+        turnDetection.GetProperty("create_response").GetBoolean().ShouldBeFalse();
+    }
+
+    [Fact]
     public async Task SendToolResult_with_empty_callId_should_throw()
     {
         var session = new FakeSession();
@@ -509,7 +528,7 @@ public class OpenAIRealtimeProviderTests
             SampleRateHz = 0,
         }, CancellationToken.None);
 
-        session.SessionUpdateEvents.Count.ShouldBe(1);
+        session.SessionUpdateEvents.Count.ShouldBe(2);
     }
 
     [Fact]
@@ -524,7 +543,7 @@ public class OpenAIRealtimeProviderTests
             Instructions = "test",
         }, CancellationToken.None);
 
-        using var document = JsonDocument.Parse(session.SessionUpdateEvents.Single());
+        using var document = JsonDocument.Parse(session.SessionUpdateEvents.Last());
         var configuredSession = document.RootElement.GetProperty("session");
         configuredSession.GetProperty("tools").GetArrayLength().ShouldBe(0);
         configuredSession.TryGetProperty("tool_choice", out _).ShouldBeFalse();


### PR DESCRIPTION
## Changed files
- 新增 internal readiness-gated voice provider session wrapper 与 bootstrapper，让 /ws/voice attach 在 provider socket 可用后即可返回 media session。
- response-producing methods 与后续 session update 等待同一个 lease-scoped readiness task；SendAudioAsync 与 CancelResponseAsync 保持直通。
- OpenAI connect 后先发送 no-auto-response baseline，caller-token tool discovery 改为使用 lease ToolContext，避免复用匿名进程级 catalog cache。
- 更新 voice/NyxID canon 文档与相关行为测试。

## Test results
- PASS: dotnet build aevatar.slnx --nologo
- PASS: dotnet test test/Aevatar.Bootstrap.Tests/Aevatar.Bootstrap.Tests.csproj --nologo --filter VoicePresenceBootstrapTests
- PASS: dotnet test test/Aevatar.AI.Core.Tests/Aevatar.AI.Core.Tests.csproj --nologo --filter AgentToolVoiceCatalogTests
- PASS: dotnet test test/Aevatar.Foundation.VoicePresence.OpenAI.Tests/Aevatar.Foundation.VoicePresence.OpenAI.Tests.csproj --nologo --filter OpenAIRealtimeProviderTests
- PASS: bash tools/ci/test_stability_guards.sh
- PASS: bash tools/docs/lint.sh

## Deviations
- Closes #2154
- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)
- Host CI_GUARDS 为空，按 host policy 记录为 guards skipped: CI_GUARDS unset。
- 未改 provider public API、NyxID surface、schema/proto，未执行 commit/push。

⟦AI:AUTO-LOOP⟧
