### PR TITLE
支持语音边缘客户端工具回传

### DIFF
--- a/docs/adr/0031-voice-edge-local-tools.md
+++ b/docs/adr/0031-voice-edge-local-tools.md
@@ -21,11 +21,12 @@ The active voice execution path is actor-side:
 - The actor sends the JSON result back to the realtime provider through
   `IRealtimeVoiceProvider.SendToolResultAsync(...)`.
 
-The current transport contract is asymmetric for local tool execution. The
-downstream realtime feed can carry `VoiceRealtimeFrame.function_call`, but
-`VoiceControlFrame` only accepts `drain_acknowledged`. There is no typed
-`function_call_output` control frame that a client can use to answer a model
-function call through the active voice transport.
+The original transport contract was asymmetric for local tool execution. The
+downstream realtime feed could carry `VoiceRealtimeFrame.function_call`, but
+`VoiceControlFrame` had no typed `function_call_output` control frame that a
+client could use to answer a model function call through the active voice
+transport. Issue #2156 closes that protocol gap by adding typed ownership and a
+typed uplink result.
 
 NyxID already has a service and node proxy surface that reaches private-host
 APIs without requiring Aevatar to add a new external feature:
@@ -50,20 +51,21 @@ through NyxID's existing proxy and connected-service tool surfaces.
 This is a design decision, not a new Aevatar protocol implementation. No new
 NyxID endpoint, schema field, or node feature is required for issue #2009.
 
-The long-term direction remains a first-class client-owned voice tool protocol,
-but it must be implemented as a typed voice contract, not as a process-local
-registry:
+The first-class client-owned voice tool protocol is implemented as a typed voice
+contract, not as a process-local registry:
 
-- Add a typed `VoiceFunctionCallOutput` message with at least `call_id`,
-  `tool_name`, `output_json`, and an explicit failure shape.
-- Add it to `VoiceControlFrame` as `function_call_output`.
-- Mark tool ownership in typed session configuration, for example actor-owned
-  versus client-owned tool definitions, rather than overloading a generic bag.
-- Keep call correlation in actor-owned voice session state. The actor may wait
-  for a client-owned output only by ending the current turn and resuming from a
-  control-frame event or timeout event.
-- Align timeout semantics with the existing tool execution timeout and return an
-  honest JSON error to the provider when a client-owned output does not arrive.
+- `VoiceFunctionCallOutput` carries `call_id`, `tool_name`, success
+  `output_json`, or a typed `VoiceFunctionCallFailure`.
+- `VoiceControlFrame.function_call_output` is the client-to-actor uplink.
+- `VoiceToolDefinition.owner` marks actor-owned versus client-owned tools.
+  Unspecified ownership remains actor-owned.
+- `VoicePendingClientToolCall` lives in actor-owned
+  `VoicePresenceRuntimeState`. The actor waits for a client output only by
+  ending the current turn and resuming from a control-frame event or timeout
+  event.
+- `VoiceClientToolCallTimeoutExpired` aligns timeout semantics with the existing
+  tool execution timeout and returns an honest JSON error to the provider when a
+  client-owned output does not arrive.
 
 Do not solve this gap with a Device GAgent outbound command queue in this slice.
 Device command subscriptions may be useful for durable device management, but
@@ -106,8 +108,8 @@ actor-owned credential contract.
   `actorId -> edge context` registry. NyxID remains the live source for
   connected services and OpenAPI specs.
 - Stable voice protocol semantics are protobuf fields. A future
-  `function_call_output` is a typed control-frame message, not JSON hidden in an
-  existing field.
+  client-owned tool semantic must continue to be a typed control-frame or
+  state/message field, not JSON hidden in an existing field.
 - The voice actor remains the authority for the voice session, call correlation,
   timeout, and provider result submission. The edge client owns only the LAN
   side effect and the tool output it returns.
@@ -154,6 +156,8 @@ Voice model function call
   are generally safe.
 - The long-term transport callback protocol remains available for low-latency
   client-owned tools and for tools that should never be exposed as HTTP services.
+  Its implemented form is the typed `function_call_output` uplink guarded by
+  actor-owned pending call state and timeout self-signals.
 
 ## Verification
 

--- a/docs/canon/voice-presence-integration.md
+++ b/docs/canon/voice-presence-integration.md
@@ -108,14 +108,23 @@ The edge consumes a JSON projection of it (camelCase), hand-parsed by
   audio was deliberately pulled out of the envelope.
 - **Control / events** — WebSocket **text** frames carry a JSON
   `VoiceControlFrame` oneof:
-  - up (client → aevatar): `drainAcknowledged`, `inputImage`
+  - up (client → aevatar): `drainAcknowledged`, `inputImage`,
+    `functionCallOutput`
   - down (aevatar → client): `sessionAccepted`, `realtimeFrame`
   - `realtimeFrame` is itself a `VoiceRealtimeFrame` oneof: `responseStarted`/
     `Done`/`Cancelled`, `speechStarted`/`Stopped`, `functionCall`,
     `transcriptDelta`/`Completed`, `error`, `disconnected`, `sessionClosed`.
-- **Ownership** — the actor owns persona, tools, turn lifecycle and VAD; the
-  edge sends no `session.update` / `response.create` / `response.cancel` and
-  drops any local `function_call_output` (tools execute actor-side).
+- **Tool ownership** — every `VoiceToolDefinition` declares typed ownership.
+  `VOICE_TOOL_OWNER_UNSPECIFIED` and `VOICE_TOOL_OWNER_ACTOR` keep the default
+  actor-owned path: the actor executes through `IVoiceToolInvoker` and submits
+  the provider result. `VOICE_TOOL_OWNER_CLIENT` makes the edge client the owner
+  of the side effect and output. The provider `function_call` is still published
+  through `VoiceRealtimeFrame.functionCall`; the actor records a
+  `VoicePendingClientToolCall` in `VoicePresenceRuntimeState` and waits for a
+  matching `VoiceControlFrame.functionCallOutput` or a durable
+  `VoiceClientToolCallTimeoutExpired` self-signal before reusing the same
+  provider result delivery path. No process-local pending map or device command
+  queue is part of this contract.
 - **Lease** — the host attaches a transport lease (`transport_lease_id`,
   `owner_id`, `lease_epoch`, `lease_expires_at`) the actor owns; the volatile
   media relay is bound to that lease. Host/provider connect paths must carry
@@ -179,10 +188,18 @@ sequenceDiagram
     H-->>VP: PCM16 response (binary)
   end
   O-->>A: function_call event (relay → actor)
-  A->>N: tool exec (proxy → node WS)
-  N->>VP: POST /edge-tools/tools/{name}
-  VP->>VP: run HA / Frigate / LCD on LAN
-  VP-->>A: result
+  alt actor-owned tool
+    A->>N: tool exec (proxy → node WS)
+    N->>VP: POST /edge-tools/tools/{name}
+    VP->>VP: run HA / Frigate / LCD on LAN
+    VP-->>A: result
+  else client-owned tool
+    A-->>H: realtimeFrame.functionCall
+    H-->>VP: functionCall (JSON)
+    VP->>VP: run local tool
+    VP-->>H: functionCallOutput (JSON)
+    H-->>A: typed control self-signal
+  end
   A->>O: SendToolResult (upstream)
   O-->>H: responseStarted/Done · transcripts → realtimeFrame
   H-->>VP: realtimeFrame (JSON)
@@ -223,7 +240,6 @@ Hardening and contract-completeness follow-ups are tracked under **milestone 23
 - #2153 — reuse the live relay provider session for upstream sends (barge-in latency)
 - #2154 — don't block first-audio on connect-time tool discovery
 - #2155 — route-scoped voice tool execution context (unblocks per-caller edge tools)
-- #2156 — typed `VoiceFunctionCallOutput` control frame
 - #2157 — replay protection for the device-event HMAC ingress
 - #2158 — harden / gate the `/ws/voice` dev-bypass route
 - #2159 — `/ws/voice` reconnect/reattach contract + wire dead attach timeouts

--- a/src/Aevatar.Foundation.VoicePresence.Abstractions/Protos/voice_presence.proto
+++ b/src/Aevatar.Foundation.VoicePresence.Abstractions/Protos/voice_presence.proto
@@ -29,6 +29,12 @@ enum VoiceTurnDetectionMode {
   VOICE_TURN_DETECTION_MODE_DISABLED = 3;
 }
 
+enum VoiceToolOwner {
+  VOICE_TOOL_OWNER_UNSPECIFIED = 0;
+  VOICE_TOOL_OWNER_ACTOR = 1;
+  VOICE_TOOL_OWNER_CLIENT = 2;
+}
+
 message VoiceProviderConfig {
   string provider_name = 1;
   string endpoint = 2;
@@ -72,6 +78,7 @@ message VoiceToolDefinition {
   string name = 1;
   string description = 2;
   string parameters_schema = 3;
+  VoiceToolOwner owner = 4;
 }
 
 message VoiceToolExecutionContext {
@@ -114,6 +121,19 @@ message VoiceProviderResponseBinding {
   int32 response_id = 2;
 }
 
+message VoicePendingClientToolCall {
+  string call_id = 1;
+  string tool_name = 2;
+  string arguments_json = 3;
+  int32 response_id = 4;
+  string provider_response_id = 5;
+  string session_id = 6;
+  string owner_id = 7;
+  string transport_lease_id = 8;
+  int64 lease_epoch = 9;
+  google.protobuf.Timestamp expires_at = 10;
+}
+
 message VoicePresenceEventDedupeFenceEntry {
   string key = 1;
   google.protobuf.Timestamp recorded_at = 2;
@@ -143,6 +163,7 @@ message VoicePresenceRuntimeState {
   int64 lease_epoch = 21;
   VoiceSessionConfig active_session_config = 22;
   VoiceToolExecutionContext active_tool_context = 23;
+  repeated VoicePendingClientToolCall pending_client_tool_calls = 24;
 }
 
 message VoicePresenceRuntimeStateChangedEvent {
@@ -193,6 +214,21 @@ message VoiceFunctionCallRequested {
   string arguments_json = 3;
   int32 response_id = 4;
   string provider_response_id = 5;
+}
+
+message VoiceFunctionCallFailure {
+  string error_code = 1;
+  string error_message = 2;
+}
+
+message VoiceFunctionCallOutput {
+  string call_id = 1;
+  string tool_name = 2;
+
+  oneof result {
+    string output_json = 3;
+    VoiceFunctionCallFailure failure = 4;
+  }
 }
 
 message VoiceSpeechStarted {}
@@ -274,6 +310,7 @@ message VoiceControlFrame {
     VoiceInputImage input_image = 2;
     VoiceTransportSessionAccepted session_accepted = 3;
     VoiceRealtimeFrame realtime_frame = 4;
+    VoiceFunctionCallOutput function_call_output = 5;
   }
 }
 
@@ -356,6 +393,15 @@ message VoiceDrainTimeoutExpired {
   int32 response_id = 5;
 }
 
+message VoiceClientToolCallTimeoutExpired {
+  string session_id = 1;
+  string owner_id = 2;
+  string transport_lease_id = 3;
+  int64 lease_epoch = 4;
+  string call_id = 5;
+  string tool_name = 6;
+}
+
 message VoiceProviderEventReceived {
   string session_id = 1;
   string transport_lease_id = 2;
@@ -406,6 +452,7 @@ message VoiceModuleSignal {
     VoiceInputImageReceived input_image_received = 17;
     VoiceTransportLeaseRenewRequested transport_lease_renew_requested = 18;
     VoiceDrainTimeoutExpired drain_timeout_expired = 19;
+    VoiceClientToolCallTimeoutExpired client_tool_call_timeout_expired = 20;
   }
 }
 

--- a/src/Aevatar.Foundation.VoicePresence/Modules/VoiceClientToolCallStateMachine.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Modules/VoiceClientToolCallStateMachine.cs
@@ -1,0 +1,195 @@
+using Aevatar.Foundation.VoicePresence.Abstractions;
+using Google.Protobuf.WellKnownTypes;
+using System.Text.Json;
+
+namespace Aevatar.Foundation.VoicePresence.Modules;
+
+internal static class VoiceClientToolCallStateMachine
+{
+    public static VoicePendingClientToolCall RecordPendingCall(
+        VoicePresenceRuntimeState state,
+        VoiceFunctionCallRequested request,
+        DateTimeOffset expiresAt,
+        string? transportLeaseId)
+    {
+        RemovePendingCall(state, request.CallId);
+
+        var pendingCall = new VoicePendingClientToolCall
+        {
+            CallId = request.CallId?.Trim() ?? string.Empty,
+            ToolName = request.ToolName?.Trim() ?? string.Empty,
+            ArgumentsJson = string.IsNullOrWhiteSpace(request.ArgumentsJson) ? "{}" : request.ArgumentsJson,
+            ResponseId = request.ResponseId,
+            ProviderResponseId = request.ProviderResponseId ?? string.Empty,
+            SessionId = state.ActiveSessionId ?? string.Empty,
+            OwnerId = state.ActiveLeaseOwnerId ?? string.Empty,
+            TransportLeaseId = !string.IsNullOrWhiteSpace(transportLeaseId)
+                ? transportLeaseId
+                : state.ActiveTransportLeaseId ?? string.Empty,
+            LeaseEpoch = state.LeaseEpoch,
+            ExpiresAt = Timestamp.FromDateTimeOffset(expiresAt),
+        };
+
+        state.PendingClientToolCalls.Add(pendingCall);
+        return pendingCall;
+    }
+
+    public static VoicePendingClientToolCall? CompletePendingCall(
+        VoicePresenceRuntimeState state,
+        VoiceFunctionCallOutput output)
+    {
+        if (string.IsNullOrWhiteSpace(output.CallId))
+            return null;
+
+        for (var i = 0; i < state.PendingClientToolCalls.Count; i++)
+        {
+            var pendingCall = state.PendingClientToolCalls[i];
+            if (!string.Equals(pendingCall.CallId, output.CallId, StringComparison.Ordinal))
+                continue;
+
+            if (!string.IsNullOrWhiteSpace(output.ToolName) &&
+                !string.Equals(pendingCall.ToolName, output.ToolName, StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            state.PendingClientToolCalls.RemoveAt(i);
+            return pendingCall;
+        }
+
+        return null;
+    }
+
+    public static VoicePendingClientToolCall? ExpirePendingCall(
+        VoicePresenceRuntimeState state,
+        VoiceClientToolCallTimeoutExpired timeout,
+        DateTimeOffset now)
+    {
+        if (string.IsNullOrWhiteSpace(timeout.CallId))
+            return null;
+
+        for (var i = 0; i < state.PendingClientToolCalls.Count; i++)
+        {
+            var pendingCall = state.PendingClientToolCalls[i];
+            if (!MatchesTimeout(pendingCall, timeout))
+                continue;
+
+            if (pendingCall.ExpiresAt == null ||
+                pendingCall.ExpiresAt.ToDateTimeOffset() > now)
+            {
+                return null;
+            }
+
+            state.PendingClientToolCalls.RemoveAt(i);
+            return pendingCall;
+        }
+
+        return null;
+    }
+
+    public static void RemovePendingCallsForTransport(
+        VoicePresenceRuntimeState state,
+        string? transportLeaseId)
+    {
+        if (string.IsNullOrWhiteSpace(transportLeaseId))
+            return;
+
+        for (var i = state.PendingClientToolCalls.Count - 1; i >= 0; i--)
+        {
+            if (string.Equals(
+                    state.PendingClientToolCalls[i].TransportLeaseId,
+                    transportLeaseId,
+                    StringComparison.Ordinal))
+            {
+                state.PendingClientToolCalls.RemoveAt(i);
+            }
+        }
+    }
+
+    public static void RemovePendingCallsForProviderResponse(
+        VoicePresenceRuntimeState state,
+        string? providerResponseId)
+    {
+        if (string.IsNullOrWhiteSpace(providerResponseId))
+            return;
+
+        for (var i = state.PendingClientToolCalls.Count - 1; i >= 0; i--)
+        {
+            if (string.Equals(
+                    state.PendingClientToolCalls[i].ProviderResponseId,
+                    providerResponseId,
+                    StringComparison.Ordinal))
+            {
+                state.PendingClientToolCalls.RemoveAt(i);
+            }
+        }
+    }
+
+    public static string BuildOutputJson(VoiceFunctionCallOutput output)
+    {
+        return output.ResultCase switch
+        {
+            VoiceFunctionCallOutput.ResultOneofCase.OutputJson when !string.IsNullOrWhiteSpace(output.OutputJson) =>
+                output.OutputJson,
+            VoiceFunctionCallOutput.ResultOneofCase.OutputJson => "{}",
+            VoiceFunctionCallOutput.ResultOneofCase.Failure => BuildFailureJson(output.Failure),
+            _ => BuildFailureJson(new VoiceFunctionCallFailure
+            {
+                ErrorCode = "invalid_client_tool_output",
+                ErrorMessage = "client tool output did not include a result",
+            }),
+        };
+    }
+
+    public static string BuildTimeoutJson(VoicePendingClientToolCall pendingCall, TimeSpan timeout) =>
+        BuildFailureJson(new VoiceFunctionCallFailure
+        {
+            ErrorCode = "client_tool_timeout",
+            ErrorMessage = $"client-owned tool '{pendingCall.ToolName}' timed out after {(int)timeout.TotalMilliseconds} ms",
+        });
+
+    private static bool RemovePendingCall(VoicePresenceRuntimeState state, string callId)
+    {
+        for (var i = state.PendingClientToolCalls.Count - 1; i >= 0; i--)
+        {
+            if (string.Equals(state.PendingClientToolCalls[i].CallId, callId, StringComparison.Ordinal))
+            {
+                state.PendingClientToolCalls.RemoveAt(i);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool MatchesTimeout(
+        VoicePendingClientToolCall pendingCall,
+        VoiceClientToolCallTimeoutExpired timeout)
+    {
+        return string.Equals(pendingCall.SessionId, timeout.SessionId, StringComparison.Ordinal) &&
+               string.Equals(pendingCall.OwnerId, timeout.OwnerId, StringComparison.Ordinal) &&
+               string.Equals(pendingCall.TransportLeaseId, timeout.TransportLeaseId, StringComparison.Ordinal) &&
+               pendingCall.LeaseEpoch == timeout.LeaseEpoch &&
+               string.Equals(pendingCall.CallId, timeout.CallId, StringComparison.Ordinal) &&
+               (string.IsNullOrWhiteSpace(timeout.ToolName) ||
+                string.Equals(pendingCall.ToolName, timeout.ToolName, StringComparison.Ordinal));
+    }
+
+    private static string BuildFailureJson(VoiceFunctionCallFailure? failure)
+    {
+        var errorCode = string.IsNullOrWhiteSpace(failure?.ErrorCode)
+            ? "client_tool_failed"
+            : failure.ErrorCode.Trim();
+        var errorMessage = string.IsNullOrWhiteSpace(failure?.ErrorMessage)
+            ? "client-owned tool failed"
+            : failure.ErrorMessage;
+        return JsonSerializer.Serialize(new
+        {
+            error = new
+            {
+                code = errorCode,
+                message = errorMessage,
+            },
+        });
+    }
+}

--- a/src/Aevatar.Foundation.VoicePresence/Modules/VoiceClientToolCallStateMachine.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Modules/VoiceClientToolCallStateMachine.cs
@@ -36,7 +36,8 @@ internal static class VoiceClientToolCallStateMachine
 
     public static VoicePendingClientToolCall? CompletePendingCall(
         VoicePresenceRuntimeState state,
-        VoiceFunctionCallOutput output)
+        VoiceFunctionCallOutput output,
+        VoiceClientToolCallCompletionFence completionFence)
     {
         if (string.IsNullOrWhiteSpace(output.CallId))
             return null;
@@ -47,11 +48,14 @@ internal static class VoiceClientToolCallStateMachine
             if (!string.Equals(pendingCall.CallId, output.CallId, StringComparison.Ordinal))
                 continue;
 
-            if (!string.IsNullOrWhiteSpace(output.ToolName) &&
+            if (string.IsNullOrWhiteSpace(output.ToolName) ||
                 !string.Equals(pendingCall.ToolName, output.ToolName, StringComparison.Ordinal))
             {
                 return null;
             }
+
+            if (!MatchesCompletionFence(pendingCall, completionFence))
+                return null;
 
             state.PendingClientToolCalls.RemoveAt(i);
             return pendingCall;
@@ -131,13 +135,9 @@ internal static class VoiceClientToolCallStateMachine
         {
             VoiceFunctionCallOutput.ResultOneofCase.OutputJson when !string.IsNullOrWhiteSpace(output.OutputJson) =>
                 output.OutputJson,
-            VoiceFunctionCallOutput.ResultOneofCase.OutputJson => "{}",
+            VoiceFunctionCallOutput.ResultOneofCase.OutputJson => BuildInvalidOutputJson(),
             VoiceFunctionCallOutput.ResultOneofCase.Failure => BuildFailureJson(output.Failure),
-            _ => BuildFailureJson(new VoiceFunctionCallFailure
-            {
-                ErrorCode = "invalid_client_tool_output",
-                ErrorMessage = "client tool output did not include a result",
-            }),
+            _ => BuildInvalidOutputJson(),
         };
     }
 
@@ -148,18 +148,26 @@ internal static class VoiceClientToolCallStateMachine
             ErrorMessage = $"client-owned tool '{pendingCall.ToolName}' timed out after {(int)timeout.TotalMilliseconds} ms",
         });
 
-    private static bool RemovePendingCall(VoicePresenceRuntimeState state, string callId)
+    private static void RemovePendingCall(VoicePresenceRuntimeState state, string callId)
     {
         for (var i = state.PendingClientToolCalls.Count - 1; i >= 0; i--)
         {
             if (string.Equals(state.PendingClientToolCalls[i].CallId, callId, StringComparison.Ordinal))
             {
                 state.PendingClientToolCalls.RemoveAt(i);
-                return true;
+                return;
             }
         }
+    }
 
-        return false;
+    private static bool MatchesCompletionFence(
+        VoicePendingClientToolCall pendingCall,
+        VoiceClientToolCallCompletionFence completionFence)
+    {
+        return string.Equals(pendingCall.SessionId, completionFence.SessionId, StringComparison.Ordinal) &&
+               string.Equals(pendingCall.OwnerId, completionFence.OwnerId, StringComparison.Ordinal) &&
+               string.Equals(pendingCall.TransportLeaseId, completionFence.TransportLeaseId, StringComparison.Ordinal) &&
+               pendingCall.LeaseEpoch == completionFence.LeaseEpoch;
     }
 
     private static bool MatchesTimeout(
@@ -174,6 +182,13 @@ internal static class VoiceClientToolCallStateMachine
                (string.IsNullOrWhiteSpace(timeout.ToolName) ||
                 string.Equals(pendingCall.ToolName, timeout.ToolName, StringComparison.Ordinal));
     }
+
+    private static string BuildInvalidOutputJson() =>
+        BuildFailureJson(new VoiceFunctionCallFailure
+        {
+            ErrorCode = "invalid_client_tool_output",
+            ErrorMessage = "client tool output did not include a result",
+        });
 
     private static string BuildFailureJson(VoiceFunctionCallFailure? failure)
     {
@@ -193,3 +208,9 @@ internal static class VoiceClientToolCallStateMachine
         });
     }
 }
+
+internal sealed record VoiceClientToolCallCompletionFence(
+    string SessionId,
+    string OwnerId,
+    string TransportLeaseId,
+    long LeaseEpoch);

--- a/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
@@ -735,7 +735,16 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
             return;
         }
 
-        await HandleControlFrameAsync(request.ControlFrame, ctx, state, ct);
+        await HandleControlFrameAsync(
+            request.ControlFrame,
+            ctx,
+            state,
+            new VoiceClientToolCallCompletionFence(
+                request.SessionId,
+                request.OwnerId ?? string.Empty,
+                request.TransportLeaseId,
+                request.LeaseEpoch),
+            ct);
     }
 
     private async Task HandleTransportRelayStoppedAsync(
@@ -986,7 +995,16 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
             return;
         }
 
-        await HandleControlFrameAsync(request.ControlFrame, ctx, state, ct);
+        await HandleControlFrameAsync(
+            request.ControlFrame,
+            ctx,
+            state,
+            new VoiceClientToolCallCompletionFence(
+                state.ActiveSessionId ?? string.Empty,
+                state.ActiveLeaseOwnerId ?? string.Empty,
+                state.ActiveTransportLeaseId ?? string.Empty,
+                state.LeaseEpoch),
+            ct);
     }
 
     private async Task<bool> CloseRemoteSessionAsync(
@@ -1274,10 +1292,14 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
     private async Task HandleFunctionCallOutputAsync(
         VoiceFunctionCallOutput output,
         VoicePresenceRuntimeState state,
+        VoiceClientToolCallCompletionFence completionFence,
         IEventHandlerContext ctx,
         CancellationToken ct)
     {
-        var pendingCall = VoiceClientToolCallStateMachine.CompletePendingCall(state, output);
+        var pendingCall = VoiceClientToolCallStateMachine.CompletePendingCall(
+            state,
+            output,
+            completionFence);
         if (pendingCall == null)
             return;
 
@@ -1291,18 +1313,6 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         await PersistRuntimeStateAsync(ctx, state, ct);
     }
 
-    // Refactor (cluster-voice-tool-result-live-relay): the function_call is emitted by the LIVE realtime
-    // socket owned by the host's VoiceVolatileMediaStreamPort relay (keyed by the transport lease), and
-    // that socket's audio is relayed to the caller. Deliver the tool result there so the
-    // function_call_output lands on the conversation that requested it and the spoken answer is heard.
-    //
-    // The lease key MUST come from the incoming provider-event envelope (envelopeLeaseId): on the
-    // policy-aware /ws/voice relay path the FunctionCall is admitted via the RemoteSessionId fallback and
-    // the transport lease is never persisted into state.ActiveTransportLeaseId (it is empty there), while
-    // the envelope's TransportLeaseId is exactly the _activeRelays key. Fall back to state only for
-    // non-relay/legacy paths, and to a throwaway provider session only when no lease is available at all —
-    // otherwise the result would be added to a brand-new empty conversation whose audio goes nowhere, and
-    // the model would re-call the tool forever.
     private async Task DeliverToolResultAsync(
         VoicePresenceRuntimeState state,
         string callId,
@@ -1438,13 +1448,14 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
     private async Task HandleControlFrameAsync(VoiceControlFrame frame, IEventHandlerContext ctx, CancellationToken ct)
     {
         var state = HydrateRuntimeStateFromActor(ctx);
-        await HandleControlFrameAsync(frame, ctx, state, ct);
+        await HandleControlFrameAsync(frame, ctx, state, null, ct);
     }
 
     private async Task HandleControlFrameAsync(
         VoiceControlFrame frame,
         IEventHandlerContext ctx,
         VoicePresenceRuntimeState state,
+        VoiceClientToolCallCompletionFence? clientToolCallCompletionFence,
         CancellationToken ct)
     {
         switch (frame.FrameCase)
@@ -1458,7 +1469,16 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
                 await PersistRuntimeStateAsync(ctx, state, ct);
                 break;
             case VoiceControlFrame.FrameOneofCase.FunctionCallOutput:
-                await HandleFunctionCallOutputAsync(frame.FunctionCallOutput, state, ctx, ct);
+                if (clientToolCallCompletionFence != null)
+                {
+                    await HandleFunctionCallOutputAsync(
+                        frame.FunctionCallOutput,
+                        state,
+                        clientToolCallCompletionFence,
+                        ctx,
+                        ct);
+                }
+
                 break;
             case VoiceControlFrame.FrameOneofCase.InputImage:
                 break;

--- a/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
@@ -153,6 +153,9 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
             case VoiceModuleSignal.SignalOneofCase.DrainTimeoutExpired:
                 await HandleDrainTimeoutExpiredAsync(signal.DrainTimeoutExpired, ctx, ct);
                 break;
+            case VoiceModuleSignal.SignalOneofCase.ClientToolCallTimeoutExpired:
+                await HandleClientToolCallTimeoutExpiredAsync(signal.ClientToolCallTimeoutExpired, ctx, ct);
+                break;
             case VoiceModuleSignal.SignalOneofCase.TransportDetachRequested:
                 await HandleTransportDetachRequestedAsync(signal.TransportDetachRequested, ctx, ct);
                 break;
@@ -233,6 +236,9 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
             case VoiceProviderEvent.EventOneofCase.ResponseCancelled:
                 state.AwaitingInjectedResponseStart = false;
                 ApplyResponseCancelled(state, normalizedEvent.ResponseCancelled.ResponseId);
+                VoiceClientToolCallStateMachine.RemovePendingCallsForProviderResponse(
+                    state,
+                    normalizedEvent.ResponseCancelled.ProviderResponseId);
                 RetireProviderResponse(state, normalizedEvent.ResponseCancelled.ProviderResponseId);
                 stateChanged = true;
                 await FlushPendingEventInjectionsAsync(state, ct);
@@ -250,6 +256,7 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
                     {
                         if (!state.CancelledProviderResponseIds.Contains(providerResponseId))
                             state.CancelledProviderResponseIds.Add(providerResponseId);
+                        VoiceClientToolCallStateMachine.RemovePendingCallsForProviderResponse(state, providerResponseId);
                         RetireProviderResponse(state, providerResponseId);
                     }
 
@@ -265,7 +272,12 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
                 stateChanged = true;
                 break;
             case VoiceProviderEvent.EventOneofCase.FunctionCall:
-                await ExecuteToolCallAsync(normalizedEvent.FunctionCall, ctx, ct, transportLeaseId);
+                stateChanged = await HandleFunctionCallRequestedAsync(
+                    normalizedEvent.FunctionCall,
+                    state,
+                    ctx,
+                    ct,
+                    transportLeaseId);
                 break;
             case VoiceProviderEvent.EventOneofCase.Disconnected:
                 state.AwaitingInjectedResponseStart = false;
@@ -273,6 +285,7 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
                 state.ProviderResponseBindings.Clear();
                 state.CancelledProviderResponseIds.Clear();
                 state.ActiveProviderResponseId = string.Empty;
+                state.PendingClientToolCalls.Clear();
                 stateChanged = true;
                 if (await CloseRemoteSessionAsync(state, "provider_disconnected", ctx, ct))
                     stateChanged = false;
@@ -438,6 +451,29 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
             state.ActiveProviderResponseId = string.Empty;
     }
 
+    private async Task<bool> HandleFunctionCallRequestedAsync(
+        VoiceFunctionCallRequested request,
+        VoicePresenceRuntimeState state,
+        IEventHandlerContext ctx,
+        CancellationToken ct,
+        string? transportLeaseId)
+    {
+        if (await ResolveToolOwnerAsync(state, request.ToolName, ct) != VoiceToolOwner.Client)
+        {
+            await ExecuteToolCallAsync(request, ctx, ct, transportLeaseId);
+            return false;
+        }
+
+        var pendingCall = VoiceClientToolCallStateMachine.RecordPendingCall(
+            state,
+            request,
+            _options.TimeProvider.GetUtcNow().Add(_options.ToolExecutionTimeout),
+            transportLeaseId);
+
+        await ScheduleClientToolCallTimeoutAsync(pendingCall, ctx, ct);
+        return true;
+    }
+
     private bool MatchesModuleName(string? moduleName) =>
         !string.IsNullOrWhiteSpace(moduleName) &&
         string.Equals(Name, moduleName, StringComparison.OrdinalIgnoreCase);
@@ -551,6 +587,39 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
             ct: ct);
     }
 
+    private async Task ScheduleClientToolCallTimeoutAsync(
+        VoicePendingClientToolCall pendingCall,
+        IEventHandlerContext ctx,
+        CancellationToken ct)
+    {
+        if (_options.ToolExecutionTimeout <= TimeSpan.Zero)
+            return;
+
+        if (string.IsNullOrWhiteSpace(pendingCall.CallId) ||
+            pendingCall.LeaseEpoch <= 0)
+        {
+            return;
+        }
+
+        await ctx.ScheduleSelfDurableTimeoutAsync(
+            BuildClientToolCallTimeoutCallbackId(pendingCall),
+            _options.ToolExecutionTimeout,
+            new VoiceModuleSignal
+            {
+                ModuleName = Name,
+                ClientToolCallTimeoutExpired = new VoiceClientToolCallTimeoutExpired
+                {
+                    SessionId = pendingCall.SessionId,
+                    OwnerId = pendingCall.OwnerId,
+                    TransportLeaseId = pendingCall.TransportLeaseId,
+                    LeaseEpoch = pendingCall.LeaseEpoch,
+                    CallId = pendingCall.CallId,
+                    ToolName = pendingCall.ToolName,
+                },
+            },
+            ct: ct);
+    }
+
     private async Task HandleTransportLeaseRenewRequestedAsync(
         VoiceTransportLeaseRenewRequested request,
         IEventHandlerContext ctx,
@@ -602,6 +671,32 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         state.LastDrainAckResponseId = request.ResponseId;
         state.Status = VoicePresenceRuntimeStatus.Idle;
         await FlushPendingEventInjectionsAsync(state, ct);
+        await PersistRuntimeStateAsync(ctx, state, ct);
+    }
+
+    private async Task HandleClientToolCallTimeoutExpiredAsync(
+        VoiceClientToolCallTimeoutExpired request,
+        IEventHandlerContext ctx,
+        CancellationToken ct)
+    {
+        var state = HydrateRuntimeStateFromActor(ctx);
+        var pendingCall = VoiceClientToolCallStateMachine.ExpirePendingCall(
+            state,
+            request,
+            _options.TimeProvider.GetUtcNow());
+        if (pendingCall == null)
+            return;
+
+        var resultJson = VoiceClientToolCallStateMachine.BuildTimeoutJson(
+            pendingCall,
+            _options.ToolExecutionTimeout);
+        await DeliverToolResultAsync(
+            state,
+            pendingCall.CallId,
+            resultJson,
+            pendingCall.TransportLeaseId,
+            ctx,
+            ct);
         await PersistRuntimeStateAsync(ctx, state, ct);
     }
 
@@ -787,8 +882,12 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
     private string BuildDrainTimeoutCallbackId(long leaseEpoch, int responseId) =>
         $"{Name}:voice-drain-timeout:{leaseEpoch}:{responseId}";
 
+    private string BuildClientToolCallTimeoutCallbackId(VoicePendingClientToolCall pendingCall) =>
+        $"{Name}:voice-client-tool-timeout:{pendingCall.LeaseEpoch}:{pendingCall.CallId}";
+
     private static void ClearTransportLeaseState(VoicePresenceRuntimeState state)
     {
+        VoiceClientToolCallStateMachine.RemovePendingCallsForTransport(state, state.ActiveTransportLeaseId);
         state.TransportAttached = false;
         state.ActiveTransportLeaseId = string.Empty;
     }
@@ -843,6 +942,7 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         state.ActiveLeaseOwnerId = string.Empty;
         state.LeaseEpoch = NextLeaseEpoch(state);
         state.ActiveToolContext = null;
+        state.PendingClientToolCalls.Clear();
         ClearTransportLeaseState(state);
         await PersistRuntimeStateAsync(ctx, state, ct);
         await using (await ConnectProviderSessionAsync(state, ct))
@@ -907,6 +1007,7 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         state.ProviderResponseBindings.Clear();
         state.CancelledProviderResponseIds.Clear();
         state.ActiveProviderResponseId = string.Empty;
+        state.PendingClientToolCalls.Clear();
         await PersistRuntimeStateAsync(ctx, state, ct);
         await PublishRemoteOutputAsync(
             new VoiceRemoteTransportOutput
@@ -944,6 +1045,7 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         state.LeaseExpiresAt = request.ExpiresAt?.Clone();
         state.LeaseEpoch = NextLeaseEpoch(state);
         state.ActiveToolContext = request.ToolContext?.Clone();
+        state.PendingClientToolCalls.Clear();
         RefreshCapabilityFacts(state, ctx, request.SessionOverrides);
         await PersistRuntimeStateAsync(ctx, state, ct);
     }
@@ -965,6 +1067,7 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         state.LeaseExpiresAt = null;
         state.ActiveLeaseOwnerId = string.Empty;
         state.ActiveToolContext = null;
+        state.PendingClientToolCalls.Clear();
         ClearTransportLeaseState(state);
         await PersistRuntimeStateAsync(ctx, state, ct);
     }
@@ -1194,6 +1297,26 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         await DeliverToolResultAsync(state, request.CallId, resultJson, transportLeaseId, ctx, ct);
     }
 
+    private async Task HandleFunctionCallOutputAsync(
+        VoiceFunctionCallOutput output,
+        VoicePresenceRuntimeState state,
+        IEventHandlerContext ctx,
+        CancellationToken ct)
+    {
+        var pendingCall = VoiceClientToolCallStateMachine.CompletePendingCall(state, output);
+        if (pendingCall == null)
+            return;
+
+        await DeliverToolResultAsync(
+            state,
+            pendingCall.CallId,
+            VoiceClientToolCallStateMachine.BuildOutputJson(output),
+            pendingCall.TransportLeaseId,
+            ctx,
+            ct);
+        await PersistRuntimeStateAsync(ctx, state, ct);
+    }
+
     // Refactor (cluster-voice-tool-result-live-relay): the function_call is emitted by the LIVE realtime
     // socket owned by the host's VoiceVolatileMediaStreamPort relay (keyed by the transport lease), and
     // that socket's audio is relayed to the caller. Deliver the tool result there so the
@@ -1302,10 +1425,28 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
                 ParametersSchema = string.IsNullOrWhiteSpace(discoveredTool.ParametersSchema)
                     ? "{}"
                     : discoveredTool.ParametersSchema,
+                Owner = discoveredTool.Owner,
             });
         }
 
         return effectiveSession;
+    }
+
+    private async Task<VoiceToolOwner> ResolveToolOwnerAsync(
+        VoicePresenceRuntimeState state,
+        string toolName,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(toolName))
+            return VoiceToolOwner.Actor;
+
+        var effectiveSessionConfig = await BuildEffectiveSessionConfigAsync(state, ct);
+        var toolDefinition = effectiveSessionConfig?.ToolDefinitions.FirstOrDefault(definition =>
+            string.Equals(definition.Name, toolName, StringComparison.OrdinalIgnoreCase));
+
+        return toolDefinition?.Owner == VoiceToolOwner.Client
+            ? VoiceToolOwner.Client
+            : VoiceToolOwner.Actor;
     }
 
     private VoiceSessionConfig? ResolveBaseSessionConfig(VoicePresenceRuntimeState state)
@@ -1342,6 +1483,9 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
                 await PublishRealtimeFrameAsync(frame, state, ctx, ct);
                 await FlushPendingEventInjectionsAsync(state, ct);
                 await PersistRuntimeStateAsync(ctx, state, ct);
+                break;
+            case VoiceControlFrame.FrameOneofCase.FunctionCallOutput:
+                await HandleFunctionCallOutputAsync(frame.FunctionCallOutput, state, ctx, ct);
                 break;
             case VoiceControlFrame.FrameOneofCase.InputImage:
                 break;

--- a/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
+++ b/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
@@ -368,6 +368,17 @@ public sealed class PolicyAwareVoiceEndpointsTests
                     PlayoutSequence = 12,
                 },
             })));
+        socket.EnqueueReceive(
+            WebSocketMessageType.Text,
+            Encoding.UTF8.GetBytes(JsonFormatter.Default.Format(new VoiceControlFrame
+            {
+                FunctionCallOutput = new VoiceFunctionCallOutput
+                {
+                    CallId = "client-call-1",
+                    ToolName = "edge.light.toggle",
+                    OutputJson = """{"ok":true}""",
+                },
+            })));
         var mediaPort = new RecordingVolatileMediaStreamPort(
             attachAsync: async transport =>
             {
@@ -421,10 +432,16 @@ public sealed class PolicyAwareVoiceEndpointsTests
         realtime.RealtimeFrame.ResponseStarted.ResponseId.Should().Be(responseId);
         realtime.RealtimeFrame.ResponseStarted.ProviderResponseId.Should().Be("provider-response-51");
 
-        var ack = receivedControls.Should().ContainSingle().Which;
+        receivedControls.Should().HaveCount(2);
+        var ack = receivedControls[0];
         ack.FrameCase.Should().Be(VoiceControlFrame.FrameOneofCase.DrainAcknowledged);
         ack.DrainAcknowledged.ResponseId.Should().Be(realtime.RealtimeFrame.ResponseStarted.ResponseId);
         ack.DrainAcknowledged.PlayoutSequence.Should().Be(12);
+
+        var output = receivedControls[1];
+        output.FrameCase.Should().Be(VoiceControlFrame.FrameOneofCase.FunctionCallOutput);
+        output.FunctionCallOutput.CallId.Should().Be("client-call-1");
+        output.FunctionCallOutput.OutputJson.Should().Be("""{"ok":true}""");
     }
 
     [Theory]

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
@@ -913,6 +913,194 @@ public class VoicePresenceModuleTests
     }
 
     [Fact]
+    public async Task Client_owned_function_call_should_wait_for_typed_control_output()
+    {
+        var provider = new RecordingVoiceProvider();
+        var invoker = new RecordingVoiceToolInvoker("""{"actor":true}""");
+        var mediaPort = new RecordingToolResultMediaPort(deliver: true);
+        var hub = new RecordingProjectionSessionEventHub();
+        var services = new ServiceCollection()
+            .AddSingleton<IVoiceVolatileMediaStreamPort>(mediaPort)
+            .AddSingleton<IProjectionSessionEventHub<VoiceRealtimeFrame>>(hub)
+            .BuildServiceProvider();
+        var module = CreateModule(
+            provider,
+            toolInvoker: invoker,
+            toolCatalog: new StaticVoiceToolCatalog([
+                new VoiceToolDefinition
+                {
+                    Name = "edge.light.toggle",
+                    Description = "toggle local light",
+                    ParametersSchema = "{}",
+                    Owner = VoiceToolOwner.Client,
+                },
+            ]));
+        var roleAgent = CreateRoleAgentWithAttachedTransport();
+        var ctx = new StubEventHandlerContext(services, roleAgent);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = DefaultModuleName,
+            ProviderEventReceived = new VoiceProviderEventReceived
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseEpoch = 7,
+                ProviderEvent = new VoiceProviderEvent
+                {
+                    FunctionCall = new VoiceFunctionCallRequested
+                    {
+                        CallId = "client-call-1",
+                        ToolName = "edge.light.toggle",
+                        ArgumentsJson = """{"room":"entry"}""",
+                        ProviderResponseId = "provider-r1",
+                    },
+                },
+            },
+        }), ctx, CancellationToken.None);
+
+        invoker.Calls.ShouldBe(0);
+        provider.ToolResults.ShouldBeEmpty();
+        var state = RoleVoiceState(ctx);
+        var pendingCall = state.PendingClientToolCalls.ShouldHaveSingleItem();
+        pendingCall.CallId.ShouldBe("client-call-1");
+        pendingCall.ToolName.ShouldBe("edge.light.toggle");
+        pendingCall.TransportLeaseId.ShouldBe("transport-current");
+        pendingCall.LeaseEpoch.ShouldBe(7);
+        var scheduled = ctx.ScheduledTimeouts.ShouldHaveSingleItem();
+        scheduled.CallbackId.ShouldBe("voice_presence:voice-client-tool-timeout:7:client-call-1");
+        var timeoutSignal = scheduled.Event.ShouldBeOfType<VoiceModuleSignal>();
+        timeoutSignal.SignalCase.ShouldBe(VoiceModuleSignal.SignalOneofCase.ClientToolCallTimeoutExpired);
+        timeoutSignal.ClientToolCallTimeoutExpired.CallId.ShouldBe("client-call-1");
+        hub.Events.ShouldHaveSingleItem().Frame.FunctionCall.CallId.ShouldBe("client-call-1");
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = DefaultModuleName,
+            TransportControlFrameReceived = new VoiceTransportControlFrameReceived
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseEpoch = 7,
+                ControlFrame = new VoiceControlFrame
+                {
+                    FunctionCallOutput = new VoiceFunctionCallOutput
+                    {
+                        CallId = "client-call-1",
+                        ToolName = "edge.light.toggle",
+                        OutputJson = """{"ok":true}""",
+                    },
+                },
+            },
+        }), ctx, CancellationToken.None);
+
+        RoleVoiceState(ctx).PendingClientToolCalls.ShouldBeEmpty();
+        mediaPort.ToolResults.ShouldHaveSingleItem();
+        mediaPort.ToolResults[0].TransportLeaseId.ShouldBe("transport-current");
+        mediaPort.ToolResults[0].CallId.ShouldBe("client-call-1");
+        mediaPort.ToolResults[0].ResultJson.ShouldBe("""{"ok":true}""");
+        provider.ToolResults.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Client_tool_output_for_unknown_or_wrong_tool_should_be_ignored()
+    {
+        var provider = new RecordingVoiceProvider();
+        var mediaPort = new RecordingToolResultMediaPort(deliver: true);
+        var services = new ServiceCollection()
+            .AddSingleton<IVoiceVolatileMediaStreamPort>(mediaPort)
+            .BuildServiceProvider();
+        var module = CreateModule(provider);
+        var roleAgent = CreateRoleAgentWithAttachedTransport();
+        roleAgent.State.VoicePresence[DefaultModuleName].PendingClientToolCalls.Add(new VoicePendingClientToolCall
+        {
+            CallId = "client-call-1",
+            ToolName = "edge.light.toggle",
+            SessionId = "lease-current",
+            OwnerId = "host-current",
+            TransportLeaseId = "transport-current",
+            LeaseEpoch = 7,
+            ExpiresAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddSeconds(10)),
+        });
+        var ctx = new StubEventHandlerContext(services, roleAgent);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = DefaultModuleName,
+            TransportControlFrameReceived = new VoiceTransportControlFrameReceived
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseEpoch = 7,
+                ControlFrame = new VoiceControlFrame
+                {
+                    FunctionCallOutput = new VoiceFunctionCallOutput
+                    {
+                        CallId = "client-call-1",
+                        ToolName = "edge.other",
+                        OutputJson = """{"ok":true}""",
+                    },
+                },
+            },
+        }), ctx, CancellationToken.None);
+
+        RoleVoiceState(ctx).PendingClientToolCalls.ShouldHaveSingleItem().CallId.ShouldBe("client-call-1");
+        mediaPort.ToolResults.ShouldBeEmpty();
+        provider.ToolResults.ShouldBeEmpty();
+        roleAgent.PersistedStates.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Client_tool_timeout_should_resume_actor_and_send_error_result()
+    {
+        var now = new DateTimeOffset(2026, 6, 18, 8, 0, 0, TimeSpan.Zero);
+        var timeProvider = new ManualTimeProvider(now);
+        var provider = new RecordingVoiceProvider();
+        var module = CreateModule(
+            provider,
+            options: new VoicePresenceModuleOptions
+            {
+                TimeProvider = timeProvider,
+                ToolExecutionTimeout = TimeSpan.FromSeconds(3),
+            });
+        var roleAgent = CreateRoleAgentWithAttachedTransport(now.AddMinutes(5));
+        roleAgent.State.VoicePresence[DefaultModuleName].PendingClientToolCalls.Add(new VoicePendingClientToolCall
+        {
+            CallId = "client-call-timeout",
+            ToolName = "edge.light.toggle",
+            SessionId = "lease-current",
+            OwnerId = "host-current",
+            TransportLeaseId = "transport-current",
+            LeaseEpoch = 7,
+            ExpiresAt = Timestamp.FromDateTimeOffset(now.AddSeconds(3)),
+        });
+        var ctx = new StubEventHandlerContext(agent: roleAgent);
+        timeProvider.Advance(TimeSpan.FromSeconds(3));
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = DefaultModuleName,
+            ClientToolCallTimeoutExpired = new VoiceClientToolCallTimeoutExpired
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseEpoch = 7,
+                CallId = "client-call-timeout",
+                ToolName = "edge.light.toggle",
+            },
+        }), ctx, CancellationToken.None);
+
+        RoleVoiceState(ctx).PendingClientToolCalls.ShouldBeEmpty();
+        provider.ToolResults.ShouldHaveSingleItem().CallId.ShouldBe("client-call-timeout");
+        provider.ToolResults[0].ResultJson.ShouldContain("client_tool_timeout");
+        provider.ToolResults[0].ResultJson.ShouldContain("timed out after 3000 ms");
+    }
+
+    [Fact]
     public async Task Module_signal_should_ignore_events_for_other_voice_module_aliases()
     {
         var module = CreateModule(
@@ -1061,7 +1249,7 @@ public class VoicePresenceModuleTests
         var moduleSource = StripLineComments(File.ReadAllLines(moduleSourcePath));
 
         moduleSource.ShouldNotContain("VoicePresenceRuntimeState _runtimeState", Case.Sensitive);
-        moduleSource.ShouldNotContain("StateMachine", Case.Sensitive);
+        moduleSource.ShouldNotContain("new VoicePresenceRuntimeState", Case.Sensitive);
         moduleSource.ShouldNotContain("IVoiceTransport? _userTransport", Case.Sensitive);
         moduleSource.ShouldNotContain("CancellationTokenSource? _relayCts", Case.Sensitive);
         moduleSource.ShouldNotContain("Task? _userToProviderRelay", Case.Sensitive);
@@ -3313,7 +3501,11 @@ public class VoicePresenceModuleTests
 
     private sealed class ManualTimeProvider(DateTimeOffset utcNow) : TimeProvider
     {
-        public override DateTimeOffset GetUtcNow() => utcNow;
+        private DateTimeOffset _utcNow = utcNow;
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan duration) => _utcNow = _utcNow.Add(duration);
     }
 
     private sealed class RecordingVoiceToolInvoker(string resultJson) : IVoiceToolInvoker

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
@@ -1057,6 +1057,159 @@ public class VoicePresenceModuleTests
     }
 
     [Fact]
+    public async Task Client_tool_output_without_valid_transport_fence_should_be_ignored()
+    {
+        var provider = new RecordingVoiceProvider();
+        var mediaPort = new RecordingToolResultMediaPort(deliver: true);
+        var services = new ServiceCollection()
+            .AddSingleton<IVoiceVolatileMediaStreamPort>(mediaPort)
+            .BuildServiceProvider();
+        var module = CreateModule(provider);
+        var roleAgent = CreateRoleAgentWithAttachedTransport();
+        roleAgent.State.VoicePresence[DefaultModuleName].PendingClientToolCalls.Add(new VoicePendingClientToolCall
+        {
+            CallId = "client-call-1",
+            ToolName = "edge.light.toggle",
+            SessionId = "lease-current",
+            OwnerId = "host-current",
+            TransportLeaseId = "transport-current",
+            LeaseEpoch = 7,
+            ExpiresAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddSeconds(10)),
+        });
+        var ctx = new StubEventHandlerContext(services, roleAgent);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceControlFrame
+        {
+            FunctionCallOutput = new VoiceFunctionCallOutput
+            {
+                CallId = "client-call-1",
+                ToolName = "edge.light.toggle",
+                OutputJson = """{"ok":true}""",
+            },
+        }), ctx, CancellationToken.None);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = DefaultModuleName,
+            TransportControlFrameReceived = new VoiceTransportControlFrameReceived
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-other",
+                LeaseEpoch = 7,
+                ControlFrame = new VoiceControlFrame
+                {
+                    FunctionCallOutput = new VoiceFunctionCallOutput
+                    {
+                        CallId = "client-call-1",
+                        ToolName = "edge.light.toggle",
+                        OutputJson = """{"ok":true}""",
+                    },
+                },
+            },
+        }), ctx, CancellationToken.None);
+
+        RoleVoiceState(ctx).PendingClientToolCalls.ShouldHaveSingleItem().CallId.ShouldBe("client-call-1");
+        mediaPort.ToolResults.ShouldBeEmpty();
+        provider.ToolResults.ShouldBeEmpty();
+        roleAgent.PersistedStates.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Client_tool_failure_output_should_clear_pending_call_and_deliver_error_json()
+    {
+        var provider = new RecordingVoiceProvider();
+        var mediaPort = new RecordingToolResultMediaPort(deliver: true);
+        var services = new ServiceCollection()
+            .AddSingleton<IVoiceVolatileMediaStreamPort>(mediaPort)
+            .BuildServiceProvider();
+        var module = CreateModule(provider);
+        var roleAgent = CreateRoleAgentWithAttachedTransport();
+        AddPendingClientToolCall(roleAgent, "client-call-failed");
+        var ctx = new StubEventHandlerContext(services, roleAgent);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = DefaultModuleName,
+            TransportControlFrameReceived = new VoiceTransportControlFrameReceived
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseEpoch = 7,
+                ControlFrame = new VoiceControlFrame
+                {
+                    FunctionCallOutput = new VoiceFunctionCallOutput
+                    {
+                        CallId = "client-call-failed",
+                        ToolName = "edge.light.toggle",
+                        Failure = new VoiceFunctionCallFailure
+                        {
+                            ErrorCode = "edge_failed",
+                            ErrorMessage = "edge tool failed",
+                        },
+                    },
+                },
+            },
+        }), ctx, CancellationToken.None);
+
+        RoleVoiceState(ctx).PendingClientToolCalls.ShouldBeEmpty();
+        mediaPort.ToolResults.ShouldHaveSingleItem();
+        mediaPort.ToolResults[0].TransportLeaseId.ShouldBe("transport-current");
+        mediaPort.ToolResults[0].CallId.ShouldBe("client-call-failed");
+        mediaPort.ToolResults[0].ResultJson.ShouldContain("edge_failed");
+        mediaPort.ToolResults[0].ResultJson.ShouldContain("edge tool failed");
+        provider.ToolResults.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Client_tool_invalid_output_should_clear_pending_call_and_deliver_error_json(bool emptyOutputJson)
+    {
+        var provider = new RecordingVoiceProvider();
+        var mediaPort = new RecordingToolResultMediaPort(deliver: true);
+        var services = new ServiceCollection()
+            .AddSingleton<IVoiceVolatileMediaStreamPort>(mediaPort)
+            .BuildServiceProvider();
+        var module = CreateModule(provider);
+        var roleAgent = CreateRoleAgentWithAttachedTransport();
+        AddPendingClientToolCall(roleAgent, "client-call-invalid");
+        var ctx = new StubEventHandlerContext(services, roleAgent);
+        var output = new VoiceFunctionCallOutput
+        {
+            CallId = "client-call-invalid",
+            ToolName = "edge.light.toggle",
+        };
+        if (emptyOutputJson)
+            output.OutputJson = string.Empty;
+
+        await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+        {
+            ModuleName = DefaultModuleName,
+            TransportControlFrameReceived = new VoiceTransportControlFrameReceived
+            {
+                SessionId = "lease-current",
+                OwnerId = "host-current",
+                TransportLeaseId = "transport-current",
+                LeaseEpoch = 7,
+                ControlFrame = new VoiceControlFrame
+                {
+                    FunctionCallOutput = output,
+                },
+            },
+        }), ctx, CancellationToken.None);
+
+        RoleVoiceState(ctx).PendingClientToolCalls.ShouldBeEmpty();
+        mediaPort.ToolResults.ShouldHaveSingleItem();
+        mediaPort.ToolResults[0].TransportLeaseId.ShouldBe("transport-current");
+        mediaPort.ToolResults[0].CallId.ShouldBe("client-call-invalid");
+        mediaPort.ToolResults[0].ResultJson.ShouldContain("invalid_client_tool_output");
+        mediaPort.ToolResults[0].ResultJson.ShouldContain("client tool output did not include a result");
+        provider.ToolResults.ShouldBeEmpty();
+    }
+
+    [Fact]
     public async Task Client_tool_timeout_should_resume_actor_and_send_error_result()
     {
         var now = new DateTimeOffset(2026, 6, 18, 8, 0, 0, TimeSpan.Zero);
@@ -3113,6 +3266,20 @@ public class VoicePresenceModuleTests
             LastDrainAckPlayoutSequence = -1,
         };
         return roleAgent;
+    }
+
+    private static void AddPendingClientToolCall(RecordingRoleAgent roleAgent, string callId)
+    {
+        roleAgent.State.VoicePresence[DefaultModuleName].PendingClientToolCalls.Add(new VoicePendingClientToolCall
+        {
+            CallId = callId,
+            ToolName = "edge.light.toggle",
+            SessionId = "lease-current",
+            OwnerId = "host-current",
+            TransportLeaseId = "transport-current",
+            LeaseEpoch = 7,
+            ExpiresAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddSeconds(10)),
+        });
     }
 
     private static EventEnvelope CreateExternalPublication(IMessage payload)

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceProtoTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceProtoTests.cs
@@ -59,6 +59,7 @@ public class VoicePresenceProtoTests
             Name = "door.close",
             Description = "close the front door",
             ParametersSchema = """{"type":"object"}""",
+            Owner = VoiceToolOwner.Client,
         });
 
         var parsedControl = VoiceControlFrame.Parser.ParseFrom(controlFrame.ToByteArray());
@@ -76,6 +77,86 @@ public class VoicePresenceProtoTests
             .ShouldContain(nameof(VoiceToolDefinition));
         VoicePresenceReflection.Descriptor.MessageTypes.Select(x => x.Name)
             .ShouldContain(nameof(VoicePresenceEventDedupeFenceEntry));
+        sessionConfig.ToolDefinitions[0].Owner.ShouldBe(VoiceToolOwner.Client);
+        VoiceToolDefinition.Descriptor.Fields["owner"].FieldNumber.ShouldBe(4);
+    }
+
+    [Fact]
+    public void VoiceFunctionCallOutput_should_roundtrip_through_control_frame_and_runtime_state()
+    {
+        var output = new VoiceFunctionCallOutput
+        {
+            CallId = "call-client-1",
+            ToolName = "edge.light.toggle",
+            OutputJson = """{"ok":true}""",
+        };
+        var controlFrame = new VoiceControlFrame
+        {
+            FunctionCallOutput = output.Clone(),
+        };
+        var pendingCall = new VoicePendingClientToolCall
+        {
+            CallId = "call-client-1",
+            ToolName = "edge.light.toggle",
+            ArgumentsJson = """{"room":"entry"}""",
+            ResponseId = 7,
+            ProviderResponseId = "provider-r7",
+            SessionId = "session-1",
+            OwnerId = "host-1",
+            TransportLeaseId = "transport-1",
+            LeaseEpoch = 4,
+            ExpiresAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddSeconds(10)),
+        };
+        var runtimeState = new VoicePresenceRuntimeState();
+        runtimeState.PendingClientToolCalls.Add(pendingCall.Clone());
+
+        var parsedControl = VoiceControlFrame.Parser.ParseFrom(controlFrame.ToByteArray());
+        var parsedState = VoicePresenceRuntimeState.Parser.ParseFrom(runtimeState.ToByteArray());
+
+        parsedControl.ShouldBe(controlFrame);
+        parsedControl.FrameCase.ShouldBe(VoiceControlFrame.FrameOneofCase.FunctionCallOutput);
+        parsedControl.FunctionCallOutput.ResultCase.ShouldBe(VoiceFunctionCallOutput.ResultOneofCase.OutputJson);
+        parsedControl.FunctionCallOutput.OutputJson.ShouldBe("""{"ok":true}""");
+        parsedState.PendingClientToolCalls.ShouldHaveSingleItem().ShouldBe(pendingCall);
+        VoiceControlFrame.Descriptor.Oneofs.Single(static oneof => oneof.Name == "frame").Fields
+            .Single(static field => field.Name == "function_call_output")
+            .FieldNumber.ShouldBe(5);
+        VoicePresenceRuntimeState.Descriptor.Fields["pending_client_tool_calls"].FieldNumber.ShouldBe(24);
+        VoicePresenceReflection.Descriptor.MessageTypes.Select(static x => x.Name)
+            .ShouldContain(nameof(VoiceFunctionCallOutput));
+        VoicePresenceReflection.Descriptor.MessageTypes.Select(static x => x.Name)
+            .ShouldContain(nameof(VoicePendingClientToolCall));
+    }
+
+    [Fact]
+    public void VoiceModuleSignal_should_roundtrip_client_tool_timeout_with_tag_20()
+    {
+        var timeout = new VoiceClientToolCallTimeoutExpired
+        {
+            SessionId = "lease-1",
+            OwnerId = "host-1",
+            TransportLeaseId = "transport-1",
+            LeaseEpoch = 14,
+            CallId = "call-client-1",
+            ToolName = "edge.light.toggle",
+        };
+        var signal = new VoiceModuleSignal
+        {
+            ModuleName = "voice_presence",
+            ClientToolCallTimeoutExpired = timeout,
+        };
+
+        var parsed = VoiceModuleSignal.Parser.ParseFrom(signal.ToByteArray());
+        var signalOneof = VoiceModuleSignal.Descriptor.Oneofs
+            .Single(static oneof => oneof.Name == "signal");
+        var timeoutField = signalOneof.Fields
+            .Single(static field => field.Name == "client_tool_call_timeout_expired");
+
+        parsed.ShouldBe(signal);
+        parsed.SignalCase.ShouldBe(VoiceModuleSignal.SignalOneofCase.ClientToolCallTimeoutExpired);
+        parsed.ClientToolCallTimeoutExpired.ShouldBe(timeout);
+        timeoutField.FieldNumber.ShouldBe(20);
+        timeoutField.MessageType.Name.ShouldBe(nameof(VoiceClientToolCallTimeoutExpired));
     }
 
     [Fact]

--- a/test/Aevatar.Foundation.VoicePresence.Tests/WebRtcVoiceTransportTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/WebRtcVoiceTransportTests.cs
@@ -69,10 +69,15 @@ public class WebRtcVoiceTransportTests
         peer.EmitAudio(codec.EncodePacket(new byte[codec.PcmBytesPerFrame]));
         peer.EmitControl(JsonFormatter.Default.Format(new VoiceControlFrame
         {
-            DrainAcknowledged = new VoiceDrainAcknowledged
+            FunctionCallOutput = new VoiceFunctionCallOutput
             {
-                ResponseId = 9,
-                PlayoutSequence = 88,
+                CallId = "client-call-1",
+                ToolName = "edge.light.toggle",
+                Failure = new VoiceFunctionCallFailure
+                {
+                    ErrorCode = "edge_failed",
+                    ErrorMessage = "edge tool failed",
+                },
             },
         }));
         peer.EmitClosed();
@@ -82,8 +87,9 @@ public class WebRtcVoiceTransportTests
         frames[0].IsAudio.ShouldBeTrue();
         frames[0].AudioPcm16.Length.ShouldBe(codec.PcmBytesPerFrame);
         frames[1].IsAudio.ShouldBeFalse();
-        frames[1].Control.ShouldNotBeNull();
-        frames[1].Control!.DrainAcknowledged.ResponseId.ShouldBe(9);
+        var control = frames[1].Control.ShouldNotBeNull();
+        control.FrameCase.ShouldBe(VoiceControlFrame.FrameOneofCase.FunctionCallOutput);
+        control.FunctionCallOutput.Failure.ErrorCode.ShouldBe("edge_failed");
     }
 
     [Fact]

--- a/test/Aevatar.Foundation.VoicePresence.Tests/WebSocketVoiceTransportTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/WebSocketVoiceTransportTests.cs
@@ -67,6 +67,34 @@ public class WebSocketVoiceTransportTests
         frames[1].Control!.DrainAcknowledged.ResponseId.ShouldBe(9);
     }
 
+    [Fact]
+    public async Task ReceiveFramesAsync_should_yield_function_call_output_control_frame()
+    {
+        var socket = new FakeWebSocket(WebSocketState.Open);
+        socket.EnqueueReceive(
+            WebSocketMessageType.Text,
+            Encoding.UTF8.GetBytes(JsonFormatter.Default.Format(new VoiceControlFrame
+            {
+                FunctionCallOutput = new VoiceFunctionCallOutput
+                {
+                    CallId = "client-call-1",
+                    ToolName = "edge.light.toggle",
+                    OutputJson = """{"ok":true}""",
+                },
+            })));
+
+        await using var transport = new WebSocketVoiceTransport(socket);
+        var frames = new List<VoiceTransportFrame>();
+
+        await foreach (var frame in transport.ReceiveFramesAsync(CancellationToken.None))
+            frames.Add(frame);
+
+        var control = frames.ShouldHaveSingleItem().Control.ShouldNotBeNull();
+        control.FrameCase.ShouldBe(VoiceControlFrame.FrameOneofCase.FunctionCallOutput);
+        control.FunctionCallOutput.CallId.ShouldBe("client-call-1");
+        control.FunctionCallOutput.OutputJson.ShouldBe("""{"ok":true}""");
+    }
+
     [Theory]
     [InlineData("image/jpeg")]
     [InlineData("image/png")]


### PR DESCRIPTION
## Changed files
实现了语音客户端自有工具的一等协议语义：`VoiceToolDefinition` 增加 owner，`VoiceControlFrame` 增加 typed `function_call_output`，actor state 持久化 pending client call correlation，并通过现有 provider result path 回写成功或失败结果。

补充了 `VoiceClientToolCallStateMachine`，在租约释放、远端会话关闭、provider 取消或断连时清理 pending call，timeout 通过 durable self-signal 回到 actor inbox 后再完成 provider error result。

更新了 voice presence integration canon 与 ADR 0031，明确默认/未指定 owner 仍为 actor-owned，client-owned 工具不引入进程内 pending map、generic bag、device command queue、NyxID 改动或 host.env 生产事实源。

Closes #2156

## Test results
已通过 `dotnet test test/Aevatar.Foundation.VoicePresence.Tests/Aevatar.Foundation.VoicePresence.Tests.csproj --nologo`、`dotnet test test/Aevatar.ChatRouting.Voice.Integration.Tests/Aevatar.ChatRouting.Voice.Integration.Tests.csproj --nologo`、`dotnet build aevatar.slnx --nologo`、`bash tools/ci/test_stability_guards.sh`、`bash tools/ci/architecture_guards.sh`。

## Deviations
无 scope extension。`HOST_REFACTOR_COMMENT_POLICY` 归一化为 `none`，因此未新增 refactor-history source comments。

⟦AI:AUTO-LOOP⟧
