### PR TITLE
强化 voice handshake 合同并移除伪 transcript

### DIFF
--- a/docs/canon/voice-presence-integration.md
+++ b/docs/canon/voice-presence-integration.md
@@ -110,9 +110,15 @@ The edge consumes a JSON projection of it (camelCase), hand-parsed by
   `VoiceControlFrame` oneof:
   - up (client → aevatar): `drainAcknowledged`, `inputImage`
   - down (aevatar → client): `sessionAccepted`, `realtimeFrame`
+  - `sessionAccepted` advertises the typed wire contract version (`1.0`) and
+    the input image policy (`maxBytes: 512000`, allowed media types
+    `image/jpeg`, `image/png`) owned by aevatar.
   - `realtimeFrame` is itself a `VoiceRealtimeFrame` oneof: `responseStarted`/
     `Done`/`Cancelled`, `speechStarted`/`Stopped`, `functionCall`,
     `transcriptDelta`/`Completed`, `error`, `disconnected`, `sessionClosed`.
+    `transcriptCompleted` represents provider transcript text only; a
+    `drainAcknowledged` playout ACK advances the actor drain fence but does not
+    publish a transcript fact.
 - **Ownership** — the actor owns persona, tools, turn lifecycle and VAD; the
   edge sends no `session.update` / `response.create` / `response.cancel` and
   drops any local `function_call_output` (tools execute actor-side).

--- a/src/Aevatar.Foundation.VoicePresence.Abstractions/Protos/voice_presence.proto
+++ b/src/Aevatar.Foundation.VoicePresence.Abstractions/Protos/voice_presence.proto
@@ -260,12 +260,19 @@ message VoiceDrainAcknowledged {
   int64 playout_sequence = 2;
 }
 
+message VoiceInputImagePolicy {
+  int32 max_bytes = 1;
+  repeated string allowed_media_types = 2;
+}
+
 message VoiceTransportSessionAccepted {
   string actor_id = 1;
   string module_name = 2;
   string session_id = 3;
   int32 pcm_sample_rate_hz = 4;
   int64 observed_state_version = 5;
+  string wire_contract_version = 6;
+  VoiceInputImagePolicy input_image_policy = 7;
 }
 
 message VoiceControlFrame {

--- a/src/Aevatar.Foundation.VoicePresence.Abstractions/VoiceWireContractDefaults.cs
+++ b/src/Aevatar.Foundation.VoicePresence.Abstractions/VoiceWireContractDefaults.cs
@@ -1,0 +1,35 @@
+namespace Aevatar.Foundation.VoicePresence.Abstractions;
+
+public static class VoiceWireContractDefaults
+{
+    public const string CurrentWireContractVersion = "1.0";
+    public const int MaxInputImageBytes = 512000;
+    public const int MaxInputImageControlFrameBytes = ((MaxInputImageBytes + 2) / 3 * 4) + 1024;
+
+    public static IReadOnlyList<string> SupportedInputImageMediaTypes { get; } =
+    [
+        "image/jpeg",
+        "image/png",
+    ];
+
+    public static VoiceInputImagePolicy CreateInputImagePolicy()
+    {
+        var policy = new VoiceInputImagePolicy
+        {
+            MaxBytes = MaxInputImageBytes,
+        };
+        policy.AllowedMediaTypes.Add(SupportedInputImageMediaTypes);
+        return policy;
+    }
+
+    public static bool IsSupportedInputImageMediaType(string? mediaType)
+    {
+        if (string.IsNullOrWhiteSpace(mediaType))
+            return false;
+
+        return SupportedInputImageMediaTypes.Contains(mediaType.Trim(), StringComparer.OrdinalIgnoreCase);
+    }
+
+    public static string FormatSupportedInputImageMediaTypes() =>
+        string.Join(" or ", SupportedInputImageMediaTypes);
+}

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/ActorOwnedVoiceRealtimeSession.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/ActorOwnedVoiceRealtimeSession.cs
@@ -149,7 +149,9 @@ public sealed class ActorOwnedVoiceRealtimeSession
             leaseHandle.SessionId,
             capability.PcmSampleRateHz,
             leaseHandle.ObservedStateVersion,
-            leaseHandle);
+            leaseHandle,
+            VoiceWireContractDefaults.CurrentWireContractVersion,
+            VoiceWireContractDefaults.CreateInputImagePolicy());
 
     private DateTimeOffset UtcNow => _timeProvider.GetUtcNow();
 

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/VoiceRealtimeSessionRequest.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/VoiceRealtimeSessionRequest.cs
@@ -22,7 +22,18 @@ public sealed record VoiceRealtimeSessionAccepted(
     string SessionId,
     int PcmSampleRateHz,
     long ObservedStateVersion,
-    VoicePresenceSessionLeaseHandle LeaseHandle);
+    VoicePresenceSessionLeaseHandle LeaseHandle,
+    string WireContractVersion = VoiceWireContractDefaults.CurrentWireContractVersion,
+    VoiceInputImagePolicy? InputImagePolicy = null)
+{
+    public string EffectiveWireContractVersion =>
+        string.IsNullOrWhiteSpace(WireContractVersion)
+            ? VoiceWireContractDefaults.CurrentWireContractVersion
+            : WireContractVersion;
+
+    public VoiceInputImagePolicy CreateEffectiveInputImagePolicy() =>
+        InputImagePolicy?.Clone() ?? VoiceWireContractDefaults.CreateInputImagePolicy();
+}
 
 public enum VoiceRealtimeSessionStartError
 {

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/VoiceRealtimeTransportControlBridge.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/VoiceRealtimeTransportControlBridge.cs
@@ -25,6 +25,8 @@ public static class VoiceRealtimeTransportControlBridge
                 SessionId = accepted.SessionId,
                 PcmSampleRateHz = accepted.PcmSampleRateHz,
                 ObservedStateVersion = accepted.ObservedStateVersion,
+                WireContractVersion = accepted.EffectiveWireContractVersion,
+                InputImagePolicy = accepted.CreateEffectiveInputImagePolicy(),
             },
         }, ct);
     }

--- a/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
@@ -990,16 +990,6 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
     }
 
     private Task PublishRealtimeFrameAsync(
-        VoiceControlFrame controlFrame,
-        VoicePresenceRuntimeState state,
-        IEventHandlerContext ctx,
-        CancellationToken ct)
-    {
-        var frame = BuildRealtimeFrame(controlFrame, state);
-        return frame == null ? Task.CompletedTask : PublishRealtimeFrameAsync(frame, ctx, ct);
-    }
-
-    private Task PublishRealtimeFrameAsync(
         VoiceRemoteTransportOutput output,
         VoicePresenceRuntimeState state,
         IEventHandlerContext ctx,
@@ -1056,22 +1046,6 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
             }),
             _ => null,
         };
-    }
-
-    private VoiceRealtimeFrame? BuildRealtimeFrame(
-        VoiceControlFrame controlFrame,
-        VoicePresenceRuntimeState state)
-    {
-        if (controlFrame.FrameCase != VoiceControlFrame.FrameOneofCase.DrainAcknowledged)
-            return null;
-
-        return CreateRealtimeFrame(state.ActiveSessionId, new VoiceRealtimeFrame
-        {
-            TranscriptCompleted = new VoiceTranscriptCompleted
-            {
-                ResponseId = controlFrame.DrainAcknowledged.ResponseId,
-            },
-        });
     }
 
     private VoiceRealtimeFrame? CreateRealtimeFrame(string? sessionId, VoiceRealtimeFrame frame)
@@ -1339,7 +1313,6 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
                     state,
                     frame.DrainAcknowledged.ResponseId,
                     frame.DrainAcknowledged.PlayoutSequence);
-                await PublishRealtimeFrameAsync(frame, state, ctx, ct);
                 await FlushPendingEventInjectionsAsync(state, ct);
                 await PersistRuntimeStateAsync(ctx, state, ct);
                 break;

--- a/src/Aevatar.Foundation.VoicePresence/Transport/WebSocketVoiceTransport.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Transport/WebSocketVoiceTransport.cs
@@ -17,15 +17,8 @@ namespace Aevatar.Foundation.VoicePresence.Transport;
 public sealed class WebSocketVoiceTransport : IVoiceTransport
 {
     private const int ReceiveBufferSize = 8 * 1024;
-    private const int MaxInputImageBytes = 500 * 1024;
-    private const int MaxTextMessageBytes = ((MaxInputImageBytes + 2) / 3 * 4) + 1024;
     private static readonly JsonFormatter ControlJsonWriter = new(JsonFormatter.Settings.Default);
     private static readonly JsonParser ControlJsonReader = new(JsonParser.Settings.Default);
-    private static readonly string[] SupportedInputImageMediaTypes =
-    [
-        "image/jpeg",
-        "image/png",
-    ];
 
     private readonly WebSocket _ws;
     private readonly TaskCompletionSource _completion =
@@ -183,8 +176,11 @@ public sealed class WebSocketVoiceTransport : IVoiceTransport
                 buffer.AsMemory(totalBytes, buffer.Length - totalBytes), ct);
             totalBytes += result.Count;
 
-            if (result.MessageType == WebSocketMessageType.Text && totalBytes > MaxTextMessageBytes)
+            if (result.MessageType == WebSocketMessageType.Text &&
+                totalBytes > VoiceWireContractDefaults.MaxInputImageControlFrameBytes)
+            {
                 throw new VoiceTransportFrameRejectedException("Voice text frame exceeds the input image size limit.");
+            }
         } while (!result.EndOfMessage);
 
         return (totalBytes, result.MessageType, buffer);
@@ -244,13 +240,15 @@ public sealed class WebSocketVoiceTransport : IVoiceTransport
             return "Voice input image data is required.";
         }
 
-        var mediaType = inputImage.MediaType.Trim();
-        if (!SupportedInputImageMediaTypes.Contains(mediaType, StringComparer.OrdinalIgnoreCase))
-            return "Voice input image media type must be image/jpeg or image/png.";
+        if (!VoiceWireContractDefaults.IsSupportedInputImageMediaType(inputImage.MediaType))
+        {
+            return
+                $"Voice input image media type must be {VoiceWireContractDefaults.FormatSupportedInputImageMediaTypes()}.";
+        }
 
-        return inputImage.Data.Length <= MaxInputImageBytes
+        return inputImage.Data.Length <= VoiceWireContractDefaults.MaxInputImageBytes
             ? null
-            : "Voice input image exceeds the 500 KB size limit.";
+            : $"Voice input image exceeds the {VoiceWireContractDefaults.MaxInputImageBytes} bytes size limit.";
     }
 
     private async Task TryClosePolicyViolationAsync(string reason, CancellationToken ct)

--- a/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
+++ b/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
@@ -414,6 +414,10 @@ public sealed class PolicyAwareVoiceEndpointsTests
         accepted.FrameCase.Should().Be(VoiceControlFrame.FrameOneofCase.SessionAccepted);
         accepted.SessionAccepted.SessionId.Should().Be("session-1");
         accepted.SessionAccepted.PcmSampleRateHz.Should().Be(24000);
+        accepted.SessionAccepted.WireContractVersion.Should().Be(VoiceWireContractDefaults.CurrentWireContractVersion);
+        accepted.SessionAccepted.InputImagePolicy.MaxBytes.Should().Be(VoiceWireContractDefaults.MaxInputImageBytes);
+        accepted.SessionAccepted.InputImagePolicy.AllowedMediaTypes
+            .Should().Equal(VoiceWireContractDefaults.SupportedInputImageMediaTypes);
 
         var realtime = JsonParser.Default.Parse<VoiceControlFrame>(socket.SentTexts[1]);
         realtime.FrameCase.Should().Be(VoiceControlFrame.FrameOneofCase.RealtimeFrame);

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceEndpointsTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceEndpointsTests.cs
@@ -333,6 +333,10 @@ public class VoicePresenceEndpointsTests
         accepted.FrameCase.ShouldBe(VoiceControlFrame.FrameOneofCase.SessionAccepted);
         accepted.SessionAccepted.SessionId.ShouldBe("session-1");
         accepted.SessionAccepted.PcmSampleRateHz.ShouldBe(24000);
+        accepted.SessionAccepted.WireContractVersion.ShouldBe(VoiceWireContractDefaults.CurrentWireContractVersion);
+        accepted.SessionAccepted.InputImagePolicy.MaxBytes.ShouldBe(VoiceWireContractDefaults.MaxInputImageBytes);
+        accepted.SessionAccepted.InputImagePolicy.AllowedMediaTypes
+            .ShouldBe(VoiceWireContractDefaults.SupportedInputImageMediaTypes);
 
         var realtime = JsonParser.Default.Parse<VoiceControlFrame>(socket.SentTexts[1]);
         realtime.FrameCase.ShouldBe(VoiceControlFrame.FrameOneofCase.RealtimeFrame);

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
@@ -61,7 +61,7 @@ public class VoicePresenceModuleTests
     }
 
     [Fact]
-    public async Task Control_transcript_frame_should_enter_projection_backed_realtime_stream()
+    public async Task Drain_acknowledged_should_not_publish_transcript_completed()
     {
         var provider = new RecordingVoiceProvider();
         var module = CreateModule(provider);
@@ -70,6 +70,8 @@ public class VoicePresenceModuleTests
             .AddSingleton<IProjectionSessionEventHub<VoiceRealtimeFrame>>(hub)
             .BuildServiceProvider();
         var ctx = new StubEventHandlerContext(services, CreateRoleAgentWithActiveSession());
+        RoleVoiceState(ctx).Status = VoicePresenceRuntimeStatus.AudioDraining;
+        RoleVoiceState(ctx).CurrentResponseId = 5;
 
         await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
         {
@@ -87,9 +89,10 @@ public class VoicePresenceModuleTests
             },
         }), ctx, CancellationToken.None);
 
-        var published = hub.Events.ShouldHaveSingleItem();
-        published.Frame.FrameCase.ShouldBe(VoiceRealtimeFrame.FrameOneofCase.TranscriptCompleted);
-        published.Frame.TranscriptCompleted.ResponseId.ShouldBe(5);
+        hub.Events.ShouldBeEmpty();
+        var state = RoleVoiceState(ctx);
+        state.Status.ShouldBe(VoicePresenceRuntimeStatus.Idle);
+        state.LastDrainAckResponseId.ShouldBe(5);
     }
 
     [Fact]

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceProtoTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceProtoTests.cs
@@ -34,10 +34,15 @@ public class VoicePresenceProtoTests
     {
         var controlFrame = new VoiceControlFrame
         {
-            DrainAcknowledged = new VoiceDrainAcknowledged
+            SessionAccepted = new VoiceTransportSessionAccepted
             {
-                ResponseId = 3,
-                PlayoutSequence = 42,
+                ActorId = "agent-1",
+                ModuleName = "voice_presence",
+                SessionId = "session-1",
+                PcmSampleRateHz = 24000,
+                ObservedStateVersion = 5,
+                WireContractVersion = VoiceWireContractDefaults.CurrentWireContractVersion,
+                InputImagePolicy = VoiceWireContractDefaults.CreateInputImagePolicy(),
             },
         };
         var providerConfig = new VoiceProviderConfig
@@ -63,8 +68,10 @@ public class VoicePresenceProtoTests
 
         var parsedControl = VoiceControlFrame.Parser.ParseFrom(controlFrame.ToByteArray());
         parsedControl.ShouldBe(controlFrame);
-        parsedControl.DrainAcknowledged.ResponseId.ShouldBe(3);
-        parsedControl.DrainAcknowledged.PlayoutSequence.ShouldBe(42);
+        parsedControl.SessionAccepted.WireContractVersion.ShouldBe(VoiceWireContractDefaults.CurrentWireContractVersion);
+        parsedControl.SessionAccepted.InputImagePolicy.MaxBytes.ShouldBe(VoiceWireContractDefaults.MaxInputImageBytes);
+        parsedControl.SessionAccepted.InputImagePolicy.AllowedMediaTypes
+            .ShouldBe(VoiceWireContractDefaults.SupportedInputImageMediaTypes);
 
         providerConfig.Clone().ShouldBe(providerConfig);
         sessionConfig.Clone().ShouldBe(sessionConfig);
@@ -76,6 +83,18 @@ public class VoicePresenceProtoTests
             .ShouldContain(nameof(VoiceToolDefinition));
         VoicePresenceReflection.Descriptor.MessageTypes.Select(x => x.Name)
             .ShouldContain(nameof(VoicePresenceEventDedupeFenceEntry));
+        VoiceTransportSessionAccepted.Descriptor.Fields.InDeclarationOrder()
+            .Select(static field => field.Name)
+            .ShouldContain("wire_contract_version");
+        VoiceTransportSessionAccepted.Descriptor.Fields.InDeclarationOrder()
+            .Select(static field => field.Name)
+            .ShouldContain("input_image_policy");
+        VoiceInputImagePolicy.Descriptor.Fields.InDeclarationOrder()
+            .Select(static field => field.Name)
+            .ShouldBe([
+                "max_bytes",
+                "allowed_media_types",
+            ]);
     }
 
     [Fact]

--- a/test/Aevatar.Foundation.VoicePresence.Tests/WebSocketVoiceTransportTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/WebSocketVoiceTransportTests.cs
@@ -133,7 +133,7 @@ public class WebSocketVoiceTransportTests
                 InputImage = new VoiceInputImage
                 {
                     MediaType = "image/jpeg",
-                    Data = ByteString.CopyFrom(new byte[(500 * 1024) + 1]),
+                    Data = ByteString.CopyFrom(new byte[VoiceWireContractDefaults.MaxInputImageBytes + 1]),
                 },
             }));
 
@@ -146,7 +146,8 @@ public class WebSocketVoiceTransportTests
         frames.ShouldBeEmpty();
         socket.CloseCalls.ShouldBe(1);
         socket.LastCloseStatus.ShouldBe(WebSocketCloseStatus.PolicyViolation);
-        socket.LastCloseDescription.ShouldBe("Voice input image exceeds the 500 KB size limit.");
+        socket.LastCloseDescription.ShouldBe(
+            $"Voice input image exceeds the {VoiceWireContractDefaults.MaxInputImageBytes} bytes size limit.");
     }
 
     private static void EnqueueTextMessage(FakeWebSocket socket, string text)


### PR DESCRIPTION
## Changed files

新增 `VoiceWireContractDefaults` 作为 voice wire version 与 input image policy 的单一事实源，并在 `sessionAccepted` 中通过强类型 proto 字段暴露 `wire_contract_version` 与 `input_image_policy`。`WebSocketVoiceTransport` 改为复用同一默认策略校验图片输入。

移除了 `drainAcknowledged` 生成空 `transcriptCompleted` 的路径；ACK 现在只推进 actor drain 状态，不再伪造 transcript fact。同步更新 voice presence 文档和相关 endpoint/module/proto/transport 测试。

Closes #2160

## Test results

- `bash -lc 'source "${CONSENSUS_RND_HOST_ENV}"; dotnet build aevatar.slnx --nologo'`: passed.
- `bash -lc 'source "${CONSENSUS_RND_HOST_ENV}"; dotnet test test/Aevatar.Foundation.VoicePresence.Tests/Aevatar.Foundation.VoicePresence.Tests.csproj --nologo'`: passed, 224 passed.
- `bash -lc 'source "${CONSENSUS_RND_HOST_ENV}"; dotnet test test/Aevatar.ChatRouting.Voice.Integration.Tests/Aevatar.ChatRouting.Voice.Integration.Tests.csproj --nologo'`: passed, 22 passed.
- `bash -lc 'source "${CONSENSUS_RND_HOST_ENV}"; bash tools/ci/test_stability_guards.sh'`: passed.
- Host `CI_GUARDS` unset, recorded as skipped.

## Deviations

- `refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)`.
- `HOST_PROTO_POLICY` empty; schema validation was covered by build and tests.
- Deferred generated frame descriptors, device-event vocabulary descriptor, and edge CI as required by the consensus artifact.

⟦AI:AUTO-LOOP⟧
