### PR TITLE
抽离 LLM run core 到 Application

### DIFF
--- a/src/platform/Aevatar.GAgentService.Abstractions/Responses/LlmRunCoreContracts.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Responses/LlmRunCoreContracts.cs
@@ -1,0 +1,43 @@
+using Aevatar.GAgentService.Abstractions;
+
+namespace Aevatar.GAgentService.Abstractions.Responses;
+
+public sealed record LlmRunCoreRequest(
+    LlmRunRequested Command,
+    string RunId,
+    string? OriginPlatform);
+
+public interface ILlmRunCore
+{
+    Task RunAsync(
+        LlmRunCoreRequest request,
+        ILlmRunSink sink,
+        CancellationToken ct = default);
+}
+
+public interface ILlmRunSink
+{
+    Task RecordStreamChunkObservedAsync(
+        LlmStreamChunkObserved observed,
+        CancellationToken ct = default);
+
+    Task RecordToolCallObservedAsync(
+        LlmToolCallObserved observed,
+        CancellationToken ct = default);
+
+    Task RecordForwardedToolCallEmittedAsync(
+        LlmSessionForwardedToolCallEmittedEvent emitted,
+        CancellationToken ct = default);
+
+    Task RecordRunCompletedAsync(
+        LlmRunCompleted completed,
+        CancellationToken ct = default);
+
+    Task RecordRunFailedAsync(
+        LlmRunFailed failed,
+        CancellationToken ct = default);
+
+    Task RecordRunCancelledAsync(
+        LlmRunCancelled cancelled,
+        CancellationToken ct = default);
+}

--- a/src/platform/Aevatar.GAgentService.Application/Responses/LlmRunCore.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/LlmRunCore.cs
@@ -1,0 +1,755 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Responses;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.GAgentService.Application.Responses;
+
+public sealed class LlmRunCore(
+    ILLMProviderFactory providerFactory,
+    IEnumerable<IResponsesToolProvider> toolProviders,
+    ILogger<LlmRunCore> logger) : ILlmRunCore
+{
+    private static readonly Duration DefaultTtl = Duration.FromTimeSpan(TimeSpan.FromHours(24));
+    private const int MaxToolRounds = 8;
+
+    public async Task RunAsync(
+        LlmRunCoreRequest request,
+        ILlmRunSink sink,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(sink);
+        ArgumentNullException.ThrowIfNull(request.Command);
+
+        try
+        {
+            await RunLlmLoopAsync(request, sink, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            await sink.RecordRunCancelledAsync(new LlmRunCancelled
+            {
+                ResponseId = request.Command.ResponseId,
+                RunId = request.RunId,
+                CancelledAt = Timestamp.FromDateTime(DateTime.UtcNow),
+            }, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            await sink.RecordRunFailedAsync(new LlmRunFailed
+            {
+                ResponseId = request.Command.ResponseId,
+                RunId = request.RunId,
+                FailureCode = MapFailureCode(ex),
+                FailureMessage = string.IsNullOrWhiteSpace(ex.Message) ? "LLM run failed." : ex.Message,
+                FailedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+            }, ct).ConfigureAwait(false);
+        }
+    }
+
+    private async Task RunLlmLoopAsync(
+        LlmRunCoreRequest request,
+        ILlmRunSink sink,
+        CancellationToken ct)
+    {
+        var command = request.Command;
+        var provider = providerFactory.GetDefault();
+        var toolContext = BuildToolContext(command);
+        var tools = await BuildEffectiveToolsAsync(command, toolContext, request.OriginPlatform, ct).ConfigureAwait(false);
+        var messages = command.Messages.Select(ToChatMessage).ToList();
+        var outputText = new System.Text.StringBuilder();
+        TokenUsage? usage = null;
+
+        for (var round = 0; round < MaxToolRounds; round++)
+        {
+            var roundRequest = new LLMRequest
+            {
+                Messages = [.. messages],
+                RequestId = command.ResponseId,
+                Metadata = toolContext.ExternalMetadata,
+                CallerContext = new LLMRequestCallerContext(
+                    toolContext.Caller.ScopeId ?? string.Empty,
+                    toolContext.Caller.OwnerSubject ?? string.Empty,
+                    toolContext.Caller.ResponseId,
+                    new LLMRequestCallerCredentials(toolContext.Credentials.NyxIdAccessToken)),
+                Tools = tools,
+                ToolContext = toolContext,
+                LlmControl = new LLMControlContext(
+                    NyxIdAccessToken: toolContext.Credentials.NyxIdAccessToken,
+                    NyxIdOrgToken: toolContext.Credentials.NyxIdOrgToken,
+                    SenderNyxIdAccessToken: toolContext.Credentials.SenderNyxIdAccessToken,
+                    ModelOverride: toolContext.Routing.ModelOverride,
+                    NyxIdRoutePreference: toolContext.Routing.NyxIdRoutePreference,
+                    MaxToolRoundsOverride: null,
+                    UserMemoryPrompt: toolContext.Routing.UserMemoryPrompt),
+                Model = NormalizeOptional(command.Model),
+                Temperature = command.HasTemperature ? command.Temperature : null,
+                MaxTokens = command.HasMaxTokens ? command.MaxTokens : null,
+            };
+
+            var toolCalls = new RuntimeToolCallAccumulator();
+            using (AgentToolContextScope.Push(toolContext))
+            {
+                await foreach (var chunk in provider.ChatStreamAsync(roundRequest, ct).ConfigureAwait(false))
+                {
+                    var delta = ExtractChunkText(chunk);
+                    if (!string.IsNullOrEmpty(delta))
+                        outputText.Append(delta);
+
+                    if (chunk.Usage is not null)
+                        usage = chunk.Usage;
+
+                    var observed = new LlmStreamChunkObserved
+                    {
+                        ResponseId = command.ResponseId,
+                        RunId = request.RunId,
+                        Round = round,
+                        DeltaText = delta ?? string.Empty,
+                        ToolCallDelta = chunk.DeltaToolCall is null ? null : ToRuntimeToolCall(chunk.DeltaToolCall),
+                        Usage = chunk.Usage is null ? null : ToSessionUsage(chunk.Usage),
+                        ObservedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+                    };
+                    await sink.RecordStreamChunkObservedAsync(observed, ct).ConfigureAwait(false);
+
+                    if (chunk.DeltaToolCall != null)
+                        toolCalls.TrackDelta(chunk.DeltaToolCall);
+
+                    if (chunk.IsLast)
+                        break;
+                }
+            }
+
+            var builtToolCalls = ApplyToolChoiceHint(toolCalls.BuildToolCalls(), command.ToolSelection);
+            var forwardedToolCalls = SelectForwardedToolCalls(builtToolCalls, command.ToolSelection);
+            foreach (var toolCall in forwardedToolCalls)
+            {
+                await sink.RecordToolCallObservedAsync(new LlmToolCallObserved
+                {
+                    ResponseId = command.ResponseId,
+                    RunId = request.RunId,
+                    Round = round,
+                    ToolCall = ToRuntimeToolCall(toolCall),
+                    Forwarded = true,
+                    ObservedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+                }, ct).ConfigureAwait(false);
+                await sink.RecordForwardedToolCallEmittedAsync(new LlmSessionForwardedToolCallEmittedEvent
+                {
+                    ResponseId = command.ResponseId,
+                    Call = BuildForwardedToolCall(toolCall, command.ToolSelection),
+                }, ct).ConfigureAwait(false);
+            }
+
+            if (forwardedToolCalls.Count > 0)
+            {
+                await sink.RecordRunCompletedAsync(new LlmRunCompleted
+                {
+                    ResponseId = command.ResponseId,
+                    RunId = request.RunId,
+                    OutputText = outputText.ToString(),
+                    ForwardedToolCalls = { forwardedToolCalls.Select(ToRuntimeToolCall) },
+                    Usage = usage is null ? null : ToSessionUsage(usage),
+                    CompletedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+                }, ct).ConfigureAwait(false);
+                return;
+            }
+
+            var localToolCalls = SelectLocalToolCalls(builtToolCalls, command.ToolSelection, tools);
+            if (localToolCalls.Count == 0)
+            {
+                await sink.RecordRunCompletedAsync(new LlmRunCompleted
+                {
+                    ResponseId = command.ResponseId,
+                    RunId = request.RunId,
+                    OutputText = outputText.ToString(),
+                    Usage = usage is null ? null : ToSessionUsage(usage),
+                    CompletedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+                }, ct).ConfigureAwait(false);
+                return;
+            }
+
+            messages.Add(new ChatMessage
+            {
+                Role = "assistant",
+                ToolCalls = localToolCalls,
+            });
+            await ExecuteLocalToolCallsAsync(command, request.RunId, round, localToolCalls, tools, messages, toolContext, sink, ct)
+                .ConfigureAwait(false);
+        }
+
+        await sink.RecordRunCompletedAsync(new LlmRunCompleted
+        {
+            ResponseId = command.ResponseId,
+            RunId = request.RunId,
+            OutputText = outputText.ToString(),
+            Usage = usage is null ? null : ToSessionUsage(usage),
+            CompletedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+        }, ct).ConfigureAwait(false);
+    }
+
+    private async Task<IReadOnlyList<IAgentTool>> BuildEffectiveToolsAsync(
+        LlmRunRequested command,
+        AgentToolExecutionContext toolContext,
+        string? originPlatform,
+        CancellationToken ct)
+    {
+        var context = new ResponsesToolProviderContext(
+            toolContext with
+            {
+                Channel = toolContext.Channel with
+                {
+                    Platform = originPlatform,
+                },
+            });
+
+        var substituteTools = new List<IAgentTool>();
+        var additiveTools = new List<IAgentTool>();
+        foreach (var provider in toolProviders)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                substituteTools.AddRange(await provider.GetSubstituteToolsAsync(context, ct).ConfigureAwait(false));
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(
+                    ex,
+                    "Responses substitute tool discovery failed for provider {ProviderType}; continuing without that provider.",
+                    provider.GetType().Name);
+            }
+
+            try
+            {
+                additiveTools.AddRange(await provider.GetAdditiveToolsAsync(context, ct).ConfigureAwait(false));
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(
+                    ex,
+                    "Responses additive tool discovery failed for provider {ProviderType}; continuing without that provider.",
+                    provider.GetType().Name);
+            }
+        }
+
+        var substitutedNames = (command.ToolSelection?.SubstitutedToolNames ?? [])
+            .ToHashSet(StringComparer.Ordinal);
+        var additiveNames = (command.ToolSelection?.AdditiveToolNames ?? [])
+            .ToHashSet(StringComparer.Ordinal);
+        var substitutesByName = substituteTools
+            .GroupBy(static tool => tool.Name, StringComparer.Ordinal)
+            .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.Ordinal);
+        var effective = new List<IAgentTool>();
+        foreach (var declaration in command.ToolSelection?.ForwardedTools ?? [])
+        {
+            if (substitutedNames.Contains(declaration.ToolName) &&
+                substitutesByName.TryGetValue(declaration.ToolName, out var substitute))
+                effective.Add(substitute);
+            else
+                effective.Add(new ForwardedRuntimeTool(declaration));
+        }
+
+        var effectiveNames = new HashSet<string>(effective.Select(static tool => tool.Name), StringComparer.Ordinal);
+        foreach (var substitutedName in substitutedNames)
+        {
+            if (effectiveNames.Contains(substitutedName))
+                continue;
+            if (substitutesByName.TryGetValue(substitutedName, out var substitute) &&
+                effectiveNames.Add(substitute.Name))
+            {
+                effective.Add(substitute);
+            }
+        }
+
+        foreach (var additive in additiveTools)
+        {
+            if (additiveNames.Contains(additive.Name) && effectiveNames.Add(additive.Name))
+                effective.Add(additive);
+        }
+
+        return effective;
+    }
+
+    private static async Task ExecuteLocalToolCallsAsync(
+        LlmRunRequested command,
+        string runId,
+        int round,
+        IReadOnlyList<ToolCall> localToolCalls,
+        IReadOnlyList<IAgentTool> tools,
+        List<ChatMessage> messages,
+        AgentToolExecutionContext toolContext,
+        ILlmRunSink sink,
+        CancellationToken ct)
+    {
+        var toolsByName = tools
+            .Where(static tool => tool is not ForwardedRuntimeTool)
+            .GroupBy(static tool => tool.Name, StringComparer.Ordinal)
+            .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.Ordinal);
+
+        using (AgentToolContextScope.Push(toolContext))
+        {
+            foreach (var toolCall in localToolCalls)
+            {
+                using var _ = AgentToolContextScope.Push(toolContext.WithCallId(toolCall.Id));
+                var argumentsJson = string.IsNullOrWhiteSpace(toolCall.ArgumentsJson)
+                    ? "{}"
+                    : toolCall.ArgumentsJson;
+                var result = toolsByName.TryGetValue(toolCall.Name, out var tool)
+                    ? await ResponsesSafeToolExecutor.ExecuteAsync(tool, argumentsJson, ct).ConfigureAwait(false)
+                    : JsonSerializer.Serialize(new
+                    {
+                        error = "aevatar_substitute_tool_not_registered",
+                        tool_name = toolCall.Name,
+                    });
+
+                await sink.RecordToolCallObservedAsync(new LlmToolCallObserved
+                {
+                    ResponseId = command.ResponseId,
+                    RunId = runId,
+                    Round = round,
+                    ToolCall = ToRuntimeToolCall(toolCall),
+                    Forwarded = false,
+                    LocalResultJson = result,
+                    LocalResult = ResponsesJsonValues.ParseBoundaryPayload(result),
+                    ObservedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+                }, ct).ConfigureAwait(false);
+                messages.Add(ChatMessage.Tool(toolCall.Id, result));
+            }
+        }
+    }
+
+    private static AgentToolExecutionContext BuildToolContext(LlmRunRequested command)
+    {
+        if (command.ToolContext is not null)
+            return AgentToolExecutionContextMapper.FromPayload(command.ToolContext);
+
+        return new(
+            new AgentToolRequestIdentity(command.ResponseId, null),
+            new AgentToolCredentials(command.BearerToken, null, null),
+            new AgentToolCallerContext(command.ScopeId, command.OwnerSubject, command.ResponseId),
+            AgentToolChannelContext.Empty,
+            AgentToolSenderBindingContext.Empty,
+            new LLMRequestRoutingContext(null, NormalizeOptional(command.RoutePreference), null, null),
+            AgentToolConnectedServicesContext.Empty,
+            AgentSkillRecoveryContext.Empty,
+            new Dictionary<string, string>(StringComparer.Ordinal));
+    }
+
+    private static ChatMessage ToChatMessage(LlmSessionRuntimeChatMessage message) =>
+        new()
+        {
+            Role = string.IsNullOrWhiteSpace(message.Role) ? "user" : message.Role,
+            Content = message.Content,
+            ReasoningContent = NormalizeOptional(message.ReasoningContent),
+            ToolCallId = NormalizeOptional(message.ToolCallId),
+            ToolCalls = message.ToolCalls.Count == 0
+                ? null
+                : message.ToolCalls.Select(ToToolCall).ToArray(),
+        };
+
+    private static ToolCall ToToolCall(LlmSessionRuntimeToolCall call) =>
+        new()
+        {
+            Id = call.CallId,
+            Name = call.ToolName,
+            ArgumentsJson = RuntimeToolArgumentsJson(call),
+        };
+
+    private static LlmSessionRuntimeToolCall ToRuntimeToolCall(ToolCall call) =>
+        new()
+        {
+            CallId = call.Id,
+            ToolName = call.Name,
+            ArgumentsJson = call.ArgumentsJson,
+            Arguments = ParseStruct(call.ArgumentsJson),
+        };
+
+    private static LlmSessionTokenUsage ToSessionUsage(TokenUsage usage) =>
+        new()
+        {
+            PromptTokens = usage.PromptTokens,
+            CompletionTokens = usage.CompletionTokens,
+            TotalTokens = usage.TotalTokens,
+        };
+
+    private static string? ExtractChunkText(LLMStreamChunk chunk)
+    {
+        if (!string.IsNullOrWhiteSpace(chunk.DeltaContent))
+            return chunk.DeltaContent;
+        if (chunk.DeltaContentPart is { Kind: ContentPartKind.Text } part && !string.IsNullOrWhiteSpace(part.Text))
+            return part.Text;
+        return null;
+    }
+
+    private static IReadOnlyList<ToolCall> SelectForwardedToolCalls(
+        IReadOnlyList<ToolCall> toolCalls,
+        LlmSessionRuntimeToolSelection? selection)
+    {
+        if (selection is null || toolCalls.Count == 0 || selection.ForwardedTools.Count == 0)
+            return [];
+
+        var forwardedToolNames = selection.ForwardedTools
+            .Select(static tool => tool.ToolName)
+            .Except(selection.SubstitutedToolNames, StringComparer.Ordinal)
+            .ToHashSet(StringComparer.Ordinal);
+        return toolCalls
+            .Where(call => forwardedToolNames.Contains(call.Name))
+            .ToArray();
+    }
+
+    private static IReadOnlyList<ToolCall> ApplyToolChoiceHint(
+        IReadOnlyList<ToolCall> toolCalls,
+        LlmSessionRuntimeToolSelection? selection)
+    {
+        if (toolCalls.Count == 0 ||
+            selection is null ||
+            string.IsNullOrWhiteSpace(selection.ToolChoiceHintName))
+        {
+            return toolCalls;
+        }
+
+        return toolCalls
+            .Select(call => ApplyToolChoiceHint(call, selection))
+            .ToArray();
+    }
+
+    private static ToolCall ApplyToolChoiceHint(
+        ToolCall call,
+        LlmSessionRuntimeToolSelection selection)
+    {
+        var toolName = selection.ToolChoiceHintName.Trim();
+        if (!string.Equals(call.Name, toolName, StringComparison.Ordinal))
+        {
+            return CloneWithArguments(
+                call,
+                BuildStructuredToolChoiceError(
+                    "tool_choice_hint_mismatch",
+                    $"Tool choice hint requires '{toolName}', but the model called '{call.Name}'.",
+                    "tool_name"));
+        }
+
+        JsonObject prefilled;
+        try
+        {
+            prefilled = ParseJsonObject(ToolChoiceHintArgumentsJson(selection));
+        }
+        catch (JsonException ex)
+        {
+            return CloneWithArguments(
+                call,
+                BuildStructuredToolChoiceError(
+                    "invalid_tool_choice_prefill",
+                    $"Tool choice prefilled arguments must be a JSON object: {ex.Message}",
+                    "tool_choice_hint_arguments_json"));
+        }
+
+        JsonObject modelArguments;
+        try
+        {
+            modelArguments = ParseJsonObject(call.ArgumentsJson);
+        }
+        catch (JsonException ex)
+        {
+            return CloneWithArguments(
+                call,
+                BuildStructuredToolChoiceError(
+                    "invalid_tool_arguments",
+                    $"Arguments must be a JSON object: {ex.Message}",
+                    "arguments"));
+        }
+
+        var merged = new JsonObject();
+        foreach (var (key, value) in prefilled)
+            merged[key] = value?.DeepClone();
+
+        foreach (var (key, value) in modelArguments)
+        {
+            if (prefilled.TryGetPropertyValue(key, out var prefilledValue) &&
+                !JsonNode.DeepEquals(prefilledValue, value))
+            {
+                return CloneWithArguments(
+                    call,
+                    BuildStructuredToolChoiceError(
+                        "tool_choice_prefill_conflict",
+                        $"Tool argument '{key}' conflicts with server-trusted prefilled_arguments.",
+                        key));
+            }
+
+            if (!prefilled.ContainsKey(key))
+                merged[key] = value?.DeepClone();
+        }
+
+        return CloneWithArguments(
+            call,
+            merged.ToJsonString(new JsonSerializerOptions { WriteIndented = false }));
+    }
+
+    private static JsonObject ParseJsonObject(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return new JsonObject();
+
+        return JsonNode.Parse(json) as JsonObject
+               ?? throw new JsonException("Root value must be an object.");
+    }
+
+    private static Struct ParseStruct(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return new Struct();
+
+        try
+        {
+            return JsonParser.Default.Parse<Struct>(json);
+        }
+        catch
+        {
+            return new Struct();
+        }
+    }
+
+    private static string RuntimeToolArgumentsJson(LlmSessionRuntimeToolCall call)
+    {
+        if (call.Arguments is { Fields.Count: > 0 })
+            return JsonFormatter.Default.Format(call.Arguments);
+        return string.IsNullOrWhiteSpace(call.ArgumentsJson) ? "{}" : call.ArgumentsJson;
+    }
+
+    private static Value ToolCallArgumentsValue(ToolCall call)
+    {
+        var arguments = ParseStruct(call.ArgumentsJson);
+        if (arguments.Fields.Count > 0)
+            return Value.ForStruct(arguments);
+        return ResponsesJsonValues.ParseBoundaryPayload(
+            string.IsNullOrWhiteSpace(call.ArgumentsJson) ? "{}" : call.ArgumentsJson);
+    }
+
+    private static string ToolChoiceHintArgumentsJson(LlmSessionRuntimeToolSelection selection)
+    {
+        if (selection.ToolChoiceHintArguments is { Fields.Count: > 0 })
+            return JsonFormatter.Default.Format(selection.ToolChoiceHintArguments);
+        return selection.ToolChoiceHintArgumentsJson;
+    }
+
+    private static string ToolDeclarationParametersJson(LlmSessionRuntimeToolDeclaration declaration)
+    {
+        if (declaration.Parameters is { Fields.Count: > 0 })
+            return JsonFormatter.Default.Format(declaration.Parameters);
+        return declaration.ParametersJson;
+    }
+
+    private static ToolCall CloneWithArguments(ToolCall call, string argumentsJson) =>
+        new()
+        {
+            Id = call.Id,
+            Name = call.Name,
+            ArgumentsJson = argumentsJson,
+        };
+
+    private static string BuildStructuredToolChoiceError(
+        string code,
+        string message,
+        string field) =>
+        JsonSerializer.Serialize(new
+        {
+            error = new
+            {
+                code,
+                message,
+                field,
+            },
+        });
+
+    private static IReadOnlyList<ToolCall> SelectLocalToolCalls(
+        IReadOnlyList<ToolCall> toolCalls,
+        LlmSessionRuntimeToolSelection? selection,
+        IReadOnlyList<IAgentTool> tools)
+    {
+        if (toolCalls.Count == 0 || tools.Count == 0)
+            return [];
+
+        var forwardedNames = (selection?.ForwardedTools ?? [])
+            .Select(static tool => tool.ToolName)
+            .Except(selection?.SubstitutedToolNames ?? [], StringComparer.Ordinal)
+            .ToHashSet(StringComparer.Ordinal);
+        var localNames = tools
+            .Where(static tool => tool is not ForwardedRuntimeTool)
+            .Select(static tool => tool.Name)
+            .Where(name => !forwardedNames.Contains(name))
+            .ToHashSet(StringComparer.Ordinal);
+        return toolCalls
+            .Where(call => localNames.Contains(call.Name))
+            .ToArray();
+    }
+
+    private static LlmSessionForwardedToolCall BuildForwardedToolCall(
+        ToolCall toolCall,
+        LlmSessionRuntimeToolSelection? selection)
+    {
+        var declaration = selection?.ForwardedTools
+            .FirstOrDefault(tool => string.Equals(tool.ToolName, toolCall.Name, StringComparison.Ordinal));
+        return new LlmSessionForwardedToolCall
+        {
+            CallId = toolCall.Id,
+            ToolName = toolCall.Name,
+            SchemaHash = declaration?.SchemaHash ?? string.Empty,
+            Arguments = ToolCallArgumentsValue(toolCall),
+            Status = LlmSessionForwardedToolCallStatus.Pending,
+            EmittedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+            Expiry = Timestamp.FromDateTime(DateTime.UtcNow.Add(DefaultTtl.ToTimeSpan())),
+        };
+    }
+
+    private static string MapFailureCode(Exception ex) =>
+        ex switch
+        {
+            NyxIdAuthenticationRequiredException => "authentication_required",
+            NyxIdUpstreamException upstream => upstream.Kind.ToString().ToLowerInvariant(),
+            _ => "execution_failed",
+        };
+
+    private static string? NormalizeOptional(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private sealed class ForwardedRuntimeTool : IAgentTool
+    {
+        public ForwardedRuntimeTool(LlmSessionRuntimeToolDeclaration declaration)
+        {
+            ArgumentNullException.ThrowIfNull(declaration);
+            Name = declaration.ToolName;
+            Description = declaration.Description;
+            ParametersSchema = ToolDeclarationParametersJson(declaration);
+        }
+
+        public string Name { get; }
+
+        public string Description { get; }
+
+        public string ParametersSchema { get; }
+
+        public bool IsReadOnly => true;
+
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
+            throw new InvalidOperationException(
+                $"Forwarded Responses tool '{Name}' must be executed by the client, not by Aevatar.");
+    }
+
+    private sealed class RuntimeToolCallAccumulator
+    {
+        private readonly Dictionary<string, ToolCallAggregate> _aggregates = new(StringComparer.Ordinal);
+        private readonly List<string> _order = [];
+        private int _anonymousCounter;
+        private string? _activeAnonymousKey;
+
+        public void TrackDelta(ToolCall delta)
+        {
+            ArgumentNullException.ThrowIfNull(delta);
+            var aggregate = ResolveAggregate(delta);
+            if (!string.IsNullOrWhiteSpace(delta.Name))
+                aggregate.Name = delta.Name;
+            if (!string.IsNullOrEmpty(delta.ArgumentsJson))
+                aggregate.Arguments.Append(delta.ArgumentsJson);
+        }
+
+        public IReadOnlyList<ToolCall> BuildToolCalls()
+        {
+            var result = new List<ToolCall>(_order.Count);
+            foreach (var key in _order)
+            {
+                var aggregate = _aggregates[key];
+                result.Add(new ToolCall
+                {
+                    Id = aggregate.Id,
+                    Name = aggregate.Name ?? string.Empty,
+                    ArgumentsJson = aggregate.Arguments.ToString(),
+                });
+            }
+
+            return result;
+        }
+
+        private ToolCallAggregate ResolveAggregate(ToolCall delta)
+        {
+            if (!string.IsNullOrWhiteSpace(delta.Id))
+                return ResolveKnownIdAggregate(delta.Id);
+
+            return ResolveAnonymousAggregate();
+        }
+
+        private ToolCallAggregate ResolveKnownIdAggregate(string id)
+        {
+            var knownKey = $"id:{id}";
+            if (TryPromoteActiveAnonymousAggregate(knownKey, id, out var promoted))
+            {
+                _activeAnonymousKey = null;
+                return promoted;
+            }
+
+            _activeAnonymousKey = null;
+            if (!_aggregates.TryGetValue(knownKey, out var aggregate))
+            {
+                aggregate = new ToolCallAggregate(id);
+                _aggregates[knownKey] = aggregate;
+                _order.Add(knownKey);
+            }
+
+            return aggregate;
+        }
+
+        private ToolCallAggregate ResolveAnonymousAggregate()
+        {
+            if (!string.IsNullOrWhiteSpace(_activeAnonymousKey))
+                return _aggregates[_activeAnonymousKey];
+
+            _anonymousCounter++;
+            var anonymousKey = $"anon:{_anonymousCounter}";
+            var aggregate = new ToolCallAggregate($"stream-tool-call-{_anonymousCounter}");
+            _aggregates[anonymousKey] = aggregate;
+            _order.Add(anonymousKey);
+            _activeAnonymousKey = anonymousKey;
+            return aggregate;
+        }
+
+        private bool TryPromoteActiveAnonymousAggregate(
+            string knownKey,
+            string knownId,
+            out ToolCallAggregate aggregate)
+        {
+            aggregate = default!;
+            if (string.IsNullOrWhiteSpace(_activeAnonymousKey))
+                return false;
+            var anonymousAggregate = _aggregates[_activeAnonymousKey];
+            if (_aggregates.ContainsKey(knownKey))
+                return false;
+            anonymousAggregate.Id = knownId;
+            _aggregates.Remove(_activeAnonymousKey);
+            _aggregates[knownKey] = anonymousAggregate;
+            _order[_order.IndexOf(_activeAnonymousKey)] = knownKey;
+            aggregate = anonymousAggregate;
+            return true;
+        }
+
+        private sealed class ToolCallAggregate(string id)
+        {
+            public string Id { get; set; } = id;
+
+            public string? Name { get; set; }
+
+            public System.Text.StringBuilder Arguments { get; } = new();
+        }
+    }
+}

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesSafeToolExecutor.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesSafeToolExecutor.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using Aevatar.AI.Abstractions.ToolProviders;
 
-namespace Aevatar.GAgentService.Core.GAgents;
+namespace Aevatar.GAgentService.Application.Responses;
 
 internal static class ResponsesSafeToolExecutor
 {

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
@@ -2,16 +2,12 @@ using Aevatar.Foundation.Abstractions.Attributes;
 using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
-using Aevatar.AI.Abstractions.LLMProviders;
-using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Responses;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using System.Text.Json;
-using System.Text.Json.Nodes;
 
 namespace Aevatar.GAgentService.Core.GAgents;
 
@@ -27,7 +23,6 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
     private const int CompletedStatus = 2;
     private const int FailedStatus = 3;
     private const int CancelledStatus = 4;
-    private const int MaxToolRounds = 8;
 
     public LlmSessionGAgent()
     {
@@ -277,9 +272,6 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
         });
     }
 
-    // Refactor (iter103/cluster-1):
-    //   Old pattern: Application facade ran LLM stream loop, tool execution, and accumulation locally.
-    //   New principle: Application dispatches LlmRunRequested; LlmSessionGAgent owns run progression through typed events.
     [EventHandler]
     public async Task HandleLlmRunRequestedAsync(LlmRunRequested command)
     {
@@ -311,30 +303,11 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
             ObservedAt = startedAt,
         });
 
-        try
-        {
-            await RunLlmLoopAsync(command, runId, CancellationToken.None);
-        }
-        catch (OperationCanceledException)
-        {
-            await PersistDomainEventAsync(new LlmRunCancelled
-            {
-                ResponseId = existing.ResponseId,
-                RunId = runId,
-                CancelledAt = Timestamp.FromDateTime(DateTime.UtcNow),
-            });
-        }
-        catch (Exception ex)
-        {
-            await PersistDomainEventAsync(new LlmRunFailed
-            {
-                ResponseId = existing.ResponseId,
-                RunId = runId,
-                FailureCode = MapFailureCode(ex),
-                FailureMessage = string.IsNullOrWhiteSpace(ex.Message) ? "LLM run failed." : ex.Message,
-                FailedAt = Timestamp.FromDateTime(DateTime.UtcNow),
-            });
-        }
+        var runCore = Services.GetRequiredService<ILlmRunCore>();
+        await runCore.RunAsync(
+            new LlmRunCoreRequest(command, runId, existing.OriginKind.ToString()),
+            new InActorLlmRunSink(this),
+            CancellationToken.None);
     }
 
     protected override LlmSessionState TransitionState(LlmSessionState current, IMessage evt) =>
@@ -579,485 +552,6 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
         return next;
     }
 
-    private async Task RunLlmLoopAsync(
-        LlmRunRequested command,
-        string runId,
-        CancellationToken ct)
-    {
-        var provider = Services.GetRequiredService<ILLMProviderFactory>().GetDefault();
-        var toolContext = BuildToolContext(command);
-        var tools = await BuildEffectiveToolsAsync(command, toolContext, ct);
-        var messages = command.Messages.Select(ToChatMessage).ToList();
-        var outputText = new System.Text.StringBuilder();
-        TokenUsage? usage = null;
-
-        for (var round = 0; round < MaxToolRounds; round++)
-        {
-            var roundRequest = new LLMRequest
-            {
-                Messages = [.. messages],
-                RequestId = command.ResponseId,
-                Metadata = toolContext.ExternalMetadata,
-                CallerContext = new LLMRequestCallerContext(
-                    toolContext.Caller.ScopeId ?? string.Empty,
-                    toolContext.Caller.OwnerSubject ?? string.Empty,
-                    toolContext.Caller.ResponseId,
-                    new LLMRequestCallerCredentials(toolContext.Credentials.NyxIdAccessToken)),
-                Tools = tools,
-                ToolContext = toolContext,
-                LlmControl = new LLMControlContext(
-                    NyxIdAccessToken: toolContext.Credentials.NyxIdAccessToken,
-                    NyxIdOrgToken: toolContext.Credentials.NyxIdOrgToken,
-                    SenderNyxIdAccessToken: toolContext.Credentials.SenderNyxIdAccessToken,
-                    ModelOverride: toolContext.Routing.ModelOverride,
-                    NyxIdRoutePreference: toolContext.Routing.NyxIdRoutePreference,
-                    MaxToolRoundsOverride: null,
-                    UserMemoryPrompt: toolContext.Routing.UserMemoryPrompt),
-                Model = NormalizeOptional(command.Model),
-                Temperature = command.HasTemperature ? command.Temperature : null,
-                MaxTokens = command.HasMaxTokens ? command.MaxTokens : null,
-            };
-
-            var toolCalls = new RuntimeToolCallAccumulator();
-            using (AgentToolContextScope.Push(toolContext))
-            {
-                await foreach (var chunk in provider.ChatStreamAsync(roundRequest, ct))
-                {
-                    var delta = ExtractChunkText(chunk);
-                    if (!string.IsNullOrEmpty(delta))
-                        outputText.Append(delta);
-
-                    if (chunk.Usage is not null)
-                        usage = chunk.Usage;
-
-                    var observed = new LlmStreamChunkObserved
-                    {
-                        ResponseId = command.ResponseId,
-                        RunId = runId,
-                        Round = round,
-                        DeltaText = delta ?? string.Empty,
-                        ToolCallDelta = chunk.DeltaToolCall is null ? null : ToRuntimeToolCall(chunk.DeltaToolCall),
-                        Usage = chunk.Usage is null ? null : ToSessionUsage(chunk.Usage),
-                        ObservedAt = Timestamp.FromDateTime(DateTime.UtcNow),
-                    };
-                    await PersistDomainEventAsync(observed);
-
-                    if (chunk.DeltaToolCall != null)
-                        toolCalls.TrackDelta(chunk.DeltaToolCall);
-
-                    if (chunk.IsLast)
-                        break;
-                }
-            }
-
-            var builtToolCalls = ApplyToolChoiceHint(toolCalls.BuildToolCalls(), command.ToolSelection);
-            var forwardedToolCalls = SelectForwardedToolCalls(builtToolCalls, command.ToolSelection);
-            foreach (var toolCall in forwardedToolCalls)
-            {
-                await PersistDomainEventAsync(new LlmToolCallObserved
-                {
-                    ResponseId = command.ResponseId,
-                    RunId = runId,
-                    Round = round,
-                    ToolCall = ToRuntimeToolCall(toolCall),
-                    Forwarded = true,
-                    ObservedAt = Timestamp.FromDateTime(DateTime.UtcNow),
-                });
-                await PersistDomainEventAsync(new LlmSessionForwardedToolCallEmittedEvent
-                {
-                    ResponseId = command.ResponseId,
-                    Call = BuildForwardedToolCall(toolCall, command.ToolSelection),
-                });
-            }
-
-            if (forwardedToolCalls.Count > 0)
-            {
-                await PersistDomainEventAsync(new LlmRunCompleted
-                {
-                    ResponseId = command.ResponseId,
-                    RunId = runId,
-                    OutputText = outputText.ToString(),
-                    ForwardedToolCalls = { forwardedToolCalls.Select(ToRuntimeToolCall) },
-                    Usage = usage is null ? null : ToSessionUsage(usage),
-                    CompletedAt = Timestamp.FromDateTime(DateTime.UtcNow),
-                });
-                return;
-            }
-
-            var localToolCalls = SelectLocalToolCalls(builtToolCalls, command.ToolSelection, tools);
-            if (localToolCalls.Count == 0)
-            {
-                await PersistDomainEventAsync(new LlmRunCompleted
-                {
-                    ResponseId = command.ResponseId,
-                    RunId = runId,
-                    OutputText = outputText.ToString(),
-                    Usage = usage is null ? null : ToSessionUsage(usage),
-                    CompletedAt = Timestamp.FromDateTime(DateTime.UtcNow),
-                });
-                return;
-            }
-
-            messages.Add(new ChatMessage
-            {
-                Role = "assistant",
-                ToolCalls = localToolCalls,
-            });
-            await ExecuteLocalToolCallsAsync(command, runId, round, localToolCalls, tools, messages, toolContext, ct);
-        }
-
-        await PersistDomainEventAsync(new LlmRunCompleted
-        {
-            ResponseId = command.ResponseId,
-            RunId = runId,
-            OutputText = outputText.ToString(),
-            Usage = usage is null ? null : ToSessionUsage(usage),
-            CompletedAt = Timestamp.FromDateTime(DateTime.UtcNow),
-        });
-    }
-
-    private async Task<IReadOnlyList<IAgentTool>> BuildEffectiveToolsAsync(
-        LlmRunRequested command,
-        AgentToolExecutionContext toolContext,
-        CancellationToken ct)
-    {
-        var providers = Services.GetServices<IResponsesToolProvider>().ToArray();
-        var context = new ResponsesToolProviderContext(
-            toolContext with
-            {
-                Channel = toolContext.Channel with
-                {
-                    Platform = State.Record?.OriginKind.ToString(),
-                },
-            });
-
-        var substituteTools = new List<IAgentTool>();
-        var additiveTools = new List<IAgentTool>();
-        foreach (var provider in providers)
-        {
-            ct.ThrowIfCancellationRequested();
-            try
-            {
-                substituteTools.AddRange(await provider.GetSubstituteToolsAsync(context, ct).ConfigureAwait(false));
-            }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                Logger.LogWarning(
-                    ex,
-                    "Responses substitute tool discovery failed for provider {ProviderType}; continuing without that provider.",
-                    provider.GetType().Name);
-            }
-
-            try
-            {
-                additiveTools.AddRange(await provider.GetAdditiveToolsAsync(context, ct).ConfigureAwait(false));
-            }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                Logger.LogWarning(
-                    ex,
-                    "Responses additive tool discovery failed for provider {ProviderType}; continuing without that provider.",
-                    provider.GetType().Name);
-            }
-        }
-
-        var substitutedNames = (command.ToolSelection?.SubstitutedToolNames ?? [])
-            .ToHashSet(StringComparer.Ordinal);
-        var additiveNames = (command.ToolSelection?.AdditiveToolNames ?? [])
-            .ToHashSet(StringComparer.Ordinal);
-        var substitutesByName = substituteTools
-            .GroupBy(static tool => tool.Name, StringComparer.Ordinal)
-            .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.Ordinal);
-        var effective = new List<IAgentTool>();
-        foreach (var declaration in command.ToolSelection?.ForwardedTools ?? [])
-        {
-            if (substitutedNames.Contains(declaration.ToolName) &&
-                substitutesByName.TryGetValue(declaration.ToolName, out var substitute))
-                effective.Add(substitute);
-            else
-                effective.Add(new ForwardedRuntimeTool(declaration));
-        }
-
-        var effectiveNames = new HashSet<string>(effective.Select(static tool => tool.Name), StringComparer.Ordinal);
-        foreach (var substitutedName in substitutedNames)
-        {
-            if (effectiveNames.Contains(substitutedName))
-                continue;
-            if (substitutesByName.TryGetValue(substitutedName, out var substitute) &&
-                effectiveNames.Add(substitute.Name))
-            {
-                effective.Add(substitute);
-            }
-        }
-
-        foreach (var additive in additiveTools)
-        {
-            if (additiveNames.Contains(additive.Name) && effectiveNames.Add(additive.Name))
-                effective.Add(additive);
-        }
-
-        return effective;
-    }
-
-    private async Task ExecuteLocalToolCallsAsync(
-        LlmRunRequested command,
-        string runId,
-        int round,
-        IReadOnlyList<ToolCall> localToolCalls,
-        IReadOnlyList<IAgentTool> tools,
-        List<ChatMessage> messages,
-        AgentToolExecutionContext toolContext,
-        CancellationToken ct)
-    {
-        var toolsByName = tools
-            .Where(static tool => tool is not ForwardedRuntimeTool)
-            .GroupBy(static tool => tool.Name, StringComparer.Ordinal)
-            .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.Ordinal);
-
-        using (AgentToolContextScope.Push(toolContext))
-        {
-            foreach (var toolCall in localToolCalls)
-            {
-                using var _ = AgentToolContextScope.Push(toolContext.WithCallId(toolCall.Id));
-                var argumentsJson = string.IsNullOrWhiteSpace(toolCall.ArgumentsJson)
-                    ? "{}"
-                    : toolCall.ArgumentsJson;
-                var result = toolsByName.TryGetValue(toolCall.Name, out var tool)
-                    ? await ResponsesSafeToolExecutor.ExecuteAsync(
-                        tool,
-                        argumentsJson,
-                        ct)
-                    : System.Text.Json.JsonSerializer.Serialize(new
-                    {
-                        error = "aevatar_substitute_tool_not_registered",
-                        tool_name = toolCall.Name,
-                    });
-
-                await PersistDomainEventAsync(new LlmToolCallObserved
-                {
-                    ResponseId = command.ResponseId,
-                    RunId = runId,
-                    Round = round,
-                    ToolCall = ToRuntimeToolCall(toolCall),
-                    Forwarded = false,
-                    LocalResultJson = result,
-                    LocalResult = ResponsesJsonValues.ParseBoundaryPayload(result),
-                    ObservedAt = Timestamp.FromDateTime(DateTime.UtcNow),
-                });
-                messages.Add(ChatMessage.Tool(toolCall.Id, result));
-            }
-        }
-    }
-
-    // Refactor (issue1521):
-    //   Old pattern: LlmRunRequested split tool control authority into scalars and provider metadata.
-    //   New principle: the command carries the existing typed AgentToolExecutionContextPayload; scalars remain legacy fallback only.
-    private static AgentToolExecutionContext BuildToolContext(LlmRunRequested command)
-    {
-        if (command.ToolContext is not null)
-            return AgentToolExecutionContextMapper.FromPayload(command.ToolContext);
-
-        return new(
-            new AgentToolRequestIdentity(command.ResponseId, null),
-            new AgentToolCredentials(command.BearerToken, null, null),
-            new AgentToolCallerContext(command.ScopeId, command.OwnerSubject, command.ResponseId),
-            AgentToolChannelContext.Empty,
-            AgentToolSenderBindingContext.Empty,
-            new LLMRequestRoutingContext(null, NormalizeOptional(command.RoutePreference), null, null),
-            AgentToolConnectedServicesContext.Empty,
-            AgentSkillRecoveryContext.Empty,
-            new Dictionary<string, string>(StringComparer.Ordinal));
-    }
-
-    private static ChatMessage ToChatMessage(LlmSessionRuntimeChatMessage message) =>
-        new()
-        {
-            Role = string.IsNullOrWhiteSpace(message.Role) ? "user" : message.Role,
-            Content = message.Content,
-            ReasoningContent = NormalizeOptional(message.ReasoningContent),
-            ToolCallId = NormalizeOptional(message.ToolCallId),
-            ToolCalls = message.ToolCalls.Count == 0
-                ? null
-                : message.ToolCalls.Select(ToToolCall).ToArray(),
-        };
-
-    private static ToolCall ToToolCall(LlmSessionRuntimeToolCall call) =>
-        new()
-        {
-            Id = call.CallId,
-            Name = call.ToolName,
-            ArgumentsJson = RuntimeToolArgumentsJson(call),
-        };
-
-    private static LlmSessionRuntimeToolCall ToRuntimeToolCall(ToolCall call) =>
-        new()
-        {
-            CallId = call.Id,
-            ToolName = call.Name,
-            ArgumentsJson = call.ArgumentsJson,
-            Arguments = ParseStruct(call.ArgumentsJson),
-        };
-
-    private static LlmSessionTokenUsage ToSessionUsage(TokenUsage usage) =>
-        new()
-        {
-            PromptTokens = usage.PromptTokens,
-            CompletionTokens = usage.CompletionTokens,
-            TotalTokens = usage.TotalTokens,
-        };
-
-    private static string? ExtractChunkText(LLMStreamChunk chunk)
-    {
-        if (!string.IsNullOrWhiteSpace(chunk.DeltaContent))
-            return chunk.DeltaContent;
-        if (chunk.DeltaContentPart is { Kind: ContentPartKind.Text } part && !string.IsNullOrWhiteSpace(part.Text))
-            return part.Text;
-        return null;
-    }
-
-    private static IReadOnlyList<ToolCall> SelectForwardedToolCalls(
-        IReadOnlyList<ToolCall> toolCalls,
-        LlmSessionRuntimeToolSelection? selection)
-    {
-        if (selection is null || toolCalls.Count == 0 || selection.ForwardedTools.Count == 0)
-            return [];
-
-        var forwardedToolNames = selection.ForwardedTools
-            .Select(static tool => tool.ToolName)
-            .Except(selection.SubstitutedToolNames, StringComparer.Ordinal)
-            .ToHashSet(StringComparer.Ordinal);
-        return toolCalls
-            .Where(call => forwardedToolNames.Contains(call.Name))
-            .ToArray();
-    }
-
-    private static IReadOnlyList<ToolCall> ApplyToolChoiceHint(
-        IReadOnlyList<ToolCall> toolCalls,
-        LlmSessionRuntimeToolSelection? selection)
-    {
-        if (toolCalls.Count == 0 ||
-            selection is null ||
-            string.IsNullOrWhiteSpace(selection.ToolChoiceHintName))
-        {
-            return toolCalls;
-        }
-
-        return toolCalls
-            .Select(call => ApplyToolChoiceHint(call, selection))
-            .ToArray();
-    }
-
-    private static ToolCall ApplyToolChoiceHint(
-        ToolCall call,
-        LlmSessionRuntimeToolSelection selection)
-    {
-        var toolName = selection.ToolChoiceHintName.Trim();
-        if (!string.Equals(call.Name, toolName, StringComparison.Ordinal))
-        {
-            return CloneWithArguments(
-                call,
-                BuildStructuredToolChoiceError(
-                    "tool_choice_hint_mismatch",
-                    $"Tool choice hint requires '{toolName}', but the model called '{call.Name}'.",
-                    "tool_name"));
-        }
-
-        JsonObject prefilled;
-        try
-        {
-            prefilled = ParseJsonObject(ToolChoiceHintArgumentsJson(selection));
-        }
-        catch (JsonException ex)
-        {
-            return CloneWithArguments(
-                call,
-                BuildStructuredToolChoiceError(
-                    "invalid_tool_choice_prefill",
-                    $"Tool choice prefilled arguments must be a JSON object: {ex.Message}",
-                    "tool_choice_hint_arguments_json"));
-        }
-
-        JsonObject modelArguments;
-        try
-        {
-            modelArguments = ParseJsonObject(call.ArgumentsJson);
-        }
-        catch (JsonException ex)
-        {
-            return CloneWithArguments(
-                call,
-                BuildStructuredToolChoiceError(
-                    "invalid_tool_arguments",
-                    $"Arguments must be a JSON object: {ex.Message}",
-                    "arguments"));
-        }
-
-        var merged = new JsonObject();
-        foreach (var (key, value) in prefilled)
-            merged[key] = value?.DeepClone();
-
-        foreach (var (key, value) in modelArguments)
-        {
-            if (prefilled.TryGetPropertyValue(key, out var prefilledValue) &&
-                !JsonNode.DeepEquals(prefilledValue, value))
-            {
-                return CloneWithArguments(
-                    call,
-                    BuildStructuredToolChoiceError(
-                        "tool_choice_prefill_conflict",
-                        $"Tool argument '{key}' conflicts with server-trusted prefilled_arguments.",
-                        key));
-            }
-
-            if (!prefilled.ContainsKey(key))
-                merged[key] = value?.DeepClone();
-        }
-
-        return CloneWithArguments(
-            call,
-            merged.ToJsonString(new JsonSerializerOptions { WriteIndented = false }));
-    }
-
-    private static JsonObject ParseJsonObject(string? json)
-    {
-        if (string.IsNullOrWhiteSpace(json))
-            return new JsonObject();
-
-        return JsonNode.Parse(json) as JsonObject
-               ?? throw new JsonException("Root value must be an object.");
-    }
-
-    // Refactor (iter355/issue1438-first): Old pattern: durable LlmSession tool arguments were reconstructed from *_json strings. New principle: actor payload helpers prefer typed Struct writes and keep empty Struct as legacy fallback.
-    private static Struct ParseStruct(string? json)
-    {
-        if (string.IsNullOrWhiteSpace(json))
-            return new Struct();
-
-        try
-        {
-            return JsonParser.Default.Parse<Struct>(json);
-        }
-        catch
-        {
-            return new Struct();
-        }
-    }
-
-    private static string RuntimeToolArgumentsJson(LlmSessionRuntimeToolCall call)
-    {
-        if (call.Arguments is { Fields.Count: > 0 })
-            return JsonFormatter.Default.Format(call.Arguments);
-        return string.IsNullOrWhiteSpace(call.ArgumentsJson) ? "{}" : call.ArgumentsJson;
-    }
-
     private static Value RuntimeToolArgumentsValue(LlmSessionRuntimeToolCall call)
     {
         if (call.Arguments is { Fields.Count: > 0 })
@@ -1066,97 +560,12 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
             string.IsNullOrWhiteSpace(call.ArgumentsJson) ? "{}" : call.ArgumentsJson);
     }
 
-    private static Value ToolCallArgumentsValue(ToolCall call)
-    {
-        var arguments = ParseStruct(call.ArgumentsJson);
-        if (arguments.Fields.Count > 0)
-            return Value.ForStruct(arguments);
-        return ResponsesJsonValues.ParseBoundaryPayload(
-            string.IsNullOrWhiteSpace(call.ArgumentsJson) ? "{}" : call.ArgumentsJson);
-    }
-
-    private static string ToolChoiceHintArgumentsJson(LlmSessionRuntimeToolSelection selection)
-    {
-        if (selection.ToolChoiceHintArguments is { Fields.Count: > 0 })
-            return JsonFormatter.Default.Format(selection.ToolChoiceHintArguments);
-        return selection.ToolChoiceHintArgumentsJson;
-    }
-
-    private static string ToolDeclarationParametersJson(LlmSessionRuntimeToolDeclaration declaration)
-    {
-        if (declaration.Parameters is { Fields.Count: > 0 })
-            return JsonFormatter.Default.Format(declaration.Parameters);
-        return declaration.ParametersJson;
-    }
-
     private static Struct MergeStruct(Struct? existing, Struct incoming)
     {
         var merged = existing?.Clone() ?? new Struct();
         foreach (var (key, value) in incoming.Fields)
             merged.Fields[key] = value.Clone();
         return merged;
-    }
-
-    private static ToolCall CloneWithArguments(ToolCall call, string argumentsJson) =>
-        new()
-        {
-            Id = call.Id,
-            Name = call.Name,
-            ArgumentsJson = argumentsJson,
-        };
-
-    private static string BuildStructuredToolChoiceError(
-        string code,
-        string message,
-        string field) =>
-        JsonSerializer.Serialize(new
-        {
-            error = new
-            {
-                code,
-                message,
-                field,
-            },
-        });
-
-    private static IReadOnlyList<ToolCall> SelectLocalToolCalls(
-        IReadOnlyList<ToolCall> toolCalls,
-        LlmSessionRuntimeToolSelection? selection,
-        IReadOnlyList<IAgentTool> tools)
-    {
-        if (toolCalls.Count == 0 || tools.Count == 0)
-            return [];
-
-        var forwardedNames = (selection?.ForwardedTools ?? [])
-            .Select(static tool => tool.ToolName)
-            .Except(selection?.SubstitutedToolNames ?? [], StringComparer.Ordinal)
-            .ToHashSet(StringComparer.Ordinal);
-        var localNames = tools
-            .Where(static tool => tool is not ForwardedRuntimeTool)
-            .Select(static tool => tool.Name)
-            .Where(name => !forwardedNames.Contains(name))
-            .ToHashSet(StringComparer.Ordinal);
-        return toolCalls
-            .Where(call => localNames.Contains(call.Name))
-            .ToArray();
-    }
-
-    private static LlmSessionForwardedToolCall BuildForwardedToolCall(
-        ToolCall toolCall,
-        LlmSessionRuntimeToolSelection? selection)
-    {
-        var declaration = selection?.ForwardedTools
-            .FirstOrDefault(tool => string.Equals(tool.ToolName, toolCall.Name, StringComparison.Ordinal));
-        return new LlmSessionForwardedToolCall
-        {
-            CallId = toolCall.Id,
-            ToolName = toolCall.Name,
-            SchemaHash = declaration?.SchemaHash ?? string.Empty,
-            Arguments = ToolCallArgumentsValue(toolCall),
-            Status = LlmSessionForwardedToolCallStatus.Pending,
-            EmittedAt = Timestamp.FromDateTime(DateTime.UtcNow),
-            Expiry = Timestamp.FromDateTime(DateTime.UtcNow.Add(DefaultTtl.ToTimeSpan())),
-        };
     }
 
     private static LlmSessionRunScope EnsureRun(
@@ -1214,140 +623,41 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
             existing.ArgumentsJson += incoming.ArgumentsJson;
     }
 
-    private static string MapFailureCode(Exception ex) =>
-        ex switch
-        {
-            NyxIdAuthenticationRequiredException => "authentication_required",
-            NyxIdUpstreamException upstream => upstream.Kind.ToString().ToLowerInvariant(),
-            _ => "execution_failed",
-        };
+    private Task PersistLlmRunEventAsync<TEvent>(TEvent evt, CancellationToken ct)
+        where TEvent : IMessage =>
+        PersistDomainEventAsync(evt, ct);
 
-    private sealed class ForwardedRuntimeTool : IAgentTool
+    private sealed class InActorLlmRunSink(LlmSessionGAgent actor) : ILlmRunSink
     {
-        public ForwardedRuntimeTool(LlmSessionRuntimeToolDeclaration declaration)
-        {
-            ArgumentNullException.ThrowIfNull(declaration);
-            Name = declaration.ToolName;
-            Description = declaration.Description;
-            ParametersSchema = ToolDeclarationParametersJson(declaration);
-        }
+        public Task RecordStreamChunkObservedAsync(
+            LlmStreamChunkObserved observed,
+            CancellationToken ct = default) =>
+            actor.PersistLlmRunEventAsync(observed, ct);
 
-        public string Name { get; }
+        public Task RecordToolCallObservedAsync(
+            LlmToolCallObserved observed,
+            CancellationToken ct = default) =>
+            actor.PersistLlmRunEventAsync(observed, ct);
 
-        public string Description { get; }
+        public Task RecordForwardedToolCallEmittedAsync(
+            LlmSessionForwardedToolCallEmittedEvent emitted,
+            CancellationToken ct = default) =>
+            actor.PersistLlmRunEventAsync(emitted, ct);
 
-        public string ParametersSchema { get; }
+        public Task RecordRunCompletedAsync(
+            LlmRunCompleted completed,
+            CancellationToken ct = default) =>
+            actor.PersistLlmRunEventAsync(completed, ct);
 
-        public bool IsReadOnly => true;
+        public Task RecordRunFailedAsync(
+            LlmRunFailed failed,
+            CancellationToken ct = default) =>
+            actor.PersistLlmRunEventAsync(failed, ct);
 
-        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
-            throw new InvalidOperationException(
-                $"Forwarded Responses tool '{Name}' must be executed by the client, not by Aevatar.");
-    }
-
-    private sealed class RuntimeToolCallAccumulator
-    {
-        private readonly Dictionary<string, ToolCallAggregate> _aggregates = new(StringComparer.Ordinal);
-        private readonly List<string> _order = [];
-        private int _anonymousCounter;
-        private string? _activeAnonymousKey;
-
-        public void TrackDelta(ToolCall delta)
-        {
-            ArgumentNullException.ThrowIfNull(delta);
-            var aggregate = ResolveAggregate(delta);
-            if (!string.IsNullOrWhiteSpace(delta.Name))
-                aggregate.Name = delta.Name;
-            if (!string.IsNullOrEmpty(delta.ArgumentsJson))
-                aggregate.Arguments.Append(delta.ArgumentsJson);
-        }
-
-        public IReadOnlyList<ToolCall> BuildToolCalls()
-        {
-            var result = new List<ToolCall>(_order.Count);
-            foreach (var key in _order)
-            {
-                var aggregate = _aggregates[key];
-                result.Add(new ToolCall
-                {
-                    Id = aggregate.Id,
-                    Name = aggregate.Name ?? string.Empty,
-                    ArgumentsJson = aggregate.Arguments.ToString(),
-                });
-            }
-
-            return result;
-        }
-
-        private ToolCallAggregate ResolveAggregate(ToolCall delta)
-        {
-            if (!string.IsNullOrWhiteSpace(delta.Id))
-                return ResolveKnownIdAggregate(delta.Id);
-
-            return ResolveAnonymousAggregate();
-        }
-
-        private ToolCallAggregate ResolveKnownIdAggregate(string id)
-        {
-            var knownKey = $"id:{id}";
-            if (TryPromoteActiveAnonymousAggregate(knownKey, id, out var promoted))
-            {
-                _activeAnonymousKey = null;
-                return promoted;
-            }
-
-            _activeAnonymousKey = null;
-            if (!_aggregates.TryGetValue(knownKey, out var aggregate))
-            {
-                aggregate = new ToolCallAggregate(id);
-                _aggregates[knownKey] = aggregate;
-                _order.Add(knownKey);
-            }
-
-            return aggregate;
-        }
-
-        private ToolCallAggregate ResolveAnonymousAggregate()
-        {
-            if (!string.IsNullOrWhiteSpace(_activeAnonymousKey))
-                return _aggregates[_activeAnonymousKey];
-
-            _anonymousCounter++;
-            var anonymousKey = $"anon:{_anonymousCounter}";
-            var aggregate = new ToolCallAggregate($"stream-tool-call-{_anonymousCounter}");
-            _aggregates[anonymousKey] = aggregate;
-            _order.Add(anonymousKey);
-            _activeAnonymousKey = anonymousKey;
-            return aggregate;
-        }
-
-        private bool TryPromoteActiveAnonymousAggregate(
-            string knownKey,
-            string knownId,
-            out ToolCallAggregate aggregate)
-        {
-            aggregate = default!;
-            if (string.IsNullOrWhiteSpace(_activeAnonymousKey))
-                return false;
-            var anonymousAggregate = _aggregates[_activeAnonymousKey];
-            if (_aggregates.ContainsKey(knownKey))
-                return false;
-            anonymousAggregate.Id = knownId;
-            _aggregates.Remove(_activeAnonymousKey);
-            _aggregates[knownKey] = anonymousAggregate;
-            _order[_order.IndexOf(_activeAnonymousKey)] = knownKey;
-            aggregate = anonymousAggregate;
-            return true;
-        }
-
-        private sealed class ToolCallAggregate(string id)
-        {
-            public string Id { get; set; } = id;
-
-            public string? Name { get; set; }
-
-            public System.Text.StringBuilder Arguments { get; } = new();
-        }
+        public Task RecordRunCancelledAsync(
+            LlmRunCancelled cancelled,
+            CancellationToken ct = default) =>
+            actor.PersistLlmRunEventAsync(cancelled, ct);
     }
 
     private static LlmSessionRecord NormalizeRecord(LlmSessionRecord record)

--- a/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -82,6 +82,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<ILlmSessionRegistrationPort, LlmSessionRegistrationAdapter>();
         services.TryAddSingleton<IResponsesAgentToolStateCommandPort, ResponsesAgentToolStateCommandAdapter>();
         services.TryAddSingleton<ILlmSessionRunObservationService, LlmSessionRunObservationService>();
+        services.TryAddSingleton<ILlmRunCore, LlmRunCore>();
         services.TryAddSingleton<IResponsesToolClassificationService, ResponsesToolClassificationService>();
         services.AddToolSetRegistry();
         services.TryAddSingleton<IResponsesDirectToolPlanService, ResponsesDirectToolPlanService>();

--- a/test/Aevatar.GAgentService.Tests/Application/LlmRunCoreTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/LlmRunCoreTests.cs
@@ -1,0 +1,347 @@
+using System.Runtime.CompilerServices;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Responses;
+using Aevatar.GAgentService.Application.Responses;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.GAgentService.Tests.Application;
+
+public sealed class LlmRunCoreTests
+{
+    [Fact]
+    public async Task RunAsync_ShouldRecordStreamingCompletionThroughSink()
+    {
+        var provider = new ScriptedLlmProviderFactory([
+            [
+                new LLMStreamChunk { DeltaContent = "hello " },
+                new LLMStreamChunk
+                {
+                    DeltaContent = "world",
+                    Usage = new TokenUsage(3, 2, 5),
+                    IsLast = true,
+                },
+            ],
+        ]);
+        var sink = new RecordingLlmRunSink();
+        var core = new LlmRunCore(provider, [], NullLogger<LlmRunCore>.Instance);
+
+        await core.RunAsync(
+            new LlmRunCoreRequest(BuildRunRequest("resp_1"), "run_1", "ApiKey"),
+            sink);
+
+        sink.StreamChunks.Should().HaveCount(2);
+        sink.Completed.Should().ContainSingle();
+        var completed = sink.Completed[0];
+        completed.ResponseId.Should().Be("resp_1");
+        completed.RunId.Should().Be("run_1");
+        completed.OutputText.Should().Be("hello world");
+        completed.Usage!.TotalTokens.Should().Be(5);
+        provider.Requests.Should().ContainSingle()
+            .Which.CallerContext!.ResponseId.Should().Be("resp_1");
+    }
+
+    [Fact]
+    public async Task RunAsync_ShouldEmitForwardedToolCallAndComplete()
+    {
+        var provider = new ScriptedLlmProviderFactory([
+            [
+                new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "call_1",
+                        Name = "get_weather",
+                        ArgumentsJson = """{"city":""",
+                    },
+                },
+                new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "call_1",
+                        Name = "get_weather",
+                        ArgumentsJson = "\"Singapore\"}",
+                    },
+                    IsLast = true,
+                },
+            ],
+        ]);
+        var sink = new RecordingLlmRunSink();
+        var core = new LlmRunCore(provider, [], NullLogger<LlmRunCore>.Instance);
+
+        await core.RunAsync(
+            new LlmRunCoreRequest(BuildRunRequest("resp_1", BuildForwardedSelection()), "run_1", "ApiKey"),
+            sink);
+
+        sink.ToolCalls.Should().ContainSingle(observed => observed.Forwarded);
+        sink.ForwardedToolCalls.Should().ContainSingle();
+        var forwarded = sink.ForwardedToolCalls[0].Call!;
+        forwarded.CallId.Should().Be("call_1");
+        forwarded.ToolName.Should().Be("get_weather");
+        forwarded.SchemaHash.Should().Be("schema-1");
+        ResponsesJsonValues.ToBoundaryJson(forwarded.Arguments).Should().Be("""{"city":"Singapore"}""");
+        sink.Completed.Should().ContainSingle()
+            .Which.ForwardedToolCalls.Should().ContainSingle()
+            .Which.Arguments.Fields["city"].StringValue.Should().Be("Singapore");
+    }
+
+    [Fact]
+    public async Task RunAsync_ShouldExecuteSubstitutedToolAndContinueNextRound()
+    {
+        var tool = new RecordingAgentTool("get_weather", """{"temperature":28}""");
+        var toolProvider = new StaticResponsesToolProvider(substituteTools: [tool]);
+        var provider = new ScriptedLlmProviderFactory([
+            [
+                new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "call_1",
+                        Name = "get_weather",
+                        ArgumentsJson = """{"city":"Singapore"}""",
+                    },
+                    IsLast = true,
+                },
+            ],
+            [
+                new LLMStreamChunk
+                {
+                    DeltaContent = "local result accepted",
+                    IsLast = true,
+                },
+            ],
+        ]);
+        var sink = new RecordingLlmRunSink();
+        var core = new LlmRunCore(provider, [toolProvider], NullLogger<LlmRunCore>.Instance);
+        var selection = BuildForwardedSelection();
+        selection.SubstitutedToolNames.Add("get_weather");
+
+        await core.RunAsync(
+            new LlmRunCoreRequest(BuildRunRequest("resp_1", selection), "run_1", "ApiKey"),
+            sink);
+
+        tool.Executions.Should().ContainSingle().Which.Should().Be("""{"city":"Singapore"}""");
+        sink.ForwardedToolCalls.Should().BeEmpty();
+        sink.ToolCalls.Should().ContainSingle(observed => !observed.Forwarded)
+            .Which.LocalResult.StructValue.Fields["temperature"].NumberValue.Should().Be(28);
+        provider.Requests.Should().HaveCount(2);
+        provider.Requests[1].Messages.Should().Contain(message =>
+            string.Equals(message.Role, "tool", StringComparison.Ordinal) &&
+            string.Equals(message.Content, """{"temperature":28}""", StringComparison.Ordinal));
+        sink.Completed.Should().ContainSingle()
+            .Which.OutputText.Should().Be("local result accepted");
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenProviderThrows_ShouldRecordFailureThroughSink()
+    {
+        var provider = new ThrowingLlmProviderFactory(
+            new NyxIdAuthenticationRequiredException("nyxid"));
+        var sink = new RecordingLlmRunSink();
+        var core = new LlmRunCore(provider, [], NullLogger<LlmRunCore>.Instance);
+
+        await core.RunAsync(
+            new LlmRunCoreRequest(BuildRunRequest("resp_1"), "run_1", "ApiKey"),
+            sink);
+
+        sink.Failed.Should().ContainSingle();
+        sink.Failed[0].FailureCode.Should().Be("authentication_required");
+        sink.Failed[0].FailureMessage.Should().Contain("NyxID authentication required");
+        sink.Completed.Should().BeEmpty();
+        sink.Cancelled.Should().BeEmpty();
+    }
+
+    private static LlmRunRequested BuildRunRequest(
+        string responseId,
+        LlmSessionRuntimeToolSelection? selection = null) =>
+        new()
+        {
+            ResponseId = responseId,
+            RunId = "run_1",
+            ScopeId = "user-1",
+            OwnerSubject = "user-1",
+            BearerToken = "token-1",
+            Model = "test-model",
+            ToolSelection = selection,
+            Messages =
+            {
+                new LlmSessionRuntimeChatMessage
+                {
+                    Role = "user",
+                    Content = "What is the weather?",
+                },
+            },
+        };
+
+    private static LlmSessionRuntimeToolSelection BuildForwardedSelection() =>
+        new()
+        {
+            ForwardedTools =
+            {
+                new LlmSessionRuntimeToolDeclaration
+                {
+                    ToolName = "get_weather",
+                    Description = "Get weather",
+                    ParametersJson = """{"type":"object"}""",
+                    Parameters = new Struct
+                    {
+                        Fields =
+                        {
+                            ["type"] = Google.Protobuf.WellKnownTypes.Value.ForString("object"),
+                        },
+                    },
+                    SchemaHash = "schema-1",
+                },
+            },
+        };
+
+    private sealed class RecordingLlmRunSink : ILlmRunSink
+    {
+        public List<LlmStreamChunkObserved> StreamChunks { get; } = [];
+        public List<LlmToolCallObserved> ToolCalls { get; } = [];
+        public List<LlmSessionForwardedToolCallEmittedEvent> ForwardedToolCalls { get; } = [];
+        public List<LlmRunCompleted> Completed { get; } = [];
+        public List<LlmRunFailed> Failed { get; } = [];
+        public List<LlmRunCancelled> Cancelled { get; } = [];
+
+        public Task RecordStreamChunkObservedAsync(
+            LlmStreamChunkObserved observed,
+            CancellationToken ct = default)
+        {
+            StreamChunks.Add(observed.Clone());
+            return Task.CompletedTask;
+        }
+
+        public Task RecordToolCallObservedAsync(
+            LlmToolCallObserved observed,
+            CancellationToken ct = default)
+        {
+            ToolCalls.Add(observed.Clone());
+            return Task.CompletedTask;
+        }
+
+        public Task RecordForwardedToolCallEmittedAsync(
+            LlmSessionForwardedToolCallEmittedEvent emitted,
+            CancellationToken ct = default)
+        {
+            ForwardedToolCalls.Add(emitted.Clone());
+            return Task.CompletedTask;
+        }
+
+        public Task RecordRunCompletedAsync(
+            LlmRunCompleted completed,
+            CancellationToken ct = default)
+        {
+            Completed.Add(completed.Clone());
+            return Task.CompletedTask;
+        }
+
+        public Task RecordRunFailedAsync(
+            LlmRunFailed failed,
+            CancellationToken ct = default)
+        {
+            Failed.Add(failed.Clone());
+            return Task.CompletedTask;
+        }
+
+        public Task RecordRunCancelledAsync(
+            LlmRunCancelled cancelled,
+            CancellationToken ct = default)
+        {
+            Cancelled.Add(cancelled.Clone());
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ScriptedLlmProviderFactory(
+        IReadOnlyList<IReadOnlyList<LLMStreamChunk>> responses) : ILLMProviderFactory, ILLMProvider
+    {
+        private int _nextResponseIndex;
+
+        public List<LLMRequest> Requests { get; } = [];
+
+        public string Name => "test";
+
+        public ILLMProvider GetProvider(string name) => this;
+
+        public ILLMProvider GetDefault() => this;
+
+        public IReadOnlyList<string> GetAvailableProviders() => [Name];
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            Requests.Add(request);
+            var response = responses[Math.Min(_nextResponseIndex, responses.Count - 1)];
+            _nextResponseIndex++;
+            foreach (var chunk in response)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return chunk;
+            }
+
+            await Task.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingLlmProviderFactory(Exception exception) : ILLMProviderFactory, ILLMProvider
+    {
+        public string Name => "test";
+
+        public ILLMProvider GetProvider(string name) => this;
+
+        public ILLMProvider GetDefault() => this;
+
+        public IReadOnlyList<string> GetAvailableProviders() => [Name];
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            _ = request;
+            ct.ThrowIfCancellationRequested();
+            await Task.CompletedTask;
+            throw exception;
+            #pragma warning disable CS0162
+            yield return new LLMStreamChunk();
+            #pragma warning restore CS0162
+        }
+    }
+
+    private sealed class StaticResponsesToolProvider(
+        IReadOnlyList<IAgentTool>? substituteTools = null,
+        IReadOnlyList<IAgentTool>? additiveTools = null) : IResponsesToolProvider
+    {
+        public ValueTask<IReadOnlyList<IAgentTool>> GetSubstituteToolsAsync(
+            ResponsesToolProviderContext context,
+            CancellationToken ct = default) =>
+            ValueTask.FromResult(substituteTools ?? []);
+
+        public ValueTask<IReadOnlyList<IAgentTool>> GetAdditiveToolsAsync(
+            ResponsesToolProviderContext context,
+            CancellationToken ct = default) =>
+            ValueTask.FromResult(additiveTools ?? []);
+    }
+
+    private sealed class RecordingAgentTool(string name, string resultJson) : IAgentTool
+    {
+        public List<string> Executions { get; } = [];
+
+        public string Name { get; } = name;
+
+        public string Description => "test tool";
+
+        public string ParametersSchema => """{"type":"object"}""";
+
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+        {
+            Executions.Add(argumentsJson);
+            return Task.FromResult(resultJson);
+        }
+    }
+}

--- a/test/Aevatar.GAgentService.Tests/Core/ResponsesSafeToolExecutorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ResponsesSafeToolExecutorTests.cs
@@ -1,9 +1,9 @@
 using System.Text.Json;
 using Aevatar.AI.Abstractions.ToolProviders;
-using Aevatar.GAgentService.Core.GAgents;
+using Aevatar.GAgentService.Application.Responses;
 using FluentAssertions;
 
-namespace Aevatar.GAgentService.Tests.Core;
+namespace Aevatar.GAgentService.Tests.Application;
 
 public sealed class ResponsesSafeToolExecutorTests
 {

--- a/test/Aevatar.GAgentService.Tests/TestSupport/GAgentServiceTestKit.cs
+++ b/test/Aevatar.GAgentService.Tests/TestSupport/GAgentServiceTestKit.cs
@@ -9,8 +9,12 @@ using Aevatar.Foundation.Runtime.Callbacks;
 using Aevatar.Foundation.Runtime.Persistence;
 using Aevatar.Foundation.Runtime.Streaming;
 using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Responses;
+using Aevatar.GAgentService.Application.Responses;
 using Google.Protobuf;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aevatar.GAgentService.Tests.TestSupport;
 
@@ -138,6 +142,8 @@ internal static class GAgentServiceTestKit
             .AddSingleton<InMemoryActorRuntimeCallbackScheduler>()
             .AddSingleton<IActorRuntimeCallbackScheduler>(sp =>
                 sp.GetRequiredService<InMemoryActorRuntimeCallbackScheduler>())
+            .AddSingleton<ILlmRunCore, LlmRunCore>()
+            .AddSingleton<ILogger<LlmRunCore>>(NullLogger<LlmRunCore>.Instance)
             .AddSingleton<IEnumerable<IGAgentExecutionHook>>(Array.Empty<IGAgentExecutionHook>());
         configureServices?.Invoke(services);
         agent.Services = services.BuildServiceProvider();


### PR DESCRIPTION
## Changed files

- 新增 Abstractions 里的 `ILlmRunCore` / `ILlmRunSink` 契约。
- 将 provider stream、tool-call 聚合、本地 tool 执行与失败映射收敛到 Application 的 `LlmRunCore`。
- `LlmSessionGAgent` 保留注册、准入、重复运行与终态保护，并通过 in-actor sink 持久化原有 typed events。
- Hosting DI 注册 `ILlmRunCore`，测试 harness 同步使用该 DI 边界。

## Test results

- `dotnet build aevatar.slnx --nologo`
- `dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --filter "LlmRunCoreTests|LlmSessionGAgentTests|ResponsesSafeToolExecutorTests" --nologo`
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/architecture_guards.sh`

## Deviations

- `refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)`
- No schema/protocol regeneration required.
- Closes #2273

⟦AI:AUTO-LOOP⟧
