### PR TITLE
统一 Voice WebSocket attach 执行器和 typed attach outcome

### DIFF
--- a/docs/canon/voice-presence-integration.md
+++ b/docs/canon/voice-presence-integration.md
@@ -122,7 +122,11 @@ The edge consumes a JSON projection of it (camelCase), hand-parsed by
   - down (aevatar → client): `sessionAccepted`, `realtimeFrame`
   - `sessionAccepted` advertises the typed wire contract version (`1.0`) and
     the input image policy (`maxBytes: 512000`, allowed media types
-    `image/jpeg`, `image/png`) owned by aevatar.
+    `image/jpeg`, `image/png`) owned by aevatar. It also carries
+    `attachOutcome`: `NEW_SESSION` for a fresh lease and `RESTARTED` when
+    aevatar intentionally evicted a previous lease before accepting the new
+    transport. Clients must not infer reset semantics from a changed
+    `sessionId`; `sessionId` remains identity.
   - `realtimeFrame` is itself a `VoiceRealtimeFrame` oneof: `responseStarted`/
     `Done`/`Cancelled`, `speechStarted`/`Stopped`, `functionCall`,
     `transcriptDelta`/`Completed`, `error`, `disconnected`, `sessionClosed`.
@@ -155,6 +159,14 @@ The edge consumes a JSON projection of it (camelCase), hand-parsed by
   results, and event injection are delivered only through the live media relay
   bound at attach time. A missing media port or relay for that lease is a
   delivery/topology gap, not permission to open a replacement provider socket.
+- **Attach lifecycle** — both the Foundation endpoint and the Mainnet
+  policy-aware endpoint use the same stateless Foundation WebSocket attach
+  executor. It sends the typed `sessionAccepted` ACK, subscribes realtime
+  control frames, attaches the volatile media relay with a bounded timeout, and
+  releases/detaches with a bounded close-wait. A pre-upgrade
+  `TransportAlreadyAttached` result returns `409` with `Retry-After: 1`;
+  post-upgrade media, credential, conflict, or timeout failures close the socket
+  with a policy-violation reason.
 - **Credential ref lifetime** — `/ws/voice` admission mints at most one
   `voice-tool:` ref for an attach attempt and hands a non-protobuf transport
   binding to the host attach path. The raw caller bearer becomes resolvable

--- a/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
@@ -49,6 +49,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Aevatar.Bootstrap.Extensions.AI;
 
@@ -194,7 +195,10 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton(sp => new VoiceVolatileToolCredentialPort(sp.GetService<TimeProvider>()));
         services.TryAddSingleton<IVoiceVolatileToolCredentialPort>(sp => sp.GetRequiredService<VoiceVolatileToolCredentialPort>());
         services.TryAddSingleton<IVoiceToolCredentialIssuer>(sp => sp.GetRequiredService<VoiceVolatileToolCredentialPort>());
+        services.AddOptions<VoiceWebSocketAttachOptions>();
         services.TryAddSingleton<IVoiceVolatileMediaStreamPort, VoiceVolatileMediaStreamPort>();
+        services.TryAddSingleton<IValidateOptions<VoiceWebSocketAttachOptions>, VoiceWebSocketAttachOptionsValidator>();
+        services.TryAddSingleton<VoiceWebSocketAttachExecutor>();
         services.TryAddSingleton<IRealtimeSession<VoiceRealtimeSessionRequest, VoiceRealtimeSessionAccepted, VoiceRealtimeSessionStartError, VoiceRealtimeFrame, VoiceRealtimeSessionCompletion>, ActorOwnedVoiceRealtimeSession>();
         services.AddVoicePresenceCapabilityProjection();
         services.AddVoicePresenceCapabilityProjectionStore(configuration);

--- a/src/Aevatar.Foundation.VoicePresence.Abstractions/Protos/voice_presence.proto
+++ b/src/Aevatar.Foundation.VoicePresence.Abstractions/Protos/voice_presence.proto
@@ -35,6 +35,14 @@ enum VoiceToolOwner {
   VOICE_TOOL_OWNER_CLIENT = 2;
 }
 
+enum VoiceTransportAttachOutcome {
+  VOICE_TRANSPORT_ATTACH_OUTCOME_UNSPECIFIED = 0;
+  VOICE_TRANSPORT_ATTACH_OUTCOME_NEW_SESSION = 1;
+  VOICE_TRANSPORT_ATTACH_OUTCOME_RESTARTED = 2;
+  reserved 3;
+  reserved "VOICE_TRANSPORT_ATTACH_OUTCOME_REATTACHED";
+}
+
 message VoiceProviderConfig {
   string provider_name = 1;
   string endpoint = 2;
@@ -309,6 +317,7 @@ message VoiceTransportSessionAccepted {
   int64 observed_state_version = 5;
   string wire_contract_version = 6;
   VoiceInputImagePolicy input_image_policy = 7;
+  VoiceTransportAttachOutcome attach_outcome = 8;
 }
 
 message VoiceControlFrame {

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/ActorOwnedVoiceRealtimeSession.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/ActorOwnedVoiceRealtimeSession.cs
@@ -48,6 +48,7 @@ public sealed class ActorOwnedVoiceRealtimeSession
         if (!capability.Initialized)
             return Failure(VoiceRealtimeSessionStartError.NotInitialized);
 
+        var attachOutcome = VoiceRealtimeAttachOutcome.NewSession;
         if (capability.TransportAttached || IsActive(capability.LeaseExpiresAt, capability.ActiveSessionId))
         {
             if (inbound.Purpose == VoiceRealtimeSessionPurpose.Detach)
@@ -96,6 +97,7 @@ public sealed class ActorOwnedVoiceRealtimeSession
                     capability.LeaseEpoch,
                     inbound.ToolContext?.Clone());
                 await _mediaStreamPort.DetachAsync(evictHandle, expectedTransport: null, ct);
+                attachOutcome = VoiceRealtimeAttachOutcome.Restarted;
                 _logger?.LogInformation(
                     "voice takeover: evicted prior session {EvictedSessionId} (transportLease={TransportLeaseId}, epoch={LeaseEpoch}) on actor {ActorId}/{ModuleName}; proceeding to acquire",
                     capability.ActiveSessionId,
@@ -127,7 +129,7 @@ public sealed class ActorOwnedVoiceRealtimeSession
             inbound.ToolContext?.Clone());
 
         var leaseHandle = await _leasePort.AcquireAsync(leaseRequest, ct);
-        var accepted = BuildAccepted(capability, leaseHandle);
+        var accepted = BuildAccepted(capability, leaseHandle, attachOutcome);
         if (onAcceptedAsync != null)
             await onAcceptedAsync(accepted, ct);
 
@@ -142,7 +144,8 @@ public sealed class ActorOwnedVoiceRealtimeSession
 
     private static VoiceRealtimeSessionAccepted BuildAccepted(
         VoicePresenceCapabilitySnapshot capability,
-        VoicePresenceSessionLeaseHandle leaseHandle) =>
+        VoicePresenceSessionLeaseHandle leaseHandle,
+        VoiceRealtimeAttachOutcome attachOutcome = VoiceRealtimeAttachOutcome.NewSession) =>
         new(
             capability.ActorId,
             capability.ModuleName,
@@ -151,7 +154,8 @@ public sealed class ActorOwnedVoiceRealtimeSession
             leaseHandle.ObservedStateVersion,
             leaseHandle,
             VoiceWireContractDefaults.CurrentWireContractVersion,
-            VoiceWireContractDefaults.CreateInputImagePolicy());
+            VoiceWireContractDefaults.CreateInputImagePolicy(),
+            attachOutcome);
 
     private DateTimeOffset UtcNow => _timeProvider.GetUtcNow();
 

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceEndpoints.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceEndpoints.cs
@@ -1,4 +1,3 @@
-using System.Net.WebSockets;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.Foundation.VoicePresence.Abstractions;
 using Aevatar.Foundation.VoicePresence.Abstractions.Sessions;
@@ -9,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Aevatar.Foundation.VoicePresence.Hosting;
 
@@ -51,65 +51,14 @@ public static class VoicePresenceEndpoints
                 return;
             }
 
+            var options = ctx.RequestServices.GetRequiredService<IOptions<VoiceWebSocketAttachOptions>>().Value;
             var result = await startSession(CreateSessionRequest(ctx, actorId, VoiceRealtimeSessionPurpose.Attach), ctx);
-            var accepted = await WriteNonAcceptedResolutionAsync(ctx, result);
+            var accepted = await VoiceWebSocketAttachExecutor.WriteNonAcceptedResolutionAsync(ctx, result, options);
             if (accepted == null)
                 return;
 
-            var ws = await ctx.WebSockets.AcceptWebSocketAsync();
-            var mediaPort = resolveMediaPort(ctx);
-            var logger = ResolveLogger(ctx);
-            var transport = new WebSocketVoiceTransport(ws, logger);
-            var attached = false;
-            var detachHandle = accepted.LeaseHandle;
-            IAsyncDisposable? realtimeSubscription = null;
-
-            try
-            {
-                realtimeSubscription = await VoiceRealtimeTransportControlBridge.SubscribeAsync(
-                    ctx.RequestServices,
-                    accepted,
-                    transport,
-                    logger,
-                    ctx.RequestAborted);
-                try
-                {
-                    await VoiceRealtimeTransportControlBridge.SendSessionAcceptedAsync(
-                        transport,
-                        accepted,
-                        ctx.RequestAborted);
-                }
-                catch
-                {
-                    await CleanupAcceptedTransportAsync(mediaPort, accepted.LeaseHandle, transport, logger);
-                    throw;
-                }
-
-                var lifetimeCompleted = await mediaPort.AttachAsync(accepted.LeaseHandle, transport, ctx.RequestAborted);
-                if (!string.IsNullOrWhiteSpace(lifetimeCompleted?.TransportLeaseId))
-                    detachHandle = detachHandle with { ActiveTransportLeaseId = lifetimeCompleted.TransportLeaseId };
-                attached = true;
-                await WaitUntilClosedAsync(transport, ctx.RequestAborted);
-            }
-            catch (VoiceVolatileMediaStreamUnavailableException)
-            {
-                await TryCloseUnsupportedRemoteAudioAsync(ws, logger);
-            }
-            catch (InvalidOperationException) when (!attached)
-            {
-                await TryCloseConflictAsync(ws, logger);
-            }
-            finally
-            {
-                if (realtimeSubscription != null)
-                    await realtimeSubscription.DisposeAsync();
-
-                if (attached)
-                    // CancellationToken.None: ctx.RequestAborted is already cancelled on a normal close,
-                    // and the dispatch port throws on a cancelled token before producing the release —
-                    // so detach must run uncancelled or the lease never releases (TransportAttached sticks).
-                    await mediaPort.DetachAsync(detachHandle, transport, CancellationToken.None);
-            }
+            await ctx.RequestServices.GetRequiredService<VoiceWebSocketAttachExecutor>()
+                .ExecuteAsync(ctx, accepted, resolveMediaPort(ctx));
         });
     }
 
@@ -282,6 +231,7 @@ public static class VoicePresenceEndpoints
                 break;
             case VoiceRealtimeSessionStartError.TransportAlreadyAttached:
                 ctx.Response.StatusCode = StatusCodes.Status409Conflict;
+                ctx.Response.Headers.RetryAfter = "1";
                 await ctx.Response.WriteAsync("Voice transport already attached.");
                 break;
             default:
@@ -310,76 +260,6 @@ public static class VoicePresenceEndpoints
         return string.IsNullOrWhiteSpace(queryModuleName)
             ? null
             : queryModuleName.Trim();
-    }
-
-    private static async Task TryCloseConflictAsync(WebSocket ws, ILogger logger)
-    {
-        if (ws.State is not WebSocketState.Open and not WebSocketState.CloseReceived)
-            return;
-
-        try
-        {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-            await ws.CloseAsync(
-                WebSocketCloseStatus.PolicyViolation,
-                "Voice transport already attached.",
-                cts.Token);
-        }
-        catch (Exception ex)
-        {
-            // best effort close after websocket upgrade
-            logger.LogWarning(ex, "Best-effort close of conflicting voice transport failed.");
-        }
-    }
-
-    private static async Task TryCloseUnsupportedRemoteAudioAsync(WebSocket ws, ILogger logger)
-    {
-        if (ws.State is not WebSocketState.Open and not WebSocketState.CloseReceived)
-            return;
-
-        try
-        {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-            await ws.CloseAsync(
-                WebSocketCloseStatus.PolicyViolation,
-                VoiceVolatileMediaStreamUnavailableException.Reason,
-                cts.Token);
-        }
-        catch (Exception ex)
-        {
-            // best effort close after websocket upgrade
-            logger.LogWarning(ex, "Best-effort close of voice transport with unsupported remote audio failed.");
-        }
-    }
-
-    private static async Task WaitUntilClosedAsync(WebSocketVoiceTransport transport, CancellationToken ct)
-    {
-        try
-        {
-            await transport.Completion.WaitAsync(ct);
-        }
-        catch (OperationCanceledException)
-        {
-        }
-    }
-
-    private static async Task CleanupAcceptedTransportAsync(
-        IVoiceVolatileMediaStreamPort mediaPort,
-        VoicePresenceSessionLeaseHandle handle,
-        WebSocketVoiceTransport transport,
-        ILogger logger)
-    {
-        try
-        {
-            await mediaPort.DetachAsync(handle, transport, CancellationToken.None);
-        }
-        catch (Exception ex)
-        {
-            // best effort cleanup for an accepted lease whose control channel failed before attach
-            logger.LogWarning(ex, "Best-effort detach of accepted voice transport failed before attach.");
-        }
-
-        await transport.DisposeAsync();
     }
 
     private static async Task<string> ReadSdpBodyAsync(HttpRequest request)

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/VoiceRealtimeSessionRequest.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/VoiceRealtimeSessionRequest.cs
@@ -24,7 +24,8 @@ public sealed record VoiceRealtimeSessionAccepted(
     long ObservedStateVersion,
     VoicePresenceSessionLeaseHandle LeaseHandle,
     string WireContractVersion = VoiceWireContractDefaults.CurrentWireContractVersion,
-    VoiceInputImagePolicy? InputImagePolicy = null)
+    VoiceInputImagePolicy? InputImagePolicy = null,
+    VoiceRealtimeAttachOutcome AttachOutcome = VoiceRealtimeAttachOutcome.NewSession)
 {
     public string EffectiveWireContractVersion =>
         string.IsNullOrWhiteSpace(WireContractVersion)
@@ -33,6 +34,12 @@ public sealed record VoiceRealtimeSessionAccepted(
 
     public VoiceInputImagePolicy CreateEffectiveInputImagePolicy() =>
         InputImagePolicy?.Clone() ?? VoiceWireContractDefaults.CreateInputImagePolicy();
+}
+
+public enum VoiceRealtimeAttachOutcome
+{
+    NewSession = 0,
+    Restarted = 1,
 }
 
 public enum VoiceRealtimeSessionStartError

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/VoiceRealtimeTransportControlBridge.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/VoiceRealtimeTransportControlBridge.cs
@@ -28,6 +28,7 @@ public static class VoiceRealtimeTransportControlBridge
                 ObservedStateVersion = accepted.ObservedStateVersion,
                 WireContractVersion = accepted.EffectiveWireContractVersion,
                 InputImagePolicy = accepted.CreateEffectiveInputImagePolicy(),
+                AttachOutcome = MapAttachOutcome(accepted.AttachOutcome),
             },
         }, ct);
     }
@@ -105,6 +106,13 @@ public static class VoiceRealtimeTransportControlBridge
         sendCts.CancelAfter(ControlSendTimeout);
         await transport.SendControlAsync(frame, sendCts.Token);
     }
+
+    private static VoiceTransportAttachOutcome MapAttachOutcome(VoiceRealtimeAttachOutcome outcome) =>
+        outcome switch
+        {
+            VoiceRealtimeAttachOutcome.Restarted => VoiceTransportAttachOutcome.Restarted,
+            _ => VoiceTransportAttachOutcome.NewSession,
+        };
 
     private sealed class NoOpAsyncDisposable : IAsyncDisposable
     {

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/VoiceWebSocketAttachExecutor.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/VoiceWebSocketAttachExecutor.cs
@@ -1,0 +1,238 @@
+using System.Net.WebSockets;
+using Aevatar.CQRS.Core.Abstractions.Streaming;
+using Aevatar.Foundation.VoicePresence.Abstractions;
+using Aevatar.Foundation.VoicePresence.Abstractions.Sessions;
+using Aevatar.Foundation.VoicePresence.Transport;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Aevatar.Foundation.VoicePresence.Hosting;
+
+public sealed class VoiceWebSocketAttachExecutor
+{
+    public const string TransportAlreadyAttachedBody = "Voice transport already attached.";
+    public const string VoiceCredentialUnavailableReason = VoiceVolatileToolCredentialUnavailableException.Reason;
+
+    private readonly IOptions<VoiceWebSocketAttachOptions> _options;
+    private readonly ILogger<VoiceWebSocketAttachExecutor>? _logger;
+    private readonly TimeProvider _timeProvider;
+
+    public VoiceWebSocketAttachExecutor(
+        IOptions<VoiceWebSocketAttachOptions> options,
+        ILogger<VoiceWebSocketAttachExecutor>? logger = null,
+        TimeProvider? timeProvider = null)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public async Task ExecuteAsync(
+        HttpContext http,
+        VoiceRealtimeSessionAccepted accepted,
+        IVoiceVolatileMediaStreamPort mediaStreamPort,
+        VoiceToolCredentialTransportBinding? transportBinding = null)
+    {
+        ArgumentNullException.ThrowIfNull(http);
+        ArgumentNullException.ThrowIfNull(accepted);
+        ArgumentNullException.ThrowIfNull(mediaStreamPort);
+
+        var options = _options.Value;
+        var ws = await http.WebSockets.AcceptWebSocketAsync();
+        var transport = new WebSocketVoiceTransport(ws, _logger);
+        var attached = false;
+        var detachHandle = accepted.LeaseHandle;
+        IAsyncDisposable? realtimeSubscription = null;
+
+        try
+        {
+            realtimeSubscription = await VoiceRealtimeTransportControlBridge.SubscribeAsync(
+                http.RequestServices,
+                accepted,
+                transport,
+                _logger,
+                http.RequestAborted);
+            try
+            {
+                await VoiceRealtimeTransportControlBridge.SendSessionAcceptedAsync(
+                    transport,
+                    accepted,
+                    http.RequestAborted);
+            }
+            catch
+            {
+                await CleanupAcceptedTransportAsync(mediaStreamPort, accepted.LeaseHandle, transport);
+                throw;
+            }
+
+            var lifetimeCompleted = await AttachWithTimeoutAsync(
+                mediaStreamPort,
+                accepted.LeaseHandle,
+                transport,
+                transportBinding,
+                options.AttachTimeout,
+                http.RequestAborted);
+            if (!string.IsNullOrWhiteSpace(lifetimeCompleted?.TransportLeaseId))
+                detachHandle = detachHandle with { ActiveTransportLeaseId = lifetimeCompleted.TransportLeaseId };
+
+            attached = true;
+            await WaitUntilClosedAsync(transport, options.CloseWaitTimeout, http.RequestAborted);
+        }
+        catch (VoiceVolatileMediaStreamUnavailableException)
+        {
+            await TryCloseAsync(ws, VoiceVolatileMediaStreamUnavailableException.Reason, options.PolicyViolationCloseTimeout);
+        }
+        catch (VoiceVolatileToolCredentialUnavailableException)
+        {
+            await TryCloseAsync(ws, VoiceCredentialUnavailableReason, options.PolicyViolationCloseTimeout);
+        }
+        catch (TimeoutException)
+        {
+            await TryCloseAsync(ws, "Voice transport attach timed out.", options.PolicyViolationCloseTimeout);
+        }
+        catch (InvalidOperationException) when (!attached)
+        {
+            await TryCloseAsync(ws, TransportAlreadyAttachedBody, options.PolicyViolationCloseTimeout);
+        }
+        finally
+        {
+            if (realtimeSubscription != null)
+                await realtimeSubscription.DisposeAsync();
+
+            if (attached)
+                await mediaStreamPort.DetachAsync(detachHandle, transport, CancellationToken.None);
+        }
+    }
+
+    public static async Task WritePreflightFailureAsync(
+        HttpContext http,
+        VoiceRealtimeSessionStartError failure,
+        VoiceWebSocketAttachOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(http);
+        ArgumentNullException.ThrowIfNull(options);
+
+        switch (failure)
+        {
+            case VoiceRealtimeSessionStartError.NotFound:
+                http.Response.StatusCode = StatusCodes.Status404NotFound;
+                await http.Response.WriteAsync("Voice session not found for this agent.", http.RequestAborted);
+                break;
+            case VoiceRealtimeSessionStartError.NotInitialized:
+                http.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                await http.Response.WriteAsync("Voice module not initialized.", http.RequestAborted);
+                break;
+            case VoiceRealtimeSessionStartError.TransportAlreadyAttached:
+                http.Response.StatusCode = StatusCodes.Status409Conflict;
+                http.Response.Headers.RetryAfter = Math.Max(1, options.ConflictRetryAfterSeconds).ToString();
+                await http.Response.WriteAsync(TransportAlreadyAttachedBody, http.RequestAborted);
+                break;
+            default:
+                http.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                await http.Response.WriteAsync("Voice session preflight failed.", http.RequestAborted);
+                break;
+        }
+    }
+
+    public static async Task<VoiceRealtimeSessionAccepted?> WriteNonAcceptedResolutionAsync(
+        HttpContext http,
+        RealtimeSessionResult<VoiceRealtimeSessionAccepted, VoiceRealtimeSessionStartError, VoiceRealtimeSessionCompletion> result,
+        VoiceWebSocketAttachOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(http);
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (result.Succeeded)
+            return result.Receipt ?? throw new InvalidOperationException("Accepted voice realtime session requires a receipt.");
+
+        switch (result.Error)
+        {
+            case VoiceRealtimeSessionStartError.Unsupported:
+                http.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                await http.Response.WriteAsync(VoiceVolatileMediaStreamUnavailableException.Reason, http.RequestAborted);
+                return null;
+            case VoiceRealtimeSessionStartError.NotFound:
+            case VoiceRealtimeSessionStartError.NotInitialized:
+            case VoiceRealtimeSessionStartError.TransportAlreadyAttached:
+                await WritePreflightFailureAsync(http, result.Error, options);
+                return null;
+            default:
+                http.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                await http.Response.WriteAsync("Voice realtime session failed.", http.RequestAborted);
+                return null;
+        }
+    }
+
+    private async Task<VoiceTransportLifetimeCompleted?> AttachWithTimeoutAsync(
+        IVoiceVolatileMediaStreamPort mediaStreamPort,
+        VoicePresenceSessionLeaseHandle leaseHandle,
+        WebSocketVoiceTransport transport,
+        VoiceToolCredentialTransportBinding? transportBinding,
+        TimeSpan timeout,
+        CancellationToken requestAborted)
+    {
+        using var timeoutCts = new CancellationTokenSource(timeout, _timeProvider);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(requestAborted, timeoutCts.Token);
+        try
+        {
+            return await mediaStreamPort.AttachAsync(leaseHandle, transport, transportBinding, linkedCts.Token);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !requestAborted.IsCancellationRequested)
+        {
+            throw new TimeoutException("Voice transport attach timed out.");
+        }
+    }
+
+    private async Task WaitUntilClosedAsync(
+        WebSocketVoiceTransport transport,
+        TimeSpan timeout,
+        CancellationToken requestAborted)
+    {
+        using var timeoutCts = new CancellationTokenSource(timeout, _timeProvider);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(requestAborted, timeoutCts.Token);
+        try
+        {
+            await transport.Completion.WaitAsync(linkedCts.Token);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !requestAborted.IsCancellationRequested)
+        {
+        }
+        catch (OperationCanceledException) when (requestAborted.IsCancellationRequested)
+        {
+        }
+    }
+
+    private async Task CleanupAcceptedTransportAsync(
+        IVoiceVolatileMediaStreamPort mediaStreamPort,
+        VoicePresenceSessionLeaseHandle handle,
+        WebSocketVoiceTransport transport)
+    {
+        try
+        {
+            await mediaStreamPort.DetachAsync(handle, transport, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Failed to detach accepted voice transport during control-channel cleanup.");
+        }
+
+        await transport.DisposeAsync();
+    }
+
+    private async Task TryCloseAsync(WebSocket ws, string reason, TimeSpan timeout)
+    {
+        if (ws.State is not WebSocketState.Open and not WebSocketState.CloseReceived)
+            return;
+
+        try
+        {
+            using var cts = new CancellationTokenSource(timeout, _timeProvider);
+            await ws.CloseAsync(WebSocketCloseStatus.PolicyViolation, reason, cts.Token);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Failed to close voice WebSocket after upgrade.");
+        }
+    }
+}

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/VoiceWebSocketAttachOptions.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/VoiceWebSocketAttachOptions.cs
@@ -1,0 +1,12 @@
+namespace Aevatar.Foundation.VoicePresence.Hosting;
+
+public sealed class VoiceWebSocketAttachOptions
+{
+    public TimeSpan AttachTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    public TimeSpan CloseWaitTimeout { get; set; } = TimeSpan.FromMinutes(5);
+
+    public TimeSpan PolicyViolationCloseTimeout { get; set; } = TimeSpan.FromSeconds(2);
+
+    public int ConflictRetryAfterSeconds { get; set; } = 1;
+}

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/VoiceWebSocketAttachOptionsValidator.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/VoiceWebSocketAttachOptionsValidator.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Options;
+
+namespace Aevatar.Foundation.VoicePresence.Hosting;
+
+public sealed class VoiceWebSocketAttachOptionsValidator : IValidateOptions<VoiceWebSocketAttachOptions>
+{
+    public ValidateOptionsResult Validate(string? name, VoiceWebSocketAttachOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var failures = new List<string>();
+        if (options.AttachTimeout <= TimeSpan.Zero)
+            failures.Add($"{nameof(VoiceWebSocketAttachOptions.AttachTimeout)} must be positive.");
+
+        if (options.CloseWaitTimeout <= TimeSpan.Zero)
+            failures.Add($"{nameof(VoiceWebSocketAttachOptions.CloseWaitTimeout)} must be positive.");
+
+        if (options.PolicyViolationCloseTimeout <= TimeSpan.Zero)
+            failures.Add($"{nameof(VoiceWebSocketAttachOptions.PolicyViolationCloseTimeout)} must be positive.");
+
+        if (options.ConflictRetryAfterSeconds <= 0)
+            failures.Add($"{nameof(VoiceWebSocketAttachOptions.ConflictRetryAfterSeconds)} must be positive.");
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/Aevatar.Mainnet.Host.Api/Voice/PolicyAwareVoiceEndpointOptions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Voice/PolicyAwareVoiceEndpointOptions.cs
@@ -1,8 +1,0 @@
-namespace Aevatar.Mainnet.Host.Api.Voice;
-
-public sealed class PolicyAwareVoiceEndpointOptions
-{
-    public TimeSpan WebSocketCloseWaitTimeout { get; set; } = TimeSpan.FromMinutes(5);
-
-    public TimeSpan AttachTimeout { get; set; } = TimeSpan.FromSeconds(10);
-}

--- a/src/Aevatar.Mainnet.Host.Api/Voice/PolicyAwareVoiceEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Voice/PolicyAwareVoiceEndpoints.cs
@@ -6,13 +6,13 @@ using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.Foundation.VoicePresence.Abstractions;
 using Aevatar.Foundation.VoicePresence.Abstractions.Sessions;
 using Aevatar.Foundation.VoicePresence.Hosting;
-using Aevatar.Foundation.VoicePresence.Transport;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Aevatar.Mainnet.Host.Api.Voice;
 
@@ -20,7 +20,6 @@ public static class PolicyAwareVoiceEndpoints
 {
     private const string DefaultPattern = "/ws/voice";
     internal const string VoiceNotConfiguredReason = "voice_not_configured";
-    private const string RemoteAudioTransportUnavailableReason = "remote_audio_transport_unavailable";
     private const string VoiceCredentialUnavailableReason = "voice_credential_unavailable";
 
     public static IEndpointConventionBuilder MapPolicyAwareVoiceEndpoint(this IEndpointRouteBuilder app) =>
@@ -61,7 +60,9 @@ public static class PolicyAwareVoiceEndpoints
         [FromServices] IChatRoutePolicyQueryPort queryPort,
         [FromServices] ChatRouteResolver resolver,
         [FromServices] IRealtimeSession<VoiceRealtimeSessionRequest, VoiceRealtimeSessionAccepted, VoiceRealtimeSessionStartError, VoiceRealtimeFrame, VoiceRealtimeSessionCompletion> voiceRealtimeSession,
-        [FromServices] IVoiceVolatileMediaStreamPort mediaStreamPort)
+        [FromServices] IVoiceVolatileMediaStreamPort mediaStreamPort,
+        [FromServices] VoiceWebSocketAttachExecutor attachExecutor,
+        [FromServices] IOptions<VoiceWebSocketAttachOptions> attachOptions)
     {
         if (!http.WebSockets.IsWebSocketRequest)
         {
@@ -91,7 +92,13 @@ public static class PolicyAwareVoiceEndpoints
             case ChatRouteAction.ActionOneofCase.ForwardToModel:
                 if (ChatRouteActionTargets.TryGetVoiceAttachTarget(action, out var voiceTarget))
                 {
-                    await AttachVoiceTargetAsync(http, voiceRealtimeSession, mediaStreamPort, voiceTarget);
+                    await AttachVoiceTargetAsync(
+                        http,
+                        voiceRealtimeSession,
+                        mediaStreamPort,
+                        attachExecutor,
+                        attachOptions.Value,
+                        voiceTarget);
                     return;
                 }
 
@@ -111,6 +118,8 @@ public static class PolicyAwareVoiceEndpoints
         HttpContext http,
         IRealtimeSession<VoiceRealtimeSessionRequest, VoiceRealtimeSessionAccepted, VoiceRealtimeSessionStartError, VoiceRealtimeFrame, VoiceRealtimeSessionCompletion> voiceRealtimeSession,
         IVoiceVolatileMediaStreamPort mediaStreamPort,
+        VoiceWebSocketAttachExecutor attachExecutor,
+        VoiceWebSocketAttachOptions attachOptions,
         ChatRouteVoiceAttachTarget voiceTarget)
     {
         var toolContextAdmission = await TryBuildToolContextAsync(http);
@@ -129,75 +138,15 @@ public static class PolicyAwareVoiceEndpoints
                 static (_, _) => ValueTask.CompletedTask,
                 ct: http.RequestAborted);
 
-            var accepted = await WriteNonAcceptedResolutionAsync(http, result);
+            var accepted = await VoiceWebSocketAttachExecutor.WriteNonAcceptedResolutionAsync(http, result, attachOptions);
             if (accepted is null)
                 return;
 
-            var ws = await http.WebSockets.AcceptWebSocketAsync();
-            var logger = GetLogger(http);
-            var transport = new WebSocketVoiceTransport(ws, logger);
-            var attached = false;
-            // AcquireAsync returns a handle with an empty ActiveTransportLeaseId (the id is only known
-            // post-attach). Carry the resolved id so the close-time DetachAsync can stop the right relay
-            // and detach the transport — without it StopRelay/transport-detach are no-ops.
-            var detachHandle = accepted.LeaseHandle;
-            IAsyncDisposable? realtimeSubscription = null;
-            try
-            {
-                realtimeSubscription = await VoiceRealtimeTransportControlBridge.SubscribeAsync(
-                    http.RequestServices,
-                    accepted,
-                    transport,
-                    logger,
-                    http.RequestAborted);
-                try
-                {
-                    await VoiceRealtimeTransportControlBridge.SendSessionAcceptedAsync(
-                        transport,
-                        accepted,
-                        http.RequestAborted);
-                }
-                catch
-                {
-                    await CleanupAcceptedTransportAsync(http, mediaStreamPort, accepted.LeaseHandle, transport);
-                    throw;
-                }
-
-                var lifetimeCompleted = await mediaStreamPort.AttachAsync(
-                    accepted.LeaseHandle,
-                    transport,
-                    toolContextAdmission.TransportBinding,
-                    http.RequestAborted);
-                if (!string.IsNullOrWhiteSpace(lifetimeCompleted?.TransportLeaseId))
-                    detachHandle = detachHandle with { ActiveTransportLeaseId = lifetimeCompleted!.TransportLeaseId };
-
-                attached = true;
-                await WaitUntilClosedAsync(transport, http.RequestAborted);
-            }
-            catch (VoiceVolatileMediaStreamUnavailableException)
-            {
-                await TryCloseAsync(http, ws, RemoteAudioTransportUnavailableReason);
-            }
-            catch (VoiceVolatileToolCredentialUnavailableException)
-            {
-                await TryCloseAsync(http, ws, VoiceCredentialUnavailableReason);
-            }
-            catch (InvalidOperationException) when (!attached)
-            {
-                await TryCloseAsync(http, ws, "Voice transport already attached.");
-            }
-            finally
-            {
-                if (realtimeSubscription != null)
-                    await realtimeSubscription.DisposeAsync();
-
-                if (attached)
-                    // CancellationToken.None: on a normal browser close http.RequestAborted is ALREADY
-                    // cancelled, and the dispatch port throws on a cancelled token before producing the
-                    // release signal — so the lease would never be released and TransportAttached would
-                    // stay stuck true (blocking the next session with 409). Detach must run uncancelled.
-                    await mediaStreamPort.DetachAsync(detachHandle, transport, CancellationToken.None);
-            }
+            await attachExecutor.ExecuteAsync(
+                http,
+                accepted,
+                mediaStreamPort,
+                toolContextAdmission.TransportBinding);
         }
         finally
         {
@@ -348,101 +297,6 @@ public static class PolicyAwareVoiceEndpoints
 
         var queryToken = http.Request.Query["access_token"].ToString();
         return string.IsNullOrWhiteSpace(queryToken) ? null : queryToken.Trim();
-    }
-
-    private static async Task<VoiceRealtimeSessionAccepted?> WriteNonAcceptedResolutionAsync(
-        HttpContext http,
-        RealtimeSessionResult<VoiceRealtimeSessionAccepted, VoiceRealtimeSessionStartError, VoiceRealtimeSessionCompletion> result)
-    {
-        if (result.Succeeded)
-            return result.Receipt ?? throw new InvalidOperationException("Accepted voice realtime session requires a receipt.");
-
-        switch (result.Error)
-        {
-            case VoiceRealtimeSessionStartError.Unsupported:
-                http.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
-                await http.Response.WriteAsync(RemoteAudioTransportUnavailableReason, http.RequestAborted);
-                return null;
-            case VoiceRealtimeSessionStartError.NotFound:
-            case VoiceRealtimeSessionStartError.NotInitialized:
-            case VoiceRealtimeSessionStartError.TransportAlreadyAttached:
-                await WritePreflightFailureAsync(http, result.Error);
-                return null;
-            default:
-                http.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
-                await http.Response.WriteAsync("Voice realtime session failed.", http.RequestAborted);
-                return null;
-        }
-    }
-
-    private static async Task WritePreflightFailureAsync(
-        HttpContext http,
-        VoiceRealtimeSessionStartError failure)
-    {
-        switch (failure)
-        {
-            case VoiceRealtimeSessionStartError.NotFound:
-                http.Response.StatusCode = StatusCodes.Status404NotFound;
-                await http.Response.WriteAsync("Voice session not found for this agent.", http.RequestAborted);
-                break;
-            case VoiceRealtimeSessionStartError.NotInitialized:
-                http.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
-                await http.Response.WriteAsync("Voice module not initialized.", http.RequestAborted);
-                break;
-            case VoiceRealtimeSessionStartError.TransportAlreadyAttached:
-                http.Response.StatusCode = StatusCodes.Status409Conflict;
-                await http.Response.WriteAsync("Voice transport already attached.", http.RequestAborted);
-                break;
-            default:
-                http.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
-                await http.Response.WriteAsync("Voice session preflight failed.", http.RequestAborted);
-                break;
-        }
-    }
-
-    private static async Task TryCloseAsync(HttpContext http, System.Net.WebSockets.WebSocket ws, string reason)
-    {
-        if (ws.State is not System.Net.WebSockets.WebSocketState.Open and not System.Net.WebSockets.WebSocketState.CloseReceived)
-            return;
-
-        try
-        {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-            await ws.CloseAsync(System.Net.WebSockets.WebSocketCloseStatus.PolicyViolation, reason, cts.Token);
-        }
-        catch (Exception ex)
-        {
-            GetLogger(http).LogWarning(ex, "Failed to close voice WebSocket after upgrade.");
-        }
-    }
-
-    private static async Task WaitUntilClosedAsync(WebSocketVoiceTransport transport, CancellationToken ct)
-    {
-        try
-        {
-            await transport.Completion.WaitAsync(ct);
-        }
-        catch (OperationCanceledException)
-        {
-        }
-    }
-
-    private static async Task CleanupAcceptedTransportAsync(
-        HttpContext http,
-        IVoiceVolatileMediaStreamPort mediaStreamPort,
-        VoicePresenceSessionLeaseHandle handle,
-        WebSocketVoiceTransport transport)
-    {
-        try
-        {
-            await mediaStreamPort.DetachAsync(handle, transport, CancellationToken.None);
-        }
-        catch (Exception ex)
-        {
-            GetLogger(http).LogWarning(ex, "Failed to detach accepted voice transport during control-channel cleanup.");
-        }
-
-        await transport.DisposeAsync();
     }
 
     private static ILogger GetLogger(HttpContext http) =>

--- a/test/Aevatar.Bootstrap.Tests/VoicePresenceBootstrapTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/VoicePresenceBootstrapTests.cs
@@ -33,6 +33,56 @@ public sealed class VoicePresenceBootstrapTests
     }
 
     [Fact]
+    public void AddAevatarAIFeatures_ShouldRegisterVoiceWebSocketAttachExecutor()
+    {
+        using var envScope = new EnvironmentVariablesScope(new Dictionary<string, string?>
+        {
+            ["OPENAI_API_KEY"] = null,
+        });
+        var services = new ServiceCollection();
+        var config = new ConfigurationBuilder().Build();
+
+        services.AddAevatarAIFeatures(config, options =>
+        {
+            options.EnableMEAIProviders = false;
+            options.VoicePresence.MiniCPMProvider = new VoiceProviderConfig
+            {
+                ProviderName = "minicpm",
+                Endpoint = "https://minicpm.example.com",
+            };
+            options.VoicePresence.MiniCPMSession = new VoiceSessionConfig
+            {
+                SampleRateHz = 16000,
+            };
+        });
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<VoiceWebSocketAttachExecutor>()
+            .Should().NotBeNull();
+        provider.GetRequiredService<Microsoft.Extensions.Options.IOptions<VoiceWebSocketAttachOptions>>()
+            .Value.ConflictRetryAfterSeconds.Should().Be(1);
+    }
+
+    [Fact]
+    public void VoiceWebSocketAttachOptionsValidator_ShouldRejectInvalidTimeouts()
+    {
+        var validator = new VoiceWebSocketAttachOptionsValidator();
+        var result = validator.Validate(null, new VoiceWebSocketAttachOptions
+        {
+            AttachTimeout = TimeSpan.Zero,
+            CloseWaitTimeout = TimeSpan.Zero,
+            PolicyViolationCloseTimeout = TimeSpan.Zero,
+            ConflictRetryAfterSeconds = 0,
+        });
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(failure => failure.Contains(nameof(VoiceWebSocketAttachOptions.AttachTimeout)));
+        result.Failures.Should().Contain(failure => failure.Contains(nameof(VoiceWebSocketAttachOptions.CloseWaitTimeout)));
+        result.Failures.Should().Contain(failure => failure.Contains(nameof(VoiceWebSocketAttachOptions.PolicyViolationCloseTimeout)));
+        result.Failures.Should().Contain(failure => failure.Contains(nameof(VoiceWebSocketAttachOptions.ConflictRetryAfterSeconds)));
+    }
+
+    [Fact]
     public void AddAevatarAIFeatures_WhenVoicePresenceOpenAIEndpointOnlyConfigured_ShouldRegisterOpenAIThroughBroker()
     {
         using var envScope = new EnvironmentVariablesScope(new Dictionary<string, string?>

--- a/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
+++ b/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
@@ -20,6 +20,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Xunit;
 using RoutingOwnerScope = Aevatar.Foundation.Abstractions.OwnerScope;
 using ScheduledOwnerScope = Aevatar.Foundation.Abstractions.OwnerScope;
@@ -471,6 +472,9 @@ public sealed class PolicyAwareVoiceEndpointsTests
         await GetEndpoint(app, "/ws/voice").RequestDelegate!(context);
 
         context.Response.StatusCode.Should().Be(expectedStatusCode);
+        if (expectedStatusCode == StatusCodes.Status409Conflict)
+            context.Response.Headers.RetryAfter.ToString().Should().Be("1");
+
         (await ReadBodyAsync(context)).Should().Be(expectedBody);
         wsFeature.AcceptCalls.Should().Be(0);
         session.Requests.Should().ContainSingle()
@@ -654,7 +658,7 @@ public sealed class PolicyAwareVoiceEndpointsTests
         RecordingCatalogQueryPort catalog,
         RecordingVoiceRealtimeSession session,
         RecordingVolatileMediaStreamPort? mediaPort = null,
-        Action<PolicyAwareVoiceEndpointOptions>? configureOptions = null,
+        Action<VoiceWebSocketAttachOptions>? configureOptions = null,
         IProjectionSessionEventHub<VoiceRealtimeFrame>? realtimeHub = null,
         IVoiceToolCredentialIssuer? toolCredentialIssuer = null)
     {
@@ -664,6 +668,9 @@ public sealed class PolicyAwareVoiceEndpointsTests
         });
         if (configureOptions != null)
             builder.Services.Configure(configureOptions);
+        builder.Services.AddOptions<VoiceWebSocketAttachOptions>();
+        builder.Services.AddSingleton<IValidateOptions<VoiceWebSocketAttachOptions>, VoiceWebSocketAttachOptionsValidator>();
+        builder.Services.AddSingleton<VoiceWebSocketAttachExecutor>();
         builder.Services.AddSingleton<IChatRoutePolicyQueryPort>(policyPort);
         builder.Services.AddSingleton(new ChatRouteResolver(new StaticFallbackProvider("fallback-model")));
         builder.Services.AddSingleton<IUserAgentCatalogQueryPort>(catalog);

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceEndpointsTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceEndpointsTests.cs
@@ -13,6 +13,8 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Shouldly;
 
 namespace Aevatar.Foundation.VoicePresence.Tests;
@@ -337,6 +339,7 @@ public class VoicePresenceEndpointsTests
         accepted.SessionAccepted.InputImagePolicy.MaxBytes.ShouldBe(VoiceWireContractDefaults.MaxInputImageBytes);
         accepted.SessionAccepted.InputImagePolicy.AllowedMediaTypes
             .ShouldBe(VoiceWireContractDefaults.SupportedInputImageMediaTypes);
+        accepted.SessionAccepted.AttachOutcome.ShouldBe(VoiceTransportAttachOutcome.NewSession);
 
         var realtime = JsonParser.Default.Parse<VoiceControlFrame>(socket.SentTexts[1]);
         realtime.FrameCase.ShouldBe(VoiceControlFrame.FrameOneofCase.RealtimeFrame);
@@ -351,16 +354,122 @@ public class VoicePresenceEndpointsTests
         mediaPort.DetachCalls.ShouldBe(1);
     }
 
+    [Fact]
+    public async Task Control_bridge_should_map_restart_attach_outcome_to_session_accepted()
+    {
+        var transport = new RecordingVoiceTransport();
+        var accepted = new VoiceRealtimeSessionAccepted(
+            "agent-1",
+            "voice_presence",
+            "session-1",
+            24000,
+            42,
+            CreateLeaseHandle(),
+            AttachOutcome: VoiceRealtimeAttachOutcome.Restarted);
+
+        await VoiceRealtimeTransportControlBridge.SendSessionAcceptedAsync(
+            transport,
+            accepted,
+            CancellationToken.None);
+
+        var control = transport.SentControls.ShouldHaveSingleItem();
+        control.FrameCase.ShouldBe(VoiceControlFrame.FrameOneofCase.SessionAccepted);
+        control.SessionAccepted.AttachOutcome.ShouldBe(VoiceTransportAttachOutcome.Restarted);
+    }
+
+    [Fact]
+    public async Task Request_should_return_retry_after_when_transport_is_already_attached()
+    {
+        var socket = new FakeWebSocket(WebSocketState.Open);
+        using var app = CreateApp(new RecordingRealtimeSession(VoiceRealtimeSessionStartError.TransportAlreadyAttached));
+        var context = CreateHttpContext(app);
+        context.Features.Set<IHttpWebSocketFeature>(new FakeHttpWebSocketFeature(socket));
+        context.Request.RouteValues["actorId"] = "agent-1";
+
+        await GetVoiceEndpoint(app).RequestDelegate!(context);
+
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status409Conflict);
+        context.Response.Headers.RetryAfter.ToString().ShouldBe("1");
+        (await ReadBodyAsync(context)).ShouldContain("Voice transport already attached.");
+        socket.CloseCalls.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Executor_should_close_websocket_when_attach_times_out()
+    {
+        var timeProvider = new ControllableTimeProvider(DateTimeOffset.Parse("2026-06-19T00:00:00Z"));
+        var executor = CreateExecutor(
+            timeProvider,
+            options =>
+            {
+                options.AttachTimeout = TimeSpan.FromSeconds(5);
+                options.CloseWaitTimeout = TimeSpan.FromSeconds(60);
+            });
+        var socket = new FakeWebSocket(WebSocketState.Open, keepOpenUntilCancelledWhenEmpty: true);
+        var mediaPort = new TimeoutAttachMediaStreamPort(timeProvider, TimeSpan.FromSeconds(5));
+        using var app = CreateApp(new RecordingRealtimeSession(), mediaPort);
+        var context = CreateHttpContext(app);
+        context.Features.Set<IHttpWebSocketFeature>(new FakeHttpWebSocketFeature(socket));
+        var accepted = new VoiceRealtimeSessionAccepted(
+            "agent-1",
+            "voice_presence",
+            "session-1",
+            24000,
+            42,
+            CreateLeaseHandle());
+
+        await executor.ExecuteAsync(context, accepted, mediaPort);
+
+        mediaPort.AttachCanceled.ShouldBeTrue();
+        socket.CloseCalls.ShouldBe(1);
+        socket.LastCloseStatus.ShouldBe(WebSocketCloseStatus.PolicyViolation);
+        socket.LastCloseDescription.ShouldBe("Voice transport attach timed out.");
+        mediaPort.DetachCalls.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Executor_should_detach_when_close_wait_times_out()
+    {
+        var timeProvider = new ControllableTimeProvider(DateTimeOffset.Parse("2026-06-19T00:00:00Z"));
+        var executor = CreateExecutor(
+            timeProvider,
+            options =>
+            {
+                options.AttachTimeout = TimeSpan.FromSeconds(60);
+                options.CloseWaitTimeout = TimeSpan.FromSeconds(5);
+            });
+        var socket = new FakeWebSocket(WebSocketState.Open, keepOpenUntilCancelledWhenEmpty: true);
+        var mediaPort = new CloseWaitTimeoutMediaStreamPort();
+        using var app = CreateApp(new RecordingRealtimeSession(), mediaPort);
+        var context = CreateHttpContext(app);
+        context.Features.Set<IHttpWebSocketFeature>(new FakeHttpWebSocketFeature(socket));
+        var accepted = new VoiceRealtimeSessionAccepted(
+            "agent-1",
+            "voice_presence",
+            "session-1",
+            24000,
+            42,
+            CreateLeaseHandle());
+
+        var executeTask = executor.ExecuteAsync(context, accepted, mediaPort);
+        await mediaPort.WaitForAttachReturnAsync();
+        timeProvider.Advance(TimeSpan.FromSeconds(5));
+        await executeTask;
+
+        mediaPort.AttachCalls.ShouldBe(1);
+        mediaPort.DetachCalls.ShouldBe(1);
+    }
+
     private static WebApplication CreateApp(
         RecordingRealtimeSession session,
-        RecordingVolatileMediaStreamPort? mediaPort = null,
+        IVoiceVolatileMediaStreamPort? mediaPort = null,
         IProjectionSessionEventHub<VoiceRealtimeFrame>? realtimeHub = null) =>
         CreateApp("/voice/{actorId}", session, mediaPort, realtimeHub);
 
     private static WebApplication CreateApp(
         string pattern,
         RecordingRealtimeSession session,
-        RecordingVolatileMediaStreamPort? mediaPort = null,
+        IVoiceVolatileMediaStreamPort? mediaPort = null,
         IProjectionSessionEventHub<VoiceRealtimeFrame>? realtimeHub = null)
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
@@ -369,6 +478,9 @@ public class VoicePresenceEndpointsTests
         });
         builder.Services.AddSingleton<IRealtimeSession<VoiceRealtimeSessionRequest, VoiceRealtimeSessionAccepted, VoiceRealtimeSessionStartError, VoiceRealtimeFrame, VoiceRealtimeSessionCompletion>>(session);
         builder.Services.AddSingleton<IVoiceVolatileMediaStreamPort>(mediaPort ?? new RecordingVolatileMediaStreamPort());
+        builder.Services.AddOptions<VoiceWebSocketAttachOptions>();
+        builder.Services.AddSingleton<IValidateOptions<VoiceWebSocketAttachOptions>, VoiceWebSocketAttachOptionsValidator>();
+        builder.Services.AddSingleton<VoiceWebSocketAttachExecutor>();
         if (realtimeHub != null)
             builder.Services.AddSingleton(realtimeHub);
         var app = builder.Build();
@@ -412,6 +524,18 @@ public class VoicePresenceEndpointsTests
             VoiceRemoteAudioSupport.Supported,
             "transport-1");
 
+    private static VoiceWebSocketAttachExecutor CreateExecutor(
+        TimeProvider timeProvider,
+        Action<VoiceWebSocketAttachOptions> configure)
+    {
+        var options = new VoiceWebSocketAttachOptions();
+        configure(options);
+        return new VoiceWebSocketAttachExecutor(
+            Options.Create(options),
+            LoggerFactory.Create(static _ => { }).CreateLogger<VoiceWebSocketAttachExecutor>(),
+            timeProvider);
+    }
+
     private sealed class RecordingRealtimeSession(
         VoiceRealtimeSessionStartError? failure = null)
         : IRealtimeSession<VoiceRealtimeSessionRequest, VoiceRealtimeSessionAccepted, VoiceRealtimeSessionStartError, VoiceRealtimeFrame, VoiceRealtimeSessionCompletion>
@@ -451,7 +575,7 @@ public class VoicePresenceEndpointsTests
         }
     }
 
-    private sealed class RecordingVolatileMediaStreamPort(
+    private class RecordingVolatileMediaStreamPort(
         Func<IVoiceTransport, CancellationToken, Task>? attachAsync = null,
         string transportLeaseId = "transport-1")
         : IVoiceVolatileMediaStreamPort
@@ -490,13 +614,13 @@ public class VoicePresenceEndpointsTests
 
         public VoicePresenceSessionLeaseHandle? LastDetachedHandle { get; private set; }
 
-        public async Task<VoiceTransportLifetimeCompleted?> AttachAsync(
+        public virtual async Task<VoiceTransportLifetimeCompleted?> AttachAsync(
             VoicePresenceSessionLeaseHandle handle,
             IVoiceTransport transport,
             CancellationToken ct = default)
             => await AttachAsync(handle, transport, null, ct);
 
-        public async Task<VoiceTransportLifetimeCompleted?> AttachAsync(
+        public virtual async Task<VoiceTransportLifetimeCompleted?> AttachAsync(
             VoicePresenceSessionLeaseHandle handle,
             IVoiceTransport transport,
             VoiceToolCredentialTransportBinding? toolCredentialBinding,
@@ -527,7 +651,7 @@ public class VoicePresenceEndpointsTests
             };
         }
 
-        public Task DetachAsync(
+        public virtual Task DetachAsync(
             VoicePresenceSessionLeaseHandle handle,
             IVoiceTransport? expectedTransport,
             CancellationToken ct = default)
@@ -536,6 +660,100 @@ public class VoicePresenceEndpointsTests
             ct.ThrowIfCancellationRequested();
             DetachCalls++;
             LastDetachedHandle = handle;
+            return Task.CompletedTask;
+        }
+
+        public virtual Task CompleteTransportLifetimeAsync(
+            VoicePresenceSessionLeaseHandle handle,
+            VoiceTransportLifetimeCompleted? completed,
+            string reason,
+            CancellationToken ct = default)
+        {
+            _ = handle;
+            _ = completed;
+            _ = reason;
+            ct.ThrowIfCancellationRequested();
+            LifetimeCompletionCalls++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TimeoutAttachMediaStreamPort(
+        ControllableTimeProvider timeProvider,
+        TimeSpan timeout) : IVoiceVolatileMediaStreamPort
+    {
+        public bool SupportsRemoteAudio => true;
+
+        public bool AttachCanceled { get; private set; }
+
+        public int DetachCalls { get; private set; }
+
+        public Task<bool> TryCancelResponseAsync(
+            string transportLeaseId,
+            CancellationToken ct = default) =>
+            Task.FromResult(false);
+
+        public Task<bool> TrySendInputImageAsync(
+            string transportLeaseId,
+            VoiceInputImage inputImage,
+            CancellationToken ct = default) =>
+            Task.FromResult(false);
+
+        public Task<bool> TrySendToolResultAsync(
+            string transportLeaseId,
+            string callId,
+            string resultJson,
+            CancellationToken ct = default) =>
+            Task.FromResult(false);
+
+        public Task<bool> TryInjectEventAsync(
+            string transportLeaseId,
+            VoiceConversationEventInjection injection,
+            CancellationToken ct = default) =>
+            Task.FromResult(false);
+
+        public Task<VoiceTransportLifetimeCompleted?> AttachAsync(
+            VoicePresenceSessionLeaseHandle handle,
+            IVoiceTransport transport,
+            CancellationToken ct = default) =>
+            AttachAsync(handle, transport, null, ct);
+
+        public async Task<VoiceTransportLifetimeCompleted?> AttachAsync(
+            VoicePresenceSessionLeaseHandle handle,
+            IVoiceTransport transport,
+            VoiceToolCredentialTransportBinding? toolCredentialBinding,
+            CancellationToken ct = default)
+        {
+            _ = handle;
+            _ = transport;
+            _ = toolCredentialBinding;
+            try
+            {
+                var wait = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                using var registration = ct.Register(static state =>
+                {
+                    ((TaskCompletionSource)state!).TrySetCanceled();
+                }, wait);
+                timeProvider.Advance(timeout);
+                await wait.Task;
+                return null;
+            }
+            catch (OperationCanceledException)
+            {
+                AttachCanceled = true;
+                throw;
+            }
+        }
+
+        public Task DetachAsync(
+            VoicePresenceSessionLeaseHandle handle,
+            IVoiceTransport? expectedTransport,
+            CancellationToken ct = default)
+        {
+            _ = handle;
+            _ = expectedTransport;
+            ct.ThrowIfCancellationRequested();
+            DetachCalls++;
             return Task.CompletedTask;
         }
 
@@ -549,8 +767,152 @@ public class VoicePresenceEndpointsTests
             _ = completed;
             _ = reason;
             ct.ThrowIfCancellationRequested();
-            LifetimeCompletionCalls++;
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class CloseWaitTimeoutMediaStreamPort() : RecordingVolatileMediaStreamPort(
+            attachAsync: static (_, _) => Task.CompletedTask)
+    {
+        private readonly TaskCompletionSource _attachReturned =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override async Task<VoiceTransportLifetimeCompleted?> AttachAsync(
+            VoicePresenceSessionLeaseHandle handle,
+            IVoiceTransport transport,
+            VoiceToolCredentialTransportBinding? toolCredentialBinding,
+            CancellationToken ct = default)
+        {
+            var completed = await base.AttachAsync(handle, transport, toolCredentialBinding, ct);
+            _attachReturned.TrySetResult();
+            return completed;
+        }
+
+        public Task WaitForAttachReturnAsync() => _attachReturned.Task;
+    }
+
+    private sealed class ControllableTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        private readonly object _gate = new();
+        private readonly List<ManualTimer> _timers = [];
+        private DateTimeOffset _utcNow = utcNow;
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            lock (_gate)
+            {
+                return _utcNow;
+            }
+        }
+
+        public void Advance(TimeSpan delta)
+        {
+            ManualTimer[] timers;
+            lock (_gate)
+            {
+                _utcNow = _utcNow.Add(delta);
+                timers = _timers.ToArray();
+            }
+
+            foreach (var timer in timers)
+                timer.FireIfDue();
+        }
+
+        public override ITimer CreateTimer(
+            TimerCallback callback,
+            object? state,
+            TimeSpan dueTime,
+            TimeSpan period)
+        {
+            var timer = new ManualTimer(this, callback, state, dueTime, period);
+            lock (_gate)
+            {
+                _timers.Add(timer);
+            }
+
+            timer.FireIfDue();
+            return timer;
+        }
+
+        private void Remove(ManualTimer timer)
+        {
+            lock (_gate)
+            {
+                _timers.Remove(timer);
+            }
+        }
+
+        private sealed class ManualTimer(
+            ControllableTimeProvider owner,
+            TimerCallback callback,
+            object? state,
+            TimeSpan dueTime,
+            TimeSpan period) : ITimer
+        {
+            private readonly object _gate = new();
+            private TimeSpan _period = period;
+            private DateTimeOffset? _dueAt = ResolveDueAt(owner.GetUtcNow(), dueTime);
+            private bool _disposed;
+
+            public bool Change(TimeSpan dueTime, TimeSpan period)
+            {
+                lock (_gate)
+                {
+                    if (_disposed)
+                        return false;
+
+                    _period = period;
+                    _dueAt = ResolveDueAt(owner.GetUtcNow(), dueTime);
+                }
+
+                FireIfDue();
+                return true;
+            }
+
+            public void FireIfDue()
+            {
+                while (true)
+                {
+                    lock (_gate)
+                    {
+                        if (_disposed || !_dueAt.HasValue || owner.GetUtcNow() < _dueAt.Value)
+                            return;
+
+                        if (_period == Timeout.InfiniteTimeSpan)
+                        {
+                            _dueAt = null;
+                        }
+                        else
+                        {
+                            _dueAt = owner.GetUtcNow().Add(_period);
+                        }
+                    }
+
+                    callback(state);
+                }
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                Dispose();
+                return ValueTask.CompletedTask;
+            }
+
+            public void Dispose()
+            {
+                lock (_gate)
+                {
+                    if (_disposed)
+                        return;
+
+                    _disposed = true;
+                }
+
+                owner.Remove(this);
+            }
+
+            private static DateTimeOffset? ResolveDueAt(DateTimeOffset now, TimeSpan dueTime) =>
+                dueTime == Timeout.InfiniteTimeSpan ? null : now.Add(dueTime);
         }
     }
 
@@ -604,6 +966,34 @@ public class VoicePresenceEndpointsTests
                 return ValueTask.CompletedTask;
             }
         }
+    }
+
+    private sealed class RecordingVoiceTransport : IVoiceTransport
+    {
+        public List<VoiceControlFrame> SentControls { get; } = [];
+
+        public Task SendAudioAsync(ReadOnlyMemory<byte> pcm16, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public Task SendControlAsync(VoiceControlFrame frame, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            SentControls.Add(frame.Clone());
+            return Task.CompletedTask;
+        }
+
+        public async IAsyncEnumerable<VoiceTransportFrame> ReceiveFramesAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
     private sealed class RecordingCloseWebSocket : WebSocket

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceProtoTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceProtoTests.cs
@@ -38,12 +38,13 @@ public class VoicePresenceProtoTests
             {
                 ActorId = "agent-1",
                 ModuleName = "voice_presence",
-                SessionId = "session-1",
-                PcmSampleRateHz = 24000,
-                ObservedStateVersion = 5,
-                WireContractVersion = VoiceWireContractDefaults.CurrentWireContractVersion,
-                InputImagePolicy = VoiceWireContractDefaults.CreateInputImagePolicy(),
-            },
+            SessionId = "session-1",
+            PcmSampleRateHz = 24000,
+            ObservedStateVersion = 5,
+            WireContractVersion = VoiceWireContractDefaults.CurrentWireContractVersion,
+            InputImagePolicy = VoiceWireContractDefaults.CreateInputImagePolicy(),
+            AttachOutcome = VoiceTransportAttachOutcome.NewSession,
+        },
         };
         var providerConfig = new VoiceProviderConfig
         {
@@ -73,6 +74,7 @@ public class VoicePresenceProtoTests
         parsedControl.SessionAccepted.InputImagePolicy.MaxBytes.ShouldBe(VoiceWireContractDefaults.MaxInputImageBytes);
         parsedControl.SessionAccepted.InputImagePolicy.AllowedMediaTypes
             .ShouldBe(VoiceWireContractDefaults.SupportedInputImageMediaTypes);
+        parsedControl.SessionAccepted.AttachOutcome.ShouldBe(VoiceTransportAttachOutcome.NewSession);
 
         providerConfig.Clone().ShouldBe(providerConfig);
         sessionConfig.Clone().ShouldBe(sessionConfig);
@@ -92,6 +94,10 @@ public class VoicePresenceProtoTests
         VoiceTransportSessionAccepted.Descriptor.Fields.InDeclarationOrder()
             .Select(static field => field.Name)
             .ShouldContain("input_image_policy");
+        VoiceTransportSessionAccepted.Descriptor.Fields["attach_outcome"].FieldNumber.ShouldBe(8);
+        ((int)VoiceTransportAttachOutcome.Unspecified).ShouldBe(0);
+        ((int)VoiceTransportAttachOutcome.NewSession).ShouldBe(1);
+        ((int)VoiceTransportAttachOutcome.Restarted).ShouldBe(2);
         VoiceInputImagePolicy.Descriptor.Fields.InDeclarationOrder()
             .Select(static field => field.Name)
             .ShouldBe([

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoiceRealtimeSessionTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoiceRealtimeSessionTests.cs
@@ -67,6 +67,7 @@ public class VoiceRealtimeSessionTests
         result.Receipt.PcmSampleRateHz.ShouldBe(16000);
         result.Receipt.ObservedStateVersion.ShouldBe(5);
         result.Receipt.LeaseHandle.LeaseEpoch.ShouldBe(7);
+        result.Receipt.AttachOutcome.ShouldBe(VoiceRealtimeAttachOutcome.NewSession);
         acceptedCallbacks.ShouldHaveSingleItem().SessionId.ShouldBe(result.Receipt.SessionId);
         var acquireRequest = leasePort.AcquireRequests.ShouldHaveSingleItem();
         acquireRequest.ModuleName.ShouldBe("voice_presence_openai");
@@ -198,6 +199,8 @@ public class VoiceRealtimeSessionTests
         result.Succeeded.ShouldBeTrue();
         mediaPort.DetachedHandles.ShouldHaveSingleItem().SessionId.ShouldBe("old-session");
         leasePort.AcquireRequests.ShouldHaveSingleItem();
+        result.Receipt.ShouldNotBeNull();
+        result.Receipt.AttachOutcome.ShouldBe(VoiceRealtimeAttachOutcome.Restarted);
     }
 
     [Fact]
@@ -260,6 +263,8 @@ public class VoiceRealtimeSessionTests
         attachResult.Succeeded.ShouldBeTrue();
         mediaPort.DetachedHandles.ShouldHaveSingleItem().SessionId.ShouldBe("session-1");
         leasePort.AcquireRequests.ShouldHaveSingleItem();
+        attachResult.Receipt.ShouldNotBeNull();
+        attachResult.Receipt.AttachOutcome.ShouldBe(VoiceRealtimeAttachOutcome.Restarted);
         detachResult.Succeeded.ShouldBeTrue();
         detachResult.Receipt.ShouldNotBeNull();
         detachResult.Receipt.SessionId.ShouldBe("session-1");


### PR DESCRIPTION
## Changed files
统一 Foundation 与 Mainnet 的 Voice WebSocket attach 生命周期，新增 Foundation 托管的 attach executor、timeout options 与 validator，并删除 Mainnet 局部 timeout options。`VoiceTransportSessionAccepted` 新增 `attach_outcome` 字段 8，fresh attach 映射为 NEW_SESSION，takeover/eviction 映射为 RESTARTED，`session_id` 保持身份语义。

## Test results
已通过 `dotnet build aevatar.slnx --nologo`、两个 verification-hint 测试项目、Bootstrap 相关测试、`test_stability_guards.sh`、`architecture_guards.sh` 与 `dotnet test aevatar.slnx --nologo`。

## Deviations
refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)。未修改外部 `/Users/chronoai/Code/voice-presence`；该仓库的 parser/reset/backoff companion work 仍是端到端验收的后续工作。Closes #2270

⟦AI:AUTO-LOOP⟧
