### PR TITLE
Implement typed LLM run-start observation

### DIFF
--- a/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
@@ -93,6 +93,7 @@ message LlmSessionRunScope {
   google.protobuf.Timestamp completed_at = 8;
   string failure_code = 9;
   string failure_message = 10;
+  int64 last_applied_sequence = 11;
 }
 
 message LlmSessionState {
@@ -225,6 +226,13 @@ message LlmRunRequested {
   aevatar.ai.AgentToolExecutionContextPayload tool_context = 13;
 }
 
+message LlmRunStartedEvent {
+  string response_id = 1;
+  string run_id = 2;
+  int64 sequence = 3;
+  google.protobuf.Timestamp started_at = 4;
+}
+
 message LlmStreamChunkObserved {
   string response_id = 1;
   string run_id = 2;
@@ -233,6 +241,7 @@ message LlmStreamChunkObserved {
   LlmSessionRuntimeToolCall tool_call_delta = 5;
   LlmSessionTokenUsage usage = 6;
   google.protobuf.Timestamp observed_at = 7;
+  int64 sequence = 8;
 }
 
 message LlmToolCallObserved {
@@ -244,6 +253,7 @@ message LlmToolCallObserved {
   string local_result_json = 6;
   google.protobuf.Timestamp observed_at = 7;
   google.protobuf.Value local_result = 8;
+  int64 sequence = 9;
 }
 
 message LlmRunCompleted {
@@ -253,6 +263,7 @@ message LlmRunCompleted {
   repeated LlmSessionRuntimeToolCall forwarded_tool_calls = 4;
   LlmSessionTokenUsage usage = 5;
   google.protobuf.Timestamp completed_at = 6;
+  int64 sequence = 7;
 }
 
 message LlmRunFailed {
@@ -261,12 +272,14 @@ message LlmRunFailed {
   string failure_code = 3;
   string failure_message = 4;
   google.protobuf.Timestamp failed_at = 5;
+  int64 sequence = 6;
 }
 
 message LlmRunCancelled {
   string response_id = 1;
   string run_id = 2;
   google.protobuf.Timestamp cancelled_at = 3;
+  int64 sequence = 4;
 }
 
 enum ChatRunSubRunWaitMode {

--- a/src/platform/Aevatar.GAgentService.Application/Responses/LlmSessionRunObservationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/LlmSessionRunObservationService.cs
@@ -64,6 +64,11 @@ public sealed class LlmSessionRunObservationService(
                 if (!TryGetObservedPayload(envelope, out var payload))
                     continue;
 
+                if (payload.Is(LlmRunStartedEvent.Descriptor))
+                {
+                    continue;
+                }
+
                 if (payload.Is(LlmStreamChunkObserved.Descriptor))
                 {
                     var delta = accumulator.ObserveChunk(payload.Unpack<LlmStreamChunkObserved>());

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
@@ -296,12 +296,18 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
             return;
 
         var startedAt = command.RequestedAt ?? Timestamp.FromDateTime(DateTime.UtcNow);
-        await PersistDomainEventAsync(new LlmStreamChunkObserved
+        if (State.ActiveRun == null ||
+            !string.Equals(State.ActiveRun.RunId, runId, StringComparison.Ordinal) ||
+            State.ActiveRun.LastAppliedSequence <= 0)
         {
-            ResponseId = existing.ResponseId,
-            RunId = runId,
-            ObservedAt = startedAt,
-        });
+            await PersistDomainEventAsync(new LlmRunStartedEvent
+            {
+                ResponseId = existing.ResponseId,
+                RunId = runId,
+                Sequence = 1,
+                StartedAt = startedAt,
+            });
+        }
 
         var runCore = Services.GetRequiredService<ILlmRunCore>();
         await runCore.RunAsync(
@@ -319,6 +325,7 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
             .On<LlmSessionForwardedToolCallEmittedEvent>(ApplyForwardedToolCallEmitted)
             .On<LlmSessionForwardedToolResultReceivedEvent>(ApplyForwardedToolResultReceived)
             .On<LlmSessionForwardedToolCallResolvedEvent>(ApplyForwardedToolCallResolved)
+            .On<LlmRunStartedEvent>(ApplyRunStarted)
             .On<LlmStreamChunkObserved>(ApplyStreamChunkObserved)
             .On<LlmToolCallObserved>(ApplyToolCallObserved)
             .On<LlmRunCompleted>(ApplyRunCompleted)
@@ -429,12 +436,32 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
         return next;
     }
 
+    private static LlmSessionState ApplyRunStarted(
+        LlmSessionState state,
+        LlmRunStartedEvent evt)
+    {
+        var next = state.Clone();
+        var startedAt = evt.StartedAt ?? Timestamp.FromDateTime(DateTime.UtcNow);
+        var run = EnsureRun(next, evt.RunId, evt.ResponseId, startedAt);
+        if (!TryAcceptRunSequence(run, evt.Sequence))
+            return state;
+
+        run.Status = RunningStatus;
+        run.StartedAt = startedAt.Clone();
+        TouchRecord(next, startedAt);
+        Bump(next, $"{evt.ResponseId}:run:{evt.RunId}:started");
+        return next;
+    }
+
     private static LlmSessionState ApplyStreamChunkObserved(
         LlmSessionState state,
         LlmStreamChunkObserved evt)
     {
         var next = state.Clone();
         var run = EnsureRun(next, evt.RunId, evt.ResponseId, evt.ObservedAt);
+        if (!TryAcceptRunSequence(run, evt.Sequence))
+            return state;
+
         run.Round = Math.Max(run.Round, evt.Round);
         if (!string.IsNullOrEmpty(evt.DeltaText))
             run.OutputText += evt.DeltaText;
@@ -451,6 +478,9 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
     {
         var next = state.Clone();
         var run = EnsureRun(next, evt.RunId, evt.ResponseId, evt.ObservedAt);
+        if (!TryAcceptRunSequence(run, evt.Sequence))
+            return state;
+
         run.Round = Math.Max(run.Round, evt.Round);
         if (evt.ToolCall != null)
             UpsertRuntimeToolCall(run, evt.ToolCall);
@@ -466,6 +496,9 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
         var next = state.Clone();
         var completedAt = evt.CompletedAt ?? Timestamp.FromDateTime(DateTime.UtcNow);
         var run = EnsureRun(next, evt.RunId, evt.ResponseId, completedAt);
+        if (!TryAcceptRunSequence(run, evt.Sequence))
+            return state;
+
         run.Status = CompletedStatus;
         run.OutputText = evt.OutputText ?? string.Empty;
         run.CompletedAt = completedAt.Clone();
@@ -505,6 +538,9 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
         var next = state.Clone();
         var failedAt = evt.FailedAt ?? Timestamp.FromDateTime(DateTime.UtcNow);
         var run = EnsureRun(next, evt.RunId, evt.ResponseId, failedAt);
+        if (!TryAcceptRunSequence(run, evt.Sequence))
+            return state;
+
         run.Status = FailedStatus;
         run.CompletedAt = failedAt.Clone();
         run.FailureCode = NormalizeOptional(evt.FailureCode) ?? "execution_failed";
@@ -532,6 +568,9 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
         var next = state.Clone();
         var cancelledAt = evt.CancelledAt ?? Timestamp.FromDateTime(DateTime.UtcNow);
         var run = EnsureRun(next, evt.RunId, evt.ResponseId, cancelledAt);
+        if (!TryAcceptRunSequence(run, evt.Sequence))
+            return state;
+
         run.Status = CancelledStatus;
         run.CompletedAt = cancelledAt.Clone();
         if (next.Record == null)
@@ -590,6 +629,30 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
         return state.ActiveRun;
     }
 
+    private long NextRunSequence(string runId)
+    {
+        if (State.ActiveRun == null ||
+            !string.Equals(State.ActiveRun.RunId, runId, StringComparison.Ordinal))
+        {
+            return 1;
+        }
+
+        return State.ActiveRun.LastAppliedSequence + 1;
+    }
+
+    private static bool TryAcceptRunSequence(LlmSessionRunScope run, long sequence)
+    {
+        if (IsRunTerminal(run.Status))
+            return false;
+        if (sequence <= 0)
+            return true;
+        if (sequence != run.LastAppliedSequence + 1)
+            return false;
+
+        run.LastAppliedSequence = sequence;
+        return true;
+    }
+
     private static void TouchRecord(LlmSessionState state, Timestamp? updatedAt)
     {
         if (state.Record == null)
@@ -602,6 +665,9 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
         state.LastAppliedEventVersion++;
         state.LastEventId = eventId;
     }
+
+    private static bool IsRunTerminal(int status) =>
+        status is CompletedStatus or FailedStatus or CancelledStatus;
 
     private static void UpsertRuntimeToolCall(
         LlmSessionRunScope run,
@@ -623,41 +689,67 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
             existing.ArgumentsJson += incoming.ArgumentsJson;
     }
 
-    private Task PersistLlmRunEventAsync<TEvent>(TEvent evt, CancellationToken ct)
-        where TEvent : IMessage =>
-        PersistDomainEventAsync(evt, ct);
+    private Task PersistStreamChunkObservedAsync(LlmStreamChunkObserved observed, CancellationToken ct)
+    {
+        observed.Sequence = NextRunSequence(observed.RunId);
+        return PersistDomainEventAsync(observed, ct);
+    }
+
+    private Task PersistToolCallObservedAsync(LlmToolCallObserved observed, CancellationToken ct)
+    {
+        observed.Sequence = NextRunSequence(observed.RunId);
+        return PersistDomainEventAsync(observed, ct);
+    }
+
+    private Task PersistRunCompletedAsync(LlmRunCompleted completed, CancellationToken ct)
+    {
+        completed.Sequence = NextRunSequence(completed.RunId);
+        return PersistDomainEventAsync(completed, ct);
+    }
+
+    private Task PersistRunFailedAsync(LlmRunFailed failed, CancellationToken ct)
+    {
+        failed.Sequence = NextRunSequence(failed.RunId);
+        return PersistDomainEventAsync(failed, ct);
+    }
+
+    private Task PersistRunCancelledAsync(LlmRunCancelled cancelled, CancellationToken ct)
+    {
+        cancelled.Sequence = NextRunSequence(cancelled.RunId);
+        return PersistDomainEventAsync(cancelled, ct);
+    }
 
     private sealed class InActorLlmRunSink(LlmSessionGAgent actor) : ILlmRunSink
     {
         public Task RecordStreamChunkObservedAsync(
             LlmStreamChunkObserved observed,
             CancellationToken ct = default) =>
-            actor.PersistLlmRunEventAsync(observed, ct);
+            actor.PersistStreamChunkObservedAsync(observed, ct);
 
         public Task RecordToolCallObservedAsync(
             LlmToolCallObserved observed,
             CancellationToken ct = default) =>
-            actor.PersistLlmRunEventAsync(observed, ct);
+            actor.PersistToolCallObservedAsync(observed, ct);
 
         public Task RecordForwardedToolCallEmittedAsync(
             LlmSessionForwardedToolCallEmittedEvent emitted,
             CancellationToken ct = default) =>
-            actor.PersistLlmRunEventAsync(emitted, ct);
+            actor.PersistDomainEventAsync(emitted, ct);
 
         public Task RecordRunCompletedAsync(
             LlmRunCompleted completed,
             CancellationToken ct = default) =>
-            actor.PersistLlmRunEventAsync(completed, ct);
+            actor.PersistRunCompletedAsync(completed, ct);
 
         public Task RecordRunFailedAsync(
             LlmRunFailed failed,
             CancellationToken ct = default) =>
-            actor.PersistLlmRunEventAsync(failed, ct);
+            actor.PersistRunFailedAsync(failed, ct);
 
         public Task RecordRunCancelledAsync(
             LlmRunCancelled cancelled,
             CancellationToken ct = default) =>
-            actor.PersistLlmRunEventAsync(cancelled, ct);
+            actor.PersistRunCancelledAsync(cancelled, ct);
     }
 
     private static LlmSessionRecord NormalizeRecord(LlmSessionRecord record)

--- a/src/platform/Aevatar.GAgentService.Projection/Projectors/LlmSessionObservationSessionEventProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Projectors/LlmSessionObservationSessionEventProjector.cs
@@ -32,7 +32,8 @@ public sealed class LlmSessionObservationSessionEventProjector
         if (!CommittedStateEventEnvelope.TryGetObservedPayload(envelope, out var payload, out _, out _) || payload == null)
             return EmptyEntries;
 
-        if (!payload.Is(LlmStreamChunkObserved.Descriptor) &&
+        if (!payload.Is(LlmRunStartedEvent.Descriptor) &&
+            !payload.Is(LlmStreamChunkObserved.Descriptor) &&
             !payload.Is(LlmToolCallObserved.Descriptor) &&
             !payload.Is(LlmRunCompleted.Descriptor) &&
             !payload.Is(LlmRunFailed.Descriptor) &&

--- a/test/Aevatar.GAgentService.Tests/Application/LlmSessionRunObservationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/LlmSessionRunObservationServiceTests.cs
@@ -48,6 +48,29 @@ public sealed class LlmSessionRunObservationServiceTests
     }
 
     [Fact]
+    public async Task ObserveAsync_ShouldIgnoreRunStartedEventForOutput()
+    {
+        var ports = new RecordingObservationPorts([
+            StartedEnvelope("resp-1"),
+            ChunkEnvelope("resp-1", "done"),
+            CompletedEnvelope("resp-1", "done"),
+        ]);
+        var service = ports.CreateService();
+        var deltas = new List<LlmSessionRunObservedDelta>();
+
+        var result = await service.ObserveAsync(Request(ports), (delta, _) =>
+        {
+            deltas.Add(delta);
+            return ValueTask.CompletedTask;
+        });
+
+        result.Error.Should().BeNull();
+        result.Completion!.OutputText.Should().Be("done");
+        deltas.Should().ContainSingle();
+        deltas[0].TextDelta.Should().Be("done");
+    }
+
+    [Fact]
     public async Task ObserveAsync_ShouldEmitToolDelta()
     {
         var ports = new RecordingObservationPorts([
@@ -283,6 +306,15 @@ public sealed class LlmSessionRunObservationServiceTests
             RunId = $"{responseId}:llm-run",
             DeltaText = text ?? string.Empty,
             ToolCallDelta = toolCallDelta,
+        });
+
+    private static EventEnvelope StartedEnvelope(string responseId) =>
+        Envelope(responseId, new LlmRunStartedEvent
+        {
+            ResponseId = responseId,
+            RunId = $"{responseId}:llm-run",
+            Sequence = 1,
+            StartedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
         });
 
     private static EventEnvelope ToolEnvelope(string responseId, LlmSessionRuntimeToolCall toolCall) =>

--- a/test/Aevatar.GAgentService.Tests/Core/LlmSessionGAgentTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/LlmSessionGAgentTests.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Runtime.Persistence;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Responses;
@@ -713,6 +714,125 @@ public sealed class LlmSessionGAgentTests
         actor.State.Completion.Usage!.PromptTokens.Should().Be(3);
         provider.Requests.Should().ContainSingle()
             .Which.CallerContext!.ResponseId.Should().Be("resp_1");
+    }
+
+    [Fact]
+    public async Task HandleLlmRunRequestedAsync_ShouldPersistTypedRunStartedEventBeforeOutput()
+    {
+        var eventStore = new InMemoryEventStore();
+        var provider = new ScriptedLlmProviderFactory([
+            [
+                new LLMStreamChunk
+                {
+                    DeltaContent = "done",
+                    IsLast = true,
+                },
+            ],
+        ]);
+        var requestedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-06-19T00:00:00+00:00"));
+        var actor = CreateActorWithStore(
+            "resp_started",
+            eventStore,
+            services => services.AddSingleton<ILLMProviderFactory>(provider));
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_started"),
+        });
+
+        var request = BuildRunRequest("resp_started");
+        request.RequestedAt = requestedAt;
+        await actor.HandleLlmRunRequestedAsync(request);
+
+        var runEvents = (await eventStore.GetEventsAsync(actor.Id))
+            .Select(static evt => evt.EventData)
+            .Where(static payload =>
+                payload.Is(LlmRunStartedEvent.Descriptor) ||
+                payload.Is(LlmStreamChunkObserved.Descriptor) ||
+                payload.Is(LlmRunCompleted.Descriptor))
+            .ToArray();
+        runEvents.Should().HaveCount(3);
+        runEvents[0].Is(LlmRunStartedEvent.Descriptor).Should().BeTrue();
+        var started = runEvents[0].Unpack<LlmRunStartedEvent>();
+        started.ResponseId.Should().Be("resp_started");
+        started.RunId.Should().Be("run_1");
+        started.Sequence.Should().Be(1);
+        started.StartedAt.Should().Be(requestedAt);
+        runEvents[1].Unpack<LlmStreamChunkObserved>().Sequence.Should().Be(2);
+        runEvents[2].Unpack<LlmRunCompleted>().Sequence.Should().Be(3);
+
+        actor.State.ActiveRun.Should().NotBeNull();
+        actor.State.ActiveRun!.StartedAt.Should().Be(requestedAt);
+        actor.State.ActiveRun.LastAppliedSequence.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task ActivateAsync_ShouldReplayOnlyConsecutiveRunEventSequences()
+    {
+        var eventStore = new InMemoryEventStore();
+        var actorId = "response-session-actor-resp_sequence";
+        await eventStore.AppendAsync(
+            actorId,
+            [
+                StateEvent(1, new LlmSessionRegisteredEvent { Record = BuildRecord("resp_sequence") }),
+                StateEvent(2, new LlmRunStartedEvent
+                {
+                    ResponseId = "resp_sequence",
+                    RunId = "run_1",
+                    Sequence = 1,
+                    StartedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-06-19T00:00:00+00:00")),
+                }),
+                StateEvent(3, new LlmStreamChunkObserved
+                {
+                    ResponseId = "resp_sequence",
+                    RunId = "run_1",
+                    Sequence = 2,
+                    DeltaText = "first",
+                    ObservedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-06-19T00:00:01+00:00")),
+                }),
+                StateEvent(4, new LlmStreamChunkObserved
+                {
+                    ResponseId = "resp_sequence",
+                    RunId = "run_1",
+                    Sequence = 2,
+                    DeltaText = "duplicate",
+                    ObservedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-06-19T00:00:02+00:00")),
+                }),
+                StateEvent(5, new LlmStreamChunkObserved
+                {
+                    ResponseId = "resp_sequence",
+                    RunId = "run_1",
+                    Sequence = 4,
+                    DeltaText = "out-of-order",
+                    ObservedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-06-19T00:00:03+00:00")),
+                }),
+                StateEvent(6, new LlmRunCompleted
+                {
+                    ResponseId = "resp_sequence",
+                    RunId = "run_1",
+                    Sequence = 3,
+                    OutputText = "first",
+                    CompletedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-06-19T00:00:04+00:00")),
+                }),
+                StateEvent(7, new LlmStreamChunkObserved
+                {
+                    ResponseId = "resp_sequence",
+                    RunId = "run_1",
+                    Sequence = 4,
+                    DeltaText = "late",
+                    ObservedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-06-19T00:00:05+00:00")),
+                }),
+            ],
+            expectedVersion: 0);
+        var actor = CreateActorWithStore("resp_sequence", eventStore);
+
+        await actor.ActivateAsync();
+
+        actor.State.LastAppliedEventVersion.Should().Be(4);
+        actor.State.ActiveRun.Should().NotBeNull();
+        actor.State.ActiveRun!.OutputText.Should().Be("first");
+        actor.State.ActiveRun.Status.Should().Be(2);
+        actor.State.ActiveRun.LastAppliedSequence.Should().Be(3);
+        actor.State.Completion!.OutputText.Should().Be("first");
     }
 
     [Fact]
@@ -1583,6 +1703,15 @@ public sealed class LlmSessionGAgentTests
                     Content = "What is the weather?",
                 },
             },
+        };
+
+    private static StateEvent StateEvent(long version, Google.Protobuf.IMessage payload) =>
+        new()
+        {
+            EventId = $"event-{version}",
+            Version = version,
+            EventData = Any.Pack(payload),
+            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-06-19T00:00:00+00:00")),
         };
 
     private static AgentToolExecutionContext NewCommandToolContext(

--- a/test/Aevatar.GAgentService.Tests/Projection/LlmSessionObservationSessionEventProjectorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/LlmSessionObservationSessionEventProjectorTests.cs
@@ -30,8 +30,8 @@ public sealed class LlmSessionObservationSessionEventProjectorTests
             ProjectionKind = "llm-session-observation",
         };
 
-        await projector.ProjectAsync(context, CommittedEnvelope("resp-1"));
-        await projector.ProjectAsync(context, CommittedEnvelope("resp-1:llm-run"));
+        await projector.ProjectAsync(context, CommittedEnvelope("resp-1", RunStartedPayload()));
+        await projector.ProjectAsync(context, CommittedEnvelope("resp-1:llm-run", RunStartedPayload()));
 
         var stream = streams.Streams.Should().ContainSingle().Subject.Value;
         stream.Produced.Should().ContainSingle();
@@ -42,14 +42,17 @@ public sealed class LlmSessionObservationSessionEventProjectorTests
         routed.Propagation!.CorrelationId.Should().Be("resp-1");
     }
 
-    private static EventEnvelope CommittedEnvelope(string correlationId)
-    {
-        var payload = new LlmStreamChunkObserved
+    private static LlmRunStartedEvent RunStartedPayload() =>
+        new()
         {
             ResponseId = "resp-1",
             RunId = "resp-1:llm-run",
-            DeltaText = "hello",
+            Sequence = 1,
+            StartedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
         };
+
+    private static EventEnvelope CommittedEnvelope(string correlationId, IMessage payload)
+    {
         return new EventEnvelope
         {
             Id = Guid.NewGuid().ToString("N"),

--- a/test/Aevatar.GAgentService.Tests/Projection/LlmSessionsProtoSurfaceRegressionTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/LlmSessionsProtoSurfaceRegressionTests.cs
@@ -34,6 +34,22 @@ public sealed class LlmSessionsProtoSurfaceRegressionTests
             .BeNull();
     }
 
+    [Fact]
+    public void LlmSessionsProto_ShouldExposeTypedRunStartedSequenceSurface()
+    {
+        var descriptor = LlmSessionsReflection.Descriptor;
+
+        TopLevelMessageNames(descriptor).Should().Contain("LlmRunStartedEvent");
+        TopLevelMessageNames(descriptor).Should().NotContain("LlmRunRecordAppliedEvent");
+        LlmRunStartedEvent.Descriptor.FindFieldByName("sequence").Should().NotBeNull();
+        LlmStreamChunkObserved.Descriptor.FindFieldByName("sequence").Should().NotBeNull();
+        LlmToolCallObserved.Descriptor.FindFieldByName("sequence").Should().NotBeNull();
+        LlmRunCompleted.Descriptor.FindFieldByName("sequence").Should().NotBeNull();
+        LlmRunFailed.Descriptor.FindFieldByName("sequence").Should().NotBeNull();
+        LlmRunCancelled.Descriptor.FindFieldByName("sequence").Should().NotBeNull();
+        LlmSessionRunScope.Descriptor.FindFieldByName("last_applied_sequence").Should().NotBeNull();
+    }
+
     private static IEnumerable<string> TopLevelMessageNames(FileDescriptor descriptor) =>
         descriptor.MessageTypes.Select(x => x.Name);
 }


### PR DESCRIPTION
## Changed files
- `llm_sessions.proto` 新增 `LlmRunStartedEvent`、run event `sequence` 字段和 run scope 的 `last_applied_sequence`。
- `LlmSessionGAgent` 改为先提交 typed run-start lifecycle fact，再提交 stream/tool/completion 事件，并在 replay/application 中按连续 sequence 接受事件。
- live observation projector 将 committed run-start fact 送入既有观察链路；response observation service 明确忽略该事件，不产生 public delta。
- 补充 actor、projection、application response 和 proto surface regression 测试。

## Test results
- `bash -lc "dotnet build aevatar.slnx --nologo"` passed with warnings only.
- `bash -lc "dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo"` passed: 900 tests, 0 failed, 0 skipped.
- `bash tools/ci/test_stability_guards.sh` passed.
- `bash tools/ci/architecture_guards.sh` passed.
- `bash -lc "dotnet test aevatar.slnx --nologo"` passed overall; existing skips unrelated.

## Deviations
- 无 scope extension；未引入 `LlmRunRecordAppliedEvent`、query/current-state visibility side path、B3/B4 executor extraction 或 off-actor dispatch。
- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)
- Closes #2272

⟦AI:AUTO-LOOP⟧
