### PR TITLE
将 LLM 会话运行记录移出 actor turn

### DIFF
--- a/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
@@ -228,6 +228,7 @@ message LlmRunRequested {
   LlmSessionRuntimeToolSelection tool_selection = 11;
   google.protobuf.Timestamp requested_at = 12;
   aevatar.ai.AgentToolExecutionContextPayload tool_context = 13;
+  google.protobuf.Duration timeout_after = 14;
 }
 
 message LlmRunStartedEvent {
@@ -337,6 +338,13 @@ message RecordLlmRunCancelled {
   string run_id = 2;
   string record_id = 3;
   google.protobuf.Timestamp cancelled_at = 4;
+}
+
+message FinalizeLlmRunTimedOut {
+  string response_id = 1;
+  string run_id = 2;
+  string record_id = 3;
+  google.protobuf.Timestamp timed_out_at = 4;
 }
 
 message LlmRunCancelled {

--- a/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
@@ -94,6 +94,7 @@ message LlmSessionRunScope {
   string failure_code = 9;
   string failure_message = 10;
   int64 last_applied_sequence = 11;
+  repeated string applied_record_ids = 12;
 }
 
 message LlmSessionState {
@@ -148,6 +149,9 @@ message RecordForwardedToolCallRequested {
 message LlmSessionForwardedToolCallEmittedEvent {
   string response_id = 1;
   LlmSessionForwardedToolCall call = 2;
+  string run_id = 3;
+  int64 sequence = 4;
+  string record_id = 5;
 }
 
 message ReceiveForwardedToolResultRequested {
@@ -233,6 +237,17 @@ message LlmRunStartedEvent {
   google.protobuf.Timestamp started_at = 4;
 }
 
+message RecordLlmStreamChunkObserved {
+  string response_id = 1;
+  string run_id = 2;
+  string record_id = 3;
+  int32 round = 4;
+  string delta_text = 5;
+  LlmSessionRuntimeToolCall tool_call_delta = 6;
+  LlmSessionTokenUsage usage = 7;
+  google.protobuf.Timestamp observed_at = 8;
+}
+
 message LlmStreamChunkObserved {
   string response_id = 1;
   string run_id = 2;
@@ -242,6 +257,19 @@ message LlmStreamChunkObserved {
   LlmSessionTokenUsage usage = 6;
   google.protobuf.Timestamp observed_at = 7;
   int64 sequence = 8;
+  string record_id = 9;
+}
+
+message RecordLlmToolCallObserved {
+  string response_id = 1;
+  string run_id = 2;
+  string record_id = 3;
+  int32 round = 4;
+  LlmSessionRuntimeToolCall tool_call = 5;
+  bool forwarded = 6;
+  string local_result_json = 7;
+  google.protobuf.Timestamp observed_at = 8;
+  google.protobuf.Value local_result = 9;
 }
 
 message LlmToolCallObserved {
@@ -254,6 +282,24 @@ message LlmToolCallObserved {
   google.protobuf.Timestamp observed_at = 7;
   google.protobuf.Value local_result = 8;
   int64 sequence = 9;
+  string record_id = 10;
+}
+
+message RecordLlmForwardedToolCallEmitted {
+  string response_id = 1;
+  string run_id = 2;
+  string record_id = 3;
+  LlmSessionForwardedToolCall call = 4;
+}
+
+message RecordLlmRunCompleted {
+  string response_id = 1;
+  string run_id = 2;
+  string record_id = 3;
+  string output_text = 4;
+  repeated LlmSessionRuntimeToolCall forwarded_tool_calls = 5;
+  LlmSessionTokenUsage usage = 6;
+  google.protobuf.Timestamp completed_at = 7;
 }
 
 message LlmRunCompleted {
@@ -264,6 +310,16 @@ message LlmRunCompleted {
   LlmSessionTokenUsage usage = 5;
   google.protobuf.Timestamp completed_at = 6;
   int64 sequence = 7;
+  string record_id = 8;
+}
+
+message RecordLlmRunFailed {
+  string response_id = 1;
+  string run_id = 2;
+  string record_id = 3;
+  string failure_code = 4;
+  string failure_message = 5;
+  google.protobuf.Timestamp failed_at = 6;
 }
 
 message LlmRunFailed {
@@ -273,6 +329,14 @@ message LlmRunFailed {
   string failure_message = 4;
   google.protobuf.Timestamp failed_at = 5;
   int64 sequence = 6;
+  string record_id = 7;
+}
+
+message RecordLlmRunCancelled {
+  string response_id = 1;
+  string run_id = 2;
+  string record_id = 3;
+  google.protobuf.Timestamp cancelled_at = 4;
 }
 
 message LlmRunCancelled {
@@ -280,6 +344,7 @@ message LlmRunCancelled {
   string run_id = 2;
   google.protobuf.Timestamp cancelled_at = 3;
   int64 sequence = 4;
+  string record_id = 5;
 }
 
 enum ChatRunSubRunWaitMode {

--- a/src/platform/Aevatar.GAgentService.Abstractions/Responses/LlmRunCoreContracts.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Responses/LlmRunCoreContracts.cs
@@ -7,6 +7,19 @@ public sealed record LlmRunCoreRequest(
     string RunId,
     string? OriginPlatform);
 
+public sealed record LlmRunExecutionRequest(
+    string SessionActorId,
+    LlmRunRequested Command,
+    string RunId,
+    string? OriginPlatform);
+
+public interface ILlmRunExecutor
+{
+    Task StartAsync(
+        LlmRunExecutionRequest request,
+        CancellationToken ct = default);
+}
+
 public interface ILlmRunCore
 {
     Task RunAsync(

--- a/src/platform/Aevatar.GAgentService.Application/Responses/LlmRunExecutor.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/LlmRunExecutor.cs
@@ -40,13 +40,17 @@ public sealed class LlmRunExecutor(
                             executionRequest.RunId,
                             executionRequest.OriginPlatform),
                         new DispatchingLlmRunSink(
-                            executionRequest.SessionActorId,
                             executionRequest.RunId,
-                            dispatchPort),
+                            (recordId, command, token) => DispatchCommandAsync(
+                                executionRequest.SessionActorId,
+                                recordId,
+                                command,
+                                token)),
                         CancellationToken.None).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
+                    await DispatchExecutorFailureAsync(executionRequest, ex).ConfigureAwait(false);
                     logger.LogError(
                         ex,
                         "Off-turn LLM run executor failed for session actor {SessionActorId} run {RunId}.",
@@ -59,10 +63,62 @@ public sealed class LlmRunExecutor(
         return Task.CompletedTask;
     }
 
-    private sealed class DispatchingLlmRunSink(
+    private async Task DispatchExecutorFailureAsync(
+        LlmRunExecutionRequest request,
+        Exception exception)
+    {
+        var recordId = $"{request.RunId}:executor-failed";
+        try
+        {
+            await DispatchCommandAsync(
+                request.SessionActorId,
+                recordId,
+                new RecordLlmRunFailed
+                {
+                    ResponseId = request.Command.ResponseId,
+                    RunId = request.RunId,
+                    RecordId = recordId,
+                    FailureCode = "executor_failed",
+                    FailureMessage = string.IsNullOrWhiteSpace(exception.Message)
+                        ? "Off-turn LLM run executor failed."
+                        : exception.Message,
+                    FailedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+                },
+                CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception dispatchException)
+        {
+            logger.LogError(
+                dispatchException,
+                "Off-turn LLM run executor could not dispatch failure record for session actor {SessionActorId} run {RunId}.",
+                request.SessionActorId,
+                request.RunId);
+        }
+    }
+
+    private Task DispatchCommandAsync(
         string sessionActorId,
+        string recordId,
+        IMessage command,
+        CancellationToken ct)
+    {
+        var envelope = new EventEnvelope
+        {
+            Id = recordId,
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(command),
+            Route = EnvelopeRouteSemantics.CreateDirect(PublisherId, sessionActorId),
+            Propagation = new EnvelopePropagation
+            {
+                CorrelationId = recordId,
+            },
+        };
+        return dispatchPort.DispatchAsync(sessionActorId, envelope, ct);
+    }
+
+    private sealed class DispatchingLlmRunSink(
         string runId,
-        IActorDispatchPort dispatchPort) : ILlmRunSink
+        Func<string, IMessage, CancellationToken, Task> dispatch) : ILlmRunSink
     {
         private long _recordIndex;
 
@@ -186,24 +242,8 @@ public sealed class LlmRunExecutor(
                 ct);
         }
 
-        private Task DispatchAsync(
-            string recordId,
-            IMessage command,
-            CancellationToken ct)
-        {
-            var envelope = new EventEnvelope
-            {
-                Id = recordId,
-                Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
-                Payload = Any.Pack(command),
-                Route = EnvelopeRouteSemantics.CreateDirect(PublisherId, sessionActorId),
-                Propagation = new EnvelopePropagation
-                {
-                    CorrelationId = recordId,
-                },
-            };
-            return dispatchPort.DispatchAsync(sessionActorId, envelope, ct);
-        }
+        private Task DispatchAsync(string recordId, IMessage command, CancellationToken ct) =>
+            dispatch(recordId, command, ct);
 
         private string NextRecordId(string kind)
         {

--- a/src/platform/Aevatar.GAgentService.Application/Responses/LlmRunExecutor.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/LlmRunExecutor.cs
@@ -1,0 +1,217 @@
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Responses;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.GAgentService.Application.Responses;
+
+public sealed class LlmRunExecutor(
+    ILlmRunCore runCore,
+    IActorDispatchPort dispatchPort,
+    ILogger<LlmRunExecutor> logger) : ILlmRunExecutor
+{
+    private const string PublisherId = "gagent-service.llm-run-executor";
+
+    public Task StartAsync(
+        LlmRunExecutionRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Command);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.SessionActorId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.RunId);
+
+        var executionRequest = new LlmRunExecutionRequest(
+            request.SessionActorId.Trim(),
+            request.Command.Clone(),
+            request.RunId.Trim(),
+            request.OriginPlatform);
+
+        _ = Task.Run(
+            async () =>
+            {
+                try
+                {
+                    await runCore.RunAsync(
+                        new LlmRunCoreRequest(
+                            executionRequest.Command.Clone(),
+                            executionRequest.RunId,
+                            executionRequest.OriginPlatform),
+                        new DispatchingLlmRunSink(
+                            executionRequest.SessionActorId,
+                            executionRequest.RunId,
+                            dispatchPort),
+                        CancellationToken.None).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(
+                        ex,
+                        "Off-turn LLM run executor failed for session actor {SessionActorId} run {RunId}.",
+                        executionRequest.SessionActorId,
+                        executionRequest.RunId);
+                }
+            },
+            CancellationToken.None);
+
+        return Task.CompletedTask;
+    }
+
+    private sealed class DispatchingLlmRunSink(
+        string sessionActorId,
+        string runId,
+        IActorDispatchPort dispatchPort) : ILlmRunSink
+    {
+        private long _recordIndex;
+
+        public Task RecordStreamChunkObservedAsync(
+            LlmStreamChunkObserved observed,
+            CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(observed);
+            var recordId = NextRecordId("chunk");
+            return DispatchAsync(
+                recordId,
+                new RecordLlmStreamChunkObserved
+                {
+                    ResponseId = observed.ResponseId,
+                    RunId = ResolveRunId(observed.RunId),
+                    RecordId = recordId,
+                    Round = observed.Round,
+                    DeltaText = observed.DeltaText ?? string.Empty,
+                    ToolCallDelta = observed.ToolCallDelta?.Clone(),
+                    Usage = observed.Usage?.Clone(),
+                    ObservedAt = observed.ObservedAt?.Clone(),
+                },
+                ct);
+        }
+
+        public Task RecordToolCallObservedAsync(
+            LlmToolCallObserved observed,
+            CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(observed);
+            var recordId = NextRecordId("tool");
+            return DispatchAsync(
+                recordId,
+                new RecordLlmToolCallObserved
+                {
+                    ResponseId = observed.ResponseId,
+                    RunId = ResolveRunId(observed.RunId),
+                    RecordId = recordId,
+                    Round = observed.Round,
+                    ToolCall = observed.ToolCall?.Clone(),
+                    Forwarded = observed.Forwarded,
+                    LocalResultJson = observed.LocalResultJson ?? string.Empty,
+                    ObservedAt = observed.ObservedAt?.Clone(),
+                    LocalResult = observed.LocalResult?.Clone(),
+                },
+                ct);
+        }
+
+        public Task RecordForwardedToolCallEmittedAsync(
+            LlmSessionForwardedToolCallEmittedEvent emitted,
+            CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(emitted);
+            var recordId = NextRecordId("forwarded-tool");
+            return DispatchAsync(
+                recordId,
+                new RecordLlmForwardedToolCallEmitted
+                {
+                    ResponseId = emitted.ResponseId,
+                    RunId = runId,
+                    RecordId = recordId,
+                    Call = emitted.Call?.Clone(),
+                },
+                ct);
+        }
+
+        public Task RecordRunCompletedAsync(
+            LlmRunCompleted completed,
+            CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(completed);
+            var recordId = NextRecordId("completed");
+            var command = new RecordLlmRunCompleted
+            {
+                ResponseId = completed.ResponseId,
+                RunId = ResolveRunId(completed.RunId),
+                RecordId = recordId,
+                OutputText = completed.OutputText ?? string.Empty,
+                Usage = completed.Usage?.Clone(),
+                CompletedAt = completed.CompletedAt?.Clone(),
+            };
+            command.ForwardedToolCalls.AddRange(completed.ForwardedToolCalls.Select(static call => call.Clone()));
+            return DispatchAsync(recordId, command, ct);
+        }
+
+        public Task RecordRunFailedAsync(
+            LlmRunFailed failed,
+            CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(failed);
+            var recordId = NextRecordId("failed");
+            return DispatchAsync(
+                recordId,
+                new RecordLlmRunFailed
+                {
+                    ResponseId = failed.ResponseId,
+                    RunId = ResolveRunId(failed.RunId),
+                    RecordId = recordId,
+                    FailureCode = failed.FailureCode ?? string.Empty,
+                    FailureMessage = failed.FailureMessage ?? string.Empty,
+                    FailedAt = failed.FailedAt?.Clone(),
+                },
+                ct);
+        }
+
+        public Task RecordRunCancelledAsync(
+            LlmRunCancelled cancelled,
+            CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(cancelled);
+            var recordId = NextRecordId("cancelled");
+            return DispatchAsync(
+                recordId,
+                new RecordLlmRunCancelled
+                {
+                    ResponseId = cancelled.ResponseId,
+                    RunId = ResolveRunId(cancelled.RunId),
+                    RecordId = recordId,
+                    CancelledAt = cancelled.CancelledAt?.Clone(),
+                },
+                ct);
+        }
+
+        private Task DispatchAsync(
+            string recordId,
+            IMessage command,
+            CancellationToken ct)
+        {
+            var envelope = new EventEnvelope
+            {
+                Id = recordId,
+                Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+                Payload = Any.Pack(command),
+                Route = EnvelopeRouteSemantics.CreateDirect(PublisherId, sessionActorId),
+                Propagation = new EnvelopePropagation
+                {
+                    CorrelationId = recordId,
+                },
+            };
+            return dispatchPort.DispatchAsync(sessionActorId, envelope, ct);
+        }
+
+        private string NextRecordId(string kind)
+        {
+            var index = Interlocked.Increment(ref _recordIndex);
+            return $"{runId}:{kind}:{index}";
+        }
+
+        private string ResolveRunId(string? candidate) =>
+            string.IsNullOrWhiteSpace(candidate) ? runId : candidate.Trim();
+    }
+}

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
@@ -296,9 +296,10 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
             return;
 
         var startedAt = command.RequestedAt ?? Timestamp.FromDateTime(DateTime.UtcNow);
-        if (State.ActiveRun == null ||
+        var shouldStartExecutor = State.ActiveRun == null ||
             !string.Equals(State.ActiveRun.RunId, runId, StringComparison.Ordinal) ||
-            State.ActiveRun.LastAppliedSequence <= 0)
+            State.ActiveRun.LastAppliedSequence <= 0;
+        if (shouldStartExecutor)
         {
             await PersistDomainEventAsync(new LlmRunStartedEvent
             {
@@ -308,12 +309,146 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
                 StartedAt = startedAt,
             });
         }
+        else
+        {
+            return;
+        }
 
-        var runCore = Services.GetRequiredService<ILlmRunCore>();
-        await runCore.RunAsync(
-            new LlmRunCoreRequest(command, runId, existing.OriginKind.ToString()),
-            new InActorLlmRunSink(this),
-            CancellationToken.None);
+        var executor = Services.GetRequiredService<ILlmRunExecutor>();
+        await executor.StartAsync(
+            new LlmRunExecutionRequest(
+                Id,
+                command.Clone(),
+                runId,
+                existing.OriginKind.ToString()));
+    }
+
+    [EventHandler]
+    public async Task HandleRecordStreamChunkObservedAsync(RecordLlmStreamChunkObserved command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        if (!TryPrepareRunRecord(command.ResponseId, command.RunId, command.RecordId, out var existing, out var runId))
+            return;
+
+        await PersistDomainEventAsync(new LlmStreamChunkObserved
+        {
+            ResponseId = existing.ResponseId,
+            RunId = runId,
+            Round = command.Round,
+            DeltaText = command.DeltaText ?? string.Empty,
+            ToolCallDelta = command.ToolCallDelta?.Clone(),
+            Usage = command.Usage?.Clone(),
+            ObservedAt = command.ObservedAt ?? Timestamp.FromDateTime(DateTime.UtcNow),
+            Sequence = NextRunSequence(runId),
+            RecordId = NormalizeRequired(command.RecordId),
+        });
+    }
+
+    [EventHandler]
+    public async Task HandleRecordToolCallObservedAsync(RecordLlmToolCallObserved command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        if (!TryPrepareRunRecord(command.ResponseId, command.RunId, command.RecordId, out var existing, out var runId))
+            return;
+
+        await PersistDomainEventAsync(new LlmToolCallObserved
+        {
+            ResponseId = existing.ResponseId,
+            RunId = runId,
+            Round = command.Round,
+            ToolCall = command.ToolCall?.Clone(),
+            Forwarded = command.Forwarded,
+            LocalResultJson = command.LocalResultJson ?? string.Empty,
+            ObservedAt = command.ObservedAt ?? Timestamp.FromDateTime(DateTime.UtcNow),
+            LocalResult = command.LocalResult?.Clone(),
+            Sequence = NextRunSequence(runId),
+            RecordId = NormalizeRequired(command.RecordId),
+        });
+    }
+
+    [EventHandler]
+    public async Task HandleRecordForwardedToolCallEmittedAsync(RecordLlmForwardedToolCallEmitted command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(command.Call);
+        if (!TryPrepareRunRecord(command.ResponseId, command.RunId, command.RecordId, out var existing, out _))
+            return;
+
+        var call = NormalizeToolCall(command.Call.Clone());
+        ValidateToolCall(call);
+
+        var existingCall = State.ForwardedToolCalls
+            .FirstOrDefault(x => string.Equals(x.CallId, call.CallId, StringComparison.Ordinal));
+        if (existingCall != null)
+        {
+            EnsureExistingToolCallMatches(existingCall, call);
+        }
+
+        await PersistDomainEventAsync(new LlmSessionForwardedToolCallEmittedEvent
+        {
+            ResponseId = existing.ResponseId,
+            Call = call,
+            RunId = State.ActiveRun!.RunId,
+            RecordId = NormalizeRequired(command.RecordId),
+            Sequence = NextRunSequence(State.ActiveRun.RunId),
+        });
+    }
+
+    [EventHandler]
+    public async Task HandleRecordRunCompletedAsync(RecordLlmRunCompleted command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        if (!TryPrepareRunRecord(command.ResponseId, command.RunId, command.RecordId, out var existing, out var runId))
+            return;
+
+        var completed = new LlmRunCompleted
+        {
+            ResponseId = existing.ResponseId,
+            RunId = runId,
+            OutputText = command.OutputText ?? string.Empty,
+            Usage = command.Usage?.Clone(),
+            CompletedAt = command.CompletedAt ?? Timestamp.FromDateTime(DateTime.UtcNow),
+            Sequence = NextRunSequence(runId),
+            RecordId = NormalizeRequired(command.RecordId),
+        };
+        completed.ForwardedToolCalls.AddRange(command.ForwardedToolCalls.Select(static call => call.Clone()));
+        await PersistDomainEventAsync(completed);
+    }
+
+    [EventHandler]
+    public async Task HandleRecordRunFailedAsync(RecordLlmRunFailed command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        if (!TryPrepareRunRecord(command.ResponseId, command.RunId, command.RecordId, out var existing, out var runId))
+            return;
+
+        await PersistDomainEventAsync(new LlmRunFailed
+        {
+            ResponseId = existing.ResponseId,
+            RunId = runId,
+            FailureCode = NormalizeOptional(command.FailureCode) ?? "execution_failed",
+            FailureMessage = NormalizeOptional(command.FailureMessage) ?? "LLM run failed.",
+            FailedAt = command.FailedAt ?? Timestamp.FromDateTime(DateTime.UtcNow),
+            Sequence = NextRunSequence(runId),
+            RecordId = NormalizeRequired(command.RecordId),
+        });
+    }
+
+    [EventHandler]
+    public async Task HandleRecordRunCancelledAsync(RecordLlmRunCancelled command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        if (!TryPrepareRunRecord(command.ResponseId, command.RunId, command.RecordId, out var existing, out var runId))
+            return;
+
+        await PersistDomainEventAsync(new LlmRunCancelled
+        {
+            ResponseId = existing.ResponseId,
+            RunId = runId,
+            CancelledAt = command.CancelledAt ?? Timestamp.FromDateTime(DateTime.UtcNow),
+            Sequence = NextRunSequence(runId),
+            RecordId = NormalizeRequired(command.RecordId),
+        });
     }
 
     protected override LlmSessionState TransitionState(LlmSessionState current, IMessage evt) =>
@@ -392,8 +527,21 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
         LlmSessionForwardedToolCallEmittedEvent evt)
     {
         var next = state.Clone();
-        if (evt.Call != null)
+        var run = string.IsNullOrWhiteSpace(evt.RunId)
+            ? null
+            : EnsureRun(next, evt.RunId, evt.ResponseId, evt.Call?.EmittedAt);
+        if (run != null && !TryAcceptRunRecord(run, evt.Sequence, evt.RecordId))
+            return state;
+
+        if (evt.Call != null &&
+            !next.ForwardedToolCalls.Any(call => string.Equals(call.CallId, evt.Call.CallId, StringComparison.Ordinal)))
+        {
             next.ForwardedToolCalls.Add(evt.Call.Clone());
+        }
+
+        if (run != null && evt.Call != null)
+            UpsertRuntimeToolCall(run, ToRuntimeToolCall(evt.Call));
+        TouchRecord(next, evt.Call?.EmittedAt);
         next.LastAppliedEventVersion = state.LastAppliedEventVersion + 1;
         next.LastEventId = $"{evt.ResponseId}:tool:{evt.Call?.CallId}:emitted";
         return next;
@@ -459,7 +607,7 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
     {
         var next = state.Clone();
         var run = EnsureRun(next, evt.RunId, evt.ResponseId, evt.ObservedAt);
-        if (!TryAcceptRunSequence(run, evt.Sequence))
+        if (!TryAcceptRunRecord(run, evt.Sequence, evt.RecordId))
             return state;
 
         run.Round = Math.Max(run.Round, evt.Round);
@@ -478,7 +626,7 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
     {
         var next = state.Clone();
         var run = EnsureRun(next, evt.RunId, evt.ResponseId, evt.ObservedAt);
-        if (!TryAcceptRunSequence(run, evt.Sequence))
+        if (!TryAcceptRunRecord(run, evt.Sequence, evt.RecordId))
             return state;
 
         run.Round = Math.Max(run.Round, evt.Round);
@@ -496,7 +644,7 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
         var next = state.Clone();
         var completedAt = evt.CompletedAt ?? Timestamp.FromDateTime(DateTime.UtcNow);
         var run = EnsureRun(next, evt.RunId, evt.ResponseId, completedAt);
-        if (!TryAcceptRunSequence(run, evt.Sequence))
+        if (!TryAcceptRunRecord(run, evt.Sequence, evt.RecordId))
             return state;
 
         run.Status = CompletedStatus;
@@ -538,7 +686,7 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
         var next = state.Clone();
         var failedAt = evt.FailedAt ?? Timestamp.FromDateTime(DateTime.UtcNow);
         var run = EnsureRun(next, evt.RunId, evt.ResponseId, failedAt);
-        if (!TryAcceptRunSequence(run, evt.Sequence))
+        if (!TryAcceptRunRecord(run, evt.Sequence, evt.RecordId))
             return state;
 
         run.Status = FailedStatus;
@@ -568,7 +716,7 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
         var next = state.Clone();
         var cancelledAt = evt.CancelledAt ?? Timestamp.FromDateTime(DateTime.UtcNow);
         var run = EnsureRun(next, evt.RunId, evt.ResponseId, cancelledAt);
-        if (!TryAcceptRunSequence(run, evt.Sequence))
+        if (!TryAcceptRunRecord(run, evt.Sequence, evt.RecordId))
             return state;
 
         run.Status = CancelledStatus;
@@ -653,6 +801,29 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
         return true;
     }
 
+    private static bool TryAcceptRunRecord(
+        LlmSessionRunScope run,
+        long sequence,
+        string? recordId)
+    {
+        if (IsRunTerminal(run.Status))
+            return false;
+
+        var normalizedRecordId = NormalizeOptional(recordId);
+        if (normalizedRecordId != null &&
+            run.AppliedRecordIds.Any(id => string.Equals(id, normalizedRecordId, StringComparison.Ordinal)))
+        {
+            return false;
+        }
+
+        if (!TryAcceptRunSequence(run, sequence))
+            return false;
+
+        if (normalizedRecordId != null)
+            run.AppliedRecordIds.Add(normalizedRecordId);
+        return true;
+    }
+
     private static void TouchRecord(LlmSessionState state, Timestamp? updatedAt)
     {
         if (state.Record == null)
@@ -689,67 +860,50 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
             existing.ArgumentsJson += incoming.ArgumentsJson;
     }
 
-    private Task PersistStreamChunkObservedAsync(LlmStreamChunkObserved observed, CancellationToken ct)
+    private static LlmSessionRuntimeToolCall ToRuntimeToolCall(LlmSessionForwardedToolCall call) =>
+        new()
+        {
+            CallId = call.CallId,
+            ToolName = call.ToolName,
+            Arguments = call.Arguments?.StructValue?.Clone(),
+        };
+
+    private bool TryPrepareRunRecord(
+        string? responseId,
+        string? requestedRunId,
+        string? recordId,
+        out LlmSessionRecord existing,
+        out string runId)
     {
-        observed.Sequence = NextRunSequence(observed.RunId);
-        return PersistDomainEventAsync(observed, ct);
-    }
+        existing = EnsureRegisteredSession(responseId);
+        runId = NormalizeRequired(requestedRunId);
+        var normalizedRecordId = NormalizeRequired(recordId);
+        if (string.IsNullOrWhiteSpace(normalizedRecordId))
+            throw new InvalidOperationException("record_id is required.");
 
-    private Task PersistToolCallObservedAsync(LlmToolCallObserved observed, CancellationToken ct)
-    {
-        observed.Sequence = NextRunSequence(observed.RunId);
-        return PersistDomainEventAsync(observed, ct);
-    }
+        if (State.ActiveRun == null || string.IsNullOrWhiteSpace(State.ActiveRun.RunId))
+            throw new InvalidOperationException(
+                $"Response session '{existing.ResponseId}' has no active LLM run.");
 
-    private Task PersistRunCompletedAsync(LlmRunCompleted completed, CancellationToken ct)
-    {
-        completed.Sequence = NextRunSequence(completed.RunId);
-        return PersistDomainEventAsync(completed, ct);
-    }
+        if (string.IsNullOrWhiteSpace(runId))
+            runId = State.ActiveRun.RunId;
 
-    private Task PersistRunFailedAsync(LlmRunFailed failed, CancellationToken ct)
-    {
-        failed.Sequence = NextRunSequence(failed.RunId);
-        return PersistDomainEventAsync(failed, ct);
-    }
+        if (!string.Equals(State.ActiveRun.RunId, runId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Response session '{existing.ResponseId}' active run is '{State.ActiveRun.RunId}' and cannot record run '{runId}'.");
+        }
 
-    private Task PersistRunCancelledAsync(LlmRunCancelled cancelled, CancellationToken ct)
-    {
-        cancelled.Sequence = NextRunSequence(cancelled.RunId);
-        return PersistDomainEventAsync(cancelled, ct);
-    }
+        if (IsRunTerminal(State.ActiveRun.Status))
+            return false;
 
-    private sealed class InActorLlmRunSink(LlmSessionGAgent actor) : ILlmRunSink
-    {
-        public Task RecordStreamChunkObservedAsync(
-            LlmStreamChunkObserved observed,
-            CancellationToken ct = default) =>
-            actor.PersistStreamChunkObservedAsync(observed, ct);
+        if (State.ActiveRun.AppliedRecordIds.Any(id => string.Equals(id, normalizedRecordId, StringComparison.Ordinal)))
+            return false;
 
-        public Task RecordToolCallObservedAsync(
-            LlmToolCallObserved observed,
-            CancellationToken ct = default) =>
-            actor.PersistToolCallObservedAsync(observed, ct);
+        if (IsTerminal(existing.Status))
+            return false;
 
-        public Task RecordForwardedToolCallEmittedAsync(
-            LlmSessionForwardedToolCallEmittedEvent emitted,
-            CancellationToken ct = default) =>
-            actor.PersistDomainEventAsync(emitted, ct);
-
-        public Task RecordRunCompletedAsync(
-            LlmRunCompleted completed,
-            CancellationToken ct = default) =>
-            actor.PersistRunCompletedAsync(completed, ct);
-
-        public Task RecordRunFailedAsync(
-            LlmRunFailed failed,
-            CancellationToken ct = default) =>
-            actor.PersistRunFailedAsync(failed, ct);
-
-        public Task RecordRunCancelledAsync(
-            LlmRunCancelled cancelled,
-            CancellationToken ct = default) =>
-            actor.PersistRunCancelledAsync(cancelled, ct);
+        return true;
     }
 
     private static LlmSessionRecord NormalizeRecord(LlmSessionRecord record)

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
@@ -1,4 +1,5 @@
 using Aevatar.Foundation.Abstractions.Attributes;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
@@ -308,6 +309,8 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
                 Sequence = 1,
                 StartedAt = startedAt,
             });
+            if (!await TryScheduleRunTimeoutAsync(existing.ResponseId, runId, startedAt, ResolveRunTimeout(command, existing)))
+                return;
         }
         else
         {
@@ -448,6 +451,41 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
             CancelledAt = command.CancelledAt ?? Timestamp.FromDateTime(DateTime.UtcNow),
             Sequence = NextRunSequence(runId),
             RecordId = NormalizeRequired(command.RecordId),
+        });
+    }
+
+    [EventHandler]
+    public async Task HandleFinalizeLlmRunTimedOutAsync(FinalizeLlmRunTimedOut command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var existing = EnsureRegisteredSession(command.ResponseId);
+        var runId = NormalizeRequired(command.RunId);
+        if (string.IsNullOrWhiteSpace(runId))
+            throw new InvalidOperationException("run_id is required.");
+
+        if (State.ActiveRun == null ||
+            !string.Equals(State.ActiveRun.RunId, runId, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        if (IsRunTerminal(State.ActiveRun.Status) || IsTerminal(existing.Status))
+            return;
+
+        var recordId = NormalizeOptional(command.RecordId) ?? BuildRunTimeoutRecordId(runId);
+        if (State.ActiveRun.AppliedRecordIds.Any(id => string.Equals(id, recordId, StringComparison.Ordinal)))
+            return;
+
+        await PersistDomainEventAsync(new LlmRunFailed
+        {
+            ResponseId = existing.ResponseId,
+            RunId = runId,
+            FailureCode = "run_timeout",
+            FailureMessage = "LLM run timed out.",
+            FailedAt = command.TimedOutAt ?? Timestamp.FromDateTime(DateTime.UtcNow),
+            Sequence = NextRunSequence(runId),
+            RecordId = recordId,
         });
     }
 
@@ -1143,6 +1181,68 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
                 ObservedAt = Timestamp.FromDateTimeOffset(expiresAt),
             });
     }
+
+    private async Task<bool> TryScheduleRunTimeoutAsync(
+        string responseId,
+        string runId,
+        Timestamp startedAt,
+        TimeSpan timeoutAfter)
+    {
+        try
+        {
+            var timeoutAt = startedAt.ToDateTimeOffset().Add(timeoutAfter);
+            var dueTime = timeoutAt - DateTimeOffset.UtcNow;
+            if (dueTime <= TimeSpan.Zero)
+                dueTime = TimeSpan.FromMilliseconds(1);
+
+            await ScheduleSelfDurableTimeoutAsync(
+                BuildRunTimeoutCallbackId(responseId, runId),
+                dueTime,
+                new FinalizeLlmRunTimedOut
+                {
+                    ResponseId = responseId,
+                    RunId = runId,
+                    RecordId = BuildRunTimeoutRecordId(runId),
+                    TimedOutAt = Timestamp.FromDateTimeOffset(timeoutAt),
+                });
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "LLM run timeout scheduling failed for response {ResponseId} run {RunId}.", responseId, runId);
+            await PersistDomainEventAsync(new LlmRunFailed
+            {
+                ResponseId = responseId,
+                RunId = runId,
+                FailureCode = "run_timeout_schedule_failed",
+                FailureMessage = string.IsNullOrWhiteSpace(ex.Message)
+                    ? "LLM run timeout scheduling failed."
+                    : ex.Message,
+                FailedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+                Sequence = NextRunSequence(runId),
+                RecordId = $"{runId}:timeout-schedule-failed",
+            });
+            return false;
+        }
+    }
+
+    private static TimeSpan ResolveRunTimeout(
+        LlmRunRequested command,
+        LlmSessionRecord record)
+    {
+        var requestedTimeout = command.TimeoutAfter?.ToTimeSpan();
+        if (requestedTimeout is { } timeout && timeout > TimeSpan.Zero)
+            return timeout;
+
+        var ttl = record.Ttl?.ToTimeSpan() ?? DefaultTtl.ToTimeSpan();
+        return ttl > TimeSpan.Zero ? ttl : DefaultTtl.ToTimeSpan();
+    }
+
+    private static string BuildRunTimeoutCallbackId(string responseId, string runId) =>
+        RuntimeCallbackKeyComposer.BuildCallbackId("llm-run-timeout", responseId, runId);
+
+    private static string BuildRunTimeoutRecordId(string runId) =>
+        $"{runId}:timeout";
 
     private static DateTimeOffset ResolveExpiry(LlmSessionRecord record)
     {

--- a/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -83,6 +83,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IResponsesAgentToolStateCommandPort, ResponsesAgentToolStateCommandAdapter>();
         services.TryAddSingleton<ILlmSessionRunObservationService, LlmSessionRunObservationService>();
         services.TryAddSingleton<ILlmRunCore, LlmRunCore>();
+        services.TryAddSingleton<ILlmRunExecutor, LlmRunExecutor>();
         services.TryAddSingleton<IResponsesToolClassificationService, ResponsesToolClassificationService>();
         services.AddToolSetRegistry();
         services.TryAddSingleton<IResponsesDirectToolPlanService, ResponsesDirectToolPlanService>();

--- a/test/Aevatar.GAgentService.Tests/Application/LlmRunExecutorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/LlmRunExecutorTests.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Responses;
@@ -45,9 +46,214 @@ public sealed class LlmRunExecutorTests
         var completed = dispatch.Calls[1].Envelope.Payload!.Unpack<RecordLlmRunCompleted>();
         completed.RecordId.Should().Be("run_1:completed:2");
         completed.OutputText.Should().Be("done");
+        AssertDirectEnvelope(dispatch.Calls[1], completed.RecordId, RecordLlmRunCompleted.Descriptor.FullName);
     }
 
-    private static LlmRunRequested BuildRunRequest(string responseId) =>
+    [Fact]
+    public async Task StartAsync_ShouldDispatchForwardedToolCallRecordCommandsInOrder()
+    {
+        var provider = new ScriptedLlmProviderFactory([
+            [
+                new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "call_1",
+                        Name = "get_weather",
+                        ArgumentsJson = """{"city":""",
+                    },
+                },
+                new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "call_1",
+                        Name = "get_weather",
+                        ArgumentsJson = "\"Singapore\"}",
+                    },
+                    Usage = new TokenUsage(5, 7, 12),
+                    IsLast = true,
+                },
+            ],
+        ]);
+        var core = new LlmRunCore(provider, [], NullLogger<LlmRunCore>.Instance);
+        var dispatch = new RecordingDispatchPort();
+        var executor = new LlmRunExecutor(core, dispatch, NullLogger<LlmRunExecutor>.Instance);
+
+        await executor.StartAsync(new LlmRunExecutionRequest(
+            "session-actor-2",
+            BuildRunRequest("resp_forwarded", BuildForwardedSelection()),
+            " run_forwarded ",
+            "ApiKey"));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await dispatch.WaitForCallsAsync(5, cts.Token);
+
+        dispatch.Calls.Select(call => call.ActorId).Should().OnlyContain(actorId => actorId == "session-actor-2");
+        var firstChunk = dispatch.Calls[0].Envelope.Payload!.Unpack<RecordLlmStreamChunkObserved>();
+        firstChunk.RecordId.Should().Be("run_forwarded:chunk:1");
+        firstChunk.ToolCallDelta!.CallId.Should().Be("call_1");
+
+        var secondChunk = dispatch.Calls[1].Envelope.Payload!.Unpack<RecordLlmStreamChunkObserved>();
+        secondChunk.RecordId.Should().Be("run_forwarded:chunk:2");
+        secondChunk.Usage!.TotalTokens.Should().Be(12);
+
+        var observedTool = dispatch.Calls[2].Envelope.Payload!.Unpack<RecordLlmToolCallObserved>();
+        observedTool.RecordId.Should().Be("run_forwarded:tool:3");
+        observedTool.RunId.Should().Be("run_forwarded");
+        observedTool.Forwarded.Should().BeTrue();
+        observedTool.ToolCall!.Arguments.Fields["city"].StringValue.Should().Be("Singapore");
+
+        var forwarded = dispatch.Calls[3].Envelope.Payload!.Unpack<RecordLlmForwardedToolCallEmitted>();
+        forwarded.RecordId.Should().Be("run_forwarded:forwarded-tool:4");
+        forwarded.RunId.Should().Be("run_forwarded");
+        forwarded.Call!.SchemaHash.Should().Be("schema-1");
+        ResponsesJsonValues.ToBoundaryJson(forwarded.Call.Arguments).Should().Be("""{"city":"Singapore"}""");
+
+        var completed = dispatch.Calls[4].Envelope.Payload!.Unpack<RecordLlmRunCompleted>();
+        completed.RecordId.Should().Be("run_forwarded:completed:5");
+        completed.ForwardedToolCalls.Should().ContainSingle()
+            .Which.CallId.Should().Be("call_1");
+        AssertDirectEnvelope(dispatch.Calls[3], forwarded.RecordId, RecordLlmForwardedToolCallEmitted.Descriptor.FullName);
+    }
+
+    [Fact]
+    public async Task StartAsync_ShouldDispatchLocalToolResultRecordCommand()
+    {
+        var tool = new RecordingAgentTool("get_weather", """{"temperature":28}""");
+        var toolProvider = new StaticResponsesToolProvider(substituteTools: [tool]);
+        var provider = new ScriptedLlmProviderFactory([
+            [
+                new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "call_local",
+                        Name = "get_weather",
+                        ArgumentsJson = """{"city":"Singapore"}""",
+                    },
+                    IsLast = true,
+                },
+            ],
+            [
+                new LLMStreamChunk
+                {
+                    DeltaContent = "local done",
+                    IsLast = true,
+                },
+            ],
+        ]);
+        var core = new LlmRunCore(provider, [toolProvider], NullLogger<LlmRunCore>.Instance);
+        var dispatch = new RecordingDispatchPort();
+        var executor = new LlmRunExecutor(core, dispatch, NullLogger<LlmRunExecutor>.Instance);
+        var selection = BuildForwardedSelection();
+        selection.SubstitutedToolNames.Add("get_weather");
+
+        await executor.StartAsync(new LlmRunExecutionRequest(
+            "session-actor-3",
+            BuildRunRequest("resp_local", selection),
+            "run_local",
+            "ApiKey"));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await dispatch.WaitForCallsAsync(4, cts.Token);
+
+        tool.Executions.Should().ContainSingle().Which.Should().Be("""{"city":"Singapore"}""");
+        var localResult = dispatch.Calls[1].Envelope.Payload!.Unpack<RecordLlmToolCallObserved>();
+        localResult.RecordId.Should().Be("run_local:tool:2");
+        localResult.Forwarded.Should().BeFalse();
+        localResult.LocalResultJson.Should().Be("""{"temperature":28}""");
+        localResult.LocalResult!.StructValue.Fields["temperature"].NumberValue.Should().Be(28);
+
+        var completed = dispatch.Calls[3].Envelope.Payload!.Unpack<RecordLlmRunCompleted>();
+        completed.RecordId.Should().Be("run_local:completed:4");
+        completed.OutputText.Should().Be("local done");
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenProviderFails_ShouldDispatchRunFailedRecordCommand()
+    {
+        var provider = new ThrowingLlmProviderFactory(new NyxIdAuthenticationRequiredException("nyxid"));
+        var core = new LlmRunCore(provider, [], NullLogger<LlmRunCore>.Instance);
+        var dispatch = new RecordingDispatchPort();
+        var executor = new LlmRunExecutor(core, dispatch, NullLogger<LlmRunExecutor>.Instance);
+
+        await executor.StartAsync(new LlmRunExecutionRequest(
+            "session-actor-4",
+            BuildRunRequest("resp_failed"),
+            "run_failed",
+            "ApiKey"));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await dispatch.WaitForCallsAsync(1, cts.Token);
+
+        var failed = dispatch.Calls[0].Envelope.Payload!.Unpack<RecordLlmRunFailed>();
+        failed.RecordId.Should().Be("run_failed:failed:1");
+        failed.RunId.Should().Be("run_failed");
+        failed.FailureCode.Should().Be("authentication_required");
+        failed.FailureMessage.Should().Contain("NyxID authentication required");
+        AssertDirectEnvelope(dispatch.Calls[0], failed.RecordId, RecordLlmRunFailed.Descriptor.FullName);
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenProviderCancels_ShouldDispatchRunCancelledRecordCommand()
+    {
+        var provider = new ThrowingLlmProviderFactory(new OperationCanceledException());
+        var core = new LlmRunCore(provider, [], NullLogger<LlmRunCore>.Instance);
+        var dispatch = new RecordingDispatchPort();
+        var executor = new LlmRunExecutor(core, dispatch, NullLogger<LlmRunExecutor>.Instance);
+
+        await executor.StartAsync(new LlmRunExecutionRequest(
+            "session-actor-5",
+            BuildRunRequest("resp_cancelled"),
+            "run_cancelled",
+            "ApiKey"));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await dispatch.WaitForCallsAsync(1, cts.Token);
+
+        var cancelled = dispatch.Calls[0].Envelope.Payload!.Unpack<RecordLlmRunCancelled>();
+        cancelled.RecordId.Should().Be("run_cancelled:cancelled:1");
+        cancelled.RunId.Should().Be("run_cancelled");
+        cancelled.CancelledAt.Should().NotBeNull();
+        AssertDirectEnvelope(dispatch.Calls[0], cancelled.RecordId, RecordLlmRunCancelled.Descriptor.FullName);
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenSinkDispatchFails_ShouldDispatchExecutorFailureRecordCommand()
+    {
+        var provider = new ScriptedLlmProviderFactory([
+            [
+                new LLMStreamChunk
+                {
+                    DeltaContent = "lost",
+                    IsLast = true,
+                },
+            ],
+        ]);
+        var core = new LlmRunCore(provider, [], NullLogger<LlmRunCore>.Instance);
+        var dispatch = new FailingThenRecordingDispatchPort(failuresBeforeSuccess: 2);
+        var executor = new LlmRunExecutor(core, dispatch, NullLogger<LlmRunExecutor>.Instance);
+
+        await executor.StartAsync(new LlmRunExecutionRequest(
+            "session-actor-6",
+            BuildRunRequest("resp_executor_failed"),
+            "run_executor_failed",
+            "ApiKey"));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await dispatch.WaitForAttemptsAsync(3, cts.Token);
+
+        dispatch.Calls.Should().ContainSingle();
+        var failed = dispatch.Calls[0].Envelope.Payload!.Unpack<RecordLlmRunFailed>();
+        failed.RecordId.Should().Be("run_executor_failed:executor-failed");
+        failed.FailureCode.Should().Be("executor_failed");
+        failed.FailureMessage.Should().Contain("Synthetic dispatch failure");
+    }
+
+    private static LlmRunRequested BuildRunRequest(
+        string responseId,
+        LlmSessionRuntimeToolSelection? selection = null) =>
         new()
         {
             ResponseId = responseId,
@@ -56,6 +262,7 @@ public sealed class LlmRunExecutorTests
             OwnerSubject = "user-1",
             BearerToken = "token-1",
             Model = "test-model",
+            ToolSelection = selection,
             Messages =
             {
                 new LlmSessionRuntimeChatMessage
@@ -66,9 +273,42 @@ public sealed class LlmRunExecutorTests
             },
         };
 
+    private static LlmSessionRuntimeToolSelection BuildForwardedSelection() =>
+        new()
+        {
+            ForwardedTools =
+            {
+                new LlmSessionRuntimeToolDeclaration
+                {
+                    ToolName = "get_weather",
+                    Description = "Get weather",
+                    ParametersJson = """{"type":"object"}""",
+                    Parameters = new Struct
+                    {
+                        Fields =
+                        {
+                            ["type"] = Google.Protobuf.WellKnownTypes.Value.ForString("object"),
+                        },
+                    },
+                    SchemaHash = "schema-1",
+                },
+            },
+        };
+
+    private static void AssertDirectEnvelope(
+        (string ActorId, EventEnvelope Envelope) call,
+        string recordId,
+        string payloadFullName)
+    {
+        call.Envelope.Id.Should().Be(recordId);
+        call.Envelope.Payload!.TypeUrl.Should().EndWith(payloadFullName);
+        call.Envelope.Route!.PublisherActorId.Should().Be("gagent-service.llm-run-executor");
+        call.Envelope.Route.GetTargetActorId().Should().Be(call.ActorId);
+        call.Envelope.Propagation!.CorrelationId.Should().Be(recordId);
+    }
+
     private sealed class GateControlledLlmProviderFactory : ILLMProviderFactory, ILLMProvider
     {
-        public TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public string Name => "test";
@@ -84,13 +324,98 @@ public sealed class LlmRunExecutorTests
             [EnumeratorCancellation] CancellationToken ct = default)
         {
             _ = request;
-            Entered.SetResult();
             await Release.Task.WaitAsync(ct);
             yield return new LLMStreamChunk
             {
                 DeltaContent = "done",
                 IsLast = true,
             };
+        }
+    }
+
+    private sealed class ScriptedLlmProviderFactory(
+        IReadOnlyList<IReadOnlyList<LLMStreamChunk>> responses) : ILLMProviderFactory, ILLMProvider
+    {
+        private int _nextResponseIndex;
+
+        public string Name => "test";
+
+        public ILLMProvider GetProvider(string name) => this;
+
+        public ILLMProvider GetDefault() => this;
+
+        public IReadOnlyList<string> GetAvailableProviders() => [Name];
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            _ = request;
+            var response = responses[Math.Min(_nextResponseIndex, responses.Count - 1)];
+            _nextResponseIndex++;
+            foreach (var chunk in response)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return chunk;
+            }
+
+            await Task.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingLlmProviderFactory(Exception exception) : ILLMProviderFactory, ILLMProvider
+    {
+        public string Name => "test";
+
+        public ILLMProvider GetProvider(string name) => this;
+
+        public ILLMProvider GetDefault() => this;
+
+        public IReadOnlyList<string> GetAvailableProviders() => [Name];
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            _ = request;
+            ct.ThrowIfCancellationRequested();
+            await Task.CompletedTask;
+            throw exception;
+            #pragma warning disable CS0162
+            yield return new LLMStreamChunk();
+            #pragma warning restore CS0162
+        }
+    }
+
+    private sealed class StaticResponsesToolProvider(
+        IReadOnlyList<IAgentTool>? substituteTools = null,
+        IReadOnlyList<IAgentTool>? additiveTools = null) : IResponsesToolProvider
+    {
+        public ValueTask<IReadOnlyList<IAgentTool>> GetSubstituteToolsAsync(
+            ResponsesToolProviderContext context,
+            CancellationToken ct = default) =>
+            ValueTask.FromResult(substituteTools ?? []);
+
+        public ValueTask<IReadOnlyList<IAgentTool>> GetAdditiveToolsAsync(
+            ResponsesToolProviderContext context,
+            CancellationToken ct = default) =>
+            ValueTask.FromResult(additiveTools ?? []);
+    }
+
+    private sealed class RecordingAgentTool(string name, string resultJson) : IAgentTool
+    {
+        public List<string> Executions { get; } = [];
+
+        public string Name { get; } = name;
+
+        public string Description => "test tool";
+
+        public string ParametersSchema => """{"type":"object"}""";
+
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+        {
+            Executions.Add(argumentsJson);
+            return Task.FromResult(resultJson);
         }
     }
 
@@ -129,6 +454,64 @@ public sealed class LlmRunExecutorTests
                 ct.Register(static state => ((TaskCompletionSource)state!).TrySetCanceled(), signal);
                 _waiters.Add((count, signal));
                 return signal.Task;
+            }
+        }
+    }
+
+    private sealed class FailingThenRecordingDispatchPort(int failuresBeforeSuccess) : IActorDispatchPort
+    {
+        private readonly List<(int Count, TaskCompletionSource Signal)> _attemptWaiters = [];
+        private int _attempts;
+
+        public List<(string ActorId, EventEnvelope Envelope)> Calls { get; } = [];
+
+        public Task<DispatchAdmission> DispatchAsync(
+            string actorId,
+            EventEnvelope envelope,
+            CancellationToken ct = default)
+        {
+            var attempts = Interlocked.Increment(ref _attempts);
+            if (attempts <= failuresBeforeSuccess)
+            {
+                SignalAttemptWaiters(attempts);
+                throw new InvalidOperationException($"Synthetic dispatch failure {attempts}.");
+            }
+
+            lock (Calls)
+            {
+                Calls.Add((actorId, envelope.Clone()));
+            }
+
+            SignalAttemptWaiters(attempts);
+            return Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
+        }
+
+        public Task WaitForAttemptsAsync(int count, CancellationToken ct)
+        {
+            if (Volatile.Read(ref _attempts) >= count)
+                return Task.CompletedTask;
+
+            lock (_attemptWaiters)
+            {
+                if (_attempts >= count)
+                    return Task.CompletedTask;
+
+                var signal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                ct.Register(static state => ((TaskCompletionSource)state!).TrySetCanceled(), signal);
+                _attemptWaiters.Add((count, signal));
+                return signal.Task;
+            }
+        }
+
+        private void SignalAttemptWaiters(int attempts)
+        {
+            lock (_attemptWaiters)
+            {
+                foreach (var waiter in _attemptWaiters.Where(waiter => attempts >= waiter.Count).ToArray())
+                {
+                    waiter.Signal.TrySetResult();
+                    _attemptWaiters.Remove(waiter);
+                }
             }
         }
     }

--- a/test/Aevatar.GAgentService.Tests/Application/LlmRunExecutorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/LlmRunExecutorTests.cs
@@ -1,0 +1,135 @@
+using System.Runtime.CompilerServices;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Responses;
+using Aevatar.GAgentService.Application.Responses;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.GAgentService.Tests.Application;
+
+public sealed class LlmRunExecutorTests
+{
+    [Fact]
+    public async Task StartAsync_ShouldReturnBeforeStreamingLoopDispatchesRecordCommands()
+    {
+        var provider = new GateControlledLlmProviderFactory();
+        var core = new LlmRunCore(provider, [], NullLogger<LlmRunCore>.Instance);
+        var dispatch = new RecordingDispatchPort();
+        var executor = new LlmRunExecutor(core, dispatch, NullLogger<LlmRunExecutor>.Instance);
+
+        await executor.StartAsync(new LlmRunExecutionRequest(
+            "session-actor-1",
+            BuildRunRequest("resp_executor"),
+            "run_1",
+            "ApiKey"));
+
+        dispatch.Calls.Should().BeEmpty();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        provider.Release.SetResult();
+        await dispatch.WaitForCallsAsync(2, cts.Token);
+
+        dispatch.Calls.Should().HaveCount(2);
+        dispatch.Calls.Select(call => call.ActorId).Should().OnlyContain(actorId => actorId == "session-actor-1");
+        var chunk = dispatch.Calls[0].Envelope.Payload!.Unpack<RecordLlmStreamChunkObserved>();
+        chunk.ResponseId.Should().Be("resp_executor");
+        chunk.RunId.Should().Be("run_1");
+        chunk.RecordId.Should().Be("run_1:chunk:1");
+        chunk.DeltaText.Should().Be("done");
+        dispatch.Calls[0].Envelope.Propagation!.CorrelationId.Should().Be(chunk.RecordId);
+
+        var completed = dispatch.Calls[1].Envelope.Payload!.Unpack<RecordLlmRunCompleted>();
+        completed.RecordId.Should().Be("run_1:completed:2");
+        completed.OutputText.Should().Be("done");
+    }
+
+    private static LlmRunRequested BuildRunRequest(string responseId) =>
+        new()
+        {
+            ResponseId = responseId,
+            RunId = "run_1",
+            ScopeId = "user-1",
+            OwnerSubject = "user-1",
+            BearerToken = "token-1",
+            Model = "test-model",
+            Messages =
+            {
+                new LlmSessionRuntimeChatMessage
+                {
+                    Role = "user",
+                    Content = "Run",
+                },
+            },
+        };
+
+    private sealed class GateControlledLlmProviderFactory : ILLMProviderFactory, ILLMProvider
+    {
+        public TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public string Name => "test";
+
+        public ILLMProvider GetProvider(string name) => this;
+
+        public ILLMProvider GetDefault() => this;
+
+        public IReadOnlyList<string> GetAvailableProviders() => [Name];
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            _ = request;
+            Entered.SetResult();
+            await Release.Task.WaitAsync(ct);
+            yield return new LLMStreamChunk
+            {
+                DeltaContent = "done",
+                IsLast = true,
+            };
+        }
+    }
+
+    private sealed class RecordingDispatchPort : IActorDispatchPort
+    {
+        private readonly List<(int Count, TaskCompletionSource Signal)> _waiters = [];
+
+        public List<(string ActorId, EventEnvelope Envelope)> Calls { get; } = [];
+
+        public Task<DispatchAdmission> DispatchAsync(
+            string actorId,
+            EventEnvelope envelope,
+            CancellationToken ct = default)
+        {
+            lock (Calls)
+            {
+                Calls.Add((actorId, envelope.Clone()));
+                foreach (var waiter in _waiters.Where(waiter => Calls.Count >= waiter.Count).ToArray())
+                {
+                    waiter.Signal.TrySetResult();
+                    _waiters.Remove(waiter);
+                }
+            }
+
+            return Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
+        }
+
+        public Task WaitForCallsAsync(int count, CancellationToken ct)
+        {
+            lock (Calls)
+            {
+                if (Calls.Count >= count)
+                    return Task.CompletedTask;
+
+                var signal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                ct.Register(static state => ((TaskCompletionSource)state!).TrySetCanceled(), signal);
+                _waiters.Add((count, signal));
+                return signal.Task;
+            }
+        }
+    }
+}

--- a/test/Aevatar.GAgentService.Tests/Core/LlmSessionGAgentTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/LlmSessionGAgentTests.cs
@@ -823,6 +823,50 @@ public sealed class LlmSessionGAgentTests
     }
 
     [Fact]
+    public async Task FinalizeLlmRunTimedOutAsync_ShouldCommitRunTimeoutOnlyForActiveRun()
+    {
+        var actor = CreateActor("resp_timeout", services => services.AddSingleton<ILlmRunExecutor, NoOpLlmRunExecutor>());
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_timeout"),
+        });
+        await actor.HandleLlmRunRequestedAsync(BuildRunRequest("resp_timeout"));
+
+        await actor.HandleFinalizeLlmRunTimedOutAsync(new FinalizeLlmRunTimedOut
+        {
+            ResponseId = "resp_timeout",
+            RunId = "run_1",
+            RecordId = "run_1:timeout",
+            TimedOutAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-06-19T00:01:00+00:00")),
+        });
+        var versionAfterTimeout = actor.State.LastAppliedEventVersion;
+
+        await actor.HandleFinalizeLlmRunTimedOutAsync(new FinalizeLlmRunTimedOut
+        {
+            ResponseId = "resp_timeout",
+            RunId = "run_1",
+            RecordId = "run_1:timeout",
+            TimedOutAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-06-19T00:02:00+00:00")),
+        });
+        await actor.HandleFinalizeLlmRunTimedOutAsync(new FinalizeLlmRunTimedOut
+        {
+            ResponseId = "resp_timeout",
+            RunId = "stale-run",
+            RecordId = "stale-run:timeout",
+            TimedOutAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-06-19T00:03:00+00:00")),
+        });
+
+        actor.State.LastAppliedEventVersion.Should().Be(versionAfterTimeout);
+        actor.State.Record!.Status.Should().Be(LlmSessionStatus.Failed);
+        actor.State.ActiveRun!.Status.Should().Be(3);
+        actor.State.ActiveRun.FailureCode.Should().Be("run_timeout");
+        actor.State.ActiveRun.AppliedRecordIds.Should().Contain("run_1:timeout");
+        actor.State.ActiveRun.LastAppliedSequence.Should().Be(2);
+        actor.State.Completion!.FailureCode.Should().Be("run_timeout");
+        actor.State.Completion.FailureMessage.Should().Be("LLM run timed out.");
+    }
+
+    [Fact]
     public async Task ActivateAsync_ShouldReplayOnlyConsecutiveRunEventSequences()
     {
         var eventStore = new InMemoryEventStore();

--- a/test/Aevatar.GAgentService.Tests/Core/LlmSessionGAgentTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/LlmSessionGAgentTests.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Foundation.Runtime.Persistence;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Responses;
@@ -820,6 +821,87 @@ public sealed class LlmSessionGAgentTests
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*active run is 'run_1' and cannot record run 'foreign-run'*");
+    }
+
+    [Fact]
+    public async Task HandleLlmRunRequestedAsync_ShouldScheduleRunTimeoutBeforeStartingExecutor()
+    {
+        var observations = new List<string>();
+        var scheduler = new RecordingRuntimeCallbackScheduler(observations);
+        var executor = new RecordingLlmRunExecutor(observations);
+        var requestedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-06-19T00:00:00+00:00"));
+        var actor = CreateActor(
+            "resp_timeout_schedule",
+            services =>
+            {
+                services.AddSingleton<IActorRuntimeCallbackScheduler>(scheduler);
+                services.AddSingleton<ILlmRunExecutor>(executor);
+            });
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_timeout_schedule"),
+        });
+
+        var request = BuildRunRequest("resp_timeout_schedule");
+        request.RequestedAt = requestedAt;
+        request.TimeoutAfter = Duration.FromTimeSpan(TimeSpan.FromMinutes(5));
+
+        await actor.HandleLlmRunRequestedAsync(request);
+
+        var runTimeout = scheduler.TimeoutRequests.Should().ContainSingle(request =>
+            string.Equals(
+                request.CallbackId,
+                "llm-run-timeout:resp_timeout_schedule:run_1",
+                StringComparison.Ordinal)).Subject;
+        runTimeout.ActorId.Should().Be(actor.Id);
+        runTimeout.DueTime.Should().BeGreaterThan(TimeSpan.Zero);
+        var payload = runTimeout.TriggerEnvelope.Payload.Unpack<FinalizeLlmRunTimedOut>();
+        payload.ResponseId.Should().Be("resp_timeout_schedule");
+        payload.RunId.Should().Be("run_1");
+        payload.RecordId.Should().Be("run_1:timeout");
+        payload.TimedOutAt.Should().Be(
+            Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-06-19T00:05:00+00:00")));
+        executor.StartRequests.Should().ContainSingle()
+            .Which.RunId.Should().Be("run_1");
+        observations.IndexOf("schedule:llm-run-timeout:resp_timeout_schedule:run_1")
+            .Should().BeLessThan(observations.IndexOf("executor:start"));
+    }
+
+    [Fact]
+    public async Task HandleLlmRunRequestedAsync_WhenRunTimeoutSchedulingFails_ShouldFailRunWithoutStartingExecutor()
+    {
+        var scheduler = new RunTimeoutFailingRuntimeCallbackScheduler();
+        var executor = new RecordingLlmRunExecutor();
+        var actor = CreateActor(
+            "resp_timeout_schedule_failure",
+            services =>
+            {
+                services.AddSingleton<IActorRuntimeCallbackScheduler>(scheduler);
+                services.AddSingleton<ILlmRunExecutor>(executor);
+            });
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_timeout_schedule_failure"),
+        });
+
+        await actor.HandleLlmRunRequestedAsync(BuildRunRequest("resp_timeout_schedule_failure"));
+
+        scheduler.TimeoutRequests.Should().ContainSingle(request =>
+            string.Equals(
+                request.CallbackId,
+                "llm-run-timeout:resp_timeout_schedule_failure:run_1",
+                StringComparison.Ordinal));
+        executor.StartRequests.Should().BeEmpty();
+        actor.State.Record!.Status.Should().Be(LlmSessionStatus.Failed);
+        actor.State.ActiveRun.Should().NotBeNull();
+        actor.State.ActiveRun!.Status.Should().Be(3);
+        actor.State.ActiveRun.FailureCode.Should().Be("run_timeout_schedule_failed");
+        actor.State.ActiveRun.FailureMessage.Should().Be("synthetic scheduler failure.");
+        actor.State.ActiveRun.AppliedRecordIds.Should().Contain("run_1:timeout-schedule-failed");
+        actor.State.ActiveRun.LastAppliedSequence.Should().Be(2);
+        actor.State.Completion.Should().NotBeNull();
+        actor.State.Completion!.FailureCode.Should().Be("run_timeout_schedule_failed");
+        actor.State.Completion.FailureMessage.Should().Be("synthetic scheduler failure.");
     }
 
     [Fact]
@@ -1989,6 +2071,96 @@ public sealed class LlmSessionGAgentTests
             _ = request;
             _ = ct;
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingLlmRunExecutor(List<string>? observations = null) : ILlmRunExecutor
+    {
+        public List<LlmRunExecutionRequest> StartRequests { get; } = [];
+
+        public Task StartAsync(
+            LlmRunExecutionRequest request,
+            CancellationToken ct = default)
+        {
+            _ = ct;
+            StartRequests.Add(request);
+            observations?.Add("executor:start");
+            return Task.CompletedTask;
+        }
+    }
+
+    private class RecordingRuntimeCallbackScheduler(List<string>? observations = null) : IActorRuntimeCallbackScheduler
+    {
+        public List<RuntimeCallbackTimeoutRequest> TimeoutRequests { get; } = [];
+
+        public virtual Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
+            RuntimeCallbackTimeoutRequest request,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            TimeoutRequests.Add(CloneRequest(request));
+            observations?.Add("schedule:" + request.CallbackId);
+            return Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                TimeoutRequests.Count,
+                RuntimeCallbackBackend.InMemory));
+        }
+
+        public Task<RuntimeCallbackLease> ScheduleTimerAsync(
+            RuntimeCallbackTimerRequest request,
+            CancellationToken ct = default)
+        {
+            _ = request;
+            ct.ThrowIfCancellationRequested();
+            throw new NotSupportedException();
+        }
+
+        public Task CancelAsync(RuntimeCallbackLease lease, CancellationToken ct = default)
+        {
+            _ = lease;
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public Task PurgeActorAsync(string actorId, CancellationToken ct = default)
+        {
+            _ = actorId;
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        private static RuntimeCallbackTimeoutRequest CloneRequest(RuntimeCallbackTimeoutRequest request) =>
+            new()
+            {
+                ActorId = request.ActorId,
+                CallbackId = request.CallbackId,
+                TriggerEnvelope = request.TriggerEnvelope.Clone(),
+                DueTime = request.DueTime,
+                DeliveryMode = request.DeliveryMode,
+            };
+    }
+
+    private sealed class RunTimeoutFailingRuntimeCallbackScheduler : RecordingRuntimeCallbackScheduler
+    {
+        public override Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
+            RuntimeCallbackTimeoutRequest request,
+            CancellationToken ct = default)
+        {
+            if (request.CallbackId.StartsWith("llm-run-timeout:", StringComparison.Ordinal))
+            {
+                TimeoutRequests.Add(new RuntimeCallbackTimeoutRequest
+                {
+                    ActorId = request.ActorId,
+                    CallbackId = request.CallbackId,
+                    TriggerEnvelope = request.TriggerEnvelope.Clone(),
+                    DueTime = request.DueTime,
+                    DeliveryMode = request.DeliveryMode,
+                });
+                throw new InvalidOperationException("synthetic scheduler failure.");
+            }
+
+            return base.ScheduleTimeoutAsync(request, ct);
         }
     }
 }

--- a/test/Aevatar.GAgentService.Tests/Core/LlmSessionGAgentTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/LlmSessionGAgentTests.cs
@@ -766,6 +766,63 @@ public sealed class LlmSessionGAgentTests
     }
 
     [Fact]
+    public async Task RecordCommands_ShouldAssignActorOwnedSequence_AndIgnoreDuplicateRecordId()
+    {
+        var actor = CreateActor("resp_records", services => services.AddSingleton<ILlmRunExecutor, NoOpLlmRunExecutor>());
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_records"),
+        });
+        await actor.HandleLlmRunRequestedAsync(BuildRunRequest("resp_records"));
+
+        await actor.HandleRecordStreamChunkObservedAsync(new RecordLlmStreamChunkObserved
+        {
+            ResponseId = "resp_records",
+            RunId = "run_1",
+            RecordId = "run_1:manual:1",
+            Round = 0,
+            DeltaText = " late",
+        });
+        var versionAfterRecord = actor.State.LastAppliedEventVersion;
+
+        await actor.HandleRecordStreamChunkObservedAsync(new RecordLlmStreamChunkObserved
+        {
+            ResponseId = "resp_records",
+            RunId = "run_1",
+            RecordId = "run_1:manual:1",
+            Round = 0,
+            DeltaText = " duplicate",
+        });
+
+        actor.State.LastAppliedEventVersion.Should().Be(versionAfterRecord);
+        actor.State.ActiveRun!.AppliedRecordIds.Should().Contain("run_1:manual:1");
+        actor.State.ActiveRun.OutputText.Should().Be(" late");
+        actor.State.ActiveRun.LastAppliedSequence.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task RecordCommands_ShouldRejectOutOfRunRecord()
+    {
+        var actor = CreateActor("resp_records", services => services.AddSingleton<ILlmRunExecutor, NoOpLlmRunExecutor>());
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_records"),
+        });
+        await actor.HandleLlmRunRequestedAsync(BuildRunRequest("resp_records"));
+
+        var act = () => actor.HandleRecordStreamChunkObservedAsync(new RecordLlmStreamChunkObserved
+        {
+            ResponseId = "resp_records",
+            RunId = "foreign-run",
+            RecordId = "foreign-run:chunk:1",
+            DeltaText = "wrong",
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*active run is 'run_1' and cannot record run 'foreign-run'*");
+    }
+
+    [Fact]
     public async Task ActivateAsync_ShouldReplayOnlyConsecutiveRunEventSequences()
     {
         var eventStore = new InMemoryEventStore();
@@ -1877,5 +1934,17 @@ public sealed class LlmSessionGAgentTests
 
         public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
             Task.FromException<string>(exception);
+    }
+
+    private sealed class NoOpLlmRunExecutor : ILlmRunExecutor
+    {
+        public Task StartAsync(
+            LlmRunExecutionRequest request,
+            CancellationToken ct = default)
+        {
+            _ = request;
+            _ = ct;
+            return Task.CompletedTask;
+        }
     }
 }

--- a/test/Aevatar.GAgentService.Tests/Projection/LlmSessionsProtoSurfaceRegressionTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/LlmSessionsProtoSurfaceRegressionTests.cs
@@ -41,6 +41,15 @@ public sealed class LlmSessionsProtoSurfaceRegressionTests
 
         TopLevelMessageNames(descriptor).Should().Contain("LlmRunStartedEvent");
         TopLevelMessageNames(descriptor).Should().NotContain("LlmRunRecordAppliedEvent");
+        TopLevelMessageNames(descriptor).Should().Contain(
+            [
+                "RecordLlmStreamChunkObserved",
+                "RecordLlmToolCallObserved",
+                "RecordLlmForwardedToolCallEmitted",
+                "RecordLlmRunCompleted",
+                "RecordLlmRunFailed",
+                "RecordLlmRunCancelled",
+            ]);
         LlmRunStartedEvent.Descriptor.FindFieldByName("sequence").Should().NotBeNull();
         LlmStreamChunkObserved.Descriptor.FindFieldByName("sequence").Should().NotBeNull();
         LlmToolCallObserved.Descriptor.FindFieldByName("sequence").Should().NotBeNull();
@@ -48,6 +57,7 @@ public sealed class LlmSessionsProtoSurfaceRegressionTests
         LlmRunFailed.Descriptor.FindFieldByName("sequence").Should().NotBeNull();
         LlmRunCancelled.Descriptor.FindFieldByName("sequence").Should().NotBeNull();
         LlmSessionRunScope.Descriptor.FindFieldByName("last_applied_sequence").Should().NotBeNull();
+        LlmSessionRunScope.Descriptor.FindFieldByName("applied_record_ids").Should().NotBeNull();
     }
 
     private static IEnumerable<string> TopLevelMessageNames(FileDescriptor descriptor) =>

--- a/test/Aevatar.GAgentService.Tests/Projection/LlmSessionsProtoSurfaceRegressionTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/LlmSessionsProtoSurfaceRegressionTests.cs
@@ -49,7 +49,9 @@ public sealed class LlmSessionsProtoSurfaceRegressionTests
                 "RecordLlmRunCompleted",
                 "RecordLlmRunFailed",
                 "RecordLlmRunCancelled",
+                "FinalizeLlmRunTimedOut",
             ]);
+        LlmRunRequested.Descriptor.FindFieldByName("timeout_after").Should().NotBeNull();
         LlmRunStartedEvent.Descriptor.FindFieldByName("sequence").Should().NotBeNull();
         LlmStreamChunkObserved.Descriptor.FindFieldByName("sequence").Should().NotBeNull();
         LlmToolCallObserved.Descriptor.FindFieldByName("sequence").Should().NotBeNull();

--- a/test/Aevatar.GAgentService.Tests/TestSupport/GAgentServiceTestKit.cs
+++ b/test/Aevatar.GAgentService.Tests/TestSupport/GAgentServiceTestKit.cs
@@ -11,6 +11,7 @@ using Aevatar.Foundation.Runtime.Streaming;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Responses;
 using Aevatar.GAgentService.Application.Responses;
+using Aevatar.GAgentService.Core.GAgents;
 using Google.Protobuf;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -145,6 +146,10 @@ internal static class GAgentServiceTestKit
             .AddSingleton<ILlmRunCore, LlmRunCore>()
             .AddSingleton<ILogger<LlmRunCore>>(NullLogger<LlmRunCore>.Instance)
             .AddSingleton<IEnumerable<IGAgentExecutionHook>>(Array.Empty<IGAgentExecutionHook>());
+        if (agent is LlmSessionGAgent llmSession)
+            services.AddSingleton<ILlmRunExecutor>(sp => new InlineLlmRunExecutor(
+                sp.GetRequiredService<ILlmRunCore>(),
+                llmSession));
         configureServices?.Invoke(services);
         agent.Services = services.BuildServiceProvider();
         return agent;
@@ -164,6 +169,140 @@ internal static class GAgentServiceTestKit
             EventEnvelope envelope,
             CancellationToken ct = default) =>
             Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
+    }
+
+    private sealed class InlineLlmRunExecutor(
+        ILlmRunCore runCore,
+        LlmSessionGAgent actor) : ILlmRunExecutor
+    {
+        public Task StartAsync(
+            LlmRunExecutionRequest request,
+            CancellationToken ct = default) =>
+            runCore.RunAsync(
+                new LlmRunCoreRequest(request.Command.Clone(), request.RunId, request.OriginPlatform),
+                new InlineLlmRunSink(actor, request.RunId),
+                ct);
+    }
+
+    private sealed class InlineLlmRunSink(
+        LlmSessionGAgent actor,
+        string runId) : ILlmRunSink
+    {
+        private long _recordIndex;
+
+        public Task RecordStreamChunkObservedAsync(
+            LlmStreamChunkObserved observed,
+            CancellationToken ct = default)
+        {
+            _ = ct;
+            var recordId = NextRecordId("chunk");
+            return actor.HandleRecordStreamChunkObservedAsync(new RecordLlmStreamChunkObserved
+            {
+                ResponseId = observed.ResponseId,
+                RunId = ResolveRunId(observed.RunId),
+                RecordId = recordId,
+                Round = observed.Round,
+                DeltaText = observed.DeltaText ?? string.Empty,
+                ToolCallDelta = observed.ToolCallDelta?.Clone(),
+                Usage = observed.Usage?.Clone(),
+                ObservedAt = observed.ObservedAt?.Clone(),
+            });
+        }
+
+        public Task RecordToolCallObservedAsync(
+            LlmToolCallObserved observed,
+            CancellationToken ct = default)
+        {
+            _ = ct;
+            var recordId = NextRecordId("tool");
+            return actor.HandleRecordToolCallObservedAsync(new RecordLlmToolCallObserved
+            {
+                ResponseId = observed.ResponseId,
+                RunId = ResolveRunId(observed.RunId),
+                RecordId = recordId,
+                Round = observed.Round,
+                ToolCall = observed.ToolCall?.Clone(),
+                Forwarded = observed.Forwarded,
+                LocalResultJson = observed.LocalResultJson ?? string.Empty,
+                ObservedAt = observed.ObservedAt?.Clone(),
+                LocalResult = observed.LocalResult?.Clone(),
+            });
+        }
+
+        public Task RecordForwardedToolCallEmittedAsync(
+            LlmSessionForwardedToolCallEmittedEvent emitted,
+            CancellationToken ct = default)
+        {
+            _ = ct;
+            var recordId = NextRecordId("forwarded-tool");
+            return actor.HandleRecordForwardedToolCallEmittedAsync(new RecordLlmForwardedToolCallEmitted
+            {
+                ResponseId = emitted.ResponseId,
+                RunId = runId,
+                RecordId = recordId,
+                Call = emitted.Call?.Clone(),
+            });
+        }
+
+        public Task RecordRunCompletedAsync(
+            LlmRunCompleted completed,
+            CancellationToken ct = default)
+        {
+            _ = ct;
+            var recordId = NextRecordId("completed");
+            var command = new RecordLlmRunCompleted
+            {
+                ResponseId = completed.ResponseId,
+                RunId = ResolveRunId(completed.RunId),
+                RecordId = recordId,
+                OutputText = completed.OutputText ?? string.Empty,
+                Usage = completed.Usage?.Clone(),
+                CompletedAt = completed.CompletedAt?.Clone(),
+            };
+            command.ForwardedToolCalls.AddRange(completed.ForwardedToolCalls.Select(static call => call.Clone()));
+            return actor.HandleRecordRunCompletedAsync(command);
+        }
+
+        public Task RecordRunFailedAsync(
+            LlmRunFailed failed,
+            CancellationToken ct = default)
+        {
+            _ = ct;
+            var recordId = NextRecordId("failed");
+            return actor.HandleRecordRunFailedAsync(new RecordLlmRunFailed
+            {
+                ResponseId = failed.ResponseId,
+                RunId = ResolveRunId(failed.RunId),
+                RecordId = recordId,
+                FailureCode = failed.FailureCode ?? string.Empty,
+                FailureMessage = failed.FailureMessage ?? string.Empty,
+                FailedAt = failed.FailedAt?.Clone(),
+            });
+        }
+
+        public Task RecordRunCancelledAsync(
+            LlmRunCancelled cancelled,
+            CancellationToken ct = default)
+        {
+            _ = ct;
+            var recordId = NextRecordId("cancelled");
+            return actor.HandleRecordRunCancelledAsync(new RecordLlmRunCancelled
+            {
+                ResponseId = cancelled.ResponseId,
+                RunId = ResolveRunId(cancelled.RunId),
+                RecordId = recordId,
+                CancelledAt = cancelled.CancelledAt?.Clone(),
+            });
+        }
+
+        private string NextRecordId(string kind)
+        {
+            var index = Interlocked.Increment(ref _recordIndex);
+            return $"{runId}:{kind}:{index}";
+        }
+
+        private string ResolveRunId(string? candidate) =>
+            string.IsNullOrWhiteSpace(candidate) ? runId : candidate.Trim();
     }
 }
 


### PR DESCRIPTION
## Changed files

本次变更把 `LlmSessionGAgent` 的 LLM run 执行从 actor handler turn 中移出：actor 只负责短 turn 的 run lifecycle、typed record command、sequence/idempotency 和 terminal 状态；新的 `LlmRunExecutor` 在 DI 中作为无状态执行器消费 `LlmRunCore` 流，并通过 accepted-only `IActorDispatchPort` 回投记录命令。

同步扩展了 `llm_sessions.proto` 的 typed recorder command 和 record id 字段，更新 session actor reducer、hosting 注册、actor test kit、proto surface regression 和 executor/actor 行为测试。

## Test results

- `dotnet build aevatar.slnx --nologo`: passed
- `dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo`: passed, 903 tests
- `dotnet test test/Aevatar.Capabilities.Tests/Aevatar.Capabilities.Tests.csproj --nologo`: passed, 299 tests
- `bash tools/ci/test_stability_guards.sh`: passed
- projection state/version, state mirror, query priming, and route mapping guards: passed
- `bash tools/ci/architecture_guards.sh`: passed

## Deviations

已记录两个 scope extension，用于现有 proto surface regression 测试文件和共享 actor test kit。`HOST_REFACTOR_COMMENT_POLICY` 为空并归一化为 `none`，因此未新增 issue-2271 refactor-history source comments。

Closes #2271

⟦AI:AUTO-LOOP⟧
