### PR TITLE
修复 LLM 工具归属计划与轮次耗尽失败语义

### DIFF
--- a/src/platform/Aevatar.GAgentService.Application/Responses/LlmRunCore.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/LlmRunCore.cs
@@ -63,6 +63,7 @@ public sealed class LlmRunCore(
         var provider = providerFactory.GetDefault();
         var toolContext = BuildToolContext(command);
         var tools = await BuildEffectiveToolsAsync(command, toolContext, request.OriginPlatform, ct).ConfigureAwait(false);
+        var ownershipPlan = LlmToolOwnershipPlan.From(command.ToolSelection, tools);
         var messages = command.Messages.Select(ToChatMessage).ToList();
         var outputText = new System.Text.StringBuilder();
         TokenUsage? usage = null;
@@ -127,7 +128,8 @@ public sealed class LlmRunCore(
             }
 
             var builtToolCalls = ApplyToolChoiceHint(toolCalls.BuildToolCalls(), command.ToolSelection);
-            var forwardedToolCalls = SelectForwardedToolCalls(builtToolCalls, command.ToolSelection);
+            var routedToolCalls = ownershipPlan.Route(builtToolCalls);
+            var forwardedToolCalls = routedToolCalls.Forwarded;
             foreach (var toolCall in forwardedToolCalls)
             {
                 await sink.RecordToolCallObservedAsync(new LlmToolCallObserved
@@ -160,7 +162,7 @@ public sealed class LlmRunCore(
                 return;
             }
 
-            var localToolCalls = SelectLocalToolCalls(builtToolCalls, command.ToolSelection, tools);
+            var localToolCalls = routedToolCalls.Local;
             if (localToolCalls.Count == 0)
             {
                 await sink.RecordRunCompletedAsync(new LlmRunCompleted
@@ -179,17 +181,17 @@ public sealed class LlmRunCore(
                 Role = "assistant",
                 ToolCalls = localToolCalls,
             });
-            await ExecuteLocalToolCallsAsync(command, request.RunId, round, localToolCalls, tools, messages, toolContext, sink, ct)
+            await ExecuteLocalToolCallsAsync(command, request.RunId, round, localToolCalls, ownershipPlan, messages, toolContext, sink, ct)
                 .ConfigureAwait(false);
         }
 
-        await sink.RecordRunCompletedAsync(new LlmRunCompleted
+        await sink.RecordRunFailedAsync(new LlmRunFailed
         {
             ResponseId = command.ResponseId,
             RunId = request.RunId,
-            OutputText = outputText.ToString(),
-            Usage = usage is null ? null : ToSessionUsage(usage),
-            CompletedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+            FailureCode = "max_tool_rounds_exhausted",
+            FailureMessage = $"LLM run exceeded the maximum of {MaxToolRounds} tool rounds.",
+            FailedAt = Timestamp.FromDateTime(DateTime.UtcNow),
         }, ct).ConfigureAwait(false);
     }
 
@@ -297,17 +299,12 @@ public sealed class LlmRunCore(
         string runId,
         int round,
         IReadOnlyList<ToolCall> localToolCalls,
-        IReadOnlyList<IAgentTool> tools,
+        LlmToolOwnershipPlan ownershipPlan,
         List<ChatMessage> messages,
         AgentToolExecutionContext toolContext,
         ILlmRunSink sink,
         CancellationToken ct)
     {
-        var toolsByName = tools
-            .Where(static tool => tool is not ForwardedRuntimeTool)
-            .GroupBy(static tool => tool.Name, StringComparer.Ordinal)
-            .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.Ordinal);
-
         using (AgentToolContextScope.Push(toolContext))
         {
             foreach (var toolCall in localToolCalls)
@@ -316,13 +313,9 @@ public sealed class LlmRunCore(
                 var argumentsJson = string.IsNullOrWhiteSpace(toolCall.ArgumentsJson)
                     ? "{}"
                     : toolCall.ArgumentsJson;
-                var result = toolsByName.TryGetValue(toolCall.Name, out var tool)
+                var result = ownershipPlan.TryGetExecutableTool(toolCall.Name, out var tool)
                     ? await ResponsesSafeToolExecutor.ExecuteAsync(tool, argumentsJson, ct).ConfigureAwait(false)
-                    : JsonSerializer.Serialize(new
-                    {
-                        error = "aevatar_substitute_tool_not_registered",
-                        tool_name = toolCall.Name,
-                    });
+                    : BuildLocalToolUnavailableResult(ownershipPlan.ResolveUnavailableToolCode(toolCall.Name), toolCall.Name);
 
                 await sink.RecordToolCallObservedAsync(new LlmToolCallObserved
                 {
@@ -401,23 +394,6 @@ public sealed class LlmRunCore(
         if (chunk.DeltaContentPart is { Kind: ContentPartKind.Text } part && !string.IsNullOrWhiteSpace(part.Text))
             return part.Text;
         return null;
-    }
-
-    private static IReadOnlyList<ToolCall> SelectForwardedToolCalls(
-        IReadOnlyList<ToolCall> toolCalls,
-        LlmSessionRuntimeToolSelection? selection)
-    {
-        if (selection is null || toolCalls.Count == 0 || selection.ForwardedTools.Count == 0)
-            return [];
-
-        var ownedToolNames = BuildOwnedToolNameSet(selection);
-        var forwardedToolNames = selection.ForwardedTools
-            .Select(static tool => tool.ToolName)
-            .Where(name => !ownedToolNames.Contains(name))
-            .ToHashSet(StringComparer.Ordinal);
-        return toolCalls
-            .Where(call => forwardedToolNames.Contains(call.Name))
-            .ToArray();
     }
 
     private static IReadOnlyList<ToolCall> ApplyToolChoiceHint(
@@ -583,29 +559,6 @@ public sealed class LlmRunCore(
             },
         });
 
-    private static IReadOnlyList<ToolCall> SelectLocalToolCalls(
-        IReadOnlyList<ToolCall> toolCalls,
-        LlmSessionRuntimeToolSelection? selection,
-        IReadOnlyList<IAgentTool> tools)
-    {
-        if (toolCalls.Count == 0 || tools.Count == 0)
-            return [];
-
-        var ownedToolNames = BuildOwnedToolNameSet(selection);
-        var forwardedNames = (selection?.ForwardedTools ?? [])
-            .Select(static tool => tool.ToolName)
-            .Where(name => !ownedToolNames.Contains(name))
-            .ToHashSet(StringComparer.Ordinal);
-        var localNames = tools
-            .Where(static tool => tool is not ForwardedRuntimeTool)
-            .Select(static tool => tool.Name)
-            .Where(name => !forwardedNames.Contains(name))
-            .ToHashSet(StringComparer.Ordinal);
-        return toolCalls
-            .Where(call => localNames.Contains(call.Name))
-            .ToArray();
-    }
-
     private static HashSet<string> BuildOwnedToolNameSet(LlmSessionRuntimeToolSelection? selection)
     {
         if (selection is null)
@@ -634,6 +587,15 @@ public sealed class LlmRunCore(
             Expiry = Timestamp.FromDateTime(DateTime.UtcNow.Add(DefaultTtl.ToTimeSpan())),
         };
     }
+
+    private static string BuildLocalToolUnavailableResult(
+        string code,
+        string toolName) =>
+        JsonSerializer.Serialize(new
+        {
+            error = code,
+            tool_name = toolName,
+        });
 
     private static string MapFailureCode(Exception ex) =>
         ex switch
@@ -667,6 +629,78 @@ public sealed class LlmRunCore(
         public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
             throw new InvalidOperationException(
                 $"Forwarded Responses tool '{Name}' must be executed by the client, not by Aevatar.");
+    }
+
+    private sealed class LlmToolOwnershipPlan
+    {
+        private readonly IReadOnlyDictionary<string, IAgentTool> _executableTools;
+        private readonly IReadOnlySet<string> _ownedToolNames;
+        private readonly IReadOnlySet<string> _forwardedToolNames;
+
+        private LlmToolOwnershipPlan(
+            IReadOnlyDictionary<string, IAgentTool> executableTools,
+            IReadOnlySet<string> ownedToolNames,
+            IReadOnlySet<string> forwardedToolNames)
+        {
+            _executableTools = executableTools;
+            _ownedToolNames = ownedToolNames;
+            _forwardedToolNames = forwardedToolNames;
+        }
+
+        public static LlmToolOwnershipPlan From(
+            LlmSessionRuntimeToolSelection? selection,
+            IReadOnlyList<IAgentTool> effectiveTools)
+        {
+            var ownedToolNames = BuildOwnedToolNameSet(selection);
+            var forwardedToolNames = (selection?.ForwardedTools ?? [])
+                .Select(static tool => tool.ToolName)
+                .Where(name => !ownedToolNames.Contains(name))
+                .ToHashSet(StringComparer.Ordinal);
+            var executableTools = effectiveTools
+                .Where(static tool => tool is not ForwardedRuntimeTool)
+                .GroupBy(static tool => tool.Name, StringComparer.Ordinal)
+                .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.Ordinal);
+
+            return new LlmToolOwnershipPlan(executableTools, ownedToolNames, forwardedToolNames);
+        }
+
+        public RoutedToolCalls Route(IReadOnlyList<ToolCall> toolCalls)
+        {
+            if (toolCalls.Count == 0)
+                return RoutedToolCalls.Empty;
+
+            var forwarded = new List<ToolCall>();
+            var local = new List<ToolCall>();
+            foreach (var toolCall in toolCalls)
+            {
+                if (_forwardedToolNames.Contains(toolCall.Name))
+                {
+                    forwarded.Add(toolCall);
+                    continue;
+                }
+
+                local.Add(toolCall);
+            }
+
+            return new RoutedToolCalls(local, forwarded);
+        }
+
+        public bool TryGetExecutableTool(
+            string toolName,
+            out IAgentTool tool) =>
+            _executableTools.TryGetValue(toolName, out tool!);
+
+        public string ResolveUnavailableToolCode(string toolName) =>
+            _ownedToolNames.Contains(toolName)
+                ? "tool_not_available"
+                : "tool_not_declared";
+    }
+
+    private sealed record RoutedToolCalls(
+        IReadOnlyList<ToolCall> Local,
+        IReadOnlyList<ToolCall> Forwarded)
+    {
+        public static RoutedToolCalls Empty { get; } = new([], []);
     }
 
     private sealed class RuntimeToolCallAccumulator

--- a/test/Aevatar.GAgentService.Tests/Application/LlmRunCoreTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/LlmRunCoreTests.cs
@@ -235,6 +235,136 @@ public sealed class LlmRunCoreTests
     }
 
     [Fact]
+    public async Task RunAsync_WhenOwnedToolIsMissingFromDiscovery_ShouldReturnLocalToolUnavailableResult()
+    {
+        var provider = new ScriptedLlmProviderFactory([
+            [
+                new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "call_missing",
+                        Name = "use_skill",
+                        ArgumentsJson = """{"name":"writer"}""",
+                    },
+                    IsLast = true,
+                },
+            ],
+            [
+                new LLMStreamChunk
+                {
+                    DeltaContent = "missing tool reported",
+                    IsLast = true,
+                },
+            ],
+        ]);
+        var sink = new RecordingLlmRunSink();
+        var core = new LlmRunCore(provider, [], NullLogger<LlmRunCore>.Instance);
+        var selection = new LlmSessionRuntimeToolSelection
+        {
+            OwnedToolNames = { "use_skill" },
+        };
+
+        await core.RunAsync(
+            new LlmRunCoreRequest(BuildRunRequest("resp_missing", selection), "run_1", "ApiKey"),
+            sink);
+
+        sink.ForwardedToolCalls.Should().BeEmpty();
+        var observed = sink.ToolCalls.Should().ContainSingle(observed => !observed.Forwarded).Subject;
+        observed.ToolCall.ToolName.Should().Be("use_skill");
+        observed.LocalResultJson.Should().Be("""{"error":"tool_not_available","tool_name":"use_skill"}""");
+        observed.LocalResult.StructValue.Fields["error"].StringValue.Should().Be("tool_not_available");
+        provider.Requests.Should().HaveCount(2);
+        provider.Requests[1].Messages.Should().Contain(message =>
+            string.Equals(message.Role, "tool", StringComparison.Ordinal) &&
+            message.Content != null &&
+            message.Content.Contains("tool_not_available", StringComparison.Ordinal));
+        sink.Completed.Should().ContainSingle()
+            .Which.OutputText.Should().Be("missing tool reported");
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenModelCallsUnknownTool_ShouldReturnLocalToolNotDeclaredResult()
+    {
+        var provider = new ScriptedLlmProviderFactory([
+            [
+                new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "call_unknown",
+                        Name = "unknown_tool",
+                        ArgumentsJson = """{"value":1}""",
+                    },
+                    IsLast = true,
+                },
+            ],
+            [
+                new LLMStreamChunk
+                {
+                    DeltaContent = "unknown tool reported",
+                    IsLast = true,
+                },
+            ],
+        ]);
+        var sink = new RecordingLlmRunSink();
+        var core = new LlmRunCore(provider, [], NullLogger<LlmRunCore>.Instance);
+
+        await core.RunAsync(
+            new LlmRunCoreRequest(BuildRunRequest("resp_unknown"), "run_1", "ApiKey"),
+            sink);
+
+        sink.ForwardedToolCalls.Should().BeEmpty();
+        var observed = sink.ToolCalls.Should().ContainSingle(observed => !observed.Forwarded).Subject;
+        observed.ToolCall.ToolName.Should().Be("unknown_tool");
+        observed.LocalResultJson.Should().Be("""{"error":"tool_not_declared","tool_name":"unknown_tool"}""");
+        observed.LocalResult.StructValue.Fields["error"].StringValue.Should().Be("tool_not_declared");
+        provider.Requests.Should().HaveCount(2);
+        provider.Requests[1].Messages.Should().Contain(message =>
+            string.Equals(message.Role, "tool", StringComparison.Ordinal) &&
+            message.Content != null &&
+            message.Content.Contains("tool_not_declared", StringComparison.Ordinal));
+        sink.Completed.Should().ContainSingle()
+            .Which.OutputText.Should().Be("unknown tool reported");
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenToolCallsExhaustMaximumRounds_ShouldRecordFailure()
+    {
+        var tool = new RecordingAgentTool("get_weather", """{"temperature":28}""");
+        var toolProvider = new StaticResponsesToolProvider(substituteTools: [tool]);
+        var provider = new ScriptedLlmProviderFactory([
+            [
+                new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "call_1",
+                        Name = "get_weather",
+                        ArgumentsJson = """{"city":"Singapore"}""",
+                    },
+                    IsLast = true,
+                },
+            ],
+        ]);
+        var sink = new RecordingLlmRunSink();
+        var core = new LlmRunCore(provider, [toolProvider], NullLogger<LlmRunCore>.Instance);
+        var selection = BuildForwardedSelection();
+        selection.OwnedToolNames.Add("get_weather");
+        selection.SubstitutedToolNames.Add("get_weather");
+
+        await core.RunAsync(
+            new LlmRunCoreRequest(BuildRunRequest("resp_rounds", selection), "run_1", "ApiKey"),
+            sink);
+
+        tool.Executions.Should().HaveCount(8);
+        provider.Requests.Should().HaveCount(8);
+        sink.Completed.Should().BeEmpty();
+        sink.Failed.Should().ContainSingle()
+            .Which.FailureCode.Should().Be("max_tool_rounds_exhausted");
+    }
+
+    [Fact]
     public async Task RunAsync_WhenProviderThrows_ShouldRecordFailureThroughSink()
     {
         var provider = new ThrowingLlmProviderFactory(

--- a/test/Aevatar.GAgentService.Tests/Projection/LlmSessionsProtoSurfaceRegressionTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/LlmSessionsProtoSurfaceRegressionTests.cs
@@ -52,6 +52,7 @@ public sealed class LlmSessionsProtoSurfaceRegressionTests
                 "FinalizeLlmRunTimedOut",
             ]);
         LlmRunRequested.Descriptor.FindFieldByName("timeout_after").Should().NotBeNull();
+        LlmSessionRuntimeToolSelection.Descriptor.FindFieldByName("owned_tool_names").Should().NotBeNull();
         LlmRunStartedEvent.Descriptor.FindFieldByName("sequence").Should().NotBeNull();
         LlmStreamChunkObserved.Descriptor.FindFieldByName("sequence").Should().NotBeNull();
         LlmToolCallObserved.Descriptor.FindFieldByName("sequence").Should().NotBeNull();


### PR DESCRIPTION
## Changed files

- `src/platform/Aevatar.GAgentService.Application/Responses/LlmRunCore.cs`: 将工具调用路由收敛到命令派生的私有 ownership plan；owned 缺失工具返回结构化本地结果，未知工具返回未声明结果；工具轮次耗尽记录失败而不是成功完成。
- `test/Aevatar.GAgentService.Tests/Application/LlmRunCoreTests.cs`: 增加 owned missing、unknown tool 和 max-round exhaustion 行为测试。
- `test/Aevatar.GAgentService.Tests/Projection/LlmSessionsProtoSurfaceRegressionTests.cs`: 增加 `owned_tool_names` proto surface 回归断言。

Closes #2279

## Test results

- `dotnet build aevatar.slnx --nologo`: passed.
- `bash tools/ci/test_stability_guards.sh`: passed.
- Filtered `Aevatar.GAgentService.Tests`: passed, 94 tests.
- `bash tools/ci/architecture_guards.sh`: passed.

## Deviations

- `refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)`.
- No scope expansion.

⟦AI:AUTO-LOOP⟧
