### PR TITLE
修复 scheduled dispatch 服务身份校验与历史投影兼容

### DIFF
--- a/src/platform/Aevatar.GAgentService.Application/Schedules/ScheduledDispatchApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Schedules/ScheduledDispatchApplicationService.cs
@@ -1,4 +1,5 @@
 using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Schedules;
 
 namespace Aevatar.GAgentService.Application.Schedules;
@@ -241,10 +242,7 @@ public sealed class ScheduledDispatchApplicationService : IScheduledDispatchAppl
     {
         var invocation = target.ServiceInvocation
             ?? throw new ArgumentException("Service invocation scheduled dispatch target is required.", nameof(target));
-        if (invocation.Identity == null)
-            throw new ArgumentException("Service invocation identity is required.", nameof(target));
-        if (string.IsNullOrWhiteSpace(invocation.Identity.ServiceId))
-            throw new ArgumentException("Service invocation service id is required.", nameof(target));
+        var identity = NormalizeServiceInvocationIdentity(invocation.Identity);
         if (string.IsNullOrWhiteSpace(invocation.EndpointId))
             throw new ArgumentException("Service invocation endpoint id is required.", nameof(target));
         if (invocation.Payload == null)
@@ -258,12 +256,37 @@ public sealed class ScheduledDispatchApplicationService : IScheduledDispatchAppl
             {
                 EndpointId = NormalizeRequired(invocation.EndpointId, nameof(invocation.EndpointId)),
                 RevisionId = NormalizeNullable(invocation.RevisionId),
-                Identity = invocation.Identity.Clone(),
+                Identity = identity,
                 Payload = invocation.Payload.Clone(),
                 Caller = invocation.Caller?.Clone(),
                 Auth = NormalizeServiceInvocationAuth(invocation.Auth),
             },
         };
+    }
+
+    private static ServiceIdentity NormalizeServiceInvocationIdentity(ServiceIdentity? identity)
+    {
+        if (identity == null)
+            throw new ArgumentException("Service invocation identity is required.", nameof(identity));
+
+        return new ServiceIdentity
+        {
+            TenantId = NormalizeRequiredServiceIdentityField(identity.TenantId, "tenant id", nameof(identity.TenantId)),
+            AppId = NormalizeRequiredServiceIdentityField(identity.AppId, "app id", nameof(identity.AppId)),
+            Namespace = NormalizeRequiredServiceIdentityField(identity.Namespace, "namespace", nameof(identity.Namespace)),
+            ServiceId = NormalizeRequiredServiceIdentityField(identity.ServiceId, "service id", nameof(identity.ServiceId)),
+        };
+    }
+
+    private static string NormalizeRequiredServiceIdentityField(
+        string? value,
+        string fieldDescription,
+        string parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException($"Service invocation {fieldDescription} is required.", parameterName);
+
+        return value.Trim();
     }
 
     private static ScheduledServiceInvocationAuth? NormalizeServiceInvocationAuth(

--- a/src/platform/Aevatar.GAgentService.Projection/Projectors/ScheduledDispatchCurrentStateProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Projectors/ScheduledDispatchCurrentStateProjector.cs
@@ -74,7 +74,7 @@ public sealed class ScheduledDispatchCurrentStateProjector
             LastError = state.LastError ?? string.Empty,
             FireCount = state.FireCount,
             FailureCount = state.FailureCount,
-            ServiceKey = serviceIdentity == null ? string.Empty : ServiceKeys.Build(serviceIdentity),
+            ServiceKey = BuildServiceKey(serviceIdentity),
             ServiceId = serviceIdentity?.ServiceId ?? string.Empty,
             ServiceEndpointId = target.ServiceInvocation?.EndpointId ?? string.Empty,
             TargetActorId = state.TargetActorId ?? string.Empty,
@@ -91,6 +91,20 @@ public sealed class ScheduledDispatchCurrentStateProjector
             .ToDictionary(x => x.Key, x => x.Value, StringComparer.Ordinal);
         document.FireRecords.Add(CreateFireRecords(state));
         return document;
+    }
+
+    private static string BuildServiceKey(ServiceIdentity? serviceIdentity)
+    {
+        if (serviceIdentity == null ||
+            string.IsNullOrWhiteSpace(serviceIdentity.TenantId) ||
+            string.IsNullOrWhiteSpace(serviceIdentity.AppId) ||
+            string.IsNullOrWhiteSpace(serviceIdentity.Namespace) ||
+            string.IsNullOrWhiteSpace(serviceIdentity.ServiceId))
+        {
+            return string.Empty;
+        }
+
+        return ServiceKeys.Build(serviceIdentity);
     }
 
     private static ScheduledDispatchFireRecordDocument[] CreateFireRecords(ScheduledDispatchState state) =>

--- a/test/Aevatar.GAgentService.Tests/Application/ScheduledDispatchApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScheduledDispatchApplicationServiceTests.cs
@@ -113,10 +113,10 @@ public sealed class ScheduledDispatchApplicationServiceTests
                     ServiceInvocation: new ScheduledServiceInvocationTargetDescriptor(
                         new ServiceIdentity
                         {
-                            TenantId = "tenant",
-                            AppId = "app",
-                            Namespace = "default",
-                            ServiceId = "svc",
+                            TenantId = " tenant ",
+                            AppId = " app ",
+                            Namespace = " default ",
+                            ServiceId = " svc ",
                         },
                         " run ",
                         payload,
@@ -135,8 +135,17 @@ public sealed class ScheduledDispatchApplicationServiceTests
         updated.Configuration.Target.ServiceInvocation.Should().NotBeNull();
         updated.Configuration.Target.ServiceInvocation!.EndpointId.Should().Be("run");
         updated.Configuration.Target.ServiceInvocation.RevisionId.Should().Be("rev-1");
+        updated.Configuration.Target.ServiceInvocation.Identity.TenantId.Should().Be("tenant");
+        updated.Configuration.Target.ServiceInvocation.Identity.AppId.Should().Be("app");
+        updated.Configuration.Target.ServiceInvocation.Identity.Namespace.Should().Be("default");
+        updated.Configuration.Target.ServiceInvocation.Identity.ServiceId.Should().Be("svc");
         updated.Configuration.Timezone.Should().Be("UTC");
         updated.Dispatch.TargetActorId.Should().Be(ScheduledDispatchAdapterConventions.ServiceInvocationTargetActorId);
+        var invocation = updated.Dispatch.TriggerEnvelope.Payload.Unpack<ServiceInvocationRequest>();
+        invocation.Identity.TenantId.Should().Be("tenant");
+        invocation.Identity.AppId.Should().Be("app");
+        invocation.Identity.Namespace.Should().Be("default");
+        invocation.Identity.ServiceId.Should().Be("svc");
     }
 
     [Fact]
@@ -245,7 +254,7 @@ public sealed class ScheduledDispatchApplicationServiceTests
             new ScheduledDispatchTargetDescriptor(
                 ScheduledDispatchTargetKind.ServiceInvocation,
                 ServiceInvocation: new ScheduledServiceInvocationTargetDescriptor(
-                    new ServiceIdentity { TenantId = "tenant" },
+                    new ServiceIdentity { TenantId = "tenant", AppId = "app", Namespace = "default" },
                     "run",
                     Any.Pack(new Empty()))),
             "0 9 * * *",
@@ -258,7 +267,7 @@ public sealed class ScheduledDispatchApplicationServiceTests
             new ScheduledDispatchTargetDescriptor(
                 ScheduledDispatchTargetKind.ServiceInvocation,
                 ServiceInvocation: new ScheduledServiceInvocationTargetDescriptor(
-                    new ServiceIdentity { ServiceId = "svc" },
+                    new ServiceIdentity { TenantId = "tenant", AppId = "app", Namespace = "default", ServiceId = "svc" },
                     " ",
                     Any.Pack(new Empty()))),
             "0 9 * * *",
@@ -272,6 +281,44 @@ public sealed class ScheduledDispatchApplicationServiceTests
             .WithMessage("*service id*");
         await missingEndpoint.Should().ThrowAsync<ArgumentException>()
             .WithMessage("*endpoint id*");
+    }
+
+    [Theory]
+    [InlineData(" ", "app", "default", "svc", "tenant id")]
+    [InlineData("tenant", " ", "default", "svc", "app id")]
+    [InlineData("tenant", "app", " ", "svc", "namespace")]
+    [InlineData("tenant", "app", "default", " ", "service id")]
+    public async Task CreateAsync_ShouldRejectIncompleteServiceInvocationIdentity(
+        string tenantId,
+        string appId,
+        string serviceNamespace,
+        string serviceId,
+        string expectedMessage)
+    {
+        var service = CreateService();
+
+        var act = () => service.CreateAsync(new ScheduledDispatchConfiguration(
+            "schedule-identity",
+            string.Empty,
+            new ScheduledDispatchTargetDescriptor(
+                ScheduledDispatchTargetKind.ServiceInvocation,
+                ServiceInvocation: new ScheduledServiceInvocationTargetDescriptor(
+                    new ServiceIdentity
+                    {
+                        TenantId = tenantId,
+                        AppId = appId,
+                        Namespace = serviceNamespace,
+                        ServiceId = serviceId,
+                    },
+                    "run",
+                    Any.Pack(new Empty()))),
+            "0 9 * * *",
+            "UTC",
+            true,
+            new Dictionary<string, string>()));
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage($"*{expectedMessage}*");
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Projection/ScheduledDispatchCurrentStateProjectorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ScheduledDispatchCurrentStateProjectorTests.cs
@@ -1,0 +1,141 @@
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Services;
+using Aevatar.GAgentService.Abstractions.Schedules;
+using Aevatar.GAgentService.Core.Schedules;
+using Aevatar.GAgentService.Projection.Contexts;
+using Aevatar.GAgentService.Projection.Projectors;
+using Aevatar.GAgentService.Projection.ReadModels;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgentService.Tests.Projection;
+
+public sealed class ScheduledDispatchCurrentStateProjectorTests
+{
+    [Fact]
+    public async Task ProjectAsync_ShouldMaterializeServiceKey_WhenIdentityIsComplete()
+    {
+        var store = new RecordingDocumentStore<ScheduledDispatchDocument>(x => x.Id);
+        var projector = new ScheduledDispatchCurrentStateProjector(
+            store,
+            new FixedProjectionClock(DateTimeOffset.Parse("2026-06-18T00:00:00+00:00")));
+        var identity = new ServiceIdentity
+        {
+            TenantId = "tenant",
+            AppId = "app",
+            Namespace = "default",
+            ServiceId = "svc",
+        };
+
+        await projector.ProjectAsync(
+            CreateContext("scheduled-dispatch:schedule-1"),
+            WrapCommitted(
+                CreateServiceInvocationState("schedule-1", identity),
+                version: 9,
+                eventId: "evt-9",
+                observedAt: DateTimeOffset.Parse("2026-06-18T01:00:00+00:00")));
+
+        var document = await store.GetAsync("schedule-1");
+        document.Should().NotBeNull();
+        document!.ServiceKey.Should().Be(ServiceKeys.Build(identity));
+        document.ServiceId.Should().Be("svc");
+        document.ServiceEndpointId.Should().Be("chat");
+        document.StateVersion.Should().Be(9);
+        document.LastEventId.Should().Be("evt-9");
+    }
+
+    [Theory]
+    [InlineData("", "app", "default", "svc")]
+    [InlineData("tenant", "", "default", "svc")]
+    [InlineData("tenant", "app", "", "svc")]
+    [InlineData("tenant", "app", "default", "")]
+    public async Task ProjectAsync_ShouldMaterializeDocumentWithoutServiceKey_WhenHistoricalIdentityIsIncomplete(
+        string tenantId,
+        string appId,
+        string serviceNamespace,
+        string serviceId)
+    {
+        var store = new RecordingDocumentStore<ScheduledDispatchDocument>(x => x.Id);
+        var projector = new ScheduledDispatchCurrentStateProjector(
+            store,
+            new FixedProjectionClock(DateTimeOffset.Parse("2026-06-18T00:00:00+00:00")));
+
+        var act = async () => await projector.ProjectAsync(
+            CreateContext("scheduled-dispatch:historical"),
+            WrapCommitted(
+                CreateServiceInvocationState(
+                    "historical",
+                    new ServiceIdentity
+                    {
+                        TenantId = tenantId,
+                        AppId = appId,
+                        Namespace = serviceNamespace,
+                        ServiceId = serviceId,
+                    }),
+                version: 11,
+                eventId: "evt-historical",
+                observedAt: DateTimeOffset.Parse("2026-06-18T01:30:00+00:00")));
+
+        await act.Should().NotThrowAsync();
+        var document = await store.GetAsync("historical");
+        document.Should().NotBeNull();
+        document!.ServiceKey.Should().BeEmpty();
+        document.ServiceId.Should().Be(serviceId);
+        document.ServiceEndpointId.Should().Be("chat");
+        document.StateVersion.Should().Be(11);
+        document.LastEventId.Should().Be("evt-historical");
+    }
+
+    private static ScheduledDispatchProjectionContext CreateContext(string rootActorId) =>
+        new()
+        {
+            RootActorId = rootActorId,
+            ProjectionKind = "scheduled-dispatch",
+        };
+
+    private static ScheduledDispatchState CreateServiceInvocationState(
+        string scheduleId,
+        ServiceIdentity identity) =>
+        new()
+        {
+            ScheduleId = scheduleId,
+            DisplayName = "Scheduled service invocation",
+            CronExpression = "0 9 * * *",
+            Timezone = "UTC",
+            Enabled = true,
+            Target = new ScheduledDispatchTargetState
+            {
+                Kind = ScheduledDispatchTargetKindState.ServiceInvocation,
+                ServiceInvocation = new ScheduledServiceInvocationTargetState
+                {
+                    Identity = identity.Clone(),
+                    EndpointId = "chat",
+                    Payload = Any.Pack(new StringValue { Value = "run" }),
+                },
+            },
+        };
+
+    private static EventEnvelope WrapCommitted(
+        ScheduledDispatchState state,
+        long version,
+        string eventId,
+        DateTimeOffset observedAt) =>
+        new()
+        {
+            Id = $"outer-{eventId}",
+            Timestamp = Timestamp.FromDateTimeOffset(observedAt.AddMinutes(1)),
+            Payload = Any.Pack(new CommittedStateEventPublished
+            {
+                StateEvent = new StateEvent
+                {
+                    EventId = eventId,
+                    Version = version,
+                    Timestamp = Timestamp.FromDateTimeOffset(observedAt),
+                    EventData = Any.Pack(new ScheduledDispatchConfiguredEvent()),
+                },
+                StateRoot = Any.Pack(state),
+            }),
+        };
+}


### PR DESCRIPTION
## Changed files
- `ScheduledDispatchApplicationService` 现在会在写入边界 trim 并要求 service invocation identity 的 `TenantId/AppId/Namespace/ServiceId` 四段完整，避免新的坏状态进入 actor state。
- `ScheduledDispatchCurrentStateProjector` 现在只在四段 identity 完整时生成 `ServiceKey`；历史缺字段状态仍会物化 `ScheduledDispatchDocument`，但 `ServiceKey` 留空。
- 增加 scheduled dispatch application service 和 projector 的行为测试，覆盖 trim、fail-fast 校验，以及历史不完整 identity 的投影兼容。

Closes #2285

## Test results
- `dotnet build aevatar.slnx --nologo` passed.
- `dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo` passed.
- `dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo` passed.
- `dotnet test aevatar.slnx --nologo` passed.
- `bash tools/ci/test_stability_guards.sh` passed.
- `bash tools/ci/architecture_guards.sh` passed.
- Projection/query专项 guards passed: `query_projection_priming_guard.sh`, `projection_state_version_guard.sh`, `projection_state_mirror_current_state_guard.sh`, `projection_route_mapping_guard.sh`.

## Deviations
- 未修改 Workflow Host projector 测试文件；对应项目测试已运行通过，新增的 owner-local projector 测试覆盖了本次缺陷。
- 未扩 scope，未改 schema/protocol。
- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)

⟦AI:AUTO-LOOP⟧
