### PR TITLE
限制 ScheduledDispatch durable callback 下一跳

### DIFF
--- a/src/platform/Aevatar.GAgentService.Core/Schedules/ScheduledDispatchGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/Schedules/ScheduledDispatchGAgent.cs
@@ -17,6 +17,7 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
 {
     private const string NextFireCallbackId = "scheduled-dispatch-next-fire";
     private const int MaxFireRecordCount = 128;
+    private static readonly TimeSpan MaxNextFireCallbackHop = TimeSpan.FromDays(7);
     private readonly IActorDispatchPort _dispatchPort;
     private readonly IScheduledServiceInvocationDispatchPort _serviceInvocationDispatchPort;
 
@@ -242,6 +243,14 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
         }
 
         var scheduledFireAt = ResolveScheduledFireAt(command);
+        if (!command.Manual && ResolveCallbackFiredAt(inboundEnvelope) < scheduledFireAt)
+        {
+            var previousLease = ScheduledDispatchRuntimeCallbackLeaseStateCodec.ToRuntime(State.NextFireLease);
+            await RecordNextFireIntentAsync(scheduledFireAt, ct);
+            await ActivateNextFireIntentAsync(scheduledFireAt, previousLease, ct);
+            return;
+        }
+
         var idempotencyKey = ScheduledDispatchCalculator.BuildIdempotencyKey(ResolveScheduleId(), scheduledFireAt);
         if (HasTerminalFireRecord(idempotencyKey))
         {
@@ -499,15 +508,18 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
         var previousLease = ScheduledDispatchRuntimeCallbackLeaseStateCodec.ToRuntime(State.NextFireLease);
         var pendingNextFireAt = State.PendingNextFireAt?.ToDateTimeOffset();
         if (pendingNextFireAt != nextFireAtUtc)
-        {
-            await PersistDomainEventAsync(new ScheduledDispatchNextFireIntentRecordedEvent
-            {
-                NextFireAt = Timestamp.FromDateTimeOffset(nextFireAtUtc),
-                RequestedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            }, ct);
-        }
+            await RecordNextFireIntentAsync(nextFireAtUtc, ct);
 
         await ActivateNextFireIntentAsync(nextFireAtUtc, previousLease, ct);
+    }
+
+    private async Task RecordNextFireIntentAsync(DateTimeOffset nextFireAtUtc, CancellationToken ct)
+    {
+        await PersistDomainEventAsync(new ScheduledDispatchNextFireIntentRecordedEvent
+        {
+            NextFireAt = Timestamp.FromDateTimeOffset(nextFireAtUtc),
+            RequestedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        }, ct);
     }
 
     private async Task ActivateNextFireIntentAsync(
@@ -515,7 +527,7 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
         RuntimeCallbackLease? previousLease,
         CancellationToken ct)
     {
-        var dueTime = ScheduledDispatchCalculator.ComputeDueTime(nextFireAtUtc, DateTimeOffset.UtcNow);
+        var dueTime = ComputeNextFireCallbackDueTime(nextFireAtUtc, DateTimeOffset.UtcNow);
         var lease = await ScheduleSelfDurableTimeoutAsync(
             NextFireCallbackId,
             dueTime,
@@ -542,6 +554,14 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
         }
 
         await CancelNextFireLeaseAsync(previousLease, CancellationToken.None);
+    }
+
+    private static TimeSpan ComputeNextFireCallbackDueTime(
+        DateTimeOffset nextFireAtUtc,
+        DateTimeOffset nowUtc)
+    {
+        var dueTime = ScheduledDispatchCalculator.ComputeDueTime(nextFireAtUtc, nowUtc);
+        return dueTime <= MaxNextFireCallbackHop ? dueTime : MaxNextFireCallbackHop;
     }
 
     private async Task CancelNextFireLeaseAsync(CancellationToken ct)
@@ -579,6 +599,18 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
     {
         if (command.ScheduledFireAt != null)
             return command.ScheduledFireAt.ToDateTimeOffset().ToUniversalTime();
+
+        return DateTimeOffset.UtcNow;
+    }
+
+    private static DateTimeOffset ResolveCallbackFiredAt(EventEnvelope? envelope)
+    {
+        if (envelope != null &&
+            RuntimeCallbackEnvelopeStateReader.TryRead(envelope, out var state) &&
+            state.FiredAtUnixTimeMs > 0)
+        {
+            return DateTimeOffset.FromUnixTimeMilliseconds(state.FiredAtUnixTimeMs);
+        }
 
         return DateTimeOffset.UtcNow;
     }

--- a/test/Aevatar.Workflow.Core.Tests/ScheduledDispatchGAgentTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/ScheduledDispatchGAgentTests.cs
@@ -121,6 +121,28 @@ public sealed class ScheduledDispatchGAgentTests
     }
 
     [Fact]
+    public async Task HandleConfigureAsync_WhenNextFireIsBeyondRuntimeRange_ShouldRegisterBoundedCallbackHop()
+    {
+        var eventStore = new TestEventStore();
+        var dispatch = new RecordingActorDispatchPort();
+        var scheduler = new RecordingRuntimeCallbackScheduler();
+        var agent = CreateAgent(eventStore, dispatch, scheduler);
+        await agent.ActivateAsync();
+
+        await agent.HandleConfigureAsync(CreateConfigureCommand(
+            cronExpression: CreateFarFutureCronExpression(),
+            enabled: true));
+
+        scheduler.TimeoutRequests.Should().ContainSingle();
+        var request = scheduler.TimeoutRequests[0];
+        request.DueTime.Should().Be(TimeSpan.FromDays(7));
+        var fireCommand = request.TriggerEnvelope.Payload.Unpack<ScheduledDispatchFireCommand>();
+        var scheduledFireAt = fireCommand.ScheduledFireAt.ToDateTimeOffset();
+        scheduledFireAt.Should().Be(agent.State.NextFireAt);
+        scheduledFireAt.Should().BeAfter(DateTimeOffset.UtcNow.AddDays(7));
+    }
+
+    [Fact]
     public async Task HandleEnsureAsync_WhenUnconfigured_ShouldCreateScheduleState()
     {
         var eventStore = new TestEventStore();
@@ -413,7 +435,11 @@ public sealed class ScheduledDispatchGAgentTests
         var firstFireCommand = firstRequest.TriggerEnvelope.Payload.Unpack<ScheduledDispatchFireCommand>();
         var firstScheduledFireAt = firstFireCommand.ScheduledFireAt.ToDateTimeOffset();
 
-        await agent.HandleEventAsync(CreateFiredCallbackEnvelope(firstRequest, generation: 1, fireIndex: 1));
+        await agent.HandleEventAsync(CreateFiredCallbackEnvelope(
+            firstRequest,
+            generation: 1,
+            fireIndex: 1,
+            firedAt: firstScheduledFireAt));
 
         var idempotencyKey = ScheduledDispatchCalculator.BuildIdempotencyKey("schedule-1", firstScheduledFireAt);
         dispatch.Dispatches.Should().ContainSingle();
@@ -448,6 +474,40 @@ public sealed class ScheduledDispatchGAgentTests
         nextFireCommand.Manual.Should().BeFalse();
         nextFireCommand.ScheduledFireAt.ToDateTimeOffset().Should().BeAfter(firstScheduledFireAt);
         agent.State.NextFireLease!.Generation.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task HandleEventAsync_WhenBoundedCallbackArrivesEarly_ShouldRearmWithoutDispatching()
+    {
+        var eventStore = new TestEventStore();
+        var dispatch = new RecordingActorDispatchPort();
+        var scheduler = new RecordingRuntimeCallbackScheduler();
+        var agent = CreateAgent(eventStore, dispatch, scheduler);
+        await agent.ActivateAsync();
+        await agent.HandleConfigureAsync(CreateConfigureCommand(
+            cronExpression: CreateFarFutureCronExpression(),
+            enabled: true));
+        var firstRequest = scheduler.TimeoutRequests.Single();
+        var firstFireCommand = firstRequest.TriggerEnvelope.Payload.Unpack<ScheduledDispatchFireCommand>();
+        var scheduledFireAt = firstFireCommand.ScheduledFireAt.ToDateTimeOffset();
+
+        await agent.HandleEventAsync(CreateFiredCallbackEnvelope(firstRequest, generation: 1, fireIndex: 1));
+
+        dispatch.Dispatches.Should().BeEmpty();
+        agent.State.FireRecords.Should().BeEmpty();
+        agent.State.FireCount.Should().Be(0);
+        scheduler.TimeoutRequests.Should().HaveCount(2);
+        scheduler.TimeoutRequests[1].DueTime.Should().Be(TimeSpan.FromDays(7));
+        var rearmedFireCommand = scheduler.TimeoutRequests[1].TriggerEnvelope.Payload.Unpack<ScheduledDispatchFireCommand>();
+        rearmedFireCommand.ScheduledFireAt.ToDateTimeOffset().Should().Be(scheduledFireAt);
+        agent.State.NextFireAt.Should().Be(scheduledFireAt);
+        agent.State.NextFireLease!.Generation.Should().Be(2);
+        scheduler.Canceled.Should().ContainSingle()
+            .Which.Generation.Should().Be(1);
+        eventStore.GetEvents(ScheduleActorId)
+            .Where(x => string.Equals(x.EventType, ScheduledDispatchFireStartedEvent.Descriptor.FullName, StringComparison.Ordinal))
+            .Should()
+            .BeEmpty();
     }
 
     [Fact]
@@ -1275,7 +1335,8 @@ public sealed class ScheduledDispatchGAgentTests
     private static EventEnvelope CreateFiredCallbackEnvelope(
         RuntimeCallbackTimeoutRequest request,
         long generation,
-        long fireIndex)
+        long fireIndex,
+        DateTimeOffset? firedAt = null)
     {
         var envelope = request.TriggerEnvelope.Clone();
         envelope.Id = Guid.NewGuid().ToString("N");
@@ -1284,7 +1345,7 @@ public sealed class ScheduledDispatchGAgentTests
         callback.CallbackId = request.CallbackId;
         callback.Generation = generation;
         callback.FireIndex = fireIndex;
-        callback.FiredAtUnixTimeMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        callback.FiredAtUnixTimeMs = (firedAt ?? DateTimeOffset.UtcNow).ToUnixTimeMilliseconds();
         return envelope;
     }
 
@@ -1374,6 +1435,12 @@ public sealed class ScheduledDispatchGAgentTests
             Enabled = enabled,
             Target = target ?? CreateTargetState(targetActorId, triggerEnvelope),
         };
+    }
+
+    private static string CreateFarFutureCronExpression()
+    {
+        var farFutureMonth = DateTimeOffset.UtcNow.AddMonths(2).Month;
+        return $"0 0 1 {farFutureMonth} *";
     }
 
     private static ScheduledDispatchTargetState CreateTargetState(string targetActorId, EventEnvelope? triggerEnvelope) =>


### PR DESCRIPTION
## Changed files
- `ScheduledDispatchGAgent` 现在把真实业务 `NextFireAt` 和 runtime callback 下一跳分开处理：远期 fire 只注册 7 天内的 durable callback hop，callback 到达后仍按原始 `ScheduledFireAt` 对账。
- 早到 callback 会记录同一个 next-fire intent 并重新挂 lease，不会提前 dispatch，也不会生成 fire record。
- `ScheduledDispatchGAgentTests` 增加远期 callback 裁剪与早到 re-arm 覆盖，并让 due callback 测试显式使用 runtime fired timestamp。

## Test results
- `bash -lc "dotnet build aevatar.slnx --nologo"`: passed.
- `dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --no-restore --nologo`: passed.
- `bash tools/ci/test_stability_guards.sh`: passed.
- `bash tools/ci/architecture_guards.sh`: passed.
- `bash -lc "dotnet test aevatar.slnx --nologo"`: passed.

## Deviations
- Closes #2284
- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)
- No scope expansion.

⟦AI:AUTO-LOOP⟧
