### PR TITLE
合入 issues #2284/#2285 scheduled dispatch 修复

### DIFF
--- a/src/platform/Aevatar.GAgentService.Application/Schedules/ScheduledDispatchApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Schedules/ScheduledDispatchApplicationService.cs
@@ -1,4 +1,5 @@
 using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Schedules;
 
 namespace Aevatar.GAgentService.Application.Schedules;
@@ -273,10 +274,7 @@ public sealed class ScheduledDispatchApplicationService : IScheduledDispatchAppl
     {
         var invocation = target.ServiceInvocation
             ?? throw new ArgumentException("Service invocation scheduled dispatch target is required.", nameof(target));
-        if (invocation.Identity == null)
-            throw new ArgumentException("Service invocation identity is required.", nameof(target));
-        if (string.IsNullOrWhiteSpace(invocation.Identity.ServiceId))
-            throw new ArgumentException("Service invocation service id is required.", nameof(target));
+        var identity = NormalizeServiceInvocationIdentity(invocation.Identity);
         if (string.IsNullOrWhiteSpace(invocation.EndpointId))
             throw new ArgumentException("Service invocation endpoint id is required.", nameof(target));
         if (invocation.Payload == null)
@@ -290,12 +288,37 @@ public sealed class ScheduledDispatchApplicationService : IScheduledDispatchAppl
             {
                 EndpointId = NormalizeRequired(invocation.EndpointId, nameof(invocation.EndpointId)),
                 RevisionId = NormalizeNullable(invocation.RevisionId),
-                Identity = invocation.Identity.Clone(),
+                Identity = identity,
                 Payload = invocation.Payload.Clone(),
                 Caller = invocation.Caller?.Clone(),
                 Auth = NormalizeServiceInvocationAuth(invocation.Auth),
             },
         };
+    }
+
+    private static ServiceIdentity NormalizeServiceInvocationIdentity(ServiceIdentity? identity)
+    {
+        if (identity == null)
+            throw new ArgumentException("Service invocation identity is required.", nameof(identity));
+
+        return new ServiceIdentity
+        {
+            TenantId = NormalizeRequiredServiceIdentityField(identity.TenantId, "tenant id", nameof(identity.TenantId)),
+            AppId = NormalizeRequiredServiceIdentityField(identity.AppId, "app id", nameof(identity.AppId)),
+            Namespace = NormalizeRequiredServiceIdentityField(identity.Namespace, "namespace", nameof(identity.Namespace)),
+            ServiceId = NormalizeRequiredServiceIdentityField(identity.ServiceId, "service id", nameof(identity.ServiceId)),
+        };
+    }
+
+    private static string NormalizeRequiredServiceIdentityField(
+        string? value,
+        string fieldDescription,
+        string parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException($"Service invocation {fieldDescription} is required.", parameterName);
+
+        return value.Trim();
     }
 
     private static ScheduledServiceInvocationAuth? NormalizeServiceInvocationAuth(

--- a/src/platform/Aevatar.GAgentService.Core/Schedules/ScheduledDispatchGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/Schedules/ScheduledDispatchGAgent.cs
@@ -17,6 +17,7 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
 {
     private const string NextFireCallbackId = "scheduled-dispatch-next-fire";
     private const int MaxFireRecordCount = 128;
+    private static readonly TimeSpan MaxNextFireCallbackHop = TimeSpan.FromDays(7);
     private readonly IActorDispatchPort _dispatchPort;
     private readonly IScheduledServiceInvocationDispatchPort _serviceInvocationDispatchPort;
 
@@ -264,6 +265,14 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
         }
 
         var scheduledFireAt = ResolveScheduledFireAt(command);
+        if (!command.Manual && ResolveCallbackFiredAt(inboundEnvelope) < scheduledFireAt)
+        {
+            var previousLease = ScheduledDispatchRuntimeCallbackLeaseStateCodec.ToRuntime(State.NextFireLease);
+            await RecordNextFireIntentAsync(scheduledFireAt, ct);
+            await ActivateNextFireIntentAsync(scheduledFireAt, previousLease, ct);
+            return;
+        }
+
         var idempotencyKey = ScheduledDispatchCalculator.BuildIdempotencyKey(ResolveScheduleId(), scheduledFireAt);
         if (HasTerminalFireRecord(idempotencyKey))
         {
@@ -521,15 +530,18 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
         var previousLease = ScheduledDispatchRuntimeCallbackLeaseStateCodec.ToRuntime(State.NextFireLease);
         var pendingNextFireAt = State.PendingNextFireAt?.ToDateTimeOffset();
         if (pendingNextFireAt != nextFireAtUtc)
-        {
-            await PersistDomainEventAsync(new ScheduledDispatchNextFireIntentRecordedEvent
-            {
-                NextFireAt = Timestamp.FromDateTimeOffset(nextFireAtUtc),
-                RequestedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            }, ct);
-        }
+            await RecordNextFireIntentAsync(nextFireAtUtc, ct);
 
         await ActivateNextFireIntentAsync(nextFireAtUtc, previousLease, ct);
+    }
+
+    private async Task RecordNextFireIntentAsync(DateTimeOffset nextFireAtUtc, CancellationToken ct)
+    {
+        await PersistDomainEventAsync(new ScheduledDispatchNextFireIntentRecordedEvent
+        {
+            NextFireAt = Timestamp.FromDateTimeOffset(nextFireAtUtc),
+            RequestedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        }, ct);
     }
 
     private async Task ActivateNextFireIntentAsync(
@@ -537,7 +549,7 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
         RuntimeCallbackLease? previousLease,
         CancellationToken ct)
     {
-        var dueTime = ScheduledDispatchCalculator.ComputeDueTime(nextFireAtUtc, DateTimeOffset.UtcNow);
+        var dueTime = ComputeNextFireCallbackDueTime(nextFireAtUtc, DateTimeOffset.UtcNow);
         var lease = await ScheduleSelfDurableTimeoutAsync(
             NextFireCallbackId,
             dueTime,
@@ -564,6 +576,14 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
         }
 
         await CancelNextFireLeaseAsync(previousLease, CancellationToken.None);
+    }
+
+    private static TimeSpan ComputeNextFireCallbackDueTime(
+        DateTimeOffset nextFireAtUtc,
+        DateTimeOffset nowUtc)
+    {
+        var dueTime = ScheduledDispatchCalculator.ComputeDueTime(nextFireAtUtc, nowUtc);
+        return dueTime <= MaxNextFireCallbackHop ? dueTime : MaxNextFireCallbackHop;
     }
 
     private async Task CancelNextFireLeaseAsync(CancellationToken ct)
@@ -601,6 +621,18 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
     {
         if (command.ScheduledFireAt != null)
             return command.ScheduledFireAt.ToDateTimeOffset().ToUniversalTime();
+
+        return DateTimeOffset.UtcNow;
+    }
+
+    private static DateTimeOffset ResolveCallbackFiredAt(EventEnvelope? envelope)
+    {
+        if (envelope != null &&
+            RuntimeCallbackEnvelopeStateReader.TryRead(envelope, out var state) &&
+            state.FiredAtUnixTimeMs > 0)
+        {
+            return DateTimeOffset.FromUnixTimeMilliseconds(state.FiredAtUnixTimeMs);
+        }
 
         return DateTimeOffset.UtcNow;
     }

--- a/src/platform/Aevatar.GAgentService.Projection/Projectors/ScheduledDispatchCurrentStateProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Projectors/ScheduledDispatchCurrentStateProjector.cs
@@ -74,7 +74,7 @@ public sealed class ScheduledDispatchCurrentStateProjector
             LastError = state.LastError ?? string.Empty,
             FireCount = state.FireCount,
             FailureCount = state.FailureCount,
-            ServiceKey = serviceIdentity == null ? string.Empty : ServiceKeys.Build(serviceIdentity),
+            ServiceKey = BuildServiceKey(serviceIdentity),
             ServiceId = serviceIdentity?.ServiceId ?? string.Empty,
             ServiceEndpointId = target.ServiceInvocation?.EndpointId ?? string.Empty,
             TargetActorId = state.TargetActorId ?? string.Empty,
@@ -93,6 +93,20 @@ public sealed class ScheduledDispatchCurrentStateProjector
             .ToDictionary(x => x.Key, x => x.Value, StringComparer.Ordinal);
         document.FireRecords.Add(CreateFireRecords(state));
         return document;
+    }
+
+    private static string BuildServiceKey(ServiceIdentity? serviceIdentity)
+    {
+        if (serviceIdentity == null ||
+            string.IsNullOrWhiteSpace(serviceIdentity.TenantId) ||
+            string.IsNullOrWhiteSpace(serviceIdentity.AppId) ||
+            string.IsNullOrWhiteSpace(serviceIdentity.Namespace) ||
+            string.IsNullOrWhiteSpace(serviceIdentity.ServiceId))
+        {
+            return string.Empty;
+        }
+
+        return ServiceKeys.Build(serviceIdentity);
     }
 
     private static ScheduledDispatchFireRecordDocument[] CreateFireRecords(ScheduledDispatchState state) =>

--- a/test/Aevatar.GAgentService.Tests/Application/ScheduledDispatchApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScheduledDispatchApplicationServiceTests.cs
@@ -148,10 +148,10 @@ public sealed class ScheduledDispatchApplicationServiceTests
                     ServiceInvocation: new ScheduledServiceInvocationTargetDescriptor(
                         new ServiceIdentity
                         {
-                            TenantId = "tenant",
-                            AppId = "app",
-                            Namespace = "default",
-                            ServiceId = "svc",
+                            TenantId = " tenant ",
+                            AppId = " app ",
+                            Namespace = " default ",
+                            ServiceId = " svc ",
                         },
                         " run ",
                         payload,
@@ -170,8 +170,17 @@ public sealed class ScheduledDispatchApplicationServiceTests
         updated.Configuration.Target.ServiceInvocation.Should().NotBeNull();
         updated.Configuration.Target.ServiceInvocation!.EndpointId.Should().Be("run");
         updated.Configuration.Target.ServiceInvocation.RevisionId.Should().Be("rev-1");
+        updated.Configuration.Target.ServiceInvocation.Identity.TenantId.Should().Be("tenant");
+        updated.Configuration.Target.ServiceInvocation.Identity.AppId.Should().Be("app");
+        updated.Configuration.Target.ServiceInvocation.Identity.Namespace.Should().Be("default");
+        updated.Configuration.Target.ServiceInvocation.Identity.ServiceId.Should().Be("svc");
         updated.Configuration.Timezone.Should().Be("UTC");
         updated.Dispatch.TargetActorId.Should().Be(ScheduledDispatchAdapterConventions.ServiceInvocationTargetActorId);
+        var invocation = updated.Dispatch.TriggerEnvelope.Payload.Unpack<ServiceInvocationRequest>();
+        invocation.Identity.TenantId.Should().Be("tenant");
+        invocation.Identity.AppId.Should().Be("app");
+        invocation.Identity.Namespace.Should().Be("default");
+        invocation.Identity.ServiceId.Should().Be("svc");
     }
 
     [Fact]
@@ -280,7 +289,7 @@ public sealed class ScheduledDispatchApplicationServiceTests
             new ScheduledDispatchTargetDescriptor(
                 ScheduledDispatchTargetKind.ServiceInvocation,
                 ServiceInvocation: new ScheduledServiceInvocationTargetDescriptor(
-                    new ServiceIdentity { TenantId = "tenant" },
+                    new ServiceIdentity { TenantId = "tenant", AppId = "app", Namespace = "default" },
                     "run",
                     Any.Pack(new Empty()))),
             "0 9 * * *",
@@ -293,7 +302,7 @@ public sealed class ScheduledDispatchApplicationServiceTests
             new ScheduledDispatchTargetDescriptor(
                 ScheduledDispatchTargetKind.ServiceInvocation,
                 ServiceInvocation: new ScheduledServiceInvocationTargetDescriptor(
-                    new ServiceIdentity { ServiceId = "svc" },
+                    new ServiceIdentity { TenantId = "tenant", AppId = "app", Namespace = "default", ServiceId = "svc" },
                     " ",
                     Any.Pack(new Empty()))),
             "0 9 * * *",
@@ -307,6 +316,44 @@ public sealed class ScheduledDispatchApplicationServiceTests
             .WithMessage("*service id*");
         await missingEndpoint.Should().ThrowAsync<ArgumentException>()
             .WithMessage("*endpoint id*");
+    }
+
+    [Theory]
+    [InlineData(" ", "app", "default", "svc", "tenant id")]
+    [InlineData("tenant", " ", "default", "svc", "app id")]
+    [InlineData("tenant", "app", " ", "svc", "namespace")]
+    [InlineData("tenant", "app", "default", " ", "service id")]
+    public async Task CreateAsync_ShouldRejectIncompleteServiceInvocationIdentity(
+        string tenantId,
+        string appId,
+        string serviceNamespace,
+        string serviceId,
+        string expectedMessage)
+    {
+        var service = CreateService();
+
+        var act = () => service.CreateAsync(new ScheduledDispatchConfiguration(
+            "schedule-identity",
+            string.Empty,
+            new ScheduledDispatchTargetDescriptor(
+                ScheduledDispatchTargetKind.ServiceInvocation,
+                ServiceInvocation: new ScheduledServiceInvocationTargetDescriptor(
+                    new ServiceIdentity
+                    {
+                        TenantId = tenantId,
+                        AppId = appId,
+                        Namespace = serviceNamespace,
+                        ServiceId = serviceId,
+                    },
+                    "run",
+                    Any.Pack(new Empty()))),
+            "0 9 * * *",
+            "UTC",
+            true,
+            new Dictionary<string, string>()));
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage($"*{expectedMessage}*");
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Projection/ScheduledDispatchCurrentStateProjectorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ScheduledDispatchCurrentStateProjectorTests.cs
@@ -1,0 +1,141 @@
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Services;
+using Aevatar.GAgentService.Abstractions.Schedules;
+using Aevatar.GAgentService.Core.Schedules;
+using Aevatar.GAgentService.Projection.Contexts;
+using Aevatar.GAgentService.Projection.Projectors;
+using Aevatar.GAgentService.Projection.ReadModels;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgentService.Tests.Projection;
+
+public sealed class ScheduledDispatchCurrentStateProjectorTests
+{
+    [Fact]
+    public async Task ProjectAsync_ShouldMaterializeServiceKey_WhenIdentityIsComplete()
+    {
+        var store = new RecordingDocumentStore<ScheduledDispatchDocument>(x => x.Id);
+        var projector = new ScheduledDispatchCurrentStateProjector(
+            store,
+            new FixedProjectionClock(DateTimeOffset.Parse("2026-06-18T00:00:00+00:00")));
+        var identity = new ServiceIdentity
+        {
+            TenantId = "tenant",
+            AppId = "app",
+            Namespace = "default",
+            ServiceId = "svc",
+        };
+
+        await projector.ProjectAsync(
+            CreateContext("scheduled-dispatch:schedule-1"),
+            WrapCommitted(
+                CreateServiceInvocationState("schedule-1", identity),
+                version: 9,
+                eventId: "evt-9",
+                observedAt: DateTimeOffset.Parse("2026-06-18T01:00:00+00:00")));
+
+        var document = await store.GetAsync("schedule-1");
+        document.Should().NotBeNull();
+        document!.ServiceKey.Should().Be(ServiceKeys.Build(identity));
+        document.ServiceId.Should().Be("svc");
+        document.ServiceEndpointId.Should().Be("chat");
+        document.StateVersion.Should().Be(9);
+        document.LastEventId.Should().Be("evt-9");
+    }
+
+    [Theory]
+    [InlineData("", "app", "default", "svc")]
+    [InlineData("tenant", "", "default", "svc")]
+    [InlineData("tenant", "app", "", "svc")]
+    [InlineData("tenant", "app", "default", "")]
+    public async Task ProjectAsync_ShouldMaterializeDocumentWithoutServiceKey_WhenHistoricalIdentityIsIncomplete(
+        string tenantId,
+        string appId,
+        string serviceNamespace,
+        string serviceId)
+    {
+        var store = new RecordingDocumentStore<ScheduledDispatchDocument>(x => x.Id);
+        var projector = new ScheduledDispatchCurrentStateProjector(
+            store,
+            new FixedProjectionClock(DateTimeOffset.Parse("2026-06-18T00:00:00+00:00")));
+
+        var act = async () => await projector.ProjectAsync(
+            CreateContext("scheduled-dispatch:historical"),
+            WrapCommitted(
+                CreateServiceInvocationState(
+                    "historical",
+                    new ServiceIdentity
+                    {
+                        TenantId = tenantId,
+                        AppId = appId,
+                        Namespace = serviceNamespace,
+                        ServiceId = serviceId,
+                    }),
+                version: 11,
+                eventId: "evt-historical",
+                observedAt: DateTimeOffset.Parse("2026-06-18T01:30:00+00:00")));
+
+        await act.Should().NotThrowAsync();
+        var document = await store.GetAsync("historical");
+        document.Should().NotBeNull();
+        document!.ServiceKey.Should().BeEmpty();
+        document.ServiceId.Should().Be(serviceId);
+        document.ServiceEndpointId.Should().Be("chat");
+        document.StateVersion.Should().Be(11);
+        document.LastEventId.Should().Be("evt-historical");
+    }
+
+    private static ScheduledDispatchProjectionContext CreateContext(string rootActorId) =>
+        new()
+        {
+            RootActorId = rootActorId,
+            ProjectionKind = "scheduled-dispatch",
+        };
+
+    private static ScheduledDispatchState CreateServiceInvocationState(
+        string scheduleId,
+        ServiceIdentity identity) =>
+        new()
+        {
+            ScheduleId = scheduleId,
+            DisplayName = "Scheduled service invocation",
+            CronExpression = "0 9 * * *",
+            Timezone = "UTC",
+            Enabled = true,
+            Target = new ScheduledDispatchTargetState
+            {
+                Kind = ScheduledDispatchTargetKindState.ServiceInvocation,
+                ServiceInvocation = new ScheduledServiceInvocationTargetState
+                {
+                    Identity = identity.Clone(),
+                    EndpointId = "chat",
+                    Payload = Any.Pack(new StringValue { Value = "run" }),
+                },
+            },
+        };
+
+    private static EventEnvelope WrapCommitted(
+        ScheduledDispatchState state,
+        long version,
+        string eventId,
+        DateTimeOffset observedAt) =>
+        new()
+        {
+            Id = $"outer-{eventId}",
+            Timestamp = Timestamp.FromDateTimeOffset(observedAt.AddMinutes(1)),
+            Payload = Any.Pack(new CommittedStateEventPublished
+            {
+                StateEvent = new StateEvent
+                {
+                    EventId = eventId,
+                    Version = version,
+                    Timestamp = Timestamp.FromDateTimeOffset(observedAt),
+                    EventData = Any.Pack(new ScheduledDispatchConfiguredEvent()),
+                },
+                StateRoot = Any.Pack(state),
+            }),
+        };
+}

--- a/test/Aevatar.Workflow.Core.Tests/ScheduledDispatchGAgentTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/ScheduledDispatchGAgentTests.cs
@@ -121,6 +121,28 @@ public sealed class ScheduledDispatchGAgentTests
     }
 
     [Fact]
+    public async Task HandleConfigureAsync_WhenNextFireIsBeyondRuntimeRange_ShouldRegisterBoundedCallbackHop()
+    {
+        var eventStore = new TestEventStore();
+        var dispatch = new RecordingActorDispatchPort();
+        var scheduler = new RecordingRuntimeCallbackScheduler();
+        var agent = CreateAgent(eventStore, dispatch, scheduler);
+        await agent.ActivateAsync();
+
+        await agent.HandleConfigureAsync(CreateConfigureCommand(
+            cronExpression: CreateFarFutureCronExpression(),
+            enabled: true));
+
+        scheduler.TimeoutRequests.Should().ContainSingle();
+        var request = scheduler.TimeoutRequests[0];
+        request.DueTime.Should().Be(TimeSpan.FromDays(7));
+        var fireCommand = request.TriggerEnvelope.Payload.Unpack<ScheduledDispatchFireCommand>();
+        var scheduledFireAt = fireCommand.ScheduledFireAt.ToDateTimeOffset();
+        scheduledFireAt.Should().Be(agent.State.NextFireAt);
+        scheduledFireAt.Should().BeAfter(DateTimeOffset.UtcNow.AddDays(7));
+    }
+
+    [Fact]
     public async Task HandleEnsureAsync_WhenUnconfigured_ShouldCreateScheduleState()
     {
         var eventStore = new TestEventStore();
@@ -530,7 +552,11 @@ public sealed class ScheduledDispatchGAgentTests
         var firstFireCommand = firstRequest.TriggerEnvelope.Payload.Unpack<ScheduledDispatchFireCommand>();
         var firstScheduledFireAt = firstFireCommand.ScheduledFireAt.ToDateTimeOffset();
 
-        await agent.HandleEventAsync(CreateFiredCallbackEnvelope(firstRequest, generation: 1, fireIndex: 1));
+        await agent.HandleEventAsync(CreateFiredCallbackEnvelope(
+            firstRequest,
+            generation: 1,
+            fireIndex: 1,
+            firedAt: firstScheduledFireAt));
 
         var idempotencyKey = ScheduledDispatchCalculator.BuildIdempotencyKey("schedule-1", firstScheduledFireAt);
         dispatch.Dispatches.Should().ContainSingle();
@@ -565,6 +591,40 @@ public sealed class ScheduledDispatchGAgentTests
         nextFireCommand.Manual.Should().BeFalse();
         nextFireCommand.ScheduledFireAt.ToDateTimeOffset().Should().BeAfter(firstScheduledFireAt);
         agent.State.NextFireLease!.Generation.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task HandleEventAsync_WhenBoundedCallbackArrivesEarly_ShouldRearmWithoutDispatching()
+    {
+        var eventStore = new TestEventStore();
+        var dispatch = new RecordingActorDispatchPort();
+        var scheduler = new RecordingRuntimeCallbackScheduler();
+        var agent = CreateAgent(eventStore, dispatch, scheduler);
+        await agent.ActivateAsync();
+        await agent.HandleConfigureAsync(CreateConfigureCommand(
+            cronExpression: CreateFarFutureCronExpression(),
+            enabled: true));
+        var firstRequest = scheduler.TimeoutRequests.Single();
+        var firstFireCommand = firstRequest.TriggerEnvelope.Payload.Unpack<ScheduledDispatchFireCommand>();
+        var scheduledFireAt = firstFireCommand.ScheduledFireAt.ToDateTimeOffset();
+
+        await agent.HandleEventAsync(CreateFiredCallbackEnvelope(firstRequest, generation: 1, fireIndex: 1));
+
+        dispatch.Dispatches.Should().BeEmpty();
+        agent.State.FireRecords.Should().BeEmpty();
+        agent.State.FireCount.Should().Be(0);
+        scheduler.TimeoutRequests.Should().HaveCount(2);
+        scheduler.TimeoutRequests[1].DueTime.Should().Be(TimeSpan.FromDays(7));
+        var rearmedFireCommand = scheduler.TimeoutRequests[1].TriggerEnvelope.Payload.Unpack<ScheduledDispatchFireCommand>();
+        rearmedFireCommand.ScheduledFireAt.ToDateTimeOffset().Should().Be(scheduledFireAt);
+        agent.State.NextFireAt.Should().Be(scheduledFireAt);
+        agent.State.NextFireLease!.Generation.Should().Be(2);
+        scheduler.Canceled.Should().ContainSingle()
+            .Which.Generation.Should().Be(1);
+        eventStore.GetEvents(ScheduleActorId)
+            .Where(x => string.Equals(x.EventType, ScheduledDispatchFireStartedEvent.Descriptor.FullName, StringComparison.Ordinal))
+            .Should()
+            .BeEmpty();
     }
 
     [Fact]
@@ -1392,7 +1452,8 @@ public sealed class ScheduledDispatchGAgentTests
     private static EventEnvelope CreateFiredCallbackEnvelope(
         RuntimeCallbackTimeoutRequest request,
         long generation,
-        long fireIndex)
+        long fireIndex,
+        DateTimeOffset? firedAt = null)
     {
         var envelope = request.TriggerEnvelope.Clone();
         envelope.Id = Guid.NewGuid().ToString("N");
@@ -1401,7 +1462,7 @@ public sealed class ScheduledDispatchGAgentTests
         callback.CallbackId = request.CallbackId;
         callback.Generation = generation;
         callback.FireIndex = fireIndex;
-        callback.FiredAtUnixTimeMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        callback.FiredAtUnixTimeMs = (firedAt ?? DateTimeOffset.UtcNow).ToUnixTimeMilliseconds();
         return envelope;
     }
 
@@ -1491,6 +1552,12 @@ public sealed class ScheduledDispatchGAgentTests
             Enabled = enabled,
             Target = target ?? CreateTargetState(targetActorId, triggerEnvelope),
         };
+    }
+
+    private static string CreateFarFutureCronExpression()
+    {
+        var farFutureMonth = DateTimeOffset.UtcNow.AddMonths(2).Month;
+        return $"0 0 1 {farFutureMonth} *";
     }
 
     private static ScheduledDispatchTargetState CreateTargetState(string targetActorId, EventEnvelope? triggerEnvelope) =>


### PR DESCRIPTION
## 摘要

这个 PR 是针对 issues #2284、#2285 的 scoped rollup，从 `origin/feature/integrate` 出发，只 cherry-pick 已经通过 consensus-loop、review gate、CI 并合入 `crnd/integrate-1877` 的两个修复提交：

- #2285 / PR #2295：修复 scheduled-dispatches read-model projection 因 `appId is required` 导致 schedule 查询 404 的问题。
- #2284 / PR #2296：限制 ScheduledDispatch durable callback 下一跳，避免远未来/固定日期 cron 触发 Orleans callback duration 超限。

#2286 已由 consensus-loop 判定为 `META_RESOLVED:drop`，issue 已关闭，本 PR 不包含 #2286 代码变更。

## 范围

相对 `feature/integrate` 只包含 2 个提交、6 个文件：

- `src/platform/Aevatar.GAgentService.Application/Schedules/ScheduledDispatchApplicationService.cs`
- `src/platform/Aevatar.GAgentService.Core/Schedules/ScheduledDispatchGAgent.cs`
- `src/platform/Aevatar.GAgentService.Projection/Projectors/ScheduledDispatchCurrentStateProjector.cs`
- `test/Aevatar.GAgentService.Tests/Application/ScheduledDispatchApplicationServiceTests.cs`
- `test/Aevatar.GAgentService.Tests/Projection/ScheduledDispatchCurrentStateProjectorTests.cs`
- `test/Aevatar.Workflow.Core.Tests/ScheduledDispatchGAgentTests.cs`

没有把 `crnd/integrate-1877` 相对 `feature/integrate` 的其它历史差异带入。

## 验证

- `bash tools/ci/test_stability_guards.sh`
- `dotnet restore test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo`
- `dotnet restore test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --nologo`
- `dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --no-restore --nologo --filter "FullyQualifiedName~ScheduledDispatch"`（63 passed）
- `dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --no-restore --nologo --filter "FullyQualifiedName~ScheduledDispatch"`（42 passed）
- `bash tools/ci/query_projection_priming_guard.sh`
- `bash tools/ci/projection_state_version_guard.sh && bash tools/ci/projection_state_mirror_current_state_guard.sh`
- `dotnet build aevatar.slnx --nologo`（0 errors，既有 warnings）

⟦AI:AUTO-LOOP⟧
