### PR TITLE
删除 scope service token 匿名 JWKS endpoint

### DIFF
--- a/src/Aevatar.Authentication.ScopeServiceTokens/ScopeServiceTokenHostExtensions.cs
+++ b/src/Aevatar.Authentication.ScopeServiceTokens/ScopeServiceTokenHostExtensions.cs
@@ -1,10 +1,6 @@
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Tokens;
 
 namespace Aevatar.Authentication.ScopeServiceTokens;
 
@@ -21,48 +17,5 @@ public static class ScopeServiceTokenHostExtensions
         services.TryAddSingleton<IScopeServiceTokenKeyProvider, ConfiguredScopeServiceTokenKeyProvider>();
         services.TryAddSingleton<IScopeServiceTokenIssuer, ScopeServiceTokenIssuer>();
         return services;
-    }
-
-    public static IApplicationBuilder MapScopeServiceTokenJwks(this WebApplication app)
-    {
-        ArgumentNullException.ThrowIfNull(app);
-
-        var options = app.Services.GetService<IOptions<ScopeServiceTokenOptions>>()?.Value;
-        if (options == null)
-            return app;
-
-        if (!options.Enabled)
-            return app;
-
-        var path = NormalizePath(options.JwksPath);
-        app.MapGet(path, (IScopeServiceTokenKeyProvider keyProvider) =>
-            Results.Json(new
-            {
-                keys = keyProvider.ValidationKeys
-                    .Where(static key => key.ValidationKey is AsymmetricSecurityKey)
-                    .Select(key =>
-                    {
-                        var jwk = JsonWebKeyConverter.ConvertFromSecurityKey(key.ValidationKey);
-                        jwk.Kid = key.Kid;
-                        jwk.Alg = key.Algorithm;
-                        jwk.KeyOps.Clear();
-                        jwk.KeyOps.Add("verify");
-                        return jwk;
-                    })
-                    .ToArray(),
-            })).AllowAnonymous();
-
-        return app;
-    }
-
-    private static string NormalizePath(string? path)
-    {
-        var normalized = path?.Trim();
-        if (string.IsNullOrWhiteSpace(normalized))
-            return "/.well-known/aevatar-scope-service-jwks.json";
-
-        return normalized.StartsWith("/", StringComparison.Ordinal)
-            ? normalized
-            : "/" + normalized;
     }
 }

--- a/src/Aevatar.Authentication.ScopeServiceTokens/ScopeServiceTokenOptions.cs
+++ b/src/Aevatar.Authentication.ScopeServiceTokens/ScopeServiceTokenOptions.cs
@@ -14,8 +14,6 @@ public sealed class ScopeServiceTokenOptions
 
     public int ClockSkewSeconds { get; set; } = 60;
 
-    public string JwksPath { get; set; } = "/.well-known/aevatar-scope-service-jwks.json";
-
     public ScopeServiceTokenSigningKeyOptions[] SigningKeys { get; set; } = [];
 
     public ScopeServiceTokenSigningKeyOptions? SigningKey { get; set; }

--- a/src/Aevatar.Bootstrap/Aevatar.Bootstrap.csproj
+++ b/src/Aevatar.Bootstrap/Aevatar.Bootstrap.csproj
@@ -10,7 +10,6 @@
     <ProjectReference Include="..\Aevatar.Configuration\Aevatar.Configuration.csproj" />
     <ProjectReference Include="..\Aevatar.Foundation.Runtime.Hosting\Aevatar.Foundation.Runtime.Hosting.csproj" />
     <ProjectReference Include="..\Aevatar.Capabilities\Aevatar.Capabilities.csproj" />
-    <ProjectReference Include="..\Aevatar.Authentication.ScopeServiceTokens\Aevatar.Authentication.ScopeServiceTokens.csproj" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/Aevatar.Bootstrap/Hosting/WebApplicationBuilderExtensions.cs
+++ b/src/Aevatar.Bootstrap/Hosting/WebApplicationBuilderExtensions.cs
@@ -1,6 +1,5 @@
 using Aevatar.Configuration;
 using Aevatar.Capabilities;
-using Aevatar.Authentication.ScopeServiceTokens;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
@@ -177,8 +176,6 @@ public static class WebApplicationBuilderExtensions
 
         if (options.EnableOpenApiDocument)
             app.MapOpenApi(options.OpenApiDocumentRoute).AllowAnonymous();
-
-        app.MapScopeServiceTokenJwks();
 
         if (options.AutoMapCapabilities)
             app.MapAevatarCapabilities();

--- a/test/Aevatar.Bootstrap.Tests/ScopeServiceTokenAuthenticationTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/ScopeServiceTokenAuthenticationTests.cs
@@ -1,11 +1,13 @@
 using System.Security.Cryptography;
 using Aevatar.Authentication.Hosting;
 using Aevatar.Authentication.ScopeServiceTokens;
+using Aevatar.Bootstrap.Hosting;
 using Aevatar.Capabilities;
 using FluentAssertions;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -48,6 +50,49 @@ public sealed class ScopeServiceTokenAuthenticationTests
             .Which.KeyId.Should().Be("scope-kid-1");
         jwtOptions.TokenValidationParameters.IssuerSigningKeyResolver.Should().BeNull();
         jwtOptions.TokenValidationParameters.ValidAudiences.Should().Contain("aevatar-scope-services");
+    }
+
+    [Fact]
+    public void UseAevatarDefaultHost_WhenScopeServiceTokensEnabled_ShouldNotExposeJwksRoute()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Development,
+        });
+
+        builder.Configuration["Aevatar:Authentication:Enabled"] = "true";
+        builder.Configuration["Aevatar:Authentication:Authority"] = "https://nyxid.example.com/";
+        builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:Enabled"] = "true";
+        builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:Issuer"] = "https://aevatar.example.com";
+        builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:Audience"] = "aevatar-scope-services";
+        builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:JwksPath"] = "/custom-jwks.json";
+        builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:SigningKeys:0:Kid"] = "scope-kid-1";
+        builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:SigningKeys:0:Algorithm"] = "HS256";
+        builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:SigningKeys:0:Key"] =
+            "0123456789abcdef0123456789abcdef";
+        builder.AddAevatarDefaultHost(options =>
+        {
+            options.AllowLocalFileSecretsStore = false;
+            options.EnableConnectorBootstrap = false;
+            options.EnableCors = false;
+            options.EnableOpenApiDocument = false;
+            options.AutoMapCapabilities = false;
+        });
+        builder.AddAevatarAuthentication();
+
+        using var app = builder.Build();
+        app.UseAevatarDefaultHost();
+
+        var routeEndpoints = ((IEndpointRouteBuilder)app).DataSources
+            .SelectMany(x => x.Endpoints)
+            .OfType<RouteEndpoint>()
+            .Select(x => x.RoutePattern.RawText)
+            .ToList();
+
+        routeEndpoints.Should().Contain("/");
+        routeEndpoints.Should().Contain("/health/live");
+        routeEndpoints.Should().NotContain("/.well-known/aevatar-scope-service-jwks.json");
+        routeEndpoints.Should().NotContain("/custom-jwks.json");
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Infrastructure/NyxIdServiceRegistrationAdapterTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Infrastructure/NyxIdServiceRegistrationAdapterTests.cs
@@ -40,5 +40,9 @@ public sealed class NyxIdServiceRegistrationAdapterTests
         root.GetProperty("forward_access_token").GetBoolean().Should().BeFalse();
         root.GetProperty("service_slug").GetString().Should().Be("orders-service");
         root.GetProperty("aevatar_desired_spec_hash").GetString().Should().Be("hash-1");
+        root.EnumerateObject()
+            .Select(x => x.Name)
+            .Should()
+            .NotContain(["jwks_url", "jwks_uri", "jwks_path"]);
     }
 }


### PR DESCRIPTION
## Changed files
- 删除 `ScopeServiceTokens` 的匿名 JWKS mapper 与 `JwksPath` option。
- Bootstrap 默认 host 不再映射 scope service token JWKS route，也不再直接引用该 hosting surface。
- 测试覆盖保留本地 `IssuerSigningKeys` 双 issuer 验证，并确认 NyxID registration 只保存/转发 credential 且 `forward_access_token=false`。

## Test results
- PASS: `dotnet build aevatar.slnx --nologo`
- PASS: `dotnet test test/Aevatar.Bootstrap.Tests/Aevatar.Bootstrap.Tests.csproj --nologo`
- PASS: `dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo`
- PASS: `bash tools/ci/test_stability_guards.sh`
- PASS: `bash tools/ci/aevatar_oauth_client_es_acl_guard.sh`
- PASS: `bash tools/ci/architecture_guards.sh`

## Deviations
- `test/Aevatar.Bootstrap.Tests/AevatarDefaultHostCoverageTests.cs` 不存在；默认 host route 覆盖落在同一授权范围内的 `ScopeServiceTokenAuthenticationTests.cs`。
- Closes #2306

⟦AI:AUTO-LOOP⟧
