### PR TITLE
Refactor GAgent service LLM run host composition

### DIFF
--- a/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -355,33 +355,3 @@ internal sealed class ScheduledDispatchInvokeAdmissionAuthorizer : IInvokeAdmiss
         return Task.CompletedTask;
     }
 }
-
-internal sealed class MissingLlmProviderRunCore : ILlmRunCore
-{
-    public static MissingLlmProviderRunCore Instance { get; } = new();
-
-    private MissingLlmProviderRunCore()
-    {
-    }
-
-    public async Task RunAsync(
-        LlmRunCoreRequest request,
-        ILlmRunSink sink,
-        CancellationToken ct = default)
-    {
-        ArgumentNullException.ThrowIfNull(request);
-        ArgumentNullException.ThrowIfNull(sink);
-        ArgumentNullException.ThrowIfNull(request.Command);
-
-        _ = await sink.RecordRunFailedAsync(
-            new LlmRunFailed
-            {
-                ResponseId = request.Command.ResponseId,
-                RunId = request.RunId,
-                FailureCode = "llm_provider_factory_missing",
-                FailureMessage = "ILLMProviderFactory is not registered. Configure an AI provider before executing LLM runs.",
-                FailedAt = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(DateTime.UtcNow),
-            },
-            ct).ConfigureAwait(false);
-    }
-}

--- a/src/platform/Aevatar.GAgentService.Hosting/Responses/MissingLlmProviderRunCore.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Responses/MissingLlmProviderRunCore.cs
@@ -1,0 +1,35 @@
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Responses;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgentService.Hosting.Responses;
+
+internal sealed class MissingLlmProviderRunCore : ILlmRunCore
+{
+    public static MissingLlmProviderRunCore Instance { get; } = new();
+
+    private MissingLlmProviderRunCore()
+    {
+    }
+
+    public async Task RunAsync(
+        LlmRunCoreRequest request,
+        ILlmRunSink sink,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(sink);
+        ArgumentNullException.ThrowIfNull(request.Command);
+
+        _ = await sink.RecordRunFailedAsync(
+            new LlmRunFailed
+            {
+                ResponseId = request.Command.ResponseId,
+                RunId = request.RunId,
+                FailureCode = "llm_provider_factory_missing",
+                FailureMessage = "ILLMProviderFactory is not registered. Configure an AI provider before executing LLM runs.",
+                FailedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+            },
+            ct).ConfigureAwait(false);
+    }
+}

--- a/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
@@ -28,6 +28,7 @@ using Aevatar.Workflow.Projection.Projectors;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Extensions.Hosting;
 using Aevatar.Workflow.Infrastructure.DependencyInjection;
+using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.GAgentService.Abstractions.Responses;
 using Aevatar.GAgentService.Application.Responses;
 using Microsoft.AspNetCore.Builder;
@@ -98,10 +99,29 @@ public sealed class GAgentServiceHostingServiceCollectionExtensionsTests
             x.ImplementationType == typeof(LlmRunExecutionWorker));
 
         using var provider = services.BuildServiceProvider();
-        provider.GetRequiredService<ILlmRunCore>().Should().NotBeNull();
+        provider.GetRequiredService<ILlmRunCore>().Should().BeOfType<MissingLlmProviderRunCore>();
+        provider.GetRequiredService<ILlmRunExecutionScheduler>()
+            .Should()
+            .BeSameAs(provider.GetRequiredService<LlmRunExecutionScheduler>());
+        provider.GetRequiredService<ILlmRunExecutionQueue>().Should().BeOfType<LlmRunExecutionQueue>();
         provider.GetRequiredService<IScopeBindingReadinessQueryPort>().Should().NotBeNull();
         provider.GetRequiredService<IServiceRolloutCommandObservationQueryReader>().Should().NotBeNull();
         provider.GetRequiredService<IGAgentRunTerminalQueryPort>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddGAgentServiceCapability_WhenLlmProviderFactoryExists_ShouldRegisterProviderBackedRunCore()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+        services.AddSingleton<ILLMProviderFactory>(new ThrowingLlmProviderFactory());
+
+        services.AddGAgentServiceCapability(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<ILlmRunCore>().Should().BeOfType<LlmRunCore>();
     }
 
     [Fact]
@@ -610,5 +630,16 @@ public sealed class GAgentServiceHostingServiceCollectionExtensionsTests
         //   New principle: tests protect against service registration by symbol name without keeping the deleted type alive.
         services.Should().NotContain(service =>
             ServiceTypeContains(service.ServiceType, "WorkflowCapabilitiesStartupArtifact"));
+    }
+
+    private sealed class ThrowingLlmProviderFactory : ILLMProviderFactory
+    {
+        public ILLMProvider GetProvider(string name) =>
+            throw new NotSupportedException("The DI test only asserts provider-backed ILlmRunCore composition.");
+
+        public ILLMProvider GetDefault() =>
+            throw new NotSupportedException("The DI test only asserts provider-backed ILlmRunCore composition.");
+
+        public IReadOnlyList<string> GetAvailableProviders() => [];
     }
 }

--- a/test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj
+++ b/test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\..\src\platform\Aevatar.GAgentService.Governance.Application\Aevatar.GAgentService.Governance.Application.csproj" />
     <ProjectReference Include="..\..\src\platform\Aevatar.GAgentService.Infrastructure\Aevatar.GAgentService.Infrastructure.csproj" />
     <ProjectReference Include="..\..\src\platform\Aevatar.GAgentService.Governance.Infrastructure\Aevatar.GAgentService.Governance.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\platform\Aevatar.GAgentService.Hosting\Aevatar.GAgentService.Hosting.csproj" />
     <ProjectReference Include="..\..\src\platform\Aevatar.GAgentService.Projection\Aevatar.GAgentService.Projection.csproj" />
     <ProjectReference Include="..\..\src\platform\Aevatar.GAgentService.Governance.Projection\Aevatar.GAgentService.Governance.Projection.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.Authentication.ScopeServiceTokens\Aevatar.Authentication.ScopeServiceTokens.csproj" />

--- a/test/Aevatar.GAgentService.Tests/Hosting/MissingLlmProviderRunCoreTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Hosting/MissingLlmProviderRunCoreTests.cs
@@ -1,0 +1,89 @@
+using System.Reflection;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Responses;
+using Aevatar.GAgentService.Hosting.DependencyInjection;
+using FluentAssertions;
+
+namespace Aevatar.GAgentService.Tests.Hosting;
+
+public sealed class MissingLlmProviderRunCoreTests
+{
+    [Fact]
+    public async Task RunAsync_ShouldRecordTerminalFailure()
+    {
+        var core = LoadMissingProviderRunCore();
+        var sink = new RecordingLlmRunSink();
+
+        await core.RunAsync(
+            new LlmRunCoreRequest(
+                new LlmRunRequested
+                {
+                    ResponseId = "resp-missing-provider",
+                    RunId = "run-missing-provider",
+                },
+                "run-missing-provider",
+                "ApiKey"),
+            sink);
+
+        sink.Failed.Should().ContainSingle();
+        var failed = sink.Failed[0];
+        failed.ResponseId.Should().Be("resp-missing-provider");
+        failed.RunId.Should().Be("run-missing-provider");
+        failed.FailureCode.Should().Be("llm_provider_factory_missing");
+        failed.FailureMessage.Should().Contain("ILLMProviderFactory is not registered");
+        failed.FailedAt.Should().NotBeNull();
+        sink.Completed.Should().BeEmpty();
+        sink.Cancelled.Should().BeEmpty();
+    }
+
+    private static ILlmRunCore LoadMissingProviderRunCore()
+    {
+        var assembly = typeof(ServiceCollectionExtensions).Assembly;
+        var type = assembly.GetType("Aevatar.GAgentService.Hosting.Responses.MissingLlmProviderRunCore", throwOnError: true)!;
+        typeof(ILlmRunCore).IsAssignableFrom(type).Should().BeTrue();
+
+        var instance = type.GetProperty("Instance", BindingFlags.Public | BindingFlags.Static)!.GetValue(null);
+        return instance.Should().BeAssignableTo<ILlmRunCore>().Subject;
+    }
+
+    private sealed class RecordingLlmRunSink : ILlmRunSink
+    {
+        public List<LlmRunCompleted> Completed { get; } = [];
+        public List<LlmRunFailed> Failed { get; } = [];
+        public List<LlmRunCancelled> Cancelled { get; } = [];
+
+        public Task<LlmRunRecordDecision> RecordStreamChunkObservedAsync(
+            LlmStreamChunkObserved observed,
+            CancellationToken ct = default) =>
+            Task.FromResult(LlmRunRecordDecision.Continue);
+
+        public Task<LlmRunRecordDecision> RecordToolCallObservedAsync(
+            LlmToolCallObserved observed,
+            CancellationToken ct = default) =>
+            Task.FromResult(LlmRunRecordDecision.Continue);
+
+        public Task<LlmRunRecordDecision> RecordRunCompletedAsync(
+            LlmRunCompleted completed,
+            CancellationToken ct = default)
+        {
+            Completed.Add(completed.Clone());
+            return Task.FromResult(LlmRunRecordDecision.Continue);
+        }
+
+        public Task<LlmRunRecordDecision> RecordRunFailedAsync(
+            LlmRunFailed failed,
+            CancellationToken ct = default)
+        {
+            Failed.Add(failed.Clone());
+            return Task.FromResult(LlmRunRecordDecision.Continue);
+        }
+
+        public Task<LlmRunRecordDecision> RecordRunCancelledAsync(
+            LlmRunCancelled cancelled,
+            CancellationToken ct = default)
+        {
+            Cancelled.Add(cancelled.Clone());
+            return Task.FromResult(LlmRunRecordDecision.Continue);
+        }
+    }
+}


### PR DESCRIPTION
## Changed files
将 missing-provider `ILlmRunCore` 适配器从 DI 扩展文件拆到 Hosting Responses 下的独立实现，并保持缺少 `ILLMProviderFactory` 时记录终态失败的运行期语义。测试更新为断言当前 off-grain queue / scheduler / worker 组合，以及有 provider factory 时解析真实 `LlmRunCore`、无 provider factory 时解析 missing-provider adapter。

## Test results
通过 `dotnet build aevatar.slnx --nologo`、`dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --filter "FullyQualifiedName~GAgentServiceHostingServiceCollectionExtensionsTests" --nologo`、`dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --filter "LlmRun|MissingLlmProvider" --nologo`、`bash tools/ci/test_stability_guards.sh`。host guard hook 报告 `guards skipped: CI_GUARDS unset`。

## Deviations
Closes #2307
为使 unit test project 能直接测试 hosting adapter 行为，扩展了 `test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj` 的 hosting project reference，并已记录 `SCOPE_EXTEND`。refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)

⟦AI:AUTO-LOOP⟧
