### PR TITLE
WIP：docs: design workflow realtime visibility

### DIFF
--- a/docs/designs/2026-06-22-team-workflow-realtime-visibility-design.md
+++ b/docs/designs/2026-06-22-team-workflow-realtime-visibility-design.md
@@ -1,0 +1,559 @@
+---
+title: "Team Workflow Realtime Visibility Design"
+status: draft
+owner: codex
+created: 2026-06-22
+source_prd: docs/designs/2026-06-22-team-workflow-realtime-visibility-prd.md
+source_plan: docs/designs/2026-06-22-team-workflow-realtime-visibility-implementation-plan.md
+branch: docs/2026-06-22_workflow-realtime-visibility-prd
+---
+
+# Team Workflow Realtime Visibility Design
+
+This document turns the agreed PRD into an implementation design. It defines the contracts, ownership boundaries, data flow, frontend state model, UI information architecture, and verification gates for the Team Run Cockpit.
+
+Related documents:
+
+- [Team Workflow Realtime Visibility PRD](2026-06-22-team-workflow-realtime-visibility-prd.md)
+- [Team Workflow Realtime Visibility Implementation Plan](2026-06-22-team-workflow-realtime-visibility-implementation-plan.md)
+
+## 1. Design Position
+
+The feature is a Team-context run inspection surface for member-owned workflow execution.
+
+The product sentence is:
+
+> Watch what this Team-entry workflow run is doing now, then reopen the same run later from durable truth.
+
+The implementation sentence is:
+
+> Resolve `scopeId + teamId + runId` into the accepted run owner tuple, then read member-scoped durable run summary and audit, with live AGUI/SSE frames as current-session evidence only.
+
+V1 is intentionally read-only. It is not a generic observability dashboard, not a workflow editor, and not a waiting-action control plane.
+
+## 2. Hard Invariants
+
+### 2.1 Identity Boundaries
+
+These identities must remain separate in routes, DTOs, local variables, tests, and UI labels.
+
+| Identity | Meaning | Allowed Use |
+| --- | --- | --- |
+| `scopeId` | Workspace boundary | Team route root and permission boundary |
+| `teamId` | Studio Team ownership surface | Product context for the cockpit |
+| `entryMemberId` | Current Team entry member | Starting new Team runs only |
+| `ownerMemberId` | Member that owned the accepted run | Historical run inspection |
+| `workflowId` | Draft or definition document identity hint | Editor/draft context only |
+| `publishedServiceId` | Callable service runtime identity | Invocation and historical service identity |
+| `runId` | One execution instance | Run detail identity |
+| `actorId` | Runtime actor address | Diagnostics or typed runtime control where allowed |
+| `commandId` | Accepted command trace identity | Diagnostics and correlation |
+| `correlationId` | Cross-boundary trace identity | Diagnostics and correlation |
+
+Rules:
+
+- `teamId` is product context, not runtime owner.
+- `entryMemberId` must not be reused as the owner of a historical run without durable verification.
+- `publishedServiceId` for a historical run is the acceptance-time value, not the member's current binding.
+- `workflowId` must never substitute for `memberId`, `publishedServiceId`, `teamId`, or `runId`.
+- Tests must use distinct ID shapes such as `team-alpha`, `m-alpha`, `wf-alpha`, `svc-alpha`, and `run-alpha`.
+
+### 2.2 Truth Sources
+
+| Concern | Authority | Non-Authority |
+| --- | --- | --- |
+| Team identity | Team read model | route label, browser cache |
+| New Team run entry member | Team read model plus member read model | old run owner |
+| Historical run owner | accepted owner envelope or durable owner resolver | current entry member |
+| Historical published service | acceptance-time owner tuple | current member binding |
+| Run status | durable run summary/current-state read model | live stream connection |
+| Timeline after refresh | durable audit artifact | browser memory |
+| Final output | durable audit or durable summary | live output preview |
+| Evidence copy safety | typed redaction/sensitivity contract | UI string guessing |
+| Waiting actions | typed backend capabilities | status strings or raw payloads |
+
+Live frames are useful evidence. They are not the source of durable truth.
+
+### 2.3 Architecture Boundaries
+
+- Commands enter runtime and eventually produce committed facts.
+- Queries read read models or durable run artifacts.
+- The owner resolver must not replay events in the query path.
+- The owner resolver must not depend on a process-local `runId -> context` dictionary.
+- The cockpit must not prime projections during page load.
+- Projection and AGUI should converge on the same committed facts rather than create a parallel truth path.
+- Backend contracts should use explicit typed fields. Do not hide stable semantics inside a generic bag.
+
+## 3. Target Architecture
+
+```mermaid
+%%{init: {"maxTextSize": 100000, "flowchart": {"useMaxWidth": false, "nodeSpacing": 10, "rankSpacing": 50}, "themeVariables": {"fontSize": "10px"}}}%%
+flowchart LR
+    U["Team Operator"] --> TD["Team Detail"]
+    TD --> Start["Start Team Run"]
+    Start --> TeamEndpoint["Team Stream Endpoint"]
+    TeamEndpoint --> EntryResolver["Entry Member Resolver"]
+    EntryResolver --> Dispatch["Runtime Dispatch"]
+    Dispatch --> OwnerEnvelope["Accepted Owner Envelope"]
+    Dispatch --> Runtime["Member-Owned Run Actor"]
+    Runtime --> Committed["Committed Run Facts"]
+    Committed --> Projection["Projection / Materialization"]
+    Projection --> Summary["Durable Run Summary"]
+    Projection --> Audit["Durable Run Audit"]
+    OwnerEnvelope --> Cockpit["Team Run Cockpit"]
+    TD --> Cockpit
+    Cockpit --> OwnerResolver["Team Run Owner Resolver"]
+    OwnerResolver --> OwnerTuple["Owner Tuple"]
+    OwnerTuple --> MemberQueries["Member-Scoped Run Queries"]
+    MemberQueries --> Summary
+    MemberQueries --> Audit
+    TeamEndpoint -. "current session only" .-> LiveFrames["Live AGUI/SSE Frames"]
+    LiveFrames -. "enhancement" .-> Cockpit
+```
+
+The central design choice is that Team creates the viewing context, while the accepted run owner tuple creates the query context.
+
+## 4. Backend Design
+
+### 4.1 Accepted Team Run Owner Envelope
+
+When a Team run is accepted for dispatch, the backend must return or stream a typed owner envelope before the frontend pins the cockpit route.
+
+Required shape:
+
+```json
+{
+  "scopeId": "scope-alpha",
+  "teamId": "team-alpha",
+  "ownerMemberId": "m-alpha",
+  "publishedServiceId": "svc-alpha",
+  "runId": "run-alpha",
+  "actorId": "actor-alpha",
+  "commandId": "cmd-alpha",
+  "correlationId": "corr-alpha",
+  "invocationSource": "team",
+  "ackStage": "dispatch_accepted"
+}
+```
+
+Contract rules:
+
+- `ackStage = "dispatch_accepted"` means accepted for dispatch only.
+- It must not claim completion, audit availability, or read-model visibility.
+- `ownerMemberId` is the accepted owner of this run.
+- `publishedServiceId` is captured at acceptance time.
+- `invocationSource = "team"` is required before Team Detail can label the run as Team work.
+
+### 4.2 Minimal Team Run Owner Resolver
+
+V1 requires a cold-start resolver for a known run link:
+
+```text
+GET /api/scopes/:scopeId/teams/:teamId/runs/:runId/owner
+```
+
+Equivalent routing is acceptable if it preserves the same resource semantics.
+
+Response shape:
+
+```json
+{
+  "scopeId": "scope-alpha",
+  "teamId": "team-alpha",
+  "runId": "run-alpha",
+  "ownerMemberId": "m-alpha",
+  "publishedServiceId": "svc-alpha",
+  "actorId": "actor-alpha",
+  "commandId": "cmd-alpha",
+  "correlationId": "corr-alpha",
+  "invocationSource": "team",
+  "acceptedAt": "2026-06-22T10:00:00Z"
+}
+```
+
+Resolver requirements:
+
+- It resolves only known Team-context runs.
+- It returns the acceptance-time owner tuple.
+- It must be durable across browser refresh and service restart.
+- It must return not found or unavailable honestly when no durable Team ownership is available.
+- It must not fall back to current Team `entryMemberId`.
+- It must not recompute `publishedServiceId` from current member state.
+- It must not query-time replay events or trigger projection priming.
+- It must not use process-local state as authority.
+
+### 4.3 Durable Owner Record
+
+If existing durable run summary/audit already contains the required owner metadata, the resolver can read that read model.
+
+If not, implementation must add a typed durable owner record at acceptance time. The record is not a full Team run index; it is a minimal lookup to reopen a known run.
+
+Minimum fields:
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `scopeId` | yes | Permission and workspace boundary |
+| `teamId` | yes | Team product context |
+| `runId` | yes | Lookup key with `teamId` |
+| `ownerMemberId` | yes | Historical owner |
+| `publishedServiceId` | yes | Acceptance-time service |
+| `actorId` | yes | Runtime diagnostic identity |
+| `commandId` | yes | Dispatch trace |
+| `correlationId` | yes | Cross-boundary trace |
+| `invocationSource` | yes | Must be `team` for Team work label |
+| `acceptedAt` | yes | Sorting and diagnostics |
+
+### 4.4 Member-Scoped Durable Run Queries
+
+After owner resolution, the cockpit can call existing member-scoped run summary and audit endpoints using:
+
+```text
+scopeId + ownerMemberId + publishedServiceId + runId
+```
+
+The frontend must not call member-scoped run queries with `teamId`, `workflowId`, or current `entryMemberId` as substitutes.
+
+### 4.5 Error Semantics
+
+The resolver and run queries should distinguish these states:
+
+| State | Meaning | UI Behavior |
+| --- | --- | --- |
+| `owner_pending` | Accepted envelope exists in session but durable owner lookup is not visible yet | Show accepted/durable pending |
+| `owner_not_found` | No durable Team owner record for this `teamId + runId` | Show cannot verify owner |
+| `owner_forbidden` | User cannot access Team or run owner | Show access denied |
+| `summary_pending` | Owner resolved but run summary not materialized | Continue polling or refresh |
+| `audit_unavailable` | Summary exists but audit is not available | Show timeline unavailable without marking run failed |
+| `live_disconnected` | SSE/AGUI stream disconnected | Mark source disconnected, not run failed |
+
+## 5. Frontend Design
+
+### 5.1 Routes
+
+Canonical route:
+
+```text
+/scopes/:scopeId/teams/:teamId/runs/:runId
+```
+
+Route semantics:
+
+- `scopeId`, `teamId`, and `runId` come from path.
+- `ownerMemberId` may be carried as a query hint only if verified by the owner resolver.
+- `workflowId` is not accepted as a run owner hint.
+- Route variables should use names like `routeScopeId`, `routeTeamId`, and `routeRunId`.
+
+Forbidden route behavior:
+
+- Do not generate `/teams/:scopeId...` legacy paths.
+- Do not parse path segments by old index positions.
+- Do not use a route `workflowId` as member, service, or run identity.
+
+### 5.2 Team Detail Strip
+
+Team Detail remains the operator's starting point.
+
+It may show:
+
+- Team display name and lifecycle.
+- Entry member display name.
+- Published workflow capability status.
+- Latest verified Team run when `invocationSource = "team"` and `teamId` matches.
+- Fallback **Entry member latest run** when only member-scoped run history is available.
+- Last output or error preview from durable summary.
+
+It must not show:
+
+- Local browser recent runs as Team truth.
+- Member-only run history labeled as Team work.
+- Current draft workflow state as historical run state.
+
+### 5.3 Cockpit Page Model
+
+The page state has five layers:
+
+| Layer | Owner | Purpose |
+| --- | --- | --- |
+| `routeContext` | Router | `scopeId + teamId + runId` |
+| `acceptedEnvelope` | Current browser session | Immediate just-started owner tuple |
+| `resolvedOwner` | Durable owner resolver | Historical owner tuple |
+| `durableRun` | Run summary/audit queries | Truth for status, output, timeline |
+| `liveSession` | Current SSE/AGUI stream | Current-session evidence and animation |
+
+Derived page states:
+
+| State | Trigger | Display |
+| --- | --- | --- |
+| `resolving_owner` | Route loaded without verified owner | Skeleton with Team/run context |
+| `accepted_pending` | Accepted envelope exists, durable owner not visible | Accepted for dispatch, durable pending |
+| `owner_resolved` | Resolver returned owner tuple | Load durable summary/audit |
+| `summary_pending` | Owner resolved, summary missing | Run accepted, waiting for materialization |
+| `audit_unavailable` | Summary exists, audit missing | Show summary and unavailable timeline state |
+| `live_enhanced` | Live frames connected | Add live-only rows/previews |
+| `live_disconnected` | Stream ended unexpectedly | Source disconnected, run status unchanged |
+| `complete` | Durable terminal status available | Durable output/error wins |
+
+### 5.4 Durable-First Merge
+
+Merge priority:
+
+1. Durable audit event with source version or durable event identity.
+2. Durable run summary.
+3. Live frame with stable event id.
+4. Live frame with composite key.
+5. Browser-local sequence for display only.
+
+Recommended row key:
+
+```text
+eventId
+runId + stepId + eventType + timestamp
+localSequence
+```
+
+Rules:
+
+- Durable audit rows replace matching live rows.
+- Durable status replaces live status.
+- Durable final output replaces live preview.
+- Durable failure reason replaces live error preview.
+- Live disconnected changes source status only.
+- Durable summary older than live frames may show a freshness note.
+- Unmatched live-only rows must be labeled as session evidence.
+
+### 5.5 Redaction-Safe Evidence
+
+Evidence is a drill-down tab. It is not the default view and not a redaction bypass.
+
+Default copy bundle may include:
+
+- `scopeId`
+- `teamId`
+- `runId`
+- `ownerMemberId`
+- `publishedServiceId`
+- `actorId`
+- `commandId`
+- `correlationId`
+- event names
+- timestamps
+- typed redacted previews
+- status and error codes
+
+Default copy bundle must exclude:
+
+- raw payload bodies when sensitivity is unknown
+- secure human input
+- untyped arbitrary JSON bodies
+- hidden tool credentials or connector payloads
+
+Raw selected payload copy is allowed only when the contract marks the payload safe, or in a future authorized debug mode.
+
+### 5.6 UI Information Architecture
+
+The cockpit uses an operational layout:
+
+- Header: Team context, owner member, workflow/service identity, run status, freshness.
+- Main default view: Timeline.
+- Inspector: selected event or step detail.
+- Secondary tabs: Information, Output, Evidence.
+
+```mermaid
+%%{init: {"maxTextSize": 100000, "flowchart": {"useMaxWidth": false, "nodeSpacing": 10, "rankSpacing": 50}, "themeVariables": {"fontSize": "10px"}}}%%
+flowchart TB
+    Page["Team Run Cockpit"]
+    Page --> Header["Header: Team, Owner, Status, Freshness"]
+    Page --> Main["Main: Timeline"]
+    Page --> Inspector["Inspector: Selected Row Detail"]
+    Page --> Tabs["Secondary Tabs"]
+    Tabs --> Info["Information"]
+    Tabs --> Output["Output"]
+    Tabs --> Evidence["Evidence"]
+```
+
+UI rules:
+
+- Timeline is the default view.
+- Graph/map is conditional on authoritative run layout.
+- Information sections render only when typed safe data exists.
+- Waiting rows are informational in V1 Core.
+- Runtime identities are visible but secondary.
+- No large marketing hero, generic observability dashboard, or decorative card stack.
+
+## 6. Data Flow
+
+### 6.1 Start Run Flow
+
+```mermaid
+%%{init: {"maxTextSize": 100000, "sequence": {"actorMargin": 24, "messageMargin": 32, "diagramMarginX": 8, "diagramMarginY": 8}, "themeVariables": {"fontSize": "10px"}}}%%
+sequenceDiagram
+    actor User as User
+    participant TeamDetail as Team Detail
+    participant TeamApi as Team Stream Endpoint
+    participant EntryResolver as Entry Member Resolver
+    participant Runtime as Runtime Dispatch
+    participant Cockpit as Team Run Cockpit
+    participant Durable as Durable Summary / Audit
+
+    User->>TeamDetail: Start Team run
+    TeamDetail->>TeamApi: Invoke with scopeId + teamId
+    TeamApi->>EntryResolver: Resolve current entry member
+    EntryResolver-->>TeamApi: entryMemberId + publishedServiceId
+    TeamApi->>Runtime: Dispatch command
+    Runtime-->>TeamApi: accepted owner envelope
+    TeamApi-->>TeamDetail: dispatch_accepted + owner tuple
+    TeamDetail->>Cockpit: Open route with scopeId + teamId + runId
+    Cockpit->>Durable: Query summary / audit using owner tuple
+    Durable-->>Cockpit: pending or materialized run facts
+```
+
+### 6.2 Reopen Run Flow
+
+```mermaid
+%%{init: {"maxTextSize": 100000, "sequence": {"actorMargin": 24, "messageMargin": 32, "diagramMarginX": 8, "diagramMarginY": 8}, "themeVariables": {"fontSize": "10px"}}}%%
+sequenceDiagram
+    actor User as User
+    participant Router as Route
+    participant Cockpit as Team Run Cockpit
+    participant OwnerResolver as Owner Resolver
+    participant RunApi as Member Run Query
+    participant Durable as Durable Summary / Audit
+
+    User->>Router: Open /scopes/:scopeId/teams/:teamId/runs/:runId
+    Router->>Cockpit: routeScopeId + routeTeamId + routeRunId
+    Cockpit->>OwnerResolver: Resolve teamId + runId
+    OwnerResolver-->>Cockpit: ownerMemberId + publishedServiceId + actorId + trace ids
+    Cockpit->>RunApi: Query using owner tuple
+    RunApi->>Durable: Read summary and audit
+    Durable-->>Cockpit: durable run facts
+```
+
+## 7. Waiting Controls
+
+V1 Core does not introduce waiting action buttons.
+
+Waiting rows can display:
+
+- waiting kind when typed
+- waiting step
+- required actor or role when typed
+- redacted prompt or requested input when typed
+- unavailable state when no safe typed detail exists
+
+V1.5 may add actions only from typed backend capabilities:
+
+```json
+{
+  "waitingKind": "human_approval",
+  "availableActions": [
+    {
+      "type": "approve",
+      "command": "resume",
+      "requiresPayload": false
+    }
+  ]
+}
+```
+
+The UI must not infer actions from labels such as `waiting`, `approval`, raw JSON fields, or step names.
+
+## 8. Permissions And Privacy
+
+This design assumes existing Team, member, and run permissions remain authoritative.
+
+Permission checks must apply to:
+
+- Team route access.
+- Owner resolver access.
+- Member-scoped run summary and audit access.
+- Evidence copy/export actions.
+
+Privacy behavior:
+
+- Unknown sensitivity is treated conservatively.
+- Secure values are redacted by contract, not by UI string matching.
+- Evidence copy is safe by default.
+- Support/debug raw export is out of V1.
+
+## 9. Testing Strategy
+
+### 9.1 Backend Tests
+
+Required behavior tests:
+
+- Starting a Team run returns an accepted owner envelope.
+- The owner envelope uses distinct `ownerMemberId`, `publishedServiceId`, `runId`, `commandId`, and `correlationId`.
+- The owner resolver reopens `scopeId + teamId + runId`.
+- Changing the Team entry member after acceptance does not change the historical owner.
+- Rebinding the owner member after acceptance does not change historical `publishedServiceId`.
+- Missing durable owner record returns an honest not-found/unavailable state.
+- Resolver does not query-time replay events.
+
+### 9.2 Frontend Tests
+
+Required behavior tests:
+
+- Route builders create `/scopes/:scopeId/teams/:teamId/runs/:runId`.
+- Route parsing keeps `routeTeamId`, `routeRunId`, `ownerMemberId`, and `publishedServiceId` distinct.
+- Owner resolver runs before member-scoped run summary/audit queries.
+- `workflowId` is not accepted as a run owner.
+- Team Detail labels verified Team runs as **Team current work**.
+- Team Detail labels member-only history as **Entry member latest run**.
+- Durable output replaces live preview.
+- Live disconnect does not mark run failed.
+- Unknown sensitivity copy-all excludes raw payload bodies.
+- Waiting rows render no action buttons without typed capabilities.
+
+### 9.3 Guard Scripts
+
+Run these when the implementation touches corresponding areas:
+
+- `bash tools/ci/test_stability_guards.sh`
+- `bash tools/ci/workflow_binding_boundary_guard.sh`
+- `bash tools/ci/query_projection_priming_guard.sh`
+- `bash tools/ci/projection_state_version_guard.sh`
+- `bash tools/ci/projection_state_mirror_current_state_guard.sh`
+- `pnpm --dir apps/aevatar-console-web tsc`
+- `pnpm --dir apps/aevatar-console-web test --runInBand`
+
+Backend targeted `dotnet test` commands should cover changed endpoint and service tests.
+
+## 10. Non-Goals
+
+V1 must not include:
+
+- global run observability
+- full Team run aggregation
+- workflow draft graph as historical run truth
+- waiting action controls without typed capabilities
+- support-only raw debug export
+- browser localStorage run authority
+- process-local run owner registry
+- query-time event replay
+- projection priming from page load
+- compatibility routes under `/teams/:scopeId...`
+
+## 11. Rollout Shape
+
+Recommended sequence:
+
+1. Read-only contract mapping.
+2. Accepted owner envelope and durable owner resolver.
+3. Frontend route and owner resolver client.
+4. Durable-first cockpit state model.
+5. Team Detail strip and cockpit UI.
+6. Verification against PRD acceptance criteria.
+
+The feature can be partially shipped only if the cockpit never guesses owner identity. If owner resolution is unavailable, the UI should show an honest unavailable state rather than falling back to current Team/member guesses.
+
+## 12. Open Design Questions
+
+These questions should be answered during `architecture-contract-map` before implementation:
+
+- Which current durable artifact is the best source for the V1 owner resolver?
+- Does the current Team stream endpoint already emit enough owner identity to pin a run immediately?
+- Is there already a typed Team invocation discriminator, or must it be added?
+- Can durable audit expose enough typed Information lineage for V1, or should Information mostly render unavailable states?
+- Which existing frontend execution parser can be reused without importing draft-editor semantics into historical run inspection?
+
+None of these questions changes the core invariant: the cockpit must resolve the immutable owner tuple before historical run inspection.

--- a/docs/designs/2026-06-22-team-workflow-realtime-visibility-implementation-plan.md
+++ b/docs/designs/2026-06-22-team-workflow-realtime-visibility-implementation-plan.md
@@ -1,0 +1,370 @@
+---
+title: "Team Workflow Realtime Visibility Implementation Plan"
+status: pending-confirmation
+owner: codex
+created: 2026-06-22
+source_prd: docs/designs/2026-06-22-team-workflow-realtime-visibility-prd.md
+branch: docs/2026-06-22_workflow-realtime-visibility-prd
+---
+
+# Team Workflow Realtime Visibility Implementation Plan
+
+This plan implements the agreed PRD:
+
+- [Team Workflow Realtime Visibility PRD](2026-06-22-team-workflow-realtime-visibility-prd.md)
+
+No code should be changed until this plan is confirmed.
+
+## 1. Semantic Brief
+
+### Goal
+
+Make Team workflow execution visible through a Team Run Cockpit: Team detail can show what Team-entry workflow work is happening, and a run cockpit can reopen a run through a durable owner tuple rather than route guesses.
+
+### Current Meaning
+
+The codebase has several partial surfaces:
+
+- Team/member invoke can stream AGUI frames while a run is active.
+- Member-scoped run endpoints expose run summaries and audit artifacts.
+- Workflow Studio execution UI can parse run frames.
+- Team detail has member/test/runtime areas, but no stable Team-owned run cockpit.
+
+The current product can easily imply "Team latest work" while actually looking at "entry member latest run." That is unsafe unless the run has durable Team invocation context.
+
+### Target Meaning
+
+Team is the product context. Runtime execution is owned by the accepted run's immutable owner tuple:
+
+```text
+scopeId + teamId context + ownerMemberId + publishedServiceId + runId
+```
+
+The cockpit must resolve this tuple before calling member-scoped run endpoints. Live frames are session evidence only. Durable run summary and audit are the source of truth.
+
+### Semantic Decision
+
+V1 Core is a read-only durable cockpit with live enhancement:
+
+- Team detail may say **Team current work** only when run data has durable `invocationSource = "team"` and matching `teamId`.
+- Without Team attribution, Team detail must say **Entry member latest run**.
+- Historical `publishedServiceId` is captured at acceptance time and must not be recomputed from the member's current binding.
+- Waiting rows do not render actions in V1 Core unless typed capabilities already exist.
+- Evidence copy must be redaction-safe; unknown sensitivity excludes raw payload bodies.
+
+### Action Safety / Recovery
+
+- Accepted run receipt means dispatch accepted, not completed.
+- Accepted-but-not-materialized is a first-class state: `accepted / durable pending`.
+- Missing audit is not failure; show `audit unavailable`.
+- Live stream disconnected is source state, not run status.
+- User-triggered controls are out of V1 Core unless typed capabilities exist.
+- No localStorage, browser recent-runs, process-local dictionary, or query-time replay can become authority.
+
+### Style Direction
+
+Dense, calm, operational, and scan-friendly:
+
+- Timeline is the default view.
+- Evidence is a drill-down layer, not the first screen.
+- Graph/map renders only when authoritative run layout exists; otherwise use ordered timeline.
+- Team context comes first; owner member and runtime identities are visible but secondary.
+
+## 2. Plan
+
+| Step | Agent | Goal | Scope | Risk | Validation | Done Criteria |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | `architecture-explorer` | Confirm current backend contracts and exact owner resolver landing point. | Read-only backend/API/tests. | Medium | Code inspection only. | Decision note for owner resolver, accepted envelope, and test targets. |
+| 2 | `logic-worker` | Add minimal durable owner resolver and accepted Team run owner envelope. | Backend endpoints/contracts/tests. | High | Targeted `dotnet test`; relevant guards if query/projection touched. | `teamId + runId` cold-start resolves immutable owner tuple; accepted Team run can pin cockpit. |
+| 3 | `logic-worker` | Add frontend route/API/navigation foundation. | Frontend routes, navigation helpers, API clients, tests. | Medium | `pnpm --dir apps/aevatar-console-web tsc`; targeted route/API tests. | `/scopes/:scopeId/teams/:teamId/runs/:runId` builds/parses; owner tuple is resolved before member queries. |
+| 4 | `logic-worker` | Build durable-first cockpit view model. | Frontend run/cockpit model modules and tests. | Medium | Focused model tests. | Durable data wins over live frames; source status differs from run status; redaction-safe copy model exists. |
+| 5 | `style-worker` | Implement Team detail strip and read-only cockpit UI. | Team pages/components/locales/tests. | Medium | Frontend tests; browser visual check when app can run. | Team strip labels are honest; cockpit has Timeline, Information, Output, Evidence; no V1 waiting actions without typed capabilities. |
+| 6 | `verifier` | Run final validation and semantic audit. | Read-only touched diff and test suite. | Medium | Guards, targeted backend tests, frontend type/test checks. | Identity boundaries, authority rules, and PRD acceptance criteria are verified. |
+
+## 3. Work Units
+
+### 3.1 Architecture Exploration
+
+```yaml
+id: architecture-contract-map
+title: Map accepted run, owner resolver, and current run query contracts
+agent_role: architecture-explorer
+semantic_decision: Team context is not runtime owner; historical run inspection requires immutable owner tuple.
+action_safety: Accepted receipt is not completion; missing durable read model is pending, not failure.
+scope_paths:
+  - src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+  - src/Aevatar.Studio.Application/Studio/Services/StudioTeamGAgentStreamInvocationService.cs
+  - src/Aevatar.Studio.Application/Studio/Services/StudioTeamEntryMemberResolver.cs
+  - src/Aevatar.Studio.Application/Studio/Services/StudioMemberService.cs
+  - src/Aevatar.Studio.Hosting/Endpoints/StudioTeamEndpoints.cs
+  - src/Aevatar.Studio.Hosting/Endpoints/StudioMemberEndpoints.cs
+  - test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/
+  - test/Aevatar.Studio.Tests/
+non_goals:
+  - no edits
+  - no new endpoint design beyond the minimal owner resolver recommendation
+risk: medium
+dependencies: []
+validation:
+  - read existing endpoint/test paths
+done_criteria:
+  - reports exact owner resolver landing point
+  - reports whether accepted Team stream already exposes enough owner identity
+  - reports required backend tests and any architecture guard impact
+user_confirmation_required: false
+```
+
+### 3.2 Backend Owner Resolver
+
+```yaml
+id: backend-owner-resolver
+title: Add durable Team run owner resolver and accepted owner envelope
+agent_role: logic-worker
+semantic_decision: Run owner tuple is captured at acceptance time and reused for historical inspection.
+action_safety: Resolver must not replay events or query current entry member as authority.
+scope_paths:
+  - src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+  - src/Aevatar.Studio.Application/Studio/Services/StudioTeamGAgentStreamInvocationService.cs
+  - src/Aevatar.Studio.Application/Studio/Abstractions/IStudioTeamGAgentStreamInvocationService.cs
+  - test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceStreamInvocationEndpointTests.cs
+  - test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceRunQueryEndpointTests.cs
+  - test/Aevatar.Studio.Tests/StudioTeamGAgentStreamInvocationServiceTests.cs
+non_goals:
+  - no full Team run list or aggregation
+  - no waiting controls
+  - no process-local run registry
+  - no query-time replay
+risk: high
+dependencies:
+  - architecture-contract-map
+validation:
+  - dotnet test targeted endpoint/service tests
+  - architecture guards if query/projection paths are touched
+done_criteria:
+  - Team stream accepted response/frame includes owner tuple fields
+  - `scopeId + teamId + runId` can resolve `ownerMemberId + publishedServiceId + actorId + commandId + correlationId`
+  - tests prove entry member changes do not change historical owner
+  - tests prove member rebinding does not change historical `publishedServiceId`
+user_confirmation_required: true
+```
+
+### 3.3 Frontend Route And API Foundation
+
+```yaml
+id: frontend-cockpit-foundation
+title: Add cockpit route, navigation helper, and owner resolver client
+agent_role: logic-worker
+semantic_decision: `teamId + runId` route is product context only; owner tuple must be resolved before member-scoped queries.
+action_safety: The page must show owner-resolution pending/error states instead of guessing.
+scope_paths:
+  - apps/aevatar-console-web/config/routes.ts
+  - apps/aevatar-console-web/src/shared/navigation/teamRoutes.ts
+  - apps/aevatar-console-web/src/shared/navigation/teamRoutes.test.ts
+  - apps/aevatar-console-web/src/shared/api/runtimeRunsApi.ts
+  - apps/aevatar-console-web/src/shared/api/scopeRuntimeApi.ts
+  - apps/aevatar-console-web/src/shared/api/runtimeRunsApi.test.ts
+  - apps/aevatar-console-web/src/shared/api/scopeRuntimeApi.test.ts
+non_goals:
+  - no cockpit visual implementation
+  - no localStorage authority
+  - no `workflowId` as owner hint
+risk: medium
+dependencies:
+  - backend-owner-resolver contract shape
+validation:
+  - pnpm --dir apps/aevatar-console-web tsc
+  - targeted frontend route/API tests
+done_criteria:
+  - route `/scopes/:scopeId/teams/:teamId/runs/:runId` exists
+  - route parser/builders use distinct `routeTeamId`, `routeRunId`, `ownerMemberId`, `publishedServiceId`
+  - owner resolver client is used before member run summary/audit calls
+user_confirmation_required: true
+```
+
+### 3.4 Durable-First Cockpit Model
+
+```yaml
+id: cockpit-view-model
+title: Build durable-first cockpit state model
+agent_role: logic-worker
+semantic_decision: Durable summary/audit owns truth; live frames are current-session evidence only.
+action_safety: Accepted pending, audit unavailable, live disconnected, and waiting-without-capability are separate states.
+scope_paths:
+  - apps/aevatar-console-web/src/pages/teams/
+  - apps/aevatar-console-web/src/shared/studio/execution.ts
+  - apps/aevatar-console-web/src/shared/api/runtimeRunsApi.ts
+  - apps/aevatar-console-web/src/shared/api/scopeRuntimeApi.ts
+non_goals:
+  - no backend schema change
+  - no waiting action controls
+  - no raw debug export
+risk: medium
+dependencies:
+  - frontend-cockpit-foundation
+validation:
+  - focused model/unit tests
+done_criteria:
+  - durable audit replaces matching live rows
+  - final output/failure/status come from durable data
+  - live stream disconnected does not change run status
+  - unknown sensitivity copy-all omits raw payload bodies
+user_confirmation_required: true
+```
+
+### 3.5 Team Strip And Cockpit UI
+
+```yaml
+id: cockpit-ui
+title: Implement Team detail strip and read-only cockpit UI
+agent_role: style-worker
+semantic_decision: Team context is primary; owner member/runtime identities are visible but secondary; Evidence is drill-down.
+action_safety: No waiting action buttons in V1 Core unless typed capabilities exist.
+scope_paths:
+  - apps/aevatar-console-web/src/pages/teams/detail.tsx
+  - apps/aevatar-console-web/src/pages/teams/components/
+  - apps/aevatar-console-web/src/pages/teams/tabs/
+  - apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+  - apps/aevatar-console-web/src/locales/en-US.ts
+non_goals:
+  - no generic observability dashboard
+  - no graph without authoritative layout
+  - no decorative/marketing layout
+risk: medium
+dependencies:
+  - cockpit-view-model
+validation:
+  - pnpm --dir apps/aevatar-console-web tsc
+  - pnpm --dir apps/aevatar-console-web test --runInBand targeted tests
+  - browser visual check if app can run
+done_criteria:
+  - Team detail distinguishes `Team current work` from `Entry member latest run`
+  - cockpit default view is Timeline
+  - Information, Output, Evidence views exist with empty/unavailable states
+  - text fits and basic keyboard/accessibility behavior is preserved
+user_confirmation_required: true
+```
+
+### 3.6 Final Verification
+
+```yaml
+id: final-verification
+title: Verify PRD authority rules and implementation safety
+agent_role: verifier
+semantic_decision: Code, tests, and docs must preserve the agreed identity and truth-source model.
+action_safety: Unsafe or inferred actions must remain absent from V1 Core.
+scope_paths:
+  - touched diff
+non_goals:
+  - no new features
+risk: medium
+dependencies:
+  - backend-owner-resolver
+  - frontend-cockpit-foundation
+  - cockpit-view-model
+  - cockpit-ui
+validation:
+  - bash tools/ci/test_stability_guards.sh
+  - bash tools/ci/workflow_binding_boundary_guard.sh if workflow binding/control paths changed
+  - bash tools/ci/query_projection_priming_guard.sh if query/projection paths changed
+  - bash tools/ci/projection_state_version_guard.sh if current-state readmodel paths changed
+  - pnpm --dir apps/aevatar-console-web tsc
+  - pnpm --dir apps/aevatar-console-web test --runInBand
+  - targeted dotnet tests for changed backend paths
+done_criteria:
+  - relevant checks pass or blockers are explicitly reported
+  - no production UI uses localStorage as Team run authority
+  - no new query-time replay or process-local run fact registry
+  - no route/test fixture assumes `memberId === workflowId`
+user_confirmation_required: false
+```
+
+## 4. Implementation Sequence
+
+### Phase A: Discovery
+
+Run `architecture-contract-map` first. It is read-only and should answer:
+
+- Where can the accepted Team stream expose the owner tuple?
+- Does a durable Team invocation discriminator already exist?
+- Can the resolver be implemented from existing read models/query contracts?
+- What tests already cover Team stream, member run query, and run audit?
+- Which guards become mandatory if query/projection code is touched?
+
+### Phase B: Backend Contract
+
+Implement the minimum durable owner path:
+
+- accepted owner envelope;
+- cold-start owner resolver;
+- tests for entry member changes;
+- tests for member rebinding after run acceptance.
+
+Do not build full Team run aggregation in this phase.
+
+### Phase C: Frontend Foundation
+
+Add route and API plumbing only after the backend contract shape is clear:
+
+- canonical cockpit route;
+- route parser/builders;
+- owner resolver client;
+- identity-distinct tests.
+
+### Phase D: Cockpit Data And UI
+
+Build the durable-first model, then UI:
+
+- accepted / durable pending state;
+- summary available / audit unavailable state;
+- timeline from audit;
+- output from durable data;
+- evidence with redaction-safe copy;
+- live frames as session-only enhancement.
+
+### Phase E: Verification
+
+Run targeted checks first, then broader checks as feasible. If a guard fails, fix the semantic issue rather than suppressing it.
+
+## 5. Risks And Decisions
+
+### Risk: Owner Resolver Source
+
+The biggest risk is whether the current backend has a durable place to answer:
+
+```text
+scopeId + teamId + runId -> ownerMemberId + publishedServiceId
+```
+
+If not, implementation must add a typed, durable owner record at run acceptance. It must not use an in-memory map.
+
+### Risk: Team Invocation Discriminator
+
+If no durable `invocationSource = "team"` or equivalent exists, Team Detail must use the honest fallback label **Entry member latest run** until the discriminator exists.
+
+### Risk: Audit Completeness
+
+If durable audit cannot rebuild Information lineage, V1 must show unavailable states rather than parse raw JSON heuristically.
+
+### Risk: Redaction
+
+If sensitivity is unknown, copy-all must omit raw payload bodies. Support-only raw export is not V1.
+
+### Risk: Existing Worktree Changes
+
+The original workspace has unrelated frontend edits. Implementation should continue in:
+
+```text
+/Users/abigaildeng/Documents/Playground/aevatar-workflow-realtime-visibility-prd
+```
+
+Do not revert or overwrite changes in the original workspace.
+
+## 6. Confirmation Gate
+
+Implementation should start only after this plan is confirmed.
+
+Suggested confirmation phrase:
+
+```text
+按这个 plan 开始执行
+```

--- a/docs/designs/2026-06-22-team-workflow-realtime-visibility-prd.md
+++ b/docs/designs/2026-06-22-team-workflow-realtime-visibility-prd.md
@@ -1,0 +1,745 @@
+---
+title: "Team Workflow Realtime Visibility PRD"
+status: agreed-prd
+owner: codex
+created: 2026-06-22
+branch: docs/2026-06-22_workflow-realtime-visibility-prd
+review_round: 3
+review_consensus: codex + chatgpt
+---
+
+# Team Workflow Realtime Visibility PRD
+
+## 0. Decision Summary
+
+Build a **Team Run Cockpit**: a Team-owned product surface for inspecting **member-owned workflow runs** in realtime and after refresh.
+
+The Team owns the operator context. The entry member and its `publishedServiceId` own execution. `runId` identifies one execution. Live frames make the run feel realtime, but durable run summary and audit remain the source of truth.
+
+V1 is deliberately narrower than a full observability console:
+
+- It supports Teams whose entry member is a published workflow member.
+- It makes Team-started workflow runs visible from Team detail.
+- It opens a read-only cockpit for a known run owner tuple.
+- It renders durable summary, timeline, output, evidence, and limited information lineage from existing or explicitly required durable contracts.
+- It treats live AGUI/SSE frames as session enhancement only.
+- It requires a minimal durable owner resolver so copied/reopened run links work after browser refresh.
+- It does not infer Team state from local browser storage, current entry member guesses, raw status strings, or process-local registries.
+
+## 1. Identity Model And Authority
+
+### 1.1 Stable Identities
+
+The product and implementation must preserve these identity boundaries:
+
+| Identity | Meaning | Product Use |
+| --- | --- | --- |
+| `scopeId` | Workspace boundary | Top-level resource owner |
+| `teamId` | Studio Team ownership surface | Product context and Team route |
+| `entryMemberId` | Current member selected as Team entry point | Used to start new Team runs |
+| `ownerMemberId` | Member that owned a specific accepted run | Used to inspect historical run |
+| `workflowId` | Draft/definition document identity hint | Never used as member/service/run identity |
+| `publishedServiceId` | Callable runtime service identity owned by a member | Runtime invocation target |
+| `runId` | One execution instance | Run detail identity |
+| `actorId` | Runtime actor address for the run | Diagnostics and run control target where required |
+| `commandId` / `correlationId` | Request tracing identities | Diagnostics and dispatch correlation |
+
+Hard rules:
+
+- `teamId` is not the runtime owner.
+- `entryMemberId` is valid for starting new Team runs, but historical run inspection must use the immutable owner identity captured when the run was accepted.
+- `ownerMemberId` is the product name for the member that actually owns a run.
+- `publishedServiceId` is the product/runtime service identity; do not downgrade it to a vague `serviceId` in product contracts.
+- Historical `publishedServiceId` must be the value captured at run acceptance time. It must not be recomputed from the member's current binding after the member has been rebound.
+- `workflowId` must never fetch, infer, or substitute for `teamId`, `memberId`, `publishedServiceId`, or `runId`.
+- A query hint such as `memberId` is only navigation convenience. It must be verified against durable run owner metadata before use.
+
+### 1.2 Immutable Run Owner Tuple
+
+Run inspection is authoritative only when the page has, or can resolve, this tuple:
+
+```text
+scopeId + teamId context + ownerMemberId + publishedServiceId + runId
+```
+
+`teamId context` explains why the user is looking at the run. It does not prove who executed the run.
+
+The tuple must be captured at run acceptance time and carried into durable run summary/audit, or returned by a Team-scoped run index. The page must not reopen a historical run by resolving the Team's **current** entry member and hoping it matches the run's owner.
+
+V1 requires a minimal durable owner resolver:
+
+```text
+scopeId + teamId + runId -> ownerMemberId + publishedServiceId + actorId + commandId + correlationId
+```
+
+This resolver is smaller than a full Team run index. It exists only to reopen a known Team-context run link without guessing the owner. A future Team run index may list and aggregate many runs, but V1 cold-start reopen must not depend on that future index.
+
+### 1.3 Team Invocation Source
+
+Team Detail may say "this Team is processing X" only when the run has durable Team invocation context:
+
+```json
+{
+  "scopeId": "scope-alpha",
+  "teamId": "team-alpha",
+  "ownerMemberId": "m-alpha",
+  "publishedServiceId": "svc-alpha",
+  "runId": "run-alpha",
+  "invocationSource": "team",
+  "commandId": "cmd-alpha",
+  "correlationId": "corr-alpha"
+}
+```
+
+If V1 only has member-scoped run history without a Team invocation discriminator, the UI must label the strip honestly as **Entry member latest run**, not **Team current work**.
+
+## 2. Product Problem
+
+The product can already run workflow members and collect pieces of evidence:
+
+- Team/member invoke can stream AGUI frames while a run is active.
+- Member-scoped run endpoints expose run lists, summaries, and audit artifacts.
+- Workflow Studio can parse execution frames into run, step, waiting, usage, output, and raw-event views.
+- Runtime/Mission surfaces expose some run health.
+
+The experience is still fragmented. A Team operator cannot look at the Team and answer:
+
+- What work did this Team just accept?
+- Which member and published service actually own this run?
+- What information entered the workflow?
+- Which step is active, completed, waiting, or failed?
+- What did each step receive and produce?
+- What final output is backed by durable evidence?
+- What can the user safely copy or share for support?
+
+The desired mental model is not "invoke something and inspect logs." It is "watch the Team work, then reopen the run later with the same truth."
+
+## 3. Users
+
+### Primary: Team Operator
+
+- Starts and monitors Team work from Team detail.
+- Needs current status, waiting/failure explanation, and final output without reading raw frames first.
+- Thinks in Teams and members, not actor addresses.
+
+### Secondary: Workflow Builder
+
+- Uses the cockpit while testing a published workflow member through the Team surface.
+- Needs step input/output, role/tool interaction, usage, and errors.
+- Needs confidence that the displayed workflow matches the published run, not a stale draft.
+
+### Tertiary: Support / Engineering
+
+- Needs raw event frames, run ids, actor ids, command ids, state versions, audit links, and copyable diagnostics.
+- Must respect redaction and permission boundaries.
+
+## 4. V1 Scope
+
+### 4.1 In Scope
+
+V1 covers:
+
+- Team detail live work strip for a workflow entry member.
+- Starting a Team run and receiving an accepted run owner envelope.
+- Read-only Team Run Cockpit for a verified owner tuple.
+- Durable run summary and durable run audit rendering.
+- Ordered timeline as the default view.
+- Final output view.
+- Evidence view with redaction-safe copy.
+- Live AGUI/SSE frames as current-session enhancement.
+- Honest states for accepted-but-not-materialized, audit unavailable, and live disconnected.
+- Identity-boundary tests with distinct id shapes.
+
+### 4.2 Conditional In Scope
+
+These are included only when the backend exposes typed contracts:
+
+- Step-level Information lineage after refresh.
+- Workflow map layout.
+
+If typed contracts are absent, V1 must degrade to durable summary, ordered timeline, output, and evidence rather than invent behavior from raw frames.
+
+Waiting controls are not part of V1 Core. They belong to V1.5 unless the backend already exposes typed waiting capabilities before implementation starts.
+
+### 4.3 Out Of Scope
+
+- Global distributed observability.
+- Full multi-member Team run list or aggregation beyond the V1 owner resolver.
+- Non-workflow Team member cockpit.
+- Run comparison.
+- Latency heatmaps.
+- Support-only raw debug mode.
+- Audit retention policy UI.
+- Published revision versus draft diff.
+- Browser localStorage as authoritative run state.
+- Query-time replay, projection priming, or process-local `runId -> context` registries.
+
+## 5. Source Of Truth
+
+| Question | Durable Source | Live Source | UI May Infer? |
+| --- | --- | --- | --- |
+| Which Team is this? | Team read model | None | No |
+| Which member starts new Team runs? | Team `entryMemberId` + member read model | None | No |
+| Who owns this historical run? | Accepted run owner envelope or Team-scoped run index | None | No |
+| Which published service executed it? | Durable owner tuple / member binding at acceptance | None | No |
+| Current run status | Run summary / workflow current-state read model | Live lifecycle frames as temporary display | No final status inference |
+| Completed/total steps | Run summary or audit | Live step frames as temporary display | No durable overwrite |
+| Waiting kind | Typed run/audit capability contract | Live waiting frames as temporary display | No string/status inference |
+| Available actions | Typed backend capabilities | None | No |
+| Final output | Durable run summary/audit | Live output frame as temporary preview | Durable wins |
+| Failure reason | Durable run summary/audit | Live error frame as temporary preview | Durable wins |
+| Timeline after refresh | Durable audit artifact | None | No |
+| Realtime animation | None | Current SSE/AGUI stream | Yes, as live-only decoration |
+| Redaction | Typed redaction/secure fields | Typed live redaction flags only | No |
+
+Durable state has precedence over live state when both describe the same event, step, output, or error. Live frames must never overwrite a durable result with a higher `stateVersion`, newer `lastEventId`, or verified audit event.
+
+## 6. Run Owner Resolution
+
+### 6.1 Starting A Team Run
+
+When a user starts a Team run:
+
+1. The frontend calls the Team stream endpoint.
+2. The backend resolves the current Team entry member.
+3. The member-owned `publishedServiceId` receives the invocation.
+4. The backend returns or streams an accepted owner envelope before the cockpit pins the run:
+
+```json
+{
+  "scopeId": "scope-alpha",
+  "teamId": "team-alpha",
+  "ownerMemberId": "m-alpha",
+  "publishedServiceId": "svc-alpha",
+  "runId": "run-alpha",
+  "actorId": "actor-alpha",
+  "commandId": "cmd-alpha",
+  "correlationId": "corr-alpha",
+  "ackStage": "dispatch_accepted"
+}
+```
+
+The accepted envelope means the command entered runtime dispatch. It does not mean the member exists in a fresh read model, the workflow completed, or audit is visible.
+
+### 6.2 Reopening A Run
+
+When opening `/scopes/:scopeId/teams/:teamId/runs/:runId`, the page must resolve the owner tuple by one of these paths:
+
+1. The V1 owner resolver returns `ownerMemberId`, `publishedServiceId`, and runtime ids for `teamId + runId`.
+2. A future Team-scoped run index returns the same owner tuple.
+3. The route carries `ownerMemberId` as a hint and the page verifies it against durable run owner metadata.
+4. The user arrives from a just-accepted run and the page holds the accepted owner envelope while waiting for durable materialization.
+
+The page must not use the current Team `entryMemberId` as the historical run owner unless durable run owner metadata verifies it.
+
+The page must also not recompute `publishedServiceId` from the owner member's current binding. Rebinding a member after a run starts must not change which historical published service the cockpit uses for that run.
+
+### 6.3 Team Latest Work
+
+Team Detail can show **Team current work** only for runs with durable `invocationSource = "team"` and matching `teamId`.
+
+If only member run history is available:
+
+- Show **Entry member latest run**.
+- Display the entry member identity.
+- Avoid saying the Team itself is processing that run.
+- Link to the cockpit only when the owner tuple can be verified.
+
+## 7. Product Surfaces
+
+### 7.1 Team Detail Live Work Strip
+
+Location:
+
+- `/scopes/:scopeId/teams/:teamId`
+
+Purpose:
+
+- Provide a compact, honest signal for recent Team-entry work.
+
+Fields:
+
+- Team name and lifecycle.
+- Entry member display name.
+- Published workflow capability state.
+- Latest verified Team run, or entry member latest run if Team attribution is unavailable.
+- Display status.
+- Workflow name.
+- Progress count.
+- Last updated time.
+- Last output/error preview.
+
+Sources:
+
+- Team read model.
+- Member read model.
+- Team-scoped run index, or verified member run summary.
+
+Empty states:
+
+- No entry member.
+- Entry member not workflow-capable.
+- Entry member not bound.
+- No verified Team runs.
+- Accepted run awaiting durable summary.
+
+Forbidden behavior:
+
+- Do not read local recent runs as authority.
+- Do not label member-only history as Team work.
+- Do not infer `publishedServiceId` from route strings.
+
+### 7.2 Team Run Cockpit
+
+Canonical route:
+
+- `/scopes/:scopeId/teams/:teamId/runs/:runId`
+
+Required route semantics:
+
+- Path identifies Team context and run id.
+- Owner identity must be resolved or verified before member-scoped run queries.
+- `workflowId` is not accepted as a run owner hint.
+
+Layout:
+
+- Header: Team, owner member, workflow name, display status, elapsed time, durable freshness.
+- Main: ordered timeline.
+- Side inspector: selected step or run detail.
+- Secondary tabs: `Information`, `Output`, `Evidence`.
+
+Default view:
+
+- `Timeline`.
+
+Forbidden behavior:
+
+- Do not show a graph generated from the current draft workflow for a historical published run.
+- Do not claim live-only frames are durable.
+- Do not expose unredacted evidence through copy/export.
+
+### 7.3 Timeline
+
+Purpose:
+
+- Show how the workflow advanced in human terms.
+
+V1 source:
+
+- Durable audit artifact when available.
+- Live frames as current-session temporary rows.
+
+Rows:
+
+- Run accepted / started.
+- Step requested.
+- Step completed / failed.
+- Human input or approval requested.
+- Waiting for signal.
+- Tool call started / ended.
+- Message chunks grouped into message rows.
+- Usage/cost/latency.
+- Run completed / failed / stopped.
+
+Workflow map rule:
+
+- V1 uses the audit artifact's step order as the authority.
+- A graphical map may render only when the run audit or verified published revision provides layout for that run.
+- If layout is unavailable, the cockpit uses an ordered timeline.
+- The current draft definition must not explain a historical published run unless the run explicitly references that exact revision.
+
+### 7.4 Information
+
+Purpose:
+
+- Explain what information the run processed.
+
+V1 behavior:
+
+- Show sections only when typed durable audit or typed live frames provide safe data.
+- Otherwise show "Not emitted" or "Audit does not include this detail" instead of inventing lineage.
+
+Sections:
+
+- Run input.
+- Step inputs.
+- Step outputs.
+- External interactions.
+- File refs.
+- Assigned variables and branch choices.
+- Redaction status.
+
+Forbidden behavior:
+
+- Do not parse arbitrary raw JSON text to infer secure values.
+- Do not show secure human input except through typed redacted fields.
+
+### 7.5 Output
+
+Purpose:
+
+- Make the final result inspectable without digging through logs.
+
+Source priority:
+
+1. Durable audit final output.
+2. Durable run summary output.
+3. Live output preview, labeled as live-only.
+
+Content:
+
+- Final output.
+- Status and completion reason.
+- Last successful step.
+- Last error if failed.
+- Usage summary when available.
+- Copy output.
+
+Rules:
+
+- Prefer business output text over raw JSON.
+- If no output has been emitted, say so.
+- If durable output differs from live output, durable output replaces live preview and the Evidence tab records the discrepancy.
+
+### 7.6 Evidence
+
+Purpose:
+
+- Preserve debuggability without making raw diagnostics the primary product.
+
+Content:
+
+- Durable run summary.
+- Durable audit artifact.
+- Live browser-session frames, clearly labeled as incomplete after refresh.
+- Owner tuple and runtime identities.
+- Redaction-safe copy actions.
+
+Rules:
+
+- Evidence is debuggability, not a redaction bypass.
+- Default copy bundle includes only redacted or non-sensitive fields.
+- When sensitivity is unknown, copy-all excludes raw payload bodies and includes only safe identifiers, timestamps, event names, redacted previews, and run owner ids.
+- Copy selected raw payload is available only if the payload is marked safe by contract or the user has an authorized debug mode in a future version.
+- Label this area `Evidence`, not `Metadata`.
+
+## 8. Realtime Merge Model
+
+Live frames improve immediacy. They do not own truth.
+
+Merge rules:
+
+- Live frames are kept in current browser memory only.
+- Live rows are keyed by the most precise available identity: `eventId`, then `runId + stepId + eventType + timestamp`, then local sequence as a last resort.
+- Durable audit rows replace matching live rows.
+- Durable run summary owns display status, final output, failure reason, completed steps, and state version.
+- If durable summary is older than live frames, the UI may show a freshness note: `Live activity observed; durable summary has not caught up`.
+- If the stream disconnects, the run status does not become failed. The live source status becomes `disconnected`, and durable polling continues.
+- When durable audit appears, the cockpit rebuilds the timeline from audit and keeps live-only unmatched rows in a clearly labeled section until they are matched or discarded.
+
+Display statuses:
+
+```text
+accepted
+running
+waiting
+completed
+failed
+stopped
+unknown
+```
+
+Source statuses:
+
+```text
+live_connected
+live_disconnected
+durable_pending
+durable_available
+audit_unavailable
+```
+
+Source status is not run status.
+
+## 9. Waiting Action Model
+
+V1 Core is read-only. Waiting rows can explain what the run is waiting for, but they do not render action buttons unless the backend already exposes typed capabilities.
+
+V1.5 renders waiting actions only from typed backend capabilities.
+
+Example shape:
+
+```json
+{
+  "waitingKind": "human_approval",
+  "availableActions": [
+    {
+      "type": "approve",
+      "command": "resume",
+      "requiresPayload": false
+    },
+    {
+      "type": "reject",
+      "command": "resume",
+      "requiresPayload": true
+    }
+  ]
+}
+```
+
+Rules:
+
+- Do not infer actions from status strings, custom payload names, step labels, or raw payload text.
+- `waiting` without capabilities is informational only.
+- Action receipts are shown as accepted, not completed.
+- The page waits for durable run updates before claiming that an action succeeded.
+- If capabilities are not available, the cockpit remains read-only for waiting rows.
+
+## 10. Redaction And Safety
+
+Data safety is a product requirement, not a UI polish task.
+
+Rules:
+
+- Redaction must come from typed contract fields.
+- Secure human input must render only redacted output.
+- Evidence copy/export must use redacted payloads by default.
+- Raw event display must show sensitivity state when known.
+- Unknown sensitivity should be treated conservatively in copy-all actions.
+- Support/debug raw export is out of V1 unless permission and redaction contracts are explicit.
+
+## 11. API And Contract Requirements
+
+### 11.1 Required V1 Contracts
+
+V1 needs these contracts to avoid guessing:
+
+- Accepted Team run owner envelope with `ownerMemberId`, `publishedServiceId`, `runId`, `actorId`, `commandId`, and `correlationId`.
+- Minimal owner resolver for cold-start reopen: `GET /api/scopes/:scopeId/teams/:teamId/runs/:runId/owner` or an equivalent typed query returning the immutable owner tuple.
+- Durable run owner metadata for reopening.
+- Team invocation discriminator for Team Detail latest work.
+- Durable run summary.
+- Durable run audit sufficient for ordered timeline and output.
+- Redaction flags for sensitive fields that can appear in Information or Evidence. When a payload has no sensitivity contract, copy-all must omit raw payload bodies.
+
+### 11.2 Existing Contracts To Reuse
+
+- `POST /api/scopes/:scopeId/teams/:teamId/invoke/chat:stream`
+- `GET /api/scopes/:scopeId/members/:ownerMemberId/runs`
+- `GET /api/scopes/:scopeId/members/:ownerMemberId/runs/:runId`
+- `GET /api/scopes/:scopeId/members/:ownerMemberId/runs/:runId/audit`
+- Member run control endpoints only when typed capabilities expose them.
+- `WorkflowRunEventEnvelope` event shapes.
+- Workflow custom payloads for step request/completion, human input, approval, signal, and observed envelope.
+
+### 11.3 Naming
+
+Required frontend/API naming:
+
+- `routeScopeId`
+- `routeTeamId`
+- `routeRunId`
+- `entryMemberId`
+- `ownerMemberId`
+- `publishedServiceId`
+- `draftWorkflowId`
+- `workflowName`
+- `actorId`
+- `definitionActorId`
+
+Forbidden naming:
+
+- `workflowId` for any member, service, or run candidate.
+- `serviceId` where the product means `publishedServiceId`.
+- `teamRunActorId` unless a Team-owned run actor actually exists.
+- Generic `id` variables carrying multiple identity candidates.
+- Generic `Metadata` bags for stable run semantics.
+
+### 11.4 Normalized Frame Model
+
+Before rendering, raw realtime frames should normalize to typed UI frames:
+
+- `RunLifecycleFrame`
+- `StepInputFrame`
+- `StepOutputFrame`
+- `MessageFrame`
+- `ToolFrame`
+- `HumanInteractionFrame`
+- `UsageFrame`
+- `RawEvidenceFrame`
+
+Each normalized frame must carry typed fields for status, step id, run id, preview text, waiting kind, error, and redaction state where applicable. Raw payload stays evidence, not control flow.
+
+## 12. UI Requirements
+
+### 12.1 Visual Direction
+
+The cockpit should feel dense, calm, operational, and scan-friendly.
+
+- Timeline is the center of gravity.
+- Graph view appears only when authoritative layout exists.
+- Active steps may use subtle motion.
+- Failure and waiting states are visually obvious.
+- Technical identities are compact and copyable in Evidence.
+- Raw logs never become the first screen.
+
+### 12.2 Required States
+
+- No Team entry member.
+- Entry member not workflow-capable.
+- Entry member not bound.
+- No verified Team runs.
+- Entry member latest run exists but Team attribution is unavailable.
+- Run accepted, durable summary pending.
+- Durable summary available, audit unavailable.
+- Audit available.
+- Running with live frames.
+- Running after refresh with durable data only.
+- Live stream disconnected.
+- Waiting without capabilities.
+- Waiting with typed capabilities.
+- Completed with output.
+- Failed with error.
+- Stopped with reason.
+- Redacted evidence available.
+- Forbidden/missing scope, Team, member, or run owner.
+
+### 12.3 Accessibility
+
+- Timeline rows are keyboard reachable.
+- Status icons have accessible labels.
+- Live updates do not steal focus.
+- Waiting action forms are keyboard reachable when present.
+- Copy and diagnostic toggles have explicit labels.
+- Color is never the only status signal.
+
+## 13. Success Metrics
+
+Product success:
+
+- A Team operator can identify the owner member, run status, current/last step, and latest output/error within 5 seconds.
+- A reopened run remains inspectable after browser refresh.
+- Team Detail does not mislabel member-only runs as Team work.
+- A support user can copy a redaction-safe evidence bundle in one action.
+
+Quality success:
+
+- No route, API helper, or test fixture assumes `memberId === workflowId`.
+- No production UI uses localStorage as authoritative Team run state.
+- No query path performs event replay or projection priming.
+- No application/projection/orchestration service adds process-local `runId -> context` fact state.
+- Tests use distinct fixture ids:
+  - `teamId = "team-alpha"`
+  - `entryMemberId = "m-entry"`
+  - `ownerMemberId = "m-alpha"`
+  - `workflowId = "wf-alpha"`
+  - `publishedServiceId = "svc-alpha"`
+  - `runId = "run-alpha"`
+
+## 14. Milestones
+
+### M1: Identity And Contract Closure
+
+- Approve immutable run owner tuple.
+- Approve canonical route.
+- Confirm accepted Team run owner envelope.
+- Confirm minimal owner resolver for cold-start reopen.
+- Confirm Team invocation discriminator or honest member-latest fallback.
+- Confirm V1 workflow-member-only scope.
+
+### M2: Durable Read-Only Cockpit
+
+- Build cockpit for a verified `ownerMemberId + publishedServiceId + runId`.
+- Render durable summary.
+- Render ordered timeline from audit when available.
+- Render output and evidence.
+- Show accepted/durable pending/audit unavailable states.
+
+### M3: Team Entry Integration
+
+- Add Team detail live work strip.
+- Start Team run and pin cockpit from accepted owner envelope.
+- Avoid claiming Team work without Team invocation source.
+
+### M4: Live Frame Enhancement
+
+- Merge current-session live frames with durable data.
+- Show live source state separately from run state.
+- De-dupe or replace live rows when durable audit catches up.
+
+### M5: Controls, Redaction, And Hardening
+
+- Add V1.5 typed waiting capabilities if backend contracts exist.
+- Harden redaction-aware Evidence copy/export beyond the V1 safe default.
+- Add support/debug bundle only with explicit permission model.
+- Add regression tests and CI guard coverage for identity and authority rules.
+
+## 15. Acceptance Criteria
+
+V1 is acceptable when:
+
+1. Given a Team has a workflow entry member, Team Detail shows entry member identity and published workflow readiness.
+2. Given a Team-started run has durable Team invocation context, Team Detail labels it as Team current/latest work.
+3. Given only member history exists without Team attribution, Team Detail labels it as entry member latest run and does not call it Team work.
+4. Given a Team run is accepted, the frontend receives an owner envelope containing `ownerMemberId`, `publishedServiceId`, `runId`, `actorId`, `commandId`, and `correlationId`.
+5. Given a user opens `/scopes/:scopeId/teams/:teamId/runs/:runId` in a fresh browser session, the page resolves the immutable owner tuple through the V1 owner resolver before calling member-scoped run endpoints.
+6. Given the Team entry member changed after a run, reopening the old run still uses the old run's `ownerMemberId`.
+7. Given the owner member was rebound after a run, reopening the old run still uses the run's acceptance-time `publishedServiceId`.
+8. Given durable summary is pending, the cockpit shows `accepted / durable pending` and does not infer failure from missing data.
+9. Given durable audit is unavailable, the cockpit still shows summary/output/error from run summary and labels audit as unavailable.
+10. Given durable audit is available, the cockpit rebuilds timeline from audit and marks durable source.
+11. Given live frames arrive before durable audit, the cockpit shows them as live-only and later lets durable audit replace matching rows.
+12. Given live stream disconnects, the cockpit marks live source disconnected without changing durable run status.
+13. Given a secure/redacted field, Information and Evidence copy do not expose raw value.
+14. Given payload sensitivity is unknown, copy-all excludes raw payload bodies.
+15. Given waiting status in V1 Core, the cockpit does not render action buttons.
+16. Given typed waiting capabilities in V1.5, the cockpit renders only those actions and treats receipts as accepted.
+17. Given distinct fixture ids for Team, member, workflow, service, and run, route/API tests pass without identity aliasing.
+
+## 16. Open Questions
+
+1. What is the retention expectation for durable audit artifacts?
+2. When should full Team-scoped multi-member run list/aggregation become required beyond the V1 owner resolver?
+3. What permission model should unlock support-only raw evidence export?
+4. How should non-workflow Team members appear in a future cockpit?
+5. Which backend contract will carry redaction state for all payload classes that can appear in Evidence?
+
+## 17. Review Log
+
+### Round 1 With ChatGPT
+
+Accepted changes from critique:
+
+- Promoted immutable run owner tuple from implicit behavior to core requirement.
+- Stopped using current `entryMemberId` as historical run authority.
+- Added Team invocation discriminator requirement.
+- Added V1 minimal owner resolver for cold-start reopen.
+- Moved accepted run identity, audit completeness, redaction, and normalized frames out of "nice-to-have" language.
+- Scoped V1 to durable read-only cockpit plus live enhancement.
+- Added durable/live merge rules.
+- Added typed waiting action capability model.
+- Added Evidence redaction boundary.
+- Removed open questions that contradicted earlier decisions.
+
+Remaining items for later review:
+
+- Whether Team-scoped multi-member run aggregation is needed after the V1 owner resolver.
+- Whether support-only raw evidence export is needed after redaction-safe copy ships.
+
+### Round 2 With ChatGPT
+
+Accepted changes from critique:
+
+- Added a V1 owner resolver so the canonical route can cold-start reopen a run without owner guessing.
+- Separated minimal owner resolver from future Team run aggregation.
+- Clarified that historical `publishedServiceId` is captured at acceptance time and must not be recomputed from current member binding.
+- Defined unknown-sensitivity copy behavior: copy-all omits raw payload bodies.
+- Reframed V1 Core as read-only and moved waiting controls to V1.5 unless typed capabilities already exist.
+
+### Round 3 With ChatGPT
+
+Final consensus:
+
+- ChatGPT agreed this version can enter final PRD state.
+- No blocking issues remained after adding the V1 owner resolver, unknown-sensitivity copy rule, read-only V1 Core boundary, and acceptance-time `publishedServiceId` rule.
+- Shared conclusion: Team is the product context; member and `publishedServiceId` own execution; run inspection depends on an immutable owner tuple; live frames are session evidence; durable summary/audit are truth; V1 is a read-only durable cockpit with live enhancement.


### PR DESCRIPTION
## Problem

Team operators need a durable way to see what a workflow run is doing, what information the Team is processing, and what evidence backs the final output. Existing surfaces expose live frames, member-scoped run data, and audit artifacts, but the product semantics around Team context, member ownership, published service identity, and run reopening need to be locked before implementation.

## Solution

This PR adds three docs-only design artifacts:

- PRD for Team Workflow Realtime Visibility
- Implementation plan with confirmable work units
- Technical design covering identity boundaries, source-of-truth rules, owner resolver, accepted owner envelope, durable-first cockpit model, UI information architecture, redaction-safe Evidence, waiting control boundaries, and verification gates

Key semantic decisions:

- Team is product context, not runtime owner.
- Historical inspection must resolve `scopeId + teamId + runId` to the accepted immutable owner tuple.
- `publishedServiceId` is captured at acceptance time and must not be recomputed from current member binding.
- Live AGUI/SSE frames are session evidence only; durable summary/audit are truth.
- V1 Core is read-only unless typed waiting capabilities already exist.

## Impact

Docs only. No production code, tests, routes, generated files, or runtime behavior are changed.

## Validation

- `bash tools/docs/lint.sh`
