### PR TITLE
refactor(chat-routing): drop multi-target forwarding scaffolding

### DIFF
--- a/src/Aevatar.ChatRouting.Abstractions/chat_route_policy.proto
+++ b/src/Aevatar.ChatRouting.Abstractions/chat_route_policy.proto
@@ -253,9 +253,11 @@ message ChatRouteDecision {
   // policy actor didn't exist or readmodel snapshot was unavailable.
   bool used_fallback = 4;
   repeated ChatRouteDeprecation deprecations = 5;
-  // Original matched policy action before runtime canonicalization. This is
-  // transient ingress context for non-LLM actor-bound entries that still need
-  // actor-specific fields (for example voice_module_name); it must not be
-  // persisted.
-  ChatRouteAction original_action = 6;
+  // tag 6 + name `original_action` was removed when route policies became
+  // tool-first. Runtime canonicalization is now identity (the single forward
+  // shape is ForwardToModel), so `action` already is the matched policy action
+  // and no "pre-canonicalization" twin is needed. Voice attach reads its typed
+  // target from `action.forward_to_model.tool_choice_hint.voice_attach_target`.
+  reserved 6;
+  reserved "original_action";
 }

--- a/src/Aevatar.ChatRouting.Core/ChatRouteResolver.cs
+++ b/src/Aevatar.ChatRouting.Core/ChatRouteResolver.cs
@@ -50,10 +50,10 @@ public sealed class ChatRouteResolver
                 continue;
             }
 
-            return ApplyDefaultToolSet(BuildDecision(rule.Action, matchedRuleId: rule.RuleId, usedFallback: false));
+            return ApplyDefaultToolSet(NewDecision(rule.Action, matchedRuleId: rule.RuleId, usedFallback: false));
         }
 
-        return ApplyDefaultToolSet(BuildDecision(snapshot.DefaultTarget, matchedRuleId: string.Empty, usedFallback: false));
+        return ApplyDefaultToolSet(NewDecision(snapshot.DefaultTarget, matchedRuleId: string.Empty, usedFallback: false));
     }
 
     private static bool HasAction(ChatRouteAction? action) =>
@@ -88,18 +88,11 @@ public sealed class ChatRouteResolver
         bool usedFallback) =>
         new()
         {
-            Action = ChatRouteActionTranslator.ToRuntimeDecisionAction(action),
-            OriginalAction = action.Clone(),
+            Action = action.Clone(),
             MatchedRuleId = matchedRuleId,
             UsedFallback = usedFallback,
             ResolvedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
         };
-
-    private ChatRouteDecision BuildDecision(
-        ChatRouteAction action,
-        string matchedRuleId,
-        bool usedFallback)
-        => NewDecision(action, matchedRuleId, usedFallback);
 
     private ChatRouteDecision ApplyDefaultToolSet(ChatRouteDecision decision)
     {
@@ -108,7 +101,6 @@ public sealed class ChatRouteResolver
             return decision;
 
         ApplyDefaultToolSet(decision.Action?.ForwardToModel, toolSetName);
-        ApplyDefaultToolSet(decision.OriginalAction?.ForwardToModel, toolSetName);
         return decision;
     }
 
@@ -125,24 +117,6 @@ public sealed class ChatRouteResolver
 
         forwardToModel.ToolSetRef = new ChatRouteToolSetRef { Name = toolSetName.Trim() };
     }
-}
-
-internal static class ChatRouteActionTranslator
-{
-    public static ChatRouteAction ToRuntimeDecisionAction(ChatRouteAction action)
-    {
-        ArgumentNullException.ThrowIfNull(action);
-
-        return action.ActionCase switch
-        {
-            ChatRouteAction.ActionOneofCase.ForwardToModel => action.Clone(),
-            ChatRouteAction.ActionOneofCase.Reject => action.Clone(),
-            _ => action.Clone(),
-        };
-    }
-
-    public static ChatRouteAction ToCanonicalPolicyAction(ChatRouteAction action) =>
-        ToRuntimeDecisionAction(action);
 }
 
 /// <summary>

--- a/test/Aevatar.ChatRouting.Core.Tests/ChatRouteResolverTests.cs
+++ b/test/Aevatar.ChatRouting.Core.Tests/ChatRouteResolverTests.cs
@@ -99,7 +99,6 @@ public sealed class ChatRouteResolverTests
         var decision = resolver.Resolve(snapshot, new ChatRouteInput());
 
         decision.Action.ForwardToModel.ToolSetRef.Name.Should().Be("workspace.default");
-        decision.OriginalAction.ForwardToModel.ToolSetRef.Name.Should().Be("workspace.default");
     }
 
     [Fact]
@@ -116,7 +115,6 @@ public sealed class ChatRouteResolverTests
 
         decision.Action.ForwardToModel.ToolSetRef.Name.Should().Be("lark.self_notify");
         decision.Action.ForwardToModel.ToolChoiceHint.ToolName.Should().Be("notify_self");
-        decision.OriginalAction.ForwardToModel.ToolSetRef.Name.Should().Be("lark.self_notify");
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

Chat route policies are tool-first: `forward_to_gagent` / `forward_to_workflow` / `forward_to_team` / `bypass` were already removed (`reserved`) from `ChatRouteAction`, and every forward now routes through `ForwardToModel` + a `ToolChoiceHint` that injects the right tool (`aevatar_invoke_gagent` / `aevatar_invoke_team` / `aevatar_start_workflow`). Scaffolding from the multi-target era was left behind and no longer carries meaning.

## Change

- **Delete `ChatRouteActionTranslator`** — `ToRuntimeDecisionAction` was an identity switch (every branch `action.Clone()`), and `ToCanonicalPolicyAction` had zero callers. `NewDecision` now clones the action directly.
- **Remove `ChatRouteDecision.original_action` (reserve tag 6)** — written but never read by any consumer. Voice attach reads `decision.action`'s typed `voice_attach_target` (`PolicyAwareVoiceEndpoints`), and once canonicalization became identity, `original_action` always equalled `action`.
- **Inline `BuildDecision`** — a pure pass-through to `NewDecision`.

The `ForwardToModel` / `Reject` oneof is kept: `Reject` is a live deny action (HTTP 403) reachable via the admin policy API and consumed by all three ingress facades + the voice endpoint.

`ChatRouteDecision` is a transient resolver output (never persisted / serialized cross-node), so removing field 6 has no wire/persistence risk. Proto is build-time generated (Grpc.Tools); no checked-in generated code.

Net: 10 insertions, 36 deletions across 3 files.

## Impact paths

- `src/Aevatar.ChatRouting.Abstractions/chat_route_policy.proto`
- `src/Aevatar.ChatRouting.Core/ChatRouteResolver.cs`
- `test/Aevatar.ChatRouting.Core.Tests/ChatRouteResolverTests.cs`

## Validation

- `dotnet build src/Aevatar.ChatRouting.Core` — proto regen, 0 errors
- `dotnet test` — ChatRouting.Core.Tests **45**, ChatRouting.Voice.Integration.Tests **25**, GAgentService.Tests **981** green
- `bash tools/ci/architecture_guards.sh` — pass (15 arch tests, docs lint 61 files / 0 errors)
- `bash tools/ci/test_stability_guards.sh` — pass

> Note: a pre-existing, unrelated red test in `Aevatar.Capabilities.Tests` (`MainnetHostCompositionTests.AddAevatarMainnetHost_ShouldRegisterNyxIdProxyFileArtifactIngressWithWorkflowFileStorage`, a `NyxIdToolOptions.ProxyFileArtifactMaxBytes` config-binding issue) fails identically on the clean base without this change — verified via `git stash`. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
