### PR TITLE
Fix member target scope authorization

### DIFF
--- a/docs/2026-04-27-member-first-studio-apis.md
+++ b/docs/2026-04-27-member-first-studio-apis.md
@@ -13,7 +13,7 @@ The current authoritative resolver maps each normalized `memberId` to a stable p
 | `publishedServiceId` | Stable service id used by backend service runtime for that member. |
 | `publishedServiceKey` | Internal service identity key for diagnostics and contract inspection. |
 
-The resolver is exposed through `IMemberPublishedServiceResolver`, so a later actor-owned member catalog can replace the deterministic mapping without changing HTTP routes. Until that catalog is authoritative, member binding writes are restricted to scope administrators; member reads and invokes require either the matching authenticated member claim or a scope administrator role.
+The resolver is exposed through `IMemberPublishedServiceResolver`, so a later actor-owned member catalog can replace the deterministic mapping without changing HTTP routes. Member-first routes are authorized at the scope boundary; `memberId` identifies the target member-owned resource, not the authenticated principal. Binding write authority remains owned by the Studio member async protocol.
 
 ## Routes
 

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -1380,8 +1380,7 @@ public static class ScopeServiceEndpoints
                 workflowRunBindingReader,
                 resumeService,
                 options,
-                ct,
-                BuildScopeServiceRunBasePath(memberResolution.ScopeId, memberResolution.PublishedServiceId, memberResolution.MemberId));
+                ct);
         }
         catch (InvalidOperationException ex)
         {
@@ -1424,8 +1423,7 @@ public static class ScopeServiceEndpoints
                 workflowRunBindingReader,
                 signalService,
                 options,
-                ct,
-                BuildScopeServiceRunBasePath(memberResolution.ScopeId, memberResolution.PublishedServiceId, memberResolution.MemberId));
+                ct);
         }
         catch (InvalidOperationException ex)
         {
@@ -1468,8 +1466,7 @@ public static class ScopeServiceEndpoints
                 workflowRunBindingReader,
                 stopService,
                 options,
-                ct,
-                BuildScopeServiceRunBasePath(memberResolution.ScopeId, memberResolution.PublishedServiceId, memberResolution.MemberId));
+                ct);
         }
         catch (InvalidOperationException ex)
         {
@@ -2296,8 +2293,7 @@ public static class ScopeServiceEndpoints
         [FromServices] IWorkflowRunBindingReader workflowRunBindingReader,
         [FromServices] ICommandDispatchService<WorkflowResumeCommand, WorkflowRunControlAcceptedReceipt, WorkflowRunControlStartError> resumeService,
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
-        CancellationToken ct,
-        string? acceptedResourcePath = null)
+        CancellationToken ct)
     {
         var resolution = await ResolveScopeServiceRunAsync(
             http,
@@ -2312,28 +2308,27 @@ public static class ScopeServiceEndpoints
         if (resolution.Failure != null)
             return resolution.Failure;
 
-        var binding = resolution.Binding!;
-        var dispatch = await resumeService.DispatchAsync(
-            new WorkflowResumeCommand(
-                binding.ActorId,
-                binding.RunId,
-                request.StepId ?? string.Empty,
-                request.CommandId,
-                request.Approved,
-                request.UserInput,
-                request.Metadata,
-                ToolApproval: request.ToolApproval == null
+        return await WorkflowCapabilityEndpoints.HandleResume(
+            new WorkflowResumeInput
+            {
+                ActorId = resolution.Binding!.ActorId,
+                RunId = resolution.Binding.RunId,
+                StepId = request.StepId ?? string.Empty,
+                CommandId = request.CommandId,
+                Approved = request.Approved,
+                UserInput = request.UserInput,
+                Metadata = request.Metadata,
+                ToolApproval = request.ToolApproval == null
                     ? null
-                    : new WorkflowToolApprovalResumeCommand(
-                        request.ToolApproval.ExecutionId ?? string.Empty,
-                        request.ToolApproval.ToolCallId ?? string.Empty,
-                        request.ToolApproval.ApprovalRequestId ?? string.Empty)),
+                    : new WorkflowToolApprovalResumeInput
+                    {
+                        ExecutionId = request.ToolApproval.ExecutionId ?? string.Empty,
+                        ToolCallId = request.ToolApproval.ToolCallId ?? string.Empty,
+                        ApprovalRequestId = request.ToolApproval.ApprovalRequestId ?? string.Empty,
+                    },
+            },
+            resumeService,
             ct);
-
-        if (!dispatch.Succeeded || dispatch.Receipt == null)
-            return CreateRunControlDispatchFailure(dispatch.Error);
-
-        return CreateRunControlAcceptedResult(dispatch.Receipt, scopeId, serviceId, acceptedResourcePath);
     }
 
     private static async Task<IResult> HandleSignalRunAsync(
@@ -2346,8 +2341,7 @@ public static class ScopeServiceEndpoints
         [FromServices] IWorkflowRunBindingReader workflowRunBindingReader,
         [FromServices] ICommandDispatchService<WorkflowSignalCommand, WorkflowRunControlAcceptedReceipt, WorkflowRunControlStartError> signalService,
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
-        CancellationToken ct,
-        string? acceptedResourcePath = null)
+        CancellationToken ct)
     {
         var resolution = await ResolveScopeServiceRunAsync(
             http,
@@ -2362,21 +2356,18 @@ public static class ScopeServiceEndpoints
         if (resolution.Failure != null)
             return resolution.Failure;
 
-        var binding = resolution.Binding!;
-        var dispatch = await signalService.DispatchAsync(
-            new WorkflowSignalCommand(
-                binding.ActorId,
-                binding.RunId,
-                request.SignalName ?? string.Empty,
-                request.CommandId,
-                request.Payload,
-                request.StepId),
+        return await WorkflowCapabilityEndpoints.HandleSignal(
+            new WorkflowSignalInput
+            {
+                ActorId = resolution.Binding!.ActorId,
+                RunId = resolution.Binding.RunId,
+                SignalName = request.SignalName ?? string.Empty,
+                StepId = request.StepId,
+                CommandId = request.CommandId,
+                Payload = request.Payload,
+            },
+            signalService,
             ct);
-
-        if (!dispatch.Succeeded || dispatch.Receipt == null)
-            return CreateRunControlDispatchFailure(dispatch.Error);
-
-        return CreateRunControlAcceptedResult(dispatch.Receipt, scopeId, serviceId, acceptedResourcePath);
     }
 
     private static async Task<IResult> HandleStopRunAsync(
@@ -2389,8 +2380,7 @@ public static class ScopeServiceEndpoints
         [FromServices] IWorkflowRunBindingReader workflowRunBindingReader,
         [FromServices] ICommandDispatchService<WorkflowStopCommand, WorkflowRunControlAcceptedReceipt, WorkflowRunControlStartError> stopService,
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
-        CancellationToken ct,
-        string? acceptedResourcePath = null)
+        CancellationToken ct)
     {
         var resolution = await ResolveScopeServiceRunAsync(
             http,
@@ -2405,84 +2395,16 @@ public static class ScopeServiceEndpoints
         if (resolution.Failure != null)
             return resolution.Failure;
 
-        var binding = resolution.Binding!;
-        var dispatch = await stopService.DispatchAsync(
-            new WorkflowStopCommand(
-                binding.ActorId,
-                binding.RunId,
-                request.CommandId,
-                request.Reason),
+        return await WorkflowCapabilityEndpoints.HandleStop(
+            new WorkflowStopInput
+            {
+                ActorId = resolution.Binding!.ActorId,
+                RunId = resolution.Binding.RunId,
+                CommandId = request.CommandId,
+                Reason = request.Reason,
+            },
+            stopService,
             ct);
-
-        if (!dispatch.Succeeded || dispatch.Receipt == null)
-            return CreateRunControlDispatchFailure(dispatch.Error);
-
-        return CreateRunControlAcceptedResult(dispatch.Receipt, scopeId, serviceId, acceptedResourcePath);
-    }
-
-    private static IResult CreateRunControlAcceptedResult(
-        WorkflowRunControlAcceptedReceipt receipt,
-        string scopeId,
-        string serviceId,
-        string? acceptedResourcePath)
-    {
-        var statusUrl = BuildScopeServiceRunControlStatusUrl(scopeId, serviceId, receipt.RunId, acceptedResourcePath);
-        return Results.Accepted(statusUrl, new
-        {
-            accepted = true,
-            actorId = receipt.ActorId,
-            runId = receipt.RunId,
-            acceptedCommandId = receipt.CommandId,
-            correlationId = receipt.CorrelationId,
-            statusUrl,
-        });
-    }
-
-    private static string BuildScopeServiceRunControlStatusUrl(
-        string scopeId,
-        string serviceId,
-        string runId,
-        string? acceptedResourcePath)
-    {
-        var basePath = string.IsNullOrWhiteSpace(acceptedResourcePath)
-            ? BuildScopeServiceRunBasePath(scopeId, serviceId)
-            : acceptedResourcePath.TrimEnd('/');
-        return $"{basePath}/runs/{Uri.EscapeDataString(runId)}";
-    }
-
-    private static IResult CreateRunControlDispatchFailure(WorkflowRunControlStartError error)
-    {
-        var (statusCode, message) = error.Code switch
-        {
-            WorkflowRunControlStartErrorCode.InvalidActorId => (
-                StatusCodes.Status400BadRequest,
-                "actorId is required."),
-            WorkflowRunControlStartErrorCode.InvalidRunId => (
-                StatusCodes.Status400BadRequest,
-                "runId is required."),
-            WorkflowRunControlStartErrorCode.InvalidStepId => (
-                StatusCodes.Status400BadRequest,
-                "stepId is required."),
-            WorkflowRunControlStartErrorCode.InvalidSignalName => (
-                StatusCodes.Status400BadRequest,
-                "signalName is required."),
-            WorkflowRunControlStartErrorCode.ActorNotFound => (
-                StatusCodes.Status404NotFound,
-                $"Actor '{error.ActorId}' not found."),
-            WorkflowRunControlStartErrorCode.ActorNotWorkflowRun => (
-                StatusCodes.Status400BadRequest,
-                $"Actor '{error.ActorId}' is not a workflow run actor."),
-            WorkflowRunControlStartErrorCode.RunBindingMissing => (
-                StatusCodes.Status409Conflict,
-                $"Actor '{error.ActorId}' does not have a bound run id."),
-            WorkflowRunControlStartErrorCode.RunBindingMismatch => (
-                StatusCodes.Status409Conflict,
-                $"Actor '{error.ActorId}' is bound to run '{error.BoundRunId}', not '{error.RequestedRunId}'"),
-            _ => (
-                StatusCodes.Status500InternalServerError,
-                "Workflow control dispatch failed."),
-        };
-        return Results.Json(new { error = message }, statusCode: statusCode);
     }
 
     private static async Task<IResult> HandleRetryCompensationRunAsync(

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -431,9 +431,6 @@ public static class ScopeServiceEndpoints
             if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
                 return denied;
 
-            if (AevatarMemberAccessGuard.TryCreateMemberAccessDeniedResult(http, memberId, out var memberDenied))
-                return memberDenied;
-
             var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
                 new MemberPublishedServiceResolveRequest(scopeId, memberId),
                 ct);
@@ -1176,9 +1173,6 @@ public static class ScopeServiceEndpoints
             if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
                 return denied;
 
-            if (AevatarMemberAccessGuard.TryCreateMemberAccessDeniedResult(http, memberId, out var memberDenied))
-                return memberDenied;
-
             var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
                 new MemberPublishedServiceResolveRequest(scopeId, memberId),
                 ct);
@@ -1251,9 +1245,6 @@ public static class ScopeServiceEndpoints
             if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
                 return denied;
 
-            if (AevatarMemberAccessGuard.TryCreateMemberAccessDeniedResult(http, memberId, out var memberDenied))
-                return memberDenied;
-
             var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
                 new MemberPublishedServiceResolveRequest(scopeId, memberId),
                 ct);
@@ -1308,9 +1299,6 @@ public static class ScopeServiceEndpoints
         {
             if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
                 return denied;
-
-            if (AevatarMemberAccessGuard.TryCreateMemberAccessDeniedResult(http, memberId, out var memberDenied))
-                return memberDenied;
 
             var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
                 new MemberPublishedServiceResolveRequest(scopeId, memberId),
@@ -1379,9 +1367,6 @@ public static class ScopeServiceEndpoints
             if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
                 return denied;
 
-            if (AevatarMemberAccessGuard.TryCreateMemberAccessDeniedResult(http, memberId, out var memberDenied))
-                return memberDenied;
-
             var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
                 new MemberPublishedServiceResolveRequest(scopeId, memberId),
                 ct);
@@ -1395,7 +1380,8 @@ public static class ScopeServiceEndpoints
                 workflowRunBindingReader,
                 resumeService,
                 options,
-                ct);
+                ct,
+                BuildScopeServiceRunBasePath(memberResolution.ScopeId, memberResolution.PublishedServiceId, memberResolution.MemberId));
         }
         catch (InvalidOperationException ex)
         {
@@ -1425,9 +1411,6 @@ public static class ScopeServiceEndpoints
             if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
                 return denied;
 
-            if (AevatarMemberAccessGuard.TryCreateMemberAccessDeniedResult(http, memberId, out var memberDenied))
-                return memberDenied;
-
             var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
                 new MemberPublishedServiceResolveRequest(scopeId, memberId),
                 ct);
@@ -1441,7 +1424,8 @@ public static class ScopeServiceEndpoints
                 workflowRunBindingReader,
                 signalService,
                 options,
-                ct);
+                ct,
+                BuildScopeServiceRunBasePath(memberResolution.ScopeId, memberResolution.PublishedServiceId, memberResolution.MemberId));
         }
         catch (InvalidOperationException ex)
         {
@@ -1471,9 +1455,6 @@ public static class ScopeServiceEndpoints
             if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
                 return denied;
 
-            if (AevatarMemberAccessGuard.TryCreateMemberAccessDeniedResult(http, memberId, out var memberDenied))
-                return memberDenied;
-
             var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
                 new MemberPublishedServiceResolveRequest(scopeId, memberId),
                 ct);
@@ -1487,7 +1468,8 @@ public static class ScopeServiceEndpoints
                 workflowRunBindingReader,
                 stopService,
                 options,
-                ct);
+                ct,
+                BuildScopeServiceRunBasePath(memberResolution.ScopeId, memberResolution.PublishedServiceId, memberResolution.MemberId));
         }
         catch (InvalidOperationException ex)
         {
@@ -2314,7 +2296,8 @@ public static class ScopeServiceEndpoints
         [FromServices] IWorkflowRunBindingReader workflowRunBindingReader,
         [FromServices] ICommandDispatchService<WorkflowResumeCommand, WorkflowRunControlAcceptedReceipt, WorkflowRunControlStartError> resumeService,
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
-        CancellationToken ct)
+        CancellationToken ct,
+        string? acceptedResourcePath = null)
     {
         var resolution = await ResolveScopeServiceRunAsync(
             http,
@@ -2329,27 +2312,28 @@ public static class ScopeServiceEndpoints
         if (resolution.Failure != null)
             return resolution.Failure;
 
-        return await WorkflowCapabilityEndpoints.HandleResume(
-            new WorkflowResumeInput
-            {
-                ActorId = resolution.Binding!.ActorId,
-                RunId = resolution.Binding.RunId,
-                StepId = request.StepId ?? string.Empty,
-                CommandId = request.CommandId,
-                Approved = request.Approved,
-                UserInput = request.UserInput,
-                Metadata = request.Metadata,
-                ToolApproval = request.ToolApproval == null
+        var binding = resolution.Binding!;
+        var dispatch = await resumeService.DispatchAsync(
+            new WorkflowResumeCommand(
+                binding.ActorId,
+                binding.RunId,
+                request.StepId ?? string.Empty,
+                request.CommandId,
+                request.Approved,
+                request.UserInput,
+                request.Metadata,
+                ToolApproval: request.ToolApproval == null
                     ? null
-                    : new WorkflowToolApprovalResumeInput
-                    {
-                        ExecutionId = request.ToolApproval.ExecutionId ?? string.Empty,
-                        ToolCallId = request.ToolApproval.ToolCallId ?? string.Empty,
-                        ApprovalRequestId = request.ToolApproval.ApprovalRequestId ?? string.Empty,
-                    },
-            },
-            resumeService,
+                    : new WorkflowToolApprovalResumeCommand(
+                        request.ToolApproval.ExecutionId ?? string.Empty,
+                        request.ToolApproval.ToolCallId ?? string.Empty,
+                        request.ToolApproval.ApprovalRequestId ?? string.Empty)),
             ct);
+
+        if (!dispatch.Succeeded || dispatch.Receipt == null)
+            return CreateRunControlDispatchFailure(dispatch.Error);
+
+        return CreateRunControlAcceptedResult(dispatch.Receipt, scopeId, serviceId, acceptedResourcePath);
     }
 
     private static async Task<IResult> HandleSignalRunAsync(
@@ -2362,7 +2346,8 @@ public static class ScopeServiceEndpoints
         [FromServices] IWorkflowRunBindingReader workflowRunBindingReader,
         [FromServices] ICommandDispatchService<WorkflowSignalCommand, WorkflowRunControlAcceptedReceipt, WorkflowRunControlStartError> signalService,
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
-        CancellationToken ct)
+        CancellationToken ct,
+        string? acceptedResourcePath = null)
     {
         var resolution = await ResolveScopeServiceRunAsync(
             http,
@@ -2377,18 +2362,21 @@ public static class ScopeServiceEndpoints
         if (resolution.Failure != null)
             return resolution.Failure;
 
-        return await WorkflowCapabilityEndpoints.HandleSignal(
-            new WorkflowSignalInput
-            {
-                ActorId = resolution.Binding!.ActorId,
-                RunId = resolution.Binding.RunId,
-                SignalName = request.SignalName ?? string.Empty,
-                StepId = request.StepId,
-                CommandId = request.CommandId,
-                Payload = request.Payload,
-            },
-            signalService,
+        var binding = resolution.Binding!;
+        var dispatch = await signalService.DispatchAsync(
+            new WorkflowSignalCommand(
+                binding.ActorId,
+                binding.RunId,
+                request.SignalName ?? string.Empty,
+                request.CommandId,
+                request.Payload,
+                request.StepId),
             ct);
+
+        if (!dispatch.Succeeded || dispatch.Receipt == null)
+            return CreateRunControlDispatchFailure(dispatch.Error);
+
+        return CreateRunControlAcceptedResult(dispatch.Receipt, scopeId, serviceId, acceptedResourcePath);
     }
 
     private static async Task<IResult> HandleStopRunAsync(
@@ -2401,7 +2389,8 @@ public static class ScopeServiceEndpoints
         [FromServices] IWorkflowRunBindingReader workflowRunBindingReader,
         [FromServices] ICommandDispatchService<WorkflowStopCommand, WorkflowRunControlAcceptedReceipt, WorkflowRunControlStartError> stopService,
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
-        CancellationToken ct)
+        CancellationToken ct,
+        string? acceptedResourcePath = null)
     {
         var resolution = await ResolveScopeServiceRunAsync(
             http,
@@ -2416,16 +2405,84 @@ public static class ScopeServiceEndpoints
         if (resolution.Failure != null)
             return resolution.Failure;
 
-        return await WorkflowCapabilityEndpoints.HandleStop(
-            new WorkflowStopInput
-            {
-                ActorId = resolution.Binding!.ActorId,
-                RunId = resolution.Binding.RunId,
-                CommandId = request.CommandId,
-                Reason = request.Reason,
-            },
-            stopService,
+        var binding = resolution.Binding!;
+        var dispatch = await stopService.DispatchAsync(
+            new WorkflowStopCommand(
+                binding.ActorId,
+                binding.RunId,
+                request.CommandId,
+                request.Reason),
             ct);
+
+        if (!dispatch.Succeeded || dispatch.Receipt == null)
+            return CreateRunControlDispatchFailure(dispatch.Error);
+
+        return CreateRunControlAcceptedResult(dispatch.Receipt, scopeId, serviceId, acceptedResourcePath);
+    }
+
+    private static IResult CreateRunControlAcceptedResult(
+        WorkflowRunControlAcceptedReceipt receipt,
+        string scopeId,
+        string serviceId,
+        string? acceptedResourcePath)
+    {
+        var statusUrl = BuildScopeServiceRunControlStatusUrl(scopeId, serviceId, receipt.RunId, acceptedResourcePath);
+        return Results.Accepted(statusUrl, new
+        {
+            accepted = true,
+            actorId = receipt.ActorId,
+            runId = receipt.RunId,
+            acceptedCommandId = receipt.CommandId,
+            correlationId = receipt.CorrelationId,
+            statusUrl,
+        });
+    }
+
+    private static string BuildScopeServiceRunControlStatusUrl(
+        string scopeId,
+        string serviceId,
+        string runId,
+        string? acceptedResourcePath)
+    {
+        var basePath = string.IsNullOrWhiteSpace(acceptedResourcePath)
+            ? BuildScopeServiceRunBasePath(scopeId, serviceId)
+            : acceptedResourcePath.TrimEnd('/');
+        return $"{basePath}/runs/{Uri.EscapeDataString(runId)}";
+    }
+
+    private static IResult CreateRunControlDispatchFailure(WorkflowRunControlStartError error)
+    {
+        var (statusCode, message) = error.Code switch
+        {
+            WorkflowRunControlStartErrorCode.InvalidActorId => (
+                StatusCodes.Status400BadRequest,
+                "actorId is required."),
+            WorkflowRunControlStartErrorCode.InvalidRunId => (
+                StatusCodes.Status400BadRequest,
+                "runId is required."),
+            WorkflowRunControlStartErrorCode.InvalidStepId => (
+                StatusCodes.Status400BadRequest,
+                "stepId is required."),
+            WorkflowRunControlStartErrorCode.InvalidSignalName => (
+                StatusCodes.Status400BadRequest,
+                "signalName is required."),
+            WorkflowRunControlStartErrorCode.ActorNotFound => (
+                StatusCodes.Status404NotFound,
+                $"Actor '{error.ActorId}' not found."),
+            WorkflowRunControlStartErrorCode.ActorNotWorkflowRun => (
+                StatusCodes.Status400BadRequest,
+                $"Actor '{error.ActorId}' is not a workflow run actor."),
+            WorkflowRunControlStartErrorCode.RunBindingMissing => (
+                StatusCodes.Status409Conflict,
+                $"Actor '{error.ActorId}' does not have a bound run id."),
+            WorkflowRunControlStartErrorCode.RunBindingMismatch => (
+                StatusCodes.Status409Conflict,
+                $"Actor '{error.ActorId}' is bound to run '{error.BoundRunId}', not '{error.RequestedRunId}'"),
+            _ => (
+                StatusCodes.Status500InternalServerError,
+                "Workflow control dispatch failed."),
+        };
+        return Results.Json(new { error = message }, statusCode: statusCode);
     }
 
     private static async Task<IResult> HandleRetryCompensationRunAsync(

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceCatalogEndpointTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceCatalogEndpointTests.cs
@@ -394,14 +394,20 @@ public sealed class ScopeServiceCatalogEndpointTests : ScopeServiceEndpointTestK
     }
 
     [Fact]
-    public async Task GetMemberPublishedServiceEndpoint_ShouldRejectDifferentAuthenticatedMember()
+    public async Task GetMemberPublishedServiceEndpoint_ShouldAllowDifferentAuthenticatedMemberInSameScope()
     {
         await using var host = await ScopeServiceEndpointTestHost.StartAsync();
         using var request = new HttpRequestMessage(HttpMethod.Get, "/api/scopes/scope-a/members/member-a/published-service");
+        request.Headers.Add("X-Test-Scope-Id", "scope-a");
         request.Headers.Add("X-Test-Member-Id", "member-b");
 
         var response = await host.Client.SendAsync(request);
+        var body = await response.Content.ReadFromJsonAsync<ScopeServiceEndpoints.MemberPublishedServiceHttpResponse>();
 
-        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body.Should().NotBeNull();
+        body!.ScopeId.Should().Be("scope-a");
+        body.MemberId.Should().Be("member-a");
+        body.PublishedServiceId.Should().Be("member-a");
     }
 }

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceRunQueryEndpointTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceRunQueryEndpointTests.cs
@@ -2,7 +2,6 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Reflection;
 using System.Security.Claims;
-using System.Text.Json;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.CQRS.Core.Abstractions.Commands;
@@ -405,12 +404,7 @@ public sealed class ScopeServiceRunQueryEndpointTests : ScopeServiceEndpointTest
 
         var response = await host.Client.SendAsync(request);
 
-        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
-        response.Headers.Location.Should().NotBeNull();
-        response.Headers.Location!.OriginalString.Should().Be("/api/scopes/scope-a/members/member-a/runs/run-member-resume-1");
-        body.GetProperty("statusUrl").GetString().Should().Be("/api/scopes/scope-a/members/member-a/runs/run-member-resume-1");
         host.ResumeDispatchService.LastCommand.Should().NotBeNull();
         host.ResumeDispatchService.LastCommand!.ActorId.Should().Be("run-actor-member-resume-1");
         host.ResumeDispatchService.LastCommand.RunId.Should().Be("run-member-resume-1");
@@ -453,12 +447,7 @@ public sealed class ScopeServiceRunQueryEndpointTests : ScopeServiceEndpointTest
 
         var response = await host.Client.SendAsync(request);
 
-        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
-        response.Headers.Location.Should().NotBeNull();
-        response.Headers.Location!.OriginalString.Should().Be("/api/scopes/scope-a/members/member-a/runs/run-member-signal-1");
-        body.GetProperty("statusUrl").GetString().Should().Be("/api/scopes/scope-a/members/member-a/runs/run-member-signal-1");
         host.SignalDispatchService.LastCommand.Should().NotBeNull();
         host.SignalDispatchService.LastCommand!.ActorId.Should().Be("run-actor-member-signal-1");
         host.SignalDispatchService.LastCommand.RunId.Should().Be("run-member-signal-1");
@@ -496,12 +485,7 @@ public sealed class ScopeServiceRunQueryEndpointTests : ScopeServiceEndpointTest
 
         var response = await host.Client.SendAsync(request);
 
-        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
-
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
-        response.Headers.Location.Should().NotBeNull();
-        response.Headers.Location!.OriginalString.Should().Be("/api/scopes/scope-a/members/member-a/runs/run-member-stop-1");
-        body.GetProperty("statusUrl").GetString().Should().Be("/api/scopes/scope-a/members/member-a/runs/run-member-stop-1");
         host.StopDispatchService.LastCommand.Should().NotBeNull();
         host.StopDispatchService.LastCommand!.ActorId.Should().Be("run-actor-member-stop-1");
         host.StopDispatchService.LastCommand.RunId.Should().Be("run-member-stop-1");

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceRunQueryEndpointTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceRunQueryEndpointTests.cs
@@ -206,9 +206,14 @@ public sealed class ScopeServiceRunQueryEndpointTests : ScopeServiceEndpointTest
             LastOutput = "done",
         };
 
-        var response = await host.Client.GetFromJsonAsync<ScopeServiceEndpoints.MemberScopeServiceRunCatalogHttpResponse>(
-            "/api/scopes/scope-a/members/member-a/runs?take=5");
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/scopes/scope-a/members/member-a/runs?take=5");
+        request.Headers.Add("X-Test-Scope-Id", "scope-a");
+        request.Headers.Add("X-Test-Member-Id", "member-b");
 
+        var httpResponse = await host.Client.SendAsync(request);
+        var response = await httpResponse.Content.ReadFromJsonAsync<ScopeServiceEndpoints.MemberScopeServiceRunCatalogHttpResponse>();
+
+        httpResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Should().NotBeNull();
         response!.ScopeId.Should().Be("scope-a");
         response.MemberId.Should().Be("member-a");
@@ -264,9 +269,14 @@ public sealed class ScopeServiceRunQueryEndpointTests : ScopeServiceEndpointTest
             DeadLetterError = "cancel failed",
         };
 
-        var response = await host.Client.GetFromJsonAsync<ScopeServiceEndpoints.MemberScopeServiceRunSummaryHttpResponse>(
-            "/api/scopes/scope-a/members/member-a/runs/run-member-detail-1");
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/scopes/scope-a/members/member-a/runs/run-member-detail-1");
+        request.Headers.Add("X-Test-Scope-Id", "scope-a");
+        request.Headers.Add("X-Test-Member-Id", "member-b");
 
+        var httpResponse = await host.Client.SendAsync(request);
+        var response = await httpResponse.Content.ReadFromJsonAsync<ScopeServiceEndpoints.MemberScopeServiceRunSummaryHttpResponse>();
+
+        httpResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Should().NotBeNull();
         response!.ScopeId.Should().Be("scope-a");
         response.MemberId.Should().Be("member-a");
@@ -341,9 +351,14 @@ public sealed class ScopeServiceRunQueryEndpointTests : ScopeServiceEndpointTest
             },
         };
 
-        var response = await host.Client.GetFromJsonAsync<ScopeServiceEndpoints.MemberScopeServiceRunAuditHttpResponse>(
-            "/api/scopes/scope-a/members/member-a/runs/run-member-audit-1/audit");
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/scopes/scope-a/members/member-a/runs/run-member-audit-1/audit");
+        request.Headers.Add("X-Test-Scope-Id", "scope-a");
+        request.Headers.Add("X-Test-Member-Id", "member-b");
 
+        var httpResponse = await host.Client.SendAsync(request);
+        var response = await httpResponse.Content.ReadFromJsonAsync<ScopeServiceEndpoints.MemberScopeServiceRunAuditHttpResponse>();
+
+        httpResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Should().NotBeNull();
         response!.Summary.MemberId.Should().Be("member-a");
         response.Summary.PublishedServiceId.Should().Be("member-a");
@@ -371,20 +386,31 @@ public sealed class ScopeServiceRunQueryEndpointTests : ScopeServiceEndpointTest
                 "scope-a"),
         ];
 
-        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/members/member-a/runs/run-member-resume-1:resume", new
-        {
-            stepId = "approval-1",
-            approved = true,
-            toolApproval = new
+        using var request = CreateAuthenticatedJsonRequest(
+            HttpMethod.Post,
+            "/api/scopes/scope-a/members/member-a/runs/run-member-resume-1:resume",
+            new
             {
-                executionId = "exec-member-1",
-                toolCallId = "tool-call-member-1",
-                approvalRequestId = "approval-member-1",
+                stepId = "approval-1",
+                approved = true,
+                toolApproval = new
+                {
+                    executionId = "exec-member-1",
+                    toolCallId = "tool-call-member-1",
+                    approvalRequestId = "approval-member-1",
+                },
             },
-        });
+            "scope-a");
+        request.Headers.Add("X-Test-Member-Id", "member-b");
+
+        var response = await host.Client.SendAsync(request);
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
 
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
         response.Headers.Location.Should().NotBeNull();
+        response.Headers.Location!.OriginalString.Should().Be("/api/scopes/scope-a/members/member-a/runs/run-member-resume-1");
+        body.GetProperty("statusUrl").GetString().Should().Be("/api/scopes/scope-a/members/member-a/runs/run-member-resume-1");
         host.ResumeDispatchService.LastCommand.Should().NotBeNull();
         host.ResumeDispatchService.LastCommand!.ActorId.Should().Be("run-actor-member-resume-1");
         host.ResumeDispatchService.LastCommand.RunId.Should().Be("run-member-resume-1");
@@ -414,14 +440,25 @@ public sealed class ScopeServiceRunQueryEndpointTests : ScopeServiceEndpointTest
                 "scope-a"),
         ];
 
-        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/members/member-a/runs/run-member-signal-1:signal", new
-        {
-            signalName = "ops_window_open",
-            stepId = "wait-1",
-        });
+        using var request = CreateAuthenticatedJsonRequest(
+            HttpMethod.Post,
+            "/api/scopes/scope-a/members/member-a/runs/run-member-signal-1:signal",
+            new
+            {
+                signalName = "ops_window_open",
+                stepId = "wait-1",
+            },
+            "scope-a");
+        request.Headers.Add("X-Test-Member-Id", "member-b");
+
+        var response = await host.Client.SendAsync(request);
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
 
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
         response.Headers.Location.Should().NotBeNull();
+        response.Headers.Location!.OriginalString.Should().Be("/api/scopes/scope-a/members/member-a/runs/run-member-signal-1");
+        body.GetProperty("statusUrl").GetString().Should().Be("/api/scopes/scope-a/members/member-a/runs/run-member-signal-1");
         host.SignalDispatchService.LastCommand.Should().NotBeNull();
         host.SignalDispatchService.LastCommand!.ActorId.Should().Be("run-actor-member-signal-1");
         host.SignalDispatchService.LastCommand.RunId.Should().Be("run-member-signal-1");
@@ -447,13 +484,24 @@ public sealed class ScopeServiceRunQueryEndpointTests : ScopeServiceEndpointTest
                 "scope-a"),
         ];
 
-        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/members/member-a/runs/run-member-stop-1:stop", new
-        {
-            reason = "manual",
-        });
+        using var request = CreateAuthenticatedJsonRequest(
+            HttpMethod.Post,
+            "/api/scopes/scope-a/members/member-a/runs/run-member-stop-1:stop",
+            new
+            {
+                reason = "manual",
+            },
+            "scope-a");
+        request.Headers.Add("X-Test-Member-Id", "member-b");
+
+        var response = await host.Client.SendAsync(request);
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
 
         response.StatusCode.Should().Be(HttpStatusCode.Accepted);
         response.Headers.Location.Should().NotBeNull();
+        response.Headers.Location!.OriginalString.Should().Be("/api/scopes/scope-a/members/member-a/runs/run-member-stop-1");
+        body.GetProperty("statusUrl").GetString().Should().Be("/api/scopes/scope-a/members/member-a/runs/run-member-stop-1");
         host.StopDispatchService.LastCommand.Should().NotBeNull();
         host.StopDispatchService.LastCommand!.ActorId.Should().Be("run-actor-member-stop-1");
         host.StopDispatchService.LastCommand.RunId.Should().Be("run-member-stop-1");


### PR DESCRIPTION
## Summary
- Remove authenticated-member equality checks from member target published-service and run endpoints while preserving scope authorization.
- Keep member run-control acknowledgements on member-scoped `Location`/`statusUrl` resources.
- Update member-first API docs and integration coverage for cross-member access within the same scope.

## Test plan
- [x] `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --filter \"FullyQualifiedName~ScopeServiceCatalogEndpointTests|FullyQualifiedName~ScopeServiceRunQueryEndpointTests|FullyQualifiedName~ScopeServiceRunControlEndpointTests\"` — 35 passed on clean PR worktree
- [x] `bash tools/ci/test_stability_guards.sh`
Closes #2308 

🤖 Generated with [Claude Code](https://claude.com/claude-code)