### PR TITLE
Align Console NyxID login with backend finalization

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Identity.Abstractions/IAevatarOAuthClientProvider.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity.Abstractions/IAevatarOAuthClientProvider.cs
@@ -48,7 +48,8 @@ public sealed record AevatarOAuthClientSnapshot(
     byte[]? PreviousHmacKey = null,
     DateTimeOffset? PreviousHmacDemotedAt = null,
     string? RedirectUri = null,
-    string? OauthScope = null);
+    string? OauthScope = null,
+    string? StudioLoginRedirectUri = null);
 
 /// <summary>
 /// Thrown when an OAuth flow tries to use the cluster client before the

--- a/agents/Aevatar.GAgents.Channel.Identity/Broker/INyxIdBrokerCallbackClient.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Broker/INyxIdBrokerCallbackClient.cs
@@ -33,6 +33,17 @@ public interface INyxIdBrokerCallbackClient
         CancellationToken ct = default);
 
     /// <summary>
+    /// Exchanges an OAuth authorization code that was issued for a caller-provided
+    /// redirect URI. Used by Studio login finalization where the SPA owns the
+    /// callback URL and the backend only performs the single-use code exchange.
+    /// </summary>
+    Task<BrokerAuthorizationCodeResult> ExchangeAuthorizationCodeAsync(
+        string authorizationCode,
+        string codeVerifier,
+        string redirectUri,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Revoke a specific NyxID-issued <paramref name="bindingId"/> by id.
     /// Used by the callback handler to clean up an orphan binding when the
     /// sender is already bound (race / replay) — without the subject lookup
@@ -47,4 +58,11 @@ public interface INyxIdBrokerCallbackClient
 /// may be null when NyxID has not yet enabled <c>broker_capability_enabled</c>
 /// on this client (see ADR-0018 §Decision).
 /// </summary>
-public sealed record BrokerAuthorizationCodeResult(string? BindingId, string? IdToken, string? AccessToken);
+public sealed record BrokerAuthorizationCodeResult(string? BindingId, string? IdToken, string? AccessToken)
+{
+    public string? TokenType { get; init; }
+
+    public int? ExpiresIn { get; init; }
+
+    public string? Scope { get; init; }
+}

--- a/agents/Aevatar.GAgents.Channel.Identity/Broker/NyxIdRemoteCapabilityBroker.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Broker/NyxIdRemoteCapabilityBroker.cs
@@ -239,7 +239,7 @@ public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxId
             result.Payload.PkceVerifier);
     }
 
-    public async Task<BrokerAuthorizationCodeResult> ExchangeAuthorizationCodeAsync(
+    public Task<BrokerAuthorizationCodeResult> ExchangeAuthorizationCodeAsync(
         string authorizationCode,
         string codeVerifier,
         CancellationToken ct = default)
@@ -247,9 +247,42 @@ public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxId
         ArgumentException.ThrowIfNullOrWhiteSpace(authorizationCode);
         ArgumentException.ThrowIfNullOrWhiteSpace(codeVerifier);
 
+        return ExchangeAuthorizationCodeCoreAsync(
+            authorizationCode,
+            codeVerifier,
+            ResolveRedirectUri(),
+            requireProvisionedRedirectUri: true,
+            ct);
+    }
+
+    public Task<BrokerAuthorizationCodeResult> ExchangeAuthorizationCodeAsync(
+        string authorizationCode,
+        string codeVerifier,
+        string redirectUri,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(authorizationCode);
+        ArgumentException.ThrowIfNullOrWhiteSpace(codeVerifier);
+        ArgumentException.ThrowIfNullOrWhiteSpace(redirectUri);
+
+        return ExchangeAuthorizationCodeCoreAsync(
+            authorizationCode,
+            codeVerifier,
+            redirectUri.Trim(),
+            requireProvisionedRedirectUri: false,
+            ct);
+    }
+
+    private async Task<BrokerAuthorizationCodeResult> ExchangeAuthorizationCodeCoreAsync(
+        string authorizationCode,
+        string codeVerifier,
+        string redirectUri,
+        bool requireProvisionedRedirectUri,
+        CancellationToken ct)
+    {
         var snapshot = await _clientProvider.GetAsync(ct).ConfigureAwait(false);
-        var redirectUri = ResolveRedirectUri();
-        EnsureClientCurrent(snapshot, redirectUri);
+        if (requireProvisionedRedirectUri)
+            EnsureClientCurrent(snapshot, redirectUri);
 
         var form = new List<KeyValuePair<string, string>>
         {
@@ -288,7 +321,12 @@ public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxId
         // client at NyxID. We surface the gap to the caller (callback handler)
         // rather than throwing — the user-visible error message guides ops to
         // toggle the flag at NyxID admin (one-time per cluster).
-        return new BrokerAuthorizationCodeResult(payload.BindingId, payload.IdToken, payload.AccessToken);
+        return new BrokerAuthorizationCodeResult(payload.BindingId, payload.IdToken, payload.AccessToken)
+        {
+            TokenType = payload.TokenType,
+            ExpiresIn = payload.ExpiresIn,
+            Scope = payload.Scope,
+        };
     }
 
     private string BuildAuthorizeUrl(

--- a/agents/Aevatar.GAgents.Channel.Identity/Endpoints/IdentityOAuthEndpoints.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Endpoints/IdentityOAuthEndpoints.cs
@@ -245,9 +245,13 @@ public static class IdentityOAuthEndpoints
             var resolvedRedirectUri = NyxIdRedirectUriResolver.Resolve();
             var redirectUriDrifted = string.IsNullOrEmpty(snapshot.RedirectUri)
                 || !string.Equals(snapshot.RedirectUri, resolvedRedirectUri, StringComparison.Ordinal);
+            var resolvedStudioLoginRedirectUri = NyxIdStudioLoginRedirectUriResolver.Resolve();
+            var studioLoginRedirectUriDrifted = string.IsNullOrEmpty(snapshot.StudioLoginRedirectUri)
+                || !string.Equals(snapshot.StudioLoginRedirectUri, resolvedStudioLoginRedirectUri, StringComparison.Ordinal);
             var oauthScopeDrifted = !AevatarOAuthClientScopes.ContainsRequiredScopes(snapshot.OauthScope);
             var status = redirectUriDrifted
                 ? "redirect_uri_drifted"
+                : studioLoginRedirectUriDrifted ? "studio_login_redirect_uri_drifted"
                 : oauthScopeDrifted ? "oauth_scope_drifted"
                 : snapshot.BrokerCapabilityObserved ? "ready" : "broker_capability_pending";
             return Results.Ok(new
@@ -259,12 +263,17 @@ public static class IdentityOAuthEndpoints
                 redirect_uri_registered = snapshot.RedirectUri,
                 redirect_uri_resolved = resolvedRedirectUri,
                 redirect_uri_drifted = redirectUriDrifted,
+                studio_login_redirect_uri_registered = snapshot.StudioLoginRedirectUri,
+                studio_login_redirect_uri_resolved = resolvedStudioLoginRedirectUri,
+                studio_login_redirect_uri_drifted = studioLoginRedirectUriDrifted,
                 oauth_scope_registered = snapshot.OauthScope,
                 oauth_scope_required = AevatarOAuthClientScopes.AuthorizationScope,
                 oauth_scope_drifted = oauthScopeDrifted,
                 broker_capability_observed = snapshot.BrokerCapabilityObserved,
                 broker_capability_observed_at = snapshot.BrokerCapabilityObservedAt,
-                ops_handoff = oauthScopeDrifted
+                ops_handoff = studioLoginRedirectUriDrifted
+                    ? "Bootstrap must re-run DCR so the OAuth client includes the Studio Console login callback registered for browser PKCE login."
+                    : oauthScopeDrifted
                     ? "Bootstrap must re-run DCR so the OAuth client includes the proxy scope required by LLM route selection."
                     : snapshot.BrokerCapabilityObserved
                         ? null
@@ -363,6 +372,7 @@ public static class IdentityOAuthEndpoints
 
         var authority = NyxIdAuthorityResolver.Resolve(logger);
         var redirectUri = NyxIdRedirectUriResolver.Resolve(logger);
+        var studioLoginRedirectUri = NyxIdStudioLoginRedirectUriResolver.Resolve(logger);
         var oauthScope = AevatarOAuthClientScopes.AuthorizationScope;
 
         // Validate Unix-seconds before dispatching: AevatarOAuthClient
@@ -404,6 +414,7 @@ public static class IdentityOAuthEndpoints
                     NyxidAuthority = authority,
                     OauthScope = oauthScope,
                     RedirectUri = redirectUri,
+                    StudioLoginRedirectUri = studioLoginRedirectUri,
                 }, ct)
                 .ConfigureAwait(false);
         }

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientBootstrapService.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientBootstrapService.cs
@@ -51,15 +51,18 @@ public sealed class AevatarOAuthClientBootstrapService : IHostedService
         // and the actor's single-threaded handler turns the broadcast into
         // exactly one DCR HTTP call. Without this seam the bootstrap path
         // races on the projection readmodel and creates orphan OAuth clients
-        // at NyxID. The redirect URI must match what the broker sends at
-        // authorize / token time — both call sites use NyxIdRedirectUriResolver.
+        // at NyxID. The binding redirect URI must match what the broker sends
+        // at authorize / token time, and the Studio login redirect URI must
+        // match what Console sends and /api/auth/nyxid/finalize validates.
         var redirectUri = NyxIdRedirectUriResolver.Resolve(_logger);
+        var studioLoginRedirectUri = NyxIdStudioLoginRedirectUriResolver.Resolve(_logger);
 
         var accepted = await _provisioningDispatch
             .DispatchAsync(new EnsureAevatarOAuthClientProvisionedCommand
             {
                 NyxidAuthority = authority,
                 RedirectUri = redirectUri,
+                StudioLoginRedirectUri = studioLoginRedirectUri,
                 ClientName = ClientName,
             }, ct)
             .ConfigureAwait(false);

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
@@ -120,6 +120,11 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             Logger.LogWarning("EnsureProvisioned rejected: redirect_uri is required");
             return;
         }
+        if (string.IsNullOrWhiteSpace(cmd.StudioLoginRedirectUri))
+        {
+            Logger.LogWarning("EnsureProvisioned rejected: studio_login_redirect_uri is required");
+            return;
+        }
 
         var sameClient = !string.IsNullOrEmpty(State.ClientId)
             && string.Equals(State.NyxidAuthority, cmd.NyxidAuthority, StringComparison.Ordinal);
@@ -138,9 +143,12 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         var redirectUriDrifted = sameClient
             && (string.IsNullOrEmpty(State.RedirectUri)
                 || !string.Equals(State.RedirectUri, cmd.RedirectUri, StringComparison.Ordinal));
+        var studioLoginRedirectUriDrifted = sameClient
+            && (string.IsNullOrEmpty(State.StudioLoginRedirectUri)
+                || !string.Equals(State.StudioLoginRedirectUri, cmd.StudioLoginRedirectUri, StringComparison.Ordinal));
         var oauthScopeDrifted = sameClient && !AevatarOAuthClientScopes.ContainsRequiredScopes(State.OauthScope);
 
-        if (sameClient && !redirectUriDrifted && !oauthScopeDrifted)
+        if (sameClient && !redirectUriDrifted && !studioLoginRedirectUriDrifted && !oauthScopeDrifted)
         {
             // Seed HMAC key on first activation against an existing client_id
             // (defence-in-depth against partial state loaded from snapshots).
@@ -179,6 +187,14 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 State.OauthScope,
                 AevatarOAuthClientScopes.AuthorizationScope);
         }
+        if (studioLoginRedirectUriDrifted)
+        {
+            Logger.LogWarning(
+                "Aevatar OAuth client Studio login redirect URI drifted: stored='{Stored}', resolved='{Resolved}'. " +
+                "Re-running DCR to register a new client_id at NyxID with the Console callback target.",
+                State.StudioLoginRedirectUri,
+                cmd.StudioLoginRedirectUri);
+        }
 
         var registrar = Services.GetService<NyxIdDynamicClientRegistrationClient>();
         if (registrar is null)
@@ -196,7 +212,11 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         // DCR call itself is bounded.
         var clientName = string.IsNullOrWhiteSpace(cmd.ClientName) ? "aevatar" : cmd.ClientName;
         var registration = await registrar
-            .RegisterPublicClientAsync(cmd.NyxidAuthority, clientName, cmd.RedirectUri, CancellationToken.None)
+            .RegisterPublicClientAsync(
+                cmd.NyxidAuthority,
+                clientName,
+                [cmd.RedirectUri, cmd.StudioLoginRedirectUri],
+                CancellationToken.None)
             .ConfigureAwait(false);
 
         // Cluster-shared Garnet event store + brief two-pod overlap during
@@ -212,6 +232,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         // active commit path (PR #552 review codex/glm-5.1).
         var previousRedirectUri = State.RedirectUri;
         var previousOauthScope = State.OauthScope;
+        var previousStudioLoginRedirectUri = State.StudioLoginRedirectUri;
         await PersistDomainEventAsync(
             new AevatarOAuthClientProvisionedEvent
             {
@@ -221,6 +242,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 PersistedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
                 RedirectUri = cmd.RedirectUri,
                 OauthScope = AevatarOAuthClientScopes.AuthorizationScope,
+                StudioLoginRedirectUri = cmd.StudioLoginRedirectUri,
             },
             onOptimisticConcurrencyConflict: occ => AbsorbPeerDcrProvisioningAsync(cmd, registration.ClientId, occ));
 
@@ -237,15 +259,18 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
 
         await PersistDriftReconciledEventsAsync(
             redirectUriDrifted,
+            studioLoginRedirectUriDrifted,
             oauthScopeDrifted,
             previousRedirectUri,
+            previousStudioLoginRedirectUri,
             previousOauthScope);
 
         Logger.LogInformation(
-            "Provisioned aevatar OAuth client via DCR: client_id={ClientId}, authority={Authority}, redirect_uri={RedirectUri}",
+            "Provisioned aevatar OAuth client via DCR: client_id={ClientId}, authority={Authority}, redirect_uri={RedirectUri}, studio_login_redirect_uri={StudioLoginRedirectUri}",
             registration.ClientId,
             cmd.NyxidAuthority,
-            cmd.RedirectUri);
+            cmd.RedirectUri,
+            cmd.StudioLoginRedirectUri);
 
         if (State.HmacKey.Length == 0)
         {
@@ -283,6 +308,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         {
             NyxidAuthority = State.ProvisioningRetryAuthority,
             RedirectUri = State.ProvisioningRetryRedirectUri,
+            StudioLoginRedirectUri = State.ProvisioningRetryStudioLoginRedirectUri,
             ClientName = State.ProvisioningRetryClientName,
         }, allowPendingRetryBypass: true).ConfigureAwait(false);
     }
@@ -301,6 +327,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             || evt.DueUnixMs != State.ProvisioningRetryDueUnixMs
             || !string.Equals(evt.NyxidAuthority, State.ProvisioningRetryAuthority, StringComparison.Ordinal)
             || !string.Equals(evt.RedirectUri, State.ProvisioningRetryRedirectUri, StringComparison.Ordinal)
+            || !string.Equals(evt.StudioLoginRedirectUri, State.ProvisioningRetryStudioLoginRedirectUri, StringComparison.Ordinal)
             || !string.Equals(evt.ClientName, State.ProvisioningRetryClientName, StringComparison.Ordinal))
         {
             return false;
@@ -320,6 +347,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         !string.IsNullOrEmpty(State.ClientId)
         && string.Equals(State.NyxidAuthority, cmd.NyxidAuthority, StringComparison.Ordinal)
         && string.Equals(State.RedirectUri, cmd.RedirectUri, StringComparison.Ordinal)
+        && string.Equals(State.StudioLoginRedirectUri, cmd.StudioLoginRedirectUri, StringComparison.Ordinal)
         && AevatarOAuthClientScopes.ContainsRequiredScopes(State.OauthScope)
         && State.HmacKey.Length > 0;
 
@@ -346,6 +374,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             DueUnixMs = due.ToUnixTimeMilliseconds(),
             NyxidAuthority = normalized.NyxidAuthority,
             RedirectUri = normalized.RedirectUri,
+            StudioLoginRedirectUri = normalized.StudioLoginRedirectUri,
             ClientName = normalized.ClientName,
             CallbackId = callbackId,
             FiredAtUnixMs = due.ToUnixTimeMilliseconds(),
@@ -363,6 +392,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             DueUnixMs = due.ToUnixTimeMilliseconds(),
             NyxidAuthority = normalized.NyxidAuthority,
             RedirectUri = normalized.RedirectUri,
+            StudioLoginRedirectUri = normalized.StudioLoginRedirectUri,
             ClientName = normalized.ClientName,
             CallbackId = lease.CallbackId,
             CallbackGeneration = lease.Generation,
@@ -392,8 +422,10 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
 
     private async Task PersistDriftReconciledEventsAsync(
         bool redirectUriDrifted,
+        bool studioLoginRedirectUriDrifted,
         bool oauthScopeDrifted,
         string previousRedirectUri,
+        string previousStudioLoginRedirectUri,
         string previousOauthScope)
     {
         var events = new List<IMessage>(capacity: 2);
@@ -420,6 +452,17 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 ReconciledAt = now,
             });
         }
+        if (studioLoginRedirectUriDrifted)
+        {
+            events.Add(new AevatarOAuthClientDriftReconciledEvent
+            {
+                DriftKind = "studio_login_redirect_uri",
+                PreviousValue = previousStudioLoginRedirectUri ?? string.Empty,
+                ExpectedValue = State.StudioLoginRedirectUri,
+                ActiveClientId = State.ClientId,
+                ReconciledAt = now,
+            });
+        }
 
         if (events.Count > 0)
             await PersistDomainEventsAsync(events).ConfigureAwait(false);
@@ -428,13 +471,18 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
     private static EnsureAevatarOAuthClientProvisionedCommand? NormalizeEnsureProvisionedCommand(
         EnsureAevatarOAuthClientProvisionedCommand cmd)
     {
-        if (string.IsNullOrWhiteSpace(cmd.NyxidAuthority) || string.IsNullOrWhiteSpace(cmd.RedirectUri))
+        if (string.IsNullOrWhiteSpace(cmd.NyxidAuthority)
+            || string.IsNullOrWhiteSpace(cmd.RedirectUri)
+            || string.IsNullOrWhiteSpace(cmd.StudioLoginRedirectUri))
+        {
             return null;
+        }
 
         return new EnsureAevatarOAuthClientProvisionedCommand
         {
             NyxidAuthority = cmd.NyxidAuthority.Trim(),
             RedirectUri = cmd.RedirectUri.Trim(),
+            StudioLoginRedirectUri = cmd.StudioLoginRedirectUri.Trim(),
             ClientName = string.IsNullOrWhiteSpace(cmd.ClientName) ? "aevatar" : cmd.ClientName.Trim(),
         };
     }
@@ -462,6 +510,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         var peerHealed = !string.IsNullOrEmpty(State.ClientId)
             && string.Equals(State.NyxidAuthority, cmd.NyxidAuthority, StringComparison.Ordinal)
             && string.Equals(State.RedirectUri, cmd.RedirectUri, StringComparison.Ordinal)
+            && string.Equals(State.StudioLoginRedirectUri, cmd.StudioLoginRedirectUri, StringComparison.Ordinal)
             && AevatarOAuthClientScopes.ContainsRequiredScopes(State.OauthScope)
             && State.HmacKey.Length > 0;
 
@@ -520,12 +569,12 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
     /// production bootstrap path uses
     /// <see cref="HandleEnsureProvisioned"/> instead so the actor (not the
     /// caller) mediates the DCR call. Idempotent: re-issuing the same
-    /// snapshot (client_id + authority + redirect_uri + oauth_scope) is a
+    /// snapshot (client_id + authority + redirect_uri + studio_login_redirect_uri + oauth_scope) is a
     /// no-op. Always seeds a fresh HMAC key when the state has none —
     /// bootstrap and provisioning are single-step.
     /// </summary>
     /// <remarks>
-    /// The same-snapshot check covers redirect_uri + oauth_scope on top of
+    /// The same-snapshot check covers redirect_uri + studio_login_redirect_uri + oauth_scope on top of
     /// client_id + authority because the operator-rebuild path
     /// (<c>POST /api/oauth/aevatar-client/rebuild</c>, issue #549) must be
     /// able to heal a wedged actor whose state has the right client_id but
@@ -558,9 +607,13 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         // rotate it away. Codex P1 on PR #570.
         var redirectUri = string.IsNullOrEmpty(cmd.RedirectUri) ? State.RedirectUri : cmd.RedirectUri;
         var oauthScope = string.IsNullOrEmpty(cmd.OauthScope) ? State.OauthScope : cmd.OauthScope;
+        var studioLoginRedirectUri = string.IsNullOrEmpty(cmd.StudioLoginRedirectUri)
+            ? State.StudioLoginRedirectUri
+            : cmd.StudioLoginRedirectUri;
         var sameSnapshot = string.Equals(State.ClientId, cmd.ClientId, StringComparison.Ordinal)
             && string.Equals(State.NyxidAuthority, cmd.NyxidAuthority, StringComparison.Ordinal)
             && string.Equals(State.RedirectUri, redirectUri, StringComparison.Ordinal)
+            && string.Equals(State.StudioLoginRedirectUri, studioLoginRedirectUri, StringComparison.Ordinal)
             && string.Equals(State.OauthScope, oauthScope, StringComparison.Ordinal);
         if (!sameSnapshot)
         {
@@ -572,12 +625,14 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 PersistedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
                 OauthScope = oauthScope,
                 RedirectUri = redirectUri,
+                StudioLoginRedirectUri = studioLoginRedirectUri,
             });
             Logger.LogInformation(
-                "Provisioned aevatar OAuth client: client_id={ClientId}, authority={Authority}, redirect_uri={RedirectUri}",
+                "Provisioned aevatar OAuth client: client_id={ClientId}, authority={Authority}, redirect_uri={RedirectUri}, studio_login_redirect_uri={StudioLoginRedirectUri}",
                 cmd.ClientId,
                 cmd.NyxidAuthority,
-                string.IsNullOrEmpty(redirectUri) ? "<unspecified>" : redirectUri);
+                string.IsNullOrEmpty(redirectUri) ? "<unspecified>" : redirectUri,
+                string.IsNullOrEmpty(studioLoginRedirectUri) ? "<unspecified>" : studioLoginRedirectUri);
         }
 
         if (State.HmacKey.Length == 0)
@@ -681,6 +736,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         next.ClientIdIssuedAtUnix = evt.ClientIdIssuedAtUnix;
         next.NyxidAuthority = evt.NyxidAuthority ?? string.Empty;
         next.RedirectUri = evt.RedirectUri ?? string.Empty;
+        next.StudioLoginRedirectUri = evt.StudioLoginRedirectUri ?? string.Empty;
         next.OauthScope = evt.OauthScope ?? string.Empty;
         // Re-provisioning resets the broker observation: a new client_id
         // starts with broker_capability_enabled=false until ops flips it.
@@ -722,6 +778,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         next.ProvisioningRetryDueUnixMs = evt.DueUnixMs;
         next.ProvisioningRetryAuthority = evt.NyxidAuthority ?? string.Empty;
         next.ProvisioningRetryRedirectUri = evt.RedirectUri ?? string.Empty;
+        next.ProvisioningRetryStudioLoginRedirectUri = evt.StudioLoginRedirectUri ?? string.Empty;
         next.ProvisioningRetryClientName = evt.ClientName ?? string.Empty;
         next.ProvisioningRetryCallbackId = evt.CallbackId ?? string.Empty;
         next.ProvisioningRetryCallbackGeneration = evt.CallbackGeneration;
@@ -739,6 +796,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         next.ProvisioningRetryDueUnixMs = 0;
         next.ProvisioningRetryAuthority = string.Empty;
         next.ProvisioningRetryRedirectUri = string.Empty;
+        next.ProvisioningRetryStudioLoginRedirectUri = string.Empty;
         next.ProvisioningRetryClientName = string.Empty;
         next.ProvisioningRetryCallbackId = string.Empty;
         next.ProvisioningRetryCallbackGeneration = 0;

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientProjectionProvider.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientProjectionProvider.cs
@@ -60,6 +60,7 @@ public sealed class AevatarOAuthClientProjectionProvider : IAevatarOAuthClientPr
             PreviousHmacKey: previousKey,
             PreviousHmacDemotedAt: previousDemotedAt,
             RedirectUri: string.IsNullOrEmpty(document.RedirectUri) ? null : document.RedirectUri,
-            OauthScope: string.IsNullOrEmpty(document.OauthScope) ? null : document.OauthScope);
+            OauthScope: string.IsNullOrEmpty(document.OauthScope) ? null : document.OauthScope,
+            StudioLoginRedirectUri: string.IsNullOrEmpty(document.StudioLoginRedirectUri) ? null : document.StudioLoginRedirectUri);
     }
 }

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientProjector.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientProjector.cs
@@ -61,6 +61,7 @@ public sealed class AevatarOAuthClientProjector
             BrokerCapabilityObservedAtUnix = state.BrokerCapabilityObservedAtUnix,
             RedirectUri = state.RedirectUri ?? string.Empty,
             OauthScope = state.OauthScope ?? string.Empty,
+            StudioLoginRedirectUri = state.StudioLoginRedirectUri ?? string.Empty,
             StateVersion = stateEvent.Version,
             LastEventId = stateEvent.EventId ?? string.Empty,
             UpdatedAt = CommittedStateEventEnvelope.ResolveTimestamp(envelope, _clock.UtcNow),

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/NyxIdDynamicClientRegistrationClient.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/NyxIdDynamicClientRegistrationClient.cs
@@ -44,15 +44,32 @@ public class NyxIdDynamicClientRegistrationClient
         string redirectUri,
         CancellationToken ct = default)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(redirectUri);
+        return await RegisterPublicClientAsync(authority, clientName, [redirectUri], ct).ConfigureAwait(false);
+    }
+
+    public virtual async Task<RegistrationResult> RegisterPublicClientAsync(
+        string authority,
+        string clientName,
+        IReadOnlyCollection<string> redirectUris,
+        CancellationToken ct = default)
+    {
         ArgumentException.ThrowIfNullOrWhiteSpace(authority);
         ArgumentException.ThrowIfNullOrWhiteSpace(clientName);
-        ArgumentException.ThrowIfNullOrWhiteSpace(redirectUri);
+        ArgumentNullException.ThrowIfNull(redirectUris);
+        var normalizedRedirectUris = redirectUris
+            .Select(static uri => uri.Trim())
+            .Where(static uri => !string.IsNullOrWhiteSpace(uri))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (normalizedRedirectUris.Length == 0)
+            throw new ArgumentException("At least one redirect URI is required.", nameof(redirectUris));
 
         var url = $"{authority.TrimEnd('/')}{RegisterEndpoint}";
         var request = new RegistrationRequest
         {
             ClientName = clientName,
-            RedirectUris = [redirectUri],
+            RedirectUris = normalizedRedirectUris,
             GrantTypes = ["authorization_code"],
             ResponseTypes = ["code"],
             TokenEndpointAuthMethod = "none",

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/NyxIdStudioLoginRedirectUriResolver.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/NyxIdStudioLoginRedirectUriResolver.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.GAgents.Channel.Identity;
+
+/// <summary>
+/// Resolves the browser callback URL registered for Studio Console NyxID
+/// login. This is intentionally separate from <see cref="NyxIdRedirectUriResolver"/>,
+/// which is the backend Lark/channel binding callback that consumes signed
+/// state tokens.
+/// </summary>
+public static class NyxIdStudioLoginRedirectUriResolver
+{
+    public const string DefaultPublicBaseUrl = "https://dashboard.aevatar.ai";
+    public const string CallbackPath = "/auth/callback";
+    public const string OverrideEnvVar = "AEVATAR_STUDIO_LOGIN_REDIRECT_BASE_URL";
+
+    public static string Resolve(ILogger? logger = null)
+    {
+        var baseUrl = ResolveBaseUrl(logger);
+        return $"{baseUrl.TrimEnd('/')}{CallbackPath}";
+    }
+
+    private static string ResolveBaseUrl(ILogger? logger)
+    {
+        var raw = Environment.GetEnvironmentVariable(OverrideEnvVar);
+        if (string.IsNullOrWhiteSpace(raw))
+            return DefaultPublicBaseUrl;
+
+        var trimmed = raw.Trim();
+        if (IsWildcardListenAddress(trimmed))
+        {
+            logger?.LogWarning(
+                "Ignoring {EnvVar}='{Value}': it is a Kestrel listen address and not a browser-reachable Studio login callback target. Falling back to '{Default}'.",
+                OverrideEnvVar,
+                trimmed,
+                DefaultPublicBaseUrl);
+            return DefaultPublicBaseUrl;
+        }
+
+        return trimmed;
+    }
+
+    private static bool IsWildcardListenAddress(string url)
+    {
+        if (url.Contains("://+", StringComparison.Ordinal)
+            || url.Contains("://*", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var parsed))
+            return false;
+
+        var host = parsed.Host;
+        return host is "+" or "*" or "0.0.0.0"
+            || string.Equals(host, "[::]", StringComparison.Ordinal)
+            || string.Equals(host, "::", StringComparison.Ordinal);
+    }
+}

--- a/agents/Aevatar.GAgents.Channel.Identity/protos/aevatar_oauth_client.proto
+++ b/agents/Aevatar.GAgents.Channel.Identity/protos/aevatar_oauth_client.proto
@@ -59,6 +59,11 @@ message AevatarOAuthClientState {
   // means legacy/unknown and forces one re-DCR on the next EnsureProvisioned
   // command so existing clients missing the proxy scope are healed.
   string oauth_scope = 13;
+  // Redirect URI registered for Studio Console login. Distinct from
+  // redirect_uri, which is the Lark/channel binding callback that consumes a
+  // backend-signed state token. Studio login uses browser PKCE state and must
+  // post the same registered URI back to /api/auth/nyxid/finalize.
+  string studio_login_redirect_uri = 22;
   // Actor-owned OAuth provisioning retry facts. Empty/zero means no retry is
   // pending. These facts are control-flow state, so they are typed fields
   // instead of a generic bag.
@@ -70,6 +75,7 @@ message AevatarOAuthClientState {
   string provisioning_retry_callback_id = 19;
   int64 provisioning_retry_callback_generation = 20;
   string provisioning_retry_last_error = 21;
+  string provisioning_retry_studio_login_redirect_uri = 23;
 }
 
 // Issued by the bootstrap startup service from every silo on cluster cold-
@@ -82,6 +88,7 @@ message EnsureAevatarOAuthClientProvisionedCommand {
   string redirect_uri = 2;
   // Optional override for the DCR <c>client_name</c>; bootstrap leaves blank.
   string client_name = 3;
+  string studio_login_redirect_uri = 4;
 }
 
 // Durable self-callback payload fired when an actor-owned OAuth provisioning
@@ -96,6 +103,7 @@ message AevatarOAuthClientProvisioningRetryFiredEvent {
   string callback_id = 6;
   int64 callback_generation = 7;
   int64 fired_at_unix_ms = 8;
+  string studio_login_redirect_uri = 9;
 }
 
 // Issued by tests / manual operator scripts that already hold a client_id
@@ -118,6 +126,7 @@ message ProvisionAevatarOAuthClientCommand {
   // client. Tests / fixture seeds may leave it empty when they don't care
   // about drift detection on a subsequent bootstrap pass.
   string redirect_uri = 5;
+  string studio_login_redirect_uri = 6;
 }
 
 // Issued by ops to force a fresh HMAC key rotation. Old tokens signed with
@@ -150,6 +159,7 @@ message AevatarOAuthClientProvisioningRetryScheduledEvent {
   int64 callback_generation = 7;
   string last_error = 8;
   google.protobuf.Timestamp scheduled_at = 9;
+  string studio_login_redirect_uri = 10;
 }
 
 // Persisted when provisioning reaches a terminal successful branch and the
@@ -186,6 +196,7 @@ message AevatarOAuthClientProvisionedEvent {
   // an older event predates scope tracking; the actor treats empty as
   // legacy/unknown and re-DCRs once so proxy-capable bindings can be minted.
   string oauth_scope = 6;
+  string studio_login_redirect_uri = 7;
 }
 
 // Persisted when the actor seeds or rotates its HMAC key. On rotation, the
@@ -250,4 +261,7 @@ message AevatarOAuthClientDocument {
   // Mirror of AevatarOAuthClientState.oauth_scope for diagnostics and
   // bootstrap drift detection.
   string oauth_scope = 17;
+  // Mirror of AevatarOAuthClientState.studio_login_redirect_uri for Studio
+  // login config/finalize validation.
+  string studio_login_redirect_uri = 18;
 }

--- a/apps/aevatar-console-web/src/shared/api/scheduledDispatchApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/scheduledDispatchApi.test.ts
@@ -1,5 +1,6 @@
 import { persistAuthSession } from "@/shared/auth/session";
 import {
+  configureScheduledDispatchRetryDelay,
   decodeScheduledDispatchSummary,
   scheduledDispatchApi,
   scheduledWorkflowPromptMaxLength,
@@ -235,6 +236,101 @@ describe("scheduledDispatchApi", () => {
     expect(String(init.body)).not.toContain("workflowChatTarget");
   });
 
+  it("retries schedule creation when the owner binding read model briefly lags after NyxID finalization", async () => {
+    const restoreRetryDelay = configureScheduledDispatchRetryDelay(async () => {});
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        text: async () =>
+          JSON.stringify({
+            error: "NyxID binding was not found for the scheduled subject.",
+          }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 202,
+        json: async () => createReceipt(),
+      } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    try {
+      await expect(
+        scheduledDispatchApi.create({
+          displayName: "Daily escalation digest",
+          cronExpression: "0 9 * * 1-5",
+          timezone: "Asia/Shanghai",
+          enabled: true,
+          workflowChatTarget: {
+            identity: {
+              tenantId: "scope-1",
+              appId: "default",
+              namespace: "default",
+              serviceId: "svc-alpha",
+            },
+            prompt: "Summarize escalations.",
+          },
+        }),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          accepted: true,
+          scheduleId: "sch-alpha",
+        }),
+      );
+    } finally {
+      restoreRetryDelay();
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls.map(([input]) => input)).toEqual([
+      "/api/schedules",
+      "/api/schedules",
+    ]);
+  });
+
+  it("stops retrying schedule creation after bounded owner binding read model attempts", async () => {
+    const retryDelays: number[] = [];
+    const restoreRetryDelay = configureScheduledDispatchRetryDelay(async (delayMs) => {
+      retryDelays.push(delayMs);
+    });
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      text: async () =>
+        JSON.stringify({
+          error: "NyxID binding was not found for the scheduled subject.",
+        }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    try {
+      await expect(
+        scheduledDispatchApi.create({
+          displayName: "Daily escalation digest",
+          cronExpression: "0 9 * * 1-5",
+          timezone: "Asia/Shanghai",
+          enabled: true,
+          workflowChatTarget: {
+            identity: {
+              tenantId: "scope-1",
+              appId: "default",
+              namespace: "default",
+              serviceId: "svc-alpha",
+            },
+          },
+        }),
+      ).rejects.toThrow("NyxID binding was not found for the scheduled subject.");
+    } finally {
+      restoreRetryDelay();
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(retryDelays).toEqual([400, 900]);
+  });
+
   it("posts workflow chat as base64 service invocation when creating without a revision", async () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,
@@ -392,6 +488,59 @@ describe("scheduledDispatchApi", () => {
     expect(String(init.body)).not.toContain("memberId");
     expect(String(init.body)).not.toContain("workflowId");
     expect(String(init.body)).not.toContain("workflowChatTarget");
+  });
+
+  it("retries schedule updates when the owner binding read model briefly lags", async () => {
+    const restoreRetryDelay = configureScheduledDispatchRetryDelay(async () => {});
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        text: async () =>
+          JSON.stringify({
+            error: "NyxID binding was not found for the scheduled subject.",
+          }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 202,
+        json: async () => createReceipt({ commandId: "cmd-update" }),
+      } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    try {
+      await expect(
+        scheduledDispatchApi.update(" sch-alpha ", {
+          displayName: "Daily escalation digest",
+          cronExpression: "0 9 * * 1-5",
+          timezone: "Asia/Shanghai",
+          enabled: true,
+          workflowChatTarget: {
+            identity: {
+              tenantId: "scope-1",
+              appId: "default",
+              namespace: "default",
+              serviceId: "svc-alpha",
+            },
+          },
+        }),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          commandId: "cmd-update",
+          scheduleId: "sch-alpha",
+        }),
+      );
+    } finally {
+      restoreRetryDelay();
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls.map(([input]) => input)).toEqual([
+      "/api/schedules/sch-alpha",
+      "/api/schedules/sch-alpha",
+    ]);
   });
 
   it("rejects oversized workflow prompts before storing the schedule payload", async () => {

--- a/apps/aevatar-console-web/src/shared/api/scheduledDispatchApi.ts
+++ b/apps/aevatar-console-web/src/shared/api/scheduledDispatchApi.ts
@@ -1,4 +1,6 @@
 import { jsonBody, requestJson, withQuery } from "./http/client";
+import { authFetch } from "@/shared/auth/fetch";
+import { readResponseErrorDetails } from "./http/error";
 import {
   expectArray,
   expectRecord,
@@ -120,6 +122,14 @@ export type ScheduledDispatchListQuery = {
   readonly includeTotalCount?: boolean;
   readonly take?: number;
 };
+
+const missingOwnerBindingMessage =
+  "NyxID binding was not found for the scheduled subject.";
+const bindingReadModelRetryDelaysMs = [400, 900] as const;
+let waitForBindingReadModelRetry = (delayMs: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
 
 function trimOptional(value: string | null | undefined): string | undefined {
   const normalized = value?.trim();
@@ -417,6 +427,70 @@ function encodePreview(input: ScheduledDispatchPreviewInput) {
   };
 }
 
+export class ScheduledDispatchApiError extends Error {
+  readonly code?: string;
+  readonly status: number;
+
+  constructor(message: string, status: number, code?: string) {
+    super(message);
+    this.name = "ScheduledDispatchApiError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+export function configureScheduledDispatchRetryDelay(
+  waitForRetry: (delayMs: number) => Promise<void>,
+): () => void {
+  const previous = waitForBindingReadModelRetry;
+  waitForBindingReadModelRetry = waitForRetry;
+  return () => {
+    waitForBindingReadModelRetry = previous;
+  };
+}
+
+function isMissingOwnerBindingError(error: unknown): boolean {
+  return (
+    error instanceof ScheduledDispatchApiError &&
+    error.message.includes(missingOwnerBindingMessage)
+  );
+}
+
+async function requestScheduledDispatchMutation<T>(
+  input: string,
+  decoder: (value: unknown, label?: string) => T,
+  init: RequestInit,
+): Promise<T> {
+  const response = await authFetch(input, init);
+  if (!response.ok) {
+    const details = await readResponseErrorDetails(response);
+    throw new ScheduledDispatchApiError(
+      details.message,
+      details.status,
+      details.code,
+    );
+  }
+
+  return decoder(await response.json());
+}
+
+async function requestScheduleMutationWithBindingRetry<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  for (let attemptIndex = 0; ; attemptIndex += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      const delayMs = bindingReadModelRetryDelaysMs[attemptIndex];
+      if (!isMissingOwnerBindingError(error) || delayMs === undefined) {
+        throw error;
+      }
+
+      await waitForBindingReadModelRetry(delayMs);
+    }
+  }
+}
+
 function listScheduledDispatches(
   query?: ScheduledDispatchListQuery,
 ): Promise<ScheduledDispatchListResult> {
@@ -483,23 +557,33 @@ export const scheduledDispatchApi = {
   create(
     input: ScheduledDispatchConfigurationInput,
   ): Promise<ScheduledDispatchMutationReceipt> {
-    return requestJson("/api/schedules", decodeScheduledDispatchMutationReceipt, {
-      method: "POST",
-      ...jsonBody(encodeConfiguration(input)),
-    });
+    const configuration = encodeConfiguration(input);
+    return requestScheduleMutationWithBindingRetry(() =>
+      requestScheduledDispatchMutation(
+        "/api/schedules",
+        decodeScheduledDispatchMutationReceipt,
+        {
+          method: "POST",
+          ...jsonBody(configuration),
+        },
+      ),
+    );
   },
 
   update(
     scheduleId: string,
     input: ScheduledDispatchConfigurationInput,
   ): Promise<ScheduledDispatchMutationReceipt> {
-    return requestJson(
-      `/api/schedules/${encodeURIComponent(scheduleId.trim())}`,
-      decodeScheduledDispatchMutationReceipt,
-      {
-        method: "PUT",
-        ...jsonBody(encodeConfiguration(input)),
-      },
+    const configuration = encodeConfiguration(input);
+    return requestScheduleMutationWithBindingRetry(() =>
+      requestScheduledDispatchMutation(
+        `/api/schedules/${encodeURIComponent(scheduleId.trim())}`,
+        decodeScheduledDispatchMutationReceipt,
+        {
+          method: "PUT",
+          ...jsonBody(configuration),
+        },
+      ),
     );
   },
 

--- a/apps/aevatar-console-web/src/shared/auth/backend.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/backend.test.ts
@@ -1,0 +1,106 @@
+import {
+  finalizeBackendNyxIDLogin,
+  loadBackendNyxIDLoginConfig,
+} from "./backend";
+
+describe("NyxID backend auth API", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it("loads the broker OAuth client config used by backend finalization", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        baseUrl: "https://nyx.example/",
+        clientId: "broker-client-1",
+        scope: "openid urn:nyxid:scope:broker_binding proxy",
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(loadBackendNyxIDLoginConfig()).resolves.toEqual({
+      baseUrl: "https://nyx.example",
+      clientId: "broker-client-1",
+      scope: "openid urn:nyxid:scope:broker_binding proxy",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/auth/nyxid/config", {
+      headers: {
+        Accept: "application/json",
+      },
+    });
+  });
+
+  it("finalizes an authorization code through the backend and preserves accepted-dispatch semantics", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        tokens: {
+          accessToken: "access-token",
+          tokenType: "Bearer",
+          expiresIn: 1800,
+          idToken: "id-token",
+          scope: "openid profile proxy",
+        },
+        user: {
+          sub: "owner-user-1",
+          email: "owner@example.com",
+          emailVerified: true,
+          roles: ["owner"],
+        },
+        bindingDispatchAccepted: true,
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(
+      finalizeBackendNyxIDLogin({
+        code: "auth-code",
+        codeVerifier: "pkce-verifier",
+        redirectUri: "http://localhost:8000/auth/callback",
+      }),
+    ).resolves.toEqual({
+      bindingDispatchAccepted: true,
+      session: {
+        tokens: {
+          accessToken: "access-token",
+          tokenType: "Bearer",
+          expiresIn: 1800,
+          expiresAt: 1_700_000_000_000 + 1_800_000,
+          idToken: "id-token",
+          scope: "openid profile proxy",
+          refreshToken: undefined,
+        },
+        user: {
+          sub: "owner-user-1",
+          email: "owner@example.com",
+          email_verified: true,
+          name: undefined,
+          picture: undefined,
+          roles: ["owner"],
+          groups: undefined,
+          permissions: undefined,
+        },
+      },
+    });
+
+    const [input, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(input).toBe("/api/auth/nyxid/finalize");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(String(init.body))).toEqual({
+      code: "auth-code",
+      codeVerifier: "pkce-verifier",
+      redirectUri: "http://localhost:8000/auth/callback",
+    });
+  });
+});

--- a/apps/aevatar-console-web/src/shared/auth/backend.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/backend.test.ts
@@ -22,6 +22,7 @@ describe("NyxID backend auth API", () => {
       json: async () => ({
         baseUrl: "https://nyx.example/",
         clientId: "broker-client-1",
+        redirectUri: "https://dashboard.example/auth/callback",
         scope: "openid urn:nyxid:scope:broker_binding proxy",
       }),
     } as Response);
@@ -30,6 +31,7 @@ describe("NyxID backend auth API", () => {
     await expect(loadBackendNyxIDLoginConfig()).resolves.toEqual({
       baseUrl: "https://nyx.example",
       clientId: "broker-client-1",
+      redirectUri: "https://dashboard.example/auth/callback",
       scope: "openid urn:nyxid:scope:broker_binding proxy",
     });
 

--- a/apps/aevatar-console-web/src/shared/auth/backend.ts
+++ b/apps/aevatar-console-web/src/shared/auth/backend.ts
@@ -4,7 +4,7 @@ import type { NyxIDAuthSession, NyxIDTokenSet, NyxIDUserInfo } from "./session";
 
 export type NyxIDBackendLoginConfig = Pick<
   NyxIDRuntimeConfig,
-  "baseUrl" | "clientId" | "scope"
+  "baseUrl" | "clientId" | "scope" | "redirectUri"
 >;
 
 export type NyxIDLoginFinalizationRequest = {
@@ -25,6 +25,8 @@ type BackendLoginConfigResponse = {
   readonly ClientId?: unknown;
   readonly scope?: unknown;
   readonly Scope?: unknown;
+  readonly redirectUri?: unknown;
+  readonly RedirectUri?: unknown;
 };
 
 type BackendFinalizationResponse = {
@@ -142,6 +144,10 @@ function decodeBackendLoginConfig(
     ),
     clientId: readString(record.clientId ?? record.ClientId, "clientId"),
     scope: readString(record.scope ?? record.Scope, "scope"),
+    redirectUri: readString(
+      record.redirectUri ?? record.RedirectUri,
+      "redirectUri",
+    ),
   };
 }
 

--- a/apps/aevatar-console-web/src/shared/auth/backend.ts
+++ b/apps/aevatar-console-web/src/shared/auth/backend.ts
@@ -1,0 +1,255 @@
+import { readResponseError } from "@/shared/api/http/error";
+import type { NyxIDRuntimeConfig } from "./config";
+import type { NyxIDAuthSession, NyxIDTokenSet, NyxIDUserInfo } from "./session";
+
+export type NyxIDBackendLoginConfig = Pick<
+  NyxIDRuntimeConfig,
+  "baseUrl" | "clientId" | "scope"
+>;
+
+export type NyxIDLoginFinalizationRequest = {
+  readonly code: string;
+  readonly codeVerifier: string;
+  readonly redirectUri: string;
+};
+
+export type NyxIDLoginFinalizationResult = {
+  readonly bindingDispatchAccepted: boolean;
+  readonly session: NyxIDAuthSession;
+};
+
+type BackendLoginConfigResponse = {
+  readonly baseUrl?: unknown;
+  readonly BaseUrl?: unknown;
+  readonly clientId?: unknown;
+  readonly ClientId?: unknown;
+  readonly scope?: unknown;
+  readonly Scope?: unknown;
+};
+
+type BackendFinalizationResponse = {
+  readonly bindingDispatchAccepted?: unknown;
+  readonly BindingDispatchAccepted?: unknown;
+  readonly tokens?: unknown;
+  readonly Tokens?: unknown;
+  readonly user?: unknown;
+  readonly User?: unknown;
+};
+
+type BackendTokenSetResponse = {
+  readonly accessToken?: unknown;
+  readonly AccessToken?: unknown;
+  readonly access_token?: unknown;
+  readonly tokenType?: unknown;
+  readonly TokenType?: unknown;
+  readonly token_type?: unknown;
+  readonly expiresIn?: unknown;
+  readonly ExpiresIn?: unknown;
+  readonly expires_in?: unknown;
+  readonly refreshToken?: unknown;
+  readonly RefreshToken?: unknown;
+  readonly refresh_token?: unknown;
+  readonly idToken?: unknown;
+  readonly IdToken?: unknown;
+  readonly id_token?: unknown;
+  readonly scope?: unknown;
+  readonly Scope?: unknown;
+};
+
+type BackendUserInfoResponse = {
+  readonly sub?: unknown;
+  readonly Sub?: unknown;
+  readonly email?: unknown;
+  readonly Email?: unknown;
+  readonly email_verified?: unknown;
+  readonly emailVerified?: unknown;
+  readonly EmailVerified?: unknown;
+  readonly name?: unknown;
+  readonly Name?: unknown;
+  readonly picture?: unknown;
+  readonly Picture?: unknown;
+  readonly roles?: unknown;
+  readonly Roles?: unknown;
+  readonly groups?: unknown;
+  readonly Groups?: unknown;
+  readonly permissions?: unknown;
+  readonly Permissions?: unknown;
+};
+
+function expectRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function readString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+
+  return value.trim();
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function readNumber(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${label} must be a number.`);
+  }
+
+  return value;
+}
+
+function readBoolean(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(`${label} must be a boolean.`);
+  }
+
+  return value;
+}
+
+function readOptionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function readOptionalStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function decodeBackendLoginConfig(
+  value: unknown,
+): NyxIDBackendLoginConfig {
+  const record = expectRecord(value, "NyxID backend login config") as
+    BackendLoginConfigResponse;
+
+  return {
+    baseUrl: readString(record.baseUrl ?? record.BaseUrl, "baseUrl").replace(
+      /\/+$/,
+      "",
+    ),
+    clientId: readString(record.clientId ?? record.ClientId, "clientId"),
+    scope: readString(record.scope ?? record.Scope, "scope"),
+  };
+}
+
+function decodeTokenSet(value: unknown): NyxIDTokenSet {
+  const record = expectRecord(value, "NyxID finalized tokens") as
+    BackendTokenSetResponse;
+  const expiresIn = readNumber(
+    record.expiresIn ?? record.ExpiresIn ?? record.expires_in,
+    "tokens.expiresIn",
+  );
+
+  return {
+    accessToken: readString(
+      record.accessToken ?? record.AccessToken ?? record.access_token,
+      "tokens.accessToken",
+    ),
+    tokenType: readString(
+      record.tokenType ?? record.TokenType ?? record.token_type,
+      "tokens.tokenType",
+    ),
+    expiresIn,
+    expiresAt: Date.now() + expiresIn * 1000,
+    refreshToken: readOptionalString(
+      record.refreshToken ?? record.RefreshToken ?? record.refresh_token,
+    ),
+    idToken: readOptionalString(
+      record.idToken ?? record.IdToken ?? record.id_token,
+    ),
+    scope: readOptionalString(record.scope ?? record.Scope),
+  };
+}
+
+function decodeUserInfo(value: unknown): NyxIDUserInfo {
+  const record = expectRecord(value, "NyxID finalized user") as
+    BackendUserInfoResponse;
+
+  return {
+    sub: readString(record.sub ?? record.Sub, "user.sub"),
+    email: readOptionalString(record.email ?? record.Email),
+    email_verified: readOptionalBoolean(
+      record.email_verified ?? record.emailVerified ?? record.EmailVerified,
+    ),
+    name: readOptionalString(record.name ?? record.Name),
+    picture: readOptionalString(record.picture ?? record.Picture),
+    roles: readOptionalStringArray(record.roles ?? record.Roles),
+    groups: readOptionalStringArray(record.groups ?? record.Groups),
+    permissions: readOptionalStringArray(
+      record.permissions ?? record.Permissions,
+    ),
+  };
+}
+
+function decodeFinalizationResult(
+  value: unknown,
+): NyxIDLoginFinalizationResult {
+  const record = expectRecord(value, "NyxID login finalization") as
+    BackendFinalizationResponse;
+
+  return {
+    bindingDispatchAccepted: readBoolean(
+      record.bindingDispatchAccepted ?? record.BindingDispatchAccepted,
+      "bindingDispatchAccepted",
+    ),
+    session: {
+      tokens: decodeTokenSet(record.tokens ?? record.Tokens),
+      user: decodeUserInfo(record.user ?? record.User),
+    },
+  };
+}
+
+async function requestBackendJson<T>(
+  input: string,
+  decoder: (value: unknown) => T,
+  init?: RequestInit,
+): Promise<T> {
+  const response = await fetch(input, init);
+  if (!response.ok) {
+    throw new Error(await readResponseError(response));
+  }
+
+  return decoder(await response.json());
+}
+
+export function loadBackendNyxIDLoginConfig(): Promise<NyxIDBackendLoginConfig> {
+  return requestBackendJson(
+    "/api/auth/nyxid/config",
+    decodeBackendLoginConfig,
+    {
+      headers: {
+        Accept: "application/json",
+      },
+    },
+  );
+}
+
+export function finalizeBackendNyxIDLogin(
+  request: NyxIDLoginFinalizationRequest,
+): Promise<NyxIDLoginFinalizationResult> {
+  return requestBackendJson(
+    "/api/auth/nyxid/finalize",
+    decodeFinalizationResult,
+    {
+      body: JSON.stringify(request),
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    },
+  );
+}

--- a/apps/aevatar-console-web/src/shared/auth/client.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/client.test.ts
@@ -69,6 +69,7 @@ describe("NyxIDAuthClient", () => {
       json: async () => ({
         baseUrl: "https://nyx.example",
         clientId: "broker-client-1",
+        redirectUri: "https://dashboard.example/auth/callback",
         scope: "openid urn:nyxid:scope:broker_binding proxy",
       }),
     } as Response);
@@ -90,7 +91,7 @@ describe("NyxIDAuthClient", () => {
     );
     expect(authorizeUrl.searchParams.get("client_id")).toBe("broker-client-1");
     expect(authorizeUrl.searchParams.get("redirect_uri")).toBe(
-      "http://localhost:8000/auth/callback",
+      "https://dashboard.example/auth/callback",
     );
     expect(authorizeUrl.searchParams.get("scope")).toBe(
       "openid urn:nyxid:scope:broker_binding proxy",
@@ -104,7 +105,7 @@ describe("NyxIDAuthClient", () => {
     expect(pending).toEqual(
       expect.objectContaining({
         clientId: "broker-client-1",
-        redirectUri: "http://localhost:8000/auth/callback",
+        redirectUri: "https://dashboard.example/auth/callback",
         returnTo: "/scopes/scope-1/teams",
         scope: "openid urn:nyxid:scope:broker_binding proxy",
         state: authorizeUrl.searchParams.get("state"),

--- a/apps/aevatar-console-web/src/shared/auth/client.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/client.test.ts
@@ -1,0 +1,181 @@
+import { TextEncoder } from "node:util";
+import { NyxIDAuthClient } from "./client";
+import type { NyxIDRuntimeConfig } from "./config";
+import { loadStoredAuthSession } from "./session";
+
+const runtimeConfig: NyxIDRuntimeConfig = {
+  enabled: true,
+  baseUrl: "https://legacy-console-client.example",
+  clientId: "console-client-1",
+  redirectUri: "http://localhost:8000/auth/callback",
+  scope: "openid profile email",
+};
+
+function installLocationAssignSpy() {
+  const assign = jest.fn();
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      ...window.location,
+      assign,
+      href: window.location.href,
+      origin: window.location.origin,
+    },
+  });
+  return assign;
+}
+
+describe("NyxIDAuthClient", () => {
+  const originalFetch = global.fetch;
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.history.replaceState({}, "", "/login");
+    jest.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    Object.defineProperty(globalThis, "TextEncoder", {
+      configurable: true,
+      value: TextEncoder,
+    });
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value: {
+        getRandomValues: (array: Uint8Array) => {
+          array.fill(7);
+          return array;
+        },
+        subtle: {
+          digest: jest.fn(async () => new Uint8Array(32).fill(9).buffer),
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    jest.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  it("starts authorize with the backend broker OAuth client config", async () => {
+    const assign = installLocationAssignSpy();
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        baseUrl: "https://nyx.example",
+        clientId: "broker-client-1",
+        scope: "openid urn:nyxid:scope:broker_binding proxy",
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await new NyxIDAuthClient(runtimeConfig).loginWithRedirect({
+      returnTo: "/scopes/scope-1/teams",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/auth/nyxid/config", {
+      headers: {
+        Accept: "application/json",
+      },
+    });
+    expect(assign).toHaveBeenCalledTimes(1);
+    const authorizeUrl = new URL(assign.mock.calls[0][0]);
+    expect(authorizeUrl.origin + authorizeUrl.pathname).toBe(
+      "https://nyx.example/oauth/authorize",
+    );
+    expect(authorizeUrl.searchParams.get("client_id")).toBe("broker-client-1");
+    expect(authorizeUrl.searchParams.get("redirect_uri")).toBe(
+      "http://localhost:8000/auth/callback",
+    );
+    expect(authorizeUrl.searchParams.get("scope")).toBe(
+      "openid urn:nyxid:scope:broker_binding proxy",
+    );
+
+    const pending = JSON.parse(
+      window.localStorage.getItem(
+        "aevatar-console:nyxid:pending:broker-client-1",
+      ) ?? "{}",
+    );
+    expect(pending).toEqual(
+      expect.objectContaining({
+        clientId: "broker-client-1",
+        redirectUri: "http://localhost:8000/auth/callback",
+        returnTo: "/scopes/scope-1/teams",
+        scope: "openid urn:nyxid:scope:broker_binding proxy",
+        state: authorizeUrl.searchParams.get("state"),
+      }),
+    );
+  });
+
+  it("finalizes callback through the backend without a browser token exchange", async () => {
+    const pendingKey = "aevatar-console:nyxid:pending:broker-client-1";
+    window.localStorage.setItem(
+      pendingKey,
+      JSON.stringify({
+        clientId: "broker-client-1",
+        codeVerifier: "pkce-verifier",
+        redirectUri: "http://localhost:8000/auth/callback",
+        returnTo: "/scopes/scope-1/teams",
+        scope: "openid urn:nyxid:scope:broker_binding proxy",
+        state: "state-1",
+      }),
+    );
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        tokens: {
+          accessToken: "access-token",
+          tokenType: "Bearer",
+          expiresIn: 1800,
+          scope: "openid profile proxy",
+        },
+        user: {
+          sub: "owner-user-1",
+        },
+        bindingDispatchAccepted: true,
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(
+      new NyxIDAuthClient(runtimeConfig).handleRedirectCallback(
+        "http://localhost:8000/auth/callback?code=auth-code&state=state-1",
+      ),
+    ).resolves.toEqual({
+      returnTo: "/scopes/scope-1/teams",
+      session: expect.objectContaining({
+        tokens: expect.objectContaining({
+          accessToken: "access-token",
+        }),
+        user: {
+          sub: "owner-user-1",
+          email: undefined,
+          email_verified: undefined,
+          groups: undefined,
+          name: undefined,
+          permissions: undefined,
+          picture: undefined,
+          roles: undefined,
+        },
+      }),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [input, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(input).toBe("/api/auth/nyxid/finalize");
+    expect(JSON.parse(String(init.body))).toEqual({
+      code: "auth-code",
+      codeVerifier: "pkce-verifier",
+      redirectUri: "http://localhost:8000/auth/callback",
+    });
+    expect(String(input)).not.toContain("/oauth/token");
+    expect(window.localStorage.getItem(pendingKey)).toBeNull();
+    expect(loadStoredAuthSession()?.tokens.accessToken).toBe("access-token");
+  });
+});

--- a/apps/aevatar-console-web/src/shared/auth/client.ts
+++ b/apps/aevatar-console-web/src/shared/auth/client.ts
@@ -3,6 +3,11 @@ import {
   type NyxIDRuntimeConfig,
 } from './config';
 import {
+  finalizeBackendNyxIDLogin,
+  loadBackendNyxIDLoginConfig,
+  type NyxIDBackendLoginConfig,
+} from './backend';
+import {
   clearStoredAuthSession,
   loadRestorableAuthSession,
   loadStoredAuthSession,
@@ -19,6 +24,7 @@ interface PendingAuthState {
   readonly redirectUri: string;
   readonly scope: string;
   readonly returnTo: string;
+  readonly clientId: string;
 }
 
 interface TokenResponse {
@@ -109,8 +115,9 @@ export class NyxIDAuthClient {
     const codeVerifier = randomUrlSafeString(48);
     const codeChallenge = await sha256Base64Url(codeVerifier);
     const state = randomUrlSafeString(24);
+    const loginConfig = await loadBackendNyxIDLoginConfig();
     const redirectUri = this.config.redirectUri;
-    const scope = this.config.scope;
+    const scope = loginConfig.scope;
     const returnTo = sanitizeReturnTo(options.returnTo);
 
     const pending: PendingAuthState = {
@@ -119,12 +126,13 @@ export class NyxIDAuthClient {
       redirectUri,
       scope,
       returnTo,
+      clientId: loginConfig.clientId,
     };
-    this.storage.setItem(this.pendingKey, JSON.stringify(pending));
+    this.storage.setItem(this.resolvePendingKey(loginConfig), JSON.stringify(pending));
 
-    const url = new URL(`${this.config.baseUrl}/oauth/authorize`);
+    const url = new URL(`${loginConfig.baseUrl}/oauth/authorize`);
     url.searchParams.set('response_type', 'code');
-    url.searchParams.set('client_id', this.config.clientId);
+    url.searchParams.set('client_id', loginConfig.clientId);
     url.searchParams.set('redirect_uri', redirectUri);
     url.searchParams.set('scope', scope);
     url.searchParams.set('code_challenge', codeChallenge);
@@ -135,6 +143,40 @@ export class NyxIDAuthClient {
     }
 
     window.location.assign(url.toString());
+  }
+
+  private resolvePendingKey(loginConfig: NyxIDBackendLoginConfig): string {
+    return `${PENDING_KEY_PREFIX}${loginConfig.clientId}`;
+  }
+
+  private loadPendingState(state: string): {
+    readonly key: string;
+    readonly pending: PendingAuthState;
+  } | null {
+    const candidateKeys = new Set<string>([this.pendingKey]);
+
+    for (let index = 0; index < this.storage.length; index += 1) {
+      const key = this.storage.key(index);
+      if (!key?.startsWith(PENDING_KEY_PREFIX)) {
+        continue;
+      }
+
+      candidateKeys.add(key);
+    }
+
+    for (const key of candidateKeys) {
+      const raw = this.storage.getItem(key);
+      if (!raw) {
+        continue;
+      }
+
+      const pending = JSON.parse(raw) as PendingAuthState;
+      if (pending.state === state) {
+        return { key, pending };
+      }
+    }
+
+    return null;
   }
 
   async handleRedirectCallback(
@@ -154,66 +196,33 @@ export class NyxIDAuthClient {
       throw new Error('Missing authorization code or state');
     }
 
-    const rawPending = this.storage.getItem(this.pendingKey);
-    const pending = rawPending ? (JSON.parse(rawPending) as PendingAuthState) : null;
-    if (!pending) {
+    const storedPending = this.loadPendingState(state);
+    if (!storedPending) {
       throw new Error('Missing PKCE state in storage');
     }
+    const { key: pendingKey, pending } = storedPending;
     if (pending.state !== state) {
-      this.storage.removeItem(this.pendingKey);
+      this.storage.removeItem(pendingKey);
       throw new Error('State mismatch');
     }
 
-    const form = new URLSearchParams();
-    form.set('grant_type', 'authorization_code');
-    form.set('code', code);
-    form.set('redirect_uri', pending.redirectUri);
-    form.set('client_id', this.config.clientId);
-    form.set('code_verifier', pending.codeVerifier);
-
     try {
-      const response = await fetch(`${this.config.baseUrl}/oauth/token`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body: form.toString(),
+      const result = await finalizeBackendNyxIDLogin({
+        code,
+        codeVerifier: pending.codeVerifier,
+        redirectUri: pending.redirectUri,
       });
-
-      if (!response.ok) {
-        const payload = (await response.json().catch(() => null)) as
-          | Record<string, unknown>
-          | null;
-        throw new Error(
-          `Token exchange failed: ${readErrorDetail(payload, response.statusText)}`,
-        );
-      }
-
-      const body = (await response.json()) as TokenResponse;
-      const tokens: NyxIDTokenSet = {
-        accessToken: body.access_token,
-        tokenType: body.token_type,
-        expiresIn: body.expires_in,
-        expiresAt: Date.now() + body.expires_in * 1000,
-        refreshToken: body.refresh_token,
-        idToken: body.id_token,
-        scope: body.scope,
-      };
-      const user = await this.getUserInfo(tokens.accessToken);
-      const session: NyxIDAuthSession = {
-        tokens,
-        user,
-      };
+      const { session } = result;
 
       persistAuthSession(session);
-      this.storage.removeItem(this.pendingKey);
+      this.storage.removeItem(pendingKey);
 
       return {
         session,
         returnTo: sanitizeReturnTo(pending.returnTo),
       };
     } catch (error) {
-      this.storage.removeItem(this.pendingKey);
+      this.storage.removeItem(pendingKey);
       throw error;
     }
   }

--- a/apps/aevatar-console-web/src/shared/auth/client.ts
+++ b/apps/aevatar-console-web/src/shared/auth/client.ts
@@ -116,7 +116,7 @@ export class NyxIDAuthClient {
     const codeChallenge = await sha256Base64Url(codeVerifier);
     const state = randomUrlSafeString(24);
     const loginConfig = await loadBackendNyxIDLoginConfig();
-    const redirectUri = this.config.redirectUri;
+    const redirectUri = loginConfig.redirectUri;
     const scope = loginConfig.scope;
     const returnTo = sanitizeReturnTo(options.returnTo);
 

--- a/src/Aevatar.Studio.Hosting/Aevatar.Studio.Hosting.csproj
+++ b/src/Aevatar.Studio.Hosting/Aevatar.Studio.Hosting.csproj
@@ -21,6 +21,10 @@
     <ProjectReference Include="..\Aevatar.Foundation.Core\Aevatar.Foundation.Core.csproj" />
     <ProjectReference Include="..\Aevatar.Scripting.Hosting\Aevatar.Scripting.Hosting.csproj" />
     <ProjectReference Include="..\platform\Aevatar.GAgentService.Abstractions\Aevatar.GAgentService.Abstractions.csproj" />
+    <ProjectReference Include="..\Aevatar.CQRS.Core.Abstractions\Aevatar.CQRS.Core.Abstractions.csproj" />
+    <ProjectReference Include="..\..\agents\Aevatar.GAgents.Channel.Abstractions\Aevatar.GAgents.Channel.Abstractions.csproj" />
+    <ProjectReference Include="..\..\agents\Aevatar.GAgents.Channel.Identity.Abstractions\Aevatar.GAgents.Channel.Identity.Abstractions.csproj" />
+    <ProjectReference Include="..\..\agents\Aevatar.GAgents.Channel.Identity\Aevatar.GAgents.Channel.Identity.csproj" />
     <ProjectReference Include="..\workflow\Aevatar.Workflow.Application.Abstractions\Aevatar.Workflow.Application.Abstractions.csproj" />
   </ItemGroup>
 

--- a/src/Aevatar.Studio.Hosting/Endpoints/NyxIdLoginFinalizationEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/NyxIdLoginFinalizationEndpoints.cs
@@ -1,0 +1,321 @@
+using System.Text.Json;
+using Aevatar.CQRS.Core.Abstractions.Commands;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.Channel.Abstractions;
+using Aevatar.GAgents.Channel.Identity;
+using Aevatar.GAgents.Channel.Identity.Abstractions;
+using Aevatar.GAgents.Channel.Identity.Broker;
+using Aevatar.GAgentService.Abstractions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.Studio.Hosting.Endpoints;
+
+public static class NyxIdLoginFinalizationEndpoints
+{
+    public static void Map(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/auth/nyxid/config", HandleConfigAsync)
+            .WithTags("Auth")
+            .AllowAnonymous()
+            .Produces<NyxIdLoginConfigurationResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status503ServiceUnavailable);
+
+        app.MapPost("/api/auth/nyxid/finalize", HandleFinalizeAsync)
+            .WithTags("Auth")
+            .AllowAnonymous()
+            .Produces<NyxIdLoginFinalizationResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status409Conflict)
+            .Produces(StatusCodes.Status503ServiceUnavailable);
+    }
+
+    internal static async Task<IResult> HandleConfigAsync(
+        [FromServices] IAevatarOAuthClientProvider oauthClientProvider,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var snapshot = await oauthClientProvider.GetAsync(ct).ConfigureAwait(false);
+            return Results.Ok(new NyxIdLoginConfigurationResponse(
+                BaseUrl: snapshot.NyxIdAuthority.TrimEnd('/'),
+                ClientId: snapshot.ClientId,
+                Scope: string.IsNullOrWhiteSpace(snapshot.OauthScope)
+                    ? AevatarOAuthClientScopes.AuthorizationScope
+                    : snapshot.OauthScope.Trim()));
+        }
+        catch (AevatarOAuthClientNotProvisionedException)
+        {
+            return Results.Json(new
+            {
+                error = "oauth_client_not_provisioned",
+                detail = "Aevatar OAuth client has not been provisioned at NyxID yet.",
+            }, statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+    }
+
+    internal static async Task<IResult> HandleFinalizeAsync(
+        NyxIdLoginFinalizationRequest request,
+        [FromServices] INyxIdBrokerCallbackClient brokerCallback,
+        [FromServices] IExternalIdentityBindingQueryPort bindingQueryPort,
+        [FromServices] ICommandDispatchService<CommitBindingCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> bindingDispatch,
+        [FromServices] ILoggerFactory loggerFactory,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var logger = loggerFactory.CreateLogger("Aevatar.Studio.NyxIdLoginFinalization");
+
+        if (string.IsNullOrWhiteSpace(request.Code))
+            return Results.BadRequest(new { error = "code_missing" });
+        if (string.IsNullOrWhiteSpace(request.CodeVerifier))
+            return Results.BadRequest(new { error = "code_verifier_missing" });
+        if (string.IsNullOrWhiteSpace(request.RedirectUri))
+            return Results.BadRequest(new { error = "redirect_uri_missing" });
+
+        BrokerAuthorizationCodeResult exchange;
+        try
+        {
+            exchange = await brokerCallback
+                .ExchangeAuthorizationCodeAsync(request.Code.Trim(), request.CodeVerifier.Trim(), request.RedirectUri.Trim(), ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "NyxID login finalization authorization-code exchange failed.");
+            return Results.Json(new
+            {
+                error = "token_exchange_failed",
+                detail = "NyxID login finalization failed during authorization-code exchange.",
+            }, statusCode: StatusCodes.Status502BadGateway);
+        }
+
+        if (string.IsNullOrWhiteSpace(exchange.BindingId))
+        {
+            return Results.Json(new
+            {
+                error = "broker_capability_disabled",
+                detail = "NyxID did not return a broker binding id for this login.",
+            }, statusCode: StatusCodes.Status409Conflict);
+        }
+
+        if (string.IsNullOrWhiteSpace(exchange.AccessToken))
+        {
+            return Results.Json(new
+            {
+                error = "access_token_missing",
+                detail = "NyxID did not return an access token for this login.",
+            }, statusCode: StatusCodes.Status502BadGateway);
+        }
+
+        var user = ResolveUserInfo(exchange.IdToken);
+        if (string.IsNullOrWhiteSpace(user.Sub))
+        {
+            await TryRevokeOrphanBindingAsync(brokerCallback, exchange.BindingId, logger, ct).ConfigureAwait(false);
+            return Results.Json(new
+            {
+                error = "subject_missing",
+                detail = "NyxID login finalization could not resolve a stable user subject.",
+            }, statusCode: StatusCodes.Status502BadGateway);
+        }
+
+        var subject = new ExternalSubjectRef
+        {
+            Platform = OwnerScope.NyxIdPlatform,
+            Tenant = string.Empty,
+            ExternalUserId = user.Sub.Trim(),
+        };
+
+        var existingBinding = await bindingQueryPort.ResolveAsync(subject, ct).ConfigureAwait(false);
+        if (existingBinding != null)
+        {
+            if (!string.Equals(existingBinding.Value, exchange.BindingId, StringComparison.Ordinal))
+                await TryRevokeOrphanBindingAsync(brokerCallback, exchange.BindingId, logger, ct).ConfigureAwait(false);
+
+            return Results.Ok(BuildResponse(exchange, user, bindingDispatchAccepted: false));
+        }
+
+        CommandDispatchResult<ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> accepted;
+        try
+        {
+            accepted = await bindingDispatch.DispatchAsync(new CommitBindingCommand
+            {
+                ExternalSubject = subject,
+                BindingId = exchange.BindingId.Trim(),
+            }, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "NyxID login finalization failed to dispatch CommitBindingCommand for {Platform}:{Tenant}:{User}.",
+                subject.Platform,
+                subject.Tenant,
+                subject.ExternalUserId);
+            await TryRevokeOrphanBindingAsync(brokerCallback, exchange.BindingId, logger, ct).ConfigureAwait(false);
+            return Results.Json(new
+            {
+                error = "actor_dispatch_failed",
+                detail = "NyxID owner binding could not be queued for local persistence.",
+            }, statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        if (!accepted.Succeeded || accepted.Receipt == null)
+        {
+            logger.LogError("NyxID login finalization binding dispatch rejected: error={Error}.", accepted.Error);
+            await TryRevokeOrphanBindingAsync(brokerCallback, exchange.BindingId, logger, ct).ConfigureAwait(false);
+            return Results.Json(new
+            {
+                error = "actor_dispatch_rejected",
+                detail = "NyxID owner binding was rejected by the local persistence queue.",
+            }, statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        return Results.Ok(BuildResponse(exchange, user, bindingDispatchAccepted: true));
+    }
+
+    private static NyxIdLoginFinalizationResponse BuildResponse(
+        BrokerAuthorizationCodeResult exchange,
+        NyxIdFinalizedUserInfo user,
+        bool bindingDispatchAccepted) =>
+        new(
+            Tokens: new NyxIdFinalizedTokenSet(
+                AccessToken: exchange.AccessToken ?? string.Empty,
+                TokenType: string.IsNullOrWhiteSpace(exchange.TokenType) ? "Bearer" : exchange.TokenType,
+                ExpiresIn: exchange.ExpiresIn ?? 3600,
+                IdToken: exchange.IdToken,
+                Scope: exchange.Scope),
+            User: user,
+            BindingDispatchAccepted: bindingDispatchAccepted);
+
+    private static NyxIdFinalizedUserInfo ResolveUserInfo(string? idToken)
+    {
+        var payload = TryReadJwtPayload(idToken);
+        return new NyxIdFinalizedUserInfo(
+            Sub: ReadString(payload, "uid") ?? ReadString(payload, "sub") ?? string.Empty,
+            Email: ReadString(payload, "email"),
+            EmailVerified: ReadBool(payload, "email_verified"),
+            Name: ReadString(payload, "name"),
+            Picture: ReadString(payload, "picture"),
+            Roles: ReadStringArray(payload, "roles"),
+            Groups: ReadStringArray(payload, "groups"),
+            Permissions: ReadStringArray(payload, "permissions"));
+    }
+
+    private static JsonElement? TryReadJwtPayload(string? jwt)
+    {
+        if (string.IsNullOrWhiteSpace(jwt))
+            return null;
+
+        var parts = jwt.Split('.');
+        if (parts.Length < 2)
+            return null;
+
+        try
+        {
+            var payload = parts[1].Replace('-', '+').Replace('_', '/');
+            payload = payload.PadRight(payload.Length + (4 - payload.Length % 4) % 4, '=');
+            var bytes = Convert.FromBase64String(payload);
+            using var document = JsonDocument.Parse(bytes);
+            return document.RootElement.Clone();
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? ReadString(JsonElement? payload, string propertyName)
+    {
+        if (payload is not { } element)
+            return null;
+        return element.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+    }
+
+    private static bool? ReadBool(JsonElement? payload, string propertyName)
+    {
+        if (payload is not { } element)
+            return null;
+        if (!element.TryGetProperty(propertyName, out var property))
+            return null;
+        return property.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            _ => null,
+        };
+    }
+
+    private static IReadOnlyList<string>? ReadStringArray(JsonElement? payload, string propertyName)
+    {
+        if (payload is not { } element)
+            return null;
+        if (!element.TryGetProperty(propertyName, out var property) || property.ValueKind != JsonValueKind.Array)
+            return null;
+
+        var values = new List<string>();
+        foreach (var item in property.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.String && !string.IsNullOrWhiteSpace(item.GetString()))
+                values.Add(item.GetString()!);
+        }
+
+        return values;
+    }
+
+    private static async Task TryRevokeOrphanBindingAsync(
+        INyxIdBrokerCallbackClient brokerCallback,
+        string bindingId,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        try
+        {
+            await brokerCallback.RevokeBindingByIdAsync(bindingId, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to revoke orphan NyxID login binding {BindingId}.", bindingId);
+        }
+    }
+}
+
+public sealed record NyxIdLoginConfigurationResponse(
+    string BaseUrl,
+    string ClientId,
+    string Scope);
+
+public sealed record NyxIdLoginFinalizationRequest
+{
+    public string? Code { get; init; }
+    public string? CodeVerifier { get; init; }
+    public string? RedirectUri { get; init; }
+}
+
+public sealed record NyxIdLoginFinalizationResponse(
+    NyxIdFinalizedTokenSet Tokens,
+    NyxIdFinalizedUserInfo User,
+    bool BindingDispatchAccepted);
+
+public sealed record NyxIdFinalizedTokenSet(
+    string AccessToken,
+    string TokenType,
+    int ExpiresIn,
+    string? IdToken,
+    string? Scope);
+
+public sealed record NyxIdFinalizedUserInfo(
+    string Sub,
+    string? Email = null,
+    bool? EmailVerified = null,
+    string? Name = null,
+    string? Picture = null,
+    IReadOnlyList<string>? Roles = null,
+    IReadOnlyList<string>? Groups = null,
+    IReadOnlyList<string>? Permissions = null);

--- a/src/Aevatar.Studio.Hosting/Endpoints/NyxIdLoginFinalizationEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/NyxIdLoginFinalizationEndpoints.cs
@@ -45,7 +45,8 @@ public static class NyxIdLoginFinalizationEndpoints
                 ClientId: snapshot.ClientId,
                 Scope: string.IsNullOrWhiteSpace(snapshot.OauthScope)
                     ? AevatarOAuthClientScopes.AuthorizationScope
-                    : snapshot.OauthScope.Trim()));
+                    : snapshot.OauthScope.Trim(),
+                RedirectUri: ResolveStudioLoginRedirectUri(snapshot)));
         }
         catch (AevatarOAuthClientNotProvisionedException)
         {
@@ -60,6 +61,7 @@ public static class NyxIdLoginFinalizationEndpoints
     internal static async Task<IResult> HandleFinalizeAsync(
         NyxIdLoginFinalizationRequest request,
         [FromServices] INyxIdBrokerCallbackClient brokerCallback,
+        [FromServices] IAevatarOAuthClientProvider oauthClientProvider,
         [FromServices] IExternalIdentityBindingQueryPort bindingQueryPort,
         [FromServices] ICommandDispatchService<CommitBindingCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> bindingDispatch,
         [FromServices] ILoggerFactory loggerFactory,
@@ -75,11 +77,39 @@ public static class NyxIdLoginFinalizationEndpoints
         if (string.IsNullOrWhiteSpace(request.RedirectUri))
             return Results.BadRequest(new { error = "redirect_uri_missing" });
 
+        string expectedRedirectUri;
+        try
+        {
+            expectedRedirectUri = ResolveStudioLoginRedirectUri(await oauthClientProvider.GetAsync(ct).ConfigureAwait(false));
+        }
+        catch (AevatarOAuthClientNotProvisionedException)
+        {
+            return Results.Json(new
+            {
+                error = "oauth_client_not_provisioned",
+                detail = "Aevatar OAuth client has not been provisioned at NyxID yet.",
+            }, statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        var postedRedirectUri = request.RedirectUri.Trim();
+        if (!string.Equals(postedRedirectUri, expectedRedirectUri, StringComparison.Ordinal))
+        {
+            logger.LogWarning(
+                "NyxID login finalization rejected redirect URI mismatch: posted='{Posted}', expected='{Expected}'.",
+                postedRedirectUri,
+                expectedRedirectUri);
+            return Results.BadRequest(new
+            {
+                error = "redirect_uri_mismatch",
+                detail = "NyxID login redirect_uri does not match the registered Studio login callback for the broker client.",
+            });
+        }
+
         BrokerAuthorizationCodeResult exchange;
         try
         {
             exchange = await brokerCallback
-                .ExchangeAuthorizationCodeAsync(request.Code.Trim(), request.CodeVerifier.Trim(), request.RedirectUri.Trim(), ct)
+                .ExchangeAuthorizationCodeAsync(request.Code.Trim(), request.CodeVerifier.Trim(), postedRedirectUri, ct)
                 .ConfigureAwait(false);
         }
         catch (Exception ex)
@@ -284,12 +314,24 @@ public static class NyxIdLoginFinalizationEndpoints
             logger.LogWarning(ex, "Failed to revoke orphan NyxID login binding {BindingId}.", bindingId);
         }
     }
+
+    private static string ResolveStudioLoginRedirectUri(AevatarOAuthClientSnapshot snapshot)
+    {
+        if (string.IsNullOrWhiteSpace(snapshot.StudioLoginRedirectUri))
+        {
+            throw new AevatarOAuthClientNotProvisionedException(
+                "Aevatar OAuth client is missing the registered Studio login redirect URI. Bootstrap must re-run DCR.");
+        }
+
+        return snapshot.StudioLoginRedirectUri.Trim();
+    }
 }
 
 public sealed record NyxIdLoginConfigurationResponse(
     string BaseUrl,
     string ClientId,
-    string Scope);
+    string Scope,
+    string RedirectUri);
 
 public sealed record NyxIdLoginFinalizationRequest
 {

--- a/src/Aevatar.Studio.Hosting/StudioCapabilityExtensions.cs
+++ b/src/Aevatar.Studio.Hosting/StudioCapabilityExtensions.cs
@@ -61,6 +61,7 @@ public static class StudioCapabilityExtensions
                 StudioEndpoints.Map(app, embeddedWorkflowMode: true);
                 StudioMemberEndpoints.Map(app);
                 StudioTeamEndpoints.Map(app);
+                NyxIdLoginFinalizationEndpoints.Map(app);
                 Controllers.ChatHistoryEndpoints.MapChatHistoryEndpoints(app);
                 app.MapExplorerEndpoints();
             });

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientBootstrapServiceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientBootstrapServiceTests.cs
@@ -25,6 +25,7 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
         var command = dispatch.Commands[0];
         command.NyxidAuthority.Should().Be(environment.Authority);
         command.RedirectUri.Should().Be(environment.RedirectUri);
+        command.StudioLoginRedirectUri.Should().Be(environment.StudioLoginRedirectUri);
         command.ClientName.Should().Be("aevatar");
     }
 
@@ -42,6 +43,7 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
         var command = dispatch.Commands[0];
         command.NyxidAuthority.Should().Be(environment.Authority);
         command.RedirectUri.Should().Be(environment.RedirectUri);
+        command.StudioLoginRedirectUri.Should().Be(environment.StudioLoginRedirectUri);
         command.ClientName.Should().Be("aevatar");
     }
 
@@ -141,23 +143,29 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
     {
         private readonly string? _oldAuthority;
         private readonly string? _oldRedirectBaseUrl;
+        private readonly string? _oldStudioLoginRedirectBaseUrl;
 
         public string Authority { get; } = "https://nyxid.test";
         public string RedirectBaseUrl { get; } = "https://aevatar.test";
         public string RedirectUri => $"{RedirectBaseUrl}{NyxIdRedirectUriResolver.CallbackPath}";
+        public string StudioLoginRedirectBaseUrl { get; } = "https://dashboard.example";
+        public string StudioLoginRedirectUri => $"{StudioLoginRedirectBaseUrl}{NyxIdStudioLoginRedirectUriResolver.CallbackPath}";
 
         public OAuthBootstrapEnvironment()
         {
             _oldAuthority = Environment.GetEnvironmentVariable(NyxIdAuthorityResolver.OverrideEnvVar);
             _oldRedirectBaseUrl = Environment.GetEnvironmentVariable(NyxIdRedirectUriResolver.OverrideEnvVar);
+            _oldStudioLoginRedirectBaseUrl = Environment.GetEnvironmentVariable(NyxIdStudioLoginRedirectUriResolver.OverrideEnvVar);
             Environment.SetEnvironmentVariable(NyxIdAuthorityResolver.OverrideEnvVar, Authority);
             Environment.SetEnvironmentVariable(NyxIdRedirectUriResolver.OverrideEnvVar, RedirectBaseUrl);
+            Environment.SetEnvironmentVariable(NyxIdStudioLoginRedirectUriResolver.OverrideEnvVar, StudioLoginRedirectBaseUrl);
         }
 
         public void Dispose()
         {
             Environment.SetEnvironmentVariable(NyxIdAuthorityResolver.OverrideEnvVar, _oldAuthority);
             Environment.SetEnvironmentVariable(NyxIdRedirectUriResolver.OverrideEnvVar, _oldRedirectBaseUrl);
+            Environment.SetEnvironmentVariable(NyxIdStudioLoginRedirectUriResolver.OverrideEnvVar, _oldStudioLoginRedirectBaseUrl);
         }
     }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
@@ -78,14 +78,20 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         {
             NyxidAuthority = "https://nyxid.test",
             RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            StudioLoginRedirectUri = "https://dashboard.example/auth/callback",
             ClientName = "aevatar",
         });
 
         _registrar.Calls.Should().HaveCount(1);
         _registrar.Calls[0].Authority.Should().Be("https://nyxid.test");
         _registrar.Calls[0].RedirectUri.Should().Be("https://aevatar.test/api/oauth/nyxid-callback");
+        _registrar.Calls[0].RedirectUris.Should().BeEquivalentTo([
+            "https://aevatar.test/api/oauth/nyxid-callback",
+            "https://dashboard.example/auth/callback",
+        ]);
         _agent.State.ClientId.Should().Be(_registrar.NextClientId);
         _agent.State.NyxidAuthority.Should().Be("https://nyxid.test");
+        _agent.State.StudioLoginRedirectUri.Should().Be("https://dashboard.example/auth/callback");
         _agent.State.OauthScope.Should().Be(AevatarOAuthClientScopes.AuthorizationScope);
         _agent.State.HmacKey.Length.Should().Be(32);
         _agent.State.ProvisioningRetryAttempt.Should().Be(0);
@@ -98,6 +104,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         {
             NyxidAuthority = "https://nyxid.test",
             RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            StudioLoginRedirectUri = "https://dashboard.example/auth/callback",
             ClientName = "aevatar",
         };
 
@@ -130,6 +137,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         {
             NyxidAuthority = "https://nyxid.test",
             RedirectUri = "http://+:8080/api/oauth/nyxid-callback",
+            StudioLoginRedirectUri = "https://dashboard.example/auth/callback",
         });
         var firstClientId = _agent.State.ClientId;
         _agent.State.RedirectUri.Should().Be("http://+:8080/api/oauth/nyxid-callback",
@@ -140,6 +148,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         {
             NyxidAuthority = "https://nyxid.test",
             RedirectUri = "https://aevatar-console-backend-api.aevatar.ai/api/oauth/nyxid-callback",
+            StudioLoginRedirectUri = "https://dashboard.example/auth/callback",
         });
 
         _registrar.Calls.Should().HaveCount(2,
@@ -168,6 +177,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         {
             NyxidAuthority = "https://nyxid.test",
             RedirectUri = "https://aevatar-console-backend-api.aevatar.ai/api/oauth/nyxid-callback",
+            StudioLoginRedirectUri = "https://dashboard.example/auth/callback",
         });
 
         _registrar.Calls.Should().ContainSingle(
@@ -184,12 +194,14 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         {
             NyxidAuthority = "https://nyxid.test",
             RedirectUri = redirectUri,
+            StudioLoginRedirectUri = "https://dashboard.example/auth/callback",
         });
 
         await _agent.HandleEnsureProvisioned(new EnsureAevatarOAuthClientProvisionedCommand
         {
             NyxidAuthority = "https://nyxid.test",
             RedirectUri = redirectUri,
+            StudioLoginRedirectUri = "https://dashboard.example/auth/callback",
         });
 
         _registrar.Calls.Should().HaveCount(1, "matching redirect URI must not re-DCR");
@@ -203,6 +215,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         {
             NyxidAuthority = "https://nyxid.test",
             RedirectUri = redirectUri,
+            StudioLoginRedirectUri = "https://dashboard.example/auth/callback",
         };
 
         await _agent.HandleEnsureProvisioned(cmd);
@@ -229,6 +242,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         {
             NyxidAuthority = "https://nyxid.test",
             RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            StudioLoginRedirectUri = "https://dashboard.example/auth/callback",
             ClientName = "aevatar",
         });
 
@@ -255,6 +269,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         {
             NyxidAuthority = "https://nyxid.test",
             RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            StudioLoginRedirectUri = "https://dashboard.example/auth/callback",
             ClientName = "aevatar",
         };
 
@@ -281,6 +296,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
             DueUnixMs = _agent.State.ProvisioningRetryDueUnixMs,
             NyxidAuthority = _agent.State.ProvisioningRetryAuthority,
             RedirectUri = _agent.State.ProvisioningRetryRedirectUri,
+            StudioLoginRedirectUri = _agent.State.ProvisioningRetryStudioLoginRedirectUri,
             ClientName = _agent.State.ProvisioningRetryClientName,
             CallbackId = _agent.State.ProvisioningRetryCallbackId,
             CallbackGeneration = _agent.State.ProvisioningRetryCallbackGeneration,
@@ -301,6 +317,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         {
             NyxidAuthority = "https://nyxid.test",
             RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            StudioLoginRedirectUri = "https://dashboard.example/auth/callback",
             ClientName = "aevatar",
         });
 
@@ -312,6 +329,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
             DueUnixMs = _agent.State.ProvisioningRetryDueUnixMs,
             NyxidAuthority = _agent.State.ProvisioningRetryAuthority,
             RedirectUri = _agent.State.ProvisioningRetryRedirectUri,
+            StudioLoginRedirectUri = _agent.State.ProvisioningRetryStudioLoginRedirectUri,
             ClientName = _agent.State.ProvisioningRetryClientName,
             CallbackId = _agent.State.ProvisioningRetryCallbackId,
             CallbackGeneration = _agent.State.ProvisioningRetryCallbackGeneration,
@@ -335,6 +353,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         {
             NyxidAuthority = "https://nyxid.test",
             RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            StudioLoginRedirectUri = "https://dashboard.example/auth/callback",
         });
 
         _registrar.ThrowOnRegister = null;
@@ -344,6 +363,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
             DueUnixMs = _agent.State.ProvisioningRetryDueUnixMs,
             NyxidAuthority = _agent.State.ProvisioningRetryAuthority,
             RedirectUri = _agent.State.ProvisioningRetryRedirectUri,
+            StudioLoginRedirectUri = _agent.State.ProvisioningRetryStudioLoginRedirectUri,
             ClientName = _agent.State.ProvisioningRetryClientName,
             CallbackId = _agent.State.ProvisioningRetryCallbackId,
             CallbackGeneration = _agent.State.ProvisioningRetryCallbackGeneration,
@@ -362,6 +382,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         {
             NyxidAuthority = "https://nyxid.test",
             RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            StudioLoginRedirectUri = "https://dashboard.example/auth/callback",
         });
 
         _registrar.ThrowOnRegister = new InvalidOperationException("second failure");
@@ -371,6 +392,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
             DueUnixMs = _agent.State.ProvisioningRetryDueUnixMs,
             NyxidAuthority = _agent.State.ProvisioningRetryAuthority,
             RedirectUri = _agent.State.ProvisioningRetryRedirectUri,
+            StudioLoginRedirectUri = _agent.State.ProvisioningRetryStudioLoginRedirectUri,
             ClientName = _agent.State.ProvisioningRetryClientName,
             CallbackId = _agent.State.ProvisioningRetryCallbackId,
             CallbackGeneration = _agent.State.ProvisioningRetryCallbackGeneration,
@@ -391,6 +413,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         {
             NyxidAuthority = "https://prod.nyxid.test",
             RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            StudioLoginRedirectUri = "https://dashboard.example/auth/callback",
         });
         var firstClientId = _agent.State.ClientId;
 
@@ -399,6 +422,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         {
             NyxidAuthority = "https://staging.nyxid.test",
             RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            StudioLoginRedirectUri = "https://dashboard.example/auth/callback",
         });
 
         _registrar.Calls.Should().HaveCount(2);
@@ -418,6 +442,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         {
             NyxidAuthority = string.Empty,
             RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            StudioLoginRedirectUri = "https://dashboard.example/auth/callback",
         });
         _agent.State.ClientId.Should().BeEmpty();
 
@@ -617,6 +642,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         {
             NyxidAuthority = "https://nyxid.test",
             RedirectUri = "http://+:8080/api/oauth/nyxid-callback",
+            StudioLoginRedirectUri = "https://dashboard.example/auth/callback",
         });
 
         var resolvedRedirect = "https://aevatar-console-backend-api.aevatar.ai/api/oauth/nyxid-callback";
@@ -638,6 +664,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
                 ClientIdIssuedAtUnix = 1700000001,
                 NyxidAuthority = "https://nyxid.test",
                 RedirectUri = resolvedRedirect,
+                StudioLoginRedirectUri = "https://dashboard.example/auth/callback",
                 OauthScope = AevatarOAuthClientScopes.AuthorizationScope,
                 PersistedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
             };
@@ -661,6 +688,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         {
             NyxidAuthority = "https://nyxid.test",
             RedirectUri = resolvedRedirect,
+            StudioLoginRedirectUri = "https://dashboard.example/auth/callback",
         });
 
         // Loser absorbed the OCC: state reflects the peer's commit, NOT
@@ -683,6 +711,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         {
             NyxidAuthority = "https://nyxid.test",
             RedirectUri = "http://+:8080/api/oauth/nyxid-callback",
+            StudioLoginRedirectUri = "https://dashboard.example/auth/callback",
         });
 
         _registrar.NextClientId = "loser-orphan-client";
@@ -720,6 +749,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         {
             NyxidAuthority = "https://nyxid.test",
             RedirectUri = "https://aevatar-console-backend-api.aevatar.ai/api/oauth/nyxid-callback",
+            StudioLoginRedirectUri = "https://dashboard.example/auth/callback",
         });
 
         _agent.State.RedirectUri.Should().Be("http://+:8080/api/oauth/nyxid-callback");
@@ -749,7 +779,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
     private sealed class RecordingDcrClient
     {
         public string NextClientId { get; set; } = "client-first";
-        public List<(string Authority, string ClientName, string RedirectUri)> Calls { get; } = new();
+        public List<DcrCall> Calls { get; } = new();
         public Exception? ThrowOnRegister { get; set; }
 
         /// <summary>
@@ -775,7 +805,13 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
             public override async Task<RegistrationResult> RegisterPublicClientAsync(
                 string authority, string clientName, string redirectUri, CancellationToken ct = default)
             {
-                _owner.Calls.Add((authority, clientName, redirectUri));
+                return await RegisterPublicClientAsync(authority, clientName, [redirectUri], ct).ConfigureAwait(false);
+            }
+
+            public override async Task<RegistrationResult> RegisterPublicClientAsync(
+                string authority, string clientName, IReadOnlyCollection<string> redirectUris, CancellationToken ct = default)
+            {
+                _owner.Calls.Add(new DcrCall(authority, clientName, redirectUris.ToArray()));
                 if (_owner.OnRegistered is not null)
                     await _owner.OnRegistered().ConfigureAwait(false);
                 if (_owner.ThrowOnRegister is not null)
@@ -788,6 +824,11 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         {
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
                 throw new InvalidOperationException("HTTP client must not be invoked in unit tests");
+        }
+
+        public sealed record DcrCall(string Authority, string ClientName, IReadOnlyList<string> RedirectUris)
+        {
+            public string RedirectUri => RedirectUris[0];
         }
     }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdDynamicClientRegistrationClientTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdDynamicClientRegistrationClientTests.cs
@@ -36,6 +36,35 @@ public sealed class NyxIdDynamicClientRegistrationClientTests
         handler.Last!.RequestUri!.AbsoluteUri.Should().Be("https://nyxid.test/oauth/register");
         var request = await handler.Last.Content!.ReadFromJsonAsync<JsonElement>();
         request.GetProperty("scope").GetString().Should().Be(AevatarOAuthClientScopes.AuthorizationScope);
+        request.GetProperty("redirect_uris").EnumerateArray()
+            .Select(static value => value.GetString())
+            .Should()
+            .BeEquivalentTo(["https://aevatar.test/api/oauth/nyxid-callback"]);
+    }
+
+    [Fact]
+    public async Task RegisterPublicClient_SendsAllRegisteredRedirectUris()
+    {
+        var handler = StubHandler.Json(HttpStatusCode.OK, new { client_id = "client-issued" });
+        var registrar = new NyxIdDynamicClientRegistrationClient(
+            new HttpClient(handler), NullLogger<NyxIdDynamicClientRegistrationClient>.Instance);
+
+        await registrar.RegisterPublicClientAsync(
+            "https://nyxid.test",
+            "aevatar",
+            [
+                "https://aevatar.test/api/oauth/nyxid-callback",
+                "https://dashboard.example/auth/callback",
+            ]);
+
+        var request = await handler.Last!.Content!.ReadFromJsonAsync<JsonElement>();
+        request.GetProperty("redirect_uris").EnumerateArray()
+            .Select(static value => value.GetString())
+            .Should()
+            .BeEquivalentTo([
+                "https://aevatar.test/api/oauth/nyxid-callback",
+                "https://dashboard.example/auth/callback",
+            ]);
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRedirectUriResolverTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRedirectUriResolverTests.cs
@@ -17,16 +17,20 @@ namespace Aevatar.GAgents.ChannelRuntime.Tests.Identity;
 public sealed class NyxIdRedirectUriResolverTests : IDisposable
 {
     private readonly string? _savedOverride;
+    private readonly string? _savedStudioLoginOverride;
 
     public NyxIdRedirectUriResolverTests()
     {
         _savedOverride = Environment.GetEnvironmentVariable(NyxIdRedirectUriResolver.OverrideEnvVar);
+        _savedStudioLoginOverride = Environment.GetEnvironmentVariable(NyxIdStudioLoginRedirectUriResolver.OverrideEnvVar);
         Environment.SetEnvironmentVariable(NyxIdRedirectUriResolver.OverrideEnvVar, null);
+        Environment.SetEnvironmentVariable(NyxIdStudioLoginRedirectUriResolver.OverrideEnvVar, null);
     }
 
     public void Dispose()
     {
         Environment.SetEnvironmentVariable(NyxIdRedirectUriResolver.OverrideEnvVar, _savedOverride);
+        Environment.SetEnvironmentVariable(NyxIdStudioLoginRedirectUriResolver.OverrideEnvVar, _savedStudioLoginOverride);
     }
 
     [Fact]
@@ -110,5 +114,37 @@ public sealed class NyxIdRedirectUriResolverTests : IDisposable
         {
             Environment.SetEnvironmentVariable("ASPNETCORE_URLS", savedAspnet);
         }
+    }
+
+    [Fact]
+    public void StudioLoginRedirect_DefaultsToProductionDashboardCallback()
+    {
+        var url = NyxIdStudioLoginRedirectUriResolver.Resolve();
+
+        url.Should().Be(
+            $"{NyxIdStudioLoginRedirectUriResolver.DefaultPublicBaseUrl}{NyxIdStudioLoginRedirectUriResolver.CallbackPath}");
+    }
+
+    [Fact]
+    public void StudioLoginRedirect_HonorsOverride()
+    {
+        Environment.SetEnvironmentVariable(NyxIdStudioLoginRedirectUriResolver.OverrideEnvVar, "https://dashboard.staging.example/");
+
+        var url = NyxIdStudioLoginRedirectUriResolver.Resolve();
+
+        url.Should().Be("https://dashboard.staging.example" + NyxIdStudioLoginRedirectUriResolver.CallbackPath);
+    }
+
+    [Theory]
+    [InlineData("http://+:8080")]
+    [InlineData("http://0.0.0.0:8080")]
+    public void StudioLoginRedirect_RejectsWildcardListenAddress(string wildcardOverride)
+    {
+        Environment.SetEnvironmentVariable(NyxIdStudioLoginRedirectUriResolver.OverrideEnvVar, wildcardOverride);
+
+        var url = NyxIdStudioLoginRedirectUriResolver.Resolve(NullLogger.Instance);
+
+        url.Should().Be(
+            $"{NyxIdStudioLoginRedirectUriResolver.DefaultPublicBaseUrl}{NyxIdStudioLoginRedirectUriResolver.CallbackPath}");
     }
 }

--- a/test/Aevatar.Studio.Tests/NyxIdLoginFinalizationEndpointsTests.cs
+++ b/test/Aevatar.Studio.Tests/NyxIdLoginFinalizationEndpointsTests.cs
@@ -1,0 +1,229 @@
+using System.Text;
+using System.Text.Json;
+using Aevatar.CQRS.Core.Abstractions.Commands;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.Channel.Abstractions;
+using Aevatar.GAgents.Channel.Identity;
+using Aevatar.GAgents.Channel.Identity.Abstractions;
+using Aevatar.GAgents.Channel.Identity.Broker;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.Studio.Hosting.Endpoints;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.Studio.Tests;
+
+public sealed class NyxIdLoginFinalizationEndpointsTests
+{
+    [Fact]
+    public async Task Config_ShouldReturnBrokerOAuthClientUsedByFinalizeExchange()
+    {
+        var result = await NyxIdLoginFinalizationEndpoints.HandleConfigAsync(
+            new StubAevatarOAuthClientProvider(new AevatarOAuthClientSnapshot(
+                ClientId: "broker-client-1",
+                ClientIdIssuedAt: DateTimeOffset.UnixEpoch,
+                HmacKid: "kid",
+                HmacKey: [1, 2, 3],
+                HmacKeyRotatedAt: DateTimeOffset.UnixEpoch,
+                NyxIdAuthority: "https://nyx.example/",
+                BrokerCapabilityObserved: true,
+                BrokerCapabilityObservedAt: DateTimeOffset.UnixEpoch,
+                OauthScope: "openid broker proxy")));
+
+        var (statusCode, payload) = await ExecuteJsonAsync<NyxIdLoginConfigurationResponse>(result);
+
+        statusCode.Should().Be(StatusCodes.Status200OK);
+        payload.Should().BeEquivalentTo(new NyxIdLoginConfigurationResponse(
+            "https://nyx.example",
+            "broker-client-1",
+            "openid broker proxy"));
+    }
+
+    [Fact]
+    public async Task Finalize_ShouldCommitOwnerBindingFromAuthorizationCodeExchange()
+    {
+        var broker = new RecordingBrokerCallback(new BrokerAuthorizationCodeResult(
+            BindingId: "bnd-owner-1",
+            IdToken: CreateIdToken(new { uid = "owner-user-1", email = "owner@example.com", name = "Owner" }),
+            AccessToken: "access-token")
+        {
+            TokenType = "Bearer",
+            ExpiresIn = 1800,
+            Scope = "openid profile proxy",
+        });
+        var queryPort = new FakeExternalIdentityBindingQueryPort();
+        var dispatch = new RecordingBindingDispatch();
+
+        var result = await NyxIdLoginFinalizationEndpoints.HandleFinalizeAsync(
+            new NyxIdLoginFinalizationRequest
+            {
+                Code = "auth-code",
+                CodeVerifier = "pkce-verifier",
+                RedirectUri = "http://localhost/auth/callback",
+            },
+            broker,
+            queryPort,
+            dispatch,
+            NullLoggerFactory.Instance);
+
+        var (statusCode, payload) = await ExecuteJsonAsync<NyxIdLoginFinalizationResponse>(result);
+
+        statusCode.Should().Be(StatusCodes.Status200OK);
+        broker.Exchanges.Should().ContainSingle().Which.Should()
+            .Be(("auth-code", "pkce-verifier", "http://localhost/auth/callback"));
+        payload.Should().NotBeNull();
+        payload!.BindingDispatchAccepted.Should().BeTrue();
+        payload.Tokens.AccessToken.Should().Be("access-token");
+        payload.Tokens.ExpiresIn.Should().Be(1800);
+        payload.User.Sub.Should().Be("owner-user-1");
+        payload.User.Email.Should().Be("owner@example.com");
+        dispatch.Commands.Should().ContainSingle().Which.Should().BeEquivalentTo(new CommitBindingCommand
+        {
+            ExternalSubject = new ExternalSubjectRef
+            {
+                Platform = OwnerScope.NyxIdPlatform,
+                Tenant = string.Empty,
+                ExternalUserId = "owner-user-1",
+            },
+            BindingId = "bnd-owner-1",
+        });
+    }
+
+    [Fact]
+    public async Task Finalize_ShouldReturnAcceptedSessionWithoutDispatch_WhenOwnerBindingAlreadyExists()
+    {
+        var broker = new RecordingBrokerCallback(new BrokerAuthorizationCodeResult(
+            BindingId: "bnd-new",
+            IdToken: CreateIdToken(new { uid = "owner-user-1" }),
+            AccessToken: "access-token"));
+        var queryPort = new FakeExternalIdentityBindingQueryPort();
+        queryPort.Bindings[SubjectKey(OwnerSubject("owner-user-1"))] = "bnd-existing";
+        var dispatch = new RecordingBindingDispatch();
+
+        var result = await NyxIdLoginFinalizationEndpoints.HandleFinalizeAsync(
+            new NyxIdLoginFinalizationRequest
+            {
+                Code = "auth-code",
+                CodeVerifier = "pkce-verifier",
+                RedirectUri = "http://localhost/auth/callback",
+            },
+            broker,
+            queryPort,
+            dispatch,
+            NullLoggerFactory.Instance);
+
+        var (statusCode, payload) = await ExecuteJsonAsync<NyxIdLoginFinalizationResponse>(result);
+
+        statusCode.Should().Be(StatusCodes.Status200OK);
+        payload!.BindingDispatchAccepted.Should().BeFalse();
+        dispatch.Commands.Should().BeEmpty();
+        broker.RevokedBindingIds.Should().ContainSingle().Which.Should().Be("bnd-new");
+    }
+
+    private static string CreateIdToken(object payload)
+    {
+        var header = Base64Url(JsonSerializer.SerializeToUtf8Bytes(new { alg = "none" }));
+        var body = Base64Url(JsonSerializer.SerializeToUtf8Bytes(payload));
+        return $"{header}.{body}.";
+    }
+
+    private static string Base64Url(byte[] bytes) =>
+        Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private static HttpContext NewHttpContext()
+    {
+        var services = new ServiceCollection()
+            .AddLogging()
+            .BuildServiceProvider();
+        var context = new DefaultHttpContext
+        {
+            RequestServices = services,
+        };
+        context.Response.Body = new MemoryStream();
+        return context;
+    }
+
+    private static async Task<(int StatusCode, T? Payload)> ExecuteJsonAsync<T>(IResult result)
+    {
+        var context = NewHttpContext();
+        await result.ExecuteAsync(context);
+        context.Response.Body.Position = 0;
+        var text = await new StreamReader(context.Response.Body, Encoding.UTF8).ReadToEndAsync();
+        return (context.Response.StatusCode, JsonSerializer.Deserialize<T>(text, new JsonSerializerOptions(JsonSerializerDefaults.Web)));
+    }
+
+    private static ExternalSubjectRef OwnerSubject(string externalUserId) =>
+        new()
+        {
+            Platform = OwnerScope.NyxIdPlatform,
+            Tenant = string.Empty,
+            ExternalUserId = externalUserId,
+        };
+
+    private static string SubjectKey(ExternalSubjectRef subject) =>
+        $"{subject.Platform}:{subject.Tenant}:{subject.ExternalUserId}";
+
+    private sealed class StubAevatarOAuthClientProvider(AevatarOAuthClientSnapshot snapshot) : IAevatarOAuthClientProvider
+    {
+        public Task<AevatarOAuthClientSnapshot> GetAsync(CancellationToken ct = default) =>
+            Task.FromResult(snapshot);
+    }
+
+    private sealed class RecordingBrokerCallback(BrokerAuthorizationCodeResult result) : INyxIdBrokerCallbackClient
+    {
+        public List<string> RevokedBindingIds { get; } = [];
+        public List<(string Code, string CodeVerifier, string RedirectUri)> Exchanges { get; } = [];
+
+        public Task<CallbackStateDecode> TryDecodeStateTokenAsync(string stateToken, CancellationToken ct = default) =>
+            Task.FromResult(CallbackStateDecode.Failed("not_supported"));
+
+        public Task<BrokerAuthorizationCodeResult> ExchangeAuthorizationCodeAsync(
+            string authorizationCode,
+            string codeVerifier,
+            CancellationToken ct = default) =>
+            Task.FromResult(result);
+
+        public Task<BrokerAuthorizationCodeResult> ExchangeAuthorizationCodeAsync(
+            string authorizationCode,
+            string codeVerifier,
+            string redirectUri,
+            CancellationToken ct = default)
+        {
+            Exchanges.Add((authorizationCode, codeVerifier, redirectUri));
+            return Task.FromResult(result);
+        }
+
+        public Task RevokeBindingByIdAsync(string bindingId, CancellationToken ct = default)
+        {
+            RevokedBindingIds.Add(bindingId);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeExternalIdentityBindingQueryPort : IExternalIdentityBindingQueryPort
+    {
+        public Dictionary<string, string> Bindings { get; } = new(StringComparer.Ordinal);
+
+        public Task<BindingId?> ResolveAsync(ExternalSubjectRef externalSubject, CancellationToken ct = default) =>
+            Task.FromResult(Bindings.TryGetValue(SubjectKey(externalSubject), out var bindingId)
+                ? new BindingId { Value = bindingId }
+                : null);
+    }
+
+    private sealed class RecordingBindingDispatch
+        : ICommandDispatchService<CommitBindingCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError>
+    {
+        public List<CommitBindingCommand> Commands { get; } = [];
+
+        public Task<CommandDispatchResult<ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError>> DispatchAsync(
+            CommitBindingCommand command,
+            CancellationToken ct = default)
+        {
+            Commands.Add(command);
+            return Task.FromResult(CommandDispatchResult<ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError>.Success(
+                new ChannelIdentityOAuthAcceptedReceipt("actor", "command", "correlation")));
+        }
+    }
+}

--- a/test/Aevatar.Studio.Tests/NyxIdLoginFinalizationEndpointsTests.cs
+++ b/test/Aevatar.Studio.Tests/NyxIdLoginFinalizationEndpointsTests.cs
@@ -30,7 +30,8 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
                 NyxIdAuthority: "https://nyx.example/",
                 BrokerCapabilityObserved: true,
                 BrokerCapabilityObservedAt: DateTimeOffset.UnixEpoch,
-                OauthScope: "openid broker proxy")));
+                OauthScope: "openid broker proxy",
+                StudioLoginRedirectUri: "https://dashboard.example/auth/callback")));
 
         var (statusCode, payload) = await ExecuteJsonAsync<NyxIdLoginConfigurationResponse>(result);
 
@@ -38,7 +39,8 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
         payload.Should().BeEquivalentTo(new NyxIdLoginConfigurationResponse(
             "https://nyx.example",
             "broker-client-1",
-            "openid broker proxy"));
+            "openid broker proxy",
+            "https://dashboard.example/auth/callback"));
     }
 
     [Fact]
@@ -61,9 +63,10 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
             {
                 Code = "auth-code",
                 CodeVerifier = "pkce-verifier",
-                RedirectUri = "http://localhost/auth/callback",
+                RedirectUri = "https://dashboard.example/auth/callback",
             },
             broker,
+            StudioLoginProvider(),
             queryPort,
             dispatch,
             NullLoggerFactory.Instance);
@@ -72,7 +75,7 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
 
         statusCode.Should().Be(StatusCodes.Status200OK);
         broker.Exchanges.Should().ContainSingle().Which.Should()
-            .Be(("auth-code", "pkce-verifier", "http://localhost/auth/callback"));
+            .Be(("auth-code", "pkce-verifier", "https://dashboard.example/auth/callback"));
         payload.Should().NotBeNull();
         payload!.BindingDispatchAccepted.Should().BeTrue();
         payload.Tokens.AccessToken.Should().Be("access-token");
@@ -107,9 +110,10 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
             {
                 Code = "auth-code",
                 CodeVerifier = "pkce-verifier",
-                RedirectUri = "http://localhost/auth/callback",
+                RedirectUri = "https://dashboard.example/auth/callback",
             },
             broker,
+            StudioLoginProvider(),
             queryPort,
             dispatch,
             NullLoggerFactory.Instance);
@@ -120,6 +124,37 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
         payload!.BindingDispatchAccepted.Should().BeFalse();
         dispatch.Commands.Should().BeEmpty();
         broker.RevokedBindingIds.Should().ContainSingle().Which.Should().Be("bnd-new");
+    }
+
+    [Fact]
+    public async Task Finalize_ShouldRejectRedirectUriMismatch_BeforeAuthorizationCodeExchange()
+    {
+        var broker = new RecordingBrokerCallback(new BrokerAuthorizationCodeResult(
+            BindingId: "bnd-owner-1",
+            IdToken: CreateIdToken(new { uid = "owner-user-1" }),
+            AccessToken: "access-token"));
+        var queryPort = new FakeExternalIdentityBindingQueryPort();
+        var dispatch = new RecordingBindingDispatch();
+
+        var result = await NyxIdLoginFinalizationEndpoints.HandleFinalizeAsync(
+            new NyxIdLoginFinalizationRequest
+            {
+                Code = "auth-code",
+                CodeVerifier = "pkce-verifier",
+                RedirectUri = "http://localhost/auth/callback",
+            },
+            broker,
+            StudioLoginProvider(),
+            queryPort,
+            dispatch,
+            NullLoggerFactory.Instance);
+
+        var (statusCode, payload) = await ExecuteJsonAsync<JsonElement>(result);
+
+        statusCode.Should().Be(StatusCodes.Status400BadRequest);
+        payload.GetProperty("error").GetString().Should().Be("redirect_uri_mismatch");
+        broker.Exchanges.Should().BeEmpty();
+        dispatch.Commands.Should().BeEmpty();
     }
 
     private static string CreateIdToken(object payload)
@@ -164,6 +199,19 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
 
     private static string SubjectKey(ExternalSubjectRef subject) =>
         $"{subject.Platform}:{subject.Tenant}:{subject.ExternalUserId}";
+
+    private static StubAevatarOAuthClientProvider StudioLoginProvider() =>
+        new(new AevatarOAuthClientSnapshot(
+            ClientId: "broker-client-1",
+            ClientIdIssuedAt: DateTimeOffset.UnixEpoch,
+            HmacKid: "kid",
+            HmacKey: [1, 2, 3],
+            HmacKeyRotatedAt: DateTimeOffset.UnixEpoch,
+            NyxIdAuthority: "https://nyx.example/",
+            BrokerCapabilityObserved: true,
+            BrokerCapabilityObservedAt: DateTimeOffset.UnixEpoch,
+            OauthScope: "openid broker proxy",
+            StudioLoginRedirectUri: "https://dashboard.example/auth/callback"));
 
     private sealed class StubAevatarOAuthClientProvider(AevatarOAuthClientSnapshot snapshot) : IAevatarOAuthClientProvider
     {


### PR DESCRIPTION
## Problem

Console NyxID login was starting authorization with the frontend-configured client, while backend Studio finalization exchanges the code with the backend broker OAuth client. OAuth authorization codes are client-bound, so this could fail with `invalid authorization code` when the two client IDs differ.

## Solution

- Add Studio NyxID login backend endpoints:
  - `GET /api/auth/nyxid/config`
  - `POST /api/auth/nyxid/finalize`
- Extend the NyxID broker callback client to exchange an authorization code with a caller-provided SPA redirect URI.
- Update Console login to build the authorize URL from backend `baseUrl/clientId/scope` and finalize via `/api/auth/nyxid/finalize`.
- Preserve PKCE state validation while allowing callback lookup across backend-client pending keys.
- Treat `bindingDispatchAccepted` as dispatch ACK only, not readmodel visibility.
- Add bounded retry for immediate schedule create/update when owner binding readmodel materialization briefly lags.

## Impact Paths

- `src/Aevatar.Studio.Hosting/Endpoints/NyxIdLoginFinalizationEndpoints.cs`
- `agents/Aevatar.GAgents.Channel.Identity/Broker/*`
- `apps/aevatar-console-web/src/shared/auth/*`
- `apps/aevatar-console-web/src/shared/api/scheduledDispatchApi.ts`

## Verification

- `dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --filter NyxIdLoginFinalizationEndpointsTests`
- `pnpm --dir apps/aevatar-console-web jest --selectProjects jsdom --runTestsByPath src/shared/auth/backend.test.ts src/shared/auth/client.test.ts src/shared/api/scheduledDispatchApi.test.ts --runInBand`
- `pnpm --dir apps/aevatar-console-web tsc`
- `pnpm --dir apps/aevatar-console-web build`
- `dotnet restore aevatar.slnx --nologo`
- `bash tools/ci/solution_split_guards.sh`
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/workflow_binding_boundary_guard.sh`
- `bash tools/ci/query_projection_priming_guard.sh`
- `bash tools/ci/projection_state_version_guard.sh`
- `bash tools/ci/projection_state_mirror_current_state_guard.sh`
- `bash tools/ci/architecture_guards.sh`

Fixes #2303
