### PR TITLE
递归禁用 Elasticsearch protobuf map 映射

### DIFF
--- a/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchProjectionDescriptorMappingSupport.cs
+++ b/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchProjectionDescriptorMappingSupport.cs
@@ -17,17 +17,15 @@ internal static class ElasticsearchProjectionDescriptorMappingSupport
 
         foreach (var field in descriptor.Fields.InDeclarationOrder())
         {
-            if (ShouldSkipField(field) || properties.ContainsKey(field.Name))
+            if (TryAugmentFieldMapping(field, properties, new HashSet<MessageDescriptor>()))
                 continue;
 
-            if (IsTimestampField(field))
+            if (!properties.ContainsKey(field.Name) &&
+                field.FieldType == FieldType.String &&
+                IsStableKeywordFieldName(field.Name))
             {
-                properties[field.Name] = CreateTypeMapping("date");
-                continue;
-            }
-
-            if (field.FieldType == FieldType.String && IsStableKeywordFieldName(field.Name))
                 properties[field.Name] = CreateTypeMapping("keyword");
+            }
         }
 
         mappings["properties"] = properties;
@@ -48,15 +46,36 @@ internal static class ElasticsearchProjectionDescriptorMappingSupport
         return new Dictionary<string, object?>(properties, StringComparer.Ordinal);
     }
 
-    private static bool ShouldSkipField(FieldDescriptor field)
+    private static bool TryAugmentFieldMapping(
+        FieldDescriptor field,
+        Dictionary<string, object?> properties,
+        HashSet<MessageDescriptor> ancestry)
     {
-        if (field.IsMap || field.IsRepeated)
+        if (field.IsMap)
+        {
+            properties.TryAdd(field.Name, CreateDisabledObjectMapping());
+            return true;
+        }
+
+        if (field.FieldType != FieldType.Message || field.MessageType == null)
+            return field.IsRepeated;
+
+        if (IsTimestampField(field))
+        {
+            if (!field.IsRepeated)
+                properties.TryAdd(field.Name, CreateTypeMapping("date"));
+
+            return true;
+        }
+
+        if (IsOpenMessage(field.MessageType))
             return true;
 
-        return field.FieldType == FieldType.Message &&
-               field.MessageType != null &&
-               (field.MessageType.FullName == Any.Descriptor.FullName ||
-                field.MessageType.FullName == Struct.Descriptor.FullName);
+        if (!ContainsMapField(field.MessageType, ancestry))
+            return field.IsRepeated;
+
+        AugmentMessageObjectMapping(field.Name, field.MessageType, properties, ancestry);
+        return true;
     }
 
     private static bool IsTimestampField(FieldDescriptor field)
@@ -64,6 +83,141 @@ internal static class ElasticsearchProjectionDescriptorMappingSupport
         return field.FieldType == FieldType.Message &&
                field.MessageType != null &&
                field.MessageType.FullName == Timestamp.Descriptor.FullName;
+    }
+
+    private static bool IsOpenMessage(MessageDescriptor descriptor)
+    {
+        return descriptor.FullName == Any.Descriptor.FullName ||
+               descriptor.FullName == Struct.Descriptor.FullName;
+    }
+
+    private static bool ContainsMapField(MessageDescriptor descriptor, HashSet<MessageDescriptor> ancestry)
+    {
+        if (!ancestry.Add(descriptor))
+            return false;
+
+        try
+        {
+            foreach (var field in descriptor.Fields.InDeclarationOrder())
+            {
+                if (field.IsMap)
+                    return true;
+
+                if (field.FieldType == FieldType.Message &&
+                    field.MessageType != null &&
+                    !IsOpenMessage(field.MessageType) &&
+                    ContainsMapField(field.MessageType, ancestry))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        finally
+        {
+            ancestry.Remove(descriptor);
+        }
+    }
+
+    private static void AugmentMessageObjectMapping(
+        string fieldName,
+        MessageDescriptor descriptor,
+        Dictionary<string, object?> properties,
+        HashSet<MessageDescriptor> ancestry)
+    {
+        if (properties.TryGetValue(fieldName, out var existingMapping))
+        {
+            TryAugmentExistingObjectMapping(fieldName, descriptor, properties, ancestry, existingMapping);
+            return;
+        }
+
+        var childProperties = new Dictionary<string, object?>(StringComparer.Ordinal);
+        AugmentMessageProperties(descriptor, childProperties, ancestry);
+        properties[fieldName] = CreateObjectMapping(childProperties);
+    }
+
+    private static void TryAugmentExistingObjectMapping(
+        string fieldName,
+        MessageDescriptor descriptor,
+        Dictionary<string, object?> properties,
+        HashSet<MessageDescriptor> ancestry,
+        object? existingMapping)
+    {
+        if (existingMapping is not IReadOnlyDictionary<string, object?> existingObject ||
+            IsDisabledObjectMapping(existingObject) ||
+            HasExplicitNonObjectType(existingObject))
+        {
+            return;
+        }
+
+        var augmentedChildProperties = ResolveChildProperties(existingObject);
+        AugmentMessageProperties(descriptor, augmentedChildProperties, ancestry);
+
+        var augmentedObject = new Dictionary<string, object?>(existingObject, StringComparer.Ordinal)
+        {
+            ["properties"] = augmentedChildProperties,
+        };
+
+        if (!augmentedObject.ContainsKey("type"))
+            augmentedObject["type"] = "object";
+
+        properties[fieldName] = augmentedObject;
+    }
+
+    private static Dictionary<string, object?> ResolveChildProperties(
+        IReadOnlyDictionary<string, object?> existingObject)
+    {
+        if (!existingObject.TryGetValue("properties", out var childPropertiesValue) ||
+            childPropertiesValue is not IReadOnlyDictionary<string, object?> existingChildProperties)
+        {
+            return new Dictionary<string, object?>(StringComparer.Ordinal);
+        }
+
+        return new Dictionary<string, object?>(existingChildProperties, StringComparer.Ordinal);
+    }
+
+    private static bool IsDisabledObjectMapping(IReadOnlyDictionary<string, object?> mapping)
+    {
+        return mapping.TryGetValue("enabled", out var enabledValue) &&
+               enabledValue is bool enabled &&
+               !enabled;
+    }
+
+    private static bool HasExplicitNonObjectType(IReadOnlyDictionary<string, object?> mapping)
+    {
+        return mapping.TryGetValue("type", out var typeValue) &&
+               typeValue is string typeName &&
+               !string.Equals(typeName, "object", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void AugmentMessageProperties(
+        MessageDescriptor descriptor,
+        Dictionary<string, object?> properties,
+        HashSet<MessageDescriptor> ancestry)
+    {
+        if (!ancestry.Add(descriptor))
+            return;
+
+        try
+        {
+            foreach (var field in descriptor.Fields.InDeclarationOrder())
+            {
+                if (TryAugmentFieldMapping(field, properties, ancestry))
+                    continue;
+
+                if (!properties.ContainsKey(field.Name) &&
+                    field.FieldType == FieldType.String &&
+                    IsStableKeywordFieldName(field.Name))
+                {
+                    properties[field.Name] = CreateTypeMapping("keyword");
+                }
+            }
+        }
+        finally
+        {
+            ancestry.Remove(descriptor);
+        }
     }
 
     private static bool IsStableKeywordFieldName(string fieldName)
@@ -88,6 +242,24 @@ internal static class ElasticsearchProjectionDescriptorMappingSupport
         return new Dictionary<string, object?>(StringComparer.Ordinal)
         {
             ["type"] = type,
+        };
+    }
+
+    private static Dictionary<string, object?> CreateDisabledObjectMapping()
+    {
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["type"] = "object",
+            ["enabled"] = false,
+        };
+    }
+
+    private static Dictionary<string, object?> CreateObjectMapping(Dictionary<string, object?> properties)
+    {
+        return new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["type"] = "object",
+            ["properties"] = properties,
         };
     }
 }

--- a/test/Aevatar.CQRS.Projection.Core.Tests/ElasticsearchProjectionDocumentStoreBehaviorTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/ElasticsearchProjectionDocumentStoreBehaviorTests.cs
@@ -243,7 +243,7 @@ public sealed class ElasticsearchProjectionDocumentStoreBehaviorTests
     }
 
     [Fact]
-    public async Task UpsertAsync_WhenDescriptorContainsOpenFields_ShouldNotInitializeStaticMappingsForThem()
+    public async Task UpsertAsync_WhenDescriptorContainsOpenFields_ShouldOnlySkipOpenMessagesAndRepeatedPrimitives()
     {
         var handler = CreateSuccessfulUpsertHandler();
         var options = new ElasticsearchProjectionDocumentStoreOptions
@@ -274,10 +274,138 @@ public sealed class ElasticsearchProjectionDocumentStoreBehaviorTests
         var properties = GetProperties(indexPayload);
         properties.Should().NotContainKey("fields_value");
         properties.Should().NotContainKey("open_payload");
-        properties.Should().NotContainKey("labels");
-        properties.Should().NotContainKey("entries");
         properties.Should().NotContainKey("tags");
+        GetMappingType(indexPayload, "labels").Should().Be("object");
+        GetFieldMapping(indexPayload, "labels").GetProperty("enabled").GetBoolean().Should().BeFalse();
         GetMappingType(indexPayload, "updated_at_utc_value").Should().Be("date");
+    }
+
+    [Fact]
+    public async Task UpsertAsync_WhenDescriptorContainsProtoMaps_ShouldDisableMapMappingsAndUseObjectParents()
+    {
+        var handler = CreateSuccessfulUpsertHandler();
+        var options = new ElasticsearchProjectionDocumentStoreOptions
+        {
+            AutoCreateIndex = true,
+        };
+        options.Endpoints = ["http://localhost:9200"];
+
+        using var store = new ElasticsearchProjectionDocumentStore<TestRecursiveWellKnownReadModel, string>(
+            options,
+            new DocumentIndexMetadata(
+                IndexName: "projection-core-tests",
+                Mappings: new Dictionary<string, object?>(),
+                Settings: new Dictionary<string, object?>(),
+                Aliases: new Dictionary<string, object?>()),
+            keySelector: model => model.Id,
+            keyFormatter: key => key,
+            httpMessageHandler: handler);
+
+        await store.UpsertAsync(new TestRecursiveWellKnownReadModel
+        {
+            Id = "actor-1",
+            ActorId = "actor-1",
+            UpdatedAt = DateTimeOffset.Parse("2026-05-15T00:00:00Z"),
+        });
+
+        var indexCreateRequest = GetIndexCreateRequest(handler);
+        var indexPayload = ParseJson(indexCreateRequest.Body);
+        var mappings = indexPayload.GetProperty("mappings");
+        mappings.TryGetProperty("dynamic", out _).Should().BeFalse();
+        indexCreateRequest.Body.Should().NotContain("\"nested\"");
+
+        GetMappingType(indexPayload, "labels").Should().Be("object");
+        GetFieldMapping(indexPayload, "labels").GetProperty("enabled").GetBoolean().Should().BeFalse();
+
+        GetMappingType(indexPayload, "primary_entry").Should().Be("object");
+        GetMappingType(indexPayload, "primary_entry", "entry_id").Should().Be("keyword");
+        GetMappingType(indexPayload, "primary_entry", "attributes").Should().Be("object");
+        GetFieldMapping(indexPayload, "primary_entry", "attributes")
+            .GetProperty("enabled")
+            .GetBoolean()
+            .Should()
+            .BeFalse();
+        GetMappingType(indexPayload, "primary_entry", "leaf").Should().Be("object");
+        GetMappingType(indexPayload, "primary_entry", "leaf", "leaf_id").Should().Be("keyword");
+        GetFieldMapping(indexPayload, "primary_entry", "leaf", "annotations")
+            .GetProperty("enabled")
+            .GetBoolean()
+            .Should()
+            .BeFalse();
+
+        GetMappingType(indexPayload, "entries").Should().Be("object");
+        GetFieldMapping(indexPayload, "entries").TryGetProperty("properties", out _).Should().BeTrue();
+        GetFieldMapping(indexPayload, "entries", "attributes")
+            .GetProperty("enabled")
+            .GetBoolean()
+            .Should()
+            .BeFalse();
+        GetMappingType(indexPayload, "child_entries").Should().Be("object");
+        GetFieldMapping(indexPayload, "child_entries", "leaf", "annotations")
+            .GetProperty("enabled")
+            .GetBoolean()
+            .Should()
+            .BeFalse();
+    }
+
+    [Fact]
+    public async Task UpsertAsync_WhenProviderDeclaresExplicitNestedMapMapping_ShouldPreserveExactPath()
+    {
+        var handler = CreateSuccessfulUpsertHandler();
+        var options = new ElasticsearchProjectionDocumentStoreOptions
+        {
+            AutoCreateIndex = true,
+        };
+        options.Endpoints = ["http://localhost:9200"];
+
+        using var store = new ElasticsearchProjectionDocumentStore<TestRecursiveWellKnownReadModel, string>(
+            options,
+            new DocumentIndexMetadata(
+                IndexName: "projection-core-tests",
+                Mappings: new Dictionary<string, object?>
+                {
+                    ["properties"] = new Dictionary<string, object?>
+                    {
+                        ["primary_entry"] = new Dictionary<string, object?>
+                        {
+                            ["type"] = "object",
+                            ["properties"] = new Dictionary<string, object?>
+                            {
+                                ["attributes"] = new Dictionary<string, object?>
+                                {
+                                    ["type"] = "object",
+                                    ["enabled"] = true,
+                                },
+                            },
+                        },
+                    },
+                },
+                Settings: new Dictionary<string, object?>(),
+                Aliases: new Dictionary<string, object?>()),
+            keySelector: model => model.Id,
+            keyFormatter: key => key,
+            httpMessageHandler: handler);
+
+        await store.UpsertAsync(new TestRecursiveWellKnownReadModel
+        {
+            Id = "actor-1",
+            ActorId = "actor-1",
+            UpdatedAt = DateTimeOffset.Parse("2026-05-15T00:00:00Z"),
+        });
+
+        var indexPayload = ParseJson(GetIndexCreateRequest(handler).Body);
+        GetMappingType(indexPayload, "primary_entry").Should().Be("object");
+        GetMappingType(indexPayload, "primary_entry", "attributes").Should().Be("object");
+        GetFieldMapping(indexPayload, "primary_entry", "attributes")
+            .GetProperty("enabled")
+            .GetBoolean()
+            .Should()
+            .BeTrue();
+        GetFieldMapping(indexPayload, "primary_entry", "leaf", "annotations")
+            .GetProperty("enabled")
+            .GetBoolean()
+            .Should()
+            .BeFalse();
     }
 
     [Fact]
@@ -1513,14 +1641,30 @@ public sealed class ElasticsearchProjectionDocumentStoreBehaviorTests
             .ToDictionary(x => x.Name, x => x.Value.Clone(), StringComparer.Ordinal);
     }
 
-    private static JsonElement GetFieldMapping(JsonElement indexPayload, string fieldName)
+    private static JsonElement GetFieldMapping(JsonElement indexPayload, params string[] fieldPath)
     {
-        return GetProperties(indexPayload)[fieldName];
+        fieldPath.Should().NotBeEmpty();
+
+        IReadOnlyDictionary<string, JsonElement> properties = GetProperties(indexPayload);
+        JsonElement mapping = default;
+        for (var index = 0; index < fieldPath.Length; index++)
+        {
+            mapping = properties[fieldPath[index]];
+            if (index == fieldPath.Length - 1)
+                return mapping;
+
+            properties = mapping
+                .GetProperty("properties")
+                .EnumerateObject()
+                .ToDictionary(x => x.Name, x => x.Value.Clone(), StringComparer.Ordinal);
+        }
+
+        throw new InvalidOperationException("The field path must contain at least one segment.");
     }
 
-    private static string? GetMappingType(JsonElement indexPayload, string fieldName)
+    private static string? GetMappingType(JsonElement indexPayload, params string[] fieldPath)
     {
-        return GetFieldMapping(indexPayload, fieldName).GetProperty("type").GetString();
+        return GetFieldMapping(indexPayload, fieldPath).GetProperty("type").GetString();
     }
 
     private static HttpResponseMessage CreateJsonResponse(HttpStatusCode statusCode, string json)

--- a/test/Aevatar.CQRS.Projection.Core.Tests/test_projection_read_models.proto
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/test_projection_read_models.proto
@@ -48,8 +48,17 @@ message TestRecursiveWellKnownReadModel {
   map<string, string> labels = 9;
   repeated TestOpenPayloadEntry entries = 10;
   repeated string tags = 11;
+  TestOpenPayloadEntry primary_entry = 12;
+  repeated TestOpenPayloadEntry child_entries = 13;
 }
 
 message TestOpenPayloadEntry {
   string entry_id = 1;
+  map<string, string> attributes = 2;
+  TestOpenPayloadLeaf leaf = 3;
+}
+
+message TestOpenPayloadLeaf {
+  string leaf_id = 1;
+  map<string, string> annotations = 2;
 }


### PR DESCRIPTION
## Changed files
- `ElasticsearchProjectionDescriptorMappingSupport` 现在递归识别 protobuf `map<>`，未显式覆盖的 map 映射为 `object` 且 `enabled:false`；包含 map 后代的 singular/repeated message 父节点映射为 `object + properties`。
- `ElasticsearchProjectionDocumentStoreBehaviorTests` 增加 root/nested map、repeated message、显式 nested exact-path override、无 `nested`、无 root `dynamic` 变更的行为断言。
- `test_projection_read_models.proto` 增加嵌套 map fixture。

## Test results
- `bash -lc "dotnet build aevatar.slnx --nologo"`：通过。
- `dotnet test test/Aevatar.CQRS.Projection.Core.Tests/Aevatar.CQRS.Projection.Core.Tests.csproj --filter ElasticsearchProjectionDocumentStoreBehaviorTests --nologo`：通过，49 passed。
- `bash tools/ci/query_projection_priming_guard.sh`：通过。
- `bash tools/ci/test_stability_guards.sh`：通过。
- `bash tools/ci/architecture_guards.sh`：通过。

## Deviations
- 无 scope extension。
- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)。
- Closes #2321

⟦AI:AUTO-LOOP⟧
