### PR TITLE
Reject create-time Studio member implementation refs

### DIFF
--- a/docs/2026-04-27-member-first-studio-apis.md
+++ b/docs/2026-04-27-member-first-studio-apis.md
@@ -19,6 +19,7 @@ The resolver is exposed through `IMemberPublishedServiceResolver`, so a later ac
 
 | Route | Purpose |
 |---|---|
+| `POST /api/scopes/{scopeId}/members` | Create a shell Studio member only. The request must omit `implementationRef`. |
 | `GET /api/scopes/{scopeId}/members/{memberId}/published-service` | Resolve the member-owned published service id. |
 | `GET /api/scopes/{scopeId}/members/{memberId}/binding` | Read the member authority's last successful binding and current async binding run. |
 | `PUT /api/scopes/{scopeId}/members/{memberId}/binding` | Start an async workflow/script/GAgent binding run for the member-owned published service. Returns `202 Accepted`. |
@@ -35,6 +36,8 @@ The resolver is exposed through `IMemberPublishedServiceResolver`, so a later ac
 ## Semantics
 
 - Member routes for Bind / Invoke / Observe-read / run lifecycle control do not require frontend callers to know or pass `serviceId`.
+- Member create is shell-only. `POST /api/scopes/{scopeId}/members` creates the member authority with lifecycle `created` and no `implementationRef`; workflow/script/GAgent implementation attachment is only accepted through post-create binding.
+- A create request that includes `implementationRef` returns `400 STUDIO_MEMBER_CREATE_IMPLEMENTATION_REF_NOT_ALLOWED` with `field = "implementationRef"`. Clients should omit `implementationRef`, create the shell member, then call `PUT /api/scopes/{scopeId}/members/{memberId}/binding`.
 - Binding writes are asynchronous. The `PUT /binding` response only means the command was accepted for dispatch and returns a stable `bindingRunId`; completion is observed through `GET /binding-runs/{bindingRunId}` or `GET /binding`.
 - Workflow binding requests must carry `workflow.workflowId` as the stable workflow identity. The first YAML document's `name` remains the runtime/display `workflowName` and may differ from `workflowId`; successful member binding returns the stable id in `implementationRef.workflow.workflowId`.
 - The binding-run `Location` is read-model backed and can be briefly unavailable immediately after `202 Accepted`. Clients should treat a short-lived `404` for the accepted run id as pending/read-model lag, not as terminal failure. Only explicit `failed` or `rejected` run status should surface as a binding error.

--- a/src/Aevatar.Studio.Application/Studio/Contracts/MemberContracts.cs
+++ b/src/Aevatar.Studio.Application/Studio/Contracts/MemberContracts.cs
@@ -202,6 +202,26 @@ public sealed record CreateStudioMemberRequest(
     string? TeamId = null,
     StudioMemberImplementationRefResponse? ImplementationRef = null);
 
+public sealed class StudioMemberCreateImplementationRefNotAllowedException : InvalidOperationException
+{
+    public const string ErrorCode = "STUDIO_MEMBER_CREATE_IMPLEMENTATION_REF_NOT_ALLOWED";
+    public const string FieldName = "implementationRef";
+    public const string BindingRouteTemplate = "PUT /api/scopes/{scopeId}/members/{memberId}/binding";
+
+    public StudioMemberCreateImplementationRefNotAllowedException(string scopeId)
+        : base(
+            "implementationRef is not accepted when creating a studio member. " +
+            "Omit implementationRef, create the member shell, then bind the implementation through " +
+            BindingRouteTemplate + ".")
+    {
+        ScopeId = scopeId;
+    }
+
+    public string ScopeId { get; }
+
+    public string Field => FieldName;
+}
+
 /// <summary>
 /// Wire body for <c>PATCH /api/scopes/{scopeId}/members/{memberId}</c> when
 /// the caller wants to change the member's team assignment (ADR-0017 §Q6).

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioMemberCreateRequestValidator.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioMemberCreateRequestValidator.cs
@@ -15,9 +15,14 @@ namespace Aevatar.Studio.Application.Studio.Services;
 /// </summary>
 internal static class StudioMemberCreateRequestValidator
 {
-    public static CreateStudioMemberRequest Validate(CreateStudioMemberRequest request)
+    public static CreateStudioMemberRequest Validate(string scopeId, CreateStudioMemberRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
+
+        if (request.ImplementationRef != null)
+        {
+            throw new StudioMemberCreateImplementationRefNotAllowedException(scopeId);
+        }
 
         ValidateDisplayName(request.DisplayName);
         ValidateDescription(request.Description);
@@ -25,11 +30,6 @@ internal static class StudioMemberCreateRequestValidator
         ValidateTeamId(request.TeamId);
 
         var implementationKind = ValidateImplementationKind(request.ImplementationKind);
-        var implementationRef = request.ImplementationRef == null
-            ? null
-            : StudioMemberService.NormalizeImplementationRef(
-                implementationKind,
-                request.ImplementationRef);
 
         return request with
         {
@@ -38,9 +38,12 @@ internal static class StudioMemberCreateRequestValidator
             MemberId = string.IsNullOrWhiteSpace(request.MemberId) ? null : request.MemberId.Trim(),
             TeamId = request.TeamId?.Trim(),
             ImplementationKind = implementationKind,
-            ImplementationRef = implementationRef,
+            ImplementationRef = null,
         };
     }
+
+    public static CreateStudioMemberRequest Validate(CreateStudioMemberRequest request) =>
+        Validate(string.Empty, request);
 
     private static string ValidateImplementationKind(string? implementationKind)
     {

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioMemberService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioMemberService.cs
@@ -53,7 +53,7 @@ public sealed class StudioMemberService : IStudioMemberService
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        var normalizedRequest = StudioMemberCreateRequestValidator.Validate(request);
+        var normalizedRequest = StudioMemberCreateRequestValidator.Validate(scopeId, request);
 
         if (!string.IsNullOrEmpty(normalizedRequest.TeamId))
         {

--- a/src/Aevatar.Studio.Hosting/Endpoints/StudioMemberEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/StudioMemberEndpoints.cs
@@ -86,6 +86,10 @@ internal static class StudioMemberEndpoints
             var summary = await memberService.CreateAsync(scopeId, request, ct);
             return Results.Created($"/api/scopes/{scopeId}/members/{summary.MemberId}", summary);
         }
+        catch (StudioMemberCreateImplementationRefNotAllowedException ex)
+        {
+            return CreateImplementationRefNotAllowed(ex);
+        }
         catch (InvalidOperationException ex)
         {
             return BadRequest("INVALID_STUDIO_MEMBER_REQUEST", ex.Message);
@@ -441,6 +445,16 @@ internal static class StudioMemberEndpoints
 
     private static IResult BadRequest(string code, string message) =>
         Results.BadRequest(new { code, message });
+
+    private static IResult CreateImplementationRefNotAllowed(
+        StudioMemberCreateImplementationRefNotAllowedException ex) =>
+        Results.BadRequest(new
+        {
+            code = StudioMemberCreateImplementationRefNotAllowedException.ErrorCode,
+            message = ex.Message,
+            scopeId = ex.ScopeId,
+            field = ex.Field,
+        });
 
     private static IResult NotFound(StudioMemberNotFoundException ex) =>
         Results.Json(

--- a/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchStudioMemberCommandService.cs
+++ b/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchStudioMemberCommandService.cs
@@ -39,6 +39,11 @@ internal sealed class ActorDispatchStudioMemberCommandService : IStudioMemberCom
     {
         ArgumentNullException.ThrowIfNull(request);
 
+        if (request.ImplementationRef != null)
+        {
+            throw new StudioMemberCreateImplementationRefNotAllowedException(scopeId);
+        }
+
         // Length caps + slug pattern are enforced at the Application
         // boundary (StudioMemberCreateRequestValidator). The transport-
         // level guards here only ensure the actor-id remains derivable —
@@ -67,8 +72,6 @@ internal sealed class ActorDispatchStudioMemberCommandService : IStudioMemberCom
             PublishedServiceId = publishedServiceId,
             CreatedAtUtc = Timestamp.FromDateTimeOffset(createdAt),
         };
-        if (request.ImplementationRef != null)
-            evt.ImplementationRef = BuildImplementationRefMessage(request.ImplementationRef);
 
         await DispatchAsync(normalizedScopeId, memberId, evt, ct);
 
@@ -100,16 +103,14 @@ internal sealed class ActorDispatchStudioMemberCommandService : IStudioMemberCom
             DisplayName: displayName,
             Description: evt.Description,
             ImplementationKind: MemberImplementationKindMapper.ToWireName(implementationKind),
-            LifecycleStage: request.ImplementationRef == null
-                ? MemberLifecycleStageNames.Created
-                : MemberLifecycleStageNames.BuildReady,
+            LifecycleStage: MemberLifecycleStageNames.Created,
             PublishedServiceId: publishedServiceId,
             LastBoundRevisionId: null,
             CreatedAt: createdAt,
             UpdatedAt: createdAt)
         {
             TeamId = responseTeamId,
-            ImplementationRef = request.ImplementationRef,
+            ImplementationRef = null,
         };
     }
 

--- a/test/Aevatar.Studio.Tests/ActorDispatchStudioMemberCommandServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/ActorDispatchStudioMemberCommandServiceTests.cs
@@ -14,8 +14,8 @@ namespace Aevatar.Studio.Tests;
 ///
 /// - CreateAsync routes through the canonical actor id and seeds the
 ///   immutable publishedServiceId from the member id (rename-safe).
-/// - All three implementation kinds (workflow / script / gagent) build the
-///   typed implementation_ref the actor expects.
+/// - CreateAsync is shell-only; implementation_ref enters through
+///   UpdateImplementationAsync / binding, not through the created event.
 /// - Binding requests route through the run actor with a stable payload hash.
 /// - Dispatch always goes through IStudioActorBootstrap before
 ///   IActorDispatchPort, so actor provisioning happens before the command
@@ -59,6 +59,7 @@ public sealed class ActorDispatchStudioMemberCommandServiceTests
         evt.PublishedServiceId.Should().Be("member-m-alpha");
         evt.DisplayName.Should().Be("Alpha");
         evt.Description.Should().Be("first member");
+        evt.ImplementationRef.Should().BeNull();
     }
 
     [Fact]
@@ -81,34 +82,31 @@ public sealed class ActorDispatchStudioMemberCommandServiceTests
     }
 
     [Fact]
-    public async Task CreateAsync_ShouldDispatchInitialImplementationRef_WhenProvided()
+    public async Task CreateAsync_ShouldRejectImplementationRefBeforeDispatch()
     {
+        var bootstrap = new RecordingBootstrap();
         var dispatch = new RecordingDispatchPort();
         var service = new ActorDispatchStudioMemberCommandService(
-            new RecordingBootstrap(),
+            bootstrap,
             CreateCommandDispatch(dispatch));
-        var implementationRef = new StudioMemberImplementationRefResponse(
-            ImplementationKind: MemberImplementationKindNames.Workflow,
-            WorkflowId: "wf-alpha",
-            WorkflowRevision: "rev-1");
 
-        var summary = await service.CreateAsync(
+        var act = () => service.CreateAsync(
             ScopeId,
             new CreateStudioMemberRequest(
                 DisplayName: "Alpha",
                 ImplementationKind: MemberImplementationKindNames.Workflow,
                 MemberId: "m-alpha",
-                ImplementationRef: implementationRef),
+                ImplementationRef: new StudioMemberImplementationRefResponse(
+                    ImplementationKind: MemberImplementationKindNames.Workflow,
+                    WorkflowId: "wf-alpha",
+                    WorkflowRevision: "rev-1")),
             CancellationToken.None);
 
-        summary.LifecycleStage.Should().Be(MemberLifecycleStageNames.BuildReady);
-        summary.ImplementationRef.Should().Be(implementationRef);
-
-        var evt = dispatch.Dispatches.Should().ContainSingle().Subject
-            .Envelope.Payload.Unpack<StudioMemberCreatedEvent>();
-        evt.ImplementationRef.Should().NotBeNull();
-        evt.ImplementationRef.Workflow.WorkflowId.Should().Be("wf-alpha");
-        evt.ImplementationRef.Workflow.WorkflowRevision.Should().Be("rev-1");
+        var thrown = await act.Should().ThrowAsync<StudioMemberCreateImplementationRefNotAllowedException>();
+        thrown.Which.ScopeId.Should().Be(ScopeId);
+        thrown.Which.Field.Should().Be("implementationRef");
+        bootstrap.EnsuredActorIds.Should().BeEmpty();
+        dispatch.Dispatches.Should().BeEmpty();
     }
 
     // Note: input validation (length caps, slug pattern, empty display

--- a/test/Aevatar.Studio.Tests/StudioMemberEndpointsTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberEndpointsTests.cs
@@ -29,16 +29,35 @@ public sealed class StudioMemberEndpointsTests
     [Fact]
     public async Task HandleCreateAsync_ShouldReturnCreated_OnSuccess()
     {
-        var implementationRef = new StudioMemberImplementationRefResponse(
-            ImplementationKind: MemberImplementationKindNames.Workflow,
-            WorkflowId: "wf-alpha");
         var service = new RecordingMemberService
         {
-            CreateResponse = NewSummary() with
-            {
-                ImplementationRef = implementationRef,
-                LifecycleStage = MemberLifecycleStageNames.BuildReady,
-            },
+            CreateResponse = NewSummary(),
+        };
+
+        var result = await InvokeHandle<IResult>(
+            "HandleCreateAsync",
+            CreateAuthenticatedContext(ScopeId),
+            ScopeId,
+            new CreateStudioMemberRequest(
+                DisplayName: "Alpha",
+                ImplementationKind: MemberImplementationKindNames.Workflow),
+            service,
+            CancellationToken.None);
+
+        var created = result.Should().BeOfType<Created<StudioMemberSummaryResponse>>().Subject;
+        created.Location.Should().Be($"/api/scopes/{ScopeId}/members/{NewSummary().MemberId}");
+        created.Value!.LifecycleStage.Should().Be(MemberLifecycleStageNames.Created);
+        created.Value.ImplementationRef.Should().BeNull();
+        service.CreateInvoked.Should().BeTrue();
+        service.CreateRequest!.ImplementationRef.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandleCreateAsync_ShouldReturnTypedBadRequest_WhenImplementationRefIsPresent()
+    {
+        var service = new RecordingMemberService
+        {
+            CreateException = new StudioMemberCreateImplementationRefNotAllowedException(ScopeId),
         };
 
         var result = await InvokeHandle<IResult>(
@@ -48,14 +67,18 @@ public sealed class StudioMemberEndpointsTests
             new CreateStudioMemberRequest(
                 DisplayName: "Alpha",
                 ImplementationKind: MemberImplementationKindNames.Workflow,
-                ImplementationRef: implementationRef),
+                ImplementationRef: new StudioMemberImplementationRefResponse(
+                    ImplementationKind: MemberImplementationKindNames.Workflow,
+                    WorkflowId: "wf-alpha")),
             service,
             CancellationToken.None);
 
-        result.Should().BeOfType<Created<StudioMemberSummaryResponse>>()
-            .Which.Location.Should().Be($"/api/scopes/{ScopeId}/members/{NewSummary().MemberId}");
+        AssertBadRequestResult(
+            result,
+            StudioMemberCreateImplementationRefNotAllowedException.ErrorCode,
+            expectedField: "implementationRef",
+            expectedScopeId: ScopeId);
         service.CreateInvoked.Should().BeTrue();
-        service.CreateRequest!.ImplementationRef.Should().Be(implementationRef);
     }
 
     [Fact]
@@ -832,7 +855,11 @@ public sealed class StudioMemberEndpointsTests
             because: $"expected JSON result with status {expectedStatus} but got {result.GetType().Name}");
     }
 
-    private static void AssertBadRequestResult(IResult result, string expectedCode)
+    private static void AssertBadRequestResult(
+        IResult result,
+        string expectedCode,
+        string? expectedField = null,
+        string? expectedScopeId = null)
     {
         result.GetType().Name.Should().StartWith("BadRequest");
 
@@ -847,6 +874,20 @@ public sealed class StudioMemberEndpointsTests
         var codeProp = value!.GetType().GetProperty("code");
         var code = codeProp?.GetValue(value) as string;
         code.Should().Be(expectedCode);
+
+        if (expectedField != null)
+        {
+            var fieldProp = value.GetType().GetProperty("field");
+            var field = fieldProp?.GetValue(value) as string;
+            field.Should().Be(expectedField);
+        }
+
+        if (expectedScopeId != null)
+        {
+            var scopeIdProp = value.GetType().GetProperty("scopeId");
+            var scopeId = scopeIdProp?.GetValue(value) as string;
+            scopeId.Should().Be(expectedScopeId);
+        }
     }
 
     private static void AssertNotFoundResult(IResult result, string expectedCode)

--- a/test/Aevatar.Studio.Tests/StudioMemberGAgentStateTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberGAgentStateTests.cs
@@ -245,7 +245,7 @@ public sealed class StudioMemberGAgentStateTests
     }
 
     [Fact]
-    public void Created_ShouldPersistInitialImplementationRefAsActorOwnedState()
+    public void Created_WithHistoricalImplementationRef_ShouldReplayActorOwnedState()
     {
         var createdAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
 

--- a/test/Aevatar.Studio.Tests/StudioMemberServiceCreateImplementationRefTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberServiceCreateImplementationRefTests.cs
@@ -13,113 +13,82 @@ public sealed class StudioMemberServiceCreateImplementationRefTests
 {
     private const string ScopeId = "scope-1";
 
-    [Fact]
-    public async Task CreateAsync_WorkflowImplementationRef_ShouldForwardNormalizedRefToCommandPort()
+    public static IEnumerable<object[]> CreateTimeImplementationRefs()
+    {
+        yield return
+        [
+            MemberImplementationKindNames.Workflow,
+            new StudioMemberImplementationRefResponse(
+                ImplementationKind: MemberImplementationKindNames.Workflow,
+                WorkflowId: "wf-alpha",
+                WorkflowRevision: "rev-1"),
+        ];
+        yield return
+        [
+            MemberImplementationKindNames.Script,
+            new StudioMemberImplementationRefResponse(
+                ImplementationKind: MemberImplementationKindNames.Script,
+                ScriptId: "script-alpha"),
+        ];
+        yield return
+        [
+            MemberImplementationKindNames.GAgent,
+            new StudioMemberImplementationRefResponse(
+                ImplementationKind: MemberImplementationKindNames.GAgent,
+                DiagnosticActorTypeName: "Aevatar.SomeAgent"),
+        ];
+    }
+
+    [Theory]
+    [MemberData(nameof(CreateTimeImplementationRefs))]
+    public async Task CreateAsync_ImplementationRef_ShouldRejectTypedExceptionBeforeCommandDispatch(
+        string implementationKind,
+        StudioMemberImplementationRefResponse implementationRef)
     {
         var commandPort = new RecordingMemberCommandPort();
         var service = NewService(commandPort);
 
-        await service.CreateAsync(
+        var act = () => service.CreateAsync(
+            ScopeId,
+            new CreateStudioMemberRequest(
+                DisplayName: "Alpha",
+                ImplementationKind: implementationKind,
+                MemberId: "m-alpha",
+                ImplementationRef: implementationRef));
+
+        var thrown = await act.Should().ThrowAsync<StudioMemberCreateImplementationRefNotAllowedException>();
+        thrown.Which.ScopeId.Should().Be(ScopeId);
+        thrown.Which.Field.Should().Be("implementationRef");
+        thrown.Which.Message.Should().Contain("create the member shell");
+        thrown.Which.Message.Should().Contain("PUT /api/scopes/{scopeId}/members/{memberId}/binding");
+        commandPort.CreateRequests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShellCreate_ShouldForwardNormalizedRequestToCommandPort()
+    {
+        var commandPort = new RecordingMemberCommandPort();
+        var service = NewService(commandPort);
+
+        var summary = await service.CreateAsync(
             ScopeId,
             new CreateStudioMemberRequest(
                 DisplayName: " Alpha ",
                 ImplementationKind: " WORKFLOW ",
-                MemberId: " m-alpha ",
-                ImplementationRef: new StudioMemberImplementationRefResponse(
-                    ImplementationKind: " WORKFLOW ",
-                    WorkflowId: " wf-alpha ",
-                    WorkflowRevision: " rev-1 ")));
+                Description: " first member ",
+                MemberId: " m-alpha "));
 
         commandPort.CreateRequests.Should().ContainSingle();
-        commandPort.CreateRequests[0].Request.Should().BeEquivalentTo(
+        commandPort.CreateRequests[0].ScopeId.Should().Be(ScopeId);
+        commandPort.CreateRequests[0].Request.Should().Be(
             new CreateStudioMemberRequest(
                 DisplayName: "Alpha",
                 ImplementationKind: MemberImplementationKindNames.Workflow,
+                Description: "first member",
                 MemberId: "m-alpha",
-                ImplementationRef: new StudioMemberImplementationRefResponse(
-                    ImplementationKind: MemberImplementationKindNames.Workflow,
-                    WorkflowId: "wf-alpha",
-                    WorkflowRevision: "rev-1")));
-    }
-
-    [Fact]
-    public async Task CreateAsync_ScriptImplementationRef_ShouldAllowOptionalRevision()
-    {
-        var commandPort = new RecordingMemberCommandPort();
-        var service = NewService(commandPort);
-
-        await service.CreateAsync(
-            ScopeId,
-            new CreateStudioMemberRequest(
-                DisplayName: "Script Member",
-                ImplementationKind: MemberImplementationKindNames.Script,
-                ImplementationRef: new StudioMemberImplementationRefResponse(
-                    ImplementationKind: MemberImplementationKindNames.Script,
-                    ScriptId: " script-alpha ")));
-
-        commandPort.CreateRequests.Should().ContainSingle();
-        commandPort.CreateRequests[0].Request.ImplementationRef.Should().Be(
-            new StudioMemberImplementationRefResponse(
-                ImplementationKind: MemberImplementationKindNames.Script,
-                ScriptId: "script-alpha"));
-    }
-
-    [Fact]
-    public async Task CreateAsync_GAgentImplementationRef_ShouldAcceptDiagnosticActorTypeName()
-    {
-        var commandPort = new RecordingMemberCommandPort();
-        var service = NewService(commandPort);
-
-        await service.CreateAsync(
-            ScopeId,
-            new CreateStudioMemberRequest(
-                DisplayName: "Agent Member",
-                ImplementationKind: MemberImplementationKindNames.GAgent,
-                ImplementationRef: new StudioMemberImplementationRefResponse(
-                    ImplementationKind: MemberImplementationKindNames.GAgent,
-                    DiagnosticActorTypeName: " Aevatar.SomeAgent ")));
-
-        commandPort.CreateRequests[0].Request.ImplementationRef.Should().Be(
-            new StudioMemberImplementationRefResponse(
-                ImplementationKind: MemberImplementationKindNames.GAgent,
-                DiagnosticActorTypeName: "Aevatar.SomeAgent"));
-    }
-
-    [Fact]
-    public async Task CreateAsync_ImplementationRef_ShouldRejectKindMismatch()
-    {
-        var service = NewService(new RecordingMemberCommandPort());
-
-        var act = () => service.CreateAsync(
-            ScopeId,
-            new CreateStudioMemberRequest(
-                DisplayName: "Alpha",
-                ImplementationKind: MemberImplementationKindNames.Workflow,
-                ImplementationRef: new StudioMemberImplementationRefResponse(
-                    ImplementationKind: MemberImplementationKindNames.Script,
-                    ScriptId: "script-alpha")));
-
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*implementationRef.implementationKind must match implementationKind 'workflow'*");
-    }
-
-    [Fact]
-    public async Task CreateAsync_WorkflowImplementationRef_ShouldRejectNonWorkflowFields()
-    {
-        var service = NewService(new RecordingMemberCommandPort());
-
-        var act = () => service.CreateAsync(
-            ScopeId,
-            new CreateStudioMemberRequest(
-                DisplayName: "Alpha",
-                ImplementationKind: MemberImplementationKindNames.Workflow,
-                ImplementationRef: new StudioMemberImplementationRefResponse(
-                    ImplementationKind: MemberImplementationKindNames.Workflow,
-                    WorkflowId: "wf-alpha",
-                    ScriptId: "script-alpha")));
-
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*implementationRef.scriptId is not allowed*");
+                ImplementationRef: null));
+        summary.LifecycleStage.Should().Be(MemberLifecycleStageNames.Created);
+        summary.ImplementationRef.Should().BeNull();
     }
 
     private static StudioMemberService NewService(RecordingMemberCommandPort commandPort) =>
@@ -148,15 +117,13 @@ public sealed class StudioMemberServiceCreateImplementationRefTests
                 DisplayName: request.DisplayName,
                 Description: request.Description ?? string.Empty,
                 ImplementationKind: request.ImplementationKind,
-                LifecycleStage: request.ImplementationRef == null
-                    ? MemberLifecycleStageNames.Created
-                    : MemberLifecycleStageNames.BuildReady,
+                LifecycleStage: MemberLifecycleStageNames.Created,
                 PublishedServiceId: "member-test",
                 LastBoundRevisionId: null,
                 CreatedAt: DateTimeOffset.UtcNow,
                 UpdatedAt: DateTimeOffset.UtcNow)
             {
-                ImplementationRef = request.ImplementationRef,
+                ImplementationRef = null,
             });
         }
 


### PR DESCRIPTION
Closes #2325

## Changed files
- Added a typed create-boundary rejection for `implementationRef` with code `STUDIO_MEMBER_CREATE_IMPLEMENTATION_REF_NOT_ALLOWED` and field `implementationRef`.
- Kept `POST /members` shell-only through application validation, endpoint mapping, and projection command-service invariants.
- Updated focused tests and member-first API docs to make post-create `PUT /api/scopes/{scopeId}/members/{memberId}/binding` the only implementation binding path.

## Test results
- `dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --filter "FullyQualifiedName~StudioMemberServiceCreateImplementationRefTests|FullyQualifiedName~ActorDispatchStudioMemberCommandServiceTests|FullyQualifiedName~StudioMemberEndpointsTests|FullyQualifiedName~StudioMemberGAgentStateTests" --nologo` passed: 91 tests.
- `bash tools/ci/test_stability_guards.sh` passed.
- `bash tools/ci/architecture_guards.sh` passed.

## Deviations
- None.

⟦AI:AUTO-LOOP⟧
