### PR TITLE
Expose durable sender bearer auth for scheduled dispatch

### DIFF
--- a/docs/canon/workflow-runtime.md
+++ b/docs/canon/workflow-runtime.md
@@ -110,6 +110,7 @@ BindWorkflowDefinition(yaml)
 - 定时唤醒走 `ScheduleSelfDurableTimeoutAsync`，在 Orleans runtime 下由 durable callback/reminder 机制承载；回调只向 schedule actor 发 fire command，不在中间层保存 schedule 状态。
 - schedule actor 只负责计算下一次 fire、生成幂等 key 并投递 prepared target envelope；workflow、GAgent service invocation 与 scripting 目标准备由 application/infrastructure adapter 承载，不进入 schedule actor core。
 - workflow schedule 的 `WorkflowName`、`Prompt`、`ScopeId` 仅存在 typed workflow target descriptor 中；service invocation 与 envelope target 使用各自 typed target descriptor；dispatch `Headers` 只保留传输扩展。
+- service invocation schedule auth 支持且仅支持一个 typed credential source：`senderNyxId`、`scopeOwnerNyxId` 或 `durableSenderBearerToken`。`durableSenderBearerToken` 可由 headless caller 直接提供，用于已有 durable sender bearer credential；它可以写入 schedule actor state 与 dispatch command，但不得进入 `ScheduledDispatchDocument` read model、query response 或 list/get API 回显。
 - workflow fork 的 HTTP/automation 入口只构造 typed `WorkflowForkRunCommand` 并走 `ICommandDispatchService<WorkflowForkRunCommand, WorkflowForkRunAcceptedReceipt, WorkflowForkRunStartError>`；seed 来源读取 `IWorkflowRunForkSeedQueryPort` read model，不走 event-store replay 或 actor state side-read。
 - public API identity fields 必须显式区分 `ScheduleActorId` 与 `TargetActorId`：`ScheduleActorId` 表示持有定时配置与 fire 事实的 schedule actor receipt，`TargetActorId` 表示最近一次或摘要中的投递目标；不得用一个 `ActorId` 混用 schedule actor receipt 和目标摘要。
 - 幂等 key 格式固定为 `schedule:{scheduleId}:fire:{scheduledFireAtUtc:o}`，并随 scheduled fire dispatch headers 透传。

--- a/src/platform/Aevatar.GAgentService.Application/Schedules/ScheduledDispatchApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Schedules/ScheduledDispatchApplicationService.cs
@@ -328,9 +328,15 @@ public sealed class ScheduledDispatchApplicationService : IScheduledDispatchAppl
             return null;
 
         var hasSenderNyxId = auth.SenderNyxId != null;
+        var durableToken = NormalizeOptional(auth.DurableSenderBearerToken);
+        var hasDurableSenderBearerToken = durableToken.Length > 0;
         var hasScopeOwnerNyxId = auth.ScopeOwnerNyxId != null;
-        if (hasSenderNyxId == hasScopeOwnerNyxId)
-            throw new ArgumentException("Exactly one service invocation NyxID credential source is required.", nameof(auth));
+        if (Convert.ToInt32(hasSenderNyxId) +
+            Convert.ToInt32(hasDurableSenderBearerToken) +
+            Convert.ToInt32(hasScopeOwnerNyxId) != 1)
+        {
+            throw new ArgumentException("Exactly one service invocation credential source is required.", nameof(auth));
+        }
 
         if (hasScopeOwnerNyxId)
         {
@@ -340,6 +346,9 @@ public sealed class ScheduledDispatchApplicationService : IScheduledDispatchAppl
                     NormalizeRequired(ownerSource.Scope, nameof(ownerSource.Scope)),
                     NormalizeOwnerSubject(ownerSource.OwnerSubject)));
         }
+
+        if (hasDurableSenderBearerToken)
+            return new ScheduledServiceInvocationAuth(DurableSenderBearerToken: durableToken);
 
         var source = auth.SenderNyxId!;
         if (source.Subject == null)

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/Schedules/ScheduledDispatchEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/Schedules/ScheduledDispatchEndpoints.cs
@@ -489,19 +489,30 @@ public sealed record ScheduledDispatchServiceInvocationTargetHttpRequest
 public sealed record ScheduledServiceInvocationAuthHttpRequest
 {
     public ScheduledServiceInvocationNyxIdCredentialSourceHttpRequest? SenderNyxId { get; init; }
+    public string? DurableSenderBearerToken { get; init; }
     public ScheduledServiceInvocationScopeOwnerNyxIdCredentialSourceHttpRequest? ScopeOwnerNyxId { get; init; }
 
     public ScheduledServiceInvocationAuth ToAuth(
         ScheduledServiceInvocationNyxIdSubjectRef? authenticatedOwnerSubject = null)
     {
         var hasSenderNyxId = SenderNyxId != null;
+        var durableToken = DurableSenderBearerToken?.Trim() ?? string.Empty;
+        var hasDurableSenderBearerToken = durableToken.Length > 0;
         var hasScopeOwnerNyxId = ScopeOwnerNyxId != null;
-        if (hasSenderNyxId == hasScopeOwnerNyxId)
-            throw new ArgumentException("Exactly one NyxID credential source is required.", nameof(SenderNyxId));
+        if (Convert.ToInt32(hasSenderNyxId) +
+            Convert.ToInt32(hasDurableSenderBearerToken) +
+            Convert.ToInt32(hasScopeOwnerNyxId) != 1)
+        {
+            throw new ArgumentException("Exactly one service invocation credential source is required.", nameof(SenderNyxId));
+        }
 
-        return hasScopeOwnerNyxId
-            ? new ScheduledServiceInvocationAuth(ScopeOwnerNyxId: ScopeOwnerNyxId!.ToSource(authenticatedOwnerSubject))
-            : new ScheduledServiceInvocationAuth(SenderNyxId: SenderNyxId!.ToSource());
+        if (hasScopeOwnerNyxId)
+            return new ScheduledServiceInvocationAuth(ScopeOwnerNyxId: ScopeOwnerNyxId!.ToSource(authenticatedOwnerSubject));
+
+        if (hasDurableSenderBearerToken)
+            return new ScheduledServiceInvocationAuth(DurableSenderBearerToken: durableToken);
+
+        return new ScheduledServiceInvocationAuth(SenderNyxId: SenderNyxId!.ToSource());
     }
 }
 

--- a/test/Aevatar.GAgentService.Integration.Tests/ScheduledDispatchEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScheduledDispatchEndpointsTests.cs
@@ -279,6 +279,28 @@ public sealed class ScheduledDispatchEndpointsTests
     }
 
     [Fact]
+    public async Task Create_ShouldAcceptDurableSenderBearerTokenWithoutOwnerBinding()
+    {
+        var service = new RecordingScheduledDispatchApplicationService();
+        var request = CreateServiceInvocationRequestWithAuth(new ScheduledServiceInvocationAuthHttpRequest
+        {
+            DurableSenderBearerToken = " durable-sender-token ",
+        });
+
+        var result = await CreateAsync(request, service);
+
+        var http = CreateHttpContext();
+        await result.ExecuteAsync(http);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        var auth = service.Created.Should().ContainSingle().Which.Target.ServiceInvocation!.Auth;
+        auth.Should().NotBeNull();
+        auth!.SenderNyxId.Should().BeNull();
+        auth.ScopeOwnerNyxId.Should().BeNull();
+        auth.DurableSenderBearerToken.Should().Be("durable-sender-token");
+    }
+
+    [Fact]
     public async Task Update_ShouldRejectScopeOwnerNyxId_WhenDurableOwnerBindingIsMissing()
     {
         var service = new RecordingScheduledDispatchApplicationService();
@@ -304,7 +326,7 @@ public sealed class ScheduledDispatchEndpointsTests
     }
 
     [Fact]
-    public async Task Create_ShouldRejectServiceInvocationAuthWithBothNyxIdSources()
+    public async Task Create_ShouldRejectServiceInvocationAuthWithMultipleCredentialSources()
     {
         var request = CreateServiceInvocationRequestWithAuth(new ScheduledServiceInvocationAuthHttpRequest
         {
@@ -312,6 +334,7 @@ public sealed class ScheduledDispatchEndpointsTests
             {
                 Scope = "proxy",
             },
+            DurableSenderBearerToken = "durable-sender-token",
             SenderNyxId = new ScheduledServiceInvocationNyxIdCredentialSourceHttpRequest
             {
                 Subject = new ScheduledServiceInvocationNyxIdSubjectRefHttpRequest

--- a/test/Aevatar.GAgentService.Tests/Application/ScheduledDispatchApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScheduledDispatchApplicationServiceTests.cs
@@ -127,6 +127,39 @@ public sealed class ScheduledDispatchApplicationServiceTests
     }
 
     [Fact]
+    public async Task CreateAsync_ShouldNormalizeDurableSenderBearerTokenAuth()
+    {
+        var actorPort = new RecordingScheduledDispatchActorPort { ResolveUnknownAsMissing = true };
+        var service = new ScheduledDispatchApplicationService(
+            actorPort,
+            new RecordingScheduledDispatchQueryPort(),
+            new ScheduledDispatchTargetPreparationService());
+
+        await service.CreateAsync(new ScheduledDispatchConfiguration(
+            "schedule-durable-auth",
+            "Invoke",
+            new ScheduledDispatchTargetDescriptor(
+                ScheduledDispatchTargetKind.ServiceInvocation,
+                ServiceInvocation: new ScheduledServiceInvocationTargetDescriptor(
+                    new ServiceIdentity { TenantId = "tenant", AppId = "app", Namespace = "default", ServiceId = "svc" },
+                    "run",
+                    Any.Pack(new StringValue { Value = "invoke" }),
+                    Auth: new ScheduledServiceInvocationAuth(DurableSenderBearerToken: " durable-run-key "))),
+            "0 9 * * *",
+            "UTC",
+            true,
+            new Dictionary<string, string>()));
+
+        var created = actorPort.Created.Should().ContainSingle().Which;
+        var configurationAuth = created.Configuration.Target.ServiceInvocation!.Auth;
+        configurationAuth.Should().NotBeNull();
+        configurationAuth!.SenderNyxId.Should().BeNull();
+        configurationAuth.ScopeOwnerNyxId.Should().BeNull();
+        configurationAuth.DurableSenderBearerToken.Should().Be("durable-run-key");
+        created.Dispatch.Descriptor.ServiceInvocation!.Auth!.DurableSenderBearerToken.Should().Be("durable-run-key");
+    }
+
+    [Fact]
     public async Task UpdateAsync_ShouldNormalizeServiceInvocationAndDispatchUpdate()
     {
         var actorPort = new RecordingScheduledDispatchActorPort();
@@ -380,7 +413,7 @@ public sealed class ScheduledDispatchApplicationServiceTests
     }
 
     [Fact]
-    public async Task CreateAsync_ShouldRejectServiceInvocationAuthWithBothNyxIdSources()
+    public async Task CreateAsync_ShouldRejectServiceInvocationAuthWithMultipleCredentialSources()
     {
         var service = CreateService();
 
@@ -397,6 +430,7 @@ public sealed class ScheduledDispatchApplicationServiceTests
                         SenderNyxId: new ScheduledServiceInvocationNyxIdCredentialSource(
                             new ScheduledServiceInvocationNyxIdSubjectRef("lark", "tenant-1", "ou-user-1"),
                             "proxy"),
+                        DurableSenderBearerToken: "durable-run-key",
                         ScopeOwnerNyxId: new ScheduledServiceInvocationScopeOwnerNyxIdCredentialSource(
                             "owner-proxy",
                             new ScheduledServiceInvocationNyxIdSubjectRef(OwnerScope.NyxIdPlatform, string.Empty, "owner-nyx-user"))))),
@@ -406,7 +440,7 @@ public sealed class ScheduledDispatchApplicationServiceTests
             new Dictionary<string, string>()));
 
         await act.Should().ThrowAsync<ArgumentException>()
-            .WithMessage("*Exactly one service invocation NyxID credential source*");
+            .WithMessage("*Exactly one service invocation credential source*");
     }
 
     [Fact]
@@ -569,6 +603,37 @@ public sealed class ScheduledDispatchApplicationServiceTests
                 Tenant = string.Empty,
                 ExternalUserId = "owner-nyx-user",
             });
+    }
+
+    [Fact]
+    public async Task ScheduledDispatchActorPort_ShouldPersistDurableSenderBearerTokenAuth()
+    {
+        var dispatchPort = new RecordingActorDispatchPort();
+        var port = new ScheduledDispatchActorPort(new RecordingActorRuntime(), dispatchPort);
+        var configuration = new ScheduledDispatchConfiguration(
+            "schedule-durable",
+            "Invoke",
+            new ScheduledDispatchTargetDescriptor(
+                ScheduledDispatchTargetKind.ServiceInvocation,
+                ServiceInvocation: new ScheduledServiceInvocationTargetDescriptor(
+                    new ServiceIdentity { TenantId = "tenant", AppId = "app", Namespace = "default", ServiceId = "svc" },
+                    "run",
+                    Any.Pack(new StringValue { Value = "invoke" }),
+                    Auth: new ScheduledServiceInvocationAuth(DurableSenderBearerToken: "durable-run-key"))),
+            "0 9 * * *",
+            "UTC",
+            true,
+            new Dictionary<string, string>(),
+            ScheduledDispatchScheduleKind.Workflow);
+        var prepared = await new ScheduledDispatchTargetPreparationService()
+            .PrepareAsync(configuration, "cmd-1", "corr-1");
+
+        await port.DispatchCreateAsync("scheduled-dispatch:schedule-durable", configuration, prepared);
+
+        var command = dispatchPort.Envelopes.Should().ContainSingle().Which.Payload.Unpack<ScheduledDispatchCreateCommand>();
+        command.Target.ServiceInvocation.Auth.SenderNyxId.Should().BeNull();
+        command.Target.ServiceInvocation.Auth.ScopeOwnerNyxId.Should().BeNull();
+        command.Target.ServiceInvocation.Auth.DurableSenderBearerToken.Should().Be("durable-run-key");
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Projection/ScheduledDispatchCurrentStateProjectorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ScheduledDispatchCurrentStateProjectorTests.cs
@@ -46,6 +46,42 @@ public sealed class ScheduledDispatchCurrentStateProjectorTests
         document.LastEventId.Should().Be("evt-9");
     }
 
+    [Fact]
+    public async Task ProjectAsync_ShouldNotProjectDurableSenderBearerToken()
+    {
+        var store = new RecordingDocumentStore<ScheduledDispatchDocument>(x => x.Id);
+        var projector = new ScheduledDispatchCurrentStateProjector(
+            store,
+            new FixedProjectionClock(DateTimeOffset.Parse("2026-06-18T00:00:00+00:00")));
+        var identity = new ServiceIdentity
+        {
+            TenantId = "tenant",
+            AppId = "app",
+            Namespace = "default",
+            ServiceId = "svc",
+        };
+        var state = CreateServiceInvocationState("schedule-secret", identity);
+        state.Target.ServiceInvocation.Auth = new ScheduledServiceInvocationAuthState
+        {
+            DurableSenderBearerToken = "durable-run-key",
+        };
+
+        await projector.ProjectAsync(
+            CreateContext("scheduled-dispatch:schedule-secret"),
+            WrapCommitted(
+                state,
+                version: 10,
+                eventId: "evt-secret",
+                observedAt: DateTimeOffset.Parse("2026-06-18T01:15:00+00:00")));
+
+        var document = await store.GetAsync("schedule-secret");
+        document.Should().NotBeNull();
+        document!.ToByteArray().AsSpan().IndexOf(ByteString.CopyFromUtf8("durable-run-key").ToByteArray()).Should().Be(-1);
+        document.ToString().Should().NotContain("durable-run-key");
+        document.ServiceKey.Should().Be(ServiceKeys.Build(identity));
+        document.StateVersion.Should().Be(10);
+    }
+
     [Theory]
     [InlineData("", "app", "default", "svc")]
     [InlineData("tenant", "", "default", "svc")]


### PR DESCRIPTION
## Changed files
- Exposed `durableSenderBearerToken` on schedule service invocation HTTP auth and mapped it to the existing durable sender bearer auth model.
- Updated application normalization to enforce exactly one credential source across `senderNyxId`, `scopeOwnerNyxId`, and `durableSenderBearerToken`.
- Added endpoint, application, and projection tests for durable token acceptance, write-state persistence, and readmodel/query non-echo behavior.
- Documented the scheduled dispatch auth boundary in `docs/canon/workflow-runtime.md`.

## Test results
- `dotnet build aevatar.slnx --nologo`: passed.
- `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --filter ScheduledDispatchEndpointsTests --nologo`: passed.
- `dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --filter "ScheduledDispatchApplicationServiceTests|ScheduledDispatchCurrentStateProjectorTests" --nologo`: passed.
- `bash tools/ci/test_stability_guards.sh`: passed.
- `bash tools/ci/architecture_guards.sh`: passed.
- `dotnet test aevatar.slnx --nologo`: passed.

## Deviations
- No scope expansion was needed.
- `CI_GUARDS` was unset, so repository architecture guards were run directly.

Closes #2327

⟦AI:AUTO-LOOP⟧
