### PR TITLE
Expose scheduleKind on scheduled dispatch requests

### DIFF
--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/Schedules/ScheduledDispatchEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/Schedules/ScheduledDispatchEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using System.Text.Json.Serialization;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.Identity.Abstractions;
@@ -361,6 +362,8 @@ public sealed record ScheduledDispatchConfigurationHttpRequest
 {
     public string? ScheduleId { get; init; }
     public string? DisplayName { get; init; }
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public ScheduledDispatchScheduleKind ScheduleKind { get; init; } = ScheduledDispatchScheduleKind.Generic;
     public required string CronExpression { get; init; }
     public string? Timezone { get; init; }
     public bool Enabled { get; init; } = true;
@@ -381,7 +384,8 @@ public sealed record ScheduledDispatchConfigurationHttpRequest
             CronExpression: CronExpression,
             Timezone: Timezone ?? string.Empty,
             Enabled: Enabled,
-            Headers: Headers ?? new Dictionary<string, string>(StringComparer.Ordinal));
+            Headers: Headers ?? new Dictionary<string, string>(StringComparer.Ordinal),
+            ScheduleKind: ScheduleKind);
 
     private async Task<ScheduledDispatchTargetDescriptor> ResolveTargetAsync(
         IServiceCatalogQueryReader catalogReader,

--- a/test/Aevatar.GAgentService.Integration.Tests/ScheduledDispatchEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScheduledDispatchEndpointsTests.cs
@@ -301,6 +301,20 @@ public sealed class ScheduledDispatchEndpointsTests
     }
 
     [Fact]
+    public async Task Create_ShouldDefaultMissingScheduleKindToGeneric()
+    {
+        var service = new RecordingScheduledDispatchApplicationService();
+
+        var result = await CreateAsync(CreateEnvelopeRequest(scheduleId: "schedule-1"), service);
+
+        var http = CreateHttpContext();
+        await result.ExecuteAsync(http);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        service.Created.Should().ContainSingle().Which.ScheduleKind.Should().Be(ScheduledDispatchScheduleKind.Generic);
+    }
+
+    [Fact]
     public async Task Update_ShouldRejectScopeOwnerNyxId_WhenDurableOwnerBindingIsMissing()
     {
         var service = new RecordingScheduledDispatchApplicationService();
@@ -718,6 +732,47 @@ public sealed class ScheduledDispatchEndpointsTests
         invocation.Payload.TypeUrl.Should().Be("type.googleapis.com/aevatar.ai.ChatRequestEvent");
         invocation.Payload.Unpack<ChatRequestEvent>().Prompt.Should().Be("summarize status");
         invocation.RevisionId.Should().Be("rev-chat");
+    }
+
+    [Fact]
+    public async Task Create_WithWorkflowScheduleKindAndDurableSenderBearerToken_ShouldForwardScheduleKind()
+    {
+        await using var host = await ScheduleEndpointTestHost.StartAsync();
+        var chat = new ChatRequestEvent { Prompt = "run durable workflow" };
+
+        var response = await host.Client.PostAsJsonAsync("/api/schedules", new
+        {
+            scheduleId = "schedule-chat",
+            displayName = "Workflow chat",
+            scheduleKind = "Workflow",
+            cronExpression = "0 9 * * *",
+            timezone = "UTC",
+            serviceInvocation = new
+            {
+                identity = new
+                {
+                    tenantId = "tenant",
+                    appId = "app",
+                    @namespace = "default",
+                    serviceId = "workflow",
+                },
+                endpointId = "chat",
+                payloadTypeUrl = Any.Pack(new ChatRequestEvent()).TypeUrl,
+                payloadBase64 = Convert.ToBase64String(chat.ToByteArray()),
+                revisionId = "rev-chat",
+                auth = new
+                {
+                    durableSenderBearerToken = " durable-sender-token ",
+                },
+            },
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        var configuration = host.Schedules.Created.Should().ContainSingle().Which;
+        configuration.ScheduleKind.Should().Be(ScheduledDispatchScheduleKind.Workflow);
+        var auth = configuration.Target.ServiceInvocation!.Auth;
+        auth.Should().NotBeNull();
+        auth!.DurableSenderBearerToken.Should().Be("durable-sender-token");
     }
 
     [Fact]


### PR DESCRIPTION
## Changed files

- `ScheduledDispatchConfigurationHttpRequest` now exposes the existing typed `scheduleKind` field and forwards it into `ScheduledDispatchConfiguration`.
- `ScheduledDispatchEndpointsTests` covers omitted `scheduleKind` as `Generic` and explicit `Workflow` schedules with `durableSenderBearerToken`.

## Test results

- `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --filter ScheduledDispatchEndpointsTests`
- `dotnet build aevatar.slnx --nologo`
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/architecture_guards.sh`

## Deviations

- No scope extension was needed.
- Host command variables were empty locally, so verification used the repository documented build command and the consensus verification hints.
- Closes #2337

⟦AI:AUTO-LOOP⟧
