### PR TITLE
Clarify NyxID redirect URI config error

### DIFF
--- a/apps/aevatar-console-web/src/shared/auth/backend.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/backend.test.ts
@@ -42,6 +42,23 @@ describe("NyxID backend auth API", () => {
     });
   });
 
+  it("reports an actionable backend contract error when redirectUri is missing", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        baseUrl: "https://nyx.example/",
+        clientId: "broker-client-1",
+        scope: "openid urn:nyxid:scope:broker_binding proxy",
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(loadBackendNyxIDLoginConfig()).rejects.toThrow(
+      "NyxID backend login config is missing redirectUri. Deploy the Studio auth backend that returns redirectUri from /api/auth/nyxid/config.",
+    );
+  });
+
   it("finalizes an authorization code through the backend and preserves accepted-dispatch semantics", async () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,

--- a/apps/aevatar-console-web/src/shared/auth/backend.ts
+++ b/apps/aevatar-console-web/src/shared/auth/backend.ts
@@ -94,6 +94,19 @@ function readString(value: unknown, label: string): string {
   return value.trim();
 }
 
+function readRequiredBackendConfigString(
+  value: unknown,
+  label: string,
+): string {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  throw new Error(
+    `NyxID backend login config is missing ${label}. Deploy the Studio auth backend that returns ${label} from /api/auth/nyxid/config.`,
+  );
+}
+
 function readOptionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0
     ? value.trim()
@@ -144,7 +157,7 @@ function decodeBackendLoginConfig(
     ),
     clientId: readString(record.clientId ?? record.ClientId, "clientId"),
     scope: readString(record.scope ?? record.Scope, "scope"),
-    redirectUri: readString(
+    redirectUri: readRequiredBackendConfigString(
       record.redirectUri ?? record.RedirectUri,
       "redirectUri",
     ),

--- a/test/Aevatar.Studio.Tests/NyxIdLoginFinalizationEndpointsTests.cs
+++ b/test/Aevatar.Studio.Tests/NyxIdLoginFinalizationEndpointsTests.cs
@@ -44,6 +44,28 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
     }
 
     [Fact]
+    public async Task Config_ShouldReturnUnavailable_WhenStudioLoginRedirectUriIsMissing()
+    {
+        var result = await NyxIdLoginFinalizationEndpoints.HandleConfigAsync(
+            new StubAevatarOAuthClientProvider(new AevatarOAuthClientSnapshot(
+                ClientId: "broker-client-1",
+                ClientIdIssuedAt: DateTimeOffset.UnixEpoch,
+                HmacKid: "kid",
+                HmacKey: [1, 2, 3],
+                HmacKeyRotatedAt: DateTimeOffset.UnixEpoch,
+                NyxIdAuthority: "https://nyx.example/",
+                BrokerCapabilityObserved: true,
+                BrokerCapabilityObservedAt: DateTimeOffset.UnixEpoch,
+                OauthScope: "openid broker proxy")));
+
+        var (statusCode, payload) = await ExecuteJsonAsync<JsonElement>(result);
+
+        statusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        payload.GetProperty("error").GetString().Should().Be("oauth_client_not_provisioned");
+        payload.GetProperty("detail").GetString().Should().Contain("not been provisioned");
+    }
+
+    [Fact]
     public async Task Finalize_ShouldCommitOwnerBindingFromAuthorizationCodeExchange()
     {
         var broker = new RecordingBrokerCallback(new BrokerAuthorizationCodeResult(

--- a/test/Aevatar.Studio.Tests/NyxIdLoginFinalizationEndpointsTests.cs
+++ b/test/Aevatar.Studio.Tests/NyxIdLoginFinalizationEndpointsTests.cs
@@ -44,28 +44,6 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
     }
 
     [Fact]
-    public async Task Config_ShouldReturnUnavailable_WhenStudioLoginRedirectUriIsMissing()
-    {
-        var result = await NyxIdLoginFinalizationEndpoints.HandleConfigAsync(
-            new StubAevatarOAuthClientProvider(new AevatarOAuthClientSnapshot(
-                ClientId: "broker-client-1",
-                ClientIdIssuedAt: DateTimeOffset.UnixEpoch,
-                HmacKid: "kid",
-                HmacKey: [1, 2, 3],
-                HmacKeyRotatedAt: DateTimeOffset.UnixEpoch,
-                NyxIdAuthority: "https://nyx.example/",
-                BrokerCapabilityObserved: true,
-                BrokerCapabilityObservedAt: DateTimeOffset.UnixEpoch,
-                OauthScope: "openid broker proxy")));
-
-        var (statusCode, payload) = await ExecuteJsonAsync<JsonElement>(result);
-
-        statusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
-        payload.GetProperty("error").GetString().Should().Be("oauth_client_not_provisioned");
-        payload.GetProperty("detail").GetString().Should().Contain("not been provisioned");
-    }
-
-    [Fact]
     public async Task Finalize_ShouldCommitOwnerBindingFromAuthorizationCodeExchange()
     {
         var broker = new RecordingBrokerCallback(new BrokerAuthorizationCodeResult(


### PR DESCRIPTION
## Problem

Console shows the raw auth config decoder error when an unauthenticated user clicks **Continue with NyxID** and the backend `/api/auth/nyxid/config` response is missing `redirectUri`.

This is not caused by the user being logged out. The login page must call the config endpoint before redirecting to NyxID, and the backend currently returns a partial config from the remote target:

```json
{
  "baseUrl": "https://nyx.chrono-ai.fun",
  "clientId": "0202beb7-6d07-44d4-952c-f4ad3c5a466e",
  "scope": "openid urn:nyxid:scope:broker_binding proxy"
}
```

The backend contract fix is tracked separately in #2340 and assigned to Louis.

## Solution

- Keep the frontend dependent on the backend-owned `redirectUri` instead of guessing it locally.
- Replace the generic `redirectUri must be a non-empty string.` decoder failure with an actionable backend auth config error.
- Add frontend coverage for the remote backend's current partial config shape.

## Impact Paths

- `apps/aevatar-console-web/src/shared/auth/backend.ts`
- `apps/aevatar-console-web/src/shared/auth/backend.test.ts`

No backend code is changed in this PR.

## Verification

```bash
pnpm --dir apps/aevatar-console-web jest src/shared/auth/backend.test.ts --runInBand
pnpm --dir apps/aevatar-console-web tsc
bash tools/ci/test_stability_guards.sh
git diff --check
```

All commands passed locally except backend `dotnet test`, which is not applicable to this frontend-only PR and `dotnet` is not available in the current shell PATH.

Manual verification:

- Started the fix branch frontend at `http://127.0.0.1:5174/login`.
- Confirmed `.env.local` proxies `/api/auth` to `https://aevatar-console-backend-api.aevatar.ai`.
- Clicking **Continue with NyxID** now shows the clearer backend config message instead of the raw decoder text.
