### PR TITLE
Align Ornn workflows with Scope Workflow authority

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
+++ b/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
@@ -179,6 +179,10 @@ Do not provide owner, scope, Lark target, Nyx provider slug, API key, service ID
 
 Use this playbook when the user asks for a recurring, scheduled, monitored, or otherwise long-running task instead of a one-off answer. Typical triggers include: "每天...", "每周...", "each week...", "monitor X and tell me...", "定时...", "recurring", "keep watching", and "长期跟踪".
 
+## Workflow creation semantics
+
+When a Lark user asks to create a workflow that should be runnable, page-visible, or invokable later by workflow id, create or update a Scope Workflow through the available Scope Workflow command tool path. Ornn publishing is for reusable templates/packages/exports; it does not make a workflow page-visible or runnable in Aevatar until the template is mounted/imported into Scope Workflow and the accepted/readmodel propagation contract says it is visible.
+
 1. Recognize the request as automation.
    - Do not answer with a one-shot summary if the user wants repeat runs.
    - Do not ask the user to hand-write the skill package.

--- a/docs/operations/2026-06-10-lark-bot-skill-hitl-notify-guide.md
+++ b/docs/operations/2026-06-10-lark-bot-skill-hitl-notify-guide.md
@@ -57,7 +57,7 @@ Follow the workflow route when a scope/workflow runtime is available. Use the li
 
 - `description` 写清触发场景，Lark bot 靠它判断是否加载 skill。
 - `tool-list` 写出会用到的工具。轻量卡片需要 `reply_with_interaction`；正式流程需要 `aevatar_start_workflow`；检查脚本可用 `code_execute`。
-- 如果有 workflow YAML，把它放在 skill 的 `assets/` 或 `workflow_yamls` 里，并在 `SKILL.md` 明确“启动 workflow 时传给 `aevatar_start_workflow.workflow_yamls`”。
+- 如果有 workflow YAML，通过 `ornn_publish_skill.workflow_yamls` 发布；包内路径会归一到 `workflows/{workflowId}.yaml`。这些 YAML 是模板/导入源，不是 scope 内已发布的可运行 workflow；需要先通过 Scope Workflow 命令链路挂载/导入，再启动运行。`assets/*.yaml` 只作为历史包读取兼容，不作为新发布路径。
 
 ## 轻量卡片交互
 
@@ -114,9 +114,9 @@ reason: hotfix validated
 
 ## 正式 HITL Workflow
 
-正式 HITL 适合审批、人工输入、敏感输入、长流程暂停恢复。skill 应该携带 workflow YAML，并要求 agent 用 `aevatar_start_workflow` 启动。
+正式 HITL 适合审批、人工输入、敏感输入、长流程暂停恢复。skill 可以携带 workflow YAML 模板，但模板必须先通过 Scope Workflow 命令链路挂载/导入，之后再按 `workflow_id` 启动已挂载的 scope workflow。
 
-启动工具参数形状：
+启动已挂载 workflow 的工具参数形状：
 
 ```json
 {
@@ -124,10 +124,11 @@ reason: hotfix validated
   "inputs": {
     "json": "{\"environment\":\"staging\",\"delivery_target_id\":\"agent-release-ops\"}"
   },
-  "wait": "stream",
-  "workflow_yamls": ["<inline workflow yaml here>"]
+  "wait": "stream"
 }
 ```
+
+只有在 Scope Workflow 挂载/导入不可用的显式降级场景，才把 inline `workflow_yamls` 作为临时导入/草稿运行输入；不要把 Ornn 包内 YAML 当成已发布、页面可见、可长期复用的 scope workflow 身份。
 
 `human_approval` 示例：
 
@@ -286,8 +287,8 @@ Notify 不适合：
 ```markdown
 ## Execution
 
-1. If a workflow-capable Aevatar scope is available, call `aevatar_start_workflow`.
-   - Pass the bundled workflow YAML in `workflow_yamls`.
+1. If a workflow-capable Aevatar scope is available, mount/import the bundled workflow template through the Scope Workflow command path, then start the mounted scope workflow after the accepted receipt/readmodel propagation contract allows it.
+   - Use inline `workflow_yamls` only as an explicit fallback when mounting is unavailable.
    - Require `delivery_target_id`; if missing, ask for it with `reply_with_interaction`.
 2. If no workflow scope is available, use lightweight `reply_with_interaction`.
 3. For lightweight card callbacks:
@@ -338,4 +339,3 @@ Notify 不适合：
 - `human_input` / `human_approval` 不使用 `interaction_template_spec`；模板卡通知只给 `notify` 用。
 - 轻量按钮点击后只是下一轮 LLM 输入，必须在 skill 中写清 `[card_action] action_id` 的处理规则。
 - 若卡片要收集输入或下拉选择，必须使用 `form_submit`，否则表单字段不会作为完整提交进入下一轮。
-

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSources.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSources.cs
@@ -127,8 +127,8 @@ internal sealed class StartWorkflowTool : IAevatarInvocationTool
     public string Name => "aevatar_start_workflow";
 
     public string Description =>
-        "Start an Aevatar workflow by workflow_id with typed inputs. " +
-        "When use_skill returns inline workflow_yamls, pass that bundle in workflow_yamls instead of treating the YAMLs as ordinary text. " +
+        "Start a mounted/imported Aevatar Scope Workflow by workflow_id with typed inputs. " +
+        "Use inline workflow_yamls only as an explicit fallback when Scope Workflow mounting/import is unavailable; Ornn workflow YAMLs from use_skill are templates/import sources, not page-visible runnable workflow authority by themselves. " +
         "Use wait=stream for channel conversations so terminal completion can be delivered asynchronously to the same reply target.";
 
     public string ParametersSchema => AevatarInvocationToolSchemas.StartWorkflow;

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnPublishSkillTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnPublishSkillTool.cs
@@ -29,7 +29,8 @@ public sealed class OrnnPublishSkillTool : IAgentTool
     public string Description =>
         "Publish a new private Ornn skill package for the current NyxID caller. " +
         "Private publishing executes directly and does not require NyxID approval. " +
-        "Use only after building a complete skill from typed fields; this validates workflow YAML, scripts, package format, then uploads the ZIP. " +
+        "Use only after building a complete skill from typed fields; this validates workflow template YAML, scripts, package format, then uploads the ZIP. " +
+        "Workflow YAMLs published here are Ornn package templates/import sources, not Scope Workflow runtime publication. " +
         "The tool never accepts credentials, service routing fields, raw file maps, metadata bags, public visibility, or skip-validation flags.";
 
     public ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnUpdateSkillTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnUpdateSkillTool.cs
@@ -30,7 +30,8 @@ public sealed class OrnnUpdateSkillTool : IAgentTool
     public string Description =>
         "Update an existing Ornn skill package for the current NyxID caller by stable skill_id. " +
         "Before calling, search or GET the current skill JSON, apply the requested full-package change, then submit the complete typed package with the same stable skill_id. " +
-        "This validates workflow YAML, scripts, package format, then uploads the ZIP with PUT by id. " +
+        "This validates workflow template YAML, scripts, package format, then uploads the ZIP with PUT by id. " +
+        "Workflow YAMLs updated here are Ornn package templates/import sources, not Scope Workflow runtime publication. " +
         "The tool never accepts credentials, service routing fields, raw file maps, metadata bags, public visibility, or skip-validation flags.";
 
     public ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;

--- a/src/Aevatar.AI.ToolProviders.Ornn/Publishing/OrnnSkillAssetPathPolicy.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/Publishing/OrnnSkillAssetPathPolicy.cs
@@ -16,7 +16,7 @@ public static class OrnnSkillAssetPathPolicy
             return (null, new OrnnSkillPublishDiagnostic("invalid_path", "workflow_id must be a path-safe file stem."));
         }
 
-        return ($"assets/{workflowId.Trim()}.yaml", null);
+        return ($"workflows/{workflowId.Trim()}.yaml", null);
     }
 
     public static (string? PackagePath, OrnnSkillPublishDiagnostic? Diagnostic) NormalizeScriptPath(string path) =>

--- a/src/Aevatar.AI.ToolProviders.Skills/SkillDefinition.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/SkillDefinition.cs
@@ -59,7 +59,7 @@ public sealed class SkillDefinition
     /// <summary>关联文件内容（远程技能可能附带多个文件）。</summary>
     public IReadOnlyDictionary<string, string>? AssociatedFiles { get; init; }
 
-    /// <summary>技能附带的可运行 workflow YAML 描述。</summary>
+    /// <summary>技能附带的 workflow 模板 YAML 描述；需先导入/挂载到 scope workflow 才可运行。</summary>
     public IReadOnlyList<SkillWorkflowDescriptor> Workflows { get; init; } = [];
 
     /// <summary>技能附带的可编译 C# script 描述。</summary>
@@ -67,14 +67,14 @@ public sealed class SkillDefinition
 }
 
 /// <summary>
-/// Skill package workflow YAML handoff descriptor.
+/// Skill package workflow template YAML handoff descriptor.
 /// </summary>
 public sealed class SkillWorkflowDescriptor
 {
-    /// <summary>Workflow identifier passed to aevatar_start_workflow.workflow_id.</summary>
+    /// <summary>Workflow template identifier used when mounting/importing into a scope workflow.</summary>
     public required string WorkflowId { get; init; }
 
-    /// <summary>Workflow YAML bundle passed to aevatar_start_workflow.workflow_yamls in stable path order.</summary>
+    /// <summary>Workflow YAML template bundle in stable path order.</summary>
     public required IReadOnlyList<string> WorkflowYamls { get; init; }
 }
 

--- a/src/Aevatar.AI.ToolProviders.Skills/UseSkillTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/UseSkillTool.cs
@@ -334,9 +334,12 @@ public sealed class UseSkillTool : IAgentTool
         try
         {
             using var doc = JsonDocument.Parse(argumentsJson);
-            if (doc.RootElement.TryGetProperty("skill", out var s))
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+                return new UseSkillArguments("", "", null);
+
+            if (doc.RootElement.TryGetProperty("skill", out var s) && s.ValueKind == JsonValueKind.String)
                 skillName = s.GetString() ?? "";
-            if (doc.RootElement.TryGetProperty("args", out var a))
+            if (doc.RootElement.TryGetProperty("args", out var a) && a.ValueKind == JsonValueKind.String)
                 args = a.GetString() ?? "";
             if (doc.RootElement.TryGetProperty("mount_workflows", out var m) &&
                 (m.ValueKind == JsonValueKind.True || m.ValueKind == JsonValueKind.False))
@@ -344,7 +347,10 @@ public sealed class UseSkillTool : IAgentTool
                 mountWorkflows = m.GetBoolean();
             }
         }
-        catch { /* use defaults */ }
+        catch (JsonException)
+        {
+            return new UseSkillArguments("", "", null);
+        }
 
         return new UseSkillArguments(skillName, args, mountWorkflows);
     }

--- a/src/Aevatar.AI.ToolProviders.Skills/UseSkillTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/UseSkillTool.cs
@@ -295,7 +295,6 @@ public sealed class UseSkillTool : IAgentTool
                     scopeId.Trim(),
                     workflow.WorkflowId.Trim(),
                     workflowYamls[0],
-                    WorkflowName: workflow.WorkflowId.Trim(),
                     DisplayName: workflow.WorkflowId.Trim(),
                     InlineWorkflowYamls: BuildInlineWorkflowYamls(workflowYamls)),
                 ct);

--- a/src/Aevatar.AI.ToolProviders.Skills/UseSkillTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/UseSkillTool.cs
@@ -388,15 +388,12 @@ public sealed class UseSkillTool : IAgentTool
         sb.AppendLine(
             "If these instructions leave you blocked by a missing capability, ambiguous workflow step, unavailable service, unknown API contract, repeated tool failure, or any other unsolved dependency, call `ornn_search_skills` with the concrete blocker/task and then `use_skill` the best matching result before trying generic proxy discovery or path guessing. Continue from the newly loaded skill.");
 
-        // Refactor (iter161/cluster-triage-ornn-skill-workflow-tool-signal #1259-first):
-        //   Old pattern: Runnable workflow YAML attachments were rendered only as generic Associated Files, leaving aevatar_start_workflow handoff implicit.
-        //   New principle: Render an explicit handoff section before generic files, preserving workflow_id and workflow_yamls as single-semantics tool fields.
         if (skill.Workflows.Count > 0)
         {
             sb.AppendLine();
-            sb.AppendLine("## aevatar_start_workflow Handoff");
+            sb.AppendLine("## Workflow Templates");
             sb.AppendLine();
-            sb.AppendLine("Call `aevatar_start_workflow` with `workflow_id` after the workflow is mounted. Use `workflow_yamls` only if the Mounted Workflows section says mounting was unavailable.");
+            sb.AppendLine("These workflow YAMLs are Ornn skill templates/import sources, not runnable scope workflows by themselves. Mount or import them through the Scope Workflow command path before starting a run. Use the inline `workflow_yamls` fallback only when the Mounted Workflows section says mounting was unavailable.");
 
             foreach (var workflow in skill.Workflows)
             {
@@ -502,7 +499,7 @@ public sealed class UseSkillTool : IAgentTool
         var sb = new StringBuilder();
         sb.AppendLine("## Mounted Workflows");
         sb.AppendLine();
-        sb.AppendLine("Workflow mount commands were accepted for dispatch; read models may still be propagating.");
+        sb.AppendLine("Workflow mount/import commands were accepted for dispatch through the Scope Workflow command path; read models may still be propagating before the workflows are page-visible or runnable.");
         sb.AppendLine();
         sb.AppendLine("```json");
         sb.AppendLine(JsonSerializer.Serialize(new { workflows = mounted }, SnakeCaseJson));
@@ -531,6 +528,8 @@ public sealed class UseSkillTool : IAgentTool
     {
         var sb = new StringBuilder();
         sb.AppendLine("## Mounted Workflows");
+        sb.AppendLine();
+        sb.AppendLine("Workflow templates were not mounted. Treat any inline workflow YAMLs above as unmounted templates/import sources, not as page-visible runnable scope workflows.");
         sb.AppendLine();
         sb.AppendLine("```json");
         sb.AppendLine(JsonSerializer.Serialize(new

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -77,12 +77,15 @@ public sealed class AevatarInvocationToolSourceTests
     }
 
     [Fact]
-    public async Task StartWorkflowToolDescription_ShouldMentionInlineWorkflowYamls()
+    public async Task StartWorkflowToolDescription_ShouldTreatInlineWorkflowYamlsAsFallback()
     {
         var tool = await DiscoverSingleAsync(new StartWorkflowToolSource(new Harness().CreateDispatcher()));
 
+        tool.Description.Should().Contain("mounted/imported Aevatar Scope Workflow");
         tool.Description.Should().Contain("workflow_yamls");
-        tool.Description.Should().Contain("use_skill");
+        tool.Description.Should().Contain("explicit fallback");
+        tool.Description.Should().Contain("templates/import sources");
+        tool.Description.Should().NotContain("pass that bundle in workflow_yamls");
     }
 
     [Fact]

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/LocalSkillCatalogTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/LocalSkillCatalogTests.cs
@@ -104,7 +104,7 @@ public sealed class LocalSkillCatalogTests
     }
 
     [Fact]
-    public async Task UseSkillTool_RendersWorkflowHandoffBeforeAssociatedFiles()
+    public async Task UseSkillTool_RendersWorkflowTemplatesBeforeAssociatedFiles()
     {
         var catalog = new LocalSkillCatalog();
         var tool = new UseSkillTool(catalog);
@@ -127,11 +127,12 @@ public sealed class LocalSkillCatalogTests
         var result = await tool.ExecuteAsync("""{"skill":"workflow-skill"}""");
         var text = ExtractText(result);
 
-        text.Should().Contain("## aevatar_start_workflow Handoff");
+        text.Should().Contain("## Workflow Templates");
         text.Should().Contain("\"workflow_id\": \"summary-report\"");
         text.Should().Contain("\"workflow_yamls\"");
-        text.Should().Contain("after the workflow is mounted");
-        text.IndexOf("## aevatar_start_workflow Handoff", StringComparison.Ordinal)
+        text.Should().Contain("not runnable scope workflows by themselves");
+        text.Should().Contain("Scope Workflow command path");
+        text.IndexOf("## Workflow Templates", StringComparison.Ordinal)
             .Should().BeLessThan(text.IndexOf("## Associated Files", StringComparison.Ordinal));
     }
 

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnPublishRoundTripContractTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnPublishRoundTripContractTests.cs
@@ -7,7 +7,7 @@ namespace Aevatar.AI.ToolProviders.Ornn.Tests;
 public sealed class OrnnPublishRoundTripContractTests
 {
     [Fact]
-    public async Task PublishedWorkflowAsset_ShouldRoundTripThroughOrnnJsonAsWorkflowDescriptor()
+    public async Task PublishedWorkflowYaml_ShouldRoundTripThroughWorkflowsRootAsWorkflowDescriptor()
     {
         var workflowYaml = "name: approval-flow\nsteps: []";
         var request = new OrnnSkillPublishRequest
@@ -27,7 +27,8 @@ public sealed class OrnnPublishRoundTripContractTests
             ],
         };
         var built = new OrnnSkillPackageBuilder().Build(request).Package!;
-        built.Files.Should().ContainKey("approval-skill/assets/approval-flow.yaml");
+        built.Files.Should().ContainKey("approval-skill/workflows/approval-flow.yaml");
+        built.Files.Should().NotContainKey("approval-skill/assets/approval-flow.yaml");
 
         var handler = OrnnTestHttpMessageHandler.ReturningJson("""
             {
@@ -36,7 +37,7 @@ public sealed class OrnnPublishRoundTripContractTests
                 "description": "Approval skill",
                 "files": {
                   "SKILL.md": "---\nname: approval-skill\n---\nRun approval.",
-                  "assets/approval-flow.yaml": "name: approval-flow\nsteps: []",
+                  "workflows/approval-flow.yaml": "name: approval-flow\nsteps: []",
                   "assets/readme.txt": "ordinary asset"
                 }
               }
@@ -50,6 +51,34 @@ public sealed class OrnnPublishRoundTripContractTests
         var workflow = skill!.Workflows.Should().ContainSingle().Subject;
         workflow.WorkflowId.Should().Be("approval-flow");
         workflow.WorkflowYamls.Should().Equal(workflowYaml);
+        skill.AssociatedFiles.Should().ContainKey("assets/readme.txt");
+        skill.AssociatedFiles.Should().NotContainKey("workflows/approval-flow.yaml");
+    }
+
+    [Fact]
+    public async Task LegacyAssetWorkflowYaml_ShouldRemainReadCompatibleWithoutBeingPublishPath()
+    {
+        var handler = OrnnTestHttpMessageHandler.ReturningJson("""
+            {
+              "data": {
+                "name": "legacy-approval-skill",
+                "description": "Approval skill",
+                "files": {
+                  "SKILL.md": "---\nname: legacy-approval-skill\n---\nRun approval.",
+                  "assets/approval-flow.yaml": "name: approval-flow\nsteps: []",
+                  "assets/readme.txt": "ordinary asset"
+                }
+              }
+            }
+            """);
+        var fetcher = new OrnnRemoteSkillFetcher(CreateClient(handler));
+
+        var skill = await fetcher.FetchSkillAsync("token", "legacy-approval-skill");
+
+        skill.Should().NotBeNull();
+        var workflow = skill!.Workflows.Should().ContainSingle().Subject;
+        workflow.WorkflowId.Should().Be("approval-flow");
+        workflow.WorkflowYamls.Should().Equal("name: approval-flow\nsteps: []");
         skill.AssociatedFiles.Should().ContainKey("assets/readme.txt");
         skill.AssociatedFiles.Should().NotContainKey("assets/approval-flow.yaml");
     }

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnPublishSkillToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnPublishSkillToolTests.cs
@@ -19,6 +19,8 @@ public sealed class OrnnPublishSkillToolTests
         tool.Name.Should().Be("ornn_publish_skill");
         tool.ApprovalMode.Should().Be(ToolApprovalMode.Auto);
         tool.SideEffectKind.Should().Be("ornn.publish.skill");
+        tool.Description.Should().Contain("templates/import sources");
+        tool.Description.Should().Contain("not Scope Workflow runtime publication");
         using var schema = JsonDocument.Parse(tool.ParametersSchema);
         var root = schema.RootElement;
         root.GetProperty("additionalProperties").GetBoolean().Should().BeFalse();

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnSkillPackageBuilderTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnSkillPackageBuilderTests.cs
@@ -71,10 +71,10 @@ public sealed class OrnnSkillPackageBuilderTests
         validation.IsValid.Should().BeTrue();
         package!.Files.Keys.Should().Equal(
             "plain-skill/SKILL.md",
-            "plain-skill/assets/approval-flow.yaml",
             "plain-skill/assets/images/icon.txt",
             "plain-skill/references/docs/usage.md",
-            "plain-skill/scripts/src/Approve.cs");
+            "plain-skill/scripts/src/Approve.cs",
+            "plain-skill/workflows/approval-flow.yaml");
     }
 
     [Theory]

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnUpdateSkillToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnUpdateSkillToolTests.cs
@@ -25,6 +25,8 @@ public sealed class OrnnUpdateSkillToolTests
         tool.SideEffectKind.Should().Be("ornn.update.skill");
         tool.Description.Should().Contain("search or GET the current skill JSON");
         tool.Description.Should().Contain("stable skill_id");
+        tool.Description.Should().Contain("templates/import sources");
+        tool.Description.Should().Contain("not Scope Workflow runtime publication");
 
         using var schema = JsonDocument.Parse(tool.ParametersSchema);
         var root = schema.RootElement;

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/SkillWorkflowsWiringTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/SkillWorkflowsWiringTests.cs
@@ -99,7 +99,7 @@ public sealed class SkillWorkflowsWiringTests
     }
 
     [Fact]
-    public async Task UseSkillTool_RendersWorkflowsSectionWithStartWorkflowInstructions()
+    public async Task UseSkillTool_RendersUnMountedWorkflowsAsTemplates()
     {
         var catalog = new LocalSkillCatalog();
         catalog.Register(new SkillDefinition
@@ -125,8 +125,10 @@ public sealed class SkillWorkflowsWiringTests
         var output = await tool.ExecuteAsync("""{"skill":"translator","mount_workflows":false}""");
         var text = ExtractText(output);
 
-        text.Should().Contain("## aevatar_start_workflow Handoff");
-        text.Should().Contain("aevatar_start_workflow");
+        text.Should().Contain("## Workflow Templates");
+        text.Should().Contain("templates/import sources");
+        text.Should().Contain("Scope Workflow command path");
+        text.Should().Contain("not runnable scope workflows by themselves");
         text.Should().Contain("workflow_yamls");
         text.Should().Contain("translate_flow");
         text.Should().Contain("```json");
@@ -149,7 +151,7 @@ public sealed class SkillWorkflowsWiringTests
         var output = await tool.ExecuteAsync("""{"skill":"plain"}""");
         var text = ExtractText(output);
 
-        text.Should().NotContain("## aevatar_start_workflow Handoff");
+        text.Should().NotContain("## Workflow Templates");
         text.Should().NotContain("aevatar_start_workflow");
     }
 
@@ -209,7 +211,7 @@ public sealed class SkillWorkflowsWiringTests
         text.Should().Contain("### script_execute");
         text.Should().Contain("\"input\": \"Use the current user request and skill arguments.\"");
 
-        text.IndexOf("## aevatar_start_workflow Handoff", StringComparison.Ordinal)
+        text.IndexOf("## Workflow Templates", StringComparison.Ordinal)
             .Should().BeLessThan(text.IndexOf("## script_compile/script_execute Handoff", StringComparison.Ordinal));
         text.IndexOf("## script_compile/script_execute Handoff", StringComparison.Ordinal)
             .Should().BeLessThan(text.IndexOf("## Associated Files", StringComparison.Ordinal));
@@ -248,7 +250,8 @@ public sealed class SkillWorkflowsWiringTests
 
         var output = await tool.ExecuteAsync("""{"skill":"translator","mount_workflows":false}""");
 
-        output.Should().Contain("## aevatar_start_workflow Handoff");
+        output.Should().Contain("## Workflow Templates");
+        output.Should().Contain("templates/import sources");
         output.Should().NotContain("## Mounted Workflows");
         commandPort.Requests.Should().BeEmpty();
     }
@@ -400,7 +403,7 @@ public sealed class SkillWorkflowsWiringTests
             .Which.Should().Be(new KeyValuePair<string, string>("workflow_1", "name: helper_flow\nsteps: []\n"));
         commandPort.Requests[1].WorkflowId.Should().Be("qa_flow");
         output.Should().Contain("## Mounted Workflows");
-        output.Should().Contain("Workflow mount commands were accepted for dispatch; read models may still be propagating.");
+        output.Should().Contain("Workflow mount/import commands were accepted for dispatch through the Scope Workflow command path; read models may still be propagating before the workflows are page-visible or runnable.");
         output.Should().Contain("\"accepted\": true");
         output.Should().Contain("\"acceptance_stage\": \"accepted\"");
         output.Should().Contain("\"propagation_stage\": \"readmodel_propagating\"");

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/SkillWorkflowsWiringTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/SkillWorkflowsWiringTests.cs
@@ -397,7 +397,7 @@ public sealed class SkillWorkflowsWiringTests
         commandPort.Requests[0].ScopeId.Should().Be("scope-1");
         commandPort.Requests[0].WorkflowId.Should().Be("translate_flow");
         commandPort.Requests[0].WorkflowYaml.Should().Be("name: translate_flow\nsteps: []\n");
-        commandPort.Requests[0].WorkflowName.Should().Be("translate_flow");
+        commandPort.Requests[0].WorkflowName.Should().BeNull();
         commandPort.Requests[0].DisplayName.Should().Be("translate_flow");
         commandPort.Requests[0].InlineWorkflowYamls.Should().ContainSingle()
             .Which.Should().Be(new KeyValuePair<string, string>("workflow_1", "name: helper_flow\nsteps: []\n"));
@@ -411,6 +411,38 @@ public sealed class SkillWorkflowsWiringTests
         output.Should().Contain("\"command_handles\"");
         output.Should().NotContain("already visible");
         output.Should().NotContain("strongly consistent");
+    }
+
+    [Fact]
+    public async Task UseSkillTool_MountWorkflowsTrue_PreservesDescriptorWorkflowIdAndLetsCommandPortParseYamlName()
+    {
+        using var _ = BeginContextScope(scopeId: "scope-1");
+        var catalog = new LocalSkillCatalog();
+        catalog.Register(new SkillDefinition
+        {
+            Name = "packaged-skill",
+            Description = "Uses packaged workflow identity",
+            Instructions = "Follow these steps.",
+            Source = SkillSource.Local,
+            Workflows =
+            [
+                new SkillWorkflowDescriptor
+                {
+                    WorkflowId = "packaged-entry",
+                    WorkflowYamls = ["name: parsed_entry\nsteps: []\n"],
+                },
+            ],
+        });
+        var commandPort = new RecordingScopeWorkflowCommandPort();
+        var tool = new UseSkillTool(catalog, scopeWorkflowCommandPort: commandPort);
+
+        await tool.ExecuteAsync("""{"skill":"packaged-skill","mount_workflows":true}""");
+
+        commandPort.Requests.Should().ContainSingle();
+        commandPort.Requests[0].WorkflowId.Should().Be("packaged-entry");
+        commandPort.Requests[0].WorkflowYaml.Should().Be("name: parsed_entry\nsteps: []\n");
+        commandPort.Requests[0].WorkflowName.Should().BeNull();
+        commandPort.Requests[0].DisplayName.Should().Be("packaged-entry");
     }
 
     [Fact]

--- a/tools/ci/guards/catch_exception_observability_baseline.tsv
+++ b/tools/ci/guards/catch_exception_observability_baseline.tsv
@@ -22,7 +22,6 @@ src/Aevatar.AI.ToolProviders.ServiceInvoke/Schema/EndpointSchemaProvider.cs	92	b
 src/Aevatar.AI.ToolProviders.ServiceInvoke/Schema/EndpointSchemaProvider.cs	153	empty broad catch block
 src/Aevatar.AI.ToolProviders.ServiceInvoke/Tools/ListServicesTool.cs	157	empty broad catch block
 src/Aevatar.AI.ToolProviders.Skills/SkillScriptExtractor.cs	119	empty broad catch block
-src/Aevatar.AI.ToolProviders.Skills/UseSkillTool.cs	348	empty broad catch block
 src/Aevatar.CQRS.Core.Abstractions/Streaming/EventSinkProjectionLeaseOrchestrator.cs	47	empty broad catch block
 src/Aevatar.CQRS.Core.Abstractions/Streaming/EventSinkProjectionLeaseOrchestrator.cs	59	empty broad catch block
 src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchOptimisticWriter.cs	170	broad catch returns null without visible failure signal


### PR DESCRIPTION
## Summary
- Normalize newly published Ornn workflow YAMLs under `workflows/{workflowId}.yaml` while keeping legacy `assets/*.yaml` read-compatible.
- Render Ornn workflow YAMLs as templates/import sources in `use_skill`, and keep runnable/page-visible authority on mounted/imported Scope Workflows.
- Align Lark prompt/docs and tool descriptions so runnable workflow creation defaults to Scope Workflow, not Ornn package publication or inline YAML starts.

## Issues
- Closes #2315
- Closes #2316
- Closes #2317

## Test plan
- [x] `dotnet test test/Aevatar.AI.ToolProviders.Ornn.Tests/Aevatar.AI.ToolProviders.Ornn.Tests.csproj --nologo`
- [x] `dotnet test test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/Aevatar.AI.ToolProviders.AevatarInvocation.Tests.csproj --nologo --filter "FullyQualifiedName~AevatarInvocationToolSourceTests"`
- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --filter "FullyQualifiedName~ConversationReplyGeneratorTests" --nologo`
- [x] `git diff --check`
- [x] `bash tools/ci/test_stability_guards.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)