### PR TITLE
Return NyxID login redirect URI in auth config

### DIFF
--- a/src/Aevatar.Studio.Hosting/Endpoints/NyxIdLoginFinalizationEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/NyxIdLoginFinalizationEndpoints.cs
@@ -40,9 +40,19 @@ public static class NyxIdLoginFinalizationEndpoints
         try
         {
             var snapshot = await oauthClientProvider.GetAsync(ct).ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(snapshot.RedirectUri))
+            {
+                return Results.Json(new
+                {
+                    error = "oauth_redirect_uri_missing",
+                    detail = "The provisioned NyxID OAuth redirect URI is missing.",
+                }, statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+
             return Results.Ok(new NyxIdLoginConfigurationResponse(
                 BaseUrl: snapshot.NyxIdAuthority.TrimEnd('/'),
                 ClientId: snapshot.ClientId,
+                RedirectUri: snapshot.RedirectUri.Trim(),
                 Scope: string.IsNullOrWhiteSpace(snapshot.OauthScope)
                     ? AevatarOAuthClientScopes.AuthorizationScope
                     : snapshot.OauthScope.Trim()));
@@ -289,6 +299,7 @@ public static class NyxIdLoginFinalizationEndpoints
 public sealed record NyxIdLoginConfigurationResponse(
     string BaseUrl,
     string ClientId,
+    string RedirectUri,
     string Scope);
 
 public sealed record NyxIdLoginFinalizationRequest

--- a/test/Aevatar.Studio.Tests/NyxIdLoginFinalizationEndpointsTests.cs
+++ b/test/Aevatar.Studio.Tests/NyxIdLoginFinalizationEndpointsTests.cs
@@ -30,6 +30,7 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
                 NyxIdAuthority: "https://nyx.example/",
                 BrokerCapabilityObserved: true,
                 BrokerCapabilityObservedAt: DateTimeOffset.UnixEpoch,
+                RedirectUri: " https://studio.example/auth/callback ",
                 OauthScope: "openid broker proxy")));
 
         var (statusCode, payload) = await ExecuteJsonAsync<NyxIdLoginConfigurationResponse>(result);
@@ -38,6 +39,7 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
         payload.Should().BeEquivalentTo(new NyxIdLoginConfigurationResponse(
             "https://nyx.example",
             "broker-client-1",
+            "https://studio.example/auth/callback",
             "openid broker proxy"));
     }
 
@@ -53,12 +55,37 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
                 HmacKeyRotatedAt: DateTimeOffset.UnixEpoch,
                 NyxIdAuthority: "https://nyx.example/",
                 BrokerCapabilityObserved: true,
-                BrokerCapabilityObservedAt: DateTimeOffset.UnixEpoch)));
+                BrokerCapabilityObservedAt: DateTimeOffset.UnixEpoch,
+                RedirectUri: "https://studio.example/auth/callback")));
 
         var (statusCode, payload) = await ExecuteJsonAsync<NyxIdLoginConfigurationResponse>(result);
 
         statusCode.Should().Be(StatusCodes.Status200OK);
-        payload!.Scope.Should().Be(AevatarOAuthClientScopes.AuthorizationScope);
+        payload!.RedirectUri.Should().Be("https://studio.example/auth/callback");
+        payload.Scope.Should().Be(AevatarOAuthClientScopes.AuthorizationScope);
+    }
+
+    [Fact]
+    public async Task Config_ShouldReturnUnavailable_WhenRedirectUriIsMissing()
+    {
+        var result = await NyxIdLoginFinalizationEndpoints.HandleConfigAsync(
+            new StubAevatarOAuthClientProvider(new AevatarOAuthClientSnapshot(
+                ClientId: "broker-client-1",
+                ClientIdIssuedAt: DateTimeOffset.UnixEpoch,
+                HmacKid: "kid",
+                HmacKey: [1, 2, 3],
+                HmacKeyRotatedAt: DateTimeOffset.UnixEpoch,
+                NyxIdAuthority: "https://nyx.example/",
+                BrokerCapabilityObserved: true,
+                BrokerCapabilityObservedAt: DateTimeOffset.UnixEpoch,
+                RedirectUri: "   ")));
+
+        var (statusCode, payload) = await ExecuteJsonAsync<ConfigurationErrorResponse>(result);
+
+        statusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        payload.Should().BeEquivalentTo(new ConfigurationErrorResponse(
+            "oauth_redirect_uri_missing",
+            "The provisioned NyxID OAuth redirect URI is missing."));
     }
 
     [Fact]
@@ -300,6 +327,8 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
         var text = await new StreamReader(context.Response.Body, Encoding.UTF8).ReadToEndAsync();
         return (context.Response.StatusCode, JsonSerializer.Deserialize<T>(text, new JsonSerializerOptions(JsonSerializerDefaults.Web)));
     }
+
+    private sealed record ConfigurationErrorResponse(string Error, string Detail);
 
     private static ExternalSubjectRef OwnerSubject(string externalUserId) =>
         new()


### PR DESCRIPTION
## Summary
- Include `redirectUri` in unauthenticated NyxID login config responses.
- Return an explicit 503 configuration error instead of a partial 200 response when the provisioned OAuth client snapshot has no redirect URI.
- Extend endpoint tests for configured, default-scope, and missing-redirect cases.

Fixes #2340

## Test plan
- [x] `dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --filter NyxIdLoginFinalizationEndpointsTests`
- [x] `bash tools/ci/test_stability_guards.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)