### PR TITLE
Support additional NyxID redirect URIs

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Identity.Abstractions/IAevatarOAuthClientProvider.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity.Abstractions/IAevatarOAuthClientProvider.cs
@@ -48,7 +48,8 @@ public sealed record AevatarOAuthClientSnapshot(
     byte[]? PreviousHmacKey = null,
     DateTimeOffset? PreviousHmacDemotedAt = null,
     string? RedirectUri = null,
-    string? OauthScope = null);
+    string? OauthScope = null,
+    IReadOnlyList<string>? RedirectUris = null);
 
 /// <summary>
 /// Thrown when an OAuth flow tries to use the cluster client before the

--- a/agents/Aevatar.GAgents.Channel.Identity/Endpoints/IdentityOAuthEndpoints.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Endpoints/IdentityOAuthEndpoints.cs
@@ -243,10 +243,15 @@ public static class IdentityOAuthEndpoints
         {
             var snapshot = await provider.GetAsync(ct).ConfigureAwait(false);
             var resolvedRedirectUri = NyxIdRedirectUriResolver.Resolve();
+            var resolvedRedirectUris = NyxIdRedirectUriResolver.ResolveRegisteredRedirectUris();
+            var registeredRedirectUris = NyxIdRedirectUriResolver.NormalizeRedirectUris(snapshot.RedirectUris ?? []);
             var redirectUriDrifted = string.IsNullOrEmpty(snapshot.RedirectUri)
                 || !string.Equals(snapshot.RedirectUri, resolvedRedirectUri, StringComparison.Ordinal);
+            var redirectUriListDrifted = registeredRedirectUris.Count == 0
+                || registeredRedirectUris.Count != resolvedRedirectUris.Count
+                || !registeredRedirectUris.SequenceEqual(resolvedRedirectUris, StringComparer.Ordinal);
             var oauthScopeDrifted = !AevatarOAuthClientScopes.ContainsRequiredScopes(snapshot.OauthScope);
-            var status = redirectUriDrifted
+            var status = redirectUriDrifted || redirectUriListDrifted
                 ? "redirect_uri_drifted"
                 : oauthScopeDrifted ? "oauth_scope_drifted"
                 : snapshot.BrokerCapabilityObserved ? "ready" : "broker_capability_pending";
@@ -259,6 +264,9 @@ public static class IdentityOAuthEndpoints
                 redirect_uri_registered = snapshot.RedirectUri,
                 redirect_uri_resolved = resolvedRedirectUri,
                 redirect_uri_drifted = redirectUriDrifted,
+                redirect_uris_registered = registeredRedirectUris,
+                redirect_uris_resolved = resolvedRedirectUris,
+                redirect_uris_drifted = redirectUriListDrifted,
                 oauth_scope_registered = snapshot.OauthScope,
                 oauth_scope_required = AevatarOAuthClientScopes.AuthorizationScope,
                 oauth_scope_drifted = oauthScopeDrifted,
@@ -363,6 +371,7 @@ public static class IdentityOAuthEndpoints
 
         var authority = NyxIdAuthorityResolver.Resolve(logger);
         var redirectUri = NyxIdRedirectUriResolver.Resolve(logger);
+        var redirectUris = NyxIdRedirectUriResolver.ResolveRegisteredRedirectUris(logger);
         var oauthScope = AevatarOAuthClientScopes.AuthorizationScope;
 
         // Validate Unix-seconds before dispatching: AevatarOAuthClient
@@ -396,15 +405,17 @@ public static class IdentityOAuthEndpoints
         CommandDispatchResult<ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> accepted;
         try
         {
+            var command = new ProvisionAevatarOAuthClientCommand
+            {
+                ClientId = body.client_id!.Trim(),
+                ClientIdIssuedAtUnix = issuedAtUnix,
+                NyxidAuthority = authority,
+                OauthScope = oauthScope,
+                RedirectUri = redirectUri,
+            };
+            command.RedirectUris.AddRange(redirectUris);
             accepted = await rebuildDispatch
-                .DispatchAsync(new ProvisionAevatarOAuthClientCommand
-                {
-                    ClientId = body.client_id!.Trim(),
-                    ClientIdIssuedAtUnix = issuedAtUnix,
-                    NyxidAuthority = authority,
-                    OauthScope = oauthScope,
-                    RedirectUri = redirectUri,
-                }, ct)
+                .DispatchAsync(command, ct)
                 .ConfigureAwait(false);
         }
         catch (Exception ex)

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientBootstrapService.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientBootstrapService.cs
@@ -54,14 +54,18 @@ public sealed class AevatarOAuthClientBootstrapService : IHostedService
         // at NyxID. The redirect URI must match what the broker sends at
         // authorize / token time — both call sites use NyxIdRedirectUriResolver.
         var redirectUri = NyxIdRedirectUriResolver.Resolve(_logger);
+        var redirectUris = NyxIdRedirectUriResolver.ResolveRegisteredRedirectUris(_logger);
+
+        var command = new EnsureAevatarOAuthClientProvisionedCommand
+        {
+            NyxidAuthority = authority,
+            RedirectUri = redirectUri,
+            ClientName = ClientName,
+        };
+        command.RedirectUris.AddRange(redirectUris);
 
         var accepted = await _provisioningDispatch
-            .DispatchAsync(new EnsureAevatarOAuthClientProvisionedCommand
-            {
-                NyxidAuthority = authority,
-                RedirectUri = redirectUri,
-                ClientName = ClientName,
-            }, ct)
+            .DispatchAsync(command, ct)
             .ConfigureAwait(false);
         if (!accepted.Succeeded || accepted.Receipt is null)
             throw new InvalidOperationException($"Aevatar OAuth client bootstrap dispatch rejected: {accepted.Error}.");

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
@@ -121,6 +121,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             return;
         }
 
+        var expectedRedirectUris = NormalizeProvisioningRedirectUris(cmd.RedirectUris, cmd.RedirectUri);
         var sameClient = !string.IsNullOrEmpty(State.ClientId)
             && string.Equals(State.NyxidAuthority, cmd.NyxidAuthority, StringComparison.Ordinal);
 
@@ -138,9 +139,12 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         var redirectUriDrifted = sameClient
             && (string.IsNullOrEmpty(State.RedirectUri)
                 || !string.Equals(State.RedirectUri, cmd.RedirectUri, StringComparison.Ordinal));
+        var redirectUriListDrifted = sameClient
+            && (State.RedirectUris.Count == 0
+                || !RedirectUriListsEqual(State.RedirectUris, expectedRedirectUris));
         var oauthScopeDrifted = sameClient && !AevatarOAuthClientScopes.ContainsRequiredScopes(State.OauthScope);
 
-        if (sameClient && !redirectUriDrifted && !oauthScopeDrifted)
+        if (sameClient && !redirectUriDrifted && !redirectUriListDrifted && !oauthScopeDrifted)
         {
             // Seed HMAC key on first activation against an existing client_id
             // (defence-in-depth against partial state loaded from snapshots).
@@ -171,6 +175,14 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 State.RedirectUri,
                 cmd.RedirectUri);
         }
+        if (redirectUriListDrifted)
+        {
+            Logger.LogWarning(
+                "Aevatar OAuth client redirect URI allowlist drifted: stored='{Stored}', resolved='{Resolved}'. " +
+                "Re-running DCR to register a new client_id at NyxID with the configured callback targets.",
+                string.Join(",", State.RedirectUris),
+                string.Join(",", expectedRedirectUris));
+        }
         if (oauthScopeDrifted)
         {
             Logger.LogWarning(
@@ -196,7 +208,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         // DCR call itself is bounded.
         var clientName = string.IsNullOrWhiteSpace(cmd.ClientName) ? "aevatar" : cmd.ClientName;
         var registration = await registrar
-            .RegisterPublicClientAsync(cmd.NyxidAuthority, clientName, cmd.RedirectUri, CancellationToken.None)
+            .RegisterPublicClientAsync(cmd.NyxidAuthority, clientName, expectedRedirectUris, CancellationToken.None)
             .ConfigureAwait(false);
 
         // Cluster-shared Garnet event store + brief two-pod overlap during
@@ -211,17 +223,20 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         // "replay state" helper a future handler could misuse outside an
         // active commit path (PR #552 review codex/glm-5.1).
         var previousRedirectUri = State.RedirectUri;
+        var previousRedirectUris = State.RedirectUris.ToArray();
         var previousOauthScope = State.OauthScope;
+        var provisioned = new AevatarOAuthClientProvisionedEvent
+        {
+            ClientId = registration.ClientId,
+            ClientIdIssuedAtUnix = registration.IssuedAt.ToUnixTimeSeconds(),
+            NyxidAuthority = cmd.NyxidAuthority,
+            PersistedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            RedirectUri = cmd.RedirectUri,
+            OauthScope = AevatarOAuthClientScopes.AuthorizationScope,
+        };
+        provisioned.RedirectUris.AddRange(expectedRedirectUris);
         await PersistDomainEventAsync(
-            new AevatarOAuthClientProvisionedEvent
-            {
-                ClientId = registration.ClientId,
-                ClientIdIssuedAtUnix = registration.IssuedAt.ToUnixTimeSeconds(),
-                NyxidAuthority = cmd.NyxidAuthority,
-                PersistedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-                RedirectUri = cmd.RedirectUri,
-                OauthScope = AevatarOAuthClientScopes.AuthorizationScope,
-            },
+            provisioned,
             onOptimisticConcurrencyConflict: occ => AbsorbPeerDcrProvisioningAsync(cmd, registration.ClientId, occ));
 
         // The loser absorber path returned (peer committed the same
@@ -237,15 +252,17 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
 
         await PersistDriftReconciledEventsAsync(
             redirectUriDrifted,
+            redirectUriListDrifted,
             oauthScopeDrifted,
             previousRedirectUri,
+            previousRedirectUris,
             previousOauthScope);
 
         Logger.LogInformation(
-            "Provisioned aevatar OAuth client via DCR: client_id={ClientId}, authority={Authority}, redirect_uri={RedirectUri}",
+            "Provisioned aevatar OAuth client via DCR: client_id={ClientId}, authority={Authority}, redirect_uris={RedirectUris}",
             registration.ClientId,
             cmd.NyxidAuthority,
-            cmd.RedirectUri);
+            string.Join(",", expectedRedirectUris));
 
         if (State.HmacKey.Length == 0)
         {
@@ -279,12 +296,14 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             return;
         }
 
-        await HandleEnsureProvisionedAsync(new EnsureAevatarOAuthClientProvisionedCommand
+        var command = new EnsureAevatarOAuthClientProvisionedCommand
         {
             NyxidAuthority = State.ProvisioningRetryAuthority,
             RedirectUri = State.ProvisioningRetryRedirectUri,
             ClientName = State.ProvisioningRetryClientName,
-        }, allowPendingRetryBypass: true).ConfigureAwait(false);
+        };
+        command.RedirectUris.AddRange(State.ProvisioningRetryRedirectUris);
+        await HandleEnsureProvisionedAsync(command, allowPendingRetryBypass: true).ConfigureAwait(false);
     }
 
     private bool HasPendingProvisioningRetryNotDue(DateTimeOffset now) =>
@@ -301,7 +320,10 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             || evt.DueUnixMs != State.ProvisioningRetryDueUnixMs
             || !string.Equals(evt.NyxidAuthority, State.ProvisioningRetryAuthority, StringComparison.Ordinal)
             || !string.Equals(evt.RedirectUri, State.ProvisioningRetryRedirectUri, StringComparison.Ordinal)
-            || !string.Equals(evt.ClientName, State.ProvisioningRetryClientName, StringComparison.Ordinal))
+            || !string.Equals(evt.ClientName, State.ProvisioningRetryClientName, StringComparison.Ordinal)
+            || !RedirectUriListsEqual(
+                NormalizeProvisioningRedirectUris(evt.RedirectUris, evt.RedirectUri),
+                State.ProvisioningRetryRedirectUris))
         {
             return false;
         }
@@ -320,6 +342,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         !string.IsNullOrEmpty(State.ClientId)
         && string.Equals(State.NyxidAuthority, cmd.NyxidAuthority, StringComparison.Ordinal)
         && string.Equals(State.RedirectUri, cmd.RedirectUri, StringComparison.Ordinal)
+        && RedirectUriListsEqual(State.RedirectUris, NormalizeProvisioningRedirectUris(cmd.RedirectUris, cmd.RedirectUri))
         && AevatarOAuthClientScopes.ContainsRequiredScopes(State.OauthScope)
         && State.HmacKey.Length > 0;
 
@@ -350,6 +373,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             CallbackId = callbackId,
             FiredAtUnixMs = due.ToUnixTimeMilliseconds(),
         };
+        callbackPayload.RedirectUris.AddRange(normalized.RedirectUris);
         var lease = await ScheduleSelfDurableTimeoutAsync(
                 callbackId,
                 delay,
@@ -357,7 +381,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 ct: CancellationToken.None)
             .ConfigureAwait(false);
 
-        await PersistDomainEventAsync(new AevatarOAuthClientProvisioningRetryScheduledEvent
+        var scheduled = new AevatarOAuthClientProvisioningRetryScheduledEvent
         {
             Attempt = nextAttempt,
             DueUnixMs = due.ToUnixTimeMilliseconds(),
@@ -368,7 +392,9 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             CallbackGeneration = lease.Generation,
             LastError = error.Message,
             ScheduledAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-        }).ConfigureAwait(false);
+        };
+        scheduled.RedirectUris.AddRange(normalized.RedirectUris);
+        await PersistDomainEventAsync(scheduled).ConfigureAwait(false);
 
         Logger.LogWarning(
             error,
@@ -392,11 +418,13 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
 
     private async Task PersistDriftReconciledEventsAsync(
         bool redirectUriDrifted,
+        bool redirectUriListDrifted,
         bool oauthScopeDrifted,
         string previousRedirectUri,
+        IReadOnlyCollection<string> previousRedirectUris,
         string previousOauthScope)
     {
-        var events = new List<IMessage>(capacity: 2);
+        var events = new List<IMessage>(capacity: 3);
         var now = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
         if (redirectUriDrifted)
         {
@@ -405,6 +433,17 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 DriftKind = "redirect_uri",
                 PreviousValue = previousRedirectUri ?? string.Empty,
                 ExpectedValue = State.RedirectUri,
+                ActiveClientId = State.ClientId,
+                ReconciledAt = now,
+            });
+        }
+        if (redirectUriListDrifted)
+        {
+            events.Add(new AevatarOAuthClientDriftReconciledEvent
+            {
+                DriftKind = "redirect_uris",
+                PreviousValue = string.Join(",", previousRedirectUris),
+                ExpectedValue = string.Join(",", State.RedirectUris),
                 ActiveClientId = State.ClientId,
                 ReconciledAt = now,
             });
@@ -431,12 +470,35 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         if (string.IsNullOrWhiteSpace(cmd.NyxidAuthority) || string.IsNullOrWhiteSpace(cmd.RedirectUri))
             return null;
 
-        return new EnsureAevatarOAuthClientProvisionedCommand
+        var normalized = new EnsureAevatarOAuthClientProvisionedCommand
         {
             NyxidAuthority = cmd.NyxidAuthority.Trim(),
             RedirectUri = cmd.RedirectUri.Trim(),
             ClientName = string.IsNullOrWhiteSpace(cmd.ClientName) ? "aevatar" : cmd.ClientName.Trim(),
         };
+        normalized.RedirectUris.AddRange(NormalizeProvisioningRedirectUris(cmd.RedirectUris, normalized.RedirectUri));
+        return normalized;
+    }
+
+    private static string[] NormalizeProvisioningRedirectUris(
+        IEnumerable<string> redirectUris,
+        string fallbackRedirectUri)
+    {
+        var values = NyxIdRedirectUriResolver.NormalizeRedirectUris(redirectUris);
+        if (values.Count > 0)
+            return values.ToArray();
+
+        var fallback = fallbackRedirectUri?.Trim();
+        return string.IsNullOrWhiteSpace(fallback) ? Array.Empty<string>() : [fallback];
+    }
+
+    private static bool RedirectUriListsEqual(
+        IEnumerable<string> stored,
+        IReadOnlyCollection<string> expected)
+    {
+        var storedValues = NyxIdRedirectUriResolver.NormalizeRedirectUris(stored);
+        return storedValues.Count == expected.Count
+            && storedValues.SequenceEqual(expected, StringComparer.Ordinal);
     }
 
     private static TimeSpan ComputeRetryDelay(int attempt)
@@ -459,9 +521,11 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         // Framework already refreshed State from the store before invoking
         // this callback. A peer healed the drift iff the cluster's stored
         // record now matches the command's intended shape.
+        var expectedRedirectUris = NormalizeProvisioningRedirectUris(cmd.RedirectUris, cmd.RedirectUri);
         var peerHealed = !string.IsNullOrEmpty(State.ClientId)
             && string.Equals(State.NyxidAuthority, cmd.NyxidAuthority, StringComparison.Ordinal)
             && string.Equals(State.RedirectUri, cmd.RedirectUri, StringComparison.Ordinal)
+            && RedirectUriListsEqual(State.RedirectUris, expectedRedirectUris)
             && AevatarOAuthClientScopes.ContainsRequiredScopes(State.OauthScope)
             && State.HmacKey.Length > 0;
 
@@ -481,11 +545,11 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
 
         Logger.LogError(
             "Aevatar OAuth client OCC race did not converge on the desired shape after replay; actor-owned retry will re-evaluate. "
-            + "stored_client_id={StoredClientId}, stored_redirect_uri={StoredRedirect}, expected_redirect_uri={ExpectedRedirect}, "
+            + "stored_client_id={StoredClientId}, stored_redirect_uris={StoredRedirectUris}, expected_redirect_uris={ExpectedRedirectUris}, "
             + "orphan_client_id={OrphanClientId}, expected_version={Expected}, actual_version={Actual}.",
             State.ClientId,
-            State.RedirectUri,
-            cmd.RedirectUri,
+            string.Join(",", State.RedirectUris),
+            string.Join(",", expectedRedirectUris),
             orphanClientId,
             occ.ExpectedVersion,
             occ.ActualVersion);
@@ -558,13 +622,17 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         // rotate it away. Codex P1 on PR #570.
         var redirectUri = string.IsNullOrEmpty(cmd.RedirectUri) ? State.RedirectUri : cmd.RedirectUri;
         var oauthScope = string.IsNullOrEmpty(cmd.OauthScope) ? State.OauthScope : cmd.OauthScope;
+        var redirectUris = cmd.RedirectUris.Count == 0
+            ? State.RedirectUris.Count == 0 ? NormalizeProvisioningRedirectUris(Array.Empty<string>(), redirectUri) : State.RedirectUris.ToArray()
+            : NormalizeProvisioningRedirectUris(cmd.RedirectUris, redirectUri);
         var sameSnapshot = string.Equals(State.ClientId, cmd.ClientId, StringComparison.Ordinal)
             && string.Equals(State.NyxidAuthority, cmd.NyxidAuthority, StringComparison.Ordinal)
             && string.Equals(State.RedirectUri, redirectUri, StringComparison.Ordinal)
+            && RedirectUriListsEqual(State.RedirectUris, redirectUris)
             && string.Equals(State.OauthScope, oauthScope, StringComparison.Ordinal);
         if (!sameSnapshot)
         {
-            await PersistDomainEventAsync(new AevatarOAuthClientProvisionedEvent
+            var provisioned = new AevatarOAuthClientProvisionedEvent
             {
                 ClientId = cmd.ClientId,
                 ClientIdIssuedAtUnix = cmd.ClientIdIssuedAtUnix,
@@ -572,12 +640,14 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 PersistedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
                 OauthScope = oauthScope,
                 RedirectUri = redirectUri,
-            });
+            };
+            provisioned.RedirectUris.AddRange(redirectUris);
+            await PersistDomainEventAsync(provisioned);
             Logger.LogInformation(
-                "Provisioned aevatar OAuth client: client_id={ClientId}, authority={Authority}, redirect_uri={RedirectUri}",
+                "Provisioned aevatar OAuth client: client_id={ClientId}, authority={Authority}, redirect_uris={RedirectUris}",
                 cmd.ClientId,
                 cmd.NyxidAuthority,
-                string.IsNullOrEmpty(redirectUri) ? "<unspecified>" : redirectUri);
+                redirectUris.Length == 0 ? "<unspecified>" : string.Join(",", redirectUris));
         }
 
         if (State.HmacKey.Length == 0)
@@ -681,6 +751,8 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         next.ClientIdIssuedAtUnix = evt.ClientIdIssuedAtUnix;
         next.NyxidAuthority = evt.NyxidAuthority ?? string.Empty;
         next.RedirectUri = evt.RedirectUri ?? string.Empty;
+        next.RedirectUris.Clear();
+        next.RedirectUris.AddRange(NormalizeProvisioningRedirectUris(evt.RedirectUris, next.RedirectUri));
         next.OauthScope = evt.OauthScope ?? string.Empty;
         // Re-provisioning resets the broker observation: a new client_id
         // starts with broker_capability_enabled=false until ops flips it.
@@ -722,6 +794,8 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         next.ProvisioningRetryDueUnixMs = evt.DueUnixMs;
         next.ProvisioningRetryAuthority = evt.NyxidAuthority ?? string.Empty;
         next.ProvisioningRetryRedirectUri = evt.RedirectUri ?? string.Empty;
+        next.ProvisioningRetryRedirectUris.Clear();
+        next.ProvisioningRetryRedirectUris.AddRange(NormalizeProvisioningRedirectUris(evt.RedirectUris, next.ProvisioningRetryRedirectUri));
         next.ProvisioningRetryClientName = evt.ClientName ?? string.Empty;
         next.ProvisioningRetryCallbackId = evt.CallbackId ?? string.Empty;
         next.ProvisioningRetryCallbackGeneration = evt.CallbackGeneration;
@@ -739,6 +813,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         next.ProvisioningRetryDueUnixMs = 0;
         next.ProvisioningRetryAuthority = string.Empty;
         next.ProvisioningRetryRedirectUri = string.Empty;
+        next.ProvisioningRetryRedirectUris.Clear();
         next.ProvisioningRetryClientName = string.Empty;
         next.ProvisioningRetryCallbackId = string.Empty;
         next.ProvisioningRetryCallbackGeneration = 0;

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientProjectionProvider.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientProjectionProvider.cs
@@ -60,6 +60,7 @@ public sealed class AevatarOAuthClientProjectionProvider : IAevatarOAuthClientPr
             PreviousHmacKey: previousKey,
             PreviousHmacDemotedAt: previousDemotedAt,
             RedirectUri: string.IsNullOrEmpty(document.RedirectUri) ? null : document.RedirectUri,
-            OauthScope: string.IsNullOrEmpty(document.OauthScope) ? null : document.OauthScope);
+            OauthScope: string.IsNullOrEmpty(document.OauthScope) ? null : document.OauthScope,
+            RedirectUris: document.RedirectUris.ToArray());
     }
 }

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientProjectionProvider.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientProjectionProvider.cs
@@ -47,6 +47,10 @@ public sealed class AevatarOAuthClientProjectionProvider : IAevatarOAuthClientPr
                 : null;
         }
 
+        var redirectUris = document.RedirectUris.Count > 0
+            ? document.RedirectUris.ToArray()
+            : string.IsNullOrEmpty(document.RedirectUri) ? [] : [document.RedirectUri];
+
         return new AevatarOAuthClientSnapshot(
             ClientId: document.ClientId,
             ClientIdIssuedAt: DateTimeOffset.FromUnixTimeSeconds(document.ClientIdIssuedAtUnix),
@@ -61,6 +65,6 @@ public sealed class AevatarOAuthClientProjectionProvider : IAevatarOAuthClientPr
             PreviousHmacDemotedAt: previousDemotedAt,
             RedirectUri: string.IsNullOrEmpty(document.RedirectUri) ? null : document.RedirectUri,
             OauthScope: string.IsNullOrEmpty(document.OauthScope) ? null : document.OauthScope,
-            RedirectUris: document.RedirectUris.ToArray());
+            RedirectUris: redirectUris);
     }
 }

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientProjector.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientProjector.cs
@@ -65,6 +65,7 @@ public sealed class AevatarOAuthClientProjector
             LastEventId = stateEvent.EventId ?? string.Empty,
             UpdatedAt = CommittedStateEventEnvelope.ResolveTimestamp(envelope, _clock.UtcNow),
         };
+        document.RedirectUris.AddRange(state.RedirectUris);
 
         await _writeDispatcher.UpsertAsync(document, ct);
     }

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/NyxIdDynamicClientRegistrationClient.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/NyxIdDynamicClientRegistrationClient.cs
@@ -38,21 +38,31 @@ public class NyxIdDynamicClientRegistrationClient
     /// registration call fails (HTTP non-success, malformed body, missing
     /// client_id) so the bootstrap caller can decide whether to retry.
     /// </summary>
-    public virtual async Task<RegistrationResult> RegisterPublicClientAsync(
+    public virtual Task<RegistrationResult> RegisterPublicClientAsync(
         string authority,
         string clientName,
         string redirectUri,
+        CancellationToken ct = default) =>
+        RegisterPublicClientAsync(authority, clientName, [redirectUri], ct);
+
+    public virtual async Task<RegistrationResult> RegisterPublicClientAsync(
+        string authority,
+        string clientName,
+        IReadOnlyCollection<string> redirectUris,
         CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(authority);
         ArgumentException.ThrowIfNullOrWhiteSpace(clientName);
-        ArgumentException.ThrowIfNullOrWhiteSpace(redirectUri);
+        ArgumentNullException.ThrowIfNull(redirectUris);
+        var normalizedRedirectUris = NyxIdRedirectUriResolver.NormalizeRedirectUris(redirectUris);
+        if (normalizedRedirectUris.Count == 0)
+            throw new ArgumentException("At least one redirect URI is required.", nameof(redirectUris));
 
         var url = $"{authority.TrimEnd('/')}{RegisterEndpoint}";
         var request = new RegistrationRequest
         {
             ClientName = clientName,
-            RedirectUris = [redirectUri],
+            RedirectUris = normalizedRedirectUris.ToArray(),
             GrantTypes = ["authorization_code"],
             ResponseTypes = ["code"],
             TokenEndpointAuthMethod = "none",

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/NyxIdRedirectUriResolver.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/NyxIdRedirectUriResolver.cs
@@ -46,6 +46,14 @@ public static class NyxIdRedirectUriResolver
     public const string OverrideEnvVar = "AEVATAR_OAUTH_REDIRECT_BASE_URL";
 
     /// <summary>
+    /// Optional comma/semicolon/newline separated list of additional redirect
+    /// URIs to register on the same NyxID OAuth client. Used for external
+    /// callbacks such as the Console SPA <c>/auth/callback</c> route. The
+    /// backend does not infer these deployment-specific frontend URLs.
+    /// </summary>
+    public const string AdditionalRedirectUrisEnvVar = "AEVATAR_OAUTH_ADDITIONAL_REDIRECT_URIS";
+
+    /// <summary>
     /// Returns the absolute callback URL DCR + authorize must use. Reads
     /// <see cref="OverrideEnvVar"/> if set; otherwise returns the
     /// hardcoded production default. A wildcard / unspecified-host
@@ -57,6 +65,47 @@ public static class NyxIdRedirectUriResolver
     {
         var baseUrl = ResolveBaseUrl(logger);
         return $"{baseUrl.TrimEnd('/')}{CallbackPath}";
+    }
+
+    public static IReadOnlyList<string> ResolveRegisteredRedirectUris(ILogger? logger = null)
+    {
+        var values = new List<string> { Resolve(logger) };
+        var additional = Environment.GetEnvironmentVariable(AdditionalRedirectUrisEnvVar);
+        if (!string.IsNullOrWhiteSpace(additional))
+        {
+            foreach (var candidate in additional.Split([',', ';', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (IsWildcardListenAddress(candidate))
+                {
+                    logger?.LogWarning(
+                        "Ignoring additional OAuth redirect URI from {EnvVar}: '{Value}' is a wildcard / unspecified-host listen address.",
+                        AdditionalRedirectUrisEnvVar,
+                        candidate);
+                    continue;
+                }
+
+                values.Add(candidate);
+            }
+        }
+
+        return NormalizeRedirectUris(values);
+    }
+
+    public static IReadOnlyList<string> NormalizeRedirectUris(IEnumerable<string> redirectUris)
+    {
+        var unique = new HashSet<string>(StringComparer.Ordinal);
+        var values = new List<string>();
+        foreach (var raw in redirectUris)
+        {
+            var normalized = raw?.Trim();
+            if (string.IsNullOrWhiteSpace(normalized))
+                continue;
+
+            if (unique.Add(normalized))
+                values.Add(normalized);
+        }
+
+        return values;
     }
 
     private static string ResolveBaseUrl(ILogger? logger)

--- a/agents/Aevatar.GAgents.Channel.Identity/protos/aevatar_oauth_client.proto
+++ b/agents/Aevatar.GAgents.Channel.Identity/protos/aevatar_oauth_client.proto
@@ -70,6 +70,13 @@ message AevatarOAuthClientState {
   string provisioning_retry_callback_id = 19;
   int64 provisioning_retry_callback_generation = 20;
   string provisioning_retry_last_error = 21;
+  // Full redirect URI allowlist that must be registered at NyxID for the
+  // active client_id. redirect_uri remains the canonical backend callback used
+  // by the broker callback flow; this list also includes explicitly configured
+  // external callbacks such as the Console SPA /auth/callback route.
+  repeated string redirect_uris = 22;
+  // Full redirect URI allowlist captured for an actor-owned provisioning retry.
+  repeated string provisioning_retry_redirect_uris = 23;
 }
 
 // Issued by the bootstrap startup service from every silo on cluster cold-
@@ -82,6 +89,9 @@ message EnsureAevatarOAuthClientProvisionedCommand {
   string redirect_uri = 2;
   // Optional override for the DCR <c>client_name</c>; bootstrap leaves blank.
   string client_name = 3;
+  // Full redirect URI allowlist to register at NyxID. Empty means legacy caller;
+  // the actor falls back to [redirect_uri].
+  repeated string redirect_uris = 4;
 }
 
 // Durable self-callback payload fired when an actor-owned OAuth provisioning
@@ -96,6 +106,7 @@ message AevatarOAuthClientProvisioningRetryFiredEvent {
   string callback_id = 6;
   int64 callback_generation = 7;
   int64 fired_at_unix_ms = 8;
+  repeated string redirect_uris = 9;
 }
 
 // Issued by tests / manual operator scripts that already hold a client_id
@@ -118,6 +129,9 @@ message ProvisionAevatarOAuthClientCommand {
   // client. Tests / fixture seeds may leave it empty when they don't care
   // about drift detection on a subsequent bootstrap pass.
   string redirect_uri = 5;
+  // Full redirect URI allowlist pinned for the supplied client_id. Empty means
+  // preserve existing list or fall back to [redirect_uri] for legacy callers.
+  repeated string redirect_uris = 6;
 }
 
 // Issued by ops to force a fresh HMAC key rotation. Old tokens signed with
@@ -150,6 +164,7 @@ message AevatarOAuthClientProvisioningRetryScheduledEvent {
   int64 callback_generation = 7;
   string last_error = 8;
   google.protobuf.Timestamp scheduled_at = 9;
+  repeated string redirect_uris = 10;
 }
 
 // Persisted when provisioning reaches a terminal successful branch and the
@@ -186,6 +201,8 @@ message AevatarOAuthClientProvisionedEvent {
   // an older event predates scope tracking; the actor treats empty as
   // legacy/unknown and re-DCRs once so proxy-capable bindings can be minted.
   string oauth_scope = 6;
+  // Full redirect URI allowlist registered with NyxID at this DCR call.
+  repeated string redirect_uris = 7;
 }
 
 // Persisted when the actor seeds or rotates its HMAC key. On rotation, the
@@ -250,4 +267,7 @@ message AevatarOAuthClientDocument {
   // Mirror of AevatarOAuthClientState.oauth_scope for diagnostics and
   // bootstrap drift detection.
   string oauth_scope = 17;
+  // Mirror of AevatarOAuthClientState.redirect_uris for diagnostics and drift
+  // detection of explicitly configured external callbacks.
+  repeated string redirect_uris = 18;
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientBootstrapServiceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientBootstrapServiceTests.cs
@@ -25,6 +25,7 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
         var command = dispatch.Commands[0];
         command.NyxidAuthority.Should().Be(environment.Authority);
         command.RedirectUri.Should().Be(environment.RedirectUri);
+        command.RedirectUris.Should().Equal(environment.RedirectUri, environment.ConsoleRedirectUri);
         command.ClientName.Should().Be("aevatar");
     }
 
@@ -42,6 +43,7 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
         var command = dispatch.Commands[0];
         command.NyxidAuthority.Should().Be(environment.Authority);
         command.RedirectUri.Should().Be(environment.RedirectUri);
+        command.RedirectUris.Should().Equal(environment.RedirectUri, environment.ConsoleRedirectUri);
         command.ClientName.Should().Be("aevatar");
     }
 
@@ -141,23 +143,28 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
     {
         private readonly string? _oldAuthority;
         private readonly string? _oldRedirectBaseUrl;
+        private readonly string? _oldAdditionalRedirectUris;
 
         public string Authority { get; } = "https://nyxid.test";
         public string RedirectBaseUrl { get; } = "https://aevatar.test";
         public string RedirectUri => $"{RedirectBaseUrl}{NyxIdRedirectUriResolver.CallbackPath}";
+        public string ConsoleRedirectUri { get; } = "https://console.test/auth/callback";
 
         public OAuthBootstrapEnvironment()
         {
             _oldAuthority = Environment.GetEnvironmentVariable(NyxIdAuthorityResolver.OverrideEnvVar);
             _oldRedirectBaseUrl = Environment.GetEnvironmentVariable(NyxIdRedirectUriResolver.OverrideEnvVar);
+            _oldAdditionalRedirectUris = Environment.GetEnvironmentVariable(NyxIdRedirectUriResolver.AdditionalRedirectUrisEnvVar);
             Environment.SetEnvironmentVariable(NyxIdAuthorityResolver.OverrideEnvVar, Authority);
             Environment.SetEnvironmentVariable(NyxIdRedirectUriResolver.OverrideEnvVar, RedirectBaseUrl);
+            Environment.SetEnvironmentVariable(NyxIdRedirectUriResolver.AdditionalRedirectUrisEnvVar, ConsoleRedirectUri);
         }
 
         public void Dispose()
         {
             Environment.SetEnvironmentVariable(NyxIdAuthorityResolver.OverrideEnvVar, _oldAuthority);
             Environment.SetEnvironmentVariable(NyxIdRedirectUriResolver.OverrideEnvVar, _oldRedirectBaseUrl);
+            Environment.SetEnvironmentVariable(NyxIdRedirectUriResolver.AdditionalRedirectUrisEnvVar, _oldAdditionalRedirectUris);
         }
     }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
@@ -83,7 +83,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
 
         _registrar.Calls.Should().HaveCount(1);
         _registrar.Calls[0].Authority.Should().Be("https://nyxid.test");
-        _registrar.Calls[0].RedirectUri.Should().Be("https://aevatar.test/api/oauth/nyxid-callback");
+        _registrar.Calls[0].RedirectUris.Should().Equal("https://aevatar.test/api/oauth/nyxid-callback");
         _agent.State.ClientId.Should().Be(_registrar.NextClientId);
         _agent.State.NyxidAuthority.Should().Be("https://nyxid.test");
         _agent.State.OauthScope.Should().Be(AevatarOAuthClientScopes.AuthorizationScope);
@@ -196,6 +196,54 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task HandleEnsureProvisioned_RegistersAndDetectsFullRedirectUriListDrift()
+    {
+        var initial = new EnsureAevatarOAuthClientProvisionedCommand
+        {
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+        };
+        initial.RedirectUris.Add("https://aevatar.test/api/oauth/nyxid-callback");
+        initial.RedirectUris.Add("https://console.test/auth/callback");
+
+        await _agent.HandleEnsureProvisioned(initial);
+
+        _registrar.Calls.Should().HaveCount(1);
+        _registrar.Calls[0].RedirectUris.Should().Equal(
+            "https://aevatar.test/api/oauth/nyxid-callback",
+            "https://console.test/auth/callback");
+        _agent.State.RedirectUris.Should().Equal(
+            "https://aevatar.test/api/oauth/nyxid-callback",
+            "https://console.test/auth/callback");
+
+        var expanded = new EnsureAevatarOAuthClientProvisionedCommand
+        {
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+        };
+        expanded.RedirectUris.Add("https://aevatar.test/api/oauth/nyxid-callback");
+        expanded.RedirectUris.Add("https://console.test/auth/callback");
+        expanded.RedirectUris.Add("https://ops.test/callback");
+
+        _registrar.NextClientId = "client-after-list-drift";
+        await _agent.HandleEnsureProvisioned(expanded);
+
+        _registrar.Calls.Should().HaveCount(2);
+        _registrar.Calls[1].RedirectUris.Should().Equal(
+            "https://aevatar.test/api/oauth/nyxid-callback",
+            "https://console.test/auth/callback",
+            "https://ops.test/callback");
+        _agent.State.ClientId.Should().Be("client-after-list-drift");
+        _agent.State.RedirectUris.Should().Equal(
+            "https://aevatar.test/api/oauth/nyxid-callback",
+            "https://console.test/auth/callback",
+            "https://ops.test/callback");
+        (await ReadEventsAsync<AevatarOAuthClientDriftReconciledEvent>())
+            .Should()
+            .ContainSingle(e => e.DriftKind == "redirect_uris");
+    }
+
+    [Fact]
     public async Task HandleEnsureProvisioned_ReDcrs_WhenLegacyScopeIsMissingProxy()
     {
         var redirectUri = "https://aevatar-console-backend-api.aevatar.ai/api/oauth/nyxid-callback";
@@ -236,6 +284,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         _agent.State.ProvisioningRetryAttempt.Should().Be(1);
         _agent.State.ProvisioningRetryAuthority.Should().Be("https://nyxid.test");
         _agent.State.ProvisioningRetryRedirectUri.Should().Be("https://aevatar.test/api/oauth/nyxid-callback");
+        _agent.State.ProvisioningRetryRedirectUris.Should().Equal("https://aevatar.test/api/oauth/nyxid-callback");
         _agent.State.ProvisioningRetryClientName.Should().Be("aevatar");
         _agent.State.ProvisioningRetryDueUnixMs.Should().BeGreaterThan(0);
         _agent.State.ProvisioningRetryCallbackGeneration.Should().Be(1);
@@ -275,7 +324,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         _agent.State.ProvisioningRetryAttempt.Should().Be(1);
         _callbackScheduler.TimeoutRequests.Should().ContainSingle();
 
-        await _agent.HandleProvisioningRetryFired(new AevatarOAuthClientProvisioningRetryFiredEvent
+        await _agent.HandleProvisioningRetryFired(AddRedirectUris(new AevatarOAuthClientProvisioningRetryFiredEvent
         {
             Attempt = _agent.State.ProvisioningRetryAttempt,
             DueUnixMs = _agent.State.ProvisioningRetryDueUnixMs,
@@ -285,7 +334,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
             CallbackId = _agent.State.ProvisioningRetryCallbackId,
             CallbackGeneration = _agent.State.ProvisioningRetryCallbackGeneration,
             FiredAtUnixMs = _agent.State.ProvisioningRetryDueUnixMs,
-        });
+        }, _agent.State.ProvisioningRetryRedirectUris));
 
         _registrar.Calls.Should().HaveCount(2,
             "only the durable self-callback may re-enter DCR before the external due-time gate opens");
@@ -641,6 +690,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
                 OauthScope = AevatarOAuthClientScopes.AuthorizationScope,
                 PersistedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
             };
+            peerEvent.RedirectUris.Add(resolvedRedirect);
             await store.AppendAsync(
                 actorId,
                 new[]
@@ -749,7 +799,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
     private sealed class RecordingDcrClient
     {
         public string NextClientId { get; set; } = "client-first";
-        public List<(string Authority, string ClientName, string RedirectUri)> Calls { get; } = new();
+        public List<(string Authority, string ClientName, string[] RedirectUris)> Calls { get; } = new();
         public Exception? ThrowOnRegister { get; set; }
 
         /// <summary>
@@ -773,9 +823,9 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
             }
 
             public override async Task<RegistrationResult> RegisterPublicClientAsync(
-                string authority, string clientName, string redirectUri, CancellationToken ct = default)
+                string authority, string clientName, IReadOnlyCollection<string> redirectUris, CancellationToken ct = default)
             {
-                _owner.Calls.Add((authority, clientName, redirectUri));
+                _owner.Calls.Add((authority, clientName, redirectUris.ToArray()));
                 if (_owner.OnRegistered is not null)
                     await _owner.OnRegistered().ConfigureAwait(false);
                 if (_owner.ThrowOnRegister is not null)
@@ -789,6 +839,14 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
                 throw new InvalidOperationException("HTTP client must not be invoked in unit tests");
         }
+    }
+
+    private static AevatarOAuthClientProvisioningRetryFiredEvent AddRedirectUris(
+        AevatarOAuthClientProvisioningRetryFiredEvent evt,
+        IEnumerable<string> redirectUris)
+    {
+        evt.RedirectUris.AddRange(redirectUris);
+        return evt;
     }
 
     private async Task<IReadOnlyList<T>> ReadEventsAsync<T>()

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientProjectionProviderTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientProjectionProviderTests.cs
@@ -1,0 +1,69 @@
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.GAgents.Channel.Identity;
+using FluentAssertions;
+using Google.Protobuf;
+using Xunit;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests.Identity;
+
+public sealed class AevatarOAuthClientProjectionProviderTests
+{
+    [Fact]
+    public async Task GetAsync_BackfillsRedirectUrisFromLegacyRedirectUri()
+    {
+        var document = ProvisionedDocument();
+        document.RedirectUri = "https://backend.test/api/oauth/nyxid-callback";
+        var provider = new AevatarOAuthClientProjectionProvider(new StubReader(document));
+
+        var snapshot = await provider.GetAsync();
+
+        snapshot.RedirectUri.Should().Be("https://backend.test/api/oauth/nyxid-callback");
+        snapshot.RedirectUris.Should().Equal("https://backend.test/api/oauth/nyxid-callback");
+    }
+
+    [Fact]
+    public async Task GetAsync_PreservesRepeatedRedirectUrisWhenPresent()
+    {
+        var document = ProvisionedDocument();
+        document.RedirectUri = "https://backend.test/api/oauth/nyxid-callback";
+        document.RedirectUris.Add("https://backend.test/api/oauth/nyxid-callback");
+        document.RedirectUris.Add("https://console.test/auth/callback");
+        var provider = new AevatarOAuthClientProjectionProvider(new StubReader(document));
+
+        var snapshot = await provider.GetAsync();
+
+        snapshot.RedirectUris.Should().Equal(
+            "https://backend.test/api/oauth/nyxid-callback",
+            "https://console.test/auth/callback");
+    }
+
+    private static AevatarOAuthClientDocument ProvisionedDocument() => new()
+    {
+        Id = AevatarOAuthClientGAgent.WellKnownId,
+        ClientId = "client-id",
+        ClientIdIssuedAtUnix = 1700000000,
+        HmacKey = ByteString.CopyFrom(new byte[32]),
+        HmacKeyRotatedAtUnix = 1700000001,
+        HmacKid = AevatarOAuthClientGAgent.InitialHmacKid,
+        NyxidAuthority = "https://nyxid.test",
+        OauthScope = AevatarOAuthClientScopes.AuthorizationScope,
+    };
+
+    private sealed class StubReader : IProjectionDocumentReader<AevatarOAuthClientDocument, string>
+    {
+        private readonly AevatarOAuthClientDocument _document;
+
+        public StubReader(AevatarOAuthClientDocument document)
+        {
+            _document = document;
+        }
+
+        public Task<AevatarOAuthClientDocument?> GetAsync(string key, CancellationToken ct = default) =>
+            Task.FromResult<AevatarOAuthClientDocument?>(_document);
+
+        public Task<ProjectionDocumentQueryResult<AevatarOAuthClientDocument>> QueryAsync(
+            ProjectionDocumentQuery query,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdDynamicClientRegistrationClientTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdDynamicClientRegistrationClientTests.cs
@@ -39,6 +39,32 @@ public sealed class NyxIdDynamicClientRegistrationClientTests
     }
 
     [Fact]
+    public async Task RegisterPublicClient_SendsAllNormalizedRedirectUris()
+    {
+        var handler = StubHandler.Json(HttpStatusCode.OK, new { client_id = "client-issued" });
+        var registrar = new NyxIdDynamicClientRegistrationClient(
+            new HttpClient(handler), NullLogger<NyxIdDynamicClientRegistrationClient>.Instance);
+
+        await registrar.RegisterPublicClientAsync(
+            "https://nyxid.test",
+            "aevatar",
+            [
+                " https://aevatar.test/api/oauth/nyxid-callback ",
+                "https://console.test/auth/callback",
+                "https://console.test/auth/callback",
+            ]);
+
+        var request = await handler.Last!.Content!.ReadFromJsonAsync<JsonElement>();
+        request.GetProperty("redirect_uris")
+            .EnumerateArray()
+            .Select(static item => item.GetString())
+            .Should()
+            .Equal(
+                "https://aevatar.test/api/oauth/nyxid-callback",
+                "https://console.test/auth/callback");
+    }
+
+    [Fact]
     public async Task RegisterPublicClient_FallsBackIssuedAt_WhenServerOmitsTimestamp()
     {
         var handler = StubHandler.Json(HttpStatusCode.OK, new { client_id = "client-no-ts" });

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRedirectUriResolverTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRedirectUriResolverTests.cs
@@ -17,16 +17,20 @@ namespace Aevatar.GAgents.ChannelRuntime.Tests.Identity;
 public sealed class NyxIdRedirectUriResolverTests : IDisposable
 {
     private readonly string? _savedOverride;
+    private readonly string? _savedAdditionalRedirectUris;
 
     public NyxIdRedirectUriResolverTests()
     {
         _savedOverride = Environment.GetEnvironmentVariable(NyxIdRedirectUriResolver.OverrideEnvVar);
+        _savedAdditionalRedirectUris = Environment.GetEnvironmentVariable(NyxIdRedirectUriResolver.AdditionalRedirectUrisEnvVar);
         Environment.SetEnvironmentVariable(NyxIdRedirectUriResolver.OverrideEnvVar, null);
+        Environment.SetEnvironmentVariable(NyxIdRedirectUriResolver.AdditionalRedirectUrisEnvVar, null);
     }
 
     public void Dispose()
     {
         Environment.SetEnvironmentVariable(NyxIdRedirectUriResolver.OverrideEnvVar, _savedOverride);
+        Environment.SetEnvironmentVariable(NyxIdRedirectUriResolver.AdditionalRedirectUrisEnvVar, _savedAdditionalRedirectUris);
     }
 
     [Fact]
@@ -85,6 +89,37 @@ public sealed class NyxIdRedirectUriResolverTests : IDisposable
 
         url.Should().Be(
             $"{NyxIdRedirectUriResolver.DefaultPublicBaseUrl}{NyxIdRedirectUriResolver.CallbackPath}");
+    }
+
+    [Fact]
+    public void ResolveRegisteredRedirectUris_IncludesExplicitAdditionalCallbacks()
+    {
+        Environment.SetEnvironmentVariable(NyxIdRedirectUriResolver.OverrideEnvVar, "https://backend.example.com");
+        Environment.SetEnvironmentVariable(
+            NyxIdRedirectUriResolver.AdditionalRedirectUrisEnvVar,
+            " https://console.example.com/auth/callback,https://ops.example.com/callback;https://console.example.com/auth/callback ");
+
+        var urls = NyxIdRedirectUriResolver.ResolveRegisteredRedirectUris();
+
+        urls.Should().Equal(
+            "https://backend.example.com" + NyxIdRedirectUriResolver.CallbackPath,
+            "https://console.example.com/auth/callback",
+            "https://ops.example.com/callback");
+    }
+
+    [Fact]
+    public void ResolveRegisteredRedirectUris_IgnoresWildcardAdditionalCallbacks()
+    {
+        Environment.SetEnvironmentVariable(NyxIdRedirectUriResolver.OverrideEnvVar, "https://backend.example.com");
+        Environment.SetEnvironmentVariable(
+            NyxIdRedirectUriResolver.AdditionalRedirectUrisEnvVar,
+            "http://+:8080/callback,https://console.example.com/auth/callback");
+
+        var urls = NyxIdRedirectUriResolver.ResolveRegisteredRedirectUris(NullLogger.Instance);
+
+        urls.Should().Equal(
+            "https://backend.example.com" + NyxIdRedirectUriResolver.CallbackPath,
+            "https://console.example.com/auth/callback");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add explicit `AEVATAR_OAUTH_ADDITIONAL_REDIRECT_URIS` support for broker OAuth client provisioning.
- Persist and drift-check the full NyxID redirect URI allowlist while keeping the backend callback as canonical.
- Expose registered/resolved redirect URI lists in status diagnostics and cover DCR, bootstrap, resolver, and actor drift behavior with tests.

## Test plan
- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo --filter \"NyxIdRedirectUriResolverTests|NyxIdDynamicClientRegistrationClientTests|AevatarOAuthClientBootstrapServiceTests|AevatarOAuthClientGAgentTests|IdentityOAuthClientRebuildEndpointTests\" -v quiet`
- [x] `bash tools/ci/test_stability_guards.sh`

Fixes #2351

🤖 Generated with [Claude Code](https://claude.com/claude-code)