### PR TITLE
Fix draft run file upload

### DIFF
--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -1058,15 +1058,29 @@ const enUSMessages = {
     'Close draft run panel',
   'teamMemberWorkflowStudio.draftRunPanel.emptyInputHint':
     'Leave blank to run this draft without user input.',
-  'teamMemberWorkflowStudio.draftRunPanel.filesBackendPendingNotice':
-    'File input for draft runs is pending backend support.',
+  'teamMemberWorkflowStudio.draftRunPanel.addFiles': 'Add files',
+  'teamMemberWorkflowStudio.draftRunPanel.attachFiles': 'Attach files',
+  'teamMemberWorkflowStudio.draftRunPanel.attachFilesButton': 'Add files',
+  'teamMemberWorkflowStudio.draftRunPanel.attachFilesInput': 'Attach files',
+  'teamMemberWorkflowStudio.draftRunPanel.dropFiles': 'Drop files here',
+  'teamMemberWorkflowStudio.draftRunPanel.filesHint':
+    'Attach files for this draft run.',
+  'teamMemberWorkflowStudio.draftRunPanel.filesLabel': 'Files',
+  'teamMemberWorkflowStudio.draftRunPanel.filesLimitHint':
+    'Images, documents, audio, video, CSV, and text files up to 10 MB.',
   'teamMemberWorkflowStudio.draftRunPanel.messageLabel':
     'Draft run input',
   'teamMemberWorkflowStudio.draftRunPanel.messagePlaceholder':
     'Optional input sent to this workflow draft run',
+  'teamMemberWorkflowStudio.draftRunPanel.noFilesAttached':
+    'No files attached',
+  'teamMemberWorkflowStudio.draftRunPanel.removeEmptyFile':
+    'Remove empty file {name} before starting the draft run.',
+  'teamMemberWorkflowStudio.draftRunPanel.removeFile': 'Remove {name}',
   'teamMemberWorkflowStudio.draftRunPanel.sectionAria': 'Draft run panel',
   'teamMemberWorkflowStudio.draftRunPanel.startDraftRun':
     'Start draft run',
+  'teamMemberWorkflowStudio.draftRunPanel.thisFile': 'this file',
   'teamMemberWorkflowStudio.draftRunPanel.title': 'Draft run',
   'teamMemberWorkflowStudio.runsPanel.description':
     'This tab only shows runs with an explicit link to the current workflow member.',

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -993,14 +993,28 @@ const zhCNMessages = {
   'teamMemberWorkflowStudio.draftRunPanel.closeAria': '关闭草稿运行面板',
   'teamMemberWorkflowStudio.draftRunPanel.emptyInputHint':
     '留空则不携带用户输入运行。',
-  'teamMemberWorkflowStudio.draftRunPanel.filesBackendPendingNotice':
-    '草稿运行文件输入等待后端支持。',
+  'teamMemberWorkflowStudio.draftRunPanel.addFiles': '添加文件',
+  'teamMemberWorkflowStudio.draftRunPanel.attachFiles': '添加文件',
+  'teamMemberWorkflowStudio.draftRunPanel.attachFilesButton': '添加文件',
+  'teamMemberWorkflowStudio.draftRunPanel.attachFilesInput': '添加文件',
+  'teamMemberWorkflowStudio.draftRunPanel.dropFiles': '拖放文件到这里',
+  'teamMemberWorkflowStudio.draftRunPanel.filesHint':
+    '为这次草稿运行添加文件。',
+  'teamMemberWorkflowStudio.draftRunPanel.filesLabel': '文件',
+  'teamMemberWorkflowStudio.draftRunPanel.filesLimitHint':
+    '支持图片、文档、音频、视频、CSV 和文本文件，单个文件最大 10 MB。',
   'teamMemberWorkflowStudio.draftRunPanel.messageLabel':
     '草稿运行输入',
   'teamMemberWorkflowStudio.draftRunPanel.messagePlaceholder':
     '本次 Workflow 草稿运行的可选输入',
+  'teamMemberWorkflowStudio.draftRunPanel.noFilesAttached':
+    '未添加文件',
+  'teamMemberWorkflowStudio.draftRunPanel.removeEmptyFile':
+    '开始草稿运行前请移除空文件 {name}。',
+  'teamMemberWorkflowStudio.draftRunPanel.removeFile': '移除 {name}',
   'teamMemberWorkflowStudio.draftRunPanel.sectionAria': '草稿运行面板',
   'teamMemberWorkflowStudio.draftRunPanel.startDraftRun': '开始草稿运行',
+  'teamMemberWorkflowStudio.draftRunPanel.thisFile': '此文件',
   'teamMemberWorkflowStudio.draftRunPanel.title': '草稿运行',
   'teamMemberWorkflowStudio.runsPanel.description':
     '这个 tab 只展示明确关联到当前 Workflow 成员的运行记录。',

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioDraftRunPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioDraftRunPanel.tsx
@@ -1,12 +1,22 @@
-import { InfoCircleOutlined, PlayCircleOutlined } from "@ant-design/icons";
-import { Button, Input, Typography } from "antd";
+import {
+  CloseOutlined,
+  FileImageOutlined,
+  FileOutlined,
+  PaperClipOutlined,
+  PlayCircleOutlined,
+} from "@ant-design/icons";
+import { Button, Input, Tooltip, Typography } from "antd";
 import React from "react";
 import { t } from "@/shared/i18n/messages";
 import WorkflowStudioSidePanel from "./WorkflowStudioSidePanel";
 
 type WorkflowStudioDraftRunPanelProps = {
+  readonly acceptedFileTypes?: string;
   readonly canRun: boolean;
   readonly disabledReason?: string;
+  readonly files?: readonly File[];
+  readonly onFilesAdd?: (files: readonly File[]) => void;
+  readonly onFileRemove?: (index: number) => void;
   readonly onClose: () => void;
   readonly onRun: () => void;
   readonly onRunMessageChange: (message: string) => void;
@@ -16,9 +26,128 @@ type WorkflowStudioDraftRunPanelProps = {
   readonly width?: number;
 };
 
+const DEFAULT_ACCEPTED_FILE_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "audio/mpeg",
+  "audio/wav",
+  "audio/wave",
+  "audio/x-wav",
+  "video/mp4",
+  "application/pdf",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "text/csv",
+  "text/plain",
+  "text/markdown",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+].join(",");
+
+const attachmentToolbarStyle: React.CSSProperties = {
+  alignItems: "center",
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 8,
+  minWidth: 0,
+};
+
+const attachmentListStyle: React.CSSProperties = {
+  alignItems: "center",
+  display: "flex",
+  flex: "1 1 220px",
+  flexWrap: "wrap",
+  gap: 6,
+  minWidth: 0,
+};
+
+const attachmentChipStyle: React.CSSProperties = {
+  alignItems: "center",
+  background: "#f8fafc",
+  border: "1px solid #dbe3ee",
+  borderRadius: 8,
+  color: "#334155",
+  display: "inline-flex",
+  gap: 6,
+  maxWidth: "100%",
+  minHeight: 28,
+  minWidth: 0,
+  padding: "3px 5px 3px 8px",
+};
+
+const attachmentNameStyle: React.CSSProperties = {
+  fontSize: 12,
+  fontWeight: 700,
+  lineHeight: "16px",
+  maxWidth: 168,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+const attachmentMetaStyle: React.CSSProperties = {
+  color: "#64748b",
+  flex: "0 0 auto",
+  fontSize: 11,
+  lineHeight: "14px",
+};
+
+const attachmentEmptyStyle: React.CSSProperties = {
+  color: "#64748b",
+  fontSize: 12,
+  lineHeight: "18px",
+};
+
+const fileDropZoneStyle: React.CSSProperties = {
+  alignItems: "center",
+  background: "#fbfcfe",
+  border: "1px dashed #cbd5e1",
+  borderRadius: 8,
+  color: "#475569",
+  display: "grid",
+  gap: 10,
+  justifyItems: "start",
+  minHeight: 84,
+  padding: "12px",
+};
+
+function formatFileSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return "0 B";
+  }
+
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+
+  const kib = bytes / 1024;
+  if (kib < 1024) {
+    return `${kib.toFixed(kib >= 10 ? 0 : 1)} KB`;
+  }
+
+  const mib = kib / 1024;
+  return `${mib.toFixed(mib >= 10 ? 0 : 1)} MB`;
+}
+
+function getFileIcon(file: File): React.ReactNode {
+  return file.type.startsWith("image/") ? <FileImageOutlined /> : <FileOutlined />;
+}
+
+function getAttachmentKey(file: File): string {
+  return [
+    file.name,
+    file.size,
+    file.lastModified,
+    file.type || "file",
+  ].join(":");
+}
+
 const WorkflowStudioDraftRunPanel: React.FC<WorkflowStudioDraftRunPanelProps> = ({
+  acceptedFileTypes = DEFAULT_ACCEPTED_FILE_TYPES,
   canRun,
   disabledReason,
+  files = [],
+  onFilesAdd,
+  onFileRemove,
   onClose,
   onRun,
   onRunMessageChange,
@@ -27,9 +156,18 @@ const WorkflowStudioDraftRunPanel: React.FC<WorkflowStudioDraftRunPanelProps> = 
   runMessage,
   width = 420,
 }) => {
+  const fileInputRef = React.useRef<HTMLInputElement | null>(null);
+  const inputLocked = pending;
+
   if (!open) {
     return null;
   }
+
+  const addFiles = (nextFiles: readonly File[]) => {
+    if (nextFiles.length > 0) {
+      onFilesAdd?.(nextFiles);
+    }
+  };
 
   return (
     <WorkflowStudioSidePanel
@@ -94,6 +232,7 @@ const WorkflowStudioDraftRunPanel: React.FC<WorkflowStudioDraftRunPanelProps> = 
               "Draft run input",
             )}
             autoSize={{ minRows: 7, maxRows: 10 }}
+            disabled={inputLocked}
             onChange={(event) => onRunMessageChange(event.target.value)}
             placeholder={t(
               "teamMemberWorkflowStudio.draftRunPanel.messagePlaceholder",
@@ -104,28 +243,126 @@ const WorkflowStudioDraftRunPanel: React.FC<WorkflowStudioDraftRunPanelProps> = 
           />
         </section>
 
-        <div
+        <section
           style={{
-            alignItems: "center",
-            background: "#f8fafc",
-            border: "1px solid #e5e7eb",
-            borderRadius: 4,
-            color: "#475569",
             display: "grid",
-            fontSize: 12,
-            gap: 8,
-            gridTemplateColumns: "auto minmax(0, 1fr)",
-            padding: "10px 12px",
+            gap: 10,
           }}
         >
-          <InfoCircleOutlined />
-          <Typography.Text style={{ color: "inherit", fontSize: 12 }}>
+          <div style={{ display: "grid", gap: 4 }}>
+            <Typography.Text strong>
+              {t("teamMemberWorkflowStudio.draftRunPanel.filesLabel", "Files")}
+            </Typography.Text>
+            <Typography.Text style={{ color: "#64748b" }}>
+              {t(
+                "teamMemberWorkflowStudio.draftRunPanel.filesHint",
+                "Attach files for this draft run.",
+              )}
+            </Typography.Text>
+          </div>
+          <input
+            ref={fileInputRef}
+            aria-label={t(
+              "teamMemberWorkflowStudio.draftRunPanel.attachFilesInput",
+              "Attach files",
+            )}
+            accept={acceptedFileTypes}
+            data-testid="draft-run-file-input"
+            multiple
+            onChange={(event) => {
+              addFiles(Array.from(event.target.files ?? []));
+              event.currentTarget.value = "";
+            }}
+            style={{ display: "none" }}
+            type="file"
+          />
+          <div
+            data-testid="draft-run-file-drop-zone"
+            onDragOver={(event) => {
+              event.preventDefault();
+              event.dataTransfer.dropEffect = inputLocked ? "none" : "copy";
+            }}
+            onDrop={(event) => {
+              event.preventDefault();
+              if (!inputLocked) {
+                addFiles(Array.from(event.dataTransfer.files ?? []));
+              }
+            }}
+            style={fileDropZoneStyle}
+          >
+            <div style={attachmentToolbarStyle}>
+              <Tooltip
+                title={t(
+                  "teamMemberWorkflowStudio.draftRunPanel.attachFiles",
+                  "Attach files",
+                )}
+              >
+                <Button
+                  aria-label={t(
+                    "teamMemberWorkflowStudio.draftRunPanel.attachFilesButton",
+                    "Add files",
+                  )}
+                  disabled={inputLocked}
+                  icon={<PaperClipOutlined />}
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  {t(
+                    "teamMemberWorkflowStudio.draftRunPanel.addFiles",
+                    "Add files",
+                  )}
+                </Button>
+              </Tooltip>
+              <Typography.Text style={{ color: "#64748b", fontSize: 12 }}>
+                {t(
+                  "teamMemberWorkflowStudio.draftRunPanel.dropFiles",
+                  "Drop files here",
+                )}
+              </Typography.Text>
+            </div>
+            <div style={attachmentListStyle}>
+              {files.length === 0 ? (
+                <span style={attachmentEmptyStyle}>
+                  {t(
+                    "teamMemberWorkflowStudio.draftRunPanel.noFilesAttached",
+                    "No files attached",
+                  )}
+                </span>
+              ) : (
+                files.map((file, index) => (
+                  <span
+                    key={getAttachmentKey(file)}
+                    data-testid="draft-run-file-chip"
+                    style={attachmentChipStyle}
+                  >
+                    {getFileIcon(file)}
+                    <Tooltip title={`${file.name} · ${file.type || "file"} · ${formatFileSize(file.size)}`}>
+                      <span style={attachmentNameStyle}>{file.name}</span>
+                    </Tooltip>
+                    <span style={attachmentMetaStyle}>{formatFileSize(file.size)}</span>
+                    <Button
+                      aria-label={t(
+                        "teamMemberWorkflowStudio.draftRunPanel.removeFile",
+                        "Remove {name}",
+                        { name: file.name },
+                      )}
+                      disabled={inputLocked}
+                      icon={<CloseOutlined />}
+                      onClick={() => onFileRemove?.(index)}
+                      size="small"
+                      type="text"
+                    />
+                  </span>
+                ))
+              )}
+            </div>
+          </div>
+          <Typography.Text style={{ color: "#64748b", fontSize: 12 }}>
             {t(
-              "teamMemberWorkflowStudio.draftRunPanel.filesBackendPendingNotice",
-              "File input for draft runs is pending backend support.",
+              "teamMemberWorkflowStudio.draftRunPanel.filesLimitHint",
+              "Images, documents, audio, video, CSV, and text files up to 10 MB.",
             )}
           </Typography.Text>
-        </div>
+        </section>
       </div>
 
       <div

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -76,6 +76,7 @@ type SavedWorkflowDraft = {
 
 type RunCurrentDraftVariables = {
   readonly document: StudioWorkflowDocument;
+  readonly files?: readonly File[];
   readonly runMessage: string;
   readonly title: string;
 };
@@ -195,10 +196,13 @@ type TeamMemberWorkflowStudioState = {
   readonly currentDraftRunPlaceholderReason: string;
   readonly executionDetail: StudioExecutionDetail | null;
   readonly executionError: string;
+  readonly draftRunFiles: readonly File[];
   readonly executionRunMessage: string;
   readonly executionStatus: WorkflowExecutionStatus;
   readonly activeExecutionLogIndex: number | null;
   readonly clearExecutionLogs: () => void;
+  readonly addDraftRunFiles: (files: readonly File[]) => void;
+  readonly removeDraftRunFile: (index: number) => void;
   readonly graph: ReturnType<typeof buildStudioGraphElements>;
   readonly insertNode: (stepType: string) => void;
   readonly linkedWorkflowMissing: boolean;
@@ -850,6 +854,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
   const [activeExecutionLogIndex, setActiveExecutionLogIndex] =
     React.useState<number | null>(null);
   const [executionRunMessage, setExecutionRunMessage] = React.useState("");
+  const [draftRunFiles, setDraftRunFiles] = React.useState<File[]>([]);
   const [pendingCreatedWorkflowMemberLink, setPendingCreatedWorkflowMemberLink] =
     React.useState<PendingCreatedWorkflowMemberLink | null>(null);
   const [publishBindingRun, setPublishBindingRun] =
@@ -1570,6 +1575,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
   const currentDraftRunMutation = useMutation({
     mutationFn: async ({
       document,
+      files,
       runMessage,
       title,
     }: RunCurrentDraftVariables): Promise<StudioExecutionDetail> => {
@@ -1619,6 +1625,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
           {
             prompt: userRunMessage,
             workflowYamls: [serialized.yaml],
+            files: files && files.length > 0 ? files : undefined,
           },
           controller.signal,
         );
@@ -2515,8 +2522,25 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
         return;
       }
 
+      const emptyFile = draftRunFiles.find((file) => file.size <= 0);
+      if (emptyFile) {
+        const errorMessage = t(
+          "teamMemberWorkflowStudio.draftRunPanel.removeEmptyFile",
+          "Remove empty file {name} before starting the draft run.",
+          {
+            name:
+              emptyFile.name ||
+              t("teamMemberWorkflowStudio.draftRunPanel.thisFile", "this file"),
+          },
+        );
+        setExecutionError(errorMessage);
+        void message.error(errorMessage);
+        return;
+      }
+
       currentDraftRunMutation.mutate({
         document: editableDocument,
+        files: draftRunFiles,
         runMessage: trimOptional(executionRunMessage),
         title: activeMemberTitle,
       });
@@ -2525,6 +2549,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     currentDraftRunPlaceholderReason,
     executionDetail,
     executionError,
+    draftRunFiles,
     executionRunMessage,
     executionStatus,
     activeExecutionLogIndex,
@@ -2532,6 +2557,16 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       setExecutionDetail(null);
       setExecutionError("");
       setActiveExecutionLogIndex(null);
+    },
+    addDraftRunFiles: (files: readonly File[]) => {
+      if (files.length > 0) {
+        setDraftRunFiles((current) => [...current, ...files]);
+      }
+    },
+    removeDraftRunFile: (index: number) => {
+      setDraftRunFiles((current) =>
+        current.filter((_, itemIndex) => itemIndex !== index),
+      );
     },
     graph: graphWithExecution,
     insertNode,

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -657,7 +657,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(runtimeRunsApi.streamChat).not.toHaveBeenCalled();
   });
 
-  it("keeps draft run file input unavailable until backend multipart support lands", async () => {
+  it("sends draft run files through the scope draft endpoint", async () => {
     window.history.replaceState(
       {},
       "",
@@ -672,13 +672,13 @@ describe("TeamMemberWorkflowStudioPage", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: "Run" }));
     const draftRunPanel = await screen.findByLabelText("Draft run panel");
-    expect(
-      within(draftRunPanel).getByText(
-        "File input for draft runs is pending backend support.",
-      ),
-    ).toBeTruthy();
-    expect(within(draftRunPanel).queryByTestId("draft-run-file-input")).toBeNull();
-    expect(within(draftRunPanel).queryByTestId("draft-run-file-drop-zone")).toBeNull();
+    expect(within(draftRunPanel).getByTestId("draft-run-file-drop-zone")).toBeTruthy();
+    expect(within(draftRunPanel).getByText("No files attached")).toBeTruthy();
+    const image = new File(["image-bytes"], "draft.png", { type: "image/png" });
+    fireEvent.change(within(draftRunPanel).getByTestId("draft-run-file-input"), {
+      target: { files: [image] },
+    });
+    expect(await within(draftRunPanel).findByText("draft.png")).toBeTruthy();
 
     fireEvent.click(await screen.findByRole("button", { name: "Add first step" }));
     fireEvent.click(
@@ -695,6 +695,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
       expect(runtimeRunsApi.streamDraftRun).toHaveBeenCalledWith(
         "scope-1",
         expect.objectContaining({
+          files: [image],
           prompt: "",
           workflowYamls: [expect.any(String)],
         }),

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
@@ -373,6 +373,9 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
         <WorkflowStudioDraftRunPanel
           canRun={studio.canRunCurrentDraft}
           disabledReason={studio.currentDraftRunPlaceholderReason}
+          files={studio.draftRunFiles}
+          onFilesAdd={studio.addDraftRunFiles}
+          onFileRemove={studio.removeDraftRunFile}
           onClose={studio.selectCanvas}
           onRun={studio.runCurrentDraft}
           onRunMessageChange={studio.setExecutionRunMessage}

--- a/apps/aevatar-console-web/src/shared/api/runtimeRunsApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/runtimeRunsApi.test.ts
@@ -439,6 +439,54 @@ describe("runtimeRunsApi", () => {
     );
   });
 
+  it("sends draft run file inputs as multipart form data", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+    } satisfies Partial<Response>);
+    const image = new File(["image-bytes"], "draft.png", { type: "image/png" });
+
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await runtimeRunsApi.streamDraftRun(
+      "scope-1",
+      {
+        files: [image],
+        metadata: { source: "studio-draft" },
+        prompt: "Describe this image",
+        workflowYamls: ["name: draft"],
+      },
+      new AbortController().signal,
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = new Headers(init.headers);
+    const formData = init.body as FormData;
+    const payload = formData.get("payload");
+    const uploadedFile = formData.get("file") as File;
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/scopes/scope-1/workflow/draft-run",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+    expect(headers.get("Accept")).toBe("text/event-stream");
+    expect(headers.has("Content-Type")).toBe(false);
+    expect(formData).toBeInstanceOf(FormData);
+    expect(typeof payload).toBe("string");
+    expect(JSON.parse(String(payload))).toEqual({
+      eventFormat: "agui",
+      prompt: "Describe this image",
+      workflowYamls: ["name: draft"],
+      headers: {
+        source: "studio-draft",
+      },
+    });
+    expect(uploadedFile.name).toBe("draft.png");
+    expect(uploadedFile.type).toBe("image/png");
+    expect(await readBlobText(uploadedFile)).toBe("image-bytes");
+  });
+
   it("routes getRunSummary through the scope run endpoint", async () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,

--- a/apps/aevatar-console-web/src/shared/api/runtimeRunsApi.ts
+++ b/apps/aevatar-console-web/src/shared/api/runtimeRunsApi.ts
@@ -222,6 +222,13 @@ export type StreamEndpointInvokeRequest = {
   files?: readonly File[];
 };
 
+export type DraftRunRequest = {
+  prompt?: string;
+  workflowYamls?: readonly string[];
+  metadata?: Record<string, string>;
+  files?: readonly File[];
+};
+
 export type WorkflowRunSummary = {
   actorId?: string;
   completionStatus?: string;
@@ -251,6 +258,53 @@ function buildStreamEndpointRequestInit(
   signal: AbortSignal
 ): RequestInit {
   const payload = buildStreamEndpointPayload(request);
+  const files = request.files?.filter(Boolean) ?? [];
+
+  if (files.length === 0) {
+    return {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "text/event-stream",
+      },
+      body: JSON.stringify(payload),
+      signal,
+    };
+  }
+
+  const formData = new FormData();
+  formData.append("payload", JSON.stringify(payload));
+  files.forEach((file) => {
+    formData.append("file", file, file.name);
+  });
+
+  return {
+    method: "POST",
+    headers: {
+      Accept: "text/event-stream",
+    },
+    body: formData,
+    signal,
+  };
+}
+
+function buildDraftRunPayload(request: DraftRunRequest) {
+  return compactObject({
+    eventFormat: "agui",
+    prompt: request.prompt?.trim() ?? "",
+    workflowYamls:
+      request.workflowYamls && request.workflowYamls.length > 0
+        ? request.workflowYamls
+        : undefined,
+    headers: request.metadata,
+  });
+}
+
+function buildDraftRunRequestInit(
+  request: DraftRunRequest,
+  signal: AbortSignal
+): RequestInit {
+  const payload = buildDraftRunPayload(request);
   const files = request.files?.filter(Boolean) ?? [];
 
   if (files.length === 0) {
@@ -359,28 +413,13 @@ export const runtimeRunsApi = {
 
   async streamDraftRun(
     scopeId: string,
-    request: ChatRunRequest,
+    request: DraftRunRequest,
     signal: AbortSignal
   ): Promise<Response> {
-    const response = await authFetch(`${buildScopePath(scopeId)}/workflow/draft-run`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "text/event-stream",
-      },
-      body: JSON.stringify(
-        compactObject({
-          eventFormat: "agui",
-          prompt: request.prompt.trim(),
-          workflowYamls:
-            request.workflowYamls && request.workflowYamls.length > 0
-              ? request.workflowYamls
-              : undefined,
-          headers: request.metadata,
-        })
-      ),
-      signal,
-    });
+    const response = await authFetch(
+      `${buildScopePath(scopeId)}/workflow/draft-run`,
+      buildDraftRunRequestInit(request, signal)
+    );
 
     if (!response.ok) {
       throw new Error(await readResponseError(response));


### PR DESCRIPTION
## Problem
- Draft run panel showed `File input for draft runs is pending backend support.` and hid file upload controls.
- Backend already supports multipart `workflow/draft-run` requests with `payload` JSON plus `file` form fields, so the frontend gating was stale.

## Solution
- Add file attachment controls to the Team member workflow draft-run side panel.
- Thread selected files through the workflow studio hook and block empty files locally before dispatch.
- Teach `runtimeRunsApi.streamDraftRun` to keep JSON for text-only runs and switch to multipart form data when files are attached.
- Update English/Chinese copy and focused tests for the restored upload path.

## Impact
- Affects `apps/aevatar-console-web` draft-run UI and the scope workflow draft-run API client only.
- No backend contract changes.

## Verification
- `pnpm --dir apps/aevatar-console-web test --runInBand src/shared/api/runtimeRunsApi.test.ts`
- `pnpm --dir apps/aevatar-console-web test --runInBand src/pages/team-member-workflow-studio/index.test.tsx`
- `pnpm --dir apps/aevatar-console-web tsc`
- `bash tools/ci/test_stability_guards.sh`
- `git diff --check`