### PR TITLE
Add force NyxID DCR startup override

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientBootstrapService.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientBootstrapService.cs
@@ -18,6 +18,7 @@ namespace Aevatar.GAgents.Channel.Identity;
 public sealed class AevatarOAuthClientBootstrapService : IHostedService
 {
     private const string ClientName = "aevatar";
+    public const string ForceDcrOnStartupEnvVar = "AEVATAR_OAUTH_FORCE_DCR_ON_STARTUP";
 
     private readonly ICommandDispatchService<EnsureAevatarOAuthClientProvisionedCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> _provisioningDispatch;
     private readonly ILogger<AevatarOAuthClientBootstrapService> _logger;
@@ -55,12 +56,24 @@ public sealed class AevatarOAuthClientBootstrapService : IHostedService
         // authorize / token time — both call sites use NyxIdRedirectUriResolver.
         var redirectUri = NyxIdRedirectUriResolver.Resolve(_logger);
         var redirectUris = NyxIdRedirectUriResolver.ResolveRegisteredRedirectUris(_logger);
+        var forceReprovision = string.Equals(
+            Environment.GetEnvironmentVariable(ForceDcrOnStartupEnvVar),
+            "true",
+            StringComparison.OrdinalIgnoreCase);
+
+        if (forceReprovision)
+        {
+            _logger.LogWarning(
+                "Aevatar OAuth client force DCR is enabled by {EnvVar}; disable it after one successful startup to avoid creating a new NyxID client on every restart.",
+                ForceDcrOnStartupEnvVar);
+        }
 
         var command = new EnsureAevatarOAuthClientProvisionedCommand
         {
             NyxidAuthority = authority,
             RedirectUri = redirectUri,
             ClientName = ClientName,
+            ForceReprovision = forceReprovision,
         };
         command.RedirectUris.AddRange(redirectUris);
 

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
@@ -62,6 +62,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             .On<AevatarOAuthClientBrokerCapabilityObservedEvent>(ApplyBrokerCapabilityObserved)
             .On<AevatarOAuthClientProvisioningRetryScheduledEvent>(ApplyProvisioningRetryScheduled)
             .On<AevatarOAuthClientProvisioningRetryClearedEvent>(ApplyProvisioningRetryCleared)
+            .On<AevatarOAuthClientForceReprovisionConsumedEvent>(ApplyForceReprovisionConsumed)
             .On<AevatarOAuthClientDriftReconciledEvent>(static (state, _) => state)
             .OrCurrent();
 
@@ -86,7 +87,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         bool allowPendingRetryBypass)
     {
         ArgumentNullException.ThrowIfNull(cmd);
-        if (!cmd.ForceReprovision && !allowPendingRetryBypass && HasPendingProvisioningRetryNotDue(DateTimeOffset.UtcNow))
+        if (!allowPendingRetryBypass && HasPendingProvisioningRetryNotDue(DateTimeOffset.UtcNow))
         {
             Logger.LogInformation(
                 "Ignoring duplicate external aevatar OAuth client provisioning ensure while actor-owned retry is pending: attempt={Attempt}, due_unix_ms={DueUnixMs}",
@@ -121,9 +122,19 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             return;
         }
 
+        if (!cmd.ForceReprovision && State.ForceReprovisionConsumed)
+        {
+            await PersistDomainEventAsync(new AevatarOAuthClientForceReprovisionConsumedEvent
+            {
+                Consumed = false,
+                PersistedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            }).ConfigureAwait(false);
+        }
+
         var expectedRedirectUris = NormalizeProvisioningRedirectUris(cmd.RedirectUris, cmd.RedirectUri);
         var sameClient = !string.IsNullOrEmpty(State.ClientId)
             && string.Equals(State.NyxidAuthority, cmd.NyxidAuthority, StringComparison.Ordinal);
+        var forceReprovision = cmd.ForceReprovision && !State.ForceReprovisionConsumed;
 
         // Redirect URI drift: re-DCR when the persisted callback no longer
         // matches what the resolver hands us. Original prod incident
@@ -144,7 +155,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 || !RedirectUriListsEqual(State.RedirectUris, expectedRedirectUris));
         var oauthScopeDrifted = sameClient && !AevatarOAuthClientScopes.ContainsRequiredScopes(State.OauthScope);
 
-        if (sameClient && !cmd.ForceReprovision && !redirectUriDrifted && !redirectUriListDrifted && !oauthScopeDrifted)
+        if (sameClient && !forceReprovision && !redirectUriDrifted && !redirectUriListDrifted && !oauthScopeDrifted)
         {
             // Seed HMAC key on first activation against an existing client_id
             // (defence-in-depth against partial state loaded from snapshots).
@@ -191,7 +202,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 State.OauthScope,
                 AevatarOAuthClientScopes.AuthorizationScope);
         }
-        if (cmd.ForceReprovision)
+        if (forceReprovision)
         {
             Logger.LogWarning(
                 "Aevatar OAuth client force DCR requested: stored_client_id={ClientId}, authority={Authority}, redirect_uris={RedirectUris}.",
@@ -287,6 +298,15 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             Logger.LogInformation("Seeded HMAC key for aevatar OAuth client");
         }
 
+        if (cmd.ForceReprovision)
+        {
+            await PersistDomainEventAsync(new AevatarOAuthClientForceReprovisionConsumedEvent
+            {
+                Consumed = true,
+                PersistedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            }).ConfigureAwait(false);
+        }
+
         await ClearProvisioningRetryAsync("ensure_provisioned");
     }
 
@@ -309,6 +329,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             NyxidAuthority = State.ProvisioningRetryAuthority,
             RedirectUri = State.ProvisioningRetryRedirectUri,
             ClientName = State.ProvisioningRetryClientName,
+            ForceReprovision = State.ProvisioningRetryForceReprovision,
         };
         command.RedirectUris.AddRange(State.ProvisioningRetryRedirectUris);
         await HandleEnsureProvisionedAsync(command, allowPendingRetryBypass: true).ConfigureAwait(false);
@@ -329,6 +350,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             || !string.Equals(evt.NyxidAuthority, State.ProvisioningRetryAuthority, StringComparison.Ordinal)
             || !string.Equals(evt.RedirectUri, State.ProvisioningRetryRedirectUri, StringComparison.Ordinal)
             || !string.Equals(evt.ClientName, State.ProvisioningRetryClientName, StringComparison.Ordinal)
+            || evt.ForceReprovision != State.ProvisioningRetryForceReprovision
             || !RedirectUriListsEqual(
                 NormalizeProvisioningRedirectUris(evt.RedirectUris, evt.RedirectUri),
                 State.ProvisioningRetryRedirectUris))
@@ -380,6 +402,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             ClientName = normalized.ClientName,
             CallbackId = callbackId,
             FiredAtUnixMs = due.ToUnixTimeMilliseconds(),
+            ForceReprovision = normalized.ForceReprovision,
         };
         callbackPayload.RedirectUris.AddRange(normalized.RedirectUris);
         var lease = await ScheduleSelfDurableTimeoutAsync(
@@ -400,6 +423,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             CallbackGeneration = lease.Generation,
             LastError = error.Message,
             ScheduledAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            ForceReprovision = normalized.ForceReprovision,
         };
         scheduled.RedirectUris.AddRange(normalized.RedirectUris);
         await PersistDomainEventAsync(scheduled).ConfigureAwait(false);
@@ -483,6 +507,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             NyxidAuthority = cmd.NyxidAuthority.Trim(),
             RedirectUri = cmd.RedirectUri.Trim(),
             ClientName = string.IsNullOrWhiteSpace(cmd.ClientName) ? "aevatar" : cmd.ClientName.Trim(),
+            ForceReprovision = cmd.ForceReprovision,
         };
         normalized.RedirectUris.AddRange(NormalizeProvisioningRedirectUris(cmd.RedirectUris, normalized.RedirectUri));
         return normalized;
@@ -805,6 +830,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         next.ProvisioningRetryRedirectUris.Clear();
         next.ProvisioningRetryRedirectUris.AddRange(NormalizeProvisioningRedirectUris(evt.RedirectUris, next.ProvisioningRetryRedirectUri));
         next.ProvisioningRetryClientName = evt.ClientName ?? string.Empty;
+        next.ProvisioningRetryForceReprovision = evt.ForceReprovision;
         next.ProvisioningRetryCallbackId = evt.CallbackId ?? string.Empty;
         next.ProvisioningRetryCallbackGeneration = evt.CallbackGeneration;
         next.ProvisioningRetryLastError = evt.LastError ?? string.Empty;
@@ -823,9 +849,19 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         next.ProvisioningRetryRedirectUri = string.Empty;
         next.ProvisioningRetryRedirectUris.Clear();
         next.ProvisioningRetryClientName = string.Empty;
+        next.ProvisioningRetryForceReprovision = false;
         next.ProvisioningRetryCallbackId = string.Empty;
         next.ProvisioningRetryCallbackGeneration = 0;
         next.ProvisioningRetryLastError = string.Empty;
+        return next;
+    }
+
+    private static AevatarOAuthClientState ApplyForceReprovisionConsumed(
+        AevatarOAuthClientState current,
+        AevatarOAuthClientForceReprovisionConsumedEvent evt)
+    {
+        var next = current.Clone();
+        next.ForceReprovisionConsumed = evt.Consumed;
         return next;
     }
 }

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
@@ -86,7 +86,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         bool allowPendingRetryBypass)
     {
         ArgumentNullException.ThrowIfNull(cmd);
-        if (!allowPendingRetryBypass && HasPendingProvisioningRetryNotDue(DateTimeOffset.UtcNow))
+        if (!cmd.ForceReprovision && !allowPendingRetryBypass && HasPendingProvisioningRetryNotDue(DateTimeOffset.UtcNow))
         {
             Logger.LogInformation(
                 "Ignoring duplicate external aevatar OAuth client provisioning ensure while actor-owned retry is pending: attempt={Attempt}, due_unix_ms={DueUnixMs}",
@@ -144,7 +144,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 || !RedirectUriListsEqual(State.RedirectUris, expectedRedirectUris));
         var oauthScopeDrifted = sameClient && !AevatarOAuthClientScopes.ContainsRequiredScopes(State.OauthScope);
 
-        if (sameClient && !redirectUriDrifted && !redirectUriListDrifted && !oauthScopeDrifted)
+        if (sameClient && !cmd.ForceReprovision && !redirectUriDrifted && !redirectUriListDrifted && !oauthScopeDrifted)
         {
             // Seed HMAC key on first activation against an existing client_id
             // (defence-in-depth against partial state loaded from snapshots).
@@ -190,6 +190,14 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 "Re-running DCR to register a new client_id at NyxID with proxy-capable scopes.",
                 State.OauthScope,
                 AevatarOAuthClientScopes.AuthorizationScope);
+        }
+        if (cmd.ForceReprovision)
+        {
+            Logger.LogWarning(
+                "Aevatar OAuth client force DCR requested: stored_client_id={ClientId}, authority={Authority}, redirect_uris={RedirectUris}.",
+                State.ClientId,
+                cmd.NyxidAuthority,
+                string.Join(",", expectedRedirectUris));
         }
 
         var registrar = Services.GetService<NyxIdDynamicClientRegistrationClient>();

--- a/agents/Aevatar.GAgents.Channel.Identity/protos/aevatar_oauth_client.proto
+++ b/agents/Aevatar.GAgents.Channel.Identity/protos/aevatar_oauth_client.proto
@@ -77,6 +77,14 @@ message AevatarOAuthClientState {
   repeated string redirect_uris = 22;
   // Full redirect URI allowlist captured for an actor-owned provisioning retry.
   repeated string provisioning_retry_redirect_uris = 23;
+  // Whether the pending actor-owned provisioning retry must preserve a
+  // break-glass force-DCR intent.
+  bool provisioning_retry_force_reprovision = 24;
+  // Actor-side one-shot guard for the startup force-DCR switch. Set after one
+  // forced DCR succeeds so multi-silo startup broadcasts cannot create one
+  // NyxID client per silo. Cleared by the next normal (non-force) ensure after
+  // operators remove AEVATAR_OAUTH_FORCE_DCR_ON_STARTUP.
+  bool force_reprovision_consumed = 25;
 }
 
 // Issued by the bootstrap startup service from every silo on cluster cold-
@@ -111,6 +119,7 @@ message AevatarOAuthClientProvisioningRetryFiredEvent {
   int64 callback_generation = 7;
   int64 fired_at_unix_ms = 8;
   repeated string redirect_uris = 9;
+  bool force_reprovision = 10;
 }
 
 // Issued by tests / manual operator scripts that already hold a client_id
@@ -169,6 +178,7 @@ message AevatarOAuthClientProvisioningRetryScheduledEvent {
   string last_error = 8;
   google.protobuf.Timestamp scheduled_at = 9;
   repeated string redirect_uris = 10;
+  bool force_reprovision = 11;
 }
 
 // Persisted when provisioning reaches a terminal successful branch and the
@@ -176,6 +186,15 @@ message AevatarOAuthClientProvisioningRetryScheduledEvent {
 message AevatarOAuthClientProvisioningRetryClearedEvent {
   string reason = 1;
   google.protobuf.Timestamp cleared_at = 2;
+}
+
+// Persisted when the actor consumes or resets the one-shot startup force-DCR
+// guard. This keeps AEVATAR_OAUTH_FORCE_DCR_ON_STARTUP cluster-idempotent
+// across multi-silo bootstrap broadcasts while allowing a later normal startup
+// to reset the guard after operators remove the env var.
+message AevatarOAuthClientForceReprovisionConsumedEvent {
+  bool consumed = 1;
+  google.protobuf.Timestamp persisted_at = 2;
 }
 
 // Persisted when actor-owned drift reconciliation succeeds through DCR.

--- a/agents/Aevatar.GAgents.Channel.Identity/protos/aevatar_oauth_client.proto
+++ b/agents/Aevatar.GAgents.Channel.Identity/protos/aevatar_oauth_client.proto
@@ -92,6 +92,10 @@ message EnsureAevatarOAuthClientProvisionedCommand {
   // Full redirect URI allowlist to register at NyxID. Empty means legacy caller;
   // the actor falls back to [redirect_uri].
   repeated string redirect_uris = 4;
+  // Break-glass: force DCR even when stored state appears provisioned. Operators
+  // must disable the startup env switch after one successful run to avoid
+  // creating a new NyxID client on every restart.
+  bool force_reprovision = 5;
 }
 
 // Durable self-callback payload fired when an actor-owned OAuth provisioning

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientBootstrapServiceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientBootstrapServiceTests.cs
@@ -27,6 +27,21 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
         command.RedirectUri.Should().Be(environment.RedirectUri);
         command.RedirectUris.Should().Equal(environment.RedirectUri, environment.ConsoleRedirectUri);
         command.ClientName.Should().Be("aevatar");
+        command.ForceReprovision.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task StartAsync_SetsForceReprovision_WhenBreakGlassEnvIsEnabled()
+    {
+        using var environment = new OAuthBootstrapEnvironment(forceDcrOnStartup: true);
+        var dispatch = new RecordingCommandDispatch<EnsureAevatarOAuthClientProvisionedCommand>(
+            static _ => OAuthClientReceipt());
+        var service = NewService(dispatch);
+
+        await service.StartAsync(CancellationToken.None);
+
+        dispatch.Commands.Should().ContainSingle();
+        dispatch.Commands[0].ForceReprovision.Should().BeTrue();
     }
 
     [Fact]
@@ -45,6 +60,7 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
         command.RedirectUri.Should().Be(environment.RedirectUri);
         command.RedirectUris.Should().Equal(environment.RedirectUri, environment.ConsoleRedirectUri);
         command.ClientName.Should().Be("aevatar");
+        command.ForceReprovision.Should().BeFalse();
     }
 
     [Fact]
@@ -144,20 +160,25 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
         private readonly string? _oldAuthority;
         private readonly string? _oldRedirectBaseUrl;
         private readonly string? _oldAdditionalRedirectUris;
+        private readonly string? _oldForceDcrOnStartup;
 
         public string Authority { get; } = "https://nyxid.test";
         public string RedirectBaseUrl { get; } = "https://aevatar.test";
         public string RedirectUri => $"{RedirectBaseUrl}{NyxIdRedirectUriResolver.CallbackPath}";
         public string ConsoleRedirectUri { get; } = "https://console.test/auth/callback";
 
-        public OAuthBootstrapEnvironment()
+        public OAuthBootstrapEnvironment(bool forceDcrOnStartup = false)
         {
             _oldAuthority = Environment.GetEnvironmentVariable(NyxIdAuthorityResolver.OverrideEnvVar);
             _oldRedirectBaseUrl = Environment.GetEnvironmentVariable(NyxIdRedirectUriResolver.OverrideEnvVar);
             _oldAdditionalRedirectUris = Environment.GetEnvironmentVariable(NyxIdRedirectUriResolver.AdditionalRedirectUrisEnvVar);
+            _oldForceDcrOnStartup = Environment.GetEnvironmentVariable(AevatarOAuthClientBootstrapService.ForceDcrOnStartupEnvVar);
             Environment.SetEnvironmentVariable(NyxIdAuthorityResolver.OverrideEnvVar, Authority);
             Environment.SetEnvironmentVariable(NyxIdRedirectUriResolver.OverrideEnvVar, RedirectBaseUrl);
             Environment.SetEnvironmentVariable(NyxIdRedirectUriResolver.AdditionalRedirectUrisEnvVar, ConsoleRedirectUri);
+            Environment.SetEnvironmentVariable(
+                AevatarOAuthClientBootstrapService.ForceDcrOnStartupEnvVar,
+                forceDcrOnStartup ? "true" : null);
         }
 
         public void Dispose()
@@ -165,6 +186,7 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
             Environment.SetEnvironmentVariable(NyxIdAuthorityResolver.OverrideEnvVar, _oldAuthority);
             Environment.SetEnvironmentVariable(NyxIdRedirectUriResolver.OverrideEnvVar, _oldRedirectBaseUrl);
             Environment.SetEnvironmentVariable(NyxIdRedirectUriResolver.AdditionalRedirectUrisEnvVar, _oldAdditionalRedirectUris);
+            Environment.SetEnvironmentVariable(AevatarOAuthClientBootstrapService.ForceDcrOnStartupEnvVar, _oldForceDcrOnStartup);
         }
     }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
@@ -119,6 +119,33 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task HandleEnsureProvisioned_ForceReprovision_ReDcrs_WhenAlreadyProvisioned()
+    {
+        var cmd = new EnsureAevatarOAuthClientProvisionedCommand
+        {
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            ClientName = "aevatar",
+        };
+        cmd.RedirectUris.Add("https://aevatar.test/api/oauth/nyxid-callback");
+        cmd.RedirectUris.Add("https://console.test/auth/callback");
+
+        await _agent.HandleEnsureProvisioned(cmd);
+        var firstClientId = _agent.State.ClientId;
+
+        _registrar.NextClientId = "client-after-force-dcr";
+        cmd.ForceReprovision = true;
+        await _agent.HandleEnsureProvisioned(cmd);
+
+        _registrar.Calls.Should().HaveCount(2, "break-glass force DCR must bypass the already-provisioned no-op");
+        _agent.State.ClientId.Should().Be("client-after-force-dcr");
+        _agent.State.ClientId.Should().NotBe(firstClientId);
+        _agent.State.RedirectUris.Should().Equal(
+            "https://aevatar.test/api/oauth/nyxid-callback",
+            "https://console.test/auth/callback");
+    }
+
+    [Fact]
     public async Task HandleEnsureProvisioned_ReDcrs_WhenRedirectUriDrifts()
     {
         // Pin the aismart-app-mainnet 2026-04-30 incident: cluster was

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
@@ -143,6 +143,83 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         _agent.State.RedirectUris.Should().Equal(
             "https://aevatar.test/api/oauth/nyxid-callback",
             "https://console.test/auth/callback");
+        _agent.State.ForceReprovisionConsumed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HandleEnsureProvisioned_ForceReprovision_IsConsumedOnce()
+    {
+        var cmd = new EnsureAevatarOAuthClientProvisionedCommand
+        {
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            ClientName = "aevatar",
+        };
+        cmd.RedirectUris.Add("https://aevatar.test/api/oauth/nyxid-callback");
+        cmd.RedirectUris.Add("https://console.test/auth/callback");
+
+        await _agent.HandleEnsureProvisioned(cmd);
+
+        _registrar.NextClientId = "client-after-force-dcr";
+        cmd.ForceReprovision = true;
+        await _agent.HandleEnsureProvisioned(cmd);
+        await _agent.HandleEnsureProvisioned(cmd);
+
+        _registrar.Calls.Should().HaveCount(2, "only one startup force DCR should be consumed cluster-wide");
+        _agent.State.ClientId.Should().Be("client-after-force-dcr");
+        _agent.State.ForceReprovisionConsumed.Should().BeTrue();
+
+        cmd.ForceReprovision = false;
+        await _agent.HandleEnsureProvisioned(cmd);
+        _agent.State.ForceReprovisionConsumed.Should().BeFalse("normal startup after env removal resets the break-glass guard");
+    }
+
+    [Fact]
+    public async Task HandleProvisioningRetryFired_PreservesForceReprovision_WhenForcedDcrFails()
+    {
+        await _agent.HandleEnsureProvisioned(new EnsureAevatarOAuthClientProvisionedCommand
+        {
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            ClientName = "aevatar",
+        });
+
+        _registrar.ThrowOnRegister = new InvalidOperationException("nyxid unavailable");
+        var force = new EnsureAevatarOAuthClientProvisionedCommand
+        {
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            ClientName = "aevatar",
+            ForceReprovision = true,
+        };
+        force.RedirectUris.Add("https://aevatar.test/api/oauth/nyxid-callback");
+        force.RedirectUris.Add("https://console.test/auth/callback");
+        await _agent.HandleEnsureProvisioned(force);
+
+        _agent.State.ProvisioningRetryForceReprovision.Should().BeTrue();
+        _callbackScheduler.TimeoutRequests.Should().ContainSingle();
+        _callbackScheduler.TimeoutRequests[0].TriggerEnvelope.Payload
+            .Unpack<AevatarOAuthClientProvisioningRetryFiredEvent>()
+            .ForceReprovision.Should().BeTrue();
+
+        _registrar.ThrowOnRegister = null;
+        _registrar.NextClientId = "client-after-force-retry";
+        await _agent.HandleProvisioningRetryFired(AddRedirectUris(new AevatarOAuthClientProvisioningRetryFiredEvent
+        {
+            Attempt = _agent.State.ProvisioningRetryAttempt,
+            DueUnixMs = _agent.State.ProvisioningRetryDueUnixMs,
+            NyxidAuthority = _agent.State.ProvisioningRetryAuthority,
+            RedirectUri = _agent.State.ProvisioningRetryRedirectUri,
+            ClientName = _agent.State.ProvisioningRetryClientName,
+            CallbackId = _agent.State.ProvisioningRetryCallbackId,
+            CallbackGeneration = _agent.State.ProvisioningRetryCallbackGeneration,
+            FiredAtUnixMs = _agent.State.ProvisioningRetryDueUnixMs,
+            ForceReprovision = true,
+        }, _agent.State.ProvisioningRetryRedirectUris));
+
+        _registrar.Calls.Should().HaveCount(3, "the retry must preserve and execute the force-DCR intent");
+        _agent.State.ClientId.Should().Be("client-after-force-retry");
+        _agent.State.ProvisioningRetryAttempt.Should().Be(0);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add `AEVATAR_OAUTH_FORCE_DCR_ON_STARTUP` as a break-glass startup override.
- Let OAuth bootstrap mark `EnsureAevatarOAuthClientProvisionedCommand` for forced reprovisioning.
- Bypass the actor already-provisioned no-op for that one forced command and cover the behavior with tests.

## Test plan
- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo --filter "AevatarOAuthClientBootstrapServiceTests|AevatarOAuthClientGAgentTests"`
- [x] `bash tools/ci/test_stability_guards.sh`

## Deployment note
Set `AEVATAR_OAUTH_FORCE_DCR_ON_STARTUP=true` for one backend restart only, confirm DCR/status, then remove the env var so future restarts do not create new NyxID clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)