### PR TITLE
Add Studio workflow save-and-bind endpoint

### DIFF
--- a/src/platform/Aevatar.GAgentService.Abstractions/Ports/IScopeWorkflowSaveAndBindPort.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Ports/IScopeWorkflowSaveAndBindPort.cs
@@ -1,0 +1,8 @@
+namespace Aevatar.GAgentService.Abstractions.Ports;
+
+public interface IScopeWorkflowSaveAndBindPort
+{
+    Task<ScopeWorkflowSaveAndBindResult> SaveAndBindAsync(
+        ScopeWorkflowSaveAndBindRequest request,
+        CancellationToken ct = default);
+}

--- a/src/platform/Aevatar.GAgentService.Abstractions/ScopeWorkflows/ScopeWorkflowModels.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/ScopeWorkflows/ScopeWorkflowModels.cs
@@ -11,6 +11,17 @@ public sealed record ScopeWorkflowUpsertRequest(
     IReadOnlyDictionary<string, string>? InlineWorkflowYamls = null,
     string? RevisionId = null);
 
+public sealed record ScopeWorkflowSaveAndBindRequest(
+    string ScopeId,
+    string? WorkflowId,
+    string WorkflowYaml,
+    string? WorkflowName = null,
+    string? DisplayName = null,
+    IReadOnlyDictionary<string, string>? InlineWorkflowYamls = null,
+    string? AppId = null,
+    string? ServiceId = null,
+    bool? ExposureDesired = null);
+
 public enum ScopeWorkflowLookupStatus
 {
     NotFound = 0,
@@ -77,3 +88,12 @@ public sealed record ScopeWorkflowUpsertResult(
     string PropagationStage = "readmodel_propagating",
     string DisplayName = "",
     string WorkflowName = "");
+
+public sealed record ScopeWorkflowSaveAndBindResult(
+    string ScopeId,
+    string WorkflowId,
+    string RevisionId,
+    ScopeWorkflowUpsertResult Workflow,
+    ScopeBindingUpsertResult Binding,
+    string AcceptanceStage = "accepted",
+    string PropagationStage = "readmodel_propagating");

--- a/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingCommandApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingCommandApplicationService.cs
@@ -367,11 +367,14 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
         CancellationToken ct)
     {
         var workflowBundle = await ParseWorkflowBundleAsync(request.Workflow?.WorkflowYamls, ct);
-        var workflowId = ResolveWorkflowBindingWorkflowId(request, identity);
-        var definitionActorIdPrefix = ScopeWorkflowCapabilityConventions.BuildDefinitionActorIdPrefix(
-            _options,
-            normalizedScopeId,
-            workflowId);
+        var suppliedWorkflowId = ScopeWorkflowCapabilityConventions.NormalizeOptional(request.Workflow?.WorkflowId);
+        var workflowId = ResolveWorkflowBindingWorkflowId(suppliedWorkflowId, identity);
+        var definitionActorIdPrefix = string.IsNullOrWhiteSpace(suppliedWorkflowId)
+            ? ScopeWorkflowCapabilityConventions.BuildDefaultDefinitionActorIdPrefix(_options, normalizedScopeId)
+            : ScopeWorkflowCapabilityConventions.BuildDefinitionActorIdPrefix(
+                _options,
+                normalizedScopeId,
+                workflowId);
         var displayName = ScopeWorkflowCapabilityConventions.ResolveDisplayName(
             request.DisplayName,
             workflowBundle.EntryWorkflowName);
@@ -546,13 +549,12 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
     }
 
     private static string ResolveWorkflowBindingWorkflowId(
-        ScopeBindingUpsertRequest request,
+        string? suppliedWorkflowId,
         ServiceIdentity identity)
     {
-        var workflowId = ScopeWorkflowCapabilityConventions.NormalizeOptional(request.Workflow?.WorkflowId);
-        return string.IsNullOrWhiteSpace(workflowId)
+        return string.IsNullOrWhiteSpace(suppliedWorkflowId)
             ? ScopeWorkflowCapabilityOptions.NormalizeRequired(identity.ServiceId, nameof(identity.ServiceId))
-            : ScopeWorkflowCapabilityConventions.NormalizeWorkflowId(workflowId);
+            : ScopeWorkflowCapabilityConventions.NormalizeWorkflowId(suppliedWorkflowId);
     }
 
     private string NormalizeGAgentKind(ScopeBindingGAgentSpec gagent)

--- a/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingCommandApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingCommandApplicationService.cs
@@ -367,9 +367,11 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
         CancellationToken ct)
     {
         var workflowBundle = await ParseWorkflowBundleAsync(request.Workflow?.WorkflowYamls, ct);
-        var workflowId = ScopeWorkflowCapabilityConventions.NormalizeOptional(request.Workflow?.WorkflowId) ??
-                         ScopeWorkflowCapabilityOptions.NormalizeRequired(identity.ServiceId, nameof(identity.ServiceId));
-        var definitionActorIdPrefix = ScopeWorkflowCapabilityConventions.BuildDefaultDefinitionActorIdPrefix(_options, normalizedScopeId);
+        var workflowId = ResolveWorkflowBindingWorkflowId(request, identity);
+        var definitionActorIdPrefix = ScopeWorkflowCapabilityConventions.BuildDefinitionActorIdPrefix(
+            _options,
+            normalizedScopeId,
+            workflowId);
         var displayName = ScopeWorkflowCapabilityConventions.ResolveDisplayName(
             request.DisplayName,
             workflowBundle.EntryWorkflowName);
@@ -541,6 +543,16 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
                     GAgent: new ScopeBindingGAgentResult(
                         diagnosticClrTypeName),
                     ExpectedDeploymentId: expectedDeploymentId));
+    }
+
+    private static string ResolveWorkflowBindingWorkflowId(
+        ScopeBindingUpsertRequest request,
+        ServiceIdentity identity)
+    {
+        var workflowId = ScopeWorkflowCapabilityConventions.NormalizeOptional(request.Workflow?.WorkflowId);
+        return string.IsNullOrWhiteSpace(workflowId)
+            ? ScopeWorkflowCapabilityOptions.NormalizeRequired(identity.ServiceId, nameof(identity.ServiceId))
+            : ScopeWorkflowCapabilityConventions.NormalizeWorkflowId(workflowId);
     }
 
     private string NormalizeGAgentKind(ScopeBindingGAgentSpec gagent)

--- a/src/platform/Aevatar.GAgentService.Application/Workflows/ScopeWorkflowSaveAndBindApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Workflows/ScopeWorkflowSaveAndBindApplicationService.cs
@@ -1,0 +1,116 @@
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+
+namespace Aevatar.GAgentService.Application.Workflows;
+
+public sealed class ScopeWorkflowSaveAndBindApplicationService : IScopeWorkflowSaveAndBindPort
+{
+    private readonly IScopeWorkflowCommandPort _workflowCommandPort;
+    private readonly IScopeBindingCommandPort _bindingCommandPort;
+
+    public ScopeWorkflowSaveAndBindApplicationService(
+        IScopeWorkflowCommandPort workflowCommandPort,
+        IScopeBindingCommandPort bindingCommandPort)
+    {
+        _workflowCommandPort = workflowCommandPort ?? throw new ArgumentNullException(nameof(workflowCommandPort));
+        _bindingCommandPort = bindingCommandPort ?? throw new ArgumentNullException(nameof(bindingCommandPort));
+    }
+
+    public async Task<ScopeWorkflowSaveAndBindResult> SaveAndBindAsync(
+        ScopeWorkflowSaveAndBindRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var normalizedScopeId = ScopeWorkflowCapabilityOptions.NormalizeRequired(request.ScopeId, nameof(request.ScopeId));
+        var normalizedWorkflowId = ResolveWorkflowId(request.WorkflowId);
+        var revisionId = ScopeWorkflowCapabilityConventions.ResolveRevisionId(null);
+        var workflowYaml = ScopeWorkflowCapabilityOptions.NormalizeRequired(request.WorkflowYaml, nameof(request.WorkflowYaml));
+        var inlineWorkflowYamls = NormalizeInlineWorkflowYamls(request.InlineWorkflowYamls);
+
+        var workflowResult = await _workflowCommandPort.UpsertAsync(
+            new ScopeWorkflowUpsertRequest(
+                normalizedScopeId,
+                normalizedWorkflowId,
+                workflowYaml,
+                request.WorkflowName,
+                request.DisplayName,
+                inlineWorkflowYamls,
+                revisionId),
+            ct);
+
+        var workflowYamls = BuildWorkflowYamls(workflowYaml, inlineWorkflowYamls);
+        var bindingResult = await _bindingCommandPort.UpsertAsync(
+            new ScopeBindingUpsertRequest(
+                normalizedScopeId,
+                ScopeBindingImplementationKind.Workflow,
+                new ScopeBindingWorkflowSpec(normalizedWorkflowId, workflowYamls),
+                DisplayName: request.DisplayName,
+                RevisionId: revisionId,
+                AppId: request.AppId,
+                ServiceId: ResolveBindingServiceId(request.ServiceId),
+                ExposureDesired: request.ExposureDesired),
+            ct);
+
+        if (!string.Equals(workflowResult.RevisionId, revisionId, StringComparison.Ordinal) ||
+            !string.Equals(bindingResult.RevisionId, revisionId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Save-and-bind revision identity must match workflow and binding results.");
+        }
+
+        return new ScopeWorkflowSaveAndBindResult(
+            normalizedScopeId,
+            normalizedWorkflowId,
+            revisionId,
+            workflowResult,
+            bindingResult);
+    }
+
+    private static string ResolveWorkflowId(string? workflowId)
+    {
+        var normalized = ScopeWorkflowCapabilityConventions.NormalizeOptional(workflowId);
+        return string.IsNullOrWhiteSpace(normalized)
+            ? $"wf-{Guid.NewGuid():N}"
+            : ScopeWorkflowCapabilityConventions.NormalizeWorkflowId(normalized);
+    }
+
+    private static string? ResolveBindingServiceId(string? serviceId)
+    {
+        var normalized = ScopeWorkflowCapabilityConventions.NormalizeOptional(serviceId);
+        return string.IsNullOrWhiteSpace(normalized)
+            ? null
+            : ScopeWorkflowCapabilityOptions.NormalizeRequired(normalized, nameof(serviceId));
+    }
+
+    private static IReadOnlyDictionary<string, string>? NormalizeInlineWorkflowYamls(
+        IReadOnlyDictionary<string, string>? inlineWorkflowYamls)
+    {
+        if (inlineWorkflowYamls == null || inlineWorkflowYamls.Count == 0)
+            return null;
+
+        var normalized = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (key, value) in inlineWorkflowYamls)
+        {
+            var normalizedKey = ScopeWorkflowCapabilityConventions.NormalizeOptional(key);
+            var normalizedValue = ScopeWorkflowCapabilityConventions.NormalizeOptional(value);
+            if (string.IsNullOrWhiteSpace(normalizedKey) || string.IsNullOrWhiteSpace(normalizedValue))
+                continue;
+
+            normalized[normalizedKey] = normalizedValue;
+        }
+
+        return normalized.Count == 0 ? null : normalized;
+    }
+
+    private static IReadOnlyList<string> BuildWorkflowYamls(
+        string workflowYaml,
+        IReadOnlyDictionary<string, string>? inlineWorkflowYamls)
+    {
+        if (inlineWorkflowYamls == null || inlineWorkflowYamls.Count == 0)
+            return [workflowYaml];
+
+        var workflowYamls = new List<string>(inlineWorkflowYamls.Count + 1) { workflowYaml };
+        workflowYamls.AddRange(inlineWorkflowYamls.OrderBy(x => x.Key, StringComparer.Ordinal).Select(x => x.Value));
+        return workflowYamls;
+    }
+}

--- a/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -162,6 +162,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<ScopeWorkflowQueryApplicationService>();
         services.TryAddSingleton<IScopeWorkflowQueryPort>(sp => sp.GetRequiredService<ScopeWorkflowQueryApplicationService>());
         services.TryAddSingleton<IScopeWorkflowCommandPort, ScopeWorkflowCommandApplicationService>();
+        services.TryAddSingleton<IScopeWorkflowSaveAndBindPort, ScopeWorkflowSaveAndBindApplicationService>();
         services.TryAddSingleton<ISkillWorkflowMountPort, SkillWorkflowMountAdapter>();
         services.TryAddSingleton<IScopeBindingCommandPort, ScopeBindingCommandApplicationService>();
         services.TryAddSingleton<IScopeBindingReadinessQueryPort, ScopeBindingReadinessQueryService>();

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
@@ -32,6 +32,9 @@ public static class ScopeWorkflowEndpoints
         group.MapPut("/{scopeId}/workflows/{workflowId}", HandleUpsertWorkflowAsync)
             .Produces<ScopeWorkflowUpsertResult>(StatusCodes.Status202Accepted)
             .Produces(StatusCodes.Status400BadRequest);
+        group.MapPost("/{scopeId}/workflows:save-and-bind", HandleSaveAndBindWorkflowAsync)
+            .Produces<ScopeWorkflowSaveAndBindResult>(StatusCodes.Status202Accepted)
+            .Produces(StatusCodes.Status400BadRequest);
         group.MapGet("/{scopeId}/workflows", HandleListWorkflowsAsync)
             .Produces(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status400BadRequest);
@@ -50,6 +53,14 @@ public static class ScopeWorkflowEndpoints
         [FromServices] IScopeWorkflowCommandPort workflowCommandPort,
         CancellationToken ct)
         => await HandleUpsertWorkflowAsyncCore(http, scopeId, workflowId, request, workflowCommandPort, ct);
+
+    internal static async Task<IResult> HandleSaveAndBindWorkflowAsync(
+        HttpContext http,
+        string scopeId,
+        SaveAndBindScopeWorkflowHttpRequest request,
+        [FromServices] IScopeWorkflowSaveAndBindPort saveAndBindPort,
+        CancellationToken ct)
+        => await HandleSaveAndBindWorkflowAsyncCore(http, scopeId, request, saveAndBindPort, ct);
 
     internal static async Task<IResult> HandleListWorkflowsAsync(
         HttpContext http,
@@ -114,6 +125,42 @@ public static class ScopeWorkflowEndpoints
                 request.InlineWorkflowYamls,
                 request.RevisionId), ct);
             return Results.Accepted(result.ReadModelUrl, result);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Results.BadRequest(new
+            {
+                code = "INVALID_USER_WORKFLOW_REQUEST",
+                message = ex.Message,
+            });
+        }
+    }
+
+    private static async Task<IResult> HandleSaveAndBindWorkflowAsyncCore(
+        HttpContext http,
+        string scopeId,
+        SaveAndBindScopeWorkflowHttpRequest request,
+        IScopeWorkflowSaveAndBindPort saveAndBindPort,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+                return denied;
+
+            var result = await saveAndBindPort.SaveAndBindAsync(
+                new ScopeWorkflowSaveAndBindRequest(
+                    scopeId,
+                    request.WorkflowId,
+                    request.WorkflowYaml,
+                    request.WorkflowName,
+                    request.DisplayName,
+                    request.InlineWorkflowYamls,
+                    request.AppId,
+                    request.ServiceId,
+                    request.ExposureDesired),
+                ct);
+            return Results.Accepted(result.Workflow.ReadModelUrl, result);
         }
         catch (InvalidOperationException ex)
         {
@@ -731,6 +778,16 @@ public static class ScopeWorkflowEndpoints
         string? DisplayName = null,
         Dictionary<string, string>? InlineWorkflowYamls = null,
         string? RevisionId = null);
+
+    public sealed record SaveAndBindScopeWorkflowHttpRequest(
+        string? WorkflowId,
+        string WorkflowYaml,
+        string? WorkflowName = null,
+        string? DisplayName = null,
+        Dictionary<string, string>? InlineWorkflowYamls = null,
+        string? AppId = null,
+        string? ServiceId = null,
+        bool? ExposureDesired = null);
 
     public sealed record RunScopeWorkflowByIdStreamHttpRequest(
         string Prompt,

--- a/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
@@ -277,6 +277,7 @@ public sealed class GAgentServiceHostingServiceCollectionExtensionsTests
         endpoints.Should().Contain("/api/services/{serviceId}/endpoint-catalog");
         endpoints.Should().Contain("/api/services/{serviceId}/policies");
         endpoints.Should().Contain("/api/scopes/{scopeId}/binding");
+        endpoints.Should().Contain("/api/scopes/{scopeId}/workflows:save-and-bind");
         endpoints.Should().Contain("/api/scopes/{scopeId}/binding/revisions/{revisionId}:activate");
         endpoints.Should().Contain("/api/scopes/{scopeId}/revisions");
         endpoints.Should().Contain("/api/scopes/{scopeId}/revisions/{revisionId}");

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
@@ -47,6 +47,46 @@ public sealed class ScopeWorkflowEndpointsTests
     }
 
     [Fact]
+    public async Task HandleSaveAndBindWorkflowAsync_ShouldReturnAccepted_WithoutRequestRevisionId()
+    {
+        var http = CreateHttpContext();
+        var port = new RecordingScopeWorkflowSaveAndBindPort();
+
+        var result = await ScopeWorkflowEndpoints.HandleSaveAndBindWorkflowAsync(
+            http,
+            "user-1",
+            new ScopeWorkflowEndpoints.SaveAndBindScopeWorkflowHttpRequest(
+                "wf-alpha",
+                "name: approval\nsteps: []\n",
+                WorkflowName: "approval",
+                DisplayName: "Approval",
+                InlineWorkflowYamls: new Dictionary<string, string>
+                {
+                    ["child"] = "name: child\nsteps: []\n",
+                },
+                AppId: "studio",
+                ServiceId: "svc-alpha",
+                ExposureDesired: true),
+            port,
+            CancellationToken.None);
+
+        await result.ExecuteAsync(http);
+        var body = await ReadBodyAsync(http.Response);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        http.Response.Headers.Location.ToString().Should().Be("/api/scopes/user-1/workflows/wf-alpha");
+        port.Request.Should().NotBeNull();
+        port.Request!.ScopeId.Should().Be("user-1");
+        port.Request.WorkflowId.Should().Be("wf-alpha");
+        port.Request.AppId.Should().Be("studio");
+        port.Request.ServiceId.Should().Be("svc-alpha");
+        port.Request.ExposureDesired.Should().BeTrue();
+        body.Should().Contain("\"revisionId\":\"rev-generated\"");
+        body.Should().Contain("\"acceptanceStage\":\"accepted\"");
+        body.Should().Contain("\"propagationStage\":\"readmodel_propagating\"");
+    }
+
+    [Fact]
     public async Task HandleRunWorkflowStreamAsync_ShouldReturnNotFound_WhenActorDoesNotBelongToUser()
     {
         var http = CreateHttpContext();
@@ -1134,6 +1174,43 @@ public sealed class ScopeWorkflowEndpointsTests
                 DateTimeOffset.UtcNow,
                 revisions.Count,
                 string.Empty));
+        }
+    }
+
+    private sealed class RecordingScopeWorkflowSaveAndBindPort : IScopeWorkflowSaveAndBindPort
+    {
+        public ScopeWorkflowSaveAndBindRequest? Request { get; private set; }
+
+        public Task<ScopeWorkflowSaveAndBindResult> SaveAndBindAsync(
+            ScopeWorkflowSaveAndBindRequest request,
+            CancellationToken ct = default)
+        {
+            Request = request;
+            var workflowId = request.WorkflowId ?? "wf-generated";
+            var workflowResult = new ScopeWorkflowUpsertResult(
+                request.ScopeId,
+                workflowId,
+                "scope-service-key",
+                "rev-generated",
+                "definition-prefix",
+                "workflow-actor",
+                "deployment-id",
+                DateTimeOffset.UtcNow,
+                [],
+                $"/api/scopes/{request.ScopeId}/workflows/{workflowId}");
+            var bindingResult = new ScopeBindingUpsertResult(
+                request.ScopeId,
+                request.ServiceId ?? "default",
+                request.DisplayName ?? "main",
+                "rev-generated",
+                ScopeBindingImplementationKind.Workflow,
+                "binding-actor");
+            return Task.FromResult(new ScopeWorkflowSaveAndBindResult(
+                request.ScopeId,
+                workflowId,
+                "rev-generated",
+                workflowResult,
+                bindingResult));
         }
     }
 

--- a/test/Aevatar.GAgentService.Tests/Application/ScopeBindingCommandApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScopeBindingCommandApplicationServiceTests.cs
@@ -66,9 +66,16 @@ public sealed class ScopeBindingCommandApplicationServiceTests
         result.AcceptanceStage.Should().Be("accepted");
         result.PropagationStage.Should().Be("readmodel_propagating");
         result.Workflow.Should().NotBeNull();
+        var expectedDefinitionActorIdPrefix = DefaultOptions.BuildDefinitionActorIdPrefix(ScopeId, "workflow-stable-id");
         result.Workflow!.WorkflowId.Should().Be("workflow-stable-id");
         result.Workflow!.WorkflowName.Should().Be("main_runtime");
+        result.Workflow.DefinitionActorIdPrefix.Should().Be(expectedDefinitionActorIdPrefix);
+        result.ExpectedActorId.Should().StartWith($"{expectedDefinitionActorIdPrefix}:");
         result.DisplayName.Should().Be("main_runtime");
+
+        var revisionCommand = commandPort.Calls[1].Command.Should().BeOfType<CreateServiceRevisionCommand>().Subject;
+        revisionCommand.Spec.WorkflowSpec.Should().NotBeNull();
+        revisionCommand.Spec.WorkflowSpec!.DefinitionActorId.Should().Be(expectedDefinitionActorIdPrefix);
 
         var createCommand = commandPort.Calls[0].Command.Should().BeOfType<CreateServiceDefinitionCommand>().Subject;
         createCommand.Spec.Identity.Should().BeEquivalentTo(new ServiceIdentity

--- a/test/Aevatar.GAgentService.Tests/Application/ScopeBindingCommandApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScopeBindingCommandApplicationServiceTests.cs
@@ -92,6 +92,38 @@ public sealed class ScopeBindingCommandApplicationServiceTests
     }
 
     [Fact]
+    public async Task UpsertAsync_ShouldKeepDefaultDefinitionPrefix_WhenWorkflowIdIsOmitted()
+    {
+        var commandPort = new RecordingServiceCommandPort();
+        var lifecyclePort = new FakeServiceLifecycleQueryPort(getResult: null);
+        var service = CreateService(
+            commandPort,
+            lifecyclePort,
+            new FakeScopeScriptQueryPort(),
+            new FakeScriptDefinitionSnapshotPort(),
+            new FakeWorkflowRunActorPort());
+
+        var result = await service.UpsertAsync(new ScopeBindingUpsertRequest(
+            ScopeId,
+            ScopeBindingImplementationKind.Workflow,
+            Workflow: new ScopeBindingWorkflowSpec(
+            [
+                "name: main_runtime\nsteps:\n  - run: echo hello",
+            ]),
+            ServiceId: "custom-service"));
+
+        var expectedDefinitionActorIdPrefix = ScopeWorkflowCapabilityConventions.BuildDefaultDefinitionActorIdPrefix(DefaultOptions, ScopeId);
+        result.Workflow.Should().NotBeNull();
+        result.Workflow!.WorkflowId.Should().Be("custom-service");
+        result.Workflow.DefinitionActorIdPrefix.Should().Be(expectedDefinitionActorIdPrefix);
+        result.ExpectedActorId.Should().StartWith($"{expectedDefinitionActorIdPrefix}:");
+
+        var revisionCommand = commandPort.Calls[1].Command.Should().BeOfType<CreateServiceRevisionCommand>().Subject;
+        revisionCommand.Spec.WorkflowSpec.Should().NotBeNull();
+        revisionCommand.Spec.WorkflowSpec!.DefinitionActorId.Should().Be(expectedDefinitionActorIdPrefix);
+    }
+
+    [Fact]
     public async Task UpsertAsync_ShouldRecordExternalExposureIntent_WhenExposureIsDesired()
     {
         var commandPort = new RecordingServiceCommandPort();

--- a/test/Aevatar.GAgentService.Tests/Application/ScopeWorkflowSaveAndBindApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScopeWorkflowSaveAndBindApplicationServiceTests.cs
@@ -1,0 +1,130 @@
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Application.Workflows;
+using FluentAssertions;
+
+namespace Aevatar.GAgentService.Tests.Application;
+
+public sealed class ScopeWorkflowSaveAndBindApplicationServiceTests
+{
+    [Fact]
+    public async Task SaveAndBindAsync_ShouldGenerateOneRevisionId_ForWorkflowAndBinding()
+    {
+        var workflowPort = new RecordingScopeWorkflowCommandPort();
+        var bindingPort = new RecordingScopeBindingCommandPort();
+        var service = new ScopeWorkflowSaveAndBindApplicationService(workflowPort, bindingPort);
+
+        var result = await service.SaveAndBindAsync(new ScopeWorkflowSaveAndBindRequest(
+            "scope-a",
+            "wf-alpha",
+            "name: main\nsteps: []\n",
+            WorkflowName: "main",
+            DisplayName: "Alpha",
+            InlineWorkflowYamls: new Dictionary<string, string>
+            {
+                ["child"] = "name: child\nsteps: []\n",
+            },
+            AppId: "studio",
+            ExposureDesired: true));
+
+        workflowPort.Request.Should().NotBeNull();
+        bindingPort.Request.Should().NotBeNull();
+        result.WorkflowId.Should().Be("wf-alpha");
+        result.RevisionId.Should().StartWith("rev-");
+        workflowPort.Request!.RevisionId.Should().Be(result.RevisionId);
+        bindingPort.Request!.RevisionId.Should().Be(result.RevisionId);
+        bindingPort.Request.Workflow!.WorkflowId.Should().Be("wf-alpha");
+        bindingPort.Request.Workflow.WorkflowYamls.Should().Equal(
+            "name: main\nsteps: []",
+            "name: child\nsteps: []");
+        bindingPort.Request.ServiceId.Should().BeNull();
+        bindingPort.Request.AppId.Should().Be("studio");
+        bindingPort.Request.ExposureDesired.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SaveAndBindAsync_ShouldGenerateWorkflowId_WhenMissing()
+    {
+        var workflowPort = new RecordingScopeWorkflowCommandPort();
+        var bindingPort = new RecordingScopeBindingCommandPort();
+        var service = new ScopeWorkflowSaveAndBindApplicationService(workflowPort, bindingPort);
+
+        var result = await service.SaveAndBindAsync(new ScopeWorkflowSaveAndBindRequest(
+            "scope-a",
+            null,
+            "name: main\nsteps: []\n"));
+
+        result.WorkflowId.Should().StartWith("wf-");
+        workflowPort.Request!.WorkflowId.Should().Be(result.WorkflowId);
+        bindingPort.Request!.Workflow!.WorkflowId.Should().Be(result.WorkflowId);
+    }
+
+    [Fact]
+    public async Task SaveAndBindAsync_ShouldRejectRevisionMismatch()
+    {
+        var workflowPort = new RecordingScopeWorkflowCommandPort();
+        var bindingPort = new RecordingScopeBindingCommandPort("rev-other");
+        var service = new ScopeWorkflowSaveAndBindApplicationService(workflowPort, bindingPort);
+
+        var act = () => service.SaveAndBindAsync(new ScopeWorkflowSaveAndBindRequest(
+            "scope-a",
+            "wf-alpha",
+            "name: main\nsteps: []\n"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*revision identity must match*");
+    }
+
+    private sealed class RecordingScopeWorkflowCommandPort : IScopeWorkflowCommandPort
+    {
+        public ScopeWorkflowUpsertRequest? Request { get; private set; }
+
+        public Task<ScopeWorkflowUpsertResult> UpsertAsync(
+            ScopeWorkflowUpsertRequest request,
+            CancellationToken ct = default)
+        {
+            Request = request;
+            var revisionId = request.RevisionId ?? string.Empty;
+            return Task.FromResult(new ScopeWorkflowUpsertResult(
+                request.ScopeId,
+                request.WorkflowId,
+                $"scope:{request.ScopeId}:workflow:{request.WorkflowId}",
+                revisionId,
+                $"scope-workflow:{request.ScopeId}:{request.WorkflowId}",
+                "actor-expected",
+                "deployment-expected",
+                DateTimeOffset.UtcNow,
+                [],
+                $"/api/scopes/{request.ScopeId}/workflows/{request.WorkflowId}",
+                DisplayName: request.DisplayName ?? string.Empty,
+                WorkflowName: request.WorkflowName ?? string.Empty));
+        }
+    }
+
+    private sealed class RecordingScopeBindingCommandPort : IScopeBindingCommandPort
+    {
+        private readonly string? _resultRevisionId;
+
+        public RecordingScopeBindingCommandPort(string? resultRevisionId = null)
+        {
+            _resultRevisionId = resultRevisionId;
+        }
+
+        public ScopeBindingUpsertRequest? Request { get; private set; }
+
+        public Task<ScopeBindingUpsertResult> UpsertAsync(
+            ScopeBindingUpsertRequest request,
+            CancellationToken ct = default)
+        {
+            Request = request;
+            var revisionId = _resultRevisionId ?? request.RevisionId ?? string.Empty;
+            return Task.FromResult(new ScopeBindingUpsertResult(
+                request.ScopeId,
+                request.ServiceId ?? "default",
+                request.DisplayName ?? "main",
+                revisionId,
+                request.ImplementationKind,
+                "binding-actor-expected"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `POST /api/scopes/{scopeId}/workflows:save-and-bind` for Studio create/update + binding publication in one call.
- Generate one backend `revisionId` and reuse it for workflow catalog save and binding publication.
- Keep orchestration in an application port/service and fix workflow binding to honor supplied `workflowId` for the definition actor prefix.

Fixes #2362

## Test plan
- [x] `dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo --filter "ScopeBindingCommandApplicationServiceTests|ScopeWorkflowSaveAndBindApplicationServiceTests"`
- [x] `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --filter "HandleSaveAndBindWorkflowAsync|AddGAgentServiceCapabilityBundle_ShouldRegisterCapabilityAndMapServiceRoutes"`
- [x] `bash tools/ci/test_stability_guards.sh`
- [x] `bash tools/ci/workflow_binding_boundary_guard.sh`
- [x] `bash tools/ci/query_projection_priming_guard.sh`
- [x] `git diff --check`

## Review
- sshx thinking triplet: minimal/structural/delete all proposed a narrow application-layer endpoint.
- sshx review triplet initially found a workflowId/definition actor prefix mismatch; fixed and second review triplet approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)