### PR TITLE
fix: persist NyxID refresh token in console

### DIFF
--- a/apps/aevatar-console-web/src/shared/auth/backend.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/backend.test.ts
@@ -1,6 +1,7 @@
 import {
   finalizeBackendNyxIDLogin,
   loadBackendNyxIDLoginConfig,
+  refreshNyxIDTokenSet,
 } from "./backend";
 
 describe("NyxID backend auth API", () => {
@@ -22,7 +23,7 @@ describe("NyxID backend auth API", () => {
       json: async () => ({
         baseUrl: "https://nyx.example/",
         clientId: "broker-client-1",
-        scope: "openid urn:nyxid:scope:broker_binding proxy",
+        scope: "openid profile email offline_access urn:nyxid:scope:broker_binding proxy",
       }),
     } as Response);
     global.fetch = fetchMock as typeof global.fetch;
@@ -30,7 +31,7 @@ describe("NyxID backend auth API", () => {
     await expect(loadBackendNyxIDLoginConfig()).resolves.toEqual({
       baseUrl: "https://nyx.example",
       clientId: "broker-client-1",
-      scope: "openid urn:nyxid:scope:broker_binding proxy",
+      scope: "openid profile email offline_access urn:nyxid:scope:broker_binding proxy",
     });
 
     expect(fetchMock).toHaveBeenCalledWith("/api/auth/nyxid/config", {
@@ -68,10 +69,11 @@ describe("NyxID backend auth API", () => {
       json: async () => ({
         tokens: {
           accessToken: "access-token",
+          refreshToken: "refresh-token",
           tokenType: "Bearer",
           expiresIn: 1800,
           idToken: "id-token",
-          scope: "openid profile proxy",
+          scope: "openid profile email offline_access proxy",
         },
         user: {
           sub: "owner-user-1",
@@ -98,9 +100,9 @@ describe("NyxID backend auth API", () => {
           tokenType: "Bearer",
           expiresIn: 1800,
           expiresAt: 1_700_000_000_000 + 1_800_000,
+          refreshToken: "refresh-token",
           idToken: "id-token",
-          scope: "openid profile proxy",
-          refreshToken: undefined,
+          scope: "openid profile email offline_access proxy",
         },
         user: {
           sub: "owner-user-1",
@@ -123,5 +125,74 @@ describe("NyxID backend auth API", () => {
       codeVerifier: "pkce-verifier",
       redirectUri: "http://localhost:8000/auth/callback",
     });
+  });
+
+  it("refreshes a NyxID token set through the OAuth refresh grant", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        access_token: "access-token-2",
+        refresh_token: "refresh-token-2",
+        token_type: "Bearer",
+        expires_in: 300,
+        id_token: "id-token-2",
+        scope: "openid profile email offline_access proxy",
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(
+      refreshNyxIDTokenSet({
+        baseUrl: "https://nyx.example/",
+        clientId: "broker-client-1",
+        refreshToken: "refresh-token-1",
+      }),
+    ).resolves.toEqual({
+      accessToken: "access-token-2",
+      refreshToken: "refresh-token-2",
+      tokenType: "Bearer",
+      expiresIn: 300,
+      expiresAt: 1_700_000_000_000 + 300_000,
+      idToken: "id-token-2",
+      scope: "openid profile email offline_access proxy",
+    });
+
+    const [input, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(input).toBe("https://nyx.example/oauth/token");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({
+      Accept: "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
+    });
+    expect(String(init.body)).toBe(
+      "grant_type=refresh_token&refresh_token=refresh-token-1&client_id=broker-client-1",
+    );
+  });
+
+  it("keeps the existing refresh token when NyxID refresh does not rotate it", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        accessToken: "access-token-2",
+        tokenType: "Bearer",
+        expiresIn: 300,
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(
+      refreshNyxIDTokenSet({
+        baseUrl: "https://nyx.example",
+        clientId: "broker-client-1",
+        refreshToken: "refresh-token-1",
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        accessToken: "access-token-2",
+        refreshToken: "refresh-token-1",
+      }),
+    );
   });
 });

--- a/apps/aevatar-console-web/src/shared/auth/backend.ts
+++ b/apps/aevatar-console-web/src/shared/auth/backend.ts
@@ -18,6 +18,12 @@ export type NyxIDLoginFinalizationResult = {
   readonly session: NyxIDAuthSession;
 };
 
+export type NyxIDTokenRefreshRequest = {
+  readonly baseUrl: string;
+  readonly clientId: string;
+  readonly refreshToken: string;
+};
+
 type BackendLoginConfigResponse = {
   readonly baseUrl?: unknown;
   readonly BaseUrl?: unknown;
@@ -55,6 +61,8 @@ type BackendTokenSetResponse = {
   readonly scope?: unknown;
   readonly Scope?: unknown;
 };
+
+type NyxIDTokenRefreshResponse = BackendTokenSetResponse;
 
 type BackendUserInfoResponse = {
   readonly sub?: unknown;
@@ -174,6 +182,39 @@ function decodeTokenSet(value: unknown): NyxIDTokenSet {
   };
 }
 
+function decodeRefreshTokenSet(
+  value: unknown,
+  fallbackRefreshToken: string,
+): NyxIDTokenSet {
+  const record = expectRecord(value, "NyxID refreshed tokens") as
+    NyxIDTokenRefreshResponse;
+  const expiresIn = readNumber(
+    record.expiresIn ?? record.ExpiresIn ?? record.expires_in,
+    "tokens.expiresIn",
+  );
+
+  return {
+    accessToken: readString(
+      record.accessToken ?? record.AccessToken ?? record.access_token,
+      "tokens.accessToken",
+    ),
+    tokenType:
+      readOptionalString(
+        record.tokenType ?? record.TokenType ?? record.token_type,
+      ) ?? "Bearer",
+    expiresIn,
+    expiresAt: Date.now() + expiresIn * 1000,
+    refreshToken:
+      readOptionalString(
+        record.refreshToken ?? record.RefreshToken ?? record.refresh_token,
+      ) ?? fallbackRefreshToken,
+    idToken: readOptionalString(
+      record.idToken ?? record.IdToken ?? record.id_token,
+    ),
+    scope: readOptionalString(record.scope ?? record.Scope),
+  };
+}
+
 function decodeUserInfo(value: unknown): NyxIDUserInfo {
   const record = expectRecord(value, "NyxID finalized user") as
     BackendUserInfoResponse;
@@ -248,6 +289,32 @@ export function finalizeBackendNyxIDLogin(
       headers: {
         Accept: "application/json",
         "Content-Type": "application/json",
+      },
+      method: "POST",
+    },
+  );
+}
+
+export function refreshNyxIDTokenSet(
+  request: NyxIDTokenRefreshRequest,
+): Promise<NyxIDTokenSet> {
+  const baseUrl = readString(request.baseUrl, "baseUrl").replace(/\/+$/, "");
+  const clientId = readString(request.clientId, "clientId");
+  const refreshToken = readString(request.refreshToken, "refreshToken");
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    client_id: clientId,
+  });
+
+  return requestBackendJson(
+    `${baseUrl}/oauth/token`,
+    (value) => decodeRefreshTokenSet(value, refreshToken),
+    {
+      body,
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
       },
       method: "POST",
     },

--- a/apps/aevatar-console-web/src/shared/auth/client.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/client.test.ts
@@ -1,5 +1,9 @@
 import { TextEncoder } from "node:util";
-import { NyxIDAuthClient } from "./client";
+import {
+  ensureActiveAuthSession,
+  hasRestorableAuthSession,
+  NyxIDAuthClient,
+} from "./client";
 import type { NyxIDRuntimeConfig } from "./config";
 import { loadStoredAuthSession } from "./session";
 
@@ -69,7 +73,7 @@ describe("NyxIDAuthClient", () => {
       json: async () => ({
         baseUrl: "https://nyx.example",
         clientId: "broker-client-1",
-        scope: "openid urn:nyxid:scope:broker_binding proxy",
+        scope: "openid profile email offline_access urn:nyxid:scope:broker_binding proxy",
         redirectUri: "https://backend.example/auth/callback",
       }),
     } as Response);
@@ -94,7 +98,7 @@ describe("NyxIDAuthClient", () => {
       "http://localhost:8000/auth/callback",
     );
     expect(authorizeUrl.searchParams.get("scope")).toBe(
-      "openid urn:nyxid:scope:broker_binding proxy",
+      "openid profile email offline_access urn:nyxid:scope:broker_binding proxy",
     );
 
     const pending = JSON.parse(
@@ -107,7 +111,7 @@ describe("NyxIDAuthClient", () => {
         clientId: "broker-client-1",
         redirectUri: "http://localhost:8000/auth/callback",
         returnTo: "/scopes/scope-1/teams",
-        scope: "openid urn:nyxid:scope:broker_binding proxy",
+        scope: "openid profile email offline_access urn:nyxid:scope:broker_binding proxy",
         state: authorizeUrl.searchParams.get("state"),
       }),
     );
@@ -132,9 +136,10 @@ describe("NyxIDAuthClient", () => {
       json: async () => ({
         tokens: {
           accessToken: "access-token",
+          refreshToken: "refresh-token",
           tokenType: "Bearer",
           expiresIn: 1800,
-          scope: "openid profile proxy",
+          scope: "openid profile email offline_access proxy",
         },
         user: {
           sub: "owner-user-1",
@@ -153,6 +158,7 @@ describe("NyxIDAuthClient", () => {
       session: expect.objectContaining({
         tokens: expect.objectContaining({
           accessToken: "access-token",
+          refreshToken: "refresh-token",
         }),
         user: {
           sub: "owner-user-1",
@@ -178,5 +184,147 @@ describe("NyxIDAuthClient", () => {
     expect(String(input)).not.toContain("/oauth/token");
     expect(window.localStorage.getItem(pendingKey)).toBeNull();
     expect(loadStoredAuthSession()?.tokens.accessToken).toBe("access-token");
+    expect(loadStoredAuthSession()?.tokens.refreshToken).toBe("refresh-token");
+  });
+
+  it("refreshes an expired local session before returning it as active", async () => {
+    window.localStorage.setItem(
+      "aevatar-console:nyxid:session",
+      JSON.stringify({
+        tokens: {
+          accessToken: "expired-token",
+          tokenType: "Bearer",
+          expiresIn: 3600,
+          expiresAt: Date.now() - 1,
+          refreshToken: "refresh-token-1",
+          idToken: "old-id-token",
+          scope: "openid profile email offline_access proxy",
+        },
+        user: {
+          sub: "owner-user-1",
+          email: "owner@example.com",
+        },
+      }),
+    );
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          baseUrl: "https://nyx.example/",
+          clientId: "broker-client-1",
+          scope: "openid profile email offline_access urn:nyxid:scope:broker_binding proxy",
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          access_token: "access-token-2",
+          refresh_token: "refresh-token-2",
+          token_type: "Bearer",
+          expires_in: 300,
+          id_token: "id-token-2",
+          scope: "openid profile email offline_access proxy",
+        }),
+      } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(ensureActiveAuthSession(runtimeConfig)).resolves.toEqual({
+      tokens: {
+        accessToken: "access-token-2",
+        refreshToken: "refresh-token-2",
+        tokenType: "Bearer",
+        expiresIn: 300,
+        expiresAt: Date.now() + 300_000,
+        idToken: "id-token-2",
+        scope: "openid profile email offline_access proxy",
+      },
+      user: {
+        sub: "owner-user-1",
+        email: "owner@example.com",
+      },
+    });
+
+    expect(hasRestorableAuthSession()).toBe(true);
+    expect(loadStoredAuthSession()?.tokens.accessToken).toBe("access-token-2");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/auth/nyxid/config");
+    expect(fetchMock.mock.calls[1][0]).toBe("https://nyx.example/oauth/token");
+    expect(String(fetchMock.mock.calls[1][1]?.body)).toBe(
+      "grant_type=refresh_token&refresh_token=refresh-token-1&client_id=broker-client-1",
+    );
+  });
+
+  it("clears expired local sessions when refresh token issuance is unavailable", async () => {
+    window.localStorage.setItem(
+      "aevatar-console:nyxid:session",
+      JSON.stringify({
+        tokens: {
+          accessToken: "expired-token",
+          tokenType: "Bearer",
+          expiresIn: 3600,
+          expiresAt: Date.now() - 1,
+        },
+        user: {
+          sub: "owner-user-1",
+        },
+      }),
+    );
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock as typeof global.fetch;
+
+    expect(hasRestorableAuthSession()).toBe(false);
+    await expect(ensureActiveAuthSession(runtimeConfig)).resolves.toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem("aevatar-console:nyxid:session")).toBeNull();
+  });
+
+  it("does not restore a stale session if local storage changes during refresh", async () => {
+    const sessionKey = "aevatar-console:nyxid:session";
+    window.localStorage.setItem(
+      sessionKey,
+      JSON.stringify({
+        tokens: {
+          accessToken: "expired-token",
+          tokenType: "Bearer",
+          expiresIn: 3600,
+          expiresAt: Date.now() - 1,
+          refreshToken: "refresh-token-1",
+        },
+        user: {
+          sub: "owner-user-1",
+        },
+      }),
+    );
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          baseUrl: "https://nyx.example/",
+          clientId: "broker-client-1",
+          scope: "openid profile email offline_access urn:nyxid:scope:broker_binding proxy",
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => {
+          window.localStorage.removeItem(sessionKey);
+          return {
+            access_token: "access-token-2",
+            refresh_token: "refresh-token-2",
+            token_type: "Bearer",
+            expires_in: 300,
+          };
+        },
+      } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(ensureActiveAuthSession(runtimeConfig)).resolves.toBeNull();
+    expect(window.localStorage.getItem(sessionKey)).toBeNull();
   });
 });

--- a/apps/aevatar-console-web/src/shared/auth/client.ts
+++ b/apps/aevatar-console-web/src/shared/auth/client.ts
@@ -5,12 +5,15 @@ import {
 import {
   finalizeBackendNyxIDLogin,
   loadBackendNyxIDLoginConfig,
+  refreshNyxIDTokenSet,
   type NyxIDBackendLoginConfig,
 } from './backend';
 import {
   clearStoredAuthSession,
+  hasActiveAccessToken,
   loadStoredAuthSession,
   persistAuthSession,
+  readStoredAuthSession,
   sanitizeReturnTo,
   type NyxIDAuthSession,
 } from './session';
@@ -35,6 +38,7 @@ export interface AuthCallbackResult {
 }
 
 const PENDING_KEY_PREFIX = 'aevatar-console:nyxid:pending:';
+let pendingRefreshPromise: Promise<NyxIDAuthSession | null> | null = null;
 
 function base64UrlEncode(input: Uint8Array): string {
   let binary = '';
@@ -202,7 +206,11 @@ export class NyxIDAuthClient {
 }
 
 export function hasRestorableAuthSession(): boolean {
-  return Boolean(loadStoredAuthSession());
+  const session = readStoredAuthSession();
+  return Boolean(
+    session &&
+      (hasActiveAccessToken(session.tokens) || session.tokens.refreshToken),
+  );
 }
 
 export async function ensureActiveAuthSession(
@@ -218,6 +226,52 @@ export async function ensureActiveAuthSession(
     return activeSession;
   }
 
-  clearStoredAuthSession();
-  return null;
+  const expiredSession = readStoredAuthSession();
+  const refreshToken = expiredSession?.tokens.refreshToken;
+  if (!expiredSession || !refreshToken) {
+    clearStoredAuthSession();
+    return null;
+  }
+
+  if (pendingRefreshPromise) {
+    return pendingRefreshPromise;
+  }
+
+  pendingRefreshPromise = refreshStoredAuthSession(expiredSession, refreshToken)
+    .catch(() => {
+      clearStoredAuthSession();
+      return null;
+    })
+    .finally(() => {
+      pendingRefreshPromise = null;
+    });
+
+  return pendingRefreshPromise;
+}
+
+async function refreshStoredAuthSession(
+  expiredSession: NyxIDAuthSession,
+  refreshToken: string,
+): Promise<NyxIDAuthSession | null> {
+  const loginConfig = await loadBackendNyxIDLoginConfig();
+  const refreshedTokens = await refreshNyxIDTokenSet({
+    baseUrl: loginConfig.baseUrl,
+    clientId: loginConfig.clientId,
+    refreshToken,
+  });
+  const currentSession = readStoredAuthSession();
+  if (currentSession?.tokens.refreshToken !== refreshToken) {
+    return loadStoredAuthSession();
+  }
+
+  const refreshedSession: NyxIDAuthSession = {
+    ...expiredSession,
+    tokens: {
+      ...expiredSession.tokens,
+      ...refreshedTokens,
+    },
+  };
+
+  persistAuthSession(refreshedSession);
+  return refreshedSession;
 }

--- a/apps/aevatar-console-web/src/shared/auth/fetch.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/fetch.test.ts
@@ -70,7 +70,7 @@ describe('authFetch', () => {
     );
   });
 
-  it('does not exchange refresh tokens in the browser for expired sessions', async () => {
+  it('refreshes expired sessions before injecting the bearer token', async () => {
     persistAuthSession({
       tokens: {
         accessToken: 'expired-token',
@@ -85,20 +85,42 @@ describe('authFetch', () => {
       },
     });
 
-    const fetchMock = jest.fn().mockResolvedValue({ ok: true } as Response);
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          baseUrl: "https://nyx.example",
+          clientId: "broker-client-1",
+          scope: "openid profile email offline_access urn:nyxid:scope:broker_binding proxy",
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          access_token: "access-token-2",
+          refresh_token: "refresh-token-2",
+          token_type: "Bearer",
+          expires_in: 300,
+        }),
+      } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
     global.fetch = fetchMock as typeof global.fetch;
 
     await authFetch('/api/agents');
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [input, init] = fetchMock.mock.calls[0] as [
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/auth/nyxid/config");
+    expect(fetchMock.mock.calls[1][0]).toBe("https://nyx.example/oauth/token");
+    const [input, init] = fetchMock.mock.calls[2] as [
       string,
       RequestInit | undefined,
     ];
     expect(input).toBe('/api/agents');
-    expect(new Headers(init?.headers).has('Authorization')).toBe(false);
-    expect(
-      fetchMock.mock.calls.some(([url]) => String(url).includes('/oauth/token')),
-    ).toBe(false);
+    expect(new Headers(init?.headers).get('Authorization')).toBe(
+      'Bearer access-token-2',
+    );
   });
 });

--- a/apps/aevatar-console-web/src/shared/auth/session.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/session.test.ts
@@ -73,7 +73,7 @@ describe('auth session storage', () => {
     expect(window.localStorage.length).toBe(0);
   });
 
-  it('clears expired sessions instead of restoring them with a browser refresh token', () => {
+  it('keeps expired sessions with a refresh token available for async restoration', () => {
     persistAuthSession({
       tokens: {
         accessToken: 'token-3',
@@ -88,8 +88,30 @@ describe('auth session storage', () => {
     });
 
     expect(loadStoredAuthSession()).toBeNull();
-    expect(loadRestorableAuthSession()).toBeNull();
-    expect(readStoredAuthSession()).toBeNull();
+    expect(loadRestorableAuthSession()).toEqual({
+      tokens: {
+        accessToken: 'token-3',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        expiresAt: Date.now() - 1,
+        refreshToken: 'refresh-token-3',
+      },
+      user: {
+        sub: 'user-3',
+      },
+    });
+    expect(readStoredAuthSession()).toEqual({
+      tokens: {
+        accessToken: 'token-3',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        expiresAt: Date.now() - 1,
+        refreshToken: 'refresh-token-3',
+      },
+      user: {
+        sub: 'user-3',
+      },
+    });
   });
 
   it('accepts only safe in-app redirect targets', () => {

--- a/apps/aevatar-console-web/src/shared/auth/session.ts
+++ b/apps/aevatar-console-web/src/shared/auth/session.ts
@@ -120,6 +120,10 @@ export function loadRestorableAuthSession(): NyxIDAuthSession | null {
     return session;
   }
 
+  if (session.tokens.refreshToken) {
+    return session;
+  }
+
   storage.removeItem(AUTH_SESSION_STORAGE_KEY);
   return null;
 }


### PR DESCRIPTION
## Summary
- Use the backend NyxID config scope as the authorize source of truth and cover the `offline_access` scope returned by `/api/auth/nyxid/config`.
- Persist `tokens.refreshToken` from backend NyxID finalization into the console auth session.
- Refresh expired console sessions with the stored refresh token instead of immediately clearing local auth, while keeping older deployments safe when refresh tokens are absent.
- Add regression coverage for finalize persistence, refresh grant decoding, authFetch token injection after refresh, missing refresh tokens, and stale-refresh race handling.

## Scope
Frontend only. Changes are limited to `apps/aevatar-console-web/src/shared/auth/*`.

## Issue
Fixes #2373.

## Test Coverage
All new auth-session paths have focused Jest coverage:
- Backend config scope contains `offline_access`.
- Backend finalize response maps and stores `tokens.refreshToken`.
- Expired local sessions refresh before `authFetch` injects a bearer token.
- Sessions without refresh tokens still clear safely.
- A refresh response cannot resurrect a session after local storage changes mid-refresh.

## Pre-Landing Review
Manual diff review completed. No unrelated files or backend changes included.

## Verification Results
- [x] `pnpm --dir apps/aevatar-console-web test -- shared/auth/backend.test.ts shared/auth/client.test.ts shared/auth/session.test.ts shared/auth/fetch.test.ts --runInBand`
  - 4 suites passed, 17 tests passed.
- [x] `pnpm --dir apps/aevatar-console-web tsc`
- [x] `bash tools/ci/test_stability_guards.sh`
- [x] Started the frontend locally on `http://localhost:5174/login` with:
  - `AEVATAR_API_TARGET=https://aevatar-console-backend-api.aevatar.ai`
  - `AEVATAR_STUDIO_API_TARGET=https://aevatar-console-backend-api.aevatar.ai`
- [x] Verified the local dev proxy returns NyxID config with `offline_access`:
  - `curl http://localhost:5174/api/auth/nyxid/config`

## Test plan
- [x] Focused auth Jest tests pass.
- [x] Frontend TypeScript check passes.
- [x] Test stability guard passes.
- [x] Local frontend starts against the remote backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
