### PR TITLE
fix: save and bind published workflow drafts

### DIFF
--- a/apps/aevatar-console-web/config/proxy.ts
+++ b/apps/aevatar-console-web/config/proxy.ts
@@ -72,6 +72,8 @@ const studioScopeProxyEntries = {
     buildProxyTarget(studioApiTarget),
   '^/api/scopes/[^/]+/workflow/draft-run$':
     buildProxyTarget(studioApiTarget),
+  '^/api/scopes/[^/]+/workflows:save-and-bind$':
+    buildProxyTarget(studioApiTarget),
   '^/api/scripts/validate$': buildProxyTarget(studioApiTarget),
   '^/api/scripts/generator$': buildProxyTarget(studioApiTarget),
   '^/api/workflows/generator$': buildProxyTarget(studioApiTarget),

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioHeader.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioHeader.tsx
@@ -966,17 +966,11 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
     pending: publishPending,
     tone: publishTone,
   });
-  const showPublishAction =
-    publishPending ||
-    (dirty && !publishDisabled) ||
-    (!showRefreshPublishStatus &&
-      (publishTone === 'processing' ||
-        publishTone === 'error' ||
-        dirty ||
-        !memberPublished ||
-        !publishDisabled));
+  const showPublishAction = Boolean(
+    !memberPublished && (publishPending || !showRefreshPublishStatus),
+  );
   const stablePublishedStatusVisible = Boolean(
-    memberPublished && publishTone === 'success' && !publishPending && !dirty,
+    memberPublished && publishTone === 'success' && !publishPending,
   );
   const publishStatusTitle = [
     publishNotice,

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -50,6 +50,7 @@ import type {
   StudioExecutionFrame,
   StudioMemberBindingRunStatusResponse,
   StudioMemberDetail,
+  StudioSaveAndBindWorkflowAcceptedResult,
   StudioWorkflowDraftCreateAcceptedReceipt,
   StudioWorkflowDocument,
   StudioWorkflowFile,
@@ -91,6 +92,12 @@ type PublishWorkflowVariables = {
 type PublishedWorkflow = {
   readonly run: StudioMemberBindingRunStatusResponse | null;
   readonly savedDraft: SavedWorkflowDraft | null;
+};
+
+type SavedAndBoundWorkflow = {
+  readonly materializedWorkflow: StudioWorkflowFile | null;
+  readonly result: StudioSaveAndBindWorkflowAcceptedResult;
+  readonly savedDraft: SavedWorkflowDraft;
 };
 
 class PublishWorkflowStatusError extends Error {
@@ -246,6 +253,8 @@ const CREATED_MEMBER_MATERIALIZATION_ATTEMPTS = 8;
 const CREATED_MEMBER_MATERIALIZATION_DELAY_MS = 450;
 const WORKFLOW_DRAFT_MATERIALIZATION_ATTEMPTS = 10;
 const WORKFLOW_DRAFT_MATERIALIZATION_DELAY_MS = 900;
+const SAVE_AND_BIND_WORKFLOW_MATERIALIZATION_ATTEMPTS = 12;
+const SAVE_AND_BIND_WORKFLOW_MATERIALIZATION_DELAY_MS = 1_000;
 const SAVED_WORKFLOW_QUERY_STALE_MS = 30_000;
 
 function trimOptional(value: string | null | undefined): string {
@@ -551,6 +560,53 @@ function waitForWorkflowDraftMaterializationTick(): Promise<void> {
   });
 }
 
+function waitForSaveAndBindWorkflowMaterializationTick(): Promise<void> {
+  return new Promise((resolve) => {
+    const testEnvironment =
+      typeof process !== "undefined" && process.env.NODE_ENV === "test";
+    window.setTimeout(
+      resolve,
+      testEnvironment ? 0 : SAVE_AND_BIND_WORKFLOW_MATERIALIZATION_DELAY_MS,
+    );
+  });
+}
+
+function workflowYamlMatches(left: string | null | undefined, right: string): boolean {
+  return String(left || "").trim() === right.trim();
+}
+
+async function waitForSaveAndBindWorkflowMaterialized(input: {
+  readonly expectedYaml: string;
+  readonly scopeId: string;
+  readonly workflowId: string;
+}): Promise<StudioWorkflowFile | null> {
+  for (
+    let attempt = 0;
+    attempt < SAVE_AND_BIND_WORKFLOW_MATERIALIZATION_ATTEMPTS;
+    attempt += 1
+  ) {
+    try {
+      const workflow = await studioApi.getPublishedWorkflow(
+        input.workflowId,
+        input.scopeId,
+      );
+      if (workflowYamlMatches(workflow.yaml, input.expectedYaml)) {
+        return workflow;
+      }
+    } catch (error) {
+      if (!isStudioApiStatus(error, 404)) {
+        throw error;
+      }
+    }
+
+    if (attempt < SAVE_AND_BIND_WORKFLOW_MATERIALIZATION_ATTEMPTS - 1) {
+      await waitForSaveAndBindWorkflowMaterializationTick();
+    }
+  }
+
+  return null;
+}
+
 async function waitForCreatedMemberVisible(input: {
   readonly memberId: string;
   readonly scopeId: string;
@@ -827,6 +883,84 @@ async function saveWorkflowDraft(input: {
     layout: nextLayout,
     title: normalizedTitle,
     workflow: savedWorkflow,
+  };
+}
+
+async function saveAndBindPublishedWorkflowDraft(input: {
+  readonly document: StudioWorkflowDocument;
+  readonly layout: unknown;
+  readonly routeScopeId: string;
+  readonly serviceId?: string | null;
+  readonly title: string;
+  readonly workflow: StudioWorkflowFile;
+}): Promise<SavedAndBoundWorkflow> {
+  const { document, layout, routeScopeId, serviceId, title, workflow } = input;
+  const workflowId = trimOptional(workflow.workflowId);
+  if (!workflowId) {
+    throw new Error("Resolve a stable workflow id before saving the published workflow.");
+  }
+
+  const normalizedTitle =
+    trimOptional(title) || trimOptional(document.name) || workflow.name || "draft";
+  const documentWithTitle: StudioWorkflowDocument = {
+    ...document,
+    name: normalizedTitle,
+  };
+  const serialized = await studioApi.serializeYaml({
+    document: documentWithTitle,
+    availableStepTypes: AVAILABLE_STEP_TYPES,
+  });
+  const savedDocument =
+    cloneWorkflowDocument(serialized.document) ?? documentWithTitle;
+  const graphForLayout = buildStudioGraphElements(savedDocument, layout);
+  const nextLayout = buildStudioWorkflowLayout(
+    normalizedTitle,
+    graphForLayout.nodes,
+    layout ?? workflow.layout,
+  );
+  const result = await studioApi.saveAndBindWorkflow({
+    scopeId: routeScopeId,
+    workflowId,
+    workflowYaml: serialized.yaml,
+    workflowName: normalizedTitle,
+    displayName: normalizedTitle,
+    inlineWorkflowYamls: {},
+    appId: "studio",
+    serviceId,
+    exposureDesired: true,
+  });
+  const resultWorkflowId = trimOptional(result.workflowId) || workflowId;
+  const materializedWorkflow = await waitForSaveAndBindWorkflowMaterialized({
+    expectedYaml: serialized.yaml,
+    scopeId: routeScopeId,
+    workflowId: resultWorkflowId,
+  });
+  const savedWorkflow: StudioWorkflowFile = materializedWorkflow
+    ? {
+        ...materializedWorkflow,
+        document:
+          cloneWorkflowDocument(materializedWorkflow.document) ?? savedDocument,
+        layout: materializedWorkflow.layout ?? nextLayout,
+      }
+    : {
+        ...workflow,
+        workflowId: resultWorkflowId,
+        name: normalizedTitle,
+        yaml: serialized.yaml,
+        layout: nextLayout,
+        document: savedDocument,
+        findings: [],
+      };
+
+  return {
+    materializedWorkflow,
+    result,
+    savedDraft: {
+      document: savedDocument,
+      layout: nextLayout,
+      title: normalizedTitle,
+      workflow: savedWorkflow,
+    },
   };
 }
 
@@ -1308,6 +1442,39 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     onSuccess: (saved) => {
       markSavedDraft(saved);
       void message.success("Workflow draft saved.");
+    },
+  });
+  const saveAndBindMutation = useMutation({
+    mutationFn: async (variables: SaveWorkflowDraftVariables) => {
+      if (!route.scopeId) {
+        throw new Error("Resolve a Team workspace before saving this workflow.");
+      }
+
+      const savedAndBound = await saveAndBindPublishedWorkflowDraft({
+        ...variables,
+        routeScopeId: route.scopeId,
+        serviceId: memberQuery.data?.summary.publishedServiceId,
+      });
+      await renameExistingMemberFromTitle(savedAndBound.savedDraft.title);
+      return savedAndBound;
+    },
+    onError: (error) => {
+      void message.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to save and publish workflow.",
+      );
+    },
+    onSuccess: ({ materializedWorkflow, savedDraft }) => {
+      markSavedDraft(savedDraft);
+      void memberQuery.refetch();
+      if (materializedWorkflow) {
+        void message.success("Published workflow saved.");
+      } else {
+        void message.info(
+          "Published workflow save was accepted. Studio is waiting for the workflow read model.",
+        );
+      }
     },
   });
   const createWorkflowMemberMutation = useMutation({
@@ -1829,13 +1996,15 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
             dirty &&
             workflowHasSteps &&
             !selectedStepConfigurationError &&
-            !createWorkflowMemberMutation.isPending,
+            !createWorkflowMemberMutation.isPending &&
+            !saveAndBindMutation.isPending,
         )
       : Boolean(
           editableDocument &&
             dirty &&
             !selectedStepConfigurationError &&
             !saveMutation.isPending &&
+            !saveAndBindMutation.isPending &&
             !createUnlinkedMemberDraftMutation.isPending &&
             ((workflowQuery.data && !linkedWorkflowMissing) ||
               canCreateUnlinkedMemberDraft),
@@ -2198,8 +2367,10 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
             : routeDraftWorkflowId
               ? "Load the workflow draft before saving."
               : "Save creates a reusable workflow draft for this editor."
-          : !workflowQuery.data
-            ? "Load a workflow member before saving."
+        : !workflowQuery.data
+          ? "Load a workflow member before saving."
+          : memberPublished
+            ? "Save updates the workflow draft and published binding."
             : "Save updates the workflow draft.";
   React.useEffect(() => {
     if (!dirty || typeof window === "undefined") {
@@ -2639,7 +2810,9 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       }
 
       if (workflowQuery.data && editableDocument) {
-        saveMutation.mutate({
+        const mutation = memberPublished ? saveAndBindMutation : saveMutation;
+
+        mutation.mutate({
           document: editableDocument,
           layout:
             editableLayout ??
@@ -2651,6 +2824,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     },
     savePending:
       saveMutation.isPending ||
+      saveAndBindMutation.isPending ||
       createWorkflowMemberMutation.isPending ||
       createUnlinkedMemberDraftMutation.isPending,
     savePlaceholderReason,

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -2082,7 +2082,6 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
         publishBindingRun.status !== "succeeded" &&
         !publishBindingRunTerminal),
   );
-  const publishHasDraftChanges = Boolean(dirty && workflowHasSteps);
   const publishPending = publishMutation.isPending;
   const memberPublished = memberIsPublished;
   const memberPublishedServiceId = trimOptional(
@@ -2153,7 +2152,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       Boolean(selectedStepConfigurationError) ||
       publishMutation.isPending ||
       publishStatusStillInProgress ||
-      (memberIsPublished && !publishHasDraftChanges),
+      memberIsPublished,
   );
   const publishPlaceholderReason =
     route.mode === "new"
@@ -2167,9 +2166,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
         : publishStatusStillInProgress
           ? "Binding run is still in progress. Use Refresh status before publishing again."
         : memberIsPublished
-          ? publishHasDraftChanges
-            ? "Publish saves draft changes, dispatches a candidate binding run, and observes the read model."
-            : "This member workflow is already published. Use Refresh status to check readiness."
+          ? "This member workflow is already published. Save changes to update the bound workflow."
         : !workflowQuery.data || !editableDocument
             ? "Load the workflow draft before publishing."
             : !workflowHasSteps

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -140,12 +140,14 @@ function getTeamMemberWorkflowStudioMemberQueryKey(
 function getTeamMemberWorkflowStudioWorkflowQueryKey(
   scopeId: string,
   workflowId: string,
+  source: "draft" | "published" = "draft",
 ) {
   return [
     "team-member-workflow-studio",
     "workflow",
     scopeId,
     workflowId,
+    source,
   ] as const;
 }
 
@@ -337,6 +339,7 @@ function readPathSegments(): {
   scopeId: string;
   teamId: string;
   workflowId: string;
+  workflowSource: "draft" | "published";
 } {
   const segments =
     typeof window === "undefined"
@@ -374,6 +377,10 @@ function readPathSegments(): {
   const isWorkflowEditorRoute = routeSurface === "workflow";
   const mode = routeMemberId === "new" ? "new" : "existing";
   const workflowId = trimOptional(params.get("workflowId"));
+  const workflowSource =
+    trimOptional(params.get("workflowSource")) === "published"
+      ? "published"
+      : "draft";
   const canonicalHref =
     isWorkflowEditorRoute && scopeId && teamId
       ? buildTeamMemberWorkflowStudioHref({
@@ -382,6 +389,10 @@ function readPathSegments(): {
           scopeId,
           teamId,
           workflowId,
+          workflowSource:
+            mode === "existing" && workflowSource === "published"
+              ? "published"
+              : undefined,
         })
       : currentHref;
 
@@ -392,6 +403,7 @@ function readPathSegments(): {
     scopeId,
     teamId,
     workflowId,
+    workflowSource,
   };
 }
 
@@ -605,6 +617,21 @@ async function waitForSaveAndBindWorkflowMaterialized(input: {
   }
 
   return null;
+}
+
+async function loadPublishedWorkflowWithDraftFallback(input: {
+  readonly scopeId: string;
+  readonly workflowId: string;
+}): Promise<StudioWorkflowFile> {
+  try {
+    return await studioApi.getPublishedWorkflow(input.workflowId, input.scopeId);
+  } catch (error) {
+    if (!isStudioApiStatus(error, 404)) {
+      throw error;
+    }
+
+    return studioApi.getWorkflow(input.workflowId, input.scopeId);
+  }
 }
 
 async function waitForCreatedMemberVisible(input: {
@@ -1122,9 +1149,12 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     isWorkflowDraftRouteId(trimOptional(route.workflowId))
       ? trimOptional(route.workflowId)
       : "";
+  const shouldLoadPublishedWorkflow =
+    route.mode === "existing" && route.workflowSource === "published";
   const workflowQueryKey = getTeamMemberWorkflowStudioWorkflowQueryKey(
     route.scopeId,
     routeDraftWorkflowId,
+    shouldLoadPublishedWorkflow ? "published" : "draft",
   );
   const workflowQuery = useQuery({
     enabled: Boolean(
@@ -1133,7 +1163,13 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
         !memberQuery.isLoading,
     ),
     queryKey: workflowQueryKey,
-    queryFn: () => studioApi.getWorkflow(routeDraftWorkflowId, route.scopeId),
+    queryFn: () =>
+      shouldLoadPublishedWorkflow
+        ? loadPublishedWorkflowWithDraftFallback({
+            scopeId: route.scopeId,
+            workflowId: routeDraftWorkflowId,
+          })
+        : studioApi.getWorkflow(routeDraftWorkflowId, route.scopeId),
     staleTime: SAVED_WORKFLOW_QUERY_STALE_MS,
     retry: false,
   });
@@ -1325,7 +1361,10 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     setDirty(false);
   }, []);
   const cacheSavedWorkflowDraft = React.useCallback(
-    (saved: SavedWorkflowDraft) => {
+    (
+      saved: SavedWorkflowDraft,
+      sources: readonly ("draft" | "published")[] = ["draft"],
+    ) => {
       const savedWorkflow = buildSavedWorkflowCacheValue(saved);
       const savedSignature = readWorkflowSourceSignature(savedWorkflow);
       const savedWorkflowId = trimOptional(savedWorkflow.workflowId);
@@ -1334,13 +1373,16 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       }
 
       suppressedSourceSignatureRef.current = savedSignature;
-      queryClient.setQueryData(
-        getTeamMemberWorkflowStudioWorkflowQueryKey(
-          route.scopeId,
-          savedWorkflowId,
-        ),
-        savedWorkflow,
-      );
+      for (const source of sources) {
+        queryClient.setQueryData(
+          getTeamMemberWorkflowStudioWorkflowQueryKey(
+            route.scopeId,
+            savedWorkflowId,
+            source,
+          ),
+          savedWorkflow,
+        );
+      }
     },
     [queryClient, route.scopeId],
   );
@@ -1361,8 +1403,11 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     [queryClient, route.scopeId],
   );
   const markSavedDraft = React.useCallback(
-    (saved: SavedWorkflowDraft) => {
-      cacheSavedWorkflowDraft(saved);
+    (
+      saved: SavedWorkflowDraft,
+      sources?: readonly ("draft" | "published")[],
+    ) => {
+      cacheSavedWorkflowDraft(saved, sources);
 
       setEditableDocument((currentDocument) =>
         currentDocument
@@ -1466,7 +1511,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       );
     },
     onSuccess: ({ materializedWorkflow, savedDraft }) => {
-      markSavedDraft(savedDraft);
+      markSavedDraft(savedDraft, ["published"]);
       void memberQuery.refetch();
       if (materializedWorkflow) {
         void message.success("Published workflow saved.");
@@ -1958,7 +2003,9 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       }
       setPublishBindingRun(run);
       void memberQuery.refetch();
-      void workflowQuery.refetch();
+      if (!shouldLoadPublishedWorkflow) {
+        void workflowQuery.refetch();
+      }
       if (run?.status === "succeeded") {
         void message.success("Workflow member published.");
       } else {

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -4105,7 +4105,6 @@ describe("TeamMemberWorkflowStudioPage", () => {
       "Run",
       "Add node",
       "Save",
-      "Publish",
       "YAML",
     ]);
 
@@ -5431,7 +5430,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(studioApi.getWorkflow).not.toHaveBeenCalled();
   });
 
-  it("allows publishing a changed draft version for an already published workflow member", async () => {
+  it("keeps publish hidden when an already published workflow member has draft changes", async () => {
     window.history.replaceState(
       {},
       "",
@@ -5476,38 +5475,6 @@ describe("TeamMemberWorkflowStudioPage", () => {
       document: mockWorkflowDocument,
       updatedAtUtc: "2026-06-08T00:00:00Z",
     });
-    (studioApi.saveWorkflow as jest.Mock).mockResolvedValue({
-      directoryId: "scope:scope-1",
-      directoryLabel: "scope-1",
-      draftExists: true,
-      fileName: "wf-alpha.yaml",
-      filePath: "scope://scope-1/wf-alpha.yaml",
-      findings: [],
-      layout: null,
-      name: "Workflow Alpha v2",
-      workflowId: "wf-alpha",
-      yaml: "name: Workflow Alpha v2\nsteps: []\n",
-      document: {
-        ...mockWorkflowDocument,
-        name: "Workflow Alpha v2",
-      },
-      updatedAtUtc: "2026-06-08T00:00:01Z",
-    });
-    (studioApi.bindMemberWorkflow as jest.Mock).mockResolvedValue({
-      bindingRunId: "binding-run-v2",
-      memberId: "m-alpha",
-      scopeId: "scope-1",
-      status: "accepted",
-    });
-    (studioApi.getMemberBindingRun as jest.Mock).mockResolvedValue({
-      bindingRunId: "binding-run-v2",
-      memberId: "m-alpha",
-      scopeId: "scope-1",
-      status: "succeeded",
-      stateVersion: 3,
-      updatedAt: "2026-06-08T00:00:02Z",
-    });
-
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
     await waitFor(() => {
@@ -5523,42 +5490,15 @@ describe("TeamMemberWorkflowStudioPage", () => {
       target: { value: "Workflow Alpha v2" },
     });
 
-    const publishButton = screen.getByRole("button", {
-      name: "Publish",
-    });
     await waitFor(() => {
-      expect(publishButton).toBeEnabled();
+      expect(screen.getByText("Unsaved changes")).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+      expect(screen.queryByRole("button", { name: "Publish" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Refresh status" })).toBeNull();
     });
-    fireEvent.click(publishButton);
-
-    await waitFor(() => {
-      expect(studioApi.saveWorkflow).toHaveBeenCalledWith(
-        expect.objectContaining({
-          scopeId: "scope-1",
-          workflowId: "wf-alpha",
-          workflowName: "Workflow Alpha v2",
-        }),
-      );
-      expect(studioApi.updateMemberDisplayName).toHaveBeenCalledWith({
-        displayName: "Workflow Alpha v2",
-        memberId: "m-alpha",
-        scopeId: "scope-1",
-      });
-      expect(studioApi.bindMemberWorkflow).toHaveBeenCalledWith({
-        displayName: "Workflow Alpha v2",
-        memberId: "m-alpha",
-        scopeId: "scope-1",
-        workflowId: "wf-alpha",
-        workflowYamls: [expect.stringContaining("name: Workflow Alpha v2")],
-      });
-      expect(studioApi.getMemberBindingRun).toHaveBeenCalledWith(
-        "scope-1",
-        "m-alpha",
-        "binding-run-v2",
-      );
-      expect(screen.queryByText("No workflow draft is linked to this member yet.")).toBeNull();
-      expect(screen.getByDisplayValue("Workflow Alpha v2")).toBeTruthy();
-    });
+    expect(studioApi.saveWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.getMemberBindingRun).not.toHaveBeenCalled();
     expect(studioApi.getPublishedWorkflow).not.toHaveBeenCalled();
     expect(studioApi.setTeamEntryMember).not.toHaveBeenCalled();
   });
@@ -5696,11 +5636,11 @@ describe("TeamMemberWorkflowStudioPage", () => {
     });
   });
 
-  it("surfaces failed republish even when an older member binding remains serviceable", async () => {
+  it("surfaces failed save-and-bind while an older member binding remains serviceable", async () => {
     window.history.replaceState(
       {},
       "",
-      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow?workflowId=wf-alpha",
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow?workflowId=wf-alpha&workflowSource=published",
     );
     (studioApi.getMember as jest.Mock).mockResolvedValue({
       implementationRef: {
@@ -5727,7 +5667,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         revisionId: "rev-1",
       },
     });
-    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+    (studioApi.getPublishedWorkflow as jest.Mock).mockResolvedValue({
       directoryId: "scope:scope-1",
       directoryLabel: "scope-1",
       draftExists: true,
@@ -5741,41 +5681,9 @@ describe("TeamMemberWorkflowStudioPage", () => {
       document: mockWorkflowDocument,
       updatedAtUtc: "2026-06-08T00:00:00Z",
     });
-    (studioApi.saveWorkflow as jest.Mock).mockResolvedValue({
-      directoryId: "scope:scope-1",
-      directoryLabel: "scope-1",
-      draftExists: true,
-      fileName: "wf-alpha.yaml",
-      filePath: "scope://scope-1/wf-alpha.yaml",
-      findings: [],
-      layout: null,
-      name: "Workflow Alpha v2",
-      workflowId: "wf-alpha",
-      yaml: "name: Workflow Alpha v2\nsteps: []\n",
-      document: {
-        ...mockWorkflowDocument,
-        name: "Workflow Alpha v2",
-      },
-      updatedAtUtc: "2026-06-08T00:00:01Z",
-    });
-    (studioApi.bindMemberWorkflow as jest.Mock).mockResolvedValue({
-      bindingRunId: "binding-run-v2",
-      memberId: "m-alpha",
-      scopeId: "scope-1",
-      status: "accepted",
-    });
-    (studioApi.getMemberBindingRun as jest.Mock).mockResolvedValue({
-      bindingRunId: "binding-run-v2",
-      failure: {
-        code: "BINDING_FAILED",
-        message: "Latest workflow draft failed to bind.",
-      },
-      memberId: "m-alpha",
-      scopeId: "scope-1",
-      status: "failed",
-      stateVersion: 3,
-      updatedAt: "2026-06-08T00:00:02Z",
-    });
+    (studioApi.saveAndBindWorkflow as jest.Mock).mockRejectedValue(
+      new StudioApiError("Latest workflow draft failed to bind.", 500),
+    );
 
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
@@ -5786,15 +5694,25 @@ describe("TeamMemberWorkflowStudioPage", () => {
     fireEvent.change(screen.getByLabelText("Workflow title"), {
       target: { value: "Workflow Alpha v2" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Publish" }));
+    expect(screen.queryByRole("button", { name: "Publish" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Error")).toBeTruthy();
-      expect(
-        screen.getByTitle(/Latest workflow draft failed to bind/),
-      ).toBeTruthy();
+      expect(screen.getByText("Latest workflow draft failed to bind.")).toBeTruthy();
     });
-    expect(screen.queryByTitle(/Published member workflow is serviceable/)).toBeNull();
+    expect(studioApi.saveAndBindWorkflow).toHaveBeenCalledWith({
+      appId: "studio",
+      displayName: "Workflow Alpha v2",
+      exposureDesired: true,
+      inlineWorkflowYamls: {},
+      scopeId: "scope-1",
+      serviceId: "svc-alpha",
+      workflowId: "wf-alpha",
+      workflowName: "Workflow Alpha v2",
+      workflowYaml: expect.stringContaining("name: Workflow Alpha v2"),
+    });
+    expect(studioApi.saveWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
   });
 
   it("refreshes a stale member current binding run from the binding-run read model", async () => {

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -138,6 +138,8 @@ jest.mock("@/shared/studio/api", () => {
       listWorkflows: jest.fn(),
       listExecutions: jest.fn(),
       parseYaml: jest.fn(),
+      getPublishedWorkflow: jest.fn(),
+      saveAndBindWorkflow: jest.fn(),
       saveWorkflow: jest.fn(),
       serializeYaml: jest.fn(),
       setTeamEntryMember: jest.fn(),
@@ -5473,6 +5475,135 @@ describe("TeamMemberWorkflowStudioPage", () => {
       );
     });
     expect(studioApi.setTeamEntryMember).not.toHaveBeenCalled();
+  });
+
+  it("saves and rebinds a changed published workflow member through save-and-bind", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow?workflowId=wf-alpha",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "wf-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: "rev-1",
+        lifecycleStage: "bind_ready",
+        memberId: "m-alpha",
+        publishedServiceId: "svc-alpha",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+      lastBinding: {
+        boundAt: "2026-06-08T00:00:00Z",
+        implementationKind: "workflow",
+        publishedServiceId: "svc-alpha",
+        revisionId: "rev-1",
+      },
+    });
+    const staleWorkflow = {
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "wf-alpha.yaml",
+      filePath: "scope://scope-1/wf-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "wf-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: mockWorkflowDocument,
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    };
+    const materializedWorkflow = {
+      ...staleWorkflow,
+      name: "Workflow Alpha v2",
+      yaml: "name: Workflow Alpha v2\nsteps:\n  - id: triage\n    type: llm_call",
+      document: {
+        ...mockWorkflowDocument,
+        name: "Workflow Alpha v2",
+      },
+      updatedAtUtc: "2026-06-08T00:00:03Z",
+    };
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue(staleWorkflow);
+    (studioApi.getPublishedWorkflow as jest.Mock)
+      .mockResolvedValueOnce(staleWorkflow)
+      .mockResolvedValueOnce(staleWorkflow)
+      .mockResolvedValue(materializedWorkflow);
+    (studioApi.saveAndBindWorkflow as jest.Mock).mockResolvedValue({
+      scopeId: "scope-1",
+      workflowId: "wf-alpha",
+      revisionId: "rev-2",
+      workflow: {
+        scopeId: "scope-1",
+        workflowId: "wf-alpha",
+        revisionId: "rev-2",
+        readModelUrl: "/api/scopes/scope-1/workflows/wf-alpha",
+        acceptanceStage: "accepted",
+        propagationStage: "readmodel_propagating",
+      },
+      binding: {
+        scopeId: "scope-1",
+        serviceId: "svc-alpha",
+        displayName: "Workflow Alpha v2",
+        revisionId: "rev-2",
+        implementationKind: "workflow",
+        targetKind: "workflow",
+        targetName: "Workflow Alpha v2",
+      },
+      acceptanceStage: "accepted",
+      propagationStage: "readmodel_propagating",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
+      expect(screen.getByText("Published")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByLabelText("Workflow title"), {
+      target: { value: "Workflow Alpha v2" },
+    });
+
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    await waitFor(() => {
+      expect(saveButton).toBeEnabled();
+    });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(studioApi.saveAndBindWorkflow).toHaveBeenCalledWith({
+        appId: "studio",
+        displayName: "Workflow Alpha v2",
+        exposureDesired: true,
+        inlineWorkflowYamls: {},
+        scopeId: "scope-1",
+        serviceId: "svc-alpha",
+        workflowId: "wf-alpha",
+        workflowName: "Workflow Alpha v2",
+        workflowYaml: expect.stringContaining("name: Workflow Alpha v2"),
+      });
+    });
+    expect(studioApi.saveWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.getMemberBindingRun).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(studioApi.updateMemberDisplayName).toHaveBeenCalledWith({
+        displayName: "Workflow Alpha v2",
+        memberId: "m-alpha",
+        scopeId: "scope-1",
+      });
+      expect(studioApi.getWorkflow).toHaveBeenCalledTimes(1);
+      expect(studioApi.getPublishedWorkflow).toHaveBeenCalledTimes(3);
+      expect(screen.getByDisplayValue("Workflow Alpha v2")).toBeTruthy();
+    });
   });
 
   it("surfaces failed republish even when an older member binding remains serviceable", async () => {

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -527,6 +527,9 @@ describe("TeamMemberWorkflowStudioPage", () => {
       scopeId: "scope-1",
       status: "accepted",
     });
+    (studioApi.getPublishedWorkflow as jest.Mock).mockImplementation(
+      (...args: unknown[]) => (studioApi.getWorkflow as jest.Mock)(...args),
+    );
   });
 
   afterEach(() => {
@@ -1640,7 +1643,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     window.history.replaceState(
       {},
       "",
-      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow?workflowId=wf-alpha",
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow?workflowId=wf-alpha&workflowSource=published",
     );
     (studioApi.getMember as jest.Mock).mockResolvedValue({
       implementationRef: {
@@ -5348,6 +5351,86 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(studioApi.setTeamEntryMember).not.toHaveBeenCalled();
   });
 
+  it("loads the published workflow for an already published member instead of a stale draft", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow?workflowId=wf-alpha&workflowSource=published",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "wf-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "document_2",
+        implementationKind: "workflow",
+        lastBoundRevisionId: "rev-2",
+        lifecycleStage: "bind_ready",
+        memberId: "m-alpha",
+        publishedServiceId: "svc-alpha",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:03Z",
+      },
+      lastBinding: {
+        boundAt: "2026-06-08T00:00:03Z",
+        implementationKind: "workflow",
+        publishedServiceId: "svc-alpha",
+        revisionId: "rev-2",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "wf-alpha.yaml",
+      filePath: "scope://scope-1/wf-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "weekly_report_4",
+      workflowId: "wf-alpha",
+      yaml: "name: weekly_report_4\nsteps: []\n",
+      document: {
+        ...mockWorkflowDocument,
+        name: "weekly_report_4",
+      },
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+    (studioApi.getPublishedWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: false,
+      fileName: "wf-alpha.yaml",
+      filePath: "scope://scope-1/wf-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "document_2",
+      workflowId: "wf-alpha",
+      yaml: "name: document_2\nsteps: []\n",
+      document: {
+        ...mockWorkflowDocument,
+        name: "document_2",
+      },
+      updatedAtUtc: "2026-06-08T00:00:03Z",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    expect(await screen.findByDisplayValue("document_2")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
+    });
+    expect(screen.queryByDisplayValue("weekly_report_4")).toBeNull();
+    expect(studioApi.getPublishedWorkflow).toHaveBeenCalledWith(
+      "wf-alpha",
+      "scope-1",
+    );
+    expect(studioApi.getWorkflow).not.toHaveBeenCalled();
+  });
+
   it("allows publishing a changed draft version for an already published workflow member", async () => {
     window.history.replaceState(
       {},
@@ -5473,7 +5556,10 @@ describe("TeamMemberWorkflowStudioPage", () => {
         "m-alpha",
         "binding-run-v2",
       );
+      expect(screen.queryByText("No workflow draft is linked to this member yet.")).toBeNull();
+      expect(screen.getByDisplayValue("Workflow Alpha v2")).toBeTruthy();
     });
+    expect(studioApi.getPublishedWorkflow).not.toHaveBeenCalled();
     expect(studioApi.setTeamEntryMember).not.toHaveBeenCalled();
   });
 
@@ -5481,7 +5567,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     window.history.replaceState(
       {},
       "",
-      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow?workflowId=wf-alpha",
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow?workflowId=wf-alpha&workflowSource=published",
     );
     (studioApi.getMember as jest.Mock).mockResolvedValue({
       implementationRef: {
@@ -5534,6 +5620,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     };
     (studioApi.getWorkflow as jest.Mock).mockResolvedValue(staleWorkflow);
     (studioApi.getPublishedWorkflow as jest.Mock)
+      .mockResolvedValueOnce(staleWorkflow)
       .mockResolvedValueOnce(staleWorkflow)
       .mockResolvedValueOnce(staleWorkflow)
       .mockResolvedValue(materializedWorkflow);
@@ -5600,8 +5687,11 @@ describe("TeamMemberWorkflowStudioPage", () => {
         memberId: "m-alpha",
         scopeId: "scope-1",
       });
-      expect(studioApi.getWorkflow).toHaveBeenCalledTimes(1);
-      expect(studioApi.getPublishedWorkflow).toHaveBeenCalledTimes(3);
+      expect(studioApi.getWorkflow).not.toHaveBeenCalled();
+      expect(studioApi.getPublishedWorkflow).toHaveBeenCalledWith(
+        "wf-alpha",
+        "scope-1",
+      );
       expect(screen.getByDisplayValue("Workflow Alpha v2")).toBeTruthy();
     });
   });

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -1976,6 +1976,9 @@ describe("TeamDetailPage", () => {
     expect(new URLSearchParams(window.location.search).get("workflowId")).toBe(
       "wf-team-alpha",
     );
+    expect(new URLSearchParams(window.location.search).get("workflowSource")).toBe(
+      "published",
+    );
   });
 
   it("uses the roster implementation workflow id instead of the route workflow hint", async () => {
@@ -1994,6 +1997,9 @@ describe("TeamDetailPage", () => {
     );
     expect(new URLSearchParams(window.location.search).get("workflowId")).toBe(
       "wf-team-alpha",
+    );
+    expect(new URLSearchParams(window.location.search).get("workflowSource")).toBe(
+      "published",
     );
   });
 
@@ -2040,6 +2046,7 @@ describe("TeamDetailPage", () => {
       "/scopes/scope-1/teams/t-alpha/members/member-team-alpha/workflow",
     );
     expect(new URLSearchParams(window.location.search).get("workflowId")).toBeNull();
+    expect(new URLSearchParams(window.location.search).get("workflowSource")).toBeNull();
   });
 
   it("does not reuse a route workflow hint for another Team member row", async () => {
@@ -2058,6 +2065,9 @@ describe("TeamDetailPage", () => {
     );
     expect(new URLSearchParams(window.location.search).get("workflowId")).toBe(
       "wf-team-alpha",
+    );
+    expect(new URLSearchParams(window.location.search).get("workflowSource")).toBe(
+      "published",
     );
   });
 

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -1523,7 +1523,7 @@ describe("TeamDetailPage", () => {
     expect(scopeRuntimeApi.listMemberRuns).not.toHaveBeenCalled();
   });
 
-  it("does not sample runtime runs while browsing members with member-owned service ids", async () => {
+  it("resolves member studio links without sampling runtime runs while browsing members", async () => {
     window.history.replaceState(
       {},
       "",
@@ -1583,7 +1583,9 @@ describe("TeamDetailPage", () => {
     await waitFor(() => {
       expect(studioApi.listTeamMembers).toHaveBeenCalledWith("scope-1", "t-alpha");
     });
-    expect(scopeRuntimeApi.listServices).not.toHaveBeenCalled();
+    expect(scopeRuntimeApi.listServices).toHaveBeenCalledWith("scope-1", {
+      appId: "default",
+    });
     expect(scopeRuntimeApi.getServiceRevisions).not.toHaveBeenCalled();
     expect(scopeRuntimeApi.listServiceRuns).not.toHaveBeenCalled();
     expect(scopeRuntimeApi.listMemberRuns).not.toHaveBeenCalled();
@@ -1974,14 +1976,14 @@ describe("TeamDetailPage", () => {
       "/scopes/scope-1/teams/t-alpha/members/member-team-alpha/workflow",
     );
     expect(new URLSearchParams(window.location.search).get("workflowId")).toBe(
-      "wf-team-alpha",
+      "workflow-1",
     );
     expect(new URLSearchParams(window.location.search).get("workflowSource")).toBe(
       "published",
     );
   });
 
-  it("uses the roster implementation workflow id instead of the route workflow hint", async () => {
+  it("uses the published service workflow id instead of the route workflow hint", async () => {
     window.history.replaceState(
       {},
       "",
@@ -1996,14 +1998,14 @@ describe("TeamDetailPage", () => {
       "/scopes/scope-1/teams/t-alpha/members/member-team-alpha/workflow",
     );
     expect(new URLSearchParams(window.location.search).get("workflowId")).toBe(
-      "wf-team-alpha",
+      "workflow-1",
     );
     expect(new URLSearchParams(window.location.search).get("workflowSource")).toBe(
       "published",
     );
   });
 
-  it("does not recover workflow ids from session storage when the roster has no implementation workflow id", async () => {
+  it("recovers a published workflow id from the bound service when the roster omits the implementation ref", async () => {
     window.history.replaceState(
       {},
       "",
@@ -2045,8 +2047,12 @@ describe("TeamDetailPage", () => {
     expect(window.location.pathname).toBe(
       "/scopes/scope-1/teams/t-alpha/members/member-team-alpha/workflow",
     );
-    expect(new URLSearchParams(window.location.search).get("workflowId")).toBeNull();
-    expect(new URLSearchParams(window.location.search).get("workflowSource")).toBeNull();
+    expect(new URLSearchParams(window.location.search).get("workflowId")).toBe(
+      "workflow-1",
+    );
+    expect(new URLSearchParams(window.location.search).get("workflowSource")).toBe(
+      "published",
+    );
   });
 
   it("does not reuse a route workflow hint for another Team member row", async () => {
@@ -2064,7 +2070,7 @@ describe("TeamDetailPage", () => {
       "/scopes/scope-1/teams/t-alpha/members/member-team-alpha/workflow",
     );
     expect(new URLSearchParams(window.location.search).get("workflowId")).toBe(
-      "wf-team-alpha",
+      "workflow-1",
     );
     expect(new URLSearchParams(window.location.search).get("workflowSource")).toBe(
       "published",

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/shared/agui/runtimeEventSemantics";
 import { parseBackendSSEStream } from "@/shared/agui/sseFrameNormalizer";
 import { runtimeRunsApi } from "@/shared/api/runtimeRunsApi";
+import { scopesApi } from "@/shared/api/scopesApi";
 import { scopeRuntimeApi } from "@/shared/api/scopeRuntimeApi";
 import { formatCompactDateTime } from "@/shared/datetime/dateTime";
 import {
@@ -30,6 +31,7 @@ import {
   formatStudioMemberLifecycleStage,
 } from "@/shared/studio/models";
 import type { StudioMemberRoster, StudioTeamSummary } from "@/shared/studio/models";
+import type { ScopeWorkflowSummary } from "@/shared/models/scopes";
 import { describeError } from "@/shared/ui/errorText";
 import {
   TeamActionRail,
@@ -60,6 +62,7 @@ const teamProjectionRetryMaxMs = 3_000;
 const entryMemberClearingId = "__clear_entry_member__";
 const teamEntryVisibilityAttempts = 5;
 const teamEntryVisibilityRetryDelayMs = 100;
+const emptyWorkflowSummaries: readonly ScopeWorkflowSummary[] = [];
 
 function isProjectionSyncing404(error: unknown): boolean {
   return isStudioApiStatus(error, 404);
@@ -74,6 +77,81 @@ function projectionRetryDelay(attemptIndex: number): number {
 
 function trimText(value: string | null | undefined): string {
   return value?.trim() ?? "";
+}
+
+function workflowMatchesBoundService(
+  workflow: ScopeWorkflowSummary,
+  service: {
+    readonly activeServingRevisionId?: string | null;
+    readonly defaultServingRevisionId?: string | null;
+    readonly serviceKey?: string | null;
+  } | null | undefined,
+): boolean {
+  if (!service) {
+    return false;
+  }
+
+  const workflowServiceKey = trimText(workflow.serviceKey);
+  if (
+    workflowServiceKey &&
+    trimText(service.serviceKey) === workflowServiceKey
+  ) {
+    return true;
+  }
+
+  const workflowRevisionId = trimText(workflow.activeRevisionId);
+  if (!workflowRevisionId) {
+    return false;
+  }
+
+  return (
+    trimText(service.activeServingRevisionId) === workflowRevisionId ||
+    trimText(service.defaultServingRevisionId) === workflowRevisionId
+  );
+}
+
+function resolveRosterMemberWorkflowId(input: {
+  readonly boundService?: {
+    readonly activeServingRevisionId?: string | null;
+    readonly defaultServingRevisionId?: string | null;
+    readonly serviceKey?: string | null;
+  } | null;
+  readonly isBoundMember: boolean;
+  readonly member: {
+    readonly implementationRef?: {
+      readonly implementationKind?: string | null;
+      readonly workflowId?: string | null;
+    } | null;
+  };
+  readonly workflows: readonly ScopeWorkflowSummary[];
+}): string {
+  const implementationRef = input.member.implementationRef;
+  const implementationWorkflowId =
+    trimText(implementationRef?.implementationKind).toLowerCase() ===
+    "workflow"
+      ? trimText(implementationRef?.workflowId)
+      : "";
+  if (!input.isBoundMember) {
+    return implementationWorkflowId;
+  }
+
+  const matchedWorkflow =
+    input.workflows.find((workflow) =>
+      workflowMatchesBoundService(workflow, input.boundService),
+    ) ?? null;
+  return trimText(matchedWorkflow?.workflowId);
+}
+
+function isBoundWorkflowRosterMember(member: {
+  readonly implementationKind?: string | null;
+  readonly lifecycleStage?: string | null;
+  readonly publishedServiceId?: string | null;
+}): boolean {
+  return (
+    trimText(member.implementationKind).toLowerCase() === "workflow" &&
+    normalizeStatus(member.lifecycleStage) === "bind_ready" &&
+    trimText(member.publishedServiceId).length > 0
+  );
 }
 
 function resolveTeamHeading(input: {
@@ -545,10 +623,45 @@ const TeamDetailPage: React.FC = () => {
     queryKey: ["teams", "services", scopeId],
     retry: false,
   });
+  const hasBoundWorkflowMembersForStudioLinks = React.useMemo(
+    () =>
+      activeTab === "members" &&
+      (teamMembersQuery.data?.members ?? []).some(isBoundWorkflowRosterMember),
+    [activeTab, teamMembersQuery.data?.members],
+  );
+  const shouldLoadMemberStudioLinkCatalog =
+    hasTeamIdentity && hasBoundWorkflowMembersForStudioLinks;
+  const memberStudioLinkWorkflowsQuery = useQuery({
+    enabled: shouldLoadMemberStudioLinkCatalog,
+    queryFn: () => scopesApi.listWorkflows(scopeId),
+    queryKey: ["teams", "workflows", scopeId],
+    retry: false,
+  });
+  const memberStudioLinkServicesQuery = useQuery({
+    enabled: shouldLoadMemberStudioLinkCatalog,
+    queryFn: () =>
+      scopeRuntimeApi.listServices(scopeId, {
+        appId: "default",
+      }),
+    queryKey: ["teams", "services", scopeId],
+    retry: false,
+  });
+  const workflowSummariesForMemberLinks =
+    activeTab === "members"
+      ? memberStudioLinkWorkflowsQuery.data ??
+        workflowsQuery.data ??
+        emptyWorkflowSummaries
+      : workflowsQuery.data ?? emptyWorkflowSummaries;
+  const isResolvingMemberStudioLinks =
+    shouldLoadMemberStudioLinkCatalog &&
+    (memberStudioLinkWorkflowsQuery.isLoading ||
+      memberStudioLinkServicesQuery.isLoading);
   const automationServiceRuntimeByServiceId = React.useMemo(() => {
     const services =
       activeTab === "automations"
         ? automationsServicesQuery.data ?? servicesQuery.data ?? []
+        : activeTab === "members"
+          ? memberStudioLinkServicesQuery.data ?? servicesQuery.data ?? []
         : servicesQuery.data ?? [];
     return new Map(
       services
@@ -563,6 +676,7 @@ const TeamDetailPage: React.FC = () => {
               serviceId: service.serviceId,
               tenantId: service.tenantId,
             },
+            serviceKey: service.serviceKey,
           },
         ] as const)
         .filter(([serviceId]) => serviceId.length > 0),
@@ -570,6 +684,7 @@ const TeamDetailPage: React.FC = () => {
   }, [
     activeTab,
     automationsServicesQuery.data,
+    memberStudioLinkServicesQuery.data,
     servicesQuery.data,
   ]);
 
@@ -785,11 +900,12 @@ const TeamDetailPage: React.FC = () => {
           publishedServiceId.length > 0;
         const automationServiceRuntime =
           automationServiceRuntimeByServiceId.get(publishedServiceId);
-        const memberDraftWorkflowId =
-          trimText(member.implementationRef?.implementationKind).toLowerCase() ===
-          "workflow"
-            ? trimText(member.implementationRef?.workflowId)
-            : "";
+        const memberDraftWorkflowId = resolveRosterMemberWorkflowId({
+          boundService: automationServiceRuntime,
+          isBoundMember,
+          member,
+          workflows: workflowSummariesForMemberLinks,
+        });
         const workflowStudioHref = buildTeamMemberWorkflowStudioHref({
           memberId: member.memberId,
           mode: "edit-member",
@@ -869,6 +985,7 @@ const TeamDetailPage: React.FC = () => {
       automationServiceRuntimeByServiceId,
       teamMembersQuery.data?.members,
       token,
+      workflowSummariesForMemberLinks,
     ],
   );
   const createMemberHref = React.useMemo(
@@ -1542,7 +1659,7 @@ const TeamDetailPage: React.FC = () => {
       prompt={teamTestPrompt}
       resultText={teamTestResultText}
       rosterError={teamMembersQuery.isError && !isTeamMembersProjectionSyncing}
-      rosterLoading={teamMembersQuery.isLoading}
+      rosterLoading={teamMembersQuery.isLoading || isResolvingMemberStudioLinks}
       rosterRows={teamRosterRows}
       rosterSyncing={isTeamMembersProjectionSyncing}
       status={teamTestStatus}
@@ -1610,9 +1727,9 @@ const TeamDetailPage: React.FC = () => {
             : undefined
         }
         rosterError={teamMembersQuery.isError && !isTeamMembersProjectionSyncing}
-        rosterLoading={teamMembersQuery.isLoading}
+        rosterLoading={teamMembersQuery.isLoading || isResolvingMemberStudioLinks}
         rosterSyncing={isTeamMembersProjectionSyncing}
-      rosterRows={teamRosterRows}
+        rosterRows={teamRosterRows}
       />
     );
   };

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -796,6 +796,10 @@ const TeamDetailPage: React.FC = () => {
           scopeId,
           teamId: selectedTeamId,
           workflowId: memberDraftWorkflowId || undefined,
+          workflowSource:
+            isWorkflowMember && isBoundMember && memberDraftWorkflowId
+              ? "published"
+              : undefined,
         });
         const memberInvokeHref = buildTeamMemberInvokeHref({
           memberId: member.memberId,

--- a/apps/aevatar-console-web/src/shared/config/proxyConfig.test.ts
+++ b/apps/aevatar-console-web/src/shared/config/proxyConfig.test.ts
@@ -142,6 +142,27 @@ describe('proxy config', () => {
     });
   });
 
+  it('routes scope workflow save-and-bind to the Studio host', () => {
+    process.env.AEVATAR_API_TARGET = 'http://127.0.0.1:5080';
+    process.env.AEVATAR_STUDIO_API_TARGET = 'http://127.0.0.1:5180';
+
+    const proxyModule = require('../../../config/proxy');
+    const devProxy = proxyModule.default.dev as Record<string, ProxyEntry>;
+
+    expect(
+      resolveProxyEntry(devProxy, '/api/scopes/scope-1/workflows:save-and-bind'),
+    ).toEqual({
+      target: 'http://127.0.0.1:5180',
+      changeOrigin: true,
+      ws: true,
+    });
+    expect(devProxy['/api/']).toEqual({
+      target: 'http://127.0.0.1:5080',
+      changeOrigin: true,
+      ws: true,
+    });
+  });
+
   it('routes scope team endpoints to the Studio host without stealing runtime member routes', () => {
     process.env.AEVATAR_API_TARGET = 'http://127.0.0.1:5080';
     process.env.AEVATAR_STUDIO_API_TARGET = 'http://127.0.0.1:5180';

--- a/apps/aevatar-console-web/src/shared/navigation/teamRoutes.test.ts
+++ b/apps/aevatar-console-web/src/shared/navigation/teamRoutes.test.ts
@@ -88,9 +88,10 @@ describe("teamRoutes", () => {
         scopeId: "scope-alpha",
         teamId: "t-alpha",
         workflowId: " workflow-alpha ",
+        workflowSource: "published",
       }),
     ).toBe(
-      "/scopes/scope-alpha/teams/t-alpha/members/member-alpha/workflow?workflowId=workflow-alpha",
+      "/scopes/scope-alpha/teams/t-alpha/members/member-alpha/workflow?workflowId=workflow-alpha&workflowSource=published",
     );
 
     expect(

--- a/apps/aevatar-console-web/src/shared/navigation/teamRoutes.ts
+++ b/apps/aevatar-console-web/src/shared/navigation/teamRoutes.ts
@@ -173,6 +173,7 @@ export function buildTeamMemberWorkflowStudioHref(options: {
   scopeId: string;
   teamId: string;
   workflowId?: string;
+  workflowSource?: 'published';
 }): string {
   const scopeId = trimOptional(options.scopeId);
   const teamId = trimOptional(options.teamId);
@@ -197,6 +198,7 @@ export function buildTeamMemberWorkflowStudioHref(options: {
     `/scopes/${encodeURIComponent(scopeId)}/teams/${encodeURIComponent(teamId)}/members/${encodeURIComponent(memberId)}/workflow`,
     {
       workflowId: options.workflowId,
+      workflowSource: options.workflowSource,
     },
   );
 }

--- a/apps/aevatar-console-web/src/shared/studio/api.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.test.ts
@@ -580,6 +580,67 @@ describe('studioApi host-session requests', () => {
     });
   });
 
+  it('loads a published scope workflow detail without checking workspace drafts', async () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: 'access-token',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        expiresAt: Date.now() + 3_600_000,
+      },
+      user: {
+        sub: 'user-1',
+      },
+    });
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        available: true,
+        scopeId: 'scope-1',
+        workflow: {
+          scopeId: 'scope-1',
+          workflowId: 'workflow-1',
+          displayName: 'published-demo-v2',
+          serviceKey: 'svc-1',
+          workflowName: 'published-demo-v2',
+          actorId: 'actor-1',
+          activeRevisionId: 'rev-2',
+          deploymentId: 'dep-1',
+          deploymentStatus: 'Running',
+          updatedAt: '2026-04-17T00:00:00Z',
+        },
+        source: {
+          workflowYaml: 'name: published-demo-v2\nsteps: []\n',
+          definitionActorId: 'definition-1',
+          inlineWorkflowYamls: null,
+        },
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(
+      studioApi.getPublishedWorkflow('workflow-1', 'scope-1'),
+    ).resolves.toEqual({
+      workflowId: 'workflow-1',
+      name: 'published-demo-v2',
+      fileName: 'workflow-1.yaml',
+      filePath: 'scope://scope-1/workflow-1.yaml',
+      directoryId: 'scope:scope-1',
+      directoryLabel: 'scope-1',
+      yaml: 'name: published-demo-v2\nsteps: []\n',
+      document: null,
+      draftExists: false,
+      findings: [],
+      updatedAtUtc: '2026-04-17T00:00:00Z',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      '/api/scopes/scope-1/workflows/workflow-1',
+    );
+  });
+
   it('creates a scoped workflow draft on first save when the loaded workflow is committed-only', async () => {
     persistAuthSession({
       tokens: {
@@ -920,6 +981,88 @@ describe('studioApi host-session requests', () => {
         workflowYamls: ['name: joker\nsteps: []\n'],
       }),
     ).toThrow('Workflow member binding requires a stable workflow id.');
+  });
+
+  it('saves and binds a published workflow using the dedicated save-and-bind endpoint', async () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: 'access-token',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        expiresAt: Date.now() + 3_600_000,
+      },
+      user: {
+        sub: 'user-1',
+      },
+    });
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 202,
+      json: async () => ({
+        scopeId: 'scope-1',
+        workflowId: 'wf-alpha',
+        revisionId: 'rev-1',
+        workflow: {
+          scopeId: 'scope-1',
+          workflowId: 'wf-alpha',
+          revisionId: 'rev-1',
+          readModelUrl: '/api/scopes/scope-1/workflows/wf-alpha',
+          acceptanceStage: 'accepted',
+          propagationStage: 'readmodel_propagating',
+        },
+        binding: {
+          scopeId: 'scope-1',
+          serviceId: 'svc-alpha',
+          displayName: 'Workflow Alpha',
+          revisionId: 'rev-1',
+          implementationKind: 'workflow',
+          targetKind: 'workflow',
+          targetName: 'Workflow Alpha',
+        },
+        acceptanceStage: 'accepted',
+        propagationStage: 'readmodel_propagating',
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    const result = await studioApi.saveAndBindWorkflow({
+      scopeId: 'scope-1',
+      workflowId: 'wf-alpha',
+      workflowYaml: 'name: Workflow Alpha\nsteps: []\n',
+      workflowName: 'Workflow Alpha',
+      displayName: 'Workflow Alpha',
+      inlineWorkflowYamls: {},
+      appId: 'studio',
+      serviceId: 'svc-alpha',
+      exposureDesired: true,
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        scopeId: 'scope-1',
+        workflowId: 'wf-alpha',
+        revisionId: 'rev-1',
+        acceptanceStage: 'accepted',
+        propagationStage: 'readmodel_propagating',
+      }),
+    );
+
+    const [input, init] = fetchMock.mock.calls[0] as [
+      string,
+      RequestInit | undefined,
+    ];
+    expect(input).toBe('/api/scopes/scope-1/workflows:save-and-bind');
+    expect(init?.method).toBe('POST');
+    expect(JSON.parse(String(init?.body))).toEqual({
+      workflowId: 'wf-alpha',
+      workflowYaml: 'name: Workflow Alpha\nsteps: []\n',
+      workflowName: 'Workflow Alpha',
+      displayName: 'Workflow Alpha',
+      appId: 'studio',
+      serviceId: 'svc-alpha',
+      exposureDesired: true,
+    });
   });
 
   it('binds a GAgent to the default service using the scope binding endpoint', async () => {

--- a/apps/aevatar-console-web/src/shared/studio/api.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.ts
@@ -44,6 +44,8 @@ import type {
   StudioScopeScriptBindingResult,
   StudioScopeScriptBindingStatus,
   StudioRuntimeTestResult,
+  StudioSaveAndBindWorkflowAcceptedResult,
+  StudioSaveAndBindWorkflowInput,
   StudioSaveSettingsInput,
   StudioSaveWorkflowInput,
   StudioSerializeYamlResult,
@@ -1034,6 +1036,94 @@ function decodeStudioScopeBindingResult(
             ]) || "",
         }
       : null,
+  };
+}
+
+function decodeStudioSaveAndBindWorkflowResult(
+  value: unknown
+): StudioSaveAndBindWorkflowAcceptedResult {
+  const record = expectRecord(value, "StudioSaveAndBindWorkflowAcceptedResult");
+  const workflowRecord =
+    record.workflow == null && record.Workflow == null
+      ? null
+      : expectRecord(
+          record.workflow ?? record.Workflow,
+          "StudioSaveAndBindWorkflowAcceptedResult.workflow"
+        );
+  const binding =
+    record.binding == null && record.Binding == null
+      ? undefined
+      : decodeStudioScopeBindingResult(record.binding ?? record.Binding);
+  const scopeId = readString(
+    record,
+    ["scopeId", "ScopeId"],
+    "StudioSaveAndBindWorkflowAcceptedResult.scopeId"
+  );
+  const workflowId = readString(
+    record,
+    ["workflowId", "WorkflowId"],
+    "StudioSaveAndBindWorkflowAcceptedResult.workflowId"
+  );
+  const revisionId = readString(
+    record,
+    ["revisionId", "RevisionId"],
+    "StudioSaveAndBindWorkflowAcceptedResult.revisionId"
+  );
+
+  return {
+    scopeId,
+    workflowId,
+    revisionId,
+    workflow: workflowRecord
+      ? {
+          scopeId: readString(
+            workflowRecord,
+            ["scopeId", "ScopeId"],
+            "StudioSaveAndBindWorkflowAcceptedResult.workflow.scopeId"
+          ),
+          workflowId: readString(
+            workflowRecord,
+            ["workflowId", "WorkflowId"],
+            "StudioSaveAndBindWorkflowAcceptedResult.workflow.workflowId"
+          ),
+          serviceKey: readOptionalString(workflowRecord, [
+            "serviceKey",
+            "ServiceKey",
+          ]),
+          revisionId: readString(
+            workflowRecord,
+            ["revisionId", "RevisionId"],
+            "StudioSaveAndBindWorkflowAcceptedResult.workflow.revisionId"
+          ),
+          readModelUrl: readOptionalString(workflowRecord, [
+            "readModelUrl",
+            "ReadModelUrl",
+          ]),
+          acceptanceStage: readOptionalString(workflowRecord, [
+            "acceptanceStage",
+            "AcceptanceStage",
+          ]),
+          propagationStage: readOptionalString(workflowRecord, [
+            "propagationStage",
+            "PropagationStage",
+          ]),
+          displayName: readOptionalString(workflowRecord, [
+            "displayName",
+            "DisplayName",
+          ]),
+          workflowName: readOptionalString(workflowRecord, [
+            "workflowName",
+            "WorkflowName",
+          ]),
+        }
+      : undefined,
+    binding,
+    acceptanceStage:
+      readOptionalString(record, ["acceptanceStage", "AcceptanceStage"]) ||
+      "accepted",
+    propagationStage:
+      readOptionalString(record, ["propagationStage", "PropagationStage"]) ||
+      "readmodel_propagating",
   };
 }
 
@@ -2218,6 +2308,16 @@ export const studioApi = {
     );
   },
 
+  async getPublishedWorkflow(
+    workflowId: string,
+    scopeId: string
+  ): Promise<StudioWorkflowFile> {
+    return toCommittedWorkflowFile(
+      scopeId.trim(),
+      await scopesApi.getWorkflowDetail(scopeId.trim(), workflowId)
+    );
+  },
+
   async saveWorkflow(input: StudioSaveWorkflowInput): Promise<StudioWorkflowSaveResult> {
     const normalizedWorkflowId = trimOptional(input.workflowId);
     const shouldUpdate =
@@ -2242,6 +2342,35 @@ export const studioApi = {
       yaml: input.yaml,
       layout: input.layout,
     });
+  },
+
+  saveAndBindWorkflow(
+    input: StudioSaveAndBindWorkflowInput
+  ): Promise<StudioSaveAndBindWorkflowAcceptedResult> {
+    return requestDecodedJson(
+      `/api/scopes/${encodeURIComponent(input.scopeId.trim())}/workflows:save-and-bind`,
+      decodeStudioSaveAndBindWorkflowResult,
+      {
+        method: "POST",
+        headers: JSON_HEADERS,
+        body: JSON.stringify(
+          compactObject({
+            workflowId: trimOptional(input.workflowId),
+            workflowYaml: input.workflowYaml,
+            workflowName: trimOptional(input.workflowName),
+            displayName: trimOptional(input.displayName),
+            inlineWorkflowYamls:
+              input.inlineWorkflowYamls &&
+              Object.keys(input.inlineWorkflowYamls).length > 0
+                ? input.inlineWorkflowYamls
+                : undefined,
+            appId: trimOptional(input.appId),
+            serviceId: trimOptional(input.serviceId),
+            exposureDesired: input.exposureDesired ?? undefined,
+          })
+        ),
+      }
+    );
   },
 
   deleteWorkflow(

--- a/apps/aevatar-console-web/src/shared/studio/models.ts
+++ b/apps/aevatar-console-web/src/shared/studio/models.ts
@@ -152,6 +152,18 @@ export interface StudioSaveWorkflowInput {
   readonly layout?: unknown;
 }
 
+export interface StudioSaveAndBindWorkflowInput {
+  readonly scopeId: string;
+  readonly workflowId?: string | null;
+  readonly workflowYaml: string;
+  readonly workflowName?: string | null;
+  readonly displayName?: string | null;
+  readonly inlineWorkflowYamls?: Record<string, string> | null;
+  readonly appId?: string | null;
+  readonly serviceId?: string | null;
+  readonly exposureDesired?: boolean | null;
+}
+
 export interface StudioWorkflowDraftCreateReadiness {
   readonly readable: boolean;
   readonly stage: string;
@@ -193,6 +205,26 @@ export type StudioWorkflowSaveResult =
       readonly kind: "accepted";
       readonly receipt: StudioWorkflowDraftCreateAcceptedReceipt;
     };
+
+export interface StudioSaveAndBindWorkflowAcceptedResult {
+  readonly scopeId: string;
+  readonly workflowId: string;
+  readonly revisionId: string;
+  readonly workflow?: {
+    readonly scopeId: string;
+    readonly workflowId: string;
+    readonly serviceKey?: string;
+    readonly revisionId: string;
+    readonly readModelUrl?: string;
+    readonly acceptanceStage?: string;
+    readonly propagationStage?: string;
+    readonly displayName?: string;
+    readonly workflowName?: string;
+  };
+  readonly binding?: StudioScopeBindingResult;
+  readonly acceptanceStage: string;
+  readonly propagationStage: string;
+}
 
 export interface StudioSerializeYamlResult {
   readonly yaml: string;


### PR DESCRIPTION
## Summary
- Add the Studio `save-and-bind` client contract for `/api/scopes/{scopeId}/workflows:save-and-bind` and route it through the Studio proxy target.
- Change published workflow member `Save` behavior to call `save-and-bind` instead of only saving a draft, so users do not need a separate publish/bind click after editing an already published workflow.
- Poll the published scope workflow read model after `save-and-bind` until the submitted YAML is visible, then keep the editor on the saved content instead of refetching stale workflow data.
- Keep non-published existing members on the old draft save path and keep new member creation behavior unchanged.

## Test Coverage
- Published workflow save path covers stale read model first, then materialized read model, and verifies the editor keeps `Workflow Alpha v2` instead of reverting.
- API tests cover `saveAndBindWorkflow` request shape and dedicated published workflow readmodel reads.
- Proxy tests cover routing `workflows:save-and-bind` to the Studio host.

## Pre-Landing Review
No blocking issues found in the scoped diff. The polling now targets the published scope workflow read model directly instead of the draft-first workflow helper, which matches the async backend materialization path.

## Design Review
No visual/layout changes. Existing button flow is preserved; only the published-member save action behavior changes.

## Eval Results
No prompt-related files changed.

## Scope Drift
Scope Check: CLEAN
Intent: save on an already published workflow should save and bind in one click, then avoid stale readmodel rollback.
Delivered: added save-and-bind client flow, readmodel polling, proxy routing, and regression coverage.

## Plan Completion
No plan file detected.

## Verification Results
- [x] `pnpm --dir apps/aevatar-console-web exec tsc --noEmit --pretty false`
- [x] `pnpm --dir apps/aevatar-console-web test src/shared/studio/api.test.ts --runInBand` (44 passed)
- [x] `pnpm --dir apps/aevatar-console-web test src/shared/config/proxyConfig.test.ts --runInBand` (7 passed)
- [x] `pnpm --dir apps/aevatar-console-web test src/pages/team-member-workflow-studio/index.test.tsx --runInBand` (69 passed)
- [x] `bash tools/ci/test_stability_guards.sh`

## Test plan
- [x] TypeScript check passes
- [x] Studio API tests pass
- [x] Proxy config tests pass
- [x] Team member workflow studio tests pass
- [x] Test stability guard passes
