### PR TITLE
Add workflow chat descriptor set

### DIFF
--- a/src/platform/Aevatar.GAgentService.Abstractions/Services/ServiceProtocolDescriptorSetBuilder.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Services/ServiceProtocolDescriptorSetBuilder.cs
@@ -1,0 +1,56 @@
+using Google.Protobuf;
+using Google.Protobuf.Reflection;
+
+namespace Aevatar.GAgentService.Abstractions.Services;
+
+public static class ServiceProtocolDescriptorSetBuilder
+{
+    public static ByteString Build(params MessageDescriptor[] descriptors)
+    {
+        var files = new Dictionary<string, FileDescriptorProto>(StringComparer.Ordinal);
+        foreach (var descriptor in descriptors)
+            AddFile(descriptor.File, files);
+
+        var descriptorSet = new FileDescriptorSet();
+        descriptorSet.File.Add(files.Values);
+        return descriptorSet.ToByteString();
+    }
+
+    private static void AddFile(
+        FileDescriptor file,
+        IDictionary<string, FileDescriptorProto> files)
+    {
+        if (files.ContainsKey(file.Name))
+            return;
+
+        var proto = file.ToProto();
+        foreach (var dependency in file.Dependencies)
+            AddFile(dependency, files);
+        foreach (var dependency in file.PublicDependencies)
+            AddFile(dependency, files);
+        foreach (var dependencyName in proto.Dependency)
+            AddKnownDependency(dependencyName, files);
+
+        files[file.Name] = proto;
+    }
+
+    private static void AddKnownDependency(
+        string dependencyName,
+        IDictionary<string, FileDescriptorProto> files)
+    {
+        var file = dependencyName switch
+        {
+            "google/protobuf/any.proto" => Google.Protobuf.WellKnownTypes.Any.Descriptor.File,
+            "google/protobuf/duration.proto" => Google.Protobuf.WellKnownTypes.Duration.Descriptor.File,
+            "google/protobuf/empty.proto" => Google.Protobuf.WellKnownTypes.Empty.Descriptor.File,
+            "google/protobuf/field_mask.proto" => Google.Protobuf.WellKnownTypes.FieldMask.Descriptor.File,
+            "google/protobuf/struct.proto" => Google.Protobuf.WellKnownTypes.Struct.Descriptor.File,
+            "google/protobuf/timestamp.proto" => Google.Protobuf.WellKnownTypes.Timestamp.Descriptor.File,
+            "google/protobuf/wrappers.proto" => Google.Protobuf.WellKnownTypes.StringValue.Descriptor.File,
+            _ => null,
+        };
+
+        if (file != null)
+            AddFile(file, files);
+    }
+}

--- a/src/platform/Aevatar.GAgentService.Abstractions/Services/ServiceProtocolDescriptorSetBuilder.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Services/ServiceProtocolDescriptorSetBuilder.cs
@@ -5,6 +5,17 @@ namespace Aevatar.GAgentService.Abstractions.Services;
 
 public static class ServiceProtocolDescriptorSetBuilder
 {
+    private static readonly IReadOnlyDictionary<string, FileDescriptor> KnownDependencies = new[]
+    {
+        Google.Protobuf.WellKnownTypes.Any.Descriptor.File,
+        Google.Protobuf.WellKnownTypes.Duration.Descriptor.File,
+        Google.Protobuf.WellKnownTypes.Empty.Descriptor.File,
+        Google.Protobuf.WellKnownTypes.FieldMask.Descriptor.File,
+        Google.Protobuf.WellKnownTypes.Struct.Descriptor.File,
+        Google.Protobuf.WellKnownTypes.Timestamp.Descriptor.File,
+        Google.Protobuf.WellKnownTypes.StringValue.Descriptor.File,
+    }.ToDictionary(file => file.Name, StringComparer.Ordinal);
+
     public static ByteString Build(params MessageDescriptor[] descriptors)
     {
         var files = new Dictionary<string, FileDescriptorProto>(StringComparer.Ordinal);
@@ -38,19 +49,7 @@ public static class ServiceProtocolDescriptorSetBuilder
         string dependencyName,
         IDictionary<string, FileDescriptorProto> files)
     {
-        var file = dependencyName switch
-        {
-            "google/protobuf/any.proto" => Google.Protobuf.WellKnownTypes.Any.Descriptor.File,
-            "google/protobuf/duration.proto" => Google.Protobuf.WellKnownTypes.Duration.Descriptor.File,
-            "google/protobuf/empty.proto" => Google.Protobuf.WellKnownTypes.Empty.Descriptor.File,
-            "google/protobuf/field_mask.proto" => Google.Protobuf.WellKnownTypes.FieldMask.Descriptor.File,
-            "google/protobuf/struct.proto" => Google.Protobuf.WellKnownTypes.Struct.Descriptor.File,
-            "google/protobuf/timestamp.proto" => Google.Protobuf.WellKnownTypes.Timestamp.Descriptor.File,
-            "google/protobuf/wrappers.proto" => Google.Protobuf.WellKnownTypes.StringValue.Descriptor.File,
-            _ => null,
-        };
-
-        if (file != null)
+        if (KnownDependencies.TryGetValue(dependencyName, out var file))
             AddFile(file, files);
     }
 }

--- a/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingCommandApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingCommandApplicationService.cs
@@ -288,6 +288,9 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
             Identity = revisionSpec.Identity.Clone(),
             RevisionId = revisionSpec.RevisionId,
             ImplementationKind = ServiceImplementationKind.Workflow,
+            ProtocolDescriptorSet = ServiceProtocolDescriptorSetBuilder.Build(
+                ChatRequestEvent.Descriptor,
+                ChatResponseEvent.Descriptor),
             Endpoints =
             {
                 new ServiceEndpointDescriptor

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/WorkflowServiceImplementationAdapter.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/WorkflowServiceImplementationAdapter.cs
@@ -1,8 +1,8 @@
 using Aevatar.AI.Abstractions;
 using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.GAgentService.Core.Ports;
 using Aevatar.Workflow.Application.Abstractions.Runs;
-using Google.Protobuf;
 using Google.Protobuf.Reflection;
 
 namespace Aevatar.GAgentService.Infrastructure.Adapters;
@@ -47,7 +47,7 @@ public sealed class WorkflowServiceImplementationAdapter : IServiceImplementatio
             Identity = request.Spec.Identity.Clone(),
             RevisionId = request.Spec.RevisionId,
             ImplementationKind = ServiceImplementationKind.Workflow,
-            ProtocolDescriptorSet = BuildProtocolDescriptorSet(
+            ProtocolDescriptorSet = ServiceProtocolDescriptorSetBuilder.Build(
                 ChatRequestEvent.Descriptor,
                 ChatResponseEvent.Descriptor),
             Endpoints =
@@ -77,53 +77,4 @@ public sealed class WorkflowServiceImplementationAdapter : IServiceImplementatio
 
     private static string GetTypeUrl(MessageDescriptor descriptor) =>
         $"type.googleapis.com/{descriptor.FullName}";
-
-    private static ByteString BuildProtocolDescriptorSet(params MessageDescriptor[] descriptors)
-    {
-        var files = new Dictionary<string, FileDescriptorProto>(StringComparer.Ordinal);
-        foreach (var descriptor in descriptors)
-            AddFile(descriptor.File, files);
-
-        var descriptorSet = new FileDescriptorSet();
-        descriptorSet.File.Add(files.Values);
-        return descriptorSet.ToByteString();
-    }
-
-    private static void AddFile(
-        FileDescriptor file,
-        IDictionary<string, FileDescriptorProto> files)
-    {
-        if (files.ContainsKey(file.Name))
-            return;
-
-        var proto = file.ToProto();
-        foreach (var dependency in file.Dependencies)
-            AddFile(dependency, files);
-        foreach (var dependency in file.PublicDependencies)
-            AddFile(dependency, files);
-        foreach (var dependencyName in proto.Dependency)
-            AddKnownDependency(dependencyName, files);
-
-        files[file.Name] = proto;
-    }
-
-    private static void AddKnownDependency(
-        string dependencyName,
-        IDictionary<string, FileDescriptorProto> files)
-    {
-        var file = dependencyName switch
-        {
-            "google/protobuf/any.proto" => Google.Protobuf.WellKnownTypes.Any.Descriptor.File,
-            "google/protobuf/duration.proto" => Google.Protobuf.WellKnownTypes.Duration.Descriptor.File,
-            "google/protobuf/empty.proto" => Google.Protobuf.WellKnownTypes.Empty.Descriptor.File,
-            "google/protobuf/field_mask.proto" => Google.Protobuf.WellKnownTypes.FieldMask.Descriptor.File,
-            "google/protobuf/struct.proto" => Google.Protobuf.WellKnownTypes.Struct.Descriptor.File,
-            "google/protobuf/timestamp.proto" => Google.Protobuf.WellKnownTypes.Timestamp.Descriptor.File,
-            "google/protobuf/wrappers.proto" => Google.Protobuf.WellKnownTypes.StringValue.Descriptor.File,
-            _ => null,
-        };
-
-        if (file != null)
-            AddFile(file, files);
-    }
 }

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/WorkflowServiceImplementationAdapter.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/WorkflowServiceImplementationAdapter.cs
@@ -2,6 +2,8 @@ using Aevatar.AI.Abstractions;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Core.Ports;
 using Aevatar.Workflow.Application.Abstractions.Runs;
+using Google.Protobuf;
+using Google.Protobuf.Reflection;
 
 namespace Aevatar.GAgentService.Infrastructure.Adapters;
 
@@ -45,6 +47,9 @@ public sealed class WorkflowServiceImplementationAdapter : IServiceImplementatio
             Identity = request.Spec.Identity.Clone(),
             RevisionId = request.Spec.RevisionId,
             ImplementationKind = ServiceImplementationKind.Workflow,
+            ProtocolDescriptorSet = BuildProtocolDescriptorSet(
+                ChatRequestEvent.Descriptor,
+                ChatResponseEvent.Descriptor),
             Endpoints =
             {
                 new ServiceEndpointDescriptor
@@ -70,6 +75,55 @@ public sealed class WorkflowServiceImplementationAdapter : IServiceImplementatio
         };
     }
 
-    private static string GetTypeUrl(Google.Protobuf.Reflection.MessageDescriptor descriptor) =>
+    private static string GetTypeUrl(MessageDescriptor descriptor) =>
         $"type.googleapis.com/{descriptor.FullName}";
+
+    private static ByteString BuildProtocolDescriptorSet(params MessageDescriptor[] descriptors)
+    {
+        var files = new Dictionary<string, FileDescriptorProto>(StringComparer.Ordinal);
+        foreach (var descriptor in descriptors)
+            AddFile(descriptor.File, files);
+
+        var descriptorSet = new FileDescriptorSet();
+        descriptorSet.File.Add(files.Values);
+        return descriptorSet.ToByteString();
+    }
+
+    private static void AddFile(
+        FileDescriptor file,
+        IDictionary<string, FileDescriptorProto> files)
+    {
+        if (files.ContainsKey(file.Name))
+            return;
+
+        var proto = file.ToProto();
+        foreach (var dependency in file.Dependencies)
+            AddFile(dependency, files);
+        foreach (var dependency in file.PublicDependencies)
+            AddFile(dependency, files);
+        foreach (var dependencyName in proto.Dependency)
+            AddKnownDependency(dependencyName, files);
+
+        files[file.Name] = proto;
+    }
+
+    private static void AddKnownDependency(
+        string dependencyName,
+        IDictionary<string, FileDescriptorProto> files)
+    {
+        var file = dependencyName switch
+        {
+            "google/protobuf/any.proto" => Google.Protobuf.WellKnownTypes.Any.Descriptor.File,
+            "google/protobuf/duration.proto" => Google.Protobuf.WellKnownTypes.Duration.Descriptor.File,
+            "google/protobuf/empty.proto" => Google.Protobuf.WellKnownTypes.Empty.Descriptor.File,
+            "google/protobuf/field_mask.proto" => Google.Protobuf.WellKnownTypes.FieldMask.Descriptor.File,
+            "google/protobuf/struct.proto" => Google.Protobuf.WellKnownTypes.Struct.Descriptor.File,
+            "google/protobuf/timestamp.proto" => Google.Protobuf.WellKnownTypes.Timestamp.Descriptor.File,
+            "google/protobuf/wrappers.proto" => Google.Protobuf.WellKnownTypes.StringValue.Descriptor.File,
+            _ => null,
+        };
+
+        if (file != null)
+            AddFile(file, files);
+    }
 }

--- a/test/Aevatar.GAgentService.Tests/Application/ScopeBindingCommandApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScopeBindingCommandApplicationServiceTests.cs
@@ -3,6 +3,7 @@ using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Commands;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.GAgentService.Application.Bindings;
 using Aevatar.GAgentService.Application.Workflows;
 using Aevatar.GAgentService.Core.Assemblers;
@@ -165,7 +166,7 @@ public sealed class ScopeBindingCommandApplicationServiceTests
         const string revisionId = "rev-platform-bind-1";
         var commandPort = new RecordingServiceCommandPort();
         var externalExposureIntentPort = new RecordingExternalExposureIntentPort(commandPort);
-        var existingHash = "9FAFFAFE586BDBA6791AF7488B3D09AA3E9AA19B587D21AC772432E52DE86709";
+        var existingHash = CreateWorkflowArtifactHash(revisionId, "main", "name: main\nsteps:\n  - run: echo hello");
         var existingService = new ServiceCatalogSnapshot(
             "scope-a:default:default:default",
             ScopeId,
@@ -1080,7 +1081,7 @@ public sealed class ScopeBindingCommandApplicationServiceTests
     {
         const string revisionId = "rev-platform-bind-1";
         var commandPort = new RecordingServiceCommandPort();
-        var existingHash = "9FAFFAFE586BDBA6791AF7488B3D09AA3E9AA19B587D21AC772432E52DE86709";
+        var existingHash = CreateWorkflowArtifactHash(revisionId, "main", "name: main\nsteps:\n  - run: echo hello");
         var lifecyclePort = new FakeServiceLifecycleQueryPort(
             new ServiceCatalogSnapshot(
                 "scope-a:default:default:default",
@@ -1883,6 +1884,9 @@ public sealed class ScopeBindingCommandApplicationServiceTests
             Identity = DefaultServiceIdentity(serviceId),
             RevisionId = revisionId,
             ImplementationKind = ServiceImplementationKind.Workflow,
+            ProtocolDescriptorSet = ServiceProtocolDescriptorSetBuilder.Build(
+                ChatRequestEvent.Descriptor,
+                ChatResponseEvent.Descriptor),
             Endpoints =
             {
                 new ServiceEndpointDescriptor
@@ -1901,7 +1905,9 @@ public sealed class ScopeBindingCommandApplicationServiceTests
                 {
                     WorkflowName = workflowName,
                     WorkflowYaml = workflowYaml,
-                    DefinitionActorId = $"scope-workflow:{ScopeId}:default",
+                    DefinitionActorId = ScopeWorkflowCapabilityConventions.BuildDefaultDefinitionActorIdPrefix(
+                        DefaultOptions,
+                        ScopeId),
                 },
             },
         };

--- a/test/Aevatar.GAgentService.Tests/Infrastructure/ServiceImplementationAdaptersTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Infrastructure/ServiceImplementationAdaptersTests.cs
@@ -1,3 +1,4 @@
+using Aevatar.AI.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.Foundation.Core.TypeSystem;
@@ -9,6 +10,7 @@ using Aevatar.Scripting.Core.Ports;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using FluentAssertions;
 using Google.Protobuf;
+using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.GAgentService.Tests.Infrastructure;
@@ -522,6 +524,36 @@ public sealed class ServiceImplementationAdaptersTests
     }
 
     [Fact]
+    public async Task WorkflowAdapter_ShouldPrepareChatProtocolDescriptorSet()
+    {
+        var workflowPort = new RecordingWorkflowRunActorPort
+        {
+            ParseResult = WorkflowYamlParseResult.Success("workflow"),
+        };
+        var adapter = new WorkflowServiceImplementationAdapter(workflowPort);
+
+        var artifact = await adapter.PrepareRevisionAsync(new PrepareServiceRevisionRequest
+        {
+            Spec = new ServiceRevisionSpec
+            {
+                Identity = GAgentServiceTestKit.CreateIdentity(),
+                RevisionId = "r1",
+                ImplementationKind = ServiceImplementationKind.Workflow,
+                WorkflowSpec = new WorkflowServiceRevisionSpec
+                {
+                    WorkflowYaml = "name: workflow",
+                },
+            },
+        });
+
+        artifact.ProtocolDescriptorSet.IsEmpty.Should().BeFalse();
+        ResolveDescriptor(artifact.ProtocolDescriptorSet, ChatRequestEvent.Descriptor.FullName)
+            .Should().NotBeNull();
+        ResolveDescriptor(artifact.ProtocolDescriptorSet, ChatResponseEvent.Descriptor.FullName)
+            .Should().NotBeNull();
+    }
+
+    [Fact]
     public async Task WorkflowAdapter_ShouldRejectInvalidWorkflowYaml()
     {
         var adapter = new WorkflowServiceImplementationAdapter(new RecordingWorkflowRunActorPort
@@ -674,6 +706,37 @@ public sealed class ServiceImplementationAdaptersTests
         nullPort.Should().Throw<ArgumentNullException>();
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("workflow implementation_spec is required.");
+    }
+
+    private static MessageDescriptor? ResolveDescriptor(ByteString descriptorSet, string fullName)
+    {
+        var fds = FileDescriptorSet.Parser.ParseFrom(descriptorSet);
+        var byteStrings = fds.File.Select(file => file.ToByteString()).ToList();
+        var fileDescriptors = FileDescriptor.BuildFromByteStrings(byteStrings);
+
+        foreach (var fileDescriptor in fileDescriptors)
+        {
+            var descriptor = FindDescriptor(fileDescriptor.MessageTypes, fullName);
+            if (descriptor != null)
+                return descriptor;
+        }
+
+        return null;
+    }
+
+    private static MessageDescriptor? FindDescriptor(IList<MessageDescriptor> messageTypes, string fullName)
+    {
+        foreach (var messageType in messageTypes)
+        {
+            if (string.Equals(messageType.FullName, fullName, StringComparison.Ordinal))
+                return messageType;
+
+            var nested = FindDescriptor(messageType.NestedTypes, fullName);
+            if (nested != null)
+                return nested;
+        }
+
+        return null;
     }
 
     private sealed class RecordingScriptDefinitionSnapshotPort : IScriptDefinitionSnapshotPort

--- a/test/Aevatar.Studio.Tests/ProjectionWorkflowBoardExecutionQueryPortTests.cs
+++ b/test/Aevatar.Studio.Tests/ProjectionWorkflowBoardExecutionQueryPortTests.cs
@@ -246,6 +246,7 @@ public sealed class ProjectionWorkflowBoardExecutionQueryPortTests
             "cmd-alpha",
             "corr-alpha",
             "chat",
+            string.Empty,
             ServiceImplementationKind.Workflow,
             targetActorId,
             "rev-alpha",


### PR DESCRIPTION
## Summary
- Populate workflow service revision artifacts with chat request/response protobuf descriptors.
- Include dependency descriptors in build order so payloadJson packing can resolve workflow chat payload types.
- Add regression coverage for workflow adapter descriptor generation.

## Test plan
- [x] `dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo --no-restore --filter ServiceImplementationAdaptersTests -v quiet`
- [x] `bash tools/ci/test_stability_guards.sh`
- [x] Local Mainnet API smoke: created workflow service revision and schedule with `payloadJson` for `type.googleapis.com/aevatar.ai.ChatRequestEvent`; schedule creation returned 202 and readback showed `scheduleKind: 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)