### PR TITLE
fix(channels): persist NyxID-assigned per-bot proxy slug for Lark replies

### DIFF
--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxApiResponseHelper.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxApiResponseHelper.cs
@@ -73,8 +73,9 @@ internal static class NyxApiResponseHelper
 
     /// <summary>
     /// Returns the trimmed per-connection proxy slug from a Nyx <c>POST /api/v1/keys</c>
-    /// (connect-service) response — <c>proxy_url_slug</c> preferred, <c>slug</c> as fallback — or
-    /// <c>null</c> when the response is an error envelope, unparseable, or carries neither field.
+    /// (connect-service) response — <c>slug</c> preferred, <c>proxy_url_slug</c> normalized as
+    /// fallback — or <c>null</c> when the response is an error envelope, unparseable, or carries
+    /// neither field.
     /// NyxID auto-numbers a base slug that is already taken (<c>api-lark-bot</c> →
     /// <c>api-lark-bot-2</c>/<c>-3</c>), so a user with several Lark bots gets a distinct proxy
     /// service per app. Capturing the slug NyxID actually assigned is what lets a later reply proxy
@@ -89,13 +90,57 @@ internal static class NyxApiResponseHelper
         {
             using var document = JsonDocument.Parse(response);
             var root = document.RootElement;
-            return ReadNonEmptyString(root, "proxy_url_slug") ?? ReadNonEmptyString(root, "slug");
+            return NormalizeProxyUrlSlug(ReadNonEmptyString(root, "slug")) ??
+                   NormalizeProxyUrlSlug(ReadNonEmptyString(root, "proxy_url_slug"));
         }
         catch (JsonException)
         {
             return null;
         }
     }
+
+    private static string? NormalizeProxyUrlSlug(string? value)
+    {
+        var trimmed = value?.Trim();
+        if (string.IsNullOrWhiteSpace(trimmed))
+            return null;
+
+        var extracted = ExtractProxySlugFromRouteTemplate(trimmed);
+        if (!string.IsNullOrWhiteSpace(extracted))
+            return extracted;
+
+        return LooksLikeProxyUrlTemplate(trimmed) ? null : trimmed;
+    }
+
+    private static string? ExtractProxySlugFromRouteTemplate(string value)
+    {
+        var path = Uri.TryCreate(value, UriKind.Absolute, out var uri) ? uri.AbsolutePath : value;
+        const string marker = "/proxy/s/";
+        var index = path.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (index < 0)
+            return null;
+
+        var start = index + marker.Length;
+        var end = path.IndexOfAny(new[] { '/', '?', '#' }, start);
+        var segment = end < 0 ? path[start..] : path[start..end];
+        string slug;
+        try
+        {
+            slug = Uri.UnescapeDataString(segment).Trim();
+        }
+        catch (UriFormatException)
+        {
+            return null;
+        }
+        return string.IsNullOrWhiteSpace(slug) || LooksLikeProxyUrlTemplate(slug) ? null : slug;
+    }
+
+    private static bool LooksLikeProxyUrlTemplate(string value) =>
+        value.Contains("://", StringComparison.Ordinal) ||
+        value.Contains('/', StringComparison.Ordinal) ||
+        value.Contains('\\', StringComparison.Ordinal) ||
+        value.Contains('?', StringComparison.Ordinal) ||
+        value.Contains('#', StringComparison.Ordinal);
 
     private static string? ReadNonEmptyString(JsonElement root, string propertyName)
     {

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxApiResponseHelper.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxApiResponseHelper.cs
@@ -72,6 +72,41 @@ internal static class NyxApiResponseHelper
 
 
     /// <summary>
+    /// Returns the trimmed per-connection proxy slug from a Nyx <c>POST /api/v1/keys</c>
+    /// (connect-service) response — <c>proxy_url_slug</c> preferred, <c>slug</c> as fallback — or
+    /// <c>null</c> when the response is an error envelope, unparseable, or carries neither field.
+    /// NyxID auto-numbers a base slug that is already taken (<c>api-lark-bot</c> →
+    /// <c>api-lark-bot-2</c>/<c>-3</c>), so a user with several Lark bots gets a distinct proxy
+    /// service per app. Capturing the slug NyxID actually assigned is what lets a later reply proxy
+    /// through the SAME Lark app this connection was created for, instead of always the first one.
+    /// </summary>
+    public static string? ExtractOptionalProxyUrlSlug(string response)
+    {
+        if (LooksLikeErrorEnvelope(response))
+            return null;
+
+        try
+        {
+            using var document = JsonDocument.Parse(response);
+            var root = document.RootElement;
+            return ReadNonEmptyString(root, "proxy_url_slug") ?? ReadNonEmptyString(root, "slug");
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? ReadNonEmptyString(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out var element) || element.ValueKind != JsonValueKind.String)
+            return null;
+
+        var value = element.GetString()?.Trim();
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    /// <summary>
     /// Returns true when the response either is unparseable or carries a top-level <c>"error":true</c>
     /// envelope (the wrapping shape Nyx applies to non-2xx HTTP responses from the upstream platform).
     /// </summary>

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxLarkProvisioningService.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxLarkProvisioningService.cs
@@ -164,9 +164,10 @@ public sealed class NyxLarkProvisioningService : INyxLarkProvisioningService, IN
             // through THIS bot's own Lark app instead of always the first one (multi-bot cross-talk).
             // Intentionally NOT in the rollback chain: the connection is reusable across
             // registrations and a failure (incl. 409) is non-fatal — it just falls back to the
-            // default slug, degrading only this bot's outbound app binding, not the relay path.
+            // requested slug, degrading only this bot's outbound app binding, not the relay path.
             var connectedProviderSlug = await ConnectLarkBotProxyServiceAsync(
                 request.AccessToken,
+                requestedProviderSlug,
                 request.AppId.Trim(),
                 request.AppSecret.Trim(),
                 ct);
@@ -310,15 +311,16 @@ public sealed class NyxLarkProvisioningService : INyxLarkProvisioningService, IN
     }
 
     /// <summary>
-    /// Connects the per-app <c>api-lark-bot</c> NyxID proxy service and returns the slug NyxID
-    /// assigned to THIS connection (e.g. <c>api-lark-bot-3</c> when the base slug is already taken).
+    /// Connects the requested per-app NyxID proxy service and returns the slug NyxID assigned to
+    /// THIS connection (e.g. <c>api-lark-bot-3</c> when the base slug is already taken).
     /// That slug is stored as the registration's provider slug so every reply for this bot proxies
     /// through its own Lark app. Best-effort: any failure (incl. a 409 already-exists) returns
-    /// <c>null</c> so the caller falls back to the default slug — the relay path still works, only
-    /// this bot's outbound app binding degrades.
+    /// <c>null</c> so the caller falls back to the requested slug - the relay path still works,
+    /// only this bot's outbound app binding degrades.
     /// </summary>
     private async Task<string?> ConnectLarkBotProxyServiceAsync(
         string accessToken,
+        string providerSlug,
         string appId,
         string appSecret,
         CancellationToken ct)
@@ -326,7 +328,7 @@ public sealed class NyxLarkProvisioningService : INyxLarkProvisioningService, IN
         try
         {
             var credential = JsonSerializer.Serialize(new { app_id = appId, app_secret = appSecret });
-            var body = JsonSerializer.Serialize(new { service_slug = DefaultNyxProviderSlug, credential, label = $"Lark App {appId}" });
+            var body = JsonSerializer.Serialize(new { service_slug = providerSlug, credential, label = $"Lark App {appId}" });
             var response = await _nyxClient.CreateServiceAsync(accessToken, body, ct);
             return NyxApiResponseHelper.ExtractOptionalProxyUrlSlug(response);
         }
@@ -334,8 +336,9 @@ public sealed class NyxLarkProvisioningService : INyxLarkProvisioningService, IN
         {
             _logger.LogWarning(
                 ex,
-                "Best-effort api-lark-bot proxy service connection failed (non-fatal). appId={AppId}",
-                appId);
+                "Best-effort Lark bot proxy service connection failed (non-fatal). appId={AppId}, providerSlug={ProviderSlug}",
+                appId,
+                providerSlug);
             return null;
         }
     }

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxLarkProvisioningService.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxLarkProvisioningService.cs
@@ -126,7 +126,7 @@ public sealed class NyxLarkProvisioningService : INyxLarkProvisioningService, IN
         var label = string.IsNullOrWhiteSpace(request.Label)
             ? $"Aevatar Lark Bot {registrationId[..8]}"
             : request.Label.Trim();
-        var nyxProviderSlug = string.IsNullOrWhiteSpace(request.NyxProviderSlug)
+        var requestedProviderSlug = string.IsNullOrWhiteSpace(request.NyxProviderSlug)
             ? DefaultNyxProviderSlug
             : request.NyxProviderSlug.Trim();
 
@@ -157,15 +157,20 @@ public sealed class NyxLarkProvisioningService : INyxLarkProvisioningService, IN
                 ct);
             routeId = await CreateDefaultRouteAsync(request.AccessToken, channelBotId, apiKeyId, ct);
 
-            // Best-effort: connect the api-lark-bot NyxID proxy service so typing
-            // reactions can call the Lark API. Intentionally NOT in the rollback chain
-            // because the service is reusable across registrations; a 409 on re-provision
-            // is the expected idempotent case, not an orphan to clean up.
-            await TryConnectLarkBotProxyServiceAsync(
+            // Connect the api-lark-bot NyxID proxy service (so card/typing calls can reach the Lark
+            // API) and capture the per-connection slug NyxID assigned. When the user already has an
+            // `api-lark-bot` connection, NyxID auto-numbers this one (api-lark-bot-2/-3...); storing
+            // that returned slug — not the generic default — is what makes a later reply proxy
+            // through THIS bot's own Lark app instead of always the first one (multi-bot cross-talk).
+            // Intentionally NOT in the rollback chain: the connection is reusable across
+            // registrations and a failure (incl. 409) is non-fatal — it just falls back to the
+            // default slug, degrading only this bot's outbound app binding, not the relay path.
+            var connectedProviderSlug = await ConnectLarkBotProxyServiceAsync(
                 request.AccessToken,
                 request.AppId.Trim(),
                 request.AppSecret.Trim(),
                 ct);
+            var nyxProviderSlug = connectedProviderSlug ?? requestedProviderSlug;
 
             var webhookUrl = $"{nyxBaseUrl}/api/v1/webhooks/channel/lark/{Uri.EscapeDataString(channelBotId)}";
             await RegisterLocalMirrorAsync(
@@ -304,7 +309,15 @@ public sealed class NyxLarkProvisioningService : INyxLarkProvisioningService, IN
         return NyxApiResponseHelper.ExtractRequiredId(response, "channel_route_id");
     }
 
-    private async Task TryConnectLarkBotProxyServiceAsync(
+    /// <summary>
+    /// Connects the per-app <c>api-lark-bot</c> NyxID proxy service and returns the slug NyxID
+    /// assigned to THIS connection (e.g. <c>api-lark-bot-3</c> when the base slug is already taken).
+    /// That slug is stored as the registration's provider slug so every reply for this bot proxies
+    /// through its own Lark app. Best-effort: any failure (incl. a 409 already-exists) returns
+    /// <c>null</c> so the caller falls back to the default slug — the relay path still works, only
+    /// this bot's outbound app binding degrades.
+    /// </summary>
+    private async Task<string?> ConnectLarkBotProxyServiceAsync(
         string accessToken,
         string appId,
         string appSecret,
@@ -314,17 +327,16 @@ public sealed class NyxLarkProvisioningService : INyxLarkProvisioningService, IN
         {
             var credential = JsonSerializer.Serialize(new { app_id = appId, app_secret = appSecret });
             var body = JsonSerializer.Serialize(new { service_slug = DefaultNyxProviderSlug, credential, label = $"Lark App {appId}" });
-            await _nyxClient.CreateServiceAsync(accessToken, body, ct);
+            var response = await _nyxClient.CreateServiceAsync(accessToken, body, ct);
+            return NyxApiResponseHelper.ExtractOptionalProxyUrlSlug(response);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            // Best-effort: 409 conflict (service already exists) or any other error is
-            // non-fatal. The core relay path works without this; only typing reactions
-            // are degraded when the proxy service is not connected.
             _logger.LogWarning(
                 ex,
                 "Best-effort api-lark-bot proxy service connection failed (non-fatal). appId={AppId}",
                 appId);
+            return null;
         }
     }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxApiResponseHelperTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxApiResponseHelperTests.cs
@@ -1,0 +1,35 @@
+using Aevatar.GAgents.Channel.NyxIdRelay;
+using FluentAssertions;
+using Xunit;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+public class NyxApiResponseHelperTests
+{
+    [Fact]
+    public void ExtractOptionalProxyUrlSlug_Prefers_ProxyUrlSlug_Over_Slug()
+    {
+        // NyxID auto-numbers a taken base slug; the connect response carries the per-connection slug.
+        NyxApiResponseHelper.ExtractOptionalProxyUrlSlug(
+                """{"id":"svc-3","slug":"api-lark-bot-3","proxy_url_slug":"api-lark-bot-3"}""")
+            .Should().Be("api-lark-bot-3");
+    }
+
+    [Fact]
+    public void ExtractOptionalProxyUrlSlug_Falls_Back_To_Slug_When_ProxyUrlSlug_Absent()
+    {
+        NyxApiResponseHelper.ExtractOptionalProxyUrlSlug("""{"id":"svc-2","slug":"api-lark-bot-2"}""")
+            .Should().Be("api-lark-bot-2");
+    }
+
+    [Theory]
+    [InlineData("""{"id":"svc-1"}""")]                                  // neither field present
+    [InlineData("""{"proxy_url_slug":"   "}""")]                        // whitespace-only
+    [InlineData("""{"error":true,"status":409,"message":"taken"}""")]   // Nyx error envelope
+    [InlineData("not-json")]                                            // unparseable
+    [InlineData("")]                                                    // empty
+    public void ExtractOptionalProxyUrlSlug_Returns_Null_When_No_Usable_Slug(string response)
+    {
+        NyxApiResponseHelper.ExtractOptionalProxyUrlSlug(response).Should().BeNull();
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxApiResponseHelperTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxApiResponseHelperTests.cs
@@ -7,11 +7,21 @@ namespace Aevatar.GAgents.ChannelRuntime.Tests;
 public class NyxApiResponseHelperTests
 {
     [Fact]
-    public void ExtractOptionalProxyUrlSlug_Prefers_ProxyUrlSlug_Over_Slug()
+    public void ExtractOptionalProxyUrlSlug_Prefers_Slug_Over_ProxyUrlSlug_Template()
     {
         // NyxID auto-numbers a taken base slug; the connect response carries the per-connection slug.
         NyxApiResponseHelper.ExtractOptionalProxyUrlSlug(
-                """{"id":"svc-3","slug":"api-lark-bot-3","proxy_url_slug":"api-lark-bot-3"}""")
+                """{"id":"svc-3","slug":"api-lark-bot-3","proxy_url_slug":"https://nyx.example.com/api/v1/proxy/s/wrong/{path}"}""")
+            .Should().Be("api-lark-bot-3");
+    }
+
+    [Theory]
+    [InlineData("""{"proxy_url_slug":"https://nyx.example.com/api/v1/proxy/s/api-lark-bot-3/{path}"}""")]
+    [InlineData("""{"proxy_url_slug":"/api/v1/proxy/s/api-lark-bot-3/{path}"}""")]
+    [InlineData("""{"proxy_url_slug":"api-lark-bot-3"}""")]
+    public void ExtractOptionalProxyUrlSlug_Normalizes_ProxyUrlSlug_To_Bare_Slug(string response)
+    {
+        NyxApiResponseHelper.ExtractOptionalProxyUrlSlug(response)
             .Should().Be("api-lark-bot-3");
     }
 
@@ -25,6 +35,7 @@ public class NyxApiResponseHelperTests
     [Theory]
     [InlineData("""{"id":"svc-1"}""")]                                  // neither field present
     [InlineData("""{"proxy_url_slug":"   "}""")]                        // whitespace-only
+    [InlineData("""{"proxy_url_slug":"https://nyx.example.com/proxy/by-id/svc-1/{path}"}""")]
     [InlineData("""{"error":true,"status":409,"message":"taken"}""")]   // Nyx error envelope
     [InlineData("not-json")]                                            // unparseable
     [InlineData("")]                                                    // empty

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxLarkProvisioningServiceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxLarkProvisioningServiceTests.cs
@@ -85,6 +85,47 @@ public class NyxLarkProvisioningServiceTests
         handler.Requests[3].Body.Should().Contain("\"service_slug\":\"api-lark-bot\"");
     }
 
+    [Fact]
+    public async Task ProvisionAsync_Stores_NyxAssigned_PerConnection_Slug_When_Connect_Returns_Suffixed_Slug()
+    {
+        // Regression: a user's 2nd+ Lark bot. NyxID auto-numbers the proxy slug when `api-lark-bot`
+        // is already taken (here api-lark-bot-3) and returns it on `POST /api/v1/keys`. The mirror
+        // must store that per-connection slug so this bot replies through ITS OWN Lark app instead
+        // of the first one (the multi-bot cross-talk bug).
+        var handler = new RecordingHandler();
+        handler.Enqueue("/api/v1/api-keys", """{"id":"key-123","full_key":"full-key"}""");
+        handler.Enqueue("/api/v1/channel-bots", """{"id":"bot-456","status":"pending_webhook"}""");
+        handler.Enqueue("/api/v1/channel-conversations", """{"id":"route-789","default_agent":true}""");
+        handler.Enqueue("/api/v1/keys", """{"id":"svc-3","slug":"api-lark-bot-3","proxy_url_slug":"api-lark-bot-3"}""");
+
+        EventEnvelope? capturedEnvelope = null;
+        var actor = Substitute.For<IActor>();
+        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
+        actorRuntime.GetAsync(ChannelBotRegistrationGAgent.WellKnownId)
+            .Returns(Task.FromResult<IActor?>(actor));
+        ((IActorDispatchPort)actorRuntime).DispatchAsync(
+                ChannelBotRegistrationGAgent.WellKnownId,
+                Arg.Do<EventEnvelope>(envelope => capturedEnvelope = envelope),
+                Arg.Any<CancellationToken>())
+            .Returns(ActorDispatchPortTestSupport.AcceptAsync);
+        var commandFacade = ChannelRegistrationCommandFacadeTestSupport.CreateFacade(actorRuntime, (IActorDispatchPort)actorRuntime);
+
+        var service = new NyxLarkProvisioningService(
+            new NyxIdApiClient(
+                new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+                new HttpClient(handler)),
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            commandFacade,
+            Substitute.For<Microsoft.Extensions.Logging.ILogger<NyxLarkProvisioningService>>());
+
+        var result = await service.ProvisionAsync(BuildRequest(), CancellationToken.None);
+
+        result.Succeeded.Should().BeTrue();
+        capturedEnvelope.Should().NotBeNull();
+        capturedEnvelope!.Payload.Unpack<ChannelBotRegisterCommand>().NyxProviderSlug
+            .Should().Be("api-lark-bot-3");
+    }
+
     [Theory]
     [InlineData("", "cli_a1b2c3", "secret-xyz", "https://aevatar.example.com", "scope-1", "missing_access_token")]
     [InlineData("user-token", "", "secret-xyz", "https://aevatar.example.com", "scope-1", "missing_app_id")]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxLarkProvisioningServiceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxLarkProvisioningServiceTests.cs
@@ -96,7 +96,7 @@ public class NyxLarkProvisioningServiceTests
         handler.Enqueue("/api/v1/api-keys", """{"id":"key-123","full_key":"full-key"}""");
         handler.Enqueue("/api/v1/channel-bots", """{"id":"bot-456","status":"pending_webhook"}""");
         handler.Enqueue("/api/v1/channel-conversations", """{"id":"route-789","default_agent":true}""");
-        handler.Enqueue("/api/v1/keys", """{"id":"svc-3","slug":"api-lark-bot-3","proxy_url_slug":"api-lark-bot-3"}""");
+        handler.Enqueue("/api/v1/keys", """{"id":"svc-3","proxy_url_slug":"https://nyx.example.com/api/v1/proxy/s/api-lark-bot-3/{path}"}""");
 
         EventEnvelope? capturedEnvelope = null;
         var actor = Substitute.For<IActor>();
@@ -124,6 +124,47 @@ public class NyxLarkProvisioningServiceTests
         capturedEnvelope.Should().NotBeNull();
         capturedEnvelope!.Payload.Unpack<ChannelBotRegisterCommand>().NyxProviderSlug
             .Should().Be("api-lark-bot-3");
+    }
+
+    [Fact]
+    public async Task ProvisionAsync_Uses_Explicit_ProviderSlug_For_Proxy_Service_Connection()
+    {
+        var handler = new RecordingHandler();
+        handler.Enqueue("/api/v1/api-keys", """{"id":"key-123","full_key":"full-key"}""");
+        handler.Enqueue("/api/v1/channel-bots", """{"id":"bot-456","status":"pending_webhook"}""");
+        handler.Enqueue("/api/v1/channel-conversations", """{"id":"route-789","default_agent":true}""");
+        handler.Enqueue("/api/v1/keys", """{"id":"svc-explicit","slug":"api-lark-bot-custom"}""");
+
+        EventEnvelope? capturedEnvelope = null;
+        var actor = Substitute.For<IActor>();
+        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
+        actorRuntime.GetAsync(ChannelBotRegistrationGAgent.WellKnownId)
+            .Returns(Task.FromResult<IActor?>(actor));
+        ((IActorDispatchPort)actorRuntime).DispatchAsync(
+                ChannelBotRegistrationGAgent.WellKnownId,
+                Arg.Do<EventEnvelope>(envelope => capturedEnvelope = envelope),
+                Arg.Any<CancellationToken>())
+            .Returns(ActorDispatchPortTestSupport.AcceptAsync);
+        var commandFacade = ChannelRegistrationCommandFacadeTestSupport.CreateFacade(actorRuntime, (IActorDispatchPort)actorRuntime);
+
+        var service = new NyxLarkProvisioningService(
+            new NyxIdApiClient(
+                new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+                new HttpClient(handler)),
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            commandFacade,
+            Substitute.For<Microsoft.Extensions.Logging.ILogger<NyxLarkProvisioningService>>());
+
+        var result = await service.ProvisionAsync(
+            BuildRequest() with { NyxProviderSlug = " api-lark-bot-custom " },
+            CancellationToken.None);
+
+        result.Succeeded.Should().BeTrue();
+        handler.Requests[3].Path.Should().Be("/api/v1/keys");
+        handler.Requests[3].Body.Should().Contain("\"service_slug\":\"api-lark-bot-custom\"");
+        capturedEnvelope.Should().NotBeNull();
+        capturedEnvelope!.Payload.Unpack<ChannelBotRegisterCommand>().NyxProviderSlug
+            .Should().Be("api-lark-bot-custom");
     }
 
     [Theory]


### PR DESCRIPTION
## Problem
With two Lark bots under one NyxID account, a DM sent to **bot B (Aevatar3)** is answered by **bot A (Aevatar2)** in bot A's window (cross-talk). Reproduced live on prod.

## Root cause (traced via prod logs + NyxID API)
- Inbound is correctly attributed to bot B (relay `agent.api_key_id=193cc1fe` = Aevatar3). aevatar handles it as bot B.
- The card-streamed reply is delivered through the **generic NyxID proxy** `POST /api/v1/proxy/s/api-lark-bot/open-apis/cardkit|im/...`, using `registration.NyxProviderSlug`.
- NyxID auto-numbers the proxy slug when the base is taken: bot A = `api-lark-bot`, bot B = `api-lark-bot-3` (confirmed in the user's `/api/v1/user-services`).
- But registration recorded the **default** `api-lark-bot` for every bot (the facade echoes `ResolveDefaultProviderSlug`), so `resolve_service_by_slug` (exact match) always resolves to the first app → reply leaves through bot A.
- (NyxID's #1026/#1027 guard sits on `/channel-relay/reply`, which the card path never calls — that is why it never fired.)

## Fix
Capture the `proxy_url_slug`/`slug` NyxID returns on `POST /api/v1/keys` during provisioning and persist it in the registration mirror; fall back to the requested slug when absent (unchanged for the first/only bot). Outbound already reads `registration.NyxProviderSlug`, so each bot now replies through its own app. No NyxID change.

## Affected paths
- `agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxApiResponseHelper.cs` (+`ExtractOptionalProxyUrlSlug`)
- `agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxLarkProvisioningService.cs` (capture + store slug)
- tests: `NyxLarkProvisioningServiceTests` (+suffixed-slug flow), `NyxApiResponseHelperTests` (new)

## Validation
- `dotnet build agents/channels/Aevatar.GAgents.Channel.NyxIdRelay` — 0 errors
- `dotnet test …ChannelRuntime.Tests --filter "NyxLarkProvisioningServiceTests|NyxApiResponseHelperTests"` — **16 passed, 0 failed**
- `bash tools/ci/test_stability_guards.sh` — passed
- `bash tools/ci/architecture_guards.sh` — passed (exit 0)

## Scope / follow-ups
- **New registrations** are fixed by this PR.
- **Existing registrations** still carry `api-lark-bot`. Immediate remediation: delete + re-register the affected bot (uses the fixed provisioning). An automated backfill (re-resolve slug per registration, update the mirror) needs a new "correct provider slug" command/event/reducer and a per-owner repair trigger — tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
