### PR TITLE
为 Firecrawl 长时作业落地 split-run self_reschedule 模板

### DIFF
--- a/docs/canon/workflow-primitives.md
+++ b/docs/canon/workflow-primitives.md
@@ -331,6 +331,7 @@ steps:
 - 运行时事件：`WaitingForSignalEvent` 会显式携带 `run_id + step_id + signal_name`，用于无状态 UI 回传。
 - 回传约束：`SignalReceivedEvent` 必须携带 `run_id`；若同一 run 下同名 signal 有多个 waiter，还必须携带 `step_id` 以消歧。
 - 长等待口径：对长时间外部执行（例如 Codex worker、人工审批前置检查、离线作业）不要把一个普通执行步骤硬拉到超过 executor 的 `600s` 单步 timeout；改成“先发起外部工作，再 `wait_signal` 等回调”的 continuation 语义。当前 `wait_signal.timeout_ms` 官方支持到 `5400000`（90 分钟）。
+- 超过 90 分钟的 submit/poll 外部作业不属于 `wait_signal` 扩容场景，也不新增 `await_job` / `async_job` 原语。必须使用拆分 run 模板：submit run 只提交一次外部 job 并把 `job_id`、`idempotency_key`、确定性 `schedule_id`、deadline 与 attempt 预算写入 poll handoff；`ScheduledDispatchGAgent` 持有 poll schedule fact；每个 poll run 只查询一次状态，终态分支用同一个 `schedule_id` 禁用 schedule。
 
 ```yaml
 steps:
@@ -680,6 +681,28 @@ steps:
     parameters:
       event_type: "workflow.completed"
       payload: "$input"
+```
+
+### `self_reschedule` submit/poll 模板
+
+- 作用：为长时外部 submit/poll job 创建或更新一个 workflow schedule。schedule fact 由 `ScheduledDispatchGAgent` 拥有，workflow run 只收到 accepted receipt。
+- 常用参数：`schedule_id`、`cron_expression`、`timezone`、`workflow_name` 或 `service_id`、`scope_id`、`prompt`、`enabled`。
+- submit/poll 合同：submit 模板把 `job_id`、`idempotency_key`、确定性 `schedule_id`、poll cadence、deadline 与 attempt 预算放进 poll workflow 的 `prompt`；poll 模板每次只 poll 一次，非终态结束本 run，终态用同一 `schedule_id` 且 `enabled: "false"` 停止 schedule。
+- `header.*` 只用于 dispatch header 扩展；不得承载 `job_id`、`idempotency_key`、`schedule_id`、deadline、attempt 或 terminal status 等业务事实。内部 workflow YAML 不使用泛化 `metadata` 承载这些事实。
+
+参考模板：`workflows/firecrawl_agent_async_submit.yaml` 与 `workflows/firecrawl_agent_async_poll.yaml`。
+
+```yaml
+steps:
+  - id: ensure_poll_schedule
+    type: self_reschedule
+    parameters:
+      schedule_id: "firecrawl:${steps.submit_crawl.json.job_id}"
+      cron_expression: "*/5 * * * *"
+      timezone: "UTC"
+      workflow_name: firecrawl_agent_async_poll
+      scope_id: "${input.scope_id}"
+      prompt: '{"job_id":"${json(steps.submit_crawl.json.job_id)}","idempotency_key":"${json(input.idempotency_key)}","schedule_id":"firecrawl:${steps.submit_crawl.json.job_id}"}'
 ```
 
 ## 7. Human 原语

--- a/docs/canon/workflow-runtime.md
+++ b/docs/canon/workflow-runtime.md
@@ -107,6 +107,8 @@ BindWorkflowDefinition(yaml)
 - `ScheduledDispatchGAgent` 是每个 schedule 的唯一写侧事实源，持有 cron、timezone、enabled、typed target descriptor、dispatch headers、next fire lease 与 recent fire records。
 - workflow 内部的 `self_reschedule` / `schedule_workflow` step 只向 `ScheduledDispatchGAgent` 发送幂等 ensure 命令；跨 run schedule fact 不归 workflow run actor 持有。
 - workflow schedule ensure 同步结果只表示 `accepted` command receipt（schedule id、schedule actor id、command id、correlation id）；readmodel freshness 通过 projection/readmodel 观察，不能由 step completion 暗示强一致。
+- 预计超过 90 分钟的外部 submit/poll job 必须建模为 split-run 模板，而不是 workflow core primitive。submit run 提交一次外部 job 并把 `job_id`、`idempotency_key`、确定性 `schedule_id`、poll cadence、deadline 与 attempt 预算交给 poll workflow；`ScheduledDispatchGAgent` 持有 schedule fact；每个 poll run 查询一次状态；终态分支用同一 `schedule_id` 幂等 ensure `enabled=false` 来停止后续 poll。
+- `await_job` / `async_job` 不是 runtime 原语，`wait_signal` 的 90 分钟上限不因 submit/poll job 放宽。poll handoff 的业务字段必须在 workflow 参数或 prompt payload 中显式表达，不能塞进 dispatch `Headers` 或泛化 `metadata`。
 - 定时唤醒走 `ScheduleSelfDurableTimeoutAsync`，在 Orleans runtime 下由 durable callback/reminder 机制承载；回调只向 schedule actor 发 fire command，不在中间层保存 schedule 状态。
 - schedule actor 只负责计算下一次 fire、生成幂等 key 并投递 prepared target envelope；workflow、GAgent service invocation 与 scripting 目标准备由 application/infrastructure adapter 承载，不进入 schedule actor core。
 - workflow schedule 的 `WorkflowName`、`Prompt`、`ScopeId` 仅存在 typed workflow target descriptor 中；service invocation 与 envelope target 使用各自 typed target descriptor；dispatch `Headers` 只保留传输扩展。

--- a/src/workflow/Aevatar.Workflow.Application/Workflows/WorkflowDefinitionCatalog.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Workflows/WorkflowDefinitionCatalog.cs
@@ -268,6 +268,8 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
             "        human_input, secure_input, human_approval,",
             "        cache, delay, emit, checkpoint, retrieve_facts, self_reschedule",
             "      - For self_reschedule, put schedule_id, cron_expression, timezone, workflow_name/service_id, scope_id, and prompt under parameters.",
+            "      - For external submit/poll jobs expected to run longer than 90 minutes, do not invent await_job or async_job and do not stretch wait_signal beyond 5400000ms. Use a checked-in split-run template: one submit workflow captures job_id/idempotency_key, a deterministic self_reschedule schedule owns polling, and each poll workflow run polls once.",
+            "      - Keep submit/poll business facts such as job_id, idempotency_key, schedule_id, deadline, attempt, max_attempts, and terminal status in typed parameters or prompt payload fields. Do not put those facts in header.* or metadata.",
             "      - Do NOT add a top-level schedule key; scheduling is a normal step type.",
             "      - NEVER use dynamic_workflow in generated YAML. dynamic_workflow is engine-internal and expects a nested ```yaml block input.",
             "      - Use snake_case for all keys.",

--- a/test/Aevatar.Workflow.Extensions.Schedules.Tests/WorkflowSelfRescheduleModuleTests.cs
+++ b/test/Aevatar.Workflow.Extensions.Schedules.Tests/WorkflowSelfRescheduleModuleTests.cs
@@ -64,6 +64,29 @@ public sealed class WorkflowSelfRescheduleModuleTests
             .Which.Event.Unpack<StepCompletedEvent>().Success.Should().BeTrue();
     }
 
+    [Fact]
+    public async Task HandleAsync_WithEnabledFalse_ShouldDisableExistingDeterministicSchedule()
+    {
+        var port = new RecordingWorkflowScheduleCommandPort();
+        var module = new WorkflowSelfRescheduleModule(port);
+        var context = new RecordingWorkflowContext();
+        var request = CreateRequest();
+        request.Parameters["schedule_id"] = "firecrawl:job-1";
+        request.Parameters["workflow_name"] = "firecrawl_agent_async_poll";
+        request.Parameters["prompt"] = """{"job_id":"job-1","schedule_id":"firecrawl:job-1"}""";
+        request.Parameters["enabled"] = "false";
+
+        await module.HandleAsync(CreateEnvelope(request), context, CancellationToken.None);
+
+        var configuration = port.Configurations.Should().ContainSingle().Which;
+        configuration.ScheduleId.Should().Be("firecrawl:job-1");
+        configuration.WorkflowName.Should().Be("firecrawl_agent_async_poll");
+        configuration.Prompt.Should().Contain("\"job_id\":\"job-1\"");
+        configuration.Enabled.Should().BeFalse();
+        context.Published.Should().ContainSingle()
+            .Which.Event.Unpack<StepCompletedEvent>().Success.Should().BeTrue();
+    }
+
     [Theory]
     [InlineData("schedule_id", "schedule_id is required.")]
     [InlineData("cron_expression", "cron_expression is required.")]

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowAsyncJobTemplateContractTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowAsyncJobTemplateContractTests.cs
@@ -1,0 +1,121 @@
+using Aevatar.Workflow.Core.Primitives;
+using Aevatar.Workflow.Core.Validation;
+using FluentAssertions;
+
+namespace Aevatar.Workflow.Host.Api.Tests;
+
+public sealed class WorkflowAsyncJobTemplateContractTests
+{
+    private static readonly WorkflowParser Parser = new();
+
+    [Fact]
+    public void FirecrawlSubmitTemplate_ShouldHandoffDurablePollFactsToSelfReschedule()
+    {
+        var workflow = ParseTemplate("firecrawl_agent_async_submit.yaml");
+
+        WorkflowValidator.Validate(workflow).Should().BeEmpty();
+        workflow.Name.Should().Be("firecrawl_agent_async_submit");
+
+        var submit = workflow.Steps.Should().Contain(step => step.Id == "submit_crawl").Subject;
+        submit.Type.Should().Be("tool_call");
+        submit.IdempotencyKey.Should().Be("${input.idempotency_key}");
+        submit.Parameters["tool"].Should().Be("firecrawl_crawl_submit");
+        submit.Parameters["arguments"].Should().Contain("\"idempotency_key\":\"${json(input.idempotency_key)}\"");
+
+        var schedule = workflow.Steps.Should().Contain(step => step.Id == "ensure_poll_schedule").Subject;
+        schedule.Type.Should().Be("self_reschedule");
+        schedule.Parameters.Should().Contain("schedule_id", "firecrawl:${steps.submit_crawl.json.job_id}");
+        schedule.Parameters.Should().Contain("cron_expression", "*/5 * * * *");
+        schedule.Parameters.Should().Contain("timezone", "UTC");
+        schedule.Parameters.Should().Contain("workflow_name", "firecrawl_agent_async_poll");
+        schedule.Parameters.Should().ContainKey("prompt");
+        schedule.Parameters["prompt"].Should().Contain("\"job_id\":\"${json(steps.submit_crawl.json.job_id)}\"");
+        schedule.Parameters["prompt"].Should().Contain("\"idempotency_key\":\"${json(input.idempotency_key)}\"");
+        schedule.Parameters["prompt"].Should().Contain("\"schedule_id\":\"firecrawl:${steps.submit_crawl.json.job_id}\"");
+        schedule.Parameters["prompt"].Should().Contain("\"scope_id\":\"${json(input.scope_id)}\"");
+        schedule.Parameters["prompt"].Should().Contain("\"attempt\":\"0\"");
+        schedule.Parameters["prompt"].Should().Contain("\"max_attempts\":\"288\"");
+        schedule.Parameters["prompt"].Should().Contain("\"deadline_utc\":\"${json(input.deadline_utc)}\"");
+    }
+
+    [Fact]
+    public void FirecrawlPollTemplate_ShouldPollOnceAndDisableSameScheduleOnTerminalBranches()
+    {
+        var workflow = ParseTemplate("firecrawl_agent_async_poll.yaml");
+
+        WorkflowValidator.Validate(workflow).Should().BeEmpty();
+        workflow.Name.Should().Be("firecrawl_agent_async_poll");
+
+        var poll = workflow.Steps.Should().Contain(step => step.Id == "poll_job").Subject;
+        poll.Type.Should().Be("tool_call");
+        poll.IdempotencyKey.Should().Be("${input.idempotency_key}");
+        poll.Parameters.Should().Contain("tool", "firecrawl_crawl_status");
+        poll.Parameters["arguments"].Should().Contain("\"job_id\":\"${json(input.job_id)}\"");
+
+        var route = workflow.Steps.Should().Contain(step => step.Id == "route_status").Subject;
+        route.Type.Should().Be("switch");
+        route.Parameters.Should().Contain("on", "${steps.poll_job.json.status}");
+        route.Branches.Should().Contain("completed", "stop_completed_schedule");
+        route.Branches.Should().Contain("failed", "stop_failed_schedule");
+        route.Branches.Should().Contain("cancelled", "stop_cancelled_schedule");
+        route.Branches.Should().Contain("_default", "mark_pending");
+
+        foreach (var terminalStepId in new[]
+                 {
+                     "stop_completed_schedule",
+                     "stop_failed_schedule",
+                     "stop_cancelled_schedule",
+                 })
+        {
+            var terminalCleanup = workflow.Steps.Should().Contain(step => step.Id == terminalStepId).Subject;
+            terminalCleanup.Type.Should().Be("self_reschedule");
+            terminalCleanup.Parameters.Should().Contain("schedule_id", "${input.schedule_id}");
+            terminalCleanup.Parameters.Should().Contain("enabled", "false");
+            terminalCleanup.Parameters.Should().Contain("workflow_name", "firecrawl_agent_async_poll");
+            terminalCleanup.Parameters.Should().Contain("prompt", "$input");
+        }
+
+        workflow.Steps.Should().Contain(step => step.Id == "mark_pending")
+            .Which.Parameters["value"].Should().Contain("\"status\":\"pending\"");
+    }
+
+    [Theory]
+    [InlineData("firecrawl_agent_async_submit.yaml")]
+    [InlineData("firecrawl_agent_async_poll.yaml")]
+    public void FirecrawlAsyncTemplates_ShouldNotUseCoreAsyncJobPrimitivesOrBusinessHeaders(string fileName)
+    {
+        var yaml = ReadTemplate(fileName);
+        var workflow = Parser.Parse(yaml);
+
+        workflow.Steps
+            .Where(step => step.Type == "await_job" || step.Type == "async_job")
+            .Should()
+            .BeEmpty();
+        yaml.Should().NotContain("type: await_job");
+        yaml.Should().NotContain("type: async_job");
+        yaml.Should().NotContain("header.job_id");
+        yaml.Should().NotContain("header.idempotency_key");
+        yaml.Should().NotContain("header.schedule_id");
+        yaml.Should().NotContain("metadata");
+        yaml.Should().NotContain("Metadata");
+    }
+
+    private static WorkflowDefinition ParseTemplate(string fileName) =>
+        Parser.Parse(ReadTemplate(fileName));
+
+    private static string ReadTemplate(string fileName) =>
+        File.ReadAllText(Path.Combine(FindRepositoryRoot(), "workflows", fileName));
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "aevatar.slnx")))
+                return directory.FullName;
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root.");
+    }
+}

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionCatalogTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionCatalogTests.cs
@@ -265,6 +265,24 @@ public class WorkflowDefinitionCatalogTests
     }
 
     [Fact]
+    public void FileLoader_ShouldLoadFirecrawlAsyncJobTemplates()
+    {
+        var registry = new WorkflowDefinitionCatalog();
+        var loader = new WorkflowDefinitionFileLoader();
+
+        var count = loader.LoadInto(
+            registry,
+            [Path.Combine(FindRepositoryRoot(), "workflows")],
+            NullLogger.Instance);
+
+        count.Should().BeGreaterThanOrEqualTo(4);
+        registry.GetYaml("firecrawl_agent_async_submit").Should().Contain("firecrawl_crawl_submit");
+        registry.GetYaml("firecrawl_agent_async_submit").Should().Contain("firecrawl_agent_async_poll");
+        registry.GetYaml("firecrawl_agent_async_poll").Should().Contain("firecrawl_crawl_status");
+        registry.GetYaml("firecrawl_agent_async_poll").Should().Contain("enabled: \"false\"");
+    }
+
+    [Fact]
     public void LarkApprovalWaitTemplates_ShouldUseExpectedWorkflowPrimitives()
     {
         var root = FindRepositoryRoot();
@@ -283,6 +301,15 @@ public class WorkflowDefinitionCatalogTests
         pollYaml.Should().Contain("value: \"${steps.get_instance.json.instance_code}\"");
         waitYaml.Should().NotContain("nyxid_proxy");
         pollYaml.Should().NotContain("nyxid_proxy");
+    }
+
+    [Fact]
+    public void BuiltInAutoYaml_ShouldSteerLongExternalJobsToSplitRunTemplates()
+    {
+        WorkflowDefinitionCatalog.BuiltInAutoYaml.Should().Contain("longer than 90 minutes");
+        WorkflowDefinitionCatalog.BuiltInAutoYaml.Should().Contain("do not invent await_job or async_job");
+        WorkflowDefinitionCatalog.BuiltInAutoYaml.Should().Contain("deterministic self_reschedule schedule owns polling");
+        WorkflowDefinitionCatalog.BuiltInAutoYaml.Should().Contain("Do not put those facts in header.* or metadata.");
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowTemplateParseTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowTemplateParseTests.cs
@@ -32,6 +32,10 @@ public class WorkflowTemplateParseTests
         definition.Name.Should().NotBeNullOrWhiteSpace();
         definition.Steps.Should().NotBeEmpty();
         WorkflowValidator.Validate(definition).Should().BeEmpty();
+        definition.Steps
+            .Where(step => step.Type == "await_job" || step.Type == "async_job")
+            .Should()
+            .BeEmpty();
     }
 
     private static string FindRepositoryRoot()

--- a/workflows/firecrawl_agent_async_poll.yaml
+++ b/workflows/firecrawl_agent_async_poll.yaml
@@ -1,0 +1,87 @@
+name: firecrawl_agent_async_poll
+description: Poll one Firecrawl crawl job once; terminal statuses disable the same deterministic poll schedule.
+steps:
+  - id: poll_job
+    type: tool_call
+    idempotency_key: "${input.idempotency_key}"
+    parameters:
+      tool: firecrawl_crawl_status
+      arguments: '{"job_id":"${json(input.job_id)}","idempotency_key":"${json(input.idempotency_key)}"}'
+    next: route_status
+
+  - id: route_status
+    type: switch
+    parameters:
+      on: "${steps.poll_job.json.status}"
+      branch.completed: stop_completed_schedule
+      branch.failed: stop_failed_schedule
+      branch.cancelled: stop_cancelled_schedule
+      branch._default: mark_pending
+    branches:
+      completed: stop_completed_schedule
+      failed: stop_failed_schedule
+      cancelled: stop_cancelled_schedule
+      _default: mark_pending
+
+  - id: stop_completed_schedule
+    type: self_reschedule
+    parameters:
+      schedule_id: "${input.schedule_id}"
+      display_name: "Firecrawl poll ${input.job_id}"
+      cron_expression: "*/5 * * * *"
+      timezone: "UTC"
+      workflow_name: firecrawl_agent_async_poll
+      scope_id: "${input.scope_id}"
+      prompt: "$input"
+      enabled: "false"
+    next: mark_completed
+
+  - id: stop_failed_schedule
+    type: self_reschedule
+    parameters:
+      schedule_id: "${input.schedule_id}"
+      display_name: "Firecrawl poll ${input.job_id}"
+      cron_expression: "*/5 * * * *"
+      timezone: "UTC"
+      workflow_name: firecrawl_agent_async_poll
+      scope_id: "${input.scope_id}"
+      prompt: "$input"
+      enabled: "false"
+    next: mark_failed
+
+  - id: stop_cancelled_schedule
+    type: self_reschedule
+    parameters:
+      schedule_id: "${input.schedule_id}"
+      display_name: "Firecrawl poll ${input.job_id}"
+      cron_expression: "*/5 * * * *"
+      timezone: "UTC"
+      workflow_name: firecrawl_agent_async_poll
+      scope_id: "${input.scope_id}"
+      prompt: "$input"
+      enabled: "false"
+    next: mark_cancelled
+
+  - id: mark_completed
+    type: assign
+    parameters:
+      target: firecrawl_async_job
+      value: '{"status":"completed","job_id":"${json(input.job_id)}","schedule_id":"${json(input.schedule_id)}","result_url":"${json(steps.poll_job.json.result_url)}"}'
+
+  - id: mark_failed
+    type: assign
+    parameters:
+      target: firecrawl_async_job
+      value: '{"status":"failed","job_id":"${json(input.job_id)}","schedule_id":"${json(input.schedule_id)}","error":"${json(steps.poll_job.json.error)}"}'
+
+  - id: mark_cancelled
+    type: assign
+    parameters:
+      target: firecrawl_async_job
+      value: '{"status":"cancelled","job_id":"${json(input.job_id)}","schedule_id":"${json(input.schedule_id)}"}'
+
+  - id: mark_pending
+    type: assign
+    parameters:
+      target: firecrawl_async_job
+      value: '{"status":"pending","job_id":"${json(input.job_id)}","schedule_id":"${json(input.schedule_id)}","attempt":"${input.attempt}","max_attempts":"${input.max_attempts}","deadline_utc":"${json(input.deadline_utc)}"}'

--- a/workflows/firecrawl_agent_async_submit.yaml
+++ b/workflows/firecrawl_agent_async_submit.yaml
@@ -1,0 +1,27 @@
+name: firecrawl_agent_async_submit
+description: Submit one Firecrawl crawl job and hand polling to a deterministic ScheduledDispatchGAgent schedule.
+steps:
+  - id: submit_crawl
+    type: tool_call
+    idempotency_key: "${input.idempotency_key}"
+    parameters:
+      tool: firecrawl_crawl_submit
+      arguments: '{"url":"${json(input.url)}","idempotency_key":"${json(input.idempotency_key)}"}'
+    next: ensure_poll_schedule
+
+  - id: ensure_poll_schedule
+    type: self_reschedule
+    parameters:
+      schedule_id: "firecrawl:${steps.submit_crawl.json.job_id}"
+      display_name: "Firecrawl poll ${steps.submit_crawl.json.job_id}"
+      cron_expression: "*/5 * * * *"
+      timezone: "UTC"
+      workflow_name: firecrawl_agent_async_poll
+      scope_id: "${input.scope_id}"
+      prompt: '{"job_id":"${json(steps.submit_crawl.json.job_id)}","idempotency_key":"${json(input.idempotency_key)}","schedule_id":"firecrawl:${steps.submit_crawl.json.job_id}","scope_id":"${json(input.scope_id)}","submitted_at":"${json(steps.submit_crawl.json.submitted_at)}","attempt":"0","max_attempts":"288","deadline_utc":"${json(input.deadline_utc)}"}'
+
+  - id: accepted
+    type: assign
+    parameters:
+      target: firecrawl_async_job
+      value: '{"status":"accepted","job_id":"${json(steps.submit_crawl.json.job_id)}","idempotency_key":"${json(input.idempotency_key)}","schedule_id":"firecrawl:${steps.submit_crawl.json.job_id}"}'


### PR DESCRIPTION
## Changed files

- 新增 `workflows/firecrawl_agent_async_submit.yaml` 与 `workflows/firecrawl_agent_async_poll.yaml`，用 submit run + poll-once run + 确定性 `self_reschedule` schedule 表达 Firecrawl 长时 submit/poll 作业。
- 更新 workflow primitives/runtime canon 文档与 built-in auto YAML 指引，明确 `>90min` submit/poll job 不新增 `await_job` / `async_job`，不拉长 `wait_signal`，也不把业务事实放入 `header.*` 或 `metadata`。
- 增加模板合同、catalog 加载、模板解析和 `enabled=false` schedule disable 行为测试。

## Test results

- `dotnet build aevatar.slnx --nologo`: passed.
- `dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo`: passed.
- `dotnet test test/Aevatar.Workflow.Extensions.Schedules.Tests/Aevatar.Workflow.Extensions.Schedules.Tests.csproj --nologo`: passed.
- `bash tools/ci/test_stability_guards.sh`: passed.
- `bash tools/docs/lint.sh`: passed.
- `bash tools/ci/architecture_guards.sh`: passed.

## Deviations

- No scope extension.
- Host `CI_GUARDS` was unset, so the host guard step reported `guards skipped: CI_GUARDS unset`.
- `HOST_REFACTOR_COMMENT_POLICY=none`; no refactor self-documentation comments were added to source files.

Closes #2390

⟦AI:AUTO-LOOP⟧
