### PR TITLE
对齐 wait_signal 长租约与 NyxID typed tool contract

### DIFF
--- a/docs/canon/nyxid-connected-service-tools.md
+++ b/docs/canon/nyxid-connected-service-tools.md
@@ -6,7 +6,7 @@ owner: eanzhao
 
 # NyxID Connected-Service LLM Tools
 
-把一个 Aevatar service 发布成 NyxID service 后，只要在它的 OpenAPI operation 上加显式标记，Aevatar 就能在直连 NyxID 的会话里把这些 endpoint 动态注册成独立 LLM 工具。工具调用经 NyxID proxy 下发，凭证注入、审计、approval、node routing、delegation 仍由 NyxID 负责。
+把一个 Aevatar service 发布成 NyxID service 后，只要在它的 live OpenAPI operation 上加显式标记，Aevatar 就能在直连 NyxID 的会话里把这些 endpoint 动态注册成独立 LLM 工具。工具调用经 NyxID proxy 下发，凭证注入、审计、approval、node routing、delegation 仍由 NyxID 负责。
 
 NyxID 始终是唯一真实源：service 列表与 OpenAPI spec 每次发现都从 NyxID live surface 读取，仓库内不保留 service/endpoint 影子目录，执行始终回到 NyxID proxy。
 
@@ -56,7 +56,7 @@ paths:
 
 每个准入的 operation 映射为一个独立 `IAgentTool`：
 
-- **Name**：`nyxid_{service_slug}__{name|operationId}`，稳定可预测；超长时按稳定哈希截断。同名冲突时保留第一个并打 `LogWarning`，其余丢弃（避免给模型歧义工具）。
+- **Name**：每个 operation 一个工具，格式为 `nyxid_{service_slug}__{name|operationId}`，稳定可预测；超长时按稳定哈希截断。同名冲突时保留第一个并打 `LogWarning`，其余丢弃（避免给模型歧义工具）。不提供 caller-facing `slug/method/path/body` 通用代理工具，也不新增 `nyxid_service_request` / `NyxIdServiceRequestTool`。
 - **Description**：取 OpenAPI `summary`/`description`，附带 service slug + `METHOD path`。
 - **ParametersSchema**：从结构化 OpenAPI 生成，不做字符串拼装。
   - `path` / `query` / `header` 参数各自成为顶层属性；`path` 参数恒为 required。
@@ -98,6 +98,7 @@ bearer 决定。
 - 不新增 NyxID endpoint / 字段 / 协议；只消费现有 `proxy/services`、`proxy/services/{id}/openapi.json`、`proxy/s/{slug}/...`。
 - 不绕过 NyxID proxy 直接打下游 base URL。
 - 不引入新的投影主链或 read model。
+- 不在 Aevatar 侧维护 shadow service catalog；tool schema、path、query、header、body 均来自该 operation 的 live OpenAPI contract。
 
 ## 6. `QuotaLedger` profile
 

--- a/docs/canon/sdk-dotnet.md
+++ b/docs/canon/sdk-dotnet.md
@@ -74,7 +74,7 @@ await client.SignalAsync(signalRequest);
 Long-running external work should use continuation semantics instead of stretching a normal executor step past its `600s` timeout. The supported pattern is:
 
 1. Start the external job from the workflow.
-2. Park the run at `wait_signal` (up to `5400000ms`) or `human_approval` (for operator gates).
+2. Park the run at `wait_signal` (up to `86400000ms`, one durable callback/signal lease) or `human_approval` (for operator gates).
 3. Resume with `SignalAsync(...)` / `ResumeAsync(...)` when the callback arrives.
 
 ## 4. Run-level error handling

--- a/docs/canon/workflow-primitives.md
+++ b/docs/canon/workflow-primitives.md
@@ -330,8 +330,8 @@ steps:
 - 常用参数：`signal_name`、`prompt`、`timeout_ms`。
 - 运行时事件：`WaitingForSignalEvent` 会显式携带 `run_id + step_id + signal_name`，用于无状态 UI 回传。
 - 回传约束：`SignalReceivedEvent` 必须携带 `run_id`；若同一 run 下同名 signal 有多个 waiter，还必须携带 `step_id` 以消歧。
-- 长等待口径：对长时间外部执行（例如 Codex worker、人工审批前置检查、离线作业）不要把一个普通执行步骤硬拉到超过 executor 的 `600s` 单步 timeout；改成“先发起外部工作，再 `wait_signal` 等回调”的 continuation 语义。当前 `wait_signal.timeout_ms` 官方支持到 `5400000`（90 分钟）。
-- 超过 90 分钟的 submit/poll 外部作业不属于 `wait_signal` 扩容场景，也不新增 `await_job` / `async_job` 原语。必须使用拆分 run 模板：submit run 只提交一次外部 job 并把 `job_id`、`idempotency_key`、确定性 `schedule_id`、deadline 与 attempt 预算写入 poll handoff；`ScheduledDispatchGAgent` 持有 poll schedule fact；每个 poll run 只查询一次状态，终态分支用同一个 `schedule_id` 禁用 schedule。
+- 长等待口径：对长时间外部执行（例如 Codex worker、人工审批前置检查、离线作业）不要把一个普通执行步骤硬拉到超过 executor 的 `600s` 单步 timeout；改成“先发起外部工作，再 `wait_signal` 等回调”的 continuation 语义。当前 `wait_signal.timeout_ms` 官方支持到 `86400000`（24 小时）。
+- submit/poll 外部作业不属于 `wait_signal` 扩容场景，也不新增 `await_job` / `async_job` 原语。`wait_signal` 只表达一个 actor-owned durable callback/signal lease；需要重复轮询或可能超过单次 callback lease 的作业必须使用拆分 run 模板：submit run 只提交一次外部 job 并把 `job_id`、`idempotency_key`、确定性 `schedule_id`、deadline 与 attempt 预算写入 poll handoff；`ScheduledDispatchGAgent` 持有 poll schedule fact；每个 poll run 只查询一次状态，终态分支用同一个 `schedule_id` 禁用 schedule。
 
 ```yaml
 steps:
@@ -340,7 +340,7 @@ steps:
     parameters:
       signal_name: "release_approved"
       prompt: "Waiting for release approval"
-      timeout_ms: "5400000"
+      timeout_ms: "86400000"
 ```
 
 ### `checkpoint`
@@ -791,7 +791,7 @@ POST /api/workflows/signal
 - `stepId`：resume 时必须对应当前挂起步骤；不要用旧步骤 ID 复用请求。
 - `signalName`：建议统一小写蛇形命名，和 YAML `signal_name` 保持一致。
 - 交互端点为无状态契约：服务端不维护 `runId -> actorId` 进程内映射，调用方必须在每次请求里显式传入 `actorId` 与 `runId`。
-- 长运行建议：对预计会 stall `3600-5400s` 的外部工作，优先采用 `emit/connector_call -> wait_signal` 或 `human_approval` continuation，而不是把普通 `llm_call/connector_call` 步骤 timeout 调大到超过 executor 的 `600s` 上限。
+- 长运行建议：对预计会超过普通 executor `600s` 单步 timeout、且能由一个外部 callback/signal 恢复的工作，优先采用 `emit/connector_call -> wait_signal` 或 `human_approval` continuation；需要重复轮询的外部 job 使用 split-run + `self_reschedule`，而不是在同一个 run 中长轮询。
 - `human_approval.on_reject`：
   - `fail`：拒绝会终止流程；
   - `skip` / `continue`：拒绝后继续下一个步骤（输入保持原值）。

--- a/docs/canon/workflow-runtime.md
+++ b/docs/canon/workflow-runtime.md
@@ -107,8 +107,8 @@ BindWorkflowDefinition(yaml)
 - `ScheduledDispatchGAgent` 是每个 schedule 的唯一写侧事实源，持有 cron、timezone、enabled、typed target descriptor、dispatch headers、next fire lease 与 recent fire records。
 - workflow 内部的 `self_reschedule` / `schedule_workflow` step 只向 `ScheduledDispatchGAgent` 发送幂等 ensure 命令；跨 run schedule fact 不归 workflow run actor 持有。
 - workflow schedule ensure 同步结果只表示 `accepted` command receipt（schedule id、schedule actor id、command id、correlation id）；readmodel freshness 通过 projection/readmodel 观察，不能由 step completion 暗示强一致。
-- 预计超过 90 分钟的外部 submit/poll job 必须建模为 split-run 模板，而不是 workflow core primitive。submit run 提交一次外部 job 并把 `job_id`、`idempotency_key`、确定性 `schedule_id`、poll cadence、deadline 与 attempt 预算交给 poll workflow；`ScheduledDispatchGAgent` 持有 schedule fact；每个 poll run 查询一次状态；终态分支用同一 `schedule_id` 幂等 ensure `enabled=false` 来停止后续 poll。
-- `await_job` / `async_job` 不是 runtime 原语，`wait_signal` 的 90 分钟上限不因 submit/poll job 放宽。poll handoff 的业务字段必须在 workflow 参数或 prompt payload 中显式表达，不能塞进 dispatch `Headers` 或泛化 `metadata`。
+- 外部 submit/poll job 必须建模为 split-run 模板，而不是 workflow core primitive。submit run 提交一次外部 job 并把 `job_id`、`idempotency_key`、确定性 `schedule_id`、poll cadence、deadline 与 attempt 预算交给 poll workflow；`ScheduledDispatchGAgent` 持有 schedule fact；每个 poll run 查询一次状态；终态分支用同一 `schedule_id` 幂等 ensure `enabled=false` 来停止后续 poll。
+- `await_job` / `async_job` 不是 runtime 原语。`wait_signal` 最多持有一个 actor-owned durable callback/signal lease，当前上限为 24 小时；它不用于把 submit/poll job 扩成同 run long polling。poll handoff 的业务字段必须在 workflow 参数或 prompt payload 中显式表达，不能塞进 dispatch `Headers` 或泛化 `metadata`。
 - 定时唤醒走 `ScheduleSelfDurableTimeoutAsync`，在 Orleans runtime 下由 durable callback/reminder 机制承载；回调只向 schedule actor 发 fire command，不在中间层保存 schedule 状态。
 - schedule actor 只负责计算下一次 fire、生成幂等 key 并投递 prepared target envelope；workflow、GAgent service invocation 与 scripting 目标准备由 application/infrastructure adapter 承载，不进入 schedule actor core。
 - workflow schedule 的 `WorkflowName`、`Prompt`、`ScopeId` 仅存在 typed workflow target descriptor 中；service invocation 与 envelope target 使用各自 typed target descriptor；dispatch `Headers` 只保留传输扩展。

--- a/src/workflow/Aevatar.Workflow.Application/Workflows/WorkflowDefinitionCatalog.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Workflows/WorkflowDefinitionCatalog.cs
@@ -268,7 +268,7 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
             "        human_input, secure_input, human_approval,",
             "        cache, delay, emit, checkpoint, retrieve_facts, self_reschedule",
             "      - For self_reschedule, put schedule_id, cron_expression, timezone, workflow_name/service_id, scope_id, and prompt under parameters.",
-            "      - For external submit/poll jobs expected to run longer than 90 minutes, do not invent await_job or async_job and do not stretch wait_signal beyond 5400000ms. Use a checked-in split-run template: one submit workflow captures job_id/idempotency_key, a deterministic self_reschedule schedule owns polling, and each poll workflow run polls once.",
+            "      - wait_signal is for one durable callback/signal lease and may wait up to 86400000ms (24h). For external submit/poll jobs that need repeated polling or may exceed one callback lease, do not invent await_job or async_job and do not model same-run long polling. Use a checked-in split-run template: one submit workflow captures job_id/idempotency_key, a deterministic self_reschedule schedule owns polling, and each poll workflow run polls once.",
             "      - Keep submit/poll business facts such as job_id, idempotency_key, schedule_id, deadline, attempt, max_attempts, and terminal status in typed parameters or prompt payload fields. Do not put those facts in header.* or metadata.",
             "      - Do NOT add a top-level schedule key; scheduling is a normal step type.",
             "      - NEVER use dynamic_workflow in generated YAML. dynamic_workflow is engine-internal and expects a nested ```yaml block input.",

--- a/src/workflow/Aevatar.Workflow.Core/Modules/WaitSignalModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/WaitSignalModule.cs
@@ -17,7 +17,7 @@ public sealed class WaitSignalModule : IEventModule<IWorkflowExecutionContext>
     private const string ModuleStateKey = "wait_signal";
     private const int DefaultSignalBufferRetentionMs = 600_000;
     private const int MaxSignalBufferRetentionMs = 3_600_000;
-    private const int MaxWaitSignalTimeoutMs = 5_400_000;
+    private const int MaxWaitSignalTimeoutMs = 86_400_000;
     private const int MaxWaitSignalTimeoutSeconds = MaxWaitSignalTimeoutMs / 1000;
 
     public string Name => "wait_signal";

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Capabilities/WorkflowInfrastructureCapabilitiesProvider.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Capabilities/WorkflowInfrastructureCapabilitiesProvider.cs
@@ -18,7 +18,7 @@ internal sealed class WorkflowInfrastructureCapabilitiesProvider : IWorkflowCapa
                 "Suspends workflow execution until an external signal arrives.",
                 [
                     new PrimitiveParameterDescriptor("signal_name", "string", true, "Signal name used to resume this waiter."),
-                    new PrimitiveParameterDescriptor("timeout_ms", "int", false, "Maximum wait duration in milliseconds."),
+                    new PrimitiveParameterDescriptor("timeout_ms", "int", false, "Maximum wait duration in milliseconds, capped at 86400000."),
                 ]),
             ["workflow_call"] = new(
                 "Invokes another workflow definition as a sub-workflow.",

--- a/test/Aevatar.AI.Tests/ConnectedServiceToolSpecParserTests.cs
+++ b/test/Aevatar.AI.Tests/ConnectedServiceToolSpecParserTests.cs
@@ -173,6 +173,8 @@ public class ConnectedServiceToolSpecParserTests
         var second = ConnectedServiceToolNaming.Build("api-shop", "search_orders");
 
         first.Should().Be("nyxid_api-shop__search_orders");
+        first.Should().StartWith("nyxid_api-shop__");
+        first.Should().NotBe("nyxid_service_request");
         first.Should().Be(second, "naming must be deterministic for a given (slug, operation) pair");
     }
 

--- a/test/Aevatar.AI.Tests/NyxIdConnectedServiceToolSourceTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdConnectedServiceToolSourceTests.cs
@@ -87,6 +87,7 @@ public class NyxIdConnectedServiceToolSourceTests
         tools.Select(t => t.Name).Should().BeEquivalentTo(
             ["nyxid_api-shop__get_order", "nyxid_api-shop__search_orders"]);
         tools.Should().NotContain(t => t.Name.Contains("secret"));
+        tools.Should().NotContain(t => t.Name == "nyxid_service_request");
     }
 
     [Fact]
@@ -138,6 +139,24 @@ public class NyxIdConnectedServiceToolSourceTests
         postCall.RelativePath.Should().Be("api-shop/orders/search");
         using var postBody = JsonDocument.Parse(postCall.Body);
         postBody.RootElement.GetProperty("q").GetString().Should().Be("shoes");
+    }
+
+    [Fact]
+    public async Task ExecuteTool_MissingRequiredBody_ReturnsErrorWithoutCallingProxy()
+    {
+        var handler = new FakeNyxIdHandler();
+        handler.ServicesByToken["user-token"] = """[{ "slug": "api-shop", "id": "svc-1" }]""";
+        handler.SpecsByServiceId["svc-1"] = ShopSpec;
+        var (source, _) = CreateSource(handler);
+
+        using var _scope = PushContext("user-token");
+        var tools = await source.DiscoverToolsAsync();
+        var search = tools.Single(t => t.Name == "nyxid_api-shop__search_orders");
+
+        var result = await search.ExecuteAsync("{}");
+
+        result.Should().Contain("error").And.Contain("body");
+        handler.ProxyRequests.Should().BeEmpty("a missing required operation body must not reach the NyxID proxy");
     }
 
     [Fact]

--- a/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
+++ b/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
@@ -302,6 +302,7 @@ public sealed class MainnetHostCompositionTests
         var nyxIdConnectedServices = registry.Resolve(new ChatRouteToolSetRef { Name = ToolSetNames.NyxIdConnectedServices });
         nyxIdConnectedServices.IsSuccess.Should().BeTrue(nyxIdConnectedServices.Error?.Message);
         nyxIdConnectedServices.Sources.Should().ContainSingle(source => source is NyxIdConnectedServiceToolSource);
+        workspace.Sources.Should().NotContain(source => source is NyxIdConnectedServiceToolSource);
 
         var voice = registry.Resolve(new ChatRouteToolSetRef { Name = "voice.realtime" });
         voice.IsSuccess.Should().BeFalse();

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlContinuationRoundTripTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlContinuationRoundTripTests.cs
@@ -32,7 +32,7 @@ public sealed class WorkflowRunControlContinuationRoundTripTests
                 Parameters =
                 {
                     ["signal_name"] = "codex_worker_done",
-                    ["timeout_ms"] = "5400000",
+                    ["timeout_ms"] = "86400000",
                 },
             }),
             context,

--- a/test/Aevatar.Workflow.Core.Tests/Modules/BackpressureModuleTopUpTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/BackpressureModuleTopUpTests.cs
@@ -313,18 +313,18 @@ public sealed class BackpressureModuleTopUpTests
                 Parameters =
                 {
                     ["signal_name"] = "codex_worker_done",
-                    ["timeout_ms"] = "5400000",
+                    ["timeout_ms"] = "86400000",
                 },
             }),
             context,
             CancellationToken.None);
 
         var waiting = context.Published.Select(x => x.Event).OfType<WaitingForSignalEvent>().Single();
-        waiting.TimeoutMs.Should().Be(5_400_000);
+        waiting.TimeoutMs.Should().Be(86_400_000);
 
         var scheduled = context.Scheduled.Should().ContainSingle().Subject;
-        scheduled.DueTime.Should().Be(TimeSpan.FromMilliseconds(5_400_000));
-        scheduled.Event.Should().BeOfType<WaitSignalTimeoutFiredEvent>().Which.TimeoutMs.Should().Be(5_400_000);
+        scheduled.DueTime.Should().Be(TimeSpan.FromHours(24));
+        scheduled.Event.Should().BeOfType<WaitSignalTimeoutFiredEvent>().Which.TimeoutMs.Should().Be(86_400_000);
     }
 
     private static EventEnvelope Envelope(IMessage evt) =>

--- a/test/Aevatar.Workflow.Core.Tests/Modules/RuntimeCallbackEventizationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/RuntimeCallbackEventizationTests.cs
@@ -299,6 +299,32 @@ public class RuntimeCallbackEventizationTests
     }
 
     [Fact]
+    public async Task WaitSignalModule_ShouldScheduleTwentyFourHourTimeoutLease()
+    {
+        var module = new WaitSignalModule();
+        var ctx = new SchedulingContext();
+
+        await module.HandleAsync(
+            Wrap(new StepRequestEvent
+            {
+                StepId = "wait-24h",
+                StepType = "wait_signal",
+                RunId = "run-wait-24h",
+                Parameters =
+                {
+                    ["signal_name"] = "callback",
+                    ["timeout_seconds"] = "86400",
+                },
+            }),
+            ctx,
+            CancellationToken.None);
+
+        var scheduled = ctx.Scheduled.Single(x => x.Event is WaitSignalTimeoutFiredEvent);
+        scheduled.DueTime.Should().Be(TimeSpan.FromHours(24));
+        ((WaitSignalTimeoutFiredEvent)scheduled.Event).TimeoutMs.Should().Be(86_400_000);
+    }
+
+    [Fact]
     public async Task WorkflowLoop_ShouldReplayTimeoutCompletion_WhenPublishFailsTransiently()
     {
         var ctx = new SchedulingContext
@@ -1366,12 +1392,11 @@ public class RuntimeCallbackEventizationTests
             EventEnvelopePublishOptions? options = null,
             CancellationToken ct = default)
         {
-            _ = dueTime;
             _ = options;
             _ = ct;
             var generation = _generations.GetValueOrDefault(callbackId, 0) + 1;
             _generations[callbackId] = generation;
-            Scheduled.Add(new ScheduledCallback(callbackId, generation, evt));
+            Scheduled.Add(new ScheduledCallback(callbackId, generation, dueTime, evt));
             return Task.FromResult(new RuntimeCallbackLease(AgentId, callbackId, generation, RuntimeCallbackBackend.InMemory));
         }
 
@@ -1539,6 +1564,7 @@ public class RuntimeCallbackEventizationTests
     private sealed record ScheduledCallback(
         string CallbackId,
         long Generation,
+        TimeSpan DueTime,
         IMessage Event);
 
     private sealed record CanceledCallback(

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WaitSignalModuleTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WaitSignalModuleTests.cs
@@ -309,7 +309,7 @@ public sealed class WaitSignalModuleTests
                     SignalName = "approval-terminal",
                     TimeoutMs = 5000,
                 },
-                scheduled),
+                scheduled.Lease),
             context,
             CancellationToken.None);
 
@@ -344,6 +344,72 @@ public sealed class WaitSignalModuleTests
             .Should()
             .BeTrue();
         committedFact.Should().BeOfType<WorkflowExternalApprovalContinuationClearedEvent>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenTimeoutIsTwentyFourHours_ShouldScheduleDurableCallback()
+    {
+        var module = new WaitSignalModule();
+        var context = new RecordingEventHandlerContext(
+            new EmptyServiceProvider(),
+            new StubAgent("workflow-24h"),
+            NullLogger.Instance);
+
+        await module.HandleAsync(
+            Envelope(new StepRequestEvent
+            {
+                StepId = "wait-24h",
+                StepType = "wait_signal",
+                RunId = "run-24h",
+                Parameters =
+                {
+                    ["signal_name"] = "callback",
+                    ["timeout_ms"] = "86400000",
+                },
+            }),
+            context,
+            CancellationToken.None);
+
+        var scheduled = context.Scheduled.Should().ContainSingle().Subject;
+        var timeout = scheduled.Event.Should().BeOfType<WaitSignalTimeoutFiredEvent>().Subject;
+        timeout.TimeoutMs.Should().Be(86_400_000);
+        context.Published.Select(item => item.Event)
+            .OfType<WaitingForSignalEvent>()
+            .Should()
+            .ContainSingle()
+            .Subject
+            .TimeoutMs.Should().Be(86_400_000);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenTimeoutExceedsTwentyFourHours_ShouldClampDurableCallback()
+    {
+        var module = new WaitSignalModule();
+        var context = new RecordingEventHandlerContext(
+            new EmptyServiceProvider(),
+            new StubAgent("workflow-clamp"),
+            NullLogger.Instance);
+
+        await module.HandleAsync(
+            Envelope(new StepRequestEvent
+            {
+                StepId = "wait-clamp",
+                StepType = "wait_signal",
+                RunId = "run-clamp",
+                Parameters =
+                {
+                    ["signal_name"] = "callback",
+                    ["timeout_ms"] = "172800000",
+                },
+            }),
+            context,
+            CancellationToken.None);
+
+        var timeout = context.Scheduled.Should().ContainSingle().Subject.Event
+            .Should()
+            .BeOfType<WaitSignalTimeoutFiredEvent>()
+            .Subject;
+        timeout.TimeoutMs.Should().Be(86_400_000);
     }
 
     [Fact]
@@ -438,7 +504,7 @@ public sealed class WaitSignalModuleTests
         }
 
         public List<(IMessage Event, TopologyAudience Direction)> Published { get; } = [];
-        public List<RuntimeCallbackLease> Scheduled { get; } = [];
+        public List<ScheduledCallbackRecord> Scheduled { get; } = [];
         public EventEnvelope InboundEnvelope { get; }
         public string AgentId => Agent.Id;
         public IAgent Agent { get; }
@@ -518,11 +584,10 @@ public sealed class WaitSignalModuleTests
             CancellationToken ct = default)
         {
             _ = dueTime;
-            _ = evt;
             _ = options;
             _ = ct;
             var lease = new RuntimeCallbackLease(AgentId, callbackId, Scheduled.Count + 1, RuntimeCallbackBackend.InMemory);
-            Scheduled.Add(lease);
+            Scheduled.Add(new ScheduledCallbackRecord(lease, dueTime, evt));
             return Task.FromResult(lease);
         }
 
@@ -544,4 +609,6 @@ public sealed class WaitSignalModuleTests
     {
         public object? GetService(System.Type serviceType) => null;
     }
+
+    private sealed record ScheduledCallbackRecord(RuntimeCallbackLease Lease, TimeSpan DueTime, IMessage Event);
 }

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionCatalogTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionCatalogTests.cs
@@ -162,6 +162,9 @@ public class WorkflowDefinitionCatalogTests
         WorkflowDefinitionCatalog.BuiltInAutoYaml.Should().Contain("name: normalize_text");
         WorkflowDefinitionCatalog.BuiltInAutoYaml.Should().Contain("name: review_summary");
         WorkflowDefinitionCatalog.BuiltInAutoYaml.Should().Contain("Do not invent extra fields.");
+        WorkflowDefinitionCatalog.BuiltInAutoYaml.Should().Contain("86400000ms");
+        WorkflowDefinitionCatalog.BuiltInAutoYaml.Should().Contain("do not invent await_job or async_job");
+        WorkflowDefinitionCatalog.BuiltInAutoYaml.Should().NotContain("5400000ms");
     }
 
     [Fact]
@@ -306,8 +309,9 @@ public class WorkflowDefinitionCatalogTests
     [Fact]
     public void BuiltInAutoYaml_ShouldSteerLongExternalJobsToSplitRunTemplates()
     {
-        WorkflowDefinitionCatalog.BuiltInAutoYaml.Should().Contain("longer than 90 minutes");
+        WorkflowDefinitionCatalog.BuiltInAutoYaml.Should().Contain("may wait up to 86400000ms (24h)");
         WorkflowDefinitionCatalog.BuiltInAutoYaml.Should().Contain("do not invent await_job or async_job");
+        WorkflowDefinitionCatalog.BuiltInAutoYaml.Should().Contain("do not model same-run long polling");
         WorkflowDefinitionCatalog.BuiltInAutoYaml.Should().Contain("deterministic self_reschedule schedule owns polling");
         WorkflowDefinitionCatalog.BuiltInAutoYaml.Should().Contain("Do not put those facts in header.* or metadata.");
     }


### PR DESCRIPTION
## Changed files
- `wait_signal` 的执行、能力描述和内置 workflow guidance 已对齐到单个 actor-owned durable callback/signal lease 最长 24h。
- NyxID connected service 文档与测试已收紧为 per-operation typed tools：`nyxid_{service_slug}__{operation}`，由 live OpenAPI `x-aevatar-tool` 驱动，并保持通过 NyxID proxy 执行。
- 相关 canon 文档、workflow catalog/capability 测试、NyxID tool parser/source 测试和 host composition 测试已同步更新。

## Test results
- PASS: `bash -lc "dotnet build aevatar.slnx --nologo"`
- PASS: `bash tools/ci/test_stability_guards.sh`
- PASS: `dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --nologo`
- PASS: `dotnet test test/Aevatar.Workflow.Application.Tests/Aevatar.Workflow.Application.Tests.csproj --nologo`
- PASS: `dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo`
- PASS: `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --nologo`
- PASS: `dotnet test test/Aevatar.Capabilities.Tests/Aevatar.Capabilities.Tests.csproj --nologo`
- PASS: `bash tools/docs/lint.sh`
- PASS: `git diff --check`
- SKIPPED: `guards skipped: CI_GUARDS unset`

## Deviations
- `HOST_REFACTOR_COMMENT_POLICY` 归一化为 `none`，未写入 refactor self-documentation 注释。
- A1 `await_job` 按 consensus 继续保持 gated，未在本 slice 实施。
- 未扩展授权 scope，未修改 schema/protocol，未提交 commit。
- Closes #2392

⟦AI:AUTO-LOOP⟧
