### PR TITLE
Preserve schedule auth across workflow reschedules

### DIFF
--- a/src/platform/Aevatar.GAgentService.Core/Schedules/ScheduledDispatchGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/Schedules/ScheduledDispatchGAgent.cs
@@ -181,6 +181,19 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
         EnsureValidDefinition(targetActorId, target, triggerEnvelope, cronExpression, timezone);
 
         var now = DateTimeOffset.UtcNow;
+        var configuredTarget = PreserveExistingServiceInvocationAuth(
+            NormalizeTarget(target),
+            isCreate);
+        Logger.LogInformation(
+            "Scheduled dispatch configuration prepared. scheduleId={ScheduleId} isCreate={IsCreate} targetKind={TargetKind} scheduleKind={ScheduleKind} hasServiceInvocationAuth={HasServiceInvocationAuth} hasScopeOwnerNyxId={HasScopeOwnerNyxId} hasSenderNyxId={HasSenderNyxId} hasDurableSenderBearerToken={HasDurableSenderBearerToken}",
+            NormalizeRequired(scheduleId, nameof(scheduleId)),
+            isCreate,
+            configuredTarget.Kind,
+            scheduleKind,
+            HasServiceInvocationAuth(configuredTarget),
+            HasScopeOwnerNyxId(configuredTarget),
+            HasSenderNyxId(configuredTarget),
+            HasDurableSenderBearerToken(configuredTarget));
         var configured = new ScheduledDispatchConfiguredEvent
         {
             ScheduleId = NormalizeRequired(scheduleId, nameof(scheduleId)),
@@ -192,7 +205,7 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
             Enabled = enabled,
             ConfiguredAt = Timestamp.FromDateTimeOffset(now),
             PayloadTypeUrl = ResolvePayloadTypeUrl(triggerEnvelope),
-            Target = NormalizeTarget(target),
+            Target = configuredTarget,
             ScheduleKind = scheduleKind,
         };
         foreach (var (key, value) in NormalizeHeaders(headers))
@@ -354,6 +367,17 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
         {
             if (prepared.Envelope.Payload?.TryUnpack<ServiceInvocationRequest>(out var request) != true)
                 throw new InvalidOperationException("Scheduled service invocation payload is not configured.");
+
+            var stateTarget = State.Target;
+            Logger.LogInformation(
+                "Scheduled service invocation fire prepared from actor state. scheduleId={ScheduleId} scheduleKind={ScheduleKind} hasServiceInvocationAuth={HasServiceInvocationAuth} hasScopeOwnerNyxId={HasScopeOwnerNyxId} hasSenderNyxId={HasSenderNyxId} hasDurableSenderBearerToken={HasDurableSenderBearerToken} projectWorkflowCallerCredential={ProjectWorkflowCallerCredential}",
+                ResolveScheduleId(),
+                State.ScheduleKind,
+                HasServiceInvocationAuth(stateTarget),
+                HasScopeOwnerNyxId(stateTarget),
+                HasSenderNyxId(stateTarget),
+                HasDurableSenderBearerToken(stateTarget),
+                State.ScheduleKind == ScheduledDispatchScheduleKindState.Workflow);
 
             var receipt = await _serviceInvocationDispatchPort.DispatchAsync(
                 new ScheduledServiceInvocationDispatchRequest(
@@ -792,6 +816,25 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
         };
     }
 
+    private ScheduledDispatchTargetState PreserveExistingServiceInvocationAuth(
+        ScheduledDispatchTargetState normalizedTarget,
+        bool isCreate)
+    {
+        if (isCreate || normalizedTarget.Kind != ScheduledDispatchTargetKindState.ServiceInvocation)
+            return normalizedTarget;
+        if (normalizedTarget.ServiceInvocation?.Auth != null)
+            return normalizedTarget;
+
+        var existingAuth = NormalizeServiceInvocationAuth(State.Target?.ServiceInvocation?.Auth);
+        if (existingAuth == null)
+            return normalizedTarget;
+
+        var preserved = normalizedTarget.Clone();
+        preserved.ServiceInvocation ??= new ScheduledServiceInvocationTargetState();
+        preserved.ServiceInvocation.Auth = existingAuth;
+        return preserved;
+    }
+
     private static ScheduledServiceInvocationAuthState? NormalizeServiceInvocationAuth(
         ScheduledServiceInvocationAuthState? auth)
     {
@@ -838,6 +881,18 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
                 Tenant = NormalizeOptional(subject.Tenant),
                 ExternalUserId = NormalizeOptional(subject.ExternalUserId),
             };
+
+    private static bool HasServiceInvocationAuth(ScheduledDispatchTargetState? target) =>
+        target?.ServiceInvocation?.Auth != null;
+
+    private static bool HasScopeOwnerNyxId(ScheduledDispatchTargetState? target) =>
+        target?.ServiceInvocation?.Auth?.ScopeOwnerNyxId != null;
+
+    private static bool HasSenderNyxId(ScheduledDispatchTargetState? target) =>
+        target?.ServiceInvocation?.Auth?.SenderNyxId != null;
+
+    private static bool HasDurableSenderBearerToken(ScheduledDispatchTargetState? target) =>
+        !string.IsNullOrWhiteSpace(target?.ServiceInvocation?.Auth?.DurableSenderBearerToken);
 
     private ScheduledDispatchState ApplyConfigured(
         ScheduledDispatchState current,

--- a/src/platform/Aevatar.GAgentService.Core/Schedules/ScheduledDispatchGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/Schedules/ScheduledDispatchGAgent.cs
@@ -720,7 +720,9 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
 
     private bool MatchesConfiguredDefinition(ScheduledDispatchEnsureCommand command)
     {
-        var normalizedTarget = NormalizeTarget(command.Target);
+        var normalizedTarget = PreserveExistingServiceInvocationAuth(
+            NormalizeTarget(command.Target),
+            isCreate: false);
         var normalizedHeaders = NormalizeHeaders(command.Headers);
         var normalizedScheduleId = NormalizeRequired(command.ScheduleId, nameof(command.ScheduleId));
         var normalizedDisplayName = NormalizeOptional(command.DisplayName);

--- a/test/Aevatar.Workflow.Core.Tests/ScheduledDispatchGAgentTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/ScheduledDispatchGAgentTests.cs
@@ -1024,6 +1024,66 @@ public sealed class ScheduledDispatchGAgentTests
     }
 
     [Fact]
+    public async Task HandleEnsureAsync_WhenServiceInvocationNoOpOmitsAuth_ShouldPreserveExistingAuthWithoutConfiguredEvent()
+    {
+        var eventStore = new TestEventStore();
+        var dispatch = new RecordingActorDispatchPort();
+        var agent = CreateAgent(eventStore, dispatch);
+        await agent.ActivateAsync();
+        var triggerEnvelope = CreateTriggerEnvelope("target-actor-1", new ChatRequestEvent
+        {
+            Prompt = "hello",
+            SessionId = "template-session",
+        });
+        await agent.HandleConfigureAsync(CreateConfigureCommand(
+            enabled: false,
+            triggerEnvelope: triggerEnvelope,
+            scheduleKind: ScheduledDispatchScheduleKindState.Workflow,
+            target: new ScheduledDispatchTargetState
+            {
+                Kind = ScheduledDispatchTargetKindState.ServiceInvocation,
+                ServiceInvocation = new ScheduledServiceInvocationTargetState
+                {
+                    Identity = new ServiceIdentity { ServiceId = "configured-service" },
+                    EndpointId = "chat",
+                    Payload = Any.Pack(new ChatRequestEvent { Prompt = "configured" }),
+                    Auth = new ScheduledServiceInvocationAuthState
+                    {
+                        ScopeOwnerNyxId = new ScheduledServiceInvocationScopeOwnerNyxIdCredentialSourceState
+                        {
+                            Scope = "proxy",
+                            OwnerSubject = new ScheduledServiceInvocationNyxIdSubjectRefState
+                            {
+                                Platform = OwnerScope.NyxIdPlatform,
+                                Tenant = string.Empty,
+                                ExternalUserId = "owner-nyx-user",
+                            },
+                        },
+                    },
+                },
+            }));
+        var eventCount = eventStore.GetEvents(ScheduleActorId).Count;
+
+        await agent.HandleEnsureAsync(CreateEnsureCommand(
+            triggerEnvelope: triggerEnvelope,
+            scheduleKind: ScheduledDispatchScheduleKindState.Workflow,
+            target: new ScheduledDispatchTargetState
+            {
+                Kind = ScheduledDispatchTargetKindState.ServiceInvocation,
+                ServiceInvocation = new ScheduledServiceInvocationTargetState
+                {
+                    Identity = new ServiceIdentity { ServiceId = "configured-service" },
+                    EndpointId = "chat",
+                    Payload = Any.Pack(new ChatRequestEvent { Prompt = "configured" }),
+                },
+            }));
+
+        eventStore.GetEvents(ScheduleActorId).Should().HaveCount(eventCount);
+        agent.State.Target!.ServiceInvocation!.Auth.Should().NotBeNull();
+        agent.State.Target.ServiceInvocation.Auth!.ScopeOwnerNyxId!.Scope.Should().Be("proxy");
+    }
+
+    [Fact]
     public async Task HandleEnsureAsync_WhenServiceInvocationUpdateOmitsAuth_ShouldPreserveExistingAuth()
     {
         var eventStore = new TestEventStore();
@@ -1815,7 +1875,8 @@ public sealed class ScheduledDispatchGAgentTests
         string cronExpression = "*/15 * * * *",
         bool enabled = false,
         EventEnvelope? triggerEnvelope = null,
-        ScheduledDispatchTargetState? target = null)
+        ScheduledDispatchTargetState? target = null,
+        ScheduledDispatchScheduleKindState scheduleKind = ScheduledDispatchScheduleKindState.Generic)
     {
         return new ScheduledDispatchEnsureCommand
         {
@@ -1831,6 +1892,7 @@ public sealed class ScheduledDispatchGAgentTests
             Timezone = "UTC",
             Enabled = enabled,
             Target = target ?? CreateTargetState(targetActorId, triggerEnvelope),
+            ScheduleKind = scheduleKind,
         };
     }
 

--- a/test/Aevatar.Workflow.Core.Tests/ScheduledDispatchGAgentTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/ScheduledDispatchGAgentTests.cs
@@ -1024,6 +1024,72 @@ public sealed class ScheduledDispatchGAgentTests
     }
 
     [Fact]
+    public async Task HandleEnsureAsync_WhenServiceInvocationUpdateOmitsAuth_ShouldPreserveExistingAuth()
+    {
+        var eventStore = new TestEventStore();
+        var dispatch = new RecordingActorDispatchPort();
+        var serviceInvocationDispatch = new RecordingScheduledServiceInvocationDispatchPort();
+        var agent = CreateAgent(
+            eventStore,
+            dispatch,
+            serviceInvocationDispatch: serviceInvocationDispatch);
+        await agent.ActivateAsync();
+        await agent.HandleConfigureAsync(CreateConfigureCommand(
+            enabled: false,
+            scheduleKind: ScheduledDispatchScheduleKindState.Workflow,
+            target: new ScheduledDispatchTargetState
+            {
+                Kind = ScheduledDispatchTargetKindState.ServiceInvocation,
+                ServiceInvocation = new ScheduledServiceInvocationTargetState
+                {
+                    Identity = new ServiceIdentity { ServiceId = "configured-service" },
+                    EndpointId = "chat",
+                    Payload = Any.Pack(new ChatRequestEvent { Prompt = "configured" }),
+                    Auth = new ScheduledServiceInvocationAuthState
+                    {
+                        ScopeOwnerNyxId = new ScheduledServiceInvocationScopeOwnerNyxIdCredentialSourceState
+                        {
+                            Scope = "proxy",
+                            OwnerSubject = new ScheduledServiceInvocationNyxIdSubjectRefState
+                            {
+                                Platform = OwnerScope.NyxIdPlatform,
+                                Tenant = string.Empty,
+                                ExternalUserId = "owner-nyx-user",
+                            },
+                        },
+                    },
+                },
+            }));
+
+        await agent.HandleEnsureAsync(CreateEnsureCommand(
+            displayName: "Updated schedule",
+            targetActorId: ScheduledDispatchAdapterConventions.ServiceInvocationTargetActorId,
+            target: new ScheduledDispatchTargetState
+            {
+                Kind = ScheduledDispatchTargetKindState.ServiceInvocation,
+                ServiceInvocation = new ScheduledServiceInvocationTargetState
+                {
+                    Identity = new ServiceIdentity { ServiceId = "configured-service" },
+                    EndpointId = "chat",
+                    Payload = Any.Pack(new ChatRequestEvent { Prompt = "updated" }),
+                },
+            }));
+        var scheduledFireAt = new DateTimeOffset(2026, 5, 29, 9, 0, 0, TimeSpan.Zero);
+        await agent.HandleFireAsync(new ScheduledDispatchFireCommand
+        {
+            ScheduledFireAt = Timestamp.FromDateTimeOffset(scheduledFireAt),
+            Manual = true,
+        });
+
+        agent.State.Target!.ServiceInvocation!.Auth.Should().NotBeNull();
+        agent.State.Target.ServiceInvocation.Auth!.ScopeOwnerNyxId!.Scope.Should().Be("proxy");
+        var auth = serviceInvocationDispatch.Auths.Should().ContainSingle().Which;
+        auth.Should().NotBeNull();
+        auth!.ScopeOwnerNyxId!.Scope.Should().Be("proxy");
+        auth.ScopeOwnerNyxId.OwnerSubject!.ExternalUserId.Should().Be("owner-nyx-user");
+    }
+
+    [Fact]
     public async Task HandleFireAsync_ForWorkflowServiceInvocationAuth_ShouldRequestWorkflowCallerCredentialProjection()
     {
         var eventStore = new TestEventStore();


### PR DESCRIPTION
## Summary
- Preserve existing service invocation auth when schedule ensure/update omits auth, preventing workflow self-reschedule from clearing NyxID credentials.
- Add actor-level configure/fire diagnostics for schedule auth state.
- Cover the auth-preservation path in ScheduledDispatchGAgent tests.

## Test plan
- [x] dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --nologo --no-restore --filter ScheduledDispatchGAgentTests
- [x] bash tools/ci/test_stability_guards.sh
- [x] git diff --check origin/feature/integrate...HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)