### PR TITLE
Fix workflow automation recurring prompt submission

### DIFF
--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -657,8 +657,10 @@ const enUSMessages = {
   'teams.automations.form.displayName': 'Name',
   'teams.automations.form.displayNameAria': 'Automation name',
   'teams.automations.form.displayNamePlaceholder': 'Daily escalation digest',
+  'teams.automations.form.clearPromptConfirm':
+    'Save this automation without a recurring prompt',
   'teams.automations.form.editPromptHint':
-    'Optional: leave it blank to save without a recurring prompt.',
+    'Saved prompts are not shown here. Enter a new prompt to replace it, or confirm saving without one.',
   'teams.automations.form.editTitle': 'Edit automation',
   'teams.automations.form.enabled': 'Enabled',
   'teams.automations.form.identityMissing':
@@ -709,6 +711,8 @@ const enUSMessages = {
   'teams.automations.messages.disableSuccess': 'Automation paused.',
   'teams.automations.messages.enableSuccess': 'Automation resumed.',
   'teams.automations.messages.previewFailed': 'Preview failed: {message}',
+  'teams.automations.messages.promptClearRequired':
+    'Confirm clearing the recurring prompt before saving.',
   'teams.automations.messages.promptTooLong':
     'Recurring prompt must be {maxLength} characters or fewer.',
   'teams.automations.messages.runNowFailed': 'Run request failed: {message}',

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -618,7 +618,9 @@ const zhCNMessages = {
   'teams.automations.form.displayName': '名称',
   'teams.automations.form.displayNameAria': '自动化名称',
   'teams.automations.form.displayNamePlaceholder': '每日升级摘要',
-  'teams.automations.form.editPromptHint': '选填：留空也可以保存为无周期 Prompt。',
+  'teams.automations.form.clearPromptConfirm': '保存为无周期 Prompt',
+  'teams.automations.form.editPromptHint':
+    '已保存的 Prompt 不会在这里显示。输入新的 Prompt 会替换旧值，或确认保存为无周期 Prompt。',
   'teams.automations.form.editTitle': '编辑自动化',
   'teams.automations.form.enabled': '启用',
   'teams.automations.form.identityMissing': '正在等待这个成员的已发布服务身份。',
@@ -661,6 +663,8 @@ const zhCNMessages = {
   'teams.automations.messages.disableSuccess': '自动化已暂停。',
   'teams.automations.messages.enableSuccess': '自动化已恢复。',
   'teams.automations.messages.previewFailed': '预览失败：{message}',
+  'teams.automations.messages.promptClearRequired':
+    '请先确认清空周期 Prompt，再保存修改。',
   'teams.automations.messages.promptTooLong': '周期 Prompt 最多 {maxLength} 个字符。',
   'teams.automations.messages.runNowFailed': '立即运行请求失败：{message}',
   'teams.automations.messages.runNowSuccess': '已请求立即运行。',

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -2677,13 +2677,20 @@ describe("TeamDetailPage", () => {
     expect(within(editDialog).getByLabelText("时区")).toHaveValue("Asia/Shanghai");
     expect(within(editDialog).getByText("目标服务为 alpha-service。")).toBeTruthy();
     expect(
-      within(editDialog).getByText("选填：留空也可以保存为无周期 Prompt。"),
+      within(editDialog).getByText(
+        "已保存的 Prompt 不会在这里显示。输入新的 Prompt 会替换旧值，或确认保存为无周期 Prompt。",
+      ),
+    ).toBeTruthy();
+    expect(
+      within(editDialog).getByRole("checkbox", {
+        name: "保存为无周期 Prompt",
+      }),
     ).toBeTruthy();
 
     fireEvent.change(within(editDialog).getByLabelText("自动化名称"), {
       target: { value: "Daily escalation digest - edited" },
     });
-    fireEvent.change(within(editDialog).getByLabelText(/周期 Prompt/), {
+    fireEvent.change(within(editDialog).getByLabelText("周期 Prompt（选填）"), {
       target: { value: "Summarize edited escalations and owners." },
     });
     fireEvent.change(within(editDialog).getByLabelText("Cron 表达式"), {
@@ -2720,6 +2727,57 @@ describe("TeamDetailPage", () => {
     expect(JSON.stringify(payload)).not.toContain("member-team-alpha");
     expect(JSON.stringify(payload)).not.toContain("wf-team-alpha");
     expect(message.success).toHaveBeenCalledWith("自动化已更新。");
+  });
+
+  it("requires explicit confirmation before editing an automation to a blank recurring prompt", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha?tab=automations",
+    );
+    (scheduledDispatchApi.listAll as jest.Mock).mockResolvedValueOnce({
+      items: [mockCreateScheduledDispatchSummary()],
+      nextCursor: null,
+      totalCount: 1,
+    });
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    expect(await screen.findByText("Daily escalation digest")).toBeTruthy();
+    fireEvent.click(await screen.findByRole("button", { name: "编辑" }));
+
+    const editDialog = await screen.findByRole("dialog", { name: "编辑自动化" });
+    expect(within(editDialog).getByLabelText("周期 Prompt（选填）")).toHaveValue("");
+    fireEvent.change(within(editDialog).getByLabelText("自动化名称"), {
+      target: { value: "Daily escalation digest - renamed" },
+    });
+
+    fireEvent.click(within(editDialog).getByRole("button", { name: "保存修改" }));
+
+    expect(scheduledDispatchApi.update).not.toHaveBeenCalled();
+    expect(message.warning).toHaveBeenCalledWith(
+      "请先确认清空周期 Prompt，再保存修改。",
+    );
+
+    fireEvent.click(
+      within(editDialog).getByRole("checkbox", {
+        name: "保存为无周期 Prompt",
+      }),
+    );
+    fireEvent.click(within(editDialog).getByRole("button", { name: "保存修改" }));
+
+    await waitFor(() => {
+      expect(scheduledDispatchApi.update).toHaveBeenCalled();
+    });
+    const [, payload] = (scheduledDispatchApi.update as jest.Mock).mock.calls[0];
+    expect(payload).toEqual(
+      expect.objectContaining({
+        displayName: "Daily escalation digest - renamed",
+        workflowChatTarget: expect.objectContaining({
+          prompt: "",
+        }),
+      }),
+    );
   });
 
   it("keeps invoke disabled for workflow members that are not bound yet", async () => {

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
@@ -12,6 +12,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Button,
+  Checkbox,
   Input,
   Modal,
   Segmented,
@@ -664,6 +665,8 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
   const [createOpen, setCreateOpen] = React.useState(false);
   const [editingSchedule, setEditingSchedule] =
     React.useState<ScheduledDispatchSummary | null>(null);
+  const [editPromptClearConfirmed, setEditPromptClearConfirmed] =
+    React.useState(false);
   const [preview, setPreview] = React.useState<ScheduledDispatchPreview | null>(null);
   const [locallyDeletedScheduleIds, setLocallyDeletedScheduleIds] =
     React.useState<ReadonlySet<string>>(() => new Set());
@@ -768,6 +771,8 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
   const trimmedPromptLength = formState.prompt.trim().length;
   const promptTooLong =
     trimmedPromptLength > scheduledWorkflowPromptMaxLength;
+  const editPromptClearBlocked =
+    isEditingAutomation && trimmedPromptLength === 0 && !editPromptClearConfirmed;
   const cronPresets = React.useMemo(
     () => [
       {
@@ -1140,6 +1145,7 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
       showCreatedScheduleFeedback({ input, member, receipt });
       setCreateOpen(false);
       setPreview(null);
+      setEditPromptClearConfirmed(false);
       scheduleDelayedRefresh();
     },
   });
@@ -1172,6 +1178,7 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
       setCreateOpen(false);
       setEditingSchedule(null);
       setPreview(null);
+      setEditPromptClearConfirmed(false);
       await invalidateSchedules();
     },
   });
@@ -1254,6 +1261,7 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
   const openCreate = React.useCallback(() => {
     const member = selectedMember;
     setEditingSchedule(null);
+    setEditPromptClearConfirmed(false);
     setFormState({
       cronExpression: defaultCronExpression,
       displayName: "",
@@ -1276,6 +1284,7 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
         cronPresets.find((item) => item.cronExpression === cronExpression)?.value ??
         customPreset;
       setEditingSchedule(schedule);
+      setEditPromptClearConfirmed(false);
       setFormState({
         cronExpression,
         displayName: trimText(schedule.displayName),
@@ -1375,6 +1384,16 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
       );
       return;
     }
+    if (editPromptClearBlocked) {
+      void message.warning(
+        intl.formatMessage({
+          id: "teams.automations.messages.promptClearRequired",
+          defaultMessage:
+            "Confirm clearing the recurring prompt before saving.",
+        }),
+      );
+      return;
+    }
 
     const input: ScheduledDispatchConfigurationInput = {
       displayName:
@@ -1418,6 +1437,7 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
     formState.prompt,
     formState.timezone,
     intl,
+    editPromptClearBlocked,
     isEditingAutomation,
     serviceIdentitiesLoading,
     showCreatedScheduleFeedback,
@@ -2241,6 +2261,7 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
             setCreateOpen(false);
             setEditingSchedule(null);
             setPreview(null);
+            setEditPromptClearConfirmed(false);
           }
         }}
         onOk={handleSaveAutomation}
@@ -2370,7 +2391,13 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
                 autoSize={{ minRows: 4, maxRows: 7 }}
                 disabled={formSubmitting}
                 maxLength={scheduledWorkflowPromptMaxLength}
-                onChange={(event) => updateForm({ prompt: event.target.value })}
+                onChange={(event) => {
+                  const nextPrompt = event.target.value;
+                  updateForm({ prompt: nextPrompt });
+                  if (nextPrompt.trim().length > 0) {
+                    setEditPromptClearConfirmed(false);
+                  }
+                }}
                 placeholder={intl.formatMessage({
                   id: "teams.automations.form.promptPlaceholder",
                   defaultMessage:
@@ -2397,9 +2424,24 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
                   {intl.formatMessage({
                     id: "teams.automations.form.editPromptHint",
                     defaultMessage:
-                      "Optional: leave it blank to save without a recurring prompt.",
+                      "Saved prompts are not shown here. Enter a new prompt to replace it, or confirm saving without one.",
                   })}
                 </Typography.Text>
+              ) : null}
+              {isEditingAutomation && trimmedPromptLength === 0 ? (
+                <Checkbox
+                  checked={editPromptClearConfirmed}
+                  disabled={formSubmitting}
+                  onChange={(event) =>
+                    setEditPromptClearConfirmed(event.target.checked)
+                  }
+                >
+                  {intl.formatMessage({
+                    id: "teams.automations.form.clearPromptConfirm",
+                    defaultMessage:
+                      "Save this automation without a recurring prompt",
+                  })}
+                </Checkbox>
               ) : null}
             </div>
           </div>

--- a/apps/aevatar-console-web/src/shared/api/scheduledDispatchApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/scheduledDispatchApi.test.ts
@@ -78,6 +78,49 @@ describe("scheduledDispatchApi", () => {
     };
   }
 
+  function decodeChatRequestEventBase64(payloadBase64: string) {
+    const bytes = Uint8Array.from(Buffer.from(payloadBase64, "base64"));
+    const fields = new Map<number, string>();
+    let offset = 0;
+
+    const readVarint = () => {
+      let value = 0;
+      let shift = 0;
+      while (offset < bytes.length) {
+        const byte = bytes[offset++];
+        value |= (byte & 0x7f) << shift;
+        if ((byte & 0x80) === 0) {
+          return value;
+        }
+        shift += 7;
+      }
+      throw new Error("Invalid varint in ChatRequestEvent payload.");
+    };
+
+    while (offset < bytes.length) {
+      const tag = readVarint();
+      const fieldNumber = tag >> 3;
+      const wireType = tag & 0x7;
+      if (wireType !== 2) {
+        throw new Error(`Unsupported ChatRequestEvent wire type ${wireType}.`);
+      }
+
+      const length = readVarint();
+      const end = offset + length;
+      fields.set(
+        fieldNumber,
+        Buffer.from(bytes.slice(offset, end)).toString("utf8"),
+      );
+      offset = end;
+    }
+
+    return {
+      prompt: fields.get(1) ?? "",
+      sessionId: fields.get(2) ?? "",
+      scopeId: fields.get(5) ?? "",
+    };
+  }
+
   it("lists schedules through the backend schedules collection", async () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,
@@ -234,6 +277,40 @@ describe("scheduledDispatchApi", () => {
     expect(String(init.body)).not.toContain("memberId");
     expect(String(init.body)).not.toContain("workflowId");
     expect(String(init.body)).not.toContain("workflowChatTarget");
+  });
+
+  it("keeps the entered recurring prompt in the final create payload", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 202,
+      json: async () => createReceipt(),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await scheduledDispatchApi.create({
+      displayName: "Daily escalation digest",
+      cronExpression: "0 9 * * 1-5",
+      timezone: "Asia/Shanghai",
+      enabled: true,
+      workflowChatTarget: {
+        identity: {
+          tenantId: "scope-1",
+          appId: "default",
+          namespace: "default",
+          serviceId: "svc-alpha",
+        },
+        prompt: " Summarize escalations, blocked accounts, and follow-up owners. ",
+      },
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(String(init.body));
+    expect(decodeChatRequestEventBase64(body.serviceInvocation.payloadBase64)).toEqual(
+      expect.objectContaining({
+        prompt: "Summarize escalations, blocked accounts, and follow-up owners.",
+        scopeId: "scope-1",
+      }),
+    );
   });
 
   it("posts workflow chat as base64 service invocation when creating without a revision", async () => {
@@ -488,6 +565,40 @@ describe("scheduledDispatchApi", () => {
     expect(String(init.body)).not.toContain("memberId");
     expect(String(init.body)).not.toContain("workflowId");
     expect(String(init.body)).not.toContain("workflowChatTarget");
+  });
+
+  it("keeps the entered recurring prompt in the final update payload", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 202,
+      json: async () => createReceipt(),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await scheduledDispatchApi.update("sch-alpha", {
+      displayName: "Edited escalation digest",
+      cronExpression: "0 10 * * 1-5",
+      timezone: "Asia/Shanghai",
+      enabled: false,
+      workflowChatTarget: {
+        identity: {
+          tenantId: "scope-1",
+          appId: "default",
+          namespace: "default",
+          serviceId: "svc-alpha",
+        },
+        prompt: " Summarize changed escalations and follow-up owners. ",
+      },
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(String(init.body));
+    expect(decodeChatRequestEventBase64(body.serviceInvocation.payloadBase64)).toEqual(
+      expect.objectContaining({
+        prompt: "Summarize changed escalations and follow-up owners.",
+        scopeId: "scope-1",
+      }),
+    );
   });
 
   it("rejects oversized workflow prompts before storing the schedule payload", async () => {


### PR DESCRIPTION
## Problem

Workflow Automations exposes a `Recurring prompt (optional)` textarea, but the schedule request must carry that text inside the protobuf `ChatRequestEvent.prompt` encoded in `serviceInvocation.payloadBase64`.

## Solution

- Keep the frontend-only contract aligned with the `feature/integrate` schedule backend: recurring prompt text is submitted through `workflowChatTarget.prompt`, which `scheduledDispatchApi` encodes into `ChatRequestEvent.prompt` inside `serviceInvocation.payloadBase64`.
- Add regression coverage that decodes the final create/update HTTP body and asserts the encoded `ChatRequestEvent.prompt` is present.
- Keep edit mode simple: saved prompts are not shown in the edit modal; entering a new prompt replaces the stored prompt, while leaving it blank saves without a recurring prompt.
- Add page-level regression coverage for create/update prompt handoff and update localized copy.

## Impact Paths

- `apps/aevatar-console-web/src/shared/api/scheduledDispatchApi.test.ts`
- `apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx`
- `apps/aevatar-console-web/src/pages/teams/detail.test.tsx`
- `apps/aevatar-console-web/src/locales/en-US.ts`
- `apps/aevatar-console-web/src/locales/zh-CN.ts`

## Verification

- `./node_modules/.bin/jest --runInBand src/pages/teams/detail.test.tsx src/shared/api/scheduledDispatchApi.test.ts src/locales/catalog.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `bash tools/ci/test_stability_guards.sh`
- `git diff --check`

Closes #2403
