### PR TITLE
Expose scheduled dispatch prompts

### DIFF
--- a/src/platform/Aevatar.GAgentService.Abstractions/Schedules/ScheduledDispatchModels.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Schedules/ScheduledDispatchModels.cs
@@ -100,7 +100,7 @@ public sealed record ScheduledDispatchSummary(
     int FailureCount,
     IReadOnlyDictionary<string, string> Headers,
     string ScheduleActorId,
-    string Prompt,
+    string? Prompt = null,
     ScheduledDispatchScheduleKind ScheduleKind = ScheduledDispatchScheduleKind.Generic,
     bool Deleted = false);
 

--- a/src/platform/Aevatar.GAgentService.Abstractions/Schedules/ScheduledDispatchModels.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Schedules/ScheduledDispatchModels.cs
@@ -100,6 +100,7 @@ public sealed record ScheduledDispatchSummary(
     int FailureCount,
     IReadOnlyDictionary<string, string> Headers,
     string ScheduleActorId,
+    string Prompt,
     ScheduledDispatchScheduleKind ScheduleKind = ScheduledDispatchScheduleKind.Generic,
     bool Deleted = false);
 

--- a/src/platform/Aevatar.GAgentService.Projection/Projectors/ScheduledDispatchCurrentStateProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Projectors/ScheduledDispatchCurrentStateProjector.cs
@@ -1,3 +1,4 @@
+using Aevatar.AI.Abstractions;
 using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.CQRS.Projection.Core.Abstractions.Orchestration;
 using Aevatar.Foundation.Abstractions;
@@ -77,6 +78,7 @@ public sealed class ScheduledDispatchCurrentStateProjector
             ServiceKey = BuildServiceKey(serviceIdentity),
             ServiceId = serviceIdentity?.ServiceId ?? string.Empty,
             ServiceEndpointId = target.ServiceInvocation?.EndpointId ?? string.Empty,
+            Prompt = ExtractPrompt(target.ServiceInvocation?.Payload),
             TargetActorId = state.TargetActorId ?? string.Empty,
             Deleted = state.Deleted,
             StateVersion = stateEvent.Version,
@@ -93,6 +95,14 @@ public sealed class ScheduledDispatchCurrentStateProjector
             .ToDictionary(x => x.Key, x => x.Value, StringComparer.Ordinal);
         document.FireRecords.Add(CreateFireRecords(state));
         return document;
+    }
+
+    private static string ExtractPrompt(Any? payload)
+    {
+        if (payload == null || !payload.Is(ChatRequestEvent.Descriptor))
+            return string.Empty;
+
+        return payload.Unpack<ChatRequestEvent>().Prompt ?? string.Empty;
     }
 
     private static string BuildServiceKey(ServiceIdentity? serviceIdentity)

--- a/src/platform/Aevatar.GAgentService.Projection/Projectors/ScheduledDispatchCurrentStateProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Projectors/ScheduledDispatchCurrentStateProjector.cs
@@ -78,7 +78,7 @@ public sealed class ScheduledDispatchCurrentStateProjector
             ServiceKey = BuildServiceKey(serviceIdentity),
             ServiceId = serviceIdentity?.ServiceId ?? string.Empty,
             ServiceEndpointId = target.ServiceInvocation?.EndpointId ?? string.Empty,
-            Prompt = ExtractPrompt(target.ServiceInvocation?.Payload),
+            Prompt = ExtractPrompt(target.ServiceInvocation?.Payload, state.TriggerEnvelope),
             TargetActorId = state.TargetActorId ?? string.Empty,
             Deleted = state.Deleted,
             StateVersion = stateEvent.Version,
@@ -95,6 +95,22 @@ public sealed class ScheduledDispatchCurrentStateProjector
             .ToDictionary(x => x.Key, x => x.Value, StringComparer.Ordinal);
         document.FireRecords.Add(CreateFireRecords(state));
         return document;
+    }
+
+    private static string ExtractPrompt(Any? serviceInvocationPayload, EventEnvelope? triggerEnvelope)
+    {
+        var prompt = ExtractPrompt(serviceInvocationPayload);
+        return string.IsNullOrEmpty(prompt)
+            ? ExtractPromptFromTriggerEnvelope(triggerEnvelope)
+            : prompt;
+    }
+
+    private static string ExtractPromptFromTriggerEnvelope(EventEnvelope? triggerEnvelope)
+    {
+        if (triggerEnvelope?.Payload == null || !triggerEnvelope.Payload.Is(ServiceInvocationRequest.Descriptor))
+            return string.Empty;
+
+        return ExtractPrompt(triggerEnvelope.Payload.Unpack<ServiceInvocationRequest>().Payload);
     }
 
     private static string ExtractPrompt(Any? payload)

--- a/src/platform/Aevatar.GAgentService.Projection/Queries/ScheduledDispatchQueryPort.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Queries/ScheduledDispatchQueryPort.cs
@@ -125,6 +125,7 @@ public sealed class ScheduledDispatchQueryPort : IScheduledDispatchQueryPort
             document.FailureCount,
             document.Headers.ToDictionary(x => x.Key, x => x.Value, StringComparer.Ordinal),
             document.ScheduleActorId ?? string.Empty,
+            document.Prompt ?? string.Empty,
             ParseScheduleKind(document.ScheduleKind),
             document.Deleted);
 

--- a/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
+++ b/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
@@ -425,6 +425,7 @@ message ScheduledDispatchDocument {
   string schedule_kind = 30;
   bool deleted = 31;
   google.protobuf.Timestamp deleted_at_utc_value = 32;
+  string prompt = 33;
 }
 
 message ScheduledDispatchFireRecordDocument {

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Schedules/WorkflowScheduleModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Schedules/WorkflowScheduleModels.cs
@@ -54,7 +54,8 @@ public sealed record WorkflowScheduleSummary(
     IReadOnlyDictionary<string, string> Headers,
     string ScopeId,
     string ScheduleActorId,
-    string TargetActorId);
+    string TargetActorId,
+    string Prompt);
 
 public sealed record WorkflowScheduleFireRecord(
     DateTimeOffset ScheduledFireAt,

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Schedules/WorkflowScheduleModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Schedules/WorkflowScheduleModels.cs
@@ -4,7 +4,7 @@ public sealed record WorkflowScheduleConfiguration(
     string ScheduleId,
     string DisplayName,
     string WorkflowName,
-    string Prompt,
+    string? Prompt,
     string CronExpression,
     string Timezone,
     bool Enabled,
@@ -55,7 +55,7 @@ public sealed record WorkflowScheduleSummary(
     string ScopeId,
     string ScheduleActorId,
     string TargetActorId,
-    string Prompt);
+    string? Prompt = null);
 
 public sealed record WorkflowScheduleFireRecord(
     DateTimeOffset ScheduledFireAt,

--- a/src/workflow/Aevatar.Workflow.Application/Schedules/WorkflowScheduleApplicationService.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Schedules/WorkflowScheduleApplicationService.cs
@@ -146,7 +146,8 @@ public sealed class WorkflowScheduleApplicationService : IWorkflowScheduleApplic
             summary.Headers,
             ResolveScopeId(summary.ServiceKey),
             summary.ScheduleActorId,
-            summary.TargetActorId);
+            summary.TargetActorId,
+            summary.Prompt);
 
     private async Task EnsureWorkflowScheduleAsync(string scheduleId, CancellationToken ct)
     {

--- a/src/workflow/Aevatar.Workflow.Application/Schedules/WorkflowScheduleConfigurationMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Schedules/WorkflowScheduleConfigurationMapper.cs
@@ -48,7 +48,7 @@ internal static class WorkflowScheduleConfigurationMapper
     {
         var request = new ChatRequestEvent
         {
-            Prompt = NormalizeRequired(configuration.Prompt, nameof(configuration.Prompt)),
+            Prompt = NormalizeOptional(configuration.Prompt, string.Empty),
         };
 
         foreach (var (key, value) in BuildWorkflowScheduleHeaders(configuration))

--- a/test/Aevatar.GAgentService.Integration.Tests/ScheduledDispatchEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScheduledDispatchEndpointsTests.cs
@@ -1448,7 +1448,8 @@ public sealed class ScheduledDispatchEndpointsTests
                 0,
                 0,
                 new Dictionary<string, string>(),
-                "actor:schedule-1"),
+                "actor:schedule-1",
+                string.Empty),
             []);
 
     private static DefaultHttpContext CreateHttpContext(

--- a/test/Aevatar.GAgentService.Tests/Application/ScheduledDispatchApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScheduledDispatchApplicationServiceTests.cs
@@ -800,6 +800,7 @@ public sealed class ScheduledDispatchApplicationServiceTests
                     0,
                     new Dictionary<string, string>(),
                     "actor:schedule-1",
+                    string.Empty,
                     Deleted: true),
                 []),
         };

--- a/test/Aevatar.GAgentService.Tests/Projection/ScheduledDispatchCurrentStateProjectorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ScheduledDispatchCurrentStateProjectorTests.cs
@@ -50,6 +50,46 @@ public sealed class ScheduledDispatchCurrentStateProjectorTests
     }
 
     [Fact]
+    public async Task ProjectAsync_ShouldMaterializePromptFromTriggerEnvelope_WhenTargetPayloadIsMissing()
+    {
+        var store = new RecordingDocumentStore<ScheduledDispatchDocument>(x => x.Id);
+        var projector = new ScheduledDispatchCurrentStateProjector(
+            store,
+            new FixedProjectionClock(DateTimeOffset.Parse("2026-06-18T00:00:00+00:00")));
+        var identity = new ServiceIdentity
+        {
+            TenantId = "tenant",
+            AppId = "app",
+            Namespace = "default",
+            ServiceId = "svc",
+        };
+        var state = CreateServiceInvocationState("schedule-envelope", identity);
+        state.Target.ServiceInvocation.Payload = null;
+        state.TriggerEnvelope = new EventEnvelope
+        {
+            Payload = Any.Pack(new ServiceInvocationRequest
+            {
+                Identity = identity.Clone(),
+                EndpointId = "chat",
+                Payload = Any.Pack(new ChatRequestEvent { Prompt = "from envelope" }),
+            }),
+        };
+
+        await projector.ProjectAsync(
+            CreateContext("scheduled-dispatch:schedule-envelope"),
+            WrapCommitted(
+                state,
+                version: 10,
+                eventId: "evt-envelope",
+                observedAt: DateTimeOffset.Parse("2026-06-18T01:15:00+00:00")));
+
+        var document = await store.GetAsync("schedule-envelope");
+        document.Should().NotBeNull();
+        document!.Prompt.Should().Be("from envelope");
+        document.StateVersion.Should().Be(10);
+    }
+
+    [Fact]
     public async Task ProjectAsync_ShouldNotProjectDurableSenderBearerToken()
     {
         var store = new RecordingDocumentStore<ScheduledDispatchDocument>(x => x.Id);

--- a/test/Aevatar.GAgentService.Tests/Projection/ScheduledDispatchCurrentStateProjectorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ScheduledDispatchCurrentStateProjectorTests.cs
@@ -1,3 +1,4 @@
+using Aevatar.AI.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Services;
@@ -42,6 +43,8 @@ public sealed class ScheduledDispatchCurrentStateProjectorTests
         document!.ServiceKey.Should().Be(ServiceKeys.Build(identity));
         document.ServiceId.Should().Be("svc");
         document.ServiceEndpointId.Should().Be("chat");
+        document.Prompt.Should().Be("run");
+        document.ScheduleKind.Should().Be(ScheduledDispatchScheduleKind.Generic.ToString());
         document.StateVersion.Should().Be(9);
         document.LastEventId.Should().Be("evt-9");
     }
@@ -148,7 +151,7 @@ public sealed class ScheduledDispatchCurrentStateProjectorTests
                 {
                     Identity = identity.Clone(),
                     EndpointId = "chat",
-                    Payload = Any.Pack(new StringValue { Value = "run" }),
+                    Payload = Any.Pack(new ChatRequestEvent { Prompt = "run" }),
                 },
             },
         };

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowScheduleApplicationServiceTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowScheduleApplicationServiceTests.cs
@@ -714,6 +714,7 @@ public sealed class WorkflowScheduleApplicationServiceTests
         var detail = await service.GetAsync(" schedule-1 ");
 
         detail.Should().NotBeNull();
+        detail!.Schedule.Prompt.Should().Be("saved prompt");
         queryPort.GetScheduleIds.Should().Equal("schedule-1");
     }
 
@@ -750,8 +751,9 @@ public sealed class WorkflowScheduleApplicationServiceTests
 
         var result = await service.ListAsync(25, "cursor", includeTotalCount: true);
 
-        result.Items.Should().ContainSingle()
-            .Which.ScheduleId.Should().Be("workflow-1");
+        var summary = result.Items.Should().ContainSingle().Subject;
+        summary.ScheduleId.Should().Be("workflow-1");
+        summary.Prompt.Should().Be("saved prompt");
         result.NextCursor.Should().Be("next-workflow");
         result.TotalCount.Should().Be(1);
         queryPort.LastQuery.Should().Be(new ScheduledDispatchListQuery(
@@ -1101,6 +1103,7 @@ public sealed class WorkflowScheduleApplicationServiceTests
                 FailureCount: 0,
                 Headers: new Dictionary<string, string>(),
                 ScheduleActorId: string.Empty,
+                Prompt: "saved prompt",
                 ScheduleKind: ScheduledDispatchScheduleKind.Workflow),
             []);
 }

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowScheduleProjectionTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowScheduleProjectionTests.cs
@@ -1,3 +1,4 @@
+using Aevatar.AI.Abstractions;
 using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Schedules;
@@ -61,7 +62,7 @@ public sealed class WorkflowScheduleProjectionTests
                         ServiceId = "workflow-a",
                     },
                     EndpointId = "chat",
-                    Payload = Any.Pack(new StringValue { Value = "run it" }),
+                    Payload = Any.Pack(new ChatRequestEvent { Prompt = "run it" }),
                 },
             },
         };
@@ -121,6 +122,7 @@ public sealed class WorkflowScheduleProjectionTests
         document.ServiceKey.Should().Be("scope-1:default:default:workflow-a");
         document.ServiceId.Should().Be("workflow-a");
         document.ServiceEndpointId.Should().Be("chat");
+        document.Prompt.Should().Be("run it");
         document.TargetActorId.Should().Be("target-actor-1");
         document.StateVersion.Should().Be(7);
         document.LastEventId.Should().Be("evt-7");
@@ -201,6 +203,7 @@ public sealed class WorkflowScheduleProjectionTests
             {
                 ["caller"] = "kept",
             },
+            Prompt = "saved prompt",
             FireRecords =
             {
                 new ScheduledDispatchFireRecordDocument
@@ -241,6 +244,7 @@ public sealed class WorkflowScheduleProjectionTests
         detail.Schedule.Headers.Should().Contain("caller", "kept");
         detail.Schedule.ScheduleActorId.Should().BeEmpty();
         detail.Schedule.TargetActorId.Should().BeEmpty();
+        detail.Schedule.Prompt.Should().Be("saved prompt");
         detail.RecentFires.Select(x => x.IdempotencyKey).Should().Equal("newer", "older");
         detail.RecentFires[0].TargetActorId.Should().Be("run-actor");
         detail.RecentFires[0].CommandId.Should().Be("cmd");
@@ -298,6 +302,7 @@ public sealed class WorkflowScheduleProjectionTests
                         {
                             ["trace"] = "on",
                         },
+                        Prompt = "list prompt",
                         ScheduleActorId = "schedule-actor",
                         TargetActorId = "target-actor",
                     },
@@ -329,6 +334,7 @@ public sealed class WorkflowScheduleProjectionTests
         summary.DisplayName.Should().Be("Daily");
         summary.CronExpression.Should().Be("0 9 * * *");
         summary.Headers.Should().Contain("trace", "on");
+        summary.Prompt.Should().Be("list prompt");
         summary.ScheduleActorId.Should().Be("schedule-actor");
         summary.TargetActorId.Should().Be("target-actor");
     }


### PR DESCRIPTION
## Summary
- Closes #2418.
- Adds a generic `Prompt` field to scheduled dispatch read/query summaries and workflow schedule summaries.
- Materializes prompts from scheduled service invocation `ChatRequestEvent` payloads during projection without coupling to `ScheduleKind` or query-time replay.

## Test plan
- [x] `dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo --filter "ScheduledDispatchCurrentStateProjectorTests|ScheduledDispatchApplicationServiceTests"`
- [x] `dotnet test test/Aevatar.Workflow.Application.Tests/Aevatar.Workflow.Application.Tests.csproj --nologo --filter "WorkflowScheduleApplicationServiceTests"`
- [x] `dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo --filter "WorkflowScheduleProjectionTests"`
- [x] `bash tools/ci/test_stability_guards.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)