### PR TITLE
fix(channels): replace a stale Lark channel-bot on re-register so re-bind works

### DIFF
--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxApiResponseHelper.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxApiResponseHelper.cs
@@ -99,6 +99,70 @@ internal static class NyxApiResponseHelper
         }
     }
 
+    /// <summary>
+    /// Returns the ids of channel-bots in a Nyx <c>GET /api/v1/channel-bots</c> list response whose
+    /// Lark app (<c>platform_bot_id</c>, falling back to <c>app_id</c>) equals <paramref name="appId"/>.
+    /// Used to delete a stale channel-bot for the SAME Lark app before re-registering it: NyxID
+    /// rejects a second channel-bot for an app that already has one with <c>409 already-exists</c>,
+    /// which otherwise aborts a re-bind (the 502 the /channels wizard surfaced). Returns an empty
+    /// list when the response is an error envelope, unparseable, or carries no match.
+    /// </summary>
+    public static IReadOnlyList<string> ExtractChannelBotIdsForApp(string listResponse, string appId)
+    {
+        var normalizedAppId = appId?.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedAppId) || LooksLikeErrorEnvelope(listResponse))
+            return Array.Empty<string>();
+
+        try
+        {
+            using var document = JsonDocument.Parse(listResponse);
+            if (!TryGetBotArray(document.RootElement, out var bots))
+                return Array.Empty<string>();
+
+            var ids = new List<string>();
+            foreach (var bot in bots.EnumerateArray())
+            {
+                if (bot.ValueKind != JsonValueKind.Object)
+                    continue;
+
+                var botAppId = ReadNonEmptyString(bot, "platform_bot_id") ?? ReadNonEmptyString(bot, "app_id");
+                if (!string.Equals(botAppId, normalizedAppId, StringComparison.Ordinal))
+                    continue;
+
+                var id = ReadNonEmptyString(bot, "id");
+                if (id is not null)
+                    ids.Add(id);
+            }
+
+            return ids;
+        }
+        catch (JsonException)
+        {
+            return Array.Empty<string>();
+        }
+    }
+
+    private static bool TryGetBotArray(JsonElement root, out JsonElement array)
+    {
+        if (root.ValueKind == JsonValueKind.Array)
+        {
+            array = root;
+            return true;
+        }
+
+        foreach (var key in new[] { "data", "channel_bots", "channelBots", "items", "bots" })
+        {
+            if (root.TryGetProperty(key, out var element) && element.ValueKind == JsonValueKind.Array)
+            {
+                array = element;
+                return true;
+            }
+        }
+
+        array = default;
+        return false;
+    }
+
     private static string? NormalizeProxyUrlSlug(string? value)
     {
         var trimmed = value?.Trim();
@@ -163,7 +227,11 @@ internal static class NyxApiResponseHelper
         try
         {
             using var document = JsonDocument.Parse(response);
-            return document.RootElement.TryGetProperty("error", out var errorProp) &&
+            var root = document.RootElement;
+            // A list response (e.g. GET /api/v1/channel-bots) is a JSON array, never an error
+            // envelope; guard the object check so TryGetProperty does not throw on a non-object root.
+            return root.ValueKind == JsonValueKind.Object &&
+                   root.TryGetProperty("error", out var errorProp) &&
                    errorProp.ValueKind == JsonValueKind.True;
         }
         catch (JsonException)

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxLarkProvisioningService.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxLarkProvisioningService.cs
@@ -148,13 +148,35 @@ public sealed class NyxLarkProvisioningService : INyxLarkProvisioningService, IN
             // 502. NyxTelegramProvisioningService never persisted it either; the local mirror's
             // NyxReplyCredentialRef is left empty (it is not used by the live relay reply path).
 
-            channelBotId = await RegisterChannelBotAsync(
-                request.AccessToken,
-                request.AppId,
-                request.AppSecret,
-                request.VerificationToken,
-                label,
-                ct);
+            // Re-bind support: a fresh bot creates cleanly on the first try. But re-registering the
+            // SAME Lark app hits NyxID's 409 already-exists (a stale channel-bot from the prior
+            // registration), which previously aborted the whole flow as a 502 in the /channels
+            // wizard. On that conflict, delete the stale channel-bot(s) for this app on the user's
+            // behalf and retry once — so a re-bind completes without manual NyxID cleanup.
+            try
+            {
+                channelBotId = await RegisterChannelBotAsync(
+                    request.AccessToken,
+                    request.AppId,
+                    request.AppSecret,
+                    request.VerificationToken,
+                    label,
+                    ct);
+            }
+            catch (InvalidOperationException ex) when (IndicatesChannelBotAlreadyExists(ex))
+            {
+                _logger.LogInformation(
+                    "Nyx channel-bot already exists for Lark app; replacing it and retrying registration: appId={AppId}",
+                    request.AppId);
+                await RemoveExistingLarkChannelBotsForAppAsync(request.AccessToken, request.AppId, ct);
+                channelBotId = await RegisterChannelBotAsync(
+                    request.AccessToken,
+                    request.AppId,
+                    request.AppSecret,
+                    request.VerificationToken,
+                    label,
+                    ct);
+            }
             routeId = await CreateDefaultRouteAsync(request.AccessToken, channelBotId, apiKeyId, ct);
 
             // Connect the api-lark-bot NyxID proxy service (so card/typing calls can reach the Lark
@@ -261,6 +283,54 @@ public sealed class NyxLarkProvisioningService : INyxLarkProvisioningService, IN
                 callback_url = relayCallbackUrl,
             }),
             ct);
+    }
+
+    /// <summary>
+    /// True when a channel-bot creation failure is NyxID's "already exists" conflict for this Lark
+    /// app (HTTP 409), i.e. the re-bind case that should delete the stale bot and retry — not a
+    /// credential/transport error, which must surface as-is. The structured failure string carries
+    /// <c>nyx_status=409</c> (see <see cref="NyxApiResponseHelper.ExtractErrorDetail"/>).
+    /// </summary>
+    private static bool IndicatesChannelBotAlreadyExists(InvalidOperationException ex) =>
+        ex.Message.Contains("nyx_status=409", StringComparison.Ordinal) ||
+        ex.Message.Contains("already", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Best-effort removal of any existing Nyx channel-bot bound to the SAME Lark app before a
+    /// (re-)registration creates a fresh one. NyxID rejects a second channel-bot for an app that
+    /// already has one with 409 already-exists; deleting the stale bot first is what lets a user
+    /// re-bind the same bot from /channels without manual NyxID cleanup. Failures are logged and
+    /// swallowed — a bot that could not be removed simply resurfaces as the create 409 it would
+    /// have produced anyway, so this never makes a fresh registration worse.
+    /// </summary>
+    private async Task RemoveExistingLarkChannelBotsForAppAsync(string accessToken, string appId, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(appId))
+            return;
+
+        string listResponse;
+        try
+        {
+            listResponse = await _nyxClient.ListChannelBotsAsync(accessToken, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Could not list Nyx channel-bots before re-registration: appId={AppId}", appId);
+            return;
+        }
+
+        foreach (var existingBotId in NyxApiResponseHelper.ExtractChannelBotIdsForApp(listResponse, appId))
+        {
+            _logger.LogInformation(
+                "Replacing existing Nyx channel-bot for Lark app before re-registration: botId={BotId}, appId={AppId}",
+                existingBotId,
+                appId);
+            await NyxApiResponseHelper.TryRollbackAsync(
+                () => _nyxClient.DeleteChannelBotAsync(accessToken, existingBotId, ct),
+                "channel_bot_replace",
+                existingBotId,
+                _logger);
+        }
     }
 
     private async Task<string> RegisterChannelBotAsync(

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxApiResponseHelperTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxApiResponseHelperTests.cs
@@ -43,4 +43,29 @@ public class NyxApiResponseHelperTests
     {
         NyxApiResponseHelper.ExtractOptionalProxyUrlSlug(response).Should().BeNull();
     }
+
+    [Fact]
+    public void ExtractChannelBotIdsForApp_Returns_Ids_Matching_App_By_PlatformBotId_Or_AppId()
+    {
+        var response = """[{"id":"b1","platform_bot_id":"cli_x"},{"id":"b2","platform_bot_id":"cli_y"},{"id":"b3","app_id":"cli_x"}]""";
+        NyxApiResponseHelper.ExtractChannelBotIdsForApp(response, "cli_x")
+            .Should().BeEquivalentTo(new[] { "b1", "b3" });
+    }
+
+    [Fact]
+    public void ExtractChannelBotIdsForApp_Reads_Wrapped_Array_And_Ignores_NonMatches()
+    {
+        NyxApiResponseHelper.ExtractChannelBotIdsForApp("""{"data":[{"id":"b1","platform_bot_id":"cli_y"}]}""", "cli_x")
+            .Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("""{"error":true,"status":409}""")]   // Nyx error envelope
+    [InlineData("not-json")]                          // unparseable
+    [InlineData("[]")]                                // empty list
+    [InlineData("")]                                  // empty
+    public void ExtractChannelBotIdsForApp_Returns_Empty_On_Error_Or_NoMatch(string response)
+    {
+        NyxApiResponseHelper.ExtractChannelBotIdsForApp(response, "cli_x").Should().BeEmpty();
+    }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxLarkProvisioningServiceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxLarkProvisioningServiceTests.cs
@@ -203,6 +203,46 @@ public class NyxLarkProvisioningServiceTests
     }
 
     [Fact]
+    public async Task ProvisionAsync_Replaces_Existing_ChannelBot_On_409_Conflict_And_Retries()
+    {
+        // Re-binding the same Lark app: the first channel-bot create hits NyxID's 409 already-exists.
+        // The service deletes the stale channel-bot for THIS app (only the matching one) and retries,
+        // so a user can re-bind from /channels without manual NyxID cleanup (the 502 the wizard showed).
+        var handler = new RecordingHandler();
+        handler.Enqueue(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-1","full_key":"x"}""");
+        handler.Enqueue(HttpMethod.Post, "/api/v1/channel-bots", """{"error":true,"status":409,"message":"channel bot already exists"}""");
+        handler.Enqueue(HttpMethod.Get, "/api/v1/channel-bots", """[{"id":"old-bot","platform_bot_id":"cli_a1b2c3"},{"id":"other","platform_bot_id":"cli_zzz"}]""");
+        handler.Enqueue(HttpMethod.Delete, "/api/v1/channel-bots/old-bot", """{"ok":true}""");
+        handler.Enqueue(HttpMethod.Post, "/api/v1/channel-bots", """{"id":"bot-new"}""");
+        handler.Enqueue(HttpMethod.Post, "/api/v1/channel-conversations", """{"id":"route-1"}""");
+        handler.Enqueue(HttpMethod.Post, "/api/v1/keys", """{"id":"svc-1","slug":"api-lark-bot-2"}""");
+
+        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
+        actorRuntime.GetAsync(ChannelBotRegistrationGAgent.WellKnownId)
+            .Returns(Task.FromResult<IActor?>(Substitute.For<IActor>()));
+        ((IActorDispatchPort)actorRuntime).DispatchAsync(
+                ChannelBotRegistrationGAgent.WellKnownId,
+                Arg.Any<EventEnvelope>(),
+                Arg.Any<CancellationToken>())
+            .Returns(ActorDispatchPortTestSupport.AcceptAsync);
+
+        var service = new NyxLarkProvisioningService(
+            new NyxIdApiClient(
+                new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+                new HttpClient(handler)),
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            ChannelRegistrationCommandFacadeTestSupport.CreateFacade(actorRuntime, (IActorDispatchPort)actorRuntime),
+            Substitute.For<Microsoft.Extensions.Logging.ILogger<NyxLarkProvisioningService>>());
+
+        var result = await service.ProvisionAsync(BuildRequest(), CancellationToken.None);
+
+        result.Succeeded.Should().BeTrue();
+        result.NyxChannelBotId.Should().Be("bot-new");
+        // Only the channel-bot for THIS Lark app was deleted before the retry.
+        handler.Requests.Should().Contain(r => r.Method == HttpMethod.Delete && r.Path == "/api/v1/channel-bots/old-bot");
+    }
+
+    [Fact]
     public async Task ProvisionAsync_ShouldReject_WhenNyxBaseUrlIsNotConfigured()
     {
         var handler = new RecordingHandler();


### PR DESCRIPTION
## Problem
Re-binding the same Lark bot from `/admin#/channels` fails: the wizard's "创建 NyxID channel-bot" step hits NyxID's **409 already-exists** and the whole registration aborts as an HTTP 502 ("返回改凭据"). Root cause: aevatar's delete-registration only removes the local mirror — it leaves the NyxID channel-bot — so the re-create collides. (This is also why a user who "deleted + re-added" still saw the stale `api-lark-bot` slug: the re-bind never actually completed.)

## Fix (server-side; no /channels UI change)
In `NyxLarkProvisioningService`, when creating the channel-bot throws NyxID's 409 conflict (`IndicatesChannelBotAlreadyExists`), `RemoveExistingLarkChannelBotsForAppAsync` lists the channel-bots, deletes the one(s) bound to **this** Lark app (`platform_bot_id`/`app_id == app_id`) on the user's behalf, and retries the create once. A fresh bot never conflicts, so the happy path and existing tests are unchanged.

Also fixes `NyxApiResponseHelper.LooksLikeErrorEnvelope` throwing `InvalidOperationException` on a JSON **array** root (the channel-bots list): `TryGetProperty` on a non-object threw past its `JsonException`-only catch. Guarded with `ValueKind == Object`.

## Affected paths
- `agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxLarkProvisioningService.cs` (409 → replace + retry)
- `agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxApiResponseHelper.cs` (`ExtractChannelBotIdsForApp`; array-root guard)
- tests: `NyxLarkProvisioningServiceTests` (409-retry flow), `NyxApiResponseHelperTests` (parser)

## Validation
- `dotnet test …ChannelRuntime.Tests --filter "NyxLarkProvisioningServiceTests|NyxApiResponseHelperTests"` — **28 passed, 0 failed**
- `bash tools/ci/test_stability_guards.sh` — passed (incl. catch-observability, lark-agent-path)

## Scope
- Deletes only the conflicting **channel-bot** (clears the 409). The prior registration's orphaned api-key/route/service are harmless (the retry creates fresh ones; the per-bot proxy slug is captured by the already-merged #2388 fix). Cascade-cleaning those is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
