### PR TITLE
Remove recurring prompt clear confirmation

### DIFF
--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -657,10 +657,6 @@ const enUSMessages = {
   'teams.automations.form.displayName': 'Name',
   'teams.automations.form.displayNameAria': 'Automation name',
   'teams.automations.form.displayNamePlaceholder': 'Daily escalation digest',
-  'teams.automations.form.clearPromptConfirm':
-    'Save this automation without a recurring prompt',
-  'teams.automations.form.editPromptHint':
-    'Saved prompts are not shown here. Enter a new prompt to replace it, or confirm saving without one.',
   'teams.automations.form.editTitle': 'Edit automation',
   'teams.automations.form.enabled': 'Enabled',
   'teams.automations.form.identityMissing':
@@ -711,8 +707,6 @@ const enUSMessages = {
   'teams.automations.messages.disableSuccess': 'Automation paused.',
   'teams.automations.messages.enableSuccess': 'Automation resumed.',
   'teams.automations.messages.previewFailed': 'Preview failed: {message}',
-  'teams.automations.messages.promptClearRequired':
-    'Confirm clearing the recurring prompt before saving.',
   'teams.automations.messages.promptTooLong':
     'Recurring prompt must be {maxLength} characters or fewer.',
   'teams.automations.messages.runNowFailed': 'Run request failed: {message}',

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -618,9 +618,6 @@ const zhCNMessages = {
   'teams.automations.form.displayName': '名称',
   'teams.automations.form.displayNameAria': '自动化名称',
   'teams.automations.form.displayNamePlaceholder': '每日升级摘要',
-  'teams.automations.form.clearPromptConfirm': '保存为无周期 Prompt',
-  'teams.automations.form.editPromptHint':
-    '已保存的 Prompt 不会在这里显示。输入新的 Prompt 会替换旧值，或确认保存为无周期 Prompt。',
   'teams.automations.form.editTitle': '编辑自动化',
   'teams.automations.form.enabled': '启用',
   'teams.automations.form.identityMissing': '正在等待这个成员的已发布服务身份。',
@@ -663,8 +660,6 @@ const zhCNMessages = {
   'teams.automations.messages.disableSuccess': '自动化已暂停。',
   'teams.automations.messages.enableSuccess': '自动化已恢复。',
   'teams.automations.messages.previewFailed': '预览失败：{message}',
-  'teams.automations.messages.promptClearRequired':
-    '请先确认清空周期 Prompt，再保存修改。',
   'teams.automations.messages.promptTooLong': '周期 Prompt 最多 {maxLength} 个字符。',
   'teams.automations.messages.runNowFailed': '立即运行请求失败：{message}',
   'teams.automations.messages.runNowSuccess': '已请求立即运行。',

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -5805,6 +5805,20 @@ describe("StudioPage", () => {
         },
       ]);
     (studioApi.getScopeBinding as jest.Mock).mockResolvedValueOnce(null);
+    (studioApi.getMemberBindingRun as jest.Mock).mockResolvedValueOnce({
+      bindingRunId: "bind-member-workflow-1",
+      scopeId: "scope-1",
+      memberId: "workspace-demo",
+      status: "succeeded",
+      result: {
+        publishedServiceId: "default",
+        revisionId: "rev-2",
+        implementationKind: "workflow",
+        expectedActorId: "actor-default",
+      },
+      failure: null,
+      updatedAt: "2026-04-27T08:15:01Z",
+    });
     mockScopeRuntimeApi.getServiceRevisions.mockImplementation(
       async () =>
         mockBuildServiceRevisionCatalog({
@@ -5963,6 +5977,12 @@ describe("StudioPage", () => {
       scopeId: "scope-1",
       memberId: "draft1",
       status: "succeeded",
+      result: {
+        publishedServiceId: "draft1",
+        revisionId: "rev-draft1",
+        implementationKind: "workflow",
+        expectedActorId: "actor-draft1",
+      },
       failure: null,
       updatedAt: "2026-04-27T08:15:01Z",
     });

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -5168,17 +5168,24 @@ const StudioPage: React.FC = () => {
       queryKey: studioMembersQueryKey,
     });
     const servicesResult = await scopeServicesQuery.refetch();
+    const observedMemberBindingResult =
+      memberBindingRunOutcome?.kind === 'succeeded'
+        ? memberBindingRunOutcome.run.result
+        : null;
     const optimisticBoundServiceId =
+      trimOptional(observedMemberBindingResult?.publishedServiceId) ||
       trimOptional(buildPendingMemberSummary?.publishedServiceId) ||
       trimOptional(buildPendingBindCandidate.displayName) ||
       trimOptional(result?.displayName) ||
       trimOptional(result?.targetName) ||
       trimOptional(result?.workflowName);
     const boundServiceId =
+      trimOptional(observedMemberBindingResult?.publishedServiceId) ||
       trimOptional(result?.serviceId) ||
       resolveBoundServiceIdFromCatalog({
         services: servicesResult.data ?? [],
         candidates: [
+          observedMemberBindingResult?.publishedServiceId,
           buildPendingBindCandidate.displayName,
           buildPendingBindCandidate.kind === 'script'
             ? buildPendingBindCandidate.scriptId
@@ -5266,6 +5273,7 @@ const StudioPage: React.FC = () => {
           trimOptional(result?.displayName) ||
           trimOptional(buildPendingBindCandidate.displayName),
         revisionId:
+          trimOptional(observedMemberBindingResult?.revisionId) ||
           trimOptional(result?.revisionId) ||
           trimOptional(buildPendingMemberSummary?.lastBoundRevisionId),
         scopeId: resolvedStudioScopeId,
@@ -7846,8 +7854,10 @@ const StudioPage: React.FC = () => {
       trimOptional(workbenchPublishedServiceId);
     const memberPublishedServiceExists =
       Boolean(memberPublishedServiceId) &&
-      publishedScopeServices.some(
+      (publishedScopeServices.some(
         (service) => trimOptional(service.serviceId) === memberPublishedServiceId,
+      ) ||
+        trimOptional(recentlyBoundServiceId) === memberPublishedServiceId
       );
     if (memberPublishedServiceExists) {
       return;
@@ -7903,6 +7913,7 @@ const StudioPage: React.FC = () => {
     history,
     isStudioLocation,
     publishedScopeServices,
+    recentlyBoundServiceId,
     resolvedStudioScopeId,
     routeBuildFocus.kind,
     routeSelectedBackendMemberKey,

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -2677,15 +2677,10 @@ describe("TeamDetailPage", () => {
     expect(within(editDialog).getByLabelText("时区")).toHaveValue("Asia/Shanghai");
     expect(within(editDialog).getByText("目标服务为 alpha-service。")).toBeTruthy();
     expect(
-      within(editDialog).getByText(
-        "已保存的 Prompt 不会在这里显示。输入新的 Prompt 会替换旧值，或确认保存为无周期 Prompt。",
+      within(editDialog).queryByText(
+        "已保存的 Prompt 不会在这里显示。输入新的 Prompt 会替换旧值，留空保存则不带周期 Prompt。",
       ),
-    ).toBeTruthy();
-    expect(
-      within(editDialog).getByRole("checkbox", {
-        name: "保存为无周期 Prompt",
-      }),
-    ).toBeTruthy();
+    ).toBeNull();
 
     fireEvent.change(within(editDialog).getByLabelText("自动化名称"), {
       target: { value: "Daily escalation digest - edited" },
@@ -2727,57 +2722,6 @@ describe("TeamDetailPage", () => {
     expect(JSON.stringify(payload)).not.toContain("member-team-alpha");
     expect(JSON.stringify(payload)).not.toContain("wf-team-alpha");
     expect(message.success).toHaveBeenCalledWith("自动化已更新。");
-  });
-
-  it("requires explicit confirmation before editing an automation to a blank recurring prompt", async () => {
-    window.history.replaceState(
-      {},
-      "",
-      "/scopes/scope-1/teams/t-alpha?tab=automations",
-    );
-    (scheduledDispatchApi.listAll as jest.Mock).mockResolvedValueOnce({
-      items: [mockCreateScheduledDispatchSummary()],
-      nextCursor: null,
-      totalCount: 1,
-    });
-
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    expect(await screen.findByText("Daily escalation digest")).toBeTruthy();
-    fireEvent.click(await screen.findByRole("button", { name: "编辑" }));
-
-    const editDialog = await screen.findByRole("dialog", { name: "编辑自动化" });
-    expect(within(editDialog).getByLabelText("周期 Prompt（选填）")).toHaveValue("");
-    fireEvent.change(within(editDialog).getByLabelText("自动化名称"), {
-      target: { value: "Daily escalation digest - renamed" },
-    });
-
-    fireEvent.click(within(editDialog).getByRole("button", { name: "保存修改" }));
-
-    expect(scheduledDispatchApi.update).not.toHaveBeenCalled();
-    expect(message.warning).toHaveBeenCalledWith(
-      "请先确认清空周期 Prompt，再保存修改。",
-    );
-
-    fireEvent.click(
-      within(editDialog).getByRole("checkbox", {
-        name: "保存为无周期 Prompt",
-      }),
-    );
-    fireEvent.click(within(editDialog).getByRole("button", { name: "保存修改" }));
-
-    await waitFor(() => {
-      expect(scheduledDispatchApi.update).toHaveBeenCalled();
-    });
-    const [, payload] = (scheduledDispatchApi.update as jest.Mock).mock.calls[0];
-    expect(payload).toEqual(
-      expect.objectContaining({
-        displayName: "Daily escalation digest - renamed",
-        workflowChatTarget: expect.objectContaining({
-          prompt: "",
-        }),
-      }),
-    );
   });
 
   it("keeps invoke disabled for workflow members that are not bound yet", async () => {

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
@@ -12,7 +12,6 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Button,
-  Checkbox,
   Input,
   Modal,
   Segmented,
@@ -665,8 +664,6 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
   const [createOpen, setCreateOpen] = React.useState(false);
   const [editingSchedule, setEditingSchedule] =
     React.useState<ScheduledDispatchSummary | null>(null);
-  const [editPromptClearConfirmed, setEditPromptClearConfirmed] =
-    React.useState(false);
   const [preview, setPreview] = React.useState<ScheduledDispatchPreview | null>(null);
   const [locallyDeletedScheduleIds, setLocallyDeletedScheduleIds] =
     React.useState<ReadonlySet<string>>(() => new Set());
@@ -771,8 +768,6 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
   const trimmedPromptLength = formState.prompt.trim().length;
   const promptTooLong =
     trimmedPromptLength > scheduledWorkflowPromptMaxLength;
-  const editPromptClearBlocked =
-    isEditingAutomation && trimmedPromptLength === 0 && !editPromptClearConfirmed;
   const cronPresets = React.useMemo(
     () => [
       {
@@ -1145,7 +1140,6 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
       showCreatedScheduleFeedback({ input, member, receipt });
       setCreateOpen(false);
       setPreview(null);
-      setEditPromptClearConfirmed(false);
       scheduleDelayedRefresh();
     },
   });
@@ -1178,7 +1172,6 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
       setCreateOpen(false);
       setEditingSchedule(null);
       setPreview(null);
-      setEditPromptClearConfirmed(false);
       await invalidateSchedules();
     },
   });
@@ -1261,7 +1254,6 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
   const openCreate = React.useCallback(() => {
     const member = selectedMember;
     setEditingSchedule(null);
-    setEditPromptClearConfirmed(false);
     setFormState({
       cronExpression: defaultCronExpression,
       displayName: "",
@@ -1284,7 +1276,6 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
         cronPresets.find((item) => item.cronExpression === cronExpression)?.value ??
         customPreset;
       setEditingSchedule(schedule);
-      setEditPromptClearConfirmed(false);
       setFormState({
         cronExpression,
         displayName: trimText(schedule.displayName),
@@ -1384,17 +1375,6 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
       );
       return;
     }
-    if (editPromptClearBlocked) {
-      void message.warning(
-        intl.formatMessage({
-          id: "teams.automations.messages.promptClearRequired",
-          defaultMessage:
-            "Confirm clearing the recurring prompt before saving.",
-        }),
-      );
-      return;
-    }
-
     const input: ScheduledDispatchConfigurationInput = {
       displayName:
         formState.displayName.trim() ||
@@ -1437,7 +1417,6 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
     formState.prompt,
     formState.timezone,
     intl,
-    editPromptClearBlocked,
     isEditingAutomation,
     serviceIdentitiesLoading,
     showCreatedScheduleFeedback,
@@ -2261,7 +2240,6 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
             setCreateOpen(false);
             setEditingSchedule(null);
             setPreview(null);
-            setEditPromptClearConfirmed(false);
           }
         }}
         onOk={handleSaveAutomation}
@@ -2391,13 +2369,7 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
                 autoSize={{ minRows: 4, maxRows: 7 }}
                 disabled={formSubmitting}
                 maxLength={scheduledWorkflowPromptMaxLength}
-                onChange={(event) => {
-                  const nextPrompt = event.target.value;
-                  updateForm({ prompt: nextPrompt });
-                  if (nextPrompt.trim().length > 0) {
-                    setEditPromptClearConfirmed(false);
-                  }
-                }}
+                onChange={(event) => updateForm({ prompt: event.target.value })}
                 placeholder={intl.formatMessage({
                   id: "teams.automations.form.promptPlaceholder",
                   defaultMessage:
@@ -2419,30 +2391,6 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
                   { maxLength: scheduledWorkflowPromptMaxLength },
                 )}
               </Typography.Text>
-              {isEditingAutomation ? (
-                <Typography.Text style={{ fontSize: 12 }} type="secondary">
-                  {intl.formatMessage({
-                    id: "teams.automations.form.editPromptHint",
-                    defaultMessage:
-                      "Saved prompts are not shown here. Enter a new prompt to replace it, or confirm saving without one.",
-                  })}
-                </Typography.Text>
-              ) : null}
-              {isEditingAutomation && trimmedPromptLength === 0 ? (
-                <Checkbox
-                  checked={editPromptClearConfirmed}
-                  disabled={formSubmitting}
-                  onChange={(event) =>
-                    setEditPromptClearConfirmed(event.target.checked)
-                  }
-                >
-                  {intl.formatMessage({
-                    id: "teams.automations.form.clearPromptConfirm",
-                    defaultMessage:
-                      "Save this automation without a recurring prompt",
-                  })}
-                </Checkbox>
-              ) : null}
             </div>
           </div>
 


### PR DESCRIPTION
## Problem
PR #2417 fixed recurring prompt submission, but edit mode added an extra checkbox for saving without a recurring prompt. The requested UX is simpler: no extra checkbox.

## Solution
- Remove the edit-mode recurring prompt clear confirmation checkbox.
- Remove the related warning and locale keys.
- Keep edit mode behavior simple: entering a new prompt replaces the saved prompt, and leaving it blank saves without a recurring prompt.
- Update page-level regression expectations.

## Impact
Frontend only, limited to `apps/aevatar-console-web`. No backend changes.

## Verification
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/jest --runInBand src/pages/teams/detail.test.tsx src/shared/api/scheduledDispatchApi.test.ts src/locales/catalog.test.ts`
- `bash tools/ci/test_stability_guards.sh`
- `git diff --check origin/dev..HEAD`

Follow-up to #2417 / #2403.