### PR TITLE
fix(channel): route Lark card reply through the inbound bot's proxy slug (fix cross-talk)

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
@@ -392,6 +392,15 @@ message TransportExtras {
   // The Lark operator `union_id` (`on_*`) for card action callbacks. Kept separate from the
   // sender union id so prompts can distinguish card operator facts from ordinary message senders.
   string nyx_lark_operator_union_id = 13;
+  // The NyxID outbound proxy slug of the inbound channel-bot that received this turn (resolved
+  // from the matched channel-bot registration by `nyx_agent_api_key_id`). This is the per-bot
+  // routing target (e.g. `api-lark-bot-4`), distinct from the generic process-wide default. The
+  // outbound CardKit/im reply MUST proxy through this slug so a reply to one bot is delivered by
+  // that bot's own NyxID app and not a sibling bot under the same account. A typed field (not a
+  // metadata bag) because it controls outbound routing and is resolved once at the runner boundary
+  // alongside `nyx_registration_scope_id`. Empty for non-relay traffic or when the registration
+  // did not record a slug, in which case downstream falls back to the configured default.
+  string nyx_provider_slug = 14;
 }
 
 // Represents one normalized activity flowing through the channel pipeline.

--- a/agents/Aevatar.GAgents.NyxidChat/ChannelCardConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelCardConversationTurnRunner.cs
@@ -22,16 +22,41 @@ public sealed class ChannelCardConversationTurnRunner : IConversationCardTurnRun
 
     private readonly ILarkCardKitClient _cardKit;
     private readonly ILarkNyxClient _larkClient;
+    private readonly ILarkOutboundClientFactory? _outboundClientFactory;
     private readonly ILogger<ChannelCardConversationTurnRunner> _logger;
 
     public ChannelCardConversationTurnRunner(
         ILarkCardKitClient cardKit,
         ILarkNyxClient larkClient,
         ILogger<ChannelCardConversationTurnRunner> logger)
+        : this(cardKit, larkClient, outboundClientFactory: null, logger)
+    {
+    }
+
+    public ChannelCardConversationTurnRunner(
+        ILarkCardKitClient cardKit,
+        ILarkNyxClient larkClient,
+        ILarkOutboundClientFactory? outboundClientFactory,
+        ILogger<ChannelCardConversationTurnRunner> logger)
     {
         _cardKit = cardKit ?? throw new ArgumentNullException(nameof(cardKit));
         _larkClient = larkClient ?? throw new ArgumentNullException(nameof(larkClient));
+        _outboundClientFactory = outboundClientFactory;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    // Resolves the CardKit/im clients bound to the inbound bot's outbound proxy slug (carried on the
+    // reply activity's TransportExtras). Falls back to the configured-default singletons when no
+    // factory is wired or the activity has no slug. This is what makes a card reply proxy through the
+    // bot that received the inbound turn instead of the process-wide default `api-lark-bot`.
+    private (ILarkCardKitClient CardKit, ILarkNyxClient Lark) ResolveOutboundClients(ChatActivity? activity)
+    {
+        var slug = activity?.TransportExtras?.NyxProviderSlug?.Trim();
+        if (_outboundClientFactory is null || string.IsNullOrEmpty(slug))
+            return (_cardKit, _larkClient);
+
+        return (_outboundClientFactory.ResolveCardKitClient(slug),
+                _outboundClientFactory.ResolveNyxClient(slug));
     }
 
     public async Task<ConversationCardCreateResult> RunCardCreateAsync(
@@ -48,6 +73,8 @@ public sealed class ChannelCardConversationTurnRunner : IConversationCardTurnRun
         if (token is null)
             return ConversationCardCreateResult.Failed("token_missing", "NyxID user access token is missing on the activity's TransportExtras.");
 
+        var (cardKit, larkClient) = ResolveOutboundClients(chunk.Activity);
+
         // 1. Allocate a CardKit entity holding an empty streaming element. The first chunk's
         //    text lands via StreamElementContentAsync (step 3) so the card_json schema and
         //    the streaming wire format stay decoupled.
@@ -55,7 +82,7 @@ public sealed class ChannelCardConversationTurnRunner : IConversationCardTurnRun
         string createResponse;
         try
         {
-            createResponse = await _cardKit.CreateCardAsync(
+            createResponse = await cardKit.CreateCardAsync(
                 token,
                 new LarkCardKitCreateRequest("card_json", initialCardJson),
                 ct);
@@ -78,7 +105,7 @@ public sealed class ChannelCardConversationTurnRunner : IConversationCardTurnRun
         var contentJson = JsonSerializer.Serialize(
             new { type = "card", data = new { card_id = cardId } },
             JsonOptions);
-        var bindResult = await BindCardToConversationAsync(token, chunk, cardId, contentJson, ct);
+        var bindResult = await BindCardToConversationAsync(larkClient, token, chunk, cardId, contentJson, ct);
         if (!bindResult.Success)
             return bindResult;
 
@@ -93,7 +120,7 @@ public sealed class ChannelCardConversationTurnRunner : IConversationCardTurnRun
         string firstStreamResponse;
         try
         {
-            firstStreamResponse = await _cardKit.StreamElementContentAsync(
+            firstStreamResponse = await cardKit.StreamElementContentAsync(
                 token,
                 new LarkCardKitStreamElementContentRequest(
                     CardId: cardId,
@@ -106,7 +133,7 @@ public sealed class ChannelCardConversationTurnRunner : IConversationCardTurnRun
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "CardKit first stream threw for correlation={CorrelationId}, card_id={CardId}", chunk.CorrelationId, cardId);
-            await TryBestEffortCloseStreamingAsync(token, cardId, sequence: 2, ct).ConfigureAwait(false);
+            await TryBestEffortCloseStreamingAsync(cardKit, token, cardId, sequence: 2, ct).ConfigureAwait(false);
             return ConversationCardCreateResult.PostSendFailed(
                 cardId,
                 cardMessageId,
@@ -116,7 +143,7 @@ public sealed class ChannelCardConversationTurnRunner : IConversationCardTurnRun
 
         if (LarkProxyResponseParser.TryParseError(firstStreamResponse, out var firstStreamError))
         {
-            await TryBestEffortCloseStreamingAsync(token, cardId, sequence: 2, ct).ConfigureAwait(false);
+            await TryBestEffortCloseStreamingAsync(cardKit, token, cardId, sequence: 2, ct).ConfigureAwait(false);
             return ClassifyPostSendFailure(cardId, cardMessageId, "card_first_stream_failed", firstStreamError);
         }
 
@@ -129,11 +156,11 @@ public sealed class ChannelCardConversationTurnRunner : IConversationCardTurnRun
     /// chat does not show a perpetually-loading bubble. Failures are logged and swallowed —
     /// the parent operation has already failed; this is a UX cleanup, not a correctness gate.
     /// </summary>
-    private async Task TryBestEffortCloseStreamingAsync(string token, string cardId, long sequence, CancellationToken ct)
+    private async Task TryBestEffortCloseStreamingAsync(ILarkCardKitClient cardKit, string token, string cardId, long sequence, CancellationToken ct)
     {
         try
         {
-            await _cardKit.SetCardSettingsAsync(
+            await cardKit.SetCardSettingsAsync(
                 token,
                 new LarkCardKitSettingsRequest(
                     CardId: cardId,
@@ -164,10 +191,12 @@ public sealed class ChannelCardConversationTurnRunner : IConversationCardTurnRun
         if (token is null)
             return ConversationCardStreamResult.Failed("token_missing", "NyxID user access token is missing on the activity's TransportExtras.");
 
+        var (cardKit, _) = ResolveOutboundClients(chunk.Activity);
+
         string response;
         try
         {
-            response = await _cardKit.StreamElementContentAsync(
+            response = await cardKit.StreamElementContentAsync(
                 token,
                 new LarkCardKitStreamElementContentRequest(
                     CardId: cardId,
@@ -205,6 +234,8 @@ public sealed class ChannelCardConversationTurnRunner : IConversationCardTurnRun
         if (token is null)
             return ConversationCardFinalizeResult.Failed("token_missing", "NyxID user access token is missing on the reference activity's TransportExtras.");
 
+        var (cardKit, _) = ResolveOutboundClients(referenceActivity);
+
         // 1. If final text drifted from the last flushed interim, write it before closing
         //    streaming mode. Order matters: closing streaming first would freeze the cursor
         //    on the stale text. Track whether the trailing write actually landed so the
@@ -215,7 +246,7 @@ public sealed class ChannelCardConversationTurnRunner : IConversationCardTurnRun
         {
             try
             {
-                var streamFinalResponse = await _cardKit.StreamElementContentAsync(
+                var streamFinalResponse = await cardKit.StreamElementContentAsync(
                     token,
                     new LarkCardKitStreamElementContentRequest(
                         CardId: cardId,
@@ -239,7 +270,7 @@ public sealed class ChannelCardConversationTurnRunner : IConversationCardTurnRun
         // 2. Close the card's streaming mode so the typewriter cursor disappears.
         try
         {
-            var settingsResponse = await _cardKit.SetCardSettingsAsync(
+            var settingsResponse = await cardKit.SetCardSettingsAsync(
                 token,
                 new LarkCardKitSettingsRequest(
                     CardId: cardId,
@@ -297,6 +328,7 @@ public sealed class ChannelCardConversationTurnRunner : IConversationCardTurnRun
     }
 
     private async Task<ConversationCardCreateResult> BindCardToConversationAsync(
+        ILarkNyxClient larkClient,
         string token,
         LlmReplyCardStreamChunkEvent chunk,
         string cardId,
@@ -313,7 +345,7 @@ public sealed class ChannelCardConversationTurnRunner : IConversationCardTurnRun
         {
             if (shouldReplyInThread)
             {
-                response = await _larkClient.ReplyToMessageAsync(
+                response = await larkClient.ReplyToMessageAsync(
                     token,
                     new LarkReplyMessageRequest(
                         MessageId: inboundMessageId!,
@@ -329,7 +361,7 @@ public sealed class ChannelCardConversationTurnRunner : IConversationCardTurnRun
                 if (receiveTarget is null)
                     return ConversationCardCreateResult.Failed("receive_target_missing", "Lark chat_id and union_id are both missing on TransportExtras.");
 
-                response = await _larkClient.SendMessageAsync(
+                response = await larkClient.SendMessageAsync(
                     token,
                     new LarkSendMessageRequest(
                         TargetType: receiveTarget.Value.ReceiveIdType,

--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -2170,6 +2170,18 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
             inboundEvent.Text,
             inboundEvent.Platform,
             _identityBindingQueryPort is null || senderBinding is not null);
+        // Stamp the inbound bot's outbound proxy slug onto the request activity so the deferred
+        // reply run (and its CardKit/im streaming sender) proxies through the bot that RECEIVED
+        // this turn, not the process-wide default. Without this, the singleton Lark clients route
+        // every card reply through the generic `api-lark-bot` slug, so a DM to one bot is answered
+        // by a sibling bot under the same NyxID account. Typed TransportExtras field, populated here
+        // where the matched registration is in hand (mirrors NyxRegistrationScopeId at ingress).
+        var inboundProviderSlug = NormalizeOptional(registration.NyxProviderSlug);
+        if (inboundProviderSlug is not null)
+        {
+            requestActivity.TransportExtras ??= new TransportExtras();
+            requestActivity.TransportExtras.NyxProviderSlug = inboundProviderSlug;
+        }
         var request = new NeedsLlmReplyEvent
         {
             CorrelationId = activity.Id,

--- a/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
@@ -99,6 +99,10 @@ public static class ServiceCollectionExtensions
                 return new ChannelCardConversationTurnRunner(
                     cardKit,
                     lark,
+                    // Routes each card reply through the inbound bot's own NyxID proxy slug (carried on
+                    // the reply activity's TransportExtras) instead of the process-wide default, so a DM
+                    // to one bot is answered by that bot's app and not a sibling under the same account.
+                    sp.GetService<ILarkOutboundClientFactory>(),
                     sp.GetRequiredService<ILogger<ChannelCardConversationTurnRunner>>());
             }));
         }

--- a/src/Aevatar.AI.ToolProviders.Lark/ILarkOutboundClientFactory.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/ILarkOutboundClientFactory.cs
@@ -1,0 +1,94 @@
+using Aevatar.AI.ToolProviders.NyxId;
+
+namespace Aevatar.AI.ToolProviders.Lark;
+
+/// <summary>
+/// Builds Lark CardKit / im clients bound to a specific NyxID outbound proxy slug.
+/// </summary>
+/// <remarks>
+/// The Lark wire clients (<see cref="ILarkCardKitClient"/> / <see cref="ILarkNyxClient"/>) bake the
+/// proxy slug into their options, so the DI-registered singletons are pinned to one slug (the
+/// configured default, <c>api-lark-bot</c>). A relayed reply must instead proxy through the slug of
+/// the channel-bot that received the inbound turn (e.g. <c>api-lark-bot-4</c>), otherwise a DM to one
+/// bot is delivered by a sibling bot under the same NyxID account. This factory lets the per-turn
+/// reply path obtain wire clients bound to that inbound slug while keeping the single shared wire
+/// implementation. When the slug is null/empty the factory yields the default-slug clients.
+/// </remarks>
+public interface ILarkOutboundClientFactory
+{
+    /// <summary>
+    /// Returns a CardKit client whose proxy calls target <paramref name="providerSlug"/>. A
+    /// null/blank slug yields the configured-default client.
+    /// </summary>
+    ILarkCardKitClient ResolveCardKitClient(string? providerSlug);
+
+    /// <summary>
+    /// Returns an im/messages client whose proxy calls target <paramref name="providerSlug"/>. A
+    /// null/blank slug yields the configured-default client.
+    /// </summary>
+    ILarkNyxClient ResolveNyxClient(string? providerSlug);
+}
+
+/// <summary>
+/// Default <see cref="ILarkOutboundClientFactory"/>. Reuses the configured-default singleton clients
+/// when the requested slug matches the configured default (or is absent), and otherwise constructs a
+/// per-slug client over the shared <see cref="NyxIdApiClient"/>. Construction is the only
+/// per-slug work; no business state is held, so building on demand keeps the slug as a pure routing
+/// derivation rather than a process-local fact source.
+/// </summary>
+public sealed class LarkOutboundClientFactory : ILarkOutboundClientFactory
+{
+    private readonly LarkToolOptions _options;
+    private readonly NyxIdApiClient _nyxClient;
+    private readonly ILarkCardKitClient _defaultCardKitClient;
+    private readonly ILarkNyxClient _defaultNyxClient;
+
+    public LarkOutboundClientFactory(
+        LarkToolOptions options,
+        NyxIdApiClient nyxClient,
+        ILarkCardKitClient defaultCardKitClient,
+        ILarkNyxClient defaultNyxClient)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _nyxClient = nyxClient ?? throw new ArgumentNullException(nameof(nyxClient));
+        _defaultCardKitClient = defaultCardKitClient ?? throw new ArgumentNullException(nameof(defaultCardKitClient));
+        _defaultNyxClient = defaultNyxClient ?? throw new ArgumentNullException(nameof(defaultNyxClient));
+    }
+
+    public ILarkCardKitClient ResolveCardKitClient(string? providerSlug) =>
+        UsesDefaultSlug(providerSlug)
+            ? _defaultCardKitClient
+            : new LarkCardKitClient(WithSlug(providerSlug!), _nyxClient);
+
+    public ILarkNyxClient ResolveNyxClient(string? providerSlug) =>
+        UsesDefaultSlug(providerSlug)
+            ? _defaultNyxClient
+            : new LarkNyxClient(WithSlug(providerSlug!), _nyxClient);
+
+    private bool UsesDefaultSlug(string? providerSlug)
+    {
+        var slug = providerSlug?.Trim();
+        return string.IsNullOrEmpty(slug) ||
+               string.Equals(slug, _options.ProviderSlug?.Trim(), StringComparison.Ordinal);
+    }
+
+    private LarkToolOptions WithSlug(string providerSlug) => new()
+    {
+        ProviderSlug = providerSlug.Trim(),
+        EnableMessageSend = _options.EnableMessageSend,
+        EnableMessageReply = _options.EnableMessageReply,
+        EnableMessageReactionCreate = _options.EnableMessageReactionCreate,
+        EnableMessageReactionList = _options.EnableMessageReactionList,
+        EnableMessageReactionDelete = _options.EnableMessageReactionDelete,
+        EnableMessageBatchGet = _options.EnableMessageBatchGet,
+        EnableChatLookup = _options.EnableChatLookup,
+        EnableSheetsAppendRows = _options.EnableSheetsAppendRows,
+        EnableApprovalsList = _options.EnableApprovalsList,
+        EnableApprovalsGet = _options.EnableApprovalsGet,
+        EnableApprovalsAct = _options.EnableApprovalsAct,
+        EnableDocxCreate = _options.EnableDocxCreate,
+        EnableBaseCreate = _options.EnableBaseCreate,
+        EnableResourceGrant = _options.EnableResourceGrant,
+        EnableWorkflowFileSubmit = _options.EnableWorkflowFileSubmit,
+    };
+}

--- a/src/Aevatar.AI.ToolProviders.Lark/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/ServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<NyxIdApiClient>();
         services.TryAddSingleton<ILarkNyxClient, LarkNyxClient>();
         services.TryAddSingleton<ILarkCardKitClient, LarkCardKitClient>();
+        services.TryAddSingleton<ILarkOutboundClientFactory, LarkOutboundClientFactory>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IAgentToolSource, LarkAgentToolSource>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IWorkflowConnectedServiceResourceFetchAdapter,

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCardConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCardConversationTurnRunnerTests.cs
@@ -231,6 +231,96 @@ public sealed class ChannelCardConversationTurnRunnerTests
         cardKit.SettingsCalls[0].Request.SettingsJson.Should().Be("""{"config":{"streaming_mode":false}}""");
     }
 
+    [Fact]
+    public async Task RunCardCreateAsync_ShouldProxyThroughInboundBotSlug_WhenActivityCarriesProviderSlug()
+    {
+        // The inbound DM was received by the bot whose NyxID proxy slug is api-lark-bot-4. The
+        // streamed card reply must proxy through THAT slug, not the process-wide default — otherwise
+        // a sibling bot under the same account answers the DM (the cross-talk bug).
+        var defaultCardKit = new RecordingCardKitClient();
+        var defaultLark = new RecordingLarkNyxClient();
+        var perBotCardKit = new RecordingCardKitClient();
+        var perBotLark = new RecordingLarkNyxClient();
+        var factory = new RecordingOutboundClientFactory(
+            defaultCardKit,
+            defaultLark,
+            new Dictionary<string, (RecordingCardKitClient, RecordingLarkNyxClient)>
+            {
+                ["api-lark-bot-4"] = (perBotCardKit, perBotLark),
+            });
+        var runner = new ChannelCardConversationTurnRunner(
+            defaultCardKit,
+            defaultLark,
+            factory,
+            NullLogger<ChannelCardConversationTurnRunner>.Instance);
+
+        var result = await runner.RunCardCreateAsync(
+            BuildChunk(
+                "corr-card-slug-1",
+                BuildSanitizedActivity(
+                    scope: ConversationScope.DirectMessage,
+                    partition: "route-dm-1",
+                    scopeSegment: "dm",
+                    conversationIdentity: "ou_user_1",
+                    platformMessageId: "om_dm_1",
+                    providerSlug: "api-lark-bot-4")),
+            "streaming_main",
+            RuntimeContext("runtime-card-token-slug"),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        // The factory was asked for the inbound bot's slug, and the per-bot clients carried the calls.
+        factory.RequestedCardKitSlugs.Should().Contain("api-lark-bot-4");
+        factory.RequestedNyxSlugs.Should().Contain("api-lark-bot-4");
+        perBotCardKit.CreateCalls.Should().ContainSingle();
+        perBotCardKit.StreamCalls.Should().ContainSingle();
+        perBotLark.SendCalls.Should().ContainSingle();
+        // The default-slug singleton clients were never used for this reply.
+        defaultCardKit.CreateCalls.Should().BeEmpty();
+        defaultCardKit.StreamCalls.Should().BeEmpty();
+        defaultLark.SendCalls.Should().BeEmpty();
+        defaultLark.ReplyCalls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RunCardCreateAsync_ShouldUseDefaultClients_WhenActivityHasNoProviderSlug()
+    {
+        // No per-bot slug on the activity → fall back to the configured-default clients. The factory
+        // must not be consulted for a per-bot client in that case.
+        var defaultCardKit = new RecordingCardKitClient();
+        var defaultLark = new RecordingLarkNyxClient();
+        var factory = new RecordingOutboundClientFactory(
+            defaultCardKit,
+            defaultLark,
+            new Dictionary<string, (RecordingCardKitClient, RecordingLarkNyxClient)>());
+        var runner = new ChannelCardConversationTurnRunner(
+            defaultCardKit,
+            defaultLark,
+            factory,
+            NullLogger<ChannelCardConversationTurnRunner>.Instance);
+
+        var result = await runner.RunCardCreateAsync(
+            BuildChunk(
+                "corr-card-no-slug-1",
+                BuildSanitizedActivity(
+                    scope: ConversationScope.DirectMessage,
+                    partition: "route-dm-1",
+                    scopeSegment: "dm",
+                    conversationIdentity: "ou_user_1",
+                    platformMessageId: "om_dm_1",
+                    providerSlug: string.Empty)),
+            "streaming_main",
+            RuntimeContext("runtime-card-token-no-slug"),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        factory.RequestedCardKitSlugs.Should().BeEmpty();
+        factory.RequestedNyxSlugs.Should().BeEmpty();
+        defaultCardKit.CreateCalls.Should().ContainSingle();
+        defaultCardKit.StreamCalls.Should().ContainSingle();
+        defaultLark.SendCalls.Should().ContainSingle();
+    }
+
     private static ConversationTurnRuntimeContext RuntimeContext(string token) =>
         new(NyxRelayReplyToken: null, NyxUserAccessToken: token);
 
@@ -266,7 +356,8 @@ public sealed class ChannelCardConversationTurnRunnerTests
         string partition = "oc_group_chat_1",
         string scopeSegment = "group",
         string conversationIdentity = "oc_group_chat_1",
-        string platformMessageId = "om_inbound_1") =>
+        string platformMessageId = "om_inbound_1",
+        string providerSlug = "") =>
         new()
         {
             Id = "msg-card-runtime-token-1",
@@ -293,6 +384,7 @@ public sealed class ChannelCardConversationTurnRunnerTests
                 NyxPlatformMessageId = platformMessageId,
                 NyxLarkChatId = "oc_group_chat_1",
                 NyxLarkUnionId = "on_union_1",
+                NyxProviderSlug = providerSlug,
             },
         };
 
@@ -400,5 +492,39 @@ public sealed class ChannelCardConversationTurnRunnerTests
 
         public Task<string> UploadApprovalFileAsync(string token, LarkApprovalFileUploadRequest request, CancellationToken ct) =>
             throw new NotSupportedException();
+    }
+
+    private sealed class RecordingOutboundClientFactory : ILarkOutboundClientFactory
+    {
+        private readonly ILarkCardKitClient _defaultCardKit;
+        private readonly ILarkNyxClient _defaultLark;
+        private readonly IReadOnlyDictionary<string, (RecordingCardKitClient CardKit, RecordingLarkNyxClient Lark)> _perSlug;
+
+        public RecordingOutboundClientFactory(
+            ILarkCardKitClient defaultCardKit,
+            ILarkNyxClient defaultLark,
+            IReadOnlyDictionary<string, (RecordingCardKitClient, RecordingLarkNyxClient)> perSlug)
+        {
+            _defaultCardKit = defaultCardKit;
+            _defaultLark = defaultLark;
+            _perSlug = perSlug;
+        }
+
+        public List<string> RequestedCardKitSlugs { get; } = [];
+        public List<string> RequestedNyxSlugs { get; } = [];
+
+        public ILarkCardKitClient ResolveCardKitClient(string? providerSlug)
+        {
+            var slug = providerSlug?.Trim() ?? string.Empty;
+            RequestedCardKitSlugs.Add(slug);
+            return _perSlug.TryGetValue(slug, out var clients) ? clients.CardKit : _defaultCardKit;
+        }
+
+        public ILarkNyxClient ResolveNyxClient(string? providerSlug)
+        {
+            var slug = providerSlug?.Trim() ?? string.Empty;
+            RequestedNyxSlugs.Add(slug);
+            return _perSlug.TryGetValue(slug, out var clients) ? clients.Lark : _defaultLark;
+        }
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
@@ -315,6 +315,31 @@ public sealed class ChannelConversationTurnRunnerTests
     }
 
     [Fact]
+    public async Task RunInboundAsync_ShouldStampInboundBotProviderSlugOntoDeferredReplyActivity()
+    {
+        // Cross-talk regression: the deferred reply activity must carry the slug of the bot that
+        // RECEIVED the inbound turn (resolved from its registration), so the downstream CardKit/im
+        // streaming sender proxies through that bot's NyxID app. Without this typed TransportExtras
+        // field the card path falls back to the process-wide default slug and a sibling bot under the
+        // same account answers the DM.
+        var registration = BuildRegistrationEntry();
+        registration.NyxProviderSlug = "api-lark-bot-4";
+        var registrationQueryPort = BuildRegistrationQueryPort(registration);
+        var adapter = new RecordingPlatformAdapter();
+        var runner = CreateRunner(registrationQueryPort, adapter);
+
+        var result = await runner.RunInboundAsync(
+            BuildInboundActivity("hello", "msg-slug-1", ConversationScope.DirectMessage, "ou_user_1"),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.LlmReplyRequest.Should().NotBeNull();
+        result.LlmReplyRequest!.Activity.Should().NotBeNull();
+        result.LlmReplyRequest.Activity!.TransportExtras.Should().NotBeNull();
+        result.LlmReplyRequest.Activity.TransportExtras!.NyxProviderSlug.Should().Be("api-lark-bot-4");
+    }
+
+    [Fact]
     public async Task RunInboundAsync_ShouldThreadRegistrationScopeIntoLlmReplyToolContext()
     {
         // Regression: a plain (non-"::") automation turn must carry the bot's registration scope


### PR DESCRIPTION
## Problem
Two Lark bots under one NyxID account: a DM to bot B (Aevatar3) is answered by bot A (Aevatar2). The streamed reply **card** goes out through the wrong Lark app.

## Root cause (proven against prod commit 4014a023)
The interactive Lark card reply (`ChannelCardConversationTurnRunner` → `ILarkCardKitClient`/`ILarkNyxClient`) builds the `/proxy/s/{slug}/…` URL from **`LarkToolOptions.ProviderSlug`**, a process-wide singleton hardcoded to `"api-lark-bot"` (`src/Aevatar.AI.ToolProviders.Lark/LarkToolOptions.cs:5`, used at `LarkCardKitClient.cs:56/76/107`, `LarkNyxClient.cs:39/62`). The card runner passes only the **token**, never a slug — so **every** card reply proxies through the single `api-lark-bot` slug regardless of which bot received the DM. NyxID maps `api-lark-bot` to a different app (Aevatar2) → cross-talk.

Live proof: a re-bound Aevatar3 has registration `nyx_provider_slug=api-lark-bot-4`, the inbound arrives on its api-key (`6aa813cb`), yet the outbound card still hit `/proxy/s/api-lark-bot/…`. PR #2388 stored the slug on the registration assuming the card path read it — it never did (`TransportExtras` had no slug field; the slug written to `NeedsLlmReplyEvent.Metadata` is consumed only by the SkillRunner tool).

## Fix
Thread the inbound bot's slug to the card runner as a typed per-turn fact and bind the wire clients to it:
1. `TransportExtras` gains `nyx_provider_slug` (proto).
2. `ChannelConversationTurnRunner.BuildLlmReplyRequestAsync` stamps `registration.NyxProviderSlug` onto the reply activity (rides through `TurnStreamingReplySink` → `chunk.Activity`, surviving the token-only sanitizers).
3. New narrow `ILarkOutboundClientFactory` returns CardKit/im clients bound to a given slug (falls back to the default singletons when absent/default).
4. `ChannelCardConversationTurnRunner` resolves per-turn clients from `activity.TransportExtras.NyxProviderSlug` for create/stream/finalize + im send.

A DM to Aevatar3 now proxies the card through `api-lark-bot-4` = Aevatar3's app.

## Validation (verbatim)
- `dotnet build src/Aevatar.Mainnet.Host.Api` — 120 projects, **0 errors**.
- New `ChannelCardConversationTurnRunnerTests` — **11 passed, 0 failed** (card proxies through the inbound slug; default singletons never used; fallback; stamp).
- Full `Aevatar.GAgents.ChannelRuntime.Tests` — **1499 passed, 0 failed**. `Aevatar.AI.ToolProviders.Lark.Tests` — **98 passed**.
- `tools/ci/test_stability_guards.sh` and `architecture_guards.sh` — both **EXIT=0**.

## Not yet verified / for review
- **No live prod verification** — code + tests + guards only. The only end-to-end proof is a real DM to Aevatar3 after deploy; I will pull logs and confirm the outbound uses `api-lark-bot-4` then.
- Scope is the interactive **card** path (the failing one). The non-card text-edit fallback already takes an explicit `target.NyxProviderSlug`.
- Adds a new narrow port `ILarkOutboundClientFactory` (with default impl + tests) — worth a reviewer's eye per CLAUDE.md interface-change guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
