### PR TITLE
fix(channels): real clipboard copy + stop fabricating a model option in the Lark wizard

### DIFF
--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/ChannelsPage.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/ChannelsPage.cs
@@ -104,6 +104,7 @@ internal static class ChannelsPage
   .copybtn { display:inline-flex; align-items:center; gap:5px; font-size:11.5px; color:var(--muted); background:var(--panel-2); border:1px solid var(--border); border-radius:var(--r-sm); padding:4px 9px; white-space:nowrap; }
   .copybtn:hover { color:var(--fg); border-color:var(--muted-2); }
   .copybtn.done { color:var(--ok); border-color:color-mix(in oklab,var(--ok) 40%,transparent); }
+  .copybtn.err { color:var(--err); border-color:color-mix(in oklab,var(--err) 40%,transparent); }
 
   /* =========================================================================
      Top bar (thin header) — 同 studio/observatory topbar 模式
@@ -974,8 +975,32 @@ function copyRow(label,value,extra){
   else { const b=el("button",{class:"copybtn","aria-label":"复制 "+label},`${ICON.copy}<span>复制</span>`); bindCopy(b,value); row.appendChild(b); }
   return row;
 }
+function flashCopyResult(btn,ok){
+  const sp=btn.querySelector("span"); const old=sp?sp.dataset.label||sp.textContent:"";
+  if(sp&&!sp.dataset.label)sp.dataset.label=old;
+  const cls=ok?"done":"err";
+  btn.classList.remove("done","err"); btn.classList.add(cls);
+  if(sp)sp.textContent=ok?"已复制":"复制失败";
+  setTimeout(()=>{ btn.classList.remove(cls); if(sp&&sp.dataset.label)sp.textContent=sp.dataset.label; },1400);
+}
+// Legacy fallback for non-secure contexts where navigator.clipboard is absent.
+function execCommandCopy(value){
+  const ta=document.createElement("textarea");
+  ta.value=value; ta.setAttribute("readonly",""); ta.style.position="fixed"; ta.style.opacity="0"; ta.style.pointerEvents="none";
+  document.body.appendChild(ta); ta.select(); ta.setSelectionRange(0,value.length);
+  let ok=false; try{ ok=document.execCommand("copy"); }catch(_){ ok=false; }
+  ta.remove(); return ok;
+}
 function bindCopy(btn,value){
-  btn.addEventListener("click",async()=>{ try{await navigator.clipboard.writeText(value);}catch(e){const ta=document.createElement("textarea");ta.value=value;document.body.appendChild(ta);ta.select();try{document.execCommand("copy");}catch(_){}ta.remove();} btn.classList.add("done"); const sp=btn.querySelector("span"); const old=sp?sp.textContent:""; if(sp)sp.textContent="已复制"; setTimeout(()=>{btn.classList.remove("done"); if(sp)sp.textContent=old;},1400); });
+  btn.addEventListener("click",()=>{
+    if(navigator.clipboard&&navigator.clipboard.writeText){
+      navigator.clipboard.writeText(value)
+        .then(()=>flashCopyResult(btn,true))
+        .catch(()=>flashCopyResult(btn,execCommandCopy(value)));
+    } else {
+      flashCopyResult(btn,execCommandCopy(value));
+    }
+  });
 }
 function footer(nodes){ const f=el("div",{class:"step-foot"}); nodes.forEach(n=>{ if(n==="spacer")f.appendChild(el("div",{class:"spacer"})); else f.appendChild(n); }); return f; }
 function btn(label,kind,icon,onClick,opts={}){ const b=el("button",{class:`btn btn-${kind}`},`${icon?icon+" ":""}<span>${label}</span>`); if(opts.disabled)b.disabled=true; if(onClick)b.addEventListener("click",onClick); return b; }
@@ -1194,13 +1219,20 @@ function renderStep4(){
   if(state.llmSel.route==null) state.llmSel.route = llm.savedRoute || llm.effectiveRoute || (routeOpts[0]&&routeOpts[0].routeValue) || "";
   const curRoute = state.llmSel.route;
   const modelsForRoute = (llm.modelGroupsByRoute||[]).filter(g=>g.routeValue===curRoute).flatMap(g=>g.models||[]);
-  if(state.llmSel.model==null) state.llmSel.model = llm.defaultModel || modelsForRoute[0] || DEFAULT_LLM.model;
+  // No fabricated model names: only offer what NyxID actually lists for this route.
+  // When the live catalog has a defaultModel it is a real option; otherwise the only honest
+  // choice is the platform default (empty value -> server resolves it on save).
+  const liveModels = modelsForRoute.length
+    ? modelsForRoute.slice()
+    : (llm.defaultModel ? [llm.defaultModel] : []);
+  if(state.llmSel.model==null) state.llmSel.model = liveModels[0] || "";
 
   const grid=el("div",{class:"select-grid"});
   const routeSel=selField("LLM 路由（route）", routeOpts.map(o=>({value:o.routeValue,label:o.label||o.routeValue})), curRoute);
   routeSel.querySelector("select").addEventListener("change",(e)=>{ state.llmSel.route=e.target.value; state.llmSel.model=null; state.llmSaved=false; render(); });
   grid.appendChild(routeSel);
-  const modelChoices = modelsForRoute.length ? modelsForRoute.map(m=>({value:m,label:m})) : [{value:state.llmSel.model,label:state.llmSel.model+"（默认）"}];
+  // Always offer the genuine "(平台默认)" sentinel; append real models when the catalog has them.
+  const modelChoices = [{value:"",label:"（平台默认）"}].concat(liveModels.map(m=>({value:m,label:m})));
   const modelSel=selField("模型 model", modelChoices, state.llmSel.model);
   modelSel.querySelector("select").addEventListener("change",(e)=>{ state.llmSel.model=e.target.value; state.llmSaved=false; });
   grid.appendChild(modelSel);


### PR DESCRIPTION
## Two UI bugs on the `/admin#/channels` Lark registration wizard (`ChannelsPage.cs`)

### 1. Fake "已复制" toast
The copy handler (`bindCopy`) set the success "已复制" state **unconditionally** after its try/catch — even when both the Clipboard API rejected (non-secure context) *and* the `execCommand` fallback returned `false`/threw. So it claimed a copy that never happened.
**Fix:** success state shows only on a real copy (`clipboard.writeText().then(...)`); falls back to `execCommand('copy')` honouring its boolean result; on total failure shows a "复制失败" state (`.copybtn.err`, existing `--err` token). Never shows "已复制" unless a copy actually succeeded. Covers both the row buttons and the permission-JSON button (single shared handler).

### 2. Reply-model dropdown fabricated a model option
The model catalog **is** live (`GET /api/user-config/llm` → NyxID `/api/v1/llm/services`), not mock. But when a route returned **no** models, the dropdown synthesized a single option from a hardcoded `DEFAULT_LLM.model` (`"gpt-5.5"`) the catalog never returned — a fabricated "live" option.
**Fix:** when the route has live models, list them; when it has none, present only the genuine "（平台默认）" option (empty value → `saveLlm` sends `model: null` and the server resolves the platform default). No specific model name is fabricated; no endpoint invented.

## Validation (verbatim)
- `node --check` on the final extracted `<script>` — **pass**.
- DOM-stub harnesses — copy (5 scenarios incl. both failure paths → `复制失败`, never "已复制") and model-choice (3 scenarios) — **all pass**.
- `dotnet build Aevatar.GAgents.Channel.NyxIdRelay` — **0 errors**; DLL re-embed confirmed (new helpers present in compiled assembly).
- Guards: `frontend_static_boundary_guard: ok`, `channel_card_literal_guard: ok`.

## Not verified
- No browser/live verification — offline JS harness + build only. Diff +35/−3, confined to the two fixes, follows existing design tokens & keyboard-accessible markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
