### PR TITLE
Prefill recurring prompt when editing automations

### DIFF
--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -304,6 +304,7 @@ function mockCreateScheduledDispatchSummary(overrides?: Record<string, any>) {
     serviceKey: "scope-1:default:default:alpha-service",
     serviceId: "alpha-service",
     serviceEndpointId: "chat",
+    prompt: "",
     cronExpression: "0 9 * * 1-5",
     timezone: "Asia/Shanghai",
     enabled: true,
@@ -2657,7 +2658,11 @@ describe("TeamDetailPage", () => {
       "/scopes/scope-1/teams/t-alpha?tab=automations",
     );
     (scheduledDispatchApi.listAll as jest.Mock).mockResolvedValueOnce({
-      items: [mockCreateScheduledDispatchSummary()],
+      items: [
+        mockCreateScheduledDispatchSummary({
+          prompt: "Summarize saved escalations and owners.",
+        }),
+      ],
       nextCursor: null,
       totalCount: 1,
     });
@@ -2681,6 +2686,9 @@ describe("TeamDetailPage", () => {
         "已保存的 Prompt 不会在这里显示。输入新的 Prompt 会替换旧值，留空保存则不带周期 Prompt。",
       ),
     ).toBeNull();
+    expect(within(editDialog).getByLabelText("周期 Prompt（选填）")).toHaveValue(
+      "Summarize saved escalations and owners.",
+    );
 
     fireEvent.change(within(editDialog).getByLabelText("自动化名称"), {
       target: { value: "Daily escalation digest - edited" },

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
@@ -1041,6 +1041,7 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
           .join(":"),
         serviceId,
         serviceEndpointId: "chat",
+        prompt: trimText(input.workflowChatTarget.prompt),
         cronExpression: input.cronExpression,
         timezone: trimText(input.timezone) || resolveDefaultTimezone(),
         enabled: input.enabled ?? true,
@@ -1282,7 +1283,7 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
         enabled: schedule.enabled,
         memberId: member?.memberId ?? "",
         preset,
-        prompt: "",
+        prompt: trimText(schedule.prompt),
         timezone: trimText(schedule.timezone) || resolveDefaultTimezone(),
       });
       setPreview(null);

--- a/apps/aevatar-console-web/src/shared/api/scheduledDispatchApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/scheduledDispatchApi.test.ts
@@ -142,6 +142,7 @@ describe("scheduledDispatchApi", () => {
     ).resolves.toEqual({
       items: [
         expect.objectContaining({
+          prompt: "",
           scheduleId: "sch-alpha",
           scheduleKind: "workflow",
           serviceId: "svc-alpha",
@@ -205,6 +206,50 @@ describe("scheduledDispatchApi", () => {
       "/api/schedules?includeTotalCount=true&take=200",
       "/api/schedules?cursor=cursor-2&includeTotalCount=true&take=200",
     ]);
+  });
+
+  it("keeps saved recurring prompts from schedule list responses", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        items: [
+          createSummary({
+            prompt: "Summarize escalations, blocked accounts, and follow-up owners.",
+          }),
+          createSummary({
+            prompt: null,
+            scheduleId: "sch-without-prompt",
+          }),
+          createSummary({
+            scheduleId: "sch-legacy",
+          }),
+        ],
+        nextCursor: null,
+        totalCount: 3,
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(scheduledDispatchApi.list()).resolves.toEqual(
+      expect.objectContaining({
+        items: [
+          expect.objectContaining({
+            prompt:
+              "Summarize escalations, blocked accounts, and follow-up owners.",
+            scheduleId: "sch-alpha",
+          }),
+          expect.objectContaining({
+            prompt: "",
+            scheduleId: "sch-without-prompt",
+          }),
+          expect.objectContaining({
+            prompt: "",
+            scheduleId: "sch-legacy",
+          }),
+        ],
+      }),
+    );
   });
 
   it("posts workflow chat as base64 service invocation when creating a schedule with a revision", async () => {
@@ -729,6 +774,7 @@ describe("scheduledDispatchApi", () => {
         TargetKind: 1,
         TargetActorId: "actor-pascal",
         PayloadTypeUrl: "type.googleapis.com/aevatar.ChatRequestEvent",
+        Prompt: "Summarize Pascal escalations.",
         ServiceKey: "scope-1:default:default:svc-pascal",
         ServiceId: "svc-pascal",
         ServiceEndpointId: "chat",
@@ -757,6 +803,7 @@ describe("scheduledDispatchApi", () => {
         targetKind: "service_invocation",
         scheduleKind: "workflow",
         deleted: false,
+        prompt: "Summarize Pascal escalations.",
       }),
     );
   });

--- a/apps/aevatar-console-web/src/shared/api/scheduledDispatchApi.ts
+++ b/apps/aevatar-console-web/src/shared/api/scheduledDispatchApi.ts
@@ -55,6 +55,7 @@ export type ScheduledDispatchSummary = {
   readonly serviceKey: string;
   readonly serviceId: string;
   readonly serviceEndpointId: string;
+  readonly prompt: string;
   readonly cronExpression: string;
   readonly timezone: string;
   readonly enabled: boolean;
@@ -257,6 +258,7 @@ export function decodeScheduledDispatchSummary(
     serviceKey: readString(record, ["serviceKey", "ServiceKey"], `${label}.serviceKey`),
     serviceId: readString(record, ["serviceId", "ServiceId"], `${label}.serviceId`),
     serviceEndpointId: readString(record, ["serviceEndpointId", "ServiceEndpointId"], `${label}.serviceEndpointId`),
+    prompt: readNullableString(record, ["prompt", "Prompt"], `${label}.prompt`) ?? "",
     cronExpression: readString(record, ["cronExpression", "CronExpression"], `${label}.cronExpression`),
     timezone: readString(record, ["timezone", "Timezone"], `${label}.timezone`),
     enabled: readBoolean(record, ["enabled", "Enabled"], `${label}.enabled`),


### PR DESCRIPTION
## Summary
- Add the schedule summary `prompt` field to the frontend API model and decoder
- Prefill the recurring prompt input from saved schedule data when editing an automation
- Preserve prompt data in optimistic newly-created schedule rows and cover null/missing prompt responses

## Validation
- `./node_modules/.bin/tsc --noEmit`
- `CI=true timeout 45s ./node_modules/.bin/jest --runInBand src/shared/api/scheduledDispatchApi.test.ts --verbose`
- `CI=true timeout 60s ./node_modules/.bin/jest --runInBand src/pages/teams/detail.test.tsx --testNamePattern "edits member recurring work with the published service identity" --verbose`
- `git diff --check`

Note: the targeted Teams test still prints the existing React/AntD `NaN height` warning, but passes.

## Related Issue
Fixes #2403