### PR TITLE
fix(channels): actually delete the conflicting Lark channel-bot on re-bind (fix #2420 dead match)

### DIFF
--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxApiResponseHelper.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxApiResponseHelper.cs
@@ -100,17 +100,19 @@ internal static class NyxApiResponseHelper
     }
 
     /// <summary>
-    /// Returns the ids of channel-bots in a Nyx <c>GET /api/v1/channel-bots</c> list response whose
-    /// Lark app (<c>platform_bot_id</c>, falling back to <c>app_id</c>) equals <paramref name="appId"/>.
-    /// Used to delete a stale channel-bot for the SAME Lark app before re-registering it: NyxID
-    /// rejects a second channel-bot for an app that already has one with <c>409 already-exists</c>,
-    /// which otherwise aborts a re-bind (the 502 the /channels wizard surfaced). Returns an empty
-    /// list when the response is an error envelope, unparseable, or carries no match.
+    /// Returns the ids of every Lark channel-bot in a Nyx <c>GET /api/v1/channel-bots</c> list
+    /// response (each list item carries <c>id</c> + <c>platform</c>, but NOT <c>platform_bot_id</c>:
+    /// the per-app identifier lives only on the per-bot detail <c>GET /channel-bots/{id}</c>). The
+    /// caller fetches each returned bot's detail and matches <c>platform_bot_id</c> against the Lark
+    /// app being (re-)registered via <see cref="ChannelBotDetailMatchesApp"/>, so only the conflicting
+    /// app's bot is deleted before the create retry — NyxID rejects a second channel-bot for an app
+    /// that already has one with <c>409 already-exists</c>, which otherwise aborts a re-bind (the 502
+    /// the /channels wizard surfaced). Returns an empty list when the response is an error envelope,
+    /// unparseable, or carries no Lark bot.
     /// </summary>
-    public static IReadOnlyList<string> ExtractChannelBotIdsForApp(string listResponse, string appId)
+    public static IReadOnlyList<string> ExtractLarkChannelBotIds(string listResponse)
     {
-        var normalizedAppId = appId?.Trim();
-        if (string.IsNullOrWhiteSpace(normalizedAppId) || LooksLikeErrorEnvelope(listResponse))
+        if (LooksLikeErrorEnvelope(listResponse))
             return Array.Empty<string>();
 
         try
@@ -125,8 +127,8 @@ internal static class NyxApiResponseHelper
                 if (bot.ValueKind != JsonValueKind.Object)
                     continue;
 
-                var botAppId = ReadNonEmptyString(bot, "platform_bot_id") ?? ReadNonEmptyString(bot, "app_id");
-                if (!string.Equals(botAppId, normalizedAppId, StringComparison.Ordinal))
+                var platform = ReadNonEmptyString(bot, "platform");
+                if (!string.Equals(platform, "lark", StringComparison.OrdinalIgnoreCase))
                     continue;
 
                 var id = ReadNonEmptyString(bot, "id");
@@ -139,6 +141,38 @@ internal static class NyxApiResponseHelper
         catch (JsonException)
         {
             return Array.Empty<string>();
+        }
+    }
+
+    /// <summary>
+    /// Returns true when a Nyx per-bot detail <c>GET /api/v1/channel-bots/{id}</c> response is for
+    /// the Lark app <paramref name="appId"/>, i.e. its <c>platform_bot_id</c> equals the app id.
+    /// This is the field the list response omits, so the conflicting-bot match must be made against
+    /// the detail. Returns false for an error envelope, an unparseable body, a non-Lark bot, or any
+    /// other app, so cleanup never deletes a bot belonging to a different Lark app.
+    /// </summary>
+    public static bool ChannelBotDetailMatchesApp(string detailResponse, string appId)
+    {
+        var normalizedAppId = appId?.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedAppId) || LooksLikeErrorEnvelope(detailResponse))
+            return false;
+
+        try
+        {
+            using var document = JsonDocument.Parse(detailResponse);
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+                return false;
+
+            var platform = ReadNonEmptyString(root, "platform");
+            if (!string.Equals(platform, "lark", StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            return string.Equals(ReadNonEmptyString(root, "platform_bot_id"), normalizedAppId, StringComparison.Ordinal);
+        }
+        catch (JsonException)
+        {
+            return false;
         }
     }
 

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxLarkProvisioningService.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxLarkProvisioningService.cs
@@ -299,13 +299,17 @@ public sealed class NyxLarkProvisioningService : INyxLarkProvisioningService, IN
     /// Best-effort removal of any existing Nyx channel-bot bound to the SAME Lark app before a
     /// (re-)registration creates a fresh one. NyxID rejects a second channel-bot for an app that
     /// already has one with 409 already-exists; deleting the stale bot first is what lets a user
-    /// re-bind the same bot from /channels without manual NyxID cleanup. Failures are logged and
-    /// swallowed — a bot that could not be removed simply resurfaces as the create 409 it would
-    /// have produced anyway, so this never makes a fresh registration worse.
+    /// re-bind the same bot from /channels without manual NyxID cleanup. The list response carries
+    /// only <c>id</c> + <c>platform</c>, not the per-app <c>platform_bot_id</c>, so each Lark bot's
+    /// detail is fetched to confirm it belongs to THIS app before deleting — a bot for a different
+    /// Lark app is never touched. Failures are logged and swallowed: a bot that could not be removed
+    /// simply resurfaces as the create 409 it would have produced anyway, so this never makes a fresh
+    /// registration worse.
     /// </summary>
     private async Task RemoveExistingLarkChannelBotsForAppAsync(string accessToken, string appId, CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(appId))
+        var normalizedAppId = appId?.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedAppId))
             return;
 
         string listResponse;
@@ -315,20 +319,38 @@ public sealed class NyxLarkProvisioningService : INyxLarkProvisioningService, IN
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            _logger.LogWarning(ex, "Could not list Nyx channel-bots before re-registration: appId={AppId}", appId);
+            _logger.LogWarning(ex, "Could not list Nyx channel-bots before re-registration: appId={AppId}", normalizedAppId);
             return;
         }
 
-        foreach (var existingBotId in NyxApiResponseHelper.ExtractChannelBotIdsForApp(listResponse, appId))
+        foreach (var candidateBotId in NyxApiResponseHelper.ExtractLarkChannelBotIds(listResponse))
         {
+            string detailResponse;
+            try
+            {
+                detailResponse = await _nyxClient.GetChannelBotAsync(accessToken, candidateBotId, ct);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Could not read Nyx channel-bot detail while resolving the conflicting Lark app bot: botId={BotId}, appId={AppId}",
+                    candidateBotId,
+                    normalizedAppId);
+                continue;
+            }
+
+            if (!NyxApiResponseHelper.ChannelBotDetailMatchesApp(detailResponse, normalizedAppId))
+                continue;
+
             _logger.LogInformation(
                 "Replacing existing Nyx channel-bot for Lark app before re-registration: botId={BotId}, appId={AppId}",
-                existingBotId,
-                appId);
+                candidateBotId,
+                normalizedAppId);
             await NyxApiResponseHelper.TryRollbackAsync(
-                () => _nyxClient.DeleteChannelBotAsync(accessToken, existingBotId, ct),
+                () => _nyxClient.DeleteChannelBotAsync(accessToken, candidateBotId, ct),
                 "channel_bot_replace",
-                existingBotId,
+                candidateBotId,
                 _logger);
         }
     }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxApiResponseHelperTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxApiResponseHelperTests.cs
@@ -45,27 +45,54 @@ public class NyxApiResponseHelperTests
     }
 
     [Fact]
-    public void ExtractChannelBotIdsForApp_Returns_Ids_Matching_App_By_PlatformBotId_Or_AppId()
+    public void ExtractLarkChannelBotIds_Returns_Only_Lark_Bot_Ids_From_Real_List_Shape()
     {
-        var response = """[{"id":"b1","platform_bot_id":"cli_x"},{"id":"b2","platform_bot_id":"cli_y"},{"id":"b3","app_id":"cli_x"}]""";
-        NyxApiResponseHelper.ExtractChannelBotIdsForApp(response, "cli_x")
-            .Should().BeEquivalentTo(new[] { "b1", "b3" });
-    }
-
-    [Fact]
-    public void ExtractChannelBotIdsForApp_Reads_Wrapped_Array_And_Ignores_NonMatches()
-    {
-        NyxApiResponseHelper.ExtractChannelBotIdsForApp("""{"data":[{"id":"b1","platform_bot_id":"cli_y"}]}""", "cli_x")
-            .Should().BeEmpty();
+        // The REAL `GET /api/v1/channel-bots` list item carries `id` + `platform` but NOT
+        // `platform_bot_id`/`app_id` (those live only on the per-bot detail). Cleanup must select by
+        // platform here, then disambiguate the app via each bot's detail. A list-time match on
+        // `platform_bot_id` (the prior fix) always returned empty against this shape.
+        var response = """
+        {"bots":[
+          {"id":"0b19376b","platform":"lark","label":"Aevatar Lark Bot","platform_bot_username":"lark_bot","webhook_registered":true,"status":"active","is_active":true},
+          {"id":"39a20d2b","platform":"telegram","label":"Aevatar Telegram Bot","platform_bot_username":"x_bot","status":"active"},
+          {"id":"133ddba3","platform":"lark","label":"Lark Bot (cli)","platform_bot_username":"lark_bot","status":"active"}
+        ],"total":3}
+        """;
+        NyxApiResponseHelper.ExtractLarkChannelBotIds(response)
+            .Should().BeEquivalentTo(new[] { "0b19376b", "133ddba3" });
     }
 
     [Theory]
-    [InlineData("""{"error":true,"status":409}""")]   // Nyx error envelope
-    [InlineData("not-json")]                          // unparseable
-    [InlineData("[]")]                                // empty list
-    [InlineData("")]                                  // empty
-    public void ExtractChannelBotIdsForApp_Returns_Empty_On_Error_Or_NoMatch(string response)
+    [InlineData("""{"error":true,"status":409}""")]                                                      // Nyx error envelope
+    [InlineData("not-json")]                                                                              // unparseable
+    [InlineData("""{"bots":[],"total":0}""")]                                                             // empty list
+    [InlineData("""{"bots":[{"id":"t1","platform":"telegram"}],"total":1}""")]                            // no lark bot
+    [InlineData("")]                                                                                      // empty
+    public void ExtractLarkChannelBotIds_Returns_Empty_On_Error_Or_NoLarkBot(string response)
     {
-        NyxApiResponseHelper.ExtractChannelBotIdsForApp(response, "cli_x").Should().BeEmpty();
+        NyxApiResponseHelper.ExtractLarkChannelBotIds(response).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ChannelBotDetailMatchesApp_Matches_When_Detail_PlatformBotId_Equals_App()
+    {
+        // The REAL `GET /api/v1/channel-bots/{id}` detail DOES carry `platform_bot_id` (the Lark app id).
+        var detail = """
+        {"id":"0b19376b","platform":"lark","label":"Aevatar Lark Bot","platform_bot_id":"cli_aab147d27238deed","platform_bot_username":"lark_bot","status":"active"}
+        """;
+        NyxApiResponseHelper.ChannelBotDetailMatchesApp(detail, "cli_aab147d27238deed").Should().BeTrue();
+        NyxApiResponseHelper.ChannelBotDetailMatchesApp(detail, " cli_aab147d27238deed ").Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("""{"id":"b","platform":"lark","platform_bot_id":"cli_other"}""", "cli_x")]   // different Lark app
+    [InlineData("""{"id":"b","platform":"telegram","platform_bot_id":"cli_x"}""", "cli_x")]   // not a Lark bot
+    [InlineData("""{"id":"b","platform":"lark"}""", "cli_x")]                                  // detail missing platform_bot_id
+    [InlineData("""{"error":true,"status":404}""", "cli_x")]                                   // Nyx error envelope
+    [InlineData("not-json", "cli_x")]                                                          // unparseable
+    [InlineData("""{"id":"b","platform":"lark","platform_bot_id":"cli_x"}""", "")]             // empty app id
+    public void ChannelBotDetailMatchesApp_Returns_False_When_Not_This_Lark_App(string detail, string appId)
+    {
+        NyxApiResponseHelper.ChannelBotDetailMatchesApp(detail, appId).Should().BeFalse();
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxLarkProvisioningServiceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxLarkProvisioningServiceTests.cs
@@ -206,13 +206,22 @@ public class NyxLarkProvisioningServiceTests
     public async Task ProvisionAsync_Replaces_Existing_ChannelBot_On_409_Conflict_And_Retries()
     {
         // Re-binding the same Lark app: the first channel-bot create hits NyxID's 409 already-exists.
-        // The service deletes the stale channel-bot for THIS app (only the matching one) and retries,
-        // so a user can re-bind from /channels without manual NyxID cleanup (the 502 the wizard showed).
+        // The REAL `GET /api/v1/channel-bots` list omits `platform_bot_id` (it lives only on the
+        // per-bot detail), so the service lists Lark bots, GETs each one's detail, and deletes only
+        // the bot whose detail `platform_bot_id` equals THIS app, then retries — so a user can re-bind
+        // from /channels without manual NyxID cleanup (the 502 the wizard showed). A second Lark bot
+        // for a DIFFERENT app is fetched but left untouched.
         var handler = new RecordingHandler();
         handler.Enqueue(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-1","full_key":"x"}""");
         handler.Enqueue(HttpMethod.Post, "/api/v1/channel-bots", """{"error":true,"status":409,"message":"channel bot already exists"}""");
-        handler.Enqueue(HttpMethod.Get, "/api/v1/channel-bots", """[{"id":"old-bot","platform_bot_id":"cli_a1b2c3"},{"id":"other","platform_bot_id":"cli_zzz"}]""");
+        // Real list shape: items have id + platform, NO platform_bot_id. Includes a telegram bot
+        // (skipped) and a second lark bot for another app (fetched, not matched, not deleted).
+        handler.Enqueue(HttpMethod.Get, "/api/v1/channel-bots",
+            """{"bots":[{"id":"old-bot","platform":"lark","platform_bot_username":"lark_bot","status":"active"},{"id":"tg-bot","platform":"telegram","status":"active"},{"id":"other-lark","platform":"lark","platform_bot_username":"lark_bot","status":"active"}],"total":3}""");
+        // Real detail shape: WITH platform_bot_id. First lark bot matches this app; second does not.
+        handler.Enqueue(HttpMethod.Get, "/api/v1/channel-bots/old-bot", """{"id":"old-bot","platform":"lark","platform_bot_id":"cli_a1b2c3","status":"active"}""");
         handler.Enqueue(HttpMethod.Delete, "/api/v1/channel-bots/old-bot", """{"ok":true}""");
+        handler.Enqueue(HttpMethod.Get, "/api/v1/channel-bots/other-lark", """{"id":"other-lark","platform":"lark","platform_bot_id":"cli_zzz","status":"active"}""");
         handler.Enqueue(HttpMethod.Post, "/api/v1/channel-bots", """{"id":"bot-new"}""");
         handler.Enqueue(HttpMethod.Post, "/api/v1/channel-conversations", """{"id":"route-1"}""");
         handler.Enqueue(HttpMethod.Post, "/api/v1/keys", """{"id":"svc-1","slug":"api-lark-bot-2"}""");
@@ -238,8 +247,12 @@ public class NyxLarkProvisioningServiceTests
 
         result.Succeeded.Should().BeTrue();
         result.NyxChannelBotId.Should().Be("bot-new");
-        // Only the channel-bot for THIS Lark app was deleted before the retry.
-        handler.Requests.Should().Contain(r => r.Method == HttpMethod.Delete && r.Path == "/api/v1/channel-bots/old-bot");
+        // Only the channel-bot for THIS Lark app (resolved via detail) was deleted before the retry.
+        handler.Requests.Should().ContainSingle(r => r.Method == HttpMethod.Delete && r.Path.StartsWith("/api/v1/channel-bots/"))
+            .Which.Path.Should().Be("/api/v1/channel-bots/old-bot");
+        // The detail of the other-app Lark bot was read but it was never deleted.
+        handler.Requests.Should().Contain(r => r.Method == HttpMethod.Get && r.Path == "/api/v1/channel-bots/other-lark");
+        handler.Requests.Should().NotContain(r => r.Method == HttpMethod.Delete && r.Path == "/api/v1/channel-bots/other-lark");
     }
 
     [Fact]


### PR DESCRIPTION
## Problem
Re-registering the same Lark bot from `/admin#/channels` fails at "创建 NyxID channel-bot" with NyxID **409 already-exists → HTTP 502**. The prior fix (PR #2420) was meant to delete the conflicting channel-bot on 409 and retry, but it **deleted nothing** — the retry 409s again and the registration 502s (user had to delete the bot from NyxID by hand).

## Root cause of the broken #2420 (confirmed live + in code)
`NyxApiResponseHelper.ExtractChannelBotIdsForApp` matched each **list** item by `platform_bot_id`/`app_id`. But the real `GET /api/v1/channel-bots` is `{"bots":[{id,platform,label,platform_bot_username,status,...}],"total":N}` — list items have **no** `platform_bot_id`/`app_id`. That field exists only on the detail `GET /api/v1/channel-bots/{id}`. So the match was always empty. #2420's tests passed only because they fed a **synthetic** list with `platform_bot_id` on the items — a shape NyxID never emits.

## Fix
`RemoveExistingLarkChannelBotsForAppAsync` now: list channel-bots → for each `platform=="lark"` bot, `GET /channel-bots/{id}` → if the detail's `platform_bot_id == appId`, `DELETE` it → then retry the create. Only this app's bot is deleted (other apps' Lark bots are read and left alone). Helpers replaced with correctly-shaped `ExtractLarkChannelBotIds` (list) + `ChannelBotDetailMatchesApp` (detail).

## Validation (verbatim)
- Build: `64 projects, 0 errors`.
- `Aevatar.GAgents.ChannelRuntime.Tests`: **1506 passed, 0 failed** (35 in the changed classes), tests rewritten to the REAL list/detail shapes.
- `test_stability_guards.sh` EXIT=0 (incl. lark agent path contract); `architecture_guards.sh` EXIT=0.
- **Revert-and-rerun bug proof:** stubbing the empty-match defect makes the integration test fail (`Expected result.Succeeded True, found False`); reverted → green. (The check #2420 skipped.)

## Not verified
- No live end-to-end re-bind through `/admin#/channels` was run; verified by build + tests against shapes confirmed against the live NyxID API. A real prod re-bind is the final proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
