### PR TITLE
fix(admin): real clipboard copy + live LLM routes in /admin#/channels wizard (#2446 fixed the wrong page)

### DIFF
--- a/src/Aevatar.Mainnet.Host.Api/BackendConsole/admin.html
+++ b/src/Aevatar.Mainnet.Host.Api/BackendConsole/admin.html
@@ -1765,6 +1765,17 @@ async function loadChannelStatus(c){
     if(s&&!s.forbidden){ mapChannelStatus(c,s); chanRerender(); } }
   catch(e){ /* status probe failed: leave row as 'unknown', don't fabricate */ }
 }
+/* Step 4 reply-model options come from the owner LLM config (GET /api/user-config/llm) —
+   the real routes/models NyxID lists for this account, NOT a hardcoded vendor menu. Mirrors
+   the /channels facade page. On failure WZ.model.llm stays null and the step degrades to the
+   genuine "（平台默认）" choice only. */
+async function loadWzLlm(){
+  WZ.model.llmLoading=true; chanRerender();
+  try{ var v=await adminJson('/api/user-config/llm');
+    WZ.model.llm=(v&&!v.forbidden)?v:null; }
+  catch(e){ if(!(e&&e.unauthorized)) WZ.model.llm=null; }
+  WZ.model.llmLoading=false; chanRerender();
+}
 async function loadChannels(){
   CHAN_LOADING=true; CHAN_ERR=null; CHAN_FORBIDDEN=false; chanRerender();
   var q=(CHAN_ACCT==='all') ? '?scope=all' : '';
@@ -2895,8 +2906,7 @@ function bindObservatory(root){
     else if(a==='obsReload'){ loadObsRuns(function(){ reList(); reDetail(); }); }
     else if(a==='obsReloadDetail'){ var rid=act.getAttribute('data-run'); if(rid){ delete OBS_DETAIL[rid]; loadObsDetail(rid,reDetail); } }
     else if(a==='obsCopy'){ var cv=act.getAttribute('data-copy');
-      if(navigator.clipboard&&navigator.clipboard.writeText){ navigator.clipboard.writeText(cv).then(function(){ toast('已复制 run id：'+cv); },function(){ toast('复制失败，请手动选择：'+cv); }); }
-      else { toast('run id：'+cv); } }
+      copyWithToast(cv, '已复制 run id：'+cv, '复制失败，请手动选择：'+cv); }
     else if(a==='artDl'){ var sel=obsSelected(), cache=sel&&OBS_DETAIL[sel.id], d=cache&&cache.detail;
       var art=d&&(d.artifacts||[]).filter(function(x){return x.name===act.getAttribute('data-name');})[0];
       if(art&&art.content!=null){ try{ var blob=new Blob([art.content],{type:'text/plain'}); var u=URL.createObjectURL(blob);
@@ -3273,7 +3283,7 @@ function bindSkills(root){
     var act=ev.target.closest('[data-act]'); if(!act||act.hasAttribute('disabled')) return; var a=act.getAttribute('data-act');
     if(a==='skBack'){ SKILL_STATE.mobileDetail=false; reDetail(); }
     else if(a==='skInvoke'){ capture(); runInvoke(); }
-    else if(a==='skCopy'){ toast('已复制：'+act.getAttribute('data-copy')); }
+    else if(a==='skCopy'){ copyWithToast(act.getAttribute('data-copy')); }
     else if(a==='skOpenRun'){ var u=act.getAttribute('data-url'); if(u){ location.assign(u); } else { navigate(['observatory'],{}); } }
     else if(a==='skReload'){ SKILL_STATE.loaded=false; SKILLS_LOADED=false; SKILL_STATE.loading=true; reList(); loadSkills(function(){ SKILL_STATE.loaded=true; SKILL_STATE.loading=false; reList(); }); }
     else if(a==='skPreset'){ capture(); SKILL_STATE.sched.cron=act.getAttribute('data-cron'); reDetail(); }
@@ -3387,7 +3397,8 @@ var CHAN_MANAGE={idx:null};
 var CHAN_CONFIRM=null;            /* 解绑确认 idx */
 function newWZ(provider){ return { provider:provider||null, step:provider?1:0, maxReached:provider?1:0, data:{}, errors:{},
   reg:{state:'idle', ticks:[false,false,false,false], botId:null, webhookUrl:null, apiKeyId:null, fail:null},
-  perm:{imported:false, open:false}, pub:{state:'idle'}, model:{route:'', model:'', state:'idle'},
+  perm:{imported:false, open:false}, pub:{state:'idle'},
+  model:{route:null, model:null, state:'idle', llm:null, llmLoading:false},
   verify:{inbound:'pending', active:'pending', started:false} }; }
 var WZ=newWZ();
 function chanMeta(id){ return CHAN_CATALOG.filter(function(c){return c.id===id;})[0]; }
@@ -3535,14 +3546,42 @@ function chanStep3(){
     wzFoot({back:true, next:{label:'下一步：回复模型', act:'wzCfgNext', disabled:WZ.pub.state!=='done'}});
 }
 function chanStep4(){
-  var m=WZ.model, routes=['NyxID 默认路由','OpenAI 直连','Anthropic 直连','自建网关'], models=['（平台默认）','gpt-4o','claude-sonnet-4','gpt-4o-mini','qwen-max'];
+  var m=WZ.model;
+  if(m.llmLoading && !m.llm){
+    return '<div class="wz-h">配置回复模型</div><div class="wz-sub">不配置则使用平台默认模型回复入站消息。</div>'+
+      '<div class="cfg-pub" style="margin-top:14px"><span class="spinner"></span> 正在读取你的回复模型配置…</div>'+
+      wzFoot({back:true, next:{label:'下一步：验证', act:'wzModelNext'}});
+  }
+  var llm=m.llm;
+  /* Honest options: real routes/models from the owner LLM catalog. No fabricated vendor menu. */
+  var routeOpts=(llm&&llm.routeOptions)||[];
+  if(m.route==null) m.route=(llm&&(llm.savedRoute||llm.effectiveRoute))||(routeOpts[0]&&routeOpts[0].routeValue)||'';
+  var curRoute=m.route;
+  var liveModels=(((llm&&llm.modelGroupsByRoute)||[]).filter(function(g){return g.routeValue===curRoute;})
+    .reduce(function(acc,g){return acc.concat(g.models||[]);},[]));
+  if(!liveModels.length && llm && llm.defaultModel) liveModels=[llm.defaultModel];
+  if(m.model==null) m.model='';
+  /* route select: when the catalog is unavailable, the only honest route is the gateway default (empty value). */
+  var routeChoices = routeOpts.length
+    ? routeOpts.map(function(o){ return {value:o.routeValue, label:o.label||o.routeValue}; })
+    : [{value:'', label:'平台默认路由'}];
+  var routeSel='<select class="std-select" id="m-route">'+routeChoices.map(function(o){
+    return '<option value="'+esc(o.value)+'"'+(curRoute===o.value?' selected':'')+'>'+esc(o.label)+'</option>'; }).join('')+'</select>';
+  /* model select: always offer the genuine "（平台默认）" sentinel (empty -> server resolves), then real models. */
+  var modelChoices=[{value:'',label:'（平台默认）'}].concat(liveModels.map(function(x){return {value:x,label:x};}));
+  var modelSel='<select class="std-select" id="m-model">'+modelChoices.map(function(o){
+    return '<option value="'+esc(o.value)+'"'+(m.model===o.value?' selected':'')+'>'+esc(o.label)+'</option>'; }).join('')+'</select>';
+  var catalogNote = (llm && llm.catalogStatus && llm.catalogStatus!=='ready')
+    ? '<div class="warn-box">⚠ 模型目录暂不可用（'+esc(llm.catalogStatus)+'）—— 现在只能选平台默认。可保存后稍后回来调整。</div>' : '';
   var saveBlk = m.state==='saved' ? '<span class="invoke-result ok" style="display:inline-flex">✓ 已保存回复模型</span>'
     : m.state==='saving' ? '<span class="cfg-pub"><span class="spinner"></span> 保存中…</span>'
     : '<button class="btn" data-act="wzSaveModel">保存回复模型</button>';
-  return '<div class="wz-h">配置回复模型</div><div class="wz-sub">不配置则使用平台默认模型回复入站消息。</div>'+
+  var errBlk = m.err ? '<div class="warn-box">'+esc(m.err)+'</div>' : '';
+  return '<div class="wz-h">配置回复模型</div><div class="wz-sub">不配置则使用平台默认模型回复入站消息。下面只列你账户实际可用的路由与模型。</div>'+
     '<div class="wz-form" style="max-width:380px">'+
-      '<div class="wz-field"><label>LLM 路由</label><select class="std-select" id="m-route">'+routes.map(function(r){return '<option'+(m.route===r?' selected':'')+'>'+r+'</option>';}).join('')+'</select></div>'+
-      '<div class="wz-field"><label>模型</label><select class="std-select" id="m-model">'+models.map(function(x){return '<option'+(m.model===x?' selected':'')+'>'+x+'</option>';}).join('')+'</select></div></div>'+
+      '<div class="wz-field"><label>LLM 路由</label>'+routeSel+'</div>'+
+      '<div class="wz-field"><label>模型</label>'+modelSel+'</div></div>'+
+    catalogNote+errBlk+
     '<div class="reg-actions">'+saveBlk+'</div>'+
     wzFoot({back:true, next:{label:'下一步：验证', act:'wzModelNext'}});
 }
@@ -3625,7 +3664,7 @@ function bindChannels(root){
     /* 向导 */
     else if(a==='wzCancel'){ CHAN_VIEW.mode='list'; CHAN_CONFIRM=null; re(); }
     else if(a==='wzPick'){ WZ.provider=act.getAttribute('data-prov'); WZ.step=1; WZ.maxReached=Math.max(WZ.maxReached,1); re(); }
-    else if(a==='wzGoto'){ capture(); var gi=+act.getAttribute('data-i'); if(gi<=WZ.maxReached){ WZ.step=gi; re(); } }
+    else if(a==='wzGoto'){ capture(); var gi=+act.getAttribute('data-i'); if(gi<=WZ.maxReached){ WZ.step=gi; re(); if(gi===4 && !WZ.model.llm) loadWzLlm(); } }
     else if(a==='wzBack'){ capture(); WZ.step=Math.max(0,WZ.step-1); re(); }
     else if(a==='wzCredNext'){ capture(); var fs=CHAN_FIELDS[WZ.provider]||[], errs={};
       fs.forEach(function(f){ if(f.req && !(WZ.data[f.k]||'').trim()) errs[f.k]='必填'; });
@@ -3635,7 +3674,7 @@ function bindChannels(root){
     else if(a==='wzPermImport'){ WZ.perm.imported=true; re(); }
     else if(a==='wzPermToggle'){ WZ.perm.open=!WZ.perm.open; re(); }
     else if(a==='wzPublish'){ WZ.pub.state='done'; re(); }   /* manual Lark-console publish; no aevatar backend — acknowledge, don't fake a server round-trip */
-    else if(a==='wzCfgNext'){ WZ.step=4; WZ.maxReached=Math.max(WZ.maxReached,4); re(); }
+    else if(a==='wzCfgNext'){ WZ.step=4; WZ.maxReached=Math.max(WZ.maxReached,4); re(); if(!WZ.model.llm) loadWzLlm(); }
     else if(a==='wzSaveModel'){ capture(); WZ.model.state='saving'; re();
       adminApi('/api/user-config/llm', { method:'PUT', headers:{'Content-Type':'application/json'},
         body:JSON.stringify({ routeValue:WZ.model.route||'', model:WZ.model.model||null }) })
@@ -3644,7 +3683,12 @@ function bindChannels(root){
     else if(a==='wzModelNext'){ capture(); WZ.step=5; WZ.maxReached=Math.max(WZ.maxReached,5); re(); }
     else if(a==='wzFinish'){
       stopVerify(); CHAN_VIEW.mode='list'; WZ=newWZ(); re(); loadChannels(); }
-    else if(a==='wzCopy'){ toast('已复制：'+act.getAttribute('data-copy')); }
+    else if(a==='wzCopy'){ copyWithToast(act.getAttribute('data-copy')); }
+  });
+  /* Switching the LLM route must refresh the per-route model list — models are route-scoped. */
+  root.addEventListener('change',function(ev){
+    if(ev.target&&ev.target.id==='m-route'){ WZ.model.route=ev.target.value; WZ.model.model=null; WZ.model.state='idle'; WZ.model.err=null; re(); }
+    else if(ev.target&&ev.target.id==='m-model'){ WZ.model.model=ev.target.value; WZ.model.state='idle'; }
   });
 }
 
@@ -3849,6 +3893,28 @@ function toast(msg){
   var el=document.createElement('div'); el.className='toast';
   el.innerHTML=ICON.check+'<span>'+esc(msg)+'</span>'; r.appendChild(el);
   setTimeout(function(){ el.style.opacity='0'; el.style.transition='opacity .3s'; setTimeout(function(){el.remove();},300); },2200);
+}
+/* Real clipboard copy. Tries the async Clipboard API, then a hidden-textarea + execCommand
+   fallback for non-secure / older contexts. Resolves to the genuine success boolean so callers
+   only ever claim "已复制" when the value actually reached the clipboard. No fake toasts. */
+function execCommandCopy(value){
+  var ta=document.createElement('textarea');
+  ta.value=value; ta.setAttribute('readonly','');
+  ta.style.position='fixed'; ta.style.top='0'; ta.style.left='0'; ta.style.opacity='0'; ta.style.pointerEvents='none';
+  document.body.appendChild(ta); ta.select(); try{ ta.setSelectionRange(0,value.length); }catch(_){}
+  var ok=false; try{ ok=document.execCommand('copy'); }catch(_){ ok=false; }
+  ta.remove(); return ok;
+}
+function copyToClipboard(value){
+  value=value==null?'':String(value);
+  if(navigator.clipboard&&navigator.clipboard.writeText){
+    return navigator.clipboard.writeText(value).then(function(){ return true; },function(){ return execCommandCopy(value); });
+  }
+  return Promise.resolve(execCommandCopy(value));
+}
+/* Copy `value`; toast the honest outcome. okMsg/errMsg accept the value for interpolation. */
+function copyWithToast(value,okMsg,errMsg){
+  copyToClipboard(value).then(function(ok){ toast(ok?(okMsg||('已复制：'+value)):(errMsg||('复制失败，请手动选择：'+value))); });
 }
 
 /* ---------- 数据来源 popover ---------- */


### PR DESCRIPTION
## Why "复制依然是骗人的" persisted after #2446
**#2446 fixed the wrong file.** `/admin#/channels` is served by `src/Aevatar.Mainnet.Host.Api/BackendConsole/admin.html` (the fused console SPA). #2446 fixed `agents/channels/.../ChannelsPage.cs` — a *separate, second* Lark wizard at the `/channels` route that has drifted apart. So the user never saw the fix. Confirmed #2446 IS deployed (live image `2e05b701` contains merge `6eb06d18`); it was simply the wrong page. This PR fixes the page the user actually uses.

## Bug 1 — fake "已复制"
`admin.html:3647` (`wzCopy`) and `:3276` (`skCopy`) called `toast('已复制：'+value)` with **no clipboard call at all** — a pure fake toast. (`obsCopy` at `:2898` used Clipboard-API-only with a silent no-op fallback.) `/admin` is a top-level page (not an iframe), so it was never an iframe-permission issue — the wizard simply never wrote to the clipboard.
**Fix:** `execCommandCopy()` (hidden-textarea + `execCommand('copy')`, honoring its boolean) → `copyToClipboard()` (Clipboard API → textarea fallback) → `copyWithToast()` (toasts the genuine outcome: "已复制" only on real success, else "复制失败，请手动选择"). All three copy sites routed through it.

## Bug 2 — hardcoded LLM route/model dropdowns
`admin.html:3538` hardcoded `routes=['NyxID 默认路由','OpenAI 直连','Anthropic 直连','自建网关']` + fabricated models (`gpt-4o`, `qwen-max`, …), and the save handler POSTed the Chinese display label as the route value. The real contract is `GET /api/user-config/llm` (`routeOptions` + `modelGroupsByRoute`) — the sibling page already uses it.
**Fix:** `loadWzLlm()` fetches the real catalog on entering step 4; `chanStep4()` renders real routes + per-route models + a genuine "（平台默认）" sentinel (empty → server resolves); switching route refreshes models; degrades to platform-default-only when the catalog is unavailable.

## Verification (verbatim, real browser)
- **gstack `/browse` harness with the verbatim functions:** `execCommandCopy('PROVE_THIS_VALUE_123')` → copy event captured `PROVE_THIS_VALUE_123` (real write); button click captured `bot_id_HARNESS_42` + toast "已复制：…"; forced-failure path → toast "复制失败…", never a false success. Route dropdown rendered the real catalog; **none** of the fabricated `OpenAI 直连 / gpt-4o / qwen-max` appeared.
- `node --check` on all 6 admin.html script blocks: pass. `dotnet build src/Aevatar.Mainnet.Host.Api`: 0 errors (embedded asset valid). `frontend_static_boundary_guard` / `channel_card_literal_guard` / `architecture_guards.sh`: pass.

## Follow-up (flagged)
Two full Lark wizards (`admin.html` vs `ChannelsPage.cs`) have drifted — the structural de-dup is a separate task that prevents this "fixed the wrong copy" class from recurring.

1 file changed (+77 −11). Not browser-verified against the live authenticated /admin page (OIDC) — verified via a real-browser harness of the exact functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
