### PR TITLE
feat(ai): add system skill overlay proto, options, and DI wiring (#2464)

### DIFF
--- a/src/Aevatar.AI.Abstractions/ai_messages.proto
+++ b/src/Aevatar.AI.Abstractions/ai_messages.proto
@@ -332,6 +332,16 @@ message AIAgentConfigOverrides {
   reserved "stream_buffer_capacity";
 }
 
+message SystemSkillOverlay {
+  string overlay_markdown = 1;
+  string source_watermark = 2;
+  int64 materialized_at = 3;
+}
+
+message SystemSkillOverlayMaterializedEvent {
+  SystemSkillOverlay overlay = 1;
+}
+
 // Agent → 前端：请求工具执行审批
 message ToolApprovalRequestEvent {
   string request_id = 1;
@@ -378,6 +388,7 @@ message RoleGAgentState {
   string role_id = 8;
   map<string, aevatar.voice.VoicePresenceRuntimeState> voice_presence = 9;
   map<string, aevatar.voice.VoiceSessionDefaults> voice_session_defaults = 10;
+  SystemSkillOverlay system_skill_overlay = 11;
 }
 
 // ─── Multi-turn tool approval continuation ───

--- a/src/Aevatar.AI.ToolProviders.Ornn/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/ServiceCollectionExtensions.cs
@@ -52,6 +52,22 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
+    /// <summary>
+    /// Registers the host-bound system skill overlay scaffold.
+    /// </summary>
+    public static IServiceCollection AddSystemSkillOverlay(
+        this IServiceCollection services,
+        Action<SystemSkillOverlayOptions>? configure = null)
+    {
+        var options = new SystemSkillOverlayOptions();
+        configure?.Invoke(options);
+        if (!options.Enabled || string.IsNullOrWhiteSpace(options.Tag))
+            return services;
+
+        services.TryAddSingleton(options);
+        return services;
+    }
+
     private static IAgentToolSource GetOrnnAgentToolSource(IServiceProvider sp) =>
         sp.GetRequiredService<OrnnAgentToolSource>();
 

--- a/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlayOptions.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlayOptions.cs
@@ -1,0 +1,37 @@
+namespace Aevatar.AI.ToolProviders.Ornn;
+
+/// <summary>System skill overlay configuration.</summary>
+public sealed class SystemSkillOverlayOptions
+{
+    /// <summary>
+    /// Host-bound Ornn tag used to select the system skills that may be materialized into the
+    /// persisted role-agent overlay.
+    /// </summary>
+    public string Tag { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Host-bound organization service token used by the future materializer to read system
+    /// skills. This is a secret and must be supplied by host configuration.
+    /// </summary>
+    public string OrgServiceToken { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Minimum interval before the future materializer should refresh the overlay from its source.
+    /// </summary>
+    public TimeSpan RefreshTtl { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
+    /// Maximum number of source skills the future materializer should include in one overlay.
+    /// </summary>
+    public int MaxSkills { get; set; }
+
+    /// <summary>
+    /// Maximum UTF-8 byte budget the future materializer should allow for one overlay.
+    /// </summary>
+    public int MaxBytes { get; set; }
+
+    /// <summary>
+    /// Enables host registration for the system skill overlay scaffold. Defaults to disabled.
+    /// </summary>
+    public bool Enabled { get; set; }
+}

--- a/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
@@ -70,6 +70,33 @@ public sealed class AevatarAIFeatureOptions
     /// NyxID catalog uses a different slug (e.g. organisations that re-registered the service).
     /// </summary>
     public string? OrnnNyxIdSlug { get; set; }
+    /// <summary>
+    /// Enables the host-bound system skill overlay scaffold. Mainnet-style hosts bind this from
+    /// <c>Aevatar:SystemSkills:Enabled</c>.
+    /// </summary>
+    public bool EnableSystemSkillOverlay { get; set; }
+    /// <summary>
+    /// Host-bound Ornn tag used to select system skills. Bound from
+    /// <c>Aevatar:SystemSkills:Tag</c>; this value is sensitive and should come from host secrets.
+    /// </summary>
+    public string? SystemSkillOverlayTag { get; set; }
+    /// <summary>
+    /// Host-bound organization service token used by the future materializer. Bound from
+    /// <c>Aevatar:SystemSkills:OrgServiceToken</c>; this value is a secret.
+    /// </summary>
+    public string? SystemSkillOverlayOrgServiceToken { get; set; }
+    /// <summary>
+    /// Bound from <c>Aevatar:SystemSkills:RefreshTtl</c>.
+    /// </summary>
+    public TimeSpan SystemSkillOverlayRefreshTtl { get; set; }
+    /// <summary>
+    /// Bound from <c>Aevatar:SystemSkills:MaxSkills</c>.
+    /// </summary>
+    public int SystemSkillOverlayMaxSkills { get; set; }
+    /// <summary>
+    /// Bound from <c>Aevatar:SystemSkills:MaxBytes</c>.
+    /// </summary>
+    public int SystemSkillOverlayMaxBytes { get; set; }
     public IAevatarSecretsStore? SecretsStore { get; set; }
     public string? ApiKey { get; set; }
     public NyxIdLlmEndpointSpec? NyxIdLlmEndpoint { get; set; }
@@ -145,6 +172,9 @@ public static class ServiceCollectionExtensions
 
         if (options.EnableOrnnSkills)
             RegisterOrnnSkills(services, options);
+
+        if (options.EnableSystemSkillOverlay)
+            RegisterSystemSkillOverlay(services, options);
 
         if (options.EnableServiceInvokeTools)
             RegisterServiceInvokeTools(services, options);
@@ -1165,6 +1195,22 @@ public static class ServiceCollectionExtensions
         });
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IOrnnSkillPublishAssetValidator, WorkflowOrnnSkillPublishAssetValidator>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IOrnnSkillPublishAssetValidator, ScriptOrnnSkillPublishAssetValidator>());
+    }
+
+    private static void RegisterSystemSkillOverlay(IServiceCollection services, AevatarAIFeatureOptions options)
+    {
+        if (!options.EnableSystemSkillOverlay || string.IsNullOrWhiteSpace(options.SystemSkillOverlayTag))
+            return;
+
+        services.AddSystemSkillOverlay(o =>
+        {
+            o.Enabled = options.EnableSystemSkillOverlay;
+            o.Tag = options.SystemSkillOverlayTag ?? string.Empty;
+            o.OrgServiceToken = options.SystemSkillOverlayOrgServiceToken ?? string.Empty;
+            o.RefreshTtl = options.SystemSkillOverlayRefreshTtl;
+            o.MaxSkills = options.SystemSkillOverlayMaxSkills;
+            o.MaxBytes = options.SystemSkillOverlayMaxBytes;
+        });
     }
 
     private static void RegisterWebTools(IServiceCollection services, AevatarAIFeatureOptions options)

--- a/src/Aevatar.Mainnet.Host.Api/appsettings.json
+++ b/src/Aevatar.Mainnet.Host.Api/appsettings.json
@@ -16,6 +16,14 @@
     "Ornn": {
       "NyxIdSlug": "ornn-api"
     },
+    "SystemSkills": {
+      "Enabled": false,
+      "Tag": "",
+      "OrgServiceToken": "",
+      "RefreshTtl": "00:00:00",
+      "MaxSkills": 0,
+      "MaxBytes": 0
+    },
     "Responses": {
       "ModelMetadataFallbacks": {
         "deepseek": {

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Hosting/AevatarPlatformHostBuilderExtensions.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Hosting/AevatarPlatformHostBuilderExtensions.cs
@@ -49,6 +49,15 @@ public static class AevatarPlatformHostBuilderExtensions
                 aiOptions.EnableSkills = true;
                 aiOptions.EnableOrnnSkills = true;
                 aiOptions.OrnnNyxIdSlug = builder.Configuration["Aevatar:Ornn:NyxIdSlug"];
+                aiOptions.EnableSystemSkillOverlay = ReadBoolean(builder.Configuration["Aevatar:SystemSkills:Enabled"]);
+                aiOptions.SystemSkillOverlayTag = builder.Configuration["Aevatar:SystemSkills:Tag"];
+                aiOptions.SystemSkillOverlayOrgServiceToken = builder.Configuration["Aevatar:SystemSkills:OrgServiceToken"];
+                if (TimeSpan.TryParse(builder.Configuration["Aevatar:SystemSkills:RefreshTtl"], out var refreshTtl))
+                    aiOptions.SystemSkillOverlayRefreshTtl = refreshTtl;
+                if (int.TryParse(builder.Configuration["Aevatar:SystemSkills:MaxSkills"], out var maxSkills))
+                    aiOptions.SystemSkillOverlayMaxSkills = maxSkills;
+                if (int.TryParse(builder.Configuration["Aevatar:SystemSkills:MaxBytes"], out var maxBytes))
+                    aiOptions.SystemSkillOverlayMaxBytes = maxBytes;
                 aiOptions.EnableWebTools = true;
                 aiOptions.WebSearchNyxIdSlug = builder.Configuration["Aevatar:WebSearch:NyxIdSlug"];
                 aiOptions.WebSearchApiBaseUrl = builder.Configuration["Aevatar:WebSearch:ApiBaseUrl"];
@@ -132,4 +141,7 @@ public static class AevatarPlatformHostBuilderExtensions
                 "Maker extensions require workflow capability to be enabled.");
         }
     }
+
+    private static bool ReadBoolean(string? value) =>
+        bool.TryParse(value, out var result) && result;
 }


### PR DESCRIPTION
## What

Implements #2464 — adds the `SystemSkillOverlay` proto field, `SystemSkillOverlayOptions`, and the `AddSystemSkillOverlay` / `RegisterSystemSkillOverlay` DI scaffolding. **No runtime behavior**: the overlay is not wired into prompt building, state hydration, or events.

实现 #2464:加入 `SystemSkillOverlay` proto 字段、`SystemSkillOverlayOptions` 选项与 `AddSystemSkillOverlay`/`RegisterSystemSkillOverlay` DI 脚手架。**无运行时行为**:overlay 没有接入 prompt 构建、state hydration 或事件。

## Changes

| File | Change |
|---|---|
| `src/Aevatar.AI.Abstractions/ai_messages.proto` | `SystemSkillOverlay` message + `SystemSkillOverlayMaterializedEvent`; field 11 on `RoleGAgentState` |
| `src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlayOptions.cs` (new) | `Tag` / `OrgServiceToken` / `RefreshTtl` / `MaxSkills` / `MaxBytes` / `Enabled` |
| `src/Aevatar.AI.ToolProviders.Ornn/ServiceCollectionExtensions.cs` | `AddSystemSkillOverlay` mirroring `AddOrnnSkills` |
| `src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs` | `AevatarAIFeatureOptions` overlay fields + `RegisterSystemSkillOverlay` mirroring `RegisterOrnnSkills` |
| `src/workflow/.../AevatarPlatformHostBuilderExtensions.cs` | host binding from `Aevatar:SystemSkills:*` |
| `appsettings.json` | `Aevatar:SystemSkills:*` keys, `Enabled=false` default |

## Design

Mirrors the Ornn options/DI pattern exactly so the surface is familiar. **No-op contract**: `Enabled=false` (default) or empty `Tag` registers nothing — unconfigured hosts are unaffected. `Tag` / `OrgServiceToken` are host-config secrets; no literals in code/proto/tests.

Spike gate #2463 (findings comment) locked the two injection seams; this PR does NOT use them yet — that is #2465–#2467.

## Test evidence

```
dotnet build aevatar.slnx
→ 0 Error(s), 390 Warning(s) (all pre-existing NU1507/NU1510 package-source warnings)
Time Elapsed 00:00:19.68
```

Acceptance: proto round-trips (compiles), options bind from config, `Enabled=false` registers nothing, build green.

Generated by codex (gpt-5.5, xhigh) under manual serial execution of milestone 31. ⟦AI:FKST⟧
