### PR TITLE
feat(ai): stateless system skill overlay builder with provenance hardening (#2465)

### DIFF
--- a/src/Aevatar.AI.Abstractions/ai_messages.proto
+++ b/src/Aevatar.AI.Abstractions/ai_messages.proto
@@ -332,6 +332,16 @@ message AIAgentConfigOverrides {
   reserved "stream_buffer_capacity";
 }
 
+message SystemSkillOverlay {
+  string overlay_markdown = 1;
+  string source_watermark = 2;
+  int64 materialized_at = 3;
+}
+
+message SystemSkillOverlayMaterializedEvent {
+  SystemSkillOverlay overlay = 1;
+}
+
 // Agent → 前端：请求工具执行审批
 message ToolApprovalRequestEvent {
   string request_id = 1;
@@ -378,6 +388,7 @@ message RoleGAgentState {
   string role_id = 8;
   map<string, aevatar.voice.VoicePresenceRuntimeState> voice_presence = 9;
   map<string, aevatar.voice.VoiceSessionDefaults> voice_session_defaults = 10;
+  SystemSkillOverlay system_skill_overlay = 11;
 }
 
 // ─── Multi-turn tool approval continuation ───

--- a/src/Aevatar.AI.ToolProviders.Ornn/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.AI.ToolProviders.Ornn.Publishing;
+using Aevatar.AI.ToolProviders.Ornn.SystemSkillOverlay;
 using Aevatar.AI.ToolProviders.Skills;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -65,6 +66,8 @@ public static class ServiceCollectionExtensions
             return services;
 
         services.TryAddSingleton(options);
+        services.TryAddSingleton<ISystemSkillOverlayBuilder, SystemSkillOverlayBuilder>();
+        // TODO: consolidate NyxIdRelayPromptConfiguration flags with this overlay registration once the materializer owns injection.
         return services;
     }
 

--- a/src/Aevatar.AI.ToolProviders.Ornn/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/ServiceCollectionExtensions.cs
@@ -52,6 +52,22 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
+    /// <summary>
+    /// Registers the host-bound system skill overlay scaffold.
+    /// </summary>
+    public static IServiceCollection AddSystemSkillOverlay(
+        this IServiceCollection services,
+        Action<SystemSkillOverlayOptions>? configure = null)
+    {
+        var options = new SystemSkillOverlayOptions();
+        configure?.Invoke(options);
+        if (!options.Enabled || string.IsNullOrWhiteSpace(options.Tag))
+            return services;
+
+        services.TryAddSingleton(options);
+        return services;
+    }
+
     private static IAgentToolSource GetOrnnAgentToolSource(IServiceProvider sp) =>
         sp.GetRequiredService<OrnnAgentToolSource>();
 

--- a/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlay/ISystemSkillOverlayBuilder.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlay/ISystemSkillOverlayBuilder.cs
@@ -1,0 +1,6 @@
+namespace Aevatar.AI.ToolProviders.Ornn.SystemSkillOverlay;
+
+public interface ISystemSkillOverlayBuilder
+{
+    Task<Aevatar.AI.Abstractions.SystemSkillOverlay> BuildAsync(CancellationToken ct);
+}

--- a/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlay/OverlayAuthoringContract.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlay/OverlayAuthoringContract.cs
@@ -1,0 +1,29 @@
+namespace Aevatar.AI.ToolProviders.Ornn.SystemSkillOverlay;
+
+public static class OverlayAuthoringContract
+{
+    public static bool Validate(OverlayFrontmatter? frontmatter) => IsValid(frontmatter);
+
+    public static bool IsValid(OverlayFrontmatter? frontmatter)
+    {
+        if (frontmatter == null ||
+            string.IsNullOrWhiteSpace(frontmatter.Title) ||
+            string.IsNullOrWhiteSpace(frontmatter.Scope) ||
+            string.IsNullOrWhiteSpace(frontmatter.Priority) ||
+            string.IsNullOrWhiteSpace(frontmatter.MaxBytes) ||
+            string.IsNullOrWhiteSpace(frontmatter.AppliesTo) ||
+            string.IsNullOrWhiteSpace(frontmatter.NonOverride))
+        {
+            return false;
+        }
+
+        if (!int.TryParse(frontmatter.Priority, out _) ||
+            !int.TryParse(frontmatter.MaxBytes, out _) ||
+            !bool.TryParse(frontmatter.NonOverride, out _))
+        {
+            return false;
+        }
+
+        return frontmatter.AppliesTo.ToLowerInvariant() is "channel" or "dm" or "both";
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlay/OverlayFrontmatter.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlay/OverlayFrontmatter.cs
@@ -1,0 +1,137 @@
+namespace Aevatar.AI.ToolProviders.Ornn.SystemSkillOverlay;
+
+public sealed record OverlayFrontmatter(
+    string? Title,
+    string? Scope,
+    string? Priority,
+    string? MaxBytes,
+    string? AppliesTo,
+    string? NonOverride)
+{
+    public static OverlayFrontmatter? Parse(string markdown) => OverlayFrontmatterParser.Parse(markdown);
+}
+
+public static class OverlayFrontmatterParser
+{
+    public static OverlayFrontmatter? Parse(string markdown)
+    {
+        return TryParse(markdown, out var frontmatter, out _)
+            ? frontmatter
+            : null;
+    }
+
+    public static bool TryParse(string markdown, out OverlayFrontmatter? frontmatter, out string body)
+    {
+        frontmatter = null;
+        body = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(markdown))
+            return false;
+
+        var openingEnd = markdown.StartsWith("---\n", StringComparison.Ordinal)
+            ? 4
+            : markdown.StartsWith("---\r\n", StringComparison.Ordinal)
+                ? 5
+                : -1;
+        if (openingEnd < 0)
+            return false;
+
+        var closingIndex = FindClosingDelimiter(markdown, openingEnd);
+        if (closingIndex < 0)
+            return false;
+
+        var block = markdown[openingEnd..closingIndex];
+        string? title = null;
+        string? scope = null;
+        string? priority = null;
+        string? maxBytes = null;
+        string? appliesTo = null;
+        string? nonOverride = null;
+
+        foreach (var rawLine in block.Split('\n'))
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0 || line.StartsWith('#'))
+                continue;
+
+            var colonIndex = line.IndexOf(':');
+            if (colonIndex <= 0)
+                return false;
+
+            var key = line[..colonIndex].Trim().Replace('-', '_').ToLowerInvariant();
+            var value = Unquote(line[(colonIndex + 1)..].Trim());
+
+            switch (key)
+            {
+                case "title":
+                    title = value;
+                    break;
+                case "scope":
+                    scope = value;
+                    break;
+                case "priority":
+                    priority = value;
+                    break;
+                case "max_bytes":
+                    maxBytes = value;
+                    break;
+                case "applies_to":
+                    appliesTo = value;
+                    break;
+                case "non_override":
+                    nonOverride = value;
+                    break;
+            }
+        }
+
+        frontmatter = new OverlayFrontmatter(title, scope, priority, maxBytes, appliesTo, nonOverride);
+        body = markdown[GetBodyStart(markdown, closingIndex)..].TrimStart('\r', '\n');
+        return true;
+    }
+
+    private static string Unquote(string value)
+    {
+        if (value.Length >= 2 &&
+            ((value[0] == '"' && value[^1] == '"') ||
+             (value[0] == '\'' && value[^1] == '\'')))
+        {
+            return value[1..^1];
+        }
+
+        return value;
+    }
+
+    private static int FindClosingDelimiter(string markdown, int startIndex)
+    {
+        var searchIndex = startIndex;
+        while (searchIndex < markdown.Length)
+        {
+            var delimiterIndex = markdown.IndexOf("\n---", searchIndex, StringComparison.Ordinal);
+            if (delimiterIndex < 0)
+                return -1;
+
+            var afterDashes = delimiterIndex + 4;
+            if (afterDashes == markdown.Length ||
+                markdown[afterDashes] == '\n' ||
+                markdown[afterDashes] == '\r')
+            {
+                return delimiterIndex;
+            }
+
+            searchIndex = afterDashes;
+        }
+
+        return -1;
+    }
+
+    private static int GetBodyStart(string markdown, int closingDelimiterIndex)
+    {
+        var bodyStart = closingDelimiterIndex + 4;
+        if (bodyStart < markdown.Length && markdown[bodyStart] == '\r')
+            bodyStart++;
+        if (bodyStart < markdown.Length && markdown[bodyStart] == '\n')
+            bodyStart++;
+
+        return bodyStart;
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlay/SystemSkillOverlayBuilder.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlay/SystemSkillOverlayBuilder.cs
@@ -1,0 +1,184 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.AI.ToolProviders.Ornn.SystemSkillOverlay;
+
+public sealed class SystemSkillOverlayBuilder : ISystemSkillOverlayBuilder
+{
+    private const string Header = "## System Skill Overlay (force-injected)";
+    private const string SkillMarkdownFileName = "SKILL.md";
+
+    private readonly SystemSkillOverlayOptions _options;
+    private readonly OrnnSkillClient _client;
+    private readonly ILogger _logger;
+
+    public SystemSkillOverlayBuilder(
+        SystemSkillOverlayOptions options,
+        OrnnSkillClient client,
+        ILogger<SystemSkillOverlayBuilder>? logger = null)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _logger = logger ?? NullLogger<SystemSkillOverlayBuilder>.Instance;
+    }
+
+    public async Task<Aevatar.AI.Abstractions.SystemSkillOverlay> BuildAsync(CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(_options.OrgServiceToken) || _options.MaxBytes <= 0)
+            return EmptyOverlay();
+
+        try
+        {
+            var result = await _client.SearchSkillsAsync(
+                _options.OrgServiceToken,
+                query: _options.Tag,
+                scope: "private",
+                pageSize: 100,
+                ct: ct);
+
+            var summaries = result.Items
+                .Where(IsTrustedSystemSkillSummary)
+                .ToArray();
+
+            var entries = new List<OverlaySkillEntry>(summaries.Length);
+            foreach (var summary in summaries)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                if (string.IsNullOrWhiteSpace(summary.Guid))
+                    continue;
+
+                var skill = await _client.GetSkillJsonAsync(_options.OrgServiceToken, summary.Guid, ct);
+                var body = ExtractSkillBody(skill);
+                if (string.IsNullOrWhiteSpace(body))
+                    continue;
+
+                if (!OverlayFrontmatterParser.TryParse(body, out var frontmatter, out var overlayBody) ||
+                    !OverlayAuthoringContract.IsValid(frontmatter))
+                {
+                    continue;
+                }
+
+                entries.Add(new OverlaySkillEntry(
+                    summary.Name ?? skill?.Name ?? summary.Guid,
+                    summary.Description ?? skill?.Description ?? string.Empty,
+                    overlayBody.Trim()));
+            }
+
+            var markdown = BuildWithinBudget(entries);
+            return string.IsNullOrEmpty(markdown)
+                ? EmptyOverlay()
+                : new Aevatar.AI.Abstractions.SystemSkillOverlay
+                {
+                    OverlayMarkdown = markdown,
+                    SourceWatermark = ComputeWatermark(entries),
+                    MaterializedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                };
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "System skill overlay build failed for tag '{Tag}'", _options.Tag);
+            return EmptyOverlay();
+        }
+    }
+
+    private bool IsTrustedSystemSkillSummary(OrnnSkillSummary summary) =>
+        summary.IsPrivate &&
+        summary.Tags != null &&
+        summary.Tags.Contains(_options.Tag);
+
+    private static string? ExtractSkillBody(OrnnSkillJson? skill)
+    {
+        if (skill?.Files == null || skill.Files.Count == 0)
+            return null;
+
+        return skill.Files
+            .FirstOrDefault(static file => file.Key.Equals(SkillMarkdownFileName, StringComparison.OrdinalIgnoreCase))
+            .Value;
+    }
+
+    private string BuildWithinBudget(IReadOnlyList<OverlaySkillEntry> entries)
+    {
+        if (entries.Count == 0)
+            return string.Empty;
+
+        var fullBodyCount = Math.Clamp(_options.MaxSkills, 0, entries.Count);
+        var markdown = Render(entries, fullBodyCount);
+        while (fullBodyCount > 0 && Utf8ByteCount(markdown) > _options.MaxBytes)
+        {
+            fullBodyCount--;
+            markdown = Render(entries, fullBodyCount);
+        }
+
+        if (Utf8ByteCount(markdown) <= _options.MaxBytes)
+            return markdown;
+
+        return RenderCatalogWithinBudget(entries);
+    }
+
+    private static string Render(IReadOnlyList<OverlaySkillEntry> entries, int fullBodyCount)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine(Header);
+
+        for (var i = 0; i < entries.Count; i++)
+        {
+            builder.AppendLine();
+            if (i < fullBodyCount)
+                builder.AppendLine(entries[i].Body);
+            else
+                builder.AppendLine(BuildCatalogLine(entries[i]));
+        }
+
+        return builder.ToString().TrimEnd();
+    }
+
+    private string RenderCatalogWithinBudget(IReadOnlyList<OverlaySkillEntry> entries)
+    {
+        var builder = new StringBuilder(Header);
+        if (Utf8ByteCount(builder.ToString()) > _options.MaxBytes)
+            return string.Empty;
+
+        foreach (var entry in entries)
+        {
+            var candidate = builder.ToString() + Environment.NewLine + Environment.NewLine + BuildCatalogLine(entry);
+            if (Utf8ByteCount(candidate) > _options.MaxBytes)
+                break;
+
+            builder.Clear();
+            builder.Append(candidate);
+        }
+
+        return builder.ToString();
+    }
+
+    private static string BuildCatalogLine(OverlaySkillEntry entry)
+    {
+        var description = string.IsNullOrWhiteSpace(entry.Description)
+            ? "No description."
+            : entry.Description.Trim();
+        return $"- {entry.Name.Trim()}: {description}";
+    }
+
+    private static int Utf8ByteCount(string value) => Encoding.UTF8.GetByteCount(value);
+
+    private static string ComputeWatermark(IReadOnlyList<OverlaySkillEntry> entries)
+    {
+        var canonical = string.Join("\n", entries.Select(static entry => $"{entry.Name}\n{entry.Description}\n{entry.Body}"));
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical))).ToLowerInvariant();
+    }
+
+    private static Aevatar.AI.Abstractions.SystemSkillOverlay EmptyOverlay() =>
+        new()
+        {
+            OverlayMarkdown = string.Empty,
+        };
+
+    private sealed record OverlaySkillEntry(string Name, string Description, string Body);
+}

--- a/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlayOptions.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlayOptions.cs
@@ -1,0 +1,37 @@
+namespace Aevatar.AI.ToolProviders.Ornn;
+
+/// <summary>System skill overlay configuration.</summary>
+public sealed class SystemSkillOverlayOptions
+{
+    /// <summary>
+    /// Host-bound Ornn tag used to select the system skills that may be materialized into the
+    /// persisted role-agent overlay.
+    /// </summary>
+    public string Tag { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Host-bound organization service token used by the future materializer to read system
+    /// skills. This is a secret and must be supplied by host configuration.
+    /// </summary>
+    public string OrgServiceToken { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Minimum interval before the future materializer should refresh the overlay from its source.
+    /// </summary>
+    public TimeSpan RefreshTtl { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
+    /// Maximum number of source skills the future materializer should include in one overlay.
+    /// </summary>
+    public int MaxSkills { get; set; }
+
+    /// <summary>
+    /// Maximum UTF-8 byte budget the future materializer should allow for one overlay.
+    /// </summary>
+    public int MaxBytes { get; set; }
+
+    /// <summary>
+    /// Enables host registration for the system skill overlay scaffold. Defaults to disabled.
+    /// </summary>
+    public bool Enabled { get; set; }
+}

--- a/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
@@ -70,6 +70,33 @@ public sealed class AevatarAIFeatureOptions
     /// NyxID catalog uses a different slug (e.g. organisations that re-registered the service).
     /// </summary>
     public string? OrnnNyxIdSlug { get; set; }
+    /// <summary>
+    /// Enables the host-bound system skill overlay scaffold. Mainnet-style hosts bind this from
+    /// <c>Aevatar:SystemSkills:Enabled</c>.
+    /// </summary>
+    public bool EnableSystemSkillOverlay { get; set; }
+    /// <summary>
+    /// Host-bound Ornn tag used to select system skills. Bound from
+    /// <c>Aevatar:SystemSkills:Tag</c>; this value is sensitive and should come from host secrets.
+    /// </summary>
+    public string? SystemSkillOverlayTag { get; set; }
+    /// <summary>
+    /// Host-bound organization service token used by the future materializer. Bound from
+    /// <c>Aevatar:SystemSkills:OrgServiceToken</c>; this value is a secret.
+    /// </summary>
+    public string? SystemSkillOverlayOrgServiceToken { get; set; }
+    /// <summary>
+    /// Bound from <c>Aevatar:SystemSkills:RefreshTtl</c>.
+    /// </summary>
+    public TimeSpan SystemSkillOverlayRefreshTtl { get; set; }
+    /// <summary>
+    /// Bound from <c>Aevatar:SystemSkills:MaxSkills</c>.
+    /// </summary>
+    public int SystemSkillOverlayMaxSkills { get; set; }
+    /// <summary>
+    /// Bound from <c>Aevatar:SystemSkills:MaxBytes</c>.
+    /// </summary>
+    public int SystemSkillOverlayMaxBytes { get; set; }
     public IAevatarSecretsStore? SecretsStore { get; set; }
     public string? ApiKey { get; set; }
     public NyxIdLlmEndpointSpec? NyxIdLlmEndpoint { get; set; }
@@ -145,6 +172,9 @@ public static class ServiceCollectionExtensions
 
         if (options.EnableOrnnSkills)
             RegisterOrnnSkills(services, options);
+
+        if (options.EnableSystemSkillOverlay)
+            RegisterSystemSkillOverlay(services, options);
 
         if (options.EnableServiceInvokeTools)
             RegisterServiceInvokeTools(services, options);
@@ -1165,6 +1195,22 @@ public static class ServiceCollectionExtensions
         });
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IOrnnSkillPublishAssetValidator, WorkflowOrnnSkillPublishAssetValidator>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IOrnnSkillPublishAssetValidator, ScriptOrnnSkillPublishAssetValidator>());
+    }
+
+    private static void RegisterSystemSkillOverlay(IServiceCollection services, AevatarAIFeatureOptions options)
+    {
+        if (!options.EnableSystemSkillOverlay || string.IsNullOrWhiteSpace(options.SystemSkillOverlayTag))
+            return;
+
+        services.AddSystemSkillOverlay(o =>
+        {
+            o.Enabled = options.EnableSystemSkillOverlay;
+            o.Tag = options.SystemSkillOverlayTag ?? string.Empty;
+            o.OrgServiceToken = options.SystemSkillOverlayOrgServiceToken ?? string.Empty;
+            o.RefreshTtl = options.SystemSkillOverlayRefreshTtl;
+            o.MaxSkills = options.SystemSkillOverlayMaxSkills;
+            o.MaxBytes = options.SystemSkillOverlayMaxBytes;
+        });
     }
 
     private static void RegisterWebTools(IServiceCollection services, AevatarAIFeatureOptions options)

--- a/src/Aevatar.Mainnet.Host.Api/appsettings.json
+++ b/src/Aevatar.Mainnet.Host.Api/appsettings.json
@@ -16,6 +16,14 @@
     "Ornn": {
       "NyxIdSlug": "ornn-api"
     },
+    "SystemSkills": {
+      "Enabled": false,
+      "Tag": "",
+      "OrgServiceToken": "",
+      "RefreshTtl": "00:00:00",
+      "MaxSkills": 0,
+      "MaxBytes": 0
+    },
     "Responses": {
       "ModelMetadataFallbacks": {
         "deepseek": {

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Hosting/AevatarPlatformHostBuilderExtensions.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Hosting/AevatarPlatformHostBuilderExtensions.cs
@@ -49,6 +49,15 @@ public static class AevatarPlatformHostBuilderExtensions
                 aiOptions.EnableSkills = true;
                 aiOptions.EnableOrnnSkills = true;
                 aiOptions.OrnnNyxIdSlug = builder.Configuration["Aevatar:Ornn:NyxIdSlug"];
+                aiOptions.EnableSystemSkillOverlay = ReadBoolean(builder.Configuration["Aevatar:SystemSkills:Enabled"]);
+                aiOptions.SystemSkillOverlayTag = builder.Configuration["Aevatar:SystemSkills:Tag"];
+                aiOptions.SystemSkillOverlayOrgServiceToken = builder.Configuration["Aevatar:SystemSkills:OrgServiceToken"];
+                if (TimeSpan.TryParse(builder.Configuration["Aevatar:SystemSkills:RefreshTtl"], out var refreshTtl))
+                    aiOptions.SystemSkillOverlayRefreshTtl = refreshTtl;
+                if (int.TryParse(builder.Configuration["Aevatar:SystemSkills:MaxSkills"], out var maxSkills))
+                    aiOptions.SystemSkillOverlayMaxSkills = maxSkills;
+                if (int.TryParse(builder.Configuration["Aevatar:SystemSkills:MaxBytes"], out var maxBytes))
+                    aiOptions.SystemSkillOverlayMaxBytes = maxBytes;
                 aiOptions.EnableWebTools = true;
                 aiOptions.WebSearchNyxIdSlug = builder.Configuration["Aevatar:WebSearch:NyxIdSlug"];
                 aiOptions.WebSearchApiBaseUrl = builder.Configuration["Aevatar:WebSearch:ApiBaseUrl"];
@@ -132,4 +141,7 @@ public static class AevatarPlatformHostBuilderExtensions
                 "Maker extensions require workflow capability to be enabled.");
         }
     }
+
+    private static bool ReadBoolean(string? value) =>
+        bool.TryParse(value, out var result) && result;
 }


### PR DESCRIPTION
## What

Implements #2465 — a stateless `ISystemSkillOverlayBuilder` that fetches and renders the forced overlay markdown from organization-owned skills with hardened provenance.

实现 #2465:无状态的 `ISystemSkillOverlayBuilder`,从组织拥有的 skill 拉取并渲染强制 overlay,带来源加固。

## Changes

| File | Change |
|---|---|
| `SystemSkillOverlay/ISystemSkillOverlayBuilder.cs` (new) | interface: `BuildAsync(ct)` |
| `SystemSkillOverlay/SystemSkillOverlayBuilder.cs` (new) | builder impl |
| `SystemSkillOverlay/OverlayFrontmatter.cs` (new) | minimal YAML frontmatter parser (no new dep) |
| `SystemSkillOverlay/OverlayAuthoringContract.cs` (new) | validates title/scope/priority/max_bytes/applies_to/non_override |
| `ServiceCollectionExtensions.cs` | register builder in `AddSystemSkillOverlay` |

## Provenance hardening (acceptance)

- Searches with **`scope="private"`** using the **host OrgServiceToken** — NOT the end-user token, NOT the discovery tool's hardcoded `"mixed"`.
- Provenance filter: `IsPrivate==true AND Tags.Contains(hostTag)`. A public skill carrying the overlay tag is therefore **never** force-injected.
- `MaxSkills` overflow → catalog line (name + description); `MaxBytes` is a hard UTF-8 byte ceiling, never exceeded.
- Error contract: empty token ⇒ empty overlay; `OperationCanceledException` rethrown; any other exception ⇒ empty overlay. The builder never throws to the caller.

Spike findings (#2463) confirmed no server-side org scope exists, so the private-scope + tag filter is the provenance lever.

## Test evidence

```
dotnet build aevatar.slnx → 0 Error(s), 513 Warning(s) (all pre-existing)
```

## Notes

- Depends on #2464 (PR #2471) — branch is based on it.
- `NyxIdRelayPromptConfiguration` consolidation is flagged as a TODO (the move is delicate; deferred for review rather than risk breaking the channel runtime).
- Not wired into prompt building yet — that is #2466/#2467.

Generated by codex (gpt-5.5, xhigh) under manual serial execution of milestone 31. ⟦AI:FKST⟧
