### PR TITLE
Fix frontend millisecond port guard literals

### DIFF
--- a/apps/aevatar-console-web/jest.config.ts
+++ b/apps/aevatar-console-web/jest.config.ts
@@ -69,7 +69,7 @@ function createProjectConfig(target: 'browser' | 'node') {
     moduleNameMapper: buildModuleNameMapper(
       baseConfig.moduleNameMapper as Record<string, unknown> | undefined,
     ),
-    openHandlesTimeout: 5000,
+    openHandlesTimeout: 5_000,
     rootDir,
     roots: ['<rootDir>/src', '<rootDir>/tests'],
     transformIgnorePatterns: ['/node_modules/(?!.*(?:lodash-es)/)'],

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
@@ -119,12 +119,12 @@ const workflowWorkbenchLayoutStyle: React.CSSProperties = {
 
 const workflowEditingSurfaceHeight = 'clamp(560px, calc(100vh - 320px), 760px)';
 const SCRIPT_SAVE_OBSERVATION_POLL_DELAYS_MS = [
-  1000,
-  2000,
-  3000,
-  5000,
-  5000,
-  5000,
+  1_000,
+  2_000,
+  3_000,
+  5_000,
+  5_000,
+  5_000,
 ] as const;
 
 const SCRIPT_STARTER_SOURCE = `using System;


### PR DESCRIPTION
## Summary

- Rewrites frontend millisecond timeout literals that contained bare `5000` text to numeric separator form.
- Keeps runtime values identical while avoiding false positives in simple `5000`/`5050` port-guard scans.

Closes #2423.

## Validation

- `rg -n "\b5000\b|\b5050\b" apps/aevatar-console-web -g '!node_modules' -g '!src/.umi'`\n- `pnpm --dir apps/aevatar-console-web tsc`\n- `pnpm --dir apps/aevatar-console-web test --runInBand --runTestsByPath src/pages/studio/components/StudioBuildPanels.test.tsx`\n- `pnpm --dir apps/aevatar-console-web build`\n- `git diff --check -- apps/aevatar-console-web`\n- `pnpm --dir apps/aevatar-console-web test --runInBand --runTestsByPath src/pages/scopes/assets.test.tsx src/pages/studio/index.test.tsx`\n\nNote: `pnpm --dir apps/aevatar-console-web test:ui` was run once and failed in two unrelated jsdom suites (`src/pages/scopes/assets.test.tsx`, `src/pages/studio/index.test.tsx`). Both failed suites passed when rerun directly with `--runTestsByPath`, and the edited files are limited to millisecond numeric literals.