### PR TITLE
Fix console-web UI test warnings

### DIFF
--- a/apps/aevatar-console-web/src/app.tsx
+++ b/apps/aevatar-console-web/src/app.tsx
@@ -872,8 +872,8 @@ const ConsoleRuntimeProviders: React.FC<ConsoleRuntimeProvidersProps> = ({
 
   return (
     <ConfigProvider
-      autoInsertSpaceInButton={false}
       locale={resolveAntdLocale(currentLocale)}
+      button={{ autoInsertSpace: false }}
       theme={aevatarThemeConfig}
     >
       <ProConfigProvider intl={resolveProIntl(currentLocale)}>

--- a/apps/aevatar-console-web/src/pages/runs/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/runs/index.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/shared/runs/draftRunSession";
 import { saveRecentRun } from "@/shared/runs/recentRuns";
 import { runtimeCatalogApi } from "@/shared/api/runtimeCatalogApi";
+import { runtimeActorsApi } from "@/shared/api/runtimeActorsApi";
 import { runtimeRunsApi } from "@/shared/api/runtimeRunsApi";
 import { parseBackendSSEStream } from "@/shared/agui/sseFrameNormalizer";
 import { renderWithQueryClient } from "../../../tests/reactQueryTestUtils";
@@ -318,6 +319,9 @@ describe("RunsPage", () => {
     signal: jest.Mock;
     stop: jest.Mock;
   };
+  const mockedRuntimeActorsApi = runtimeActorsApi as unknown as {
+    getActorSnapshot: jest.Mock;
+  };
   const mockedParseBackendSSEStream = parseBackendSSEStream as jest.Mock;
 
   beforeEach(() => {
@@ -346,6 +350,27 @@ describe("RunsPage", () => {
       body: {},
     });
     mockedRuntimeRunsApi.streamDraftRun.mockResolvedValue({});
+    mockedRuntimeActorsApi.getActorSnapshot.mockResolvedValue({
+      actorId: "actor-1",
+      workflowName: "Test workflow",
+      lastCommandId: "cmd-1",
+      completionStatusValue: 0,
+      stateVersion: 1,
+      lastEventId: "event-1",
+      lastUpdatedAt: "2026-06-30T00:00:00Z",
+      lastSuccess: true,
+      lastOutput: "",
+      lastError: "",
+      totalSteps: 0,
+      requestedSteps: 0,
+      completedSteps: 0,
+      roleReplyCount: 0,
+      currentStateJson: "{}",
+      timelineCount: 0,
+      parentActorId: null,
+      childActorIds: [],
+      latestEvents: [],
+    });
     mockedRuntimeCatalogApi.listWorkflowCatalog.mockResolvedValue([]);
     mockedParseBackendSSEStream.mockImplementation(
       () => (async function* () {})()
@@ -353,9 +378,13 @@ describe("RunsPage", () => {
   });
 
   it("renders the run console header and setup-first state before any run starts", async () => {
+    const consoleError = jest.spyOn(console, "error");
     const { container } = renderWithQueryClient(React.createElement(RunsPage));
 
     expect(container.textContent).toContain("Run Console");
+    expect(consoleError).not.toHaveBeenCalledWith(
+      expect.stringContaining("`NaN` is an invalid value for the `height`")
+    );
     expect(
       screen.getByRole("button", { name: "Open runtime console guide" })
     );

--- a/apps/aevatar-console-web/tests/setupTests.jsx
+++ b/apps/aevatar-console-web/tests/setupTests.jsx
@@ -114,6 +114,42 @@ if (typeof window !== 'undefined') {
     });
   }
 }
+
+const realGetComputedStyle = window.getComputedStyle.bind(window);
+const textareaAutosizeMetricFallbacks = new Map([
+  ['box-sizing', 'border-box'],
+  ['-moz-box-sizing', 'border-box'],
+  ['-webkit-box-sizing', 'border-box'],
+  ['padding-top', '0px'],
+  ['padding-bottom', '0px'],
+  ['border-top-width', '0px'],
+  ['border-bottom-width', '0px'],
+]);
+
+Object.defineProperty(window, 'getComputedStyle', {
+  configurable: true,
+  value: (element) => {
+    const computedStyle = realGetComputedStyle(element);
+
+    if (!(element instanceof HTMLTextAreaElement)) {
+      return computedStyle;
+    }
+
+    return new Proxy(computedStyle, {
+      get(target, property, receiver) {
+        if (property !== 'getPropertyValue') {
+          return Reflect.get(target, property, receiver);
+        }
+
+        return (name) => {
+          const value = target.getPropertyValue(name);
+          return value || textareaAutosizeMetricFallbacks.get(name) || value;
+        };
+      },
+    });
+  },
+});
+
 const ignoredConsoleErrors = [
   'Warning: An update to %s inside a test was not wrapped in act(...)',
   'inside a test was not wrapped in act(...)',
@@ -123,13 +159,30 @@ const ignoredConsoleErrors = [
   'Warning: [antd: Alert] `message` is deprecated. Please use `title` instead.',
 ];
 
+const isIgnoredConsoleError = (rest) => {
+  const logStr = rest.join('');
+  if (ignoredConsoleErrors.some((message) => logStr.includes(message))) {
+    return true;
+  }
+
+  const [error, details] = rest;
+  const cssDetails = details || error;
+
+  return (
+    error?.message === 'Could not parse CSS stylesheet' &&
+    cssDetails?.type === 'css parsing' &&
+    typeof cssDetails.detail === 'string' &&
+    cssDetails.detail.includes('.ant-steps') &&
+    cssDetails.detail.includes('@container style(--ant-steps-description-max-width)')
+  );
+};
+
 const errorLog = console.error;
 Object.defineProperty(global.window.console, 'error', {
   writable: true,
   configurable: true,
   value: (...rest) => {
-    const logStr = rest.join('');
-    if (ignoredConsoleErrors.some((message) => logStr.includes(message))) {
+    if (isIgnoredConsoleError(rest)) {
       return;
     }
     errorLog(...rest);


### PR DESCRIPTION
## Problem

Closes #2477.

The console-web frontend validation from `origin/dev` was passing, but `test:ui` emitted noisy console warnings/errors that could hide real regressions:

- AntD `ConfigProvider` deprecated `autoInsertSpaceInButton` warning.
- React Query `Query data cannot be undefined` for `run-actor-snapshot` in runs page tests.
- React `height: NaN` style warning from textarea autosize under jsdom.
- jsdom CSS parser noise for AntD Steps generated `@container style(...)` rules.

## FKST provenance

- Skill: aevatar-frontend-fkst
- Issue: #2477
- Worktree: /Users/xiezixin/Documents/work/aevatar-fkst-console-web-audit
- Branch: fix/2026-06-30_console-web-fkst-audit
- Operator: AbigailDeng
- Freshness: issue #2477 created 2026-06-30; user explicitly selected keeping and updating PR #2478 on 2026-07-01.

## Solution

- Migrated `ConfigProvider` to the supported AntD 6 `button.autoInsertSpace` API.
- Added a valid default actor snapshot mock for runs page tests.
- Added a focused regression assertion against the `height: NaN` warning.
- Added jsdom textarea metric fallbacks for rc-textarea autosize.
- Added a narrow test-environment filter for the known AntD Steps container-query parser limitation without broadly silencing CSS errors.

## Impact Paths

- `apps/aevatar-console-web/src/app.tsx`
- `apps/aevatar-console-web/src/pages/runs/index.test.tsx`
- `apps/aevatar-console-web/tests/setupTests.jsx`

Frontend-only change. No backend, root build, CI, solution, or docs files were modified.

## Validation

- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web tsc`
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web jest --selectProjects jsdom --runTestsByPath src/pages/runs/index.test.tsx --runInBand`
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web jest --selectProjects jsdom --runTestsByPath src/app.layout.test.ts --runInBand`
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web jest --selectProjects jsdom --runTestsByPath src/pages/governance/components/GovernanceAuditTimeline.test.tsx --runInBand`
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web test:ui` — 105 suites / 891 tests passed
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web build`
- `bash tools/ci/test_stability_guards.sh`
- `~/.fkst/hosts/aevatar-frontend/run.sh doctor`
- `git diff --check`

## Recurrence Prevention

- Immediate symptom: `test:ui` passed but console emitted AntD deprecation, React Query undefined-data warning, React `height: NaN`, and jsdom CSS parser noise.
- Root cause: AntD ConfigProvider API changed; runs tests did not return valid actor snapshot query data; jsdom lacks browser textarea layout metrics; jsdom 20 cannot parse AntD Steps `@container style(...)` CSS.
- General failure pattern: green tests with noisy console output can hide real UI regressions; async query mocks without valid return contracts; browser-layout-dependent UI libraries running under jsdom.
- Similar locations searched: ConfigProvider usage, runtime actor snapshot mocks, TextArea autoSize callers, GraphCanvas/height style call sites, AntD Steps trigger path.
- Guard added: supported AntD config API, actor snapshot mock contract, textarea metric fallback, narrow AntD Steps css-parser filter.
- Regression test added: runs first-render test asserts no `height: NaN` console error.
- Hard gate: console-web `tsc`, focused jsdom tests, full `test:ui`, build, test stability guard, diff check.
- Remaining risks: future third-party modern CSS can still exceed jsdom parser support; this PR intentionally avoids broad console silencing.

## Rebase update - 2026-07-01

Rebased onto latest `origin/dev` (`cb78de69e01375c67c9a36246ef3da53f177746e`) and force-pushed with lease.

Validation after rebase:

- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web tsc` ✅
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web test:ui --runInBand` ✅ 105 suites / 892 tests passed
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web build` ✅
- `bash tools/ci/test_stability_guards.sh` ✅
- `~/.fkst/hosts/aevatar-frontend/run.sh doctor` ✅
- `git diff --check` ✅
- Frontend scope check: `git diff --name-only origin/dev...HEAD -- ':!apps/aevatar-console-web/**'` returned no files ✅
