### PR TITLE
Add workflow studio invoke entry

### DIFF
--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -962,6 +962,13 @@ const enUSMessages = {
   'teamMemberWorkflowStudio.header.editWorkflowName': 'Edit workflow name',
   'teamMemberWorkflowStudio.header.identityAria': 'Workflow identity',
   'teamMemberWorkflowStudio.header.inputSet': 'input set',
+  'teamMemberWorkflowStudio.header.invoke': 'Invoke',
+  'teamMemberWorkflowStudio.header.invoke.open':
+    'Open the published member invoke workbench.',
+  'teamMemberWorkflowStudio.header.invoke.publishFirst':
+    'Publish this member before invoking it.',
+  'teamMemberWorkflowStudio.header.invoke.saveFirst':
+    'Save this member before invoking it.',
   'teamMemberWorkflowStudio.header.more': 'More',
   'teamMemberWorkflowStudio.header.moreActions': 'More workflow actions',
   'teamMemberWorkflowStudio.header.nodeActionsAria':

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -900,6 +900,13 @@ const zhCNMessages = {
   'teamMemberWorkflowStudio.header.editWorkflowName': '编辑 Workflow 名称',
   'teamMemberWorkflowStudio.header.identityAria': 'Workflow 身份信息',
   'teamMemberWorkflowStudio.header.inputSet': '已设置输入',
+  'teamMemberWorkflowStudio.header.invoke': '调用',
+  'teamMemberWorkflowStudio.header.invoke.open':
+    '打开已发布成员的调用工作台。',
+  'teamMemberWorkflowStudio.header.invoke.publishFirst':
+    '先发布这个成员，再调用它。',
+  'teamMemberWorkflowStudio.header.invoke.saveFirst':
+    '先保存这个成员，再调用它。',
   'teamMemberWorkflowStudio.header.more': '更多',
   'teamMemberWorkflowStudio.header.moreActions': '更多 Workflow 操作',
   'teamMemberWorkflowStudio.header.nodeActionsAria':

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioHeader.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioHeader.tsx
@@ -25,7 +25,10 @@ type WorkflowStudioHeaderProps = {
   readonly automationsHref: string;
   readonly automationsPlaceholderReason?: string;
   readonly canOpenAutomations: boolean;
+  readonly canOpenInvoke: boolean;
   readonly canOpenPublishedRuns: boolean;
+  readonly invokeHref: string;
+  readonly invokePlaceholderReason?: string;
   readonly memberPublished: boolean;
   readonly publishedRunsHref: string;
   readonly publishedRunsPlaceholderReason?: string;
@@ -48,6 +51,7 @@ type WorkflowStudioHeaderProps = {
   readonly currentDraftRunPlaceholderReason?: string;
   readonly onPublishMember: () => void;
   readonly onOpenAutomations: () => void;
+  readonly onOpenInvoke: () => void;
   readonly onOpenPublishedRuns: () => void;
   readonly onRefreshPublishStatus: () => void;
   readonly onAddNode: () => void;
@@ -565,14 +569,18 @@ type HeaderActionsProps = {
   readonly automationsPlaceholderReason?: string;
   readonly canOpenAutomations: boolean;
   readonly canOpenDraftRunPanel: boolean;
+  readonly canOpenInvoke: boolean;
   readonly canOpenPublishedRuns: boolean;
   readonly canSave: boolean;
   readonly canViewYaml: boolean;
+  readonly invokeHref: string;
+  readonly invokePlaceholderReason?: string;
   readonly onAddNode: () => void;
   readonly onDeleteConnection: () => void;
   readonly onDeleteNode: () => void;
   readonly onOpenAutomations: () => void;
   readonly onOpenDraftRunPanel: () => void;
+  readonly onOpenInvoke: () => void;
   readonly onOpenPublishedRuns: () => void;
   readonly onPasteYamlClick: () => void;
   readonly onPublishMember: () => void;
@@ -600,14 +608,18 @@ const HeaderActions: React.FC<HeaderActionsProps> = ({
   automationsPlaceholderReason,
   canOpenAutomations,
   canOpenDraftRunPanel,
+  canOpenInvoke,
   canOpenPublishedRuns,
   canSave,
   canViewYaml,
+  invokeHref,
+  invokePlaceholderReason,
   onAddNode,
   onDeleteConnection,
   onDeleteNode,
   onOpenAutomations,
   onOpenDraftRunPanel,
+  onOpenInvoke,
   onOpenPublishedRuns,
   onPasteYamlClick,
   onPublishMember,
@@ -700,6 +712,23 @@ const HeaderActions: React.FC<HeaderActionsProps> = ({
       >
         <span className="workflow-studio-header__action-label">
           {t('teamMemberWorkflowStudio.header.run', 'Run')}
+        </span>
+      </Button>
+      <Button
+        aria-label={t('teamMemberWorkflowStudio.header.invoke', 'Invoke')}
+        className="workflow-studio-header__compact-button"
+        disabled={!canOpenInvoke}
+        href={canOpenInvoke ? invokeHref : undefined}
+        icon={<PlayCircleOutlined />}
+        onClick={(event) => {
+          event.preventDefault();
+          onOpenInvoke();
+        }}
+        size="small"
+        title={invokePlaceholderReason}
+      >
+        <span className="workflow-studio-header__action-label workflow-studio-header__action-label--secondary">
+          {t('teamMemberWorkflowStudio.header.invoke', 'Invoke')}
         </span>
       </Button>
       <Button
@@ -920,7 +949,10 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
   automationsHref,
   automationsPlaceholderReason,
   canOpenAutomations,
+  canOpenInvoke,
   canOpenPublishedRuns,
+  invokeHref,
+  invokePlaceholderReason,
   memberPublished,
   publishedRunsHref,
   publishedRunsPlaceholderReason,
@@ -938,6 +970,7 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
   currentDraftRunPlaceholderReason,
   onPublishMember,
   onOpenAutomations,
+  onOpenInvoke,
   onOpenPublishedRuns,
   onRefreshPublishStatus,
   onAddNode,
@@ -1009,14 +1042,18 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
           automationsPlaceholderReason={automationsPlaceholderReason}
           canOpenAutomations={canOpenAutomations}
           canOpenDraftRunPanel={canOpenDraftRunPanel}
+          canOpenInvoke={canOpenInvoke}
           canOpenPublishedRuns={canOpenPublishedRuns}
           canSave={canSave}
           canViewYaml={canViewYaml}
+          invokeHref={invokeHref}
+          invokePlaceholderReason={invokePlaceholderReason}
           onAddNode={onAddNode}
           onDeleteConnection={onDeleteConnection}
           onDeleteNode={onDeleteNode}
           onOpenAutomations={onOpenAutomations}
           onOpenDraftRunPanel={onOpenDraftRunPanel}
+          onOpenInvoke={onOpenInvoke}
           onOpenPublishedRuns={onOpenPublishedRuns}
           onPasteYamlClick={onOpenPasteYaml}
           onPublishMember={onPublishMember}

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -17,6 +17,7 @@ import { t } from "@/shared/i18n/messages";
 import {
   buildTeamDetailHref,
   buildTeamMemberAutomationsHref,
+  buildTeamMemberInvokeHref,
   buildTeamMemberPublishedRunsHref,
   buildTeamMemberWorkflowStudioHref,
   buildTeamsHref,
@@ -161,6 +162,9 @@ type TeamMemberWorkflowStudioState = {
   readonly automationsHref: string;
   readonly canOpenAutomations: boolean;
   readonly automationsPlaceholderReason: string;
+  readonly canOpenInvoke: boolean;
+  readonly invokeHref: string;
+  readonly invokePlaceholderReason: string;
   readonly canOpenPublishedRuns: boolean;
   readonly publishedRunsHref: string;
   readonly publishedRunsPlaceholderReason: string;
@@ -176,6 +180,7 @@ type TeamMemberWorkflowStudioState = {
   readonly showRefreshPublishStatus: boolean;
   readonly backHref: string;
   readonly navigateToTeam: () => void;
+  readonly navigateToInvoke: () => void;
   readonly navigateToPublishedRuns: () => void;
   readonly navigateToAutomations: () => void;
   readonly navigateToTeams: () => void;
@@ -2087,6 +2092,33 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
   const memberPublishedServiceId = trimOptional(
     memberQuery.data?.summary.publishedServiceId,
   );
+  const invokeHref = buildTeamMemberInvokeHref({
+    memberId: route.memberId || undefined,
+    scopeId: route.scopeId,
+    teamId: route.teamId,
+  });
+  const canOpenInvoke = Boolean(
+    route.mode === "existing" &&
+      route.scopeId &&
+      route.teamId &&
+      route.memberId &&
+      memberIsPublished &&
+      memberPublishedServiceId,
+  );
+  const invokePlaceholderReason = !route.memberId
+    ? t(
+        "teamMemberWorkflowStudio.header.invoke.saveFirst",
+        "Save this member before invoking it.",
+      )
+    : !memberIsPublished || !memberPublishedServiceId
+      ? t(
+          "teamMemberWorkflowStudio.header.invoke.publishFirst",
+          "Publish this member before invoking it.",
+        )
+      : t(
+          "teamMemberWorkflowStudio.header.invoke.open",
+          "Open the published member invoke workbench.",
+        );
   const publishedRunsHref = buildTeamMemberPublishedRunsHref({
     memberId: route.memberId || undefined,
     scopeId: route.scopeId,
@@ -2644,6 +2676,9 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     automationsHref,
     canOpenAutomations,
     automationsPlaceholderReason,
+    canOpenInvoke,
+    invokeHref,
+    invokePlaceholderReason,
     canOpenPublishedRuns,
     publishedRunsHref,
     publishedRunsPlaceholderReason,
@@ -2681,6 +2716,11 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     navigateToTeams: () => {
       if (!dirty || confirmDiscardUnsavedChanges()) {
         history.push(teamsHref);
+      }
+    },
+    navigateToInvoke: () => {
+      if (canOpenInvoke && (!dirty || confirmDiscardUnsavedChanges())) {
+        history.push(invokeHref);
       }
     },
     navigateToPublishedRuns: () => {

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -548,6 +548,12 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(await screen.findByDisplayValue("Untitled member")).toBeTruthy();
     expect(screen.getByText("Add first step")).toBeTruthy();
     expect(screen.getByText("nodes:0")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Invoke" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Invoke" })).toHaveAttribute(
+      "title",
+      "Save this member before invoking it.",
+    );
+    expect(screen.queryByRole("link", { name: "Invoke" })).toBeNull();
     expect(screen.getByRole("button", { name: "Recurring work" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Recurring work" })).toHaveAttribute(
       "title",
@@ -1694,6 +1700,68 @@ describe("TeamMemberWorkflowStudioPage", () => {
 
     expect(window.location.pathname).toBe(
       "/scopes/scope-1/teams/t-alpha/members/m-alpha/automations",
+    );
+    expect(window.location.search).toBe("");
+    expect(studioApi.getWorkflow).toHaveBeenCalledWith("wf-alpha", "scope-1");
+    expect(studioApi.getWorkflow).not.toHaveBeenCalledWith("m-alpha", "scope-1");
+    expect(studioApi.getWorkflow).not.toHaveBeenCalledWith("svc-alpha", "scope-1");
+  });
+
+  it("opens the published member invoke workbench without passing workflow or service identities", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/workflow?workflowId=wf-alpha&workflowSource=published",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "wf-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: "rev-alpha",
+        lifecycleStage: "bind_ready",
+        memberId: "m-alpha",
+        publishedServiceId: "svc-alpha",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "wf-alpha.yaml",
+      filePath: "scope://scope-1/wf-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "wf-alpha",
+      yaml: "name: Workflow Alpha\nsteps: []\n",
+      document: mockWorkflowDocument,
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    expect(await screen.findByDisplayValue("Workflow Alpha")).toBeTruthy();
+    const invokeLink = await screen.findByRole("link", {
+      name: "Invoke",
+    });
+    expect(invokeLink).toHaveAttribute(
+      "href",
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/invoke",
+    );
+
+    fireEvent.click(invokeLink);
+
+    expect(window.location.pathname).toBe(
+      "/scopes/scope-1/teams/t-alpha/members/m-alpha/invoke",
     );
     expect(window.location.search).toBe("");
     expect(studioApi.getWorkflow).toHaveBeenCalledWith("wf-alpha", "scope-1");

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
@@ -231,7 +231,10 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
         automationsHref={studio.automationsHref}
         automationsPlaceholderReason={studio.automationsPlaceholderReason}
         canOpenAutomations={studio.canOpenAutomations}
+        canOpenInvoke={studio.canOpenInvoke}
         canOpenPublishedRuns={studio.canOpenPublishedRuns}
+        invokeHref={studio.invokeHref}
+        invokePlaceholderReason={studio.invokePlaceholderReason}
         memberPublished={studio.memberPublished}
         publishedRunsHref={studio.publishedRunsHref}
         publishedRunsPlaceholderReason={studio.publishedRunsPlaceholderReason}
@@ -248,6 +251,7 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
         dirty={studio.dirty}
         currentDraftRunPlaceholderReason={studio.currentDraftRunPlaceholderReason}
         onOpenAutomations={studio.navigateToAutomations}
+        onOpenInvoke={studio.navigateToInvoke}
         onOpenPublishedRuns={studio.navigateToPublishedRuns}
         onPublishMember={studio.publishMember}
         onRefreshPublishStatus={studio.refreshPublishStatus}


### PR DESCRIPTION
## Summary
- Add an Invoke action to the Team Member Workflow Studio header, placed beside Run for published workflow members.
- Route the action to the canonical member invoke surface: `/scopes/:scopeId/teams/:teamId/members/:memberId/invoke`.
- Keep identity boundaries explicit: `workflowId` is only used to load the workflow, while `publishedServiceId` only gates invoke availability and is never used to construct the invoke route.

## Test Plan
- [x] `pnpm --dir apps/aevatar-console-web test:ui --runInBand src/pages/team-member-workflow-studio/index.test.tsx -t "published member invoke workbench|blank new workflow member editor"`
- [x] `pnpm --dir apps/aevatar-console-web test:ui --runInBand src/pages/team-member-workflow-studio/index.test.tsx`
- [x] `pnpm --dir apps/aevatar-console-web tsc`
- [x] `bash tools/ci/test_stability_guards.sh`
- [x] `git diff --check`
