### PR TITLE
Fix NyxID broker redirect URI handling

### DIFF
--- a/apps/aevatar-console-web/src/shared/auth/backend.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/backend.test.ts
@@ -41,7 +41,7 @@ describe("NyxID backend auth API", () => {
     });
   });
 
-  it("ignores redirect URI fields on the backend login config boundary", async () => {
+  it("loads the optional broker redirect URI when the backend provides it", async () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -58,6 +58,7 @@ describe("NyxID backend auth API", () => {
     await expect(loadBackendNyxIDLoginConfig()).resolves.toEqual({
       baseUrl: "https://nyx.example",
       clientId: "broker-client-1",
+      redirectUri: "https://backend.example/auth/callback",
       scope: "openid urn:nyxid:scope:broker_binding proxy",
     });
   });

--- a/apps/aevatar-console-web/src/shared/auth/backend.ts
+++ b/apps/aevatar-console-web/src/shared/auth/backend.ts
@@ -5,7 +5,9 @@ import type { NyxIDAuthSession, NyxIDTokenSet, NyxIDUserInfo } from "./session";
 export type NyxIDBackendLoginConfig = Pick<
   NyxIDRuntimeConfig,
   "baseUrl" | "clientId" | "scope"
->;
+> & {
+  readonly redirectUri?: string;
+};
 
 export type NyxIDLoginFinalizationRequest = {
   readonly code: string;
@@ -29,6 +31,8 @@ type BackendLoginConfigResponse = {
   readonly BaseUrl?: unknown;
   readonly clientId?: unknown;
   readonly ClientId?: unknown;
+  readonly redirectUri?: unknown;
+  readonly RedirectUri?: unknown;
   readonly scope?: unknown;
   readonly Scope?: unknown;
 };
@@ -142,6 +146,9 @@ function decodeBackendLoginConfig(
 ): NyxIDBackendLoginConfig {
   const record = expectRecord(value, "NyxID backend login config") as
     BackendLoginConfigResponse;
+  const redirectUri = readOptionalString(
+    record.redirectUri ?? record.RedirectUri,
+  );
 
   return {
     baseUrl: readString(record.baseUrl ?? record.BaseUrl, "baseUrl").replace(
@@ -149,6 +156,7 @@ function decodeBackendLoginConfig(
       "",
     ),
     clientId: readString(record.clientId ?? record.ClientId, "clientId"),
+    ...(redirectUri ? { redirectUri } : {}),
     scope: readString(record.scope ?? record.Scope, "scope"),
   };
 }

--- a/apps/aevatar-console-web/src/shared/auth/client.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/client.test.ts
@@ -65,7 +65,7 @@ describe("NyxIDAuthClient", () => {
     window.localStorage.clear();
   });
 
-  it("starts authorize with the backend broker OAuth client config", async () => {
+  it("starts authorize with the backend broker OAuth client config and redirect URI", async () => {
     const assign = installLocationAssignSpy();
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,
@@ -95,7 +95,7 @@ describe("NyxIDAuthClient", () => {
     );
     expect(authorizeUrl.searchParams.get("client_id")).toBe("broker-client-1");
     expect(authorizeUrl.searchParams.get("redirect_uri")).toBe(
-      "http://localhost:8000/auth/callback",
+      "https://backend.example/auth/callback",
     );
     expect(authorizeUrl.searchParams.get("scope")).toBe(
       "openid profile email offline_access urn:nyxid:scope:broker_binding proxy",
@@ -109,12 +109,39 @@ describe("NyxIDAuthClient", () => {
     expect(pending).toEqual(
       expect.objectContaining({
         clientId: "broker-client-1",
-        redirectUri: "http://localhost:8000/auth/callback",
+        redirectUri: "https://backend.example/auth/callback",
         returnTo: "/scopes/scope-1/teams",
         scope: "openid profile email offline_access urn:nyxid:scope:broker_binding proxy",
         state: authorizeUrl.searchParams.get("state"),
       }),
     );
+  });
+
+  it("falls back to the frontend callback redirect URI for older backend config responses", async () => {
+    const assign = installLocationAssignSpy();
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        baseUrl: "https://nyx.example",
+        clientId: "broker-client-1",
+        scope: "openid urn:nyxid:scope:broker_binding proxy",
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await new NyxIDAuthClient(runtimeConfig).loginWithRedirect();
+
+    const authorizeUrl = new URL(assign.mock.calls[0][0]);
+    expect(authorizeUrl.searchParams.get("redirect_uri")).toBe(
+      "http://localhost:8000/auth/callback",
+    );
+    const pending = JSON.parse(
+      window.localStorage.getItem(
+        "aevatar-console:nyxid:pending:broker-client-1",
+      ) ?? "{}",
+    );
+    expect(pending.redirectUri).toBe("http://localhost:8000/auth/callback");
   });
 
   it("finalizes callback through the backend without a browser token exchange", async () => {

--- a/apps/aevatar-console-web/src/shared/auth/client.ts
+++ b/apps/aevatar-console-web/src/shared/auth/client.ts
@@ -93,7 +93,7 @@ export class NyxIDAuthClient {
     const codeChallenge = await sha256Base64Url(codeVerifier);
     const state = randomUrlSafeString(24);
     const loginConfig = await loadBackendNyxIDLoginConfig();
-    const redirectUri = this.config.redirectUri;
+    const redirectUri = loginConfig.redirectUri ?? this.config.redirectUri;
     const scope = loginConfig.scope;
     const returnTo = sanitizeReturnTo(options.returnTo);
 


### PR DESCRIPTION
Closes #2303

## Problem

Console NyxID login decoded only `baseUrl`, `clientId`, and `scope` from `/api/auth/nyxid/config`, then always used the frontend fallback callback URI for broker authorization. When the backend broker OAuth client is registered with a different callback, NyxID can reject authorize before the console callback with `invalid_redirect_uri`.

## Solution

- Decode optional backend `redirectUri` / `RedirectUri` from `/api/auth/nyxid/config`.
- Prefer the backend-provided broker redirect URI when building the authorize URL.
- Persist the exact authorize redirect URI in the pending PKCE state so finalize receives the same value.
- Keep the frontend fallback redirect URI for older backend config responses.

## Impact Paths

- `apps/aevatar-console-web/src/shared/auth/backend.ts`
- `apps/aevatar-console-web/src/shared/auth/client.ts`
- `apps/aevatar-console-web/src/shared/auth/backend.test.ts`
- `apps/aevatar-console-web/src/shared/auth/client.test.ts`

## Validation

- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web jest --selectProjects jsdom --runTestsByPath src/shared/auth/client.test.ts src/shared/auth/backend.test.ts src/shared/api/scheduledDispatchApi.test.ts --runInBand`: passed, 3 suites / 27 tests
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web tsc`: passed
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web test:ui`: passed, 105 suites / 892 tests; known console noise is already tracked by #2477 / #2478
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web build`: passed; only existing Browserslist caniuse-lite warning
- `bash tools/ci/test_stability_guards.sh`: passed
- `git diff --check`: passed
- Frontend boundary check: no changed paths outside `apps/aevatar-console-web/**`

## Recurrence Prevention

- Immediate symptom: NyxID authorize can fail before callback with `invalid_redirect_uri` when the backend broker OAuth client has a registered callback different from the frontend fallback.
- Root cause: The frontend decoded only `baseUrl`, `clientId`, and `scope` from `/api/auth/nyxid/config`, then always used its local fallback `redirectUri` for broker-client authorization.
- General failure pattern: OAuth authorize/finalize flow split across frontend/backend used duplicated redirect URI authority; the broker client contract was not fully represented in the frontend config type.
- Similar locations searched: NyxID login client, backend config decoder, callback finalization, token refresh, scheduled dispatch owner-binding lag handling, existing NyxID auth tests, and related #2303 history.
- Guard added: `NyxIDBackendLoginConfig` now models optional `redirectUri`; authorize URL and pending PKCE state use the backend-provided value when present.
- Regression test added: auth client test verifies backend broker `redirectUri` is used and persisted; fallback test covers older backend config responses; backend decoder test verifies optional `redirectUri`.
- Hard gate: focused auth/schedule tests, `tsc`, full `test:ui`, `build`, `test_stability_guards.sh`, `git diff --check`, and frontend-only path check.
- Remaining risks: The deployed backend must return a redirect URI registered for the broker OAuth client, or NyxID must register the frontend fallback URI; the frontend cannot override provider registration.
