### PR TITLE
Fix Studio run stop availability

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -3064,15 +3064,17 @@ jest.mock("./components/StudioWorkbenchSections", () => {
           "Execution stop requested",
           "Execution stop failed"
         ),
-        React.createElement(
-          "button",
-          {
-            key: "stop",
-            type: "button",
-            onClick: () => props.onStopExecution?.(),
-          },
-          "Stop"
-        ),
+        props.executionCanStop
+          ? React.createElement(
+              "button",
+              {
+                key: "stop",
+                type: "button",
+                onClick: () => props.onStopExecution?.(),
+              },
+              "Stop"
+            )
+          : null,
       ].filter(Boolean)
     );
 
@@ -8197,6 +8199,30 @@ describe("StudioPage", () => {
     });
 
     expect(await screen.findByText("Execution stop requested")).toBeTruthy();
+  });
+
+  it("does not offer stop before the selected member has a runnable execution", async () => {
+    mockScopeRuntimeApi.listServiceRuns.mockResolvedValueOnce({
+      scopeId: "scope-1",
+      serviceId: "default",
+      serviceKey: "scope-1:default:default:default",
+      displayName: "workspace-demo",
+      runs: [],
+    });
+
+    renderStudioPage(
+      "/studio?scopeId=scope-1&memberId=default&step=observe&tab=executions"
+    );
+
+    expect(await screen.findByText("Logs")).toBeTruthy();
+
+    await waitFor(() => {
+      expect(screen.getByText("observe-runs:none")).toBeTruthy();
+      expect(screen.getByText("observe-selected:none")).toBeTruthy();
+    });
+
+    expect(screen.queryByRole("button", { name: "Stop" })).toBeNull();
+    expect(mockRuntimeRunsApi.stop).not.toHaveBeenCalled();
   });
 
   it("falls back to the build editor when a removed roles tab still carries a workflow draft", async () => {

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -1254,6 +1254,10 @@ function clearStudioAutoReloginAttempt(returnTo: string): void {
 
 function isExecutionStopAllowed(status: string | undefined): boolean {
   const normalized = status?.trim().toLowerCase() ?? '';
+  if (!normalized) {
+    return false;
+  }
+
   return !['completed', 'failed', 'stopped', 'cancelled'].includes(normalized);
 }
 
@@ -10256,12 +10260,14 @@ const StudioPage: React.FC = () => {
       ? trimOptional(workbenchPublishedServiceRevision?.workflowName)
       : '') ||
     currentMemberImplementationLabel;
-  const executionCanStop = isExecutionStopAllowed(
-    selectedExecutionQuery.data?.status ||
-      (selectedObserveBackendRunSummary
-        ? normalizeObserveRunStatus(selectedObserveBackendRunSummary.completionStatus)
-        : selectedObserveFallbackExecution?.status),
-  );
+  const executionCanStop =
+    selectedExecutionInCurrentMember &&
+    isExecutionStopAllowed(
+      selectedExecutionQuery.data?.status ||
+        (selectedObserveBackendRunSummary
+          ? normalizeObserveRunStatus(selectedObserveBackendRunSummary.completionStatus)
+          : selectedObserveFallbackExecution?.status),
+    );
   const observeEmptyState = useMemo(() => {
     if (!hasSelectedMemberFocus) {
       return {


### PR DESCRIPTION
## Summary
- require a selected current-member execution before Studio Observe exposes the stop action
- treat blank execution status as not stoppable, so the initial/no-run state no longer shows a dead Stop button
- update the Studio page test mock to respect `executionCanStop` and add a no-run regression test

Closes #227

## Validation
- `pnpm --dir apps/aevatar-console-web tsc`
- `pnpm --dir apps/aevatar-console-web test:ui`
- `pnpm --dir apps/aevatar-console-web build`