### PR TITLE
Fix scoped workflow first-edit draft lookup

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -483,6 +483,32 @@ function mockCreateDefaultTeamSummary(overrides: Record<string, unknown> = {}) {
   };
 }
 
+async function mockBindMemberWorkflowSuccess(input: {
+  scopeId: string;
+  memberId: string;
+  displayName?: string;
+  workflowId: string;
+  workflowYamls: string[];
+}) {
+  mockStudioMembers = mockStudioMembers.map((member) =>
+    member.memberId === input.memberId
+      ? {
+          ...member,
+          lifecycleStage: "bind_ready",
+          lastBoundRevisionId: "rev-2",
+          updatedAt: "2026-04-27T08:15:00Z",
+        }
+      : member
+  );
+
+  return {
+    status: "accepted",
+    bindingRunId: "bind-member-workflow-1",
+    scopeId: input.scopeId,
+    memberId: input.memberId,
+  };
+}
+
 async function mockAuthorWorkflowSuccess(
   _input: { prompt: string },
   options?: {
@@ -1270,31 +1296,7 @@ jest.mock("@/shared/studio/api", () => ({
         expectedActorId: `scope-script:${input.scopeId}:${serviceId}:dep-1`,
       };
     }),
-    bindMemberWorkflow: jest.fn(async (input: {
-      scopeId: string;
-      memberId: string;
-      displayName?: string;
-      workflowId: string;
-      workflowYamls: string[];
-    }) => {
-      mockStudioMembers = mockStudioMembers.map((member) =>
-        member.memberId === input.memberId
-          ? {
-              ...member,
-              lifecycleStage: "bind_ready",
-              lastBoundRevisionId: "rev-2",
-              updatedAt: "2026-04-27T08:15:00Z",
-            }
-          : member
-      );
-
-      return {
-        status: "accepted",
-        bindingRunId: "bind-member-workflow-1",
-        scopeId: input.scopeId,
-        memberId: input.memberId,
-      };
-    }),
+    bindMemberWorkflow: jest.fn(mockBindMemberWorkflowSuccess),
     bindMemberGAgent: jest.fn(async (input: {
       scopeId: string;
       memberId: string;
@@ -3367,6 +3369,10 @@ describe("StudioPage", () => {
     (studioApi.authorWorkflow as jest.Mock).mockReset();
     (studioApi.authorWorkflow as jest.Mock).mockImplementation(
       mockAuthorWorkflowSuccess
+    );
+    (studioApi.bindMemberWorkflow as jest.Mock).mockReset();
+    (studioApi.bindMemberWorkflow as jest.Mock).mockImplementation(
+      mockBindMemberWorkflowSuccess
     );
     (studioApi.getScopeBinding as jest.Mock).mockReset();
     (studioApi.getScopeBinding as jest.Mock).mockResolvedValue({
@@ -5784,41 +5790,50 @@ describe("StudioPage", () => {
         updatedAtUtc: "2026-03-18T00:10:00Z",
       },
     ]);
-    mockScopeRuntimeApi.listServices
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([
+    let defaultServicePublished = false;
+    const defaultService = {
+      serviceId: "default",
+      displayName: "draft2",
+      deploymentStatus: "Active",
+      primaryActorId: "actor-default",
+      endpoints: [
         {
-          serviceId: "default",
-          displayName: "draft2",
-          deploymentStatus: "Active",
-          primaryActorId: "actor-default",
-          endpoints: [
-            {
-              endpointId: "chat",
-              displayName: "Chat",
-              kind: "chat",
-              description: "Chat with the published workflow.",
-              requestTypeUrl: "",
-              responseTypeUrl: "",
-            },
-          ],
+          endpointId: "chat",
+          displayName: "Chat",
+          kind: "chat",
+          description: "Chat with the published workflow.",
+          requestTypeUrl: "",
+          responseTypeUrl: "",
         },
-      ]);
-    (studioApi.getScopeBinding as jest.Mock).mockResolvedValueOnce(null);
-    (studioApi.getMemberBindingRun as jest.Mock).mockResolvedValueOnce({
-      bindingRunId: "bind-member-workflow-1",
-      scopeId: "scope-1",
-      memberId: "workspace-demo",
-      status: "succeeded",
-      result: {
-        publishedServiceId: "default",
-        revisionId: "rev-2",
-        implementationKind: "workflow",
-        expectedActorId: "actor-default",
+      ],
+    };
+    mockScopeRuntimeApi.listServices.mockImplementation(async () =>
+      defaultServicePublished ? [defaultService] : [],
+    );
+    (studioApi.bindMemberWorkflow as jest.Mock).mockImplementation(
+      async (input: Parameters<typeof mockBindMemberWorkflowSuccess>[0]) => {
+        defaultServicePublished = true;
+        return mockBindMemberWorkflowSuccess(input);
       },
-      failure: null,
-      updatedAt: "2026-04-27T08:15:01Z",
-    });
+    );
+    (studioApi.getScopeBinding as jest.Mock).mockResolvedValueOnce(null);
+    (studioApi.getMemberBindingRun as jest.Mock).mockImplementation(
+      async (scopeId: string, memberId: string, bindingRunId: string) => ({
+        bindingRunId,
+        scopeId,
+        memberId,
+        status: "succeeded",
+        result: {
+          publishedServiceId:
+            memberId === "workspace-demo" ? "default" : `member-${memberId}`,
+          revisionId: "rev-2",
+          implementationKind: "workflow",
+          expectedActorId: "actor-default",
+        },
+        failure: null,
+        updatedAt: "2026-04-27T08:15:01Z",
+      }),
+    );
     mockScopeRuntimeApi.getServiceRevisions.mockImplementation(
       async () =>
         mockBuildServiceRevisionCatalog({
@@ -5963,29 +5978,39 @@ describe("StudioPage", () => {
     mockScopeRuntimeApi.listServices.mockImplementation(async () =>
       draft1ServicePublished ? [draft2Service, draft1Service] : [draft2Service],
     );
-    (studioApi.bindMemberWorkflow as jest.Mock).mockImplementationOnce(async () => {
-      draft1ServicePublished = true;
-      return {
-      status: "accepted",
-      bindingRunId: "bind-draft1",
-      scopeId: "scope-1",
-      memberId: "draft1",
-      };
-    });
-    (studioApi.getMemberBindingRun as jest.Mock).mockResolvedValueOnce({
-      bindingRunId: "bind-draft1",
-      scopeId: "scope-1",
-      memberId: "draft1",
-      status: "succeeded",
-      result: {
-        publishedServiceId: "draft1",
-        revisionId: "rev-draft1",
-        implementationKind: "workflow",
-        expectedActorId: "actor-draft1",
+    (studioApi.bindMemberWorkflow as jest.Mock).mockImplementation(
+      async (input: Parameters<typeof mockBindMemberWorkflowSuccess>[0]) => {
+        if (input.memberId !== "draft1") {
+          return mockBindMemberWorkflowSuccess(input);
+        }
+
+        draft1ServicePublished = true;
+        await mockBindMemberWorkflowSuccess(input);
+        return {
+          status: "accepted",
+          bindingRunId: "bind-draft1",
+          scopeId: input.scopeId,
+          memberId: input.memberId,
+        };
       },
-      failure: null,
-      updatedAt: "2026-04-27T08:15:01Z",
-    });
+    );
+    (studioApi.getMemberBindingRun as jest.Mock).mockImplementation(
+      async (scopeId: string, memberId: string, bindingRunId: string) => ({
+        bindingRunId,
+        scopeId,
+        memberId,
+        status: "succeeded",
+        result: {
+          publishedServiceId: memberId === "draft1" ? "draft1" : "default",
+          revisionId: memberId === "draft1" ? "rev-draft1" : "rev-2",
+          implementationKind: "workflow",
+          expectedActorId:
+            memberId === "draft1" ? "actor-draft1" : "actor-default",
+        },
+        failure: null,
+        updatedAt: "2026-04-27T08:15:01Z",
+      }),
+    );
     (studioApi.getScopeBinding as jest.Mock).mockResolvedValue({
       available: true,
       scopeId: "scope-1",

--- a/apps/aevatar-console-web/src/shared/studio/api.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.test.ts
@@ -510,6 +510,84 @@ describe('studioApi host-session requests', () => {
     ]);
   });
 
+  it('associates opaque first-edit scoped drafts with the published workflow entry', async () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: 'access-token',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        expiresAt: Date.now() + 3_600_000,
+      },
+      user: {
+        sub: 'user-1',
+      },
+    });
+
+    const fetchMock = jest.fn().mockImplementation(async (input: string) => {
+      if (input === '/api/workspace/workflow-drafts?scopeId=scope-1') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              workflowId: 'opaque-draft-id',
+              name: 'published-demo',
+              description: 'first edit draft',
+              fileName: 'workflow-1.yaml',
+              filePath: 'scope://scope-1/workflow-1.yaml',
+              directoryId: 'scope:scope-1',
+              directoryLabel: 'scope-1',
+              stepCount: 2,
+              hasLayout: true,
+              updatedAtUtc: '2026-04-18T00:00:00Z',
+            },
+          ],
+        } as Response;
+      }
+
+      if (input === '/api/scopes/scope-1/workflows?includeSource=false') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              scopeId: 'scope-1',
+              workflowId: 'workflow-1',
+              displayName: 'published-demo',
+              serviceKey: 'svc-1',
+              workflowName: 'published-demo',
+              actorId: 'actor-1',
+              activeRevisionId: 'rev-1',
+              deploymentId: 'dep-1',
+              deploymentStatus: 'Running',
+              updatedAt: '2026-04-16T00:00:00Z',
+            },
+          ],
+        } as Response;
+      }
+
+      throw new Error(`Unexpected request: ${input}`);
+    });
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(studioApi.listWorkflows('scope-1')).resolves.toEqual([
+      {
+        activeRevisionId: 'rev-1',
+        serviceKey: 'svc-1',
+        workflowId: 'opaque-draft-id',
+        name: 'published-demo',
+        description: 'first edit draft',
+        fileName: 'workflow-1.yaml',
+        filePath: 'scope://scope-1/workflow-1.yaml',
+        directoryId: 'scope:scope-1',
+        directoryLabel: 'scope-1',
+        stepCount: 2,
+        hasLayout: true,
+        updatedAtUtc: '2026-04-18T00:00:00Z',
+      },
+    ]);
+  });
+
   it('falls back to the published scope workflow detail when a scoped draft is missing', async () => {
     persistAuthSession({
       tokens: {
@@ -561,6 +639,14 @@ describe('studioApi host-session requests', () => {
         } as Response;
       }
 
+      if (input === '/api/workspace/workflow-drafts?scopeId=scope-1') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [],
+        } as Response;
+      }
+
       throw new Error(`Unexpected request: ${input}`);
     });
     global.fetch = fetchMock as typeof global.fetch;
@@ -577,6 +663,116 @@ describe('studioApi host-session requests', () => {
       draftExists: false,
       findings: [],
       updatedAtUtc: '2026-04-16T00:00:00Z',
+    });
+  });
+
+  it('loads an opaque first-edit scoped draft when opening the published workflow id', async () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: 'access-token',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        expiresAt: Date.now() + 3_600_000,
+      },
+      user: {
+        sub: 'user-1',
+      },
+    });
+
+    const fetchMock = jest.fn().mockImplementation(async (input: string) => {
+      if (input === '/api/workspace/workflow-drafts/workflow-1?scopeId=scope-1') {
+        return {
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+          text: async () => JSON.stringify({ title: 'Not Found', status: 404 }),
+        } as Response;
+      }
+
+      if (input === '/api/workspace/workflow-drafts?scopeId=scope-1') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              workflowId: 'opaque-draft-id',
+              name: 'published-demo',
+              description: 'first edit draft',
+              fileName: 'workflow-1.yaml',
+              filePath: 'scope://scope-1/workflow-1.yaml',
+              directoryId: 'scope:scope-1',
+              directoryLabel: 'scope-1',
+              stepCount: 2,
+              hasLayout: true,
+              updatedAtUtc: '2026-04-18T00:00:00Z',
+            },
+          ],
+        } as Response;
+      }
+
+      if (input === '/api/workspace/workflow-drafts/opaque-draft-id?scopeId=scope-1') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            workflowId: 'opaque-draft-id',
+            name: 'published-demo',
+            fileName: 'workflow-1.yaml',
+            filePath: 'scope://scope-1/workflow-1.yaml',
+            directoryId: 'scope:scope-1',
+            directoryLabel: 'scope-1',
+            yaml: 'name: published-demo\nsteps:\n  - id: approve_step\n',
+            layout: null,
+            updatedAtUtc: '2026-04-18T00:00:00Z',
+          }),
+        } as Response;
+      }
+
+      if (input === '/api/scopes/scope-1/workflows/workflow-1') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            available: true,
+            scopeId: 'scope-1',
+            workflow: {
+              scopeId: 'scope-1',
+              workflowId: 'workflow-1',
+              displayName: 'published-demo',
+              serviceKey: 'svc-1',
+              workflowName: 'published-demo',
+              actorId: 'actor-1',
+              activeRevisionId: 'rev-1',
+              deploymentId: 'dep-1',
+              deploymentStatus: 'Running',
+              updatedAt: '2026-04-16T00:00:00Z',
+            },
+            source: {
+              workflowYaml: 'name: published-demo\nsteps: []\n',
+              definitionActorId: 'definition-1',
+              inlineWorkflowYamls: null,
+            },
+          }),
+        } as Response;
+      }
+
+      throw new Error(`Unexpected request: ${input}`);
+    });
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(studioApi.getWorkflow('workflow-1', 'scope-1')).resolves.toEqual({
+      workflowId: 'opaque-draft-id',
+      name: 'published-demo',
+      fileName: 'workflow-1.yaml',
+      filePath: 'scope://scope-1/workflow-1.yaml',
+      directoryId: 'scope:scope-1',
+      directoryLabel: 'scope-1',
+      yaml: 'name: published-demo\nsteps:\n  - id: approve_step\n',
+      document: null,
+      draftExists: true,
+      findings: [],
+      layout: null,
+      updatedAtUtc: '2026-04-18T00:00:00Z',
     });
   });
 

--- a/apps/aevatar-console-web/src/shared/studio/api.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.ts
@@ -179,6 +179,19 @@ function toScopeWorkflowPath(scopeId: string, workflowId: string): string {
   return `scope://${scopeId}/${workflowId}.yaml`;
 }
 
+function normalizeCaseInsensitiveKey(value: string | null | undefined): string {
+  return trimOptional(value)?.toLowerCase() ?? "";
+}
+
+function buildScopedWorkflowDraftAssociationKey(input: {
+  readonly directoryId?: string | null;
+  readonly fileName?: string | null;
+}): string {
+  const directoryId = normalizeCaseInsensitiveKey(input.directoryId);
+  const fileName = normalizeCaseInsensitiveKey(input.fileName);
+  return directoryId && fileName ? `${directoryId}/${fileName}` : "";
+}
+
 function resolveScopeWorkflowName(workflow: ScopeWorkflowSummary): string {
   return workflow.displayName?.trim() || workflow.workflowName?.trim() || workflow.workflowId;
 }
@@ -201,6 +214,37 @@ function toCommittedWorkflowSummary(
     hasLayout: false,
     updatedAtUtc: workflow.updatedAt,
   };
+}
+
+function findScopedDraftForCommittedWorkflow(
+  drafts: readonly StudioWorkflowDraftSummary[],
+  committed: {
+    readonly workflowId: string;
+    readonly directoryId: string;
+    readonly fileName: string;
+  }
+): StudioWorkflowDraftSummary | null {
+  const committedWorkflowId = trimOptional(committed.workflowId);
+  const directMatch = drafts.find(
+    (draft) => trimOptional(draft.workflowId) === committedWorkflowId
+  );
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const committedAssociationKey =
+    buildScopedWorkflowDraftAssociationKey(committed);
+  if (!committedAssociationKey) {
+    return null;
+  }
+
+  return (
+    drafts.find(
+      (draft) =>
+        buildScopedWorkflowDraftAssociationKey(draft) ===
+        committedAssociationKey
+    ) ?? null
+  );
 }
 
 function toCommittedWorkflowFile(
@@ -2249,15 +2293,40 @@ export const studioApi = {
       scopesApi.listWorkflows(normalizedScopeId),
     ]).then(([drafts, committed]) => {
       const merged = new Map<string, StudioWorkflowSummary>();
+      const associatedDraftIds = new Set<string>();
 
       for (const workflow of committed) {
-        merged.set(
-          workflow.workflowId,
-          toCommittedWorkflowSummary(normalizedScopeId, workflow)
+        const committedSummary = toCommittedWorkflowSummary(
+          normalizedScopeId,
+          workflow
         );
+        const draft = findScopedDraftForCommittedWorkflow(
+          drafts,
+          committedSummary
+        );
+
+        if (!draft) {
+          merged.set(workflow.workflowId, committedSummary);
+          continue;
+        }
+
+        associatedDraftIds.add(draft.workflowId);
+        merged.set(draft.workflowId, {
+          ...draft,
+          activeRevisionId: committedSummary.activeRevisionId ?? null,
+          serviceKey: committedSummary.serviceKey ?? null,
+          updatedAtUtc: selectLatestTimestamp(
+            draft.updatedAtUtc,
+            committedSummary.updatedAtUtc
+          ),
+        });
       }
 
       for (const draft of drafts) {
+        if (associatedDraftIds.has(draft.workflowId)) {
+          continue;
+        }
+
         const existing = merged.get(draft.workflowId);
         merged.set(
           draft.workflowId,
@@ -2302,9 +2371,21 @@ export const studioApi = {
       return toWorkflowFile(draft, true);
     }
 
-    return toCommittedWorkflowFile(
+    const committedWorkflow = toCommittedWorkflowFile(
       normalizedScopeId,
       await scopesApi.getWorkflowDetail(normalizedScopeId, workflowId)
+    );
+    const associatedDraftSummary = findScopedDraftForCommittedWorkflow(
+      await this.listWorkflowDrafts(normalizedScopeId),
+      committedWorkflow
+    );
+    if (!associatedDraftSummary) {
+      return committedWorkflow;
+    }
+
+    return this.getWorkflowDraftFile(
+      associatedDraftSummary.workflowId,
+      normalizedScopeId
     );
   },
 


### PR DESCRIPTION
## Summary

Fixes #2006.

This PR keeps first-edit scoped workflow drafts associated with their published workflow entry even when the backend creates the draft with a new opaque `workflowId`.

Changes:
- Centralizes scoped draft-to-published workflow association in `studioApi`.
- Keeps exact `workflowId` matching first, then falls back to the scoped `directoryId + fileName` association that the frontend already controls when creating first-edit drafts.
- Applies the association in both `listWorkflows(scopeId)` and `getWorkflow(publishedWorkflowId, scopeId)` so the Studio rail does not show duplicate drafts and reopening the published id loads the draft.
- Adds regression coverage for the duplicate-list symptom and the reopened-committed-id symptom.

## Validation

- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web install --frozen-lockfile` ✅
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web test:ui --runTestsByPath src/shared/studio/api.test.ts --runInBand` ✅ 46 tests
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web test:ui --runTestsByPath src/pages/studio/index.test.tsx --runInBand` ✅ 113 tests
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web tsc` ✅
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web test:ui --runInBand` ✅ 105 suites / 894 tests
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web build` ✅
- `bash tools/ci/test_stability_guards.sh` ✅
- `git diff --check` ✅
- Frontend scope check: `git diff --name-only -- ':!apps/aevatar-console-web/**'` returned no paths ✅

Notes:
- Full UI tests still print existing jsdom/antd console warnings unrelated to this change, but the suite exits successfully.
- Build still prints the existing Browserslist caniuse-lite warning.

## Recurrence prevention

- Immediate symptom: First edit of a published scoped workflow could appear as a separate opaque draft, and reopening the published workflow id could ignore that draft.
- Root cause: Scoped workflow draft reconciliation assumed the draft id and published workflow id were the same.
- General failure pattern: Frontend merge/read logic used backend-generated identity as the only association key even though first-edit drafts now receive backend-owned opaque ids.
- Similar locations searched: Searched Studio workflow save/list/get paths, page-level save selection, team-member workflow studio draft save paths, and existing scoped workflow API tests.
- Guard added: Centralized `findScopedDraftForCommittedWorkflow` keeps exact id matching first, then associates same-scope drafts by `directoryId + fileName`.
- Regression test added: Added API tests for scoped list dedupe and committed-id reopen loading an opaque first-edit draft.
- Hard gate: `tsc`, focused API/page tests, full `test:ui`, build, test stability guard, diff check, and frontend-only path check.
- Remaining risks: If backend stops preserving the original committed workflow filename for first-edit drafts, frontend cannot infer the association without a new typed backend association field.
