### PR TITLE
Clarify Studio script navigation guard

### DIFF
--- a/apps/aevatar-console-web/src/locales/projectMessages.en-US.ts
+++ b/apps/aevatar-console-web/src/locales/projectMessages.en-US.ts
@@ -3520,6 +3520,7 @@ const projectMessages = {
   "pages.studio.index.member.type.locked.after.creation": "Member type is fixed after this member is created.",
   "pages.studio.index.member.workbench": "Member workbench",
   "pages.studio.index.member.workflow.canvas.step": "Continue building around the current member workflow canvas, step details, and dry-run",
+  "pages.studio.index.navigation.blocked.by.unsaved.script": "Navigation stayed on Script Build because the current script draft has unsaved changes. Save or discard the draft before switching work areas.",
   "pages.studio.index.no.bound.service": "No bound service",
   "pages.studio.index.no.runs.for.member": "No runs for {member} yet.",
   "pages.studio.index.no.runs.for.yet": "No runs for {value1} yet.",

--- a/apps/aevatar-console-web/src/locales/projectMessages.zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/projectMessages.zh-CN.ts
@@ -3520,6 +3520,7 @@ const projectMessages = {
   "pages.studio.index.member.type.locked.after.creation": "成员创建后，类型不可再切换。",
   "pages.studio.index.member.workbench": "成员工作台",
   "pages.studio.index.member.workflow.canvas.step": "围绕当前成员的 Workflow 画布、步骤详情和试运行继续构建",
+  "pages.studio.index.navigation.blocked.by.unsaved.script": "导航仍停留在 Script Build，因为当前脚本草稿有未保存更改。请先保存或放弃草稿，再切换工作区。",
   "pages.studio.index.no.bound.service": "暂无绑定服务",
   "pages.studio.index.no.runs.for.member": "{member} 还没有运行记录。",
   "pages.studio.index.no.runs.for.yet": "{value1} 还没有运行记录。",

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -4159,6 +4159,11 @@ describe("StudioPage", () => {
       expect(screen.getByTestId("studio-script-build-panel")).toBeTruthy();
       expect(screen.queryByTestId("studio-bind-surface")).toBeNull();
     });
+    expect(
+      screen.getByText(
+        "Navigation stayed on Script Build because the current script draft has unsaved changes. Save or discard the draft before switching work areas.",
+      ),
+    ).toBeTruthy();
   });
 
   it("saves edited workflow drafts back to the Studio workspace API", async () => {

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -30,6 +30,7 @@ import {
   normalizeUserLlmRoute,
 } from '../chat/chatConversationConfig';
 import {
+  Alert,
   Button,
   Modal,
   Popover,
@@ -2995,6 +2996,7 @@ const StudioPage: React.FC = () => {
   const [selectedGraphNodeId, setSelectedGraphNodeId] = useState('');
   const [executionStopPending, setExecutionStopPending] = useState(false);
   const [executionNotice, setExecutionNotice] = useState<StudioNotice | null>(null);
+  const [navigationNotice, setNavigationNotice] = useState<StudioNotice | null>(null);
   const [logsPopoutMode] = useState(() => readStudioRouteState().logsMode);
   const [recentlyBoundMemberKey, setRecentlyBoundMemberKey] = useState('');
   const [recentlyBoundServiceId, setRecentlyBoundServiceId] = useState('');
@@ -5578,8 +5580,27 @@ const StudioPage: React.FC = () => {
     }
 
     const leaveGuard = scriptLeaveGuardRef.current;
-    return leaveGuard ? await leaveGuard() : true;
-  }, [isBuildScriptsSurface]);
+    if (!leaveGuard) {
+      return true;
+    }
+
+    const canLeave = await leaveGuard();
+    if (!canLeave) {
+      const blockedMessage = t(
+        "pages.studio.index.navigation.blocked.by.unsaved.script",
+        "Navigation stayed on Script Build because the current script draft has unsaved changes. Save or discard the draft before switching work areas.",
+      );
+      setNavigationNotice({
+        type: 'warning',
+        message: blockedMessage,
+      });
+      void message.warning(blockedMessage);
+      return false;
+    }
+
+    setNavigationNotice(null);
+    return true;
+  }, [isBuildScriptsSurface, t]);
 
   const resolveWorkflowSavePayload = useCallback(
     async (
@@ -10906,6 +10927,22 @@ const StudioPage: React.FC = () => {
       />
     ) : null;
 
+  const studioAlerts = navigationNotice ? (
+    <Alert
+      message={navigationNotice.message}
+      showIcon
+      type={
+        navigationNotice.type === 'error'
+          ? 'error'
+          : navigationNotice.type === 'warning'
+            ? 'warning'
+            : navigationNotice.type === 'success'
+              ? 'success'
+              : 'info'
+      }
+    />
+  ) : null;
+
   const pageContainerTitle =
     logsPopoutMode === 'popout' ? 'Execution logs' : undefined;
 
@@ -10936,6 +10973,7 @@ const StudioPage: React.FC = () => {
         ) : (
           <>
             <StudioShell
+              alerts={studioAlerts}
               contentScrollMode={isInvokeSurface ? 'page' : 'contained'}
               contextBar={studioContextBar}
               currentLifecycleStep={currentLifecycleStep}


### PR DESCRIPTION
## Summary

Refs #221.

This FKST slice addresses the highest-signal frontend-only Studio navigation issue I found in #221: when Script Build has unsaved draft changes and the leave guard blocks a lifecycle/work-area switch, Studio stayed on Script Build without a persistent in-page explanation.

Changes are restricted to `apps/aevatar-console-web/**`:

- surfaces a Studio-level warning alert when Script Build navigation is blocked by unsaved script draft changes
- keeps the existing toast warning behavior for immediate feedback
- clears the warning after a successful leave guard pass
- adds English and zh-CN catalog entries for the new user-visible copy
- extends the Studio page regression test to assert the warning is visible when Bind navigation is blocked

## Validation

- `~/.fkst/hosts/aevatar-frontend/run.sh doctor`
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web test --runTestsByPath src/locales/hardcodedCopyAudit.test.ts --runInBand`
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web test --runTestsByPath src/pages/studio/index.test.tsx --runInBand`
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web tsc`
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web test:ui --runInBand`
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web build`
- `bash tools/ci/test_stability_guards.sh`
- `git diff --check`
- `git diff --name-only -- ':!apps/aevatar-console-web/**'`

## Recurrence prevention

- Immediate symptom: Attempting to leave dirty Script Build for another Studio area could be blocked while the user saw only that they remained on the same surface.
- Root cause: The centralized Script Build leave guard returned `false` to callers without publishing a durable Studio-level explanation.
- General failure pattern: Navigation guards can protect state correctly while still leaving users without visible recovery context.
- Similar locations searched: Searched Studio leave-guard registration, `confirmScriptsStudioLeave` call sites, Studio notice surfaces, and message warning call sites under `apps/aevatar-console-web/src/pages/studio/**`; Script Build is the only registered leave-guard path.
- Guard added: A centralized warning notice is set inside `confirmScriptsStudioLeave` whenever the Script Build guard blocks navigation, and is cleared when leaving succeeds.
- Regression test added: `src/pages/studio/index.test.tsx` now verifies the blocked lifecycle switch keeps Script Build active and shows the warning text.
- Hard gate: Existing i18n fallback catalog audit, Studio page test, `tsc`, full `test:ui`, production `build`, test stability guard, and frontend scope check all passed locally.
- Remaining risks: #221 covers broader navigation smoothness and target clarity; this PR intentionally fixes only the unsaved Script Build blocked-navigation slice.
