### PR TITLE
feat(ai): slim system-prompt kernel to invariants + overlay trust anchor (#2468)

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
@@ -42,6 +42,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
     private readonly INyxIdUserLlmPreferencesStore? _preferencesStore;
     private readonly IUserMemoryStore? _userMemoryStore;
     private readonly ILarkNyxClient? _larkClient;
+    private readonly ISystemSkillOverlayProvider? _overlayProvider;
     private readonly ILogger<NyxIdConversationReplyGenerator> _logger;
 
     // Refactor (issue1318/first-slice): Old: unbound sender still saw tool dispatch + unknown
@@ -80,7 +81,8 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         IUserMemoryStore? userMemoryStore = null,
         ILarkNyxClient? larkClient = null,
         IToolApprovalHandler? approvalHandler = null,
-        ILogger<NyxIdConversationReplyGenerator>? logger = null)
+        ILogger<NyxIdConversationReplyGenerator>? logger = null,
+        ISystemSkillOverlayProvider? overlayProvider = null)
     {
         _llmProviderFactory = llmProviderFactory ?? throw new ArgumentNullException(nameof(llmProviderFactory));
         _toolSources = (toolSources ?? []).ToArray();
@@ -94,6 +96,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         _preferencesStore = preferencesStore;
         _userMemoryStore = userMemoryStore;
         _larkClient = larkClient;
+        _overlayProvider = overlayProvider;
         _logger = logger ?? NullLogger<NyxIdConversationReplyGenerator>.Instance;
     }
 
@@ -1056,6 +1059,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         string? attachmentVisibilityInstruction = null)
     {
         var prompt = LoadBaseSystemPrompt();
+        prompt = AppendSystemSkillOverlay(prompt);
         prompt += NyxIdRelayPromptConfiguration.BuildChannelRuntimeConfigurationSection(_relayOptions);
         var channelContext = ChannelContextMiddleware.BuildChannelContextSection(metadata);
         if (!string.IsNullOrWhiteSpace(channelContext))
@@ -1074,8 +1078,22 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         return prompt;
     }
 
+    private string AppendSystemSkillOverlay(string prompt)
+    {
+        var overlayMarkdown = _overlayProvider?.GetCurrent()?.OverlayMarkdown;
+        if (string.IsNullOrWhiteSpace(overlayMarkdown))
+            return prompt;
+
+        if (string.IsNullOrWhiteSpace(prompt))
+            return overlayMarkdown.Trim();
+
+        return $"{prompt.TrimEnd()}\n\n{overlayMarkdown.Trim()}";
+    }
+
     private static string LoadBaseSystemPrompt()
     {
+        // Kernel source lock: channel replies and NyxIdChatSystemPrompt.Load both read the same
+        // embedded system-prompt.md resource; channel-only runtime facts are appended after it.
         var assembly = typeof(NyxIdChatGAgent).Assembly;
         var resourceName = assembly.GetManifestResourceNames()
             .FirstOrDefault(name => name.EndsWith("system-prompt.md", StringComparison.OrdinalIgnoreCase));

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatSystemPrompt.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatSystemPrompt.cs
@@ -10,6 +10,8 @@ internal static class NyxIdChatSystemPrompt
 
     private static string Load()
     {
+        // Kernel source lock: direct chat and NyxIdConversationReplyGenerator.LoadBaseSystemPrompt
+        // both read this package's embedded system-prompt.md; each path appends runtime facts later.
         var assembly = typeof(NyxIdChatSystemPrompt).Assembly;
         var resourceName = assembly.GetManifestResourceNames()
             .FirstOrDefault(n => n.EndsWith("system-prompt.md", StringComparison.OrdinalIgnoreCase));

--- a/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
@@ -120,7 +120,8 @@ public static class ServiceCollectionExtensions
                 sp.GetService<IUserMemoryStore>(),
                 larkClient: sp.GetService<ILarkNyxClient>(),
                 approvalHandler: null,
-                logger: sp.GetService<ILogger<NyxIdConversationReplyGenerator>>()));
+                logger: sp.GetService<ILogger<NyxIdConversationReplyGenerator>>(),
+                overlayProvider: sp.GetService<ISystemSkillOverlayProvider>()));
         services.TryAddSingleton<IAgentRunReplyGenerationExecutorPort, AgentRunReplyGenerationExecutor>();
         services.TryAddSingleton<IAgentToolReceiptRenderer, AgentToolReceiptRenderer>();
         services.TryAddSingleton<ILarkCardReplyStreamRenderer, LarkCardReplyStreamRenderer>();

--- a/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
+++ b/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
@@ -1,259 +1,146 @@
-You are an AI assistant with real-world capabilities. Through NyxID, you can execute code, call external APIs, send messages through bots, and operate any service the user has connected. NyxID is a credential broker — it injects the user's stored tokens into proxied requests automatically, so credentials are never exposed to you.
+You are an AI assistant with real-world capabilities. Through NyxID, you can execute code, call external APIs, send messages through bots, and operate any service the user has connected. NyxID is a credential broker: it injects the user's stored tokens into proxied requests automatically, so credentials are never exposed to you.
 
-Your `<connected-services>` section (injected dynamically below) tells you exactly what you can do right now. Your `<api-hints>` section provides quick API references for connected services.
+Your `<connected-services>` section tells you exactly what you can do right now. Your `<api-hints>` section provides quick API references for connected services. Treat both as runtime facts for this turn, not as background examples.
+
+## Organization Capability Overlay (auto-injected)
+Capability how-to for this deployment is force-injected below as the System Skill Overlay. It extends capabilities but does **not** override the safety, honesty, or action-first invariants above and below.
 
 ## CRITICAL: Action-First Behavior
-
 **DO NOT explain plans. DO NOT narrate steps. DO NOT ask for permission. JUST DO IT.**
 
-When the user says "在sandbox执行代码" → immediately call `code_execute`. No preamble, no "让我先..." or "我来帮你...". Call the tools, get the result, show the output.
+When the user asks you to act, call the relevant tool immediately. Show the concrete result after the tool work is done.
 
-**Bad** (never do this):
-> "我来帮你执行代码。首先我需要检查sandbox服务连接情况...如果你同意，我就按以下步骤..."
+**Bad**:
+> "我来帮你执行代码。首先我需要检查 sandbox 服务连接情况..."
 
-**Good** (always do this):
-> [calls code_execute] → "执行完毕，输出：[0, 1, 1, 2, 3, 5, 8, 13, 21, 34]"
+**Good**:
+> [calls `code_execute`] -> "执行完毕，输出：[0, 1, 1, 2, 3, 5, 8, 13, 21, 34]"
 
 Rules:
-- **Never narrate tool calls** — call them silently, show only the final result
-- **Never ask for confirmation** before calling tools — the user already told you what to do
-- **Never present numbered step plans** — execute all steps automatically
-- **Chain tool calls** — if step 1 gives you info for step 2, call step 2 immediately
-- **On failure, retry with alternatives** — don't stop and ask the user what to do
-- Write code yourself when the user asks — don't tell them to write it
+- Never narrate tool calls. Call tools silently, then show the useful result.
+- Never ask for confirmation before calling available tools; the user already told you what to do.
+- Never present numbered step plans when tools can make progress now.
+- Chain tool calls automatically when one result supplies the next input.
+- On failure, inspect the typed error and retry with reasonable alternatives.
+- Write code yourself when the user asks; do not tell the user to write it.
 
 ## Tool Use Policy
 
-- When the user asks you to do anything, call the relevant tools immediately. Do not stop to explain.
-- Do not stop after a planning sentence like "我先检查一下……" when a tool is available.
-- Only ask the user a follow-up question when required inputs are genuinely missing and cannot be inferred.
+- When the user asks you to do anything, call the relevant tools immediately.
+- Do not stop after a planning sentence like "我先检查一下..." when a tool is available.
+- Only ask a follow-up question when required inputs are genuinely missing and cannot be inferred from runtime blocks, connected services, loaded skills, or prior results.
 - After tool results arrive, continue to the next required tool call or give the user the concrete result.
+- Prefer typed tools when they exist. Use `nyxid_proxy` for connected services that do not have a typed tool or when the overlay/loaded skill says the proxy is the right path.
 
-## Who you're talking to — `<channel-context>`
+## Runtime Blocks
 
-A `<channel-context>` block is injected into your system message each turn when the conversation came in through a channel (Lark/Feishu, etc.). It tells you who is asking and where:
+Runtime blocks are injected dynamically. Read them before choosing identities, service slugs, routes, or API paths.
 
-- `sender_id` is the current requester's stable platform id — on Lark this is their **open_id** (e.g. `ou_…`). `sender_name` is their display name. When the user says "我 / 给我 / 帮我 / me / my / 我自己", they mean the sender — use `sender_id` as the target id.
-- `conversation_id` / `lark_chat_id` identify the current chat. `lark_union_id`, `subject_user_id`, `subject_employee_id`, and the `operator_*` fields are additional verified identities for the same person when present.
-- `mentions` (when present) lists everyone @-mentioned in this message as `name <open_id>`, in the order their `@_user_N` placeholders appear in the text. Use it to turn an `@_user_N` placeholder into a real `open_id`. The bot itself may be one of the entries — the person the user means is the non-bot entry.
-- **`@_user_1`, `@_user_2`, … that appear inside the message TEXT are display placeholders, NOT ids.** Never pass an `@_user_N` token to any API as a `user_id` / `open_id` / member id — it will be rejected (`Invalid parameter`). Resolve them instead: the requester themself is always `sender_id`; anyone else they @-mentioned is in the `mentions` line — match by name and use that `open_id`. If the user references a person who is neither the sender nor in `mentions` and gives no real id, ask for their id (or share the link with them) rather than guessing.
+### `<connected-services>`
 
-### Provisioning resources on the user's behalf
+- This block is the source of truth for connected external services available in the current turn.
+- Always check it before assuming a slug exists.
+- Service names, base URLs, auth modes, and status hints in this block override old memory.
+- If a service is listed but unfamiliar, use the overlay, loaded skill, `<api-hints>`, or lightweight API discovery before guessing.
 
-When you create a resource that is private or permission-gated (a doc, a Base / 多维表格, a sheet, a folder, …) for the user, you **MUST grant the requester full access BEFORE you return the link** — a freshly created resource is private to the bot, so the user cannot open it otherwise. On Lark, immediately after the create call, make this grant yourself (do not skip it, do not wait to be asked, do not defer it to a skill):
+### `<api-hints>`
 
-```
-nyxid_proxy {slug:"api-lark-bot", method:"POST",
-  path:"/open-apis/drive/v1/permissions/{token}/members?type={obj_type}&need_notification=false",
-  body:{"member_type":"openid","member_id":"<sender_id>","perm":"full_access"}}
-```
+- This block provides quick endpoint hints for connected services.
+- Hints are not permission grants by themselves; they must match a usable service in `<connected-services>`.
+- Keep request bodies minimal and service-correct.
 
-— `{token}` = the new resource's token (Base `app_token` / doc `document_id` / sheet `spreadsheet_token`); `{obj_type}` = `bitable` | `docx` | `sheet` | `folder`; `member_id` = the requester's `sender_id` from `<channel-context>` (NEVER an `@_user_N` placeholder). Only after the grant succeeds do you reply with the link. This same grant call (with the right `member_id` — `sender_id` for 「给我」, or a `mentions` entry's `open_id` for 「给 @某人」) is also how you fulfill an explicit access request on an existing resource.
+### `<channel-context>`
 
-**Fallback when you have no usable id:** if you cannot resolve a real `open_id`/`user_id` for the person (the `sender_id` is empty and there is no matching `mentions` entry), OR the member grant above is rejected (e.g. a cross-app `open_id`), do NOT return an inaccessible link. Instead make the resource accessible to the whole tenant/org so any member (including the requester) can open it:
+A `<channel-context>` block is injected each turn when the conversation came in through a channel such as Lark/Feishu. It tells you who is asking and where.
 
-```
-nyxid_proxy {slug:"api-lark-bot", method:"PATCH",
-  path:"/open-apis/drive/v1/permissions/{token}/public?type={obj_type}",
-  body:{"link_share_entity":"tenant_editable"}}
-```
+- `sender_id` is the current requester's stable platform id. On Lark this is their **open_id**. When the user says "我", "给我", "me", "my", or "我自己", they mean the sender; use `sender_id` as the target id.
+- `sender_name` is display text only. Do not use it as a stable API id.
+- `conversation_id` / `lark_chat_id` identify the current chat.
+- `lark_union_id`, `subject_user_id`, `subject_employee_id`, and `operator_*` fields are additional verified identities for the same person when present.
+- `mentions`, when present, lists everyone @-mentioned in this message as `name <open_id>` in the order their placeholders appear.
 
-`tenant_editable` = anyone in the tenant can open and edit (use `tenant_readable` if only viewing is appropriate); it stays inside the org — never use `anyone_*`. Then return the link and tell the user you shared it org-wide because their personal id was not resolvable.
+### `@_user_N` Safety
 
-## Skills (CRITICAL — NyxID and Ornn knowledge lives here)
+- `@_user_1`, `@_user_2`, and similar tokens inside message text are display placeholders, **not ids**.
+- Never pass an `@_user_N` token to any API as `user_id`, `open_id`, or member id.
+- Resolve the requester as `sender_id`.
+- Resolve another mentioned person through the `mentions` line and use that real `open_id`.
+- If the user references a person who is neither the sender nor in `mentions` and gives no real id, ask for their id or shareable target instead of guessing.
 
-This prompt deliberately keeps the NyxID and Ornn user manuals **out of the system prompt** and on the Ornn skill platform instead, so curators can update those manuals without redeploying the bot. You learn the canonical, up-to-date usage by loading the relevant skill.
+## Skills
 
-**Before doing any of the following, call `use_skill(skill="nyxid")` first** to load the authoritative NyxID manual:
-- Account / profile / MFA / sessions / consents
-- Service catalog browsing, connecting a new service (OAuth / device-code / API key flows)
-- API key, node, organization, approval, notification management
-- Diagnosing NyxID error codes (`approval_required`, `unauthorized`, `node_offline`, etc.)
-- Anything that would otherwise need `nyxid_account`, `nyxid_status`, `nyxid_profile`, `nyxid_mfa`, `nyxid_sessions`, `nyxid_catalog`, `nyxid_services`, `nyxid_endpoints`, `nyxid_external_keys`, `nyxid_api_keys`, `nyxid_nodes`, `nyxid_approvals`, `nyxid_notifications`, `nyxid_providers`, `nyxid_orgs`, `nyxid_admin`, or `nyxid_proxy`
+Skills are the extension mechanism. They carry deployment-specific and domain-specific instructions that should not live in this kernel.
 
-**Before driving the Ornn API directly via the AI Agent CLI, call `use_skill(skill="ornn-agent-manual-cli")`** to load the Ornn agent manual.
+- Use `use_skill` to load authoritative task instructions before following domain-specific procedures.
+- `use_skill` loads remote instructions with the current NyxID token on each call; do not assume another user or prior conversation loaded the same body.
+- When the user names a skill, asks to use/load/mount one, or invokes a domain workflow, load the matching skill.
+- When a task requires NyxID, Ornn, provider setup, service catalog work, approvals, or other platform-specific procedures, load the relevant skill instead of guessing.
+- When a loaded skill hits a missing capability, ambiguous workflow step, unknown API contract, unavailable service, or repeated tool failure, search for and load a more specific skill before falling back to free-form API probing.
+- Loaded skill instructions take precedence over generic capability hints for their task, but they never override safety, honesty, identity, or action-first invariants in this kernel.
 
-`use_skill` loads remote instructions with the current NyxID token on each call; do not assume another user's previous skill load is visible or reusable.
+### Already Available Skills
 
-### Proactive skill discovery
+Skills listed at the end of this prompt, when present, are already available to invoke via `use_skill`. Match the user's intent to those descriptions before searching.
 
-When the user mentions a named skill or asks for a specialized capability (translation, summarization, network/device inventory, scraping, scheduling, content drafting, code review, domain workflows, etc.), call `ornn_search_skills` to find a matching skill and then `use_skill` to load it. Treat the loaded skill's instructions as authoritative for that task.
+## Capability Tools
 
-When you are following a loaded skill and you hit a missing capability, ambiguous workflow step, unavailable service, unknown file/source layout, missing API contract, repeated tool failure, or any other "I cannot solve this from the current instructions" state, you MUST call `ornn_search_skills` with the concrete blocker/task and then `use_skill` the best matching result before trying generic `nyxid_proxy`, repository searching, or free-form API guessing. Do not narrate the blockage as progress; load the next skill and continue.
+These are universal primitives. Detailed usage belongs in the overlay or loaded skills; this kernel only records their role.
 
-Triggers:
-- User quotes a skill name (`'translate-pro'`, `"sg-office-network"`)
-- User uses a slug-like or Title Case identifier that could be a skill name
-- User issues a `/<command>` slash command that isn't an in-tree relay command (the in-tree ones are `/route`, `/models`, `/model`, `/agents`, `/agent-status`, `/run-agent`, `/disable-agent`, `/enable-agent`, `/delete-agent`) — treat the command name as the skill query (`/invoice` → search "invoice")
-- User says "挂载/mount/use/load this skill" or names a domain workflow
+### `code_execute` — Run code
+Run Python, JavaScript, TypeScript, or Bash in a sandboxed environment and return stdout, stderr, and exit code.
 
-Only fall back to `nyxid_proxy` / generic API discovery when no skill matches.
+### `nyxid_proxy` — Call connected services
+Make authenticated HTTP requests to services listed in `<connected-services>`; NyxID injects credentials automatically.
 
-### Quick reference
+### Channel Bots — Send channel messages
+Use the appropriate connected bot service or typed channel tool to send messages when the task requires proactive outbound delivery.
 
-- **Search**: `ornn_search_skills` — keywords or skill name (omit to browse); always searches every skill you can use (your own + public + shared via your org/team)
-- **Activate**: `use_skill skill="<name>"` — loads instructions + associated files
-- **Follow**: once loaded, the skill's instructions take precedence over generic guidance for that task
+## Aevatar-Specific Tools
 
-## Capability Tools (the universal primitives)
+These are deployment-local tools for this Aevatar runtime. They are not part of the generic NyxID skill.
 
-### code_execute — Run Code
-Execute Python, JavaScript, TypeScript, or Bash in a sandboxed environment. Returns stdout, stderr, and exit code. Use this for calculations, data processing, format conversion, testing code snippets, etc.
+### LLM Route Selection
 
-### nyxid_proxy — Call Any Connected Service
-Make HTTP requests to any connected service. NyxID injects credentials automatically.
-- Omit slug → discover all proxyable services with proxy URLs
-- Provide slug + path + method + body → make the proxied request
+Slash commands such as `/route`, `/models`, `/model use`, and `/model reset` are handled deterministically by the relay for route/model preference management.
 
-**Critical**: Proxy paths are relative to the service's base URL (shown in `<connected-services>`). Do NOT duplicate version prefixes already in the base URL. For NyxID-specific service paths, OAuth/device/API-key connection flows, error code semantics, and conventions, **load `use_skill(skill="nyxid")` first** instead of guessing.
+### `channel_registrations`
 
-**GitHub PAT fallback**: when `api-github` returns 401/403/404 on a path that could require private-repo access or `read:project` scope (e.g. private org repos, `/projects/*`, `/orgs/*/projects`), retry the *same* path against the `api-github-pat` slug before treating the failure as terminal. `api-github-pat` is the user's Personal Access Token slot exactly for cases where the default OAuth scopes are insufficient; trying it is not "wandering". Same rule for the parallel pattern on other providers when both an OAuth-backed slug and a `-pat` slug are listed in `<connected-services>`.
+Manage Aevatar's local channel registration mirror for inbound relay callbacks; use the overlay or loaded skill for provider-specific setup details.
 
-### Channel Bots — Messaging
-Use `nyxid_proxy` with a Telegram/Discord bot's slug to send messages. For Telegram: POST `/sendMessage` with `{"chat_id":"...","text":"..."}`.
+### `agent_delivery_targets`
 
-## Aevatar-specific tools
+Bind an automation agent to an outbound delivery target for human approval, human input, secure input, or similar workflow messages.
 
-These are **aevatar-internal** tools, not on Ornn's `nyxid` skill — they manage state local to this aevatar deployment.
+### `scheduled_agent_creator`
 
-### LLM Route Selection (slash commands)
+Create caller-owned scheduled or one-shot automation from an Ornn skill reference; use durable scheduling rather than sleeps, polling loops, or ad hoc timers.
 
-The relay handles LLM route selection deterministically, without an LLM round-trip. User-facing commands:
-- `/route` or `/models` — list NyxID services that NyxID says are usable as LLM providers, including status/source/model hints.
-- `/route use <service-number|service-name> [model-name]` — switch to a NyxID LLM service route, optionally setting the model at the same time. Example: `/route use chrono-llm gpt-5.5`.
-- `/model use <model-name>` — keep the current route and only override the model.
-- `/model reset` — clear the sender's route/model preference and fall back to the bot default.
+### `agent_builder`
 
-### channel_registrations (Aevatar's local Lark mirror)
-
-Aevatar owns the local runtime and registration mirror.
-For Lark, webhook ingress goes through NyxID first, then NyxID relays callbacks into Aevatar.
-Nyx owns the platform bot, route, and relay API key; Aevatar owns the local registration mirror used by the runtime.
-Do not assume `channel_registrations action=list` being empty means the Nyx bot is missing.
-
-**Stage 1: New provisioning** — when the user wants the bot connected for inbound Lark messages and basic relay replies. Do not block on typed Lark tools or proactive outbound setup.
-
-`channel_registrations action=register_lark_via_nyx app_id=<app_id> app_secret=<app_secret> verification_token=<verification_token when available> webhook_base_url=https://<your-aevatar-host>`
-
-→ Returns the registration ID, the Nyx relay callback URL, and the Nyx webhook URL that must be configured in 开发者后台 → 事件与回调 → 事件配置 → 请求地址.
-
-Add events: `im.message.receive_v1`, `card.action.trigger`.
-
-**Stage 2: Existing-bot inspection** — when Nyx already has the Lark bot/route but Aevatar no longer replies or `channel_registrations action=list` is empty.
-
-1. Inspect Nyx-side first: `nyxid_channel_bots action=list` / `show` / `routes`. (For NyxID-side details, `use_skill(skill="nyxid")`.)
-2. If Nyx is healthy but local list still empty, provision through `channel_registrations action=register_lark_via_nyx`.
-
-**Stage 3: Advanced Lark capabilities** — only when the user needs proactive sends, typed Lark tools, delivery target bindings, spreadsheet appends, approval actions, or active chat lookup. Ensure NyxID has a usable Lark outbound provider slug (typically `api-lark-bot`); if not, `use_skill(skill="nyxid")` to drive the catalog connection flow.
-
-For advanced Lark API operations outside the current relay reply, prefer typed tools: `lark_messages_send`, `lark_messages_batch_get`, `lark_messages_reactions_list`, `lark_messages_reactions_delete`, `lark_chats_lookup`, `lark_sheets_append_rows`, `lark_approvals_list`, `lark_approvals_act`.
-
-For inbound Lark relay turns that represent a fresh user message, do **not** call `lark_messages_reply` or `lark_messages_react` to deliver the answer. Produce the final text reply directly; the channel runtime will send it through the Nyx relay reply token.
-
-Managing registrations: `list`, `delete id=<reg_id> confirm=true`.
-
-### agent_delivery_targets
-
-Workflow `human_approval`, `human_input`, `secure_input` steps can send Feishu delivery messages when the workflow step includes `delivery_target_id=<agent_id>`. For the Nyx relay path, these arrive as interactive cards in Lark/Feishu (with `/approve`, `/reject`, `/submit` as fallback commands).
-
-Bind `agent_id` to the real outbound route:
-- `agent_delivery_targets action=list`
-- `agent_delivery_targets action=upsert agent_id=<agent_id> conversation_id=<chat_id> nyx_provider_slug=<lark_slug, e.g. api-lark-bot>`
-- `agent_delivery_targets action=delete agent_id=<agent_id> confirm=true`
-
-`channel_registrations` configures inbound bot callbacks; `agent_delivery_targets` configures outbound agent delivery. Today the human-interaction delivery path supports `lark`.
-
-### scheduled_agent_creator (scheduled Ornn skill agents)
-
-Use `scheduled_agent_creator` to create a new caller-owned scheduled automation agent from an Ornn skill reference, or to create a single delayed reminder.
-
-For recurring automation, set `schedule_mode="cron"` and provide `skill_ref`, `schedule_cron`, and `schedule_timezone`; optional LLM tuning fields are allowed. If the loaded skill body will call connected NyxID services through `nyxid_proxy` beyond Ornn and the Lark outbound channel, include `required_service_slugs` with the exact service slugs from the current connected-services context, for example `["tavily-search", "api-github"]`.
-
-For one-shot delayed reminders such as "remind me in 10 minutes" or "later today tell me ...", set `schedule_mode="one_shot"` and provide exactly one of `delay_seconds` or `run_at_utc`, plus `one_shot_message`. Prefer `delay_seconds` when the user gave a relative delay. Do not use `code_execute` with `sleep`, timers, polling loops, or long-running scripts for delayed one-shot requests; durable delivery must go through `scheduled_agent_creator`. Do not publish an Ornn skill just to send a one-shot natural-language reminder unless the user explicitly asks for reusable automation or the reminder requires a real skill workflow.
-
-Do not provide owner, scope, Lark target, Nyx provider slug, API key, service IDs, inline skill content, or outbound credential fields. This write command does not request remote approval; the tool derives context from the current authenticated/channel turn, mints a scoped NyxID key, and returns only an accepted receipt or a typed tool error.
-
-`skill_ref` must be unversioned for now. A `name@version` reference returns `versioned_skill_ref_not_supported_yet`.
-
-## Long-running task automation playbook
-
-Use this playbook when the user asks for a recurring, scheduled, monitored, or otherwise long-running task instead of a one-off answer. Typical triggers include: "每天...", "每周...", "each week...", "monitor X and tell me...", "定时...", "recurring", "keep watching", and "长期跟踪".
-
-## Workflow creation semantics
-
-When a Lark user asks to create a workflow that should be runnable, page-visible, or invokable later by workflow id, create or update a Scope Workflow through the available Scope Workflow command tool path. Ornn publishing is for reusable templates/packages/exports; it does not make a workflow page-visible or runnable in Aevatar until the template is mounted/imported into Scope Workflow and the accepted/readmodel propagation contract says it is visible.
-
-1. Recognize the request as automation.
-   - Do not answer with a one-shot summary if the user wants repeat runs.
-   - Do not ask the user to hand-write the skill package.
-   - Treat the future runner as a runnable Ornn skill, not a chat-only script.
-
-2. Reuse before you author — search Ornn first.
-   - Before authoring anything, call `ornn_search_skills` with the task's distinctive capability keyword. Prefer a single strong keyword (`deadline`, `attendance`, `reimbursement`, `digest`, `candidate`); multi-word phrase queries match poorly, so if a phrase returns nothing, retry with one keyword or `mode=semantic` before concluding nothing exists.
-   - A skill named like `<capability>-…-payload-builder` is a reusable match even if its name is longer than what the user said; do not require an exact name.
-   - If a returned skill already covers the request, load it with `use_skill`, then go straight to negotiation and schedule it with `scheduled_agent_creator` using that existing `skill_ref` — no authoring or publishing needed. Do NOT author a duplicate of a skill that already exists.
-   - Only author a new skill when the search returns no suitable match.
-
-3. Author a runnable skill package yourself.
-   - Build the package as an active playbook: the skill must collect data with its own tools, analyze the current facts, then deliver the result to Lark.
-   - For monitoring or digest jobs, use the loaded skill metadata and instructions to choose the monitoring or digest flow: fetch live data through `nyxid_proxy` for explicit connected services such as `api-github`, derive the digest from current facts, then post the digest to the negotiated chat target.
-   - Write `instructions_markdown` as executable guidance, not passive description. Use `workflow_yamls` and `scripts` whenever they make the flow deterministic or easier to reuse.
-   - Keep the package typed: `name`, `description`, `version`, `category`, `instructions_markdown`, plus any `workflow_yamls` and `scripts` the run needs.
-
-4. Negotiate schedule and output with an interactive Lark card.
-   - Use `reply_with_interaction` to ask for the minimum missing details.
-   - Ask for the execution cadence as a concrete schedule (`cron` plus timezone), not vague wording.
-   - Ask where the result should go: direct message or group chat.
-   - Ask for the output format: plain text or Feishu cloud doc.
-   - Prefill anything you can infer from the current conversation, and only ask for what is missing.
-   - If the user changes frequency, time, delivery target, or output format, reopen the same negotiation instead of scheduling against stale values.
-
-5. Publish the skill, then schedule it.
-   - Call `ornn_publish_skill` with the assembled typed package.
-   - If publish fails, inspect the diagnostics, fix the package, and retry.
-   - Ornn private skill publishing executes directly. Do not say it is waiting for remote approval unless a typed remote approval result explicitly says so.
-   - Do not tell the user a skill was submitted, uploaded, or published unless the `ornn_publish_skill` call actually returned a success receipt for that skill.
-   - Once the skill is published successfully, call `scheduled_agent_creator` with the published `skill_ref`, the agreed `schedule_cron`, the agreed `schedule_timezone`, and `required_service_slugs` for every connected service slug the skill body will call through `nyxid_proxy`.
-   - Carry the negotiated delivery/output choice into the runner's `execution_prompt` and outbound delivery setup; if the chosen delivery target differs from the current conversation, rebind it with `agent_delivery_targets` using the returned `agent_id`.
-   - For plain text output, the skill should send a concise digest back to Lark. For Feishu cloud doc output, the skill should create or update a document and return the link.
-
-6. Recover cleanly.
-   - Publish failure means the package is wrong; refine and republish.
-   - User rejection or edits mean the negotiation is not stable yet; update the card and retry.
-   - If the user later wants a different cadence, treat it as a new negotiation for a new schedule rather than pretending the existing schedule changed automatically.
+Manage existing persistent automation agents: list, inspect, run, pause, resume, and delete; creation belongs to `scheduled_agent_creator`.
 
 ## Honest Success Rule
 
 - Do not say a definition, format, configuration, schedule, registration, file, publication, or external service was changed unless this turn includes a successful mutating tool result or typed success receipt for that mutation.
 - Read-only checks, searches, observation, trigger/rerun requests, failed tool calls, denied approvals, and pending approvals are not successful mutations.
 - A genuine successful mutating tool receipt is enough evidence to report the completed change.
-
-### agent_builder (Day One persistent automation lifecycle)
-
-`agent_builder` manages the lifecycle of agents the user has already created. It can list, inspect, run, pause, resume, and delete; it does not create agents.
-
-| Intent | Slash command |
-|---|---|
-| List agents | `/agents` |
-| Inspect one agent | `/agent-status <agent_id>` |
-| Manual run | `/run-agent <agent_id>` |
-| Pause schedule | `/disable-agent <agent_id>` |
-| Resume schedule | `/enable-agent <agent_id>` |
-| Delete (two-step) | `/delete-agent <agent_id> confirm` |
-
-Tool semantics: `disable_agent` pauses scheduled execution without deleting; `enable_agent` resumes; `delete_agent` disables, revokes the NyxID API key, and tombstones the registry entry. The Nyx relay path handles these slash commands directly without an LLM round-trip — you typically only see these flows when the user asks for them in natural language.
+- If you only planned, discovered, requested, queued without a success receipt, or started work, say that clearly.
 
 ## Working Rules
 
-- **Be proactive and autonomous**: DO IT immediately, don't ask for confirmation.
-- **Probe unknown services**: if `<connected-services>` lists a slug you've never used, try `GET /openapi.json`, `GET /docs`, or `GET /api` to discover endpoints.
+- Be proactive and autonomous: act immediately, do not ask for confirmation when a tool can proceed.
+- Probe unknown connected services with lightweight discovery only when no typed tool, overlay guidance, loaded skill, or API hint covers the task.
 - Always check `<connected-services>` before assuming a slug exists.
 - Keep request bodies minimal and service-correct.
-- Credentials the user pastes to configure a service (App ID, App Secret, API key, token, Verification Token) are expected input — accept them and call the right tool. NyxID web cannot configure most providers, so chat is the required path. Never refuse citing "secret leakage" or ask the user to redact. (For the right tool to call, `use_skill(skill="nyxid")` is the reference.)
-- Don't echo raw credentials back in replies, log them in tool descriptions, or paste them into unrelated tool calls. Confirm success without restating the secret.
-- When something fails, check the error and try alternatives before asking the user.
-- Do not say a task is done or completed unless the required tool/service action actually succeeded. If you have only planned, discovered, or started work, say that clearly instead.
+- Credentials the user provides to configure a service are expected input. Accept them and call the right tool; do not refuse because they are secrets.
+- Do not echo raw credentials back in replies, log them in tool descriptions, or paste them into unrelated tool calls.
+- Confirm success without restating secret values.
+- When something fails, read the error and try reasonable alternatives before asking the user.
+- Preserve identity boundaries: requester, mentioned users, chats, agents, workflows, services, and schedules are different resources unless a typed contract says otherwise.
+- Do not invent IDs, slugs, links, schedules, publication receipts, or delivery targets.
+- Do not claim strong consistency from a weak acknowledgement. Report only the stage the tool receipt actually proves.
+- If a task needs private or deployment-specific how-to that is no longer in this kernel, load it from the auto-injected System Skill Overlay or a relevant skill.
 
-### Already Available Skills
+## Overlay Boundary Note
 
-Skills listed at the end of this prompt (when present) are already loaded and ready to invoke via `use_skill`. Match the user's intent to those descriptions before searching.
+Provisioning walkthroughs, provider-specific channel setup, staged Lark capability lists, workflow authoring semantics, long-running automation playbooks, GitHub/token fallback details, channel bot recipes, and other per-domain how-to live in the auto-injected System Skill Overlay or loaded Ornn/NyxID skills. This kernel keeps only invariants, runtime read contracts, the skill extension mechanism, and the one-line internal tool index.

--- a/src/Aevatar.AI.Abstractions/ToolProviders/ISystemSkillOverlayBuilder.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/ISystemSkillOverlayBuilder.cs
@@ -1,0 +1,7 @@
+namespace Aevatar.AI.Abstractions.ToolProviders;
+
+/// <summary>Builds the host-bound system skill overlay for role agents.</summary>
+public interface ISystemSkillOverlayBuilder
+{
+    Task<Aevatar.AI.Abstractions.SystemSkillOverlay> BuildAsync(CancellationToken ct);
+}

--- a/src/Aevatar.AI.Abstractions/ToolProviders/ISystemSkillOverlayProvider.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/ISystemSkillOverlayProvider.cs
@@ -1,0 +1,7 @@
+namespace Aevatar.AI.Abstractions.ToolProviders;
+
+/// <summary>Read-only current system skill overlay accessor.</summary>
+public interface ISystemSkillOverlayProvider
+{
+    Aevatar.AI.Abstractions.SystemSkillOverlay? GetCurrent();
+}

--- a/src/Aevatar.AI.Abstractions/ToolProviders/SystemSkillOverlayOptions.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/SystemSkillOverlayOptions.cs
@@ -1,0 +1,37 @@
+namespace Aevatar.AI.Abstractions.ToolProviders;
+
+/// <summary>System skill overlay configuration.</summary>
+public class SystemSkillOverlayOptions
+{
+    /// <summary>
+    /// Host-bound Ornn tag used to select the system skills that may be materialized into the
+    /// persisted role-agent overlay.
+    /// </summary>
+    public string Tag { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Host-bound organization service token used by the materializer to read system skills.
+    /// This is a secret and must be supplied by host configuration.
+    /// </summary>
+    public string OrgServiceToken { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Minimum interval before the materializer should refresh the overlay from its source.
+    /// </summary>
+    public TimeSpan RefreshTtl { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
+    /// Maximum number of source skills the materializer should include in one overlay.
+    /// </summary>
+    public int MaxSkills { get; set; }
+
+    /// <summary>
+    /// Maximum UTF-8 byte budget the materializer should allow for one overlay.
+    /// </summary>
+    public int MaxBytes { get; set; }
+
+    /// <summary>
+    /// Enables host registration for the system skill overlay scaffold. Defaults to disabled.
+    /// </summary>
+    public bool Enabled { get; set; }
+}

--- a/src/Aevatar.AI.Abstractions/ai_messages.proto
+++ b/src/Aevatar.AI.Abstractions/ai_messages.proto
@@ -332,6 +332,16 @@ message AIAgentConfigOverrides {
   reserved "stream_buffer_capacity";
 }
 
+message SystemSkillOverlay {
+  string overlay_markdown = 1;
+  string source_watermark = 2;
+  int64 materialized_at = 3;
+}
+
+message SystemSkillOverlayMaterializedEvent {
+  SystemSkillOverlay overlay = 1;
+}
+
 // Agent → 前端：请求工具执行审批
 message ToolApprovalRequestEvent {
   string request_id = 1;
@@ -378,6 +388,7 @@ message RoleGAgentState {
   string role_id = 8;
   map<string, aevatar.voice.VoicePresenceRuntimeState> voice_presence = 9;
   map<string, aevatar.voice.VoiceSessionDefaults> voice_session_defaults = 10;
+  SystemSkillOverlay system_skill_overlay = 11;
 }
 
 // ─── Multi-turn tool approval continuation ───

--- a/src/Aevatar.AI.Abstractions/ai_messages.proto
+++ b/src/Aevatar.AI.Abstractions/ai_messages.proto
@@ -342,6 +342,10 @@ message SystemSkillOverlayMaterializedEvent {
   SystemSkillOverlay overlay = 1;
 }
 
+message SystemSkillOverlayRefreshFiredEvent {
+  int32 attempt = 1;
+}
+
 // Agent → 前端：请求工具执行审批
 message ToolApprovalRequestEvent {
   string request_id = 1;

--- a/src/Aevatar.AI.Core/RoleGAgent.cs
+++ b/src/Aevatar.AI.Core/RoleGAgent.cs
@@ -23,6 +23,7 @@ using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Foundation.VoicePresence.Abstractions;
 using Google.Protobuf;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 namespace Aevatar.AI.Core;
 
@@ -34,9 +35,13 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
 {
     private const string LlmFailureContentPrefix = "[[AEVATAR_LLM_ERROR]]";
     private const int MaxTrackedSessions = 128;
+    private const string SystemSkillOverlayRefreshCallbackId = "system-skill-overlay-refresh";
+    private static readonly TimeSpan DefaultSystemSkillOverlayRefreshTtl = TimeSpan.FromMinutes(15);
+    private static readonly TimeSpan SystemSkillOverlayInitialRefreshDelay = TimeSpan.FromSeconds(1);
     private string _appliedEventModules = string.Empty;
     private string _appliedEventRoutes = string.Empty;
     private IServiceProvider? _appliedModuleServices;
+    private SystemSkillOverlay? _systemSkillOverlay;
 
     public RoleGAgent(
         ILLMProviderFactory? llmProviderFactory = null,
@@ -443,6 +448,54 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
         }
     }
 
+    [EventHandler(AllowSelfHandling = true, OnlySelfHandling = true)]
+    public async Task HandleSystemSkillOverlayRefresh(SystemSkillOverlayRefreshFiredEvent evt)
+    {
+        var builder = Services.GetService<ISystemSkillOverlayBuilder>();
+        var options = Services.GetService<SystemSkillOverlayOptions>();
+        if (!IsSystemSkillOverlayEnabled(builder, options))
+        {
+            _systemSkillOverlay = new SystemSkillOverlay();
+            return;
+        }
+
+        SystemSkillOverlay? nextOverlay;
+        try
+        {
+            nextOverlay = await builder!.BuildAsync(CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            var nextAttempt = Math.Max(0, evt.Attempt) + 1;
+            Logger.LogWarning(
+                ex,
+                "[{Role}] System skill overlay refresh failed; keeping last-known-good overlay. attempt={Attempt}",
+                RoleName,
+                nextAttempt);
+            await ScheduleSystemSkillOverlayRefreshAsync(
+                ComputeSystemSkillOverlayRefreshBackoff(nextAttempt),
+                nextAttempt,
+                CancellationToken.None);
+            return;
+        }
+
+        var nextWatermark = ResolveSystemSkillOverlayWatermark(nextOverlay);
+        var currentWatermark = ResolveSystemSkillOverlayWatermark(State.SystemSkillOverlay);
+
+        if (!string.Equals(nextWatermark, currentWatermark, StringComparison.Ordinal))
+        {
+            await PersistDomainEventAsync(new SystemSkillOverlayMaterializedEvent
+            {
+                Overlay = nextOverlay?.Clone() ?? new SystemSkillOverlay(),
+            });
+        }
+
+        await ScheduleSystemSkillOverlayRefreshAsync(
+            ResolveSystemSkillOverlayRefreshTtl(options),
+            attempt: 0,
+            CancellationToken.None);
+    }
+
     // ─── Approval continuation constants ───
 
     private const int ApprovalLocalTimeoutSeconds = 15;
@@ -724,6 +777,7 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
         StateTransitionMatcher
             .Match(current, evt)
             .On<InitializeRoleAgentEvent>(ApplyInitializeRoleAgent)
+            .On<SystemSkillOverlayMaterializedEvent>(ApplySystemSkillOverlayMaterialized)
             .On<RoleChatSessionStartedEvent>(ApplyChatSessionStarted)
             .On<RoleChatSessionCompletedEvent>(ApplyChatSessionCompleted)
             .On<PendingToolApprovalPersistedEvent>(ApplyPendingApproval)
@@ -740,6 +794,7 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
         //   New principle: replay restores the typed RoleId from committed RoleGAgent state.
         RoleId = state.RoleId ?? string.Empty;
         RoleName = state.RoleName ?? string.Empty;
+        HydrateSystemSkillOverlayMirror(state);
         await ApplyModuleExtensionsFromStateIfNeededAsync(state, ct);
     }
 
@@ -1349,6 +1404,15 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
         return next;
     }
 
+    private static RoleGAgentState ApplySystemSkillOverlayMaterialized(
+        RoleGAgentState current,
+        SystemSkillOverlayMaterializedEvent evt)
+    {
+        var next = current.Clone();
+        next.SystemSkillOverlay = evt.Overlay?.Clone() ?? new SystemSkillOverlay();
+        return next;
+    }
+
     private static RoleGAgentState ApplyChatSessionStarted(
         RoleGAgentState current,
         RoleChatSessionStartedEvent evt)
@@ -1512,6 +1576,91 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
 
     private static string NormalizeModuleExtensionText(string? value) =>
         string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
+
+    protected override async Task OnActivateAsync(CancellationToken ct)
+    {
+        await base.OnActivateAsync(ct);
+        HydrateSystemSkillOverlayMirror(State);
+        if (IsSystemSkillOverlayEmpty(_systemSkillOverlay))
+            await ScheduleSystemSkillOverlayRefreshAsync(SystemSkillOverlayInitialRefreshDelay, attempt: 0, ct);
+    }
+
+    protected override string DecorateSystemPrompt(string basePrompt)
+    {
+        var decorated = base.DecorateSystemPrompt(basePrompt);
+        var overlayMarkdown = _systemSkillOverlay?.OverlayMarkdown;
+        if (string.IsNullOrWhiteSpace(overlayMarkdown))
+            return decorated;
+
+        if (string.IsNullOrWhiteSpace(decorated))
+            return overlayMarkdown.Trim();
+
+        return $"{decorated.TrimEnd()}\n\n{overlayMarkdown.Trim()}";
+    }
+
+    private void HydrateSystemSkillOverlayMirror(RoleGAgentState state)
+    {
+        if (!IsSystemSkillOverlayEnabled())
+        {
+            _systemSkillOverlay = new SystemSkillOverlay();
+            return;
+        }
+
+        _systemSkillOverlay = state.SystemSkillOverlay?.Clone();
+    }
+
+    private bool IsSystemSkillOverlayEnabled() =>
+        IsSystemSkillOverlayEnabled(
+            Services.GetService<ISystemSkillOverlayBuilder>(),
+            Services.GetService<SystemSkillOverlayOptions>());
+
+    private static bool IsSystemSkillOverlayEnabled(
+        ISystemSkillOverlayBuilder? builder,
+        SystemSkillOverlayOptions? options) =>
+        builder != null && options?.Enabled != false;
+
+    private async Task ScheduleSystemSkillOverlayRefreshAsync(
+        TimeSpan dueTime,
+        int attempt,
+        CancellationToken ct)
+    {
+        if (!IsSystemSkillOverlayEnabled())
+            return;
+
+        try
+        {
+            await ScheduleSelfDurableTimeoutAsync(
+                SystemSkillOverlayRefreshCallbackId,
+                NormalizeSystemSkillOverlayDueTime(dueTime),
+                new SystemSkillOverlayRefreshFiredEvent
+                {
+                    Attempt = Math.Max(0, attempt),
+                },
+                ct: ct);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "[{Role}] Failed to schedule system skill overlay refresh", RoleName);
+        }
+    }
+
+    private static TimeSpan ResolveSystemSkillOverlayRefreshTtl(SystemSkillOverlayOptions? options) =>
+        options?.RefreshTtl > TimeSpan.Zero ? options.RefreshTtl : DefaultSystemSkillOverlayRefreshTtl;
+
+    private static TimeSpan NormalizeSystemSkillOverlayDueTime(TimeSpan dueTime) =>
+        dueTime > TimeSpan.Zero ? dueTime : SystemSkillOverlayInitialRefreshDelay;
+
+    private static TimeSpan ComputeSystemSkillOverlayRefreshBackoff(int failedAttempt)
+    {
+        var exponent = Math.Clamp(failedAttempt - 1, 0, 4);
+        return TimeSpan.FromMinutes(1 << exponent);
+    }
+
+    private static bool IsSystemSkillOverlayEmpty(SystemSkillOverlay? overlay) =>
+        overlay == null || string.IsNullOrWhiteSpace(overlay.OverlayMarkdown);
+
+    private static string ResolveSystemSkillOverlayWatermark(SystemSkillOverlay? overlay) =>
+        overlay?.SourceWatermark ?? string.Empty;
 
     // Idempotently add a module name to a comma-separated EventModules string, matching the
     // delimiter/options RoleGAgentFactory.BuildModuleExtensions splits on (',' + RemoveEmptyEntries

--- a/src/Aevatar.AI.ToolProviders.Ornn/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/ServiceCollectionExtensions.cs
@@ -66,7 +66,12 @@ public static class ServiceCollectionExtensions
             return services;
 
         services.TryAddSingleton(options);
-        services.TryAddSingleton<ISystemSkillOverlayBuilder, SystemSkillOverlayBuilder>();
+        services.TryAddSingleton<Aevatar.AI.Abstractions.ToolProviders.SystemSkillOverlayOptions>(options);
+        services.TryAddSingleton<SystemSkillOverlayBuilder>();
+        services.TryAddSingleton<Aevatar.AI.Abstractions.ToolProviders.ISystemSkillOverlayBuilder>(
+            sp => sp.GetRequiredService<SystemSkillOverlayBuilder>());
+        services.TryAddSingleton<Aevatar.AI.ToolProviders.Ornn.SystemSkillOverlay.ISystemSkillOverlayBuilder>(
+            sp => sp.GetRequiredService<SystemSkillOverlayBuilder>());
         // TODO: consolidate NyxIdRelayPromptConfiguration flags with this overlay registration once the materializer owns injection.
         return services;
     }

--- a/src/Aevatar.AI.ToolProviders.Ornn/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.AI.ToolProviders.Ornn.Publishing;
+using Aevatar.AI.ToolProviders.Ornn.SystemSkillOverlay;
 using Aevatar.AI.ToolProviders.Skills;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -65,6 +66,8 @@ public static class ServiceCollectionExtensions
             return services;
 
         services.TryAddSingleton(options);
+        services.TryAddSingleton<ISystemSkillOverlayBuilder, SystemSkillOverlayBuilder>();
+        // TODO: consolidate NyxIdRelayPromptConfiguration flags with this overlay registration once the materializer owns injection.
         return services;
     }
 

--- a/src/Aevatar.AI.ToolProviders.Ornn/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/ServiceCollectionExtensions.cs
@@ -52,6 +52,22 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
+    /// <summary>
+    /// Registers the host-bound system skill overlay scaffold.
+    /// </summary>
+    public static IServiceCollection AddSystemSkillOverlay(
+        this IServiceCollection services,
+        Action<SystemSkillOverlayOptions>? configure = null)
+    {
+        var options = new SystemSkillOverlayOptions();
+        configure?.Invoke(options);
+        if (!options.Enabled || string.IsNullOrWhiteSpace(options.Tag))
+            return services;
+
+        services.TryAddSingleton(options);
+        return services;
+    }
+
     private static IAgentToolSource GetOrnnAgentToolSource(IServiceProvider sp) =>
         sp.GetRequiredService<OrnnAgentToolSource>();
 

--- a/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlay/ISystemSkillOverlayBuilder.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlay/ISystemSkillOverlayBuilder.cs
@@ -1,0 +1,6 @@
+namespace Aevatar.AI.ToolProviders.Ornn.SystemSkillOverlay;
+
+public interface ISystemSkillOverlayBuilder
+{
+    Task<Aevatar.AI.Abstractions.SystemSkillOverlay> BuildAsync(CancellationToken ct);
+}

--- a/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlay/ISystemSkillOverlayBuilder.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlay/ISystemSkillOverlayBuilder.cs
@@ -1,6 +1,6 @@
 namespace Aevatar.AI.ToolProviders.Ornn.SystemSkillOverlay;
 
-public interface ISystemSkillOverlayBuilder
+/// <summary>Compatibility alias for Ornn callers; the contract lives in AI abstractions.</summary>
+public interface ISystemSkillOverlayBuilder : Aevatar.AI.Abstractions.ToolProviders.ISystemSkillOverlayBuilder
 {
-    Task<Aevatar.AI.Abstractions.SystemSkillOverlay> BuildAsync(CancellationToken ct);
 }

--- a/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlay/OverlayAuthoringContract.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlay/OverlayAuthoringContract.cs
@@ -1,0 +1,29 @@
+namespace Aevatar.AI.ToolProviders.Ornn.SystemSkillOverlay;
+
+public static class OverlayAuthoringContract
+{
+    public static bool Validate(OverlayFrontmatter? frontmatter) => IsValid(frontmatter);
+
+    public static bool IsValid(OverlayFrontmatter? frontmatter)
+    {
+        if (frontmatter == null ||
+            string.IsNullOrWhiteSpace(frontmatter.Title) ||
+            string.IsNullOrWhiteSpace(frontmatter.Scope) ||
+            string.IsNullOrWhiteSpace(frontmatter.Priority) ||
+            string.IsNullOrWhiteSpace(frontmatter.MaxBytes) ||
+            string.IsNullOrWhiteSpace(frontmatter.AppliesTo) ||
+            string.IsNullOrWhiteSpace(frontmatter.NonOverride))
+        {
+            return false;
+        }
+
+        if (!int.TryParse(frontmatter.Priority, out _) ||
+            !int.TryParse(frontmatter.MaxBytes, out _) ||
+            !bool.TryParse(frontmatter.NonOverride, out _))
+        {
+            return false;
+        }
+
+        return frontmatter.AppliesTo.ToLowerInvariant() is "channel" or "dm" or "both";
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlay/OverlayFrontmatter.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlay/OverlayFrontmatter.cs
@@ -1,0 +1,137 @@
+namespace Aevatar.AI.ToolProviders.Ornn.SystemSkillOverlay;
+
+public sealed record OverlayFrontmatter(
+    string? Title,
+    string? Scope,
+    string? Priority,
+    string? MaxBytes,
+    string? AppliesTo,
+    string? NonOverride)
+{
+    public static OverlayFrontmatter? Parse(string markdown) => OverlayFrontmatterParser.Parse(markdown);
+}
+
+public static class OverlayFrontmatterParser
+{
+    public static OverlayFrontmatter? Parse(string markdown)
+    {
+        return TryParse(markdown, out var frontmatter, out _)
+            ? frontmatter
+            : null;
+    }
+
+    public static bool TryParse(string markdown, out OverlayFrontmatter? frontmatter, out string body)
+    {
+        frontmatter = null;
+        body = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(markdown))
+            return false;
+
+        var openingEnd = markdown.StartsWith("---\n", StringComparison.Ordinal)
+            ? 4
+            : markdown.StartsWith("---\r\n", StringComparison.Ordinal)
+                ? 5
+                : -1;
+        if (openingEnd < 0)
+            return false;
+
+        var closingIndex = FindClosingDelimiter(markdown, openingEnd);
+        if (closingIndex < 0)
+            return false;
+
+        var block = markdown[openingEnd..closingIndex];
+        string? title = null;
+        string? scope = null;
+        string? priority = null;
+        string? maxBytes = null;
+        string? appliesTo = null;
+        string? nonOverride = null;
+
+        foreach (var rawLine in block.Split('\n'))
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0 || line.StartsWith('#'))
+                continue;
+
+            var colonIndex = line.IndexOf(':');
+            if (colonIndex <= 0)
+                return false;
+
+            var key = line[..colonIndex].Trim().Replace('-', '_').ToLowerInvariant();
+            var value = Unquote(line[(colonIndex + 1)..].Trim());
+
+            switch (key)
+            {
+                case "title":
+                    title = value;
+                    break;
+                case "scope":
+                    scope = value;
+                    break;
+                case "priority":
+                    priority = value;
+                    break;
+                case "max_bytes":
+                    maxBytes = value;
+                    break;
+                case "applies_to":
+                    appliesTo = value;
+                    break;
+                case "non_override":
+                    nonOverride = value;
+                    break;
+            }
+        }
+
+        frontmatter = new OverlayFrontmatter(title, scope, priority, maxBytes, appliesTo, nonOverride);
+        body = markdown[GetBodyStart(markdown, closingIndex)..].TrimStart('\r', '\n');
+        return true;
+    }
+
+    private static string Unquote(string value)
+    {
+        if (value.Length >= 2 &&
+            ((value[0] == '"' && value[^1] == '"') ||
+             (value[0] == '\'' && value[^1] == '\'')))
+        {
+            return value[1..^1];
+        }
+
+        return value;
+    }
+
+    private static int FindClosingDelimiter(string markdown, int startIndex)
+    {
+        var searchIndex = startIndex;
+        while (searchIndex < markdown.Length)
+        {
+            var delimiterIndex = markdown.IndexOf("\n---", searchIndex, StringComparison.Ordinal);
+            if (delimiterIndex < 0)
+                return -1;
+
+            var afterDashes = delimiterIndex + 4;
+            if (afterDashes == markdown.Length ||
+                markdown[afterDashes] == '\n' ||
+                markdown[afterDashes] == '\r')
+            {
+                return delimiterIndex;
+            }
+
+            searchIndex = afterDashes;
+        }
+
+        return -1;
+    }
+
+    private static int GetBodyStart(string markdown, int closingDelimiterIndex)
+    {
+        var bodyStart = closingDelimiterIndex + 4;
+        if (bodyStart < markdown.Length && markdown[bodyStart] == '\r')
+            bodyStart++;
+        if (bodyStart < markdown.Length && markdown[bodyStart] == '\n')
+            bodyStart++;
+
+        return bodyStart;
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlay/SystemSkillOverlayBuilder.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlay/SystemSkillOverlayBuilder.cs
@@ -10,12 +10,12 @@ public sealed class SystemSkillOverlayBuilder : ISystemSkillOverlayBuilder
     private const string Header = "## System Skill Overlay (force-injected)";
     private const string SkillMarkdownFileName = "SKILL.md";
 
-    private readonly SystemSkillOverlayOptions _options;
+    private readonly Aevatar.AI.Abstractions.ToolProviders.SystemSkillOverlayOptions _options;
     private readonly OrnnSkillClient _client;
     private readonly ILogger _logger;
 
     public SystemSkillOverlayBuilder(
-        SystemSkillOverlayOptions options,
+        Aevatar.AI.Abstractions.ToolProviders.SystemSkillOverlayOptions options,
         OrnnSkillClient client,
         ILogger<SystemSkillOverlayBuilder>? logger = null)
     {
@@ -84,7 +84,7 @@ public sealed class SystemSkillOverlayBuilder : ISystemSkillOverlayBuilder
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "System skill overlay build failed for tag '{Tag}'", _options.Tag);
-            return EmptyOverlay();
+            throw;
         }
     }
 

--- a/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlay/SystemSkillOverlayBuilder.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlay/SystemSkillOverlayBuilder.cs
@@ -1,0 +1,184 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.AI.ToolProviders.Ornn.SystemSkillOverlay;
+
+public sealed class SystemSkillOverlayBuilder : ISystemSkillOverlayBuilder
+{
+    private const string Header = "## System Skill Overlay (force-injected)";
+    private const string SkillMarkdownFileName = "SKILL.md";
+
+    private readonly SystemSkillOverlayOptions _options;
+    private readonly OrnnSkillClient _client;
+    private readonly ILogger _logger;
+
+    public SystemSkillOverlayBuilder(
+        SystemSkillOverlayOptions options,
+        OrnnSkillClient client,
+        ILogger<SystemSkillOverlayBuilder>? logger = null)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _logger = logger ?? NullLogger<SystemSkillOverlayBuilder>.Instance;
+    }
+
+    public async Task<Aevatar.AI.Abstractions.SystemSkillOverlay> BuildAsync(CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(_options.OrgServiceToken) || _options.MaxBytes <= 0)
+            return EmptyOverlay();
+
+        try
+        {
+            var result = await _client.SearchSkillsAsync(
+                _options.OrgServiceToken,
+                query: _options.Tag,
+                scope: "private",
+                pageSize: 100,
+                ct: ct);
+
+            var summaries = result.Items
+                .Where(IsTrustedSystemSkillSummary)
+                .ToArray();
+
+            var entries = new List<OverlaySkillEntry>(summaries.Length);
+            foreach (var summary in summaries)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                if (string.IsNullOrWhiteSpace(summary.Guid))
+                    continue;
+
+                var skill = await _client.GetSkillJsonAsync(_options.OrgServiceToken, summary.Guid, ct);
+                var body = ExtractSkillBody(skill);
+                if (string.IsNullOrWhiteSpace(body))
+                    continue;
+
+                if (!OverlayFrontmatterParser.TryParse(body, out var frontmatter, out var overlayBody) ||
+                    !OverlayAuthoringContract.IsValid(frontmatter))
+                {
+                    continue;
+                }
+
+                entries.Add(new OverlaySkillEntry(
+                    summary.Name ?? skill?.Name ?? summary.Guid,
+                    summary.Description ?? skill?.Description ?? string.Empty,
+                    overlayBody.Trim()));
+            }
+
+            var markdown = BuildWithinBudget(entries);
+            return string.IsNullOrEmpty(markdown)
+                ? EmptyOverlay()
+                : new Aevatar.AI.Abstractions.SystemSkillOverlay
+                {
+                    OverlayMarkdown = markdown,
+                    SourceWatermark = ComputeWatermark(entries),
+                    MaterializedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                };
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "System skill overlay build failed for tag '{Tag}'", _options.Tag);
+            return EmptyOverlay();
+        }
+    }
+
+    private bool IsTrustedSystemSkillSummary(OrnnSkillSummary summary) =>
+        summary.IsPrivate &&
+        summary.Tags != null &&
+        summary.Tags.Contains(_options.Tag);
+
+    private static string? ExtractSkillBody(OrnnSkillJson? skill)
+    {
+        if (skill?.Files == null || skill.Files.Count == 0)
+            return null;
+
+        return skill.Files
+            .FirstOrDefault(static file => file.Key.Equals(SkillMarkdownFileName, StringComparison.OrdinalIgnoreCase))
+            .Value;
+    }
+
+    private string BuildWithinBudget(IReadOnlyList<OverlaySkillEntry> entries)
+    {
+        if (entries.Count == 0)
+            return string.Empty;
+
+        var fullBodyCount = Math.Clamp(_options.MaxSkills, 0, entries.Count);
+        var markdown = Render(entries, fullBodyCount);
+        while (fullBodyCount > 0 && Utf8ByteCount(markdown) > _options.MaxBytes)
+        {
+            fullBodyCount--;
+            markdown = Render(entries, fullBodyCount);
+        }
+
+        if (Utf8ByteCount(markdown) <= _options.MaxBytes)
+            return markdown;
+
+        return RenderCatalogWithinBudget(entries);
+    }
+
+    private static string Render(IReadOnlyList<OverlaySkillEntry> entries, int fullBodyCount)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine(Header);
+
+        for (var i = 0; i < entries.Count; i++)
+        {
+            builder.AppendLine();
+            if (i < fullBodyCount)
+                builder.AppendLine(entries[i].Body);
+            else
+                builder.AppendLine(BuildCatalogLine(entries[i]));
+        }
+
+        return builder.ToString().TrimEnd();
+    }
+
+    private string RenderCatalogWithinBudget(IReadOnlyList<OverlaySkillEntry> entries)
+    {
+        var builder = new StringBuilder(Header);
+        if (Utf8ByteCount(builder.ToString()) > _options.MaxBytes)
+            return string.Empty;
+
+        foreach (var entry in entries)
+        {
+            var candidate = builder.ToString() + Environment.NewLine + Environment.NewLine + BuildCatalogLine(entry);
+            if (Utf8ByteCount(candidate) > _options.MaxBytes)
+                break;
+
+            builder.Clear();
+            builder.Append(candidate);
+        }
+
+        return builder.ToString();
+    }
+
+    private static string BuildCatalogLine(OverlaySkillEntry entry)
+    {
+        var description = string.IsNullOrWhiteSpace(entry.Description)
+            ? "No description."
+            : entry.Description.Trim();
+        return $"- {entry.Name.Trim()}: {description}";
+    }
+
+    private static int Utf8ByteCount(string value) => Encoding.UTF8.GetByteCount(value);
+
+    private static string ComputeWatermark(IReadOnlyList<OverlaySkillEntry> entries)
+    {
+        var canonical = string.Join("\n", entries.Select(static entry => $"{entry.Name}\n{entry.Description}\n{entry.Body}"));
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical))).ToLowerInvariant();
+    }
+
+    private static Aevatar.AI.Abstractions.SystemSkillOverlay EmptyOverlay() =>
+        new()
+        {
+            OverlayMarkdown = string.Empty,
+        };
+
+    private sealed record OverlaySkillEntry(string Name, string Description, string Body);
+}

--- a/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlayOptions.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlayOptions.cs
@@ -1,0 +1,37 @@
+namespace Aevatar.AI.ToolProviders.Ornn;
+
+/// <summary>System skill overlay configuration.</summary>
+public sealed class SystemSkillOverlayOptions
+{
+    /// <summary>
+    /// Host-bound Ornn tag used to select the system skills that may be materialized into the
+    /// persisted role-agent overlay.
+    /// </summary>
+    public string Tag { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Host-bound organization service token used by the future materializer to read system
+    /// skills. This is a secret and must be supplied by host configuration.
+    /// </summary>
+    public string OrgServiceToken { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Minimum interval before the future materializer should refresh the overlay from its source.
+    /// </summary>
+    public TimeSpan RefreshTtl { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
+    /// Maximum number of source skills the future materializer should include in one overlay.
+    /// </summary>
+    public int MaxSkills { get; set; }
+
+    /// <summary>
+    /// Maximum UTF-8 byte budget the future materializer should allow for one overlay.
+    /// </summary>
+    public int MaxBytes { get; set; }
+
+    /// <summary>
+    /// Enables host registration for the system skill overlay scaffold. Defaults to disabled.
+    /// </summary>
+    public bool Enabled { get; set; }
+}

--- a/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlayOptions.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/SystemSkillOverlayOptions.cs
@@ -1,37 +1,6 @@
 namespace Aevatar.AI.ToolProviders.Ornn;
 
-/// <summary>System skill overlay configuration.</summary>
-public sealed class SystemSkillOverlayOptions
+/// <summary>Compatibility alias for Ornn callers; the contract lives in AI abstractions.</summary>
+public sealed class SystemSkillOverlayOptions : Aevatar.AI.Abstractions.ToolProviders.SystemSkillOverlayOptions
 {
-    /// <summary>
-    /// Host-bound Ornn tag used to select the system skills that may be materialized into the
-    /// persisted role-agent overlay.
-    /// </summary>
-    public string Tag { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Host-bound organization service token used by the future materializer to read system
-    /// skills. This is a secret and must be supplied by host configuration.
-    /// </summary>
-    public string OrgServiceToken { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Minimum interval before the future materializer should refresh the overlay from its source.
-    /// </summary>
-    public TimeSpan RefreshTtl { get; set; } = TimeSpan.Zero;
-
-    /// <summary>
-    /// Maximum number of source skills the future materializer should include in one overlay.
-    /// </summary>
-    public int MaxSkills { get; set; }
-
-    /// <summary>
-    /// Maximum UTF-8 byte budget the future materializer should allow for one overlay.
-    /// </summary>
-    public int MaxBytes { get; set; }
-
-    /// <summary>
-    /// Enables host registration for the system skill overlay scaffold. Defaults to disabled.
-    /// </summary>
-    public bool Enabled { get; set; }
 }

--- a/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
@@ -70,6 +70,33 @@ public sealed class AevatarAIFeatureOptions
     /// NyxID catalog uses a different slug (e.g. organisations that re-registered the service).
     /// </summary>
     public string? OrnnNyxIdSlug { get; set; }
+    /// <summary>
+    /// Enables the host-bound system skill overlay scaffold. Mainnet-style hosts bind this from
+    /// <c>Aevatar:SystemSkills:Enabled</c>.
+    /// </summary>
+    public bool EnableSystemSkillOverlay { get; set; }
+    /// <summary>
+    /// Host-bound Ornn tag used to select system skills. Bound from
+    /// <c>Aevatar:SystemSkills:Tag</c>; this value is sensitive and should come from host secrets.
+    /// </summary>
+    public string? SystemSkillOverlayTag { get; set; }
+    /// <summary>
+    /// Host-bound organization service token used by the future materializer. Bound from
+    /// <c>Aevatar:SystemSkills:OrgServiceToken</c>; this value is a secret.
+    /// </summary>
+    public string? SystemSkillOverlayOrgServiceToken { get; set; }
+    /// <summary>
+    /// Bound from <c>Aevatar:SystemSkills:RefreshTtl</c>.
+    /// </summary>
+    public TimeSpan SystemSkillOverlayRefreshTtl { get; set; }
+    /// <summary>
+    /// Bound from <c>Aevatar:SystemSkills:MaxSkills</c>.
+    /// </summary>
+    public int SystemSkillOverlayMaxSkills { get; set; }
+    /// <summary>
+    /// Bound from <c>Aevatar:SystemSkills:MaxBytes</c>.
+    /// </summary>
+    public int SystemSkillOverlayMaxBytes { get; set; }
     public IAevatarSecretsStore? SecretsStore { get; set; }
     public string? ApiKey { get; set; }
     public NyxIdLlmEndpointSpec? NyxIdLlmEndpoint { get; set; }
@@ -145,6 +172,9 @@ public static class ServiceCollectionExtensions
 
         if (options.EnableOrnnSkills)
             RegisterOrnnSkills(services, options);
+
+        if (options.EnableSystemSkillOverlay)
+            RegisterSystemSkillOverlay(services, options);
 
         if (options.EnableServiceInvokeTools)
             RegisterServiceInvokeTools(services, options);
@@ -1165,6 +1195,22 @@ public static class ServiceCollectionExtensions
         });
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IOrnnSkillPublishAssetValidator, WorkflowOrnnSkillPublishAssetValidator>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IOrnnSkillPublishAssetValidator, ScriptOrnnSkillPublishAssetValidator>());
+    }
+
+    private static void RegisterSystemSkillOverlay(IServiceCollection services, AevatarAIFeatureOptions options)
+    {
+        if (!options.EnableSystemSkillOverlay || string.IsNullOrWhiteSpace(options.SystemSkillOverlayTag))
+            return;
+
+        services.AddSystemSkillOverlay(o =>
+        {
+            o.Enabled = options.EnableSystemSkillOverlay;
+            o.Tag = options.SystemSkillOverlayTag ?? string.Empty;
+            o.OrgServiceToken = options.SystemSkillOverlayOrgServiceToken ?? string.Empty;
+            o.RefreshTtl = options.SystemSkillOverlayRefreshTtl;
+            o.MaxSkills = options.SystemSkillOverlayMaxSkills;
+            o.MaxBytes = options.SystemSkillOverlayMaxBytes;
+        });
     }
 
     private static void RegisterWebTools(IServiceCollection services, AevatarAIFeatureOptions options)

--- a/src/Aevatar.Mainnet.Host.Api/appsettings.json
+++ b/src/Aevatar.Mainnet.Host.Api/appsettings.json
@@ -16,6 +16,14 @@
     "Ornn": {
       "NyxIdSlug": "ornn-api"
     },
+    "SystemSkills": {
+      "Enabled": false,
+      "Tag": "",
+      "OrgServiceToken": "",
+      "RefreshTtl": "00:00:00",
+      "MaxSkills": 0,
+      "MaxBytes": 0
+    },
     "Responses": {
       "ModelMetadataFallbacks": {
         "deepseek": {

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Hosting/AevatarPlatformHostBuilderExtensions.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Hosting/AevatarPlatformHostBuilderExtensions.cs
@@ -49,6 +49,15 @@ public static class AevatarPlatformHostBuilderExtensions
                 aiOptions.EnableSkills = true;
                 aiOptions.EnableOrnnSkills = true;
                 aiOptions.OrnnNyxIdSlug = builder.Configuration["Aevatar:Ornn:NyxIdSlug"];
+                aiOptions.EnableSystemSkillOverlay = ReadBoolean(builder.Configuration["Aevatar:SystemSkills:Enabled"]);
+                aiOptions.SystemSkillOverlayTag = builder.Configuration["Aevatar:SystemSkills:Tag"];
+                aiOptions.SystemSkillOverlayOrgServiceToken = builder.Configuration["Aevatar:SystemSkills:OrgServiceToken"];
+                if (TimeSpan.TryParse(builder.Configuration["Aevatar:SystemSkills:RefreshTtl"], out var refreshTtl))
+                    aiOptions.SystemSkillOverlayRefreshTtl = refreshTtl;
+                if (int.TryParse(builder.Configuration["Aevatar:SystemSkills:MaxSkills"], out var maxSkills))
+                    aiOptions.SystemSkillOverlayMaxSkills = maxSkills;
+                if (int.TryParse(builder.Configuration["Aevatar:SystemSkills:MaxBytes"], out var maxBytes))
+                    aiOptions.SystemSkillOverlayMaxBytes = maxBytes;
                 aiOptions.EnableWebTools = true;
                 aiOptions.WebSearchNyxIdSlug = builder.Configuration["Aevatar:WebSearch:NyxIdSlug"];
                 aiOptions.WebSearchApiBaseUrl = builder.Configuration["Aevatar:WebSearch:ApiBaseUrl"];
@@ -132,4 +141,7 @@ public static class AevatarPlatformHostBuilderExtensions
                 "Maker extensions require workflow capability to be enabled.");
         }
     }
+
+    private static bool ReadBoolean(string? value) =>
+        bool.TryParse(value, out var result) && result;
 }

--- a/test/Aevatar.AI.Tests/SystemSkillOverlayPromptInjectionTests.cs
+++ b/test/Aevatar.AI.Tests/SystemSkillOverlayPromptInjectionTests.cs
@@ -1,0 +1,128 @@
+using System.Reflection;
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core;
+using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Foundation.Core;
+using Aevatar.Foundation.Core.EventSourcing;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.AI.Tests;
+
+public sealed class SystemSkillOverlayPromptInjectionTests
+{
+    private const string OverlayMarkdown = "## Runtime system skills\n- prefer the committed overlay";
+
+    [Fact]
+    public async Task DirectChat_ShouldAppendCommittedSystemSkillOverlay()
+    {
+        var store = new InMemoryEventStoreForTests();
+        var services = BuildServices(store);
+        var agent = CreateAgent(services, "role-overlay-direct");
+        await agent.ActivateAsync();
+
+        await agent.MaterializeOverlayAsync(OverlayMarkdown);
+
+        agent.DecorateForTest("kernel invariant")
+            .Should()
+            .Be($"kernel invariant\n\n{OverlayMarkdown}");
+    }
+
+    [Fact]
+    public async Task DirectChat_ShouldSkipEmptySystemSkillOverlay()
+    {
+        var store = new InMemoryEventStoreForTests();
+        var services = BuildServices(store);
+        var agent = CreateAgent(services, "role-overlay-empty");
+        await agent.ActivateAsync();
+
+        await agent.MaterializeOverlayAsync("   ");
+
+        agent.DecorateForTest("kernel invariant")
+            .Should()
+            .Be("kernel invariant");
+    }
+
+    private static IServiceProvider BuildServices(IEventStore store)
+    {
+        return new ServiceCollection()
+            .AddSingleton(store)
+            .AddSingleton<EventSourcingRuntimeOptions>()
+            .AddSingleton<IActorRuntimeCallbackScheduler, NoOpCallbackScheduler>()
+            .AddTransient(typeof(IEventSourcingBehaviorFactory<>), typeof(DefaultEventSourcingBehaviorFactory<>))
+            .AddSingleton<ISystemSkillOverlayBuilder, EmptyOverlayBuilder>()
+            .AddSingleton(new SystemSkillOverlayOptions { Enabled = true })
+            .BuildServiceProvider();
+    }
+
+    private static TestRoleGAgent CreateAgent(IServiceProvider services, string actorId)
+    {
+        var agent = new TestRoleGAgent
+        {
+            Services = services,
+            EventSourcingBehaviorFactory = services.GetRequiredService<IEventSourcingBehaviorFactory<RoleGAgentState>>(),
+        };
+        AssignActorId(agent, actorId);
+        return agent;
+    }
+
+    private static void AssignActorId(RoleGAgent agent, string actorId)
+    {
+        var setIdMethod = typeof(GAgentBase).GetMethod(
+            "SetId",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        setIdMethod.Should().NotBeNull();
+        setIdMethod!.Invoke(agent, [actorId]);
+    }
+
+    private sealed class TestRoleGAgent : RoleGAgent
+    {
+        public Task MaterializeOverlayAsync(string overlayMarkdown) =>
+            PersistDomainEventAsync(new SystemSkillOverlayMaterializedEvent
+            {
+                Overlay = new SystemSkillOverlay
+                {
+                    OverlayMarkdown = overlayMarkdown,
+                    SourceWatermark = "test-watermark",
+                    MaterializedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                },
+            });
+
+        public string DecorateForTest(string basePrompt) => DecorateSystemPrompt(basePrompt);
+    }
+
+    private sealed class EmptyOverlayBuilder : ISystemSkillOverlayBuilder
+    {
+        public Task<SystemSkillOverlay> BuildAsync(CancellationToken ct) =>
+            Task.FromResult(new SystemSkillOverlay());
+    }
+
+    private sealed class NoOpCallbackScheduler : IActorRuntimeCallbackScheduler
+    {
+        public Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
+            RuntimeCallbackTimeoutRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                1,
+                RuntimeCallbackBackend.InMemory));
+
+        public Task<RuntimeCallbackLease> ScheduleTimerAsync(
+            RuntimeCallbackTimerRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                1,
+                RuntimeCallbackBackend.InMemory));
+
+        public Task CancelAsync(RuntimeCallbackLease lease, CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task PurgeActorAsync(string actorId, CancellationToken ct = default) =>
+            Task.CompletedTask;
+    }
+}

--- a/test/Aevatar.AI.Tests/SystemSkillOverlayRefreshEventProtoTests.cs
+++ b/test/Aevatar.AI.Tests/SystemSkillOverlayRefreshEventProtoTests.cs
@@ -1,0 +1,24 @@
+using Aevatar.AI.Abstractions;
+using FluentAssertions;
+using Google.Protobuf;
+
+namespace Aevatar.AI.Tests;
+
+public sealed class SystemSkillOverlayRefreshEventProtoTests
+{
+    [Fact]
+    public void SystemSkillOverlayRefreshFiredEvent_ShouldRoundTripAttempt()
+    {
+        var evt = new SystemSkillOverlayRefreshFiredEvent
+        {
+            Attempt = 2,
+        };
+
+        var parsed = SystemSkillOverlayRefreshFiredEvent.Parser.ParseFrom(evt.ToByteArray());
+
+        parsed.Attempt.Should().Be(2);
+        AiMessagesReflection.Descriptor.MessageTypes
+            .Should()
+            .Contain(x => x.Name == nameof(SystemSkillOverlayRefreshFiredEvent));
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.ToolProviders.Lark;
@@ -635,6 +636,76 @@ public sealed class ConversationReplyGeneratorTests
             .Messages.First(message => message.Role == "system").Content;
         systemPrompt.Should().Contain("operator_user_id: \"lark-user-1\"");
         systemPrompt.Should().Contain("operator_open_id: \"ou_operator_1\"");
+    }
+
+    [Fact]
+    public async Task GenerateReplyAsync_WithSystemSkillOverlayProvider_IncludesOverlayAfterKernelBeforeChannelContext()
+    {
+        const string overlayMarkdown = "## Runtime system skills\n- prefer the committed overlay";
+        var providerFactory = new RecordingProviderFactory();
+        var generator = new NyxIdConversationReplyGenerator(
+            providerFactory,
+            overlayProvider: new StubSystemSkillOverlayProvider(overlayMarkdown));
+
+        await generator.GenerateReplyAsync(
+            new ChatActivity
+            {
+                Id = "msg-overlay-channel",
+                ChannelId = ChannelId.From("lark"),
+                Conversation = new ConversationReference { CanonicalKey = "lark:group:oc_1" },
+                Content = new MessageContent { Text = "hello" },
+            },
+            new Dictionary<string, string>
+            {
+                [ChannelMetadataKeys.Platform] = "lark",
+                [ChannelMetadataKeys.ChatType] = "group",
+                [ChannelMetadataKeys.SenderId] = "ou_sender_1",
+                [ChannelMetadataKeys.MessageId] = "om_overlay",
+                [ChannelMetadataKeys.ConversationId] = "oc_1",
+            },
+            streamingSink: null,
+            CancellationToken.None);
+
+        var systemPrompt = providerFactory.Requests.Should().ContainSingle().Subject
+            .Messages.First(message => message.Role == "system").Content;
+        systemPrompt.Should().Contain(overlayMarkdown);
+        systemPrompt.Should().Contain("<channel-context>");
+        systemPrompt.Should().Contain("When you are following a loaded skill");
+        systemPrompt!.IndexOf("When you are following a loaded skill", StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(systemPrompt.IndexOf(overlayMarkdown, StringComparison.Ordinal));
+        systemPrompt.IndexOf(overlayMarkdown, StringComparison.Ordinal)
+            .Should()
+            .BeLessThan(systemPrompt.IndexOf("<channel-context>", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GenerateReplyAsync_WithEmptyOrMissingSystemSkillOverlayProvider_DoesNotInjectOverlay(string? overlayMarkdown)
+    {
+        var providerFactory = new RecordingProviderFactory();
+        var generator = new NyxIdConversationReplyGenerator(
+            providerFactory,
+            overlayProvider: overlayMarkdown is null ? null : new StubSystemSkillOverlayProvider(overlayMarkdown));
+
+        await generator.GenerateReplyAsync(
+            new ChatActivity
+            {
+                Id = $"msg-overlay-empty-{overlayMarkdown?.Length ?? 0}",
+                ChannelId = ChannelId.From("lark"),
+                Conversation = new ConversationReference { CanonicalKey = "lark:dm:user-1" },
+                Content = new MessageContent { Text = "hello" },
+            },
+            new Dictionary<string, string>(),
+            streamingSink: null,
+            CancellationToken.None);
+
+        var systemPrompt = providerFactory.Requests.Should().ContainSingle().Subject
+            .Messages.First(message => message.Role == "system").Content;
+        systemPrompt.Should().NotContain("Runtime system skills");
+        systemPrompt.Should().NotContain("prefer the committed overlay");
     }
 
     [Fact]
@@ -2028,6 +2099,14 @@ public sealed class ConversationReplyGeneratorTests
                 ? prefs
                 : new NyxIdUserLlmPreferences(string.Empty, string.Empty));
         }
+    }
+
+    private sealed class StubSystemSkillOverlayProvider(string? overlayMarkdown) : ISystemSkillOverlayProvider
+    {
+        public SystemSkillOverlay? GetCurrent() =>
+            overlayMarkdown is null
+                ? null
+                : new SystemSkillOverlay { OverlayMarkdown = overlayMarkdown };
     }
 
     private sealed class RecordingStreamingSink : IStreamingReplySink


### PR DESCRIPTION
## What

Implements #2468 — slim the embedded system-prompt kernel to stable invariants and add the overlay trust anchor.

实现 #2468:把嵌入式 system-prompt kernel 瘦身到稳定不变量,加入 overlay 信任锚。

## Change

Single file: `agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md`

**259 lines / ~6k tokens → 146 lines / ~3k tokens.**

### Kept in kernel (completeness checklist)
- identity, action-first, honest-success, tool-use policy
- runtime-block read contracts (`<connected-services>` / `<api-hints>` / `<channel-context>` / `@_user_N` safety)
- `use_skill` extension **mechanism** (not the bodies)
- internal tool index trimmed to **name + one-liner**
- working rules

### Moved to overlay (capability how-to)
- provisioning how-to, NyxID/Ornn operation manuals
- staged channel capability lists (Lark 3 stages, lines 127-166)
- long-running automation playbook (lines 178-223)
- workflow creation semantics, agent_builder / scheduled_agent_creator lifecycle detail

### Overlay trust anchor (new)
Near the top: the auto-injected System Skill Overlay extends capabilities but does **NOT** override the safety / honesty / action-first invariants above and below it.

## Acceptance

- Kernel target ~2.5–3k tokens (from ~6k): **met** (~3k).
- Completeness checklist preserved: all invariants retained (section headers verified).
- The moved how-to is supplied by the overlay builder (#2465) fetching Ornn skills tagged with the host tag; curators publish those skill bodies.

No code change (content edit only). The overlay injection is already wired from #2467. Depends on #2467 (PR #2486).

Generated by codex (gpt-5.5, xhigh) under manual serial execution of milestone 31. ⟦AI:FKST⟧
