### PR TITLE
Add script list source fallback

### DIFF
--- a/apps/aevatar-console-web/src/shared/studio/scriptsApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/scriptsApi.test.ts
@@ -4,6 +4,20 @@ import { persistAuthSession } from '@/shared/auth/session';
 describe('scriptsApi host-session requests', () => {
   const originalFetch = global.fetch;
 
+  function jsonResponse(body: unknown, status = 200): Response {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: status === 400 ? 'Bad Request' : 'OK',
+      headers: {
+        get: (name: string) =>
+          name.toLowerCase() === 'content-type' ? 'application/json' : null,
+      },
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    } as Response;
+  }
+
   beforeEach(() => {
     window.localStorage.clear();
     jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
@@ -122,6 +136,66 @@ describe('scriptsApi host-session requests', () => {
       definitionActorId: 'definition-1',
       runtimeActorId: 'runtime-1',
     });
+  });
+
+  it('falls back to script summaries when the backend rejects includeSource list requests', async () => {
+    const scripts = [
+      {
+        available: true,
+        scopeId: 'scope-1',
+        script: {
+          scopeId: 'scope-1',
+          scriptId: 'demo',
+          catalogActorId: 'catalog-1',
+          definitionActorId: 'definition-1',
+          activeRevision: 'rev-1',
+          activeSourceHash: 'hash-1',
+          updatedAt: '2026-03-27T00:00:00Z',
+        },
+        source: null,
+      },
+    ];
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ message: 'includeSource is unsupported' }, 400))
+      .mockResolvedValueOnce(jsonResponse(scripts));
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(scriptsApi.listScripts('scope-1', true)).resolves.toEqual(scripts);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      '/api/scopes/scope-1/scripts?includeSource=true',
+      expect.objectContaining({ credentials: 'same-origin' }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      '/api/scopes/scope-1/scripts?includeSource=false',
+      expect.objectContaining({ credentials: 'same-origin' }),
+    );
+  });
+
+  it('does not retry script list failures that are unrelated to includeSource compatibility', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ message: 'Forbidden' }, 403));
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(scriptsApi.listScripts('scope-1', true)).rejects.toThrow('Forbidden');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('requests script summaries directly when source is not required', async () => {
+    const fetchMock = jest.fn().mockResolvedValueOnce(jsonResponse([]));
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(scriptsApi.listScripts('scope-1')).resolves.toEqual([]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/scopes/scope-1/scripts?includeSource=false',
+      expect.objectContaining({ credentials: 'same-origin' }),
+    );
   });
 
   it('reads runtime activity from the Studio app host routes', async () => {

--- a/apps/aevatar-console-web/src/shared/studio/scriptsApi.ts
+++ b/apps/aevatar-console-web/src/shared/studio/scriptsApi.ts
@@ -53,6 +53,10 @@ async function requestJson<T>(
   init?: RequestInit,
 ): Promise<T> {
   const response = await scriptsFetch(input, init);
+  return readJsonResponse(response);
+}
+
+async function readJsonResponse<T>(response: Response): Promise<T> {
   if (!response.ok) {
     throw new Error(await readResponseError(response));
   }
@@ -188,6 +192,10 @@ function scopePath(scopeId: string): string {
   return `/api/scopes/${encodeURIComponent(scopeId)}`;
 }
 
+function scriptsListPath(scopeId: string, includeSource: boolean): string {
+  return `${scopePath(scopeId)}/scripts?includeSource=${includeSource ? 'true' : 'false'}`;
+}
+
 export const scriptsApi = {
   validateDraft(
     payload: {
@@ -206,10 +214,17 @@ export const scriptsApi = {
     });
   },
 
-  listScripts(scopeId: string, includeSource = false): Promise<ScopedScriptDetail[]> {
-    return requestJson(
-      `${scopePath(scopeId)}/scripts?includeSource=${includeSource ? 'true' : 'false'}`,
-    );
+  async listScripts(scopeId: string, includeSource = false): Promise<ScopedScriptDetail[]> {
+    if (!includeSource) {
+      return requestJson(scriptsListPath(scopeId, false));
+    }
+
+    const response = await scriptsFetch(scriptsListPath(scopeId, true));
+    if (response.status === 400) {
+      return requestJson(scriptsListPath(scopeId, false));
+    }
+
+    return readJsonResponse(response);
   },
 
   getScript(scopeId: string, scriptId: string): Promise<ScopedScriptDetail> {


### PR DESCRIPTION
## Summary
- Add a centralized script-list compatibility fallback in `scriptsApi.listScripts(scopeId, true)`.
- Retry once with `includeSource=false` only when the expanded script list request returns HTTP 400.
- Preserve non-400 failures and summary-only calls without extra requests.

## Issue
Closes #220

## Impact paths
- `apps/aevatar-console-web/src/shared/studio/scriptsApi.ts`
- `apps/aevatar-console-web/src/shared/studio/scriptsApi.test.ts`

## Validation
- `~/.fkst/hosts/aevatar-frontend/run.sh doctor`
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web install --frozen-lockfile`
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web test --runTestsByPath src/shared/studio/scriptsApi.test.ts --runInBand`
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web test --runTestsByPath src/pages/studio/components/StudioFilesPage.test.tsx src/pages/studio/index.test.tsx --runInBand`
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web test:ui --runInBand` — 105 suites / 895 tests passed
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web tsc`
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web build`
- `bash tools/ci/test_stability_guards.sh`
- `git diff --check`
- Frontend scope check: `git diff --name-only origin/dev..HEAD -- ':!apps/aevatar-console-web/**'` returned no files

## Notes
Full `test:ui` passed, but existing unrelated console warnings are still visible in other suites: `height: NaN`, React Query undefined data, jsdom CSS parsing for Ant Design generated CSS, and an Ant Design ConfigProvider deprecation warning. They are outside this PR's script-list fallback scope and are candidates for separate FKST rounds.

## Recurrence prevention
- Immediate symptom: Script behavior pages requested `/api/scopes/{scopeId}/scripts?includeSource=true`; backends that reject that query returned 400 and left the script workspace unable to load scope scripts.
- Root cause: Source-inclusive script list support was assumed at every caller, with no compatibility path for summary-only script list responses.
- General failure pattern: Optional read expansion parameters can become hard dependencies when frontend callers request expanded payloads directly and do not centralize fallback behavior.
- Similar locations searched: Searched all `scriptsApi.listScripts(..., true)` call sites under `apps/aevatar-console-web/src/pages/studio/**` and the summary-only `scopesApi.listScripts` implementation; current source-inclusive callers all go through `scriptsApi.listScripts`.
- Guard added: `scriptsApi.listScripts(scopeId, true)` now retries once with `includeSource=false` only for HTTP 400, while preserving non-400 failures.
- Regression test added: `src/shared/studio/scriptsApi.test.ts` covers 400 fallback, non-400 no-retry behavior, and direct summary requests.
- Hard gate: Focused API and Studio page tests, full `test:ui`, `tsc`, `build`, test stability guard, FKST doctor, `git diff --check`, and frontend scope check passed locally.
- Remaining risks: Fallback returns `source: null`, so pages needing source content must still fetch individual script details before editing; this PR only prevents the list load from failing when the expanded list endpoint is unavailable.
