### PR TITLE
Expose Script Build entrypoints

### DIFF
--- a/apps/aevatar-console-web/src/locales/projectMessages.en-US.ts
+++ b/apps/aevatar-console-web/src/locales/projectMessages.en-US.ts
@@ -3676,6 +3676,7 @@ const projectMessages = {
   "pages.studio.studiobuildpanels.advanced.package.2": "Advanced package",
   "pages.studio.studiobuildpanels.advanced.routing.json": "Advanced routing JSON",
   "pages.studio.studiobuildpanels.advanced.routing.json.2": "Advanced routing JSON",
+  "pages.studio.studiobuildpanels.script.files": "Script files",
   "pages.studio.studiobuildpanels.applied": "{value1} (applied)",
   "pages.studio.studiobuildpanels.apply.changes": "Apply changes",
   "pages.studio.studiobuildpanels.apply.changes.2": "Apply changes",

--- a/apps/aevatar-console-web/src/locales/projectMessages.zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/projectMessages.zh-CN.ts
@@ -3676,6 +3676,7 @@ const projectMessages = {
   "pages.studio.studiobuildpanels.advanced.package.2": "高级包",
   "pages.studio.studiobuildpanels.advanced.routing.json": "高级路由 JSON",
   "pages.studio.studiobuildpanels.advanced.routing.json.2": "高级路由 JSON",
+  "pages.studio.studiobuildpanels.script.files": "脚本文件",
   "pages.studio.studiobuildpanels.applied": "{value1}（已应用）",
   "pages.studio.studiobuildpanels.apply.changes": "应用更改",
   "pages.studio.studiobuildpanels.apply.changes.2": "应用更改",

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
@@ -606,6 +606,35 @@ describe('StudioWorkflowBuildPanel', () => {
     expect(handleCreateScriptDraft).toHaveBeenCalled();
   });
 
+  it('keeps a visible Script create and file editing path after a script is selected', () => {
+    const handleCreateScriptDraft = jest.fn();
+
+    render(
+      <StudioScriptBuildPanel
+        scopeId="scope-1"
+        scriptsQuery={{
+          data: [scriptDetail],
+          error: null,
+          isError: false,
+          isLoading: false,
+        }}
+        selectedScriptId="script-alpha"
+        onContinueToBind={jest.fn()}
+        onCreateScriptDraft={handleCreateScriptDraft}
+        onSelectScriptId={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Add script' })).toBeEnabled();
+    expect(screen.getByText('Script files')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add C#' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Add proto' })).toBeVisible();
+    expect(screen.getByLabelText('Mock script code editor')).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add script' }));
+    expect(handleCreateScriptDraft).toHaveBeenCalledTimes(1);
+  });
+
   it('starts a named Script draft without a saved catalog script', async () => {
     const handleDraftSaved = jest.fn();
     mockedScriptsApi.saveScript.mockResolvedValueOnce({
@@ -1084,7 +1113,7 @@ describe('StudioWorkflowBuildPanel', () => {
     );
 
     expect(screen.getByLabelText('Script package tree')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('Advanced package'));
+    expect(screen.getByText('Script files')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Add C#' }));
     expect(screen.getByRole('button', { name: /Support\.cs/ })).toBeInTheDocument();
 

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
@@ -8,6 +8,7 @@ import {
   CheckCircleOutlined,
   CodeOutlined,
   PlayCircleOutlined,
+  PlusOutlined,
   RobotOutlined,
   ApartmentOutlined,
 } from '@ant-design/icons';
@@ -2762,6 +2763,14 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
             </Space>
             {hasActiveScript ? (
               <Space wrap size={[8, 8]}>
+                {onCreateScriptDraft ? (
+                  <Button
+                    className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
+                    icon={<PlusOutlined />}
+                    onClick={onCreateScriptDraft}
+                  >
+                    {t("pages.studio.studiobuildpanels.add.script.2", "Add script")}</Button>
+                ) : null}
                 <Button
                   className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
                   disabled={validationPending}
@@ -2824,6 +2833,7 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
             <div style={{ display: 'grid', gap: 12 }}>
               <details
                 aria-label={t("pages.studio.studiobuildpanels.script.package.tree.2", "Script package tree")}
+                open
                 style={{
                   border: '1px solid #efe7da',
                   borderRadius: 16,
@@ -2841,7 +2851,7 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
                     listStyle: 'none',
                   }}
                 >
-                  <span style={sectionEyebrowStyle}>{t("pages.studio.studiobuildpanels.advanced.package.2", "Advanced package")}</span>
+                  <span style={sectionEyebrowStyle}>{t("pages.studio.studiobuildpanels.script.files", "Script files")}</span>
                   <Typography.Text type="secondary">
                     {packageEntries.length} {t("pages.studio.studiobuildpanels.file.2", "file")}{packageEntries.length === 1 ? '' : 's'} ·{' '}
                     {scriptPackage.entrySourcePath || t("pages.studio.studiobuildpanels.no.entry.2", "no entry")} {t("pages.studio.studiobuildpanels.entry.2", "entry")}</Typography.Text>


### PR DESCRIPTION
## Summary
- Keep the Script Build create path visible after a script is already selected.
- Make the script file editing controls visible by default under a user-facing `Script files` section.
- Add focused regression coverage for the selected-script create/edit entrypoints and sync locale catalogs.

## Issue
Closes #225

## Impact paths
- `apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx`
- `apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx`
- `apps/aevatar-console-web/src/locales/projectMessages.en-US.ts`
- `apps/aevatar-console-web/src/locales/projectMessages.zh-CN.ts`

## Validation
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web install --frozen-lockfile`
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web jest --selectProjects jsdom --runTestsByPath src/pages/studio/components/StudioBuildPanels.test.tsx --runInBand`
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web jest --selectProjects jsdom --runTestsByPath src/locales/hardcodedCopyAudit.test.ts --runInBand`
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web jest --selectProjects jsdom --runTestsByPath src/pages/studio/index.test.tsx --runInBand`
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web tsc`
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web test:ui --runInBand` — 105 suites / 893 tests passed
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web build`
- `bash tools/ci/test_stability_guards.sh`
- `~/.fkst/hosts/aevatar-frontend/run.sh doctor`
- `git diff --check`
- Frontend scope check: `git diff --name-only origin/dev..HEAD -- ':!apps/aevatar-console-web/**'` returned no files

## Notes
Full `test:ui` still prints the existing console warnings tracked by #2477 / #2478: `height: NaN`, React Query undefined data, jsdom AntD Steps CSS parsing, and AntD ConfigProvider deprecation. They are outside this PR's script entrypoint scope.

## Recurrence prevention
- Immediate symptom: Studio Script Build could show an existing script draft but did not keep a visible create-another-script path, and file editing controls were hidden behind an `Advanced package` disclosure.
- Root cause: The create action was only rendered in the no-selected-script empty state, and file controls were framed as advanced internals rather than the main script editing path.
- General failure pattern: User-critical workflow entrypoints can disappear when UI state moves from empty state to selected state, especially when the same action is not centralized across both states.
- Similar locations searched: Script Build empty state, selected Script Build toolbar, Studio create-member modal tests, script package editor tests, and issue/PR search for existing #225 coverage.
- Guard added: Selected Script Build now renders the same `Add script` action when creation is available, and the file section is open by default with the user-facing `Script files` label.
- Regression test added: `StudioBuildPanels.test.tsx` now asserts selected-script state exposes `Add script`, `Script files`, file add actions, and the code editor.
- Hard gate: Focused Script Build tests, Studio page tests, i18n audit, `tsc`, full `test:ui`, `build`, test stability guard, FKST doctor, `git diff --check`, and frontend scope check passed locally.
- Remaining risks: This PR improves the in-page entrypoints; it does not redesign the full Script resource rail or add new backend script capabilities.
