### PR TITLE
Use save-and-bind for Studio scope workflow publish

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -96,7 +96,26 @@ function mockCloneValue<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
 
-function mockBuildWorkflowYaml(document: typeof mockWorkflowDocument): string {
+type MockWorkflowYamlDocument = {
+  readonly name: string;
+  readonly description?: string;
+  readonly roles: ReadonlyArray<{
+    readonly id: string;
+    readonly name?: string;
+    readonly provider?: string;
+    readonly model?: string;
+  }>;
+  readonly steps: ReadonlyArray<{
+    readonly id: string;
+    readonly type: string;
+    readonly targetRole?: string | null;
+    readonly parameters?: Record<string, unknown> | null;
+    readonly next?: string | null;
+    readonly branches?: Record<string, string>;
+  }>;
+};
+
+function mockBuildWorkflowYaml(document: MockWorkflowYamlDocument): string {
   const roleLines = document.roles.flatMap((role) => {
     const lines = [`  - id: ${role.id}`];
     if (role.name) {
@@ -1212,6 +1231,43 @@ jest.mock("@/shared/studio/api", () => ({
       workflowName: input.displayName || "workspace-demo",
       definitionActorIdPrefix: "scope-workflow:scope-1:default",
       expectedActorId: "scope-workflow:scope-1:default:dep-1",
+    })),
+    saveAndBindWorkflow: jest.fn(async (input: {
+      scopeId: string;
+      workflowId?: string;
+      workflowYaml: string;
+      workflowName?: string;
+      displayName?: string;
+      inlineWorkflowYamls?: Record<string, string>;
+      appId?: string;
+      serviceId?: string;
+      exposureDesired?: boolean;
+    }) => ({
+      scopeId: input.scopeId,
+      workflowId: input.workflowId || "workflow-1",
+      revisionId: "rev-save-bind",
+      workflow: {
+        scopeId: input.scopeId,
+        workflowId: input.workflowId || "workflow-1",
+        revisionId: "rev-save-bind",
+        workflowName: input.workflowName || input.displayName || "workspace-demo",
+        acceptanceStage: "accepted",
+        propagationStage: "readmodel_propagating",
+      },
+      binding: {
+        scopeId: input.scopeId,
+        serviceId: input.serviceId || "default",
+        displayName: input.displayName || input.workflowName || "workspace-demo",
+        targetKind: "workflow",
+        targetName: input.workflowName || input.displayName || "workspace-demo",
+        implementationKind: "workflow",
+        revisionId: "rev-save-bind",
+        workflowName: input.workflowName || input.displayName || "workspace-demo",
+        definitionActorIdPrefix: "scope-workflow:scope-1:default",
+        expectedActorId: "scope-workflow:scope-1:default:dep-1",
+      },
+      acceptanceStage: "accepted",
+      propagationStage: "readmodel_propagating",
     })),
     bindScopeScript: jest.fn(async (input: {
       scopeId: string;
@@ -5359,6 +5415,178 @@ describe("StudioPage", () => {
     expect(screen.queryByTestId("studio-invoke-surface")).toBeNull();
     const searchParams = new URLSearchParams(window.location.search);
     expect(searchParams.get("step")).not.toBe("invoke");
+  });
+
+  it("uses save-and-bind for scope workflow publishing without a backend member", async () => {
+    mockStudioMembers = [];
+    mockScopeRuntimeApi.listServices.mockReset();
+    mockScopeRuntimeApi.listServices
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          serviceId: "default",
+          displayName: "workspace-demo",
+          deploymentStatus: "Active",
+          primaryActorId: "actor-default",
+          endpoints: [
+            {
+              endpointId: "chat",
+              displayName: "Chat",
+              kind: "chat",
+              description: "Chat with workspace-demo.",
+              requestTypeUrl: "",
+              responseTypeUrl: "",
+            },
+          ],
+        },
+      ]);
+    (studioApi.getScopeBinding as jest.Mock).mockResolvedValueOnce(null);
+
+    renderStudioPage("/studio?scopeId=scope-1&focus=workflow%3Aworkflow-1&tab=studio");
+
+    expect(await screen.findByTestId("studio-workflow-build-panel")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Continue to Bind" }));
+    expect(await screen.findByTestId("studio-bind-surface")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText("candidate:workspace-demo")).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Bind current member" }));
+    });
+
+    await waitFor(() => {
+      expect(studioApi.saveAndBindWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scopeId: "scope-1",
+          workflowId: "workflow-1",
+          workflowName: "workspace-demo",
+          displayName: "workspace-demo",
+          workflowYaml: expect.stringContaining("name: workspace-demo"),
+          inlineWorkflowYamls: {},
+          appId: "studio",
+          serviceId: "default",
+          exposureDesired: true,
+        }),
+      );
+    });
+    expect(studioApi.bindScopeWorkflow).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByText("service:default")).toBeTruthy();
+      expect(screen.getByText("services:default")).toBeTruthy();
+    });
+  });
+
+  it("passes referenced child workflows as save-and-bind inline YAMLs", async () => {
+    mockStudioMembers = [];
+    const rootDocument: MockWorkflowYamlDocument = {
+      ...mockCloneValue(mockWorkflowDocument),
+      steps: [
+        {
+          id: "call_child",
+          type: "workflow_call",
+          targetRole: "",
+          parameters: {
+            workflow: "child-flow",
+          },
+          next: null,
+          branches: {},
+        },
+      ],
+    };
+    const childDocument: MockWorkflowYamlDocument = {
+      ...mockCloneValue(mockWorkflowDocument),
+      name: "child-flow",
+      steps: [
+        {
+          id: "child_answer",
+          type: "llm_call",
+          targetRole: "assistant",
+          parameters: {
+            prompt_prefix: "Answer from the child workflow",
+          },
+          next: null,
+          branches: {},
+        },
+      ],
+    };
+    const rootWorkflowFile = {
+      ...mockWorkflowFile,
+      workflowId: "workflow-1",
+      name: "workspace-demo",
+      fileName: "workspace-demo.yaml",
+      yaml: mockBuildWorkflowYaml(rootDocument),
+      document: rootDocument,
+    };
+    const childWorkflowFile = {
+      ...mockWorkflowFile,
+      workflowId: "child-flow-id",
+      name: "child-flow",
+      fileName: "child-flow.yaml",
+      filePath: "/tmp/workflows/child-flow.yaml",
+      yaml: mockBuildWorkflowYaml(childDocument),
+      document: childDocument,
+    };
+    mockParsedDocument = mockCloneValue(rootDocument) as typeof mockWorkflowDocument;
+    mockWorkflowFile = rootWorkflowFile;
+    mockWorkflowSummaries = [
+      ...mockCreateDefaultWorkflowSummaries(),
+      {
+        workflowId: "child-flow-id",
+        name: "child-flow",
+        description: "Child workflow",
+        fileName: "child-flow.yaml",
+        filePath: "/tmp/workflows/child-flow.yaml",
+        directoryId: "dir-1",
+        directoryLabel: "Workspace",
+        stepCount: 1,
+        hasLayout: true,
+        updatedAtUtc: "2026-03-18T00:01:00Z",
+      },
+    ];
+    (studioApi.listWorkflows as jest.Mock).mockResolvedValue(mockWorkflowSummaries);
+    (studioApi.getWorkflow as jest.Mock).mockImplementation(
+      async (workflowId: string) =>
+        workflowId === "child-flow-id" ? childWorkflowFile : rootWorkflowFile,
+    );
+    mockScopeRuntimeApi.listServices.mockReset();
+    mockScopeRuntimeApi.listServices
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          serviceId: "default",
+          displayName: "workspace-demo",
+          deploymentStatus: "Active",
+          primaryActorId: "actor-default",
+          endpoints: [],
+        },
+      ]);
+    (studioApi.getScopeBinding as jest.Mock).mockResolvedValueOnce(null);
+
+    renderStudioPage("/studio?scopeId=scope-1&focus=workflow%3Aworkflow-1&tab=studio");
+
+    expect(await screen.findByTestId("studio-workflow-build-panel")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Continue to Bind" }));
+    expect(await screen.findByTestId("studio-bind-surface")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText("candidate:workspace-demo")).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Bind current member" }));
+    });
+
+    await waitFor(() => {
+      expect(studioApi.saveAndBindWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workflowYaml: expect.stringContaining("workflow: child-flow"),
+          inlineWorkflowYamls: {
+            "child-flow.yaml": expect.stringContaining("name: child-flow"),
+          },
+        }),
+      );
+    });
+    expect(studioApi.bindScopeWorkflow).not.toHaveBeenCalled();
   });
 
   it("pins Invoke to the selected member instead of exposing every runtime service", async () => {

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -249,6 +249,28 @@ const WORKFLOW_DRAFT_MATERIALIZATION_ATTEMPTS = 10;
 const WORKFLOW_DRAFT_MATERIALIZATION_DELAY_MS = 900;
 const SAVED_WORKFLOW_QUERY_STALE_MS = 30_000;
 
+type StudioWorkflowYamlBundleEntry = {
+  readonly workflowName: string;
+  readonly yaml: string;
+};
+
+function buildInlineWorkflowYamlMap(
+  workflowBundle: readonly StudioWorkflowYamlBundleEntry[],
+): Record<string, string> {
+  const inlineWorkflowYamls: Record<string, string> = {};
+
+  for (let index = 1; index < workflowBundle.length; index += 1) {
+    const entry = workflowBundle[index];
+    const yaml = trimOptional(entry.yaml);
+    if (yaml) {
+      const workflowName = trimOptional(entry.workflowName);
+      inlineWorkflowYamls[workflowName ? `${workflowName}.yaml` : `workflow-${index}.yaml`] = yaml;
+    }
+  }
+
+  return inlineWorkflowYamls;
+}
+
 // Refactor (iter160/cluster-1200): member binding run waiting uses shared
 //   probeAsyncOperation normalized states instead of duplicated page-local
 //   status mapping. The fixed timeout remains pre-refactor page-local pacing;
@@ -4487,12 +4509,12 @@ const StudioPage: React.FC = () => {
     [availableStepTypes],
   );
 
-  const buildWorkflowYamlBundle = useCallback(async (
+  const buildWorkflowYamlBundleEntries = useCallback(async (
     pendingStepDraft?: {
       readonly stepId: string;
       readonly draft: StudioStepInspectorDraft;
     } | null,
-  ): Promise<string[]> => {
+  ): Promise<StudioWorkflowYamlBundleEntry[]> => {
     let rootYaml = draftYaml.trim();
     let rootDocument: StudioWorkflowDocument | null | undefined =
       activeWorkflowDocument;
@@ -4549,7 +4571,7 @@ const StudioPage: React.FC = () => {
     const workflowIdsByName = new Map(
       workspaceWorkflows.map((item) => [item.name, item.workflowId]),
     );
-    const bundle: string[] = [];
+    const bundle: StudioWorkflowYamlBundleEntry[] = [];
     const seen = new Set<string>();
     const queue: Array<{
       workflowName: string;
@@ -4599,7 +4621,10 @@ const StudioPage: React.FC = () => {
             current.document,
             availableWorkflowNames,
           );
-      bundle.push(normalizedCurrent.yaml);
+      bundle.push({
+        workflowName: normalizedWorkflowName,
+        yaml: normalizedCurrent.yaml,
+      });
 
       for (const targetWorkflow of readWorkflowCallTargets(normalizedCurrent.document)) {
         if (seen.has(targetWorkflow)) {
@@ -4650,6 +4675,18 @@ const StudioPage: React.FC = () => {
     visibleWorkflowSummaries,
     workflowNames,
   ]);
+  const buildWorkflowYamlBundle = useCallback(
+    async (
+      pendingStepDraft?: {
+        readonly stepId: string;
+        readonly draft: StudioStepInspectorDraft;
+      } | null,
+    ): Promise<string[]> => {
+      const bundle = await buildWorkflowYamlBundleEntries(pendingStepDraft);
+      return bundle.map((entry) => entry.yaml);
+    },
+    [buildWorkflowYamlBundleEntries],
+  );
   const recentPromptHistory = useMemo(
     () => promptHistory.slice(0, 3),
     [promptHistory],
@@ -5072,11 +5109,39 @@ const StudioPage: React.FC = () => {
           );
         }
       } else {
-        result = await studioApi.bindScopeWorkflow({
+        const workflowBundle = await buildWorkflowYamlBundleEntries();
+        const workflowYaml = trimOptional(workflowBundle[0]?.yaml);
+        if (!workflowYaml) {
+          throw new Error('Workflow YAML is required before save-and-bind.');
+        }
+
+        const saveAndBindResult = await studioApi.saveAndBindWorkflow({
           scopeId: resolvedStudioScopeId,
+          workflowId: selectedWorkflowId || activeWorkflowFile?.workflowId || undefined,
+          workflowYaml,
+          workflowName: activeWorkflowName || draftWorkflowName,
           displayName: buildPendingBindCandidate.displayName,
-          workflowYamls: await buildWorkflowYamlBundle(),
+          inlineWorkflowYamls: buildInlineWorkflowYamlMap(workflowBundle),
+          appId: 'studio',
+          serviceId: 'default',
+          exposureDesired: true,
         });
+        result = saveAndBindResult.binding ?? {
+          scopeId: saveAndBindResult.scopeId,
+          serviceId: 'default',
+          displayName: buildPendingBindCandidate.displayName,
+          implementationKind: 'workflow',
+          targetKind: 'workflow',
+          targetName:
+            saveAndBindResult.workflow?.workflowName ||
+            buildPendingBindCandidate.displayName,
+          revisionId: saveAndBindResult.revisionId,
+          workflowName:
+            saveAndBindResult.workflow?.workflowName ||
+            buildPendingBindCandidate.displayName,
+          definitionActorIdPrefix: '',
+          expectedActorId: '',
+        };
       }
     } else if (buildPendingBindCandidate.kind === 'script') {
       if (resolvedBuildMemberId) {


### PR DESCRIPTION
## Problem

Studio's scope workflow publish/bind action still used the legacy `bindScopeWorkflow` path when no backend member identity was selected, even though the API client already exposes the backend's atomic `saveAndBindWorkflow` contract from #2368.

## Solution

- Route the no-member workflow publish flow through `studioApi.saveAndBindWorkflow`.
- Preserve the existing member-owned workflow binding path because the save-and-bind endpoint does not carry member identity.
- Keep the existing public `buildWorkflowYamls` behavior as `string[]`, while retaining an internal `{ workflowName, yaml }` bundle for save-and-bind.
- Pass referenced child workflows as `inlineWorkflowYamls` keyed by workflow name, e.g. `child-flow.yaml`, instead of dropping them or inventing opaque keys.
- Add Studio regression coverage for the scope workflow publish path and the child-workflow inline YAML bundle.

## Impact Paths

- `apps/aevatar-console-web/src/pages/studio/index.tsx`
- `apps/aevatar-console-web/src/pages/studio/index.test.tsx`

## Validation

- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web tsc` ✅
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web test:ui --runInBand src/pages/studio/index.test.tsx` ✅ 115 passed
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web test:ui --runInBand` ✅ 105 suites / 894 tests passed
- `corepack pnpm@10.2.1 --dir apps/aevatar-console-web build` ✅
- `bash tools/ci/test_stability_guards.sh` ✅
- `~/.fkst/hosts/aevatar-frontend/run.sh doctor` ✅
- `git diff --check` ✅
- `git diff --name-only origin/dev..HEAD -- ':!apps/aevatar-console-web/**'` ✅ empty

Known existing test-console warnings were observed during the full UI suite: React `height: NaN`, React Query undefined data, AntD `autoInsertSpaceInButton` deprecation, and jsdom CSS parsing warnings. The suite still passed, and these warnings are outside this issue's changed paths.

## Recurrence prevention

- Immediate symptom: Studio scope workflow publish/bind still called the legacy bind endpoint instead of the dedicated save-and-bind endpoint.
- Root cause: The API client gained `saveAndBindWorkflow`, but the no-member Studio workflow bind branch kept duplicated legacy publish assumptions.
- General failure pattern: UI workflow code continued wiring a stronger backend contract through older per-step endpoint assumptions.
- Similar locations searched: `bindScopeWorkflow`, `bindMemberWorkflow`, `saveAndBindWorkflow`, team-member workflow Studio save-and-bind usage, Studio workflow bundle creation, and related Studio/API tests.
- Guard added: Scope workflow save+publish now centralizes on `studioApi.saveAndBindWorkflow`; internal bundle entries preserve workflow names so child workflows are passed as named inline YAMLs.
- Regression test added: StudioPage tests assert no-member scope workflow publishing calls `saveAndBindWorkflow`, does not call `bindScopeWorkflow`, and includes referenced child workflows in `inlineWorkflowYamls`.
- Hard gate: `tsc`, focused/full `test:ui`, `build`, test stability guard, FKST doctor, whitespace diff check, and frontend scope check.
- Remaining risks: Member-owned workflow binding still uses `bindMemberWorkflow` because the save-and-bind endpoint has no member identity field; backend-specific inline child workflow naming rules may need adjustment if it rejects the frontend's `{workflowName}.yaml` convention.

Fixes #2368
