### PR TITLE
Stabilize frontend UI test script

### DIFF
--- a/apps/aevatar-console-web/jest.config.ts
+++ b/apps/aevatar-console-web/jest.config.ts
@@ -80,6 +80,7 @@ const browserProjectConfig = createProjectConfig('browser');
 const nodeProjectConfig = createProjectConfig('node');
 
 const nodeTestFiles = [
+  '<rootDir>/tests/packageScripts.test.ts',
   '<rootDir>/src/pages/MissionControl/runtimeAdapter.test.ts',
   '<rootDir>/src/pages/actors/actorPresentation.test.ts',
   '<rootDir>/src/pages/governance/components/governanceQuery.test.ts',

--- a/apps/aevatar-console-web/package.json
+++ b/apps/aevatar-console-web/package.json
@@ -17,7 +17,7 @@
     "start:dev": "PORT=\"${PORT:-${AEVATAR_CONSOLE_FRONTEND_PORT:-5173}}\" UMI_ENV=dev MOCK=none max dev",
     "test": "jest",
     "test:unit": "jest --selectProjects node",
-    "test:ui": "jest --selectProjects jsdom",
+    "test:ui": "jest --selectProjects jsdom --runInBand",
     "test:coverage": "npm run jest -- --coverage",
     "tsc": "tsc --noEmit"
   },

--- a/apps/aevatar-console-web/tests/packageScripts.test.ts
+++ b/apps/aevatar-console-web/tests/packageScripts.test.ts
@@ -1,0 +1,15 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('package scripts', () => {
+  it('runs jsdom UI tests serially to keep heavy Studio suites stable', () => {
+    const packageJsonPath = path.join(__dirname, '..', 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(packageJson.scripts?.['test:ui']).toBe(
+      'jest --selectProjects jsdom --runInBand',
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Closes #2571.

The frontend FKST validation command `pnpm --dir apps/aevatar-console-web test:ui` used the default Jest worker pool for the `jsdom` project. On latest `origin/dev` (`cb78de69e`), this produced flaky failures in heavy Studio/Team page suites: timeouts, stale async UI assertions, and save-observation drift.

The same failing files passed when run serially with `--runInBand`:

- 5 suites passed
- 286 tests passed

## Solution

- Run `test:ui` as `jest --selectProjects jsdom --runInBand`.
- Add a small node-project contract test so the UI validation script does not silently regress back to parallel workers.
- Keep the change scoped to `apps/aevatar-console-web/**`.

## Impact Paths

- `apps/aevatar-console-web/package.json`
- `apps/aevatar-console-web/jest.config.ts`
- `apps/aevatar-console-web/tests/packageScripts.test.ts`

## Validation

```sh
pnpm --dir apps/aevatar-console-web exec jest --selectProjects node --runTestsByPath tests/packageScripts.test.ts --runInBand
# PASS node tests/packageScripts.test.ts, 1 passed

pnpm --dir apps/aevatar-console-web tsc
# PASS, tsc --noEmit exit 0

pnpm --dir apps/aevatar-console-web test:ui
# PASS, 105 suites passed, 892 tests passed

pnpm --dir apps/aevatar-console-web build
# PASS, Webpack compiled successfully

pnpm --dir apps/aevatar-console-web test:unit
# PASS, 17 suites passed, 94 tests passed

bash tools/ci/test_stability_guards.sh
# PASS
```

Note: `test:ui` still prints pre-existing console noise from AntD/jsdom (`height: NaN`, CSS stylesheet parsing, deprecated `autoInsertSpaceInButton`, and one React Query undefined-data warning), but the command now completes successfully and the original flaky failures no longer reproduce under the script entry point.
