### PR TITLE
Fix workflow role test helper service lifetime

### DIFF
--- a/test/Aevatar.Integration.Tests/TestDoubles/WorkflowGAgentTestBase.cs
+++ b/test/Aevatar.Integration.Tests/TestDoubles/WorkflowGAgentTestBase.cs
@@ -65,7 +65,7 @@ public abstract class WorkflowGAgentTestBase
             ILLMProviderFactory llmProviderFactory,
             string agentId)
         {
-            await using var services = new ServiceCollection()
+            var services = new ServiceCollection()
                 .AddSingleton<IEventStore>(eventStore)
                 .AddSingleton(eventStore)
                 .AddSingleton<EventSourcingRuntimeOptions>()


### PR DESCRIPTION
## Summary
- Keep the workflow role test helper service provider alive after returning the agent.
- Fixes the integration test failures where `WorkflowRoleGAgentInteractionTests` hit disposed services before reaching fake LLM providers.

## Test plan
- [x] `dotnet test test/Aevatar.Integration.Tests/Aevatar.Integration.Tests.csproj --nologo --filter FullyQualifiedName~WorkflowRoleGAgentInteractionTests`
- [x] `bash tools/ci/test_stability_guards.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)