### PR TITLE
fix: require https callback_url when registering channel relay bots

### DIFF
--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxLarkProvisioningService.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxLarkProvisioningService.cs
@@ -115,6 +115,8 @@ public sealed class NyxLarkProvisioningService : INyxLarkProvisioningService, IN
             return Failure("missing_app_secret");
         if (string.IsNullOrWhiteSpace(request.WebhookBaseUrl))
             return Failure("missing_webhook_base_url");
+        if (!NyxRelayCallbackUrl.IsSecureBaseUrl(request.WebhookBaseUrl))
+            return Failure("insecure_webhook_base_url");
         if (string.IsNullOrWhiteSpace(request.ScopeId))
             return Failure("missing_scope_id");
         if (string.IsNullOrWhiteSpace(_nyxOptions.BaseUrl))
@@ -122,7 +124,7 @@ public sealed class NyxLarkProvisioningService : INyxLarkProvisioningService, IN
 
         var registrationId = Guid.NewGuid().ToString("N");
         var nyxBaseUrl = _nyxOptions.BaseUrl.TrimEnd('/');
-        var relayCallbackUrl = $"{request.WebhookBaseUrl.Trim().TrimEnd('/')}/api/webhooks/nyxid-relay";
+        var relayCallbackUrl = NyxRelayCallbackUrl.Build(request.WebhookBaseUrl);
         var label = string.IsNullOrWhiteSpace(request.Label)
             ? $"Aevatar Lark Bot {registrationId[..8]}"
             : request.Label.Trim();

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxRelayCallbackUrl.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxRelayCallbackUrl.cs
@@ -1,0 +1,36 @@
+namespace Aevatar.GAgents.Channel.NyxIdRelay;
+
+/// <summary>
+/// Builds and validates the relay callback URL that aevatar registers with NyxID as a
+/// channel bot's <c>callback_url</c>. NyxID delivers each inbound relay callback to this URL
+/// carrying the short-lived <c>X-NyxID-User-Token</c> (a first-party bearer credential), so the
+/// URL MUST be https to keep that credential off cleartext transports. Loopback hosts are exempt
+/// so local development against <c>http://localhost</c> keeps working.
+/// </summary>
+internal static class NyxRelayCallbackUrl
+{
+    private const string RelayCallbackPath = "/api/webhooks/nyxid-relay";
+
+    /// <summary>
+    /// True when <paramref name="webhookBaseUrl"/> is an absolute https URL, or an http URL whose
+    /// host is loopback (localhost / 127.0.0.1 / ::1). Everything else is rejected because the
+    /// registered callback would ship the relay user token over the wire in the clear.
+    /// </summary>
+    public static bool IsSecureBaseUrl(string? webhookBaseUrl)
+    {
+        if (!Uri.TryCreate(webhookBaseUrl?.Trim(), UriKind.Absolute, out var uri))
+            return false;
+
+        if (uri.Scheme == Uri.UriSchemeHttps)
+            return true;
+
+        return uri.Scheme == Uri.UriSchemeHttp && uri.IsLoopback;
+    }
+
+    /// <summary>
+    /// Builds the relay callback URL from an already-validated <paramref name="webhookBaseUrl"/>.
+    /// Callers must gate on <see cref="IsSecureBaseUrl"/> first.
+    /// </summary>
+    public static string Build(string webhookBaseUrl) =>
+        $"{webhookBaseUrl.Trim().TrimEnd('/')}{RelayCallbackPath}";
+}

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxRelayCallbackUrl.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxRelayCallbackUrl.cs
@@ -1,3 +1,5 @@
+using Aevatar.AI.ToolProviders.NyxId;
+
 namespace Aevatar.GAgents.Channel.NyxIdRelay;
 
 /// <summary>
@@ -13,19 +15,12 @@ internal static class NyxRelayCallbackUrl
 
     /// <summary>
     /// True when <paramref name="webhookBaseUrl"/> is an absolute https URL, or an http URL whose
-    /// host is loopback (localhost / 127.0.0.1 / ::1). Everything else is rejected because the
-    /// registered callback would ship the relay user token over the wire in the clear.
+    /// host is loopback (localhost / 127.0.0.1 / ::1). Delegates to
+    /// <see cref="NyxRelayCallbackUrlPolicy.IsSecureUrl"/> so this provisioning path and the
+    /// nyxid_api_keys tool enforce one shared policy.
     /// </summary>
-    public static bool IsSecureBaseUrl(string? webhookBaseUrl)
-    {
-        if (!Uri.TryCreate(webhookBaseUrl?.Trim(), UriKind.Absolute, out var uri))
-            return false;
-
-        if (uri.Scheme == Uri.UriSchemeHttps)
-            return true;
-
-        return uri.Scheme == Uri.UriSchemeHttp && uri.IsLoopback;
-    }
+    public static bool IsSecureBaseUrl(string? webhookBaseUrl) =>
+        NyxRelayCallbackUrlPolicy.IsSecureUrl(webhookBaseUrl);
 
     /// <summary>
     /// Builds the relay callback URL from an already-validated <paramref name="webhookBaseUrl"/>.

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxTelegramProvisioningService.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxTelegramProvisioningService.cs
@@ -78,6 +78,8 @@ public sealed class NyxTelegramProvisioningService : INyxTelegramProvisioningSer
             return Failure("missing_bot_token");
         if (string.IsNullOrWhiteSpace(request.WebhookBaseUrl))
             return Failure("missing_webhook_base_url");
+        if (!NyxRelayCallbackUrl.IsSecureBaseUrl(request.WebhookBaseUrl))
+            return Failure("insecure_webhook_base_url");
         if (string.IsNullOrWhiteSpace(request.ScopeId))
             return Failure("missing_scope_id");
         if (string.IsNullOrWhiteSpace(_nyxOptions.BaseUrl))
@@ -85,7 +87,7 @@ public sealed class NyxTelegramProvisioningService : INyxTelegramProvisioningSer
 
         var registrationId = Guid.NewGuid().ToString("N");
         var nyxBaseUrl = _nyxOptions.BaseUrl.TrimEnd('/');
-        var relayCallbackUrl = $"{request.WebhookBaseUrl.Trim().TrimEnd('/')}/api/webhooks/nyxid-relay";
+        var relayCallbackUrl = NyxRelayCallbackUrl.Build(request.WebhookBaseUrl);
         var label = string.IsNullOrWhiteSpace(request.Label)
             ? $"Aevatar Telegram Bot {registrationId[..8]}"
             : request.Label.Trim();

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxRelayCallbackUrlPolicy.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxRelayCallbackUrlPolicy.cs
@@ -1,0 +1,31 @@
+namespace Aevatar.AI.ToolProviders.NyxId;
+
+/// <summary>
+/// Shared policy for whether a NyxID channel-bot relay <c>callback_url</c> is safe to register.
+/// NyxID delivers each inbound relay callback to this URL carrying the short-lived
+/// <c>X-NyxID-User-Token</c> (a first-party bearer credential), so a cleartext http callback would
+/// ship that credential over the wire in the clear. Absolute https is accepted; http is accepted
+/// only for loopback hosts (localhost / 127.0.0.1 / ::1) so local development keeps working.
+///
+/// Owned here — the lowest layer both callback-URL registration paths already depend on (the relay
+/// provisioning services in Aevatar.GAgents.Channel.NyxIdRelay reference this project, and the
+/// nyxid_api_keys tool lives here) — so both paths enforce one policy that cannot drift.
+/// </summary>
+public static class NyxRelayCallbackUrlPolicy
+{
+    /// <summary>
+    /// True when <paramref name="callbackUrl"/> is an absolute https URL, or an http URL whose host
+    /// is loopback. Everything else (cleartext public host, non-http(s) scheme, non-absolute URL) is
+    /// rejected because the registered callback would leak the relay user token in the clear.
+    /// </summary>
+    public static bool IsSecureUrl(string? callbackUrl)
+    {
+        if (!Uri.TryCreate(callbackUrl?.Trim(), UriKind.Absolute, out var uri))
+            return false;
+
+        if (uri.Scheme == Uri.UriSchemeHttps)
+            return true;
+
+        return uri.Scheme == Uri.UriSchemeHttp && uri.IsLoopback;
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdApiKeysTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdApiKeysTool.cs
@@ -125,11 +125,30 @@ public sealed class NyxIdApiKeysTool : IAgentTool
         var name = args.Str("name");
         if (string.IsNullOrWhiteSpace(name))
             return """{"error":"'name' is required for create"}""";
+        if (RejectInsecureCallbackUrl(args) is { } callbackError)
+            return callbackError;
         return await _client.CreateApiKeyAsync(token, JsonSerializer.Serialize(BuildPayload(args, name)), ct);
     }
 
-    private async Task<string> UpdateKeyAsync(string token, string id, ToolArgs args, CancellationToken ct) =>
-        await _client.UpdateApiKeyAsync(token, id, JsonSerializer.Serialize(BuildPayload(args, args.Str("name"))), ct);
+    private async Task<string> UpdateKeyAsync(string token, string id, ToolArgs args, CancellationToken ct)
+    {
+        if (RejectInsecureCallbackUrl(args) is { } callbackError)
+            return callbackError;
+        return await _client.UpdateApiKeyAsync(token, id, JsonSerializer.Serialize(BuildPayload(args, args.Str("name"))), ct);
+    }
+
+    // A channel-bot relay callback_url receives NyxID's inbound relay callback carrying the
+    // short-lived X-NyxID-User-Token. Refuse to register a cleartext callback on this agent-facing
+    // key create/update path — the same fail-closed policy the Lark/Telegram provisioning services
+    // apply — so it cannot be used (via nyxid_api_keys create/update + nyxid_channel_bots
+    // create_route) to route that credential to a cleartext public host. Empty is left to NyxID.
+    private static string? RejectInsecureCallbackUrl(ToolArgs args)
+    {
+        var callbackUrl = args.Str("callback_url");
+        if (string.IsNullOrWhiteSpace(callbackUrl) || NyxRelayCallbackUrlPolicy.IsSecureUrl(callbackUrl))
+            return null;
+        return """{"error":"callback_url must be https (or http only for loopback hosts); refusing to register a cleartext callback that would leak the relay user token."}""";
+    }
 
     private async Task<string> BindKeyAsync(string token, string keyId, ToolArgs args, CancellationToken ct)
     {

--- a/test/Aevatar.AI.Tests/NyxIdApiKeysToolCallbackUrlGuardTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdApiKeysToolCallbackUrlGuardTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.AI.ToolProviders.NyxId.Tools;
+using FluentAssertions;
+using Xunit;
+
+namespace Aevatar.AI.Tests;
+
+/// <summary>
+/// The agent-facing nyxid_api_keys tool forwards <c>callback_url</c> into the NyxID API-key payload,
+/// which can then be bound to a channel route — a second path (besides the Lark/Telegram provisioning
+/// services) that would ship the relay user token to a cleartext callback. Pins that create/update
+/// reject a cleartext public callback before any NyxID call, while https/loopback pass through.
+/// </summary>
+public class NyxIdApiKeysToolCallbackUrlGuardTests
+{
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Requests.Add(request);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"ok":true}"""),
+            });
+        }
+    }
+
+    private static (NyxIdApiKeysTool Tool, RecordingHandler Handler) CreateTool()
+    {
+        var handler = new RecordingHandler();
+        var client = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example" },
+            new HttpClient(handler));
+        return (new NyxIdApiKeysTool(client), handler);
+    }
+
+    private static IDisposable PushToken(string token)
+    {
+        var previous = AgentToolRequestContext.Current;
+        AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
+        {
+            Credentials = new AgentToolCredentials(token, null, null),
+        };
+        return new ContextReset(previous);
+    }
+
+    private sealed class ContextReset(AgentToolExecutionContext? previous) : IDisposable
+    {
+        public void Dispose() => AgentToolRequestContext.Current = previous;
+    }
+
+    [Theory]
+    [InlineData("create")]
+    [InlineData("update")]
+    public async Task RejectsCleartextPublicCallbackUrl_WithoutCallingNyx(string action)
+    {
+        var (tool, handler) = CreateTool();
+        using var _ = PushToken("user-token");
+
+        var result = await tool.ExecuteAsync(
+            $$"""{"action":"{{action}}","id":"key-1","name":"k","callback_url":"http://aevatar.example.com"}""");
+
+        result.Should().Contain("error").And.Contain("callback_url");
+        handler.Requests.Should().BeEmpty("a cleartext public callback_url must be rejected before any NyxID call");
+    }
+
+    [Theory]
+    [InlineData("https://relay.example.com/cb")]
+    [InlineData("http://localhost/cb")]
+    [InlineData("http://127.0.0.1/cb")]
+    public async Task AcceptsSecureOrLoopbackCallbackUrl_AndCallsNyx(string callbackUrl)
+    {
+        var (tool, handler) = CreateTool();
+        using var _ = PushToken("user-token");
+
+        await tool.ExecuteAsync(
+            $$"""{"action":"create","name":"k","callback_url":"{{callbackUrl}}"}""");
+
+        handler.Requests.Should().NotBeEmpty("a secure/loopback callback_url must be allowed through to NyxID");
+    }
+
+    [Fact]
+    public async Task CreateWithoutCallbackUrl_IsUnaffected()
+    {
+        var (tool, handler) = CreateTool();
+        using var _ = PushToken("user-token");
+
+        await tool.ExecuteAsync("""{"action":"create","name":"k"}""");
+
+        handler.Requests.Should().NotBeEmpty("omitting callback_url leaves the create path unchanged");
+    }
+}

--- a/test/Aevatar.AI.Tests/NyxRelayCallbackUrlPolicyTests.cs
+++ b/test/Aevatar.AI.Tests/NyxRelayCallbackUrlPolicyTests.cs
@@ -1,0 +1,28 @@
+using Aevatar.AI.ToolProviders.NyxId;
+using FluentAssertions;
+using Xunit;
+
+namespace Aevatar.AI.Tests;
+
+/// <summary>
+/// Pins the shared relay callback-URL security policy: absolute https is accepted, http only for
+/// loopback hosts; cleartext public hosts, non-http(s) schemes, and non-absolute URLs are rejected
+/// so a registered callback can never ship the relay user token in the clear.
+/// </summary>
+public class NyxRelayCallbackUrlPolicyTests
+{
+    [Theory]
+    [InlineData("https://relay.example.com", true)]
+    [InlineData("https://relay.example.com/api/webhooks/nyxid-relay", true)]
+    [InlineData("http://localhost/cb", true)]
+    [InlineData("http://127.0.0.1/cb", true)]
+    [InlineData("http://[::1]/cb", true)]
+    [InlineData("http://aevatar.example.com", false)]
+    [InlineData("http://192.168.1.10/cb", false)]
+    [InlineData("ftp://relay.example.com", false)]
+    [InlineData("not-a-url", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void IsSecureUrl_MatchesSchemeAndLoopbackPolicy(string? url, bool expected) =>
+        NyxRelayCallbackUrlPolicy.IsSecureUrl(url).Should().Be(expected);
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxLarkProvisioningServiceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxLarkProvisioningServiceTests.cs
@@ -86,6 +86,41 @@ public class NyxLarkProvisioningServiceTests
     }
 
     [Fact]
+    public async Task ProvisionAsync_Rejects_Cleartext_Http_WebhookBaseUrl_Before_Calling_Nyx()
+    {
+        // The relay callback URL receives the short-lived X-NyxID-User-Token; registering a
+        // cleartext http:// callback would ship that first-party bearer over the wire in the clear.
+        var handler = new RecordingHandler();
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler));
+        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
+        var commandFacade = ChannelRegistrationCommandFacadeTestSupport.CreateFacade(actorRuntime, (IActorDispatchPort)actorRuntime);
+        var service = new NyxLarkProvisioningService(
+            nyxClient,
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            commandFacade,
+            Substitute.For<Microsoft.Extensions.Logging.ILogger<NyxLarkProvisioningService>>());
+
+        var result = await service.ProvisionAsync(
+            new NyxLarkProvisioningRequest(
+                AccessToken: "user-token",
+                AppId: "cli_a1b2c3",
+                AppSecret: "secret-xyz",
+                VerificationToken: "verify-123",
+                WebhookBaseUrl: "http://aevatar.example.com",
+                ScopeId: "scope-1",
+                Label: "Ops Bot",
+                NyxProviderSlug: "api-lark-bot"),
+            CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be("insecure_webhook_base_url");
+        // Guard must fail closed BEFORE any NyxID provisioning call is made.
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task ProvisionAsync_Stores_NyxAssigned_PerConnection_Slug_When_Connect_Returns_Suffixed_Slug()
     {
         // Regression: a user's 2nd+ Lark bot. NyxID auto-numbers the proxy slug when `api-lark-bot`

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayCallbackUrlTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayCallbackUrlTests.cs
@@ -1,0 +1,33 @@
+using Aevatar.GAgents.Channel.NyxIdRelay;
+using FluentAssertions;
+using Xunit;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+public class NyxRelayCallbackUrlTests
+{
+    [Theory]
+    [InlineData("https://aevatar.example.com", true)]      // https public host
+    [InlineData("https://aevatar.example.com/", true)]
+    [InlineData("http://localhost", true)]                 // loopback dev exemption
+    [InlineData("http://localhost:5051", true)]
+    [InlineData("http://127.0.0.1:8080", true)]
+    [InlineData("http://[::1]", true)]
+    [InlineData("http://aevatar.example.com", false)]      // cleartext public host -> rejected
+    [InlineData("ftp://aevatar.example.com", false)]       // non-http(s) scheme
+    [InlineData("aevatar.example.com", false)]             // not an absolute URL
+    [InlineData("/api/webhooks/nyxid-relay", false)]       // relative path
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void IsSecureBaseUrl_allows_https_and_loopback_http_only(string? webhookBaseUrl, bool expected)
+    {
+        NyxRelayCallbackUrl.IsSecureBaseUrl(webhookBaseUrl).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Build_appends_relay_callback_path_and_trims_trailing_slash()
+    {
+        NyxRelayCallbackUrl.Build("https://aevatar.example.com/")
+            .Should().Be("https://aevatar.example.com/api/webhooks/nyxid-relay");
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxTelegramProvisioningServiceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxTelegramProvisioningServiceTests.cs
@@ -84,6 +84,7 @@ public class NyxTelegramProvisioningServiceTests
     [InlineData("", "bot-token", "https://aevatar.example.com", "scope-1", "missing_access_token")]
     [InlineData("user-token", "", "https://aevatar.example.com", "scope-1", "missing_bot_token")]
     [InlineData("user-token", "bot-token", "", "scope-1", "missing_webhook_base_url")]
+    [InlineData("user-token", "bot-token", "http://aevatar.example.com", "scope-1", "insecure_webhook_base_url")]
     [InlineData("user-token", "bot-token", "https://aevatar.example.com", "", "missing_scope_id")]
     public async Task ProvisionAsync_rejects_invalid_requests_before_calling_nyx(
         string accessToken,

--- a/tools/ci/guards/catch_exception_observability_baseline.tsv
+++ b/tools/ci/guards/catch_exception_observability_baseline.tsv
@@ -15,8 +15,8 @@ src/Aevatar.AI.ToolProviders.ChronoStorage/Tools/ChronoGlobTool.cs	51	empty broa
 src/Aevatar.AI.ToolProviders.ChronoStorage/Tools/ChronoGrepTool.cs	65	empty broad catch block
 src/Aevatar.AI.ToolProviders.ChronoStorage/Tools/ChronoTreeTool.cs	70	empty broad catch block
 src/Aevatar.AI.ToolProviders.MCP/MCPConnector.cs	209	empty broad catch block
-src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdApiKeysTool.cs	161	empty broad catch block
-src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdApiKeysTool.cs	188	empty broad catch block
+src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdApiKeysTool.cs	180	empty broad catch block
+src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdApiKeysTool.cs	207	empty broad catch block
 src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdServicesTool.cs	149	empty broad catch block
 src/Aevatar.AI.ToolProviders.ServiceInvoke/Schema/EndpointSchemaProvider.cs	92	broad catch returns null without visible failure signal
 src/Aevatar.AI.ToolProviders.ServiceInvoke/Schema/EndpointSchemaProvider.cs	153	empty broad catch block


### PR DESCRIPTION
## Problem

When aevatar registers a channel-relay bot with the upstream credential broker, it registers a `callback_url` built from the caller-supplied `WebhookBaseUrl`, with **no scheme validation**. The broker delivers each inbound relay callback to that URL carrying the short-lived `X-NyxID-User-Token` — a first-party bearer credential. A cleartext `http://` callback would ship that token over the wire in the clear, where it can be observed and replayed for its lifetime.

Both the Lark and Telegram provisioning services duplicated the same inline `{WebhookBaseUrl}/api/webhooks/nyxid-relay` construction and neither checked the scheme.

## Change

- Add `NyxRelayCallbackUrl` with:
  - `IsSecureBaseUrl` — accepts `https`, or `http` only for loopback hosts (`localhost` / `127.0.0.1` / `::1`) so local development keeps working; rejects cleartext public hosts, non-http(s) schemes, and non-absolute URLs.
  - `Build` — the single shared callback-URL construction, so both platforms build and validate through one path.
- Gate both `NyxLarkProvisioningService` and `NyxTelegramProvisioningService` on `IsSecureBaseUrl` **before any broker call**, failing closed with `insecure_webhook_base_url`.

## Impact paths

- `agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxRelayCallbackUrl.cs` (new)
- `agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxLarkProvisioningService.cs`
- `agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxTelegramProvisioningService.cs`

No behavior change for the existing https registrations (production callback base is already https); local `http://localhost` dev registration is preserved by the loopback exemption.

## Validation

- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests` (Nyx provisioning + callback-url subset): **green**. New tests:
  - `NyxRelayCallbackUrlTests` — scheme matrix incl. loopback exemption + `Build`.
  - `NyxLarkProvisioningServiceTests.ProvisionAsync_Rejects_Cleartext_Http_WebhookBaseUrl_Before_Calling_Nyx` — rejects `http://` before any broker call.
  - `NyxTelegramProvisioningServiceTests` — `insecure_webhook_base_url` InlineData row.
- `bash tools/ci/test_stability_guards.sh` — pass.
- `bash tools/ci/architecture_guards.sh` — pass.

## Follow-up

This is the "done" half of a channel-relay credential-trust-boundary hardening review. The two remaining aevatar-side defense-in-depth items — (1) stripping runtime-only credentials from the persisted per-step waterline, and (2) gating human-only NyxID platform tools out of relay-token turns — are tracked in #2580.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
