### PR TITLE
Harden channel-relay credential trust boundary: strip persisted per-step credentials + gate human-only NyxID tools

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
@@ -494,13 +494,19 @@ public sealed partial class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
 
     private async Task PersistStepStateAsync(AgentRunReplyStepState stepState)
     {
+        // The persisted per-step waterline must never carry bearer tokens (agent_run.proto
+        // contract). Strip runtime credentials at the single commit funnel: the executor
+        // re-supplies them from the transient self-message request at execution time, so a
+        // committed AgentRunReplyStepStateUpdatedEvent — and State.GenerationStep rebuilt from
+        // it — keeps only identity/routing facts.
+        var persisted = AgentRunReplyStepCredentials.StripRuntimeCredentials(stepState);
         await PersistDomainEventAsync(new AgentRunReplyStepStateUpdatedEvent
         {
-            RunId = stepState.RunId,
-            CorrelationId = stepState.CorrelationId,
-            TargetActorId = stepState.TargetActorId,
-            Attempt = stepState.Attempt,
-            StepState = stepState.Clone(),
+            RunId = persisted.RunId,
+            CorrelationId = persisted.CorrelationId,
+            TargetActorId = persisted.TargetActorId,
+            Attempt = persisted.Attempt,
+            StepState = persisted,
         });
     }
 
@@ -928,8 +934,14 @@ public sealed partial class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
 
         var request = command.Request?.Clone() ?? BuildStepRequest(command);
         ApplyTargetRefOverrides(request);
+        // The persisted owner-fallback control is token-less (credentials are stripped before commit).
+        // Capture the bot-owner token from the transient request's inbound LlmControl — it rode the
+        // self-message chain and is never persisted — before overwriting request.LlmControl, and
+        // re-supply it so the executor's uniform per-step credential re-supply uses the bot-owner
+        // token on the owner-fallback step.
+        var inboundControl = request.LlmControl;
         request.Activity = ClearRuntimeUserAccessToken(request.Activity);
-        request.LlmControl = ResolveOwnerFallbackControl(currentStep).ToPayload();
+        request.LlmControl = ReSupplyOwnerFallbackToken(ResolveOwnerFallbackControl(currentStep), inboundControl).ToPayload();
         request.ToolContext = ResolveOwnerFallbackToolContext(currentStep).ToPayload();
         StripServerDefaultFallbackMetadata(request.Metadata);
 
@@ -1063,6 +1075,23 @@ public sealed partial class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
             !string.Equals(message.Role, "assistant", StringComparison.Ordinal) &&
             !string.Equals(message.Role, "tool", StringComparison.Ordinal)));
         return next;
+    }
+
+    // ResolveOwnerFallbackControl now yields only server-default routing (the persisted
+    // OwnerFallbackLlmControl is token-less after the strip). Re-supply the bot-owner token from the
+    // transient request's inbound LlmControl so the owner-fallback step still authenticates as the
+    // bot owner; the executor picks this up through its per-step credential re-supply.
+    private static LLMControlContext ReSupplyOwnerFallbackToken(
+        LLMControlContext fallbackControl,
+        Aevatar.AI.Abstractions.LLMControlContextPayload? inboundControl)
+    {
+        if (inboundControl is null)
+            return fallbackControl;
+        return fallbackControl with
+        {
+            NyxIdAccessToken = NormalizeOptional(inboundControl.NyxIdAccessToken),
+            NyxIdOrgToken = NormalizeOptional(inboundControl.NyxIdOrgToken),
+        };
     }
 
     private static LLMControlContext ResolveOwnerFallbackControl(AgentRunReplyStepState stepState)

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs
@@ -222,6 +222,8 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
                 planToolContext = UseServerDefaultRouting(planToolContext, stepControl);
             }
         }
+        (stepControl, planToolContext) = await ReSupplyRuntimeCredentialsAsync(request, stepControl, planToolContext, ct)
+            .ConfigureAwait(false);
         var plan = await generator.BuildStepPlanAsync(
                 request.Activity!,
                 stepMetadata,
@@ -337,11 +339,15 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
         //   New principle: Executor returns typed IO facts only; AgentRunGAgent applies deterministic step-state transition and persists state inside actor event handling.
         var request = workItem.Request.Clone();
         var generator = RequireStepGenerator();
+        var stepControl = AgentRunReplyStepMappers.LlmControlFromProto(workItem.StepState);
+        var planToolContext = AgentRunReplyStepMappers.ToolContextFromProto(workItem.StepState);
+        (stepControl, planToolContext) = await ReSupplyRuntimeCredentialsAsync(request, stepControl, planToolContext, ct)
+            .ConfigureAwait(false);
         var plan = await generator.BuildStepPlanAsync(
                 request.Activity!,
                 AgentRunReplyStepMappers.ToDictionary(workItem.StepState.ExternalMetadata),
-                AgentRunReplyStepMappers.LlmControlFromProto(workItem.StepState),
-                AgentRunReplyStepMappers.ToolContextFromProto(workItem.StepState),
+                stepControl,
+                planToolContext,
                 priorHistory: null,
                 attachmentContext: null,
                 forceDisableTools: false,
@@ -590,15 +596,7 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
         var ownerFallbackControl = control with { SenderNyxIdAccessToken = null };
         var ownerFallbackToolContext = ClearSenderBinding(toolContext);
 
-        var userAccessToken = request.Activity?.TransportExtras?.NyxUserAccessToken?.Trim();
-        if (!string.IsNullOrWhiteSpace(userAccessToken))
-        {
-            control = control with
-            {
-                NyxIdAccessToken = userAccessToken,
-                NyxIdOrgToken = userAccessToken,
-            };
-        }
+        control = OverlayActivityUserToken(request, control);
 
         return new ReplyGenerationContext(
             metadata,
@@ -683,6 +681,51 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
                 subject.ExternalUserId);
             return control;
         }
+    }
+
+    // Re-supplies runtime credentials onto the token-less per-step control/tool-context read from the
+    // persisted (stripped) step-state. Reproduces BuildGenerationContextAsync's derivation from the
+    // transient request: owner token from the Activity user token, sender token re-minted from the
+    // retained binding identity (choice A — re-mint per step keeps the persisted waterline free of
+    // bearer tokens and hands each step a fresh short-lived sender token). On the owner-fallback step
+    // the run actor has cleared the Activity token and the sender binding, so the owner token comes
+    // from request.LlmControl (the bot-owner token it re-supplied) and no sender token is minted.
+    private async Task<(LLMControlContext Control, AgentToolExecutionContext ToolContext)> ReSupplyRuntimeCredentialsAsync(
+        NeedsLlmReplyEvent request,
+        LLMControlContext stepControl,
+        AgentToolExecutionContext planToolContext,
+        CancellationToken ct)
+    {
+        var requestControl = LLMControlContextMapper.FromPayload(request.LlmControl);
+        requestControl = await ApplySenderTokenAsync(request, planToolContext, requestControl, ct).ConfigureAwait(false);
+        requestControl = OverlayActivityUserToken(request, requestControl);
+
+        var control = stepControl with
+        {
+            NyxIdAccessToken = requestControl.NyxIdAccessToken,
+            NyxIdOrgToken = requestControl.NyxIdOrgToken,
+            SenderNyxIdAccessToken = requestControl.SenderNyxIdAccessToken,
+        };
+        var toolContext = planToolContext with
+        {
+            Credentials = new AgentToolCredentials(
+                requestControl.NyxIdAccessToken,
+                requestControl.NyxIdOrgToken,
+                requestControl.SenderNyxIdAccessToken),
+        };
+        return (control, toolContext);
+    }
+
+    private static LLMControlContext OverlayActivityUserToken(NeedsLlmReplyEvent request, LLMControlContext control)
+    {
+        var userAccessToken = NormalizeOptional(request.Activity?.TransportExtras?.NyxUserAccessToken);
+        if (userAccessToken is null)
+            return control;
+        return control with
+        {
+            NyxIdAccessToken = userAccessToken,
+            NyxIdOrgToken = userAccessToken,
+        };
     }
 
     private static bool TryRebuildSenderSubject(

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyStepCredentials.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyStepCredentials.cs
@@ -1,0 +1,43 @@
+namespace Aevatar.GAgents.NyxidChat;
+
+/// <summary>
+/// Strips runtime-only NyxID credentials from an <see cref="AgentRunReplyStepState"/> before it is
+/// committed to the event store as an <c>AgentRunReplyStepStateUpdatedEvent</c>. The proto contract
+/// already declares that the persisted per-step waterline must NOT carry credentials — the executor
+/// re-supplies the owner token from the transient self-message request and re-mints the sender token
+/// from the retained binding id at execution time, so the persisted state keeps only identity facts
+/// (binding id, subject, scope, routing), never bearer tokens.
+///
+/// Only the token <em>strings</em> are cleared; the credential sub-messages themselves are left in
+/// place so structural checks (for example <c>AgentRunReplyGenerationExecutor.TryBuildOwnerFallbackCommand</c>,
+/// which gates on whether the owner-fallback sub-messages exist) keep working.
+/// </summary>
+internal static class AgentRunReplyStepCredentials
+{
+    public static AgentRunReplyStepState StripRuntimeCredentials(AgentRunReplyStepState stepState)
+    {
+        ArgumentNullException.ThrowIfNull(stepState);
+        var stripped = stepState.Clone();
+        ClearControlTokens(stripped.LlmControl);
+        ClearControlTokens(stripped.OwnerFallbackLlmControl);
+        ClearCredentialTokens(stripped.ToolContext?.Credentials);
+        ClearCredentialTokens(stripped.OwnerFallbackToolContext?.Credentials);
+        return stripped;
+    }
+
+    private static void ClearControlTokens(Aevatar.AI.Abstractions.LLMControlContextPayload? control)
+    {
+        if (control is null) return;
+        control.NyxIdAccessToken = string.Empty;
+        control.NyxIdOrgToken = string.Empty;
+        control.SenderNyxIdAccessToken = string.Empty;
+    }
+
+    private static void ClearCredentialTokens(Aevatar.AI.Abstractions.AgentToolCredentialsPayload? credentials)
+    {
+        if (credentials is null) return;
+        credentials.NyxIdAccessToken = string.Empty;
+        credentials.NyxIdOrgToken = string.Empty;
+        credentials.SenderNyxIdAccessToken = string.Empty;
+    }
+}

--- a/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
@@ -160,7 +160,8 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         }
 
         var replyPlan = await BuildEffectiveReplyPlanAsync(metadata, llmControl, toolContext, ct);
-        var primaryTools = await BuildTurnToolsAsync(replyPlan.DisableTools, ct);
+        var isChannelTurn = IsChannelTurn(metadata);
+        var primaryTools = await BuildTurnToolsAsync(replyPlan.DisableTools, isChannelTurn, ct);
 
         try
         {
@@ -186,7 +187,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
                 "Sender LLM request failed; retrying with bot owner LLM config and no tools. activity={ActivityId}",
                 activity.Id);
 
-            var fallbackTools = await BuildTurnToolsAsync(disableTools: true, ct);
+            var fallbackTools = await BuildTurnToolsAsync(disableTools: true, isChannelTurn, ct);
             return await GenerateWithMetadataAsync(
                     activity,
                     replyPlan.OwnerFallback,
@@ -257,7 +258,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         var replyPlan = await BuildEffectiveReplyPlanAsync(metadata, llmControl, toolContext, ct);
         var provider = ResolveProvider();
         var disableTools = forceDisableTools || replyPlan.DisableTools;
-        var tools = await BuildTurnToolsAsync(disableTools, ct);
+        var tools = await BuildTurnToolsAsync(disableTools, IsChannelTurn(metadata), ct);
         var externalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(replyPlan.Primary);
         var effectiveToolContext = replyPlan.PrimaryControl.ToToolContext(
             replyPlan.PrimaryToolContext ?? AgentToolExecutionContext.Empty with
@@ -301,13 +302,13 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
     // slash silently consumed.
     // New: unbound sender disables tool dispatch; unknown slash gates to /init bootstrap;
     // non-slash text path unchanged (owner-LLM chat fallback).
-    private async Task<ToolManager> BuildTurnToolsAsync(bool disableTools, CancellationToken ct)
+    private async Task<ToolManager> BuildTurnToolsAsync(bool disableTools, bool isChannelTurn, CancellationToken ct)
     {
         var tools = new ToolManager();
         if (disableTools)
             return tools;
 
-        foreach (var tool in await DiscoverToolsAsync(ct))
+        foreach (var tool in await DiscoverToolsAsync(isChannelTurn, ct))
             tools.Register(tool);
 
         // Refactor (iter27/cluster-027-skill-registry-remote-skill-process-state):
@@ -995,7 +996,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         metadata.ContainsKey(ChannelMetadataKeys.SenderId) &&
         metadata.ContainsKey(ChannelMetadataKeys.MessageId);
 
-    private async Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct)
+    private async Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(bool isChannelTurn, CancellationToken ct)
     {
         if (_toolSources.Count == 0)
             return [];
@@ -1015,6 +1016,15 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
                 // depended on these tools, so this changes no existing channel flow.
                 if (IsExcludedFromDirectChannelChat(tool))
                     continue;
+
+                // Issue #2580 Item 2: in a channel-relay turn the effective credential is a
+                // bot-class relay/API-key token that the broker rejects on human-only surfaces, so a
+                // tool self-declaring RequiresHumanSession can only fail. Filter it out of channel
+                // turns — never offered to the model, never registered so it cannot be invoked.
+                // Console/studio human-session turns keep the full set. Name-agnostic, like above.
+                if (isChannelTurn && DeclaresCapability(tool, AgentToolCapabilities.RequiresHumanSession))
+                    continue;
+
                 discovered[tool.Name] = tool;
             }
         }
@@ -1027,12 +1037,12 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
     // The channel path never inspects a specific tool name; eligibility is a property of
     // the tool, keeping channel routing agnostic to individual tool/skill identities.
     private static bool IsExcludedFromDirectChannelChat(IAgentTool tool) =>
+        DeclaresCapability(tool, AgentToolCapabilities.ExcludeFromDirectChannelChat);
+
+    private static bool DeclaresCapability(IAgentTool tool, string capability) =>
         tool is IAgentToolCapabilityDescriptor descriptor &&
-        descriptor.Capabilities.Any(static capability =>
-            string.Equals(
-                capability,
-                AgentToolCapabilities.ExcludeFromDirectChannelChat,
-                StringComparison.OrdinalIgnoreCase));
+        descriptor.Capabilities.Any(declared =>
+            string.Equals(declared, capability, StringComparison.OrdinalIgnoreCase));
 
     private ILLMProvider ResolveProvider()
     {

--- a/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
@@ -160,7 +160,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         }
 
         var replyPlan = await BuildEffectiveReplyPlanAsync(metadata, llmControl, toolContext, ct);
-        var isChannelTurn = IsChannelTurn(metadata);
+        var isChannelTurn = IsChannelRelayTurn(toolContext);
         var primaryTools = await BuildTurnToolsAsync(replyPlan.DisableTools, isChannelTurn, ct);
 
         try
@@ -258,7 +258,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         var replyPlan = await BuildEffectiveReplyPlanAsync(metadata, llmControl, toolContext, ct);
         var provider = ResolveProvider();
         var disableTools = forceDisableTools || replyPlan.DisableTools;
-        var tools = await BuildTurnToolsAsync(disableTools, IsChannelTurn(metadata), ct);
+        var tools = await BuildTurnToolsAsync(disableTools, IsChannelRelayTurn(toolContext), ct);
         var externalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(replyPlan.Primary);
         var effectiveToolContext = replyPlan.PrimaryControl.ToToolContext(
             replyPlan.PrimaryToolContext ?? AgentToolExecutionContext.Empty with
@@ -995,6 +995,21 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         metadata.ContainsKey(ChannelMetadataKeys.Platform) &&
         metadata.ContainsKey(ChannelMetadataKeys.SenderId) &&
         metadata.ContainsKey(ChannelMetadataKeys.MessageId);
+
+    // Channel-relay detection for the human-only tool gate (issue #2580 Item 2). It must read the
+    // TYPED channel context, not metadata: channel.platform / sender_id / message_id are owned control
+    // keys that AgentToolExecutionContextMapper.StripOwnedControlKeys removes before the step state is
+    // persisted, so from the second LLM round the per-step metadata no longer carries them. The typed
+    // toolContext.Channel is an identity fact that survives stripping and every round, so the gate
+    // stays on for the whole relay turn (mirrors IsChannelTurn's Platform+SenderId+MessageId shape).
+    private static bool IsChannelRelayTurn(AgentToolExecutionContext? toolContext)
+    {
+        var channel = toolContext?.Channel;
+        return channel is not null &&
+            !string.IsNullOrWhiteSpace(channel.Platform) &&
+            !string.IsNullOrWhiteSpace(channel.SenderId) &&
+            !string.IsNullOrWhiteSpace(channel.MessageId);
+    }
 
     private async Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(bool isChannelTurn, CancellationToken ct)
     {

--- a/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolCapabilities.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolCapabilities.cs
@@ -19,4 +19,15 @@ public static class AgentToolCapabilities
     /// can still select it); only direct-channel discovery filters it out.
     /// </summary>
     public const string ExcludeFromDirectChannelChat = "surface.exclude_from_direct_channel_chat";
+
+    /// <summary>
+    /// Surface signal: a tool carrying this capability targets a broker surface that only accepts a
+    /// human-session credential. In a channel-relay turn the effective credential is a bot-class
+    /// relay/API-key token, which the broker rejects (403) on those surfaces — so the tool can only
+    /// fail if offered. Direct-channel discovery filters it out of channel-relay turns (it is never
+    /// offered to the model and never registered, so it cannot be invoked); console/studio
+    /// human-session turns keep the full set, and the tool stays in the global catalog for other
+    /// surfaces. Eligibility is a property of the tool, so the channel path stays name-agnostic.
+    /// </summary>
+    public const string RequiresHumanSession = "surface.requires_human_session";
 }

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdAccountTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdAccountTool.cs
@@ -4,8 +4,10 @@ using Aevatar.AI.Abstractions.ToolProviders;
 namespace Aevatar.AI.ToolProviders.NyxId.Tools;
 
 /// <summary>Tool to view current NyxID user profile and account status.</summary>
-public sealed class NyxIdAccountTool : IAgentTool
+public sealed class NyxIdAccountTool : IAgentTool, IAgentToolCapabilityDescriptor
 {
+    public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
+
     private readonly NyxIdApiClient _client;
 
     public NyxIdAccountTool(NyxIdApiClient client) => _client = client;

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdAdminTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdAdminTool.cs
@@ -4,8 +4,10 @@ using Aevatar.AI.Abstractions.ToolProviders;
 
 namespace Aevatar.AI.ToolProviders.NyxId.Tools;
 
-public sealed class NyxIdAdminTool : IAgentTool
+public sealed class NyxIdAdminTool : IAgentTool, IAgentToolCapabilityDescriptor
 {
+    public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
+
     private readonly NyxIdApiClient _client;
 
     public NyxIdAdminTool(NyxIdApiClient client) => _client = client;

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdApiKeysTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdApiKeysTool.cs
@@ -5,8 +5,10 @@ using Aevatar.AI.Abstractions.ToolProviders;
 namespace Aevatar.AI.ToolProviders.NyxId.Tools;
 
 /// <summary>Tool to manage NyxID API keys for programmatic access.</summary>
-public sealed class NyxIdApiKeysTool : IAgentTool
+public sealed class NyxIdApiKeysTool : IAgentTool, IAgentToolCapabilityDescriptor
 {
+    public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
+
     private readonly NyxIdApiClient _client;
 
     public NyxIdApiKeysTool(NyxIdApiClient client) => _client = client;

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdApprovalsTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdApprovalsTool.cs
@@ -5,8 +5,10 @@ using Aevatar.AI.Abstractions.ToolProviders;
 namespace Aevatar.AI.ToolProviders.NyxId.Tools;
 
 /// <summary>Tool to manage NyxID approval requests, grants, and settings.</summary>
-public sealed class NyxIdApprovalsTool : IAgentTool
+public sealed class NyxIdApprovalsTool : IAgentTool, IAgentToolCapabilityDescriptor
 {
+    public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
+
     private readonly NyxIdApiClient _client;
 
     public NyxIdApprovalsTool(NyxIdApiClient client) => _client = client;

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdChannelBotsTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdChannelBotsTool.cs
@@ -5,8 +5,10 @@ using Aevatar.AI.Abstractions.ToolProviders;
 namespace Aevatar.AI.ToolProviders.NyxId.Tools;
 
 /// <summary>Tool to manage NyxID channel bots and conversation routes.</summary>
-public sealed class NyxIdChannelBotsTool : IAgentTool
+public sealed class NyxIdChannelBotsTool : IAgentTool, IAgentToolCapabilityDescriptor
 {
+    public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
+
     private readonly NyxIdApiClient _client;
 
     public NyxIdChannelBotsTool(NyxIdApiClient client) => _client = client;

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdEndpointsTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdEndpointsTool.cs
@@ -5,8 +5,10 @@ using Aevatar.AI.Abstractions.ToolProviders;
 namespace Aevatar.AI.ToolProviders.NyxId.Tools;
 
 /// <summary>Tool to manage NyxID user endpoints (service base URLs).</summary>
-public sealed class NyxIdEndpointsTool : IAgentTool
+public sealed class NyxIdEndpointsTool : IAgentTool, IAgentToolCapabilityDescriptor
 {
+    public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
+
     private readonly NyxIdApiClient _client;
 
     public NyxIdEndpointsTool(NyxIdApiClient client) => _client = client;

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdExternalKeysTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdExternalKeysTool.cs
@@ -5,8 +5,10 @@ using Aevatar.AI.Abstractions.ToolProviders;
 namespace Aevatar.AI.ToolProviders.NyxId.Tools;
 
 /// <summary>Tool to manage NyxID external API keys/credentials.</summary>
-public sealed class NyxIdExternalKeysTool : IAgentTool
+public sealed class NyxIdExternalKeysTool : IAgentTool, IAgentToolCapabilityDescriptor
 {
+    public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
+
     private readonly NyxIdApiClient _client;
 
     public NyxIdExternalKeysTool(NyxIdApiClient client) => _client = client;

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdMfaTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdMfaTool.cs
@@ -5,8 +5,10 @@ using Aevatar.AI.Abstractions.ToolProviders;
 namespace Aevatar.AI.ToolProviders.NyxId.Tools;
 
 /// <summary>Tool to manage NyxID multi-factor authentication.</summary>
-public sealed class NyxIdMfaTool : IAgentTool
+public sealed class NyxIdMfaTool : IAgentTool, IAgentToolCapabilityDescriptor
 {
+    public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
+
     private readonly NyxIdApiClient _client;
 
     public NyxIdMfaTool(NyxIdApiClient client) => _client = client;

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdNodesTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdNodesTool.cs
@@ -5,8 +5,10 @@ using Aevatar.AI.Abstractions.ToolProviders;
 namespace Aevatar.AI.ToolProviders.NyxId.Tools;
 
 /// <summary>Tool to manage NyxID on-premise node agents.</summary>
-public sealed class NyxIdNodesTool : IAgentTool
+public sealed class NyxIdNodesTool : IAgentTool, IAgentToolCapabilityDescriptor
 {
+    public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
+
     private readonly NyxIdApiClient _client;
 
     public NyxIdNodesTool(NyxIdApiClient client) => _client = client;

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdNotificationsTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdNotificationsTool.cs
@@ -5,8 +5,10 @@ using Aevatar.AI.Abstractions.ToolProviders;
 namespace Aevatar.AI.ToolProviders.NyxId.Tools;
 
 /// <summary>Tool to manage NyxID notification settings and Telegram integration.</summary>
-public sealed class NyxIdNotificationsTool : IAgentTool
+public sealed class NyxIdNotificationsTool : IAgentTool, IAgentToolCapabilityDescriptor
 {
+    public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
+
     private readonly NyxIdApiClient _client;
 
     public NyxIdNotificationsTool(NyxIdApiClient client) => _client = client;

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdOrgTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdOrgTool.cs
@@ -4,8 +4,10 @@ using Aevatar.AI.Abstractions.ToolProviders;
 
 namespace Aevatar.AI.ToolProviders.NyxId.Tools;
 
-public sealed class NyxIdOrgTool : IAgentTool
+public sealed class NyxIdOrgTool : IAgentTool, IAgentToolCapabilityDescriptor
 {
+    public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
+
     private readonly NyxIdApiClient _client;
 
     public NyxIdOrgTool(NyxIdApiClient client) => _client = client;

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdProfileTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdProfileTool.cs
@@ -5,8 +5,10 @@ using Aevatar.AI.Abstractions.ToolProviders;
 namespace Aevatar.AI.ToolProviders.NyxId.Tools;
 
 /// <summary>Tool to manage NyxID user profile and OAuth consents.</summary>
-public sealed class NyxIdProfileTool : IAgentTool
+public sealed class NyxIdProfileTool : IAgentTool, IAgentToolCapabilityDescriptor
 {
+    public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
+
     private readonly NyxIdApiClient _client;
 
     public NyxIdProfileTool(NyxIdApiClient client) => _client = client;

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdProvidersTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdProvidersTool.cs
@@ -5,8 +5,10 @@ using Aevatar.AI.Abstractions.ToolProviders;
 namespace Aevatar.AI.ToolProviders.NyxId.Tools;
 
 /// <summary>Tool to manage OAuth provider connections in NyxID.</summary>
-public sealed class NyxIdProvidersTool : IAgentTool
+public sealed class NyxIdProvidersTool : IAgentTool, IAgentToolCapabilityDescriptor
 {
+    public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
+
     private readonly NyxIdApiClient _client;
 
     public NyxIdProvidersTool(NyxIdApiClient client) => _client = client;

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdServicesTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdServicesTool.cs
@@ -5,8 +5,10 @@ using Aevatar.AI.Abstractions.ToolProviders;
 namespace Aevatar.AI.ToolProviders.NyxId.Tools;
 
 /// <summary>Tool to manage user's connected services in NyxID.</summary>
-public sealed class NyxIdServicesTool : IAgentTool
+public sealed class NyxIdServicesTool : IAgentTool, IAgentToolCapabilityDescriptor
 {
+    public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
+
     private readonly NyxIdApiClient _client;
 
     public NyxIdServicesTool(NyxIdApiClient client) => _client = client;

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdSessionsTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdSessionsTool.cs
@@ -4,8 +4,10 @@ using Aevatar.AI.Abstractions.ToolProviders;
 namespace Aevatar.AI.ToolProviders.NyxId.Tools;
 
 /// <summary>Tool to list NyxID active sessions.</summary>
-public sealed class NyxIdSessionsTool : IAgentTool
+public sealed class NyxIdSessionsTool : IAgentTool, IAgentToolCapabilityDescriptor
 {
+    public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
+
     private readonly NyxIdApiClient _client;
 
     public NyxIdSessionsTool(NyxIdApiClient client) => _client = client;

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdStatusTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdStatusTool.cs
@@ -5,8 +5,10 @@ using Aevatar.AI.Abstractions.ToolProviders;
 namespace Aevatar.AI.ToolProviders.NyxId.Tools;
 
 /// <summary>Tool to show NyxID account overview (user, services, API keys, nodes).</summary>
-public sealed class NyxIdStatusTool : IAgentTool
+public sealed class NyxIdStatusTool : IAgentTool, IAgentToolCapabilityDescriptor
 {
+    public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
+
     private readonly NyxIdApiClient _client;
 
     public NyxIdStatusTool(NyxIdApiClient client) => _client = client;

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdToolSurfaces.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdToolSurfaces.cs
@@ -1,0 +1,18 @@
+using Aevatar.AI.Abstractions.ToolProviders;
+
+namespace Aevatar.AI.ToolProviders.NyxId.Tools;
+
+/// <summary>
+/// Surface classification shared by the NyxID platform tools. A tool declares
+/// <see cref="HumanSessionOnly"/> when its broker endpoints only accept a human-session credential:
+/// in a channel-relay turn the effective credential is a bot-class relay/API-key token that the
+/// broker rejects on those surfaces (account, identity, keys, nodes, endpoints, providers, org,
+/// admin, mfa, sessions, notifications, channel-bots, and service/approval management, plus the
+/// account-aggregate status), so the tool can only fail if offered. The channel reply path filters
+/// tools carrying this capability out of channel turns by capability, never by tool name.
+/// </summary>
+internal static class NyxIdToolSurfaces
+{
+    public static readonly IReadOnlyCollection<string> HumanSessionOnly =
+        [AgentToolCapabilities.RequiresHumanSession];
+}

--- a/test/Aevatar.AI.Tests/NyxIdAgentToolSourceHumanSessionGatingTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdAgentToolSourceHumanSessionGatingTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.ToolProviders.NyxId;
+using FluentAssertions;
+using Xunit;
+
+namespace Aevatar.AI.Tests;
+
+/// <summary>
+/// Issue #2580 Item 2: NyxID platform tools whose broker endpoints only accept a human-session
+/// credential self-declare <c>AgentToolCapabilities.RequiresHumanSession</c> so the channel reply
+/// path can filter them out of bot-class relay turns (where the broker would reject them). Tools that
+/// target the delegated proxy / LLM / discovery surfaces must NOT declare it — they stay available in
+/// relay turns. This pins the classification and fails loudly if a new tool is left unclassified.
+/// </summary>
+public class NyxIdAgentToolSourceHumanSessionGatingTests
+{
+    private static readonly HashSet<string> HumanSessionOnlyTools = new(StringComparer.Ordinal)
+    {
+        "nyxid_account", "nyxid_profile", "nyxid_mfa", "nyxid_sessions", "nyxid_api_keys",
+        "nyxid_external_keys", "nyxid_nodes", "nyxid_endpoints", "nyxid_notifications",
+        "nyxid_providers", "nyxid_orgs", "nyxid_admin", "nyxid_channel_bots", "nyxid_status",
+        "nyxid_services", "nyxid_approvals",
+    };
+
+    private static readonly HashSet<string> RelaySafeTools = new(StringComparer.Ordinal)
+    {
+        "nyxid_proxy", "code_execute", "nyxid_llm_status", "nyxid_catalog", "nyxid_channel_events",
+    };
+
+    [Fact]
+    public async Task DiscoverToolsAsync_ClassifiesEveryToolByHumanSessionRequirement()
+    {
+        var source = new NyxIdAgentToolSource(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example" },
+            new NyxIdApiClient(new NyxIdToolOptions { BaseUrl = "https://nyx.example" }, new HttpClient()));
+
+        var tools = await source.DiscoverToolsAsync();
+
+        tools.Should().NotBeEmpty();
+        foreach (var tool in tools)
+        {
+            var isClassified = HumanSessionOnlyTools.Contains(tool.Name) || RelaySafeTools.Contains(tool.Name);
+            isClassified.Should().BeTrue(
+                $"{tool.Name} is unclassified — add it to the human-only or relay-safe set for the relay-turn gate");
+            DeclaresHumanSession(tool).Should().Be(
+                HumanSessionOnlyTools.Contains(tool.Name),
+                $"{tool.Name}'s RequiresHumanSession capability must match its broker-surface classification");
+        }
+
+        tools.Select(t => t.Name).Should().Contain(HumanSessionOnlyTools);
+        tools.Select(t => t.Name).Should().Contain(RelaySafeTools);
+    }
+
+    private static bool DeclaresHumanSession(IAgentTool tool) =>
+        tool is IAgentToolCapabilityDescriptor descriptor &&
+        descriptor.Capabilities.Contains(AgentToolCapabilities.RequiresHumanSession);
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
@@ -1359,6 +1359,91 @@ public sealed class AgentRunGAgentTests
     }
 
     [Fact]
+    public async Task HandleStartAsync_PersistsStepStateWithoutRuntimeCredentials_ButStillRepliesWithLiveToken()
+    {
+        // Issue #2580 Item 1: the persisted per-step waterline must never carry a bearer token.
+        // The inbound carries owner + sender tokens on LlmControl, a sender runtime token on the
+        // Activity, and a sender binding on the tool context. After the turn, the persisted step
+        // state (State.GenerationStep, rebuilt from the committed AgentRunReplyStepStateUpdatedEvent)
+        // must be token-less, yet the LLM request must still have executed with a live credential
+        // re-supplied from the transient request.
+        var targetActor = Substitute.For<IActor>();
+        targetActor.Id.Returns("conversation:c");
+        targetActor.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var providerFactory = new SingleReplyProviderFactory("clean reply");
+        var replyGenerator = new NyxIdConversationReplyGenerator(
+            providerFactory,
+            toolSources: [new CountingAgentRunToolSource(new AgentRunNoopTool())],
+            localSkillCatalog: new LocalSkillCatalog());
+        var actorRuntime = new DispatchingActorRuntime(("conversation:c", targetActor));
+        var runtime = CreateRunAgent(
+            actorRuntime,
+            replyGenerator,
+            new AsyncLocalInteractiveReplyCollector(),
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true });
+        var activity = BuildRelayActivity();
+        activity.TransportExtras ??= new TransportExtras();
+        activity.TransportExtras.NyxUserAccessToken = "sender-runtime-token";
+
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-strip-persisted-credentials",
+            TargetActorId = "conversation:c",
+            RegistrationId = "reg-1",
+            Activity = activity,
+            ReplyToken = "relay-token-strip-persisted-credentials",
+            ToolContext = (AgentToolExecutionContext.Empty with
+            {
+                SenderBinding = new AgentToolSenderBindingContext("bnd-user-1"),
+            }).ToPayload(),
+            LlmControl = new LLMControlContext(
+                "owner-token",
+                "owner-token",
+                "inbound-sender-token",
+                "owner-model",
+                "/api/v1/proxy/s/owner",
+                4,
+                null).ToPayload(),
+            Metadata =
+            {
+                [ChannelMetadataKeys.Platform] = "lark",
+                [ChannelMetadataKeys.SenderId] = "ou_user_1",
+                [ChannelMetadataKeys.MessageId] = "msg-strip-persisted-credentials",
+            },
+        });
+
+        // The turn completed with a live credential re-supplied from the transient request.
+        runtime.State.Status.Should().Be(AgentRunStatus.ReplyHandedOff);
+        runtime.State.ProducedReplyText.Should().Be("clean reply");
+        providerFactory.Requests.Should().ContainSingle();
+        providerFactory.Requests[0].LlmControl!.NyxIdAccessToken.Should().NotBeNullOrEmpty(
+            "the executor re-supplies a live credential from the transient request even though the persisted state is stripped");
+
+        // The persisted per-step waterline carries no bearer token in any of the four sub-messages.
+        var persisted = runtime.State.GenerationStep;
+        persisted.Should().NotBeNull();
+        (persisted!.LlmControl?.NyxIdAccessToken ?? string.Empty).Should().BeEmpty();
+        (persisted.LlmControl?.NyxIdOrgToken ?? string.Empty).Should().BeEmpty();
+        (persisted.LlmControl?.SenderNyxIdAccessToken ?? string.Empty).Should().BeEmpty();
+        (persisted.ToolContext?.Credentials?.NyxIdAccessToken ?? string.Empty).Should().BeEmpty();
+        (persisted.ToolContext?.Credentials?.NyxIdOrgToken ?? string.Empty).Should().BeEmpty();
+        (persisted.ToolContext?.Credentials?.SenderNyxIdAccessToken ?? string.Empty).Should().BeEmpty();
+        (persisted.OwnerFallbackLlmControl?.NyxIdAccessToken ?? string.Empty).Should().BeEmpty();
+        (persisted.OwnerFallbackLlmControl?.NyxIdOrgToken ?? string.Empty).Should().BeEmpty();
+        (persisted.OwnerFallbackLlmControl?.SenderNyxIdAccessToken ?? string.Empty).Should().BeEmpty();
+        (persisted.OwnerFallbackToolContext?.Credentials?.NyxIdAccessToken ?? string.Empty).Should().BeEmpty();
+        (persisted.OwnerFallbackToolContext?.Credentials?.NyxIdOrgToken ?? string.Empty).Should().BeEmpty();
+        (persisted.OwnerFallbackToolContext?.Credentials?.SenderNyxIdAccessToken ?? string.Empty).Should().BeEmpty();
+
+        // Belt-and-suspenders: no inbound token value survives anywhere in the committed state bytes.
+        var persistedText = System.Text.Encoding.UTF8.GetString(persisted.ToByteArray());
+        persistedText.Should().NotContain("owner-token");
+        persistedText.Should().NotContain("inbound-sender-token");
+        persistedText.Should().NotContain("sender-runtime-token");
+    }
+
+    [Fact]
     public async Task HandleStartAsync_WhenBoundToolSchemaIsRejected_RetriesWithOwnerNoTools()
     {
         var targetActor = Substitute.For<IActor>();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunReplyStepCredentialsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunReplyStepCredentialsTests.cs
@@ -1,0 +1,119 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.GAgents.NyxidChat;
+using FluentAssertions;
+using Xunit;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+/// <summary>
+/// Pins <see cref="AgentRunReplyStepCredentials.StripRuntimeCredentials"/>: every plaintext NyxID
+/// token on all four credential sub-messages is cleared before the per-step waterline is committed,
+/// while identity/routing facts survive, the input is not mutated, and the sub-message objects
+/// themselves are left in place (so structural owner-fallback checks keep working).
+/// </summary>
+public sealed class AgentRunReplyStepCredentialsTests
+{
+    private static AgentRunReplyStepState BuildStateWithTokens() => new()
+    {
+        RunId = "run-1",
+        LlmControl = new LLMControlContextPayload
+        {
+            NyxIdAccessToken = "user-token",
+            NyxIdOrgToken = "org-token",
+            SenderNyxIdAccessToken = "sender-token",
+            NyxIdRoutePreference = "/api/v1/proxy/s/owner",
+        },
+        ToolContext = new AgentToolExecutionContextPayload
+        {
+            Credentials = new AgentToolCredentialsPayload
+            {
+                NyxIdAccessToken = "user-token",
+                NyxIdOrgToken = "org-token",
+                SenderNyxIdAccessToken = "sender-token",
+            },
+            SenderBinding = new AgentToolSenderBindingContextPayload { BindingId = "bnd-1" },
+            Caller = new AgentToolCallerContextPayload { OwnerSubject = "owner-subj", ScopeId = "scope-1" },
+            Routing = new LLMRequestRoutingContextPayload { ModelOverride = "gpt-x" },
+        },
+        OwnerFallbackLlmControl = new LLMControlContextPayload
+        {
+            NyxIdAccessToken = "owner-token",
+            NyxIdOrgToken = "owner-org-token",
+            SenderNyxIdAccessToken = "leaked-sender",
+        },
+        OwnerFallbackToolContext = new AgentToolExecutionContextPayload
+        {
+            Credentials = new AgentToolCredentialsPayload
+            {
+                NyxIdAccessToken = "owner-token",
+                NyxIdOrgToken = "owner-org-token",
+                SenderNyxIdAccessToken = "leaked-sender",
+            },
+        },
+    };
+
+    [Fact]
+    public void StripRuntimeCredentials_ClearsEveryTokenOnAllFourSubMessages()
+    {
+        var stripped = AgentRunReplyStepCredentials.StripRuntimeCredentials(BuildStateWithTokens());
+
+        stripped.LlmControl.NyxIdAccessToken.Should().BeEmpty();
+        stripped.LlmControl.NyxIdOrgToken.Should().BeEmpty();
+        stripped.LlmControl.SenderNyxIdAccessToken.Should().BeEmpty();
+        stripped.ToolContext.Credentials.NyxIdAccessToken.Should().BeEmpty();
+        stripped.ToolContext.Credentials.NyxIdOrgToken.Should().BeEmpty();
+        stripped.ToolContext.Credentials.SenderNyxIdAccessToken.Should().BeEmpty();
+        stripped.OwnerFallbackLlmControl.NyxIdAccessToken.Should().BeEmpty();
+        stripped.OwnerFallbackLlmControl.NyxIdOrgToken.Should().BeEmpty();
+        stripped.OwnerFallbackLlmControl.SenderNyxIdAccessToken.Should().BeEmpty();
+        stripped.OwnerFallbackToolContext.Credentials.NyxIdAccessToken.Should().BeEmpty();
+        stripped.OwnerFallbackToolContext.Credentials.NyxIdOrgToken.Should().BeEmpty();
+        stripped.OwnerFallbackToolContext.Credentials.SenderNyxIdAccessToken.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void StripRuntimeCredentials_PreservesIdentityAndRoutingFacts()
+    {
+        var stripped = AgentRunReplyStepCredentials.StripRuntimeCredentials(BuildStateWithTokens());
+
+        stripped.RunId.Should().Be("run-1");
+        stripped.LlmControl.NyxIdRoutePreference.Should().Be("/api/v1/proxy/s/owner");
+        stripped.ToolContext.SenderBinding.BindingId.Should().Be("bnd-1");
+        stripped.ToolContext.Caller.OwnerSubject.Should().Be("owner-subj");
+        stripped.ToolContext.Caller.ScopeId.Should().Be("scope-1");
+        stripped.ToolContext.Routing.ModelOverride.Should().Be("gpt-x");
+    }
+
+    [Fact]
+    public void StripRuntimeCredentials_DoesNotMutateInput()
+    {
+        var original = BuildStateWithTokens();
+
+        AgentRunReplyStepCredentials.StripRuntimeCredentials(original);
+
+        original.LlmControl.NyxIdAccessToken.Should().Be("user-token");
+        original.ToolContext.Credentials.SenderNyxIdAccessToken.Should().Be("sender-token");
+        original.OwnerFallbackLlmControl.NyxIdAccessToken.Should().Be("owner-token");
+    }
+
+    [Fact]
+    public void StripRuntimeCredentials_KeepsSubMessagesInPlaceForStructuralChecks()
+    {
+        var stripped = AgentRunReplyStepCredentials.StripRuntimeCredentials(BuildStateWithTokens());
+
+        // The owner-fallback trigger gates on sub-message presence, not token strings.
+        stripped.OwnerFallbackLlmControl.Should().NotBeNull();
+        stripped.OwnerFallbackToolContext.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void StripRuntimeCredentials_ToleratesMissingSubMessages()
+    {
+        var minimal = new AgentRunReplyStepState { RunId = "run-2" };
+
+        var strip = () => AgentRunReplyStepCredentials.StripRuntimeCredentials(minimal);
+
+        strip.Should().NotThrow();
+        strip().RunId.Should().Be("run-2");
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
@@ -57,6 +57,15 @@ public sealed class ConversationReplyGeneratorTests
                 SenderBinding = new AgentToolSenderBindingContext(senderBindingId),
             };
 
+    // A channel-relay tool context carries the typed channel identity (platform/sender/message) that
+    // survives metadata stripping and every LLM round — the signal the human-only tool gate keys on.
+    private static AgentToolExecutionContext RelayToolContext(string senderBindingId, string messageId = "msg-relay") =>
+        AgentToolExecutionContext.Empty with
+        {
+            SenderBinding = new AgentToolSenderBindingContext(senderBindingId),
+            Channel = new AgentToolChannelContext("lark", "ou_user_1", "scope-1", messageId, null),
+        };
+
     private static ChatActivity CreateLarkImageActivity(
         string id,
         string text,
@@ -395,7 +404,7 @@ public sealed class ConversationReplyGeneratorTests
         };
 
         var channelPlan = await generator.BuildStepPlanAsync(
-            activity, channelMetadata, Control(token: "runtime-token"), ToolContext("bnd-1"),
+            activity, channelMetadata, Control(token: "runtime-token"), RelayToolContext("bnd-1", "msg-gate"),
             priorHistory: null, attachmentContext: null, forceDisableTools: false, CancellationToken.None);
         var channelToolNames = OfferedToolNames(channelPlan);
 
@@ -403,7 +412,7 @@ public sealed class ConversationReplyGeneratorTests
         channelToolNames.Should().NotContain("human_only_tool",
             "the human-session tool would be rejected by the broker in a relay turn, so it must not be offered");
 
-        // A non-channel (console/studio) human-session turn keeps the full set.
+        // A non-channel (console/studio) human-session turn (no typed channel context) keeps the full set.
         var consolePlan = await generator.BuildStepPlanAsync(
             activity, new Dictionary<string, string>(), Control(token: "runtime-token"), ToolContext("bnd-1"),
             priorHistory: null, attachmentContext: null, forceDisableTools: false, CancellationToken.None);
@@ -411,6 +420,35 @@ public sealed class ConversationReplyGeneratorTests
 
         consoleToolNames.Should().Contain("delegated_tool");
         consoleToolNames.Should().Contain("human_only_tool");
+    }
+
+    [Fact]
+    public async Task BuildStepPlanAsync_InLaterRelayRoundWithStrippedMetadata_StillGatesHumanSessionTools()
+    {
+        // Issue #2580 Item 2 regression (PR #2583 review): from the second LLM round the per-step
+        // metadata no longer carries channel.platform / sender_id / message_id (owned control keys
+        // stripped by AgentToolExecutionContextMapper.StripOwnedControlKeys), so a metadata-based gate
+        // would re-offer the human-only tools. With the typed channel context still present, the gate
+        // must stay on — otherwise a relay turn could call a relay-safe tool, advance a round, and
+        // regain nyxid_api_keys / nyxid_services under a bot-class token.
+        var providerFactory = new RecordingProviderFactory { Capabilities = MultimodalCapabilities };
+        var toolSource = new StubToolSource(
+            new HumanSessionStubTool("human_only_tool"),
+            new StubTool("delegated_tool"));
+        IAgentRunStepConversationReplyGenerator generator = new NyxIdConversationReplyGenerator(
+            providerFactory,
+            toolSources: [toolSource]);
+        var activity = CreateLarkActivity("msg-round2", "next round", "om_round2", token: "runtime-token");
+
+        // Round 2+ shape: channel.* metadata keys already stripped, typed channel context retained.
+        var plan = await generator.BuildStepPlanAsync(
+            activity, new Dictionary<string, string>(), Control(token: "runtime-token"), RelayToolContext("bnd-1", "msg-round2"),
+            priorHistory: null, attachmentContext: null, forceDisableTools: false, CancellationToken.None);
+        var toolNames = OfferedToolNames(plan);
+
+        toolNames.Should().Contain("delegated_tool");
+        toolNames.Should().NotContain("human_only_tool",
+            "the durable typed channel context must keep the human-only gate on after the channel metadata is stripped");
     }
 
     private static IReadOnlyList<string> OfferedToolNames(AgentRunReplyStepPlan plan)

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
@@ -374,6 +374,79 @@ public sealed class ConversationReplyGeneratorTests
     }
 
     [Fact]
+    public async Task BuildStepPlanAsync_InChannelRelayTurn_GatesOutHumanSessionTools()
+    {
+        // Issue #2580 Item 2: in a channel-relay turn the effective credential is bot-class, so a
+        // tool declaring RequiresHumanSession is filtered out (never offered), while a delegated tool
+        // stays. A console/studio (non-channel) turn keeps the full set.
+        var providerFactory = new RecordingProviderFactory { Capabilities = MultimodalCapabilities };
+        var toolSource = new StubToolSource(
+            new HumanSessionStubTool("human_only_tool"),
+            new StubTool("delegated_tool"));
+        IAgentRunStepConversationReplyGenerator generator = new NyxIdConversationReplyGenerator(
+            providerFactory,
+            toolSources: [toolSource]);
+        var activity = CreateLarkActivity("msg-gate", "hi", "om_gate", token: "runtime-token");
+        var channelMetadata = new Dictionary<string, string>
+        {
+            [ChannelMetadataKeys.Platform] = "lark",
+            [ChannelMetadataKeys.SenderId] = "ou_user_1",
+            [ChannelMetadataKeys.MessageId] = "msg-gate",
+        };
+
+        var channelPlan = await generator.BuildStepPlanAsync(
+            activity, channelMetadata, Control(token: "runtime-token"), ToolContext("bnd-1"),
+            priorHistory: null, attachmentContext: null, forceDisableTools: false, CancellationToken.None);
+        var channelToolNames = OfferedToolNames(channelPlan);
+
+        channelToolNames.Should().Contain("delegated_tool");
+        channelToolNames.Should().NotContain("human_only_tool",
+            "the human-session tool would be rejected by the broker in a relay turn, so it must not be offered");
+
+        // A non-channel (console/studio) human-session turn keeps the full set.
+        var consolePlan = await generator.BuildStepPlanAsync(
+            activity, new Dictionary<string, string>(), Control(token: "runtime-token"), ToolContext("bnd-1"),
+            priorHistory: null, attachmentContext: null, forceDisableTools: false, CancellationToken.None);
+        var consoleToolNames = OfferedToolNames(consolePlan);
+
+        consoleToolNames.Should().Contain("delegated_tool");
+        consoleToolNames.Should().Contain("human_only_tool");
+    }
+
+    private static IReadOnlyList<string> OfferedToolNames(AgentRunReplyStepPlan plan)
+    {
+        var llmRequest = plan.StepExecutor.BuildLlmStepRequest(
+            [ChatMessage.User("hi")],
+            requestId: "req",
+            plan.Metadata,
+            plan.ToolContext,
+            plan.LlmControl,
+            round: 0,
+            finalNoTools: false);
+        return (llmRequest.Tools ?? []).Select(tool => tool.Name).ToArray();
+    }
+
+    private sealed class StubToolSource(params IAgentTool[] tools) : IAgentToolSource
+    {
+        public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<IAgentTool>>(tools);
+    }
+
+    private class StubTool(string name) : IAgentTool
+    {
+        public string Name => name;
+        public string Description => name;
+        public string ParametersSchema => """{"type":"object","properties":{}}""";
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
+            Task.FromResult("{}");
+    }
+
+    private sealed class HumanSessionStubTool(string name) : StubTool(name), IAgentToolCapabilityDescriptor
+    {
+        public IReadOnlyCollection<string> Capabilities => [AgentToolCapabilities.RequiresHumanSession];
+    }
+
+    [Fact]
     public async Task GenerateReplyAsync_WithTextOnlyProviderAndImageAttachment_AddsHonestVisibilityWarning()
     {
         var lark = new RecordingLarkNyxClient(

--- a/tools/ci/guards/catch_exception_observability_baseline.tsv
+++ b/tools/ci/guards/catch_exception_observability_baseline.tsv
@@ -15,9 +15,9 @@ src/Aevatar.AI.ToolProviders.ChronoStorage/Tools/ChronoGlobTool.cs	51	empty broa
 src/Aevatar.AI.ToolProviders.ChronoStorage/Tools/ChronoGrepTool.cs	65	empty broad catch block
 src/Aevatar.AI.ToolProviders.ChronoStorage/Tools/ChronoTreeTool.cs	70	empty broad catch block
 src/Aevatar.AI.ToolProviders.MCP/MCPConnector.cs	209	empty broad catch block
-src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdApiKeysTool.cs	161	empty broad catch block
-src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdApiKeysTool.cs	188	empty broad catch block
-src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdServicesTool.cs	149	empty broad catch block
+src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdApiKeysTool.cs	163	empty broad catch block
+src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdApiKeysTool.cs	190	empty broad catch block
+src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdServicesTool.cs	151	empty broad catch block
 src/Aevatar.AI.ToolProviders.ServiceInvoke/Schema/EndpointSchemaProvider.cs	92	broad catch returns null without visible failure signal
 src/Aevatar.AI.ToolProviders.ServiceInvoke/Schema/EndpointSchemaProvider.cs	153	empty broad catch block
 src/Aevatar.AI.ToolProviders.ServiceInvoke/Tools/ListServicesTool.cs	157	empty broad catch block


### PR DESCRIPTION
## Context

The two remaining aevatar-side defense-in-depth items from the channel-relay credential-trust-boundary review (#2580). The "done" half — the https guard on the registered callback URL — is #2581, which this PR is **stacked on** (base = its branch, so this diff is just the two commits below; retarget to `feature/integrate` once #2581 merges). Neither item is an actively-exploitable public vulnerability (both fail closed); the broker already restricts the relay token to proxy/LLM/MCP surfaces with a ~300s TTL.

## Item 1 — strip runtime credentials from the persisted per-step waterline

`AgentRunGAgent.PersistStepStateAsync` committed `AgentRunReplyStepStateUpdatedEvent { StepState }` with plaintext NyxID access/org/sender tokens in all four credential sub-messages of `AgentRunReplyStepState`, contradicting the proto's own contract (*"Runtime-only credentials remain only on the transient self-message request"*). Exposure was confined to event-store / backup / replay, which is exactly the boundary that widens over time.

- New `AgentRunReplyStepCredentials.StripRuntimeCredentials` clears the token **strings** (keeps identity/routing facts and the sub-message objects, so structural owner-fallback checks still work) and is applied at the single commit funnel.
- Because `State.GenerationStep` is rebuilt from the stripped event, the executor now re-supplies credentials from the transient `workItem.Request` on every continuation: owner token from the Activity user token, sender token **re-minted per step** from the retained binding identity.
- The owner-fallback step re-supplies the bot-owner token from the inbound `LlmControl` before it is overwritten, so it still authenticates as the bot owner (pinned by the existing `AgentRunGAgentTests` owner-fallback test).

## Item 2 — gate human-only NyxID tools out of channel-relay turns

`NyxIdAgentToolSource` offered tools whose broker endpoints only accept a human-session credential; in a channel-relay turn the effective credential is a bot-class token the broker rejects (403), so the model could call them and always fail.

- New generic capability `AgentToolCapabilities.RequiresHumanSession`; the 16 human-only NyxID tools self-declare it via `IAgentToolCapabilityDescriptor`. The channel reply path filters tools carrying it out of `IsChannelTurn` turns **by capability, never by tool name** (mirrors the existing `ExcludeFromDirectChannelChat` filter), so they are never offered and never registered.
- **GATE:** account, profile, mfa, sessions, api_keys, external_keys, nodes, endpoints, notifications, providers, orgs, admin, channel_bots, status, services, approvals. **KEEP:** proxy, code_execute, llm_status, catalog, channel_events.
- Note: the issue text lists "status" as keep, but `NyxIdStatusTool` calls `GetCurrentUser`/`ListApiKeys`/`ListNodes` and `nyxid_services`/`nyxid_approvals` do write ops — all human-only surfaces — so they are gated. Console/studio human-session turns keep the full set.

## Impact paths

- `agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs`, `AgentRunReplyGenerationExecutor.cs`, `AgentRunReplyStepCredentials.cs` (new), `ConversationReplyGenerator.cs`
- `src/Aevatar.AI.Abstractions/ToolProviders/AgentToolCapabilities.cs`; `src/Aevatar.AI.ToolProviders.NyxId/Tools/` (16 tools + `NyxIdToolSurfaces.cs` new)

## Validation

- `dotnet build aevatar.slnx --nologo` — **0 errors**.
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests` — **1546 green** (incl. the pinned owner-fallback test + a new `AgentRunReplyStepStateUpdatedEvent` leak-regression test + the relay-turn tool-gate test).
- `dotnet test test/Aevatar.AI.Tests` — **1018 green** (incl. the per-tool human-session classification test).
- `bash tools/ci/architecture_guards.sh` and `bash tools/ci/test_stability_guards.sh` — **pass** (the 2-line capability insert shifted 3 pre-existing baselined empty-catch findings; baseline line numbers updated to match).

Closes #2580.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
