### PR TITLE
fix(schedules): make silently-dropped cron beats observable (#2578)

### DIFF
--- a/src/platform/Aevatar.GAgentService.Abstractions/Schedules/ScheduledDispatchModels.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Schedules/ScheduledDispatchModels.cs
@@ -102,7 +102,9 @@ public sealed record ScheduledDispatchSummary(
     string ScheduleActorId,
     string? Prompt = null,
     ScheduledDispatchScheduleKind ScheduleKind = ScheduledDispatchScheduleKind.Generic,
-    bool Deleted = false);
+    bool Deleted = false,
+    int OverdueFireDetectedCount = 0,
+    DateTimeOffset? LastOverdueFireAt = null);
 
 public sealed record ScheduledDispatchFireRecord(
     DateTimeOffset ScheduledFireAt,

--- a/src/platform/Aevatar.GAgentService.Core/Schedules/ScheduledDispatchGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/Schedules/ScheduledDispatchGAgent.cs
@@ -17,6 +17,11 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
 {
     private const string NextFireCallbackId = "scheduled-dispatch-next-fire";
     private const int MaxFireRecordCount = 128;
+    // How overdue an armed occurrence must be, when the actor reactivates, before it counts as
+    // a detected miss. Wide enough that routine reactivation catch-up (pod churn at the boundary
+    // is seconds-to-minutes late) is not flagged, tight enough that genuine drops (production
+    // misses run 90+ minutes) always are.
+    private static readonly TimeSpan OverdueFireGracePeriod = TimeSpan.FromMinutes(10);
     private const string LegacyDurableSenderBearerBlockedError =
         "Scheduled service invocation contains legacy durable bearer auth; reconfigure the schedule with senderNyxId or scopeOwnerNyxId.";
     private static readonly TimeSpan MaxNextFireCallbackHop = TimeSpan.FromDays(7);
@@ -37,6 +42,7 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
         await base.OnActivateAsync(ct);
         if (State.Enabled && !string.IsNullOrWhiteSpace(State.CronExpression))
         {
+            await DetectOverdueArmedFireAsync(DateTimeOffset.UtcNow, ct);
             if (State.PendingNextFireAt != null)
             {
                 var pendingNextFireAt = State.PendingNextFireAt.ToDateTimeOffset();
@@ -80,6 +86,7 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
             .On<ScheduledDispatchFireStartedEvent>(ApplyFireStarted)
             .On<ScheduledDispatchFireDispatchedEvent>(ApplyFireDispatched)
             .On<ScheduledDispatchFireFailedEvent>(ApplyFireFailed)
+            .On<ScheduledDispatchFireOverdueDetectedEvent>(ApplyFireOverdueDetected)
             .OrCurrent();
 
     [EventHandler]
@@ -284,15 +291,28 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
             return;
         }
 
+        var scheduledFireAt = ResolveScheduledFireAt(command);
+        var callbackFiredAt = command.Manual ? (DateTimeOffset?)null : ResolveCallbackFiredAt(inboundEnvelope);
+
         if (!command.Manual && !MatchesNextFireLease(inboundEnvelope))
         {
-            Logger.LogInformation("Scheduled dispatch {ActorId} ignored stale fire callback.", Id);
+            Logger.LogInformation(
+                "Scheduled dispatch {ActorId} ignored stale fire callback scheduleId={ScheduleId} scheduledFireAt={ScheduledFireAt} leaseGeneration={LeaseGeneration}.",
+                Id,
+                ResolveScheduleId(),
+                scheduledFireAt,
+                State.NextFireLease?.Generation);
             return;
         }
 
-        var scheduledFireAt = ResolveScheduledFireAt(command);
-        if (!command.Manual && ResolveCallbackFiredAt(inboundEnvelope) < scheduledFireAt)
+        if (!command.Manual && callbackFiredAt < scheduledFireAt)
         {
+            Logger.LogInformation(
+                "Scheduled dispatch {ActorId} re-armed early fire callback scheduleId={ScheduleId} scheduledFireAt={ScheduledFireAt} callbackFiredAt={CallbackFiredAt}.",
+                Id,
+                ResolveScheduleId(),
+                scheduledFireAt,
+                callbackFiredAt);
             var previousLease = ScheduledDispatchRuntimeCallbackLeaseStateCodec.ToRuntime(State.NextFireLease);
             await RecordNextFireIntentAsync(scheduledFireAt, ct);
             await ActivateNextFireIntentAsync(scheduledFireAt, previousLease, ct);
@@ -302,13 +322,40 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
         var idempotencyKey = ScheduledDispatchCalculator.BuildIdempotencyKey(ResolveScheduleId(), scheduledFireAt);
         if (HasTerminalFireRecord(idempotencyKey))
         {
-            Logger.LogInformation(
-                "Scheduled dispatch {ActorId} ignored duplicate fire {IdempotencyKey}.",
+            State.FireRecords.TryGetValue(idempotencyKey, out var priorRecord);
+            // A suppressed fire was previously an Information no-op, so #2366-style silent skips
+            // left no signal for ops post-mortems. Elevate to Warning with the full decision
+            // context: the stale-lease guard above already absorbs superseded re-deliveries, so a
+            // duplicate that reaches here is an unexpected same-occurrence collision worth seeing.
+            Logger.LogWarning(
+                "Scheduled dispatch {ActorId} suppressed duplicate fire scheduleId={ScheduleId} idempotencyKey={IdempotencyKey} scheduledFireAt={ScheduledFireAt} nextFireAt={NextFireAt} callbackFiredAt={CallbackFiredAt} leaseGeneration={LeaseGeneration} priorStatus={PriorStatus} manual={Manual}.",
                 Id,
-                idempotencyKey);
+                ResolveScheduleId(),
+                idempotencyKey,
+                scheduledFireAt,
+                State.NextFireAt,
+                callbackFiredAt,
+                State.NextFireLease?.Generation,
+                priorRecord?.Status,
+                command.Manual);
             if (!command.Manual)
                 await EnsureNextFireScheduledAsync(scheduledFireAt, ct);
             return;
+        }
+
+        if (callbackFiredAt is { } firedAt && firedAt - scheduledFireAt > OverdueFireGracePeriod)
+        {
+            // The callback reached the handler well after its scheduled time (late delivery while
+            // the grain stayed active, so OnActivate never re-ran). The fire still dispatches; the
+            // Warning makes the lateness observable even though it is not counted as an overdue
+            // detection.
+            Logger.LogWarning(
+                "Scheduled dispatch {ActorId} dispatching overdue fire scheduleId={ScheduleId} scheduledFireAt={ScheduledFireAt} callbackFiredAt={CallbackFiredAt} overdueSeconds={OverdueSeconds}.",
+                Id,
+                ResolveScheduleId(),
+                scheduledFireAt,
+                firedAt,
+                (long)(firedAt - scheduledFireAt).TotalSeconds);
         }
 
         await PersistDomainEventAsync(new ScheduledDispatchFireStartedEvent
@@ -676,6 +723,44 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
 
         var lease = ScheduledDispatchRuntimeCallbackLeaseStateCodec.ToRuntime(State.NextFireLease);
         return lease != null && RuntimeCallbackEnvelopeStateReader.MatchesLease(envelope, lease);
+    }
+
+    private async Task DetectOverdueArmedFireAsync(DateTimeOffset nowUtc, CancellationToken ct)
+    {
+        // The occurrence the actor is about to (re-)arm: a pending intent that never armed, or the
+        // steady-state armed NextFireAt. When it is overdue past the grace window with no terminal
+        // record, the tick that should have fired was silently dropped (a dead reminder or a
+        // callback that never reached this handler) and we only notice now, on reactivation.
+        var candidate = State.PendingNextFireAt?.ToDateTimeOffset() ?? State.NextFireAt;
+        if (candidate == null)
+            return;
+
+        var overdue = nowUtc - candidate.Value;
+        if (overdue <= OverdueFireGracePeriod)
+            return;
+
+        var idempotencyKey = ScheduledDispatchCalculator.BuildIdempotencyKey(ResolveScheduleId(), candidate.Value);
+        if (HasTerminalFireRecord(idempotencyKey))
+            return;
+
+        // Once-per-occurrence: LastOverdueFireAt is persisted state, so repeated reactivations
+        // against the same still-overdue armed occurrence do not inflate the counter.
+        if (State.LastOverdueFireAt == candidate.Value)
+            return;
+
+        Logger.LogWarning(
+            "Scheduled dispatch {ActorId} detected overdue armed fire scheduleId={ScheduleId} scheduledFireAt={ScheduledFireAt} overdueSeconds={OverdueSeconds} with no terminal record; re-arming as catch-up.",
+            Id,
+            ResolveScheduleId(),
+            candidate.Value,
+            (long)overdue.TotalSeconds);
+
+        await PersistDomainEventAsync(new ScheduledDispatchFireOverdueDetectedEvent
+        {
+            ScheduledFireAt = Timestamp.FromDateTimeOffset(candidate.Value),
+            DetectedAt = Timestamp.FromDateTimeOffset(nowUtc),
+            OverdueSeconds = (long)overdue.TotalSeconds,
+        }, ct);
     }
 
     private bool HasTerminalFireRecord(string idempotencyKey)
@@ -1071,6 +1156,20 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
             Manual = evt.Manual,
             Status = ScheduledDispatchFireStatusState.Failed,
         });
+        return next;
+    }
+
+    private static ScheduledDispatchState ApplyFireOverdueDetected(
+        ScheduledDispatchState current,
+        ScheduledDispatchFireOverdueDetectedEvent evt)
+    {
+        var next = current.Clone();
+        next.OverdueFireDetectedCount++;
+        next.LastOverdueFireAt = evt.ScheduledFireAt?.ToDateTimeOffset();
+        next.UpdatedAt =
+            evt.DetectedAt?.ToDateTimeOffset() ??
+            evt.ScheduledFireAt?.ToDateTimeOffset() ??
+            DateTimeOffset.UtcNow;
         return next;
     }
 

--- a/src/platform/Aevatar.GAgentService.Core/Schedules/ScheduledDispatchState.Partial.cs
+++ b/src/platform/Aevatar.GAgentService.Core/Schedules/ScheduledDispatchState.Partial.cs
@@ -29,6 +29,12 @@ public sealed partial class ScheduledDispatchState
         set => LastFireAtUtcValue = value.HasValue ? ToTimestamp(value.Value) : null;
     }
 
+    public DateTimeOffset? LastOverdueFireAt
+    {
+        get => LastOverdueFireAtUtcValue == null ? null : LastOverdueFireAtUtcValue.ToDateTimeOffset();
+        set => LastOverdueFireAtUtcValue = value.HasValue ? ToTimestamp(value.Value) : null;
+    }
+
     public DateTimeOffset? DeletedAt
     {
         get => DeletedAtUtcValue == null ? null : DeletedAtUtcValue.ToDateTimeOffset();

--- a/src/platform/Aevatar.GAgentService.Core/Schedules/scheduled_dispatch_state.proto
+++ b/src/platform/Aevatar.GAgentService.Core/Schedules/scheduled_dispatch_state.proto
@@ -37,6 +37,13 @@ message ScheduledDispatchState
   ScheduledDispatchScheduleKindState schedule_kind = 26;
   bool deleted = 27;
   google.protobuf.Timestamp deleted_at_utc_value = 28;
+  // Number of times the actor reactivated and found an armed occurrence overdue
+  // past the grace window with no terminal fire record. This is a detection
+  // counter (once per overdue armed occurrence), not a total-missed-occurrence
+  // tally: a long-dormant actor that misses many ticks records one detection
+  // when it reactivates against the earliest still-armed occurrence.
+  int32 overdue_fire_detected_count = 29;
+  google.protobuf.Timestamp last_overdue_fire_at_utc_value = 30;
 }
 
 enum ScheduledDispatchScheduleKindState
@@ -259,6 +266,13 @@ message ScheduledDispatchFireFailedEvent
   string idempotency_key = 3;
   string error = 4;
   bool manual = 5;
+}
+
+message ScheduledDispatchFireOverdueDetectedEvent
+{
+  google.protobuf.Timestamp scheduled_fire_at = 1;
+  google.protobuf.Timestamp detected_at = 2;
+  int64 overdue_seconds = 3;
 }
 
 message ScheduledDispatchFireRecordState

--- a/src/platform/Aevatar.GAgentService.Projection/Projectors/ScheduledDispatchCurrentStateProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Projectors/ScheduledDispatchCurrentStateProjector.cs
@@ -75,6 +75,7 @@ public sealed class ScheduledDispatchCurrentStateProjector
             LastError = state.LastError ?? string.Empty,
             FireCount = state.FireCount,
             FailureCount = state.FailureCount,
+            OverdueFireDetectedCount = state.OverdueFireDetectedCount,
             ServiceKey = BuildServiceKey(serviceIdentity),
             ServiceId = serviceIdentity?.ServiceId ?? string.Empty,
             ServiceEndpointId = target.ServiceInvocation?.EndpointId ?? string.Empty,
@@ -90,6 +91,7 @@ public sealed class ScheduledDispatchCurrentStateProjector
         document.UpdatedAt = CommittedStateEventEnvelope.ResolveTimestamp(envelope, _clock.UtcNow);
         document.NextFireAt = state.NextFireAt;
         document.LastFireAt = state.LastFireAt;
+        document.LastOverdueFireAt = state.LastOverdueFireAt;
         document.DeletedAt = state.DeletedAt;
         document.Headers = state.Headers
             .ToDictionary(x => x.Key, x => x.Value, StringComparer.Ordinal);

--- a/src/platform/Aevatar.GAgentService.Projection/Queries/ScheduledDispatchQueryPort.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Queries/ScheduledDispatchQueryPort.cs
@@ -127,7 +127,9 @@ public sealed class ScheduledDispatchQueryPort : IScheduledDispatchQueryPort
             document.ScheduleActorId ?? string.Empty,
             document.Prompt ?? string.Empty,
             ParseScheduleKind(document.ScheduleKind),
-            document.Deleted);
+            document.Deleted,
+            document.OverdueFireDetectedCount,
+            document.LastOverdueFireAt);
 
     private static ScheduledDispatchFireRecord MapFireRecord(ScheduledDispatchFireRecordDocument document) =>
         new(

--- a/src/platform/Aevatar.GAgentService.Projection/ReadModels/ServiceProjectionReadModels.Partial.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/ReadModels/ServiceProjectionReadModels.Partial.cs
@@ -442,6 +442,12 @@ public sealed partial class ScheduledDispatchDocument : IProjectionReadModel<Sch
         set => LastFireAtUtcValue = ServiceProjectionReadModelSupport.ToNullableTimestamp(value);
     }
 
+    public DateTimeOffset? LastOverdueFireAt
+    {
+        get => ServiceProjectionReadModelSupport.ToNullableDateTimeOffset(LastOverdueFireAtUtcValue);
+        set => LastOverdueFireAtUtcValue = ServiceProjectionReadModelSupport.ToNullableTimestamp(value);
+    }
+
     public DateTimeOffset? DeletedAt
     {
         get => ServiceProjectionReadModelSupport.ToNullableDateTimeOffset(DeletedAtUtcValue);

--- a/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
+++ b/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
@@ -426,6 +426,8 @@ message ScheduledDispatchDocument {
   bool deleted = 31;
   google.protobuf.Timestamp deleted_at_utc_value = 32;
   string prompt = 33;
+  int32 overdue_fire_detected_count = 34;
+  google.protobuf.Timestamp last_overdue_fire_at_utc_value = 35;
 }
 
 message ScheduledDispatchFireRecordDocument {

--- a/test/Aevatar.GAgentService.Tests/Projection/ScheduledDispatchCurrentStateProjectorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ScheduledDispatchCurrentStateProjectorTests.cs
@@ -167,6 +167,39 @@ public sealed class ScheduledDispatchCurrentStateProjectorTests
         document.LastEventId.Should().Be("evt-historical");
     }
 
+    [Fact]
+    public async Task ProjectAsync_ShouldMirrorOverdueFireDetection()
+    {
+        var store = new RecordingDocumentStore<ScheduledDispatchDocument>(x => x.Id);
+        var projector = new ScheduledDispatchCurrentStateProjector(
+            store,
+            new FixedProjectionClock(DateTimeOffset.Parse("2026-07-02T00:00:00+00:00")));
+        var identity = new ServiceIdentity
+        {
+            TenantId = "tenant",
+            AppId = "app",
+            Namespace = "default",
+            ServiceId = "svc",
+        };
+        var state = CreateServiceInvocationState("schedule-overdue", identity);
+        var lastOverdueFireAt = DateTimeOffset.Parse("2026-07-01T09:00:00+00:00");
+        state.OverdueFireDetectedCount = 3;
+        state.LastOverdueFireAt = lastOverdueFireAt;
+
+        await projector.ProjectAsync(
+            CreateContext("scheduled-dispatch:schedule-overdue"),
+            WrapCommitted(
+                state,
+                version: 12,
+                eventId: "evt-overdue",
+                observedAt: DateTimeOffset.Parse("2026-07-02T01:00:00+00:00")));
+
+        var document = await store.GetAsync("schedule-overdue");
+        document.Should().NotBeNull();
+        document!.OverdueFireDetectedCount.Should().Be(3);
+        document.LastOverdueFireAt.Should().Be(lastOverdueFireAt);
+    }
+
     private static ScheduledDispatchProjectionContext CreateContext(string rootActorId) =>
         new()
         {

--- a/test/Aevatar.Workflow.Core.Tests/ScheduledDispatchGAgentTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/ScheduledDispatchGAgentTests.cs
@@ -84,6 +84,35 @@ public sealed class ScheduledDispatchGAgentTests
     }
 
     [Fact]
+    public async Task HandleFireAsync_WhenNonManualCallbackDeliveredPastGrace_ShouldStillDispatch()
+    {
+        var eventStore = new TestEventStore();
+        var dispatch = new RecordingActorDispatchPort();
+        var scheduler = new RecordingRuntimeCallbackScheduler();
+        var agent = CreateAgent(eventStore, dispatch, scheduler);
+        await agent.ActivateAsync();
+        await agent.HandleConfigureAsync(CreateConfigureCommand(cronExpression: "*/15 * * * *", enabled: true));
+
+        var request = scheduler.TimeoutRequests.Single();
+        var scheduledFireAt = agent.State.NextFireAt!.Value;
+
+        // The callback reaches the handler 20 minutes after its scheduled time (late delivery while
+        // the grain stayed active). A late fire must still dispatch, not be suppressed, and is not
+        // counted as an OnActivate overdue detection (that is a separate, reactivation-time signal).
+        await agent.HandleEventAsync(CreateFiredCallbackEnvelope(
+            request,
+            generation: 1,
+            fireIndex: 1,
+            firedAt: scheduledFireAt.AddMinutes(20),
+            scheduledFireAt: scheduledFireAt));
+
+        dispatch.Dispatches.Should().ContainSingle();
+        var idempotencyKey = ScheduledDispatchCalculator.BuildIdempotencyKey("schedule-1", scheduledFireAt);
+        agent.State.FireRecords[idempotencyKey].Status.Should().Be(ScheduledDispatchFireStatusState.Dispatched);
+        agent.State.OverdueFireDetectedCount.Should().Be(0);
+    }
+
+    [Fact]
     public async Task HandleConfigureAsync_WhenEnabled_ShouldRegisterDurableNextFireCallback()
     {
         var eventStore = new TestEventStore();
@@ -1725,6 +1754,127 @@ public sealed class ScheduledDispatchGAgentTests
         var reactivationRequest = scheduler.TimeoutRequests[^1];
         var reactivationFire = reactivationRequest.TriggerEnvelope.Payload.Unpack<ScheduledDispatchFireCommand>();
         reactivationFire.ScheduledFireAt.ToDateTimeOffset().Should().BeAfter(DateTimeOffset.UtcNow);
+    }
+
+    [Fact]
+    public async Task OnActivateAsync_WhenArmedFireOverduePastGrace_ShouldRecordOverdueDetection()
+    {
+        var eventStore = new TestEventStore();
+        var dispatch = new RecordingActorDispatchPort();
+        var scheduler = new RecordingRuntimeCallbackScheduler();
+        var armedFireAt = await ArmOverdueFireAsync(eventStore, dispatch, scheduler, overdueBy: TimeSpan.FromMinutes(30));
+
+        var reactivated = CreateAgent(eventStore, dispatch, scheduler);
+        await reactivated.ActivateAsync();
+
+        // The armed occurrence came due while the actor was dormant and is overdue well past
+        // the grace window with no terminal record, so reactivation records exactly one overdue
+        // detection and remembers which occurrence it was.
+        reactivated.State.OverdueFireDetectedCount.Should().Be(1);
+        reactivated.State.LastOverdueFireAt.Should().Be(armedFireAt);
+        reactivated.State.NextFireAt.Should().Be(armedFireAt);
+        eventStore.GetEvents(ScheduleActorId)
+            .Where(x => string.Equals(x.EventType, ScheduledDispatchFireOverdueDetectedEvent.Descriptor.FullName, StringComparison.Ordinal))
+            .Should()
+            .ContainSingle();
+    }
+
+    [Fact]
+    public async Task OnActivateAsync_WhenArmedFireWithinGrace_ShouldNotRecordOverdueDetection()
+    {
+        var eventStore = new TestEventStore();
+        var dispatch = new RecordingActorDispatchPort();
+        var scheduler = new RecordingRuntimeCallbackScheduler();
+        await ArmOverdueFireAsync(eventStore, dispatch, scheduler, overdueBy: TimeSpan.FromMinutes(1));
+
+        var reactivated = CreateAgent(eventStore, dispatch, scheduler);
+        await reactivated.ActivateAsync();
+
+        // A near-boundary catch-up (armed fire only seconds/minutes late, e.g. routine pod churn)
+        // is not an overdue detection: it stays within the grace window.
+        reactivated.State.OverdueFireDetectedCount.Should().Be(0);
+        reactivated.State.LastOverdueFireAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task OnActivateAsync_WhenOverdueAlreadyRecordedForSameOccurrence_ShouldNotDoubleCount()
+    {
+        var eventStore = new TestEventStore();
+        var dispatch = new RecordingActorDispatchPort();
+        var scheduler = new RecordingRuntimeCallbackScheduler();
+        var armedFireAt = await ArmOverdueFireAsync(eventStore, dispatch, scheduler, overdueBy: TimeSpan.FromMinutes(30));
+
+        var firstReactivation = CreateAgent(eventStore, dispatch, scheduler);
+        await firstReactivation.ActivateAsync();
+        firstReactivation.State.OverdueFireDetectedCount.Should().Be(1);
+
+        var secondReactivation = CreateAgent(eventStore, dispatch, scheduler);
+        await secondReactivation.ActivateAsync();
+
+        // Repeated reactivations against the same still-overdue armed occurrence must not
+        // inflate the counter: detection is once-per-occurrence via persisted LastOverdueFireAt.
+        secondReactivation.State.OverdueFireDetectedCount.Should().Be(1);
+        secondReactivation.State.LastOverdueFireAt.Should().Be(armedFireAt);
+    }
+
+    [Fact]
+    public async Task OnActivateAsync_WhenOverdueArmedFireAlreadyHasTerminalRecord_ShouldNotRecordOverdueDetection()
+    {
+        var eventStore = new TestEventStore();
+        var dispatch = new RecordingActorDispatchPort();
+        var scheduler = new RecordingRuntimeCallbackScheduler();
+        var agent = CreateAgent(eventStore, dispatch, scheduler);
+        await agent.ActivateAsync();
+        await agent.HandleConfigureAsync(CreateConfigureCommand(cronExpression: "* * * * *", enabled: true));
+
+        // The overdue occurrence already reached a terminal (dispatched) record via a manual fire,
+        // then gets armed as NextFireAt. Reactivation must not flag it as overdue: it did fire.
+        var occurrence = DateTimeOffset.UtcNow - TimeSpan.FromMinutes(30);
+        await agent.HandleFireAsync(new ScheduledDispatchFireCommand
+        {
+            ScheduledFireAt = Timestamp.FromDateTimeOffset(occurrence),
+            Manual = true,
+        });
+        var firstRequest = scheduler.TimeoutRequests[0];
+        await agent.HandleEventAsync(CreateFiredCallbackEnvelope(
+            firstRequest,
+            generation: 1,
+            fireIndex: 1,
+            firedAt: occurrence.AddSeconds(-1),
+            scheduledFireAt: occurrence));
+        agent.State.NextFireAt.Should().Be(occurrence);
+
+        var reactivated = CreateAgent(eventStore, dispatch, scheduler);
+        await reactivated.ActivateAsync();
+
+        reactivated.State.OverdueFireDetectedCount.Should().Be(0);
+        reactivated.State.LastOverdueFireAt.Should().BeNull();
+    }
+
+    private static async Task<DateTimeOffset> ArmOverdueFireAsync(
+        TestEventStore eventStore,
+        RecordingActorDispatchPort dispatch,
+        RecordingRuntimeCallbackScheduler scheduler,
+        TimeSpan overdueBy)
+    {
+        var agent = CreateAgent(eventStore, dispatch, scheduler);
+        await agent.ActivateAsync();
+        await agent.HandleConfigureAsync(CreateConfigureCommand(cronExpression: "* * * * *", enabled: true));
+
+        // Arm NextFireAt for a fire time in the past via the early-callback re-arm path, exactly
+        // like steady state after a normal arm (NextFireAt set, PendingNextFireAt cleared).
+        var armedFireAt = DateTimeOffset.UtcNow - overdueBy;
+        var firstRequest = scheduler.TimeoutRequests.Single();
+        await agent.HandleEventAsync(CreateFiredCallbackEnvelope(
+            firstRequest,
+            generation: 1,
+            fireIndex: 1,
+            firedAt: armedFireAt.AddSeconds(-1),
+            scheduledFireAt: armedFireAt));
+        agent.State.NextFireAt.Should().Be(armedFireAt);
+        agent.State.PendingNextFireAt.Should().BeNull();
+        agent.State.OverdueFireDetectedCount.Should().Be(0);
+        return armedFireAt;
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

`ScheduledDispatchGAgent` is the shared fire handler for **every** platform cron schedule. It can silently drop a beat, and the failure is invisible to ops (issue #2578; #2366 root cause never actually landed — the closing commit `ac325cc70` fixed a related reactivation gap, not the dedup no-op). Two observed production modes:

- **Dedup no-op (#2366):** a suppressed fire logged only at `Information` ("ignored duplicate fire") — no signal for post-mortems.
- **Dormant / late (2026-07-01):** the fire never reached the handler; `nextFireAt` sat 90–1400 min overdue with `fireCount`/`lastFireAt` frozen and zero log lines.

Per the issue, the goal is defense-in-depth (make the drop observable), not pinning the exact race.

## Approach

1. **Overdue detection + counter (observability).** On reactivation, if the armed occurrence (`PendingNextFireAt ?? NextFireAt`) is overdue past a 10-min grace with no terminal fire record, record a new `ScheduledDispatchFireOverdueDetectedEvent` (once per occurrence via persisted `LastOverdueFireAt`) and log `Warning`. `overdue_fire_detected_count` + `last_overdue_fire_at` are mirrored through the projector → readmodel → schedule DTO, so they are queryable via `GET /schedules/{id}` and list.
2. **Honest structured logging.** Elevate the suppressed-duplicate branch `Information → Warning` with full decision context (`scheduledFireAt`, `nextFireAt`, lease generation, prior record status, callback `firedAt`, manual); structure the stale/early-callback logs; and `Warn` when a fire dispatches past the grace window (late delivery while the grain stayed active). No control-flow change.

Codex-reviewed: dropped a cron cross-validation idea as cargo-cult (full-precision idempotency keys + the stale-lease guard already prevent false-positive dedup).

### Out of scope (called out honestly)

A proactive sweeper for a **permanently** dormant actor (dead reminder that never reactivates) is a separate detection system and is not built here. This PR surfaces the miss whenever the grain reactivates, plus exposes `overdue_fire_detected_count` / `last_overdue_fire_at` / the existing `nextFireAt` on the readmodel so ops can identify overdue schedules. A dedicated `?overdue=true` list filter is a reasonable follow-up (a server-side `nextFireAt < now-grace` filter on a nullable timestamp needs cross-store verification I couldn't do here).

## Impact paths

- `ScheduledDispatchGAgent` — `OnActivateAsync` detection, `HandleFireAsync` logging, new reducer.
- `scheduled_dispatch_state.proto` / `.Partial.cs` — `overdue_fire_detected_count`, `last_overdue_fire_at`, `ScheduledDispatchFireOverdueDetectedEvent`.
- Projection mirror: projector, `service_projection_read_models.proto`, readmodel partial, query `MapSummary`, `ScheduledDispatchSummary` DTO.

## Verification

- Tests: `Aevatar.Workflow.Core.Tests` 599 ✓, `Aevatar.GAgentService.Tests` 1069 ✓, `Aevatar.GAgentService.Integration.Tests` (ScheduledDispatch) 44 ✓, `Aevatar.Workflow.Host.Api.Tests` (ScheduledDispatch) 3 ✓. New tests cover overdue detection, within-grace non-detection, once-per-occurrence, terminal-record guard, and the projection mirror.
- Guards: `architecture_guards.sh`, `test_stability_guards.sh`, `proto_lint_guard.sh`, `projection_state_version_guard.sh`, `projection_state_mirror_current_state_guard.sh`, `runtime_callback_guards.sh` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)