### PR TITLE
Add FKST host supervise entrypoint

### DIFF
--- a/.fkst/compose/package-roots
+++ b/.fkst/compose/package-roots
@@ -6,3 +6,4 @@ fkst-packages:packages/github-devloop-intake
 fkst-packages:packages/github-devloop-intake-default
 fkst-packages:packages/github-devloop
 fkst-packages:packages/github-devloop-pr
+fkst-packages:packages/github-devloop-ops

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 .env
 local-dev/
 
+# FKST local runtime state
+.fkst/env
+.fkst/run/
+
 # User-specific files
 *.rsuser
 *.suo

--- a/fkst.lock
+++ b/fkst.lock
@@ -1,0 +1,35 @@
+[[external_source]]
+id = "fkst-packages"
+git = "https://github.com/ChronoAIProject/fkst-packages.git"
+
+[external_source.intent]
+rev = "7b0bbca4501ec47a25d2a43600708fbc0ae66f71"
+
+[external_source.resolved]
+rev = "7b0bbca4501ec47a25d2a43600708fbc0ae66f71"
+tree_sha256 = "sha256-6dc4ecb1e5d6fa697a222280945b711ab698847174aa182327d19e6b94469bfe"
+
+[[external_source.libraries]]
+name = "contract"
+unit = "libraries/contract"
+exports_sha256 = "sha256-9487770eeef2a2bfa024c954a30560bdf8157bb96132f31e1dca4624a15bdb65"
+
+[[external_source.libraries]]
+name = "forge"
+unit = "libraries/forge"
+exports_sha256 = "sha256-e488aa9d2be48d815698dac4ef73d17c498e1be14da4948aeabce670f470330b"
+
+[[external_source.libraries]]
+name = "testkit"
+unit = "libraries/testkit"
+exports_sha256 = "sha256-e6c28d60bc9a3107afd1d7af4ef81fbc9f1abfc6c5236f29313a97eebf6c0b03"
+
+[[external_source.libraries]]
+name = "workflow"
+unit = "libraries/workflow"
+exports_sha256 = "sha256-424318804b37262d3c708840720b2f1c10d58a620305279cd0abf5cb5467cee8"
+
+[[external_source.libraries]]
+name = "devloop"
+unit = "libraries/devloop"
+exports_sha256 = "sha256-1d0a3673cc0ee3cba36dedef9ea44a0ce459f1f1ba4d0ff89a1362e6f2bf417b"

--- a/fkst.workspace.toml
+++ b/fkst.workspace.toml
@@ -4,3 +4,19 @@ packages = [".fkst/local-packages/*"]
 
 [registries]
 workspace = "workspace"
+
+[[external_sources]]
+id = "fkst-packages"
+git = "https://github.com/ChronoAIProject/fkst-packages.git"
+rev = "7b0bbca4501ec47a25d2a43600708fbc0ae66f71"
+libraries = ["contract", "forge", "testkit", "workflow", "devloop"]
+packages = [
+  "github-proxy",
+  "consensus",
+  "github-devloop-decompose",
+  "github-devloop-intake",
+  "github-devloop-intake-default",
+  "github-devloop",
+  "github-devloop-pr",
+  "github-devloop-ops",
+]

--- a/tools/fkst/supervise.sh
+++ b/tools/fkst/supervise.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: tools/fkst/supervise.sh [--background] [--restart] [-- <extra supervise args>]
+
+Environment:
+  FKST_ENV_FILE       Optional env file. Defaults to $HOME/.config/fkst/aevatar.env.
+  FKST_PLATFORM_ROOT  Required unless set in FKST_ENV_FILE. Path to fkst-packages.
+  FKST_HOST_ROOT      Optional. Defaults to this repository root.
+  FKST_STATE_ROOT     Optional. Defaults to ${XDG_STATE_HOME:-$HOME/.local/state}/fkst/aevatar.
+  FKST_DURABLE_ROOT   Optional. Defaults to $FKST_STATE_ROOT/durable.
+  FKST_RUNTIME_ROOT   Optional. Defaults to $FKST_STATE_ROOT/runtime.
+  FKST_RATE_POOL_ROOT Optional. Defaults to $FKST_STATE_ROOT/rate.
+  FKST_LOG_DIR        Optional. Defaults to $FKST_STATE_ROOT/logs.
+
+This script uses FKST host startup so package composition is read from
+.fkst/compose/package-roots instead of being duplicated in this script.
+USAGE
+}
+
+BACKGROUND=0
+RESTART=0
+EXTRA_ARGS=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --background)
+      BACKGROUND=1
+      shift
+      ;;
+    --restart)
+      RESTART=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      EXTRA_ARGS=("$@")
+      break
+      ;;
+    *)
+      EXTRA_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+ENV_FILE="${FKST_ENV_FILE:-$HOME/.config/fkst/aevatar.env}"
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+  set +a
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOST_ROOT="${FKST_HOST_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+if [ -z "${FKST_PLATFORM_ROOT:-}" ]; then
+  cat >&2 <<'ERROR'
+FKST_PLATFORM_ROOT is required. Set it in the environment or in $HOME/.config/fkst/aevatar.env.
+Example:
+  FKST_PLATFORM_ROOT=/path/to/fkst-packages
+ERROR
+  exit 2
+fi
+
+STATE_ROOT="${FKST_STATE_ROOT:-${XDG_STATE_HOME:-$HOME/.local/state}/fkst/aevatar}"
+export FKST_DURABLE_ROOT="${FKST_DURABLE_ROOT:-$STATE_ROOT/durable}"
+export FKST_RUNTIME_ROOT="${FKST_RUNTIME_ROOT:-$STATE_ROOT/runtime}"
+export FKST_RATE_POOL_ROOT="${FKST_RATE_POOL_ROOT:-$STATE_ROOT/rate}"
+LOG_DIR="${FKST_LOG_DIR:-$STATE_ROOT/logs}"
+
+mkdir -p "$FKST_DURABLE_ROOT" "$FKST_RUNTIME_ROOT" "$FKST_RATE_POOL_ROOT" "$LOG_DIR"
+
+cmd=(
+  "$FKST_PLATFORM_ROOT/scripts/run.sh" host
+  --host-root "$HOST_ROOT"
+  --platform-root "$FKST_PLATFORM_ROOT"
+  -- supervise
+  --durable-root "$FKST_DURABLE_ROOT"
+  --runtime-root "$FKST_RUNTIME_ROOT"
+)
+
+if [ "$RESTART" -eq 1 ]; then
+  cmd+=(--restart)
+fi
+
+cmd+=("${EXTRA_ARGS[@]}")
+
+if [ "$BACKGROUND" -eq 1 ]; then
+  log_file="$LOG_DIR/supervise.log"
+  nohup "${cmd[@]}" > "$log_file" 2>&1 &
+  pid=$!
+  printf 'FKST supervise started: pid=%s log=%s\n' "$pid" "$log_file"
+  exit 0
+fi
+
+exec "${cmd[@]}"


### PR DESCRIPTION
## Summary
- Add a `tools/fkst/supervise.sh` wrapper that runs FKST through host composition instead of duplicating platform package lists.
- Lock the `fkst-packages` external source and include `github-devloop-ops` in host package composition.
- Ignore local FKST runtime/env state so machine-specific supervise config stays out of the repo.

## Test plan
- [x] `bash -n tools/fkst/supervise.sh`
- [x] `/Users/liyingpei/Desktop/Code/fkst-packages/scripts/run.sh host --host-root /Users/liyingpei/Desktop/Code/aevatar2 --platform-root /Users/liyingpei/Desktop/Code/fkst-packages -- check`
- [x] Method B supervise smoke test with isolated roots and `FKST_GITHUB_WRITE=0`: liveness and merge queue delivered successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)