### PR TITLE
记录平台审计轨迹架构口径

### DIFF
--- a/docs/adr/0039-platform-audit-trail.md
+++ b/docs/adr/0039-platform-audit-trail.md
@@ -1,0 +1,143 @@
+---
+title: "Platform Audit Trail"
+status: accepted
+owner: eanzhao
+---
+
+# ADR-0039: Platform Audit Trail
+
+## Context
+
+Aevatar needs a platform audit trail for security, governance, and incident
+review. The tempting implementation shape is to reuse familiar read-side names
+and build an `AuditLogReadModel`, a central audit actor, or an alternate
+projection rail that tries to reconstruct facts from endpoint records.
+
+That shape would violate existing architecture rules:
+
+1. Read models are actor-scoped current-state replicas, not append-only audit
+   history.
+2. Projection already has one canonical committed-fact pipeline.
+3. Boundary endpoint records cannot prove committed business facts.
+4. Audit storage must never capture credential material, raw identity subjects,
+   full prompts, full tool arguments, or full tool results.
+
+The applicable reference frame is security audit logging governance plus
+CQRS/event-sourcing: audit records are append-only, allowlist-driven,
+sanitized, and separate from business authority.
+
+## Decision
+
+Platform audit trail v1 is an append-only audit artifact store.
+
+Audit capture is split by plane:
+
+1. Boundary endpoint filter captures request-plane artifacts.
+2. Tool-execution middleware captures tool-plane artifacts.
+3. Projection Pipeline artifact sink captures committed-fact-plane artifacts.
+
+Each plane writes sanitized audit artifacts directly to the audit artifact
+store. The Projection Pipeline artifact sink consumes only the existing
+committed feed. It is a fan-out materialization target, not a new projection
+pipeline, read model, or actor authority.
+
+Identity in audit artifacts uses an HMAC-derived key plus `identity_key_id`.
+The HMAC key is host-owned configuration or KMS material. Audit artifacts never
+store raw token-minting subject ids, `sender_binding_id`, credential material,
+tokens, headers, cookies, OAuth codes, API keys, full prompts, full tool
+arguments, or full tool results.
+
+The canonical implementation vocabulary and validation rules live in
+[Platform Audit Trail](../canon/audit-trail.md).
+
+## Locked Rules
+
+1. Platform audit trail is an append-only artifact store, not an actor-scoped
+   current-state read model.
+2. No `AuditLogReadModel` or equivalent readmodel-shaped audit history.
+3. No dedicated hot audit actor that becomes a shared audit serialization
+   bottleneck.
+4. No second projection rail, second event envelope, or parallel reducer route.
+5. Committed-fact audit artifacts come only from the committed feed consumed by
+   the existing Projection Pipeline.
+6. Boundary endpoint artifacts may record request acceptance, rejection, and
+   safe receipt metadata, but they must not reconstruct committed business
+   facts.
+7. Tool-execution artifacts record safe execution summaries and artifact
+   references, never full prompts, full arguments, full results, or model
+   payloads.
+8. Credential material, tokens, headers, cookies, OAuth codes, API keys,
+   `sender_binding_id`, raw token-minting subject ids, full prompts, full tool
+   args, and full tool results are structurally excluded from artifact schemas.
+9. Audit identity uses HMAC plus `identity_key_id`; raw subjects are not stored
+   for later joins.
+10. Audit queries read audit artifacts only. They must not trigger projection
+    activation, event replay, actor state reads, or query-time reconstruction.
+
+## Required Artifact Contract
+
+The first implementation must define a typed audit artifact contract with these
+field families:
+
+| Field family | Required meaning |
+|---|---|
+| `audit_id` | Stable audit artifact id. |
+| `captured_at` | Capture timestamp. |
+| `capture_plane` | Boundary endpoint, tool execution, or projection artifact. |
+| `action` | Allowlisted action name. |
+| `resource` | Typed safe resource summary. |
+| `actor_identity` | HMAC identity key plus `identity_key_id`. |
+| `correlation` | Safe request, command, run, trace, or projection correlation ids. |
+| `committed_fact_ref` | Optional committed feed reference and authoritative state version. |
+| `outcome` | Allowlisted status or error class. |
+| `safe_summary` | Redacted governance summary. |
+
+This ADR does not authorize an untyped payload bag for internal audit
+semantics. If an external extension boundary needs a bag, it must remain outside
+the internal platform audit contract and obey the same redaction rules.
+
+## Consequences
+
+Positive consequences:
+
+1. Audit trail gets a clear governance surface without becoming a second
+   business fact source.
+2. CQRS and Projection Pipeline remain single-rail.
+3. Endpoint, tool, and committed-fact planes can evolve independently while
+   sharing one sanitized artifact store.
+4. Identity joins survive key rotation through `identity_key_id` without
+   storing raw subjects.
+5. Sensitive content is excluded by schema, not by after-the-fact log scrubbing.
+
+Tradeoffs:
+
+1. Audit queries cannot answer current business state questions; callers must
+   use read models for that.
+2. Some forensic detail is intentionally unavailable because full prompts,
+   full tool payloads, headers, cookies, tokens, and credential material are not
+   stored.
+3. Backfill and export require explicit artifact-store operations rather than
+   query-time replay.
+
+## Non-Goals
+
+1. Defining the physical storage provider.
+2. Adding a public audit API shape.
+3. Adding a new actor, read model, reducer, envelope type, or projection
+   lifecycle.
+4. Changing existing observability semantic conventions.
+5. Reconstructing historical audit detail from raw request bodies, raw tool
+   payloads, credential stores, or event-store replay.
+
+## Validation
+
+For this docs-first decision:
+
+```bash
+bash tools/docs/lint.sh
+dotnet build aevatar.slnx --nologo
+```
+
+Future implementation work must additionally prove that forbidden fields cannot
+be serialized into audit artifacts and that committed-fact artifacts consume
+only committed feed inputs.

--- a/docs/canon/audit-trail.md
+++ b/docs/canon/audit-trail.md
@@ -1,0 +1,221 @@
+---
+title: "Platform Audit Trail"
+status: active
+owner: eanzhao
+---
+
+# Platform Audit Trail
+
+## 1. Purpose
+
+Platform audit trail is the governance record for security-relevant platform
+actions. It answers: who initiated an action, which plane captured it, what
+resource was touched, what decision or outcome was recorded, and which
+committed fact version proves the business result when a committed fact exists.
+
+It is not a domain read model, not an actor state replica, not an observability
+trace, and not a second projection rail.
+
+The mature frame is security audit logging governance plus CQRS/event-sourcing:
+audit records are append-only, allowlist-driven, sanitized, and separated from
+business authority.
+
+## 2. Canonical Shape
+
+Platform audit trail v1 is an append-only audit artifact store.
+
+Each audit artifact is an immutable record written by exactly one capture
+plane. The artifact can be queried for governance and incident review, but it
+does not define business state and cannot be used as the source for command
+decisions.
+
+Required artifact shape:
+
+| Field family | Meaning |
+|---|---|
+| `audit_id` | Stable audit artifact id. |
+| `captured_at` | Capture timestamp from the writing plane. |
+| `capture_plane` | One of `boundary_endpoint`, `tool_execution`, or `projection_artifact`. |
+| `action` | Allowlisted action name such as request accepted, tool started, tool completed, or committed artifact observed. |
+| `resource` | Typed resource summary, such as scope, service, workflow, run, connector, or channel resource. |
+| `actor_identity` | Sanitized identity key and `identity_key_id`, never a raw subject or credential. |
+| `correlation` | Request, command, run, trace, or projection correlation ids that are already safe to expose. |
+| `committed_fact_ref` | Optional reference to the committed feed item and state version when the artifact is about a committed fact. |
+| `outcome` | Allowlisted result summary, error class, or status. |
+| `safe_summary` | Short redacted summary suitable for governance review. |
+
+Artifact payloads must be schema-governed and allowlisted. Free-form bags may be
+used only at an external extension boundary; internal platform semantics must
+use typed fields.
+
+## 3. Capture Planes
+
+### 3.1 Boundary Endpoint Filter
+
+The boundary endpoint filter records request-plane facts at Host or adapter
+edges. Examples include authenticated request accepted, authorization denied,
+rate limit rejected, request body rejected by validation, and command receipt
+returned.
+
+Boundary endpoint artifacts may include safe request method, route template,
+scope id, resource id, command id, correlation id, and sanitized caller
+identity. They must not reconstruct committed business facts. If the request
+later produces a committed event, that committed result is captured by the
+committed feed path, not by replaying or enriching the boundary artifact.
+
+### 3.2 Tool-Execution Middleware
+
+Tool-execution middleware records tool-plane facts around tool invocation. It
+captures the tool identity, execution phase, safe caller and scope identity,
+safe resource target, timing, result class, and redacted diagnostic summary.
+
+It must not store full prompts, full tool arguments, full tool results, raw
+model responses, bearer tokens, OAuth codes, API keys, cookies, headers, or
+connector credential material. If a tool result needs later inspection, the
+tool must produce a separate safe artifact reference and record only that
+reference in the audit artifact.
+
+### 3.3 Projection Pipeline Artifact Sink
+
+The Projection Pipeline artifact sink records committed-fact-plane audit
+artifacts after committed facts flow through the existing Projection Pipeline.
+This plane consumes the same committed feed as the normal projection path and
+writes audit artifacts as append-only governance artifacts.
+
+It must not create a dedicated audit read model such as `AuditLogReadModel`,
+must not add a hot audit actor, and must not subscribe to inbound commands,
+self-continuation events, actor runtime structures, or boundary-only records to
+infer committed facts.
+
+Committed fact artifacts must reference the authoritative source version, such
+as committed state event id, actor id, actor type, event type url, and state
+version when available. Local artifact counters are not authoritative state
+versions.
+
+## 4. Identity and Redaction
+
+Audit identity is represented by an HMAC-derived key plus `identity_key_id`.
+
+Rules:
+
+1. The HMAC secret is host-owned configuration or KMS material. It is never
+   written to actor state, read models, audit artifacts, logs, traces, or
+   repository defaults.
+2. `identity_key_id` identifies the active key used for the digest so rotation
+   can be verified later.
+3. Raw platform subjects, token-minting subject ids, `sender_binding_id`,
+   OAuth subject ids, email addresses, phone numbers, access tokens, refresh
+   tokens, API keys, cookies, authorization headers, and full credential
+   handles are structurally excluded from audit artifacts.
+4. Rotation keeps old `identity_key_id` values queryable for historical
+   artifacts. Rewriting old artifacts is not required.
+5. Joins across planes use the sanitized identity key plus safe correlation ids,
+   not raw subjects.
+
+The exclusion rule is structural, not best-effort logging hygiene. Producers
+must shape the artifact contract so forbidden material has no field where it
+can be stored.
+
+## 5. Relationship to CQRS, Projection, and Observability
+
+### 5.1 CQRS Boundary
+
+Audit artifacts are not command receipts, domain events, actor state, or current
+state read models.
+
+Commands still follow:
+
+```text
+Command -> Actor -> Domain Event -> Committed Feed -> Projection -> ReadModel
+```
+
+Audit trail follows:
+
+```text
+Capture Plane -> Sanitized Audit Artifact -> Append-Only Artifact Store
+```
+
+When an audit artifact references a committed business fact, it references the
+committed feed item. It does not become the fact.
+
+### 5.2 Projection Boundary
+
+The Projection Pipeline may fan out to an audit artifact sink. That sink is a
+materialization target for governance artifacts, not a new Projection Pipeline
+and not a second event router.
+
+Projection must continue to consume committed facts through the canonical
+`EventEnvelope<CommittedStateEventPublished>` path. Audit capture must not
+justify query-time replay, projection priming, event-store side reads, or
+boundary-only reconstruction.
+
+### 5.3 Observability Boundary
+
+Observability traces and logs diagnose runtime behavior. Audit artifacts record
+governance facts. They can share safe correlation ids, but neither one is the
+other's authority.
+
+Observability data may be sampled or aggregated. Audit artifacts are append-only
+and retention-governed.
+
+## 6. Forbidden Patterns
+
+Do not implement platform audit trail as:
+
+1. `AuditLogReadModel` or another actor-scoped current-state read model.
+2. A dedicated hot audit actor that serializes all platform audit writes.
+3. A boundary-only reconstruction of committed facts.
+4. A second projection rail, second event envelope, or parallel reducer route.
+5. A query-time event replay or readmodel priming path.
+6. A raw log sink that accepts untyped payloads, prompts, tool arguments,
+   headers, cookies, tokens, OAuth codes, API keys, credential material,
+   `sender_binding_id`, raw token-minting subject ids, or full tool results.
+7. A governance decision source for command execution.
+
+## 7. Query Semantics
+
+Audit queries read the append-only artifact store. They may filter by time,
+capture plane, safe action, safe resource key, sanitized identity key,
+`identity_key_id`, correlation id, committed fact reference, and outcome.
+
+Audit query results must expose that they are governance artifacts. They must
+not claim current business state, readmodel freshness, or actor completion
+beyond the committed fact reference they carry.
+
+If a product surface needs current business state, it must query the relevant
+read model. If it needs governance review, it queries audit artifacts.
+
+## 8. Retention and Operations
+
+Retention, export, and legal hold are artifact-store concerns. They do not
+change actor state, committed events, or read models.
+
+Operational requirements:
+
+1. Append-only writes are idempotent by `audit_id` or by a deterministic capture
+   key owned by the writing plane.
+2. Failed audit writes must be observable as operational failures, but they must
+   not be patched by replaying request bodies or reading raw credential stores.
+3. Backfill is a maintenance action over safe committed feeds or existing safe
+   artifacts. It is not part of query handling.
+4. Export jobs must keep the same redaction rules as online queries.
+
+## 9. Validation
+
+Changes to audit trail contracts or implementation must verify:
+
+1. Docs lint passes for this canon and its ADR.
+2. Producers cannot store forbidden material because the artifact schema has no
+   such fields.
+3. Committed-fact audit artifacts consume only committed feed inputs.
+4. Audit queries do not trigger projection activation, event replay, actor
+   state reads, or request-body reconstruction.
+5. Identity key rotation preserves `identity_key_id` and never exposes raw
+   subjects.
+
+Related references:
+
+- [ADR-0039: Platform Audit Trail](../adr/0039-platform-audit-trail.md)
+- [CQRS Projection](cqrs-projection.md)
+- [Event Sourcing](event-sourcing.md)
+- [Observability](observability.md)


### PR DESCRIPTION
## Changed files

- `docs/adr/0039-platform-audit-trail.md`: 新增 ADR，明确 platform audit trail v1 是 append-only audit artifact store，并锁定三类 capture plane、HMAC identity 与敏感字段结构性排除规则。
- `docs/canon/audit-trail.md`: 新增 canon 文档，定义 audit artifact 形状、CQRS/Projection/Observability 边界、禁止模式、查询语义与验证要求。

## Test results

- `dotnet build aevatar.slnx --nologo`: 通过，存在仓库既有 warning。
- `bash tools/docs/lint.sh`: 通过。
- `bash tools/ci/architecture_guards.sh`: 通过。

## Deviations

- Closes #2593
- 未扩展 scope；未修改代码或 proto；未提交 commit。
- `HOST_REFACTOR_COMMENT_POLICY` 为空，按规则归一为 `none`，未添加 Refactor 自说明注释。

⟦AI:AUTO-LOOP⟧
