### PR TITLE
Fix NyxID callback finalization

### DIFF
--- a/apps/aevatar-console-web/src/pages/auth/callback/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/auth/callback/index.test.tsx
@@ -1,0 +1,112 @@
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import CallbackPage from './index';
+import { NyxIDAuthClient } from '@/shared/auth/client';
+import { CONSOLE_HOME_ROUTE } from '@/shared/navigation/consoleHome';
+import { persistAuthSession } from '@/shared/auth/session';
+
+const replaceLocation = jest.fn();
+const handleRedirectCallback = jest.fn();
+
+jest.mock('@/shared/auth/client', () => ({
+  NyxIDAuthClient: jest.fn(),
+}));
+
+function mockLocationReplace(search = window.location.search) {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: {
+      ...window.location,
+      href: window.location.href,
+      origin: window.location.origin,
+      replace: replaceLocation,
+      search,
+    },
+  });
+}
+
+describe('NyxID callback page', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.history.replaceState(
+      {},
+      '',
+      '/auth/callback?code=auth-code&state=state-1',
+    );
+    replaceLocation.mockReset();
+    handleRedirectCallback.mockReset();
+    (NyxIDAuthClient as jest.Mock).mockImplementation(() => ({
+      handleRedirectCallback,
+    }));
+    mockLocationReplace();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+    jest.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  it('finalizes the OAuth callback even when a previous session exists', async () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: 'old-access-token',
+        expiresAt: Date.now() + 60_000,
+        expiresIn: 60,
+        tokenType: 'Bearer',
+      },
+      user: {
+        sub: 'old-user',
+      },
+    });
+    handleRedirectCallback.mockResolvedValue({
+      returnTo: '/runtime/runs',
+      session: {
+        tokens: {
+          accessToken: 'new-access-token',
+          expiresAt: Date.now() + 60_000,
+          expiresIn: 60,
+          tokenType: 'Bearer',
+        },
+        user: {
+          sub: 'new-user',
+        },
+      },
+    });
+
+    render(React.createElement(CallbackPage));
+
+    await waitFor(() => {
+      expect(handleRedirectCallback).toHaveBeenCalledTimes(1);
+    });
+    expect(replaceLocation).toHaveBeenCalledWith('/runtime/runs');
+  });
+
+  it('skips callback finalization when no callback payload is present and a session exists', async () => {
+    window.history.replaceState({}, '', '/auth/callback');
+    mockLocationReplace('');
+    persistAuthSession({
+      tokens: {
+        accessToken: 'access-token',
+        expiresAt: Date.now() + 60_000,
+        expiresIn: 60,
+        tokenType: 'Bearer',
+      },
+      user: {
+        sub: 'user-1',
+      },
+    });
+
+    render(React.createElement(CallbackPage));
+
+    await waitFor(() => {
+      expect(replaceLocation).toHaveBeenCalledWith(CONSOLE_HOME_ROUTE);
+    });
+    expect(handleRedirectCallback).not.toHaveBeenCalled();
+  });
+});

--- a/apps/aevatar-console-web/src/pages/auth/callback/index.tsx
+++ b/apps/aevatar-console-web/src/pages/auth/callback/index.tsx
@@ -33,7 +33,13 @@ const CallbackPage: React.FC = () => {
       }
     };
 
-    if (!loadStoredAuthSession()) {
+    const callbackParams = new URLSearchParams(window.location.search);
+    const hasCallbackPayload =
+      callbackParams.has('code') ||
+      callbackParams.has('state') ||
+      callbackParams.has('error');
+
+    if (hasCallbackPayload || !loadStoredAuthSession()) {
       void finishLogin();
     } else {
       window.location.replace(CONSOLE_HOME_ROUTE);


### PR DESCRIPTION
## Summary

- Fix NyxID OAuth callback handling so a returned `code/state/error` payload always runs the callback finalization path.
- Preserve the existing shortcut to console home only for `/auth/callback` visits without OAuth callback payload and with an active session.
- Add a regression test for stale/previous local session plus fresh NyxID callback payload.

## Problem and solution

The frontend callback page skipped `NyxIDAuthClient.handleRedirectCallback()` whenever `loadStoredAuthSession()` returned an active session. If an operator had a previous active session and then completed a new NyxID OAuth login, the callback URL still contained `code` and `state`, but the page redirected to the console home before calling `/api/auth/nyxid/finalize`.

The fix treats callback payload as authoritative: if the URL contains `code`, `state`, or `error`, the page runs `handleRedirectCallback()` and lets the auth client call the backend finalization endpoint.

## Impact paths

- `apps/aevatar-console-web/src/pages/auth/callback/index.tsx`
- `apps/aevatar-console-web/src/pages/auth/callback/index.test.tsx`

## Verification

- `./node_modules/.bin/jest --selectProjects jsdom --runTestsByPath src/pages/auth/callback/index.test.tsx src/shared/auth/client.test.ts src/shared/auth/backend.test.ts --runInBand` ✅
- `./node_modules/.bin/tsc --noEmit` ✅

Note: `pnpm --dir apps/aevatar-console-web ...` initially hit local pnpm build-script approval in the fresh worktree, so verification used the installed workspace binaries directly.

## FKST provenance

- Skill: aevatar-frontend-fkst
- Issue: current user-reported NyxID callback regression
- Worktree: /Users/xiezixin/Documents/work/aevatar-fix-nyxid-finalize-auth-callback
- Branch: fix/2026-07-07_nyxid-finalize-auth-callback
- Operator: AbigailDeng
- Freshness: current production/login-flow evidence from July 7, 2026
