### PR TITLE
fix(channels): tell the model the truth when a turn's tool surface is detached

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -557,6 +557,20 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
     // Normal LLM messages are allowed to use the bot owner's LLM config when
     // the sender has no NyxID binding. Binding is only required by commands
     // that configure or inspect per-user state (/models, /model use, ...).
+    //
+    // A lookup FAILURE deliberately degrades to null (owner config, tools off)
+    // instead of failing the turn, even though null also trips the issue-#1318
+    // unbound-sender tool gate. Failing the turn was tried and is worse on the
+    // relay path: the deferred inbound-turn retry rebuilds its runtime context
+    // without the runtime-only reply token and terminally fails with
+    // missing_runtime_reply_token before ever re-invoking the runner, and letting
+    // the exception propagate drops the message outright (durable envelope retry
+    // refuses credential-carrying relay events). Typed transient classification
+    // is also unreliable at this seam — the production ES-backed reader surfaces
+    // 5xx/429 as InvalidOperationException. So: reply now on owner config, and
+    // the reply generator's tools-disabled system-prompt notice keeps the model
+    // honest about the missing tool surface instead of it denying the capability
+    // exists. Real cancellation still propagates.
     private async Task<ResolvedSenderBinding?> TryResolveSenderBindingAsync(
         InboundMessage inbound,
         ChannelBotRegistrationEntry registration,
@@ -574,17 +588,18 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         {
             existing = await queryPort.ResolveAsync(subject, ct);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
             throw;
         }
         catch (Exception ex) when (IsTransientBindingLookupFailure(ex))
         {
-            // Transient infra failures (DB blip, transient HTTP, JSON shape mismatch from
-            // upstream): degrade to owner credentials and keep the conversation alive.
+            // Transient infra failures (readmodel blip, transient HTTP/timeout, JSON
+            // shape mismatch from upstream): degrade to owner credentials and keep
+            // the conversation alive.
             _logger.LogWarning(
                 ex,
-                "Transient sender NyxID binding lookup failure; falling back to bot owner LLM config. subject={Platform}:{Tenant}:{User}",
+                "Transient sender NyxID binding lookup failure; falling back to bot owner LLM config with tools disabled. subject={Platform}:{Tenant}:{User}",
                 subject.Platform,
                 subject.Tenant,
                 subject.ExternalUserId);
@@ -592,12 +607,13 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         }
         catch (Exception ex)
         {
-            // Non-transient (programmer error, unexpected NRE, serialization break): surface
-            // at Error level so ops can distinguish from "sender just isn't bound" — but still
-            // fall through to owner credentials so the user gets a reply rather than nothing.
+            // Non-transient shape (includes the ES reader's InvalidOperationException
+            // wrapping of 5xx/429): surface at Error level so ops can distinguish from
+            // "sender just isn't bound" — but still fall through to owner credentials
+            // so the user gets an honest degraded reply rather than nothing.
             _logger.LogError(
                 ex,
-                "Sender NyxID binding lookup raised non-transient exception; falling back to bot owner LLM config. subject={Platform}:{Tenant}:{User}",
+                "Sender NyxID binding lookup raised non-transient exception; falling back to bot owner LLM config with tools disabled. subject={Platform}:{Tenant}:{User}",
                 subject.Platform,
                 subject.Tenant,
                 subject.ExternalUserId);
@@ -612,7 +628,9 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
 
     /// <summary>
     /// Distinguish infra-shaped binding lookup failures (worth a Warning + owner fallback)
-    /// from logic/programmer errors (worth an Error log so ops sees them).
+    /// from logic/programmer errors (worth an Error log so ops sees them). Both degrade to
+    /// the owner-config reply; see <see cref="TryResolveSenderBindingAsync"/> for why the
+    /// turn must not fail here.
     /// </summary>
     private static bool IsTransientBindingLookupFailure(Exception ex) =>
         ex is HttpRequestException

--- a/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
@@ -30,6 +30,34 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
     private const int MaxWorkingSetMessages = 200;
     private const int MaxInlineImageBytes = 10 * 1024 * 1024;
 
+    // Appended to the system prompt when the unbound-sender gate detaches the tool
+    // surface for a channel turn. The kernel prompt documents the deployment's tools
+    // unconditionally, so the model must be told the honest, recoverable reason no
+    // tool is attached — otherwise it reports the capability itself as missing.
+    // Wording is tool-name-agnostic by design (CLAUDE.md: no per-skill hardcoding);
+    // /init is the channel binding bootstrap the slash path already prompts for.
+    private const string UnboundSenderToolsDisabledNotice =
+        "## Tools disabled for this turn\n" +
+        "No tools are attached to this turn: the sender's identity is not bound, and " +
+        "channel tool execution requires a bound identity. Any tool or capability " +
+        "documentation above describes tools you cannot invoke right now. Do not claim " +
+        "a capability is missing from this deployment, and do not claim any action was " +
+        "performed. If the request needs a tool, tell the user tool execution is " +
+        "disabled for this turn because their identity is not bound, and that sending " +
+        "/init in this chat starts the binding that enables tools.";
+
+    // Appended instead of the unbound notice when a bound sender's attempt failed and
+    // the reply is retried on the bot owner's configuration with tools stripped — the
+    // same prompt/tool-surface honesty gap, different recoverable reason.
+    private const string DegradedTurnToolsDisabledNotice =
+        "## Tools disabled for this turn\n" +
+        "No tools are attached to this turn: the sender-scoped attempt failed and this " +
+        "reply is a degraded retry on the bot owner's configuration without tools. Any " +
+        "tool or capability documentation above describes tools you cannot invoke right " +
+        "now. Do not claim a capability is missing from this deployment, and do not claim " +
+        "any action was performed. If the request needs a tool, tell the user this turn " +
+        "ran degraded without tools and ask them to retry shortly.";
+
     private readonly ILLMProviderFactory _llmProviderFactory;
     private readonly IReadOnlyList<IAgentToolSource> _toolSources;
     private readonly IReadOnlyList<IAgentRunMiddleware> _agentMiddlewares;
@@ -172,6 +200,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
                     replyPlan.PrimaryToolContext,
                     priorHistory,
                     primaryTools,
+                    systemPromptSuffix: replyPlan.DisableTools ? UnboundSenderToolsDisabledNotice : null,
                     streamingSink,
                     ct)
                 .ConfigureAwait(false);
@@ -195,6 +224,9 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
                     replyPlan.OwnerFallbackToolContext,
                     priorHistory,
                     fallbackTools,
+                    systemPromptSuffix: replyPlan.DisableTools
+                        ? UnboundSenderToolsDisabledNotice
+                        : DegradedTurnToolsDisabledNotice,
                     streamingSink,
                     ct)
                 .ConfigureAwait(false);
@@ -279,9 +311,16 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
             tools,
             input.AttachmentVisibilityInstruction);
 
+        // The unbound-sender gate (issue #1318) detaches the entire tool surface while
+        // the kernel prompt still documents those tools; without this override the
+        // model reports the capability as missing instead of the actual, recoverable
+        // reason. Keyed on the plan's own gate (not forceDisableTools): per-step rebuilds
+        // discard InitialMessages, so this notice is stamped exactly once per run.
         var initialMessages = new List<ChatMessage>
         {
-            ChatMessage.System(BuildSystemPrompt(externalMetadata, effectiveToolContext, input.AttachmentVisibilityInstruction)),
+            ChatMessage.System(AppendSystemPromptSuffix(
+                BuildSystemPrompt(externalMetadata, effectiveToolContext, input.AttachmentVisibilityInstruction),
+                replyPlan.DisableTools ? UnboundSenderToolsDisabledNotice : null)),
         };
         initialMessages.AddRange((priorHistory ?? []).Where(IsReplayableHistoryEntry).TakeLast(MaxRecentPriorHistoryMessages).Select(ToChatMessage));
         initialMessages.Add(ChatMessage.User(input.Parts, input.Text));
@@ -330,6 +369,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         AgentToolExecutionContext? baseToolContext,
         IReadOnlyList<ConversationHistoryEntry>? priorHistory,
         ToolManager tools,
+        string? systemPromptSuffix,
         IStreamingReplySink? streamingSink,
         CancellationToken ct)
     {
@@ -369,7 +409,9 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
             {
                 Messages =
                 [
-                    ChatMessage.System(BuildSystemPrompt(effectiveMetadata, toolContext, input.AttachmentVisibilityInstruction)),
+                    ChatMessage.System(AppendSystemPromptSuffix(
+                        BuildSystemPrompt(effectiveMetadata, toolContext, input.AttachmentVisibilityInstruction),
+                        systemPromptSuffix)),
                 ],
                 Metadata = externalMetadata,
                 ToolContext = toolContext,
@@ -1078,6 +1120,9 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
             .ToArray();
         return valid.Length == 0 ? null : valid;
     }
+
+    private static string AppendSystemPromptSuffix(string prompt, string? suffix) =>
+        string.IsNullOrEmpty(suffix) ? prompt : $"{prompt.TrimEnd()}\n\n{suffix}";
 
     private string BuildSystemPrompt(
         IReadOnlyDictionary<string, string> metadata,

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
@@ -694,6 +694,58 @@ public sealed class ChannelConversationTurnRunnerTests
         result.LlmReplyRequest!.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.ModelOverride);
     }
 
+    // A binding-lookup failure must NOT fail or drop the turn: the deferred relay retry
+    // cannot re-run a relay turn (the runtime-only reply token is never persisted, so the
+    // retry terminally fails with missing_runtime_reply_token before re-invoking the
+    // runner), and a propagated exception drops the message outright. The pinned contract
+    // is: degrade to an owner-config LLM reply with an EMPTY sender binding — the reply
+    // generator's tools-disabled notice then keeps the model honest about the missing
+    // tool surface (2026-07 incident). Covers both classifier branches, including the
+    // production ES reader's InvalidOperationException wrapping of 5xx/429.
+    [Theory]
+    [InlineData(typeof(HttpRequestException))]
+    [InlineData(typeof(TaskCanceledException))]
+    [InlineData(typeof(InvalidOperationException))]
+    public async Task RunInboundAsync_ShouldDegradeToOwnerConfigLlmReply_WhenSenderBindingLookupThrows(System.Type failureType)
+    {
+        var failure = (Exception)Activator.CreateInstance(failureType, "binding readmodel unavailable")!;
+        var bindingPort = new ThrowingIdentityBindingQueryPort(failure);
+        var services = new ServiceCollection()
+            .AddSingleton<IExternalIdentityBindingQueryPort>(bindingPort)
+            .BuildServiceProvider();
+        var registrationQueryPort = BuildRegistrationQueryPort();
+        var adapter = new RecordingPlatformAdapter();
+        var runner = CreateRunner(registrationQueryPort, adapter, services);
+
+        var result = await runner.RunInboundAsync(
+            BuildInboundActivity("hello", "msg-binding-lookup-fails"),
+            CancellationToken.None);
+
+        bindingPort.Calls.Should().Be(1);
+        result.Success.Should().BeTrue();
+        result.LlmReplyRequest.Should().NotBeNull();
+        var toolContext = AgentToolExecutionContextMapper.FromPayload(result.LlmReplyRequest!.ToolContext);
+        toolContext.SenderBinding.BindingId.Should().BeNullOrEmpty();
+    }
+
+    // Real cancellation is not a lookup failure and must still propagate.
+    [Fact]
+    public async Task RunInboundAsync_ShouldPropagateCancellation_WhenSenderBindingLookupIsCanceled()
+    {
+        using var cts = new CancellationTokenSource();
+        var bindingPort = new CancellingIdentityBindingQueryPort(cts);
+        var services = new ServiceCollection()
+            .AddSingleton<IExternalIdentityBindingQueryPort>(bindingPort)
+            .BuildServiceProvider();
+        var runner = CreateRunner(BuildRegistrationQueryPort(), new RecordingPlatformAdapter(), services);
+
+        var act = () => runner.RunInboundAsync(
+            BuildInboundActivity("hello", "msg-binding-lookup-canceled"),
+            cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
     [Fact]
     public async Task RunInboundAsync_ShouldSkipOwnerConfigOverrides_WhenSpecificFieldsEmpty()
     {
@@ -4358,6 +4410,27 @@ public sealed class ChannelConversationTurnRunnerTests
         }
 
         public NyxIdApiClient CreateClient() => _client;
+    }
+
+    private sealed class ThrowingIdentityBindingQueryPort(Exception failure) : IExternalIdentityBindingQueryPort
+    {
+        public int Calls { get; private set; }
+
+        public Task<BindingId?> ResolveAsync(ExternalSubjectRef externalSubject, CancellationToken ct = default)
+        {
+            Calls++;
+            throw failure;
+        }
+    }
+
+    private sealed class CancellingIdentityBindingQueryPort(CancellationTokenSource cts) : IExternalIdentityBindingQueryPort
+    {
+        public Task<BindingId?> ResolveAsync(ExternalSubjectRef externalSubject, CancellationToken ct = default)
+        {
+            cts.Cancel();
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult<BindingId?>(null);
+        }
     }
 
     private sealed class StubUserLlmOptionsService : IUserLlmOptionsService

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
@@ -3,11 +3,16 @@ using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.ToolProviders.Lark;
+using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.AI.ToolProviders.Skills;
+using Aevatar.Foundation.Abstractions.Credentials.Testing;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgents.Authoring.Lark;
 using Aevatar.GAgents.Channel.Abstractions;
+using Aevatar.GAgents.Scheduled;
 using FluentAssertions;
+using NSubstitute;
 using Xunit;
 using Aevatar.GAgents.Channel.NyxIdRelay;
 using Aevatar.GAgents.Channel.Runtime;
@@ -1915,6 +1920,97 @@ public sealed class ConversationReplyGeneratorTests
         var request = providerFactory.Requests.Should().ContainSingle().Subject;
         request.Tools.Should().BeNull();
         toolSource.DiscoverCount.Should().Be(0);
+    }
+
+    // The unbound-sender gate detaches every tool while the kernel prompt still documents
+    // them; the system prompt must carry the honest override so the model reports "tools
+    // disabled this turn, bind to enable" instead of denying the capability exists
+    // (2026-07 incident: the bot answered "no scheduling tool entry point" to a bound-
+    // looking user whose turn ran in the unbound degrade).
+    [Fact]
+    public async Task GenerateReplyAsync_ForUnboundChannelTurn_TellsModelToolsAreDisabledAndBindable()
+    {
+        var providerFactory = new RecordingProviderFactory();
+        var generator = new NyxIdConversationReplyGenerator(
+            providerFactory,
+            toolSources: [new SingleToolSource(new FixedResultTool("any_tool", """{"ok":true}"""))]);
+
+        await generator.GenerateReplyAsync(
+            new ChatActivity
+            {
+                Id = "msg-unbound-tools-notice",
+                Conversation = new ConversationReference { CanonicalKey = "lark:dm:user-1" },
+                Content = new MessageContent { Text = "remind me in five minutes" },
+            },
+            new Dictionary<string, string>
+            {
+                [ChannelMetadataKeys.Platform] = "lark",
+                [ChannelMetadataKeys.SenderId] = "ou_user_1",
+                [ChannelMetadataKeys.MessageId] = "msg-unbound-tools-notice",
+            },
+            Control("owner-only-model", "owner-route", 4),
+            toolContext: null,
+            streamingSink: null,
+            CancellationToken.None);
+
+        var request = providerFactory.Requests.Should().ContainSingle().Subject;
+        request.Tools.Should().BeNull();
+        var systemMessage = request.Messages.Should().Contain(message => message.Role == "system").Which;
+        systemMessage.Content.Should().Contain("Tools disabled for this turn");
+        systemMessage.Content.Should().Contain("/init");
+    }
+
+    // The production DI pool hands the channel reply generator EVERY registered tool
+    // source, including the Lark authoring source carrying the scheduling tool. Pin the
+    // full bound-sender relay path — real AgentBuilderToolSource → discovery → channel
+    // filters → LLM request — so a future change that drops the source or gates its tools
+    // out of channel turns fails here instead of shipping. Concrete tool names appear as
+    // test fixtures only (CLAUDE.md testfile exception).
+    [Fact]
+    public async Task GenerateReplyAsync_ForBoundLarkRelayTurn_InjectsAgentBuilderToolsIntoLlmRequest()
+    {
+        var providerFactory = new RecordingProviderFactory();
+        var nyxClientFactory = Substitute.For<INyxIdApiClientFactory>();
+        var agentBuilderSource = new AgentBuilderToolSource(
+            Substitute.For<IUserAgentCatalogQueryPort>(),
+            Substitute.For<ISkillRunnerExecutionQueryPort>(),
+            nyxClientFactory,
+            Substitute.For<ISkillRunnerCommandPort>(),
+            Substitute.For<IUserAgentCatalogCommandPort>(),
+            Substitute.For<ICallerScopeResolver>(),
+            new ScheduledAgentCreateRequestMapper(new InMemorySecretVault()),
+            new ScheduledAgentApiKeyIssuer(nyxClientFactory, new ScheduledAgentCreatorOptions()));
+        var generator = new NyxIdConversationReplyGenerator(
+            providerFactory,
+            toolSources: [agentBuilderSource]);
+
+        await generator.GenerateReplyAsync(
+            new ChatActivity
+            {
+                Id = "msg-bound-channel-tools",
+                Conversation = new ConversationReference { CanonicalKey = "lark:dm:user-1" },
+                Content = new MessageContent { Text = "remind me in five minutes" },
+            },
+            new Dictionary<string, string>
+            {
+                [ChannelMetadataKeys.Platform] = "lark",
+                [ChannelMetadataKeys.SenderId] = "ou_user_1",
+                [ChannelMetadataKeys.MessageId] = "msg-bound-channel-tools",
+            },
+            Control("sender-model", "sender-route", 4),
+            RelayToolContext("bnd-user-1", "msg-bound-channel-tools"),
+            streamingSink: null,
+            CancellationToken.None);
+
+        var request = providerFactory.Requests.Should().ContainSingle().Subject;
+        request.Tools.Should().NotBeNull();
+        request.Tools!.Select(static tool => tool.Name).Should().Contain(
+        [
+            "scheduled_agent_creator",
+            "agent_builder",
+        ]);
+        request.Messages.Should().Contain(message => message.Role == "system")
+            .Which.Content.Should().NotContain("Tools disabled for this turn");
     }
 
     [Fact]


### PR DESCRIPTION
## 问题

用户对 Lark bot 说"5分钟后提醒我喝水"，bot 回复"我这边当前没有可用的定时/日程工具调用入口"——否认了部署里实际存在的 `scheduled_agent_creator` 能力（2026-07 事故）。

根因：issue #1318 的 unbound-sender 断闸把 channel turn 的**整个工具面**剥光（`disableTools = IsChannelTurn && SenderBinding 为空`），但 kernel prompt（`system-prompt.md`）仍无条件宣传这些工具，模型只能得出"能力不存在"的错误结论。触发方式包括：sender 确实未绑定/被撤销、readmodel 滞后，以及 binding 查询失败被降级为"未绑定"。

## 方案

1. **诚实降级提示**：任何禁工具的 channel turn，system prompt 追加确定性说明，覆盖两条 prompt 构建接缝——AgentRun step-plan 路径（initial messages，每 run 一次）与 in-place `GenerateReplyAsync` 路径（新 `systemPromptSuffix` 参数）。unbound 场景指引用户 `/init` 绑定；owner-fallback 降级场景说明"本 turn 降级运行，请稍后重试"。措辞不点名任何具体工具/skill。
2. **binding 查询失败保持降级答复**，并把机理写进注释：deferred relay retry 无法重跑 relay turn（runtime-only reply token 不入持久态 → `missing_runtime_reply_token` 终态），且生产 ES 读侧把 5xx/429 包成 `InvalidOperationException`——失败转重试会直接丢消息。改进：HttpClient 超时（`TaskCanceledException`）现在降级而非上抛丢消息；真取消仍传播。
3. **端到端 pin 测试**：绑定 sender 的 relay turn 的 LLM 请求必须含真实 `AgentBuilderToolSource` 的工具；unbound turn 必须带 bind-to-enable 提示；3 类查询异常（含 ES 的 `InvalidOperationException` 形态）必须降级出 owner-config LLM 答复且 sender binding 为空，不得失败或丢 turn；真取消必须传播。

## 影响路径

- `agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs`
- `agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs`
- `test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs`
- `test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs`

## 验证

- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests --nologo` → 1610/1610 通过
- `bash tools/ci/test_stability_guards.sh` → 通过
- `bash tools/ci/architecture_guards.sh` → 通过

遗留（独立会话处理中）：AgentRun 路径 owner-fallback 降级步的同类诚实提示 + `LlmOwnerFallbackPolicy` 子串路由收窄。

🤖 Generated with [Claude Code](https://claude.com/claude-code)