### PR TITLE
Allow Studio chat workflow to create teams and members

### DIFF
--- a/src/workflow/Aevatar.Workflow.Application/Workflows/WorkflowDefinitionCatalog.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Workflows/WorkflowDefinitionCatalog.cs
@@ -79,8 +79,8 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
     /// <para>
     /// The role carries an <c>allowed_tools</c> allowlist (parsed by <c>WorkflowParser</c> →
     /// <c>RoleDefinition.AgentToolScope</c>, intersected with any step scope by the execution kernel →
-    /// <c>ToolVisibility</c>). It INCLUDES <c>aevatar_provision_workflow_schedule</c> + the observe tools and
-    /// EXCLUDES both the Lark <c>scheduled_agent_creator</c> and the hanging loose-definition tools
+    /// <c>ToolVisibility</c>). It INCLUDES Studio team/member creation, <c>aevatar_provision_workflow_schedule</c>
+    /// + the observe tools and EXCLUDES both the Lark <c>scheduled_agent_creator</c> and the hanging loose-definition tools
     /// (<c>workflow_create_def</c>/<c>update</c>/<c>read</c>/<c>list_defs</c>, <c>aevatar_start_workflow</c>);
     /// the allowlist is the lever that keeps those out of the studio surface entirely (prompt steering alone is
     /// unreliable while a tool is visible).
@@ -95,11 +95,15 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
           - id: studio
             name: Studio Agent
             system_prompt: |
-              You are the Aevatar Studio agent. You help the user build and run real **workflows**, and
-              you deliver results to the **Observatory** (/workflow/observatory) — never to a chat or bot.
+              You are the Aevatar Studio agent. You help the user create Studio teams/members and build real
+              **workflows** whose runs are delivered to the **Observatory** (/workflow/observatory) — never to a chat or bot.
 
               How to work:
-              1. Author the workflow as inline YAML in the conversation. Keep it complete and runnable.
+              1. If the user asks to create a Studio team, call `aevatar_create_team` with `display_name` and optional
+                 `description`; do not claim you cannot create platform teams. If the user asks to create a Studio member,
+                 call `aevatar_create_member` with `display_name`, `implementation_kind`, and optional `description`,
+                 `member_id`, or `team_id`.
+              2. For workflow requests, author the workflow as inline YAML in the conversation. Keep it complete and runnable.
                  Workflow YAML schema (follow strictly, snake_case keys):
                  - Top-level keys are EXACTLY: name (required), description, configuration, roles, steps.
                    Do NOT use keys from other workflow dialects — no version, inputs, outputs, triggers,
@@ -122,7 +126,7 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
                          target_role: analyst
                          parameters:
                            prompt_prefix: "Summarize:"
-              2. Persist and schedule it by calling `aevatar_provision_workflow_schedule` with `workflow_yaml`
+              3. Persist and schedule workflows by calling `aevatar_provision_workflow_schedule` with `workflow_yaml`
                  and a `display_name`. This creates the workflow as a persisted member whose runs land in
                  /workflow/observatory — that persisted, observatory-delivered workflow is the deliverable.
                  Scheduling rules:
@@ -162,6 +166,8 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
               - The owning scope and your credentials come from the session; do not ask the user for scope,
                 channel, owner, or tokens.
             allowed_tools:
+              - aevatar_create_team
+              - aevatar_create_member
               - aevatar_provision_workflow_schedule
               - aevatar_observe_run
               - aevatar_read_workflow_run_artifact

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionCatalogTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionCatalogTests.cs
@@ -200,6 +200,8 @@ public class WorkflowDefinitionCatalogTests
         // member/provision path — NOT a bare "helpful assistant", NOT a Lark/skill-publishing playbook,
         // and NOT the loose-definition author-then-run-by-name path that hangs.
         role.SystemPrompt.Should().Contain("Studio agent");
+        role.SystemPrompt.Should().Contain("aevatar_create_team");
+        role.SystemPrompt.Should().Contain("aevatar_create_member");
         role.SystemPrompt.Should().Contain("aevatar_provision_workflow_schedule");
         role.SystemPrompt.Should().Contain("/workflow/observatory");
         role.SystemPrompt.Should().Contain("Do NOT");
@@ -224,6 +226,8 @@ public class WorkflowDefinitionCatalogTests
         // tools out of the studio surface, and brings the channel-free provision tool in.
         role.AgentToolScope.Should().NotBeNull();
         var allowed = role.AgentToolScope!.AllowedToolNames;
+        allowed.Should().Contain("aevatar_create_team");
+        allowed.Should().Contain("aevatar_create_member");
         allowed.Should().Contain("aevatar_provision_workflow_schedule");
         allowed.Should().Contain("aevatar_observe_run");
         allowed.Should().Contain("aevatar_read_workflow_run_artifact");


### PR DESCRIPTION
## Summary
- Add Studio team/member creation tools to the built-in `studio` workflow allowlist used by `/api/chat`.
- Update the Studio workflow prompt so Team/Member requests call `aevatar_create_team` / `aevatar_create_member` instead of claiming the platform API is unavailable.
- Extend the catalog regression test to pin the prompt and allowlist entries.

## Test plan
- [x] `dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo --filter \"BuiltInStudioYaml_ShouldParseAsMemberProvisionStudioRoleWithToolAllowlist\" -v minimal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)